### PR TITLE
Refactor interpret '==' and '!=' of MacroId

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1146,13 +1146,7 @@ module Crystal
       case method
       when "==", "!="
         case arg = args.first?
-        when StringLiteral
-          if method == "=="
-            return BoolLiteral.new(@value == arg.value)
-          else
-            return BoolLiteral.new(@value != arg.value)
-          end
-        when SymbolLiteral
+        when StringLiteral, SymbolLiteral
           if method == "=="
             return BoolLiteral.new(@value == arg.value)
           else


### PR DESCRIPTION
It is the best. Thanks @Sija.

<del>

Not the best, but a better.

I think the best is:

```crystal
        if (arg = args.first?).is_a?(StringLiteral | SymbolLiteral)
          if method == "=="
            return BoolLiteral.new(@value == arg.value)
          else
            return BoolLiteral.new(@value != arg.value)
          end
        end
        return super
```

However, compiler doesn't accept this.

</del>