### PR TITLE
Implement JSON format documentation

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -54,12 +54,17 @@ class Crystal::Doc::Generator
     end
 
     if filename
-      body = doc(program_type, File.read(filename))
+      raw_body = File.read(filename)
+      body = doc(program_type, raw_body)
     else
+      raw_body = ""
       body = ""
     end
 
     File.write "#{@dir}/index.html", MainTemplate.new(body, types, repository_name)
+
+    type_refs = types.map { |t| JSONise::TypeRef.new(t) }
+    File.write "#{@dir}/index.json", JSONise::Main.new(raw_body, type_refs, repository_name)
   end
 
   def copy_files
@@ -74,11 +79,14 @@ class Crystal::Doc::Generator
     types.each do |type|
       if type.program?
         filename = "#{dir}/toplevel.html"
+        jsonname = "#{dir}/toplevel.json"
       else
         filename = "#{dir}/#{type.name}.html"
+        jsonname = "#{dir}/#{type.name}.json"
       end
 
       File.write filename, TypeTemplate.new(type, all_types)
+      File.write jsonname, JSONise::Type.new(type)
 
       next if type.program?
 

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -63,8 +63,8 @@ class Crystal::Doc::Generator
 
     File.write "#{@dir}/index.html", MainTemplate.new(body, types, repository_name)
 
-    type_refs = types.map { |t| JSONise::TypeRef.new(t) }
-    File.write "#{@dir}/index.json", JSONise::Main.new(raw_body, type_refs, repository_name)
+    type_refs = types.map { |t| JSONSerializer::TypeRef.new(t) }
+    File.write "#{@dir}/index.json", JSONSerializer::Main.new(raw_body, type_refs, repository_name)
   end
 
   def copy_files
@@ -86,7 +86,7 @@ class Crystal::Doc::Generator
       end
 
       File.write filename, TypeTemplate.new(type, all_types)
-      File.write jsonname, JSONise::Type.new(type)
+      File.write jsonname, JSONSerializer::Type.new(type)
 
       next if type.program?
 

--- a/src/compiler/crystal/tools/doc/json_serializer.cr
+++ b/src/compiler/crystal/tools/doc/json_serializer.cr
@@ -1,7 +1,7 @@
 require "json"
 require "json/*"
 
-module Crystal::Doc::JSONise
+module Crystal::Doc::JSONSerializer
   macro mapping(src, properties, strict = false)
     JSON.mapping({{properties}}, {{strict}})
 
@@ -30,7 +30,7 @@ module Crystal::Doc::JSONise
   end
 
   macro mapping(src, **properties)
-    JSONise.mapping({{src}}, {{properties}})
+    JSONSerializer.mapping({{src}}, {{properties}})
   end
 
   record Main, body : String, types : Array(TypeRef), repository_name : String do
@@ -46,7 +46,7 @@ module Crystal::Doc::JSONise
   end
 
   class Type
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Type,
       html_id: {type: String, nilable: false},
       json_path: {type: String, nilable: false},
@@ -78,7 +78,7 @@ module Crystal::Doc::JSONise
   end
 
   class TypeRef
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Type,
       html_id: {type: String, nilable: false},
       json_path: {type: String, nilable: false},
@@ -89,7 +89,7 @@ module Crystal::Doc::JSONise
   end
 
   class Constant
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Constant,
       name: {type: String, nilable: false},
       doc: {type: String, nilable: true},
@@ -98,7 +98,7 @@ module Crystal::Doc::JSONise
   end
 
   class Method
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Method,
       id: {type: String, nilable: false},
       html_id: {type: String, nilable: false},
@@ -112,7 +112,7 @@ module Crystal::Doc::JSONise
   end
 
   class Macro
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Macro,
       id: {type: String, nilable: false},
       html_id: {type: String, nilable: false},
@@ -126,7 +126,7 @@ module Crystal::Doc::JSONise
   end
 
   class DefAST
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Def,
       name: {type: String, nilable: false},
       args: {type: Array(ArgAST), nilable: false, wrap: ArgAST},
@@ -141,7 +141,7 @@ module Crystal::Doc::JSONise
   end
 
   class MacroAST
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Macro,
       name: {type: String, nilable: false},
       args: {type: Array(ArgAST), nilable: false, wrap: ArgAST},
@@ -154,7 +154,7 @@ module Crystal::Doc::JSONise
   end
 
   class ArgAST
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Arg,
       name: {type: String, nilable: false},
       doc: {type: String, nilable: true},
@@ -165,7 +165,7 @@ module Crystal::Doc::JSONise
   end
 
   class RelativeLocation
-    JSONise.mapping(
+    JSONSerializer.mapping(
       Crystal::Doc::Generator::RelativeLocation,
       filename: {type: String, nilable: false, default: ""},
       line_number: {type: Int32, nilable: false, default: 0},

--- a/src/compiler/crystal/tools/doc/jsonise.cr
+++ b/src/compiler/crystal/tools/doc/jsonise.cr
@@ -1,0 +1,175 @@
+require "json"
+require "json/*"
+
+module Crystal::Doc::JSONise
+  macro mapping(src, properties, strict = false)
+    JSON.mapping({{properties}}, {{strict}})
+
+    def initialize(src : {{src.id}})
+      {% for key, value in properties %}
+        {% if value[:wrap] %}
+          {% if value[:type].is_a?(Generic) %}
+            @{{key.id}} = src.{{(value[:method] || key).id}}.map { |s| {{ value[:wrap].id }}.new(s).as({{ value[:wrap].id }}) }
+          {% else %}
+            @{{key.id}} =
+              {% if value[:nilable] %}
+                (%orig = src.{{(value[:method] || key).id}}) ? {{ value[:wrap].id }}.new(%orig) : nil
+              {% else %}
+                {{ value[:wrap].id }}.new(src.{{(value[:method] || key).id}})
+              {% end %}
+          {% end %}
+        {% else %}
+          @{{key.id}} = src.{{(value[:method] || key).id}}
+        {% end %}
+      {% end %}
+    end
+
+    def to_s(io : IO)
+      to_json(io)
+    end
+  end
+
+  macro mapping(src, **properties)
+    JSONise.mapping({{src}}, {{properties}})
+  end
+
+  record Main, body : String, types : Array(TypeRef), repository_name : String do
+    JSON.mapping(
+      repository_name: {type: String, nilable: false},
+      body: {type: String, nilable: false},
+      types: {type: Array(TypeRef), nilable: false}
+    )
+
+    def to_s(io : IO)
+      to_json(io)
+    end
+  end
+
+  class Type
+    JSONise.mapping(
+      Crystal::Doc::Type,
+      html_id: {type: String, nilable: false},
+      json_path: {type: String, nilable: false},
+      kind: {type: Symbol, nilable: true},
+      full_name: {type: String, nilable: false},
+      name: {type: String, nilable: false},
+      abstract: {type: Bool, nilable: false, method: :abstract?},
+      superclass: {type: TypeRef, nilable: true, wrap: TypeRef},
+      ancestors: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      locations: {type: Array(RelativeLocation), nilable: false, wrap: RelativeLocation},
+      repository_name: {type: String, nilable: false},
+      program: {type: Bool, nilable: false, method: :program?},
+      enum: {type: Bool, nilable: false, method: :enum?},
+      alias: {type: Bool, nilable: false, method: :alias?},
+      aliased: {type: String, nilable: true, method: "alias_definition.try(&.to_s)"},
+      const: {type: Bool, nilable: false, method: :const?},
+      types: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      constants: {type: Array(Constant), nilable: false, wrap: Constant},
+      included_modules: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      extended_modules: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      subclasses: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      including_types: {type: Array(TypeRef), nilable: false, wrap: TypeRef},
+      namespace: {type: TypeRef, nilable: true, wrap: TypeRef},
+      doc: {type: String, nilable: true},
+      class_methods: {type: Array(Method), nilable: false, wrap: Method},
+      instance_methods: {type: Array(Method), nilable: false, wrap: Method},
+      macros: {type: Array(Macro), nilable: false, wrap: Macro}
+    )
+  end
+
+  class TypeRef
+    JSONise.mapping(
+      Crystal::Doc::Type,
+      html_id: {type: String, nilable: false},
+      json_path: {type: String, nilable: false},
+      kind: {type: Symbol, nilable: true},
+      full_name: {type: String, nilable: false},
+      name: {type: String, nilable: false}
+    )
+  end
+
+  class Constant
+    JSONise.mapping(
+      Crystal::Doc::Constant,
+      name: {type: String, nilable: false},
+      doc: {type: String, nilable: true},
+      value: {type: String, nilable: true, method: "value.to_s"}
+    )
+  end
+
+  class Method
+    JSONise.mapping(
+      Crystal::Doc::Method,
+      id: {type: String, nilable: false},
+      html_id: {type: String, nilable: false},
+      name: {type: String, nilable: false},
+      doc: {type: String, nilable: true},
+      abstract: {type: Bool, nilable: false, method: :abstract?},
+      args: {type: String, nilable: true, method: :args_to_s},
+      source_link: {type: String, nilable: true},
+      def: {type: DefAST, nilable: false, wrap: DefAST}
+    )
+  end
+
+  class Macro
+    JSONise.mapping(
+      Crystal::Doc::Macro,
+      id: {type: String, nilable: false},
+      html_id: {type: String, nilable: false},
+      name: {type: String, nilable: false},
+      doc: {type: String, nilable: true},
+      abstract: {type: Bool, nilable: false, method: :abstract?},
+      args: {type: String, nilable: true, method: :args_to_s},
+      source_link: {type: String, nilable: true},
+      def: {type: MacroAST, nilable: false, wrap: MacroAST, method: :macro}
+    )
+  end
+
+  class DefAST
+    JSONise.mapping(
+      Crystal::Def,
+      name: {type: String, nilable: false},
+      args: {type: Array(ArgAST), nilable: false, wrap: ArgAST},
+      double_splat: {type: ArgAST, nilable: true, wrap: ArgAST},
+      splat_index: {type: Int32, nilable: true},
+      yields: {type: Int32, nilable: true},
+      block_arg: {type: ArgAST, nilable: true, wrap: ArgAST},
+      return_type: {type: String, nilable: true, method: "return_type.try(&.to_s)"},
+      visibility: {type: String, nilable: false, method: "visibility.to_s"},
+      body: {type: String, nilable: true, method: "body.try(&.to_s)"}
+    )
+  end
+
+  class MacroAST
+    JSONise.mapping(
+      Crystal::Macro,
+      name: {type: String, nilable: false},
+      args: {type: Array(ArgAST), nilable: false, wrap: ArgAST},
+      double_splat: {type: ArgAST, nilable: true, wrap: ArgAST},
+      splat_index: {type: Int32, nilable: true},
+      block_arg: {type: ArgAST, nilable: true, wrap: ArgAST},
+      visibility: {type: String, nilable: false, method: "visibility.to_s"},
+      body: {type: String, nilable: true, method: "body.try(&.to_s)"}
+    )
+  end
+
+  class ArgAST
+    JSONise.mapping(
+      Crystal::Arg,
+      name: {type: String, nilable: false},
+      doc: {type: String, nilable: true},
+      default_value: {type: String, nilable: true, method: "default_value.try(&.to_s)"},
+      external_name: {type: String, nilable: false, method: "external_name.try(&.to_s)"},
+      restriction: {type: String, nilable: true, method: "restriction.try(&.to_s)"}
+    )
+  end
+
+  class RelativeLocation
+    JSONise.mapping(
+      Crystal::Doc::Generator::RelativeLocation,
+      filename: {type: String, nilable: false, default: ""},
+      line_number: {type: Int32, nilable: false, default: 0},
+      url: {type: String, nilable: true}
+    )
+  end
+end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -134,12 +134,12 @@ class Crystal::Doc::Type
   end
 
   def alias_definition
-    alias_def = @type.as(AliasType).aliased_type
+    alias_def = @type.as?(AliasType).try(&.aliased_type)
     alias_def
   end
 
   def formatted_alias_definition
-    type_to_html alias_definition
+    type_to_html alias_definition.as(Crystal::Type)
   end
 
   @types : Array(Type)?
@@ -344,6 +344,10 @@ class Crystal::Doc::Type
     else
       "#{name}.html"
     end
+  end
+
+  def json_path
+    path.sub(/\.html$/, ".json")
   end
 
   def path_from(type)


### PR DESCRIPTION
In order to make it easy to extend the documentation, I think that we needed JSON format output.

The current documentation includes HTML, JS, CSS in the compiler. The more i try to make it rich, the more i should add unnecessary assets to the compiler.

Also, if you want to link class names between shards, there is currently no way to parse HTML.

I think that JSON documentation output can solve these problems, what do you think?

ref: https://github.com/crystal-lang/crystal/pull/1834#issuecomment-266775448