### PR TITLE
Fix file spec when HOME ends with /

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -14,7 +14,10 @@ private def rootdir
 end
 
 private def home
-  ENV["HOME"]
+  home = ENV["HOME"]
+  return home if home == "/"
+
+  home.chomp('/')
 end
 
 private def it_raises_on_null_byte(operation, &block)


### PR DESCRIPTION
For example:

```
  1) File expand_path converts a pathname to an absolute pathname, using ~ (home) as base
	     Failure/Error: File.expand_path("~/").should eq(home)
	
	       expected: "/jenkins-slave/"
	            got: "/jenkins-slave"
	
	     # spec/std/file_spec.cr:417
```