### PR TITLE
Fix #1663 for HTTP::WebSocket::Protocol.read_size

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -146,7 +146,7 @@ describe HTTP::WebSocket do
     it "read very long packet" do
       data_slice = Slice(UInt8).new(10 + 0x010000)
       header = packet(0x82, 127_u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00)
-      data_slice.copy_from(header,10)
+      data_slice.copy_from(header, 10)
 
       data = data_slice.pointer(data_slice.bytesize)
 

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -318,7 +318,3 @@ describe HTTP::WebSocket do
   typeof(HTTP::WebSocket.new("localhost", "/"))
   typeof(HTTP::WebSocket.new("ws://localhost"))
 end
-
-describe HTTP::WebSocket::Protocol do
-
-end

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -143,22 +143,6 @@ describe HTTP::WebSocket do
       String.new(buffer[0, 1023]).should eq("x" * 1023)
     end
 
-    it "read longer packet" do
-      data_slice = Slice(UInt8).new(4 + 0x0100)
-      header = packet(0x82, 126_u8, 0x01, 0x00)
-      data_slice.copy_from(header,4)
-
-      data = data_slice.pointer(data_slice.bytesize)
-
-      io = PointerIO.new(pointerof(data))
-      ws = HTTP::WebSocket::Protocol.new(io)
-
-      buffer = Slice(UInt8).new(0x0100)
-
-      result = ws.receive(buffer)
-      assert_binary_packet result, 0x0100, final: true
-    end
-
     it "read very long packet" do
       data_slice = Slice(UInt8).new(10 + 0x010000)
       header = packet(0x82, 127_u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -38,7 +38,7 @@ class HTTP::WebSocket::Protocol
     @mask = uninitialized UInt8[4]
     @mask_offset = 0
     @opcode = Opcode::CONTINUATION
-    @remaining = 0
+    @remaining = 0_u64
     @masked = !!masked
   end
 
@@ -177,13 +177,13 @@ class HTTP::WebSocket::Protocol
   end
 
   private def read_size
-    size = (@header[1] & 0x7f_u8).to_i
+    size = (@header[1] & 0x7f_u8).to_u64
     if size == 126
-      size = 0
+      size = 0_u64
       2.times { size <<= 8; size += @io.read_byte.not_nil! }
     elsif size == 127
-      size = 0
-      4.times { size <<= 8; size += @io.read_byte.not_nil! }
+      size = 0_u64
+      8.times { size <<= 8; size += @io.read_byte.not_nil! }
     end
     size
   end

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -1,6 +1,7 @@
 {% if flag?(:linux) || flag?(:freebsd) %}
   @[Link("m")]
 {% end %}
+
 lib LibM
   # ## To be uncommented once LLVM is updated
   # LLVM binary operations


### PR DESCRIPTION
#1663 is still present in HTTP::WebSocket::Protocol.read_size. 

See [RFC 6455 Section 5.2](https://tools.ietf.org/html/rfc6455#section-5.2).

>  Payload length:  7 bits, 7+16 bits, or 7+64 bits
> 
>       The length of the "Payload data", in bytes: [...]  If 127, the
>       following 8 bytes interpreted as a 64-bit unsigned integer [...]. 