### PR TITLE
Compiler: try to infer types from class method bodies

### DIFF
--- a/spec/compiler/type_inference/global_spec.cr
+++ b/spec/compiler/type_inference/global_spec.cr
@@ -189,7 +189,8 @@ describe "Global inference" do
     assert_error %(
       class Foo(T)
         def self.new
-          10
+          a = 10
+          a
         end
       end
 


### PR DESCRIPTION
This is a complement to #2486 to need less type annotations in class methods.

After #2486, this is possible:

```crystal
class Foo
  def initialize
    # Inferred to Bar, because Bar.create has a return type annotation
    @value = Bar.create
  end
end

class Bar
  def self.create : self
    new
  end
end
```

However, the `self` return type annotation is not really needed. If it's not there, the compiler could check the method's body and see it's a simple call to `new`, and from there infer the type to be `Bar`.

Effectively, this PR does just that: the `self` return type annotation is not needed anymore in this case.

This PR does more: it applies the usual guessing rules to a class method's body. So this works too:

```crystal
class Foo
  def initialize
    # Inferred to Int32, because default_size's body is a literal
    @size = Foo.default_size
  end

  def self.default_size
    1
  end
end
```

And if inside the method a class method is invoked, and the class method has a return type, the return type is used:

```crystal
class Foo
  def initialize
    # Inferred to String, because Foo.default_name's body
    # is String.build, and String.build has a self return
    # type annotation
    @name = Foo.default_name
  end

  def self.default_name
    String.build do |str|
      # some stuff...
    end
  end
end

class String
  def self.build : self
    # The implementation...
  end
end
```

Ultimately, as always, the goal is to reduce redundant type annotations if the compiler (and a human) can easily infer them ("easily" == no need to do type flow analysis on local vars, or depend on the type of other instance/class/global variables).

I think that the less type annotations we require from a programmer, the happier she'll be (as in Ruby).

The downside of this PR, as usual, is that it makes the rules a bit more complex. But the only moment where you'll get a "can't infer the type of ..." error is when you are defining a class and defining its constructor or adding more instance vars, and at that moment if the compiler can't infer the type for you, you can simply add a type annotation. 