### PR TITLE
Prefer new `lib` path over old `libs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD . /opt/crystal-head
 
 WORKDIR /opt/crystal-head
 ENV CRYSTAL_CONFIG_VERSION HEAD
-ENV CRYSTAL_CONFIG_PATH libs:lib:/opt/crystal-head/src:/opt/crystal-head/libs
+ENV CRYSTAL_CONFIG_PATH lib:libs:/opt/crystal-head/src:/opt/crystal-head/libs
 ENV LIBRARY_PATH /opt/crystal/embedded/lib
 ENV PATH /opt/crystal-head/bin:/opt/llvm-3.5.0-1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/bin/crystal
+++ b/bin/crystal
@@ -116,7 +116,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=$CRYSTAL_ROOT/src:libs:lib
+export CRYSTAL_PATH=$CRYSTAL_ROOT/src:lib:libs
 
 if [ -x "$CRYSTAL_DIR/crystal" ]
 then

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -39,12 +39,14 @@ module Crystal
     describe_file "example/.gitignore" do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should contain("/shard.lock")
+      gitignore.should contain("/lib/")
       gitignore.should contain("/libs/")
     end
 
     describe_file "example_app/.gitignore" do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should_not contain("/shard.lock")
+      gitignore.should contain("/lib/")
       gitignore.should contain("/libs/")
     end
 


### PR DESCRIPTION
Instead of removing `libs` from search path (see #3593) prefer `lib` so upgrading to 0.20.0 is easier.

/cc @asterite 