### PR TITLE
Accept Char in String#[](str)

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -138,6 +138,13 @@ describe "String" do
       "FooBar"["Baz"]?.should be_nil
     end
 
+    it "gets with a char" do
+      "foo/bar"['/'].should eq '/'
+      expect_raises { "foo/bar"['-'] }
+      "foo/bar"['/']?.should eq '/'
+      "foo/bar"['-']?.should be_nil
+    end
+
     it "gets with index and []?" do
       "hello"[1]?.should eq('e')
       "hello"[5]?.should be_nil

--- a/src/string.cr
+++ b/src/string.cr
@@ -775,7 +775,7 @@ class String
     at(index) { nil }
   end
 
-  def []?(str : String)
+  def []?(str : String | Char)
     includes?(str) ? str : nil
   end
 
@@ -788,7 +788,7 @@ class String
     match[group]? if match
   end
 
-  def [](str : String)
+  def [](str : String | Char)
     self[str]?.not_nil!
   end
 


### PR DESCRIPTION
This PR extends `String#[](str)` to accept `Char` in type restriction.
Useful for things like `email['@']?`