### PR TITLE
failing test: udp socket send

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -225,6 +225,24 @@ describe TCPSocket do
 end
 
 describe UDPSocket do
+  it "sends messages to nowhere, once" do
+    client = UDPSocket.new(Socket::Family::INET)
+    client.connect("127.0.0.1", 12341)
+
+    client << "message"
+  end
+
+  it "flaky: sends messages to nowhere, iterate" do
+    client = UDPSocket.new(Socket::Family::INET)
+    client.connect("127.0.0.1", 12342)
+
+    10.times do |iteration|
+      client << "message"
+      p iteration
+    end
+    client.close
+  end
+
   it "sends and receives messages by reading and writing" do
     port = free_udp_socket_port
 

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -226,21 +226,19 @@ end
 
 describe UDPSocket do
   it "sends messages to nowhere, once" do
-    client = UDPSocket.new(Socket::Family::INET)
-    client.connect("127.0.0.1", 12341)
+    client = UDPSocket.new
+    destination = Socket::IPAddress.new(Socket::Family::INET, "127.0.0.1", 12341)
 
-    client << "message"
+    client.send("message", destination)
   end
 
-  it "flaky: sends messages to nowhere, iterate" do
-    client = UDPSocket.new(Socket::Family::INET)
-    client.connect("127.0.0.1", 12342)
+  it "sends messages to nowhere, iterate" do
+    client = UDPSocket.new
+    destination = Socket::IPAddress.new(Socket::Family::INET, "127.0.0.1", 12342)
 
     10.times do |iteration|
-      client << "message"
-      p iteration
+      client.send("message", destination)
     end
-    client.close
   end
 
   it "sends and receives messages by reading and writing" do


### PR DESCRIPTION
This commit should expose some of the flakiness when trying to open a
socket once, and send multiple messages to a non-listening server.

Typically, the first test will pass, and the second one fails. There definitely seems to be an 'ordering' thing going on here, as in testing I was able to emit 1, 2 messages successfully most of the time with no stacktrace:

```
       Error writing file: Connection refused
       [4548360178] *CallStack::unwind:Array(Pointer(Void)) +82
       [4548360081] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
       [4548360040] *CallStack::new:CallStack +40
       [4548370505] *Exception@Exception#initialize<Errno, String>:CallStack +41
       [4548370435] *Errno#initialize<Errno, String>:CallStack +115
       [4548370289] *Errno::new<String>:Errno +113
       [4548640355] *UDPSocket@IO::FileDescriptor#unbuffered_write<UDPSocket, Slice(UInt8)>:Int32 +627
       [4548644656] *UDPSocket@IO::Buffered#write<UDPSocket, Slice(UInt8)>:Int32? +112
       [4548644361] *UDPSocket@IO#write_utf8<UDPSocket, Slice(UInt8)>:Nil +105
       [4548359706] *String#to_s<String, UDPSocket>:Nil +74
       [4548644232] *UDPSocket@IO#<<<UDPSocket, String>:UDPSocket +24
       [4548326279] ~proc( -> Void)@./spec/std/socket_spec.cr:236 +87
       [4548298164] *it<String, String, Int32, &( -> Void)>:(Array(Spec::Result) | Bool | Nil) +420
       [4548325038] ~proc( -> Void)@./spec/std/socket_spec.cr:227 +142
       [4548505370] *Spec::RootContext::describe<String, String, Int32, &( -> Void)>:Spec::Context+ +314
       [4548324883] *describe<UDPSocket:Class, String, Int32, &( -> Void)>:Spec::Context+ +51
       [4548284608] __crystal_main +39120
       [4548294120] main +40
```

This is in attempt to make a singleton client for the statsd.cr shard, that should have a graceful degradation model for the listener failing.

Currently, [creating and closing a UDPSocket per request works](https://github.com/miketheman/statsd.cr/blob/b4cc5821ee2dc16e64bfdab022d78ed5d145b6c3/src/statsd/client.cr#L36-L41), but is far from optimal.