### PR TITLE
StringScanner should work with small strings

### DIFF
--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -233,6 +233,8 @@ describe StringScanner, "#inspect" do
   it "works with small strings" do
     s = StringScanner.new("hi")
     s.inspect.should eq(%(#<StringScanner 0/2 "hi" >))
+    s.scan(/\w\w/)
+    s.inspect.should eq(%(#<StringScanner 2/2 "hi" >))
   end
 end
 

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -229,6 +229,11 @@ describe StringScanner, "#inspect" do
     s.scan(/\w+\s\w+/)
     s.inspect.should eq(%(#<StringScanner 16/16 "tring" >))
   end
+
+  it "works with small strings" do
+    s = StringScanner.new("hi")
+    s.inspect.should eq(%(#<StringScanner 0/2 "hi" >))
+  end
 end
 
 describe StringScanner, "#peek" do

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -254,7 +254,7 @@ class StringScanner
     io << "#<StringScanner "
     offset = offset()
     io << offset << "/" << @str.size
-    start = Math.min(Math.max(offset - 2, 0), @str.size - 5)
+    start = Math.min(Math.max(offset - 2, 0), Math.max(0, @str.size - 5))
     io << " \"" << @str[start, 5] << "\" >"
   end
 end


### PR DESCRIPTION
`StringScanner#inspect` failed with strings smaller than 5 characters. This should fix it.