### PR TITLE
HTTP::Request#path: fallback to /

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -168,6 +168,12 @@ module HTTP
         request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path.should eq("/api/v3/some/resource")
       end
+
+      it "falls back to /" do
+        request = Request.new("GET", "/foo")
+        request.path = nil
+        request.path.should eq("/")
+      end
     end
 
     describe "#path=" do

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -77,7 +77,7 @@ class HTTP::Request
 
   # Lazily parses and return the request's path component.
   def path
-    uri.path
+    uri.path || "/"
   end
 
   # Sets request's path component.


### PR DESCRIPTION
`nil` doesn't make much sense as a value here, `"/"` seems a reasonable enough default for that case.