### PR TITLE
A method to escape a string into uri safe structure

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -164,7 +164,7 @@ describe "URI" do
          .should eq("hello&world")
     end
 
-    it "escape a String into a url safe structure" do
+    it "escape a String into a uri safe structure" do
       URI.escape_uri_safe(":/?#[]@!$&\'()*+,;=").should eq(":/?#[]@!$&\'()*+,;=")
     end
   end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -163,6 +163,10 @@ describe "URI" do
       URI.unescape("hello&world") { |byte| URI.reserved? byte }
          .should eq("hello&world")
     end
+
+    it "escape a String into a url safe structure" do
+      URI.escape_uri_safe(":/?#[]@!$&\'()*+,;=").should eq(":/?#[]@!$&\'()*+,;=")
+    end
   end
 
   describe "reserved?" do

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -256,7 +256,7 @@ class URI
     self.escape(string, io, space_to_plus, uri_safe) { |byte| URI.unreserved? byte }
   end
 
-  # URL-encode a string into a URI safe way
+  # URL-encode a string into a URI safe structure
   def self.escape_uri_safe(string : String) : String
     String.build { |io| escape(string, io, false, true) }
   end


### PR DESCRIPTION
Hi there,
There is a critical difference between Ruby and Crystal for an implementation of URI.escape.

```
require "uri"
p URI.escape("https://crystal-lang.org/")
```
Then,
```
$ ruby sample.cr
-> "https://crystal-lang.org/"
$ crystal sample.cr
-> "https%3A%2F%2Fcrystal-lang.org%2F"
```
So it is difficult to escape a String in uri-safe structure like as Ruby's behavior.
So I added a method to keep the String url structure.
```
require "uri"
p URI.escape_uri_safe(":/?#[]@!$&\'()*+,;= ")
p URI.escape_uri_safe("https://crystal-lang.org?test=あああ")
```
Then,
```
$ crystal sample.cr
-> ":/?#[]@!$&'()*+,;=%20"
   "https://crystal-lang.org?test=%E3%81%82%E3%81%82%E3%81%82"
```

May be [this](https://github.com/crystal-lang/crystal/issues/2098) issue is involved.

Thanks for your review.