### PR TITLE
Add IO::MultiWriter

### DIFF
--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -24,7 +24,7 @@ private class PartialReaderIO
 end
 
 describe "IO::Delimited" do
-  describe ".read" do
+  describe "#read" do
     it "doesn't read past the limit" do
       io = MemoryIO.new("abcderzzrfgzr")
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
@@ -96,7 +96,7 @@ describe "IO::Delimited" do
     end
   end
 
-  describe ".write" do
+  describe "#write" do
     it "raises" do
       delimited = IO::Delimited.new(MemoryIO.new, read_delimiter: "zr")
       expect_raises(IO::Error, "Can't write to IO::Delimited") do
@@ -105,7 +105,7 @@ describe "IO::Delimited" do
     end
   end
 
-  describe ".close" do
+  describe "#close" do
     it "stops reading" do
       io = MemoryIO.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr")

--- a/spec/std/io/multi_writer_spec.cr
+++ b/spec/std/io/multi_writer_spec.cr
@@ -1,0 +1,52 @@
+require "spec"
+
+describe "IO::MultiWriter" do
+  describe "#write" do
+    it "writes to multiple IOs" do
+      io1 = MemoryIO.new
+      io2 = MemoryIO.new
+
+      writer = IO::MultiWriter.new(io1, io2)
+
+      writer.puts "foo bar"
+
+      io1.to_s.should eq("foo bar\n")
+      io2.to_s.should eq("foo bar\n")
+    end
+  end
+
+  describe "#read" do
+    it "raises" do
+      writer = IO::MultiWriter.new(Array(IO).new)
+
+      expect_raises(IO::Error, "Can't read from IO::MultiWriter") do
+        writer.read_byte
+      end
+    end
+  end
+
+  describe "#close" do
+    it "stops reading" do
+      io = MemoryIO.new
+      writer = IO::MultiWriter.new(io)
+
+      writer.close
+
+      expect_raises(IO::Error, "closed") do
+        writer.puts "foo"
+      end
+
+      io.closed?.should eq(false)
+      io.to_s.should eq("")
+    end
+
+    it "closes the underlying stream if sync_close is true" do
+      io = MemoryIO.new
+      writer = IO::MultiWriter.new(io, sync_close: true)
+
+      writer.close
+
+      io.closed?.should eq(true)
+    end
+  end
+end

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
 describe "IO::Sized" do
-  describe ".read" do
+  describe "#read" do
     it "doesn't read past the limit when reading char-by-char" do
       io = MemoryIO.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)
@@ -47,7 +47,7 @@ describe "IO::Sized" do
     end
   end
 
-  describe ".write" do
+  describe "#write" do
     it "raises" do
       sized = IO::Sized.new(MemoryIO.new, read_size: 5)
       expect_raises(IO::Error, "Can't write to IO::Sized") do
@@ -56,7 +56,7 @@ describe "IO::Sized" do
     end
   end
 
-  describe ".close" do
+  describe "#close" do
     it "stops reading" do
       io = MemoryIO.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -1,0 +1,52 @@
+module IO
+  # An IO which writes to a number of underlying writer IOs.
+  #
+  # ```
+  # io1 = IO::Memory.new
+  # io2 = IO::Memory.new
+  # writer = IO::MultiWriter.new(io1, io2)
+  # writer.puts "foo bar"
+  # io1.to_s # => "foo bar\n"
+  # io2.to_s # => "foo bar\n"
+  # ```
+  class MultiWriter
+    include IO
+
+    # If `sync_close` is true, closing this IO will close all of the underlying
+    # IOs.
+    property? sync_close
+    getter? closed = false
+
+    @writers : Array(IO)
+
+    # Creates a new `IO::MultiWriter` which writes to *writers*. If
+    # *sync_close* is set, calling `#close` calls `#close` on all underlying
+    # writers.
+    def initialize(@writers : Array(IO), @sync_close = false)
+    end
+
+    # Creates a new `IO::MultiWriter` which writes to *writers*. If
+    # *sync_close* is set, calling `#close` calls `#close` on all underlying
+    # writers.
+    def initialize(*writers : IO, @sync_close = false)
+      @writers = writers.map(&.as(IO)).to_a
+    end
+
+    def write(slice : Slice(UInt8))
+      check_open
+
+      @writers.each { |writer| writer.write(slice) }
+    end
+
+    def read(slice : Slice(UInt8))
+      raise IO::Error.new("Can't read from IO::MultiWriter")
+    end
+
+    def close
+      return if @closed
+      @closed = true
+
+      @writers.each { |writer| writer.close } if sync_close?
+    end
+  end
+end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -7,6 +7,9 @@
 # When you are developing the system, however, you probably want to know about the program’s internal state,
 # and would set the Logger to DEBUG.
 #
+# If logging to multiple locations is required, an `IO::MultiWriter` can be
+# used.
+#
 # ### Example
 #
 # ```crystal


### PR DESCRIPTION
Useful for writing log output to multiple locations (stdout + file) or any sort of parallel processing of IO data.