### PR TITLE
Add temporary directory creation on Dir class

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -72,19 +72,57 @@ describe "Dir" do
     end
   end
 
+  describe "mktmpdir" do
+    it "creates the temporary directory" do
+      tmp_dir = Dir.mktmpdir
+
+      Dir.exists?(tmp_dir).should be_true
+    end
+
+    it "accepts a prefix when creating the temporary directory" do
+      prefix = "foo"
+      path = Dir.mktmpdir(prefix)
+
+      Dir.exists?(path).should be_true
+      (path =~ /#{prefix}/).should_not be_nil
+    end
+
+    describe "with a block" do
+      it "creates the dir" do
+        Dir.mktmpdir do |dir|
+          Dir.exists?(dir).should be_true
+        end
+      end
+
+      it "removes the dir" do
+        tmp_dir = "/"
+        Dir.mktmpdir do |dir|
+          tmp_dir = dir
+        end
+
+        Dir.exists?(tmp_dir).should be_false
+      end
+    end
+  end
+
   describe "tmpdir" do
     it "returns default tmp directory" do
-      old_tmpdir = ENV["TMPDIR"]?
-        ENV.delete("TMPDIR")
+      original_tmpdir = ENV["TMPDIR"]?
+      ENV.delete("TMPDIR")
       Dir.tmpdir.should eq("/tmp")
-      ENV["TMPDIR"] = old_tmpdir if old_tmpdir
+      ENV["TMPDIR"] = original_tmpdir if original_tmpdir
     end
 
     it "returns configured tmp directory" do
       original_tmpdir = ENV["TMPDIR"]?
-        ENV["TMPDIR"] = "/my/tmp"
+      ENV["TMPDIR"] = "/my/tmp"
       Dir.tmpdir.should eq("/my/tmp")
-      ENV["TMPDIR"] = original_tmpdir if original_tmpdir
+
+      if original_tmpdir
+        ENV["TMPDIR"] = original_tmpdir
+      else
+        ENV.delete("TMPDIR")
+      end
     end
   end
 

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -72,6 +72,22 @@ describe "Dir" do
     end
   end
 
+  describe "tmpdir" do
+    it "returns default tmp directory" do
+      old_tmpdir = ENV["TMPDIR"]?
+        ENV.delete("TMPDIR")
+      Dir.tmpdir.should eq("/tmp")
+      ENV["TMPDIR"] = old_tmpdir if old_tmpdir
+    end
+
+    it "returns configured tmp directory" do
+      original_tmpdir = ENV["TMPDIR"]?
+        ENV["TMPDIR"] = "/my/tmp"
+      Dir.tmpdir.should eq("/my/tmp")
+      ENV["TMPDIR"] = original_tmpdir if original_tmpdir
+    end
+  end
+
   describe "glob" do
     it "tests glob with a single pattern" do
       assert_dir_glob [

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -126,6 +126,28 @@ describe "Dir" do
     end
   end
 
+  describe "rm_r" do
+    it "deletes a directory recursively" do
+      data_path = File.join(__DIR__, "data")
+      path = File.join(data_path, "rm_r_test")
+
+      begin
+        Dir.mkdir(path)
+        File.write(File.join(path, "a"), "")
+        Dir.mkdir(File.join(path, "b"))
+        File.write(File.join(path, "b/c"), "")
+
+        Dir.rm_r(path)
+        Dir.exists?(path).should be_false
+      ensure
+        File.delete(File.join(path, "b/c")) if File.exists?(File.join(path, "b/c"))
+        File.delete(File.join(path, "a")) if File.exists?(File.join(path, "a"))
+        Dir.rmdir(File.join(path, "b")) if Dir.exists?(File.join(path, "b"))
+        Dir.rmdir(path) if Dir.exists?(path)
+      end
+    end
+  end
+
   describe "glob" do
     it "tests glob with a single pattern" do
       assert_dir_glob [

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -77,26 +77,4 @@ describe "FileUtils" do
       end
     end
   end
-
-  describe "rm_r" do
-    it "deletes a directory recursively" do
-      data_path = File.join(__DIR__, "data")
-      path = File.join(data_path, "rm_r_test")
-
-      begin
-        Dir.mkdir(path)
-        File.write(File.join(path, "a"), "")
-        Dir.mkdir(File.join(path, "b"))
-        File.write(File.join(path, "b/c"), "")
-
-        FileUtils.rm_r(path)
-        Dir.exists?(path).should be_false
-      ensure
-        File.delete(File.join(path, "b/c")) if File.exists?(File.join(path, "b/c"))
-        File.delete(File.join(path, "a")) if File.exists?(File.join(path, "a"))
-        Dir.rmdir(File.join(path, "b")) if Dir.exists?(File.join(path, "b"))
-        Dir.rmdir(path) if Dir.exists?(path)
-      end
-    end
-  end
 end

--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -53,18 +53,4 @@ describe Tempfile do
     tempfile.gets.should eq("Hello!\n")
     tempfile.close
   end
-
-  it "returns default directory for tempfiles" do
-    old_tmpdir = ENV["TMPDIR"]?
-    ENV.delete("TMPDIR")
-    Tempfile.dirname.should eq("/tmp")
-    ENV["TMPDIR"] = old_tmpdir if old_tmpdir
-  end
-
-  it "returns configure directory for tempfiles" do
-    old_tmpdir = ENV["TMPDIR"]?
-    ENV["TMPDIR"] = "/my/tmp"
-    Tempfile.dirname.should eq("/my/tmp")
-    ENV["TMPDIR"] = old_tmpdir if old_tmpdir
-  end
 end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -250,6 +250,28 @@ class Dir
     0
   end
 
+  # Deletes a file or directory *path*
+  # If *path* is a directory, this method removes all its contents recursively
+  # ```
+  # Dir.rm_r("dir")
+  # Dir.rm_r("file.cr")
+  # ```
+  def self.rm_r(path : String)
+    if Dir.exists?(path)
+      Dir.open(path) do |dir|
+        dir.each do |entry|
+          if entry != "." && entry != ".."
+            src = File.join(path, entry)
+            rm_r(src)
+          end
+        end
+      end
+      Dir.rmdir(path)
+    else
+      File.delete(path)
+    end
+  end
+
   def to_s(io)
     io << "#<Dir:" << @path << ">"
   end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -191,6 +191,20 @@ class Dir
     0
   end
 
+  # Returns the tmp dir
+  #
+  # ```
+  # Dir.tmpdir # => "/tmp"
+  # ```
+  def self.tmpdir : String
+    unless tmpdir = ENV["TMPDIR"]?
+      tmpdir = "/tmp"
+    end
+    tmpdir = tmpdir + File::SEPARATOR unless tmpdir.ends_with? File::SEPARATOR
+
+    File.dirname(tmpdir)
+  end
+
   # Removes the directory at the given path.
   def self.rmdir(path)
     if LibC.rmdir(path.check_no_null_byte) == -1

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -1,7 +1,6 @@
 require "c/dirent"
 require "c/unistd"
 require "c/sys/stat"
-require "file_utils"
 
 # Objects of class Dir are directory streams representing directories in the underlying file system.
 # They provide a variety of ways to list directories and their contents. See also `File`.
@@ -222,7 +221,7 @@ class Dir
     begin
       yield tmp_dir
     ensure
-      FileUtils.rm_r(tmp_dir)
+      Dir.rm_r(tmp_dir)
     end
 
     tmp_dir

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -81,18 +81,6 @@ module FileUtils
   # FileUtils.rm_r("file.cr")
   # ```
   def rm_r(path : String)
-    if Dir.exists?(path)
-      Dir.open(path) do |dir|
-        dir.each do |entry|
-          if entry != "." && entry != ".."
-            src = File.join(path, entry)
-            rm_r(src)
-          end
-        end
-      end
-      Dir.rmdir(path)
-    else
-      File.delete(path)
-    end
+    Dir.rm_r(path)
   end
 end

--- a/src/lib_c/i686-linux-gnu/c/stdlib.cr
+++ b/src/lib_c/i686-linux-gnu/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(name : Char*) : Char*
   fun malloc(size : SizeT) : Void*
   fun mkstemp(template : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(string : Char*) : Int
   fun realloc(ptr : Void*, size : SizeT) : Void*
   fun realpath(name : Char*, resolved : Char*) : Char*

--- a/src/lib_c/i686-linux-musl/c/stdlib.cr
+++ b/src/lib_c/i686-linux-musl/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(x0 : Char*) : Char*
   fun malloc(x0 : SizeT) : Void*
   fun mkstemp(x0 : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(x0 : Char*) : Int
   fun realloc(x0 : Void*, x1 : SizeT) : Void*
   fun realpath(x0 : Char*, x1 : Char*) : Char*

--- a/src/lib_c/x86_64-linux-gnu/c/stdlib.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(name : Char*) : Char*
   fun malloc(size : SizeT) : Void*
   fun mkstemp(template : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(string : Char*) : Int
   fun realloc(ptr : Void*, size : SizeT) : Void*
   fun realpath(name : Char*, resolved : Char*) : Char*

--- a/src/lib_c/x86_64-linux-musl/c/stdlib.cr
+++ b/src/lib_c/x86_64-linux-musl/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(x0 : Char*) : Char*
   fun malloc(x0 : SizeT) : Void*
   fun mkstemp(x0 : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(x0 : Char*) : Int
   fun realloc(x0 : Void*, x1 : SizeT) : Void*
   fun realpath(x0 : Char*, x1 : Char*) : Char*

--- a/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(x0 : Char*) : Char*
   fun malloc(x0 : SizeT) : Void*
   fun mkstemp(x0 : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(x0 : Char*) : Int
   fun realloc(x0 : Void*, x1 : SizeT) : Void*
   fun realpath(x0 : Char*, x1 : Char*) : Char*

--- a/src/lib_c/x86_64-portbld-freebsd/c/stdlib.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(x0 : Char*) : Char*
   fun malloc(x0 : SizeT) : Void*
   fun mkstemp(x0 : Char*) : Int
+  fun mkdtemp(template : Char*) : Char*
   fun putenv(x0 : Char*) : Int
   fun realloc(x0 : Void*, x1 : SizeT) : Void*
   fun realpath(x0 : Char*, x1 : Char*) : Char*

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -34,7 +34,7 @@ require "c/stdlib"
 class Tempfile < IO::FileDescriptor
   # Creates a `Tempfile` with the given filename.
   def initialize(name)
-    tmpdir = self.class.dirname + File::SEPARATOR
+    tmpdir = Dir.tmpdir + File::SEPARATOR
     @path = "#{tmpdir}#{name}.XXXXXX"
     fileno = LibC.mkstemp(@path)
     if fileno == -1
@@ -66,18 +66,6 @@ class Tempfile < IO::FileDescriptor
       tempfile.close
     end
     tempfile
-  end
-
-  # Returns the tmp dir used for tempfile
-  # ```
-  # Tempfile.dirname # => "/tmp"
-  # ```
-  def self.dirname : String
-    unless tmpdir = ENV["TMPDIR"]?
-      tmpdir = "/tmp"
-    end
-    tmpdir = tmpdir + File::SEPARATOR unless tmpdir.ends_with? File::SEPARATOR
-    File.dirname(tmpdir)
   end
 
   # Deletes this tempfile.

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -34,8 +34,7 @@ require "c/stdlib"
 class Tempfile < IO::FileDescriptor
   # Creates a `Tempfile` with the given filename.
   def initialize(name)
-    tmpdir = Dir.tmpdir + File::SEPARATOR
-    @path = "#{tmpdir}#{name}.XXXXXX"
+    @path = File.join(Dir.tmpdir, "#{name}.XXXXXX")
     fileno = LibC.mkstemp(@path)
     if fileno == -1
       raise Errno.new("mkstemp")


### PR DESCRIPTION
Usage:

Without prefix:

``` crystal
puts Dir.mktmpdir
# => /tmp/c.a39bF4
```

With prefix:

``` crystal
puts Dir.mktmpdir("foo")
# => /tmp/foo.a39bF4
```

The solution uses the `LibC.mkdtemp` bind. 
The mkdtemp function creates a directory with a unique name. If it
succeeds, it overwrites template with the name of the directory, and
returns template. As with mktemp and mkstemp, template should be a
string ending with ‘XXXXXX’.

Reference:
- http://www.gnu.org/software/libc/manual/html_node/Temporary-Files.html
