### PR TITLE
Guess types from `T.method`, if `T.method` has a return type annotation

### DIFF
--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -319,14 +319,16 @@ module Crystal
 
         1. `#{example_name} = 1` (or other literals), inferred to the literal's type
         2. `#{example_name} = Type.new`, type is inferred to be Type
-        3. `#{example_name} = arg`, with 'arg' being a method argument with a
-           type restriction 'Type', type is inferred to be Type
+        3. `#{example_name} = Type.method`, where `method` has a return type
+           annotation, type is inferred from it
         4. `#{example_name} = arg`, with 'arg' being a method argument with a
-           default value, type is inferred using rules 1 and 2 from it
-        5. `#{example_name} = uninitialized Type`, type is inferred to be Type
-        6. `#{example_name} = LibSome.func`, and `LibSome` is a `lib`, type
+           type restriction 'Type', type is inferred to be Type
+        5. `#{example_name} = arg`, with 'arg' being a method argument with a
+           default value, type is inferred using rules 1, 2 and 3 from it
+        6. `#{example_name} = uninitialized Type`, type is inferred to be Type
+        7. `#{example_name} = LibSome.func`, and `LibSome` is a `lib`, type
            is inferred from that fun.
-        7. `LibSome.func(out #{example_name})`, and `LibSome` is a `lib`, type
+        8. `LibSome.func(out #{example_name})`, and `LibSome` is a `lib`, type
            is inferred from that fun argument.
 
       Other assignments have no effect on its type.

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -67,6 +67,7 @@ module Crystal
 
     def visit(node : Generic)
       node.name.accept self
+      return false if !@raise && !@type
 
       instance_type = self.type
       unless instance_type.is_a?(GenericClassType)


### PR DESCRIPTION
This change makes it so that this:

```crystal
class Bar
  def self.from_string("hello") : Bar
    Bar.new # or something more complex
  end
end

class Foo
  def initialize
    @value = Bar.from_string("hello")
  end
end
```

compiles without needing a type annotation on `@value` of `Foo` because `Bar.from_string` has itself a return type annotation.

This rule is only applied if the expression is `T.method(...)`, where `T` must be a constant or a generic type (like `Foo` or `Foo(Int32)`). In something like `local_variable.method`, or even `T.method1.method2` the rule won't be applied.

Given the proper type annotations in these "factory" methods, a lot of type annotations won't be needed. Factory (or factory-like) methods are very useful and common. For example:

* `Time.now`
* `Array(Int32).from_json(...)`
* `Fiber.current`
* `Dir.glob("...")`
* `Base64.encode(...)`
* (and many others)

Now, let's see the pros and cons.

Pros:
* Only one type annotation is needed for a method's return type, instead of having to add this annotation in every type that sets an instance variable using this factory method. Right now if I do `@time = Time.now` I also have to add `@time : Time`. With this change we just need to add the annotation in `def Time.now : Time`.

Cons:
* This is one more rule needed to learn (and we should probably list it in the error message).
* The rules become much more hippie and maybe harder to understand.

Does this mean that the best thing to do is to add return type annotations everywhere? No, only in class methods that are probably going to be used to initialize an object ("factory" methods). And, if I forget to add such return type annotation I can always add it to the instance variable that uses it.

Our main fear with this change is confusion. However, the way I see it, you can use the language without adding type annotations. Then the compiler will tell you "I can't infer the type of this". Then you decide how to make the compiler know the type: either adding a type annotation in that variable, or if it's being initialized with a factory method you could add a return type annotation there. Problem solved. I mean, before these changes the language was much more chaotic, inferring types from every possible expression. This makes it be closer to the old behaviour, but in a more organized and strict way.

I didn't include return type annotations for `Time.now` and others here, but we can add them if this PR gets accepted. 
