### PR TITLE
Fix stats for spec and eval

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -451,6 +451,7 @@ class Crystal::Command
       compiler.release = true
     end
     opts.on("-s", "--stats", "Enable statistics output") do
+      @stats = true
       compiler.stats = true
     end
     opts.on("-h", "--help", "Show this message") do


### PR DESCRIPTION
#3643. Sorry I missed to add `@stats = true` for `crystal spec` and `crystal eval`.