### PR TITLE
`crystal doc` checks is_crystal_repo based on any remote

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -19,8 +19,8 @@ class Crystal::Doc::Generator
     @base_dir = `pwd`.chomp
     @types = {} of Crystal::Type => Doc::Type
     @repo_name = ""
+    @is_crystal_repo = false
     compute_repository
-    @is_crystal_repo = @repo_name == "github.com/crystal-lang/crystal"
   end
 
   def run
@@ -283,6 +283,8 @@ class Crystal::Doc::Generator
 
     github_remote_pattern = /github\.com(?:\:|\/)((?:\w|-|_)+)\/((?:\w|-|_|\.)+)/
     github_remotes = remotes.lines.select &.match(github_remote_pattern)
+    @is_crystal_repo = github_remotes.any? { |gr| gr =~ %r{github\.com[/:]crystal-lang/crystal} }
+
     remote = github_remotes.find(&.starts_with?("origin")) || github_remotes.first?
     return unless remote
 


### PR DESCRIPTION
In crystal doc, instead of checking only the origin remote to detect if we are in the crystal repo, check any of the remotes.
I find this useful because I prefer to have my fork as 'origin', and keep the crystal-lang repo as 'lang'. However, doing this means when I `make doc`, i don't get the Crystal section with all the builtins.