### PR TITLE
Array/Enumerable/Iterator reuse flag

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -136,6 +136,30 @@ describe Iterator do
       iter.next.should eq [4]
       iter.next.should be_a Iterator::Stop
     end
+
+    it "returns each_slice iterator with reuse = true" do
+      iter = (1..5).each.each_slice(2, reuse: true)
+
+      a = iter.next
+      a.should eq([1, 2])
+
+      b = iter.next
+      b.should eq([3, 4])
+      b.should be(a)
+    end
+
+    it "returns each_slice iterator with reuse = array" do
+      reuse = [] of Int32
+      iter = (1..5).each.each_slice(2, reuse: reuse)
+
+      a = iter.next
+      a.should eq([1, 2])
+      a.should be(reuse)
+
+      b = iter.next
+      b.should eq([3, 4])
+      b.should be(reuse)
+    end
   end
 
   describe "in_groups_of" do
@@ -179,6 +203,22 @@ describe Iterator do
     it "still works with other iterator methods like to_a" do
       iter = (1..3).each.in_groups_of(2, 'z')
       iter.to_a.should eq [[1, 2], [3, 'z']]
+    end
+
+    it "creats a group of two with reuse = true" do
+      iter = (1..3).each.in_groups_of(2, reuse: true)
+
+      a = iter.next
+      a.should eq([1, 2])
+
+      b = iter.next
+      b.should eq([3, nil])
+      b.should be(a)
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq [1, 2]
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -961,15 +961,22 @@ class Array(T)
   #     a.each_permutation(2) { |p| sums << p.sum } #=> [1, 2, 3]
   #     sums #=> [3, 4, 3, 5, 4, 5]
   #
-  def each_permutation(size : Int = self.size)
+  # By default, a new array is created and yielded for each permutation.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  def each_permutation(size : Int = self.size, reuse = false)
     n = self.size
     return self if size > n
 
     raise ArgumentError.new("size must be positive") if size < 0
 
+    reuse = check_reuse(reuse, size)
     pool = self.dup
     cycles = (n - size + 1..n).to_a.reverse!
-    yield pool[0, size]
+    yield pool_slice(pool, size, reuse)
 
     while true
       stop = true
@@ -983,7 +990,7 @@ class Array(T)
           cycles[i] = n - i
         else
           pool.swap i, -ci
-          yield pool[0, size]
+          yield pool_slice(pool, size, reuse)
           stop = false
           break
         end
@@ -1006,10 +1013,17 @@ class Array(T)
   # iter.next # => [3, 2, 1]
   # iter.next # => Iterator::Stop
   # ```
-  def each_permutation(size : Int = self.size)
+  #
+  # By default, a new array is created and returned for each permutation.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  def each_permutation(size : Int = self.size, reuse = false)
     raise ArgumentError.new("size must be positive") if size < 0
 
-    PermutationIterator.new(self, size.to_i)
+    PermutationIterator.new(self, size.to_i, reuse)
   end
 
   def combinations(size : Int = self.size)
@@ -1020,16 +1034,18 @@ class Array(T)
     ary
   end
 
-  def each_combination(size : Int = self.size)
+  def each_combination(size : Int = self.size, reuse = false)
     n = self.size
     return self if size > n
     raise ArgumentError.new("size must be positive") if size < 0
 
+    reuse = check_reuse(reuse, size)
     copy = self.dup
     pool = self.dup
 
     indices = (0...size).to_a
-    yield pool[0, size]
+
+    yield pool_slice(pool, size, reuse)
 
     while true
       stop = true
@@ -1052,14 +1068,35 @@ class Array(T)
         pool[j] = copy[indices[j]]
       end
 
-      yield pool[0, size]
+      yield pool_slice(pool, size, reuse)
     end
   end
 
-  def each_combination(size : Int = self.size)
+  private def each_combination_piece(pool, size, reuse)
+    if reuse
+      reuse.clear
+      size.times { |i| reuse << pool[i] }
+      reuse
+    else
+      pool[0, size]
+    end
+  end
+
+  def each_combination(size : Int = self.size, reuse = false)
     raise ArgumentError.new("size must be positive") if size < 0
 
-    CombinationIterator.new(self, size.to_i)
+    CombinationIterator.new(self, size.to_i, reuse)
+  end
+
+  private def check_reuse(reuse, size)
+    if reuse
+      unless reuse.is_a?(Array)
+        reuse = typeof(self).new(size)
+      end
+    else
+      reuse = nil
+    end
+    reuse
   end
 
   # Returns a new Array that is a one-dimensional flattening of self (recursively).
@@ -1084,16 +1121,17 @@ class Array(T)
     ary
   end
 
-  def each_repeated_combination(size : Int = self.size)
+  def each_repeated_combination(size : Int = self.size, reuse = false)
     n = self.size
     return self if size > n && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
 
+    reuse = check_reuse(reuse, size)
     copy = self.dup
     indices = Array.new(size, 0)
     pool = indices.map { |i| copy[i] }
 
-    yield pool[0, size]
+    yield pool_slice(pool, size, reuse)
 
     while true
       stop = true
@@ -1113,14 +1151,14 @@ class Array(T)
       indices.fill(i, size - i) { ii }
       pool.fill(i, size - i) { tmp }
 
-      yield pool[0, size]
+      yield pool_slice(pool, size, reuse)
     end
   end
 
-  def each_repeated_combination(size : Int = self.size)
+  def each_repeated_combination(size : Int = self.size, reuse = false)
     raise ArgumentError.new("size must be positive") if size < 0
 
-    RepeatedCombinationIterator.new(self, size.to_i)
+    RepeatedCombinationIterator.new(self, size.to_i, reuse)
   end
 
   def self.product(arrays)
@@ -1135,13 +1173,23 @@ class Array(T)
     product(arrays.to_a)
   end
 
-  def self.each_product(arrays)
+  def self.each_product(arrays : Array(Array), reuse = false)
     pool = arrays.map &.first
     lens = arrays.map &.size
     return if lens.any? &.==(0)
+
     n = arrays.size
     indices = Array.new(n, 0)
-    yield pool[0, n]
+
+    if reuse
+      unless reuse.is_a?(Array)
+        reuse = typeof(pool).new(n)
+      end
+    else
+      reuse = nil
+    end
+
+    yield pool_slice(pool, n, reuse)
 
     while true
       i = n - 1
@@ -1155,12 +1203,12 @@ class Array(T)
         indices[i] += 1
       end
       pool[i] = arrays[i][indices[i]]
-      yield pool[0, n]
+      yield pool_slice(pool, n, reuse)
     end
   end
 
-  def self.each_product(*arrays : Array)
-    each_product(arrays.to_a) do |result|
+  def self.each_product(*arrays : Array, reuse = false)
+    each_product(arrays.to_a, reuse: reuse) do |result|
       yield result
     end
   end
@@ -1173,7 +1221,7 @@ class Array(T)
     ary
   end
 
-  def each_repeated_permutation(size : Int = self.size)
+  def each_repeated_permutation(size : Int = self.size, reuse = false)
     n = self.size
     return self if size != 0 && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
@@ -1181,7 +1229,7 @@ class Array(T)
     if size == 0
       yield([] of T)
     else
-      Array.each_product(Array.new(size, self)) { |r| yield r }
+      Array.each_product(Array.new(size, self), reuse: reuse) { |r| yield r }
     end
 
     self
@@ -1952,14 +2000,23 @@ class Array(T)
     @stop : Bool
     @i : Int32
     @first : Bool
+    @reuse : Array(T)?
 
-    def initialize(@array : Array(T), @size)
+    def initialize(@array : Array(T), @size, reuse)
       @n = @array.size
       @cycles = (@n - @size + 1..@n).to_a.reverse!
       @pool = @array.dup
       @stop = @size > @n
       @i = @size - 1
       @first = true
+
+      if reuse
+        if reuse.is_a?(Array)
+          @reuse = reuse
+        else
+          @reuse = Array(T).new(@size)
+        end
+      end
     end
 
     def next
@@ -1967,7 +2024,7 @@ class Array(T)
 
       if @first
         @first = false
-        return @pool[0, @size]
+        return pool_slice(@pool, @size, @reuse)
       end
 
       while @i >= 0
@@ -1979,7 +2036,7 @@ class Array(T)
           @cycles[@i] = @n - @i
         else
           @pool.swap @i, -ci
-          value = @pool[0, @size]
+          value = pool_slice(@pool, @size, @reuse)
           @i = @size - 1
           return value
         end
@@ -2011,8 +2068,9 @@ class Array(T)
     @stop : Bool
     @i : Int32
     @first : Bool
+    @reuse : Array(T)?
 
-    def initialize(array : Array(T), @size)
+    def initialize(array : Array(T), @size, reuse)
       @n = array.size
       @copy = array.dup
       @pool = array.dup
@@ -2020,6 +2078,14 @@ class Array(T)
       @stop = @size > @n
       @i = @size - 1
       @first = true
+
+      if reuse
+        if reuse.is_a?(Array)
+          @reuse = reuse
+        else
+          @reuse = Array(T).new(@size)
+        end
+      end
     end
 
     def next
@@ -2027,7 +2093,7 @@ class Array(T)
 
       if @first
         @first = false
-        return @pool[0, @size]
+        return pool_slice(@pool, @size, @reuse)
       end
 
       while @i >= 0
@@ -2040,7 +2106,7 @@ class Array(T)
             @pool[j] = @copy[@indices[j]]
           end
 
-          value = @pool[0, @size]
+          value = pool_slice(@pool, @size, @reuse)
           @i = @size - 1
           return value
         end
@@ -2072,8 +2138,9 @@ class Array(T)
     @stop : Bool
     @i : Int32
     @first : Bool
+    @reuse : Array(T)?
 
-    def initialize(array : Array(T), @size)
+    def initialize(array : Array(T), @size, reuse)
       @n = array.size
       @copy = array.dup
       @indices = Array.new(@size, 0)
@@ -2081,6 +2148,14 @@ class Array(T)
       @stop = @size > @n
       @i = @size - 1
       @first = true
+
+      if reuse
+        if reuse.is_a?(Array)
+          @reuse = reuse
+        else
+          @reuse = Array(T).new(@size)
+        end
+      end
     end
 
     def next
@@ -2088,7 +2163,7 @@ class Array(T)
 
       if @first
         @first = false
-        return @pool[0, @size]
+        return pool_slice(@pool, @size, @reuse)
       end
 
       while @i >= 0
@@ -2098,7 +2173,7 @@ class Array(T)
           @indices.fill(@i, @size - @i) { ii }
           @pool.fill(@i, @size - @i) { tmp }
 
-          value = @pool[0, @size]
+          value = pool_slice(@pool, @size, @reuse)
           @i = @size - 1
           return value
         end
@@ -2145,5 +2220,15 @@ class Array(T)
         ary
       end
     end
+  end
+end
+
+private def pool_slice(pool, size, reuse)
+  if reuse
+    reuse.clear
+    size.times { |i| reuse << pool[i] }
+    reuse
+  else
+    pool[0, size]
   end
 end

--- a/src/iterable.cr
+++ b/src/iterable.cr
@@ -19,18 +19,18 @@ module Iterable(T)
   #     (0..7).chunk(&./(3)).to_a => [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7]}]
   #
   # See `Iterator#chunks`
-  def chunk(&block : T -> U) forall U
-    each.chunk &block
+  def chunk(reuse = false, &block : T -> U) forall U
+    each.chunk reuse, &block
   end
 
-  # Same as `each.slice(count)`.
-  def each_slice(count : Int)
-    each.slice(count)
+  # Same as `each.slice(count, reuse)`.
+  def each_slice(count : Int, reuse = false)
+    each.slice(count, reuse)
   end
 
   # Same as `each.cons(count)`.
-  def each_cons(count : Int)
-    each.cons(count)
+  def each_cons(count : Int, reuse = false)
+    each.cons(count, reuse)
   end
 
   # Same as `each.with_index(offset)`.

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -230,17 +230,33 @@ module Iterator(T)
   #     iter.next # => [3, 4, 5]
   #     iter.next # => Iterator::Stop::INSTANCE
   #
-  def cons(n : Int)
+  # By default, a new array is returned for each consecutive slice when invoking `next`.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  def cons(n : Int, reuse = false)
     raise ArgumentError.new "invalid cons size: #{n}" if n <= 0
-    Cons(typeof(self), T, typeof(n)).new(self, n)
+    Cons(typeof(self), T, typeof(n)).new(self, n, reuse)
   end
 
   private struct Cons(I, T, N)
     include Iterator(Array(T))
     include IteratorWrapper
 
-    def initialize(@iterator : I, @n : N)
-      @values = Array(T).new(@n)
+    def initialize(@iterator : I, @n : N, reuse)
+      if reuse
+        if reuse.is_a?(Array)
+          @values = reuse
+        else
+          @values = Array(T).new(@n)
+        end
+        @reuse = true
+      else
+        @values = Array(T).new(@n)
+        @reuse = false
+      end
     end
 
     def next
@@ -250,7 +266,12 @@ module Iterator(T)
         @values.shift if @values.size > @n
         break if @values.size == @n
       end
-      @values.dup
+
+      if @reuse
+        @values
+      else
+        @values.dup
+      end
     end
 
     def rewind
@@ -364,8 +385,14 @@ module Iterator(T)
   #     iter.next # => [7, 8, 9]
   #     iter.next # => Iterator::Stop::INSTANCE
   #
-  def each_slice(n)
-    slice(n)
+  # By default, a new array is returned for each silce when invoking `next`.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  def each_slice(n, reuse = false)
+    slice(n, reuse)
   end
 
   # Returns an iterator that flattens nested iterators and arrays into a single iterator
@@ -462,21 +489,45 @@ module Iterator(T)
   #     iter.next # => [3, 'z']
   #     iter.next # => Iterator::Stop::INSTANCE
   #
-  def in_groups_of(size : Int, filled_up_with = nil)
+  # By default, a new array is created and yielded for each group.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  def in_groups_of(size : Int, filled_up_with = nil, reuse = false)
     raise ArgumentError.new("size must be positive") if size <= 0
-    InGroupsOf(typeof(self), T, typeof(size), typeof(filled_up_with)).new(self, size, filled_up_with)
+    InGroupsOf(typeof(self), T, typeof(size), typeof(filled_up_with)).new(self, size, filled_up_with, reuse)
   end
 
   private struct InGroupsOf(I, T, N, U)
     include Iterator(Array(T | U))
     include IteratorWrapper
 
-    def initialize(@iterator : I, @size : N, @filled_up_with : U)
+    @reuse : Array(T | U)?
+
+    def initialize(@iterator : I, @size : N, @filled_up_with : U, reuse)
+      if reuse
+        if reuse.is_a?(Array)
+          @reuse = reuse
+        else
+          @reuse = Array(T | U).new(@size)
+        end
+      else
+        @reuse = nil
+      end
     end
 
     def next
       value = wrapped_next
-      array = Array(T | U).new(@size)
+
+      if reuse = @reuse
+        reuse.clear
+        array = reuse
+      else
+        array = Array(T | U).new(@size)
+      end
+
       array << value
       (@size - 1).times do
         new_value = @iterator.next
@@ -643,29 +694,38 @@ module Iterator(T)
     end
   end
 
-  # Returns an iterator that returns slices of n elements of the initial
-  # iterator.
-  #
-  #     iter = (1..9).each.slice(3)
-  #     iter.next # => [1, 2, 3]
-  #     iter.next # => [4, 5, 6]
-  #     iter.next # => [7, 8, 9]
-  #     iter.next # => Iterator::Stop::INSTANCE
-  #
-  def slice(n : Int)
+  # Alias of `each_slice`
+  def slice(n : Int, reuse = false)
     raise ArgumentError.new "invalid slice size: #{n}" if n <= 0
-    Slice(typeof(self), T, typeof(n)).new(self, n)
+    Slice(typeof(self), T, typeof(n)).new(self, n, reuse)
   end
 
   private struct Slice(I, T, N)
     include Iterator(Array(T))
     include IteratorWrapper
 
-    def initialize(@iterator : I, @n : N)
+    @reuse : Array(T)?
+
+    def initialize(@iterator : I, @n : N, reuse)
+      if reuse
+        if reuse.is_a?(Array)
+          @reuse = reuse
+        else
+          @reuse = Array(T).new(@n)
+        end
+      else
+        @reuse = nil
+      end
     end
 
     def next
-      values = Array(T).new(@n)
+      if reuse = @reuse
+        reuse.clear
+        values = reuse
+      else
+        values = Array(T).new(@n)
+      end
+
       @n.times do
         value = @iterator.next
         break if value.is_a?(Stop)
@@ -996,21 +1056,34 @@ module Iterator(T)
   # * `Enumerable::Chunk::Drop` specifies that the elements should be dropped
   # * `Enumerable::Chunk::Alone` specifies that the element should be chunked by itself
   #
+  # By default, a new array is returned for each chunk when invoking `next`.
+  # If *reuse* is given, the array can be reused: if *reuse* is
+  # an `Array`, this array will be reused; if *reuse* if truthy,
+  # the method will create a new array and reuse it. This can be
+  # used to prevent many memory allocations when each slice of
+  # interest is to be used in a read-only fashion.
+  #
   # See also: `Enumerable#chunks`
-  def chunk(&block : T -> U) forall T, U
-    Chunk(typeof(self), T, U).new(self, &block)
+  def chunk(reuse = false, &block : T -> U) forall T, U
+    Chunk(typeof(self), T, U).new(self, reuse, &block)
   end
 
   # :nodoc:
   class Chunk(I, T, U)
     include Iterator(Tuple(U, Array(T)))
     @iterator : I
+    @init : {U, T}?
 
-    def initialize(@iterator : Iterator(T), &@original_block : T -> U)
-      @acc = Enumerable::Chunk::Accumulator(T, U).new
+    def initialize(@iterator : Iterator(T), reuse, &@original_block : T -> U)
+      @acc = Enumerable::Chunk::Accumulator(T, U).new(reuse)
     end
 
     def next
+      if init = @init
+        @acc.init(*init)
+        @init = nil
+      end
+
       @iterator.each do |val|
         key = @original_block.call(val)
 
@@ -1018,8 +1091,12 @@ module Iterator(T)
           @acc.add(val)
         else
           tuple = @acc.fetch
-          @acc.init(key, val)
-          return tuple if tuple
+          if tuple
+            @init = {key, val}
+            return tuple
+          else
+            @acc.init(key, val)
+          end
         end
       end
 
@@ -1035,7 +1112,9 @@ module Iterator(T)
     end
 
     private def init_state
-      @acc = Enumerable::Chunk::Accumulator(T, U).new
+      @init = nil
+      @acc.reset
+      self
     end
   end
 end


### PR DESCRIPTION
This adds an optional argument `reuse` to some Array, Enumerable and Iterator methods.

Crystal, like Ruby, provides many methods to iterate through chunks of an enumerable/array/iterator. For example:

```cr
r = (1..10)

# Compute sums of each consecutive slice of 2 elements
p r.each_slice(2).map { |s| s.sum }.to_a  # => [3, 7, 11, 15, 19]
```

While I really like these methods, they aren't particularly efficient: a new array is created each time the block is executed (in this case, every `s` is a different array). Because of this, I sometimes choose not to use these methods and instead do something more manual, so performance is better, less memory is allocated and there's less pressure on the GC... specially in tight loops or bottlenecks.

However, I'd say that in most cases we use these "slices" or chunks of data as read-only data. In the above case we are interested in the sum of each slice. A single array could be created and reused for every slice. This is what the `reuse` optional argument is about. We can rewrite the above like this:

```cr
r = (1..10)
p r.each_slice(2, reuse: true).map { |s| s.sum }.to_a  # => [3, 7, 11, 15, 19]
```

We get the same result, but only a single array is created: `s` will be the same array in every iteration, but with different contents each time.

To show how performance is improved, I made this program:

```cr
# foo.cr
r = (1..10_000_000)

reuse = ENV["REUSE"]? == "1"

time = Time.now
s = 0
r.chunk(reuse: reuse, &.itself).each do |x, a|
  s += a.sum
end
puts "chunk: #{Time.now - time} (#{s})"

time = Time.now
s = 0
r.each_slice(3, reuse: reuse) do |a|
  s += a.sum
end
puts "each_slice: #{Time.now - time} (#{s})"

a = (1..50).to_a

time = Time.now
s = 0
a.each_permutation(3, reuse: reuse) do |a|
  s += a.sum
end
puts "each_permutation: #{Time.now - time} (#{s})"

time = Time.now
s = 0
a.each_combination(3, reuse: reuse) do |a|
  s += a.sum
end
puts "each_combination: #{Time.now - time} (#{s})"

time = Time.now
s = 0
a.each_repeated_combination(3, reuse: reuse) do |a|
  s += a.sum
end
puts "each_repeated_combination: #{Time.now - time} (#{s})"

time = Time.now
s = 0
r.each_cons(3, reuse: reuse) do |a|
  s += a.sum
end
puts "each_cons: #{Time.now - time} (#{s})"
```

We compile it with `--release` and then run it with REUSE=0 and REUSE=1:

```
$ time REUSE=0 ./foo
chunk: 00:00:00.9652130 (-2004260032)
each_slice: 00:00:00.3240950 (-2004260032)
each_permutation: 00:00:00.0137700 (8996400)
each_combination: 00:00:00.0022050 (1499400)
each_repeated_combination: 00:00:00.0025910 (1690650)
each_cons: 00:00:01.5072000 (-1747812803)

real  0m2.822s
user  0m1.751s
sys 0m2.645s

$ time REUSE=1 ./foo
chunk: 00:00:00.1730330 (-2004260032)
each_slice: 00:00:00.0424320 (-2004260032)
each_permutation: 00:00:00.0028600 (8996400)
each_combination: 00:00:00.0004450 (1499400)
each_repeated_combination: 00:00:00.0004990 (1690650)
each_cons: 00:00:00.1141390 (-1747812803)

real  0m0.340s
user  0m0.334s
sys 0m0.004s
```

In some cases we get more than a 10x performance improvement. 
