### PR TITLE
Clean: gethostname belongs to unistd.h

### DIFF
--- a/src/lib_c/i686-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-gnu/c/sys/socket.cr
@@ -43,7 +43,6 @@ lib LibC
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int

--- a/src/lib_c/i686-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-musl/c/sys/socket.cr
@@ -43,7 +43,6 @@ lib LibC
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockname(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockopt(x0 : Int, x1 : Int, x2 : Int, x3 : Void*, x4 : SocklenT*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -43,7 +43,6 @@ lib LibC
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
@@ -43,7 +43,6 @@ lib LibC
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockname(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockopt(x0 : Int, x1 : Int, x2 : Int, x3 : Void*, x4 : SocklenT*) : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
@@ -43,7 +43,6 @@ lib LibC
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockname(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockopt(x0 : Int, x1 : Int, x2 : Int, x3 : Void*, x4 : SocklenT*) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
@@ -44,7 +44,6 @@ lib LibC
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
-  fun gethostname(name : Char*, len : SizeT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockname(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
   fun getsockopt(x0 : Int, x1 : Int, x2 : Int, x3 : Void*, x4 : SocklenT*) : Int

--- a/src/system.cr
+++ b/src/system.cr
@@ -1,4 +1,4 @@
-require "c/sys/socket"
+require "c/unistd"
 
 module System
   # Returns the hostname


### PR DESCRIPTION
POSIX states that `gethostname` belongs to `unistd.h` not `sys/socket.h`. It was already present there.