### PR TITLE
Allow WebSocketHandler callback to access HTTP::Server::Context

### DIFF
--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -8,9 +8,9 @@ else
 end
 
 class HTTP::WebSocketHandler < HTTP::Handler
-  @proc : WebSocket ->
+  @proc : WebSocket, Server::Context ->
 
-  def initialize(&@proc : WebSocket ->)
+  def initialize(&@proc : WebSocket, Server::Context ->)
   end
 
   def call(context)
@@ -30,7 +30,7 @@ class HTTP::WebSocketHandler < HTTP::Handler
       response.headers["Sec-Websocket-Accept"] = accept_code
       response.upgrade do |io|
         ws_session = WebSocket.new(io)
-        @proc.call(ws_session)
+        @proc.call(ws_session, context)
         ws_session.run
         io.close
       end


### PR DESCRIPTION
With this change the server is able to initialize a websocket based with initial request context.

```crystal
WebSocketHandler.new do |ws, context|
  # executed when a websocket is stablished
  path = context.request.path 
  ws.on_message do |message|
    # executed when a message is received
  end
end
```

Thanks to proc/blocks arguments rules, this change is backward compatible.

cc: @waj 