### PR TITLE
Syntax: special handling of tuple condition in case expression

### DIFF
--- a/spec/compiler/normalize/chained_comparisons_spec.cr
+++ b/spec/compiler/normalize/chained_comparisons_spec.cr
@@ -2,22 +2,22 @@ require "../../spec_helper"
 
 describe "Normalize: chained comparisons" do
   it "normalizes one comparison with literal" do
-    assert_normalize "1 <= 2 <= 3", "1 <= 2 && 2 <= 3"
+    assert_normalize "1 <= 2 <= 3", "(1 <= 2) && (2 <= 3)"
   end
 
   it "normalizes one comparison with var" do
-    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n1 <= b && b <= 3"
+    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n(1 <= b) && (b <= 3)"
   end
 
   it "normalizes one comparison with call" do
-    assert_normalize "1 <= b <= 3", "1 <= (__temp_1 = b) && __temp_1 <= 3"
+    assert_normalize "1 <= b <= 3", "(1 <= (__temp_1 = b)) && (__temp_1 <= 3)"
   end
 
   it "normalizes two comparisons with literal" do
-    assert_normalize "1 <= 2 <= 3 <= 4", "1 <= 2 && 2 <= 3 && 3 <= 4"
+    assert_normalize "1 <= 2 <= 3 <= 4", "((1 <= 2) && (2 <= 3)) && (3 <= 4)"
   end
 
   it "normalizes two comparisons with calls" do
-    assert_normalize "1 <= a <= b <= 4", "1 <= (__temp_2 = a) && __temp_2 <= (__temp_1 = b) && __temp_1 <= 4"
+    assert_normalize "1 <= a <= b <= 4", "((1 <= (__temp_2 = a)) && (__temp_2 <= (__temp_1 = b))) && (__temp_1 <= 4)"
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -859,6 +859,11 @@ describe "Parser" do
   it_parses "case 1\nwhen .foo\n2\nend", Case.new(1.int32, [When.new([Call.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)])
   it_parses "case when 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
   it_parses "case \nwhen 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
+  it_parses "case {1, 2}\nwhen {3, 4}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode)] of ASTNode, 5.int32)])
+  it_parses "case {1, 2}\nwhen {3, 4}, {5, 6}\n7\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode), TupleLiteral.new([5.int32, 6.int32] of ASTNode)] of ASTNode, 7.int32)])
+  it_parses "case {1, 2}\nwhen {.foo, .bar}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([Call.new(ImplicitObj.new, "foo"), Call.new(ImplicitObj.new, "bar")] of ASTNode)] of ASTNode, 5.int32)])
+  it_parses "case {1, 2}\nwhen foo\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new(["foo".call] of ASTNode, 5.int32)])
+  assert_syntax_error "case {1, 2}; when {3}; 4; end", "wrong number of tuple elements (given 1, expected 2)", 1, 19
 
   it_parses "def foo(x); end; x", [Def.new("foo", ["x".arg]), "x".call]
   it_parses "def foo; / /; end", Def.new("foo", body: regex(" "))

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -219,4 +219,12 @@ describe "Tuple" do
 
     Tuple.new.last?.should be_nil
   end
+
+  it "does ===" do
+    ({1, 2} === {1, 2}).should be_true
+    ({1, 2} === {1, 3}).should be_false
+    ({1, 2, 3} === {1, 2}).should be_false
+    ({/o+/, "bar"} === {"fox", "bar"}).should be_true
+    ({1, 2} === nil).should be_false
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -345,18 +345,43 @@ module Crystal
     #     if temp.is_a?(Bar)
     #       1
     #     end
+    #
+    # We also take care to expand multiple conds
+    #
+    # From:
+    #
+    #     case {x, y}
+    #     when {1, 2}, {3, 4}
+    #       3
+    #     end
+    #
+    # To:
+    #
+    #     if (1 === x && y === 2) || (3 === x && 4 === y)
+    #       3
+    #     end
     def expand(node : Case)
       node_cond = node.cond
       if node_cond
-        case node_cond
-        when Var, InstanceVar
-          temp_var = node.cond
-        when Assign
-          temp_var = node_cond.target
-          assign = node_cond
+        if node_cond.is_a?(TupleLiteral)
+          conds = node_cond.elements
         else
-          temp_var = new_temp_var
-          assign = Assign.new(temp_var.clone, node_cond)
+          conds = [node_cond]
+        end
+
+        assigns = [] of ASTNode
+        temp_vars = conds.map do |cond|
+          case cond
+          when Var, InstanceVar
+            temp_var = cond
+          when Assign
+            temp_var = cond.target
+            assigns << cond
+          else
+            temp_var = new_temp_var
+            assigns << Assign.new(temp_var.clone, cond)
+          end
+          temp_var
         end
       end
 
@@ -365,7 +390,30 @@ module Crystal
       node.whens.each do |wh|
         final_comp = nil
         wh.conds.each do |cond|
-          comp = case_when_comparison(temp_var, cond).at(cond)
+          next if cond.is_a?(Underscore)
+
+          if node_cond.is_a?(TupleLiteral)
+            if cond.is_a?(TupleLiteral)
+              comp = nil
+              cond.elements.zip(temp_vars.not_nil!) do |lh, rh|
+                next if lh.is_a?(Underscore)
+
+                sub_comp = case_when_comparison(rh, lh).at(cond)
+                if comp
+                  comp = And.new(comp, sub_comp)
+                else
+                  comp = sub_comp
+                end
+              end
+            else
+              comp = case_when_comparison(TupleLiteral.new(temp_vars.not_nil!.clone), cond)
+            end
+          else
+            temp_var = temp_vars.try &.first
+            comp = case_when_comparison(temp_var, cond).at(cond)
+          end
+
+          next unless comp
 
           if final_comp
             final_comp = Or.new(final_comp, comp)
@@ -374,7 +422,9 @@ module Crystal
           end
         end
 
-        wh_if = If.new(final_comp.not_nil!, wh.body)
+        final_comp ||= BoolLiteral.new(true)
+
+        wh_if = If.new(final_comp, wh.body)
         if a_if
           a_if.else = wh_if
         else
@@ -388,8 +438,9 @@ module Crystal
       end
 
       final_if = final_if.not_nil!
-      final_exp = if assign
-                    Expressions.new([assign, final_if] of ASTNode)
+      final_exp = if assigns && !assigns.empty?
+                    assigns << final_if
+                    Expressions.new(assigns)
                   else
                     final_if
                   end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -957,14 +957,14 @@ module Crystal
     end
 
     def to_s_binary(node, op)
-      left_needs_parens = node.left.is_a?(Assign) || node.left.is_a?(Expressions)
+      left_needs_parens = need_parens(node.left)
       in_parenthesis(left_needs_parens, node.left)
 
       @str << " "
       @str << op
       @str << " "
 
-      right_needs_parens = node.right.is_a?(Assign) || node.right.is_a?(Expressions)
+      right_needs_parens = need_parens(node.right)
       in_parenthesis(right_needs_parens, node.right)
       false
     end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -203,6 +203,39 @@ struct Tuple
     true
   end
 
+  # Returns `true` if case equality holds for the elements in `self` and *other*.
+  #
+  # ```
+  # {1, 2} === {1, 2} # => true
+  # {1, 2} === {1, 3} # => false
+  # ```
+  #
+  # See `Object#===`
+  def ===(other : self)
+    {% for i in 0...@type.size %}
+      return false unless self[{{i}}] === other[{{i}}]
+    {% end %}
+    true
+  end
+
+  # Returns `true` if `self` and *other* have the same size and case equality holds
+  # for the elements in `self` and *other*.
+  #
+  # ```
+  # {1, 2} === {1, 2, 3}             # => false
+  # {/o+/, "bar"} === {"foo", "bar"} # => true
+  # ```
+  #
+  # See `Object#===`
+  def ===(other : Tuple)
+    return false unless size == other.size
+
+    size.times do |i|
+      return false unless self[i] === other[i]
+    end
+    true
+  end
+
   # Implements the comparison operator.
   #
   # Each object in each tuple is compared (using the <=> operator).


### PR DESCRIPTION
This is a follow up of #2239

Thanks to suggestions from @kostya and @ysbaddaden, I changed the proposed syntax from this:

```crystal
case exp1, exp2, ..., expN
when cond1, cond2, ..., condN
  body
end
```

To this:

```crystal
case {exp1, exp2, ..., expN}
when {cond1, cond2, ..., condN}
  body
end
```

As you can see, that syntax is already supported by the current compiler, so the compiler is just updated to rewrite the code in a few special cases. Specifically, if the case condition is a tuple literal, then:
- If a when condition is a tuple literal (starts with `{`), then the "implicit object" notation is allowed in its members (for example `{.even?, .odd?}`)
- If a when condition is a tuple literal, a compile error is issued if its size is not that of the condition (otherwise you are checking a case that will always be false)
- If a when condition is a tuple literal, the comparison made against the case tuple expression is done in a smarter way, similar to how a regular case is handled. For example, `case {x, y}; when {Int32, Float64}` is rewritten to `if x.is_a?(Int32) && y.is_a?(Float64)`, allowing type filters to work, something that doesn't work right now (this is the main motivation for adding this funcionality).
- If a when condition is **not** a tuple literal, the regular `===` is used. For this to work, I added `Tuple#===`, which was missing.

With this, we can finally solve real world problems like fizzbuzz in an elegant way:

```crystal
100.times do |i|
  case {i % 3, i % 5}
  when {0, 0}
    puts "FizzBuzz"
  when {0, _}
    puts "Fizz"
  when {_, 0}
    puts "Buzz"
  else
    puts i
  end
end
```

Of, if you want `{0, 0}` as a constant, you can do it too:

```crystal
ZEROS = {0, 0}

100.times do |i|
  case {i % 3, i % 5}
  when ZEROS
    puts "FizzBuzz"
  when {0, _}
    puts "Fizz"
  when {_, 0}
    puts "Buzz"
  else
    puts i
  end
end
```

Another advantage of this syntax is that it allows multiple when conditions, for example:

```crystal
case {x, y}
when {0, 0}, {1, 1}
  # ...
end
```