### PR TITLE
Correctly implement dup and clone. Fixes #2627

### DIFF
--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -22,7 +22,7 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
+    token_before_expression = token.dup
 
     token = lexer.next_token
     token.type.should eq(:IDENT)
@@ -51,7 +51,7 @@ describe "Lexer macro" do
       token = lexer.next_macro_token(token.macro_state, false)
       token.type.should eq(:MACRO_EXPRESSION_START)
 
-      token_before_expression = token.clone
+      token_before_expression = token.dup
 
       token = lexer.next_token
       token.type.should eq(:IDENT)
@@ -88,7 +88,7 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
+    token_before_expression = token.dup
 
     token = lexer.next_token
     token.type.should eq(:IDENT)
@@ -120,7 +120,7 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
+    token_before_expression = token.dup
 
     token = lexer.next_token
     token.type.should eq(:IDENT)
@@ -148,7 +148,7 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
+    token_before_expression = token.dup
 
     token = lexer.next_token
     token.type.should eq(:IDENT)
@@ -206,8 +206,6 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
-
     token = lexer.next_token
     token.type.should eq(:IDENT)
     token.value.should eq("var")
@@ -221,7 +219,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_LITERAL)
     token.value.should eq("\n")
 
-    token = lexer.next_macro_token(token_before_expression.macro_state, false)
+    token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_END)
   end
 
@@ -366,7 +364,7 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
 
-    token_before_expression = token.clone
+    token_before_expression = token.dup
     token_before_expression.macro_state.comment.should be_true
 
     token = lexer.next_token

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -98,4 +98,9 @@ describe "BigFloat" do
     b = 123.to_big_f
     b.hash.should eq(b.to_f64.hash)
   end
+
+  it "clones" do
+    x = 1.to_big_f
+    x.clone.should eq(x)
+  end
 end

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -223,4 +223,9 @@ describe "BigInt" do
     hash.should eq(5)
     typeof(hash).should eq(UInt64)
   end
+
+  it "clones" do
+    x = 1.to_big_i
+    x.clone.should eq(x)
+  end
 end

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -155,4 +155,9 @@ describe BigRational do
   it "is a number" do
     br(10, 3).is_a?(Number).should be_true
   end
+
+  it "clones" do
+    x = br(10, 3)
+    x.clone.should eq(x)
+  end
 end

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -36,4 +36,9 @@ describe "Bool" do
     assert { true.to_s.should eq("true") }
     assert { false.to_s.should eq("false") }
   end
+
+  describe "clone" do
+    assert { true.clone.should be_true }
+    assert { false.clone.should be_false }
+  end
 end

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -272,4 +272,8 @@ describe "Char" do
     'a'.control?.should be_false
     '\u0019'.control?.should be_true
   end
+
+  describe "clone" do
+    assert { 'a'.clone.should eq('a') }
+  end
 end

--- a/spec/std/class_spec.cr
+++ b/spec/std/class_spec.cr
@@ -22,4 +22,12 @@ describe Class do
     (Int32 | Char).should eq(typeof(1, 'a'))
     (Int32 | Char | Float64).should eq(typeof(1, 'a', 1.0))
   end
+
+  it "dups" do
+    Int32.dup.should eq(Int32)
+  end
+
+  it "clones" do
+    Int32.clone.should eq(Int32)
+  end
 end

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -163,4 +163,9 @@ describe "Complex" do
       (-5.7/(Complex.new(2.27, 8.92))).should eq(Complex.new(-0.1527278908111847, 0.6001466017778712))
     end
   end
+
+  it "clones" do
+    c = Complex.new(4, 6.2)
+    c.clone.should eq(c)
+  end
 end

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -111,4 +111,8 @@ describe Enum do
     SpecEnum.parse?("Two").should eq(SpecEnum::Two)
     SpecEnum.parse?("Four").should be_nil
   end
+
+  it "clones" do
+    SpecEnum::One.clone.should eq(SpecEnum::One)
+  end
 end

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -195,4 +195,9 @@ describe "Float" do
     f.should eq(-1.5_f32)
     f.should be_a(Float32)
   end
+
+  it "clones" do
+    1.0.clone.should eq(1.0)
+    1.0_f32.clone.should eq(1.0_f32)
+  end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -431,4 +431,10 @@ describe "Int" do
       end
     end
   end
+
+  it "clones" do
+    [1_u8, 2_u16, 3_u32, 4_u64, 5_i8, 6_i16, 7_i32, 8_i64].each do |value|
+      value.clone.should eq(value)
+    end
+  end
 end

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -245,4 +245,9 @@ describe "Pointer" do
     (!Pointer(Int32).null).should be_true
     (!Pointer(Int32).new(123)).should be_false
   end
+
+  it "clones" do
+    ptr = Pointer(Int32).new(123)
+    ptr.clone.should eq(ptr)
+  end
 end

--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -60,4 +60,9 @@ describe "Proc" do
     func2 = ->{ 1 }
     func2.should_not eq(func)
   end
+
+  it "clones" do
+    func = ->{ 1 }
+    func.clone.should eq(func)
+  end
 end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -355,4 +355,12 @@ describe "Range" do
       (1...2).step(1).to_a.should eq([1])
     end
   end
+
+  it "clones" do
+    range = [1]..[2]
+    clone = range.clone
+    clone.should eq(range)
+    clone.begin.should_not be(range.begin)
+    clone.end.should_not be(range.end)
+  end
 end

--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -1,17 +1,30 @@
 require "spec"
 
-class ReferenceSpecTestClass
-  @x : Int32
-  @y : String
+module ReferenceSpec
+  class TestClass
+    @x : Int32
+    @y : String
 
-  def initialize(@x, @y)
+    def initialize(@x, @y)
+    end
   end
-end
 
-class ReferenceSpecTestClassBase
-end
+  class TestClassBase
+  end
 
-class ReferenceSpecTestClassSubclass < ReferenceSpecTestClassBase
+  class TestClassSubclass < TestClassBase
+  end
+
+  class DupCloneClass
+    getter x, y
+
+    def initialize
+      @x = 1
+      @y = [1, 2, 3]
+    end
+
+    def_clone
+  end
 end
 
 describe "Reference" do
@@ -32,13 +45,13 @@ describe "Reference" do
   end
 
   it "does inspect" do
-    r = ReferenceSpecTestClass.new(1, "hello")
-    r.inspect.should eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)} @x=1, @y="hello">))
+    r = ReferenceSpec::TestClass.new(1, "hello")
+    r.inspect.should eq(%(#<ReferenceSpec::TestClass:0x#{r.object_id.to_s(16)} @x=1, @y="hello">))
   end
 
   it "does to_s" do
-    r = ReferenceSpecTestClass.new(1, "hello")
-    r.to_s.should eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)}>))
+    r = ReferenceSpec::TestClass.new(1, "hello")
+    r.to_s.should eq(%(#<ReferenceSpec::TestClass:0x#{r.object_id.to_s(16)}>))
   end
 
   it "does inspect for class" do
@@ -50,11 +63,28 @@ describe "Reference" do
   end
 
   it "does to_s for class if virtual" do
-    [ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass].to_s.should eq("[ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass]")
+    [ReferenceSpec::TestClassBase, ReferenceSpec::TestClassSubclass].to_s.should eq("[ReferenceSpec::TestClassBase, ReferenceSpec::TestClassSubclass]")
   end
 
   it "returns itself" do
     x = "hello"
     x.itself.should be(x)
+  end
+
+  it "dups" do
+    original = ReferenceSpec::DupCloneClass.new
+    duplicate = original.dup
+    duplicate.should_not be(original)
+    duplicate.x.should eq(original.x)
+    duplicate.y.should be(original.y)
+  end
+
+  it "clones with def_clone" do
+    original = ReferenceSpec::DupCloneClass.new
+    clone = original.clone
+    clone.should_not be(original)
+    clone.x.should eq(original.x)
+    clone.y.should_not be(original.y)
+    clone.y.should eq(original.y)
   end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -132,4 +132,14 @@ describe "Regex" do
       Regex.union(/skiing/i, /sledding/).should eq(/skiing/i + /sledding/)
     end
   end
+
+  it "dups" do
+    regex = /foo/
+    regex.dup.should be(regex)
+  end
+
+  it "clones" do
+    regex = /foo/
+    regex.clone.should be(regex)
+  end
 end

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -56,14 +56,36 @@ describe "Set" do
   end
 
   describe "dup" do
-    it "creates an independent copy" do
-      set1 = Set{1, 2, 3}
+    it "creates a dup" do
+      set1 = Set{[1, 2]}
       set2 = set1.dup
 
-      set1 << 4
-      set2 << 5
+      set1.should eq(set2)
+      set1.should_not be(set2)
 
-      set2.should eq(Set{1, 2, 3, 5})
+      set1.to_a.first.should be(set2.to_a.first)
+
+      set1 << [3]
+      set2 << [4]
+
+      set2.should eq(Set{[1, 2], [4]})
+    end
+  end
+
+  describe "clone" do
+    it "creates a clone" do
+      set1 = Set{[1, 2]}
+      set2 = set1.clone
+
+      set1.should eq(set2)
+      set1.should_not be(set2)
+
+      set1.to_a.first.should_not be(set2.to_a.first)
+
+      set1 << [3]
+      set2 << [4]
+
+      set2.should eq(Set{[1, 2], [4]})
     end
   end
 

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -124,4 +124,11 @@ describe "StaticArray" do
     a[1].should eq(4)
     a[2].should eq(3)
   end
+
+  it "clones" do
+    a = StaticArray(Array(Int32), 1).new { |i| [1] }
+    b = a.clone
+    b[0].should eq(a[0])
+    b[0].should_not be(a[0])
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1789,4 +1789,16 @@ describe "String" do
     "barbar".insert(0, "foo").size.should eq(9)
     "ともだち".insert(0, "ねこ").size.should eq(6)
   end
+
+  it "dups" do
+    string = "foo"
+    dup = string.dup
+    string.should be(dup)
+  end
+
+  it "clones" do
+    string = "foo"
+    clone = string.clone
+    string.should be(clone)
+  end
 end

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -1,38 +1,72 @@
 require "spec"
 require "big_int"
 
-struct StructSpecTestClass
-  @x : Int32
-  @y : String
+module StructSpec
+  struct TestClass
+    @x : Int32
+    @y : String
 
-  def initialize(@x, @y)
+    def initialize(@x, @y)
+    end
   end
-end
 
-struct StructSpecBigIntWrapper
-  @value : BigInt
+  struct BigIntWrapper
+    @value : BigInt
 
-  def initialize(@value : BigInt)
+    def initialize(@value : BigInt)
+    end
+  end
+
+  struct DupCloneStruct
+    property x, y
+
+    def initialize
+      @x = 1
+      @y = [1, 2, 3]
+    end
+
+    def_clone
   end
 end
 
 describe "Struct" do
   it "does to_s" do
-    s = StructSpecTestClass.new(1, "hello")
-    s.to_s.should eq(%(StructSpecTestClass(@x=1, @y="hello")))
+    s = StructSpec::TestClass.new(1, "hello")
+    s.to_s.should eq(%(StructSpec::TestClass(@x=1, @y="hello")))
   end
 
   it "does ==" do
-    s = StructSpecTestClass.new(1, "hello")
+    s = StructSpec::TestClass.new(1, "hello")
     s.should eq(s)
   end
 
   it "does hash" do
-    s = StructSpecTestClass.new(1, "hello")
+    s = StructSpec::TestClass.new(1, "hello")
     s.hash.should eq(31 + "hello".hash)
   end
 
   it "does hash for struct wrapper (#1940)" do
-    StructSpecBigIntWrapper.new(BigInt.new(0)).hash.should eq(0)
+    StructSpec::BigIntWrapper.new(BigInt.new(0)).hash.should eq(0)
+  end
+
+  it "does dup" do
+    original = StructSpec::DupCloneStruct.new
+    duplicate = original.dup
+    duplicate.x.should eq(original.x)
+    duplicate.y.should be(original.y)
+
+    original.x = 10
+    duplicate.x.should_not eq(10)
+  end
+
+  it "clones with def_clone" do
+    original = StructSpec::DupCloneStruct.new
+    clone = original.clone
+    clone.x.should eq(original.x)
+    clone.y.should_not be(original.y)
+    clone.y.should eq(original.y)
+
+    original.x = 10
+    clone.x.should_not eq(10)
   end
 end

--- a/spec/std/symbol_spec.cr
+++ b/spec/std/symbol_spec.cr
@@ -21,4 +21,8 @@ describe Symbol do
     b = "[:+, :-, :*, :/, :==, :<, :<=, :>, :>=, :!, :!=, :=~, :!~, :&, :|, :^, :~, :**, :>>, :<<, :%, :[], :<=>, :===, :[]?, :[]=]"
     a.inspect.should eq(b)
   end
+
+  describe "clone" do
+    assert { :foo.clone.should eq(:foo) }
+  end
 end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -183,6 +183,10 @@ struct BigFloat < Float
     (expptr - length).times { io << 0 } if expptr > 0
   end
 
+  def clone
+    self
+  end
+
   private def mpf
     pointerof(@mpf)
   end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -307,6 +307,10 @@ struct BigInt < Int
     self
   end
 
+  def clone
+    self
+  end
+
   private def check_division_by_zero(value)
     if value == 0
       raise DivisionByZero.new

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -172,6 +172,10 @@ struct BigRational < Number
     to_s io
   end
 
+  def clone
+    self
+  end
+
   private def mpq
     pointerof(@mpq)
   end

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -55,4 +55,8 @@ struct Bool
   def to_s(io)
     io << to_s
   end
+
+  def clone
+    self
+  end
 end

--- a/src/char.cr
+++ b/src/char.cr
@@ -587,4 +587,8 @@ struct Char
   def ===(byte : Int)
     ord === byte
   end
+
+  def clone
+    self
+  end
 end

--- a/src/class.cr
+++ b/src/class.cr
@@ -54,4 +54,12 @@ class Class
   def to_s(io)
     io << name
   end
+
+  def dup
+    self
+  end
+
+  def clone
+    self
+  end
 end

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -18,7 +18,7 @@ module Crystal
     end
 
     def clone
-      MatchContext.new(@owner, @type_lookup, @free_vars.clone)
+      MatchContext.new(@owner, @type_lookup, @free_vars.dup)
     end
   end
 

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -212,6 +212,10 @@ struct Complex
     Complex.new(@real / other, @imag / other)
   end
 
+  def clone
+    self
+  end
+
   # Returns the number 0 in complex form
   def self.zero : Complex
     new 0, 0

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -372,6 +372,10 @@ struct Enum
     {% end %}
   end
 
+  def clone
+    self
+  end
+
   # Convenience macro to create an *or*ed enum from the given members.
   #
   # ```

--- a/src/float.cr
+++ b/src/float.cr
@@ -175,6 +175,10 @@ struct Float32
     n = self
     pointerof(n).as(Int32*).value
   end
+
+  def clone
+    self
+  end
 end
 
 struct Float64
@@ -398,5 +402,9 @@ struct Float64
   def hash
     n = self
     pointerof(n).as(Int64*).value
+  end
+
+  def clone
+    self
   end
 end

--- a/src/int.cr
+++ b/src/int.cr
@@ -492,6 +492,10 @@ struct Int8
   def popcount
     Intrinsics.popcount8(self)
   end
+
+  def clone
+    self
+  end
 end
 
 struct Int16
@@ -509,6 +513,10 @@ struct Int16
 
   def popcount
     Intrinsics.popcount16(self)
+  end
+
+  def clone
+    self
   end
 end
 
@@ -528,6 +536,10 @@ struct Int32
   def popcount
     Intrinsics.popcount32(self)
   end
+
+  def clone
+    self
+  end
 end
 
 struct Int64
@@ -545,6 +557,10 @@ struct Int64
 
   def popcount
     Intrinsics.popcount64(self)
+  end
+
+  def clone
+    self
   end
 end
 
@@ -564,6 +580,10 @@ struct UInt8
   def popcount
     Intrinsics.popcount8(self)
   end
+
+  def clone
+    self
+  end
 end
 
 struct UInt16
@@ -581,6 +601,10 @@ struct UInt16
 
   def popcount
     Intrinsics.popcount16(self)
+  end
+
+  def clone
+    self
   end
 end
 
@@ -600,6 +624,10 @@ struct UInt32
   def popcount
     Intrinsics.popcount32(self)
   end
+
+  def clone
+    self
+  end
 end
 
 struct UInt64
@@ -617,5 +645,9 @@ struct UInt64
 
   def popcount
     Intrinsics.popcount64(self)
+  end
+
+  def clone
+    self
   end
 end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -407,11 +407,6 @@ struct NamedTuple
     {% end %}
   end
 
-  # Returns *self*.
-  def dup
-    self
-  end
-
   # Returns a named tuple with the same keys but with cloned values, using the `clone` method.
   def clone
     {% begin %}

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -101,4 +101,8 @@ struct Nil
   def not_nil!
     raise "Nil assertion failed"
   end
+
+  def clone
+    self
+  end
 end

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -468,4 +468,8 @@ struct Pointer(T)
     ptr = self.as(Pointer(Void))
     Intrinsics.memset(self.as(Void*), 0_u8, (count * sizeof(T)).to_u32, 0_u32, false)
   end
+
+  def clone
+    self
+  end
 end

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -129,6 +129,10 @@ struct Proc
     object_id.hash
   end
 
+  def clone
+    self
+  end
+
   def to_s(io)
     io << "#<"
     io << {{@type.name.stringify}}

--- a/src/range.cr
+++ b/src/range.cr
@@ -270,6 +270,11 @@ struct Range(B, E)
     end
   end
 
+  # Returns a new Range with `begin` and `end` cloned.
+  def clone
+    Range.new(@begin.clone, @end.clone, @exclusive)
+  end
+
   # :nodoc:
   class ItemIterator(B, E)
     include Iterator(B)

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -32,6 +32,18 @@ class Reference
     false
   end
 
+  # Returns a shallow copy of this object.
+  #
+  # This allocates a new object and copies the contents of
+  # `self` into it.
+  def dup
+    {% begin %}
+      dup = {{@type}}.allocate
+      dup.as(Void*).copy_from(self.as(Void*), instance_sizeof({{@type}}))
+      dup
+    {% end %}
+  end
+
   # Returns this reference's `object_id` as the hash value.
   def hash
     object_id

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -209,6 +209,14 @@ class Regex
       io << ">"
     end
 
+    def dup
+      self
+    end
+
+    def clone
+      self
+    end
+
     private def check_index_out_of_bounds(index)
       raise IndexError.new unless valid_group?(index)
     end

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -502,4 +502,12 @@ class Regex
     io << source
     io << ")"
   end
+
+  def dup
+    self
+  end
+
+  def clone
+    self
+  end
 end

--- a/src/set.cr
+++ b/src/set.cr
@@ -234,6 +234,15 @@ struct Set(T)
     Set(T).new.merge(self)
   end
 
+  # Returns a new set with all of the elements cloned.
+  def clone
+    clone = Set(T).new
+    each do |element|
+      clone << element.clone
+    end
+    clone
+  end
+
   # Returns the elements as an array
   #
   #     Set.new([1,5]).to_a  # => [1,5]

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -253,6 +253,15 @@ struct StaticArray(T, N)
     io << "]"
   end
 
+  # Returns a new StaticArray where each element is cloned from elements in `self`.
+  def clone
+    array = uninitialized self
+    N.times do |i|
+      array.to_unsafe[i] = to_unsafe[i].clone
+    end
+    array
+  end
+
   private def check_index_out_of_bounds(index)
     index += size if index < 0
     unless 0 <= index < size

--- a/src/string.cr
+++ b/src/string.cr
@@ -2975,6 +2975,14 @@ class String
     Slice.new(to_unsafe, bytesize)
   end
 
+  def clone
+    self
+  end
+
+  def dup
+    self
+  end
+
   def to_s
     self
   end

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -79,4 +79,8 @@ struct Symbol
     end
     false
   end
+
+  def clone
+    self
+  end
 end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -332,11 +332,6 @@ struct Tuple
     hash
   end
 
-  # Returns self.
-  def dup
-    self
-  end
-
   # Returns a tuple containing cloned elements of this tuple using the `clone` method.
   def clone
     {% if true %}

--- a/src/value.cr
+++ b/src/value.cr
@@ -13,4 +13,13 @@ struct Value
   def ==(other)
     false
   end
+
+  # Returns a shallow copy of this object.
+  #
+  # Because `Value` is a value type, this method returns `self`,
+  # which already involves a shallow copy of this object because
+  # value types are passed by value.
+  def dup
+    self
+  end
 end


### PR DESCRIPTION
This implements all of the points from [this comment](https://github.com/crystal-lang/crystal/issues/2627#issuecomment-220800874), basically:

* Remove `dup` and `clone` from Object
* Implement `dup` for Reference by memcpy of the underlying bytes
* Implement `dup` for Value by returning `self` (because that returns a copy)
* Implement `clone` for primitive types (`Int`, `Float`, `Nil`, `Bool`, `Char`) as returning `self`, because they are immutable
* We don't implement `clone` for `Reference` or `Struct`: that's logic that is specific to each subclass. We of course implement it for some types in the standard library, like `Array`, `Hash`, `Set`, etc.

Additionally, there's a macro `Object#def_clone` that defines a clone method that invokes `clone` on all instance variables, which can be handy. The name is similar to other macros that define methods, like `def_equals` and `def_hash`.

This makes `dup`'s default behaviour consistent, as it returns a new, different object for `Reference` types (before this PR it would return `self`).

`clone` is also improved: it doesn't exist by default so invoking `clone` on a method that doesn't define it is a compile error, and at that point one must define its correct behaviour. So, this is a breaking change if someone was relying on this behaviour, but it's a breaking change that will likely spot bugs (or misuses of `clone`, I found one in the compiler's source code).