### PR TITLE
WebSocket: Add support for receiving binary messages

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -40,6 +40,9 @@ class HTTP::WebSocket
   def on_message(&@on_message : String ->)
   end
 
+  def on_binary(&@on_binary : Slice(UInt8) ->)
+  end
+
   def on_close(&@on_close : String ->)
   end
 
@@ -71,6 +74,12 @@ class HTTP::WebSocket
         @current_message.write @buffer[0, info.size]
         if info.final
           @on_message.try &.call(@current_message.to_s)
+          @current_message.clear
+        end
+      when Protocol::Opcode::BINARY
+        @current_message.write @buffer[0, info.size]
+        if info.final
+          @on_binary.try &.call(@current_message.to_slice)
           @current_message.clear
         end
       when Protocol::Opcode::CLOSE


### PR DESCRIPTION
This is not an ideal implementation, it would be better if the `on_binary` block received some kind of IO that could be read while each part of the binary message arrives instead. I'll do that at a later moment. Either way, this is at least working.
