### PR TITLE
Implement Rabin-Karp algorithm for String#index

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -600,6 +600,8 @@ describe "String" do
         assert { "foobarbaz".index("ba", -5).should eq(6) }
         assert { "foo".index("ba", 1).should be_nil }
         assert { "foo".index("ba", -20).should be_nil }
+        assert { "foo".index("", 3).should eq(3) }
+        assert { "foo".index("", 4).should be_nil }
         assert { "日本語日本語".index("本語", 2).should eq(4) }
       end
     end
@@ -616,6 +618,8 @@ describe "String" do
         assert { "foobarbaz".index(/ba/, -5).should eq(6) }
         assert { "Foo".index(/[A-Z]/, 1).should be_nil }
         assert { "foo".index(/o/, 2).should eq(2) }
+        assert { "foo".index(//, 3).should eq(3) }
+        assert { "foo".index(//, 4).should be_nil }
         assert { "日本語日本語".index(/本語/, 2).should eq(4) }
       end
     end


### PR DESCRIPTION
Benchmark is [here](https://gist.github.com/MakeNowJust/57b9be3ed726be4820a171f4f5896491).

My result is:

```console
$ crystal run --release index_bench.cr
       index_old 473.18  (  2.11ms) (± 8.92%)  2.72× slower
index_rabin_karp   1.29k (777.94µs) (±11.77%)       fastest
```

(I recommend you run this benchmark on your environment ;)