### PR TITLE
Update the links under Literals section

### DIFF
--- a/_gitbook/syntax_and_semantics/literals/named_tuple.md
+++ b/_gitbook/syntax_and_semantics/literals/named_tuple.md
@@ -15,7 +15,7 @@ To denote a named tuple type you can write:
 NamedTuple(x: Int32, y: String)
 ```
 
-In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](type_grammar.html):
+In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](../type_grammar.html):
 
 ```crystal
 # An array of named tuples of x: Int32, y: String

--- a/_gitbook/syntax_and_semantics/literals/proc.md
+++ b/_gitbook/syntax_and_semantics/literals/proc.md
@@ -40,7 +40,7 @@ Proc(Void)
 Proc(Int32, String, Char)
 ```
 
-In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](type_grammar.html):
+In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](../type_grammar.html):
 
 ```crystal
 # An array of Proc(Int32, String, Char)

--- a/_gitbook/syntax_and_semantics/literals/tuple.md
+++ b/_gitbook/syntax_and_semantics/literals/tuple.md
@@ -18,7 +18,7 @@ To denote a tuple type you can write:
 Tuple(Int32, String, Char)
 ```
 
-In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](type_grammar.html):
+In type restrictions, generic type arguments and other places where a type is expected, you can use a shorter syntax, as explained in the [type](../type_grammar.html):
 
 ```crystal
 # An array of tuples of Int32, String and Char


### PR DESCRIPTION
This will solve #2812.

And this not only fixed the link in `Tuple` and `NamedTuple` page, but also included `Proc`.

BTW, I didn't check other pages outside `Literals` section.