### PR TITLE
Implement String#lchomp

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -483,6 +483,18 @@ describe "String" do
     assert { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
   end
 
+  describe "lchomp" do
+    assert { "hello".lchomp('g').should eq("hello") }
+    assert { "hello".lchomp('h').should eq("ello") }
+    assert { "かたな".lchomp('か').should eq("たな") }
+
+    assert { "hello".lchomp("good").should eq("hello") }
+    assert { "hello".lchomp("hel").should eq("lo") }
+    assert { "かたな".lchomp("かた").should eq("な") }
+
+    assert { "\n\n\n\nhello".lchomp("").should eq("\n\n\n\nhello") }
+  end
+
   describe "chomp" do
     assert { "hello\n".chomp.should eq("hello") }
     assert { "hello\r".chomp.should eq("hello") }

--- a/src/string.cr
+++ b/src/string.cr
@@ -958,6 +958,34 @@ class String
     end
   end
 
+  # Returns a new String with *char* removed if the string starts with it.
+  #
+  # ```
+  # "hello".lchomp('h') # => "ello"
+  # "hello".lchomp('g') # => "hello"
+  # ```
+  def lchomp(char : Char)
+    if starts_with?(char)
+      unsafe_byte_slice_string(char.bytesize, bytesize - char.bytesize)
+    else
+      self
+    end
+  end
+
+  # Returns a new String with *str* removed if the string starts with it.
+  #
+  # ```
+  # "hello".lchomp("hel") # => "lo"
+  # "hello".lchomp("eh")  # => "hello"
+  # ```
+  def lchomp(str : String)
+    if starts_with?(str)
+      unsafe_byte_slice_string(str.bytesize, bytesize - str.bytesize)
+    else
+      self
+    end
+  end
+
   # Returns a new String with the last carriage return removed (that is, it
   # will remove \n, \r, and \r\n).
   #


### PR DESCRIPTION
This PR adds `String#lchomp` method which removes given `String | Char` from the beginning of the string.

It's quite handy method, many times requested to be included in Ruby's stdlib.
See for instance https://www.reddit.com/r/ruby/comments/19khox/cmon_ruby_we_need_stringlchomp/

Other solutions to this issue are way less optimal:
- `"hello".reverse.chomp("hel".reverse).reverse`
- `"hello".starts_with?("hel") ? "hello"["hel".size..-1] : "hello"`
- `"hello".sub(/\Ahel/, "")`