### PR TITLE
Add type restrictions to `Array#concat`

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -394,7 +394,7 @@ class Array(T)
     delete nil
   end
 
-  def concat(other : Array)
+  def concat(other : Array(T))
     other_length = other.length
     new_length = length + other_length
     if new_length > @capacity
@@ -407,7 +407,7 @@ class Array(T)
     self
   end
 
-  def concat(other : Enumerable)
+  def concat(other : Enumerable(T))
     left_before_resize = @capacity - @length
     len = @length
     buf = @buffer + len


### PR DESCRIPTION
To stop something

```
in ./src/array.cr:420: no overload matches 'Pointer(Int32)#value=' with types (String | Int32 | Char)
Overloads are:
 - Pointer(Int32)#value=(value : Int32)
Couldn't find overloads for these types:
 - Pointer(Int32)#value=(value : String)
 - Pointer(Int32)#value=(value : Char)

      buf.value = elem
          ^~~~~
```

but I still face these bug

```crystal
a = [1, 2, 3]
a.concat(["4", 'e', 2])

# compile error
Using compiled compiler at .build/crystal
Error in crystal/one.cr:24: instantiating 'Array(Int32)#concat(Array((String | Int32 | Char)))'

      a.concat(["4", 'e', 2])
        ^~~~~~

in ./src/array.cr:414: instantiating 'Array((String | Int32 | Char))#each()'

    other.each do |elem|
          ^~~~

in ./src/array.cr:497: instantiating 'each_index()'

    each_index do |i|
    ^~~~~~~~~~

in ./src/array.cr:497: instantiating 'each_index()'

    each_index do |i|
    ^~~~~~~~~~

in ./src/array.cr:414: instantiating 'Array((String | Int32 | Char))#each()'

    other.each do |elem|
          ^~~~

in ./src/array.cr:420: no overload matches 'Pointer(Int32)#value=' with types (String | Int32 | Char)
Overloads are:
 - Pointer(Int32)#value=(value : Int32)
Couldn't find overloads for these types:
 - Pointer(Int32)#value=(value : String)
 - Pointer(Int32)#value=(value : Char)

      buf.value = elem
          ^~~~~
```

I can not find out why `concat(other : Enumerable(T))` is called, sorry :(