### PR TITLE
Adds strict option for string equality comparison

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -269,7 +269,7 @@ module Spec
             fail "expected {{klass.id}} with message matching #{ %msg.inspect }, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
           end
         when String
-          unless %ex_to_s.includes?(%msg)
+          unless %ex_to_s == %msg
             backtrace = %ex.backtrace.map { |f| "  # #{f}" }.join "\n"
             fail "expected {{klass.id}} with #{ %msg.inspect }, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
           end


### PR DESCRIPTION
~~Solves #3707~~

~~Doing:~~

```ruby
expect_raises MyError, "my message", strict: true do...
```

~~...will now do a strict comparison of messages instead of `ex_to_s.includes?(msg)`~~

Does strict string equality comparison for `expect_raises` spec messages.