### PR TITLE
Rescue doesn't accept global type path

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -836,8 +836,11 @@ describe "Parser" do
   it_parses "begin; 1; ensure; 2; end", ExceptionHandler.new(1.int32, ensure: 2.int32)
   it_parses "begin\n1\nensure\n2\nend", ExceptionHandler.new(1.int32, ensure: 2.int32)
   it_parses "begin; 1; rescue Foo; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, ["Foo".path] of ASTNode)])
+  it_parses "begin; 1; rescue ::Foo; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, [Path.global("Foo")] of ASTNode)])
   it_parses "begin; 1; rescue Foo | Bar; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, ["Foo".path, "Bar".path] of ASTNode)])
+  it_parses "begin; 1; rescue ::Foo | ::Bar; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, [Path.global("Foo"), Path.global("Bar")] of ASTNode)])
   it_parses "begin; 1; rescue ex : Foo | Bar; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, ["Foo".path, "Bar".path] of ASTNode, "ex")])
+  it_parses "begin; 1; rescue ex : ::Foo | ::Bar; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, [Path.global("Foo"), Path.global("Bar")] of ASTNode, "ex")])
   it_parses "begin; 1; rescue ex; 2; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32, nil, "ex")])
   it_parses "begin; 1; rescue; 2; else; 3; end", ExceptionHandler.new(1.int32, [Rescue.new(2.int32)], 3.int32)
   it_parses "begin; 1; rescue ex; 2; end; ex", [ExceptionHandler.new(1.int32, [Rescue.new(2.int32, nil, "ex")]), "ex".var]

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1306,6 +1306,7 @@ module Crystal
     end
 
     SemicolonOrNewLine = [:";", :NEWLINE]
+    ConstOrDoubleColon = [:CONST, :"::"]
 
     def parse_rescue
       next_token_skip_space
@@ -1318,10 +1319,10 @@ module Crystal
 
         if @token.type == :":"
           next_token_skip_space_or_newline
-          check :CONST
+          check ConstOrDoubleColon
           types = parse_rescue_types
         end
-      when :CONST
+      when :CONST, :"::"
         types = parse_rescue_types
       end
 


### PR DESCRIPTION
This code occurs a compiler's error because the parser doesn't accept global type paths at rescue:

```crystal
begin
  # ...
rescue ::Foo
  # ...
end
```

I quickly fixed the corresponding source code, but it may be not perfect. In addition, my code doesn't consider Underscore nodes like:

```crystal
begin
  # ...
rescue _ # occurs an error 
  # ...
end
```

```crystal
begin
  # ...
rescue ex : _ # occurs an error, too
  # ...
end
```

Thank you.