### PR TITLE
Don't use libevent's getaddrinfo, use C's getaddrinfo

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -240,6 +240,8 @@ class HTTP::Client
     self.connect_timeout = connect_timeout.total_seconds
   end
 
+  # **This method has no effect right now**
+  #
   # Set the number of seconds to wait when resolving a name, before raising an `IO::Timeout`.
   #
   # ```
@@ -255,6 +257,8 @@ class HTTP::Client
     @dns_timeout = dns_timeout.to_f
   end
 
+  # **This method has no effect right now**
+  #
   # Set the number of seconds to wait when resolving a name with a `Time::Span`, before raising an `IO::Timeout`.
   #
   # ```

--- a/src/lib_c/i686-linux-gnu/c/netdb.cr
+++ b/src/lib_c/i686-linux-gnu/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(ecode : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/lib_c/i686-linux-musl/c/netdb.cr
+++ b/src/lib_c/i686-linux-musl/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(x0 : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/lib_c/x86_64-linux-gnu/c/netdb.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(ecode : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/lib_c/x86_64-linux-musl/c/netdb.cr
+++ b/src/lib_c/x86_64-linux-musl/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(x0 : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/netdb.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(x0 : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/lib_c/x86_64-portbld-freebsd/c/netdb.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/netdb.cr
@@ -15,4 +15,6 @@ lib LibC
   end
 
   fun gai_strerror(x0 : Int) : Char*
+  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
+  fun freeaddrinfo(ai : Addrinfo*)
 end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -41,10 +41,39 @@ class IPSocket < Socket
   # (to connect or bind, for example), and false otherwise. If it returns false and
   # the LibC::Addrinfo has a next LibC::Addrinfo, it is yielded to the block, and so on.
   private def getaddrinfo(host, port, family, socktype, protocol = LibC::IPPROTO_IP, timeout = nil)
-    IPSocket.getaddrinfo(host, port, family, socktype, protocol, timeout) { |ai| yield ai }
+    # Using getaddrinfo from libevent doesn't work well,
+    # see https://github.com/crystal-lang/crystal/issues/2660
+    #
+    # For now it's better to have this working well but maybe a bit slow than
+    # having it working fast but something working bad or not seeing some networks.
+    IPSocket.getaddrinfo_c_call(host, port, family, socktype, protocol, timeout) { |ai| yield ai }
   end
 
-  def self.getaddrinfo(host, port, family, socktype, protocol = LibC::IPPROTO_IP, timeout = nil)
+  # :nodoc:
+  def self.getaddrinfo_c_call(host, port, family, socktype, protocol = LibC::IPPROTO_IP, timeout = nil)
+    hints = LibC::Addrinfo.new
+    hints.ai_family = (family || LibC::AF_UNSPEC).to_i32
+    hints.ai_socktype = socktype
+    hints.ai_protocol = protocol
+    hints.ai_flags = 0
+
+    ret = LibC.getaddrinfo(host, port.to_s, pointerof(hints), out addrinfo)
+    raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}") if ret != 0
+
+    begin
+      current_addrinfo = addrinfo
+      while current_addrinfo
+        success = yield current_addrinfo.value
+        break if success
+        current_addrinfo = current_addrinfo.value.ai_next
+      end
+    ensure
+      LibC.freeaddrinfo(addrinfo)
+    end
+  end
+
+  # :nodoc:
+  def self.getaddrinfo_libevent(host, port, family, socktype, protocol = LibC::IPPROTO_IP, timeout = nil)
     hints = LibC::Addrinfo.new
     hints.ai_family = (family || LibC::AF_UNSPEC).to_i32
     hints.ai_socktype = socktype

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -1,6 +1,7 @@
 require "./ip_socket"
 
 class TCPSocket < IPSocket
+  # Note: dns_timeout is currently ignored
   def initialize(host, port, dns_timeout = nil, connect_timeout = nil)
     getaddrinfo(host, port, nil, LibC::SOCK_STREAM, LibC::IPPROTO_TCP, timeout: dns_timeout) do |addrinfo|
       super(create_socket(addrinfo.ai_family, addrinfo.ai_socktype, addrinfo.ai_protocol))


### PR DESCRIPTION
This makes #2660 more robust, but of course slower. I prefer things that work, even a bit slow, than broken things.

Also, since libevent's getaddrinfo is basically useless and we'll have to use other mechanisms, such as `getaddrinfo_a` on linux, lets go back to plain old C's `getaddrinfo` and improve from there. For example, after this someone could send a PR to make use of `getaddrinfo_a` in linux, etc.

I couldn't find a good way to test that this indeed improves #2660. I have docker but I don't know how to configure it to check if I can access it's network from my machine. So if someone can try this and check that it works with this PR, it would be awesome :-)