### PR TITLE
Add `now` macro method

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1342,4 +1342,23 @@ describe "Code gen: macro" do
       {1, 3}.foo(1)
       )).to_i.should eq(2)
   end
+
+  it "executes now" do
+    run(%(
+      {{ now("%Y-%m-%d") }}
+      )).to_string.should eq(Time.now.to_s("%Y-%m-%d"))
+  end
+
+  it "executes now utc" do
+    run(%(
+      {{ now("%Y-%m-%d", utc: true) }}
+      )).to_string.should eq(Time.utc_now.to_s("%Y-%m-%d"))
+  end
+
+  it "gives error on wrong number of arguments for now" do
+    assert_error %(
+      {{ now() }}
+      ),
+      "wrong number of arguments"
+  end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -15,6 +15,11 @@ module Crystal::Macros
   def env(name) : StringLiteral | NilLiteral
   end
 
+  # Returns `Time.now` (or `Time.utc_now`) formatted with the given *format*,
+  # as specified by `Time::Format`.
+  def now(format, utc = false) : StringLiteral
+  end
+
   # Prints an AST node at compile-time. Useful for debugging macros.
   def puts(expression) : Nop
   end


### PR DESCRIPTION
This adds a `now(format, utc = false)` macro method that returns `Time.now`, or `Time.utc_now` formatter according to the give format.

This can be useful to paste the build time of a program into the executable, and it's more portable than shelling out and using `date`.