### PR TITLE
New class Mmap.

### DIFF
--- a/spec/std/mmap_spec.cr
+++ b/spec/std/mmap_spec.cr
@@ -1,0 +1,53 @@
+require "spec"
+require "mmap"
+
+struct MmapTestStruct
+  property int, float
+
+  def initialize @int : Int32, @float : Float64
+  end
+end
+
+describe Mmap do
+  it "mmaps UInt8" do
+    foo = "foo"
+    bar = "bar"
+
+    Mmap(UInt8).open(size: 4096) do |mmap|
+      mmap[4] = foo.to_slice
+      mmap[8] = bar.to_slice
+      String.new(mmap[4, 8]).should eq("foo\0bar\0")
+
+      mmap[4095] = "a".to_slice
+      expect_raises(ArgumentError) do
+        mmap[4095] = "ab".to_slice
+      end
+    end
+  end
+
+  it "mmaps Int64" do
+    Mmap(Int64).open(size: 2) do |mmap|
+      mmap[1] = 1.to_i64
+      mmap[1].should eq(1.to_i64)
+
+      expect_raises(ArgumentError) do
+        mmap[2] = 2.to_i64
+      end
+    end
+  end
+
+  it "mmaps a struct" do
+    Mmap(MmapTestStruct).open(size: 2) do |mmap|
+      st = MmapTestStruct.new 1, 2.0
+      mmap[1] = st
+      mmap[1].should eq(st)
+
+      st.int += 1
+      mmap[1].should_not eq(st)
+
+      expect_raises(ArgumentError) do
+        mmap[2] = st
+      end
+    end
+  end
+end

--- a/src/libc.cr
+++ b/src/libc.cr
@@ -44,25 +44,6 @@ lib LibC
   fun memcmp(p1 : Void*, p2 : Void*, size : SizeT) : Int32
   fun _exit(status : Int) : NoReturn
 
-  PROT_NONE = 0x00
-  PROT_READ = 0x01
-  PROT_WRITE = 0x02
-  PROT_EXEC = 0x04
-  MAP_SHARED = 0x0001
-  MAP_PRIVATE = 0x0002
-
-  ifdef darwin
-    MAP_ANON = 0x1000
-  end
-  ifdef linux
-    MAP_ANON = 0x0020
-  end
-
-  MAP_FAILED = Pointer(Void).new(SizeT.new(-1))
-
-  fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : SSizeT) : Void*
-  fun munmap(addr : Void*, len : SizeT)
-
   # used by [event, io, time]
   struct TimeSpec
     tv_sec  : LibC::TimeT

--- a/src/mmap.cr
+++ b/src/mmap.cr
@@ -1,0 +1,133 @@
+lib LibC
+  MAP_FAILED = Pointer(Void).new(SizeT.new(-1))
+
+  fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : SSizeT) : Void*
+  fun munmap(addr : Void*, len : SizeT) : Int
+  fun madvise(addr : Void*, length : SizeT, advice : Int) : Int
+  fun msync(addr : Void*, length : SizeT, flags : Int) : Int
+end
+
+class Mmap(T)
+  @[Flags]
+  enum Prot
+    None = 0x00
+    Read = 0x01
+    Write = 0x02
+    Exec = 0x04
+    ReadWrite = Read | Write
+  end
+
+  ifdef darwin
+    @[Flags]
+    enum Flags
+      Shared = 0x0001
+      Private = 0x0002
+      Anon = 0x1000
+      Default = Private | Anon
+    end
+  elsif linux
+    @[Flags]
+    enum Flags
+      Shared = 0x0001
+      Private = 0x0002
+      Anon = 0x0020
+      Default = Private | Anon
+    end
+  end
+
+  getter size
+
+  def self.open addr = nil, size = 0, prot = Prot::ReadWrite, flags = Flags::Default, fd = -1, offset = 0
+    mmap = new addr, size, prot, flags, fd, offset
+    begin
+      yield mmap
+    ensure
+      mmap.close
+    end
+  end
+
+  # size is specified in the number of T's or bytes for Void.
+  def initialize addr = nil, @size = 0, prot = Prot::ReadWrite, flags = Flags::Default, fd = -1, offset = 0
+    ret = LibC.mmap(addr, bytesize, prot, flags, fd, offset)
+    raise Errno.new("mmap") if ret == LibC::MAP_FAILED
+    @pointer = ret as Pointer(T)
+  end
+
+  # Gets the value pointed at this pointer's address plus `offset * sizeof(T)`.
+  def [](offset) : T
+    dst = pointer_offset offset
+    dst.value
+  end
+
+  # Returns a `Slice(T)` that points to this pointer and is bounded by the given *length*.
+  def [](offset, length) : Slice(T)
+    dst = pointer_offset offset
+    Slice(T).new dst, length
+  end
+
+  # Sets the value pointed at this pointer's address plus `offset * sizeof(T)`.
+  def []=(offset, val : T) : T
+    dst = pointer_offset offset
+    src = pointerof(val)
+    dst.copy_from src, 1
+    val
+  end
+
+  # Copies *slice.count* elements from *slice* into *self*.
+  def []= offset, slice : Slice(T)
+    dst = pointer_offset offset, slice.size
+    slice.copy_to dst, slice.size
+    slice
+  end
+
+  def bytesize
+    sizeof(T) * @size
+  end
+
+  # See POSIX madvise()
+  def advise offset, length, advice
+    dst = pointer_offset offset, length
+    if LibC.madvise(dst, length, advice) != 0
+      raise Errno.new("madvise")
+    end
+    nil
+  end
+
+  # See POSIX msync()
+  def sync offset, length, flags
+    dst = pointer_offset offset, length
+    if LibC.madvise(dst, length, flags) != 0
+      raise Errno.new("msync")
+    end
+    nil
+  end
+
+  # After closing all slices and pointers referencing the mmap'd area will be inaccessible.
+  def close
+    ptr = @pointer
+    return if ptr.null?
+
+    if LibC.munmap(ptr as Pointer(Void), bytesize) != 0
+      raise Errno.new("munmap")
+    end
+    @pointer = Pointer(T).null
+    @size = 0
+    nil
+  end
+
+  def to_unsafe
+    @pointer
+  end
+
+  def finalize
+    close
+  end
+
+  private def pointer_offset offset, length = 1
+    if offset + length > @size
+      raise ArgumentError.new("copy would extend out of mapped memory offset=#{offset} length=#{length} mmap_size=#{@size}")
+    end
+
+    @pointer + offset
+  end
+end


### PR DESCRIPTION
Change Fiber to use Mmap instead of LibC.mmap.
Move mmap related functions and constants from libc.cr to mmap.cr.

@asterite This class has several future uses.
* Thread stack allocation so multithreading can finally work with fibers.
* Everything else you would use mmap for (shared semaphores, zero copy io, databases, etc).
