### PR TITLE
Pass an exception object to `at_exit` block.

### DIFF
--- a/src/exception.cr
+++ b/src/exception.cr
@@ -180,3 +180,21 @@ class DivisionByZero < Exception
     super(message)
   end
 end
+
+# Created when the program exit.
+#
+# This exception is not raised, but created in `exit` method internaly.
+# You can see this in `at_exit` block.
+#
+# ```
+# at_exit do |error|
+#   p error
+# end
+#
+# exit 1 # SystemExit: Program exit with status 1
+# ```
+class SystemExit < Exception
+  def initialize(status, message = "Program exit with status #{status}")
+    super(message)
+  end
+end

--- a/src/main.cr
+++ b/src/main.cr
@@ -6,16 +6,16 @@ end
 macro redefine_main(name = main)
   fun main = {{name}}(argc : Int32, argv : UInt8**) : Int32
     %ex = nil
-    %status = begin
+    begin
       GC.init
       {{yield LibCrystalMain.__crystal_main(argc, argv)}}
-      0
+      %status = 0
     rescue ex
       %ex = ex
-      1
+      %status = 1
     end
 
-    AtExitHandlers.run %status
+    AtExitHandlers.run %ex
     %ex.inspect_with_backtrace STDERR if %ex
     STDOUT.flush
     %status


### PR DESCRIPTION
It is more useful than integer status code.
