### PR TITLE
[WIP] JSON.mapping: add `store_other_attributes_in` flag

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -134,6 +134,12 @@ class JSONWithNilableRootEmitNull
   })
 end
 
+class JSONWithUnknownAttributes
+  JSON.mapping({
+    x: Int32, y: Int32,
+  }, store_other_attributes_in: extra)
+end
+
 {% if Crystal::VERSION == "0.18.0" %}
   class JSONWithNilableUnion
     JSON.mapping({
@@ -394,6 +400,17 @@ describe "JSON mapping" do
     result = JSONWithNilableRootEmitNull.from_json(json)
     result.result.should be_nil
     result.to_json.should eq(json)
+  end
+
+  it "parses with unknown attributes" do
+    json = %({"x": 1, "z": 2, "foo": [1, 2, 3], "y": 3})
+    result = JSONWithUnknownAttributes.from_json(json)
+    result.x.should eq(1)
+    result.y.should eq(3)
+    result.extra.should be_a(Hash(String, JSON::Any))
+    result.extra["z"].should eq(2)
+    result.extra["foo"].should eq([1, 2, 3])
+    result.to_json.should eq(%({"x":1,"y":3,"z":2,"foo":[1,2,3]}))
   end
 
   {% if Crystal::VERSION == "0.18.0" %}


### PR DESCRIPTION
This PR isn't finished but I'd like to start and discuss the design around this.

Check the added specs to see what this is all about. This idea originated [here](https://github.com/mperham/sidekiq.cr/issues/1#issuecomment-226008722)

The things to discuss are:
- The name of the `JSON.mapping` parameter
- What if we want to store the extra attributes as raw strings, to later parse them as we want? Of course we can just call `to_s` on each hash value, but that's not memory efficient if we will lazily parse the string. So, an option to invoke `pull.read_raw` instead of creating a JSON::Any. I can't come up with a good API for this. Maybe a second parameter, `store_other_attributes_as_raw_strings: true`?

We could then copy this to `YAML.mapping`.
