### PR TITLE
Integer exponentiation should avoid using floats

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -33,6 +33,12 @@ describe "Int" do
       end
     end
 
+    it "should work with large integers" do
+      x = 51_i64 ** 11
+      x.should eq(6071163615208263051_i64)
+      x.should be_a(Int64)
+    end
+
     describe "with float" do
       assert { (2 ** 2.0).should be_close(4, 0.0001) }
       assert { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -189,8 +189,14 @@ struct Int
       raise ArgumentError.new "cannot raise an integer to a negative integer power, use floats for that"
     end
 
-    # TODO: this can probably be optimized by not using float pow
-    self.class.new(to_f ** exponent)
+    result = self.class.new(1)
+    k = self
+    while exponent > 0
+      result *= k if exponent & 0b1 != 0
+      k *= k
+      exponent = exponent.unsafe_shr(1)
+    end
+    result
   end
 
   # Returns the value of raising *self* to the power of *exponent*.


### PR DESCRIPTION
Using float exponentiation generates error when working with long integers besides it's performance penalization.
Some examples:
```
61 ** 9 => 11694146092834141 # Expected 11694146092834140
126 ** 9 => 8004512848309156864 # Expected 8004512848309157376
```
Using [Exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring) it gives  correct result.