### PR TITLE
Move Array#zip to Indexable#zip

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1690,30 +1690,6 @@ class Array(T)
     @buffer[index] = yield @buffer[index]
   end
 
-  def zip(other : Array)
-    each_with_index do |elem, i|
-      yield elem, other[i]
-    end
-  end
-
-  def zip(other : Array(U)) forall U
-    pairs = Array({T, U}).new(size)
-    zip(other) { |x, y| pairs << {x, y} }
-    pairs
-  end
-
-  def zip?(other : Array)
-    each_with_index do |elem, i|
-      yield elem, other[i]?
-    end
-  end
-
-  def zip?(other : Array(U)) forall U
-    pairs = Array({T, U?}).new(size)
-    zip?(other) { |x, y| pairs << {x, y} }
-    pairs
-  end
-
   private def check_needs_resize
     double_capacity if @size == @capacity
   end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -405,6 +405,30 @@ module Indexable(T)
     indexes.map { |index| self[index] }
   end
 
+  def zip(other : Indexable)
+    each_with_index do |elem, i|
+      yield elem, other[i]
+    end
+  end
+
+  def zip(other : Indexable(U)) forall U
+    pairs = Array({T, U}).new(size)
+    zip(other) { |x, y| pairs << {x, y} }
+    pairs
+  end
+
+  def zip?(other : Indexable)
+    each_with_index do |elem, i|
+      yield elem, other[i]?
+    end
+  end
+
+  def zip?(other : Indexable(U)) forall U
+    pairs = Array({T, U?}).new(size)
+    zip?(other) { |x, y| pairs << {x, y} }
+    pairs
+  end
+
   private def check_index_out_of_bounds(index)
     check_index_out_of_bounds(index) { raise IndexError.new }
   end


### PR DESCRIPTION
`Array#zip` implementation is reusable on `Indexable`.