### PR TITLE
Syntax: allow parentheses for tuple literals. Fixes #2261

### DIFF
--- a/spec/compiler/crystal/types_spec.cr
+++ b/spec/compiler/crystal/types_spec.cr
@@ -62,7 +62,11 @@ describe "types to_s of" do
       end
 
       it "in tuples" do
-        assert_type_to_s "{String, Int32 | String}" { tuple_of [string, union_of(string, int32)] }
+        assert_type_to_s "(String, Int32 | String)" { tuple_of [string, union_of(string, int32)] }
+      end
+
+      it "in tuples with 1 element" do
+        assert_type_to_s "(String,)" { tuple_of [string] of Type }
       end
     end
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -71,10 +71,16 @@ describe Crystal::Formatter do
   assert_format "Set { 1 , 2 }", "Set{1, 2}"
   assert_format "[\n1,\n\n2]", "[\n  1,\n\n  2,\n]"
 
-  assert_format "{1, 2, 3}"
-  assert_format "{ {1, 2, 3} }"
-  assert_format "{ {1 => 2} }"
-  assert_format "{ {1, 2, 3} => 4 }"
+  assert_format "{1, 2, 3}", "(1, 2, 3)"
+  assert_format "(1, 2, 3)"
+  assert_format "()"
+  assert_format "(1,)"
+  assert_format "(1,2,)", "(1, 2)"
+
+  assert_format "((1, 2, 3))"
+  assert_format "({1 => 2})"
+  assert_format "{(1, 2, 3) => 4}"
+  assert_format "{ {1 => 2} => 3 }"
 
   assert_format "{  } of  A   =>   B", "{} of A => B"
   assert_format "{ 1   =>   2 }", "{1 => 2}"
@@ -241,7 +247,9 @@ describe Crystal::Formatter do
     assert_format "#{keyword}  1", "#{keyword} 1"
     assert_format "#{keyword}( 1 , 2 )", "#{keyword}(1, 2)"
     assert_format "#{keyword}  1 ,  2", "#{keyword} 1, 2"
-    assert_format "#{keyword} { 1 ,  2 }", "#{keyword} {1, 2}" unless keyword == "yield"
+    assert_format "#{keyword} ( 1 ,  2 )", "#{keyword} (1, 2)" unless keyword == "yield"
+    assert_format "#{keyword} (1), 2"
+    assert_format "#{keyword} (1).foo, 2"
   end
 
   assert_format "yield 1\n2", "yield 1\n2"
@@ -387,7 +395,9 @@ describe Crystal::Formatter do
   assert_format "x  :   (A | B)", "x : (A | B)"
   assert_format "x  :   (A -> B)", "x : (A -> B)"
   assert_format "x  :   (A -> B)?", "x : (A -> B)?"
-  assert_format "x  :   {A, B}", "x : {A, B}"
+  assert_format "x  :   {A, B}", "x : (A, B)"
+  assert_format "x  :   ( A, B )", "x : (A, B)"
+  assert_format "x  :   ( A,  )", "x : (A,)"
   assert_format "class Foo\n@x  : Int32\nend", "class Foo\n  @x : Int32\nend"
   assert_format "class Foo\n@x  :  Int32\nend", "class Foo\n  @x : Int32\nend"
   assert_format "class Foo\nx = 1\nend", "class Foo\n  x = 1\nend"
@@ -805,4 +815,6 @@ describe Crystal::Formatter do
   assert_format "foo.[1]"
 
   assert_format "@foo : Int32 # comment\n\ndef foo\nend"
+
+  assert_format "(1,\n  2).foo"
 end

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -50,7 +50,7 @@ describe "MacroExpander" do
   end
 
   it "expands macro with tuple" do
-    assert_macro "", %({{{1, 2, 3}}}), [] of ASTNode, %({1, 2, 3})
+    assert_macro "", %({{{1, 2, 3}}}), [] of ASTNode, %((1, 2, 3))
   end
 
   it "expands macro with range" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -551,7 +551,7 @@ describe "macro methods" do
     end
 
     it "executes to_a" do
-      assert_macro "", %({{{a: 1, b: 3}.to_a}}), [] of ASTNode, "[{:a, 1}, {:b, 3}]"
+      assert_macro "", %({{{a: 1, b: 3}.to_a}}), [] of ASTNode, "[(:a, 1), (:b, 3)]"
     end
   end
 

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -78,7 +78,7 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with multiple expressions and non-tuple" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === ({x, y})\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === ((x, y))\n  4\nend"
   end
 
   it "normalizes case with single expressions with underscore" do

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -67,7 +67,7 @@ describe "Normalize: def" do
   it "expands with splat with one arg after and just one argument (#1340)" do
     a_def = parse("def foo(*args, x); args; end") as Def
     actual = a_def.expand_default_arguments(Program.new, 1)
-    actual.to_s.should eq("def foo(x)\n  args = {}\n  args\nend")
+    actual.to_s.should eq("def foo(x)\n  args = ()\n  args\nend")
   end
 
   it "expands with splat with one arg before and after" do
@@ -80,13 +80,13 @@ describe "Normalize: def" do
   it "expands with splat and zero" do
     a_def = parse("def foo(*args); args; end") as Def
     actual = a_def.expand_default_arguments(Program.new, 0)
-    actual.to_s.should eq("def foo\n  args = {}\n  args\nend")
+    actual.to_s.should eq("def foo\n  args = ()\n  args\nend")
   end
 
   it "expands with splat and default argument" do
     a_def = parse("def foo(x = 1, *args); args; end") as Def
     actual = a_def.expand_default_arguments(Program.new, 0)
-    actual.to_s.should eq("def foo\n  x = 1\n  args = {}\n  args\nend")
+    actual.to_s.should eq("def foo\n  x = 1\n  args = ()\n  args\nend")
   end
 
   it "expands with named argument" do

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -41,4 +41,6 @@ describe "ASTNode#to_s" do
   expect_to_s %[(1 || 1.1) as Int32]
   expect_to_s %[1 & 2 & (3 | 4)], %[(1 & 2) & (3 | 4)]
   expect_to_s %[(1 & 2) & (3 | 4)]
+  expect_to_s "(1, 2, 3)"
+  expect_to_s "(1,)"
 end

--- a/spec/compiler/type_inference/splat_spec.cr
+++ b/spec/compiler/type_inference/splat_spec.cr
@@ -44,7 +44,7 @@ describe "Type inference: splat" do
       a = {1} || {1, 2}
       foo *a
       ),
-      "splatting a union ({Int32, Int32} | {Int32}) is not yet supported"
+      "splatting a union ((Int32, Int32) | (Int32,)) is not yet supported"
   end
 
   it "errors if splatting non-tuple type" do

--- a/spec/compiler/type_inference/tuple_spec.cr
+++ b/spec/compiler/type_inference/tuple_spec.cr
@@ -31,7 +31,7 @@ describe "Type inference: tuples" do
 
   it "gives error when indexing out of range" do
     assert_error "{1, 'a'}[2]",
-      "index out of bounds for tuple {Int32, Char}"
+      "index out of bounds for tuple (Int32, Char)"
   end
 
   it "can name a tuple type" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -110,7 +110,8 @@ describe "Tuple" do
   end
 
   it "does to_s" do
-    {1, 2, 3}.to_s.should eq("{1, 2, 3}")
+    {1, 2, 3}.to_s.should eq("(1, 2, 3)")
+    {1}.to_s.should eq("(1,)")
   end
 
   it "does each" do

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -873,12 +873,13 @@ module Crystal
     end
 
     def visit(node : TupleLiteral)
-      @str << "{"
+      @str << "("
       node.elements.each_with_index do |exp, i|
         @str << ", " if i > 0
         exp.accept self
       end
-      @str << "}"
+      @str << "," if node.elements.size == 1
+      @str << ")"
       false
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -546,13 +546,22 @@ module Crystal
     end
 
     def visit(node : TupleLiteral)
-      format_literal_elements node.elements, :"{", :"}"
+      format_literal_elements node.elements, :"{", :"}", tuple: node
       false
     end
 
-    def format_literal_elements(elements, prefix, suffix)
+    def format_literal_elements(elements, prefix, suffix, tuple = nil)
       slash_is_regex!
-      write_token prefix
+
+      if tuple
+        unless @token.type == :"{" || @token.type == :"("
+          raise "Bug: expected `(`, `{`"
+        end
+        write "("
+        next_token
+      else
+        write_token prefix
+      end
       has_newlines = false
       wrote_newline = false
       write_space_at_end = false
@@ -583,7 +592,7 @@ module Crystal
           current_element = current_element.key
         end
 
-        if prefix == :"{" && i == 0 && !wrote_newline && (current_element.is_a?(TupleLiteral) || current_element.is_a?(HashLiteral))
+        if prefix == :"{" && i == 0 && !wrote_newline && current_element.is_a?(HashLiteral)
           write " "
           write_space_at_end = true
         end
@@ -621,7 +630,7 @@ module Crystal
         end
       end
 
-      finish_list suffix, has_newlines, found_comment, found_first_newline, write_space_at_end
+      finish_list suffix, has_newlines, found_comment, found_first_newline, write_space_at_end, tuple: tuple
     end
 
     def visit(node : HashLiteral)
@@ -687,16 +696,26 @@ module Crystal
       end
     end
 
-    def finish_list(suffix, has_newlines, found_comment, found_first_newline, write_space_at_end)
-      if @token.type == suffix && !found_first_newline
+    def finish_list(suffix, has_newlines, found_comment, found_first_newline, write_space_at_end, tuple = nil)
+      if (@token.type == suffix || (tuple && @token.type == :")")) && !found_first_newline
         if @wrote_newline
           write_indent
         else
           write " " if write_space_at_end
         end
+        if tuple && tuple.elements.size == 1
+          write ","
+        end
       else
         found_comment ||= skip_space_or_newline
-        check suffix
+
+        if tuple
+          unless @token.type == :"}" || @token.type == :")"
+            raise "Bug: expected `)`, `}`"
+          end
+        else
+          check suffix
+        end
 
         if has_newlines
           unless found_comment
@@ -705,12 +724,27 @@ module Crystal
           end
           write_indent
         elsif write_space_at_end
+          if tuple && tuple.elements.size == 1
+            write ","
+          end
           write " "
+        else
+          if tuple && tuple.elements.size == 1
+            write ","
+          end
         end
         skip_space_or_newline
       end
 
-      write_token suffix
+      if tuple
+        unless @token.type == :"}" || @token.type == :")"
+          raise "Bug: expected `)`, `}`"
+        end
+        write ")"
+        next_token
+      else
+        write_token suffix
+      end
     end
 
     def check_hash_info(hash, key, start_line, start_column, middle_column)
@@ -811,7 +845,12 @@ module Crystal
 
       # Check if it's {A, B} instead of Tuple(A, B)
       if first_name == "Tuple" && @token.value != "Tuple"
-        write_token :"{"
+        if @token.type == :"{" || @token.type == :"("
+          write "("
+          next_token
+        else
+          raise "Bug: expected `(` or `{`"
+        end
         skip_space_or_newline
         node.type_vars.each_with_index do |type_var, i|
           accept type_var
@@ -821,7 +860,15 @@ module Crystal
             next_token_skip_space_or_newline
           end
         end
-        write_token :"}"
+        if node.type_vars.size == 1
+          write ","
+        end
+        if @token.type == :"}" || @token.type == :")"
+          write ")"
+          next_token
+        else
+          raise "Bug: expected `)` or `}`"
+        end
         return false
       end
 
@@ -2643,7 +2690,10 @@ module Crystal
         write " " unless has_parentheses
         skip_space
 
-        if exp.is_a?(TupleLiteral) && @token.type != :"{"
+        if @token.type == :"(" && exp.is_a?(TupleLiteral) && (first = exp.elements.first?) && starts_with_parens?(first)
+          format_args(exp.elements, has_parentheses)
+          skip_space if has_parentheses
+        elsif exp.is_a?(TupleLiteral) && (@token.type != :"{" && @token.type != :"(")
           format_args(exp.elements, has_parentheses)
           skip_space if has_parentheses
         else
@@ -2655,6 +2705,19 @@ module Crystal
       write_token :")" if has_parentheses
 
       false
+    end
+
+    def starts_with_parens?(node)
+      case node
+      when TupleLiteral
+        true
+      when Expressions
+        node.keyword == :"("
+      when Call
+        starts_with_parens?(node.obj)
+      else
+        false
+      end
     end
 
     def visit(node : Yield)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1864,12 +1864,13 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens = false : Bool, generic_args = true : Bool)
-      io << "{"
+      io << "("
       @tuple_types.each_with_index do |tuple_type, i|
         io << ", " if i > 0
         tuple_type.to_s_with_options(io, skip_union_parens: true)
       end
-      io << "}"
+      io << "," if @tuple_types.size == 1
+      io << ")"
     end
 
     def type_desc

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -343,9 +343,10 @@ struct Tuple
   # tuple.to_s # => "{1, \"hello\"}"
   # ```
   def to_s(io)
-    io << "{"
+    io << "("
     join ", ", io, &.inspect(io)
-    io << "}"
+    io << "," if size == 1
+    io << ")"
   end
 
   # Returns a new tuple where elements are mapped by the given block.


### PR DESCRIPTION
I did this just to see what could possibly break with this change. It's not sure that we'll eventually merge this.

One thing that I found is that we currently support this:

```crystal
alias Callback = (Int32, Float64) -> String
```

This means "A function that accepts two arguments, one Int32 and one Float64, and returns a String". This is also the same as this:

```crystal
alias Callback = Int32, Float64 -> String
```

If we make `(A, B)` mean a tuple type, the above meaning will now mean "A function that accepts a tuple of (Int32, Float64) and returns a String", thus breaking existing code.

I chose to keep the current meaning of `(A, B) -> C`. If you want a tuple as an argument you have to do `((A, B)) -> C`. But this shouldn't be common at all (besides, the instances I found of that was in C bindings, and there you can't use a tuple).

Some sample code with the new syntax:

```crystal
tuples = [1, 2, 3].map { |x| (x, x * 2) }
p tuples # => [(1, 2), (2, 4), (3, 6)]
```

```crystal
a = [] of (Int32, Int32)
a << (1, 2)
p a # => [(1, 2)]
```

```crystal
# FizzBuzz
100.times do |i|
  case (i % 3, i % 5)
  when (0, 0)
    puts "FizzBuzz"
  when (0, _)
    puts "Fizz"
  when (_, 0)
    puts "Buzz"
  else
    puts i
  end
end
```

```crystal
a = rand < 0.5 ? 1 : "foo"
b = rand < 0.5 ? 1 : "foo"

case (a, b)
when (Int32, Int32)
  puts "Both ints: #{a + 1}, #{b + 1}"
when (String, String)
  puts "Both strings: #{a.upcase}, #{b.upcase}"
else
  puts "Meh..."
end
```

With this change we also have a syntax for the empty tuple: `()`

Also, if you previously wanted to have a hash literal with tuples as keys, if you wrote:

```crystal
{{1, 2} => 3}
```

that would be a syntax error, because `{{` means a macro expression. You'd have to write:

```crystal
{ {1, 2} => 3}
```

Now it's simply:

```crystal
{(1, 2) => 3}
```

Not a huge gain, but less confusion.

This PR keeps the old `{...}` syntax. The formatter is changed to rewrite curly braces to parentheses, so the upgrade should be really easy. We can remove the `{...}` syntax in a later release.

Final comment: I personally feel this new syntax is more lightweight. I also feel parentheses are usually used for grouping stuff, and a tuple groups stuff, so it feels more right to me. And then, if we ever have named tuples, `(x: 1, y: 2)` would look better if tuples use parens.