### PR TITLE
Add Char methods and specs, include Comparable.

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -21,10 +21,39 @@ describe "Char" do
     assert { 'ぃ'.pred.should eq('あ') }
   end
 
+  describe "uppercase?" do
+    assert { 'a'.uppercase?.should be_false }
+    assert { 'A'.uppercase?.should be_true }
+    assert { '1'.uppercase?.should be_false }
+    assert { ' '.uppercase?.should be_false }
+  end
+
+  describe "lowercase?" do
+    assert { 'a'.lowercase?.should be_true }
+    assert { 'A'.lowercase?.should be_false }
+    assert { '1'.lowercase?.should be_false }
+    assert { ' '.lowercase?.should be_false }
+  end
+
+  describe "alpha?" do
+    assert { 'a'.alpha?.should be_true }
+    assert { 'A'.alpha?.should be_true }
+    assert { '1'.alpha?.should be_false }
+    assert { ' '.alpha?.should be_false }
+  end
+
+  describe "alphanumeric?" do
+    assert { 'a'.alphanumeric?.should be_true }
+    assert { 'A'.alphanumeric?.should be_true }
+    assert { '1'.alphanumeric?.should be_true }
+    assert { ' '.alphanumeric?.should be_false }
+  end
+
   describe "whitespace?" do
     [' ', '\t', '\n', '\v', '\f', '\r'].each do |char|
       assert { char.whitespace?.should be_true }
     end
+    assert { 'A'.whitespace?.should be_false }
   end
 
   it "dumps" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -1,3 +1,5 @@
+require "comparable"
+
 # A Char represents a [Unicode](http://en.wikipedia.org/wiki/Unicode) [code point](http://en.wikipedia.org/wiki/Code_point).
 # It occupies 32 bits.
 #
@@ -45,6 +47,8 @@
 # '\u{41}' # == 'A'
 # ```
 struct Char
+  include Comparable(Char)
+
   # The character representing the end of a C string.
   ZERO = '\0'
 
@@ -84,8 +88,6 @@ struct Char
   # ```
   # 'a' <=> 'c' # => -2
   # ```
-  #
-  # See `Object#<=>`
   def <=>(other : Char)
     self - other
   end
@@ -97,7 +99,29 @@ struct Char
   # 'z'.digit? # => false
   # ```
   def digit?
-    '0' <= self && self <= '9'
+    '0' <= self <= '9'
+  end
+
+  # Returns true if this char is a lowercase ASCII letter.
+  #
+  # ```
+  # 'c'.lowercase? # => true
+  # 'G'.lowercase? # => false
+  # '.'.lowercase? # => false
+  # ```
+  def lowercase?
+    'a' <= self <= 'z'
+  end
+
+  # Returns true if this char is an uppercase ASCII letter.
+  #
+  # ```
+  # 'H'.uppercase? # => true
+  # 'c'.uppercase? # => false
+  # '.'.uppercase? # => false
+  # ```
+  def uppercase?
+    'A' <= self <= 'Z'
   end
 
   # Returns true if this char is an ASCII letter ('a' to 'z', 'A' to 'Z').
@@ -107,8 +131,7 @@ struct Char
   # '8'.alpha? # => false
   # ```
   def alpha?
-    ('a' <= self && self <= 'z') ||
-      ('A' <= self && self <= 'Z')
+    lowercase? || uppercase?
   end
 
   # Returns true if this char is an ASCII letter or digit ('0' to '9', 'a' to 'z', 'A' to 'Z').
@@ -220,7 +243,7 @@ struct Char
   # '.'.downcase # => '.'
   # ```
   def downcase
-    if 'A' <= self && self <= 'Z'
+    if uppercase?
       (self.ord + 32).chr
     else
       self
@@ -235,7 +258,7 @@ struct Char
   # '.'.upcase # => '.'
   # ```
   def upcase
-    if 'a' <= self && self <= 'z'
+    if lowercase?
       (self.ord - 32).chr
     else
       self
@@ -383,7 +406,7 @@ struct Char
   # 'c'.to_i { 10 } # => 10
   # ```
   def to_i
-    if '0' <= self <= '9'
+    if digit?
       self - '0'
     else
       yield

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -969,14 +969,14 @@ module Crystal
 
         scan_ident(start)
       else
-        if 'A' <= current_char <= 'Z'
+        if current_char.uppercase?
           start = current_pos
           while ident_part?(next_char)
             # Nothing to do
           end
           @token.type = :CONST
           @token.value = string_range(start)
-        elsif ('a' <= current_char <= 'z') || current_char == '_' || current_char.ord > 0x9F
+        elsif current_char.lowercase? || current_char == '_' || current_char.ord > 0x9F
           next_char
           scan_ident(start)
         else

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4252,7 +4252,7 @@ module Crystal
         next_token_skip_space_or_newline
         type = parse_single_type
 
-        if 'A' <= name[0] <= 'Z'
+        if name[0].uppercase?
           raise "external variables must start with lowercase, use for example `$#{name.underscore} = #{name} : #{type}`", location
         end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -461,7 +461,7 @@ module Crystal
     end
 
     def is_alpha(string)
-      'a' <= string[0].downcase <= 'z'
+      string[0].alpha?
     end
 
     def visit(node : Assign)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1643,7 +1643,7 @@ module Crystal
       end
 
       # This is the case of an enum member
-      if 'A' <= node.name[0] <= 'Z' && @token.type == :","
+      if node.name[0].uppercase? && @token.type == :","
         write ", "
         next_token_skip_space
         @exp_needs_indent = @token.type == :NEWLINE

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -38,8 +38,8 @@ struct HTTP::Headers
     private def normalize_byte(byte)
       char = byte.chr
 
-      return byte if 'a' <= char <= 'z' || char == '-' # Optimize the common case
-      return byte + 32 if 'A' <= char <= 'Z'
+      return byte if char.lowercase? || char == '-' # Optimize the common case
+      return byte + 32 if char.uppercase?
       return '-'.ord if char == '_'
 
       byte

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -63,7 +63,7 @@ struct Symbol
     else
       string.each_char do |char|
         case char
-        when '0'..'9', 'A'..'Z', 'a'..'z', '_'
+        when .alphanumeric?, '_'
           # Nothing
         else
           return true


### PR DESCRIPTION
~~There is a strange compiler side-effect bug with ```include Comparable(Char)```, see https://travis-ci.org/MaloJaffre/crystal/jobs/114014085 but I can compile and pass char specs.~~