### PR TITLE
StaticArray: Prohibit usage of default #initialize()  Fixes #3308

### DIFF
--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -217,4 +217,8 @@ struct StaticArray(T, N)
     end
     array
   end
+
+  private def initialize
+    # Never used.
+  end
 end


### PR DESCRIPTION
By providing an empty, private #initialize the compiler now rejects the example code.