### PR TITLE
Fixed example codes (semantics)

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -31,7 +31,7 @@
 # `new` method and a `<<` method. `Set` is one such type:
 #
 # ```
-# set = Set{1, 2, 3} # => [1, 2, 3]
+# set = Set{1, 2, 3} # => Set{1, 2, 3}
 # set.class          # => Set(Int32)
 # ```
 #
@@ -313,7 +313,7 @@ class Array(T)
   # ary[0] = 5
   # p ary # => [5,2,3]
   #
-  # ary[3] = 5 # => IndexError
+  # ary[3] = 5 # raises IndexError
   # ```
   @[AlwaysInline]
   def []=(index : Int, value : T)
@@ -449,7 +449,7 @@ class Array(T)
   # a = ["a", "b", "c", "d", "e"]
   # a[1..3]    # => ["b", "c", "d"]
   # a[4..7]    # => ["e"]
-  # a[6..10]   # => Index Error
+  # a[6..10]   # raise IndexError
   # a[5..10]   # => []
   # a[-2...-1] # => ["d"]
   # ```
@@ -469,7 +469,7 @@ class Array(T)
   # ```
   # a = ["a", "b", "c", "d", "e"]
   # a[-3, 3] # => ["c", "d", "e"]
-  # a[6, 1]  # => Index Error
+  # a[6, 1]  # raise IndexError
   # a[1, 2]  # => ["b", "c"]
   # a[5, 1]  # => []
   # ```
@@ -618,7 +618,7 @@ class Array(T)
   # a = ["ant", "bat", "cat", "dog"]
   # a.delete_at(2)  # => "cat"
   # a               # => ["ant", "bat", "dog"]
-  # a.delete_at(99) # => IndexError
+  # a.delete_at(99) # raises IndexError
   # ```
   def delete_at(index : Int)
     index = check_index_out_of_bounds index
@@ -638,7 +638,7 @@ class Array(T)
   # a = ["ant", "bat", "cat", "dog"]
   # a.delete_at(1..2)    # => ["bat", "cat"]
   # a                    # => ["ant", "dog"]
-  # a.delete_at(99..100) # => IndexError
+  # a.delete_at(99..100) # raises IndexError
   # ```
   def delete_at(range : Range(Int, Int))
     from, size = range_to_index_and_count(range)
@@ -654,7 +654,7 @@ class Array(T)
   # a = ["ant", "bat", "cat", "dog"]
   # a.delete_at(1, 2)  # => ["bat", "cat"]
   # a                  # => ["ant", "dog"]
-  # a.delete_at(99, 1) # => IndexError
+  # a.delete_at(99, 1) # raises IndexError
   # ```
   def delete_at(index : Int, count : Int)
     val = self[index, count]
@@ -1014,7 +1014,7 @@ class Array(T)
   # iter.next # => [2, 3, 1]
   # iter.next # => [3, 1, 2]
   # iter.next # => [3, 2, 1]
-  # iter.next # => Iterator::Stop
+  # iter.next # => #<Iterator::Stop>
   # ```
   #
   # By default, a new array is created and returned for each permutation.
@@ -1109,8 +1109,8 @@ class Array(T)
   # ```
   # s = [1, 2, 3]          # => [1, 2, 3]
   # t = [4, 5, 6, [7, 8]]  # => [4, 5, 6, [7, 8]]
-  # u = [9, [10, 11].each] # => [9, Indexable#ItemIterator]
-  # a = [s, t, u, 12, 13]  # => [[1, 2, 3], [4, 5, 6, [7, 8]], 9, 10]
+  # u = [9, [10, 11].each] # => [9, #<Indexable::ItemIterator>]
+  # a = [s, t, u, 12, 13]  # => [[1, 2, 3], [4, 5, 6, [7, 8]], 9, #<Indexable::ItemIterator>, 12, 13]
   # a.flatten              # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
   # ```
   def flatten
@@ -1325,7 +1325,7 @@ class Array(T)
   # ```
   # a = ["a", "b"]
   # a.push("c") # => ["a", "b", "c"]
-  # a.push(1)   # => Errors, because the array only accepts String.
+  # a.push(1)   # Errors, because the array only accepts String.
   #
   # a = ["a", "b"] of (Int32 | String)
   # a.push("c") # => ["a", "b", "c"]
@@ -1714,12 +1714,12 @@ class Array(T)
   #
   # ```
   # a = ["a", "b"]
-  # a.unshift("c") # => ["c", a", "b"]
-  # a.unshift(1)   # => Errors, because the array only accepts String.
+  # a.unshift("c") # => ["c", "a", "b"]
+  # a.unshift(1)   # Errors, because the array only accepts String.
   #
   # a = ["a", "b"] of (Int32 | String)
   # a.unshift("c") # => ["c", "a", "b"]
-  # a.unshift(1)   # => [1, "a", "b", "c"]
+  # a.unshift(1)   # => [1, "c", "a", "b"]
   # ```
   def unshift(obj : T)
     insert 0, obj

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -104,8 +104,8 @@ struct Atomic(T)
   #
   # ```
   # atomic = Atomic.new(5)
-  # atomic.or(3) # => 5
-  # atomic.get   # => 6
+  # atomic.xor(3) # => 5
+  # atomic.get    # => 6
   # ```
   def xor(value : T)
     Ops.atomicrmw(:xor, pointerof(@value), value, :sequentially_consistent, false)
@@ -153,8 +153,8 @@ struct Atomic(T)
   #
   # ```
   # atomic = Atomic.new(5)
-  # atomic.set(10) # => 5
-  # atomic.get     # => 10
+  # atomic.swap(10) # => 5
+  # atomic.get      # => 10
   # ```
   def swap(value : T)
     Ops.atomicrmw(:xchg, pointerof(@value), value, :sequentially_consistent, false)

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -10,7 +10,7 @@
 # require "base64"
 #
 # enc = Base64.encode("Send reinforcements") # => "U2VuZCByZWluZm9yY2VtZW50cw==\n"
-# plain = Base64.decode(enc)                 # => "Send reinforcements"
+# plain = Base64.decode_string(enc)          # => "Send reinforcements"
 # ```
 #
 # The purpose of using base64 to encode data is that it translates any binary
@@ -32,8 +32,6 @@ module Base64
   # Line feeds are added to every 60 encoded characters.
   #
   # ```
-  # require "base64"
-  #
   # puts Base64.encode("Now is the time for all good coders\nto learn Crystal")
   # ```
   #
@@ -41,6 +39,7 @@ module Base64
   #
   # ```text
   # Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g
+  # Q3J5c3RhbA==
   # ```
   def encode(data) : String
     slice = data.to_slice
@@ -57,9 +56,7 @@ module Base64
   # Line feeds are added to every 60 encoded characters.
   #
   # ```
-  # require "base64"
-  #
-  # Base64.encode("Now is the time for all good coders\nto learn Crystal", io)
+  # Base64.encode("Now is the time for all good coders\nto learn Crystal", STDOUT)
   # ```
   def encode(data, io : IO)
     count = 0
@@ -90,8 +87,6 @@ module Base64
   # This method complies with RFC 4648.
   #
   # ```
-  # require "base64"
-  #
   # puts Base64.strict_encode("Now is the time for all good coders\nto learn Crystal")
   # ```
   #
@@ -118,9 +113,7 @@ module Base64
   # This method complies with RFC 4648.
   #
   # ```
-  # require "base64"
-  #
-  # Base64.strict_encode("Now is the time for all good coders\nto learn Crystal", io)
+  # Base64.strict_encode("Now is the time for all good coders\nto learn Crystal", STDOUT)
   # ```
   def strict_encode(data, io : IO)
     strict_encode_to_io_internal(data, io, CHARS_STD, pad: true)

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -27,7 +27,7 @@ require "./benchmark/**"
 #
 # ```
 # Benchmark.ips(warmup: 4, calculation: 10) do |x|
-#   # …
+#   x.report("sleep") { sleep 0.01 }
 # end
 # ```
 #

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -6,6 +6,8 @@ require "./big"
 # denominator is positive. Zero has the unique representation 0/1.
 #
 # ```
+# require "big_rational"
+#
 # r = BigRational.new(BigInt.new(7), BigInt.new(3))
 # r.to_s # => "7/3"
 #

--- a/src/char.cr
+++ b/src/char.cr
@@ -157,7 +157,7 @@ struct Char
   #
   # ```
   # 'c'.ascii_lowercase? # => true
-  # 'ç'.lowercase?       # => false
+  # 'ç'.lowercase?       # => true
   # 'G'.ascii_lowercase? # => false
   # '.'.ascii_lowercase? # => false
   # ```
@@ -479,9 +479,9 @@ struct Char
   #
   # ```
   # 'a'.inspect      # => "'a'"
-  # '\t'.inspect     # => "'\t'"
+  # '\t'.inspect     # => "'\\t'"
   # 'あ'.inspect      # => "'あ'"
-  # '\u0012'.inspect # => "'\u{12}'"
+  # '\u0012'.inspect # => "'\\u{12}'"
   # ```
   def inspect
     dump_or_inspect do |io|
@@ -507,9 +507,9 @@ struct Char
   #
   # ```
   # 'a'.dump      # => "'a'"
-  # '\t'.dump     # => "'\t'"
-  # 'あ'.dump      # => "'\u{3042}'"
-  # '\u0012'.dump # => "'\u{12}'"
+  # '\t'.dump     # => "'\\t'"
+  # 'あ'.dump      # => "'\\u{3042}'"
+  # '\u0012'.dump # => "'\\u{12}'"
   # ```
   def dump
     dump_or_inspect do |io|
@@ -557,11 +557,11 @@ struct Char
   # ```
   # '1'.to_i     # => 1
   # '8'.to_i     # => 8
-  # 'c'.to_i     # => ArgumentError
+  # 'c'.to_i     # raises ArgumentError
   # '1'.to_i(16) # => 1
   # 'a'.to_i(16) # => 10
   # 'f'.to_i(16) # => 15
-  # 'z'.to_i(16) # => ArgumentError
+  # 'z'.to_i(16) # raises ArgumentError
   # ```
   def to_i(base : Int = 10) : Int32
     to_i?(base) || raise ArgumentError.new("Invalid integer: #{self}")
@@ -573,11 +573,11 @@ struct Char
   # ```
   # '1'.to_i     # => 1
   # '8'.to_i     # => 8
-  # 'c'.to_i     # => ArgumentError
+  # 'c'.to_i     # raises ArgumentError
   # '1'.to_i(16) # => 1
   # 'a'.to_i(16) # => 10
   # 'f'.to_i(16) # => 15
-  # 'z'.to_i(16) # => ArgumentError
+  # 'z'.to_i(16) # raises ArgumentError
   # ```
   def to_i?(base : Int = 10) : Int32?
     raise ArgumentError.new "invalid base #{base}, expected 2 to 36" unless 2 <= base <= 36
@@ -623,7 +623,7 @@ struct Char
   # ```
   # '1'.to_i # => 1.0
   # '8'.to_i # => 8.0
-  # 'c'.to_i # => ArgumentError
+  # 'c'.to_i # raises ArgumentError
   # ```
   def to_f
     to_f64
@@ -635,7 +635,7 @@ struct Char
   # ```
   # '1'.to_i # => 1.0
   # '8'.to_i # => 8.0
-  # 'c'.to_i # => ArgumentError
+  # 'c'.to_i # raises ArgumentError
   # ```
   def to_f?
     to_f64?

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -6,8 +6,8 @@
 # ```
 # require "complex"
 #
-# Complex.new(1, 0)   # => 1 + 0i
-# Complex.new(5, -12) #  => 5 - 12i
+# Complex.new(1, 0)   # => 1.0 + 0.0i
+# Complex.new(5, -12) # => 5.0 - 12.0i
 # ```
 struct Complex
   #  Returns the real part of self
@@ -39,7 +39,7 @@ struct Complex
   # Write this complex object to an io
   #
   # ```
-  # Complex.new(42, 2).to_s # => 42 + 2i
+  # Complex.new(42, 2).to_s # => "42.0 + 2.0i"
   # ```
   def to_s(io : IO)
     io << @real
@@ -51,7 +51,7 @@ struct Complex
   # Write this complex object to an io, surrounded by parentheses.
   #
   # ```
-  # Complex.new(42, 2).inspect # => (42 + 2i)
+  # Complex.new(42, 2).inspect # => "(42.0 + 2.0i)"
   # ```
   def inspect(io : IO)
     io << '('
@@ -63,8 +63,8 @@ struct Complex
   # number form, using the Pythagorean theorem.
   #
   # ```
-  # Complex.new(42, 2).abs  # => 42.0476
-  # Complex.new(-42, 2).abs # => 42.0476
+  # Complex.new(42, 2).abs  # => 42.047592083257278
+  # Complex.new(-42, 2).abs # => 42.047592083257278
   # ```
   def abs
     Math.hypot(@real, @imag)
@@ -91,7 +91,7 @@ struct Complex
   # Returns a tuple with the abs value and the phase.
   #
   # ```
-  # Complex.new(42, 2).polar # => {2.54311, 0.665774}
+  # Complex.new(42, 2).polar # => {42.047592083257278, 0.047583103276983396}
   # ```
   def polar
     {abs, phase}
@@ -100,8 +100,8 @@ struct Complex
   # Returns the conjugate of self
   #
   # ```
-  # Complex.new(42, 2).conj  # => 42 - 2i
-  # Complex.new(42, -2).conj # => 42 + 2i
+  # Complex.new(42, 2).conj  # => 42.0 - 2.0i
+  # Complex.new(42, -2).conj # => 42.0 + 2.0i
   # ```
   def conj
     Complex.new(@real, -@imag)
@@ -139,7 +139,7 @@ struct Complex
   # Calculates the exp of self
   #
   # ```
-  # Complex.new(4, 2).exp #  => -22.7208 + 49.646i
+  # Complex.new(4, 2).exp # => -22.720847417619233 + 49.645957334580565i
   # ```
   def exp
     r = Math.exp(@real)

--- a/src/concurrent/future.cr
+++ b/src/concurrent/future.cr
@@ -120,8 +120,8 @@ end
 # Access to get is synchronized between fibers.  *&block* is only called once.
 # May be canceled before *&block* is called by calling `cancel`.
 # ```
-# d = delay(1) { Process.kill(Process.pid) }
-# long_operation
+# d = delay(1) { Process.kill(Signal::KILL, Process.pid) }
+# # ... long operations ...
 # d.cancel
 # ```
 def delay(delay, &block : -> _)
@@ -131,9 +131,9 @@ end
 # Spawns a `Fiber` to compute *&block* in the background.
 # Access to get is synchronized between fibers.  *&block* is only called once.
 # ```
-# f = future { http_request }
-# ... other actions ...
-# f.get #=> String
+# f = future { `echo hello` }
+# # ... other actions ...
+# f.get # => "hello\n"
 # ```
 def future(&exp : -> _)
   Concurrent::Future.new &exp

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -35,8 +35,8 @@ class Crypto::Bcrypt::Password
   # ```
   # password = Crypto::Bcrypt::Password.new("$2a$10$X6rw/jDiLBuzHV./JjBNXe8/Po4wTL0fhdDNdAdjcKN/Fup8tGCya")
   # password.version # => "2a"
-  # password.salt    # => X6rw/jDiLBuzHV./JjBNXe
-  # password.digest  # => 8/Po4wTL0fhdDNdAdjcKN/Fup8tGCya
+  # password.salt    # => "X6rw/jDiLBuzHV./JjBNXe"
+  # password.digest  # => "8/Po4wTL0fhdDNdAdjcKN/Fup8tGCya"
   # ```
   def initialize(@raw_hash : String)
     parts = @raw_hash.split("$")

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -113,7 +113,7 @@ class CSV
   #   csv.row "one", "two"
   #   csv.row "three"
   # end
-  # result # => "one,two\nthree"
+  # result # => "one,two\nthree\n"
   # ```
   def self.build : String
     String.build do |io|
@@ -131,7 +131,7 @@ class CSV
   #   csv.row "one", "two"
   #   csv.row "three"
   # end
-  # io.to_s # => "HEADER\none,two\nthree"
+  # io.to_s # => "HEADER\none,two\nthree\n"
   # ```
   def self.build(io : IO)
     builder = Builder.new(io)

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -183,8 +183,8 @@ class Deque(T)
   #
   # ```
   # a = Deque{"a", "b", "b", "b", "c"}
-  # a.delete("b")
-  # a # => Deque{"a", "c"}
+  # a.delete("b") # => true
+  # a             # => Deque{"a", "c"}
   # ```
   def delete(obj)
     found = false
@@ -205,7 +205,8 @@ class Deque(T)
   #
   # ```
   # a = Deque{1, 2, 3}
-  # a.delete_at(1) # => Deque{1, 3}
+  # a.delete_at(1) # => 2
+  # a              # => Deque{1, 3}
   # ```
   def delete_at(index : Int)
     if index < 0
@@ -356,7 +357,7 @@ class Deque(T)
   # ```
   # a = Deque{1, 2, 3}
   # a.pop # => 3
-  # # a == Deque{1, 2}
+  # a     # => Deque{1, 2}
   # ```
   def pop
     pop { raise IndexError.new }
@@ -435,7 +436,7 @@ class Deque(T)
   # ```
   # a = Deque{1, 2, 3}
   # a.shift # => 1
-  # # a == Deque{2, 3}
+  # a       # => Deque{2, 3}
   # ```
   def shift
     shift { raise IndexError.new }

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -44,6 +44,9 @@ class Dir
   # passing the filename of each entry as a parameter to the block.
   #
   # ```
+  # Dir.mkdir("testdir")
+  # File.write("testdir/config.h", "")
+  #
   # d = Dir.new("testdir")
   # d.each { |x| puts "Got #{x}" }
   # ```
@@ -54,7 +57,6 @@ class Dir
   # Got .
   # Got ..
   # Got config.h
-  # Got main.rb
   # ```
   def each
     while entry = read
@@ -70,9 +72,11 @@ class Dir
   #
   # ```
   # d = Dir.new("testdir")
-  # d.read # => "."
-  # d.read # => ".."
-  # d.read # => "config.h"
+  # array = [] of String
+  # while file = d.read
+  #   array << file
+  # end
+  # array.sort # => [".", "..", "config.h"]
   # ```
   def read
     # readdir() returns NULL for failure and sets errno or returns NULL for EOF but leaves errno as is.  wtf.

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -44,14 +44,14 @@
 # An enum can be created from an integer:
 #
 # ```
-# puts Color.new(1) # => prints "Green"
+# puts Color.new(1) # => "Green"
 # ```
 #
 # Values that don't correspond to an enum's constants are allowed: the value will still be of type Color,
 # but when printed you will get the underlying value:
 #
 # ```
-# puts Color.new(10) # => prints "10"
+# puts Color.new(10) # => "10"
 # ```
 #
 # This method is mainly intended to convert integers from C to enums in Crystal.
@@ -167,9 +167,9 @@ struct Enum
   # to this enum member's value.
   #
   # ```
-  # Color::Red + 1 # => Color::Blue
-  # Color::Red + 2 # => Color::Green
-  # Color::Red + 3 # => 3
+  # Color::Red + 1 # => Color::Green
+  # Color::Red + 2 # => Color::Blue
+  # Color::Red + 3 # => Color.new(3)
   # ```
   def +(other : Int)
     self.class.new(value + other)
@@ -181,7 +181,7 @@ struct Enum
   # ```
   # Color::Blue - 1 # => Color::Green
   # Color::Blue - 2 # => Color::Red
-  # Color::Blue - 3 # => -1
+  # Color::Blue - 3 # => Color.new(-1)
   # ```
   def -(other : Int)
     self.class.new(value - other)
@@ -356,7 +356,7 @@ struct Enum
   # Color.from_value(0) # => Color::Red
   # Color.from_value(1) # => Color::Green
   # Color.from_value(2) # => Color::Blue
-  # Color.from_value(3) # => Exception
+  # Color.from_value(3) # raises Exception
   # ```
   def self.from_value(value) : self
     from_value?(value) || raise "Unknown enum #{self} value: #{value}"
@@ -380,7 +380,7 @@ struct Enum
   # ```
   # Color.parse("Red")    # => Color::Red
   # Color.parse("BLUE")   # => Color::Blue
-  # Color.parse("Yellow") # => Exception
+  # Color.parse("Yellow") # raises ArgumentError
   # ```
   def self.parse(string) : self
     parse?(string) || raise ArgumentError.new("Unknown enum #{self} value: #{string}")

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -375,9 +375,10 @@ module Enumerable(T)
   # Iterates over the collection, passing each element and the initial object *obj*. Returns that object.
   #
   # ```
-  # ["Alice", "Bob"].each_with_object({} of String => Int32) do |user, sizes|
+  # hash = ["Alice", "Bob"].each_with_object({} of String => Int32) do |user, sizes|
   #   sizes[user] = user.size
-  # end # => {"Alice" => 5, "Bob" => 3}
+  # end
+  # hash # => {"Alice" => 5, "Bob" => 3}
   # ```
   def each_with_object(obj)
     each do |elem|
@@ -418,9 +419,10 @@ module Enumerable(T)
   # every element in the collection.
   #
   # ```
-  # ["Alice", "Bob"].flat_map do |user|
+  # array = ["Alice", "Bob"].flat_map do |user|
   #   user.chars
-  # end # => ['A', 'l', 'i', 'c', 'e', 'B', 'o', 'b']
+  # end
+  # array # => ['A', 'l', 'i', 'c', 'e', 'B', 'o', 'b']
   # ```
   def flat_map(&block : T -> Array(U) | Iterator(U) | U) forall U
     ary = [] of U
@@ -1249,8 +1251,8 @@ module Enumerable(T)
   # 2 element structure (for instance a `Tuple` or an `Array`)
   #
   # ```
-  # [[:a, :b], [:c, :d]].to_h        # => {a: :b, c: :d}
-  # Tuple.new({:a, 1}, {:c, 2}).to_h # => {a: 1, c: 2}
+  # [[:a, :b], [:c, :d]].to_h        # => {:a => :b, :c => :d}
+  # Tuple.new({:a, 1}, {:c, 2}).to_h # => {:a => 1, :c => 2}
   # ```
   def to_h
     each_with_object(Hash(typeof(first[0]), typeof(first[1])).new) do |item, hash|

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -41,7 +41,7 @@ end
 #
 # ```
 # a = [:foo, :bar]
-# a[2] # => IndexError: index out of bounds
+# a[2] # raises IndexError
 # ```
 class IndexError < Exception
   def initialize(message = "Index out of bounds")
@@ -52,7 +52,7 @@ end
 # Raised when the arguments are wrong and there isn't a more specific `Exception` class.
 #
 # ```
-# [1, 2, 3].first(-4) # => ArgumentError: attempt to take negative size
+# [1, 2, 3].first(-4) # raises ArgumentError (attempt to take negative size)
 # ```
 class ArgumentError < Exception
   def initialize(message = "Argument error")
@@ -63,7 +63,7 @@ end
 # Raised when the type cast failed.
 #
 # ```
-# [1, "hi"][1].as(Int32) # => TypeCastError: cast to Int32 failed
+# [1, "hi"][1].as(Int32) # raises TypeCastError (cast to Int32 failed)
 # ```
 class TypeCastError < Exception
   def initialize(message = "Type Cast error")
@@ -81,7 +81,7 @@ end
 #
 # ```
 # h = {"foo" => "bar"}
-# h["baz"] # => KeyError: Missing hash key: "baz"
+# h["baz"] # raises KeyError (Missing hash key: "baz")
 # ```
 class KeyError < Exception
 end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -6,7 +6,7 @@ module FileUtils
   # ```
   # require "file_utils"
   #
-  # FileUtils.cd("to/directory")
+  # FileUtils.cd("/tmp")
   # ```
   #
   # NOTE: Alias of `Dir.cd`
@@ -18,7 +18,7 @@ module FileUtils
   # and invoked the block, restoring the original working directory when the block exits.
   #
   # ```
-  # FileUtils.cd("to/directory") { puts "Do something useful here!" }
+  # FileUtils.cd("/tmp") { Dir.current } # => "/tmp"
   # ```
   #
   # NOTE: Alias of `Dir.cd` with block
@@ -30,7 +30,9 @@ module FileUtils
   # Returns true if content are the same, false otherwise.
   #
   # ```
-  # FileUtils.cmp("foo.cr", "bar.cr")
+  # File.write("file.cr", "1")
+  # File.write("bar.cr", "1")
+  # FileUtils.cmp("file.cr", "bar.cr") # => true
   # ```
   def cmp(filename1 : String, filename2 : String)
     return false unless File.size(filename1) == File.size(filename2)
@@ -46,7 +48,10 @@ module FileUtils
   # Returns true if content are the same, false otherwise.
   #
   # ```
-  # FileUtils.cmp(stream1 : IO, stream2 : IO)
+  # File.write("afile", "123")
+  # stream1 = File.open("afile")
+  # stream2 = IO::Memory.new("123")
+  # FileUtils.cmp(stream1, stream2) # => true
   # ```
   def cmp(stream1 : IO, stream2 : IO)
     buf1 = uninitialized UInt8[1024]
@@ -67,7 +72,9 @@ module FileUtils
   # Permission bits are copied too.
   #
   # ```
-  # FileUtils.cp("file_utils.cr", "file_utils_copy.cr")
+  # File.chmod("afile", 0o600)
+  # FileUtils.cp("afile", "afile_copy")
+  # File.stat("afile_copy").perm # => 0o600
   # ```
   def cp(src_path : String, dest : String)
     File.open(src_path) do |s|
@@ -82,7 +89,8 @@ module FileUtils
   # *dest* must be an existing directory.
   #
   # ```
-  # FileUtils.cp({"cgi.cr", "complex.cr", "date.cr"}, "files")
+  # Dir.mkdir("files")
+  # FileUtils.cp({"bar.cr", "afile"}, "files")
   # ```
   def cp(srcs : Enumerable(String), dest : String)
     raise ArgumentError.new("no such directory : #{dest}") unless Dir.exists?(dest)
@@ -95,7 +103,7 @@ module FileUtils
   # If *src_path* is a directory, this method copies all its contents recursively
   #
   # ```
-  # FileUtils.cp_r("src_dir", "src_dir_copy")
+  # FileUtils.cp_r("files", "dir")
   # ```
   def cp_r(src_path : String, dest_path : String)
     if Dir.exists?(src_path)
@@ -118,7 +126,7 @@ module FileUtils
   # can be specified, with a default of 777 (0o777).
   #
   # ```
-  # FileUtils.mkdir("foo")
+  # FileUtils.mkdir("src")
   # ```
   #
   # NOTE: Alias of `Dir.mkdir`
@@ -156,7 +164,7 @@ module FileUtils
   # with a default of 777 (0o777).
   #
   # ```
-  # FileUtils.mkdir_p(["foo", "bar"])
+  # FileUtils.mkdir_p(["foo", "bar", "baz", "dir1", "dir2", "dir3"])
   # ```
   def mkdir_p(paths : Enumerable(String), mode = 0o777) : Nil
     paths.each do |path|
@@ -178,7 +186,7 @@ module FileUtils
   # Moves every *srcs* to *dest*.
   #
   # ```
-  # FileUtils.mv(["afile", "foo", "bar"], "src")
+  # FileUtils.mv(["foo", "bar"], "src")
   # ```
   def mv(srcs : Enumerable(String), dest : String) : Nil
     raise ArgumentError.new("no such directory : #{dest}") unless Dir.exists?(dest)
@@ -215,7 +223,7 @@ module FileUtils
   # Deletes all *paths* file given.
   #
   # ```
-  # FileUtils.rm(["afile.cr", "bfile.cr"])
+  # FileUtils.rm(["dir/afile", "afile_copy"])
   # ```
   def rm(paths : Enumerable(String)) : Nil
     paths.each do |path|
@@ -250,7 +258,7 @@ module FileUtils
   # If one path is a directory, this method removes all its contents recursively
   #
   # ```
-  # FileUtils.rm_r(["dir", "file.cr"])
+  # FileUtils.rm_r(["files", "bar.cr"])
   # ```
   def rm_r(paths : Enumerable(String)) : Nil
     paths.each do |path|
@@ -293,7 +301,7 @@ module FileUtils
   # Removes the directory at the given *path*.
   #
   # ```
-  # FileUtils.rmdir("dir")
+  # FileUtils.rmdir("baz")
   # ```
   #
   # NOTE: Alias of `Dir.rmdir`

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -166,7 +166,7 @@ class Hash(K, V)
   # hash = {"foo" => "bar", "baz" => "qux"}
   # hash.key("bar")    # => "foo"
   # hash.key("qux")    # => "baz"
-  # hash.key("foobar") # => Missing hash key for value: foobar (KeyError)
+  # hash.key("foobar") # raises KeyError (Missing hash key for value: foobar)
   # ```
   def key(value)
     key(value) { raise KeyError.new "Missing hash key for value: #{value}" }
@@ -627,7 +627,7 @@ class Hash(K, V)
   # hash       # => {"baz" => "qux"}
   #
   # hash = {} of String => String
-  # hash.shift # => Index out of bounds (IndexError)
+  # hash.shift # raises IndexError
   # ```
   def shift
     shift { raise IndexError.new }

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -139,7 +139,7 @@ class HTTP::Client
   # uri = URI.parse("https://secure.example.com")
   # client = HTTP::Client.new(uri)
   #
-  # client.tls? # => true
+  # client.tls? # => #<OpenSSL::SSL::Context::Client>
   # client.get("/")
   # ```
   # This constructor will *ignore* any path or query segments in the URI
@@ -165,7 +165,7 @@ class HTTP::Client
   # ```
   # uri = URI.parse("https://secure.example.com")
   # HTTP::Client.new(uri) do |client|
-  #   client.tls? # => true
+  #   client.tls? # => #<OpenSSL::SSL::Context::Client>
   #   client.get("/")
   # end
   # ```

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -71,8 +71,9 @@ module HTTP
     # This is basically
     #
     # ```
+    # line = "Server: nginx"
     # name, value = line.split ':', 2
-    # {name, value.lstrip}
+    # {name, value.lstrip} # => {"Server", "nginx"}
     # ```
     #
     # except that it's faster because we only create 2 strings

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -165,6 +165,7 @@ module HTTP
     # no explicit domain restriction and the path `/`.
     #
     # ```
+    # request = HTTP::Request.new "GET", "/"
     # request.cookies["foo"] = "bar"
     # ```
     def []=(key, value : String)
@@ -176,6 +177,7 @@ module HTTP
     # `ArgumentError` is raised.
     #
     # ```
+    # response = HTTP::Client::Response.new(200)
     # response.cookies["foo"] = HTTP::Cookie.new("foo", "bar", "/admin", Time.now + 12.hours, secure: true)
     # ```
     def []=(key, value : Cookie)
@@ -198,6 +200,7 @@ module HTTP
     # Get the current `HTTP::Cookie` for the given *key* or `nil` if none is set.
     #
     # ```
+    # request = HTTP::Request.new "GET", "/"
     # request.cookies["foo"]? # => nil
     # request.cookies["foo"] = "bar"
     # request.cookies["foo"]?.try &.value # > "bar"
@@ -219,7 +222,7 @@ module HTTP
     # with the same name if present.
     #
     # ```
-    # response.cookies << Cookie.new("foo", "bar", http_only: true)
+    # response.cookies << HTTP::Cookie.new("foo", "bar", http_only: true)
     # ```
     def <<(cookie : Cookie)
       self[cookie.name] = cookie

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -23,6 +23,7 @@ module HTTP
     # Parses an HTTP query and yields each key-value pair
     #
     # ```
+    # query = "foo=bar&foo=baz&qux=zoo"
     # HTTP::Params.parse(query) do |key, value|
     #   # ...
     # end
@@ -90,7 +91,7 @@ module HTTP
     #   form.add "name", "crystal"
     #   form.add "year", "2012 - today"
     # end
-    # params # => "color=black&name=crystal&year=2012%20-%20today"
+    # params # => "color=black&name=crystal&year=2012+-+today"
     # ```
     def self.build(&block : Builder ->) : String
       form_builder = Builder.new
@@ -114,6 +115,7 @@ module HTTP
     # Returns first value for specified param name.
     #
     # ```
+    # params = HTTP::Params.parse("email=john@example.org")
     # params["email"]              # => "john@example.org"
     # params["non_existent_param"] # KeyError
     # ```
@@ -152,6 +154,7 @@ module HTTP
     # Returns all values for specified param name.
     #
     # ```
+    # params.set_all("item", ["pencil", "book", "workbook"])
     # params.fetch_all("item") # => ["pencil", "book", "workbook"]
     # ```
     def fetch_all(name)
@@ -184,8 +187,8 @@ module HTTP
     # of provided block when there is no such param.
     #
     # ```
-    # params.fetch("email") { raise InvalidUser("email is missing") }    # InvalidUser "email is missing"
-    # params.fetch("non_existent_param") { "default computed value" }    # => "default computed value"
+    # params.fetch("email") { raise "email is missing" }              # raises "email is missing"
+    # params.fetch("non_existent_param") { "default computed value" } # => "default computed value"
     # ```
     def fetch(name)
       return yield unless has_key?(name)
@@ -257,6 +260,7 @@ module HTTP
     # values.
     #
     # ```
+    # params.set_all("comments", ["hello, world!", ":+1:"])
     # params.delete_all("comments") # => ["hello, world!", ":+1:"]
     # params.has_key?("comments")   # => false
     # ```
@@ -267,8 +271,10 @@ module HTTP
     # Serializes to string representation as http url encoded form
     #
     # ```
-    # params.to_s # => "item=keychain&item=keynote&email=john@example.org"
+    # params = HTTP::Params.parse("item=keychain&item=keynote&email=john@example.org")
+    # params.to_s # => "item=keychain&item=keynote&email=john%40example.org"
     # ```
+    # TODO: `to_s` should escape @ to %40 ?
     def to_s(io)
       builder = Builder.new(io)
       each do |name, value|

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -46,7 +46,7 @@ module Indexable(T)
   # ```
   # a = [:foo, :bar]
   # a.at(0) # => :foo
-  # a.at(2) # => IndexError
+  # a.at(2) # raises IndexError
   # ```
   @[AlwaysInline]
   def at(index : Int)
@@ -237,7 +237,7 @@ module Indexable(T)
   #
   # ```
   # ([1, 2, 3]).first   # => 1
-  # ([] of Int32).first # => raises IndexError
+  # ([] of Int32).first # raises IndexError
   # ```
   def first
     first { raise IndexError.new }
@@ -287,7 +287,7 @@ module Indexable(T)
   # is found.
   #
   # ```
-  # [1, 2, 3, 1, 2, 3].rindex(offset: 4) { |x| x < 2 } # => 4
+  # [1, 2, 3, 1, 2, 3].index(offset: 2) { |x| x < 2 } # => 3
   # ```
   def index(offset : Int = 0)
     offset += size if offset < 0
@@ -305,7 +305,7 @@ module Indexable(T)
   #
   # ```
   # ([1, 2, 3]).last   # => 3
-  # ([] of Int32).last # => raises IndexError
+  # ([] of Int32).last # raises IndexError
   # ```
   def last
     last { raise IndexError.new }
@@ -324,7 +324,7 @@ module Indexable(T)
   # Returns the last element of `self` if it's not empty, or `nil`.
   #
   # ```
-  # ([1, 2, 3]).last?   # => 1
+  # ([1, 2, 3]).last?   # => 3
   # ([] of Int32).last? # => nil
   # ```
   def last?

--- a/src/int.cr
+++ b/src/int.cr
@@ -208,10 +208,10 @@ struct Int
   # * If *count* is negative, a right shift is performed
   #
   # ```
-  # 8000 << 1  # => 4000
-  # 8000 << 2  # => 2000
+  # 8000 << 1  # => 16000
+  # 8000 << 2  # => 32000
   # 8000 << 32 # => 0
-  # 8000 << -1 # => 16000
+  # 8000 << -1 # => 4000
   # ```
   def <<(count : Int)
     if count < 0
@@ -475,7 +475,7 @@ struct Int
   #
   # ```
   # 5.popcount   # => 2
-  # -15.popcount # => 5
+  # -15.popcount # => 29
   # ```
   abstract def popcount
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -80,7 +80,7 @@ module IO
   #
   # ```
   # STDIN.read_timeout = 1
-  # STDIN.gets # => IO::Timeout (after 1 second)
+  # STDIN.gets # raises IO::Timeout (after 1 second)
   # ```
   class Timeout < Exception
   end
@@ -164,9 +164,9 @@ module IO
   # io = IO::Memory.new "hello"
   # slice = Bytes.new(4)
   # io.read(slice) # => 4
-  # slice          # => [104, 101, 108, 108]
+  # slice          # => Bytes[104, 101, 108, 108]
   # io.read(slice) # => 1
-  # slice          # => [111, 101, 108, 108]
+  # slice          # => Bytes[111, 101, 108, 108]
   # ```
   abstract def read(slice : Bytes)
 
@@ -418,7 +418,7 @@ module IO
   # If no encoding is set, this is the same as `#read_byte`.
   #
   # ```
-  # bytes = "你".encode("GB2312") # => [196, 227]
+  # bytes = "你".encode("GB2312") # => Bytes[196, 227]
   #
   # io = IO::Memory.new(bytes)
   # io.set_encoding("GB2312")
@@ -442,14 +442,14 @@ module IO
   # If no encoding is set, this is the same as `#read(slice)`.
   #
   # ```
-  # bytes = "你".encode("GB2312") # => [196, 227]
+  # bytes = "你".encode("GB2312") # => Bytes[196, 227]
   #
   # io = IO::Memory.new(bytes)
   # io.set_encoding("GB2312")
   #
   # buffer = uninitialized UInt8[1024]
   # bytes_read = io.read_utf8(buffer.to_slice) # => 3
-  # buffer.to_slice[0, bytes_read]             # => [228, 189, 160]
+  # buffer.to_slice[0, bytes_read]             # => Bytes[228, 189, 160]
   #
   # "你".bytes # => [228, 189, 160]
   # ```
@@ -511,8 +511,8 @@ module IO
   # io = IO::Memory.new "123451234"
   # slice = Bytes.new(5)
   # io.read_fully(slice) # => 5
-  # slice                # => [49, 50, 51, 52, 53]
-  # io.read_fully(slice) # => EOFError
+  # slice                # => Bytes[49, 50, 51, 52, 53]
+  # io.read_fully(slice) # raises IO::EOFError
   # ```
   def read_fully(slice : Bytes)
     read_fully?(slice) || raise(EOFError.new)
@@ -526,7 +526,7 @@ module IO
   # io = IO::Memory.new "123451234"
   # slice = Bytes.new(5)
   # io.read_fully?(slice) # => 5
-  # slice                 # => [49, 50, 51, 52, 53]
+  # slice                 # => Bytes[49, 50, 51, 52, 53]
   # io.read_fully?(slice) # => nil
   # ```
   def read_fully?(slice : Bytes)
@@ -544,7 +544,6 @@ module IO
   # ```
   # io = IO::Memory.new "hello world"
   # io.gets_to_end # => "hello world"
-  # io.gets_to_end # => ""
   # ```
   def gets_to_end : String
     String.build do |str|
@@ -844,7 +843,7 @@ module IO
   # ```
   # io = IO::Memory.new("hello\nworld")
   # iter = io.each_line
-  # iter.next # => "hello\n"
+  # iter.next # => "hello"
   # iter.next # => "world"
   # ```
   def each_line(*args, **options)

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -20,9 +20,9 @@
 # ### Encode to bytes
 #
 # ```
-# bytes = uninitialized UInt8[2]
-# IO::ByteFormat::LittleEndian.encode(0x1234_i16, bytes.to_slice)
-# bytes # => Bytes[0x34, 0x12]
+# raw = uninitialized UInt8[2]
+# IO::ByteFormat::LittleEndian.encode(0x1234_i16, raw.to_slice)
+# raw # => StaticArray[0x34, 0x12]
 # ```
 #
 # ### Encode to IO

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -9,7 +9,7 @@ module IO
   # delimited = IO::Delimited.new(io, read_delimiter: "||")
   #
   # delimited.gets_to_end # => "abc"
-  # delimited.gets_to_end # => nil
+  # delimited.gets_to_end # => ""
   # io.gets_to_end        # => "123"
   # ```
   class Delimited

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -118,6 +118,8 @@ class IO::FileDescriptor
   # Returns `self`.
   #
   # ```
+  # File.write("testfile", "abc")
+  #
   # file = File.new("testfile")
   # file.gets(3) # => "abc"
   # file.seek(1, IO::Seek::Set)
@@ -159,10 +161,12 @@ class IO::FileDescriptor
   # Returns the current position (in bytes) in this IO.
   #
   # ```
-  # io = IO::Memory.new "hello"
-  # io.pos     # => 0
-  # io.gets(2) # => "he"
-  # io.pos     # => 2
+  # File.write("testfile", "hello")
+  #
+  # file = File.new("testfile")
+  # file.pos     # => 0
+  # file.gets(2) # => "he"
+  # file.pos     # => 2
   # ```
   def pos
     check_open
@@ -176,9 +180,11 @@ class IO::FileDescriptor
   # Sets the current position (in bytes) in this IO.
   #
   # ```
-  # io = IO::Memory.new "hello"
-  # io.pos = 3
-  # io.gets_to_end # => "lo"
+  # File.write("testfile", "hello")
+  #
+  # file = File.new("testfile")
+  # file.pos = 3
+  # file.gets_to_end # => "lo"
   # ```
   def pos=(value)
     seek value

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -9,7 +9,7 @@
 # Example:
 # ```
 # require "io/hexdump"
-#
+# socket = IO::Memory.new("abc")
 # io = IO::Hexdump.new(socket, output: STDERR, read: true)
 # ```
 #

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -65,7 +65,7 @@ class IO::Memory
   # io = IO::Memory.new "hello"
   # io.pos        # => 0
   # io.gets(2)    # => "he"
-  # io.print "hi" # raises
+  # io.print "hi" # raises IO::Error
   # ```
   def self.new(string : String)
     new string.to_slice, writeable: false
@@ -207,11 +207,16 @@ class IO::Memory
   # if this IO::Memory is non-resizeable.
   #
   # ```
-  # io = IO::Memory.new "hello"
-  # io.gets(3) # => "hel"
+  # io = IO::Memory.new
+  # io << "abc"
+  # io.rewind
+  # io.gets(1) # => "a"
   # io.clear
   # io.pos         # => 0
   # io.gets_to_end # => ""
+  #
+  # io = IO::Memory.new "hello"
+  # io.clear # raises IO::Error
   # ```
   def clear
     check_open
@@ -315,7 +320,7 @@ class IO::Memory
   # ```
   # io = IO::Memory.new "hello"
   # io.close
-  # io.gets_to_end # => IO::Error: closed stream
+  # io.gets_to_end # raises IO::Error (closed stream)
   # ```
   def close
     @closed = true

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -6,7 +6,7 @@ module IO
   # sized = IO::Sized.new(io, read_size: 3)
   #
   # sized.gets_to_end # => "abc"
-  # sized.gets_to_end # => nil
+  # sized.gets_to_end # => ""
   # io.gets_to_end    # => "de"
   # ```
   class Sized

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -494,9 +494,9 @@ module Iterator(T)
   # ```
   # iter = [1, 2, 3].each.flat_map { |x| [x, x] }
   #
-  # iter.next # => [1, 1]
-  # iter.next # => [2, 2]
-  # iter.next # => [3, 3]
+  # iter.next # => 1
+  # iter.next # => 1
+  # iter.next # => 2
   #
   # iter = [1, 2, 3].each.flat_map { |x| [x, x].each }
   #
@@ -999,7 +999,7 @@ module Iterator(T)
   # value to be checked for uniqueness.
   #
   # ```
-  # iter = [["a", "a"], ["b", "a"], ["a", "c"]].uniq &.first
+  # iter = [["a", "a"], ["b", "a"], ["a", "c"]].each.uniq &.first
   # iter.next # => ["a", "a"]
   # iter.next # => ["b", "a"]
   # iter.next # => Iterator::Stop::INSTANCE

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -22,7 +22,7 @@ module JSON
   #
   # house = House.from_json(%({"address": "Crystal Road 1234", "location": {"lat": 12.3, "lng": 34.5}}))
   # house.address  # => "Crystal Road 1234"
-  # house.location # => #&lt;Location:0x10cd93d80 @lat=12.3, @lng=34.5>
+  # house.location # => #<Location:0x10cd93d80 @lat=12.3, @lng=34.5>
   # house.to_json  # => %({"address":"Crystal Road 1234","location":{"lat":12.3,"lng":34.5}})
   # ```
   #

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -158,15 +158,15 @@ end
 # ```
 # require "json"
 #
-# class Person
+# class Timestamp
 #   JSON.mapping({
-#     birth_date: {type: Time, converter: Time::EpochMillisConverter},
+#     value: {type: Time, converter: Time::EpochMillisConverter},
 #   })
 # end
 #
-# person = Person.from_json(%({"birth_date": 1459860483856}))
-# person.birth_date # => 2016-04-05 12:48:03 UTC
-# person.to_json    # => %({"birth_date":1459860483856})
+# timestamp = Timestamp.from_json(%({"value": 1459860483856}))
+# timestamp.value   # => 2016-04-05 12:48:03.856 UTC
+# timestamp.to_json # => %({"value":1459860483856})
 # ```
 module Time::EpochMillisConverter
   def self.to_json(value : Time, json : JSON::Builder)

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -12,8 +12,7 @@
 # ```
 # record Point, x : Int32, y : Int32
 #
-# point = Point.new 1, 2
-# point.to_s # => "Point(@x=1, @y=2)"
+# Point.new 1, 2 # => #<Point(@x=1, @y=2)>
 # ```
 #
 # An example with the block version:
@@ -34,8 +33,8 @@
 # ```
 # record Point, x : Int32 = 0, y : Int32 = 0
 #
-# Point.new      # => Point(@x=0, @y=0)
-# Point.new y: 2 # => Point(@x=0, @y=2)
+# Point.new      # => #<Point(@x=0, @y=0)>
+# Point.new y: 2 # => #<Point(@x=0, @y=2)>
 # ```
 #
 # An example with assignments (in this case the compiler must be able to
@@ -44,8 +43,8 @@
 # ```
 # record Point, x = 0, y = 0
 #
-# Point.new      # => Point(@x=0, @y=0)
-# Point.new y: 2 # => Point(@x=0, @y=2)
+# Point.new      # => #<Point(@x=0, @y=0)>
+# Point.new y: 2 # => #<Point(@x=0, @y=2)>
 # ```
 macro record(name, *properties)
   struct {{name.id}}
@@ -88,9 +87,9 @@ end
 #
 # ```
 # a = 1
-# pp a # prints "a # => 1"
+# pp a # => "a # => 1"
 #
-# pp [1, 2, 3].map(&.to_s) # prints "[1, 2, 3].map(&.to_s) # => ["1", "2", "3"]"
+# pp [1, 2, 3].map(&.to_s) # => "[1, 2, 3].map(&.to_s) # => ["1", "2", "3"]"
 # ```
 macro pp(*exps)
   {% if exps.size == 0 %}

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -9,8 +9,8 @@
 # ```
 # language = {name: "Crystal", year: 2011} # NamedTuple(name: String, year: Int32)
 #
-# language[:name]  # => "Crystal" (String)
-# language[:year]  # => 2011      (Int32)
+# language[:name]  # => "Crystal"
+# language[:year]  # => 2011
 # language[:other] # compile time error
 # ```
 #
@@ -30,9 +30,8 @@ struct NamedTuple
   #
   # ```
   # NamedTuple.new(name: "Crystal", year: 2011) #=> {name: "Crystal", year: 2011}
-  # NamedTuple.new                  #=> {}
-  #
-  # {}                         # syntax error
+  # NamedTuple.new # => {}
+  # {}             # syntax error
   # ```
   def self.new(**options : **T)
     options
@@ -59,6 +58,8 @@ struct NamedTuple
   # This allows you to easily pass a hash as individual named arguments to a method.
   #
   # ```
+  # require "json"
+  #
   # def speak_about(thing : String, n : Int64)
   #   "I see #{n} #{thing}s"
   # end
@@ -92,7 +93,7 @@ struct NamedTuple
   # tuple[key] # => 2011
   #
   # key = :other
-  # tuple[key] # # => KeyError
+  # tuple[key] # raises KeyError
   # ```
   def [](key : Symbol | String)
     fetch(key) { raise KeyError.new "Missing named tuple key: #{key.inspect}" }

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -265,7 +265,7 @@ abstract class OpenSSL::SSL::Context
   #
   # Example:
   # ```
-  # context.remove_options(OpenSSL::SSL::NO_SSLV3)
+  # context.remove_options(OpenSSL::SSL::Options::NO_SSLV3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
     OpenSSL::SSL::Options.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -83,6 +83,7 @@ class OptionParser
   # Example:
   #
   # ```
+  # parser = OptionParser.new
   # parser.banner = "Usage: crystal [command] [switches] [program file] [--] [arguments]"
   # ```
   setter banner : String?

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -312,10 +312,10 @@ struct Pointer(T)
   #
   # ```
   # ptr1 = Pointer(Int32).new(1234)
-  # ptr1.to_s # => Pointer(Int32)@0x4D2
+  # ptr1.to_s # => "Pointer(Int32)@0x4d2"
   #
   # ptr2 = Pointer(Int32).new(0)
-  # ptr2.to_s # => Pointer(Int32).null
+  # ptr2.to_s # => "Pointer(Int32).null"
   # ```
   def to_s(io : IO)
     io << "Pointer("
@@ -408,14 +408,13 @@ struct Pointer(T)
   # ```
   # # Allocate memory for an Int32: 4 bytes
   # ptr = Pointer(Int32).malloc
-  # ptr.value #=> 0
+  # ptr.value # => 0
   #
   # # Allocate memory for 10 Int32: 40 bytes
   # ptr = Pointer(Int32).malloc(10)
-  # ptr[0] #=> 0
-  # ...
-  # ptr[9] #=> 0
-  #
+  # ptr[0] # => 0
+  # # ...
+  # ptr[9] # => 0
   # ```
   def self.malloc(size : Int = 1)
     if size < 0
@@ -472,8 +471,8 @@ struct Pointer(T)
   # Returns a `Slice` that points to this pointer and is bounded by the given *size*.
   #
   # ```
-  # ptr = Pointer.malloc(6) { |i| i + 10 } #   [10, 11, 12, 13, 14, 15]
-  # slice = ptr.to_slice(4)                # => [10, 11, 12, 13]
+  # ptr = Pointer.malloc(6) { |i| i + 10 } # [10, 11, 12, 13, 14, 15]
+  # slice = ptr.to_slice(4)                # => Slice[10, 11, 12, 13]
   # slice.class                            # => Slice(Int32)
   # ```
   def to_slice(size)
@@ -483,9 +482,9 @@ struct Pointer(T)
   # Clears (sets to "zero" bytes) a number of values pointed by this pointer.
   #
   # ```
-  # ptr = Pointer.malloc(6) { |i| i + 10 } #   [10, 11, 12, 13, 14, 15]
+  # ptr = Pointer.malloc(6) { |i| i + 10 } # [10, 11, 12, 13, 14, 15]
   # ptr.clear(3)
-  # ptr #   [0, 0, 0, 13, 14, 15]
+  # ptr.to_slice(6) # => Slice[0, 0, 0, 13, 14, 15]
   # ```
   def clear(count = 1)
     ptr = self.as(Pointer(Void))

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -142,14 +142,13 @@ struct Pointer(T)
   # ```
   # # Allocate memory for an Int32: 4 bytes
   # ptr = Pointer(Int32).malloc(1_u64)
-  # ptr.value #=> 0
+  # ptr.value # => 0
   #
   # # Allocate memory for 10 Int32: 40 bytes
   # ptr = Pointer(Int32).malloc(10_u64)
-  # ptr[0] #=> 0
-  # ...
-  # ptr[9] #=> 0
-  #
+  # ptr[0] # => 0
+  # # ...
+  # ptr[9] # => 0
   # ```
   @[Primitive(:pointer_malloc)]
   def self.malloc(size : UInt64)

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -62,7 +62,7 @@
 # ```
 # module Ticker
 #   # The callback for the user doesn't have a Void*
-#   @@box : Box(Int32 ->)
+#   @@box : Pointer(Void)?
 #
 #   def self.on_tick(&callback : Int32 ->)
 #     # Since Proc is a {Void*, Void*}, we can't turn that into a Void*, so we

--- a/src/process.cr
+++ b/src/process.cr
@@ -442,7 +442,7 @@ end
 # Example:
 #
 # ```
-# `echo *` # => "LICENSE shard.yml Readme.md spec src\n"
+# `echo hi` # => "hi\n"
 # ```
 def `(command) : String
   process = Process.new(command, shell: true, input: true, output: nil, error: true)

--- a/src/range.cr
+++ b/src/range.cr
@@ -20,7 +20,7 @@
 #
 #   getter size
 #
-#   def initialize(@size)
+#   def initialize(@size : Int32)
 #   end
 #
 #   def succ
@@ -45,9 +45,10 @@
 # An example of using `Xs` to construct a range:
 #
 # ```
-# r = Xs.new(3)..Xs.new(6) # => xxx..xxxxxx
-# r.to_a                   # => [xxx, xxxx, xxxxx, xxxxxx]
-# r.includes?(Xs.new(5))   # => true
+# r = Xs.new(3)..Xs.new(6)
+# r.to_s                 # => "xxx..xxxxxx"
+# r.to_a                 # => [Xs.new(3), Xs.new(4), Xs.new(5), Xs.new(6)]
+# r.includes?(Xs.new(5)) # => true
 # ```
 struct Range(B, E)
   include Enumerable(B)
@@ -85,7 +86,7 @@ struct Range(B, E)
   # Returns an `Iterator` that cycles over the values of this range.
   #
   # ```
-  # (1..3).cycle.first(5).to_a # => [1, 2, 3, 1, 3]
+  # (1..3).cycle.first(5).to_a # => [1, 2, 3, 1, 2]
   # ```
   def cycle
     each.cycle

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -21,7 +21,7 @@ require "./regex/*"
 # x = "a"
 # /#{x}/.match("asdf") # => #<Regex::MatchData "a">
 # x = "("
-# /#{x}/ # => ArgumentError
+# /#{x}/ # raises ArgumentError
 # ```
 #
 # When we check to see if a particular regular expression describes a string,
@@ -57,7 +57,7 @@ require "./regex/*"
 # $~                     # => #<Regex::MatchData "stack">
 # /needle/ =~ "haystack" # => nil
 # "haystack" =~ /needle/ # => nil
-# $~                     # => nil
+# $~                     # raises Exception
 # ```
 #
 # When matching a regular expression using `#match` (either `String#match` or
@@ -70,7 +70,7 @@ require "./regex/*"
 # $~                         # => #<Regex::MatchData "hay">
 # /needle/.match("haystack") # => nil
 # "haystack".match(/needle/) # => nil
-# $~                         # => nil
+# $~                         # raises Exception
 # ```
 #
 # [Regular expressions](https://en.wikipedia.org/wiki/Regular_expression)
@@ -164,10 +164,10 @@ require "./regex/*"
 # * `x`: extended (PCRE_EXTENDED)
 #
 # ```
-# /asdf/ =~ "ASDF"         # => nil
-# /asdf/i =~ "ASDF"        # => 0
-# /asdf\nz/i =~ "ASDF\nZ"  # => nil
-# /asdf\nz/im =~ "ASDF\nZ" # => 0
+# /asdf/ =~ "ASDF"    # => nil
+# /asdf/i =~ "ASDF"   # => 0
+# /^z/i =~ "ASDF\nZ"  # => nil
+# /^z/im =~ "ASDF\nZ" # => 5
 # ```
 #
 # PCRE supports other encodings, but Crystal strings are UTF-8 only, so Crystal
@@ -200,7 +200,8 @@ class Regex
   # Return a `Regex::Options` representing the optional flags applied to this Regex.
   #
   # ```
-  # /ab+c/ix.options # => IGNORE_CASE, EXTENDED
+  # /ab+c/ix.options      # => Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
+  # /ab+c/ix.options.to_s # => "IGNORE_CASE, EXTENDED"
   # ```
   getter options : Options
 

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -78,7 +78,7 @@ class Regex
     #
     # ```
     # "Crystal".match(/r/).not_nil!.byte_begin(0)     # => 1
-    # "Crystal".match(/r(ys)/).not_nil!.byte_begin(1) # => 4
+    # "Crystal".match(/r(ys)/).not_nil!.byte_begin(1) # => 2
     # "クリスタル".match(/リ(ス)/).not_nil!.byte_begin(0)    # => 3
     # ```
     def byte_begin(n = 0)
@@ -125,7 +125,7 @@ class Regex
     #
     # ```
     # "Crystal".match(/r(ys)/).not_nil![1] # => "ys"
-    # "Crystal".match(/r(ys)/).not_nil![2] # => raises IndexError
+    # "Crystal".match(/r(ys)/).not_nil![2] # raises IndexError
     # ```
     def [](n)
       check_index_out_of_bounds n
@@ -151,7 +151,7 @@ class Regex
     #
     # ```
     # "Crystal".match(/r(?<ok>ys)/).not_nil!["ok"] # => "ys"
-    # "Crystal".match(/r(?<ok>ys)/).not_nil!["ng"] # => raises ArgumentError
+    # "Crystal".match(/r(?<ok>ys)/).not_nil!["ng"] # raises ArgumentError
     # ```
     def [](group_name : String)
       match = self[group_name]?

--- a/src/set.cr
+++ b/src/set.cr
@@ -345,8 +345,8 @@ struct Set(T)
   # of elements in this set must be present in the *other* set.
   #
   # ```
-  # Set{1, 5}.subset? Set{1, 3, 5}    # => true
-  # Set{1, 3, 5}.subset? Set{1, 3, 5} # => false
+  # Set{1, 5}.proper_subset? Set{1, 3, 5}    # => true
+  # Set{1, 3, 5}.proper_subset? Set{1, 3, 5} # => false
   # ```
   def proper_subset?(other : Set)
     return false if other.size <= size
@@ -372,8 +372,8 @@ struct Set(T)
   # elements in the *other* set must be present in this set.
   #
   # ```
-  # Set{1, 3, 5}.superset? Set{1, 5}    # => true
-  # Set{1, 3, 5}.superset? Set{1, 3, 5} # => false
+  # Set{1, 3, 5}.proper_superset? Set{1, 5}    # => true
+  # Set{1, 3, 5}.proper_superset? Set{1, 3, 5} # => false
   # ```
   def proper_superset?(other : Set)
     other.proper_subset?(self)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -53,7 +53,7 @@ struct Slice(T)
   #
   # slice = Slice.new(ptr, 3)
   # slice.size # => 3
-  # slice      # => [97, 98, 99]
+  # slice      # => Bytes[97, 98, 99]
   #
   # String.new(slice) # => "abc"
   # ```
@@ -71,7 +71,7 @@ struct Slice(T)
   #
   # ```
   # slice = Slice(UInt8).new(3)
-  # slice # => [0, 0, 0]
+  # slice # => Bytes[0, 0, 0]
   # ```
   def self.new(size : Int)
     {% unless T <= Int::Primitive || T <= Float::Primitive %}
@@ -91,7 +91,7 @@ struct Slice(T)
   #
   # ```
   # slice = Slice.new(3) { |i| i + 10 }
-  # slice # => [10, 11, 12]
+  # slice # => Slice[10, 11, 12]
   # ```
   def self.new(size : Int)
     pointer = Pointer.malloc(size) { |i| yield i }
@@ -106,7 +106,7 @@ struct Slice(T)
   #
   # ```
   # slice = Slice.new(3, 10)
-  # slice # => [10, 10, 10]
+  # slice # => Slice[10, 10, 10]
   # ```
   def self.new(size : Int, value : T)
     new(size) { value }
@@ -126,10 +126,10 @@ struct Slice(T)
   #
   # ```
   # slice = Slice.new(5) { |i| i + 10 }
-  # slice # => [10, 11, 12, 13, 14]
+  # slice # => Slice[10, 11, 12, 13, 14]
   #
   # slice2 = slice + 2
-  # slice2 # => [12, 13, 14]
+  # slice2 # => Slice[12, 13, 14]
   # ```
   def +(offset : Int)
     unless 0 <= offset <= size
@@ -148,9 +148,9 @@ struct Slice(T)
   # slice = Slice.new(5) { |i| i + 10 }
   # slice[0] = 20
   # slice[-1] = 30
-  # slice # => [20, 11, 12, 13, 30]
+  # slice # => Slice[20, 11, 12, 13, 30]
   #
-  # slice[4] = 1 # => IndexError
+  # slice[10] = 1 # raises IndexError
   # ```
   @[AlwaysInline]
   def []=(index : Int, value : T)
@@ -169,10 +169,10 @@ struct Slice(T)
   #
   # ```
   # slice = Slice.new(5) { |i| i + 10 }
-  # slice # => [10, 11, 12, 13, 14]
+  # slice # => Slice[10, 11, 12, 13, 14]
   #
   # slice2 = slice[1, 3]
-  # slice2 # => [11, 12, 13]
+  # slice2 # => Slice[11, 12, 13]
   # ```
   def [](start, count)
     unless 0 <= start <= @size
@@ -233,7 +233,7 @@ struct Slice(T)
   # dst = Slice['b', 'b', 'b', 'b', 'b']
   # src.copy_to dst
   # dst             # => Slice['a', 'a', 'a', 'b', 'b']
-  # dst.copy_to src # => IndexError
+  # dst.copy_to src # raises IndexError
   # ```
   def copy_to(target : self)
     @pointer.copy_to(target.pointer(size), size)
@@ -266,7 +266,7 @@ struct Slice(T)
   # dst = Slice['b', 'b', 'b', 'b', 'b']
   # src.move_to dst
   # dst             # => Slice['a', 'a', 'a', 'b', 'b']
-  # dst.move_to src # => IndexError
+  # dst.move_to src # raises IndexError
   # ```
   #
   # See also: `Pointer#move_to`.
@@ -292,7 +292,7 @@ struct Slice(T)
   #
   # ```
   # slice = UInt8.slice(97, 62, 63, 8, 255)
-  # slice.hexstring # => "61626308ff"
+  # slice.hexstring # => "613e3f08ff"
   # ```
   def hexstring
     self.as(Slice(UInt8))

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -94,7 +94,7 @@ class Socket < IO::FileDescriptor
   #
   # ```
   # sock = Socket.unix
-  # sock.connect UNIXAddress.new("/tmp/service.sock")
+  # sock.connect Socket::UNIXAddress.new("/tmp/service.sock")
   # ```
   def connect(addr, timeout = nil) : Nil
     connect(addr, timeout) { |error| raise error }
@@ -246,8 +246,8 @@ class Socket < IO::FileDescriptor
   #
   # ```
   # sock = Socket.unix(Socket::Type::DGRAM)
-  # sock.connect("/tmp/service.sock")
-  # sock.send(binary_message)
+  # sock.connect Socket::UNIXAddress.new("/tmp/service.sock")
+  # sock.send(Bytes[0])
   # ```
   def send(message : Bytes)
     bytes_sent = LibC.send(fd, message.to_unsafe.as(Void*), message.size, 0)

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -23,7 +23,7 @@ class Socket
     #
     # Example:
     # ```
-    # addrinfos = Socket::Addrinfo.resolve("example.org", "http", type: Socket::Type::STREAM, protocol: Socket::Type::TCP)
+    # addrinfos = Socket::Addrinfo.resolve("example.org", "http", type: Socket::Type::STREAM, protocol: Socket::Protocol::TCP)
     # ```
     def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
       addrinfos = [] of Addrinfo

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -27,7 +27,7 @@ struct StaticArray(T, N)
   # block's value in that index.
   #
   # ```
-  # StaticArray(Int32, 3).new { |i| i * 2 } # => [0, 2, 4]
+  # StaticArray(Int32, 3).new { |i| i * 2 } # => StaticArray[0, 2, 4]
   # ```
   def self.new(&block : Int32 -> T)
     array = uninitialized self
@@ -40,7 +40,7 @@ struct StaticArray(T, N)
   # Creates a new static array filled with the given value.
   #
   # ```
-  # StaticArray(Int32, 3).new(42) # => [42, 42, 42]
+  # StaticArray(Int32, 3).new(42) # => StaticArray[42, 42, 42]
   # ```
   def self.new(value : T)
     new { value }
@@ -56,9 +56,9 @@ struct StaticArray(T, N)
   # corresponding element in *other*.
   #
   # ```
-  # array = StaticArray(Int32, 3).new 0  # => [0, 0, 0]
-  # array2 = StaticArray(Int32, 3).new 0 # => [0, 0, 0]
-  # array3 = StaticArray(Int32, 3).new 1 # => [1, 1, 1]
+  # array = StaticArray(Int32, 3).new 0  # => StaticArray[0, 0, 0]
+  # array2 = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
+  # array3 = StaticArray(Int32, 3).new 1 # => StaticArray[1, 1, 1]
   # array == array2                      # => true
   # array == array3                      # => false
   # ```
@@ -73,7 +73,7 @@ struct StaticArray(T, N)
   # Equality with another object. Always returns *false*.
   #
   # ```
-  # array = StaticArray(Int32, 3).new 0 # => [0, 0, 0]
+  # array = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
   # array == nil                        # => false
   # ```
   def ==(other)
@@ -91,9 +91,10 @@ struct StaticArray(T, N)
   # Raises `IndexError` if trying to set an element outside the array's range.
   #
   # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => [1, 2, 3]
-  # array[2] = 2                                    # => [1, 2, 2]
-  # array[4] = 4                                    # => IndexError
+  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
+  # array[2] = 2                                    # => 2
+  # array                                           # => StaticArray[1, 2, 2]
+  # array[4] = 4                                    # raises IndexError
   # ```
   @[AlwaysInline]
   def []=(index : Int, value : T)
@@ -105,9 +106,10 @@ struct StaticArray(T, N)
   # Raises `IndexError` if trying to set an element outside the array's range.
   #
   # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => [1, 2, 3]
-  # array.update(1) { |x| x * 2 }                   # => [1, 4, 3]
-  # array.update(5) { |x| x * 2 }                   # => IndexError
+  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
+  # array.update(1) { |x| x * 2 }                   # => 4
+  # array                                           # => StaticArray[1, 4, 3]
+  # array.update(5) { |x| x * 2 }                   # raises IndexError
   # ```
   def update(index : Int)
     index = check_index_out_of_bounds index
@@ -128,7 +130,8 @@ struct StaticArray(T, N)
   #
   # ```
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.[]= 2 # => [2, 2, 2]
+  # array.[]= 2 # => 3
+  # array       # => StaticArray[2, 2, 2]
   # ```
   def []=(value : T)
     size.times do |i|
@@ -140,9 +143,9 @@ struct StaticArray(T, N)
   # using the given *random* number generator.  Returns `self`.
   #
   # ```
-  # a = StaticArray(Int32, 3).new { |i| i + 1 } # => [1, 2, 3]
-  # a.shuffle!(Random.new(42))                  # => [3, 2, 1]
-  # a                                           # => [3, 2, 1]
+  # a = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
+  # a.shuffle!(Random.new(42))                  # => StaticArray[3, 2, 1]
+  # a                                           # => StaticArray[3, 2, 1]
   # ```
   def shuffle!(random = Random::DEFAULT)
     to_slice.shuffle!(random)
@@ -154,7 +157,7 @@ struct StaticArray(T, N)
   #
   # ```
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.map! { |x| x*x } # => [1, 4, 9]
+  # array.map! { |x| x*x } # => StaticArray[1, 4, 9]
   # ```
   def map!
     to_unsafe.map!(size) { |e| yield e }
@@ -165,7 +168,7 @@ struct StaticArray(T, N)
   #
   # ```
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.reverse! # => [3, 2, 1]
+  # array.reverse! # => StaticArray[3, 2, 1]
   # ```
   def reverse!
     to_slice.reverse!
@@ -177,9 +180,9 @@ struct StaticArray(T, N)
   #
   # ```
   # array = StaticArray(Int32, 3).new(2)
-  # slice = array.to_slice # => [2, 2, 2]
+  # slice = array.to_slice # => Slice[2, 2, 2]
   # slice[0] = 3
-  # array # => [3, 2, 2]
+  # array # => StaticArray[3, 2, 2]
   # ```
   def to_slice
     Slice.new(to_unsafe, size)
@@ -199,7 +202,7 @@ struct StaticArray(T, N)
   #
   # ```
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.to_s # => "[1, 2, 3]"
+  # array.to_s # => "StaticArray[1, 2, 3]"
   # ```
   def to_s(io : IO)
     io << "StaticArray["

--- a/src/time.cr
+++ b/src/time.cr
@@ -6,9 +6,9 @@ require "c/time"
 # ### Basic Usage
 #
 # ```
-# time = Time.now # => 2016-02-15 10:20:30 UTC
+# time = Time.new(2016, 2, 15, 10, 20, 30)
 #
-# time.year    # => 2015
+# time.year    # => 2016
 # time.month   # => 2
 # time.day     # => 15
 # time.hour    # => 10
@@ -28,7 +28,8 @@ require "c/time"
 # The `to_s` method returns a `String` value in the assigned format.
 #
 # ```
-# Time.now.to_s("%Y-%m-%d") # => "2015-10-12"
+# time = Time.new(2015, 10, 12)
+# time.to_s("%Y-%m-%d") # => "2015-10-12"
 # ```
 #
 # See `Time::Format` for all the directives.
@@ -154,7 +155,7 @@ struct Time
   # milliseconds elapsed since the unix epoch (00:00:00 UTC on 1 January 1970)
   #
   # ```
-  # time = Time.epoch_ms(981173106789) # => 2001-02-03 04:05:06 UTC
+  # time = Time.epoch_ms(981173106789) # => 2001-02-03 04:05:06.789 UTC
   # time.millisecond                   # => 789
   # ```
   def self.epoch_ms(milliseconds : Int) : self
@@ -339,7 +340,8 @@ struct Time
   # Formats this time using the given format (see `Time::Format`).
   #
   # ```
-  # Time.now.to_s("%F") # => "2016-04-05"
+  # time = Time.new(2016, 4, 5)
+  # time.to_s("%F") # => "2016-04-05"
   # ```
   def to_s(format : String) : String
     Format.new(format).format(self)
@@ -364,7 +366,8 @@ struct Time
   # Returns the number of seconds since the Epoch for this time.
   #
   # ```
-  # Time.new(2016, 1, 2, 3, 4, 5).epoch # => 1451714645
+  # time = Time.parse("2016-01-12 03:04:05 UTC", "%F %T %z")
+  # time.epoch # => 1452567845
   # ```
   def epoch : Int64
     (to_utc.ticks - UnixEpoch) / Span::TicksPerSecond
@@ -373,7 +376,8 @@ struct Time
   # Returns the number of milliseconds since the Epoch for this time.
   #
   # ```
-  # Time.new(2016, 1, 2, 3, 4, 5, 678).epoch_ms # => 1451714645678
+  # time = Time.parse("2016-01-12 03:04:05.678 UTC", "%F %T.%L %z")
+  # time.epoch_ms # => 1452567845678
   # ```
   def epoch_ms : Int64
     (to_utc.ticks - UnixEpoch) / Span::TicksPerMillisecond
@@ -383,7 +387,8 @@ struct Time
   # as a `Float64`.
   #
   # ```
-  # Time.new(2016, 1, 2, 3, 4, 5, 678).epoch_f # => 1.45171e+09
+  # time = Time.parse("2016-01-12 03:04:05.678 UTC", "%F %T.%L %z")
+  # time.epoch_f # => 1452567845.678
   # ```
   def epoch_f : Float64
     (to_utc.ticks - UnixEpoch) / Span::TicksPerSecond.to_f

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -5,7 +5,7 @@
 # Check all `#new` methods for details.
 #
 # ```
-# Time::Span.new(10000)          # => 0:0:0.010000
+# Time::Span.new(10000)          # => 00:00:00.001
 # Time::Span.new(10, 10, 10)     # => 10:10:10
 # Time::Span.new(10, 10, 10, 10) # => 10.10:10:10
 # ```

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -8,9 +8,9 @@
 #
 # ```
 # tuple = {1, "hello", 'x'} # Tuple(Int32, String, Char)
-# tuple[0]                  # => 1       (Int32)
-# tuple[1]                  # => "hello" (String)
-# tuple[2]                  # => 'x'     (Char)
+# tuple[0]                  # => 1
+# tuple[1]                  # => "hello"
+# tuple[2]                  # => 'x'
 # ```
 #
 # The compiler knows what types are in each position, so when indexing
@@ -59,7 +59,8 @@
 # end
 #
 # tuple = splat_test 1, "hello", 'x'
-# tuple # => {1, "hello", 'x'} (Tuple(Int32, String, Char))
+# tuple.class # => Tuple(Int32, String, Char)
+# tuple       # => {1, "hello", 'x'}
 # ```
 struct Tuple
   include Indexable(Union(*T))
@@ -105,7 +106,7 @@ struct Tuple
   # end
   #
   # data = JSON.parse(%(["world", 2])).as_a
-  # speak_about(*{String, Int64}).from(data)) # => "I see 2 worlds"
+  # speak_about(*{String, Int64}.from(data)) # => "I see 2 worlds"
   # ```
   def from(array : Array)
     if size != array.size
@@ -131,13 +132,13 @@ struct Tuple
   # ```
   # tuple = {1, "hello", 'x'}
   # tuple[0] # => 1 (Int32)
-  # tuple[3] # => compile error: index out of bounds for tuple {Int32, String, Char}
+  # tuple[3] # compile error: index out of bounds for tuple {Int32, String, Char}
   #
   # i = 0
   # tuple[i] # => 1 (Int32 | String | Char)
   #
   # i = 3
-  # tuple[i] # => runtime error: IndexError
+  # tuple[i] # raises IndexError
   # ```
   def [](index : Int)
     at(index)
@@ -159,7 +160,7 @@ struct Tuple
   # ```
   # tuple = {1, "hello", 'x'}
   # tuple.at(0) # => 1
-  # tuple.at(3) # => raises IndexError
+  # tuple.at(3) # raises IndexError
   # ```
   def at(index : Int)
     at(index) { raise IndexError.new }
@@ -364,11 +365,11 @@ struct Tuple
     {{T.size}}
   end
 
-  # Returns a tuple containing the types of this tuple.
+  # Returns the types of this tuple.
   #
   # ```
   # tuple = {1, "hello", 'x'}
-  # tuple.types # => {Int32, String, Char}
+  # tuple.types # => Tuple(Int32, String, Char)
   # ```
   def types
     T

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -14,14 +14,10 @@ require "./uri/uri_parser"
 #
 # uri = URI.parse "http://foo.com/posts?id=30&limit=5#time=1305298413"
 # # => #&lt;URI:0x1003f1e40 @scheme="http", @host="foo.com", @port=nil, @path="/posts", @query="id=30&limit=5", ... >
-# uri.scheme
-# # => "http"
-# uri.host
-# # => "foo.com"
-# uri.query
-# # => "id=30&limit=5"
-# uri.to_s
-# # => "http://foo.com/posts?id=30&limit=5#time=1305298413"
+# uri.scheme # => "http"
+# uri.host   # => "foo.com"
+# uri.query  # => "id=30&limit=5"
+# uri.to_s   # => "http://foo.com/posts?id=30&limit=5#time=1305298413"
 # ```
 class URI
   class Error < Exception
@@ -187,12 +183,9 @@ class URI
   # ```
   # require "uri"
   #
-  # uri = URI.parse("http://crystal-lang.org")
-  # # => #<URI:0x1068a7e40 @scheme="http", @host="crystal-lang.org", ... >
-  # uri.scheme
-  # # => "http"
-  # uri.host
-  # # => "crystal-lang.org"
+  # uri = URI.parse("http://crystal-lang.org") # => #<URI:0x1068a7e40 @scheme="http", @host="crystal-lang.org", ... >
+  # uri.scheme                                 # => "http"
+  # uri.host                                   # => "crystal-lang.org"
   # ```
   def self.parse(raw_url : String) : URI
     URI::Parser.new(raw_url).run.uri

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -445,7 +445,10 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `Bool`.
   #
   # ```
-  # node.xpath_bool("count(//person) > 0")
+  # require "xml"
+  # doc = XML.parse("<person></person>")
+  #
+  # doc.xpath_bool("count(//person) > 0") # => true
   # ```
   def xpath_bool(path, namespaces = nil, variables = nil)
     xpath(path, namespaces).as(Bool)
@@ -454,7 +457,7 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `Float64`.
   #
   # ```
-  # node.xpath_float("count(//person)")
+  # doc.xpath_float("count(//person)") # => 1.0
   # ```
   def xpath_float(path, namespaces = nil, variables = nil)
     xpath(path, namespaces).as(Float64)
@@ -463,7 +466,9 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `NodeSet`.
   #
   # ```
-  # node.xpath_nodes("//person")
+  # nodes = doc.xpath_nodes("//person")
+  # nodes.class       # => XML::NodeSet
+  # nodes.map(&.name) # => ["person"]
   # ```
   def xpath_nodes(path, namespaces = nil, variables = nil)
     xpath(path, namespaces).as(NodeSet)
@@ -472,7 +477,8 @@ struct XML::Node
   # Searches this node for XPath *path* for nodes and returns the first one.
   # or nil if not found
   # ```
-  # node.xpath_node("//person")
+  # doc.xpath_node("//person")  # => #<XML::Node:0x2013e80 name="person">
+  # doc.xpath_node("//invalid") # => nil
   # ```
   def xpath_node(path, namespaces = nil, variables = nil)
     xpath_nodes(path, namespaces).first?
@@ -481,7 +487,7 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `String`.
   #
   # ```
-  # node.xpath_string("string(/persons/person[1])")
+  # doc.xpath_string("string(/persons/person[1])")
   # ```
   def xpath_string(path, namespaces = nil, variables = nil)
     xpath(path, namespaces).as(String)

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -53,11 +53,11 @@ require "./yaml/*"
 # otherwise it will be returned as a string. Similarly, `#to_yaml` (with or without an `IO`) on any object does the same.
 #
 # ```
-# yaml = YAML.dump({hello: "world"})                                # => "--- \nhello: world"
-# File.open("file.yml", "w") { |f| YAML.dump({hello: "world"}, f) } # => writes it to the file
+# yaml = YAML.dump({hello: "world"})                               # => "---\nhello: world\n"
+# File.open("foo.yml", "w") { |f| YAML.dump({hello: "world"}, f) } # writes it to the file
 # # or:
-# yaml = {hello: "world"}.to_yaml                                # => "--- \nhello: world"
-# File.open("file.yml", "w") { |f| {hello: "world"}.to_yaml(f) } # => writes it to the file
+# yaml = {hello: "world"}.to_yaml                               # => "---\nhello: world\n"
+# File.open("foo.yml", "w") { |f| {hello: "world"}.to_yaml(f) } # writes it to the file
 # ```
 module YAML
   class Error < Exception

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -12,7 +12,7 @@
 #                - qux
 #                - fox
 #          END
-# data["foo"]["bar"]["baz"][1].as_s # => "qux"
+# data["foo"]["bar"]["baz"][0].as_s # => "qux"
 # data["foo"]["bar"]["baz"].as_a    # => ["qux", "fox"]
 # ```
 #

--- a/src/yaml/mapping.cr
+++ b/src/yaml/mapping.cr
@@ -29,16 +29,15 @@ module YAML
   #
   # ```
   # employee = Employee.from_yaml("title: Manager\nname: John\nage: 30")
-  # employee.age # => undefined method 'age'.
+  # employee.age # undefined method 'age'. (compile error)
   #
-  # employee = Employee.from_yaml("title: Manager")
-  # # => ParseException: missing yaml attribute: name
+  # Employee.from_yaml("title: Manager") # raises YAML::ParseException
   # ```
   #
   # You can also define attributes for each property.
   #
   # ```
-  # class Employee
+  # class Employer
   #   YAML.mapping(
   #     title: String,
   #     name: {

--- a/src/zlib/deflate.cr
+++ b/src/zlib/deflate.cr
@@ -11,6 +11,8 @@
 # ```
 # require "zlib"
 #
+# File.write("file.txt", "abc")
+#
 # File.open("./file.txt", "r") do |input_file|
 #   File.open("./file.gzip", "w") do |output_file|
 #     Zlib::Deflate.gzip(output_file) do |deflate|

--- a/src/zlib/inflate.cr
+++ b/src/zlib/inflate.cr
@@ -9,12 +9,14 @@
 # ```
 # require "zlib"
 #
-# string = File.open("./file.gzip", "r") do |file|
+# File.write("file.gzip", Bytes[31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 75, 76, 74, 6, 0, 194, 65, 36, 53, 3, 0, 0, 0])
+#
+# string = File.open("file.gzip", "r") do |file|
 #   Zlib::Inflate.gzip(file) do |inflate|
 #     inflate.gets_to_end
 #   end
 # end
-# puts string
+# string # => "abc"
 # ```
 #
 # See also: `Zlib::Deflate` for compressing data.


### PR DESCRIPTION
Fixed and updated example codes in src files.

1. Fixed wrong or outdated code and return values
2. Updated comment parts to embed hints for spec

### Strategy of updating comments

#### assumed format to generate spec
- `value # XXX` : treats `XXX` just as a comment (NOP)
- `value # => XXX` : generates `( value ).should eq( XXX )`
- `value # raises XXX` : generates `expect_raises(XXX) { value }`
- `value # xxx error` : generates `# value` used for compilation errors

These rules help to generate specs automatically.

#### Example

The example code of `slice.cr`

```crystal
slice = Slice[1, 'a']
slice[0]    # => 1
slice[3]    # raises IndexError
slice.class # => Slice(Char | Int32)
```

can be automatically converted to

```crystal
slice = Slice[1, 'a']
( slice[0] ).should eq( 1 )
expect_raises(IndexError) { slice[3] }
( slice.class ).should eq( Slice(Char | Int32) )
```

### CI

Run spec all crystal example codes by
- convert comments to spec: https://github.com/maiha/comment-spec.cr
- extract and run spec: https://github.com/maiha/crystal-examples

#### master (5739844 2017-01-01 18:47)

```
Specs 127 (47 successes, 60 failures, 20 pending)
Examples 1191 (132 successes, 889 failures, 170 pending)
```

#### This PR

- generated specs: https://github.com/maiha/crystal-examples/tree/master/gen/spec

```
Specs 126 (102 successes, 4 failures, 20 pending)
Examples 1190 (994 successes, 9 failures, 187 pending)
```
- 9 failures will be fixed in 0.20.4 (such as `YAML.build`)

Thanks.