### PR TITLE
allow calling raise without arguments

### DIFF
--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -13,4 +13,8 @@ describe "Exception" do
     ex.to_s.should eq("foo? -- bar!")
     ex.inspect_with_backtrace.should contain("foo? -- bar!")
   end
+
+  it "can raise without message" do
+    expect_raises(Exception, "") { raise }
+  end
 end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -108,6 +108,10 @@ def raise(message : String) : NoReturn
   raise Exception.new(message)
 end
 
+def raise : NoReturn
+  raise Exception.new("")
+end
+
 # :nodoc:
 fun __crystal_raise_string(message : UInt8*)
   raise String.new(message)


### PR DESCRIPTION
sometimes I just want to `raise` to stop execution or do something stupid / debug ... would be nice if that worked

... not sure about the test location ... and was unable to run with 0.19.2 
```
bin/crystal spec spec/std/exception_spec.cr
cc: error: /app/src/ext/libcrystal.a: No such file or directory
Error: execution of command failed with code: 1: `cc -o "/root/.cache/crystal/crystal-run-spec.tmp" "${@}"  -rdynamic  -lxml2 -lpcre -lm -lgc -lpthread /app/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/lib -L/usr/local/lib`
```