### PR TITLE
Remove `libs` from search path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD . /opt/crystal-head
 
 WORKDIR /opt/crystal-head
 ENV CRYSTAL_CONFIG_VERSION HEAD
-ENV CRYSTAL_CONFIG_PATH lib:libs:/opt/crystal-head/src:/opt/crystal-head/libs
+ENV CRYSTAL_CONFIG_PATH lib:/opt/crystal-head/src:/opt/crystal-head/libs
 ENV LIBRARY_PATH /opt/crystal/embedded/lib
 ENV PATH /opt/crystal-head/bin:/opt/llvm-3.5.0-1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/bin/crystal
+++ b/bin/crystal
@@ -116,7 +116,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=$CRYSTAL_ROOT/src:lib:libs
+export CRYSTAL_PATH=$CRYSTAL_ROOT/src:lib
 
 if [ -x "$CRYSTAL_DIR/crystal" ]
 then

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -40,14 +40,12 @@ module Crystal
       gitignore.should contain("/.shards/")
       gitignore.should contain("/shard.lock")
       gitignore.should contain("/lib/")
-      gitignore.should contain("/libs/")
     end
 
     describe_file "example_app/.gitignore" do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should_not contain("/shard.lock")
       gitignore.should contain("/lib/")
-      gitignore.should contain("/libs/")
     end
 
     describe_file "example/LICENSE" do |license|

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,5 +1,4 @@
 /doc/
-/libs/
 /lib/
 /bin/
 /.shards/


### PR DESCRIPTION
This PR removes `libs` directory from the search path.

#2788 should have removed `libs`, I guess, it only added `lib`.

/cc @ysbaddaden