### PR TITLE
Add XML.build and XML::Writer

### DIFF
--- a/spec/std/xml/writer_spec.cr
+++ b/spec/std/xml/writer_spec.cr
@@ -1,0 +1,244 @@
+require "spec"
+require "xml"
+
+private def assert_written(expected)
+  io = IO::Memory.new
+  writer = XML::Writer.new(io)
+  with writer yield writer
+  writer.flush
+  io.rewind
+  io.to_s.should eq(expected)
+end
+
+describe XML::Writer do
+  it "writes document" do
+    assert_written(%[<?xml version=\"1.0\"?>\n\n]) do
+      document { }
+    end
+  end
+
+  it "writes element" do
+    assert_written(%[<?xml version="1.0"?>\n<foo/>\n]) do
+      document do
+        element("foo") { }
+      end
+    end
+  end
+
+  it "writes nested element" do
+    assert_written(%[<?xml version="1.0"?>\n<foo><bar/></foo>\n]) do
+      document do
+        element("foo") do
+          element("bar") { }
+        end
+      end
+    end
+  end
+
+  it "writes element with namspace" do
+    assert_written(%[<?xml version="1.0"?>\n<x:foo id="1" xmlns:x="http://foo.com"/>\n]) do
+      document do
+        element("x", "foo", "http://foo.com", id: 1) { }
+      end
+    end
+  end
+
+  it "writes element with namspace, without block" do
+    assert_written(%[<?xml version="1.0"?>\n<x:foo id="1" xmlns:x="http://foo.com"/>\n]) do
+      document do
+        element("x", "foo", "http://foo.com", id: 1)
+      end
+    end
+  end
+
+  it "writes attribute" do
+    assert_written(%[<?xml version="1.0"?>\n<foo id="1"/>\n]) do
+      document do
+        element("foo") do
+          attribute("id", 1)
+        end
+      end
+    end
+  end
+
+  it "writes attribute with namespace" do
+    assert_written(%[<?xml version="1.0"?>\n<foo x:id="1" xmlns:x="http://ww.foo.com"/>\n]) do
+      document do
+        element("foo") do
+          attribute("x", "id", "http://ww.foo.com", 1)
+        end
+      end
+    end
+  end
+
+  it "writes text" do
+    assert_written(%[<?xml version="1.0"?>\n<foo>1 &lt; 2</foo>\n]) do
+      document do
+        element("foo") do
+          text "1 < 2"
+        end
+      end
+    end
+  end
+
+  it "sets indent with string" do
+    assert_written("<?xml version=\"1.0\"?>\n<foo>\n\t<bar/>\n</foo>\n") do |writer|
+      writer.indent = "\t"
+      document do
+        element("foo") do
+          element("bar")
+        end
+      end
+    end
+  end
+
+  it "sets indent with count" do
+    assert_written("<?xml version=\"1.0\"?>\n<foo>\n  <bar/>\n</foo>\n") do |writer|
+      writer.indent = 2
+      document do
+        element("foo") do
+          element("bar")
+        end
+      end
+    end
+  end
+
+  it "sets quote char" do
+    assert_written("<?xml version='1.0'?>\n<foo id='1'/>\n") do |writer|
+      writer.quote_char = '\''
+      document do
+        element("foo") do
+          attribute("id", 1)
+        end
+      end
+    end
+  end
+
+  it "writes element with attributes as named tuple" do
+    assert_written(%[<?xml version="1.0"?>\n<foo id="1" name="foo"/>\n]) do |writer|
+      document do
+        element("foo", id: 1, name: "foo")
+      end
+    end
+  end
+
+  it "writes element with attributes as named tuple, nesting" do
+    assert_written(%[<?xml version="1.0"?>\n<foo id="1" name="foo" baz="2"/>\n]) do |writer|
+      document do
+        element("foo", id: 1, name: "foo") do
+          attribute "baz", 2
+        end
+      end
+    end
+  end
+
+  it "writes element with attributes as hash" do
+    assert_written(%[<?xml version="1.0"?>\n<foo id="1" name="foo"/>\n]) do |writer|
+      document do
+        element("foo", {"id" => 1, "name" => "foo"})
+      end
+    end
+  end
+
+  it "writes element with attributes as hash, nesting" do
+    assert_written(%[<?xml version="1.0"?>\n<foo id="1" name="foo" baz="2"/>\n]) do |writer|
+      document do
+        element("foo", {"id" => 1, "name" => "foo"}) do
+          attribute "baz", 2
+        end
+      end
+    end
+  end
+
+  it "writes cdata" do
+    assert_written(%{<?xml version="1.0"?>\n<foo><![CDATA[hello]]></foo>\n}) do |writer|
+      document do
+        element("foo") do
+          cdata("hello")
+        end
+      end
+    end
+  end
+
+  it "writes cdata with block" do
+    assert_written(%{<?xml version="1.0"?>\n<foo><![CDATA[hello]]></foo>\n}) do |writer|
+      document do
+        element("foo") do
+          cdata do
+            text "hello"
+          end
+        end
+      end
+    end
+  end
+
+  it "writes comment" do
+    assert_written(%{<?xml version="1.0"?>\n<foo><!--hello--></foo>\n}) do |writer|
+      document do
+        element("foo") do
+          comment("hello")
+        end
+      end
+    end
+  end
+
+  it "writes comment with block" do
+    assert_written(%{<?xml version="1.0"?>\n<foo><!--hello--></foo>\n}) do |writer|
+      document do
+        element("foo") do
+          comment do
+            text "hello"
+          end
+        end
+      end
+    end
+  end
+
+  it "writes DTD" do
+    assert_written(%{<?xml version="1.0"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" [subset]>\n}) do |writer|
+      document do
+        dtd "html", "-//W3C//DTD XHTML 1.0 Transitional//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd", "subset"
+      end
+    end
+  end
+
+  it "writes DTD with block" do
+    assert_written(%{<?xml version="1.0"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" [subset]>\n}) do |writer|
+      document do
+        dtd "html", "-//W3C//DTD XHTML 1.0 Transitional//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" do
+          text "subset"
+        end
+      end
+    end
+  end
+
+  it "writes namespace" do
+    assert_written(%{<?xml version="1.0"?>\n<foo x:xmlns="http://foo.com"/>\n}) do |writer|
+      document do
+        element("foo") do
+          namespace "x", "http://foo.com"
+        end
+      end
+    end
+  end
+
+  it "writes to string" do
+    str = XML.build do |xml|
+      xml.element("foo", id: 1) do
+        xml.text "hello"
+      end
+    end
+    str.should eq("<?xml version=\"1.0\"?>\n<foo id=\"1\">hello</foo>\n")
+  end
+
+  it "writes to IO" do
+    io = IO::Memory.new
+    XML.build(io) do |xml|
+      xml.element("foo", id: 1) do
+        xml.text "hello"
+      end
+    end
+    io.rewind
+    io.to_s.should eq("<?xml version=\"1.0\"?>\n<foo id=\"1\">hello</foo>\n")
+  end
+end

--- a/src/xml.cr
+++ b/src/xml.cr
@@ -1,5 +1,7 @@
 # The XML module allows parsing and generating [XML](https://www.w3.org/XML/) documents.
 #
+# ### Parsing
+#
 # `XML#parse` will parse xml from `String` or `IO` and return xml document as an `XML:Node` which represents all kinds of xml nodes.
 #
 # Example:
@@ -26,6 +28,23 @@
 #     puts child.content                               # Jane : String?
 #   end
 # end
+# ```
+#
+# ## Generating
+#
+# Use `XML.build`, which uses an `XML::Writer`:
+#
+# ```
+# require "xml"
+#
+# string = XML.build(indent: "  ") do |xml|
+#   xml.element("person", id: 1) do
+#     xml.element("firstname") { xml.text "Jane" }
+#     xml.element("lastname") { xml.text "Doe" }
+#   end
+# end
+#
+# string # => "<?xml version=\"1.0\"?>\n<person id=\"1\">\n  <firstname>Jane</firstname>\n  <lastname>Doe</lastname>\n</person>\n"
 # ```
 module XML
   SUBSTITUTIONS = {

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -139,6 +139,47 @@ lib LibXML
   fun xmlSaveTree(ctx : SaveCtxPtr, node : Node*) : LibC::Long
   fun xmlSaveClose(ctx : SaveCtxPtr) : Int
 
+  struct OutputBuffer
+    context : Void*
+    writecallback : OutputWriteCallback
+    closecallback : OutputCloseCallback
+    xmlCharEncodingHandlerPtr : Void*
+    buffer : Void*
+    conv : Void*
+    writter : Int
+    error : Int
+  end
+
+  type TextWriter = Void*
+
+  fun xmlNewTextWriter(out : OutputBuffer*) : TextWriter
+  fun xmlTextWriterStartDocument(TextWriter, version : UInt8*, encoding : UInt8*, standalone : UInt8*) : Int
+  fun xmlTextWriterEndDocument(TextWriter) : Int
+  fun xmlTextWriterStartElement(TextWriter, name : UInt8*) : Int
+  fun xmlTextWriterEndElement(TextWriter) : Int
+  fun xmlTextWriterStartAttribute(TextWriter, name : UInt8*) : Int
+  fun xmlTextWriterEndAttribute(TextWriter) : Int
+  fun xmlTextWriterFlush(TextWriter) : Int
+  fun xmlTextWriterSetIndent(TextWriter, indent : Int) : Int
+  fun xmlTextWriterSetIndentString(TextWriter, str : UInt8*) : Int
+  fun xmlTextWriterSetQuoteChar(TextWriter, char : UInt8) : Int
+  fun xmlTextWriterWriteAttribute(TextWriter, name : UInt8*, content : UInt8*) : Int
+  fun xmlTextWriterWriteString(TextWriter, content : UInt8*) : Int
+  fun xmlTextWriterStartAttributeNS(TextWriter, prefix : UInt8*, name : UInt8*, namespaceURI : UInt8*) : Int
+  fun xmlTextWriterWriteAttributeNS(TextWriter, prefix : UInt8*, name : UInt8*, namespaceURI : UInt8*, content : UInt8*) : Int
+  fun xmlTextWriterStartElementNS(TextWriter, prefix : UInt8*, name : UInt8*, namespaceURI : UInt8*) : Int
+  fun xmlTextWriterStartCDATA(TextWriter) : Int
+  fun xmlTextWriterEndCDATA(TextWriter) : Int
+  fun xmlTextWriterWriteCDATA(TextWriter, content : UInt8*) : Int
+  fun xmlTextWriterStartComment(TextWriter) : Int
+  fun xmlTextWriterEndComment(TextWriter) : Int
+  fun xmlTextWriterWriteComment(TextWriter, content : UInt8*) : Int
+  fun xmlTextWriterStartDTD(TextWriter, name : UInt8*, pubid : UInt8*, sysid : UInt8*) : Int
+  fun xmlTextWriterEndDTD(TextWriter) : Int
+  fun xmlTextWriterWriteDTD(TextWriter, name : UInt8*, pubid : UInt8*, sysid : UInt8*, subset : UInt8*) : Int
+
+  fun xmlOutputBufferCreateIO(iowrite : OutputWriteCallback, ioclose : OutputCloseCallback, ioctx : Void*, encoder : Void*) : OutputBuffer*
+
   enum ErrorLevel
     NONE    = 0
     WARNING = 1

--- a/src/xml/writer.cr
+++ b/src/xml/writer.cr
@@ -1,0 +1,312 @@
+module XML
+  # Returns the resulting String of writing XML to the yielded `XML::Writer`.
+  #
+  # ```
+  # require "xml"
+  #
+  # string = XML.build(indent: "  ") do |xml|
+  #   xml.element("person", id: 1) do
+  #     xml.element("firstname") { xml.text "Jane" }
+  #     xml.element("lastname") { xml.text "Doe" }
+  #   end
+  # end
+  #
+  # string # => "<?xml version=\"1.0\"?>\n<person id=\"1\">\n  <firstname>Jane</firstname>\n  <lastname>Doe</lastname>\n</person>\n"
+  # ```
+  def self.build(version : String? = nil, encoding : String? = nil, indent = nil)
+    String.build do |str|
+      build(str, version, encoding, indent) do |xml|
+        yield xml
+      end
+    end
+  end
+
+  # Writes XML into the given IO. An `XML::Writer` is yielded to the block.
+  def self.build(io : IO, version : String? = nil, encoding : String? = nil, indent = nil)
+    xml = XML::Writer.new(io)
+    xml.indent = indent if indent
+    v = xml.document(version, encoding) do
+      yield xml
+    end
+    xml.flush
+    v
+  end
+
+  # An XML writer.
+  struct Writer
+    @box : Void*
+
+    # Creates a writer that writes to the given *io*.
+    def initialize(io : IO)
+      @box = Box.box(io)
+      buffer = LibXML.xmlOutputBufferCreateIO(
+        ->(ctx, buffer, len) {
+          Box(IO).unbox(ctx).write(Slice.new(buffer, len))
+          len
+        },
+        ->(ctx) {
+          Box(IO).unbox(ctx).flush
+          0
+        },
+        @box,
+        nil
+      )
+      @writer = LibXML.xmlNewTextWriter(buffer)
+    end
+
+    # Emits the start of the document.
+    def start_document(version = nil, encoding = nil) : Nil
+      call StartDocument, version, encoding, nil
+    end
+
+    # Emits the end of a document.
+    def end_document : Nil
+      call EndDocument
+    end
+
+    # Emits the start of the document, invokes the block,
+    # and then emits the end of the document.
+    def document(version = nil, encoding = nil)
+      start_document version, encoding
+      yield.tap { end_document }
+    end
+
+    # Emits the start of an element.
+    def start_element(name : String) : Nil
+      call StartElement, name
+    end
+
+    # Emits the start of an element with namespace info.
+    def start_element(prefix : String?, name : String, namespace_uri : String?) : Nil
+      call StartElementNS, string_to_unsafe(prefix), name, string_to_unsafe(namespace_uri)
+    end
+
+    # Emits the end of an element.
+    def end_element : Nil
+      call EndElement
+    end
+
+    # Emits the start of an element with the given attributes,
+    # invokes the block and then emits the end of the element.
+    def element(__name__ : String, **attributes)
+      element(__name__, attributes) do
+        yield
+      end
+    end
+
+    # ditto
+    def element(__name__ : String, attributes : Hash | NamedTuple)
+      start_element __name__
+      attributes(attributes)
+      yield.tap { end_element }
+    end
+
+    # Emits an element with the given attributes.
+    def element(__name__ : String, **attributes)
+      element(__name__, attributes)
+    end
+
+    # ditto
+    def element(name : String, attributes : Hash | NamedTuple)
+      element(name, attributes) { }
+    end
+
+    # Emits the start of an element with namespace info with the given attributes,
+    # invokes the block and then emits the end of the element.
+    def element(__prefix__ : String?, __name__ : String, __namespace_uri__ : String?, **attributes)
+      element(__prefix__, __name__, __namespace_uri__, attributes) do
+        yield
+      end
+    end
+
+    # ditto
+    def element(__prefix__ : String?, __name__ : String, __namespace_uri__ : String?, attributes : Hash | NamedTuple)
+      start_element __prefix__, __name__, __namespace_uri__
+      attributes(attributes)
+      yield.tap { end_element }
+    end
+
+    # Emits an element with namespace info with the given attributes.
+    def element(prefix : String?, name : String, namespace_uri : String?, **attributes)
+      element(prefix, name, namespace_uri, attributes)
+    end
+
+    # ditto
+    def element(prefix : String?, name : String, namespace_uri : String?, attributes : Hash | NamedTuple)
+      start_element(prefix, name, namespace_uri)
+      attributes(attributes)
+      end_element
+    end
+
+    # Emits the start of an attribute.
+    def start_attribute(name : String) : Nil
+      call StartAttribute, name
+    end
+
+    # Emits the start of an attribute with namespace info.
+    def start_attribute(prefix : String?, name : String, namespace_uri : String?)
+      call StartAttributeNS, string_to_unsafe(prefix), name, string_to_unsafe(namespace_uri)
+    end
+
+    # Emits the end of an attribute.
+    def end_attribute : Nil
+      call EndAttribute
+    end
+
+    # Emits the start of an attribute, invokes the block,
+    # and then emits the end of the attribute.
+    def attribute(*args, **nargs)
+      start_attribute *args, **nargs
+      yield.tap { end_attribute }
+    end
+
+    # Emits an attribute with a value.
+    def attribute(name : String, value) : Nil
+      call WriteAttribute, name, value.to_s
+    end
+
+    # Emits an attribute with namespace info and a value.
+    def attribute(prefix : String?, name : String, namespace_uri : String?, value) : Nil
+      call WriteAttributeNS, string_to_unsafe(prefix), name, string_to_unsafe(namespace_uri), value.to_s
+    end
+
+    # Emits the given attributes with their values.
+    def attributes(**attributes)
+      attributes(attributes)
+    end
+
+    # ditto
+    def attributes(attributes : Hash | NamedTuple)
+      attributes.each do |key, value|
+        attribute key.to_s, value
+      end
+    end
+
+    # Emits text content.
+    #
+    # Text content can happen inside of an `element`, `attribute` value, `cdata`, `dtd`, etc.
+    def text(content : String) : Nil
+      call WriteString, content
+    end
+
+    # Emits the start of a CDATA section.
+    def start_cdata : Nil
+      call StartCDATA
+    end
+
+    # Emits the end of a CDATA section.
+    def end_cdata : Nil
+      call EndCDATA
+    end
+
+    # Emits the start of a CDATA section, invokes the block
+    # and then emits the end of the CDATA section.
+    def cdata
+      start_cdata
+      yield.tap { end_cdata }
+    end
+
+    # Emits a CDATA section.
+    def cdata(text : String) : Nil
+      call WriteCDATA, text
+    end
+
+    # Emits the start of a comment.
+    def start_comment : Nil
+      call StartComment
+    end
+
+    # Emits the end of a comment.
+    def end_comment : Nil
+      call EndComment
+    end
+
+    # Emits the start of a comment, invokes the block
+    # and then emits the end of the comment.
+    def comment
+      start_comment
+      yield.tap { end_comment }
+    end
+
+    # Emits a comment.
+    def comment(text : String) : Nil
+      call WriteComment, text
+    end
+
+    # Emits the start of a DTD.
+    def start_dtd(name : String, pubid : String, sysid : String) : Nil
+      call StartDTD, name, pubid, sysid
+    end
+
+    # Emits the end of a DTD.
+    def end_dtd : Nil
+      call EndDTD
+    end
+
+    # Emits the start of a DTD, invokes the block
+    # and then emits the end of the DTD.
+    def dtd(name : String, pubid : String, sysid : String) : Nil
+      start_dtd name, pubid, sysid
+      yield.tap { end_dtd }
+    end
+
+    # Emits a DTD.
+    def dtd(name : String, pubid : String, sysid : String, subset : String? = nil) : Nil
+      call WriteDTD, name, pubid, sysid, string_to_unsafe(subset)
+    end
+
+    # Emits a namespace.
+    def namespace(prefix, uri)
+      attribute prefix, "xmlns", nil, uri
+    end
+
+    # Forces content written to this writer to be flushed to
+    # this writer's IO.
+    def flush
+      call Flush
+    end
+
+    # Sets the indent string.
+    def indent=(str : String)
+      if str.empty?
+        call SetIndent, 0
+      else
+        call SetIndent, 1
+        call SetIndentString, str
+      end
+    end
+
+    # Sets the indent level (number of spaces)
+    def indent=(level : Int)
+      if level <= 0
+        call SetIndent, 0
+      else
+        call SetIndent, 1
+        call SetIndentString, " " * level
+      end
+    end
+
+    # Set the quote char to use, either ' or ".
+    def quote_char=(char : Char)
+      unless char == '\'' || char == '"'
+        raise ArgumentError.new("quote char must be ' or \", not #{char}")
+      end
+
+      call SetQuoteChar, char.ord
+    end
+
+    # TODO: mark as private
+    macro call(name, *args)
+      ret = LibXML.xmlTextWriter{{name}}(@writer, {{*args}})
+      check ret, {{@def.name.stringify}}
+    end
+
+    private def check(ret, msg)
+      raise XML::Error.new("error in #{msg}", 0) if ret < 0
+    end
+
+    private def string_to_unsafe(string)
+      string ? string.to_unsafe : Pointer(UInt8).null
+    end
+  end
+end


### PR DESCRIPTION
Right now it's impossible to generate correct XML in an easy way. This PR fixes that. It wraps a libxml2 writer. Writing to the writer directly writes to the underlying IO.

Example:

```cr
require "xml"

string = XML.write(indent: "  ") do |xml|
  xml.element("person", id: 1) do
    xml.element("firstname") { xml.text "Jane" }
    xml.element("lastname") { xml.text "Doe" }
  end
end

puts string
```

Output:

```xml
<?xml version="1.0"?>
<person id="1">
  <firstname>Jane</firstname>
  <lastname>Doe</lastname>
</person>
```

As you can see, there's no "magic" in the writer. You have to call `element` to emit elements. You also have `attribute`, `text` and other methods to emit these individually.

I thought about either adding a separate `XML::Builder` class that uses `method_missing` and is similar to [Nokogiri::XML::Builder](http://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Builder), or either adding that functionality to `XML::Writer`, but I'm not sure about that. For example in Nokogiri you have to use `type_` or `object_id_` (with an ending underscore) if you need these names so they don't conflict with existing methods. Also you basically have to learn a new mini-language for emitting stuff, and it gets a bit more complex when namespaces and attributes are involved. So I prefer to keep things simple and straight-forward here (though a builder using `method_missing` is definitely possible (in master)).