### PR TITLE
disallow other type inherit from String

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -109,6 +109,10 @@ class String
 
   include Comparable(self)
 
+  macro inherited
+    {{ raise "cannot inherit from String" }}
+  end
+
   # Creates a `String` from the given *slice*. `Bytes` will be copied from the slice.
   #
   # This method is always safe to call, and the resulting string will have


### PR DESCRIPTION
solved #3864 
if we try to inherit from String, compiler will give such error
```Crystal
class Foo < String
end
```
```
Error in test3.cr:1: cannot inherit from String

class Foo < String
      ^
```