### PR TITLE
Support LLVM 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ SPEC_SOURCES := $(shell find spec -name '*.cr')
 FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )$(if $(debug),-d )
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 SHELL = bash
-LLVM_CONFIG_FINDER := command -v llvm-config-3.8 || command -v llvm-config38 || (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.8*) command -v llvm-config;; *) false;; esac)) || command -v llvm-config-3.6 || command -v llvm-config36 || command -v llvm-config-3.5 || command -v llvm-config35 || command -v llvm-config
+LLVM_CONFIG_FINDER := \
+	[ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+	command -v llvm-config-3.9 || command -v llvm-config39 || (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.9*) command -v llvm-config;; *) false;; esac)) || \
+	command -v llvm-config-3.8 || command -v llvm-config38 || (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.8*) command -v llvm-config;; *) false;; esac)) || \
+	command -v llvm-config-3.6 || command -v llvm-config36 || \
+	command -v llvm-config-3.5 || command -v llvm-config35 || \
+	command -v llvm-config
 LLVM_CONFIG := $(shell $(LLVM_CONFIG_FINDER))
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
@@ -16,7 +22,9 @@ LIB_CRYSTAL_TARGET = src/ext/libcrystal.a
 CFLAGS += -fPIC
 
 ifeq (${LLVM_CONFIG},)
-$(error Could not locate llvm-config, make sure it is installed and in your PATH)
+$(error Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
+else
+  $(info Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)])
 endif
 
 .PHONY: all

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1177,7 +1177,7 @@ module Crystal
       end
 
       ex = Call.new(Path.global("TypeCastError"), "new", StringInterpolation.new(pieces))
-      call = Call.global("raise", ex)
+      call = Call.global("raise", ex).at(node)
       call = @program.normalize(call)
 
       meta_vars = MetaVars.new

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -293,12 +293,9 @@ module Crystal
       end
 
       @modules.each do |name, mod|
-        if @debug
-          add_compile_unit_metadata(mod, name == "" ? "main" : name)
-        end
+        push_debug_info_metadata(mod) if @debug
 
         mod.dump if dump_all_llvm || name =~ dump_llvm_regex
-        # puts mod
 
         # Always run verifications so we can catch bugs earlier and more often.
         # We can probably remove this, or only enable this when compiling in

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -15,9 +15,6 @@ module Crystal
   PERSONALITY_NAME   = "__crystal_personality"
   GET_EXCEPTION_NAME = "__crystal_get_exception"
 
-  DataLayout32 = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:32:32-n8:16:32"
-  DataLayout64 = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
-
   class Program
     def run(code, filename = nil)
       parser = Parser.new(code)
@@ -227,7 +224,7 @@ module Crystal
     end
 
     def data_layout
-      @program.has_flag?("x86_64") ? DataLayout64 : DataLayout32
+      @program.target_machine.data_layout
     end
 
     class CodegenWellKnownFunctions < Visitor

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -331,7 +331,9 @@ module Crystal
 
     protected def optimize(llvm_mod)
       fun_pass_manager = llvm_mod.new_function_pass_manager
-      fun_pass_manager.add_target_data target_machine.data_layout
+      {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+        fun_pass_manager.add_target_data target_machine.data_layout
+      {% end %}
       pass_manager_builder.populate fun_pass_manager
       fun_pass_manager.run llvm_mod
       module_pass_manager.run llvm_mod
@@ -342,7 +344,9 @@ module Crystal
     private def module_pass_manager
       @module_pass_manager ||= begin
         mod_pass_manager = LLVM::ModulePassManager.new
-        mod_pass_manager.add_target_data target_machine.data_layout
+        {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+          mod_pass_manager.add_target_data target_machine.data_layout
+        {% end %}
         pass_manager_builder.populate mod_pass_manager
         mod_pass_manager
       end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -247,7 +247,7 @@ module Crystal
 
       # First write bitcodes: it breaks if we paralellize it
       unless multithreaded
-        Crystal.timing("Codegen (cyrstal)", @stats) do
+        Crystal.timing("Codegen (crystal)", @stats) do
           units.each &.write_bitcode
         end
       end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -492,7 +492,7 @@ class Crystal::Call
         arg_type.tuple_types.each_with_index do |tuple_type, index|
           num = NumberLiteral.new(index)
           num.type = program.int32
-          tuple_indexer = Call.new(arg.exp, "[]", num)
+          tuple_indexer = Call.new(arg.exp, "[]", num).at(arg)
           parent_visitor.prepare_call(tuple_indexer)
           tuple_indexer.recalculate
           new_args << tuple_indexer
@@ -508,7 +508,7 @@ class Crystal::Call
           sym = SymbolLiteral.new(entry.name)
           sym.type = program.symbol
           program.symbols.add sym.value
-          tuple_indexer = Call.new(arg.exp, "[]", sym)
+          tuple_indexer = Call.new(arg.exp, "[]", sym).at(arg)
           parent_visitor.prepare_call(tuple_indexer)
           tuple_indexer.recalculate
           new_args << tuple_indexer
@@ -531,7 +531,7 @@ class Crystal::Call
         vars << arg
         args << arg
       end
-      block = Block.new(vars, Call.new(block_arg.clone, "call", args))
+      block = Block.new(vars, Call.new(block_arg.clone, "call", args).at(block_arg))
       block.vars = self.before_vars
       self.block = block
     else

--- a/src/compiler/crystal/semantic/conversions.cr
+++ b/src/compiler/crystal/semantic/conversions.cr
@@ -1,7 +1,7 @@
 module Crystal::Conversions
   def self.numeric_argument(node, var, visitor, unaliased_type, expected_type, actual_type)
     convert_call_name = "to_#{unaliased_type.kind}"
-    convert_call = Call.new(var, convert_call_name)
+    convert_call = Call.new(var, convert_call_name).at(node)
 
     begin
       convert_call.accept visitor
@@ -34,7 +34,7 @@ module Crystal::Conversions
   end
 
   def self.try_to_unsafe(target, visitor)
-    unsafe_call = Call.new(target, "to_unsafe")
+    unsafe_call = Call.new(target, "to_unsafe").at(target)
     begin
       unsafe_call.accept visitor
     rescue ex : TypeException

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -194,7 +194,7 @@ class Crystal::Def
         end
       end
 
-      call = Call.new(nil, name, new_args)
+      call = Call.new(nil, name, new_args).at(self)
       call.expansion = true
       body << call
 

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -314,13 +314,13 @@ module Crystal
       end
 
       if capacity <= 64
-        call = Call.new(Path.global(["String", "Builder"]), "new")
+        call = Call.new(Path.global(["String", "Builder"]), "new").at(node)
       else
-        call = Call.new(Path.global(["String", "Builder"]), "new", NumberLiteral.new(capacity))
+        call = Call.new(Path.global(["String", "Builder"]), "new", NumberLiteral.new(capacity)).at(node)
       end
 
       node.expressions.each do |piece|
-        call = Call.new(call, "<<", piece)
+        call = Call.new(call, "<<", piece).at(node)
       end
       Call.new(call, "to_s").at(node)
     end
@@ -638,7 +638,7 @@ module Crystal
         end
       end
 
-      Call.new(cond, "===", right_side)
+      Call.new(cond, "===", right_side).at(obj)
     end
 
     macro check_implicit_obj(type)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1056,7 +1056,7 @@ module Crystal
         obj.accept self
       end
 
-      call = Call.new(obj, node.name)
+      call = Call.new(obj, node.name).at(obj)
       prepare_call(call)
 
       # Check if it's ->LibFoo.foo, so we deduce the type from that method

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -192,7 +192,7 @@ module Crystal
       end
 
       assign = Assign.new(obj.clone, alloc)
-      init = Call.new(obj.clone, "initialize", new_vars, named_args: named_args)
+      init = Call.new(obj.clone, "initialize", new_vars, named_args: named_args).at(self)
 
       # If the initialize yields, call it with a block
       # that yields those arguments.

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -81,12 +81,12 @@ module Crystal
         when NumberLiteral, Var, InstanceVar
           transform_many node.args
           left = obj
-          right = Call.new(middle.clone, node.name, node.args)
+          right = Call.new(middle.clone, node.name, node.args).at(middle)
         else
           temp_var = program.new_temp_var
           temp_assign = Assign.new(temp_var.clone, middle)
-          left = Call.new(obj.obj, obj.name, temp_assign)
-          right = Call.new(temp_var.clone, node.name, node.args)
+          left = Call.new(obj.obj, obj.name, temp_assign).at(obj.obj)
+          right = Call.new(temp_var.clone, node.name, node.args).at(node)
         end
         node = And.new(left, right)
         node = node.transform self

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -562,7 +562,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def define_enum_question_method(enum_type, member, is_flags)
     method_name = is_flags ? "includes?" : "=="
-    a_def = Def.new("#{member.name.underscore}?", body: Call.new(Var.new("self").at(member), method_name, Path.new(member.name).at(member))).at(member)
+    body = Call.new(Var.new("self").at(member), method_name, Path.new(member.name).at(member)).at(member)
+    a_def = Def.new("#{member.name.underscore}?", body: body).at(member)
     enum_type.add_def a_def
   end
 

--- a/src/llvm/function_pass_manager.cr
+++ b/src/llvm/function_pass_manager.cr
@@ -2,9 +2,11 @@ class LLVM::FunctionPassManager
   def initialize(@unwrap : LibLLVM::PassManagerRef)
   end
 
-  def add_target_data(target_data)
-    LibLLVM.add_target_data target_data, self
-  end
+  {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+    def add_target_data(target_data)
+      LibLLVM.add_target_data target_data, self
+    end
+  {% end %}
 
   def run(mod : Module)
     changed = false

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -296,4 +296,16 @@ lib LibLLVM
     fun create_target_data_layout = LLVMCreateTargetDataLayout(t : TargetMachineRef) : TargetDataRef
     fun set_module_data_layout = LLVMSetModuleDataLayout(mod : ModuleRef, data : TargetDataRef)
   {% end %}
+
+  {% if LibLLVM::IS_35 %}
+    DEBUG_METADATA_VERSION = 1
+  {% elsif LibLLVM::IS_36 %}
+    DEBUG_METADATA_VERSION = 2
+  {% else %}
+    DEBUG_METADATA_VERSION = 3
+  {% end %}
+
+  enum ModuleFlag : Int32
+    Warning = 2
+  end
 end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -244,7 +244,6 @@ lib LibLLVM
   fun initialize_ipa = LLVMInitializeIPA(r : PassRegistryRef)
   fun initialize_code_gen = LLVMInitializeCodeGen(r : PassRegistryRef)
   fun initialize_target = LLVMInitializeTarget(r : PassRegistryRef)
-  fun add_target_data = LLVMAddTargetData(td : TargetDataRef, pm : PassManagerRef)
   fun get_next_target = LLVMGetNextTarget(t : TargetRef) : TargetRef
   fun get_default_target_triple = LLVMGetDefaultTargetTriple : UInt8*
   fun print_module_to_string = LLVMPrintModuleToString(mod : ModuleRef) : UInt8*
@@ -276,4 +275,8 @@ lib LibLLVM
   fun dispose_pass_manager_builder = LLVMPassManagerBuilderDispose(PassManagerBuilderRef)
   fun set_volatile = LLVMSetVolatile(value : ValueRef, volatile : UInt32)
   fun set_alignment = LLVMSetAlignment(value : ValueRef, bytes : UInt32)
+
+  {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+    fun add_target_data = LLVMAddTargetData(td : TargetDataRef, pm : PassManagerRef)
+  {% end %}
 end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -10,8 +10,12 @@ class LLVM::Module
     LibLLVM.set_target(self, target)
   end
 
-  def data_layout=(data)
-    LibLLVM.set_data_layout(self, data)
+  def data_layout=(data : TargetData)
+    {% if LibLLVM::IS_38 || LibLLVM::IS_36 || LibLLVM::IS_35 %}
+      LibLLVM.set_data_layout(self, data.to_data_layout_string)
+    {% else %}
+      LibLLVM.set_module_data_layout(self, data)
+    {% end %}
   end
 
   def dump

--- a/src/llvm/module_pass_manager.cr
+++ b/src/llvm/module_pass_manager.cr
@@ -3,9 +3,11 @@ class LLVM::ModulePassManager
     @unwrap = LibLLVM.pass_manager_create
   end
 
-  def add_target_data(target_data)
-    LibLLVM.add_target_data target_data, self
-  end
+  {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+    def add_target_data(target_data)
+      LibLLVM.add_target_data target_data, self
+    end
+  {% end %}
 
   def run(mod)
     LibLLVM.run_pass_manager(self, mod) != 0

--- a/src/llvm/target_data.cr
+++ b/src/llvm/target_data.cr
@@ -25,4 +25,8 @@ struct LLVM::TargetData
   def offset_of_element(struct_type, element)
     LibLLVM.offset_of_element(self, struct_type, element)
   end
+
+  def to_data_layout_string
+    String.new(LibLLVM.copy_string_rep_of_target_data(self))
+  end
 end

--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -8,8 +8,14 @@ class LLVM::TargetMachine
   end
 
   def data_layout
-    layout = LibLLVM.get_target_machine_data(self)
-    layout ? TargetData.new(layout) : raise "Missing layout for #{self}"
+    @layout ||= begin
+      layout = {% if LibLLVM::IS_38 || LibLLVM::IS_36 || LibLLVM::IS_35 %}
+                 LibLLVM.get_target_machine_data(self)
+               {% else %}
+                 LibLLVM.create_target_data_layout(self)
+               {% end %}
+      layout ? TargetData.new(layout) : raise "Missing layout for #{self}"
+    end
   end
 
   def triple


### PR DESCRIPTION
Breaking changes (introduced by LLVM 3.9):
- LLVMAddTargetData was removed (deprecated since 3.7).
- LLVMGetTargetMachineData was removed (replaced by `LLVMCreateTargetDataLayout`).

Also:
- drop custom data layouts to favor the LLVM default ones;
- kept support for 3.5, 3.6 and 3.8 along with 3.9;
- nice LLVM version macros (copied from Rust);
- select `llvm-config` to use with `make LLVM_CONFIG=llvm-config-3.6` to select a specific LLVM version among the many that are installed.

Errors:
- [ ]  #crashing compiler specs (not reproducible when run directly)

  `libgcc_s` crashes when trying to unwind from an exception raised in a compiler spec. Not reproducible when run directly. Not reproducible with 3.8 and lower.

- [x] `--debug` fails with `Module validation failed: subprogram definitions must have a compile unit`

  We used to generate the DICompileUnit after generating the IR code, but LLVM reverses the DICompileUnit and DISubprogram relationships. It now refers to the CU from the SP. We thus have to genrate the CU as soon as possible (i.e. immediately after instanciating the DIBuilder).

- [x] `--debug` fail with `inlinable function call in a function with debug info must have a !dbg location`

closes #3237 