### PR TITLE
Compiler: Do not cast enum value to i32 if not specified. Fixes #194

### DIFF
--- a/spec/compiler/type_inference/c_enum_spec.cr
+++ b/spec/compiler/type_inference/c_enum_spec.cr
@@ -43,4 +43,9 @@ describe "Type inference: c enum" do
     assert_error "lib LibFoo; enum Bar : Float32; X; end; end; LibFoo::Bar::X",
       "enum base type must be an integer type"
   end
+
+  it "errors if enum value is different from default (Int32) (#194)" do
+    assert_error "lib LibFoo; enum Bar; X = 0x00000001_u32; end; end; LibFoo::Bar::X",
+      "enum value must be an Int32"
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -564,6 +564,14 @@ module Crystal
             if default_value = member.default_value
               counter = interpret_enum_value(default_value, enum_base_type)
             end
+
+            if default_value.is_a?(Crystal::NumberLiteral)
+              enum_base_kind = enum_base_type.kind
+              if (enum_base_kind == :i32) && (enum_base_kind != default_value.kind)
+                default_value.raise "enum value must be an Int32"
+              end
+            end
+
             all_value |= counter
             const_value = NumberLiteral.new(counter, enum_base_type.kind)
             member.default_value = const_value


### PR DESCRIPTION
If enum base type is not specified, default is assumed (i32), and if any
enum value is specified with a different type it should be casted to
i32, but it's an undesired behavior, thats why now an exception is
raised to alert developer.