### PR TITLE
Fix bug not to accept recursive alias in Fun

### DIFF
--- a/spec/compiler/type_inference/alias_spec.cr
+++ b/spec/compiler/type_inference/alias_spec.cr
@@ -61,6 +61,20 @@ describe "type inference: alias" do
     union_types[1].should eq(mod.int32)
   end
 
+  it "allows defining recursive fun aliases" do
+    result = assert_type(%(
+      alias Alias = Alias -> Alias
+      1
+      )) { int32 }
+
+    mod = result.program
+
+    a = mod.types["Alias"].as(AliasType)
+    aliased_type = a.aliased_type.as(FunInstanceType)
+
+    aliased_type.should eq(mod.fun_of(a, a))
+  end
+
   it "allows recursive array with alias" do
     assert_type(%(
       alias Type = Nil | Pointer(Type)

--- a/src/compiler/crystal/semantic/base_type_visitor.cr
+++ b/src/compiler/crystal/semantic/base_type_visitor.cr
@@ -91,8 +91,10 @@ module Crystal
     end
 
     def visit(node : Fun)
+      @in_type_args += 1
       node.inputs.try &.each &.accept(self)
       node.output.try &.accept(self)
+      @in_type_args -= 1
 
       if inputs = node.inputs
         types = inputs.map &.type.instance_type.virtual_type


### PR DESCRIPTION
Below example is accepted:

```crystal
alias T = Proc(Int32, T)
```

However, next cannot be accepted:

```crystal
alias T = Int32 -> T
```

These examples are same, so this behavior is bug.