### PR TITLE
fixed #2393.

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -73,7 +73,7 @@ module Crystal
       program.wants_doc = wants_doc?
       program.color = color?
 
-      @link_flags = "#{@link_flags} -rdynamic"
+      @link_flags = "#{@link_flags} -rdynamic -shared"
 
       node, original_node = parse program, sources
       node = infer_type program, node


### PR DESCRIPTION
Look here https://github.com/crystal-lang/crystal/issues/2393.
```
 ➜  cc -o "/home/zeno/crystal-icr/icr" "${@}"  -rdynamic  /opt/crystal/src/llvm/ext/llvm_ext.o `(llvm-config-3.6 --libs --system-libs --ldflags 2> /dev/null) || (llvm-config-3.5 --libs --system-libs --ldflags 2> /dev/null) || (llvm-config --libs --system-libs --ldflags 2>/dev/null)` -lstdc++ -lcrypto -lreadline /opt/crystal/src/ext/libcrystal.a -levent -lrt -lpcre -lm -lgc -lpthread -ldl
/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crt1.o：In function ‘_start’：
/build/glibc-ryFjv0/glibc-2.21/csu/../sysdeps/x86_64/start.S:114：undefined reference to ‘main’
```

Seems lost '-shared' flag when reference to .o file which does not have a `main` function.