### PR TITLE
Fix filtering of `allocate` for doc-gen

### DIFF
--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -217,7 +217,7 @@ class Crystal::Doc::Type
               body = a_def.body
 
               # Skip auto-generated allocate method
-              if body.is_a?(Crystal::Primitive) && body.name == :allocate
+              if body.is_a?(Crystal::Primitive) && body.name == "allocate"
                 next
               end
 


### PR DESCRIPTION
`Crystal::Primitive#@name` is `String`, so compare failed always.