### PR TITLE
Make Hash (and others) yield tuples in each

### DIFF
--- a/samples/degree_days.cr
+++ b/samples/degree_days.cr
@@ -36,7 +36,7 @@ class DegreeDays
   end
 
   private def sum(ary)
-    ary.reduce(0) { |a, i| a + i }
+    ary.reduce(0) { |i, a| a + i }
   end
 
   private def avg(ary)

--- a/samples/neural_net.cr
+++ b/samples/neural_net.cr
@@ -31,7 +31,7 @@ class Neuron
   end
 
   def calculate_output
-    activation = synapses_in.reduce(0.0) do |sum, synapse|
+    activation = synapses_in.reduce(0.0) do |synapse, sum|
       sum + synapse.weight * synapse.source_neuron.output
     end
     activation -= threshold
@@ -49,7 +49,7 @@ class Neuron
   end
 
   def hidden_train(rate)
-    @error = synapses_out.reduce(0.0) do |sum, synapse|
+    @error = synapses_out.reduce(0.0) do |synapse, sum|
       sum + synapse.prev_weight * synapse.dest_neuron.error
     end * derivative
     update_weights(rate)

--- a/spec/compiler/type_inference/block_spec.cr
+++ b/spec/compiler/type_inference/block_spec.cr
@@ -820,16 +820,16 @@ describe "Block inference" do
 
       class Hash
         def map
-          ary = Array(typeof(yield first_key, first_value)).new(@size)
-          each do |k, v|
-            ary.push yield k, v
+          ary = Array(typeof(yield({first_key, first_value}))).new(@size)
+          each do |(k, v)|
+            ary.push(yield({k, v}))
           end
           ary
         end
       end
 
       hash = {} of Int32 => Int32
-      z = hash.map {|key| key + 1 }
+      z = hash.map {|(key, value)| key + 1 }
       hash[1] = z.size
       z
       )) { array_of int32 }

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -7,7 +7,7 @@ describe "Base64" do
     eqs = {"" => "", "a" => "YQ==\n", "ab" => "YWI=\n", "abc" => "YWJj\n",
       "abcd" => "YWJjZA==\n", "abcde" => "YWJjZGU=\n", "abcdef" => "YWJjZGVm\n",
       "abcdefg" => "YWJjZGVmZw==\n"}
-    eqs.each do |a, b|
+    eqs.each do |(a, b)|
       it "encode #{a.inspect} to #{b.inspect}" do
         Base64.encode(a).should eq(b)
       end
@@ -36,7 +36,7 @@ describe "Base64" do
       "Now is the time for all good coders\nto learn Crystal"                  => "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nQ3J5c3RhbA==\n",
       "This is line one\nThis is line two\nThis is line three\nAnd so on...\n" => "VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGlu\nZSB0aHJlZQpBbmQgc28gb24uLi4K\n",
       "hahah⊙ⓧ⊙"                                                               => "aGFoYWjiipnik6fiipk=\n"}
-    eqs.each do |a, b|
+    eqs.each do |(a, b)|
       it "encode #{a.inspect} to #{b.inspect}" do
         Base64.encode(a).should eq(b)
       end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -264,7 +264,7 @@ describe "Hash" do
 
   it "maps" do
     hash = {1 => 2, 3 => 4}
-    array = hash.map { |k, v| k + v }
+    array = hash.map { |(k, v)| k + v }
     array.should eq([3, 7])
   end
 
@@ -365,7 +365,7 @@ describe "Hash" do
   it "selects" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
-    h2 = h1.select { |k, v| k == :b }
+    h2 = h1.select { |(k, v)| k == :b }
     h2.should eq({:b => 2})
     h2.should_not be(h1)
   end
@@ -373,7 +373,7 @@ describe "Hash" do
   it "selects!" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
-    h2 = h1.select! { |k, v| k == :b }
+    h2 = h1.select! { |(k, v)| k == :b }
     h2.should eq({:b => 2})
     h2.should be(h1)
   end
@@ -389,7 +389,7 @@ describe "Hash" do
   it "rejects" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
-    h2 = h1.reject { |k, v| k == :b }
+    h2 = h1.reject { |(k, v)| k == :b }
     h2.should eq({:a => 1, :c => 3})
     h2.should_not be(h1)
   end
@@ -397,7 +397,7 @@ describe "Hash" do
   it "rejects!" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
-    h2 = h1.reject! { |k, v| k == :b }
+    h2 = h1.reject! { |(k, v)| k == :b }
     h2.should eq({:a => 1, :c => 3})
     h2.should be(h1)
   end
@@ -559,14 +559,14 @@ describe "Hash" do
     it "pass key, value, index values into block" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index { |k, v, i| results << k + v + i }
+      hash.each_with_index { |(k, v), i| results << k + v + i }
       results.should eq [6, 16, 23]
     end
 
     it "can be used with offset" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index(3) { |k, v, i| results << k + v + i }
+      hash.each_with_index(3) { |(k, v), i| results << k + v + i }
       results.should eq [9, 19, 26]
     end
   end
@@ -574,7 +574,7 @@ describe "Hash" do
   describe "each_with_object" do
     it "passes memo, key and value into block" do
       hash = {:a => 'b'}
-      hash.each_with_object(:memo) do |memo, k, v|
+      hash.each_with_object(:memo) do |(k, v), memo|
         memo.should eq(:memo)
         k.should eq(:a)
         v.should eq('b')
@@ -583,7 +583,7 @@ describe "Hash" do
 
     it "reduces the hash to the accumulated value of memo" do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
-      result = hash.each_with_object({} of Char => Symbol) do |memo, k, v|
+      result = hash.each_with_object({} of Char => Symbol) do |(k, v), memo|
         memo[v] = k
       end
       result.should eq({'b' => :a, 'd' => :c, 'f' => :e})
@@ -593,7 +593,7 @@ describe "Hash" do
   describe "all?" do
     it "passes key and value into block" do
       hash = {:a => 'b'}
-      hash.all? do |k, v|
+      hash.all? do |(k, v)|
         k.should eq(:a)
         v.should eq('b')
       end
@@ -601,16 +601,16 @@ describe "Hash" do
 
     it "returns true if the block evaluates truthy for every kv pair" do
       hash = {:a => 'b', :c => 'd'}
-      result = hash.all? { |k, v| v < 'e' ? "truthy" : nil }
+      result = hash.all? { |(k, v)| v < 'e' ? "truthy" : nil }
       result.should be_true
       hash[:d] = 'e'
-      result = hash.all? { |k, v| v < 'e' ? "truthy" : nil }
+      result = hash.all? { |(k, v)| v < 'e' ? "truthy" : nil }
       result.should be_false
     end
 
     it "evaluates the block for only for as many kv pairs as necessary" do
       hash = {:a => 'b', :c => 'd'}
-      hash.all? do |k, v|
+      hash.all? do |(k, v)|
         raise Exception.new("continued iterating") if v == 'd'
         v == 'a' # this is false for the first kv pair
       end
@@ -620,7 +620,7 @@ describe "Hash" do
   describe "any?" do
     it "passes key and value into block" do
       hash = {:a => 'b'}
-      hash.any? do |k, v|
+      hash.any? do |(k, v)|
         k.should eq(:a)
         v.should eq('b')
       end
@@ -628,16 +628,16 @@ describe "Hash" do
 
     it "returns true if the block evaluates truthy for at least one kv pair" do
       hash = {:a => 'b', :c => 'd'}
-      result = hash.any? { |k, v| v > 'b' ? "truthy" : nil }
+      result = hash.any? { |(k, v)| v > 'b' ? "truthy" : nil }
       result.should be_true
       hash[:d] = 'e'
-      result = hash.any? { |k, v| v > 'e' ? "truthy" : nil }
+      result = hash.any? { |(k, v)| v > 'e' ? "truthy" : nil }
       result.should be_false
     end
 
     it "evaluates the block for only for as many kv pairs as necessary" do
       hash = {:a => 'b', :c => 'd'}
-      hash.any? do |k, v|
+      hash.any? do |(k, v)|
         raise Exception.new("continued iterating") if v == 'd'
         v == 'b' # this is true for the first kv pair
       end
@@ -657,7 +657,7 @@ describe "Hash" do
   describe "reduce" do
     it "passes memo, key and value into block" do
       hash = {:a => 'b'}
-      hash.reduce(:memo) do |memo, k, v|
+      hash.reduce(:memo) do |(k, v), memo|
         memo.should eq(:memo)
         k.should eq(:a)
         v.should eq('b')
@@ -666,7 +666,7 @@ describe "Hash" do
 
     it "reduces the hash to the accumulated value of memo" do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
-      result = hash.reduce("") do |memo, k, v|
+      result = hash.reduce("") do |(k, v), memo|
         memo + v
       end
       result.should eq("bdf")

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -27,7 +27,7 @@ describe HTTP::Headers do
   it "should retain the input casing" do
     headers = HTTP::Headers{"FOO_BAR": "bar", "Foobar-foo": "baz"}
     serialized = String.build do |io|
-      headers.each do |name, values|
+      headers.each do |(name, values)|
         io << name << ": " << values.first << ";"
       end
     end

--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -37,7 +37,7 @@ module HTTP
       }.each do |(to, from)|
         it "builds form from #{from}" do
           encoded = Params.build do |form|
-            from.each do |key, values|
+            from.each do |(key, values)|
               values.each do |value|
                 form.add(key, value)
               end

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -53,7 +53,7 @@ class JSON::PullParser
 
   def assert(hash : Hash)
     assert_object do
-      hash.each do |key, value|
+      hash.each do |(key, value)|
         assert(key.as(String)) do
           assert value
         end

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -102,7 +102,7 @@ describe "NamedTuple" do
   it "does each" do
     tup = {a: 1, b: "hello"}
     i = 0
-    tup.each do |key, value|
+    tup.each do |(key, value)|
       case i
       when 0
         key.should eq(:a)
@@ -149,7 +149,7 @@ describe "NamedTuple" do
   it "does each_with_index" do
     tup = {a: 1, b: "hello"}
     i = 0
-    tup.each_with_index do |key, value, index|
+    tup.each_with_index do |(key, value), index|
       case i
       when 0
         key.should eq(:a)
@@ -188,7 +188,7 @@ describe "NamedTuple" do
 
   it "does map" do
     tup = {a: 1, b: 'a'}
-    strings = tup.map { |k, v| "#{k.inspect}-#{v.inspect}" }
+    strings = tup.map { |(k, v)| "#{k.inspect}-#{v.inspect}" }
     strings.should eq([":a-1", ":b-'a'"])
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -1058,7 +1058,7 @@ class Array(T)
   #
   # See `Object#hash`.
   def hash
-    reduce(31 * @size) do |memo, elem|
+    reduce(31 * @size) do |elem, memo|
       31 * memo + elem.hash
     end
   end
@@ -1954,7 +1954,7 @@ class Array(T)
     return self if removed == 0
 
     ptr = @buffer
-    hash.each do |k, v|
+    hash.each do |(k, v)|
       ptr.value = v
       ptr += 1
     end

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -172,7 +172,7 @@ module Benchmark
         @ran = true
         @size = samples.size
         @mean = samples.sum.to_f / size.to_f
-        @variance = (samples.reduce(0) { |acc, i| acc + ((i - mean) ** 2) }).to_f / size.to_f
+        @variance = (samples.reduce(0) { |i, acc| acc + ((i - mean) ** 2) }).to_f / size.to_f
         @stddev = Math.sqrt(variance)
         @relative_stddev = 100.0 * (stddev / mean)
       end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -272,7 +272,7 @@ module Crystal
         dump_llvm_regex = Regex.new(env_dump)
       end
 
-      @modules.each do |name, mod|
+      @modules.each do |(name, mod)|
         if @debug
           add_compile_unit_metadata(mod, name == "" ? "main" : name)
         end
@@ -1651,7 +1651,7 @@ module Crystal
 
       in_alloca_block do
         # Allocate all variables which are not closured and don't belong to an outer closure
-        vars.each do |name, var|
+        vars.each do |(name, var)|
           next if name == "self" || context.vars[name]?
 
           var_type = var.type? || @mod.nil
@@ -1743,7 +1743,7 @@ module Crystal
     def undef_vars(vars, obj)
       return unless vars
 
-      vars.each do |name, var|
+      vars.each do |(name, var)|
         # Don't remove special vars because they are local for the entire method
         if var.belongs_to?(obj) && !var.special_var?
           context.vars.delete(name)
@@ -1755,7 +1755,7 @@ module Crystal
       vars = block.vars
       return unless vars
 
-      vars.each do |name, var|
+      vars.each do |(name, var)|
         if var.context == block && bound_to_mod_nil?(var)
           context_var = context.vars[name]
           assign context_var.pointer, context_var.type, @mod.nil, llvm_nil

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -55,7 +55,7 @@ module Crystal
     end
 
     def create_debug_type(type : EnumType)
-      elements = type.types.map do |name, item|
+      elements = type.types.map do |(name, item)|
         value = if item.is_a?(Const) && (value = item.value).is_a?(NumberLiteral)
                   value.value.to_i64 rescue value.value.to_u64
                 else
@@ -75,7 +75,7 @@ module Crystal
       tmp_debug_type = di_builder.temporary_md_node(LLVM::Context.global)
       debug_type_cache[type] = tmp_debug_type
 
-      ivars.each_with_index do |name, ivar, idx|
+      ivars.each_with_index do |(name, ivar), idx|
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
           offset = @mod.target_machine.data_layout.offset_of_element(struct_type, idx + (type.struct? ? 0 : 1))
           size = @mod.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -100,7 +100,7 @@ class Crystal::CodeGenVisitor
 
         if @debug
           in_alloca_block do
-            context.vars.each do |name, var|
+            context.vars.each do |(name, var)|
               declare_variable(name, var.type, var.pointer, target_def)
             end
           end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -224,7 +224,7 @@ module Crystal
     private def create_llvm_struct_type(type : CStructType)
       LLVM::Type.struct(type.llvm_name, type.packed) do |a_struct|
         @struct_cache[type] = a_struct
-        type.vars.map { |name, var| llvm_embedded_c_type(var.type).as(LLVM::Type) }
+        type.vars.map { |(name, var)| llvm_embedded_c_type(var.type).as(LLVM::Type) }
       end
     end
 
@@ -237,7 +237,7 @@ module Crystal
         max_align_type = nil
         max_align_type_size = 0
 
-        type.vars.each do |name, var|
+        type.vars.each do |(name, var)|
           var_type = var.type
           unless var_type.void?
             llvm_type = llvm_embedded_c_type(var_type)
@@ -283,7 +283,7 @@ module Crystal
           element_types.push LLVM::Int32 # For the type id
         end
 
-        ivars.each do |name, ivar|
+        ivars.each do |(name, ivar)|
           if ivar_type = ivar.type?
             element_types.push llvm_embedded_type(ivar_type)
           else

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -180,7 +180,7 @@ class Crystal::Command
     }
 
     if ARGV.empty?
-      vars.each do |key, value|
+      vars.each do |(key, value)|
         puts "#{key}=#{value.inspect}"
       end
     else

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -172,7 +172,7 @@ module Crystal
 
       bc_flags_changed = check_bc_flags_changed output_dir
 
-      units = llvm_modules.map do |type_name, llvm_mod|
+      units = llvm_modules.map do |(type_name, llvm_mod)|
         CompilationUnit.new(self, type_name, llvm_mod, output_dir, bc_flags_changed)
       end
 

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -686,8 +686,8 @@ module Crystal
       # So, we use gsub to replace the yield values.
       value = node.value
 
-      @yields.each do |name, node|
-        value = value.gsub(name) { node.to_s }
+      @yields.each do |(name, node2)|
+        value = value.gsub(name) { node2.to_s }
       end
 
       node.value = value

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1031,7 +1031,7 @@ module Crystal
 
       all_ivars = type.all_instance_vars
       ivars = Array(ASTNode).new(all_ivars.size)
-      all_ivars.each do |name, ivar|
+      all_ivars.each do |(name, ivar)|
         # An instance var might not have a type, so we skip it
         if ivar_type = ivar.type?
           ivars.push MetaVar.new((is_struct ? name : name[1..-1]), ivar_type)
@@ -1062,7 +1062,7 @@ module Crystal
     end
 
     def self.constants(type)
-      names = type.types.map { |name, member_type| MacroId.new(name).as(ASTNode) }
+      names = type.types.map { |(name, member_type)| MacroId.new(name).as(ASTNode) }
       ArrayLiteral.new names
     end
 
@@ -1072,7 +1072,7 @@ module Crystal
 
     def self.methods(type)
       defs = [] of ASTNode
-      type.defs.try &.each do |name, metadatas|
+      type.defs.try &.each do |(name, metadatas)|
         metadatas.each do |metadata|
           defs << metadata.def
         end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -309,7 +309,7 @@ module Crystal
     end
 
     def named_tuple_of(hash : Hash(String, Type))
-      entries = hash.map { |k, v| NamedArgumentType.new(k, v.as(Type)) }
+      entries = hash.map { |(k, v)| NamedArgumentType.new(k, v.as(Type)) }
       named_tuple_of(entries)
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -491,7 +491,7 @@ module Crystal
       when UnionType
         haystack.union_types.any? { |sub| type_includes?(sub, needle) }
       when GenericClassInstanceType
-        haystack.type_vars.any? { |key, sub| sub.is_a?(Var) && type_includes?(sub.type, needle) }
+        haystack.type_vars.any? { |(key, sub)| sub.is_a?(Var) && type_includes?(sub.type, needle) }
       else
         false
       end

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -18,8 +18,8 @@ module Crystal
 
       # First gather them all
       class_var_initializers = [] of ClassVarInitializer
-      visitor.class_vars.each do |owner, vars|
-        vars.each do |name, assign_and_node|
+      visitor.class_vars.each do |(owner, vars)|
+        vars.each do |(name, assign_and_node)|
           node = assign_and_node[1]
 
           # If the initializer is nil there's no need to initialize anything

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -288,8 +288,8 @@ module Crystal
     end
 
     def each
-      @filters.each do |key, value|
-        yield key, value
+      @filters.each do |(key, value)|
+        yield({key, value})
       end
     end
 
@@ -299,7 +299,7 @@ module Crystal
 
     def not
       filters = TypeFilters.new
-      each do |key, value|
+      each do |(key, value)|
         filters[key] = value.not
       end
       filters

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -89,7 +89,7 @@ module Crystal
         else
           meta_vars = @mod.vars
         end
-        vars.each do |name, var|
+        vars.each do |(name, var)|
           meta_var = new_meta_var(name)
           meta_var.bind_to(var)
           meta_vars[name] = meta_var
@@ -775,7 +775,7 @@ module Crystal
 
       # Special vars, even if only assigned inside a block,
       # must be inside the def's metavars.
-      meta_vars.each do |name, var|
+      meta_vars.each do |(name, var)|
         if var.special_var?
           define_special_var(name, var)
         end
@@ -790,7 +790,7 @@ module Crystal
 
     def bind_vars(from_vars, to_vars, ignored = nil)
       if to_vars
-        from_vars.each do |name, block_var|
+        from_vars.each do |(name, block_var)|
           unless ignored.try &.find { |arg| arg.name == name }
             to_var = to_vars[name]?
             if to_var && !to_var.same?(block_var)
@@ -952,7 +952,7 @@ module Crystal
         before_vars = MetaVars.new
         after_vars = MetaVars.new
 
-        @vars.each do |name, var|
+        @vars.each do |(name, var)|
           before_var = MetaVar.new(name)
           before_var.bind_to(var)
           before_var.nil_if_read = var.nil_if_read
@@ -1727,7 +1727,7 @@ module Crystal
 
       cond_var = get_while_cond_assign_target(cond)
 
-      while_vars.each do |name, while_var|
+      while_vars.each do |(name, while_var)|
         before_cond_var = before_cond_vars[name]?
         after_cond_var = after_cond_vars[name]?
 
@@ -1783,7 +1783,7 @@ module Crystal
       # We also need to merge types from breaks inside while.
       if all_break_vars
         all_break_vars.each do |break_vars|
-          break_vars.each do |name, break_var|
+          break_vars.each do |(name, break_var)|
             var = @vars[name]?
             unless var
               # Fix for issue #2441:
@@ -1839,7 +1839,7 @@ module Crystal
     end
 
     def filter_vars(filters)
-      filters.try &.each do |name, filter|
+      filters.try &.each do |(name, filter)|
         existing_var = @vars[name]
         filtered_var = MetaVar.new(name)
         filtered_var.bind_to(existing_var.filtered_by(yield filter))
@@ -2223,7 +2223,7 @@ module Crystal
         # Any variable introduced in the begin block is possibly nil
         # in the rescue blocks because we can't know if an exception
         # was raised before assigning any of the vars.
-        exception_handler_vars.each do |name, var|
+        exception_handler_vars.each do |(name, var)|
           unless before_body_vars[name]?
             var.nil_if_read = true
           end
@@ -2270,7 +2270,7 @@ module Crystal
 
           # Variables in the ensure block might be nil because we don't know
           # if an exception was thrown before any assignment.
-          @vars.each do |name, var|
+          @vars.each do |(name, var)|
             unless before_body_vars[name]?
               var.nil_if_read = true
             end
@@ -2288,7 +2288,7 @@ module Crystal
         # after the ensure clause, so variables don't matter. But if
         # an exception was not raised then all variables were declared
         # successfully.
-        @vars.each do |name, var|
+        @vars.each do |(name, var)|
           unless before_body_vars[name]?
             var.nil_if_read = false
           end
@@ -2320,7 +2320,7 @@ module Crystal
       after_vars = MetaVars.new
 
       all_rescue_vars.each do |rescue_vars|
-        rescue_vars.each do |name, var|
+        rescue_vars.each do |(name, var)|
           after_var = (after_vars[name] ||= new_meta_var(name))
           if var.nil_if_read || !body_vars[name]?
             after_var.bind_to(mod.nil_var)
@@ -2330,7 +2330,7 @@ module Crystal
         end
       end
 
-      body_vars.each do |name, var|
+      body_vars.each do |(name, var)|
         after_var = (after_vars[name] ||= new_meta_var(name))
         after_var.bind_to(var)
       end
@@ -2684,7 +2684,7 @@ module Crystal
     def bind_initialize_instance_vars(owner)
       names_to_remove = [] of String
 
-      @vars.each do |name, var|
+      @vars.each do |(name, var)|
         if name.starts_with? '@'
           if var.nil_if_read
             ivar = owner.lookup_instance_var(name)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -423,7 +423,7 @@ module Crystal
       end
 
       i = 0
-      type_vars.each do |name, type_var|
+      type_vars.each do |(name, type_var)|
         other_type_var = other.type_vars[i]
         restricted = restrict_type_var(type_var, other_type_var, context)
         return nil unless restricted
@@ -436,7 +436,7 @@ module Crystal
     def restrict(other : GenericClassInstanceType, context)
       return super unless generic_class == other.generic_class
 
-      type_vars.each do |name, type_var|
+      type_vars.each do |(name, type_var)|
         other_type_var = other.type_vars[name]
         restricted = restrict_type_var(type_var, other_type_var, context)
         return super unless restricted
@@ -574,7 +574,7 @@ module Crystal
     def restriction_of?(other : GenericClassInstanceType, owner)
       return nil unless extended_class == other.generic_class
 
-      mapping.each do |name, node|
+      mapping.each do |(name, node)|
         typevar_type = TypeLookup.lookup(extending_class, node)
         other_type = other.type_vars[name].type.devirtualize
         unless typevar_type.implements?(other_type)

--- a/src/compiler/crystal/semantic/suggestions.cr
+++ b/src/compiler/crystal/semantic/suggestions.cr
@@ -29,7 +29,7 @@ module Crystal
         best_def = nil
         best_match = nil
         Levenshtein.find(name) do |finder|
-          defs.each do |def_name, hash|
+          defs.each do |(def_name, hash)|
             if def_name =~ SuggestableName
               hash.each do |def_with_metadata|
                 if def_with_metadata.max_size == args_size && def_with_metadata.yields == !!block && def_with_metadata.def.name != name

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -113,13 +113,13 @@ module Crystal
       node.accept type_decl_visitor
 
       # Use the last type found for global variables to declare them
-      type_decl_visitor.globals.each do |name, type|
+      type_decl_visitor.globals.each do |(name, type)|
         declare_meta_type_var(@program.global_vars, @program, name, type)
       end
 
       # Use the last type found for class variables to declare them
-      type_decl_visitor.class_vars.each do |owner, vars|
-        vars.each do |name, type|
+      type_decl_visitor.class_vars.each do |(owner, vars)|
+        vars.each do |(name, type)|
           declare_meta_type_var(owner.class_vars, owner, name, type)
         end
       end
@@ -131,13 +131,13 @@ module Crystal
       node.accept type_guess_visitor
 
       # Process global variables
-      type_guess_visitor.globals.each do |name, info|
+      type_guess_visitor.globals.each do |(name, info)|
         declare_meta_type_var(@program.global_vars, @program, name, info)
       end
 
       # Process class variables
-      type_guess_visitor.class_vars.each do |owner, vars|
-        vars.each do |name, info|
+      type_guess_visitor.class_vars.each do |(owner, vars)|
+        vars.each do |(name, info)|
           declare_meta_type_var(owner.class_vars, owner, name, info)
         end
       end
@@ -215,12 +215,12 @@ module Crystal
       owners = sort_types_by_depth(owners)
       owners.each do |owner|
         vars = @explicit_instance_vars[owner]?
-        vars.try &.each do |name, type_decl|
+        vars.try &.each do |(name, type_decl)|
           process_owner_instance_var_declaration(owner, name, type_decl)
         end
 
         vars = @guessed_instance_vars[owner]?
-        vars.try &.each do |name, type_decl|
+        vars.try &.each do |(name, type_decl)|
           process_owner_guessed_instance_var_declaration(owner, name, type_decl)
         end
       end
@@ -512,8 +512,8 @@ module Crystal
     end
 
     private def check_nilable_instance_vars
-      @nilable_instance_vars.each do |owner, vars|
-        vars.each do |name, info|
+      @nilable_instance_vars.each do |(owner, vars)|
+        vars.each do |(name, info)|
           case owner
           when NonGenericClassType
             ivar = owner.lookup_instance_var_with_owner?(name)
@@ -550,8 +550,8 @@ module Crystal
     end
 
     private def check_cant_use_type_errors
-      @errors.each do |type, entries|
-        entries.each do |name, error|
+      @errors.each do |(type, entries)|
+        entries.each do |(name, error)|
           case name
           when .starts_with?("$")
             error.node.raise "can't use #{error.type} as the type of global variable #{name}, use a more specific type"
@@ -566,8 +566,8 @@ module Crystal
 
     private def check_class_var_errors(type_decl_class_vars, guesser_class_vars)
       {type_decl_class_vars, guesser_class_vars}.each do |all_vars|
-        all_vars.each do |owner, vars|
-          vars.each do |name, info|
+        all_vars.each do |(owner, vars)|
+          vars.each do |(name, info)|
             owner_class_var = owner.lookup_class_var?(name)
             next unless owner_class_var
 

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -7,7 +7,7 @@ module Crystal
   class PrettyTypeNameJsonConverter
     def self.to_json(hash, io)
       io.json_object do |obj|
-        hash.each do |key, value|
+        hash.each do |(key, value)|
           obj.field(key) do
             io << '"'
             pretty_type_name(value, io)
@@ -141,7 +141,7 @@ module Crystal
 
       if type.is_a?(GenericType)
         type_vars = type.type_vars
-        type.generic_types.each do |type_vars_args, instanced_types|
+        type.generic_types.each do |(type_vars_args, instanced_types)|
           process_type(instanced_types) do
             type_vars.each.zip(type_vars_args.each).each do |e|
               generic_arg_name, generic_arg_type = e
@@ -167,7 +167,7 @@ module Crystal
 
       if @contexts.empty?
         @context = HashStringType.new
-        result.program.vars.each do |name, var|
+        result.program.vars.each do |(name, var)|
           add_context name, var.type
         end
         result.node.accept(self)
@@ -212,7 +212,7 @@ module Crystal
           add_context arg.name, arg.type
         end
         node.vars.try do |vars|
-          vars.each do |name, meta_var|
+          vars.each do |(name, meta_var)|
             add_context name, meta_var.type
           end
         end
@@ -226,7 +226,7 @@ module Crystal
           add_context arg.name, arg.type
         end
         node.vars.try do |vars|
-          vars.each do |_, var|
+          vars.each do |(_, var)|
             add_context var.name, var.type
           end
         end
@@ -259,12 +259,12 @@ module Crystal
         if filters
           # make a copy of the current context
           current_context = {} of String => MetaVar
-          @context.each do |name, type|
+          @context.each do |(name, type)|
             current_context[name] = MetaVar.new(name, type)
           end
 
           # restrict the whole context
-          filters.each do |name, filter|
+          filters.each do |(name, filter)|
             filtered_var = current_context[name]
             filtered_var.bind_to(current_context[name].filtered_by(filter))
             add_context name, filtered_var.type

--- a/src/compiler/crystal/tools/doc/html/methods_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/methods_inherited.html
@@ -1,7 +1,7 @@
 <% method_groups = methods.group_by { |method| method.name } %>
 <% unless method_groups.empty? %>
   <h3><%= label %> methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
-  <% method_groups.each_with_index do |method_name, methods, i| %>
+  <% method_groups.each_with_index do |(method_name, methods), i| %>
     <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="tooltip">
       <span><%= methods.map { |method| method.name + method.args_to_s } .join("<br/>") %></span>
     <%= method_name %></a><%= ", " if i != method_groups.size - 1 %>

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -179,7 +179,7 @@ class Crystal::Doc::Type
         [] of Method
       when DefContainer
         defs = [] of Method
-        type.defs.try &.each do |def_name, defs_with_metadata|
+        type.defs.try &.each do |(def_name, defs_with_metadata)|
           defs_with_metadata.each do |def_with_metadata|
             case def_with_metadata.def.visibility
             when .private?, .protected?

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -160,7 +160,7 @@ module Crystal
 
       max_name_size = instance_vars.keys.max_of &.size
 
-      instance_vars.each do |name, types|
+      instance_vars.each do |(name, types)|
         print_indent
         print (@indents.last ? "|" : " ")
         if has_subtypes

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1581,7 +1581,7 @@ module Crystal
       declared_instance_vars = (@declared_instance_vars ||= {} of String => Array(TypeVar))
       declared_instance_vars[name] = type_vars
 
-      generic_types.each do |key, instance|
+      generic_types.each do |(key, instance)|
         instance.declare_instance_var(name, type_vars)
       end
 
@@ -1593,7 +1593,7 @@ module Crystal
     def initialize_instance(instance)
       if decl_ivars = @declared_instance_vars
         visitor = TypeLookup.new(instance)
-        decl_ivars.each do |name, type_vars|
+        decl_ivars.each do |(name, type_vars)|
           type = instance.solve_type_vars(type_vars)
 
           ivar = MetaTypeVar.new(name, type)

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -351,7 +351,7 @@ class Deque(T)
   end
 
   def hash
-    reduce(31 * @size) do |memo, elem|
+    reduce(31 * @size) do |elem, memo|
       31 * memo + elem.hash
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -386,7 +386,7 @@ module Enumerable(T)
     found = false
 
     each do |elem|
-      memo = found ? (yield memo, elem) : elem
+      memo = found ? (yield elem, memo) : elem
       found = true
     end
 
@@ -399,7 +399,7 @@ module Enumerable(T)
   #
   def reduce(memo)
     each do |elem|
-      memo = yield memo, elem
+      memo = yield elem, memo
     end
     memo
   end
@@ -890,7 +890,7 @@ module Enumerable(T)
   #
   #     ([] of String).sum(1) { |name| name.size } #=> 1
   def sum(initial, &block)
-    reduce(initial) { |memo, e| memo + (yield e) }
+    reduce(initial) { |e, memo| memo + (yield e) }
   end
 
   # Multiplies all the elements in the collection together.
@@ -943,7 +943,7 @@ module Enumerable(T)
   #
   #     ([] of String).product(1) { |name| name.size } #=> 1
   def product(initial : Number, &block)
-    reduce(initial) { |memo, e| memo * (yield e) }
+    reduce(initial) { |e, memo| memo * (yield e) }
   end
 
   # Returns an array with the first *count* elements in the collection.

--- a/src/env.cr
+++ b/src/env.cr
@@ -12,6 +12,8 @@ require "c/stdlib"
 #     # Later use that env var.
 #     puts ENV["PORT"].to_i
 module ENV
+  extend Enumerable({String, String})
+
   # Retrieves the value for environment variable named `key` as a `String`.
   # Raises `KeyError` if the named variable does not exist.
   def self.[](key : String) : String
@@ -70,14 +72,14 @@ module ENV
   # Returns an array of all the environment variable names.
   def self.keys : Array(String)
     keys = [] of String
-    each { |key, v| keys << key }
+    each { |(key, v)| keys << key }
     keys
   end
 
   # Returns an array of all the environment variable values.
   def self.values : Array(String)
     values = [] of String
-    each { |k, value| values << value }
+    each { |(k, value)| values << value }
     values
   end
 
@@ -95,7 +97,7 @@ module ENV
   # Iterates over all `KEY=VALUE` pairs of environment variables, yielding both
   # the `key` and `value`.
   #
-  #     ENV.each do |key, value|
+  #     ENV.each do |(key, value)|
   #       puts "#{key} => #{value}"
   #     end
   def self.each
@@ -106,7 +108,7 @@ module ENV
         key_value = String.new(environ_value).split('=', 2)
         key = key_value[0]
         value = key_value[1]? || ""
-        yield key, value
+        yield({key, value})
         environ_ptr += 1
       else
         break
@@ -122,7 +124,7 @@ module ENV
   def self.inspect(io)
     io << "{"
     found_one = false
-    each do |key, value|
+    each do |(key, value)|
       io << ", " if found_one
       key.inspect(io)
       io << " => "

--- a/src/event/signal_child_handler.cr
+++ b/src/event/signal_child_handler.cr
@@ -20,7 +20,7 @@ class Event::SignalChildHandler
 
   def after_fork
     @pending.clear
-    @waiting.each { |pid, chan| chan.send(nil) }
+    @waiting.each { |(pid, chan)| chan.send(nil) }
     @waiting.clear
   end
 

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -363,7 +363,7 @@ class HTTP::Client
   # ```
   def post_form(path, form : Hash, headers : HTTP::Headers? = nil) : HTTP::Client::Response
     body = HTTP::Params.build do |form_builder|
-      form.each do |key, value|
+      form.each do |(key, value)|
         form_builder.add key, value
       end
     end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -124,7 +124,7 @@ module HTTP
       headers["Content-Length"] = body.bytesize.to_s
     end
 
-    headers.each do |name, values|
+    headers.each do |(name, values)|
       values.each do |value|
         io << name << ": " << value << "\r\n"
       end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -3,6 +3,8 @@
 # Two headers are considered the same if their downcase representation is the same
 # (in which `_` is the downcase version of `-`).
 struct HTTP::Headers
+  include Enumerable({String, Array(String)})
+
   # :nodoc:
   record Key, name : String do
     forward_missing_to @name
@@ -144,7 +146,7 @@ struct HTTP::Headers
   end
 
   def merge!(other)
-    other.each do |key, value|
+    other.each do |(key, value)|
       self[wrap(key)] = value
     end
     self
@@ -157,7 +159,7 @@ struct HTTP::Headers
   def ==(other : Hash)
     return false unless @hash.size == other.size
 
-    other.each do |key, value|
+    other.each do |(key, value)|
       this_value = @hash[wrap(key)]?
       if this_value
         case value
@@ -177,8 +179,8 @@ struct HTTP::Headers
   end
 
   def each
-    @hash.each do |key, value|
-      yield key.name, value
+    @hash.each do |(key, value)|
+      yield({key.name, value})
     end
   end
 
@@ -192,7 +194,7 @@ struct HTTP::Headers
 
   def dup
     dup = HTTP::Headers.new
-    @hash.each do |key, value|
+    @hash.each do |(key, value)|
       dup.@hash[key] = value
     end
     dup
@@ -208,7 +210,7 @@ struct HTTP::Headers
 
   def to_s(io : IO)
     io << "HTTP::Headers{"
-    @hash.each_with_index do |key, values, index|
+    @hash.each_with_index do |(key, values), index|
       io << ", " if index > 0
       key.name.inspect(io)
       io << " => "

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -212,7 +212,7 @@ module HTTP
     # # item => keynote
     # ```
     def each
-      raw_params.each do |name, values|
+      raw_params.each do |(name, values)|
         values.each do |value|
           yield(name, value)
         end

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -118,7 +118,7 @@ class HTTP::Server
     protected def write_headers
       status_message = HTTP.default_status_message_for(@status_code)
       @io << @version << " " << @status_code << " " << status_message << "\r\n"
-      headers.each do |name, values|
+      headers.each do |(name, values)|
         values.each do |value|
           @io << name << ": " << value << "\r\n"
         end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -127,7 +127,7 @@ struct JSON::Any
         yield Any.new(elem), Any.new(nil)
       end
     when Hash
-      object.each do |key, value|
+      object.each do |(key, value)|
         yield Any.new(key), Any.new(value)
       end
     else

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -246,7 +246,7 @@ class Hash
     end
 
     io.json_object do |object|
-      each do |key, value|
+      each do |(key, value)|
         object.field key, value
       end
     end

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -237,7 +237,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
       if type.packed_struct?
         1
       else
-        type.struct_element_types.reduce(1) do |memo, elem|
+        type.struct_element_types.reduce(1) do |elem, memo|
           Math.max(memo, align(elem))
         end
       end
@@ -260,11 +260,11 @@ class LLVM::ABI::X86_64 < LLVM::ABI
       8
     when Type::Kind::Struct
       if type.packed_struct?
-        type.struct_element_types.reduce(0) do |memo, elem|
+        type.struct_element_types.reduce(0) do |elem, memo|
           memo + size(elem)
         end
       else
-        size = type.struct_element_types.reduce(0) do |memo, elem|
+        size = type.struct_element_types.reduce(0) do |elem, memo|
           align(memo, elem) + size(elem)
         end
         align(size, type)

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -144,7 +144,7 @@ class LLVM::Builder
 
   def switch(value, otherwise, cases)
     switch = LibLLVM.build_switch self, value, otherwise, cases.size
-    cases.each do |case_value, block|
+    cases.each do |(case_value, block)|
       LibLLVM.add_case switch, case_value, block
     end
     switch

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -219,7 +219,7 @@ struct NamedTuple
   #
   # ```
   # tuple = {name: "Crystal", year: 2011}
-  # tuple.each do |key, value|
+  # tuple.each do |(key, value)|
   #   puts "#{key} = #{value}"
   # end
   # ```
@@ -232,7 +232,7 @@ struct NamedTuple
   # ```
   def each
     {% for key in T %}
-      yield {{key.symbolize}}, self[{{key.symbolize}}]
+      yield({ {{key.symbolize}}, self[{{key.symbolize}}] })
     {% end %}
     self
   end
@@ -285,7 +285,7 @@ struct NamedTuple
   #
   # ```
   # tuple = {name: "Crystal", year: 2011}
-  # tuple.each_with_index do |key, value, i|
+  # tuple.each_with_index do |(key, value), i|
   #   puts "#{i + 1}) #{key} = #{value}"
   # end
   # ```
@@ -298,8 +298,8 @@ struct NamedTuple
   # ```
   def each_with_index(offset = 0)
     i = offset
-    each do |key, value|
-      yield key, value, i
+    each do |(key, value)|
+      yield({key, value}, i)
       i += 1
     end
     self
@@ -310,12 +310,12 @@ struct NamedTuple
   #
   # ```
   # tuple = {name: "Crystal", year: 2011}
-  # tuple.map { |k, v| "#{name}: #{year}" } # => ["name: Crystal", "year: 2011"]
+  # tuple.map { |(k, v)| "#{name}: #{year}" } # => ["name: Crystal", "year: 2011"]
   # ```
   def map
-    array = Array(typeof(yield first_key_internal, first_value_internal)).new(size)
-    each do |k, v|
-      array.push yield k, v
+    array = Array(typeof(yield({first_key_internal, first_value_internal}))).new(size)
+    each do |(k, v)|
+      array.push yield({k, v})
     end
     array
   end
@@ -328,7 +328,7 @@ struct NamedTuple
   # ```
   def to_a
     ary = Array({typeof(first_key_internal), typeof(first_value_internal)}).new(size)
-    each do |key, value|
+    each do |(key, value)|
       ary << {key.as(typeof(first_key_internal)), value.as(typeof(first_value_internal))}
     end
     ary

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -69,7 +69,7 @@ struct OAuth::Signature
     params.add "oauth_token", @oauth_token
     params.add "oauth_version", "1.0"
 
-    @extra_params.try &.each do |key, value|
+    @extra_params.try &.each do |(key, value)|
       params.add key, value
     end
 

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -123,7 +123,7 @@ class Process
         reopen_io(fork_error || error, STDERR, "w")
 
         ENV.clear if clear_env
-        env.try &.each do |key, val|
+        env.try &.each do |(key, val)|
           if val
             ENV[key] = val
           else

--- a/src/uri/uri_parser.cr
+++ b/src/uri/uri_parser.cr
@@ -145,7 +145,7 @@ class URI
         if numeric?
           @ptr += 1
         elsif end_of_host?
-          @uri.port = (start...@ptr).reduce(0) do |memo, i|
+          @uri.port = (start...@ptr).reduce(0) do |i, memo|
             (memo * 10) + (@input[i] - '0'.ord)
           end
           step parse_path

--- a/src/xml/xpath_context.cr
+++ b/src/xml/xpath_context.cr
@@ -27,7 +27,7 @@ struct XML::XPathContext
   end
 
   def register_namespaces(namespaces)
-    namespaces.each do |prefix, uri|
+    namespaces.each do |(prefix, uri)|
       register_namespace prefix, uri
     end
   end
@@ -37,7 +37,7 @@ struct XML::XPathContext
   end
 
   def register_variables(variables)
-    variables.each do |name, value|
+    variables.each do |(name, value)|
       register_variable name, value
     end
   end

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -132,7 +132,7 @@ struct YAML::Any
         yield Any.new(elem), Any.new(nil)
       end
     when Hash
-      object.each do |key, value|
+      object.each do |(key, value)|
         yield Any.new(key), Any.new(value)
       end
     else

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -42,7 +42,7 @@ end
 class Hash
   def to_yaml(yaml : YAML::Generator)
     yaml.indented do
-      each do |k, v|
+      each do |(k, v)|
         yaml.nl
         k.to_yaml(yaml)
         yaml << ": "


### PR DESCRIPTION
This is an alternative to #2778, proposed in [this comment](https://github.com/crystal-lang/crystal/pull/2778#issuecomment-224619197).

Basically, now you have to do:

```crystal
hash = {1 => 2}
hash.each do |(key, value|)|
  key # => 1
  value # => 2
end
```

If you do `do |key, value|`, `key` will be a tuple and `value` will be `nil`. We can of course discuss if this should actually be a compile error instead of binding the variable to `nil`.

I also changed the order in `Enumerable#reduce` to be `elem, memo`, which is more consistent with everything else.

`HTTP::Headers` and `ENV` are also changed to this new behaviour, and now include `Enumerable`.

Now, my opinion about this vs. #2778 . If you look at the diff you'll see most changes change `|key, value|` with `|(key, value)|`. To me, this adds no information at all, and feels redundant and is definitely more tedious to type. It's hard to get confused if auto-unpacking would be turned on, because `key` and `value` are self-describing names, so someone reading the code would know what to expect.

The same thought applies to changes from `|key, value, index|` to `|(key, value), index|`, it feels like the language is forcing me to add parentheses for no real reason (no more type safe, and I could still use the explicit unpacking if I wanted to).

Additionally, in some places there's `each_with_index do |elem, index|` and one might wonder why it's not `|(elem, index)|` instead. Maybe it's because the iterated element, and the index, are separate entities. Should we change `Array#zip` to return tuples, or yield two elements? If a class isn't Enumerable but yields two things in a method, should one use a tuple or not? All these questions start to appear. Auto-unpacking make them all go away, and leaves the door open for the programmer, on the call site, when writing the block, to choose explicit unpacking, or implicit auto-unpacking.

This PR of course breaks most code out there, as they need to upgrade to the new `each` method. Auto-unpacking, on the other hand, is almost backwards compatible, unless you did something like `hash.each { |key| ... }` (didn't happen in the bunch of projects I tested).

If Crystal is to be a pragmatic, less noisy, practical language, I think #2778 is the way to go. But of course this approach isn't that bad either, it just feels a bit more cumbersome to code like this, though it's always explicit and there's no "magic".