### PR TITLE
Updates doc styles for a slightly more modern appeal

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -8,7 +8,7 @@ html, body {
 }
 
 body {
-  font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
+  font-family: "Avenir", "Tahoma", "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
   color: #333;
 }
 
@@ -21,11 +21,22 @@ a:visited {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin: 30px 0;
+  margin: 35px 0 25px;
+  color: #444444;
 }
 
 h1.type-name {
   color: #47266E;
+  margin: 20px 0 30px;
+  background-color: #F8F8F8;
+  padding: 10px 12px;
+  border: 1px solid #EBEBEB;
+  border-radius: 2px;
+}
+
+h2 {
+  border-bottom: 1px solid #E6E6E6;
+  padding-bottom: 5px;
 }
 
 #types-list, #main-content {
@@ -39,6 +50,7 @@ h1.type-name {
   left: 0;
   width: 20%;
   background-color: #2E1052;
+  padding: 0 0 30px;
 }
 
 #types-list #search-box {
@@ -55,8 +67,38 @@ h1.type-name {
   line-height: 1.2;
   width: 100%;
   border: 0;
-  border-radius: 50px;
   outline: 0;
+  border-radius: 2px;
+  box-shadow: 0px 3px 5px rgba(0,0,0,.25);
+  transition: box-shadow .12s;
+}
+
+#types-list input:focus {
+  box-shadow: 0px 5px 6px rgba(0,0,0,.5);
+}
+
+#types-list input::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #C8C8C8;
+  font-size: 14px;
+  text-indent: 2px;
+}
+
+#types-list input::-moz-placeholder { /* Firefox 19+ */
+  color: #C8C8C8;
+  font-size: 14px;
+  text-indent: 2px;
+}
+
+#types-list input:-ms-input-placeholder { /* IE 10+ */
+  color: #C8C8C8;
+  font-size: 14px;
+  text-indent: 2px;
+}
+
+#types-list input:-moz-placeholder { /* Firefox 18- */
+  color: #C8C8C8;
+  font-size: 14px;
+  text-indent: 2px;
 }
 
 #types-list ul {
@@ -78,7 +120,12 @@ h1.type-name {
   display: block;
   padding: 5px 15px 5px 30px;
   text-decoration: none;
-  color: #fff;
+  color: #F8F4FD;
+  transition: color .14s;
+}
+
+#types-list a:focus {
+  outline: 1px solid #D1B7F1;
 }
 
 #types-list .current > a,
@@ -189,6 +236,8 @@ h1.type-name {
   border: 1px solid #f0f0f0;
   text-decoration: none;
   border-radius: 3px;
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  transition: background .15s, border-color .15s;
 }
 
 .superclass-hierarchy .superclass a:hover,
@@ -200,6 +249,10 @@ h1.type-name {
 
 .entry-summary .summary {
   padding-left: 32px;
+}
+
+.entry-summary .summary p {
+  margin: 12px 0 16px;
 }
 
 .entry-summary a {
@@ -219,6 +272,7 @@ h1.type-name {
   background-color: #f8f8f8;
   color: #47266E;
   border: 1px solid #f0f0f0;
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
   transition: .2s ease-in-out;
 }
 
@@ -275,8 +329,9 @@ pre {
   line-height: 1.45;
   overflow: auto;
   color: #333;
-  background: #f7f7f7;
+  background: #fdfdfd;
   font-size: 14px;
+  border: 1px solid #eee;
 }
 
 code {

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -54,7 +54,7 @@ h2 {
 }
 
 #types-list #search-box {
-  padding: 5px;
+  padding: 8px 9px;
 }
 
 #types-list input {

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -51,6 +51,7 @@ h2 {
   width: 20%;
   background-color: #2E1052;
   padding: 0 0 30px;
+  box-shadow: inset -3px 0 4px rgba(0,0,0,.35);
 }
 
 #types-list #search-box {


### PR DESCRIPTION
- updates to more modern font-stack.
- optimizes margin for headers and changes color
  to lighter shade of gray.
- adds box around `h1`.
- adds border under `h2`s.
- adds bottom padding to types list.
- adds slight color transition on hover for types-list links and code signatures
- changes style for search input and adds subtle
  shadowing on focus.
- adds monospace fonts to signatures.
- decreases top margin for summary paragraphs.
- adds light border to `pre` elements.

**Before**  
<img width="1280" alt="array-before" src="https://cloud.githubusercontent.com/assets/9119269/19616710/a3479adc-97d7-11e6-89ca-2715b131ccea.png">

**After**   
<img width="1280" alt="array-after" src="https://cloud.githubusercontent.com/assets/9119269/19616715/c1e9ac82-97d7-11e6-8e6b-e5c8108cb188.png">

<br /><hr /><br />

**Before**   
<img width="1280" alt="array-instance-methods-before" src="https://cloud.githubusercontent.com/assets/9119269/19616719/cabc4dc4-97d7-11e6-9fe4-f09caa24f48d.png">


**After**   
<img width="1280" alt="array-instance-methods-after" src="https://cloud.githubusercontent.com/assets/9119269/19616722/d3485c1c-97d7-11e6-88c9-9327a8c1b08c.png">

