### PR TITLE
Improve Crystal version detection

### DIFF
--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -5,7 +5,8 @@ describe "Proc" do
     str = MemoryIO.new
     f = ->(x : Int32) { x.to_f }
     f.to_s(str)
-    {% if Crystal::VERSION == "0.18.1" %}
+    # TODO: Change to .starts_with? "0.18.1" once 0.18.1 is released
+    {% if Crystal::VERSION.starts_with?("0.18.0+") %}
       str.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
     {% else %}
       str.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
@@ -17,7 +18,8 @@ describe "Proc" do
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s(str)
-    {% if Crystal::VERSION == "0.18.1" %}
+    # TODO: Change to .starts_with? "0.18.1" once 0.18.1 is released
+    {% if Crystal::VERSION.starts_with?("0.18.0+") %}
       str.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")
     {% else %}
       str.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")
@@ -27,7 +29,8 @@ describe "Proc" do
   it "does to_s" do
     str = MemoryIO.new
     f = ->(x : Int32) { x.to_f }
-    {% if Crystal::VERSION == "0.18.1" %}
+    # TODO: Change to .starts_with? "0.18.1" once 0.18.1 is released
+    {% if Crystal::VERSION.starts_with?("0.18.0+") %}
       f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
     {% else %}
       f.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
@@ -38,7 +41,8 @@ describe "Proc" do
     str = MemoryIO.new
     a = 1.5
     f = ->(x : Int32) { x + a }
-    {% if Crystal::VERSION == "0.18.1" %}
+    # TODO: Change to .starts_with? "0.18.1" once 0.18.1 is released
+    {% if Crystal::VERSION.starts_with?("0.18.0+") %}
       f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")
     {% else %}
       f.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -272,7 +272,8 @@ describe "Tuple" do
 
   it "does types" do
     tuple = {1, 'a', "hello"}
-    {% if Crystal::VERSION == "0.18.1" %}
+    # TODO: Change to .starts_with? "0.18.1" once 0.18.1 is released
+    {% if Crystal::VERSION.starts_with?("0.18.0+") %}
       tuple.types.to_s.should eq("Tuple(Int32, Char, String)")
     {% else %}
       tuple.types.to_s.should eq("{Int32, Char, String}")

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -1,32 +1,50 @@
 module Crystal
   module Config
-    PATH    = {{ env("CRYSTAL_CONFIG_PATH") || "" }}
-    VERSION = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long --always 2>/dev/null)`.stringify.chomp }}
-
     def self.path
-      PATH
+      {{env("CRYSTAL_CONFIG_PATH") || ""}}
     end
 
     def self.version
-      VERSION
+      version_and_sha.first
     end
 
     def self.description
-      tag, sha = tag_and_sha
+      version, sha = version_and_sha
       if sha
-        "Crystal #{tag} [#{sha}] (#{date})"
+        "Crystal #{version} [#{sha}] (#{date})"
       else
-        "Crystal #{tag} (#{date})"
+        "Crystal #{version} (#{date})"
       end
     end
 
-    def self.tag_and_sha
-      pieces = version.split("-")
-      tag = pieces[0]? || "?"
-      sha = pieces[2]?
-      if sha
-        sha = sha[1..-1] if sha.starts_with? 'g'
-      end
+    @@version_and_sha : {String, String?}?
+
+    def self.version_and_sha
+      @@version_and_sha ||= compute_version_and_sha
+    end
+
+    private def self.compute_version_and_sha
+      # Set explicitly: 0.0.0, ci, HEAD, whatever
+      config_version = {{env("CRYSTAL_CONFIG_VERSION")}}
+      return {config_version, nil} if config_version
+
+      git_version = {{`(git describe --tags --long --always 2>/dev/null)`.stringify.chomp}}
+
+      # Failed git and no explicit version set: ""
+      # We inherit the version of the compiler building us for now.
+      # TODO: Remove interpolation once formatter bug is fixed.
+      return {"#{{{Crystal::VERSION}}}", nil} if git_version.empty?
+
+      # Shallow clone with no tag in reach: abcd123
+      # We assume being compiled with the latest released compiler
+      return {"#{{{Crystal::VERSION}}}+?", git_version} unless git_version.includes? '-'
+
+      # On release: 0.0.0-0-gabcd123
+      # Ahead of last release: 0.0.0-42-gabcd123
+      tag, commits, sha = git_version.split("-")
+      sha = sha[1..-1]                                # Strip g
+      tag = "#{tag}+#{commits}" unless commits == "0" # Reappend commits since release unless we hit it exactly
+
       {tag, sha}
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -192,7 +192,7 @@ module Crystal
       types["Crystal"] = @crystal = crystal = NonGenericModuleType.new self, self, "Crystal"
       crystal.locations << Location.new(__LINE__ - 1, 0, __FILE__)
 
-      tag, sha = Crystal::Config.tag_and_sha
+      version, sha = Crystal::Config.version_and_sha
 
       if sha
         define_crystal_string_constant "BUILD_COMMIT", sha
@@ -205,7 +205,7 @@ module Crystal
       define_crystal_string_constant "DEFAULT_PATH", Crystal::Config.path
       define_crystal_string_constant "DESCRIPTION", Crystal::Config.description
       define_crystal_string_constant "PATH", Crystal::CrystalPath.default_path
-      define_crystal_string_constant "VERSION", tag
+      define_crystal_string_constant "VERSION", version
     end
 
     private def define_crystal_string_constant(name, value)


### PR DESCRIPTION
* Inherit parent compiler version if git is unavailable/failed and no explicit version is given
* Handle shallow clones by assuming being compiled by the latest
  released compiler
* Preserve commits since release in version number unless there are none

The last point means the head version now looks like this: `Crystal 0.18.0+23 [adf408d] (2016-06-16)`, with `Crystal::VERSION` being `0.18.0+23`. This is in accordance with http://semver.org/#spec-item-10

Travis does shallow clones, but it will always compile with the latest released compiler, that means with this the first `std_spec` run will have `Crystal::VERSION` be the latest released compiler, so currently `0.18.0`, the second `std_spec` run will have `Crystal::VERSION` with the shallow clone case, so currently `0.18.0+?`.

**The build in this PR will fail as long as `CRYSTAL_CONFIG_VERSION` is set via Travis web interface. This is why it's always to prefer to set environment variables via `.travis.yml` or `bin/ci`.**