### PR TITLE
OptionParser: parse arguments from shorflag if it is only referenced …

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -133,8 +133,28 @@ describe "OptionParser" do
     expect_doesnt_capture_option [] of String, "-f [FLAG]"
   end
 
-  it "doesn't raise if required option is not specified with separated short flag 2" do
+  it "doesn't raise if required option is not specified with separated short flag" do
     expect_doesnt_capture_option [] of String, "-f FLAG"
+  end
+
+  it "parses argument when only referenced in long flag" do
+    captured = ""
+    parser = OptionParser.parse([] of String) do |opts|
+      opts.on("-f", "--flag X", "some flag") { |x| captured = x }
+    end
+    parser.parse(["-f", "12"])
+    captured.should eq "12"
+    parser.to_s.should contain "   -f, --flag X"
+  end
+
+  it "parses argument when referenced in long and short flag" do
+    captured = ""
+    parser = OptionParser.parse([] of String) do |opts|
+      opts.on("-f X", "--flag X", "some flag") { |x| captured = x }
+    end
+    parser.parse(["-f", "12"])
+    captured.should eq "12"
+    parser.to_s.should contain "   -f X, --flag X"
   end
 
   it "does to_s with banner" do

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -107,6 +107,13 @@ class OptionParser
   # See the other definition of `on` for examples.
   def on(short_flag, long_flag, description, &block : String ->)
     append_flag "#{short_flag}, #{long_flag}", description
+
+    has_argument = /([ =].+)/
+    if long_flag =~ has_argument
+      argument = $1
+      short_flag += argument unless short_flag =~ has_argument
+    end
+
     @handlers << Handler.new(short_flag, block)
     @handlers << Handler.new(long_flag, block)
   end


### PR DESCRIPTION
…on longflag

solves https://github.com/crystal-lang/crystal/issues/3204

 - way to improve logic ?
 - should I use a constant for the regex instead ?
 - extract into it's own method ?