### PR TITLE
Add argument to Array#flatten to specify amount of levels to flatten.

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1677,4 +1677,10 @@ describe "Array" do
   it "flattens" do
     [[1, 'a'], [[[[true], "hi"]]]].flatten.should eq([1, 'a', true, "hi"])
   end
+
+  it "flattens the specified amount" do
+    [[1, 'a'], [[[[true], "hi"]]]].flatten(1).should eq([1, 'a', [[[true], "hi"]]])
+    [[1, 'a'], [[[[true], "hi"]]]].flatten(2).should eq([1, 'a', [[true], "hi"]])
+    [[1, 'a'], [[[[true], "hi"]]]].flatten(100).should eq([1, 'a', true, "hi"])
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -1066,15 +1066,17 @@ class Array(T)
   # Returns a new Array that is a one-dimensional flattening of self (recursively).
   #
   # That is, for every element that is an array, extract its elements into the new array.
+  # It is also possible to give it an Integer argument telling it how many Array levels to flatten.
   #
   # ```
   # s = [1, 2, 3]         # => [1, 2, 3]
   # t = [4, 5, 6, [7, 8]] # => [4, 5, 6, [7, 8]]
   # a = [s, t, 9, 10]     # => [[1, 2, 3], [4, 5, 6, [7, 8]], 9, 10]
   # a.flatten             # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  # a.flatten(1)          # => [1, 2, 3, 4, 5, 6, [7, 8], 9, 10]
   # ```
-  def flatten
-    FlattenHelper(typeof(FlattenHelper.element_type(self))).flatten(self)
+  def flatten(steps : Int = -2)
+    FlattenHelper(typeof(FlattenHelper.element_type(self, steps))).flatten(self, steps)
   end
 
   def repeated_combinations(size : Int = self.size)
@@ -1969,25 +1971,29 @@ class Array(T)
   end
 
   private struct FlattenHelper(T)
-    def self.flatten(ary)
+    def self.flatten(ary, steps)
       result = [] of T
-      flatten ary, result
+      flatten ary, result, steps
       result
     end
 
-    def self.flatten(ary : Array, result)
-      ary.each do |elem|
-        flatten elem, result
+    def self.flatten(ary : Array, result, steps)
+      if steps == -1
+        result << ary
+      else
+        ary.each do |elem|
+          flatten elem, result, steps - 1
+        end
       end
     end
 
-    def self.flatten(other : T, result)
+    def self.flatten(other : T, result, steps)
       result << other
     end
 
-    def self.element_type(ary)
-      if ary.is_a?(Array)
-        element_type(ary.first)
+    def self.element_type(ary, steps)
+      if ary.is_a?(Array) && steps != -1
+        element_type(ary.first, steps - 1)
       else
         ary
       end


### PR DESCRIPTION
Ruby 1.8.7 added an optional numerical argument to Array#flatten to specify the amount of array levels that should be present. In practice, I've found that I almost always use flatten with an argument of 1 - in some situations it may protect against people that input arrays where the whole array shouldn't be flattened but just the topmost level. 

Regarding the implementation, I'm not all that happy with the recursion criteria. It is pretty trivial apart from that. It may be a good idea to add tests for the types of the array, but I am not certain how to write that so I left it out for now.