### PR TITLE
Improve specifying phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-.PHONY: all spec std_spec compiler_spec doc crystal \
-	all_spec all_compiler_spec all_std_spec \
-	llvm_ext libcrystal deps clean
-
 -include Makefile.local # for optional local options e.g. threads
 
 O := .build
@@ -22,32 +18,41 @@ ifeq (${LLVM_CONFIG},)
 $(error Could not locate llvm-config, make sure it is installed and in your PATH)
 endif
 
+.PHONY: all
 all: crystal
 
+.PHONY: help
 help: ## Show this help
 	@printf '\033[34mtargets:\033[0m\n'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
 		sort |\
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: spec
 spec: all_spec ## Run all specs
 	$(O)/all_spec
 
+.PHONY: std_spec
 std_spec: all_std_spec ## Run standard library specs
 	$(O)/std_spec
 
+.PHONY: compiler_spec
 compiler_spec: all_compiler_spec ## Run compiler specs
 	$(O)/compiler_spec
 
+.PHONY: doc
 doc: ## Generate standard library documentation
 	$(BUILD_PATH) ./bin/crystal doc src/docs_main.cr
 
+.PHONY: crystal
 crystal: $(O)/crystal ## Build the compiler
 
+.PHONY: all_spec all_std_spec all_compiler_spec
 all_spec: $(O)/all_spec
 all_std_spec: $(O)/std_spec
 all_compiler_spec: $(O)/compiler_spec
 
+.PHONY: llvm_ext libcrystal deps
 llvm_ext: $(LLVM_EXT_OBJ)
 libcrystal: $(LIB_CRYSTAL_TARGET)
 deps: llvm_ext libcrystal
@@ -74,6 +79,7 @@ $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 $(LIB_CRYSTAL_TARGET): $(LIB_CRYSTAL_OBJS)
 	ar -rcs $@ $^
 
+.PHONY: clean
 clean: ## Clean up built directories and files
 	rm -rf $(O)
 	rm -rf ./doc


### PR DESCRIPTION
This PR added `help` to `.PHONY` targets.

To add `.PHONY` in front of each of phony target definitions is better than to add in `Makefile`'s head.