### PR TITLE
Fix comment about how the initialize method is generated

### DIFF
--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -139,8 +139,8 @@ module Crystal
       # This creates:
       #
       #    x = allocate
-      #    GC.add_finalizer x
       #    x.initialize ..., &block
+      #    GC.add_finalizer x if x.responds_to? :finalize
       #    x
       var = Var.new("_")
       new_vars = args.map { |arg| Var.new(arg.name) as ASTNode }


### PR DESCRIPTION
Very small change. If `initialize` raises, the finalize method will never be called, it is added to the GC after.