### PR TITLE
Checks if cookies is empty before adding to header

### DIFF
--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -246,7 +246,7 @@ module HTTP
     # `Cookie` headers in it.
     def add_request_headers(headers)
       headers.delete("Cookie")
-      headers.add("Cookie", map(&.to_cookie_header).join("; "))
+      headers.add("Cookie", map(&.to_cookie_header).join("; ")) unless empty?
 
       headers
     end


### PR DESCRIPTION
see greyblake/crystal-cossack#4

One item that is unclear is if it should erase the previous cookies if there are none in the instance of `HTTP::Cookies`.

I erred on the side of erasing them still, since I assume the canonical representation of the cookies is more likely to be the instance of `HTTP::Cookies`.