### PR TITLE
Support LLVM 4

### DIFF
--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -92,13 +92,13 @@ module Crystal
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
           offset = @program.target_machine.data_layout.offset_of_element(struct_type, idx + (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
-          member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, offset * 8, 0, ivar_debug_type)
+          member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, offset * 8, LLVM::DIFlags::Zero, ivar_debug_type)
           element_types << member
         end
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      debug_type = di_builder.create_struct_type(nil, type.to_s, nil, 1, size, size, 0, nil, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_struct_type(nil, type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, di_builder.get_or_create_type_array(element_types))
       unless type.struct?
         debug_type = di_builder.create_pointer_type(debug_type, llvm_typer.pointer_size * 8, llvm_typer.pointer_size * 8, type.to_s)
       end
@@ -128,7 +128,17 @@ module Crystal
 
     def declare_variable(var_name, var_type, alloca, location)
       declare_local(var_type, alloca, location) do |scope, file, line_number, debug_type|
-        di_builder.create_auto_variable scope, var_name, file, line_number, debug_type
+        di_builder.create_auto_variable scope, var_name, file, line_number, debug_type, align_of(var_type)
+      end
+    end
+
+    private def align_of(type)
+      case type
+      when CharType    then 32
+      when IntegerType then type.bits
+      when FloatType   then type.bytes * 8
+      when BoolType    then 8
+      else                  0 # unsupported
       end
     end
 
@@ -238,7 +248,7 @@ module Crystal
       file, dir = file_and_dir(filename)
       scope = di_builder.create_file(file, dir)
       fn_metadata = di_builder.create_function(scope, MAIN_NAME, MAIN_NAME, scope,
-        0, fun_metadata_type, true, true, 0, 0_u32, false, main_fun)
+        0, fun_metadata_type, true, true, 0, LLVM::DIFlags::Zero, false, main_fun)
       fun_metadatas[main_fun] = fn_metadata
     end
 
@@ -249,7 +259,8 @@ module Crystal
       file, dir = file_and_dir(location.filename)
       scope = di_builder.create_file(file, dir)
       fn_metadata = di_builder.create_function(scope, target_def.name, target_def.name, scope,
-        location.line_number, fun_metadata_type, true, true, location.line_number, 0_u32, false, context.fun)
+        location.line_number, fun_metadata_type, true, true,
+        location.line_number, LLVM::DIFlags::Zero, false, context.fun)
       fun_metadatas[context.fun] = fn_metadata
     end
   end

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -34,10 +34,14 @@ class Crystal::CodeGenVisitor
       func.return_type,
       func.varargs?
     )
-    func.params.to_a.zip(new_fun.params.to_a) do |p1, p2|
-      val = p1.attributes
-      p2.add_attribute val if val.value != 0
+
+    p2 = new_fun.params.to_a
+
+    func.params.to_a.each_with_index do |p1, index|
+      attrs = new_fun.attributes(index + 1)
+      new_fun.add_attribute(attrs, index + 1) unless attrs.value == 0
     end
+
     new_fun
   end
 
@@ -287,7 +291,7 @@ class Crystal::CodeGenVisitor
       abi_arg_type = abi_info.arg_types[i]
 
       if attr = abi_arg_type.attr
-        param.add_attribute attr
+        context.fun.add_attribute(attr, i + offset + 1)
       end
 
       i += 1 unless abi_arg_type.kind == LLVM::ABI::ArgKind::Ignore
@@ -295,7 +299,7 @@ class Crystal::CodeGenVisitor
 
     # This is for sret
     if (attr = abi_info.return_type.attr) && attr == LLVM::Attribute::StructRet
-      context.fun.params[0].add_attribute attr
+      context.fun.add_attribute(attr, 1)
     end
 
     args
@@ -369,7 +373,7 @@ class Crystal::CodeGenVisitor
       if !is_fun_literal && (i == 0 && self_type.passed_as_self?)
         # here self is already in context.vars
       else
-        create_local_copy_of_arg(target_def, target_def_vars, arg, param)
+        create_local_copy_of_arg(target_def, target_def_vars, arg, param, i + offset)
       end
     end
   end
@@ -385,11 +389,11 @@ class Crystal::CodeGenVisitor
 
   def create_local_copy_of_block_args(target_def, self_type, call_args, args_base_index)
     target_def.args.each_with_index do |arg, i|
-      create_local_copy_of_arg(target_def, target_def.vars, arg, call_args[args_base_index + i])
+      create_local_copy_of_arg(target_def, target_def.vars, arg, call_args[args_base_index + i], args_base_index + i)
     end
   end
 
-  def create_local_copy_of_arg(target_def, target_def_vars, arg, value)
+  def create_local_copy_of_arg(target_def, target_def_vars, arg, value, index)
     # An argument name can be "_" in the case of a captured block,
     # and we must ignore these
     return if arg.name == "_"
@@ -411,7 +415,7 @@ class Crystal::CodeGenVisitor
     else
       # If it's an extern struct on a def that must be codegened with C ABI
       # compatibility, and it's not passed byval, we must cast the value
-      if target_def.c_calling_convention? && arg.type.extern? && !value.attributes.by_val?
+      if target_def.c_calling_convention? && arg.type.extern? && !context.fun.attributes(index + 1).by_val?
         pointer = alloca(llvm_type(var_type), arg.name)
         casted_pointer = bit_cast pointer, value.type.pointer
         store value, casted_pointer
@@ -428,14 +432,14 @@ class Crystal::CodeGenVisitor
           pointer = alloca(llvm_type(var_type), arg.name)
           context.vars[arg.name] = LLVMVar.new(pointer, var_type)
 
-          if arg.type.passed_by_value? && !value.attributes.by_val?
+          if arg.type.passed_by_value? && !context.fun.attributes(index + 1).by_val?
             # Create an alloca and store it there, so assign works well
             pointer2 = alloca(llvm_type(arg.type))
             store value, pointer2
             value = pointer2
           end
         else
-          if arg.type.passed_by_value? && !value.attributes.by_val?
+          if arg.type.passed_by_value? && !context.fun.attributes(index + 1).by_val?
             # For pass-by-value we create an alloca so the value
             # is behind a pointer, as everywhere else
             pointer = alloca(llvm_type(var_type), arg.name)

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -43,12 +43,12 @@ struct LLVM::DIBuilder
     {% end %}
   end
 
-  def create_auto_variable(scope, name, file, line, type)
-    LibLLVMExt.di_builder_create_auto_variable(self, scope, name, file, line, type, 0, 0)
+  def create_auto_variable(scope, name, file, line, type, align_in_bits)
+    LibLLVMExt.di_builder_create_auto_variable(self, scope, name, file, line, type, 0, DIFlags::Zero, align_in_bits)
   end
 
   def create_parameter_variable(scope, name, argno, file, line, type)
-    LibLLVMExt.di_builder_create_parameter_variable(self, scope, name, argno, file, line, type, 0, 0)
+    LibLLVMExt.di_builder_create_parameter_variable(self, scope, name, argno, file, line, type, 0, DIFlags::Zero)
   end
 
   def create_expression(addr, length)

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -1,34 +1,182 @@
 module LLVM
-  @[Flags]
-  enum Attribute : UInt32
-    ZExt            = 1 << 0
-    SExt            = 1 << 1
-    NoReturn        = 1 << 2
-    InReg           = 1 << 3
-    StructRet       = 1 << 4
-    NoUnwind        = 1 << 5
-    NoAlias         = 1 << 6
-    ByVal           = 1 << 7
-    Nest            = 1 << 8
-    ReadNone        = 1 << 9
-    ReadOnly        = 1 << 10
-    NoInline        = 1 << 11
-    AlwaysInline    = 1 << 12
-    OptimizeForSize = 1 << 13
-    StackProtect    = 1 << 14
-    StackProtectReq = 1 << 15
-    Alignment       = 31 << 16
-    NoCapture       = 1 << 21
-    NoRedZone       = 1 << 22
-    NoImplicitFloat = 1 << 23
-    Naked           = 1 << 24
-    InlineHint      = 1 << 25
-    StackAlignment  = 7 << 26
-    ReturnsTwice    = 1 << 29
-    UWTable         = 1 << 30
-    NonLazyBind     = 1 << 31
-    # AddressSafety = 1_u64 << 32,
-    # StackProtectStrong = 1_u64 << 33
+  {% if LibLLVM.has_constant?(:AttributeRef) %}
+    @[Flags]
+    enum Attribute : UInt64
+      None = 0
+      Alignment = 1 << 0
+      AllocSize = 1 << 1
+      AlwaysInline = 1 << 2
+      ArgMemOnly = 1 << 3
+      Builtin = 1 << 4
+      ByVal = 1 << 5
+      Cold = 1 << 6
+      Convergent = 1 << 7
+      Dereferenceable = 1 << 8
+      DereferenceableOrNull = 1 << 9
+      InAlloca = 1 << 10
+      InReg = 1 << 11
+      InaccessibleMemOnly = 1 << 12
+      InaccessibleMemOrArgMemOnly = 1 << 13
+      InlineHint = 1 << 14
+      JumpTable = 1 << 15
+      MinSize = 1 << 16
+      Naked = 1 << 17
+      Nest = 1 << 18
+      NoAlias = 1 << 19
+      NoBuiltin = 1 << 20
+      NoCapture = 1 << 21
+      NoDuplicate = 1 << 22
+      NoImplicitFloat = 1 << 23
+      NoInline = 1 << 24
+      NoRecurse = 1 << 25
+      NoRedZone = 1 << 26
+      NoReturn = 1 << 27
+      NoUnwind = 1 << 28
+      NonLazyBind = 1 << 29
+      NonNull = 1 << 30
+      OptimizeForSize = 1 << 31
+      OptimizeNone = 1 << 32
+      ReadNone = 1 << 33
+      ReadOnly = 1 << 34
+      Returned = 1 << 35
+      ReturnsTwice = 1 << 36
+      SExt = 1 << 37
+      SafeStack = 1 << 38
+      SanitizeAddress = 1 << 39
+      SanitizeMemory = 1 << 40
+      SanitizeThread = 1 << 41
+      StackAlignment = 1 << 42
+      StackProtect = 1 << 43
+      StackProtectReq = 1 << 44
+      StackProtectStrong = 1 << 45
+      StructRet = 1 << 46
+      SwiftError = 1 << 47
+      SwiftSelf = 1 << 48
+      UWTable = 1 << 49
+      WriteOnly = 1 << 50
+      ZExt = 1 << 51
+
+      @@kind_ids = load_llvm_kinds_from_names.as(Hash(Attribute, UInt32))
+
+      def each_kind(&block)
+        return if value == 0
+        \{% for member in @type.constants %}
+          \{% if member.stringify != "All" %}
+            if includes?(\{{@type}}::\{{member}})
+              yield @@kind_ids[\{{@type}}::\{{member}}]
+            end
+          \{% end %}
+        \{% end %}
+      end
+
+      private def self.kind_for_name(name : String)
+        LibLLVM.get_enum_attribute_kind_for_name(name, name.bytesize)
+      end
+
+      private def self.load_llvm_kinds_from_names
+        kinds = {} of Attribute => UInt32
+        kinds[Alignment]                   = kind_for_name("align")
+        kinds[AllocSize]                   = kind_for_name("allocsize")
+        kinds[AlwaysInline]                = kind_for_name("alwaysinline")
+        kinds[ArgMemOnly]                  = kind_for_name("argmemonly")
+        kinds[Builtin]                     = kind_for_name("builtin")
+        kinds[ByVal]                       = kind_for_name("byval")
+        kinds[Cold]                        = kind_for_name("cold")
+        kinds[Convergent]                  = kind_for_name("convergent")
+        kinds[Dereferenceable]             = kind_for_name("dereferenceable")
+        kinds[DereferenceableOrNull]       = kind_for_name("dereferenceable_or_null")
+        kinds[InAlloca]                    = kind_for_name("inalloca")
+        kinds[InReg]                       = kind_for_name("inreg")
+        kinds[InaccessibleMemOnly]         = kind_for_name("inaccessiblememonly")
+        kinds[InaccessibleMemOrArgMemOnly] = kind_for_name("inaccessiblemem_or_argmemonly")
+        kinds[InlineHint]                  = kind_for_name("inlinehint")
+        kinds[JumpTable]                   = kind_for_name("jumptable")
+        kinds[MinSize]                     = kind_for_name("minsize")
+        kinds[Naked]                       = kind_for_name("naked")
+        kinds[Nest]                        = kind_for_name("nest")
+        kinds[NoAlias]                     = kind_for_name("noalias")
+        kinds[NoBuiltin]                   = kind_for_name("nobuiltin")
+        kinds[NoCapture]                   = kind_for_name("nocapture")
+        kinds[NoDuplicate]                 = kind_for_name("noduplicate")
+        kinds[NoImplicitFloat]             = kind_for_name("noimplicitfloat")
+        kinds[NoInline]                    = kind_for_name("noinline")
+        kinds[NoRecurse]                   = kind_for_name("norecurse")
+        kinds[NoRedZone]                   = kind_for_name("noredzone")
+        kinds[NoReturn]                    = kind_for_name("noreturn")
+        kinds[NoUnwind]                    = kind_for_name("nounwind")
+        kinds[NonLazyBind]                 = kind_for_name("nonlazybind")
+        kinds[NonNull]                     = kind_for_name("nonnull")
+        kinds[OptimizeForSize]             = kind_for_name("optsize")
+        kinds[OptimizeNone]                = kind_for_name("optnone")
+        kinds[ReadNone]                    = kind_for_name("readnone")
+        kinds[ReadOnly]                    = kind_for_name("readonly")
+        kinds[Returned]                    = kind_for_name("returned")
+        kinds[ReturnsTwice]                = kind_for_name("returns_twice")
+        kinds[SExt]                        = kind_for_name("signext")
+        kinds[SafeStack]                   = kind_for_name("safestack")
+        kinds[SanitizeAddress]             = kind_for_name("sanitize_address")
+        kinds[SanitizeMemory]              = kind_for_name("sanitize_memory")
+        kinds[SanitizeThread]              = kind_for_name("sanitize_thread")
+        kinds[StackAlignment]              = kind_for_name("alignstack")
+        kinds[StackProtect]                = kind_for_name("ssp")
+        kinds[StackProtectReq]             = kind_for_name("sspreq")
+        kinds[StackProtectStrong]          = kind_for_name("sspstrong")
+        kinds[StructRet]                   = kind_for_name("sret")
+        kinds[SwiftError]                  = kind_for_name("swifterror")
+        kinds[SwiftSelf]                   = kind_for_name("swiftself")
+        kinds[UWTable]                     = kind_for_name("uwtable")
+        kinds[WriteOnly]                   = kind_for_name("writeonly")
+        kinds[ZExt]                        = kind_for_name("zeroext")
+        kinds
+      end
+
+      def self.kind_for(member)
+        @@kind_ids[member]
+      end
+
+      def self.from_kind(kind)
+        @@kind_ids.key(kind)
+      end
+    end
+  {% else %}
+    @[Flags]
+    enum Attribute : UInt32
+      ZExt            = 1 << 0
+      SExt            = 1 << 1
+      NoReturn        = 1 << 2
+      InReg           = 1 << 3
+      StructRet       = 1 << 4
+      NoUnwind        = 1 << 5
+      NoAlias         = 1 << 6
+      ByVal           = 1 << 7
+      Nest            = 1 << 8
+      ReadNone        = 1 << 9
+      ReadOnly        = 1 << 10
+      NoInline        = 1 << 11
+      AlwaysInline    = 1 << 12
+      OptimizeForSize = 1 << 13
+      StackProtect    = 1 << 14
+      StackProtectReq = 1 << 15
+      Alignment       = 31 << 16
+      NoCapture       = 1 << 21
+      NoRedZone       = 1 << 22
+      NoImplicitFloat = 1 << 23
+      Naked           = 1 << 24
+      InlineHint      = 1 << 25
+      StackAlignment  = 7 << 26
+      ReturnsTwice    = 1 << 29
+      UWTable         = 1 << 30
+      NonLazyBind     = 1 << 31
+      # AddressSafety = 1_u64 << 32,
+      # StackProtectStrong = 1_u64 << 33
+    end
+  {% end %}
+
+  # Attribute index are either ReturnIndex (0), FunctionIndex (-1) or a
+  # parameter number ranging from 1 to N.
+  enum AttributeIndex : UInt32
+    ReturnIndex   = 0_u32
+    FunctionIndex = ~0_u32
   end
 
   enum Linkage

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -196,4 +196,32 @@ module LLVM
     UMax
     UMin
   end
+
+  enum DIFlags : UInt32
+    Zero                = 0
+    Private             = 1
+    Protected           = 2
+    Public              = 3
+    FwdDecl             = 1 << 2
+    AppleBlock          = 1 << 3
+    BlockByrefStruct    = 1 << 4
+    Virtual             = 1 << 5
+    Artificial          = 1 << 6
+    Explicit            = 1 << 7
+    Prototyped          = 1 << 8
+    ObjcClassComplete   = 1 << 9
+    ObjectPointer       = 1 << 10
+    Vector              = 1 << 11
+    StaticMember        = 1 << 12
+    LValueReference     = 1 << 13
+    RValueReference     = 1 << 14
+    ExternalTypeRef     = 1 << 15
+    SingleInheritance   = 1 << 16
+    MultipleInheritance = 2 << 16
+    VirtualInheritance  = 3 << 16
+    IntroducedVirtual   = 1 << 18
+    BitField            = 1 << 19
+    NoReturn            = 1 << 20
+    MainSubprogram      = 1 << 21
+  end
 end

--- a/src/llvm/function.cr
+++ b/src/llvm/function.cr
@@ -15,16 +15,49 @@ struct LLVM::Function
     LibLLVM.set_function_call_convention(self, cc)
   end
 
-  def add_attribute(attribute)
-    LibLLVM.add_function_attr self, attribute
+  def add_attribute(attribute : Attribute, index = AttributeIndex::FunctionIndex)
+    return if attribute.value == 0
+    {% if LibLLVM.has_constant?(:AttributeRef) %}
+      context = LibLLVM.get_module_context(LibLLVM.get_global_parent(self))
+      attribute.each_kind do |kind|
+        attribute_ref = LibLLVM.create_enum_attribute(context, kind, 0)
+        LibLLVM.add_attribute_at_index(self, index, attribute_ref)
+      end
+    {% else %}
+      case index
+      when AttributeIndex::FunctionIndex
+        LibLLVM.add_function_attr(self, attribute)
+      when AttributeIndex::ReturnIndex
+        raise "unsupported: can't set attributes on function return type in LLVM < 3.9"
+      else
+        LibLLVM.add_attribute(params[index.to_i - 1], attribute)
+      end
+    {% end %}
   end
 
   def add_target_dependent_attribute(name, value)
     LibLLVM.add_target_dependent_function_attr self, name, value
   end
 
-  def attributes
-    LibLLVM.get_function_attr(self)
+  def attributes(index = AttributeIndex::FunctionIndex)
+    {% if LibLLVM.has_constant?(:AttributeRef) %}
+      attrs = Attribute::None
+      0.upto(LibLLVM.get_last_enum_attribute_kind) do |kind|
+        if LibLLVM.get_enum_attribute_at_index(self, index, kind)
+          attrs |= Attribute.from_kind(kind)
+        end
+      end
+      attrs
+    {% else %}
+      case index
+      when AttributeIndex::FunctionIndex
+        LibLLVM.get_function_attr(self)
+      when AttributeIndex::ReturnIndex
+        raise "unsupported: can't get attributes from function return type in LLVM < 3.9"
+      else
+        LibLLVM.get_attribute(params[index.to_i - 1])
+      end
+    {% end %}
   end
 
   def function_type

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -1,6 +1,11 @@
 require "./lib_llvm"
 @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.o")]
 lib LibLLVMExt
+  alias Char = LibC::Char
+  alias Int = LibC::Int
+  alias UInt = LibC::UInt
+  alias SizeT = LibC::SizeT
+
   type DIBuilder = Void*
   type Metadata = Void*
 
@@ -9,51 +14,51 @@ lib LibLLVMExt
 
   {% if LibLLVM::IS_36 || LibLLVM::IS_35 %}
     fun di_builder_create_function = LLVMDIBuilderCreateFunction(
-                                                                 builder : DIBuilder, scope : Metadata, name : LibC::Char*,
-                                                                 linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
-                                                                 composite_type : Metadata, is_local_to_unit : LibC::Int, is_definition : LibC::Int,
-                                                                 scope_line : LibC::UInt, flags : LLVM::DIFlags, is_optimized : LibC::Int, func : LibLLVM::ValueRef) : Metadata
+                                                                 builder : DIBuilder, scope : Metadata, name : Char*,
+                                                                 linkage_name : Char*, file : Metadata, line : UInt,
+                                                                 composite_type : Metadata, is_local_to_unit : Int, is_definition : Int,
+                                                                 scope_line : UInt, flags : LLVM::DIFlags, is_optimized : Int, func : LibLLVM::ValueRef) : Metadata
   {% else %}
     fun di_builder_create_function = LLVMDIBuilderCreateFunction(
-                                                                 builder : DIBuilder, scope : Metadata, name : LibC::Char*,
-                                                                 linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
+                                                                 builder : DIBuilder, scope : Metadata, name : Char*,
+                                                                 linkage_name : Char*, file : Metadata, line : UInt,
                                                                  composite_type : Metadata, is_local_to_unit : Bool, is_definition : Bool,
-                                                                 scope_line : LibC::UInt, flags : LLVM::DIFlags, is_optimized : Bool, func : LibLLVM::ValueRef) : Metadata
+                                                                 scope_line : UInt, flags : LLVM::DIFlags, is_optimized : Bool, func : LibLLVM::ValueRef) : Metadata
   {% end %}
 
-  fun di_builder_create_file = LLVMDIBuilderCreateFile(builder : DIBuilder, file : LibC::Char*, dir : LibC::Char*) : Metadata
+  fun di_builder_create_file = LLVMDIBuilderCreateFile(builder : DIBuilder, file : Char*, dir : Char*) : Metadata
   fun di_builder_create_compile_unit = LLVMDIBuilderCreateCompileUnit(builder : DIBuilder,
-                                                                      lang : LibC::UInt, file : LibC::Char*,
-                                                                      dir : LibC::Char*,
-                                                                      producer : LibC::Char*,
-                                                                      optimized : LibC::Int, flags : LibC::Char*,
-                                                                      runtime_version : LibC::UInt) : Metadata
+                                                                      lang : UInt, file : Char*,
+                                                                      dir : Char*,
+                                                                      producer : Char*,
+                                                                      optimized : Int, flags : Char*,
+                                                                      runtime_version : UInt) : Metadata
   fun di_builder_create_lexical_block = LLVMDIBuilderCreateLexicalBlock(builder : DIBuilder,
                                                                         scope : Metadata,
                                                                         file : Metadata,
-                                                                        line : LibC::Int,
-                                                                        column : LibC::Int) : Metadata
+                                                                        line : Int,
+                                                                        column : Int) : Metadata
 
   fun di_builder_create_basic_type = LLVMDIBuilderCreateBasicType(builder : DIBuilder,
-                                                                  name : LibC::Char*,
+                                                                  name : Char*,
                                                                   size_in_bits : UInt64,
                                                                   align_in_bits : UInt64,
-                                                                  encoding : LibC::UInt) : Metadata
+                                                                  encoding : UInt) : Metadata
 
   fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable(builder : DIBuilder,
                                                                         scope : Metadata,
-                                                                        name : LibC::Char*,
-                                                                        file : Metadata, line : LibC::UInt,
+                                                                        name : Char*,
+                                                                        file : Metadata, line : UInt,
                                                                         type : Metadata,
-                                                                        always_preserve : LibC::Int,
+                                                                        always_preserve : Int,
                                                                         flags : LLVM::DIFlags,
                                                                         align_in_bits : UInt32) : Metadata
 
   fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable(builder : DIBuilder,
                                                                                   scope : Metadata,
-                                                                                  name : LibC::Char*, arg_no : LibC::UInt,
-                                                                                  file : Metadata, line : LibC::UInt, type : Metadata,
-                                                                                  always_preserve : LibC::Int, flags : LLVM::DIFlags) : Metadata
+                                                                                  name : Char*, arg_no : UInt,
+                                                                                  file : Metadata, line : UInt, type : Metadata,
+                                                                                  always_preserve : Int, flags : LLVM::DIFlags) : Metadata
 
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
@@ -63,44 +68,44 @@ lib LibLLVMExt
                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
 
   fun di_builder_create_expression = LLVMDIBuilderCreateExpression(builder : DIBuilder,
-                                                                   addr : Int64*, length : LibC::SizeT) : Metadata
+                                                                   addr : Int64*, length : SizeT) : Metadata
 
-  fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray(builder : DIBuilder, data : Metadata*, length : LibC::SizeT) : Metadata
-  fun di_builder_create_enumerator = LLVMDIBuilderCreateEnumerator(builder : DIBuilder, name : LibC::Char*, value : Int64) : Metadata
+  fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
+  fun di_builder_create_enumerator = LLVMDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : Metadata
   fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType(builder : DIBuilder,
-                                                                              scope : Metadata, name : LibC::Char*, file : Metadata, line_number : LibC::UInt,
+                                                                              scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
                                                                               size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
 
-  fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray(builder : DIBuilder, data : Metadata*, length : LibC::SizeT) : Metadata
+  fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
   fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
 
   fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType(builder : DIBuilder,
-                                                                    scope : Metadata, name : LibC::Char*, file : Metadata, line : LibC::UInt, size_in_bits : UInt64,
+                                                                    scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
                                                                     align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
 
   fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType(builder : DIBuilder,
-                                                                    scope : Metadata, name : LibC::Char*, file : Metadata, line : LibC::UInt, size_in_bits : UInt64,
+                                                                    scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
                                                                     align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
 
   fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType(builder : DIBuilder,
                                                                       pointee_type : Metadata,
                                                                       size_in_bits : UInt64,
                                                                       align_in_bits : UInt64,
-                                                                      name : LibC::Char*) : Metadata
+                                                                      name : Char*) : Metadata
 
   {% if LibLLVM::IS_35 || LibLLVM::IS_36 %}
-    fun temporary_md_node = LLVMTemporaryMDNode(context : LibLLVM::ContextRef, mds : Metadata*, count : LibC::UInt) : Metadata
+    fun temporary_md_node = LLVMTemporaryMDNode(context : LibLLVM::ContextRef, mds : Metadata*, count : UInt) : Metadata
     fun metadata_replace_all_uses_with = LLVMMetadataReplaceAllUsesWith(Metadata, Metadata)
   {% else %}
     fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
                                                                                                    scope : Metadata,
-                                                                                                   name : LibC::Char*,
+                                                                                                   name : Char*,
                                                                                                                     file : Metadata,
-                                                                                                   line : LibC::UInt) : Metadata
+                                                                                                   line : UInt) : Metadata
     fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
   {% end %}
 
-  fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, LibC::Int, LibC::Int, Metadata, Metadata)
+  fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, Int, Int, Metadata, Metadata)
 
   fun build_cmpxchg = LLVMExtBuildCmpxchg(builder : LibLLVM::BuilderRef, pointer : LibLLVM::ValueRef, cmp : LibLLVM::ValueRef, new : LibLLVM::ValueRef, success_ordering : LLVM::AtomicOrdering, failure_ordering : LLVM::AtomicOrdering) : LibLLVM::ValueRef
   fun set_ordering = LLVMExtSetOrdering(value : LibLLVM::ValueRef, ordering : LLVM::AtomicOrdering)

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -12,13 +12,13 @@ lib LibLLVMExt
                                                                  builder : DIBuilder, scope : Metadata, name : LibC::Char*,
                                                                  linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
                                                                  composite_type : Metadata, is_local_to_unit : LibC::Int, is_definition : LibC::Int,
-                                                                 scope_line : LibC::UInt, flags : LibC::UInt, is_optimized : LibC::Int, func : LibLLVM::ValueRef) : Metadata
+                                                                 scope_line : LibC::UInt, flags : LLVM::DIFlags, is_optimized : LibC::Int, func : LibLLVM::ValueRef) : Metadata
   {% else %}
     fun di_builder_create_function = LLVMDIBuilderCreateFunction(
                                                                  builder : DIBuilder, scope : Metadata, name : LibC::Char*,
                                                                  linkage_name : LibC::Char*, file : Metadata, line : LibC::UInt,
                                                                  composite_type : Metadata, is_local_to_unit : Bool, is_definition : Bool,
-                                                                 scope_line : LibC::UInt, flags : LibC::UInt, is_optimized : Bool, func : LibLLVM::ValueRef) : Metadata
+                                                                 scope_line : LibC::UInt, flags : LLVM::DIFlags, is_optimized : Bool, func : LibLLVM::ValueRef) : Metadata
   {% end %}
 
   fun di_builder_create_file = LLVMDIBuilderCreateFile(builder : DIBuilder, file : LibC::Char*, dir : LibC::Char*) : Metadata
@@ -45,13 +45,15 @@ lib LibLLVMExt
                                                                         name : LibC::Char*,
                                                                         file : Metadata, line : LibC::UInt,
                                                                         type : Metadata,
-                                                                        always_preserve : LibC::Int, flags : LibC::UInt) : Metadata
+                                                                        always_preserve : LibC::Int,
+                                                                        flags : LLVM::DIFlags,
+                                                                        align_in_bits : UInt32) : Metadata
 
   fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable(builder : DIBuilder,
                                                                                   scope : Metadata,
                                                                                   name : LibC::Char*, arg_no : LibC::UInt,
                                                                                   file : Metadata, line : LibC::UInt, type : Metadata,
-                                                                                  always_preserve : LibC::Int, flags : LibC::UInt) : Metadata
+                                                                                  always_preserve : LibC::Int, flags : LLVM::DIFlags) : Metadata
 
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
@@ -74,11 +76,11 @@ lib LibLLVMExt
 
   fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType(builder : DIBuilder,
                                                                     scope : Metadata, name : LibC::Char*, file : Metadata, line : LibC::UInt, size_in_bits : UInt64,
-                                                                    align_in_bits : UInt64, flags : LibC::UInt, derived_from : Metadata, element_types : Metadata) : Metadata
+                                                                    align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
 
   fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType(builder : DIBuilder,
                                                                     scope : Metadata, name : LibC::Char*, file : Metadata, line : LibC::UInt, size_in_bits : UInt64,
-                                                                    align_in_bits : UInt64, offset_in_bits : UInt64, flags : LibC::UInt, ty : Metadata) : Metadata
+                                                                    align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
 
   fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType(builder : DIBuilder,
                                                                       pointee_type : Metadata,

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -10,16 +10,16 @@ module LLVM::ValueMethods
     String.new LibLLVM.get_value_name(self)
   end
 
-  def add_attribute(attribute)
-    LibLLVM.add_attribute self, attribute
-  end
-
   def add_instruction_attribute(index : Int, attribute : LLVM::Attribute)
-    LibLLVM.add_instr_attribute(self, index, attribute)
-  end
-
-  def attributes
-    LibLLVM.get_attribute(self)
+    return if attribute.value == 0
+    {% if LibLLVM.has_constant?(:AttributeRef) %}
+      attribute.each_kind do |kind|
+        attribute_ref = LibLLVM.create_enum_attribute(LLVM::Context.global, kind, 0)
+        LibLLVM.add_call_site_attribute(self, index, attribute_ref)
+      end
+    {% else %}
+      LibLLVM.add_instr_attribute(self, index, attribute)
+    {% end %}
   end
 
   def constant?


### PR DESCRIPTION
LLVM 4 is due to be released in February, but hey, let's live on the edge for once. Maybe Crystal could get featured in the release notes?

This is mostly about implementing the `LLVMAttribute` to `LLVMAttributeRef` changes introduced in LLVM 3.9 and dropped in LLVM 4. It also fixes some `DIBuilder` changes. See individual commits for some details.

There is a lost commit that adds `Enum#each` for flags enums, but I didn't need it eventually. I can either remove it, or push it to another pull request?