### PR TITLE
Fix the order of output in "no overload matches" error

### DIFF
--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -419,10 +419,6 @@ class Crystal::Call
 
       str << arg.name
 
-      if arg_default = arg.default_value
-        str << " = "
-        str << arg.default_value
-      end
       if arg_type = arg.type?
         str << " : "
         str << arg_type
@@ -442,6 +438,10 @@ class Crystal::Call
             str << res_to_s
           end
         end
+      end
+      if arg_default = arg.default_value
+        str << " = "
+        str << arg.default_value
       end
       printed = true
     end


### PR DESCRIPTION
```crystal
def test(a : Int8 = 0)
end

test(5)
```

Before (invalid syntax in error message):
```
no overload matches 'test' with type Int32
Overloads are:
 - test(a = 0 : Int8)
```
After:
```
 - test(a : Int8 = 0)
```