### PR TITLE
add base64

### DIFF
--- a/src/base64.cr
+++ b/src/base64.cr
@@ -1,4 +1,6 @@
 module Base64
+  extend self
+
   CHARS_STD  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
   CHARS_SAFE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
   LINE_SIZE = 60
@@ -8,7 +10,7 @@ module Base64
   class Error < Exception; end
 
   def self.encode64(str)
-    String.new_with_capacity_and_return_length(encode_size(str.length, true)) do |buf|
+    String.new_with_capacity_and_length(encode_size(str.length, true)) do |buf|
       bufc = 0
       inc = 0
       to_base64(str, CHARS_STD, true) do |byte| 
@@ -30,7 +32,7 @@ module Base64
   end
 
   def self.strict_encode64(str : String)
-    String.new_with_capacity_and_return_length(encode_size(str.length)) do |buf|
+    String.new_with_capacity_and_length(encode_size(str.length)) do |buf|
       bufc = 0
       to_base64(str, CHARS_STD, true) { |b| buf[bufc] = b; bufc += 1 }
       bufc
@@ -38,7 +40,7 @@ module Base64
   end
 
   def self.urlsafe_encode64(str)
-    String.new_with_capacity_and_return_length(encode_size(str.length)) do |buf|
+    String.new_with_capacity_and_length(encode_size(str.length)) do |buf|
       bufc = 0
       to_base64(str, CHARS_SAFE, false) { |byte| buf[bufc] = byte; bufc += 1 }
       bufc
@@ -46,7 +48,7 @@ module Base64
   end
 
   def self.decode64(str)
-    String.new_with_capacity_and_return_length(decode_size(str.length)) do |buf|
+    String.new_with_capacity_and_length(decode_size(str.length)) do |buf|
       bufc = 0
       from_base64(str) do |b|
         buf[bufc] = b

--- a/src/string.cr
+++ b/src/string.cr
@@ -52,15 +52,6 @@ class String
     str as String
   end
 
-  def self.new_with_capacity_and_return_length(capacity)
-    str = Pointer(UInt8).malloc(capacity + 9)
-    buffer = (str as String).cstr
-    len = yield buffer
-    (str as Int32*).value = "".crystal_type_id
-    ((str as Int32*) + 1).value = len
-    str as String
-  end
-
   def self.new_with_length(length)
     str = Pointer(UInt8).malloc(length + 9)
     buffer = (str as String).cstr


### PR DESCRIPTION
in most cases faster than ruby, but with long strings slower.

``` ruby
require "base64"

u = 0
s = "a" * 10_000_000
s2 = ""
s3 = ""
t1 = Time.now

10.times do
  s2 = Base64.strict_encode64(s)
  u += s2.length
end

t2 = Time.now

10.times do
  s3 = Base64.strict_decode64(s2)
  u += s3.length
end

p t2 - t1
p Time.now - t2
p u
```

crystal:

```
0.179535
0.252145
233333360
```

ruby:

```
0.152786164
0.159499939
233333360
```
