### PR TITLE
Add '/bin/' into .gitignore

### DIFF
--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,6 +1,7 @@
 /doc/
 /libs/
 /lib/
+/bin/
 /.shards/
 <%- if config.skeleton_type == "lib" -%>
 


### PR DESCRIPTION
Since `shards build` builds crystal projects and generates executable binary onto bin/, the project should ignore `bin` directory to be added by git command.
I added /bin/ onto .gitignore's template file.