### PR TITLE
Allow TCPSocket to bind to specific local address

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -386,6 +386,27 @@ describe TCPSocket do
       TCPSocket.new("localhostttttt", 12345)
     end
   end
+
+  it "binds to a local port" do
+    port = TCPServer.open("::", 0) do |server|
+      server.local_address.port
+    end
+    port.should be > 0
+
+    TCPServer.open("::", port) do |server|
+      server.local_address.family.should eq(Socket::Family::INET6)
+      server.local_address.port.should eq(port)
+      server.local_address.address.should eq("::")
+
+      # test sync flag propagation after accept
+      server.sync = !server.sync?
+
+      TCPSocket.open("::", server.local_address.port, "::", 54321) do |client|
+        sock = server.accept
+        sock.sync?.should eq(server.sync?)
+      end
+    end
+  end
 end
 
 describe UDPSocket do

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -67,18 +67,10 @@ class TCPSocket < IPSocket
   # Opens a TCP socket to a remote TCP server, yields it to the block, then
   # eventually closes the socket when the block returns.
   #
+  # Forwards all params to TCPSocket#new.
   # Returns the value of the block.
-  def self.open(host, port, local_host, local_port)
-    sock = new(host, port, local_host: local_host, local_port: local_port)
-    begin
-      yield sock
-    ensure
-      sock.close
-    end
-  end
-
-  def self.open(host, port)
-    sock = new(host, port)
+  def self.open(*args, **kwargs)
+    sock = new(*args, **kwargs)
     begin
       yield sock
     ensure


### PR DESCRIPTION
Allows a TCPSocket to use a specific address for outgoing connections, for use in systems with more than a single interface. Adds two TCPSocket overloads to the existing instantiation methods, `TCPSocket.open` and `TCPSocket.new`, with additional parameters to allow specifying an IP and port combination to bind. Not sure how great the specs are, UDPSocket has much better testing for this but unfortunately TCPSocket cannot be instantiated in the same way as UDPSocket.

cc @RX14 