### PR TITLE
Add Indexable

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -126,4 +126,47 @@ describe "BitArray" do
       e.should eq({1, 3, 5, 7, 8, 10, 12, 14, 40, 42}.includes?(i))
     end
   end
+
+  it "provides an iterator" do
+    ary = BitArray.new(2)
+    ary[0] = true
+    ary[1] = false
+
+    iter = ary.each
+    iter.next.should be_true
+    iter.next.should be_false
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should be_true
+
+    iter.rewind
+    iter.cycle.first(3).to_a.should eq([true, false, true])
+  end
+
+  it "provides an index iterator" do
+    ary = BitArray.new(2)
+
+    iter = ary.each_index
+    iter.next.should eq(0)
+    iter.next.should eq(1)
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq(0)
+  end
+
+  it "provides a reverse iterator" do
+    ary = BitArray.new(2)
+    ary[0] = true
+    ary[1] = false
+
+    iter = ary.reverse_each
+    iter.next.should be_false
+    iter.next.should be_true
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should be_false
+  end
 end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -601,6 +601,20 @@ describe "Deque" do
     end
   end
 
+  describe "reverse each iterator" do
+    it "does next" do
+      a = Deque{1, 2, 3}
+      iter = a.reverse_each
+      iter.next.should eq(3)
+      iter.next.should eq(2)
+      iter.next.should eq(1)
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(3)
+    end
+  end
+
   describe "cycle" do
     it "cycles" do
       a = [] of Int32

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -266,6 +266,9 @@ describe "Slice" do
 
     iter.rewind
     iter.next.should eq(1)
+
+    iter.rewind
+    iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
   end
 
   it "does reverse iterator" do
@@ -278,6 +281,17 @@ describe "Slice" do
 
     iter.rewind
     iter.next.should eq(3)
+  end
+
+  it "does index iterator" do
+    slice = Slice(Int32).new(2) { |i| i + 1 }
+    iter = slice.each_index
+    iter.next.should eq(0)
+    iter.next.should eq(1)
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq(0)
   end
 
   it "does to_a" do
@@ -324,6 +338,19 @@ describe "Slice" do
     slices = itself(Slice[1, 2], Slice[3])
     slices[0].to_a.should eq([1, 2])
     slices[1].to_a.should eq([3])
+  end
+
+  it "reverses" do
+    slice = Bytes[1, 2, 3]
+    slice.reverse!
+    slice.to_a.should eq([3, 2, 1])
+  end
+
+  it "shuffles" do
+    a = Bytes[1, 2, 3]
+    a.shuffle!
+    b = [1, 2, 3]
+    3.times { a.includes?(b.shift).should be_true }
   end
 end
 

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -131,4 +131,34 @@ describe "StaticArray" do
     b[0].should eq(a[0])
     b[0].should_not be(a[0])
   end
+
+  it "iterates with each" do
+    a = StaticArray(Int32, 3).new { |i| i + 1 }
+    iter = a.each
+    iter.next.should eq(1)
+    iter.next.should eq(2)
+    iter.next.should eq(3)
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq(1)
+
+    iter.rewind
+    iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
+  end
+
+  it "iterates with reverse each" do
+    a = StaticArray(Int32, 3).new { |i| i + 1 }
+    iter = a.reverse_each
+    iter.next.should eq(3)
+    iter.next.should eq(2)
+    iter.next.should eq(1)
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq(3)
+
+    iter.rewind
+    iter.cycle.first(5).to_a.should eq([3, 2, 1, 3, 2])
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -45,7 +45,7 @@
 # ```
 class Array(T)
   include Enumerable(T)
-  include Iterable
+  include Indexable(T)
   include Comparable(Array)
 
   # Returns the number of elements in the array.
@@ -304,46 +304,6 @@ class Array(T)
     push(value)
   end
 
-  # Returns the element at the given index.
-  #
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to access an element outside the array's range.
-  #
-  # ```
-  # ary = ['a', 'b', 'c']
-  # ary[0]  # => 'a'
-  # ary[2]  # => 'c'
-  # ary[-1] # => 'c'
-  # ary[-2] # => 'b'
-  #
-  # ary[3]  # raises IndexError
-  # ary[-4] # raises IndexError
-  # ```
-  @[AlwaysInline]
-  def [](index : Int)
-    at(index)
-  end
-
-  # Returns the element at the given index.
-  #
-  # Negative indices can be used to start counting from the end of the array.
-  # Returns `nil` if trying to access an element outside the array's range.
-  #
-  # ```
-  # ary = ['a', 'b', 'c']
-  # ary[0]?  # => 'a'
-  # ary[2]?  # => 'c'
-  # ary[-1]? # => 'c'
-  # ary[-2]? # => 'b'
-  #
-  # ary[3]?  # nil
-  # ary[-4]? # nil
-  # ```
-  @[AlwaysInline]
-  def []?(index : Int)
-    at(index) { nil }
-  end
-
   # Sets the given value at the given index.
   #
   # Negative indices can be used to start counting from the end of the array.
@@ -536,82 +496,10 @@ class Array(T)
     end
   end
 
-  # Returns the element at the given index, if in bounds,
-  # otherwise raises `IndexError`.
-  #
-  # ```
-  # a = [:foo, :bar]
-  # a.at(0) # => :foo
-  # a.at(2) # => IndexError
-  # ```
+  # :nodoc:
   @[AlwaysInline]
-  def at(index : Int)
-    at(index) { raise IndexError.new }
-  end
-
-  # Returns the element at the given index, if in bounds,
-  # otherwise executes the given block and returns its value.
-  #
-  # ```
-  # a = [:foo, :bar]
-  # a.at(0) { :baz } # => :foo
-  # a.at(2) { :baz } # => :baz
-  # ```
-  def at(index : Int)
-    index += size if index < 0
-    if 0 <= index < size
-      @buffer[index]
-    else
-      yield
-    end
-  end
-
-  # Returns a tuple populated with the elements at the given indexes.
-  # Raises `IndexError` if any index is invalid.
-  #
-  # ```
-  # ["a", "b", "c", "d"].values_at(0, 2) # => {"a", "c"}
-  # ```
-  def values_at(*indexes : Int)
-    indexes.map { |index| self[index] }
-  end
-
-  # By using binary search, returns the first element
-  # for which the passed block returns `true`.
-  #
-  # If the block returns `false`, the finding element exists
-  # behind. If the block returns `true`, the finding element
-  # is itself or exists infront.
-  #
-  # Binary search needs sorted array, so self has to be sorted.
-  #
-  # Returns `nil` if the block didn't return `true` for any element.
-  #
-  # ```
-  # [2, 5, 7, 10].bsearch { |x| x >= 4 } # => 5
-  # [2, 5, 7, 10].bsearch { |x| x > 10 } # => nil
-  # ```
-  def bsearch
-    bsearch_index { |value| yield value }.try { |index| self[index] }
-  end
-
-  # By using binary search, returns the index of the first element
-  # for which the passed block returns `true`.
-  #
-  # If the block returns `false`, the finding element exists
-  # behind. If the block returns `true`, the finding element
-  # is itself or exists infront.
-  #
-  # Binary search needs sorted array, so self has to be sorted.
-  #
-  # Returns `nil` if the block didn't return `true` for any element.
-  #
-  # ```
-  # [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 } # => 1
-  # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
-  # ```
-  def bsearch_index
-    (0...size).bsearch { |index| yield self[index], index }
+  def unsafe_at(index : Int)
+    @buffer[index]
   end
 
   # Removes all elements from self.
@@ -796,108 +684,6 @@ class Array(T)
     end
   end
 
-  # Calls the given block once for each element in `self`, passing that
-  # element as a parameter.
-  #
-  # ```
-  # a = ["a", "b", "c"]
-  # a.each { |x| print x, " -- " }
-  # ```
-  #
-  # produces:
-  #
-  # ```text
-  # a -- b -- c --
-  # ```
-  def each
-    each_index do |i|
-      yield @buffer[i]
-    end
-  end
-
-  # Returns an `Iterator` for the elements of `self`.
-  #
-  # ```
-  # a = ["a", "b", "c"]
-  # iter = a.each
-  # iter.next # => "a"
-  # iter.next # => "b"
-  # ```
-  #
-  # The returned iterator keeps a reference to `self`: if the array
-  # changes, the returned values of the iterator change as well.
-  def each
-    ItemIterator.new(self)
-  end
-
-  # Calls the given block once for each index in `self`, passing that
-  # index as a parameter.
-  #
-  # ```
-  # a = ["a", "b", "c"]
-  # a.each_index { |x| print x, " -- " }
-  # ```
-  #
-  # produces:
-  #
-  # ```text
-  # 0 -- 1 -- 2 --
-  # ```
-  def each_index
-    i = 0
-    while i < size
-      yield i
-      i += 1
-    end
-    self
-  end
-
-  # Returns an `Iterator` for each index in `self`.
-  #
-  # ```
-  # a = ["a", "b", "c"]
-  # iter = a.each_index
-  # iter.next # => 0
-  # iter.next # => 1
-  # ```
-  #
-  # The returned iterator keeps a reference to `self`. If the array
-  # changes, the returned values of the iterator will change as well.
-  def each_index
-    IndexIterator.new(self)
-  end
-
-  # Returns *true* if `self` is empty, *false* otherwise.
-  #
-  # ```
-  # ([] of Int32).empty? # => true
-  # ([1]).empty?         # => false
-  # ```
-  def empty?
-    @size == 0
-  end
-
-  # Determines if `self` equals *other* according to a comparison
-  # done by the given block.
-  #
-  # If `self`'s size is the same as *other*'s size, this method yields
-  # elements from `self` and *other* in tandem: if the block returns true
-  # for all of them, this method returns *true*. Otherwise it returns *false*.
-  #
-  # ```
-  # a = [1, 2, 3]
-  # b = ["a", "ab", "abc"]
-  # a.equals?(b) { |x, y| x == y.size } # => true
-  # a.equals?(b) { |x, y| x == y }      # => false
-  # ```
-  def equals?(other : Array)
-    return false if @size != other.size
-    each_with_index do |item, i|
-      return false unless yield(item, other[i])
-    end
-    true
-  end
-
   # Yields each index of `self` to the given block and then assigns
   # the block's value in that position. Returns `self`.
   #
@@ -1014,26 +800,6 @@ class Array(T)
     fill(range) { value }
   end
 
-  # Returns the first element of `self` if it's not empty, or raises `IndexError`.
-  #
-  # ```
-  # ([1, 2, 3]).first   # => 1
-  # ([] of Int32).first # => raises IndexError
-  # ```
-  def first
-    first { raise IndexError.new }
-  end
-
-  # Returns the first element of `self` if it's not empty, or the given block's value.
-  #
-  # ```
-  # ([1, 2, 3]).first { 4 }   # => 1
-  # ([] of Int32).first { 4 } # => 4
-  # ```
-  def first
-    @size == 0 ? yield : @buffer[0]
-  end
-
   # Returns the first `n` elements of the array.
   #
   # ```
@@ -1042,25 +808,6 @@ class Array(T)
   # ```
   def first(n : Int)
     self[0, n]
-  end
-
-  # Returns the first element of `self` if it's not empty, or `nil`.
-  #
-  # ```
-  # ([1, 2, 3]).first?   # => 1
-  # ([] of Int32).first? # => nil
-  # ```
-  def first?
-    first { nil }
-  end
-
-  # Returns a hash code based on `self`'s size and elements.
-  #
-  # See `Object#hash`.
-  def hash
-    reduce(31 * @size) do |memo, elem|
-      31 * memo + elem.hash
-    end
   end
 
   # Insert *object* before the element at *index* and shifting successive elements, if any.
@@ -1096,26 +843,6 @@ class Array(T)
     to_s io
   end
 
-  # Returns the last element of `self` if it's not empty, or raises `IndexError`.
-  #
-  # ```
-  # ([1, 2, 3]).last   # => 3
-  # ([] of Int32).last # => raises IndexError
-  # ```
-  def last
-    last { raise IndexError.new }
-  end
-
-  # Returns the last element of `self` if it's not empty, or the given block's value.
-  #
-  # ```
-  # ([1, 2, 3]).last { 4 }   # => 3
-  # ([] of Int32).last { 4 } # => 4
-  # ```
-  def last
-    @size == 0 ? yield : @buffer[@size - 1]
-  end
-
   # Returns the last `n` elements of the array.
   #
   # ```
@@ -1128,16 +855,6 @@ class Array(T)
     else
       dup
     end
-  end
-
-  # Returns the last element of `self` if it's not empty, or `nil`.
-  #
-  # ```
-  # ([1, 2, 3]).last?   # => 1
-  # ([] of Int32).last? # => nil
-  # ```
-  def last?
-    last { nil }
   end
 
   # :nodoc:
@@ -1581,51 +1298,8 @@ class Array(T)
 
   # Reverses in-place all the elements of `self`.
   def reverse!
-    i = 0
-    j = size - 1
-    while i < j
-      @buffer.swap i, j
-      i += 1
-      j -= 1
-    end
+    Slice.new(@buffer, size).reverse!
     self
-  end
-
-  # Calls the given block once for each element in `self` in reverse order,
-  # passing that element as a parameter.
-  #
-  # ```
-  # a = ["a", "b", "c"]
-  # a.reverse_each { |x| print x, " -- " }
-  # ```
-  #
-  # produces:
-  #
-  # ```text
-  # c -- b -- a --
-  # ```
-  def reverse_each
-    (size - 1).downto(0) do |i|
-      yield @buffer[i]
-    end
-    self
-  end
-
-  def reverse_each
-    ReverseIterator.new(self)
-  end
-
-  def rindex(value)
-    rindex { |elem| elem == value }
-  end
-
-  def rindex
-    (size - 1).downto(0) do |i|
-      if yield @buffer[i]
-        return i
-      end
-    end
-    nil
   end
 
   def rotate!(n = 1)
@@ -1657,20 +1331,6 @@ class Array(T)
     res
   end
 
-  # Returns a random element from `self`, using the given *random* number generator.
-  # Raises IndexError if `self` is empty.
-  #
-  # ```
-  # a = [1, 2, 3]
-  # a.sample                # => 2
-  # a.sample                # => 1
-  # a.sample(Random.new(1)) # => 3
-  # ```
-  def sample(random = Random::DEFAULT)
-    raise IndexError.new if @size == 0
-    @buffer[random.rand(@size)]
-  end
-
   # Returns *n* number of random elements from `self`, using the given *random* number generator.
   # Raises IndexError if `self` is empty.
   #
@@ -1690,14 +1350,14 @@ class Array(T)
     when 1
       return [sample] of T
     else
-      if n >= @size
+      if n >= size
         return dup.shuffle!
       end
 
       ary = Array(T).new(n) { |i| @buffer[i] }
       buffer = ary.to_unsafe
 
-      n.upto(@size - 1) do |i|
+      n.upto(size - 1) do |i|
         j = random.rand(i + 1)
         if j <= n
           buffer[j] = @buffer[i]
@@ -2086,14 +1746,6 @@ class Array(T)
     quicksort!(l, (a + n) - l) unless l == a
   end
 
-  private def check_index_out_of_bounds(index)
-    index += size if index < 0
-    unless 0 <= index < size
-      raise IndexError.new
-    end
-    index
-  end
-
   protected def to_lookup_hash
     to_lookup_hash { |elem| elem }
   end
@@ -2119,76 +1771,6 @@ class Array(T)
     size = 0 if size < 0
 
     {from, size}
-  end
-
-  # :nodoc:
-  class ItemIterator(T)
-    include Iterator(T)
-
-    @array : Array(T)
-    @index : Int32
-
-    def initialize(@array : Array(T), @index = 0)
-    end
-
-    def next
-      value = @array.at(@index) { stop }
-      @index += 1
-      value
-    end
-
-    def rewind
-      @index = 0
-      self
-    end
-  end
-
-  # :nodoc:
-  class IndexIterator(T)
-    include Iterator(Int32)
-
-    @array : Array(T)
-    @index : Int32
-
-    def initialize(@array : Array(T), @index = 0)
-    end
-
-    def next
-      return stop if @index >= @array.size
-
-      value = @index
-      @index += 1
-      value
-    end
-
-    def rewind
-      @index = 0
-      self
-    end
-  end
-
-  # :nodoc:
-  class ReverseIterator(T)
-    include Iterator(T)
-
-    @array : Array(T)
-    @index : Int32
-
-    def initialize(@array : Array(T), @index = array.size - 1)
-    end
-
-    def next
-      return stop if @index < 0
-
-      value = @array.at(@index) { stop }
-      @index -= 1
-      value
-    end
-
-    def rewind
-      @index = @array.size - 1
-      self
-    end
   end
 
   # :nodoc:

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -16,6 +16,7 @@
 #     ba[2]                 # => true
 struct BitArray
   include Enumerable(Bool)
+  include Indexable(Bool)
 
   # The number of bits the BitArray stores
   getter size : Int32
@@ -29,14 +30,9 @@ struct BitArray
     @bits = Pointer(UInt32).malloc(malloc_size, value)
   end
 
-  # Returns the bit at the given index.
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to access a bit outside the array's range.
-  #
-  #     ba = BitArray.new(5)
-  #     ba[3] # => false
-  def [](index)
-    bit_index, sub_index = bit_index_and_sub_index(index)
+  # :nodoc:
+  def unsafe_at(index : Int)
+    bit_index, sub_index = index.divmod(32)
     (@bits[bit_index] & (1 << sub_index)) > 0
   end
 
@@ -83,20 +79,6 @@ struct BitArray
     end
   end
 
-  # Calls the given block once for each element in self, passing that element as a parameter.
-  #
-  #     ba = BitArray.new(5)
-  #     ba[2] = true; ba[3] = true
-  #     ba # => BitArray[00110]
-  #     ba.each do |i|
-  #         print i, ", "
-  #     end # => false, false, true, true, false
-  def each
-    @size.times do |i|
-      yield self[i]
-    end
-  end
-
   # Creates a string representation of self.
   #
   #     ba = BitArray.new(5)
@@ -122,9 +104,13 @@ struct BitArray
   end
 
   private def bit_index_and_sub_index(index)
-    index += @size if index < 0
-    raise IndexError.new if index >= @size || index < 0
+    bit_index_and_sub_index(index) { raise IndexError.new }
+  end
 
+  private def bit_index_and_sub_index(index)
+    index = check_index_out_of_bounds(index) do
+      return yield
+    end
     index.divmod(32)
   end
 

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -11,7 +11,7 @@
 # [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer).
 class Deque(T)
   include Enumerable(T)
-  include Iterable
+  include Indexable(T)
   include Comparable(Deque)
 
   # This Deque is based on a circular buffer. It works like a normal array, but when an item is removed from the left
@@ -137,22 +137,6 @@ class Deque(T)
     push(value)
   end
 
-  # Returns the element at the given `index`.
-  #
-  # Negative indices can be used to start counting from the end of the deque.
-  # Raises `IndexError` if trying to access an element outside the deque's range.
-  def [](index : Int)
-    at(index)
-  end
-
-  # Returns the element at the given index.
-  #
-  # Negative indices can be used to start counting from the end of the deque.
-  # Returns `nil` if trying to access an element outside the deque's range.
-  def []?(index : Int)
-    at(index) { nil }
-  end
-
   # Sets the given value at the given index.
   #
   # Raises `IndexError` if the deque had no previous value at the given index.
@@ -166,21 +150,11 @@ class Deque(T)
     @buffer[index] = value
   end
 
-  # Returns the element at the given index, if in bounds, otherwise raises `IndexError`.
-  def at(index : Int)
-    at(index) { raise IndexError.new }
-  end
-
-  # Returns the element at the given index, if in bounds, otherwise executes the given block and returns its value.
-  def at(index : Int)
-    index += @size if index < 0
-    unless 0 <= index < @size
-      yield
-    else
-      index += @start
-      index -= @capacity if index >= @capacity
-      @buffer[index]
-    end
+  # :nodoc:
+  def unsafe_at(index : Int)
+    index += @start
+    index -= @capacity if index >= @capacity
+    @buffer[index]
   end
 
   # Removes all elements from self.
@@ -302,60 +276,6 @@ class Deque(T)
     end
   end
 
-  # Gives an iterator over each item in this deque, from first to last.
-  def each
-    ItemIterator.new(self)
-  end
-
-  # Yields indices of each item in this deque, from first (`0`) to last (`size - 1`).
-  def each_index
-    (0...@size).each do |i|
-      yield i
-    end
-    self
-  end
-
-  # Gives an iterator over the indices of each item in this deque, from first (`0`) to last (`size - 1`).
-  def each_index
-    IndexIterator.new(self)
-  end
-
-  # Returns true if this deque has 0 items.
-  def empty?
-    @size == 0
-  end
-
-  # Zips two deques and gives each pair to the passed block. Returns `true` if the block returns `true` every time.
-  def equals?(other : Deque)
-    return false if @size != other.size
-    each_with_index do |x, i|
-      return false unless yield(x, other[i])
-    end
-    true
-  end
-
-  # Returns the leftmost item in the deque (index `0`). Raises `IndexError` if empty.
-  def first
-    first { raise IndexError.new }
-  end
-
-  # Returns the leftmost item in the deque (index `0`), if not empty, otherwise executes the given block and returns its
-  # value.
-  def first
-    @size == 0 ? yield : @buffer[@start]
-  end
-
-  # Returns the leftmost item in the deque (index `0`), if not empty, otherwise `nil`.
-  def first?
-    first { nil }
-  end
-
-  def hash
-    reduce(31 * @size) do |memo, elem|
-      31 * memo + elem.hash
-    end
-  end
-
   # Insert a new item before the item at `index`. Items to the right of this one will have their indices incremented.
   #
   # ```
@@ -419,22 +339,6 @@ class Deque(T)
     io << "Deque{...}" unless executed
   end
 
-  # Returns the rightmost item in the deque (index `size - 1`). Raises `IndexError` if empty.
-  def last
-    last { raise IndexError.new }
-  end
-
-  # Returns the rightmost item in the deque (index `size - 1`), if not empty, otherwise executes the given block and
-  # returns its value.
-  def last
-    @size == 0 ? yield : self[@size - 1]
-  end
-
-  # Returns the rightmost item in the deque (index `size - 1`), if not empty, otherwise `nil`.
-  def last?
-    last { nil }
-  end
-
   # Returns the number of elements in the deque.
   #
   # ```
@@ -496,16 +400,6 @@ class Deque(T)
     index -= @capacity if index >= @capacity
     @buffer[index] = value
     @size += 1
-    self
-  end
-
-  # Yields each item in this deque, from last to first.
-  #
-  # Do not modify the deque while using `reverse_each`!
-  def reverse_each
-    (size - 1).downto(0) do |i|
-      yield self[i]
-    end
     self
   end
 
@@ -654,52 +548,6 @@ class Deque(T)
         (@buffer + @start).clear(to_move)
         @start = new_start
       end
-    end
-  end
-
-  # :nodoc:
-  class ItemIterator(T)
-    include Iterator(T)
-
-    @deque : Deque(T)
-    @index : Int32
-
-    def initialize(@deque : Deque(T), @index = 0)
-    end
-
-    def next
-      value = @deque.at(@index) { stop }
-      @index += 1
-      value
-    end
-
-    def rewind
-      @index = 0
-      self
-    end
-  end
-
-  # :nodoc:
-  class IndexIterator(T)
-    include Iterator(Int32)
-
-    @deque : Deque(T)
-    @index : Int32
-
-    def initialize(@deque : Deque(T), @index = 0)
-    end
-
-    def next
-      return stop if @index >= @deque.size
-
-      value = @index
-      @index += 1
-      value
-    end
-
-    def rewind
-      @index = 0
-      self
     end
   end
 end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -1,0 +1,435 @@
+# A container that allows accessing elements via a numeric index.
+#
+# Indexing starts at 0. A negative index is assumed to be
+# relative to the end of the container: -1 indicates the last element,
+# -2 is the next to last element, and so on.
+#
+# Types including this module are typically `Array`-like types.
+module Indexable(T)
+  include Iterable
+
+  # TODO: the compiler doesn't realize that if X includes Indexable then X is Enumerable
+  # This is fixed in 0.19.0
+  # include Enumerable(T)
+
+  # Returns the number of elements in this container
+  abstract def size
+
+  # Returns the element at the given *index*, without doing any bounds check.
+  #
+  # `Indexable` makes sure to invoke this method with *index* in `0...size`,
+  # so converting negative indices to positive ones is not needed here.
+  #
+  # Clients never invoke this method directly. Instead, they access
+  # elements with `#[](index)` and `#[]?(index)`.
+  protected abstract def unsafe_at(index : Int)
+
+  # Returns the element at the given index, if in bounds,
+  # otherwise executes the given block and returns its value.
+  #
+  # ```
+  # a = [:foo, :bar]
+  # a.at(0) { :baz } # => :foo
+  # a.at(2) { :baz } # => :baz
+  # ```
+  def at(index : Int)
+    index = check_index_out_of_bounds(index) do
+      return yield
+    end
+    unsafe_at(index)
+  end
+
+  # Returns the element at the given index, if in bounds,
+  # otherwise raises `IndexError`.
+  #
+  # ```
+  # a = [:foo, :bar]
+  # a.at(0) # => :foo
+  # a.at(2) # => IndexError
+  # ```
+  @[AlwaysInline]
+  def at(index : Int)
+    at(index) { raise IndexError.new }
+  end
+
+  # Returns the element at the given index.
+  #
+  # Negative indices can be used to start counting from the end of the array.
+  # Raises `IndexError` if trying to access an element outside the array's range.
+  #
+  # ```
+  # ary = ['a', 'b', 'c']
+  # ary[0]  # => 'a'
+  # ary[2]  # => 'c'
+  # ary[-1] # => 'c'
+  # ary[-2] # => 'b'
+  #
+  # ary[3]  # raises IndexError
+  # ary[-4] # raises IndexError
+  # ```
+  @[AlwaysInline]
+  def [](index : Int)
+    at(index)
+  end
+
+  # Returns the element at the given index.
+  #
+  # Negative indices can be used to start counting from the end of the array.
+  # Returns `nil` if trying to access an element outside the array's range.
+  #
+  # ```
+  # ary = ['a', 'b', 'c']
+  # ary[0]?  # => 'a'
+  # ary[2]?  # => 'c'
+  # ary[-1]? # => 'c'
+  # ary[-2]? # => 'b'
+  #
+  # ary[3]?  # nil
+  # ary[-4]? # nil
+  # ```
+  @[AlwaysInline]
+  def []?(index : Int)
+    at(index) { nil }
+  end
+
+  # By using binary search, returns the first element
+  # for which the passed block returns `true`.
+  #
+  # If the block returns `false`, the finding element exists
+  # behind. If the block returns `true`, the finding element
+  # is itself or exists infront.
+  #
+  # Binary search needs sorted array, so self has to be sorted.
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
+  #
+  # ```
+  # [2, 5, 7, 10].bsearch { |x| x >= 4 } # => 5
+  # [2, 5, 7, 10].bsearch { |x| x > 10 } # => nil
+  # ```
+  def bsearch
+    bsearch_index { |value| yield value }.try { |index| unsafe_at(index) }
+  end
+
+  # By using binary search, returns the index of the first element
+  # for which the passed block returns `true`.
+  #
+  # If the block returns `false`, the finding element exists
+  # behind. If the block returns `true`, the finding element
+  # is itself or exists infront.
+  #
+  # Binary search needs sorted array, so self has to be sorted.
+  #
+  # Returns `nil` if the block didn't return `true` for any element.
+  #
+  # ```
+  # [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 } # => 1
+  # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
+  # ```
+  def bsearch_index
+    (0...size).bsearch { |index| yield unsafe_at(index), index }
+  end
+
+  # Calls the given block once for each element in `self`, passing that
+  # element as a parameter.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # a.each { |x| print x, " -- " }
+  # ```
+  #
+  # produces:
+  #
+  # ```text
+  # a -- b -- c --
+  # ```
+  def each
+    each_index do |i|
+      yield unsafe_at(i)
+    end
+  end
+
+  # Returns an `Iterator` for the elements of `self`.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # iter = a.each
+  # iter.next # => "a"
+  # iter.next # => "b"
+  # ```
+  #
+  # The returned iterator keeps a reference to `self`: if the array
+  # changes, the returned values of the iterator change as well.
+  def each
+    ItemIterator(self, T).new(self)
+  end
+
+  # Calls the given block once for each index in `self`, passing that
+  # index as a parameter.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # a.each_index { |x| print x, " -- " }
+  # ```
+  #
+  # produces:
+  #
+  # ```text
+  # 0 -- 1 -- 2 --
+  # ```
+  def each_index
+    i = 0
+    while i < size
+      yield i
+      i += 1
+    end
+    self
+  end
+
+  # Returns an `Iterator` for each index in `self`.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # iter = a.each_index
+  # iter.next # => 0
+  # iter.next # => 1
+  # ```
+  #
+  # The returned iterator keeps a reference to `self`. If the array
+  # changes, the returned values of the iterator will change as well.
+  def each_index
+    IndexIterator.new(self)
+  end
+
+  # Returns *true* if `self` is empty, *false* otherwise.
+  #
+  # ```
+  # ([] of Int32).empty? # => true
+  # ([1]).empty?         # => false
+  # ```
+  def empty?
+    size == 0
+  end
+
+  # Determines if `self` equals *other* according to a comparison
+  # done by the given block.
+  #
+  # If `self`'s size is the same as *other*'s size, this method yields
+  # elements from `self` and *other* in tandem: if the block returns true
+  # for all of them, this method returns *true*. Otherwise it returns *false*.
+  #
+  # ```
+  # a = [1, 2, 3]
+  # b = ["a", "ab", "abc"]
+  # a.equals?(b) { |x, y| x == y.size } # => true
+  # a.equals?(b) { |x, y| x == y }      # => false
+  # ```
+  def equals?(other)
+    return false if size != other.size
+    each_with_index do |item, i|
+      return false unless yield(item, other[i])
+    end
+    true
+  end
+
+  # Returns the first element of `self` if it's not empty, or raises `IndexError`.
+  #
+  # ```
+  # ([1, 2, 3]).first   # => 1
+  # ([] of Int32).first # => raises IndexError
+  # ```
+  def first
+    first { raise IndexError.new }
+  end
+
+  # Returns the first element of `self` if it's not empty, or the given block's value.
+  #
+  # ```
+  # ([1, 2, 3]).first { 4 }   # => 1
+  # ([] of Int32).first { 4 } # => 4
+  # ```
+  def first
+    size == 0 ? yield : unsafe_at(0)
+  end
+
+  # Returns the first element of `self` if it's not empty, or `nil`.
+  #
+  # ```
+  # ([1, 2, 3]).first?   # => 1
+  # ([] of Int32).first? # => nil
+  # ```
+  def first?
+    first { nil }
+  end
+
+  # Returns a hash code based on `self`'s size and elements.
+  #
+  # See `Object#hash`.
+  def hash
+    reduce(31 * size) do |memo, elem|
+      31 * memo + elem.hash
+    end
+  end
+
+  # Returns the last element of `self` if it's not empty, or raises `IndexError`.
+  #
+  # ```
+  # ([1, 2, 3]).last   # => 3
+  # ([] of Int32).last # => raises IndexError
+  # ```
+  def last
+    last { raise IndexError.new }
+  end
+
+  # Returns the last element of `self` if it's not empty, or the given block's value.
+  #
+  # ```
+  # ([1, 2, 3]).last { 4 }   # => 3
+  # ([] of Int32).last { 4 } # => 4
+  # ```
+  def last
+    size == 0 ? yield : unsafe_at(size - 1)
+  end
+
+  # Returns the last element of `self` if it's not empty, or `nil`.
+  #
+  # ```
+  # ([1, 2, 3]).last?   # => 1
+  # ([] of Int32).last? # => nil
+  # ```
+  def last?
+    last { nil }
+  end
+
+  # Same as `#each`, but works in reverse.
+  def reverse_each(&block)
+    (size - 1).downto(0) do |i|
+      yield unsafe_at(i)
+    end
+    self
+  end
+
+  # Returns an `Iterator` over the elements of `self` in reverse order.
+  def reverse_each
+    ReverseItemIterator(self, T).new(self)
+  end
+
+  def rindex(value)
+    rindex { |elem| elem == value }
+  end
+
+  def rindex
+    (size - 1).downto(0) do |i|
+      if yield unsafe_at(i)
+        return i
+      end
+    end
+    nil
+  end
+
+  # Returns a random element from `self`, using the given *random* number generator.
+  # Raises IndexError if `self` is empty.
+  #
+  # ```
+  # a = [1, 2, 3]
+  # a.sample                # => 2
+  # a.sample                # => 1
+  # a.sample(Random.new(1)) # => 3
+  # ```
+  def sample(random = Random::DEFAULT)
+    raise IndexError.new if size == 0
+    unsafe_at(random.rand(size))
+  end
+
+  # Returns a tuple populated with the elements at the given indexes.
+  # Raises `IndexError` if any index is invalid.
+  #
+  # ```
+  # ["a", "b", "c", "d"].values_at(0, 2) # => {"a", "c"}
+  # ```
+  def values_at(*indexes : Int)
+    indexes.map { |index| self[index] }
+  end
+
+  private def check_index_out_of_bounds(index)
+    check_index_out_of_bounds(index) { raise IndexError.new }
+  end
+
+  private def check_index_out_of_bounds(index)
+    index += size if index < 0
+    if 0 <= index < size
+      index
+    else
+      yield
+    end
+  end
+
+  # :nodoc:
+  class ItemIterator(A, T)
+    include Iterator(T)
+
+    def initialize(@array : A, @index = 0)
+    end
+
+    def next
+      if @index >= @array.size
+        stop
+      else
+        value = @array[@index]
+        @index += 1
+        value
+      end
+    end
+
+    def rewind
+      @index = 0
+      self
+    end
+  end
+
+  # :nodoc:
+  class ReverseItemIterator(A, T)
+    include Iterator(T)
+
+    def initialize(@array : A, @index : Int32 = array.size - 1)
+    end
+
+    def next
+      if @index < 0
+        stop
+      else
+        value = @array[@index]
+        @index -= 1
+        value
+      end
+    end
+
+    def rewind
+      @index = @array.size - 1
+      self
+    end
+  end
+
+  # :nodoc:
+  class IndexIterator(A)
+    include Iterator(Int32)
+
+    def initialize(@array : A, @index = 0)
+    end
+
+    def next
+      if @index >= @array.size
+        stop
+      else
+        value = @index
+        @index += 1
+        value
+      end
+    end
+
+    def rewind
+      @index = 0
+      self
+    end
+  end
+end

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -15,6 +15,7 @@ require "comparable"
 require "exception"
 require "iterable"
 require "iterator"
+require "indexable"
 require "string"
 
 # Alpha-sorted list

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -1,6 +1,7 @@
 # A fixed-size, stack allocated array.
 struct StaticArray(T, N)
   include Enumerable(T)
+  include Indexable(T)
 
   # Create a new `StaticArray` with the given *args*. The type of the
   # static array will be the union of the type of the given *args*,
@@ -74,33 +75,9 @@ struct StaticArray(T, N)
     false
   end
 
-  # Calls the given block once for each element in `self`, passing that element as a parameter
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new 0     # => [0, 0, 0]
-  # puts array.each { |x| print x, " -- " } # => 0 -- 0 -- 0 -- 3
-  # ```
-  def each
-    N.times do |i|
-      yield to_unsafe[i]
-    end
-  end
-
-  # Returns the element at the given index.
-  #
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to set an element outside the array's range.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => [1 ,2 ,3]
-  # array[0]                                        # => 1
-  # array[1]                                        # => 2
-  # array[2]                                        # => 3
-  # array[4]                                        # => IndexError
-  # ```
+  # :nodoc:
   @[AlwaysInline]
-  def [](index : Int)
-    index = check_index_out_of_bounds index
+  def unsafe_at(index : Int)
     to_unsafe[index]
   end
 
@@ -118,17 +95,6 @@ struct StaticArray(T, N)
   def []=(index : Int, value : T)
     index = check_index_out_of_bounds index
     to_unsafe[index] = value
-  end
-
-  # Returns a tuple populated with the elements at the given indexes.
-  # Raises if any index is invalid.
-  #
-  # ```
-  # a = StaticArray(Int32, 4).new { |i| i + 1 }
-  # a.values_at(0, 2) # => {1, 3}
-  # ```
-  def values_at(*indexes : Int)
-    indexes.map { |index| self[index] }
   end
 
   # Yields the current element at the given index and updates the value at the given index with the block's value
@@ -176,7 +142,7 @@ struct StaticArray(T, N)
   # a                                           # => [3, 2, 1]
   # ```
   def shuffle!(random = Random::DEFAULT)
-    to_unsafe.shuffle!(size, random)
+    to_slice.shuffle!(random)
     self
   end
 
@@ -199,13 +165,7 @@ struct StaticArray(T, N)
   # array.reverse! # => [3, 2, 1]
   # ```
   def reverse!
-    i = 0
-    j = size - 1
-    while i < j
-      to_unsafe.swap i, j
-      i += 1
-      j -= 1
-    end
+    to_slice.reverse!
     self
   end
 
@@ -220,15 +180,6 @@ struct StaticArray(T, N)
   # ```
   def to_slice
     Slice.new(to_unsafe, size)
-  end
-
-  # Returns a hash code based on `self`'s size and elements.
-  #
-  # See `Object#hash`.
-  def hash
-    reduce(31 * size) do |memo, elem|
-      31 * memo + elem.hash
-    end
   end
 
   # Returns a pointer to this static array's data.
@@ -260,13 +211,5 @@ struct StaticArray(T, N)
       array.to_unsafe[i] = to_unsafe[i].clone
     end
     array
-  end
-
-  private def check_index_out_of_bounds(index)
-    index += size if index < 0
-    unless 0 <= index < size
-      raise IndexError.new
-    end
-    index
   end
 end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -62,8 +62,8 @@
 # tuple # => {1, "hello", 'x'} (Tuple(Int32, String, Char))
 # ```
 struct Tuple
-  include Enumerable(typeof((i = 0; self[i])))
-  include Iterable
+  include Enumerable(Union(*T))
+  include Indexable(Union(*T))
   include Comparable(Tuple)
 
   # Creates a tuple that will contain the given arguments.
@@ -118,6 +118,11 @@ struct Tuple
     {% end %}
     )
     {% end %}
+  end
+
+  # :nodoc:
+  def unsafe_at(index : Int)
+    self[index]
   end
 
   # Returns the element at the given index. Read the type docs to understand
@@ -175,16 +180,6 @@ struct Tuple
     yield
   end
 
-  # Returns a tuple populated with the elements at the given indexes.
-  # Raises if any index is invalid.
-  #
-  # ```
-  # {"a", "b", "c", "d"}.values_at(0, 2) # => {"a", "c"}
-  # ```
-  def values_at(*indexes : Int)
-    indexes.map { |index| self[index] }
-  end
-
   # Yields each of the elements in this tuple.
   #
   # ```
@@ -206,15 +201,6 @@ struct Tuple
       yield self[{{i}}]
     {% end %}
     self
-  end
-
-  # Returns an `Iterator` for the elements in this tuple.
-  #
-  # ```
-  # {1, 'a'}.each.cycle.first(3).to_a # => [1, 'a', 1]
-  # ```
-  def each
-    ItemIterator(self, typeof((i = 0; self[i]))).new(self)
   end
 
   # Returns `true` if this tuple has the same size as the other tuple
@@ -369,16 +355,6 @@ struct Tuple
     {% end %}
   end
 
-  # Returns true if this tuple is empty.
-  #
-  # ```
-  # Tuple.new.empty? # => true
-  # {1, 2}.empty?    # => false
-  # ```
-  def empty?
-    size == 0
-  end
-
   # Returns the number of elements in this tuple.
   #
   # ```
@@ -470,15 +446,6 @@ struct Tuple
     self
   end
 
-  # Returns an `Iterator` for the elements in this tuple.
-  #
-  # ```
-  # {1, 'a'}.reverse_each.cycle.first(3).to_a # => [1, 'a', 1]
-  # ```
-  def reverse_each
-    ReverseIterator(self, typeof((i = 0; self[i]))).new(self)
-  end
-
   # Returns the first element of this tuple. Doesn't compile
   # if the tuple is empty.
   #
@@ -536,50 +503,5 @@ struct Tuple
     {% else %}
       self[{{T.size - 1}}]
     {% end %}
-  end
-
-  class ItemIterator(I, T)
-    include Iterator(T)
-
-    @tuple : I
-    @index : Int32
-
-    def initialize(@tuple, @index = 0)
-    end
-
-    def next
-      value = @tuple.at(@index) { stop }
-      @index += 1
-      value
-    end
-
-    def rewind
-      @index = 0
-      self
-    end
-  end
-
-  # :nodoc:
-  class ReverseIterator(I, T)
-    include Iterator(T)
-
-    @tuple : I
-    @index : Int32
-
-    def initialize(@tuple, @index = tuple.size - 1)
-    end
-
-    def next
-      return stop if @index < 0
-
-      value = @tuple.at(@index) { stop }
-      @index -= 1
-      value
-    end
-
-    def rewind
-      @index = @tuple.size - 1
-      self
-    end
   end
 end


### PR DESCRIPTION
This was proposed many times in the past and I think it's time to implement this.

All started with me trying to implement the sieve exercise on exercism. I came up with a solution very similar to that of @jhass ( http://exercism.io/submissions/dd85bc5d9c6947dd98fcc807db62afe8 ), using Array, and then wanted to use BitArray only to find out it didn't have an `each` method. So I thought about adding it, but it was very similar to that of Array. And that of Slice, and Deque. So I extracted all those iterators into a separate class, but then thought many other methods were similar. Then I remembered about the idea of adding an `Indexable` module so all implementations can be in sync, and also to avoid a lot of boilerplate in every implementation.

Indexable needs a protected `unsafe_at(index)` to be implemented. This allows for some methods to be implemented much more efficiently (I did some benchmarks), to avoid some index bounds check when it's safe to avoid them.

I found a couple of compiler bugs: if you include a generic module that includes another generic module, that second generic module isn't seen in restrictions. Then protected methods aren't correctly considered in generic modules so for now I made the `unsafe_at` methods public. But we can change these when we fix the compiler bugs.

One drawback of this change is that now some Array methods are not immediately seen in the Array docs, but you need to jump to `Indexable`, so newcomers might be confused with this.

Indexable only provides read access, not write access. I didn't find the write methods in Array, Slice, StaticArray and Deque to be similar, and there's also the thing that Tuple is read-only. 