### PR TITLE
Allow rand(range) to accept range of Float

### DIFF
--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -35,6 +35,12 @@ describe "Random" do
     x.should be < 4
   end
 
+  it "does with range of Float" do
+    x = rand(-5.0..2.5)
+    x.should be >= -5.0
+    x.should be <= 2.5
+  end
+
   it "raises on invalid range" do
     expect_raises ArgumentError, "incorrect rand value: 1...1" do
       rand(1...1)

--- a/src/random.cr
+++ b/src/random.cr
@@ -105,6 +105,15 @@ module Random
     end
   end
 
+  # Returns a random `Float64` in the given *range*.
+  # ```
+  # Random.new.rand(-1.0..1.0) # => -0.450051
+  # ```
+  def rand(range : Range(Float, Float)) : Float64
+    span = range.end - range.begin
+    rand * span + range.begin
+  end
+
   # see `#rand`
   def self.rand : Float64
     DEFAULT.rand
@@ -113,6 +122,11 @@ module Random
   # see `#rand(x)`
   def self.rand(x) : Int32
     DEFAULT.rand(x)
+  end
+
+  # see `#rand(range)`
+  def self.rand(range : Range(Float, Float)) : Float64
+    DEFAULT.rand(range)
   end
 end
 


### PR DESCRIPTION
It's possible to do `rand(1..2)` with integers, so I guess the same should work for Float as well.

The question to discuss: should `rand(Range(Float, Float))` try to respect `range.excludes_end?` The probability of `rand` returning `1.0` is extremely small, however is possible: I did an experiment, and get it after ~1_091_000_000 attempts:)