### PR TITLE
Faster array spec

### DIFF
--- a/spec/codegen/array_spec.rb
+++ b/spec/codegen/array_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Code gen: faster array' do
+describe 'Code gen: array' do
   it "codegens array length" do
     run('require "array"; a = [1, 2]; a.length').to_i.should eq(2)
   end


### PR DESCRIPTION
This speeds up the array spec by about 2 seconds. I'm sure lots of other specs have similar optimizations.

```
farleyknight@farleyknight-desktop:~/dev/crystal/crystal$ rspec spec/codegen/faster_array_spec.rb
Run options: exclude {:primitives=>true, :integration=>true}
.........

Finished in 3.81 seconds
9 examples, 0 failures
farleyknight@farleyknight-desktop:~/dev/crystal/crystal$ rspec spec/codegen/faster_array_spec.rb 
Run options: exclude {:primitives=>true, :integration=>true}
.........

Finished in 3.48 seconds
9 examples, 0 failures
farleyknight@farleyknight-desktop:~/dev/crystal/crystal$ rspec spec/codegen/array_spec.rb 
Run options: exclude {:primitives=>true, :integration=>true}
.........

Finished in 5.67 seconds
9 examples, 0 failures
farleyknight@farleyknight-desktop:~/dev/crystal/crystal$ rspec spec/codegen/array_spec.rb 
Run options: exclude {:primitives=>true, :integration=>true}
.........

Finished in 5.57 seconds
9 examples, 0 failures
```
