### PR TITLE
Fix typo in Regex::MatchData documentation

### DIFF
--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -135,8 +135,8 @@ class Regex
     # if there is no `n`th capture group.
     #
     # ```
-    # "Crystal".match(/r(ys)/) { |md| md[1]? } # => "ys"
-    # "Crystal".match(/r(ys)/) { |md| md[2]? } # => raises IndexError
+    # "Crystal".match(/r(ys)/) { |md| md[1] } # => "ys"
+    # "Crystal".match(/r(ys)/) { |md| md[2] } # => raises IndexError
     # ```
     def [](n)
       check_index_out_of_bounds n


### PR DESCRIPTION
Looks like a simple copy-pasta error, documentation for `[]` was using the `[]?` method instead.