### PR TITLE
Reset location after block yielding in macro expansion

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1642,4 +1642,28 @@ describe "Code gen: macro" do
       foo
       ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(10)
   end
+
+  it "keeps line number with no block" do
+    run(%(
+      macro foo
+        {{ yield }}
+        __LINE__
+      end
+
+      foo
+    ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+  end
+
+  it "keeps line number with a block" do
+    run(%(
+      macro foo
+        {{ yield }}
+        __LINE__
+      end
+
+      foo do
+        1
+      end
+    ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+  end
 end

--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -68,6 +68,38 @@ describe "Lexer: location" do
     token.filename.should eq("foo")
   end
 
+  it "pushes and pops its location" do
+    lexer = Lexer.new %(#<loc:push>#<loc:"foo",12,34>1 + #<loc:pop>2)
+    lexer.filename = "bar"
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.line_number.should eq(12)
+    token.column_number.should eq(34)
+    token.filename.should eq("foo")
+
+    token = lexer.next_token
+    token.type.should eq(:SPACE)
+    token.line_number.should eq(12)
+    token.column_number.should eq(35)
+
+    token = lexer.next_token
+    token.type.should eq(:"+")
+    token.line_number.should eq(12)
+    token.column_number.should eq(36)
+
+    token = lexer.next_token
+    token.type.should eq(:SPACE)
+    token.line_number.should eq(12)
+    token.column_number.should eq(37)
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.line_number.should eq(1)
+    token.column_number.should eq(44)
+    token.filename.should eq("bar")
+  end
+
   it "uses two consecutive loc pragma " do
     lexer = Lexer.new %(1#<loc:"foo",12,34>#<loc:"foo",56,78>2)
     lexer.filename = "bar"

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -102,9 +102,9 @@ module Crystal
         # retaining the original node's location, so error messages
         # are shown in the block instead of in the generated macro source
         is_yield = node.exp.is_a?(Yield) && !@last.is_a?(Nop)
-        @str << " #<loc:save>begin " if is_yield
+        @str << " #<loc:push>begin " if is_yield
         @last.to_s(@str, emit_loc_pragma: is_yield)
-        @str << " end#<loc:reset> " if is_yield
+        @str << " end#<loc:pop> " if is_yield
       end
 
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -102,9 +102,9 @@ module Crystal
         # retaining the original node's location, so error messages
         # are shown in the block instead of in the generated macro source
         is_yield = node.exp.is_a?(Yield) && !@last.is_a?(Nop)
-        @str << " begin " if is_yield
+        @str << " #<loc:save>begin " if is_yield
         @last.to_s(@str, emit_loc_pragma: is_yield)
-        @str << " end " if is_yield
+        @str << " end#<loc:reset> " if is_yield
       end
 
       false


### PR DESCRIPTION
This pull request Introduces `#<loc:save>` and `#<loc:reset>` new pragma comment, `#<loc:save>` saves current location and `#<loc:reset>` resets it. They are useful to keep original location when block yielding in macro expansion.

For example, this code makes broken error message:

```crystal
macro foo
  a = {{ yield }}
  a.ok
end

foo { 1 }
```

It cannot be compiled and error message is:

    in foo.cr:7: undefined method 'ok' for Int32

Error message points line 7 of foo.cr, but this code consists only 6 lines.

This bug comes from a location is not reset after block yielding in macro expansion. In fact, `foo { 1 }` expands to:

```crystal
a =  begin #<loc:"foo.cr",6,7>1 end
a.ok
```

So, the parser reports `a.ok` is on line 7 of foo.cr.

This pull request also fixes it by wrapping `#<loc:save>` and `#<loc:reeset>` to yielding expanded code, such a like:

```crystal
a =  #<loc:save>begin #<loc:"foo.cr",6,7>1 end#<loc:reset>
a.ok
```

It works well.