### PR TITLE
Added `%f` to full ISO 8601 Full Time Format that being generally used as JSON time format.

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -116,13 +116,13 @@ describe "Regex" do
       Regex.union(["+", "-"]).should eq /\+|\-/
     end
 
-    it "accepts a single Array(String | Regexp) argument" do
+    it "accepts a single Array(String | Regex) argument" do
       Regex.union(["skiing", "sledding"]).should eq /skiing|sledding/
       Regex.union([/dogs/, /cats/i]).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
-    it "accepts a single Tuple(String | Regexp) argument" do
+    it "accepts a single Tuple(String | Regex) argument" do
       Regex.union({"skiing", "sledding"}).should eq /skiing|sledding/
       Regex.union({/dogs/, /cats/i}).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -218,10 +218,10 @@ class Regex
   # Creates a new Regex out of the given source String.
   #
   # ```
-  # Regexp.new("^a-z+:\s+\w+")                     # => /^a-z+:\s+\w+/
-  # Regexp.new("cat", Regex::Options::IGNORE_CASE) # => /cat/i
+  # Regex.new("^a-z+:\s+\w+")                     # => /^a-z+:\s+\w+/
+  # Regex.new("cat", Regex::Options::IGNORE_CASE) # => /cat/i
   # options = Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
-  # Regexp.new("dog", options) # => /dog/ix
+  # Regex.new("dog", options) # => /dog/ix
   # ```
   def initialize(source, @options : Options = Options::None)
     # PCRE's pattern must have their null characters escaped


### PR DESCRIPTION
The spec for the format is here: https://www.w3.org/TR/NOTE-datetime

JavaScript also represents default JSON time format as ISO 8601 Full Time Format

```js
JSON.stringify({'now': new Date()})
```

will output

```json
{"now":"2013-10-21T13:28:06.419Z"}
```

which makes `%f` useful.