### PR TITLE
Allow Time::Span to be divided by Time::Span

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -207,6 +207,14 @@ describe Time::Span do
     # TODO check overflow
   end
 
+  it "divides by another Time::Span" do
+    ratio = 20.minutes / 15.seconds
+    ratio.should eq(80.0)
+
+    ratio2 = 45.seconds / 1.minute
+    ratio2.should eq(0.75)
+  end
+
   it "test to_s" do
     t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -224,6 +224,10 @@ struct Time::Span
     Span.new(ticks / number)
   end
 
+  def /(other : self)
+    ticks.to_f64 / other.ticks.to_f64
+  end
+
   def <=>(other : self)
     ticks <=> other.ticks
   end


### PR DESCRIPTION
Dividing a time span by a time span gives a ratio. This is useful for example for working out the number of periods in a larger time (e.g. `time_span / 15.seconds`).