### PR TITLE
Fix compilation of `llvm_ext.cc` with LLVM 3.5

### DIFF
--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -248,7 +248,11 @@ LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd(DIBuilderRef Dref,
                      unwrapDI<DIExpression>(Expr),
 # endif
                      unwrap(Block));
+# if LLVM_VERSION_EQ(3, 5)
+  Instr->setDebugLoc(DebugLoc::getFromDILocation(unwrap<MDNode>(DL)));
+# else
   Instr->setDebugLoc(DebugLoc::getFromDILocation(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())));
+# endif
 #else /* LLVM > 3.6 */
   Instruction *Instr =
     Dref->insertDeclare(unwrap(Storage), unwrap<DILocalVariable>(VarInfo),


### PR DESCRIPTION
Debug location in LLVM 3.5 is wrapped directly in a `MDNode` instead of a `MetadataAsValue`.
