### PR TITLE
add enumerable#chunk

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -92,6 +92,118 @@ describe "Enumerable" do
     end
   end
 
+  describe "chunk" do
+    it "works" do
+      [1].chunk { true }.to_a.should eq [{true, [1]}]
+      [1, 2].chunk { false }.to_a.should eq [{false, [1, 2]}]
+      [1, 1, 2, 3, 3].chunk(&.itself).to_a.should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
+      [1, 1, 2, 3, 3].chunk(&.<=(2)).to_a.should eq [{true, [1, 1, 2]}, {false, [3, 3]}]
+      (0..10).chunk(&./(3)).to_a.should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
+    end
+
+    it "work with class" do
+      [1, 1, 2, 3, 3].chunk(&.class).to_a.should eq [{Int32, [1, 1, 2, 3, 3]}]
+    end
+
+    it "works with block" do
+      res = [] of Tuple(Bool, Array(Int32))
+      [1, 2, 3].chunk { |x| x < 3 }.each { |(k, v)| res << {k, v} }
+      res.should eq [{true, [1, 2]}, {false, [3]}]
+    end
+
+    it "rewind" do
+      i = (0..10).chunk(&./(3))
+      i.next.should eq({0, [0, 1, 2]})
+      i.next.should eq({1, [3, 4, 5]})
+      i.rewind
+      i.next.should eq({0, [0, 1, 2]})
+      i.next.should eq({1, [3, 4, 5]})
+    end
+
+    it "returns elements of the Enumerable in an Array of Tuple, {v, ary}, where 'ary' contains the consecutive elements for which the block returned the value 'v'" do
+      result = [1, 2, 3, 2, 3, 2, 1].chunk { |x| x < 3 ? 1 : 0 }.to_a
+      result.should eq [{1, [1, 2]}, {0, [3]}, {1, [2]}, {0, [3]}, {1, [2, 1]}]
+    end
+
+    it "returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays" do
+      result = [1, 2, 3, 2, 1].chunk { |x| x < 2 ? Enumerable::Chunk::Alone : false }.to_a
+      result.should eq [{Enumerable::Chunk::Alone, [1]}, {false, [2, 3, 2]}, {Enumerable::Chunk::Alone, [1]}]
+    end
+
+    it "alone all" do
+      result = [1, 2].chunk { Enumerable::Chunk::Alone }.to_a
+      result.should eq [{Enumerable::Chunk::Alone, [1]}, {Enumerable::Chunk::Alone, [2]}]
+    end
+
+    it "does not return elements for which the block returns Enumerable::Chunk::Drop" do
+      result = [1, 2, 3, 3, 2, 1].chunk { |x| x == 2 ? Enumerable::Chunk::Drop : 1 }.to_a
+      result.should eq [{1, [1]}, {1, [3, 3]}, {1, [1]}]
+    end
+
+    it "drop all" do
+      result = [1, 2].chunk { Enumerable::Chunk::Drop }.to_a
+      result.size.should eq 0
+    end
+
+    it "nil allowed as value" do
+      result = [1, 2, 3, 2, 1].chunk { |x| x == 2 ? nil : 1 }.to_a
+      result.should eq [{1, [1]}, {nil, [2]}, {1, [3]}, {nil, [2]}, {1, [1]}]
+    end
+
+    it "nil 2 case" do
+      result = [nil, nil, 1, 1, nil].chunk(&.itself).to_a
+      result.should eq [{nil, [nil, nil]}, {1, [1, 1]}, {nil, [nil]}]
+    end
+  end
+
+  describe "chunks" do
+    it "works" do
+      [1].chunks { true }.should eq [{true, [1]}]
+      [1, 2].chunks { false }.should eq [{false, [1, 2]}]
+      [1, 1, 2, 3, 3].chunks(&.itself).should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
+      [1, 1, 2, 3, 3].chunks(&.<=(2)).should eq [{true, [1, 1, 2]}, {false, [3, 3]}]
+      (0..10).chunks(&./(3)).should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
+    end
+
+    it "work with class" do
+      [1, 1, 2, 3, 3].chunks(&.class).should eq [{Int32, [1, 1, 2, 3, 3]}]
+    end
+
+    it "work with pure enumerable" do
+      SpecEnumerable.new.chunks(&./(2)).should eq [{0, [1]}, {1, [2, 3]}]
+    end
+
+    it "returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays" do
+      result = [1, 2, 3, 2, 1].chunks { |x| x < 2 ? Enumerable::Chunk::Alone : false }
+      result.should eq [{Enumerable::Chunk::Alone, [1]}, {false, [2, 3, 2]}, {Enumerable::Chunk::Alone, [1]}]
+    end
+
+    it "alone all" do
+      result = [1, 2].chunks { Enumerable::Chunk::Alone }
+      result.should eq [{Enumerable::Chunk::Alone, [1]}, {Enumerable::Chunk::Alone, [2]}]
+    end
+
+    it "does not return elements for which the block returns Enumerable::Chunk::Drop" do
+      result = [1, 2, 3, 3, 2, 1].chunks { |x| x == 2 ? Enumerable::Chunk::Drop : 1 }
+      result.should eq [{1, [1]}, {1, [3, 3]}, {1, [1]}]
+    end
+
+    it "drop all" do
+      result = [1, 2].chunks { Enumerable::Chunk::Drop }
+      result.size.should eq 0
+    end
+
+    it "nil allowed as value" do
+      result = [1, 2, 3, 2, 1].chunks { |x| x == 2 ? nil : 1 }
+      result.should eq [{1, [1]}, {nil, [2]}, {1, [3]}, {nil, [2]}, {1, [1]}]
+    end
+
+    it "nil 2 case" do
+      result = [nil, nil, 1, 1, nil].chunks(&.itself)
+      result.should eq [{nil, [nil, nil]}, {1, [1, 1]}, {nil, [nil]}]
+    end
+  end
+
   describe "each_cons" do
     it "returns running pairs" do
       array = [] of Array(Int32)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -998,4 +998,53 @@ module Iterator(T)
       self
     end
   end
+
+  # Returns an iterator that returns a chunks.
+  #
+  #     iter = (1..3).chunk(&./(2))
+  #     iter.next # => {0, [1]}
+  #     iter.next # => {1, [2, 3]}
+  #     iter.next # => Iterator::Stop::INSTANCE
+  #
+  def chunk(&block : T -> U)
+    Chunk(typeof(self), T, U).new(self, &block)
+  end
+
+  # :nodoc:
+  class Chunk(I, T, U)
+    include Iterator(Tuple(U, Array(T)))
+    @iterator : I
+
+    def initialize(@iterator : Iterator(T), &@original_block : T -> U)
+      @acc = Enumerable::Chunk::Accumulator(T, U).new
+    end
+
+    def next
+      @iterator.each do |val|
+        key = @original_block.call(val)
+
+        if @acc.same_as?(key)
+          @acc.add(val)
+        else
+          tuple = @acc.fetch
+          @acc.init(key, val)
+          return tuple if tuple
+        end
+      end
+
+      if tuple = @acc.fetch
+        return tuple
+      end
+      stop
+    end
+
+    def rewind
+      @iterator.rewind
+      init_state
+    end
+
+    private def init_state
+      @acc = Enumerable::Chunk::Accumulator(T, U).new
+    end
+  end
 end


### PR DESCRIPTION
this version return array, but ruby returns enumerator class(implemented on fibers), which missing in crystal. at least this is 10 times faster than ruby

```crystal
s = 0
t = Time.now
x = Array.new(100000) { rand(10000) }
100.times do
  s += x.chunk { |a| a } .to_a.size
end
p s
p Time.now - t
```

```
crystal
9999100
00:00:00.7460890

ruby
9999300
7.995598
```