### PR TITLE
Add chomp option to gets, lines, each_line

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -280,7 +280,7 @@ describe "macro methods" do
     end
 
     it "executes lines" do
-      assert_macro "x", %({{x.lines}}), [StringLiteral.new("1\n2\n3")] of ASTNode, %(["1\\n", "2\\n", "3"])
+      assert_macro "x", %({{x.lines}}), [StringLiteral.new("1\n2\n3")] of ASTNode, %(["1", "2", "3"])
     end
 
     it "executes size" do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -52,12 +52,29 @@ describe "File" do
   it "reads lines from file" do
     lines = File.read_lines "#{__DIR__}/data/test_file.txt"
     lines.size.should eq(20)
+    lines.first.should eq("Hello World")
+  end
+
+  it "reads lines from file with chomp = false" do
+    lines = File.read_lines "#{__DIR__}/data/test_file.txt", chomp: false
+    lines.size.should eq(20)
     lines.first.should eq("Hello World\n")
   end
 
   it "reads lines from file with each" do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt") do |line|
+      if idx == 0
+        line.should eq("Hello World")
+      end
+      idx += 1
+    end
+    idx.should eq(20)
+  end
+
+  it "reads lines from file with each, chomp = false" do
+    idx = 0
+    File.each_line("#{__DIR__}/data/test_file.txt", chomp: false) do |line|
       if idx == 0
         line.should eq("Hello World\n")
       end
@@ -69,6 +86,17 @@ describe "File" do
   it "reads lines from file with each as iterator" do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt").each do |line|
+      if idx == 0
+        line.should eq("Hello World")
+      end
+      idx += 1
+    end
+    idx.should eq(20)
+  end
+
+  it "reads lines from file with each as iterator, chomp = false" do
+    idx = 0
+    File.each_line("#{__DIR__}/data/test_file.txt", chomp: false).each do |line|
       if idx == 0
         line.should eq("Hello World\n")
       end

--- a/spec/std/io/argf_spec.cr
+++ b/spec/std/io/argf_spec.cr
@@ -44,9 +44,19 @@ describe IO::ARGF do
       stdin = IO::Memory.new("hello\nworld\n")
 
       argf = IO::ARGF.new argv, stdin
-      argf.gets.should eq("hello\n")
-      argf.gets.should eq("world\n")
+      argf.gets.should eq("hello")
+      argf.gets.should eq("world")
       argf.gets.should be_nil
+    end
+
+    it "reads from STDIN if ARGV isn't specified, chomp = false" do
+      argv = [] of String
+      stdin = IO::Memory.new("hello\nworld\n")
+
+      argf = IO::ARGF.new argv, stdin
+      argf.gets(chomp: false).should eq("hello\n")
+      argf.gets(chomp: false).should eq("world\n")
+      argf.gets(chomp: false).should be_nil
     end
 
     it "reads from ARGV if specified" do
@@ -58,16 +68,16 @@ describe IO::ARGF do
       argf = IO::ARGF.new argv, stdin
       argv.should eq([path1, path2])
 
-      argf.gets.should eq("12345\n")
+      argf.gets(chomp: false).should eq("12345\n")
       argv.should eq([path2])
 
-      argf.gets.should eq("67890\n")
+      argf.gets(chomp: false).should eq("67890\n")
       argv.empty?.should be_true
 
-      argf.gets.should be_nil
+      argf.gets(chomp: false).should be_nil
 
       argv << path1
-      str = argf.gets
+      str = argf.gets(chomp: false)
       str.should eq("12345\n")
     end
   end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -61,6 +61,15 @@ private class SimpleIOMemory
     Slice.new(@buffer, @bytesize)
   end
 
+  def to_s
+    String.new @buffer, @bytesize
+  end
+
+  def rewind
+    @pos = 0
+    self
+  end
+
   private def check_needs_resize
     resize_to_capacity(@capacity * 2) if @bytesize == @capacity
   end
@@ -113,8 +122,19 @@ describe IO do
 
   describe "IO iterators" do
     it "iterates by line" do
-      io = IO::Memory.new("hello\nbye\n")
+      io = SimpleIOMemory.new("hello\nbye\n")
       lines = io.each_line
+      lines.next.should eq("hello")
+      lines.next.should eq("bye")
+      lines.next.should be_a(Iterator::Stop)
+
+      lines.rewind
+      lines.next.should eq("hello")
+    end
+
+    it "iterates by line with chomp false" do
+      io = SimpleIOMemory.new("hello\nbye\n")
+      lines = io.each_line(chomp: false)
       lines.next.should eq("hello\n")
       lines.next.should eq("bye\n")
       lines.next.should be_a(Iterator::Stop)
@@ -124,7 +144,7 @@ describe IO do
     end
 
     it "iterates by char" do
-      io = IO::Memory.new("abあぼ")
+      io = SimpleIOMemory.new("abあぼ")
       chars = io.each_char
       chars.next.should eq('a')
       chars.next.should eq('b')
@@ -137,7 +157,7 @@ describe IO do
     end
 
     it "iterates by byte" do
-      io = IO::Memory.new("ab")
+      io = SimpleIOMemory.new("ab")
       bytes = io.each_byte
       bytes.next.should eq('a'.ord)
       bytes.next.should eq('b'.ord)
@@ -150,24 +170,24 @@ describe IO do
 
   it "copies" do
     string = "abあぼ"
-    src = IO::Memory.new(string)
-    dst = IO::Memory.new
+    src = SimpleIOMemory.new(string)
+    dst = SimpleIOMemory.new
     IO.copy(src, dst).should eq(string.bytesize)
     dst.to_s.should eq(string)
   end
 
   it "copies with limit" do
     string = "abcあぼ"
-    src = IO::Memory.new(string)
-    dst = IO::Memory.new
+    src = SimpleIOMemory.new(string)
+    dst = SimpleIOMemory.new
     IO.copy(src, dst, 3).should eq(3)
     dst.to_s.should eq("abc")
   end
 
   it "raises on copy with negative limit" do
     string = "abcあぼ"
-    src = IO::Memory.new(string)
-    dst = IO::Memory.new
+    src = SimpleIOMemory.new(string)
+    dst = SimpleIOMemory.new
     expect_raises(ArgumentError, "negative limit") do
       IO.copy(src, dst, -10)
     end
@@ -177,7 +197,7 @@ describe IO do
     File.open("#{__DIR__}/../data/test_file.txt") do |file1|
       File.open("#{__DIR__}/../data/test_file.ini") do |file2|
         file2.reopen(file1)
-        file2.gets.should eq("Hello World\n")
+        file2.gets.should eq("Hello World")
       end
     end
   end
@@ -185,15 +205,30 @@ describe IO do
   describe "read operations" do
     it "does gets" do
       io = SimpleIOMemory.new("hello\nworld\n")
-      io.gets.should eq("hello\n")
-      io.gets.should eq("world\n")
+      io.gets.should eq("hello")
+      io.gets.should eq("world")
       io.gets.should be_nil
+    end
+
+    it "does gets with \\r\\n" do
+      io = SimpleIOMemory.new("hello\r\nworld\r\nfoo\rbar\n")
+      io.gets.should eq("hello")
+      io.gets.should eq("world")
+      io.gets.should eq("foo\rbar")
+      io.gets.should be_nil
+    end
+
+    it "does gets with chomp false" do
+      io = SimpleIOMemory.new("hello\nworld\n")
+      io.gets(chomp: false).should eq("hello\n")
+      io.gets(chomp: false).should eq("world\n")
+      io.gets(chomp: false).should be_nil
     end
 
     it "does gets with big line" do
       big_line = "a" * 20_000
       io = SimpleIOMemory.new("#{big_line}\nworld\n")
-      io.gets.should eq("#{big_line}\n")
+      io.gets.should eq(big_line)
     end
 
     it "does gets with char delimiter" do
@@ -216,6 +251,13 @@ describe IO do
       io.gets("lo").should eq("hello")
       io.gets("rl").should eq(" worl")
       io.gets("foo").should eq("d")
+    end
+
+    it "gets with string as delimiter and chomp = true" do
+      io = SimpleIOMemory.new("hello world")
+      io.gets("lo", chomp: true).should eq("hel")
+      io.gets("rl", chomp: true).should eq(" wo")
+      io.gets("foo", chomp: true).should eq("d")
     end
 
     it "gets with empty string as delimiter" do
@@ -271,7 +313,7 @@ describe IO do
 
     it "reads all remaining content" do
       io = SimpleIOMemory.new("foo\nbar\nbaz\n")
-      io.gets.should eq("foo\n")
+      io.gets.should eq("foo")
       io.gets_to_end.should eq("bar\nbaz\n")
     end
 
@@ -311,9 +353,9 @@ describe IO do
       io.each_line do |line|
         case counter
         when 0
-          line.should eq("a\n")
+          line.should eq("a")
         when 1
-          line.should eq("bb\n")
+          line.should eq("bb")
         when 2
           line.should eq("cc")
         end
@@ -428,13 +470,23 @@ describe IO do
       end
 
       it "gets" do
-        str = "Hello world\nFoo\nBar"
+        str = "Hello world\r\nFoo\nBar"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
-        io.gets.should eq("Hello world\n")
-        io.gets.should eq("Foo\n")
+        io.gets.should eq("Hello world")
+        io.gets.should eq("Foo")
         io.gets.should eq("Bar")
         io.gets.should be_nil
+      end
+
+      it "gets with chomp = false" do
+        str = "Hello world\r\nFoo\nBar"
+        io = SimpleIOMemory.new(str.encode("UCS-2LE"))
+        io.set_encoding("UCS-2LE")
+        io.gets(chomp: false).should eq("Hello world\r\n")
+        io.gets(chomp: false).should eq("Foo\n")
+        io.gets(chomp: false).should eq("Bar")
+        io.gets(chomp: false).should be_nil
       end
 
       it "gets big string" do
@@ -442,8 +494,8 @@ describe IO do
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         10_000.times do |i|
-          io.gets.should eq("Hello\n")
-          io.gets.should eq("World\n")
+          io.gets.should eq("Hello")
+          io.gets.should eq("World")
         end
       end
 
@@ -453,7 +505,7 @@ describe IO do
           io = SimpleIOMemory.new(str)
           io.set_encoding("GB2312")
           1000.times do
-            io.gets.should eq("你好我是人\n")
+            io.gets.should eq("你好我是人")
           end
         end
       end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -57,10 +57,17 @@ describe IO::Memory do
   end
 
   it "reads each line" do
-    io = IO::Memory.new("foo\r\nbar\r\n")
-    io.gets.should eq("foo\r\n")
-    io.gets.should eq("bar\r\n")
+    io = IO::Memory.new("foo\r\nbar\n")
+    io.gets.should eq("foo")
+    io.gets.should eq("bar")
     io.gets.should eq(nil)
+  end
+
+  it "reads each line with chomp = false" do
+    io = IO::Memory.new("foo\r\nbar\r\n")
+    io.gets(chomp: false).should eq("foo\r\n")
+    io.gets(chomp: false).should eq("bar\r\n")
+    io.gets(chomp: false).should eq(nil)
   end
 
   it "gets with char as delimiter" do
@@ -301,16 +308,25 @@ describe IO::Memory do
         str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
-        io.gets.should eq("Hello world\n")
-        io.gets.should eq("Foo\n")
-        io.gets.should eq("Bar\n")
+        io.gets(chomp: false).should eq("Hello world\n")
+        io.gets(chomp: false).should eq("Foo\n")
+        io.gets(chomp: false).should eq("Bar\n")
+      end
+
+      it "gets with chomp = false" do
+        str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
+        io = IO::Memory.new(str.encode("UCS-2LE"))
+        io.set_encoding("UCS-2LE")
+        io.gets.should eq("Hello world")
+        io.gets.should eq("Foo")
+        io.gets.should eq("Bar")
       end
 
       it "reads char" do
         str = "x\nHello world" + ("1234567890" * 1000)
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
-        io.gets.should eq("x\n")
+        io.gets(chomp: false).should eq("x\n")
         str = str[2..-1]
         str.each_char do |char|
           io.read_char.should eq(char)

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -94,9 +94,18 @@ describe "IO::Sized" do
   it "gets" do
     io = IO::Memory.new "foo\nbar\nbaz"
     sized = IO::Sized.new(io, read_size: 9)
-    sized.gets.should eq("foo\n")
-    sized.gets.should eq("bar\n")
+    sized.gets.should eq("foo")
+    sized.gets.should eq("bar")
     sized.gets.should eq("b")
     sized.gets.should be_nil
+  end
+
+  it "gets with chomp = false" do
+    io = IO::Memory.new "foo\nbar\nbaz"
+    sized = IO::Sized.new(io, read_size: 9)
+    sized.gets(chomp: false).should eq("foo\n")
+    sized.gets(chomp: false).should eq("bar\n")
+    sized.gets(chomp: false).should eq("b")
+    sized.gets(chomp: false).should be_nil
   end
 end

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -37,7 +37,7 @@ describe "Logger" do
       logger.progname = "crystal"
       logger.warn "message"
 
-      r.gets.should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
+      r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
     end
   end
 
@@ -49,7 +49,7 @@ describe "Logger" do
       end
       logger.warn "message", "prog"
 
-      r.gets.should eq("W prog: message\n")
+      r.gets(chomp: false).should eq("W prog: message\n")
     end
   end
 
@@ -59,8 +59,8 @@ describe "Logger" do
       logger.error { "message" }
       logger.unknown { "another message" }
 
-      r.gets.should match(/ERROR -- : message\n/)
-      r.gets.should match(/  ANY -- : another message\n/)
+      r.gets(chomp: false).should match(/ERROR -- : message\n/)
+      r.gets(chomp: false).should match(/  ANY -- : another message\n/)
     end
   end
 
@@ -70,8 +70,8 @@ describe "Logger" do
       logger.error("crystal") { "message" }
       logger.unknown("shard") { "another message" }
 
-      r.gets.should match(/ERROR -- crystal: message\n/)
-      r.gets.should match(/  ANY -- shard: another message\n/)
+      r.gets(chomp: false).should match(/ERROR -- crystal: message\n/)
+      r.gets(chomp: false).should match(/  ANY -- shard: another message\n/)
     end
   end
 

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -18,4 +18,20 @@ describe String::Builder do
 
     expect_raises { builder.to_s }
   end
+
+  it "goes back" do
+    s = String::Builder.build do |str|
+      str << 12
+      str.back(1)
+    end
+    s.should eq("1")
+  end
+
+  it "goes back all" do
+    s = String::Builder.build do |str|
+      str << 12
+      str.back(2)
+    end
+    s.should eq("")
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -494,6 +494,7 @@ describe "String" do
     assert { "かたな\r\n".chomp.should eq("かたな") }
     assert { "hello\n\n".chomp.should eq("hello\n") }
     assert { "hello\r\n\n".chomp.should eq("hello\r\n") }
+    assert { "hello\r\n".chomp('\n').should eq("hello") }
 
     assert { "hello".chomp('a').should eq("hello") }
     assert { "hello".chomp('o').should eq("hell") }
@@ -1819,20 +1820,52 @@ describe "String" do
   end
 
   it "gets lines" do
+    "".lines.should eq([] of String)
+    "\n".lines.should eq([""] of String)
+    "\r".lines.should eq(["\r"] of String)
+    "\r\n".lines.should eq([""] of String)
     "foo".lines.should eq(["foo"])
-    "foo\nbar\nbaz\n".lines.should eq(["foo\n", "bar\n", "baz\n"])
+    "foo\n".lines.should eq(["foo"])
+    "foo\r\n".lines.should eq(["foo"])
+    "foo\nbar\r\nbaz\n".lines.should eq(["foo", "bar", "baz"])
+    "foo\nbar\r\nbaz\r\n".lines.should eq(["foo", "bar", "baz"])
+  end
+
+  it "gets lines with chomp = false" do
+    "foo".lines(chomp: false).should eq(["foo"])
+    "foo\nbar\r\nbaz\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\n"])
+    "foo\nbar\r\nbaz\r\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\r\n"])
   end
 
   it "gets each_line" do
     lines = [] of String
-    "foo\n\nbar\nbaz\n".each_line do |line|
+    "foo\n\nbar\r\nbaz\n".each_line do |line|
       lines << line
     end
-    lines.should eq(["foo\n", "\n", "bar\n", "baz\n"])
+    lines.should eq(["foo", "", "bar", "baz"])
+  end
+
+  it "gets each_line with chomp = false" do
+    lines = [] of String
+    "foo\n\nbar\r\nbaz\r\n".each_line(chomp: false) do |line|
+      lines << line
+    end
+    lines.should eq(["foo\n", "\n", "bar\r\n", "baz\r\n"])
   end
 
   it "gets each_line iterator" do
-    iter = "foo\nbar\nbaz\n".each_line
+    iter = "foo\nbar\r\nbaz\r\n".each_line
+    iter.next.should eq("foo")
+    iter.next.should eq("bar")
+    iter.next.should eq("baz")
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq("foo")
+  end
+
+  it "gets each_line iterator with chomp = false" do
+    iter = "foo\nbar\nbaz\n".each_line(chomp: false)
     iter.next.should eq("foo\n")
     iter.next.should eq("bar\n")
     iter.next.should eq("baz\n")

--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -48,9 +48,9 @@ describe Tempfile do
     tempfile.seek(0, IO::Seek::Set)
     tempfile.tell.should eq(0)
     tempfile.pos.should eq(0)
-    tempfile.gets.should eq("Hello!\n")
+    tempfile.gets(chomp: false).should eq("Hello!\n")
     tempfile.pos = 0
-    tempfile.gets.should eq("Hello!\n")
+    tempfile.gets(chomp: false).should eq("Hello!\n")
     tempfile.close
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -440,17 +440,17 @@ class File < IO::FileDescriptor
   #   # loop
   # end
   # ```
-  def self.each_line(filename, encoding = nil, invalid = nil)
+  def self.each_line(filename, encoding = nil, invalid = nil, chomp = true)
     File.open(filename, "r", encoding: encoding, invalid: invalid) do |file|
-      file.each_line do |line|
+      file.each_line(chomp: chomp) do |line|
         yield line
       end
     end
   end
 
   # Returns an `Iterator` for each line in *filename*.
-  def self.each_line(filename, encoding = nil, invalid = nil)
-    File.open(filename, "r", encoding: encoding, invalid: invalid).each_line
+  def self.each_line(filename, encoding = nil, invalid = nil, chomp = true)
+    File.open(filename, "r", encoding: encoding, invalid: invalid).each_line(chomp: chomp)
   end
 
   # Returns all lines in *filename* as an array of strings.
@@ -459,9 +459,9 @@ class File < IO::FileDescriptor
   # File.write("foobar", "foo\nbar")
   # File.read_lines("foobar") # => ["foo\n", "bar\n"]
   # ```
-  def self.read_lines(filename, encoding = nil, invalid = nil) : Array(String)
+  def self.read_lines(filename, encoding = nil, invalid = nil, chomp = true) : Array(String)
     lines = [] of String
-    each_line(filename, encoding: encoding, invalid: invalid) do |line|
+    each_line(filename, encoding: encoding, invalid: invalid, chomp: chomp) do |line|
       lines << line
     end
     lines

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -17,7 +17,7 @@ module HTTP
     headers = Headers.new
 
     while line = io.gets
-      if line == "\r\n" || line == "\n"
+      if line.empty?
         body = nil
         if body_type.prohibited?
           body = nil

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -34,10 +34,10 @@ module HTTP
       @io.read_byte
     end
 
-    def gets(delimiter : Char, limit : Int) : String?
+    def gets(delimiter : Char, limit : Int, chomp = false) : String?
       return super if @encoding
 
-      @io.gets(delimiter, limit)
+      @io.gets(delimiter, limit, chomp)
     end
 
     def write(slice : Slice(UInt8))

--- a/src/io.cr
+++ b/src/io.cr
@@ -534,17 +534,22 @@ module IO
   # Reads a line from this IO. A line is terminated by the `\n` character.
   # Returns `nil` if called at the end of this IO.
   #
+  # By default the newline is removed from the returned string,
+  # unless *chomp* is false.
+  #
   # ```
-  # io = IO::Memory.new "hello\nworld"
-  # io.gets # => "hello\n"
-  # io.gets # => "world"
-  # io.gets # => nil
+  # io = IO::Memory.new "hello\nworld\nfoo\n"
+  # io.gets               # => "hello"
+  # io.gets(chomp: false) # => "world\n"
+  # io.gets               # => "foo"
+  # io.gets               # => nil
   # ```
-  def gets : String?
-    gets '\n'
+  def gets(chomp = true) : String?
+    gets '\n', chomp: chomp
   end
 
-  # Reads a line of at most `limit` bytes from this IO. A line is terminated by the `\n` character.
+  # Reads a line of at most `limit` bytes from this IO.
+  # A line is terminated by the `\n` character.
   # Returns `nil` if called at the end of this IO.
   #
   # ```
@@ -555,8 +560,8 @@ module IO
   # io.gets(3) # => "ld"
   # io.gets(3) # => nil
   # ```
-  def gets(limit : Int) : String?
-    gets '\n', limit
+  def gets(limit : Int, chomp = false) : String?
+    gets '\n', limit: limit, chomp: chomp
   end
 
   # Reads until *delimiter* is found, or the end of the IO is reached.
@@ -569,8 +574,8 @@ module IO
   # io.gets('z') # => "ld"
   # io.gets('w') # => nil
   # ```
-  def gets(delimiter : Char) : String?
-    gets delimiter, Int32::MAX
+  def gets(delimiter : Char, chomp = false) : String?
+    gets delimiter, Int32::MAX, chomp: chomp
   end
 
   # Reads until *delimiter* is found, `limit` bytes are read, or the end of the IO is reached.
@@ -583,14 +588,16 @@ module IO
   # io.gets('z', 10) # => "ld"
   # io.gets('w', 10) # => nil
   # ```
-  def gets(delimiter : Char, limit : Int) : String?
+  def gets(delimiter : Char, limit : Int, chomp = false) : String?
     raise ArgumentError.new "negative limit" if limit < 0
 
     # # If the char's representation is a single byte and we have an encoding,
     # search the delimiter in the buffer
     if delimiter.ascii? && (decoder = decoder())
-      return decoder.gets(self, delimiter.ord.to_u8, limit)
+      return decoder.gets(self, delimiter.ord.to_u8, limit: limit, chomp: chomp)
     end
+
+    chomp_rn = delimiter == '\n' && chomp
 
     buffer = String::Builder.new
     total = 0
@@ -602,8 +609,31 @@ module IO
 
       char, char_bytesize = info
 
-      buffer << char
-      break if char == delimiter
+      # Consider the case of \r\n when the delimiter is \n and chomp = true
+      if chomp_rn && char == '\r'
+        info2 = read_char_with_bytesize
+        unless info2
+          buffer << char
+          break
+        end
+
+        char2, char_bytesize2 = info2
+        if char2 == '\n'
+          break
+        end
+
+        buffer << '\r'
+        total += char_bytesize
+        break if total >= limit
+
+        buffer << char2
+        total += char_bytesize2
+      elsif char == delimiter
+        buffer << char unless chomp
+        break
+      else
+        buffer << char
+      end
 
       total += char_bytesize
       break if total >= limit
@@ -620,7 +650,7 @@ module IO
   # io.gets("wo") # => "rld"
   # io.gets("wo") # => nil
   # ```
-  def gets(delimiter : String) : String?
+  def gets(delimiter : String, chomp = false) : String?
     # Empty string: read all
     if delimiter.empty?
       return gets_to_end
@@ -628,12 +658,12 @@ module IO
 
     # One byte: use gets(Char)
     if delimiter.bytesize == 1
-      return gets(delimiter.unsafe_byte_at(0).unsafe_chr)
+      return gets(delimiter.unsafe_byte_at(0).unsafe_chr, chomp: chomp)
     end
 
     # One char: use gets(Char)
     if delimiter.size == 1
-      return gets(delimiter[0])
+      return gets(delimiter[0], chomp: chomp)
     end
 
     # The 'hard' case: we read until we match the last byte,
@@ -649,9 +679,12 @@ module IO
       buffer.write_byte(byte)
       total_bytes += 1
 
-      break if (byte == last_byte) &&
-               (buffer.bytesize >= delimiter.bytesize) &&
-               (buffer.buffer + total_bytes - delimiter.bytesize).memcmp(delimiter.to_unsafe, delimiter.bytesize) == 0
+      if (byte == last_byte) &&
+         (buffer.bytesize >= delimiter.bytesize) &&
+         (buffer.buffer + total_bytes - delimiter.bytesize).memcmp(delimiter.to_unsafe, delimiter.bytesize) == 0
+        buffer.back(delimiter.bytesize) if chomp
+        break
+      end
     end
     buffer.to_s
   end
@@ -771,7 +804,7 @@ module IO
   # iter.next # => "world"
   # ```
   def each_line(*args, **options)
-    LineIterator.new(self, args, **options)
+    LineIterator.new(self, args, options)
   end
 
   # Inovkes the given block with each `Char` in this IO.
@@ -918,14 +951,14 @@ module IO
     limit - remaining
   end
 
-  private struct LineIterator(I, A)
+  private struct LineIterator(I, A, N)
     include Iterator(String)
 
-    def initialize(@io : I, @args : A)
+    def initialize(@io : I, @args : A, @nargs : N)
     end
 
     def next
-      @io.gets(*@args) || stop
+      @io.gets(*@args, **@nargs) || stop
     end
 
     def rewind

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -32,25 +32,25 @@ class IO::ARGF
   end
 
   # :nodoc:
-  def gets(delimiter : Char, limit : Int) : String?
+  def gets(delimiter : Char, limit : Int, chomp = false) : String?
     return super if @encoding
 
     first_initialize unless @initialized
 
     if current_io = @current_io
-      string = current_io.gets(delimiter, limit)
+      string = current_io.gets(delimiter, limit, chomp)
       if !string && !@read_from_stdin
         current_io.close
         if @argv.empty?
           @current_io = nil
         else
           read_next_argv
-          string = gets(delimiter, limit)
+          string = gets(delimiter, limit, chomp)
         end
       end
     elsif !@read_from_stdin && !@argv.empty?
       read_next_argv
-      string = gets(delimiter, limit)
+      string = gets(delimiter, limit, chomp)
     else
       string = nil
     end

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -30,7 +30,7 @@ module IO::Buffered
   abstract def unbuffered_rewind
 
   # :nodoc:
-  def gets(delimiter : Char, limit : Int)
+  def gets(delimiter : Char, limit : Int, chomp = false)
     check_open
 
     if delimiter.ord >= 128 || @encoding
@@ -61,8 +61,18 @@ module IO::Buffered
         index += 1
       end
 
+      advance = index
+
+      if chomp && index > 0 && @in_buffer_rem[index - 1] === delimiter_byte
+        index -= 1
+
+        if delimiter == '\n' && index > 0 && @in_buffer_rem[index - 1] === '\r'
+          index -= 1
+        end
+      end
+
       string = String.new(@in_buffer_rem[0, index])
-      @in_buffer_rem += index
+      @in_buffer_rem += advance
       return string
     end
 
@@ -101,6 +111,7 @@ module IO::Buffered
           break
         end
       end
+      buffer.chomp!(delimiter_byte) if chomp
     end
   end
 

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -132,7 +132,7 @@ class IO::Memory
   end
 
   # :nodoc:
-  def gets(delimiter : Char, limit : Int32)
+  def gets(delimiter : Char, limit : Int32, chomp = false)
     return super if @encoding || delimiter.ord >= 128
 
     check_open
@@ -155,8 +155,18 @@ class IO::Memory
       end
     end
 
+    advance = index
+
+    if chomp && index > 0 && (@buffer + @pos + index - 1).value === delimiter
+      index -= 1
+
+      if delimiter == '\n' && index > 0 && (@buffer + @pos + index - 1).value === '\r'
+        index -= 1
+      end
+    end
+
     string = String.new(@buffer + @pos, index)
-    @pos += index
+    @pos += advance
     string
   end
 

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -49,14 +49,19 @@ module IO
       end
     end
 
-    def gets(delimiter : Char, limit : Int) : String?
+    def gets(delimiter : Char, limit : Int, chomp = false) : String?
       check_open
 
       return super if @encoding
       return nil if @read_remaining == 0
 
+      # We can't pass chomp here, because it will remove part of the delimiter
+      # and then we won't know how much we consumed from @io, so we chomp later
       string = @io.gets(delimiter, Math.min(limit, @read_remaining))
-      @read_remaining -= string.bytesize if string
+      if string
+        @read_remaining -= string.bytesize
+        string = string.chomp(delimiter) if chomp
+      end
       string
     end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -994,7 +994,9 @@ class String
   # "hello".chomp('a') # => "hello"
   # ```
   def chomp(char : Char)
-    if ends_with?(char)
+    if char == '\n'
+      chomp
+    elsif ends_with?(char)
       unsafe_byte_slice_string(0, bytesize - char.bytesize)
     else
       self
@@ -2657,9 +2659,9 @@ class String
     ary
   end
 
-  def lines
+  def lines(chomp = true)
     lines = [] of String
-    each_line do |line|
+    each_line(chomp: chomp) do |line|
       lines << line
     end
     lines
@@ -2678,11 +2680,21 @@ class String
   # # => EVEN THE MONKEY SEEMS TO want
   # # => A LITTLE COAT OF STRAW
   # ```
-  def each_line
+  def each_line(chomp = true)
+    return if empty?
+
     offset = 0
 
     while byte_index = byte_index('\n'.ord.to_u8, offset)
-      yield unsafe_byte_slice_string(offset, byte_index + 1 - offset)
+      count = byte_index - offset + 1
+      if chomp
+        count -= 1
+        if offset + count > 0 && to_unsafe[offset + count - 1] === '\r'
+          count -= 1
+        end
+      end
+
+      yield unsafe_byte_slice_string(offset, count)
       offset = byte_index + 1
     end
 
@@ -2692,8 +2704,8 @@ class String
   end
 
   # Returns an `Iterator` which yields each line of this string (see `String#each_line`).
-  def each_line
-    LineIterator.new(self)
+  def each_line(chomp = true)
+    LineIterator.new(self, chomp)
   end
 
   # Converts camelcase boundaries to underscores.
@@ -3452,11 +3464,7 @@ class String
   private class LineIterator
     include Iterator(String)
 
-    @string : String
-    @offset : Int32
-    @end : Bool
-
-    def initialize(@string)
+    def initialize(@string : String, @chomp : Bool)
       @offset = 0
       @end = false
     end
@@ -3466,7 +3474,15 @@ class String
 
       byte_index = @string.byte_index('\n'.ord.to_u8, @offset)
       if byte_index
-        value = @string.unsafe_byte_slice_string(@offset, byte_index + 1 - @offset)
+        count = byte_index - @offset + 1
+        if @chomp
+          count -= 1
+          if @offset + count > 0 && @string.to_unsafe[@offset + count - 1] === '\r'
+            count -= 1
+          end
+        end
+
+        value = @string.unsafe_byte_slice_string(@offset, count)
         @offset = byte_index + 1
       else
         if @offset == @string.bytesize

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -7,8 +7,8 @@ class String::Builder
   include IO
 
   getter bytesize : Int32
-  @capacity : Int32
-  @buffer : Pointer(UInt8)
+  getter capacity : Int32
+  getter buffer : Pointer(UInt8)
 
   def initialize(capacity : Int = 64)
     String.check_capacity_in_bounds(capacity)
@@ -59,6 +59,29 @@ class String::Builder
 
   def empty?
     @bytesize == 0
+  end
+
+  # Chomps the last byte from the string buffer.
+  # If the byte is '\n' and there's a '\r' before it, it is
+  # also removed.
+  def chomp!(byte : UInt8)
+    if bytesize > 0 && buffer[bytesize - 1] == byte
+      back(1)
+
+      if byte === '\n' && bytesize > 0 && buffer[bytesize - 1] === '\r'
+        back(1)
+      end
+    end
+  end
+
+  # Moves the write pointer, and the resulting string bytesize,
+  # by the given amount
+  def back(amount : Int)
+    unless 0 <= amount <= @bytesize
+      raise ArgumentError.new "invalid back amount"
+    end
+
+    @bytesize -= amount
   end
 
   def to_s


### PR DESCRIPTION
This adds a `chomp` optional argument to `IO#gets`, `IO#each_line`, `String#lines`, `String#each_line` and generally to every method that reads lines, or by line.

This feature was [added recently to Ruby 2.4](https://www.ruby-lang.org/en/news/2016/12/12/ruby-2-4-0-rc1-released/), and honestly I always wanted to be able to do this, both in Ruby and Crystal, so keeping the way Ruby does it is good (I also imagined the same API before Ruby added it).

There's a slight difference with Ruby, though. The default `chomp` value in Ruby is always `false`. This is to preserve backwards compatibility, I guess. In our case breaking backwards compatibility is fine before 1.0. So, the rules are:

* argless `gets`, `each_line` and `lines` assume `chomp = true`
* other `gets` overloads assume `chomp = false`

The idea is that argless `gets` is semantically equivalent to reading a line. So in every case where we read a line, we chomp it if it ends with a newline (or `"\r\n"`). If we pass an argument to `gets`, for example `gets('a')`, we usually want to read up to, and including, that delimiter. Same goes with `gets(3)`: we want to read a String of 3 bytes, please don't chomp it by default.

**Note:** I wouldn't mind having `chomp = true` in every case. I actually don't know what use cases exist for `gets` with a delimiter. If we make it always `true` by default it's maybe more consistent, and one can always pass `chomp = false` to disable this behaviour, so please share your thoughts and use cases about this.

In summary:

```cr
# No args, chomp is true by default
io = IO::Memory.new("one\ntwo\r\nthree")
io.gets # => "one"
io.gets # => "two"
io.gets # => "three"
io.gets # => nil

# No args, explicit chomp is false
io = IO::Memory.new("one\ntwo\r\nthree")
io.gets(chomp: false) # => "one\n"
io.gets(chomp: false) # => "two\r\n"
io.gets(chomp: false) # => "three"
io.gets(chomp: false) # => nil

# Passing a parameter will not implicitly chomp
io = IO::Memory.new("some long word")
io.gets('e') # => "some"
io.gets('g', chomp: true) # => "lon"
```

Of course one can always do `gets.try &.chomp`. The difference is that this will allocate two strings: one that is read, and one chomped. So `chomp: true` can also improve performance a bit if we don't care about the ending newline (and I'd say in most cases we don't).

As a side story, I was curious about what happens in these cases in Ruby 2.4:

```rb
"".lines
"\n".lines
"\r\n".lines
```

The first one returns an empty array. The second and third ones return an array with a single empty string. Well, almost, the second case actually triggers a segmentation fault, [which I just reported](https://bugs.ruby-lang.org/issues/13037). I just wanted to share this little story because it's a good change of air, from receiving segmentation faults and bug reports to Crystal, to be able to actually report one in another project (and help it become better, of course) 😸 