### PR TITLE
Fixes #3715 and the same problem with forall and comment

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -170,7 +170,17 @@ describe Crystal::Formatter do
   assert_format "def %(x)\n  1\nend"
   assert_format "def `(x)\n  1\nend"
   assert_format "def /(x)\n  1\nend"
-  assert_format "def foo(x : X)  forall   X ,   Y; end", "def foo(x : X) forall X, Y\nend"
+  assert_format "def foo(x : X)  forall   X ,   Y; end", "def foo(x : X) forall X, Y; end"
+
+  assert_format "def foo(a : T) forall T \n  #\nend", "def foo(a : T) forall T\n  #\nend"
+  assert_format "def foo(a : T, b : U) forall T, U\n  #\nend", "def foo(a : T, b : U) forall T, U\n  #\nend"
+  assert_format "def foo(a : T, b : U) forall T, U         #\n  #\nend", "def foo(a : T, b : U) forall T, U #\n  #\nend"
+  assert_format "def foo(a : T) forall T\n  #\n\nend", "def foo(a : T) forall T\n  #\n\nend"
+  assert_format "def foo(a : T) forall T\n  #\n\n\nend", "def foo(a : T) forall T\n  #\n\nend"
+  assert_format "def foo\n  1\n  #\nrescue\nend"
+  assert_format "def foo\n  1 #\n\nrescue\nend"
+  assert_format "def foo\n  1 #\nrescue\nend"
+  assert_format "def foo\n  1\n  #\n\n\nrescue\nend", "def foo\n  1\n  #\n\nrescue\nend"
 
   assert_format "foo"
   assert_format "foo()"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1309,18 +1309,18 @@ module Crystal
         skip_space_or_newline
         write " forall "
         next_token
+        last_index = free_vars.size - 1
         free_vars.each_with_index do |free_var, i|
           skip_space_or_newline
           check :CONST
           write free_var
-          next_token_skip_space_or_newline
+          next_token
+          skip_space_or_newline if last_index != i
           if @token.type == :","
             write ", "
             next_token_skip_space_or_newline
           end
         end
-        skip_space
-        write " "
       end
 
       body = remove_to_skip node, to_skip
@@ -3507,9 +3507,7 @@ module Crystal
       implicit_handler = false
       if node.implicit
         accept node.body
-        skip_space_or_newline
-
-        write_line
+        write_line unless skip_space_or_newline last: true
         implicit_handler = true
         column = @def_indent
       else


### PR DESCRIPTION
Fixes #3715. 
And now 
```Crystal
def foo(a : T) forall T
  #
end

def bar
  1
  #
rescue
end
```
will work fine