### PR TITLE
Fix to concat a union of arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -396,6 +396,12 @@ describe "Array" do
       a.concat(1..4)
       a.@capacity.should eq(6)
     end
+
+    it "concats a union of arrays" do
+      a = [1, '2']
+      a.concat([3] || ['4'])
+      a.should eq([1, '2', 3])
+    end
   end
 
   describe "delete" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -554,12 +554,24 @@ class Array(T)
 
   # Appends the elements of *other* to `self`, and returns `self`.
   #
+  # It is synonym for `other.concat_to(self)`.
+  #
   # ```
   # ary = ["a", "b"]
   # ary.concat(["c", "d"])
   # ary # => ["a", "b", "c", "d"]
   # ```
-  def concat(other : Array)
+  def concat(other)
+    other.concat_to(self)
+  end
+
+  # :nodoc:
+  def concat_to(array)
+    array.concat_array(self)
+  end
+
+  # :nodoc:
+  def concat_array(other : Array(T))
     other_size = other.size
     new_size = size + other_size
     if new_size > @capacity
@@ -572,8 +584,8 @@ class Array(T)
     self
   end
 
-  # ditto
-  def concat(other : Enumerable)
+  # :nodoc:
+  def concat_enumerable(other : Enumerable(T))
     left_before_resize = @capacity - @size
     len = @size
     buf = @buffer + len

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1143,4 +1143,14 @@ module Enumerable(T)
       hash[item[0]] = item[1]
     end
   end
+
+  # Appends the elements of `self` to *array* and returns *array*.
+  #
+  #     ary = ['a', 'b']
+  #     ('c'..'d').concat_to(ary)
+  #     ary # => ['a', 'b', 'c', 'd']
+  #
+  def concat_to(array)
+    array.concat_enumerable(self)
+  end
 end


### PR DESCRIPTION
It is cannot be compiled:

```crystal
p [1, 2.0].concat([3] || [4.0])

# can't cast (Pointer(Float64) | Pointer(Int32)) to Pointer(Void)
```

This pull request fixes it by adding `Array#concat_to` and `Enumerable#concat_to`, and forwarding from `Array#concat` to them.