### PR TITLE
Ensure wrapper usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ as the standard library. Otherwise the barebones `crystal` executable uses the s
 your installation.
 
 Next, make changes to the standard library, making sure you also provide corresponding specs. To run
-the specs for the standard library, run `bin/crystal spec/std_spec.cr`. To run a particular spec: `bin/crystal spec/std/array_spec.cr`.
+the specs for the standard library, run `make std_spec`. To run a particular spec: `bin/crystal spec/std/array_spec.cr`.
+You can use `make help` for a list of available make targets.
 
 Note: at this point you might get long compile error that include "library not found for: ...". This means
 you are [missing some libraries](https://github.com/crystal-lang/crystal/wiki/All-required-libraries).
@@ -56,13 +57,13 @@ Then push your changes and create a pull request.
 If you want to add/change something in the compiler,
 the first thing you will need to do is to [install the compiler](https://crystal-lang.org/docs/installation/index.html).
 
-Once you have a compiler up and running, and that executing `crystal` on the command line prints its usage,
-it's time to setup your environment to compile Crystal itself, which is written in Crystal. Check out
+Once you have a compiler up and running, check that executing `crystal` on the command line prints its usage.
+Now you can setup your environment to compile Crystal itself, which is itself written in Crystal. Check out
 the `install` and `before_install` sections found in [.travis.yml](https://github.com/crystal-lang/crystal/blob/master/.travis.yml).
 These set-up LLVM 3.6 and its required libraries.
 
 Next, executing `make clean crystal spec` should compile a compiler and using that compiler compile and execute
-the specs. All specs should pass.
+the specs. All specs should pass. You can use `make help` for a list of available make targets.
 
 ## Maintain clean pull requests
 

--- a/bin/crystal
+++ b/bin/crystal
@@ -117,6 +117,7 @@ CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
 export CRYSTAL_PATH=$CRYSTAL_ROOT/src:lib:libs
+export CRYSTAL_HAS_WRAPPER=true
 
 if [ -x "$CRYSTAL_DIR/crystal" ]
 then

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,5 @@
+{% raise("Please use `make spec` or `bin/crystal` when running specs, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
+
 ENV["CRYSTAL_PATH"] = "#{__DIR__}/../src"
 
 require "spec"

--- a/src/compiler/crystal.cr
+++ b/src/compiler/crystal.cr
@@ -1,6 +1,8 @@
 # This is the file that is compiled to generate the
 # executable for the compiler.
 
+{% raise("Please use `make crystal` to build the compiler, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
+
 require "./crystal/**"
 
 Crystal::Command.run


### PR DESCRIPTION
This pull request makes compiling the compiler or specs fail when you attempt to compile without `bin/crystal`. Note that attempting to require *parts* of the compiler will never fail, so programs which reuse parts of the compiler are unaffected.

I also added a bit to `CONTRIBUTING.md` to mention `make help` and a few other fixes.