### PR TITLE
Fix iconv error handling

### DIFF
--- a/src/errno.cr
+++ b/src/errno.cr
@@ -19,6 +19,8 @@ end
 #
 # This class is the exception thrown when errno errors are encountered.
 class Errno < Exception
+  # Argument list too long
+  E2BIG = LibC::E2BIG
   # Operation not permitted
   EPERM = LibC::EPERM
   # No such file or directory


### PR DESCRIPTION
Corrects the detection of `iconv_open` returning an error, and raises Errno when `iconv_close` fails.

I also added the missing Errno::E2BIG constant.

fixes #3271 