### PR TITLE
Fix to_s: `responds_to?`. Fix msg in parser, same.

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -50,4 +50,6 @@ describe "ASTNode#to_s" do
   expect_to_s "foo._bar"
   expect_to_s "foo._bar(1)"
   expect_to_s "_foo.bar"
+  expect_to_s "1.responds_to?(:to_s)"
+  expect_to_s "1.responds_to?(:\"&&\")"
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -798,7 +798,7 @@ module Crystal
 
     def parse_responds_to_name
       if @token.type != :SYMBOL
-        unexpected_token msg: "expected name or symbol"
+        unexpected_token msg: "expected symbol"
       end
 
       @token.value.to_s

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -43,9 +43,11 @@ module Crystal
     end
 
     def visit(node : SymbolLiteral)
-      @str << ':'
+      visit_symbol_literal_value node.value
+    end
 
-      value = node.value
+    def visit_symbol_literal_value(value : String)
+      @str << ':'
       if Symbol.needs_quotes?(value)
         value.inspect(@str)
       else
@@ -1118,7 +1120,9 @@ module Crystal
 
     def visit(node : RespondsTo)
       node.obj.accept self
-      @str << ".responds_to?(" << node.name << ")"
+      @str << ".responds_to?("
+      visit_symbol_literal_value node.name
+      @str << ")"
       false
     end
 


### PR DESCRIPTION
Seemed unnecessary to bloat specs with test for this.

The to_s problem (testing with to_s, LOL):
```crystal
pp 1.responds_to? :to_s
```

The message in the parser:
```crystal
1.responds_to? to_s
```
