### PR TITLE
Add IO::Delimited

### DIFF
--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -1,0 +1,133 @@
+require "spec"
+
+class PartialReaderIO
+  include IO
+
+  @slice : Slice(UInt8)
+
+  def initialize(data : String)
+    @slice = data.to_slice
+  end
+
+  def read(slice : Bytes)
+    return 0 if @slice.size == 0
+    max_read_size = {slice.size, @slice.size}.min
+    read_size = rand(1..max_read_size)
+    slice.copy_from(@slice[0, read_size])
+    @slice += read_size
+    read_size
+  end
+
+  def write(slice : Bytes)
+    raise "write"
+  end
+end
+
+describe "IO::Delimited" do
+  describe ".read" do
+    it "doesn't read past the limit" do
+      io = MemoryIO.new("abcderzzrfgzr")
+      delimited = IO::Delimited.new(io, read_delimiter: "zr")
+
+      delimited.gets_to_end.should eq("abcderz")
+      io.gets_to_end.should eq("fgzr")
+    end
+
+    it "doesn't read past the limit (char-by-char)" do
+      io = MemoryIO.new("abcderzzrfg")
+      delimited = IO::Delimited.new(io, read_delimiter: "zr")
+
+      delimited.read_char.should eq('a')
+      delimited.read_char.should eq('b')
+      delimited.read_char.should eq('c')
+      delimited.read_char.should eq('d')
+      delimited.read_char.should eq('e')
+      delimited.read_char.should eq('r')
+      delimited.read_char.should eq('z')
+      delimited.read_char.should eq(nil)
+      delimited.read_char.should eq(nil)
+      delimited.read_char.should eq(nil)
+      delimited.read_char.should eq(nil)
+
+      io.read_char.should eq('f')
+      io.read_char.should eq('g')
+    end
+
+    it "doesn't clobber active_delimiter_buffer" do
+      io = MemoryIO.new("ab12312")
+      delimited = IO::Delimited.new(io, read_delimiter: "12345")
+
+      delimited.gets_to_end.should eq("ab12312")
+    end
+
+    it "handles the delimiter at the start" do
+      io = MemoryIO.new("ab12312")
+      delimited = IO::Delimited.new(io, read_delimiter: "ab1")
+
+      delimited.read_char.should eq(nil)
+    end
+
+    it "handles the delimiter at the end" do
+      io = MemoryIO.new("ab12312z")
+      delimited = IO::Delimited.new(io, read_delimiter: "z")
+
+      delimited.gets_to_end.should eq("ab12312")
+    end
+
+    it "handles nearly a delimiter at the end" do
+      io = MemoryIO.new("ab12312")
+      delimited = IO::Delimited.new(io, read_delimiter: "122")
+
+      delimited.gets_to_end.should eq("ab12312")
+    end
+
+    it "doesn't clobber the buffer on closely-offset partial matches" do
+      io = MemoryIO.new("abab1234abcdefgh")
+      delimited = IO::Delimited.new(io, read_delimiter: "abcdefgh")
+
+      delimited.gets_to_end.should eq("abab1234")
+    end
+
+    it "handles partial reads" do
+      io = PartialReaderIO.new("abab1234abcdefgh")
+      delimited = IO::Delimited.new(io, read_delimiter: "abcdefgh")
+
+      delimited.gets_to_end.should eq("abab1234")
+    end
+  end
+
+  describe ".write" do
+    it "raises" do
+      delimited = IO::Delimited.new(MemoryIO.new, read_delimiter: "zr")
+      expect_raises(IO::Error, "Can't write to IO::Delimited") do
+        delimited.puts "test string"
+      end
+    end
+  end
+
+  describe ".close" do
+    it "stops reading" do
+      io = MemoryIO.new "abcdefg"
+      delimited = IO::Delimited.new(io, read_delimiter: "zr")
+
+      delimited.read_char.should eq('a')
+      delimited.read_char.should eq('b')
+
+      delimited.close
+      delimited.closed?.should eq(true)
+      expect_raises(IO::Error, "closed stream") do
+        delimited.read_char
+      end
+    end
+
+    it "closes the underlying stream if sync_close is true" do
+      io = MemoryIO.new "abcdefg"
+      delimited = IO::Delimited.new(io, read_delimiter: "zr", sync_close: true)
+      delimited.sync_close?.should eq(true)
+
+      io.closed?.should eq(false)
+      delimited.close
+      io.closed?.should eq(true)
+    end
+  end
+end

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -1,0 +1,124 @@
+module IO
+  # An IO that wraps another IO, and only reads up to the beginning of a
+  # specified delimiter.
+  #
+  # This is useful for exposing part of an underlying stream to a client.
+  #
+  # ```
+  # io = MemoryIO.new "abc||123"
+  # delimited = IO::Delimited.new(io, read_delimiter: "||")
+  #
+  # delimited.gets_to_end # => "abc"
+  # delimited.gets_to_end # => nil
+  # io.gets_to_end        # => "123"
+  # ```
+  class Delimited
+    include IO
+
+    # If `sync_close` is true, closing this IO will close the underlying IO.
+    property? sync_close
+
+    getter read_delimiter
+    getter? closed : Bool
+
+    @delimiter_buffer : Bytes
+    @active_delimiter_buffer : Bytes
+
+    # Creates a new `IO::Delimited` which wraps *io*, and can read until the
+    # byte sequence *read_delimiter* (interpreted as UTF-8) is found. If
+    # *sync_close* is set, calling `#close` calls `#close` on the underlying
+    # IO.
+    def self.new(io : IO, read_delimiter : String, sync_close : Bool = false)
+      new(io, read_delimiter.to_slice, sync_close)
+    end
+
+    # Creates a new `IO::Delimited` which wraps *io*, and can read until the
+    # byte sequence *read_delimiter* is found. If *sync_close* is set, calling
+    # `#close` calls `#close` on the underlying IO.
+    def initialize(@io : IO, @read_delimiter : Bytes, @sync_close : Bool = false)
+      @closed = false
+      @finished = false
+
+      # The buffer where we do all our work.
+      @delimiter_buffer = Bytes.new(@read_delimiter.size)
+      # Slice inside delimiter buffer where bytes waiting to be read are stored.
+      @active_delimiter_buffer = Bytes.new(Pointer(UInt8).null, 0)
+    end
+
+    def read(slice : Slice(UInt8))
+      check_open
+      return 0 if @finished
+
+      first_byte = @read_delimiter[0]
+      read_bytes = 0
+
+      while read_bytes < slice.size
+        # Select the next byte as the head of the active delimiter buffer,
+        # or the next byte from the io if the buffer is not in use.
+        if @active_delimiter_buffer.size > 0
+          byte = @active_delimiter_buffer[0]
+          @active_delimiter_buffer += 1
+        else
+          byte = @io.read_byte
+        end
+
+        break if byte.nil?
+
+        # We know we don't need to check if the delimiter matches when the buffer
+        # has been resized, because this signals we are coming to the end of the IO.
+        if byte == first_byte && @delimiter_buffer.size == @read_delimiter.size
+          buffer = @delimiter_buffer
+          buffer[0] = byte
+          read_start = 1
+
+          # If we have an active delimiter buffer copy it in after the current
+          # character, and update where we should start our read operation.
+          if @active_delimiter_buffer.size > 0
+            (buffer + 1).move_from(@active_delimiter_buffer)
+            read_start += @active_delimiter_buffer.size
+          end
+
+          read_buffer = buffer + read_start
+          bytes = 0
+          while read_buffer.size > 0
+            partial_bytes = @io.read(read_buffer)
+            break if partial_bytes == 0
+
+            read_buffer += partial_bytes
+            bytes += partial_bytes
+          end
+
+          # If read didn't read as many bytes as we asked it to, resize the buffer
+          # to remove garbage bytes.
+          if bytes != buffer.size - read_start
+            buffer = buffer[0, read_start + bytes]
+          end
+
+          if buffer == @read_delimiter
+            @finished = true
+            return read_bytes
+          end
+
+          @delimiter_buffer = buffer
+          @active_delimiter_buffer = buffer + 1
+        end
+
+        slice[read_bytes] = byte
+        read_bytes += 1
+      end
+
+      read_bytes
+    end
+
+    def write(slice : Slice(UInt8))
+      raise IO::Error.new "Can't write to IO::Delimited"
+    end
+
+    def close
+      return if @closed
+      @closed = true
+
+      @io.close if @sync_close
+    end
+  end
+end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -239,6 +239,66 @@ struct Slice(T)
     pointer(count).copy_to(target, count)
   end
 
+  # Copies the contents of this slice into *target*.
+  #
+  # Raises if the desination slice cannot fit the data being transferred
+  # e.g. dest.size < self.size.
+  #
+  # ```
+  # src = Slice['a', 'a', 'a']
+  # dst = Slice['b', 'b', 'b', 'b', 'b']
+  # src.copy_to dst
+  # dst             # => Slice['a', 'a', 'a', 'b', 'b']
+  # dst.copy_to src # => IndexError
+  # ```
+  def copy_to(target : self)
+    @pointer.copy_to(target.pointer(size), size)
+  end
+
+  # Copies the contents of *source* into this slice.
+  #
+  # Truncates if the other slice doesn't fit. The same as `source.copy_to(self)`.
+  @[AlwaysInline]
+  def copy_from(source : self)
+    source.copy_to(self)
+  end
+
+  def move_from(source : Pointer(T), count)
+    pointer(count).move_from(source, count)
+  end
+
+  def move_to(target : Pointer(T), count)
+    pointer(count).move_to(target, count)
+  end
+
+  # Moves the contents of this slice into *target*. *target* and *self* may
+  # overlap; the copy is always done in a non-destructive manner.
+  #
+  # Raises if the desination slice cannot fit the data being transferred
+  # e.g. dest.size < self.size.
+  #
+  # See `Pointer#move_to`
+  #
+  # ```
+  # src = Slice['a', 'a', 'a']
+  # dst = Slice['b', 'b', 'b', 'b', 'b']
+  # src.move_to dst
+  # dst             # => Slice['a', 'a', 'a', 'b', 'b']
+  # dst.move_to src # => IndexError
+  # ```
+  def move_to(target : self)
+    @pointer.move_to(target.pointer(size), size)
+  end
+
+  # Moves the contents of *source* into this slice. *source* and *self* may
+  # overlap; the copy is always done in a non-destructive manner.
+  #
+  # Truncates if the other slice doesn't fit. The same as `source.move_to(self)`.
+  @[AlwaysInline]
+  def move_from(source : self)
+    source.move_to(self)
+  end
+
   def inspect(io)
     to_s(io)
   end


### PR DESCRIPTION
From docs:
> An IO that wraps another IO, and only reads up to the beginning of a specified delimiter.
>
> This is useful for exposing part of an underlying stream to a client.

Also adds some convenience methods to `Slice` that are (or were) utilised in implementing `IO::Delimited`.

The algorithm for `IO::Delimited`is a little complex, but I believe it's readable with the docs and comments I've added. It's also reasonably performant: [benchmarks](https://gist.github.com/RX14/cfa513686bed3d195bcb9db163399677). It seems to be able to do about 1gbps/core, which should be enough for most usages.