### PR TITLE
Disallow 3-byte UTF-8 surrogate pair

### DIFF
--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -91,6 +91,10 @@ describe "Char::Reader" do
     expect_raises(InvalidByteSequenceError) { Char::Reader.new(String.new Bytes[0xe0, 0x9F, 0xA0]) }
   end
 
+  it "errors if first_byte == 0xED && second_byte >= 0xA0" do
+    expect_raises(InvalidByteSequenceError) { Char::Reader.new(String.new Bytes[0xed, 0xB0, 0xA0]) }
+  end
+
   it "errors if first_byte < 0xF0 && (third_byte & 0xC0) != 0x80" do
     expect_raises(InvalidByteSequenceError) { Char::Reader.new(String.new Bytes[0xe0, 0xA0, 0]) }
   end

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -150,8 +150,6 @@ struct Char
     end
 
     private def decode_char_at(pos)
-      # See http://en.wikipedia.org/wiki/UTF-8#Sample_code
-
       first = byte_at(pos)
       if first < 0x80
         return yield first, 1
@@ -177,6 +175,10 @@ struct Char
 
       if first < 0xf0
         if first == 0xe0 && second < 0xa0
+          invalid_byte_sequence(second, pos + 1)
+        end
+
+        if first == 0xed && second >= 0xa0
           invalid_byte_sequence(second, pos + 1)
         end
 


### PR DESCRIPTION
All surrogate pair should not be contained in valid UTF-8 sequence.

And, I removed Wikipedia link comment because this sample code is deleted in [this revision](https://en.wikipedia.org/w/index.php?title=UTF-8&oldid=671406059). (Also, this has a same bug :-)