### PR TITLE
Splat parameters WIP.

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -75,4 +75,4 @@ fi
 
 export PATH="$DEPS_DIR/llvm/bin":$PATH
 export CRYSTAL_PATH="$SCRIPT_ROOT/src:libs"
-"$CRYSTAL_DIR/crystal" "$@"
+exec "$CRYSTAL_DIR/crystal" "$@"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -242,6 +242,7 @@ describe "Parser" do
   it_parses "def foo(@var); end", Def.new("foo", [Arg.new("var")], [Assign.new("@var".instance_var, "var".var)] of ASTNode)
   it_parses "def foo(@var); 1; end", Def.new("foo", [Arg.new("var")], [Assign.new("@var".instance_var, "var".var), 1.int32] of ASTNode)
   it_parses "def foo(@var = 1); 1; end", Def.new("foo", [Arg.new("var", 1.int32)], [Assign.new("@var".instance_var, "var".var), 1.int32] of ASTNode)
+  it_parses "def foo(*vars); ; end", Def.new("foo", [Arg.new("vars")], [] of ASTNode, nil, nil, nil, 0)
 
   it_parses "foo", "foo".call
   it_parses "foo()", "foo".call
@@ -650,5 +651,10 @@ describe "Parser" do
   it "errors if arg doesn't have a default value after a previous one has one" do
     assert_syntax_error "def foo(x = 1, y); end",
       "argument must have a default value"
+  end
+
+  it "errors if def contains more than one splat argument" do
+    assert_syntax_error "def foo(*x, *y); end",
+      "only one splat argument allowed"
   end
 end

--- a/src/compiler/crystal/ast.cr
+++ b/src/compiler/crystal/ast.cr
@@ -831,11 +831,12 @@ module Crystal
     property :block_arg
     property :yields
     property :instance_vars
+    property :splat_arg_idx
     property :calls_super
     property :uses_block_arg
     property :name_column_number
 
-    def initialize(@name, @args : Array(Arg), body = nil, @receiver = nil, @block_arg = nil, @yields = nil)
+    def initialize(@name, @args : Array(Arg), body = nil, @receiver = nil, @block_arg = nil, @yields = nil, @splat_arg_idx = -1)
       @body = Expressions.from body
     end
 
@@ -847,7 +848,7 @@ module Crystal
     end
 
     def ==(other : self)
-      other.receiver == receiver && other.name == name && other.args == args && other.body == body && other.yields == yields && other.block_arg == block_arg
+      other.receiver == receiver && other.name == name && other.args == args && other.body == body && other.yields == yields && other.block_arg == block_arg && other.splat_arg_idx == splat_arg_idx 
     end
 
     def name_length
@@ -862,6 +863,10 @@ module Crystal
       a_def.name_column_number = name_column_number
       a_def
     end
+
+    def has_splat_argument?
+      @splat_arg_idx != -1
+    end
   end
 
   class Macro < ASTNode
@@ -873,7 +878,7 @@ module Crystal
     property :yields
     property :name_column_number
 
-    def initialize(@name, @args : Array(Arg), body = nil, @receiver = nil, @block_arg = nil, @yields = nil)
+    def initialize(@name, @args : Array(Arg), body = nil, @receiver = nil, @block_arg = nil, @yields = nil, @splat_arg_idx = -1)
       @body = Expressions.from body
     end
 

--- a/src/compiler/crystal/to_s.cr
+++ b/src/compiler/crystal/to_s.cr
@@ -448,6 +448,7 @@ module Crystal
         @str << "("
         node.args.each_with_index do |arg, i|
           @str << ", " if i > 0
+          @str << "*" if i == node.splat_arg_idx
           arg.accept self
         end
         if block_arg = node.block_arg

--- a/src/compiler/crystal/type_inference/call.cr
+++ b/src/compiler/crystal/type_inference/call.cr
@@ -525,9 +525,17 @@ module Crystal
         raise error_msg, owner_trace
       end
 
-      defs_matching_args_length = defs.select { |a_def| a_def.args.length == self.args.length }
+      defs_matching_args_length = defs.select do |a_def|
+        ! a_def.has_splat_argument? && a_def.args.length == self.args.length
+      end
       if defs_matching_args_length.empty?
-        all_arguments_lengths = defs.map { |a_def| a_def.args.length }.uniq!
+        all_arguments_lengths = defs.map do |a_def|
+          if a_def.has_splat_argument?
+            a_def.args.length.to_s + "+"
+          else
+            a_def.args.length.to_s
+          end
+        end.uniq!
         raise "wrong number of arguments for '#{full_name(owner, def_name)}' (#{args.length} for #{all_arguments_lengths.join ", "})"
       end
 


### PR DESCRIPTION
Maybe this isn't the best way to go about this, but this pull request is currently incomplete. I was hoping to raise it here so I could get some answers to questions I had about the compiler source code while I complete the feature. I hope that's okay.

The first question I had is about the Matches object and the Cover type, I wondered what the Cover type is for, why sometimes it is used to delay type checking. I also wondered if you have any advice/guidance about other areas of the code this should touch.

I guess you were also thinking that the splat parameters should end up as tuples? I wonder also if tuples of size 0 could be used (a bit like C++ variadic template parameters) for instances like:

``` ruby
def puts(a, *following)
end

puts "hello" # following would be a tuple of 0 length in puts
```

I also wondered, when I pass a type to a function as a non-type argument (like the klass parameters) does this end up being a run-time type argument or would it be a compile time constant and not in the llvm args?
