### PR TITLE
Add Enum.each and Enum#each

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -63,6 +63,31 @@ describe Enum do
     (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::Three).should be_false
   end
 
+  describe "each" do
+    it "won't yield None" do
+      SpecEnumFlags::None.each do |name|
+        raise "unexpected yield"
+      end
+    end
+
+    it "won't yield All" do
+      SpecEnumFlags::All.each do |name|
+        raise "unexpected yield" if name == SpecEnumFlags::All
+      end
+    end
+
+    it "yields each member" do
+      names = [] of SpecEnumFlags
+      values = [] of Int32
+      SpecEnumFlags.flags(One, Three).each do |name, value|
+        names << name
+        values << value
+      end
+      names.should eq([SpecEnumFlags::One, SpecEnumFlags::Three])
+      values.should eq([SpecEnumFlags::One.value, SpecEnumFlags::Three.value])
+    end
+  end
+
   describe "names" do
     it "for simple enum" do
       SpecEnum.names.should eq(%w(One Two Three))

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -170,4 +170,32 @@ describe Enum do
   it "clones" do
     SpecEnum::One.clone.should eq(SpecEnum::One)
   end
+
+  describe "each" do
+    it "iterates each member" do
+      keys = [] of SpecEnum
+      values = [] of Int8
+
+      SpecEnum.each do |key, value|
+        keys << key
+        values << value
+      end
+
+      keys.should eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
+      values.should eq([SpecEnum::One.value, SpecEnum::Two.value, SpecEnum::Three.value])
+    end
+
+    it "iterates each flag" do
+      keys = [] of SpecEnumFlags
+      values = [] of Int32
+
+      SpecEnumFlags.each do |key, value|
+        keys << key
+        values << value
+      end
+
+      keys.should eq([SpecEnumFlags::One, SpecEnumFlags::Two, SpecEnumFlags::Three])
+      values.should eq([SpecEnumFlags::One.value, SpecEnumFlags::Two.value, SpecEnumFlags::Three.value])
+    end
+  end
 end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -426,9 +426,21 @@ struct Enum
       {{ @type }}::{{ value }}{% end %}\
   end
 
-  # def self.each
-  #   to_h.each do |key, value|
-  #     yield key, value
-  #   end
+  # Iterates each member of the enum. It won't iterate the None and All members
+  # of flags enums.
+  #
+  # ```
+  # IOMode.each do |member, value|
+  #   # yield IOMode::Read, 1
+  #   # yield IOMode::Write, 2
+  #   # yield IOMode::Async, 3
   # end
+  # ```
+  def self.each
+    {% for member in @type.constants %}
+      {% unless @type.has_attribute?("Flags") && %w(none all).includes?(member.stringify.downcase) %}
+        yield {{@type}}::{{member}}, {{@type}}::{{member}}.value
+      {% end %}
+    {% end %}
+  end
 end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -276,6 +276,29 @@ struct Enum
     value.hash
   end
 
+  # Iterates each values in a Flags Enum.
+  #
+  # ```
+  # (IOMode::Read | IOMode::Async).each do |member, value|
+  #   # yield IOMode::Read, 1
+  #   # yield IOMode::Async, 3
+  # end
+  # ```
+  def each
+    {% if @type.has_attribute?("Flags") %}
+      return if value == 0
+      {% for member in @type.constants %}
+        {% if member.stringify != "All" %}
+          if includes?({{@type}}::{{member}})
+            yield {{@type}}::{{member}}, {{@type}}::{{member}}.value
+          end
+        {% end %}
+      {% end %}
+    {% else %}
+      {% raise "Can't iterate #{@type}: only Flags Enum can be iterated" %}
+    {% end %}
+  end
+
   # Returns all enum members as an `Array(String)`.
   #
   # ```


### PR DESCRIPTION
Add `Enum.each` to iterate the enum constants (and values) as well as `Enum#each` to iterate flags included in the enum value.

Examples:

```crystal
enum MyEnum
  One
  Two
end

@[Flags]
enum MyFlags
  One
  Two
  Three
end

MyEnum.each do |member, value|
  # yield One, 0
  # yield Two, 1
end

# note that `None` and `All` aren't iterated
MyFlags.each do |member, value|
  # yield One, 1
  # yield Two, 2
  # yield Three, 3
end

(MyFlags::One | MyFlags::Three).each do |member, value|
  # yield One, 1
  # yield Three, 3
end
```