### PR TITLE
Update crystal init with new info available in shards v0.7.0

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -91,6 +91,13 @@ dependencies:
       parsed["version"].should eq("0.1.0")
       parsed["authors"].should eq(["John Smith <john@smith.com>"])
       parsed["license"].should eq("MIT")
+      parsed["crystal"].should eq(Crystal::VERSION)
+      parsed["targets"]?.should be_nil
+    end
+
+    describe_file "example_app/shard.yml" do |shard_yml|
+      parsed = YAML.parse(shard_yml)
+      parsed["targets"].should eq({"example_app" => {"main" => "src/example_app.cr"}})
     end
 
     describe_file "example/.travis.yml" do |travis|

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -934,4 +934,17 @@ describe "Semantic: macro" do
       Foo.foo
       ), inject_primitives: false) { int32 }
   end
+
+  it "gives correct error when method is invoked but macro exists at the same scope" do
+    assert_error %(
+      macro foo(x)
+      end
+
+      class Foo
+      end
+
+      Foo.new.foo
+      ),
+      "undefined method 'foo'"
+  end
 end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -480,6 +480,9 @@ class Crystal::Call
   end
 
   def check_macro_wrong_number_of_arguments(def_name)
+    obj = self.obj
+    return if obj && !obj.is_a?(Path)
+
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros
 

--- a/src/compiler/crystal/tools/init/template/shard.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/shard.yml.ecr
@@ -4,4 +4,12 @@ version: 0.1.0
 authors:
   - <%= config.author %> <<%= config.email %>>
 
+<%- if config.skeleton_type == "app" -%>
+targets:
+  <%= config.name %>:
+    main: src/<%= config.name %>.cr
+<%- end -%>
+
+crystal: <%= Crystal::VERSION %>
+
 license: MIT


### PR DESCRIPTION
This PR makes it so that when running `crystal init`, `shard.yml` will now contain the current crystal version and, if generating an app, the default target to build.