### PR TITLE
Parse `T?` as `Union(T, Nil)`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -929,4 +929,10 @@ describe Crystal::Formatter do
   assert_format "{ {{FOO}}, nil}", "{ {{FOO}}, nil }"
   assert_format "{ {% begin %}1{% end %}, nil }"
   assert_format "{ {% for x in 1..2 %}3{% end %}, nil }"
+
+  assert_format "String?"
+  assert_format "String???"
+  assert_format "Foo::Bar?"
+  assert_format "Foo::Bar(T, U?)?"
+  assert_format "Union(Foo::Bar?, Baz?, Qux(T, U?))"
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1207,6 +1207,14 @@ describe "Parser" do
   assert_syntax_error "{{ {{ 1 }} }}", "can't nest macro expressions"
   assert_syntax_error "{{ {% begin %} }}", "can't nest macro expressions"
 
+  it_parses "Foo?", Crystal::Generic.new(Path.global("Union"), ["Foo".path, Path.global("Nil")] of ASTNode)
+  it_parses "Foo::Bar?", Crystal::Generic.new(Path.global("Union"), [Path.new(%w(Foo Bar)), Path.global("Nil")] of ASTNode)
+  it_parses "Foo(T)?", Crystal::Generic.new(Path.global("Union"), [Generic.new("Foo".path, ["T".path] of ASTNode), Path.global("Nil")] of ASTNode)
+  it_parses "Foo??", Crystal::Generic.new(Path.global("Union"), [
+    Crystal::Generic.new(Path.global("Union"), ["Foo".path, Path.global("Nil")] of ASTNode),
+    Path.global("Nil"),
+  ] of ASTNode)
+
   assert_syntax_error "return do\nend", "unexpected token: do"
 
   %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -983,6 +983,13 @@ module Crystal
         return false
       end
 
+      # Check if it's T? instead of Union(T, Nil)
+      if first_name == "Union" && @token.value != "Union"
+        node.type_vars.first.accept self
+        write_token :"?"
+        return false
+      end
+
       accept name
       skip_space_or_newline
 


### PR DESCRIPTION
The reason we'd want to introduce this is that now we can do `Union(String, Nil)` to refer to that union type in regular syntax, but nilable types are more commonly written as `String?` in other places where a type is expected. Now that `Union` can participate in many more places as it's a first class citizen, and given that nilable types are very common, maybe this change in syntax is good.

Note that `T?` and `T ?` are parsed differently: the first is a nilable type, the second is the ternary operator with `T` as a condition (of course `if_true : if_false` must follow, otherwise it's a syntax error). So this still allows using the previous "feature": using a type as a conditional (though that isn't useful by itself).

One could suggest adding `T*` after this, but this wouldn't be as useful as `T?` because pointers are unsafe, low-level.