### PR TITLE
Add Tuple.from, Tuple#from, NamedTuple.from and NamedTuple#from

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -5,6 +5,50 @@ describe "NamedTuple" do
     NamedTuple.new(x: 1, y: 2).should eq({x: 1, y: 2})
   end
 
+  it "does NamedTuple.from" do
+    t = NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :bar => 2})
+    t.should eq({foo: 1, bar: 2})
+    t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
+
+    t = NamedTuple(foo: Int32, bar: Int32).from({"foo" => 1, "bar" => 2})
+    t.should eq({foo: 1, bar: 2})
+    t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
+
+    expect_raises ArgumentError do
+      NamedTuple(foo: Int32, bar: Int32).from({:foo => 1})
+    end
+
+    expect_raises KeyError do
+      NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :baz => 2})
+    end
+
+    expect_raises(TypeCastError, /cast to Int32 failed/) do
+      NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :bar => "foo"})
+    end
+  end
+
+  it "does NamedTuple#from" do
+    t = {foo: Int32, bar: Int32}.from({:foo => 1, :bar => 2})
+    t.should eq({foo: 1, bar: 2})
+    t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
+
+    t = {foo: Int32, bar: Int32}.from({"foo" => 1, "bar" => 2})
+    t.should eq({foo: 1, bar: 2})
+    t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
+
+    expect_raises ArgumentError do
+      {foo: Int32, bar: Int32}.from({:foo => 1})
+    end
+
+    expect_raises KeyError do
+      {foo: Int32, bar: Int32}.from({:foo => 1, :baz => 2})
+    end
+
+    expect_raises(TypeCastError, /cast to Int32 failed/) do
+      {foo: Int32, bar: Int32}.from({:foo => 1, :bar => "foo"})
+    end
+  end
+
   it "gets size" do
     {a: 1, b: 3}.size.should eq(2)
   end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -141,8 +141,37 @@ describe "Tuple" do
     u[1].should_not be(r2)
   end
 
-  it "does Tuple#new" do
+  it "does Tuple.new" do
     Tuple.new(1, 2, 3).should eq({1, 2, 3})
+    Tuple.new([1, 2, 3]).should eq({[1, 2, 3]})
+  end
+
+  it "does Tuple.from" do
+    t = Tuple(Int32, Float64).from([1_i32, 2.0_f64])
+    t.should eq({1_i32, 2.0_f64})
+    t.class.should eq(Tuple(Int32, Float64))
+
+    expect_raises ArgumentError do
+      Tuple(Int32).from([1, 2])
+    end
+
+    expect_raises(TypeCastError, /cast to Int32 failed/) do
+      Tuple(Int32, String).from(["foo", 1])
+    end
+  end
+
+  it "does Tuple#from" do
+    t = {Int32, Float64}.from([1_i32, 2.0_f64])
+    t.should eq({1_i32, 2.0_f64})
+    t.class.should eq(Tuple(Int32, Float64))
+
+    expect_raises ArgumentError do
+      {Int32}.from([1, 2])
+    end
+
+    expect_raises(TypeCastError, /cast to Int32 failed/) do
+      {Int32, String}.from(["foo", 1])
+    end
   end
 
   it "clones empty tuple" do

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -81,6 +81,45 @@ struct Tuple
     args
   end
 
+  # Creates a tuple from the given array, with elements casted to the given types. See `#from`.
+  #
+  # ```
+  # Tuple(String, Int64).from(["world", 2])       # => {"world", 2}
+  # Tuple(String, Int64).from(["world", 2]).class # => {String, Int64}
+  # ```
+  def self.from(array : Array)
+    {% begin %}
+    Tuple.new({{@type.type_vars.argify}}).from(array)
+    {% end %}
+  end
+
+  # Expects to be called on a tuple of types, creates a tuple from the given array,
+  # with types casted appropriately.
+  #
+  # This allows you to easily pass an array as individual arguments to a method.
+  #
+  # ```
+  # def speak_about(thing : String, n : Int64)
+  #   "I see #{n} #{thing}s"
+  # end
+  #
+  # data = JSON.parse(%(["world", 2])).as_a
+  # speak_about(*{String, Int64}).from(data)) # => "I see 2 worlds"
+  # ```
+  def from(array : Array)
+    if size != array.size
+      raise ArgumentError.new "Expected array of size #{size} but one of size #{array.size} was given."
+    end
+
+    {% begin %}
+    Tuple.new(
+    {% for i in 0...@type.size %}
+      self[{{i}}].cast(array[{{i}}]),
+    {% end %}
+    )
+    {% end %}
+  end
+
   # Returns the element at the given index. Read the type docs to understand
   # the difference between indexing with a number literal or a variable.
   #


### PR DESCRIPTION
Similar arguments as for `values_at(*args)` back then, except it can handle
mixed types.

In general I thought it might be a generally useful and a neat trick. It can also
provide a nice way to parse mixed JSON or YAML arrays.

```cr
thing, n = {String, Int64}.from(JSON.parse(%(["world", 2])) as Array)
```