### PR TITLE
Add select keyword

### DIFF
--- a/samples/channel_select.cr
+++ b/samples/channel_select.cr
@@ -14,7 +14,7 @@ ch2 = generator(1.5)
 ch3 = generator(5)
 
 loop do
-  index, value = Channel.select(ch1.receive_op, ch2.receive_op, ch3.receive_op)
+  index, value = Channel.select(ch1.receive_select_action, ch2.receive_select_action, ch3.receive_select_action)
   case index
   when 0
     int = value.as(typeof(ch1.receive))

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -449,6 +449,13 @@ describe Crystal::Formatter do
   assert_format "case 1\nwhen 1 then\n2\nwhen 3\n4\nend", "case 1\nwhen 1\n  2\nwhen 3\n  4\nend"
   assert_format "case  1 \n when 2 \n 3 \n else 4 \n end", "case 1\nwhen 2\n  3\nelse 4\nend"
 
+  assert_format "select   \n when  foo \n 2 \n end", "select\nwhen foo\n  2\nend"
+  assert_format "select   \n when  foo \n 2 \n when bar \n 3 \n end", "select\nwhen foo\n  2\nwhen bar\n  3\nend"
+  assert_format "select   \n when  foo  then  2 \n end", "select\nwhen foo then 2\nend"
+  assert_format "select   \n when  foo  ;  2 \n end", "select\nwhen foo; 2\nend"
+  assert_format "select   \n when  foo \n 2 \n else \n 3 \n end", "select\nwhen foo\n  2\nelse\n  3\nend"
+  assert_format "def foo\nselect   \n when  foo \n 2 \n else \n 3 \nend\nend", "def foo\n  select\n  when foo\n    2\n  else\n    3\n  end\nend"
+
   assert_format "foo.@bar"
 
   assert_format "@[Foo]"

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -128,7 +128,7 @@ describe "Lexer" do
   it_lexes_keywords [:def, :if, :else, :elsif, :end, :true, :false, :class, :module, :include,
     :extend, :while, :until, :nil, :do, :yield, :return, :unless, :next, :break,
     :begin, :lib, :fun, :type, :struct, :union, :enum, :macro, :out, :require,
-    :case, :when, :then, :of, :abstract, :rescue, :ensure, :is_a?, :alias,
+    :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?, :alias,
     :pointerof, :sizeof, :instance_sizeof, :ifdef, :as, :as?, :typeof, :for, :in,
     :with, :self, :super, :private, :protected, :asm, :uninitialized, :nil?]
   it_lexes_idents ["ident", "something", "with_underscores", "with_1", "foo?", "bar!", "fooBar",

--- a/spec/compiler/normalize/select_spec.cr
+++ b/spec/compiler/normalize/select_spec.cr
@@ -1,0 +1,68 @@
+require "../../spec_helper"
+
+describe "Normalize: case" do
+  it "normalizes select with call" do
+    assert_expand "select; when foo; body; when bar; baz; end", <<-CODE
+      __temp_1, __temp_2 = ::Channel.select({foo_select_action, bar_select_action})
+      case __temp_1
+      when 0
+        body
+      when 1
+        baz
+      else
+        ::raise("Bug: invalid select index")
+      end
+      CODE
+  end
+
+  it "normalizes select with assign" do
+    assert_expand "select; when x = foo; x + 1; end", <<-CODE
+      __temp_1, __temp_2 = ::Channel.select({foo_select_action})
+      case __temp_1
+      when 0
+        x = __temp_2.as(typeof(foo))
+        x + 1
+      else
+        ::raise("Bug: invalid select index")
+      end
+      CODE
+  end
+
+  it "normalizes select with else" do
+    assert_expand "select; when foo; body; else; baz; end", <<-CODE
+      __temp_1, __temp_2 = ::Channel.select({foo_select_action}, true)
+      case __temp_1
+      when 0
+        body
+      else
+        baz
+      end
+      CODE
+  end
+
+  it "normalizes select with assign and question method" do
+    assert_expand "select; when x = foo?; x + 1; end", <<-CODE
+      __temp_1, __temp_2 = ::Channel.select({foo_select_action?})
+      case __temp_1
+      when 0
+        x = __temp_2.as(typeof(foo?))
+        x + 1
+      else
+        ::raise("Bug: invalid select index")
+      end
+      CODE
+  end
+
+  it "normalizes select with assign and bang method" do
+    assert_expand "select; when x = foo!; x + 1; end", <<-CODE
+      __temp_1, __temp_2 = ::Channel.select({foo_select_action!})
+      case __temp_1
+      when 0
+        x = __temp_2.as(typeof(foo!))
+        x + 1
+      else
+        ::raise("Bug: invalid select index")
+      end
+      CODE
+  end
+end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -902,6 +902,12 @@ describe "Parser" do
   it_parses "case {1, 2}\nwhen foo\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new(["foo".call] of ASTNode, 5.int32)])
   assert_syntax_error "case {1, 2}; when {3}; 4; end", "wrong number of tuple elements (given 1, expected 2)", 1, 19
 
+  it_parses "select\nwhen foo\n2\nend", Select.new([Select::When.new("foo".call, 2.int32)])
+  it_parses "select\nwhen foo\n2\nwhen bar\n4\nend", Select.new([Select::When.new("foo".call, 2.int32), Select::When.new("bar".call, 4.int32)])
+  it_parses "select\nwhen foo\n2\nelse\n3\nend", Select.new([Select::When.new("foo".call, 2.int32)], 3.int32)
+
+  assert_syntax_error "select\nwhen 1\n2\nend", "invalid select when expression: must be an assignment or call"
+
   it_parses "def foo(x); end; x", [Def.new("foo", ["x".arg]), "x".call]
   it_parses "def foo; / /; end", Def.new("foo", body: regex(" "))
 

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -78,7 +78,12 @@ describe Channel::Unbuffered do
     ch1 = Channel::Unbuffered(Int32).new
     ch2 = Channel::Unbuffered(Int32).new
     spawn { ch1.send 123 }
-    Channel.select(ch1.receive_op, ch2.receive_op).should eq({0, 123})
+    Channel.select(ch1.receive_select_action, ch2.receive_select_action).should eq({0, 123})
+  end
+
+  it "works with select else" do
+    ch1 = Channel::Unbuffered(Int32).new
+    Channel.select({ch1.receive_select_action}, true).should eq({1, nil})
   end
 
   it "can send and receive nil" do
@@ -180,7 +185,7 @@ describe Channel::Buffered do
     ch1 = Channel::Buffered(Int32).new
     ch2 = Channel::Buffered(Int32).new
     spawn { ch1.send 123 }
-    Channel.select(ch1.receive_op, ch2.receive_op).should eq({0, 123})
+    Channel.select(ch1.receive_select_action, ch2.receive_select_action).should eq({0, 123})
   end
 
   it "can send and receive nil" do

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -519,7 +519,7 @@ module Crystal
                    ArrayLiteral HashLiteral RegexLiteral RangeLiteral
                    Case StringInterpolation
                    MacroExpression MacroIf MacroFor MultiAssign
-                   SizeOf InstanceSizeOf Global Require) %}
+                   SizeOf InstanceSizeOf Global Require Select) %}
     class {{name.id}}
       include ExpandableNode
     end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2657,6 +2657,11 @@ module Crystal
       false
     end
 
+    def visit(node : Select)
+      expand(node)
+      false
+    end
+
     def visit(node : MultiAssign)
       expand(node)
       false

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1147,6 +1147,30 @@ module Crystal
     def_equals_and_hash @cond, @whens, @else
   end
 
+  class Select < ASTNode
+    record When, condition : ASTNode, body : ASTNode
+
+    property whens : Array(When)
+    property else : ASTNode?
+
+    def initialize(@whens, @else = nil)
+    end
+
+    def accept_children(visitor)
+      @whens.each do |select_when|
+        select_when.condition.accept visitor
+        select_when.body.accept visitor
+      end
+      @else.try &.accept visitor
+    end
+
+    def clone_without_location
+      Select.new(@whens.clone, @else.clone)
+    end
+
+    def_equals_and_hash @whens, @else
+  end
+
   # Node that represents an implicit obj in:
   #
   #     case foo

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -926,8 +926,15 @@ module Crystal
       when 's'
         case next_char
         when 'e'
-          if next_char == 'l' && next_char == 'f'
-            return check_ident_or_keyword(:self, start)
+          if next_char == 'l'
+            case next_char
+            when 'e'
+              if next_char == 'c' && next_char == 't'
+                return check_ident_or_keyword(:select, start)
+              end
+            when 'f'
+              return check_ident_or_keyword(:self, start)
+            end
           end
         when 'i'
           if next_char == 'z' && next_char == 'e' && next_char == 'o' && next_char == 'f'

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1263,6 +1263,25 @@ module Crystal
       false
     end
 
+    def visit(node : Select)
+      @str << keyword("select")
+      newline
+      node.whens.each do |a_when|
+        @str << "when "
+        a_when.condition.accept self
+        newline
+        accept_with_indent a_when.body
+      end
+      if a_else = node.else
+        @str << "else"
+        newline
+        accept_with_indent a_else
+      end
+      @str << keyword("end")
+      newline
+      false
+    end
+
     def visit(node : ImplicitObj)
       false
     end

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -220,6 +220,18 @@ module Crystal
       node
     end
 
+    def transform(node : Select)
+      node.whens.map! do |a_when|
+        Select::When.new(a_when.condition.transform(self), a_when.body.transform(self))
+      end
+
+      if node_else = node.else
+        node.else = node_else.transform(self)
+      end
+
+      node
+    end
+
     def transform(node : ImplicitObj)
       node
     end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3265,6 +3265,69 @@ module Crystal
       false
     end
 
+    def visit(node : Select)
+      slash_is_regex!
+      write_keyword :select
+      skip_space_or_newline
+      skip_semicolon
+      write_line
+
+      node.whens.each do |a_when|
+        needs_indent = false
+        write_indent
+        write_keyword :when
+        skip_space_or_newline
+        write " "
+        a_when.condition.accept self
+        skip_space
+        if @token.type == :";"
+          next_token_skip_space
+          if @token.type == :NEWLINE
+            write_line
+            skip_space_or_newline
+            needs_indent = true
+          else
+            write "; "
+            skip_space_or_newline
+          end
+        elsif @token.keyword?(:then)
+          next_token_skip_space
+          if @token.type == :NEWLINE
+            write_line
+            skip_space_or_newline
+            needs_indent = true
+          else
+            write "then "
+            skip_space_or_newline
+          end
+        else
+          write_line
+          skip_space_or_newline
+          needs_indent = true
+        end
+        if needs_indent
+          format_nested(a_when.body)
+        else
+          a_when.body.accept self
+          write_line
+        end
+        skip_space_or_newline
+      end
+
+      if node_else = node.else
+        write_indent
+        write_keyword :else
+        skip_space_or_newline
+        format_nested(node_else)
+        skip_space_or_newline
+      end
+
+      write_indent
+      write_keyword :end
+
+      false
+    end
+
     def visit(node : Attribute)
       write_token :"@["
       skip_space_or_newline

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -257,7 +257,7 @@ module Enumerable(T)
   #     ["Alice", "Bob"].grep(/^A/)  #=> ["Alice"]
   #
   def grep(pattern)
-    select { |elem| pattern === elem }
+    self.select { |elem| pattern === elem }
   end
 
   # Returns a `Hash` whose keys are each different value that the passed block returned when run for each element in the

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -526,7 +526,7 @@ class Hash(K, V)
   end
 
   def select(*keys)
-    select(keys)
+    self.select(keys)
   end
 
   # Removes every element except the given ones.

--- a/src/io.cr
+++ b/src/io.cr
@@ -86,7 +86,7 @@ module IO
   end
 
   def self.select(read_ios, write_ios = nil, error_ios = nil)
-    select(read_ios, write_ios, error_ios, nil).not_nil!
+    self.select(read_ios, write_ios, error_ios, nil).not_nil!
   end
 
   # Returns an array of all given IOs that are


### PR DESCRIPTION
Fixes #688 

This adds the `select` keyword, which is syntax sugar to perform
a `Channel.select` more easily.

For example, our current channel_select sample is:

```cr
def generator(n : T)
  channel = Channel(T).new
  spawn do
    loop do
      sleep n
      channel.send n
    end
  end
  channel
end

ch1 = generator(1)
ch2 = generator(1.5)
ch3 = generator(5)

loop do
  index, value = Channel.select(ch1.receive_select_action, ch2.receive_select_action, ch3.receive_select_action)
  case index
  when 0
    int = value.as(typeof(ch1.receive))
    puts "Int: #{int}"
  when 1
    float = value.as(typeof(ch2.receive))
    puts "Float: #{float}"
  when 2
    break
  else
    raise "BUG: Channel.select returned invalid index #{index}"
  end
end
```

With the new syntax it can be written as:

```cr
def generator(n : T)
  channel = Channel(T).new
  spawn do
    loop do
      sleep n
      channel.send n
    end
  end
  channel
end

ch1 = generator(1)
ch2 = generator(1.5)
ch3 = generator(5)

loop do
  select
  when int = ch1.receive
    puts "Int: #{int}"
  when float = ch2.receive
    puts "Float: #{float}"
  when ch3.receive
    break
  end
end
```

A `select` `when` expression can either be a call or an assignment whose right-hand side is a call. The call name is added "_select_action" (taking bang and question marks into account) and that is passed to the `Channel.select` method.

The nice thing about this is that this is extensible: we could define a `timeout_select_action(n)` method, so one could do:

```cr
select
when x = ch.receive
  puts x
when timeout(5.seconds)
  puts "Timeout!"
end
```

In fact we were able to implement this but this will be pushed in a later commit (the interface and docs about how to implement a "select action" are current missing).

This is a **breaking change**, because now `select` can't be used as a method call, just like `case` can't be used for that. One has to use an explicit receiver, like `foo.select` or `self.select`, or `::select`.


