### PR TITLE
Docker: Preinstall git in released docker image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,7 +4,7 @@ RUN \
   apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 && \
   echo "deb http://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
   apt-get update && \
-  apt-get install -y crystal gcc pkg-config libssl-dev && \
+  apt-get install -y crystal gcc pkg-config libssl-dev git && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/crystal


### PR DESCRIPTION
This is a fix for 4f7d5bc which installed git in the wrong image (head).

See #2615 