### PR TITLE
.to_json for Time, specs for Time and Time::Format

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -121,6 +121,16 @@ describe "JSON serialization" do
     it "does for Tuple" do
       {1, "hello"}.to_json.should eq(%([1,"hello"]))
     end
+
+    it "does for Time" do
+      Time.new(2015, 10, 10).to_json.should eq("1444435200")
+    end
+
+    it "does for Time::Format" do
+      formatter = Time::Format.new("%Y-%m-%d")
+
+      formatter.format(Time.new(2015, 10, 10)).to_json.should eq("\"2015-10-10\"")
+    end
   end
 
   describe "to_pretty_json" do

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -274,6 +274,12 @@ struct Tuple
   end
 end
 
+struct Time
+  def to_json(io : IO)
+    io << epoch.to_s
+  end
+end
+
 struct Time::Format
   def to_json(value : Time, io : IO)
     format(value).to_json(io)


### PR DESCRIPTION
Provide method `#to_json` for Time that returns Unix time stamp in `String` format  because it could be needed in API or something like that, + it's needed when working with shards like `active_record` to map Time columns. Also I've provided specs for this and for `Time::Format`.


`Time.now.to_json` => "1459618706"