### PR TITLE
Implement tuple and named tuple covariance

### DIFF
--- a/spec/compiler/codegen/named_tuple_spec.cr
+++ b/spec/compiler/codegen/named_tuple_spec.cr
@@ -179,4 +179,67 @@ describe "Code gen: named tuple" do
       foo[:x]
       )).to_i.should eq(42)
   end
+
+  it "allows named tuple covariance" do
+    run(%(
+       class Obj
+         def initialize
+           @tuple = {foo: Foo.new}
+         end
+
+         def tuple=(@tuple)
+         end
+
+         def tuple
+           @tuple
+         end
+       end
+
+       class Foo
+         def bar
+           21
+         end
+       end
+
+       class Bar < Foo
+         def bar
+           42
+         end
+       end
+
+       obj = Obj.new
+       obj.tuple = {foo: Bar.new}
+       obj.tuple[:foo].bar
+       )).to_i.should eq(42)
+  end
+
+  it "merges two named tuple types with same keys but different types (1)" do
+    run(%(
+       def foo
+         if 1 == 2
+           {x: "foo", y: 10}
+         else
+           {y: nil, x: "foo"}
+         end
+       end
+
+       val = foo[:y]
+       val || 20
+       )).to_i.should eq(20)
+  end
+
+  it "merges two named tuple types with same keys but different types (2)" do
+    run(%(
+       def foo
+         if 1 == 1
+           {x: "foo", y: 10}
+         else
+           {y: nil, x: "foo"}
+         end
+       end
+
+       val = foo[:y]
+       val || 20
+       )).to_i.should eq(10)
+  end
 end

--- a/spec/compiler/type_inference/tuple_spec.cr
+++ b/spec/compiler/type_inference/tuple_spec.cr
@@ -106,4 +106,77 @@ describe "Type inference: tuples" do
       ),
       "recursive splat expansion"
   end
+
+  it "allows tuple covariance" do
+    assert_type(%(
+      class Obj
+        def initialize
+          @tuple = {Foo.new}
+        end
+
+        def tuple=(@tuple)
+        end
+
+        def tuple
+          @tuple
+        end
+      end
+
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      obj = Obj.new
+      obj.tuple = {Bar.new}
+      obj.tuple
+      )) { tuple_of [types["Foo"].virtual_type!] }
+  end
+
+  it "merges two tuple types of same size" do
+    assert_type(%(
+      def foo
+        if 1 == 2
+          {"foo", 1}
+        else
+          {"foo", nil}
+        end
+      end
+
+      foo
+      )) { tuple_of [string, nilable(int32)] }
+  end
+
+  it "accept tuple in type restriction" do
+    assert_type(%(
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      def foo(x : {Foo})
+        x
+      end
+
+      foo({Bar.new})
+      )) { tuple_of [types["Bar"]] }
+  end
+
+  it "accepts tuple covariance in array" do
+    assert_type(%(
+      require "prelude"
+
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      a = [] of {Foo, Foo}
+      a << {Bar.new, Bar.new}
+      a[0]
+      )) { tuple_of [types["Foo"].virtual_type!, types["Foo"].virtual_type!] }
+  end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -108,10 +108,14 @@ class Crystal::CodeGenVisitor
     # It might happen that some types inside the union `value_type` are not inside `target_type`,
     # for example with named tuple of same keys with different order. In that case we need cast
     # those value to the correct type before finally storing them in the target union.
-    if value_type.union_types.any? { |vt| vt.is_a?(NamedTupleInstanceType) && !target_type.union_types.any? &.==(vt) }
-      # Compute the values that need a cast
-      types_needing_cast = value_type.union_types.select { |vt| vt.is_a?(NamedTupleInstanceType) && !target_type.union_types.any? &.==(vt) }
+    needs_union_value_cast = value_type.union_types.any? do |vt|
+      needs_value_cast_inside_union?(vt, target_type)
+    end
 
+    if needs_union_value_cast # Compute the values that need a cast
+      types_needing_cast = value_type.union_types.select do |vt|
+        needs_value_cast_inside_union?(vt, target_type)
+      end
       # Fetch the value's type id
       value_type_id = type_id(value, value_type)
 
@@ -148,6 +152,11 @@ class Crystal::CodeGenVisitor
     end
   end
 
+  def needs_value_cast_inside_union?(value_type, union_type)
+    return false unless value_type.is_a?(TupleInstanceType) || value_type.is_a?(NamedTupleInstanceType)
+    !union_type.union_types.any? &.==(value_type)
+  end
+
   def assign_distinct_union_types(target_pointer, target_type, value_type, value)
     casted_value = cast_to_pointer value, target_type
     store load(casted_value), target_pointer
@@ -171,7 +180,7 @@ class Crystal::CodeGenVisitor
 
   def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : Type, value)
     case value_type
-    when NamedTupleInstanceType
+    when TupleInstanceType, NamedTupleInstanceType
       # It might happen that `value_type` is not of the union but it's compatible with one of them.
       # We need to first cast the value to the compatible type and then store it in the value.
       unless target_type.union_types.any? &.==(value_type)
@@ -220,6 +229,18 @@ class Crystal::CodeGenVisitor
 
   def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : TypeDefType, value)
     assign_distinct target_pointer, target_type, value_type.typedef, value
+  end
+
+  def assign_distinct(target_pointer, target_type : TupleInstanceType, value_type : TupleInstanceType, value)
+    index = 0
+    target_type.tuple_types.zip(value_type.tuple_types) do |target_tuple_type, value_tuple_type|
+      target_ptr = gep target_pointer, 0, index
+      value_ptr = gep value, 0, index
+      loaded_value = load value_ptr
+      assign(target_ptr, target_tuple_type, value_tuple_type, loaded_value)
+      index += 1
+    end
+    value
   end
 
   def assign_distinct(target_pointer, target_type : NamedTupleInstanceType, value_type : NamedTupleInstanceType, value)
@@ -425,9 +446,15 @@ class Crystal::CodeGenVisitor
     # It might happen that some types inside the union `from_type` are not inside `to_type`,
     # for example with named tuple of same keys with different order. In that case we need cast
     # those value to the correct type before finally storing them in the target union.
-    if from_type.union_types.any? { |vt| vt.is_a?(NamedTupleInstanceType) && !to_type.union_types.any? &.==(vt) }
+    needs_union_value_cast = from_type.union_types.any? do |vt|
+      needs_value_cast_inside_union?(vt, to_type)
+    end
+
+    if needs_union_value_cast
       # Compute the values that need a cast
-      types_needing_cast = from_type.union_types.select { |vt| vt.is_a?(NamedTupleInstanceType) && !to_type.union_types.any? &.==(vt) }
+      types_needing_cast = from_type.union_types.select do |vt|
+        needs_value_cast_inside_union?(vt, to_type)
+      end
 
       # Fetch the value's type id
       from_type_id = type_id(value, from_type)
@@ -481,7 +508,7 @@ class Crystal::CodeGenVisitor
     # It might happen that from_type is not of the union but it's compatible with one of them.
     # We need to first cast the value to the compatible type and to to_type
     case from_type
-    when NamedTupleInstanceType
+    when TupleInstanceType, NamedTupleInstanceType
       unless to_type.union_types.any? &.==(from_type)
         compatible_type = to_type.union_types.find { |ut| from_type.implements?(ut) }.not_nil!
         value = upcast(value, compatible_type, from_type)
@@ -496,6 +523,12 @@ class Crystal::CodeGenVisitor
 
   def upcast_distinct(value, to_type : EnumType, from_type : Type)
     value
+  end
+
+  def upcast_distinct(value, to_type : TupleInstanceType, from_type : TupleInstanceType)
+    target_ptr = alloca llvm_type(to_type)
+    assign(target_ptr, to_type, from_type, value)
+    target_ptr
   end
 
   def upcast_distinct(value, to_type : NamedTupleInstanceType, from_type : NamedTupleInstanceType)

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -247,7 +247,8 @@ class Crystal::CodeGenVisitor
     value_type.names_and_types.each_with_index do |name_and_type, index|
       value_at_index = load aggregate_index(value, index)
       target_index = target_type.name_index(name_and_type[0]).not_nil!
-      assign aggregate_index(target_pointer, target_index), name_and_type[1], name_and_type[1], value_at_index
+      target_index_type = target_type.name_type(name_and_type[0])
+      assign aggregate_index(target_pointer, target_index), target_index_type, name_and_type[1], value_at_index
     end
   end
 
@@ -536,7 +537,8 @@ class Crystal::CodeGenVisitor
     from_type.names_and_types.each_with_index do |name_and_type, index|
       value_at_index = load aggregate_index(value, index)
       target_index = to_type.name_index(name_and_type[0]).not_nil!
-      assign aggregate_index(struct_type, target_index), name_and_type[1], name_and_type[1], value_at_index
+      target_index_type = to_type.name_type(name_and_type[0])
+      assign aggregate_index(struct_type, target_index), target_index_type, name_and_type[1], value_at_index
     end
     struct_type
   end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -410,6 +410,12 @@ module Crystal
   end
 
   class TupleInstanceType
+    def is_restriction_of?(other : TupleInstanceType, owner)
+      return true if self == other || self.implements?(other)
+
+      false
+    end
+
     def restrict(other : Generic, context)
       generic_class = context.type_lookup.lookup_type other.name
       return super unless generic_class == self.generic_class
@@ -426,7 +432,7 @@ module Crystal
     end
 
     def restrict(other : TupleInstanceType, context)
-      self == other ? self : nil
+      self.implements?(other) ? self : nil
     end
   end
 

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -256,7 +256,7 @@ module Crystal
       return nil unless self.size == other.size
 
       result_types = tuple_types.map_with_index do |self_tuple_type, index|
-        Type.merge!(self_tuple_type, other.tuple_types[index]) as Type
+        Type.merge!(self_tuple_type, other.tuple_types[index]).as(Type)
       end
       program.tuple_of(result_types)
     end
@@ -264,7 +264,26 @@ module Crystal
 
   class NamedTupleInstanceType
     def common_ancestor(other : NamedTupleInstanceType)
-      self.implements?(other) ? self : nil
+      return nil if self.size != other.size
+
+      self_names_and_types = self.names_and_types.sort_by &.[0]
+      other_names_and_types = other.names_and_types.sort_by &.[0]
+
+      # First check if the names are the same
+      self_names_and_types.zip(other_names_and_types) do |self_name_and_type, other_name_and_type|
+        return nil unless self_name_and_type[0] == other_name_and_type[0]
+      end
+
+      # If the names are the same we now merge the types for each key
+      # Note: we use self's order to preserve the order of the tuple on the left hand side
+      merged_names_and_types = self.names_and_types.map_with_index do |self_name_and_type, i|
+        name = self_name_and_type[0]
+        other_type = other.name_type(name)
+        merged_type = Type.merge!(self_name_and_type[1], other_type).as(Type)
+        {name, merged_type}
+      end
+
+      program.named_tuple_of(merged_names_and_types)
     end
   end
 end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -251,6 +251,17 @@ module Crystal
     end
   end
 
+  class TupleInstanceType
+    def common_ancestor(other : TupleInstanceType)
+      return nil unless self.size == other.size
+
+      result_types = tuple_types.map_with_index do |self_tuple_type, index|
+        Type.merge!(self_tuple_type, other.tuple_types[index]) as Type
+      end
+      program.tuple_of(result_types)
+    end
+  end
+
   class NamedTupleInstanceType
     def common_ancestor(other : NamedTupleInstanceType)
       self.implements?(other) ? self : nil

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2018,7 +2018,12 @@ module Crystal
         self_names_and_types = self.names_and_types.sort_by &.[0]
         other_names_and_types = other.names_and_types.sort_by &.[0]
 
-        self_names_and_types == other_names_and_types
+        self_names_and_types.zip(other_names_and_types) do |self_name_and_type, other_name_and_type|
+          return nil unless self_name_and_type[0] == other_name_and_type[0]
+          return nil unless self_name_and_type[1].implements?(other_name_and_type[1])
+        end
+
+        self
       else
         super
       end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1901,6 +1901,22 @@ module Crystal
       end
     end
 
+    def implements?(other : Type)
+      return true if self == other
+
+      if other.is_a?(TupleInstanceType)
+        return false unless self.size == other.size
+
+        tuple_types.zip(other.tuple_types) do |self_tuple_type, other_tuple_type|
+          return false unless self_tuple_type.implements?(other_tuple_type)
+        end
+
+        return true
+      end
+
+      super
+    end
+
     def var
       type_vars["T"]
     end


### PR DESCRIPTION
Fixes #357 

This also creates tuples/named-tuples of unions instead of unions of tuples/named-tuples, if the size/keys match. So this is possible:

```crystal
# 1.
ary = [] of {Int32 | String, Char}
ary << {1, 'a'}
ary << {"hello", 'a'}
 
# 2.
class Foo; end
class Bar < Foo; end

ary = [] of {Foo, Foo}
ary << {Foo.new, Bar.new}
```

And:

```crystal
# 1.
ary = [] of {foo: Int32 | String, bar: Char}
ary << {foo: 1, bar: 'a'}
ary << {bar: 'a', foo: "hello"}

# 2.
class Foo; end
class Bar < Foo; end

ary = [] of {foo: Foo, bar: Foo}
ary << {foo: Foo.new, bar: Bar.new}
```

The snippets above don't work right now, but they do with this change.