### PR TITLE
UDPSocket#recvfrom, #send, and #sendto

### DIFF
--- a/samples/tcp_server.cr
+++ b/samples/tcp_server.cr
@@ -3,7 +3,7 @@ require "socket"
 # goes with tcp_client.cr
 
 def process(client)
-  client_addr = "#{client.peeraddr.ip_address}:#{client.peeraddr.ip_port}"
+  client_addr = "#{client.peeraddr.address}:#{client.peeraddr.port}"
   puts "#{client_addr} connected"
 
   while msg = client.read_line

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -1,6 +1,28 @@
 require "spec"
 require "socket"
 
+describe "Socket::Addr" do
+  it "transforms into C SockAddr struct ip4" do
+    addr1 = Socket::Addr.new("AF_INET", 8080.to_u16, "127.0.0.1")
+    sockaddr = addr1.to_sockaddr
+    addr2 = Socket::Addr.new(sockaddr)
+
+    addr1.family.should eq(addr2.family)
+    addr1.ip_port.should eq(addr2.ip_port)
+    addr1.ip_address.should eq(addr2.ip_address)
+  end
+
+  it "transforms into C SockAddr struct ip6" do
+    addr1 = Socket::Addr.new("AF_INET6", 12345.to_u16, "2001:db8:8714:3a90::12")
+    sockaddr = addr1.to_sockaddr
+    addr2 = Socket::Addr.new(sockaddr)
+
+    addr1.family.should eq(addr2.family)
+    addr1.ip_port.should eq(addr2.ip_port)
+    addr1.ip_address.should eq(addr2.ip_address)
+  end
+end
+
 describe "UNIXSocket" do
   it "sends and receives messages" do
     path = "/tmp/crystal-test-unix-sock"

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -21,6 +21,13 @@ describe "Socket::Addr" do
     addr1.ip_port.should eq(addr2.ip_port)
     addr1.ip_address.should eq(addr2.ip_address)
   end
+
+  it "raises when the address family is not IPv4 or IPv6" do
+    addr = Socket::Addr.new("AF_UNIX", "/tmp/test")
+    expect_raises(Exception, "Unsupported address family") do
+      addr.to_sockaddr
+    end
+  end
 end
 
 describe "UNIXSocket" do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -268,7 +268,7 @@ describe "UDPSocket" do
     client.connect("255.255.255.255", 12349)
     client.broadcast = true
     client.broadcast?.should be_true
-    client.write("broadcast".to_slice).should eq(9)
+    client.send("broadcast".to_slice).should eq(9)
     client.close
   end
 end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -272,9 +272,9 @@ describe "UDPSocket" do
 
   it "broadcast messages" do
     client = UDPSocket.new(Socket::Family::INET)
-    client.connect("255.255.255.255", 12349)
     client.broadcast = true
     client.broadcast?.should be_true
+    client.connect("255.255.255.255", 12349)
     client.send("broadcast".to_slice).should eq(9)
     client.close
   end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -141,18 +141,18 @@ describe "TCPSocket" do
         # so for now we keep it commented. Once we can force the family
         # we can uncomment them.
 
-        # client.addr.family.should eq("AF_INET")
-        # client.addr.ip_address.should eq("127.0.0.1")
+        # client.addr.family.should eq(Socket::Family::INET)
+        # client.addr.address.should eq("127.0.0.1")
 
         sock = server.accept
         sock.sync?.should eq(server.sync?)
 
-        # sock.addr.family.should eq("AF_INET6")
-        # sock.addr.ip_port.should eq(12345)
-        # sock.addr.ip_address.should eq("::ffff:127.0.0.1")
+        # sock.addr.family.should eq(Socket::Family::INET6)
+        # sock.addr.port.should eq(12345)
+        # sock.addr.address.should eq("::ffff:127.0.0.1")
 
-        # sock.peeraddr.family.should eq("AF_INET6")
-        # sock.peeraddr.ip_address.should eq("::ffff:127.0.0.1")
+        # sock.peeraddr.family.should eq(Socket::Family::INET6)
+        # sock.peeraddr.address.should eq("::ffff:127.0.0.1")
 
         # test protocol specific socket options
         (client.tcp_nodelay = true).should be_true

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "socket"
 
 describe "Socket::Addr" do
-  it "transforms into C SockAddr struct ip4" do
+  it "transforms into C SockAddr struct IPv4" do
     addr1 = Socket::Addr.new("AF_INET", 8080.to_u16, "127.0.0.1")
     sockaddr = addr1.to_sockaddr
     addr2 = Socket::Addr.new(sockaddr)
@@ -12,7 +12,7 @@ describe "Socket::Addr" do
     addr1.ip_address.should eq(addr2.ip_address)
   end
 
-  it "transforms into C SockAddr struct ip6" do
+  it "transforms into C SockAddr struct IPv6" do
     addr1 = Socket::Addr.new("AF_INET6", 12345.to_u16, "2001:db8:8714:3a90::12")
     sockaddr = addr1.to_sockaddr
     addr2 = Socket::Addr.new(sockaddr)
@@ -225,7 +225,7 @@ describe "UDPSocket" do
     server.close
   end
 
-  it "sends and receives messages by sendto and recvfrom" do
+  it "sends and receives messages by sendto and recvfrom over IPv4" do
     server = UDPSocket.new
     server.bind("localhost", 12347)
 
@@ -247,9 +247,25 @@ describe "UDPSocket" do
     client.close
   end
 
+  it "sends and receives messages by sendto and recvfrom over IPv6" do
+    server = UDPSocket.new(Socket::Family::INET6)
+    server.bind("::1", 12348)
+
+    client = UDPSocket.new(Socket::Family::INET6)
+
+    client.sendto("message".to_slice, server.addr)
+    message, addr = server.recvfrom(1500)
+    String.new(message).should eq("message")
+    addr.family.should eq(server.addr.family)
+    addr.ip_address.should eq(server.addr.ip_address)
+
+    server.close
+    client.close
+  end
+
   it "broadcast messages" do
     client = UDPSocket.new
-    client.connect("255.255.255.255", 12348)
+    client.connect("255.255.255.255", 12349)
     client.broadcast = true
     client.broadcast?.should be_true
     client.write("broadcast".to_slice).should eq(9)

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -201,7 +201,7 @@ describe "TCPSocket" do
 end
 
 describe "UDPSocket" do
-  it "sends and receives messages" do
+  it "sends and receives messages by reading and writing" do
     server = UDPSocket.new(Socket::Family::INET6)
     server.bind("::", 12346)
 
@@ -223,6 +223,28 @@ describe "UDPSocket" do
 
     client.close
     server.close
+  end
+
+  it "sends and receives messages by sendto and recvfrom" do
+    server = UDPSocket.new
+    server.bind("localhost", 12347)
+
+    client = UDPSocket.new
+
+    client.sendto("message equal to buffer".to_slice, server.addr)
+    message1, addr1 = server.recvfrom(23)
+    String.new(message1).should eq("message equal to buffer")
+    addr1.family.should eq(server.addr.family)
+    addr1.ip_address.should eq(server.addr.ip_address)
+
+    client.sendto("message less than buffer".to_slice, server.addr)
+    message2, addr2 = server.recvfrom(256)
+    String.new(message2).should eq("message less than buffer")
+    addr2.family.should eq(server.addr.family)
+    addr2.ip_address.should eq(server.addr.ip_address)
+
+    server.close
+    client.close
   end
 
   it "broadcast messages" do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -202,4 +202,13 @@ describe "UDPSocket" do
     client.close
     server.close
   end
+
+  it "broadcast messages" do
+    client = UDPSocket.new
+    client.connect("255.255.255.255", 12348)
+    client.broadcast = true
+    client.broadcast?.should be_true
+    client.write("broadcast".to_slice).should eq(9)
+    client.close
+  end
 end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -233,10 +233,10 @@ describe "UDPSocket" do
   end
 
   it "sends and receives messages by sendto and recvfrom over IPv4" do
-    server = UDPSocket.new
-    server.bind("localhost", 12347)
+    server = UDPSocket.new(Socket::Family::INET)
+    server.bind("127.0.0.1", 12347)
 
-    client = UDPSocket.new
+    client = UDPSocket.new(Socket::Family::INET)
 
     client.sendto("message equal to buffer".to_slice, server.addr)
     message1, addr1 = server.recvfrom(23)
@@ -271,7 +271,7 @@ describe "UDPSocket" do
   end
 
   it "broadcast messages" do
-    client = UDPSocket.new
+    client = UDPSocket.new(Socket::Family::INET)
     client.connect("255.255.255.255", 12349)
     client.broadcast = true
     client.broadcast?.should be_true

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -8,11 +8,7 @@ class IPSocket < Socket
         raise Errno.new("{{method.id}}")
       end
 
-      if addrlen == sizeof(LibC::SockAddrIn6)
-        Addr.new((pointerof(sockaddr) as LibC::SockAddrIn6*).value)
-      else
-        Addr.new((pointerof(sockaddr) as LibC::SockAddrIn*).value)
-      end
+      IPAddr.new(sockaddr, addrlen)
     end
   end
 

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -1,22 +1,18 @@
 class IPSocket < Socket
   macro sockname(name, method)
     def {{name.id}}
-      addr :: LibC::SockAddrIn6
+      sockaddr :: LibC::SockAddrIn6
       addrlen = LibC::SocklenT.new(sizeof(LibC::SockAddrIn6))
 
-      if LibC.{{method.id}}(fd, pointerof(addr) as LibC::SockAddr*, pointerof(addrlen)) != 0
+      if LibC.{{method.id}}(fd, pointerof(sockaddr) as LibC::SockAddr*, pointerof(addrlen)) != 0
         raise Errno.new("{{method.id}}")
       end
 
       if addrlen == sizeof(LibC::SockAddrIn6)
-        family_name = "AF_INET6"
-        result_addr = (pointerof(addr) as LibC::SockAddrIn6*).value
+        Addr.new((pointerof(sockaddr) as LibC::SockAddrIn6*).value)
       else
-        family_name = "AF_INET"
-        result_addr = (pointerof(addr) as LibC::SockAddrIn*).value
+        Addr.new((pointerof(sockaddr) as LibC::SockAddrIn*).value)
       end
-
-      Addr.new(family_name, LibC.htons(result_addr.port).to_u16, Socket.inet_ntop(result_addr))
     end
   end
 

--- a/src/socket/libc.cr
+++ b/src/socket/libc.cr
@@ -176,6 +176,8 @@ lib LibC
   fun getsockopt(sock : Int, level : Int, opt : Int, optval : Void*, optlen : SocklenT*) : Int
   fun setsockopt(sock : Int, level : Int, opt : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(sock : Int, how : Shutdown) : Int
+  fun sendto(sock : Int, buffer : Void*, length : SizeT, flags : Int, dest_addr : SockAddr*, dest_len : SocklenT) : SSizeT
+  fun recvfrom(sock : Int, buffer : Void*, length : SizeT, flags : Int, addr : SockAddr*, addr_len : SocklenT*) : SSizeT
 
   SOCK_STREAM = 1
   SOCK_DGRAM = 2

--- a/src/socket/libc.cr
+++ b/src/socket/libc.cr
@@ -176,6 +176,7 @@ lib LibC
   fun getsockopt(sock : Int, level : Int, opt : Int, optval : Void*, optlen : SocklenT*) : Int
   fun setsockopt(sock : Int, level : Int, opt : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(sock : Int, how : Shutdown) : Int
+  fun send(sock : Int, buffer : Void*, length : SizeT, flags : Int) : SSizeT
   fun sendto(sock : Int, buffer : Void*, length : SizeT, flags : Int, dest_addr : SockAddr*, dest_len : SocklenT) : SSizeT
   fun recvfrom(sock : Int, buffer : Void*, length : SizeT, flags : Int, addr : SockAddr*, addr_len : SocklenT*) : SSizeT
 

--- a/src/socket/libc.cr
+++ b/src/socket/libc.cr
@@ -86,6 +86,7 @@ lib LibC
     SOL_SOCKET = 0xffff
     SO_REUSEADDR = 0x0004
     SO_KEEPALIVE = 0x0008
+    SO_BROADCAST = 0x0020
     SO_LINGER = 0x0080
     SO_SNDBUF = 0x1001
     SO_RCVBUF = 0x1002
@@ -129,6 +130,7 @@ lib LibC
 
     SOL_SOCKET = 1
     SO_REUSEADDR = 2
+    SO_BROADCAST = 6
     SO_SNDBUF = 7
     SO_RCVBUF = 8
     SO_KEEPALIVE = 9

--- a/src/socket/libc.cr
+++ b/src/socket/libc.cr
@@ -165,6 +165,7 @@ lib LibC
   fun inet_pton(af : Int, src : Char*, dst : Void*) : Int
   fun inet_ntop(af : Int, src : Void*, dst : Char*, size : SocklenT) : Char*
   fun htons(n : UInt16T) : UInt16T
+  fun ntohs(n : UInt16T) : UInt16T
   fun bind(fd : Int, addr : SockAddr*, addr_len : SocklenT) : Int
   fun listen(fd : Int, backlog : Int) : Int
   fun accept(fd : Int, addr : SockAddr*, addr_len : SocklenT*) : Int

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -37,7 +37,7 @@ class Socket < IO::FileDescriptor
       @family = case sockaddr.family
       when LibC::AF_INET then "AF_INET"
       when LibC::AF_INET6 then "AF_INET6"
-      else raise "Unsupported family address"
+      else raise "Unsupported address family"
       end
       @ip_port = LibC.htons(sockaddr.port).to_u16
       @ip_address = Socket.inet_ntop(sockaddr)
@@ -45,29 +45,34 @@ class Socket < IO::FileDescriptor
 
     def to_sockaddr
       case family
-      when "AF_INET"
-        sockaddr1 = LibC::SockAddrIn.new
-        sockaddr1.family = LibC::AF_INET.to_u8
-
-        addr1 = sockaddr1.addr
-        LibC.inet_pton(LibC::AF_INET, ip_address || "", pointerof(addr1) as Void*)
-
-        sockaddr1.port = LibC.ntohs(ip_port || 0_i16).to_i16
-        sockaddr1.addr = addr1
-        sockaddr1
-      when "AF_INET6"
-        sockaddr = LibC::SockAddrIn6.new
-        sockaddr.family = LibC::AF_INET6.to_u8
-
-        addr = sockaddr.addr
-        LibC.inet_pton(LibC::AF_INET6, ip_address || "", pointerof(addr) as Void*)
-
-        sockaddr.port = LibC.ntohs(ip_port || 0_i16).to_i16
-        sockaddr.addr = addr
-        sockaddr
-      else
-        raise "Unsupported family address"
+      when "AF_INET" then to_sockaddrin
+      when "AF_INET6" then to_sockaddrin6
+      else raise "Unsupported address family"
       end
+    end
+
+    private def to_sockaddrin
+      sockaddr = LibC::SockAddrIn.new
+      sockaddr.family = LibC::AF_INET.to_u8
+
+      addr = sockaddr.addr
+      LibC.inet_pton(LibC::AF_INET, ip_address || "", pointerof(addr) as Void*)
+
+      sockaddr.port = LibC.ntohs(ip_port || 0_i16).to_i16
+      sockaddr.addr = addr
+      sockaddr
+    end
+
+    private def to_sockaddrin6
+      sockaddr = LibC::SockAddrIn6.new
+      sockaddr.family = LibC::AF_INET6.to_u8
+
+      addr = sockaddr.addr
+      LibC.inet_pton(LibC::AF_INET6, ip_address || "", pointerof(addr) as Void*)
+
+      sockaddr.port = LibC.ntohs(ip_port || 0_i16).to_i16
+      sockaddr.addr = addr
+      sockaddr
     end
   end
 

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -99,6 +99,14 @@ class Socket < IO::FileDescriptor
     setsockopt_bool LibC::SO_REUSEADDR, val
   end
 
+  def broadcast?
+    getsockopt_bool LibC::SO_BROADCAST
+  end
+
+  def broadcast= val : Bool
+    setsockopt_bool LibC::SO_BROADCAST, val
+  end
+
   def keepalive?
     getsockopt_bool LibC::SO_KEEPALIVE
   end

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -24,55 +24,85 @@ class Socket < IO::FileDescriptor
     INET6  = LibC::AF_INET6
   end
 
-  struct Addr
-    property :family, :ip_port, :ip_address, :path
+  struct IPAddr
+    getter family
+    getter address
+    getter port
 
-    def initialize(@family, @ip_port, @ip_address)
-    end
-
-    def initialize(@family, @path)
-    end
-
-    def initialize(sockaddr : LibC::SockAddrIn | LibC::SockAddrIn6)
-      @family = case sockaddr.family
-      when LibC::AF_INET then "AF_INET"
-      when LibC::AF_INET6 then "AF_INET6"
-      else raise "Unsupported address family"
+    def initialize(family : Family, address : String, port : Int16)
+      if family != Family::INET && family != Family::INET6
+        raise ArgumentError.new("Unsupported address family")
       end
-      @ip_port = LibC.htons(sockaddr.port).to_u16
-      @ip_address = Socket.inet_ntop(sockaddr)
+
+      @family = family
+      @address = address
+      @port = port
     end
 
-    def to_sockaddr
+    def initialize(sockaddr : LibC::SockAddrIn6, addrlen : LibC::SocklenT)
+      case addrlen
+      when LibC::SocklenT.new(sizeof(LibC::SockAddrIn))
+        sockaddrin = (pointerof(sockaddr) as LibC::SockAddrIn*).value
+        addr = sockaddrin.addr
+        @family = Family::INET
+        @address = inet_ntop(family.value, pointerof(addr) as Void*, addrlen)
+      when LibC::SocklenT.new(sizeof(LibC::SockAddrIn6))
+        addr6 = sockaddr.addr
+        @family = Family::INET6
+        @address = inet_ntop(family.value, pointerof(addr6) as Void*, addrlen)
+      else
+        raise ArgumentError.new("Unsupported address family")
+      end
+      @port = LibC.htons(sockaddr.port).to_i16
+    end
+
+    def sockaddr
+      sockaddrin6 = LibC::SockAddrIn6.new
+      sockaddrin6.family = family.value.to_u8
+
       case family
-      when "AF_INET" then to_sockaddrin
-      when "AF_INET6" then to_sockaddrin6
-      else raise "Unsupported address family"
+      when Family::INET
+        sockaddrin = (pointerof(sockaddrin6) as LibC::SockAddrIn*).value
+        addr = sockaddrin.addr
+        LibC.inet_pton(family.value, address, pointerof(addr) as Void*)
+        sockaddrin.addr = addr
+        sockaddrin6 = (pointerof(sockaddrin) as LibC::SockAddrIn6*).value
+      when Family::INET6
+        addr6 = sockaddrin6.addr
+        LibC.inet_pton(family.value, address, pointerof(addr6) as Void*)
+        sockaddrin6.addr = addr6
+      end
+
+      sockaddrin6.port = LibC.ntohs(port).to_i16
+      sockaddrin6
+    end
+
+    def addrlen
+      case family
+      when Family::INET then LibC::SocklenT.new(sizeof(LibC::SockAddrIn))
+      when Family::INET6 then LibC::SocklenT.new(sizeof(LibC::SockAddrIn6))
+      else LibC::SocklenT.new(0)
       end
     end
 
-    private def to_sockaddrin
-      sockaddr = LibC::SockAddrIn.new
-      sockaddr.family = LibC::AF_INET.to_u8
+    private def inet_ntop(af : Int, src : Void*, len : LibC::SocklenT)
+      dest = GC.malloc_atomic(addrlen.to_u32) as UInt8*
+      if LibC.inet_ntop(af, src, dest, len).null?
+        raise Errno.new("Failed to convert IP address")
+      end
+      String.new(dest)
+    end
+  end
 
-      addr = sockaddr.addr
-      LibC.inet_pton(LibC::AF_INET, ip_address || "", pointerof(addr) as Void*)
+  struct UNIXAddr
+    getter path
 
-      sockaddr.port = LibC.ntohs(ip_port || 0_i16).to_i16
-      sockaddr.addr = addr
-      sockaddr
+    def initialize(path)
+      @path = path
     end
 
-    private def to_sockaddrin6
-      sockaddr = LibC::SockAddrIn6.new
-      sockaddr.family = LibC::AF_INET6.to_u8
-
-      addr = sockaddr.addr
-      LibC.inet_pton(LibC::AF_INET6, ip_address || "", pointerof(addr) as Void*)
-
-      sockaddr.port = LibC.ntohs(ip_port || 0_i16).to_i16
-      sockaddr.addr = addr
-      sockaddr
+    def family
+      Family::UNIX
     end
   end
 
@@ -218,24 +248,6 @@ class Socket < IO::FileDescriptor
     v = optval ? 1 : 0
     ret = setsockopt optname, v, level
     optval
-  end
-
-  def self.inet_ntop(sa : LibC::SockAddrIn6)
-    ip_address = GC.malloc_atomic(LibC::INET6_ADDRSTRLEN.to_u32) as UInt8*
-    addr = sa.addr
-    if LibC.inet_ntop(LibC::AF_INET6, pointerof(addr) as Void*, ip_address, LibC::INET6_ADDRSTRLEN).null?
-      raise Errno.new("inet_ntop")
-    end
-    String.new(ip_address)
-  end
-
-  def self.inet_ntop(sa : LibC::SockAddrIn)
-    ip_address = GC.malloc_atomic(LibC::INET_ADDRSTRLEN.to_u32) as UInt8*
-    addr = sa.addr
-    if LibC.inet_ntop(LibC::AF_INET, pointerof(addr) as Void*, ip_address, LibC::INET_ADDRSTRLEN).null?
-      raise Errno.new("inet_ntop")
-    end
-    String.new(ip_address)
   end
 
   private def nonblocking_connect host, port, ai, timeout = nil

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -75,6 +75,17 @@ class UDPSocket < IPSocket
     end
   end
 
+  def send(slice : Slice(UInt8))
+    bytes_sent = LibC.send(fd, (slice.to_unsafe as Void*), slice.size, 0)
+    if bytes_sent != -1
+      return bytes_sent
+    end
+
+    raise Errno.new("Error writing datagram")
+  ensure
+    add_write_event unless writers.empty?
+  end
+
   def sendto(slice : Slice(UInt8), dest_addr : Addr)
     case dest_addr.family
     when "AF_INET"

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -76,8 +76,17 @@ class UDPSocket < IPSocket
   end
 
   def sendto(slice : Slice(UInt8), dest_addr : Addr)
-    sockaddr = dest_addr.to_sockaddr as LibC::SockAddrIn
-    bytes_sent = LibC.sendto(fd, (slice.to_unsafe as Void*), slice.size, 0, pointerof(sockaddr) as LibC::SockAddr*, sizeof(LibC::SockAddrIn))
+    case dest_addr.family
+    when "AF_INET"
+      d4 = dest_addr.to_sockaddr as LibC::SockAddrIn
+      bytes_sent = LibC.sendto(fd, (slice.to_unsafe as Void*), slice.size, 0, pointerof(d4) as LibC::SockAddr*, sizeof(LibC::SockAddrIn))
+    when "AF_INET6"
+      d6 = dest_addr.to_sockaddr as LibC::SockAddrIn6
+      bytes_sent = LibC.sendto(fd, (slice.to_unsafe as Void*), slice.size, 0, pointerof(d6) as LibC::SockAddr*, sizeof(LibC::SockAddrIn6))
+    else
+      raise "Unsupported family"
+    end
+
     if bytes_sent != -1
       return bytes_sent
     end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -51,10 +51,10 @@ class UNIXSocket < Socket
   end
 
   def addr
-    Addr.new("AF_UNIX", path.to_s)
+    UNIXAddr.new(path.to_s)
   end
 
   def peeraddr
-    Addr.new("AF_UNIX", path.to_s)
+    UNIXAddr.new(path.to_s)
   end
 end


### PR DESCRIPTION
Hey,

This patch adds support for `recvfrom`, `send`, and `sendto` to `UDPSocket` without any breaking changes. The basic idea is that a Crystal programmer only has to work with `Socket::Addr` which abstracts away the subtle differences between IPv4, IPv6 and the sharp edges of the C APIs.

``` crystal
server = UDPSocket.new
server.bind("localhost", 12345)

client = UDPSocket.new
client.sendto("message equal to buffer".to_slice, server.addr)
message, addr = server.recvfrom(23)

String.new(message) # => "message equal to buffer"
addr.family # => "AF_INET"
addr.ip_address # => "127.0.0.1"
addr.ip_port => 40539

# ...
```

We achieve this by extending `Socket::Addr` to transparently handle the transformation between C SockAddr structs. There's a fair bit of casting between the IPv6 and IPv4 variants that could probably be cleaned up, although some of it feels unavoidable.

This patch also adds the option to set the BROADCAST socket option. Mac OS X will deny sending messages to the broadcast address unless this option is set.

``` crystal
client = UDPSocket.new
client.connect("255.255.255.255", 12349)
client.broadcast = true
```

I'd love to get this patch in to help me with my Crystal implementation of the [LIFX LAN protocol](http://lan.developer.lifx.com). Currently I get around the omission of `recvfrom` by reading in a couple of bytes, determining in if this is a protocol message, and then attempting to parse the rest of the message. This can be avoided by correctly using `recvfrom`. Similar APIs exist in other languages such as [Ruby](http://ruby-doc.org/stdlib-1.9.3/libdoc/socket/rdoc/Socket.html), [Python](https://docs.python.org/3/library/socket.html), and [Go](https://golang.org/pkg/net/#IPConn.ReadFromIP).

Other items to consider:

* Should these functions exist in `IPSocket` and not just `UDPSocket`? The man pages seem indicate it can be used on any type of socket, although I only care about UDP specifically.
* Still need to implement the options that `recvfrom`, `send`, and `sendto` accept.
* More documentation with basic examples

I'm relatively new to these low level APIs and welcome all feedback if you think this patch is useful.
