### PR TITLE
Sockets refactor: allow any family/type/protocol association

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -310,10 +310,19 @@ end
 
 describe TCPServer do
   it "fails when port is in use" do
+    port = free_udp_socket_port
+
     expect_raises Errno, /(already|Address) in use/ do
-      TCPServer.open("::", 0) do |server|
-        TCPServer.open("::", server.local_address.port) { }
-      end
+      sock = Socket.tcp(Socket::Family::INET6)
+      sock.bind(Socket::IPAddress.new("::1", port))
+
+      TCPServer.open("::1", port) {}
+    end
+  end
+
+  it "allows to share the same port (SO_REUSEPORT)" do
+    TCPServer.open("::", 0) do |server|
+      TCPServer.open("::", server.local_address.port) {}
     end
   end
 end

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -212,8 +212,7 @@ class Errno < Exception
   #   raise Errno.new("some_call")
   # end
   # ```
-  def initialize(message)
-    errno = Errno.value
+  def initialize(message, errno = Errno.value)
     @errno = errno
     super "#{message}: #{String.new(LibC.strerror(errno))}"
   end

--- a/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/socket.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/socket.cr
@@ -36,6 +36,14 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_len : UChar
+    ss_family : SaFamilyT
+    __ss_pad1 : StaticArray(Char, 6)
+    __ss_pad2 : ULongLong
+    __ss_pad3 : StaticArray(Char, 240)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/socket.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 0x0080
   SO_RCVBUF      = 0x1002
   SO_REUSEADDR   = 0x0004
+  SO_REUSEPORT   = 0x0200
   SO_SNDBUF      = 0x1001
   PF_INET        = LibC::AF_INET
   PF_INET6       = LibC::AF_INET6

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/i686-linux-gnu/c/netdb.cr
+++ b/src/lib_c/i686-linux-gnu/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     = 0x0001
+  AI_CANONNAME   = 0x0002
+  AI_NUMERICHOST = 0x0004
+  AI_NUMERICSERV = 0x0400
+  AI_V4MAPPED    = 0x0008
+  AI_ALL         = 0x0010
+  AI_ADDRCONFIG  = 0x0020
+  EAI_AGAIN      =     -3
+  EAI_BADFLAGS   =     -1
+  EAI_FAIL       =     -4
+  EAI_FAMILY     =     -6
+  EAI_MEMORY     =    -10
+  EAI_NONAME     =     -2
+  EAI_SERVICE    =     -8
+  EAI_SOCKTYPE   =     -7
+  EAI_SYSTEM     =    -11
+  EAI_OVERFLOW   =    -12
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(ai : Addrinfo*) : Void
   fun gai_strerror(ecode : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(name : Char*, service : Char*, req : Addrinfo*, pai : Addrinfo**) : Int
+  fun getnameinfo(sa : Sockaddr*, salen : SocklenT, host : Char*, hostlen : SocklenT, serv : Char*, servlen : SocklenT, flags : Int) : Int
 end

--- a/src/lib_c/i686-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-gnu/c/sys/socket.cr
@@ -35,6 +35,12 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_family : SaFamilyT
+    __ss_align : ULong
+    __ss_padding : StaticArray(Char, 120)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int
@@ -47,10 +53,10 @@ lib LibC
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int
   fun listen(fd : Int, n : Int) : Int
-  fun recv(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
-  fun recvfrom(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
-  fun send(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
-  fun sendto(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
+  fun recv(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
+  fun recvfrom(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
+  fun send(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
+  fun sendto(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
   fun setsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(fd : Int, how : Int) : Int
   fun socket(domain : Int, type : Int, protocol : Int) : Int

--- a/src/lib_c/i686-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-gnu/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/i686-linux-musl/c/netdb.cr
+++ b/src/lib_c/i686-linux-musl/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     =  0x01
+  AI_CANONNAME   =  0x02
+  AI_NUMERICHOST =  0x04
+  AI_NUMERICSERV = 0x400
+  AI_V4MAPPED    =  0x08
+  AI_ALL         =  0x10
+  AI_ADDRCONFIG  =  0x20
+  EAI_AGAIN      =    -3
+  EAI_BADFLAGS   =    -1
+  EAI_FAIL       =    -4
+  EAI_FAMILY     =    -6
+  EAI_MEMORY     =   -10
+  EAI_NONAME     =    -2
+  EAI_SERVICE    =    -8
+  EAI_SOCKTYPE   =    -7
+  EAI_SYSTEM     =   -11
+  EAI_OVERFLOW   =   -12
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(x0 : Addrinfo*) : Void
   fun gai_strerror(x0 : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(x0 : Char*, x1 : Char*, x2 : Addrinfo*, x3 : Addrinfo**) : Int
+  fun getnameinfo(x0 : Sockaddr*, x1 : SocklenT, x2 : Char*, x3 : SocklenT, x4 : Char*, x5 : SocklenT, x6 : Int) : Int
 end

--- a/src/lib_c/i686-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-musl/c/sys/socket.cr
@@ -35,6 +35,12 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_family : SaFamilyT
+    __ss_align : ULong
+    __ss_padding : StaticArray(Char, 112)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int

--- a/src/lib_c/i686-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/i686-linux-musl/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/x86_64-linux-gnu/c/netdb.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     = 0x0001
+  AI_CANONNAME   = 0x0002
+  AI_NUMERICHOST = 0x0004
+  AI_NUMERICSERV = 0x0400
+  AI_V4MAPPED    = 0x0008
+  AI_ALL         = 0x0010
+  AI_ADDRCONFIG  = 0x0020
+  EAI_AGAIN      =     -3
+  EAI_BADFLAGS   =     -1
+  EAI_FAIL       =     -4
+  EAI_FAMILY     =     -6
+  EAI_MEMORY     =    -10
+  EAI_NONAME     =     -2
+  EAI_SERVICE    =     -8
+  EAI_SOCKTYPE   =     -7
+  EAI_SYSTEM     =    -11
+  EAI_OVERFLOW   =    -12
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(ai : Addrinfo*) : Void
   fun gai_strerror(ecode : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(name : Char*, service : Char*, req : Addrinfo*, pai : Addrinfo**) : Int
+  fun getnameinfo(sa : Sockaddr*, salen : SocklenT, host : Char*, hostlen : SocklenT, serv : Char*, servlen : SocklenT, flags : Int) : Int
 end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -35,6 +35,12 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_family : SaFamilyT
+    __ss_align : ULong
+    __ss_padding : StaticArray(Char, 112)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int
@@ -47,10 +53,10 @@ lib LibC
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int
   fun listen(fd : Int, n : Int) : Int
-  fun recv(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
-  fun recvfrom(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
-  fun send(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
-  fun sendto(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
+  fun recv(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
+  fun recvfrom(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
+  fun send(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
+  fun sendto(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
   fun setsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(fd : Int, how : Int) : Int
   fun socket(domain : Int, type : Int, protocol : Int) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/x86_64-linux-musl/c/netdb.cr
+++ b/src/lib_c/x86_64-linux-musl/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     =  0x01
+  AI_CANONNAME   =  0x02
+  AI_NUMERICHOST =  0x04
+  AI_NUMERICSERV = 0x400
+  AI_V4MAPPED    =  0x08
+  AI_ALL         =  0x10
+  AI_ADDRCONFIG  =  0x20
+  EAI_AGAIN      =    -3
+  EAI_BADFLAGS   =    -1
+  EAI_FAIL       =    -4
+  EAI_FAMILY     =    -6
+  EAI_MEMORY     =   -10
+  EAI_NONAME     =    -2
+  EAI_SERVICE    =    -8
+  EAI_SOCKTYPE   =    -7
+  EAI_SYSTEM     =   -11
+  EAI_OVERFLOW   =   -12
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(x0 : Addrinfo*) : Void
   fun gai_strerror(x0 : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(x0 : Char*, x1 : Char*, x2 : Addrinfo*, x3 : Addrinfo**) : Int
+  fun getnameinfo(x0 : Sockaddr*, x1 : SocklenT, x2 : Char*, x3 : SocklenT, x4 : Char*, x5 : SocklenT, x6 : Int) : Int
 end

--- a/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
@@ -35,6 +35,12 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_family : SaFamilyT
+    __ss_align : ULong
+    __ss_padding : StaticArray(Char, 112)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int

--- a/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 13
   SO_RCVBUF      =  8
   SO_REUSEADDR   =  2
+  SO_REUSEPORT   = 15
   SO_SNDBUF      =  7
   PF_INET        =  2
   PF_INET6       = 10

--- a/src/lib_c/x86_64-macosx-darwin/c/netdb.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     = 0x00000001
+  AI_CANONNAME   = 0x00000002
+  AI_NUMERICHOST = 0x00000004
+  AI_NUMERICSERV = 0x00001000
+  AI_V4MAPPED    = 0x00000800
+  AI_ALL         = 0x00000100
+  AI_ADDRCONFIG  = 0x00000400
+  EAI_AGAIN      =          2
+  EAI_BADFLAGS   =          3
+  EAI_FAIL       =          4
+  EAI_FAMILY     =          5
+  EAI_MEMORY     =          6
+  EAI_NONAME     =          8
+  EAI_SERVICE    =          9
+  EAI_SOCKTYPE   =         10
+  EAI_SYSTEM     =         11
+  EAI_OVERFLOW   =         14
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(x0 : Addrinfo*) : Void
   fun gai_strerror(x0 : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(x0 : Char*, x1 : Char*, x2 : Addrinfo*, x3 : Addrinfo**) : Int
+  fun getnameinfo(x0 : Sockaddr*, x1 : SocklenT, x2 : Char*, x3 : SocklenT, x4 : Char*, x5 : SocklenT, x6 : Int) : Int
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
@@ -35,6 +35,14 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_len : SaFamilyT
+    ss_family : SaFamilyT
+    __ss_pad1 : StaticArray(Char, 6)
+    __ss_align : LongLong
+    __ss_pad2 : StaticArray(Char, 112)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 0x0080
   SO_RCVBUF      = 0x1002
   SO_REUSEADDR   = 0x0004
+  SO_REUSEPORT   = 0x0200
   SO_SNDBUF      = 0x1001
   PF_INET        = LibC::AF_INET
   PF_INET6       = LibC::AF_INET6

--- a/src/lib_c/x86_64-portbld-freebsd/c/netdb.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/netdb.cr
@@ -3,6 +3,24 @@ require "./sys/socket"
 require "./stdint"
 
 lib LibC
+  AI_PASSIVE     = 0x00000001
+  AI_CANONNAME   = 0x00000002
+  AI_NUMERICHOST = 0x00000004
+  AI_NUMERICSERV = 0x00000008
+  AI_V4MAPPED    = 0x00000800
+  AI_ALL         = 0x00000100
+  AI_ADDRCONFIG  = 0x00000400
+  EAI_AGAIN      =          2
+  EAI_BADFLAGS   =          3
+  EAI_FAIL       =          4
+  EAI_FAMILY     =          5
+  EAI_MEMORY     =          6
+  EAI_NONAME     =          8
+  EAI_SERVICE    =          9
+  EAI_SOCKTYPE   =         10
+  EAI_SYSTEM     =         11
+  EAI_OVERFLOW   =         14
+
   struct Addrinfo
     ai_flags : Int
     ai_family : Int
@@ -14,7 +32,8 @@ lib LibC
     ai_next : Addrinfo*
   end
 
+  fun freeaddrinfo(x0 : Addrinfo*) : Void
   fun gai_strerror(x0 : Int) : Char*
-  fun getaddrinfo(hostname : Char*, servname : Char*, hints : Addrinfo*, res : Addrinfo**) : Int
-  fun freeaddrinfo(ai : Addrinfo*)
+  fun getaddrinfo(x0 : Char*, x1 : Char*, x2 : Addrinfo*, x3 : Addrinfo**) : Int
+  fun getnameinfo(x0 : Void*, x1 : SocklenT, x2 : Char*, x3 : SizeT, x4 : Char*, x5 : SizeT, x6 : Int) : Int
 end

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
@@ -36,6 +36,14 @@ lib LibC
     sa_data : StaticArray(Char, 14)
   end
 
+  struct SockaddrStorage
+    ss_len : Char
+    ss_family : SaFamilyT
+    __ss_pad1 : StaticArray(Char, 6)
+    __ss_align : Long
+    __ss_pad2 : StaticArray(Char, 112)
+  end
+
   struct Linger
     l_onoff : Int
     l_linger : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/socket.cr
@@ -11,6 +11,7 @@ lib LibC
   SO_LINGER      = 0x0080
   SO_RCVBUF      = 0x1002
   SO_REUSEADDR   = 0x0004
+  SO_REUSEPORT   = 0x0200
   SO_SNDBUF      = 0x1001
   PF_INET        = LibC::AF_INET
   PF_INET6       = LibC::AF_INET6

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -387,6 +387,14 @@ class Socket < IO::FileDescriptor
     setsockopt_bool LibC::SO_REUSEADDR, val
   end
 
+  def reuse_port?
+    getsockopt_bool LibC::SO_REUSEPORT
+  end
+
+  def reuse_port=(val : Bool)
+    setsockopt_bool LibC::SO_REUSEPORT, val
+  end
+
   def broadcast?
     getsockopt_bool LibC::SO_BROADCAST
   end

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -1,0 +1,188 @@
+class Socket
+  abstract struct Address
+    getter family : Family
+    getter size : Int32
+
+    def self.from(sockaddr : LibC::Sockaddr*, addrlen) : Address
+      case family = Family.new(sockaddr.value.sa_family)
+      when Family::INET6
+        IPAddress.new(sockaddr.as(LibC::SockaddrIn6*), addrlen.to_i)
+      when Family::INET
+        IPAddress.new(sockaddr.as(LibC::SockaddrIn*), addrlen.to_i)
+      when Family::UNIX
+        UNIXAddress.new(sockaddr.as(LibC::SockaddrUn*), addrlen.to_i)
+      else
+        raise "unsupported family type: #{family} (#{family.value})"
+      end
+    end
+
+    def initialize(@family : Family, @size : Int32)
+    end
+
+    abstract def to_unsafe : LibC::Sockaddr*
+
+    def ==(other)
+      false
+    end
+  end
+
+  struct IPAddress < Address
+    getter port : Int32
+
+    @address : String?
+    @addr6 : LibC::In6Addr?
+    @addr4 : LibC::InAddr?
+
+    def initialize(@address : String, @port : Int32)
+      if @addr6 = ip6?(address)
+        @family = Family::INET6
+        @size = sizeof(LibC::SockaddrIn6)
+      elsif @addr4 = ip4?(address)
+        @family = Family::INET
+        @size = sizeof(LibC::SockaddrIn)
+      else
+        raise Error.new("Invalid IP address: #{address}")
+      end
+    end
+
+    def self.from(sockaddr : LibC::Sockaddr*, addrlen) : IPAddress
+      case family = Family.new(sockaddr.value.sa_family)
+      when Family::INET6
+        new(sockaddr.as(LibC::SockaddrIn6*), addrlen.to_i)
+      when Family::INET
+        new(sockaddr.as(LibC::SockaddrIn*), addrlen.to_i)
+      else
+        raise "unsupported family type: #{family} (#{family.value})"
+      end
+    end
+
+    protected def initialize(sockaddr : LibC::SockaddrIn6*, @size)
+      @family = Family::INET6
+      @addr6 = sockaddr.value.sin6_addr
+      @port = LibC.ntohs(sockaddr.value.sin6_port).to_i
+    end
+
+    protected def initialize(sockaddr : LibC::SockaddrIn*, @size)
+      @family = Family::INET
+      @addr4 = sockaddr.value.sin_addr
+      @port = LibC.ntohs(sockaddr.value.sin_port).to_i
+    end
+
+    private def ip6?(address)
+      addr = uninitialized LibC::In6Addr
+      addr if LibC.inet_pton(LibC::AF_INET6, address, pointerof(addr)) == 1
+    end
+
+    private def ip4?(address)
+      addr = uninitialized LibC::InAddr
+      addr if LibC.inet_pton(LibC::AF_INET, address, pointerof(addr)) == 1
+    end
+
+    def address
+      @address ||= begin
+        case family
+        when Family::INET6 then chars = address(@addr6)
+        when Family::INET  then chars = address(@addr4)
+        else                    raise "unsupported IP address family: #{family}"
+        end
+        raise Errno.new("Failed to convert IP address") unless chars
+        String.new(chars)
+      end
+    end
+
+    private def address(addr : LibC::In6Addr)
+      chars = GC.malloc_atomic(46).as(UInt8*)
+      chars if LibC.inet_ntop(family, pointerof(addr).as(Void*), chars, 46)
+    end
+
+    private def address(addr : LibC::InAddr)
+      chars = GC.malloc_atomic(16).as(UInt8*)
+      chars if LibC.inet_ntop(family, pointerof(addr).as(Void*), chars, 16)
+    end
+
+    private def address(addr) : Nil
+      # shouldn't happen
+    end
+
+    def ==(other : IPAddress)
+      family == other.family &&
+        port == other.port &&
+        address == other.address
+    end
+
+    def to_s(io)
+      if family == Family::INET6
+        io << '[' << address << ']' << ':' << port
+      else
+        io << address << ':' << port
+      end
+    end
+
+    def to_unsafe : LibC::Sockaddr*
+      case family
+      when Family::INET6
+        to_sockaddr_in6
+      when Family::INET
+        to_sockaddr_in
+      else
+        raise "unsupported IP address family: #{family}"
+      end
+    end
+
+    private def to_sockaddr_in6
+      sockaddr = Pointer(LibC::SockaddrIn6).malloc
+      sockaddr.value.sin6_family = family
+      sockaddr.value.sin6_port = LibC.htons(port)
+      sockaddr.value.sin6_addr = @addr6.not_nil!
+      sockaddr.as(LibC::Sockaddr*)
+    end
+
+    private def to_sockaddr_in
+      sockaddr = Pointer(LibC::SockaddrIn).malloc
+      sockaddr.value.sin_family = family
+      sockaddr.value.sin_port = LibC.htons(port)
+      sockaddr.value.sin_addr = @addr4.not_nil!
+      sockaddr.as(LibC::Sockaddr*)
+    end
+  end
+
+  struct UNIXAddress < Address
+    getter path : String
+
+    # :nodoc:
+    MAX_PATH_SIZE = LibC::SockaddrUn.new.sun_path.size - 1
+
+    def initialize(@path : String)
+      if @path.bytesize + 1 > MAX_PATH_SIZE
+        raise ArgumentError.new("Path size exceeds the maximum size of #{MAX_PATH_SIZE} bytes")
+      end
+      @family = Family::UNIX
+      @size = sizeof(LibC::SockaddrUn)
+    end
+
+    def self.from(sockaddr : LibC::Sockaddr*, addrlen) : UNIXAddress
+      new(sockaddr.as(LibC::SockaddrUn*), addrlen.to_i)
+    end
+
+    protected def initialize(sockaddr : LibC::SockaddrUn*, size)
+      @family = Family::UNIX
+      @path = String.new(sockaddr.value.sun_path.to_unsafe)
+      @size = size || sizeof(LibC::SockaddrUn)
+    end
+
+    def ==(other : UNIXAddress)
+      path == other.path
+    end
+
+    def to_s(io)
+      io << path
+    end
+
+    def to_unsafe : LibC::Sockaddr*
+      sockaddr = Pointer(LibC::SockaddrUn).malloc
+      sockaddr.value.sun_family = family
+      sockaddr.value.sun_path.to_unsafe.copy_from(@path.to_unsafe, @path.bytesize + 1)
+      sockaddr.as(LibC::Sockaddr*)
+    end
+  end
+end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -1,0 +1,91 @@
+class Socket
+  struct Addrinfo
+    getter family : Family
+    getter type : Type
+    getter protocol : Protocol
+    getter size : Int32
+
+    @addr : LibC::Sockaddr*
+    @next : LibC::Addrinfo*
+
+    def self.resolve(host, service, family : Family, type : Type, protocol : Protocol = Protocol::IP, timeout = nil)
+      hints = LibC::Addrinfo.new
+      hints.ai_family = (family || Family::UNSPEC).to_i32
+      hints.ai_socktype = type
+      hints.ai_protocol = protocol
+      hints.ai_flags = 0
+
+      if service.is_a?(Int)
+        hints.ai_flags |= LibC::AI_NUMERICSERV
+      end
+
+      case ret = LibC.getaddrinfo(host, service.to_s, pointerof(hints), out ptr)
+      when 0
+        # success
+      when LibC::EAI_NONAME
+        raise Socket::Error.new("No address found for #{host}:#{service} over #{protocol}")
+      else
+        raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}")
+      end
+
+      begin
+        addrinfo = new(ptr)
+        error = nil
+
+        loop do
+          error = yield addrinfo.not_nil!
+          return unless error
+
+          unless addrinfo = addrinfo.try(&.next?)
+            if error.is_a?(Errno) && error.errno == Errno::ECONNREFUSED
+              raise Errno.new("Error connecting to '#{host}:#{service}': Connection refused", error.errno)
+            else
+              raise error if error
+            end
+          end
+        end
+      ensure
+        LibC.freeaddrinfo(ptr)
+      end
+    end
+
+    def self.tcp(host, service, family = Family::UNSPEC, timeout = nil)
+      resolve(host, service, family, Type::STREAM, Protocol::TCP) { |addrinfo| yield addrinfo }
+    end
+
+    def self.udp(host, service, family = Family::UNSPEC, timeout = nil)
+      resolve(host, service, family, Type::DGRAM, Protocol::UDP) { |addrinfo| yield addrinfo }
+    end
+
+    protected def initialize(addrinfo : LibC::Addrinfo*)
+      @family = Family.from_value(addrinfo.value.ai_family)
+      @type = Type.from_value(addrinfo.value.ai_socktype)
+      @protocol = Protocol.from_value(addrinfo.value.ai_protocol)
+      @size = addrinfo.value.ai_addrlen.to_i
+
+      @addr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
+      @next = addrinfo.value.ai_next
+
+      case @family
+      when Family::INET6
+        addrinfo.value.ai_addr.as(LibC::SockaddrIn6*).copy_to(@addr.as(LibC::SockaddrIn6*), 1)
+      when Family::INET
+        addrinfo.value.ai_addr.as(LibC::SockaddrIn*).copy_to(@addr.as(LibC::SockaddrIn*), 1)
+      end
+    end
+
+    def ip_address
+      @ip_address = IPAddress.from(@addr, @addrlen)
+    end
+
+    def to_unsafe
+      @addr
+    end
+
+    protected def next?
+      if addrinfo = @next
+        Addrinfo.new(addrinfo)
+      end
+    end
+  end
+end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -5,7 +5,7 @@ class Socket
     getter protocol : Protocol
     getter size : Int32
 
-    @addr : LibC::Sockaddr*
+    @addr : LibC::SockaddrIn6
     @next : LibC::Addrinfo*
 
     def self.resolve(host, service, family : Family, type : Type, protocol : Protocol = Protocol::IP, timeout = nil)
@@ -63,14 +63,14 @@ class Socket
       @protocol = Protocol.from_value(addrinfo.value.ai_protocol)
       @size = addrinfo.value.ai_addrlen.to_i
 
-      @addr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
+      @addr = uninitialized LibC::SockaddrIn6
       @next = addrinfo.value.ai_next
 
       case @family
       when Family::INET6
-        addrinfo.value.ai_addr.as(LibC::SockaddrIn6*).copy_to(@addr.as(LibC::SockaddrIn6*), 1)
+        addrinfo.value.ai_addr.as(LibC::SockaddrIn6*).copy_to(pointerof(@addr).as(LibC::SockaddrIn6*), 1)
       when Family::INET
-        addrinfo.value.ai_addr.as(LibC::SockaddrIn*).copy_to(@addr.as(LibC::SockaddrIn*), 1)
+        addrinfo.value.ai_addr.as(LibC::SockaddrIn*).copy_to(pointerof(@addr).as(LibC::SockaddrIn*), 1)
       end
     end
 
@@ -79,7 +79,7 @@ class Socket
     end
 
     def to_unsafe
-      @addr
+      pointerof(@addr).as(LibC::Sockaddr*)
     end
 
     protected def next?

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -1,139 +1,25 @@
 class IPSocket < Socket
   # Returns the `IPAddress` for the local end of the IP socket.
   def local_address
-    sockaddr = uninitialized LibC::SockaddrIn6
+    sockaddr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
     addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrIn6))
 
-    if LibC.getsockname(fd, pointerof(sockaddr).as(LibC::Sockaddr*), pointerof(addrlen)) != 0
+    if LibC.getsockname(fd, sockaddr, pointerof(addrlen)) != 0
       raise Errno.new("getsockname")
     end
 
-    IPAddress.new(sockaddr, addrlen)
+    IPAddress.from(sockaddr, addrlen)
   end
 
   # Returns the `IPAddress` for the remote end of the IP socket.
   def remote_address
-    sockaddr = uninitialized LibC::SockaddrIn6
-    addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrIn6))
+    sockaddr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
+    addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrStorage))
 
-    if LibC.getpeername(fd, pointerof(sockaddr).as(LibC::Sockaddr*), pointerof(addrlen)) != 0
+    if LibC.getpeername(fd, sockaddr, pointerof(addrlen)) != 0
       raise Errno.new("getpeername")
     end
 
-    IPAddress.new(sockaddr, addrlen)
-  end
-
-  class DnsRequestCbArg
-    getter value : Int32 | Pointer(LibC::Addrinfo) | Nil
-    @fiber : Fiber
-
-    def initialize
-      @fiber = Fiber.current
-    end
-
-    def value=(val)
-      @value = val
-      @fiber.resume
-    end
-  end
-
-  # Yields LibC::Addrinfo to the block while the block returns false and there are more LibC::Addrinfo results.
-  #
-  # The block must return true if it succeeded using that addressinfo
-  # (to connect or bind, for example), and false otherwise. If it returns false and
-  # the LibC::Addrinfo has a next LibC::Addrinfo, it is yielded to the block, and so on.
-  private def getaddrinfo(host, port, family, socktype, protocol = Protocol::IP, timeout = nil)
-    # Using getaddrinfo from libevent doesn't work well,
-    # see https://github.com/crystal-lang/crystal/issues/2660
-    #
-    # For now it's better to have this working well but maybe a bit slow than
-    # having it working fast but something working bad or not seeing some networks.
-    IPSocket.getaddrinfo_c_call(host, port, family, socktype, protocol, timeout) { |ai| yield ai }
-  end
-
-  # :nodoc:
-  def self.getaddrinfo_c_call(host, port, family, socktype, protocol = Protocol::IP, timeout = nil)
-    hints = LibC::Addrinfo.new
-    hints.ai_family = (family || Family::UNSPEC).to_i32
-    hints.ai_socktype = socktype
-    hints.ai_protocol = protocol
-    hints.ai_flags = 0
-
-    ret = LibC.getaddrinfo(host, port.to_s, pointerof(hints), out addrinfo)
-    raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}") if ret != 0
-
-    begin
-      current_addrinfo = addrinfo
-      while current_addrinfo
-        success = yield current_addrinfo.value
-        break if success
-        current_addrinfo = current_addrinfo.value.ai_next
-      end
-    ensure
-      LibC.freeaddrinfo(addrinfo)
-    end
-  end
-
-  # :nodoc:
-  def self.getaddrinfo_libevent(host, port, family, socktype, protocol = Protocol::IP, timeout = nil)
-    hints = LibC::Addrinfo.new
-    hints.ai_family = (family || Family::UNSPEC).to_i32
-    hints.ai_socktype = socktype
-    hints.ai_protocol = protocol
-    hints.ai_flags = 0
-
-    dns_req = DnsRequestCbArg.new
-
-    # may fire immediately or on the next event loop
-    req = Scheduler.create_dns_request(host, port.to_s, pointerof(hints), dns_req) do |err, addr, data|
-      dreq = data.as(DnsRequestCbArg)
-
-      if err == 0
-        dreq.value = addr
-      else
-        dreq.value = err
-      end
-    end
-
-    if timeout && req
-      spawn do
-        sleep timeout.not_nil!
-        req.not_nil!.cancel unless dns_req.value
-      end
-    end
-
-    success = false
-
-    value = dns_req.value
-    # BUG: not thread safe.  change when threads are implemented
-    unless value
-      Scheduler.reschedule
-      value = dns_req.value
-    end
-
-    if value.is_a?(LibC::Addrinfo*)
-      begin
-        cur_addr = value
-        while cur_addr
-          success = yield cur_addr.value
-
-          break if success
-          cur_addr = cur_addr.value.ai_next
-        end
-      ensure
-        LibEvent2.evutil_freeaddrinfo value
-      end
-    elsif value.is_a?(Int)
-      if value == LibEvent2::EVUTIL_EAI_CANCEL
-        raise IO::Timeout.new("Failed to resolve #{host} in #{timeout} seconds")
-      end
-      error_message = String.new(LibC.gai_strerror(value))
-      raise Socket::Error.new("getaddrinfo: #{error_message}")
-    else
-      raise "unknown type #{value.inspect}"
-    end
-
-    # shouldn't raise
-    raise Socket::Error.new("getaddrinfo: unspecified error") unless success
+    IPAddress.from(sockaddr, addrlen)
   end
 end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -1,7 +1,8 @@
 class IPSocket < Socket
   # Returns the `IPAddress` for the local end of the IP socket.
   def local_address
-    sockaddr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
+    sockaddr6 = uninitialized LibC::SockaddrIn6
+    sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
     addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrIn6))
 
     if LibC.getsockname(fd, sockaddr, pointerof(addrlen)) != 0
@@ -13,8 +14,9 @@ class IPSocket < Socket
 
   # Returns the `IPAddress` for the remote end of the IP socket.
   def remote_address
-    sockaddr = Pointer(LibC::SockaddrIn6).malloc.as(LibC::Sockaddr*)
-    addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrStorage))
+    sockaddr6 = uninitialized LibC::SockaddrIn6
+    sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
+    addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrIn6))
 
     if LibC.getpeername(fd, sockaddr, pointerof(addrlen)) != 0
       raise Errno.new("getpeername")

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -1,0 +1,51 @@
+class Socket
+  module Server
+    # Accepts an incoming connection and yields the client socket to the block.
+    # Eventually closes the connection when the block returns.
+    #
+    # Returns the value of the block. If the server is closed after invoking this
+    # method, an `IO::Error` (closed stream) exception will be raised.
+    #
+    # ```
+    # require "socket"
+    #
+    # server = TCPServer.new(2202)
+    # server.accept do |socket|
+    #   socket.puts Time.now
+    # end
+    # ```
+    def accept
+      sock = accept
+      begin
+        yield sock
+      ensure
+        sock.close
+      end
+    end
+
+    # Accepts an incoming connection and yields the client socket to the block.
+    # Eventualy closes the connection when the block returns.
+    #
+    # Returns the value of the block or `nil` if the server is closed after
+    # invoking this method.
+    #
+    # ```
+    # require "socket"
+    #
+    # server = UNIXServer.new("/tmp/service.sock")
+    # server.accept? do |socket|
+    #   socket.puts Time.now
+    # end
+    # ```
+    def accept?
+      sock = accept?
+      return unless sock
+
+      begin
+        yield sock
+      ensure
+        sock.close
+      end
+    end
+  end
+end

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -22,6 +22,7 @@ class TCPServer < TCPSocket
       super(addrinfo.family, addrinfo.type, addrinfo.protocol)
 
       self.reuse_address = true
+      self.reuse_port = true
 
       if errno = bind(addrinfo) { |errno| errno }
         close

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -20,21 +20,21 @@ class TCPSocket < IPSocket
   #
   # Note that `dns_timeout` is currently ignored.
   def initialize(host, port, dns_timeout = nil, connect_timeout = nil)
-    getaddrinfo(host, port, nil, Type::STREAM, Protocol::TCP, timeout: dns_timeout) do |addrinfo|
-      super create_socket(addrinfo.ai_family, addrinfo.ai_socktype, addrinfo.ai_protocol)
-
-      if err = nonblocking_connect(host, port, addrinfo, timeout: connect_timeout)
+    Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
+      super(addrinfo.family, addrinfo.type, addrinfo.protocol)
+      connect(addrinfo, timeout: connect_timeout) do |error|
         close
-        next false if addrinfo.ai_next
-        raise err
+        error
       end
-
-      true
     end
   end
 
-  protected def initialize(fd : Int32)
-    super fd
+  protected def initialize(family : Family, type : Type, protocol : Protocol)
+    super family, type, protocol
+  end
+
+  protected def initialize(fd : Int32, family : Family, type : Type, protocol : Protocol)
+    super fd, family, type, protocol
   end
 
   # Opens a TCP socket to a remote TCP server, yields it to the block, then

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -1,6 +1,6 @@
 require "./ip_socket"
 
-# A User Datagram Protocol socket.
+# A User Datagram Protocol (UDP) socket.
 #
 # UDP runs on top of the Internet Protocol (IP) and was developed for applications that do
 # not require reliability, acknowledgement, or flow control features at the transport layer.
@@ -27,8 +27,11 @@ require "./ip_socket"
 # client = UDPSocket.new
 # client.connect "localhost", 1234
 #
-# client.puts "message" # send message to server
-# server.gets           # => "message\n"
+# # Send a text message to server
+# client.send "message"
+#
+# # Receive text message from client
+# message, client_addr = server.receive
 #
 # # Close client and server
 # client.close
@@ -48,113 +51,35 @@ require "./ip_socket"
 # end
 # ```
 class UDPSocket < IPSocket
-  def initialize(@family : Family = Family::INET)
-    super create_socket(family.value, Type::DGRAM, Protocol::UDP)
+  def initialize(family : Family = Family::INET)
+    super(family, Type::DGRAM, Protocol::UDP)
   end
 
-  # Binds the UDP socket to a local address.
+  # Receives a text message from the previously bound address.
   #
   # ```
   # server = UDPSocket.new
-  # server.bind "localhost", 1234
-  # ```
-  def bind(host, port, dns_timeout = nil)
-    getaddrinfo(host, port, @family, Type::DGRAM, Protocol::UDP, timeout: dns_timeout) do |addrinfo|
-      self.reuse_address = true
-
-      ret =
-        {% if flag?(:freebsd) || flag?(:openbsd) %}
-          LibC.bind(fd, addrinfo.ai_addr.as(LibC::Sockaddr*), addrinfo.ai_addrlen)
-        {% else %}
-          LibC.bind(fd, addrinfo.ai_addr, addrinfo.ai_addrlen)
-        {% end %}
-      unless ret == 0
-        next false if addrinfo.ai_next
-        raise Errno.new("Error binding UDP socket at #{host}:#{port}")
-      end
-
-      true
-    end
-  end
-
-  # Connects the UDP socket to a remote address to send messages to.
+  # server.bind("localhost", 1234)
   #
+  # message, client_addr = server.receive
   # ```
-  # client = UDPSocket.new
-  # client.connect("localhost", 1234)
-  # client.send("a text message")
-  # ```
-  def connect(host, port, dns_timeout = nil, connect_timeout = nil)
-    getaddrinfo(host, port, @family, Type::DGRAM, Protocol::UDP, timeout: dns_timeout) do |addrinfo|
-      if err = nonblocking_connect host, port, addrinfo, timeout: connect_timeout
-        next false if addrinfo.ai_next
-        raise err
-      end
-
-      true
-    end
+  def receive(max_message_size = 512) : {String, IPAddress}
+    bytes = Bytes.new(max_message_size)
+    bytes_read, sockaddr, addrlen = recvfrom(bytes)
+    {String.new(bytes.to_unsafe, bytes_read), IPAddress.from(sockaddr, addrlen)}
   end
 
-  # Sends a text message to the previously connected remote address. See
-  # `#connect`.
-  def send(message : String)
-    send(message.to_slice)
-  end
-
-  # Sends a binary message to the previously connected remote address. See
-  # `#connect`.
-  def send(message : Bytes)
-    bytes_sent = LibC.send(fd, (message.to_unsafe.as(Void*)), message.size, 0)
-    raise Errno.new("Error sending datagram") if bytes_sent == -1
-    bytes_sent
-  ensure
-    if (writers = @writers) && !writers.empty?
-      add_write_event
-    end
-  end
-
-  # Sends a text message to the specified remote address.
-  def send(message : String, addr : IPAddress)
-    send(message.to_slice, addr)
-  end
-
-  # Sends a binary message to the specified remote address.
-  def send(message : Bytes, addr : IPAddress)
-    sockaddr = addr.sockaddr
-    bytes_sent = LibC.sendto(fd, (message.to_unsafe.as(Void*)), message.size, 0, pointerof(sockaddr).as(LibC::Sockaddr*), addr.addrlen)
-    raise Errno.new("Error sending datagram to #{addr}") if bytes_sent == -1
-    bytes_sent
-  end
-
-  # Receives a binary message on the previously bound address.
+  # Receives a binary message from the previously bound address.
   #
   # ```
   # server = UDPSocket.new
   # server.bind "localhost", 1234
   #
   # message = Bytes.new(32)
-  # message_size, client_addr = server.receive(message)
+  # bytes_read, client_addr = server.receive(message)
   # ```
   def receive(message : Bytes) : {Int32, IPAddress}
-    loop do
-      sockaddr = uninitialized LibC::SockaddrIn6
-      addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrIn6))
-      bytes_read = LibC.recvfrom(fd, (message.to_unsafe.as(Void*)), message.size, 0, pointerof(sockaddr).as(LibC::Sockaddr*), pointerof(addrlen))
-
-      if bytes_read == -1
-        if Errno.value == Errno::EAGAIN
-          wait_readable
-        else
-          raise Errno.new("Error receiving datagram")
-        end
-      else
-        return {bytes_read.to_i32, IPAddress.new(sockaddr, addrlen)}
-      end
-    end
-  ensure
-    # see IO::FileDescriptor#unbuffered_read
-    if (readers = @readers) && !readers.empty?
-      add_read_event
-    end
+    bytes_read, sockaddr, addrlen = recvfrom(message)
+    {bytes_read, IPAddress.from(sockaddr, addrlen)}
   end
 end

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -64,9 +64,13 @@ class UDPSocket < IPSocket
   # message, client_addr = server.receive
   # ```
   def receive(max_message_size = 512) : {String, IPAddress}
-    bytes = Bytes.new(max_message_size)
-    bytes_read, sockaddr, addrlen = recvfrom(bytes)
-    {String.new(bytes.to_unsafe, bytes_read), IPAddress.from(sockaddr, addrlen)}
+    address = nil
+    message = String.new(max_message_size) do |buffer|
+      bytes_read, sockaddr, addrlen = recvfrom(Slice.new(buffer, max_message_size))
+      address = IPAddress.from(sockaddr, addrlen)
+      {bytes_read, 0}
+    end
+    {message, address.not_nil!}
   end
 
   # Receives a binary message from the previously bound address.


### PR DESCRIPTION
The whole idea behing this refactor is to give more possibilities over sockets, for some less common scenarios (eg: DGRAM UNIX sockets) as well as cleanup the sockets implementation, by avoiding some repetition.

Refactor:

- Socket is now enough to create, configure and use any kind of socket association of family, type and protocol is also possible, as long as it's supported by the underlying OS implementation;
  - as a consequence the `connect`, `bind`, `listen`, `accept`, `send` and `receive` methods were moved from subclasses into `Socket` itself;
- The `TCPSocket`, `TCPServer`, `UDPSocket`, `UNIXSocket` and `UNIXServer` classes are merely sugar to avoid having to deal with socket details;
- `UNIXSocket` and `UNIXServer` can now be used in DGRAM type, in addition to the default STREAM type.

Features:

- `Addrinfo` DNS resolver, that wraps results from `getaddrinfo`;
- `Socket#receive : {String, IPAddress}` to receive a String (like we can `send(String)`;
- `Socket#bind(Int)` to bind to all available interfaces;
- `Socket::Server` module, included by both `TCPServer` and `UNIXServer`;
- `SO_REUSEPORT` socket option; automatically set for `TCPServer` —see http://stackoverflow.com/a/14388707/199791

Breaking Change:

- `IPAddress` now automatically detects the address family, so the argument was removed (limited impact).

Examples:

```crystal
sock = UNIXSocket.new(Socket::Family::DGRAM)
sock.connect("/tmp/service.sock")
sock.send(message)
```

```crystal
sock = Socket.tcp(Socket::Family::INET6)
# set some socket options (e.g. SO_REUSEPORT)
sock.bind(80)
sock.listen
```

closes #3214
closes #3495 
refs #3586