### PR TITLE
String#index and String#rindex with Regex

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -571,6 +571,22 @@ describe "String" do
         assert { "日本語日本語".index("本語", 2).should eq(4) }
       end
     end
+
+    describe "by regex" do
+      assert { "string 12345".index(/\d+/).should eq(7) }
+      assert { "12345".index(/\d/).should eq(0) }
+      assert { "Hello, world!".index(/\d/).should be_nil }
+      assert { "abcdef".index(/[def]/).should eq(3) }
+      assert { "日本語日本語".index(/本語/).should eq(1) }
+
+      describe "with offset" do
+        assert { "abcDef".index(/[A-Z]/).should eq(3) }
+        assert { "foobarbaz".index(/ba/, -5).should eq(6) }
+        assert { "Foo".index(/[A-Z]/, 1).should be_nil }
+        assert { "foo".index(/o/, 2).should eq(2) }
+        assert { "日本語日本語".index(/本語/, 2).should eq(4) }
+      end
+    end
   end
 
   describe "rindex" do
@@ -595,6 +611,18 @@ describe "String" do
         assert { "foo baro baz".rindex("o b", 6).should eq(2) }
         assert { "foo baro baz".rindex("fg").should be_nil }
         assert { "日本語日本語".rindex("日本", 2).should eq(0) }
+      end
+    end
+
+    describe "by regex" do
+      assert { "bbbb".rindex(/b/).should eq(3) }
+      assert { "a43b53".rindex(/\d+/).should eq(4) }
+      assert { "bbbb".rindex(/\d/).should be_nil }
+
+      describe "with offset" do
+        assert { "bbbb".rindex(/b/, -3).should eq(2) }
+        assert { "bbbb".rindex(/b/, -1235).should be_nil }
+        assert { "日本語日本語".rindex(/日本/, 2).should eq(0) }
       end
     end
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2088,6 +2088,8 @@ class String
   # "Hello, World".index('Z')    # => nil
   # "Hello, World".index("o", 5) # => 8
   # "Hello, World".index("H", 2) # => nil
+  # "Hello, World".index(/[ ]+/) # => 5
+  # "Hello, World".index(/d+/)   # => nil
   # ```
   def index(search : Char, offset = 0)
     # If it's ASCII we can delegate to slice
@@ -2126,6 +2128,14 @@ class String
     end
 
     nil
+  end
+
+  # ditto
+  def index(search : Regex, offset = 0)
+    offset += size if offset < 0
+    return nil unless 0 <= offset <= size
+
+    self.match(search, offset).try &.begin
   end
 
   # Returns the index of the _last_ appearance of *c* in the string,
@@ -2175,6 +2185,19 @@ class String
     end
 
     last_index
+  end
+
+  # ditto
+  def rindex(search : Regex, offset = 0)
+    offset += size if offset < 0
+    return nil unless 0 <= offset <= size
+
+    match_result = nil
+    self[0, self.size - offset].scan(search) do |match_data|
+      match_result = match_data
+    end
+
+    match_result.try &.begin(0)
   end
 
   def byte_index(byte : Int, offset = 0)


### PR DESCRIPTION
Includes specs.
Allows you to do things like `"ab d 64 aef".index(/\d+/)`.