### PR TITLE
JSON: preserve raw string. Fixes #2506

### DIFF
--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -37,6 +37,7 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
     token = lexer.next_token
     token.type.should eq(:INT)
     token.int_value.should eq(int_value)
+    token.raw_value.should eq(string)
   end
 
   it "lexes #{string} from IO", file, line do
@@ -44,6 +45,7 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
     token = lexer.next_token
     token.type.should eq(:INT)
     token.int_value.should eq(int_value)
+    token.raw_value.should eq(string)
   end
 end
 
@@ -53,6 +55,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
     token = lexer.next_token
     token.type.should eq(:FLOAT)
     token.float_value.should eq(float_value)
+    token.raw_value.should eq(string)
   end
 
   it "lexes #{string} from IO", file, line do
@@ -60,6 +63,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
     token = lexer.next_token
     token.type.should eq(:FLOAT)
     token.float_value.should eq(float_value)
+    token.raw_value.should eq(string)
   end
 end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -112,6 +112,12 @@ class JSONWithTimeEpochMillis
   })
 end
 
+class JSONWithRaw
+  JSON.mapping({
+    value: {type: String, converter: String::RawConverter},
+  })
+end
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -320,6 +326,27 @@ describe "JSON mapping" do
     json = JSONWithTimeEpochMillis.from_json(string)
     json.value.should be_a(Time)
     json.value.should eq(Time.epoch_ms(1459860483856))
+    json.to_json.should eq(string)
+  end
+
+  it "parses raw value from int" do
+    string = %({"value":123456789123456789123456789123456789})
+    json = JSONWithRaw.from_json(string)
+    json.value.should eq("123456789123456789123456789123456789")
+    json.to_json.should eq(string)
+  end
+
+  it "parses raw value from float" do
+    string = %({"value":123456789123456789.123456789123456789})
+    json = JSONWithRaw.from_json(string)
+    json.value.should eq("123456789123456789.123456789123456789")
+    json.to_json.should eq(string)
+  end
+
+  it "parses raw value from object" do
+    string = %({"value":[null,true,false,{"x":[1,1.5]}]})
+    json = JSONWithRaw.from_json(string)
+    json.value.should eq(%([null,true,false,{"x":[1,1.5]}]))
     json.to_json.should eq(string)
   end
 end

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -111,6 +111,13 @@ private def assert_pull_parse_error(string)
   end
 end
 
+private def assert_raw(string, file = __FILE__, line = __LINE__)
+  it "parses raw #{string.inspect}", file, line do
+    pull = JSON::PullParser.new(string)
+    pull.read_raw.should eq(string)
+  end
+end
+
 describe JSON::PullParser do
   assert_pull_parse "null"
   assert_pull_parse "false"
@@ -285,5 +292,16 @@ describe JSON::PullParser do
         end
       end
     end
+  end
+
+  describe "raw" do
+    assert_raw "null"
+    assert_raw "true"
+    assert_raw "false"
+    assert_raw "1234"
+    assert_raw "1234.5678"
+    assert_raw %("hello")
+    assert_raw %([1,"hello",true,false,null,[1,2,3]])
+    assert_raw %({"foo":[1,2,{"bar":[1,"hello",true,false,1.5]}]})
   end
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -1,5 +1,7 @@
 require "spec"
 require "json"
+require "big"
+require "big/json"
 
 enum JSONSpecEnum
   Zero
@@ -63,6 +65,24 @@ describe "JSON serialization" do
       tuple = Tuple(Int32, String).from_json(%([1, "hello"]))
       tuple.should eq({1, "hello"})
       tuple.should be_a(Tuple(Int32, String))
+    end
+
+    it "does for BigInt" do
+      big = BigInt.from_json("123456789123456789123456789123456789123456789")
+      big.should be_a(BigInt)
+      big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
+    end
+
+    it "does for BigFloat" do
+      big = BigFloat.from_json("1234.567891011121314")
+      big.should be_a(BigFloat)
+      big.should eq(BigFloat.new("1234.567891011121314"))
+    end
+
+    it "does for BigFloat from int" do
+      big = BigFloat.from_json("1234")
+      big.should be_a(BigFloat)
+      big.should eq(BigFloat.new("1234"))
     end
 
     # TODO: uncomment after 0.15.0
@@ -147,6 +167,16 @@ describe "JSON serialization" do
 
     it "does for Enum" do
       JSONSpecEnum::One.to_json.should eq("1")
+    end
+
+    it "does for BigInt" do
+      big = BigInt.new("123456789123456789123456789123456789123456789")
+      big.to_json.should eq("123456789123456789123456789123456789123456789")
+    end
+
+    it "does for BigFloat" do
+      big = BigFloat.new("1234.567891011121314")
+      big.to_json.should eq("1234.567891011121314")
     end
   end
 

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -1,5 +1,7 @@
 require "spec"
 require "yaml"
+require "big"
+require "big/yaml"
 
 enum YAMLSpecEnum
   Zero
@@ -58,6 +60,18 @@ describe "YAML serialization" do
 
     it "does Tuple#from_yaml" do
       Tuple(Int32, String, Bool).from_yaml("---\n- 1\n- foo\n- true\n").should eq({1, "foo", true})
+    end
+
+    it "does for BigInt" do
+      big = BigInt.from_yaml("123456789123456789123456789123456789123456789")
+      big.should be_a(BigInt)
+      big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
+    end
+
+    it "does for BigFloat" do
+      big = BigFloat.from_yaml("1234.567891011121314")
+      big.should be_a(BigFloat)
+      big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
     # TODO: uncomment after 0.15.0
@@ -135,6 +149,16 @@ describe "YAML serialization" do
 
     it "does for Tuple" do
       Tuple(Int32, String).from_yaml({1, "hello"}.to_yaml).should eq({1, "hello"})
+    end
+
+    it "does for BigInt" do
+      big = BigInt.new("123456789123456789123456789123456789123456789")
+      BigInt.from_yaml(big.to_yaml).should eq(big)
+    end
+
+    it "does for BigFloat" do
+      big = BigFloat.new("1234.567891011121314")
+      BigFloat.from_yaml(big.to_yaml).should eq(big)
     end
 
     # TODO: uncomment after 0.15.0

--- a/src/big/big.cr
+++ b/src/big/big.cr
@@ -1,1 +1,4 @@
-require "./*"
+require "./lib_gmp"
+require "./big_int"
+require "./big_float"
+require "./big_rational"

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -1,4 +1,4 @@
-require "./*"
+require "./big"
 
 # A BigInt can represent arbitrarily large floats.
 #

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -1,4 +1,4 @@
-require "./*"
+require "./big"
 
 # A BigInt can represent arbitrarily large integers.
 #

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -1,4 +1,4 @@
-require "./*"
+require "./big"
 
 # Rational numbers are represented as the quotient of arbitrarily large
 # numerators and denominators. Rationals are canonicalized such that the

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -1,0 +1,12 @@
+require "json"
+require "./big"
+
+def BigInt.new(pull : JSON::PullParser)
+  pull.read_int
+  BigInt.new(pull.raw_value)
+end
+
+def BigFloat.new(pull : JSON::PullParser)
+  pull.read_float
+  BigFloat.new(pull.raw_value)
+end

--- a/src/big/yaml.cr
+++ b/src/big/yaml.cr
@@ -1,0 +1,10 @@
+require "yaml"
+require "./big"
+
+def BigInt.new(pull : YAML::PullParser)
+  BigInt.new(pull.read_scalar)
+end
+
+def BigFloat.new(pull : YAML::PullParser)
+  BigFloat.new(pull.read_scalar)
+end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -149,3 +149,9 @@ module Time::EpochMillisConverter
     Time.epoch_ms(value.read_int)
   end
 end
+
+module String::RawConverter
+  def self.from_json(value : JSON::PullParser)
+    value.read_raw
+  end
+end

--- a/src/json/lexer/io_based.cr
+++ b/src/json/lexer/io_based.cr
@@ -14,4 +14,16 @@ class JSON::Lexer::IOBased < JSON::Lexer
   private def consume_string
     consume_string_with_buffer
   end
+
+  private def number_start
+    @buffer.clear
+  end
+
+  private def append_number_char
+    @buffer << current_char
+  end
+
+  private def number_end
+    @token.raw_value = @buffer.to_s
+  end
 end

--- a/src/json/lexer/string_based.cr
+++ b/src/json/lexer/string_based.cr
@@ -3,6 +3,7 @@ class JSON::Lexer::StringBased < JSON::Lexer
   def initialize(string)
     super()
     @reader = Char::Reader.new(string)
+    @number_start = 0
   end
 
   # Consume a string by remembering the start position of it and then
@@ -59,5 +60,17 @@ class JSON::Lexer::StringBased < JSON::Lexer
 
   private def current_char
     @reader.current_char
+  end
+
+  private def number_start
+    @number_start = current_pos
+  end
+
+  private def append_number_char
+    # Nothing
+  end
+
+  private def number_end
+    @token.raw_value = string_range(@number_start, current_pos)
   end
 end

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -320,3 +320,29 @@ module Time::EpochMillisConverter
     io << value.epoch_ms
   end
 end
+
+# Converter to be used with `JSON.mapping` to read the raw
+# value of a JSON object property as a String.
+#
+# It can be useful to read ints and floats without loosing precision,
+# or to read an object and deserialize it later based on some
+# condition.
+#
+# ```
+# require "json"
+#
+# class Raw
+#   JSON.mapping({
+#     value: {type: String, converter: String::RawConverter},
+#   })
+# end
+#
+# raw = Raw.from_json(%({"value": 123456789876543212345678987654321}))
+# raw.value   # => "123456789876543212345678987654321"
+# raw.to_json # => %({"value":123456789876543212345678987654321})
+# ```
+module String::RawConverter
+  def self.to_json(value : String, io : IO)
+    io << value
+  end
+end

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -5,6 +5,7 @@ class JSON::Token
   property float_value : Float64
   property line_number : Int32
   property column_number : Int32
+  property raw_value : String
 
   def initialize
     @type = :EOF
@@ -13,6 +14,7 @@ class JSON::Token
     @string_value = ""
     @int_value = 0_i64
     @float_value = 0.0
+    @raw_value = ""
   end
 
   def to_s(io)


### PR DESCRIPTION
This adds a few things:

* The lexer now keeps the raw string for ints and floats, and exposes it
* The pull parser too
* BigInt and BigFloat use this for JSON/YAML parsing (to use it, `require "big/json"`)
* Instead of adding a `raw` option in the `JSON.mapping` macro I decided to add a `String::RawConverter` so the mapping code doesn't need to change. In this way, if you need a big value but don't want to work with it as a BigInt/BigFloat you can still do it (maybe you just need to store it from an API but not to process it, or process it later)