### PR TITLE
Adding documentation for BigInt.to_s methods

### DIFF
--- a/src/big_int/big_int.cr
+++ b/src/big_int/big_int.cr
@@ -202,15 +202,28 @@ struct BigInt < Int
     to_s io
   end
 
+  # Returns a string representation of self.
+  #
+  # ```
+  # puts BigInt.new("123456789101101987654321").to_s  # => 123456789101101987654321
+  # ```
   def to_s
     String.new(to_cstr)
   end
 
+  # ditto
   def to_s(io)
     str = to_cstr
     io.write_utf8 Slice.new(str, LibC.strlen(str))
   end
-
+  
+  # Returns a string containing the representation of big radix base (2 through 36).
+  # 
+  # ```
+  # puts BigInt.new("123456789101101987654321").to_s(8)  # => 32111154373025463465765261
+  # puts BigInt.new("123456789101101987654321").to_s(16) # => 1a249b1f61599cd7eab1
+  # puts BigInt.new("123456789101101987654321").to_s(36) # => k3qmt029k48nmpd
+  # ```
   def to_s(base : Int)
     raise "Invalid base #{base}" unless 2 <= base <= 36
     cstr = LibGMP.get_str(nil, base, self)


### PR DESCRIPTION
In src/big_int/big_int.cr :
- add documentation for to_s