### PR TITLE
Fix 'make crystal', .PHONY targets, don't assume . is in PATH.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .crystal
 coverage/
 deps/
+.build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all spec crystal clean
+
+O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
 
@@ -5,22 +8,14 @@ all: crystal
 spec: all_spec
 	./all_spec
 
-crystal: $(SOURCES)
-	@if [ -x crystal ]; then \
-		echo mv crystal crystal-old; \
-		mv crystal crystal-old; \
-		echo ./crystal-old src/compiler/crystal.cr; \
-		./crystal-old src/compiler/crystal.cr; \
-	else \
-		echo bin/crystal src/compiler/crystal.cr; \
-	  bin/crystal src/compiler/crystal.cr; \
-	fi
+crystal: $(O)/crystal
 
 all_spec: $(SOURCES) $(SPEC_SOURCES)
-	@if [ -x crystal ]; then \
-		echo ./crystal spec/all_spec.cr; \
-		./crystal spec/all_spec.cr; \
-	else \
-		echo bin/crystal spec/all_spec.cr; \
-	  bin/crystal spec/all_spec.cr; \
-	fi
+	./bin/crystal spec/all_spec.cr
+
+$(O)/crystal: $(SOURCES)
+	@mkdir -p $(O)
+	./bin/crystal -o $@ src/compiler/crystal.cr
+
+clean:
+	@rm -rf $(O)

--- a/bin/crystal
+++ b/bin/crystal
@@ -2,6 +2,11 @@
 SCRIPT_PATH=`dirname $(readlink $0 || echo $0)`
 DEPS_DIR="$SCRIPT_PATH/../deps"
 
+CRYSTAL_DIR="$SCRIPT_PATH/../.build"
+if [ ! -x $CRYSTAL_DIR/crystal ] ; then
+  CRYSTAL_DIR=$DEPS_DIR
+fi
+
 OS_NAME=`uname -s`
 HW_NAME=`uname -m`
 EXTRACT_FLAG="z"
@@ -72,4 +77,4 @@ fi
 
 export PATH="$DEPS_DIR/llvm/bin":$PATH
 export CRYSTAL_PATH="$SCRIPT_PATH/../src:libs"
-"$DEPS_DIR/crystal" "$@"
+"$CRYSTAL_DIR/crystal" "$@"


### PR DESCRIPTION
Invoking "./crystal" doesn't seem to work anymore so I removed that from the makefile and simplified it.

Also the ".PHONY" target was missing, this is necessary for make targets that don't correspond to generated output files. Lastly it doesn't assume "." is in the PATH anymore (some consider "." in the PATH as a security risk).
