### PR TITLE
Remove instance variable error for abstract classes

### DIFF
--- a/spec/compiler/type_inference/instance_var_spec.cr
+++ b/spec/compiler/type_inference/instance_var_spec.cr
@@ -2401,6 +2401,22 @@ describe "Type inference: instance var" do
       )) { types["Bar"] }
   end
 
+  it "doesn't throw an error for abstract classes (#2827)" do
+    assert_type(%(
+      abstract class Foo
+        @a : Int32
+      end
+
+      class Bar < Foo
+        @b : Int32
+        def initialize(@a, @b)
+        end
+      end
+
+      Bar.new(1, 2)
+    )) {types["Bar"]}
+  end
+
   it "errors on undefined constant" do
     assert_error %(
       class Foo

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -188,11 +188,11 @@ module Crystal
       var = declare_meta_type_var(vars, owner, name, info.type.as(Type))
       var.location = info.location
 
-      # If the variable is gueseed to be nilable because it is not initialized
-      # in all of the initialize methods, and the explicit type is not nilable,
-      # give an error right now
+      # If the variable is guessed to be nilable because it is not initialized
+      # in all of the initialize methods, the explicit type is not nilable, and
+      # the owner class is not abstract, give an error right now
       if instance_var && !var.type.includes_type?(@program.nil)
-        if nilable_instance_var?(owner, name)
+        if !owner.abstract? && nilable_instance_var?(owner, name)
           raise_not_initialized_in_all_initialize(var, name, owner)
         end
       end


### PR DESCRIPTION
Remove instance variable error for abstract classes

Fixes #2827

Test Plan:
- Compile the following code:

``` crystal
abstract class Base
  @a : Int32
end

class Sub < Base
  @b : Int32
  def initialize(@a, @b)
  end
end
```
- No error messages should be thrown
