### PR TITLE
Primitives: correctly compare signed and unsigned integers. Fixes #571

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "big_int"
 
 private def to_s_with_io(num)
   String.build { |str| num.to_s(str) }
@@ -387,5 +388,23 @@ describe "Int" do
     assert { 5_i64.popcount.should eq(2) }
     assert { 9223372036854775807_i64.popcount.should eq(63) }
     assert { 18446744073709551615_u64.popcount.should eq(64) }
+  end
+
+  it "compares signed vs. unsigned integers" do
+    signed_ints = [Int8::MAX, Int16::MAX, Int32::MAX, Int64::MAX, Int8::MIN, Int16::MIN, Int32::MIN, Int64::MIN, 0_i8, 0_i16, 0_i32, 0_i64]
+    unsigned_ints = [UInt8::MAX, UInt16::MAX, UInt32::MAX, UInt64::MAX, 0_u8, 0_u16, 0_u32, 0_u64]
+
+    big_signed_ints = signed_ints.map &.to_big_i
+    big_unsigned_ints = unsigned_ints.map &.to_big_i
+
+    signed_ints.zip(big_signed_ints) do |si, bsi|
+      unsigned_ints.zip(big_unsigned_ints) do |ui, bui|
+        {% for op in %w(< <= > >=).map(&.id) %}
+          if (si {{op}} ui) != (bsi {{op}} bui)
+            fail "comparison of #{si} {{op}} #{ui} (#{si.class} {{op}} #{ui.class}) gave incorrect result"
+          end
+        {% end %}
+      end
+    end
   end
 end

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -24,6 +24,10 @@ module Crystal
       int32(n)
     end
 
+    def int(n, type)
+      LLVM.int llvm_type(type), n
+    end
+
     def null
       int(0)
     end


### PR DESCRIPTION
This PR changes the generated code for comparisons of signed vs. unsigned integers to always give the correct result.

If both numbers are not known at compile time, it's twice slower than before. For example:

```crystal
nums1 = Array.new(20_000) { rand(0..255).to_u8 }
nums2 = Array.new(20_000) { rand(-1000..1000).to_i32 }

total = 0

time = Time.now
nums1.each do |n1|
  nums2.each do |n2|
    total += 1 if n1 < n2
  end
end
puts Time.now - time

puts total
``` 

Before: 0.205s
After: 0.394s

If one of the numbers is known at compile-time, the performance stays the same as before.

Since unsigned numbers are not commonly used (in application-level code I imagine Int32 or Int64 used a lot, and unsigned numbers mostly for C interoperability), I'd say to make this change. It's better to avoid incorrect runtime results. And you can always cast one of the numbers to the other type if you are sure it will fit, and get the performance back.