### PR TITLE
Compiler: mark LLVM return type as Nil when program ends with no typed ASTNode

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -131,8 +131,8 @@ module Crystal
       @abi = @program.target_machine.abi
       @llvm_typer = @program.llvm_typer
       @llvm_id = LLVMId.new(@program)
-      @main_ret_type = node.type
-      ret_type = @llvm_typer.llvm_return_type(node.type)
+      @main_ret_type = node.type? || @program.nil_type
+      ret_type = @llvm_typer.llvm_return_type(@main_ret_type)
       @main = @llvm_mod.functions.add(MAIN_NAME, [LLVM::Int32, LLVM::VoidPointer.pointer], ret_type)
       @main.linkage = LLVM::Linkage::Internal unless expose_crystal_main
 


### PR DESCRIPTION
Compiler crashes when the crystal code ends with no typed ASTNode such as `@[Foo]`.

#### test.cr
```crystal
@[Foo]
```

#### run
```shell
% crystal -v
Crystal 0.19.0 [dcfb2b6] (2016-09-02)

% crystal test.cr
(...snip...)
@[Foo]
` at  has no type
[8917383] *CallStack::unwind:Array(Pointer(Void)) +87
[8917274] *CallStack#initialize:Array(Pointer(Void)) +10
[8917226] *CallStack::new:CallStack +42
[8756568] *raise<Exception>:NoReturn +24
[8756542] ???
[13486612] *Crystal::ASTNode+ +148
[21386979] *Crystal::CodeGenVisitor#initialize<Crystal::Program, Crystal::AS
TNode+, (Array(String) | Bool | Nil), Bool, LLVM::Module, Bool>:Bool +339
[21386606] *Crystal::CodeGenVisitor::new:single_module:debug:llvm_mod:expose
_crystal_main<Crystal::Program, Crystal::ASTNode+, (Array(String) | Bool | N
il), Bool, LLVM::Module, Bool>:Crystal::CodeGenVisitor +222
...
```

I think this will occur in all crystal versions because I got same errors in 0.18.7.

#### PR

This PR uses `nil` for LLVM return type when typeless node appears in the last sentence.

```shell
% ./bin/crystal -v
Using compiled compiler at .build/crystal
Crystal 0.19.0+24 [4e00257] (2016-09-08)

% ./bin/crystal test.cr
Using compiled compiler at .build/crystal
# (→ no errors )
```

Although it's nice that the attributes should be typed correctly,
we also need this fix because compiler must not crash in any cases we don't predict.

`make clean crystal spec` has been passed.

Thanks.