### PR TITLE
Add HTTP::Request#host and HTTP::Request#host_with_port for convenience

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -275,6 +275,16 @@ module HTTP
         request.query = new_query
         request.query_params.to_s.should eq(new_query)
       end
+
+      it "gets request host from the headers" do
+        request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
+        request.host.should eq("host.example.org")
+      end
+
+      it "gets request host with port from the headers" do
+        request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
+        request.host_with_port.should eq("host.example.org:3000")
+      end
     end
   end
 end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -98,6 +98,19 @@ class HTTP::Request
     value
   end
 
+  # Return request host from headers
+  def host
+    host = @headers["Host"]?
+    return unless host
+    index = host.index(":")
+    index ? host[0...index] : host
+  end
+
+  # Return request host with port from headers
+  def host_with_port
+    @headers["Host"]?
+  end
+
   private def uri
     (@uri ||= URI.parse(@resource)).not_nil!
   end


### PR DESCRIPTION
Today i needed to access the `host` of the incoming `HTTP::Request` and couldn't find a convenient way to do so in Crystal.

I used  [rack](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L225-L236) for the implementation.
