### PR TITLE
Use `$HOME/.crystal` as the default cache dir.

### DIFF
--- a/src/compiler/crystal/codegen/cache_dir.cr
+++ b/src/compiler/crystal/codegen/cache_dir.cr
@@ -1,0 +1,131 @@
+module Crystal
+  # Manages cache files in the ".crystal" directory.
+  #
+  # For each compiled program a directory is created in the cache
+  # that stores .bc and .o files that could possibly be reused
+  # from a previous compilation.
+  #
+  # To keep the cache dir small, only the 10 most recently used
+  # directories are kept. We use the directory's modification
+  # time for this.
+  class CacheDir
+    def self.instance
+      @@instance ||= new
+    end
+
+    @dir : String?
+
+    private def initialize
+    end
+
+    # Returns the directory where cache files related to the
+    # given sources will be stored. The directory will be
+    # created if it doesn't exist.
+    def directory_for(sources : Array(Compiler::Source))
+      directory_for(sources.first.filename)
+    end
+
+    # Returns the directory where cache files related to the
+    # given filenames will be stored. The directory will be
+    # created if it doesn't exist.
+    def directory_for(filename : String)
+      dir = compute_dir
+
+      name = filename.gsub('/', '-')
+      while name.starts_with?('-')
+        name = name[1..-1]
+      end
+      output_dir = File.join(dir, name)
+      Dir.mkdir_p(output_dir)
+      output_dir
+    end
+
+    # Keeps the 10 most recently used directories in the cache,
+    # and removes all others. This also removes non-directory
+    # files inside the cache directory (temporary executables
+    # resulting from `crystal run` or `run` macro calls).
+    def cleanup
+      dir = compute_dir
+      entries = gather_cache_entries(dir)
+      cleanup_dirs(entries)
+      cleanup_files(entries)
+    end
+
+    # Returns a filename that has prepended the cache directory.
+    def join(filename)
+      dir = compute_dir
+      File.join(dir, filename)
+    end
+
+    # Returns the cache directory.
+    def dir
+      compute_dir
+    end
+
+    private def compute_dir
+      dir = @dir
+      return dir if dir
+
+      # Try to use one of these as a cache directory, in order
+      candidates = [
+        ENV["CRYSTAL_CACHE_DIR"]?,
+        ENV["XDG_CACHE_HOME"]?.try { |home| "#{home}/crystal" },
+        ENV["HOME"]?.try { |home| "#{home}/.cache/crystal" },
+        ENV["HOME"]?.try { |home| "#{home}/.crystal" },
+        ".crystal",
+      ]
+      candidates = candidates
+        .compact
+        .map { |file| File.expand_path(file) }
+        .uniq
+
+      # Return the first one for which we could create a directory
+      candidates.each do |candidate|
+        begin
+          Dir.mkdir_p(candidate)
+          return @dir = candidate
+        rescue Errno
+          # Try next one
+        end
+      end
+
+      msg = String.build do |io|
+        io.puts "Error: can't create cache directory."
+        io.puts
+        io.puts "Crystal needs a cache directory. These directories were candidates for it:"
+        io.puts
+        candidates.each do |candidate|
+          io << " - " << candidate << "\n"
+        end
+        io.puts
+        io.puts "but none of them are writable."
+        io.puts
+        io.puts "Please specify a writable cache directory by setting the CRYSTAL_CACHE_DIR environment variable."
+      end
+
+      puts msg
+      exit 1
+    end
+
+    private def cleanup_dirs(entries)
+      entries
+        .select { |dir| Dir.exists?(dir) }
+        .sort_by! { |dir| File.stat(dir).mtime rescue Time.epoch(0) }
+        .reverse!
+        .skip(10)
+        .each { |name| `rm -rf "#{name}"` rescue nil }
+    end
+
+    private def cleanup_files(entries)
+      entries
+        .select { |dir| File.file?(dir) }
+        .each { |name| File.delete(name) rescue nil }
+    end
+
+    private def gather_cache_entries(dir)
+      Dir.entries(dir)
+         .reject { |name| name == "." || name == ".." }
+         .map! { |name| File.join(dir, name) }
+    end
+  end
+end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -132,9 +132,10 @@ module Crystal
       realfile = case file
                  when String then file
                  when VirtualFile
-                   Dir.mkdir_p(".crystal")
-                   File.write(".crystal/macro#{file.object_id}.cr", file.source)
-                   ".crystal/macro#{file.object_id}.cr"
+                   filename = "macro#{file.object_id}.cr"
+                   absolute_filename = CacheDir.instance.join(filename)
+                   File.write(absolute_filename, file.source)
+                   absolute_filename
                  else
                    raise "Unknown file type: #{file}"
                  end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -171,8 +171,9 @@ class Crystal::Command
     end
 
     vars = {
-      "CRYSTAL_PATH":    CrystalPath::DEFAULT_PATH,
-      "CRYSTAL_VERSION": Config::VERSION || "",
+      "CRYSTAL_CACHE_DIR": CacheDir.instance.dir,
+      "CRYSTAL_PATH":      CrystalPath::DEFAULT_PATH,
+      "CRYSTAL_VERSION":   Config::VERSION || "",
     }
 
     if ARGV.empty?
@@ -309,8 +310,10 @@ class Crystal::Command
       end
     end
 
+    source_filename = File.expand_path("spec")
+
     source = target_filenames.map { |filename| %(require "./#{filename}") }.join("\n")
-    sources = [Compiler::Source.new("spec", source)]
+    sources = [Compiler::Source.new(source_filename, source)]
 
     output_filename = tempfile "spec"
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -149,13 +149,15 @@ module Crystal
         program.codegen node, debug: @debug, single_module: @single_module || @release || @cross_compile_flags || @emit, expose_crystal_main: false
       end
 
+      cache_dir = CacheDir.instance
+
       if @cross_compile_flags
         output_dir = "."
       else
-        output_dir = File.join(Config.cache_dir, sources.first.filename)
+        output_dir = cache_dir.directory_for(sources)
       end
 
-      Dir.mkdir_p(output_dir)
+      cache_dir.cleanup
 
       bc_flags_changed = check_bc_flags_changed output_dir
 

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -1,13 +1,6 @@
 module Crystal
   module Config
-    PATH      = {{ env("CRYSTAL_CONFIG_PATH") || "" }}
-    VERSION   = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long 2>/dev/null)`.stringify.chomp }}
-    CACHE_DIR = ENV["CRYSTAL_CACHE_DIR"]? || ".crystal"
-
-    @@cache_dir : String?
-
-    def self.cache_dir
-      @@cache_dir ||= File.expand_path(CACHE_DIR)
-    end
+    PATH    = {{ env("CRYSTAL_CONFIG_PATH") || "" }}
+    VERSION = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long 2>/dev/null)`.stringify.chomp }}
   end
 end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -39,7 +39,6 @@ module Crystal
   end
 
   def self.tempfile(basename)
-    Dir.mkdir_p Config.cache_dir
-    File.join(Config.cache_dir, "crystal-run-#{basename}.tmp")
+    CacheDir.instance.join("crystal-run-#{basename}.tmp")
   end
 end


### PR DESCRIPTION
And only keep the 10 most recently used directories. Fixes #2435.

The default directory will now be `$HOME/.crystal` so we don't end up with `.crystal` directories everywhere.

I considered @will's [comment](https://github.com/crystal-lang/crystal/issues/2435#issuecomment-211416861) about ignoring `eval` in this, but since we are keeping 10 most recently used directories, and `eval` is always assigned a same directory, the case where a very used directory is evicted is very unlikely, you must be working on 10 programs at the same time, plus using eval. When you run `crystal spec` a `spec` directory inside the cache is also used. In conclusion, probably the 8 most used programs are kept in this cache, if we consider `eval` and `spec` to always be present, which I think it's still good and it keeps the compiler's logic simple.  