### PR TITLE
Improve error suggestion when using logical operators. Fixes #2715

### DIFF
--- a/spec/compiler/type_inference/did_you_mean_spec.cr
+++ b/spec/compiler/type_inference/did_you_mean_spec.cr
@@ -242,4 +242,23 @@ describe "Type inference: did you mean" do
       end
       ), "did you mean @@foobar"
   end
+
+  it "suggests a better alternative to logical operators (#2715)" do
+    message = "undefined method 'and'"
+    message = " (did you mean '&&'?)".colorize.yellow.bold.to_s
+    assert_error %(
+      def rand(x : Int32)
+      end
+
+      class String
+        def bytes
+          self
+        end
+      end
+
+      if "a".bytes and 1
+        1
+      end
+      ), message
+  end
 end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -90,6 +90,9 @@ class Crystal::Call
       error_msg = String.build do |msg|
         if obj && owner != mod
           msg << "undefined method '#{def_name}' for #{owner}"
+        elsif convert_to_logical_operator(def_name)
+          msg << "undefined method '#{def_name}'"
+          similar_name = convert_to_logical_operator(def_name)
         elsif args.size > 0 || has_parenthesis
           msg << "undefined method '#{def_name}'"
         else
@@ -280,6 +283,15 @@ class Crystal::Call
     end
 
     raise message, owner_trace
+  end
+
+  def convert_to_logical_operator(def_name)
+    case def_name
+    when "and"; "&&"
+    when "or" ; "||"
+    when "not"; "!"
+    else        nil
+    end
   end
 
   # If there's only one def that could match, and there are named


### PR DESCRIPTION
When using `if foo and bar` the compiler was suggestion the use of
`rand` method, and that is because `rand` is defined at top level and
Crystal::MatchesLookup was finding it as the nearest option.

Now it checks the missing method is `and` or `or` and suggest the right
`&&` and `||` operators.