### PR TITLE
Moves permalink hashtag into gutter in docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -285,11 +285,21 @@ h2 {
 .entry-detail .signature .method-permalink {
   position: absolute;
   top: 0;
-  right: 0;
+  left: -35px;
   padding: 5px 15px;
   text-decoration: none;
   font-weight: bold;
   color: #624288;
+  opacity: .4;
+  transition: opacity .2s;
+}
+
+.entry-detail .signature .method-permalink:hover {
+  opacity: 1;
+}
+
+.entry-detail:target .signature .method-permalink {
+  opacity: 1;
 }
 
 .methods-inherited {


### PR DESCRIPTION
Moving the permalink hashtag into the left gutter makes the header for the method more visually distinguishable. It can be difficult when looking at a large doc to distinguish where one method ends and another begins. With the octothorp in the gutter a user can use their peripheral vision, which mean better UX.

**Before**  
![default_before](https://cloud.githubusercontent.com/assets/9119269/19732890/86f1d89e-9b5f-11e6-9923-e24cdd4e00aa.png)

**After**  
![default_after](https://cloud.githubusercontent.com/assets/9119269/19732896/8ed88486-9b5f-11e6-8523-b85da99edeb2.png)

<hr/>

**Before**  
![highlighted_before](https://cloud.githubusercontent.com/assets/9119269/19732920/9d7e7d06-9b5f-11e6-9b62-80e2c4ba242d.png)

**After**  
![highlighted_after](https://cloud.githubusercontent.com/assets/9119269/19732928/a92dd980-9b5f-11e6-8a4f-88585f611e49.png)
