### PR TITLE
Expose URI from HTTP::Request

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -118,6 +118,13 @@ module HTTP
       request.body.should eq("thisisthebody")
     end
 
+    describe "#uri" do
+      it "returns the URI object wrapping the given resource" do
+        request = Request.new "GET", "http://example.com"
+        request.uri.should be_a(URI)
+      end
+    end
+
     describe "keep-alive" do
       it "is false by default in HTTP/1.0" do
         request = Request.new "GET", "/", version: "HTTP/1.0"

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -84,7 +84,7 @@ class HTTP::Request
     value
   end
 
-  private def uri
+  def uri
     (@uri ||= URI.parse(@resource)).not_nil!
   end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -8,7 +8,7 @@ class HTTP::Request
   getter body
   getter version
 
-  def initialize(@method : String, @resource, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
+  def initialize(@method : String, @resource : String, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
     if body = @body
       @headers["Content-Length"] = body.bytesize.to_s
     elsif @method == "POST" || @method == "PUT"


### PR DESCRIPTION
Might be additional reasons I'm unaware for doing this, but having access to the underlying URI would be very useful. Moreover Ruby's [Net::HTTPRequest](https://github.com/ruby/ruby/blob/trunk/lib/net/http/generic_request.rb#L55) (via GenericRequest) exposes this as well.

Are there historical reasons for not doing this? And in this change, there are perhaps better ways to ensure that the URI is present at access time than the current code provides. Willing to make refactors with some guidance.