### PR TITLE
Make `Void` mean `Nil`, but keep `Void*` as such

### DIFF
--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -687,27 +687,4 @@ describe "Code gen: fun" do
       end
       )).to_i.should eq(42)
   end
-
-  it "assigns non-void proc to void proc (#2672)" do
-    run(%(
-      $x = 0
-
-      class Foo
-        @action : ->
-
-        def initialize
-          @action = ->{ $x += 1 }
-          1
-        end
-
-        def action
-          @action
-        end
-      end
-
-      Foo.new.action.call
-
-      $x
-      )).to_i.should eq(1)
-  end
 end

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -371,4 +371,39 @@ describe "Code gen: pointer" do
       foo.x
       )).to_i.should eq(123)
   end
+
+  it "can assign nil to void pointer" do
+    codegen(%(
+      require "prelude"
+
+      ptr = Pointer(Void).malloc(1_u64)
+      ptr.value = ptr.value
+      ))
+  end
+
+  it "can pass any pointer to something expecting void* in lib call" do
+    codegen(%(
+      lib LibFoo
+        fun foo(x : Void*) : Float64
+      end
+
+      LibFoo.foo(Pointer(Int32).malloc(1_u64))
+      ))
+  end
+
+  it "can pass any pointer to something expecting void* in lib call, with to_unsafe" do
+    codegen(%(
+      lib LibFoo
+        fun foo(x : Void*) : Float64
+      end
+
+      class Foo
+        def to_unsafe
+          Pointer(Int32).malloc(1_u64)
+        end
+      end
+
+      LibFoo.foo(Foo.new)
+      ))
+  end
 end

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -87,4 +87,25 @@ describe "Code gen: void" do
       bar LibC.foo
     ))
   end
+
+  it "returns void from nil functions, doesn't crash when passing value" do
+    run(%(
+      def baz(x)
+        1
+      end
+
+      struct Nil
+        def bar
+          baz(self)
+        end
+      end
+
+      def foo
+        1
+        nil
+      end
+
+      foo.bar
+      )).to_i.should eq(1)
+  end
 end

--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -47,7 +47,8 @@ class Crystal::Playground::TestAgent < Playground::Agent
   end
 end
 
-fun a_sample_void : Void
+def a_sample_void
+  Pointer(Void).malloc(1_u64).value
 end
 
 describe Playground::Agent do
@@ -62,9 +63,9 @@ describe Playground::Agent do
     agent.i(1) { nil.as(Void?) }
     agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"nil","value_type":"Void?"}))
     agent.i(1) { a_sample_void.as(Void?) }
-    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"(void)","value_type":"Void?"}))
+    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"nil","value_type":"Void?"}))
     agent.i(1) { a_sample_void }
-    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"(void)","value_type":"Void"}))
+    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"nil","value_type":"Nil"}))
   end
 end
 

--- a/spec/compiler/type_inference/block_spec.cr
+++ b/spec/compiler/type_inference/block_spec.cr
@@ -721,7 +721,7 @@ describe "Block inference" do
       foo do
         1
       end
-      )) { void }
+      )) { |mod| mod.nil }
   end
 
   it "ignores void return type (2) (#427)" do

--- a/spec/compiler/type_inference/closure_spec.cr
+++ b/spec/compiler/type_inference/closure_spec.cr
@@ -317,7 +317,7 @@ describe "Type inference: closure" do
       foo do |x|
         x.to_f
       end
-      ") { void }
+      ") { |mod| mod.nil }
   end
 
   it "errors when transforming block to fun literal if type mismatch" do

--- a/spec/compiler/type_inference/fun_spec.cr
+++ b/spec/compiler/type_inference/fun_spec.cr
@@ -129,7 +129,7 @@ describe "Type inference: fun" do
       end
 
       foo ->(x : Int32) { x.to_f }
-      ") { void }
+      ") { |mod| mod.nil }
   end
 
   it "has fun literal as restriction and errors if output is different" do
@@ -457,7 +457,7 @@ describe "Type inference: fun" do
       f = foo { |f| f.bar }
       Foo.new
       f
-      )) { fun_of(types["Foo"], void) }
+      )) { |mod| fun_of(types["Foo"], mod.nil) }
   end
 
   it "gives correct error message when fun return type is incorrect (#219)" do
@@ -805,6 +805,6 @@ describe "Type inference: fun" do
   it "sets proc type as void if explicitly told so, when using new" do
     assert_type(%(
       Proc(Int32, Void).new { 1 }
-      )) { fun_of(int32, void) }
+      )) { |mod| fun_of(int32, mod.nil) }
   end
 end

--- a/spec/compiler/type_inference/instance_var_spec.cr
+++ b/spec/compiler/type_inference/instance_var_spec.cr
@@ -3063,24 +3063,6 @@ describe "Type inference: instance var" do
       "can't declare instance variables in Object"
   end
 
-  it "unifies Void proc with non-Void proc (#2672)" do
-    assert_type(%(
-      class Foo
-        @action : ->
-
-        def initialize
-          @action = -> { }
-        end
-
-        def action
-          @action
-        end
-      end
-
-      Foo.new.action
-      )) { fun_of(void) }
-  end
-
   it "gives correct error when trying to use Int as an instance variable type" do
     assert_error %(
       class Foo

--- a/spec/compiler/type_inference/lib_spec.cr
+++ b/spec/compiler/type_inference/lib_spec.cr
@@ -226,22 +226,6 @@ describe "Type inference: lib" do
       ", "argument 'x' of 'LibC#foo' must be Int32, not Foo (nor Char returned by 'Foo#to_unsafe')"
   end
 
-  it "error if passing nil to pointer through to_unsafe" do
-    assert_error "
-      lib LibC
-        fun foo(x : Void*) : Int32
-      end
-
-      class Foo
-        def to_unsafe
-          nil
-        end
-      end
-
-      LibC.foo Foo.new
-      ", "argument 'x' of 'LibC#foo' must be Pointer(Void), not Foo (nor Nil returned by 'Foo#to_unsafe')"
-  end
-
   it "error if passing non primitive type as varargs" do
     assert_error "
       lib LibC
@@ -787,5 +771,35 @@ describe "Type inference: lib" do
       LibC.foo(x: out x)
       x
       )) { int32 }
+  end
+
+  it "types fun returning nothing as nil" do
+    assert_type(%(
+      lib LibFoo
+        fun foo
+      end
+
+      LibFoo.foo
+      )) { |mod| mod.nil }
+  end
+
+  it "types fun returning void as nil" do
+    assert_type(%(
+      lib LibFoo
+        fun foo : Void
+      end
+
+      LibFoo.foo
+      )) { |mod| mod.nil }
+  end
+
+  it "types fun returning nil as nil" do
+    assert_type(%(
+      lib LibFoo
+        fun foo : Nil
+      end
+
+      LibFoo.foo
+      )) { |mod| mod.nil }
   end
 end

--- a/spec/compiler/type_inference/nil_spec.cr
+++ b/spec/compiler/type_inference/nil_spec.cr
@@ -142,4 +142,24 @@ describe "Type inference: nil" do
       1
       ") { int32 }
   end
+
+  it "doesn't check return type for nil" do
+    assert_type(%(
+      def foo : Nil
+        1
+      end
+
+      foo
+      )) { |mod| mod.nil }
+  end
+
+  it "doesn't check return type for void" do
+    assert_type(%(
+      def foo : Void
+        1
+      end
+
+      foo
+      )) { |mod| mod.nil }
+  end
 end

--- a/spec/compiler/type_inference/pointer_spec.cr
+++ b/spec/compiler/type_inference/pointer_spec.cr
@@ -129,4 +129,37 @@ describe "Type inference: pointer" do
       ),
       "use `null?`"
   end
+
+  it "can assign nil to void pointer" do
+    assert_type(%(
+      ptr = Pointer(Void).malloc(1_u64)
+      ptr.value = ptr.value
+      )) { |mod| mod.nil }
+  end
+
+  it "can pass any pointer to something expecting void* in lib call" do
+    assert_type(%(
+      lib LibFoo
+        fun foo(x : Void*) : Float64
+      end
+
+      LibFoo.foo(Pointer(Int32).malloc(1_u64))
+      )) { float64 }
+  end
+
+  it "can pass any pointer to something expecting void* in lib call, with to_unsafe" do
+    assert_type(%(
+      lib LibFoo
+        fun foo(x : Void*) : Float64
+      end
+
+      class Foo
+        def to_unsafe
+          Pointer(Int32).malloc(1_u64)
+        end
+      end
+
+      LibFoo.foo(Foo.new)
+      )) { float64 }
+  end
 end

--- a/spec/compiler/type_inference/primitives_spec.cr
+++ b/spec/compiler/type_inference/primitives_spec.cr
@@ -68,7 +68,7 @@ describe "Type inference: primitives" do
       end
 
       LibFoo.foo == 1
-      ), "undefined method '==' for Void"
+      ), "undefined method '==' for Nil"
   end
 
   it "correctly types first hash from type vars (bug)" do

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -68,13 +68,17 @@ class Crystal::CodeGenVisitor
 
     # First self.
     if owner.passed_as_self?
-      if obj && obj.type.passed_as_self?
-        call_args << downcast(@last, target_def.owner, obj.type, true)
+      if owner.nil_type?
+        call_args << llvm_nil
       else
-        if node.uses_with_scope? && (yield_scope = context.vars["%scope"]?)
-          call_args << downcast(yield_scope.pointer, target_def.owner, node.with_scope.not_nil!, true)
+        if obj && obj.type.passed_as_self?
+          call_args << downcast(@last, target_def.owner, obj.type, true)
         else
-          call_args << llvm_self(owner)
+          if node.uses_with_scope? && (yield_scope = context.vars["%scope"]?)
+            call_args << downcast(yield_scope.pointer, target_def.owner, node.with_scope.not_nil!, true)
+          else
+            call_args << llvm_self(owner)
+          end
         end
       end
     end
@@ -88,6 +92,7 @@ class Crystal::CodeGenVisitor
         call_arg = int8(0)
       else
         call_arg = @last
+        call_arg = llvm_nil if arg.type.nil_type?
         call_arg = downcast(call_arg, def_arg.type, arg.type, true)
       end
       call_args << call_arg
@@ -165,6 +170,7 @@ class Crystal::CodeGenVisitor
           def_arg = target_def.args[i]?
 
           call_arg = @last
+          call_arg = llvm_nil if arg.type.nil_type?
 
           if def_arg && arg.type.nil_type? && (def_arg.type.pointer? || def_arg.type.fun?)
             # Nil to pointer

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -325,6 +325,11 @@ class Crystal::CodeGenVisitor
     value
   end
 
+  def downcast_distinct(value, to_type : PointerInstanceType, from_type : PointerInstanceType)
+    # cast of a pointer being cast to Void*
+    bit_cast value, LLVM::VoidPointer
+  end
+
   def downcast_distinct(value, to_type : TypeDefType, from_type : NilablePointerType)
     downcast_distinct value, to_type.typedef, from_type
   end

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -173,7 +173,7 @@ class Crystal::CodeGenVisitor
       end
       llvm_arg_type
     end
-    llvm_return_type = llvm_type(target_def.type)
+    llvm_return_type = llvm_return_type(target_def.type)
 
     if is_closure
       llvm_args_types.insert(0, LLVM::VoidPointer)

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -148,6 +148,7 @@ module Crystal
     delegate llvm_embedded_type, llvm_typer
     delegate llvm_c_type, llvm_typer
     delegate llvm_c_return_type, llvm_typer
+    delegate llvm_return_type, llvm_typer
 
     def llvm_fun_type(type)
       llvm_typer.fun_type(type.as(FunInstanceType))

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -387,8 +387,20 @@ module Crystal
       llvm_type(type)
     end
 
+    def llvm_c_return_type(type : NilType)
+      LLVM::Void
+    end
+
     def llvm_c_return_type(type)
       llvm_c_type(type)
+    end
+
+    def llvm_return_type(type : NilType)
+      LLVM::Void
+    end
+
+    def llvm_return_type(type)
+      llvm_type(type)
     end
 
     def closure_type(type : FunInstanceType)

--- a/src/compiler/crystal/codegen/phi.cr
+++ b/src/compiler/crystal/codegen/phi.cr
@@ -50,7 +50,7 @@ class Crystal::CodeGenVisitor
       return unreachable if @node_type.try &.no_return?
 
       if @needs_value
-        unless @node_type.try &.void?
+        unless @node_type.try(&.void?) || @node_type.try(&.nil_type?)
           value = @codegen.upcast value, @node_type.not_nil!, type
           @phi_table.not_nil!.add insert_block, value
         end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -428,6 +428,10 @@ class Crystal::CodeGenVisitor
 
   def codegen_primitive_pointer_set(node, target_def, call_args)
     type = context.type.remove_typedef.as(PointerInstanceType)
+
+    # Assinging to a Pointer(Void) has no effect
+    return llvm_nil if type.element_type.void?
+
     value = call_args[1]
     assign call_args[0], type.element_type, node.type, value
     value

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -392,6 +392,9 @@ module Crystal
 
     def fun_of(types : Array)
       type_vars = types.map { |type| type.as(TypeVar) }
+      unless type_vars.empty?
+        type_vars[-1] = self.nil if type_vars[-1].is_a?(VoidType)
+      end
       proc.instantiate(type_vars)
     end
 
@@ -400,6 +403,7 @@ module Crystal
       nodes.each do |node|
         type_vars << node.type
       end
+      return_type = self.nil if return_type.void?
       type_vars << return_type
       proc.instantiate(type_vars)
     end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -386,6 +386,15 @@ module Crystal
         yield arg, arg_index, object, object_index
       end
     end
+
+    def map_type(type)
+      # If the return type is nil, our type is nil
+      if freeze_type.try &.nil_type?
+        freeze_type
+      else
+        type
+      end
+    end
   end
 
   class Macro
@@ -595,7 +604,7 @@ module Crystal
   end
 
   class FunLiteral
-    property force_void = false
+    property force_nil = false
     property expected_return_type : Type?
 
     def update(from = nil)
@@ -603,10 +612,10 @@ module Crystal
       return unless self.def.type?
 
       types = self.def.args.map &.type
-      return_type = @force_void ? self.def.type.program.void : self.def.type
+      return_type = @force_nil ? self.def.type.program.nil : self.def.type
 
       expected_return_type = @expected_return_type
-      if expected_return_type && !expected_return_type.void? && !return_type.implements?(expected_return_type)
+      if expected_return_type && !expected_return_type.nil_type? && !return_type.implements?(expected_return_type)
         raise "expected block to return #{expected_return_type.devirtualize}, not #{return_type}"
       end
 

--- a/src/compiler/crystal/semantic/base_type_visitor.cr
+++ b/src/compiler/crystal/semantic/base_type_visitor.cr
@@ -229,8 +229,9 @@ module Crystal
           node_return_type.accept self
         end
         return_type = check_primitive_like(node_return_type)
+        return_type = @mod.nil if return_type.void?
       else
-        return_type = @mod.void
+        return_type = @mod.nil
       end
 
       external = node.external?
@@ -268,7 +269,7 @@ module Crystal
 
         inferred_return_type = @mod.type_merge([node_body.type?, external.type?])
 
-        if return_type && return_type != @mod.void && inferred_return_type != return_type
+        if return_type && return_type != @mod.nil && inferred_return_type != return_type
           node.raise "expected fun to return #{return_type} but it returned #{inferred_return_type}"
         end
 

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -214,7 +214,7 @@ class Crystal::Call
 
     implicit_call_type = implicit_call.type?
     if implicit_call_type
-      if implicit_call_type.compatible_with?(expected_type)
+      if implicit_call_type.compatible_with?(expected_type) || implicit_call_type.implicitly_converted_in_c_to?(expected_type)
         self.args[index] = implicit_call
       else
         arg_name = lib_arg_name(typed_def_arg, index)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -204,6 +204,11 @@ module Crystal
         return self
       end
 
+      # Allow Nil to match Void (useful for `Pointer(Void)#value=`)
+      if nil_type? && other.void?
+        return self
+      end
+
       if parents.try &.any? &.restriction_of?(other, context.owner)
         return self
       end
@@ -777,7 +782,7 @@ module Crystal
 
       if return_type == other_return_type
         # Ok
-      elsif other_return_type.void?
+      elsif other_return_type.nil_type?
         # Ok, can cast fun to void
       elsif return_type.no_return?
         # Ok, NoReturn can be "cast" to anything

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -251,22 +251,6 @@ module Crystal
     end
   end
 
-  class FunInstanceType
-    def common_ancestor(other : FunInstanceType)
-      if other == self
-        return self
-      end
-
-      if return_type.void? && arg_types == other.arg_types
-        self
-      elsif other.return_type.void? && arg_types == other.arg_types
-        other
-      else
-        nil
-      end
-    end
-  end
-
   class TupleInstanceType
     def common_ancestor(other : TupleInstanceType)
       return nil unless self.size == other.size

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -192,11 +192,14 @@ module Crystal
         # nil will be sent as pointer
         expected_type.pointer? || expected_type.fun?
       when FunInstanceType
-        # fun will be cast to return void
-        expected_type.is_a?(FunInstanceType) && expected_type.return_type == program.void && expected_type.arg_types == self.arg_types
+        # fun will be cast to return nil
+        expected_type.is_a?(FunInstanceType) && expected_type.return_type == program.nil && expected_type.arg_types == self.arg_types
       when NilablePointerType
         # nilable pointer is just a pointer
         self.pointer_type == expected_type
+      when PointerInstanceType
+        # any pointer matches a void*
+        expected_type.is_a?(PointerInstanceType) && expected_type.element_type.void?
       else
         false
       end
@@ -2743,6 +2746,10 @@ module Crystal
     end
 
     def reference_like?
+      true
+    end
+
+    def primitive_like?
       true
     end
 


### PR DESCRIPTION
This is yet another way to solve #2673, different from #2687

The changes are:
* When `Void` is used as a return type, either in a proc, a method or a lib fun, it is replaced by `Nil`
* `Void*` (or `Pointer(Void)`) is still allowed with the same meaning as C: a pointer to some bytes without an unknown meaning.

What matters most for this PR is to get rid of the `Void` type, and use only `Nil` to mean "absence of a value". In Crystal land one should use `Nil`, never `Void`, and once (and if) we merge this, after the next release we can replace all usages of `Void` with `Nil`.

However, when writing C bindings, it's common to use `Void*`: it's easier to copy from a C header and it's also how the type is called in C. But it should only be used for interfacing with C, in Crystal one can use `UInt8*` to mean "a pointer to raw bytes" (though one usually uses slices instead). 

When writing C bindings it's also common to use `Void` as a return type. One can do that, but that `Void` gets automatically translated to `Nil`, because that's the way to represent that concept in Crystal.

In this way, a `Void` value can never be produced, with one exception: reading from a `Pointer(Void)`. But one never reads from such pointer because it has no meaning, so this shouldn't happen.

In a way, this solution is closer to the original intention of #2673, which was to replace `Void` with `Nil`. One can simply program thinking that `Void` is an alias of `Nil`, but one can still use `Void*` in C bindings, and that's different from `Nil*`. A later minor change that we plan to do is to allow any pointer to match an argument of type `Void*` (there are a few redundant `.as(Void*)` casts in the code right now), but that shouldn't apply for `Nil*`, so that's why `Void` isn't exactly an alias of `Nil`.

In any case, for a user that doesn't have to deal with C bindings, `Void` will never appear or bother.

Another thing this PR does is to allow marking a method as returning `Nil`, and then the compiler won't check the return type:

```crystal
def foo : Nil
  1 + 2
end

foo # => nil
```

One can of course just return `nil` at the end, but in this way one is telling the compiler, and the user reading the docs or the method signature, "this method doesn't return anything useful".

This change affects issue #2672, it now behaves like this:

```crystal
class Foo
  # This is Proc(Nil)
  @action : ->

   def initialize
    # OK, this is Proc(Nil)  
    @action = ->{ }

    # Error, this is Proc(Int32)
    @action = ->{ 1 }

    # OK, this is also Proc(Nil)
    @action = ->{ 1; nil }
   end
end
```

But the main problem in #2672 was that one can't easily produce a value of type `Void`, so would have to use `Proc(Void).new { ... }`. If one needs a proc to return `nil` one can simply add `nil` at the end of it. 

I personally like this solution more than #2687, because it doesn't introduce a new type/concept (void), and it makes `nil` be used in more places where previously void was used/returned.