### PR TITLE
Allow to pass IO to from_yaml

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -46,6 +46,11 @@ describe "YAML serialization" do
       Array(Int32).from_yaml("---\n- 1\n- 2\n- 3\n").should eq([1, 2, 3])
     end
 
+    it "does Array#from_yaml from IO" do
+      io = IO::Memory.new "---\n- 1\n- 2\n- 3\n"
+      Array(Int32).from_yaml(io).should eq([1, 2, 3])
+    end
+
     it "does Array#from_yaml with block" do
       elements = [] of Int32
       Array(Int32).from_yaml("---\n- 1\n- 2\n- 3\n") do |element|

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -1,5 +1,5 @@
-def Object.from_yaml(string : String) : self
-  YAML::PullParser.new(string) do |parser|
+def Object.from_yaml(string_or_io) : self
+  YAML::PullParser.new(string_or_io) do |parser|
     parser.read_stream do
       parser.read_document do
         new parser
@@ -8,8 +8,8 @@ def Object.from_yaml(string : String) : self
   end
 end
 
-def Array.from_yaml(string : String)
-  YAML::PullParser.new(string) do |parser|
+def Array.from_yaml(string_or_io)
+  YAML::PullParser.new(string_or_io) do |parser|
     parser.read_stream do
       parser.read_document do
         new(parser) do |element|


### PR DESCRIPTION
I don't know why `from_yaml` is restricted by `String` (Yesterday's implementation doesn't support IO?)