### PR TITLE
Add Iterator#auto_rewind? and auto_rewind=

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -11,7 +11,7 @@ describe Iterator do
     it "creates singleton from block" do
       a = 0
       iter = Iterator.of { a += 1 }
-      iter.first(3).to_a.should eq([1, 2, 3])
+      iter = iter.first(3).to_a.should eq([1, 2, 3])
     end
   end
 
@@ -697,6 +697,31 @@ describe Iterator do
       iter.next.should eq(3)
 
       iter.rewind.to_a.should eq([1, 2, 2, 3, 3])
+    end
+  end
+
+  describe "auto_rewind?" do
+    it "default value is true" do
+      [1, 2, 3].each.auto_rewind?.should be_true
+    end
+
+    it "rewinds after each" do
+      iter = [1, 2, 3].each
+      iter.to_a.should eq([1, 2, 3])
+      iter.to_a.should eq([1, 2, 3])
+    end
+
+    it "doesn't rewind after each if auto_rewind? is false" do
+      iter = [1, 2, 3].each
+      iter.auto_rewind = false
+      iter.to_a.should eq([1, 2, 3])
+      iter.to_a.should eq([] of Int32)
+    end
+
+    it "inherits value" do
+      iter = [1, 2, 3].each
+      iter.auto_rewind = false
+      iter.first(2).auto_rewind?.should be_false
     end
   end
 end


### PR DESCRIPTION
If `Iterator#auto_rewind?` returns `true`, the iterator is rewinded after `Iterator#each` automatically. Otherwise it returns false, the iterator is not rewinded.

`Iterator#auto_rewind?` default value is true, it is just breaking change.

This feature motivation is to be able to apply more `Enumerable` algorithm to `Iterator`. In current implementation, `Iterator#each` works only first time.