### PR TITLE
Rename MemoryIO to IO::Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **(breaking change)** Removed `ifdef` from the language
 * **(breaking change)** Removed `PointerIO`
 * **(breaking change)** The `body` property of `HTTP::Request` is now an `IO?` (previously it was `String`). Use `request.body.try(&.gets_to_end)`  if you need the entire body as a String.
+* **(breaking change)** `MemoryIO` has been renamed to `IO::Memory`. The old name can still be used but will produce a compile-time warning. `MemoryIO` will be removed immediately after 0.20.0.
 * **(breaking change)** `Char#digit?` was split into `Char#ascii_number?` and `Char#number?`. The old name is still available and will produce a compile-time warning, but will be removed immediately after 0.20.0.
 * **(breaking change)** `Char#alpha?` was split into `Char#ascii_letter?` and `Char#letter?`. The old name is still available and will produce a compile-time warning, but will be removed immediately after 0.20.0.
 * **(breaking change)** The `Iterable` module is now generic

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -64,7 +64,7 @@ describe "Base64" do
     end
 
     it "encode to stream" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       count = Base64.encode("Now is the time for all good coders\nto learn Crystal", io)
       count.should eq 74
       io.rewind
@@ -72,7 +72,7 @@ describe "Base64" do
     end
 
     it "decode from stream" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       count = Base64.decode("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==", io)
       count.should eq 52
       io.rewind
@@ -163,7 +163,7 @@ describe "Base64" do
     it "encode to stream" do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
-      io = MemoryIO.new
+      io = IO::Memory.new
       Base64.strict_encode(s, io).should eq(56)
       io.rewind
       io.gets_to_end.should eq se
@@ -180,7 +180,7 @@ describe "Base64" do
     it "encode to stream" do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw=="
-      io = MemoryIO.new
+      io = IO::Memory.new
       Base64.urlsafe_encode(s, io).should eq(56)
       io.rewind
       io.gets_to_end.should eq se

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -98,7 +98,7 @@ describe "colorize" do
   end
 
   it "colorizes io with method" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     with_color.red.surround(io) do
       io << "hello"
     end
@@ -106,7 +106,7 @@ describe "colorize" do
   end
 
   it "colorizes io with symbol" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     with_color(:red).surround(io) do
       io << "hello"
     end
@@ -114,7 +114,7 @@ describe "colorize" do
   end
 
   it "colorizes with push and pop" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     with_color.red.push(io) do
       io << "hello"
       with_color.green.push(io) do
@@ -126,7 +126,7 @@ describe "colorize" do
   end
 
   it "colorizes with push and pop resets" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     with_color.red.push(io) do
       io << "hello"
       with_color.green.bold.push(io) do

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -68,7 +68,7 @@ describe CSV do
     end
 
     it "parses from IO" do
-      CSV.parse(MemoryIO.new(%("hel""lo",world))).should eq([[%(hel"lo), %(world)]])
+      CSV.parse(IO::Memory.new(%("hel""lo",world))).should eq([[%(hel"lo), %(world)]])
     end
 
     it "takes an optional separator argument" do

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -36,31 +36,31 @@ describe "ECR" do
   end
 
   it "does with <%= -%>" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template2.ecr", io
     io.to_s.should eq("123")
   end
 
   it "does with <%- %> (1)" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template3.ecr", io
     io.to_s.should eq("01")
   end
 
   it "does with <%- %> (2)" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template4.ecr", io
     io.to_s.should eq("hi\n01")
   end
 
   it "does with <% -%>" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template5.ecr", io
     io.to_s.should eq("hi\n      0\n      1\n  ")
   end
 
   it "does with -% inside string" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template6.ecr", io
     io.to_s.should eq("string with -%")
   end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -468,7 +468,7 @@ describe "Enumerable" do
     end
 
     it "joins with io and block" do
-      str = MemoryIO.new
+      str = IO::Memory.new
       [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
       str.to_s.should eq("2, 3, 4")
     end

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -3,7 +3,7 @@ require "http/content"
 
 describe HTTP::ChunkedContent do
   it "delays reading the next chunk as soon as one is consumed (#3270)" do
-    mem = MemoryIO.new("4\r\n123\n\r\n0\r\n\r\n")
+    mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
     bytes = uninitialized UInt8[4]
     bytes_read = content.read(bytes.to_slice)

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -47,8 +47,8 @@ module HTTP
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get("http://www.example.com"))
-    typeof(Client.post("http://www.example.com", body: MemoryIO.new))
-    typeof(Client.new("host").post("/", body: MemoryIO.new))
+    typeof(Client.post("http://www.example.com", body: IO::Memory.new))
+    typeof(Client.new("host").post("/", body: IO::Memory.new))
     typeof(Client.post("http://www.example.com", body: Bytes[65]))
     typeof(Client.new("host").post("/", body: Bytes[65]))
 

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -4,7 +4,7 @@ require "http/client/response"
 class HTTP::Client
   describe Response do
     it "parses response with body" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
       response.status_message.should eq("OK")
@@ -14,7 +14,7 @@ class HTTP::Client
     end
 
     it "parses response with streamed body" do
-      Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld")) do |response|
+      Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld")) do |response|
         response.version.should eq("HTTP/1.1")
         response.status_code.should eq(200)
         response.status_message.should eq("OK")
@@ -26,13 +26,13 @@ class HTTP::Client
     end
 
     it "parses response with streamed body, huge content-length" do
-      Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: #{UInt64::MAX}\r\n\r\nhelloworld")) do |response|
+      Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: #{UInt64::MAX}\r\n\r\nhelloworld")) do |response|
         response.headers["content-length"].should eq("#{UInt64::MAX}")
       end
     end
 
     it "parses response with body without \\r" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 5\n\nhelloworld"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 5\n\nhelloworld"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
       response.status_message.should eq("OK")
@@ -42,7 +42,7 @@ class HTTP::Client
     end
 
     it "parses response with body but without content-length" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\n\r\nhelloworld"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\n\r\nhelloworld"))
       response.status_code.should eq(200)
       response.status_message.should eq("OK")
       response.headers.size.should eq(0)
@@ -50,7 +50,7 @@ class HTTP::Client
     end
 
     it "parses response with empty body but without content-length" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 404 Not Found\r\n\r\n"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 404 Not Found\r\n\r\n"))
       response.status_code.should eq(404)
       response.status_message.should eq("Not Found")
       response.headers.size.should eq(0)
@@ -58,7 +58,7 @@ class HTTP::Client
     end
 
     it "parses response without body" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 100 Continue\r\n\r\n"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 100 Continue\r\n\r\n"))
       response.status_code.should eq(100)
       response.status_message.should eq("Continue")
       response.headers.size.should eq(0)
@@ -66,7 +66,7 @@ class HTTP::Client
     end
 
     it "parses response without status message" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200\r\n\r\n"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200\r\n\r\n"))
       response.status_code.should eq(200)
       response.status_message.should eq("")
       response.headers.size.should eq(0)
@@ -74,37 +74,37 @@ class HTTP::Client
     end
 
     it "parses response with duplicated headers" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nWarning: 111 Revalidation failed\r\nWarning: 110 Response is stale\r\n\r\nhelloworld"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nWarning: 111 Revalidation failed\r\nWarning: 110 Response is stale\r\n\r\nhelloworld"))
       response.headers.get("Warning").should eq(["111 Revalidation failed", "110 Response is stale"])
     end
 
     it "parses response with cookies" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: a=b\r\nSet-Cookie: c=d\r\n\r\nhelloworld"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: a=b\r\nSet-Cookie: c=d\r\n\r\nhelloworld"))
       response.cookies["a"].value.should eq("b")
       response.cookies["c"].value.should eq("d")
     end
 
     it "parses response with chunked body" do
-      response = Response.from_io(io = MemoryIO.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n"))
+      response = Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n"))
       response.body.should eq("abcde0123456789")
       io.gets.should be_nil
     end
 
     it "parses response with streamed chunked body" do
-      Response.from_io(io = MemoryIO.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n")) do |response|
+      Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n")) do |response|
         response.body_io.gets_to_end.should eq("abcde0123456789")
         io.gets.should be_nil
       end
     end
 
     it "parses response with chunked body of size 0" do
-      response = Response.from_io(io = MemoryIO.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"))
+      response = Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"))
       response.body.should eq("")
       io.gets.should be_nil
     end
 
     it "parses response ignoring body" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"), true)
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"), true)
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
       response.status_message.should eq("OK")
@@ -114,7 +114,7 @@ class HTTP::Client
     end
 
     it "parses 204 response without body but Content-Length == 0 (#2512)" do
-      response = Response.from_io(MemoryIO.new("HTTP/1.1 204 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\n\r\n"))
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 204 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\n\r\n"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(204)
       response.status_message.should eq("OK")
@@ -144,7 +144,7 @@ class HTTP::Client
       headers["Content-Length"] = "5"
 
       response = Response.new(200, "hello", headers)
-      io = MemoryIO.new
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello")
     end
@@ -157,7 +157,7 @@ class HTTP::Client
 
       response = Response.new(200, "hello", headers)
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: foo=bar; path=/\r\n\r\nhello")
 
@@ -177,28 +177,28 @@ class HTTP::Client
 
     it "sets content length from body" do
       response = Response.new(200, "hello")
-      io = MemoryIO.new
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
     end
 
     it "sets content length even without body" do
       response = Response.new(200)
-      io = MemoryIO.new
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
     end
 
     it "serialize as chunked with body_io" do
-      response = Response.new(200, body_io: MemoryIO.new("hello"))
-      io = MemoryIO.new
+      response = Response.new(200, body_io: IO::Memory.new("hello"))
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")
     end
 
     it "serialize as not chunked with body_io if HTTP/1.0" do
-      response = Response.new(200, version: "HTTP/1.0", body_io: MemoryIO.new("hello"))
-      io = MemoryIO.new
+      response = Response.new(200, version: "HTTP/1.0", body_io: IO::Memory.new("hello"))
+      io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello")
     end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -9,7 +9,7 @@ module HTTP
       orignal_headers = headers.dup
       request = Request.new "GET", "/", headers
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
       headers.should eq(orignal_headers)
@@ -21,7 +21,7 @@ module HTTP
       orignal_headers = headers.dup
       request = Request.new "GET", "/greet?q=hello&name=world", headers
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
       headers.should eq(orignal_headers)
@@ -34,7 +34,7 @@ module HTTP
       request = Request.new "GET", "/", headers
       request.cookies << Cookie.new("foo", "bar")
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
       headers.should eq(orignal_headers)
@@ -48,7 +48,7 @@ module HTTP
 
       request = Request.new "GET", "/", headers
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: foo=bar\r\n\r\n")
 
@@ -69,39 +69,39 @@ module HTTP
 
     it "serialize POST (with body)" do
       request = Request.new "POST", "/", body: "thisisthebody"
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
     end
 
     it "serialize POST (with bytes body)" do
       request = Request.new "POST", "/", body: Bytes['a'.ord, 'b'.ord]
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nab")
     end
 
     it "serialize POST (with io body, without content-length header)" do
-      request = Request.new "POST", "/", body: MemoryIO.new("thisisthebody")
-      io = MemoryIO.new
+      request = Request.new "POST", "/", body: IO::Memory.new("thisisthebody")
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nd\r\nthisisthebody\r\n0\r\n\r\n")
     end
 
     it "serialize POST (with io body, with content-length header)" do
       string = "thisisthebody"
-      request = Request.new "POST", "/", body: MemoryIO.new(string)
+      request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize
-      io = MemoryIO.new
+      io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
     end
 
     it "raises if serializing POST body with incorrect content-length (less then real)" do
       string = "thisisthebody"
-      request = Request.new "POST", "/", body: MemoryIO.new(string)
+      request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize - 1
-      io = MemoryIO.new
+      io = IO::Memory.new
       expect_raises(ArgumentError) do
         request.to_io(io)
       end
@@ -109,44 +109,44 @@ module HTTP
 
     it "raises if serializing POST body with incorrect content-length (more then real)" do
       string = "thisisthebody"
-      request = Request.new "POST", "/", body: MemoryIO.new(string)
+      request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize + 1
-      io = MemoryIO.new
+      io = IO::Memory.new
       expect_raises(ArgumentError) do
         request.to_io(io)
       end
     end
 
     it "parses GET" do
-      request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
     it "parses GET with query params" do
-      request = Request.from_io(MemoryIO.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/greet")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
     it "parses GET without \\r" do
-      request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
     it "parses empty header" do
-      request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org", "Referer" => ""})
     end
 
     it "parses GET with cookie" do
-      request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: a=b\r\n\r\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: a=b\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.cookies["a"].value.should eq("b")
@@ -156,7 +156,7 @@ module HTTP
     end
 
     it "headers are case insensitive" do
-      request = Request.from_io(MemoryIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       headers = request.headers.not_nil!
       headers["HOST"].should eq("host.example.org")
       headers["host"].should eq("host.example.org")
@@ -164,7 +164,7 @@ module HTTP
     end
 
     it "parses POST (with body)" do
-      request = Request.from_io(MemoryIO.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).as(Request)
+      request = Request.from_io(IO::Memory.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).as(Request)
       request.method.should eq("POST")
       request.path.should eq("/foo")
       request.headers.should eq({"Content-Length" => "13"})
@@ -172,7 +172,7 @@ module HTTP
     end
 
     it "handles malformed request" do
-      request = Request.from_io(MemoryIO.new("nonsense"))
+      request = Request.from_io(IO::Memory.new("nonsense"))
       request.should be_a(Request::BadRequest)
     end
 
@@ -208,7 +208,7 @@ module HTTP
 
     describe "#path" do
       it "returns parsed path" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path.should eq("/api/v3/some/resource")
       end
 
@@ -221,22 +221,22 @@ module HTTP
 
     describe "#path=" do
       it "sets path" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
         request.path.should eq("/api/v2/greet")
       end
 
       it "updates @resource" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
         request.resource.should eq("/api/v2/greet?filter=hello&world=test")
       end
 
       it "updates serialized form" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
 
-        io = MemoryIO.new
+        io = IO::Memory.new
         request.to_io(io)
         io.to_s.should eq("GET /api/v2/greet?filter=hello&world=test HTTP/1.1\r\n\r\n")
       end
@@ -244,29 +244,29 @@ module HTTP
 
     describe "#query" do
       it "returns request's query" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query.should eq("filter=hello&world=test")
       end
     end
 
     describe "#query=" do
       it "sets query" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
         request.query.should eq("q=isearchforsomething&locale=de")
       end
 
       it "updates @resource" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
         request.resource.should eq("/api/v3/some/resource?q=isearchforsomething&locale=de")
       end
 
       it "updates serialized form" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
 
-        io = MemoryIO.new
+        io = IO::Memory.new
         request.to_io(io)
         io.to_s.should eq("GET /api/v3/some/resource?q=isearchforsomething&locale=de HTTP/1.1\r\n\r\n")
       end
@@ -274,7 +274,7 @@ module HTTP
 
     describe "#query_params" do
       it "returns parsed HTTP::Params" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
         params["foo"].should eq("bar")
@@ -283,14 +283,14 @@ module HTTP
       end
 
       it "happily parses when query is not a canonical url-encoded string" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?{\"hello\":\"world\"} HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?{\"hello\":\"world\"} HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
         params["{\"hello\":\"world\"}"].should eq("")
         params.to_s.should eq("%7B%22hello%22%3A%22world%22%7D=")
       end
 
       it "affects #query when modified" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
         params["foo"] = "not-bar"
@@ -298,7 +298,7 @@ module HTTP
       end
 
       it "updates @resource when modified" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
         params["foo"] = "not-bar"
@@ -306,18 +306,18 @@ module HTTP
       end
 
       it "updates serialized form when modified" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
         params["foo"] = "not-bar"
 
-        io = MemoryIO.new
+        io = IO::Memory.new
         request.to_io(io)
         io.to_s.should eq("GET /api/v3/some/resource?foo=not-bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")
       end
 
       it "is affected when #query is modified" do
-        request = Request.from_io(MemoryIO.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
+        request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
         new_query = "foo=not-bar&foo=not-baz&not-baz=hello&name=world"

--- a/spec/std/http/server/handlers/deflate_handler_spec.cr
+++ b/spec/std/http/server/handlers/deflate_handler_spec.cr
@@ -3,7 +3,7 @@ require "http/server"
 
 describe HTTP::DeflateHandler do
   it "doesn't deflates if doesn't have 'deflate' in Accept-Encoding header" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
@@ -20,7 +20,7 @@ describe HTTP::DeflateHandler do
   end
 
   it "deflates if has deflate in 'deflate' Accept-Encoding header" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, deflate, other"
 
@@ -38,7 +38,7 @@ describe HTTP::DeflateHandler do
     response2 = HTTP::Client::Response.from_io(io, decompress: false)
     body = response2.body
 
-    io2 = MemoryIO.new
+    io2 = IO::Memory.new
     deflate = Zlib::Deflate.new(io2)
     deflate.print "Hello"
     deflate.close
@@ -48,7 +48,7 @@ describe HTTP::DeflateHandler do
   end
 
   it "deflates gzip if has deflate in 'deflate' Accept-Encoding header" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, gzip, other"
 
@@ -66,7 +66,7 @@ describe HTTP::DeflateHandler do
     response2 = HTTP::Client::Response.from_io(io, decompress: false)
     body = response2.body
 
-    io2 = MemoryIO.new
+    io2 = IO::Memory.new
     deflate = Zlib::Deflate.gzip(io2)
     deflate.print "Hello"
     deflate.close

--- a/spec/std/http/server/handlers/error_handler_spec.cr
+++ b/spec/std/http/server/handlers/error_handler_spec.cr
@@ -3,7 +3,7 @@ require "http/server"
 
 describe HTTP::ErrorHandler do
   it "rescues from exception" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
@@ -22,7 +22,7 @@ describe HTTP::ErrorHandler do
   end
 
   it "can return a generic error message" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)

--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -9,7 +9,7 @@ end
 
 describe HTTP::Handler do
   it "responds with not found if there's no next handler" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -3,13 +3,13 @@ require "http/server"
 
 describe HTTP::LogHandler do
   it "logs" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
     called = false
-    log_io = MemoryIO.new
+    log_io = IO::Memory.new
     handler = HTTP::LogHandler.new(log_io)
     handler.next = ->(ctx : HTTP::Server::Context) { called = true }
     handler.call(context)
@@ -18,13 +18,13 @@ describe HTTP::LogHandler do
   end
 
   it "does log errors" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
 
     called = false
-    log_io = MemoryIO.new
+    log_io = IO::Memory.new
     handler = HTTP::LogHandler.new(log_io)
     handler.next = ->(ctx : HTTP::Server::Context) { raise "foo" }
     expect_raises do

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "http/server"
 
 private def handle(request, fallthrough = true)
-  io = MemoryIO.new
+  io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
   handler = HTTP::StaticFileHandler.new "#{__DIR__}/static", fallthrough

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -3,7 +3,7 @@ require "http/server"
 
 describe HTTP::WebSocketHandler do
   it "returns not found if the request is not an websocket upgrade" do
-    io = MemoryIO.new
+    io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
@@ -20,7 +20,7 @@ describe HTTP::WebSocketHandler do
 
   {% for connection in ["Upgrade", "keep-alive, Upgrade"] %}
     it "gives upgrade response for websocket upgrade request with '{{connection.id}}' request" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       headers = HTTP::Headers{
         "Upgrade" =>           "websocket",
         "Connection" =>        {{connection}},
@@ -36,7 +36,7 @@ describe HTTP::WebSocketHandler do
       begin
         handler.call context
       rescue IO::Error
-        # Raises because the MemoryIO is empty
+        # Raises because the IO::Memory is empty
       end
 
       response.close

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -48,14 +48,14 @@ module HTTP
   class Server
     describe Response do
       it "closes" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.close
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
       end
 
       it "prints less then buffer's size" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.print("Hello")
         response.close
@@ -63,7 +63,7 @@ module HTTP
       end
 
       it "prints less then buffer's size to output" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.output.print("Hello")
         response.output.close
@@ -71,7 +71,7 @@ module HTTP
       end
 
       it "prints more then buffer's size" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         str = "1234567890"
         1000.times do
@@ -84,7 +84,7 @@ module HTTP
       end
 
       it "prints with content length" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.headers["Content-Length"] = "10"
         response.print("1234")
@@ -94,7 +94,7 @@ module HTTP
       end
 
       it "prints with content length (method)" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.content_length = 10
         response.print("1234")
@@ -104,7 +104,7 @@ module HTTP
       end
 
       it "adds header" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.headers["Content-Type"] = "text/plain"
         response.print("Hello")
@@ -113,7 +113,7 @@ module HTTP
       end
 
       it "sets content type" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.content_type = "text/plain"
         response.print("Hello")
@@ -122,7 +122,7 @@ module HTTP
       end
 
       it "changes status and others" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.status_code = 404
         response.version = "HTTP/1.0"
@@ -131,7 +131,7 @@ module HTTP
       end
 
       it "flushes" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.print("Hello")
         response.flush
@@ -141,7 +141,7 @@ module HTTP
       end
 
       it "wraps output" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.output = ReverseResponseOutput.new(response.output)
         response.print("1234")
@@ -150,7 +150,7 @@ module HTTP
       end
 
       it "writes and flushes with HTTP 1.0" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io, "HTTP/1.0")
         response.print("1234")
         response.flush
@@ -158,7 +158,7 @@ module HTTP
       end
 
       it "resets and clears headers and cookies" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.headers["Foo"] = "Bar"
         response.cookies["Bar"] = "Foo"
@@ -168,13 +168,13 @@ module HTTP
       end
 
       it "writes cookie headers" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.cookies["Bar"] = "Foo"
         response.close
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\n")
 
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.cookies["Bar"] = "Foo"
         response.print("Hello")
@@ -183,13 +183,13 @@ module HTTP
       end
 
       it "responds with an error" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.content_type = "text/html"
         response.respond_with_error
         io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n1a\r\n500 Internal Server Error\n\r\n")
 
-        io = MemoryIO.new
+        io = IO::Memory.new
         response = Response.new(io)
         response.respond_with_error("Bad Request", 400)
         io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n10\r\n400 Bad Request\n\r\n")
@@ -230,8 +230,8 @@ module HTTP
         context.response.print "Hello world"
       end
 
-      input = MemoryIO.new("GET / HTTP/1.1\r\n\r\n")
-      output = MemoryIO.new
+      input = IO::Memory.new("GET / HTTP/1.1\r\n\r\n")
+      output = IO::Memory.new
       processor.process(input, output)
       output.rewind
       output.gets_to_end.should eq(requestize(<<-RESPONSE
@@ -251,7 +251,7 @@ module HTTP
         context.response.puts "Hello world\r"
       end
 
-      input = MemoryIO.new(requestize(<<-REQUEST
+      input = IO::Memory.new(requestize(<<-REQUEST
         POST / HTTP/1.1
         Content-Length: 7
 
@@ -262,7 +262,7 @@ module HTTP
         hello
         REQUEST
       ))
-      output = MemoryIO.new
+      output = IO::Memory.new
       processor.process(input, output)
       output.rewind
       output.gets_to_end.should eq(requestize(<<-RESPONSE
@@ -286,16 +286,16 @@ module HTTP
     it "handles Errno" do
       processor = HTTP::Server::RequestProcessor.new { }
       input = RaiseErrno.new(Errno::ECONNRESET)
-      output = MemoryIO.new
+      output = IO::Memory.new
       processor.process(input, output)
       output.rewind.gets_to_end.empty?.should be_true
     end
 
     it "catches raised error on handler" do
       processor = HTTP::Server::RequestProcessor.new { raise "OH NO" }
-      input = MemoryIO.new("GET / HTTP/1.1\r\n\r\n")
-      output = MemoryIO.new
-      error = MemoryIO.new
+      input = IO::Memory.new("GET / HTTP/1.1\r\n\r\n")
+      output = IO::Memory.new
+      error = IO::Memory.new
       processor.process(input, output, error)
       output.rewind.gets_to_end.should match(/Internal Server Error/)
     end

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -27,7 +27,7 @@ describe HTTP::WebSocket do
   describe "receive" do
     it "can read a small text packet" do
       data = Bytes[0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(64)
@@ -39,7 +39,7 @@ describe HTTP::WebSocket do
     it "can read partial packets" do
       data = Bytes[0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
         0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(3)
@@ -58,7 +58,7 @@ describe HTTP::WebSocket do
     it "can read masked text message" do
       data = Bytes[0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58,
         0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(3)
@@ -78,7 +78,7 @@ describe HTTP::WebSocket do
       data = Bytes[0x01, 0x03, 0x48, 0x65, 0x6c, 0x80, 0x02, 0x6c, 0x6f,
         0x01, 0x03, 0x48, 0x65, 0x6c, 0x80, 0x02, 0x6c, 0x6f]
 
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(10)
@@ -96,7 +96,7 @@ describe HTTP::WebSocket do
 
     it "read ping packet" do
       data = Bytes[0x89, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(64)
@@ -109,7 +109,7 @@ describe HTTP::WebSocket do
       data = Bytes[0x01, 0x03, 0x48, 0x65, 0x6c,
         0x89, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
         0x80, 0x02, 0x6c, 0x6f]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(64)
@@ -129,7 +129,7 @@ describe HTTP::WebSocket do
 
     it "read long packet" do
       data = File.read("#{__DIR__}/../data/websocket_longpacket.bin")
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(2048)
@@ -145,7 +145,7 @@ describe HTTP::WebSocket do
       header = Bytes[0x82, 127_u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0]
       data.copy_from(header)
 
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(0x010000)
@@ -156,7 +156,7 @@ describe HTTP::WebSocket do
 
     it "can read a close packet" do
       data = Bytes[0x88, 0x00]
-      io = MemoryIO.new(data)
+      io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
 
       buffer = Slice(UInt8).new(64)
@@ -169,7 +169,7 @@ describe HTTP::WebSocket do
     it "sends long data with correct header" do
       size = UInt16::MAX.to_u64 + 1
       big_string = "a" * size
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.send(big_string)
       bytes = io.to_slice
@@ -186,7 +186,7 @@ describe HTTP::WebSocket do
     it "sets binary opcode if used with slice" do
       sent_bytes = uninitialized UInt8[4]
 
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io, masked: true)
       ws.send(sent_bytes.to_slice)
       bytes = io.to_slice
@@ -196,7 +196,7 @@ describe HTTP::WebSocket do
 
   describe "stream" do
     it "sends continuous data and splits it to frames" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.stream do |io| # default frame size of 1024
         3.times { io.write(("a" * 512).to_slice) }
@@ -227,7 +227,7 @@ describe HTTP::WebSocket do
     end
 
     it "sets opcode of first frame to binary if stream is called with binary = true" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.stream(binary: true) { |io| }
 
@@ -239,7 +239,7 @@ describe HTTP::WebSocket do
   describe "send_masked" do
     it "sends the data with a bitmask" do
       sent_string = "hello"
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io, masked: true)
       ws.send(sent_string)
       bytes = io.to_slice
@@ -256,7 +256,7 @@ describe HTTP::WebSocket do
     it "sends long data with correct header" do
       size = UInt16::MAX.to_u64 + 1
       big_string = "a" * size
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io, masked: true)
       ws.send(big_string)
       bytes = io.to_slice
@@ -275,7 +275,7 @@ describe HTTP::WebSocket do
   describe "close" do
     it "closes with message" do
       message = "bye"
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.close(message)
       bytes = io.to_slice
@@ -284,7 +284,7 @@ describe HTTP::WebSocket do
     end
 
     it "closes without message" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.close
       bytes = io.to_slice

--- a/spec/std/io/argf_spec.cr
+++ b/spec/std/io/argf_spec.cr
@@ -3,7 +3,7 @@ require "spec"
 describe IO::ARGF do
   it "reads from STDIN if ARGV isn't specified" do
     argv = [] of String
-    stdin = MemoryIO.new("hello")
+    stdin = IO::Memory.new("hello")
 
     argf = IO::ARGF.new argv, stdin
     argf.path.should eq("-")
@@ -14,7 +14,7 @@ describe IO::ARGF do
   it "reads from ARGV if specified" do
     path1 = "#{__DIR__}/../data/argf_test_file_1.txt"
     path2 = "#{__DIR__}/../data/argf_test_file_2.txt"
-    stdin = MemoryIO.new("")
+    stdin = IO::Memory.new("")
     argv = [path1, path2]
 
     argf = IO::ARGF.new argv, stdin

--- a/spec/std/io/byte_format_spec.cr
+++ b/spec/std/io/byte_format_spec.cr
@@ -13,7 +13,7 @@ private def assert_bytes_reversed(io, *bytes)
 end
 
 private def new_string_io(*bytes)
-  io = MemoryIO.new
+  io = IO::Memory.new
   bytes.each { |byte| io.write_byte byte.to_u8 }
   io.rewind
   io
@@ -23,43 +23,43 @@ describe IO::ByteFormat do
   describe "little endian" do
     describe "encode" do
       it "writes int8" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x12_i8, IO::ByteFormat::LittleEndian
         assert_bytes io, 0x12
       end
 
       it "writes int16" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x1234_i16, IO::ByteFormat::LittleEndian
         assert_bytes io, 0x34, 0x12
       end
 
       it "writes uint16" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x1234_u16, IO::ByteFormat::LittleEndian
         assert_bytes io, 0x34, 0x12
       end
 
       it "writes int32" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x12345678_i32, IO::ByteFormat::LittleEndian
         assert_bytes io, 0x78, 0x56, 0x34, 0x12
       end
 
       it "writes int64" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x123456789ABCDEF0_i64, IO::ByteFormat::LittleEndian
         assert_bytes io, 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12
       end
 
       it "writes float32" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 1.234_f32, IO::ByteFormat::LittleEndian
         assert_bytes io, 0xB6, 0xF3, 0x9D, 0x3F
       end
 
       it "writes float64" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 1.234, IO::ByteFormat::LittleEndian
         assert_bytes io, 0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F
       end
@@ -113,37 +113,37 @@ describe IO::ByteFormat do
   describe "big endian" do
     describe "encode" do
       it "writes int8" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x12_i8, IO::ByteFormat::BigEndian
         assert_bytes io, 0x12
       end
 
       it "writes int16" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x1234_i16, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x34, 0x12
       end
 
       it "writes int32" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x12345678_i32, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x78, 0x56, 0x34, 0x12
       end
 
       it "writes int64" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 0x123456789ABCDEF0_i64, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12
       end
 
       it "writes float32" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 1.234_f32, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0xB6, 0xF3, 0x9D, 0x3F
       end
 
       it "writes float64" do
-        io = MemoryIO.new
+        io = IO::Memory.new
         io.write_bytes 1.234, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F
       end

--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -26,7 +26,7 @@ end
 describe "IO::Delimited" do
   describe "#read" do
     it "doesn't read past the limit" do
-      io = MemoryIO.new("abcderzzrfgzr")
+      io = IO::Memory.new("abcderzzrfgzr")
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
       delimited.gets_to_end.should eq("abcderz")
@@ -34,7 +34,7 @@ describe "IO::Delimited" do
     end
 
     it "doesn't read past the limit (char-by-char)" do
-      io = MemoryIO.new("abcderzzrfg")
+      io = IO::Memory.new("abcderzzrfg")
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
       delimited.read_char.should eq('a')
@@ -54,35 +54,35 @@ describe "IO::Delimited" do
     end
 
     it "doesn't clobber active_delimiter_buffer" do
-      io = MemoryIO.new("ab12312")
+      io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "12345")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
     it "handles the delimiter at the start" do
-      io = MemoryIO.new("ab12312")
+      io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "ab1")
 
       delimited.read_char.should eq(nil)
     end
 
     it "handles the delimiter at the end" do
-      io = MemoryIO.new("ab12312z")
+      io = IO::Memory.new("ab12312z")
       delimited = IO::Delimited.new(io, read_delimiter: "z")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
     it "handles nearly a delimiter at the end" do
-      io = MemoryIO.new("ab12312")
+      io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "122")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
     it "doesn't clobber the buffer on closely-offset partial matches" do
-      io = MemoryIO.new("abab1234abcdefgh")
+      io = IO::Memory.new("abab1234abcdefgh")
       delimited = IO::Delimited.new(io, read_delimiter: "abcdefgh")
 
       delimited.gets_to_end.should eq("abab1234")
@@ -98,7 +98,7 @@ describe "IO::Delimited" do
 
   describe "#write" do
     it "raises" do
-      delimited = IO::Delimited.new(MemoryIO.new, read_delimiter: "zr")
+      delimited = IO::Delimited.new(IO::Memory.new, read_delimiter: "zr")
       expect_raises(IO::Error, "Can't write to IO::Delimited") do
         delimited.puts "test string"
       end
@@ -107,7 +107,7 @@ describe "IO::Delimited" do
 
   describe "#close" do
     it "stops reading" do
-      io = MemoryIO.new "abcdefg"
+      io = IO::Memory.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
       delimited.read_char.should eq('a')
@@ -121,7 +121,7 @@ describe "IO::Delimited" do
     end
 
     it "closes the underlying stream if sync_close is true" do
-      io = MemoryIO.new "abcdefg"
+      io = IO::Memory.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr", sync_close: true)
       delimited.sync_close?.should eq(true)
 

--- a/spec/std/io/hexdump_spec.cr
+++ b/spec/std/io/hexdump_spec.cr
@@ -15,7 +15,7 @@ describe IO::Hexdump do
         EOF
 
       IO.pipe do |r, w|
-        io = MemoryIO.new(ascii_table.bytesize)
+        io = IO::Memory.new(ascii_table.bytesize)
         r = IO::Hexdump.new(r, output: io, read: true)
 
         slice = Slice(UInt8).new(101) { |i| i.to_u8 + 32 }
@@ -42,7 +42,7 @@ describe IO::Hexdump do
         EOF
 
       IO.pipe do |r, w|
-        io = MemoryIO.new(ascii_table.bytesize)
+        io = IO::Memory.new(ascii_table.bytesize)
         w = IO::Hexdump.new(w, output: io, write: true)
 
         slice = Slice(UInt8).new(96) { |i| i.to_u8 + 32 }

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -2,10 +2,10 @@ require "spec"
 require "big_int"
 require "base64"
 
-# This is a non-optimized version of MemoryIO so we can test
+# This is a non-optimized version of IO::Memory so we can test
 # raw IO. Optimizations for specific IOs are tested separately
 # (for example in buffered_io_spec)
-private class SimpleMemoryIO
+private class SimpleIOMemory
   include IO
 
   getter buffer : UInt8*
@@ -113,7 +113,7 @@ describe IO do
 
   describe "IO iterators" do
     it "iterates by line" do
-      io = MemoryIO.new("hello\nbye\n")
+      io = IO::Memory.new("hello\nbye\n")
       lines = io.each_line
       lines.next.should eq("hello\n")
       lines.next.should eq("bye\n")
@@ -124,7 +124,7 @@ describe IO do
     end
 
     it "iterates by char" do
-      io = MemoryIO.new("abあぼ")
+      io = IO::Memory.new("abあぼ")
       chars = io.each_char
       chars.next.should eq('a')
       chars.next.should eq('b')
@@ -137,7 +137,7 @@ describe IO do
     end
 
     it "iterates by byte" do
-      io = MemoryIO.new("ab")
+      io = IO::Memory.new("ab")
       bytes = io.each_byte
       bytes.next.should eq('a'.ord)
       bytes.next.should eq('b'.ord)
@@ -150,24 +150,24 @@ describe IO do
 
   it "copies" do
     string = "abあぼ"
-    src = MemoryIO.new(string)
-    dst = MemoryIO.new
+    src = IO::Memory.new(string)
+    dst = IO::Memory.new
     IO.copy(src, dst).should eq(string.bytesize)
     dst.to_s.should eq(string)
   end
 
   it "copies with limit" do
     string = "abcあぼ"
-    src = MemoryIO.new(string)
-    dst = MemoryIO.new
+    src = IO::Memory.new(string)
+    dst = IO::Memory.new
     IO.copy(src, dst, 3).should eq(3)
     dst.to_s.should eq("abc")
   end
 
   it "raises on copy with negative limit" do
     string = "abcあぼ"
-    src = MemoryIO.new(string)
-    dst = MemoryIO.new
+    src = IO::Memory.new(string)
+    dst = IO::Memory.new
     expect_raises(ArgumentError, "negative limit") do
       IO.copy(src, dst, -10)
     end
@@ -184,7 +184,7 @@ describe IO do
 
   describe "read operations" do
     it "does gets" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.gets.should eq("hello\n")
       io.gets.should eq("world\n")
       io.gets.should be_nil
@@ -192,12 +192,12 @@ describe IO do
 
     it "does gets with big line" do
       big_line = "a" * 20_000
-      io = SimpleMemoryIO.new("#{big_line}\nworld\n")
+      io = SimpleIOMemory.new("#{big_line}\nworld\n")
       io.gets.should eq("#{big_line}\n")
     end
 
     it "does gets with char delimiter" do
-      io = SimpleMemoryIO.new("hello world")
+      io = SimpleIOMemory.new("hello world")
       io.gets('w').should eq("hello w")
       io.gets('r').should eq("or")
       io.gets('r').should eq("ld")
@@ -205,33 +205,33 @@ describe IO do
     end
 
     it "does gets with unicode char delimiter" do
-      io = SimpleMemoryIO.new("こんにちは")
+      io = SimpleIOMemory.new("こんにちは")
       io.gets('ち').should eq("こんにち")
       io.gets('ち').should eq("は")
       io.gets('ち').should be_nil
     end
 
     it "gets with string as delimiter" do
-      io = SimpleMemoryIO.new("hello world")
+      io = SimpleIOMemory.new("hello world")
       io.gets("lo").should eq("hello")
       io.gets("rl").should eq(" worl")
       io.gets("foo").should eq("d")
     end
 
     it "gets with empty string as delimiter" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.gets("").should eq("hello\nworld\n")
     end
 
     it "gets with single byte string as delimiter" do
-      io = SimpleMemoryIO.new("hello\nworld\nbye")
+      io = SimpleIOMemory.new("hello\nworld\nbye")
       io.gets("\n").should eq("hello\n")
       io.gets("\n").should eq("world\n")
       io.gets("\n").should eq("bye")
     end
 
     it "does gets with limit" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.gets(3).should eq("hel")
       io.gets(10_000).should eq("lo\n")
       io.gets(10_000).should eq("world\n")
@@ -239,7 +239,7 @@ describe IO do
     end
 
     it "does gets with char and limit" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.gets('o', 2).should eq("he")
       io.gets('w', 10_000).should eq("llo\nw")
       io.gets('z', 10_000).should eq("orld\n")
@@ -247,14 +247,14 @@ describe IO do
     end
 
     it "raises if invoking gets with negative limit" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       expect_raises ArgumentError, "negative limit" do
         io.gets(-1)
       end
     end
 
     it "does read_line with limit" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.read_line(3).should eq("hel")
       io.read_line(10_000).should eq("lo\n")
       io.read_line(10_000).should eq("world\n")
@@ -262,7 +262,7 @@ describe IO do
     end
 
     it "does read_line with char and limit" do
-      io = SimpleMemoryIO.new("hello\nworld\n")
+      io = SimpleIOMemory.new("hello\nworld\n")
       io.read_line('o', 2).should eq("he")
       io.read_line('w', 10_000).should eq("llo\nw")
       io.read_line('z', 10_000).should eq("orld\n")
@@ -270,13 +270,13 @@ describe IO do
     end
 
     it "reads all remaining content" do
-      io = SimpleMemoryIO.new("foo\nbar\nbaz\n")
+      io = SimpleIOMemory.new("foo\nbar\nbaz\n")
       io.gets.should eq("foo\n")
       io.gets_to_end.should eq("bar\nbaz\n")
     end
 
     it "reads char" do
-      io = SimpleMemoryIO.new("hi 世界")
+      io = SimpleIOMemory.new("hi 世界")
       io.read_char.should eq('h')
       io.read_char.should eq('i')
       io.read_char.should eq(' ')
@@ -296,7 +296,7 @@ describe IO do
     end
 
     it "reads byte" do
-      io = SimpleMemoryIO.new("hello")
+      io = SimpleIOMemory.new("hello")
       io.read_byte.should eq('h'.ord)
       io.read_byte.should eq('e'.ord)
       io.read_byte.should eq('l'.ord)
@@ -306,7 +306,7 @@ describe IO do
     end
 
     it "does each_line" do
-      io = SimpleMemoryIO.new("a\nbb\ncc")
+      io = SimpleIOMemory.new("a\nbb\ncc")
       counter = 0
       io.each_line do |line|
         case counter
@@ -323,7 +323,7 @@ describe IO do
     end
 
     it "raises on EOF with read_line" do
-      str = SimpleMemoryIO.new("hello")
+      str = SimpleIOMemory.new("hello")
       str.read_line.should eq("hello")
 
       expect_raises IO::EOFError, "end of file reached" do
@@ -332,7 +332,7 @@ describe IO do
     end
 
     it "raises on EOF with readline and delimiter" do
-      str = SimpleMemoryIO.new("hello")
+      str = SimpleIOMemory.new("hello")
       str.read_line('e').should eq("he")
       str.read_line('e').should eq("llo")
 
@@ -342,7 +342,7 @@ describe IO do
     end
 
     it "does read_fully" do
-      str = SimpleMemoryIO.new("hello")
+      str = SimpleIOMemory.new("hello")
       slice = Slice(UInt8).new(4)
       str.read_fully(slice)
       String.new(slice).should eq("hell")
@@ -355,13 +355,13 @@ describe IO do
 
   describe "write operations" do
     it "does puts" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.puts "Hello"
       io.gets_to_end.should eq("Hello\n")
     end
 
     it "does puts with big string" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       s = "*" * 20_000
       io << "hello"
       io << s
@@ -369,49 +369,49 @@ describe IO do
     end
 
     it "does puts many times" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       10_000.times { io << "hello" }
       io.gets_to_end.should eq("hello" * 10_000)
     end
 
     it "puts several arguments" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.puts(1, "aaa", "\n")
       io.gets_to_end.should eq("1\naaa\n\n")
     end
 
     it "prints" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.print "foo"
       io.gets_to_end.should eq("foo")
     end
 
     it "prints several arguments" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.print "foo", "bar", "baz"
       io.gets_to_end.should eq("foobarbaz")
     end
 
     it "writes bytes" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       10_000.times { io.write_byte 'a'.ord.to_u8 }
       io.gets_to_end.should eq("a" * 10_000)
     end
 
     it "writes with printf" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.printf "Hello %d", 123
       io.gets_to_end.should eq("Hello 123")
     end
 
     it "writes with printf as an array" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io.printf "Hello %d", [123]
       io.gets_to_end.should eq("Hello 123")
     end
 
     it "skips a few bytes" do
-      io = SimpleMemoryIO.new
+      io = SimpleIOMemory.new
       io << "hello world"
       io.skip(6)
       io.gets_to_end.should eq("world")
@@ -422,14 +422,14 @@ describe IO do
     describe "decode" do
       it "gets_to_end" do
         str = "Hello world" * 200
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets_to_end.should eq(str)
       end
 
       it "gets" do
         str = "Hello world\nFoo\nBar"
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets.should eq("Hello world\n")
         io.gets.should eq("Foo\n")
@@ -439,7 +439,7 @@ describe IO do
 
       it "gets big string" do
         str = "Hello\nWorld\n" * 10_000
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         10_000.times do |i|
           io.gets.should eq("Hello\n")
@@ -450,7 +450,7 @@ describe IO do
       it "gets big GB2312 string" do
         2.times do
           str = ("你好我是人\n" * 1000).encode("GB2312")
-          io = SimpleMemoryIO.new(str)
+          io = SimpleIOMemory.new(str)
           io.set_encoding("GB2312")
           1000.times do
             io.gets.should eq("你好我是人\n")
@@ -459,38 +459,38 @@ describe IO do
       end
 
       it "does gets on unicode with char and limit without off-by-one" do
-        io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
+        io = SimpleIOMemory.new("test\nabc".encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets('a', 5).should eq("test\n")
-        io = SimpleMemoryIO.new("test\nabc".encode("UCS-2LE"))
+        io = SimpleIOMemory.new("test\nabc".encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets('a', 6).should eq("test\na")
       end
 
       it "gets with limit" do
         str = "Hello\nWorld\n"
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(3).should eq("Hel")
       end
 
       it "gets with limit (small, no newline)" do
         str = "Hello world" * 10_000
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(3).should eq("Hel")
       end
 
       it "gets with limit (big)" do
         str = "Hello world" * 10_000
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(20_000).should eq(str[0, 20_000])
       end
 
       it "gets with string delimiter" do
         str = "Hello world\nFoo\nBar"
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets("wo").should eq("Hello wo")
         io.gets("oo").should eq("rld\nFoo")
@@ -500,7 +500,7 @@ describe IO do
 
       it "reads char" do
         str = "Hello world"
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         str.each_char do |char|
           io.read_char.should eq(char)
@@ -510,7 +510,7 @@ describe IO do
 
       it "reads utf8 byte" do
         str = "Hello world"
-        io = SimpleMemoryIO.new(str.encode("UCS-2LE"))
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         str.each_byte do |byte|
           io.read_utf8_byte.should eq(byte)
@@ -519,7 +519,7 @@ describe IO do
       end
 
       it "reads utf8" do
-        io = MemoryIO.new("你".encode("GB2312"))
+        io = IO::Memory.new("你".encode("GB2312"))
         io.set_encoding("GB2312")
 
         buffer = uninitialized UInt8[1024]
@@ -529,7 +529,7 @@ describe IO do
       end
 
       it "raises on incomplete byte sequence" do
-        io = SimpleMemoryIO.new("好".byte_slice(0, 1))
+        io = SimpleIOMemory.new("好".byte_slice(0, 1))
         io.set_encoding("GB2312")
         expect_raises ArgumentError, "incomplete multibyte sequence" do
           io.read_char
@@ -537,7 +537,7 @@ describe IO do
       end
 
       it "says invalid byte sequence" do
-        io = SimpleMemoryIO.new(Slice.new(1, 140_u8))
+        io = SimpleIOMemory.new(Slice.new(1, 140_u8))
         io.set_encoding("GB2312")
         expect_raises ArgumentError, "invalid multibyte sequence" do
           io.read_char
@@ -550,7 +550,7 @@ describe IO do
           str.write_byte 140_u8
           str.write "是".encode("GB2312")
         end
-        io = SimpleMemoryIO.new(string)
+        io = SimpleIOMemory.new(string)
         io.set_encoding("GB2312", invalid: :skip)
         io.read_char.should eq('好')
         io.read_char.should eq('是')
@@ -558,14 +558,14 @@ describe IO do
       end
 
       it "says invalid 'invalid' option" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         expect_raises ArgumentError, "valid values for `invalid` option are `nil` and `:skip`, not :foo" do
           io.set_encoding("GB2312", invalid: :foo)
         end
       end
 
       it "says invalid encoding" do
-        io = SimpleMemoryIO.new("foo")
+        io = SimpleIOMemory.new("foo")
         io.set_encoding("FOO")
         expect_raises ArgumentError, "invalid encoding: FOO" do
           io.gets_to_end
@@ -573,28 +573,28 @@ describe IO do
       end
 
       it "does skips when converting to UTF-8" do
-        io = SimpleMemoryIO.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
+        io = SimpleIOMemory.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
         io.set_encoding("UTF-8", invalid: :skip)
         io.gets_to_end.should eq "{/*  */}"
       end
 
       it "decodes incomplete multibyte sequence with skip (#3285)" do
         bytes = Bytes[195, 229, 237, 229, 240, 224, 246, 232, 255, 32, 241, 234, 240, 232, 239, 242, 224, 32, 48, 46, 48, 49, 50, 54, 32, 241, 229, 234, 243, 237, 228, 10]
-        m = MemoryIO.new(bytes)
+        m = IO::Memory.new(bytes)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.should eq("  0.0126 \n")
       end
 
       it "decodes incomplete multibyte sequence with skip (2) (#3285)" do
         str = File.read("#{__DIR__}/../data/io_data_incomplete_multibyte_sequence.txt")
-        m = MemoryIO.new(Base64.decode_string str)
+        m = IO::Memory.new(Base64.decode_string str)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.bytesize.should eq(4277)
       end
 
       it "decodes incomplete multibyte sequence with skip (3) (#3285)" do
         str = File.read("#{__DIR__}/../data/io_data_incomplete_multibyte_sequence_2.txt")
-        m = MemoryIO.new(Base64.decode_string str)
+        m = IO::Memory.new(Base64.decode_string str)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.bytesize.should eq(8977)
       end
@@ -603,7 +603,7 @@ describe IO do
     describe "encode" do
       it "prints a string" do
         str = "Hello world"
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print str
         slice = io.to_slice
@@ -611,7 +611,7 @@ describe IO do
       end
 
       it "prints numbers" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 0
         io.print 1_u8
@@ -629,7 +629,7 @@ describe IO do
       end
 
       it "prints bool" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print true
         io.print false
@@ -638,7 +638,7 @@ describe IO do
       end
 
       it "prints char" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 'a'
         slice = io.to_slice
@@ -646,7 +646,7 @@ describe IO do
       end
 
       it "prints symbol" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print :foo
         slice = io.to_slice
@@ -654,7 +654,7 @@ describe IO do
       end
 
       it "prints big int" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 123_456.to_big_i
         slice = io.to_slice
@@ -662,7 +662,7 @@ describe IO do
       end
 
       it "puts" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.puts 1
         io.puts
@@ -671,7 +671,7 @@ describe IO do
       end
 
       it "printf" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.printf "%s-%d-%.2f", "hi", 123, 45.67
         slice = io.to_slice
@@ -679,7 +679,7 @@ describe IO do
       end
 
       it "raises on invalid byte sequence" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("GB2312")
         expect_raises ArgumentError, "invalid multibyte sequence" do
           io.print "ñ"
@@ -687,14 +687,14 @@ describe IO do
       end
 
       it "skips on invalid byte sequence" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("GB2312", invalid: :skip)
         io.print "ñ"
         io.print "foo"
       end
 
       it "raises on incomplete byte sequence" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("GB2312")
         expect_raises ArgumentError, "incomplete multibyte sequence" do
           io.print "好".byte_slice(0, 1)
@@ -702,7 +702,7 @@ describe IO do
       end
 
       it "says invalid encoding" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("FOO")
         expect_raises ArgumentError, "invalid encoding: FOO" do
           io.puts "a"
@@ -712,11 +712,11 @@ describe IO do
 
     describe "#encoding" do
       it "returns \"UTF-8\" if the encoding is not manually set" do
-        SimpleMemoryIO.new.encoding.should eq("UTF-8")
+        SimpleIOMemory.new.encoding.should eq("UTF-8")
       end
 
       it "returns the name of the encoding set via #set_encoding" do
-        io = SimpleMemoryIO.new
+        io = SimpleIOMemory.new
         io.set_encoding("UTF-16LE")
         io.encoding.should eq("UTF-16LE")
       end

--- a/spec/std/io/multi_writer_spec.cr
+++ b/spec/std/io/multi_writer_spec.cr
@@ -3,8 +3,8 @@ require "spec"
 describe "IO::MultiWriter" do
   describe "#write" do
     it "writes to multiple IOs" do
-      io1 = MemoryIO.new
-      io2 = MemoryIO.new
+      io1 = IO::Memory.new
+      io2 = IO::Memory.new
 
       writer = IO::MultiWriter.new(io1, io2)
 
@@ -27,7 +27,7 @@ describe "IO::MultiWriter" do
 
   describe "#close" do
     it "stops reading" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       writer = IO::MultiWriter.new(io)
 
       writer.close
@@ -41,7 +41,7 @@ describe "IO::MultiWriter" do
     end
 
     it "closes the underlying stream if sync_close is true" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       writer = IO::MultiWriter.new(io, sync_close: true)
 
       writer.close

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -3,7 +3,7 @@ require "spec"
 describe "IO::Sized" do
   describe "#read" do
     it "doesn't read past the limit when reading char-by-char" do
-      io = MemoryIO.new "abcdefg"
+      io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)
 
       sized.read_char.should eq('a')
@@ -19,7 +19,7 @@ describe "IO::Sized" do
     end
 
     it "doesn't read past the limit when reading the correct size" do
-      io = MemoryIO.new("1234567")
+      io = IO::Memory.new("1234567")
       sized = IO::Sized.new(io, read_size: 5)
       slice = Bytes.new(5)
 
@@ -31,7 +31,7 @@ describe "IO::Sized" do
     end
 
     it "reads partially when supplied with a larger slice" do
-      io = MemoryIO.new("1234567")
+      io = IO::Memory.new("1234567")
       sized = IO::Sized.new(io, read_size: 5)
       slice = Bytes.new(10)
 
@@ -40,7 +40,7 @@ describe "IO::Sized" do
     end
 
     it "raises on negative numbers" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       expect_raises(ArgumentError, "negative read_size") do
         IO::Sized.new(io, read_size: -1)
       end
@@ -49,7 +49,7 @@ describe "IO::Sized" do
 
   describe "#write" do
     it "raises" do
-      sized = IO::Sized.new(MemoryIO.new, read_size: 5)
+      sized = IO::Sized.new(IO::Memory.new, read_size: 5)
       expect_raises(IO::Error, "Can't write to IO::Sized") do
         sized.puts "test string"
       end
@@ -58,7 +58,7 @@ describe "IO::Sized" do
 
   describe "#close" do
     it "stops reading" do
-      io = MemoryIO.new "abcdefg"
+      io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)
 
       sized.read_char.should eq('a')
@@ -72,7 +72,7 @@ describe "IO::Sized" do
     end
 
     it "closes the underlying stream if sync_close is true" do
-      io = MemoryIO.new "abcdefg"
+      io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5, sync_close: true)
       sized.sync_close?.should eq(true)
 
@@ -83,7 +83,7 @@ describe "IO::Sized" do
   end
 
   it "read_byte" do
-    io = MemoryIO.new "abcdefg"
+    io = IO::Memory.new "abcdefg"
     sized = IO::Sized.new(io, read_size: 3)
     sized.read_byte.should eq('a'.ord)
     sized.read_byte.should eq('b'.ord)

--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -9,7 +9,7 @@ private def it_lexes(string, expected_type, file = __FILE__, line = __LINE__)
   end
 
   it "lexes #{string} from IO", file, line do
-    lexer = JSON::Lexer.new MemoryIO.new(string)
+    lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(expected_type)
   end
@@ -24,7 +24,7 @@ private def it_lexes_string(string, string_value, file = __FILE__, line = __LINE
   end
 
   it "lexes #{string} from IO", file, line do
-    lexer = JSON::Lexer.new MemoryIO.new(string)
+    lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:STRING)
     token.string_value.should eq(string_value)
@@ -41,7 +41,7 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
   end
 
   it "lexes #{string} from IO", file, line do
-    lexer = JSON::Lexer.new MemoryIO.new(string)
+    lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:INT)
     token.int_value.should eq(int_value)
@@ -59,7 +59,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
   end
 
   it "lexes #{string} from IO", file, line do
-    lexer = JSON::Lexer.new MemoryIO.new(string)
+    lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:FLOAT)
     token.float_value.should eq(float_value)

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -48,7 +48,7 @@ describe "JSON serialization" do
     end
 
     it "does for Array(Int32) from IO" do
-      io = MemoryIO.new "[1, 2, 3]"
+      io = IO::Memory.new "[1, 2, 3]"
       Array(Int32).from_json(io).should eq([1, 2, 3])
     end
 

--- a/spec/std/openssl/cipher_spec.cr
+++ b/spec/std/openssl/cipher_spec.cr
@@ -18,8 +18,8 @@ describe OpenSSL::Cipher do
     c1.key = c2.key = key
     c1.iv = c2.iv = iv
 
-    s1 = MemoryIO.new
-    s2 = MemoryIO.new
+    s1 = IO::Memory.new
+    s2 = IO::Memory.new
     s1.write(c1.update("DATA"))
     s1.write(c1.update("DATA" * 4))
     s1.write(c1.final)
@@ -34,8 +34,8 @@ describe OpenSSL::Cipher do
     c1.key = c2.key = key
     c1.iv = c2.iv = iv
 
-    s3 = MemoryIO.new
-    s4 = MemoryIO.new
+    s3 = IO::Memory.new
+    s4 = IO::Memory.new
     s3.write(c1.update(s1.to_slice))
     s3.write(c1.final)
 

--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -2,14 +2,14 @@ require "spec"
 
 describe "Proc" do
   it "does to_s(io)" do
-    str = MemoryIO.new
+    str = IO::Memory.new
     f = ->(x : Int32) { x.to_f }
     f.to_s(str)
     str.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
   it "does to_s(io) when closured" do
-    str = MemoryIO.new
+    str = IO::Memory.new
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s(str)
@@ -17,13 +17,13 @@ describe "Proc" do
   end
 
   it "does to_s" do
-    str = MemoryIO.new
+    str = IO::Memory.new
     f = ->(x : Int32) { x.to_f }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
   it "does to_s when closured" do
-    str = MemoryIO.new
+    str = IO::Memory.new
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -48,7 +48,7 @@ describe Process do
   end
 
   it "sends input in IO" do
-    value = Process.run("/bin/cat", input: MemoryIO.new("hello")) do |proc|
+    value = Process.run("/bin/cat", input: IO::Memory.new("hello")) do |proc|
       proc.input?.should be_nil
       proc.output.gets_to_end
     end
@@ -56,13 +56,13 @@ describe Process do
   end
 
   it "sends output to IO" do
-    output = MemoryIO.new
+    output = IO::Memory.new
     Process.run("/bin/sh", {"-c", "echo hello"}, output: output)
     output.to_s.should eq("hello\n")
   end
 
   it "sends error to IO" do
-    error = MemoryIO.new
+    error = IO::Memory.new
     Process.run("/bin/sh", {"-c", "echo hello 1>&2"}, error: error)
     error.to_s.should eq("hello\n")
   end
@@ -161,7 +161,7 @@ describe Process do
   end
 
   it "can link processes together" do
-    buffer = MemoryIO.new
+    buffer = IO::Memory.new
     Process.run("/bin/cat") do |cat|
       Process.run("/bin/cat", input: cat.output, output: buffer) do
         1000.times { cat.input.puts "line" }

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -21,7 +21,7 @@ describe StringPool do
 
   it "gets string IO" do
     pool = StringPool.new
-    io = MemoryIO.new "foo"
+    io = IO::Memory.new "foo"
 
     s1 = pool.get io
     s2 = pool.get "foo"

--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -40,7 +40,7 @@ describe XML do
   end
 
   it "parses HTML from IO" do
-    io = MemoryIO.new(%(\
+    io = IO::Memory.new(%(\
       <!doctype html>
       <html>
       <head>

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -77,7 +77,7 @@ describe XML do
   end
 
   it "parses from io" do
-    io = MemoryIO.new(<<-XML
+    io = IO::Memory.new(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <people>
         <person id="1" id2="2">
@@ -211,7 +211,7 @@ describe XML do
   it "reads big xml file (#1455)" do
     content = "." * 20_000
     string = %(<?xml version="1.0"?><root>#{content}</root>)
-    parsed = XML.parse(MemoryIO.new(string))
+    parsed = XML.parse(IO::Memory.new(string))
     parsed.root.not_nil!.children[0].text.should eq(content)
   end
 

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -113,7 +113,7 @@ describe "YAML" do
       end
 
       it "parses from IO" do
-        YAML.parse(MemoryIO.new("- foo\n- bar")).should eq(["foo", "bar"])
+        YAML.parse(IO::Memory.new("- foo\n- bar")).should eq(["foo", "bar"])
       end
     end
   end

--- a/spec/std/zlib/deflate_spec.cr
+++ b/spec/std/zlib/deflate_spec.cr
@@ -5,7 +5,7 @@ module Zlib
   describe Deflate do
     it "should be able to deflate" do
       message = "this is a test string !!!!\n"
-      io = MemoryIO.new
+      io = IO::Memory.new
       deflate = Deflate.new(io)
       deflate.print message
       deflate.close
@@ -16,7 +16,7 @@ module Zlib
     end
 
     it "can be closed without sync" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       deflate = Deflate.new(io)
       deflate.close
       deflate.closed?.should be_true
@@ -28,7 +28,7 @@ module Zlib
     end
 
     it "can be closed with sync (1)" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       deflate = Deflate.new(io, sync_close: true)
       deflate.close
       deflate.closed?.should be_true
@@ -36,7 +36,7 @@ module Zlib
     end
 
     it "can be closed with sync (2)" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       deflate = Deflate.new(io)
       deflate.sync_close = true
       deflate.close
@@ -45,7 +45,7 @@ module Zlib
     end
 
     it "can be flushed" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       deflate = Deflate.new(io)
 
       deflate.print "this"

--- a/spec/std/zlib/inflate_spec.cr
+++ b/spec/std/zlib/inflate_spec.cr
@@ -4,7 +4,7 @@ require "zlib"
 module Zlib
   describe Inflate do
     it "should be able to inflate" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       "789c2bc9c82c5600a2448592d4e21285e292a2ccbc74054520e00200854f087b".scan(/../).each do |match|
         io.write_byte match[0].to_u8(16)
       end
@@ -21,7 +21,7 @@ module Zlib
     end
 
     it "can be closed without sync" do
-      io = MemoryIO.new("")
+      io = IO::Memory.new("")
       inflate = Inflate.new(io)
       inflate.close
       inflate.closed?.should be_true
@@ -33,7 +33,7 @@ module Zlib
     end
 
     it "can be closed with sync (1)" do
-      io = MemoryIO.new("")
+      io = IO::Memory.new("")
       inflate = Inflate.new(io, sync_close: true)
       inflate.close
       inflate.closed?.should be_true
@@ -41,7 +41,7 @@ module Zlib
     end
 
     it "can be closed with sync (2)" do
-      io = MemoryIO.new("")
+      io = IO::Memory.new("")
       inflate = Inflate.new(io)
       inflate.sync_close = true
       inflate.close
@@ -50,13 +50,13 @@ module Zlib
     end
 
     it "should not inflate from empty stream" do
-      io = MemoryIO.new("")
+      io = IO::Memory.new("")
       inflate = Inflate.new(io)
       inflate.read_byte.should be_nil
     end
 
     it "should not freeze when reading empty slice" do
-      io = MemoryIO.new
+      io = IO::Memory.new
       "789c2bc9c82c5600a2448592d4e21285e292a2ccbc74054520e00200854f087b".scan(/../).each do |match|
         io.write_byte match[0].to_u8(16)
       end

--- a/spec/std/zlib/stress_spec.cr
+++ b/spec/std/zlib/stress_spec.cr
@@ -8,7 +8,7 @@ module Zlib
         1_000_000.times { rand(2000).to_i.to_s(32, io) }
       end
 
-      io = MemoryIO.new
+      io = IO::Memory.new
 
       deflate = Deflate.new(io)
       deflate.print expected
@@ -22,7 +22,7 @@ module Zlib
     it "inflate deflate should be inverse (utf-8)" do
       expected = "日本さん語日本さん語"
 
-      io = MemoryIO.new
+      io = IO::Memory.new
 
       deflate = Deflate.new(io)
       deflate.print expected

--- a/src/compiler/crystal/codegen/asm.cr
+++ b/src/compiler/crystal/codegen/asm.cr
@@ -2,7 +2,7 @@ require "./codegen"
 
 class Crystal::CodeGenVisitor
   def visit(node : Asm)
-    constraints = MemoryIO.new
+    constraints = IO::Memory.new
 
     if ptrof = node.ptrof
       output = node.output.not_nil!

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -76,7 +76,7 @@ module Crystal
     def initialize(@program : Program,
                    @scope : Type, @path_lookup : Type, @location : Location?,
                    @vars = {} of String => ASTNode, @block : Block? = nil, @def : Def? = nil)
-      @str = MemoryIO.new(512) # Can't be String::Builder because of `{{debug()}}
+      @str = IO::Memory.new(512) # Can't be String::Builder because of `{{debug()}}
       @last = Nop.new
     end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -194,7 +194,7 @@ class Crystal::Call
     end
 
     if defs_matching_args_size.size > 0
-      str = MemoryIO.new
+      str = IO::Memory.new
       if check_single_def_error_message(defs_matching_args_size, named_args_types, str)
         raise str.to_s
       else

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -291,7 +291,7 @@ module Crystal
       Call.new(path, "new", [node.from, node.to, bool]).at(node)
     end
 
-    # Convert an interpolation to a concatenation with a MemoryIO:
+    # Convert an interpolation to a concatenation with an IO::Memory:
     #
     # From:
     #
@@ -299,7 +299,7 @@ module Crystal
     #
     # To:
     #
-    #     (MemoryIO.new << "foo" << bar << "baz").to_s
+    #     (IO::Memory.new << "foo" << bar << "baz").to_s
     def expand(node : StringInterpolation)
       # Compute how long at least the string will be, so we
       # can allocate enough space.

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -150,7 +150,7 @@ module Crystal
           when '='
             next_char :"<<="
           when '-'
-            here = MemoryIO.new(20)
+            here = IO::Memory.new(20)
             has_single_quote = false
             found_closing_single_quote = false
 
@@ -464,7 +464,7 @@ module Crystal
           line = @line_number
           column = @column_number
           start = current_pos + 1
-          io = MemoryIO.new
+          io = IO::Memory.new
           while true
             char = next_char
             case char
@@ -1128,7 +1128,7 @@ module Crystal
       if doc_buffer = @token.doc_buffer
         doc_buffer << '\n'
       else
-        @token.doc_buffer = doc_buffer = MemoryIO.new
+        @token.doc_buffer = doc_buffer = IO::Memory.new
       end
 
       doc_buffer.write slice_range(start_pos)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1896,7 +1896,7 @@ module Crystal
     end
 
     def remove_heredoc_indent(pieces : Array, indent)
-      current_line = MemoryIO.new
+      current_line = IO::Memory.new
       remove_indent = true
       new_pieces = [] of ASTNode
       previous_line_number = 0

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -16,7 +16,7 @@ module Crystal
   class ToSVisitor < Visitor
     @str : IO
 
-    def initialize(@str = MemoryIO.new, @emit_loc_pragma = false)
+    def initialize(@str = IO::Memory.new, @emit_loc_pragma = false)
       @indent = 0
       @inside_macro = 0
       @inside_lib = false

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -11,7 +11,7 @@ module Crystal
     property delimiter_state : DelimiterState
     property macro_state : MacroState
     property passed_backslash_newline : Bool
-    property doc_buffer : MemoryIO?
+    property doc_buffer : IO::Memory?
     property raw : String
     property start : Int32
 

--- a/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
@@ -9,7 +9,7 @@ class Crystal::Doc::MarkdownDocRenderer < Markdown::HTMLRenderer
     super(io)
 
     @inside_inline_code = false
-    @code_buffer = MemoryIO.new
+    @code_buffer = IO::Memory.new
     @inside_code = false
     @inside_link = false
   end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -51,8 +51,8 @@ module Crystal
     @line : Int32
     @column : Int32
     @token : Token
-    @output : MemoryIO
-    @line_output : MemoryIO
+    @output : IO::Memory
+    @line_output : IO::Memory
     @wrote_newline : Bool
     @wrote_comment : Bool
     @macro_state : Token::MacroState
@@ -88,8 +88,8 @@ module Crystal
       @token = @lexer.token
       @token = next_token
 
-      @output = MemoryIO.new(source.bytesize)
-      @line_output = MemoryIO.new
+      @output = IO::Memory.new(source.bytesize)
+      @line_output = IO::Memory.new
       @wrote_newline = false
       @wrote_comment = false
       @macro_state = Token::MacroState.default

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -125,7 +125,7 @@ class CSV
   # that writes to the given IO.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts "HEADER"
   # CSV.build(io) do |csv|
   #   csv.row "one", "two"

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -30,7 +30,7 @@ abstract class CSV::Lexer
   # :nodoc:
   def initialize(@separator : Char = DEFAULT_SEPARATOR, @quote_char : Char = DEFAULT_QUOTE_CHAR)
     @token = Token.new
-    @buffer = MemoryIO.new
+    @buffer = IO::Memory.new
     @column_number = 1
     @line_number = 1
     @last_empty_column = false

--- a/src/ecr/macros.cr
+++ b/src/ecr/macros.cr
@@ -54,7 +54,7 @@ module ECR
   #
   # name = "World"
   #
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # ECR.embed "greeting.ecr", io
   # io.to_s # => "Hello World!"
   # ```

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -27,7 +27,7 @@ module HTTP
       return if query.empty?
 
       key = nil
-      buffer = MemoryIO.new
+      buffer = IO::Memory.new
 
       i = 0
       bytesize = query.bytesize
@@ -290,7 +290,7 @@ module HTTP
       @io : IO
       @first : Bool
 
-      def initialize(@io = MemoryIO.new)
+      def initialize(@io = IO::Memory.new)
         @first = true
       end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -9,7 +9,7 @@ require "http/params"
 #
 # A request always holds an IO as a body.
 # When creating a request with a `String` or `Bytes` its body
-# will be a `MemoryIO` wrapping these, and the Content-Length
+# will be a `IO::Memory` wrapping these, and the Content-Length
 # header will be set appropriately.
 class HTTP::Request
   property method : String
@@ -59,12 +59,12 @@ class HTTP::Request
   end
 
   def body=(body : String)
-    @body = MemoryIO.new(body)
+    @body = IO::Memory.new(body)
     self.content_length = body.bytesize
   end
 
   def body=(body : Bytes)
-    @body = MemoryIO.new(body)
+    @body = IO::Memory.new(body)
     self.content_length = body.size
   end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -7,7 +7,7 @@ class HTTP::WebSocket
   # :nodoc:
   def initialize(@ws : Protocol)
     @buffer = Slice(UInt8).new(4096)
-    @current_message = MemoryIO.new
+    @current_message = IO::Memory.new
   end
 
   # Opens a new websocket using the information provided by the URI. This will also handle the handshake

--- a/src/io.cr
+++ b/src/io.cr
@@ -7,7 +7,7 @@ require "c/unistd"
 
 # The IO module is the basis for all input and output in Crystal.
 #
-# This module is included by types like `File`, `Socket` and `MemoryIO` and
+# This module is included by types like `File`, `Socket` and `IO::Memory` and
 # provide many useful methods for reading to and writing from an IO, like `print`, `puts`,
 # `gets` and `printf`.
 #
@@ -161,7 +161,7 @@ module IO
   # Reads at most *slice.size* bytes from this IO into *slice*. Returns the number of bytes read.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # slice = Slice(UInt8).new(4)
   # io.read(slice) # => 4
   # slice          # => [104, 101, 108, 108]
@@ -173,7 +173,7 @@ module IO
   # Writes the contents of *slice* into this IO.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # slice = Slice(UInt8).new(4) { |i| ('a'.ord + i).to_u8 }
   # io.write(slice)
   # io.to_s #=> "abcd"
@@ -253,7 +253,7 @@ module IO
   # This ends up calling `to_s(io)` on the object.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io << 1
   # io << '-'
   # io << "Crystal"
@@ -267,7 +267,7 @@ module IO
   # Same as `<<`
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.print 1
   # io.print '-'
   # io.print "Crystal"
@@ -282,7 +282,7 @@ module IO
   # on each of the objects.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.print 1, '-', "Crystal"
   # io.to_s # => "1-Crystal"
   # ```
@@ -297,7 +297,7 @@ module IO
   # unless the string already ends with one.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts "hello\n"
   # io.puts "world"
   # io.to_s # => "hello\nworld\n"
@@ -311,7 +311,7 @@ module IO
   # Writes the given object to this IO followed by a newline character.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts 1
   # io.puts "Crystal"
   # io.to_s # => "1\nCrystal\n"
@@ -324,7 +324,7 @@ module IO
   # Writes a newline character.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts
   # io.to_s # => "\n"
   # ```
@@ -336,7 +336,7 @@ module IO
   # Writes the given objects, each followed by a newline character.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts 1, '-', "Crystal"
   # io.to_s # => "1\n-\nCrystal\n"
   # ```
@@ -361,7 +361,7 @@ module IO
   # data to read.
   #
   # ```
-  # io = MemoryIO.new "a"
+  # io = IO::Memory.new "a"
   # io.read_byte # => 97
   # io.read_byte # => nil
   # ```
@@ -378,7 +378,7 @@ module IO
   # more data to read.
   #
   # ```
-  # io = MemoryIO.new "あ"
+  # io = IO::Memory.new "あ"
   # io.read_char # => 'あ'
   # io.read_char # => nil
   # ```
@@ -419,7 +419,7 @@ module IO
   # ```
   # bytes = "你".encode("GB2312") # => [196, 227]
   #
-  # io = MemoryIO.new(bytes)
+  # io = IO::Memory.new(bytes)
   # io.set_encoding("GB2312")
   # io.read_utf8_byte # => 228
   # io.read_utf8_byte # => 189
@@ -443,7 +443,7 @@ module IO
   # ```
   # bytes = "你".encode("GB2312") # => [196, 227]
   #
-  # io = MemoryIO.new(bytes)
+  # io = IO::Memory.new(bytes)
   # io.set_encoding("GB2312")
   #
   # buffer = uninitialized UInt8[1024]
@@ -490,7 +490,7 @@ module IO
   # Raises `EOFError` if there aren't `slice.size` bytes of data.
   #
   # ```
-  # io = MemoryIO.new "123451234"
+  # io = IO::Memory.new "123451234"
   # slice = Slice(UInt8).new(5)
   # io.read_fully(slice)
   # slice         # => [49, 50, 51, 52, 53]
@@ -509,7 +509,7 @@ module IO
   # Reads the rest of this IO data as a `String`.
   #
   # ```
-  # io = MemoryIO.new "hello world"
+  # io = IO::Memory.new "hello world"
   # io.gets_to_end # => "hello world"
   # io.gets_to_end # => ""
   # ```
@@ -535,7 +535,7 @@ module IO
   # Returns `nil` if called at the end of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello\nworld"
+  # io = IO::Memory.new "hello\nworld"
   # io.gets # => "hello\n"
   # io.gets # => "world"
   # io.gets # => nil
@@ -548,7 +548,7 @@ module IO
   # Returns `nil` if called at the end of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello\nworld"
+  # io = IO::Memory.new "hello\nworld"
   # io.gets(3) # => "hel"
   # io.gets(3) # => "lo\n"
   # io.gets(3) # => "wor"
@@ -563,7 +563,7 @@ module IO
   # Returns `nil` if called at the end of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello\nworld"
+  # io = IO::Memory.new "hello\nworld"
   # io.gets('o') # => "hello"
   # io.gets('r') # => "\nwor"
   # io.gets('z') # => "ld"
@@ -577,7 +577,7 @@ module IO
   # Returns `nil` if called at the end of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello\nworld"
+  # io = IO::Memory.new "hello\nworld"
   # io.gets('o', 3)  # => "hel"
   # io.gets('r', 10) # => "lo\nwor"
   # io.gets('z', 10) # => "ld"
@@ -615,7 +615,7 @@ module IO
   # Returns `nil` if called at the end of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello\nworld"
+  # io = IO::Memory.new "hello\nworld"
   # io.gets("wo") # => "hello\nwo"
   # io.gets("wo") # => "rld"
   # io.gets("wo") # => nil
@@ -664,7 +664,7 @@ module IO
   # Reads and discards *bytes_count* bytes.
   #
   # ```
-  # io = MemoryIO.new "hello world"
+  # io = IO::Memory.new "hello world"
   # io.skip(6)
   # io.gets # => "world"
   # ```
@@ -680,7 +680,7 @@ module IO
   # Writes a single byte into this IO.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.write_byte 97_u8
   # io.to_s # => "a"
   # ```
@@ -698,7 +698,7 @@ module IO
   # See `Int#to_io` and `Float#to_io`.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.write_bytes(0x01020304, IO::ByteFormat::LittleEndian)
   # io.rewind
   # io.gets(4) # => "\u{4}\u{3}\u{2}\u{1}"
@@ -716,7 +716,7 @@ module IO
   # See `Int#from_io` and `Float#from_io`.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.puts "\u{4}\u{3}\u{2}\u{1}"
   # io.rewind
   # io.read_bytes(Int32, IO::ByteFormat::LittleEndian) # => 0x01020304
@@ -730,8 +730,8 @@ module IO
   # IO returns `false`, but including types may override.
   #
   # ```
-  # STDIN.tty?        # => true
-  # MemoryIO.new.tty? # => false
+  # STDIN.tty?          # => true
+  # IO::Memory.new.tty? # => false
   # ```
   def tty? : Bool
     false
@@ -742,7 +742,7 @@ module IO
   # ones as in the `gets` methods.
   #
   # ```
-  # io = MemoryIO.new("hello\nworld")
+  # io = IO::Memory.new("hello\nworld")
   # io.each_line do |line|
   #   puts line.chomp.reverse
   # end
@@ -765,7 +765,7 @@ module IO
   # ones as in the `gets` methods.
   #
   # ```
-  # io = MemoryIO.new("hello\nworld")
+  # io = IO::Memory.new("hello\nworld")
   # iter = io.each_line
   # iter.next # => "hello\n"
   # iter.next # => "world"
@@ -777,7 +777,7 @@ module IO
   # Inovkes the given block with each `Char` in this IO.
   #
   # ```
-  # io = MemoryIO.new("あめ")
+  # io = IO::Memory.new("あめ")
   # io.each_char do |char|
   #   puts char
   # end
@@ -798,7 +798,7 @@ module IO
   # Returns an `Iterator` for the chars in this IO.
   #
   # ```
-  # io = MemoryIO.new("あめ")
+  # io = IO::Memory.new("あめ")
   # iter = io.each_char
   # iter.next # => 'あ'
   # iter.next # => 'め'
@@ -810,7 +810,7 @@ module IO
   # Inovkes the given block with each byte (`UInt8`) in this IO.
   #
   # ```
-  # io = MemoryIO.new("aあ")
+  # io = IO::Memory.new("aあ")
   # io.each_byte do |byte|
   #   puts byte
   # end
@@ -833,7 +833,7 @@ module IO
   # Returns an `Iterator` for the bytes in this IO.
   #
   # ```
-  # io = MemoryIO.new("aあ")
+  # io = IO::Memory.new("aあ")
   # iter = io.each_byte
   # iter.next # => 97
   # iter.next # => 227
@@ -879,8 +879,8 @@ module IO
   # Copy all contents from *src* to *dst*.
   #
   # ```
-  # io = MemoryIO.new "hello"
-  # io2 = MemoryIO.new
+  # io = IO::Memory.new "hello"
+  # io2 = IO::Memory.new
   #
   # IO.copy io, io2
   #
@@ -899,8 +899,8 @@ module IO
   # Copy at most *limit* bytes from *src* to *dst*.
   #
   # ```
-  # io = MemoryIO.new "hello"
-  # io2 = MemoryIO.new
+  # io = IO::Memory.new "hello"
+  # io2 = IO::Memory.new
   #
   # IO.copy io, io2, 3
   #

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -46,7 +46,7 @@ module IO::Buffered
     # We first check, after filling the buffer, if the delimiter
     # is already in the buffer. In that case it's much faster to create
     # a String from a slice of the buffer instead of appending to a
-    # MemoryIO, which happens in the other case.
+    # IO::Memory, which happens in the other case.
     fill_buffer if @in_buffer_rem.empty?
     if @in_buffer_rem.empty?
       return nil
@@ -66,7 +66,7 @@ module IO::Buffered
       return string
     end
 
-    # We didn't find the delimiter, so we append to a MemoryIO until we find it,
+    # We didn't find the delimiter, so we append to an IO::Memory until we find it,
     # or we reach the limit
     String.build do |buffer|
       loop do

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -5,7 +5,7 @@ module IO
   # This is useful for exposing part of an underlying stream to a client.
   #
   # ```
-  # io = MemoryIO.new "abc||123"
+  # io = IO::Memory.new "abc||123"
   # delimited = IO::Delimited.new(io, read_delimiter: "||")
   #
   # delimited.gets_to_end # => "abc"

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -159,7 +159,7 @@ class IO::FileDescriptor
   # Returns the current position (in bytes) in this IO.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.pos     # => 0
   # io.gets(2) # => "he"
   # io.pos     # => 2
@@ -176,7 +176,7 @@ class IO::FileDescriptor
   # Sets the current position (in bytes) in this IO.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.pos = 3
   # io.gets_to_end # => "lo"
   # ```

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -1,8 +1,8 @@
 # An IO that reads and writes from a buffer in memory.
 #
 # The internal buffer can be resizeable and/or writeable depending
-# on how a MemoryIO is constructed.
-class MemoryIO
+# on how an IO::Memory is constructed.
+class IO::Memory
   include IO
 
   # Returns the internal buffer as a `Pointer(UInt8)`.
@@ -13,11 +13,11 @@ class MemoryIO
 
   @capacity : Int32
 
-  # Creates an empty, resizeable and writeable MemoryIO with the given
+  # Creates an empty, resizeable and writeable IO::Memory with the given
   # initialize capactiy for the internal buffer.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.pos  # => 0
   # io.read # => ""
   # ```
@@ -33,14 +33,14 @@ class MemoryIO
     @writeable = true
   end
 
-  # Creates a MemoryIO that will read, and optionally write, from/to
-  # the given slice. The created MemoryIO is non-resizeable.
+  # Creates an IO::Memory that will read, and optionally write, from/to
+  # the given slice. The created IO::Memory is non-resizeable.
   #
   # The IO starts at position zero for reading.
   #
   # ```
   # slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
-  # io = MemoryIO.new slice, writeable: false
+  # io = IO::Memory.new slice, writeable: false
   # io.pos  # => 0
   # io.read # => "abcdef"
   # ```
@@ -53,13 +53,13 @@ class MemoryIO
     @writeable = writeable
   end
 
-  # Creates a MemoryIO whose contents are the exact contents of *string*.
-  # The created MemoryIO is non-resizeable and non-writeable.
+  # Creates an IO::Memory whose contents are the exact contents of *string*.
+  # The created IO::Memory is non-resizeable and non-writeable.
   #
   # The IO starts at position zero for reading.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.pos        # => 0
   # io.gets(2)    # => "he"
   # io.print "hi" # raises
@@ -79,7 +79,7 @@ class MemoryIO
     count
   end
 
-  # See `IO#write(slice)`. Raises if this MemoryIO is non-writeable,
+  # See `IO#write(slice)`. Raises if this IO::Memory is non-writeable,
   # or if it's non-resizeable and a resize is needed.
   def write(slice : Slice(UInt8))
     check_writeable
@@ -107,7 +107,7 @@ class MemoryIO
     nil
   end
 
-  # See `IO#write_byte`. Raises if this MemoryIO is non-writeable,
+  # See `IO#write_byte`. Raises if this IO::Memory is non-writeable,
   # or if it's non-resizeable and a resize is needed.
   def write_byte(byte : UInt8)
     check_writeable
@@ -191,10 +191,10 @@ class MemoryIO
   end
 
   # Clears the internal buffer and resets the position to zero. Raises
-  # if this MemoryIO is non-resizeable.
+  # if this IO::Memory is non-resizeable.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.gets(3) # => "hel"
   # io.clear
   # io.pos         # => 0
@@ -207,10 +207,10 @@ class MemoryIO
     @pos = 0
   end
 
-  # Returns `true` if this MemoryIO has no contents.
+  # Returns `true` if this IO::Memory has no contents.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.empty? # => true
   # io.print "hello"
   # io.empty? # => false
@@ -222,7 +222,7 @@ class MemoryIO
   # Rewinds this IO to the initial position (zero).
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.gets(2) => "he"
   # io.rewind
   # io.gets(2) #=> "he"
@@ -235,7 +235,7 @@ class MemoryIO
   # Returns the total number of bytes in this IO.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.size # => 5
   # ```
   def size
@@ -250,7 +250,7 @@ class MemoryIO
   # Seeks to a given *offset* (in bytes) according to the *whence* argument.
   #
   # ```
-  # io = MemoryIO.new("abcdef")
+  # io = IO::Memory.new("abcdef")
   # io.gets(3) # => "abc"
   # io.seek(1, IO::Seek::Set)
   # io.gets(2) # => "bc"
@@ -275,7 +275,7 @@ class MemoryIO
   # Returns the current position (in bytes) of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.pos     # => 0
   # io.gets(2) # => "he"
   # io.pos     # => 2
@@ -287,7 +287,7 @@ class MemoryIO
   # Sets the current position (in bytes) of this IO.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.pos = 3
   # io.gets # => "lo"
   # ```
@@ -300,7 +300,7 @@ class MemoryIO
   # Closes this IO. Further operations on this IO will raise an `IO::Error`.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.close
   # io.gets_to_end # => IO::Error: closed stream
   # ```
@@ -311,7 +311,7 @@ class MemoryIO
   # Determines if this IO is closed.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # io.closed? # => false
   # io.close
   # io.closed? # => true
@@ -323,7 +323,7 @@ class MemoryIO
   # Returns a new String that contains the contents of the internal buffer.
   #
   # ```
-  # io = MemoryIO.new
+  # io = IO::Memory.new
   # io.print 1, 2, 3
   # io.to_s # => "123"
   # ```
@@ -335,7 +335,7 @@ class MemoryIO
   # modifies the internal buffer.
   #
   # ```
-  # io = MemoryIO.new "hello"
+  # io = IO::Memory.new "hello"
   # slice = io.to_slice
   # slice[0] = 97_u8
   # io.gets_to_end # => "aello"
@@ -368,5 +368,13 @@ class MemoryIO
   private def resize_to_capacity(capacity)
     @capacity = capacity
     @buffer = @buffer.realloc(@capacity)
+  end
+end
+
+# DEPRECATED: MemoryIO has been deprecated in 0.20.0 and will be removed afterwards. Please use `IO::Memory` instead.
+class MemoryIO < IO::Memory
+  def self.new(*args, **nargs)
+    {{ puts "Warning: MemoryIO is deprecated and will be removed after 0.20.0, use IO::Memory instead".id }}
+    super
   end
 end

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -2,7 +2,7 @@ module IO
   # An IO that wraps another IO, setting a limit for the number of bytes that can be read.
   #
   # ```
-  # io = MemoryIO.new "abcde"
+  # io = IO::Memory.new "abcde"
   # sized = IO::Sized.new(io, read_size: 3)
   #
   # sized.gets_to_end # => "abc"

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -16,7 +16,7 @@ abstract class JSON::Lexer
     @token = Token.new
     @line_number = 1
     @column_number = 1
-    @buffer = MemoryIO.new
+    @buffer = IO::Memory.new
     @string_pool = StringPool.new
     @skip = false
     @expects_object_key = false

--- a/src/oauth/authorization_header.cr
+++ b/src/oauth/authorization_header.cr
@@ -1,7 +1,7 @@
 # :nodoc:
 struct OAuth::AuthorizationHeader
   def initialize
-    @str = MemoryIO.new
+    @str = IO::Memory.new
     @str << "OAuth "
     @first = true
   end

--- a/src/openssl/x509/extension.cr
+++ b/src/openssl/x509/extension.cr
@@ -57,7 +57,7 @@ module OpenSSL::X509
     end
 
     def value
-      bio = OpenSSL::BIO.new(io = MemoryIO.new)
+      bio = OpenSSL::BIO.new(io = IO::Memory.new)
 
       if LibCrypto.x509v3_ext_print(bio, @ext, 0, 0) == 0
         LibCrypto.asn1_string_print(bio, LibCrypto.x509_extension_get_data(@ext))

--- a/src/string.cr
+++ b/src/string.cr
@@ -99,7 +99,7 @@ require "c/string"
 #
 # This ends up invoking `Object#to_s(IO)` on each expression enclosed by `#{...}`.
 #
-# If you need to dynamically build a string, use `String#build` or `MemoryIO`.
+# If you need to dynamically build a string, use `String#build` or `IO::Memory`.
 class String
   # :nodoc:
   TYPE_ID = "".crystal_type_id
@@ -1015,7 +1015,7 @@ class String
   # "好".bytes            # => [229, 165, 189]
   # ```
   def encode(encoding : String, invalid : Symbol? = nil) : Slice(UInt8)
-    io = MemoryIO.new
+    io = IO::Memory.new
     String.encode(to_slice, "UTF-8", encoding, io, invalid)
     io.to_slice
   end

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -1,6 +1,6 @@
 require "io"
 
-# Similar to `MemoryIO`, but optimized for building a single string.
+# Similar to `IO::Memory`, but optimized for building a single string.
 #
 # You should never have to deal with this class. Instead, use `String.build`.
 class String::Builder

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -277,7 +277,7 @@ struct String::Formatter(A)
     format_buf = format_buf(capacity)
     original_format_buf = format_buf
 
-    io = MemoryIO.new(Slice(UInt8).new(format_buf, capacity))
+    io = IO::Memory.new(Slice(UInt8).new(format_buf, capacity))
     io << '%'
     io << '+' if flags.plus
     io << '-' if flags.minus

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -89,19 +89,19 @@ class StringPool
     entry
   end
 
-  # Returns a string with the contents of the given `MemoryIO`.
+  # Returns a string with the contents of the given `IO::Memory`.
   #
   # If a string with those contents was already present in the pool, that one is returned.
   # Otherwise a new string is created, put in the pool and returned
   #
   # ```
   # pool = StringPool.new
-  # io = MemoryIO.new "crystal"
+  # io = IO::Memory.new "crystal"
   # pool.empty? # => true
   # pool.get(io)
   # pool.empty? # => false
   # ```
-  def get(str : MemoryIO)
+  def get(str : IO::Memory)
     get(str.buffer, str.bytesize)
   end
 


### PR DESCRIPTION
Similar to #3401. MemoryIO is still available but produces a deprecation warning at compile-time, to ease migration.

