### PR TITLE
`crystal build` without spepecified program files

### DIFF
--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -25,4 +25,11 @@ describe "Compiler" do
       `#{tempfile.path}`.should eq("Hello!")
     end
   end
+
+  it "build a project without specified sources" do
+    Dir.cd "#{__DIR__}/data/" do
+      Crystal::Command.run ["build"]
+      File.delete("dummy-proj")
+    end
+  end
 end

--- a/spec/compiler/data/shard.yml
+++ b/spec/compiler/data/shard.yml
@@ -1,0 +1,1 @@
+name: dummy-proj

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -9,6 +9,7 @@
 # an executable.
 
 require "json"
+require "yaml"
 require "./command/*"
 
 class Crystal::Command
@@ -388,8 +389,17 @@ class Crystal::Command
     end
 
     if filenames.size == 0 || (cursor_command && cursor_location.nil?)
-      puts option_parser
-      exit 1
+      unless shard_yml_exists?
+        puts option_parser
+        exit 1
+      else
+        if shard_proj_name.is_a?(String)
+          filenames << "./src/#{shard_proj_name}.cr"
+        else
+          error "\'name\' key is missing in shard.yml"
+          exit 1
+        end
+      end
     end
 
     sources = gather_sources(filenames)
@@ -455,6 +465,16 @@ class Crystal::Command
       end
     end
     values
+  end
+
+  private def shard_yml_exists?
+    return true if File.exists?("shard.yml") && File.file?("shard.yml")
+    false
+  end
+
+  private def shard_proj_name
+    config = YAML.parse(File.read("shard.yml")).as_h
+    config["name"].to_s if config.has_key?("name")
   end
 
   private def error(msg, exit_code = 1)


### PR DESCRIPTION
Hi all,

Currently, `crystal build` is not working without specified program files but just shows the usage.
But given the fact that almost all projects are created by `crystal init`, I think `crystal build` should work in that case.
I added a feature to the crystal command that `crystal build` works in a root directory of the project created by `crystal init`.
When user doesn't run `crystal build` in a root directory of a crystal project, it works as the same as before.

Best