### PR TITLE
Added HTTP::Server.run method

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -149,6 +149,14 @@ class HTTP::Server
     end
   end
 
+  def run
+    if server = @server
+      until @wants_close
+        spawn handle_client(server.accept?)
+      end
+    end
+  end
+
   def close
     @wants_close = true
     @processor.close


### PR DESCRIPTION
Hi, today I just discovered the Crystal language and was amazed with performance of HTTP server.

I was trying to implement the fork model based multi process HTTP server but I ran into the problem that once you start listen to the TCPServer I am unable to fork anymore so I add one more method to allow use `HTTP::Server.bind` & `HTTP::Server.run` to make possible fork the process and then start accepting connections.

Here is my small code example I was trying to test

```crystal
require "http"

server = HTTP::Server.new(3000) do |context|
  context.response.content_type = "text/plain"
  context.response.print "Hello world, got #{Process.pid}!"
end

server.bind

puts "Listening on http://127.0.0.1:3000"

process = nil
4.times do |i|  
  process = Process.fork

  if (nil == process)
    server.run
    exit
  end
end
  
process.as(Process).wait()
```

Here is performance difference between single process and 4 process.

```
Running 20s test @ http://127.0.0.1:3000/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.35ms  425.43us  10.29ms   76.25%
    Req/Sec    37.04k     5.02k   51.45k    61.00%
  1474238 requests in 20.01s, 156.06MB read
Requests/sec:  73663.69
Transfer/sec:      7.80MB
```

```
Running 20s test @ http://127.0.0.1:3000/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.13ms  360.19us  15.57ms   85.06%
    Req/Sec    44.28k     5.57k   50.56k    70.75%
  1761893 requests in 20.01s, 186.51MB read
Requests/sec:  88032.69
Transfer/sec:      9.32MB
```

Difference is not so big as I was only running 2 threads but still really not bad improvement and ability to extend HTTP server to work bit differently then intended.

P.S. I am yet not much familiar with project so if I miss something please tell me I will try to help.
P.P.S I opened this pull request as open discussion on this topic.