### PR TITLE
Allows running spec within Docker container

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ RUN \
   apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54 && \
   echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list && \
   apt-get update && \
-  apt-get install -y crystal gcc pkg-config libssl-dev git make && \
+  apt-get install -y crystal gcc pkg-config libssl-dev libxml2-dev libyaml-dev git make && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/crystal


### PR DESCRIPTION
`crystal spec` commands now supports JUnit XML output, which requires libxml2 to be installed.

With current defaults, the command fails due missing `libxml2-dev` dependencies in the image.

This change ensures `libxml2-dev` is installed along the other dependencies so can be used for both building executables and running specs.

Without this change, attempt to use official docker image fails with the following:

```
# crystal spec
/usr/bin/ld: cannot find -lxml2
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc -o "/root/.cache/crystal/crystal-run-spec.tmp" "${@}"  -rdynamic  -lyaml -lxml2 -lpcre -lm -lgc -lpthread /opt/crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/lib -L/usr/local/lib`
```

But with this change:

```
# crystal spec
..............................................

Finished in 2.21 milliseconds
46 examples, 0 failures, 0 errors, 0 pending
```

I'm still not sure if including xml is desired for the *release* container, but considering might others need XML support during compilation too perhaps is not a bad idea?

Thank you :heart: :heart: :heart: :heart: 