### PR TITLE
Update to use compile instead of build command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install: bin/ci prepare_system
 install: bin/ci prepare_build
 script:
   - bin/ci with_build_env 'make crystal std_spec compiler_spec doc'
-  - bin/ci with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
+  - bin/ci with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal compile --no-codegen'
   - bin/ci with_build_env './bin/crystal tool format --check'
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,19 @@ deps: llvm_ext libcrystal
 
 $(O)/all_spec: deps $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
-	$(BUILD_PATH) ./bin/crystal build $(FLAGS) -o $@ spec/all_spec.cr
+	$(BUILD_PATH) ./bin/crystal compile $(FLAGS) -o $@ spec/all_spec.cr
 
 $(O)/std_spec: deps $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
-	$(BUILD_PATH) ./bin/crystal build $(FLAGS) -o $@ spec/std_spec.cr
+	$(BUILD_PATH) ./bin/crystal compile $(FLAGS) -o $@ spec/std_spec.cr
 
 $(O)/compiler_spec: deps $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
-	$(BUILD_PATH) ./bin/crystal build $(FLAGS) -o $@ spec/compiler_spec.cr
+	$(BUILD_PATH) ./bin/crystal compile $(FLAGS) -o $@ spec/compiler_spec.cr
 
 $(O)/crystal: deps $(SOURCES)
 	@mkdir -p $(O)
-	$(BUILD_PATH) $(EXPORTS) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
+	$(BUILD_PATH) $(EXPORTS) ./bin/crystal compile $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(CXX) -c -o $@ $< `$(LLVM_CONFIG) --cxxflags`


### PR DESCRIPTION
Update locations on Travis and Makefile, so don't get deprecation warning on the build.

I didn't change some [references](https://github.com/crystal-lang/crystal/blob/9d258f6f1a0405072d75a751c9086aef0cef032f/Makefile#L48) to work "Build the compiler", including the [build target](https://github.com/crystal-lang/crystal/blob/9d258f6f1a0405072d75a751c9086aef0cef032f/Makefile#L3) because I wasn't sure about the convention and was concerned about changed the semantics of the sentence.

