### PR TITLE
allow setting and deleting of attributes on supported XML::Node types

### DIFF
--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -32,7 +32,8 @@ struct XML::Node
     attributes[attribute]?.try &.content
   end
 
-  # sets *attribute* of this node to *value*. Raises `XML::Error` if this node does not support attributes.
+  # Sets *attribute* of this node to *value*.
+  # Raises `XML::Error` if this node does not support attributes.
   def []=(name : String, value : String)
     raise XML::Error.new("Can't set attribute of #{type}", 0) unless element?
     attributes[name] = value

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -21,17 +21,27 @@ struct XML::Node
   end
 
   # Gets the attribute content for the *attribute* given by name.
-  #
   # Raises `KeyError` if attribute is not found.
   def [](attribute : String) : String
     attributes[attribute].content || raise(KeyError.new("Missing attribute: #{attribute}"))
   end
 
   # Gets the attribute content for the *attribute* given by name.
-  #
   # Returns `nil` if attribute is not found.
   def []?(attribute : String) : String?
     attributes[attribute]?.try &.content
+  end
+
+  # sets *attribute* of this node to *value*. Raises `XML::Error` if this node does not support attributes.
+  def []=(name : String, value : String)
+    raise XML::Error.new("Can't set attribute of #{type}", 0) unless element?
+    attributes[name] = value
+  end
+
+  # Deletes attribute given by *name*.
+  # Returns attributes value, or `nil` if attribute not found.
+  def delete(name : String)
+    attributes.delete(name)
   end
 
   # Compares with *other*.


### PR DESCRIPTION
Allow node[name]=value and node.attributes.delete(name)

I'm not sure if Attributes#delete is the correct place for the delete method, but I'm open to suggestions. Maybe Node#delete_attribute?
Also, are we avoiding all methods in libxml2 that require the LIBXML_TREE_ENABLED define? (I've continued that pattern in this PR.)
That should probably be noted somewhere if so.
