### PR TITLE
Use the OpenBSD version of LLVM when cross-compiling for it

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -27,7 +27,7 @@ end
 
 {% begin %}
   lib LibLLVM
-    IS_38 = {{LibLLVM::VERSION.starts_with?("3.8")}}
+    IS_38 = {{LibLLVM::VERSION.starts_with?("3.8") || flag?(:openbsd)}}
     IS_36 = {{LibLLVM::VERSION.starts_with?("3.6")}}
     IS_35 = {{LibLLVM::VERSION.starts_with?("3.5")}}
   end


### PR DESCRIPTION
When cross compiling an object file from an OS that has a newer version of LLVM install, we need to use the version of LLVM supported on the cross-compile target.