### PR TITLE
Fix example code for delegate

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -914,7 +914,7 @@ class Object
   #
   # ```
   # class StringWrapper
-  #   def initialize(@string)
+  #   def initialize(@string : String)
   #   end
   #
   #   delegate downcase, to: @string


### PR DESCRIPTION
Fixed that the example code for `delegate` macro does not work because the compiler cannot infer the type of `@string` without an explicit type annotation.