### PR TITLE
add String#scrub, String#valid_encoding?

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1628,4 +1628,32 @@ describe "String" do
       String.new(bytes, "GB2312", invalid: :skip).should eq("好是")
     end
   end
+
+  describe "scrub" do
+    it "returns new String same as original string" do
+      "ABC日本語".scrub.should eq "ABC日本語"
+    end
+
+    it "returns replaced string if the string contains invalid byte" do
+      "日本語".byte_slice(1, 6).scrub.should eq "??本?"
+    end
+
+    it "replaces the string with given char" do
+      "日本語".byte_slice(1, 6).scrub('〓').should eq "〓〓本〓"
+    end
+
+    it "replaces the string with given string" do
+      "日本語".byte_slice(1, 6).scrub("<invalid>").should eq "<invalid><invalid>本<invalid>"
+    end
+  end
+
+  describe "valid_encoding?" do
+    it "returns true if the string does not contains invalid byte" do
+      "ABC日本語".valid_encoding?.should eq true
+    end
+
+    it "returns false if the string contains invalid byte" do
+      "日本語".byte_slice(1, 6).valid_encoding?.should eq false
+    end
+  end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2802,6 +2802,58 @@ class String
     end
   end
 
+  # Returns a new string that invalid byte has been replaced.
+  def scrub(repl='?')
+    String.build do |str|
+      pos = 0
+      while pos < bytesize
+        size = charsize_at(pos)
+        unless size
+          str << repl
+          pos += 1
+          next
+        end
+        str << byte_slice(pos, size)
+        pos += size
+      end
+    end
+  end
+
+  # Returns false if the string contains invalid byte.
+  def valid_encoding?
+    pos = 0
+    while pos < bytesize
+      size = charsize_at(pos)
+      return false unless size
+      pos += size
+    end
+    true
+  end
+
+  # :nodoc:
+  def charsize_at(pos)
+    return nil unless pos < bytesize
+    case c = byte_at(pos)
+    when .< 0x80
+      size = 1
+    when .< 0xc2
+      return nil
+    when .< 0xe0
+      size = 2
+    when .< 0xf0
+      size = 3
+    when .< 0xf8
+      size = 4
+    else
+      return nil
+    end
+    return nil unless pos + size - 1 < bytesize
+    (size - 1).times do |i|
+      return nil unless byte_at(pos + i + 1) & 0xc0 == 0x80
+    end
+    return size
+  end
+
   # :nodoc:
   class CharIterator
     include Iterator(Char)


### PR DESCRIPTION
add String#scrub and String#valid_encoding?

``` crystal
slice = Slice.new(5){|i| i.to_u8+0x41}
slice[2] = 0xffu8          #=> ['A', 'B', 0xFF, 'D', 'E']
str = String.new(slice)    #=> "AB<FF>DE"
str.valid_encoding?        #=> false
str.scrub                  #=> "AB?DE"
str.scrub('\uFFFD')        #=> "AB�DE"
str.scrub("<invalid>")     #=> "AB<invalid>DE"
```
