### PR TITLE
Fix: use __iconv on FreeBSD to skip invalid bytes

### DIFF
--- a/src/iconv.cr
+++ b/src/iconv.cr
@@ -8,10 +8,12 @@ struct Iconv
     original_from, original_to = from, to
 
     @skip_invalid = invalid == :skip
+    {% unless flag?(:freebsd) %}
     if @skip_invalid
       from = "#{from}//IGNORE"
       to = "#{to}//IGNORE"
     end
+    {% end %}
 
     @iconv = LibC.iconv_open(to, from)
 
@@ -40,6 +42,11 @@ struct Iconv
   end
 
   def convert(inbuf : UInt8**, inbytesleft : LibC::SizeT*, outbuf : UInt8**, outbytesleft : LibC::SizeT*)
+    {% if flag?(:freebsd) %}
+    if @skip_invalid
+      return LibC.__iconv(@iconv, inbuf, inbytesleft, outbuf, outbytesleft, LibC::ICONV_F_HIDE_INVALID, out invalids)
+    end
+    {% end %}
     LibC.iconv(@iconv, inbuf, inbytesleft, outbuf, outbytesleft)
   end
 

--- a/src/lib_c/x86_64-portbld-freebsd/c/iconv.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/iconv.cr
@@ -6,4 +6,7 @@ lib LibC
   fun iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*) : SizeT
   fun iconv_close(x0 : IconvT) : Int
   fun iconv_open(x0 : Char*, x1 : Char*) : IconvT
+
+  ICONV_F_HIDE_INVALID = 0x0001
+  fun __iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*, flags : UInt32, invalids : SizeT*) : SizeT
 end


### PR DESCRIPTION
The GNU extensions from "libiconv" aren't supported on FreeBSD. We must use `__iconv` to skip invalid bytes instead of adding `//IGNORE` to the charsets.

There are now only 3 specs failing. One is minor (EINVAL is reported instead of EILSEQ), the 2 others should raise, but they don't... so maybe there is another issue (maybe in the way we should report invalids with `__iconv`)?

refs #3271