### PR TITLE
fix system date

### DIFF
--- a/src/compiler/crystal/version.cr
+++ b/src/compiler/crystal/version.cr
@@ -1,7 +1,7 @@
 module Crystal
   def self.version_string
     str = {{ system(%((git describe --tags --long 2>/dev/null) || echo "?-?-?")).stringify }}
-    build_date = {{ system("date -u").stringify }}
+    build_date = {{ system("date -Ru").stringify }}
     a = str.split("-")
     tag = a[0]? || "?"
     # patch = a[1]? || "0"


### PR DESCRIPTION
fix for date bug.

```

in /home/kostya/crystal/src/compiler/crystal/version.cr:4: macro didn't expand to a valid program, it expanded to:

================================================================================
--------------------------------------------------------------------------------
  1. "\xxF\xzD. \xz0\xz2\xz3. 11 21:32:03 UTC 2014"
--------------------------------------------------------------------------------
Syntax error in expand macro:1: invalid hex escape

"\xxF\xzD. \xz0\xz2\xz3. 11 21:32:03 UTC 2014"
   ^

================================================================================

    build_date = {{ system("date -u").stringify }}

```
