### PR TITLE
Add FileUtils#cp

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -11,4 +11,44 @@ describe "FileUtils" do
       FileUtils.cmp("#{__DIR__}/data/test_file.txt", "#{__DIR__}/data/test_file.ini").should be_false
     end
   end
+
+  describe "cp" do
+    it "copies a file" do
+      src_path = "#{__DIR__}/data/test_file.txt"
+      out_path = "#{__DIR__}/data/test_file_cp.txt"
+      begin
+        FileUtils.cp(src_path, out_path)
+        File.exists?(out_path).should be_true
+        FileUtils.cmp(src_path, out_path).should be_true
+      ensure
+        File.delete(out_path) if File.exists?(out_path)
+      end
+    end
+
+    it "raises an error if the directory doesn't exists" do
+      expect_raises(ArgumentError, "no such directory : not_existing_dir") do
+        FileUtils.cp({"#{__DIR__}/data/test_file.text"}, "not_existing_dir")
+      end
+    end
+
+    it "copies multiple files" do
+      src_name1 = "test_file.txt"
+      src_name2 = "test_file.ini"
+      src_path = "#{__DIR__}/data/"
+      out_path = "#{__DIR__}/data/cps_path/"
+
+      begin
+        Dir.mkdir(out_path) rescue nil
+        FileUtils.cp({src_path + src_name1, src_path + src_name2}, out_path)
+        File.exists?(out_path + src_name1).should be_true
+        File.exists?(out_path + src_name2).should be_true
+        FileUtils.cmp(src_path + src_name1, out_path + src_name1).should be_true
+        FileUtils.cmp(src_path + src_name2, out_path + src_name2).should be_true
+      ensure
+        File.delete(out_path + src_name1) if File.exists?(out_path + src_name1)
+        File.delete(out_path + src_name2) if File.exists?(out_path + src_name2)
+        Dir.rmdir(out_path) if Dir.exists?(out_path)
+      end
+    end
+  end
 end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -24,4 +24,31 @@ module FileUtils
       return true if read1 == 0
     end
   end
+
+  # Copies the file *src_path* to the file or directory *dest*.
+  # If *dest* is a directory, a file with the same basename as *src_path* is created in *dest*
+  # Permission bits are copied too.
+  # ```
+  # FileUtils.cp("file_utils.cr", "file_utils_copy.cr")
+  # ```
+  def cp(src_path : String, dest : String)
+    File.open(src_path) do |s|
+      dest += File::SEPARATOR + File.basename(src_path) if Dir.exists?(dest)
+      File.open(dest, "wb", s.stat.mode) do |d|
+        IO.copy(s, d)
+      end
+    end
+  end
+
+  # Copies a list of files *src* to *dest*.
+  # *dest* must be an existing directory.
+  # ```
+  # FileUtils.cp({"cgi.cr", "complex.cr", "date.cr"}, "files")
+  # ```
+  def cp(srcs : Enumerable(String), dest : String)
+    raise ArgumentError.new("no such directory : #{dest}") unless Dir.exists?(dest)
+    srcs.each do |src|
+      cp(src, dest)
+    end
+  end
 end


### PR DESCRIPTION
Adds a method to copy a file or a list of files in the class FileUtils.
And the associated tests in spec/std/file_utils_spec.cr


:dolphin: