### PR TITLE
expose socket ADDR in http

### DIFF
--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -5,10 +5,12 @@ class HTTP::Response
   getter status_code
   getter status_message
   getter headers
+  getter addr
+  getter peeraddr
   getter! body_io
   property upgrade_handler
 
-  def initialize(@status_code, @body = nil, @headers = Headers.new : Headers, status_message = nil, @version = "HTTP/1.1", @body_io = nil)
+  def initialize(@status_code, @body = nil, @headers = Headers.new : Headers, status_message = nil, @version = "HTTP/1.1", @body_io = nil, @addr = nil, @peeraddr = nil)
     @status_message = status_message || self.class.default_status_message_for(@status_code)
 
     if Response.mandatory_body?(@status_code)
@@ -89,7 +91,9 @@ class HTTP::Response
   end
 
   def self.from_io(io, ignore_body = false, &block)
-    line = io.gets
+    addr     = io.addr
+    peeraddr = io.peeraddr
+    line     = io.gets
     if line
       http_version, status_code, status_message = line.split(3)
       status_code = status_code.to_i
@@ -99,7 +103,7 @@ class HTTP::Response
       body_type = HTTP::BodyType::Prohibited if ignore_body
 
       HTTP.parse_headers_and_body(io, body_type) do |headers, body|
-        return yield new status_code, nil, headers, status_message, http_version, body
+        return yield new status_code, nil, headers, status_message, http_version, body, addr, peeraddr
       end
     end
 

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -1,9 +1,13 @@
 class OpenSSL::SSL::Socket
   include IO
+  getter addr
+  getter peeraddr
 
   def initialize(io, mode = :client, context = Context.default)
-    @ssl = LibSSL.ssl_new(context)
-    @bio = BIO.new(io)
+    @ssl      = LibSSL.ssl_new(context)
+    @bio      = BIO.new(io)
+    @addr     = io.addr
+    @peeraddr = io.peeraddr
     LibSSL.ssl_set_bio(@ssl, @bio, @bio)
 
     if mode == :client


### PR DESCRIPTION
Unsure if this is the rigth way, perhaps openssl should inherit IPSocket or TCPSocket instead? Dunno how to do specs, as the MemoryIO does not have addrs, and unsure if it's correct place to add them.
Use case for this is so that web framework can easily tell client's IP.

[ytti@ytti.fi ~/usr/git/sykemittari]% ./moi
response.addr = Socket::Addr(@family="AF_INET", @ip_port=53380, @ip_address="194.100.7.227")
response.peeraddr = Socket::Addr(@family="AF_INET", @ip_port=80, @ip_address="62.78.98.162")
request.addr = Socket::Addr(@family="AF_INET", @ip_port=40748, @ip_address="127.0.0.1")
request.peeraddr = Socket::Addr(@family="AF_INET", @ip_port=1122, @ip_address="127.0.0.1")
^C
[130 ytti@ytti.fi ~/usr/git/sykemittari]% cat moi.cr
require "http/server"
require "http/client"

client = HTTP::Client.new("google.com")
response = client.get("/")
pp response.addr
pp response.peeraddr

server = HTTP::Server.new(1122) do |request|
  pp request.addr
  pp request.peeraddr
  HTTP::Response.ok "text/plain", "yaya"
end

server.listen
[ytti@ytti.fi ~/usr/git/sykemittari]%