### PR TITLE
[performance] Change Fiber.yield to not generate a timer event and instead just add itself as the last runnable fiber

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -273,7 +273,8 @@ class Fiber
   end
 
   def yield
-    sleep(0)
+    Scheduler.enqueue self
+    Scheduler.reschedule
   end
 
   def self.sleep(time)


### PR DESCRIPTION
This has the same behavior as far as I can tell but without calling into libevent, registering a timer event and waiting for the event to be pulled. This saves some system calls and should be faster.

Benchmark:

```cr

class Fiber
  def yield2
    Scheduler.enqueue self
    Scheduler.reschedule
  end
  def self.yield2
    Fiber.current.yield2
  end
end

require "benchmark"
N = 10_000_000

Benchmark.bm do |x|
  x.report("before") do
    spawn do
      N.times {|i| Fiber.yield }
    end

    N.times { Fiber.yield }
  end
  x.report("after") do
    spawn do
      N.times {|i| Fiber.yield2 }
    end

    N.times { Fiber.yield2 }
  end
end
```

---

```
             user     system      total        real
before   3.410000   0.750000   4.160000 (  4.172480)
after    0.520000   0.000000   0.520000 (  0.515067)
```