### PR TITLE
Do not add `libs/` to `.gitignore`

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -40,14 +40,12 @@ module Crystal
       gitignore.should contain("/.shards/")
       gitignore.should contain("/shard.lock")
       gitignore.should contain("/lib/")
-      gitignore.should contain("/libs/")
     end
 
     describe_file "example_app/.gitignore" do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should_not contain("/shard.lock")
       gitignore.should contain("/lib/")
-      gitignore.should contain("/libs/")
     end
 
     describe_file "example/LICENSE" do |license|

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,5 +1,4 @@
 /doc/
-/libs/
 /lib/
 /bin/
 /.shards/


### PR DESCRIPTION
As `libs/` was removed in 663c75d we do not need to gitignore `libs/`
anymore.

See also #3593