### PR TITLE
LLVM intrinsics refactor, adding bitswap.

### DIFF
--- a/src/base64.cr
+++ b/src/base64.cr
@@ -150,7 +150,7 @@ module Base64
     cstr = data.pointer(size)
     endcstr = cstr + size - size % 3
     while cstr < endcstr
-      n = Intrinsics.bswap32(cstr.as(UInt32*).value)
+      n = Intrinsics.bswap(cstr.as(UInt32*).value)
       yield bytes[(n >> 26) & 63]
       yield bytes[(n >> 20) & 63]
       yield bytes[(n >> 14) & 63]

--- a/src/int.cr
+++ b/src/int.cr
@@ -490,7 +490,7 @@ struct Int8
   end
 
   def popcount
-    Intrinsics.popcount8(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -508,7 +508,7 @@ struct Int16
   end
 
   def popcount
-    Intrinsics.popcount16(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -526,7 +526,7 @@ struct Int32
   end
 
   def popcount
-    Intrinsics.popcount32(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -544,7 +544,7 @@ struct Int64
   end
 
   def popcount
-    Intrinsics.popcount64(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -562,7 +562,7 @@ struct UInt8
   end
 
   def popcount
-    Intrinsics.popcount8(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -580,7 +580,7 @@ struct UInt16
   end
 
   def popcount
-    Intrinsics.popcount16(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -598,7 +598,7 @@ struct UInt32
   end
 
   def popcount
-    Intrinsics.popcount32(self)
+    Intrinsics.ctpop(self)
   end
 end
 
@@ -616,6 +616,6 @@ struct UInt64
   end
 
   def popcount
-    Intrinsics.popcount64(self)
+    Intrinsics.ctpop(self)
   end
 end

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -1,21 +1,11 @@
-lib Intrinsics
-  fun debugtrap = "llvm.debugtrap"
-  ifdef x86_64
-    fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
-    fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
-    fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)
-  else
-    fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
-    fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
-    fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, align : UInt32, is_volatile : Bool)
-  end
-  fun read_cycle_counter = "llvm.readcyclecounter" : UInt64
-  fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
+require "./intrinsics/*"
 
-  fun popcount8 = "llvm.ctpop.i8"(src : Int8) : Int8
-  fun popcount16 = "llvm.ctpop.i16"(src : Int16) : Int16
-  fun popcount32 = "llvm.ctpop.i32"(src : Int32) : Int32
-  fun popcount64 = "llvm.ctpop.i64"(src : Int64) : Int64
+# http://llvm.org/docs/LangRef.html#intrinsic-functions
+module Intrinsics
+  extend Intrinsics::General
+  extend Intrinsics::StdCLib
+  extend Intrinsics::BitManipulation
+  extend Intrinsics::CodeGenerator
 end
 
 macro debugger

--- a/src/intrinsics/bit_manipulation.cr
+++ b/src/intrinsics/bit_manipulation.cr
@@ -1,0 +1,102 @@
+
+# Bit Manipulation Intrinsics
+#
+# See http://llvm.org/docs/LangRef.html#bit-manipulation-intrinsics
+module Intrinsics::BitManipulation
+
+  lib Lib
+
+    # http://llvm.org/docs/LangRef.html#llvm-ctpop-intrinsic
+    fun ctpop_i8 = "llvm.ctpop.i8"(src : Int8) : Int8
+    fun ctpop_i16 = "llvm.ctpop.i16"(src : Int16) : Int16
+    fun ctpop_i32 = "llvm.ctpop.i32"(src : Int32) : Int32
+    fun ctpop_i64 = "llvm.ctpop.i64"(src : Int64) : Int64
+
+    # http://llvm.org/docs/LangRef.html#llvm-bswap-intrinsics
+    fun bswap_i16 = "llvm.bswap.i16"(value : Int16) : Int16
+    fun bswap_i32 = "llvm.bswap.i32"(value : Int32) : Int32
+    fun bswap_i64 = "llvm.bswap.i64"(value : Int64) : Int64
+
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : Int8) : Int8
+    Lib.ctpop_i8(src)
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : UInt8) : UInt8
+    Lib.ctpop_i8(pointerof(src).as(Int8*).value).to_u8
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : Int16) : Int16
+    Lib.ctpop_i16(src)
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : UInt16) : UInt16
+    Lib.ctpop_i16(pointerof(src).as(Int16*).value).to_u16
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : Int32) : Int32
+    Lib.ctpop_i32(src)
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : UInt32) : UInt32
+    Lib.ctpop_i32(pointerof(src).as(Int32*).value).to_u32
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : Int64) : Int64
+    Lib.ctpop_i64(src)
+  end
+
+  @[AlwaysInline]
+  def ctpop(src : UInt64) : UInt64
+    Lib.ctpop_i64(pointerof(src).as(Int64*).value).to_u64
+  end
+
+  @[AlwaysInline]
+  def bswap(value : Int16) : Int16
+    Lib.bswap_i16(value)
+  end
+
+  @[AlwaysInline]
+  def bswap(value : Int32) : Int32
+    Lib.bswap_i32(value)
+  end
+
+  @[AlwaysInline]
+  def bswap(value : Int64) : Int64
+    Lib.bswap_i64(value)
+  end
+
+  @[AlwaysInline]
+  def bswap(value : UInt16) : UInt16
+    pointerof(Lib.bswap_i16(pointerof(value).as(Int16*).value)).as(UInt16*).value
+  end
+
+  @[AlwaysInline]
+  def bswap(value : UInt32) : UInt32
+    pointerof(Lib.bswap_i32(pointerof(value).as(Int32*).value)).as(UInt32*).value
+  end
+
+  @[AlwaysInline]
+  def bswap(value : UInt64) : UInt64
+    pointerof(Lib.bswap_i64(pointerof(value).as(Int64*).value)).as(UInt64*).value
+  end
+
+  @[AlwaysInline]
+  def bswap(value : Float32) : Float32
+    pointerof(Lib.bswap_i32(pointerof(value).as(Int32*).value)).as(Float32*).value
+  end
+
+  @[AlwaysInline]
+  def bswap(value : Float64) : Float64
+    pointerof(Lib.bswap_i64(pointerof(value).as(Int64*).value)).as(Float64*).value
+  end
+
+end

--- a/src/intrinsics/code_generator.cr
+++ b/src/intrinsics/code_generator.cr
@@ -1,0 +1,24 @@
+
+# Code Generator Intrinsics
+#
+# See http://llvm.org/docs/LangRef.html#code-generator-intrinsics
+module Intrinsics::CodeGenerator
+
+  lib Lib
+
+    # http://llvm.org/docs/LangRef.html#llvm-readcyclecounter-intrinsic
+    fun readcyclecounter = "llvm.readcyclecounter" : UInt64
+
+  end
+
+  # Returns low latency, high accuracy clock count on CPUs that support it.
+  #
+  # Please note it overflows quickly (9 seconds on Alpha CPU) so it should be used for small timings only.
+  #
+  # For more information see http://llvm.org/docs/LangRef.html#llvm-readcyclecounter-intrinsic.
+  @[AlwaysInline]
+  def read_cycle_counter : UInt64
+    Lib.readcyclecounter
+  end
+
+end

--- a/src/intrinsics/general.cr
+++ b/src/intrinsics/general.cr
@@ -1,0 +1,19 @@
+
+# General Intrinsics
+#
+# See http://llvm.org/docs/LangRef.html#general-intrinsics
+module Intrinsics::General
+
+  lib Lib
+
+    # http://llvm.org/docs/LangRef.html#llvm-debugtrap-intrinsic
+    fun debugtrap = "llvm.debugtrap"
+
+  end
+
+  @[AlwaysInline]
+  def debugtrap
+    Lib.debugtrap
+  end
+
+end

--- a/src/intrinsics/std_c_lib.cr
+++ b/src/intrinsics/std_c_lib.cr
@@ -1,0 +1,36 @@
+
+# Standard C Library Intrinsics
+#
+# See http://llvm.org/docs/LangRef.html#standard-c-library-intrinsics
+module Intrinsics::StdCLib
+
+  lib Lib
+
+    # http://llvm.org/docs/LangRef.html#llvm-memcpy-intrinsic
+    # http://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic
+    # http://llvm.org/docs/LangRef.html#llvm-memset-intrinsics
+    ifdef x86_64
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)
+    else
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, align : UInt32, is_volatile : Bool)
+    end
+
+  end
+
+  def memcpy(dest, src, len, align, is_volatile)
+    Lib.memcpy(dest, src, len, align, is_volatile)
+  end
+
+  def memmove(dest, src, len, align, is_volatile)
+    Lib.memmove(dest, src, len, align, is_volatile)
+  end
+
+  def memset(dest, src, len, align, is_volatile)
+    Lib.memset(dest, src, len, align, is_volatile)
+  end
+
+end

--- a/src/intrinsics/std_c_lib.cr
+++ b/src/intrinsics/std_c_lib.cr
@@ -21,14 +21,17 @@ module Intrinsics::StdCLib
 
   end
 
+  @[AlwaysInline]
   def memcpy(dest, src, len, align, is_volatile)
     Lib.memcpy(dest, src, len, align, is_volatile)
   end
 
+  @[AlwaysInline]
   def memmove(dest, src, len, align, is_volatile)
     Lib.memmove(dest, src, len, align, is_volatile)
   end
 
+  @[AlwaysInline]
   def memset(dest, src, len, align, is_volatile)
     Lib.memset(dest, src, len, align, is_volatile)
   end


### PR DESCRIPTION
Changes:
* `::Intrinsics` lib changed to module
* split by topic, i.e. `Intrinsics::BitManipulation`
* separate llvm api (explicit, 1-1 naming etc.) from crystal api
  (overloading, crystal names etc.)
* added bit swapping (should it be called `flip` or something else
  instead of `bswap`?)

The rationale behind separating into topic modules is that there are a
lot of intrinsic functions and that's how they are documented at
http://llvm.org/docs/LangRef.html#llvm-readcyclecounter-intrinsic.

Separation between llvm and crystal apis means that you can look up llvm
docs and know what the function does and crystal functions are... well,
crystallised with overloading for crystal types, our documentation etc.