### PR TITLE
Validate HTTP header content's characters

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -18,6 +18,12 @@ describe HTTP::Headers do
     headers["foobar_foo"].should eq("baz")
   end
 
+  it "raises an error if header value contains invalid character" do
+    expect_raises ArgumentError do
+      headers = HTTP::Headers{"invalid-header": "\r\nLocation: http://example.com"}
+    end
+  end
+
   it "should retain the input casing" do
     headers = HTTP::Headers{"FOO_BAR": "bar", "Foobar-foo": "baz"}
     serialized = String.build do |io|

--- a/spec/std/oauth2/access_token_spec.cr
+++ b/spec/std/oauth2/access_token_spec.cr
@@ -93,7 +93,7 @@ class OAuth2::AccessToken
       headers = HTTP::Headers.new
       headers["Host"] = "localhost:4000"
 
-      token = Mac.new("3n2\b-YaAzH67YH9UJ-9CnJ_PS-vSy1MRLM-q7TZknPw", 3600, "hmac-sha-256", "i-pt1Lir-yAfUdXbt-AXM1gMupK7vDiOK1SZGWkASDc")
+      token = Mac.new("3n2-YaAzH67YH9UJ-9CnJ_PS-vSy1MRLM-q7TZknPw", 3600, "hmac-sha-256", "i-pt1Lir-yAfUdXbt-AXM1gMupK7vDiOK1SZGWkASDc")
       request = HTTP::Request.new "GET", "/some/resource.json", headers
       token.authenticate request, false
       auth = request.headers["Authorization"]


### PR DESCRIPTION
According to RFC 7230, characters accepted as HTTP header are `'\t'`, `' '`, all US-ASCII printable characters and range from `'\x80'` to `'\xff'` (but the last is obsoleted.)

And, fixed an OAuth2 spec. The spec had been broken because access token must not contain such a invalid character by RFC 6749 Appendex A.12.