### PR TITLE
Fix pkg-config: command not found errors

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,4 +1,4 @@
-@[Link(ldflags: "`pkg-config --libs libcrypto || printf %s '-lcrypto'`")]
+@[Link(ldflags: "`pkg-config --libs libcrypto 2> /dev/null || printf %s '-lcrypto'`")]
 lib LibCrypto
   alias Char = LibC::Char
   alias Int = LibC::Int
@@ -237,7 +237,7 @@ lib LibCrypto
   fun x509v3_ext_print = X509V3_EXT_print(out : Bio*, ext : X509_EXTENSION, flag : Int, indent : Int) : Int
 end
 
-{% if `(pkg-config --atleast-version=1.0.2 libcrypto && printf %s true) || printf %s false` == "true" %}
+{% if `(pkg-config --atleast-version=1.0.2 libcrypto 2> /dev/null && printf %s true) || printf %s false` == "true" %}
 lib LibCrypto
   OPENSSL_102 = true
 end

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -1,6 +1,6 @@
 require "./lib_crypto"
 
-@[Link(ldflags: "`pkg-config --libs libssl || printf %s '-lssl -lcrypto'`")]
+@[Link(ldflags: "`pkg-config --libs libssl 2> /dev/null || printf %s '-lssl -lcrypto'`")]
 lib LibSSL
   alias Int = LibC::Int
   alias Char = LibC::Char
@@ -166,7 +166,7 @@ lib LibSSL
   fun ssl_ctx_set_cert_verify_callback = SSL_CTX_set_cert_verify_callback(ctx : SSLContext, callback : CertVerifyCallback, arg : Void*)
 end
 
-{% if `(pkg-config --atleast-version=1.0.2 libssl && printf %s true) || printf %s false` == "true" %}
+{% if `(pkg-config --atleast-version=1.0.2 libssl 2> /dev/null && printf %s true) || printf %s false` == "true" %}
 lib LibSSL
   OPENSSL_102 = true
 end


### PR DESCRIPTION
On OS X I sometimes get the following output on stderr:

```
--: pkg-config: command not found
--: pkg-config: command not found
```

From what I can tell from scanning through the source I think this is because `src/openssl/lib_crypto.cr` and `src/openssl/lib_ssl.cr` call out to pkg-config without checking if pkg-config exists (unlike `src/compiler/crystal/codegen/link.cr` which checks).

A better fix might be to explicitly declare the alternate flags, but I don't know enough about dealing with system libs and your preferences on how to structure that, so I've gone for the simpler fix of redirecting to /dev/null (as `src/llvm/lib_llvm.cr` does).