### PR TITLE
Improve docs to require equal length size

### DIFF
--- a/spec/std/crypto/subtle_spec.cr
+++ b/spec/std/crypto/subtle_spec.cr
@@ -3,16 +3,26 @@ require "crypto/subtle"
 
 describe "Subtle" do
   it "compares constant times" do
-    data = [
+    data1 = [
       {"a" => Slice.new(1, 0x11), "b" => Slice.new(1, 0x11), "result" => true},
-      {"a" => Slice.new(1, 0x12), "b" => Slice.new(1, 0x11), "result" => false},
-      {"a" => Slice.new(1, 0x11), "b" => Slice.new(2) { |i| 0x11 + i }, "result" => false},
-      {"a" => Slice.new(2) { |i| 0x11 + i }, "b" => Slice.new(1, 0x11), "result" => false},
+      {"a" => Slice.new(1, 0x12), "b" => Slice.new(1, 0x11), "result" => false}
     ]
 
-    data.each do |test|
+    data1.each do |test|
       Crypto::Subtle.constant_time_compare(test["a"].as(Slice(Int32)), test["b"].as(Slice(Int32))).should eq(test["result"])
     end
+
+    data2 = [
+      {"a" => Slice.new(1, 0x11), "b" => Slice.new(2) { |i| 0x11 + i }},
+      {"a" => Slice.new(2) { |i| 0x11 + i }, "b" => Slice.new(1, 0x11)}
+    ]
+
+    data2.each do |test|
+      expect_raises(ArgumentError, /Arguments must be equal length/) do
+        Crypto::Subtle.constant_time_compare(test["a"].as(Slice(Int32)), test["b"].as(Slice(Int32)))
+      end
+    end
+
   end
 
   it "compares constant time bytes on equality" do

--- a/src/crypto/subtle.cr
+++ b/src/crypto/subtle.cr
@@ -1,6 +1,6 @@
 module Crypto::Subtle
   # Compares *x* and *y* in constant time and returns true if they are the same, and false if they are not.
-  # Note: *x* and *y* must be able to respond to `to_slice`.
+  # Note: *x* and *y* must be able to respond to `to_slice` and *x* and *y* must be of equal length.
   #
   # ```
   # require "crypto/subtle"
@@ -10,7 +10,7 @@ module Crypto::Subtle
   def self.constant_time_compare(x, y) : Bool
     x = x.to_slice
     y = y.to_slice
-    return false if x.size != y.size
+    raise ArgumentError.new("Arguments must be equal lengths") unless x.size == y.size
 
     v = 0_u8
 


### PR DESCRIPTION
#3722 noted the potential to leak whether or not args were of equal length. @ysbaddaden suggested two changes:

1. Note in docs that args must be of equal length
2. For specificity, raise an exception instead of returning false

This implements both changes