### PR TITLE
Fix #divmod

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -91,6 +91,33 @@ describe "Float" do
 
     assert { 1.4.divmod(0.3)[0].should eq(4) }
     assert { 1.4.divmod(0.3)[1].should be_close(0.2, 0.00001) }
+
+    assert { -1.2.divmod(0.3)[0].should eq(-4) }
+    assert { -1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
+
+    assert { -1.3.divmod(0.3)[0].should eq(-5) }
+    assert { -1.3.divmod(0.3)[1].should be_close(0.2, 0.00001) }
+
+    assert { -1.4.divmod(0.3)[0].should eq(-5) }
+    assert { -1.4.divmod(0.3)[1].should be_close(0.1, 0.00001) }
+
+    assert { 1.2.divmod(-0.3)[0].should eq(-4) }
+    assert { 1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
+
+    assert { 1.3.divmod(-0.3)[0].should eq(-5) }
+    assert { 1.3.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
+
+    assert { 1.4.divmod(-0.3)[0].should eq(-5) }
+    assert { 1.4.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
+
+    assert { -1.2.divmod(-0.3)[0].should eq(4) }
+    assert { -1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
+
+    assert { -1.3.divmod(-0.3)[0].should eq(4) }
+    assert { -1.3.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
+
+    assert { -1.4.divmod(-0.3)[0].should eq(4) }
+    assert { -1.4.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
   end
 
   describe "to_s" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -82,6 +82,17 @@ describe "Float" do
     assert { 1.0.fdiv(0).should eq 1.0/0.0 }
   end
 
+  describe "divmod" do
+    assert { 1.2.divmod(0.3)[0].should eq(4) }
+    assert { 1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
+
+    assert { 1.3.divmod(0.3)[0].should eq(4) }
+    assert { 1.3.divmod(0.3)[1].should be_close(0.1, 0.00001) }
+
+    assert { 1.4.divmod(0.3)[0].should eq(4) }
+    assert { 1.4.divmod(0.3)[1].should be_close(0.2, 0.00001) }
+  end
+
   describe "to_s" do
     it "does to_s for f64" do
       12.34.to_s.should eq("12.34")

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -104,8 +104,16 @@ describe "Number" do
 
   it "divides and calculs the modulo" do
     10.divmod(2).should eq({5, 0})
+    11.divmod(2).should eq({5, 1})
+
     10.divmod(-2).should eq({-5, 0})
     11.divmod(-2).should eq({-6, -1})
+
+    -10.divmod(2).should eq({-5, 0})
+    -11.divmod(2).should eq({-6, 1})
+
+    -10.divmod(-2).should eq({5, 0})
+    -11.divmod(-2).should eq({5, -1})
   end
 
   it "compare the numbers" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -103,6 +103,9 @@ describe "Number" do
   end
 
   it "divides and calculs the modulo" do
+    11.divmod(3).should eq({3, 2})
+    11.divmod(-3).should eq({-4, -1})
+
     10.divmod(2).should eq({5, 0})
     11.divmod(2).should eq({5, 1})
 

--- a/src/number.cr
+++ b/src/number.cr
@@ -158,7 +158,7 @@ struct Number
   # 11.divmod(-3) # => {-3, 2}
   # ```
   def divmod(number)
-    {(self / number).to_i, self % number}
+    {(self / number).floor, self % number}
   end
 
   # Implements the comparison operator.

--- a/src/number.cr
+++ b/src/number.cr
@@ -158,7 +158,7 @@ struct Number
   # 11.divmod(-3) # => {-3, 2}
   # ```
   def divmod(number)
-    {self / number, self % number}
+    {(self / number).to_i, self % number}
   end
 
   # Implements the comparison operator.

--- a/src/number.cr
+++ b/src/number.cr
@@ -155,7 +155,7 @@ struct Number
   #
   # ```
   # 11.divmod(3)  # => {3, 2}
-  # 11.divmod(-3) # => {-3, 2}
+  # 11.divmod(-3) # => {-4, 1}
   # ```
   def divmod(number)
     {(self / number).floor, self % number}


### PR DESCRIPTION
Two changes:

* The first element of the tuple should be an integer (quotient rounded down), rather than a float containing the quotient itself.

* Documentation for negative integer divmod is now correct, and has additional tests for the examples.

Before:

```crystal
1.4.divmod(0.3)[0]
# => 4.6666…
```

After:

```crystal
1.4.divmod(0.3)[0]
# => 4
```