### PR TITLE
make builds cross compile to correct target for x86_64-apple-darwin16.1.0 

### DIFF
--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -21,7 +21,7 @@ module Crystal
         triple[0] = "i686"
       end
 
-      target = if triple.any?(&.includes?("macosx"))
+      target = if triple.any?(&.includes?("macosx")) || triple.any?(&.includes?("darwin"))
                  {triple[0], "macosx", "darwin"}.join('-')
                elsif triple.any?(&.includes?("freebsd"))
                  {triple[0], triple[1], "freebsd"}.join('-')

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -23,7 +23,7 @@ class Crystal::Program
 
   private def parse_flags(flags_name)
     set = flags_name.map(&.downcase).to_set
-    set.add "darwin" if set.any?(&.starts_with?("macosx"))
+    set.add "darwin" if set.any?(&.starts_with?("macosx")) || set.any?(&.starts_with?("darwin"))
     set.add "freebsd" if set.any?(&.starts_with?("freebsd"))
     set.add "openbsd" if set.any?(&.starts_with?("openbsd"))
     set.add "x86_64" if set.any?(&.starts_with?("amd64"))


### PR DESCRIPTION
Without this you get:

```
$ ./bin/crystal build -o .build/crystal_cyg src/compiler/crystal.cr --target x86_64-apple-darwin16.1.0
Using compiled compiler at .build/crystal
using path x86_64-apple-darwin16.1.0
Error while requiring "prelude"

in src/prelude.cr:15: while requiring "exception"

require "exception"
^

in src/exception.cr:1: while requiring "callstack"

require "callstack"
^

in src/callstack.cr:1: while requiring "c/dlfcn": can't find file 'c/dlfcn' relative to '/Users/packrd/dev/ruby/downloads/crystal/src'

require "c/dlfcn"
^
```