### PR TITLE
Make HTTP::Handler a module

### DIFF
--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -1,7 +1,9 @@
 require "spec"
 require "http/server"
 
-private class EmptyHTTPHandler < HTTP::Handler
+private class EmptyHTTPHandler
+  include HTTP::Handler
+
   def call(context)
     call_next(context)
   end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -291,7 +291,9 @@ module Crystal::Playground
     end
   end
 
-  class PageHandler < HTTP::Handler
+  class PageHandler
+    include HTTP::Handler
+
     @page : PlaygroundPage
 
     def initialize(@path : String, filename : String)
@@ -312,7 +314,9 @@ module Crystal::Playground
     end
   end
 
-  class WorkbookHandler < HTTP::Handler
+  class WorkbookHandler
+    include HTTP::Handler
+
     def call(context)
       case {context.request.method, context.request.path}
       when {"GET", /\/workbook\/playground\/(.*)/}
@@ -371,7 +375,9 @@ module Crystal::Playground
     end
   end
 
-  class EnvironmentHandler < HTTP::Handler
+  class EnvironmentHandler
+    include HTTP::Handler
+
     def initialize(@server : Playground::Server)
     end
 

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -1,18 +1,20 @@
-# A handler is a class which inherits from HTTP::Handler and implements the `call` method.
+# A handler is a class which includes HTTP::Handler and implements the `call` method.
 # You can use a handler to intercept any incoming request and can modify the response. These can be used for request throttling,
 # ip-based whitelisting, adding custom headers e.g.
 #
 # ### A custom handler
 #
 # ```
-# class CustomHandler < HTTP::Handler
+# class CustomHandler
+#   include HTTP::Handler
+#
 #   def call(context)
 #     puts "Doing some stuff"
 #     call_next(context)
 #   end
 # end
 # ```
-abstract class HTTP::Handler
+module HTTP::Handler
   property next : Handler | Proc | Nil
 
   abstract def call(context : HTTP::Server::Context)

--- a/src/http/server/handlers/deflate_handler.cr
+++ b/src/http/server/handlers/deflate_handler.cr
@@ -4,7 +4,9 @@
 
 # A handler that configures an `HTTP::Server::Response` to compress the response
 # output, either using gzip or deflate, depending on the `Accept-Encoding` request header.
-class HTTP::DeflateHandler < HTTP::Handler
+class HTTP::DeflateHandler
+  include HTTP::Handler
+
   def call(context)
     {% if flag?(:without_zlib) %}
       call_next(context)

--- a/src/http/server/handlers/error_handler.cr
+++ b/src/http/server/handlers/error_handler.cr
@@ -4,7 +4,9 @@
 #  In verbose mode prints the exception with its backtrace to the response,
 #  else a generic error message is returned to the client. Use the LogHandler before this
 #  to log the exception on the server side.
-class HTTP::ErrorHandler < HTTP::Handler
+class HTTP::ErrorHandler
+  include HTTP::Handler
+
   def initialize(@verbose : Bool = false)
   end
 

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -1,6 +1,8 @@
 # A handler that logs the request method, resource, status code, and
 # the time used to execute the next handler, to the given `IO`.
-class HTTP::LogHandler < HTTP::Handler
+class HTTP::LogHandler
+  include HTTP::Handler
+
   # Initializes this handler to log to the given `IO`.
   def initialize(@io : IO = STDOUT)
   end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -3,7 +3,9 @@ require "html"
 require "uri"
 
 # A simple handler that lists directories and serves files under a given public directory.
-class HTTP::StaticFileHandler < HTTP::Handler
+class HTTP::StaticFileHandler
+  include HTTP::Handler
+
   @public_dir : String
 
   # Creates a handler that will serve files in the given *public_dir*, after

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -7,7 +7,9 @@ require "../../web_socket"
   require "openssl/sha1"
 {% end %}
 
-class HTTP::WebSocketHandler < HTTP::Handler
+class HTTP::WebSocketHandler
+  include HTTP::Handler
+
   def initialize(&@proc : WebSocket, Server::Context ->)
   end
 


### PR DESCRIPTION
 Because HTTP::Handler was just an interface, it is less restrictive on applications to be an includeable module rather than in inheritable class.

This is a proof of concept of what I mentioned in #3690