### PR TITLE
Implement String#split with block

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -751,6 +751,7 @@ describe "String" do
       assert { "   foo  bar".split(' ').should eq(["", "", "", "foo", "", "bar"]) }
       assert { "   foo   bar\n\t  baz   ".split(' ').should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
       assert { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
+      assert { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
       assert { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
       assert { "   foo   bar\n\t  baz   ".split(" ").should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
       assert { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -2642,7 +2642,7 @@ class String
     end
 
     if separator.empty?
-      split_by_empty_separator(limit).each do |string|
+      split_by_empty_separator(limit) do |string|
         yield string
       end
       return
@@ -2715,7 +2715,7 @@ class String
     end
 
     if separator.source.empty?
-      split_by_empty_separator(limit).each do |string|
+      split_by_empty_separator(limit) do |string|
         yield string
       end
       return
@@ -2762,19 +2762,19 @@ class String
     yield byte_slice(slice_offset)
   end
 
-  private def split_by_empty_separator(limit)
-    ary = Array(String).new
+  private def split_by_empty_separator(limit, &block : String -> _)
+    yielded = 0
 
     each_char do |c|
-      ary.push c.to_s
-      break if limit && ary.size + 1 == limit
+      yield c.to_s
+      yielded += 1
+      break if limit && yielded + 1 == limit
     end
 
-    if limit && ary.size != size
-      ary.push(self[ary.size..-1])
+    if limit && yielded != size
+      yield self[yielded..-1]
+      yielded += 1
     end
-
-    ary
   end
 
   def lines(chomp = true)

--- a/src/string.cr
+++ b/src/string.cr
@@ -2556,31 +2556,46 @@ class String
   # "foo,bar,baz".split(',', 2) # => ["foo", "bar,baz"]
   # ```
   def split(separator : Char, limit = nil)
-    if empty? || (limit && limit <= 1)
-      return [self]
+    ary = Array(String).new
+    split(separator, limit) do |string|
+      ary << string
+    end
+    ary
+  end
+
+  # Splits the string after each character *separator* and yields each part to a block.
+  #
+  # If *limit* is present, up to *limit* new strings will be created,
+  # with the entire remainder added to the last string.
+  #
+  # ```
+  # ary = [] of String
+  # "foo,bar,baz".split(',') { |string| ary << string }; ary # => ["foo", "bar", "baz"]
+  # ary.clear
+  # "foo,bar,baz".split(',', 2) { |string| ary << string }; ary # => ["foo", "bar,baz"]
+  # ```
+  def split(separator : Char, limit = nil, &block : String -> _)
+    if empty? || limit && limit <= 1
+      yield self
+      return
     end
 
-    ary = Array(String).new
-
+    yielded = 0
     byte_offset = 0
-    single_byte_optimizable = ascii_only?
 
     reader = Char::Reader.new(self)
     reader.each do |char|
       if char == separator
         piece_bytesize = reader.pos - byte_offset
-        piece_size = single_byte_optimizable ? piece_bytesize : 0
-        ary.push String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
+        yield String.new(to_unsafe + byte_offset, piece_bytesize)
+        yielded += 1
         byte_offset = reader.pos + reader.current_char_width
-        break if limit && ary.size + 1 == limit
+        break if limit && yielded + 1 == limit
       end
     end
 
     piece_bytesize = bytesize - byte_offset
-    piece_size = single_byte_optimizable ? piece_bytesize : 0
-    ary.push String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
-
-    ary
+    yield String.new(to_unsafe + byte_offset, piece_bytesize)
   end
 
   # Makes an array by splitting the string on *separator* (and removing instances of *separator*).

--- a/src/string.cr
+++ b/src/string.cr
@@ -2612,15 +2612,43 @@ class String
   # long_river_name.split("")   # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
   def split(separator : String, limit = nil)
+    ary = Array(String).new
+    split(separator, limit) do |string|
+      ary << string
+    end
+    ary
+  end
+
+  # Splits the string after each string *separator* and yields each part to a block.
+  #
+  # If *limit* is present, the array will be limited to *limit* items and
+  # the final item will contain the remainder of the string.
+  #
+  # If *separator* is an empty string (`""`), the string will be separated into one-character strings.
+  #
+  # ```
+  # ary = [] of String
+  # long_river_name = "Mississippi"
+  # long_river_name.split("ss") { |s| ary << s }; ary # => ["Mi", "i", "ippi"]
+  # ary.clear
+  # long_river_name.split("i") { |s| ary << s }; ary # => ["M", "ss", "ss", "pp"]
+  # ary.clear
+  # long_river_name.split("") { |s| ary << s }; ary # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
+  # ```
+  def split(separator : String, limit = nil, &block : String -> _)
     if empty? || (limit && limit <= 1)
-      return [self]
+      yield self
+      return
     end
 
     if separator.empty?
-      return split_by_empty_separator(limit)
+      split_by_empty_separator(limit).each do |string|
+        yield string
+      end
+      return
     end
 
-    ary = Array(String).new
+    yielded = 0
     byte_offset = 0
     separator_bytesize = separator.bytesize
 
@@ -2632,19 +2660,18 @@ class String
       if (to_unsafe + i).memcmp(separator.to_unsafe, separator_bytesize) == 0
         piece_bytesize = i - byte_offset
         piece_size = single_byte_optimizable ? piece_bytesize : 0
-        ary.push String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
+        yield String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
+        yielded += 1
         byte_offset = i + separator_bytesize
         i += separator_bytesize - 1
-        break if limit && ary.size + 1 == limit
+        break if limit && yielded + 1 == limit
       end
       i += 1
     end
 
     piece_bytesize = bytesize - byte_offset
     piece_size = single_byte_optimizable ? piece_bytesize : 0
-    ary.push String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
-
-    ary
+    yield String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
   end
 
   # Makes an array by splitting the string on *separator* (and removing instances of *separator*).

--- a/src/string.cr
+++ b/src/string.cr
@@ -2471,11 +2471,36 @@ class String
   # old_pond.split(3) # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
   # ```
   def split(limit : Int32? = nil)
+    ary = Array(String).new
+    split(limit) do |string|
+      ary << string
+    end
+    ary
+  end
+
+  # Splits the string after any ASCII whitespace character and yields each part to a block.
+  #
+  # If *limit* is present, up to *limit* new strings will be created,
+  # with the entire remainder added to the last string.
+  #
+  # ```
+  # ary = [] of String
+  # old_pond = "
+  #   Old pond
+  #   a frog leaps in
+  #   water's sound
+  # "
+  # old_pond.split { |s| ary << s }; ary # => ["Old", "pond", "a", "frog", "leaps", "in", "water's", "sound"]
+  # ary.clear
+  # old_pond.split(3) { |s| ary << s }; ary # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
+  # ```
+  def split(limit : Int32? = nil, &block : String -> _)
     if limit && limit <= 1
-      return [self]
+      yield self
+      return
     end
 
-    ary = Array(String).new
+    yielded = 0
     single_byte_optimizable = ascii_only?
     index = 0
     i = 0
@@ -2489,10 +2514,11 @@ class String
           if c.unsafe_chr.ascii_whitespace?
             piece_bytesize = i - 1 - index
             piece_size = single_byte_optimizable ? piece_bytesize : 0
-            ary.push String.new(to_unsafe + index, piece_bytesize, piece_size)
+            yield String.new(to_unsafe + index, piece_bytesize, piece_size)
+            yielded += 1
             looking_for_space = false
 
-            if limit && ary.size + 1 == limit
+            if limit && yielded + 1 == limit
               limit_reached = true
             end
 
@@ -2516,9 +2542,8 @@ class String
     if looking_for_space
       piece_bytesize = bytesize - index
       piece_size = single_byte_optimizable ? piece_bytesize : 0
-      ary.push String.new(to_unsafe + index, piece_bytesize, piece_size)
+      yield String.new(to_unsafe + index, piece_bytesize, piece_size)
     end
-    ary
   end
 
   # Makes an array by splitting the string on the given character *separator* (and removing that character).

--- a/src/string.cr
+++ b/src/string.cr
@@ -2674,6 +2674,28 @@ class String
     yield String.new(to_unsafe + byte_offset, piece_bytesize, piece_size)
   end
 
+  # Splits the string after each regex *separator* and yields each part to a block.
+  #
+  # If *limit* is present, the array will be limited to *limit* items and
+  # the final item will contain the remainder of the string.
+  #
+  # If *separator* is an empty regex (`//`), the string will be separated into one-character strings.
+  #
+  # ```
+  # ary = [] of String
+  # long_river_name = "Mississippi"
+  # long_river_name.split(/s+/) { |s| ary << s }; ary # => ["Mi", "i", "ippi"]
+  # ary.clear
+  # long_river_name.split(//) { |s| ary << s }; ary # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
+  # ```
+  def split(separator : Regex, limit = nil)
+    ary = Array(String).new
+    split(separator, limit) do |string|
+      ary << string
+    end
+    ary
+  end
+
   # Makes an array by splitting the string on *separator* (and removing instances of *separator*).
   #
   # If *limit* is present, the array will be limited to *limit* items and
@@ -2686,16 +2708,19 @@ class String
   # long_river_name.split(/s+/) # => ["Mi", "i", "ippi"]
   # long_river_name.split(//)   # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
-  def split(separator : Regex, limit = nil)
+  def split(separator : Regex, limit = nil, &block : String -> _)
     if empty? || (limit && limit <= 1)
-      return [self]
+      yield self
+      return
     end
 
     if separator.source.empty?
-      return split_by_empty_separator(limit)
+      split_by_empty_separator(limit).each do |string|
+        yield string
+      end
+      return
     end
 
-    ary = Array(String).new
     count = 0
     match_offset = 0
     slice_offset = 0
@@ -2709,15 +2734,15 @@ class String
       if slice_offset == 0 && slice_size == 0 && match_bytesize == 0
         # Skip
       elsif slice_offset == bytesize && slice_size == 0
-        ary.push byte_slice(last_slice_offset)
+        yield byte_slice(last_slice_offset)
       else
-        ary.push byte_slice(slice_offset, slice_size)
+        yield byte_slice(slice_offset, slice_size)
       end
       count += 1
 
       1.upto(match.size) do |i|
         if group = match[i]?
-          ary.push group
+          yield group
         end
       end
 
@@ -2734,9 +2759,7 @@ class String
       break if slice_offset > bytesize
     end
 
-    ary.push byte_slice(slice_offset)
-
-    ary
+    yield byte_slice(slice_offset)
   end
 
   private def split_by_empty_separator(limit)


### PR DESCRIPTION
Hi,

this PR enhances all flavors of `String#split` with a block.

After this PR, you can pass a block to `String#split`:

```crystal
"foo bar".split { |chunk| p chunk }
"foo bar".split(' ') { |chunk| p chunk }
"foo bar".split(" ") { |chunk| p chunk }
"foo bar".split(/ /) { |chunk| p chunk }
```

Additional tests were not added because all non-block versions of `String#split` exercise `String#split(..., &block)`. (Only one test for an edge case was added, though)

Kind regards,
  Peter