### PR TITLE
Add missing --no-color option to spec and eval command

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -445,6 +445,10 @@ class Crystal::Command
       puts opts
       exit
     end
+    opts.on("--no-color", "Disable colored output") do
+      @color = false
+      compiler.color = false
+    end
     opts.invalid_option { }
   end
 


### PR DESCRIPTION
It may be useful to pass output to another command.