### PR TITLE
Fixes #3547; as call with implicit receiver when invoked as a parameter to a method call

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1218,6 +1218,14 @@ describe "Parser" do
 
   it_parses "Foo.foo(count: 3).bar { }", Call.new(Call.new("Foo".path, "foo", named_args: [NamedArgument.new("count", 3.int32)]), "bar", block: Block.new)
 
+  it_parses %(
+    class Foo
+      def bar
+        print as Foo
+      end
+    end
+  ), ClassDef.new("Foo".path, Def.new("bar", body: Call.new(nil, "print", Cast.new(Var.new("self"), "Foo".path))))
+
   assert_syntax_error "a = a", "can't use variable name 'a' inside assignment to variable 'a'"
 
   assert_syntax_error "{{ {{ 1 }} }}", "can't nest macro expressions"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3885,7 +3885,7 @@ module Crystal
     end
 
     def parse_call_args_space_consumed(check_plus_and_minus = true, allow_curly = false, control = false)
-      if (@token.keyword?(:as) || @token.keyword?(:end)) && !next_comes_colon_space?
+      if @token.keyword?(:end) && !next_comes_colon_space?
         return nil
       end
 


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/3547.

This code:
```crystal
class Foo
  def bar
    print as Foo
  end
end
Foo.new.bar
```
will now print the instance of Foo, instead of raising an unexpected token error.

I'm not sure what the implications of this is on a higher level, as this is my first PR against Crystal. It seems like this check is perhaps legacy -- by fact of this conditional check singling out `as`, it makes a clear break from the behavior of `as?`. It also looks like this check has been in here [quite a while](https://github.com/crystal-lang/crystal/commit/09207b42b680c92276c6c8992b23030c342ca22f). Let me know what you think.

cc @asterite