### PR TITLE
Use Deque instead of Array on Channel::Buffered

### DIFF
--- a/src/concurrent/channel.cr
+++ b/src/concurrent/channel.cr
@@ -158,7 +158,7 @@ end
 
 class Channel::Buffered(T) < Channel(T)
   def initialize(@capacity = 32)
-    @queue = Array(T).new(@capacity)
+    @queue = Deque(T).new(@capacity)
     super()
   end
 


### PR DESCRIPTION
`Channel::Buffered` currently uses an `Array` buffer, with `receive` applying a shifting the buffer. `shift` on arrays is `O(n)`, slow. shifting all elements becomes a quadratic operation on the size of the buffer, the bigger it is, worse performance gets. This is a benchmark before and after this change:

Before:
```
$ crystal run --release bench.cr
   channel_stress(10, 50000) 779.58  (±11.97%)       fastest
  channel_stress(100, 50000) 710.04  (± 4.68%)  1.10× slower
 channel_stress(1000, 50000) 324.99  (± 8.10%)  2.40× slower
channel_stress(10000, 50000)  38.11  (± 5.22%) 20.46× slower
```

After:
```
$ crystal run --release bench.cr
   channel_stress(10, 50000) 778.46  (±12.05%)  1.37× slower
  channel_stress(100, 50000)      1k (± 7.66%)  1.06× slower
 channel_stress(1000, 50000)   1.07k (± 7.44%)       fastest
channel_stress(10000, 50000)   1.04k (± 6.86%)  1.02× slower
```

Benchmarking code:

```crystal
require "benchmark"

def channel_stress(n, m)
  channel = Channel(Int32).new(n)
  spawn do
    m.times.each do |i|
      channel.send(i)
    end
  end

  m.times do
    channel.receive
  end
end

Benchmark.ips do |x|
  x.report("channel_stress(10, 50000)")    { channel_stress(10,    50000) }
  x.report("channel_stress(100, 50000)")   { channel_stress(100,   50000) }
  x.report("channel_stress(1000, 50000)")  { channel_stress(1000,  50000) }
  x.report("channel_stress(10000, 50000)") { channel_stress(10000, 50000) }
end
```