### PR TITLE
Fix wrong macro generation when LLVM --built-targets returns only one on OS X

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -21,7 +21,7 @@ end
   @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
   lib LibLLVM
     VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}
-    BUILT_TARGETS = {{ `#{LibLLVM::LLVM_CONFIG} --targets-built`.chomp.downcase.split(' ').map(&.id.symbolize) }}
+    BUILT_TARGETS = {{ `#{LibLLVM::LLVM_CONFIG} --targets-built`.strip.downcase.split(' ').map(&.id.symbolize) }}
   end
 {% end %}
 


### PR DESCRIPTION
This happens on Crystal master (Crystal 0.19.4+103 [00a9a8a] (2016-11-04)) on OS X 10.11

```
➜  crystal git:(master) ✗ /usr/local/bin/llvm-config-3.6 --targets-built
X86
```

This leads to invalid macro generation when compiling the compiler.

```
Using /usr/local/bin/llvm-config-3.6 [version=3.6.2]
rm -rf .build
rm -rf ./doc
rm -rf src/llvm/ext/llvm_ext.o
rm -rf src/ext/sigfault.o src/ext/libcrystal.a
clang++-3.6 -stdlib=libc++ -c  -nostdinc++ -I/usr/local/opt/llvm36/lib/llvm-3.6/include/c++/v1  -o src/llvm/ext/llvm_ext.o src/llvm/ext/llvm_ext.cc `/usr/local/bin/llvm-config-3.6 --cxxflags`
cc -fPIC    -c -o src/ext/sigfault.o src/ext/sigfault.c
ar -rcs src/ext/libcrystal.a src/ext/sigfault.o
CRYSTAL_CONFIG_PATH=`pwd`/src ./bin/crystal build  -o .build/crystal src/compiler/crystal.cr -D without_openssl -D without_zlib
Error in ./src/compiler/crystal.cr:4: while requiring "./crystal/**"

require "./crystal/**"
^

in ./src/compiler/crystal/program.cr:1: while requiring "llvm"

require "llvm"
^

in ./src/llvm.cr:1: while requiring "./llvm/**"

require "./llvm/**"
^

in ./src/llvm/di_builder.cr:1: while requiring "./lib_llvm"

require "./lib_llvm"
^

in ./src/llvm/lib_llvm.cr:19: macro didn't expand to a valid program, it expanded to:

================================================================================
--------------------------------------------------------------------------------
   1.
   2.   @[Link("stdc++")]
   3.   @[Link(ldflags: "`/usr/local/bin/llvm-config-3.6 --libs --system-libs --ldflags 2> /dev/null`")]
   4.   lib LibLLVM
   5.     VERSION = "3.6.2"
   6.     BUILT_TARGETS = [:x86, :]
   7.   end
--------------------------------------------------------------------------------
Syntax error in expanded macro: macro_4596053872:6: unterminated array literal

    BUILT_TARGETS = [:x86, :]
                    ^

================================================================================

{% begin %}
^

make: *** [.build/crystal] Error 1
```

Weirdly this line

```
{{ `#{LibLLVM::LLVM_CONFIG} --targets-built`.chomp.strip.downcase.split(' ').map(&.id.symbolize) }} # => [:x86, :]
```

which is invalid Crystal code.