### PR TITLE
.crystal directory is no longer created

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -39,14 +39,12 @@ module Crystal
       gitignore.should contain("/.shards/")
       gitignore.should contain("/shard.lock")
       gitignore.should contain("/libs/")
-      gitignore.should contain("/.crystal/")
     end
 
     describe_file "example_app/.gitignore" do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should_not contain("/shard.lock")
       gitignore.should contain("/libs/")
-      gitignore.should contain("/.crystal/")
     end
 
     describe_file "example/LICENSE" do |license|

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,7 +1,6 @@
 /doc/
 /libs/
 /lib/
-/.crystal/
 /.shards/
 
 <% if config.skeleton_type == "lib" %>


### PR DESCRIPTION
I know `.crystal` directory is created if the environment variables `CRYSTAL_CACHE_DIR`, `XDG_CACHE_HOMR` or `HOME` are not set or all candidates are unavailable. However it is special case, and if so, `.gitignore` should not contain `/.crystal/`, but `.crystal/` (it dose not restrict project root.)