### PR TITLE
Fix: allow i486 and i586 for target machine ABI

### DIFF
--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -38,7 +38,7 @@ class LLVM::TargetMachine
     case triple
     when /x86_64|amd64/
       ABI::X86_64.new(self)
-    when /i386|i686/
+    when /i386|i486|i586|i686/
       ABI::X86.new(self)
     else
       raise "Unsupported ABI for target triple: #{triple}"


### PR DESCRIPTION
This prevents compilation on Alpine Linux 32 bits.