### PR TITLE
improved error message in raise_not_initialized_in_all_initialize

### DIFF
--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -630,11 +630,11 @@ struct Crystal::TypeDeclarationProcessor
   end
 
   private def raise_not_initialized_in_all_initialize(node : ASTNode, name, owner)
-    node.raise "instance variable '#{name}' of #{owner} was not initialized in all of the 'initialize' methods, rendering it nilable"
+      node.raise "instance variable '#{name}' of #{owner} was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
   private def raise_not_initialized_in_all_initialize(location : Location, name, owner)
-    raise TypeException.new "instance variable '#{name}' of #{owner} was not initialized in all of the 'initialize' methods, rendering it nilable", location
+      raise TypeException.new "instance variable '#{name}' of #{owner} was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported.", location
   end
 
   private def raise_doesnt_explicitly_initializes(info, name, ivar)


### PR DESCRIPTION
Disucssion in #3387 raised idea that this error message could be improved. Here's an attempt to do that. 

Please scroll right on the diff. I've added "Indirect initialization is not supported." at the end but github isn't making that obvious.

Question: would it be better to say "Indirect initialization is not _currently_ supported." ? I'm not sure if there are plans to change that. 

cc @luislavena @kirbyfan64 @ozra  (commenters on original issue)
