### PR TITLE
Add `read_file` macro method

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1039,4 +1039,18 @@ describe "macro methods" do
       assert_macro "", %({{flag?(:foo)}}), [] of ASTNode, %(false)
     end
   end
+
+  describe "read_file" do
+    it "reads file (exists)" do
+      run(%q<
+        {{read_file("#{__DIR__}/../data/build")}}
+        >, filename = __FILE__).to_string.should eq(File.read("#{__DIR__}/../data/build"))
+    end
+
+    it "reads file (doesn't exists)" do
+      run(%q<
+        {{read_file("#{__DIR__}/../data/build_foo")}} ? 10 : 20
+        >, filename = __FILE__).to_i.should eq(20)
+    end
+  end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -39,6 +39,17 @@ module Crystal::Macros
   def raise(message) : NoReturn
   end
 
+  # Reads a file: if it exists, returns a StringLiteral with its contents;
+  # otherwise `nil` is returned.
+  #
+  # To read a file relative to where the macro is defined, use:
+  #
+  # ```
+  # read_file("#{__DIR__}/some_file.txt")
+  # ```
+  def read_file(filename) : StringLiteral | NilLiteral
+  end
+
   # Compiles and execute a Crystal program and returns its output
   # as a `MacroId`.
   #

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -19,6 +19,8 @@ module Crystal
         interpret_system(node)
       when "raise"
         interpret_raise(node)
+      when "read_file"
+        interpret_read_file(node)
       when "run"
         interpret_run(node)
       else
@@ -92,6 +94,20 @@ module Crystal
       end
 
       @last = Nop.new
+    end
+
+    def interpret_read_file(node)
+      if node.args.size == 1
+        node.args[0].accept self
+        filename = @last.to_macro_id
+        if File.exists?(filename)
+          @last = StringLiteral.new(File.read(filename))
+        else
+          @last = NilLiteral.new
+        end
+      else
+        node.wrong_number_of_arguments "macro call 'read_file'", node.args.size, 1
+      end
     end
 
     def interpret_system(node)


### PR DESCRIPTION
Check the diff for the docs.

The rationale for introducing this is that:
1. Embedding resources has already popped up several times, either here in github or talking with others personally.
2. One can currently use `cat filename.txt` but that's not portable, and one has to redirect errors to avoid getting a compilation error.
3. `read_file` returns `nil` if the file doesn't exist. With that, one can choose to deal with `nil` at compile time or runtime.
4. It should be a bit faster because an external process doesn't need to be started

~~This works for text files, but one can also use it for binary data: simply call `to_slice` afterwards to get the bytes (though we probably need a literal for binary data, but that's another issue)~~

Actually, it doesn't work for binary files because the string won't be able to be embedded at all. We could probably add a `read_binary_file` later, if we really want to do that.

Fixes #1649 and #2751
