### PR TITLE
Add Hash#compact and Hash#compact!

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -420,6 +420,30 @@ describe "Hash" do
     h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
+  it "compacts" do
+    h1 = {:a => 1, :b => 2, :c => nil}
+
+    h2 = h1.compact
+    h2.should be_a(Hash(Symbol, Int32))
+    h2.should eq({:a => 1, :b => 2})
+  end
+
+  it "compacts!" do
+    h1 = {:a => 1, :b => 2, :c => nil}
+
+    h2 = h1.compact!
+    h2.should eq({:a => 1, :b => 2})
+    h2.should be(h1)
+  end
+
+  it "returns nil when using compact! and no changes were made" do
+    h1 = {:a => 1, :b => 2, :c => 3}
+
+    h2 = h1.compact!
+    h2.should be_nil
+    h1.should eq({:a => 1, :b => 2, :c => 3})
+  end
+
   it "zips" do
     ary1 = [1, 2, 3]
     ary2 = ['a', 'b', 'c']

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -554,6 +554,29 @@ class Hash(K, V)
     select!(keys)
   end
 
+  # Returns new `Hash` without `nil` values.
+  #
+  # ```
+  # hash = {"hello" => "world", "foo" => nil}
+  # hash.compact # => {"hello" => "world"}
+  # ```
+  def compact
+    each_with_object({} of K => typeof(self.first_value.not_nil!)) do |(key, value), memo|
+      memo[key] = value unless value.nil?
+    end
+  end
+
+  # Removes all `nil` value from `self`. Returns nil if no changes were made.
+  #
+  # ```
+  # hash = {"hello" => "world", "foo" => nil}
+  # hash.compact! # => {"hello" => "world"}
+  # hash.compact! # => nil
+  # ```
+  def compact!
+    reject! { |key, value| value.nil? }
+  end
+
   # Zips two arrays into a `Hash`, taking keys from *ary1* and values from *ary2*.
   #
   # ```


### PR DESCRIPTION
Ruby 2.4 has `Hash#compact` and `Hash#compact!`. This pull request introduces them into Crystal.

`Hash#compact` makes a new `Hash` without all `nil` values:

```crystal
h1 = {"hello" => "world", "foo" => nil}
h1.class # => Hash(String, String | Nil)
h2 = h1.compact
h2       # => {"hello" => "world"}
h2.class # => Hash(String, String)
```

And, `Hash#compact!` removes all `nil` values from `self`, and returns `self` or `nil` if it were made no changes like `Hash#reject!`:

```crystal
h1 = {"hello" => "world", "foo" => nil}
h1.compact! # => {"hello" => "world"}
h1          # => {"hello" => "world"}
h1.class    # => Hash(String, String | Nil)
h1.compact! # => nil
```

Their behaviors are same as Ruby.
