### PR TITLE
Make it possible to use all types of Int* with JSON/YAML mappings

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -93,6 +93,13 @@ class JsonWithDefaults
   })
 end
 
+class JSONWithSmallIntegers
+  JSON.mapping({
+    foo: Int16,
+    bar: Int8
+  })
+end
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -206,6 +213,16 @@ describe "JSON mapping" do
   it "parses json array as set" do
     json = JsonWithSet.from_json(%({"set": ["a", "a", "b"]}))
     json.set.should eq(Set(String){"a", "b"})
+  end
+
+  it "allows small types of integer" do
+    json = JSONWithSmallIntegers.from_json(%({"foo": 23, "bar": 7}))
+
+    json.foo.should eq(23)
+    typeof(json.foo).should eq(Int16)
+
+    json.bar.should eq(7)
+    typeof(json.bar).should eq(Int8)
   end
 
   describe "parses json with defaults" do

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -62,6 +62,13 @@ class YAMLWithAny
   end
 end
 
+class YAMLWithSmallIntegers
+  YAML.mapping({
+    foo: Int16,
+    bar: Int8
+  })
+end
+
 describe "YAML mapping" do
   it "parses person" do
     person = YAMLPerson.from_yaml("---\nname: John\nage: 30\n")
@@ -127,6 +134,16 @@ describe "YAML mapping" do
     yaml.key.should eq("foo")
     yaml.value.should eq(1)
     yaml.pull.should eq(2)
+  end
+
+  it "allows small types of integer" do
+    yaml = YAMLWithSmallIntegers.from_yaml(%({"foo": 21, "bar": 7}))
+
+    yaml.foo.should eq(21)
+    typeof(yaml.foo).should eq(Int16)
+
+    yaml.bar.should eq(7)
+    typeof(yaml.bar).should eq(Int8)
   end
 
   describe "parses YAML with defaults" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -41,6 +41,14 @@ def Bool.new(pull : JSON::PullParser)
   pull.read_bool
 end
 
+def Int8.new(pull : JSON::PullParser)
+  pull.read_int.to_i8
+end
+
+def Int16.new(pull : JSON::PullParser)
+  pull.read_int.to_i16
+end
+
 def Int32.new(pull : JSON::PullParser)
   pull.read_int.to_i
 end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -41,21 +41,11 @@ def Bool.new(pull : JSON::PullParser)
   pull.read_bool
 end
 
-def Int8.new(pull : JSON::PullParser)
-  pull.read_int.to_i8
-end
-
-def Int16.new(pull : JSON::PullParser)
-  pull.read_int.to_i16
-end
-
-def Int32.new(pull : JSON::PullParser)
-  pull.read_int.to_i
-end
-
-def Int64.new(pull : JSON::PullParser)
-  pull.read_int.to_i64
-end
+{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+  def {{type.id}}.new(pull : JSON::PullParser)
+    {{type.id}}.new(pull.read_int)
+  end
+{% end %}
 
 def Float32.new(pull : JSON::PullParser)
   case pull.kind

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -27,6 +27,14 @@ def Bool.new(pull : YAML::PullParser)
   pull.read_scalar == "true"
 end
 
+def Int8.new(pull : YAML::PullParser)
+  pull.read_scalar.to_i8
+end
+
+def Int16.new(pull : YAML::PullParser)
+  pull.read_scalar.to_i16
+end
+
 def Int32.new(pull : YAML::PullParser)
   pull.read_scalar.to_i
 end

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -27,21 +27,12 @@ def Bool.new(pull : YAML::PullParser)
   pull.read_scalar == "true"
 end
 
-def Int8.new(pull : YAML::PullParser)
-  pull.read_scalar.to_i8
-end
 
-def Int16.new(pull : YAML::PullParser)
-  pull.read_scalar.to_i16
-end
-
-def Int32.new(pull : YAML::PullParser)
-  pull.read_scalar.to_i
-end
-
-def Int64.new(pull : YAML::PullParser)
-  pull.read_scalar.to_i64
-end
+{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+  def {{type.id}}.new(pull : YAML::PullParser)
+    {{type.id}}.new(pull.read_scalar)
+  end
+{% end %}
 
 def String.new(pull : YAML::PullParser)
   pull.read_scalar


### PR DESCRIPTION

Add Int8 and In16 initializer definitions in order to make possible to
use instead of Int32 or Int64 whenever necessary

Solve: #2301