### PR TITLE
Fix sigfault error in XML::Node#namespace_scopes method.

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -177,6 +177,17 @@ describe XML do
     namespaces[1].prefix.should eq("openSearch")
   end
 
+  it "returns empty array if no namespaces scopes exists" do
+    doc = XML.parse(<<-XML
+      <?xml version='1.0' encoding='UTF-8'?>
+      <name>John</name>
+      XML
+    )
+    namespaces = doc.root.not_nil!.namespace_scopes
+
+    namespaces.size.should eq(0)
+  end
+
   it "gets root namespaces as hash" do
     doc = XML.parse(<<-XML
       <?xml version="1.0" encoding="UTF-8"?>

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -245,9 +245,12 @@ struct XML::Node
     scopes = [] of Namespace
 
     ns_list = LibXML.xmlGetNsList(@node.value.doc, @node)
-    while ns_list.value
-      scopes << Namespace.new(document, ns_list.value)
-      ns_list += 1
+
+    if ns_list
+      while ns_list.value
+        scopes << Namespace.new(document, ns_list.value)
+        ns_list += 1
+      end
     end
 
     scopes


### PR DESCRIPTION
When no namespace found a sigfault error occured instead of returning an empty array.