### PR TITLE
Support HTTP server and client request streaming (single HTTP::Request)

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -47,6 +47,10 @@ module HTTP
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get("http://www.example.com"))
+    typeof(Client.post("http://www.example.com", body: MemoryIO.new))
+    typeof(Client.new("host").post("/", body: MemoryIO.new))
+    typeof(Client.post("http://www.example.com", body: Bytes[65]))
+    typeof(Client.new("host").post("/", body: Bytes[65]))
 
     describe "from URI" do
       it "has sane defaults" do

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -140,6 +140,16 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n0\r\n\r\n")
       end
 
+      it "closes request io when flushing" do
+        request_io = MemoryIO.new("hello")
+        response_io = MemoryIO.new
+        response = Response.new(response_io)
+        response.request_io = request_io
+        response.print("Hello")
+        response.flush
+        request_io.closed?.should be_true
+      end
+
       it "wraps output" do
         io = MemoryIO.new
         response = Response.new(io)

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -30,6 +30,7 @@ class HTTP::Server::RequestProcessor
           return
         end
 
+        response.request_io = request.body_io
         response.version = request.version
         response.reset
         response.headers["Connection"] = "keep-alive" if request.keep_alive?

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -30,7 +30,6 @@ class HTTP::Server::RequestProcessor
           return
         end
 
-        response.request_io = request.body_io
         response.version = request.version
         response.reset
         response.headers["Connection"] = "keep-alive" if request.keep_alive?
@@ -55,6 +54,10 @@ class HTTP::Server::RequestProcessor
         output.flush
 
         break unless request.keep_alive?
+
+        # Skip request body in case the handler
+        # didn't read it all, for the next request
+        request.body.try &.close
       end
     rescue ex : Errno
       # IO-related error, nothing to do

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -32,10 +32,6 @@ class HTTP::Server
     # body. If not set, the default value is 200 (OK).
     property status_code : Int32
 
-    # Hold a reference to the request's IO: before writing anything
-    # into the response we must close this IO to advance the pointer in the socket
-    protected property request_io : IO?
-
     # :nodoc:
     def initialize(@io : IO, @version = "HTTP/1.1")
       @headers = Headers.new
@@ -120,10 +116,6 @@ class HTTP::Server
     end
 
     protected def write_headers
-      # Make sure to finish reading the request
-      # before writing anything to the response
-      request_io.try &.close
-
       status_message = HTTP.default_status_message_for(@status_code)
       @io << @version << " " << @status_code << " " << status_message << "\r\n"
       headers.each do |name, values|

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -80,7 +80,9 @@ struct OAuth::Signature
     body = request.body
     content_type = request.headers["Content-type"]?
     if body && content_type == "application/x-www-form-urlencoded"
-      params.add_query body
+      form = body.gets_to_end
+      params.add_query form
+      request.body = form
     end
 
     params


### PR DESCRIPTION
This is an alternative implementation to #3395

I realized there's no need to have two distinct types representing an `HTTP::Request`. I copy its docs:

```cr
# An HTTP request.
#
# It serves both to perform requests by an `HTTP::Client` and to
# represent requests received by an `HTTP::Server`.
#
# In the case of an `HTTP::Server`, `#body` will always raise
# and `#body_io` will optionally have an `IO` representing the request
# body. This will be `nil` if the request has no body.
```

With that we make sure users always invoke `body_io` to stream the request body. With two request types we could remove the `body` method completely, so it'll be a compile-time error, but this exception will be pretty evident as soon as you test your endpoint, so I think that's OK.

Having a single type is better in my opinion:

1. It's simpler: less types to learn and deal with.
2. It's backwards compatible.
3. You can easily implement a proxy: just pass the request to an `HTTP::Client` (with two types you'd need to correctly convert one request type to another)
4. It's the same way in Go, so that means this way of modelling things has been successful in another language. This also means that we can now stream request data with an `HTTP::Client`. For example we can pass an open `File` as a request's `body_io`, which covers the file-upload scenario (for other cases one would probably have to use a pipe).