### PR TITLE
Use Exception#message getter instead of @ivar to allow overloading

### DIFF
--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+
+class FooError < Exception
+  def message
+    "#{super || ""} -- bar!"
+  end
+end
+
+describe "Exception" do
+  it "allows subclassing #message" do
+    ex = FooError.new("foo?")
+    ex.message.should eq("foo? -- bar!")
+    ex.to_s.should eq("foo? -- bar!")
+    ex.inspect_with_backtrace.should contain("foo? -- bar!")
+  end
+end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -157,7 +157,7 @@ class Exception
   end
 
   def to_s(io : IO)
-    io << @message
+    io << message
   end
 
   def inspect_with_backtrace
@@ -167,8 +167,8 @@ class Exception
   end
 
   def inspect_with_backtrace(io : IO)
-    io << @message << " (" << self.class << ")\n"
-    backtrace.try &.each do |frame|
+    io << message << " (" << self.class << ")\n"
+    backtrace?.try &.each do |frame|
       io.puts frame
     end
     io.flush


### PR DESCRIPTION
Suggestion as in the title. It would match Ruby behavior too.

```
ruby -e "class FooError < RuntimeError; def message; super + ' -- bar!'; end; end" -e "raise FooError.new('foo?')"
```
```
-e:2:in '<main>': foo? -- bar! (FooError)
```