### PR TITLE
Added behavior for Array#zip when no block is given

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -590,6 +590,20 @@ describe "Array" do
     end
   end
 
+  describe "zip" do
+    it "yields pairs of self's elements with those of the passed array, when a block is given" do
+      a, b, r = [1, 2, 3], [4, 5, 6], ""
+      a.zip(b) { |x, y| r += "#{x}:#{y}," }
+      r.should eq("1:4,2:5,3:6,")
+    end
+
+    it "returns an array of paired elements, when no block is given" do
+      a, b = [1, 2, 3], [4, 5, 6]
+      r = a.zip(b)
+      r.should eq([[1, 4], [2, 5], [3, 6]])
+    end
+  end
+
   describe "swap" do
     it "swaps" do
       a = [1, 2, 3]

--- a/src/array.cr
+++ b/src/array.cr
@@ -472,6 +472,12 @@ class Array(T)
     end
   end
 
+  def zip(other : Array)
+    pairs = [] of Array(T)
+    zip(other) { |x, y| pairs << [x, y] }
+    pairs
+  end
+
   def swap(index0, index1)
     index0 += length if index0 < 0
     index1 += length if index1 < 0


### PR DESCRIPTION
Added spec for existing `Array#zip` method and added behavior when no array is given.

I believe this would be the expected behavior when no block is provided.
