### PR TITLE
Allow optional block with Hash#delete

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -257,6 +257,22 @@ describe "Hash" do
       a = {1 => 2}
       a.delete(2).should be_nil
     end
+
+    describe "with block" do
+      it "returns the value if a key is found" do
+        a = {1 => 2}
+        a.delete(1) { 5 }.should eq(2)
+      end
+
+      it "returns the value of the block if key is not found" do
+        a = {1 => 2}
+        a.delete(3) { |key| key }.should eq(3)
+      end
+
+      it "returns nil if key is found and value is nil" do
+        {3 => nil}.delete(3) { 7 }.should be_nil
+      end
+    end
   end
 
   describe "size" do

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -198,12 +198,24 @@ class Hash(K, V)
     yield value
   end
 
-  # Deletes the key-value pair and returns the value.
+  # Deletes the key-value pair and returns the value, otherwise returns `nil`.
   #
   # ```
   # h = {"foo" => "bar"}
   # h.delete("foo")     # => "bar"
   # h.fetch("foo", nil) # => nil
+  # ```
+  def delete(key)
+    delete(key) { nil }
+  end
+
+  # Deletes the key-value pair and returns the value, else yields *key* with given block.
+  #
+  # ```
+  # h = {"foo" => "bar"}
+  # h.delete("foo") { |key| "#{key} not found" } # => "bar"
+  # h.fetch("foo", nil)                          # => nil
+  # h.delete("baz") { |key| "#{key} not found" } # => "baz not found"
   # ```
   def delete(key)
     index = bucket_index(key)
@@ -242,7 +254,7 @@ class Hash(K, V)
       previous_entry = entry
       entry = entry.next
     end
-    nil
+    yield key
   end
 
   # Deletes each key-value pair for which the given block returns `true`.


### PR DESCRIPTION
In Ruby we can pass an optional block to Hash#delete whose result can be returned if a key is not found.

This adds similar functionality to Crystal's Hash#delete.

Thanks!