### PR TITLE
Reduce threads spawned for codegen

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -5,6 +5,7 @@ require "http/common"
 require "colorize"
 require "tempfile"
 require "crypto/md5"
+require "math/math"
 
 module Crystal
   class Compiler
@@ -219,24 +220,20 @@ module Crystal
       end
     end
 
+    private def codegen_many_units_serial(units, target_triple, multithreaded)
+      units.each { |unit|
+        codegen_single_unit(unit, target_triple, multithreaded)
+      }
+    end
+
     private def codegen_many_units(units, target_triple, multithreaded)
-      jobs_count = 0
-
-      while unit = units.pop?
-        fork { codegen_single_unit(unit, target_triple, multithreaded) }
-
-        jobs_count += 1
-
-        if jobs_count >= @n_threads
-          LibC.waitpid(-1, out stat_loc, 0)
-          jobs_count -= 1
-        end
-      end
-
-      while jobs_count > 0
-        LibC.waitpid(-1, out stat_loc, 0)
-        jobs_count -= 1
-      end
+      # 0 units might be codegened, each_slice fails when count=0
+      task_size = Math.max(units.length / @n_threads, 1)
+      units.each_slice(task_size).map { |unit_slice|
+        fork {
+          codegen_many_units_serial(unit_slice, target_triple, multithreaded)
+        } # force strict execution with to_a
+      }.to_a.each { |pid| LibC.waitpid(pid, out stat_loc, 0) }
     end
 
     private def codegen_single_unit(unit, target_triple, multithreaded)


### PR DESCRIPTION
Before:

```
30.59user 45.65system 0:36.92elapsed 206%CPU (0avgtext+0avgdata 946896maxresident)k
0inputs+532768outputs (0major+824582minor)pagefaults 0swaps
```

After:

```
29.47user 3.11system 0:22.75elapsed 143%CPU (0avgtext+0avgdata 945240maxresident)k
0inputs+531824outputs (0major+497122minor)pagefaults 0swaps
```

Note that the system time is reduced from 45 seconds to 3 seconds: this time is almost pure overhead spent copying pages.
