### PR TITLE
Added support for negating unsigned integers

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -206,6 +206,13 @@ describe "Int" do
     assert { (~1_u32).should eq(4294967294) }
   end
 
+  describe "-" do
+    assert { (-(42_u8)).should eq(-42_i16) }
+    assert { (-(42_u16)).should eq(-42_i32) }
+    assert { (-(42_u32)).should eq(-42_i64) }
+    assert { (-(42_u64)).should eq(-42_i64) }
+  end
+
   describe ">>" do
     assert { (8000 >> 1).should eq(4000) }
     assert { (8000 >> 2).should eq(2000) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -587,6 +587,10 @@ struct UInt8
     value.to_u8
   end
 
+  def -
+    0_i16 - self
+  end
+
   def abs
     self
   end
@@ -607,6 +611,10 @@ struct UInt16
   # Returns an `UInt16` by invoking `to_u16` on *value*.
   def self.new(value)
     value.to_u16
+  end
+
+  def -
+    0_i32 - self
   end
 
   def abs
@@ -631,6 +639,10 @@ struct UInt32
     value.to_u32
   end
 
+  def -
+    0_i64 - self
+  end
+
   def abs
     self
   end
@@ -651,6 +663,10 @@ struct UInt64
   # Returns an `UInt64` by invoking `to_u64` on *value*.
   def self.new(value)
     value.to_u64
+  end
+
+  def -
+    0_i64 - self
   end
 
   def abs


### PR DESCRIPTION
This should be valid:
```
a = 42_u32
b = -a
```

But it gives a compilation error:
```
Error in line 2: wrong number of arguments for 'UInt32#-' (given 0, expected 1)
```
