### PR TITLE
 WIP: Re-set port zero after listening

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -168,6 +168,21 @@ module HTTP
     end
   end
 
+  describe HTTP::Server do
+    it "re-sets special port zero after bind" do
+      server = Server.new(0) { |ctx| }
+      server.bind
+      server.port.should_not eq(0)
+    end
+
+    it "re-sets port to zero after close" do
+      server = Server.new(0) { |ctx| }
+      server.bind
+      server.close
+      server.port.should eq(0)
+    end
+  end
+
   typeof(begin
     # Initialize with custom host
     server = Server.new("0.0.0.0", 0) { |ctx| }


### PR DESCRIPTION
This is useful for HTTP Server integration tests where you
want to bind to any free port (port 0) but the HTTP client
needs to the specific port.

I'm not happy about the `sleep 0.0001` hack in spec :-(