### PR TITLE
Compiler: bare splat and required named arguments

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -473,56 +473,6 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "runs macro with arg and splat in first position (1)" do
-    run(%(
-      macro foo(*args, name)
-        {{args.size}}
-      end
-
-      foo 1, 1, 1, bar
-      )).to_i.should eq(3)
-  end
-
-  it "runs macro with arg and splat in first position (2)" do
-    run(%(
-      macro foo(*args, name)
-        {{name}}
-      end
-
-      foo 1, 1, 1, "hello"
-      )).to_string.should eq("hello")
-  end
-
-  it "runs macro with arg and splat in the middle (1)" do
-    run(%(
-      macro foo(foo, *args, name)
-        {{args.size}}
-      end
-
-      foo x, 1, 1, 1, bar
-      )).to_i.should eq(3)
-  end
-
-  it "runs macro with arg and splat in the middle (2)" do
-    run(%(
-      macro foo(foo, *args, name)
-        {{foo}}
-      end
-
-      foo "yellow", 1, 1, 1, bar
-      )).to_string.should eq("yellow")
-  end
-
-  it "runs macro with arg and splat in the middle (3)" do
-    run(%(
-      macro foo(foo, *args, name)
-        {{name}}
-      end
-
-      foo "yellow", 1, 1, 1, "cool"
-      )).to_string.should eq("cool")
-  end
-
   it "expands macro that yields" do
     run(%(
       def foo

--- a/spec/compiler/codegen/named_args_spec.cr
+++ b/spec/compiler/codegen/named_args_spec.cr
@@ -122,4 +122,54 @@ describe "Code gen: named args" do
       foo y: 42, x: "foo"
       )).to_i.should eq(42)
   end
+
+  it "overloads based on required named args" do
+    run(%(
+      def foo(x, *, y)
+        x + y
+      end
+
+      def foo(x, *, z)
+        x * z
+      end
+
+      a = foo(10, y: 20)
+      b = foo(30, z: 40)
+      a + b
+      )).to_i.should eq(10 + 20 + 30*40)
+  end
+
+  it "overloads based on required named args, with restrictions" do
+    run(%(
+      def foo(x, *, z : Int32)
+        x + z
+      end
+
+      def foo(x, *, z : Float64)
+        x * z.to_i
+      end
+
+      a = foo(10, z: 20)
+      b = foo(30, z: 40.0)
+      a + b
+      )).to_i.should eq(10 + 20 + 30*40)
+  end
+
+  it "uses bare splat in new (2)" do
+    run(%(
+      class Foo
+        def initialize(*, y = 22)
+          @y = y
+        end
+
+        def y
+          @y
+        end
+      end
+
+      v1 = Foo.new.y
+      v2 = Foo.new(y: 20).y
+      v1 + v2
+      )).to_i.should eq(42)
+  end
 end

--- a/spec/compiler/codegen/splat_spec.cr
+++ b/spec/compiler/codegen/splat_spec.cr
@@ -29,20 +29,6 @@ describe "Code gen: splat" do
       )).to_i.should eq(12)
   end
 
-  it "splats with two other args" do
-    run(%(
-      struct Tuple
-        def size; {{T.size}}; end
-      end
-
-      def foo(x, *args, z)
-        x + args.size + z
-      end
-
-      foo 10, 2, 20
-      )).to_i.should eq(31)
-  end
-
   it "splats on call" do
     run(%(
       def foo(x, y)

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -886,4 +886,7 @@ describe Crystal::Formatter do
   assert_format "foo.as?(T).bar"
   assert_format "foo &.as?(T)"
   assert_format "foo &.bar.as?(T)"
+
+  assert_format "def foo(x, *, z)\nend"
+  assert_format "macro foo(x, *, z)\nend"
 end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -57,26 +57,6 @@ describe "Normalize: def" do
     actual.should eq(expected)
   end
 
-  it "expands with splat with one arg after" do
-    a_def = parse("def foo(*args, x); args; end").as(Def)
-    actual = a_def.expand_default_arguments(Program.new, 3)
-    expected = parse("def foo(__temp_1, __temp_2, x)\n  args = {__temp_1, __temp_2}\n  args\nend")
-    actual.should eq(expected)
-  end
-
-  it "expands with splat with one arg after and just one argument (#1340)" do
-    a_def = parse("def foo(*args, x); args; end").as(Def)
-    actual = a_def.expand_default_arguments(Program.new, 1)
-    actual.to_s.should eq("def foo(x)\n  args = {}\n  args\nend")
-  end
-
-  it "expands with splat with one arg before and after" do
-    a_def = parse("def foo(x, *args, z); args; end").as(Def)
-    actual = a_def.expand_default_arguments(Program.new, 3)
-    expected = parse("def foo(x, __temp_1, z)\n  args = {__temp_1}\n  args\nend")
-    actual.should eq(expected)
-  end
-
   it "expands with splat and zero" do
     a_def = parse("def foo(*args); args; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0)
@@ -162,12 +142,6 @@ describe "Normalize: def" do
     other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  yield x, file, line\nend")
   end
 
-  it "expands with single splat and named arguments" do
-    a_def = parse("def foo(*args); args; end").as(Def)
-    other_def = a_def.expand_default_arguments(Program.new, 0, ["x", "y"])
-    other_def.to_s.should eq("def foo:x:y(x, y)\n  args = { {x: x, y: y} }\n  args\nend")
-  end
-
   it "expands a def with double splat and no args" do
     a_def = parse("def foo(**options); options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0)
@@ -190,5 +164,23 @@ describe "Normalize: def" do
     a_def = parse("def foo(*args, **options); args + options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 2, ["x", "y"])
     other_def.to_s.should eq("def foo:x:y(__temp_1, __temp_2, x, y)\n  args = {__temp_1, __temp_2}\n  options = {x: x, y: y}\n  args + options\nend")
+  end
+
+  it "expands arg with default value after splat" do
+    a_def = parse("def foo(*args, x = 10); args + x; end").as(Def)
+    other_def = a_def.expand_default_arguments(Program.new, 0)
+    other_def.to_s.should eq("def foo\n  x = 10\n  args = {}\n  args + x\nend")
+  end
+
+  it "expands default value after splat index" do
+    a_def = parse("def foo(x, *y, z = 10); x + y + z; end").as(Def)
+    other_def = a_def.expand_default_arguments(Program.new, 3)
+    other_def.to_s.should eq("def foo(x, __temp_1, __temp_2)\n  z = 10\n  y = {__temp_1, __temp_2}\n  (x + y) + z\nend")
+  end
+
+  it "uses bare *" do
+    a_def = parse("def foo(x, *, y); x + y; end").as(Def)
+    other_def = a_def.expand_default_arguments(Program.new, 1, ["y"])
+    other_def.to_s.should eq("def foo:y(x, y)\n  x + y\nend")
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -196,6 +196,11 @@ describe "Parser" do
   it_parses "def foo(@@var = 1); 1; end", Def.new("foo", [Arg.new("var", 1.int32)], [Assign.new("@@var".class_var, "var".var), 1.int32] of ASTNode)
   it_parses "def foo(&@block); end", Def.new("foo", body: Assign.new("@block".instance_var, "block".var), block_arg: Arg.new("block"), yields: 0)
 
+  it_parses "def foo(x, *args, y = 2); 1; end", Def.new("foo", args: ["x".arg, "args".arg, Arg.new("y", default_value: 2.int32)], body: 1.int32, splat_index: 1)
+  it_parses "def foo(x, *args, y = 2, w, z = 3); 1; end", Def.new("foo", args: ["x".arg, "args".arg, Arg.new("y", default_value: 2.int32), "w".arg, Arg.new("z", default_value: 3.int32)], body: 1.int32, splat_index: 1)
+  it_parses "def foo(x, *, y); 1; end", Def.new("foo", args: ["x".arg, "".arg, "y".arg], body: 1.int32, splat_index: 1)
+  assert_syntax_error "def foo(x, *); 1; end", "named arguments must follow bare *"
+
   assert_syntax_error "def foo(var = 1 : Int32); end", "the syntax for an argument with a default value V and type T is `arg : T = V`"
   assert_syntax_error "def foo(var = x : Int); end", "the syntax for an argument with a default value V and type T is `arg : T = V`"
 
@@ -203,10 +208,13 @@ describe "Parser" do
   it_parses "def foo(x, **args)\n1\nend", Def.new("foo", body: 1.int32, args: ["x".arg], double_splat: "args")
   it_parses "def foo(x, **args, &block)\n1\nend", Def.new("foo", body: 1.int32, args: ["x".arg], double_splat: "args", block_arg: "block".arg, yields: 0)
   it_parses "def foo(**args)\nargs\nend", Def.new("foo", body: "args".var, double_splat: "args")
+  it_parses "def foo(x = 1, **args)\n1\nend", Def.new("foo", body: 1.int32, args: [Arg.new("x", default_value: 1.int32)], double_splat: "args")
 
   assert_syntax_error "def foo(**args, **args2)"
 
   it_parses "macro foo(**args)\n1\nend", Macro.new("foo", body: MacroLiteral.new("1\n"), double_splat: "args")
+
+  assert_syntax_error "macro foo(x, *); 1; end", "named arguments must follow bare *"
 
   it_parses "abstract def foo", Def.new("foo", abstract: true)
   it_parses "abstract def foo; 1", [Def.new("foo", abstract: true), 1.int32]
@@ -1126,7 +1134,6 @@ describe "Parser" do
 
   assert_syntax_error "1 2", "unexpected token: 2"
   assert_syntax_error "macro foo(*x, *y); end", "unexpected token: *"
-  assert_syntax_error "def foo(*x, y = 1); end", "unexpected token: ="
 
   assert_syntax_error "foo x: 1, x: 1", "duplicated named argument: x", 1, 11
   assert_syntax_error "def foo(x, x); end", "duplicated argument name: x", 1, 12

--- a/spec/compiler/type_inference/double_splat_spec.cr
+++ b/spec/compiler/type_inference/double_splat_spec.cr
@@ -96,4 +96,22 @@ describe "Type inference: double splat" do
       foo 1, 'a', x: "foo", y: true
       )) { tuple_of([tuple_of([int32, char]), named_tuple_of({"x": string, "y": bool})]) }
   end
+
+  it "uses double splat in new" do
+    assert_type(%(
+      class Foo
+        @x : Int32
+
+        def initialize(**options)
+          @x = options[:x]
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new(x: 1).x
+      )) { int32 }
+  end
 end

--- a/spec/compiler/type_inference/macro_spec.cr
+++ b/spec/compiler/type_inference/macro_spec.cr
@@ -733,7 +733,7 @@ describe "Type inference: macro" do
 
       foo x: 1, y: 2
       ),
-      "can't use named args with macros that have a splat argument"
+      "no argument named 'x'"
   end
 
   it "errors if named arg matches splat argument" do
@@ -743,17 +743,27 @@ describe "Type inference: macro" do
 
       foo x: 1, y: 2
       ),
-      "can't use named args with macros that have a splat argument"
+      "wrong number of arguments for macro 'foo' (given 0, expected 1+)"
   end
 
-  it "doesn't allow named arg if there's a splat" do
+  it "says missing argument because positional args don't match past splat" do
     assert_error %(
-      macro foo(*y, x)
+      macro foo(x, *y, z)
       end
 
-      foo 1, x: 2
+      foo 1, 2
       ),
-      "can't use named args with macros that have a splat argument"
+      "missing argument: z"
+  end
+
+  it "allows named args after splat" do
+    assert_type(%(
+      macro foo(*y, x)
+        { {{y}}, {{x}} }
+      end
+
+      foo 1, x: 'a'
+      )) { tuple_of([tuple_of([int32]), char]) }
   end
 
   it "errors if missing one argument" do
@@ -859,5 +869,45 @@ describe "Type inference: macro" do
 
       1
       )) { int32 }
+  end
+
+  it "matches with default value after splat" do
+    assert_type(%(
+      macro foo(x, *y, z = true)
+        { {{x}}, {{y}}, {{z}} }
+      end
+
+      foo 1, 'a'
+      )) { tuple_of([int32, tuple_of([char]), bool]) }
+  end
+
+  it "uses bare *" do
+    assert_type(%(
+      macro foo(x, *, y)
+        { {{x}}, {{y}} }
+      end
+
+      foo 10, y: 'a'
+      )) { tuple_of([int32, char]) }
+  end
+
+  it "uses bare *, doesn't let more args" do
+    assert_error %(
+      macro foo(x, *, y)
+      end
+
+      foo 10, 20, y: 30
+      ),
+      "wrong number of arguments for macro 'foo' (given 2, expected 1)"
+  end
+
+  it "uses bare *, doesn't let more args" do
+    assert_error %(
+      def foo(x, *, y)
+      end
+
+      foo 10, 20, y: 30
+      ),
+      "wrong number of arguments for 'foo' (given 2, expected 1)"
   end
 end

--- a/spec/compiler/type_inference/named_args_spec.cr
+++ b/spec/compiler/type_inference/named_args_spec.cr
@@ -112,7 +112,7 @@ describe "Type inference: named args" do
 
       foo x: 1, y: 2
       ),
-      "can't use named args with methods that have a splat argument"
+      "no argument named 'x'"
   end
 
   it "errors if named arg matches splat argument" do
@@ -122,17 +122,17 @@ describe "Type inference: named args" do
 
       foo x: 1, y: 2
       ),
-      "can't use named args with methods that have a splat argument"
+      "wrong number of arguments for 'foo' (given 0, expected 1+)"
   end
 
-  it "doesn't allow named arg if there's a splat" do
-    assert_error %(
+  it "allows named arg if there's a splat" do
+    assert_type(%(
       def foo(*y, x)
+        { x, y }
       end
 
-      foo 1, x: 2
-      ),
-      "can't use named args with methods that have a splat argument"
+      foo 1, x: 'a'
+      )) { tuple_of([char, tuple_of([int32])]) }
   end
 
   it "errors if missing one argument" do
@@ -176,6 +176,61 @@ describe "Type inference: named args" do
 
       foo(x: 2)
       ),
-      "no overload matches"
+      "wrong number of arguments for 'foo' (given 0, expected 2..3)"
+  end
+
+  it "gives correct error message for missing args after *" do
+    assert_error %(
+      def foo(*, x, y)
+      end
+
+      foo
+      ),
+      "missing arguments: x, y"
+  end
+
+  it "overloads based on required named args" do
+    assert_type(%(
+      def foo(x, *, y)
+        1
+      end
+
+      def foo(x, *, z)
+        'a'
+      end
+
+      a = foo(1, y: 2)
+      b = foo(1, z: 2)
+
+      {a, b}
+      )) { tuple_of([int32, char]) }
+  end
+
+  it "overloads based on required named args, with restrictions" do
+    assert_type(%(
+      def foo(x, *, z : Int32)
+        1
+      end
+
+      def foo(x, *, z : Float64)
+        'a'
+      end
+
+      a = foo(1, z: 1)
+      b = foo(1, z: 1.5)
+
+      {a, b}
+      )) { tuple_of([int32, char]) }
+  end
+
+  it "uses bare splat in new" do
+    assert_type(%(
+      class Foo
+        def initialize(*, y = nil)
+        end
+      end
+
+      Foo.new
+      )) { types["Foo"] }
   end
 end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -1,6 +1,6 @@
 require "spec"
 
-private def assert_dir_glob(*patterns, expected_result)
+private def assert_dir_glob(expected_result, *patterns)
   result = Dir[*patterns]
   result.sort.should eq(expected_result.sort)
 end
@@ -70,22 +70,20 @@ describe "Dir" do
 
   describe "glob" do
     it "tests glob with a single pattern" do
-      assert_dir_glob "#{__DIR__}/data/dir/*.txt",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+      ], "#{__DIR__}/data/dir/*.txt"
     end
 
     it "tests glob with multiple patterns" do
-      assert_dir_glob "#{__DIR__}/data/dir/*.txt", "#{__DIR__}/data/dir/subdir/*.txt",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir/f1.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir/f1.txt",
+      ], "#{__DIR__}/data/dir/*.txt", "#{__DIR__}/data/dir/subdir/*.txt"
     end
 
     it "tests glob with a single pattern with block" do
@@ -101,95 +99,86 @@ describe "Dir" do
     end
 
     it "tests a recursive glob" do
-      assert_dir_glob "#{__DIR__}/data/dir/**/*.txt",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir/f1.txt",
-          "#{__DIR__}/data/dir/subdir/subdir2/f2.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir/f1.txt",
+        "#{__DIR__}/data/dir/subdir/subdir2/f2.txt",
+      ], "#{__DIR__}/data/dir/**/*.txt"
     end
 
     it "tests a recursive glob with '?'" do
-      assert_dir_glob "#{__DIR__}/data/dir/f?.tx?",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/f3.txx",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/f3.txx",
+      ], "#{__DIR__}/data/dir/f?.tx?"
     end
 
     it "tests a recursive glob with alternation" do
-      assert_dir_glob "#{__DIR__}/data/{dir,dir/subdir}/*.txt",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir/f1.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir/f1.txt",
+      ], "#{__DIR__}/data/{dir,dir/subdir}/*.txt"
     end
 
     it "tests a glob with recursion inside alternation" do
-      assert_dir_glob "#{__DIR__}/data/dir/{**/*.txt,**/*.txx}",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/f3.txx",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir/f1.txt",
-          "#{__DIR__}/data/dir/subdir/subdir2/f2.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/f3.txx",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir/f1.txt",
+        "#{__DIR__}/data/dir/subdir/subdir2/f2.txt",
+      ], "#{__DIR__}/data/dir/{**/*.txt,**/*.txx}"
     end
 
     it "tests a recursive glob with nested alternations" do
-      assert_dir_glob "#{__DIR__}/data/dir/{?1.*,{f,g}2.txt}",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+      ], "#{__DIR__}/data/dir/{?1.*,{f,g}2.txt}"
     end
 
     it "tests with *" do
-      assert_dir_glob "#{__DIR__}/data/dir/*",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/f3.txx",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir",
-          "#{__DIR__}/data/dir/subdir2",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/f3.txx",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir",
+        "#{__DIR__}/data/dir/subdir2",
+      ], "#{__DIR__}/data/dir/*"
     end
 
     it "tests with ** (same as *)" do
-      assert_dir_glob "#{__DIR__}/data/dir/**",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/f3.txx",
-          "#{__DIR__}/data/dir/g2.txt",
-          "#{__DIR__}/data/dir/subdir",
-          "#{__DIR__}/data/dir/subdir2",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/f3.txx",
+        "#{__DIR__}/data/dir/g2.txt",
+        "#{__DIR__}/data/dir/subdir",
+        "#{__DIR__}/data/dir/subdir2",
+      ], "#{__DIR__}/data/dir/**"
     end
 
     it "tests with */" do
-      assert_dir_glob "#{__DIR__}/data/dir/*/",
-        [
-          "#{__DIR__}/data/dir/subdir/",
-          "#{__DIR__}/data/dir/subdir2/",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/subdir/",
+        "#{__DIR__}/data/dir/subdir2/",
+      ], "#{__DIR__}/data/dir/*/"
     end
 
     it "tests glob with a single pattern with extra slashes" do
-      assert_dir_glob "#{__DIR__}////data////dir////*.txt",
-        [
-          "#{__DIR__}/data/dir/f1.txt",
-          "#{__DIR__}/data/dir/f2.txt",
-          "#{__DIR__}/data/dir/g2.txt",
-        ]
+      assert_dir_glob [
+        "#{__DIR__}/data/dir/f1.txt",
+        "#{__DIR__}/data/dir/f2.txt",
+        "#{__DIR__}/data/dir/g2.txt",
+      ], "#{__DIR__}////data////dir////*.txt"
     end
   end
 

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -111,23 +111,15 @@ module Crystal
         # Gather splat args into an array
         if splat_index
           splat_arg = a_macro.args[splat_index]
-          splat_elements = if splat_index < call.args.size
-                             splat_size = Splat.size(a_macro, call.args)
-                             call.args[splat_index, splat_size]
-                           else
-                             [] of ASTNode
-                           end
-
-          # If there are named arguments, put them there too as a separate named tuple literal,
-          # but only if there's no double splat
-          if !double_splat && (named_args = call.named_args)
-            named_tuple_elems = named_args.map do |named_arg|
-              NamedTupleLiteral::Entry.new(named_arg.name, named_arg.value)
-            end
-            splat_elements << NamedTupleLiteral.new(named_tuple_elems)
+          unless splat_arg.name.empty?
+            splat_elements = if splat_index < call.args.size
+                               splat_size = Splat.size(a_macro, call.args)
+                               call.args[splat_index, splat_size]
+                             else
+                               [] of ASTNode
+                             end
+            vars[splat_arg.name] = TupleLiteral.new(splat_elements)
           end
-
-          vars[splat_arg.name] = TupleLiteral.new(splat_elements)
         end
 
         # The double splat argument

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -408,9 +408,6 @@ module Crystal
       Splat.at(a_def, objects) do |arg, arg_index, object, object_index|
         yield arg, arg_index, object, object_index
       end
-      Splat.after(a_def, objects) do |arg, arg_index, object, object_index|
-        yield arg, arg_index, object, object_index
-      end
     end
 
     # Yields `arg, arg_index, object, object_index` corresponding
@@ -434,47 +431,28 @@ module Crystal
     # If there are more objects than arguments in the method, they are not yielded.
     # If splat index is `nil`, all args and objects (with their indices) are yielded.
     def self.at(a_def, objects, &block)
-      splat = a_def.splat_index
-      return unless splat
+      splat_index = a_def.splat_index
+      return unless splat_index
 
-      splat_size = objects.size - (a_def.args.size - 1)
+      splat_size = Splat.size(a_def, objects, splat_index)
       splat_size.times do |i|
-        obj_index = splat + i
+        obj_index = splat_index + i
         obj = objects[obj_index]?
         break unless obj
 
-        yield a_def.args[splat], splat, obj, obj_index
-      end
-
-      nil
-    end
-
-    # Yields `arg, arg_index, object, object_index` corresponding
-    # to arguments after a def's splat index, matching the given objects.
-    # If there are more objects than arguments in the method, they are not yielded.
-    # If splat index is `nil`, all args and objects (with their indices) are yielded.
-    def self.after(a_def, objects, &block)
-      splat = a_def.splat_index
-      return unless splat
-
-      splat_size = objects.size - (a_def.args.size - 1)
-      remaining_size = objects.size - (splat + splat_size)
-      remaining_size.times do |i|
-        arg_index = splat + 1 + i
-        obj_index = splat + splat_size + i
-        obj = objects[obj_index]?
-        break unless obj
-
-        yield a_def.args[arg_index], arg_index, obj, obj_index
+        yield a_def.args[splat_index], splat_index, obj, obj_index
       end
 
       nil
     end
 
     # Returns the splat size of this def matching the given objects.
-    # Returns `nil` if this def has no splat index.
-    def self.size(a_def, objects)
-      objects.size - (a_def.args.size - 1)
+    def self.size(a_def, objects, splat_index = a_def.splat_index)
+      if splat_index
+        objects.size - splat_index
+      else
+        0
+      end
     end
   end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -153,8 +153,10 @@ class Crystal::Call
       min_size <= real_args_size <= max_size
     end
 
+    # bare_splat = splat_index && args[splat_index].name.empty?
+
     # Don't say "wrong number of arguments" when there are named args in this call
-    if defs_matching_args_size.empty? && !named_args_types
+    if defs_matching_args_size.empty? # && (!named_args_types || bare)
       all_arguments_sizes = [] of Int32
       min_splat = Int32::MAX
       defs.each do |a_def|
@@ -277,7 +279,6 @@ class Crystal::Call
   # If there's only one def that could match, and there are named
   # arguments in this call, we can give a better error message.
   def check_single_def_error_message(defs, named_args, io)
-    return false unless named_args
     return false unless defs.size == 1
 
     a_def = defs.first
@@ -292,13 +293,9 @@ class Crystal::Call
   end
 
   def check_named_args_and_splats(a_def, named_args)
-    if a_def.splat_index
-      if a_def.is_a?(Def)
-        return "can't use named args with methods that have a splat argument"
-      else
-        return "can't use named args with macros that have a splat argument"
-      end
-    end
+    splat_index = a_def.splat_index
+    return if !splat_index && !named_args
+    return if splat_index == a_def.args.size - 1
 
     # Check if some mandatory arguments are missing
     mandatory_args = BitArray.new(a_def.args.size)
@@ -306,7 +303,7 @@ class Crystal::Call
       mandatory_args[arg_index] = true
     end
 
-    named_args.each do |named_arg|
+    named_args.try &.each do |named_arg|
       found_index = a_def.args.index { |arg| arg.name == named_arg.name }
       if found_index
         mandatory_args[found_index] = true
@@ -319,6 +316,7 @@ class Crystal::Call
 
       arg = a_def.args[index]
       next if arg.default_value
+      next if arg.name.empty?
 
       missing_args << arg.name
     end
@@ -452,13 +450,13 @@ class Crystal::Call
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros
 
-    if macros.size == 1 && (named_args = @named_args)
+    if macros.size == 1
       if msg = check_named_args_and_splats(macros.first, named_args)
         raise msg
       end
     end
 
-    all_arguments_sizes = Set(Int32).new
+    all_arguments_sizes = Set(String).new
     macros.each do |a_macro|
       named_args.try &.each do |named_arg|
         index = a_macro.args.index { |arg| arg.name == named_arg.name }
@@ -471,16 +469,28 @@ class Crystal::Call
         end
       end
 
-      min_size = a_macro.args.index(&.default_value) || a_macro.args.size
-      min_size.upto(a_macro.args.size) do |args_size|
-        all_arguments_sizes << args_size
-      end
-    end
+      plus = false
 
-    if macros.size == 1 && (named_args = self.named_args)
-      a_macro = macros.first
-      if msg = check_named_args_and_splats(a_macro, named_args)
-        raise msg
+      splat_index = a_macro.splat_index
+      if splat_index
+        if a_macro.args[splat_index].name.empty?
+          min_size = max_size = splat_index
+        else
+          min_size = splat_index
+          max_size = a_macro.args.size
+          plus = true
+        end
+      else
+        min_size = a_macro.args.index(&.default_value) || a_macro.args.size
+        max_size = a_macro.args.size
+      end
+
+      if plus
+        all_arguments_sizes << "#{min_size}+"
+      else
+        min_size.upto(max_size) do |args_size|
+          all_arguments_sizes << args_size.to_s
+        end
       end
     end
 

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -5,7 +5,7 @@ class Crystal::Def
     # If the named arguments cover all arguments with a default value and
     # they come in the same order, we can safely return this def without
     # needing a useless indirection.
-    if named_args && args_size + named_args.size == args.size
+    if !splat_index && named_args && args_size + named_args.size == args.size
       all_match = true
       named_args.each_with_index do |named_arg, i|
         arg = args[args_size + i]
@@ -36,39 +36,35 @@ class Crystal::Def
 
     retain_body = yields || splat_index || double_splat || assigns_special_var || macro_def? || args.any? { |arg| arg.default_value && arg.restriction }
 
-    splat_index = self.splat_index || -1
+    splat_index = self.splat_index
     double_splat = self.double_splat
 
     new_args = [] of Arg
 
     # Args before splat index
-    if splat_index == -1
-      before_size = 0
+    if splat_index
+      before_splat_size = Math.min(args_size, splat_index)
     else
-      before_size = Math.min(args_size, splat_index)
-      before_size.times do |index|
-        new_args << args[index].clone
-      end
+      before_splat_size = args_size
+    end
+
+    before_splat_size.times do |index|
+      new_args << args[index].clone
     end
 
     # Splat arg
-    if splat_index == -1
-      splat_size = 0
-    else
+    if splat_index && !args[splat_index].name.empty?
       splat_names = [] of String
-      splat_size = args_size - (args.size - 1)
+
+      splat_size = args_size - splat_index
       splat_size = 0 if splat_size < 0
       splat_size.times do |index|
         splat_name = program.new_temp_var_name
         splat_names << splat_name
         new_args << Arg.new(splat_name)
       end
-    end
-
-    base = splat_index + 1
-    after_size = args_size - before_size - splat_size
-    after_size.times do |i|
-      new_args << args[base + i].clone
+    else
+      splat_size = 0
     end
 
     if named_args
@@ -100,16 +96,17 @@ class Crystal::Def
       new_body = [] of ASTNode
       body = self.body.clone
 
-      # Default values
-      if splat_index == -1
-        end_index = args.size - 1
-      else
-        end_index = Math.min(args_size, splat_index - 1)
-      end
-
       # Declare variables that are not covered
-      args_size.upto(end_index) do |index|
-        arg = args[index]
+      args.each_with_index do |arg, index|
+        # Skip if the argument is covered by a positional argument
+        next if index < args_size && !(splat_index && index > splat_index)
+
+        # Skip if this is the splat index argument
+        next if index == splat_index
+
+        # pp arg, index, splat_index, args_size
+        # pp index, args_size, splat_index
+        # next if index <= splat_index || index < args_size
 
         # But first check if we already have it in the named arguments
         unless named_args.try &.index(arg.name)
@@ -136,22 +133,11 @@ class Crystal::Def
       end
 
       # Splat argument
-      if splat_names
+      if splat_names && splat_index
         tuple_args = [] of ASTNode
         splat_size.times do |i|
           tuple_args << Var.new(splat_names[i])
         end
-
-        # If there are named args and just a single splat argument,
-        # it's the case of named args matching a splat
-        # (don't do this if there's a double splat)
-        if !double_splat && named_args && splat_index == 0 && self.args.size == 1
-          entries = named_args.map_with_index do |named_arg, i|
-            NamedTupleLiteral::Entry.new(named_arg, Var.new(named_arg))
-          end
-          tuple_args << NamedTupleLiteral.new(entries)
-        end
-
         tuple = TupleLiteral.new(tuple_args)
         new_body << Assign.new(Var.new(args[splat_index].name), tuple)
       end
@@ -209,6 +195,8 @@ class Crystal::Def
 
       expansion.body = Expressions.new(body)
     end
+
+    # pp expansion
 
     expansion
   end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -131,16 +131,12 @@ module Crystal
       named_args = signature.named_args
       splat_index = a_def.splat_index
 
-      # If there's a splat in the method and named args in the call,
-      # there's no match (it's confusing to determine what should happen),
-      # unless there's a single argument in this call and it's the splat,
-      # and there's also a double splat.
-      if named_args && splat_index
-        # If there's a restriction on the splat, named args won't match
-        if a_def.double_splat && a_def.args.size == 1 && !a_def.args[splat_index].restriction
-          return Match.new(a_def, arg_types, context)
+      # If there are arguments past the splat index and no named args, there's no match,
+      # unless all args past it have default values
+      if splat_index && a_def.args.size > splat_index + 1 && !named_args
+        unless (splat_index + 1...a_def.args.size).all? { |i| a_def.args[i].default_value }
+          return nil
         end
-        return nil
       end
 
       # If there are named args we must check that all mandatory args

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -114,6 +114,7 @@ module Crystal
 
       new_def = Def.new("new", def_args, Nop.new)
       new_def.splat_index = splat_index
+      new_def.double_splat = double_splat
       new_def.yields = yields
       new_def.visibility = Visibility::Private if visibility.private?
 
@@ -142,15 +143,34 @@ module Crystal
       #    x.initialize ..., &block
       #    GC.add_finalizer x if x.responds_to? :finalize
       #    x
-      var = Var.new("_")
-      new_vars = args.map { |arg| Var.new(arg.name).as(ASTNode) }
+      obj = Var.new("_")
 
-      if splat_index = self.splat_index
-        new_vars[splat_index] = Splat.new(new_vars[splat_index])
+      new_vars = [] of ASTNode
+      named_args = nil
+      splat_index = self.splat_index
+
+      args.each_with_index do |arg, i|
+        # This is the case of a bare splat argument
+        next if arg.name.empty?
+
+        # Check if the argument has to be passed as a named argument
+        if splat_index && i > splat_index
+          named_args ||= [] of NamedArgument
+          named_args << NamedArgument.new(arg.name, Var.new(arg.name))
+        else
+          new_var = Var.new(arg.name)
+          new_var = Splat.new(new_var) if i == splat_index
+          new_vars << new_var
+        end
       end
 
-      assign = Assign.new(var, alloc)
-      init = Call.new(var, "initialize", new_vars)
+      # Make sure to forward the double splat argument
+      if double_splat = self.double_splat
+        new_vars << DoubleSplat.new(Var.new(double_splat))
+      end
+
+      assign = Assign.new(obj, alloc)
+      init = Call.new(obj, "initialize", new_vars, named_args: named_args)
 
       # If the initialize yields, call it with a block
       # that yields those arguments.
@@ -163,8 +183,8 @@ module Crystal
       exps = Array(ASTNode).new(4)
       exps << assign
       exps << init
-      exps << Call.new(Path.global("GC"), "add_finalizer", var) if instance_type.has_finalizer?
-      exps << var
+      exps << Call.new(Path.global("GC"), "add_finalizer", obj) if instance_type.has_finalizer?
+      exps << obj
 
       # Forward block argument if any
       if uses_block_arg

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -95,7 +95,46 @@ module Crystal
         end
       end
 
+      # Check required named arguments
+      self_named_args = self.required_named_arguments
+      other_named_args = other.required_named_arguments
+
+      # If both have named args we must restrict name by name
+      if self_named_args && other_named_args
+        self_names = self_named_args.map(&.name)
+        other_names = other_named_args.map(&.name)
+
+        # If the names of the required named args are different, these are different overloads
+        return false if self_names != other_names
+
+        # They are the same, so we apply usual restriction checking on the args
+        self_named_args.zip(other_named_args) do |self_arg, other_arg|
+          self_restriction = self_arg.restriction
+          other_restriction = other_arg.restriction
+          return false if self_restriction == nil && other_restriction != nil
+
+          if self_restriction && other_restriction
+            return false unless self_restriction.is_restriction_of?(other_restriction, owner)
+          end
+        end
+
+        return true
+      end
+
+      # If one has required named args and the other doesn't, none is stricter than the other
+      if (self_named_args || other_named_args)
+        return false
+      end
+
       true
+    end
+
+    def required_named_arguments
+      if (splat_index = self.def.splat_index) && splat_index != self.def.args.size - 1
+        self.def.args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by &.name
+      else
+        nil
+      end
     end
   end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1308,8 +1308,15 @@ module Crystal
           end
 
           to_skip += 1 if at_skip?
-          indent(prefix_size, arg)
+
+          if i == splat_index && arg.name.empty?
+            # Nothing
+          else
+            indent(prefix_size, arg)
+          end
+
           skip_space
+
           if @token.type == :","
             write "," unless last?(i, args)
             next_token

--- a/src/object.cr
+++ b/src/object.cr
@@ -619,12 +619,12 @@ class Object
     setter {{*names}}
   end
 
-  # Delegate methods to to_object.
+  # Delegate *method* to *to_object*.
   #
   # Syntax is: delegate method1, [method2, ..., ], to_object
   #
   # Note that due to current language limitations this is only useful
-  # when neither named arguments nor blocks are involved.
+  # when no blocks are involved.
   #
   # ```
   # class StringWrapper
@@ -642,15 +642,25 @@ class Object
   # wrapper.empty?         # => false
   # wrapper.capitalize     # => "Hello"
   # ```
-  macro delegate(method, *other_methods, to_object)
-    def {{method.id}}(*args)
-      {{to_object.id}}.{{method.id}}(*args)
-    end
-
-    {% for name, index in other_methods %}
-      def {{name.id}}(*args)
-        {{to_object.id}}.{{name.id}}(*args)
+  macro delegate(method, required, *others)
+    {% if others.empty? %}
+      def {{method.id}}(*args)
+        {{required.id}}.{{method.id}}(*args)
       end
+    {% else %}
+      def {{method.id}}(*args)
+        {{others[-1].id}}.{{method.id}}(*args)
+      end
+
+      def {{required.id}}(*args)
+        {{others[-1].id}}.{{required.id}}(*args)
+      end
+
+      {% for i in 0...others.size - 1 %}
+        def {{others[i].id}}(*args)
+          {{others[-1].id}}.{{others[i].id}}(*args)
+        end
+      {% end %}
     {% end %}
   end
 


### PR DESCRIPTION
This PR changes the way arguments, splats and named arguments work. It's mostly backwards compatible except for the case where you had a method with a splat and other arguments following it.

It basically implements [PEP 3102](https://www.python.org/dev/peps/pep-3102/) as suggested by @BlaXpirit [here](https://github.com/crystal-lang/crystal/pull/2580#issuecomment-218612032), although there is a big difference: Crystal has method overloading.

I'll briefly explain how arguments will work, without comparing it to how they work now.

## The components of a method definition

A method definition consist of:
* required and optional positional arguments
* an optional splat argument, whose name can be empty
* required and optional named arguments
* an optional double splat argument

For example:

```crystal
def foo(
  # These are positional arguments:
  x, y, z = 1,
  # This is the splat argument:
  *args,
  # These are the named arguments:
  a, b, c = 2,
  # This is the double splat argument:
  **options
) 
end
````

Each one of them is optional, so I can have a method without the double splat, or without the splat, or without positional arguments.

## The components of a method call 

A method call also has some parts:

```crystal
foo(
  # These are positional arguments
  1, 2,
  # These are named arguments
  a: 1, b: 2
)
```

Additionally, a call argument can have a splat (`*`) or double splat (`**`). A splat expands a tuple into positional arguments, while a double splat expands a named tuple into named arguments. Multiple argument splats and double splats are allowed.

## How call arguments are matched to method arguments

When invoking a method, the algorithm to match call arguments to method arguments is:
* First positional arguments are matched with positional method arguments. The number of these must be at least the number of positional arguments without a default value. If there's a splat method argument  **with a name** (the case without a name is explained below), more positional arguments are allowed and they are captured as a tuple. Positional arguments *never* match past the splat method argument.
* Then named arguments are matched, by name, with any argument in the method (it can be before or after the splat method argument). If an argument was already filled by a positional argument then it's an error.
* Extra named arguments are placed in the double splat method argument, as a named tuple, if it exists, otherwise it's an error.

When a splat method argument has no name, it means no more positional arguments can be passed, and next arguments must be passed as named arguments. For example:

```crystal
# Only one positional argument allowed, y must be passed as a named argument
def foo(x, *, y)
end

foo 1 # Error, missing argument: y
foo 1, 2 # Error: wrong number of arguments (given 2, expected 1)
foo 1, y: 10 # OK
```

But even if a splat method argument has a name, arguments that follow it must be passed as named arguments:

```crystal
# One or more positional argument allowed, y must be passed as a named argument
def foo(x, *args, y)
end

foo 1 # Error, missing argument: y
foo 1, 2 # Error: missing argument; y
foo 1, 2, 3 # Error: missing argument: y
foo 1, y: 10 # OK
foo 1, 2, 3, y: 4 # OK
```

There's also the possibility of making a method only receive named arguments (and list them), by placing the star at the beginning:

```crystal
# A method with two required named arguments: x and y
def foo(*, x, y)
end

foo # Error: missing arguments: x, y
foo x: 1 # Error: missing argument: y
foo x: 1, y: 2 # OK
```

Arguments past the star can also have default values. It means: they must be passed as named arguments, but they aren't required (so: optional named arguments):

```crystal
# A method with two required named arguments: x and y
def foo(*, x, y = 2)
end

foo # Error: missing argument: x
foo x: 1 # OK, y is 2
foo x: 1, y: 3 # OK, y is 3
```

Because arguments (without a default value) after the splat method argument must be passed by name, two methods with different required named arguments overload:

```crystal
def foo(*, x)
  puts "Passed with x: #{x}"
end

def foo(*, y)
  puts "Passed with y: #{y}"
end

foo x: 1 # => Passed with x: 1
foo y: 2 # => Passed with y: 2
```

This last bit is the difference between this and Python's PEP.

As a note (maybe it's not clear from the above), positional arguments can still be matched with named arguments:

```crystal
def foo(x, *, y)
end

foo 1, y: 2 # OK
foo y: 2, x: 3 # OK
```

## Recap

So, let's recap all the things we can do with this:

* Required positional arguments: ✓
* Optional positional arguments: ✓
* Variadic positional arguments (splat): ✓
* Required named arguments: ✓
* Optional named arguments: ✓
* Variadic named arguments (double splat): ✓
* Overloading based on named arguments: ✓
* Positional arguments past the splat argument : ✗
* Disallowing matching a positional argument with a named argument: ✗

The last point can be achieved if we allow external and internal names (#2583) for method arguments, by using an underscore as the external name (so it can't match with a named argument).

About positional arguments past the splat argument: it'll be impossible (this is the breaking change), but I don't think it's that useful, or else it can be written with required named arguments past the splat argument, or put the splat argument at the end.

With this we can craft APIs in any way we want. I can already imagine using this in many parts of the standard library. For example, `String.new` has several overloads, and they are all based on the number and types of arguments (because that's the only way we can overload right now). We have this:

```crystal
class String
  # Pointer and bytesize, default (UTF-8) encoding
  def self.new(chars : UInt8*, bytesize : Int, size = 0)
    # ...
  end

  # Slice of bytes and encoding, we decode from the slice
  def self.new(bytes : Slice(UInt8), encoding : String, invalid : Symbol? = nil) : String
  end
end
```

In the above example, I believe it's much better to have the second overload require `encoding` as a named argument:

```crystal
bytes = ...
chars = ...
String.new(bytes, 10) # create from bytes and bytesize
String.new(chars, "UTF-8") # Probably good
String.new(chars, encoding: "UTF-8") # Better
```

We can also use this in `File.new` and `File.open`. Right now it's like this:

```crystal
class File
  def initialize(filename : String, mode = "r", perm = DEFAULT_CREATE_MODE, encoding = nil, invalid = nil)
  end
end
```

It's fine for the filename and mode arguments to be positional, because that's the most common way to open a file (give the filename, specify if we want to read or write to it). However, `perm`, `encoding` and `invalid` have an arbitrary order and I'd say that passing them positionally can be bug prone and it's probably not very clear. Forcing them to be passed as named arguments (even if they are optional named arguments) forces better readability on the caller side, and also allows us to reorder arguments without fear or breaking code (because they can never be matched positionally).

Ruby (and I guess Python) allows for great APIs and DSLs because  it's so flexible in the way arguments can be passed and matched. I believe this PR, for Crystal, will allow the same, and probably more, because argument matching is type-safe.

(I think some of you might have suggested this before and I might have ignored it or disliked it: if that was the case it was only because we didn't have named tuples nor double splats and I imagined the task to be huge/impossible at that moment)


