### PR TITLE
Add the latest xcode image for OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - env: ARCH=x86_64 ARCH_CMD=linux64
       os: linux
     - os: osx
+    - os: osx
+      osx_image: xcode7.3
 before_install: bin/ci prepare_system
 install: bin/ci prepare_build
 script:


### PR DESCRIPTION
> Travis CI uses OS X 10.9.5 (and Xcode 6.1) by default.

This will run the build on the modern version of OSX and produce build/specs
against El Capitan.

Ref: https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version

CI-only.