### PR TITLE
Add CodeTriage badge to increase awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-Crystal [![Build Status](https://travis-ci.org/crystal-lang/crystal.svg)](https://travis-ci.org/crystal-lang/crystal) [![Bountysource](https://api.bountysource.com/badge/team?team_id=89730&style=raised)](https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language)
-=======
+# Crystal
+
+[![Build Status](https://travis-ci.org/crystal-lang/crystal.svg)](https://travis-ci.org/crystal-lang/crystal)
+[![Bountysource](https://api.bountysource.com/badge/team?team_id=89730&style=raised)](https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language)
+[![Code Triagers Badge](http://www.codetriage.com/crystal-lang/crystal/badges/users.svg)](http://www.codetriage.com/crystal-lang/crystal)
+
+---
 
 ![born-and-raised](https://cloud.githubusercontent.com/assets/209371/13291809/022e2360-daf8-11e5-8be7-d02c1c8b38fb.png)
 


### PR DESCRIPTION
There are already 10 people on CodeTriage who have subscribed to receive
notices on assisting triage open issues and pull requests.

Minor updates to Markdown heading, move badges to individual lines to
prevent run-on, while preserving a "clean" look.

## Before:

<img width="454" alt="screenshot 2016-05-31 11 14 13" src="https://cloud.githubusercontent.com/assets/529516/15679812/37d3281a-2721-11e6-90ee-a5ba2960e8d1.png">

## After:

<img width="418" alt="screenshot 2016-05-31 11 13 10" src="https://cloud.githubusercontent.com/assets/529516/15679813/39bbd154-2721-11e6-939c-7eac12270fee.png">

