### PR TITLE
Enhancement to Regex::MatchData methods

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -100,4 +100,96 @@ describe "Regex::MatchData" do
       "há日本語".match(/本/).not_nil!.pre_match.should eq "há日"
     end
   end
+
+  describe "to_a" do
+    it "produces an array containing the full and group matches" do
+      str = "Crystal is great!"
+      re = /([A-Z]*).* (.*) .*?(?<vowels>[aeiou]+)t!/
+      md = re.match(str).not_nil!
+      md.to_a.should eq(["Crystal is great!", "C", "is", "ea"])
+    end
+
+    it "includes nil for optional groups that don't match" do
+      str = "Crystal is great!"
+      re = /([A-Z][^ ]*) is (not ?)?.*([0-9])*.*(.)$/
+      md = re.match(str).not_nil!
+      md.to_a.should eq(["Crystal is great!", "Crystal", nil, nil, "!"])
+    end
+
+    it "contains only the full match if there are no groups" do
+      str = "Crystal is great!"
+      re = /[A-Z][^ ]* is (?:not ?)?.*$/
+      md = re.match(str).not_nil!
+      md.to_a.should eq(["Crystal is great!"])
+    end
+  end
+
+  describe "to_h" do
+    it "produces a hash containing the key-value pairs for named group and match" do
+      str = "Regex is super fun!"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.+)?)/i
+      md = re.match(str).not_nil!
+      md.to_h.should eq({"subject" => "Regex", "predicate" => "is super fun!", "verb" => "is", "adjective" => "super", "noun" => "fun", "extra" => "!"})
+    end
+
+    it "produces keys with nil values when the given named group has no match" do
+      str = "Crystal is fast"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.+)?)/i
+      md = re.match(str).not_nil!
+      md.to_h.should eq({"subject" => "Crystal", "predicate" => "is fast", "verb" => "is", "adjective" => nil, "noun" => "fast", "extra" => nil})
+    end
+
+    it "produces an empty hash when there are no named groups" do
+      str = "Crystal is great!"
+      re = /([A-Z][^ ]*) is (not ?)?.*([0-9])*.*(.)$/
+      md = re.match(str).not_nil!
+      md.to_h.should eq({} of String => (String | Nil))
+    end
+  end
+
+  describe "group_names" do
+    it "returns an array of group names" do
+      str = "Regex is super fun!"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.+)?)/i
+      md = re.match(str).not_nil!
+      md.group_names.should eq(["subject", "predicate", "verb", "adjective", "noun", "extra"])
+    end
+
+    it "returns full list of group names even if some don't match" do
+      str = "Crystal is fast"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.+)?)/i
+      md = re.match(str).not_nil!
+      md.group_names.should eq(["subject", "predicate", "verb", "adjective", "noun", "extra"])
+    end
+
+    it "returns an empty array if there are no named groups" do
+      str = "Crystal is great!"
+      re = /([A-Z][^ ]*) is (not ?)?.*([0-9])*.*(.)$/
+      md = re.match(str).not_nil!
+      md.group_names.should eq([] of String)
+    end
+  end
+
+  describe "matched_named_groups" do
+    it "returns an array of group names that have matches" do
+      str = "Regex is super fun!"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.*)?$)/i
+      md = re.match(str).not_nil!
+      md.matched_group_names.should eq(["subject", "predicate", "verb", "adjective", "noun", "extra"])
+    end
+
+    it "returns only the group names that have matches" do
+      str = "Crystal is fast"
+      re = /(?<subject>[a-z]+) (?<predicate>(?<verb>[a-z]+) (?:(?<adjective>[a-z]+) )?(?<noun>[a-z]+)(?<extra>.*)?$)/i
+      md = re.match(str).not_nil!
+      md.matched_group_names.should eq(["subject", "predicate", "verb", "noun", "extra"])
+    end
+
+    it "returns an empty array if there are no named groups" do
+      str = "Crystal is great!"
+      re = /([A-Z][^ ]*) is (not ?)?.*([0-9])*.*(.)$/
+      md = re.match(str).not_nil!
+      md.matched_group_names.should eq([] of String)
+    end
+  end
 end

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -161,6 +161,30 @@ class Regex
       match
     end
 
+    # Returns the array of named capture groups in the order they appear in the
+    # RE.
+    #
+    # ```
+    # "Crystal".match(/r(ys)/).not_nil!.group_names                        # => []
+    # "Crystal".match(/r(?<ok>ys)/).not_nil!.group_names                   # => ["ok"]
+    # "Crystal".match(/^(?<first>..)(.*)(?<last>.)*/).not_nil!.group_names # => ["first","last"]
+    # ```
+    def group_names
+      (1..size).select { |i| @regex.name_table[i]? }.map { |i| @regex.name_table[i] }
+    end
+
+    # Returns the array of named capture groups that actually matched a
+    # substring, in the order they appear in the RE.
+    #
+    # ```
+    # "Crystal".match(/r(ys)/).not_nil!.matched_group_names                        # => []
+    # "Crystal".match(/r(?<ok>ys)?/).not_nil!.matched_group_names                  # => ["ok"]
+    # "Crystal".match(/^(?<first>..)(.*)(?<last>.)*/).not_nil!.matched_group_names # => ["first"]
+    # ```
+    def matched_group_names
+      group_names.select { |k| self.[k]? }
+    end
+
     # Returns the part of the original string before the match. If the match
     # starts at the start of the string, returns the empty string.
     #
@@ -200,6 +224,29 @@ class Regex
         end
       end
       io << ">"
+    end
+
+    # Returns an array containing all the matches found.  Optional groups that
+    # did not match will contain `nil`, while all matching groups will contain
+    # the matching substring.  Matches on named groups will also be included,
+    # as if they were unnamed.
+    #
+    # ```
+    # "Crystal".match(/^(?<first>..)(?:.)(.*)(.)*(?<last>.)/).not_nil!.to_a
+    # # => ["Crystal", "Cr", "sta", nil, "l"]
+    # ```
+    def to_a
+      (0..size).map { |i| self[i]? }
+    end
+
+    # Returns a hash of matches from named groups
+    #
+    # ```
+    # "Crystal".match(/^(?<first>..)(?:.)(.*)(?<mid>.)*(?<last>.)/).not_nil!.to_a
+    # # => {"first" => "Cr", "last" => "l", "mid" => nil}
+    # ```
+    def to_h
+      @regex.name_table.values.map { |k| [k, self[k]?] }.to_h
     end
 
     def dup


### PR DESCRIPTION
In order to work more easily with matches, the following methods were
added, influenced by similar methods from Ruby:

`Regex::MatchData#to_a`: converts matches to Array object, allowing for
full array operations (slices, reversal, index).

`Regex::MatchData#to_h`: converts named matches to a hash with the name as
the key.

`Regex::MatchData#group_names`: lists the names of the groups in order
they appear in the RE.

`Regex::MatchData#matched_group_names`: lists only the named groups that
matched against the source string.