### PR TITLE
OptionParser: make flag addition code simpler and faster

### DIFF
--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -146,14 +146,7 @@ class OptionParser
   end
 
   private def append_flag(flag, description)
-    @flags << String.build do |str|
-      str << "    "
-      str << flag
-      (33 - flag.size).times do
-        str << " "
-      end
-      str << description
-    end
+    @flags << "    #{flag}#{" " * (33 - flag.size)}#{description}"
   end
 
   # Parses the passed *args*, running the handlers associated to each option.


### PR DESCRIPTION
I'd guess I'm missing something, but this code is imo easier to read and a simple/naive benchmark shows it's 50x faster to do `" " * x` ...  (5s vs 0.1s)

```Crystal
require "benchmark"
y = 0
z = Benchmark.realtime do
  1000000.times do
    x = " " * 100
    y += x.size
  end
end
puts y
puts z

vs

x = String.build do |str|
  100.times do
  str << " "
  end
str
end
```

