### PR TITLE
Use codespell for correcting some typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,7 @@
 ## 0.10.1 (2016-01-08)
 
 * Added `Int#popcount` (thanks @rmosolgo)
-* Added `@[Naked]` attribute for ommiting a method's prelude
+* Added `@[Naked]` attribute for omitting a method's prelude
 * Check that abstract methods are implemented by subtypes
 * Some bug fixes
 
@@ -617,7 +617,7 @@
 * Correctly support the X86_64 and X86 ABIs. Now bindings to C APIs that pass and return structs works perfectly fine.
 * Added `crystal init` to quickly create a skeleton library or application (thanks @waterlink)
 * Added `--emit` flag to the compiler. Now you can easily see the generated LLVM IR, LLVM bitcode, assembly and object files.
-* Added `--no-color` flag to supress color output, useful for editor tools.
+* Added `--no-color` flag to suppress color output, useful for editor tools.
 * Added macro vars: `%var` and `%var{x, y}` create uniqely named variables inside macros.
 * Added [typed splats](https://github.com/crystal-lang/crystal/issues/291).
 * Added `Iterator` and many methods that return iterators, like `Array#each`, `Hash#each`, `Int#times`, `Int#step`, `String#each_char`, etc.
@@ -955,7 +955,7 @@
 * Added a `Base64` module (thanks @kostya)
 * Allow default arguments in macros
 * Allow invoking `new` on a function type. For example: `alias F = Int32 -> Int32; f = F.new { |x| x + 1 }; f.call(2) #=> 3`.
-* Allow ommiting function argument types when invoking C functions that accept functions as arguments.
+* Allow omitting function argument types when invoking C functions that accept functions as arguments.
 * Renamed `@name` to `@class_name` inside macros. `@name` will be deprecated in the next version.
 * Added IO#read_fully
 * Macro hooks: `inherited`, `included` and `extended`
@@ -1014,7 +1014,7 @@
 
     Invoking `id` on any other kind of node has no effect on the pasted result.
 * Allow escaping curly braces inside macros with `\{`. This allows defining macros that, when expanded, can contain other macro expressions.
-* Added a special comment-like pragma to change the lexer's filename, line number and colum number.
+* Added a special comment-like pragma to change the lexer's filename, line number and column number.
 
     ```ruby
     # foo.cr

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
 describe "JUnit Formatter" do
-  it "reports succesful results" do
+  it "reports successful results" do
     output = build_report do |f|
       f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil, nil)
       f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil, nil)

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -262,7 +262,7 @@ describe "Tuple" do
     (tuple1 <=> tuple2).should eq(0)
   end
 
-  it "does <=> with the same begining and different size" do
+  it "does <=> with the same beginning and different size" do
     tuple1 = {1, 2, 3}
     tuple2 = {1, 2}
     (tuple1 <=> tuple2).should eq(1)

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -957,7 +957,7 @@ module Crystal
     end
   end
 
-  # Ficticious node to bind yield expressions to block arguments
+  # Fictitious node to bind yield expressions to block arguments
   class YieldBlockBinder < ASTNode
     getter block
     property yield_vars : Array(Var)?

--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -242,7 +242,7 @@ Playground.Inspector = function(session, line) {
   }.bind(this);
 
   this.dataLabels = function() {
-    // collect all data labels, in order of apperance
+    // collect all data labels, in order of appearance
     var res = []
     var resSet = {}
     for(var i = 0; i < this.messages.length; i++) {

--- a/src/compiler/crystal/tools/playground/views/_about.html
+++ b/src/compiler/crystal/tools/playground/views/_about.html
@@ -74,7 +74,7 @@ When <code>crystal play</code> is run from your awesome Crystal app or shard you
 </p>
 
 <p>
-In loops it is sometimes usefull to inspect the values of multiple variables. Tuple literals are handy for this since each element of the tuple will appear in a different column in the table.
+In loops it is sometimes useful to inspect the values of multiple variables. Tuple literals are handy for this since each element of the tuple will appear in a different column in the table.
 </p>
 
 <pre class="playground">

--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -1,6 +1,6 @@
 # This is the main file used for generating docs for the standard library.
 # It, for example, doesn't include API for the compiler, but does include
-# the ficticious API for the Crystal::Macros module.
+# the fictitious API for the Crystal::Macros module.
 
 require "./big/**"
 require "./compiler/crystal/macros"

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -334,7 +334,7 @@ end
 # Converter to be used with `JSON.mapping` to read the raw
 # value of a JSON object property as a String.
 #
-# It can be useful to read ints and floats without loosing precision,
+# It can be useful to read ints and floats without losing precision,
 # or to read an object and deserialize it later based on some
 # condition.
 #


### PR DESCRIPTION
See https://github.com/lucasdemarchi/codespell