### PR TITLE
Add :nodoc: to Class#crystal_instance_type_id

### DIFF
--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -52,6 +52,7 @@ class Reference
 end
 
 class Class
+  # :nodoc:
   @[Primitive(:class_crystal_instance_type_id)]
   def crystal_instance_type_id
   end


### PR DESCRIPTION
Same as for `Object#crystal_type_id`.