### PR TITLE
Make `{"foo": 1}` also be a named tuple

### DIFF
--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -82,8 +82,9 @@ describe "Code gen: exception" do
 
       y = 1
       x = 1
+
       x = begin
-            y == 1 ? raise "Oh no!" : nil
+            y == 1 ? raise("Oh no!") : nil
             y = 10
           rescue
             y = 4
@@ -126,7 +127,7 @@ describe "Code gen: exception" do
       require "prelude"
 
       y = begin
-            1 > 0 ? raise "Oh no!" : 0
+            1 > 0 ? raise("Oh no!") : 0
           rescue
             2.1
           end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -916,4 +916,10 @@ describe Crystal::Formatter do
   assert_format "[\n  1, 2, # foo\n  3,\n]"
   assert_format "[\n  1, 2, # foo\n  3, 4,\n]"
   assert_format "foo { |x, *y| }"
+
+  assert_format %(foo "bar": 1, "baz qux": 2)
+  assert_format %(foo("bar": 1, "baz qux": 2))
+
+  assert_format %(Foo("bar": Int32, "baz qux": Float64))
+  assert_format %(x : {"foo bar": Int32})
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -67,4 +67,7 @@ describe "ASTNode#to_s" do
   expect_to_s "macro foo(**args)\nend"
   expect_to_s "macro foo(x, **args)\nend"
   expect_to_s "def foo(x y)\nend"
+  expect_to_s %(foo("bar baz": 2))
+  expect_to_s %(Foo("bar baz": Int32))
+  expect_to_s %({"foo bar": 1})
 end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1010,7 +1010,7 @@ describe "Array" do
       calls = Hash(String, Int32).new(0)
       a = ["foo", "a", "hello"]
       a.sort_by! { |e| calls[e] += 1; e.size }
-      calls.should eq({"foo": 1, "a": 1, "hello": 1})
+      calls.should eq({"foo" => 1, "a" => 1, "hello" => 1})
     end
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -138,12 +138,12 @@ describe "Hash" do
 
   describe "values_at" do
     it "returns the given keys" do
-      {"a": 1, "b": 2, "c": 3, "d": 4}.values_at("b", "a", "c").should eq({2, 1, 3})
+      {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.values_at("b", "a", "c").should eq({2, 1, 3})
     end
 
     it "raises when passed an invalid key" do
       expect_raises KeyError do
-        {"a": 1}.values_at("b")
+        {"a" => 1}.values_at("b")
       end
     end
 
@@ -154,25 +154,25 @@ describe "Hash" do
 
   describe "key" do
     it "returns the first key with the given value" do
-      hash = {"foo": "bar", "baz": "qux"}
+      hash = {"foo" => "bar", "baz" => "qux"}
       hash.key("bar").should eq("foo")
       hash.key("qux").should eq("baz")
     end
 
     it "raises when no key pairs with the given value" do
       expect_raises KeyError do
-        {"foo": "bar"}.key("qux")
+        {"foo" => "bar"}.key("qux")
       end
     end
 
     describe "if block is given," do
       it "returns the first key with the given value" do
-        hash = {"foo": "bar", "baz": "bar"}
+        hash = {"foo" => "bar", "baz" => "bar"}
         hash.key("bar") { |value| value.upcase }.should eq("foo")
       end
 
       it "yields the argument if no hash key pairs with the value" do
-        hash = {"foo": "bar"}
+        hash = {"foo" => "bar"}
         hash.key("qux") { |value| value.upcase }.should eq("QUX")
       end
     end
@@ -180,13 +180,13 @@ describe "Hash" do
 
   describe "key?" do
     it "returns the first key with the given value" do
-      hash = {"foo": "bar", "baz": "qux"}
+      hash = {"foo" => "bar", "baz" => "qux"}
       hash.key?("bar").should eq("foo")
       hash.key?("qux").should eq("baz")
     end
 
     it "returns nil if no key pairs with the given value" do
-      hash = {"foo": "bar", "baz": "qux"}
+      hash = {"foo" => "bar", "baz" => "qux"}
       hash.key?("foobar").should eq nil
       hash.key?("bazqux").should eq nil
     end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -9,7 +9,7 @@ class TestServer < TCPServer
       spawn do
         io = server.accept
         sleep read_time
-        response = HTTP::Client::Response.new(200, headers: HTTP::Headers{"Content-Type": "text/plain"}, body: "OK")
+        response = HTTP::Client::Response.new(200, headers: HTTP::Headers{"Content-Type" => "text/plain"}, body: "OK")
         response.to_io(io)
         io.flush
       end
@@ -32,11 +32,11 @@ module HTTP
     {% for method in %w(get post put head delete patch) %}
       typeof(Client.{{method.id}} "url")
       typeof(Client.new("host").{{method.id}}("uri"))
-      typeof(Client.new("host").{{method.id}}("uri", headers: Headers {"Content-Type": "text/plain"}))
+      typeof(Client.new("host").{{method.id}}("uri", headers: Headers {"Content-Type" => "text/plain"}))
       typeof(Client.new("host").{{method.id}}("uri", body: "body"))
     {% end %}
 
-    typeof(Client.post_form "url", {"a": "b"})
+    typeof(Client.post_form "url", {"a" => "b"})
     typeof(Client.new("host").basic_auth("username", "password"))
     typeof(Client.new("host").before_request { |req| })
     typeof(Client.new("host").close)

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -210,31 +210,31 @@ class HTTP::Client
     end
 
     it "returns content type and no charset" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type": "text/plain"})
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain"})
       response.content_type.should eq("text/plain")
       response.charset.should be_nil
     end
 
     it "returns content type and charset, removes semicolon" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type": "text/plain ; charset=UTF-8"})
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; charset=UTF-8"})
       response.content_type.should eq("text/plain")
       response.charset.should eq("UTF-8")
     end
 
     it "returns content type and no charset, other parameter (#2520)" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type": "text/plain ; colenc=U"})
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; colenc=U"})
       response.content_type.should eq("text/plain")
       response.charset.should be_nil
     end
 
     it "returns content type and charset, removes semicolon, with multiple parameters (#2520)" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type": "text/plain ; colenc=U ; charset=UTF-8"})
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; colenc=U ; charset=UTF-8"})
       response.content_type.should eq("text/plain")
       response.charset.should eq("UTF-8")
     end
 
     it "creates Response with status code 204, no body and Content-Length == 0 (#2512)" do
-      response = Response.new(204, version: "HTTP/1.0", body: "", headers: HTTP::Headers{"Content-Length": "0"})
+      response = Response.new(204, version: "HTTP/1.0", body: "", headers: HTTP::Headers{"Content-Length" => "0"})
       response.status_code.should eq(204)
       response.body.should eq("")
     end

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -8,24 +8,24 @@ describe HTTP::Headers do
   end
 
   it "is case insensitive" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     headers["foo"].should eq("bar")
   end
 
   it "it allows indifferent access for underscore and dash separated keys" do
-    headers = HTTP::Headers{"foo_Bar": "bar", "Foobar-foo": "baz"}
+    headers = HTTP::Headers{"foo_Bar" => "bar", "Foobar-foo" => "baz"}
     headers["foo-bar"].should eq("bar")
     headers["foobar_foo"].should eq("baz")
   end
 
   it "raises an error if header value contains invalid character" do
     expect_raises ArgumentError do
-      headers = HTTP::Headers{"invalid-header": "\r\nLocation: http://example.com"}
+      headers = HTTP::Headers{"invalid-header" => "\r\nLocation: http://example.com"}
     end
   end
 
   it "should retain the input casing" do
-    headers = HTTP::Headers{"FOO_BAR": "bar", "Foobar-foo": "baz"}
+    headers = HTTP::Headers{"FOO_BAR" => "bar", "Foobar-foo" => "baz"}
     serialized = String.build do |io|
       headers.each do |name, values|
         io << name << ": " << values.first << ";"
@@ -44,7 +44,7 @@ describe HTTP::Headers do
   end
 
   it "fetches" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     headers.fetch("foo").should eq("bar")
   end
 
@@ -65,24 +65,24 @@ describe HTTP::Headers do
   end
 
   it "has key" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     headers.has_key?("foo").should be_true
     headers.has_key?("bar").should be_false
   end
 
   it "deletes" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     headers.delete("foo").should eq("bar")
     headers.empty?.should be_true
   end
 
   it "equals another hash" do
-    headers = HTTP::Headers{"Foo": "bar"}
-    headers.should eq({"foo": "bar"})
+    headers = HTTP::Headers{"Foo" => "bar"}
+    headers.should eq({"foo" => "bar"})
   end
 
   it "dups" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     other = headers.dup
     other.should be_a(HTTP::Headers)
     other["foo"].should eq("bar")
@@ -92,7 +92,7 @@ describe HTTP::Headers do
   end
 
   it "clones" do
-    headers = HTTP::Headers{"Foo": "bar"}
+    headers = HTTP::Headers{"Foo" => "bar"}
     other = headers.clone
     other.should be_a(HTTP::Headers)
     other["foo"].should eq("bar")
@@ -116,7 +116,7 @@ describe HTTP::Headers do
   end
 
   it "gets all values" do
-    headers = HTTP::Headers{"foo": "bar"}
+    headers = HTTP::Headers{"foo" => "bar"}
     headers.get("foo").should eq(["bar"])
 
     headers.get?("foo").should eq(["bar"])
@@ -124,24 +124,24 @@ describe HTTP::Headers do
   end
 
   it "does to_s" do
-    headers = HTTP::Headers{"Foo_quux": "bar", "Baz-Quux": ["a", "b"]}
+    headers = HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}
     headers.to_s.should eq(%(HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}))
   end
 
   it "merges and return self" do
     headers = HTTP::Headers.new
-    headers.should be headers.merge!({"foo": "bar"})
+    headers.should be headers.merge!({"foo" => "bar"})
   end
 
   it "matches word" do
-    headers = HTTP::Headers{"foo": "bar"}
+    headers = HTTP::Headers{"foo" => "bar"}
     headers.includes_word?("foo", "bar").should be_true
     headers.includes_word?("foo", "ba").should be_false
     headers.includes_word?("foo", "ar").should be_false
   end
 
   it "matches word with comma separated value" do
-    headers = HTTP::Headers{"foo": "bar, baz"}
+    headers = HTTP::Headers{"foo" => "bar, baz"}
     headers.includes_word?("foo", "bar").should be_true
     headers.includes_word?("foo", "baz").should be_true
     headers.includes_word?("foo", "ba").should be_false

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -22,9 +22,9 @@ describe HTTP::WebSocketHandler do
     it "gives upgrade response for websocket upgrade request with '{{connection.id}}' request" do
       io = MemoryIO.new
       headers = HTTP::Headers{
-        "Upgrade":           "websocket",
-        "Connection":        {{connection}},
-        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+        "Upgrade" =>           "websocket",
+        "Connection" =>        {{connection}},
+        "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
       }
       request = HTTP::Request.new("GET", "/", headers: headers)
       response = HTTP::Server::Response.new(io)

--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -46,8 +46,8 @@ describe JSON::Any do
     end
 
     it "gets hash" do
-      JSON.parse(%({"foo": "bar"})).as_h.should eq({"foo": "bar"})
-      JSON.parse(%({"foo": "bar"})).as_h?.should eq({"foo": "bar"})
+      JSON.parse(%({"foo": "bar"})).as_h.should eq({"foo" => "bar"})
+      JSON.parse(%({"foo": "bar"})).as_h?.should eq({"foo" => "bar"})
       JSON.parse("true").as_h?.should be_nil
     end
   end

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -242,7 +242,7 @@ describe "JSON mapping" do
   it "parses json with any" do
     json = JSONWithAny.from_json(%({"name": "Hi", "any": [{"x": 1}, 2, "hey", true, false, 1.5, null]}))
     json.name.should eq("Hi")
-    json.any.raw.should eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
+    json.any.raw.should eq([{"x" => 1}, 2, "hey", true, false, 1.5, nil])
     json.to_json.should eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
   end
 

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -14,6 +14,12 @@ describe "NamedTuple" do
     t.should eq({foo: 1, bar: 2})
     t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
 
+    {% if Crystal::VERSION == "0.18.0" %}
+      t = NamedTuple("foo bar": Int32, "baz qux": Int32).from({"foo bar" => 1, "baz qux" => 2})
+      t.should eq({"foo bar": 1, "baz qux": 2})
+      t.class.should eq(NamedTuple("foo bar": Int32, "baz qux": Int32))
+    {% end %}
+
     expect_raises ArgumentError do
       NamedTuple(foo: Int32, bar: Int32).from({:foo => 1})
     end
@@ -233,6 +239,11 @@ describe "NamedTuple" do
 
     tup1[:b] << 4
     tup2[:b].should eq([1, 2, 3])
+
+    {% if Crystal::VERSION == "0.18.0" %}
+      tup2 = {"foo bar": 1}
+      tup2.clone.should eq(tup2)
+    {% end %}
   end
 
   it "does keys" do

--- a/spec/std/oauth/consumer_spec.cr
+++ b/spec/std/oauth/consumer_spec.cr
@@ -31,7 +31,7 @@ describe OAuth::Consumer do
 
     request_token = OAuth::RequestToken.new "request_token", "request_secret"
     consumer.get_access_token(request_token, "oauth_verifier")
-    consumer.get_access_token(request_token, "oauth_verifier", {"a": "b"})
+    consumer.get_access_token(request_token, "oauth_verifier", {"a" => "b"})
 
     access_token = OAuth::AccessToken.new "token", "secret"
 

--- a/spec/std/oauth/signature_spec.cr
+++ b/spec/std/oauth/signature_spec.cr
@@ -22,7 +22,7 @@ describe OAuth::Signature do
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
-        "oauth_callback": "some+callback",
+        "oauth_callback" => "some+callback",
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
       base_string.should eq("POST&http%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
@@ -35,7 +35,7 @@ describe OAuth::Signature do
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
-        "oauth_callback": "some+callback",
+        "oauth_callback" => "some+callback",
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
       base_string.should eq("POST&http%3A%2F%2Fsome.host%3A5678%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
@@ -48,7 +48,7 @@ describe OAuth::Signature do
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
-        "oauth_callback": "some+callback",
+        "oauth_callback" => "some+callback",
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
       base_string.should eq("POST&https%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")

--- a/spec/std/simple_hash_spec.cr
+++ b/spec/std/simple_hash_spec.cr
@@ -24,7 +24,7 @@ describe "SimpleHash" do
 
   describe "[]?" do
     it "returns nil if the key is missing" do
-      a = SimpleHash{"one": 1, "two": 2}
+      a = SimpleHash{"one" => 1, "two" => 2}
       a["three"]?.should eq(nil)
       a[:one]?.should eq(nil)
     end
@@ -58,7 +58,7 @@ describe "SimpleHash" do
 
   describe "has_key?" do
     it "returns true if the given key is present, false otherwise" do
-      a = SimpleHash{"one": 1, "two": 2}
+      a = SimpleHash{"one" => 1, "two" => 2}
       a.has_key?("one").should be_true
       a.has_key?("two").should be_true
       a.has_key?(:one).should be_false
@@ -67,7 +67,7 @@ describe "SimpleHash" do
 
   describe "delete" do
     it "deletes the key-value pair corresponding to the given key" do
-      a = SimpleHash{"one": 1, "two": 2}
+      a = SimpleHash{"one" => 1, "two" => 2}
       a.delete("two")
       a["two"]?.should eq(nil)
       a["one"].should eq(1)
@@ -76,7 +76,7 @@ describe "SimpleHash" do
 
   describe "dup" do
     it "returns a duplicate of the SimpleHash" do
-      a = SimpleHash{"one": "1", "two": "2"}
+      a = SimpleHash{"one" => "1", "two" => "2"}
       a.should eq(a.dup)
     end
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -791,8 +791,8 @@ describe "String" do
 
     it "subs with regex and hash" do
       str = "hello"
-      str.sub(/(he|l|o)/, {"he": "ha", "l": "la"}).should eq("hallo")
-      str.sub(/(he|l|o)/, {"l": "la"}).should be(str)
+      str.sub(/(he|l|o)/, {"he" => "ha", "l" => "la"}).should eq("hallo")
+      str.sub(/(he|l|o)/, {"l" => "la"}).should be(str)
     end
 
     it "subs using $~" do
@@ -943,7 +943,7 @@ describe "String" do
 
     it "gsubs with regex and hash" do
       str = "hello"
-      str.gsub(/(he|l|o)/, {"he": "ha", "l": "la"}).should eq("halala")
+      str.gsub(/(he|l|o)/, {"he" => "ha", "l" => "la"}).should eq("halala")
     end
 
     it "gsubs using $~" do
@@ -1629,18 +1629,18 @@ describe "String" do
 
   context "%" do
     it "substitutes one placeholder" do
-      res = "change %{this}" % {"this": "nothing"}
+      res = "change %{this}" % {"this" => "nothing"}
       res.should eq "change nothing"
     end
 
     it "substitutes multiple placeholder" do
-      res = "change %{this} and %{more}" % {"this": "nothing", "more": "something"}
+      res = "change %{this} and %{more}" % {"this" => "nothing", "more" => "something"}
       res.should eq "change nothing and something"
     end
 
     it "throws an error when the key is not found" do
       expect_raises KeyError do
-        "change %{this}" % {"that": "wrong key"}
+        "change %{this}" % {"that" => "wrong key"}
       end
     end
 
@@ -1652,12 +1652,12 @@ describe "String" do
 
     it "raises on unbalanced curly" do
       expect_raises(ArgumentError, "malformed name - unmatched parenthesis") do
-        "change %{this" % {"this": 1}
+        "change %{this" % {"this" => 1}
       end
     end
 
     it "applies formatting to %<...> placeholder" do
-      res = "change %<this>.2f" % {"this": 23.456}
+      res = "change %<this>.2f" % {"this" => 23.456}
       res.should eq "change 23.46"
     end
   end

--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -75,7 +75,7 @@ module XML
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
         </feed>
         ))
-      nodes = doc.xpath("//atom:feed", namespaces: {"atom": "http://www.w3.org/2005/Atom"}).as(NodeSet)
+      nodes = doc.xpath("//atom:feed", namespaces: {"atom" => "http://www.w3.org/2005/Atom"}).as(NodeSet)
       nodes.size.should eq(1)
       nodes[0].name.should eq("feed")
       ns = nodes[0].namespace.not_nil!
@@ -105,7 +105,7 @@ module XML
           <person id="2"/>
         </feed>
         ))
-      nodes = doc.xpath("//feed/person[@id=$value]", variables: {"value": 2}).as(NodeSet)
+      nodes = doc.xpath("//feed/person[@id=$value]", variables: {"value" => 2}).as(NodeSet)
       nodes.size.should eq(1)
       nodes[0]["id"].should eq("2")
     end

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -16,7 +16,7 @@ describe YAML::Any do
     end
 
     it "gets hash" do
-      YAML.parse("foo: bar").as_h.should eq({"foo": "bar"})
+      YAML.parse("foo: bar").as_h.should eq({"foo" => "bar"})
     end
   end
 

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -55,7 +55,7 @@ describe "YAML" do
           bar:
             !!str '<<': *foo
         ))
-        doc.should eq({"foo": {"hello": "world"}, "bar": {"<<": {"hello": "world"}}})
+        doc.should eq({"foo" => {"hello" => "world"}, "bar" => {"<<" => {"hello" => "world"}}})
       end
 
       it "doesn't merge empty mapping" do
@@ -64,7 +64,7 @@ describe "YAML" do
           bar:
             <<: *foo
         ))
-        doc["bar"].should eq({"<<": ""})
+        doc["bar"].should eq({"<<" => ""})
       end
 
       it "doesn't merge arrays" do
@@ -74,7 +74,7 @@ describe "YAML" do
           bar:
             <<: *foo
         ))
-        doc["bar"].should eq({"<<": ["1"]})
+        doc["bar"].should eq({"<<" => ["1"]})
       end
 
       it "has correct line/number info (#2585)" do

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -174,9 +174,9 @@ class Crystal::Command
     end
 
     vars = {
-      "CRYSTAL_CACHE_DIR": CacheDir.instance.dir,
-      "CRYSTAL_PATH":      CrystalPath.default_path,
-      "CRYSTAL_VERSION":   Config.version || "",
+      "CRYSTAL_CACHE_DIR" => CacheDir.instance.dir,
+      "CRYSTAL_PATH"      => CrystalPath.default_path,
+      "CRYSTAL_VERSION"   => Config.version || "",
     }
 
     if ARGV.empty?

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -313,6 +313,11 @@ module Crystal
       named_tuple_of(entries)
     end
 
+    def named_tuple_of(hash : NamedTuple)
+      entries = hash.map { |k, v| NamedArgumentType.new(k.to_s, v.as(Type)) }
+      named_tuple_of(entries)
+    end
+
     def named_tuple_of(entries : Array(NamedArgumentType))
       named_tuple.instantiate_named_args(entries)
     end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -226,7 +226,7 @@ module Crystal
         end
       end
 
-      meta_vars = MetaVars{"self": MetaVar.new("self", @self_type)}
+      meta_vars = MetaVars{"self" => MetaVar.new("self", @self_type)}
       visitor = MainVisitor.new(program, meta_vars)
       node.expressions.each &.accept visitor
       @type = program.type_merge node.expressions

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -144,7 +144,7 @@ module Crystal
       @str << "{"
       node.entries.each_with_index do |entry, i|
         @str << ", " if i > 0
-        @str << entry.key
+        visit_named_arg_name(entry.key)
         @str << ": "
         entry.value.accept self
       end
@@ -421,7 +421,7 @@ module Crystal
     end
 
     def visit(node : NamedArgument)
-      @str << node.name
+      visit_named_arg_name(node.name)
       @str << ": "
       node.value.accept self
       false
@@ -814,7 +814,7 @@ module Crystal
       if named_args = node.named_args
         named_args.each do |named_arg|
           @str << ", " if printed_arg
-          @str << named_arg.name
+          visit_named_arg_name(named_arg.name)
           @str << ": "
           named_arg.value.accept self
           printed_arg = true
@@ -823,6 +823,14 @@ module Crystal
 
       @str << ")"
       false
+    end
+
+    def visit_named_arg_name(name)
+      if Symbol.needs_quotes?(name)
+        name.inspect(@str)
+      else
+        @str << name
+      end
     end
 
     def visit(node : Underscore)
@@ -1342,7 +1350,7 @@ module Crystal
         if named_args = node.named_args
           @str << ", " if printed_arg
           named_args.each do |named_arg|
-            @str << named_arg.name
+            visit_named_arg_name(named_arg.name)
             @str << ": "
             named_arg.value.accept self
             printed_arg = true

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -793,9 +793,7 @@ module Crystal
       start_line = @line
       start_column = @column
       found_in_same_line = false
-
-      write @token
-      next_token
+      format_named_argument_name(entry.key)
       slash_is_regex!
       write_token :":", " "
       middle_column = @column
@@ -805,6 +803,15 @@ module Crystal
 
       if found_in_same_line
         @hash_in_same_line << hash.object_id
+      end
+    end
+
+    def format_named_argument_name(name)
+      if @token.type == :DELIMITER_START
+        StringLiteral.new(name).accept self
+      else
+        write @token
+        next_token
       end
     end
 
@@ -2335,8 +2342,8 @@ module Crystal
     end
 
     def visit(node : NamedArgument)
-      write node.name
-      next_token_skip_space_or_newline
+      format_named_argument_name(node.name)
+      skip_space_or_newline
       write_token :":", " "
       skip_space_or_newline
       accept node.value

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2077,7 +2077,12 @@ module Crystal
       io << "{"
       @entries.each_with_index do |entry, i|
         io << ", " if i > 0
-        io << entry.name << ": "
+        if Symbol.needs_quotes?(entry.name)
+          entry.name.inspect(io)
+        else
+          io << entry.name
+        end
+        io << ": "
         entry.type.to_s_with_options(io, skip_union_parens: true)
       end
       io << "}"

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -72,7 +72,11 @@ struct NamedTuple
     {% begin %}
       NamedTuple.new(
       {% for key, value in T %}
-        {{key}}: self[{{key.symbolize}}].cast(hash.fetch(:{{key}}) { hash["{{key}}"] }),
+        {% if Crystal::VERSION == "0.18.0" %}
+          {{key.stringify}}: self[{{key.symbolize}}].cast(hash.fetch({{key.symbolize}}) { hash["{{key}}"] }),
+        {% else %}
+          {{key}}: self[{{key.symbolize}}].cast(hash.fetch({{key.symbolize}}) { hash["{{key}}"] }),
+        {% end %}
       {% end %}
       )
     {% end %}
@@ -208,7 +212,12 @@ struct NamedTuple
       {% if i > 0 %}
         io << ", "
       {% end %}
-      io << {{key.stringify}}
+      key = {{key.stringify}}
+      if Symbol.needs_quotes?(key)
+        key.inspect(io)
+      else
+        io << key
+      end
       io << ": "
       self[{{key.symbolize}}].inspect(io)
     {% end %}
@@ -412,7 +421,11 @@ struct NamedTuple
     {% begin %}
       {
         {% for key in T %}
-          {{key}}: self[{{key.symbolize}}].clone,
+          {% if Crystal::VERSION == "0.18.0" %}
+            {{key.stringify}}: self[{{key.symbolize}}].clone,
+          {% else %}
+            {{key}}: self[{{key.symbolize}}].clone,
+          {% end %}
         {% end %}
       }
     {% end %}

--- a/src/oauth/consumer.cr
+++ b/src/oauth/consumer.cr
@@ -11,7 +11,7 @@ class OAuth::Consumer
   end
 
   def get_request_token(oauth_callback = "oob")
-    with_new_http_client(nil, nil, {"oauth_callback": oauth_callback}) do |client|
+    with_new_http_client(nil, nil, {"oauth_callback" => oauth_callback}) do |client|
       response = client.post @request_token_uri
       handle_response(response) do
         RequestToken.from_response(response.body)

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -85,12 +85,12 @@ struct Char
   end
 
   {% for op, desc in {
-                       "==": "equal to",
-                       "!=": "not equal to",
-                       "<":  "less than",
-                       "<=": "less than or equal to",
-                       ">":  "greater than",
-                       ">=": "greater than or equal to",
+                       "==" => "equal to",
+                       "!=" => "not equal to",
+                       "<"  => "less than",
+                       "<=" => "less than or equal to",
+                       ">"  => "greater than",
+                       ">=" => "greater than or equal to",
                      } %}
     # Returns true if *self*'s codepoint is {{desc.id}} *other*'s codepoint.
     @[Primitive(:binary)]
@@ -263,7 +263,7 @@ end
   {% ints = %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
   {% floats = %w(Float32 Float64) %}
   {% nums = %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64 Float32 Float64) %}
-  {% binaries = {"+": "adding", "-": "subtracting", "*": "multiplying", "/": "dividing"} %}
+  {% binaries = {"+" => "adding", "-" => "subtracting", "*" => "multiplying", "/" => "dividing"} %}
 
   {% for num in nums %}
     struct {{num.id}}
@@ -281,12 +281,12 @@ end
 
       {% for num2 in nums %}
         {% for op, desc in {
-                             "==": "equal to",
-                             "!=": "not equal to",
-                             "<":  "less than",
-                             "<=": "less than or equal to",
-                             ">":  "greater than",
-                             ">=": "greater than or equal to",
+                             "==" => "equal to",
+                             "!=" => "not equal to",
+                             "<"  => "less than",
+                             "<=" => "less than or equal to",
+                             ">"  => "greater than",
+                             ">=" => "greater than or equal to",
                            } %}
           # Returns true if *self* is {{desc.id}} *other*.
           @[Primitive(:binary)]


### PR DESCRIPTION
Fixes #2631

This makes `"foo bar": 1` (string literal, colon, expression) mean a named tuple literal everywhere now, and only `=>` can be used for a hash literal.

The places where this is applicable is:
* Named tuples: `{"foo bar": 1}`
* Named tuple types: `x : {"foo bar": Int32}`
* NamedTuple instantiation: `NamedTuple("foo bar": Int32)`
* Calls: `foo bar: 1, "baz qux": 3`

I tried using this new syntax in [html_builder](https://github.com/crystal-lang/html_builder) and it worked well:

```crystal
require "./src/html_builder"

string =
  HTML.build do
    html do
      body do
        a(href: "http://crystal-lang.org", "data-awesome": "true") do
          text "crystal is awesome"
        end
      end
    end
  end

puts string # => "<html><body><a href="http://crystal-lang.org" data-awesome="true">crystal is awesome</a></body></html>"
```

This is a breaking change, but it makes things more consistent, and allows things like the above.
