### PR TITLE
Update cross compile docs, flags docs and use flag? instead of ifdef in the examples

### DIFF
--- a/_gitbook/syntax_and_semantics/c_bindings/alias.md
+++ b/_gitbook/syntax_and_semantics/c_bindings/alias.md
@@ -24,11 +24,11 @@ An `alias` is most useful to avoid writing long types over and over, but also to
 
 ```crystal
 lib C
-  ifdef x86_64
+  {% if flag?:(x86_64) %}
     alias SizeT = Int64
-  else
+  {% else %}
     alias SizeT = Int32
-  end
+  {% end %}
 
   fun memcmp(p1 : Void*, p2 : Void*, size : C::SizeT) : Int32
 end

--- a/_gitbook/syntax_and_semantics/cross-compilation.md
+++ b/_gitbook/syntax_and_semantics/cross-compilation.md
@@ -4,17 +4,17 @@ Crystal supports a basic form of [cross compilation](http://en.wikipedia.org/wik
 
 In order to achieve this, the compiler executable provides two flags:
 
-* `--cross-compile`: the [compile-time flags](compile_time_flags.html) to use
-* `--target`: the [LLVM Target Triple](http://llvm.org/docs/LangRef.html#target-triple) to use
-
-To get the `--cross-compile` flags you can execute `uname -m -s` on a unix system. For example, if you are on a Mac, the `uname -m -s` command says "Darwin x86_64". On some linux 64 bits it will say "Linux x86_64".
+* `--cross-compile`: When given enables cross compilation mode
+* `--target`: the [LLVM Target Triple](http://llvm.org/docs/LangRef.html#target-triple) to use and set the default [compile-time flags](compile_time_flags.html) from
 
 To get the `--target` flags you can execute `llvm-config --host-target` using an installed LLVM 3.5. For example on a Linux it could say "x86_64-unknown-linux-gnu".
+
+If you need to set any compile-time flags not set implicitly through `--target`, you can use the `-D` command line flag.
 
 Using these two, we can compile a program in a Mac that will run on that Linux like this:
 
 ```bash
-crystal compile your_program.cr --cross-compile "Linux x86_64" --target "x86_64-unknown-linux-gnu"
+crystal compile your_program.cr --cross-compile --target "x86_64-unknown-linux-gnu"
 ```
 
 This will generate a `.o` ([Object file](http://en.wikipedia.org/wiki/Object_file)) and will print a line with a command to execute on the system we are trying to cross-compile to. For example:
@@ -32,5 +32,3 @@ This procedure is usually done with the compiler itself to port it to new platfo
 The first alternative is long and cumbersome, while the second one is much easier.
 
 Cross-compiling can be done for other executables, but its main target is the compiler. If Crystal isn't available in some system you can try cross-compiling it there.
-
-**Note:** there currently isn't a way to add more compile-time flags and not do a cross-compile at the same time.

--- a/_gitbook/using_the_compiler/README.md
+++ b/_gitbook/using_the_compiler/README.md
@@ -92,7 +92,7 @@ $ crystal compile --help
 Usage: crystal compile [options] [programfile] [--] [arguments]
 
 Options:
-    --cross-compile flags            cross-compile
+    --cross-compile                  cross-compile
     -d, --debug                      Add symbolic debug info
     -D FLAG, --define FLAG           Define a compile-time flag
     --emit [asm|llvm-bc|llvm-ir|obj] Comma separated list of types of output for the compiler to emit


### PR DESCRIPTION
Should not be merged before 0.18 is released.