### PR TITLE
Support musl-libc

### DIFF
--- a/spec/std/double_spec.cr
+++ b/spec/std/double_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 describe "Double" do
   describe "**" do
-    assert { (2.5 ** 2).should eq(6.25) }
-    assert { (2.5 ** 2.5_f32).should eq(9.882117688026186) }
-    assert { (2.5 ** 2.5).should eq(9.882117688026186) }
+    assert { (2.5 ** 2).should be_close(6.25, 0.0001) }
+    assert { (2.5 ** 2.5_f32).should be_close(9.882117688026186, 0.0001) }
+    assert { (2.5 ** 2.5).should be_close(9.882117688026186, 0.0001) }
   end
 end

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -2,14 +2,14 @@ require "spec"
 
 describe "Float" do
   describe "**" do
-    assert { (2.5_f32 ** 2_i32).should eq(6.25_f32) }
-    assert { (2.5_f32 ** 2).should eq(6.25_f32) }
-    assert { (2.5_f32 ** 2.5_f32).should eq(9.882117688026186_f32) }
-    assert { (2.5_f32 ** 2.5).should eq(9.882117688026186_f32) }
-    assert { (2.5_f64 ** 2_i32).should eq(6.25_f64) }
-    assert { (2.5_f64 ** 2).should eq(6.25_f64) }
-    assert { (2.5_f64 ** 2.5_f64).should eq(9.882117688026186_f64) }
-    assert { (2.5_f64 ** 2.5).should eq(9.882117688026186_f64) }
+    assert { (2.5_f32 ** 2_i32).should be_close(6.25_f32, 0.0001) }
+    assert { (2.5_f32 ** 2).should be_close(6.25_f32, 0.0001) }
+    assert { (2.5_f32 ** 2.5_f32).should be_close(9.882117688026186_f32, 0.0001) }
+    assert { (2.5_f32 ** 2.5).should be_close(9.882117688026186_f32, 0.0001) }
+    assert { (2.5_f64 ** 2_i32).should be_close(6.25_f64, 0.0001) }
+    assert { (2.5_f64 ** 2).should be_close(6.25_f64, 0.0001) }
+    assert { (2.5_f64 ** 2.5_f64).should be_close(9.882117688026186_f64, 0.0001) }
+    assert { (2.5_f64 ** 2.5).should be_close(9.882117688026186_f64, 0.001) }
   end
 
   describe "%" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -11,9 +11,9 @@ end
 
 describe "Int" do
   describe "**" do
-    assert { (2 ** 2).should eq(4) }
-    assert { (2 ** 2.5_f32).should eq(5.656854249492381) }
-    assert { (2 ** 2.5).should eq(5.656854249492381) }
+    assert { (2 ** 2).should be_close(4, 0.0001) }
+    assert { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }
+    assert { (2 ** 2.5).should be_close(5.656854249492381, 0.0001) }
   end
 
   describe "#===(:Char)" do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -94,7 +94,7 @@ end
 
 describe "TCPServer" do
   it "fails when port is in use" do
-    expect_raises Errno, /already in use/ do
+    expect_raises Errno, /(already|Address) in use/ do
       TCPServer.open("::", 0) do |server|
         TCPServer.open("::", server.addr.ip_port) { }
       end
@@ -183,7 +183,7 @@ describe "TCPSocket" do
   end
 
   it "fails when host doesn't exist" do
-    expect_raises(Socket::Error, /^getaddrinfo: (.+ not known|no address .+|Non-recoverable failure in name resolution)$/i) do
+    expect_raises(Socket::Error, /^getaddrinfo: (.+ not known|no address .+|Non-recoverable failure in name resolution|Name does not resolve)$/i) do
       TCPSocket.new("localhostttttt", 12345)
     end
   end

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -1,10 +1,10 @@
 class Crystal::Program
   def flags
-    @flags ||= parse_flags(`uname -m -s`)
+    @flags ||= parse_flags(target_machine.triple.split('-'))
   end
 
   def flags=(flags)
-    @flags = parse_flags(flags)
+    @flags = parse_flags(flags.split)
   end
 
   def has_flag?(name)
@@ -18,7 +18,10 @@ class Crystal::Program
   end
 
   private def parse_flags(flags_name)
-    flags_name.split.map(&.downcase).to_set
+    set = flags_name.map(&.downcase).to_set
+    set.add "darwin" if set.any?(&.starts_with?("macosx"))
+    set.add "i686" if set.any? { |flag| %w(i586 i486 i386).includes?(flag) }
+    set
   end
 
   class FlagsEvaluator < Visitor

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -1,7 +1,11 @@
 lib LibC
   ifdef linux
-    @[ThreadLocal]
-    $errno : Int
+    ifdef musl
+      fun __errno_location : Int*
+    else
+      @[ThreadLocal]
+      $errno : Int
+    end
   elsif darwin
     fun __error : Int*
   end
@@ -215,7 +219,11 @@ class Errno < Exception
   # Returns the value of libc's errno.
   def self.value
     ifdef linux
-      LibC.errno
+      ifdef musl
+        LibC.__errno_location.value
+      else
+        LibC.errno
+      end
     elsif darwin
       LibC.__error.value
     end
@@ -224,7 +232,11 @@ class Errno < Exception
   # Sets the value of libc's errno.
   def self.value=(value)
     ifdef linux
-      LibC.errno = value
+      ifdef musl
+        LibC.__errno_location.value = value
+      else
+        LibC.errno = value
+      end
     elsif darwin
       LibC.__error.value = value
     end

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -5,6 +5,15 @@ lib LibC
   end
 
   fun gettimeofday(tp : TimeVal*, tzp : TimeZone*) : Int
+
+  ifdef linux
+    fun tzset() : Void
+    $timezone : Int
+  end
+end
+
+ifdef linux
+  LibC.tzset
 end
 
 # The `Time` library allows you to inspect, analyze, calculate, and format time. Here are some examples:
@@ -507,13 +516,13 @@ struct Time
   end
 
   def self.local_ticks
-    compute_ticks do |ticks, tp, tzp|
-      ticks - (tzp.tz_minuteswest.to_i64 * Span::TicksPerMinute)
+    compute_ticks do |ticks, tp, tz|
+      ticks - tz
     end
   end
 
   def self.utc_ticks
-    compute_ticks do |ticks, tp, tzp|
+    compute_ticks do |ticks, tp, tz|
       ticks
     end
   end
@@ -525,21 +534,25 @@ struct Time
   # Time.local_offset_in_minutes # => -180
   # ```
   def self.local_offset_in_minutes
-    if LibC.gettimeofday(nil, out tzp) != 0
-      raise Errno.new("gettimeofday")
+    ifdef linux
+      -LibC.timezone.to_i32 / 60
+    else
+      if LibC.gettimeofday(nil, out tzp) != 0
+        raise Errno.new("gettimeofday")
+      end
+      -tzp.tz_minuteswest.to_i32
     end
-    -tzp.tz_minuteswest.to_i32
   end
 
   protected def self.compute_utc_ticks(ticks)
-    compute_ticks do |t, tp, tzp|
-      ticks + tzp.tz_minuteswest.to_i64 * Span::TicksPerMinute
+    compute_ticks do |t, tp, tz|
+      ticks + tz
     end
   end
 
   protected def self.compute_local_ticks(ticks)
-    compute_ticks do |t, tp, tzp|
-      ticks - tzp.tz_minuteswest.to_i64 * Span::TicksPerMinute
+    compute_ticks do |t, tp, tz|
+      ticks - tz
     end
   end
 
@@ -549,7 +562,14 @@ struct Time
     end
     ticks = tp.tv_sec.to_i64 * Span::TicksPerSecond + tp.tv_usec.to_i64 * 10_i64
     ticks += UnixEpoch
-    yield ticks, tp, tzp
+
+    ifdef linux
+      tz = LibC.timezone.to_i64 / 60
+    else
+      tz = tzp.tz_minuteswest.to_i64
+    end
+
+    yield ticks, tp, tz * Span::TicksPerMinute
   end
 end
 


### PR DESCRIPTION
Here are changes to support musl-libc, in addition to glibc on Linux.

- [x] initialize compiler flags from target triple instead of `uname -m -s` in order to detect musl (this is required on Alpine Linux);
  - [x] fix: fails to detect darwin,
  - [x] fix: fails to detect linux 32bits;
- [x] fix bindings to errno;
- [x] local time is invalid (timezone struct of `gettimeofday` and returns invalid data, it's deprecated anyway on Linux);
- [ ] IO/String encoding specs always raise "invalid encoding GB2312" (musl iconv doesn't support encoding to GB2312, [see](http://www.openwall.com/lists/musl/2013/06/26/8))
- [x] fix float comparison specs (eg: `(2 ** 2.5).should eq(5.656854249492381)`)

closes #686 