### PR TITLE
Fix problem of XML parsing empty html string. Fixes #2752

### DIFF
--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -63,4 +63,10 @@ describe XML do
     xml.errors.should_not be_nil
     xml.xpath_node("//html/body/nav").should_not be_nil
   end
+
+  it "raises error when parsing empty string (#2752)" do
+    expect_raises XML::Error, "Document is empty" do
+      XML.parse_html("")
+    end
+  end
 end

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -96,6 +96,12 @@ describe XML do
     person["id"].should eq("1")
   end
 
+  it "raises exception on empty string" do
+    expect_raises XML::Error, "Document is empty" do
+      XML.parse("")
+    end
+  end
+
   it "does to_s" do
     string = <<-XML
       <?xml version='1.0' encoding='UTF-8'?>\

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -42,6 +42,7 @@ module XML
   # Parses an XML document from *string* with *options* into an `XML::Node`.
   # See `ParserOptions.default` for default options.
   def self.parse(string : String, options : ParserOptions = ParserOptions.default) : Node
+    raise XML::Error.new("Document is empty", 0) if string.empty?
     from_ptr LibXML.xmlReadMemory(string, string.bytesize, nil, nil, options)
   end
 
@@ -63,6 +64,7 @@ module XML
   # Parses an HTML document from *string* with *options* into an `XML::Node`.
   # See `HTMLParserOptions.default` for default options.
   def self.parse_html(string : String, options : HTMLParserOptions = HTMLParserOptions.default) : Node
+    raise XML::Error.new("Document is empty", 0) if string.empty?
     from_ptr LibXML.htmlReadMemory(string, string.bytesize, nil, nil, options)
   end
 


### PR DESCRIPTION
Raise an exception when XML.parse_html called with an empty string.

This is a small PR, probably self-explanatory. Please give any suggestion of better place to put the test or make the check.

Thank you!