### PR TITLE
Fixed Iterator#map_with_index

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -599,6 +599,12 @@ describe "Enumerable" do
       result = ["Alice", "Bob"].map_with_index { |name, i| "User ##{i}: #{name}" }
       result.should eq ["User #0: Alice", "User #1: Bob"]
     end
+
+    it "yields the element and the index of an iterator" do
+      str = "hello"
+      result = str.each_char.map_with_index { |char, i| "#{char}#{i}" }
+      result.should eq ["h0", "e1", "l2", "l3", "o4"]
+    end
   end
 
   describe "max" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -618,7 +618,7 @@ module Enumerable(T)
   #
   #     ["Alice", "Bob"].map_with_index { |name, i| "User ##{i}: #{name}" }  #=> ["User #0: Alice", "User #1: Bob"]
   #
-  def map_with_index(&block : T, Int32 -> U)
+  def map_with_index(&block : T, Int32 -> U) forall U
     ary = [] of U
     each_with_index { |e, i| ary << yield e, i }
     ary


### PR DESCRIPTION
A missing `forall U` was the reason Iterator#map_with_index wouldn't compile.

I added the missing statement and wrote a small test case. Is it in the right spec?

BTW: [Here](https://travis-ci.com/KCreate/charly-lang/builds/37187003) is the build log that first uncovered the bug.