### PR TITLE
Fixed #3124: Added documentation for printf in MemoryIO

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -347,6 +347,15 @@ module IO
     nil
   end
 
+  # Writes the formatted string to STDOUT. The format can include
+  # format specifiers(subsequences beginning with %). The arguments
+  # replace the format specifiers in the format string.
+  #
+  # ```
+  # io = MemoryIO.new
+  # io.printf("Hello %s", "Crystal")
+  # io.to_s # => "Hello Crystal"
+  # ```
   def printf(format_string, *args) : Nil
     printf format_string, args
   end


### PR DESCRIPTION
Adding the documentation for `printf` in the `MemoryIO` class to fix [this issue](https://github.com/crystal-lang/crystal/issues/3124).