### PR TITLE
Move line break to front of line break rather than end

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -269,7 +269,7 @@ class Crystal::Doc::Generator
     String.build do |io|
       string.each_line.join("", io) do |line, io|
         if line =~ flag_regexp
-          io << line << '\n'
+          io << '\n' << line
         else
           io << line
         end


### PR DESCRIPTION
With one simple change flags can now be written across several lines.

**Old behavior**

```ruby
# My Class
#
# Wwww www w wwwwwww www w wwww www
# NOTE: Xxxxxx xxxxx xx xxxxxxx x xx.
# NOTE: Yyyyyy y yyy y y yyy yyy yy yyyyy yyyy
# Ppppp pppp ppp ppppp pp ppp  pppp ppppppp p pppp        <-- NOT part of the note
# pppp pp p pppppppp pppp pppppp pp.
# NOTE: Zzzzz zzzzzz zzz zzzzzz.
#
# Qqqq qq q q q qqqqq qqq q qqqq qq q qqq q qqqq q qqqq q.
class MyClass
end
```

**New Behavior**

```ruby
# My Class
#
# Wwww www w wwwwwww www w wwww www
# NOTE: Xxxxxx xxxxx xx xxxxxxx x xx.
# NOTE: Yyyyyy y yyy y y yyy yyy yy yyyyy yyyy
# yyy yyyyy y yyyy y yyyyy yyyyyyy yy yy yyyy yy            <-- Part of the note
# yyyyyyyyy yyyyyyyy y yy yy yyyy y.
# NOTE: Zzzzz zzzzzz zzz zzzzzz.
#
# Qqqq qq q q q qqqqq qqq q qqqq qq q qqq q qqqq q qqqq q.
class MyClass
end
```

cc: @Sija 