### PR TITLE
Fix #2920: don't modify headers when calling cookies

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -107,7 +107,9 @@ module HTTP
       request.method.should eq("GET")
       request.path.should eq("/")
       request.cookies["a"].value.should eq("b")
-      request.headers.should eq({"Host" => "host.example.org"})
+
+      # Headers should not be modified (#2920)
+      request.headers.should eq({"Host" => "host.example.org", "Cookie" => "a=b"})
     end
 
     it "headers are case insensitive" do

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -145,14 +145,12 @@ module HTTP
         values.each do |header|
           Cookie::Parser.parse_cookies(header) { |cookie| self << cookie }
         end
-        headers.delete "Cookie"
       end
 
       if values = headers.get?("Set-Cookie")
         values.each do |header|
           Cookie::Parser.parse_set_cookie(header).try { |cookie| self << cookie }
         end
-        headers.delete "Set-Cookie"
       end
       self
     end


### PR DESCRIPTION
Response headers shouldn't be modified when asking its cookies, otherwise headers can't be easily forwarded.