### PR TITLE
Include Enumerable in CSV

### DIFF
--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -121,6 +121,12 @@ describe CSV do
     end
   end
 
+  it "can do map_with_index (and other enumerable methods)" do
+    csv = new_csv headers: true
+    values = csv.map_with_index { |csv, index| "#{csv.row[0]}-#{index}" }
+    values.should eq(["1-0", "3-1", "5-2"])
+  end
+
   it "can do new with block" do
     CSV.new(%(one, two\n1, 2\n3, 4\n5), headers: true, strip: true) do |csv|
       csv["one"].should eq("1")

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -59,6 +59,8 @@ class CSV
   DEFAULT_SEPARATOR  = ','
   DEFAULT_QUOTE_CHAR = '"'
 
+  include Enumerable(self)
+
   # Parses a CSV or IO into an array.
   # takes optional *separator* and *quote_char* arguments for defining
   # non-standard csv cell separators and quote characters


### PR DESCRIPTION
Include Enumerable in CSV, and add a test for `map_with_index`.