### PR TITLE
Expand macro expressions arguments before macro calls. Fixes #2388

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1269,4 +1269,26 @@ describe "Code gen: macro" do
       id(A)
       )).to_i.should eq(1)
   end
+
+  it "solves macro expression arguments before macro expansion (type)" do
+    run(%(
+      macro name(x)
+        {{x.name.stringify}}
+      end
+
+      name({{String}})
+      )).to_string.should eq("String")
+  end
+
+  it "solves macro expression arguments before macro expansion (constant)" do
+    run(%(
+      CONST = 1
+
+      macro id(x)
+        {{x}}
+      end
+
+      id({{CONST}})
+      )).to_i.should eq(1)
+  end
 end


### PR DESCRIPTION
This change makes this code:

```crystal
call({{argument}})
```

to first expand `{{argument}}`. If it's a `Path` denoting a type, a `TypeNode` is passed to the macro. If it denotes a constant, the constant's value is passed to the macro. Otherwise the regular expansion is passed to it.

This makes it possible to extract a repeated macro argument into a constant:

```crystal
require "json"
require "yaml"

class Point
  MAPPING = {
    x: Int32,
    y: Int32,
  }

  JSON.mapping({{MAPPING}})
  YAML.mapping({{MAPPING}})
end
``` 

Or, following @BlaXpirit 's [example](https://github.com/crystal-lang/crystal/issues/2388#issuecomment-203875086) you can include the constants of a type inside another type:

```crystal
macro include_constants(t)
  {% for c in t.constants %}
    {{c}} = {{t}}::{{c}}
  {% end %}
end

enum E
  A, B, C
end

class T1
  include_constants({{E}})
end

p T1::A # works
p T1::B # works
p T1::C # works
```

In fact in the above case it can also be simplified for the macro caller by using a second macro, because the expected argument is always expected to be a type:

```crystal
macro include_constants(t)
  include_constants_for_real(\{{ {{t}} }})
end

macro include_constants_for_real(t)
  {% for c in t.constants %}
    {{c}} = {{t}}::{{c}}
  {% end %}
end

enum E
  A, B, C
end

class T1
  include_constants(E)
end

p T1::A # works
p T1::B # works
p T1::C # works
```

For this last case we might also want to make it simpler by maybe putting a `TypeNode` type restriction in the macro, so the compiler will always try to convert a Path argument to a `TypeNode` so there's no need to surround it in curly braces. But this won't solve the JSON/YAML Mapping reuse, so it's still worth introducing this feature.