### PR TITLE
Sockets: docs for IPAddress, Addrinfo + some helpers

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -114,6 +114,13 @@ describe Socket::Addrinfo do
       end
     end
   end
+
+  describe "#ip_address" do
+    assert do
+      addrinfos = Socket::Addrinfo.udp("localhost", 80)
+      typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
+    end
+  end
 end
 
 describe Socket::IPAddress do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -64,6 +64,58 @@ describe Socket do
   end
 end
 
+describe Socket::Addrinfo do
+  describe ".resolve" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::STREAM)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+
+    it "eventually raises returned error" do
+      expect_raises(Socket::Error) do |addrinfo|
+        Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
+          Socket::Error.new("please fail")
+        end
+      end
+    end
+  end
+
+  describe ".tcp" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.tcp("localhost", 80)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.tcp("localhost", 80) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+  end
+
+  describe ".udp" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.udp("localhost", 80)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.udp("localhost", 80) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+  end
+end
+
 describe Socket::IPAddress do
   it "transforms an IPv4 address into a C struct and back" do
     addr1 = Socket::IPAddress.new("127.0.0.1", 8080)
@@ -81,6 +133,12 @@ describe Socket::IPAddress do
     addr2.family.should eq(addr1.family)
     addr2.port.should eq(addr1.port)
     addr2.address.should eq(addr1.address)
+  end
+
+  it "won't resolve domains" do
+    expect_raises(Socket::Error, /Invalid IP address/) do
+      Socket::IPAddress.new("localhost", 1234)
+    end
   end
 
   it "to_s" do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -367,6 +367,14 @@ describe UNIXSocket do
 end
 
 describe TCPServer do
+  it "creates a raw socket" do
+    sock = TCPServer.new
+    sock.family.should eq(Socket::Family::INET)
+
+    sock = TCPServer.new(Socket::Family::INET6)
+    sock.family.should eq(Socket::Family::INET6)
+  end
+
   it "fails when port is in use" do
     port = free_udp_socket_port
 
@@ -386,6 +394,14 @@ describe TCPServer do
 end
 
 describe TCPSocket do
+  it "creates a raw socket" do
+    sock = TCPSocket.new
+    sock.family.should eq(Socket::Family::INET)
+
+    sock = TCPSocket.new(Socket::Family::INET6)
+    sock.family.should eq(Socket::Family::INET6)
+  end
+
   it "sends and receives messages" do
     port = TCPServer.open("::", 0) do |server|
       server.local_address.port
@@ -483,6 +499,14 @@ describe TCPSocket do
 end
 
 describe UDPSocket do
+  it "creates a raw socket" do
+    sock = UDPSocket.new
+    sock.family.should eq(Socket::Family::INET)
+
+    sock = UDPSocket.new(Socket::Family::INET6)
+    sock.family.should eq(Socket::Family::INET6)
+  end
+
   it "reads and writes data to server" do
     port = free_udp_socket_port
 

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -153,9 +153,11 @@ class Socket
       end
     end
 
+    @ip_address : IPAddress?
+
     # Returns an `IPAddress` matching this addrinfo.
     def ip_address
-      @ip_address = IPAddress.from(@addr, @addrlen)
+      @ip_address ||= IPAddress.from(to_unsafe, size)
     end
 
     def to_unsafe

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -17,6 +17,11 @@ require "./tcp_socket"
 class TCPServer < TCPSocket
   include Socket::Server
 
+  # Creates a new `TCPServer`, waiting to be bound.
+  def self.new(family : Family = Family::INET)
+    super(family)
+  end
+
   def initialize(host : String, port : Int, backlog = SOMAXCONN, dns_timeout = nil)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol)

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -12,6 +12,11 @@ require "./ip_socket"
 # client.close
 # ```
 class TCPSocket < IPSocket
+  # Creates a new `TCPSocket`, waiting to be connected.
+  def self.new(family : Family = Family::INET)
+    super(family, Type::STREAM, Protocol::TCP)
+  end
+
   # Creates a new TCP connection to a remote TCP server.
   #
   # You may limit the DNS resolution time with `dns_timeout` and limit the


### PR DESCRIPTION
- Adds documentation to `Socket::IPAddress` and `Socket::Addrinfo`, to differentiate how they are different: one holds an IP address when the other will resolve against a DNS server or `/etc/hosts`.
- Adds overloads to `Socket::Addrinfo` that return an `Array(Socket::Addrinfo)` instead of yielding results.
- Adds argless constructors to `TCPSocket` and `TCPServer` that don't connect nor bind.