### PR TITLE
Macros: add `flag?` method. Part of #2710

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -989,4 +989,14 @@ describe "macro methods" do
       assert_macro "", %({{env("FOO")}}), [] of ASTNode, %(nil)
     end
   end
+
+  describe "flag?" do
+    it "has flag" do
+      assert_macro "", %({{flag?(:foo)}}), [] of ASTNode, %(true), flags: "foo"
+    end
+
+    it "doesn't have flag" do
+      assert_macro "", %({{flag?(:foo)}}), [] of ASTNode, %(false)
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -231,12 +231,13 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
-def assert_macro(macro_args, macro_body, call_args, expected)
-  assert_macro(macro_args, macro_body, expected) { call_args }
+def assert_macro(macro_args, macro_body, call_args, expected, flags = nil)
+  assert_macro(macro_args, macro_body, expected, flags) { call_args }
 end
 
-def assert_macro(macro_args, macro_body, expected)
+def assert_macro(macro_args, macro_body, expected, flags = nil)
   program = Program.new
+  program.flags = flags if flags
   sub_node = yield program
   assert_macro_internal program, sub_node, macro_args, macro_body, expected
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -9,6 +9,8 @@ module Crystal
         interpret_debug
       when "env"
         interpret_env(node)
+      when "flag?"
+        interpret_flag?(node)
       when "puts", "p"
         interpret_puts(node)
       when "pp"
@@ -37,6 +39,16 @@ module Crystal
         @last = env_value ? StringLiteral.new(env_value) : NilLiteral.new
       else
         node.wrong_number_of_arguments "macro call 'env'", node.args.size, 1
+      end
+    end
+
+    def interpret_flag?(node)
+      if node.args.size == 1
+        node.args[0].accept self
+        flag = @last.to_macro_id
+        @last = BoolLiteral.new(@mod.has_flag?(flag))
+      else
+        node.wrong_number_of_arguments "macro call 'flag?'", node.args.size, 1
       end
     end
 


### PR DESCRIPTION
A separate PR, which will probably take me a bit more time, will make possible to use macros inside lib declarations, so we'll then be able to replace all uses of `ifdef` with `{% if ... %}`.