### PR TITLE
Added Process.daemonize, spec, and samples

### DIFF
--- a/samples/daemonize/daemonize.cr
+++ b/samples/daemonize/daemonize.cr
@@ -1,0 +1,30 @@
+require "logger"
+require "tempfile"
+puts "Daemonizing..."
+
+stdout = Tempfile.new("out")
+stderr = Tempfile.new("err")
+stdin = Tempfile.new("in")
+
+puts <<-THE_END
+STDOUT is #{stdout.path}
+STDERR is #{stderr.path}
+STDIN  is #{stdin.path}
+THE_END
+
+Process.daemonize(stdout: stdout.path, stderr: stderr.path, stdin: stdin.path)
+
+begin
+  log = Logger.new(STDERR)
+  log.level = Logger::WARN
+
+  loop do
+    sleep 1
+    puts "I am writing to STDOUT"
+    log.warn("I am writing to STDERR")
+  end
+ensure
+  stdout.delete
+  stderr.delete
+  stdin.delete
+end

--- a/samples/daemonize/tail_daemon.cr
+++ b/samples/daemonize/tail_daemon.cr
@@ -1,0 +1,24 @@
+require "tempfile"
+
+stdout = Tempfile.new("out")
+stdin = Tempfile.new("in")
+
+puts <<-THE_END
+Reading from #{stdin.path}
+Writing to #{stdout.path}
+To kill daemon: 'echo "exit" >> #{stdin.path}'
+THE_END
+
+Process.daemonize(stdin: stdin.path, stdout: stdout.path)
+
+def process(msg)
+  if msg
+    puts "read line '#{msg.chop}'"
+    if msg.chop == "exit"
+      puts "bye"
+      exit
+    end
+  end
+end
+
+loop { process(STDIN.gets) }

--- a/samples/daemonize/tcp_client.cr
+++ b/samples/daemonize/tcp_client.cr
@@ -1,0 +1,12 @@
+require "socket"
+
+# goes with daemonize/tcp_server_daemon.cr
+
+socket = TCPSocket.new "127.0.0.1", 9000
+10.times do |i|
+  socket.puts "#{i}"
+  puts "server response #{socket.gets}"
+  sleep 0.5
+end
+
+socket.puts "exit"

--- a/samples/daemonize/tcp_server_daemon.cr
+++ b/samples/daemonize/tcp_server_daemon.cr
@@ -1,0 +1,24 @@
+require "socket"
+
+# goes with tcp_client.cr
+
+Process.daemonize
+
+def process(client)
+  client_addr = client.remote_address
+  puts "#{client_addr} connected"
+
+  while msg = client.read_line.chop
+    Process.exit if msg == "exit"
+    puts "#{client_addr} msg '#{msg}'"
+    client << msg
+  end
+rescue IO::EOFError
+  puts "#{client_addr} dissconnected"
+ensure
+  client.close
+end
+
+server = TCPServer.new "127.0.0.1", 9000
+puts "listen on 127.0.0.1:9000"
+loop { spawn process(server.accept) }

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "process"
+require "tempfile"
 
 describe Process do
   it "runs true" do
@@ -167,5 +168,24 @@ describe Process do
       end
     end
     buffer.to_s.lines.size.should eq(1000)
+  end
+
+  it "daemonizes and has parent pid == 1" do
+    # run = ->(command : String) {
+    #   Process.run(
+    #     "/bin/sh", input: MemoryIO.new(command), output: STDOUT, error: STDOUT
+    #   )
+    # }
+
+    tmp = Tempfile.new("it_daemonizes")
+    fork {
+      Process.daemonize
+      sleep 1
+      File.write(tmp.path, Process.ppid.to_s)
+    }
+    sleep 2
+    res = File.read(tmp.path)
+    res.should eq("1")
+    tmp.delete
   end
 end

--- a/src/process/process.cr
+++ b/src/process/process.cr
@@ -7,6 +7,8 @@ lib LibC
   fun kill(pid : PidT, signal : Int) : Int
   fun getpid : PidT
   fun getppid : PidT
+  fun setsid : PidT
+  fun getsid(pid : PidT) : PidT
   fun exit(status : Int) : NoReturn
 
   ifdef x86_64
@@ -41,6 +43,14 @@ class Process
     ret = LibC.getpgid(pid)
     raise Errno.new(ret) if ret < 0
     ret
+  end
+
+  def self.setsid
+    LibC.setsid
+  end
+
+  def self.sid(pid : Int32 = 0)
+    LibC.getsid(pid)
   end
 
   def self.kill(signal : Signal, *pids : Int)
@@ -111,6 +121,27 @@ class Process
     hertz = LibC.sysconf(LibC::SC_CLK_TCK).to_f
     LibC.times(out tms)
     Tms.new(tms.utime / hertz, tms.stime / hertz, tms.cutime / hertz, tms.cstime / hertz)
+  end
+
+  # Daemonizes the process
+  #
+  # This method detaches the process from the terminal so the program
+  # may run in the backgound without the terminal.
+  #
+  # By default STDIN, STDOUT, and STDERR are redirected to /dev/null.
+  # They may be redirected to a file to be read-in by STDIN, or written-
+  # to by STDOUT and STDERR.
+  #
+  # By default, the daemonized process will change to root as a working directory.
+  # Another working directory can be provided.
+  def self.daemonize(stdin : String = "/dev/null", stdout : String = "/dev/null", stderr : String = "/dev/null", dir : String = "/")
+    exit if fork
+    setsid
+    exit if fork
+    Dir.cd(dir)
+    STDIN.reopen(File.open(stdin, "a+"))
+    STDOUT.reopen(File.open(stdout, "a"))
+    STDERR.reopen(File.open(stderr, "a"))
   end
 end
 


### PR DESCRIPTION
Detaches a process from the terminal to run in background.

STDIN, STDOUT, STDERR default to /dev/null. Can override with file paths.

`Process.daemonize(stdin: "/dev/null", stdout: "/dev/null", stderr: "/dev/null”)`

New PR to clean up commits from #2363.