### PR TITLE
Adds flag statement (TODO, FIXME, ...) parsing for docs

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -4,6 +4,17 @@ class Crystal::Doc::Generator
   @base_dir : String
   @is_crystal_repo : Bool
 
+  # Adding a flag and associated css class will add support in parser
+  FLAG_COLORS = {
+    "BUG"        => "red",
+    "DEPRECATED" => "red",
+    "FIXME"      => "yellow",
+    "NOTE"       => "purple",
+    "OPTIMIZE"   => "green",
+    "TODO"       => "orange",
+  }
+  FLAGS = FLAG_COLORS.keys
+
   def initialize(@program : Program, @included_dirs : Array(String), @dir = "./doc")
     @base_dir = `pwd`.chomp
     @types = {} of Crystal::Type => Doc::Type
@@ -43,13 +54,9 @@ class Crystal::Doc::Generator
     end
 
     if filename
-      body = File.read(filename)
+      body = doc(program_type, File.read(filename))
     else
       body = ""
-    end
-
-    body = String.build do |io|
-      Markdown.parse body, MarkdownDocRenderer.new(program_type, io)
     end
 
     File.write "#{@dir}/index.html", MainTemplate.new(body, types, repository_name)
@@ -226,9 +233,11 @@ class Crystal::Doc::Generator
   end
 
   def doc(context, string)
-    String.build do |io|
+    string = isolate_flag_lines string
+    markdown = String.build do |io|
       Markdown.parse string, MarkdownDocRenderer.new(context, io)
     end
+    generate_flags markdown
   end
 
   def fetch_doc_lines(doc)
@@ -237,6 +246,33 @@ class Crystal::Doc::Generator
         " "
       else
         "\n"
+      end
+    end
+  end
+
+  # Replaces flag keywords with html equivalent
+  #
+  # Assumes that flag keywords are at the beginning of respective `p` element
+  def generate_flags(string)
+    FLAGS.reduce(string) do |str, flag|
+      flag_regexp = /<p>\s*#{flag}:?/
+      element_sub = %(<p><span class="flag #{FLAG_COLORS[flag]}">#{flag}</span> )
+      str.gsub(flag_regexp, element_sub)
+    end
+  end
+
+  # Adds extra line break to flag keyword lines
+  #
+  # Guarantees that line is within its own paragraph element when parsed
+  def isolate_flag_lines(string)
+    flag_regexp = /^ ?(#{FLAGS.join('|')}):?/
+    String.build do |io|
+      string.each_line.join('\n', io) do |line|
+        if line =~ flag_regexp
+          io << line << '\n'
+        else
+          io << line
+        end
       end
     end
   end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -267,7 +267,7 @@ class Crystal::Doc::Generator
   def isolate_flag_lines(string)
     flag_regexp = /^ ?(#{FLAGS.join('|')}):?/
     String.build do |io|
-      string.each_line.join('\n', io) do |line|
+      string.each_line.join("", io) do |line, io|
         if line =~ flag_regexp
           io << line << '\n'
         else

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -349,6 +349,44 @@ code {
   font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
 }
 
+span.flag {
+  padding: 2px 4px 1px;
+  border-radius: 3px;
+  margin-right: 3px;
+  font-size: 11px;
+  border: 1px solid transparent;
+}
+
+span.flag.orange {
+  background-color: #EE8737;
+  color: #FCEBDD;
+  border-color: #EB7317;
+}
+
+span.flag.yellow {
+  background-color: #E4B91C;
+  color: #FCF8E8;
+  border-color: #B69115;
+}
+
+span.flag.green {
+  background-color: #469C14;
+  color: #E2F9D3;
+  border-color: #34700E;
+}
+
+span.flag.red {
+  background-color: #BF1919;
+  color: #F9ECEC;
+  border-color: #822C2C;
+}
+
+span.flag.purple {
+  background-color: #2E1052;
+  color: #ECE1F9;
+  border-color: #1F0B37;
+}
+
 .tooltip>span {
   position: absolute;
   opacity: 0;


### PR DESCRIPTION
Adds parsing for flag statements (TODO, FIXME, BUG, ...) for docs as discussed in issue **#3460**

I had to create a workaround because `TODO:` and other keywords are not part of the markdown parser.

The code I added:  
(1) Makes sure that lines starting with `TODO:` are isolated into their own paragraph  
(2) Splits the HTML output by paragraph, and then replaces `TODO:` with the relevant HTML

If there is another way to do this (e.g. with the markdown parser) point me in the right direction and I'll see what I can do.

Screenshot

<img width="1280" alt="screen shot 2016-10-23 at 10 18 17 am" src="https://cloud.githubusercontent.com/assets/9119269/19627693/2dcc5624-990a-11e6-893c-00aea40e0760.png">