### PR TITLE
Clean up trailing extra newlines in files generated by crystal init

### DIFF
--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -3,9 +3,9 @@
 /lib/
 /.crystal/
 /.shards/
+<%- if config.skeleton_type == "lib" -%>
 
-<% if config.skeleton_type == "lib" %>
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
 /shard.lock
-<% end %>
+<%- end -%>

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -4,7 +4,7 @@ TODO: Write a description here
 
 ## Installation
 
-<% if config.skeleton_type == "lib" %>
+<%- if config.skeleton_type == "lib" -%>
 Add this to your application's `shard.yml`:
 
 ```yaml
@@ -12,18 +12,18 @@ dependencies:
   <%= config.name %>:
     github: <%= config.github_name %>/<%= config.name %>
 ```
-<% else %>
+<%- else -%>
 TODO: Write installation instructions here
-<% end %>
+<%- end -%>
 
 ## Usage
 
-<% if config.skeleton_type == "lib" %>
+<%- if config.skeleton_type == "lib" -%>
 ```crystal
 require "<%= config.name %>"
 ```
-<% end %>
 
+<%- end -%>
 TODO: Write usage instructions here
 
 ## Development


### PR DESCRIPTION
On `crystal init app foo`, we get `foo/.gitignore`:

```
/doc/
/libs/
/lib/
/.crystal/
/.shards/


```

Last 2 empty lines are unnecessary. And, `README.md` has same problem. I fixed it.