### PR TITLE
Add `expect` syntax to spec

### DIFF
--- a/spec/std/spec/expect_spec.cr
+++ b/spec/std/spec/expect_spec.cr
@@ -1,0 +1,46 @@
+require "spec"
+
+describe "Expect Syntax" do
+  it "constructs a new instance targetting the given argument" do
+    expect(expect(7).target).to eq(7)
+  end
+
+  it "constructs a new instance targetting the value of the given block" do
+    block = ->{ 1 }
+    expect(expect(&block).target).to eq(1)
+  end
+
+  it "can be passed nil" do
+    expect(expect(nil).target).to be_nil
+  end
+
+  it "passes a valid positive expectation" do
+    expect(5).to eq(5)
+  end
+
+  it "passes a valid negative expectation" do
+    expect(5).not_to eq(4)
+  end
+
+  it "passes a valid negative expectation with a split infinitive" do
+    expect(5).to_not eq(4)
+  end
+
+  it "fails an invalid positive expectation" do
+    expect_raises(Spec::AssertionFailed, /expected: 4.+got: 5/m) do
+      expect(5).to eq(4)
+    end
+  end
+
+  it "fails an invalid negative expectation" do
+    expect_raises(Spec::AssertionFailed, /expected: actual_value != 5.+got: 5/m) do
+      expect(5).to_not eq(5)
+    end
+  end
+
+  context "when passed a block" do
+    it "passes a valid positive expectation" do
+      expect { 5 }.to eq(5)
+    end
+  end
+end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -286,22 +286,56 @@ module Spec
     end
   end
 
-  module ObjectExtensions
-    def should(expectation, file = __FILE__, line = __LINE__)
-      unless expectation.match self
-        fail(expectation.failure_message(self), file, line)
+  struct ExpectationTarget(T)
+    getter :target
+
+    # :nodoc:
+    def initialize(@target : T)
+    end
+
+    def to(expectation, file = __FILE__, line = __LINE__)
+      unless expectation.match @target
+        fail(expectation.failure_message(@target), file, line)
       end
     end
 
-    def should_not(expectation, file = __FILE__, line = __LINE__)
-      if expectation.match self
-        fail(expectation.negative_failure_message(self), file, line)
+    def to_not(expectation, file = __FILE__, line = __LINE__)
+      if expectation.match @target
+        fail(expectation.negative_failure_message(@target), file, line)
       end
+    end
+
+    # alias to `to_not`
+    def not_to(expectation, file = __FILE__, line = __LINE__)
+      to_not(expectation, file = __FILE__, line = __LINE__)
+    end
+  end
+
+  module ObjectExtensions
+    def should(expectation, file = __FILE__, line = __LINE__)
+      target = ExpectationTarget.new self
+      target.to(expectation, file, line)
+    end
+
+    def should_not(expectation, file = __FILE__, line = __LINE__)
+      target = ExpectationTarget.new self
+      target.to_not(expectation, file, line)
+    end
+  end
+
+  module ExpectExtentions
+    def expect(value)
+      ExpectationTarget.new(value)
+    end
+
+    def expect
+      ExpectationTarget.new(yield)
     end
   end
 end
 
 include Spec::Expectations
+include Spec::ExpectExtentions
 
 class Object
   include Spec::ObjectExtensions


### PR DESCRIPTION
Adding support to the `expect` syntax in specs.

The `expect` syntax was introduced [in the middle of 2012 into rspec](http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/) and the old syntax(`should`, `should_not`) was marked as deprecated in RSpec 3 in an effort to avoid Monkey Patching([read more here](http://rspec.info/blog/2013/07/the-plan-for-rspec-3/#what-about-the-old-expectationmock-syntax
)).

Because that(make tests without monkey patching) and because a liked the `expect` syntax I made this implementation pretty near of [rspec-expectations](https://github.com/rspec/rspec-expectations)