### PR TITLE
Accept to pass compiler options to crystal docs

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -425,9 +425,11 @@ class Crystal::Command
     end
   end
 
-  private def setup_simple_compiler_options(compiler, opts)
-    opts.on("-d", "--debug", "Add symbolic debug info") do
-      compiler.debug = true
+  private def setup_simple_compiler_options(compiler, opts, no_codegen = false)
+    unless no_codegen
+      opts.on("-d", "--debug", "Add symbolic debug info") do
+        compiler.debug = true
+      end
     end
     opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
       compiler.flags << flag
@@ -435,15 +437,17 @@ class Crystal::Command
     opts.on("--error-trace", "Show full error trace") do
       compiler.show_error_trace = true
     end
-    opts.on("--release", "Compile in release mode") do
-      compiler.release = true
-    end
-    opts.on("-s", "--stats", "Enable statistics output") do
-      compiler.stats = true
-    end
     opts.on("-h", "--help", "Show this message") do
       puts opts
       exit
+    end
+    unless no_codegen
+      opts.on("--release", "Compile in release mode") do
+        compiler.release = true
+      end
+      opts.on("-s", "--stats", "Enable statistics output") do
+        compiler.stats = true
+      end
     end
     opts.invalid_option { }
   end

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -5,6 +5,13 @@
 
 class Crystal::Command
   private def docs
+    compiler = Compiler.new
+    compiler.wants_doc = true
+    OptionParser.parse(options) do |opts|
+      opts.banner = "Usage: crystal docs [options] [files]\n\nOptions:"
+      setup_simple_compiler_options compiler, opts, no_codegen: true
+    end
+
     if options.empty?
       sources = [Compiler::Source.new("require", %(require "./src/**"))]
       included_dirs = [] of String
@@ -16,8 +23,6 @@ class Crystal::Command
 
     included_dirs << File.expand_path("./src")
 
-    compiler = Compiler.new
-    compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 
     Doc::Generator.new(result.program, included_dirs).run


### PR DESCRIPTION
`crystal docs` dose not build a program, however it uses the compiler. So, `crystal docs` should be accepted compiler options.