### PR TITLE
fix OptionParser to distinguish forward match options

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -329,4 +329,30 @@ describe "OptionParser" do
       args.should eq(%w(-))
     end
   end
+
+  describe "forward-match" do
+    it "distinguishes between '--lamb VALUE' and '--lambda VALUE'" do
+      args = %w(--lamb value1 --lambda value2)
+      value1 = nil
+      value2 = nil
+      OptionParser.parse(args) do |opts|
+        opts.on("--lamb VALUE", "") { |v| value1 = v }
+        opts.on("--lambda VALUE", "") { |v| value2 = v }
+      end
+      value1.should eq("value1")
+      value2.should eq("value2")
+    end
+
+    it "distinguishes between '--lamb=VALUE' and '--lambda=VALUE'" do
+      args = %w(--lamb=value1 --lambda=value2)
+      value1 = nil
+      value2 = nil
+      OptionParser.parse(args) do |opts|
+        opts.on("--lamb=VALUE", "") { |v| value1 = v }
+        opts.on("--lambda=VALUE", "") { |v| value2 = v }
+      end
+      value1.should eq("value1")
+      value2.should eq("value2")
+    end
+  end
 end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -208,7 +208,7 @@ class OptionParser
     end
 
     private def process_double_flag(flag, block, raise_if_missing = false)
-      while index = args_index { |arg| arg.starts_with?(flag) }
+      while index = args_index { |arg| arg.split("=")[0] == flag }
         arg = @args[index]
         if arg.size == flag.size
           delete_arg_at_index(index)


### PR DESCRIPTION
This code causes an infinite loop:

```crystal
OptionParser.parse("--lambda", "value") do |opts|
  opts.on("--lamb VALUE", "") { ... }
  opts.on("--lambda VALUE", "") { ... }
end
```

Because `OptionParser::ParserTask#process_double_flag` interprets multiple 'forward-match' options wrongly.