### PR TITLE
added spec tests to confirm heredocs work tabs + spaces

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1152,6 +1152,9 @@ describe "Parser" do
   it_parses "<<-FOO\n1\nFOO + 2", Call.new("1".string, "+", 2.int32)
 
   it_parses "<<-FOO\n\t1\n\tFOO", StringLiteral.new("1")
+  it_parses "<<-FOO\n \t1\n \tFOO", StringLiteral.new("1")
+  it_parses "<<-FOO\n \t 1\n \t FOO", StringLiteral.new("1")
+  it_parses "<<-FOO\n\t 1\n\t FOO", StringLiteral.new("1")
 
   it_parses "enum Foo; A\nB, C\nD = 1; end", EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)
   it_parses "enum Foo; A = 1, B; end", EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Arg.new("B")] of ASTNode)


### PR DESCRIPTION
this is to address the problem that some
codebases have mixed space + tab indentation
(presumably this is unintentional)

enhances tests for issue #3109