### PR TITLE
Add Clock.monotonic for measuring elapsed time

### DIFF
--- a/spec/std/clock_spec.cr
+++ b/spec/std/clock_spec.cr
@@ -1,0 +1,49 @@
+require "spec"
+require "clock"
+
+describe Clock do
+  it "returns monotonic clock" do
+    Clock.monotonic.should be_a(Clock)
+  end
+
+  it "measures block duration" do
+    span = Clock.duration { sleep(0.001) }
+    span.to_f.should be_close(0.001, delta: 0.002)
+  end
+
+  it "returns clock value" do
+    Clock.monotonic.to_f.should be_close(Clock.monotonic.to_f, delta: 0.1)
+  end
+
+  it "substracts" do
+    (Clock.new(1234_i64, 500_000_000) - Clock.new(1234_i64, 0)).to_f.should be_close(0.5, 0.001)
+    (Clock.new(1234_i64, 500_000_000) - 1234.seconds).to_f.should be_close(0.5, 0.001)
+    (Clock.new(1234_i64, 500_000_000) - 1234.0).to_f.should be_close(0.5, 0.001)
+  end
+
+  it "compares" do
+    (Clock.new(2_i64, 0) <=> Clock.new(1_i64, 0)).should eq(1)
+    (Clock.new(1_i64, 500_000_000) <=> Clock.new(1_i64, 500_000_000)).should eq(0)
+    (Clock.new(1_i64, 0) <=> Clock.new(2_i64, 0)).should eq(-1)
+
+    (Clock.new(2_i64, 0) <=> 1.seconds).should eq(1)
+    (Clock.new(1_i64, 500_000_000) <=> 1.5.seconds).should eq(0)
+    (Clock.new(1_i64, 0) <=> 2.seconds).should eq(-1)
+
+    (Clock.new(2_i64, 0) <=> 1).should eq(1)
+    (Clock.new(1_i64, 500_000_000) <=> 1.5).should eq(0)
+    (Clock.new(1_i64, 0) <=> 2).should eq(-1)
+  end
+
+  it "elapsed?" do
+    clock = Clock.monotonic
+
+    # disabled: randomly fails
+    # clock.elapsed?(0.seconds).should be_true
+
+    clock.elapsed?(5.seconds).should be_false
+    clock.elapsed?(5.0).should be_false
+    sleep 0.01
+    clock.elapsed?(0.001).should be_true
+  end
+end

--- a/src/clock.cr
+++ b/src/clock.cr
@@ -1,0 +1,121 @@
+require "crystal/system/time"
+
+# Monotonic Clock.
+#
+# A monotonic clock is tied to the system and isn't affected by time
+# fluctuations, for example leap seconds or manually changing the computer's
+# time.
+#
+# Compared to `Time`, a `Clock` value isn't interesting and most likely means
+# nothing, but its value is guaranteed to be linearily increasing from a fixed
+# point in time (whose origin is unspecified), thus useful to calculate the
+# elapsed time between two clocks.
+#
+# Example:
+#
+# ```
+# timeout = 5.seconds
+# clock = Clock.monotonic
+#
+# until clock.elapsed?(timeout)
+#   do_domething
+# end
+# ```
+struct Clock
+  include Comparable(self)
+  include Comparable(Time::Span)
+  include Comparable(Float64 | Float32)
+
+  protected getter seconds : Int64
+  protected getter nanoseconds : Int32
+
+  # Creates a `Clock` from the system monotonic clock, which is guaranteed to be
+  # always increasing as linearly as possible.
+  def self.monotonic : self
+    seconds, nanoseconds = Crystal::System::Time.monotonic
+    new(seconds, nanoseconds)
+  end
+
+  # Measures how long the block takes to run.
+  #
+  # ```
+  # seconds = Clock.duration { sleep(1.234) }
+  # seconds # => close to 1.234
+  # ```
+  def self.duration : Time::Span
+    start = monotonic
+    yield
+    monotonic - start
+  end
+
+  protected def initialize(@seconds, @nanoseconds)
+  end
+
+  def -(other : Time::Span)
+    seconds = @seconds - other.to_i
+    nanoseconds = @nanoseconds - other.nanoseconds
+    Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
+  end
+
+  def -(other : self)
+    seconds = @seconds - other.seconds
+    nanoseconds = @nanoseconds - other.nanoseconds
+    Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
+  end
+
+  def -(other : Float | Int)
+    self - other.seconds
+  end
+
+  def <=>(other : Time::Span)
+    cmp = @seconds <=> other.seconds
+    cmp = @nanoseconds <=> other.nanoseconds if cmp == 0
+    cmp
+  end
+
+  def <=>(other : self)
+    cmp = @seconds <=> other.seconds
+    cmp = @nanoseconds <=> other.nanoseconds if cmp == 0
+    cmp
+  end
+
+  def <=>(other : Float | Int)
+    self <=> other.seconds
+  end
+
+  # Returns true once *span* time has passed since the clock was created.
+  #
+  # ```
+  # clock = Clock.monotonic
+  #
+  # until clock.elapsed?(5.seconds)
+  #   do_domething
+  # end
+  # ```
+  def elapsed?(span : Time::Span)
+    (Clock.monotonic - self) >= span
+  end
+
+  # Returns true once *span* seconds have passed since the clock was created.
+  def elapsed?(span : Float | Int)
+    elapsed?(span.seconds)
+  end
+
+  def to_f
+    @seconds + @nanoseconds.to_f / 1_000_000_000
+  end
+
+  def inspect(io : IO)
+    @seconds.to_s(io)
+    io << '.'
+    io << '0' if @nanoseconds < 100_000_000
+    io << '0' if @nanoseconds < 10_000_000
+    io << '0' if @nanoseconds < 1_000_000
+    io << '0' if @nanoseconds < 100_000
+    io << '0' if @nanoseconds < 10_000
+    io << '0' if @nanoseconds < 1_000
+    io << '0' if @nanoseconds < 100
+    io << '0' if @nanoseconds < 10
+    @nanoseconds.to_s(io)
+  end
+end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -1,6 +1,15 @@
 require "c/sys/time"
 require "c/time"
 
+{% if flag?(:darwin) %}
+  # Darwin supports clock_gettime starting from macOS Sierra, but we can't
+  # use it because it would prevent running binaries built on macOS Sierra
+  # to run on older macOS releases.
+  #
+  # Furthermore, mach_absolute_time is reported to have a higher precision.
+  require "c/mach/mach_time"
+{% end %}
+
 module Crystal::System::Time
   UnixEpochInSeconds = 62135596800_i64
 
@@ -37,4 +46,28 @@ module Crystal::System::Time
       {timeval.tv_sec.to_i64 + UnixEpochInSeconds, timeval.tv_usec.to_i * 1_000}
     {% end %}
   end
+
+  def self.monotonic
+    {% if flag?(:darwin) %}
+      info = mach_timebase_info
+      nanoseconds = LibC.mach_absolute_time.to_i64 * info.numer / info.denom
+      {nanoseconds / 1_000_000_000, nanoseconds.remainder(1_000_000_000).to_i32}
+    {% else %}
+      if LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp) == 1
+        raise Errno.new("clock_gettime(CLOCK_MONOTONIC)")
+      end
+      {tp.tv_sec.to_i64, tp.tv_nsec.to_i32}
+    {% end %}
+  end
+
+  {% if flag?(:darwin) %}
+    @@mach_timebase_info : LibC::MachTimebaseInfo?
+
+    private def self.mach_timebase_info
+      @@mach_timebase_info ||= begin
+        LibC.mach_timebase_info(out info)
+        info
+      end
+    end
+  {% end %}
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/mach/mach_time.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/mach/mach_time.cr
@@ -1,0 +1,9 @@
+lib LibC
+  struct MachTimebaseInfo
+    numer : UInt32
+    denom : UInt32
+  end
+
+  fun mach_timebase_info(info : MachTimebaseInfo*) : LibC::Int
+  fun mach_absolute_time : UInt64
+end

--- a/src/time.cr
+++ b/src/time.cr
@@ -51,6 +51,12 @@ require "crystal/system/time"
 # span       # => 01:00:00
 # span.class # => Time::Span
 # span.hours # => 1
+#
+# ### Realtime clock
+#
+# `Time` uses a realtime clock, and is thus affected by time fluctuations (e.g.
+# leap seconds or manually changing the system clock). For a monotonic clock and
+# measuring durations, you should refer to `Clock` instead.
 # ```
 struct Time
   include Comparable(self)


### PR DESCRIPTION
`Time` uses a realtime clock which is subject to jumps and fluctuations over time (e.g. leap seconds, manually changing computer's time) which is a [source of bugs](https://en.wikipedia.org/wiki/Leap_second#Examples_of_problems_associated_with_the_leap_second) when measuring elapsed time.

A monotonic clock, in comparison, doesn't mean anything by itself but is guaranteed to be linearly increasing, thus useful to measure time duration more correctly. It's not perfect, since it's still affected by NTP adjustments (at least on Linux) but still better than realtime.

I propose here a new `Clock` type to mark the difference from `Time`, with sugar `elapsed?` and `duration(&block)` methods.

Achieve work for a given duration:
```crystal
clock = Clock.monotonic

until clock.elapsed?(5.seconds)
  do_something
end
```

Measuring how long a block takes to run:
```crystal
span = Clock.duration { sleep(5.1234) } # => Time::Span
span.to_f # roughly 5.1234
```

The clock precision is platform specific, yet all calculations are achieved through `Time::Span` which has a 10th of millisecond precision.