### PR TITLE
Implement Rabin-Karp algorithm for String#rindex

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -653,7 +653,8 @@ describe "String" do
 
       describe "with offset" do
         assert { "foo baro baz".rindex("o b", 6).should eq(2) }
-        assert { "foo baro baz".rindex("fg").should be_nil }
+        assert { "foo".rindex("", 3).should eq(3) }
+        assert { "foo".rindex("", 4).should eq(3) }
         assert { "日本語日本語".rindex("日本", 2).should eq(0) }
       end
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2175,8 +2175,20 @@ class String
     end
   end
 
-  # Prime number constant for Rabin-Karp algorithm
+  # Prime number constant for Rabin-Karp algorithm `String#index`
   private PRIME_RK = 2097169u32
+
+  # Update rolling hash for Rabin-Karp algorithm `String#index`
+  private macro update_hash(n)
+    {% for i in 1..n %}
+      {% if i != 1 %}
+        byte = head_pointer.value
+      {% end %}
+      hash = hash * PRIME_RK + pointer.value - pow * byte
+      pointer += 1
+      head_pointer += 1
+    {% end %}
+  end
 
   # Returns the index of *search* in the string, or `nil` if the string is not present.
   # If *offset* is present, it defines the position to start the search.
@@ -2210,14 +2222,14 @@ class String
   # ditto
   def index(search : String, offset = 0)
     offset += size if offset < 0
-    return nil if offset < 0
+    return if offset < 0
 
     return size < offset ? nil : offset if search.empty?
 
     # Rabin-Karp algorithm
     # https://en.wikipedia.org/wiki/Rabin%E2%80%93Karp_algorithm
 
-    # calculate a rolling hash of search string (needle)
+    # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.each_byte do |b|
       search_hash = search_hash * PRIME_RK + b
@@ -2262,16 +2274,20 @@ class String
       return if pointer >= end_pointer
 
       byte = head_pointer.value
-      char_index += 1 if (byte & 0x80) == 0 || (byte & 0x40) != 0
 
-      # update a rolling hash of this text (haystack)
-      hash = hash * PRIME_RK + pointer.value - pow * byte
-
-      head_pointer += 1
-      pointer += 1
+      # update a rolling hash of this text (heystack)
+      # thanks @MaxLap for suggesting this loop reduction
+      if byte < 0x80
+        update_hash 1
+      elsif byte < 0xe0
+        update_hash 2
+      elsif byte < 0xf0
+        update_hash 3
+      else
+        update_hash 4
+      end
+      char_index += 1
     end
-
-    nil
   end
 
   # ditto

--- a/src/string.cr
+++ b/src/string.cr
@@ -2331,20 +2331,54 @@ class String
   # ditto
   def rindex(search : String, offset = size - search.size)
     offset += size if offset < 0
-    return nil if offset < 0
+    return if offset < 0
 
-    end_size = size - search.size
+    # Rabin-Karp algorithm
+    # https://en.wikipedia.org/wiki/Rabin%E2%80%93Karp_algorithm
 
-    last_index = nil
+    # calculate a rolling hash of search text (needle)
+    search_hash = 0u32
+    search.to_slice.reverse_each do |b|
+      search_hash = search_hash * PRIME_RK + b
+    end
+    pow = PRIME_RK ** search.bytesize
 
-    reader = Char::Reader.new(self)
-    reader.each_with_index do |char, i|
-      if i <= end_size && i <= offset && (to_unsafe + reader.pos).memcmp(search.to_unsafe, search.bytesize) == 0
-        last_index = i
-      end
+    hash = 0u32
+    char_index = size
+
+    begin_pointer = to_unsafe
+    pointer = begin_pointer + bytesize
+    tail_pointer = pointer
+    hash_begin_pointer = pointer - search.bytesize
+
+    return if hash_begin_pointer < begin_pointer
+
+    # calculate a rolling hash of this text (haystack)
+    while hash_begin_pointer < pointer
+      pointer -= 1
+      byte = pointer.value
+      char_index -= 1 if (byte & 0xC0) != 0x80
+
+      hash = hash * PRIME_RK + byte
     end
 
-    last_index
+    while true
+      # check hash equality and real string equality
+      if hash == search_hash && char_index <= offset &&
+         pointer.memcmp(search.to_unsafe, search.bytesize) == 0
+        return char_index
+      end
+
+      return if begin_pointer == pointer
+
+      pointer -= 1
+      tail_pointer -= 1
+      byte = pointer.value
+      char_index -= 1 if (byte & 0xC0) != 0x80
+
+      # update a rolling hash of this text (haystack)
+      hash = hash * PRIME_RK + byte - pow * tail_pointer.value
+    end
   end
 
   # ditto


### PR DESCRIPTION
Reverse version of [this](https://github.com/crystal-lang/crystal/pull/3873).

Benchmark is [here](https://gist.github.com/MakeNowJust/7a3c08cb6fab3862a305a01dec223ad0).

My result is:

```console
$ crystal run --release rindex_bench.cr
For long string:
       rindex_old 258.31  (  3.87ms) (± 6.69%) 11.04× slower
rindex_rabin_karp   2.85k ( 350.8µs) (± 6.77%)       fastest
For short string:
       short_rindex_old   1.92M (520.84ns) (± 6.08%)  2.66× slower
short_rindex_rabin_karp   5.11M (195.87ns) (± 8.64%)       fastest
```

(I recommend you run this benchmark on your environment ;)