### PR TITLE
Let SimpleCov do it's magic locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tags
 .tags_sorted_by_file
 .vagrant
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'rspec'
 gem 'ruby-llvm', git: "https://github.com/manastech/ruby-llvm.git"
 gem 'levenshtein-ffi'
 gem 'pry'
@@ -9,4 +8,9 @@ gem 'pry-debugger'
 gem 'ruby-graphviz'
 gem 'ruby-prof', git: 'https://github.com/ruby-prof/ruby-prof.git'
 gem 'json', '~> 1.7.7'
-gem 'coveralls', require: false
+
+
+group :test do
+  gem 'rspec'
+  gem 'coveralls', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ruby-prof/ruby-prof.git
-  revision: ef0d3f5ab07590756f4367a3f54ec2680d489ca9
+  revision: e1d1ba17e13f8ef5e24097034095ecc182d785e0
   specs:
     ruby-prof (0.13.0)
 
@@ -16,29 +16,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.0.9)
-    colorize (0.5.8)
     columnize (0.3.6)
-    coveralls (0.6.7)
-      colorize
+    coveralls (0.7.0)
       multi_json (~> 1.3)
       rest-client
       simplecov (>= 0.7)
+      term-ansicolor
       thor
-    debugger (1.6.0)
+    debugger (1.6.1)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.1)
+      debugger-ruby_core_source (~> 1.2.3)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.2.3)
-    diff-lcs (1.2.1)
+    diff-lcs (1.2.4)
     ffi (1.9.0)
     json (1.7.7)
     levenshtein-ffi (1.0.2)
       ffi
       ffi
-    method_source (0.8.1)
-    mime-types (1.23)
-    multi_json (1.7.3)
+    method_source (0.8.2)
+    mime-types (1.25)
+    multi_json (1.8.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -49,21 +48,24 @@ GEM
     rake (0.9.6)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.0)
-    rspec-expectations (2.13.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.0)
-    ruby-graphviz (1.0.8)
+    rspec-mocks (2.14.3)
+    ruby-graphviz (1.0.9)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    slop (3.4.5)
+    slop (3.4.6)
+    term-ansicolor (1.2.2)
+      tins (~> 0.8)
     thor (0.18.1)
+    tins (0.9.0)
 
 PLATFORMS
   ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ if ENV["CI"]
     add_filter 'lib/crystal/graph.rb'
     add_filter 'lib/crystal/print_types_visitor.rb'
   end
+else
+  require 'simplecov'
+  require 'coveralls'
+  SimpleCov.start
 end
 
 require(File.expand_path("../../lib/crystal",  __FILE__))


### PR DESCRIPTION
At the time of this writing, Coveralls reports a coverage of 89%.

My main objective with this branch is to be able to run SimpleCov locally so I can see what files are not covered by tests and potentially write tests for them in the future.
