### PR TITLE
Add StringLiteral#> and StringLiteral#<

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -310,6 +310,26 @@ describe "macro methods" do
       assert_macro "", %({{"hello" =~ /ell/}}), [] of ASTNode, %(true)
     end
 
+    it "executes string > string" do
+      assert_macro "", %({{"fooa" > "foo"}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"foo" > "fooa"}}), [] of ASTNode, %(false)
+    end
+
+    it "executes string > macroid" do
+      assert_macro "", %({{"fooa" > "foo".id}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"foo" > "fooa".id}}), [] of ASTNode, %(false)
+    end
+
+    it "executes string < string" do
+      assert_macro "", %({{"fooa" < "foo"}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"foo" < "fooa"}}), [] of ASTNode, %(true)
+    end
+
+    it "executes string < macroid" do
+      assert_macro "", %({{"fooa" < "foo".id}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"foo" < "fooa".id}}), [] of ASTNode, %(true)
+    end
+
     it "executes tr" do
       assert_macro "", %({{"hello".tr("e", "o")}}), [] of ASTNode, %("hollo")
     end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -251,6 +251,14 @@ module Crystal::Macros
     def =~(range : RegexLiteral) : BoolLiteral
     end
 
+    # Similar to `String#>`
+    def >(other : StringLiteral | MacroId) : BoolLiteral
+    end
+
+    # Similar to `String#<`
+    def <(other : StringLiteral | MacroId) : BoolLiteral
+    end
+
     # Similar to `String#+`.
     def +(other : StringLiteral | CharLiteral) : StringLiteral
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -449,6 +449,24 @@ module Crystal
             BoolLiteral.new(false)
           end
         end
+      when ">"
+        interpret_one_arg_method(method, args) do |arg|
+          case arg
+          when StringLiteral, MacroId
+            return BoolLiteral.new(interpret_compare(arg) > 0)
+          else
+            raise "Can't compare StringLiteral with #{arg.class_desc}"
+          end
+        end
+      when "<"
+        interpret_one_arg_method(method, args) do |arg|
+          case arg
+          when StringLiteral, MacroId
+            return BoolLiteral.new(interpret_compare(arg) < 0)
+          else
+            raise "Can't compare StringLiteral with #{arg.class_desc}"
+          end
+        end
       when "+"
         interpret_one_arg_method(method, args) do |arg|
           case arg


### PR DESCRIPTION
Given #2856, then starting with 0.19 (or 0.18.2, depending on whether we want 0.18.x to be compilable with 0.18.0 or 0.17.4 or not) we should be able to do stuff like `{% if Crystal::VERSION > "0.19.0" %}` with this, which will then patch things in for 0.19.0+x, 0.19.1 etc.