### PR TITLE
Compiler: don't use byval in codegen

### DIFF
--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -69,7 +69,7 @@ require "./codegen"
 # type into a specific type (such as when casting a Foo to a Bar, with Bar < Foo).
 
 class Crystal::CodeGenVisitor
-  def assign(target_pointer, target_type, value_type, value)
+  def assign(target_pointer, target_type, value_type, value, already_loaded = false)
     return if @builder.end
 
     target_type = target_type.remove_indirection
@@ -79,34 +79,35 @@ class Crystal::CodeGenVisitor
       if target_type.nil_type?
         value
       else
-        store to_rhs(value, target_type), target_pointer
+        value = to_rhs(value, target_type) unless already_loaded
+        store value, target_pointer
       end
     else
-      assign_distinct target_pointer, target_type, value_type, value
+      assign_distinct target_pointer, target_type, value_type, value, already_loaded
     end
   end
 
-  def assign_distinct(target_pointer, target_type : NilableType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : NilableType, value_type : Type, value, already_loaded)
     store upcast(value, target_type, value_type), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : ReferenceUnionType, value)
+  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : ReferenceUnionType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : VirtualType, value)
+  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : VirtualType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : ReferenceUnionType, value_type : Type, value, already_loaded)
     store cast_to(value, target_type), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilableReferenceUnionType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : NilableReferenceUnionType, value_type : Type, value, already_loaded)
     store upcast(value, target_type, value_type), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : MixedUnionType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : MixedUnionType, value, already_loaded)
     # It might happen that some types inside the union `value_type` are not inside `target_type`,
     # for example with named tuple of same keys with different order. In that case we need cast
     # those value to the correct type before finally storing them in the target union.
@@ -169,23 +170,23 @@ class Crystal::CodeGenVisitor
     store load(casted_value), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilableType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilableType, value, already_loaded)
     store_in_union target_pointer, value_type, value
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : VoidType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : VoidType, value, already_loaded)
     store type_id(value_type), union_type_id(target_pointer)
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : BoolType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : BoolType, value, already_loaded)
     store_bool_in_union target_type, target_pointer, value
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilType, value, already_loaded)
     store_nil_in_union target_pointer, target_type
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : Type, value, already_loaded)
     case value_type
     when TupleInstanceType, NamedTupleInstanceType
       # It might happen that `value_type` is not of the union but it's compatible with one of them.
@@ -197,52 +198,53 @@ class Crystal::CodeGenVisitor
       end
     end
 
-    store_in_union target_pointer, value_type, to_rhs(value, value_type)
+    value = to_rhs(value, value_type) unless already_loaded
+    store_in_union target_pointer, value_type, value
   end
 
-  def assign_distinct(target_pointer, target_type : VirtualType, value_type : MixedUnionType, value)
+  def assign_distinct(target_pointer, target_type : VirtualType, value_type : MixedUnionType, value, already_loaded)
     casted_value = cast_to_pointer(union_value(value), target_type)
     store load(casted_value), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : VirtualType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : VirtualType, value_type : Type, value, already_loaded)
     store cast_to(value, target_type), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : MetaclassType, value)
+  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : MetaclassType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : VirtualMetaclassType, value)
+  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : VirtualMetaclassType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : NilType, value)
+  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : NilType, value, already_loaded)
     nilable_fun = make_nilable_fun target_type
     store nilable_fun, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : ProcInstanceType, value)
+  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : ProcInstanceType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : TypeDefType, value)
-    assign_distinct target_pointer, target_type, value_type.typedef, value
+  def assign_distinct(target_pointer, target_type : NilableProcType, value_type : TypeDefType, value, already_loaded)
+    assign_distinct target_pointer, target_type, value_type.typedef, value, already_loaded
   end
 
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : NilType, value)
+  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : NilType, value, already_loaded)
     store llvm_type(target_type).null, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : PointerInstanceType, value)
+  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : PointerInstanceType, value, already_loaded)
     store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : TypeDefType, value)
-    assign_distinct target_pointer, target_type, value_type.typedef, value
+  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : TypeDefType, value, already_loaded)
+    assign_distinct target_pointer, target_type, value_type.typedef, value, already_loaded
   end
 
-  def assign_distinct(target_pointer, target_type : TupleInstanceType, value_type : TupleInstanceType, value)
+  def assign_distinct(target_pointer, target_type : TupleInstanceType, value_type : TupleInstanceType, value, already_loaded)
     index = 0
     target_type.tuple_types.zip(value_type.tuple_types) do |target_tuple_type, value_tuple_type|
       target_ptr = gep target_pointer, 0, index
@@ -254,7 +256,7 @@ class Crystal::CodeGenVisitor
     value
   end
 
-  def assign_distinct(target_pointer, target_type : NamedTupleInstanceType, value_type : NamedTupleInstanceType, value)
+  def assign_distinct(target_pointer, target_type : NamedTupleInstanceType, value_type : NamedTupleInstanceType, value, already_loaded)
     value_type.entries.each_with_index do |entry, index|
       value_ptr = aggregate_index(value, index)
       value_at_index = to_lhs(value_ptr, entry.type)
@@ -264,12 +266,13 @@ class Crystal::CodeGenVisitor
     end
   end
 
-  def assign_distinct(target_pointer, target_type : ProcInstanceType, value_type : ProcInstanceType, value)
+  def assign_distinct(target_pointer, target_type : ProcInstanceType, value_type : ProcInstanceType, value, already_loaded)
     # Cast of a non-void proc to a void proc
-    store to_rhs(value, target_type), target_pointer
+    value = to_rhs(value, target_type) unless already_loaded
+    store value, target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : Type, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : Type, value_type : Type, value, already_loaded)
     raise "Bug: trying to assign #{target_type} <- #{value_type}"
   end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -905,17 +905,7 @@ module Crystal
         llvm_value = check_proc_is_not_closure(llvm_value, target.type)
       end
 
-      if target.is_a?(Var) && target.special_var? && !target_type.reference_like?
-        # For special vars that are not reference-like, the function argument will
-        # be a pointer to the struct value. So, we need to first cast the value to
-        # that type (without the pointer), load it, and store it in the argument.
-        # If it's a reference-like then it's just a pointer and we can reuse the
-        # logic in the other branch.
-        llvm_value = upcast llvm_value, target_type, value.type
-        store load(llvm_value), ptr
-      else
-        assign ptr, target_type, value.type, llvm_value
-      end
+      assign ptr, target_type, value.type, llvm_value
 
       false
     end

--- a/src/compiler/crystal/codegen/phi.cr
+++ b/src/compiler/crystal/codegen/phi.cr
@@ -89,7 +89,10 @@ class Crystal::CodeGenVisitor
           @codegen.last = llvm_nil
         else
           if @exit_block
-            @codegen.last = phi llvm_arg_type(@node_type.not_nil!), phi_table
+            node_type = @node_type.not_nil!
+            type = llvm_type(node_type)
+            type = type.pointer if node_type.passed_by_value?
+            @codegen.last = phi type, phi_table
           else
             @codegen.last = phi_table.values.first
           end


### PR DESCRIPTION
This makes the codegen never emit `byval` in function parameters except in C function calls because it seems that is required by the C ABI (or put another way, I tried not to use `byval` and it didn't work).

@ysbaddaden You can try to apply this PR's diff on top of #3424 and then see if the new compiler can compile the Base64 spec and it passes on ARM (I didn't because I changed the pi's password in the office and back home I remembered I don't have a usb keyboard, so I'll be able to test this tomorrow)