### PR TITLE
Add File.chown and File.chmod

### DIFF
--- a/src/file/stat.cr
+++ b/src/file/stat.cr
@@ -85,7 +85,7 @@ class File
       io << " dev=0x"
       dev.to_s(16, io)
       io << ", ino=" << ino
-      io << ", mode=0"
+      io << ", mode=0o"
       mode.to_s(8, io)
       io << ", nlink=" << nlink
       io << ", uid=" << uid


### PR DESCRIPTION
Implements `File.chown(path, uid, gid)` as well as `File.chmod(path, mode)`.

I followed the POSIX definitions which made more sense in the context of File, instead of following the Ruby definitions that behave like the UNIX CLI tools: `chown uid, gid, *paths` and `chmod mode, *paths`. These last forms would be better into FileUtils (which is expected to behave like a shell).

I didn't:
- implement the `File#chown` and `File#chmod` counterparts (targeting a file descriptor, not a path). I'm not sure they are that useful (I never needed `fchown` nor `fchmod`).
- write specs for `chown` because it required special privileges or a particular computer setup. I manually tested it behaved as documented instead.