### PR TITLE
Add JSON::Any#to_a and JSON::Any#to_h

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -52,6 +52,20 @@ describe JSON::Any do
     end
   end
 
+  describe "converts" do
+    it "to array" do
+      JSON.parse(%([1, 2, 3])).to_a.should eq([1, 2, 3].map { |x| JSON::Any.new x.to_i64 })
+      JSON.parse(%([1, 2, 3])).to_a?.should eq([1, 2, 3].map { |x| JSON::Any.new x.to_i64 })
+      JSON.parse("true").as_a?.should be_nil
+    end
+
+    it "to hash" do
+      JSON.parse(%({"foo": "bar"})).to_h.should eq({"foo" => JSON::Any.new "bar"})
+      JSON.parse(%({"foo": "bar"})).to_h?.should eq({"foo" => JSON::Any.new "bar"})
+      JSON.parse("true").as_h?.should be_nil
+    end
+  end
+
   describe "#size" do
     it "of array" do
       JSON.parse("[1, 2, 3]").size.should eq(3)

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -220,6 +220,32 @@ struct JSON::Any
     as_h if @raw.is_a?(Hash(String, Type))
   end
 
+  # Creates a new array with `JSON::Any` values.
+  def to_a : Array(Any)
+    as_a.map do |value|
+      Any.new value
+    end
+  end
+
+  # Checks that underlying value is `Array`, and creates a new array with `JSON::Any` values.
+  # Returns nil otherwise.
+  def to_a? : Array(Any)?
+    to_a if @raw.is_a?(Array(Type))
+  end
+
+  # Creates a new hash with `String` keys and `JSON::Any` values.
+  def to_h : Hash(String, Any)
+    as_h.each_with_object(Hash(String, Any).new) do |(key, value), hash|
+      hash[key] = Any.new value
+    end
+  end
+
+  # Checks that underlying value is `Hash`, and creates a new hash with `String` keys and `JSON::Any` values.
+  # Returns nil otherwise.
+  def to_h? : Hash(String, Any)?
+    to_h if @raw.is_a?(Hash(String, Type))
+  end
+
   # :nodoc:
   def inspect(io)
     @raw.inspect(io)


### PR DESCRIPTION
It keeps values as `JSON::Any`. Refs #3881

For example, we can use `Hash#each` with `JSON::Any` values:

```crystal
require "json"

json = JSON.parse %({"foo": 1, "bar": [2, 3]})
json.to_h.each do |key, value|
  pp key
  pp typeof(key)
  pp value
  pp typeof(value)
end
```