### PR TITLE
Add Hash#has_value?

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -204,6 +204,18 @@ describe "Hash" do
     end
   end
 
+  describe "has_value?" do
+    it "returns true if contains the value" do
+      a = {1 => 2}
+      a.has_value?(2).should be_true
+    end
+
+    it "returns false if does not contain the value" do
+      a = {1 => 2}
+      a.has_value?(1).should be_false
+    end
+  end
+
   describe "delete" do
     it "deletes key in the beginning" do
       a = {1 => 2, 3 => 4, 5 => 6}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -206,13 +206,13 @@ describe "Hash" do
 
   describe "has_value?" do
     it "returns true if contains the value" do
-      a = {1 => 2}
-      a.has_value?(2).should be_true
+      a = {1 => 2, 3 => 4, 5 => 6}
+      a.has_value?(4).should be_true
     end
 
     it "returns false if does not contain the value" do
-      a = {1 => 2}
-      a.has_value?(1).should be_false
+      a = {1 => 2, 3 => 4, 5 => 6}
+      a.has_value?(3).should be_false
     end
   end
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -85,6 +85,20 @@ class Hash(K, V)
     !!find_entry(key)
   end
 
+  # Returns `true` when value given by *value* exists, otherwise `false`.
+  #
+  # ```
+  # h = {"foo" => "bar"}
+  # h.has_value?("foo") # => false
+  # h.has_value?("bar") # => true
+  # ```
+  def has_value?(val)
+    each_value do |value|
+      return true if value == val
+    end
+    false
+  end
+
   # Returns the value for the key given by *key*.
   # If not found, returns the default value given by `Hash.new`, otherwise raises `KeyError`.
   #


### PR DESCRIPTION
* Ruby has `has_value?`. Is it a rejected one in crystal?
* If it is reasonable, should I add `Env#has_value?` and `SimpleHash#has_value?`? ref: https://github.com/crystal-lang/crystal/issues/2331
