### PR TITLE
add match with block method to string. Fixes incorrect usage in docs

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1680,6 +1680,14 @@ describe "String" do
     match[0].should eq("")
   end
 
+  it "matches with a block" do
+    "Crystal".match(/[p-s]/) do |md|
+      md.not_nil!.string.should eq "Crystal"
+      md.not_nil![0].should eq "r"
+      md.not_nil![1]?.should eq nil
+    end
+  end
+
   it "has size (same as size)" do
     "テスト".size.should eq(3)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2936,6 +2936,14 @@ class String
     match
   end
 
+  # Finds match of *regex*, starting at *pos* and passes to *block*
+  # and yields a `Regex::MatchData` instance
+  def match(regex : Regex, pos = 0, &block : Regex::MatchData? -> _)
+    match = match(regex, pos)
+    yield match
+    match
+  end
+
   # Searches the string for instances of *pattern*, yielding a `Regex::MatchData` for each match.
   def scan(pattern : Regex)
     byte_offset = 0


### PR DESCRIPTION
In the [docs for MatchData](https://crystal-lang.org/api/0.20.0/Regex/MatchData.html) it mentions an example using a block:

```crystal
"Crystal".match(/[p-s]/) do |md|
  md.string # => "Crystal"
  md[0]     # => "r"
  md[1]?    # => nil
end
```

This example doesn't work in master as it throws `'String#match' is not expected to be invoked with a block, but a block was given`. This PR adds this block method in. 

One thing I do have a question about is in the docs it says `md.string`, but running the code like that will throw a `undefined method 'string' for Nil` compile-time error. Adding `not_nil!` makes it work, but it feels weird to always have to add that in. Should this block just yield `match.not_nil!`? or should I also add in an update to the docs to show that usage?