### PR TITLE
Emit debug information for toplevel variables

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -202,6 +202,8 @@ module Crystal
       initialize_simple_class_vars_and_constants
 
       alloca_vars @program.vars, @program
+
+      emit_vars_debug_info(@program.vars) if @debug
     end
 
     # Here we only initialize simple constants and class variables, those
@@ -344,6 +346,8 @@ module Crystal
         file_module = @program.file_module(node.filename)
         if vars = file_module.vars?
           alloca_vars vars, file_module
+
+          emit_vars_debug_info(vars) if @debug
         end
         node.node.accept self
       end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -149,6 +149,19 @@ module Crystal
       di_builder.insert_declare_at_end(alloca, var, expr, builder.current_debug_location, alloca_block)
     end
 
+    # Emit debug info for toplevel variables. Used for the main module and all
+    # required files.
+    def emit_vars_debug_info(vars)
+      in_alloca_block do
+        vars.each do |name, var|
+          llvm_var = context.vars[name]
+          set_current_debug_location var.location
+          declare_variable name, var.type, llvm_var.pointer, var.location
+        end
+        clear_current_debug_location
+      end
+    end
+
     def file_and_dir(file)
       # @file_and_dir ||= {} of String | VirtualFile => {String, String}
       realfile = case file

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -668,6 +668,9 @@ module Crystal
 
       meta_var = (@meta_vars[var_name] ||= new_meta_var(var_name))
 
+      # Save variable assignment location for debugging output
+      meta_var.location ||= target.location
+
       begin
         meta_var.bind_to value
       rescue ex : FrozenTypeException


### PR DESCRIPTION
When compiling with debug output, emit debug information for toplevel variables both in the main file and in required files. For example, given a file `foo.cr`:

```crystal
foo1 = 1
foo2 = 10
foo3 = 100
foo4 = foo1 + foo2 + foo3

puts "foo4 = #{foo4}"
```

and a file `bar.cr`:

```crystal
require "./foo"

bar1 = 2
bar2 = 3
bar3 = 5
bar4 = bar1 * bar2 * bar3

puts "bar4 = #{bar4}"
```

Compiling `bar.cr` with debugging information will allow:

```
(gdb) b foo.cr:1
Breakpoint 1 at 0x100000ce5: file /Users/ggiraldez/ScratchPad/crystal-debug/foo.cr, line 1.
(gdb) b bar.cr:1
Breakpoint 2 at 0x100000d40: file /Users/ggiraldez/ScratchPad/crystal-debug/bar.cr, line 1.
(gdb) run
Starting program: /Users/ggiraldez/ScratchPad/crystal-debug/bar

Breakpoint 1, __crystal_main () at /Users/ggiraldez/ScratchPad/crystal-debug/foo.cr:1
1	foo1 = 1
(gdb) info locals
foo1 = 32767
foo2 = 1900987092
foo3 = 32767
foo4 = -2028132910
(gdb) n
2	foo2 = 10
(gdb) n
3	foo3 = 100
(gdb) n
4	foo4 = foo1 + foo2 + foo3
(gdb) n
6	puts "foo4 = #{foo4}"
(gdb) info locals
foo1 = 1
foo2 = 10
foo3 = 100
foo4 = 111
(gdb) c
Continuing.
foo4 = 111

Breakpoint 2, __crystal_main () at /Users/ggiraldez/ScratchPad/crystal-debug/bar.cr:3
3	bar1 = 2
(gdb) info locals
bar1 = 32767
bar2 = 1606416352
bar3 = 1
bar4 = 34723
(gdb) n
4	bar2 = 3
(gdb) n
5	bar3 = 5
(gdb) n
6	bar4 = bar1 * bar2 * bar3
(gdb) n
8	puts "bar4 = #{bar4}"
(gdb) info locals
bar1 = 2
bar2 = 3
bar3 = 5
bar4 = 30
```
