### PR TITLE
Fix: UNIXServer shouldn't delete path on bind failures

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -149,6 +149,23 @@ describe UNIXServer do
     end
   end
 
+  it "won't delete existing file on bind failure" do
+    path = "/tmp/crystal-test-unix.sock"
+
+    File.write(path, "")
+    File.exists?(path).should be_true
+
+    begin
+      expect_raises Errno, /(already|Address) in use/ do
+        UNIXServer.new(path)
+      end
+
+      File.exists?(path).should be_true
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
   describe "accept" do
     it "returns the client UNIXSocket" do
       UNIXServer.open("/tmp/crystal-test-unix-sock") do |server|

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -29,7 +29,7 @@ class UNIXServer < UNIXSocket
     super(Family::UNIX, type)
 
     bind(UNIXAddress.new(path)) do |error|
-      close
+      close(delete: false)
       raise error
     end
 
@@ -65,10 +65,10 @@ class UNIXServer < UNIXSocket
   end
 
   # Closes the socket, then deletes the filesystem pathname if it exists.
-  def close
-    super
+  def close(delete = true)
+    super()
   ensure
-    if path = @path
+    if delete && (path = @path)
       File.delete(path) if File.exists?(path)
       @path = nil
     end


### PR DESCRIPTION
fixes #3764