### PR TITLE
Add support for LLVM 3.8

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -84,7 +84,7 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean'
-  with_build_env 'make crystal std_spec compiler_spec doc'
+  with_build_env 'make crystal spec doc'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check'
 }
@@ -147,10 +147,9 @@ EOF
 prepare_build() {
   on_linux verify_linux_environment
 
-  on_linux docker pull "jhass/crystal-build-$ARCH"
+  on_linux docker pull "jhass/crystal-build-$ARCH:llvm38"
 
-  on_osx brew install libevent crystal-lang
-  on_osx /bin/bash -c "'curl \"http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-darwin-x86_64.tar.gz\" | tar xz -C /tmp'"
+  on_osx brew install llvm libevent crystal-lang
 }
 
 with_build_env() {
@@ -166,10 +165,10 @@ with_build_env() {
     -v $(pwd):/mnt \
     -w /mnt \
     -e LIBRARY_PATH="/opt/crystal/embedded/lib/" \
-    "jhass/crystal-build-$ARCH" \
+    "jhass/crystal-build-$ARCH:llvm38" \
     "$ARCH_CMD" /bin/bash -c "'$command'"
 
-  on_osx PATH="/tmp/llvm-3.5.0-1/bin:\$PATH" \
+  on_osx PATH="/usr/local/opt/llvm/bin:\$PATH" \
     CRYSTAL_CACHE_DIR="/tmp/crystal" \
     /bin/bash -c "'$command'"
 

--- a/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
@@ -63,7 +63,7 @@ require "../../../spec_helper"
         LibFoo.foo(s)
         )).first_value
       str = mod.to_s
-      str.should contain("call void (...)* @foo({ i64 }")
+      str.should contain("call void (...)")
     end
 
     it "passes struct between 64 and 128 bits as { i64, i64 }" do

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -80,21 +80,24 @@ describe OpenSSL::SSL::Context do
   it "adds options" do
     context = OpenSSL::SSL::Context::Client.new
     context.remove_options(context.options) # reset
-    context.add_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    default_options = context.options       # options we can't unset
+    context.add_options(OpenSSL::SSL::Options::ALL).should eq(default_options | OpenSSL::SSL::Options::ALL)
     context.add_options(OpenSSL::SSL::Options.flags(NO_SSLV2, NO_SSLV3))
            .should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2, NO_SSLV3))
   end
 
   it "removes options" do
     context = OpenSSL::SSL::Context::Client.insecure
-    context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
-    context.remove_options(OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::NO_SSLV2)
+    default_options = context.options
+    context.add_options(OpenSSL::SSL::Options.flags(NO_TLSV1, NO_SSLV2))
+    context.remove_options(OpenSSL::SSL::Options::NO_TLSV1).should eq(default_options | OpenSSL::SSL::Options::NO_SSLV2)
   end
 
   it "returns options" do
     context = OpenSSL::SSL::Context::Client.insecure
+    default_options = context.options
     context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
-    context.options.should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
+    context.options.should eq(default_options | OpenSSL::SSL::Options.flags(ALL, NO_SSLV2))
   end
 
   it "adds modes" do

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -1,3 +1,5 @@
+require "./lib_llvm"
+
 struct LLVM::DIBuilder
   def initialize(llvm_module)
     @unwrap = LibLLVMExt.create_di_builder(llvm_module)
@@ -41,9 +43,15 @@ struct LLVM::DIBuilder
     LibLLVMExt.di_builder_create_expression(self, addr, length)
   end
 
+  {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
   def insert_declare_at_end(storage, var_info, expr, block)
     LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, block)
   end
+  {% else %}
+  def insert_declare_at_end(storage, var_info, expr, dl, block)
+    LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
+  end
+  {% end %}
 
   def get_or_create_array(elements : Array(LibLLVMExt::Metadata))
     LibLLVMExt.di_builder_get_or_create_array(self, elements, elements.size)

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,18 +1,25 @@
-#include <llvm-c/Core.h>
-#include <llvm/IR/DebugLoc.h>
-#include <llvm/IR/Metadata.h>
-#include "llvm/Support/CBindingWrapping.h"
-#include <llvm/IR/LLVMContext.h>
-#include "llvm/IR/Module.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/CBindingWrapping.h"
+#include <llvm-c/Core.h>
+#include <llvm/IR/DebugLoc.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Metadata.h>
 
 using namespace llvm;
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 5
-  #define HAVE_LLVM_35 1
+#define HAVE_LLVM_35 1
 #endif
 
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR <= 6
+#define HAVE_LLVM_36_OR_LOWER 1
+#endif
+
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 8
+#define HAVE_LLVM_38 1
+#endif
 
 typedef struct LLVMOpaqueDIBuilder *LLVMDIBuilderRef;
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DIBuilder, LLVMDIBuilderRef)
@@ -20,18 +27,32 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DIBuilder, LLVMDIBuilderRef)
 #if HAVE_LLVM_35
 typedef LLVMValueRef LLVMMetadataRef;
 typedef Value Metadata;
+#define DIBuilderRef LLVMDIBuilderRef
 #else
 typedef struct LLVMOpaqueMetadata *LLVMMetadataRef;
 DEFINE_ISA_CONVERSION_FUNCTIONS(Metadata, LLVMMetadataRef)
 
 inline Metadata **unwrap(LLVMMetadataRef *Vals) {
-  return reinterpret_cast<Metadata**>(Vals);
+  return reinterpret_cast<Metadata **>(Vals);
 }
 #endif
 
-template <typename T> T unwrapDI(LLVMMetadataRef v) {
+#if HAVE_LLVM_36_OR_LOWER
+template <typename T> T unwrapDIptr(LLVMMetadataRef v) {
   return v ? T(unwrap<MDNode>(v)) : T();
 }
+#define DIBuilderRef LLVMDIBuilderRef
+#else
+typedef DIBuilder *DIBuilderRef;
+#define DIArray DINodeArray
+
+template <typename T> T *unwrapDIptr(LLVMMetadataRef v) {
+  return (T *)(v ? unwrap<MDNode>(v) : NULL);
+}
+#endif
+
+#define DIDescriptor DIScope
+#define unwrapDI unwrapDIptr
 
 extern "C" {
 
@@ -42,44 +63,61 @@ LLVMDIBuilderRef LLVMNewDIBuilder(LLVMModuleRef mref) {
 
 void LLVMDIBuilderFinalize(LLVMDIBuilderRef dref) { unwrap(dref)->finalize(); }
 
-LLVMMetadataRef LLVMDIBuilderCreateFile(LLVMDIBuilderRef Dref, const char *File, const char *Dir) {
+LLVMMetadataRef LLVMDIBuilderCreateFile(DIBuilderRef Dref, const char *File,
+                                        const char *Dir) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DIFile F = D->createFile(File, Dir);
   return wrap(F);
+#else
+  return wrap(Dref->createFile(File, Dir));
+#endif
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef Dref,
-                                               unsigned Lang, const char *File,
+LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(DIBuilderRef Dref, unsigned Lang,
+                                               const char *File,
                                                const char *Dir,
                                                const char *Producer,
                                                int Optimized, const char *Flags,
                                                unsigned RuntimeVersion) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DICompileUnit CU = D->createCompileUnit(Lang, File, Dir, Producer, Optimized,
                                           Flags, RuntimeVersion);
   return wrap(CU);
+#else
+  return wrap(Dref->createCompileUnit(Lang, File, Dir, Producer, Optimized,
+                                      Flags, RuntimeVersion));
+#endif
 }
 
-
 LLVMMetadataRef LLVMDIBuilderCreateFunction(
-    LLVMDIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
+    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     const char *LinkageName, LLVMMetadataRef File, unsigned Line,
-    LLVMMetadataRef CompositeType, int IsLocalToUnit, int IsDefinition,
-    unsigned ScopeLine, unsigned Flags, int IsOptimized, LLVMValueRef Func) {
+    LLVMMetadataRef CompositeType, bool IsLocalToUnit, bool IsDefinition,
+    unsigned ScopeLine, unsigned Flags, bool IsOptimized, LLVMValueRef Func) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
-  DISubprogram SP = D->createFunction(
+  DISubprogram Sub = D->createFunction(
       unwrapDI<DIDescriptor>(Scope), Name, LinkageName, unwrapDI<DIFile>(File),
       Line, unwrapDI<DICompositeType>(CompositeType), IsLocalToUnit,
       IsDefinition, ScopeLine, Flags, IsOptimized, unwrap<Function>(Func));
-  return wrap(SP);
+#else
+  DISubprogram *Sub = Dref->createFunction(
+      unwrapDI<DIScope>(Scope), Name, LinkageName, unwrapDI<DIFile>(File), Line,
+      unwrapDI<DISubroutineType>(CompositeType), IsLocalToUnit, IsDefinition,
+      ScopeLine, Flags, IsOptimized);
+  unwrap<Function>(Func)->setSubprogram(Sub);
+#endif
+  return wrap(Sub);
 }
 
-
-LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(LLVMDIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(DIBuilderRef Dref,
                                                 LLVMMetadataRef Scope,
                                                 LLVMMetadataRef File,
                                                 unsigned Line,
                                                 unsigned Column) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DILexicalBlock LB = D->createLexicalBlock(
 #if HAVE_LLVM_35
@@ -88,23 +126,30 @@ LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(LLVMDIBuilderRef Dref,
       unwrapDI<DIDescriptor>(Scope), unwrapDI<DIFile>(File), Line, Column);
 #endif
   return wrap(LB);
+#else
+  return wrap(Dref->createLexicalBlock(unwrapDI<DIDescriptor>(Scope),
+                                       unwrapDI<DIFile>(File), Line, Column));
+#endif
 }
 
-
-LLVMMetadataRef LLVMDIBuilderCreateBasicType(LLVMDIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreateBasicType(DIBuilderRef Dref,
                                              const char *Name,
                                              uint64_t SizeInBits,
                                              uint64_t AlignInBits,
                                              unsigned Encoding) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DIBasicType T = D->createBasicType(Name, SizeInBits, AlignInBits, Encoding);
   return wrap(T);
+#else
+  return wrap(Dref->createBasicType(Name, SizeInBits, AlignInBits, Encoding));
+#endif
 }
 
-
-LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(LLVMDIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(DIBuilderRef Dref,
                                                   LLVMMetadataRef *Data,
-                                                  size_t Length) {
+                                                  unsigned Length) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
 #if HAVE_LLVM_35
   Value **DataValue = unwrap(Data);
@@ -116,20 +161,34 @@ LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(LLVMDIBuilderRef Dref,
   DITypeArray A = D->getOrCreateTypeArray(Elements);
 #endif
   return wrap(A);
+#else
+  Metadata **DataValue = unwrap(Data);
+  return wrap(
+      Dref->getOrCreateTypeArray(ArrayRef<Metadata *>(DataValue, Length))
+          .get());
+#endif
 }
 
-LLVMMetadataRef LLVMDIBuilderGetOrCreateArray(LLVMDIBuilderRef dref, LLVMMetadataRef *data, size_t length) {
-  DIBuilder *D = unwrap(dref);
-  ArrayRef<Metadata *> elements(unwrap(data), length);
+LLVMMetadataRef LLVMDIBuilderGetOrCreateArray(DIBuilderRef Dref,
+                                              LLVMMetadataRef *Data,
+                                              unsigned Length) {
+#if HAVE_LLVM_36_OR_LOWER
+  DIBuilder *D = unwrap(Dref);
+  ArrayRef<Metadata *> elements(unwrap(Data), Length);
   DIArray a = D->getOrCreateArray(elements);
 
   return wrap(a);
+#else
+  Metadata **DataValue = unwrap(Data);
+  return wrap(
+      Dref->getOrCreateArray(ArrayRef<Metadata *>(DataValue, Length)).get());
+#endif
 }
 
-
 LLVMMetadataRef
-LLVMDIBuilderCreateSubroutineType(LLVMDIBuilderRef Dref, LLVMMetadataRef File,
+LLVMDIBuilderCreateSubroutineType(DIBuilderRef Dref, LLVMMetadataRef File,
                                   LLVMMetadataRef ParameterTypes) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DICompositeType CT = D->createSubroutineType(
 #if HAVE_LLVM_35
@@ -137,20 +196,39 @@ LLVMDIBuilderCreateSubroutineType(LLVMDIBuilderRef Dref, LLVMMetadataRef File,
 #else
       unwrapDI<DIFile>(File), unwrapDI<DITypeArray>(ParameterTypes));
 #endif
+#else
+  DISubroutineType *CT = Dref->createSubroutineType(
+      DITypeRefArray(unwrap<MDTuple>(ParameterTypes)));
+#endif
   return wrap(CT);
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateLocalVariable(
-    LLVMDIBuilderRef Dref, unsigned Tag, LLVMMetadataRef Scope,
-    const char *Name, LLVMMetadataRef File, unsigned Line, LLVMMetadataRef Ty,
-    int AlwaysPreserve, unsigned Flags, unsigned ArgNo) {
+    DIBuilderRef Dref, unsigned Tag, LLVMMetadataRef Scope, const char *Name,
+    LLVMMetadataRef File, unsigned Line, LLVMMetadataRef Ty, int AlwaysPreserve,
+    unsigned Flags, unsigned ArgNo) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DIVariable V = D->createLocalVariable(
       Tag, unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
       unwrapDI<DIType>(Ty), AlwaysPreserve, Flags, ArgNo);
   return wrap(V);
+#else
+  if (Tag == 0x100) { // DW_TAG_auto_variable
+    DILocalVariable *V = Dref->createAutoVariable(
+        unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
+        unwrapDI<DIType>(Ty), AlwaysPreserve, Flags);
+    return wrap(V);
+  } else {
+    DILocalVariable *V = Dref->createParameterVariable(
+        unwrapDI<DIDescriptor>(Scope), Name, ArgNo, unwrapDI<DIFile>(File),
+        Line, unwrapDI<DIType>(Ty), AlwaysPreserve, Flags);
+    return wrap(V);
+  }
+#endif
 }
 
+#if HAVE_LLVM_36_OR_LOWER
 LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd(LLVMDIBuilderRef Dref,
                                              LLVMValueRef Storage,
                                              LLVMMetadataRef VarInfo,
@@ -158,91 +236,149 @@ LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd(LLVMDIBuilderRef Dref,
                                              LLVMBasicBlockRef Block) {
   DIBuilder *D = unwrap(Dref);
   Instruction *Instr =
-      D->insertDeclare(unwrap(Storage),
-        unwrapDI<DIVariable>(VarInfo),
-#ifdef HAVE_LLVM_35
+      D->insertDeclare(unwrap(Storage), unwrapDI<DIVariable>(VarInfo),
+#if HAVE_LLVM_35
 #else
-        unwrapDI<DIExpression>(Expr),
+                       unwrapDI<DIExpression>(Expr),
 #endif
-        unwrap(Block));
+                       unwrap(Block));
+#else
+LLVMValueRef
+LLVMDIBuilderInsertDeclareAtEnd(DIBuilderRef Dref, LLVMValueRef Storage,
+                                LLVMMetadataRef VarInfo, LLVMMetadataRef Expr,
+                                LLVMValueRef DL, LLVMBasicBlockRef Block) {
+  Instruction *Instr = Dref->insertDeclare(
+      unwrap(Storage), unwrap<DILocalVariable>(VarInfo),
+      unwrapDI<DIExpression>(Expr),
+      DebugLoc(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())),
+      unwrap(Block));
+#endif
   return wrap(Instr);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateExpression(LLVMDIBuilderRef Dref,
-                                              int64_t *Addr, size_t Length) {
-#ifdef HAVE_LLVM_35
+LLVMMetadataRef LLVMDIBuilderCreateExpression(DIBuilderRef Dref, int64_t *Addr,
+                                              size_t Length) {
+#if HAVE_LLVM_36_OR_LOWER
+#if HAVE_LLVM_35
   return nullptr;
 #else
   DIBuilder *D = unwrap(Dref);
   DIExpression Expr = D->createExpression(ArrayRef<int64_t>(Addr, Length));
   return wrap(Expr);
 #endif
+#else
+  return wrap(Dref->createExpression(ArrayRef<int64_t>(Addr, Length)));
+#endif
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateEnumerationType(LLVMDIBuilderRef Dref,
-  LLVMMetadataRef scope, const char* name, LLVMMetadataRef file, unsigned lineNumber,
-  uint64_t sizeInBits, uint64_t alignInBits, LLVMMetadataRef elements, LLVMMetadataRef underlyingType) {
-
+LLVMMetadataRef LLVMDIBuilderCreateEnumerationType(
+    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
+    LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
+    uint64_t AlignInBits, LLVMMetadataRef Elements,
+    LLVMMetadataRef UnderlyingType) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
-  DICompositeType enumType = D->createEnumerationType(unwrapDI<DIDescriptor>(scope), name,
-        unwrapDI<DIFile>(file), lineNumber, sizeInBits, alignInBits, unwrapDI<DIArray>(elements),
-        unwrapDI<DIType>(underlyingType));
-
+  DICompositeType enumType = D->createEnumerationType(
+      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
+      SizeInBits, AlignInBits, unwrapDI<DIArray>(Elements),
+      unwrapDI<DIType>(UnderlyingType));
+#else
+  DICompositeType *enumType = Dref->createEnumerationType(
+      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
+      SizeInBits, AlignInBits, DINodeArray(unwrapDI<MDTuple>(Elements)),
+      unwrapDI<DIType>(UnderlyingType));
+#endif
   return wrap(enumType);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateEnumerator(LLVMDIBuilderRef dref, const char* name, int64_t value) {
-  DIBuilder *D = unwrap(dref);
-  DIEnumerator e = D->createEnumerator(name, value);
+LLVMMetadataRef LLVMDIBuilderCreateEnumerator(DIBuilderRef Dref,
+                                              const char *Name, int64_t Value) {
+#if HAVE_LLVM_36_OR_LOWER
+  DIBuilder *D = unwrap(Dref);
+  DIEnumerator e = D->createEnumerator(Name, Value);
+  return wrap(e);
+#else
+  DIEnumerator *e = Dref->createEnumerator(Name, Value);
+#endif
   return wrap(e);
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateStructType(
-    LLVMDIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
+    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     LLVMMetadataRef File, unsigned Line, uint64_t SizeInBits,
     uint64_t AlignInBits, unsigned Flags, LLVMMetadataRef DerivedFrom,
-    LLVMMetadataRef ElementTypes) {
+    LLVMMetadataRef Elements) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DICompositeType CT = D->createStructType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
       SizeInBits, AlignInBits, Flags, unwrapDI<DIType>(DerivedFrom),
-      unwrapDI<DIArray>(ElementTypes));
+      unwrapDI<DIArray>(Elements));
+#else
+  DICompositeType *CT = Dref->createStructType(
+      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
+      SizeInBits, AlignInBits, Flags, unwrapDI<DIType>(DerivedFrom),
+      DINodeArray(unwrapDI<MDTuple>(Elements)));
+#endif
   return wrap(CT);
 }
 
 LLVMMetadataRef
-LLVMDIBuilderCreateMemberType(LLVMDIBuilderRef Dref, LLVMMetadataRef Scope,
+LLVMDIBuilderCreateMemberType(DIBuilderRef Dref, LLVMMetadataRef Scope,
                               const char *Name, LLVMMetadataRef File,
                               unsigned Line, uint64_t SizeInBits,
                               uint64_t AlignInBits, uint64_t OffsetInBits,
                               unsigned Flags, LLVMMetadataRef Ty) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DIDerivedType DT = D->createMemberType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
       SizeInBits, AlignInBits, OffsetInBits, Flags, unwrapDI<DIType>(Ty));
+#else
+  DIDerivedType *DT = Dref->createMemberType(
+      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
+      SizeInBits, AlignInBits, OffsetInBits, Flags, unwrapDI<DIType>(Ty));
+#endif
   return wrap(DT);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreatePointerType(LLVMDIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreatePointerType(DIBuilderRef Dref,
                                                LLVMMetadataRef PointeeType,
                                                uint64_t SizeInBits,
                                                uint64_t AlignInBits,
                                                const char *Name) {
+#if HAVE_LLVM_36_OR_LOWER
   DIBuilder *D = unwrap(Dref);
   DIDerivedType T = D->createPointerType(unwrapDI<DIType>(PointeeType),
                                          SizeInBits, AlignInBits, Name);
+#else
+  DIDerivedType *T = Dref->createPointerType(unwrapDI<DIType>(PointeeType),
+                                             SizeInBits, AlignInBits, Name);
+#endif
   return wrap(T);
 }
 
-LLVMMetadataRef LLVMTemporaryMDNode(LLVMContextRef C, LLVMMetadataRef *MDs, unsigned Count) {
-  return wrap(MDNode::getTemporary(*unwrap(C), ArrayRef<Metadata *>(unwrap(MDs), Count)));
+LLVMMetadataRef LLVMTemporaryMDNode(LLVMContextRef C, LLVMMetadataRef *MDs,
+                                    unsigned Count) {
+#if HAVE_LLVM_36_OR_LOWER
+  return wrap(MDNode::getTemporary(*unwrap(C),
+                                   ArrayRef<Metadata *>(unwrap(MDs), Count)));
+#else
+  return wrap(MDTuple::getTemporary(*unwrap(C),
+                                    ArrayRef<Metadata *>(unwrap(MDs), Count))
+                  .release());
+#endif
 }
 
 void LLVMMetadataReplaceAllUsesWith(LLVMMetadataRef MD, LLVMMetadataRef New) {
-#ifdef HAVE_LLVM_35
+#if HAVE_LLVM_36_OR_LOWER
+#if HAVE_LLVM_35
   auto *Node = unwrap<MDNode>(MD);
 #else
   auto *Node = unwrap<MDNodeFwdDecl>(MD);
+#endif
+#else
+  auto *Node = unwrap<MDNode>(MD);
 #endif
   Node->replaceAllUsesWith(unwrap<MDNode>(New));
   MDNode::deleteTemporary(Node);
@@ -255,7 +391,4 @@ void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Bref, unsigned Line,
       DebugLoc::get(Line, Col, Scope ? unwrap<MDNode>(Scope) : nullptr,
                     InlinedAt ? unwrap<MDNode>(InlinedAt) : nullptr));
 }
-
-
-
 }

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,7 +1,27 @@
 require "./enums"
 
-@[Link("stdc++")]
-@[Link(ldflags: "`$(command -v llvm-config-3.6 || command -v llvm-config36 || command -v llvm-config-3.5 || command -v llvm-config35 || command -v llvm-config) --libs --system-libs --ldflags 2> /dev/null`")]
+{% begin %}
+lib LibLLVM
+  LLVM_CONFIG = {{`command -v llvm-config-3.8 || command -v llvm-config38 || (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.8*) command -v llvm-config;; *) false;; esac)) || command -v llvm-config-3.6 || command -v llvm-config36 || command -v llvm-config-3.5 || command -v llvm-config35 || command -v llvm-config `.chomp.stringify}}
+end
+{% end %}
+
+{% begin %}
+  @[Link("stdc++")]
+  @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
+  lib LibLLVM
+    VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}
+  end
+{% end %}
+
+{% begin %}
+  lib LibLLVM
+    IS_38 = {{LibLLVM::VERSION.starts_with?("3.8")}}
+    IS_36 = {{LibLLVM::VERSION.starts_with?("3.6")}}
+    IS_35 = {{LibLLVM::VERSION.starts_with?("3.5")}}
+  end
+{% end %}
+
 lib LibLLVM
   type ContextRef = Void*
   type ModuleRef = Void*

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -1,3 +1,4 @@
+require "./lib_llvm"
 @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.o")]
 lib LibLLVMExt
   type DIBuilder = Void*
@@ -5,11 +6,19 @@ lib LibLLVMExt
 
   fun create_di_builder = LLVMNewDIBuilder(LibLLVM::ModuleRef) : DIBuilder
   fun di_builder_finalize = LLVMDIBuilderFinalize(DIBuilder)
+  {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
   fun di_builder_create_function = LLVMDIBuilderCreateFunction(
                                                                builder : DIBuilder, scope : Metadata, name : LibC::Char*,
                                                                linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
                                                                composite_type : Metadata, is_local_to_unit : LibC::Int, is_definition : LibC::Int,
                                                                scope_line : LibC::UInt, flags : LibC::UInt, is_optimized : LibC::Int, func : LibLLVM::ValueRef) : Metadata
+{% else %}
+  fun di_builder_create_function = LLVMDIBuilderCreateFunction(
+                                                               builder : DIBuilder, scope : Metadata, name : LibC::Char*,
+                                                               linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
+                                                               composite_type : Metadata, is_local_to_unit : Bool, is_definition : Bool,
+                                                               scope_line : LibC::UInt, flags : LibC::UInt, is_optimized : Bool, func : LibLLVM::ValueRef) : Metadata
+{% end %}
   fun di_builder_create_file = LLVMDIBuilderCreateFile(builder : DIBuilder, file : LibC::Char*, dir : LibC::Char*) : Metadata
   fun di_builder_create_compile_unit = LLVMDIBuilderCreateCompileUnit(builder : DIBuilder,
                                                                       lang : LibC::UInt, file : LibC::Char*,
@@ -34,11 +43,20 @@ lib LibLLVMExt
                                                                           name : LibC::Char*, file : Metadata, line : LibC::UInt, type : Metadata,
                                                                           always_preserve : LibC::Int, flags : LibC::UInt, arg_no : LibC::UInt) : Metadata
 
+  {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
                                                                          var_info : Metadata,
                                                                          expr : Metadata,
                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
+{% else %}
+  fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
+                                                                         storage : LibLLVM::ValueRef,
+                                                                         var_info : Metadata,
+                                                                         expr : Metadata,
+                                                                         dl : LibLLVM::ValueRef,
+                                                                         block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
+{% end %}
 
   fun di_builder_create_expression = LLVMDIBuilderCreateExpression(builder : DIBuilder,
                                                                    addr : Int64*, length : LibC::SizeT) : Metadata


### PR DESCRIPTION
Incompatible with 3.7, but is backwards compatible for currently supported versions of LLVM. Closes #1614. It is also necessary for #26, as TLS is now supported on cygwin targets with [emutls](http://llvm.org/releases/3.8.0/docs/ReleaseNotes.html#changes-to-the-x86-target). 

Build times using 3.8 appear to be slower on average.