### PR TITLE
Select anchor from location.hash on page load

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -86,4 +86,18 @@ document.addEventListener('DOMContentLoaded', function() {
   if(initialY > 0) {
     typesList.scrollTop = initialY;
   }
+
+  var scrollToEntryFromLocationHash = function() {
+    var hash = window.location.hash;
+    if (hash) {
+      var targetAnchor = unescape(hash.substr(1));
+      var targetEl = document.querySelectorAll('.entry-detail[id="' + targetAnchor + '"]');
+
+      if (targetEl && targetEl.length > 0) {
+        targetEl[0].offsetParent.scrollTop = targetEl[0].offsetTop;
+      }
+    }
+  };
+  window.addEventListener("hashchange", scrollToEntryFromLocationHash, false);
+  scrollToEntryFromLocationHash();
 });


### PR DESCRIPTION
This PR fixes scrolling to section given in URI hash (like in https://crystal-lang.org/api/0.20.0/Array.html#clear-instance-method). This works around bug which resets container scroll on page refresh.