### PR TITLE
YAML support for emitting tags and style

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -9,6 +9,20 @@ enum YAMLSpecEnum
   Two
 end
 
+class YAMLScalarTester
+  @val : String
+  @tag : String?
+  @style : LibYAML::ScalarStyle?
+  def initialize(value, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    @val = value
+    @tag = tag
+    @style = style
+  end
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    @val.to_yaml(emitter, tag: tag || @tag, style: style || @style)
+  end
+end
+
 describe "YAML serialization" do
   describe "from_yaml" do
     it "does Nil#from_yaml" do
@@ -214,5 +228,236 @@ describe "YAML serialization" do
       end
       string.should eq("---\n- a\n- b\n- c\n")
     end
+  end
+
+  describe "emits custom tag" do
+    describe "for class" do
+      it "String" do
+        s = "HELLO"
+        r = s.to_yaml("!custom")
+        r.should eq("--- !custom HELLO\n...\n")
+      end
+
+      it "Symbol" do
+        s = :HELLO
+        r = s.to_yaml("!custom")
+        r.should eq("--- !custom HELLO\n...\n")
+      end
+
+      it "Int" do
+        x = 10
+        r = x.to_yaml("!custom")
+        r.should eq("--- !custom 10\n...\n")
+      end
+
+      it "Array" do
+        a = [10,11]
+        r = a.to_yaml(tag: "!custom")
+        r.should eq("--- !custom\n- 10\n- 11\n")
+      end
+
+      it "Hash" do
+        h = {"a"=>"b"}
+        r = h.to_yaml(tag: "!custom")
+        r.should eq("--- !custom\na: b\n")
+      end
+
+      it "Tuple" do
+        t = {"a", "b"}
+        r = t.to_yaml(tag: "!custom")
+        r.should eq("--- !custom\n- a\n- b\n")
+      end
+
+      it "NamedTuple" do
+        n = {a: "b"}
+        r = n.to_yaml(tag: "!custom")
+        r.should eq("--- !custom\na: b\n")
+      end
+
+      it "Time" do
+        t = Time.now
+        r = t.to_yaml(tag: "!mytime")
+        r.starts_with?("--- !mytime").should eq(true)
+      end
+    end
+
+    describe "but not for core tag" do
+      it "!!str" do
+        x = "HELLO"
+        r = x.to_yaml("tag:yaml.org,2002:str")
+        r.should eq("--- HELLO\n...\n")
+      end
+
+      it "!!int" do
+        x = 10
+        r = x.to_yaml("tag:yaml.org,2002:int")
+        r.should eq("--- 10\n...\n")
+      end
+
+      it "!!float" do
+        x = 10.5
+        r = x.to_yaml("tag:yaml.org,2002:float")
+        r.should eq("--- 10.5\n...\n")
+      end
+
+      it "!!null" do
+        x = nil
+        r = x.to_yaml("tag:yaml.org,2002:null")
+        r.should eq("--- \n...\n")
+      end
+
+      it "!!bool" do
+        x = true
+        r = x.to_yaml("tag:yaml.org,2002:bool")
+        r.should eq("--- true\n...\n")
+
+        x = false
+        r = x.to_yaml("tag:yaml.org,2002:bool")
+        r.should eq("--- false\n...\n")
+      end
+
+      it "!!seq" do
+        x = ["A"]
+        r = x.to_yaml("tag:yaml.org,2002:seq")
+        r.should eq("---\n- A\n")
+      end
+
+      it "!!map" do
+        x = {"A"=>"X"}
+        r = x.to_yaml("tag:yaml.org,2002:map")
+        r.should eq("---\nA: X\n")
+      end
+    end
+
+    describe "miscellaneous" do
+      it "core tag" do
+        x = "A"
+        r = x.to_yaml("tag:yaml.org,2002:foo")
+        r.should eq("--- !!foo A\n...\n")
+      end
+
+      it "full tag" do
+        x = "A"
+        r = x.to_yaml("tag:foo.org,2002:bar")
+        r.should eq("--- !<tag:foo.org,2002:bar> A\n...\n")
+      end
+
+      it "for array element" do
+        x = YAMLScalarTester.new("10", "!custom")
+        a = [ x ]
+        r = a.to_yaml
+        r.should eq("---\n- !custom 10\n")
+      end
+    end
+  end
+
+  describe "emits specified style" do
+    describe "scalar style" do
+      # TODO: Output seems incorrect, but it has to be something with LibYAML.
+      pending "PLAIN" do
+        s = "ABC\nXYZ"
+        r = s.to_yaml(style: LibYAML::ScalarStyle::PLAIN)
+        r.should eq("---\n  ABC\n\n  XYZ\n")
+      end
+
+      pending "PLAIN as array element" do
+        s = YAMLScalarTester.new("ABC\nXYZ", style: LibYAML::ScalarStyle::PLAIN)
+        r = [s].to_yaml
+        r.should eq("---\n- ABC\n\n  XYZ\n")
+      end
+
+      it "SINGLE_QUOTED" do
+        s = "ABC"
+        r = s.to_yaml(style: LibYAML::ScalarStyle::SINGLE_QUOTED)
+        r.should eq("--- 'ABC'\n")
+      end
+
+      it "DOUBLE_QUOTED" do
+        s = "ABC"
+        r = s.to_yaml(style: LibYAML::ScalarStyle::DOUBLE_QUOTED)
+        r.should eq("--- \"ABC\"\n")
+      end
+
+      it "LITERAL" do
+        s = "ABC\nXYZ\n"
+        r = s.to_yaml(style: LibYAML::ScalarStyle::LITERAL)
+        r.should eq("--- |\n  ABC\n  XYZ\n")
+      end
+
+      it "FOLDED" do
+        s = "ABC\nXYZ\n"
+        r = s.to_yaml(style: LibYAML::ScalarStyle::FOLDED)
+        r.should eq("--- >\n  ABC\n\n  XYZ\n")
+      end
+    end
+
+    describe "sequence style" do
+      it "BLOCK" do
+        a = ["A","B","C"]
+        r = a.to_yaml(style: LibYAML::SequenceStyle::BLOCK)
+        r.should eq("---\n- A\n- B\n- C\n")
+      end
+
+      it "FLOW" do
+        a = ["A","B","C"]
+        r = a.to_yaml(style: LibYAML::SequenceStyle::FLOW)
+        r.should eq("--- [A, B, C]\n")
+      end
+    end
+
+    describe "mapping style" do
+      it "BLOCK" do
+        h = {"A"=>"X", "B"=>"Y", "C"=>"Z"}
+        r = h.to_yaml(style: LibYAML::MappingStyle::BLOCK)
+        r.should eq("---\nA: X\nB: Y\nC: Z\n")
+      end
+
+      it "FLOW" do
+        h = {"A"=>"X", "B"=>"Y", "C"=>"Z"}
+        r = h.to_yaml(style: LibYAML::MappingStyle::FLOW)
+        r.should eq("--- {A: X, B: Y, C: Z}\n")
+      end
+    end
+  end
+
+  describe "with custom tag and specified style" do
+    it "single quoted" do
+      s = "ABC"
+      r = s.to_yaml("!custom", LibYAML::ScalarStyle::SINGLE_QUOTED)
+      r.should eq("--- !custom 'ABC'\n")
+    end
+
+    it "single quoted using named arguments" do
+      i = 10
+      r = i.to_yaml(tag: "!custom", style: LibYAML::ScalarStyle::SINGLE_QUOTED)
+      r.should eq("--- !custom '10'\n")
+    end
+
+    it "double quoted symbol" do
+      s = :ABC
+      r = s.to_yaml("!custom", LibYAML::ScalarStyle::DOUBLE_QUOTED)
+      r.should eq("--- !custom \"ABC\"\n")
+    end
+  end
+
+  describe "complex example with custom tags and style" do
+    yaml = <<-YAML
+    --- !x
+    - !a A
+    - !b 'B'
+    - !c "C"
+    - !a A: !b 'B'
+      !b 'B': !c "C"\n
+    YAML
+
+    a1 = YAMLScalarTester.new("A", "!a")
+    a2 = YAMLScalarTester.new("B", "!b", LibYAML::ScalarStyle::SINGLE_QUOTED)
+    a3 = YAMLScalarTester.new("C", "!c", LibYAML::ScalarStyle::DOUBLE_QUOTED)
+    h = {a1 => a2, a2 => a3}
+
+    x = [a1, a2, a3, h]
+
+    r = x.to_yaml("!x", LibYAML::SequenceStyle::BLOCK)
+    r.should eq(yaml)
   end
 end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -13,11 +13,13 @@ class YAMLScalarTester
   @val : String
   @tag : String?
   @style : LibYAML::ScalarStyle?
+
   def initialize(value, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
     @val = value
     @tag = tag
     @style = style
   end
+
   def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
     @val.to_yaml(emitter, tag: tag || @tag, style: style || @style)
   end
@@ -251,13 +253,13 @@ describe "YAML serialization" do
       end
 
       it "Array" do
-        a = [10,11]
+        a = [10, 11]
         r = a.to_yaml(tag: "!custom")
         r.should eq("--- !custom\n- 10\n- 11\n")
       end
 
       it "Hash" do
-        h = {"a"=>"b"}
+        h = {"a" => "b"}
         r = h.to_yaml(tag: "!custom")
         r.should eq("--- !custom\na: b\n")
       end
@@ -323,7 +325,7 @@ describe "YAML serialization" do
       end
 
       it "!!map" do
-        x = {"A"=>"X"}
+        x = {"A" => "X"}
         r = x.to_yaml("tag:yaml.org,2002:map")
         r.should eq("---\nA: X\n")
       end
@@ -344,7 +346,7 @@ describe "YAML serialization" do
 
       it "for array element" do
         x = YAMLScalarTester.new("10", "!custom")
-        a = [ x ]
+        a = [x]
         r = a.to_yaml
         r.should eq("---\n- !custom 10\n")
       end
@@ -393,13 +395,13 @@ describe "YAML serialization" do
 
     describe "sequence style" do
       it "BLOCK" do
-        a = ["A","B","C"]
+        a = ["A", "B", "C"]
         r = a.to_yaml(style: LibYAML::SequenceStyle::BLOCK)
         r.should eq("---\n- A\n- B\n- C\n")
       end
 
       it "FLOW" do
-        a = ["A","B","C"]
+        a = ["A", "B", "C"]
         r = a.to_yaml(style: LibYAML::SequenceStyle::FLOW)
         r.should eq("--- [A, B, C]\n")
       end
@@ -407,13 +409,13 @@ describe "YAML serialization" do
 
     describe "mapping style" do
       it "BLOCK" do
-        h = {"A"=>"X", "B"=>"Y", "C"=>"Z"}
+        h = {"A" => "X", "B" => "Y", "C" => "Z"}
         r = h.to_yaml(style: LibYAML::MappingStyle::BLOCK)
         r.should eq("---\nA: X\nB: Y\nC: Z\n")
       end
 
       it "FLOW" do
-        h = {"A"=>"X", "B"=>"Y", "C"=>"Z"}
+        h = {"A" => "X", "B" => "Y", "C" => "Z"}
         r = h.to_yaml(style: LibYAML::MappingStyle::FLOW)
         r.should eq("--- {A: X, B: Y, C: Z}\n")
       end

--- a/src/yaml/emitter.cr
+++ b/src/yaml/emitter.cr
@@ -164,5 +164,4 @@ class YAML::Emitter
   private def ctag(tag : String?)
     tag.try(&.to_unsafe) || Pointer(UInt8).null
   end
-
 end

--- a/src/yaml/emitter.cr
+++ b/src/yaml/emitter.cr
@@ -50,12 +50,28 @@ class YAML::Emitter
     emit scalar, nil, nil, string, string.bytesize, 1, 1, LibYAML::ScalarStyle::ANY
   end
 
+  def scalar(string, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    style ||= LibYAML::ScalarStyle::ANY
+    implicit = implicit(tag)
+    LibYAML.yaml_scalar_event_initialize(
+      pointerof(@event), nil, ctag(tag), string, string.bytesize, implicit, implicit, style
+    )
+    yaml_emit("scalar")
+  end
+
   def <<(value)
     scalar value.to_s
   end
 
   def sequence_start
     emit sequence_start, nil, nil, 0, LibYAML::SequenceStyle::ANY
+  end
+
+  def sequence_start(tag : String? = nil, style : LibYAML::SequenceStyle? = nil)
+    style ||= LibYAML::SequenceStyle::ANY
+    implicit = implicit(tag)
+    LibYAML.yaml_sequence_start_event_initialize(pointerof(@event), nil, ctag(tag), implicit, style)
+    yaml_emit("sequence_start")
   end
 
   def sequence_end
@@ -68,8 +84,22 @@ class YAML::Emitter
     sequence_end
   end
 
+  def sequence(tag : String? = nil, style : LibYAML::SequenceStyle? = nil)
+    style ||= LibYAML::SequenceStyle::ANY
+    sequence_start(tag, style)
+    yield
+    sequence_end
+  end
+
   def mapping_start
     emit mapping_start, nil, nil, 0, LibYAML::MappingStyle::ANY
+  end
+
+  def mapping_start(tag : String? = nil, style : LibYAML::MappingStyle? = nil)
+    style ||= LibYAML::MappingStyle::ANY
+    implicit = implicit(tag)
+    LibYAML.yaml_mapping_start_event_initialize(pointerof(@event), nil, ctag(tag), implicit, style)
+    yaml_emit("mapping_start")
   end
 
   def mapping_end
@@ -78,6 +108,13 @@ class YAML::Emitter
 
   def mapping
     mapping_start
+    yield
+    mapping_end
+  end
+
+  def mapping(tag : String? = nil, style : LibYAML::MappingStyle? = nil)
+    style ||= LibYAML::MappingStyle::ANY
+    mapping_start(tag, style)
     yield
     mapping_end
   end
@@ -107,4 +144,25 @@ class YAML::Emitter
       raise YAML::Error.new("error emitting #{event_name}")
     end
   end
+
+  # Determine if a tag can be implicit. All the core YAML types can be.
+  private def implicit(tag : String?)
+    case tag
+    when nil
+      1
+    when LibYAML::TAG_STR, LibYAML::TAG_INT, LibYAML::TAG_FLOAT,
+         LibYAML::TAG_BOOL, LibYAML::TAG_NULL,
+         LibYAML::TAG_SEQ, LibYAML::TAG_MAP
+      1
+    else
+      0
+    end
+  end
+
+  # Union type `(String | Nil)` of `tag` causes an error.
+  # This bit of code works around that.
+  private def ctag(tag : String?)
+    tag.try(&.to_unsafe) || Pointer(UInt8).null
+  end
+
 end

--- a/src/yaml/lib_yaml.cr
+++ b/src/yaml/lib_yaml.cr
@@ -15,6 +15,14 @@ lib LibYAML
     EMITTER_SIZE = 264
   {% end %}
 
+  TAG_STR   = "tag:yaml.org,2002:str"
+  TAG_SEQ   = "tag:yaml.org,2002:seq"
+  TAG_MAP   = "tag:yaml.org,2002:map"
+  TAG_INT   = "tag:yaml.org,2002:int"
+  TAG_FLOAT = "tag:yaml.org,2002:float"
+  TAG_BOOL  = "tag:yaml.org,2002:bool"
+  TAG_NULL  = "tag:yaml.org,2002:null"
+
   enum Encoding
     Any
     UTF8
@@ -62,6 +70,8 @@ lib LibYAML
     BLOCK
     FLOW
   end
+
+  alias Style = ScalarStyle | SequenceStyle | MappingStyle | Nil
 
   struct StreamStartEvent
     encoding : Int32

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -1,24 +1,29 @@
 class Object
-  def to_yaml
+  def to_yaml(tag : String? = nil, style : LibYAML::Style = nil)
     String.build do |str|
-      to_yaml(str)
+      to_yaml(str, tag, style)
     end
   end
 
-  def to_yaml(io : IO)
+  def to_yaml(io : IO, tag : String? = nil, style : LibYAML::Style = nil)
     YAML::Emitter.new(io) do |emitter|
       emitter.stream do
         emitter.document do
-          to_yaml(emitter)
+          to_yaml(emitter, tag, style)
         end
       end
     end
   end
+
+  # backward compatability
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::Style = nil)
+    to_yaml(emitter)
+  end
 end
 
 class Hash
-  def to_yaml(emitter : YAML::Emitter)
-    emitter.mapping do
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::MappingStyle? = nil)
+    emitter.mapping(tag, style) do
       each do |key, value|
         key.to_yaml(emitter)
         value.to_yaml(emitter)
@@ -28,24 +33,24 @@ class Hash
 end
 
 class Array
-  def to_yaml(emitter : YAML::Emitter)
-    emitter.sequence do
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::SequenceStyle? = nil)
+    emitter.sequence(tag, style) do
       each &.to_yaml(emitter)
     end
   end
 end
 
 struct Tuple
-  def to_yaml(emitter : YAML::Emitter)
-    emitter.sequence do
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::SequenceStyle? = nil)
+    emitter.sequence(tag, style) do
       each &.to_yaml(emitter)
     end
   end
 end
 
 struct NamedTuple
-  def to_yaml(emitter : YAML::Emitter)
-    emitter.mapping do
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::MappingStyle? = nil)
+    emitter.mapping(tag, style) do
       {% for key in T.keys %}
         {{key.symbolize}}.to_yaml(emitter)
         self[{{key.symbolize}}].to_yaml(emitter)
@@ -55,69 +60,69 @@ struct NamedTuple
 end
 
 class String
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << self
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(to_s, tag, style)
   end
 end
 
 struct Number
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << self
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(to_s, tag, style)
   end
 end
 
 struct Nil
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << ""
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar("", tag, style)
   end
 end
 
 struct Bool
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << self
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(to_s, tag, style)
   end
 end
 
 struct Set
-  def to_yaml(emitter : YAML::Emitter)
-    emitter.sequence do
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::SequenceStyle? = nil)
+    emitter.sequence(tag, style) do
       each &.to_yaml(emitter)
     end
   end
 end
 
 struct Symbol
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << self
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(to_s, tag, style)
   end
 end
 
 struct Enum
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << value
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(value.to_s, tag, style)
   end
 end
 
 struct Time
-  def to_yaml(emitter : YAML::Emitter)
-    emitter << Time::Format::ISO_8601_DATE_TIME.format(self)
+  def to_yaml(emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(Time::Format::ISO_8601_DATE_TIME.format(self), tag, style)
   end
 end
 
 struct Time::Format
-  def to_yaml(value : Time, emitter : YAML::Emitter)
-    format(value).to_yaml(emitter)
+  def to_yaml(value : Time, emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    format(value).to_yaml(emitter, tag, style)
   end
 end
 
 module Time::EpochConverter
-  def self.to_yaml(value : Time, emitter : YAML::Emitter)
-    emitter << value.epoch
+  def self.to_yaml(value : Time, emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(value.epoch.to_s, tag, style)
   end
 end
 
 module Time::EpochMillisConverter
-  def self.to_yaml(value : Time, emitter : YAML::Emitter)
-    emitter << value.epoch_ms
+  def self.to_yaml(value : Time, emitter : YAML::Emitter, tag : String? = nil, style : LibYAML::ScalarStyle? = nil)
+    emitter.scalar(value.epoch_ms.to_s, tag, style)
   end
 end


### PR DESCRIPTION
This code adds support for tag and style control to the YAML Emitter class and #to_yaml methods. This addition to the YAML library will make is possible to add tag and style support to `YAML.mapping` in the future. It is also fully backward compatible, so no worries there. 
