### PR TITLE
Specs: JUnit formatter

### DIFF
--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -1,0 +1,135 @@
+require "spec"
+
+describe "JUnit Formatter" do
+  it "reports succesful results" do
+    output = build_report do |f|
+      f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil)
+      f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil)
+    end
+
+    expected = <<-XML
+                 <testsuite tests="2" errors="0" failed="0">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else">
+                 </testcase>
+                 </testsuite>
+                 XML
+
+    output.should eq(expected)
+  end
+
+  it "reports failures" do
+    output = build_report do |f|
+      f.report Spec::Result.new(:fail, "should do something", "spec/some_spec.cr", 33, nil)
+    end
+
+    expected = <<-XML
+                 <testsuite tests="1" errors="0" failed="1">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 <failure />
+                 </testcase>
+                 </testsuite>
+                 XML
+
+    output.should eq(expected)
+  end
+
+  it "reports errors" do
+    output = build_report do |f|
+      f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil)
+    end
+
+    expected = <<-XML
+                 <testsuite tests="1" errors="1" failed="0">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 <error />
+                 </testcase>
+                 </testsuite>
+                 XML
+
+    output.should eq(expected)
+  end
+
+  it "reports mixed results" do
+    output = build_report do |f|
+      f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, nil)
+      f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, nil)
+      f.report Spec::Result.new(:error, "should do something3", "spec/some_spec.cr", 65, nil)
+      f.report Spec::Result.new(:error, "should do something4", "spec/some_spec.cr", 80, nil)
+    end
+
+    expected = <<-XML
+                 <testsuite tests="4" errors="2" failed="1">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1">
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
+                 <failure />
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
+                 <error />
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
+                 <error />
+                 </testcase>
+                 </testsuite>
+                 XML
+
+    output.should eq(expected)
+  end
+
+  it "escapes spec names" do
+    output = build_report do |f|
+      f.report Spec::Result.new(:success, "complicated \" <n>'&ame", __FILE__, __LINE__, nil)
+    end
+
+    name = XML.parse(output).xpath_string("string(//testsuite/testcase[1]/@name)")
+    name.should eq("complicated \" <n>'&ame")
+  end
+
+  it "report failure stacktrace if present" do
+    cause = exception_with_backtrace("Something happened")
+
+    output = build_report do |f|
+      f.report Spec::Result.new(:fail, "foo", __FILE__, __LINE__, cause)
+    end
+
+    xml = XML.parse(output)
+    name = xml.xpath_string("string(//testsuite/testcase[1]/failure/@message)")
+    name.should eq("Something happened")
+
+    backtrace = xml.xpath_string("string(//testsuite/testcase[1]/failure/text())")
+    backtrace.should eq(cause.backtrace.join("\n"))
+  end
+
+  it "report error stacktrace if present" do
+    cause = exception_with_backtrace("Something happened")
+
+    output = build_report do |f|
+      f.report Spec::Result.new(:error, "foo", __FILE__, __LINE__, cause)
+    end
+
+    xml = XML.parse(output)
+    name = xml.xpath_string("string(//testsuite/testcase[1]/error/@message)")
+    name.should eq("Something happened")
+
+    backtrace = xml.xpath_string("string(//testsuite/testcase[1]/error/text())")
+    backtrace.should eq(cause.backtrace.join("\n"))
+  end
+end
+
+def build_report
+  output = String::Builder.new
+  formatter = Spec::JUnitFormatter.new(output)
+  yield formatter
+  formatter.finish
+  output.to_s
+end
+
+def exception_with_backtrace(msg)
+  begin
+    raise Exception.new(msg)
+  rescue e
+    e
+  end
+end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -119,7 +119,6 @@ describe "URI" do
       {"hello%252%2Bworld", "hello%2+world"},
       {"%E3%81%AA%E3%81%AA", "なな"},
       {"%27Stop%21%27%20said%20Fred", "'Stop!' said Fred"},
-      {"%FF", String.new(1) { |buf| buf.value = 255_u8; {1, 0} }},
       {"%0A", "\n"},
     ].each do |(from, to)|
       it "escapes #{to}" do
@@ -130,6 +129,20 @@ describe "URI" do
         String.build do |str|
           URI.escape(to, str)
         end.should eq(from)
+      end
+    end
+
+    describe "invalid utf8 strings" do
+      input = String.new(1) { |buf| buf.value = 255_u8; {1, 0} }
+
+      it "escapes without failing" do
+        URI.escape(input).should eq("%FF")
+      end
+
+      it "escapes to IO without failing" do
+        String.build do |str|
+          URI.escape(input, str)
+        end.should eq("%FF")
       end
     end
 

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -275,4 +275,18 @@ describe XML do
     doc = XML.parse(xml_str)
     doc.root.to_s.should eq("<person>\n  <name>たろう</name>\n</person>")
   end
+
+  describe "escape" do
+    it "does not change a safe string" do
+      str = XML.escape("safe_string")
+
+      str.should eq("safe_string")
+    end
+
+    it "escapes dangerous characters from a string" do
+      str = XML.escape("< & >")
+
+      str.should eq("&lt; &amp; &gt;")
+    end
+  end
 end

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -88,4 +88,12 @@ module Spec
   def self.formatters
     @@formatters
   end
+
+  def self.override_default_formatter(formatter)
+    @@formatters[0] = formatter
+  end
+
+  def self.add_formatter(formatter)
+    @@formatters << formatter
+  end
 end

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -1,0 +1,93 @@
+require "xml"
+
+module Spec
+  # :nodoc:
+  class JUnitFormatter < Formatter
+    @output : IO
+    @results = [] of Spec::Result
+    @summary = {} of Symbol => Int32
+
+    def initialize(@output)
+    end
+
+    def push(context)
+    end
+
+    def pop
+    end
+
+    def before_example(description)
+    end
+
+    def report(result)
+      current = @summary[result.kind]? || 0
+      @summary[result.kind] = current + 1
+      @results << result
+    end
+
+    def finish
+      io = @output
+      io << "<testsuite tests=\"#{@results.size}\" \
+                        errors=\"#{@summary[:error]? || 0}\" \
+                        failed=\"#{@summary[:fail]? || 0}\">\n"
+
+      @results.each { |r| write_report(r, io) }
+
+      io << "</testsuite>"
+      io.close
+    end
+
+    def self.file(output_dir)
+      Dir.mkdir_p(output_dir)
+      output_file_path = File.join(output_dir, "output.xml")
+      file = File.new(output_file_path, "w")
+      JUnitFormatter.new(file)
+    end
+
+    # -------- private utility methods
+    private def write_report(result, io)
+      io << "<testcase file=\"#{result.file}\" classname=\"#{classname(result)}\" name=\"#{XML.escape(result.description)}\">\n"
+
+      if (has_inner_content(result.kind))
+        tag = inner_content_tag(result.kind)
+        ex = result.exception
+        if ex
+          write_inner_content(tag, ex, io)
+        else
+          io << "<#{tag} />\n"
+        end
+      end
+
+      io << "</testcase>\n"
+    end
+
+    private def has_inner_content(kind)
+      kind == :fail || kind == :error
+    end
+
+    private def inner_content_tag(kind)
+      case kind
+      when :error
+        :error
+      when :fail
+        :failure
+      end
+    end
+
+    private def write_inner_content(tag, exception, io)
+      m = exception.message
+      if m
+        io << "<#{tag} message=\"#{XML.escape(m)}\">"
+      else
+        io << "<#{tag}>"
+      end
+      backtrace = exception.backtrace? || ([] of String)
+      io << XML.escape(backtrace.join("\n"))
+      io << "</#{tag}>\n"
+    end
+
+    private def classname(result)
+      result.file.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+    end
+  end
+end

--- a/src/spec/spec.cr
+++ b/src/spec/spec.cr
@@ -221,12 +221,16 @@ OptionParser.parse! do |opts|
       exit
     end
   end
+  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
+    junit_formatter = Spec::JUnitFormatter.file(output_dir)
+    Spec.add_formatter(junit_formatter)
+  end
   opts.on("--help", "show this help") do |pattern|
     puts opts
     exit
   end
   opts.on("-v", "--verbose", "verbose output") do
-    Spec.formatters.replace([Spec::VerboseFormatter.new])
+    Spec.override_default_formatter(Spec::VerboseFormatter.new)
   end
   opts.on("--no-color", "Disable colored output") do
     Spec.use_colors = false

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -27,7 +27,6 @@
 # end
 # ```
 module XML
-
   SUBSTITUTIONS = {
     '>' => "&gt;",
     '<' => "&lt;",

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -27,6 +27,19 @@
 # end
 # ```
 module XML
+
+  SUBSTITUTIONS = {
+    '>' => "&gt;",
+    '<' => "&lt;",
+    '"' => "&quot;",
+    ''' => "&apos;",
+    '&' => "&amp;",
+  }
+
+  def self.escape(string : String)
+    string.gsub(SUBSTITUTIONS)
+  end
+
   # Parses an XML document from *string* with *options* into an `XML::Node`.
   # See `ParserOptions.default` for default options.
   def self.parse(string : String, options : ParserOptions = ParserOptions.default) : Node


### PR DESCRIPTION
This PR adds the option to enable JUnit xml output to a file while running specs. This allows more detailed reporting of tests and API access to results in CircleCI. See:

https://circleci.com/blog/announcing-detailed-test-failure-reporting/
https://circleci.com/docs/test-metadata/

Usage:
```
# circle.yml
test:
  override:
    - mkdir "$CIRCLE_TEST_REPORTS/crystal"
    - crystal spec --junit_output "$CIRCLE_TEST_REPORTS/crystal/junit.xml"
```

This will displayed as:
![screen shot 2016-04-14 at 5 19 28 pm](https://cloud.githubusercontent.com/assets/753421/14542400/1d059c9c-0265-11e6-80c1-70c66609a1ba.png)

Also, this could be useful to integrate with other CI services in the future, since this format seems to be a de facto standard for reporting test results.