### PR TITLE
Add HTML.unescape [Closes #3107]

### DIFF
--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -27,4 +27,56 @@ describe "HTML" do
       str.should eq("nbsp&nbsp;space ")
     end
   end
+
+  describe ".unescape" do
+    it "does not change a safe string" do
+      str = HTML.unescape("safe_string")
+
+      str.should eq("safe_string")
+    end
+
+    it "unescapes dangerous characters from a string" do
+      str = HTML.unescape("&lt; &amp; &gt;")
+
+      str.should eq("< & >")
+    end
+
+    it "unescapes javascript example from a string" do
+      str = HTML.unescape("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;/script&gt;")
+
+      str.should eq("<script>alert('You are being hacked')</script>")
+    end
+
+    it "unescapes decimal encoded chars" do
+      str = HTML.unescape("&lt;&#104;&#101;llo world&gt;")
+
+      str.should eq("<hello world>")
+    end
+
+    it "unescapes with invalid entities" do
+      str = HTML.unescape("&&lt;&amp&gt;&quot&abcdefghijklmn")
+
+      str.should eq("&<&amp>&quot&abcdefghijklmn")
+    end
+
+    it "unescapes hex encoded chars" do
+      str = HTML.unescape("3 &#x0002B; 2 &#x0003D; 5")
+
+      str.should eq("3 + 2 = 5")
+    end
+
+    it "unescapes &nbsp;" do
+      str = HTML.unescape("nbsp&nbsp;space ")
+
+      str.should eq("nbsp space ")
+    end
+
+    it "unescapes Char::MAX_CODEPOINT" do
+      str = HTML.unescape("limit &#x10FFFF;")
+      str.should eq("limit 􏿿")
+
+      str = HTML.unescape("limit &#1114111;")
+      str.should eq("limit 􏿿")
+    end
+  end
 end

--- a/src/html.cr
+++ b/src/html.cr
@@ -30,4 +30,36 @@ module HTML
       io << SUBSTITUTIONS.fetch(char, char)
     end
   end
+
+  def self.unescape(string : String)
+    return string unless string.includes? '&'
+
+    string.gsub(/&(apos|amp|quot|gt|lt|nbsp|\#[0-9]+|\#[xX][0-9A-Fa-f]+);/) do |string, _match|
+      match = _match[1]
+      case match
+      when "apos" then "'"
+      when "amp"  then "&"
+      when "quot" then "\""
+      when "gt"   then ">"
+      when "lt"   then "<"
+      when "nbsp" then " "
+      when /\A#0*(\d+)\z/
+        n = $1.to_i
+        if n <= Char::MAX_CODEPOINT
+          n.unsafe_chr
+        else
+          "&##{$1};"
+        end
+      when /\A#x([0-9a-f]+)\z/i
+        n = $1.to_i(16)
+        if n <= Char::MAX_CODEPOINT
+          n.unsafe_chr
+        else
+          "&#x#{$1};"
+        end
+      else
+        "&#{match};"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Given the ruby implementation [CGI::unescapeHTML](https://github.com/ruby/ruby/blob/94dc3e71bb4782b68d49e463242d348b90ad9dca/lib/cgi/util.rb#L61-L115) and the comments on https://github.com/crystal-lang/crystal/pull/3226 I'm made this implementation of `HTML.unescape`. 

~~I tried to translate the unescape for hexadecimal codes without success~~
~~Someone can help me?~~ Thanks @chaniks 