### PR TITLE
adding gmp to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM crystallang/crystal
 
 RUN apt-get update && \
-    apt-get install -y build-essential curl libevent-dev git && \
+    apt-get install -y build-essential curl libevent-dev libssl-dev libgmp-dev  git && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-linux-x86_64.tar.gz | tar xz -C /opt

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,7 +4,7 @@ RUN \
   apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 && \
   echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
   apt-get update && \
-  apt-get install -y crystal gcc pkg-config libssl-dev git && \
+  apt-get install -y crystal gcc pkg-config libssl-dev libgmp-dev git && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/crystal


### PR DESCRIPTION
i tried to use the `crystallang/crystal:0.18.4` image but i couldn't compile my code since gmp is missing.
this adds gmp to remove complication restrictions

thx