### PR TITLE
Added type restrictions to many collections methods. Fixes #1764

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -339,15 +339,15 @@ describe "Array" do
   end
 
   describe "compact!" do
-    it "returns true if removed" do
+    it "returns self if removed" do
       a = [1, nil, 2, nil, 3]
-      b = a.compact!.should be_true
+      a.compact!.should be(a)
       a.should eq([1, 2, 3])
     end
 
-    it "returns false if not removed" do
+    it "returns nil if not removed" do
       a = [1]
-      b = a.compact!.should be_false
+      a.compact!.should be_nil
       a.should eq([1])
     end
   end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -710,7 +710,6 @@ describe "Hash" do
 
   describe "select" do
     assert { {a: 2, b: 3}.select(:b, :d).should eq({b: 3}) }
-    assert { {a: 2, b: 3}.select.should eq({} of Symbol => Int32) }
     assert { {a: 2, b: 3}.select(:b, :a).should eq({a: 2, b: 3}) }
     it "does not change currrent hash" do
       h = {a: 3, b: 6, c: 9}
@@ -721,7 +720,6 @@ describe "Hash" do
 
   describe "select!" do
     assert { {a: 2, b: 3}.select!(:b, :d).should eq({b: 3}) }
-    assert { {a: 2, b: 3}.select!.should eq({} of Symbol => Int32) }
     assert { {a: 2, b: 3}.select!(:b, :a).should eq({a: 2, b: 3}) }
     it "does change currrent hash" do
       h = {a: 3, b: 6, c: 9}

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -22,8 +22,8 @@ describe "Pointer" do
 
   it "does index with count" do
     p1 = Pointer.malloc(4) { |i| i ** 2 }
-    p1.to_slice(4).index(4).should eq(2)
-    p1.to_slice(4).index(5).should be_nil
+    p1.to_slice(4).index(4.0).should eq(2)
+    p1.to_slice(4).index(5.0).should be_nil
   end
 
   describe "copy_from" do

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -121,10 +121,10 @@ describe "Set" do
   end
 
   it "does -" do
-    set1 = Set{1, 2, 3, 4, 'b'}
+    set1 = Set{1, 2, 3, 4}
     set2 = Set{2, 4, 5}
     set3 = set1 - set2
-    set3.should eq(Set{1, 3, 'b'})
+    set3.should eq(Set{1, 3})
   end
 
   it "does -" do
@@ -136,7 +136,7 @@ describe "Set" do
 
   it "does -" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
+    set2 = [2, 4]
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
   end
@@ -157,16 +157,16 @@ describe "Set" do
 
   it "does ^" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
+    set2 = Set{2, 4, 9}
     set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'a'})
+    set3.should eq(Set{1, 3, 5, 9})
   end
 
   it "does ^" do
-    set1 = Set{1, 2, 3, 4, 'b'}
+    set1 = Set{1, 2, 3, 4, 9}
     set2 = Set{2, 4, 5}
     set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'b'})
+    set3.should eq(Set{1, 3, 5, 9})
   end
 
   it "does ^" do
@@ -178,16 +178,16 @@ describe "Set" do
 
   it "does ^" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
+    set2 = [2, 4, 9]
     set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'a'})
+    set3.should eq(Set{1, 3, 5, 9})
   end
 
   it "does ^" do
-    set1 = Set{1, 2, 3, 4, 'b'}
+    set1 = Set{1, 2, 3, 4, 9}
     set2 = [2, 4, 5]
     set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'b'})
+    set3.should eq(Set{1, 3, 5, 9})
   end
 
   it "does subtract" do
@@ -199,16 +199,16 @@ describe "Set" do
 
   it "does subtract" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
+    set2 = Set{2, 4, 9}
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
   it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 'b'}
+    set1 = Set{1, 2, 3, 4, 9}
     set2 = Set{2, 4, 5}
     set1.subtract set2
-    set1.should eq(Set{1, 3, 'b'})
+    set1.should eq(Set{1, 3, 9})
   end
 
   it "does subtract" do
@@ -220,16 +220,16 @@ describe "Set" do
 
   it "does subtract" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
+    set2 = [2, 4, 9]
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
   it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 'b'}
+    set1 = Set{1, 2, 3, 4, 9}
     set2 = [2, 4, 5]
     set1.subtract set2
-    set1.should eq(Set{1, 3, 'b'})
+    set1.should eq(Set{1, 3, 9})
   end
 
   it "does to_a" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -280,7 +280,7 @@ class Array(T)
   # ```
   # [1, 2, 3] - [2, 1] # => [3]
   # ```
-  def -(other : Array(U))
+  def -(other : Array(T))
     ary = Array(T).new(Math.max(size - other.size, 0))
     hash = other.to_lookup_hash
     each do |obj|
@@ -638,7 +638,7 @@ class Array(T)
   # ary # => ["a", "b", "c"]
   # ```
   def compact!
-    delete nil
+    reject! &.is_a?(Nil)
   end
 
   # Appends the elements of *other* to `self`, and returns `self`.
@@ -690,7 +690,7 @@ class Array(T)
   # a.delete("b")
   # a # => ["a", "c"]
   # ```
-  def delete(obj)
+  def delete(obj : T)
     reject! { |e| e == obj } != nil
   end
 
@@ -1286,7 +1286,7 @@ class Array(T)
     ReverseIterator.new(self)
   end
 
-  def rindex(value)
+  def rindex(value : T)
     rindex { |elem| elem == value }
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -98,7 +98,7 @@ module Enumerable(T)
   #
   #     [1, 2, 3, 4].count(3)  #=> 1
   #
-  def count(item)
+  def count(item : T)
     count { |e| e == item }
   end
 
@@ -321,7 +321,7 @@ module Enumerable(T)
   #     [1, 2, 3].includes?(2)  #=> true
   #     [1, 2, 3].includes?(5)  #=> false
   #
-  def includes?(obj)
+  def includes?(obj : T)
     any? { |e| e == obj }
   end
 
@@ -342,7 +342,7 @@ module Enumerable(T)
   #     ["Alice", "Bob"].index("Alice")  #=> 0
   #
   # Returns `nil` if *obj* is not in the collection.
-  def index(obj)
+  def index(obj : T)
     index { |e| e == obj }
   end
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -81,7 +81,7 @@ class Hash(K, V)
   end
 
   # See `Hash#fetch`
-  def [](key)
+  def [](key : K)
     fetch(key)
   end
 
@@ -96,7 +96,7 @@ class Hash(K, V)
   # h = Hash(String, String).new("bar")
   # h["foo"]? # => nil
   # ```
-  def []?(key)
+  def []?(key : K)
     fetch(key, nil)
   end
 
@@ -107,7 +107,7 @@ class Hash(K, V)
   # h.has_key?("foo") # => true
   # h.has_key?("bar") # => false
   # ```
-  def has_key?(key)
+  def has_key?(key : K)
     !!find_entry(key)
   end
 
@@ -127,7 +127,7 @@ class Hash(K, V)
   # h = Hash(String, String).new
   # h["foo"] # raises KeyError
   # ```
-  def fetch(key)
+  def fetch(key : K)
     fetch(key) do
       if block = @block
         block.call(self, key)
@@ -145,7 +145,7 @@ class Hash(K, V)
   # h.fetch("foo", "foo") # => "bar"
   # h.fetch("bar", "foo") # => "foo"
   # ```
-  def fetch(key, default)
+  def fetch(key : K, default)
     fetch(key) { default }
   end
 
@@ -156,7 +156,7 @@ class Hash(K, V)
   # h.fetch("foo") { |key| key.upcase } # => "bar"
   # h.fetch("bar") { |key| key.upcase } # => "BAR"
   # ```
-  def fetch(key)
+  def fetch(key : K)
     entry = find_entry(key)
     entry ? entry.value : yield key
   end
@@ -179,7 +179,7 @@ class Hash(K, V)
   # hash.key("qux")    # => "baz"
   # hash.key("foobar") # => Missing hash key for value: foobar (KeyError)
   # ```
-  def key(value)
+  def key(value : V)
     key(value) { raise KeyError.new "Missing hash key for value: #{value}" }
   end
 
@@ -191,7 +191,7 @@ class Hash(K, V)
   # hash.key?("qux")    # => "baz"
   # hash.key?("foobar") # => nil
   # ```
-  def key?(value)
+  def key?(value : V)
     key(value) { nil }
   end
 
@@ -202,7 +202,7 @@ class Hash(K, V)
   # hash.key("bar") { |value| value.upcase } # => "foo"
   # hash.key("qux") { |value| value.upcase } # => "QUX"
   # ```
-  def key(value)
+  def key(value : V)
     each do |k, v|
       return k if v == value
     end
@@ -216,7 +216,7 @@ class Hash(K, V)
   # h.delete("foo")     # => "bar"
   # h.fetch("foo", nil) # => nil
   # ```
-  def delete(key)
+  def delete(key : K)
     index = bucket_index(key)
     entry = @buckets[index]
 
@@ -464,7 +464,7 @@ class Hash(K, V)
   # h.key_index("foo") # => 0
   # h.key_index("qux") # => nil
   # ```
-  def key_index(key)
+  def key_index(key : K)
     each_with_index do |my_key, my_value, i|
       return i if key == my_key
     end
@@ -575,7 +575,7 @@ class Hash(K, V)
   # ```
   # {"a": 1, "b": 2, "c": 3, "d": 4}.reject("a", "c") # => {"b": 2, "d": 4}
   # ```
-  def reject(*keys)
+  def reject(*keys : K)
     hash = self.dup
     hash.reject!(*keys)
   end
@@ -586,7 +586,7 @@ class Hash(K, V)
   # h = {"a": 1, "b": 2, "c": 3, "d": 4}.reject!("a", "c")
   # h # => {"b": 2, "d": 4}
   # ```
-  def reject!(*keys)
+  def reject!(*keys : K)
     keys.each { |k| delete(k) }
     self
   end
@@ -596,7 +596,7 @@ class Hash(K, V)
   # ```
   # {"a": 1, "b": 2, "c": 3, "d": 4}.select("a", "c") # => {"a": 1, "c": 3}
   # ```
-  def select(*keys)
+  def select(*keys : K)
     hash = {} of K => V
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
@@ -608,7 +608,7 @@ class Hash(K, V)
   # h = {"a": 1, "b": 2, "c": 3, "d": 4}.select!("a", "c")
   # h # => {"a": 1, "c": 3}
   # ```
-  def select!(*keys)
+  def select!(*keys : K)
     each { |k, v| delete(k) unless keys.includes?(k) }
     self
   end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -46,7 +46,7 @@ module HTTP
     bytesize = line.bytesize
 
     # Get the colon index and name
-    colon_index = cstr.to_slice(bytesize).index(':'.ord) || 0
+    colon_index = cstr.to_slice(bytesize).index(':'.ord.to_u8) || 0
     name = line.byte_slice(0, colon_index)
 
     # Get where the header value starts (skip space)

--- a/src/io/memory_io.cr
+++ b/src/io/memory_io.cr
@@ -85,7 +85,7 @@ class MemoryIO
 
     raise ArgumentError.new "negative limit" if limit < 0
 
-    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord)
+    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord.to_u8)
     if index
       if index > limit
         index = limit

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -332,12 +332,12 @@ class Markdown::Parser
           if link
             @renderer.text line.byte_slice(cursor, pos - cursor)
 
-            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.ord).not_nil!
+            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.ord.to_u8).not_nil!
             alt = line.byte_slice(pos + 2, bracket_idx)
 
             @renderer.image link, alt
 
-            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.ord).not_nil!
+            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.ord.to_u8).not_nil!
             pos += 2 + bracket_idx + 1 + paren_idx
             cursor = pos + 1
           end
@@ -357,7 +357,7 @@ class Markdown::Parser
           @renderer.text line.byte_slice(cursor, pos - cursor)
           @renderer.end_link
 
-          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord).not_nil!
+          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord.to_u8).not_nil!
           pos += paren_idx + 1
           cursor = pos + 1
           in_link = false
@@ -377,7 +377,7 @@ class Markdown::Parser
   def has_closing?(char, count, str, pos, bytesize)
     str += pos
     bytesize -= pos
-    idx = str.to_slice(bytesize).index char.ord
+    idx = str.to_slice(bytesize).index char.ord.to_u8
     return false unless idx
 
     if count == 2
@@ -408,7 +408,7 @@ class Markdown::Parser
 
     return nil unless str[bracket_idx + 1] === '('
 
-    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord
+    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord.to_u8
     return nil unless paren_idx
 
     String.new(Slice.new(str + bracket_idx + 2, paren_idx - 1))

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -461,7 +461,7 @@ class Regex
     LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMETABLE, pointerof(table_pointer) as Pointer(Int32))
     name_table = table_pointer.to_slice(name_entry_size*name_count)
 
-    lookup = Hash(UInt16, String).new
+    lookup = Hash(Int32, String).new
 
     name_count.times do |i|
       capture_offset = i * name_entry_size
@@ -470,7 +470,7 @@ class Regex
       name_offset = capture_offset + 2
       name = String.new((name_table + name_offset).pointer(name_entry_size - 3))
 
-      lookup[capture_number] = name
+      lookup[capture_number.to_i] = name
     end
 
     lookup

--- a/src/set.cr
+++ b/src/set.cr
@@ -75,7 +75,7 @@ struct Set(T)
   #     s = Set.new [1,5]
   #     s.includes? 5  # => true
   #     s.includes? 9  # => false
-  def includes?(object)
+  def includes?(object : T)
     @hash.has_key?(object)
   end
 
@@ -85,7 +85,7 @@ struct Set(T)
   #     s.includes? 5  # => true
   #     s.delete 5
   #     s.includes? 5  # => false
-  def delete(object)
+  def delete(object : T)
     @hash.delete(object)
     self
   end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -47,7 +47,7 @@ class YAML::Parser
     when EventKind::SCALAR
       anchor @pull_parser.value, @pull_parser.scalar_anchor
     when EventKind::ALIAS
-      @anchors[@pull_parser.alias_anchor]
+      @anchors[@pull_parser.alias_anchor.not_nil!]
     when EventKind::SEQUENCE_START
       parse_sequence
     when EventKind::MAPPING_START


### PR DESCRIPTION
This fixes #1764 and #988 by adding type restrictions to methods like `includes?` and `delete`.

Just adding this helped me find a [bug in the compiler](https://github.com/manastech/crystal/commit/a8e0b68d57852a2829cfa19a0fb4ef85fb91a06a): a case wasn't handled and a variable remained `nil`, and it could leak into these `delete` and `includes?` checks just fine.

I had to remove some `Set` specs that involved sets of different types, like `Set{1, 2, 3} - Set{1, 'a'}`. I checked some local projects against this PR and they all compiled fine, except one where I had to be a bit more strict, but it definitely helped me rethink those "unexpected" cases a bit more, so it didn't feel like something annoying. So removing those `Set` specs should be OK, in practice those cases don't seem to appear. If they do, we can think of alternative methods.

It would be nice if you could test the compiler with this PR applied against your projects and see if it breaks code, or if you find a case where you definitely need the old functionality.

