### PR TITLE
Fix FreeBSD linking issues

### DIFF
--- a/samples/sdl/sdl/lib_sdl.cr
+++ b/samples/sdl/sdl/lib_sdl.cr
@@ -158,7 +158,7 @@ ifdef linux
   fun main(argc : Int32, argv : UInt8**) : Int32
     return LibSDL.main(argc, argv)
   end
-else
+elsif darwin
   redefine_main(SDL_main) do |main|
     {{main}}
   end

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -18,6 +18,12 @@ module Crystal
       has_pkg_config = nil
 
       String.build do |flags|
+        # Add the default path as -L flags: important on FreeBSD,
+        # where the default cc doesn't use /usr/local/lib by default
+        library_path.each do |path|
+          flags << " -L#{path}"
+        end
+
         link_attributes.reverse_each do |attr|
           if ldflags = attr.ldflags
             flags << " " << ldflags

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -1,4 +1,4 @@
-@[Link("m")] ifdef linux
+@[Link("m")] ifdef linux || freebsd
 lib LibM
   # ## To be uncommented once LLVM is updated
   # LLVM binary operations


### PR DESCRIPTION
This PR:

- Removes the need for setting `LIBRARY_PATH` to `/lib:/usr/lib:/usr/local/lib` from @ysbaddaden's FreeBSD [instructions](https://dl.dropboxusercontent.com/u/53345358/freebsd/setup.txt).
- Fixes `libm` linking on FreeBSD — examples like `neural_net` now work.
- Fixes SDL examples on FreeBSD (I assume the `redefine_main` thing is for OS X — on FreeBSD, it breaks everything, but the examples work without it).