### PR TITLE
Fixed #2624: Running multiple macro runs doesn't work

### DIFF
--- a/src/compiler/crystal/codegen/cache_dir.cr
+++ b/src/compiler/crystal/codegen/cache_dir.cr
@@ -41,14 +41,11 @@ module Crystal
     end
 
     # Keeps the 10 most recently used directories in the cache,
-    # and removes all others. This also removes non-directory
-    # files inside the cache directory (temporary executables
-    # resulting from `crystal run` or `run` macro calls).
+    # and removes all others.
     def cleanup
       dir = compute_dir
       entries = gather_cache_entries(dir)
       cleanup_dirs(entries)
-      cleanup_files(entries)
     end
 
     # Returns a filename that has prepended the cache directory.
@@ -114,12 +111,6 @@ module Crystal
         .reverse!
         .skip(10)
         .each { |name| `rm -rf "#{name}"` rescue nil }
-    end
-
-    private def cleanup_files(entries)
-      entries
-        .select { |dir| File.file?(dir) }
-        .each { |name| File.delete(name) rescue nil }
     end
 
     private def gather_cache_entries(dir)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -63,7 +63,7 @@ module Crystal
     end
 
     def compile(sources : Array(Source), output_filename)
-      program = new_program
+      program = new_program(sources)
       node, original_node = parse program, sources
       node = program.infer_type node, @stats
       codegen program, node, sources, output_filename unless @no_codegen
@@ -75,14 +75,15 @@ module Crystal
     end
 
     def type_top_level(sources : Array(Source))
-      program = new_program
+      program = new_program(sources)
       node, original_node = parse program, sources
       node = program.infer_type_top_level(node, @stats)
       Result.new program, node, original_node
     end
 
-    private def new_program
+    private def new_program(sources)
       program = Program.new
+      program.cache_dir = CacheDir.instance.directory_for(sources)
       program.target_machine = target_machine
       if cross_compile_flags = @cross_compile_flags
         program.flags = cross_compile_flags
@@ -167,8 +168,6 @@ module Crystal
         output_dir = cache_dir.directory_for(sources)
       end
 
-      cache_dir.cleanup
-
       bc_flags_changed = check_bc_flags_changed output_dir
 
       units = llvm_modules.map do |type_name, llvm_mod|
@@ -180,6 +179,8 @@ module Crystal
       else
         codegen program, units, lib_flags, output_filename, output_dir
       end
+
+      cache_dir.cleanup
     end
 
     private def cross_compile(program, units, lib_flags, output_filename)

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -86,7 +86,9 @@ module Crystal
       compiler.release = true
 
       safe_filename = filename.gsub(/[^a-zA-Z\_\-\.]/, "_")
-      tempfile_path = Crystal.tempfile("macro-run-#{safe_filename}")
+
+      tempfile_path = @mod.new_tempfile("macro-run-#{safe_filename}")
+
       compiler.compile Compiler::Source.new(filename, source), tempfile_path
 
       tempfile_path

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -29,6 +29,13 @@ module Crystal
     getter! string_pool
     @flags : Set(String)?
 
+    # The cache directory where temporary files are placed.
+    setter cache_dir : String?
+
+    # Temporary files generates by macro runs that need to be
+    # deleted after compilation finishes.
+    getter! tempfiles : Array(String)
+
     # Here we store class var initializers and constants, in the
     # order that they are used. They will be initialized as soon
     # as the program starts, before the main code.
@@ -59,6 +66,7 @@ module Crystal
       @string_pool = StringPool.new
       @class_var_and_const_initializers = [] of ClassVarInitializer | Const
       @class_var_and_const_being_typed = [] of MetaTypeVar | Const
+      @tempfiles = [] of String
 
       types = @types = {} of String => Type
 
@@ -177,6 +185,16 @@ module Crystal
 
     private def crystal_path
       @crystal_path ||= CrystalPath.new(target_triple: target_machine.triple)
+    end
+
+    def new_tempfile(basename)
+      filename = if cache_dir = @cache_dir
+                   File.join(cache_dir, basename)
+                 else
+                   Crystal.tempfile(basename)
+                 end
+      tempfiles << filename
+      filename
     end
 
     def add_def(node : Def)

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -41,6 +41,12 @@ module Crystal
         initializer.value = initializer.value.transform(transformer)
       end
     end
+
+    def cleanup_files
+      tempfiles.each do |tempfile|
+        File.delete(tempfile) rescue nil
+      end
+    end
   end
 
   # This visitor runs at the end and does some simplifications to the resulting AST node.

--- a/src/compiler/crystal/semantic/type_inference.cr
+++ b/src/compiler/crystal/semantic/type_inference.cr
@@ -36,6 +36,7 @@ module Crystal
       end
       Crystal.timing("Semantic (cleanup)", stats) do
         cleanup_types
+        cleanup_files
       end
       Crystal.timing("Semantic (recursive struct check)", stats) do
         check_recursive_structs


### PR DESCRIPTION
This:

* No longer removes all temporary files at the end of a compilation
* Scopes temporary executable files created by `macro run` inside the cache directory related to the program being compiled (as suggested by @jhass)
* At the end of a compilation, temporary files created by `macro run` calls are deleted