### PR TITLE
Add mean iteration time to Benchmark.ips

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -87,3 +87,28 @@ describe Benchmark::IPS::Entry, "#human_mean" do
   assert { h_mean(12345678901.2345).should eq(" 12.35G") }
   assert { h_mean(123456789012.345).should eq("123.46G") }
 end
+
+private def h_ips(seconds)
+  mean = 1.0 / seconds
+  create_entry.tap { |e| e.mean = mean }.human_iteration_time
+end
+
+describe Benchmark::IPS::Entry, "#human_iteration_time" do
+  assert { h_ips(1234.567_890_123).should eq("1234.57s ") }
+  assert { h_ips(123.456_789_012_3).should eq("123.46s ") }
+  assert { h_ips(12.345_678_901_23).should eq(" 12.35s ") }
+  assert { h_ips(1.234_567_890_123).should eq("  1.23s ") }
+
+  assert { h_ips(0.123_456_789_012).should eq("123.46ms") }
+  assert { h_ips(0.012_345_678_901).should eq(" 12.35ms") }
+  assert { h_ips(0.001_234_567_890).should eq("  1.23ms") }
+
+  assert { h_ips(0.000_123_456_789).should eq("123.46µs") }
+  assert { h_ips(0.000_012_345_678).should eq(" 12.35µs") }
+  assert { h_ips(0.000_001_234_567).should eq("  1.23µs") }
+
+  assert { h_ips(0.000_000_123_456).should eq("123.46ns") }
+  assert { h_ips(0.000_000_012_345).should eq(" 12.35ns") }
+  assert { h_ips(0.000_000_001_234).should eq("  1.23ns") }
+  assert { h_ips(0.000_000_000_123).should eq("  0.12ns") }
+end

--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -68,6 +68,7 @@ private def h_mean(mean)
 end
 
 describe Benchmark::IPS::Entry, "#human_mean" do
+  assert { h_mean(0.01234567890123).should eq("  0.01 ") }
   assert { h_mean(0.12345678901234).should eq("  0.12 ") }
 
   assert { h_mean(1.23456789012345).should eq("  1.23 ") }

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -45,9 +45,10 @@ module Benchmark
         max_compare = ran_items.max_of &.human_compare.size
 
         ran_items.each do |item|
-          printf "%s %s (±%5.2f%%) %s\n",
+          printf "%s %s (%s) (±%5.2f%%) %s\n",
             item.label.rjust(max_label),
             item.human_mean,
+            item.human_iteration_time,
             item.relative_stddev,
             item.human_compare.rjust(max_compare)
         end
@@ -195,6 +196,26 @@ module Benchmark
 
         "#{digits.round(2).to_s.rjust(6)}#{suffix}"
       end
+
+      def human_iteration_time
+        iteration_time = 1.0 / mean
+
+        case Math.log10(iteration_time)
+        when 0..Float64::MAX
+          digits = iteration_time
+          suffix = "s "
+        when -3..0
+          digits = iteration_time * 1000
+          suffix = "ms"
+        when -6..-3
+          digits = iteration_time * 1_000_000
+          suffix = "µs"
+        else
+          digits = iteration_time * 1_000_000_000
+          suffix = "ns"
+        end
+
+        "#{digits.round(2).to_s.rjust(6)}#{suffix}"
       end
 
       def human_compare

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -178,17 +178,23 @@ module Benchmark
       end
 
       def human_mean
-        pair = case Math.log10(mean)
-               when -1..3
-                 {mean, ' '}
-               when 3..6
-                 {mean/1_000, 'k'}
-               when 6..9
-                 {mean/1_000_000, 'M'}
-               else
-                 {mean/1_000_000_000, 'G'}
-               end
-        "#{pair[0].round(2).to_s.rjust(6)}#{pair[1]}"
+        case Math.log10(mean)
+        when Float64::MIN..3
+          digits = mean
+          suffix = ' '
+        when 3..6
+          digits = mean / 1000
+          suffix = 'k'
+        when 6..9
+          digits = mean / 1_000_000
+          suffix = 'M'
+        else
+          digits = mean / 1_000_000_000
+          suffix = 'G'
+        end
+
+        "#{digits.round(2).to_s.rjust(6)}#{suffix}"
+      end
       end
 
       def human_compare


### PR DESCRIPTION
Adds mean time per iteration to the output of `Benchmark.ips`. I find this metric quite useful in addition to iterations per second because it's an easier metric to compare to values like network roundtrip times and disk seeks.

Also cleans up `Benchmark::IPS::Entry#human_mean`, and fixes output with iteration times greater than 10 seconds (`log10(mean) < -1`)