### PR TITLE
String: allow back-references in sub and gsub. Fixes #2199. Fixes #684

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -798,6 +798,49 @@ describe "String" do
     it "subs using $~" do
       "foo".sub(/(o)/) { "x#{$1}x" }.should eq("fxoxo")
     end
+
+    it "subs using with \\" do
+      "foo".sub(/(o)/, "\\").should eq("f\\o")
+    end
+
+    it "subs using with z\\w" do
+      "foo".sub(/(o)/, "z\\w").should eq("fz\\wo")
+    end
+
+    it "replaces with numeric back-reference" do
+      "foo".sub(/o/, "x\\0x").should eq("fxoxo")
+      "foo".sub(/(o)/, "x\\1x").should eq("fxoxo")
+      "foo".sub(/(o)/, "\\\\1").should eq("f\\1o")
+      "hello".sub(/[aeiou]/, "(\\0)").should eq("h(e)llo")
+    end
+
+    it "replaces with incomplete named back-reference (1)" do
+      "foo".sub(/(oo)/, "|\\k|").should eq("f|\\k|")
+    end
+
+    it "replaces with incomplete named back-reference (2)" do
+      "foo".sub(/(oo)/, "|\\k\\1|").should eq("f|\\koo|")
+    end
+
+    it "replaces with named back-reference" do
+      "foo".sub(/(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
+    end
+
+    it "replaces with multiple named back-reference" do
+      "fooxx".sub(/(?<bar>oo)(?<baz>x+)/, "|\\k<bar>|\\k<baz>|").should eq("f|oo|xx|")
+    end
+
+    it "replaces with \\a" do
+      "foo".sub(/(oo)/, "|\\a|").should eq("f|\\a|")
+    end
+
+    it "replaces with \\\\\\1" do
+      "foo".sub(/(oo)/, "|\\\\\\1|").should eq("f|\\oo|")
+    end
+
+    it "ignores if backreferences: false" do
+      "foo".sub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xo")
+    end
   end
 
   describe "gsub" do
@@ -905,6 +948,62 @@ describe "String" do
 
     it "gsubs using $~" do
       "foo".gsub(/(o)/) { "x#{$1}x" }.should eq("fxoxxox")
+    end
+
+    it "replaces with numeric back-reference" do
+      "foo".gsub(/o/, "x\\0x").should eq("fxoxxox")
+      "foo".gsub(/(o)/, "x\\1x").should eq("fxoxxox")
+      "foo".gsub(/(ここ)|(oo)/, "x\\1\\2x").should eq("fxoox")
+    end
+
+    it "replaces with named back-reference" do
+      "foo".gsub(/(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
+      "foo".gsub(/(?<x>ここ)|(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
+    end
+
+    it "replaces with incomplete back-reference (1)" do
+      "foo".gsub(/o/, "\\").should eq("f\\\\")
+    end
+
+    it "replaces with incomplete back-reference (2)" do
+      "foo".gsub(/o/, "\\\\").should eq("f\\\\")
+    end
+
+    it "replaces with incomplete back-reference (3)" do
+      "foo".gsub(/o/, "\\k").should eq("f\\k\\k")
+    end
+
+    it "raises with incomplete back-reference (1)" do
+      expect_raises(ArgumentError) do
+        "foo".gsub(/(?<bar>oo)/, "|\\k<bar|")
+      end
+    end
+
+    it "raises with incomplete back-reference (2)" do
+      expect_raises(ArgumentError, "missing ending '>' for '\\\\k<...") do
+        "foo".gsub(/o/, "\\k<")
+      end
+    end
+
+    it "replaces with back-reference to missing capture group" do
+      "foo".gsub(/o/, "\\1").should eq("f")
+
+      expect_raises(IndexError, "undefined group name reference: \"bar\"") do
+        "foo".gsub(/o/, "\\k<bar>").should eq("f")
+      end
+
+      expect_raises(IndexError, "undefined group name reference: \"\"") do
+        "foo".gsub(/o/, "\\k<>")
+      end
+    end
+
+    it "replaces with escaped back-reference" do
+      "foo".gsub(/o/, "\\\\0").should eq("f\\0\\0")
+      "foo".gsub(/oo/, "\\\\k<bar>").should eq("f\\k<bar>")
+    end
+
+    it "ignores if backreferences: false" do
+      "foo".gsub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xx\\0x")
     end
   end
 


### PR DESCRIPTION
This is basically an optimized version of #2199, originally written by @bjmllr (thank you @bjmllr, I reused a lot of your code's ideas and also the documentation!)

While benchmarking this, I didn't notice any difference between turning backreferences scanning on or off. I then remembered: if the replacement string is known at compile-time, then, when compiled in release mode, LLVM knows whether the string has backslashes or not, and can optimize it right away. And since this is probably going to be true %99 of the time, there's no performance penalty. Basically:

```crystal
# LLVM knows that "hello" doesn't have "\", so at runtime the string
# isn't even scanned to see if there are backreferences, so the performance
# stays the same as before this PR
"foo".gsub(/o/, "hello")
```

So, once more, big thanks to LLVM :-)

Because of the above reasoning, I'm super in favor now of having backreferences, and having them turned on by default.

And this is a benchmark I made to compare it with Ruby:

```crystal
subject = "foofoofoofoo"
with_backrefs = "xyzxyzxyzxyz\\1xyzxyzxyz\\1xyzxyzxyz\\1xyzxyz" * 15
with_named_backrefs = "xyzxyzxyzxyz\\k<bar>xyzxyzxyz\\k<bar>xyzxyzxyz\\k<bar>xyzxyz" * 15
without_backrefs = "xyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyz" * 15

p subject.gsub(/(o+)/, with_backrefs)
p subject.gsub(/(?<bar>o+)/, with_named_backrefs)
p subject.gsub(/(o+)/, without_backrefs)

time = Time.now
200_000.times do
  subject.gsub(/(o+)/, with_backrefs)
end
puts "with backrefs: #{Time.now - time}"

time = Time.now
200_000.times do
  subject.gsub(/(?<bar>o+)/, with_named_backrefs)
end
puts "with named backrefs: #{Time.now - time}"

time = Time.now
200_000.times do
  subject.gsub(/(o+)/, without_backrefs)
end
puts "without backrefs: #{Time.now - time}"
```

Ruby:

```
with backrefs: 8.061402
with named backrefs: 12.444838
without backrefs: 1.095619
```

Crystal:

```
with backrefs: 00:00:02.8218800
with named backrefs: 00:00:05.2087920
without backrefs: 00:00:00.7943960
``` 