### PR TITLE
Use codespell for correcting some typos.

### DIFF
--- a/_drafts/type-inference-part-2.md
+++ b/_drafts/type-inference-part-2.md
@@ -14,7 +14,7 @@ def dup(x)
 end
 {% endhighlight ruby %}
 
-`dup` definition does not generates any program by itself. Only when it is called the body is analyzed. Also, each time `dup` is called it could end up calling actualy different versions of the compiled function. Wait... What? You could see every def as a _C++ template function_. At every invoke, thanks to the context information of the arguments the type inference (and the codegen later) will find or create a _typed def_. So each _typed def_ could be seen as a _C++ overload_.
+`dup` definition does not generates any program by itself. Only when it is called the body is analyzed. Also, each time `dup` is called it could end up calling actually different versions of the compiled function. Wait... What? You could see every def as a _C++ template function_. At every invoke, thanks to the context information of the arguments the type inference (and the codegen later) will find or create a _typed def_. So each _typed def_ could be seen as a _C++ overload_.
 
 A _typed def_ is an specialization of the original _def_ for a given types of arguments. The next code use `dup` both for `String` and `Int32`.
 

--- a/_gitbook/conventions/documenting_code.md
+++ b/_gitbook/conventions/documenting_code.md
@@ -144,7 +144,7 @@ entire project instead of a single file.
 ``````crystal
 # A unicorn is a **legendary animal** (see the `Legendary` module) that has been
 # described since antiquity as a beast with a large, spiraling horn projecting
-# from its forhead.
+# from its forehead.
 #
 # To create a unicorn:
 #

--- a/_gitbook/syntax_and_semantics/c_bindings/callbacks.md
+++ b/_gitbook/syntax_and_semantics/c_bindings/callbacks.md
@@ -90,7 +90,7 @@ If a C function executes a user-provided callback that might raise, it must be a
 
 The compiler infers this attribute for a method if it invokes a method that is marked as `@[Raises]` or raises (recursively).
 
-However, some C functions accept callbacks to be executed by other C functions. For example, suppose a ficticious library:
+However, some C functions accept callbacks to be executed by other C functions. For example, suppose a fictitious library:
 
 ```crystal
 lib LibFoo

--- a/_gitbook/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
+++ b/_gitbook/syntax_and_semantics/default_values_named_arguments_splats_tuples_and_overloading.md
@@ -145,7 +145,7 @@ The first use case is using keywords as named arguments:
 
 ```crystal
 def plan(begin begin_time, end end_time)
-  puts "Planning bewteen #{begin_time} and #{end_time}"
+  puts "Planning between #{begin_time} and #{end_time}"
 end
 
 plan begin: Time.now, end: 2.days.from_now

--- a/_gitbook/syntax_and_semantics/macros.md
+++ b/_gitbook/syntax_and_semantics/macros.md
@@ -79,7 +79,7 @@ Note that `:foo` was the result of the interpolation, because that's what was pa
 
 ## Macro calls
 
-You can invoke a **fixed subset** of methods on AST nodes at compile-time. These methods are documented in a ficticious [Crystal::Macros](http://crystal-lang.org/api/Crystal/Macros.html) module.
+You can invoke a **fixed subset** of methods on AST nodes at compile-time. These methods are documented in a fictitious [Crystal::Macros](http://crystal-lang.org/api/Crystal/Macros.html) module.
 
 For example, invoking `ASTNode#id` in the above example solves the problem:
 
@@ -202,7 +202,7 @@ baz #=> 2
 
 The arguments are packed into an `ArrayLiteral` and passed to the macro.
 
-Additionaly, using `*` when interpolating an `ArrayLiteral` interpolates the elements separated by commas:
+Additionally, using `*` when interpolating an `ArrayLiteral` interpolates the elements separated by commas:
 
 ```crystal
 macro println(*values)

--- a/_gitbook/syntax_and_semantics/structs.md
+++ b/_gitbook/syntax_and_semantics/structs.md
@@ -24,7 +24,7 @@ The last point has a reason to it: a struct has a very well defined memory layou
 ary = [] of Point
 ```
 
-If `Point` is inherited, an array of such type must also account for the fact that other types can be inside it, so the size of each element must grow to accomodate that. That is certainly unexpected. So, non-abstract structs can't be inherited. Abstract structs, on the other hand, will have descendants, so it's expected that an array of them will account the possibility of having multiple types inside it.
+If `Point` is inherited, an array of such type must also account for the fact that other types can be inside it, so the size of each element must grow to accommodate that. That is certainly unexpected. So, non-abstract structs can't be inherited. Abstract structs, on the other hand, will have descendants, so it's expected that an array of them will account the possibility of having multiple types inside it.
 
 A struct can also includes modules and can be generic, just like a class.
 

--- a/_gitbook/syntax_and_semantics/type_inference.md
+++ b/_gitbook/syntax_and_semantics/type_inference.md
@@ -154,7 +154,7 @@ In the following example, `@address` is inferred to be `Address`, because the cl
 ```crystal
 class Person
   def initialize
-    @address = Address.unkown
+    @address = Address.unknown
   end
 end
 
@@ -173,7 +173,7 @@ In fact, the above code doesn't need the return type annotation in `self.unknown
 ```crystal
 class Person
   def initialize
-    @address = Address.unkown
+    @address = Address.unknown
   end
 end
 

--- a/_gitbook/syntax_and_semantics/typeof.md
+++ b/_gitbook/syntax_and_semantics/typeof.md
@@ -22,7 +22,7 @@ another_hash = typeof(hash).new #:: Hash(Int32, String)
 
 Since `typeof` doesn't actually evaluate the expression, it can be
 used on methods at compile time, such as in this example, which
-recursively forms a union type out of nested type paramters:
+recursively forms a union type out of nested type parameters:
 
 ```crystal
 class Array

--- a/_posts/2013-09-04-happy-birthday-crystal.md
+++ b/_posts/2013-09-04-happy-birthday-crystal.md
@@ -304,7 +304,7 @@ puts foo # Prints: 1
 
 The macros getter, setter and property are implemented in a similar way, but we've
 been thinking of a more powerful and simpler way to achieve the same thing so this
-feature might dissappear.
+feature might disappear.
 
 ### Yield with scope
 
@@ -354,7 +354,7 @@ describe "Array" do
 end
 {% endhighlight ruby %}
 
-So Crystal makes it extremly easy to write tests, and at the same time gives you type safety.
+So Crystal makes it extremely easy to write tests, and at the same time gives you type safety.
 The best of both worlds.
 
 ## Roadmap

--- a/_posts/2013-09-15-to-proc.md
+++ b/_posts/2013-09-15-to-proc.md
@@ -38,7 +38,7 @@ Not only that, but since Ruby has to convert the Symbol to a Proc there's a slig
 penalty over doing it with a normal block.
 
 Finally, Ruby's implementation of [Symbol#to_proc](http://ruby-doc.org/core-2.0.0/Symbol.html#method-i-to_proc)
-has a cache of Procs so they are not created everytime you use the same symbol, but still, it's slightly
+has a cache of Procs so they are not created every time you use the same symbol, but still, it's slightly
 slower than a normal block.
 
 ### Crystal to_proc?

--- a/_posts/2013-09-23-type-inference-part-1.md
+++ b/_posts/2013-09-23-type-inference-part-1.md
@@ -62,7 +62,7 @@ Once more, we show the AST nodes, the context where the variables and their type
 
 When a new type arrives to the variable in the context, this is added to the "ongoing" known types. So the union appears.
 
-There is one thing that is not shown still. *Every* ocurrence of the variables have a dependency to the context. This is shown in the following picture:
+There is one thing that is not shown still. *Every* occurrence of the variables have a dependency to the context. This is shown in the following picture:
 
 <img src="/images/type-inference/conditional-2.png" width="563" height="325" class="center"/>
 

--- a/_posts/2013-12-05-garbage-collector.md
+++ b/_posts/2013-12-05-garbage-collector.md
@@ -7,7 +7,7 @@ author: waj
 
 Finally Crystal will start giving some memory back to the operating system! Today we managed to fit the [Boehm-Demers-Weiser conservative garbage collector](http://www.hpl.hp.com/personal/Hans_Boehm/gc/) into the language.
 
-Although we plan to implement a more appropiate and custom garbage collector in the future, it's a really good starting point to make the language more robust and usable.
+Although we plan to implement a more appropriate and custom garbage collector in the future, it's a really good starting point to make the language more robust and usable.
 
 In order to make this collector work with Crystal we had to make sure all the allocated block pointers were properly [aligned in memory](https://github.com/crystal-lang/crystal/commit/6657d3c84c93ec0c886aa9262b2a33791e22285f). Unions and type hierarchies were using packed structs and that made some pointers "invisible" to the GC and thus many blocks still in use were being deallocated and consecuently making everything crash quite easily.
 

--- a/_posts/2014-04-27-type-inference-rules.md
+++ b/_posts/2014-04-27-type-inference-rules.md
@@ -243,7 +243,7 @@ the logic for variables' types is very similar to that of a ```while```.
 
 ### NoReturn
 
-There's a misterious type in Crystal called ```NoReturn```. One such example is
+There's a mysterious type in Crystal called ```NoReturn```. One such example is
 C's ```exit``` function:
 
 {% highlight ruby %}

--- a/_posts/2014-06-19-crystal-0.1.0-released.md
+++ b/_posts/2014-06-19-crystal-0.1.0-released.md
@@ -353,7 +353,7 @@ puts build_date
 The `stringify` is needed in order to convert the `date` output to a string literal, otherwise the generated
 code would be an invalid program (`Thu Jun 19 14:15:57 ART 2014` is an invalid program, but `"Thu Jun 19 14:15:57 ART 2014"` is not.)
 
-Our idea is to extend this to allow execution of other Crystal programs that would recieve AST nodes as argument and
+Our idea is to extend this to allow execution of other Crystal programs that would receive AST nodes as argument and
 will generate code that would be embedded in the program currently being compiled. In this way you could generate
 a class definition from a database schema, or a file in the disk, or convert an ERB/HAML template into efficient
 Crystal code. We still have to materialize all of these ideas.

--- a/_posts/2015-03-04-internals.md
+++ b/_posts/2015-03-04-internals.md
@@ -363,7 +363,7 @@ entry:
 {% endhighlight llvm %}
 
 This is even harder to digest, but basically some memory is asked that will contain the value of the variable `a`, and
-the Proc recieves it and uses it. In this case the memory is asked with `malloc`, but with the regular prelude the memory
+the Proc receives it and uses it. In this case the memory is asked with `malloc`, but with the regular prelude the memory
 will be allocated by the GC and released when no longer needed.
 
 ### Class

--- a/_posts/2015-04-01-auto.md
+++ b/_posts/2015-04-01-auto.md
@@ -7,7 +7,7 @@ author: asterite
 
 **Note: this was an April's Fool post. However, with Crystal macros you could do this.**
 
-We Crystal developers belive compilers should be smart. You don't need to add type annotations everywhere:
+We Crystal developers believe compilers should be smart. You don't need to add type annotations everywhere:
 only when needed, or when you want them. Can we make the compiler even smarter?
 
 This past month we have been thinking that since Crystal is a relatively young language with a still


### PR DESCRIPTION
See https://github.com/lucasdemarchi/codespell.