### PR TITLE
improve performance of Levenshtein distance

### DIFF
--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -26,21 +26,21 @@ module Levenshtein
       t_size, s_size = s_size, t_size
     end
 
-    v0 = Pointer(Int32).malloc(t_size + 1) { |i| i }
-    v1 = Pointer(Int32).malloc(t_size + 1)
+    v = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
     s_size.times do |i|
-      v1[0] = i + 1
+      last_cost = i + 1
 
-      0.upto(t_size - 1) do |j|
-        cost = s[i] == t[j] ? 0 : 1
-        v1[j + 1] = Math.min(Math.min(v1[j] + 1, v0[j + 1] + 1), v0[j] + cost)
+      t_size.times do |j|
+        sub_cost = s[i] == t[j] ? 0 : 1
+        cost = Math.min(Math.min(last_cost + 1, v[j + 1] + 1), v[j] + sub_cost)
+        v[j] = last_cost
+        last_cost = cost
       end
-
-      v0.copy_from(v1, t_size + 1)
+      v[t_size] = last_cost
     end
 
-    v1[t_size]
+    v[t_size]
   end
 
   # Finds the closest string to a given string amongst many strings.


### PR DESCRIPTION
This adjusts the Levenshtein implementation to only require storage of a single full matrix row, reducing memory allocation and improving performance. 

```ruby
words = File.read("/usr/share/dict/words").split(/\n/).take(100)
Benchmark.ips do |x|
  x.report "before" do
    words.each_cons(2) { |a| Levenshtein.distance a[0], a[1] }
  end
  x.report "after" do
    words.each_cons(2) { |a| Levenshtein.distance2 a[0], a[1] }
  end
end
```

```
before  18.11k (± 2.84%)  1.22× slower
 after  22.01k (± 3.05%)       fastest
```