### PR TITLE
[WIP] Allow testing on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,29 @@
+variables:
+  TRAVIS_OS_NAME: docker
+  LIBRARY_PATH: /opt/crystal/embedded/lib/
+
+cache:
+  key: "crystal"
+  paths:
+    - .crystal
+
+.test-crystal: &test-crystal
+  before_script:
+    - bin/ci prepare_system
+    - bin/ci prepare_build
+  script:
+    - bin/ci build
+
+x86_64:
+  <<: *test-crystal
+  image: jhass/crystal-build-x86_64
+  variables:
+    ARCH: x86_64
+    ARCH_CMD: linux64
+
+i386:
+  <<: *test-crystal
+  image: jhass/crystal-build-i386
+  variables:
+    ARCH: i386
+    ARCH_CMD: linux32

--- a/bin/ci
+++ b/bin/ci
@@ -77,6 +77,10 @@ on_osx() {
   fail_on_error on_os "osx" "${@}"
 }
 
+on_docker() {
+  fail_on_error on_os "docker" "${@}"
+}
+
 prepare_system() {
   on_osx brew update
   on_deploy sudo pip install awscli
@@ -173,6 +177,8 @@ with_build_env() {
     CRYSTAL_CACHE_DIR="/tmp/crystal" \
     /bin/bash -c "'$command'"
 
+  on_docker verify_linux_environment
+  on_docker /bin/bash -c "'$command'"
 }
 
 usage() {


### PR DESCRIPTION
In case that anyone has a fork of Crystal on a GitLab instance this PR provides the corresponding `.gitlab-ci.yml` so testing on the built-in GitLab CI would work out of the box.

Examples:
* Mirror on GitLab.com: https://gitlab.com/splattael/crystal/pipelines (:exclamation:  will work once merged)
* Private instance: https://git.zilium.de/splattael/crystal/pipelines (:white_check_mark: already working)

On systems other than GitLab this additional files does nothing.