### PR TITLE
GIve syntax error when using a local variable inside an assignment to…

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1210,6 +1210,8 @@ describe "Parser" do
 
   it_parses "Foo.foo(count: 3).bar { }", Call.new(Call.new("Foo".path, "foo", named_args: [NamedArgument.new("count", 3.int32)]), "bar", block: Block.new)
 
+  assert_syntax_error "a = a", "read before definition of local variable 'a'"
+
   assert_syntax_error "{{ {{ 1 }} }}", "can't nest macro expressions"
   assert_syntax_error "{{ {% begin %} }}", "can't nest macro expressions"
 

--- a/spec/compiler/type_inference/var_spec.cr
+++ b/spec/compiler/type_inference/var_spec.cr
@@ -36,18 +36,13 @@ describe "Type inference: var" do
     ", "undefined local variable or method 'something'"
   end
 
-  it "reports read before assignment" do
-    assert_error "a = a + 1",
-      "undefined local variable or method 'a'"
-  end
-
   it "reports there's no self" do
     assert_error "self", "there's no self in this scope"
   end
 
   it "reports variable always nil" do
     assert_error "1 == 2 ? (a = 1) : a",
-      "read before definition of 'a'"
+      "read before definition of local variable 'a'"
   end
 
   it "lets type on else side of if with a Bool | Nil union" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -75,7 +75,7 @@ struct Char
   # 'f' + "oo" # => "foo"
   # ```
   def +(str : String)
-    bytesize = str.bytesize + bytesize
+    bytesize = str.bytesize + self.bytesize
     String.new(bytesize) do |buffer|
       count = 0
       each_byte do |byte|

--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -55,7 +55,7 @@ module Crystal
           end
         end
 
-        str << name.gsub('@', '.')
+        str << self.name.gsub('@', '.')
 
         next_def = self.next
         while next_def

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1306,9 +1306,9 @@ module Crystal
             block_var = block_context.vars[arg.name]
             if i == splat_index
               exp_value = allocate_tuple(arg.type.as(TupleInstanceType)) do |tuple_type|
-                exp_value, exp_type = exp_values[j]
+                exp_value2, exp_type = exp_values[j]
                 j += 1
-                {exp_type, exp_value}
+                {exp_type, exp_value2}
               end
               exp_type = arg.type
             else

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -56,8 +56,8 @@ module Crystal
 
     def create_debug_type(type : EnumType)
       elements = type.types.map do |name, item|
-        value = if item.is_a?(Const) && (value = item.value).is_a?(NumberLiteral)
-                  value.value.to_i64 rescue value.value.to_u64
+        value = if item.is_a?(Const) && (value2 = item.value).is_a?(NumberLiteral)
+                  value2.value.to_i64 rescue value2.value.to_u64
                 else
                   0
                 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1049,7 +1049,7 @@ module Crystal
         end
       when "size"
         interpret_argless_method(method, args) do
-          type = type.instance_type
+          type = self.type.instance_type
           case type
           when TupleInstanceType
             NumberLiteral.new(type.tuple_types.size)
@@ -1061,7 +1061,7 @@ module Crystal
         end
       when "keys"
         interpret_argless_method(method, args) do
-          type = type.instance_type
+          type = self.type.instance_type
           if type.is_a?(NamedTupleInstanceType)
             ArrayLiteral.map(type.entries) { |entry| MacroId.new(entry.name) }
           else
@@ -1070,7 +1070,7 @@ module Crystal
         end
       when "[]"
         interpret_one_arg_method(method, args) do |arg|
-          type = type.instance_type
+          type = self.type.instance_type
           case type
           when NamedTupleInstanceType
             case arg

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -795,7 +795,7 @@ module Crystal
     def update(from = nil)
       return unless entries.all? &.value.type?
 
-      entries = entries.map do |element|
+      entries = self.entries.map do |element|
         NamedArgumentType.new(element.key, element.value.type)
       end
 

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -494,7 +494,7 @@ class Crystal::Call
     arg = args.first
     if arg.is_a?(SymbolLiteral)
       name = arg.value
-      index = index = instance_type.name_index(name)
+      index = instance_type.name_index(name)
       if index || nilable
         indexer_def = yield instance_type, (index || -1)
         indexer_match = Match.new(indexer_def, arg_types, MatchContext.new(owner, owner))

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -120,7 +120,7 @@ class Crystal::Call
 
         # Check if it's an instance variable that was never assigned a value
         if obj.is_a?(InstanceVar)
-          scope = scope.as(InstanceVarContainer)
+          scope = self.scope.as(InstanceVarContainer)
           ivar = scope.lookup_instance_var(obj.name)
           deps = ivar.dependencies?
           if deps && deps.size == 1 && deps.first.same?(mod.nil_var)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -157,7 +157,7 @@ module Crystal
         special_var = define_special_var(node.name, mod.nil_var)
         node.bind_to special_var
       else
-        node.raise "read before definition of '#{node.name}'"
+        node.raise "read before definition of local variable '#{node.name}'"
       end
     end
 

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -121,7 +121,7 @@ module Crystal
 
       # Forward block argument if any
       if uses_block_arg
-        block_arg = block_arg.not_nil!
+        block_arg = self.block_arg.not_nil!
         new_def.block_arg = block_arg.clone
         new_def.uses_block_arg = true
       end
@@ -193,7 +193,7 @@ module Crystal
 
       # Forward block argument if any
       if uses_block_arg
-        block_arg = block_arg.not_nil!
+        block_arg = self.block_arg.not_nil!
         init.block_arg = Var.new(block_arg.name)
       end
 
@@ -256,7 +256,7 @@ module Crystal
       expansion.yields = yields
       expansion.visibility = Visibility::Private if visibility.private?
       if uses_block_arg
-        block_arg = block_arg.not_nil!
+        block_arg = self.block_arg.not_nil!
         expansion.block_arg = block_arg.clone
         expansion.uses_block_arg = true
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -58,6 +58,7 @@ module Crystal
       #
       # then this flag is set to `true` when parsing `foo`'s arguments.
       @stop_on_do = false
+      @assigned_vars = [] of String
     end
 
     def wants_doc=(wants_doc)
@@ -360,7 +361,13 @@ module Crystal
               atomic = UninitializedVar.new(atomic, type).at(location)
               return atomic
             else
-              value = parse_op_assign_no_control
+              if atomic.is_a?(Var) && !var?(atomic.name)
+                @assigned_vars.push atomic.name
+                value = parse_op_assign_no_control
+                @assigned_vars.pop
+              else
+                value = parse_op_assign_no_control
+              end
             end
 
             pop_def if needs_new_scope
@@ -3661,6 +3668,10 @@ module Crystal
               end
               Var.new name
             else
+              if !force_call && !block_arg && !named_args && !global && !has_parentheses && @assigned_vars.includes?(name)
+                raise "read before definition of local variable '#{name}'", location
+              end
+
               Call.new nil, name, [] of ASTNode, nil, block_arg, named_args, global, name_column_number, has_parentheses
             end
           end


### PR DESCRIPTION
… that same local variable

Fixes #2142

I'm sending this as a PR because I'm not sure about this change.

Basically, this now gives a syntax error:

```crystal
def a
  20
end

a = a + 1
```

Previously that compiled fine: the `a` inside the assignment refers to the `a` method. If no such method exists you would get an error saying "undefined local variable or method 'a'". Now it always gives an error.

For this particular case, one can do:

```crystal
a = ::a + 1
```

Or

```crystal
a = a() + 1
```

If inside a method and we want to refer to an instance method, we must use `self.name` now, as you can see in the diff in several places.

The "downside" is that this also disallows declaring a variable with the same name inside an outer declaration:

```crystal
var = if some_condition
        var = 1
        do_something_else
        var
      end
```

Nor this:

```crystal
var = if (var = some_expression)
        10
      end
```

But maybe this is good? It basically makes it impossible to write code that shadows a variable inside an assignment to that variable, which can be very confusing. And when wanting to call a method with that same it forces one to use `self.`, making it more explicit and obvious.

Of course this is a breaking change.