### PR TITLE
Add OptionParser#missing_option and OptionParser#invalid_option

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -183,6 +183,32 @@ describe "OptionParser" do
     end
   end
 
+  it "calls the handler for invalid options" do
+    called = false
+    OptionParser.parse(["-f", "-j"]) do |opts|
+      opts.on("-f", "some flag") { }
+      opts.invalid_option do |flag|
+        flag.should eq("-j")
+        called = true
+      end
+    end
+
+    called.should be_true
+  end
+
+  it "calls the handler for missing options" do
+    called = false
+    OptionParser.parse(["-f"]) do |opts|
+      opts.on("-f FOO", "some flag") { }
+      opts.missing_option do |flag|
+        flag.should eq("-f")
+        called = true
+      end
+    end
+
+    called.should be_true
+  end
+
   describe "multiple times" do
     it "gets an existence flag multiple times" do
       args = %w(-f -f -f)


### PR DESCRIPTION
These callbacks provide a nicer API to toplevel option parsing,
removing the need to rescue the exceptions and store the parser in a
local in order to provide the help message in these events.