### PR TITLE
docs command: don't show error on console when not a git repository 

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -34,9 +34,6 @@ class Crystal::Doc::Generator
     @repo_name = ""
     @is_crystal_repo = false
     compute_repository
-    if @repo_name == ""
-      puts "WARNING cannot detect GitHub/GitLab repository, some features are not available."
-    end
   end
 
   def run

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -34,6 +34,9 @@ class Crystal::Doc::Generator
     @repo_name = ""
     @is_crystal_repo = false
     compute_repository
+    if @repo_name == ""
+      puts "WARNING cannot detect GitHub/GitLab repository, some features are not available."
+    end
   end
 
   def run
@@ -300,6 +303,10 @@ class Crystal::Doc::Generator
   end
 
   def compute_repository
+    # check whether inside git work-tree
+    `git rev-parse --is-inside-work-tree >/dev/null 2>&1`
+    return unless $?.success?
+
     remotes = `git remote -v`
     return unless $?.success?
 


### PR DESCRIPTION
Currently, we get git error message when `crystal docs` run not inside git repository:

```console
$ crystal docs
fatal: Not a git repository (or any of the parent directories): .git
```

It is unkind. This pull request fixes to output warning message instead of git error.