### PR TITLE
Fixes Float#to_s for scientific notation

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -105,6 +105,8 @@ describe "Float" do
       12.9999.to_s.should eq("12.9999")
       12.999999999999.to_s.should eq("13.0")
       1.0.to_s.should eq("1.0")
+      2e20.to_s.should eq("2e+20")
+      1e-10.to_s.should eq("1e-10")
     end
 
     it "does to_s for f32" do

--- a/src/float.cr
+++ b/src/float.cr
@@ -212,6 +212,12 @@ struct Float64
   private def to_s_internal(buffer)
     LibC.snprintf(buffer, 22, "%.17g", self)
     len = LibC.strlen(buffer)
+    slice = Slice.new(buffer, len)
+
+    # If this is in scientific notation, return immediately
+    if slice.index('e'.ord.to_u8)
+      return len
+    end
 
     # Check if we have a run of zeros or nines after
     # the decimal digit. If so, we remove them
@@ -219,7 +225,6 @@ struct Float64
     # (and probably inefficient) algorithm, but a good
     # one is much longer and harder to do: we can probably
     # do that later.
-    slice = Slice.new(buffer, len)
     index = slice.index('.'.ord.to_u8)
 
     # If there's no dot add ".0" to it, if there's enough size


### PR DESCRIPTION
This affects the JSON writter/parser. Previously:

```crystal
p 2e20.to_s   # "2e+20.0"   <= extra ".0"
JSON.parse(2e20.to_json) # raises invalid json
```