### PR TITLE
crystal init: add targets and crystal version for the upcoming shards  v0.7.0

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -91,6 +91,13 @@ dependencies:
       parsed["version"].should eq("0.1.0")
       parsed["authors"].should eq(["John Smith <john@smith.com>"])
       parsed["license"].should eq("MIT")
+      parsed["crystal"].should eq(Crystal::VERSION)
+      parsed["targets"]?.should be_nil
+    end
+
+    describe_file "example_app/shard.yml" do |shard_yml|
+      parsed = YAML.parse(shard_yml)
+      parsed["targets"].should eq({"example_app" => {"main" => "src/example_app.cr"}})
     end
 
     describe_file "example/.travis.yml" do |travis|

--- a/src/compiler/crystal/tools/init/template/shard.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/shard.yml.ecr
@@ -4,4 +4,12 @@ version: 0.1.0
 authors:
   - <%= config.author %> <<%= config.email %>>
 
+<%- if config.skeleton_type == "app" -%>
+targets:
+  <%= config.name %>:
+    main: src/<%= config.name %>.cr
+<%- end -%>
+
+crystal: <%= Crystal::VERSION %>
+
 license: MIT


### PR DESCRIPTION
This PR makes it so that when running crystal init, shard.yml will now contain the current crystal version and, if generating an app, the default target to build.