### PR TITLE
TLS hostname check

### DIFF
--- a/spec/manual/badssl_spec.cr
+++ b/spec/manual/badssl_spec.cr
@@ -1,0 +1,88 @@
+require "spec"
+require "socket"
+require "openssl"
+
+private def connect_to(host, context = OpenSSL::SSL::Context::Client.new)
+  io = TCPSocket.new(host, 443)
+  socket = OpenSSL::SSL::Socket::Client.new(io, context: context, hostname: host)
+  socket << "GET / HTTP/1.1\r\nHost: #{host}\r\n\r\n"
+  socket.gets
+  true
+ensure
+  io.close if io
+  socket.close if socket
+end
+
+describe "OpenSSL::SSL::Context has sane client defaults" do
+  {
+    "expired.badssl.com",
+    "wrong.host.badssl.com",
+    "self-signed.badssl.com",
+    "incomplete-chain.badssl.com",
+    "superfish.badssl.com",
+    "edellroot.badssl.com",
+    "dsdtestprovider.badssl.com",
+    "subdomain.preloaded-hsts.badssl.com",
+  }.each do |host|
+    it "shouldn't connect to #{host}" do
+      expect_raises(OpenSSL::SSL::Error) do
+        connect_to(host)
+      end
+    end
+
+    it "should connect to #{host} with verification disabled" do
+      context = OpenSSL::SSL::Context::Client.new
+      context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+      connect_to(host, context).should be_true
+    end
+  end
+
+  {
+    "rc4.badssl.com",
+    "10000-sans.badssl.com",
+    "dh480.badssl.com",
+  }.each do |host|
+    it "shouldn't connect to #{host}" do
+      expect_raises(OpenSSL::SSL::Error) do
+        connect_to(host)
+      end
+    end
+
+    it "shouldn't connect to #{host} with verification disabled" do
+      context = OpenSSL::SSL::Context::Client.new
+      context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+
+      expect_raises(OpenSSL::SSL::Error) do
+        connect_to(host, context).should be_true
+      end
+    end
+  end
+
+  {
+    "google.com",
+    "sha1-2016.badssl.com",
+    "sha1-2017.badssl.com",
+    "sha256.badssl.com",
+    "1000-sans.badssl.com",
+    "rsa8192.badssl.com",
+    "mixed-script.badssl.com",
+    "very.badssl.com",
+    "mixed.badssl.com",
+    "mixed-favicon.badssl.com",
+    "cbc.badssl.com",
+    "mozilla-old.badssl.com",
+    "mozilla-intermediate.badssl.com",
+    "mozilla-modern.badssl.com",
+    "dh1024.badssl.com",
+    "dh2048.badssl.com",
+    "dh-small-subgroup.badssl.com",
+    "dh-composite.badssl.com",
+    "hsts.badssl.com",
+    "upgrade.badssl.com",
+    "preloaded-hsts.badssl.com",
+  }.each do |host|
+    it "should connect to #{host} successfully" do
+      connect_to(host).should be_true
+    end
+  end
+end

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -31,10 +31,6 @@ module HTTP
     end
 
     describe Response do
-      it "creates default ssl context" do
-        HTTP::Server.default_ssl_context.should be_a(OpenSSL::SSL::Context::Server)
-      end
-
       it "closes" do
         io = MemoryIO.new
         response = Response.new(io)

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -4,13 +4,23 @@ require "openssl"
 describe OpenSSL::SSL::Context do
   it "new for client" do
     ssl_context = OpenSSL::SSL::Context::Client.new
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(
+      ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE
+    ))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+
     OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
   end
 
   it "new for server" do
     ssl_context = OpenSSL::SSL::Context::Server.new
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(
+      ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE, CIPHER_SERVER_PREFERENCE
+    ))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+
     OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)
   end
 
@@ -18,6 +28,9 @@ describe OpenSSL::SSL::Context do
     ssl_context = OpenSSL::SSL::Context::Client.insecure
     ssl_context.should be_a(OpenSSL::SSL::Context::Client)
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    ssl_context.options.no_ssl_v3?.should_not be_true
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+
     OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
   end
 
@@ -25,6 +38,9 @@ describe OpenSSL::SSL::Context do
     ssl_context = OpenSSL::SSL::Context::Server.insecure
     ssl_context.should be_a(OpenSSL::SSL::Context::Server)
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    ssl_context.options.no_ssl_v3?.should_not be_true
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+
     OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end
 
@@ -64,40 +80,40 @@ describe OpenSSL::SSL::Context do
   it "adds options" do
     ssl_context = OpenSSL::SSL::Context::Client.new
     ssl_context.remove_options(ssl_context.options) # reset
-    ssl_context.add_options(LibSSL::Options::ALL).should eq(LibSSL::Options::ALL)
-    ssl_context.add_options(LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
-               .should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2 | LibSSL::Options::NO_SSLV3)
+    ssl_context.add_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(NO_SSLV2, NO_SSLV3))
+               .should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2, NO_SSLV3))
   end
 
   it "removes options" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
-    ssl_context.remove_options(LibSSL::Options::ALL).should eq(LibSSL::Options::NO_SSLV2)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
+    ssl_context.remove_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_options(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
-    ssl_context.options.should eq(LibSSL::Options::ALL | LibSSL::Options::NO_SSLV2)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
+    ssl_context.options.should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
   end
 
   it "adds modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::AUTO_RETRY)
-    ssl_context.add_modes(LibSSL::Modes::RELEASE_BUFFERS)
-               .should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
+    ssl_context.add_modes(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
+               .should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "removes modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
-    ssl_context.remove_modes(LibSSL::Modes::AUTO_RETRY).should eq(LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    ssl_context.remove_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
   end
 
   it "returns modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.add_modes(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
-    ssl_context.modes.should eq(LibSSL::Modes::AUTO_RETRY | LibSSL::Modes::RELEASE_BUFFERS)
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
+    ssl_context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    ssl_context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "sets the verify mode" do
@@ -110,7 +126,7 @@ describe OpenSSL::SSL::Context do
 
   pending "alpn_protocol=" do
     # requires OpenSSL 1.0.2+
-    ssl_context = OpenSSL::SSL::Context::Client.new
+    ssl_context = OpenSSL::SSL::Context::Client.insecure
     ssl_context.alpn_protocol = "h2"
   end
 end

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -124,9 +124,10 @@ describe OpenSSL::SSL::Context do
     ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
   end
 
-  pending "alpn_protocol=" do
-    # requires OpenSSL 1.0.2+
+  {% if LibSSL::OPENSSL_102 %}
+  it "alpn_protocol=" do
     ssl_context = OpenSSL::SSL::Context::Client.insecure
     ssl_context.alpn_protocol = "h2"
   end
+  {% end %}
 end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -4,53 +4,6 @@ module HTTP
   # :nodoc:
   DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
 
-  ifdef !without_openssl
-    # The list of secure ciphers (intermediate security) as of May 2016 as per
-    # https://wiki.mozilla.org/Security/Server_Side_TLS
-    SSL_CIPHERS = %w(
-      ECDHE-ECDSA-CHACHA20-POLY1305
-      ECDHE-RSA-CHACHA20-POLY1305
-      ECDHE-ECDSA-AES128-GCM-SHA256
-      ECDHE-RSA-AES128-GCM-SHA256
-      ECDHE-ECDSA-AES256-GCM-SHA384
-      ECDHE-RSA-AES256-GCM-SHA384
-      DHE-RSA-AES128-GCM-SHA256
-      DHE-RSA-AES256-GCM-SHA384
-      ECDHE-ECDSA-AES128-SHA256
-      ECDHE-RSA-AES128-SHA256
-      ECDHE-ECDSA-AES128-SHA
-      ECDHE-RSA-AES256-SHA384
-      ECDHE-RSA-AES128-SHA
-      ECDHE-ECDSA-AES256-SHA384
-      ECDHE-ECDSA-AES256-SHA
-      ECDHE-RSA-AES256-SHA
-      DHE-RSA-AES128-SHA256
-      DHE-RSA-AES128-SHA
-      DHE-RSA-AES256-SHA256
-      DHE-RSA-AES256-SHA
-      ECDHE-ECDSA-DES-CBC3-SHA
-      ECDHE-RSA-DES-CBC3-SHA
-      EDH-RSA-DES-CBC3-SHA
-      AES128-GCM-SHA256
-      AES256-GCM-SHA384
-      AES128-SHA256
-      AES256-SHA256
-      AES128-SHA
-      AES256-SHA
-      DES-CBC3-SHA
-      !RC4
-      !aNULL
-      !eNULL
-      !LOW
-      !3DES
-      !MD5
-      !EXP
-      !PSK
-      !SRP
-      !DSS
-    ).join(' ')
-  end
-
   # :nodoc:
   enum BodyType
     OnDemand

--- a/src/http/server/server.cr
+++ b/src/http/server/server.cr
@@ -90,26 +90,6 @@ require "../common"
 class HTTP::Server
   ifdef !without_openssl
     property ssl : OpenSSL::SSL::Context::Server?
-
-    def self.default_ssl_context : OpenSSL::SSL::Context
-      ctx = OpenSSL::SSL::Context::Server.new
-      ctx.add_options(
-        LibSSL::Options::ALL |
-          LibSSL::Options::NO_SSLV2 |
-          LibSSL::Options::NO_SSLV3 |
-          LibSSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION |
-          LibSSL::Options::SINGLE_ECDH_USE |
-          LibSSL::Options::SINGLE_DH_USE |
-          LibSSL::Options::CIPHER_SERVER_PREFERENCE
-      )
-      ctx.add_modes(
-        LibSSL::Modes::AUTO_RETRY |
-          LibSSL::Modes::RELEASE_BUFFERS
-      )
-      ctx.ciphers = HTTP::SSL_CIPHERS
-      ctx.set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
-      ctx
-    end
   end
 
   @wants_close = false

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,4 +1,4 @@
-@[Link("crypto")]
+@[Link(ldflags: "`pkg-config --libs libcrypto || echo -n -lcrypto`")]
 lib LibCrypto
   alias Char = LibC::Char
   alias Int = LibC::Int
@@ -171,3 +171,47 @@ lib LibCrypto
   fun ec_key_new_by_curve_name = EC_KEY_new_by_curve_name(nid : Int) : EC_KEY
   fun ec_key_free = EC_KEY_free(key : EC_KEY)
 end
+
+{% if `(pkg-config --atleast-version=1.0.2 libcrypto && echo -n true) || echo -n false` == "true" %}
+lib LibCrypto
+  OPENSSL_102 = true
+end
+{% else %}
+lib LibCrypto
+  OPENSSL_102 = false
+end
+{% end %}
+
+{% if LibCrypto::OPENSSL_102 %}
+lib LibCrypto
+  type X509VerifyParam = Void*
+
+  @[Flags]
+  enum X509VerifyFlags : ULong
+    CB_ISSUER_CHECK      =      0x1
+    USE_CHECK_TIME       =      0x2
+    CRL_CHECK            =      0x4
+    CRL_CHECK_ALL        =      0x8
+    IGNORE_CRITICAL      =     0x10
+    X509_STRICT          =     0x20
+    ALLOW_PROXY_CERTS    =     0x40
+    POLICY_CHECK         =     0x80
+    EXPLICIT_POLICY      =    0x100
+    INHIBIT_ANY          =    0x200
+    INHIBIT_MAP          =    0x400
+    NOTIFY_POLICY        =    0x800
+    EXTENDED_CRL_SUPPORT =   0x1000
+    USE_DELTAS           =   0x2000
+    CHECK_SS_SIGNATURE   =   0x4000
+    TRUSTED_FIRST        =   0x8000
+    SUITEB_128_LOS_ONLY  =  0x10000
+    SUITEB_192_LOS       =  0x20000
+    SUITEB_128_LOS       =  0x30000
+    PARTIAL_CHAIN        =  0x80000
+    NO_ALT_CHAINS        = 0x100000
+  end
+
+  fun x509_verify_param_lookup = X509_VERIFY_PARAM_lookup(name : UInt8*) : X509VerifyParam
+  fun x509_verify_param_set_flags = X509_VERIFY_PARAM_set_flags(param : X509VerifyParam, flags : X509VerifyFlags) : Int
+end
+{% end %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -212,6 +212,8 @@ lib LibCrypto
   end
 
   fun x509_verify_param_lookup = X509_VERIFY_PARAM_lookup(name : UInt8*) : X509VerifyParam
+  fun x509_verify_param_set1_host = X509_VERIFY_PARAM_set1_host(param : X509VerifyParam, name : UInt8*, len : SizeT) : Int
+  fun x509_verify_param_set1_ip_asc = X509_VERIFY_PARAM_set1_ip_asc(param : X509VerifyParam, ip : UInt8*) : Int
   fun x509_verify_param_set_flags = X509_VERIFY_PARAM_set_flags(param : X509VerifyParam, flags : X509VerifyFlags) : Int
 end
 {% end %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -127,6 +127,7 @@ lib LibSSL
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_library_init = SSL_library_init
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long
   fun ssl_free = SSL_free(handle : SSL)
 
@@ -156,7 +157,6 @@ lib LibSSL
   fun ssl_ctx_get_verify_mode = SSL_CTX_get_verify_mode(ctx : SSLContext) : VerifyMode
   fun ssl_ctx_set_verify = SSL_CTX_set_verify(ctx : SSLContext, mode : VerifyMode, callback : VerifyCallback)
   fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSLContext) : Int
-  fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : ULong, parg : Void*) : ULong
 
   @[Raises]
@@ -178,6 +178,7 @@ lib LibSSL
   alias ALPNCallback = (SSL, Char**, Char*, Char*, Int, Void*) -> Int
   alias X509VerifyParam = LibCrypto::X509VerifyParam
 
+  fun ssl_get0_param = SSL_get0_param(handle : SSL) : X509VerifyParam
   fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
   fun ssl_ctx_get0_param = SSL_CTX_get0_param(ctx : SSLContext) : X509VerifyParam
   fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int

--- a/src/openssl/openssl.cr
+++ b/src/openssl/openssl.cr
@@ -27,6 +27,9 @@ module OpenSSL
     alias Options = LibSSL::Options
     alias VerifyMode = LibSSL::VerifyMode
     alias ErrorType = LibSSL::SSLError
+    {% if LibSSL::OPENSSL_102 %}
+    alias X509VerifyFlags = LibCrypto::X509VerifyFlags
+    {% end %}
 
     class Error < OpenSSL::Error
       getter error : ErrorType


### PR DESCRIPTION
Based on #2707 

With 1.0.2 OpenSSL gained support for doing hostname checks, see https://wiki.openssl.org/index.php/Hostname_validation

However is it okay to depend on 1.0.2? Should we implement our own hostname checking [like Ruby does](https://github.com/ruby/ruby/blob/c57c719e4ab00e4b7a9fc8af21b4140945167554/ext/openssl/lib/openssl/ssl.rb#L162-L244)? Or given we find a way to detect the OpenSSL version (how?), should we use this only for OpenSSL 1.0.2+ or either this or a manual check?

I included a network dependent integration spec that should only manually be run, as well as API to enable CRL checks fairly easily, see #2707 and #2709.