### PR TITLE
Compiler: implement double splat

### DIFF
--- a/spec/compiler/codegen/double_splat_spec.cr
+++ b/spec/compiler/codegen/double_splat_spec.cr
@@ -1,0 +1,100 @@
+require "../../spec_helper"
+
+describe "Codegen: double splat" do
+  it "double splats named argument into arguments (1)" do
+    run(%(
+      def foo(x, y)
+        x - y
+      end
+
+      tup = {x: 32, y: 10}
+      foo **tup
+      )).to_i.should eq(32 - 10)
+  end
+
+  it "double splats named argument into arguments (2)" do
+    run(%(
+      def foo(x, y)
+        x - y
+      end
+
+      tup = {y: 10, x: 32}
+      foo **tup
+      )).to_i.should eq(32 - 10)
+  end
+
+  it "double splats named argument with positional arguments" do
+    run(%(
+      def foo(x, y, z)
+        x - y*z
+      end
+
+      tup = {y: 20, z: 30}
+      foo 1000, **tup
+      )).to_i.should eq(1000 - 20*30)
+  end
+
+  it "double splats named argument with named args (1)" do
+    run(%(
+      def foo(x, y, z)
+        x - y*z
+      end
+
+      tup = {x: 1000, z: 30}
+      foo **tup, y: 20
+      )).to_i.should eq(1000 - 20*30)
+  end
+
+  it "double splats named argument with named args (2)" do
+    run(%(
+      def foo(x, y, z)
+        x - y*z
+      end
+
+      tup = {z: 30}
+      foo **tup, x: 1000, y: 20
+      )).to_i.should eq(1000 - 20*30)
+  end
+
+  it "double splats twice " do
+    run(%(
+      def foo(x, y, z, w)
+        (x - y*z) * w
+      end
+
+      tup1 = {x: 1000, z: 30}
+      tup2 = {y: 20, w: 40}
+      foo **tup2, **tup1
+      )).to_i.should eq((1000 - 20*30) * 40)
+  end
+
+  it "matches double splat on method with named args" do
+    run(%(
+      def foo(**options)
+        options[:x] - options[:y]
+      end
+
+      foo x: 10, y: 3
+      )).to_i.should eq(7)
+  end
+
+  it "matches double splat on method with named args and regular args" do
+    run(%(
+      def foo(x, **args)
+        x - args[:y]*args[:z]
+      end
+
+      foo y: 20, z: 30, x: 1000
+      )).to_i.should eq(1000 - 20*30)
+  end
+
+  it "matches double splat with regular splat" do
+    run(%(
+      def foo(*args, **options)
+        (args[0] - args[1]*options[:z]) * options[:w]
+      end
+
+      foo 1000, 20, z: 30, w: 40
+      )).to_i.should eq((1000 - 20*30) * 40)
+  end
+end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -201,6 +201,7 @@ describe Crystal::Formatter do
   assert_format "foo  x:  1,  y:  2", "foo x: 1, y: 2"
   assert_format "foo a , b ,  x:  1", "foo a, b, x: 1"
   assert_format "foo a , *b", "foo a, *b"
+  assert_format "foo a , **b", "foo a, **b"
   assert_format "foo   &bar", "foo &bar"
   assert_format "foo 1 ,  &bar", "foo 1, &bar"
   assert_format "foo(&.bar)"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -199,6 +199,15 @@ describe "Parser" do
   assert_syntax_error "def foo(var = 1 : Int32); end", "the syntax for an argument with a default value V and type T is `arg : T = V`"
   assert_syntax_error "def foo(var = x : Int); end", "the syntax for an argument with a default value V and type T is `arg : T = V`"
 
+  it_parses "def foo(**args)\n1\nend", Def.new("foo", body: 1.int32, double_splat: "args")
+  it_parses "def foo(x, **args)\n1\nend", Def.new("foo", body: 1.int32, args: ["x".arg], double_splat: "args")
+  it_parses "def foo(x, **args, &block)\n1\nend", Def.new("foo", body: 1.int32, args: ["x".arg], double_splat: "args", block_arg: "block".arg, yields: 0)
+  it_parses "def foo(**args)\nargs\nend", Def.new("foo", body: "args".var, double_splat: "args")
+
+  assert_syntax_error "def foo(**args, **args2)"
+
+  it_parses "macro foo(**args)\n1\nend", Macro.new("foo", body: MacroLiteral.new("1\n"), double_splat: "args")
+
   it_parses "abstract def foo", Def.new("foo", abstract: true)
   it_parses "abstract def foo; 1", [Def.new("foo", abstract: true), 1.int32]
   it_parses "abstract def foo\n1", [Def.new("foo", abstract: true), 1.int32]
@@ -945,6 +954,18 @@ describe "Parser" do
   it_parses "foo[*baz]", Call.new("foo".call, "[]", "baz".call.splat)
   it_parses "foo[*baz] = 1", Call.new("foo".call, "[]=", ["baz".call.splat, 1.int32] of ASTNode)
 
+  it_parses "foo **bar", Call.new(nil, "foo", DoubleSplat.new("bar".call))
+  it_parses "foo(**bar)", Call.new(nil, "foo", DoubleSplat.new("bar".call))
+
+  it_parses "foo 1, **bar", Call.new(nil, "foo", [1.int32, DoubleSplat.new("bar".call)])
+  it_parses "foo(1, **bar)", Call.new(nil, "foo", [1.int32, DoubleSplat.new("bar".call)])
+
+  it_parses "foo 1, **bar, &block", Call.new(nil, "foo", args: [1.int32, DoubleSplat.new("bar".call)], block_arg: "block".call)
+  it_parses "foo(1, **bar, &block)", Call.new(nil, "foo", args: [1.int32, DoubleSplat.new("bar".call)], block_arg: "block".call)
+
+  # assert_syntax_error "foo **bar, 1"
+  # assert_syntax_error "foo(**bar, 1)"
+
   it_parses "private def foo; end", VisibilityModifier.new(Visibility::Private, Def.new("foo"))
   it_parses "protected def foo; end", VisibilityModifier.new(Visibility::Protected, Def.new("foo"))
 
@@ -1111,6 +1132,11 @@ describe "Parser" do
   assert_syntax_error "def foo(x, x); end", "duplicated argument name: x", 1, 12
   assert_syntax_error "class Foo(T, T); end", "duplicated type var name: T", 1, 14
   assert_syntax_error "->(x : Int32, x : Int32) {}", "duplicated argument name: x", 1, 15
+
+  assert_syntax_error "def foo(*x, **x); end", "duplicated argument name: x"
+  assert_syntax_error "def foo(*x, &x); end", "duplicated argument name: x"
+  assert_syntax_error "def foo(**x, &x); end", "duplicated argument name: x"
+  assert_syntax_error "def foo(x, **x); end", "duplicated argument name: x"
 
   assert_syntax_error "Set {1, 2, 3} of Int32"
   assert_syntax_error "Hash {foo: 1} of Int32 => Int32"

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -60,4 +60,9 @@ describe "ASTNode#to_s" do
   expect_to_s "{ {1 => 2} }"
   expect_to_s "{ {1, 2, 3} => 4 }"
   expect_to_s "{ {foo: 2} }"
+  expect_to_s "def foo(**args)\nend"
+  expect_to_s "def foo(x, **args)\nend"
+  expect_to_s "def foo(x, **args, &block)\nend"
+  expect_to_s "macro foo(**args)\nend"
+  expect_to_s "macro foo(x, **args)\nend"
 end

--- a/spec/compiler/type_inference/double_splat_spec.cr
+++ b/spec/compiler/type_inference/double_splat_spec.cr
@@ -1,0 +1,99 @@
+require "../../spec_helper"
+
+describe "Type inference: double splat" do
+  it "double splats named argument into arguments (1)" do
+    assert_type(%(
+      def foo(x, y)
+        x
+      end
+
+      tup = {x: 1, y: 'a'}
+      foo **tup
+      )) { int32 }
+  end
+
+  it "double splats named argument into arguments (2)" do
+    assert_type(%(
+      def foo(x, y)
+        x
+      end
+
+      tup = {y: 'a', x: 1}
+      foo **tup
+      )) { int32 }
+  end
+
+  it "errors if duplicate keys on call side with two double splats" do
+    assert_error %(
+      def foo(**args)
+      end
+
+      t1 = {x: 1, y: 2}
+      t2 = {z: 3, x: 4}
+      foo **t1, **t2
+      ),
+      "duplicate key: x"
+  end
+
+  it "errors if duplicate keys on call side with double splat and named args" do
+    assert_error %(
+      def foo(**args)
+      end
+
+      t1 = {x: 1, y: 2}
+      foo **t1, z: 3, x: 4
+      ),
+      "duplicate key: x"
+  end
+
+  it "errors missing argument with double splat" do
+    assert_error %(
+      def foo(x, y)
+      end
+
+      tup = {x: 1}
+      foo **tup
+      ),
+      "missing argument: y"
+  end
+
+  it "matches double splat on method (empty)" do
+    assert_type(%(
+      def foo(**args)
+        args
+      end
+
+      foo
+      )) { named_tuple_of({} of String => Type) }
+  end
+
+  it "matches double splat on method with named args" do
+    assert_type(%(
+      def foo(**args)
+        args
+      end
+
+      foo x: 1, y: 'a'
+      )) { named_tuple_of({"x": int32, "y": char}) }
+  end
+
+  it "matches double splat on method with named args and regular args" do
+    assert_type(%(
+      def foo(x, **args)
+        args
+      end
+
+      foo y: 'a', z: 3, x: "foo"
+      )) { named_tuple_of({"y": char, "z": int32}) }
+  end
+
+  it "matches double splat with regular splat" do
+    assert_type(%(
+      def foo(*args, **options)
+        {args, options}
+      end
+
+      foo 1, 'a', x: "foo", y: true
+      )) { tuple_of([tuple_of([int32, char]), named_tuple_of({"x": string, "y": bool})]) }
+  end
+end

--- a/spec/compiler/type_inference/named_args_spec.cr
+++ b/spec/compiler/type_inference/named_args_spec.cr
@@ -105,6 +105,16 @@ describe "Type inference: named args" do
       )) { int32 }
   end
 
+  it "errors if named arg matches single splat argument" do
+    assert_error %(
+      def foo(*y)
+      end
+
+      foo x: 1, y: 2
+      ),
+      "can't use named args with methods that have a splat argument"
+  end
+
   it "errors if named arg matches splat argument" do
     assert_error %(
       def foo(x, *y)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -392,142 +392,8 @@ module Crystal
 
   class ArrayLiteral
     def interpret(method, args, block, interpreter)
-      case method
-      when "any?"
-        interpret_argless_method(method, args) do
-          raise "any? expects a block" unless block
-
-          block_arg = block.args.first?
-
-          BoolLiteral.new(elements.any? do |elem|
-            interpreter.define_var(block_arg.name, elem) if block_arg
-            interpreter.accept(block.body).truthy?
-          end)
-        end
-      when "all?"
-        interpret_argless_method(method, args) do
-          raise "all? expects a block" unless block
-
-          block_arg = block.args.first?
-
-          BoolLiteral.new(elements.all? do |elem|
-            interpreter.define_var(block_arg.name, elem) if block_arg
-            interpreter.accept(block.body).truthy?
-          end)
-        end
-      when "argify"
-        interpret_argless_method(method, args) do
-          MacroId.new(elements.join ", ")
-        end
-      when "empty?"
-        interpret_argless_method(method, args) { BoolLiteral.new(elements.empty?) }
-      when "find"
-        interpret_argless_method(method, args) do
-          raise "find expects a block" unless block
-
-          block_arg = block.args.first?
-
-          found = elements.find do |elem|
-            interpreter.define_var(block_arg.name, elem) if block_arg
-            interpreter.accept(block.body).truthy?
-          end
-          found ? found : NilLiteral.new
-        end
-      when "first"
-        interpret_argless_method(method, args) { elements.first? || NilLiteral.new }
-      when "includes?"
-        interpret_one_arg_method(method, args) do |arg|
-          BoolLiteral.new(elements.includes?(arg))
-        end
-      when "join"
-        interpret_one_arg_method(method, args) do |arg|
-          StringLiteral.new(elements.map(&.to_macro_id).join arg.to_macro_id)
-        end
-      when "last"
-        interpret_argless_method(method, args) { elements.last? || NilLiteral.new }
-      when "size"
-        interpret_argless_method(method, args) { NumberLiteral.new(elements.size) }
-      when "map"
-        interpret_argless_method(method, args) do
-          raise "map expects a block" unless block
-
-          block_arg = block.args.first?
-
-          ArrayLiteral.map(elements) do |elem|
-            interpreter.define_var(block_arg.name, elem) if block_arg
-            interpreter.accept block.body
-          end
-        end
-      when "select"
-        interpret_argless_method(method, args) do
-          raise "select expects a block" unless block
-          filter(block, interpreter)
-        end
-      when "reject"
-        interpret_argless_method(method, args) do
-          raise "reject expects a block" unless block
-          filter(block, interpreter, keep: false)
-        end
-      when "shuffle"
-        ArrayLiteral.new(elements.shuffle)
-      when "sort"
-        ArrayLiteral.new(elements.sort { |x, y| x.interpret_compare(y) })
-      when "uniq"
-        ArrayLiteral.new(elements.uniq)
-      when "[]"
-        case args.size
-        when 1
-          arg = args.first
-          unless arg.is_a?(NumberLiteral)
-            arg.raise "argument to [] must be a number, not #{arg.class_desc}:\n\n#{arg}"
-          end
-
-          index = arg.to_number.to_i
-          value = elements[index]?
-          if value
-            value
-          else
-            NilLiteral.new
-          end
-        else
-          wrong_number_of_arguments "ArrayLiteral#[]", args.size, 1
-        end
-      when "unshift"
-        case args.size
-        when 1
-          elements.unshift(args.first)
-          self
-        else
-          wrong_number_of_arguments "ArrayLiteral#unshift", args.size, 1
-        end
-      when "push", "<<"
-        case args.size
-        when 1
-          elements << args.first
-          self
-        else
-          wrong_number_of_arguments "ArrayLiteral##{method}", args.size, 1
-        end
-      when "+"
-        interpret_one_arg_method(method, args) do |arg|
-          unless arg.is_a?(ArrayLiteral)
-            arg.raise "argument to `ArrayLiteral#+` must be an array, not #{arg.class_desc}:\n\n#{arg}"
-          end
-          ArrayLiteral.new(elements + arg.elements)
-        end
-      else
-        super
-      end
-    end
-
-    def filter(block, interpreter, keep = true)
-      block_arg = block.args.first?
-
-      ArrayLiteral.new(elements.select { |elem|
-        interpreter.define_var(block_arg.name, elem) if block_arg
-        block_result = interpreter.accept(block.body).truthy?
-        keep ? block_result : !block_result
-      })
+      value = intepret_array_of_tuple_method(self, ArrayLiteral, method, args, block, interpreter)
+      value || super
     end
   end
 
@@ -644,32 +510,8 @@ module Crystal
 
   class TupleLiteral
     def interpret(method, args, block, interpreter)
-      case method
-      when "empty?"
-        interpret_argless_method(method, args) { BoolLiteral.new(elements.empty?) }
-      when "size"
-        interpret_argless_method(method, args) { NumberLiteral.new(elements.size) }
-      when "[]"
-        case args.size
-        when 1
-          arg = args.first
-          unless arg.is_a?(NumberLiteral)
-            arg.raise "argument to [] must be a number, not #{arg.class_desc}:\n\n#{arg}"
-          end
-
-          index = arg.to_number.to_i
-          value = elements[index]?
-          if value
-            value
-          else
-            raise "tuple index out of bounds: #{index} in #{self}"
-          end
-        else
-          wrong_number_of_arguments "TupleLiteral#[]", args.size, 1
-        end
-      else
-        super
-      end
+      value = intepret_array_of_tuple_method(self, TupleLiteral, method, args, block, interpreter)
+      value || super
     end
   end
 
@@ -1162,4 +1004,148 @@ module Crystal
       end
     end
   end
+end
+
+private def intepret_array_of_tuple_method(object, klass, method, args, block, interpreter)
+  case method
+  when "any?"
+    object.interpret_argless_method(method, args) do
+      raise "any? expects a block" unless block
+
+      block_arg = block.args.first?
+
+      Crystal::BoolLiteral.new(object.elements.any? do |elem|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.accept(block.body).truthy?
+      end)
+    end
+  when "all?"
+    object.interpret_argless_method(method, args) do
+      raise "all? expects a block" unless block
+
+      block_arg = block.args.first?
+
+      Crystal::BoolLiteral.new(object.elements.all? do |elem|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.accept(block.body).truthy?
+      end)
+    end
+  when "argify"
+    object.interpret_argless_method(method, args) do
+      Crystal::MacroId.new(object.elements.join ", ")
+    end
+  when "empty?"
+    object.interpret_argless_method(method, args) { Crystal::BoolLiteral.new(object.elements.empty?) }
+  when "find"
+    object.interpret_argless_method(method, args) do
+      raise "find expects a block" unless block
+
+      block_arg = block.args.first?
+
+      found = object.elements.find do |elem|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.accept(block.body).truthy?
+      end
+      found ? found : Crystal::NilLiteral.new
+    end
+  when "first"
+    object.interpret_argless_method(method, args) { object.elements.first? || Crystal::NilLiteral.new }
+  when "includes?"
+    object.interpret_one_arg_method(method, args) do |arg|
+      Crystal::BoolLiteral.new(object.elements.includes?(arg))
+    end
+  when "join"
+    object.interpret_one_arg_method(method, args) do |arg|
+      Crystal::StringLiteral.new(object.elements.map(&.to_macro_id).join arg.to_macro_id)
+    end
+  when "last"
+    object.interpret_argless_method(method, args) { object.elements.last? || Crystal::NilLiteral.new }
+  when "size"
+    object.interpret_argless_method(method, args) { Crystal::NumberLiteral.new(object.elements.size) }
+  when "map"
+    object.interpret_argless_method(method, args) do
+      raise "map expects a block" unless block
+
+      block_arg = block.args.first?
+
+      klass.map(object.elements) do |elem|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.accept block.body
+      end
+    end
+  when "select"
+    object.interpret_argless_method(method, args) do
+      raise "select expects a block" unless block
+      filter(object, klass, block, interpreter)
+    end
+  when "reject"
+    object.interpret_argless_method(method, args) do
+      raise "reject expects a block" unless block
+      filter(object, klass, block, interpreter, keep: false)
+    end
+  when "shuffle"
+    klass.new(object.elements.shuffle)
+  when "sort"
+    klass.new(object.elements.sort { |x, y| x.interpret_compare(y) })
+  when "uniq"
+    klass.new(object.elements.uniq)
+  when "[]"
+    case args.size
+    when 1
+      arg = args.first
+      unless arg.is_a?(Crystal::NumberLiteral)
+        arg.raise "argument to [] must be a number, not #{arg.class_desc}:\n\n#{arg}"
+      end
+
+      index = arg.to_number.to_i
+      value = object.elements[index]?
+      if value
+        value
+      else
+        Crystal::NilLiteral.new
+      end
+    else
+      object.wrong_number_of_arguments "#{klass}#[]", args.size, 1
+    end
+  when "unshift"
+    case args.size
+    when 1
+      object.elements.unshift(args.first)
+      object
+    else
+      object.wrong_number_of_arguments "#{klass}#unshift", args.size, 1
+    end
+  when "push", "<<"
+    case args.size
+    when 1
+      object.elements << args.first
+      object
+    else
+      object.wrong_number_of_arguments "#{klass}##{method}", args.size, 1
+    end
+  when "+"
+    object.interpret_one_arg_method(method, args) do |arg|
+      case arg
+      when Crystal::TupleLiteral
+        other_elements = arg.elements
+      when Crystal::ArrayLiteral
+        other_elements = arg.elements
+      else
+        arg.raise "argument to `#{klass}#+` must be a tuple or array, not #{arg.class_desc}:\n\n#{arg}"
+      end
+      klass.new(object.elements + other_elements)
+    end
+  else
+    nil
+  end
+end
+
+def filter(object, klass, block, interpreter, keep = true)
+  block_arg = block.args.first?
+
+  klass.new(object.elements.select { |elem|
+    interpreter.define_var(block_arg.name, elem) if block_arg
+    block_result = interpreter.accept(block.body).truthy?
+    keep ? block_result : !block_result
+  })
 end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -21,11 +21,11 @@ class Crystal::ASTNode
 end
 
 class Crystal::Call
-  def raise_matches_not_found(owner : CStructType, def_name, matches = nil)
+  def raise_matches_not_found(owner : CStructType, def_name, arg_types, named_args_types, matches = nil)
     raise_struct_or_union_field_not_found owner, def_name
   end
 
-  def raise_matches_not_found(owner : CUnionType, def_name, matches = nil)
+  def raise_matches_not_found(owner : CUnionType, def_name, arg_types, named_args_types, matches = nil)
     raise_struct_or_union_field_not_found owner, def_name
   end
 
@@ -42,7 +42,7 @@ class Crystal::Call
     end
   end
 
-  def raise_matches_not_found(owner, def_name, matches = nil)
+  def raise_matches_not_found(owner, def_name, arg_types, named_args_types, matches = nil)
     # Special case: Foo+:Class#new
     if owner.is_a?(VirtualMetaclassType) && def_name == "new"
       raise_matches_not_found_for_virtual_metaclass_new owner
@@ -133,14 +133,7 @@ class Crystal::Call
       raise error_msg, owner_trace
     end
 
-    real_args_size = self.args.sum do |arg|
-      arg_type = arg.type
-      if arg.is_a?(Splat) && arg_type.is_a?(TupleInstanceType)
-        arg_type.tuple_types.size
-      else
-        1
-      end
-    end
+    real_args_size = arg_types.size
 
     # If it's on an initialize method and there's a similar method name, it's probably a typo
     if (def_name == "initialize" || def_name == "new") && (similar_def = owner.instance_type.lookup_similar_def("initialize", self.args.size, block))
@@ -161,7 +154,7 @@ class Crystal::Call
     end
 
     # Don't say "wrong number of arguments" when there are named args in this call
-    if defs_matching_args_size.empty? && !named_args
+    if defs_matching_args_size.empty? && !named_args_types
       all_arguments_sizes = [] of Int32
       min_splat = Int32::MAX
       defs.each do |a_def|
@@ -178,7 +171,7 @@ class Crystal::Call
       all_arguments_sizes.uniq!.sort!
 
       raise(String.build do |str|
-        unless check_single_def_error_message(defs, str)
+        unless check_single_def_error_message(defs, named_args_types, str)
           str << "wrong number of arguments for '"
           str << full_name(owner, def_name)
           str << "' (given "
@@ -203,15 +196,20 @@ class Crystal::Call
     end
 
     if defs_matching_args_size.size > 0
-      if block && defs_matching_args_size.all? { |a_def| !a_def.yields }
-        raise "'#{full_name(owner, def_name)}' is not expected to be invoked with a block, but a block was given"
-      elsif !block && defs_matching_args_size.all?(&.yields)
-        raise "'#{full_name(owner, def_name)}' is expected to be invoked with a block, but no block was given"
-      end
+      str = MemoryIO.new
+      if check_single_def_error_message(defs_matching_args_size, named_args_types, str)
+        raise str.to_s
+      else
+        if block && defs_matching_args_size.all? { |a_def| !a_def.yields }
+          raise "'#{full_name(owner, def_name)}' is not expected to be invoked with a block, but a block was given"
+        elsif !block && defs_matching_args_size.all?(&.yields)
+          raise "'#{full_name(owner, def_name)}' is expected to be invoked with a block, but no block was given"
+        end
 
-      if named_args = @named_args
-        defs_matching_args_size.each do |a_def|
-          check_named_args_mismatch owner, named_args, a_def
+        if named_args_types
+          defs_matching_args_size.each do |a_def|
+            check_named_args_mismatch owner, named_args_types, a_def
+          end
         end
       end
     end
@@ -223,33 +221,21 @@ class Crystal::Call
     arg_names = [] of Array(String)
 
     message = String.build do |msg|
-      unless check_single_def_error_message(defs, msg)
+      unless check_single_def_error_message(defs, named_args_types, msg)
         msg << "no overload matches '#{full_name(owner, def_name)}'"
         unless args.empty?
-          types = [] of Type
-          args.each_with_index do |arg|
-            arg_type = arg.type
-
-            if arg.is_a?(Splat) && arg_type.is_a?(TupleInstanceType)
-              arg_type.tuple_types.each_with_index do |tuple_type, sub_index|
-                types << tuple_type
-              end
-            else
-              types << arg_type
-            end
-          end
           msg << " with type"
-          msg << "s" if types.size > 1 || @named_args
+          msg << "s" if arg_types.size > 1 || named_args_types
           msg << " "
-          types.join(", ", msg)
+          arg_types.join(", ", msg)
         end
 
-        if named_args = @named_args
-          named_args.each do |named_arg|
+        if named_args_types
+          named_args_types.each do |named_arg|
             msg << ", "
             msg << named_arg.name
             msg << ": "
-            msg << named_arg.value.type
+            msg << named_arg.type
           end
         end
 
@@ -290,8 +276,7 @@ class Crystal::Call
 
   # If there's only one def that could match, and there are named
   # arguments in this call, we can give a better error message.
-  def check_single_def_error_message(defs, io)
-    named_args = self.named_args
+  def check_single_def_error_message(defs, named_args, io)
     return false unless named_args
     return false unless defs.size == 1
 
@@ -357,7 +342,8 @@ class Crystal::Call
     return unless !matches || (matches.try &.empty?)
     return unless defs.all? &.abstract?
 
-    signature = CallSignature.new(def_name, args.map(&.type), block, named_args)
+    named_args_types = NamedArgumentType.from_args(named_args)
+    signature = CallSignature.new(def_name, args.map(&.type), block, named_args_types)
     defs.each do |a_def|
       context = MatchContext.new(owner, a_def.owner)
       match = MatchesLookup.match_def(signature, DefWithMetadata.new(a_def), context)
@@ -405,8 +391,9 @@ class Crystal::Call
   def self.append_def_full_name(owner, a_def, str)
     str << full_name(owner, a_def.name)
     str << '('
+    printed = false
     a_def.args.each_with_index do |arg, i|
-      str << ", " if i > 0
+      str << ", " if printed
       str << '*' if a_def.splat_index == i
       str << arg.name
       if arg_default = arg.default_value
@@ -428,9 +415,22 @@ class Crystal::Call
           str << res
         end
       end
+      printed = true
     end
 
-    str << ", &block" if a_def.yields
+    if a_def.double_splat
+      str << ", " if printed
+      str << "**" << a_def.double_splat
+      printed = true
+    end
+
+    if block_arg = a_def.block_arg
+      str << ", " if printed
+      str << "&" << block_arg.name
+    elsif a_def.yields
+      str << ", " if printed
+      str << "&block"
+    end
     str << ")"
   end
 
@@ -451,6 +451,12 @@ class Crystal::Call
   def check_macro_wrong_number_of_arguments(def_name)
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros
+
+    if macros.size == 1 && (named_args = @named_args)
+      if msg = check_named_args_and_splats(macros.first, named_args)
+        raise msg
+      end
+    end
 
     all_arguments_sizes = Set(Int32).new
     macros.each do |a_macro|
@@ -487,7 +493,7 @@ class Crystal::Call
       if found_index
         min_size = args.size
         if found_index < min_size
-          named_arg.raise "argument '#{named_arg.name}' already specified"
+          raise "argument '#{named_arg.name}' already specified"
         end
       else
         similar_name = Levenshtein.find(named_arg.name, a_def.args.select(&.default_value).map(&.name))
@@ -506,7 +512,7 @@ class Crystal::Call
           str << "Matches are:"
           append_matches defs, str, matched_def: a_def, argument_name: named_arg.name
         end
-        named_arg.raise msg
+        raise msg
       end
     end
   end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -414,6 +414,8 @@ module Crystal
         end
       end
 
+      node.replace_splats
+
       # Convert named arguments to regular arguments, because intermediate
       # defs with the needed number of arguments are already defined.
       if named_args = node.named_args
@@ -422,8 +424,6 @@ module Crystal
         end
         node.named_args = nil
       end
-
-      node.replace_splats
 
       # check_comparison_of_unsigned_integer_with_zero_or_negative_literal(node)
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1302,6 +1302,10 @@ module Crystal
       node.bind_to node.exp
     end
 
+    def end_visit(node : DoubleSplat)
+      node.bind_to node.exp
+    end
+
     def visit(node : Underscore)
       if @in_type_args == 0
         node.raise "can't read from _"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -18,7 +18,7 @@ module Crystal
 
     def initialize(str, string_pool : StringPool? = nil, @def_vars = [Set(String).new])
       super(str, string_pool)
-      @last_call_has_parenthesis = true
+      @last_call_has_parentheses = true
       @temp_token = Token.new
       @unclosed_stack = [] of Unclosed
       @calls_super = false
@@ -53,8 +53,8 @@ module Crystal
     end
 
     def parse_expressions
-      value, _ = preserve_last_call_has_parenthesis do
-        @last_call_has_parenthesis = true
+      value, _ = preserve_last_call_has_parentheses do
+        @last_call_has_parentheses = true
         parse_expressions_internal
       end
       value
@@ -688,7 +688,7 @@ module Crystal
               ).at(location)
               next
             else
-              call_args, last_call_has_parenthesis = preserve_last_call_has_parenthesis { space_consumed ? parse_call_args_space_consumed : parse_call_args }
+              call_args, last_call_has_parentheses = preserve_last_call_has_parentheses { space_consumed ? parse_call_args_space_consumed : parse_call_args }
               if call_args
                 args = call_args.args
                 block = call_args.block
@@ -699,7 +699,7 @@ module Crystal
               end
             end
 
-            block = parse_block(block, stop_on_do: space_consumed && !@last_call_has_parenthesis)
+            block = parse_block(block, stop_on_do: space_consumed && !@last_call_has_parentheses)
             if block || block_arg
               atomic = Call.new atomic, name, (args || [] of ASTNode), block, block_arg, named_args, name_column_number: name_column_number
             else
@@ -1429,8 +1429,8 @@ module Crystal
         else
           # At this point we want to attach the "do" to the next call,
           # so we set this var to true to make the parser think the call
-          # has parenthesis and so a "do" must be attached to it
-          @last_call_has_parenthesis = true
+          # has parentheses and so a "do" must be attached to it
+          @last_call_has_parentheses = true
           call = parse_var_or_call(force_call: true).at(location)
 
           if call.is_a?(Call)
@@ -1658,7 +1658,7 @@ module Crystal
       elsif @token.type == :"{"
         next_token_skip_statement_end
         check_not_pipe_before_proc_literal_body
-        @last_call_has_parenthesis = true
+        @last_call_has_parentheses = true
         body = parse_expressions
         end_location = token_end_location
         check :"}"
@@ -2506,21 +2506,33 @@ module Crystal
 
       found_default_value = false
       found_splat = false
+      found_double_splat = nil
 
       splat_index = nil
+      double_splat = nil
       index = 0
 
       case @token.type
       when :"("
         next_token_skip_space_or_newline
         while @token.type != :")"
-          extras = parse_arg(args, nil, true, found_default_value, found_splat, allow_restrictions: false)
+          extras = parse_arg(args,
+            extra_assigns: nil,
+            parentheses: true,
+            found_default_value: found_default_value,
+            found_splat: found_splat,
+            found_double_splat: found_double_splat,
+            allow_restrictions: false)
           if !found_default_value && extras.default_value
             found_default_value = true
           end
           if !splat_index && extras.splat
             splat_index = index
             found_splat = true
+          end
+          if extras_double_splat = extras.double_splat
+            double_splat = extras_double_splat
+            found_double_splat = double_splat
           end
           if block_arg = extras.block_arg
             check :")"
@@ -2556,7 +2568,7 @@ module Crystal
 
       pop_def
 
-      node = Macro.new name, args, body, block_arg, splat_index
+      node = Macro.new name, args, body, block_arg, splat_index, double_splat: double_splat
       node.name_column_number = name_column_number
       node.doc = doc
       node.end_location = end_location
@@ -2819,7 +2831,7 @@ module Crystal
 
       # At this point we want to attach the "do" to calls inside the def,
       # not to calls that might have this def as a macro argument.
-      @last_call_has_parenthesis = true
+      @last_call_has_parentheses = true
 
       next_token
 
@@ -2912,21 +2924,34 @@ module Crystal
 
       found_default_value = false
       found_splat = false
+      found_double_splat = nil
 
       index = 0
       splat_index = nil
+      double_splat = nil
 
       case @token.type
       when :"("
         next_token_skip_space_or_newline
         while @token.type != :")"
-          extras = parse_arg(args, extra_assigns, true, found_default_value, found_splat)
+          extras = parse_arg(args,
+            extra_assigns: extra_assigns,
+            parentheses: true,
+            found_default_value: found_default_value,
+            found_splat: found_splat,
+            found_double_splat: found_double_splat,
+            allow_restrictions: true,
+          )
           if !found_default_value && extras.default_value
             found_default_value = true
           end
           if !splat_index && extras.splat
             splat_index = index
             found_splat = true
+          end
+          if extras_double_splat = extras.double_splat
+            double_splat = extras_double_splat
+            found_double_splat = extras_double_splat
           end
           if block_arg = extras.block_arg
             compute_block_arg_yields block_arg
@@ -2946,7 +2971,7 @@ module Crystal
         if @token.type == :SYMBOL
           raise "a space is mandatory between ':' and return type", @token
         end
-      when :IDENT, :INSTANCE_VAR, :CLASS_VAR, :"*"
+      when :IDENT, :INSTANCE_VAR, :CLASS_VAR, :"*", :"**"
         if @token.keyword?(:end)
           unexpected_token @token.to_s, "expected ';' or newline"
         else
@@ -3005,7 +3030,7 @@ module Crystal
       @doc_enabled = !!@wants_doc
       pop_def
 
-      node = Def.new name, args, body, receiver, block_arg, return_type, is_macro_def, @yields, is_abstract, splat_index
+      node = Def.new name, args, body, receiver, block_arg, return_type, is_macro_def, @yields, is_abstract, splat_index, double_splat: double_splat
       node.name_column_number = name_column_number
       set_visibility node
       node.end_location = end_location
@@ -3036,22 +3061,37 @@ module Crystal
     record ArgExtras,
       block_arg : Arg?,
       default_value : Bool,
-      splat : Bool
+      splat : Bool,
+      double_splat : String?
 
-    def parse_arg(args, extra_assigns, parenthesis, found_default_value, found_splat, allow_restrictions = true)
+    def parse_arg(args, extra_assigns, parentheses, found_default_value, found_splat, found_double_splat, allow_restrictions)
       if @token.type == :"&"
         next_token_skip_space_or_newline
         block_arg = parse_block_arg(extra_assigns)
-        return ArgExtras.new(block_arg, false, false)
+        if args.any?(&.name.==(block_arg.name)) || found_double_splat == block_arg.name
+          raise "duplicated argument name: #{block_arg.name}", block_arg.location.not_nil!
+        end
+        return ArgExtras.new(block_arg, false, false, nil)
       end
 
       splat = false
-      if @token.type == :"*"
+      double_splat = false
+
+      case @token.type
+      when :"*"
         if found_splat
           unexpected_token
         end
 
         splat = true
+        next_token_skip_space
+      when :"**"
+        if found_double_splat
+          unexpected_token
+        end
+
+        double_splat = true
+        allow_restrictions = false
         next_token_skip_space
       end
 
@@ -3066,7 +3106,7 @@ module Crystal
       restriction = nil
       found_space = false
 
-      if parenthesis
+      if parentheses
         next_token
         found_space = @token.type == :SPACE || @token.type == :NEWLINE
         skip_space_or_newline
@@ -3094,7 +3134,7 @@ module Crystal
         found_colon = true
       end
 
-      unless splat
+      if !splat && !double_splat
         if @token.type == :"="
           if found_splat || splat
             unexpected_token
@@ -3132,11 +3172,17 @@ module Crystal
 
       raise "Bug: arg_name is nil" unless arg_name
 
-      arg = Arg.new(arg_name, default_value, restriction).at(arg_location)
-      args << arg
-      push_var arg
+      if double_splat
+        double_splat = arg_name
+        push_var_name double_splat
+      else
+        arg = Arg.new(arg_name, default_value, restriction).at(arg_location)
+        args << arg
+        push_var arg
+        double_splat = nil
+      end
 
-      ArgExtras.new(nil, !!default_value, splat)
+      ArgExtras.new(nil, !!default_value, splat, double_splat)
     end
 
     def parse_block_arg(extra_assigns)
@@ -3387,8 +3433,8 @@ module Crystal
         @calls_previous_def = true
       end
 
-      call_args, last_call_has_parenthesis = preserve_last_call_has_parenthesis do
-        parse_call_args stop_on_do_after_space: (is_var || !@last_call_has_parenthesis)
+      call_args, last_call_has_parentheses = preserve_last_call_has_parentheses do
+        parse_call_args stop_on_do_after_space: (is_var || !@last_call_has_parentheses)
       end
       if call_args
         args = call_args.args
@@ -3405,7 +3451,7 @@ module Crystal
         #     end
         #
         # In this case, since x is a variable and the previous call (foo)
-        # doesn't have parenthesis, we don't parse "x do end" as an invocation
+        # doesn't have parentheses, we don't parse "x do end" as an invocation
         # to a method x with a block. Instead, we just stop on x and we don't
         # consume the block, leaving the block for 'foo' to consume.
       else
@@ -3414,7 +3460,7 @@ module Crystal
 
       node =
         if block || block_arg || global
-          Call.new nil, name, (args || [] of ASTNode), block, block_arg, named_args, global, name_column_number, last_call_has_parenthesis
+          Call.new nil, name, (args || [] of ASTNode), block, block_arg, named_args, global, name_column_number, last_call_has_parentheses
         else
           if args
             if (!force_call && is_var) && args.size == 1 && (num = args[0]) && (num.is_a?(NumberLiteral) && num.has_sign?)
@@ -3422,7 +3468,7 @@ module Crystal
               num.value = num.value.byte_slice(1)
               Call.new(Var.new(name), sign, args)
             else
-              Call.new(nil, name, args, nil, block_arg, named_args, global, name_column_number, last_call_has_parenthesis)
+              Call.new(nil, name, args, nil, block_arg, named_args, global, name_column_number, last_call_has_parentheses)
             end
           else
             if @no_type_declaration == 0 && @token.type == :":"
@@ -3435,7 +3481,7 @@ module Crystal
               end
               Var.new name
             else
-              Call.new nil, name, [] of ASTNode, nil, block_arg, named_args, global, name_column_number, last_call_has_parenthesis
+              Call.new nil, name, [] of ASTNode, nil, block_arg, named_args, global, name_column_number, last_call_has_parentheses
             end
           end
         end
@@ -3444,12 +3490,12 @@ module Crystal
       node
     end
 
-    def preserve_last_call_has_parenthesis
-      old_last_call_has_parenthesis = @last_call_has_parenthesis
+    def preserve_last_call_has_parentheses
+      old_last_call_has_parentheses = @last_call_has_parentheses
       value = yield
-      last_call_has_parenthesis = @last_call_has_parenthesis
-      @last_call_has_parenthesis = old_last_call_has_parenthesis
-      {value, last_call_has_parenthesis}
+      last_call_has_parentheses = @last_call_has_parentheses
+      @last_call_has_parentheses = old_last_call_has_parentheses
+      {value, last_call_has_parentheses}
     end
 
     def parse_block(block, stop_on_do = false)
@@ -3523,7 +3569,7 @@ module Crystal
     def parse_call_args(stop_on_do_after_space = false, allow_curly = false, control = false)
       case @token.type
       when :"{"
-        @last_call_has_parenthesis = false
+        @last_call_has_parentheses = false
         nil
       when :"("
         slash_is_regex!
@@ -3565,7 +3611,7 @@ module Crystal
           end
           end_location = token_end_location
           next_token_skip_space
-          @last_call_has_parenthesis = true
+          @last_call_has_parentheses = true
         end
 
         CallArgs.new args, nil, nil, nil, false, end_location
@@ -3573,7 +3619,7 @@ module Crystal
         slash_is_not_regex!
         end_location = token_end_location
         next_token
-        @last_call_has_parenthesis = false unless control
+        @last_call_has_parentheses = false unless control
 
         if stop_on_do_after_space && @token.keyword?(:do)
           return CallArgs.new nil, nil, nil, nil, true, end_location
@@ -3585,7 +3631,7 @@ module Crystal
 
         parse_call_args_space_consumed check_plus_and_minus: true, allow_curly: allow_curly
       else
-        @last_call_has_parenthesis = false
+        @last_call_has_parentheses = false
         nil
       end
     end
@@ -3606,7 +3652,7 @@ module Crystal
         return nil unless allow_curly
       when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"+", :"-", :"~", :"&", :"->", :"{{", :__LINE__, :__FILE__, :__DIR__, :UNDERSCORE
         # Nothing
-      when :"*"
+      when :"*", :"**"
         if current_char.whitespace?
           return nil
         end
@@ -3703,15 +3749,29 @@ module Crystal
       if @token.keyword?(:out)
         parse_out
       else
-        splat = false
-        if @token.type == :"*"
+        splat = nil
+        case @token.type
+        when :"*"
           unless current_char.whitespace?
-            splat = true
+            splat = :single
+            next_token
+          end
+        when :"**"
+          unless current_char.whitespace?
+            splat = :double
             next_token
           end
         end
+
         arg = parse_op_assign_no_control
-        arg = Splat.new(arg).at(arg.location) if splat
+
+        case splat
+        when :single
+          arg = Splat.new(arg).at(arg.location)
+        when :double
+          arg = DoubleSplat.new(arg).at(arg.location)
+        end
+
         arg
       end
     end
@@ -3882,7 +3942,7 @@ module Crystal
       type = parse_type(allow_primitives, allow_commas: allow_commas)
       case type
       when Array
-        raise "unexpected ',' in type (use parenthesis to disambiguate)", location
+        raise "unexpected ',' in type (use parentheses to disambiguate)", location
       when ASTNode
         type
       else
@@ -4312,7 +4372,7 @@ module Crystal
       end_location = token_end_location
       next_token
 
-      call_args, last_call_has_parenthesis = preserve_last_call_has_parenthesis { parse_call_args }
+      call_args, last_call_has_parentheses = preserve_last_call_has_parentheses { parse_call_args }
 
       if call_args
         args = call_args.args
@@ -4343,8 +4403,8 @@ module Crystal
       end_location = token_end_location
       next_token
 
-      call_args, last_call_has_parenthesis = preserve_last_call_has_parenthesis do
-        @last_call_has_parenthesis = true
+      call_args, last_call_has_parentheses = preserve_last_call_has_parentheses do
+        @last_call_has_parentheses = true
         parse_call_args allow_curly: true, control: true
       end
       args = call_args.args if call_args

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -519,6 +519,11 @@ module Crystal
       node
     end
 
+    def transform(node : DoubleSplat)
+      node.exp = node.exp.transform(self)
+      node
+    end
+
     def transform(node : VisibilityModifier)
       node.exp = node.exp.transform(self)
       node

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1756,10 +1756,17 @@ module Crystal
     end
 
     def visit(node : Splat)
-      write_token :"*"
+      visit_splat node, :"*"
+    end
+
+    def visit(node : DoubleSplat)
+      visit_splat node, :"**"
+    end
+
+    def visit_splat(node, token)
+      write_token token
       skip_space_or_newline
       accept node.exp
-
       false
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -522,11 +522,17 @@ module Crystal
     end
   end
 
+  record NamedArgumentType, name : String, type : Type do
+    def self.from_args(named_args : Array(NamedArgument)?)
+      named_args.try &.map { |named_arg| new(named_arg.name, named_arg.value.type) }
+    end
+  end
+
   record CallSignature,
     name : String,
     arg_types : Array(Type),
     block : Block?,
-    named_args : Array(NamedArgument)?
+    named_args : Array(NamedArgumentType)?
 
   module MatchesLookup
     def lookup_first_def(name, block)
@@ -733,7 +739,7 @@ module Crystal
     def_object_id : UInt64,
     arg_types : Array(Type),
     block_type : Type?,
-    named_args : Array({String, Type})?
+    named_args : Array(NamedArgumentType)?
 
   module DefInstanceContainer
     def def_instances

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -23,6 +23,21 @@
 # a value whose type is the union of all the types in the named tuple,
 # and might raise `KeyError`.
 struct NamedTuple
+  # Creates a named tuple that will contain the given arguments.
+  #
+  # This method is useful in macros and generic code because with it you can
+  # creates empty named tuples, something that you can't do with a tuple literal.
+  #
+  # ```
+  # NamedTuple.new(name: "Crystal", year: 2011) #=> {name: "Crystal", year: 2011}
+  # NamedTuple.new                  #=> {}
+  #
+  # {}                         # syntax error
+  # ```
+  # def self.new(**options)
+  #   options
+  # end
+
   # Returns the value for the given *key*, if there's such key, otherwise raises `KeyError`.
   #
   # ```


### PR DESCRIPTION
This PR adds double splatting to the language.

A double splat:
* can appear in a method/macro definition and in a call
* when used in a call argument, it "splats" a named tuple
* when used in a method argument, it "unsplats" named arguments

If you are familiar with Ruby double splat, it's similar, although a bit different in Crystal because Crystal doesn't have keyword args, and we also use a named tuple instead of a hash.

With some examples all of this will become clear, you can look at the specs [here](https://github.com/crystal-lang/crystal/blob/feature/double_splat/spec/compiler/type_inference/double_splat_spec.cr) and [here](https://github.com/crystal-lang/crystal/blob/feature/double_splat/spec/compiler/codegen/double_splat_spec.cr).

With this, we can make the delegate macro work with named arguments, because this now works:

```crystal
def foo(x, y)
  x - y
end

# forward all args and named args
def bar(*args, **nargs)
  foo(*args, **nargs)
end

bar 10, 2 # => 8
bar 10, y: 2 #=> 8
bar x: 10, y: 2 # => 8
bar y: 2, x: 10 # => 8
```

Another useful thing is that one can now catch all named arguments with a double splat:

```crystal
def foo(**options)
  options[:x] - options[:y] 
end

foo y: 2, x: 10 # => 8
```

The above is specially useful to avoid repeating a set of options in multiple methods that simply forward this information. Remember that doing `options[:x]` in the code above will give a compile error if `x` is not passed, so it's super type-safe.

With the above, we can also force method arguments to always be passed as named arguments. For example:

```crystal
# options must include :element and :in
def put(**options)
  options[:in] << options[:element]
end

ary = [1, 2, 3]
put element: 4, in: ary
ary # => [1, 2, 3, 4]

puts 4, [1] # compile error
put element: 4, innnn: [1, 2, 3] # compile error (when accessing options[:in])
```

The only "problem" with the above is that we can pass extra named arguments and we won't get an error. We can solve this problem later with a type restriction on options, to restrict the keys and also the types.

Double splats are also available in macro arguments as well.

In a method/macro, a double splat can be mixed with a splat:

```crystal
def foo(*args, **options)
end

foo 1, 2, x: 10, y: 20 # OK, args is {1, 2}, options is {x: 10, y: 20}
```

However, this doesn't work if there are positional arguments in the method/macro definition:
```crystal
def foo(x, *args, **options)
end

foo 10, 20, 30, y: 40, z: 50 # probably obvious
foo 10, 20, 30, x: 40, z: 50 # but this...?
```

The reason is that it becomes very hard to know what would happen, where the args will go, and it might also not be very useful, so for now it's out of the language.

Of course after this the only thing remaining to be able to entirely forward a call's information is forwarding a block. This will probably come in the future, right now it's kind of hard to do.