### PR TITLE
Fix typo in Hash#zip doc

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -622,7 +622,8 @@ class Hash(K, V)
   # Zips two arrays into a `Hash`, taking keys from *ary1* and values from *ary2*.
   #
   # ```
-  # Hash.zip(["foo", "bar"], ["baz", "qux"]) # => {"foo" => "baz", "baz" => "quz"}
+  # Hash.zip(["key1", "key2", "key3"], ["value1", "value2", "value3"])
+  # # => {"key1" => "value1", "key2" => "value2", "key3" => "value3"}
   # ```
   def self.zip(ary1 : Array(K), ary2 : Array(V))
     hash = {} of K => V


### PR DESCRIPTION
Fix small typo in the doc for `Hash#zip`.
```
icr(0.12.0) > Hash.zip(["foo", "bar"], ["baz", "qux"])
 => {"foo" => "baz", "bar" => "qux"}
```
`"baz" => "quz"` is not the same `"bar" => "qux"`, as written in the doc.
However for this example I guess `abc` and `xyz` are better, because they have stronger association with each other:)