### PR TITLE
Fixed #2999: allow '~' in HTTP header value

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -160,4 +160,10 @@ describe HTTP::Headers do
     headers.includes_word?("foo", "bar").should be_false
     headers.includes_word?("foo", "").should be_false
   end
+
+  it "can create header value with all US-ASCII visible chars (#2999)" do
+    headers = HTTP::Headers.new
+    value = (32..126).map(&.chr).join
+    headers.add("foo", value)
+  end
 end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -259,7 +259,7 @@ struct HTTP::Headers
     value.each_byte do |byte|
       char = byte.unsafe_chr
       next if char == '\t'
-      if char < ' ' || char > '\u{ff}' || char == '\u{7e}'
+      if char < ' ' || char > '\u{ff}'
         raise ArgumentError.new("header content contains invalid character #{char.inspect}")
       end
     end


### PR DESCRIPTION
@MakeNowJust Any reason why `~` was specifically disallowed in an HTTP header value?