### PR TITLE
Array#uniq considers each element eql? method to check if exists

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -10,6 +10,12 @@ class BadSortingClass
   end
 end
 
+class ArrayEql
+  def eql?(other)
+    return true if other.is_a?(ArrayEql)
+  end
+end
+
 describe "Array" do
   describe "new" do
     it "creates with default value" do
@@ -1060,6 +1066,13 @@ describe "Array" do
       b = a.uniq
       b.should eq([1, 2, 3, 4, 5])
       a.same?(b).should be_false
+    end
+
+    it "uniqs calling class hash" do
+      a = [] of ArrayEql
+      a = [ArrayEql.new, ArrayEql.new]
+      b = a.uniq
+      b.size.should eq(1)
     end
 
     it "uniqs with block" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -2101,8 +2101,11 @@ class Array(T)
   protected def to_lookup_hash(&block : T -> U)
     each_with_object(Hash(U, T).new) do |o, h|
       key = yield o
+      if o.responds_to?(:eql?)
+        duplicated = h.values.any? { |x| o.eql?(x) }
+      end
       unless h.has_key?(key)
-        h[key] = o
+        h[key] = o unless duplicated
       end
     end
   end


### PR DESCRIPTION
The motivation for this PR is when you have an array with two elements:

```crystal
array = [Element.new(name: 'foo'), Element.new(name: 'bar')]
```

In this case an `array.uniq` will always return two elements, but consider you want to return only on Element no matter the name, how should we proceed?

The idea is to implement a `#eql?` method on Element class the computes the hash based on instance information, so we can return unique elements, consider in our case we just want to return the first Element

```crystal
class Element
  def eq?(other)
    return true if other.is_a?(Element)
  end
end
```

How the returned hash `array.uniq` will return

```crystal
array = [Element.new(name: 'foo'), Element.new(name: 'bar')]
array.uniq
# [Element(name: foo)]
```

ps: I don't believe this is the best implementation, specially because this algorithm is O(n2), I'm justing opening this PR to check if makes sense this addition so I can work on a better solution to this problem.