### PR TITLE
Add BitArray#to_slice to return a UInt8 slice useful for

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -92,4 +92,37 @@ describe "BitArray" do
     ary = BitArray.new(64, true)
     ary.size.times { |i| ary[i].should be_true }
   end
+
+  it "reads bits from slice" do
+    ary = BitArray.new(43) # 5 bytes 3 bits
+    # 11010000_00000000_00001011_00000000_00000000_101xxxxx
+    ary[0] = true
+    ary[1] = true
+    ary[3] = true
+    ary[20] = true
+    ary[22] = true
+    ary[23] = true
+    ary[40] = true
+    ary[42] = true
+    slice = ary.to_slice
+
+    slice.size.should eq(6)
+    slice[0].should eq(0b00001011_u8)
+    slice[1].should eq(0b00000000_u8)
+    slice[2].should eq(0b11010000_u8)
+    slice[3].should eq(0b00000000_u8)
+    slice[4].should eq(0b00000000_u8)
+    slice[5].should eq(0b00000101_u8)
+  end
+
+  it "read bits written from slice" do
+    ary = BitArray.new(43) # 5 bytes 3 bits
+    slice = ary.to_slice
+    slice[0] = 0b10101010_u8
+    slice[1] = 0b01010101_u8
+    slice[5] = 0b11111101_u8
+    ary.each_with_index do |e, i|
+      e.should eq({1, 3, 5, 7, 8, 10, 12, 14, 40, 42}.includes?(i))
+    end
+  end
 end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -109,6 +109,13 @@ struct BitArray
     io << "]"
   end
 
+  # Returns a Slice(UInt8) able to read and write bytes from a buffer.
+  # The slice will be long enough to hold all the bits groups in bytes despite the `UInt32` internal representation.
+  # It's useful for reading and writing a bit array from a byte buffer directly.
+  def to_slice : Slice(UInt8)
+    Slice.new(@bits as Pointer(UInt8), (@size / 8.0).ceil.to_i)
+  end
+
   private def bit_index_and_sub_index(index)
     index += @size if index < 0
     raise IndexError.new if index >= @size || index < 0


### PR DESCRIPTION
At least in mysql protocol I needed the ability to read/write a bit array to a `IO`. In this scenario snapping to a byte boundary instead of the `UInt32` internal representation.