### PR TITLE
[WIP] Support http server request streaming

### DIFF
--- a/spec/std/http/client/request_spec.cr
+++ b/spec/std/http/client/request_spec.cr
@@ -1,0 +1,227 @@
+require "spec"
+require "http/client/request"
+
+class HTTP::Client
+  describe Request do
+    it "serialize GET" do
+      headers = HTTP::Headers.new
+      headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
+      request = Request.new "GET", "/", headers
+
+      io = MemoryIO.new
+      request.to_io(io)
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
+      headers.should eq(orignal_headers)
+    end
+
+    it "serialize GET (with query params)" do
+      headers = HTTP::Headers.new
+      headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
+      request = Request.new "GET", "/greet?q=hello&name=world", headers
+
+      io = MemoryIO.new
+      request.to_io(io)
+      io.to_s.should eq("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
+      headers.should eq(orignal_headers)
+    end
+
+    it "serialize GET (with cookie)" do
+      headers = HTTP::Headers.new
+      headers["Host"] = "host.example.org"
+      orignal_headers = headers.dup
+      request = Request.new "GET", "/", headers
+      request.cookies << Cookie.new("foo", "bar")
+
+      io = MemoryIO.new
+      request.to_io(io)
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
+      headers.should eq(orignal_headers)
+    end
+
+    it "serialize GET (with cookies, from headers)" do
+      headers = HTTP::Headers.new
+      headers["Host"] = "host.example.org"
+      headers["Cookie"] = "foo=bar"
+      orignal_headers = headers.dup
+
+      request = Request.new "GET", "/", headers
+
+      io = MemoryIO.new
+      request.to_io(io)
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
+
+      request.cookies["foo"].value.should eq "bar" # Force lazy initialization
+
+      io.clear
+      request.to_io(io)
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
+
+      request.cookies["foo"] = "baz"
+      request.cookies["quux"] = "baz"
+
+      io.clear
+      request.to_io(io)
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=baz; quux=baz\r\n\r\n")
+      headers.should eq(orignal_headers)
+    end
+
+    it "serialize POST (with body)" do
+      request = Request.new "POST", "/", body: "thisisthebody"
+      io = MemoryIO.new
+      request.to_io(io)
+      io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
+    end
+
+    describe "keep-alive" do
+      it "is false by default in HTTP/1.0" do
+        request = Request.new "GET", "/", version: "HTTP/1.0"
+        request.keep_alive?.should be_false
+      end
+
+      it "is true in HTTP/1.0 if `Connection: keep-alive` header is present" do
+        headers = HTTP::Headers.new
+        headers["Connection"] = "keep-alive"
+        orignal_headers = headers.dup
+        request = Request.new "GET", "/", headers: headers, version: "HTTP/1.0"
+        request.keep_alive?.should be_true
+        headers.should eq(orignal_headers)
+      end
+
+      it "is true by default in HTTP/1.1" do
+        request = Request.new "GET", "/", version: "HTTP/1.1"
+        request.keep_alive?.should be_true
+      end
+
+      it "is false in HTTP/1.1 if `Connection: close` header is present" do
+        headers = HTTP::Headers.new
+        headers["Connection"] = "close"
+        orignal_headers = headers.dup
+        request = Request.new "GET", "/", headers: headers, version: "HTTP/1.1"
+        request.keep_alive?.should be_false
+        headers.should eq(orignal_headers)
+      end
+    end
+
+    describe "#path" do
+      it "returns parsed path" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.path.should eq("/api/v3/some/resource")
+      end
+
+      it "falls back to /" do
+        request = Request.new("GET", "/foo")
+        request.path = nil
+        request.path.should eq("/")
+      end
+    end
+
+    describe "#path=" do
+      it "sets path" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.path = "/api/v2/greet"
+        request.path.should eq("/api/v2/greet")
+      end
+
+      it "updates @resource" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.path = "/api/v2/greet"
+        request.resource.should eq("/api/v2/greet?filter=hello&world=test")
+      end
+
+      it "updates serialized form" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.path = "/api/v2/greet"
+
+        io = MemoryIO.new
+        request.to_io(io)
+        io.to_s.should eq("GET /api/v2/greet?filter=hello&world=test HTTP/1.1\r\n\r\n")
+      end
+    end
+
+    describe "#query" do
+      it "returns request's query" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.query.should eq("filter=hello&world=test")
+      end
+    end
+
+    describe "#query=" do
+      it "sets query" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.query = "q=isearchforsomething&locale=de"
+        request.query.should eq("q=isearchforsomething&locale=de")
+      end
+
+      it "updates @resource" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.query = "q=isearchforsomething&locale=de"
+        request.resource.should eq("/api/v3/some/resource?q=isearchforsomething&locale=de")
+      end
+
+      it "updates serialized form" do
+        request = Request.new("GET", "/api/v3/some/resource?filter=hello&world=test")
+        request.query = "q=isearchforsomething&locale=de"
+
+        io = MemoryIO.new
+        request.to_io(io)
+        io.to_s.should eq("GET /api/v3/some/resource?q=isearchforsomething&locale=de HTTP/1.1\r\n\r\n")
+      end
+    end
+
+    describe "#query_params" do
+      it "returns parsed HTTP::Params" do
+        request = Request.new("GET", "/api/v3/some/resource?foo=bar&foo=baz&baz=qux")
+        params = request.query_params
+
+        params["foo"].should eq("bar")
+        params.fetch_all("foo").should eq(["bar", "baz"])
+        params["baz"].should eq("qux")
+      end
+
+      it "happily parses when query is not a canonical url-encoded string" do
+        request = Request.new("GET", "/api/v3/some/resource?{\"hello\":\"world\"}")
+        params = request.query_params
+        params["{\"hello\":\"world\"}"].should eq("")
+        params.to_s.should eq("%7B%22hello%22%3A%22world%22%7D=")
+      end
+
+      it "affects #query when modified" do
+        request = Request.new("GET", "/api/v3/some/resource?foo=bar&foo=baz&baz=qux")
+        params = request.query_params
+
+        params["foo"] = "not-bar"
+        request.query.should eq("foo=not-bar&foo=baz&baz=qux")
+      end
+
+      it "updates @resource when modified" do
+        request = Request.new("GET", "/api/v3/some/resource?foo=bar&foo=baz&baz=qux")
+        params = request.query_params
+
+        params["foo"] = "not-bar"
+        request.resource.should eq("/api/v3/some/resource?foo=not-bar&foo=baz&baz=qux")
+      end
+
+      it "updates serialized form when modified" do
+        request = Request.new("GET", "/api/v3/some/resource?foo=bar&foo=baz&baz=qux")
+        params = request.query_params
+
+        params["foo"] = "not-bar"
+
+        io = MemoryIO.new
+        request.to_io(io)
+        io.to_s.should eq("GET /api/v3/some/resource?foo=not-bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")
+      end
+
+      it "is affected when #query is modified" do
+        request = Request.new("GET", "/api/v3/some/resource?foo=bar&foo=baz&baz=qux")
+        params = request.query_params
+
+        new_query = "foo=not-bar&foo=not-baz&not-baz=hello&name=world"
+        request.query = new_query
+        request.query_params.to_s.should eq(new_query)
+      end
+    end
+  end
+end

--- a/spec/std/http/server/handlers/deflate_handler_spec.cr
+++ b/spec/std/http/server/handlers/deflate_handler_spec.cr
@@ -4,7 +4,7 @@ require "http/server"
 describe HTTP::DeflateHandler do
   it "doesn't deflates if doesn't have 'deflate' in Accept-Encoding header" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
@@ -21,7 +21,7 @@ describe HTTP::DeflateHandler do
 
   it "deflates if has deflate in 'deflate' Accept-Encoding header" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, deflate, other"
 
     response = HTTP::Server::Response.new(io)
@@ -49,7 +49,7 @@ describe HTTP::DeflateHandler do
 
   it "deflates gzip if has deflate in 'deflate' Accept-Encoding header" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, gzip, other"
 
     response = HTTP::Server::Response.new(io)

--- a/spec/std/http/server/handlers/error_handler_spec.cr
+++ b/spec/std/http/server/handlers/error_handler_spec.cr
@@ -4,7 +4,7 @@ require "http/server"
 describe HTTP::ErrorHandler do
   it "rescues from exception" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
@@ -23,7 +23,7 @@ describe HTTP::ErrorHandler do
 
   it "can return a generic error message" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 

--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -10,7 +10,7 @@ end
 describe HTTP::Handler do
   it "responds with not found if there's no next handler" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -4,7 +4,7 @@ require "http/server"
 describe HTTP::LogHandler do
   it "logs" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
@@ -19,7 +19,7 @@ describe HTTP::LogHandler do
 
   it "does log errors" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -16,42 +16,42 @@ describe HTTP::StaticFileHandler do
   file_text = File.read "#{__DIR__}/static/test.txt"
 
   it "should serve a file" do
-    response = handle HTTP::Request.new("GET", "/test.txt")
+    response = handle HTTP::Server::Request.new("GET", "/test.txt")
     response.status_code.should eq(200)
     response.body.should eq(File.read("#{__DIR__}/static/test.txt"))
   end
 
   it "should list directory's entries" do
-    response = handle HTTP::Request.new("GET", "/")
+    response = handle HTTP::Server::Request.new("GET", "/")
     response.status_code.should eq(200)
     response.body.should match(/test.txt/)
   end
 
   it "should not serve a not found file" do
-    response = handle HTTP::Request.new("GET", "/not_found_file.txt")
+    response = handle HTTP::Server::Request.new("GET", "/not_found_file.txt")
     response.status_code.should eq(404)
   end
 
   it "should not serve a not found directory" do
-    response = handle HTTP::Request.new("GET", "/not_found_dir/")
+    response = handle HTTP::Server::Request.new("GET", "/not_found_dir/")
     response.status_code.should eq(404)
   end
 
   it "should not serve a file as directory" do
-    response = handle HTTP::Request.new("GET", "/test.txt/")
+    response = handle HTTP::Server::Request.new("GET", "/test.txt/")
     response.status_code.should eq(404)
   end
 
   it "should handle only GET and HEAD method" do
     %w(GET HEAD).each do |method|
-      response = handle HTTP::Request.new(method, "/test.txt")
+      response = handle HTTP::Server::Request.new(method, "/test.txt")
       response.status_code.should eq(200)
     end
 
     %w(POST PUT DELETE).each do |method|
-      response = handle HTTP::Request.new(method, "/test.txt")
+      response = handle HTTP::Server::Request.new(method, "/test.txt")
       response.status_code.should eq(404)
-      response = handle HTTP::Request.new(method, "/test.txt"), false
+      response = handle HTTP::Server::Request.new(method, "/test.txt"), false
       response.status_code.should eq(405)
       response.headers["Allow"].should eq("GET, HEAD")
     end
@@ -59,14 +59,14 @@ describe HTTP::StaticFileHandler do
 
   it "should expand a request path" do
     %w(../test.txt ../../test.txt test.txt/../test.txt a/./b/../c/../../test.txt).each do |path|
-      response = handle HTTP::Request.new("GET", "/#{path}")
+      response = handle HTTP::Server::Request.new("GET", "/#{path}")
       response.status_code.should eq(302)
       response.headers["Location"].should eq("/test.txt")
     end
 
     # directory
     %w(.. ../ ../.. a/.. a/.././b/../).each do |path|
-      response = handle HTTP::Request.new("GET", "/#{path}")
+      response = handle HTTP::Server::Request.new("GET", "/#{path}")
       response.status_code.should eq(302)
       response.headers["Location"].should eq("/")
     end
@@ -74,13 +74,13 @@ describe HTTP::StaticFileHandler do
 
   it "should unescape a request path" do
     %w(test%2Etxt %74%65%73%74%2E%74%78%74).each do |path|
-      response = handle HTTP::Request.new("GET", "/#{path}")
+      response = handle HTTP::Server::Request.new("GET", "/#{path}")
       response.status_code.should eq(200)
       response.body.should eq(file_text)
     end
 
     %w(%2E%2E/test.txt found%2F%2E%2E%2Ftest%2Etxt).each do |path|
-      response = handle HTTP::Request.new("GET", "/#{path}")
+      response = handle HTTP::Server::Request.new("GET", "/#{path}")
       response.status_code.should eq(302)
       response.headers["Location"].should eq("/test.txt")
     end
@@ -88,7 +88,7 @@ describe HTTP::StaticFileHandler do
 
   it "should return 400" do
     %w(%00 test.txt%00).each do |path|
-      response = handle HTTP::Request.new("GET", "/#{path}")
+      response = handle HTTP::Server::Request.new("GET", "/#{path}")
       response.status_code.should eq(400)
     end
   end

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -4,7 +4,7 @@ require "http/server"
 describe HTTP::WebSocketHandler do
   it "returns not found if the request is not an websocket upgrade" do
     io = MemoryIO.new
-    request = HTTP::Request.new("GET", "/")
+    request = HTTP::Server::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
@@ -26,7 +26,7 @@ describe HTTP::WebSocketHandler do
         "Connection" =>        {{connection}},
         "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
       }
-      request = HTTP::Request.new("GET", "/", headers: headers)
+      request = HTTP::Server::Request.new("GET", "/", headers: headers)
       response = HTTP::Server::Response.new(io)
       context = HTTP::Server::Context.new(request, response)
 

--- a/spec/std/http/server/request_spec.cr
+++ b/spec/std/http/server/request_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
-require "http/request"
+require "http/client/request"
 
-module HTTP
+class HTTP::Server
   describe Request do
     it "serialize GET" do
       headers = HTTP::Headers.new
@@ -68,10 +68,10 @@ module HTTP
     end
 
     it "serialize POST (with body)" do
-      request = Request.new "POST", "/", body: "thisisthebody"
+      request = Request.new "POST", "/", body_io: MemoryIO.new("thisisthebody")
       io = MemoryIO.new
       request.to_io(io)
-      io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
+      io.to_s.should eq("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nd\r\nthisisthebody\r\n0\r\n\r\n")
     end
 
     it "parses GET" do

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -140,6 +140,18 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n0\r\n\r\n")
       end
 
+      it "closes request io when flushing" do
+        request_io = MemoryIO.new("hello")
+        response_io = MemoryIO.new
+        response = Response.new(response_io)
+        response.request_io = request_io
+        response.print("Hello")
+        response.flush
+        response_io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n")
+        response.close
+        response_io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n0\r\n\r\n")
+      end
+
       it "wraps output" do
         io = MemoryIO.new
         response = Response.new(io)

--- a/spec/std/oauth/signature_spec.cr
+++ b/spec/std/oauth/signature_spec.cr
@@ -16,7 +16,7 @@ describe OAuth::Signature do
 
   describe "base string" do
     it "computes without port in host" do
-      request = HTTP::Request.new "POST", "/some/path"
+      request = HTTP::Client::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
       tls = false
       ts = "1234"
@@ -29,7 +29,7 @@ describe OAuth::Signature do
     end
 
     it "computes with port in host" do
-      request = HTTP::Request.new "POST", "/some/path"
+      request = HTTP::Client::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host:5678"
       tls = false
       ts = "1234"
@@ -42,7 +42,7 @@ describe OAuth::Signature do
     end
 
     it "computes when TLS" do
-      request = HTTP::Request.new "POST", "/some/path"
+      request = HTTP::Client::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
       tls = true
       ts = "1234"
@@ -57,7 +57,7 @@ describe OAuth::Signature do
 
   # https://dev.twitter.com/oauth/overview/creating-signatures
   it "does twitter sample" do
-    request = HTTP::Request.new "POST", "/1/statuses/update.json?include_entities=true", body: "status=Hello%20Ladies%20%2b%20Gentlemen%2c%20a%20signed%20OAuth%20request%21"
+    request = HTTP::Client::Request.new "POST", "/1/statuses/update.json?include_entities=true", body: "status=Hello%20Ladies%20%2b%20Gentlemen%2c%20a%20signed%20OAuth%20request%21"
     request.headers["Host"] = "api.twitter.com"
     request.headers["Content-type"] = "application/x-www-form-urlencoded"
     tls = true

--- a/spec/std/oauth2/access_token_spec.cr
+++ b/spec/std/oauth2/access_token_spec.cr
@@ -42,7 +42,7 @@ class OAuth2::AccessToken
 
     it "authenticates request" do
       token = Bearer.new("access token", 3600, "refresh token")
-      request = HTTP::Request.new "GET", "/"
+      request = HTTP::Client::Request.new "GET", "/"
       token.authenticate request, false
       request.headers["Authorization"].should eq("Bearer access token")
     end
@@ -112,7 +112,7 @@ class OAuth2::AccessToken
       headers["Host"] = "localhost:4000"
 
       token = Mac.new("3n2-YaAzH67YH9UJ-9CnJ_PS-vSy1MRLM-q7TZknPw", 3600, "hmac-sha-256", "i-pt1Lir-yAfUdXbt-AXM1gMupK7vDiOK1SZGWkASDc")
-      request = HTTP::Request.new "GET", "/some/resource.json", headers
+      request = HTTP::Client::Request.new "GET", "/some/resource.json", headers
       token.authenticate request, false
       auth = request.headers["Authorization"]
       (auth =~ /MAC id=".+?", nonce=".+?", ts=".+?", mac=".+?"/).should be_truthy

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -286,8 +286,8 @@ class HTTP::Client
   # end
   # client.get "/"
   # ```
-  def before_request(&callback : HTTP::Request ->)
-    before_request = @before_request ||= [] of (HTTP::Request ->)
+  def before_request(&callback : Request ->)
+    before_request = @before_request ||= [] of (Request ->)
     before_request << callback
   end
 
@@ -439,10 +439,10 @@ class HTTP::Client
   #
   # ```
   # client = HTTP::Client.new "www.example.com"
-  # response = client.exec HTTP::Request.new("GET", "/")
+  # response = client.exec HTTP::Client::Request.new("GET", "/")
   # response.body # => "..."
   # ```
-  def exec(request : HTTP::Request) : HTTP::Client::Response
+  def exec(request : Request) : Response
     execute_callbacks(request)
     exec_internal(request)
   end
@@ -461,11 +461,11 @@ class HTTP::Client
   #
   # ```
   # client = HTTP::Client.new "www.example.com"
-  # client.exec(HTTP::Request.new("GET", "/")) do |response|
+  # client.exec(HTTP::Client::Request.new("GET", "/")) do |response|
   #   response.body_io.gets # => "..."
   # end
   # ```
-  def exec(request : HTTP::Request, &block)
+  def exec(request : Request, &block)
     execute_callbacks(request)
     exec_internal(request) do |response|
       yield response
@@ -476,7 +476,7 @@ class HTTP::Client
     decompress = set_defaults request
     request.to_io(socket)
     socket.flush
-    HTTP::Client::Response.from_io(socket, ignore_body: request.ignore_body?, decompress: decompress) do |response|
+    Response.from_io(socket, ignore_body: request.ignore_body?, decompress: decompress) do |response|
       value = yield response
       response.body_io.try &.close
       close unless response.keep_alive?
@@ -561,7 +561,7 @@ class HTTP::Client
   end
 
   private def new_request(method, path, headers, body)
-    HTTP::Request.new(method, path, headers, body).tap do |request|
+    Request.new(method, path, headers, body).tap do |request|
       request.headers["Host"] ||= host_header
     end
   end
@@ -675,5 +675,6 @@ end
 require "socket"
 require "uri"
 require "base64"
+require "./client/request"
 require "./client/response"
 require "./common"

--- a/src/http/client/request.cr
+++ b/src/http/client/request.cr
@@ -1,8 +1,8 @@
-require "./common"
+require "../common"
 require "uri"
 require "http/params"
 
-class HTTP::Request
+class HTTP::Client::Request
   getter method : String
   getter headers : Headers
   getter body : String?
@@ -50,29 +50,6 @@ class HTTP::Request
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
     HTTP.serialize_headers_and_body(io, headers, @body, nil, @version)
-  end
-
-  # :nodoc:
-  record BadRequest
-
-  # Returns:
-  # * nil: EOF
-  # * BadRequest: bad request
-  # * HTTP::Request: successfully parsed
-  def self.from_io(io)
-    request_line = io.gets
-    return unless request_line
-
-    parts = request_line.split
-    return BadRequest.new unless parts.size == 3
-
-    method, resource, http_version = parts
-    HTTP.parse_headers_and_body(io) do |headers, body|
-      return new method, resource, headers, body.try &.gets_to_end, http_version
-    end
-
-    # Unexpected end of http request
-    BadRequest.new
   end
 
   # Lazily parses and return the request's path component.

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -272,8 +272,6 @@ module HTTP
   end
 end
 
-require "./request"
-require "./client/response"
 require "./headers"
 require "./content"
 require "./cookie"

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -133,7 +133,7 @@ module HTTP
     # Create a new instance by parsing the `Cookie` and `Set-Cookie`
     # headers in the given `HTTP::Headers`.
     #
-    # See `HTTP::Request#cookies` and `HTTP::Client::Response#cookies`.
+    # See `HTTP::Server::Request#cookies` and `HTTP::Client::Response#cookies`.
     def self.from_headers(headers) : self
       new.tap { |cookies| cookies.fill_from_headers(headers) }
     end

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -10,7 +10,7 @@ require "./common"
 # An HTTP server.
 #
 # A server is given a handler that receives an `HTTP::Server::Context` that holds
-# the `HTTP::Request` to process and must in turn configure and write to an `HTTP::Server::Response`.
+# the `HTTP::Server::Request` to process and must in turn configure and write to an `HTTP::Server::Response`.
 #
 # The `HTTP::Server::Response` object has `status` and `headers` properties that can be
 # configured before writing the response body. Once response output is written,

--- a/src/http/server/context.cr
+++ b/src/http/server/context.cr
@@ -1,7 +1,7 @@
 class HTTP::Server
   # Instances of this class are passed to an `HTTP::Server` handler.
   class Context
-    # The `HTTP::Request` to process.
+    # The `HTTP::Server::Request` to process.
     getter request : Request
 
     # The `HTTP::Server::Response` to configure and write to.

--- a/src/http/server/request.cr
+++ b/src/http/server/request.cr
@@ -1,0 +1,118 @@
+require "../common"
+require "uri"
+require "http/params"
+
+class HTTP::Server::Request
+  getter method : String
+  getter headers : Headers
+  getter body_io : IO?
+  getter version : String
+  @cookies : Cookies?
+  @query_params : Params?
+  @uri : URI?
+  @body : String?
+
+  def initialize(@method : String, @resource : String, headers : Headers? = nil, @body_io = nil, @version = "HTTP/1.1")
+    @headers = headers.try(&.dup) || Headers.new
+  end
+
+  def body
+    @body ||= (@body_io.try(&.gets_to_end) || "")
+  end
+
+  # Returns a convenience wrapper around querying and setting cookie related
+  # headers, see `HTTP::Cookies`.
+  def cookies
+    @cookies ||= Cookies.from_headers(headers)
+  end
+
+  # Returns a convenience wrapper around querying and setting query params,
+  # see `HTTP::Params`.
+  def query_params
+    @query_params ||= parse_query_params
+  end
+
+  def resource
+    update_uri
+    @uri.try(&.full_path) || @resource
+  end
+
+  def keep_alive?
+    HTTP.keep_alive?(self)
+  end
+
+  def ignore_body?
+    @method == "HEAD"
+  end
+
+  def to_io(io)
+    io << @method << " " << resource << " " << @version << "\r\n"
+    cookies = @cookies
+    headers = cookies ? cookies.add_request_headers(@headers) : @headers
+    HTTP.serialize_headers_and_body(io, headers, nil, @body_io, @version)
+  end
+
+  # :nodoc:
+  record BadRequest
+
+  # Returns:
+  # * nil: EOF
+  # * BadRequest: bad request
+  # * HTTP::Server::Request: successfully parsed
+  def self.from_io(io)
+    request_line = io.gets
+    return unless request_line
+
+    parts = request_line.split
+    return BadRequest.new unless parts.size == 3
+
+    method, resource, http_version = parts
+    HTTP.parse_headers_and_body(io) do |headers, body|
+      return new method, resource, headers, body, http_version
+    end
+
+    # Unexpected end of http request
+    BadRequest.new
+  end
+
+  # Lazily parses and return the request's path component.
+  def path
+    uri.path || "/"
+  end
+
+  # Sets request's path component.
+  def path=(path)
+    uri.path = path
+  end
+
+  # Lazily parses and returns the request's query component.
+  def query
+    update_uri
+    uri.query
+  end
+
+  # Sets request's query component.
+  def query=(value)
+    uri.query = value
+    update_query_params
+    value
+  end
+
+  private def uri
+    (@uri ||= URI.parse(@resource)).not_nil!
+  end
+
+  private def parse_query_params
+    HTTP::Params.parse(uri.query || "")
+  end
+
+  private def update_query_params
+    return unless @query_params
+    @query_params = parse_query_params
+  end
+
+  private def update_uri
+    return unless @query_params
+    uri.query = query_params.to_s
+  end
+end

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -19,17 +19,18 @@ class HTTP::Server::RequestProcessor
 
     begin
       until @wants_close
-        request = HTTP::Request.from_io(input)
+        request = HTTP::Server::Request.from_io(input)
 
         # EOF
         break unless request
 
-        if request.is_a?(HTTP::Request::BadRequest)
+        if request.is_a?(HTTP::Server::Request::BadRequest)
           response.respond_with_error("Bad Request", 400)
           response.close
           return
         end
 
+        response.request_io = request.body_io
         response.version = request.version
         response.reset
         response.headers["Connection"] = "keep-alive" if request.keep_alive?

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -251,7 +251,7 @@ class HTTP::WebSocket::Protocol
     headers["Sec-WebSocket-Key"] = Base64.strict_encode(StaticArray(UInt8, 16).new { rand(256).to_u8 })
 
     path = "/" if path.empty?
-    handshake = HTTP::Request.new("GET", path, headers)
+    handshake = HTTP::Client::Request.new("GET", path, headers)
     handshake.to_io(socket)
     handshake_response = HTTP::Client::Response.from_io(socket)
     unless handshake_response.status_code == 101

--- a/src/oauth2/access_token/access_token.cr
+++ b/src/oauth2/access_token/access_token.cr
@@ -51,7 +51,7 @@ abstract class OAuth2::AccessToken
     @expires_in = expires_in.to_i64
   end
 
-  abstract def authenticate(request : HTTP::Request, tls)
+  abstract def authenticate(request : HTTP::Client::Request, tls)
 
   def authenticate(client : HTTP::Client)
     client.before_request do |request|

--- a/src/oauth2/access_token/bearer.cr
+++ b/src/oauth2/access_token/bearer.cr
@@ -9,7 +9,7 @@ class OAuth2::AccessToken::Bearer < OAuth2::AccessToken
     "Bearer"
   end
 
-  def authenticate(request : HTTP::Request, tls)
+  def authenticate(request : HTTP::Client::Request, tls)
     request.headers["Authorization"] = "Bearer #{access_token}"
   end
 

--- a/src/oauth2/access_token/mac.cr
+++ b/src/oauth2/access_token/mac.cr
@@ -20,7 +20,7 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
     "Mac"
   end
 
-  def authenticate(request : HTTP::Request, tls)
+  def authenticate(request : HTTP::Client::Request, tls)
     ts = Time.now.epoch
     nonce = "#{ts - @issued_at}:#{SecureRandom.hex}"
     method = request.method


### PR DESCRIPTION
(work in progress: do not merge)

Right now `HTTP::Server` has a problem: it consumes the whole request body into a string, every time. So if you post a big body into a server then the memory consumption will go pretty high.

To solve this, this PR splits `HTTP::Request` into two classes: `HTTP::Client::Request` and `HTTP::Server::Request`. The `HTTP::Server::Request` exposes two properties:
* `body_io : IO?` an `IO` to the request's body. Will be `nil` if the request has no body (for example in a `GET` request)
* `body : String`: if you call this, it will consume the `body_io` and give you back a String (and memoize it)

The server will automatically read the request for you (without storing it into a string) if you write to the response. I tried posting big strings into the server and memory consumption would go up to a few gigas before, and now it remains stable at 1 MB.

This is a WIP because:
* Maybe we could remove the `body` property, because invoking it can potentially bring back the old problem. Also invoking `request.body_io.try &.gets_to_end` isn't very complex either, and it makes you think "Hmm... this could potentially load the whole thing into memory". But in most cases you could feed the `IO` directly to a parse, for example to parse JSON or multipart data.
* I copied HTTP::Request into the other two types so a lot of methods are currently duplicated, but maybe it doesn't make sense to retain the same methods in both types

Once we merge this, one last thing remains: supporting streaming http client requests. That is, if you want to do a big POST and instead of building a big string you want to write directly into the socket, you can't do that right now. I imagine providing a callback to `HTTP::Client::Request` where you write to the `IO` would be OK. But this is the subject of another PR :-)

This change is of course backwards incompatible, but necessary.