### PR TITLE
String: add `sub` with index and range

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -841,6 +841,62 @@ describe "String" do
     it "ignores if backreferences: false" do
       "foo".sub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xo")
     end
+
+    it "subs at index with char" do
+      string = "hello".sub(1, 'a')
+      string.should eq("hallo")
+      string.bytesize.should eq(5)
+      string.size.should eq(5)
+    end
+
+    it "subs at index with char, non-ascii" do
+      string = "あいうえお".sub(2, 'の')
+      string.should eq("あいのえお")
+      string.size.should eq(5)
+      string.bytesize.should eq("あいのえお".bytesize)
+    end
+
+    it "subs at index with string" do
+      string = "hello".sub(1, "eee")
+      string.should eq("heeello")
+      string.bytesize.should eq(7)
+      string.size.should eq(7)
+    end
+
+    it "subs at index with string, non-ascii" do
+      string = "あいうえお".sub(2, "けくこ")
+      string.should eq("あいけくこえお")
+      string.bytesize.should eq("あいけくこえお".bytesize)
+      string.size.should eq(7)
+    end
+
+    it "subs range with char" do
+      string = "hello".sub(1..2, 'a')
+      string.should eq("halo")
+      string.bytesize.should eq(4)
+      string.size.should eq(4)
+    end
+
+    it "subs range with char, non-ascii" do
+      string = "あいうえお".sub(1..2, 'け')
+      string.should eq("あけえお")
+      string.size.should eq(4)
+      string.bytesize.should eq("あけえお".bytesize)
+    end
+
+    it "subs range with string" do
+      string = "hello".sub(1..2, "eee")
+      string.should eq("heeelo")
+      string.size.should eq(6)
+      string.bytesize.should eq(6)
+    end
+
+    it "subs range with string, non-ascii" do
+      string = "あいうえお".sub(1..2, "けくこ")
+      string.should eq("あけくこえお")
+      string.size.should eq(6)
+      string.bytesize.should eq("あけくこえお".bytesize)
+    end
   end
 
   describe "gsub" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -633,15 +633,7 @@ class String
   # "hello"[1...-1] # "ell"
   # ```
   def [](range : Range(Int, Int))
-    from = range.begin
-    from += size if from < 0
-    raise IndexError.new if from < 0
-
-    to = range.end
-    to += size if to < 0
-    to -= 1 if range.excludes_end?
-    size = to - from + 1
-    size = 0 if size < 0
+    from, size = range_to_index_and_size(range)
     self[from, size]
   end
 
@@ -1357,6 +1349,111 @@ class String
       $~ = match
       yield str, match, buffer
       buffer.write unsafe_byte_slice(match.byte_begin + str.bytesize)
+    end
+  end
+
+  # Returns a new String with the character at the given index
+  # replaced by *replacement*.
+  #
+  # ```
+  # "hello".sub(1, 'a') # => "hallo"
+  # ```
+  def sub(index : Int, replacement : Char)
+    sub_index(index.to_i, replacement) do |buffer|
+      replacement.each_byte do |byte|
+        buffer.value = byte
+        buffer += 1
+      end
+      {buffer, @length}
+    end
+  end
+
+  # Returns a new String with the character at the given index
+  # replaced by *replacement*.
+  #
+  # ```
+  # "hello".sub(1, "eee") # => "heeello"
+  # ```
+  def sub(index : Int, replacement : String)
+    sub_index(index.to_i, replacement) do |buffer|
+      buffer.copy_from(replacement.to_unsafe, replacement.bytesize)
+      buffer += replacement.bytesize
+      {buffer, self.size_known? && replacement.size_known? ? self.size + replacement.size - 1 : 0}
+    end
+  end
+
+  private def sub_index(index, replacement)
+    index += size + 1 if index < 0
+
+    byte_index = char_index_to_byte_index(index)
+    raise IndexError.new unless byte_index
+
+    reader = Char::Reader.new(self)
+    reader.pos = byte_index
+    width = reader.current_char_width
+    replacement_width = replacement.bytesize
+    new_bytesize = bytesize - width + replacement_width
+
+    String.new(new_bytesize) do |buffer|
+      buffer.copy_from(to_unsafe, byte_index)
+      buffer += byte_index
+      buffer, length = yield buffer
+      buffer.copy_from(to_unsafe + byte_index + width, bytesize - byte_index - width)
+      {new_bytesize, length}
+    end
+  end
+
+  # Returns a new String with characters at the given range
+  # replaced by *replacement*.
+  #
+  # ```
+  # "hello".sub(1..2, 'a') # => "halo"
+  # ```
+  def sub(range : Range(Int, Int), replacement : Char)
+    sub_range(range, replacement) do |buffer, from_index, to_index|
+      replacement.each_byte do |byte|
+        buffer.value = byte
+        buffer += 1
+      end
+      {buffer, single_byte_optimizable? ? bytesize - (to_index - from_index) + 1 : 0}
+    end
+  end
+
+  # Returns a new String with characters at the given range
+  # replaced by *replacement*.
+  #
+  # ```
+  # "hello".sub(1..2, "eee") # => "heeelo"
+  # ```
+  def sub(range : Range(Int, Int), replacement : String)
+    sub_range(range, replacement) do |buffer|
+      buffer.copy_from(replacement.to_unsafe, replacement.bytesize)
+      buffer += replacement.bytesize
+      {buffer, 0}
+    end
+  end
+
+  private def sub_range(range, replacement)
+    from, size = range_to_index_and_size(range)
+
+    from_index = char_index_to_byte_index(from)
+    raise IndexError.new unless from_index
+
+    if size == 0
+      to_index = from_index
+    else
+      to_index = char_index_to_byte_index(from + size)
+      raise IndexError.new unless to_index
+    end
+
+    new_bytesize = bytesize - (to_index - from_index) + replacement.bytesize
+
+    String.new(new_bytesize) do |buffer|
+      buffer.copy_from(to_unsafe, from_index)
+      buffer += from_index
+      buffer, length = yield buffer, from_index, to_index
+      buffer.copy_from(to_unsafe + to_index, bytesize - to_index)
+      {new_bytesize, length}
     end
   end
 
@@ -3013,6 +3110,20 @@ class String
     end
 
     {bytes, bytesize}
+  end
+
+  private def range_to_index_and_size(range)
+    from = range.begin
+    from += size if from < 0
+    raise IndexError.new if from < 0
+
+    to = range.end
+    to += size if to < 0
+    to -= 1 if range.excludes_end?
+    size = to - from + 1
+    size = 0 if size < 0
+
+    {from, size}
   end
 
   # Raises an `ArgumentError` if `self` has null bytes. Returns `self` otherwise.


### PR DESCRIPTION
In Ruby this is `String#[]=`, which we were missing. Suggestions for alternatives to the name `sub` are accepted, but maybe `sub` is good enough.