### PR TITLE
Includes debug flag when compiling in debug mode

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -151,7 +151,8 @@ module Crystal
       program = Program.new
       program.cache_dir = CacheDir.instance.directory_for(sources)
       program.target_machine = target_machine
-      program.flags << "release" if @release
+      program.flags << "release" if release?
+      program.flags << "debug" if debug?
       program.flags.merge! @flags
       program.wants_doc = wants_doc?
       program.color = color?


### PR DESCRIPTION
Allow usage of `flag?(:debug)` in macros for builds been done with `--debug` option.

This pairs with `--release` and `flag?(:release)` usage in similar way to allow include or exclude code from the compilation process.

```crystal
{% if flag?(:debug) %}
  # debug-only code
{% end %}
```

Cheers.