### PR TITLE
Introduce Order as a return of `<=>` instead of Int32

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -171,7 +171,7 @@ describe "Code gen: proc" do
       LibC.qsort((ary.to_unsafe as Void*), LibC::SizeT.new(ary.size), LibC::SizeT.new(sizeof(Int32)), ->(a : Void*, b : Void*) {
         a = a as Int32*
         b = b as Int32*
-        a.value <=> b.value
+        (a.value <=> b.value).value
       })
       ary[0]
       )).to_i.should eq(1)

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -5,8 +5,8 @@ alias RecursiveArray = Array(RecursiveArray)
 class BadSortingClass
   include Comparable(self)
 
-  def <=>(other)
-    1
+  def <=>(other) : Order
+    Order::GT
   end
 end
 
@@ -971,7 +971,7 @@ describe "Array" do
     end
 
     it "doesn't crash on special situations" do
-      [1, 2, 3].sort { 1 }
+      [1, 2, 3].sort { Order::GT }
       Array.new(10) { BadSortingClass.new }.sort
     end
   end
@@ -1128,16 +1128,16 @@ describe "Array" do
     b = [4, 5, 6]
     c = [1, 2]
 
-    (a <=> b).should be < 1
-    (a <=> c).should be > 0
-    (b <=> c).should be > 0
-    (b <=> a).should be > 0
-    (c <=> a).should be < 0
-    (c <=> b).should be < 0
-    (a <=> a).should eq(0)
+    (a <=> b).lt_eq?.should be_true
+    (a <=> c).gt?.should be_true
+    (b <=> c).gt?.should be_true
+    (b <=> a).gt?.should be_true
+    (c <=> a).lt?.should be_true
+    (c <=> b).lt?.should be_true
+    (a <=> a).eq?.should be_true
 
-    ([8] <=> [1, 2, 3]).should be > 0
-    ([8] <=> [8, 1, 2]).should be < 0
+    ([8] <=> [1, 2, 3]).gt?.should be_true
+    ([8] <=> [8, 1, 2]).lt?.should be_true
 
     [[1, 2, 3], [4, 5], [8], [1, 2, 3, 4]].sort.should eq([[1, 2, 3], [1, 2, 3, 4], [4, 5], [8]])
   end

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -8,18 +8,18 @@ end
 private def test_comp(val, less, equal, greater, file = __FILE__, line = __LINE__)
   (val < greater).should eq(true), file, line
   (greater < val).should eq(false), file, line
-  (val <=> greater).should eq(-1), file, line
-  (greater <=> val).should eq(1), file, line
+  (val <=> greater).lt?.should be_true, file, line
+  (greater <=> val).gt?.should be_true, file, line
 
   (val == equal).should eq(true), file, line
   (equal == val).should eq(true), file, line
-  (val <=> equal).should eq(0), file, line
-  (equal <=> val).should eq(0), file, line
+  (val <=> equal).eq?.should be_true, file, line
+  (equal <=> val).eq?.should be_true, file, line
 
   (val > less).should eq(true), file, line
   (less > val).should eq(false), file, line
-  (val <=> less).should eq(1), file, line
-  (less <=> val).should eq(-1), file, line
+  (val <=> less).gt?.should be_true, file, line
+  (less <=> val).lt?.should be_true, file, line
 end
 
 describe BigRational do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -179,9 +179,9 @@ describe "Char" do
   end
 
   it "does <=>" do
-    ('a' <=> 'b').should be < 0
-    ('a' <=> 'a').should eq(0)
-    ('b' <=> 'a').should be > 0
+    ('a' <=> 'b').lt?.should be_true
+    ('a' <=> 'a').eq?.should be_true
+    ('b' <=> 'a').gt?.should be_true
   end
 
   describe "+" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -109,9 +109,9 @@ describe "Number" do
   end
 
   it "compare the numbers" do
-    10.<=>(10).should eq(0)
-    10.<=>(11).should eq(-1)
-    11.<=>(10).should eq(1)
+    (10 <=> 10).eq?.should be_true
+    (10 <=> 11).lt?.should be_true
+    (11 <=> 10).gt?.should be_true
   end
 
   it "creates an array with [] and some elements" do

--- a/spec/std/order_spec.cr
+++ b/spec/std/order_spec.cr
@@ -1,0 +1,66 @@
+require "spec"
+
+describe Order do
+  describe Order::LT do
+    it "'s value is -1" do
+      Order::LT.value.should eq(-1)
+    end
+
+    it "is reversed, then it is GT" do
+      Order::LT.reverse.should eq Order::GT
+    end
+
+    it "mean 'lesser than'" do
+      Order::LT.lt?.should be_true
+      Order::LT.lt_eq?.should be_true
+    end
+
+    it "dosen't means 'equal' or 'greater than'" do
+      Order::LT.eq?.should be_false
+      Order::LT.gt?.should be_false
+      Order::LT.gt_eq?.should be_false
+    end
+  end
+
+  describe Order::EQ do
+    it "'s value is 0" do
+      Order::EQ.value.should eq 0
+    end
+
+    it "is reversed, then it is EQ" do
+      Order::EQ.reverse.should eq Order::EQ
+    end
+
+    it "means 'equal'" do
+      Order::EQ.eq?.should be_true
+      Order::EQ.lt_eq?.should be_true
+      Order::EQ.gt_eq?.should be_true
+    end
+
+    it "dosen't mean 'lesser than' or 'greater than'" do
+      Order::EQ.lt?.should be_false
+      Order::EQ.gt?.should be_false
+    end
+  end
+
+  describe Order::GT do
+    it "'s value is 1" do
+      Order::GT.value.should eq 1
+    end
+
+    it "is reversed, then it is LT" do
+      Order::GT.reverse.should eq Order::LT
+    end
+
+    it "mean 'greater than'" do
+      Order::GT.gt?.should be_true
+      Order::GT.gt_eq?.should be_true
+    end
+
+    it "dosen't means 'equal' or 'lesser than'" do
+      Order::GT.eq?.should be_false
+      Order::GT.lt?.should be_false
+      Order::GT.lt_eq?.should be_false
+    end
+  end
+end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1681,21 +1681,21 @@ describe "String" do
   end
 
   it "compares non-case insensitive" do
-    "fo".compare("foo").should eq(-1)
-    "foo".compare("fo").should eq(1)
-    "foo".compare("foo").should eq(0)
-    "foo".compare("fox").should eq(-1)
-    "fox".compare("foo").should eq(1)
-    "foo".compare("Foo").should eq(1)
+    "fo".compare("foo").lt?.should be_true
+    "foo".compare("fo").gt?.should be_true
+    "foo".compare("foo").eq?.should be_true
+    "foo".compare("fox").lt?.should be_true
+    "fox".compare("foo").gt?.should be_true
+    "foo".compare("Foo").gt?.should be_true
   end
 
   it "compares case insensitive" do
-    "fo".compare("FOO", case_insensitive: true).should eq(-1)
-    "foo".compare("FO", case_insensitive: true).should eq(1)
-    "foo".compare("FOO", case_insensitive: true).should eq(0)
-    "foo".compare("FOX", case_insensitive: true).should eq(-1)
-    "fox".compare("FOO", case_insensitive: true).should eq(1)
-    "fo\u{0000}".compare("FO", case_insensitive: true).should eq(1)
+    "fo".compare("FOO", case_insensitive: true).lt?.should be_true
+    "foo".compare("FO", case_insensitive: true).gt?.should be_true
+    "foo".compare("FOO", case_insensitive: true).eq?.should be_true
+    "foo".compare("FOX", case_insensitive: true).lt?.should be_true
+    "fox".compare("FOO", case_insensitive: true).gt?.should be_true
+    "fo\u{0000}".compare("FO", case_insensitive: true).gt?.should be_true
   end
 
   it "raises if String.build negative capacity" do

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -132,10 +132,10 @@ describe Time::Span do
     t1 = Time::Span.new -1
     t2 = Time::Span.new 1
 
-    (t1 <=> t2).should eq(-1)
-    (t2 <=> t1).should eq(1)
-    (t2 <=> t2).should eq(0)
-    (Time::Span::MinValue <=> Time::Span::MaxValue).should eq(-1)
+    (t1 <=> t2).lt?.should be_true
+    (t2 <=> t1).gt?.should be_true
+    (t2 <=> t2).eq?.should be_true
+    (Time::Span::MinValue <=> Time::Span::MaxValue).lt?.should be_true
 
     (t1 == t2).should be_false
     (t1 > t2).should be_false

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -226,7 +226,7 @@ describe Time do
     t1 = Time.new 2014, 10, 30, 21, 18, 13
     t2 = Time.new 2014, 10, 30, 21, 18, 14
 
-    (t1 <=> t2).should eq(-1)
+    (t1 <=> t2).lt?.should be_true
     (t1 == t2).should be_false
     (t1 < t2).should be_true
   end
@@ -594,7 +594,7 @@ describe Time do
 
   it "compares different kinds" do
     time = Time.now
-    (time.to_utc <=> time).should eq(0)
+    (time.to_utc <=> time).eq?.should be_true
   end
 
   it %(changes timezone with ENV["TZ"]) do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -252,20 +252,20 @@ describe "Tuple" do
   it "does comparison" do
     tuple1 = {"a", "a", "c"}
     tuple2 = {"a", "b", "c"}
-    (tuple1 <=> tuple2).should eq(-1)
-    (tuple2 <=> tuple1).should eq(1)
+    (tuple1 <=> tuple2).lt?.should be_true
+    (tuple2 <=> tuple1).gt?.should be_true
   end
 
   it "does <=> for equality" do
     tuple1 = {0, 1}
     tuple2 = {0.0, 1}
-    (tuple1 <=> tuple2).should eq(0)
+    (tuple1 <=> tuple2).eq?.should be_true
   end
 
   it "does <=> with the same beginning and different size" do
     tuple1 = {1, 2, 3}
     tuple2 = {1, 2}
-    (tuple1 <=> tuple2).should eq(1)
+    (tuple1 <=> tuple2).gt?.should be_true
   end
 
   it "does types" do

--- a/spec/std/uint_spec.cr
+++ b/spec/std/uint_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 describe "UInt" do
   it "compares with <=>" do
-    (1_u32 <=> 0_u32).should eq(1)
-    (0_u32 <=> 0_u32).should eq(0)
-    (0_u32 <=> 1_u32).should eq(-1)
+    (1_u32 <=> 0_u32).gt?.should be_true
+    (0_u32 <=> 0_u32).eq?.should be_true
+    (0_u32 <=> 1_u32).lt?.should be_true
   end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -182,11 +182,11 @@ class Array(T)
   # [2] <=> [4, 2, 3] # => -1
   # [1, 2] <=> [1, 2] # => 0
   # ```
-  def <=>(other : Array)
+  def <=>(other : Array) : Order
     min_size = Math.min(size, other.size)
     0.upto(min_size - 1) do |i|
       n = @buffer[i] <=> other.to_unsafe[i]
-      return n if n != 0
+      return n if n != Order::EQ
     end
     size <=> other.size
   end
@@ -1794,7 +1794,7 @@ class Array(T)
     dup.sort!
   end
 
-  def sort(&block : T, T -> Int32)
+  def sort(&block : T, T -> Order)
     dup.sort! &block
   end
 
@@ -1813,7 +1813,7 @@ class Array(T)
     self
   end
 
-  def sort!(&block : T, T -> Int32)
+  def sort!(&block : T, T -> Order)
     Array.quicksort!(@buffer, @size, block)
     self
   end
@@ -2048,9 +2048,9 @@ class Array(T)
     l = a
     r = a + n - 1
     while l <= r
-      if comp.call(l.value, p) < 0
+      if comp.call(l.value, p) < Order::EQ
         l += 1
-      elsif comp.call(r.value, p) > 0
+      elsif comp.call(r.value, p) > Order::EQ
         r -= 1
       else
         t = l.value

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -47,20 +47,20 @@ struct BigFloat < Float
     LibGMP.mpf_set_default_prec(prec.to_u64)
   end
 
-  def <=>(other : BigFloat)
-    LibGMP.mpf_cmp(self, other)
+  def <=>(other : BigFloat) : Order
+    Order.from_value LibGMP.mpf_cmp(self, other)
   end
 
-  def <=>(other : Float)
-    LibGMP.mpf_cmp_d(self, other.to_f64)
+  def <=>(other : Float) : Order
+    Order.from_value LibGMP.mpf_cmp_d(self, other.to_f64)
   end
 
-  def <=>(other : Int::Signed)
-    LibGMP.mpf_cmp_si(self, other.to_i64)
+  def <=>(other : Int::Signed) : Order
+    Order.from_value LibGMP.mpf_cmp_si(self, other.to_i64)
   end
 
-  def <=>(other : Int::Unsigned)
-    LibGMP.mpf_cmp_ui(self, other.to_u64)
+  def <=>(other : Int::Unsigned) : Order
+    Order.from_value LibGMP.mpf_cmp_ui(self, other.to_u64)
   end
 
   def -

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -74,28 +74,28 @@ struct BigInt < Int
     new(mpz)
   end
 
-  def <=>(other : BigInt)
-    LibGMP.cmp(mpz, other)
+  def <=>(other : BigInt) : Order
+    Order.from_value LibGMP.cmp(mpz, other)
   end
 
-  def <=>(other : Int::Signed)
+  def <=>(other : Int::Signed) : Order
     if LibC::Long::MIN <= other <= LibC::Long::MAX
-      LibGMP.cmp_si(mpz, other)
+      Order.from_value LibGMP.cmp_si(mpz, other)
     else
       self <=> BigInt.new(other)
     end
   end
 
-  def <=>(other : Int::Unsigned)
+  def <=>(other : Int::Unsigned) : Order
     if other <= LibC::ULong::MAX
-      LibGMP.cmp_ui(mpz, other)
+      Order.from_value LibGMP.cmp_ui(mpz, other)
     else
       self <=> BigInt.new(other)
     end
   end
 
-  def <=>(other : Float)
-    LibGMP.cmp_d(mpz, other)
+  def <=>(other : Float) : Order
+    Order.from_value LibGMP.cmp_d(mpz, other)
   end
 
   def +(other : BigInt) : BigInt
@@ -333,8 +333,8 @@ end
 struct Int
   include Comparable(BigInt)
 
-  def <=>(other : BigInt)
-    -(other <=> self)
+  def <=>(other : BigInt) : Order
+    (other <=> self).reverse
   end
 
   def +(other : BigInt) : BigInt
@@ -375,8 +375,8 @@ end
 struct Float
   include Comparable(BigInt)
 
-  def <=>(other : BigInt)
-    -(other <=> self)
+  def <=>(other : BigInt) : Order
+    (other <=> self).reverse
   end
 
   # Returns a BigInt representing this float (rounded using `floor`).

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -55,16 +55,16 @@ struct BigRational < Number
     BigInt.new { |mpz| LibGMP.mpq_get_den(mpz, self) }
   end
 
-  def <=>(other : BigRational)
-    LibGMP.mpq_cmp(mpq, other)
+  def <=>(other : BigRational) : Order
+    Order.from_value LibGMP.mpq_cmp(mpq, other)
   end
 
-  def <=>(other : Float)
+  def <=>(other : Float) : Order
     self.to_f <=> other
   end
 
-  def <=>(other : Int)
-    LibGMP.mpq_cmp(mpq, other.to_big_r)
+  def <=>(other : Int) : Order
+    Order.from_value LibGMP.mpq_cmp(mpq, other.to_big_r)
   end
 
   def +(other : BigRational)
@@ -202,8 +202,8 @@ struct Int
     BigRational.new(self, 1)
   end
 
-  def <=>(other : BigRational)
-    -(other <=> self)
+  def <=>(other : BigRational) : Order
+    (other <=> self).reverse
   end
 
   def +(other : BigRational)
@@ -226,7 +226,7 @@ end
 struct Float
   include Comparable(BigRational)
 
-  def <=>(other : BigRational)
-    -(other <=> self)
+  def <=>(other : BigRational) : Order
+    (other <=> self).reverse
   end
 end

--- a/src/char.cr
+++ b/src/char.cr
@@ -94,8 +94,8 @@ struct Char
   # ```
   # 'a' <=> 'c' # => -2
   # ```
-  def <=>(other : Char)
-    self - other
+  def <=>(other : Char) : Order
+    ord <=> other.ord
   end
 
   # Returns `true` if this char is an ASCII digit in specified base.

--- a/src/comparable.cr
+++ b/src/comparable.cr
@@ -1,19 +1,19 @@
 # The Comparable mixin is used by classes whose objects may be ordered.
 #
 # Including types must provide an `<=>` method, which compares the receiver against
-# another object, returning -1, 0, or +1 depending on whether the receiver is less than,
-# equal to, or greater than the other object.
+# another object, returning `Order::LT`, `Order::EQ`, or `Order::GT` depending on
+# whether the receiver is less than, equal to, or greater than the other object.
 #
 # Comparable uses `<=>` to implement the conventional comparison operators (`<`, `<=`, `==`, `>=`, and `>`).
 module Comparable(T)
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `-1`.
   def <(other : T)
-    (self <=> other) < 0
+    (self <=> other).lt?
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `-1` or `0`.
   def <=(other : T)
-    (self <=> other) <= 0
+    (self <=> other).lt_eq?
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `0`.
@@ -27,17 +27,17 @@ module Comparable(T)
       return true if other.is_a?(Nil) && self.same?(other)
     end
 
-    (self <=> other) == 0
+    (self <=> other).eq?
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `1`.
   def >(other : T)
-    (self <=> other) > 0
+    (self <=> other).gt?
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `1` or `0`.
   def >=(other : T)
-    (self <=> other) >= 0
+    (self <=> other).gt_eq?
   end
 
   # Comparison operator. Returns 0 if the two objects are equal,
@@ -50,5 +50,5 @@ module Comparable(T)
   # # Sort in a descending way
   # [4, 7, 2].sort { |x, y| y <=> x } # => [7, 4, 2]
   # ```
-  abstract def <=>(other : T)
+  abstract def <=>(other : T) : Order
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -291,7 +291,7 @@ module Crystal
       when "<="
         bool_bin_op(method, args) { |me, other| me <= other }
       when "<=>"
-        num_bin_op(method, args) { |me, other| me <=> other }
+        num_bin_op(method, args) { |me, other| (me <=> other).value }
       when "+"
         if args.empty?
           self
@@ -344,7 +344,7 @@ module Crystal
     end
 
     def interpret_compare(other : NumberLiteral)
-      to_number <=> other.to_number
+      (to_number <=> other.to_number).value
     end
 
     def bool_bin_op(op, args)
@@ -594,7 +594,7 @@ module Crystal
     end
 
     def interpret_compare(other : StringLiteral | MacroId)
-      value <=> other.value
+      (value <=> other.value).value
     end
 
     def to_macro_id
@@ -968,7 +968,7 @@ module Crystal
     end
 
     def interpret_compare(other : MacroId | StringLiteral)
-      value <=> other.value
+      (value <=> other.value).value
     end
   end
 
@@ -1463,7 +1463,7 @@ private def intepret_array_or_tuple_method(object, klass, method, args, block, i
   when "shuffle"
     klass.new(object.elements.shuffle)
   when "sort"
-    klass.new(object.elements.sort { |x, y| x.interpret_compare(y) })
+    klass.new(object.elements.sort { |x, y| Order.from_value x.interpret_compare(y) })
   when "uniq"
     klass.new(object.elements.uniq)
   when "[]"

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -622,10 +622,10 @@ module Crystal
           if t2.module?
             t1.object_id <=> t2.object_id
           else
-            -1
+            Order::LT
           end
         elsif t2.module?
-          1
+          Order::GT
         else
           t1.depth <=> t2.depth
         end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -51,7 +51,7 @@ module Crystal
       io << filename << ":" << line_number << ":" << column_number
     end
 
-    def <=>(other)
+    def <=>(other) : Order?
       self_file = @filename
       other_file = other.filename
       if self_file.is_a?(String) && other_file.is_a?(String) && self_file == other_file

--- a/src/number.cr
+++ b/src/number.cr
@@ -164,8 +164,8 @@ struct Number
   # Implements the comparison operator.
   #
   # See `Object#<=>`
-  def <=>(other)
-    self > other ? 1 : (self < other ? -1 : 0)
+  def <=>(other) : Order
+    self < other ? Order::LT : (self > other ? Order::GT : Order::EQ)
   end
 
   # Keeps *digits* significants digits of this number in the given *base*.

--- a/src/order.cr
+++ b/src/order.cr
@@ -1,0 +1,53 @@
+# Order is the order between two objects. It is used
+# when comparing two objects. For example, `Comparable#<=>`
+# must return it.
+enum Order
+  LT = -1
+  EQ =  0
+  GT =  1
+
+  # Is it means "equal"?
+  def eq?
+    self.value == EQ.value
+  end
+
+  # Is it means "lesser than"?
+  def lt?
+    self.value < EQ.value
+  end
+
+  # Is it means "lesser than or equal"?
+  def lt_eq?
+    self.value <= EQ.value
+  end
+
+  # Is it means "greater than"?
+  def gt?
+    self.value > EQ.value
+  end
+
+  # Is it means "greater than or equals"?
+  def gt_eq?
+    self.value >= EQ.value
+  end
+
+  # Reverse the order. `LT` becomes `GT`, and `GT` becomes `LT`.
+  # But, `EQ` is `EQ`.
+  def reverse
+    self.lt? ? GT : (self.gt? ? LT : EQ)
+  end
+
+  # Make an order instance from given *value*.
+  # If *value* is positive number, it returns `LT`.
+  # If *value* is negative number, it returns `GT`.
+  # If *value* is `0`, it returns `EQ`.
+  def self.from_value?(value)
+    if value < EQ.value
+      LT
+    elsif value > EQ.value
+      GT
+    else
+      EQ
+    end
+  end
+end

--- a/src/order.cr
+++ b/src/order.cr
@@ -37,6 +37,28 @@ enum Order
     self.lt? ? GT : (self.gt? ? LT : EQ)
   end
 
+  # If it means "equals", it yields given block and returns it.
+  # Otherwise, it returns itself.
+  #
+  # It is useful to implement custom `<=>` method.
+  # For example:
+  #
+  # ```
+  # record Person, name, age, height, weight do
+  #   include Comparable(self)
+  #
+  #   def <=>(other : self)
+  #     (name <=> other.name)
+  #       .eq_or { age <=> other.age }
+  #       .eq_or { height <=> other.height }
+  #       .eq_or { weight <=> other.weight }
+  #   end
+  # end
+  # ```
+  def eq_or(&compare : -> self)
+    self.eq? ? yield : self
+  end
+
   # Make an order instance from given *value*.
   # If *value* is positive number, it returns `LT`.
   # If *value* is negative number, it returns `GT`.

--- a/src/partial_comparable.cr
+++ b/src/partial_comparable.cr
@@ -1,22 +1,23 @@
 # The PartialComparable mixin is used by classes whose objects may be partially ordered.
 #
 # Including types must provide an `<=>` method, which compares the receiver against
-# another object, returning -1, 0, +1 or nil depending on whether the receiver is less than,
-# equal to, greater than the other object, or no order can be established.
+# another object, returning `Order::LT`, `Order::EQ`, `Order::GT` or `nil`depending
+# on whether the receiver is less than, equal to, greater than the other object, or
+# no order can be established.
 #
 # PartialComparable uses `<=>` to implement the conventional comparison operators (`<`, `<=`, `==`, `>=`, and `>`).
 module PartialComparable(T)
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `-1`.
   def <(other : T)
     compare_with(other) do |cmp|
-      cmp < 0
+      cmp.lt?
     end
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `-1` or `0`.
   def <=(other : T)
     compare_with(other) do |cmp|
-      cmp <= 0
+      cmp.lt_eq?
     end
   end
 
@@ -28,21 +29,21 @@ module PartialComparable(T)
     end
 
     compare_with(other) do |cmp|
-      cmp == 0
+      cmp.eq?
     end
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `1`.
   def >(other : T)
     compare_with(other) do |cmp|
-      cmp > 0
+      cmp.gt?
     end
   end
 
   # Compares this object to *other* based on the receiver’s `<=>` method, returning `true` if it returns `1` or `0`.
   def >=(other : T)
     compare_with(other) do |cmp|
-      cmp >= 0
+      cmp.gt_eq?
     end
   end
 
@@ -54,4 +55,6 @@ module PartialComparable(T)
       false
     end
   end
+
+  abstract def <=>(other : T) : Order?
 end

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -97,7 +97,7 @@ struct Pointer(T)
   # respectively.
   #
   # See `Object#<=>`.
-  def <=>(other : self)
+  def <=>(other : self) : Order
     address <=> other.address
   end
 

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -11,6 +11,7 @@
 require "lib_c"
 require "macros"
 require "object"
+require "order"
 require "comparable"
 require "exception"
 require "iterable"

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -47,13 +47,13 @@ class SemanticVersion
     end
   end
 
-  def <=>(other : self) : Int32
+  def <=>(other : self) : Order
     r = major <=> other.major
-    return r if r != 0
+    return r unless r.eq?
     r = minor <=> other.minor
-    return r if r != 0
+    return r unless r.eq?
     r = patch <=> other.patch
-    return r if r != 0
+    return r unless r.eq?
 
     pre1 = prerelease
     pre2 = other.prerelease
@@ -86,37 +86,37 @@ class SemanticVersion
       end
     end
 
-    def <=>(other : self) : Int32
+    def <=>(other : self) : Order
       if identifiers.empty?
         if other.identifiers.empty?
-          return 0
+          return Order::EQ
         else
-          return 1
+          return Order::GT
         end
       elsif other.identifiers.empty?
-        return -1
+        return Order::LT
       else
         # continue
       end
 
       identifiers.each_with_index do |item, i|
-        return 1 if i >= other.identifiers.size # larger = higher precedenc
+        return Order::GT if i >= other.identifiers.size # larger = higher precedenc
 
         oitem = other.identifiers[i]
         r = compare item, oitem
-        return r if r != 0
+        return r if r != Order::EQ
       end
 
-      return -1 if identifiers.size != other.identifiers.size # larger = higher precedence
-      0
+      return Order::LT if identifiers.size != other.identifiers.size # larger = higher precedence
+      Order::EQ
     end
 
     private def compare(x : Int32, y : String)
-      -1
+      Order::LT
     end
 
     private def compare(x : String, y : Int32)
-      1
+      Order::GT
     end
 
     private def compare(x : Int32, y : Int32)

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -26,7 +26,7 @@ struct Symbol
   # or +1 depending on whether symbol is less than, equal to, or greater than
   # other_symbol.
   # See `String#<=>` for more information.
-  def <=>(other : Symbol)
+  def <=>(other : Symbol) : Order
     to_s <=> other.to_s
   end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -288,7 +288,7 @@ struct Time
     kind == Kind::Local
   end
 
-  def <=>(other : self)
+  def <=>(other : self) : Order
     if utc? && other.local?
       self <=> other.to_utc
     elsif local? && other.utc?

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -224,7 +224,7 @@ struct Time::Span
     Span.new(ticks / number)
   end
 
-  def <=>(other : self)
+  def <=>(other : self) : Order
     ticks <=> other.ticks
   end
 

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -303,20 +303,20 @@ struct Tuple
   # ```
   #
   # See `Object#<=>`.
-  def <=>(other : self)
+  def <=>(other : self) : Order
     {% for i in 0...T.size %}
       cmp = self[{{i}}] <=> other[{{i}}]
-      return cmp unless cmp == 0
+      return cmp unless cmp.eq?
     {% end %}
-    0
+    Order::EQ
   end
 
   # ditto
-  def <=>(other : Tuple)
+  def <=>(other : Tuple) : Order
     min_size = Math.min(size, other.size)
     min_size.times do |i|
       cmp = self[i] <=> other[i]
-      return cmp unless cmp == 0
+      return cmp unless cmp.eq?
     end
     size <=> other.size
   end


### PR DESCRIPTION
Currently, many language uses integer value as a return of compare function/operator. However, this is a vice coming from C because it makes some magic numbers `-1` / `0` / `1`. I and almost all programmers hate magic numbers as you know, so I introduce Order enum class. It has three values `LT` / `EQ` / `GT`, they can replace `-1` / `0` / `1`.
