### PR TITLE
Clean up empty line of shard.yml on crystal init lib

### DIFF
--- a/src/compiler/crystal/tools/init/template/shard.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/shard.yml.ecr
@@ -8,8 +8,8 @@ authors:
 targets:
   <%= config.name %>:
     main: src/<%= config.name %>.cr
-<%- end -%>
 
+<%- end -%>
 crystal: <%= Crystal::Config.version %>
 
 license: MIT


### PR DESCRIPTION
`crystal init lib foo` makes such a `shard.yml` today:

```yaml
name: foo
version: 0.1.0

authors:
  - TSUYUSATO Kitsune <make.just.on@gmail.com>


crystal: 0.20.1

license: MIT
```

It has two empty lines between `authors` and `crystal`.