### PR TITLE
Fix #830 .step() .upto() .downto() and .to() arguments

### DIFF
--- a/samples/binary-trees.cr
+++ b/samples/binary-trees.cr
@@ -35,7 +35,7 @@ stretch_tree = nil
 
 long_lived_tree = bottom_up_tree(0, max_depth)
 
-min_depth.step(max_depth + 1, 2) do |depth|
+min_depth.step(to: max_depth + 1, by: 2) do |depth|
   iterations = 2**(max_depth - depth + min_depth)
 
   check = 0

--- a/samples/mandelbrot.cr
+++ b/samples/mandelbrot.cr
@@ -23,8 +23,8 @@ def mandelconverge(real, imag)
 end
 
 def mandelhelp(xmin, xmax, xstep, ymin, ymax, ystep)
-  ymin.step(ymax, ystep) do |y|
-    xmin.step(xmax, xstep) do |x|
+  ymin.step(to: ymax, by: ystep) do |y|
+    xmin.step(to: xmax, by: xstep) do |x|
       print_density mandelconverge(x, y)
     end
     puts

--- a/samples/mandelbrot2.cr
+++ b/samples/mandelbrot2.cr
@@ -4,8 +4,8 @@ def mandelbrot(a)
   Iterator.of(a).first(100).reduce(a) { |z, c| z*z + c }
 end
 
-(1.0).step(-1, -0.05) do |y|
-  (-2.0).step(0.5, 0.0315) do |x|
+(1.0).step(to: -1, by: -0.05) do |y|
+  (-2.0).step(to: 0.5, by: 0.0315) do |x|
     print mandelbrot(x + y.i).abs < 2 ? '*' : ' '
   end
   puts

--- a/samples/sieve.cr
+++ b/samples/sieve.cr
@@ -5,9 +5,9 @@ sieve = Array.new(max + 1, true)
 sieve[0] = false
 sieve[1] = false
 
-2.step(Math.sqrt(max)) do |i|
+2.step(to: Math.sqrt(max)) do |i|
   if sieve[i]
-    (i * i).step(max, i) do |j|
+    (i * i).step(to: max, by: i) do |j|
       sieve[j] = false
     end
   end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -297,7 +297,7 @@ describe "Int" do
   describe "step" do
     it "steps through limit" do
       passed = false
-      1.step(1) { |x| passed = true }
+      1.step(to: 1) { |x| passed = true }
       fail "expected step to pass through 1" unless passed
     end
   end

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -156,27 +156,39 @@ describe "Number" do
     ary[2].should eq(300.to_u8)
   end
 
-  it "steps from int to float" do
-    count = 0
-    0.step(by: 0.1, limit: 0.3) do |x|
-      typeof(x).should eq(typeof(0.1))
-      case count
-      when 0 then x.should eq(0.0)
-      when 1 then x.should eq(0.1)
-      when 2 then x.should eq(0.2)
+  describe "step" do
+    it "from int to float" do
+      count = 0
+      0.step(by: 0.1, to: 0.3) do |x|
+        typeof(x).should eq(typeof(0.1))
+        case count
+        when 0 then x.should eq(0.0)
+        when 1 then x.should eq(0.1)
+        when 2 then x.should eq(0.2)
+        end
+        count += 1
       end
-      count += 1
     end
-  end
 
-  it "does step iterator" do
-    iter = 0.step(by: 0.1, limit: 0.3)
-    iter.next.should eq(0.0)
-    iter.next.should eq(0.1)
-    iter.next.should eq(0.2)
-    iter.next.should be_a(Iterator::Stop)
+    it "iterator" do
+      iter = 0.step(by: 0.1, to: 0.3)
+      iter.next.should eq(0.0)
+      iter.next.should eq(0.1)
+      iter.next.should eq(0.2)
+      iter.next.should be_a(Iterator::Stop)
 
-    iter.rewind
-    iter.next.should eq(0.0)
+      iter.rewind
+      iter.next.should eq(0.0)
+    end
+
+    it "iterator without limit" do
+      iter = 0.step
+
+      1000.times do
+        iter.next
+      end
+
+      iter.next.should eq(1000)
+    end
   end
 end

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -97,7 +97,7 @@ class Crypto::Bcrypt
     cdata = CIPHER_TEXT.dup
     size = cdata.size
 
-    0.step(4, 2) do |i|
+    0.step(to: 4, by: 2) do |i|
       64.times do
         l, r = blowfish.encrypt_pair(cdata[i], cdata[i + 1])
         cdata[i], cdata[i + 1] = l, r

--- a/src/crypto/bcrypt/blowfish.cr
+++ b/src/crypto/bcrypt/blowfish.cr
@@ -21,7 +21,7 @@ class Crypto::Bcrypt::Blowfish < Crypto::Blowfish
 
     l, r, pos = 0, 0, 0
 
-    0.step(17, 2) do |i|
+    0.step(to: 17, by: 2) do |i|
       l ^= next_word(data, pointerof(pos))
       r ^= next_word(data, pointerof(pos))
       l, r = encrypt_pair(l, r)
@@ -30,7 +30,7 @@ class Crypto::Bcrypt::Blowfish < Crypto::Blowfish
     end
 
     0.upto(3) do |i|
-      0.step(255, 2) do |j|
+      0.step(to: 255, by: 2) do |j|
         l ^= next_word(data, pointerof(pos))
         r ^= next_word(data, pointerof(pos))
         l, r = encrypt_pair(l, r)

--- a/src/crypto/blowfish.cr
+++ b/src/crypto/blowfish.cr
@@ -18,14 +18,14 @@ class Crypto::Blowfish
 
     l, r = 0, 0
 
-    0.step(17, 2) do |i|
+    0.step(to: 17, by: 2) do |i|
       l, r = encrypt_pair(l, r)
       @p[i] = l
       @p[i + 1] = r
     end
 
     0.upto(3) do |i|
-      0.step(255, 2) do |j|
+      0.step(to: 255, by: 2) do |j|
         l, r = encrypt_pair(l, r)
         @s[i][j] = l
         @s[i][j + 1] = r

--- a/src/int.cr
+++ b/src/int.cr
@@ -341,45 +341,45 @@ struct Int
     TimesIterator(typeof(self)).new(self)
   end
 
-  def upto(n, &block : self ->)
+  def upto(to, &block : self ->)
     x = self
-    while x <= n
+    while x <= to
       yield x
       x += 1
     end
     self
   end
 
-  def upto(n)
-    UptoIterator(typeof(self), typeof(n)).new(self, n)
+  def upto(to)
+    UptoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  def downto(n, &block : self ->)
+  def downto(to, &block : self ->)
     x = self
-    while x >= n
+    while x >= to
       yield x
       x -= 1
     end
     self
   end
 
-  def downto(n)
-    DowntoIterator(typeof(self), typeof(n)).new(self, n)
+  def downto(to)
+    DowntoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  def to(n, &block : self ->)
-    if self < n
-      upto(n) { |i| yield i }
-    elsif self > n
-      downto(n) { |i| yield i }
+  def to(to, &block : self ->)
+    if self < to
+      upto(to) { |i| yield i }
+    elsif self > to
+      downto(to) { |i| yield i }
     else
       yield self
     end
     self
   end
 
-  def to(n)
-    self <= n ? upto(n) : downto(n)
+  def to(to)
+    self <= to ? upto(to) : downto(to)
   end
 
   def modulo(other)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -858,15 +858,15 @@ module Iterator(T)
     include Iterator(T)
     include IteratorWrapper
 
-    def initialize(@iterator : I, @n : N)
-      raise ArgumentError.new("n must be greater or equal 1") if @n < 1
+    def initialize(@iterator : I, @by : N)
+      raise ArgumentError.new("n must be greater or equal 1") if @by < 1
     end
 
     def next
       value = @iterator.next
       return stop if value.is_a?(Stop)
 
-      (@n - 1).times do
+      (@by - 1).times do
         @iterator.next
       end
 

--- a/src/number.cr
+++ b/src/number.cr
@@ -71,10 +71,10 @@ struct Number
   end
 
   # Invokes the given block with the sequence of numbers starting at `self`,
-  # incremented by *by* on each call, and with an optional *limit*.
+  # incremented by *by* on each call, and with an optional *to*.
   #
   # ```
-  # 3.step(by: 2, limit: 10) do |n|
+  # 3.step(to: 10, by: 2) do |n|
   #   puts n
   # end
   # ```
@@ -87,17 +87,17 @@ struct Number
   # 7
   # 9
   # ```
-  def step(limit = nil, by = 1)
+  def step(*, to = nil, by = 1)
     x = self + (by - by)
 
-    if limit
+    if to
       if by > 0
-        while x <= limit
+        while x <= to
           yield x
           x += by
         end
       elsif by < 0
-        while x >= limit
+        while x >= to
           yield x
           x += by
         end
@@ -112,8 +112,8 @@ struct Number
     self
   end
 
-  def step(limit = nil, by = 1)
-    StepIterator.new(self + (by - by), limit, by)
+  def step(*, to = nil, by = 1)
+    StepIterator.new(self + (by - by), to, by)
   end
 
   # Returns the absolute value of this number.
@@ -242,20 +242,20 @@ struct Number
     include Iterator(T)
 
     @n : T
-    @limit : L
+    @to : L
     @by : B
     @original : T
 
-    def initialize(@n : T, @limit : L, @by : B)
+    def initialize(@n : T, @to : L, @by : B)
       @original = @n
     end
 
     def next
-      if limit = @limit
+      if to = @to
         if @by > 0
-          return stop if @n > limit
+          return stop if @n > to
         elsif @by < 0
-          return stop if @n < limit
+          return stop if @n < to
         end
 
         value = @n

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -68,7 +68,7 @@ class Random::ISAAC
     4.times(&mix)
 
     scramble = ->(seed : StaticArray(UInt32, 256)) {
-      0.step(255, 8) do |i|
+      0.step(to: 255, by: 8) do |i|
         a += seed[i]; b += seed[i + 1]; c += seed[i + 2]; d += seed[i + 3]
         e += seed[i + 4]; f += seed[i + 5]; g += seed[i + 6]; h += seed[i + 7]
         mix.call

--- a/src/range.cr
+++ b/src/range.cr
@@ -166,13 +166,13 @@ struct Range(B, E)
   # ```
   #
   # See `Range`'s overview for the definition of `Xs`.
-  def step(n = 1)
+  def step(by = 1)
     current = @begin
     while current < @end
       yield current
-      n.times { current = current.succ }
+      by.times { current = current.succ }
     end
-    yield current if current == @end && !@exclusive
+    yield current if !@exclusive &&  current == @end
     self
   end
 
@@ -181,8 +181,8 @@ struct Range(B, E)
   # ```
   # (1..10).step(3).skip(1).to_a # => [4, 7, 10]
   # ```
-  def step(n : Int = 1)
-    StepIterator(self, B, typeof(n)).new(self, n)
+  def step(by = 1)
+    StepIterator(self, B, typeof(by)).new(self, by)
   end
 
   # Returns true if this range excludes the *end* element.


### PR DESCRIPTION
Renaming of arguments for `.step()` function as mentioned in https://github.com/crystal-lang/crystal/issues/830

- For Iterator `[1,2,3,4,5].each.step([by:]2)`
- For Number `2.step(to: 10, by: 2)` - required named arguments


For discussion: I was thinking about rename arguments for methods like `.upto()` in same manner. `.upto(n: 2)` will be `.upto(to: 2)`. What do you think?