### PR TITLE
Add File and Dir empty? methods

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -30,6 +30,24 @@ describe "Dir" do
     Dir.exists?("#{__FILE__}/").should be_false
   end
 
+  describe "empty?" do
+    it "tests empty? on a full directory" do
+      Dir.empty?(File.join([__DIR__, "../"])).should be_false
+    end
+
+    it "tests empty? on an empty directory" do
+      path = "/tmp/crystal_empty_test_#{Process.pid}/"
+      Dir.mkdir(path, 0o700).should eq(0)
+      Dir.empty?(path).should be_true
+    end
+
+    it "tests empty? on nonexistent directory" do
+      expect_raises Errno do
+        Dir.empty?(File.join([__DIR__, "/foo/bar/"]))
+      end
+    end
+  end
+
   it "tests mkdir and rmdir with a new path" do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
     Dir.mkdir(path, 0o700).should eq(0)

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -74,6 +74,23 @@ describe "File" do
     idx.should eq(20)
   end
 
+  describe "empty?" do
+    it "gives true when file is empty" do
+      File.empty?("#{__DIR__}/data/blank_test_file.txt").should be_true
+    end
+
+    it "gives false when file is not empty" do
+      File.empty?("#{__DIR__}/data/test_file.txt").should be_false
+    end
+
+    it "raises an error when the file does not exist" do
+      filename = "#{__DIR__}/data/non_existing_file.txt"
+      expect_raises Errno do
+        File.empty?(filename)
+      end
+    end
+  end
+
   describe "exists?" do
     it "gives true" do
       File.exists?("#{__DIR__}/data/test_file.txt").should be_true

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -160,6 +160,15 @@ class Dir
     File::Stat.new(stat).directory?
   end
 
+  def self.empty?(path) : Bool
+    raise Errno.new("Error determining size of '#{path}'") unless exists?(path)
+
+    foreach(path) do |f|
+      return false unless {".", ".."}.includes?(f)
+    end
+    true
+  end
+
   # Creates a new directory at the given path. The linux-style permission mode
   # can be specified, with a default of 777 (0o777).
   def self.mkdir(path, mode = 0o777)

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -160,6 +160,15 @@ class Dir
     File::Stat.new(stat).directory?
   end
 
+  # Returns `true` if the directory at *path* is empty, otherwise returns `false`.
+  # Raises `Errno` if the directory at *path* does not exist.
+  #
+  # ```
+  # Dir.mkdir("bar")
+  # Dir.empty?("bar") # => true
+  # File.write("bar/a_file", "The content")
+  # Dir.empty?("bar") # => false
+  # ```
   def self.empty?(path) : Bool
     raise Errno.new("Error determining size of '#{path}'") unless exists?(path)
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -119,6 +119,14 @@ class File < IO::FileDescriptor
     accessible?(path, LibC::F_OK)
   end
 
+  def self.empty?(path) : Bool
+    begin
+      stat(path).size == 0
+    rescue Errno
+      raise Errno.new("Error determining size of '#{path}'")
+    end
+  end
+
   # Returns `true` if *path* is readable by the real user id of this process else returns `false`.
   #
   # ```

--- a/src/file.cr
+++ b/src/file.cr
@@ -119,6 +119,15 @@ class File < IO::FileDescriptor
     accessible?(path, LibC::F_OK)
   end
 
+  # Returns `true` if the file at *path* is empty, otherwise returns `false`.
+  # Raises `Errno` if the file at *path* does not exist.
+  #
+  # ```
+  # File.write("foo", "")
+  # File.empty?("foo") # => true
+  # File.write("foo", "foo")
+  # File.empty?("foo") # => false
+  # ```
   def self.empty?(path) : Bool
     begin
       stat(path).size == 0


### PR DESCRIPTION
Adds `empty?` to the `File` and `Dir` classes. Closes #2951.

This follows the proposed behavior of [this comment](https://github.com/crystal-lang/crystal/issues/2951#issuecomment-230740384). This varies from Ruby in that an error is raised if the file / dir is not found.

In terms of implementation -- the File version is [pretty much identical](https://github.com/ruby/ruby/blob/trunk/file.c#L1749) to Ruby's. Interestingly, their implementation for Dir seems to have an optimization that leverages [getattrlist](https://github.com/ruby/ruby/blob/trunk/dir.c#L2670). I didn't know if this was super valuable, but it's an optimization that could be added in a later PR. 