### PR TITLE
Fix: Socket.unix

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -62,6 +62,18 @@ describe Socket do
     Socket.ip?("::0::ffff:c0a8:5e4").should be_false
     Socket.ip?("c0a8").should be_false
   end
+
+  describe ".unix" do
+    it "creates a unix socket" do
+      sock = Socket.unix
+      sock.should be_a(Socket)
+      sock.family.should eq(Socket::Family::UNIX)
+      sock.type.should eq(Socket::Type::STREAM)
+
+      sock = Socket.unix(Socket::Type::DGRAM)
+      sock.type.should eq(Socket::Type::DGRAM)
+    end
+  end
 end
 
 describe Socket::Addrinfo do

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -52,7 +52,7 @@ class Socket < IO::FileDescriptor
 
   # Creates an UNIX socket. Consider using `UNIXSocket` or `UNIXServer` unless
   # you need full control over the socket.
-  def self.unix(type : Type = Type::Stream, blocking = false)
+  def self.unix(type : Type = Type::STREAM, blocking = false)
     new(Family::UNIX, type, blocking: blocking)
   end
 


### PR DESCRIPTION
`Socket.unix` is broken due to a tiny typo, and it has no references from spec.

```shell
in src/socket.cr:55: undefined constant Type::Stream (did you mean 'Type::STREAM')
  def self.unix(type : Type = Type::Stream, blocking = false)
```

#### This PR
- Fixed `Socket.unix`
- Added a simple spec for it to avoid dead code

```crystal
Socket.unix.family # => UNIX
```

Thanks.