### PR TITLE
Promote results of +-*|&^ operations to 64-bit if any operand is 64-bit

### DIFF
--- a/spec/compiler/codegen/implicit_type_conversions.cr
+++ b/spec/compiler/codegen/implicit_type_conversions.cr
@@ -1,0 +1,39 @@
+require "../../spec_helper"
+
+describe "Code gen: implicit type conversions" do
+  it "codegens 'Int32 + Int64' (#567)" do
+    run("1_i32 + 2147483647_i64 == 2147483648_i64").to_b.should be_true
+  end
+
+  it "codegens 'UInt32 + Int64'" do
+    run("1_u32 + 2147483647_i64 == 2147483648_i64").to_b.should be_true
+  end
+
+  it "codegens 'UInt32 + UInt64'" do
+    run("1_u32 + 2147483647_u64 == 2147483648_u64").to_b.should be_true
+  end
+
+  it "codegens (Int32 + Int64).is_a?(Int64)" do
+    run("(1 + 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+
+  it "codegens (Int32 - Int64).is_a?(Int64)" do
+    run("(1 - 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+
+  it "codegens (Int32 * Int64).is_a?(Int64)" do
+    run("(1 * 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+
+  it "codegens (Int32 | Int64).is_a?(Int64)" do
+    run("(1 | 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+
+  it "codegens (Int32 & Int64).is_a?(Int64)" do
+    run("(1 & 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+
+  it "codegens (Int32 ^ Int64).is_a?(Int64)" do
+    run("(1 ^ 2147483647_i64).is_a?(Int64)").to_b.should be_true
+  end
+end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -137,7 +137,17 @@ class Crystal::CodeGenVisitor
             end
 
     if t1.normal_rank != t2.normal_rank && t1.rank < t2.rank
-      @last = trunc @last, llvm_type(t1)
+      # Truncate the result, unless implicitly expanding it to a larger data type regardless
+      # of the operands order. See: https://github.com/crystal-lang/crystal/issues/567
+      @last = trunc @last, llvm_type(t1) unless case op
+                                                when "+", "-", "*", "|", "&", "^"
+                                                  case {t1.to_s, t2.to_s}
+                                                  when {"Int32", "Int64"},
+                                                       {"UInt32", "Int64"},
+                                                       {"UInt32", "UInt64"}
+                                                    true
+                                                  end
+                                                end
     end
 
     @last

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1872,6 +1872,15 @@ module Crystal
 
     def visit_binary(node)
       case typed_def.name
+      when "+", "-", "*", "|", "&", "^"
+        t1 = scope.remove_typedef
+        t2 = typed_def.args[0].type
+        case {t1.to_s, t2.to_s}
+        when {"Int32", "Int64"}, {"UInt32", "Int64"}, {"UInt32", "UInt64"}
+          return node.type = t2
+        end
+      end
+      case typed_def.name
       when "+", "-", "*", "/", "unsafe_div"
         t1 = scope.remove_typedef
         t2 = typed_def.args[0].type


### PR DESCRIPTION
In the case if both "a" and "b" are 64-bit variables, the expressions
like "(1 + a) * b" used to produce a 32-bit result. Which is the root
cause of rather annoying and hard to debug problems when doing 64-bit
integer calculations.

This patch promotes the result of the "+", "-", "*", "|", "&"
and "^" operaions to a 64-bit type if one of the operands is
64-bit.

Fixes https://github.com/crystal-lang/crystal/issues/567