### PR TITLE
Add --stdout to format tool

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -186,6 +186,7 @@ USAGE
 
   private def format
     @format = "text"
+    @stdout = false
 
     option_parser =
       OptionParser.parse(options) do |opts|
@@ -202,6 +203,10 @@ USAGE
 
         opts.on("--no-color", "Disable colored output") do
           @color = false
+        end
+
+        opts.on("--stdout", "Output to STDOUT") do
+          @stdout = true
         end
       end
 
@@ -246,7 +251,12 @@ USAGE
     source = File.read(filename)
 
     begin
-      File.write(filename, Crystal::Formatter.format(source, filename: filename))
+      result = Crystal::Formatter.format(source, filename: filename)
+      if @stdout
+        puts result
+      else
+        File.write(filename, result)
+      end
     rescue ex : Crystal::SyntaxException
       if @format == "json"
         puts ex.to_json
@@ -288,7 +298,12 @@ USAGE
       result = Crystal::Formatter.format(source, filename: filename)
       return if result == source
 
-      File.write(filename, result)
+      if @stdout
+        puts result
+      else
+        File.write(filename, result)
+      end
+
       STDOUT << "Format".colorize(:green).toggle(@color) << " " << filename << "\n"
     rescue ex : Crystal::SyntaxException
       STDOUT << "Syntax Error:".colorize(:yellow).toggle(@color) << " " << ex.message << " at " << filename << ":" << ex.line_number << ":" << ex.column_number << "\n"


### PR DESCRIPTION
Allow `crystal tool format` to output to stdout instead of modifying files in-place by specifying `--stdout`.

This is a very basic implementation that introduces the minimal amount of change.

Closes #1863