### PR TITLE
DNS: threaded resolver [WIP]

### DIFF
--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -69,16 +69,6 @@ class Scheduler
     event
   end
 
-  @@dns_base : Event::DnsBase?
-
-  private def self.dns_base
-    @@dns_base ||= @@eb.new_dns_base
-  end
-
-  def self.create_dns_request(nodename, servname, hints, data, &callback : LibEvent2::DnsGetAddrinfoCallback)
-    dns_base.getaddrinfo(nodename, servname, hints, data, &callback)
-  end
-
   def self.enqueue(fiber : Fiber)
     @@runnables << fiber
   end

--- a/src/event.cr
+++ b/src/event.cr
@@ -79,28 +79,5 @@ module Event
     def loop_break
       LibEvent2.event_base_loopbreak(@base)
     end
-
-    def new_dns_base(init = true)
-      DnsBase.new LibEvent2.evdns_base_new(@base, init ? 1 : 0)
-    end
-  end
-
-  struct DnsBase
-    def initialize(@dns_base : LibEvent2::DnsBase)
-    end
-
-    def getaddrinfo(nodename, servname, hints, data, &callback : LibEvent2::DnsGetAddrinfoCallback)
-      request = LibEvent2.evdns_getaddrinfo(@dns_base, nodename, servname, hints, callback, data.as(Void*))
-      GetAddrInfoRequest.new request if request
-    end
-
-    struct GetAddrInfoRequest
-      def initialize(@request : LibEvent2::DnsGetAddrinfoRequest)
-      end
-
-      def cancel
-        LibEvent2.evdns_getaddrinfo_cancel(@request)
-      end
-    end
   end
 end

--- a/src/event/lib_event2.cr
+++ b/src/event/lib_event2.cr
@@ -52,17 +52,4 @@ lib LibEvent2
   fun event_free(event : Event)
   fun event_add(event : Event, timeout : LibC::Timeval*) : Int
   fun event_del(event : Event) : Int
-
-  type DnsBase = Void*
-  type DnsGetAddrinfoRequest = Void*
-
-  EVUTIL_EAI_CANCEL = -90001
-
-  alias DnsGetAddrinfoCallback = (Int32, LibC::Addrinfo*, Void*) ->
-
-  fun evdns_base_new(base : EventBase, init : Int32) : DnsBase
-  fun evdns_base_free(base : DnsBase, fail_requests : Int32)
-  fun evdns_getaddrinfo(base : DnsBase, nodename : UInt8*, servname : UInt8*, hints : LibC::Addrinfo*, cb : DnsGetAddrinfoCallback, arg : Void*) : DnsGetAddrinfoRequest
-  fun evdns_getaddrinfo_cancel(DnsGetAddrinfoRequest)
-  fun evutil_freeaddrinfo(ai : LibC::Addrinfo*)
 end

--- a/src/event/lib_event2.cr
+++ b/src/event/lib_event2.cr
@@ -11,6 +11,7 @@ require "c/netdb"
 @[Link("event")]
 {% end %}
 lib LibEvent2
+  alias Char = LibC::Char
   alias Int = LibC::Int
 
   {% if flag?(:windows) %}
@@ -52,4 +53,35 @@ lib LibEvent2
   fun event_free(event : Event)
   fun event_add(event : Event, timeout : LibC::Timeval*) : Int
   fun event_del(event : Event) : Int
+
+  struct EvutilAddrinfo
+    ai_flags : Int
+    ai_family : Int
+    ai_socktype : Int
+    ai_protocol : Int
+    ai_addrlen : LibC::SizeT
+    ai_canonname : Char*
+    ai_addr : LibC::Sockaddr*
+    ai_next : EvutilAddrinfo*
+  end
+
+  # EVUTIL_AI_PASSIVE     = 0
+  # EVUTIL_AI_CANONNAME   = 0
+  # EVUTIL_AI_NUMERICHOST = 0
+  # EVUTIL_AI_NUMERICSERV = 0
+  # EVUTIL_AI_V4MAPPED    = 0
+  # EVUTIL_AI_ALL         = 0
+  # EVUTIL_AI_ADDRCONFIG  = 0
+
+  type EvdnsBase = Void*
+  type EvdnsGetaddrinfoRequest = Void*
+
+  alias EvdnsGetaddrinfoCallback = (Int, EvutilAddrinfo*, Void*) ->
+
+  fun evdns_base_new(event_base : EventBase, initialize : Int) : EvdnsBase
+  fun evdns_base_free(base : EvdnsBase, fail_requests : Int)
+  fun evdns_getaddrinfo(dns_base : EvdnsBase*, nodename : Char*, servname : Char*, hints_in : EvutilAddrinfo*, cb : EvdnsGetaddrinfoCallback*, arg : Void*) : EvdnsGetaddrinfoRequest
+  fun evdns_getaddrinfo_cancel(req : EvdnsGetaddrinfoRequest) : Void
+  fun evutil_freeaddrinfo(ai : EvutilAddrinfo*) : Void
+  fun evutil_gai_strerror(err : Int) : Char*
 end

--- a/src/socket/addrinfo/blocking.cr
+++ b/src/socket/addrinfo/blocking.cr
@@ -1,0 +1,45 @@
+require "./resolver"
+
+class Socket
+  struct Addrinfo
+    # Calls the system `getaddrinfo` function directly from the current thread.
+    # Blocks the event loop until the domain is resolved by the system.
+    #
+    # The `timeout` parameter is discarded.
+    class Blocking < Resolver
+      def getaddrinfo(domain, service, family, type, protocol, timeout = nil, &block)
+        hints = LibC::Addrinfo.new
+        hints.ai_family = (family || Family::UNSPEC).to_i32
+        hints.ai_socktype = type
+        hints.ai_protocol = protocol
+        hints.ai_flags = 0
+
+        if service.is_a?(Int)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+
+          {% if flag?(:darwin) %}
+            # avoid a segfault on macOS < 10.12
+            if service == 0 || service == nil
+              service = "00"
+            end
+          {% end %}
+        end
+
+        case ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
+        when 0
+          # success
+        when LibC::EAI_NONAME
+          raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
+        else
+          raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}")
+        end
+
+        begin
+          yield Addrinfo.new(ptr)
+        ensure
+          LibC.freeaddrinfo(ptr)
+        end
+      end
+    end
+  end
+end

--- a/src/socket/addrinfo/resolver.cr
+++ b/src/socket/addrinfo/resolver.cr
@@ -1,0 +1,13 @@
+class Socket
+  struct Addrinfo
+    abstract class Resolver
+      abstract def getaddrinfo(domain, service, family, type, protocol, timeout = nil, &block)
+    end
+
+    class_setter resolver : Resolver?
+
+    def self.resolver
+      @@resolver ||= Blocking.new
+    end
+  end
+end

--- a/src/socket/addrinfo/threaded.cr
+++ b/src/socket/addrinfo/threaded.cr
@@ -1,0 +1,105 @@
+require "mutex"
+require "thread/queue"
+require "./resolver"
+
+class Socket
+  struct Addrinfo
+    # Threaded DNS resolver.
+    #
+    # Calls the system `getaddrinfo` function in a thread pool, blocking only
+    # the current `Fiber`, not the event loop (unlike the `Blocking` resolver).
+    #
+    # The threaded resolver only starts a single thread. You'll may want to
+    # start many, depending on your need for concurrential resolves.
+    #
+    # A `timeout` (in seconds) may be specified; an `IO::Timeout` exception will
+    # be raised if the system can't resolve the domain until the timeout is
+    # reached. The resolver thread will still be blocked until `getaddrinfo`
+    # returns thought, and not available to resolve more domains in the
+    # meantime.
+    #
+    # Example:
+    # ```
+    # Socket::Addrinfo.resolver = Socket::Addrinfo::Threaded.new(size: 5)
+    # ```
+    class Threaded < Resolver
+      # :nodoc:
+      alias Request = Tuple(String, Service, Socket::Family, Socket::Type, Socket::Protocol, Deque(Response))
+
+      # :nodoc:
+      alias Response = Pointer(LibC::Addrinfo) | Int32
+
+      def initialize(@size = 1, @timeout : Int32? = nil)
+        @started = false
+        @requests = Thread::Queue(Request).new
+        @mutex = Mutex.new
+      end
+
+      def getaddrinfo(domain, service, family, type, protocol, timeout = @timeout, &block)
+        @mutex.synchronize { start_workers }
+        start = Time.now
+
+        queue = Deque(Response).new(1)
+        @requests.push({domain, service, family, type, protocol, queue})
+
+        loop do
+          case response = queue.first?
+          when Pointer(LibC::Addrinfo)
+            begin
+              yield Addrinfo.new(response)
+            rescue
+              LibC.freeaddrinfo(response)
+            end
+          when Int32
+            if response == LibC::EAI_NONAME
+              raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
+            end
+            raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(response))}")
+          else
+            if timeout && ((Time.now - start.not_nil!) > timeout.seconds)
+              raise IO::Timeout.new("Failed to resolve #{domain} in #{timeout} #seconds")
+            end
+            Fiber.yield
+          end
+        end
+      end
+
+      private def start_workers
+        return if @started
+        @started = true
+
+        @size.times do
+          Thread.new do
+            loop do
+              domain, service, family, type, protocol, queue = @requests.pop
+              response = resolve(domain, service, family, type, protocol)
+              queue.push(response)
+            end
+          end
+        end
+      end
+
+      private def resolve(domain, service, family, type, protocol)
+        hints = LibC::Addrinfo.new
+        hints.ai_family = (family || Family::UNSPEC).to_i32
+        hints.ai_socktype = type
+        hints.ai_protocol = protocol
+        hints.ai_flags = 0
+
+        if service.is_a?(Int)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+
+          {% if flag?(:darwin) %}
+            # avoid a segfault on macOS < 10.12
+            if service == 0 || service == nil
+              service = "00"
+            end
+          {% end %}
+        end
+
+        code = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
+        code == 0 ? ptr : code
+      end
+    end
+  end
+end

--- a/src/thread/queue.cr
+++ b/src/thread/queue.cr
@@ -3,7 +3,7 @@
 # Licensed under the BSD 3-clause
 
 # :nodoc:
-class Thread(T, R)
+class Thread
   # :nodoc:
   class Queue(T)
     class Error < Exception; end

--- a/src/thread/queue.cr
+++ b/src/thread/queue.cr
@@ -1,0 +1,53 @@
+# Based on rubysl-thread ruby gem implementation
+# Copyright (c) 2013, Brian Shirai
+# Licensed under the BSD 3-clause
+
+# :nodoc:
+class Thread(T, R)
+  # :nodoc:
+  class Queue(T)
+    class Error < Exception; end
+
+    def initialize
+      @que = Deque(T).new(16)
+      @mutex = Thread::Mutex.new
+      @resource = Thread::ConditionVariable.new
+    end
+
+    def push(item : T)
+      @mutex.synchronize do
+        @que.push(item)
+        @resource.signal
+      end
+    end
+
+    def pop(blocking = true)
+      loop do
+        @mutex.synchronize do
+          if @que.empty?
+            raise Error.new("queue is empty") unless blocking
+            @resource.wait(@mutex)
+          else
+            item = @que.shift
+            @resource.signal
+            return item
+          end
+        end
+      end
+    end
+
+    def clear
+      @mutex.synchronize do
+        @que.clear
+      end
+    end
+
+    def empty?
+      size == 0
+    end
+
+    def size
+      @que.size
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request proposes to call `getaddrinfo` within threads and to synchronize with the main thread to receive the request and send back the response, thus allowing to not stop-the-world whenever a Fiber needs to resolve a Domain Name. The threadpool size can be adjusted with `Socket::Addrinfo.threadpool_size = 4` for example before a Domain Name is first resolved, or even disabled with `Socket::Addrinfo.threadpool_size = 0`.
- [x] start configurable threadpool;
- [x] call `getaddrinfo` in threads;
- [x] fallback to call `getaddrinfo` from the main thread if the threadpool is disabled (ie. to set `0`);
- [x] modify `IPSocket`, `TCPSocket`, `TCPServer` and `UDPSocket` to use `DNS.getaddrinfo`;
- [x] drop `IPSocket.getaddrinfo` ~~or~~ and avoid a `DNS` namespace to use `Socket::Addrinfo` instead;
- [x] ~~consider reducing duplication of `DNS::Addrinfo` with `Socket::IPAddress` if any (?)~~ the Addrinfo wrapper struct was dropped, because of IP4/IP6 issues and it's not particularly useful, unless we want to open a public API (let's see that later);
- [x] ~~specs !~~ this is a private API, socket specs already test that it works;
- [ ] generate bindings for the `AI_*` and `EAI_*` LibC constants for each supported target.

I was wondering about having different resolvers under `DNS` that let applications use the strategy they want, since none is perfect. For example a blocking resolver that merely calls `getaddrinfo`; a threaded resolver that uses threads to call `getaddrinfo` (ie. this PR, should be the default); a resolver that would link against [c-ares](http://c-ares.haxx.se/) for applications that don't care about libc extensions and want a real async DNS resolver (eg: servers).

Note that this solution may be dropped and no longer be the default when the event-loop will become multithreaded. Limiting the number of concurrent calls to `getaddrinfo` in order to not block all threads (like go does) may be preferable.

refs #2745 #2660 
