### PR TITLE
OpenSSL: get selected ALPN protocol

### DIFF
--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -182,6 +182,7 @@ lib LibSSL
   alias X509VerifyParam = LibCrypto::X509VerifyParam
 
   fun ssl_get0_param = SSL_get0_param(handle : SSL) : X509VerifyParam
+  fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
   fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
   fun ssl_ctx_get0_param = SSL_CTX_get0_param(ctx : SSLContext) : X509VerifyParam
   fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -117,6 +117,15 @@ abstract class OpenSSL::SSL::Socket
     @bio.io.flush
   end
 
+  {% if LibSSL::OPENSSL_102 %}
+  # Returns the negotiated ALPN protocol (eg: "h2") of nil if no protocol was
+  # negotiated.
+  def alpn_protocol
+    LibSSL.ssl_get0_alpn_selected(@ssl, out protocol, out len)
+    String.new(protocol, len) unless protocol.null?
+  end
+  {% end %}
+
   def close
     return if @closed
     @closed = true


### PR DESCRIPTION
Get the selected protocol for a socket after one has been negotiated through ALPN.