### PR TITLE
Syntax: allow multiple expressions in a case condition

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -419,6 +419,7 @@ describe Crystal::Formatter do
   assert_format "case  1 \n when  .foo? \n 3 \n end", "case 1\nwhen .foo?\n  3\nend"
   assert_format "case 1\nwhen 1 then\n2\nwhen 3\n4\nend", "case 1\nwhen 1\n  2\nwhen 3\n  4\nend"
   assert_format "case  1 \n when 2 \n 3 \n else 4 \n end", "case 1\nwhen 2\n  3\nelse 4\nend"
+  assert_format "case  1 , 2 \n when 3 , 4 \n 5 \n end", "case 1, 2\nwhen 3, 4\n  5\nend"
 
   assert_format "foo.@bar"
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -741,10 +741,10 @@ describe "macro methods" do
   end
 
   describe "case methods" do
-    case_node = Case.new(NumberLiteral.new(1), [When.new([NumberLiteral.new(2), NumberLiteral.new(3)] of ASTNode, NumberLiteral.new(4))], NumberLiteral.new(5))
+    case_node = Case.new([NumberLiteral.new(1)] of ASTNode, [When.new([NumberLiteral.new(2), NumberLiteral.new(3)] of ASTNode, NumberLiteral.new(4))], NumberLiteral.new(5))
 
     it "executes cond" do
-      assert_macro "x", %({{x.cond}}), [case_node] of ASTNode, "1"
+      assert_macro "x", %({{x.conds}}), [case_node] of ASTNode, "[1]"
     end
 
     it "executes whens" do

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -48,4 +48,20 @@ describe "Normalize: case" do
   it "normalizes case with nil to is_a?" do
     assert_expand_second "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
   end
+
+  it "normalizes case with multiple expressions" do
+    assert_expand_second "x, y = 1, 2; case x, y; when 2, 3; 4; end", "if 2 === x && 3 === y\n  4\nend"
+  end
+
+  it "normalizes case with multiple expressions with underscore" do
+    assert_expand_second "x, y = 1, 2; case x, y; when 2, _; 4; end", "if 2 === x\n  4\nend"
+  end
+
+  it "normalizes case with multiple expressions with all underscores" do
+    assert_expand_second "x, y = 1, 2; case x, y; when _, _; 4; end", "if true\n  4\nend"
+  end
+
+  it "normalizes case with single expressions with underscore" do
+    assert_expand_second "x = 1; case x; when _; 2; end", "if true\n  2\nend"
+  end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -844,20 +844,24 @@ describe "Parser" do
   it_parses "require \"foo\"", Require.new("foo")
   it_parses "require \"foo\"; [1]", [Require.new("foo"), ([1.int32] of ASTNode).array]
 
-  it_parses "case 1; when 1; 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-  it_parses "case 1; when 0, 1; 2; else; 3; end", Case.new(1.int32, [When.new([0.int32, 1.int32] of ASTNode, 2.int32)], 3.int32)
-  it_parses "case 1\nwhen 1\n2\nelse\n3\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-  it_parses "case 1\nwhen 1\n2\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)])
-  it_parses "case / /; when / /; / /; else; / /; end", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
-  it_parses "case / /\nwhen / /\n/ /\nelse\n/ /\nend", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
+  it_parses "case 1; when 1; 2; else; 3; end", Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
+  it_parses "case 1; when 0, 1; 2; else; 3; end", Case.new([1.int32] of ASTNode, [When.new([0.int32, 1.int32] of ASTNode, 2.int32)], 3.int32)
+  it_parses "case 1\nwhen 1\n2\nelse\n3\nend", Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
+  it_parses "case 1\nwhen 1\n2\nend", Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)])
+  it_parses "case / /; when / /; / /; else; / /; end", Case.new([regex(" ")] of ASTNode, [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
+  it_parses "case / /\nwhen / /\n/ /\nelse\n/ /\nend", Case.new([regex(" ")] of ASTNode, [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
 
-  it_parses "case 1; when 1 then 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-  it_parses "case 1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
-  it_parses "case\n1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
+  it_parses "case 1; when 1 then 2; else; 3; end", Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
+  it_parses "case 1\nwhen 1\n2\nend\nif a\nend", [Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
+  it_parses "case\n1\nwhen 1\n2\nend\nif a\nend", [Case.new([1.int32] of ASTNode, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
 
-  it_parses "case 1\nwhen .foo\n2\nend", Case.new(1.int32, [When.new([Call.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)])
+  it_parses "case 1\nwhen .foo\n2\nend", Case.new([1.int32] of ASTNode, [When.new([Call.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)])
   it_parses "case when 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
   it_parses "case \nwhen 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
+
+  it_parses "case 1, 2, 3; when 4, 5, 6; 7; else; 8; end", Case.new([1.int32, 2.int32, 3.int32] of ASTNode, [When.new([4.int32, 5.int32, 6.int32] of ASTNode, 7.int32)], 8.int32)
+  it_parses "case 1; when _; 2; end", Case.new([1.int32] of ASTNode, [When.new([Underscore.new] of ASTNode, 2.int32)])
+  assert_syntax_error "case 1, 2; when 3; 4; end", "wrong number of when expressions (given 1, expected 2)", 1, 12
 
   it_parses "def foo(x); end; x", [Def.new("foo", ["x".arg]), "x".call]
   it_parses "def foo; / /; end", Def.new("foo", body: regex(" "))

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -969,8 +969,14 @@ module Crystal
   class Case
     def interpret(method, args, block, interpreter)
       case method
-      when "cond"
-        interpret_argless_method(method, args) { cond || Nop.new }
+      when "conds"
+        interpret_argless_method(method, args) do
+          if conds = self.conds
+            ArrayLiteral.new(conds)
+          else
+            Nop.new
+          end
+        end
       when "whens"
         interpret_argless_method(method, args) { ArrayLiteral.map whens, &.itself }
       when "else"

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1131,23 +1131,24 @@ module Crystal
   end
 
   class Case < ASTNode
-    property :cond
+    property conds : Array(ASTNode)?
     property :whens
     property :else
 
-    def initialize(@cond, @whens, @else = nil)
+    def initialize(@conds : Array(ASTNode)?, @whens, @else = nil)
     end
 
     def accept_children(visitor)
+      @conds.try &.each &.accept visitor
       @whens.each &.accept visitor
       @else.try &.accept visitor
     end
 
     def clone_without_location
-      Case.new(@cond.clone, @whens.clone, @else.clone)
+      Case.new(@conds.clone, @whens.clone, @else.clone)
     end
 
-    def_equals_and_hash @cond, @whens, @else
+    def_equals_and_hash @conds, @whens, @else
   end
 
   # Node that represents an implicit obj in:

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1145,9 +1145,12 @@ module Crystal
 
     def visit(node : Case)
       @str << keyword("case")
-      if cond = node.cond
+      if conds = node.conds
         @str << " "
-        cond.accept self
+        conds.each_with_index do |cond, i|
+          @str << ", " if i > 0
+          cond.accept self
+        end
       end
       newline
       node.whens.each do |wh|

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -189,7 +189,7 @@ module Crystal
     end
 
     def transform(node : Case)
-      node.cond = node.cond.try &.transform(self)
+      transform_many node.conds
       transform_many node.whens
 
       if node_else = node.else

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2648,9 +2648,18 @@ module Crystal
       write_keyword :case
       skip_space
 
-      if cond = node.cond
+      if conds = node.conds
         write " "
-        accept cond
+        conds.each_with_index do |cond, i|
+          accept cond
+          unless last?(i, conds)
+            skip_space
+            if @token.type == :","
+              write ", "
+              next_token_skip_space_or_newline
+            end
+          end
+        end
       end
 
       skip_space_write_line


### PR DESCRIPTION
This PR adds this syntax:

```crystal
case exp1, exp2, ..., expN
when cond1, cond2, ..., condN
  body
end
```

This is just a simple syntax sugar of this:

```crystal
if cond1 === exp1 && cond2 === exp2 && .. && condN === expN
  body
end
```

However, as with the regular case, you can use a type and, in the case of a variable, it will be restricted. For example:

```crystal
a = rand < 0.5 ? 1 : "hello"
b = rand < 0.5 ? 1 : "hello"

case a, b
when Int32, Int32
  puts "Both ints: #{a + 1}, #{b + 1}"
when String, String
  puts "Both strings: #{a.upcase}, #{b.upcase}"
else
  puts "Other: #{a}, #{b}"
end
```

Or the "implicit obj" notation:

```crystal
a = rand(1..10)
b = rand(1..10)

pp a, b
case a, b
when .even?, .even?
  puts "Both even"
when .odd?, .odd?
  puts "Both odd"
else
  puts "Meh"
end
```

An underscore is also allowed as an expression, and the comparison is just "true".

Finally, the compiler checks that the number of "when" expressions matches the number of "case" expressions, in case there is more than one expression.