### PR TITLE
Unify String and Char to integer/float conversion API

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -124,7 +124,38 @@ describe "Char" do
     ('0'..'9').each_with_index do |c, i|
       c.to_i.should eq(i)
     end
-    'a'.to_i.should eq(0)
+    expect_raises(ArgumentError) { 'a'.to_i }
+    'a'.to_i?.should be_nil
+
+    '1'.to_i8.should eq(1i8)
+    '1'.to_i16.should eq(1i16)
+    '1'.to_i32.should eq(1i32)
+    '1'.to_i64.should eq(1i64)
+
+    expect_raises(ArgumentError) { 'a'.to_i8 }
+    expect_raises(ArgumentError) { 'a'.to_i16 }
+    expect_raises(ArgumentError) { 'a'.to_i32 }
+    expect_raises(ArgumentError) { 'a'.to_i64 }
+
+    'a'.to_i8?.should be_nil
+    'a'.to_i16?.should be_nil
+    'a'.to_i32?.should be_nil
+    'a'.to_i64?.should be_nil
+
+    '1'.to_u8.should eq(1u8)
+    '1'.to_u16.should eq(1u16)
+    '1'.to_u32.should eq(1u32)
+    '1'.to_u64.should eq(1u64)
+
+    expect_raises(ArgumentError) { 'a'.to_u8 }
+    expect_raises(ArgumentError) { 'a'.to_u16 }
+    expect_raises(ArgumentError) { 'a'.to_u32 }
+    expect_raises(ArgumentError) { 'a'.to_u64 }
+
+    'a'.to_u8?.should be_nil
+    'a'.to_u16?.should be_nil
+    'a'.to_u32?.should be_nil
+    'a'.to_u64?.should be_nil
   end
 
   it "does to_i with 16 base" do
@@ -137,8 +168,8 @@ describe "Char" do
     ('A'..'F').each_with_index do |c, i|
       c.to_i(16).should eq(10 + i)
     end
-    'Z'.to_i(16).should eq(0)
-    'Z'.to_i(16, or_else: -1).should eq(-1)
+    expect_raises(ArgumentError) { 'Z'.to_i(16) }
+    'Z'.to_i?(16).should be_nil
   end
 
   it "does to_i with base 36" do
@@ -159,6 +190,18 @@ describe "Char" do
     expect_raises ArgumentError, "invalid base 37" do
       '0'.to_i(37)
     end
+  end
+
+  it "does to_f" do
+    ('0'..'9').each.zip((0..9).each).each do |c, i|
+      c.to_f.should eq(i.to_f)
+    end
+    expect_raises(ArgumentError) { 'A'.to_f }
+    '1'.to_f32.should eq(1.0f32)
+    '1'.to_f64.should eq(1.0f64)
+    'a'.to_f?.should be_nil
+    'a'.to_f32?.should be_nil
+    'a'.to_f64?.should be_nil
   end
 
   it "does ord for multibyte char" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -329,8 +329,18 @@ describe "String" do
   end
 
   it "does to_f" do
+    expect_raises(ArgumentError) { "".to_f }
+    "".to_f?.should be_nil
+    expect_raises(ArgumentError) { " ".to_f }
+    " ".to_f?.should be_nil
+    "0".to_f.should eq(0_f64)
+    "0.0".to_f.should eq(0_f64)
+    "+0.0".to_f.should eq(0_f64)
+    "-0.0".to_f.should eq(0_f64)
     "1234.56".to_f.should eq(1234.56_f64)
     "1234.56".to_f?.should eq(1234.56_f64)
+    "+1234.56".to_f?.should eq(1234.56_f64)
+    "-1234.56".to_f?.should eq(-1234.56_f64)
     expect_raises(ArgumentError) { "foo".to_f }
     "foo".to_f?.should be_nil
     "  1234.56  ".to_f.should eq(1234.56_f64)
@@ -339,11 +349,26 @@ describe "String" do
     "  1234.56  ".to_f?(whitespace: false).should be_nil
     expect_raises(ArgumentError) { "  1234.56foo".to_f }
     "  1234.56foo".to_f?.should be_nil
+    "123.45 x".to_f64(strict: false).should eq(123.45_f64)
+    expect_raises(ArgumentError) { "x1.2".to_f64 }
+    "x1.2".to_f64?.should be_nil
+    expect_raises(ArgumentError) { "x1.2".to_f64(strict: false) }
+    "x1.2".to_f64?(strict: false).should be_nil
   end
 
   it "does to_f32" do
+    expect_raises(ArgumentError) { "".to_f32 }
+    "".to_f32?.should be_nil
+    expect_raises(ArgumentError) { " ".to_f32 }
+    " ".to_f32?.should be_nil
+    "0".to_f32.should eq(0_f32)
+    "0.0".to_f32.should eq(0_f32)
+    "+0.0".to_f32.should eq(0_f32)
+    "-0.0".to_f32.should eq(0_f32)
     "1234.56".to_f32.should eq(1234.56_f32)
     "1234.56".to_f32?.should eq(1234.56_f32)
+    "+1234.56".to_f32?.should eq(1234.56_f32)
+    "-1234.56".to_f32?.should eq(-1234.56_f32)
     expect_raises(ArgumentError) { "foo".to_f32 }
     "foo".to_f32?.should be_nil
     "  1234.56  ".to_f32.should eq(1234.56_f32)
@@ -352,11 +377,26 @@ describe "String" do
     "  1234.56  ".to_f32?(whitespace: false).should be_nil
     expect_raises(ArgumentError) { "  1234.56foo".to_f32 }
     "  1234.56foo".to_f32?.should be_nil
+    "123.45 x".to_f32(strict: false).should eq(123.45_f32)
+    expect_raises(ArgumentError) { "x1.2".to_f32 }
+    "x1.2".to_f32?.should be_nil
+    expect_raises(ArgumentError) { "x1.2".to_f32(strict: false) }
+    "x1.2".to_f32?(strict: false).should be_nil
   end
 
   it "does to_f64" do
+    expect_raises(ArgumentError) { "".to_f64 }
+    "".to_f64?.should be_nil
+    expect_raises(ArgumentError) { " ".to_f64 }
+    " ".to_f64?.should be_nil
+    "0".to_f64.should eq(0_f64)
+    "0.0".to_f64.should eq(0_f64)
+    "+0.0".to_f64.should eq(0_f64)
+    "-0.0".to_f64.should eq(0_f64)
     "1234.56".to_f64.should eq(1234.56_f64)
     "1234.56".to_f64?.should eq(1234.56_f64)
+    "+1234.56".to_f?.should eq(1234.56_f64)
+    "-1234.56".to_f?.should eq(-1234.56_f64)
     expect_raises(ArgumentError) { "foo".to_f64 }
     "foo".to_f64?.should be_nil
     "  1234.56  ".to_f64.should eq(1234.56_f64)
@@ -365,6 +405,11 @@ describe "String" do
     "  1234.56  ".to_f64?(whitespace: false).should be_nil
     expect_raises(ArgumentError) { "  1234.56foo".to_f64 }
     "  1234.56foo".to_f64?.should be_nil
+    "123.45 x".to_f64(strict: false).should eq(123.45_f64)
+    expect_raises(ArgumentError) { "x1.2".to_f64 }
+    "x1.2".to_f64?.should be_nil
+    expect_raises(ArgumentError) { "x1.2".to_f64(strict: false) }
+    "x1.2".to_f64?(strict: false).should be_nil
   end
 
   it "compares strings: different size" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -178,7 +178,7 @@ describe "String" do
     end
   end
 
-  describe "to_i" do
+  describe "i" do
     assert { "1234".to_i.should eq(1234) }
     assert { "   +1234   ".to_i.should eq(1234) }
     assert { "   -1234   ".to_i.should eq(-1234) }
@@ -330,14 +330,41 @@ describe "String" do
 
   it "does to_f" do
     "1234.56".to_f.should eq(1234.56_f64)
+    "1234.56".to_f?.should eq(1234.56_f64)
+    expect_raises(ArgumentError) { "foo".to_f }
+    "foo".to_f?.should be_nil
+    "  1234.56  ".to_f.should eq(1234.56_f64)
+    "  1234.56  ".to_f?.should eq(1234.56_f64)
+    expect_raises(ArgumentError) { "  1234.56  ".to_f(whitespace: false) }
+    "  1234.56  ".to_f?(whitespace: false).should be_nil
+    expect_raises(ArgumentError) { "  1234.56foo".to_f }
+    "  1234.56foo".to_f?.should be_nil
   end
 
   it "does to_f32" do
     "1234.56".to_f32.should eq(1234.56_f32)
+    "1234.56".to_f32?.should eq(1234.56_f32)
+    expect_raises(ArgumentError) { "foo".to_f32 }
+    "foo".to_f32?.should be_nil
+    "  1234.56  ".to_f32.should eq(1234.56_f32)
+    "  1234.56  ".to_f32?.should eq(1234.56_f32)
+    expect_raises(ArgumentError) { "  1234.56  ".to_f32(whitespace: false) }
+    "  1234.56  ".to_f32?(whitespace: false).should be_nil
+    expect_raises(ArgumentError) { "  1234.56foo".to_f32 }
+    "  1234.56foo".to_f32?.should be_nil
   end
 
   it "does to_f64" do
     "1234.56".to_f64.should eq(1234.56_f64)
+    "1234.56".to_f64?.should eq(1234.56_f64)
+    expect_raises(ArgumentError) { "foo".to_f64 }
+    "foo".to_f64?.should be_nil
+    "  1234.56  ".to_f64.should eq(1234.56_f64)
+    "  1234.56  ".to_f64?.should eq(1234.56_f64)
+    expect_raises(ArgumentError) { "  1234.56  ".to_f64(whitespace: false) }
+    "  1234.56  ".to_f64?(whitespace: false).should be_nil
+    expect_raises(ArgumentError) { "  1234.56foo".to_f64 }
+    "  1234.56foo".to_f64?.should be_nil
   end
 
   it "compares strings: different size" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -108,7 +108,7 @@ struct Char
   # 'z'.digit?(36) # => true
   # ```
   def digit?(base : Int = 10)
-    !!to_i(base) { false }
+    !!to_i?(base)
   end
 
   # Returns `true` if this char is a lowercase ASCII letter.
@@ -404,70 +404,114 @@ struct Char
     end
   end
 
-  # Returns the integer value of this char if it's an ASCII char denoting a digit,
-  # 0 otherwise.
+  # Returns the integer value of this char if it's an ASCII char denoting a digit
+  # in *base*, raises otherwise.
   #
   # ```
-  # '1'.to_i # => 1
-  # '8'.to_i # => 8
-  # 'c'.to_i # => 0
+  # '1'.to_i     # => 1
+  # '8'.to_i     # => 8
+  # 'c'.to_i     # => ArgumentError
+  # '1'.to_i(16) # => 1
+  # 'a'.to_i(16) # => 10
+  # 'f'.to_i(16) # => 15
+  # 'z'.to_i(16) # => ArgumentError
   # ```
-  def to_i
-    to_i { 0 }
+  def to_i(base : Int = 10)
+    to_i?(base) || raise ArgumentError.new("Invalid integer: #{self}")
   end
 
-  # Returns the integer value of this char if it's an ASCII char denoting a digit,
-  # otherwise the value returned by the block.
+  # Returns the integer value of this char if it's an ASCII char denoting a digit
+  # in *base*,  `nil` otherwise.
   #
   # ```
-  # '1'.to_i { 10 } # => 1
-  # '8'.to_i { 10 } # => 8
-  # 'c'.to_i { 10 } # => 10
+  # '1'.to_i     # => 1
+  # '8'.to_i     # => 8
+  # 'c'.to_i     # => ArgumentError
+  # '1'.to_i(16) # => 1
+  # 'a'.to_i(16) # => 10
+  # 'f'.to_i(16) # => 15
+  # 'z'.to_i(16) # => ArgumentError
   # ```
-  def to_i
-    if digit?
-      self - '0'
-    else
-      yield
-    end
-  end
-
-  # Returns the integer value of this char if it's an ASCII char denoting a digit in *base*,
-  # otherwise the value of *or_else*.
-  #
-  # ```
-  # '1'.to_i(16)     # => 1
-  # 'a'.to_i(16)     # => 10
-  # 'f'.to_i(16)     # => 15
-  # 'z'.to_i(16)     # => 0
-  # 'z'.to_i(16, 20) # => 20
-  # ```
-  def to_i(base, or_else = 0)
-    to_i(base) { or_else }
-  end
-
-  # Returns the integer value of this char if it's an ASCII char denoting a digit in *base*,
-  # otherwise the value return by the given block.
-  #
-  # ```
-  # '1'.to_i(16) { 20 } # => 1
-  # 'a'.to_i(16) { 20 } # => 10
-  # 'f'.to_i(16) { 20 } # => 15
-  # 'z'.to_i(16) { 20 } # => 20
-  # ```
-  def to_i(base)
+  def to_i?(base : Int = 10)
     raise ArgumentError.new "invalid base #{base}, expected 2 to 36" unless 2 <= base <= 36
 
-    ord = ord()
-    if 0 <= ord < 256
-      digit = String::CHAR_TO_DIGIT.to_unsafe[ord]
-      if digit == -1 || digit >= base
-        return yield
-      end
-      digit
+    if base == 10
+      return unless '0' <= self <= '9'
+      self - '0'
     else
-      return yield
+      ord = ord()
+      if 0 <= ord < 256
+        digit = String::CHAR_TO_DIGIT.to_unsafe[ord]
+        return if digit == -1 || digit >= base
+        digit
+      end
     end
+  end
+
+  # Same as `to_i`
+  def to_i32(base : Int = 10)
+    to_i(base)
+  end
+
+  # Same as `to_i?`
+  def to_i32?(base : Int = 10)
+    to_i?(base)
+  end
+
+  {% for type in %w(i8 i16 i64 u8 u16 u32 u64) %}
+    # See `to_i`
+    def to_{{type.id}}(base : Int = 10)
+      to_i(base).to_{{type.id}}
+    end
+
+    # See `to_i?`
+    def to_{{type.id}}?(base : Int = 10)
+      to_i?(base).try &.to_{{type.id}}
+    end
+  {% end %}
+
+  # Returns the integer value of this char as a float if it's an ASCII char denoting a digit,
+  # raises otherwise.
+  #
+  # ```
+  # '1'.to_i # => 1.0
+  # '8'.to_i # => 8.0
+  # 'c'.to_i # => ArgumentError
+  # ```
+  def to_f
+    to_f64
+  end
+
+  # Returns the integer value of this char as a float if it's an ASCII char denoting a digit,
+  # `nil` otherwise.
+  #
+  # ```
+  # '1'.to_i # => 1.0
+  # '8'.to_i # => 8.0
+  # 'c'.to_i # => ArgumentError
+  # ```
+  def to_f?
+    to_f64?
+  end
+
+  # See `to_f`
+  def to_f32
+    to_i.to_f32
+  end
+
+  # See `to_f?`
+  def to_f32?
+    to_i?.try &.to_f32
+  end
+
+  # Same as `to_f`
+  def to_f64
+    to_i.to_f64
+  end
+
+  # Same as `to_f?`
+  def to_f64?
+    to_i?.try &.to_f64
   end
 
   # Yields each of the bytes of this char as encoded by UTF-8.

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -199,7 +199,7 @@ abstract class JSON::Lexer
     hexnum = 0
     4.times do
       char = next_char
-      hexnum = (hexnum << 4) | char.to_i(16) { raise "unexpected char in hex number: #{char.inspect}" }
+      hexnum = (hexnum << 4) | (char.to_i?(16) || raise "unexpected char in hex number: #{char.inspect}")
     end
     hexnum
   end

--- a/src/lib_c/i686-linux-gnu/c/stdlib.cr
+++ b/src/lib_c/i686-linux-gnu/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(name : Char*, resolved : Char*) : Char*
   fun setenv(name : Char*, value : Char*, replace : Int) : Int
   fun strtof(nptr : Char*, endptr : Char**) : Float
+  fun strtod(nptr : Char*, endptr : Char**) : Double
   fun unsetenv(name : Char*) : Int
 end

--- a/src/lib_c/i686-linux-musl/c/stdlib.cr
+++ b/src/lib_c/i686-linux-musl/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(x0 : Char*, x1 : Char*) : Char*
   fun setenv(x0 : Char*, x1 : Char*, x2 : Int) : Int
   fun strtof(x0 : Char*, x1 : Char**) : Float
+  fun strtod(x0 : Char*, x1 : Char**) : Double
   fun unsetenv(x0 : Char*) : Int
 end

--- a/src/lib_c/x86_64-linux-gnu/c/stdlib.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(name : Char*, resolved : Char*) : Char*
   fun setenv(name : Char*, value : Char*, replace : Int) : Int
   fun strtof(nptr : Char*, endptr : Char**) : Float
+  fun strtod(nptr : Char*, endptr : Char**) : Double
   fun unsetenv(name : Char*) : Int
 end

--- a/src/lib_c/x86_64-linux-musl/c/stdlib.cr
+++ b/src/lib_c/x86_64-linux-musl/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(x0 : Char*, x1 : Char*) : Char*
   fun setenv(x0 : Char*, x1 : Char*, x2 : Int) : Int
   fun strtof(x0 : Char*, x1 : Char**) : Float
+  fun strtod(x0 : Char*, x1 : Char**) : Double
   fun unsetenv(x0 : Char*) : Int
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(x0 : Char*, x1 : Char*) : Char*
   fun setenv(x0 : Char*, x1 : Char*, x2 : Int) : Int
   fun strtof(x0 : Char*, x1 : Char**) : Float
+  fun strtod(x0 : Char*, x1 : Char**) : Double
   fun unsetenv(x0 : Char*) : Int
 end

--- a/src/lib_c/x86_64-portbld-freebsd/c/stdlib.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/stdlib.cr
@@ -19,5 +19,6 @@ lib LibC
   fun realpath(x0 : Char*, x1 : Char*) : Char*
   fun setenv(x0 : Char*, x1 : Char*, x2 : Int) : Int
   fun strtof(x0 : Char*, x1 : Char**) : Float
+  fun strtod(x0 : Char*, x1 : Char**) : Double
   fun unsetenv(x0 : Char*) : Int
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -578,31 +578,79 @@ class String
     ToU64Info.new value, negative, invalid
   end
 
-  # Returns the result of interpreting leading characters in this string as a floating point number (`Float64`).
-  # Extraneous characters past the end of a valid number are ignored. If there is not a valid number at the start of str,
-  # 0.0 is returned. This method never raises an exception.
+  # Returns the result of interpreting characters in this string as a floating point number (`Float64`).
+  # This method raises an exception if the string is not a valid float representation.
+  # If *whitespace* is `true`, the default, leading and trailing whitespace is ignored.
   #
   # ```
   # "123.45e1".to_f      # => 1234.5
   # "45.67 degrees".to_f # => 45.67
-  # "thx1138".to_f       # => 0.0
+  # "thx1138".to_f       # => ArgumentError
   # ```
-  def to_f
-    to_f64
+  def to_f(whitespace = true)
+    to_f64(whitespace: whitespace)
   end
 
-  # Returns the result of interpreting leading characters in this string as a floating point number (`Float32`).
-  # Extraneous characters past the end of a valid number are ignored. If there is not a valid number at the start of str,
-  # 0.0 is returned. This method never raises an exception.
+  # Returns the result of interpreting characters in this string as a floating point number (`Float64`).
+  # This method returns `nil` if the string is not a valid float representation.
+  # If *whitespace* is `true`, the default, leading and trailing whitespace is ignored.
+  #
+  # ```
+  # "123.45e1".to_f?      # => 1234.5
+  # "45.67 degrees".to_f? # => 45.67
+  # "thx1138".to_f?       # => nil
+  # ```
+  def to_f?(whitespace = true)
+    to_f64?(whitespace: whitespace)
+  end
+
+  # Returns the result of interpreting characters in this string as a floating point number (`Float32`).
+  # This method raises an exception if the string is not a valid float representation.
+  # If *whitespace* is `true`, the default, leading and trailing whitespace is ignored.
   #
   # See `#to_f`.
-  def to_f32
-    LibC.strtof self, nil
+  def to_f32(whitespace = true)
+    to_f32?(whitespace: whitespace) || raise ArgumentError.new("Invalid Float32: #{self}")
+  end
+
+  # Returns the result of interpreting characters in this string as a floating point number (`Float32`).
+  # This method returns `nil` if the string is not a valid float representation.
+  # If *whitespace* is `true`, the default, leading and trailing whitespace is ignored.
+  #
+  # See `#to_f`.
+  def to_f32?(whitespace = true)
+    to_f_impl(whitespace: whitespace) do
+      v = LibC.strtof self, out endptr
+      {v, endptr}
+    end
   end
 
   # Same as `#to_f`.
-  def to_f64
-    LibC.atof self
+  def to_f64(whitespace = true)
+    to_f64?(whitespace: whitespace) || raise ArgumentError.new("Invalid Float64: #{self}")
+  end
+
+  # Same as `#to_f?`.
+  def to_f64?(whitespace = true)
+    to_f_impl(whitespace: whitespace) do
+      v = LibC.strtod self, out endptr
+      {v, endptr}
+    end
+  end
+
+  private def to_f_impl(whitespace = true)
+    return unless whitespace || '0' <= self[0] <= '9' || self[0] == '-' || self[0] == '+'
+
+    v, endptr = yield
+    string_end = to_unsafe + bytesize
+
+    if whitespace
+      while endptr <= string_end && endptr.value.chr.whitespace?
+        endptr += 1
+      end
+    end
+
+    endptr >= string_end ? v : nil
   end
 
   # Returns the `Char` at the given *index*, or raises `IndexError` if out of bounds.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -321,7 +321,7 @@ class URI
     if char == '%' && i < bytesize - 2
       i += 1
       first = string.unsafe_byte_at(i)
-      first_num = first.unsafe_chr.to_i 16, or_else: nil
+      first_num = first.unsafe_chr.to_i? 16
       unless first_num
         io.write_byte byte
         return i
@@ -329,7 +329,7 @@ class URI
 
       i += 1
       second = string.unsafe_byte_at(i)
-      second_num = second.unsafe_chr.to_i 16, or_else: nil
+      second_num = second.unsafe_chr.to_i? 16
       unless second_num
         io.write_byte byte
         io.write_byte first


### PR DESCRIPTION
* Add Char#to_i\*, Char#to_i\*?, Char#to_u\* and Char#to_u\*?
* Add Char#to_f, Char#to_f?, Char#to_f\* and Char#to_f\*?
* Add String#to_f? and String#to_f\*?
* Make to_f behaviour consistent with to_i behaviour
* Remove Char#to_i with a block and second argument

The char integer and all float stuff still lacks the amount of options the string integer stuff has, but this should be a good first step and unify for the common usages.

Closes #3024