### PR TITLE
Add secure_compare for String to allow for polynomial time comparison.

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -357,6 +357,23 @@ describe "String" do
     "foo".should_not eq("bar")
   end
 
+  it "securely compares strings: different size" do
+    "foo".secure_compare("abcde").should eq(false)
+  end
+
+  it "securely compares strings: same object" do
+    f = "foo"
+    f.secure_compare(f).should eq(true)
+  end
+
+  it "securely compares strings: same size, same string" do
+    "foo".secure_compare("fo" + "o").should eq(true)
+  end
+
+  it "securely compares strings: same size, different string" do
+    "foo".secure_compare("bar").should eq(false)
+  end
+
   it "interpolates string" do
     foo = "<foo>"
     bar = 123

--- a/src/string.cr
+++ b/src/string.cr
@@ -1810,6 +1810,31 @@ class String
     end
   end
 
+  # Compares this string with *other* in polynomial time for strings of the same length,
+  # returning true for matching strings and false for strings that don't match. Helpful in
+  # preventing timing attacks.
+  # ```
+  # "abcdef".secure_compare("abcde")  # => false
+  # "abcdef".secure_compare("abcdef") # => true
+  # ```
+  def secure_compare(other : String)
+    return false unless bytesize == other.bytesize
+
+    reader1 = Char::Reader.new(self)
+    reader2 = Char::Reader.new(other)
+
+    res = 0
+
+    while reader1.has_next? && reader2.has_next?
+      res |= reader2.current_char.ord ^ reader1.current_char.ord
+
+      reader1.next_char
+      reader2.next_char
+    end
+
+    res == 0
+  end
+
   # Tests whether *str* matches *regex*.
   # If successful, it returns the position of the first match.
   # If unsuccessful, it returns `nil`.


### PR DESCRIPTION
Securely comparing strings helps to prevent timing attacks. This allows you to compare two strings of equal length in O(n) time. This is helpful in libraries that are comparing two hashes as a result of bcrypt, pbkdf2 etc.