### PR TITLE
Move OpenSSL::SSL::Context defaults to the context itself

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -31,10 +31,6 @@ module HTTP
     end
 
     describe Response do
-      it "creates default ssl context" do
-        HTTP::Server.default_ssl_context.should be_a(OpenSSL::SSL::Context::Server)
-      end
-
       it "closes" do
         io = MemoryIO.new
         response = Response.new(io)

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -4,13 +4,23 @@ require "openssl"
 describe OpenSSL::SSL::Context do
   it "new for client" do
     ssl_context = OpenSSL::SSL::Context::Client.new
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(
+      ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE
+    ))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+
     OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
   end
 
   it "new for server" do
     ssl_context = OpenSSL::SSL::Context::Server.new
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(
+      ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE, CIPHER_SERVER_PREFERENCE
+    ))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+
     OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)
   end
 
@@ -18,6 +28,9 @@ describe OpenSSL::SSL::Context do
     ssl_context = OpenSSL::SSL::Context::Client.insecure
     ssl_context.should be_a(OpenSSL::SSL::Context::Client)
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    ssl_context.options.no_ssl_v3?.should_not be_true
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+
     OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
   end
 
@@ -25,6 +38,9 @@ describe OpenSSL::SSL::Context do
     ssl_context = OpenSSL::SSL::Context::Server.insecure
     ssl_context.should be_a(OpenSSL::SSL::Context::Server)
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    ssl_context.options.no_ssl_v3?.should_not be_true
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+
     OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end
 
@@ -64,40 +80,40 @@ describe OpenSSL::SSL::Context do
   it "adds options" do
     ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.remove_options(ssl_context.options) # reset
-    ssl_context.add_options(LibSSL::Options::ALL).should eq(LibSSL::Options::ALL)
-    ssl_context.add_options(LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
-               .should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
+    ssl_context.add_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(NO_SSLV2, NO_SSLV3))
+               .should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2, NO_SSLV3))
   end
 
   it "removes options" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
-    ssl_context.remove_options(LibSSL::Options::ALL).should eq(LibSSL::Options::NO_SSLV2)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
+    ssl_context.remove_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
-    ssl_context.options.should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
   end
 
   it "adds modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::AUTO_RETRY)
-    ssl_context.add_modes(LibSSL::Modes::RELEASE_BUFFERS)
-               .should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
+    ssl_context.add_modes(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
+               .should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "removes modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
-    ssl_context.remove_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    ssl_context.remove_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
   end
 
   it "returns modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
-    ssl_context.modes.should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "sets the verify mode" do
@@ -110,7 +126,7 @@ describe OpenSSL::SSL::Context do
 
   pending "alpn_protocol=" do
     # requires OpenSSL 1.0.2+
-    ssl_context = OpenSSL::SSL::Context::Client.new
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
     ssl_context.alpn_protocol = "h2"
   end
 end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -4,53 +4,6 @@ module HTTP
   # :nodoc:
   DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
 
-  ifdef !without_openssl
-    # The list of secure ciphers (intermediate security) as of May 2016 as per
-    # https://wiki.mozilla.org/Security/Server_Side_TLS
-    SSL_CIPHERS = %w(
-      ECDHE-ECDSA-CHACHA20-POLY1305
-      ECDHE-RSA-CHACHA20-POLY1305
-      ECDHE-ECDSA-AES128-GCM-SHA256
-      ECDHE-RSA-AES128-GCM-SHA256
-      ECDHE-ECDSA-AES256-GCM-SHA384
-      ECDHE-RSA-AES256-GCM-SHA384
-      DHE-RSA-AES128-GCM-SHA256
-      DHE-RSA-AES256-GCM-SHA384
-      ECDHE-ECDSA-AES128-SHA256
-      ECDHE-RSA-AES128-SHA256
-      ECDHE-ECDSA-AES128-SHA
-      ECDHE-RSA-AES256-SHA384
-      ECDHE-RSA-AES128-SHA
-      ECDHE-ECDSA-AES256-SHA384
-      ECDHE-ECDSA-AES256-SHA
-      ECDHE-RSA-AES256-SHA
-      DHE-RSA-AES128-SHA256
-      DHE-RSA-AES128-SHA
-      DHE-RSA-AES256-SHA256
-      DHE-RSA-AES256-SHA
-      ECDHE-ECDSA-DES-CBC3-SHA
-      ECDHE-RSA-DES-CBC3-SHA
-      EDH-RSA-DES-CBC3-SHA
-      AES128-GCM-SHA256
-      AES256-GCM-SHA384
-      AES128-SHA256
-      AES256-SHA256
-      AES128-SHA
-      AES256-SHA
-      DES-CBC3-SHA
-      !RC4
-      !aNULL
-      !eNULL
-      !LOW
-      !3DES
-      !MD5
-      !EXP
-      !PSK
-      !SRP
-      !DSS
-    ).join(' ')
-  end
-
   # :nodoc:
   enum BodyType
     OnDemand

--- a/src/http/server/server.cr
+++ b/src/http/server/server.cr
@@ -90,26 +90,6 @@ require "../common"
 class HTTP::Server
   ifdef !without_openssl
     property ssl : OpenSSL::SSL::Context::Server?
-
-    def self.default_ssl_context : OpenSSL::SSL::Context
-      ctx = OpenSSL::SSL::Context::Server.new
-      ctx.add_options(
-        LibSSL::Options::ALL |
-          LibSSL::Options::NO_SSLV2 |
-          LibSSL::Options::NO_SSLV3 |
-          LibSSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
-          LibSSL::Options::SINGLE_ECDH_USE |
-          LibSSL::Options::SINGLE_DH_USE |
-          LibSSL::Options::CIPHER_SERVER_PREFERENCE
-      )
-      ctx.add_modes(
-        LibSSL::Modes::AUTO_RETRY |
-          LibSSL::Modes::RELEASE_BUFFERS
-      )
-      ctx.ciphers = HTTP::SSL_CIPHERS
-      ctx.set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
-      ctx
-    end
   end
 
   @wants_close = false


### PR DESCRIPTION
Also set the default verify param accordingly.

Hopefully fixes #2674 somebody with an affected system has to verify.

I didn't enable CRL checking (contrary to Ruby) as it's slow and slowly being deprecated in favor of OCSP. <del>However API to enable it fairly easily is included.</del> Moved to #2708 for now since the fairly convenient API of course is 1.0.2 only again. Will perhaps look into the legacy API for this.