### PR TITLE
Can't parse enum from upcase word

### DIFF
--- a/src/enum.cr
+++ b/src/enum.cr
@@ -343,7 +343,7 @@ struct Enum
   #
   # ```
   # Color.parse("Red")    # => Color::Red
-  # Color.parse("BLUE")   # => Color::Blue
+  # Color.parse("blue")   # => Color::Blue
   # Color.parse("Yellow") # => Exception
   # ```
   def self.parse(string) : self
@@ -356,7 +356,7 @@ struct Enum
   #
   # ```
   # Color.parse?("Red")    # => Color::Red
-  # Color.parse?("BLUE")   # => Color::Blue
+  # Color.parse?("blue")   # => Color::Blue
   # Color.parse?("Yellow") # => nil
   # ```
   def self.parse?(string) : self?


### PR DESCRIPTION
I'm not sure if this was the case before. I don't know if this is a bug or just misdocumented, but I expect there are not tests for it or else they would fail.

Due to the camelcasing, it won't convert `"BLUE"` into `"Blue"`, it outputs `"BLUE"` which is not found in the enum. However, using a lowercase `"blue"` works because that gives `"Blue"`.