### PR TITLE
Fix doc typo for Number#divmod

### DIFF
--- a/src/number.cr
+++ b/src/number.cr
@@ -155,7 +155,7 @@ struct Number
   #
   # ```
   # 11.divmod(3)  # => {3, 2}
-  # 11.divmod(-3) # => {-4, 1}
+  # 11.divmod(-3) # => {-4, -1}
   # ```
   def divmod(number)
     {(self / number).floor, self % number}


### PR DESCRIPTION
As per https://github.com/crystal-lang/crystal/pull/3426#issuecomment-254293080.