### PR TITLE
Fix #3125: Added documentation for printf in the MemoryIO class

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -350,11 +350,29 @@ module IO
   # Writes the formatted string to this IO. The format can include
   # format specifiers(subsequences beginning with %). The arguments
   # replace the format specifiers in the format string.
+  # The specifiers that can be supplied to the method are
+  # %s => strings
+  # %b => binary
+  # %o => octal
+  # %d => decimal
+  # %i => decimal
+  # %x => hexadecimal
+  # %X => hexadecimal
+  # %a, %A, %e, %E, %f, %g, %G => char
   #
   # ```
   # io = MemoryIO.new
   # io.printf("Hello %s", "Crystal")
   # io.to_s # => "Hello Crystal"
+  # ```
+  #
+  # When the number of arguments supplied are less than the
+  # number of format specifiers, an ArgumentError is thrown
+  #
+  # ```
+  # io = MemoryIO.new
+  # io.printf("Hello %s %s", "Crystal")
+  # => too few arguments (ArgumentError)
   # ```
   def printf(format_string, *args) : Nil
     printf format_string, args

--- a/src/io.cr
+++ b/src/io.cr
@@ -347,6 +347,15 @@ module IO
     nil
   end
 
+  # Writes the formatted string to this IO. The format can include
+  # format specifiers(subsequences beginning with %). The arguments
+  # replace the format specifiers in the format string.
+  #
+  # ```
+  # io = MemoryIO.new
+  # io.printf("Hello %s", "Crystal")
+  # io.to_s # => "Hello Crystal"
+  # ```
   def printf(format_string, *args) : Nil
     printf format_string, args
   end


### PR DESCRIPTION
Adding the documentation for printf in the MemoryIO class to fix [this issue](https://github.com/crystal-lang/crystal/issues/3124)