### PR TITLE
run standard library specs in release mode on travis

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -85,6 +85,7 @@ prepare_system() {
 build() {
   with_build_env 'make std_spec clean'
   with_build_env 'make crystal spec doc'
+  with_build_env 'make std_spec release=1'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check samples spec src'
 }


### PR DESCRIPTION
This should catch codegen bugs that only appear after LLVM optimizations.
