### PR TITLE
Fix empty class pretty print

### DIFF
--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -105,4 +105,9 @@ describe "Reference" do
     clone.y.should_not be(original.y)
     clone.y.should eq(original.y)
   end
+
+  it "pretty_print" do
+    ReferenceSpec::TestClassBase.new.pretty_inspect.should match(/\A#<ReferenceSpec::TestClassBase:0x[0-9a-f]+>\Z/)
+    ReferenceSpec::TestClass.new(42, "foo").pretty_inspect.should match(/\A#<ReferenceSpec::TestClass:0x[0-9a-f]+ @x=42, @y="foo">\Z/)
+  end
 end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -81,9 +81,11 @@ class Reference
     {% else %}
       prefix = "#<#{{{@type.name.id.stringify}}}:0x#{object_id.to_s(16)}"
       executed = exec_recursive(:pretty_print) do
-        pp.surround(prefix, ">", left_break: " ", right_break: nil) do
+        pp.surround(prefix, ">", left_break: nil, right_break: nil) do
           {% for ivar, i in @type.instance_vars.map(&.name).sort %}
-            {% if i > 0 %}
+            {% if i == 0 %}
+              pp.breakable
+            {% else %}
               pp.comma
             {% end %}
             pp.group do


### PR DESCRIPTION
For example:

```crystal
class Foo
end

p Foo.new.pretty_inspect # => "#<Foo:0xdeadbeef >"
```

The result of `Foo.new.pretty_inspect` contains unnecessary space after address. This pull request fixed it.