### PR TITLE
Add restrictions to collection methods. Fixes #1764. Fixes #988

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -710,7 +710,6 @@ describe "Hash" do
 
   describe "select!" do
     assert { {:a => 2, :b => 3}.select!(:b, :d).should eq({:b => 3}) }
-    assert { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
     assert { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
     assert { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
     it "does change currrent hash" do

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -123,9 +123,9 @@ describe "Set" do
 
   it "does |" do
     set1 = Set{1, 2, 3}
-    set2 = Set{4, 2, 5, "3"}
+    set2 = Set{4, 2, 5, 9}
     set3 = set1 | set2
-    set3.should eq(Set{1, 2, 3, 4, 5, "3"})
+    set3.should eq(Set{1, 2, 3, 4, 5, 9})
   end
 
   it "does -" do
@@ -137,37 +137,9 @@ describe "Set" do
 
   it "does -" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
-    set3 = set1 - set2
-    set3.should eq(Set{1, 3, 5})
-  end
-
-  it "does -" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = Set{2, 4, 5}
-    set3 = set1 - set2
-    set3.should eq(Set{1, 3, 'b'})
-  end
-
-  it "does -" do
-    set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
-  end
-
-  it "does -" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
-    set3 = set1 - set2
-    set3.should eq(Set{1, 3, 5})
-  end
-
-  it "does -" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = [2, 4, 5]
-    set3 = set1 - set2
-    set3.should eq(Set{1, 3, 'b'})
   end
 
   it "does ^" do
@@ -179,37 +151,9 @@ describe "Set" do
 
   it "does ^" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
-    set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'a'})
-  end
-
-  it "does ^" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = Set{2, 4, 5}
-    set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'b'})
-  end
-
-  it "does ^" do
-    set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 6})
-  end
-
-  it "does ^" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
-    set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'a'})
-  end
-
-  it "does ^" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = [2, 4, 5]
-    set3 = set1 ^ set2
-    set3.should eq(Set{1, 3, 5, 'b'})
   end
 
   it "does subtract" do
@@ -221,37 +165,9 @@ describe "Set" do
 
   it "does subtract" do
     set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 5})
-  end
-
-  it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = Set{2, 4, 5}
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 'b'})
-  end
-
-  it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
-  end
-
-  it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 5})
-  end
-
-  it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 'b'}
-    set2 = [2, 4, 5]
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 'b'})
   end
 
   it "does to_a" do
@@ -311,7 +227,6 @@ describe "Set" do
     empty_set = Set(Int32).new
 
     set.subset?(Set{1, 2, 3, 4}).should be_true
-    set.subset?(Set{1, 2, 3, "4"}).should be_true
     set.subset?(Set{1, 2, 3}).should be_true
     set.subset?(Set{1, 2}).should be_false
     set.subset?(empty_set).should be_false
@@ -325,7 +240,6 @@ describe "Set" do
     empty_set = Set(Int32).new
 
     set.proper_subset?(Set{1, 2, 3, 4}).should be_true
-    set.proper_subset?(Set{1, 2, 3, "4"}).should be_true
     set.proper_subset?(Set{1, 2, 3}).should be_false
     set.proper_subset?(Set{1, 2}).should be_false
     set.proper_subset?(empty_set).should be_false
@@ -335,12 +249,11 @@ describe "Set" do
   end
 
   it "check superset" do
-    set = Set{1, 2, "3"}
+    set = Set{1, 2, 33}
     empty_set = Set(Int32).new
 
     set.superset?(empty_set).should be_true
     set.superset?(Set{1, 2}).should be_true
-    set.superset?(Set{1, 2, "3"}).should be_true
     set.superset?(Set{1, 2, 3}).should be_false
     set.superset?(Set{1, 2, 3, 4}).should be_false
     set.superset?(Set{1, 4}).should be_false
@@ -349,12 +262,11 @@ describe "Set" do
   end
 
   it "check proper_superset" do
-    set = Set{1, 2, "3"}
+    set = Set{1, 2, 33}
     empty_set = Set(Int32).new
 
     set.proper_superset?(empty_set).should be_true
     set.proper_superset?(Set{1, 2}).should be_true
-    set.proper_superset?(Set{1, 2, "3"}).should be_false
     set.proper_superset?(Set{1, 2, 3}).should be_false
     set.proper_superset?(Set{1, 2, 3, 4}).should be_false
     set.proper_superset?(Set{1, 4}).should be_false

--- a/src/array.cr
+++ b/src/array.cr
@@ -200,7 +200,7 @@ class Array(T)
   # ```
   #
   # See also: `#uniq`.
-  def &(other : Array(U))
+  def &(other : Array(T))
     return Array(T).new if self.empty? || other.empty?
 
     hash = other.to_lookup_hash
@@ -272,7 +272,7 @@ class Array(T)
   # ```
   # [1, 2, 3] - [2, 1] # => [3]
   # ```
-  def -(other : Array(U))
+  def -(other : Array(T))
     ary = Array(T).new(Math.max(size - other.size, 0))
     hash = other.to_lookup_hash
     each do |obj|
@@ -663,7 +663,16 @@ class Array(T)
   # ary # => ["a", "b", "c"]
   # ```
   def compact!
-    delete nil
+    found = false
+    reject! do |obj|
+      if obj.nil?
+        found = true
+        true
+      else
+        false
+      end
+    end
+    found
   end
 
   # Appends the elements of *other* to `self`, and returns `self`.
@@ -715,7 +724,7 @@ class Array(T)
   # a.delete("b")
   # a # => ["a", "c"]
   # ```
-  def delete(obj)
+  def delete(obj : T)
     reject! { |e| e == obj } != nil
   end
 
@@ -1615,7 +1624,7 @@ class Array(T)
     ReverseIterator.new(self)
   end
 
-  def rindex(value)
+  def rindex(value : T)
     rindex { |elem| elem == value }
   end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -613,7 +613,7 @@ class Crystal::Command
 
     output_filename ||= original_output_filename
     output_format ||= "text"
-    if !["text", "json"].includes?(output_format)
+    unless {"text", "json"}.includes?(output_format.not_nil!)
       error "You have input an invalid format, only text and JSON are supported"
     end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3168,7 +3168,8 @@ module Crystal
     end
 
     def check_valid_def_name
-      if {:is_a?, :as, :as?, :responds_to?, :nil?}.includes?(@token.value)
+      value = @token.value
+      if value.is_a?(Symbol) && {:is_a?, :as, :as?, :responds_to?, :nil?}.includes?(value)
         raise "'#{@token.value}' is a pseudo-method and can't be redefined", @token
       end
     end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -216,7 +216,7 @@ class Deque(T)
   # a.delete("b")
   # a # => Deque{"a", "c"}
   # ```
-  def delete(obj)
+  def delete(obj : T)
     found = false
     i = 0
     while i < @size

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -104,7 +104,7 @@ module Enumerable(T)
   #
   #     [1, 2, 3, 4].count(3)  #=> 1
   #
-  def count(item)
+  def count(item : T)
     count { |e| e == item }
   end
 
@@ -327,7 +327,7 @@ module Enumerable(T)
   #     [1, 2, 3].includes?(2)  #=> true
   #     [1, 2, 3].includes?(5)  #=> false
   #
-  def includes?(obj)
+  def includes?(obj : T)
     any? { |e| e == obj }
   end
 
@@ -348,7 +348,7 @@ module Enumerable(T)
   #     ["Alice", "Bob"].index("Alice")  #=> 0
   #
   # Returns `nil` if *obj* is not in the collection.
-  def index(obj)
+  def index(obj : T)
     index { |e| e == obj }
   end
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -55,7 +55,7 @@ class Hash(K, V)
   end
 
   # See `Hash#fetch`
-  def [](key)
+  def [](key : T)
     fetch(key)
   end
 
@@ -70,7 +70,7 @@ class Hash(K, V)
   # h = Hash(String, String).new("bar")
   # h["foo"]? # => nil
   # ```
-  def []?(key)
+  def []?(key : T)
     fetch(key, nil)
   end
 
@@ -81,7 +81,7 @@ class Hash(K, V)
   # h.has_key?("foo") # => true
   # h.has_key?("bar") # => false
   # ```
-  def has_key?(key)
+  def has_key?(key : T)
     !!find_entry(key)
   end
 
@@ -101,7 +101,7 @@ class Hash(K, V)
   # h = Hash(String, String).new
   # h["foo"] # raises KeyError
   # ```
-  def fetch(key)
+  def fetch(key : T)
     fetch(key) do
       if (block = @block) && key.is_a?(K)
         block.call(self, key.as(K))
@@ -119,7 +119,7 @@ class Hash(K, V)
   # h.fetch("foo", "foo") # => "bar"
   # h.fetch("bar", "foo") # => "foo"
   # ```
-  def fetch(key, default)
+  def fetch(key : T, default)
     fetch(key) { default }
   end
 
@@ -130,7 +130,7 @@ class Hash(K, V)
   # h.fetch("foo") { |key| key.upcase } # => "bar"
   # h.fetch("bar") { |key| key.upcase } # => "BAR"
   # ```
-  def fetch(key)
+  def fetch(key : T)
     entry = find_entry(key)
     entry ? entry.value : yield key
   end
@@ -153,7 +153,7 @@ class Hash(K, V)
   # hash.key("qux")    # => "baz"
   # hash.key("foobar") # => Missing hash key for value: foobar (KeyError)
   # ```
-  def key(value)
+  def key(value : T)
     key(value) { raise KeyError.new "Missing hash key for value: #{value}" }
   end
 
@@ -165,7 +165,7 @@ class Hash(K, V)
   # hash.key?("qux")    # => "baz"
   # hash.key?("foobar") # => nil
   # ```
-  def key?(value)
+  def key?(value : T)
     key(value) { nil }
   end
 
@@ -176,7 +176,7 @@ class Hash(K, V)
   # hash.key("bar") { |value| value.upcase } # => "foo"
   # hash.key("qux") { |value| value.upcase } # => "QUX"
   # ```
-  def key(value)
+  def key(value : T)
     each do |k, v|
       return k if v == value
     end
@@ -190,7 +190,7 @@ class Hash(K, V)
   # h.delete("foo")     # => "bar"
   # h.fetch("foo", nil) # => nil
   # ```
-  def delete(key)
+  def delete(key : T)
     index = bucket_index(key)
     entry = @buckets[index]
 
@@ -397,7 +397,7 @@ class Hash(K, V)
   # h.key_index("foo") # => 0
   # h.key_index("qux") # => nil
   # ```
-  def key_index(key)
+  def key_index(key : T)
     each_with_index do |(my_key, my_value), index|
       return index if key == my_key
     end
@@ -510,7 +510,7 @@ class Hash(K, V)
     self
   end
 
-  def reject!(*keys)
+  def reject!(*keys : K)
     reject!(keys)
   end
 
@@ -540,7 +540,7 @@ class Hash(K, V)
     self
   end
 
-  def select!(*keys)
+  def select!(*keys : K)
     select!(keys)
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -82,7 +82,7 @@ module HTTP
     bytesize = line.bytesize
 
     # Get the colon index and name
-    colon_index = cstr.to_slice(bytesize).index(':'.ord) || 0
+    colon_index = cstr.to_slice(bytesize).index(':'.ord.to_u8) || 0
     name = line.byte_slice(0, colon_index)
 
     # Get where the header value starts (skip space)

--- a/src/io/memory_io.cr
+++ b/src/io/memory_io.cr
@@ -139,7 +139,7 @@ class MemoryIO
 
     raise ArgumentError.new "negative limit" if limit < 0
 
-    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord)
+    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord.to_u8)
     if index
       if index > limit
         index = limit

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -370,12 +370,12 @@ class Markdown::Parser
           if link
             @renderer.text line.byte_slice(cursor, pos - cursor)
 
-            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.ord).not_nil!
+            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.ord.to_u8).not_nil!
             alt = line.byte_slice(pos + 2, bracket_idx)
 
             @renderer.image link, alt
 
-            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.ord).not_nil!
+            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.ord.to_u8).not_nil!
             pos += 2 + bracket_idx + 1 + paren_idx
             cursor = pos + 1
           end
@@ -395,7 +395,7 @@ class Markdown::Parser
           @renderer.text line.byte_slice(cursor, pos - cursor)
           @renderer.end_link
 
-          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord).not_nil!
+          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord.to_u8).not_nil!
           pos += paren_idx + 1
           cursor = pos + 1
           in_link = false
@@ -415,7 +415,7 @@ class Markdown::Parser
   def has_closing?(char, count, str, pos, bytesize)
     str += pos
     bytesize -= pos
-    idx = str.to_slice(bytesize).index char.ord
+    idx = str.to_slice(bytesize).index char.ord.to_u8
     return false unless idx
 
     if count == 2
@@ -446,7 +446,7 @@ class Markdown::Parser
 
     return nil unless str[bracket_idx + 1] === '('
 
-    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord
+    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord.to_u8
     return nil unless paren_idx
 
     String.new(Slice.new(str + bracket_idx + 2, paren_idx - 1))

--- a/src/set.cr
+++ b/src/set.cr
@@ -75,7 +75,7 @@ struct Set(T)
   #     s = Set.new [1,5]
   #     s.includes? 5  # => true
   #     s.includes? 9  # => false
-  def includes?(object)
+  def includes?(object : T)
     @hash.has_key?(object)
   end
 
@@ -85,7 +85,7 @@ struct Set(T)
   #     s.includes? 5  # => true
   #     s.delete 5
   #     s.includes? 5  # => false
-  def delete(object)
+  def delete(object : T)
     @hash.delete(object)
     self
   end
@@ -136,7 +136,7 @@ struct Set(T)
   #
   #     Set.new([1,1,3,5]) & Set.new([1,2,3])               #=> Set{1, 3}
   #     Set.new(['a','b','b','z']) & Set.new(['a','b','c']) #=> Set{'a', 'b'}
-  def &(other : Set)
+  def &(other : Set(T))
     set = Set(T).new
     each do |value|
       set.add value if other.includes?(value)
@@ -160,7 +160,7 @@ struct Set(T)
   #
   #     Set.new([1,2,3,4,5]) - Set.new([2,4])               #=> Set{1, 3, 5}
   #     Set.new(['a','b','b','z']) - Set.new(['a','b','c']) #=> Set{'z'}
-  def -(other : Set)
+  def -(other : Set(T))
     set = Set(T).new
     each do |value|
       set.add value unless other.includes?(value)
@@ -182,8 +182,8 @@ struct Set(T)
   #
   #     Set.new([1,2,3,4,5]) ^ Set.new([2,4,6])             #=> Set{1, 3, 5, 6}
   #     Set.new(['a','b','b','z']) ^ Set.new(['a','b','c']) #=> Set{'z', 'c'}
-  def ^(other : Set(U))
-    set = Set(T | U).new
+  def ^(other : Set)
+    set = Set(T).new
     each do |value|
       set.add value unless other.includes?(value)
     end
@@ -198,8 +198,8 @@ struct Set(T)
   #
   #     Set.new([1,2,3,4,5]) ^ [2,4,6]             #=> Set{1, 3, 5, 6}
   #     Set.new(['a','b','b','z']) ^ ['a','b','c'] #=> Set{'z', 'c'}
-  def ^(other : Enumerable(U))
-    set = Set(T | U).new.merge(self)
+  def ^(other : Enumerable)
+    set = Set(T).new.merge(self)
     other.each do |value|
       if includes?(value)
         set.delete value
@@ -266,7 +266,7 @@ struct Set(T)
   # Set{1, 2, 3}.intersects? Set{4, 5} # => false
   # Set{1, 2, 3}.intersects? Set{3, 4} # => true
   # ```
-  def intersects?(other : Set)
+  def intersects?(other : Set(T))
     if size < other.size
       any? { |o| other.includes?(o) }
     else
@@ -288,7 +288,7 @@ struct Set(T)
   #
   #     Set.new([1,5]).subset? Set.new([1,3,5])   # => true
   #     Set.new([1,3,5]).subset? Set.new([1,3,5]) # => true
-  def subset?(other : Set)
+  def subset?(other : Set(T))
     return false if other.size < size
     all? { |value| other.includes?(value) }
   end
@@ -300,7 +300,7 @@ struct Set(T)
   #
   #     Set.new([1,5]).subset? Set.new([1,3,5])   # => true
   #     Set.new([1,3,5]).subset? Set.new([1,3,5]) # => false
-  def proper_subset?(other : Set)
+  def proper_subset?(other : Set(T))
     return false if other.size <= size
     all? { |value| other.includes?(value) }
   end
@@ -312,7 +312,7 @@ struct Set(T)
   #
   #     Set.new([1,3,5]).superset? Set.new([1,5])   # => true
   #     Set.new([1,3,5]).superset? Set.new([1,3,5]) # => true
-  def superset?(other : Set)
+  def superset?(other : Set(T))
     other.subset?(self)
   end
 
@@ -323,7 +323,7 @@ struct Set(T)
   #
   #     Set.new([1,3,5]).superset? Set.new([1,5])   # => true
   #     Set.new([1,3,5]).superset? Set.new([1,3,5]) # => false
-  def proper_superset?(other : Set)
+  def proper_superset?(other : Set(T))
     other.proper_subset?(self)
   end
 


### PR DESCRIPTION
Instead of rebasing #1851 I decided to do it again after discussing this better with @mverzilli and @juanedi 

With this, all of these don't compile anymore:

``` cr
[1, 2, 3].includes?(nil)
[1, 2, 3].includes?(1_i64)
[1, 2, 3].delete "foo"
[1, 2, 3] - [1, 'a']

{1 => 2}["foo"]
{1 => 2}["foo"]?
{1 => 2}.has_key?('foo")
```

In this way you get a compile error when trying to pass an invalid type to an operation. The reason behind this is that, for example, `{1 => 2}["foo"]` will always raise, so why would you want that in a program. Similarly, `[1, 2].includes?("foo")` is always going to be false, so that check is redundant.

This is a bit against generic programming, but the few cases I had to change/fix in the compiler, plus some other few cases I noticed needed to change in some shards makes me think this is a good change.

This is, of course, not backwards compatible.
