### PR TITLE
Fixes and improvements for debugging output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 LIB_CRYSTAL_SOURCES = $(shell find src/ext -name '*.c')
 LIB_CRYSTAL_OBJS = $(subst .c,.o,$(LIB_CRYSTAL_SOURCES))
 LIB_CRYSTAL_TARGET = src/ext/libcrystal.a
-CFLAGS += -fPIC
+CFLAGS += -fPIC $(if $(debug),-g -O0)
+CXXFLAGS += $(if $(debug),-g -O0)
 
 ifeq (${LLVM_CONFIG},)
 $(error Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
@@ -83,7 +84,7 @@ $(O)/crystal: deps $(SOURCES)
 	$(BUILD_PATH) $(EXPORTS) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
-	$(CXX) -c -o $@ $< `$(LLVM_CONFIG) --cxxflags`
+	$(CXX) -c $(CXXFLAGS) -o $@ $< `$(LLVM_CONFIG) --cxxflags`
 
 $(LIB_CRYSTAL_TARGET): $(LIB_CRYSTAL_OBJS)
 	ar -rcs $@ $^

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -158,8 +158,6 @@ module Crystal
       builder = LLVM::Builder.new
       @builder = wrap_builder builder
 
-      @dbg_kind = LibLLVM.get_md_kind_id("dbg", 3)
-
       @modules = {"" => @main_mod} of String => LLVM::Module
       @types_to_modules = {} of Type => LLVM::Module
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -98,15 +98,23 @@ class Crystal::CodeGenVisitor
         set_current_debug_location target_def if @debug
         alloca_vars target_def.vars, target_def, args, context.closure_parent_context
 
+        create_local_copy_of_fun_args(target_def, self_type, args, is_fun_literal, is_closure)
+
         if @debug
           in_alloca_block do
+            args_offset = !is_fun_literal && self_type.passed_as_self? ? 2 : 1
+            location = target_def.location
             context.vars.each do |name, var|
-              declare_variable(name, var.type, var.pointer, target_def)
+              if name == "self"
+                declare_parameter(name, var.type, 1, var.pointer, location)
+              elsif arg_no = args.index { |arg| arg.name == name }
+                declare_parameter(name, var.type, arg_no + args_offset, var.pointer, location)
+              else
+                declare_variable(name, var.type, var.pointer, location)
+              end
             end
           end
         end
-
-        create_local_copy_of_fun_args(target_def, self_type, args, is_fun_literal, is_closure)
 
         context.return_type = target_def.type?
         context.return_phi = nil

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -56,11 +56,7 @@ struct LLVM::DIBuilder
   end
 
   def insert_declare_at_end(storage, var_info, expr, dl, block)
-    {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
-      LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, block)
-    {% else %}
-      LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
-    {% end %}
+    LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
   end
 
   def get_or_create_array(elements : Array(LibLLVMExt::Metadata))
@@ -91,18 +87,18 @@ struct LLVM::DIBuilder
   end
 
   def create_replaceable_composite_type(scope, name, file, line)
-    {% if LibLLVM::IS_38 %}
-      LibLLVMExt.di_builder_create_replaceable_composite_type(self, scope, name, file, line)
-    {% else %}
+    {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
       LibLLVMExt.temporary_md_node(LLVM::Context.global, nil, 0).as(LibLLVMExt::Metadata)
+    {% else %}
+      LibLLVMExt.di_builder_create_replaceable_composite_type(self, scope, name, file, line)
     {% end %}
   end
 
   def replace_temporary(from, to)
-    {% if LibLLVM::IS_38 %}
-      LibLLVMExt.di_builder_replace_temporary(self, from, to)
-    {% else %}
+    {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
       LibLLVMExt.metadata_replace_all_uses_with(from, to)
+    {% else %}
+      LibLLVMExt.di_builder_replace_temporary(self, from, to)
     {% end %}
   end
 

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -31,27 +31,37 @@ struct LLVM::DIBuilder
 
   def create_function(scope, name, linkage_name, file, line, composite_type, is_local_to_unit, is_definition,
                       scope_line, flags, is_optimized, func)
-    LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, line, composite_type, is_local_to_unit, is_definition,
-      scope_line, flags, is_optimized, func)
+    {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
+      LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, line, composite_type,
+                                            is_local_to_unit ? 1 : 0,
+                                            is_definition ? 1 : 0,
+                                            scope_line, flags,
+                                            is_optimized ? 1 : 0, func)
+    {% else %}
+      LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, line, composite_type,
+                                            is_local_to_unit, is_definition, scope_line, flags, is_optimized, func)
+    {% end %}
   end
 
-  def create_local_variable(tag, scope, name, file, line, type)
-    LibLLVMExt.di_builder_create_local_variable(self, tag.value, scope, name, file, line, type, 0, 0, 0)
+  def create_auto_variable(scope, name, file, line, type)
+    LibLLVMExt.di_builder_create_auto_variable(self, scope, name, file, line, type, 0, 0)
+  end
+
+  def create_parameter_variable(scope, name, argno, file, line, type)
+    LibLLVMExt.di_builder_create_parameter_variable(self, scope, name, argno, file, line, type, 0, 0)
   end
 
   def create_expression(addr, length)
     LibLLVMExt.di_builder_create_expression(self, addr, length)
   end
 
-  {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
-  def insert_declare_at_end(storage, var_info, expr, block)
-    LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, block)
-  end
-  {% else %}
   def insert_declare_at_end(storage, var_info, expr, dl, block)
-    LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
+    {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
+      LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, block)
+    {% else %}
+      LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
+    {% end %}
   end
-  {% end %}
 
   def get_or_create_array(elements : Array(LibLLVMExt::Metadata))
     LibLLVMExt.di_builder_get_or_create_array(self, elements, elements.size)
@@ -80,12 +90,20 @@ struct LLVM::DIBuilder
     LibLLVMExt.di_builder_create_pointer_type(self, pointee, size_in_bits, align_in_bits, name)
   end
 
-  def temporary_md_node(context)
-    LibLLVMExt.temporary_md_node(context, nil, 0).as(LibLLVMExt::Metadata)
+  def create_replaceable_composite_type(scope, name, file, line)
+    {% if LibLLVM::IS_38 %}
+      LibLLVMExt.di_builder_create_replaceable_composite_type(self, scope, name, file, line)
+    {% else %}
+      LibLLVMExt.temporary_md_node(LLVM::Context.global, nil, 0).as(LibLLVMExt::Metadata)
+    {% end %}
   end
 
-  def replace_all_uses(from, to)
-    LibLLVMExt.metadata_replace_all_uses_with(from, to)
+  def replace_temporary(from, to)
+    {% if LibLLVM::IS_38 %}
+      LibLLVMExt.di_builder_replace_temporary(self, from, to)
+    {% else %}
+      LibLLVMExt.metadata_replace_all_uses_with(from, to)
+    {% end %}
   end
 
   def finalize

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -40,12 +40,20 @@ lib LibLLVMExt
                                                                   align_in_bits : UInt64,
                                                                   encoding : LibC::UInt) : Metadata
 
-  fun di_builder_create_local_variable = LLVMDIBuilderCreateLocalVariable(builder : DIBuilder,
-                                                                          tag : LibC::UInt, scope : Metadata,
-                                                                          name : LibC::Char*, file : Metadata, line : LibC::UInt, type : Metadata,
-                                                                          always_preserve : LibC::Int, flags : LibC::UInt, arg_no : LibC::UInt) : Metadata
+  fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable(builder : DIBuilder,
+                                                                        scope : Metadata,
+                                                                        name : LibC::Char*,
+                                                                        file : Metadata, line : LibC::UInt,
+                                                                        type : Metadata,
+                                                                        always_preserve : LibC::Int, flags : LibC::UInt) : Metadata
 
-  {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
+  fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable(builder : DIBuilder,
+                                                                                  scope : Metadata,
+                                                                                  name : LibC::Char*, arg_no : LibC::UInt,
+                                                                                  file : Metadata, line : LibC::UInt, type : Metadata,
+                                                                                  always_preserve : LibC::Int, flags : LibC::UInt) : Metadata
+
+{% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
                                                                          var_info : Metadata,
@@ -86,8 +94,17 @@ lib LibLLVMExt
                                                                       align_in_bits : UInt64,
                                                                       name : LibC::Char*) : Metadata
 
+{% if LibLLVM::IS_38 %}
+  fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
+                                                                                                 scope : Metadata,
+                                                                                                 name : LibC::Char*,
+                                                                                                 file : Metadata,
+                                                                                                 line : LibC::UInt) : Metadata
+  fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
+{% else %}
   fun temporary_md_node = LLVMTemporaryMDNode(context : LibLLVM::ContextRef, mds : Metadata*, count : LibC::UInt) : Metadata
   fun metadata_replace_all_uses_with = LLVMMetadataReplaceAllUsesWith(Metadata, Metadata)
+{% end %}
 
   fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, LibC::Int, LibC::Int, Metadata, Metadata)
 

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -53,20 +53,12 @@ lib LibLLVMExt
                                                                                   file : Metadata, line : LibC::UInt, type : Metadata,
                                                                                   always_preserve : LibC::Int, flags : LibC::UInt) : Metadata
 
-{% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
-  fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
-                                                                         storage : LibLLVM::ValueRef,
-                                                                         var_info : Metadata,
-                                                                         expr : Metadata,
-                                                                         block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
-{% else %}
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
                                                                          var_info : Metadata,
                                                                          expr : Metadata,
                                                                          dl : LibLLVM::ValueRef,
                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
-{% end %}
 
   fun di_builder_create_expression = LLVMDIBuilderCreateExpression(builder : DIBuilder,
                                                                    addr : Int64*, length : LibC::SizeT) : Metadata
@@ -94,17 +86,17 @@ lib LibLLVMExt
                                                                       align_in_bits : UInt64,
                                                                       name : LibC::Char*) : Metadata
 
-{% if LibLLVM::IS_38 %}
-  fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
-                                                                                                 scope : Metadata,
-                                                                                                 name : LibC::Char*,
-                                                                                                 file : Metadata,
-                                                                                                 line : LibC::UInt) : Metadata
-  fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
-{% else %}
-  fun temporary_md_node = LLVMTemporaryMDNode(context : LibLLVM::ContextRef, mds : Metadata*, count : LibC::UInt) : Metadata
-  fun metadata_replace_all_uses_with = LLVMMetadataReplaceAllUsesWith(Metadata, Metadata)
-{% end %}
+  {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
+    fun temporary_md_node = LLVMTemporaryMDNode(context : LibLLVM::ContextRef, mds : Metadata*, count : LibC::UInt) : Metadata
+    fun metadata_replace_all_uses_with = LLVMMetadataReplaceAllUsesWith(Metadata, Metadata)
+  {% else %}
+    fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
+                                                                                                   scope : Metadata,
+                                                                                                   name : LibC::Char*,
+                                                                                                                    file : Metadata,
+                                                                                                   line : LibC::UInt) : Metadata
+    fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
+  {% end %}
 
   fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, LibC::Int, LibC::Int, Metadata, Metadata)
 


### PR DESCRIPTION
- Output declarations of both parameters and local variables when emitting function debugging information.
- Add functions for forward declaration of types in LLVM >= 3.8 (wrap `llvm::DIBuilder.createReplaceableCompositeType` and `llvm::DIBuilder.replaceTemporary`
- Push LLVM version conditionals from `debug.cr` into `di_builder.cr`
- Add spacing and comments in preprocessor directives in `llvm_ext.cc` to improve readability

Eg. when compiling with debug info the following code

```crystal
def my_add(x, y)
  z = x + y
  z
end

my_add(10, 20)
```

you can now display the values of the parameters `x` and `y`, like so:

```sh
(gdb) break my_add
Breakpoint 1 at 0x1000041ca: file /Users/ggiraldez/ScratchPad/crystal-debug/foo.cr, line 1.
(gdb) run
...
Breakpoint 1, my_add (x=10, y=20) at /Users/ggiraldez/ScratchPad/crystal-debug/foo.cr:1
1	def my_add(x, y)
(gdb) info locals
z = 0
(gdb) info arg
x = 10
y = 20
(gdb) 
```


Regarding the new functions to handle forward declarations, using `LLVMTemporaryMDNode` and `LLVMMetadataReplaceAllUsesWith` no longer works in LLVM 3.8. I run into this issue simply by compiling with LLVM 3.8.1 from Homebrew, then trying to compile this program with debug info:

```crystal
class Foo
  @parent = uninitialized Foo
end

def test
  f = Foo.new
end

test
```

This crashed the compiler with a failed assertion:

```
Using compiled compiler at .build/crystal
Assertion failed: ((!MD || isa<MDString>(MD) || isa<T>(MD)) && "Expected valid ref"), function TypedDINodeRef, file /private/tmp/llvm38-20161006-73093-mrdx69/llvm-3.8.1.src/include/llvm/IR/DebugInfoMetadata.h, line 60.
Abort trap: 6
```

Found the solution here: https://groups.google.com/d/msg/llvm-dev/9C3yuck4JZY/yDxxP9ypEwAJ

