### PR TITLE
Add `TypeNode` comparison macro methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -914,6 +914,60 @@ describe "macro methods" do
         [TypeNode.new(program.string)] of ASTNode
       end
     end
+
+    it "executes ==" do
+      assert_macro("x", "{{x == Reference}}", "false") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+      assert_macro("x", "{{x == String}}", "true") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+    end
+
+    it "executes !=" do
+      assert_macro("x", "{{x != Reference}}", "true") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+      assert_macro("x", "{{x != String}}", "false") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+    end
+
+    it "executes <" do
+      assert_macro("x", "{{x < Reference}}", "true") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+      assert_macro("x", "{{x < String}}", "false") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+    end
+
+    it "executes <=" do
+      assert_macro("x", "{{x <= Reference}}", "true") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+      assert_macro("x", "{{x <= String}}", "true") do |program|
+        [TypeNode.new(program.string)] of ASTNode
+      end
+    end
+
+    it "executes >" do
+      assert_macro("x", "{{x > Reference}}", "false") do |program|
+        [TypeNode.new(program.reference)] of ASTNode
+      end
+      assert_macro("x", "{{x > String}}", "true") do |program|
+        [TypeNode.new(program.reference)] of ASTNode
+      end
+    end
+
+    it "executes >=" do
+      assert_macro("x", "{{x >= Reference}}", "true") do |program|
+        [TypeNode.new(program.reference)] of ASTNode
+      end
+      assert_macro("x", "{{x >= String}}", "true") do |program|
+        [TypeNode.new(program.reference)] of ASTNode
+      end
+    end
   end
 
   describe "type declaration methods" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1202,6 +1202,24 @@ module Crystal::Macros
     # methods by invoking `type.class.methods`.
     def class : TypeNode
     end
+
+    # Returns `true` if *other* is an ancestor of `self`.
+    def <(other : TypeNode) : BoolLiteral
+    end
+
+    # Returns `true` if `self` is the same as *other* or if
+    # *other* is an ancestor of `self`.
+    def <=(other : TypeNode) : BoolLiteral
+    end
+
+    # Returns `true` if `self` is an ancestor of *other*.
+    def >(other : TypeNode) : BoolLiteral
+    end
+
+    # Returns `true` if *other* is the same as `self` or if
+    # `self` is an ancestor of *other*.
+    def >=(other : TypeNode) : BoolLiteral
+    end
   end
 
   # A binary expression like `And` and `Or`.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1104,6 +1104,26 @@ module Crystal
         end
       when "class"
         interpret_argless_method(method, args) { TypeNode.new(type.metaclass) }
+      when "<", "<=", ">", ">="
+        interpret_one_arg_method(method, args) do |arg|
+          unless arg.is_a?(TypeNode)
+            raise "TypeNode##{method} expects TypeNode, not #{arg.class_desc}"
+          end
+
+          self_type = self.type
+          other_type = arg.type
+          case method
+          when "<"
+            value = self_type != other_type && self_type.implements?(other_type)
+          when "<="
+            value = self_type.implements?(other_type)
+          when ">"
+            value = self_type != other_type && other_type.implements?(self_type)
+          else # ">="
+            value = other_type.implements?(self_type)
+          end
+          BoolLiteral.new(!!value)
+        end
       else
         super
       end


### PR DESCRIPTION
These are generally useful, but we can particularly use them to implement `Box.box` and `Box.unbox` in a more efficient way: if `T < Reference` then just cast the reference to and from `Void*`. 