### PR TITLE
Add HTTP::Client::Response `success?` status code  helper 

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -210,5 +210,19 @@ class HTTP::Client
       response.content_type.should eq("text/plain")
       response.charset.should eq("UTF-8")
     end
+
+    describe "success?" do
+      it "returns true for the 2xx" do
+        response = Response.new(200)
+
+        response.success?.should eq(true)
+      end
+
+      it "returns false for other ranges" do
+        response = Response.new(500)
+
+        response.success?.should eq(false)
+      end
+    end
   end
 end

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -31,6 +31,10 @@ class HTTP::Client::Response
     @body
   end
 
+  def success?
+    (200..299).includes?(status_code)
+  end
+
   # Returns a convenience wrapper around querying and setting cookie related
   # headers, see `HTTP::Cookies`.
   def cookies


### PR DESCRIPTION
 
Add HTTP::Client::Response `success?` helper

I think that would make it easy to use the HTTP::Client in order to abstract the basic range of status codes, which we all do when coding. 

What do you guys think?