### PR TITLE
Feature: Add default result to try method

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -333,4 +333,35 @@ describe Object do
       obj.property10?.should be_false
     end
   end
+
+  describe "try" do
+    it "yields self when not nil" do
+      obj = "An arbitrary string"
+      obj.try(&.itself).should eq(obj)
+    end
+
+    it "yields self when not nil even when default given" do
+      obj = "An arbitrary string"
+      obj.try("another value") { |o| o }.should eq(obj)
+    end
+
+    it "yields nil when nil" do
+      obj = nil
+      obj.try(&.itself).should eq(nil)
+    end
+
+    it "yields given default value when nil" do
+      obj = nil
+      default = "Default value"
+      obj.try(default, &.itself).should eq(default)
+    end
+
+    it "should use type of default as return type when default is provided" do
+      obj = /.* (.)(.)(.)/.match("An arbitrary string")
+      typeof(obj).should eq(Regex::MatchData | Nil)
+      typeof(obj.try(&.size)).should eq(Int32 | Nil)
+      typeof(obj.try(0, &.size)).should eq(Int32)
+      typeof(obj.try("none", &.size)).should eq(Int32 | String)
+    end
+  end
 end

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -92,9 +92,13 @@ struct Nil
     io << "nil"
   end
 
-  # Doesn't yields to the block. See `Object#try`.
-  def try(&block)
-    self
+  # Returns the given value if the receiver is nil, which by default is also
+  # nil. This can be used to make the return value homogeneous, allowing
+  # further methods to be chained without requiring further try calls. The
+  # alternate way of doing this is `(obj.try &block || if_nil_value)`, but this
+  # method is safe for `false`. See `Object#try`.
+  def try(default = nil, &block)
+    default
   end
 
   # Raises an exception. See `Object#not_nil!`.

--- a/src/object.cr
+++ b/src/object.cr
@@ -142,13 +142,15 @@ class Object
   # Yields self. Nil overrides this method and doesn't yield.
   #
   # This method is useful for dealing with nilable types, to safely
-  # perform operations only when the value is not nil.
+  # perform operations only when the value is not nil.  The default argument is
+  # used by Nil#try to provide an alternate return value when nil, but ignored
+  # in this method.
   #
   # ```
   # # First program argument in downcase, or nil
   # ARGV[0]?.try &.downcase
   # ```
-  def try
+  def try(default = nil)
     yield self
   end
 


### PR DESCRIPTION
Rational:
  To facilitate chaining of method calls without successive try
  wrappers, the addition of a default value to the try call that is
  returned when the receiver is nil allows the returned type to be made
  homogeneous.

  ```
  my_string_or_nil.try(&.size)    # => could be Nil or Int32
  my_string_or_nil.try(0, &.size) # => will always be Int32
  ```
  While this is similar to `(my_string_or_nil.try(&.size) || 0)`, the
  use of a default in try more elegantly solves the case when the result
  could be false or nil.