### PR TITLE
Run RSpec tests in a random order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --format progress
---order rand


### PR DESCRIPTION
http://blog.davidchelimsky.net/blog/2012/01/05/rspec-28-is-released/

> When you use --order random, RSpec prints out the random number it used to seed the randomizer. When you think you’ve found an order-dependency bug, you can pass the seed along and the order will remain consistent.
