### PR TITLE
Reimplement NamedTuble#fetch(String) using a Trie

### DIFF
--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -139,6 +139,30 @@ struct NamedTuple
     {% end %}
     yield
   end
+  
+  macro fetch_trie_expand(keys, index, size)
+    {% if keys.size < 16 %}
+      {% for key in keys %}
+        return self[{{key}}] if {{key}} == key
+      {% end %}
+    {% else %}
+      {% chars = keys.map {|key| key.chars[index] }.uniq %}
+      case key[{{index}}]
+      {% for char in chars %}
+      when {{char}}
+        {% subkeys = keys.select {|key| key.chars[index] == char } %}
+        {% if index+1 == size %}
+          {% ans = subkeys[0] %}
+          {% if ans %}
+            return self[{{ans.id.symbolize}}]
+          {% end %}
+        {% else %}
+          fetch_trie_expand({{subkeys}}, {{index+1}}, {{size}})
+        {% end %}
+      {% end %}
+      end
+    {% end %}
+  end
 
   # Returns the value for the given *key*, if there's such key, otherwise the value returned by the block.
   #
@@ -148,8 +172,15 @@ struct NamedTuple
   # tuple.fetch("other") { 0 }        # => 0
   # ```
   def fetch(key : String, &block)
-    {% for key in T %}
-      return self[{{key.symbolize}}] if {{key.stringify}} == key
+    {% begin %}
+      {% keys = T.keys.map(&.stringify) %}
+      {% sizes = keys.map(&.size).uniq %}
+      case key.size
+      {% for size in sizes %}
+      when {{size}}
+        fetch_trie_expand({{ keys.select {|key| key.size == size} }}, 0, {{size}})
+      {% end %}
+      end
     {% end %}
     yield
   end


### PR DESCRIPTION
Instead of comparing each string key one by one, build a [Prefix Tree](https://en.wikipedia.org/wiki/Trie) at compile-time and make a single comparison per char. This improves performance by 16x on large named tuples and about 1.5x on smaller ones.

Large benchmark: https://gist.github.com/lbguilherme/c7249c408d2a226bdbb6892dda5e9ab2
Small benchmark: https://gist.github.com/lbguilherme/7dba63104c4b44d3adcd5bcc9f9d7c20

See #3143 and #2966
