### PR TITLE
Crypto::MD5 also allow Slice(UInt8)

### DIFF
--- a/spec/std/crypto/md5_spec.cr
+++ b/spec/std/crypto/md5_spec.cr
@@ -13,4 +13,15 @@ describe Crypto::MD5 do
     s[2] = 0x6f_u8 # 'o'
     Crypto::MD5.hex_digest(s).should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
+
+  it "can take a block" do
+    s = Slice(UInt8).new(2)
+    s[0] = 0x6f_u8 # 'o'
+    s[1] = 0x6f_u8 # 'o'
+
+    Crypto::MD5.hex_digest do |ctx|
+      ctx.update "f"
+      ctx.update s
+    end.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+  end
 end

--- a/spec/std/crypto/md5_spec.cr
+++ b/spec/std/crypto/md5_spec.cr
@@ -1,8 +1,16 @@
 require "spec"
 require "crypto/md5"
 
-describe "MD5" do
+describe Crypto::MD5 do
   it "calculates hash from string" do
     Crypto::MD5.hex_digest("foo").should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+  end
+
+  it "calculates hash from UInt8 slices" do
+    s = Slice(UInt8).new(3)
+    s[0] = 0x66_u8 # 'f'
+    s[1] = 0x6f_u8 # 'o'
+    s[2] = 0x6f_u8 # 'o'
+    Crypto::MD5.hex_digest(s).should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 end

--- a/spec/std/crypto/md5_spec.cr
+++ b/spec/std/crypto/md5_spec.cr
@@ -7,21 +7,14 @@ describe Crypto::MD5 do
   end
 
   it "calculates hash from UInt8 slices" do
-    s = Slice(UInt8).new(3)
-    s[0] = 0x66_u8 # 'f'
-    s[1] = 0x6f_u8 # 'o'
-    s[2] = 0x6f_u8 # 'o'
+    s = UInt8.slice(0x66, 0x6f, 0x6f) # f,o,o
     Crypto::MD5.hex_digest(s).should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
   it "can take a block" do
-    s = Slice(UInt8).new(2)
-    s[0] = 0x6f_u8 # 'o'
-    s[1] = 0x6f_u8 # 'o'
-
     Crypto::MD5.hex_digest do |ctx|
       ctx.update "f"
-      ctx.update s
+      ctx.update UInt8.slice(0x6f, 0x6f)
     end.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 end

--- a/src/crypto/md5.cr
+++ b/src/crypto/md5.cr
@@ -1,7 +1,7 @@
 class Crypto::MD5
-  def self.hex_digest(data : String) : String
+  def self.hex_digest(data : String | Slice(UInt8)) : String
     context = Context.new
-    context.update(data.to_unsafe, data.bytesize.to_u32)
+    context.update data
     context.final
     context.hex
   end
@@ -17,6 +17,10 @@ class Crypto::MD5
       @buf[3] = 0x10325476_u32
       @in = StaticArray(UInt8, 64).new(0_u8)
       @digest = uninitialized UInt8[16]
+    end
+
+    def update(data : String | Slice(UInt8))
+      update(data.to_unsafe, data.bytesize.to_u32)
     end
 
     def update(inBuf, inLen)

--- a/src/crypto/md5.cr
+++ b/src/crypto/md5.cr
@@ -1,9 +1,37 @@
 class Crypto::MD5
+  # Returns a String the hexadecimal representation of the MD5 hash of *data*
+  #
+  #     Crypto::MD5.hex_digest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
   def self.hex_digest(data : String | Slice(UInt8)) : String
     context = Context.new
     context.update data
     context.final
     context.hex
+  end
+
+  # Yields a context object with an `#update(data : String | Slice(UInt8))`
+  # method available. Returns a String the hexadecimal representation of the
+  # MD5 hash all data passed in.
+  #
+  #     Crypto::MD5.hex_digest do |ctx|
+  #        ctx.update "f"
+  #        ctx.update "oo"
+  #     end                            # => "acbd18db4cc2f85cedef654fccc4a4d8"
+  def self.hex_digest : String
+    context = ContextWrapper.new
+    yield context
+    context.final
+    context.hex
+  end
+
+  # :nodoc:
+  class ContextWrapper
+    getter context : Context
+    delegate update, final, hex, context
+
+    def initialize
+      @context = Context.new
+    end
   end
 
   # :nodoc:


### PR DESCRIPTION
I was also thinking of a 

```cr
MD5.hex_digest do |c|
  c << "data"
  c << "more data"
end
```

form, but since the context is a struct that doesn't work, and it's probably not worth making classes.