### PR TITLE
Fix to get VERSION if repository has no tag

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -1,7 +1,7 @@
 module Crystal
   module Config
     PATH    = {{ env("CRYSTAL_CONFIG_PATH") || "" }}
-    VERSION = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long 2>/dev/null)`.stringify.chomp }}
+    VERSION = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long --always 2>/dev/null)`.stringify.chomp }}
 
     def self.path
       PATH


### PR DESCRIPTION
`crystal-lang/crystal` is large repository, so I often use `git clone --depth 1`in such a case. However, `git describe --tags --long` makes an error if repository have no tag, and `--depth 1` repository has no tag.