### PR TITLE
File::Stat: return local time for atime, ctime and mtime

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -242,6 +242,17 @@ describe "File" do
     end
   end
 
+  it "should return local times for atime, ctime and mtime" do
+    tmp = Tempfile.new "tmp"
+    begin
+      tmp.stat.atime.local?.should be_true
+      tmp.stat.ctime.local?.should be_true
+      tmp.stat.mtime.local?.should be_true
+    ensure
+      tmp.delete
+    end
+  end
+
   describe "size" do
     assert { File.size("#{__DIR__}/data/test_file.txt").should eq(240) }
     assert do

--- a/src/file/stat.cr
+++ b/src/file/stat.cr
@@ -207,7 +207,7 @@ class File
     end
 
     private def time(value)
-      Time.new value, Time::Kind::Utc
+      Time.new(value, Time::Kind::Utc).to_local
     end
   end
 end


### PR DESCRIPTION
``` crystal
stat = File.stat(__FILE__)
pp stat.atime
pp stat.mtime
pp stat.ctime
```

Before:

```
stat.atime = 2016-04-18 17:07:24 UTC
stat.mtime = 2016-04-18 17:07:19 UTC
stat.ctime = 2016-04-18 17:07:19 UTC
```

After:

```
stat.atime = 2016-04-18 14:07:53 -0300
stat.mtime = 2016-04-18 14:07:19 -0300
stat.ctime = 2016-04-18 14:07:19 -0300
```

I think it's easier to work with local times regarding file information.
