### PR TITLE
Disallow multiple constants assignment

### DIFF
--- a/spec/compiler/normalize/multi_assign_spec.cr
+++ b/spec/compiler/normalize/multi_assign_spec.cr
@@ -5,10 +5,6 @@ describe "Normalize: multi assign" do
     assert_expand "a, b, c = 1, 2, 3", "__temp_1 = 1\n__temp_2 = 2\n__temp_3 = 3\na = __temp_1\nb = __temp_2\nc = __temp_3"
   end
 
-  it "normalizes n to n with constants" do
-    assert_expand "a, B, C = 1, 2, 3", "__temp_1 = 1\na = __temp_1\nB = 2\nC = 3"
-  end
-
   it "normalizes 1 to n" do
     assert_expand_second "d = 1\na, b, c = d", "__temp_1 = d\na = __temp_1[0]\nb = __temp_1[1]\nc = __temp_1[2]"
   end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -134,7 +134,6 @@ describe "Parser" do
 
   it_parses "@a, b = 1, 2", MultiAssign.new(["@a".instance_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "@@a, b = 1, 2", MultiAssign.new(["@@a".class_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
-  it_parses "A, b = 1, 2", MultiAssign.new(["A".path, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
   assert_syntax_error "1 == 2, a = 4"
   assert_syntax_error "x : String, a = 4"
@@ -1324,6 +1323,7 @@ describe "Parser" do
   assert_syntax_error "/foo)/", "invalid regex"
   assert_syntax_error "def =\nend"
   assert_syntax_error "def foo; A = 1; end", "dynamic constant assignment"
+  assert_syntax_error "FOO, BAR = 1, 2", "Multiple assignment is not allowed for constants"
   assert_syntax_error "{1, ->{ |x| x } }", "unexpected token '|'"
   assert_syntax_error "{1, ->do\n|x| x\end }", "unexpected token '|'"
 

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -237,4 +237,8 @@ describe "Semantic: const" do
       FOO
       )) { types["Foo"] }
   end
+
+  it "errors on multiple constant assignment (#3466)" do
+    assert_error "FOO, BAR = 1, 2", "Multiple assignment is not allowed for constants"
+  end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -108,16 +108,16 @@ module Crystal
 
     def parse_multi_assign
       location = @token.location
-
       last = parse_expression
       skip_space
 
       last_is_target = multi_assign_target?(last)
-
       case @token.type
       when :","
-        # Continue
-        unexpected_token unless last_is_target
+        unless last_is_target
+          raise "Multiple assignment is not allowed for constants" if last.is_a?(Path)
+          unexpected_token
+        end
       when :NEWLINE, :";"
         return last
       else
@@ -173,7 +173,7 @@ module Crystal
         targets << assign
         values << assign.args.pop
       else
-        raise "Bug: mutliassign index expression can only be Assign or Call"
+        raise "Bug: multiassign index expression can only be Assign or Call"
       end
 
       values.concat exps[assign_index + 1..-1]
@@ -187,7 +187,7 @@ module Crystal
 
     def multi_assign_target?(exp)
       case exp
-      when Underscore, Var, InstanceVar, ClassVar, Global, Path, Assign
+      when Underscore, Var, InstanceVar, ClassVar, Global, Assign
         true
       when Call
         !exp.has_parentheses? && (


### PR DESCRIPTION
This is my first time deep diving into the compiler 😄  Fixes #3466 

I added a spec to `spec/compiler/semantic/const_spec.cr` with `assert_error`, it's working but failing. 

```
Failures:

  1) Semantic: const errors on multiple constant assignment (#3466)

       Syntax error in :2: Multiple assignment is not allowed for constants
       [4386931682] *CallStack::unwind:Array(Pointer(Void)) +82
       [4386931585] *CallStack#initialize:Array(Pointer(Void)) +17
       [4386931544] *CallStack::new:CallStack +40
       [4386881281] *raise<Crystal::SyntaxException>:NoReturn +17
       [4395110195] *Crystal::Parser@Crystal::Lexer#raise<String, Int32, Int32, (Crystal::VirtualFile | String | Nil)>:NoReturn +35
       [4395110158] *Crystal::Parser@Crystal::Lexer#raise<String>:NoReturn +62
       [4395126494] *Crystal::Parser#parse_multi_assign:Crystal::ASTNode+ +206
       [4395125219] *Crystal::Parser#parse_expressions_internal:Crystal::ASTNode+ +163
       [4395125012] *Crystal::Parser#parse_expressions:Crystal::ASTNode+ +52
       [4395075326] *Crystal::Parser#parse:Crystal::ASTNode+ +30
       [4386881258] *parse<String, Bool>:Crystal::ASTNode+ +58
       [4386881183] *parse<String>:Crystal::ASTNode+ +31
       [4386904867] *assert_error<String, String, Bool>:Nil +83
       [4386904775] *assert_error<String, String>:Nil +39
       [4386909101] ~procProc(Nil)@./spec/compiler/semantic/const_spec.cr:241 +29
       [4386879831] *it<String, String, Int32, &Proc(Nil)>:(Array(Spec::Result) | Nil) +375
       [4386879432] ~procProc(Nil)@./spec/compiler/semantic/const_spec.cr:3 +2088
       [4387385321] *Spec::RootContext::describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +361
       [4386877289] *describe<String, String, Int32, &Proc(Nil)>:Spec::Context+ +9
       [4386784117] __crystal_main +4661
       [4386855336] main +40

Finished in 1.41 seconds
28 examples, 0 failures, 1 errors, 0 pending
```

Any help wecome 👍 