### PR TITLE
Add missing PartialOrder#<=>

### DIFF
--- a/src/partial_comparable.cr
+++ b/src/partial_comparable.cr
@@ -54,4 +54,6 @@ module PartialComparable(T)
       false
     end
   end
+
+  abstract def <=>(other : T)
 end


### PR DESCRIPTION
I think it's a bug.
