### PR TITLE
Fix clock_gettime

### DIFF
--- a/std/time.linux.cr
+++ b/std/time.linux.cr
@@ -1,4 +1,4 @@
-lib C
+lib Librt("rt")
   struct TimeSpec
     tv_sec, tv_nsec : Int64
   end
@@ -7,7 +7,7 @@ end
 
 class Time
   def initialize
-    C.clock_gettime(0, out time)
+    Librt.clock_gettime(0, out time)
     @seconds = time.tv_sec + time.tv_nsec / 1e9
   end
 end


### PR DESCRIPTION
after update crystal i got

```
./bin/crystal 1.cr -O3
/tmp/user/1011/ccwyspM7.o: In function `__crystal_main':
<stdin>:(.text+0x245): undefined reference to `clock_gettime'
<stdin>:(.text+0x3e0): undefined reference to `clock_gettime'
<stdin>:(.text+0x466): undefined reference to `clock_gettime'
<stdin>:(.text+0x552): undefined reference to `clock_gettime'
collect2: выполнение ld завершилось с кодом возврата 1
```

after this fix, is ok.
