### PR TITLE
Move filename and some file location methods doc under to Crystal::Macros::ASTNode

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -75,39 +75,6 @@ module Crystal::Macros
   def run(filename, *args) : MacroId
   end
 
-  # Returns the filename where this node is located.
-  # Might return nil if the location is not known.
-  def filename : StringLiteral | NilLiteral
-  end
-
-  # Returns the line number where this node begins.
-  # Might return nil if the location is not known.
-  #
-  # The first line number in a file is 1.
-  def line_number : StringLiteral | NilLiteral
-  end
-
-  # Returns the column number where this node begins.
-  # Might return nil if the location is not known.
-  #
-  # The first column number in a line is 1.
-  def column_number : StringLiteral | NilLiteral
-  end
-
-  # Returns the line number where this node ends.
-  # Might return nil if the location is not known.
-  #
-  # The first line number in a file is 1.
-  def end_line_number : StringLiteral | NilLiteral
-  end
-
-  # Returns the column number where this node ends.
-  # Might return nil if the location is not known.
-  #
-  # The first column number in a line is 1.
-  def end_column_number : StringLiteral | NilLiteral
-  end
-
   # This is the base class of all AST nodes. This methods are
   # available to all AST nodes.
   abstract class ASTNode
@@ -155,6 +122,39 @@ module Crystal::Macros
     # puts test # => prints StringLiteral
     # ```
     def class_name : StringLiteral
+    end
+
+    # Returns the filename where this node is located.
+    # Might return nil if the location is not known.
+    def filename : StringLiteral | NilLiteral
+    end
+
+    # Returns the line number where this node begins.
+    # Might return nil if the location is not known.
+    #
+    # The first line number in a file is 1.
+    def line_number : StringLiteral | NilLiteral
+    end
+
+    # Returns the column number where this node begins.
+    # Might return nil if the location is not known.
+    #
+    # The first column number in a line is 1.
+    def column_number : StringLiteral | NilLiteral
+    end
+
+    # Returns the line number where this node ends.
+    # Might return nil if the location is not known.
+    #
+    # The first line number in a file is 1.
+    def end_line_number : StringLiteral | NilLiteral
+    end
+
+    # Returns the column number where this node ends.
+    # Might return nil if the location is not known.
+    #
+    # The first column number in a line is 1.
+    def end_column_number : StringLiteral | NilLiteral
     end
 
     # Returns true if this node's textual representation is the same as


### PR DESCRIPTION
These methods are added by cf24ccf04c803a1b32053d43ec0875f543e2909a, however these places are mistaken.