### PR TITLE
Iterator#flat_map returns an iterator

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -439,6 +439,10 @@ describe "Enumerable" do
     it "does example 4" do
       [{1 => 2}, {3 => 4}].flat_map { |e| e }.should eq([{1 => 2}, {3 => 4}])
     end
+
+    it "flattens iterators" do
+      [[1, 2], [3, 4]].flat_map(&.each).should eq([1, 2, 3, 4])
+    end
   end
 
   describe "grep" do

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -633,4 +633,63 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
   end
+
+  describe "#flat_map" do
+    it "flattens returned arrays" do
+      iter = [1, 2, 3].each.flat_map { |x| [x, x] }
+
+      iter.next.should eq(1)
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq(2)
+      iter.next.should eq(3)
+      iter.next.should eq(3)
+
+      iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
+    end
+
+    it "flattens returned items" do
+      iter = [1, 2, 3].each.flat_map { |x| x }
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq(3)
+
+      iter.rewind.to_a.should eq([1, 2, 3])
+    end
+
+    it "flattens returned iterators" do
+      iter = [1, 2, 3].each.flat_map { |x| [x, x].each }
+
+      iter.next.should eq(1)
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq(2)
+      iter.next.should eq(3)
+      iter.next.should eq(3)
+
+      iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
+    end
+
+    it "flattens returned values" do
+      iter = [1, 2, 3].each.flat_map do |x|
+        case x
+        when 1
+          x
+        when 2
+          [x, x]
+        else
+          [x, x].each
+        end
+      end
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq(2)
+      iter.next.should eq(3)
+      iter.next.should eq(3)
+
+      iter.rewind.to_a.should eq([1, 2, 2, 3, 3])
+    end
+  end
 end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -396,11 +396,11 @@ module Enumerable(T)
   #     ["Alice", "Bob"].flat_map do |user|
   #       user.chars
   #     end  #=> ['A', 'l', 'i', 'c', 'e', 'B', 'o', 'b']
-  def flat_map(&block : T -> Array(U) | U) forall U
+  def flat_map(&block : T -> Array(U) | Iterator(U) | U) forall U
     ary = [] of U
     each do |e|
-      v = yield e
-      if v.is_a?(Array)
+      case v = yield e
+      when Array, Iterator
         ary.concat(v)
       else
         ary.push(v)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -475,6 +475,84 @@ module Iterator(T)
     end
   end
 
+  # Returns a new iterator with the concatenated results of running the block (which is expected to return arrays or iterators)
+  # once for every element in the collection.
+  #
+  #     iter = [1, 2, 3].each.flat_map { |x| [x, x] }
+  #
+  #     iter.next #=> [1, 1]
+  #     iter.next #=> [2, 2]
+  #     iter.next #=> [3, 3]
+  #
+  #     iter = [1, 2, 3].each.flat_map { |x| [x, x].each }
+  #
+  #     iter.to_a #=> [1, 1, 2, 2, 3, 3]
+  #
+  def flat_map(&func : T -> Array(U) | Iterator(U) | U) forall U
+    FlatMap(typeof(self), U, typeof(FlatMap.iterator_type(self, func)), typeof(func)).new self, func
+  end
+
+  private class FlatMap(I0, T, I, F)
+    include Iterator(T)
+    include IteratorWrapper
+
+    @iterator : I0
+    @func : F
+    @nest_iterator : I?
+    @stopped : Array(I)
+
+    def initialize(@iterator, @func)
+      @nest_iterator = nil
+      @stopped = [] of I
+    end
+
+    def next
+      if iter = @nest_iterator
+        value = iter.next
+        if value.is_a?(Stop)
+          @stopped << iter
+          @nest_iterator = nil
+          self.next
+        else
+          value
+        end
+      else
+        case value = @func.call wrapped_next
+        when Array
+          @nest_iterator = value.each
+          self.next
+        when Iterator
+          @nest_iterator = value
+          self.next
+        else
+          value
+        end
+      end
+    end
+
+    def rewind
+      @nest_iterator.try &.rewind
+      @nest_iterator = nil
+      @stopped.each &.rewind
+      @stopped.clear
+      super
+    end
+
+    def self.iterator_type(iter, func)
+      value = iter.next
+      raise "" if value.is_a?(Stop)
+
+      case value = func.call value
+      when Array
+        value.each
+      when Iterator
+        value
+      else
+        raise ""
+      end
+    end
+  end
+
   # Returns an iterator that chunks the iterator's elements in arrays of *size*
   # filling up the remaining elements if no element remains with nil or a given
   # optional parameter.


### PR DESCRIPTION
And, `Enumerable#flat_map`  flatten `Iterator` like `Array#flatten` now.

In Ruby, `Enumrator::Lazy#flat_map` returns `Enumerator::Lazy`, so I think it is good that `Iterator#flat_map` returns a iterator like Ruby.