### PR TITLE
fix gets call with delimiter exactly at limit

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -94,6 +94,13 @@ describe "IO::Buffered" do
     io.gets('a', 3).should be_nil
   end
 
+  it "does gets with char and limit without off-by-one" do
+    io = BufferedWrapper.new(MemoryIO.new("test\nabc"))
+    io.gets('a', 5).to_s.size.should eq 5
+    io = BufferedWrapper.new(MemoryIO.new("test\nabc"))
+    io.gets('a', 6).to_s.size.should eq 6
+  end
+
   it "does gets with char and limit when not found in buffer" do
     io = BufferedWrapper.new(MemoryIO.new(("a" * (IO::Buffered::BUFFER_SIZE + 10)) + "b"))
     io.gets('b', 2).should eq("aa")

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -96,9 +96,9 @@ describe "IO::Buffered" do
 
   it "does gets with char and limit without off-by-one" do
     io = BufferedWrapper.new(MemoryIO.new("test\nabc"))
-    io.gets('a', 5).to_s.size.should eq 5
+    io.gets('a', 5).should eq("test\n")
     io = BufferedWrapper.new(MemoryIO.new("test\nabc"))
-    io.gets('a', 6).to_s.size.should eq 6
+    io.gets('a', 6).should eq("test\na")
   end
 
   it "does gets with char and limit when not found in buffer" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -21,10 +21,6 @@ private class SimpleMemoryIO
     @pos = 0
   end
 
-  def pos=(p : Int)
-    @pos = p
-  end
-
   def self.new(string : String, max_read = nil)
     io = new(string.bytesize, max_read: max_read)
     io << string

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -461,10 +461,10 @@ describe IO do
       it "does gets on unicode with char and limit without off-by-one" do
         io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
-        io.gets('a', 5).to_s.size.should eq 5
+        io.gets('a', 5).should eq("test\n")
         io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
-        io.gets('a', 6).to_s.size.should eq 6
+        io.gets('a', 6).should eq("test\na")
       end
 
       it "gets with limit" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -21,6 +21,10 @@ private class SimpleMemoryIO
     @pos = 0
   end
 
+  def pos=(p : Int)
+    @pos = p
+  end
+
   def self.new(string : String, max_read = nil)
     io = new(string.bytesize, max_read: max_read)
     io << string
@@ -456,6 +460,15 @@ describe IO do
             io.gets.should eq("你好我是人\n")
           end
         end
+      end
+
+      it "does gets on unicode with char and limit without off-by-one" do
+        io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
+        io.set_encoding("UCS-2LE")
+        io.gets('a', 5).to_s.size.should eq 5
+        io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
+        io.set_encoding("UCS-2LE")
+        io.gets('a', 6).to_s.size.should eq 6
       end
 
       it "gets with limit" do

--- a/spec/std/io/memory_io_spec.cr
+++ b/spec/std/io/memory_io_spec.cr
@@ -88,6 +88,13 @@ describe "MemoryIO" do
     io.gets(3).should be_nil
   end
 
+  it "does gets with char and limit without off-by-one" do
+    io = MemoryIO.new("test\nabc")
+    io.gets('a', 5).to_s.size.should eq 5
+    io = MemoryIO.new("test\nabc")
+    io.gets('a', 6).to_s.size.should eq 6
+  end
+
   it "raises if invoking gets with negative limit" do
     io = MemoryIO.new("hello\nworld\n")
     expect_raises ArgumentError, "negative limit" do

--- a/spec/std/io/memory_io_spec.cr
+++ b/spec/std/io/memory_io_spec.cr
@@ -90,9 +90,9 @@ describe "MemoryIO" do
 
   it "does gets with char and limit without off-by-one" do
     io = MemoryIO.new("test\nabc")
-    io.gets('a', 5).to_s.size.should eq 5
+    io.gets('a', 5).should eq("test\n")
     io = MemoryIO.new("test\nabc")
-    io.gets('a', 6).to_s.size.should eq 6
+    io.gets('a', 6).should eq("test\na")
   end
 
   it "raises if invoking gets with negative limit" do

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -55,7 +55,7 @@ module IO::Buffered
     index = @in_buffer_rem.index(delimiter_byte)
     if index
       # If we find it past the limit, limit the result
-      if index > limit
+      if index >= limit
         index = limit
       else
         index += 1
@@ -91,7 +91,7 @@ module IO::Buffered
 
         index = @in_buffer_rem.index(delimiter_byte)
         if index
-          if index > limit
+          if index >= limit
             index = limit
           else
             index += 1

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -163,7 +163,7 @@ module IO
       index = @out_slice.index(delimiter)
       if index
         # If we find it past the limit, limit the result
-        if index > limit
+        if index >= limit
           index = limit
         else
           index += 1
@@ -194,7 +194,7 @@ module IO
 
           index = @out_slice.index(delimiter)
           if index
-            if index > limit
+            if index >= limit
               index = limit
             else
               index += 1

--- a/src/io/memory_io.cr
+++ b/src/io/memory_io.cr
@@ -141,7 +141,7 @@ class MemoryIO
 
     index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord)
     if index
-      if index > limit
+      if index >= limit
         index = limit
       else
         index += 1
@@ -150,7 +150,7 @@ class MemoryIO
       index = @bytesize - @pos
       return nil if index == 0
 
-      if index > limit
+      if index >= limit
         index = limit
       end
     end


### PR DESCRIPTION
If a gets call with a limit and delimiter was run on a string whose delimiter was exactly at limit,
crystal would increase the perceived location of delimiter,
returning a string larger by one than the supplied limit.
Second of the supplied test cases 