### PR TITLE
FileUtils#rm_r removes a symlink itself

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -98,5 +98,30 @@ describe "FileUtils" do
         Dir.rmdir(path) if Dir.exists?(path)
       end
     end
+
+    it "doesn't follow symlinks" do
+      data_path = File.join(__DIR__, "data")
+      removed_path = File.join(data_path, "rm_r_test_removed")
+      linked_path = File.join(data_path, "rm_r_test_linked")
+      link_path = File.join(removed_path, "link")
+      file_path = File.join(linked_path, "file")
+
+      begin
+        Dir.mkdir(removed_path)
+        Dir.mkdir(linked_path)
+        File.symlink(linked_path, link_path)
+        File.write(file_path, "")
+
+        FileUtils.rm_r(removed_path)
+        Dir.exists?(removed_path).should be_false
+        Dir.exists?(linked_path).should be_true
+        File.exists?(file_path).should be_true
+      ensure
+        File.delete(file_path) if File.exists?(file_path)
+        File.delete(link_path) if File.exists?(link_path)
+        Dir.rmdir(linked_path) if Dir.exists?(linked_path)
+        Dir.rmdir(removed_path) if Dir.exists?(removed_path)
+      end
+    end
   end
 end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -81,7 +81,7 @@ module FileUtils
   # FileUtils.rm_r("file.cr")
   # ```
   def rm_r(path : String)
-    if Dir.exists?(path)
+    if Dir.exists?(path) && !File.symlink?(path)
       Dir.open(path) do |dir|
         dir.each do |entry|
           if entry != "." && entry != ".."


### PR DESCRIPTION
This is for fix and improvement both.

If a directory have a symbolic link, `FileUtils#rm_r` fails with an error message like:

```
Unable to remove directory '/path/to/the/symlink': Not a directory
```

And if the symlink also points to a directory, rm_r also deletes all files under the directory. I feel it's a bit dangerous. The `rm` command and Ruby's `FileUtils#rm_r` remove a symlink itself instead.

Thank you!