### PR TITLE
Make Array#swap dangerous

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1056,14 +1056,16 @@ describe "Array" do
   describe "swap" do
     it "swaps" do
       a = [1, 2, 3]
-      a.swap(0, 2)
-      a.should eq([3, 2, 1])
+      b = a.swap(0, 2)
+      a.should eq([1, 2, 3])
+      b.should eq([3, 2, 1])
     end
 
     it "swaps with negative indices" do
       a = [1, 2, 3]
-      a.swap(-3, -1)
-      a.should eq([3, 2, 1])
+      b = a.swap(-3, -1)
+      a.should eq([1, 2, 3])
+      b.should eq([3, 2, 1])
     end
 
     it "swaps but raises out of bounds on left" do
@@ -1077,6 +1079,34 @@ describe "Array" do
       a = [1, 2, 3]
       expect_raises IndexError do
         a.swap(0, 3)
+      end
+    end
+  end
+
+  describe "swap!" do
+    it "swaps" do
+      a = [1, 2, 3]
+      a.swap!(0, 2)
+      a.should eq([3, 2, 1])
+    end
+
+    it "swaps with negative indices" do
+      a = [1, 2, 3]
+      a.swap!(-3, -1)
+      a.should eq([3, 2, 1])
+    end
+
+    it "swaps but raises out of bounds on left" do
+      a = [1, 2, 3]
+      expect_raises IndexError do
+        a.swap!(3, 0)
+      end
+    end
+
+    it "swaps but raises out of bounds on right" do
+      a = [1, 2, 3]
+      expect_raises IndexError do
+        a.swap!(0, 3)
       end
     end
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -989,7 +989,7 @@ class Array(T)
           pool[n - 1] = e
           cycles[i] = n - i
         else
-          pool.swap i, -ci
+          pool.swap! i, -ci
           yield pool_slice(pool, size, reuse)
           stop = false
           break
@@ -1562,7 +1562,7 @@ class Array(T)
     self
   end
 
-  def swap(index0, index1)
+  private def internal_swap(index0, index1, arr)
     index0 += size if index0 < 0
     index1 += size if index1 < 0
 
@@ -1570,8 +1570,31 @@ class Array(T)
       raise IndexError.new
     end
 
-    @buffer[index0], @buffer[index1] = @buffer[index1], @buffer[index0]
+    arr[index0], arr[index1] = arr[index1], arr[index0]
+    arr
+  end
 
+  # Returns a new array with elements at *index0* and *index1* swapped. If the
+  # arguments are negative, indices are counted from the end of the array. 
+  #
+  # ```
+  # a = [1, 2, 3]
+  # a.swap(0, 2) # => [3, 2, 1]
+  # ```
+  def swap(index0, index1)
+    internal_swap(index0, index1, dup)
+  end
+
+  # Modifies `self` in place so that elements at *index0* and *index1* are
+  # swapped. If the arguments are negative, indices are counted from the end of
+  # the array.
+  #
+  # ```
+  # a = [1, 2, 3]
+  # a.swap!(0, 2) # => [3, 2, 1]
+  # ```
+  def swap!(index0, index1)
+    internal_swap(index0, index1, @buffer)
     self
   end
 
@@ -2037,7 +2060,7 @@ class Array(T)
           @pool[@n - 1] = e
           @cycles[@i] = @n - @i
         else
-          @pool.swap @i, -ci
+          @pool.swap! @i, -ci
           value = pool_slice(@pool, @size, @reuse)
           @i = @size - 1
           return value


### PR DESCRIPTION
By modifying `self` in place, Array#swap was "dangerous". I've moved that functionality to Array#swap! and created a new Array#swap that operates on a duplicate array.