### PR TITLE
Optimize JSON parsing of unions

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -136,6 +136,14 @@ class JSONWithNilableRootEmitNull
   })
 end
 
+{% if Crystal::VERSION == "0.18.0" %}
+  class JSONWithNilableUnion
+    JSON.mapping({
+      value: Int32 | Nil,
+    })
+  end
+{% end %}
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -389,4 +397,16 @@ describe "JSON mapping" do
     result.result.should be_nil
     result.to_json.should eq(json)
   end
+
+  {% if Crystal::VERSION == "0.18.0" %}
+    it "parses nilable union" do
+      obj = JSONWithNilableUnion.from_json(%({"value": 1}))
+      obj.value.should eq(1)
+      obj.to_json.should eq(%({"value":1}))
+
+      obj = JSONWithNilableUnion.from_json(%({"value": null}))
+      obj.value.should be_nil
+      obj.to_json.should eq(%({}))
+    end
+  {% end %}
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -116,6 +116,26 @@ describe "JSON serialization" do
       it "deserializes union" do
         Array(Int32 | String).from_json(%([1, "hello"])).should eq([1, "hello"])
       end
+
+      it "deserializes union with bool (fast path)" do
+        Union(Bool, Array(Int32)).from_json(%(true)).should be_true
+      end
+
+      {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64).map(&.id) %}
+        it "deserializes union with {{type}} (fast path)" do
+          Union({{type}}, Array(Int32)).from_json(%(#{ {{type}}::MAX })).should eq({{type}}::MAX)
+        end
+      {% end %}
+
+      it "deserializes union with Float32 (fast path)" do
+        Union(Float32, Array(Int32)).from_json(%(1)).should eq(1)
+        Union(Float32, Array(Int32)).from_json(%(1.23)).should eq(1.23_f32)
+      end
+
+      it "deserializes union with Float64 (fast path)" do
+        Union(Float64, Array(Int32)).from_json(%(1)).should eq(1)
+        Union(Float64, Array(Int32)).from_json(%(1.23)).should eq(1.23)
+      end
     {% end %}
   end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -96,7 +96,11 @@ module JSON
               {% if value[:converter] %}
                 {{value[:converter]}}.from_json(%pull)
               {% else %}
-                {{value[:type]}}.new(%pull)
+                {% if Crystal::VERSION == "0.18.0" %}
+                  Union({{value[:type]}}).new(%pull)
+                {% else %}
+                  {{value[:type]}}.new(%pull)
+                {% end %}
               {% end %}
 
               {% if value[:root] %}
@@ -133,7 +137,7 @@ module JSON
         {% elsif value[:default] != nil %}
           @{{key.id}} = %var{key.id}.is_a?(Nil) ? {{value[:default]}} : %var{key.id}
         {% else %}
-          @{{key.id}} = %var{key.id}.not_nil!
+          @{{key.id}} = (%var{key.id}).as({{value[:type]}})
         {% end %}
       {% end %}
     end

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -249,6 +249,56 @@ class JSON::PullParser
     @kind
   end
 
+  def read?(klass : Bool.class)
+    read_bool if kind == :bool
+  end
+
+  def read?(klass : Int8.class)
+    read_int.to_i8 if kind == :int
+  end
+
+  def read?(klass : Int16.class)
+    read_int.to_i16 if kind == :int
+  end
+
+  def read?(klass : Int32.class)
+    read_int.to_i32 if kind == :int
+  end
+
+  def read?(klass : Int64.class)
+    read_int.to_i64 if kind == :int
+  end
+
+  def read?(klass : UInt8.class)
+    read_int.to_u8 if kind == :int
+  end
+
+  def read?(klass : UInt16.class)
+    read_int.to_u16 if kind == :int
+  end
+
+  def read?(klass : UInt32.class)
+    read_int.to_u32 if kind == :int
+  end
+
+  def read?(klass : UInt64.class)
+    read_int.to_u64 if kind == :int
+  end
+
+  def read?(klass : Float32.class)
+    return read_int.to_f32 if kind == :int
+    return read_float.to_f32 if kind == :float
+  end
+
+  def read?(klass : Float64.class)
+    return read_int.to_f64 if kind == :int
+    return read_float.to_f64 if kind == :float
+  end
+
+  def read?(klass : String.class)
+    read_string if kind == :string
+  end
+
   private def read_next_internal
     current_kind = @kind
 


### PR DESCRIPTION
This includes two things:

1. One can now pass `Int32 | Nil` to `JSON.mapping`, instead of having to use the more verbose `{type: Int32, nilable: true}`.
2. Optimized parsing for Union where primitive types are involved

I did a small benchmark for this:

```crystal
time = Time.now
100_000.times do
  Float64.from_json(%(1))
  String.from_json(%("hello"))
  Bool.from_json(%(false))
  Array(Int32).from_json(%([1, 2, 3]))
end
puts Time.now - time

time = Time.now
100_000.times do
  Union(Float64, String, Bool, Array(Int32)).from_json(%(1))
  Union(Float64, String, Bool, Array(Int32)).from_json(%("hello"))
  Union(Float64, String, Bool, Array(Int32)).from_json(%(false))
  Union(Float64, String, Bool, Array(Int32)).from_json(%([1, 2, 3]))
end
puts Time.now - time
```

Before the optimization:

```
00:00:00.4988820
00:00:03.9123560
```

After the optimization:

```
00:00:00.4549360
00:00:00.4819530
```

So I'd say these optimizations, even though they make the code just a bit longer, are very good :-)

Point 1 means we can now do:

```crystal
class Foo
  JSON.mapping({
    x: Int32 | Nil,
  })
end
```

instead of:

```crystal
class Foo
  JSON.mapping({
    x: {type: Int32, nilable: true},
  })
end
```

That's definitely better. But, wouldn't it be nice, since this notation is used in other places, to be able to just write:

```crystal
class Foo
  JSON.mapping({
    x: Int32?,
  })
end
```

I understand that it's simpler not adding parser support for `Int32?` outside the type grammar, but one of Crystal's philosophy is pragmatism and developer happiness. I believe parsing `T?` as `Union(T, ::Nil)` everywhere will make things less verbose and more consistent. I'll send that in a separate PR and later we can see if we merge it.