### PR TITLE
Allow HTTP::Client block initializer to be used when passing an URI

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -103,6 +103,20 @@ module HTTP
           Client.new(URI.parse("http:/"))
         end
       end
+
+      it "yields to a block" do
+        Client.new(URI.parse("http://example.com")) do |client|
+          typeof(client)
+        end
+      end
+    end
+
+    context "from a host" do
+      it "yields to a block" do
+        Client.new("example.com") do |client|
+          typeof(client)
+        end
+      end
     end
 
     it "doesn't read the body if request was HEAD" do

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -154,7 +154,7 @@ class HTTP::Client
   def self.new(uri : URI, tls = nil)
     tls = tls_flag(uri, tls)
     host = validate_host(uri)
-    client = new(host, uri.port, tls)
+    new(host, uri.port, tls)
   end
 
   # Creates a new HTTP client from a URI, yields it to the block and closes the

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -131,7 +131,7 @@ class HTTP::Client
   {% end %}
 
   # Creates a new HTTP client from a URI. Parses the *host*, *port*,
-  # and *tls* configuration from the url provided. Port defaults to
+  # and *tls* configuration from the URI provided. Port defaults to
   # 80 if not specified unless using the https protocol, which defaults
   # to port 443 and sets tls to `true`.
   #
@@ -151,13 +151,33 @@ class HTTP::Client
   #
   # This constructor will raise an exception if any scheme but HTTP or HTTPS
   # is used.
-
   def self.new(uri : URI, tls = nil)
     tls = tls_flag(uri, tls)
     host = validate_host(uri)
     client = new(host, uri.port, tls)
   end
 
+  # Creates a new HTTP client from a URI, yields it to the block and closes the
+  # client afterwards. Parses the *host*, *port*, and *tls* configuration from
+  # the URI provided. Port defaults to 80 if not specified unless using the
+  # https protocol, which defaults to port 443 and sets tls to `true`.
+  #
+  # ```
+  # uri = URI.parse("https://secure.example.com")
+  # HTTP::Client.new(uri) do |client|
+  #   client.tls? # => true
+  #   client.get("/")
+  # end
+  # ```
+  # This constructor will *ignore* any path or query segments in the URI
+  # as those will need to be passed to the client when a request is made.
+  #
+  # If *tls* is given it will be used, if not a new TLS context will be created.
+  # If *tls* is given and *uri* is a HTTP URI, `ArgumentError` is raised.
+  # In any case the active context can be accessed through `tls`.
+  #
+  # This constructor will raise an exception if any scheme but HTTP or HTTPS
+  # is used.
   def self.new(uri : URI, tls = nil)
     tls = tls_flag(uri, tls)
     host = validate_host(uri)


### PR DESCRIPTION
This pull request addresses issue #3492.

It adds tests to make sure that passing a URI or a host, port, tls combination both yield a client to a block.

It tightens up the types on the initializers for `HTTP::Client`, expecting a string for host names in particular.

It includes a second definition of `self.new(uri : URI, tls = nil)` which yields to a block and completes this task.

All feedback welcome 🙂