### PR TITLE
Add IO::Sized

### DIFF
--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -1,0 +1,84 @@
+require "spec"
+
+describe "IO::Sized" do
+  describe ".read" do
+    it "doesn't read past the limit when reading char-by-char" do
+      io = MemoryIO.new "abcdefg"
+      sized = IO::Sized.new(io, read_size: 5)
+
+      sized.read_char.should eq('a')
+      sized.read_char.should eq('b')
+      sized.read_char.should eq('c')
+      sized.read_remaining.should eq(2)
+      sized.read_char.should eq('d')
+      sized.read_char.should eq('e')
+      sized.read_remaining.should eq(0)
+      sized.read_char.should be_nil
+      sized.read_remaining.should eq(0)
+      sized.read_char.should be_nil
+    end
+
+    it "doesn't read past the limit when reading the correct size" do
+      io = MemoryIO.new("1234567")
+      sized = IO::Sized.new(io, read_size: 5)
+      slice = Bytes.new(5)
+
+      sized.read(slice).should eq(5)
+      String.new(slice).should eq("12345")
+
+      sized.read(slice).should eq(0)
+      String.new(slice).should eq("12345")
+    end
+
+    it "reads partially when supplied with a larger slice" do
+      io = MemoryIO.new("1234567")
+      sized = IO::Sized.new(io, read_size: 5)
+      slice = Bytes.new(10)
+
+      sized.read(slice).should eq(5)
+      String.new(slice).should eq("12345\0\0\0\0\0")
+    end
+
+    it "raises on negative numbers" do
+      io = MemoryIO.new
+      expect_raises(ArgumentError, "negative read_size") do
+        IO::Sized.new(io, read_size: -1)
+      end
+    end
+  end
+
+  describe ".write" do
+    it "raises" do
+      sized = IO::Sized.new(MemoryIO.new, read_size: 5)
+      expect_raises(IO::Error, "Can't write to IO::Sized") do
+        sized.puts "test string"
+      end
+    end
+  end
+
+  describe ".close" do
+    it "stops reading" do
+      io = MemoryIO.new "abcdefg"
+      sized = IO::Sized.new(io, read_size: 5)
+
+      sized.read_char.should eq('a')
+      sized.read_char.should eq('b')
+
+      sized.close
+      sized.closed?.should eq(true)
+      expect_raises(IO::Error, "closed stream") do
+        sized.read_char
+      end
+    end
+
+    it "closes the underlying stream if sync_close is true" do
+      io = MemoryIO.new "abcdefg"
+      sized = IO::Sized.new(io, read_size: 5, sync_close: true)
+      sized.sync_close?.should eq(true)
+
+      io.closed?.should eq(false)
+      sized.close
+      io.closed?.should eq(true)
+    end
+  end
+end

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -1,0 +1,51 @@
+module IO
+  # An IO that wraps another IO, setting a limit for the number of bytes that can be read.
+  #
+  # ```
+  # io = MemoryIO.new "abcde"
+  # sized = IO::Sized.new(io, read_size: 3)
+  #
+  # sized.gets_to_end # => "abc"
+  # sized.gets_to_end # => nil
+  # io.gets_to_end    # => "de"
+  # ```
+  class Sized
+    include IO
+
+    # If `sync_close` is true, closing this IO will close the underlying IO.
+    property? sync_close : Bool
+
+    # The number of remaining bytes to be read.
+    getter read_remaining : UInt64
+    getter? closed : Bool
+
+    # Creates a new `IO::Sized` which wraps *io*, and can read a maximum of
+    # *read_size* bytes. If *sync_close* is set, calling `#close` calls
+    # `#close` on the underlying IO.
+    def initialize(@io : IO, read_size : Int, @sync_close = false)
+      raise ArgumentError.new "negative read_size" if read_size < 0
+      @closed = false
+      @read_remaining = read_size.to_u64
+    end
+
+    def read(slice : Slice(UInt8))
+      check_open
+
+      count = {slice.size.to_u64, @read_remaining}.min
+      bytes_read = @io.read slice[0, count]
+      @read_remaining -= bytes_read
+      bytes_read
+    end
+
+    def write(slice : Slice(UInt8))
+      raise IO::Error.new "Can't write to IO::Sized"
+    end
+
+    def close
+      return if @closed
+      @closed = true
+
+      @io.close if @sync_close
+    end
+  end
+end


### PR DESCRIPTION
This class is a wrapper around an `IO` which has a limited read size. A similar class is already used in the crystal stdlib for handling `Content-Length` headers in HTTP, so I replaced that with a implementation that extends IO::Sized.

Apart from that, this is a useful complement to `IO::Delimited`.