### PR TITLE
Add check for llvm-config- to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ LIB_CRYSTAL_SOURCES = $(shell find src/ext -name '*.c')
 LIB_CRYSTAL_OBJS = $(subst .c,.o,$(LIB_CRYSTAL_SOURCES))
 LIB_CRYSTAL_TARGET = src/ext/libcrystal.a
 
+ifeq (${LLVM_CONFIG},)
+$(error Could not locate llvm-config, make sure it is installed and in your PATH)
+endif
+
 all: crystal
 spec: all_spec
 	$(O)/all_spec


### PR DESCRIPTION
Add check to make sure that we found an llvm-config- variant before trying to execute it. 

Eliminates errors such as:
/bin/bash: --cxxflags: command not found
When llvm is not installed