### PR TITLE
Array.new(size, &block) accepts UInt32, other Ints

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -20,6 +20,9 @@ describe "Array" do
     it "creates with default value in block" do
       ary = Array.new(5) { |i| i * 2 }
       ary.should eq([0, 2, 4, 6, 8])
+
+      ary = Array.new(5_u32) { |i| i * 2 }
+      ary.should eq([0, 2, 4, 6, 8])
     end
 
     it "raises on negative count" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -127,7 +127,7 @@ class Array(T)
   # ```
   def self.new(size : Int, &block : Int32 -> T)
     Array(T).build(size) do |buffer|
-      size.times do |i|
+      size.to_i.times do |i|
         buffer[i] = yield i
       end
       size


### PR DESCRIPTION
Not a huge deal, but something I just ran into. Either this, or changing the signature to be explicit that it actually requires only Int32.

In the common case, I assume the `#to_i` would be a noop. 