### PR TITLE
Fix ModeT and add TimeT

### DIFF
--- a/src/c.cr
+++ b/src/c.cr
@@ -1,10 +1,16 @@
 lib C
+  ifdef darwin
+    alias ModeT = UInt16
+  elsif linux
+    alias ModeT = UInt32
+  end
+
   ifdef x86_64
-    alias ModeT = Int32
     alias SizeT = UInt64
+    alias TimeT = Int64
   else
-    alias ModeT = Int16
     alias SizeT = UInt32
+    alias TimeT = Int32
   end
 
   fun time(t : Int64) : Int64

--- a/src/int.cr
+++ b/src/int.cr
@@ -83,10 +83,10 @@ struct Int
   end
 
   def to_modet
-    ifdef x86_64
-      to_i32
-    else
-      to_i16
+    ifdef darwin
+      to_u16
+    elsif linux
+      to_u32
     end
   end
 
@@ -95,6 +95,14 @@ struct Int
       to_u64
     else
       to_u32
+    end
+  end
+
+  def to_timet
+    ifdef x86_64
+      to_i64
+    else
+      to_i32
     end
   end
 end


### PR DESCRIPTION
I got ModeT wrong in a previous commit. ModeT seems to be the same type across different architectures of the same platform. TimeT is needed for a pull request that I will submit soon.
