### PR TITLE
Add tables support for Markdown

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -98,6 +98,9 @@ describe Markdown do
 
   assert_render "[![foo](bar)](baz)", %(<p><a href="baz"><img src="bar" alt="foo"/></a></p>)
 
+  assert_render "|:- CHeader -:|- RHeader with Spaces -:|: LHeader :- with ::- Characters -|- DHeader |\n| row1-1 | row1-2 | row1-3 | row1-4 |\n| row2-1 | row2-2 | row2-3 | row2-4 |\n| row3-1 | row3-2 | row3-3 | row3-4 |", "<table><tr><th style='text-align: center;'> CHeader </th><th style='text-align: right;'> RHeader with Spaces </th><th style='text-align: left;'> LHeader :- with ::- Characters </th><th style='text-align: left;'> DHeader </th></tr><tr><td style='text-align: center;'> row1-1 </td><td style='text-align: right;'> row1-2 </td><td style='text-align: left;'> row1-3 </td><td style='text-align: left;'> row1-4 </td></tr><tr><td style='text-align: center;'> row2-1 </td><td style='text-align: right;'> row2-2 </td><td style='text-align: left;'> row2-3 </td><td style='text-align: left;'> row2-4 </td></tr><tr><td style='text-align: center;'> row3-1 </td><td style='text-align: right;'> row3-2 </td><td style='text-align: left;'> row3-3 </td><td style='text-align: left;'> row3-4 </td></tr></table>"
+  assert_render "|:- CHeader -:|- RHeader with Spaces -:|: LHeader :- with ::- Characters -|- DHeader |", "<table><tr><th style='text-align: center;'> CHeader </th><th style='text-align: right;'> RHeader with Spaces </th><th style='text-align: left;'> LHeader :- with ::- Characters </th><th style='text-align: left;'> DHeader </th></tr></table>"
+
   assert_render "***", "<hr/>"
   assert_render "---", "<hr/>"
   assert_render "___", "<hr/>"

--- a/src/markdown/html_renderer.cr
+++ b/src/markdown/html_renderer.cr
@@ -119,4 +119,30 @@ class Markdown::HTMLRenderer
   def horizontal_rule
     @io << "<hr/>"
   end
+
+  def begin_table
+    @io << "<table>"
+  end
+
+  def end_table
+    @io << "</table>"
+  end
+
+  def begin_table_row
+    @io << "<tr>"
+  end
+
+  def end_table_row
+    @io << "</tr>"
+  end
+
+  def begin_table_cell(alignment, cellType)
+    text = cellType == "td" ? "<td style='text-align: #{alignment};'>" : "<th style='text-align: #{alignment};'>"
+    @io << text
+  end
+
+  def end_table_cell(cellType)
+    text = cellType == "td" ? "</td>" : "</th>"
+    @io << text
+  end
 end

--- a/src/markdown/renderer.cr
+++ b/src/markdown/renderer.cr
@@ -24,4 +24,8 @@ module Markdown::Renderer
   abstract def image(url, alt)
   abstract def text(text)
   abstract def horizontal_rule
+  abstract def begin_table
+  abstract def end_table
+  abstract def begin_table_cell(alignment, cellType)
+  abstract def end_table_cell(cellType)
 end


### PR DESCRIPTION
This commit lets this syntax work for markdown:

`-` denotes a header, and `:` denotes alignment.

```md
|:- Center Align -:|- Right Align -:|: Left Align -|- Default (left) |
| Row1-1 | Row1-2 | Row1-3 | Row1-4 |
| Row2-1 | Row2-2 | Row2-3 | Row2-4 |
```

This style saves the extra line of typical markdown syntax:
```md
| Header |
|: --- |
| Row1-1 |
```

This is my first contribution, so if my implementation can be made better or more "Crystal-like" please let me know.