### PR TITLE
Improve #1859, add binary searching methods

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -318,16 +318,16 @@ describe "Array" do
   end
 
   it "find the element by using binary search" do
-    [2, 5, 7, 10].bsearch{ |x| x >= 4 }.should eq 5
-    [2, 5, 7, 10].bsearch{ |x| x > 10 }.should be_nil
+    [2, 5, 7, 10].bsearch { |x| x >= 4 }.should eq 5
+    [2, 5, 7, 10].bsearch { |x| x > 10 }.should be_nil
   end
 
   it "find the index by using binary search" do
-    [2, 5, 7, 10].bsearch_index{ |x, i| x >= 4 }.should eq 1
-    [2, 5, 7, 10].bsearch_index{ |x, i| x > 10 }.should be_nil
+    [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 }.should eq 1
+    [2, 5, 7, 10].bsearch_index { |x, i| x > 10 }.should be_nil
 
-    [2, 5, 7, 10].bsearch_index{ |x, i| i >= 3 }.should eq 3
-    [2, 5, 7, 10].bsearch_index{ |x, i| i > 3 }.should be_nil
+    [2, 5, 7, 10].bsearch_index { |x, i| i >= 3 }.should eq 3
+    [2, 5, 7, 10].bsearch_index { |x, i| i > 3 }.should be_nil
   end
 
   it "does clear" do

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -317,6 +317,19 @@ describe "Array" do
     end
   end
 
+  it "find the element by using binary search" do
+    [2, 5, 7, 10].bsearch{ |x| x >= 4 }.should eq 5
+    [2, 5, 7, 10].bsearch{ |x| x > 10 }.should be_nil
+  end
+
+  it "find the index by using binary search" do
+    [2, 5, 7, 10].bsearch_index{ |x, i| x >= 4 }.should eq 1
+    [2, 5, 7, 10].bsearch_index{ |x, i| x > 10 }.should be_nil
+
+    [2, 5, 7, 10].bsearch_index{ |x, i| i >= 3 }.should eq 3
+    [2, 5, 7, 10].bsearch_index{ |x, i| i > 3 }.should be_nil
+  end
+
   it "does clear" do
     a = [1, 2, 3]
     a.clear

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -26,14 +26,6 @@ struct RangeSpecIntWrapper
   end
 end
 
-private def assert_in_delta(expect, actual, delta)
-  if actual
-    ((expect - actual).abs <= delta).should be_true
-  else
-    true.should be_false
-  end
-end
-
 describe "Range" do
   it "initialized with new method" do
     Range.new(1, 10).should eq(1..10)
@@ -109,73 +101,69 @@ describe "Range" do
   describe "bsearch" do
     it "Int" do
       ary = [3, 4, 7, 9, 12]
-      (0...ary.size).bsearch{ |i| ary[i] >= 2 }.should eq 0
-      (0...ary.size).bsearch{ |i| ary[i] >= 4 }.should eq 1
-      (0...ary.size).bsearch{ |i| ary[i] >= 6 }.should eq 2
-      (0...ary.size).bsearch{ |i| ary[i] >= 8 }.should eq 3
-      (0...ary.size).bsearch{ |i| ary[i] >= 10 }.should eq 4
-      (0...ary.size).bsearch{ |i| ary[i] >= 100 }.should eq nil
-      (0...ary.size).bsearch{ |i| true }.should eq 0
-      (0...ary.size).bsearch{ |i| false }.should eq nil
+      (0...ary.size).bsearch { |i| ary[i] >= 2 }.should eq 0
+      (0...ary.size).bsearch { |i| ary[i] >= 4 }.should eq 1
+      (0...ary.size).bsearch { |i| ary[i] >= 6 }.should eq 2
+      (0...ary.size).bsearch { |i| ary[i] >= 8 }.should eq 3
+      (0...ary.size).bsearch { |i| ary[i] >= 10 }.should eq 4
+      (0...ary.size).bsearch { |i| ary[i] >= 100 }.should eq nil
+      (0...ary.size).bsearch { |i| true }.should eq 0
+      (0...ary.size).bsearch { |i| false }.should eq nil
 
       ary = [0, 100, 100, 100, 200]
-      (0...ary.size).bsearch{ |i| ary[i] >= 100 }.should eq 1
+      (0...ary.size).bsearch { |i| ary[i] >= 100 }.should eq 1
 
-      (0_i8..10_i8).bsearch{ |x| x >= 10 }.should eq 10_i8
-      (0_i8...10_i8).bsearch{ |x| x >= 10 }.should eq nil
-      (-10_i8...10_i8).bsearch{ |x| x >= -5 }.should eq -5_i8
+      (0_i8..10_i8).bsearch { |x| x >= 10 }.should eq 10_i8
+      (0_i8...10_i8).bsearch { |x| x >= 10 }.should eq nil
+      (-10_i8...10_i8).bsearch { |x| x >= -5 }.should eq -5_i8
 
-      (0_u8..10_u8).bsearch{ |x| x >= 10 }.should eq 10_u8
-      (0_u8...10_u8).bsearch{ |x| x >= 10 }.should eq nil
-      (0_u32..10_u32).bsearch{ |x| x >= 10 }.should eq 10_u32
-      (0_u32...10_u32).bsearch{ |x| x >= 10 }.should eq nil
+      (0_u8..10_u8).bsearch { |x| x >= 10 }.should eq 10_u8
+      (0_u8...10_u8).bsearch { |x| x >= 10 }.should eq nil
+      (0_u32..10_u32).bsearch { |x| x >= 10 }.should eq 10_u32
+      (0_u32...10_u32).bsearch { |x| x >= 10 }.should eq nil
 
-      (BigInt.new("-10")...BigInt.new("10")).bsearch{ |x| x >= -5 }.should eq BigInt.new("-5")
+      (BigInt.new("-10")...BigInt.new("10")).bsearch { |x| x >= -5 }.should eq BigInt.new("-5")
     end
 
     it "Float" do
       inf = Float64::INFINITY
-      assert_in_delta(10.0, (0.0...100.0).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
-      assert_in_delta(10.0, (0.0...inf).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
-      assert_in_delta(-10.0, (-inf..100.0).bsearch {|x| x >= 0 || Math.log(-x / 10) < 0 }, 0.0001)
-      assert_in_delta(10.0, (-inf..inf).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
-      (-inf..5).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }.should eq nil
+      (0.0...100.0).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (0.0...inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (-inf..100.0).bsearch { |x| x >= 0 || Math.log(-x / 10) < 0 }.not_nil!.should be_close(-10.0, 0.0001)
+      (-inf..inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (-inf..5).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should be_nil
 
-      assert_in_delta(10.0, (-inf.. 10).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
-      (inf...10).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }.should eq nil
+      (-inf..10).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (inf...10).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should be_nil
 
-      (-inf..inf).bsearch { false }.should eq nil
+      (-inf..inf).bsearch { false }.should be_nil
       (-inf..inf).bsearch { true }.should eq -inf
 
-      (0..inf).bsearch {|x| x == inf }.should eq inf
-      (0...inf).bsearch {|x| x == inf }.should eq nil
+      (0..inf).bsearch { |x| x == inf }.should eq inf
+      (0...inf).bsearch { |x| x == inf }.should be_nil
 
-      v = (0.0..1.0).bsearch {|x| x > 0 }
-      if v
-        assert_in_delta(0, v, 0.0001)
-        (0 < v).should be_true
-      else
-        true.should be_false
-      end
+      v = (0.0..1.0).bsearch { |x| x > 0 }.not_nil!
+      v.should be_close(0, 0.0001)
+      (0 < v).should be_true
 
-      (-1.0..0.0).bsearch {|x| x >= 0 }.should eq 0.0
-      (-1.0...0.0).bsearch {|x| x >= 0 }.should be_nil
+      (-1.0..0.0).bsearch { |x| x >= 0 }.should eq 0.0
+      (-1.0...0.0).bsearch { |x| x >= 0 }.should be_nil
 
-      assert_in_delta(1.0, (0.0..inf).bsearch {|x| Math.log(x) >= 0 }, 0.0001)
+      (0.0..inf).bsearch { |x| Math.log(x) >= 0 }.not_nil!.should be_close(1.0, 0.0001)
 
-      assert_in_delta(3.5, (0.0..10).bsearch {|x| x >= 3.5 }, 0.0001)
-      assert_in_delta(3.5, (0..10.0).bsearch {|x| x >= 3.5 }, 0.0001)
+      (0.0..10).bsearch { |x| x >= 3.5 }.not_nil!.should be_close(3.5, 0.0001)
+      (0..10.0).bsearch { |x| x >= 3.5 }.not_nil!.should be_close(3.5, 0.0001)
 
-      assert_in_delta(5_f32, (0_f32..5_f32).bsearch { |x| x >= 5_f32 }, 0.0001_f32)
-      (0_f32...5_f32).bsearch{ |x| x >= 5_f32 }.should be_nil
-      assert_in_delta(5.0, (0_f32..5.0).bsearch { |x| x >= 5.0 }, 0.0001)
-      assert_in_delta(5.0, (0..5.0_f32).bsearch { |x| x >= 5.0 }, 0.0001)
+      (0_f32..5_f32).bsearch { |x| x >= 5_f32 }.not_nil!.should be_close(5_f32, 0.0001_f32)
+      (0_f32...5_f32).bsearch { |x| x >= 5_f32 }.should be_nil
+      (0_f32..5.0).bsearch { |x| x >= 5.0 }.not_nil!.should be_close(5.0, 0.0001)
+      (0..5.0_f32).bsearch { |x| x >= 5.0 }.not_nil!.should be_close(5.0, 0.0001)
 
       inf32 = Float32::INFINITY
-      (0..inf32).bsearch {|x| x == inf32 }.should eq inf32
-      (0_f32..inf).bsearch {|x| x == inf }.should eq inf
-      (0.0..inf32).bsearch {|x| x == inf32 }.should eq inf32
-      (0_f32...5_f32).bsearch{ |x| x >= 5_f32 }.should be_nil
+      (0..inf32).bsearch { |x| x == inf32 }.should eq inf32
+      (0_f32..inf).bsearch { |x| x == inf }.should eq inf
+      (0.0..inf32).bsearch { |x| x == inf32 }.should eq inf32
+      (0_f32...5_f32).bsearch { |x| x >= 5_f32 }.should be_nil
     end
   end
 

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -26,6 +26,14 @@ struct RangeSpecIntWrapper
   end
 end
 
+private def assert_in_delta(expect, actual, delta)
+  if actual
+    ((expect - actual).abs <= delta).should be_true
+  else
+    true.should be_false
+  end
+end
+
 describe "Range" do
   it "initialized with new method" do
     Range.new(1, 10).should eq(1..10)
@@ -95,6 +103,79 @@ describe "Range" do
       (1..3).step(2).sum { |x| x * 2 }.should eq 8
       (RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(3)).sum.should eq RangeSpecIntWrapper.new(6)
       (RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(3)).step(2).sum.should eq RangeSpecIntWrapper.new(4)
+    end
+  end
+
+  describe "bsearch" do
+    it "Int" do
+      ary = [3, 4, 7, 9, 12]
+      (0...ary.size).bsearch{ |i| ary[i] >= 2 }.should eq 0
+      (0...ary.size).bsearch{ |i| ary[i] >= 4 }.should eq 1
+      (0...ary.size).bsearch{ |i| ary[i] >= 6 }.should eq 2
+      (0...ary.size).bsearch{ |i| ary[i] >= 8 }.should eq 3
+      (0...ary.size).bsearch{ |i| ary[i] >= 10 }.should eq 4
+      (0...ary.size).bsearch{ |i| ary[i] >= 100 }.should eq nil
+      (0...ary.size).bsearch{ |i| true }.should eq 0
+      (0...ary.size).bsearch{ |i| false }.should eq nil
+
+      ary = [0, 100, 100, 100, 200]
+      (0...ary.size).bsearch{ |i| ary[i] >= 100 }.should eq 1
+
+      (0_i8..10_i8).bsearch{ |x| x >= 10 }.should eq 10_i8
+      (0_i8...10_i8).bsearch{ |x| x >= 10 }.should eq nil
+      (-10_i8...10_i8).bsearch{ |x| x >= -5 }.should eq -5_i8
+
+      (0_u8..10_u8).bsearch{ |x| x >= 10 }.should eq 10_u8
+      (0_u8...10_u8).bsearch{ |x| x >= 10 }.should eq nil
+      (0_u32..10_u32).bsearch{ |x| x >= 10 }.should eq 10_u32
+      (0_u32...10_u32).bsearch{ |x| x >= 10 }.should eq nil
+
+      (BigInt.new("-10")...BigInt.new("10")).bsearch{ |x| x >= -5 }.should eq BigInt.new("-5")
+    end
+
+    it "Float" do
+      inf = Float64::INFINITY
+      assert_in_delta(10.0, (0.0...100.0).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
+      assert_in_delta(10.0, (0.0...inf).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
+      assert_in_delta(-10.0, (-inf..100.0).bsearch {|x| x >= 0 || Math.log(-x / 10) < 0 }, 0.0001)
+      assert_in_delta(10.0, (-inf..inf).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
+      (-inf..5).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }.should eq nil
+
+      assert_in_delta(10.0, (-inf.. 10).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }, 0.0001)
+      (inf...10).bsearch {|x| x > 0 && Math.log(x / 10) >= 0 }.should eq nil
+
+      (-inf..inf).bsearch { false }.should eq nil
+      (-inf..inf).bsearch { true }.should eq -inf
+
+      (0..inf).bsearch {|x| x == inf }.should eq inf
+      (0...inf).bsearch {|x| x == inf }.should eq nil
+
+      v = (0.0..1.0).bsearch {|x| x > 0 }
+      if v
+        assert_in_delta(0, v, 0.0001)
+        (0 < v).should be_true
+      else
+        true.should be_false
+      end
+
+      (-1.0..0.0).bsearch {|x| x >= 0 }.should eq 0.0
+      (-1.0...0.0).bsearch {|x| x >= 0 }.should be_nil
+
+      assert_in_delta(1.0, (0.0..inf).bsearch {|x| Math.log(x) >= 0 }, 0.0001)
+
+      assert_in_delta(3.5, (0.0..10).bsearch {|x| x >= 3.5 }, 0.0001)
+      assert_in_delta(3.5, (0..10.0).bsearch {|x| x >= 3.5 }, 0.0001)
+
+      assert_in_delta(5_f32, (0_f32..5_f32).bsearch { |x| x >= 5_f32 }, 0.0001_f32)
+      (0_f32...5_f32).bsearch{ |x| x >= 5_f32 }.should be_nil
+      assert_in_delta(5.0, (0_f32..5.0).bsearch { |x| x >= 5.0 }, 0.0001)
+      assert_in_delta(5.0, (0..5.0_f32).bsearch { |x| x >= 5.0 }, 0.0001)
+
+      inf32 = Float32::INFINITY
+      (0..inf32).bsearch {|x| x == inf32 }.should eq inf32
+      (0_f32..inf).bsearch {|x| x == inf }.should eq inf
+      (0.0..inf32).bsearch {|x| x == inf32 }.should eq inf32
+      (0_f32...5_f32).bsearch{ |x| x >= 5_f32 }.should be_nil
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -577,6 +577,44 @@ class Array(T)
     indexes.map { |index| self[index] }
   end
 
+  # By using binary search, returns the first element
+  # for which the passed block returns `true`.
+  #
+  # If the block returns `false`, the finding element exists
+  # behind. If the block returns `true`, the finding element
+  # is itself or exists infront.
+  #
+  # Binary search need sorted array, so self have to be sorted.
+  #
+  # ```
+  # [2, 5, 7, 10].bsearch{ |x| x >= 4 } # => 5
+  # [2, 5, 7, 10].bsearch{ |x| x > 10 } # => nil
+  # ```
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
+  def bsearch
+    bsearch_index{ |value| yield value }.try { |index| self[index] }
+  end
+
+  # By using binary search, returns the index of the first element
+  # for which the passed block returns `true`.
+  #
+  # If the block returns `false`, the finding element exists
+  # behind. If the block returns `true`, the finding element
+  # is itself or exists infront.
+  #
+  # Binary search need sorted array, so self have to be sorted.
+  #
+  # ```
+  # [2, 5, 7, 10].bsearch_index{ |x, i| x >= 4 } # => 1
+  # [2, 5, 7, 10].bsearch_index{ |x, i| x > 10 } # => nil
+  # ```
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
+  def bsearch_index
+    (0...size).bsearch{ |index| yield self[index], index }
+  end
+
   # Removes all elements from self.
   #
   # ```

--- a/src/array.cr
+++ b/src/array.cr
@@ -584,14 +584,14 @@ class Array(T)
   # behind. If the block returns `true`, the finding element
   # is itself or exists infront.
   #
-  # Binary search need sorted array, so self have to be sorted.
+  # Binary search needs sorted array, so self has to be sorted.
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
   #
   # ```
   # [2, 5, 7, 10].bsearch{ |x| x >= 4 } # => 5
   # [2, 5, 7, 10].bsearch{ |x| x > 10 } # => nil
   # ```
-  #
-  # Returns `nil` if the block didn't return `true` for any element.
   def bsearch
     bsearch_index{ |value| yield value }.try { |index| self[index] }
   end
@@ -603,14 +603,14 @@ class Array(T)
   # behind. If the block returns `true`, the finding element
   # is itself or exists infront.
   #
-  # Binary search need sorted array, so self have to be sorted.
+  # Binary search needs sorted array, so self has to be sorted.
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
   #
   # ```
   # [2, 5, 7, 10].bsearch_index{ |x, i| x >= 4 } # => 1
   # [2, 5, 7, 10].bsearch_index{ |x, i| x > 10 } # => nil
   # ```
-  #
-  # Returns `nil` if the block didn't return `true` for any element.
   def bsearch_index
     (0...size).bsearch{ |index| yield self[index], index }
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -589,11 +589,11 @@ class Array(T)
   # Returns `nil` if the block didn't return `true` for any element.
   #
   # ```
-  # [2, 5, 7, 10].bsearch{ |x| x >= 4 } # => 5
-  # [2, 5, 7, 10].bsearch{ |x| x > 10 } # => nil
+  # [2, 5, 7, 10].bsearch { |x| x >= 4 } # => 5
+  # [2, 5, 7, 10].bsearch { |x| x > 10 } # => nil
   # ```
   def bsearch
-    bsearch_index{ |value| yield value }.try { |index| self[index] }
+    bsearch_index { |value| yield value }.try { |index| self[index] }
   end
 
   # By using binary search, returns the index of the first element
@@ -608,11 +608,11 @@ class Array(T)
   # Returns `nil` if the block didn't return `true` for any element.
   #
   # ```
-  # [2, 5, 7, 10].bsearch_index{ |x, i| x >= 4 } # => 1
-  # [2, 5, 7, 10].bsearch_index{ |x, i| x > 10 } # => nil
+  # [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 } # => 1
+  # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
   # ```
   def bsearch_index
-    (0...size).bsearch{ |index| yield self[index], index }
+    (0...size).bsearch { |index| yield self[index], index }
   end
 
   # Removes all elements from self.

--- a/src/range.cr
+++ b/src/range.cr
@@ -355,3 +355,5 @@ struct Range(B, E)
     end
   end
 end
+
+require "./range/*"

--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -76,8 +76,8 @@ struct Range(B, E)
   # is itself or exists infront.
   #
   # ```
-  # (0..10).bsearch{ |x| x >= 5 } # => 5
-  # (0..Float64::INFINITY).bsearch{ |x| x ** 4 >= 256 } # => 4
+  # (0..10).bsearch { |x| x >= 5 }                       # => 5
+  # (0..Float64::INFINITY).bsearch { |x| x ** 4 >= 256 } # => 4
   # ```
   #
   # Returns `nil` if the block didn't return `true` for any value.

--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -1,26 +1,10 @@
-private macro bsearch_search(exclusive, mid)
-  saved_to = to
-  satisfied = nil
-  while from < to
-    mid = {{ mid.id }}
-
-    if yield mid
-      satisfied = mid
-      to = mid
-    else
-      from = mid + 1
-    end
-  end
-
-  if ! {{ exclusive }} && from == saved_to && yield from
-    satisfied = from
-  end
-
-  satisfied
-end
-
 {% for p in [64, 32] %}
-  private def int_to_float(i : Int{{ p }})
+  # Cast integer as floating number value with keeping binary structure.
+  private def int_as_float(i : Int{{ p }})
+    # Integer uses two's complement to represent signed number, but
+    # floating number value uses sign bit. This difference causes a
+    # problem that it reproduce incorrect value when you sum positive
+    # number and negative number. It fixes this problem.
     if i < 0
       i = -i
       -(pointerof(i) as Pointer(Float{{ p }})).value
@@ -29,7 +13,8 @@ end
     end
   end
 
-  private def float_to_int(f : Float{{ p }})
+  # Cast floating number value as integer with keeping binary structure.
+  private def float_as_int(f : Float{{ p }})
     if f < 0
       f = -f
       -(pointerof(f) as Pointer(Int{{ p }})).value
@@ -51,18 +36,34 @@ end
   end
 
   private def bsearch_internal(from : Float{{ p }}, to : Float{{ p }}, exclusive)
-    from = float_to_int from
-    to = float_to_int to
+    from = float_as_int from
+    to = float_as_int to
     to -= 1 if exclusive
 
-    bsearch_internal(from, to, false){ |i| yield int_to_float i }
-      .try{ |i| int_to_float i }
+    bsearch_internal(from, to, false){ |i| yield int_as_float i }
+      .try{ |i| int_as_float i }
   end
 
-  private def bsearch_internal(from : Int{{ p }}, to : Int{{ p }}, exclusive, &block)
-    bsearch_search(exclusive,
-      "(from < 0) == (to < 0) ? from + (to - from) / 2
-      : (from < -to) ? -((- from - to - 1) / 2 + 1) : (from + to) / 2")
+  private def bsearch_internal(from : Int{{ p }}, to : Int{{ p }}, exclusive)
+    saved_to = to
+    satisfied = nil
+    while from < to
+      mid = (from < 0) == (to < 0) ? from + (to - from) / 2
+          : (from < -to) ? -((- from - to - 1) / 2 + 1) : (from + to) / 2
+
+      if yield mid
+        satisfied = mid
+        to = mid
+      else
+        from = mid + 1
+      end
+    end
+
+    if !exclusive && from == saved_to && yield from
+      satisfied = from
+    end
+
+    satisfied
   end
 {% end %}
 
@@ -80,10 +81,16 @@ struct Range(B, E)
   # ```
   #
   # Returns `nil` if the block didn't return `true` for any value.
-  def bsearch(&block)
+  def bsearch
     from = self.begin
     to = self.end
 
+    # If the range consists of floating value,
+    # it uses specialized implementation for floating value.
+    # This implementation is very fast. For example,
+    # `(1..1e300).bsearch{ false }` loops over 2000 times in
+    # popular implementation, but in this implementation loops 65 times
+    # at most.
     {% for v in %w(from to) %}
       if {{ v.id }}.is_a?(Float::Primitive)
         return bsearch_internal from, to, self.excludes_end? do |value|
@@ -92,6 +99,23 @@ struct Range(B, E)
       end
     {% end %}
 
-    bsearch_search(self.excludes_end?, "from + (to - from) / 2")
+    saved_to = to
+    satisfied = nil
+    while from < to
+      mid = from + (to - from) / 2
+
+      if yield mid
+        satisfied = mid
+        to = mid
+      else
+        from = mid + 1
+      end
+    end
+
+    if !self.excludes_end? && from == saved_to && yield from
+      satisfied = from
+    end
+
+    satisfied
   end
 end

--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -1,0 +1,97 @@
+private macro bsearch_search(exclusive, mid)
+  saved_to = to
+  satisfied = nil
+  while from < to
+    mid = {{ mid.id }}
+
+    if yield mid
+      satisfied = mid
+      to = mid
+    else
+      from = mid + 1
+    end
+  end
+
+  if ! {{ exclusive }} && from == saved_to && yield from
+    satisfied = from
+  end
+
+  satisfied
+end
+
+{% for p in [64, 32] %}
+  private def int_to_float(i : Int{{ p }})
+    if i < 0
+      i = -i
+      -(pointerof(i) as Pointer(Float{{ p }})).value
+    else
+      (pointerof(i) as Pointer(Float{{ p }})).value
+    end
+  end
+
+  private def float_to_int(f : Float{{ p }})
+    if f < 0
+      f = -f
+      -(pointerof(f) as Pointer(Int{{ p }})).value
+    else
+      (pointerof(f) as Pointer(Int{{ p }})).value
+    end
+  end
+
+  private def bsearch_internal(from : Float{{ p }}, to, exclusive, &block)
+    bsearch_internal from, to.to_f{{ p }}, exclusive do |value|
+      yield value
+    end
+  end
+
+  private def bsearch_internal(from, to : Float{{ p }}, exclusive)
+    bsearch_internal from.to_f{{ p }}, to, exclusive do |value|
+      yield value
+    end
+  end
+
+  private def bsearch_internal(from : Float{{ p }}, to : Float{{ p }}, exclusive)
+    from = float_to_int from
+    to = float_to_int to
+    to -= 1 if exclusive
+
+    bsearch_internal(from, to, false){ |i| yield int_to_float i }
+      .try{ |i| int_to_float i }
+  end
+
+  private def bsearch_internal(from : Int{{ p }}, to : Int{{ p }}, exclusive, &block)
+    bsearch_search(exclusive,
+      "(from < 0) == (to < 0) ? from + (to - from) / 2
+      : (from < -to) ? -((- from - to - 1) / 2 + 1) : (from + to) / 2")
+  end
+{% end %}
+
+struct Range(B, E)
+  # By using binary search, returns the first value
+  # for which the passed block returns `true`.
+  #
+  # If the block returns `false`, the finding value exists
+  # behind. If the block returns `true`, the finding value
+  # is itself or exists infront.
+  #
+  # ```
+  # (0..10).bsearch{ |x| x >= 5 } # => 5
+  # (0..Float64::INFINITY).bsearch{ |x| x ** 4 >= 256 } # => 4
+  # ```
+  #
+  # Returns `nil` if the block didn't return `true` for any value.
+  def bsearch(&block)
+    from = self.begin
+    to = self.end
+
+    {% for v in %w(from to) %}
+      if {{ v.id }}.is_a?(Float::Primitive)
+        return bsearch_internal from, to, self.excludes_end? do |value|
+          yield value
+        end
+      end
+    {% end %}
+
+    bsearch_search(self.excludes_end?, "from + (to - from) / 2")
+  end
+end


### PR DESCRIPTION
See #1859.

This implementation supports to search in Int range and also Float
or some types range.

It uses integer and floating point value hack. This hack comes from [Ruby's implementation](https://github.com/ruby/ruby/blob/72ff61f4a8ae7a8bf05b0bd6f91b3b290645627c/range.c#L595-L662).