### PR TITLE
Fix each* methods to return a receiver itself

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -333,9 +333,15 @@ describe "Char" do
     end
   end
 
-  it "raises on codepoint bigger than 0x10ffff when doing each_byte" do
-    expect_raises InvalidByteSequenceError do
-      (0x10ffff + 1).unsafe_chr.each_byte { |b| }
+  describe "each_byte" do
+    it "raises on codepoint bigger than 0x10ffff when doing each_byte" do
+      expect_raises InvalidByteSequenceError do
+        (0x10ffff + 1).unsafe_chr.each_byte { |b| }
+      end
+    end
+
+    it "returns self" do
+      'a'.each_byte(&.should eq('a'.ord)).should eq('a')
     end
   end
 

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -115,10 +115,14 @@ describe CSV do
 
   it "can do each" do
     csv = new_csv headers: true
+    ones = [] of String
+    twos = [] of String
     csv.each do
-      csv["one"].should eq("1")
-      break
-    end
+      ones << csv["one"]
+      twos << csv["two"]
+    end.should be(csv)
+    ones.should eq(["1", "3", "5"])
+    twos.should eq([" 2", " 4", ""])
   end
 
   it "can do new with block" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -277,6 +277,14 @@ describe "Deque" do
     a.should eq(Deque{x})
   end
 
+  it "does each" do
+    a = Deque{1}
+    a2 = a.each do |x|
+      x.should eq(1)
+    end
+    a2.should be(a)
+  end
+
   it "does each_index" do
     a = Deque{1, 1, 1}
     b = 0

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -236,7 +236,7 @@ describe "Dir" do
     dir = Dir.new(__DIR__)
     dir.each do |filename|
       filenames << filename
-    end
+    end.should be(dir)
     dir.close
 
     filenames.includes?("dir_spec.cr").should be_true

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -294,7 +294,7 @@ module HTTP
       cookies.each do |cookie|
         cookie.name.should eq "a"
         cookie.value.should eq "b"
-      end
+      end.should be(cookies)
 
       cookie = cookies.each.next
       cookie.should eq Cookie.new("a", "b")

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -29,7 +29,7 @@ describe HTTP::Headers do
     serialized = String.build do |io|
       headers.each do |name, values|
         io << name << ": " << values.first << ";"
-      end
+      end.should be(headers)
     end
 
     serialized.should eq("FOO_BAR: bar;Foobar-foo: baz;")

--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -196,6 +196,11 @@ module HTTP
     end
 
     describe "#each" do
+      it "returns self" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.each { }.should eq(params)
+      end
+
       it "calls provided proc for each name, value pair, including multiple values per one param name" do
         received = [] of {String, String}
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -370,7 +370,7 @@ describe IO do
           line.should eq("cc")
         end
         counter += 1
-      end
+      end.should be(io)
       counter.should eq(3)
     end
 

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -15,6 +15,13 @@ describe Iterator do
     end
   end
 
+  describe "each" do
+    it "returns self" do
+      iter = (1..3).each
+      iter.each { }.should be(iter)
+    end
+  end
+
   describe "compact_map" do
     it "applies the function and removes nil values" do
       iter = (1..3).each.compact_map { |e| e.odd? ? e : nil }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1794,6 +1794,13 @@ describe "String" do
     sprintf("%12.2f %12.2f %6.2f %.2f" % {2.0, 3.0, 4.0, 5.0}).should eq("        2.00         3.00   4.00 5.00")
   end
 
+  it "gets each_char with block" do
+    s = "abc"
+    a = [] of Char
+    s.each_char { |c| a << c }.should be(s)
+    a.should eq(['a', 'b', 'c'])
+  end
+
   it "gets each_char iterator" do
     iter = "abc".each_char
     iter.next.should eq('a')
@@ -1815,6 +1822,13 @@ describe "String" do
 
   it "cycles chars" do
     "abc".each_char.cycle.first(8).join.should eq("abcabcab")
+  end
+
+  it "gets each_byte with block" do
+    s = "abc"
+    a = [] of UInt8
+    s.each_byte { |x| a << x }.should be(s)
+    a.should eq(['a', 'b', 'c'].map &.ord)
   end
 
   it "gets each_byte iterator" do
@@ -1850,11 +1864,17 @@ describe "String" do
     "foo\nbar\r\nbaz\r\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\r\n"])
   end
 
+  it "gets each_line if empty" do
+    s = ""
+    s.each_line { fail "empty_string.each_line don't call block" }.should be(s)
+  end
+
   it "gets each_line" do
     lines = [] of String
-    "foo\n\nbar\r\nbaz\n".each_line do |line|
+    s = "foo\n\nbar\r\nbaz\n"
+    s.each_line do |line|
       lines << line
-    end
+    end.should be(s)
     lines.should eq(["foo", "", "bar", "baz"])
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -712,6 +712,8 @@ struct Char
     else
       raise InvalidByteSequenceError.new("Invalid char value #{dump}")
     end
+
+    self
   end
 
   # Returns the number of UTF-8 bytes in this char.

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -192,6 +192,7 @@ class CSV
     while self.next
       yield self
     end
+    self
   end
 
   # Advanced the cursor to the next row. Must be called once to position

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -270,6 +270,7 @@ class Deque(T)
         yield @buffer[i]
       end
     end
+    self
   end
 
   # Insert a new item before the item at *index*. Items to the right of this one will have their indices incremented.

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -60,6 +60,7 @@ class Dir
     while entry = read
       yield entry
     end
+    self
   end
 
   def each

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -230,6 +230,7 @@ module HTTP
       @cookies.values.each do |cookie|
         yield cookie
       end
+      self
     end
 
     # Returns an iterator over the cookies of this collection.

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -191,6 +191,7 @@ struct HTTP::Headers
     @hash.each do |key, value|
       yield({key.name, value})
     end
+    self
   end
 
   def get(key)

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -233,6 +233,7 @@ module HTTP
           yield({name, value})
         end
       end
+      self
     end
 
     # Deletes first value for provided param name. If there are no values left,

--- a/src/io.cr
+++ b/src/io.cr
@@ -835,6 +835,7 @@ module IO
     while line = gets(*args, **options)
       yield line
     end
+    self
   end
 
   # Returns an `Iterator` for the *lines* in this IO, where a line
@@ -870,6 +871,7 @@ module IO
     while char = read_char
       yield char
     end
+    self
   end
 
   # Returns an `Iterator` for the chars in this IO.
@@ -905,6 +907,7 @@ module IO
     while byte = read_byte
       yield byte
     end
+    self
   end
 
   # Returns an `Iterator` for the bytes in this IO.

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -383,6 +383,7 @@ module Iterator(T)
       break if value.is_a?(Stop)
       yield value
     end
+    self
   end
 
   # Returns an iterator that then returns slices of n elements of the initial

--- a/src/string.cr
+++ b/src/string.cr
@@ -2827,7 +2827,7 @@ class String
   # # => A LITTLE COAT OF STRAW
   # ```
   def each_line(chomp = true)
-    return if empty?
+    return self if empty?
 
     offset = 0
 
@@ -2847,6 +2847,8 @@ class String
     unless offset == bytesize
       yield unsafe_byte_slice_string(offset)
     end
+
+    self
   end
 
   # Returns an `Iterator` which yields each line of this string (see `String#each_line`).

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -45,6 +45,8 @@ struct XML::Attributes
       yield Node.new(props)
       props = props.value.next
     end
+
+    self
   end
 
   def to_s(io)

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -22,6 +22,8 @@ struct XML::NodeSet
     size.times do |i|
       yield internal_at(i)
     end
+
+    self
   end
 
   def empty?


### PR DESCRIPTION
All `each` and methods like `each` should return a receiver itself. For example, current `Deque#each` returns `Range?`, it looks like a bug. (But `each_cons` and some `Enumerable` methods return `nil` same as Ruby)