### PR TITLE
Macro ancestors 

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1014,6 +1014,31 @@ describe "macro methods" do
       end
     end
 
+    it "executes ancestors" do
+      assert_macro("x", "{{x.ancestors}}", %([SomeModule, Reference, Object])) do |program|
+        mod = NonGenericModuleType.new(program, program, "SomeModule")
+        klass = NonGenericClassType.new(program, program, "SomeType", program.reference)
+        klass.include mod
+
+        [TypeNode.new(klass)] of ASTNode
+      end
+    end
+
+    it "executes ancestors (with generic)" do
+      assert_macro("x", "{{x.ancestors}}", %([SomeGenericModule(String), SomeGenericType(String), Reference, Object])) do |program|
+        generic_type = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+        generic_mod = GenericModuleType.new(program, program, "SomeGenericModule", ["T"])
+        type_var = {"T" => TypeNode.new(program.string)} of String => ASTNode
+        type = GenericClassInstanceType.new(program, generic_type, program.reference, type_var)
+        mod = GenericModuleInstanceType.new(program, generic_mod, type_var)
+
+        klass = NonGenericClassType.new(program, program, "SomeType", type)
+        klass.include mod
+
+        [TypeNode.new(klass)] of ASTNode
+      end
+    end
+
     it "executes superclass" do
       assert_macro("x", "{{x.superclass}}", %(Reference)) do |program|
         [TypeNode.new(program.string)] of ASTNode

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1462,6 +1462,10 @@ module Crystal::Macros
     def instance_vars : ArrayLiteral(MetaVar)
     end
 
+    # Returns all ancestors of this type.
+    def ancestors : ArrayLiteral(TypeNode)
+    end
+
     # Returns the direct superclass of this type.
     def superclass : TypeNode | NilLiteral
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1305,6 +1305,8 @@ module Crystal
         interpret_argless_method(method, args) { TypeNode.type_vars(type) }
       when "instance_vars"
         interpret_argless_method(method, args) { TypeNode.instance_vars(type) }
+      when "ancestors"
+        interpret_argless_method(method, args) { TypeNode.ancestors(type) }
       when "superclass"
         interpret_argless_method(method, args) { TypeNode.superclass(type) }
       when "subclasses"
@@ -1455,6 +1457,10 @@ module Crystal
       else
         ArrayLiteral.new
       end
+    end
+
+    def self.ancestors(type)
+      ArrayLiteral.map(type.ancestors) { |ancestor| TypeNode.new(ancestor) }
     end
 
     def self.superclass(type)


### PR DESCRIPTION
Solved #3871 .

After this PR, we can use `#ancestors` and `#superclasses` in macro to get the inherit chain of the type.

```crystal
class Foo
  def self.ancestors
    {{@type.ancestors}}
  end
  def self.superclasses # returns all superclass (without includes)
    {{@type.superclasses}}
  end
end

module Bar; end
class FooBar < Foo
  include Bar
end

puts FooBar.ancestors #=> [Bar, Foo, Reference, Class]
puts FooBar.superclasses #=> [Foo, Reference, Class]
```