### PR TITLE
Replace Pygments with Rouge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 gem 'github-pages'
+gem 'rouge'
 gem 'haml'
 gem 'less'
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     rdiscount (2.1.7)
     redcarpet (3.3.2)
     ref (2.0.0)
+    rouge (1.10.1)
     safe_yaml (1.0.4)
     sass (3.4.18)
     terminal-table (1.5.2)
@@ -148,7 +149,8 @@ DEPENDENCIES
   haml
   less
   rake
+  rouge
   therubyracer
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: Crystal Programming Language
 description: Crystal Programming Language's blog
 url: http://crystal-lang.org
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown


### PR DESCRIPTION
Pygments in Jekyll is broken, in a rather cryptic way, for many
people. The recommendation is to switch to Rouge for syntax
highlighting:

https://github.com/jekyll/jekyll/issues/2604#issuecomment-49099487

There are claims by the authors of Jekyll that certain version
of Python will work, however many people in issue comments have
claimed this not to be the case.

https://github.com/jekyll/jekyll/search?utf8=%E2%9C%93&q=%22Failed+to+get+header%22&type=Issues

For this reason I believe the best course of action is to
change to Rogue, instead of instructing people to use old
versions of Python which may not fix the problem.


Before this fix running the commands the the contributor guide result in the following error:

```shell
>(gh-pages ✔) rake build && jekyll serve
Parsed haml layout files
Parsed haml include files
Parsed haml index files
Parsed main.sass
info: loading book configuration....OK
info: >> 0 plugins loaded
info: start generation with website generator
info: clean website generatorOK
info: generation is finished

Done, without error
Configuration file: /Users/yolo/source/crystal/_config.yml
            Source: /Users/yolo/source/crystal
       Destination: /Users/yolo/source/crystal/_site
      Generating...
  Liquid Exception: No header received back. in _posts/2013-07-10-hello-world.md
jekyll 2.4.0 | Error:  No header received back.
```