### PR TITLE
Allow named args to match arguments that don't have a default value

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1320,4 +1320,40 @@ describe "Code gen: macro" do
       hash[foo]
       )).to_i.should eq(42)
   end
+
+  it "executes with named arguments for positional arg (1)" do
+    run(%(
+      macro foo(x)
+        {{x}} + 1
+      end
+
+      foo x: 2
+      )).to_i.should eq(3)
+  end
+
+  it "executes with named arguments for positional arg (2)" do
+    run(%(
+      macro foo(x, y)
+        {{x}} + {{y}} + 1
+      end
+
+      foo x: 2, y: 3
+      )).to_i.should eq(6)
+  end
+
+  it "executes with named arguments for positional arg (3)" do
+    run(%(
+      class String
+        def bytesize
+          @bytesize
+        end
+      end
+
+      macro foo(x, y)
+        {{x}} + {{y}}.bytesize + 1
+      end
+
+      foo y: "foo", x: 2
+      )).to_i.should eq(6)
+  end
 end

--- a/spec/compiler/codegen/named_args_spec.cr
+++ b/spec/compiler/codegen/named_args_spec.cr
@@ -82,4 +82,44 @@ describe "Code gen: named args" do
       a.foo 1, z: 20
       )).to_i.should eq(22)
   end
+
+  it "sends one regular argument as named argument" do
+    run(%(
+      def foo(x)
+        x
+      end
+
+      foo x: 42
+      )).to_i.should eq(42)
+  end
+
+  it "sends two regular arguments as named arguments" do
+    run(%(
+      def foo(x, y)
+        x + y
+      end
+
+      foo x: 10, y: 32
+      )).to_i.should eq(42)
+  end
+
+  it "sends two regular arguments as named arguments in inverted position (1)" do
+    run(%(
+      def foo(x, y)
+        x
+      end
+
+      foo y: 42, x: "foo"
+      )).to_string.should eq("foo")
+  end
+
+  it "sends two regular arguments as named arguments in inverted position (2)" do
+    run(%(
+      def foo(x, y)
+        y
+      end
+
+      foo y: 42, x: "foo"
+      )).to_i.should eq(42)
+  end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -838,6 +838,7 @@ describe "Parser" do
   it_parses "foo out @x; @x", [Call.new(nil, "foo", Out.new("@x".instance_var)), "@x".instance_var]
   it_parses "foo(out @x); @x", [Call.new(nil, "foo", Out.new("@x".instance_var)), "@x".instance_var]
   it_parses "foo out _", Call.new(nil, "foo", Out.new(Underscore.new))
+  it_parses "foo z: out x; x", [Call.new(nil, "foo", named_args: [NamedArgument.new("z", Out.new("x".var))]), "x".var]
 
   it_parses "{1 => 2, 3 => 4}", HashLiteral.new([HashLiteral::Entry.new(1.int32, 2.int32), HashLiteral::Entry.new(3.int32, 4.int32)])
   it_parses "{a: 1, b: 2}", HashLiteral.new([HashLiteral::Entry.new("a".symbol, 1.int32), HashLiteral::Entry.new("b".symbol, 2.int32)])

--- a/spec/compiler/type_inference/macro_spec.cr
+++ b/spec/compiler/type_inference/macro_spec.cr
@@ -716,4 +716,44 @@ describe "Type inference: macro" do
       end
       )) { int32 }
   end
+
+  it "errors if named arg matches splat argument" do
+    assert_error %(
+      macro foo(x, *y)
+      end
+
+      foo x: 1, y: 2
+      ),
+      "can't use named args with macros that have a splat argument"
+  end
+
+  it "doesn't allow named arg if there's a splat" do
+    assert_error %(
+      macro foo(*y, x)
+      end
+
+      foo 1, x: 2
+      ),
+      "can't use named args with macros that have a splat argument"
+  end
+
+  it "errors if missing one argument" do
+    assert_error %(
+      macro foo(x, y, z)
+      end
+
+      foo x: 1, y: 2
+      ),
+      "missing argument: z"
+  end
+
+  it "errors if missing two arguments" do
+    assert_error %(
+      macro foo(x, y, z)
+      end
+
+      foo y: 2
+      ),
+      "missing arguments: x, z"
+  end
 end

--- a/spec/compiler/type_inference/named_args_spec.cr
+++ b/spec/compiler/type_inference/named_args_spec.cr
@@ -64,4 +64,97 @@ describe "Type inference: named args" do
       ),
       "argument 'headers' already specified"
   end
+
+  it "sends one regular argument as named argument" do
+    assert_type(%(
+      def foo(x)
+        x
+      end
+
+      foo x: 1
+      )) { int32 }
+  end
+
+  it "sends two regular arguments as named arguments" do
+    assert_type(%(
+      def foo(x, y)
+        x + y
+      end
+
+      foo x: 1, y: 2
+      )) { int32 }
+  end
+
+  it "sends two regular arguments as named arguments in inverted position (1)" do
+    assert_type(%(
+      def foo(x, y)
+        x
+      end
+
+      foo y: 1, x: "foo"
+      )) { string }
+  end
+
+  it "sends two regular arguments as named arguments in inverted position (2)" do
+    assert_type(%(
+      def foo(x, y)
+        y
+      end
+
+      foo y: 1, x: "foo"
+      )) { int32 }
+  end
+
+  it "errors if named arg matches splat argument" do
+    assert_error %(
+      def foo(x, *y)
+      end
+
+      foo x: 1, y: 2
+      ),
+      "can't use named args with methods that have a splat argument"
+  end
+
+  it "doesn't allow named arg if there's a splat" do
+    assert_error %(
+      def foo(*y, x)
+      end
+
+      foo 1, x: 2
+      ),
+      "can't use named args with methods that have a splat argument"
+  end
+
+  it "errors if missing one argument" do
+    assert_error %(
+      def foo(x, y, z)
+      end
+
+      foo x: 1, y: 2
+      ),
+      "missing argument: z"
+  end
+
+  it "errors if missing two arguments" do
+    assert_error %(
+      def foo(x, y, z)
+      end
+
+      foo y: 2
+      ),
+      "missing arguments: x, z"
+  end
+
+  it "says no overload matches with named arg" do
+    assert_error %(
+      def foo(x, y)
+      end
+
+      def foo(x, y, z)
+      end
+
+      foo(x: 2)
+      ),
+      "no overload matches"
+  end
 end

--- a/src/compiler/crystal/semantic/base_type_visitor.cr
+++ b/src/compiler/crystal/semantic/base_type_visitor.cr
@@ -509,7 +509,7 @@ module Crystal
         end
         return false unless macro_scope.is_a?(Type)
 
-        the_macro = macro_scope.metaclass.lookup_macro(node.name, node.args.size, node.named_args)
+        the_macro = macro_scope.metaclass.lookup_macro(node.name, node.args, node.named_args)
       when Nil
         return false if node.name == "super" || node.name == "previous_def"
         the_macro = node.lookup_macro

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -584,7 +584,7 @@ class Crystal::Call
   end
 
   def lookup_macro
-    in_macro_target &.lookup_macro(name, args.size, named_args)
+    in_macro_target &.lookup_macro(name, args, named_args)
   end
 
   def in_macro_target

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -2,16 +2,19 @@ require "../types"
 
 module Crystal
   class Type
+    ONE_ARG    = [Arg.new("a1")]
+    THREE_ARGS = [Arg.new("a1"), Arg.new("a2"), Arg.new("a3")]
+
     def check_method_missing(signature)
       false
     end
 
     def lookup_method_missing
       # method_missing is actually stored in the metaclass
-      method_missing = metaclass.lookup_macro("method_missing", 1, nil)
+      method_missing = metaclass.lookup_macro("method_missing", ONE_ARG, nil)
       return method_missing if method_missing
 
-      method_missing = metaclass.lookup_macro("method_missing", 3, nil)
+      method_missing = metaclass.lookup_macro("method_missing", THREE_ARGS, nil)
       return method_missing if method_missing
 
       parents.try &.each do |parent|

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3576,7 +3576,13 @@ module Crystal
         next_token
         check :":"
         next_token_skip_space_or_newline
-        value = parse_op_assign
+
+        if @token.keyword?(:out)
+          value = parse_out
+        else
+          value = parse_op_assign
+        end
+
         named_args << NamedArgument.new(name, value).at(location)
         skip_space_or_newline if allow_newline
         if @token.type == :","

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -353,7 +353,7 @@ module Crystal
       raise "Bug: #{self} doesn't implement add_macro"
     end
 
-    def lookup_macro(name, args_size, named_args)
+    def lookup_macro(name, args : Array, named_args)
       raise "Bug: #{self} doesn't implement lookup_macro"
     end
 
@@ -577,14 +577,14 @@ module Crystal
       [] of Def
     end
 
-    def lookup_macro(name, args_size, named_args)
+    def lookup_macro(name, args : Array, named_args)
       if macros = self.macros.try &.[name]?
-        match = macros.find &.matches?(args_size, named_args)
+        match = macros.find &.matches?(args, named_args)
         return match if match
       end
 
       instance_type.parents.try &.each do |parent|
-        parent_macro = parent.metaclass.lookup_macro(name, args_size, named_args)
+        parent_macro = parent.metaclass.lookup_macro(name, args, named_args)
         return parent_macro if parent_macro
       end
 
@@ -2867,7 +2867,7 @@ module Crystal
       type.metaclass
     end
 
-    def lookup_macro(name, args_size, named_args)
+    def lookup_macro(name, args : Array, named_args)
       nil
     end
 


### PR DESCRIPTION
As the title says, with this PR this is now possible and works:

```crystal
def foo(x, y, z)
  x + y + z
end

foo(1, 2, 3) # OK
foo(x: 1, y: 2, z: 3) # OK
foo(y: 1, x: 2, z: 3) # OK
foo(1, z: 2, y: 3) # OK
foo(x: 1) # Error, missing arguments: y, z
foo(y: 1, z: 2) # Error, missing argument: x
```

This PR addresses these issues:
* Some methods have many arguments and it's more readable to use named arguments in such cases (such as [OAuth2::Client](http://crystal-lang.org/api/OAuth2/Client.html#new%28host%3AString%2Cclient_id%3AString%2Cclient_secret%3AString%2Cport%3D%3Cspanclass%3D%22n%22%3E443%3C%2Fspan%3E%2Cscheme%3D%3Cspanclass%3D%22s%22%3E%26quot%3Bhttps%26quot%3B%3C%2Fspan%3E%2Cauthorize_uri%3D%3Cspanclass%3D%22s%22%3E%26quot%3B%2Foauth2%2Fauthorize%26quot%3B%3C%2Fspan%3E%2Ctoken_uri%3D%3Cspanclass%3D%22s%22%3E%26quot%3B%2Foauth2%2Ftoken%26quot%3B%3C%2Fspan%3E%2Credirect_uri%3D%3Cspanclass%3D%22n%22%3Enil%3C%2Fspan%3E%29-class-method)). This also prevents passing an argument in an incorrect position, if you use named args (you can of course still use positional args if you want)
* Some methods have boolean arguments that toggle some behaviour, without necessarily having a default value. It's more readable to use named args in such cases. For example: `parse_exception_handler(exp, true)` vs `parse_exception_handler(exp, inline: true)`.
* Some calls for methods that have arguments with default values are maybe more readable if all arguments are passed as named args. For example `HTTP::Client.new "example.com", port: 81` vs. `HTTP::Client.new host: "example.com", port: 81`.

So, this PR is all about improving readability at the call site.

The only downside of this change is that all method arguments are now part of an API. If I want to rename an argument I might risk breaking code that uses it with named arguments. But, I think that argument renames are pretty rare, and in any case clients will get a compile error that is easily detectable and fixable (because this is a compiled language).

What's missing, **maybe**, is a way to force an argument to be passed as a named argument. One idea could be:

```crystal
def foo(x =)
end 

foo(1) # Error
foo(x : 1) # OK
```

However, if we do this, then maybe arguments with a default value should also always be sent as named arguments:

```crystal
def foo(x = 1)
end 

foo(2) # Error
foo(x: 1) # OK
```

But this is maybe annoying in some cases:

```crystal
[1, 2, 3].join # OK
[1, 2, 3].join(",") # Error, but annoying
[1, 2, 3].join(with: ", ") # OK, but maybe unnecessary
```

Well, that last case could probably be defined with two methods, one without arguments and another with a regular argument:

```crystal
module Enumerable
  def join
    join(",")
  end

  def join(with)
    # ...
  end
end
```

Or maybe we could think of a different syntax to specify that an argument must be passed as a named argument.

But I think that, in the end, named arguments are about improving readability and avoiding mistakes in parameter orders. So maybe this PR is good enough and there's no need to think about mandatory named arguments. It will later depend on the caller to use named arguments if she considers it more readable, but the possibility will now be open for that.

Thoughts?