### PR TITLE
Raises on failure to run a process (Fixes #3517)

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -13,9 +13,10 @@ describe Process do
     process.wait.exit_code.should eq(1)
   end
 
-  it "returns status 127 if command could not be executed" do
-    process = Process.new("foobarbaz")
-    process.wait.exit_code.should eq(127)
+  it "raises if command could not be executed" do
+    expect_raises Errno do
+      Process.new("foobarbaz")
+    end
   end
 
   it "run waits for the process" do

--- a/src/process.cr
+++ b/src/process.cr
@@ -228,8 +228,12 @@ class Process
       end
     end
 
+    parent_sock, child_sock = IO.pipe
+
     @pid = Process.fork_internal(run_hooks: false) do
       begin
+        parent_sock.close
+        child_sock.close_on_exec = true
         Process.exec_internal(
           command,
           argv,
@@ -240,12 +244,22 @@ class Process
           fork_error || error,
           chdir
         )
+      rescue ex : Errno
+        value = ex.errno
+        child_sock.write(Bytes.new(pointerof(value).as(UInt8*), 4))
       rescue ex
         ex.inspect_with_backtrace STDERR
-        LibC._exit 127 # TODO: remove after 0.19
       ensure
         LibC._exit 127
       end
+    end
+
+    child_sock.close
+    slice = Bytes.new(4)
+    if parent_sock.read(slice) == 4
+      parent_sock.close
+      Errno.value = slice.pointer(4).as(Int32*).value
+      raise Errno.new("execvp")
     end
 
     @waitpid_future = Event::SignalChildHandler.instance.waitpid(pid)


### PR DESCRIPTION
This changes the behavior of `Process.new` to block until `execvp` is performed and raise an exception if it fails. Previous behavior was to return immediately and set let the forked process exit with 127. See #3517.

Before:

```cr
it "returns status 127 if command could not be executed" do
  process = Process.new("foobarbaz")
  process.wait.exit_code.should eq(127)
end
```

After:

```cr
it "raises if command could not be executed" do
  expect_raises Errno do
    Process.new("foobarbaz")
  end
end
```