### PR TITLE
Feature/crystal env

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -14,10 +14,11 @@ class Crystal::Command
     Command:
         init                     generate a new project
         build                    compile program
-        play                     starts crystal playground server
         deps                     install project dependencies
         docs                     generate documentation
+        env                      print Crystal environment information
         eval                     eval code from args or standard input
+        play                     starts crystal playground server
         run (default)            compile and run program
         spec                     compile and run specs (in spec directory)
         tool                     run a tool
@@ -73,7 +74,10 @@ class Crystal::Command
       when "docs".starts_with?(command)
         options.shift
         docs
-      when "eval".starts_with?(command)
+      when command == "env"
+        options.shift
+        env
+      when command == "eval"
         options.shift
         eval
       when "run".starts_with?(command)
@@ -157,6 +161,37 @@ class Crystal::Command
   private def build
     config = create_compiler "build"
     config.compile
+  end
+
+  private def env
+    if ARGV.size == 1 && {"--help", "-h"}.includes?(ARGV[0])
+      puts <<-USAGE
+      Usage: crystal env [var ...]
+
+      Prints Crystal environment information.
+
+      By default it prints information as a shell script.
+      If one or more variable names is given as arguments,
+      it prints the value of each named variable on its own line.
+      USAGE
+
+      exit
+    end
+
+    vars = {
+      "CRYSTAL_PATH":    Config::PATH || "",
+      "CRYSTAL_VERSION": Config::VERSION || "",
+    }
+
+    if ARGV.empty?
+      vars.each do |key, value|
+        puts "#{key}=#{value.inspect}"
+      end
+    else
+      ARGV.each do |key|
+        puts vars[key]?
+      end
+    end
   end
 
   private def eval


### PR DESCRIPTION
This adds a `crystal env` command.

This is useful for tools that use the `crystal` command, mostly to get a correct `CRYSTAL_PATH`.

For example:

```
$ crystal env
CRYSTAL_PATH="/Users/asterite/Projects/crystal/src"
CRYSTAL_VERSION="0.13.0-193-gcf51d92"
```

```
$ crystal env --help
Usage: crystal env [var ...]

Prints Crystal environment information.

By default it prints information as a shell script.
If one or more variable names is given as arguments,
it prints the value of each named variable on its own line.
```

```
$ crystal env CRYSTAL_PATH
/Users/asterite-manas/Projects/crystal/src
```

```
$ crystal env CRYSTAL_VERSION CRYSTAL_PATH
0.13.0-193-gcf51d92
/Users/asterite-manas/Projects/crystal/src
```
