### PR TITLE
Change delegate macro to be `delegate *methods, to: object`

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -276,11 +276,7 @@ class Crystal::SpecRunOutput
     @output
   end
 
-  delegate to_i, @output
-  delegate to_u64, @output
-  delegate to_f, @output
-  delegate to_f32, @output
-  delegate to_f64, @output
+  delegate to_i, to_u64, to_f, to_f32, to_f64, to: @output
 
   def to_b
     @output == "true"

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 module ObjectSpec
   class StringWrapper
-    delegate downcase, @string
-    delegate upcase, capitalize, @string
+    delegate downcase, to: @string
+    delegate upcase, capitalize, at, scan, to: @string
 
     @string : String
 
@@ -95,6 +95,19 @@ describe Object do
       wrapper.downcase.should eq("hello")
       wrapper.upcase.should eq("HELLO")
       wrapper.capitalize.should eq("Hello")
+
+      wrapper.at(0).should eq('H')
+      wrapper.at(index: 1).should eq('e')
+
+      {% if Crystal::VERSION == "0.18.0" %}
+        wrapper.at(10) { 20 }.should eq(20)
+
+        matches = [] of String
+        wrapper.scan(/l/) do |match|
+          matches << match[0]
+        end
+        matches.should eq(["l", "l"])
+      {% end %}
     end
   end
 

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -72,23 +72,23 @@ module Crystal
       builder.inbounds_gep ptr, index0, index1, name
     end
 
-    delegate ptr2int, builder
-    delegate int2ptr, builder
-    delegate and, builder
-    delegate or, builder
-    delegate not, builder
-    delegate call, builder
-    delegate bit_cast, builder
-    delegate trunc, builder
-    delegate load, builder
-    delegate store, builder
-    delegate br, builder
-    delegate insert_block, builder
-    delegate position_at_end, builder
-    delegate unreachable, builder
-    delegate cond, builder
-    delegate phi, builder
-    delegate extract_value, builder
+    delegate ptr2int, to: builder
+    delegate int2ptr, to: builder
+    delegate and, to: builder
+    delegate or, to: builder
+    delegate not, to: builder
+    delegate call, to: builder
+    delegate bit_cast, to: builder
+    delegate trunc, to: builder
+    delegate load, to: builder
+    delegate store, to: builder
+    delegate br, to: builder
+    delegate insert_block, to: builder
+    delegate position_at_end, to: builder
+    delegate unreachable, to: builder
+    delegate cond, to: builder
+    delegate phi, to: builder
+    delegate extract_value, to: builder
 
     def ret
       builder.ret
@@ -142,13 +142,13 @@ module Crystal
       bit_cast value, llvm_type(type).pointer
     end
 
-    delegate llvm_type, llvm_typer
-    delegate llvm_struct_type, llvm_typer
-    delegate llvm_arg_type, llvm_typer
-    delegate llvm_embedded_type, llvm_typer
-    delegate llvm_c_type, llvm_typer
-    delegate llvm_c_return_type, llvm_typer
-    delegate llvm_return_type, llvm_typer
+    delegate llvm_type, to: llvm_typer
+    delegate llvm_struct_type, to: llvm_typer
+    delegate llvm_arg_type, to: llvm_typer
+    delegate llvm_embedded_type, to: llvm_typer
+    delegate llvm_c_type, to: llvm_typer
+    delegate llvm_c_return_type, to: llvm_typer
+    delegate llvm_return_type, to: llvm_typer
 
     def llvm_proc_type(type)
       llvm_typer.proc_type(type.as(ProcInstanceType))

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -328,8 +328,8 @@ module Crystal
   end
 
   class AliasType
-    delegate lookup_matches, aliased_type
-    delegate lookup_matches_without_parents, aliased_type
+    delegate lookup_matches, to: aliased_type
+    delegate lookup_matches_without_parents, to: aliased_type
   end
 
   module VirtualTypeLookup

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -82,7 +82,7 @@ module Crystal
   end
 
   class GenericClassInstanceType
-    delegate check_method_missing, @generic_class
+    delegate check_method_missing, to: @generic_class
   end
 
   class VirtualType

--- a/src/compiler/crystal/semantic/suggestions.cr
+++ b/src/compiler/crystal/semantic/suggestions.cr
@@ -98,33 +98,33 @@ module Crystal
   end
 
   class IncludedGenericModule
-    delegate lookup_similar_def, @module
-    delegate lookup_similar_type_name, @module
+    delegate lookup_similar_def, to: @module
+    delegate lookup_similar_type_name, to: @module
   end
 
   class InheritedGenericClass
-    delegate lookup_similar_def, @extended_class
-    delegate lookup_similar_type_name, @extended_class
+    delegate lookup_similar_def, to: @extended_class
+    delegate lookup_similar_type_name, to: @extended_class
   end
 
   class AliasType
-    delegate lookup_similar_def, aliased_type
+    delegate lookup_similar_def, to: aliased_type
   end
 
   class MetaclassType
-    delegate lookup_similar_type_name, instance_type
+    delegate lookup_similar_type_name, to: instance_type
   end
 
   class GenericClassInstanceMetaclassType
-    delegate lookup_similar_type_name, instance_type
+    delegate lookup_similar_type_name, to: instance_type
   end
 
   class VirtualType
-    delegate lookup_similar_def, base_type
-    delegate lookup_similar_type_name, base_type
+    delegate lookup_similar_def, to: base_type
+    delegate lookup_similar_type_name, to: base_type
   end
 
   class VirtualMetaclassType
-    delegate lookup_similar_type_name, instance_type
+    delegate lookup_similar_type_name, to: instance_type
   end
 end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -28,7 +28,7 @@ module Crystal
     def initialize(@root, @self_type, @raise = true, @allow_typeof = true)
     end
 
-    delegate program, @root
+    delegate program, to: @root
 
     def visit(node : ASTNode)
       true
@@ -440,7 +440,7 @@ module Crystal
   end
 
   class AliasType
-    delegate types, aliased_type
-    delegate types?, aliased_type
+    delegate types, to: aliased_type
+    delegate types?, to: aliased_type
   end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1687,19 +1687,19 @@ module Crystal
       self
     end
 
-    delegate leaf?, @generic_class
-    delegate depth, @generic_class
-    delegate defs, @generic_class
-    delegate superclass, @generic_class
-    delegate macros, @generic_class
-    delegate :abstract?, @generic_class
-    delegate struct?, @generic_class
-    delegate passed_by_value?, @generic_class
-    delegate type_desc, @generic_class
-    delegate container, @generic_class
-    delegate lookup_new_in_ancestors?, @generic_class
-    delegate splat_index, @generic_class
-    delegate double_variadic, @generic_class
+    delegate leaf?, to: @generic_class
+    delegate depth, to: @generic_class
+    delegate defs, to: @generic_class
+    delegate superclass, to: @generic_class
+    delegate macros, to: @generic_class
+    delegate :abstract?, to: @generic_class
+    delegate struct?, to: @generic_class
+    delegate passed_by_value?, to: @generic_class
+    delegate type_desc, to: @generic_class
+    delegate container, to: @generic_class
+    delegate lookup_new_in_ancestors?, to: @generic_class
+    delegate splat_index, to: @generic_class
+    delegate double_variadic, to: @generic_class
 
     def declare_instance_var(name, type_vars : Array(TypeVar))
       type = solve_type_vars(type_vars)
@@ -2103,17 +2103,17 @@ module Crystal
       @module.add_including_type type
     end
 
-    delegate container, @module
-    delegate name, @module
-    delegate defs, @module
-    delegate macros, @module
-    delegate implements?, @module
-    delegate lookup_defs, @module
-    delegate lookup_defs_with_modules, @module
-    delegate lookup_macro, @module
-    delegate lookup_macros, @module
-    delegate has_def?, @module
-    delegate metaclass, @module
+    delegate container, to: @module
+    delegate name, to: @module
+    delegate defs, to: @module
+    delegate macros, to: @module
+    delegate implements?, to: @module
+    delegate lookup_defs, to: @module
+    delegate lookup_defs_with_modules, to: @module
+    delegate lookup_macro, to: @module
+    delegate lookup_macros, to: @module
+    delegate has_def?, to: @module
+    delegate metaclass, to: @module
 
     def instance_of?(type)
       type == @module
@@ -2164,22 +2164,22 @@ module Crystal
       type == @extended_class
     end
 
-    delegate depth, @extended_class
-    delegate superclass, @extended_class
-    delegate add_subclass, @extended_class
-    delegate container, @extended_class
-    delegate name, @extended_class
-    delegate defs, @extended_class
-    delegate macros, @extended_class
-    delegate implements?, @extended_class
-    delegate lookup_defs, @extended_class
-    delegate lookup_defs_with_modules, @extended_class
-    delegate lookup_macro, @extended_class
-    delegate lookup_macros, @extended_class
-    delegate has_def?, @extended_class
-    delegate notify_subclass_added, @extended_class
-    delegate has_def_without_parents?, @extended_class
-    delegate add_def, @extended_class
+    delegate depth, to: @extended_class
+    delegate superclass, to: @extended_class
+    delegate add_subclass, to: @extended_class
+    delegate container, to: @extended_class
+    delegate name, to: @extended_class
+    delegate defs, to: @extended_class
+    delegate macros, to: @extended_class
+    delegate implements?, to: @extended_class
+    delegate lookup_defs, to: @extended_class
+    delegate lookup_defs_with_modules, to: @extended_class
+    delegate lookup_macro, to: @extended_class
+    delegate lookup_macros, to: @extended_class
+    delegate has_def?, to: @extended_class
+    delegate notify_subclass_added, to: @extended_class
+    delegate has_def_without_parents?, to: @extended_class
+    delegate add_def, to: @extended_class
 
     def lookup_instance_var?(name, create = false)
       nil
@@ -2285,11 +2285,11 @@ module Crystal
       typedef.remove_indirection
     end
 
-    delegate pointer?, typedef
-    delegate defs, typedef
-    delegate macros, typedef
-    delegate passed_by_value?, typedef
-    delegate reference_like?, typedef
+    delegate pointer?, to: typedef
+    delegate defs, to: typedef
+    delegate macros, to: typedef
+    delegate passed_by_value?, to: typedef
+    delegate reference_like?, to: typedef
 
     def parents
       # We need to repoint "self" in included generic modules to this typedef,
@@ -2334,17 +2334,17 @@ module Crystal
       @value_processed = false
     end
 
-    delegate lookup_defs, aliased_type
-    delegate lookup_defs_with_modules, aliased_type
-    delegate lookup_first_def, aliased_type
-    delegate def_instances, aliased_type
-    delegate add_def_instance, aliased_type
-    delegate lookup_def_instance, aliased_type
-    delegate lookup_macro, aliased_type
-    delegate lookup_macros, aliased_type
-    delegate cover, aliased_type
-    delegate cover_size, aliased_type
-    delegate passed_by_value?, aliased_type
+    delegate lookup_defs, to: aliased_type
+    delegate lookup_defs_with_modules, to: aliased_type
+    delegate lookup_first_def, to: aliased_type
+    delegate def_instances, to: aliased_type
+    delegate add_def_instance, to: aliased_type
+    delegate lookup_def_instance, to: aliased_type
+    delegate lookup_macro, to: aliased_type
+    delegate lookup_macros, to: aliased_type
+    delegate cover, to: aliased_type
+    delegate cover_size, to: aliased_type
+    delegate passed_by_value?, to: aliased_type
 
     def aliased_type
       aliased_type?.not_nil!
@@ -2592,9 +2592,9 @@ module Crystal
       @program.class_type
     end
 
-    delegate :abstract?, instance_type
-    delegate :generic_nest, instance_type
-    delegate :lookup_new_in_ancestors?, instance_type
+    delegate :abstract?, to: instance_type
+    delegate :generic_nest, to: instance_type
+    delegate :lookup_new_in_ancestors?, to: instance_type
 
     def class_var_owner
       instance_type
@@ -2641,13 +2641,13 @@ module Crystal
       end
     end
 
-    delegate add_def, instance_type.generic_class.metaclass
-    delegate defs, instance_type.generic_class.metaclass
-    delegate macros, instance_type.generic_class.metaclass
-    delegate type_vars, instance_type
-    delegate :abstract?, instance_type
-    delegate generic_nest, instance_type
-    delegate lookup_new_in_ancestors?, instance_type
+    delegate add_def, to: instance_type.generic_class.metaclass
+    delegate defs, to: instance_type.generic_class.metaclass
+    delegate macros, to: instance_type.generic_class.metaclass
+    delegate type_vars, to: instance_type
+    delegate :abstract?, to: instance_type
+    delegate generic_nest, to: instance_type
+    delegate lookup_new_in_ancestors?, to: instance_type
 
     def metaclass?
       true
@@ -3002,25 +3002,25 @@ module Crystal
     def initialize(@program, @base_type)
     end
 
-    delegate leaf?, base_type
-    delegate superclass, base_type
-    delegate lookup_first_def, base_type
-    delegate lookup_defs, base_type
-    delegate lookup_defs_with_modules, base_type
-    delegate lookup_instance_var, base_type
-    delegate lookup_instance_var?, base_type
-    delegate lookup_instance_var_with_owner, base_type
-    delegate lookup_instance_var_with_owner?, base_type
-    delegate index_of_instance_var, base_type
-    delegate lookup_macro, base_type
-    delegate lookup_macros, base_type
-    delegate all_instance_vars, base_type
-    delegate :abstract?, base_type
-    delegate subclass_of?, base_type
-    delegate implements?, base_type
-    delegate covariant?, base_type
-    delegate ancestors, base_type
-    delegate struct?, base_type
+    delegate leaf?, to: base_type
+    delegate superclass, to: base_type
+    delegate lookup_first_def, to: base_type
+    delegate lookup_defs, to: base_type
+    delegate lookup_defs_with_modules, to: base_type
+    delegate lookup_instance_var, to: base_type
+    delegate lookup_instance_var?, to: base_type
+    delegate lookup_instance_var_with_owner, to: base_type
+    delegate lookup_instance_var_with_owner?, to: base_type
+    delegate index_of_instance_var, to: base_type
+    delegate lookup_macro, to: base_type
+    delegate lookup_macros, to: base_type
+    delegate all_instance_vars, to: base_type
+    delegate :abstract?, to: base_type
+    delegate subclass_of?, to: base_type
+    delegate implements?, to: base_type
+    delegate covariant?, to: base_type
+    delegate ancestors, to: base_type
+    delegate struct?, to: base_type
 
     def passed_by_value?
       struct?
@@ -3118,9 +3118,9 @@ module Crystal
       instance_type.leaf?
     end
 
-    delegate base_type, instance_type
-    delegate cover, instance_type
-    delegate lookup_first_def, instance_type
+    delegate base_type, to: instance_type
+    delegate cover, to: instance_type
+    delegate lookup_first_def, to: instance_type
 
     def virtual_lookup(type)
       type.metaclass

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -92,7 +92,7 @@ class Crypto::Bcrypt
     to_s(io)
   end
 
-  delegate :to_slice, :to_s
+  delegate to_slice, to: to_s
 
   private def hash_password
     blowfish = Blowfish.new(BLOWFISH_ROUNDS)

--- a/src/crypto/md5.cr
+++ b/src/crypto/md5.cr
@@ -27,7 +27,7 @@ class Crypto::MD5
   # :nodoc:
   class ContextWrapper
     getter context : Context
-    delegate update, final, hex, context
+    delegate update, final, hex, to: context
 
     def initialize
       @context = Context.new

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -121,7 +121,7 @@ module HTTP
     # params.has_key?("email")   # => true
     # params.has_key?("garbage") # => false
     # ```
-    delegate has_key?, raw_params
+    delegate has_key?, to: raw_params
 
     # Sets first value for specified param name.
     #

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -93,9 +93,9 @@ class JSON::Parser
     object
   end
 
-  private delegate token, @lexer
-  private delegate next_token, @lexer
-  private delegate next_token_expect_object_key, @lexer
+  private delegate token, to: @lexer
+  private delegate next_token, to: @lexer
+  private delegate next_token_expect_object_key, to: @lexer
 
   private def value_and_next_token(value)
     next_token

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -455,9 +455,9 @@ class JSON::PullParser
     @object_stack.last?
   end
 
-  private delegate token, @lexer
-  private delegate next_token, @lexer
-  private delegate next_token_expect_object_key, @lexer
+  private delegate token, to: @lexer
+  private delegate next_token, to: @lexer
+  private delegate next_token_expect_object_key, to: @lexer
 
   private def next_token_after_value
     case next_token.type

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -120,8 +120,8 @@ class JSON::PrettyWriter
     @indent = 0
   end
 
-  delegate read, @io
-  delegate write, @io
+  delegate read, to: @io
+  delegate write, to: @io
 
   def json_object
     self << "{\n"

--- a/src/object.cr
+++ b/src/object.cr
@@ -907,21 +907,19 @@ class Object
     {% end %}
   end
 
-  # Delegate *method* to *to_object*.
-  #
-  # Syntax is: delegate method1, [method2, ..., ], to_object
+  # Delegate *methods* to *to*.
   #
   # Note that due to current language limitations this is only useful
-  # when no blocks are involved.
+  # when no captured blocks are involved.
   #
   # ```
   # class StringWrapper
   #   def initialize(@string)
   #   end
   #
-  #   delegate downcase, @string
-  #   delegate gsub, @string
-  #   delegate empty?, capitalize, @string
+  #   delegate downcase, to: @string
+  #   delegate gsub, to: @string
+  #   delegate empty?, capitalize, to: @string
   # end
   #
   # wrapper = StringWrapper.new "HELLO"
@@ -930,23 +928,17 @@ class Object
   # wrapper.empty?         # => false
   # wrapper.capitalize     # => "Hello"
   # ```
-  macro delegate(method, required, *others)
-    {% if others.empty? %}
-      def {{method.id}}(*args)
-        {{required.id}}.{{method.id}}(*args)
-      end
-    {% else %}
-      def {{method.id}}(*args)
-        {{others[-1].id}}.{{method.id}}(*args)
+  macro delegate(*methods, to object)
+    {% for method in methods %}
+      def {{method.id}}(*args, **options)
+        {{object.id}}.{{method.id}}(*args, **options)
       end
 
-      def {{required.id}}(*args)
-        {{others[-1].id}}.{{required.id}}(*args)
-      end
-
-      {% for i in 0...others.size - 1 %}
-        def {{others[i].id}}(*args)
-          {{others[-1].id}}.{{others[i].id}}(*args)
+      {% if Crystal::VERSION == "0.18.0" %}
+        def {{method.id}}(*args, **options)
+          {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
+            yield *yield_args
+          end
         end
       {% end %}
     {% end %}


### PR DESCRIPTION
This is the way I wanted `delegate` to work in the first place, though the language couldn't express that.

This is a breaking change, but it makes code easier to read and understand:

```crystal
delegate foo, bar, baz
# vs.
delegate foo, bar, to: baz
```

Additionally, an extra overload that receives a block is added, which forwards all block arguments, so this covers now all cases except that when a block is captured.