### PR TITLE
Make the `system` macro call set the current working directory

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -101,7 +101,8 @@ module Crystal
       end
       cmd = cmd.join " "
 
-      result = `#{cmd}`
+      dir = node.location.try(&.dirname)
+      result = Process.run(cmd, shell: true, chdir: dir, &.output.gets_to_end)
       if $?.success?
         @last = MacroId.new(result)
       elsif result.empty?
@@ -128,7 +129,7 @@ module Crystal
 
       node.args.first.accept self
       filename = @last.to_macro_id
-      original_filanme = filename
+      original_filename = filename
 
       # Support absolute paths
       if filename.starts_with?("/")
@@ -172,7 +173,7 @@ module Crystal
       if success
         @last = MacroId.new(result)
       else
-        node.raise "Error executing run: #{original_filanme} #{run_args.map(&.inspect).join " "}\n\nGot:\n\n#{result}\n"
+        node.raise "Error executing run: #{original_filename} #{run_args.map(&.inspect).join " "}\n\nGot:\n\n#{result}\n"
       end
     end
   end


### PR DESCRIPTION
Fixes #2750

I think it makes more sense. If I have:

```crystal
{{ `cat foo.txt`.stringify }}
```

I'd expect "foo.txt" to be relative to the file where the macro is defined. This makes builds reproducible, which doesn't happen right now because this basically depends on the current working directory where the program is compiled.

I know that `__DIR__` can be used, but when dealing with files it will always have to be used, which makes things more verboise and harder to understand.