### PR TITLE
Fixes for documentation generator

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -257,12 +257,15 @@ h1.type-name {
   color: #6C518B;
 }
 
-.methods-inherited .tooltip span {
+.methods-inherited .tooltip>span {
   background: #D5CAE3;
-  color: #47266E;
   padding: 4px 8px;
   border-radius: 3px;
   margin: -4px -8px;
+}
+
+.methods-inherited .tooltip * {
+    color: #47266E;
 }
 
 pre {
@@ -280,14 +283,14 @@ code {
   font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
 }
 
-.tooltip span {
+.tooltip>span {
   position: absolute;
   opacity: 0;
   display: none;
   pointer-events: none;
 }
 
-.tooltip:hover span {
+.tooltip:hover>span {
   display: inline-block;
   opacity: 1;
 }

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -29,7 +29,7 @@ class Crystal::Doc::Macro
 
   def id
     String.build do |io|
-      io << to_s.gsub(' ', "")
+      io << to_s.gsub(/<.+?>/, "").gsub(' ', "")
       io << "-macro"
     end
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -55,7 +55,7 @@ class Crystal::Doc::Method
 
   def id
     String.build do |io|
-      io << to_s.gsub(' ', "")
+      io << to_s.gsub(/<.+?>/, "").gsub(' ', "")
       if @class_method
         io << "-class-method"
       else


### PR DESCRIPTION
Before/after:

![Before/after](https://cloud.githubusercontent.com/assets/371383/17278090/92310ef6-575c-11e6-9a5f-d96c6f5c26d1.gif)
