### PR TITLE
Add dig method to Enumerable

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -204,6 +204,38 @@ describe "Enumerable" do
     end
   end
 
+  describe "dig" do
+    it "gets the value at given path given splat" do
+      a = [1, 2, 3]
+      h = {"a" => {"b" => {"c" => [10, 20]}}, a => {"a" => "b"}}
+
+      h.dig("a", "b", "c", 1).should eq(20)
+      h.dig("a", "b", "c").should eq([10, 20])
+      h.dig([1, 2, 3], "a").should eq("b")
+    end
+
+    it "can traverse arrays" do
+      h = {"w" => ["x", {"y" => "z"}]}
+      h.dig("w", 1, "y").should eq("z")
+    end
+
+    it "returns nil if not found" do
+      a = [1, 2, 3]
+      h = {"a" => {"b" => {"c" => 300}}, a => {"a" => "b"}}
+
+      h.dig("a", "b", "c", "d", "e").should eq(nil)
+      h.dig("z").should eq(nil)
+      h.dig("").should eq(nil)
+    end
+
+    it "works with arrays" do
+      a = ["z", {"a" => [[1], [["x"], "y"]]}]
+      a.dig(1, "a", 1, 0, 0).should eq("x")
+      a.dig(1, "a", 3, 9999999999).should eq(nil)
+      a.dig(1, "z").should eq(nil)
+    end
+  end
+
   describe "each_cons" do
     it "returns running pairs" do
       array = [] of Array(Int32)

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -198,6 +198,30 @@ module Enumerable(T)
     n.times { each { |x| yield x } }
   end
 
+  # Traverses the depth of a structure and returns the value.
+  # Returns nil if not found.
+  #
+  # ```
+  # h = {"a" => {"b" => [10, 20, 30]}}
+  # h.dig "a", "b", 1             # => 20
+  # h.dig "a", "b", "c", "d", "e" # => nil
+  # ```
+  def dig(key : K, *subkeys)
+    if (value = self[key]?) && value.responds_to?(:dig)
+      value.dig(*subkeys)
+    end
+  end
+
+  def dig(key : K)
+    self[key]?
+  end
+
+  def dig(key : Int32, *subkeys)
+    if (value = self[key]?) && value.responds_to?(:dig)
+      value.dig(*subkeys)
+    end
+  end
+
   # Iterates over the collection yielding chunks of size *count*, but advancing one by one.
   #
   #     [1, 2, 3, 4, 5].each_cons(2) do |cons|


### PR DESCRIPTION
Add the `dig` method as seen in Ruby's [Hash#dig](https://ruby-doc.org/core-2.3.1/Hash.html#method-i-dig) and [Array#dig](https://ruby-doc.org/core-2.3.1/Array.html#method-i-dig)

~~Also adds a `dig?` method that will not raise an error but will instead return `nil` if the key path doesn't exist.~~