### PR TITLE
Fix String#scan behavior same as Ruby

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1673,6 +1673,7 @@ describe "String" do
     it "works when match is empty" do
       r = %r([\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*))
       "hello".scan(r).map(&.[0]).should eq(["hello", ""])
+      "hello world".scan(/\w+|(?= )/).map(&.[0]).should eq(["hello", "", "world"])
     end
 
     it "works with strings with block" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -809,7 +809,9 @@ describe "String" do
       assert { "foo,bar,baz,qux".split(/,/, 30).should eq(["foo", "bar", "baz", "qux"]) }
       assert { "a b c".split(Regex.new(" "), 2).should eq(["a", "b c"]) }
       assert { "日本ん語日本ん語".split(/ん/).should eq(["日本", "語日本", "語"]) }
+      assert { "九十九十九".split(/(?=十)/).should eq(["九", "十九", "十九"]) }
       assert { "hello world".split(/\b/).should eq(["hello", " ", "world", ""]) }
+      assert { "hello world".split(/\w+|(?= )/).should eq(["", " ", ""]) }
       assert { "abc".split(//).should eq(["a", "b", "c"]) }
       assert { "hello".split(/\w+/).should eq(["", ""]) }
       assert { "foo".split(/o/).should eq(["f", "", ""]) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -3154,7 +3154,7 @@ class String
       $~ = match
       yield match
       match_bytesize = match[0].bytesize
-      break if match_bytesize == 0
+      match_bytesize += 1 if match_bytesize == 0
       byte_offset = index + match_bytesize
     end
 


### PR DESCRIPTION
For example, Ruby's String#scan is:

```ruby
"hello world".scan(/\w+|(?= )/) # => ["hello", "", "world"]
```

But Crystal's is:

```crystal
"hello world".scan(/\w+|(?= )/).map &.[0] # => ["hello", ""]
```

This pull request fixes it by continuing to scan when match is empty.