### PR TITLE
Update gitignore template for .DS_Store files

### DIFF
--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -9,3 +9,5 @@
 # Dependencies will be locked in application that uses them
 /shard.lock
 <% end %>
+
+.DS_Store


### PR DESCRIPTION
These are [meaningless files](https://en.wikipedia.org/wiki/.DS_Store) present in OSX directories.