### PR TITLE
Fix each* methods to return only nil

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -67,7 +67,7 @@ describe "Block inference" do
     assert_type("
       require \"prelude\"
       a = [1] || [1.1]
-      a.each { |x| x }
+      a.tap { |x| x }
     ") { union_of(array_of(int32), array_of(float64)) }
   end
 

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -511,7 +511,7 @@ describe "Array" do
   it "does each_index" do
     a = [1, 1, 1]
     b = 0
-    a.each_index { |i| b += i }
+    a.each_index { |i| b += i }.should be_nil
     b.should eq(3)
   end
 
@@ -1193,7 +1193,7 @@ describe "Array" do
     a.each do
       count += 1
       a.clear
-    end
+    end.should be_nil
     count.should eq(1)
   end
 
@@ -1203,7 +1203,7 @@ describe "Array" do
     a.each_index do
       count += 1
       a.clear
-    end
+    end.should be_nil
     count.should eq(1)
   end
 
@@ -1477,7 +1477,7 @@ describe "Array" do
       sums = [] of Int32
       [1, 2, 3].each_permutation(2) do |perm|
         sums << perm.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([3, 4, 3, 5, 4, 5])
     end
 
@@ -1486,7 +1486,7 @@ describe "Array" do
       [1, 2, 3].each_permutation(3) do |perm|
         perm.map! &.+(1)
         sums << perm.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([9, 9, 9, 9, 9, 9])
     end
 
@@ -1497,7 +1497,7 @@ describe "Array" do
         object_ids << perm.object_id
         perm.map! &.+(1)
         sums << perm.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([9, 9, 9, 9, 9, 9])
       object_ids.size.should eq(1)
     end
@@ -1561,7 +1561,7 @@ describe "Array" do
       sums = [] of Int32
       [1, 2, 3].each_combination(2) do |comb|
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([3, 4, 5])
     end
 
@@ -1570,7 +1570,7 @@ describe "Array" do
       [1, 2, 3].each_combination(3) do |comb|
         comb.map! &.+(1)
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([9])
     end
 
@@ -1580,7 +1580,7 @@ describe "Array" do
       [1, 2, 3].each_combination(2, reuse: true) do |comb|
         sums << comb.sum
         object_ids << comb.object_id
-      end
+      end.should be_nil
       sums.should eq([3, 4, 5])
       object_ids.size.should eq(1)
     end
@@ -1591,7 +1591,7 @@ describe "Array" do
       [1, 2, 3].each_combination(2, reuse: reuse) do |comb|
         sums << comb.sum
         comb.should be(reuse)
-      end
+      end.should be_nil
       sums.should eq([3, 4, 5])
     end
 
@@ -1652,7 +1652,7 @@ describe "Array" do
       sums = [] of Int32
       [1, 2, 3].each_repeated_combination(2) do |comb|
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([2, 3, 4, 4, 5, 6])
     end
 
@@ -1661,7 +1661,7 @@ describe "Array" do
       [1, 2, 3].each_repeated_combination(3) do |comb|
         comb.map! &.+(1)
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 8, 9, 10, 9, 10, 11, 12])
     end
 
@@ -1674,7 +1674,7 @@ describe "Array" do
         object_ids << comb.object_id
         comb.map! &.+(1)
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 8, 9, 10, 9, 10, 11, 12])
       object_ids.size.should eq(1)
     end
@@ -1686,7 +1686,7 @@ describe "Array" do
         comb.should be(reuse)
         comb.map! &.+(1)
         sums << comb.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 8, 9, 10, 9, 10, 11, 12])
     end
 
@@ -1745,7 +1745,7 @@ describe "Array" do
       sums = [] of Int32
       [1, 2, 3].each_repeated_permutation(2) do |a|
         sums << a.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([2, 3, 4, 3, 4, 5, 4, 5, 6])
     end
 
@@ -1754,7 +1754,7 @@ describe "Array" do
       [1, 2, 3].each_repeated_permutation(3) do |a|
         a.map! &.+(1)
         sums << a.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 7, 8, 9, 8, 9, 10, 7, 8, 9, 8, 9, 10, 9, 10, 11, 8, 9, 10, 9, 10, 11, 10, 11, 12])
     end
 
@@ -1765,7 +1765,7 @@ describe "Array" do
         object_ids << a.object_id
         a.map! &.+(1)
         sums << a.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 7, 8, 9, 8, 9, 10, 7, 8, 9, 8, 9, 10, 9, 10, 11, 8, 9, 10, 9, 10, 11, 10, 11, 12])
       object_ids.size.should eq(1)
     end
@@ -1777,7 +1777,7 @@ describe "Array" do
         a.should be(reuse)
         a.map! &.+(1)
         sums << a.sum
-      end.should eq([1, 2, 3])
+      end.should be_nil
       sums.should eq([6, 7, 8, 7, 8, 9, 8, 9, 10, 7, 8, 9, 8, 9, 10, 9, 10, 11, 8, 9, 10, 9, 10, 11, 10, 11, 12])
     end
 

--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -67,7 +67,7 @@ describe "Char::Reader" do
     sum = 0
     reader.each do |char|
       sum += char.ord
-    end
+    end.should be_nil
     sum.should eq(294)
   end
 
@@ -75,7 +75,7 @@ describe "Char::Reader" do
     reader = Char::Reader.new("")
     reader.each do |char|
       fail "reader each shouldn't yield on empty string"
-    end
+    end.should be_nil
   end
 
   it "errors if 0x80 <= first_byte < 0xC2" do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -339,6 +339,10 @@ describe "Char" do
     end
   end
 
+  it "does each_byte" do
+    'a'.each_byte(&.should eq('a'.ord)).should be_nil
+  end
+
   it "does bytes" do
     '\u{FF}'.bytes.should eq([195, 191])
   end

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -91,7 +91,7 @@ describe CSV do
     sum = 0
     CSV.each_row("1,2\n3,4\n") do |row|
       sum += row.map(&.to_i).sum
-    end
+    end.should be_nil
     sum.should eq(10)
   end
 

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -118,7 +118,7 @@ describe CSV do
     csv.each do
       csv["one"].should eq("1")
       break
-    end
+    end.should be_nil
   end
 
   it "can do new with block" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -277,10 +277,17 @@ describe "Deque" do
     a.should eq(Deque{x})
   end
 
+  it "does each" do
+    a = Deque{1, 1, 1}
+    b = 0
+    a.each { |i| b += i }.should be_nil
+    b.should eq(3)
+  end
+
   it "does each_index" do
     a = Deque{1, 1, 1}
     b = 0
-    a.each_index { |i| b += i }
+    a.each_index { |i| b += i }.should be_nil
     b.should eq(3)
   end
 

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -236,7 +236,7 @@ describe "Dir" do
     dir = Dir.new(__DIR__)
     dir.each do |filename|
       filenames << filename
-    end
+    end.should be_nil
     dir.close
 
     filenames.includes?("dir_spec.cr").should be_true
@@ -248,7 +248,7 @@ describe "Dir" do
     Dir.open(__DIR__) do |dir|
       dir.each do |filename|
         filenames << filename
-      end
+      end.should be_nil
     end
 
     filenames.includes?("dir_spec.cr").should be_true

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -535,6 +535,36 @@ describe "Hash" do
     %w(a c).should contain h3[1]
   end
 
+  it "does each" do
+    hash = {"foo" => 1, "bar" => 2}
+    ks = [] of String
+    vs = [] of Int32
+    hash.each do |k, v|
+      ks << k
+      vs << v
+    end.should be_nil
+    ks.should eq(["foo", "bar"])
+    vs.should eq([1, 2])
+  end
+
+  it "does each_key" do
+    hash = {"foo" => 1, "bar" => 2}
+    ks = [] of String
+    hash.each_key do |k|
+      ks << k
+    end.should be_nil
+    ks.should eq(["foo", "bar"])
+  end
+
+  it "does each_value" do
+    hash = {"foo" => 1, "bar" => 2}
+    vs = [] of Int32
+    hash.each_value do |v|
+      vs << v
+    end.should be_nil
+    vs.should eq([1, 2])
+  end
+
   it "gets each iterator" do
     iter = {:a => 1, :b => 2}.each
     iter.next.should eq({:a, 1})
@@ -569,14 +599,14 @@ describe "Hash" do
     it "pass key, value, index values into block" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index { |(k, v), i| results << k + v + i }
+      hash.each_with_index { |(k, v), i| results << k + v + i }.should be_nil
       results.should eq [6, 16, 23]
     end
 
     it "can be used with offset" do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
-      hash.each_with_index(3) { |(k, v), i| results << k + v + i }
+      hash.each_with_index(3) { |(k, v), i| results << k + v + i }.should be_nil
       results.should eq [9, 19, 26]
     end
   end

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -34,4 +34,22 @@ describe Indexable do
     indexable = SafeIndexable.new(3)
     indexable.rindex(0, 100).should be_nil
   end
+
+  it "does each" do
+    indexable = SafeIndexable.new(3)
+    is = [] of Int32
+    indexable.each do |i|
+      is << i
+    end.should be_nil
+    is.should eq([0, 1, 2])
+  end
+
+  it "does each_index" do
+    indexable = SafeIndexable.new(3)
+    is = [] of Int32
+    indexable.each_index do |i|
+      is << i
+    end.should be_nil
+    is.should eq([0, 1, 2])
+  end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -229,19 +229,19 @@ describe "Int" do
   describe "to" do
     it "does upwards" do
       a = 0
-      1.to(3) { |i| a += i }
+      1.to(3) { |i| a += i }.should be_nil
       a.should eq(6)
     end
 
     it "does downards" do
       a = 0
-      4.to(2) { |i| a += i }
+      4.to(2) { |i| a += i }.should be_nil
       a.should eq(9)
     end
 
     it "does when same" do
       a = 0
-      2.to(2) { |i| a += i }
+      2.to(2) { |i| a += i }.should be_nil
       a.should eq(2)
     end
   end
@@ -376,6 +376,16 @@ describe "Int" do
     (4 % 2).should eq(0)
   end
 
+  it "does times" do
+    i = sum = 0
+    3.times do |n|
+      i += 1
+      sum += n
+    end.should be_nil
+    i.should eq(3)
+    sum.should eq(3)
+  end
+
   it "gets times iterator" do
     iter = 3.times
     iter.next.should eq(0)
@@ -403,6 +413,16 @@ describe "Int" do
     -13.remainder(-4).should eq(-1)
   end
 
+  it "does upto" do
+    i = sum = 0
+    1.upto(3) do |n|
+      i += 1
+      sum += n
+    end.should be_nil
+    i.should eq(3)
+    sum.should eq(6)
+  end
+
   it "gets upto iterator" do
     iter = 1.upto(3)
     iter.next.should eq(1)
@@ -412,6 +432,16 @@ describe "Int" do
 
     iter.rewind
     iter.next.should eq(1)
+  end
+
+  it "does downto" do
+    i = sum = 0
+    3.downto(1) do |n|
+      i += 1
+      sum += n
+    end.should be_nil
+    i.should eq(3)
+    sum.should eq(6)
   end
 
   it "gets downto iterator" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -370,7 +370,41 @@ describe IO do
           line.should eq("cc")
         end
         counter += 1
-      end
+      end.should be_nil
+      counter.should eq(3)
+    end
+
+    it "does each_char" do
+      io = SimpleIOMemory.new("あいう")
+      counter = 0
+      io.each_char do |c|
+        case counter
+        when 0
+          c.should eq('あ')
+        when 1
+          c.should eq('い')
+        when 2
+          c.should eq('う')
+        end
+        counter += 1
+      end.should be_nil
+      counter.should eq(3)
+    end
+
+    it "does each_byte" do
+      io = SimpleIOMemory.new("abc")
+      counter = 0
+      io.each_byte do |b|
+        case counter
+        when 0
+          b.should eq('a'.ord)
+        when 1
+          b.should eq('b'.ord)
+        when 2
+          b.should eq('c'.ord)
+        end
+        counter += 1
+      end.should be_nil
       counter.should eq(3)
     end
 

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -116,7 +116,7 @@ describe Iterator do
     it "yields the individual elements to the block" do
       iter = ["a", "b", "c"].each
       concatinated = ""
-      iter.each { |e| concatinated += e }
+      iter.each { |e| concatinated += e }.should be_nil
       concatinated.should eq "abc"
     end
   end

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -154,7 +154,7 @@ describe "NamedTuple" do
         value.should eq("hello")
       end
       i += 1
-    end
+    end.should be_nil
     i.should eq(2)
   end
 
@@ -169,7 +169,7 @@ describe "NamedTuple" do
         key.should eq(:b)
       end
       i += 1
-    end
+    end.should be_nil
     i.should eq(2)
   end
 
@@ -184,7 +184,7 @@ describe "NamedTuple" do
         value.should eq("hello")
       end
       i += 1
-    end
+    end.should be_nil
     i.should eq(2)
   end
 
@@ -203,7 +203,7 @@ describe "NamedTuple" do
         index.should eq(1)
       end
       i += 1
-    end
+    end.should be_nil
     i.should eq(2)
   end
 

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -295,6 +295,16 @@ describe "Set" do
     h1.should eq(h2)
   end
 
+  it "does each" do
+    set = Set{1, 2, 3}
+    i = 1
+    set.each do |v|
+      v.should eq(i)
+      i += 1
+    end.should be_nil
+    i.should eq(4)
+  end
+
   it "gets each iterator" do
     iter = Set{1, 2, 3}.each
     iter.next.should eq(1)

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1794,6 +1794,23 @@ describe "String" do
     sprintf("%12.2f %12.2f %6.2f %.2f" % {2.0, 3.0, 4.0, 5.0}).should eq("        2.00         3.00   4.00 5.00")
   end
 
+  it "does each_char" do
+    s = "abc"
+    i = 0
+    s.each_char do |c|
+      case i
+      when 0
+        c.should eq('a')
+      when 1
+        c.should eq('b')
+      when 2
+        c.should eq('c')
+      end
+      i += 1
+    end.should be_nil
+    i.should eq(3)
+  end
+
   it "gets each_char iterator" do
     iter = "abc".each_char
     iter.next.should eq('a')
@@ -1815,6 +1832,23 @@ describe "String" do
 
   it "cycles chars" do
     "abc".each_char.cycle.first(8).join.should eq("abcabcab")
+  end
+
+  it "does each_byte" do
+    s = "abc"
+    i = 0
+    s.each_byte do |b|
+      case i
+      when 0
+        b.should eq('a'.ord)
+      when 1
+        b.should eq('b'.ord)
+      when 2
+        b.should eq('c'.ord)
+      end
+      i += 1
+    end.should be_nil
+    i.should eq(3)
   end
 
   it "gets each_byte iterator" do
@@ -1854,7 +1888,7 @@ describe "String" do
     lines = [] of String
     "foo\n\nbar\r\nbaz\n".each_line do |line|
       lines << line
-    end
+    end.should be_nil
     lines.should eq(["foo", "", "bar", "baz"])
   end
 
@@ -1862,7 +1896,7 @@ describe "String" do
     lines = [] of String
     "foo\n\nbar\r\nbaz\r\n".each_line(chomp: false) do |line|
       lines << line
-    end
+    end.should be_nil
     lines.should eq(["foo\n", "\n", "bar\r\n", "baz\r\n"])
   end
 
@@ -1892,7 +1926,7 @@ describe "String" do
     codepoints = [] of Int32
     "ab☃".each_codepoint do |codepoint|
       codepoints << codepoint
-    end
+    end.should be_nil
     codepoints.should eq [97, 98, 9731]
   end
 

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -117,7 +117,7 @@ describe "Tuple" do
     a = 0
     {1, 2, 3}.each do |i|
       a += i
-    end
+    end.should be_nil
     a.should eq(6)
   end
 
@@ -205,7 +205,7 @@ describe "Tuple" do
     str = ""
     {"a", "b", "c"}.reverse_each do |i|
       str += i
-    end
+    end.should be_nil
     str.should eq("cba")
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -970,7 +970,7 @@ class Array(T)
   # the method will create a new array and reuse it. This can be
   # used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
-  def each_permutation(size : Int = self.size, reuse = false)
+  def each_permutation(size : Int = self.size, reuse = false) : Nil
     n = self.size
     return if size > n
 
@@ -1037,7 +1037,7 @@ class Array(T)
     ary
   end
 
-  def each_combination(size : Int = self.size, reuse = false)
+  def each_combination(size : Int = self.size, reuse = false) : Nil
     n = self.size
     return if size > n
     raise ArgumentError.new("size must be positive") if size < 0
@@ -1125,7 +1125,7 @@ class Array(T)
     ary
   end
 
-  def each_repeated_combination(size : Int = self.size, reuse = false)
+  def each_repeated_combination(size : Int = self.size, reuse = false) : Nil
     n = self.size
     return if size > n && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
@@ -1225,7 +1225,7 @@ class Array(T)
     ary
   end
 
-  def each_repeated_permutation(size : Int = self.size, reuse = false)
+  def each_repeated_permutation(size : Int = self.size, reuse = false) : Nil
     n = self.size
     return if size != 0 && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
@@ -1235,8 +1235,6 @@ class Array(T)
     else
       Array.each_product(Array.new(size, self), reuse: reuse) { |r| yield r }
     end
-
-    nil
   end
 
   # Removes the last value from `self`, at index *size - 1*.

--- a/src/array.cr
+++ b/src/array.cr
@@ -972,7 +972,7 @@ class Array(T)
   # interest is to be used in a read-only fashion.
   def each_permutation(size : Int = self.size, reuse = false)
     n = self.size
-    return self if size > n
+    return if size > n
 
     raise ArgumentError.new("size must be positive") if size < 0
 
@@ -1000,7 +1000,7 @@ class Array(T)
         i -= 1
       end
 
-      return self if stop
+      return if stop
     end
   end
 
@@ -1039,7 +1039,7 @@ class Array(T)
 
   def each_combination(size : Int = self.size, reuse = false)
     n = self.size
-    return self if size > n
+    return if size > n
     raise ArgumentError.new("size must be positive") if size < 0
 
     reuse = check_reuse(reuse, size)
@@ -1061,7 +1061,7 @@ class Array(T)
         i -= 1
       end
 
-      return self if stop
+      return if stop
 
       indices[i] += 1
       pool[i] = copy[indices[i]]
@@ -1127,7 +1127,7 @@ class Array(T)
 
   def each_repeated_combination(size : Int = self.size, reuse = false)
     n = self.size
-    return self if size > n && n == 0
+    return if size > n && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
 
     reuse = check_reuse(reuse, size)
@@ -1148,7 +1148,7 @@ class Array(T)
         end
         i -= 1
       end
-      return self if stop
+      return if stop
 
       ii = indices[i] + 1
       tmp = copy[ii]
@@ -1227,7 +1227,7 @@ class Array(T)
 
   def each_repeated_permutation(size : Int = self.size, reuse = false)
     n = self.size
-    return self if size != 0 && n == 0
+    return if size != 0 && n == 0
     raise ArgumentError.new("size must be positive") if size < 0
 
     if size == 0
@@ -1236,7 +1236,7 @@ class Array(T)
       Array.each_product(Array.new(size, self), reuse: reuse) { |r| yield r }
     end
 
-    self
+    nil
   end
 
   # Removes the last value from `self`, at index *size - 1*.

--- a/src/char.cr
+++ b/src/char.cr
@@ -712,6 +712,8 @@ struct Char
     else
       raise InvalidByteSequenceError.new("Invalid char value #{dump}")
     end
+
+    nil
   end
 
   # Returns the number of UTF-8 bytes in this char.

--- a/src/char.cr
+++ b/src/char.cr
@@ -687,7 +687,7 @@ struct Char
   # 129
   # 130
   # ```
-  def each_byte
+  def each_byte : Nil
     # See http://en.wikipedia.org/wiki/UTF-8#Sample_code
 
     c = ord
@@ -712,8 +712,6 @@ struct Char
     else
       raise InvalidByteSequenceError.new("Invalid char value #{dump}")
     end
-
-    nil
   end
 
   # Returns the number of UTF-8 bytes in this char.

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -147,7 +147,7 @@ struct Char
         @pos += @current_char_width
         decode_current_char
       end
-      self
+      nil
     end
 
     private def decode_char_at(pos)

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -141,13 +141,12 @@ struct Char
     # B
     # C
     # ```
-    def each
+    def each : Nil
       while has_next?
         yield current_char
         @pos += @current_char_width
         decode_current_char
       end
-      nil
     end
 
     private def decode_char_at(pos)

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -123,12 +123,14 @@ module Crystal
       all_types = [types.shift] of Type
 
       types.each do |t2|
-        not_found = all_types.each do |t1|
+        not_found = all_types.all? do |t1|
           ancestor = t1.common_ancestor(t2)
           if ancestor
             all_types.delete t1
             all_types << ancestor.virtual_type
-            break
+            false
+          else
+            true
           end
         end
         if not_found

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -574,7 +574,7 @@ module Crystal
 
     def transform(node : Asm)
       node.output = node.output.try &.transform(self)
-      node.inputs = node.inputs.try &.each &.transform(self)
+      node.inputs.try &.each &.transform(self)
       node
     end
 

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -188,11 +188,10 @@ class CSV
   end
 
   # Invokes the block once for each row in this CSV, yielding `self`.
-  def each
+  def each : Nil
     while self.next
       yield self
     end
-    nil
   end
 
   # Advanced the cursor to the next row. Must be called once to position

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -192,6 +192,7 @@ class CSV
     while self.next
       yield self
     end
+    nil
   end
 
   # Advanced the cursor to the next row. Must be called once to position

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -24,6 +24,7 @@ class CSV::Parser
     while row = next_row
       yield row
     end
+    nil
   end
 
   # Returns an `Iterator` of `Array(String)` for the remaining rows.

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -20,11 +20,10 @@ class CSV::Parser
   end
 
   # Yields each of the remaining rows as an `Array(String)`.
-  def each_row
+  def each_row : Nil
     while row = next_row
       yield row
     end
-    nil
   end
 
   # Returns an `Iterator` of `Array(String)` for the remaining rows.

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -270,6 +270,7 @@ class Deque(T)
         yield @buffer[i]
       end
     end
+    nil
   end
 
   # Insert a new item before the item at *index*. Items to the right of this one will have their indices incremented.

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -264,13 +264,12 @@ class Deque(T)
   # Yields each item in this deque, from first to last.
   #
   # Do not modify the deque while using this variant of `each`!
-  def each
+  def each : Nil
     halfs do |r|
       r.each do |i|
         yield @buffer[i]
       end
     end
-    nil
   end
 
   # Insert a new item before the item at *index*. Items to the right of this one will have their indices incremented.

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -56,11 +56,10 @@ class Dir
   # Got config.h
   # Got main.rb
   # ```
-  def each
+  def each : Nil
     while entry = read
       yield entry
     end
-    nil
   end
 
   def each

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -60,6 +60,7 @@ class Dir
     while entry = read
       yield entry
     end
+    nil
   end
 
   def each

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -290,13 +290,12 @@ class Hash(K, V)
   #   key_and_value # => {"foo", "bar"}
   # end
   # ```
-  def each
+  def each : Nil
     current = @first
     while current
       yield({current.key, current.value})
       current = current.fore
     end
-    nil
   end
 
   # Returns an iterator over the hash entries.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -296,7 +296,7 @@ class Hash(K, V)
       yield({current.key, current.value})
       current = current.fore
     end
-    self
+    nil
   end
 
   # Returns an iterator over the hash entries.

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -35,6 +35,8 @@ struct HTTP::Headers
 
         return false if byte1 != byte2
       end
+
+      true
     end
 
     private def normalize_byte(byte)

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -184,7 +184,7 @@ module Indexable(T)
       yield i
       i += 1
     end
-    self
+    nil
   end
 
   # Returns an `Iterator` for each index in `self`.
@@ -336,7 +336,7 @@ module Indexable(T)
     (size - 1).downto(0) do |i|
       yield unsafe_at(i)
     end
-    self
+    nil
   end
 
   # Returns an `Iterator` over the elements of `self` in reverse order.

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -178,13 +178,12 @@ module Indexable(T)
   # ```text
   # 0 -- 1 -- 2 --
   # ```
-  def each_index
+  def each_index : Nil
     i = 0
     while i < size
       yield i
       i += 1
     end
-    nil
   end
 
   # Returns an `Iterator` for each index in `self`.
@@ -332,11 +331,10 @@ module Indexable(T)
   end
 
   # Same as `#each`, but works in reverse.
-  def reverse_each(&block)
+  def reverse_each(&block) : Nil
     (size - 1).downto(0) do |i|
       yield unsafe_at(i)
     end
-    nil
   end
 
   # Returns an `Iterator` over the elements of `self` in reverse order.

--- a/src/int.cr
+++ b/src/int.cr
@@ -328,46 +328,43 @@ struct Int
     self - 1
   end
 
-  def times(&block : self ->)
+  def times(&block : self ->) : Nil
     i = self ^ self
     while i < self
       yield i
       i += 1
     end
-    self
   end
 
   def times
     TimesIterator(typeof(self)).new(self)
   end
 
-  def upto(n, &block : self ->)
+  def upto(n, &block : self ->) : Nil
     x = self
     while x <= n
       yield x
       x += 1
     end
-    self
   end
 
   def upto(n)
     UptoIterator(typeof(self), typeof(n)).new(self, n)
   end
 
-  def downto(n, &block : self ->)
+  def downto(n, &block : self ->) : Nil
     x = self
     while x >= n
       yield x
       x -= 1
     end
-    self
   end
 
   def downto(n)
     DowntoIterator(typeof(self), typeof(n)).new(self, n)
   end
 
-  def to(n, &block : self ->)
+  def to(n, &block : self ->) : Nil
     if self < n
       upto(n) { |i| yield i }
     elsif self > n
@@ -375,7 +372,6 @@ struct Int
     else
       yield self
     end
-    self
   end
 
   def to(n)

--- a/src/io.cr
+++ b/src/io.cr
@@ -831,11 +831,10 @@ module IO
   # olleh
   # dlrow
   # ```
-  def each_line(*args, **options)
+  def each_line(*args, **options) : Nil
     while line = gets(*args, **options)
       yield line
     end
-    nil
   end
 
   # Returns an `Iterator` for the *lines* in this IO, where a line
@@ -867,11 +866,10 @@ module IO
   # あ
   # め
   # ```
-  def each_char
+  def each_char : Nil
     while char = read_char
       yield char
     end
-    nil
   end
 
   # Returns an `Iterator` for the chars in this IO.
@@ -903,11 +901,10 @@ module IO
   # 129
   # 130
   # ```
-  def each_byte
+  def each_byte : Nil
     while byte = read_byte
       yield byte
     end
-    nil
   end
 
   # Returns an `Iterator` for the bytes in this IO.

--- a/src/io.cr
+++ b/src/io.cr
@@ -835,6 +835,7 @@ module IO
     while line = gets(*args, **options)
       yield line
     end
+    nil
   end
 
   # Returns an `Iterator` for the *lines* in this IO, where a line
@@ -870,6 +871,7 @@ module IO
     while char = read_char
       yield char
     end
+    nil
   end
 
   # Returns an `Iterator` for the chars in this IO.
@@ -905,6 +907,7 @@ module IO
     while byte = read_byte
       yield byte
     end
+    nil
   end
 
   # Returns an `Iterator` for the bytes in this IO.

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -383,6 +383,7 @@ module Iterator(T)
       break if value.is_a?(Stop)
       yield value
     end
+    nil
   end
 
   # Returns an iterator that then returns slices of n elements of the initial

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -377,13 +377,12 @@ module Iterator(T)
   # iter = ["a", "b", "c"].each
   # iter.each { |x| print x, " " } # Prints "a b c"
   # ```
-  def each
+  def each : Nil
     while true
       value = self.next
       break if value.is_a?(Stop)
       yield value
     end
-    nil
   end
 
   # Returns an iterator that then returns slices of n elements of the initial

--- a/src/llvm/function_collection.cr
+++ b/src/llvm/function_collection.cr
@@ -30,6 +30,6 @@ struct LLVM::FunctionCollection
       yield LLVM::Function.new f
       f = LibLLVM.get_next_function(f)
     end
-    self
+    nil
   end
 end

--- a/src/llvm/function_collection.cr
+++ b/src/llvm/function_collection.cr
@@ -24,12 +24,11 @@ struct LLVM::FunctionCollection
     func ? Function.new(func) : nil
   end
 
-  def each
+  def each : Nil
     f = LibLLVM.get_first_function(@mod)
     while f
       yield LLVM::Function.new f
       f = LibLLVM.get_next_function(f)
     end
-    nil
   end
 end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -285,7 +285,7 @@ struct NamedTuple
     {% for key in T %}
       yield {{key.symbolize}}, self[{{key.symbolize}}]
     {% end %}
-    self
+    nil
   end
 
   # Yields each key in this named tuple.
@@ -307,7 +307,7 @@ struct NamedTuple
     {% for key in T %}
       yield {{key.symbolize}}
     {% end %}
-    self
+    nil
   end
 
   # Yields each value in this named tuple.
@@ -329,7 +329,7 @@ struct NamedTuple
     {% for key in T %}
       yield self[{{key.symbolize}}]
     {% end %}
-    self
+    nil
   end
 
   # Yields each key and value, together with an index starting at *offset*, in this named tuple.
@@ -353,7 +353,7 @@ struct NamedTuple
       yield key, value, i
       i += 1
     end
-    self
+    nil
   end
 
   # Returns an `Array` populated with the results of each iteration in the given block,

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -281,11 +281,10 @@ struct NamedTuple
   # name = Crystal
   # year = 2011
   # ```
-  def each
+  def each : Nil
     {% for key in T %}
       yield {{key.symbolize}}, self[{{key.symbolize}}]
     {% end %}
-    nil
   end
 
   # Yields each key in this named tuple.
@@ -303,11 +302,10 @@ struct NamedTuple
   # name
   # year
   # ```
-  def each_key
+  def each_key : Nil
     {% for key in T %}
       yield {{key.symbolize}}
     {% end %}
-    nil
   end
 
   # Yields each value in this named tuple.
@@ -325,11 +323,10 @@ struct NamedTuple
   # Crystal
   # 2011
   # ```
-  def each_value
+  def each_value : Nil
     {% for key in T %}
       yield self[{{key.symbolize}}]
     {% end %}
-    nil
   end
 
   # Yields each key and value, together with an index starting at *offset*, in this named tuple.
@@ -353,7 +350,6 @@ struct NamedTuple
       yield key, value, i
       i += 1
     end
-    nil
   end
 
   # Returns an `Array` populated with the results of each iteration in the given block,

--- a/src/range.cr
+++ b/src/range.cr
@@ -97,14 +97,13 @@ struct Range(B, E)
   # (10..15).each { |n| print n, ' ' }
   # # prints: 10 11 12 13 14 15
   # ```
-  def each
+  def each : Nil
     current = @begin
     while current < @end
       yield current
       current = current.succ
     end
     yield current if !@exclusive && current == @end
-    nil
   end
 
   # Returns an `Iterator` over the elements of this range.
@@ -122,14 +121,13 @@ struct Range(B, E)
   # (10...15).reverse_each { |n| print n, ' ' }
   # # prints: 14 13 12 11 10
   # ```
-  def reverse_each
+  def reverse_each : Nil
     yield @end if !@exclusive && !(@end < @begin)
     current = @end
     while @begin < current
       current = current.pred
       yield current
     end
-    nil
   end
 
   # Returns a reverse `Iterator` over the elements of this range.

--- a/src/range.cr
+++ b/src/range.cr
@@ -104,7 +104,7 @@ struct Range(B, E)
       current = current.succ
     end
     yield current if !@exclusive && current == @end
-    self
+    nil
   end
 
   # Returns an `Iterator` over the elements of this range.
@@ -129,7 +129,7 @@ struct Range(B, E)
       current = current.pred
       yield current
     end
-    self
+    nil
   end
 
   # Returns a reverse `Iterator` over the elements of this range.

--- a/src/set.cr
+++ b/src/set.cr
@@ -144,7 +144,7 @@ struct Set(T)
     @hash.each_key do |key|
       yield key
     end
-    self
+    nil
   end
 
   # Returns an iterator for each element of the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -144,7 +144,6 @@ struct Set(T)
     @hash.each_key do |key|
       yield key
     end
-    nil
   end
 
   # Returns an iterator for each element of the set.

--- a/src/string.cr
+++ b/src/string.cr
@@ -2847,6 +2847,8 @@ class String
     unless offset == bytesize
       yield unsafe_byte_slice_string(offset)
     end
+
+    nil
   end
 
   # Returns an `Iterator` which yields each line of this string (see `String#each_line`).
@@ -3162,7 +3164,7 @@ class String
         yield char
       end
     end
-    self
+    nil
   end
 
   # Returns an iterator over each character in the string.
@@ -3191,7 +3193,7 @@ class String
       yield char, i
       i += 1
     end
-    self
+    nil
   end
 
   # Returns an array of all characters in the string.
@@ -3262,7 +3264,7 @@ class String
     to_unsafe.to_slice(bytesize).each do |byte|
       yield byte
     end
-    self
+    nil
   end
 
   # Returns an iterator over each byte in the string.

--- a/src/string.cr
+++ b/src/string.cr
@@ -2826,7 +2826,7 @@ class String
   # # => EVEN THE MONKEY SEEMS TO want
   # # => A LITTLE COAT OF STRAW
   # ```
-  def each_line(chomp = true)
+  def each_line(chomp = true) : Nil
     return if empty?
 
     offset = 0
@@ -2847,8 +2847,6 @@ class String
     unless offset == bytesize
       yield unsafe_byte_slice_string(offset)
     end
-
-    nil
   end
 
   # Returns an `Iterator` which yields each line of this string (see `String#each_line`).
@@ -3154,7 +3152,7 @@ class String
   #   char # => 'a', 'b', '☃'
   # end
   # ```
-  def each_char
+  def each_char : Nil
     if ascii_only?
       each_byte do |byte|
         yield byte.unsafe_chr
@@ -3164,7 +3162,6 @@ class String
         yield char
       end
     end
-    nil
   end
 
   # Returns an iterator over each character in the string.
@@ -3193,7 +3190,6 @@ class String
       yield char, i
       i += 1
     end
-    nil
   end
 
   # Returns an array of all characters in the string.

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -200,7 +200,7 @@ struct Tuple
     {% for i in 0...T.size %}
       yield self[{{i}}]
     {% end %}
-    self
+    nil
   end
 
   # Returns `true` if this tuple has the same size as the other tuple
@@ -447,7 +447,7 @@ struct Tuple
     {% for i in 1..T.size %}
       yield self[{{T.size - i}}]
     {% end %}
-    self
+    nil
   end
 
   # Returns the first element of this tuple. Doesn't compile

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -196,11 +196,10 @@ struct Tuple
   # "hello"
   # 'x'
   # ```
-  def each
+  def each : Nil
     {% for i in 0...T.size %}
       yield self[{{i}}]
     {% end %}
-    nil
   end
 
   # Returns `true` if this tuple has the same size as the other tuple

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -37,7 +37,7 @@ struct XML::Attributes
     find { |node| node.name == name }
   end
 
-  def each
+  def each : Nil
     return unless @node.element?
 
     props = self.props
@@ -45,8 +45,6 @@ struct XML::Attributes
       yield Node.new(props)
       props = props.value.next
     end
-
-    nil
   end
 
   def to_s(io)

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -45,6 +45,8 @@ struct XML::Attributes
       yield Node.new(props)
       props = props.value.next
     end
+
+    nil
   end
 
   def to_s(io)

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -18,11 +18,10 @@ struct XML::NodeSet
     internal_at(index)
   end
 
-  def each
+  def each : Nil
     size.times do |i|
       yield internal_at(i)
     end
-    nil
   end
 
   def empty?

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -22,6 +22,7 @@ struct XML::NodeSet
     size.times do |i|
       yield internal_at(i)
     end
+    nil
   end
 
   def empty?


### PR DESCRIPTION
Related pull request: #3815 

In fact, I fixed only two ([1](https://github.com/MakeNowJust/crystal/blob/fix/each-return-nil/src/compiler/crystal/semantic/type_merge.cr#L126) and [2](https://github.com/MakeNowJust/crystal/blob/fix/each-return-nil/src/compiler/crystal/syntax/transformer.cr#L577)) by this change. This change has no effect for codes in many case.