### PR TITLE
Feature/align pp

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -93,8 +93,20 @@ end
 # pp [1, 2, 3].map(&.to_s) # prints "[1, 2, 3].map(&.to_s) # => ["1", "2", "3"]"
 # ```
 macro pp(*exps)
-  {% for exp in exps %}
+  {% if exps.size == 0 %}
+    # Nothing
+  {% elsif exps.size == 1 %}
+    {{ exp = exps.first }}
     ::puts "#{ {{exp.stringify}} } # => #{ ({{exp}}).inspect }"
+  {% else %}
+    %strings = [] of {String, String}
+    {% for exp in exps %}
+      %strings.push({ {{exp.stringify}}, ({{exp}}).inspect })
+    {% end %}
+    %max_size = %strings.max_of &.[0].size
+    %strings.each do |%left, %right|
+      ::puts "#{%left.ljust(%max_size)} # => #{%right}"
+    end
   {% end %}
 end
 


### PR DESCRIPTION
For this program:

```cr
a = 1
b = 2
pp a, b, a + b
```

Output before:

```
a # => 1
b # => 2
a + b # => 3
```

Output after:

```
a     # => 1
b     # => 2
a + b # => 3
```

When debugging code I often use `pp` with a few related expressions/values, and it's much easier to quickly understand them if they are aligned. This is of course slower because the strings need to be stored in an array, but since this is for debugging it doesn't matter much.