### PR TITLE
Enhance --stats option

### DIFF
--- a/src/compiler/crystal/command/cursor.cr
+++ b/src/compiler/crystal/command/cursor.cr
@@ -45,7 +45,9 @@ class Crystal::Command
 
     file = File.expand_path(file)
 
-    result = yield Location.new(file, line_number, column_number), config, result
+    result = Crystal.timing("Tool (#{command.split(' ')[1]})", @stats) do
+      yield Location.new(file, line_number, column_number), config, result
+    end
 
     case format
     when "json"

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -23,15 +23,19 @@ module Crystal
     exit(exit_code) if exit_code
   end
 
-  def self.timing(label, stats)
+  def self.timing(label, stats, delay = false)
     if stats
-      print "%-34s" % "#{label}:"
+      print "%-34s" % "#{label}:" unless delay
       time = Time.now
       value = yield
       elapsed_time = Time.now - time
       LibGC.get_heap_usage_safe(out heap_size, out free_bytes, out unmapped_bytes, out bytes_since_gc, out total_bytes)
       mb = heap_size / 1024.0 / 1024.0
-      puts " %s (%7.2fMB)" % {elapsed_time, mb}
+      if delay
+        puts "%-34s %s (%7.2fMB)" % {"#{label}:", elapsed_time, mb}
+      else
+        puts " %s (%7.2fMB)" % {elapsed_time, mb}
+      end
       value
     else
       yield


### PR DESCRIPTION
This pull request adds a statistic of the last process of some `crystal` sub-command (i.e. built binary execution time for `crystal run`, calculation time for `crystal tool implementation`, etc...)

It is useful to distinguish real execution time from parsing time, processing AST time and generation binary time *in one shot*.