### PR TITLE
Implement Kernel#p(NamedTuple)

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -92,6 +92,18 @@ def p(*objects)
   objects
 end
 
+# Pretty prints each object in *objects* to STDOUT, followed
+# by a newline. Returns *objects*.
+#
+# ```
+# p foo: 23, bar: 42 # => {foo: 23, bar: 42}
+# ```
+#
+# See `Object#pretty_print(pp)`
+def p(**objects)
+  p(objects)
+end
+
 # :nodoc:
 module AtExitHandlers
   @@running = false


### PR DESCRIPTION
Before this commit `p`ing a simple key values was cumbersome:

    p({foo: 23, bar: 42})

Other variations did not work:

    p {foo: 23, bar: 42}
    Syntax error in eval:1: expecting token 'CONST', not '23'

    p foo: 23, bar: 42
    Error in line 1: no argument named 'foo'
    Matches are:
     - p(object)
     - p(*objects) (trying this one)

After this commit this possible:

    p foo: 23, bar: 42
    {foo: 23, bar: 42}