### PR TITLE
Fix indents in  spec/compiler/codegen/def_spec.cr

### DIFF
--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -95,8 +95,8 @@ describe "Code gen: def" do
           @next = n
         end
 
-         def next
-           @next
+        def next
+          @next
         end
       end
 
@@ -115,8 +115,8 @@ describe "Code gen: def" do
           @next = n
         end
 
-         def next
-           @next
+        def next
+          @next
         end
       end
 
@@ -127,8 +127,8 @@ describe "Code gen: def" do
           @next = n
         end
 
-         def next
-           @next
+        def next
+          @next
         end
       end
 


### PR DESCRIPTION
I've mentioned this in PR, but probably you haven't seen it