### PR TITLE
Block arg '&' dose not always follow no whitespace

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -349,8 +349,10 @@ describe "Parser" do
 
   it_parses "foo(&block)", Call.new(nil, "foo", block_arg: "block".call)
   it_parses "foo &block", Call.new(nil, "foo", block_arg: "block".call)
+  it_parses "foo(& block)", Call.new(nil, "foo", block_arg: "block".call)
   it_parses "a.foo &block", Call.new("a".call, "foo", block_arg: "block".call)
   it_parses "a.foo(&block)", Call.new("a".call, "foo", block_arg: "block".call)
+  it_parses "a.foo(& block)", Call.new("a".call, "foo", block_arg: "block".call)
 
   it_parses "foo(&.block)", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
   it_parses "foo &.block", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
@@ -386,6 +388,7 @@ describe "Parser" do
 
   it_parses "foo(a: 1, &block)", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)], block_arg: "block".call)
   it_parses "foo a: 1, &block", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)], block_arg: "block".call)
+  it_parses "foo a: 1, & block", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)], block_arg: "block".call)
 
   it_parses "x = 1; foo x do\nend", [Assign.new("x".var, 1.int32), Call.new(nil, "foo", ["x".var] of ASTNode, Block.new)]
   it_parses "x = 1; foo x { }", [Assign.new("x".var, 1.int32), Call.new(nil, "foo", [Call.new(nil, "x", block: Block.new)] of ASTNode)]

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1365,7 +1365,7 @@ module Crystal
     end
 
     def call_block_arg_follows?
-      @token.type == :"&" && !current_char.whitespace?
+      @token.type == :"&"
     end
 
     def parse_call_block_arg(args, check_paren, named_args = nil)


### PR DESCRIPTION
What no-whitespace check is needed on is only when block arg is passed as first argument and method calling is not wrapped by parentheses, because such a case cannot ditinguish between block arg '&' and binary operator '&'. e.g.

```crystal
foo 1, & bar # == foo(1, &bar)
foo(& bar)   # == foo(&bar)

foo & bar    # which dose it mean 'foo(&bar)' or '(foo & bar)'?
             # curretly, it parsed to '(foo & bar)'.
```

You may think this fix makes syntax more complex. Don't worry, plus '+' and minus '-' syntax have same complexity already. e.g.

```crystal
foo +1  # == foo(+1)
foo + 1 # == (foo + 1)
```

Current implementation accepts only no-whitespace case, dose not accept following whitespace case. This behavior is different from Ruby, and this change is useful to write some complex expression as block args.

Note: no-whitespace following check is [here](https://github.com/crystal-lang/crystal/blob/6e6afd4442d2dc0d32643c74931729e892504120/src/compiler/crystal/syntax/parser.cr#L3524-L3525).