### PR TITLE
WIP: Add new HTTP::Headers constructors

### DIFF
--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -52,6 +52,19 @@ struct HTTP::Headers
     @hash = Hash(Key, Array(String)).new
   end
 
+  def initialize(hash : Hash(String, String))
+    @hash = hash.map do |key, val|
+      {wrap(key), [val]}
+    end.to_h
+  end
+
+  def initialize(hash : Hash(String, Array(String)))
+    @hash = hash.map do |key, val|
+      check_invalid_header_content val
+       {wrap(key), val}
+     end.to_h
+  end
+
   def []=(key, value : String)
     self[wrap(key)] = [value]
   end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -61,8 +61,8 @@ struct HTTP::Headers
   def initialize(hash : Hash(String, Array(String)))
     @hash = hash.map do |key, val|
       check_invalid_header_content val
-       {wrap(key), val}
-     end.to_h
+      {wrap(key), val}
+    end.to_h
   end
 
   def []=(key, value : String)


### PR DESCRIPTION
Edit: found HTT::Headers{} method, so these constructors seems to be pretty useless ^^
Hello, is this feature acceptable ?

* Add ``HTTP::Headers#new(Hash(String, String))``
  Work based on the same way than ``HTTP::Headers.[]=(String, String)``
* Add ``HTTP::Headers#new(Hash(String, Array(String)))``
  Work based on the same way than ``HTTP::Headers.[]=(String, Array(String))``
It allows the construction of the ``HTTP::Headers`` without using ``[]=``

Example:
```crystal
HTTP::Headers.new({"User-Agent" => "CrystalBot", "Accept-Language" => "en-US,en;q=0.5"})
```