### PR TITLE
Support to_yaml in YAML.mapping generated classes

### DIFF
--- a/src/yaml/mapping.cr
+++ b/src/yaml/mapping.cr
@@ -146,6 +146,15 @@ module YAML
         {% end %}
       {% end %}
     end
+
+    def to_yaml(%emitter : YAML::Emitter)
+      %emitter.mapping do
+        {% for key, value in properties %}
+          {{key.id.stringify}}.to_yaml(%emitter)
+          @{{key.id}}.to_yaml(%emitter)
+        {% end %}
+      end
+    end
   end
 
   # This is a convenience method to allow invoking `YAML.mapping`

--- a/src/yaml/mapping.cr
+++ b/src/yaml/mapping.cr
@@ -150,8 +150,19 @@ module YAML
     def to_yaml(%emitter : YAML::Emitter)
       %emitter.mapping do
         {% for key, value in properties %}
-          {{key.id.stringify}}.to_yaml(%emitter)
-          @{{key.id}}.to_yaml(%emitter)
+          _{{key.id}} = @{{key.id}}
+
+          unless _{{key.id}}.is_a?(Nil)
+            # Key
+            {{value[:key] || key.id.stringify}}.to_yaml(%emitter)
+
+            # Value
+            {% if value[:converter] %}
+              {{ value[:converter] }}.to_yaml(_{{key.id}}, %emitter)
+            {% else %}
+              _{{key.id}}.to_yaml(%emitter)
+            {% end %}
+          end
         {% end %}
       end
     end

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -104,8 +104,20 @@ struct Time
   end
 end
 
+struct Time::Format
+  def to_yaml(value : Time, emitter : YAML::Emitter)
+    format(value).to_yaml(emitter)
+  end
+end
+
 module Time::EpochConverter
-  def self.to_yaml(value : Time, io : IO)
-    io << value.epoch
+  def self.to_yaml(value : Time, emitter : YAML::Emitter)
+    emitter << value.epoch
+  end
+end
+
+module Time::EpochMillisConverter
+  def self.to_yaml(value : Time, emitter : YAML::Emitter)
+    emitter << value.epoch_ms
   end
 end


### PR DESCRIPTION
Allows `to_yaml` on classes generated through `YAML.mapping`, prior to this patch you'd get an error as demonstrated [here](https://carc.in/#/r/1ecy).