### PR TITLE
Add Int#to_big_i

### DIFF
--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -450,6 +450,19 @@ struct Float
   end
 end
 
+struct Int
+  include Comparable(BigInt)
+
+  def <=>(other : BigInt)
+    -(other <=> self)
+  end
+
+  # Returns a BigInt representing this int.
+  def to_big_i : BigInt
+    BigInt.new(self)
+  end
+end
+
 class String
   # Returns a BigInt from this string, in the given *base*.
   #


### PR DESCRIPTION
Was surprised to not find this method. Looks like it was just forgotten to add, as there's Float#to_big_i. Also mirrors the other #to_X methods.