### PR TITLE
Make heredoc end if the end matches and a non-identifier char is found

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -961,4 +961,7 @@ describe Crystal::Formatter do
   assert_format "Union(Foo::Bar?, Baz?, Qux(T, U?))"
 
   assert_format "lib Foo\n  {% if 1 %}\n    2\n  {% end %}\nend\n\nmacro bar\n  1\nend"
+
+  assert_format %(puts(<<-FOO\n1\nFOO, 2))
+  assert_format %(puts <<-FOO\n1\nFOO, 2)
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1138,6 +1138,9 @@ describe "Parser" do
   it_parses "<<-'HERE'\n  hello \\n world\n  \#{1}\n  HERE", StringLiteral.new("hello \\n world\n\#{1}")
   assert_syntax_error "<<-'HERE\n", "expecting closing single quote"
 
+  it_parses "<<-FOO\n1\nFOO.bar", Call.new("1".string, "bar")
+  it_parses "<<-FOO\n1\nFOO + 2", Call.new("1".string, "+", 2.int32)
+
   it_parses "enum Foo; A\nB, C\nD = 1; end", EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)
   it_parses "enum Foo; A = 1, B; end", EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Arg.new("B")] of ASTNode)
   it_parses "enum Foo : UInt16; end", EnumDef.new("Foo".path, base_type: "UInt16".path)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1817,7 +1817,8 @@ module Crystal
 
             if reached_end &&
                (current_char == '\n' || current_char == '\0' ||
-               (current_char == '\r' && peek_next_char == '\n' && next_char))
+               (current_char == '\r' && peek_next_char == '\n' && next_char) ||
+               !ident_part?(current_char))
               @token.type = :DELIMITER_END
               @token.delimiter_state = @token.delimiter_state.with_heredoc_indent(indent)
             else

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2340,7 +2340,7 @@ module Crystal
         end
         next_needs_indent = false
         unless last?(i, args)
-          if @last_is_heredoc
+          if @last_is_heredoc && @token.type == :NEWLINE
             write_line
             skip_space_or_newline
             write_indent


### PR DESCRIPTION
This is an alternative way to fix #2089

I'll write the examples on that issue with this new feature:

```crystal
puts <<-END
SOME TEXT
END.downcase
```

```crystal
items = Item.find_by_sql(<<-SQL
   select * from items where id = ?
SQL, item_id)
```

```crystal
puts <<-TITLE
    Something
TITLE.downcase + "Name: #{<<-NAME
    John Doe
    NAME}"
```

```crystal
puts <<-HERE
apple
banana
HERE.gsub /[aeiou]/, "*"
```

And one can also do:

```crystal
puts(1, 2, <<-FOO
  some text
  FOO)
```

that is, end a method call with parentheses, after a heredoc, or add more arguments after that.

One downside to this change is that if you have a line that starts with the delimiter then the heredoc will end there. However, in the old behaviour, if you had a single line in the text that matched the delimiter it also ended there... so there's always a change that the heredoc will break unintentionally. But with a well chosen delimiter it shouldn't happen, or one can change it (it's static text).

This way of writing heredocs is more natural, you read from left to right. No need to move your eyes up and down to understand the text.