### PR TITLE
Always generate line numbers debug information

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -13,7 +13,7 @@ describe "Code gen: debug" do
       end
 
       x = Foo.new || Bar.new
-      ), debug: true)
+      ), debug: Crystal::Debug::All)
   end
 
   it "inlines instance var access through getter in debug mode" do
@@ -45,6 +45,6 @@ describe "Code gen: debug" do
       foo = Foo.new
       foo.set
       foo.bar.x
-      ), debug: true, filename: "foo.cr").to_i.should eq(2)
+      ), debug: Crystal::Debug::All, filename: "foo.cr").to_i.should eq(2)
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -275,7 +275,7 @@ def parse(string, wants_doc = false)
   parser.parse
 end
 
-def codegen(code, inject_primitives = true, debug = false)
+def codegen(code, inject_primitives = true, debug = Crystal::Debug::None)
   code = inject_primitives(code) if inject_primitives
   node = parse code
   result = semantic node
@@ -299,7 +299,7 @@ class Crystal::SpecRunOutput
   end
 end
 
-def run(code, filename = nil, inject_primitives = true, debug = false)
+def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None)
   code = inject_primitives(code) if inject_primitives
 
   # Code that requires the prelude doesn't run in LLVM's MCJIT

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -452,7 +452,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_call_or_invoke(node, target_def, self_type, func, call_args, raises, type, is_closure = false, fun_type = nil)
-    set_current_debug_location node if @debug
+    set_current_debug_location node if @debug.line_numbers?
 
     if raises && (rescue_block = @rescue_block)
       invoke_out_block = new_block "invoke_out"

--- a/src/compiler/crystal/codegen/exception.cr
+++ b/src/compiler/crystal/codegen/exception.cr
@@ -134,7 +134,7 @@ class Crystal::CodeGenVisitor
             if a_rescue_name = a_rescue.name
               context.vars = context.vars.dup
               get_exception_fun = main_fun(GET_EXCEPTION_NAME)
-              set_current_debug_location node if @debug
+              set_current_debug_location node if @debug.line_numbers?
               exception_ptr = call get_exception_fun, [bit_cast(unwind_ex_obj, get_exception_fun.params.first.type)]
               exception = int2ptr exception_ptr, LLVMTyper::TYPE_ID_POINTER
               unless a_rescue.type.virtual?

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -65,7 +65,7 @@ class Crystal::CodeGenVisitor
 
       needs_body = !target_def.is_a?(External) || is_exported_fun
       if needs_body
-        emit_def_debug_metadata target_def if @debug
+        emit_def_debug_metadata target_def unless @debug.none?
 
         context.fun.add_attribute LLVM::Attribute::UWTable
         if @program.has_flag?("darwin")
@@ -77,7 +77,7 @@ class Crystal::CodeGenVisitor
         new_entry_block
 
         if is_closure
-          clear_current_debug_location if @debug
+          clear_current_debug_location if @debug.line_numbers?
           setup_closure_vars context.closure_vars.not_nil!
         else
           context.reset_closure
@@ -95,12 +95,12 @@ class Crystal::CodeGenVisitor
           context.closure_parent_context = closure_parent_context
         end
 
-        set_current_debug_location target_def if @debug
+        set_current_debug_location target_def if @debug.line_numbers?
         alloca_vars target_def.vars, target_def, args, context.closure_parent_context
 
         create_local_copy_of_fun_args(target_def, self_type, args, is_fun_literal, is_closure)
 
-        if @debug
+        if @debug.variables?
           in_alloca_block do
             args_offset = !is_fun_literal && self_type.passed_as_self? ? 2 : 1
             location = target_def.location
@@ -121,7 +121,9 @@ class Crystal::CodeGenVisitor
 
         accept target_def.body
 
-        set_current_debug_location target_def.end_location if @debug
+        if @debug.line_numbers?
+          set_current_debug_location target_def.end_location
+        end
 
         codegen_return(target_def)
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -281,8 +281,11 @@ class Crystal::Command
             compiler.cross_compile = true
           end
         end
-        opts.on("-d", "--debug", "Add symbolic debug info") do
-          compiler.debug = true
+        opts.on("-d", "--debug", "Add full symbolic debug info") do
+          compiler.debug = Crystal::Debug::All
+        end
+        opts.on("", "--no-debug", "Skip any symbolic debug info") do
+          compiler.debug = Crystal::Debug::None
         end
       end
 
@@ -443,8 +446,11 @@ class Crystal::Command
   end
 
   private def setup_simple_compiler_options(compiler, opts)
-    opts.on("-d", "--debug", "Add symbolic debug info") do
-      compiler.debug = true
+    opts.on("-d", "--debug", "Add full symbolic debug info") do
+      compiler.debug = Crystal::Debug::All
+    end
+    opts.on("", "--no-debug", "Skip any symbolic debug info") do
+      compiler.debug = Crystal::Debug::None
     end
     opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
       compiler.flags << flag

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -5,6 +5,13 @@ require "colorize"
 require "crypto/md5"
 
 module Crystal
+  @[Flags]
+  enum Debug
+    LineNumbers
+    Variables
+    Default     = LineNumbers
+  end
+
   # Main interface to the compiler.
   #
   # A Compiler parses source code, type checks it and
@@ -35,7 +42,7 @@ module Crystal
 
     # If `true`, the executable will be generated with debug code
     # that can be understood by `gdb` and `lldb`.
-    property? debug = false
+    property debug = Debug::Default
 
     # If `true`, `.ll` files will be generated in the default cache
     # directory for each generated LLVM module.
@@ -153,7 +160,7 @@ module Crystal
       program.cache_dir = CacheDir.instance.directory_for(sources)
       program.target_machine = target_machine
       program.flags << "release" if release?
-      program.flags << "debug" if debug?
+      program.flags << "debug" unless debug.none?
       program.flags.merge! @flags
       program.wants_doc = wants_doc?
       program.color = color?
@@ -209,7 +216,7 @@ module Crystal
       @link_flags = "#{@link_flags} -rdynamic"
 
       llvm_modules = Crystal.timing("Codegen (crystal)", @stats) do
-        program.codegen node, debug: @debug, single_module: @single_module || @release || @cross_compile || @emit, expose_crystal_main: false
+        program.codegen node, debug: debug, single_module: @single_module || @release || @cross_compile || @emit, expose_crystal_main: false
       end
 
       if @cross_compile


### PR DESCRIPTION
Adds a `Crystal::Debug` flags enum to select the kinds of debug information to generate, and alters the build flags:

- default: only generate line numbers debug info (including function names);
- `--debug`: generate all debug info;
- `--no-debug`: don't generate any debug info.

For example, when compiling the crystal compiler, I see a 12% file increase for line numbers vs 45% for the full debug info (compile units, variables, ...)

- default: 26MB
- `--debug`: 34MB
- `--no-debug`: 23MB