### PR TITLE
Restrict argument types having a default value

### DIFF
--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -33,8 +33,8 @@ describe "Normalize: def" do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x); y = 1; z = 2i64; x + y + z; end").as(Def)
-    expected.body.as(Expressions).expressions.insert 1, TypeRestrict.new Var.new("y"), Path.new(["Int32"])
-    expected.body.as(Expressions).expressions.insert 3, TypeRestrict.new Var.new("z"), Path.new(["Int64"])
+    expected.body.as(Expressions).expressions.insert 1, TypeRestriction.new Var.new("y"), Path.new(["Int32"])
+    expected.body.as(Expressions).expressions.insert 3, TypeRestriction.new Var.new("z"), Path.new(["Int64"])
     actual.should eq(expected)
   end
 
@@ -42,7 +42,7 @@ describe "Normalize: def" do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
     expected = parse("def foo(x, y : Int32); z = 2i64; x + y + z; end").as(Def)
-    expected.body.as(Expressions).expressions.insert 1, TypeRestrict.new Var.new("z"), Path.new(["Int64"])
+    expected.body.as(Expressions).expressions.insert 1, TypeRestriction.new Var.new("z"), Path.new(["Int64"])
     actual.should eq(expected)
   end
 

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -30,16 +30,19 @@ describe "Normalize: def" do
   end
 
   it "expands a def on request with default arguments and type restrictions" do
-    a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2); x + y + z; end").as(Def)
+    a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
-    expected = parse("def foo(x); y = 1; z = 2; x + y + z; end")
+    expected = parse("def foo(x); y = 1; z = 2i64; x + y + z; end").as(Def)
+    expected.body.as(Expressions).expressions.insert 1, TypeRestrict.new Var.new("y"), Path.new(["Int32"])
+    expected.body.as(Expressions).expressions.insert 3, TypeRestrict.new Var.new("z"), Path.new(["Int64"])
     actual.should eq(expected)
   end
 
   it "expands a def on request with default arguments and type restrictions (2)" do
-    a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2); x + y + z; end").as(Def)
+    a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
-    expected = parse("def foo(x, y : Int32); z = 2; x + y + z; end")
+    expected = parse("def foo(x, y : Int32); z = 2i64; x + y + z; end").as(Def)
+    expected.body.as(Expressions).expressions.insert 1, TypeRestrict.new Var.new("z"), Path.new(["Int64"])
     actual.should eq(expected)
   end
 

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -171,6 +171,16 @@ describe "Semantic: def" do
       "undefined method"
   end
 
+  it "errors when type restriction is incompatible with default value" do
+    assert_error "
+      def foo(x : Int64 = 1)
+      end
+
+      foo
+      ",
+      "can't restrict Int32 to Int64"
+  end
+
   it "types call with global scope" do
     assert_type("
       def bar

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -423,6 +423,26 @@ describe "Semantic: def" do
       )) { int32.metaclass }
   end
 
+  it "uses free variable with metaclass" do
+    assert_type(%(
+      def foo(x : Free.class) forall Free
+        Free
+      end
+
+      foo(Int32)
+      )) { int32.metaclass }
+  end
+
+  it "uses free variable with metaclass and default value" do
+    assert_type(%(
+      def foo(x : Free.class = Int32) forall Free
+        Free
+      end
+
+      foo
+      )) { int32.metaclass }
+  end
+
   it "uses free variable as block return type" do
     assert_type(%(
       def foo(&block : -> Free) forall Free

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -171,7 +171,7 @@ describe "Semantic: def" do
       "undefined method"
   end
 
-  it "errors when type restriction is incompatible with default value" do
+  it "errors when default value is incompatible with type restriction" do
     assert_error "
       def foo(x : Int64 = 1)
       end

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -775,6 +775,18 @@ describe "Semantic: macro" do
       )) { int32.metaclass }
   end
 
+  it "finds free type vars" do
+    assert_type(%(
+      module Foo(T)
+        def self.foo(foo : U) forall U
+          { {{ T }}, {{ U }} }
+        end
+      end
+
+      Foo(Int32).foo("foo")
+    )) { tuple_of([int32.metaclass, string.metaclass]) }
+  end
+
   it "gets named arguments in double splat" do
     assert_type(%(
       macro foo(**options)

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -81,17 +81,17 @@ module Crystal
   #
   # It is used for type restrection of method arguments.
   class TypeRestriction < ASTNode
-    getter value
-    getter restriction
+    getter obj
+    getter to
 
-    def initialize(@value : ASTNode, @restriction : ASTNode)
+    def initialize(@obj : ASTNode, @to : ASTNode)
     end
 
     def clone_without_location
-      TypeRestriction.new @value.clone, @restriction.clone
+      TypeRestriction.new @obj.clone, @to.clone
     end
 
-    def_equals_and_hash value, restriction
+    def_equals_and_hash obj, to
   end
 
   class Arg

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -80,7 +80,7 @@ module Crystal
   # Fictitious node to represent a type restriction
   #
   # It is used for type restrection of method arguments.
-  class TypeRestrict < ASTNode
+  class TypeRestriction < ASTNode
     getter value
     getter restriction
 
@@ -88,7 +88,7 @@ module Crystal
     end
 
     def clone_without_location
-      TypeRestrict.new @value.clone, @restriction.clone
+      TypeRestriction.new @value.clone, @restriction.clone
     end
 
     def_equals_and_hash value, restriction

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -77,6 +77,23 @@ module Crystal
     def_equals_and_hash type
   end
 
+  # Fictitious node to represent a type restriction
+  #
+  # It is used for type restrection of method arguments.
+  class TypeRestrict < ASTNode
+    getter value
+    getter restriction
+
+    def initialize(@value : ASTNode, @restriction : ASTNode)
+    end
+
+    def clone_without_location
+      TypeRestrict.new @value.clone, @restriction.clone
+    end
+
+    def_equals_and_hash value, restriction
+  end
+
   class Arg
     def initialize(@name : String, @default_value : ASTNode? = nil, @restriction : ASTNode? = nil, external_name : String? = nil, @type : Type? = nil)
       @external_name = external_name || @name

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -362,7 +362,7 @@ class Crystal::Call
           bubbling_exception do
             visitor = MainVisitor.new(program, typed_def_args, typed_def)
             visitor.yield_vars = yield_vars
-            visitor.free_vars = match.context.free_vars
+            visitor.match_context = match.context
             visitor.untyped_def = match.def
             visitor.call = self
             visitor.scope = lookup_self_type

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -124,14 +124,8 @@ class Crystal::Def
           else
             new_body << Assign.new(Var.new(arg.name), default_value)
 
-            # If the restriction is a free var it will be lost in the replacement, so we save the default value in
-            # a temporary variable (tmp_var) and then replace all ocurrences of that free var with typeof(tmp_var)
-            # to achieve the same effect, since we can't define a type alias inside a method.
-            restriction = arg.restriction
-            if restriction.is_a?(Path) && restriction.names.size == 1 && free_vars.try(&.includes?(restriction.names.first))
-              restriction_name = program.new_temp_var_name
-              new_body << Assign.new(Var.new(restriction_name), Var.new(arg.name))
-              body = body.transform(ReplaceFreeVarTransformer.new(restriction.names.first, restriction_name))
+            if restriction = arg.restriction
+              new_body << TypeRestrict.new(Var.new(arg.name), restriction).at(arg)
             end
           end
         end
@@ -202,24 +196,5 @@ class Crystal::Def
     end
 
     expansion
-  end
-
-  class ReplaceFreeVarTransformer < Transformer
-    def initialize(@free_var_name : String, @replacement_name : String)
-    end
-
-    def transform(node : Generic)
-      # Don't transform the name, because it must always be a Path
-      transform_many node.type_vars
-      node
-    end
-
-    def transform(node : Path)
-      if !node.global? && node.names.size == 1 && node.names.first == @free_var_name
-        TypeOf.new([Var.new(@replacement_name)] of ASTNode)
-      else
-        node
-      end
-    end
   end
 end

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -125,7 +125,7 @@ class Crystal::Def
             new_body << Assign.new(Var.new(arg.name), default_value)
 
             if restriction = arg.restriction
-              new_body << TypeRestrict.new(Var.new(arg.name), restriction).at(arg)
+              new_body << TypeRestriction.new(Var.new(arg.name), restriction).at(arg)
             end
           end
         end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2835,19 +2835,19 @@ module Crystal
     end
 
     def visit(node : TypeRestriction)
-      value = node.value
-      restriction = node.restriction
+      obj = node.obj
+      to = node.to
 
-      value.accept self
+      obj.accept self
 
       unless context = match_context
         node.raise "BUG: there is no match context"
       end
 
-      if type = value.type.restrict(restriction, context)
+      if type = obj.type.restrict(to, context)
         node.type = type
       else
-        node.raise "can't restrict #{value.type} to #{restriction}"
+        node.raise "can't restrict #{obj.type} to #{to}"
       end
 
       false

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2834,7 +2834,7 @@ module Crystal
       false
     end
 
-    def visit(node : TypeRestrict)
+    def visit(node : TypeRestriction)
       value = node.value
       restriction = node.restriction
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -50,9 +50,7 @@ module Crystal
     property block_nest = 0
     property with_scope : Type?
 
-    # These are the free variables that came from matches. We look up
-    # here first if we find a single-element Path like `T`.
-    property free_vars
+    property match_context : MatchContext?
 
     # These are the variables and types that come from a block specification
     # like `&block : Int32 -> Int32`. When doing `yield 1` we need to verify
@@ -146,7 +144,7 @@ module Crystal
     end
 
     def visit(node : Path)
-      type = (@path_lookup || @scope || @current_type).lookup_type_var(node, free_vars: @free_vars)
+      type = (@path_lookup || @scope || @current_type).lookup_type_var(node, free_vars: free_vars)
       case type
       when Const
         if !type.value.type? && !type.visited?
@@ -978,7 +976,7 @@ module Crystal
 
       block_visitor = MainVisitor.new(program, before_block_vars, @typed_def, meta_vars)
       block_visitor.yield_vars = @yield_vars
-      block_visitor.free_vars = @free_vars
+      block_visitor.match_context = @match_context
       block_visitor.untyped_def = @untyped_def
       block_visitor.call = @call
       block_visitor.fun_literal_context = @fun_literal_context
@@ -1075,7 +1073,7 @@ module Crystal
       block_visitor = MainVisitor.new(program, fun_vars, node.def, meta_vars)
       block_visitor.current_type = current_type
       block_visitor.yield_vars = @yield_vars
-      block_visitor.free_vars = @free_vars
+      block_visitor.match_context = @match_context
       block_visitor.untyped_def = node.def
       block_visitor.call = @call
       block_visitor.scope = @scope
@@ -2836,7 +2834,30 @@ module Crystal
       false
     end
 
+    def visit(node : TypeRestrict)
+      value = node.value
+      restriction = node.restriction
+
+      value.accept self
+
+      unless context = match_context
+        node.raise "BUG: there is no match context"
+      end
+
+      if type = value.type.restrict(restriction, context)
+        node.type = type
+      else
+        node.raise "can't restrict #{value.type} to #{restriction}"
+      end
+
+      false
+    end
+
     # # Helpers
+
+    def free_vars
+      match_context.try &.free_vars
+    end
 
     def check_closured(var)
       return if @typeof_nest > 0

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -65,9 +65,6 @@ module Crystal
 
           match = signature.match(item, context)
 
-          context.defining_type = path_lookup if macro_owner
-          context.def_free_vars = nil
-
           if match
             matches_array ||= [] of Match
             matches_array << match
@@ -91,6 +88,11 @@ module Crystal
             if arg_types_equal && named_arg_types_equal
               return Matches.new(matches_array, true, owner)
             end
+
+            context = MatchContext.new(owner, path_lookup)
+          else
+            context.defining_type = path_lookup if macro_owner
+            context.def_free_vars = nil
           end
         end
       end

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -12,7 +12,6 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   property! scope : Type
   setter scope
 
-  @free_vars : Hash(String, TypeVar)?
   @path_lookup : Type?
   @untyped_def : Def?
   @typed_def : Def?
@@ -199,6 +198,11 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     end
   end
 
+  # Returns free variables
+  def free_vars : Hash(String, TypeVar)?
+    nil
+  end
+
   def nesting_exp?(node)
     case node
     when Expressions, LibDef, CStructOrUnionDef, ClassDef, ModuleDef, FunDef, Def, Macro,
@@ -232,7 +236,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     case obj
     when Path
       base_type = @path_lookup || @scope || @current_type
-      macro_scope = base_type.lookup_type_var?(obj, free_vars: @free_vars, raise: raise_on_missing_const)
+      macro_scope = base_type.lookup_type_var?(obj, free_vars: free_vars, raise: raise_on_missing_const)
       return false unless macro_scope.is_a?(Type)
 
       macro_scope = macro_scope.remove_alias
@@ -360,7 +364,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     the_macro = Macro.new("macro_#{node.object_id}", [] of Arg, node).at(node.location)
 
     generated_nodes = expand_macro(the_macro, node, mode: mode) do
-      @program.expand_macro node, (@scope || current_type), @path_lookup, @free_vars, @untyped_def
+      @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
     end
 
     node.expanded = generated_nodes

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -44,6 +44,14 @@ module Crystal
       false
     end
 
+    def visit(node : TypeRestrict)
+      @str << "# type restrict: "
+      node.value.accept self
+      @str << " : "
+      node.restriction.accept self
+      false
+    end
+
     def visit(node : YieldBlockBinder)
       false
     end

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -46,9 +46,9 @@ module Crystal
 
     def visit(node : TypeRestriction)
       @str << "# type restrict: "
-      node.value.accept self
+      node.obj.accept self
       @str << " : "
-      node.restriction.accept self
+      node.to.accept self
       false
     end
 

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -44,7 +44,7 @@ module Crystal
       false
     end
 
-    def visit(node : TypeRestrict)
+    def visit(node : TypeRestriction)
       @str << "# type restrict: "
       node.value.accept self
       @str << " : "

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -45,7 +45,7 @@ module Crystal
     end
 
     def visit(node : TypeRestriction)
-      @str << "# type restrict: "
+      @str << "# type restriction: "
       node.obj.accept self
       @str << " : "
       node.to.accept self

--- a/src/compiler/crystal/semantic/transformer.cr
+++ b/src/compiler/crystal/semantic/transformer.cr
@@ -2,7 +2,7 @@ require "../syntax/transformer"
 
 module Crystal
   class Transformer
-    def transform(node : MetaVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | YieldBlockBinder | MacroId)
+    def transform(node : MetaVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestrict | YieldBlockBinder | MacroId)
       node
     end
 

--- a/src/compiler/crystal/semantic/transformer.cr
+++ b/src/compiler/crystal/semantic/transformer.cr
@@ -2,7 +2,7 @@ require "../syntax/transformer"
 
 module Crystal
   class Transformer
-    def transform(node : MetaVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestrict | YieldBlockBinder | MacroId)
+    def transform(node : MetaVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestriction | YieldBlockBinder | MacroId)
       node
     end
 

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -174,7 +174,7 @@ class HTTP::Server
   end
 
   # Builds all handlers as the middleware for HTTP::Server.
-  def self.build_middleware(handlers, last_handler : Context -> = nil)
+  def self.build_middleware(handlers, last_handler : (Context ->)? = nil)
     raise ArgumentError.new "You must specify at least one HTTP Handler." if handlers.empty?
     0.upto(handlers.size - 2) { |i| handlers[i].next = handlers[i + 1] }
     handlers.last.next = last_handler if last_handler


### PR DESCRIPTION
For example:

```crystal
def foo(x : String = 1)
  x
end

foo
```

I think above code is invalid, but current compiler accepts it.
This pull request fixes it.

Another effect, below code works fine now:

```crystal
def foo(x : T.class = String) forall T
  {{ T }}
end

foo # => String
```

(Before, we got "undefined constant T" error.)

Implementation point is introducing `TypeRestrict` fictitious node and applying it when instantiate a method with arguments having a default value.