### PR TITLE
Do not mutate the users HTTP::Headers object in HTTP::Client

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -6,38 +6,45 @@ module HTTP
     it "serialize GET" do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
       request = Request.new "GET", "/", headers
 
       io = MemoryIO.new
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
+      headers.should eq(orignal_headers)
     end
 
     it "serialize GET (with query params)" do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
       request = Request.new "GET", "/greet?q=hello&name=world", headers
 
       io = MemoryIO.new
       request.to_io(io)
       io.to_s.should eq("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
+      headers.should eq(orignal_headers)
     end
 
     it "serialize GET (with cookie)" do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
       request = Request.new "GET", "/", headers
       request.cookies << Cookie.new("foo", "bar")
 
       io = MemoryIO.new
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
+      headers.should eq(orignal_headers)
     end
 
     it "serialize GET (with cookies, from headers)" do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
       headers["Cookie"] = "foo=bar"
+      orignal_headers = headers.dup
 
       request = Request.new "GET", "/", headers
 
@@ -57,6 +64,7 @@ module HTTP
       io.clear
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=baz; quux=baz\r\n\r\n")
+      headers.should eq(orignal_headers)
     end
 
     it "serialize POST (with body)" do
@@ -132,8 +140,10 @@ module HTTP
       it "is true in HTTP/1.0 if `Connection: keep-alive` header is present" do
         headers = HTTP::Headers.new
         headers["Connection"] = "keep-alive"
+        orignal_headers = headers.dup
         request = Request.new "GET", "/", headers: headers, version: "HTTP/1.0"
         request.keep_alive?.should be_true
+        headers.should eq(orignal_headers)
       end
 
       it "is true by default in HTTP/1.1" do
@@ -144,8 +154,10 @@ module HTTP
       it "is false in HTTP/1.1 if `Connection: close` header is present" do
         headers = HTTP::Headers.new
         headers["Connection"] = "close"
+        orignal_headers = headers.dup
         request = Request.new "GET", "/", headers: headers, version: "HTTP/1.1"
         request.keep_alive?.should be_false
+        headers.should eq(orignal_headers)
       end
     end
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -349,9 +349,9 @@ class HTTP::Client
   # response = client.post_form "/", "foo=bar"
   # ```
   def post_form(path, form : String, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-    headers ||= HTTP::Headers.new
-    headers["Content-type"] = "application/x-www-form-urlencoded"
-    post path, headers, form
+    request = new_request("POST", path, headers, form)
+    request.headers["Content-type"] = "application/x-www-form-urlencoded"
+    exec request
   end
 
   # Executes a POST with form data. The "Content-type" header is set
@@ -510,9 +510,9 @@ class HTTP::Client
   end
 
   private def new_request(method, path, headers, body)
-    headers ||= HTTP::Headers.new
-    headers["Host"] ||= host_header
-    HTTP::Request.new method, path, headers, body
+    HTTP::Request.new(method, path, headers, body).tap do |request|
+      request.headers["Host"] ||= host_header
+    end
   end
 
   private def execute_callbacks(request)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -11,7 +11,8 @@ class HTTP::Request
   @query_params : Params?
   @uri : URI?
 
-  def initialize(@method : String, @resource : String, @headers : Headers = Headers.new, @body = nil, @version = "HTTP/1.1")
+  def initialize(@method : String, @resource : String, headers : Headers? = nil, @body = nil, @version = "HTTP/1.1")
+    @headers = headers.try(&.dup) || Headers.new
     if body = @body
       @headers["Content-Length"] = body.bytesize.to_s
     elsif @method == "POST" || @method == "PUT"


### PR DESCRIPTION
We should not modify a user passed object, that's violating OOP principles. In this case it also actually causes erroneous behavior in case a user reuses a `HTTP::Headers` object for quite different kind of objects or requests to different hosts. Having a common `HTTP::Headers` assigned to some constant and be used throughout a library or application is and will not be an uncommon burden. The user should not be responsible for creating copies just because we mutate their object.

The solution chosen here of taking a copy is not the ideal one, but everything else seems to require heavy restructuring of `HTTP::Client`. This is to fix the issue for the short term, we can open an issue to track work towards a solution that can work without copies.