### PR TITLE
Add `@[Extern]` attribute

### DIFF
--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -1,0 +1,145 @@
+require "../../spec_helper"
+
+describe "Codegen: extern struct" do
+  it "declares extern struct with no constructor" do
+    run(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(0)
+  end
+
+  it "declares extern struct with no constructor, assigns var" do
+    run(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+
+        def x=(@x)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      foo = Foo.new
+      foo.x = 10
+      foo.x
+      )).to_i.should eq(10)
+  end
+
+  it "declares extern union with no constructor" do
+    run(%(
+      @[Extern(union: true)]
+      struct Foo
+        @x = uninitialized Int32
+        @y = uninitialized Float32
+
+        def x=(@x)
+        end
+
+        def x
+          @x
+        end
+
+        def y=(@y)
+        end
+      end
+
+      foo = Foo.new
+      foo.x = 1
+      foo.y = 1.5_f32
+      foo.x
+      )).to_i.should eq(1069547520)
+  end
+
+  it "declares extern struct, sets and gets insance var" do
+    run(%(
+      @[Extern]
+      struct Foo
+        @y = uninitialized Float64
+        @x = uninitialized Int32
+
+        def foo
+          @x = 42
+          @x
+        end
+      end
+
+      Foo.new.foo
+      )).to_i.should eq(42)
+  end
+
+  it "declares extern union, sets and gets insance var" do
+    run(%(
+      @[Extern(union: true)]
+      struct Foo
+        @x = uninitialized Int32
+        @y = uninitialized Float32
+
+        def foo
+          @x = 1
+          @y = 1.5_f32
+          @x
+        end
+      end
+
+      Foo.new.foo
+      )).to_i.should eq(1069547520)
+  end
+
+  it "sets callback on extern struct" do
+    run(%(
+      require "prelude"
+
+      @[Extern]
+      struct Foo
+        @x = uninitialized -> Int32
+
+        def set
+          @x = ->{ 42 }
+        end
+
+        def get
+          @x.call
+        end
+      end
+
+      foo = Foo.new
+      foo.set
+      foo.get
+      )).to_i.should eq(42)
+  end
+
+  it "sets callback on extern union" do
+    run(%(
+      require "prelude"
+
+      @[Extern(union: true)]
+      struct Foo
+        @y = uninitialized Float64
+        @x = uninitialized -> Int32
+
+        def set
+          @x = ->{ 42 }
+        end
+
+        def get
+          @x.call
+        end
+      end
+
+      foo = Foo.new
+      foo.set
+      foo.get
+      )).to_i.should eq(42)
+  end
+end

--- a/spec/compiler/semantic/extern_spec.cr
+++ b/spec/compiler/semantic/extern_spec.cr
@@ -1,0 +1,160 @@
+require "../../spec_helper"
+
+describe "Semantic: extern struct" do
+  it "declares extern struct with no constructor" do
+    assert_type(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { int32 }
+  end
+
+  it "declares with constructor" do
+    assert_type(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+
+        def initialize(@x)
+        end
+
+        def foo
+          @x
+        end
+      end
+
+      Foo.new(1).foo
+      )) { int32 }
+  end
+
+  it "overrides getter" do
+    assert_type(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+
+        def x
+          'a'
+        end
+      end
+
+      Foo.new.x
+      )) { char }
+  end
+
+  it "can be passed to C fun" do
+    assert_type(%(
+      @[Extern]
+      struct Foo
+        @x = uninitialized Int32
+      end
+
+      lib LibFoo
+        fun foo(x : Foo) : Float64
+      end
+
+      LibFoo.foo(Foo.new)
+      )) { float64 }
+  end
+
+  it "can include module" do
+    assert_type(%(
+      module Moo
+        @x = uninitialized Int32
+
+        def x
+          @x
+        end
+      end
+
+      @[Extern]
+      struct Foo
+        include Moo
+      end
+
+      Foo.new.x
+      )) { int32 }
+  end
+
+  it "errors if using non-primitive for field type" do
+    assert_error %(
+      class Bar
+      end
+
+      @[Extern]
+      struct Foo
+        @x = uninitialized Bar
+      end
+      ),
+      "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
+  end
+
+  it "errors if using non-primitive for field type via module" do
+    assert_error %(
+      class Bar
+      end
+
+      module Moo
+        @x = uninitialized Bar
+      end
+
+      @[Extern]
+      struct Foo
+        include Moo
+      end
+      ),
+      "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
+  end
+
+  it "errors if using non-primitive type in constructor" do
+    assert_error %(
+      class Bar
+      end
+
+      @[Extern]
+      struct Foo
+        def initialize
+          @x = Bar.new
+        end
+      end
+      ),
+      "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
+  end
+
+  it "declares extern union with no constructor" do
+    assert_type(%(
+      @[Extern(union: true)]
+      struct Foo
+        @x = uninitialized Int32
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { int32 }
+  end
+
+  it "can use extern struct in lib" do
+    assert_type(%(
+      @[Extern]
+      struct Foo
+      end
+
+      lib LibFoo
+        fun foo(x : Foo) : Foo
+      end
+
+      foo = Foo.new
+      LibFoo.foo(foo)
+      )) { types["Foo"] }
+  end
+end

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -386,7 +386,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   def check_allowed_in_lib(node, type = node.type.instance_type)
     unless type.allowed_in_lib?
       msg = String.build do |msg|
-        msg << "only primitive types, pointers, structs, unions, enums and tuples are allowed in lib declarations"
+        msg << "only primitive types, pointers, structs, unions, enums and tuples are allowed in lib declarations, not #{type}"
         msg << " (did you mean LibC::Int?)" if type == @program.int
         msg << " (did you mean LibC::Float?)" if type == @program.float
       end

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -170,6 +170,10 @@ struct Crystal::TypeDeclarationProcessor
 
     remove_error owner, name
 
+    if owner.extern? && !type.allowed_in_lib?
+      raise TypeException.new("only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations, not #{type}", location.not_nil!)
+    end
+
     var = MetaTypeVar.new(name)
     var.owner = owner
     var.type = type
@@ -191,7 +195,11 @@ struct Crystal::TypeDeclarationProcessor
       raise_cant_declare_instance_var(owner, info.location)
     end
 
-    var = declare_meta_type_var(vars, owner, name, info.type.as(Type))
+    if instance_var && !owner.allows_instance_vars?
+      raise_cant_declare_instance_var(owner, info.location)
+    end
+
+    var = declare_meta_type_var(vars, owner, name, info.type.as(Type), info.location)
     var.location = info.location
 
     # Check if var is uninitialized


### PR DESCRIPTION
Fixes #2422 

This PR works but I want to discuss this a bit before merging this.

Right now `lib` structs, unions and funs are restricted to either primitive types (Int32, Float32, etc.), pointers, enums, and structs and unions inside lib types. You can't use a "regular" crystal class or struct.

With this PR one can now mark a crystal struct (defined outside a `lib` declaration) as `@[Extern]`, and then the compiler lets you use this type in the above places.

`lib` structs and unions automatically receive getters and setters for each field, and they get an empty constructor that sets the type to zero (memzero):

```cr
lib LibFoo
  struct Foo
    x : Int32
    y : Int32
  end
end

foo = LibFoo::Foo.new
p foo # => LibFoo::Foo(@x=0, @y=0)
```

In contrast, and this is what I'd like to discuss, a regular struct marked with `@[Extern]` follows crystal rules, and the compiler will complain if declaring an instance variable and not properly initializing it. However, one can use `@x = uninitialized ...` to mark that variable as "unsafe" and not needing a check from the compiler.

Alternatively, we could automatically generate getters and setters for every instance variable, but I feel this is less safe and nice. One disadvantage of not doing this is that for C struct/union getters the compiler will invoke `to_unsafe` to do numeric conversions, but without these getters one would have to do these conversions.

But, I think that this extern structs will probably be used with types that are created by `lib` functions, and you rarely need to set their instance variables, but instead you query them (or maybe you use them but don't let users query them). And in any case you can define setters and do a manual conversion there, if needed.

One can also mark a struct with `@[Extern(union: true)]`, and now the struct will behave as a C union. For example:

```cr
@[Extern(union: true)]
struct Int64OrFloat64
  @int = uninitialized Int64
  @float = uninitialized Float64

  property int
  property float
end

x = Int64OrFloat64.new
x.int = 10_i64
p x # => Int64OrFloat64(@int=10, @float=4.9406564584124654e-323)
```

With this new `@[Extern]` attribute writing C bindings that have lots of structs and unions is greatly simplified, as one doesn't need to wrap these in a Crystal struct. There is also no need to define a `to_unsafe` because the type is already the type that's passed directly to C. I checked if this could be applied to, for example, the LLVM bindings and yes, and many `LLVM:Value.new(LibLLVM.get_some_value)` are replaced with just `LibLLVM.get_some_value`. But in this case the gain is very little. I think libraries such as SDL or SFML will benefit more from this because they expose structs that can be accessed directly, not only via an opaque pointer.

One missing thing mentioned in #2422 is that, in order to keep binary compatibility with the C library, one shouldn't be able to add more instance variables to such structs. We could trust the user not to do so, or simply allow instance variable declarations on the first definition of the type, disallowing adding more instance variables later. For now we can start with the first option and eventually implement the second for a more robust solution.

Thoughts?