### PR TITLE
switched :rubygems to 'https://rubygems.org' since :rubygems was deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     coderay (1.0.7)
     columnize (0.3.6)


### PR DESCRIPTION
"The source :rubygems is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not."

I changed it to 'https://rubygems.org' because it was recommended. Alternatively, 'http://rubygems.org' would preserve existing behavior and avoid the warning when running bundler, if OpenSSL being required is undesired.
