### PR TITLE
Websocket masking: replace `% 4` with `& 0b11` for performance.

### DIFF
--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -138,8 +138,8 @@ class HTTP::WebSocket::Protocol
     @io.write mask_array.to_slice
 
     data.each_with_index do |byte, index|
-      mask = mask_array[index % 4]
-      @io.write_byte(byte ^ mask_array[index % 4])
+      mask = mask_array[index & 0b11] # x & 0b11 == x % 4
+      @io.write_byte(byte ^ mask_array[index & 0b11])
     end
   end
 
@@ -193,7 +193,7 @@ class HTTP::WebSocket::Protocol
     @io.read_fully(buffer[0, count])
     if masked?
       count.times do |i|
-        buffer[i] ^= @mask[@mask_offset % 4]
+        buffer[i] ^= @mask[@mask_offset & 0b11] # x & 0b11 == x % 4
         @mask_offset += 1
       end
     end


### PR DESCRIPTION
By replacing `% 4` with `& 0b11` websocket masking gets about 30% faster. This small change can make websockets up to 10% faster (in my testcase). This will become handy when binary websockets will be supported. (like in #2774)

For benchmark please run:
```crystal
require "benchmark"

Benchmark.ips(warmup: 4, calculation: 10) do |x|

  buffer = MemoryIO.new(2048)
  buffer << "DaTA"*512
  slice = buffer.to_slice
  count = 2048
  mask = [1_u8,2_u8,3_u8,4_u8]

  x.report("mask_offset & 0b11") do
    mask_offset = 0

    count.times do |i|
       slice[i] ^= mask[mask_offset & 0b11]
       mask_offset += 1
     end
  end

  x.report("mask_offset % 4") do
    mask_offset = 0

    count.times do |i|
       slice[i] ^= mask[mask_offset % 4]
       mask_offset += 1
     end
  end
end
```
```
mask_offset & 0b11 297.81k (± 6.07%)       fastest
   mask_offset % 4 227.89k (± 8.37%)  1.31× slower
```
