### PR TITLE
Add IO#noecho and IO#noecho!

### DIFF
--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -1,6 +1,15 @@
 require "termios"
 
 module IO
+  # Turn off character echoing for the duration of the given block.
+  # This will prevent displaying back to the user what they enter on the terminal.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
+  #
+  # ```
+  # print "Enter password: "
+  # password = STDIN.noecho &.gets.try &.chomp
+  # puts
+  # ```
   def noecho
     preserving_tc_mode("can't set IO#noecho") do |mode|
       noecho_from_tc_mode!
@@ -8,6 +17,9 @@ module IO
     end
   end
 
+  # Turn off character echoing for this IO.
+  # This will prevent displaying back to the user what they enter on the terminal.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
   def noecho!
     if LibC.tcgetattr(fd, out mode) != 0
       raise Errno.new "can't set IO#noecho!"
@@ -20,6 +32,11 @@ module IO
     LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
+  # Enable character processing for the duration of the given block.
+  # The so called cooked mode is the standard behavior of a terminal,
+  # doing line wise editing by the terminal and only sending the input to
+  # the program on a newline.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
   def cooked
     preserving_tc_mode("can't set IO#cooked") do |mode|
       cooked_from_tc_mode!
@@ -27,6 +44,11 @@ module IO
     end
   end
 
+  # Enable character processing for this IO.
+  # The so called cooked mode is the standard behavior of a terminal,
+  # doing line wise editing by the terminal and only sending the input to
+  # the program on a newline.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
   def cooked!
     if LibC.tcgetattr(fd, out mode) != 0
       raise Errno.new "can't set IO#cooked!"
@@ -50,6 +72,10 @@ module IO
     LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
+  # Enable raw mode for the duration of the given block.
+  # In raw mode every keypress is directly sent to the program, no interpretation
+  # is done by the terminal.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
   def raw
     preserving_tc_mode("can't set IO#raw") do |mode|
       raw_from_tc_mode!
@@ -57,6 +83,10 @@ module IO
     end
   end
 
+  # Enable raw mode for this IO.
+  # In raw mode every keypress is directly sent to the program, no interpretation
+  # is done by the terminal.
+  # Only call this when this IO is a TTY, such as a not redirected stdin.
   def raw!
     if LibC.tcgetattr(fd, out mode) != 0
       raise Errno.new "can't set IO#raw!"


### PR DESCRIPTION
These disable printing what's entered into the terminal.

```cr
require "io/console"
print "Enter password: "
password = STDIN.noecho &.gets.try &.chomp
puts
```