### PR TITLE
Relax `Enum#parse`. Fixes #3108

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -8,6 +8,7 @@ end
 
 enum SpecEnum2
   FourtyTwo
+  FOURTY_FOUR
 end
 
 @[Flags]
@@ -104,7 +105,17 @@ describe Enum do
     SpecEnum.parse("Two").should eq(SpecEnum::Two)
     SpecEnum2.parse("FourtyTwo").should eq(SpecEnum2::FourtyTwo)
     SpecEnum2.parse("fourty_two").should eq(SpecEnum2::FourtyTwo)
-    expect_raises(Exception, "Unknown enum SpecEnum value: Four") { SpecEnum.parse("Four") }
+    expect_raises(ArgumentError, "Unknown enum SpecEnum value: Four") { SpecEnum.parse("Four") }
+
+    SpecEnum.parse("TWO").should eq(SpecEnum::Two)
+    SpecEnum.parse("TwO").should eq(SpecEnum::Two)
+    SpecEnum2.parse("FOURTY_TWO").should eq(SpecEnum2::FourtyTwo)
+
+    SpecEnum2.parse("FOURTY_FOUR").should eq(SpecEnum2::FOURTY_FOUR)
+    SpecEnum2.parse("fourty_four").should eq(SpecEnum2::FOURTY_FOUR)
+    SpecEnum2.parse("FourtyFour").should eq(SpecEnum2::FOURTY_FOUR)
+    SpecEnum2.parse("FOURTYFOUR").should eq(SpecEnum2::FOURTY_FOUR)
+    SpecEnum2.parse("fourtyfour").should eq(SpecEnum2::FOURTY_FOUR)
   end
 
   it "parses?" do

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -338,8 +338,11 @@ struct Enum
   # end
 
   # Returns the enum member that has the given name, or
-  # raises if no such member exists. The comparison is made by using
-  # `String#camelcase` between *string* and the enum members names.
+  # raises `ArgumentError` if no such member exists. The comparison is made by using
+  # `String#camelcase` and `String#downcase` between *string* and
+  # the enum members names, so a member named "FourtyTwo" or "FOURTY_TWO"
+  # is found with any of these strings: "fourty_two", "FourtyTwo", "FOURTY_TWO",
+  # "FOURTYTWO", "fourtytwo".
   #
   # ```
   # Color.parse("Red")    # => Color::Red
@@ -347,12 +350,15 @@ struct Enum
   # Color.parse("Yellow") # => Exception
   # ```
   def self.parse(string) : self
-    parse?(string) || raise "Unknown enum #{self} value: #{string}"
+    parse?(string) || raise ArgumentError.new("Unknown enum #{self} value: #{string}")
   end
 
   # Returns the enum member that has the given name, or
   # `nil` if no such member exists. The comparison is made by using
-  # `String#camelcase` between *string* and the enum members names.
+  # `String#camelcase` and `String#downcase` between *string* and
+  # the enum members names, so a member named "FourtyTwo" or "FOURTY_TWO"
+  # is found with any of these strings: "fourty_two", "FourtyTwo", "FOURTY_TWO",
+  # "FOURTYTWO", "fourtytwo".
   #
   # ```
   # Color.parse?("Red")    # => Color::Red
@@ -361,9 +367,9 @@ struct Enum
   # ```
   def self.parse?(string) : self?
     {% begin %}
-      case string.camelcase
+      case string.camelcase.downcase
       {% for member in @type.constants %}
-        when {{member.stringify.camelcase}}
+        when {{member.stringify.camelcase.downcase}}
           {{@type}}::{{member}}
       {% end %}
       else


### PR DESCRIPTION
I think the use cases for paring a string into an enum come from scenarios where a more relaxed parsing is preferable, for example if the string comes from a JSON, CSV, or even user input, so it's better to guess the closest enum value from its name.