### PR TITLE
Not include Enumerable directly

### DIFF
--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -15,7 +15,6 @@
 #     ba                    # => "BitArray[101010101010]"
 #     ba[2]                 # => true
 struct BitArray
-  include Enumerable(Bool)
   include Indexable(Bool)
 
   # The number of bits the BitArray stores

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -62,7 +62,6 @@
 # tuple # => {1, "hello", 'x'} (Tuple(Int32, String, Char))
 # ```
 struct Tuple
-  include Enumerable(Union(*T))
   include Indexable(Union(*T))
   include Comparable(Tuple)
 


### PR DESCRIPTION
You said "*This is fixed in 0.19.0*".