### PR TITLE
Check formatting early in CI

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -83,10 +83,10 @@ prepare_system() {
 }
 
 build() {
+  with_build_env './bin/crystal tool format --check samples spec src'
   with_build_env 'make std_spec clean'
   with_build_env 'make crystal spec doc'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
-  with_build_env './bin/crystal tool format --check samples spec src'
 }
 
 deploy() {


### PR DESCRIPTION
This commit makes formatting the first check, so that CI doesn't run for
hours only to fail on style.