### PR TITLE
Turn on TLS client certificate validation by default, expose OpenSSL::SSL::Context in HTTP::Client

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -61,13 +61,13 @@ module HTTP
         end
 
         it "keeps context" do
-          ctx = OpenSSL::SSL::Context.new_for_client
+          ctx = OpenSSL::SSL::Context::Client.new
           cl = Client.new(URI.parse("https://example.com"), ctx)
           cl.ssl.should be(ctx)
         end
 
         it "doesn't take context for HTTP" do
-          ctx = OpenSSL::SSL::Context.new_for_client
+          ctx = OpenSSL::SSL::Context::Client.new
           expect_raises(ArgumentError, "SSL context given") do
             Client.new(URI.parse("http://example.com"), ctx)
           end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -48,26 +48,47 @@ module HTTP
 
     describe "from URI" do
       it "has sane defaults" do
-        cl = Client.new(URI.parse("http://demo.com"))
-        cl.ssl?.should be_false
+        cl = Client.new(URI.parse("http://example.com"))
+        cl.ssl?.should be_nil
         cl.port.should eq(80)
       end
 
-      it "detects ssl" do
-        cl = Client.new(URI.parse("https://demo.com"))
-        cl.ssl?.should be_true
-        cl.port.should eq(443)
-      end
+      ifdef !without_openssl
+        it "detects ssl" do
+          cl = Client.new(URI.parse("https://example.com"))
+          cl.ssl?.should be_truthy
+          cl.port.should eq(443)
+        end
 
-      it "allows for specified ports" do
-        cl = Client.new(URI.parse("https://demo.com:9999"))
-        cl.ssl?.should be_true
-        cl.port.should eq(9999)
+        it "keeps context" do
+          ctx = OpenSSL::SSL::Context.new_for_client
+          cl = Client.new(URI.parse("https://example.com"), ctx)
+          cl.ssl.should be(ctx)
+        end
+
+        it "doesn't take context for HTTP" do
+          ctx = OpenSSL::SSL::Context.new_for_client
+          expect_raises(ArgumentError, "SSL context given") do
+            Client.new(URI.parse("http://example.com"), ctx)
+          end
+        end
+
+        it "allows for specified ports" do
+          cl = Client.new(URI.parse("https://example.com:9999"))
+          cl.ssl?.should be_truthy
+          cl.port.should eq(9999)
+        end
+      else
+        it "raises when trying to activate SSL" do
+          expect_raises do
+            Client.new "example.org", 443, ssl: true
+          end
+        end
       end
 
       it "raises error if not http schema" do
         expect_raises(ArgumentError, "Unsupported scheme: ssh") do
-          Client.new(URI.parse("ssh://demo.com"))
+          Client.new(URI.parse("ssh://example.com"))
         end
       end
 

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -32,7 +32,7 @@ module HTTP
 
     describe Response do
       it "creates default ssl context" do
-        HTTP::Server.default_ssl_context.should be_a(OpenSSL::SSL::Context)
+        HTTP::Server.default_ssl_context.should be_a(OpenSSL::SSL::Context::Server)
       end
 
       it "closes" do

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -2,46 +2,53 @@ require "spec"
 require "openssl"
 
 describe OpenSSL::SSL::Context do
-  it "new" do
-    OpenSSL::SSL::Context.new
-    OpenSSL::SSL::Context.new(LibSSL.tlsv1_method)
+  it "new_for_client" do
+    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+    OpenSSL::SSL::Context.new_for_client(LibSSL.tlsv1_method)
+  end
+
+  it "new_for_server" do
+    ssl_context = OpenSSL::SSL::Context.new_for_server
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    OpenSSL::SSL::Context.new_for_server(LibSSL.tlsv1_method)
   end
 
   it "sets certificate chain" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.certificate_chain = File.join(__DIR__, "openssl.crt")
   end
 
   it "fails to set certificate chain" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = File.join(__DIR__, "unknown.crt") }
     expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = __FILE__ }
   end
 
   it "sets private key" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.private_key = File.join(__DIR__, "openssl.key")
   end
 
   it "fails to set private key" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     expect_raises(OpenSSL::Error) { ssl_context.private_key = File.join(__DIR__, "unknown.key") }
     expect_raises(OpenSSL::Error) { ssl_context.private_key = __FILE__ }
   end
 
   it "sets ciphers" do
     ciphers = "EDH+aRSA DES-CBC3-SHA !RC4"
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     (ssl_context.ciphers = ciphers).should eq(ciphers)
   end
 
   it "adds temporary ecdh curve (P-256)" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.set_tmp_ecdh_key
   end
 
   it "adds options" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.remove_options(ssl_context.options) # reset
     ssl_context.add_options(LibSSL::Options::ALL).should eq(LibSSL::Options::ALL)
     ssl_context.add_options(LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
@@ -49,39 +56,47 @@ describe OpenSSL::SSL::Context do
   end
 
   it "removes options" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
     ssl_context.remove_options(LibSSL::Options::ALL).should eq(LibSSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
     ssl_context.options.should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
   end
 
   it "adds modes" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::AUTO_RETRY)
     ssl_context.add_modes(LibSSL::Modes::RELEASE_BUFFERS)
                .should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
   end
 
   it "removes modes" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
     ssl_context.remove_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::RELEASE_BUFFERS)
   end
 
   it "returns modes" do
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
     ssl_context.modes.should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
   end
 
+  it "sets the verify mode" do
+    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+  end
+
   pending "alpn_protocol=" do
     # requires OpenSSL 1.0.2+
-    ssl_context = OpenSSL::SSL::Context.new
+    ssl_context = OpenSSL::SSL::Context.new_for_client
     ssl_context.alpn_protocol = "h2"
   end
 end

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -2,53 +2,67 @@ require "spec"
 require "openssl"
 
 describe OpenSSL::SSL::Context do
-  it "new_for_client" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+  it "new for client" do
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
-    OpenSSL::SSL::Context.new_for_client(LibSSL.tlsv1_method)
+    OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
   end
 
-  it "new_for_server" do
-    ssl_context = OpenSSL::SSL::Context.new_for_server
+  it "new for server" do
+    ssl_context = OpenSSL::SSL::Context::Server.new
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
-    OpenSSL::SSL::Context.new_for_server(LibSSL.tlsv1_method)
+    OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)
+  end
+
+  it "insecure for client" do
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.should be_a(OpenSSL::SSL::Context::Client)
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
+  end
+
+  it "insecure for server" do
+    ssl_context = OpenSSL::SSL::Context::Server.insecure
+    ssl_context.should be_a(OpenSSL::SSL::Context::Server)
+    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end
 
   it "sets certificate chain" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.certificate_chain = File.join(__DIR__, "openssl.crt")
   end
 
   it "fails to set certificate chain" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = File.join(__DIR__, "unknown.crt") }
     expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = __FILE__ }
   end
 
   it "sets private key" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.private_key = File.join(__DIR__, "openssl.key")
   end
 
   it "fails to set private key" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     expect_raises(OpenSSL::Error) { ssl_context.private_key = File.join(__DIR__, "unknown.key") }
     expect_raises(OpenSSL::Error) { ssl_context.private_key = __FILE__ }
   end
 
   it "sets ciphers" do
     ciphers = "EDH+aRSA DES-CBC3-SHA !RC4"
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     (ssl_context.ciphers = ciphers).should eq(ciphers)
   end
 
   it "adds temporary ecdh curve (P-256)" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.set_tmp_ecdh_key
   end
 
   it "adds options" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.remove_options(ssl_context.options) # reset
     ssl_context.add_options(LibSSL::Options::ALL).should eq(LibSSL::Options::ALL)
     ssl_context.add_options(LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
@@ -56,38 +70,38 @@ describe OpenSSL::SSL::Context do
   end
 
   it "removes options" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
     ssl_context.remove_options(LibSSL::Options::ALL).should eq(LibSSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
     ssl_context.options.should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
   end
 
   it "adds modes" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::AUTO_RETRY)
     ssl_context.add_modes(LibSSL::Modes::RELEASE_BUFFERS)
                .should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
   end
 
   it "removes modes" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
     ssl_context.remove_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::RELEASE_BUFFERS)
   end
 
   it "returns modes" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
     ssl_context.modes.should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
   end
 
   it "sets the verify mode" do
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
@@ -96,7 +110,7 @@ describe OpenSSL::SSL::Context do
 
   pending "alpn_protocol=" do
     # requires OpenSSL 1.0.2+
-    ssl_context = OpenSSL::SSL::Context.new_for_client
+    ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.alpn_protocol = "h2"
   end
 end

--- a/src/http/server/server.cr
+++ b/src/http/server/server.cr
@@ -89,10 +89,10 @@ require "../common"
 # ```
 class HTTP::Server
   ifdef !without_openssl
-    property ssl : OpenSSL::SSL::Context?
+    property ssl : OpenSSL::SSL::Context::Server?
 
     def self.default_ssl_context : OpenSSL::SSL::Context
-      ctx = OpenSSL::SSL::Context.new_for_server
+      ctx = OpenSSL::SSL::Context::Server.new
       ctx.add_options(
         LibSSL::Options::ALL |
           LibSSL::Options::NO_SSLV2 |
@@ -176,7 +176,7 @@ class HTTP::Server
 
     ifdef !without_openssl
       if ssl = @ssl
-        io = OpenSSL::SSL::Socket.new(io, :server, ssl, sync_close: true)
+        io = OpenSSL::SSL::Socket::Server.new(io, ssl, sync_close: true)
       end
     end
 

--- a/src/http/server/server.cr
+++ b/src/http/server/server.cr
@@ -92,7 +92,7 @@ class HTTP::Server
     property ssl : OpenSSL::SSL::Context?
 
     def self.default_ssl_context : OpenSSL::SSL::Context
-      ctx = OpenSSL::SSL::Context.new
+      ctx = OpenSSL::SSL::Context.new_for_server
       ctx.add_options(
         LibSSL::Options::ALL |
           LibSSL::Options::NO_SSLV2 |

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -231,7 +231,14 @@ class HTTP::WebSocket::Protocol
     socket = TCPSocket.new(host, port)
 
     ifdef !without_openssl
-      socket = OpenSSL::SSL::Socket.new(socket, sync_close: true) if ssl
+      if ssl
+        if ssl.is_a?(Bool) # true, but we want to get rid of the union
+          context = OpenSSL::SSL::Context.new_for_client
+        else
+          context = ssl
+        end
+        socket = OpenSSL::SSL::Socket.new(socket, context: context, sync_close: true)
+      end
     end
 
     headers = HTTP::Headers.new

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -233,11 +233,11 @@ class HTTP::WebSocket::Protocol
     ifdef !without_openssl
       if ssl
         if ssl.is_a?(Bool) # true, but we want to get rid of the union
-          context = OpenSSL::SSL::Context.new_for_client
+          context = OpenSSL::SSL::Context::Client.new
         else
           context = ssl
         end
-        socket = OpenSSL::SSL::Socket.new(socket, context: context, sync_close: true)
+        socket = OpenSSL::SSL::Socket::Client.new(socket, context: context, sync_close: true)
       end
     end
 

--- a/src/openssl/openssl.cr
+++ b/src/openssl/openssl.cr
@@ -1,6 +1,10 @@
 require "./lib_ssl"
 
 module OpenSSL
+  module SSL
+    alias VerifyMode = LibSSL::VerifyMode
+  end
+
   class Error < Exception
     getter! code : LibCrypto::ULong?
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -1,8 +1,4 @@
 class OpenSSL::SSL::Context
-  def self.default : self
-    @@default ||= new
-  end
-
   # Generates a new SSL context.
   #
   # By default it defaults to the `SSLv23_method` which actually means that

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -1,4 +1,56 @@
-class OpenSSL::SSL::Socket
+abstract class OpenSSL::SSL::Socket
+  class Client < Socket
+    def initialize(io, context : Context::Client = Context::Client.new, sync_close : Bool = false, hostname : String? = nil)
+      super(io, context, sync_close)
+
+      if hostname
+        # Macro from OpenSSL: SSL_ctrl(s,SSL_CTRL_SET_TLSEXT_HOSTNAME,TLSEXT_NAMETYPE_host_name,(char *)name)
+        LibSSL.ssl_ctrl(
+          @ssl,
+          LibSSL::SSLCtrl::SET_TLSEXT_HOSTNAME,
+          LibSSL::TLSExt::NAMETYPE_host_name,
+          hostname.to_unsafe.as(Pointer(Void))
+        )
+      end
+
+      ret = LibSSL.ssl_connect(@ssl)
+      unless ret == 1
+        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_connect")
+      end
+    end
+
+    def self.open(io, context : Context::Client = Context::Client.new, sync_close : Bool = false, hostname : String? = nil)
+      socket = new(io, context, sync_close, hostname)
+
+      begin
+        yield socket
+      ensure
+        socket.close
+      end
+    end
+  end
+
+  class Server < Socket
+    def initialize(io, context : Context::Server = Context::Server.new, sync_close : Bool = false)
+      super(io, context, sync_close)
+
+      ret = LibSSL.ssl_accept(@ssl)
+      unless ret == 1
+        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
+      end
+    end
+
+    def self.open(io, context : Context::Server = Context::Server.new, sync_close : Bool = false)
+      socket = new(io, context, sync_close)
+
+      begin
+        yield socket
+      ensure
+        socket.close
+      end
+    end
+  end
+
   include IO
 
   # If `sync_close` is true, closing this socket will
@@ -7,45 +59,15 @@ class OpenSSL::SSL::Socket
 
   getter? closed : Bool
 
-  def initialize(io, mode = :client, context : Context? = nil, @sync_close : Bool = false, hostname : String? = nil)
+  protected def initialize(io, context : Context, @sync_close : Bool = false)
     @closed = false
 
-    if mode != :client && mode != :server
-      raise ArgumentError.new("mode must be :client or :server, not #{mode.inspect}")
-    end
-
-    context ||= mode == :client ? Context.new_for_client : Context.new_for_server
     @ssl = LibSSL.ssl_new(context)
     unless @ssl
       raise OpenSSL::Error.new("SSL_new")
     end
     @bio = BIO.new(io)
     LibSSL.ssl_set_bio(@ssl, @bio, @bio)
-
-    if mode == :client
-      self.hostname = hostname if hostname
-      ret = LibSSL.ssl_connect(@ssl)
-      unless ret == 1
-        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_connect")
-      end
-    else
-      raise ArgumentError.new("hostname has no meaning in server mode") if hostname
-      ret = LibSSL.ssl_accept(@ssl)
-      unless ret == 1
-        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
-      end
-    end
-  end
-
-  # Calling this for server or after connect has no effect
-  private def hostname=(hostname : String)
-    # Macro from OpenSSL: SSL_ctrl(s,SSL_CTRL_SET_TLSEXT_HOSTNAME,TLSEXT_NAMETYPE_host_name,(char *)name)
-    LibSSL.ssl_ctrl(
-      @ssl,
-      LibSSL::SSLCtrl::SET_TLSEXT_HOSTNAME,
-      LibSSL::TLSExt::NAMETYPE_host_name,
-      hostname.to_unsafe.as(Pointer(Void))
-    )
   end
 
   def finalize
@@ -114,15 +136,6 @@ class OpenSSL::SSL::Socket
     rescue IO::Error
     ensure
       @bio.io.close if @sync_close
-    end
-  end
-
-  def self.open_client(io, context = Context.new_for_client)
-    ssl_sock = new(io, :client, context)
-    begin
-      yield ssl_sock
-    ensure
-      ssl_sock.close
     end
   end
 end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -7,7 +7,7 @@ class OpenSSL::SSL::Socket
 
   getter? closed : Bool
 
-  def initialize(io, mode = :client, context = Context.default, @sync_close : Bool = false, hostname : String? = nil)
+  def initialize(io, mode = :client, context = Context.new, @sync_close : Bool = false, hostname : String? = nil)
     @closed = false
     @ssl = LibSSL.ssl_new(context)
     unless @ssl
@@ -111,7 +111,7 @@ class OpenSSL::SSL::Socket
     end
   end
 
-  def self.open_client(io, context = Context.default)
+  def self.open_client(io, context = Context.new)
     ssl_sock = new(io, :client, context)
     begin
       yield ssl_sock


### PR DESCRIPTION
<del>Don't merge before #2671, includes redundant work that's better done there.</del>

This is basically an alternative to #2343. Fixes #2073.

This does three things:
* Makes `HTTP::Client#ssl` a `OpenSSL::SSL:Context::Client` as well as all `ssl` options in `HTTP::Client` also take one.
* Turns on peer verification by default.
* Remove `OpenSSL::SSL::Context.default`, since it's not easy to copy a context, we should avoid global mutable defaults. More reasoning in the commit message.

This does not yet setup a strong cipher suite as #2671 does for the server side, which would fix #2674's second issue. We can look into what we can reuse from there in a follow up PR. It also does not yet set a sane default for enabled protocol versions, for largely the same reasons.