### PR TITLE
Fix typo in compiler commands

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -256,7 +256,7 @@ module Crystal::Command
         opts.on("--release", "Compile in release mode") do
           compiler.release = true
         end
-        opts.on("-s", "--stats", "Enable statistis output") do
+        opts.on("-s", "--stats", "Enable statistics output") do
           compiler.stats = true
         end
         opts.on("--single-module", "Generate a single LLVM module") do


### PR DESCRIPTION
Fixes a tiny typo in the compiler command helper text.
