### PR TITLE
Build standard library specs with the currently released compiler first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 before_install: bin/ci prepare_system
 install: bin/ci prepare_build
 script:
+  - bin/ci with_build_env 'make std_spec clean'
   - bin/ci with_build_env 'make crystal std_spec compiler_spec doc'
   - bin/ci with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   - bin/ci with_build_env './bin/crystal tool format --check'

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -28,7 +28,8 @@ describe "NamedTuple" do
       NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :baz => 2})
     end
 
-    expect_raises(TypeCastError, /cast from String to Int32 failed/) do
+    # TODO: simplify regex and use TypeCastError after 0.18
+    expect_raises(Exception, /cast (?:from String )?to Int32 failed/) do
       NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :bar => "foo"})
     end
   end
@@ -50,7 +51,8 @@ describe "NamedTuple" do
       {foo: Int32, bar: Int32}.from({:foo => 1, :baz => 2})
     end
 
-    expect_raises(TypeCastError, /cast from String to Int32 failed/) do
+    # TODO: simplify regex and use TypeCastError after 0.18
+    expect_raises(Exception, /cast (?:from String )?to Int32 failed/) do
       {foo: Int32, bar: Int32}.from({:foo => 1, :bar => "foo"})
     end
   end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -155,7 +155,8 @@ describe "Tuple" do
       Tuple(Int32).from([1, 2])
     end
 
-    expect_raises(TypeCastError, /cast from String to Int32 failed/) do
+    # TODO: simplify regex and use TypeCastError after 0.18
+    expect_raises(Exception, /cast (?:from String )?to Int32 failed/) do
       Tuple(Int32, String).from(["foo", 1])
     end
   end
@@ -169,7 +170,8 @@ describe "Tuple" do
       {Int32}.from([1, 2])
     end
 
-    expect_raises(TypeCastError, /cast from String to Int32 failed/) do
+    # TODO: simplify regex and use TypeCastError after 0.18
+    expect_raises(Exception, /cast (?:from String )?to Int32 failed/) do
       {Int32, String}.from(["foo", 1])
     end
   end


### PR DESCRIPTION
Because @asterite want's the stdlib to compile with the current release, not just the next one.

PR mainly to see how much extra CI time this would cost.