### PR TITLE
Improve URI#escape and URI#unescape

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -73,8 +73,8 @@ describe "URI" do
   describe ".unescape" do
     {
       {"hello", "hello"},
-      {"hello+world", "hello world"},
       {"hello%20world", "hello world"},
+      {"hello+world", "hello+world"},
       {"hello%", "hello%"},
       {"hello%2", "hello%2"},
       {"hello%2B", "hello+"},
@@ -82,7 +82,7 @@ describe "URI" do
       {"hello%2%2Bworld", "hello%2+world"},
       {"%E3%81%AA%E3%81%AA", "なな"},
       {"%e3%81%aa%e3%81%aa", "なな"},
-      {"%27Stop%21%27+said+Fred", "'Stop!' said Fred"},
+      {"%27Stop%21%27+said+Fred", "'Stop!'+said+Fred"},
     }.each do |tuple|
       from, to = tuple
 
@@ -95,6 +95,18 @@ describe "URI" do
           URI.unescape(from, str)
         end.should eq(to)
       end
+    end
+
+    it "unescapes plus to space" do
+      URI.unescape("hello+world", plus_to_space: true).should eq("hello world")
+      String.build do |str|
+        URI.unescape("hello+world", str, plus_to_space: true)
+      end.should eq("hello world")
+    end
+
+    it "dose not unescape string when block returns true" do
+      URI.unescape("hello%26world"){ |byte| URI.reserved? byte }
+        .should eq("hello%26world")
     end
   end
 
@@ -121,6 +133,38 @@ describe "URI" do
         String.build do |str|
           URI.escape(to, str)
         end.should eq(from)
+      end
+    end
+
+    it "escape space to plus when space_to_plus flag is true" do
+      URI.escape("hello world", space_to_plus: true).should eq("hello+world")
+      URI.escape("'Stop!' said Fred", space_to_plus: true).should eq("%27Stop%21%27+said+Fred")
+    end
+
+    it "does not escape character when block returns true" do
+      URI.unescape("hello&world"){ |byte| URI.reserved? byte }
+        .should eq("hello&world")
+    end
+  end
+
+  describe "reserved?" do
+    reserved_chars = Set.new([':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='])
+
+    ('\u{00}'..'\u{7F}').each do |char|
+      ok = reserved_chars.includes? char
+      it "should return #{ok} on given #{char}" do
+        URI.reserved?(char.ord.to_u8).should eq(ok)
+      end
+    end
+  end
+
+  describe "unreserved?" do
+    unreserved_chars = Set.new(('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '.', '-', '~'])
+
+    ('\u{00}'..'\u{7F}').each do |char|
+      ok = unreserved_chars.includes? char
+      it "should return #{ok} on given #{char}" do
+        URI.unreserved?(char.ord.to_u8).should eq(ok)
       end
     end
   end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -186,35 +186,83 @@ class URI
 
   # URL-decode a string.
   #
-  #     URI.unescape("%27Stop%21%27+said+Fred") #=> "'Stop!' said Fred"
-  def self.unescape(string : String)
-    String.build { |io| unescape(string, io) }
+  # If *plus_to_space* is true, it replace plus character (0x2B) to ' '.
+  # e.g. `application/x-www-form-urlencoded` wants this replace.
+  #
+  #     URI.unescape("%27Stop%21%27%20said%20Fred")                  #=> "'Stop!' said Fred"
+  #     URI.unescape("%27Stop%21%27+said+Fred", plus_to_space: true) #=> "'Stop!' said Fred"
+  def self.unescape(string : String, plus_to_space = false)
+    String.build { |io| unescape(string, io, plus_to_space) }
+  end
+
+  # URL-decode a string.
+  #
+  # This method requires block, the block is called with each bytes
+  # whose is less than `0x80`. The bytes that block returns `true`
+  # are not unescaped, other characters are unescaped.
+  def self.unescape(string : String, plus_to_space = false, &block)
+    String.build { |io| unescape(string, io, plus_to_space){ |byte| yield byte } }
   end
 
   # URL-decode a string and write the result to an `IO`.
-  def self.unescape(string : String, io : IO)
+  def self.unescape(string : String, io : IO, plus_to_space = false)
+    self.unescape(string, io, plus_to_space) { false }
+  end
+
+  # URL-decode a string and write the result to an `IO`.
+  #
+  # This method requires block.
+  def self.unescape(string : String, io : IO, plus_to_space = false, &block)
     i = 0
     bytesize = string.bytesize
     while i < bytesize
       byte = string.unsafe_byte_at(i)
       char = byte.chr
-      i = unescape_one string, bytesize, i, byte, char, io
+      i = unescape_one(string, bytesize, i, byte, char, io, plus_to_space){ |byte| yield byte }
     end
     io
   end
 
   # URL-encode a string.
   #
-  #     URI.escape("'Stop!' said Fred") #=> "%27Stop%21%27+said+Fred"
-  def self.escape(string : String)
-    String.build { |io| escape(string, io) }
+  # If *space_to_plus* is true, it replace space character (0x20) to '+' and '+' is
+  # encoded to '%2B'. e.g. `application/x-www-form-urlencoded` want this replace.
+  #
+  #     URI.escape("'Stop!' said Fred")                      #=> "%27Stop%21%27%20said%20Fred"
+  #     URI.escape("'Stop!' said Fred", space_to_plus: true) #=> "%27Stop%21%27+said+Fred"
+  def self.escape(string : String, space_to_plus = false)
+    String.build { |io| escape(string, io, space_to_plus) }
+  end
+
+  # URL-encode a string.
+  #
+  # This method requires block, the block is called with each characters
+  # whose code is less than `0x80`. The characters that block returns
+  # `true` are not escaped, other characters are escaped.
+  #
+  #     # Escape URI path
+  #     URI.escape("/foo/file?(1).txt") do |byte|
+  #       URI.unreserved?(byte) || byte.chr == '/'
+  #     end
+  #     #=> "/foo/file%3F%281%29.txt"
+  def self.escape(string : String, space_to_plus = false, &block)
+    String.build { |io| escape(string, io, space_to_plus){ |byte| yield byte } }
   end
 
   # URL-encode a string and write the result to an `IO`.
-  def self.escape(string : String, io : IO)
+  def self.escape(string : String, io : IO, space_to_plus = false)
+    self.escape(string, io, space_to_plus) { |byte| URI.unreserved? byte }
+  end
+
+  # URL-encode a string and write the result to an `IO`.
+  #
+  # This method requires block.
+  def self.escape(string : String, io : IO, space_to_plus = false, &block)
     string.each_byte do |byte|
-      case byte.chr
-      when 'a'..'z', 'A'..'Z', '0'..'9', '_', '.', '-'
+      char = byte.chr
+      if char == ' ' && space_to_plus
+        io.write_byte '+'.ord.to_u8
+      elsif byte < 0x80 && yield(byte) && (!space_to_plus || char != '+')
         io.write_byte byte
       else
         io.write_byte '%'.ord.to_u8
@@ -223,6 +271,25 @@ class URI
       end
     end
     io
+  end
+
+  # Returns whether given byte is reserved character defined in RFC 3986.
+  #
+  # Reserved characters are ':', '/', '?', '#', '[', ']', '@', '!',
+  # '$', '&', "'", '(', ')', '*', '+', ',', ';' and '='.
+  def self.reserved?(byte)
+    char = byte.chr
+    '&' <= char <= ',' ||
+      {'!', '#', '$', '/', ':', ';', '?', '@', '[', ']', '='}.includes?(char)
+  end
+
+  # Returns whether given byte is unreserved character defined in RFC 3986.
+  #
+  # Unreserved characters are alphabet, digit, '_', '.', '-', '~'.
+  def self.unreserved?(byte)
+    char = byte.chr
+    char.alphanumeric? ||
+      {'_', '.', '-', '~'}.includes?(char)
   end
 
   # Returns the user-information component containing the provided username and password.
@@ -238,9 +305,14 @@ class URI
   end
 
   # :nodoc:
+  def self.unescape_one(string, bytesize, i, byte, char, io, plus_to_space = false)
+    self.unescape_one(string, bytesize, i, byte, char, io) { false }
+  end
+
+  # :nodoc:
   # Unescapes one character. Private API
-  def self.unescape_one(string, bytesize, i, byte, char, io)
-    if char == '+'
+  def self.unescape_one(string, bytesize, i, byte, char, io, plus_to_space = false)
+    if plus_to_space && char == '+'
       io.write_byte ' '.ord.to_u8
       i += 1
       return i
@@ -264,8 +336,15 @@ class URI
         return i
       end
 
-      io.write_byte (first_num * 16 + second_num).to_u8
+      encoded = (first_num * 16 + second_num).to_u8
       i += 1
+      if encoded < 0x80 && yield encoded
+        io.write_byte byte
+        io.write_byte first
+        io.write_byte second
+        return i
+      end
+      io.write_byte encoded
       return i
     end
 
@@ -275,22 +354,10 @@ class URI
   end
 
   private def userinfo(user, io)
-    escape(user, io)
+    URI.escape(user, io)
     if password = @password
       io << ':'
-      escape(password, io)
-    end
-  end
-
-  private def escape(str, io)
-    str.each_byte do |byte|
-      case byte
-      when ':', '@', '/'
-        io << '%'
-        byte.to_s(16, io, upcase: true)
-      else
-        io.write_byte byte
-      end
+      URI.escape(password, io)
     end
   end
 end


### PR DESCRIPTION
`URI#escape` and `URI#unescape` take a block, this block decides to encode/unencode a character. The encoded/unencoded characters we expected are different in response to some RFC and situations. Also, which escaping `' '` (space character) to `'+'` or `%2B` is decided by user, it is better.