### PR TITLE
Discussion: Crystal Install - Install Crystal Command Line Tools

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -17,6 +17,7 @@ class Crystal::Command
 
     Command:
         init                     generate a new project
+        install                  install a crystal project into your path
         build                    build an executable
         deps                     install project dependencies
         docs                     generate documentation


### PR DESCRIPTION
I wanted to start this discussion before I continued down the wrong path....

**tl;dr**
Crystal needs an easy way to install command line packages from local and remote sources.

**Why?**
Command line tools are at the heart of the developer ecosystem and are one of the reasons why many languages become popular. Let's have Crystal take a lesson from it's ruby cousin and allow for a native way to install global command line packages in the path with `crystal install`.

**How?**
Crystal would use a similar method as shards for fetching remote dependencies and would use the shard.yml to actually build and install the binary. The follow commands should work:

`crystal install git:https://github.com/ysbaddaden/minitest.cr.git`
`crystal install github:ysbaddaden/minitest.cr`
`crystal install /some/local/path`

The follow commands would:
1. Pull the repo into a temporary directory (download if remote).
2. Run `shards install` within the directory, therefore fetching all the dependencies.
3. Run `crystal build --release -o $PATH` and install each of the shards binaries into the local directory.

**Changes to crystal shards:**
In order for this to work, I would suggest adding a bin section to the shard file that would correlate with the bin name and the crystal file that contains the code for said binary.

```yml
# ...
bin:
  kemal: ./commands/kemal-cli.cr
# ...
```

*What's next?*
I would like this to drive a discussion with the Crystal core team and the crystal community before I move forward.