### PR TITLE
Add elapsed runtime tracking for verbose spec output, fixes #2854

### DIFF
--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -3,8 +3,8 @@ require "spec"
 describe "JUnit Formatter" do
   it "reports succesful results" do
     output = build_report do |f|
-      f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil)
-      f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil)
+      f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil, nil)
+      f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil, nil)
     end
 
     expected = <<-XML
@@ -21,7 +21,7 @@ describe "JUnit Formatter" do
 
   it "reports failures" do
     output = build_report do |f|
-      f.report Spec::Result.new(:fail, "should do something", "spec/some_spec.cr", 33, nil)
+      f.report Spec::Result.new(:fail, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
 
     expected = <<-XML
@@ -37,7 +37,7 @@ describe "JUnit Formatter" do
 
   it "reports errors" do
     output = build_report do |f|
-      f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil)
+      f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
 
     expected = <<-XML
@@ -53,10 +53,10 @@ describe "JUnit Formatter" do
 
   it "reports mixed results" do
     output = build_report do |f|
-      f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, nil)
-      f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, nil)
-      f.report Spec::Result.new(:error, "should do something3", "spec/some_spec.cr", 65, nil)
-      f.report Spec::Result.new(:error, "should do something4", "spec/some_spec.cr", 80, nil)
+      f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, 2.seconds, nil)
+      f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, 0.5.seconds, nil)
+      f.report Spec::Result.new(:error, "should do something3", "spec/some_spec.cr", 65, nil, nil)
+      f.report Spec::Result.new(:error, "should do something4", "spec/some_spec.cr", 80, nil, nil)
     end
 
     expected = <<-XML
@@ -80,7 +80,7 @@ describe "JUnit Formatter" do
 
   it "escapes spec names" do
     output = build_report do |f|
-      f.report Spec::Result.new(:success, "complicated \" <n>'&ame", __FILE__, __LINE__, nil)
+      f.report Spec::Result.new(:success, "complicated \" <n>'&ame", __FILE__, __LINE__, nil, nil)
     end
 
     name = XML.parse(output).xpath_string("string(//testsuite/testcase[1]/@name)")
@@ -91,7 +91,7 @@ describe "JUnit Formatter" do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|
-      f.report Spec::Result.new(:fail, "foo", __FILE__, __LINE__, cause)
+      f.report Spec::Result.new(:fail, "foo", __FILE__, __LINE__, nil, cause)
     end
 
     xml = XML.parse(output)
@@ -106,7 +106,7 @@ describe "JUnit Formatter" do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|
-      f.report Spec::Result.new(:error, "foo", __FILE__, __LINE__, cause)
+      f.report Spec::Result.new(:error, "foo", __FILE__, __LINE__, nil, cause)
     end
 
     xml = XML.parse(output)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -126,6 +126,13 @@ module Spec
   def self.line=(@@line : Int32)
   end
 
+  def self.slowest=(@@slowest : Int32)
+  end
+
+  def self.slowest
+    @@slowest
+  end
+
   def self.add_location(file, line)
     locations = @@locations ||= {} of String => Array(Int32)
     lines = locations[File.expand_path(file)] ||= [] of Int32
@@ -209,6 +216,9 @@ OptionParser.parse! do |opts|
   end
   opts.on("-l ", "--line LINE", "run examples whose line matches LINE") do |line|
     Spec.line = line.to_i
+  end
+  opts.on("-p", "--profile", "Print the 10 slowest specs") do
+    Spec.slowest = 10
   end
   opts.on("--fail-fast", "abort the run on first failure") do
     Spec.fail_fast = true

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -100,6 +100,15 @@ module Spec
         end
       end
 
+      if Spec.slowest
+        puts
+        results = @results[:success] + @results[:fail]
+        topN = results.sort_by {|res| -res.elapsed.not_nil!.to_f }[0..Spec.slowest.not_nil!]
+        topN.each do |res|
+          puts "#{res.description} : #{res.elapsed.not_nil!.to_f} sec"
+        end
+      end
+
       puts
 
       success = @results[:success]

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -9,6 +9,7 @@ module Spec
     description : String,
     file : String,
     line : Int32,
+    elapsed : Time::Span?,
     exception : Exception?
 
   # :nodoc:
@@ -30,8 +31,8 @@ module Spec
       @results[:fail].empty? && @results[:error].empty?
     end
 
-    def self.report(kind, full_description, file, line, ex = nil)
-      result = Result.new(kind, full_description, file, line, ex)
+    def self.report(kind, full_description, file, line, elapsed = nil, ex = nil)
+      result = Result.new(kind, full_description, file, line, elapsed, ex)
       @@contexts_stack.last.report(result)
     end
 
@@ -165,7 +166,7 @@ module Spec
     end
 
     def report(result)
-      @parent.report Result.new(result.kind, "#{@description} #{result.description}", result.file, result.line, result.exception)
+      @parent.report Result.new(result.kind, "#{@description} #{result.description}", result.file, result.line, result.elapsed, result.exception)
     end
 
     def matches?(pattern, line, locations)

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -12,15 +12,16 @@ module Spec::DSL
 
     Spec.formatters.each(&.before_example(description))
 
+    start = Time.now
     begin
       Spec.run_before_each_hooks
       block.call
-      Spec::RootContext.report(:success, description, file, line)
+      Spec::RootContext.report(:success, description, file, line, Time.now - start)
     rescue ex : Spec::AssertionFailed
-      Spec::RootContext.report(:fail, description, file, line, ex)
+      Spec::RootContext.report(:fail, description, file, line, Time.now - start, ex)
       Spec.abort! if Spec.fail_fast?
     rescue ex
-      Spec::RootContext.report(:error, description, file, line, ex)
+      Spec::RootContext.report(:error, description, file, line, Time.now - start, ex)
       Spec.abort! if Spec.fail_fast?
     ensure
       Spec.run_after_each_hooks

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -78,7 +78,12 @@ module Spec
     def report(result)
       print '\r'
       print_indent
-      puts Spec.color(@last_description, result.kind)
+      timing = ""
+      time = result.elapsed.try &.to_f
+      if time && time > 0.01
+        timing = ": #{time}s"
+      end
+      puts Spec.color("#{@last_description}#{timing}", result.kind)
     end
   end
 

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -78,12 +78,7 @@ module Spec
     def report(result)
       print '\r'
       print_indent
-      timing = ""
-      time = result.elapsed.try &.to_f
-      if time && time > 0.01
-        timing = ": #{time}s"
-      end
-      puts Spec.color("#{@last_description}#{timing}", result.kind)
+      puts Spec.color(@last_description, result.kind)
     end
   end
 


### PR DESCRIPTION
It currently looks like this:

```
Sidekiq::CLI
  parses
  handles no arguments gracefully
ruby compatibility
  API
    works with Ruby-based retries: 0.152789s
Sidekiq::Heartbeat
  beats
Sidekiq::Job
  serialization
    deserializes a simple job: 0.151404s
    deserializes a retry: 0.149071s
Sidekiq::Logger
  basics
    logs
    allows multi-level context
```

Printing the elapsed time after every line makes for noisy output.  I added an arbitrary threshold of 10ms, any tests above this runtime will print out.  Better ideas?