### PR TITLE
Spec: show time in human friendly way in `--profile`

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -133,6 +133,26 @@ module Spec
     @@slowest
   end
 
+  def self.to_human(span : Time::Span)
+    total_milliseconds = span.total_milliseconds
+    if total_milliseconds < 1
+      return "#{(span.total_milliseconds * 1000).round.to_i} microseconds"
+    end
+
+    total_seconds = span.total_seconds
+    if total_seconds < 1
+      return "#{span.total_milliseconds.round(2)} milliseconds"
+    end
+
+    if total_seconds < 60
+      return "#{total_seconds.round(2)} seconds"
+    end
+
+    minutes = span.minutes
+    seconds = span.seconds
+    "#{minutes}:#{seconds < 10 ? "0" : ""}#{seconds} minutes"
+  end
+
   def self.add_location(file, line)
     locations = @@locations ||= {} of String => Array(Int32)
     lines = locations[File.expand_path(file)] ||= [] of Int32


### PR DESCRIPTION
Before:

```
$ crystal spec spec/std/int_spec.cr --profile
...

Int compares signed vs. unsigned integers : 0.000459 sec
Int ** raises with negative exponent : 4.3e-05 sec
Int to_s in base raises on base 1 : 1.2e-05 sec
Int ** with float assert : 1.1e-05 sec
Int to_s does to_s for various int sizes with IO : 1.1e-05 sec
Int to_s does to_s for various int sizes : 1.0e-05 sec
Int #chr : 1.0e-05 sec
Int ** with positive Int32 : 9.0e-06 sec
Int to_s in base raises on base 37 with io : 7.0e-06 sec
Int to_s in base raises on base 1 with io : 7.0e-06 sec
Int raises when divides by zero : 7.0e-06 sec

Finished in 1.92 milliseconds
141 examples, 0 failures, 0 errors, 0 pending
```

After:

```
$ bin/crystal spec spec/std/int_spec.cr --profile
...

Int ** raises with negative exponent : 34 microseconds
Int compares signed vs. unsigned integers : 33 microseconds
Int to_s in base raises on base 1 : 11 microseconds
Int to_s does to_s for various int sizes with IO : 10 microseconds
Int to_s does to_s for various int sizes : 9 microseconds
Int ** with positive Int32 : 9 microseconds
Int to_s in base raises on base 37 with io : 8 microseconds
Int ** with float assert : 8 microseconds
Int to_s in base raises on base 62 with upcase with io : 7 microseconds
Int to_s in base raises on base 1 with io : 7 microseconds
Int #chr : 7 microseconds

Finished in 1.4 milliseconds
141 examples, 0 failures, 0 errors, 0 pending
```