### PR TITLE
Fix: IPAddress#address returns a nilable

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -142,6 +142,7 @@ describe Socket::IPAddress do
 
     addr2.family.should eq(addr1.family)
     addr2.port.should eq(addr1.port)
+    typeof(addr2.address).should eq(String)
     addr2.address.should eq(addr1.address)
   end
 
@@ -151,6 +152,7 @@ describe Socket::IPAddress do
 
     addr2.family.should eq(addr1.family)
     addr2.port.should eq(addr1.port)
+    typeof(addr2.address).should eq(String)
     addr2.address.should eq(addr1.address)
   end
 

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -107,8 +107,8 @@ class Socket
     def address
       @address ||= begin
         case family
-        when Family::INET6 then address(@addr6)
-        when Family::INET  then address(@addr4)
+        when Family::INET6 then address(@addr6.not_nil!)
+        when Family::INET  then address(@addr4.not_nil!)
         else                    raise "unsupported IP address family: #{family}"
         end
       end
@@ -130,10 +130,6 @@ class Socket
         end
         {LibC.strlen(buffer), 0}
       end
-    end
-
-    private def address(addr) : Nil
-      # shouldn't happen
     end
 
     def ==(other : IPAddress)


### PR DESCRIPTION
The socket refactor led `IPAddress#address` to now return a nilable when it should only ever return a `String`.

refs https://github.com/ysbaddaden/prax.cr/issues/42