### PR TITLE
Allow 'private macro' inside classes

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -547,7 +547,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "erros if applying protected modifier to macro" do
+  it "errors if applying protected modifier to macro" do
     assert_error %(
       class Foo
         protected macro foo

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -547,14 +547,16 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors if using private on non-top-level macro" do
+  it "erros if applying protected modifier to macro" do
     assert_error %(
       class Foo
-        private macro bar
+        protected macro foo
+          1
         end
       end
-      ),
-      "private macros can only be declared at the top-level"
+
+      Foo.foo
+    ), "can only use 'private' for macros"
   end
 
   it "expands macro with break inside while (#1852)" do

--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -125,6 +125,52 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
+  it "find module private macro inside the module" do
+    assert_type(%(
+      class Foo
+        private macro foo
+          def bar
+            1
+          end
+        end
+
+        foo
+      end
+
+      Foo.new.bar
+      )) { int32 }
+  end
+
+  it "find module private macro inside a module, which is inherited by the module" do
+    assert_type(%(
+      class Foo
+        private macro foo
+          def bar
+            1
+          end
+        end
+      end
+
+      class Bar < Foo
+        foo
+      end
+
+      Bar.new.bar
+      )) { int32 }
+  end
+
+  it "doesn't find module private macro outside the module" do
+    assert_error %(
+      class Foo
+        private macro foo
+          1
+        end
+      end
+
+      Foo.foo
+    ), "private macro 'foo' called for Foo"
+  end
+
   it "finds private def when invoking from inside macro (#2082)" do
     assert_type(%(
       private def foo

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -268,6 +268,8 @@ module Base64
     end
   end
 
+  # TODO: uncomment if release 'private macro'
+  # private macro next_decoded_value
   # :nodoc:
   macro next_decoded_value
     sym = cstr.value

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -485,6 +485,7 @@ class Crystal::Call
 
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros
+    macros = macros.reject &.visibility.private?
 
     if macros.size == 1
       if msg = check_named_args_and_splats(macros.first, named_args)

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -238,6 +238,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
       macro_scope = macro_scope.remove_alias
 
       the_macro = macro_scope.metaclass.lookup_macro(node.name, node.args, node.named_args)
+      node.raise "private macro '#{node.name}' called for #{obj}" if the_macro && the_macro.visibility.private?
     when Nil
       return false if node.name == "super" || node.name == "previous_def"
       the_macro = node.lookup_macro

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -654,11 +654,11 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     when Def
       return false
     when Macro
-      if current_type != @program.program
-        node.raise "#{node.modifier.to_s.downcase} macros can only be declared at the top-level"
+      if node.modifier.private?
+        return false
+      else
+        node.raise "can only use 'private' for macros"
       end
-
-      return false
     when Call
       # Don't give an error yet: wait to see if the
       # call doesn't resolve to a method/macro

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -210,7 +210,7 @@ class Crystal::Doc::Type
       macros = [] of Macro
       @type.metaclass.macros.try &.each_value do |the_macros|
         the_macros.each do |a_macro|
-          if @generator.must_include? a_macro
+          if a_macro.visibility.public? && @generator.must_include? a_macro
             macros << self.macro(a_macro)
           end
         end

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -261,6 +261,8 @@ module Debug
         end
       end
 
+      # TODO: uncomment if release 'private macro'
+      # private macro increment_address_and_op_index(operation_advance)
       # :nodoc:
       macro increment_address_and_op_index(operation_advance)
         if sequence.maximum_operations_per_instruction == 1


### PR DESCRIPTION
I know Crystal has file-level `private macro`, but no class-level `private macro`. In some case, we want class-level `private macro`. For example, [Base64 class has a `:nodoc:`-ed macro `next_decode_value`](https://github.com/crystal-lang/crystal/blob/e45144c764ed7188252e6f423e680f9337b2400a/src/base64.cr#L271-L272). If we had class-level `private macro`, it uses `private macro` without `:nodoc:`.