### PR TITLE
Add `Union(X, Y)` to denote a union type `X | Y`. Fixes #2659

### DIFF
--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -192,4 +192,10 @@ describe "Code gen: union type" do
       )).to_string
     (str == "(Int32 | Float64)" || str == "(Float64 | Int32)").should be_true
   end
+
+  it "codegens union" do
+    codegen(%(
+      Union(Int32, String)
+      ))
+  end
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -913,4 +913,6 @@ describe Crystal::Formatter do
   assert_format "[\n  1, # foo\n  3,\n]"
   assert_format "[\n  1, 2, # foo\n  3,\n]"
   assert_format "[\n  1, 2, # foo\n  3, 4,\n]"
+
+  assert_format "Union(X, Y)"
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1142,6 +1142,8 @@ describe "Parser" do
 
   it_parses "Foo.foo(count: 3).bar { }", Call.new(Call.new("Foo".path, "foo", named_args: [NamedArgument.new("count", 3.int32)]), "bar", block: Block.new)
 
+  it_parses "Union(X, Y)", Union.new(["X".path, "Y".path] of ASTNode)
+
   assert_syntax_error "return do\nend", "unexpected token: do"
 
   %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -67,4 +67,6 @@ describe "ASTNode#to_s" do
   expect_to_s "macro foo(**args)\nend"
   expect_to_s "macro foo(x, **args)\nend"
   expect_to_s "def foo(x y)\nend"
+  expect_to_s "Union(X, Y)"
+  expect_to_s "def foo(x : X | Y)\nend"
 end

--- a/spec/compiler/type_inference/union_spec.cr
+++ b/spec/compiler/type_inference/union_spec.cr
@@ -58,4 +58,10 @@ describe "Type inference: union" do
       LibC::Foo.new.a
       ), flags: "some_flag") { int32 }
   end
+
+  it "types union" do
+    assert_type(%(
+      Union(Int32, String)
+      )) { union_of(int32, string).metaclass }
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -626,6 +626,11 @@ module Crystal
       false
     end
 
+    def visit(node : Union)
+      @last = type_id(node.type)
+      false
+    end
+
     def visit(node : Include)
       node.runtime_initializers.try &.each &.accept self
 

--- a/src/compiler/crystal/semantic/base_type_visitor.cr
+++ b/src/compiler/crystal/semantic/base_type_visitor.cr
@@ -129,10 +129,13 @@ module Crystal
       @in_is_a = old_in_is_a
 
       if @in_is_a
-        node.type = @mod.type_merge_union_of(types)
+        type = @mod.type_merge_union_of(types)
       else
-        node.type = @mod.type_merge(types)
+        type = @mod.type_merge(types)
       end
+
+      type = @in_type_args > 0 ? type : type.try &.metaclass
+      node.type = type
 
       false
     end

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -17,7 +17,9 @@ module Crystal
         TypeNode.new(type).accept(self)
       elsif restriction = node.restriction
         @str << " : "
-        restriction.accept self
+        inside_type_expression do
+          restriction.accept self
+        end
       end
       if default_value = node.default_value
         @str << " = "

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4004,7 +4004,12 @@ module Crystal
         end
 
         check :")"
-        const = Generic.new(const, types, named_args).at(location)
+
+        if !global && !named_args && names.size == 1 && names.first == "Union"
+          const = Union.new(types).at(location)
+        else
+          const = Generic.new(const, types, named_args).at(location)
+        end
         const.end_location = token_end_location
 
         next_token_skip_space

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -999,6 +999,13 @@ module Crystal
     end
 
     def visit(node : Union)
+      if @token.type == :CONST && @token.value == "Union"
+        write "Union"
+        next_token_skip_space
+        format_literal_elements node.types, :"(", :")"
+        return false
+      end
+
       if @token.type == :IDENT && @token.value == "self?" && node.types.size == 2 &&
          node.types.any?(&.is_a?(Self)) &&
          node.types.any? { |t| t.to_s == "::Nil" }


### PR DESCRIPTION
This makes the parser produce a `Union` AST node when finding `Union(X, Y)`. It's a special case, but with this we can now talk about any type using a name (this was the only missing type)