### PR TITLE
Add finished macro hook

### DIFF
--- a/spec/compiler/codegen/hooks_spec.cr
+++ b/spec/compiler/codegen/hooks_spec.cr
@@ -144,4 +144,28 @@ describe "Code gen: hooks" do
       Bar.y
       ").to_i.should eq(123)
   end
+
+  it "does finished" do
+    run(%(
+      class Foo
+        A = [1]
+
+        macro finished
+          {% A[0] = A[0] + 1 %}
+        end
+
+        macro finished
+          {% A[0] = A[0] * 2 %}
+        end
+
+        macro finished
+          def self.foo
+            {{ A[0] }}
+          end
+        end
+      end
+
+      Foo.foo
+      )).to_i.should eq(4)
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -61,6 +61,7 @@ module Crystal
     def codegen(node, single_module = false, debug = false, llvm_mod = LLVM::Module.new("main_module"), expose_crystal_main = true)
       visitor = CodeGenVisitor.new self, node, single_module: single_module, debug: debug, llvm_mod: llvm_mod, expose_crystal_main: expose_crystal_main
       node.accept visitor
+      visitor.process_finished_hooks
       visitor.finish
 
       visitor.modules
@@ -1833,6 +1834,12 @@ module Crystal
       end
 
       aggregate_index pointer, index
+    end
+
+    def process_finished_hooks
+      last = @last
+      @program.process_finished_hooks(self)
+      @last = last
     end
 
     def build_string_constant(str, name = "str")

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -30,10 +30,12 @@ class Crystal::Program
     processor.check_non_nilable_class_vars_without_initializers
 
     Crystal.timing("Semantic (ivars initializers)", stats) do
-      node.accept InstanceVarsInitializerVisitor.new(self)
+      visitor = InstanceVarsInitializerVisitor.new(self)
+      visit_with_finished_hooks(node, visitor)
     end
+
     result = Crystal.timing("Semantic (main)", stats) do
-      visit_main(node)
+      visit_main(node, process_finished_hooks: true)
     end
     Crystal.timing("Semantic (cleanup)", stats) do
       cleanup_types
@@ -54,6 +56,8 @@ class Crystal::Program
     new_expansions = Crystal.timing("Semantic (top level)", stats) do
       visitor = TopLevelVisitor.new(self)
       node.accept visitor
+      visitor.process_finished_hooks
+      process_finished_hooks(visitor)
       visitor.new_expansions
     end
     Crystal.timing("Semantic (new)", stats) do

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -14,7 +14,7 @@ module Crystal
   class Program
     def visit_class_vars_initializers(node)
       visitor = ClassVarsInitializerVisitor.new(self)
-      node.accept visitor
+      visit_with_finished_hooks(node, visitor)
 
       # First gather them all
       class_var_initializers = [] of ClassVarInitializer

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -116,7 +116,7 @@ struct Crystal::TypeDeclarationProcessor
 
   def process(node)
     # First check type declarations
-    node.accept type_decl_visitor
+    @program.visit_with_finished_hooks(node, type_decl_visitor)
 
     # Use the last type found for class variables to declare them
     type_decl_visitor.class_vars.each do |owner, vars|
@@ -127,7 +127,7 @@ struct Crystal::TypeDeclarationProcessor
 
     # Then use several syntactic rules to infer the types of
     # variables that don't have an explicit type set
-    node.accept type_guess_visitor
+    @program.visit_with_finished_hooks(node, type_guess_visitor)
 
     # Process class variables
     type_guess_visitor.class_vars.each do |owner, vars|


### PR DESCRIPTION
Fixes #3604 , fixes #2987

This adds a new macro hook: `finished`. I chose that name because it's a past participle and similar/compatible with `included`, `inherited`, `extended`. This macro can be thought as if it's placed at the end of the program, though scope is preserved.

For example, to define a base JSON mapping and let users extend it with custom (typed) attributes, one would do:

```cr
require "json"

class Foo
  # This is our base mapping.
  # Remember that in Crystal constants aren't typed unless used
  # in a program. If we only use them at compile time, we can
  # use them to remember and gather data at compile time.
  MAPPING = {
    x: Int32,
    y: Int32,
  }

  # We tell users to use this for extending JSON attributes
  macro extra_attributes(**values)
    # We mutate MAPPING at compile time
    {% for key, value in values %}
      {% MAPPING[key] = value %}
    {% end %}
  end

  # This runs once the bottom of the program is reached.
  # Scope is preserved, so MAPPING refers to the above constant.
  macro finished
    JSON.mapping({{MAPPING}})
  end
end

# One extension
class Foo
  extra_attributes z: Int32?
end

# Another extension
class Foo
  extra_attributes w: Int32?
end

# All of these work
p Foo.from_json(%<{"x": 1, "y": 2}>)
p Foo.from_json(%<{"x": 1, "y": 2, "z": 3}>)
p Foo.from_json(%<{"x": 1, "y": 2, "z": 3, "w": 4}>)
```

In fact, with this some APIs could be defined more nicely. Imagine a mapping to a DB model:

```cr
class ModelBase
  # Here we capture all properties. The `of Nil => Nil` is needed for syntax,
  # but the contents will never be used at runtime, so no problem
  PROPERTIES = {} of Nil => Nil

  macro attribute(decl)
    {% PROPERTIES[decl.name] = decl.type %}
  end

  macro finished
    # And now we process PROPERTIES and generate methods, etc.
  end
end

class User < ModelBase
  attribute name : String
  attribute age : Int32
end

# Without finished one would probably need to specify all attributes in one go:
class User < ModelBase
  attributes({
    name : String,
    age : Int32
  })
end
```

In fact, we could change JSON.mapping with this "additive" behaviour, though we probably won't do it because mappings are usually pretty well defined and "closed".
