### PR TITLE
Fix Reference#dup of file private class

### DIFF
--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -219,6 +219,28 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
+  it "finds private type in macro expansion with {{@type}}" do
+    compiler = Compiler.new
+    sources = [
+      Compiler::Source.new("foo.cr", %(
+                                        class Foo
+                                          def bar
+                                            {{@type}}.new
+                                          end
+                                        end
+                                      )),
+      Compiler::Source.new("bar.cr", %(
+                                        private class Bar < Foo
+                                        end
+
+                                        Bar.new.bar
+                                      )),
+    ]
+    compiler.no_codegen = true
+    compiler.prelude = "empty"
+    compiler.compile sources, "output"
+  end
+
   it "can use types in private type" do
     assert_type(%(
       private class Foo

--- a/src/int.cr
+++ b/src/int.cr
@@ -140,7 +140,7 @@ struct Int
 
     {% begin %}
       if self < 0 && self == {{@type}}::MIN && other == -1
-        raise ArgumentError.new "overflow: {{@type}}::MIN / -1"
+        raise ArgumentError.new "overflow: {{@type.id}}::MIN / -1"
       end
     {% end %}
   end


### PR DESCRIPTION
For instance:

```crystal
private class Foo
end

Foo.new.dup
```

this code causes an error:

```
Error in foo.cr:4: instantiating 'Foo#dup()'

Foo.new.dup
        ^~~

in /.../src/reference.cr:40: expanding macro

    {% if @type.abstract? %}
    ^

in macro 'macro_XXX' /.../src/reference.cr:40, line 2:

   1.
>  2.       dup = Foo.allocate
   3.       dup.as(Void*).copy_from(self.as(Void*), instance_sizeof(Foo))
   4.       dup
   5.
```

This commit fixes it by wrapping `{{@type}}` expansion with `#<loc:>` pragma
of class defined location.