### PR TITLE
Docker: Install git so shards works out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM crystallang/crystal
 
 RUN apt-get update && \
-    apt-get install -y build-essential curl libevent-dev && \
+    apt-get install -y build-essential curl libevent-dev git && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-linux-x86_64.tar.gz | tar xz -C /opt


### PR DESCRIPTION
Before this commit, a user using `crystallang/crystal` docker image (e.g. on CI) was not able to use `shards`
which requires `git` to be installed if the dependencies' source is git-based (GitHub, BitBucket or pure git).

I think `shards` is an essential tool for every Crystal project.

This commit installs `git` in the Docker image you don't have to `apt-get install -y git` over and over :-)