### PR TITLE
Add support for concurrency safe file operations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ all_spec: $(O)/all_spec
 
 $(O)/all_spec: $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
+	uname -a
 	$(BUILD_PATH) ./bin/crystal build $(FLAGS) -o $@ spec/all_spec.cr
 
 $(O)/crystal: $(SOURCES)

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -1,3 +1,11 @@
+# Temporary workaround for missing openat functionality on macos.
+# Remove when Yosemite is ubiquitous.
+ifdef darwin
+  HAVE_OPENAT = {{ `uname -r | cut -f1 -d.`.id == 14 }} # Yosemite
+else
+  HAVE_OPENAT = true
+end
+
 lib LibC
   type Dir = Void*
 
@@ -52,6 +60,20 @@ lib LibC
     end
   end
 
+  ifdef linux
+    enum AtFlags
+      AT_NONE = 0
+      AT_REMOVEDIR = 0x200
+      AT_SYMLINK_NOFOLLOW = 0x100
+    end
+  elsif darwin
+    enum AtFlags
+      AT_NONE = 0
+      AT_REMOVEDIR = 0x0080
+      AT_SYMLINK_NOFOLLOW = 0x0020
+    end
+  end
+
   enum GlobErrors
     NOSPACE = 1
     ABORTED = 2
@@ -62,6 +84,7 @@ lib LibC
   fun chdir = chdir(path : UInt8*) : Int32
   fun opendir(name : UInt8*) : Dir*
   fun closedir(dir : Dir*) : Int32
+  fun dirfd(dir : Dir*) : Int32
 
   fun mkdir(path : UInt8*, mode : LibC::ModeT) : Int32
   fun rmdir(path : UInt8*) : Int32
@@ -77,6 +100,19 @@ lib LibC
   fun glob(pattern : UInt8*, flags : GlobFlags, errfunc : (UInt8*, Int32) -> Int32, result : Glob*) : Int32
   fun globfree(result : Glob*)
 end
+
+{% if HAVE_OPENAT %}
+lib LibC
+  # openat family
+  fun fdopendir(fd : Int32) : Dir*
+  fun openat(dirfd : Int32, path : UInt8*, oflag : Int32, ...) : Int32
+  fun mkdirat(dirfd : Int32, path : UInt8*, mode : LibC::ModeT) : Int32
+  fun fstatat(dirfd : Int32, path : UInt8*, stat : Stat *, flags : AtFlags) : Int32
+  fun linkat(olddirfd : Int32, oldpath : UInt8*, newdirfd : Int32, newpath : UInt8*) : Int32
+  fun renameat(olddirfd : Int32, oldpath : UInt8*, newdirfd : Int32, newpath : UInt8*) : Int32
+  fun unlinkat(dirfd : Int32, path : UInt8*, flags : AtFlags) : Int32
+end
+{% end %}
 
 # Objects of class Dir are directory streams representing directories in the underlying file system.
 # They provide a variety of ways to list directories and their contents. See also `File`.
@@ -96,6 +132,21 @@ class Dir
       raise Errno.new("Error opening directory '#{@path}'")
     end
   end
+
+{% if HAVE_OPENAT %}
+  def initialize fd : Int32, @path
+    fd2 = LibC.openat(fd, path, LibC::O_DIRECTORY | LibC::O_RDONLY | LibC::O_CLOEXEC, 0)
+    if fd2 == -1
+      raise Errno.new("Error opening directory '#{@path}'")
+    end
+
+    @dir = LibC.fdopendir(fd2)
+    unless @dir
+      LibC.close(fd2)
+      raise Errno.new("Error opening directory (fdopendir) '#{@path}'")
+    end
+  end
+{% end %}
 
   # Alias for `new(path)`
   def self.open(path)
@@ -166,6 +217,85 @@ class Dir
   def close
     LibC.closedir(@dir)
   end
+
+  def fd
+    LibC.dirfd(@dir)
+  end
+
+{% if HAVE_OPENAT %}
+  def open path
+    Dir.new(fd, path)
+  end
+
+  def open_file path, mode = "r"
+    File.new(fd, path, mode)
+  end
+
+  def open_file path, mode = "r"
+    file = open_file(path, mode)
+    begin
+      yield file
+    ensure
+      file.close
+    end
+  end
+
+  def stat path
+    if LibC.fstatat(fd, path, out stat, LibC::AtFlags::AT_NONE) != 0
+      raise Errno.new("Unable to get stat for '#{path}'")
+    end
+    File::Stat.new(stat)
+  end
+
+  def lstat path
+    if LibC.fstatat(fd, path, out stat, LibC::AtFlags::AT_SYMLINK_NOFOLLOW) != 0
+      raise Errno.new("Unable to get stat for '#{path}'")
+    end
+    File::Stat.new(stat)
+  end
+
+  # Doesn't distinguish between file or directory.  Something exists
+  def exists? path
+# BUG: check ENOENT, may give incorrect results for EPERM or others.  also incorrect in File#exists?
+    if LibC.fstatat(fd, path, out stat, LibC::AtFlags::AT_NONE) != 0
+      return false
+    end
+
+    return true
+  end
+
+  def mkdir path, mode=0o777
+    if LibC.mkdirat(fd, path, LibC::ModeT.cast(mode)) == -1
+      raise Errno.new("Unable to create directory '#{path}'")
+    end
+    nil
+  end
+
+  def rmdir path
+    if LibC.unlinkat(fd, path, LibC::AtFlags::AT_REMOVEDIR) == -1
+      raise Errno.new("Unable to remove directory '#{path}'")
+    end
+    nil
+  end
+
+  def delete path
+    if LibC.unlinkat(fd, path, LibC::AtFlags::AT_NONE) == -1
+      raise Errno.new("Unable to remove file '#{path}'")
+    end
+    nil
+  end
+
+  def rename old_path, new_path
+    rename(old_path, self, new_path)
+  end
+
+  def rename old_path, new_dir : Dir, new_path
+    if LibC.renameat(fd, old_path, new_dir.fd, new_path) != 0
+      raise Errno.new("Error renaming file '#{old_path}' to '#{new_path}'")
+    end
+    nil
+  end
+{% end %}
 
   def self.working_directory
     dir = LibC.getcwd(nil, 0)

--- a/src/io.cr
+++ b/src/io.cr
@@ -12,6 +12,8 @@ lib LibC
     O_CREAT    = 0o0000100
     O_TRUNC    = 0o0001000
     O_NONBLOCK = 0o0004000
+    O_CLOEXEC  = 0o2000000
+    O_DIRECTORY = 0o200000
   elsif darwin
     O_RDONLY   = 0x0000
     O_WRONLY   = 0x0001
@@ -20,6 +22,8 @@ lib LibC
     O_CREAT    = 0x0200
     O_TRUNC    = 0x0400
     O_NONBLOCK = 0x0004
+    O_CLOEXEC  = 0x1000000
+    O_DIRECTORY = 0x100000
   end
 
   S_IRWXU    = 0o000700         # RWX mask for owner


### PR DESCRIPTION
The purpose of the openat() function is to enable opening files in directories other than the current working directory without exposure to race conditions. Any part of the path of a file could be changed in parallel to a call to open(), resulting in unspecified behavior. By opening a file descriptor for the target directory and using the openat() function it can be guaranteed that the opened file is located relative to the desired directory.

openat() is part of POSIX.1-2008.

New Dir methods:
  open, open_file, exists?, stat, lstat, mkdir, rmdir, rename, delete