### PR TITLE
Fix typo in TCP server sample

### DIFF
--- a/samples/tcp_server.cr
+++ b/samples/tcp_server.cr
@@ -11,7 +11,7 @@ def process(client)
     client << msg
   end
 rescue IO::EOFError
-  puts "#{client_addr} dissconnected"
+  puts "#{client_addr} disconnected"
 ensure
   client.close
 end


### PR DESCRIPTION
Typo in ```samples/tcp_server.cr```.