### PR TITLE
Optimize bc+obj codegen, focus: devel rebuilds.

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -17,6 +17,7 @@ lib LibLLVM
   type PassManagerBuilderRef = Void*
   type PassManagerRef = Void*
   type PassRegistryRef = Void*
+  type MemoryBufferRef = Void*
 
   struct JITCompilerOptions
     opt_level : UInt32
@@ -200,6 +201,7 @@ lib LibLLVM
   fun type_of = LLVMTypeOf(val : ValueRef) : TypeRef
   fun void_type = LLVMVoidType : TypeRef
   fun write_bitcode_to_file = LLVMWriteBitcodeToFile(module : ModuleRef, path : UInt8*) : Int32
+  fun write_bitcode_to_memory_buffer = LLVMWriteBitcodeToMemoryBuffer(mod : ModuleRef) : MemoryBufferRef
   fun verify_module = LLVMVerifyModule(module : ModuleRef, action : LLVM::VerifierFailureAction, outmessage : UInt8**) : Int32
   fun link_in_jit = LLVMLinkInJIT
   fun link_in_mc_jit = LLVMLinkInMCJIT
@@ -252,4 +254,7 @@ lib LibLLVM
   fun dispose_pass_manager = LLVMDisposePassManager(PassManagerRef)
   fun dispose_target_data = LLVMDisposeTargetData(TargetDataRef)
   fun dispose_pass_manager_builder = LLVMPassManagerBuilderDispose(PassManagerBuilderRef)
+  fun dispose_memory_buffer = LLVMDisposeMemoryBuffer(buf : MemoryBufferRef) : Void
+  fun get_buffer_start = LLVMGetBufferStart(buf : MemoryBufferRef) : UInt8*
+  fun get_buffer_size = LLVMGetBufferSize(buf : MemoryBufferRef) : LibC::SizeT
 end


### PR DESCRIPTION
- Renders bc-file in RAM
- Compares cached bc-file with ram-buffer
- Writes out if changed
- Generates obj if changed
- File writes always go via a temp-file -> rename now
- bc-flags changes incorporated in cached files names
- Removes forking for each render
- Only single threaded concurrency now (could be improved further using core-count threads with one part of the list each)
- On _my_ machine I consistently get about 2s bc-obj-phase in re-compile (when working on the parser in the compiler for instance) compared to about 40s before - (for the bc-obj-phase alone).
  - Full compile in re-compile is about 20s vs ca 60s before (on my slow HDD machine).
- Again: the focus is improving compile time for _re-compile_ in _devel_ mode, when there's obviously changes in just a few files each iteration.
- _Please try and bench it with similar test-case on your machine, comparing with main-compiler_.
- Bonus: I can actually do other things while compiling now - before my machine completely froze during compile.
