### PR TITLE
Changed Crypto::Subtle.constant_time_compare to return a boolean.

### DIFF
--- a/spec/std/crypto/subtle_spec.cr
+++ b/spec/std/crypto/subtle_spec.cr
@@ -4,10 +4,10 @@ require "crypto/subtle"
 describe "Subtle" do
   it "compares constant times" do
     data = [
-      {"a" => Slice.new(1, 0x11), "b" => Slice.new(1, 0x11), "result" => 1},
-      {"a" => Slice.new(1, 0x12), "b" => Slice.new(1, 0x11), "result" => 0},
-      {"a" => Slice.new(1, 0x11), "b" => Slice.new(2) { |i| 0x11 + i }, "result" => 0},
-      {"a" => Slice.new(2) { |i| 0x11 + i }, "b" => Slice.new(1, 0x11), "result" => 0},
+      {"a" => Slice.new(1, 0x11), "b" => Slice.new(1, 0x11), "result" => true},
+      {"a" => Slice.new(1, 0x12), "b" => Slice.new(1, 0x11), "result" => false},
+      {"a" => Slice.new(1, 0x11), "b" => Slice.new(2) { |i| 0x11 + i }, "result" => false},
+      {"a" => Slice.new(2) { |i| 0x11 + i }, "b" => Slice.new(1, 0x11), "result" => false},
     ]
 
     data.each do |test|
@@ -32,6 +32,14 @@ describe "Subtle" do
   it "compares constant time bytes bug" do
     h1 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOa9lH9zigNKnksVaDwViFNgPU4WkrD53J"
     h2 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOaHlSGFuDDwMuVg6gOzdxQ0xN4rFOwMUn"
-    Crypto::Subtle.constant_time_compare(h1.to_slice, h2.to_slice).should eq(0)
+    Crypto::Subtle.constant_time_compare(h1, h2).should eq(false)
+  end
+
+  it "compares constant time and slices strings" do
+    h1 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOa9lH9zigNKnksVaDwViFNgPU4WkrD53J"
+    h2 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOaHlSGFuDDwMuVg6gOzdxQ0xN4rFOwMUn"
+
+    slice_result = Crypto::Subtle.constant_time_compare(h1.to_slice, h2.to_slice)
+    Crypto::Subtle.constant_time_compare(h1, h2).should eq(slice_result)
   end
 end

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -59,7 +59,7 @@ class Crypto::Bcrypt::Password
   # ```
   def ==(password)
     hashed_password = Bcrypt.new(password, salt, cost)
-    Crypto::Subtle.constant_time_compare(@raw_hash.to_slice, hashed_password.to_slice) == 1
+    Crypto::Subtle.constant_time_compare(@raw_hash, hashed_password)
   end
 
   def to_s(io)

--- a/src/crypto/subtle.cr
+++ b/src/crypto/subtle.cr
@@ -1,6 +1,15 @@
 module Crypto::Subtle
+  # Compares *x* and *y* in constant time and returns true if they are the same, and false if they are not.
+  # Note: *x* and *y* must be able to respond to `to_slice`.
+  #
+  # ```
+  # Crypto::Suble.constant_time_compare("foo","bar") => false
+  # Crypto::Suble.constant_time_compare("foo","foo") => true
+  # ```
   def self.constant_time_compare(x, y)
-    return 0 if x.size != y.size
+    x = x.to_slice
+    y = y.to_slice
+    return false if x.size != y.size
 
     v = 0_u8
 
@@ -8,7 +17,7 @@ module Crypto::Subtle
       v |= x[i] ^ y[i]
     end
 
-    constant_time_byte_eq(v, 0)
+    constant_time_byte_eq(v, 0) == 1
   end
 
   def self.constant_time_byte_eq(x, y)


### PR DESCRIPTION
In most use cases returning the actual difference is irrelevant when doing a constant time comparison. Where returning a boolean is what is expected.