### PR TITLE
Remove default new for modules

### DIFF
--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -26,7 +26,7 @@ module Crystal
     def define_default_new_single(type)
       check = case type
               when self.object, self.value, self.number, self.int, self.float,
-                   self.struct, self.enum, self.tuple, self.proc
+                   self.struct, self.enum, self.tuple, self.proc, .module?
                 false
               when NonGenericClassType, GenericClassType
                 true


### PR DESCRIPTION
Fixed #3885 . 

Now will throw the correct message of executing `SomeModule.new`:

```crystal
module Foo; end

Foo.new # undefined method 'new' for Foo:Module
```