### PR TITLE
Add cache control headers to http static file handler + a few more mi…

### DIFF
--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "http/server"
 
-private def handle(request, fallthrough = true, directory_listing = true)
+private def handle(request, fallthrough = true, directory_listing = true, ignore_body = false)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
@@ -9,7 +9,7 @@ private def handle(request, fallthrough = true, directory_listing = true)
   handler.call context
   response.close
   io.rewind
-  HTTP::Client::Response.from_io(io)
+  HTTP::Client::Response.from_io(io, ignore_body)
 end
 
 describe HTTP::StaticFileHandler do
@@ -18,6 +18,22 @@ describe HTTP::StaticFileHandler do
   it "should serve a file" do
     response = handle HTTP::Request.new("GET", "/test.txt")
     response.status_code.should eq(200)
+    response.body.should eq(File.read("#{__DIR__}/static/test.txt"))
+  end
+
+  it "should return 304 (not modified) if file is not modified" do
+    headers = HTTP::Headers.new
+    headers["If-Modified-Since"] = File.stat("#{__DIR__}/static/test.txt").mtime.to_s("%a, %-d %h %C%y %T GMT")
+    response = handle HTTP::Request.new("GET", "/test.txt", headers), ignore_body: true
+    response.status_code.should eq(304)
+  end
+
+  it "should serve file if it is modified" do
+    headers = HTTP::Headers.new
+    headers["If-Modified-Since"] = Time.epoch(0).to_s("%a, %-d %h %C%y %T GMT")
+    response = handle HTTP::Request.new("GET", "/test.txt")
+    response.status_code.should eq(200)
+    response.headers["Last-Modified"].should eq(File.stat("#{__DIR__}/static/test.txt").mtime.to_s("%a, %-d %h %C%y %T GMT"))
     response.body.should eq(File.read("#{__DIR__}/static/test.txt"))
   end
 

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -71,7 +71,6 @@ class HTTP::StaticFileHandler
           return
         end
       end
-      context.response.headers["Cache-Control"] = "public"
       context.response.headers["Last-Modified"] = last_modified
       context.response.content_type = mime_type(file_path)
       context.response.content_length = File.size(file_path)

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -101,9 +101,6 @@ class HTTP::StaticFileHandler
     when ".htm", ".html" then "text/html"
     when ".css"          then "text/css"
     when ".js"           then "application/javascript"
-    when ".jpg"          then "image/jpeg"
-    when ".png"          then "image/png"
-    when ".svg"          then "image/svg+xml"
     else                      "application/octet-stream"
     end
   end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -64,14 +64,23 @@ class HTTP::StaticFileHandler
       context.response.content_type = "text/html"
       directory_listing(context.response, request_path, file_path)
     elsif is_file
-      last_modified = File.stat(file_path).mtime.to_s("%a, %-d %h %C%y %T GMT")
+      last_modified = File.stat(file_path).mtime
+      context.response.headers["Last-Modified"] = HTTP.rfc1123_date(last_modified)
+
       if if_modified_since = context.request.headers.fetch("If-Modified-Since", nil)
-        if last_modified == if_modified_since
+        # TODO: Use a more generalized time format parser for better compatibility to RFC 7232
+        header_time = Time.parse(if_modified_since, "%a, %d %b %Y %H:%M:%S GMT")
+
+        # File mtime probably has a higher resolution than the header value.
+        # An exact comparison might be slightly off, so we add 1s padding.
+        # Static files should generally not be modified in subsecond intervals, so this is perfectly safe.
+        # This might replaced by a more sophisticated time comparison when it becomes available.
+        if last_modified <= header_time + 1.second
           context.response.status_code = 304
           return
         end
       end
-      context.response.headers["Last-Modified"] = last_modified
+
       context.response.content_type = mime_type(file_path)
       context.response.content_length = File.size(file_path)
       File.open(file_path) do |file|

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -67,7 +67,7 @@ class HTTP::StaticFileHandler
       last_modified = File.stat(file_path).mtime
       context.response.headers["Last-Modified"] = HTTP.rfc1123_date(last_modified)
 
-      if if_modified_since = context.request.headers.fetch("If-Modified-Since", nil)
+      if if_modified_since = context.request.headers["If-Modified-Since"]?
         # TODO: Use a more generalized time format parser for better compatibility to RFC 7232
         header_time = Time.parse(if_modified_since, "%a, %d %b %Y %H:%M:%S GMT")
 


### PR DESCRIPTION
Was trying out Kemal and had a problem serving some static image files. It turned out that Kemal just uses the std library static file handler which does not define very many mime types. Added a few and thought it would also be nice to enable caching (Last-Modified / If-Modified-Since headers).

Hope you like it :)
