### PR TITLE
Add Array#bsearch, Array#bsearch_index, Range#bsearch

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1770,4 +1770,12 @@ class Array(T)
       end
     end
   end
+
+  def bsearch
+    idx=(0...self.size).bsearch{|i|yield self[i]}
+    idx ? self[idx] : nil
+  end
+  def bsearch_index
+    (0...self.size).bsearch{|i|yield self[i]}
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -1771,11 +1771,14 @@ class Array(T)
     end
   end
 
-  def bsearch
-    idx=(0...self.size).bsearch{|i|yield self[i]}
+  # This method returns the i-th element. If i is equal to ary.size, it returns nil.
+  def bsearch(&block : T -> Int|Float|Bool?)
+    idx=bsearch_index(&block)
     idx ? self[idx] : nil
   end
-  def bsearch_index
+
+  # This method returns the index of the element instead of the element itself.
+  def bsearch_index(&block : T -> Int|Float|Bool?)
     (0...self.size).bsearch{|i|yield self[i]}
   end
 end

--- a/src/range.cr
+++ b/src/range.cr
@@ -306,9 +306,13 @@ struct Range(B, E)
     end
   end
 
-  #Perform binary search
-  #Based on Marc-André Lafortune's Ruby backports implementation, ported by T. Yamada
-  def bsearch
+  # By using binary search, finds a value in range which meets
+  # the given condition in O(log n) where n is the size of the range.
+  #
+  # If x is within the range, this method returns the value x. Otherwise, it returns nil.
+  #
+  # Based on Marc-André Lafortune's Ruby backports implementation, ported by T. Yamada
+  def bsearch(&block : B -> Int|Float|Bool?)
     from = self.begin
     to   = self.end
     unless from.is_a?(Int) && to.is_a?(Int)
@@ -322,7 +326,7 @@ struct Range(B, E)
     to -= 1 if excludes_end?
     satisfied = nil
     while from <= to
-      midpoint = (from + to)/2
+      midpoint = from + (to - from)/2
       result = yield(cur = convert.call)
       case result
       when Int
@@ -335,8 +339,6 @@ struct Range(B, E)
         satisfied = cur
       when nil, false
         # nothing to do
-      else
-        raise "wrong argument type #{result.class} (must be numeric, true, false or nil)"
       end
 
       if result

--- a/src/range.cr
+++ b/src/range.cr
@@ -305,4 +305,46 @@ struct Range(B, E)
       self
     end
   end
+
+  #Perform binary search
+  #Based on Marc-André Lafortune's Ruby backports implementation, ported by T. Yamada
+  def bsearch
+    from = self.begin
+    to   = self.end
+    unless from.is_a?(Int) && to.is_a?(Int)
+      # Float support is currently dropped
+      raise "can't do binary search for #{from.class}"
+    end
+
+    midpoint = 0 # placeholder
+    convert = ->{ midpoint }
+
+    to -= 1 if excludes_end?
+    satisfied = nil
+    while from <= to
+      midpoint = (from + to)/2
+      result = yield(cur = convert.call)
+      case result
+      when Int
+        return cur if result == 0
+        result = result < 0
+      when Float
+        return cur if result == 0
+        result = result < 0
+      when true
+        satisfied = cur
+      when nil, false
+        # nothing to do
+      else
+        raise "wrong argument type #{result.class} (must be numeric, true, false or nil)"
+      end
+
+      if result
+        to = midpoint - 1
+      else
+        from = midpoint + 1
+      end
+    end
+    satisfied
+  end
 end

--- a/src/range.cr
+++ b/src/range.cr
@@ -315,8 +315,7 @@ struct Range(B, E)
   def bsearch(&block : B -> Int|Float|Bool?)
     from = self.begin
     to   = self.end
-    unless from.is_a?(Int) && to.is_a?(Int)
-      # Float support is currently dropped
+    unless from.is_a?(Number) && to.is_a?(Number)
       raise "can't do binary search for #{from.class}"
     end
 
@@ -329,10 +328,7 @@ struct Range(B, E)
       midpoint = from + (to - from)/2
       result = yield(cur = convert.call)
       case result
-      when Int
-        return cur if result == 0
-        result = result < 0
-      when Float
+      when Number
         return cur if result == 0
         result = result < 0
       when true


### PR DESCRIPTION
Currently Crystal lacks binary search, which is a great feature of Ruby 2.0+.

I have (partially) ported https://github.com/marcandre/backports/blob/master/lib/backports/2.0.0/range/bsearch.rb .
The only point is that current port lacks Float support, which requires reinterpreting Float64 as Int64.

And, `->{ (pointerof(midpoint) as Pointer(Int64)).value }.call` caused
```
Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/manastech/crystal/issues
```

Anyway, the Int version works flawlessly. How do you think of this pull request?
Currently it is also available as https://github.com/cielavenir/crystal-bsearch shard and the spec will be ported after approval (I'll need to fix the indent).
