### PR TITLE
Replace obsolote Regexp with Regex

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -116,13 +116,13 @@ describe "Regex" do
       Regex.union(["+", "-"]).should eq /\+|\-/
     end
 
-    it "accepts a single Array(String | Regexp) argument" do
+    it "accepts a single Array(String | Regex) argument" do
       Regex.union(["skiing", "sledding"]).should eq /skiing|sledding/
       Regex.union([/dogs/, /cats/i]).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
-    it "accepts a single Tuple(String | Regexp) argument" do
+    it "accepts a single Tuple(String | Regex) argument" do
       Regex.union({"skiing", "sledding"}).should eq /skiing|sledding/
       Regex.union({/dogs/, /cats/i}).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -218,10 +218,10 @@ class Regex
   # Creates a new Regex out of the given source String.
   #
   # ```
-  # Regexp.new("^a-z+:\s+\w+")                     # => /^a-z+:\s+\w+/
-  # Regexp.new("cat", Regex::Options::IGNORE_CASE) # => /cat/i
+  # Regex.new("^a-z+:\s+\w+")                     # => /^a-z+:\s+\w+/
+  # Regex.new("cat", Regex::Options::IGNORE_CASE) # => /cat/i
   # options = Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
-  # Regexp.new("dog", options) # => /dog/ix
+  # Regex.new("dog", options) # => /dog/ix
   # ```
   def initialize(source, @options : Options = Options::None)
     # PCRE's pattern must have their null characters escaped


### PR DESCRIPTION
In code examples Regexp is used which misleaded me. I changed it into `Regex` which is correct. Simply ack'd the repository and found misleading `Regexp` strings and converted to `Regex`.