### PR TITLE
Add file-private types. Part of #2950

### DIFF
--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 require "tempfile"
 
-describe "Codegen: private def" do
+describe "Codegen: private" do
   it "codegens private def in same file" do
     compiler = Compiler.new
     sources = [

--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -1,6 +1,6 @@
 require "../../spec_helper"
 
-describe "Semantic: private def" do
+describe "Semantic: private" do
   it "doesn't find private def in another file" do
     expect_raises Crystal::TypeException, "undefined local variable or method 'foo'" do
       compiler = Compiler.new
@@ -135,5 +135,102 @@ describe "Semantic: private def" do
         foo
       {% end %}
       )) { int32 }
+  end
+
+  it "doesn't find private class in another file" do
+    expect_raises Crystal::TypeException, "undefined constant Foo" do
+      compiler = Compiler.new
+      sources = [
+        Compiler::Source.new("foo.cr", %(
+                                          private class Foo
+                                          end
+                                        )),
+        Compiler::Source.new("bar.cr", %(
+                                          Foo
+                                        )),
+      ]
+      compiler.no_codegen = true
+      compiler.prelude = "empty"
+      compiler.compile sources, "output"
+    end
+  end
+
+  it "finds private type in same file" do
+    compiler = Compiler.new
+    sources = [
+      Compiler::Source.new("foo.cr", %(
+                                        private class Foo
+                                          def foo
+                                            1
+                                          end
+                                        end
+
+                                        Foo.new.foo
+                                      )),
+    ]
+    compiler.no_codegen = true
+    compiler.prelude = "empty"
+    compiler.compile sources, "output"
+  end
+
+  it "can use types in private type" do
+    assert_type(%(
+      private class Foo
+        def initialize(@x : Int32)
+        end
+
+        def foo
+          @x + 20
+        end
+      end
+
+      Foo.new(10).foo
+      )) { int32 }
+  end
+
+  it "can use class var initializer in private type" do
+    assert_type(%(
+      private class Foo
+        @@x = 1
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x
+      ), inject_primitives: false) { int32 }
+  end
+
+  it "can use instance var initializer in private type" do
+    assert_type(%(
+      private class Foo
+        @x = 1
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      ), inject_primitives: false) { int32 }
+  end
+
+  it "finds private class in macro expansion" do
+    assert_type(%(
+      private class Foo
+        @x = 1
+
+        def x
+          @x
+        end
+      end
+
+      macro foo
+        Foo.new.x
+      end
+
+      foo
+      ), inject_primitives: false) { int32 }
   end
 end

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -120,7 +120,7 @@ module Crystal
       when TypeDeclaration
         node.var.is_a?(ClassVar)
       when FileNode, Expressions, ClassDef, ModuleDef, EnumDef, Alias, Include, Extend, LibDef, Def, Macro, Call, Require,
-           MacroExpression, MacroIf, MacroFor
+           MacroExpression, MacroIf, MacroFor, VisibilityModifier
         true
       else
         false

--- a/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
@@ -33,7 +33,7 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
     when TypeDeclaration
       node.var.is_a?(InstanceVar)
     when FileNode, Expressions, ClassDef, ModuleDef, Alias, Include, Extend, LibDef, Def, Macro, Call, Require,
-         MacroExpression, MacroIf, MacroFor
+         MacroExpression, MacroIf, MacroFor, VisibilityModifier
       true
     else
       false

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -10,6 +10,9 @@ module Crystal
       # We also need to define empty `new` methods for types
       # that don't have any `initialize` methods.
       define_default_new(self)
+      file_modules.each_value do |file_module|
+        define_default_new(file_module)
+      end
     end
 
     def define_default_new(type)

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -105,7 +105,7 @@ class Crystal::Type
         if node.names.size == 1
           return free_var
         elsif free_var.is_a?(Type)
-          type = free_var.lookup_path(node.names[1..-1], lookup_in_namespace: false)
+          type = free_var.lookup_path(node.names[1..-1], lookup_in_namespace: false, location: node.location)
         end
       else
         type = @root.lookup_path(node)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1220,6 +1220,7 @@ module Crystal
     property splat_index : Int32?
     property? abstract : Bool
     property? struct : Bool
+    property visibility = Visibility::Public
 
     def initialize(@name, body = nil, @superclass = nil, @type_vars = nil, @abstract = false, @struct = false, @name_column_number = 0, @splat_index = nil)
       @body = Expressions.from body
@@ -1250,6 +1251,7 @@ module Crystal
     property splat_index : Int32?
     property name_column_number : Int32
     property doc : String?
+    property visibility = Visibility::Public
 
     def initialize(@name, body = nil, @type_vars = nil, @name_column_number = 0, @splat_index = nil)
       @body = Expressions.from body
@@ -1719,6 +1721,7 @@ module Crystal
     property members : Array(ASTNode)
     property base_type : ASTNode?
     property doc : String?
+    property visibility = Visibility::Public
 
     def initialize(@name, @members = [] of ASTNode, @base_type = nil)
     end


### PR DESCRIPTION
This makes it possible to use `private` with top-level types in a file, making them file-private. This is similar to using `private` on a top-level def.

For example:

```cr
# foo.cr
private class Foo
end

Foo.new # OK

# bar.cr
require "./foo.cr"

Foo.new # Error: undefined constant 'Foo'
```

This can be useful in specs, where we need to define some types only for some specs without fear of having name conflicts, but sometimes we might also need types what we don't want to expose outside a file.

Eventually we can add types private to a type, but for now this is a good start. See #2950