### PR TITLE
Adds favicon to generated docs.

### DIFF
--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta id="repository-name" content="<%= repository_name %>">
   <link href="css/style.css" rel="stylesheet" type="text/css" />
+  <link href='/images/favico.png' rel='icon' type='image/png'>
+  <link href='/images/favico.ico' rel='shortcut icon' type='image/x-icon'>
   <script type="text/javascript" src="js/doc.js"></script>
   <title>README - <%= repository_name %></title>
 </head>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta id="repository-name" content="<%= type.repository_name %>">
   <link href="<%= type.path_to "css/style.css" %>" rel="stylesheet" type="text/css" />
+  <link href='/images/favico.png' rel='icon' type='image/png'>
+  <link href='/images/favico.ico' rel='shortcut icon' type='image/x-icon'>
   <script type="text/javascript" src="<%= type.path_to "js/doc.js" %>"></script>
   <title><%= type.full_name %> - <%= type.repository_name %></title>
 </head>


### PR DESCRIPTION
When I have a bunch of tabs open and I am trying to find docs pages it is hard
because there is no visible favicon.

This commit adds <link> elements to the <head> of the two docs HTML templates.
It uses the the main site favicon which, when generated and hosted at
crystal-lang.org, is located at the absolute path /images/favico.{ico,png}.