### PR TITLE
Add `String#sub(Regex, NamedTuple)`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1001,6 +1001,12 @@ describe "String" do
       str.sub(/(he|l|o)/, {"l" => "la"}).should be(str)
     end
 
+    it "subs with regex and named tuple" do
+      str = "hello"
+      str.sub(/(he|l|o)/, {he: "ha", l: "la"}).should eq("hallo")
+      str.sub(/(he|l|o)/, {l: "la"}).should be(str)
+    end
+
     it "subs using $~" do
       "foo".sub(/(o)/) { "x#{$1}x" }.should eq("fxoxo")
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -1423,7 +1423,7 @@ class String
   # "hello".sub(/(he|l|o)/, {"he": "ha", "l": "la"}) # => "hallo"
   # "hello".sub(/(he|l|o)/, {"l": "la"})             # => "hello"
   # ```
-  def sub(pattern : Regex, hash : Hash(String, _))
+  def sub(pattern : Regex, hash : Hash(String, _) | NamedTuple)
     sub(pattern) { |match|
       if hash.has_key?(match)
         hash[match]


### PR DESCRIPTION
`String#sub(Regex, NamedTuple)` has gone before I knew it.
