### PR TITLE
Accept Connection="keep-alive, Upgrade" header in websocket handler

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -132,4 +132,32 @@ describe HTTP::Headers do
     headers = HTTP::Headers.new
     headers.should be headers.merge!({"foo": "bar"})
   end
+
+  it "matches word" do
+    headers = HTTP::Headers{"foo": "bar"}
+    headers.includes_word?("foo", "bar").should be_true
+    headers.includes_word?("foo", "ba").should be_false
+    headers.includes_word?("foo", "ar").should be_false
+  end
+
+  it "matches word with comma separated value" do
+    headers = HTTP::Headers{"foo": "bar, baz"}
+    headers.includes_word?("foo", "bar").should be_true
+    headers.includes_word?("foo", "baz").should be_true
+    headers.includes_word?("foo", "ba").should be_false
+  end
+
+  it "matches word among headers" do
+    headers = HTTP::Headers.new
+    headers.add("foo", "bar")
+    headers.add("foo", "baz")
+    headers.includes_word?("foo", "bar").should be_true
+    headers.includes_word?("foo", "baz").should be_true
+  end
+
+  it "does not matches word if missing header" do
+    headers = HTTP::Headers.new
+    headers.includes_word?("foo", "bar").should be_false
+    headers.includes_word?("foo", "").should be_false
+  end
 end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -71,6 +71,27 @@ struct HTTP::Headers
     values ? concat(values) : nil
   end
 
+  # Returns if among the headers for `key` there is some that contains `word` as a value.
+  # The `word` is expected to match between word boundaries (i.e. non-alphanumeric chars).
+  #
+  # ```
+  # headers = HTTP::Headers{"Connection": "keep-alive, Upgrade"}
+  # headers.includes_word?("Connection", "Upgrade") # => true
+  # ```
+  def includes_word?(key, word)
+    # iterates over all header values avoiding the concatenation
+    get?(key).try &.each do |value|
+      start = value.index(word)
+      next unless start
+      # check if the match is not surrounded by alphanumeric chars
+      next if start > 0 && value[start - 1].alphanumeric?
+      next if start + word.size < value.size && value[start + word.size].alphanumeric?
+      return true
+    end
+
+    false
+  end
+
   def add(key, value : String)
     check_invalid_header_content value
 

--- a/src/http/server/handlers/deflate_handler.cr
+++ b/src/http/server/handlers/deflate_handler.cr
@@ -7,12 +7,12 @@ class HTTP::DeflateHandler < HTTP::Handler
     ifdef without_zlib
       call_next(context)
     else
-      encoding = context.request.headers["Accept-Encoding"]?
+      request_headers = context.request.headers
 
-      if encoding.try &.includes?("gzip")
+      if request_headers.includes_word?("Accept-Encoding", "gzip")
         context.response.headers["Content-Encoding"] = "gzip"
         context.response.output = Zlib::Deflate.gzip(context.response.output, sync_close: true)
-      elsif encoding.try &.includes?("deflate")
+      elsif request_headers.includes_word?("Accept-Encoding", "deflate")
         context.response.headers["Content-Encoding"] = "deflate"
         context.response.output = Zlib::Deflate.new(context.response.output, sync_close: true)
       end

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -14,7 +14,7 @@ class HTTP::WebSocketHandler < HTTP::Handler
   end
 
   def call(context)
-    if context.request.headers["Upgrade"]? == "websocket" && context.request.headers["Connection"]? == "Upgrade"
+    if context.request.headers["Upgrade"]? == "websocket" && context.request.headers.includes_word?("Connection", "Upgrade")
       key = context.request.headers["Sec-Websocket-Key"]
 
       ifdef without_openssl


### PR DESCRIPTION
Firefox is unable to establish websockets connection.
This is because the Connection header Firefox send "keep-alive, Upgrade", while Chrome will just send "Upgrade".

This PR fix the issue.
Would we prefer other check than `.includes?` ? The same method is used to check for "deflate" in `deflate_handler.cr`

Related source: https://support.mozilla.org/en-US/questions/1078689

cc: @luislavena ;-)