### PR TITLE
Add external/internal names of method/macro arguments

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -896,4 +896,8 @@ describe Crystal::Formatter do
   assert_format "def foo(**z, &block)\nend"
   assert_format "def foo(x, **z)\nend"
   assert_format "def foo(x, **z, &block)\nend"
+
+  assert_format "def foo(x y)\nend"
+  assert_format "def foo(x @y)\nend"
+  assert_format "def foo(x @@y)\nend"
 end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -183,4 +183,30 @@ describe "Normalize: def" do
     other_def = a_def.expand_default_arguments(Program.new, 1, ["y"])
     other_def.to_s.should eq("def foo:y(x, y)\n  x + y\nend")
   end
+
+  it "expands a def with external names (1)" do
+    a_def = parse("def foo(x y); y; end").as(Def)
+    actual = a_def.expand_default_arguments(Program.new, 0, ["x"])
+    actual.should be(a_def)
+  end
+
+  it "expands a def with external names (2)" do
+    a_def = parse("def foo(x x1, y y1); x1 + y1; end").as(Def)
+    other_def = a_def.expand_default_arguments(Program.new, 0, ["y", "x"])
+    other_def.to_s.should eq("def foo:y:x(y y1, x x1)\n  foo(x1, y1)\nend")
+  end
+
+  it "expands a def on request with default arguments (external names)" do
+    a_def = parse("def foo(x x1, y y1 = 1, z z1 = 2); x1 + y1 + z1; end").as(Def)
+    actual = a_def.expand_default_arguments(Program.new, 1)
+    expected = parse("def foo(x x1); y1 = 1; z1 = 2; foo(x1, y1, z1); end")
+    actual.should eq(expected)
+  end
+
+  it "expands a def on request with default arguments that yields (external names)" do
+    a_def = parse("def foo(x x1, y y1 = 1, z z1 = 2); yield x1 + y1 + z1; end").as(Def)
+    actual = a_def.expand_default_arguments(Program.new, 1)
+    expected = parse("def foo(x x1); y1 = 1; z1 = 2; yield x1 + y1 + z1; end")
+    actual.should eq(expected)
+  end
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -65,4 +65,5 @@ describe "ASTNode#to_s" do
   expect_to_s "def foo(x, **args, &block)\nend"
   expect_to_s "macro foo(**args)\nend"
   expect_to_s "macro foo(x, **args)\nend"
+  expect_to_s "def foo(x y)\nend"
 end

--- a/spec/compiler/type_inference/external_internal_spec.cr
+++ b/spec/compiler/type_inference/external_internal_spec.cr
@@ -1,0 +1,65 @@
+require "../../spec_helper"
+
+describe "Type inference: external/internal" do
+  it "can call with external name and use with internal" do
+    assert_type(%(
+      def foo(x y)
+        y
+      end
+
+      foo x: 10
+      )) { int32 }
+  end
+
+  it "can call positionally" do
+    assert_type(%(
+      def foo(x y)
+        y
+      end
+
+      foo 10
+      )) { int32 }
+  end
+
+  it "can call with external name and use with internal, after splat" do
+    assert_type(%(
+      def foo(*, x y)
+        y
+      end
+
+      foo x: 10
+      )) { int32 }
+  end
+
+  context "macros" do
+    it "can call with external name and use with internal" do
+      assert_type(%(
+        macro foo(x y)
+          {{y}}
+        end
+
+        foo x: 10
+        )) { int32 }
+    end
+
+    it "can call positionally" do
+      assert_type(%(
+        macro foo(x y)
+          {{y}}
+        end
+
+        foo 10
+        )) { int32 }
+    end
+
+    it "can call with external name and use with internal, after splat" do
+      assert_type(%(
+        macro foo(*, x y)
+          {{y}}
+        end
+
+        foo x: 10
+        )) { int32 }
+    end
+  end
+end

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -128,7 +128,7 @@ module Crystal
           if named_args = call.named_args
             named_args.each do |named_arg|
               # Skip an argument that's already there as a positional argument
-              next if a_macro.args.any? &.name.==(named_arg.name)
+              next if a_macro.args.any? &.external_name.==(named_arg.name)
 
               named_tuple_elems << NamedTupleLiteral::Entry.new(named_arg.name, named_arg.value)
             end
@@ -150,7 +150,9 @@ module Crystal
 
         # The named arguments
         call.named_args.try &.each do |named_arg|
-          vars[named_arg.name] = named_arg.value
+          arg = a_macro.args.find { |arg| arg.external_name == named_arg.name }
+          arg_name = arg.try(&.name) || named_arg.name
+          vars[arg_name] = named_arg.value
         end
 
         # The block arg

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -300,7 +300,8 @@ module Crystal
   end
 
   class Arg
-    def initialize(@name, @default_value : ASTNode? = nil, @restriction : ASTNode? = nil, @type : Type? = nil)
+    def initialize(@name : String, @default_value : ASTNode? = nil, @restriction : ASTNode? = nil, external_name : String? = nil, @type : Type? = nil)
+      @external_name = external_name || @name
     end
 
     def clone_without_location

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1045,11 +1045,13 @@ class Crystal::Call
     end
 
     named_args_types.try &.each do |named_arg|
+      arg = typed_def.args.find { |arg| arg.external_name == named_arg.name }.not_nil!
+
       type = named_arg.type
-      var = MetaVar.new(named_arg.name, type)
+      var = MetaVar.new(arg.name, type)
       var.bind_to(var)
-      args[named_arg.name] = var
-      arg = typed_def.args.find { |arg| arg.name == named_arg.name }.not_nil!
+
+      args[arg.name] = var
       arg.type = type
     end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -304,7 +304,7 @@ class Crystal::Call
     end
 
     named_args.try &.each do |named_arg|
-      found_index = a_def.args.index { |arg| arg.name == named_arg.name }
+      found_index = a_def.args.index { |arg| arg.external_name == named_arg.name }
       if found_index
         mandatory_args[found_index] = true
       end
@@ -316,9 +316,9 @@ class Crystal::Call
 
       arg = a_def.args[index]
       next if arg.default_value
-      next if arg.name.empty?
+      next if arg.external_name.empty?
 
-      missing_args << arg.name
+      missing_args << arg.external_name
     end
 
     case missing_args.size
@@ -393,7 +393,14 @@ class Crystal::Call
     a_def.args.each_with_index do |arg, i|
       str << ", " if printed
       str << '*' if a_def.splat_index == i
+
+      if arg.external_name != arg.name
+        str << (arg.external_name.empty? ? "_" : arg.external_name)
+        str << " "
+      end
+
       str << arg.name
+
       if arg_default = arg.default_value
         str << " = "
         str << arg.default_value

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -172,7 +172,7 @@ module Crystal
       if named_args
         min_index = signature.arg_types.size
         named_args.each do |named_arg|
-          found_index = a_def.args.index { |arg| arg.name == named_arg.name }
+          found_index = a_def.args.index { |arg| arg.external_name == named_arg.name }
           if found_index
             # A named arg can't target the splat index
             if found_index == splat_index

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -3,6 +3,10 @@ require "../syntax/to_s"
 module Crystal
   class ToSVisitor
     def visit(node : Arg)
+      if node.external_name != node.name
+        @str << (node.external_name.empty? ? "_" : node.external_name)
+        @str << " "
+      end
       if node.name
         @str << decorate_arg(node, node.name)
       else

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -835,12 +835,15 @@ module Crystal
   class Arg < ASTNode
     include SpecialVar
 
+    # The internal name
     property name : String
+    property external_name : String
     property default_value : ASTNode?
     property restriction : ASTNode?
     property doc : String?
 
-    def initialize(@name, @default_value : ASTNode? = nil, @restriction : ASTNode? = nil)
+    def initialize(@name : String, @default_value : ASTNode? = nil, @restriction : ASTNode? = nil, external_name : String? = nil)
+      @external_name = external_name || @name
     end
 
     def accept_children(visitor)
@@ -853,10 +856,10 @@ module Crystal
     end
 
     def clone_without_location
-      Arg.new @name, @default_value.clone, @restriction.clone
+      Arg.new @name, @default_value.clone, @restriction.clone, @external_name.clone
     end
 
-    def_equals_and_hash name, default_value, restriction
+    def_equals_and_hash name, default_value, restriction, external_name
   end
 
   class Fun < ASTNode
@@ -1006,7 +1009,7 @@ module Crystal
       splat_index = self.splat_index
 
       if splat_index
-        if args[splat_index].name.empty?
+        if args[splat_index].external_name.empty?
           min_args_size = max_args_size = splat_index
         else
           min_args_size -= 1
@@ -1043,7 +1046,7 @@ module Crystal
 
       # Check named args
       named_args.try &.each do |named_arg|
-        found_index = args.index { |arg| arg.name == named_arg.name }
+        found_index = args.index { |arg| arg.external_name == named_arg.name }
         if found_index
           # A named arg can't target the splat index
           if found_index == splat_index

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -731,6 +731,10 @@ module Crystal
     end
 
     def visit(node : Arg)
+      if node.external_name != node.name
+        @str << (node.external_name.empty? ? "_" : node.external_name)
+        @str << " "
+      end
       if node.name
         @str << decorate_arg(node, node.name)
       else

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -66,12 +66,22 @@ class Crystal::Doc::Macro
   def args_to_s(io)
     return if @macro.args.empty?
 
+    printed = false
     io << '('
+
     @macro.args.each_with_index do |arg, i|
-      io << ", " if i > 0
+      io << ", " if printed
       io << '*' if @macro.splat_index == i
       io << arg
+      printed = true
     end
+
+    if double_splat = @macro.double_splat
+      io << ", " if printed
+      io << "**"
+      io << double_splat
+    end
+
     io << ')'
   end
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -107,17 +107,25 @@ class Crystal::Doc::Method
 
     if has_args?
       io << '('
+      printed = false
       @def.args.each_with_index do |arg, i|
-        io << ", " if i > 0
+        io << ", " if printed
         io << '*' if @def.splat_index == i
         arg_to_html arg, io, links: links
+        printed = true
+      end
+      if double_splat = @def.double_splat
+        io << ", " if printed
+        io << "**"
+        io << double_splat
+        printed = true
       end
       if block_arg = @def.block_arg
-        io << ", " unless @def.args.empty?
+        io << ", " if printed
         io << '&'
         arg_to_html block_arg, io, links: links
       elsif @def.yields
-        io << ", " unless @def.args.empty?
+        io << ", " if printed
         io << "&block"
       end
       io << ')'
@@ -136,7 +144,13 @@ class Crystal::Doc::Method
   end
 
   def arg_to_html(arg : Arg, io, links = true)
+    if arg.external_name != arg.name
+      io << (arg.external_name.empty? ? "_" : arg.external_name)
+      io << " "
+    end
+
     io << arg.name
+
     if restriction = arg.restriction
       io << " : "
       node_to_html restriction, io, links: links


### PR DESCRIPTION
This implements #2583 

## Pros

1) You can use an underscore as an external name to disallow passing an argument as positional, **something that can't be done right now**

```crystal
def foo(_ x, _y)
  x + y
end

foo 1, 2 # OK
foo 1, y: 2 # Error
foo x: 1, y: 2 # Error
````

2) You can pass an argument as a named argument with an identifier that's a keyword (like `class`, or `if`), **something that can't be done right now**

```crystal
def say_hi(if condition)
  puts "Hi!" if condition
end

say_hi if: 1 == 2
```

We could actually use this in the compiler's source code, because an `If` node has `then` and `else` properties, but you can't do `If.new(cond, else: some_code)`, you have to either do `If.new(cond,nil, some_code)` or `If.new(cond, a_else: some_ncode)` (both ways are ugly).

I can also imagine `if: ...` and `unless: ...` are going to be very common, and having a way to refer to an argument like that, instead of going through the double splat, will definitely be useful.

3) Argument names can be readable for the caller side and the method's body:

```crystal
class Time
  # Returns a new Time instance that matches the given *unix_epoch* seconds.
  def self.new(*, unix_epoch seconds : Int)
    do_something_with(seconds)
  end
end

Time.new unix_epoch: 1234
```

## Cons

It's one more thing to learn. But I think the explanation is pretty simple: if an argument has "two names", you use the name on the left for named arguments, on the caller side, and the one on the right inside the method's body.

My main fear is the underscore being used all over the place, to prevent matching arguments by name... I'll write in the docs that, if we always do this, it will probably lead to less readable code, so this should only be done for public APIs where you think you might want to change an argument's name, or you absolutely don't want it to be passed by name.

I personally disliked this feature the moment @waj told me about it. Whenever I told him about double splats and named args he asked "and external names...?". Eventually it grew on me, as @ozra [says](https://github.com/crystal-lang/crystal/issues/2583#issuecomment-219028020). Right there we have 3 things that can't be done right now, and these only contribute to better code (more readable code), so of course my vote for this is 👍  now.