### PR TITLE
JSON: added `root` option to mapping, and `root` argument overload to…

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -118,6 +118,24 @@ class JSONWithRaw
   })
 end
 
+class JSONWithRoot
+  JSON.mapping({
+    result: {type: Array(JSONPerson), root: "heroes"},
+  })
+end
+
+class JSONWithNilableRoot
+  JSON.mapping({
+    result: {type: Array(JSONPerson), root: "heroes", nilable: true},
+  })
+end
+
+class JSONWithNilableRootEmitNull
+  JSON.mapping({
+    result: {type: Array(JSONPerson), root: "heroes", nilable: true, emit_null: true},
+  })
+end
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -348,5 +366,27 @@ describe "JSON mapping" do
     json = JSONWithRaw.from_json(string)
     json.value.should eq(%([null,true,false,{"x":[1,1.5]}]))
     json.to_json.should eq(string)
+  end
+
+  it "parses with root" do
+    json = %({"result":{"heroes":[{"name":"Batman"}]}})
+    result = JSONWithRoot.from_json(json)
+    result.result.should be_a(Array(JSONPerson))
+    result.result.first.name.should eq "Batman"
+    result.to_json.should eq(json)
+  end
+
+  it "parses with nilable root" do
+    json = %({"result":null})
+    result = JSONWithNilableRoot.from_json(json)
+    result.result.should be_nil
+    result.to_json.should eq("{}")
+  end
+
+  it "parses with nilable root and emit null" do
+    json = %({"result":null})
+    result = JSONWithNilableRootEmitNull.from_json(json)
+    result.result.should be_nil
+    result.to_json.should eq(json)
   end
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -107,6 +107,11 @@ describe "JSON serialization" do
         JSONSpecEnum.from_json(%("Three"))
       end
     end
+
+    it "deserializes with root" do
+      Int32.from_json(%({"foo": 1}), root: "foo").should eq(1)
+      Array(Int32).from_json(%({"foo": [1, 2]}), root: "foo").should eq([1, 2])
+    end
   end
 
   describe "to_json" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -1,6 +1,31 @@
+# Deserializes the given JSON in *string_or_io* into
+# an instance of `self`. This simply creates a `parser = JSON::PullParser`
+# and invokes `new(parser)`: classes that want to provide JSON
+# deserialization must provide an `def initialize(parser : JSON::PullParser`
+# method.
+#
+# ```
+# Int32.from_json("1")                # => 1
+# Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
+# ```
 def Object.from_json(string_or_io) : self
   parser = JSON::PullParser.new(string_or_io)
   new parser
+end
+
+# Deserializes the given JSON in *string_or_io* into
+# an instance of `self`, assuming the JSON consists
+# of an JSON object with key *root*, and whose value is
+# the value to deserialize.
+#
+# ```
+# Int32.from_json(%({"main": 1}), root: "main").should eq(1)
+# ```
+def Object.from_json(string_or_io, root : String) : self
+  parser = JSON::PullParser.new(string_or_io)
+  parser.on_key!(root) do
+    new parser
+  end
 end
 
 # Parses a String or IO denoting a JSON array, yielding

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -226,11 +226,12 @@ class JSON::PullParser
 
   def on_key!(key)
     found = false
+    value = uninitialized typeof(yield)
 
     read_object do |some_key|
       if some_key == key
         found = true
-        yield
+        value = yield
       else
         skip
       end
@@ -239,6 +240,8 @@ class JSON::PullParser
     unless found
       raise "json key not found: #{key}"
     end
+
+    value
   end
 
   def read_next


### PR DESCRIPTION
… `Object.from_json`. Fixes #2642

A tricky case is root + nilable + emit_null, I think I got it right (but in any case, I don't think it matters much as I'm not sure there are some cases like this in the wild)