### PR TITLE
Implement auto-tuple unpacking in block arguments, Rule 1

### DIFF
--- a/samples/pretty_json.cr
+++ b/samples/pretty_json.cr
@@ -53,7 +53,7 @@ class PrettyPrinter
     print "[\n"
     @indent += 1
     i = 0
-    @pull.read_array do |obj|
+    @pull.read_array do
       if i > 0
         print ','
         print '\n' if @indent > 0

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -721,26 +721,6 @@ describe "Code gen: block" do
     ")
   end
 
-  it "allows yields with less arguments than in block" do
-    run("
-      struct Nil
-        def to_i
-          0
-        end
-      end
-
-      def foo
-        yield 1
-      end
-
-      a = 0
-      foo do |x, y|
-        a += x + y.to_i
-      end
-      a
-      ").to_i.should eq(1)
-  end
-
   it "codegens block with nilable type with return (1)" do
     run("
       def foo
@@ -1421,18 +1401,6 @@ describe "Code gen: block" do
       )).to_i.should eq(3)
   end
 
-  it "uses splat in block argument, but not enough yield expressions" do
-    run(%(
-      def foo
-        yield 42
-      end
-
-      foo do |x, y, z, *w|
-        x
-      end
-      )).to_i.should eq(42)
-  end
-
   it "auto-unpacks tuple" do
     run(%(
       def foo
@@ -1442,32 +1410,6 @@ describe "Code gen: block" do
 
       foo do |x, y, z|
         (x + y) * z
-      end
-      )).to_i.should eq((1 + 2) * 4)
-  end
-
-  it "auto-unpacks tuple, more args" do
-    run(%(
-      def foo
-        tup = {1, 2}
-        yield tup, 4
-      end
-
-      foo do |x, y, z|
-        (x + y) * z
-      end
-      )).to_i.should eq((1 + 2) * 4)
-  end
-
-  it "doesn't auto-unpack if not enough args" do
-    run(%(
-      def foo
-        tup = {1, 2}
-        yield tup, 4
-      end
-
-      foo do |x, y|
-        (x[0] + x[1]) * y
       end
       )).to_i.should eq((1 + 2) * 4)
   end

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1432,4 +1432,43 @@ describe "Code gen: block" do
       end
       )).to_i.should eq(42)
   end
+
+  it "auto-unpacks tuple" do
+    run(%(
+      def foo
+        tup = {1, 2, 4}
+        yield tup
+      end
+
+      foo do |x, y, z|
+        (x + y) * z
+      end
+      )).to_i.should eq((1 + 2) * 4)
+  end
+
+  it "auto-unpacks tuple, more args" do
+    run(%(
+      def foo
+        tup = {1, 2}
+        yield tup, 4
+      end
+
+      foo do |x, y, z|
+        (x + y) * z
+      end
+      )).to_i.should eq((1 + 2) * 4)
+  end
+
+  it "doesn't auto-unpack if not enough args" do
+    run(%(
+      def foo
+        tup = {1, 2}
+        yield tup, 4
+      end
+
+      foo do |x, y|
+        (x[0] + x[1]) * y
+      end
+      )).to_i.should eq((1 + 2) * 4)
+  end
 end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -559,14 +559,22 @@ describe "Hash" do
     it "pass key, value, index values into block" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index { |k, v, i| results << k + v + i }
+      {% if Crystal::VERSION == "0.18.0" %}
+        hash.each_with_index { |(k, v), i| results << k + v + i }
+      {% else %}
+        hash.each_with_index { |k, v, i| results << k + v + i }
+      {% end %}
       results.should eq [6, 16, 23]
     end
 
     it "can be used with offset" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index(3) { |k, v, i| results << k + v + i }
+      {% if Crystal::VERSION == "0.18.0" %}
+        hash.each_with_index(3) { |(k, v), i| results << k + v + i }
+      {% else %}
+        hash.each_with_index(3) { |k, v, i| results << k + v + i }
+      {% end %}
       results.should eq [9, 19, 26]
     end
   end
@@ -574,18 +582,33 @@ describe "Hash" do
   describe "each_with_object" do
     it "passes memo, key and value into block" do
       hash = {:a => 'b'}
-      hash.each_with_object(:memo) do |memo, k, v|
-        memo.should eq(:memo)
-        k.should eq(:a)
-        v.should eq('b')
-      end
+      {% if Crystal::VERSION == "0.18.0" %}
+        hash.each_with_object(:memo) do |(k, v), memo|
+          memo.should eq(:memo)
+          k.should eq(:a)
+          v.should eq('b')
+        end
+      {% else %}
+        hash.each_with_object(:memo) do |memo, k, v|
+          memo.should eq(:memo)
+          k.should eq(:a)
+          v.should eq('b')
+        end
+      {% end %}
     end
 
     it "reduces the hash to the accumulated value of memo" do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
-      result = hash.each_with_object({} of Char => Symbol) do |memo, k, v|
-        memo[v] = k
-      end
+      result = nil
+      {% if Crystal::VERSION == "0.18.0" %}
+        result = hash.each_with_object({} of Char => Symbol) do |(k, v), memo|
+          memo[v] = k
+        end
+      {% else %}
+        result = hash.each_with_object({} of Char => Symbol) do |memo, k, v|
+          memo[v] = k
+        end
+      {% end %}
       result.should eq({'b' => :a, 'd' => :c, 'f' => :e})
     end
   end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -75,13 +75,16 @@ module Crystal
       tmp_debug_type = di_builder.temporary_md_node(LLVM::Context.global)
       debug_type_cache[type] = tmp_debug_type
 
-      ivars.each_with_index do |name, ivar, idx|
+      # TOOD: use each_with_index
+      idx = 0
+      ivars.each do |name, ivar|
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
           offset = @mod.target_machine.data_layout.offset_of_element(struct_type, idx + (type.struct? ? 0 : 1))
           size = @mod.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
           member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, offset * 8, 0, ivar_debug_type)
           element_types << member
         end
+        idx += 1
       end
 
       size = @mod.target_machine.data_layout.size_in_bits(struct_type)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -746,22 +746,19 @@ class Crystal::Call
     end
 
     if yield_vars
-      i = 0
-      yield_vars.each do |yield_var|
-        yield_var_type = yield_var.type
-        # Check if tuple unpkacing is needed
-        if i == 0 && yield_var_type.is_a?(TupleInstanceType) &&
-           ((yield_vars.size == 1 && block.args.size > 1) ||
-           block.args.size > yield_var_type.tuple_types.size)
-          yield_var_type.tuple_types.each do |tuple_type|
-            arg = block.args[i]?
-            arg.type = tuple_type if arg
-            i += 1
-          end
-        else
+      # Check if tuple unpkacing is needed
+      if yield_vars.size == 1 &&
+         (yield_var_type = yield_vars.first.type).is_a?(TupleInstanceType) &&
+         block.args.size > 1
+        yield_var_type.tuple_types.each_with_index do |tuple_type, i|
+          arg = block.args[i]?
+          arg.type = tuple_type if arg
+        end
+      else
+        yield_vars.each_with_index do |yield_var, i|
+          yield_var_type = yield_var.type
           arg = block.args[i]?
           arg.bind_to(yield_var || mod.nil_var) if arg
-          i += 1
         end
       end
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3609,6 +3609,8 @@ module Crystal
     end
 
     def parse_block2
+      location = @token.location
+
       block_args = [] of Var
       extra_assigns = nil
       block_body = nil
@@ -3716,7 +3718,7 @@ module Crystal
       end_location = token_end_location
       next_token_skip_space
 
-      Block.new(block_args, block_body, splat_index).at_end(end_location)
+      Block.new(block_args, block_body, splat_index).at(location).at_end(end_location)
     end
 
     record CallArgs,

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -812,7 +812,7 @@ module Crystal
       end
 
       if named_args = node.named_args
-        named_args.each do |named_arg, i|
+        named_args.each do |named_arg|
           @str << ", " if printed_arg
           @str << named_arg.name
           @str << ": "

--- a/src/compiler/crystal/tools/doc/html/methods_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/methods_inherited.html
@@ -1,9 +1,11 @@
 <% method_groups = methods.group_by { |method| method.name } %>
 <% unless method_groups.empty? %>
   <h3><%= label %> methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
-  <% method_groups.each_with_index do |method_name, methods, i| %>
+  <% i = 0 %>
+  <% method_groups.each do |method_name, methods| %>
     <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="tooltip">
       <span><%= methods.map { |method| method.name + method.args_to_s } .join("<br/>") %></span>
     <%= method_name %></a><%= ", " if i != method_groups.size - 1 %>
+    <% i += 1 %>
   <% end %>
 <% end %>

--- a/src/env.cr
+++ b/src/env.cr
@@ -12,6 +12,10 @@ require "c/stdlib"
 #     # Later use that env var.
 #     puts ENV["PORT"].to_i
 module ENV
+  {% if Crystal::VERSION == "0.18.0" %}
+    extend Enumerable({String, String})
+  {% end %}
+
   # Retrieves the value for environment variable named `key` as a `String`.
   # Raises `KeyError` if the named variable does not exist.
   def self.[](key : String) : String
@@ -106,7 +110,11 @@ module ENV
         key_value = String.new(environ_value).split('=', 2)
         key = key_value[0]
         value = key_value[1]? || ""
-        yield key, value
+        {% if Crystal::VERSION == "0.18.0" %}
+          yield({key, value})
+        {% else %}
+          yield key, value
+        {% end %}
         environ_ptr += 1
       else
         break

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -3,6 +3,10 @@ require "uri"
 module HTTP
   # Represents a collection of http parameters and their respective values.
   struct Params
+    {% if Crystal::VERSION == "0.18.0" %}
+      include Enumerable({String, String})
+    {% end %}
+
     # Parses an HTTP query string into a `HTTP::Params`
     #
     #     HTTP::Params.parse("foo=bar&foo=baz&qux=zoo")
@@ -214,7 +218,11 @@ module HTTP
     def each
       raw_params.each do |name, values|
         values.each do |value|
-          yield(name, value)
+          {% if Crystal::VERSION == "0.18.0" %}
+            yield({name, value})
+          {% else %}
+            yield(name, value)
+          {% end %}
         end
       end
     end


### PR DESCRIPTION
This is similar to #2778 but only Rule 1 (explained there) is implemented.

Additionally, an error is now given if more than expected block arguments are passed, as explained [here](https://github.com/crystal-lang/crystal/pull/2778#issuecomment-224717753).

Finally, the code has version checks so that in 0.18.0 `Hash` will be `Enumerable`, as well as a few other types (`HTTP::Headers`, `HTTP::Params` and `ENV`). These checks will disappear once we make a new release, but it allows us to avoid having to do an intermediate release that can use the new behaviour.

I personally still like Rule 2 and see no harm in it, specially if combined with the error when extra block arguments are passed. Could be nice for `each_with_index` and `each_with_object`, when used on a `Hash`. But since there aren't many cases of that in the compiler (about ~6) and just a few in other projects I tried, maybe it's not very important.

I'd still like to be able to do `hash.each { |key, value| ... }` instead of `hash.each { |(key, value)| ... }`, mostly because the later doesn't add any type safety, just noise. Basically, if I specify more arguments is because I'm expecting a tuple unpack to happen. If that's not the case (it's not a tuple), I get a compile error, so mistakes can't happen. With Rule 2 it's a bit more complicated because there are many more variants to consider.

