### PR TITLE
Fixed `Iterator#uniq` with block

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -449,7 +449,7 @@ describe Iterator do
     end
 
     it "with block" do
-      iter = (1..8).each.uniq { |x| x % 3 }
+      iter = (1..8).each.uniq { |x| (x % 3).to_s }
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should eq(3)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1013,7 +1013,7 @@ module Iterator(T)
     include IteratorWrapper
 
     def initialize(@iterator : I, @func : T -> U)
-      @hash = {} of T => Bool
+      @hash = {} of U => Bool
     end
 
     def next


### PR DESCRIPTION
Current implementation works only with `block : T -> T`, otherwise it breaks.

#### master : `Crystal 0.20.3+40 [a62dff3] (2016-12-30)`

```crystal
(1..3).each.uniq(&.+ 1).next   # => 1
(1..3).each.uniq(&.even?).next
```

```text
instantiating 'Iterator::Uniq(Range::ItemIterator(Int32, Int32), Int32, Bool)#next()'
in /home/maiha/git/maiha/crystal/src/iterator.cr:1025: no overload matches 'Hash(Int32, Bool)#[]=' with types Bool, Bool
Overloads are:
 - Hash(K, V)#[]=(key : K, value : V)

          @hash[transformed] = true
```

#### This PR : `Crystal 0.20.3+41 [d9fca7b] (2016-12-30)`

- Fixed code to keep flags with `U`
- Fixed spec to use block `T -> U` rather than `T -> T`

```crystal
(1..3).each.uniq(&.+ 1).next   # => 1
(1..3).each.uniq(&.even?).next # => 1
```

Thanks.