### PR TITLE
Handle clearing doc search field via (x) button

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', function() {
   };
 
   var searchTimeout;
-  searchInput.addEventListener('keyup', function() {
+  var performSearch = function() {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(function() {
       var text = searchInput.value;
@@ -75,7 +75,12 @@ document.addEventListener('DOMContentLoaded', function() {
         };
       }
     }, 200);
-  });
+  };
+  if (searchInput.value.length > 0) {
+    performSearch();
+  }
+  searchInput.addEventListener('keyup', performSearch);
+  searchInput.addEventListener('input', performSearch);
 
   typesList.onscroll = function() {
     var y = typesList.scrollTop;


### PR DESCRIPTION
This PR makes `(x)` clearing button in doc search field works as expected. Also, it fires up search on page load if there's anything in the search input field — which happens on firefox when page is loaded from cache.