### PR TITLE
Add wrapper for icr binary.

### DIFF
--- a/bin/icr
+++ b/bin/icr
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+SCRIPT_PATH=`dirname $(readlink $0 || echo $0)`
+DEPS_DIR="$SCRIPT_PATH/../deps"
+ICR_BIN="$DEPS_DIR/icr"
+
+# Build icr if it's not where we expect it.
+if [ ! -x "$ICR_BIN" ]; then
+  echo "Building icr - this will take just a while."
+  "$SCRIPT_PATH/crystal" "$SCRIPT_PATH/../src/compiler/icr.cr" -o "$DEPS_DIR/icr"
+fi
+
+# Make sure Crystal knows where to find its libraries.
+export CRYSTAL_PATH="$SCRIPT_PATH/../src:libs"
+"$ICR_BIN" "$@"


### PR DESCRIPTION
I was having trouble running `icr` once I was able to get it to compile. I found that the $CRYSTAL_PATH environment variable had to be set properly. This wrapper will allow future users to get started using `icr` without any of that hassle. The script follows the same basic idea as `bin/crystal`.
