### PR TITLE
Improving Deque#delete

### DIFF
--- a/src/deque.cr
+++ b/src/deque.cr
@@ -222,11 +222,15 @@ class Deque(T)
   # a # => Deque{"a", "c"}
   # ```
   def delete(obj)
-    # TODO this can probably be optimized a lot
     found = false
-    while index = index(obj)
-      delete_at(index)
-      found = true
+    i = 0
+    while i < @size
+      if self[i] == obj
+        delete_at(i)
+        found = true
+      else
+        i += 1
+      end
     end
     found
   end


### PR DESCRIPTION
This is an attempt to improve Deque#delete a bit.  This eliminates the object lookup step `index(obj)`, but probably could still use some improvement with the actual deletion (`delete_at`).

How is everyone benchmarking code execution?