### PR TITLE
Fix: LibC.mmap and off_t definitions

### DIFF
--- a/src/fiber/fiber.cr
+++ b/src/fiber/fiber.cr
@@ -75,7 +75,7 @@ class Fiber
     @@stack_pool.pop? || LibC.mmap(nil, Fiber::STACK_SIZE,
       LibC::PROT_READ | LibC::PROT_WRITE,
       LibC::MAP_PRIVATE | LibC::MAP_ANON,
-      -1, LibC::SSizeT.new(0)).tap do |pointer|
+      -1, 0).tap do |pointer|
       raise Errno.new("Cannot allocate new fiber stack") if pointer == LibC::MAP_FAILED
       ifdef linux
         LibC.madvise(pointer, Fiber::STACK_SIZE, LibC::MADV_NOHUGEPAGE)

--- a/src/libc.cr
+++ b/src/libc.cr
@@ -23,7 +23,12 @@ lib LibC
   alias PtrDiffT = SSizeT
   alias TimeT = SSizeT
   alias PidT = Int
-  alias OffT = SSizeT
+
+  ifdef musl
+    alias OffT = Int64
+  else
+    alias OffT = SSizeT
+  end
 
   ifdef darwin
     alias ModeT = UInt16
@@ -67,7 +72,7 @@ lib LibC
 
   MAP_FAILED = Pointer(Void).new(SizeT.new(-1))
 
-  fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : SSizeT) : Void*
+  fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : OffT) : Void*
   fun munmap(addr : Void*, len : SizeT)
   fun madvise(addr : Void*, len : SizeT, advise : Int) : Int
   fun mprotect(addr : Void*, len : SizeT, prot : Int) : Int


### PR DESCRIPTION
The last argument to `mmap` is an `off_t` not a `ssize_t`. This caused a failure on musl-libc where `off_t` is a 64bits integer on all arch —whereas on glibc it's arch dependent (`long`).