### PR TITLE
Lift the restriction that type variables can only be single letter names

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -420,6 +420,7 @@ describe "Parser" do
   it_parses "class Foo < Bar; end", ClassDef.new("Foo".path, superclass: "Bar".path)
   it_parses "class Foo(T); end", ClassDef.new("Foo".path, type_vars: ["T"])
   it_parses "class Foo(T1); end", ClassDef.new("Foo".path, type_vars: ["T1"])
+  it_parses "class Foo(Type); end", ClassDef.new("Foo".path, type_vars: ["Type"])
   it_parses "abstract class Foo; end", ClassDef.new("Foo".path, abstract: true)
   it_parses "abstract struct Foo; end", ClassDef.new("Foo".path, abstract: true, struct: true)
 
@@ -1328,9 +1329,6 @@ describe "Parser" do
     "can't change the value of self"
 
   assert_syntax_error "macro foo(x : Int32); end"
-
-  assert_syntax_error "class Foo(Something); end", "type variables can only be single letters"
-  assert_syntax_error "module Foo(Something); end", "type variables can only be single letters"
 
   assert_syntax_error "/foo)/", "invalid regex"
   assert_syntax_error "def =\nend"

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -370,4 +370,15 @@ describe "Restrictions" do
       Foo.new { nil.as(Rec)}.t
       )) { types["Rec"].metaclass }
   end
+
+  it "matches free variable for type variable" do
+    assert_type(%(
+      class Foo(Type)
+        def initialize(x : Type)
+        end
+      end
+
+      Foo.new(1)
+      )) { generic_class "Foo", int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -368,8 +368,11 @@ module Crystal
         return restrict ident_type, context
       end
 
-      if single_name && Parser.free_var_name?(other.names.first)
-        return context.set_free_var(other.names.first, self)
+      if single_name
+        first_name = other.names.first
+        if context.defining_type.type_var?(first_name) || Parser.free_var_name?(first_name)
+          return context.set_free_var(first_name, self)
+        end
       end
 
       if had_ident_type
@@ -830,8 +833,9 @@ module Crystal
       else
         single_name = other.names.size == 1
         if single_name
-          if Parser.free_var_name?(other.names.first)
-            return context.set_free_var(other.names.first, self)
+          first_name = other.names.first
+          if context.defining_type.type_var?(first_name) || Parser.free_var_name?(first_name)
+            return context.set_free_var(first_name, self)
           else
             other.raise_undefined_constant(context.defining_type)
           end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1582,10 +1582,6 @@ module Crystal
           end
           type_var_name = check_const
 
-          unless Parser.free_var_name?(type_var_name)
-            raise "type variables can only be single letters optionally followed by a digit", @token
-          end
-
           if type_vars.includes? type_var_name
             raise "duplicated type var name: #{type_var_name}", @token
           end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -528,6 +528,11 @@ module Crystal
     def private=(set_private)
     end
 
+    # Returns true if *name* if an unbound type variable in this (generic) type.
+    def type_var?(name)
+      false
+    end
+
     def inspect(io)
       to_s(io)
     end
@@ -1261,6 +1266,10 @@ module Crystal
         superclass = superclass.replace_type_parameters(instance)
       end
       superclass
+    end
+
+    def type_var?(name)
+      type_vars.includes? name
     end
   end
 
@@ -2338,7 +2347,8 @@ module Crystal
       program.class_type
     end
 
-    delegate abstract?, generic_nest, lookup_new_in_ancestors?, to: instance_type
+    delegate abstract?, generic_nest, lookup_new_in_ancestors?,
+      type_var?, to: instance_type
 
     def class_var_owner
       instance_type
@@ -2732,7 +2742,8 @@ module Crystal
     delegate leaf?, superclass, lookup_first_def, lookup_defs,
       lookup_defs_with_modules, lookup_instance_var, lookup_instance_var?,
       index_of_instance_var, lookup_macro, lookup_macros, all_instance_vars,
-      abstract?, implements?, covariant?, ancestors, struct?, to: base_type
+      abstract?, implements?, covariant?, ancestors, struct?,
+      type_var?, to: base_type
 
     def remove_indirection
       if struct?


### PR DESCRIPTION
Conclusion of #3288

With this change, generic type variable can be named however we want. For example:

```cr
class ArrayWrapper(Type)
  def initialize(@array : Array(Type))
  end

  def <<(x : Type)
    @array << 1
  end
end

some = ArrayWrapper.new([1, 2, 3])
some << 1
some << "a" # Error

ArrayWrapper(String).new([1, 2, 3]) # Error
```

In the above example, when solving `ArrayWrapper.new([1, 2, 3])`, because the method is invoked on an uninstantiated type (`ArrayWrapper(Type)`), `Type` acts as a free variable that will  take the type of the given Array, `Int32`, which makes the returned value be of type `ArrayWrapper(Int32)`.

When solving `some << 1`, `Type` is already bound to `Int32` so the call succeeds. This is why `some << "a"` is an error.

The last case where we invoke `new` on an instantiated type is similar and will give an error. So `Type` can only act as a free variable on uninstantiated generic types.

I believe this will make the language a bit better: using T, K and V for collections is OK, but for other non-collection types it might be good to use a more descriptive name instead of just a single letter.

This change still keeps the limitation that types `T` and `U` can't be declared at the top-level, though that might change soon.