### PR TITLE
OpenSSL additions + HTTP::Client support for more ssl options

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -65,6 +65,14 @@ module HTTP
         cl.port.should eq(9999)
       end
 
+      it "allows changing ssl settings" do
+        cl = Client.new(URI.parse("https://demo.com"))
+        cl.ssl_method = OpenSSL::SSL::Method::TLSv1
+        cl.ssl_cert_file = "/path/to/cert"
+        cl.ssl_key_file = "/path/to/key"
+        cl.ssl_ca_file = "/path/to/ca"
+      end
+
       it "raises error if not http schema" do
         expect_raises(ArgumentError, "Unsupported scheme: ssh") do
           Client.new(URI.parse("ssh://demo.com"))

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -495,9 +495,9 @@ class HTTP::Client
 
   def ssl_context
     ctx = OpenSSL::SSL::Context.new(ssl_method)
-    ctx.ca_file = ssl_ca_file unless ssl_ca_file
-    ctx.private_key = ssl_key_file unless ssl_key_file
-    ctx.certificate_file = ssl_cert_file unless ssl_cert_file
+    ctx.ca_file = ssl_ca_file unless ssl_ca_file.empty?
+    ctx.private_key = ssl_key_file unless ssl_key_file.empty?
+    ctx.certificate_file = ssl_cert_file unless ssl_cert_file.empty?
     ctx
   end
 

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -1,3 +1,5 @@
+require "openssl"
+
 # An HTTP Client.
 #
 # ### One-shot usage
@@ -80,6 +82,11 @@ class HTTP::Client
   # Whether automatic compression/decompression is enabled.
   property? compress : Bool
 
+  property! ssl_ca_file : String
+  property! ssl_cert_file : String
+  property! ssl_key_file : String
+  property! ssl_method : OpenSSL::SSL::Method
+
   @before_request : Array(Request ->)?
 
   ifdef without_openssl
@@ -105,6 +112,7 @@ class HTTP::Client
 
     @port = (port || (ssl ? 443 : 80)).to_i
     @compress = true
+    @ssl_method = OpenSSL::SSL::Method::SSLv23 if ssl
   end
 
   # Creates a new HTTP client from a URI. Parses the *host*, *port*,
@@ -485,6 +493,14 @@ class HTTP::Client
     @socket = nil
   end
 
+  def ssl_context
+    ctx = OpenSSL::SSL::Context.new(ssl_method)
+    ctx.ca_file = ssl_ca_file unless ssl_ca_file
+    ctx.private_key = ssl_key_file unless ssl_key_file
+    ctx.certificate_file = ssl_cert_file unless ssl_cert_file
+    ctx
+  end
+
   private def new_request(method, path, headers, body)
     headers ||= HTTP::Headers.new
     headers["Host"] ||= host_header
@@ -506,7 +522,7 @@ class HTTP::Client
 
     ifdef !without_openssl
       if @ssl
-        ssl_socket = OpenSSL::SSL::Socket.new(socket, sync_close: true)
+        ssl_socket = OpenSSL::SSL::Socket.new(socket, context: ssl_context, sync_close: true)
         @socket = socket = ssl_socket
       end
     end

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -13,9 +13,12 @@ lib LibSSL
     ASN1 = 2
   end
 
+  fun sslv3_method = SSLv3_method : SSLMethod
+  fun sslv23_method = SSLv23_method : SSLMethod
+  fun tlsv1_method = TLSv1_method : SSLMethod
+
   fun ssl_load_error_strings = SSL_load_error_strings
   fun ssl_library_init = SSL_library_init
-  fun sslv23_method = SSLv23_method : SSLMethod
   fun ssl_ctx_new = SSL_CTX_new(method : SSLMethod) : SSLContext
   fun ssl_ctx_free = SSL_CTX_free(context : SSLContext)
 
@@ -41,4 +44,7 @@ lib LibSSL
   fun ssl_ctx_use_certificate_chain_file = SSL_CTX_use_certificate_chain_file(ctx : SSLContext, file : UInt8*) : Int
   fun ssl_ctx_use_privatekey_file = SSL_CTX_use_PrivateKey_file(ctx : SSLContext, file : UInt8*, filetype : SSLFileType) : Int
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  fun ssl_ctx_load_verify_locations = SSL_CTX_load_verify_locations(ctx: SSLContext, ca_file: UInt8*, ca_path: UInt8*) : Int32
+  fun ssl_ctx_use_certificate_file = SSL_CTX_use_certificate_file(ctx: SSLContext, file: UInt8*, type: Int32) : Int32
+
 end

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -7,8 +7,8 @@ class OpenSSL::SSL::Context
 
   @handle : LibSSL::SSLContext
 
-  def initialize
-    @handle = LibSSL.ssl_ctx_new(LibSSL.sslv23_method)
+  def initialize(method = Method::SSLv23)
+    @handle = LibSSL.ssl_ctx_new(method)
   end
 
   def finalize
@@ -21,6 +21,18 @@ class OpenSSL::SSL::Context
 
   def private_key=(file_path)
     LibSSL.ssl_ctx_use_privatekey_file(@handle, file_path, LibSSL::SSLFileType::PEM)
+  end
+
+  def ca_file=(file_path)
+    if LibSSL.ssl_ctx_load_verify_locations(@handle, file_path, nil) == 0
+      raise "unable to set CA file"
+    end
+  end
+
+  def certificate_file=(file_path)
+    if LibSSL.ssl_ctx_use_certificate_file(@handle, file_path, 1) == 0
+      raise "unable to set certificate file"
+    end
   end
 
   def to_unsafe

--- a/src/openssl/ssl/method.cr
+++ b/src/openssl/ssl/method.cr
@@ -1,0 +1,18 @@
+enum OpenSSL::SSL::Method
+  SSLv23
+  SSLv3
+  TLSv1
+
+  def to_unsafe
+    case self
+    when SSLv23
+      LibSSL.sslv23_method
+    when SSLv3
+      LibSSL.sslv3_method
+    when TLSv1
+      LibSSL.tlsv1_method
+    else
+      raise "Unsupported SSL method"
+    end
+  end
+end


### PR DESCRIPTION
- Added LibSSL functions for CA and certificate files
- Added OpenSSL::SSL::Method from @datanoise with added SSLv3 and TLSv1
- Allow setting `OpenSSL::SSL::Method` on `OpenSSL::SSL::Context` constructor
- Added `ssl_` methods to HTTP::Client for specifying:
  - CA file path
  - Private key file path
  - Certificate file path
  - SSL method to use

I'm in need of these changes to SSL for my Docker API client (https://github.com/jeromegn/docker.cr). For now, I've extended the various libs and classes within the shard, but I think these small changes could be beneficial to a lot of people.

I'm not entirely sure how to test these, for now I've just tested that it's possible to set ssl options on the `HTTP::Client` and since OpenSSL was vastly untested, I didn't bother adding more there.

I did some manual testing, with a slightly modified version of my shard and using this version of crystal's binaries and it worked.

I inspired from Ruby's Net::HTTP methods for ssl, but I don't think they were quite right and I don't think this syntax I created is quite right either. I was debating adding a lot of initialization options, but then I would've had to add them on every method initializing or calling an initializer (there are 3 of them, that got quite verbose.) So I decided to let users set the SSL options after initialization.

I also had to explicitly `require "openssl"` in `HTTP::Client` due to the property. This could probably be avoided by not specifying the type there.

My goal is to make this mergeable, so if there's anything, please let me know and I'll be happy to discuss and fix :)