### PR TITLE
Replace /bin/bash with /bin/sh

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ################## https://github.com/mkropat/sh-realpath #####################
 #

--- a/bin/crystal
+++ b/bin/crystal
@@ -111,6 +111,34 @@ remove_path_item() {
 
 ##############################################################################
 
+__has_colors() {
+  local num_colors=$(tput colors 2>/dev/null)
+
+  if [ "$num_colors" -gt 2 ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+SUPPORTS_COLORS=$(__has_colors)
+__error_msg() {
+  if $SUPPORTS_COLORS; then
+    # bold red coloring
+    printf '%b\n' "\033[31;1m$@\033[0m" 1>&2
+  else
+    printf '%b\n' "$@" 1>&2
+  fi
+}
+__warning_msg() {
+  if $SUPPORTS_COLORS; then
+    # brown coloring
+    printf '%b\n' "\033[33m$@\033[0m" 1>&2
+  else
+    printf '%b\n' "$@" 1>&2
+  fi
+}
+
+
 SCRIPT_PATH="$(realpath "$0")"
 SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
@@ -121,11 +149,11 @@ export CRYSTAL_HAS_WRAPPER=true
 
 if [ -x "$CRYSTAL_DIR/crystal" ]
 then
-  >&2 echo -e "\x1B[33mUsing compiled compiler at .build/crystal\x1B[0m"
+  __warning_msg "Using compiled compiler at \`.build/crystal'"
   exec "$CRYSTAL_DIR/crystal" "$@"
 elif ! command -v crystal > /dev/null
 then
-  echo -e "\x1B[31mYou need to have a crystal executable in your path!\x1B[0m" 1>&2
+  __error_msg 'You need to have a crystal executable in your path!'
   exit 1
 elif [ "$(command -v crystal)" = "$SCRIPT_PATH" ] || [ "$(command -v crystal)" = "bin/crystal" ]
 then


### PR DESCRIPTION
This also addresses idiosyncrasies with `echo` versus `printf` (see [StackExchange answer](http://unix.stackexchange.com/a/65819/190757) about this).

Since bash is a more fully-featured shell and `sh` (in Ubuntu, this is aliased to `/bin/dash`) is lighter weight, it makes more sense to use `sh` to run the realpath script in `./bin/crystal`. I've benchmarked it on my system and there's a very slight increase in performance. It also, in part, reduces dependencies to run crystal.

Changes were made to the escape sequence coloring to support more shells, also per [StackExchange](http://stackoverflow.com/a/37351799). 