### PR TITLE
Fix bin/crystal in the case of stdout

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -89,7 +89,7 @@ _canonicalize_file_path() {
     local dir file
     dir=$(dirname -- "$1")
     file=$(basename -- "$1")
-    (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
+    (cd "$dir" 2>/dev/null >/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
 }
 
 ##############################################################################


### PR DESCRIPTION
As per the cd manpage:
```
STDOUT
       If a non-empty directory name from CDPATH is used, or if cd − is used, an absolute pathname of the new working directory shall be written to the standard output as follows:

           "%s\n", <new directory>

       Otherwise, there shall be no output.
```

This means that the `cd` utility can write it's path to stdout, causing `_canonicalize_file_path` to contain `"/full/dir/path\n/full/dir/path/file"`, which breaks setting `CRYSTAL_PATH`.