### PR TITLE
Compiler: guess types from `obj.tap { ... }` (guess from `obj`)

### DIFF
--- a/spec/compiler/type_inference/instance_var_spec.cr
+++ b/spec/compiler/type_inference/instance_var_spec.cr
@@ -2112,6 +2112,48 @@ describe "Type inference: instance var" do
       )) { int32 }
   end
 
+  it "infers from tap" do
+    assert_type(%(
+      require "prelude"
+
+      class Bar
+      end
+
+      class Foo
+        def initialize
+          @x = Bar.new.tap { }
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { types["Bar"] }
+  end
+
+  it "infers from tap in generic type" do
+    assert_type(%(
+      require "prelude"
+
+      class Bar
+      end
+
+      class Foo(T)
+        def initialize
+          @x = T.new.tap { }
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo(Bar).new.x
+      )) { types["Bar"] }
+  end
+
   # -----------------
   # ||| OLD SPECS |||
   # vvv           vvv


### PR DESCRIPTION
Related to #2443

This adds a new rule to guess, in an expression like

```crystal
@x = obj.tap { ... }
```

the type from `obj` (`obj` can be a literal, a `T.new`, etc.)

The reasons for this are [here](https://github.com/crystal-lang/crystal/pull/2443#issuecomment-211016065). The reasons against it is that this rule needs to be learned and documented, but I think `tap` is a very useful construct that you eventually learn, and it's specially useful when initializing/configuring an object for the first time. 