### PR TITLE
Autodetect triple if the default triple is not compatible with the rootfs

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -240,7 +240,7 @@ module Crystal
 
     private def codegen_single_unit(unit, target_triple, multithreaded)
       unit.llvm_mod.target = target_triple
-      ifdef x86_64
+      if target_triple =~ /^x86_64/
         unit.llvm_mod.data_layout = DataLayout64
       else
         unit.llvm_mod.data_layout = DataLayout32

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -1,5 +1,24 @@
 class Crystal::Program
   def flags
+    unless @flags
+      # Try to reconstruct the expected best "uname" info from the triple.
+      # Running real "uname" is not always a good idea because it may be,
+      # for example, a 32-bit x86 system running with a 64-bit linux kernel.
+      case LLVM.default_target_triple
+      when /^x86_64\-.*\-linux\-gnu/
+        @flags = parse_flags("Linux x86_64")
+      when /^i(\d)86.*\-linux\-gnu/
+        if $1.to_i > 3
+          @flags = parse_flags("Linux i686")
+        else
+          @flags = parse_flags("Linux i386")
+        end
+      when /^armv7.*\-linux/
+        @flags = parse_flags("Linux armv7l")
+      when /^arm.*\-linux/
+        @flags = parse_flags("Linux armv6l")
+      end
+    end
     @flags ||= parse_flags(`uname -m -s`)
   end
 

--- a/src/llvm/llvm.cr
+++ b/src/llvm/llvm.cr
@@ -65,9 +65,39 @@ module LLVM
     LibLLVM.is_multithreaded != 0
   end
 
+  private def self.default_target_triple_from_cc?
+    cc = ENV["CC"]? || "cc"
+    `#{cc} -v 2>&1`.split("\n").each do |line|
+      return $1.strip if line =~ /^Target: (.*)/
+    end
+    nil
+  end
+
   def self.default_target_triple
     chars = LibLLVM.get_default_target_triple
-    String.new(chars).tap { LibLLVM.dispose_message(chars) }
+    triple = String.new(chars).tap { LibLLVM.dispose_message(chars) }
+
+    # Check if there is a correct dynamic linker present for the target triple
+    # in the rootfs (see https://wiki.debian.org/Multiarch/LibraryPathOverview).
+    # If not, then we are probably running a static Crystal compiler binary
+    # (natively or emulated via QEMU & binfmt_misc) in an "alien" chroot and it
+    # makes sense to guess a better triple by probing the installed C compiler.
+    case triple
+    when /^x86_64\-.*\-linux\-gnu$/
+      unless File.exists?("/lib/ld-linux-x86-64.so.2")
+        triple = default_target_triple_from_cc? || triple
+      end
+    when /^i\d86\-.*\-linux\-gnu$/
+      unless File.exists?("/lib/ld-linux.so.2")
+        triple = default_target_triple_from_cc? || triple
+      end
+    when /^arm.*\-linux\-gnueabihf$/
+      unless File.exists?("/lib/ld-linux-armhf.so.3")
+        triple = default_target_triple_from_cc? || triple
+      end
+    end
+
+    triple
   end
 
   def self.to_io(chars, io)


### PR DESCRIPTION
This allows to inject a statically built x86_64 Crystal compiler into
a 32-bit x86 Linux rootfs and successfully use it there. The compiler
will see that the x86_64 dynamic loader is not present in the system.
And automatically override the triple configuration with the tuple
string obtained by probing the (hopefully) installed GCC or Clang.

It also makes porting Crystal to ARM, MIPS or other non-x86 systems
much easier. Because the statically built x86_64 Crystal compiler
binary can work nicely in the QEMU user chroot and also pick the
right target triple automatically.

More info:
  https://wiki.debian.org/Multiarch/Tuples
  https://wiki.debian.org/Multiarch/LibraryPathOverview
