### PR TITLE
Fix doc comment for Proc

### DIFF
--- a/src/proc.cr
+++ b/src/proc.cr
@@ -63,7 +63,7 @@
 # module Ticker
 #   # The callback for the user doesn't have a Void*
 #   @@box : Box(Int32 ->)
-
+#
 #   def self.on_tick(&callback : Int32 ->)
 #     # Since Proc is a {Void*, Void*}, we can't turn that into a Void*, so we
 #     # "box" it: we allocate memory and store the Proc there


### PR DESCRIPTION
Missing `#` results in borked overview - see https://crystal-lang.org/api/0.19.1/Proc.html