### PR TITLE
allow reject/select to receive arrays

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -695,6 +695,7 @@ describe "Hash" do
   describe "reject" do
     assert { {a: 2, b: 3}.reject(:b, :d).should eq({a: 2}) }
     assert { {a: 2, b: 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
+    assert { {a: 2, b: 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
     it "does not change currrent hash" do
       h = {a: 3, b: 6, c: 9}
       h2 = h.reject(:b, :c)
@@ -705,6 +706,7 @@ describe "Hash" do
   describe "reject!" do
     assert { {a: 2, b: 3}.reject!(:b, :d).should eq({a: 2}) }
     assert { {a: 2, b: 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
+    assert { {a: 2, b: 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
     it "changes currrent hash" do
       h = {a: 3, b: 6, c: 9}
       h.reject!(:b, :c)
@@ -716,6 +718,7 @@ describe "Hash" do
     assert { {a: 2, b: 3}.select(:b, :d).should eq({b: 3}) }
     assert { {a: 2, b: 3}.select.should eq({} of Symbol => Int32) }
     assert { {a: 2, b: 3}.select(:b, :a).should eq({a: 2, b: 3}) }
+    assert { {a: 2, b: 3}.select([:b, :a]).should eq({a: 2, b: 3}) }
     it "does not change currrent hash" do
       h = {a: 3, b: 6, c: 9}
       h2 = h.select(:b, :c)
@@ -727,6 +730,7 @@ describe "Hash" do
     assert { {a: 2, b: 3}.select!(:b, :d).should eq({b: 3}) }
     assert { {a: 2, b: 3}.select!.should eq({} of Symbol => Int32) }
     assert { {a: 2, b: 3}.select!(:b, :a).should eq({a: 2, b: 3}) }
+    assert { {a: 2, b: 3}.select!([:b, :a]).should eq({a: 2, b: 3}) }
     it "does change currrent hash" do
       h = {a: 3, b: 6, c: 9}
       h.select!(:b, :c)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -592,9 +592,13 @@ class Hash(K, V)
   # h = {"a": 1, "b": 2, "c": 3, "d": 4}.reject!("a", "c")
   # h # => {"b": 2, "d": 4}
   # ```
-  def reject!(*keys)
+  def reject!(keys : Array | Tuple)
     keys.each { |k| delete(k) }
     self
+  end
+
+  def reject!(*keys)
+    reject!(keys)
   end
 
   # Returns a new `Hash` with the given keys.
@@ -602,10 +606,14 @@ class Hash(K, V)
   # ```
   # {"a": 1, "b": 2, "c": 3, "d": 4}.select("a", "c") # => {"a": 1, "c": 3}
   # ```
-  def select(*keys)
+  def select(keys : Array | Tuple)
     hash = {} of K => V
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
+  end
+
+  def select(*keys)
+    select(keys)
   end
 
   # Removes every element except the given ones.
@@ -614,9 +622,13 @@ class Hash(K, V)
   # h = {"a": 1, "b": 2, "c": 3, "d": 4}.select!("a", "c")
   # h # => {"a": 1, "c": 3}
   # ```
-  def select!(*keys)
+  def select!(keys : Array | Tuple)
     each { |k, v| delete(k) unless keys.includes?(k) }
     self
+  end
+
+  def select!(*keys)
+    select!(keys)
   end
 
   # Zips two arrays into a `Hash`, taking keys from *ary1* and values from *ary2*.


### PR DESCRIPTION
Super useful in the case where you are programmatically generating an array to pass to reject/select as in a hash diff method:

```crystal
def modified(one : Hash, two : Hash)
  diff_keys = one.keys - two.keys
  one.select(diff_keys)
end
```

The above code doesn't work with current Crystal as `select` takes a tuple only. 