### PR TITLE
Syntax: allow keyword names to be used for a TypeDeclaration node

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1114,6 +1114,14 @@ describe "Parser" do
   it_parses "foo 1.bar do\nend", Call.new(nil, "foo", args: [Call.new(1.int32, "bar")] of ASTNode, block: Block.new)
   it_parses "return 1.bar do\nend", Return.new(Call.new(1.int32, "bar", block: Block.new))
 
+  %w(begin nil true false yield with abstract def macro require case if ifdef unless include extend class struct module enum while
+    until return next break lib fun alias pointerof sizeof instance_sizeof typeof private protected asm end do else elsif when rescue ensure as).each do |keyword|
+    it_parses "#{keyword} : Int32", TypeDeclaration.new(keyword.var, "Int32".path)
+    it_parses "property #{keyword} : Int32", Call.new(nil, "property", TypeDeclaration.new(keyword.var, "Int32".path))
+  end
+
+  it_parses "case :foo; when :bar; 2; end", Case.new("foo".symbol, [When.new(["bar".symbol] of ASTNode, 2.int32)])
+
   assert_syntax_error "return do\nend", "unexpected token: do"
 
   %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|


### PR DESCRIPTION
Right now you can do this:

```crystal
class Foo
  property x
end
```

But what if you need a property that's named "end" (for example the "end date" of something?). No problem:

```crystal
class Foo
  # Use a symbol because "end" is invalid syntax
  property :end
end
```

So far so good. But what if we need "end" to have a type? Let's try:

```crystal
class Foo
  # Doesn't work, same problem as before
  property end : Time

  # "Symbol colon Type" is invalid syntax, so doesn't work either
  property :end : Time
end
```

So, there's no way to do it. We have to do something like:

```crystal
class Foo
  property :end
  @end : Time
end
```

but it's not quite the same.

The problem also affects code that wants to use `property`, or basically use type declarations (`name : Type`), for example `JSON.mapping` and `YAML.mapping`. Right now these don't reuse `property` because of these issues. For example:

```crystal
class Foo
  # Could simple expand to `property end : Time`, but no, doesn't work
  JSON.mapping({
    # This *is* valid syntax, because it's a hash key
    end: Time
  })
end
```

With this PR, the parser now parses "keyword : Type" as a type declaration, where "keyword" can be any keyword, like "abstract", "def", "end", "class", etc. So it would be possible to do:

```crystal
class Foo
  property end : Time
end
```

and it would just work.

I believe this will cause less surprises and annoyances while using the language, and make it more consistent. The parser needs a few look aheads for this, but I checked the performance and it stays the same.