### PR TITLE
Silence warnings from "which" correctly.

### DIFF
--- a/src/compiler/crystal/codegen/llvm_config.cr
+++ b/src/compiler/crystal/codegen/llvm_config.cr
@@ -6,9 +6,9 @@ module Crystal
 
     def llvm_config
       @llvm_config ||= begin
-        if system("which llvm-config-3.3 > /dev/null") == 0
+        if system("which llvm-config-3.3 > /dev/null 2>&1") == 0
           "llvm-config-3.3"
-        elsif system("which llvm-config > /dev/null") == 0
+        elsif system("which llvm-config > /dev/null 2>&1") == 0
           "llvm-config"
         else
           raise "Couldn't determine llvm-config binary"


### PR DESCRIPTION
Before this change I get "blah blah cannot find llvm-config-3.3" on every crystal invocation as the "which" stderr is not redirected and becomes part of the console output.
