### PR TITLE
Replace and rename all mentions of SSL with TLS

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -25,7 +25,7 @@ module HTTP
   describe Client do
     typeof(Client.new("host"))
     typeof(Client.new("host", port: 8080))
-    typeof(Client.new("host", ssl: true))
+    typeof(Client.new("host", tls: true))
     typeof(Client.new(URI.new))
     typeof(Client.new(URI.parse("http://www.example.com")))
 
@@ -49,39 +49,39 @@ module HTTP
     describe "from URI" do
       it "has sane defaults" do
         cl = Client.new(URI.parse("http://example.com"))
-        cl.ssl?.should be_nil
+        cl.tls?.should be_nil
         cl.port.should eq(80)
       end
 
       ifdef !without_openssl
-        it "detects ssl" do
+        it "detects HTTPS" do
           cl = Client.new(URI.parse("https://example.com"))
-          cl.ssl?.should be_truthy
+          cl.tls?.should be_truthy
           cl.port.should eq(443)
         end
 
         it "keeps context" do
           ctx = OpenSSL::SSL::Context::Client.new
           cl = Client.new(URI.parse("https://example.com"), ctx)
-          cl.ssl.should be(ctx)
+          cl.tls.should be(ctx)
         end
 
         it "doesn't take context for HTTP" do
           ctx = OpenSSL::SSL::Context::Client.new
-          expect_raises(ArgumentError, "SSL context given") do
+          expect_raises(ArgumentError, "TLS context given") do
             Client.new(URI.parse("http://example.com"), ctx)
           end
         end
 
         it "allows for specified ports" do
           cl = Client.new(URI.parse("https://example.com:9999"))
-          cl.ssl?.should be_truthy
+          cl.tls?.should be_truthy
           cl.port.should eq(9999)
         end
       else
-        it "raises when trying to activate SSL" do
+        it "raises when trying to activate TLS" do
           expect_raises do
-            Client.new "example.org", 443, ssl: true
+            Client.new "example.org", 443, tls: true
           end
         end
       end

--- a/spec/std/oauth/signature_spec.cr
+++ b/spec/std/oauth/signature_spec.cr
@@ -18,39 +18,39 @@ describe OAuth::Signature do
     it "computes without port in host" do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
-      ssl = false
+      tls = false
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
         "oauth_callback" => "some+callback",
       }
-      base_string = signature.base_string request, ssl, ts, "nonce"
+      base_string = signature.base_string request, tls, ts, "nonce"
       base_string.should eq("POST&http%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
     it "computes with port in host" do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host:5678"
-      ssl = false
+      tls = false
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
         "oauth_callback" => "some+callback",
       }
-      base_string = signature.base_string request, ssl, ts, "nonce"
+      base_string = signature.base_string request, tls, ts, "nonce"
       base_string.should eq("POST&http%3A%2F%2Fsome.host%3A5678%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
-    it "computes when ssl" do
+    it "computes when TLS" do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
-      ssl = true
+      tls = true
       ts = "1234"
 
       signature = OAuth::Signature.new "consumer_key", "consumer secret", extra_params: {
         "oauth_callback" => "some+callback",
       }
-      base_string = signature.base_string request, ssl, ts, "nonce"
+      base_string = signature.base_string request, tls, ts, "nonce"
       base_string.should eq("POST&https%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
   end
@@ -60,7 +60,7 @@ describe OAuth::Signature do
     request = HTTP::Request.new "POST", "/1/statuses/update.json?include_entities=true", body: "status=Hello%20Ladies%20%2b%20Gentlemen%2c%20a%20signed%20OAuth%20request%21"
     request.headers["Host"] = "api.twitter.com"
     request.headers["Content-type"] = "application/x-www-form-urlencoded"
-    ssl = true
+    tls = true
     ts = "1318622958"
     nonce = "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg"
     consumer_key = "xvz1evFS4wEEPTGEFPHBog"
@@ -69,17 +69,17 @@ describe OAuth::Signature do
     oauth_token_secret = "LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE"
 
     signature = OAuth::Signature.new consumer_key, consumer_secret, oauth_token: oauth_token, token_shared_secret: oauth_token_secret
-    base_string = signature.base_string(request, ssl, ts, nonce)
+    base_string = signature.base_string(request, tls, ts, nonce)
     expected_base_string = "POST&https%3A%2F%2Fapi.twitter.com%2F1%2Fstatuses%2Fupdate.json&include_entities%3Dtrue%26oauth_consumer_key%3Dxvz1evFS4wEEPTGEFPHBog%26oauth_nonce%3DkYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1318622958%26oauth_token%3D370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb%26oauth_version%3D1.0%26status%3DHello%2520Ladies%2520%252B%2520Gentlemen%252C%2520a%2520signed%2520OAuth%2520request%2521"
 
     base_string.should eq(expected_base_string)
 
-    computed = signature.compute request, ssl, ts, nonce
+    computed = signature.compute request, tls, ts, nonce
     expected_computed = "tnnArxj06cWHq44gCs1OSKk/jLY="
 
     computed.should eq(expected_computed)
 
-    header = signature.authorization_header request, ssl, ts, nonce
+    header = signature.authorization_header request, tls, ts, nonce
     expected_header = %(OAuth oauth_consumer_key="xvz1evFS4wEEPTGEFPHBog", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1318622958", oauth_nonce="kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg", oauth_signature="tnnArxj06cWHq44gCs1OSKk%2FjLY%3D", oauth_token="370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb", oauth_version="1.0")
 
     header.should eq(expected_header)

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -3,131 +3,131 @@ require "openssl"
 
 describe OpenSSL::SSL::Context do
   it "new for client" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.options.should eq(OpenSSL::SSL.options_flags(
+    context = OpenSSL::SSL::Context::Client.new
+    context.options.should eq(OpenSSL::SSL.options_flags(
       ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE
     ))
-    ssl_context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+    context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
 
     OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
   end
 
   it "new for server" do
-    ssl_context = OpenSSL::SSL::Context::Server.new
-    ssl_context.options.should eq(OpenSSL::SSL.options_flags(
+    context = OpenSSL::SSL::Context::Server.new
+    context.options.should eq(OpenSSL::SSL.options_flags(
       ALL, NO_SSLV2, NO_SSLV3, NO_SESSION_RESUMPTION_ON_RENEGOTIATION, SINGLE_ECDH_USE, SINGLE_DH_USE, CIPHER_SERVER_PREFERENCE
     ))
-    ssl_context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
 
     OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)
   end
 
   it "insecure for client" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.should be_a(OpenSSL::SSL::Context::Client)
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
-    ssl_context.options.no_ssl_v3?.should_not be_true
-    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.should be_a(OpenSSL::SSL::Context::Client)
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    context.options.no_ssl_v3?.should_not be_true
+    context.modes.should eq(OpenSSL::SSL::Modes::None)
 
     OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
   end
 
   it "insecure for server" do
-    ssl_context = OpenSSL::SSL::Context::Server.insecure
-    ssl_context.should be_a(OpenSSL::SSL::Context::Server)
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
-    ssl_context.options.no_ssl_v3?.should_not be_true
-    ssl_context.modes.should eq(OpenSSL::SSL::Modes::None)
+    context = OpenSSL::SSL::Context::Server.insecure
+    context.should be_a(OpenSSL::SSL::Context::Server)
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    context.options.no_ssl_v3?.should_not be_true
+    context.modes.should eq(OpenSSL::SSL::Modes::None)
 
     OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end
 
   it "sets certificate chain" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.certificate_chain = File.join(__DIR__, "openssl.crt")
+    context = OpenSSL::SSL::Context::Client.new
+    context.certificate_chain = File.join(__DIR__, "openssl.crt")
   end
 
   it "fails to set certificate chain" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = File.join(__DIR__, "unknown.crt") }
-    expect_raises(OpenSSL::Error) { ssl_context.certificate_chain = __FILE__ }
+    context = OpenSSL::SSL::Context::Client.new
+    expect_raises(OpenSSL::Error) { context.certificate_chain = File.join(__DIR__, "unknown.crt") }
+    expect_raises(OpenSSL::Error) { context.certificate_chain = __FILE__ }
   end
 
   it "sets private key" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.private_key = File.join(__DIR__, "openssl.key")
+    context = OpenSSL::SSL::Context::Client.new
+    context.private_key = File.join(__DIR__, "openssl.key")
   end
 
   it "fails to set private key" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    expect_raises(OpenSSL::Error) { ssl_context.private_key = File.join(__DIR__, "unknown.key") }
-    expect_raises(OpenSSL::Error) { ssl_context.private_key = __FILE__ }
+    context = OpenSSL::SSL::Context::Client.new
+    expect_raises(OpenSSL::Error) { context.private_key = File.join(__DIR__, "unknown.key") }
+    expect_raises(OpenSSL::Error) { context.private_key = __FILE__ }
   end
 
   it "sets ciphers" do
     ciphers = "EDH+aRSA DES-CBC3-SHA !RC4"
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    (ssl_context.ciphers = ciphers).should eq(ciphers)
+    context = OpenSSL::SSL::Context::Client.new
+    (context.ciphers = ciphers).should eq(ciphers)
   end
 
   it "adds temporary ecdh curve (P-256)" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.set_tmp_ecdh_key
+    context = OpenSSL::SSL::Context::Client.new
+    context.set_tmp_ecdh_key
   end
 
   it "adds options" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.remove_options(ssl_context.options) # reset
-    ssl_context.add_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
-    ssl_context.add_options(OpenSSL::SSL.options_flags(NO_SSLV2, NO_SSLV3))
-               .should eq(OpenSSL::SSL.options_flags(ALL, NO_SSLV2, NO_SSLV3))
+    context = OpenSSL::SSL::Context::Client.new
+    context.remove_options(context.options) # reset
+    context.add_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    context.add_options(OpenSSL::SSL.options_flags(NO_SSLV2, NO_SSLV3))
+           .should eq(OpenSSL::SSL.options_flags(ALL, NO_SSLV2, NO_SSLV3))
   end
 
   it "removes options" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.add_options(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
-    ssl_context.remove_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::NO_SSLV2)
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.add_options(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
+    context.remove_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.add_options(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
-    ssl_context.options.should eq(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.add_options(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
+    context.options.should eq(OpenSSL::SSL.options_flags(ALL, NO_SSLV2))
   end
 
   it "adds modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.add_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
-    ssl_context.add_modes(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
-               .should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.add_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
+    context.add_modes(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
+           .should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "removes modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.add_modes(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
-    ssl_context.remove_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.add_modes(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.remove_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
   end
 
   it "returns modes" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.add_modes(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
-    ssl_context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.add_modes(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.modes.should eq(OpenSSL::SSL.modes_flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
   it "sets the verify mode" do
-    ssl_context = OpenSSL::SSL::Context::Client.new
-    ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
-    ssl_context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-    ssl_context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
+    context = OpenSSL::SSL::Context::Client.new
+    context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
+    context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
+    context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
   end
 
   {% if LibSSL::OPENSSL_102 %}
   it "alpn_protocol=" do
-    ssl_context = OpenSSL::SSL::Context::Client.insecure
-    ssl_context.alpn_protocol = "h2"
+    context = OpenSSL::SSL::Context::Client.insecure
+    context.alpn_protocol = "h2"
   end
   {% end %}
 end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -69,18 +69,18 @@ class HTTP::Client
   # ```
   getter port : Int32
 
-  # If this client uses SSL, returns its `OpenSSL::SSL::Context::Client`, raises otherwise.
+  # If this client uses TLS, returns its `OpenSSL::SSL::Context::Client`, raises otherwise.
   #
   # Changes made after the initial request will have no effect.
   #
   # ```
-  # client = HTTP::Client.new "www.example.com", ssl: true
-  # client.ssl # => #<OpenSSL::SSL::Context::Client ...>
+  # client = HTTP::Client.new "www.example.com", tls: true
+  # client.tls # => #<OpenSSL::SSL::Context::Client ...>
   # ```
   ifdef without_openssl
-    getter! ssl : Nil
+    getter! tls : Nil
   else
-    getter! ssl : OpenSSL::SSL::Context::Client?
+    getter! tls : OpenSSL::SSL::Context::Client?
   end
 
   # Whether automatic compression/decompression is enabled.
@@ -96,62 +96,62 @@ class HTTP::Client
   @connect_timeout : Float64?
   @read_timeout : Float64?
 
-  # Creates a new HTTP client with the given *host*, *port* and *ssl*
+  # Creates a new HTTP client with the given *host*, *port* and *tls*
   # configurations. If no port is given, the default one will
-  # be used depending on the *ssl* arguments: 80 for if *ssl* is `false`,
-  # 443 if *ssl* is truthy. If *ssl* is `true` a new `OpenSSL::SSL::Context::Client` will
-  # be used, else the given one. In any case the active context can be accessed through `ssl`.
+  # be used depending on the *tls* arguments: 80 for if *tls* is `false`,
+  # 443 if *tls* is truthy. If *tls* is `true` a new `OpenSSL::SSL::Context::Client` will
+  # be used, else the given one. In any case the active context can be accessed through `tls`.
   ifdef without_openssl
-    def initialize(@host, port = nil, ssl : Bool = false)
-      @ssl = nil
-      if ssl
-        raise "HTTP::Client ssl is disabled because `-D without_openssl` was passed at compile time"
+    def initialize(@host, port = nil, tls : Bool = false)
+      @tls = nil
+      if tls
+        raise "HTTP::Client TLS is disabled because `-D without_openssl` was passed at compile time"
       end
 
-      @port = (port || (@ssl ? 443 : 80)).to_i
+      @port = (port || (@tls ? 443 : 80)).to_i
       @compress = true
     end
   else
-    def initialize(@host, port = nil, ssl : Bool | OpenSSL::SSL::Context::Client = false)
-      @ssl = case ssl
+    def initialize(@host, port = nil, tls : Bool | OpenSSL::SSL::Context::Client = false)
+      @tls = case tls
              when true
                OpenSSL::SSL::Context::Client.new
              when OpenSSL::SSL::Context::Client
-               ssl
+               tls
              when false
                nil
              end
 
-      @port = (port || (@ssl ? 443 : 80)).to_i
+      @port = (port || (@tls ? 443 : 80)).to_i
       @compress = true
     end
   end
 
   # Creates a new HTTP client from a URI. Parses the *host*, *port*,
-  # and *ssl* configuration from the url provided. Port defaults to
+  # and *tls* configuration from the url provided. Port defaults to
   # 80 if not specified unless using the https protocol, which defaults
-  # to port 443 and sets ssl to `true`.
+  # to port 443 and sets tls to `true`.
   #
   # ```
   # uri = URI.parse("https://secure.example.com")
   # client = HTTP::Client.new(uri)
   #
-  # client.ssl? # => true
+  # client.tls? # => true
   # client.get("/")
   # ```
   # This constructor will *ignore* any path or query segments in the URI
   # as those will need to be passed to the client when a request is made.
   #
-  # If *ssl* is given it will be used, if not a new SSL context will be created.
-  # If *ssl* is given and *uri* is a HTTP URI, `ArgumentError` is raised.
-  # In any case the active context can be accessed through `ssl`.
+  # If *tls* is given it will be used, if not a new TLS context will be created.
+  # If *tls* is given and *uri* is a HTTP URI, `ArgumentError` is raised.
+  # In any case the active context can be accessed through `tls`.
   #
   # This constructor will raise an exception if any scheme but HTTP or HTTPS
   # is used.
-  def self.new(uri : URI, ssl = nil)
-    ssl = ssl_flag(uri, ssl)
+  def self.new(uri : URI, tls = nil)
+    tls = tls_flag(uri, tls)
     host = validate_host(uri)
-    new(host, uri.port, ssl)
+    new(host, uri.port, tls)
   end
 
   # Creates a new HTTP client, yields it to the block, and closes
@@ -162,8 +162,8 @@ class HTTP::Client
   #   client.get "/"
   # end
   # ```
-  def self.new(host, port = nil, ssl = false)
-    client = new(host, port, ssl)
+  def self.new(host, port = nil, tls = false)
+    client = new(host, port, tls)
     begin
       yield client
     ensure
@@ -322,8 +322,8 @@ class HTTP::Client
     # response = HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-agent": "AwesomeApp"}, body: "Hello!")
     # response.body #=> "..."
     # ```
-    def self.{{method.id}}(url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, ssl = nil) : HTTP::Client::Response
-      exec {{method.upcase}}, url, headers, body, ssl
+    def self.{{method.id}}(url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, tls = nil) : HTTP::Client::Response
+      exec {{method.upcase}}, url, headers, body, tls
     end
 
     # Executes a {{method.id.upcase}} request and yields the response to the block.
@@ -334,8 +334,8 @@ class HTTP::Client
     #   response.body_io.gets #=> "..."
     # end
     # ```
-    def self.{{method.id}}(url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, ssl = nil)
-      exec {{method.upcase}}, url, headers, body, ssl do |response|
+    def self.{{method.id}}(url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, tls = nil)
+      exec {{method.upcase}}, url, headers, body, tls do |response|
         yield response
       end
     end
@@ -377,8 +377,8 @@ class HTTP::Client
   # ```
   # response = HTTP::Client.post_form "http://www.example.com", "foo=bar"
   # ```
-  def self.post_form(url, form : String | Hash, headers : HTTP::Headers? = nil, ssl = nil) : HTTP::Client::Response
-    exec(url, ssl) do |client, path|
+  def self.post_form(url, form : String | Hash, headers : HTTP::Headers? = nil, tls = nil) : HTTP::Client::Response
+    exec(url, tls) do |client, path|
       client.post_form(path, form, headers)
     end
   end
@@ -481,8 +481,8 @@ class HTTP::Client
   # response = HTTP::Client.exec "GET", "http://www.example.com"
   # response.body # => "..."
   # ```
-  def self.exec(method, url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, ssl = nil) : HTTP::Client::Response
-    exec(url, ssl) do |client, path|
+  def self.exec(method, url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, tls = nil) : HTTP::Client::Response
+    exec(url, tls) do |client, path|
       client.exec method, path, headers, body
     end
   end
@@ -495,8 +495,8 @@ class HTTP::Client
   #   response.body_io.gets # => "..."
   # end
   # ```
-  def self.exec(method, url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, ssl = nil)
-    exec(url, ssl) do |client, path|
+  def self.exec(method, url : String | URI, headers : HTTP::Headers? = nil, body : String? = nil, tls = nil)
+    exec(url, tls) do |client, path|
       client.exec(method, path, headers, body) do |response|
         yield response
       end
@@ -529,9 +529,9 @@ class HTTP::Client
     @socket = socket
 
     ifdef !without_openssl
-      if ssl = @ssl
-        ssl_socket = OpenSSL::SSL::Socket::Client.new(socket, context: ssl, sync_close: true, hostname: @host)
-        @socket = socket = ssl_socket
+      if tls = @tls
+        tls_socket = OpenSSL::SSL::Socket::Client.new(socket, context: tls, sync_close: true, hostname: @host)
+        @socket = socket = tls_socket
       end
     end
 
@@ -539,14 +539,14 @@ class HTTP::Client
   end
 
   private def host_header
-    if (@ssl && @port != 443) || (!@ssl && @port != 80)
+    if (@tls && @port != 443) || (!@tls && @port != 80)
       "#{@host}:#{@port}"
     else
       @host
     end
   end
 
-  private def self.exec(string : String, ssl = nil)
+  private def self.exec(string : String, tls = nil)
     uri = URI.parse(string)
 
     unless uri.scheme && uri.host
@@ -554,13 +554,13 @@ class HTTP::Client
       uri = URI.parse("http://#{string}")
     end
 
-    exec(uri, ssl) do |client, path|
+    exec(uri, tls) do |client, path|
       yield client, path
     end
   end
 
   ifdef without_openssl
-    protected def self.ssl_flag(uri, context : Nil)
+    protected def self.tls_flag(uri, context : Nil)
       scheme = uri.scheme
       case scheme
       when nil
@@ -574,7 +574,7 @@ class HTTP::Client
       end
     end
   else
-    protected def self.ssl_flag(uri, context : OpenSSL::SSL::Context::Client?)
+    protected def self.tls_flag(uri, context : OpenSSL::SSL::Context::Client?)
       scheme = uri.scheme
       case {scheme, context}
       when {nil, _}
@@ -582,7 +582,7 @@ class HTTP::Client
       when {"http", nil}
         false
       when {"http", OpenSSL::SSL::Context::Client}
-        raise ArgumentError.new("SSL context given for HTTP URI")
+        raise ArgumentError.new("TLS context given for HTTP URI")
       when {"https", nil}
         true
       when {"https", OpenSSL::SSL::Context::Client}
@@ -600,8 +600,8 @@ class HTTP::Client
     raise ArgumentError.new %(Request URI must have host (URI is: #{uri}))
   end
 
-  private def self.exec(uri : URI, ssl = nil)
-    ssl = ssl_flag(uri, ssl)
+  private def self.exec(uri : URI, tls = nil)
+    tls = tls_flag(uri, tls)
     host = validate_host(uri)
 
     port = uri.port
@@ -609,7 +609,7 @@ class HTTP::Client
     user = uri.user
     password = uri.password
 
-    HTTP::Client.new(host, port, ssl) do |client|
+    HTTP::Client.new(host, port, tls) do |client|
       if user && password
         client.basic_auth(user, password)
       end

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -89,7 +89,7 @@ require "./common"
 # ```
 class HTTP::Server
   ifdef !without_openssl
-    property ssl : OpenSSL::SSL::Context::Server?
+    property tls : OpenSSL::SSL::Context::Server?
   end
 
   @wants_close = false
@@ -158,8 +158,8 @@ class HTTP::Server
     io.sync = false
 
     ifdef !without_openssl
-      if ssl = @ssl
-        io = OpenSSL::SSL::Socket::Server.new(io, ssl, sync_close: true)
+      if tls = @tls
+        io = OpenSSL::SSL::Socket::Server.new(io, tls, sync_close: true)
       end
     end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -14,12 +14,12 @@ class HTTP::WebSocket
   # and will raise an exception if the handshake did not complete successfully. This method will also raise
   # an exception if the URI is missing the host and/or the path.
   #
-  # Please note that the scheme will only be used to identify if SSL should be used or not. Therefore, schemes
+  # Please note that the scheme will only be used to identify if TLS should be used or not. Therefore, schemes
   # apart from `wss` and `https` will be treated as the default which is `ws`.
   #
   # ```
   # WebSocket.new(URI.parse("ws://websocket.example.com/chat"))        # Creates a new WebSocket to `websocket.example.com`
-  # WebSocket.new(URI.parse("wss://websocket.example.com/chat"))       # Creates a new WebSocket with SSL to `websocket.example.com`
+  # WebSocket.new(URI.parse("wss://websocket.example.com/chat"))       # Creates a new WebSocket with TLS to `websocket.example.com`
   # WebSocket.new(URI.parse("http://websocket.example.com:8080/chat")) # Creates a new WebSocket to `websocket.example.com` on port `8080`
   # ```
   def self.new(uri : URI | String)
@@ -30,11 +30,11 @@ class HTTP::WebSocket
   # and will raise an exception if the handshake did not complete successfully.
   #
   # ```
-  # WebSocket.new("websocket.example.com", "/chat")             # Creates a new WebSocket to `websocket.example.com`
-  # WebSocket.new("websocket.example.com", "/chat", ssl = true) # Creates a new WebSocket with SSL to `ẁebsocket.example.com`
+  # WebSocket.new("websocket.example.com", "/chat")            # Creates a new WebSocket to `websocket.example.com`
+  # WebSocket.new("websocket.example.com", "/chat", tls: true) # Creates a new WebSocket with TLS to `ẁebsocket.example.com`
   # ```
-  def self.new(host : String, path : String, port = nil, ssl = false)
-    new(Protocol.new(host, path, port, ssl))
+  def self.new(host : String, path : String, port = nil, tls = false)
+    new(Protocol.new(host, path, port, tls))
   end
 
   def on_message(&@on_message : String ->)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -219,23 +219,23 @@ class HTTP::WebSocket::Protocol
     end
   end
 
-  def self.new(host : String, path : String, port = nil, ssl = false)
+  def self.new(host : String, path : String, port = nil, tls = false)
     ifdef without_openssl
-      if ssl
-        raise "WebSocket ssl is disabled because `-D without_openssl` was passed at compile time"
+      if tls
+        raise "WebSocket TLS is disabled because `-D without_openssl` was passed at compile time"
       end
     end
 
-    port = port || (ssl ? 443 : 80)
+    port = port || (tls ? 443 : 80)
 
     socket = TCPSocket.new(host, port)
 
     ifdef !without_openssl
-      if ssl
-        if ssl.is_a?(Bool) # true, but we want to get rid of the union
+      if tls
+        if tls.is_a?(Bool) # true, but we want to get rid of the union
           context = OpenSSL::SSL::Context::Client.new
         else
-          context = ssl
+          context = tls
         end
         socket = OpenSSL::SSL::Socket::Client.new(socket, context: context, sync_close: true)
       end
@@ -263,8 +263,8 @@ class HTTP::WebSocket::Protocol
     uri = URI.parse(uri) if uri.is_a?(String)
 
     if (host = uri.host) && (path = uri.path)
-      ssl = uri.scheme == "https" || uri.scheme == "wss"
-      return new(host, path, uri.port, ssl)
+      tls = uri.scheme == "https" || uri.scheme == "wss"
+      return new(host, path, uri.port, tls)
     end
 
     raise ArgumentError.new("No host or path specified which are required.")

--- a/src/oauth/consumer.cr
+++ b/src/oauth/consumer.cr
@@ -1,5 +1,5 @@
 class OAuth::Consumer
-  @ssl : Bool
+  @tls : Bool
 
   def initialize(@host : String, @consumer_key : String, @consumer_secret : String,
                  @port : Int32 = 443,
@@ -7,7 +7,7 @@ class OAuth::Consumer
                  @request_token_uri : String = "/oauth/request_token",
                  @authorize_uri : String = "/oauth/authorize",
                  @access_token_uri : String = "/oauth/access_token")
-    @ssl = @scheme == "https"
+    @tls = @scheme == "https"
   end
 
   def get_request_token(oauth_callback = "oob")
@@ -46,7 +46,7 @@ class OAuth::Consumer
   end
 
   private def with_new_http_client(oauth_token, token_shared_secret, extra_params)
-    client = HTTP::Client.new @host, @port, ssl: @ssl
+    client = HTTP::Client.new @host, @port, tls: @tls
     authenticate client, oauth_token, token_shared_secret, extra_params
     begin
       yield client
@@ -70,7 +70,7 @@ class OAuth::Consumer
     nonce = SecureRandom.hex
 
     signature = Signature.new @consumer_key, @consumer_secret, oauth_token, token_shared_secret, extra_params
-    signature.authorization_header request, client.ssl?, ts, nonce
+    signature.authorization_header request, client.tls?, ts, nonce
   end
 
   private def handle_response(response)

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -3,8 +3,8 @@ struct OAuth::Signature
   def initialize(@consumer_key : String, @client_shared_secret : String, @oauth_token : String? = nil, @token_shared_secret : String? = nil, @extra_params : Hash(String, String)? = nil)
   end
 
-  def base_string(request, ssl, ts, nonce)
-    base_string request, ssl, gather_params(request, ts, nonce)
+  def base_string(request, tls, ts, nonce)
+    base_string request, tls, gather_params(request, ts, nonce)
   end
 
   def key
@@ -17,13 +17,13 @@ struct OAuth::Signature
     end
   end
 
-  def compute(request, ssl, ts, nonce)
-    base_string = base_string(request, ssl, ts, nonce)
+  def compute(request, tls, ts, nonce)
+    base_string = base_string(request, tls, ts, nonce)
     Base64.strict_encode(OpenSSL::HMAC.digest :sha1, key, base_string)
   end
 
-  def authorization_header(request, ssl, ts, nonce)
-    oauth_signature = compute request, ssl, ts, nonce
+  def authorization_header(request, tls, ts, nonce)
+    oauth_signature = compute request, tls, ts, nonce
 
     auth_header = AuthorizationHeader.new
     auth_header.add "oauth_consumer_key", @consumer_key
@@ -39,13 +39,13 @@ struct OAuth::Signature
     auth_header.to_s
   end
 
-  private def base_string(request, ssl, params)
-    host, port = host_and_port(request, ssl)
+  private def base_string(request, tls, params)
+    host, port = host_and_port(request, tls)
 
     String.build do |str|
       str << request.method
       str << '&'
-      str << (ssl ? "https" : "http")
+      str << (tls ? "https" : "http")
       str << "%3A%2F%2F"
       URI.escape host, str
       if port
@@ -86,7 +86,7 @@ struct OAuth::Signature
     params
   end
 
-  private def host_and_port(request, ssl)
+  private def host_and_port(request, tls)
     host_header = request.headers["Host"]
     if colon_index = host_header.index ':'
       host = host_header[0...colon_index]

--- a/src/oauth2/access_token/access_token.cr
+++ b/src/oauth2/access_token/access_token.cr
@@ -48,11 +48,11 @@ abstract class OAuth2::AccessToken
     @expires_in = expires_in.to_i64
   end
 
-  abstract def authenticate(request : HTTP::Request, ssl)
+  abstract def authenticate(request : HTTP::Request, tls)
 
   def authenticate(client : HTTP::Client)
     client.before_request do |request|
-      authenticate request, client.ssl?
+      authenticate request, client.tls?
     end
   end
 end

--- a/src/oauth2/access_token/mac.cr
+++ b/src/oauth2/access_token/mac.cr
@@ -16,12 +16,12 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
     "Mac"
   end
 
-  def authenticate(request : HTTP::Request, ssl)
+  def authenticate(request : HTTP::Request, tls)
     ts = Time.now.epoch
     nonce = "#{ts - @issued_at}:#{SecureRandom.hex}"
     method = request.method
     uri = request.resource
-    host, port = host_and_port request, ssl
+    host, port = host_and_port request, tls
     ext = ""
 
     mac = Mac.signature ts, nonce, method, uri, host, port, ext, mac_algorithm, mac_key
@@ -55,14 +55,14 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
 
   def_equals_and_hash access_token, expires_in, mac_algorithm, mac_key, refresh_token, scope
 
-  private def host_and_port(request, ssl)
+  private def host_and_port(request, tls)
     host_header = request.headers["Host"]
     if colon_index = host_header.index ':'
       host = host_header[0...colon_index]
       port = host_header[colon_index + 1..-1].to_i
     else
       host = host_header
-      port = ssl ? 443 : 80
+      port = tls ? 443 : 80
     end
     {host, port}
   end

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -45,7 +45,7 @@ abstract class OpenSSL::SSL::Context
   ).join(' ')
 
   class Client < Context
-    # Generates a new SSL client context with sane defaults for a client connection.
+    # Generates a new TLS client context with sane defaults for a client connection.
     #
     # By default it defaults to the `SSLv23_method` which actually means that
     # OpenSSL will negotiate the TLS or SSL protocol to use with the remote
@@ -58,8 +58,8 @@ abstract class OpenSSL::SSL::Context
     # protocols but disable the deprecated SSLv2 and SSLv3 protocols:
     #
     # ```
-    # ssl_context = OpenSSL::SSL::Context::Client.new
-    # ssl_context.options = OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3
+    # context = OpenSSL::SSL::Context::Client.new
+    # context.options = OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3
     # ```
     def initialize(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
       super(method)
@@ -70,7 +70,7 @@ abstract class OpenSSL::SSL::Context
       {% end %}
     end
 
-    # Returns a new SSL client context with only the given method set.
+    # Returns a new TLS client context with only the given method set.
     #
     # For everything else this uses the defaults of your OpenSSL.
     # Use this only if undoing the defaults that `new` sets is too much hassle.
@@ -96,7 +96,7 @@ abstract class OpenSSL::SSL::Context
   end
 
   class Server < Context
-    # Generates a new SSL server context with sane defaults for a server connection.
+    # Generates a new TLS server context with sane defaults for a server connection.
     #
     # By default it defaults to the `SSLv23_method` which actually means that
     # OpenSSL will negotiate the TLS or SSL protocol to use with the remote
@@ -109,8 +109,8 @@ abstract class OpenSSL::SSL::Context
     # protocols but disable the deprecated SSLv2 and SSLv3 protocols:
     #
     # ```
-    # ssl_context = OpenSSL::SSL::Context::Server.new
-    # ssl_context.options = OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3
+    # context = OpenSSL::SSL::Context::Server.new
+    # context.options = OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3
     # ```
     def initialize(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
       super(method)
@@ -121,7 +121,7 @@ abstract class OpenSSL::SSL::Context
       {% end %}
     end
 
-    # Returns a new SSL server context with only the given method set.
+    # Returns a new TLS server context with only the given method set.
     #
     # For everything else this uses the defaults of your OpenSSL.
     # Use this only if undoing the defaults that `new` sets is too much hassle.
@@ -206,14 +206,14 @@ abstract class OpenSSL::SSL::Context
     raise OpenSSL::Error.new("SSL_CTX_use_PrivateKey_file") unless ret == 1
   end
 
-  # Specify a list of SSL ciphers to use or discard.
+  # Specify a list of TLS ciphers to use or discard.
   def ciphers=(ciphers : String)
     ret = LibSSL.ssl_ctx_set_cipher_list(@handle, ciphers)
     raise OpenSSL::Error.new("SSL_CTX_set_cipher_list") if ret == 0
     ciphers
   end
 
-  # Adds a temporary ECDH key curve to the SSL context. This is required to
+  # Adds a temporary ECDH key curve to the TLS context. This is required to
   # enable the EECDH cipher suites. By default the prime256 curve will be used.
   def set_tmp_ecdh_key(curve = LibCrypto::NID_X9_62_prime256v1)
     key = LibCrypto.ec_key_new_by_curve_name(curve)
@@ -222,31 +222,31 @@ abstract class OpenSSL::SSL::Context
     LibCrypto.ec_key_free(key)
   end
 
-  # Returns the current modes set on the SSL context.
+  # Returns the current modes set on the TLS context.
   def modes
     OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, 0, nil)
   end
 
-  # Adds modes to the SSL context.
+  # Adds modes to the TLS context.
   def add_modes(mode : OpenSSL::SSL::Modes)
     OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, mode, nil)
   end
 
-  # Removes modes from the SSL context.
+  # Removes modes from the TLS context.
   def remove_modes(mode : OpenSSL::SSL::Modes)
     OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_MODE, mode, nil)
   end
 
-  # Returns the current options set on the SSL context.
+  # Returns the current options set on the TLS context.
   def options
     OpenSSL::SSL::Options.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
   end
 
-  # Adds options to the SSL context.
+  # Adds options to the TLS context.
   #
   # Example:
   # ```
-  # ssl_context.add_options(
+  # context.add_options(
   #   OpenSSL::SSL::Options::ALL |        # various workarounds
   #     OpenSSL::SSL::Options::NO_SSLV2 | # disable overly deprecated SSLv2
   #     OpenSSL::SSL::Options::NO_SSLV3   # disable deprecated SSLv3
@@ -256,11 +256,11 @@ abstract class OpenSSL::SSL::Context
     OpenSSL::SSL::Options.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
   end
 
-  # Removes options from the SSL context.
+  # Removes options from the TLS context.
   #
   # Example:
   # ```
-  # ssl_context.remove_options(OpenSSL::SSL::NO_SSLV3)
+  # context.remove_options(OpenSSL::SSL::NO_SSLV3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
     OpenSSL::SSL::Options.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
@@ -286,7 +286,7 @@ abstract class OpenSSL::SSL::Context
   #
   # Example:
   # ```
-  # ssl_context.alpn_protocol = "h2"
+  # context.alpn_protocol = "h2"
   # ```
   def alpn_protocol=(protocol : String)
     proto = Slice(UInt8).new(protocol.bytesize + 1)


### PR DESCRIPTION
Implements #2683, since there was no discussion over there and only positive reactions so far. Also I think this goes well with the already existing breaking changes in this area in 0.18.