### PR TITLE
Include amd64 because OpenBSD uses it in its target string

### DIFF
--- a/src/compiler/crystal/codegen/target_machine.cr
+++ b/src/compiler/crystal/codegen/target_machine.cr
@@ -5,7 +5,7 @@ module Crystal
   module TargetMachine
     def self.create(target_triple, cpu = "", features = "", release = false) : LLVM::TargetMachine
       case target_triple
-      when /^(x86_64|i[3456]86)/
+      when /^(x86_64|i[3456]86|amd64)/
         LLVM.init_x86
       when /^arm/
         LLVM.init_arm


### PR DESCRIPTION
Fixes OpenBSD support as it uses the following target triple: 'amd64-unknown-openbsd6.0'