### PR TITLE
Add casts to make Readline.readline work again.

### DIFF
--- a/src/readline.cr
+++ b/src/readline.cr
@@ -1,14 +1,14 @@
 lib LibReadline("readline")
-  fun readline(prompt : Char*) : Char*
-  fun add_history(line : Char*)
+  fun readline(prompt : UInt8*) : UInt8*
+  fun add_history(line : UInt8*)
 end
 
 module Readline
   def self.readline(prompt, add_history = false)
-    line = LibReadline.readline(prompt.cstr as Char*)
+    line = LibReadline.readline(prompt.cstr)
     if line
       LibReadline.add_history(line) if add_history
-      String.new(line as UInt8*)
+      String.new(line)
     else
       nil
     end


### PR DESCRIPTION
I couldn't get `icr` to compile on `master`:

```
in /Users/booch/Work/Projects/Crystal/crystal/src/readline.cr:8: argument 'prompt' of 'LibReadline#readline' must be Char*, not String
    line = LibReadline.readline(prompt)
                                ^~~~~~
```

This pull request fixes that, allowing `icr` to compile and run. (Although it won't run any code yet, due to not being able to find `"prelude"`.)
