### PR TITLE
returns nil if xpath_nodes is empty

### DIFF
--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -70,6 +70,11 @@ module XML
       end
     end
 
+    it "returns nil with invalid xpath" do
+      doc = doc()
+      doc.xpath_node("//invalid").should be_nil
+    end
+
     it "finds with namespace" do
       doc = XML.parse(%(\
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -478,8 +478,7 @@ struct XML::Node
   # node.xpath_node("//person")
   # ```
   def xpath_node(path, namespaces = nil, variables = nil)
-    xpath = xpath_nodes(path, namespaces)
-    xpath.empty? ? nil : xpath.first
+    xpath_nodes(path, namespaces).first?
   end
 
   # Searches this node for XPath *path* and restricts the return type to `String`.

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -473,12 +473,13 @@ struct XML::Node
   end
 
   # Searches this node for XPath *path* for nodes and returns the first one.
-  #
+  # or nil if not found
   # ```
   # node.xpath_node("//person")
   # ```
   def xpath_node(path, namespaces = nil, variables = nil)
-    xpath_nodes(path, namespaces).first
+    xpath = xpath_nodes(path, namespaces)
+    xpath.empty? ? nil : xpath.first
   end
 
   # Searches this node for XPath *path* and restricts the return type to `String`.


### PR DESCRIPTION
When you search for xpath_node and this node doesn't exist, will raise Enumerable::EmptyError.
I wondering if not found, just return nil.
Don't know if is the best approach to do that, maybe I can implement this in XML::XPathContext::evaluate
