### PR TITLE
Fix doc of the type inherited from generics class or module

### DIFF
--- a/src/compiler/crystal/tools/doc/html/methods_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/methods_inherited.html
@@ -1,6 +1,6 @@
 <% method_groups = methods.group_by { |method| method.name } %>
 <% unless method_groups.empty? %>
-  <h3><%= label %> methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
+  <h3><%= label %> methods inherited from <%= ancestor.kind %> <code><%= ancestor.link_from(type) %></code></h3>
   <% i = 0 %>
   <% method_groups.each do |method_name, methods| %>
     <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="tooltip">


### PR DESCRIPTION
For example, [`BitArray`'s doc](https://crystal-lang.org/api/0.20.0/BitArray.html):

![2016-12-01 14 36 53](https://cloud.githubusercontent.com/assets/6679325/20783654/88fb9edc-b7d8-11e6-841f-a7969e022bb6.png)

I fixed it to:

![2016-12-01 15 16 51](https://cloud.githubusercontent.com/assets/6679325/20783754/3e12fd56-b7d9-11e6-9d3f-e2c523dbfa94.png)
