### PR TITLE
Add `as` special method. Fixes #2482

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -861,4 +861,10 @@ describe Crystal::Formatter do
 
   assert_format "page= <<-HTML\n  foo\nHTML", "page = <<-HTML\n  foo\nHTML"
   assert_format "page= <<-HTML\n  \#{1}foo\nHTML", "page = <<-HTML\n  \#{1}foo\nHTML"
+
+  assert_format "foo.as ( Int32* )", "foo.as(Int32*)"
+  assert_format "foo.as   Int32*", "foo.as Int32*"
+  assert_format "foo.as(T).bar"
+  assert_format "foo &.as(T)"
+  assert_format "foo &.bar.as(T)"
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -366,6 +366,7 @@ describe "Parser" do
   it_parses "foo &.[0] = 1", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "[]=", 0.int32, 1.int32)))
   it_parses "foo(&.is_a?(T))", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], IsA.new(Var.new("__arg0"), "T".path)))
   it_parses "foo(&.responds_to?(:foo))", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], RespondsTo.new(Var.new("__arg0"), "foo")))
+  it_parses "foo(&.as(T))", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Cast.new(Var.new("__arg0"), "T".path)))
   it_parses "foo &.each {\n}", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
   it_parses "foo &.each do\nend", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
 
@@ -966,6 +967,12 @@ describe "Parser" do
   it_parses "foo as Bar", Cast.new("foo".call, "Bar".path)
   it_parses "foo.bar as Bar", Cast.new(Call.new("foo".call, "bar"), "Bar".path)
   it_parses "call(foo as Bar, Baz)", Call.new(nil, "call", args: [Cast.new("foo".call, "Bar".path), "Baz".path])
+
+  it_parses "1.as Bar", Cast.new(1.int32, "Bar".path)
+  it_parses "1.as(Bar)", Cast.new(1.int32, "Bar".path)
+  it_parses "foo.as(Bar)", Cast.new("foo".call, "Bar".path)
+  it_parses "foo.bar.as(Bar)", Cast.new(Call.new("foo".call, "bar"), "Bar".path)
+  it_parses "call(foo.as Bar, Baz)", Call.new(nil, "call", args: [Cast.new("foo".call, "Bar".path), "Baz".path])
 
   it_parses "typeof(1)", TypeOf.new([1.int32] of ASTNode)
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -615,6 +615,8 @@ module Crystal
 
           if @token.value == :is_a?
             atomic = parse_is_a(atomic).at(location)
+          elsif @token.value == :as
+            atomic = parse_as(atomic).at(location)
           elsif @token.value == :responds_to?
             atomic = parse_responds_to(atomic).at(location)
           elsif @token.value == :nil?
@@ -774,6 +776,22 @@ module Crystal
       end
 
       IsA.new(atomic, type)
+    end
+
+    def parse_as(atomic)
+      next_token_skip_space
+
+      if @token.type == :"("
+        next_token_skip_space_or_newline
+        type = parse_single_type
+        skip_space
+        check :")"
+        next_token_skip_space
+      else
+        type = parse_single_type(allow_commas: false)
+      end
+
+      Cast.new(atomic, type)
     end
 
     def parse_responds_to(atomic)
@@ -1367,6 +1385,8 @@ module Crystal
 
         if @token.value == :is_a?
           call = parse_is_a(obj).at(location)
+        elsif @token.value == :as
+          call = parse_as(obj).at(location)
         elsif @token.value == :responds_to?
           call = parse_responds_to(obj).at(location)
         elsif @token.value == :nil?


### PR DESCRIPTION
This PR doesn't make the formatter upgrade to the new syntax, mostly because travis will try to check that no changes are made when formatting the code, but there will be changes (we could skip that check, but I prefer not to). In 0.16.0 we can do this, and in 0.17.0 we can deprecate/remove the current syntax.