### PR TITLE
Add MIME multipart parsing

### DIFF
--- a/spec/std/http/multipart/generator_spec.cr
+++ b/spec/std/http/multipart/generator_spec.cr
@@ -1,0 +1,269 @@
+require "http"
+require "spec"
+
+describe HTTP::Multipart::Generator do
+  it "generates valid multipart messages" do
+    io = MemoryIO.new
+    generator = HTTP::Multipart::Generator.new(io, "fixed-boundary")
+
+    headers = HTTP::Headers{"X-Foo" => "bar"}
+    generator.body_part headers, "body part 1"
+
+    headers = HTTP::Headers{"X-Type" => "Empty-Body", "X-Foo" => "Bar"}
+    generator.body_part headers
+
+    generator.finish
+
+    expected_message = <<-MULTIPART
+      --fixed-boundary
+      X-Foo: bar
+
+      body part 1
+      --fixed-boundary
+      X-Type: Empty-Body
+      X-Foo: Bar
+      --fixed-boundary--
+      MULTIPART
+
+    io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
+  end
+
+  it "generates valid multipart messages with preamble and epilogue" do
+    io = MemoryIO.new
+    generator = HTTP::Multipart::Generator.new(io, "fixed-boundary")
+
+    generator.preamble "Here is a preamble to explain why multipart/mixed "
+    generator.preamble "exists and why your mail client should support it"
+
+    headers = HTTP::Headers{"X-Foo" => "bar"}
+    generator.body_part headers, "body part 1"
+
+    headers = HTTP::Headers{"X-Type" => "Empty-Body", "X-Foo" => "Bar"}
+    generator.body_part headers
+
+    generator.epilogue "Irelevant text"
+    generator.epilogue "Much more irelevant text"
+
+    generator.finish
+
+    expected_message = <<-MULTIPART
+      Here is a preamble to explain why multipart/mixed exists and why your mail client should support it
+      --fixed-boundary
+      X-Foo: bar
+
+      body part 1
+      --fixed-boundary
+      X-Type: Empty-Body
+      X-Foo: Bar
+      --fixed-boundary--
+      Irelevant textMuch more irelevant text
+      MULTIPART
+
+    io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
+  end
+
+  describe "#content_type" do
+    it "calculates the content type" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new, "a delimiter string with a quote in \"")
+      generator.content_type("alternative").should eq(%q(multipart/alternative; boundary="a delimiter string with a quote in \""))
+    end
+  end
+
+  describe ".preamble" do
+    it "accepts different data types" do
+      io = MemoryIO.new
+      generator = HTTP::Multipart::Generator.new(io, "boundary")
+
+      generator.preamble "string\r\n"
+      generator.preamble "slice\r\n".to_slice
+      preamble_io = MemoryIO.new "io\r\n"
+      generator.preamble preamble_io
+      generator.preamble do |io|
+        io.print "io"
+        io << ' '
+        io.print "block"
+        io << "\r\n"
+      end
+
+      generator.body_part(HTTP::Headers.new)
+      generator.finish
+
+      generated_multipart = io.to_s
+      expected_multipart = <<-MULTIPART
+        string
+        slice
+        io
+        io block
+
+        --boundary
+        --boundary--
+        MULTIPART
+
+      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+    end
+
+    it "raises when called after starting the body" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      generator.body_part HTTP::Headers.new, "test"
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate preamble: body already started") do
+        generator.preamble "test"
+      end
+    end
+  end
+
+  describe ".body_part" do
+    it "accepts different data types" do
+      io = MemoryIO.new
+      generator = HTTP::Multipart::Generator.new(io, "boundary")
+
+      headers = HTTP::Headers{"X-Foo" => "Bar"}
+
+      generator.body_part headers, "string\r\n"
+      generator.body_part headers, "slice".to_slice
+      body_part_io = MemoryIO.new "io"
+      generator.body_part headers, body_part_io
+      generator.body_part(headers) do |io|
+        io.print "io"
+        io << ' '
+        io.print "block"
+      end
+      generator.body_part(headers)
+
+      generator.finish
+
+      generated_multipart = io.to_s
+      expected_multipart = <<-MULTIPART
+        --boundary
+        X-Foo: Bar
+
+        string
+
+        --boundary
+        X-Foo: Bar
+
+        slice
+        --boundary
+        X-Foo: Bar
+
+        io
+        --boundary
+        X-Foo: Bar
+
+        io block
+        --boundary
+        X-Foo: Bar
+        --boundary--
+        MULTIPART
+
+      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+    end
+
+    it "raises when called after finishing" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      generator.body_part HTTP::Headers.new, "test"
+      generator.finish
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate body part: already finished") do
+        generator.body_part HTTP::Headers.new, "test"
+      end
+    end
+
+    it "raises when called after epilogue" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      generator.body_part HTTP::Headers.new, "test"
+      generator.epilogue "test"
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate body part: after epilogue") do
+        generator.body_part HTTP::Headers.new, "test"
+      end
+    end
+  end
+
+  describe ".epilogue" do
+    it "accepts different data types" do
+      io = MemoryIO.new
+      generator = HTTP::Multipart::Generator.new(io, "boundary")
+
+      generator.body_part(HTTP::Headers.new)
+
+      generator.epilogue "string\r\n"
+      generator.epilogue "slice\r\n".to_slice
+      epilogue_io = MemoryIO.new "io\r\n"
+      generator.epilogue epilogue_io
+      generator.epilogue do |io|
+        io.print "io"
+        io << ' '
+        io.print "block"
+        io << "\r\n"
+      end
+
+      generator.finish
+
+      generated_multipart = io.to_s
+      expected_multipart = <<-MULTIPART
+        --boundary
+        --boundary--
+        string
+        slice
+        io
+        io block
+
+        MULTIPART
+
+      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+    end
+
+    it "raises when called after finishing" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      generator.body_part HTTP::Headers.new, "test"
+      generator.finish
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate epilogue: already finished") do
+        generator.epilogue "test"
+      end
+    end
+
+    it "raises when called with no body parts" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate epilogue: no body parts") do
+        generator.epilogue "test"
+      end
+
+      generator.preamble "test"
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot generate epilogue: no body parts") do
+        generator.epilogue "test"
+      end
+    end
+  end
+
+  describe ".finish" do
+    it "raises if no body exists" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot finish multipart: no body parts") do
+        generator.finish
+      end
+
+      generator.preamble "test"
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot finish multipart: no body parts") do
+        generator.finish
+      end
+    end
+
+    it "raises if already finished" do
+      generator = HTTP::Multipart::Generator.new(MemoryIO.new)
+
+      generator.body_part HTTP::Headers.new, "test"
+      generator.finish
+
+      expect_raises(HTTP::Multipart::GenerationException, "Cannot finish multipart: already finished") do
+        generator.finish
+      end
+    end
+  end
+end

--- a/spec/std/http/multipart/parser_spec.cr
+++ b/spec/std/http/multipart/parser_spec.cr
@@ -1,0 +1,131 @@
+require "http"
+require "spec"
+
+def mp_parse(delim, data)
+  data_io = MemoryIO.new(data.gsub("\n", "\r\n"))
+  parser = HTTP::Multipart::Parser.new(data_io, delim)
+
+  parsed = [] of {headers: HTTP::Headers, body: String}
+  while parser.has_next?
+    parser.next { |h, io| parsed << {headers: h, body: io.gets_to_end} }
+  end
+  parsed
+end
+
+describe HTTP::Multipart::Parser do
+  it "parses basic multipart messages" do
+    data = mp_parse "AaB03x", <<-MULTIPART
+      --AaB03x
+      Content-Disposition: form-data; name="submit-name"
+
+      Larry
+      --AaB03x
+      Content-Disposition: form-data; name="files"; filename="file1.txt"
+      Content-Type: text/plain
+
+      ... contents of file1.txt ...
+      --AaB03x--
+      MULTIPART
+
+    data[0][:body].should eq("Larry")
+    data[0][:headers]["Content-Disposition"].should eq("form-data; name=\"submit-name\"")
+
+    data[1][:body].should eq("... contents of file1.txt ...")
+    data[1][:headers]["Content-Disposition"].should eq("form-data; name=\"files\"; filename=\"file1.txt\"")
+    data[1][:headers]["Content-Type"].should eq("text/plain")
+  end
+
+  it "parses messages with preambles and epilogues" do
+    data = mp_parse "AaB03x", <<-MULTIPART
+      preamble
+      AaB03x
+      --AaB03x
+      Content-Disposition: form-data; name="foo"
+
+      foo
+      --AaB03x
+      Content-Disposition: form-data; name="bar"
+
+      bar
+      --AaB03x--
+      AaB03x
+      epilogue
+      MULTIPART
+
+    data[0][:body].should eq("foo")
+    data[0][:headers]["Content-Disposition"].should eq("form-data; name=\"foo\"")
+
+    data[1][:body].should eq("bar")
+    data[1][:headers]["Content-Disposition"].should eq("form-data; name=\"bar\"")
+  end
+
+  it "raises calling #next after finished" do
+    input = <<-MULTIPART
+      --AaB03x
+
+      Foo
+      --AaB03x--
+      MULTIPART
+    parser = HTTP::Multipart::Parser.new(MemoryIO.new(input.gsub("\n", "\r\n")), "AaB03x")
+
+    parser.next { }
+    parser.has_next?.should eq(false)
+
+    expect_raises(HTTP::Multipart::ParseException, "Multipart parser already finished parsing") do
+      parser.next { }
+    end
+  end
+
+  it "raises calling #next after errored" do
+    input = <<-MULTIPART
+      --AaB03x
+      --AaB03x--
+      MULTIPART
+    parser = HTTP::Multipart::Parser.new(MemoryIO.new(input.gsub("\n", "\r\n")), "AaB03x")
+
+    expect_raises(HTTP::Multipart::ParseException, "Invalid multipart message") do
+      parser.next { }
+    end
+
+    parser.has_next?.should eq(false)
+
+    expect_raises(HTTP::Multipart::ParseException, "Multipart parser is in an errored state") do
+      parser.next { }
+    end
+  end
+
+  it "handles break/next in blocks" do
+    input = <<-MULTIPART
+      --b
+
+      --b
+
+      --b
+
+      --b
+
+      --b--
+      MULTIPART
+
+    parser = HTTP::Multipart::Parser.new(MemoryIO.new(input.gsub("\n", "\r\n")), "b")
+
+    ios = [] of IO
+
+    2.times do
+      parser.next do |headers, io|
+        ios << io
+        next
+      end
+    end
+
+    2.times do
+      parser.next do |headers, io|
+        ios << io
+        break
+      end
+    end
+
+    parser.@state.should eq(:FINISHED)
+    ios.each { |io| io.closed?.should eq(true) }
+  end
+end

--- a/spec/std/http/multipart_spec.cr
+++ b/spec/std/http/multipart_spec.cr
@@ -1,0 +1,39 @@
+require "http"
+require "spec"
+
+describe HTTP::Multipart do
+  describe ".parse" do
+    it "parses multipart messages" do
+      multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nabcd\r\n--aA40--"
+      HTTP::Multipart.parse(MemoryIO.new(multipart), "aA40") do |headers, io|
+        headers["Content-Type"].should eq("text/plain")
+        io.gets_to_end.should eq("abcd")
+      end
+    end
+  end
+
+  describe ".parse_boundary" do
+    it "parses unquoted boundaries" do
+      content_type = "multipart/mixed; boundary=a_-47HDS"
+      HTTP::Multipart.parse_boundary(content_type).should eq("a_-47HDS")
+    end
+
+    it "parses quoted boundaries" do
+      content_type = %{multipart/mixed; boundary="aA_-<>()"}
+      HTTP::Multipart.parse_boundary(content_type).should eq(%{aA_-<>()})
+    end
+  end
+
+  describe ".parse" do
+    it "parses multipart messages" do
+      headers = HTTP::Headers{"Content-Type" => "multipart/mixed; boundary=aA40"}
+      body = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
+      request = HTTP::Request.new("POST", "/", headers, body)
+
+      HTTP::Multipart.parse(request) do |headers, io|
+        headers["Content-Type"].should eq("text/plain")
+        io.gets_to_end.should eq("body")
+      end
+    end
+  end
+end

--- a/src/http/multipart.cr
+++ b/src/http/multipart.cr
@@ -1,0 +1,63 @@
+module HTTP::Multipart
+  # Parses a MIME multipart message, yielding `HTTP::Headers` and an `IO` for
+  # each body part.
+  #
+  # Please note that the IO object yielded to the block is only valid while the
+  # block is executing. The IO is closed as soon as the supplied block returns.
+  #
+  # ```
+  # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
+  # HTTP::Multipart.parse(MemoryIO.new(multipart), "aA40") do |headers, io|
+  #   headers["Content-Type"] # => "text/plain"
+  #   io.gets_to_end          # => "body"
+  # end
+  # ```
+  #
+  # See: `Multipart::Parser`
+  def self.parse(io, boundary)
+    parser = Parser.new(io, boundary)
+    while parser.has_next?
+      parser.next { |headers, io| yield headers, io }
+    end
+  end
+
+  # Parses the multipart boundary from the value of the Content-Type header,
+  # or nil if the boundary was not found.
+  #
+  # ```
+  # HTTP::Multipart.parse_boundary("multipart/mixed; boundary=\"abcde\"") # => "abcde"
+  # ```
+  def self.parse_boundary(content_type)
+    # TODO: optimise and handle escapes in quoted strings
+    match = content_type.match(/\Amultipart\/.*boundary="?([^";,]+)"?/i)
+    return nil unless match
+    match[1]
+  end
+
+  # Parses a MIME multipart message, yielding `HTTP::Headers` and an `IO` for
+  # each body part.
+  #
+  # Please note that the IO object yielded to the block is only valid while the
+  # block is executing. The IO is closed as soon as the supplied block returns.
+  #
+  # ```
+  # headers = HTTP::Headers{"Content-Type" => "multipart/mixed; boundary=aA40"}
+  # body = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
+  # request = HTTP::Request.new("POST", "/", headers, body)
+  #
+  # HTTP::Multipart.parse(request) do |headers, io|
+  #   headers["Content-Type"] # => "text/plain"
+  #   io.gets_to_end          # => "body"
+  # end
+  # ```
+  #
+  # See: `Multipart::Parser`
+  def self.parse(request : HTTP::Request)
+    boundary = parse_boundary(request.headers["Content-Type"])
+    return nil unless boundary
+
+    body = request.body
+    return nil unless body
+    parse(MemoryIO.new(body), boundary) { |headers, io| yield headers, io }
+  end
+end

--- a/src/http/multipart.cr
+++ b/src/http/multipart.cr
@@ -60,4 +60,20 @@ module HTTP::Multipart
     return nil unless body
     parse(MemoryIO.new(body), boundary) { |headers, io| yield headers, io }
   end
+
+  # Yields a `Multipart::Generator` to the given block, writing to *io* and
+  # using *boundary*.
+  def self.generate(io, boundary = "--------------------------#{SecureRandom.urlsafe_base64(18)}")
+    generator = Generator.new(io, boundary)
+    yield generator
+    generator.finish
+  end
+
+  # Yields a `Multipart::Generator` to the given block, returning the generated
+  # message as a `String`.
+  def self.generate(boundary = "--------------------------#{SecureRandom.urlsafe_base64(18)}")
+    String.build do |io|
+      generate(io, boundary) { |g| yield g }
+    end
+  end
 end

--- a/src/http/multipart/generator.cr
+++ b/src/http/multipart/generator.cr
@@ -1,0 +1,193 @@
+require "secure_random"
+
+module HTTP::Multipart
+  class GenerationException < Exception
+  end
+
+  # Generates a multipart MIME message.
+  #
+  # ### Example
+  #
+  # ```
+  # io = MemoryIO.new
+  # multipart = HTTP::Multipart::Generator.new(io)
+  # multipart.body_part HTTP::Headers{"Content-Type" => "text/plain"}, "hello!"
+  # multipart.finish
+  # io.to_s # => "----------------------------DTf61dRTHYzprx7rwVQhTWr7\r\nContent-Type: text/plain\r\n\r\nhello!\r\n----------------------------DTf61dRTHYzprx7rwVQhTWr7--"
+  # ```
+  class Generator
+    # Creates a new `Multipart::Generator` which writes the generated multipart
+    # message to *io*, using the multipart boundary *boundary*.
+    def initialize(@io : IO, @boundary = "--------------------------#{SecureRandom.urlsafe_base64(18)}")
+      @state = :START
+    end
+
+    getter boundary
+
+    # Finite State Machine diagram: https://gist.github.com/RX14/221c1edfa98d1196711515d4b5c264eb
+
+    # Generates a content type header with multipart subtype *subtype*, and
+    # boundary parameter added.
+    #
+    # ```
+    # generator = HTTP::Multipart::Generator.new(io, "a4VF")
+    # generator.content_type("mixed") # => "multipart/mixed; boundary=\"a4VF\""
+    # ```
+    def content_type(subtype = "mixed")
+      %(multipart/#{subtype}; boundary="#{boundary.gsub('"', %q[\"])}")
+    end
+
+    # Appends *string* to the preamble segment of the multipart message. Throws
+    # if `#body_part` is called before this method.
+    #
+    # Can be called multiple times to append to the preamble multiple times.
+    def preamble(string : String)
+      preamble { |io| string.to_s(io) }
+    end
+
+    # Appends *data* to the preamble segment of the multipart message. Throws
+    # if `#body_part` is called before this method.
+    #
+    # Can be called multiple times to append to the preamble multiple times.
+    def preamble(data : Bytes)
+      preamble { |io| io.write data }
+    end
+
+    # Appends *preamble_io* to the preamble segment of the multipart message.
+    # Throws if `#body_part` is called before this method.
+    #
+    # Can be called multiple times to append to the preamble multiple times.
+    def preamble(preamble_io : IO)
+      preamble { |io| IO.copy(preamble_io, io) }
+    end
+
+    # Yields an IO that can be used to append to the preamble of the multipart
+    # message. Throws if `#body_part` is called before this method.
+    #
+    # Can be called multiple times to append to the preamble multiple times.
+    def preamble
+      fail "Cannot generate preamble: body already started" if @state != :START && @state != :PREAMBLE
+      yield @io
+      @state = :PREAMBLE
+    end
+
+    # Appends a body part to the multipart message with the given *headers*
+    # and *string*. Throws if `#finish` or `#epilogue` is called before this
+    # method.
+    def body_part(headers : HTTP::Headers, string : String)
+      body_part_impl(headers) { |io| string.to_s(io) }
+    end
+
+    # Appends a body part to the multipart message with the given *headers*
+    # and *data*. Throws if `#finish` or `#epilogue` is called before this
+    # method.
+    def body_part(headers : HTTP::Headers, data : Bytes)
+      body_part_impl(headers) { |io| io.write data }
+    end
+
+    # Appends a body part to the multipart message with the given *headers*
+    # and data from *body_io*. Throws if `#finish` or `#epilogue` is called
+    # before this method.
+    def body_part(headers : HTTP::Headers, body_io : IO)
+      body_part_impl(headers) { |io| IO.copy(body_io, io) }
+    end
+
+    # Yields an IO that can be used to write to a body part which is appended
+    # to the multipart message with the given *headers*. Throws is `#finish` or
+    # `#epilogue` is called before this method.
+    def body_part(headers : HTTP::Headers)
+      body_part_impl(headers) { |io| yield io }
+    end
+
+    # Appends a body part to the multipart message with the given *headers*
+    # and no body data. Throws is `#finish` or `#epilogue` is called before
+    # this method.
+    def body_part(headers : HTTP::Headers)
+      body_part_impl(headers, empty: true) { }
+    end
+
+    private def body_part_impl(headers, empty = false)
+      fail "Cannot generate body part: already finished" if @state == :FINISHED
+      fail "Cannot generate body part: after epilogue" if @state == :EPILOGUE
+
+      # We don't add a crlf before the first boundary if this is the first body
+      # part and there is no preamble
+      @io << "\r\n" unless @state == :START
+      @io << "--" << @boundary
+      headers.each do |name, values|
+        values.each do |value|
+          @io << "\r\n" << name << ": " << value
+        end
+      end
+      @io << "\r\n\r\n" unless empty
+
+      yield @io
+
+      @state = :BODY_PART
+    end
+
+    # Appends *string* to the epilogue segment of the multipart message. Throws
+    # if `#finish` is called before this method, or no body parts have been
+    # appended.
+    #
+    # Can be called multiple times to append to the epilogue multiple times.
+    def epilogue(string : String)
+      epilogue { |io| string.to_s(io) }
+    end
+
+    # Appends *data* to the epilogue segment of the multipart message. Throws
+    # if `#finish` is called before this method, or no body parts have been
+    # appended.
+    #
+    # Can be called multiple times to append to the epilogue multiple times.
+    def epilogue(data : Bytes)
+      epilogue { |io| io.write data }
+    end
+
+    # Appends *preamble_io* to the epilogue segment of the multipart message.
+    # Throws if `#finish` is called before this method, or no body parts have
+    # been appended.
+    #
+    # Can be called multiple times to append to the epilogue multiple times.
+    def epilogue(epilogue_io : IO)
+      epilogue { |io| IO.copy(epilogue_io, io) }
+    end
+
+    # Yields an IO that can be used to append to the epilogue of the multipart
+    # message. Throws if `#finish` is called before this method, or no body
+    # parts have been appended.
+    #
+    # Can be called multiple times to append to the preamble multiple times.
+    def epilogue
+      fail "Cannot generate epilogue: already finished" if @state == :FINISHED
+      fail "Cannot generate epilogue: no body parts" if @state == :START || @state == :PREAMBLE
+
+      if @state != :EPILOGUE
+        # We need to send the end boundary
+        @io << "\r\n--" << @boundary << "--\r\n"
+      end
+
+      yield @io
+
+      @state = :EPILOGUE
+    end
+
+    # Finalizes the multipart message, this method must be called before the
+    # generated multipart message written to the IO is considered valid.
+    def finish
+      fail "Cannot finish multipart: no body parts" if @state == :START || @state == :PREAMBLE
+      fail "Cannot finish multipart: already finished" if @state == :FINISHED
+
+      if @state == :BODY_PART
+        # We need to send the end boundary
+        @io << "\r\n--" << @boundary << "--"
+      end
+
+      @state = :FINISHED
+    end
+
+    private def fail(message)
+      raise GenerationException.new(message)
+    end
+  end
+end

--- a/src/http/multipart/parser.cr
+++ b/src/http/multipart/parser.cr
@@ -1,0 +1,131 @@
+module HTTP::Multipart
+  class ParseException < Exception
+  end
+
+  # Parses multipart MIME messages.
+  #
+  # ### Example
+  #
+  # ```
+  # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
+  # parser = HTTP::Multipart::Parser.new(MemoryIO.new(multipart), "aA40")
+  #
+  # while parser.has_next?
+  #   parser.next do |headers, io|
+  #     headers["Content-Type"] # => "text/plain"
+  #     io.gets_to_end          # => "body"
+  #   end
+  # end
+  # ```
+  #
+  # Please note that the IO object yielded by `#next` is only valid until the
+  # block returns.
+  class Parser
+    # Creates a new `Multipart::Parser` which parses *io* with multipart
+    # boundary *boundary*.
+    def initialize(@io : IO, @boundary : String)
+      @state = :PREAMBLE
+      @dash_boundary = "--#{@boundary}"
+      @delimiter = "\r\n#{@dash_boundary}"
+    end
+
+    # Parses the next body part and yields headers as `HTTP::Headers` and the
+    # body text as an `IO`.
+    #
+    # This method yields once instead of returning the values, because the IO
+    # object yielded to the block is only valid while the block is executing.
+    # The IO object will be closed as soon as the block returns. To store the
+    # content of the body part for longer than the block, the IO must be read
+    # into memory.
+    #
+    # ```
+    # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
+    # parser = HTTP::Multipart::Parser.new(MemoryIO.new(multipart), "aA40")
+    # parser.next do |headers, io|
+    #   headers["Content-Type"] # => "text/plain"
+    #   io.gets_to_end          # => "body"
+    # end
+    # ```
+    def next
+      raise ParseException.new "Multipart parser already finished parsing" if @state == :FINISHED
+      raise ParseException.new "Multipart parser is in an errored state" if @state == :ERRORED
+
+      if @state == :PREAMBLE
+        preamble_io = IO::Delimited.new(@io, read_delimiter: @dash_boundary)
+
+        # Discard preamble
+        buffer = uninitialized UInt8[1024]
+        while preamble_io.read(buffer.to_slice) > 0
+        end
+
+        fail if close_delimiter?
+        @state = :PART_START
+      end
+
+      if @state == :PART_START
+        body_io = IO::Delimited.new(@io, read_delimiter: @delimiter)
+        headers = parse_headers(body_io)
+
+        begin
+          yield headers, body_io
+        ensure
+          # Read to end of body
+          buffer2 = uninitialized UInt8[1024]
+          while body_io.read(buffer2.to_slice) > 0
+          end
+
+          body_io.close
+
+          @state = :FINISHED if close_delimiter?
+        end
+      end
+    rescue ex
+      @state = :ERRORED
+      raise ex
+    end
+
+    # True if `#next` can be called legally.
+    def has_next?
+      @state != :FINISHED && @state != :ERRORED
+    end
+
+    private def parse_headers(io)
+      headers = HTTP::Headers.new
+
+      while line = io.gets
+        if line == "\r\n"
+          # Finished parsing
+          return headers
+        end
+
+        name, value = HTTP.parse_header(line)
+        headers.add(name, value)
+      end
+
+      headers
+    end
+
+    # This method is used directly after reading a boundary, to determine if
+    # it's a close delimiter or not.
+    #
+    # If it's not a close delimiter, it eats the transport padding and crlf
+    # after a delimiter.
+    private def close_delimiter?
+      transport_padding_crlf = @io.gets("\r\n")
+      fail unless transport_padding_crlf
+
+      if transport_padding_crlf != "\r\n"
+        return true if transport_padding_crlf.starts_with?("--")
+
+        fail unless transport_padding_crlf.ends_with?("\r\n")
+        fail unless transport_padding_crlf[0..-2].chars.all? { |chr| chr == ' ' || chr == '\t' }
+      end
+
+      false
+    end
+
+    private def fail
+      raise ParseException.new "Invalid multipart message"
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds classes for parsing and generating MIME `multipart/*` messages, based on [RFC2046 Section 5.1](https://tools.ietf.org/html/rfc2046#section-5.1).

This pr depends on #2972, #2973.
