### PR TITLE
Provide Unix epoch in Time::Format

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -121,6 +121,13 @@ describe "JSON serialization" do
     it "does for Tuple" do
       {1, "hello"}.to_json.should eq(%([1,"hello"]))
     end
+
+    it "does for Time::Format" do
+      formatter = Time::Format.new("%s")
+      time = Time.new(2015, 10, 10)
+
+      formatter.format(time).to_json.should eq("\"1444435200\"")
+    end
   end
 
   describe "to_pretty_json" do

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -366,6 +366,9 @@ describe Time do
   assert { Time.parse("2014", "%Y").year.should eq(2014) }
   assert { Time.parse("19", "%C").year.should eq(1900) }
   assert { Time.parse("14", "%y").year.should eq(2014) }
+  assert { Time.parse("1444435200", "%s").month.should eq(10) }
+  # Ignores all symbols except %s
+  assert { Time.parse("1444435200", "%s %Y-%m-%d").year.should eq(2015) }
   assert { Time.parse("09", "%m").month.should eq(9) }
   assert { Time.parse(" 9", "%_m").month.should eq(9) }
   assert { Time.parse("9", "%-m").month.should eq(9) }

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -11,6 +11,8 @@ struct Time::Format
   end
 
   def parse(string, kind = @kind)
+    @pattern = "%s" if @pattern.includes?("%s")
+
     parser = Parser.new(string)
     parser.visit(pattern)
     parser.time(kind)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -11,6 +11,10 @@ struct Time::Format
     def initialize(@time, @io)
     end
 
+    def unix_epoch
+      io << time.epoch
+    end
+
     def year
       pad4(time.year, '0')
     end

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -14,6 +14,8 @@ struct Time::Format
     @pm : Bool
     @offset_in_minutes : Int32?
     @kind : Time::Kind?
+    @epoch_time : Time
+    @epoch_based : Bool
 
     def initialize(string)
       @reader = Char::Reader.new(string)
@@ -25,9 +27,13 @@ struct Time::Format
       @second = 0
       @millisecond = 0
       @pm = false
+      @epoch_based = false
+      @epoch_time = Time.new(0)
     end
 
     def time(kind = Time::Kind::Unspecified)
+      return @epoch_time if @epoch_based
+
       @hour += 12 if @pm
 
       time_kind = @kind || kind
@@ -108,6 +114,13 @@ struct Time::Format
 
     def day_of_month_zero_padded
       @day = consume_number(2)
+    end
+
+    def unix_epoch
+      string = @reader.string
+      @epoch_based = true
+
+      @epoch_time = Time.epoch(string.to_i)
     end
 
     def day_of_month_blank_padded

--- a/src/time/format/pattern.cr
+++ b/src/time/format/pattern.cr
@@ -61,6 +61,8 @@ struct Time::Format
           twelve_hour_time
         when 'R'
           twenty_four_hour_time
+        when 's'
+          unix_epoch
         when 'S'
           second
         when 'T', 'X'


### PR DESCRIPTION
Provide `%s` letter-option in `Time::Format` that allows to get Unix epoch representation of Time

As well it works as a parser option, and if it exists in parser pattern it ignores all the other symbols there