### PR TITLE
Remove dot segments in uri path as per RFC 3986 6.2.2.3

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -39,6 +39,31 @@ describe "URI" do
   assert { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
   assert { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
 
+  it "removes dot notation from path" do
+    cases = {
+      "../bar"      => "bar",
+      "./bar"       => "bar",
+      ".././bar"    => "bar",
+      "/foo/./bar"  => "/foo/bar",
+      "/bar/./"     => "/bar/",
+      "/."          => "/",
+      "/bar/."      => "/bar/",
+      "/foo/../bar" => "/bar",
+      "/bar/../"    => "/",
+      "/.."         => "/",
+      "/bar/.."     => "/",
+      "/foo/bar/.." => "/foo/",
+      "."           => "",
+      ".."          => "",
+    }
+
+    cases.each do |input, expected|
+      uri = URI.parse(input)
+
+      uri.path.should eq(expected), "failed to remote dot notation from #{input}"
+    end
+  end
+
   it "implements ==" do
     URI.parse("http://example.com").should eq(URI.parse("http://example.com"))
   end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -39,28 +39,31 @@ describe "URI" do
   assert { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
   assert { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
 
-  it "removes dot notation from path" do
-    cases = {
-      "../bar"      => "bar",
-      "./bar"       => "bar",
-      ".././bar"    => "bar",
-      "/foo/./bar"  => "/foo/bar",
-      "/bar/./"     => "/bar/",
-      "/."          => "/",
-      "/bar/."      => "/bar/",
-      "/foo/../bar" => "/bar",
-      "/bar/../"    => "/",
-      "/.."         => "/",
-      "/bar/.."     => "/",
-      "/foo/bar/.." => "/foo/",
-      "."           => "",
-      ".."          => "",
-    }
+  describe "normalize" do
+    it "removes dot notation from path" do
+      cases = {
+        "../bar"      => "bar",
+        "./bar"       => "bar",
+        ".././bar"    => "bar",
+        "/foo/./bar"  => "/foo/bar",
+        "/bar/./"     => "/bar/",
+        "/."          => "/",
+        "/bar/."      => "/bar/",
+        "/foo/../bar" => "/bar",
+        "/bar/../"    => "/",
+        "/.."         => "/",
+        "/bar/.."     => "/",
+        "/foo/bar/.." => "/foo/",
+        "."           => "",
+        ".."          => "",
+      }
 
-    cases.each do |input, expected|
-      uri = URI.parse(input)
+      cases.each do |input, expected|
+        uri = URI.parse(input)
+        uri = uri.normalize
 
-      uri.path.should eq(expected), "failed to remote dot notation from #{input}"
+        uri.path.should eq(expected), "failed to remove dot notation from #{input}"
+      end
     end
   end
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -131,7 +131,7 @@ class URI
   # ```
   def full_path
     String.build do |str|
-      str << (path.try { |p| !p.empty? } ? path : "/")
+      str << (@path.try { |p| !p.empty? } ? @path : "/")
       str << "?" << @query if @query
     end
   end
@@ -170,8 +170,16 @@ class URI
     end
   end
 
-  def path
-    remove_dot_segments(@path)
+  # Returns normalized URI
+  def normalize
+    uri = dup
+    uri.normalize!
+    uri
+  end
+
+  # Destructive normalize
+  def normalize!
+    @path = remove_dot_segments(path)
   end
 
   # Parses `raw_url` into an URI. The `raw_url` may be relative or absolute.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -131,7 +131,7 @@ class URI
   # ```
   def full_path
     String.build do |str|
-      str << (@path.try { |p| !p.empty? } ? @path : "/")
+      str << (path.try { |p| !p.empty? } ? path : "/")
       str << "?" << @query if @query
     end
   end
@@ -168,6 +168,10 @@ class URI
       io << '#'
       io << fragment
     end
+  end
+
+  def path
+    remove_dot_segments(@path)
   end
 
   # Parses `raw_url` into an URI. The `raw_url` may be relative or absolute.
@@ -353,6 +357,57 @@ class URI
     io.write_byte byte
     i += 1
     i
+  end
+
+  # RFC 3986 6.2.2.3
+  # https://tools.ietf.org/html/rfc3986#section-5.2.4
+  private def remove_dot_segments(path : String?)
+    return if path.nil?
+
+    result = [] of String
+    while path.size > 0
+      # A.  If the input buffer begins with a prefix of "../" or "./",
+      #     then remove that prefix from the input buffer; otherwise,
+      if path.starts_with?("../")
+        path = path[3..-1]
+      elsif path.starts_with?("./")
+        path = path[2..-1]
+        # B.  if the input buffer begins with a prefix of "/./" or "/.",
+        #     where "." is a complete path segment, then replace that
+        #     prefix with "/" in the input buffer; otherwise,
+      elsif path.starts_with?("/./")
+        path = "/" + path[3..-1]
+      elsif path == "/."
+        path = "/" + path[2..-1]
+        # C.  if the input buffer begins with a prefix of "/../" or "/..",
+        #     where ".." is a complete path segment, then replace that
+        #     prefix with "/" in the input buffer and remove the last
+        #     segment and its preceding "/" (if any) from the output
+        #     buffer; otherwise,
+      elsif path.starts_with?("/../")
+        path = "/" + path[4..-1]
+        result.pop if result.size > 0
+      elsif path == "/.."
+        path = "/" + path[3..-1]
+        result.pop if result.size > 0
+        # D.  if the input buffer consists only of "." or "..", then remove
+        #     that from the input buffer; otherwise,
+      elsif path == ".." || path == "."
+        path = ""
+        # E.  move the first path segment in the input buffer to the end of
+        #     the output buffer, including the initial "/" character (if
+        #     any) and any subsequent characters up to, but not including,
+        #     the next "/" character or the end of the input buffer.
+      else
+        slash_search_idx = path[0] == '/' ? 1 : 0
+        segment_end_idx = path.index("/", slash_search_idx)
+        segment_end_idx ||= path.size
+        result << path[0...segment_end_idx]
+        path = path[segment_end_idx..-1]
+      end
+    end
+
+    result.join
   end
 
   private def userinfo(user, io)


### PR DESCRIPTION
As per [3986 6.2.2](https://tools.ietf.org/html/rfc3986#section-6.2.2.3) URI paths should be normalized. This adds part of the normalization process and handles relative paths (6.2.2.3). ie `/example/..` would be `/`. 

Another option would be to add a `normalized_path` method.

Let me know what you think :)