### PR TITLE
Fix LICENSE and add NOTICE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,211 @@
-Copyright 2012-2020 Manas Technology Solutions.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-      http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+----------------------------------------------------------------------------
+
+Runtime Library Exception to the Apache 2.0 License:
+
+   As an exception, if you use this Software to compile your source code
+   and portions of this Software are embedded into the binary product as a
+   result, you may redistribute such product without providing attribution
+   as would otherwise be required by Sections 4(a), 4(b) and 4(d) of the
+   License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -30,11 +30,11 @@ Crystal standard library uses the following libraries, which have their own lice
   * [libiconv][] - [LGPLv3][]
   * [bdwgc][] - [MIT][]
   * [Zlib][] - [Zlib][Zlib-license]
-  * [OpenSSL][] - [Apache License v2.0](https://www.openssl.org/source/apache-license-2.0.txt)
+  * [OpenSSL][] - [Apache-2.0][]
   * [Libxml2][] - [MIT][]
   * [LibYAML][] - [MIT][]
-  * [readline](https://tiswww.case.edu/php/chet/readline/rltop.html) - [GPLv3][]
-  * [GMP](https://gmplib.org/) - [LGPLv3][]
+  * [readline][] - [GPLv3][]
+  * [GMP][] - [LGPLv3][]
 
 Crystal playground includes the following libraries, which have their own licenses.
 (There are these files under [/src/compiler/crystal/tools/playground/public/vendor](/src/compiler/crystal/tools/playground/public/vendor)):
@@ -47,6 +47,7 @@ Crystal playground includes the following libraries, which have their own licens
    * [ansi\_up][] - [MIT][] `Copyright (c) 2011 Dru Nelson`
 
 <!-- licenses -->
+[Apache-2.0]: https://www.openssl.org/source/apache-license-2.0.txt
 [BSD-3]: https://opensource.org/licenses/BSD-3-Clause
 [BSD-3, effectively]: http://releases.llvm.org/2.8/LICENSE.TXT
 [GPLv3]: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -59,6 +60,7 @@ Crystal playground includes the following libraries, which have their own licens
 [bdwgc]: http://www.hboehm.info/gc/
 [Codemirror]: https://codemirror.net/
 [jQuery]: https://jquery.com/
+[GMP]: https://gmplib.org/
 [libevent2]: http://libevent.org/
 [libiconv]: https://www.gnu.org/software/libiconv/
 [Libxml2]: http://xmlsoft.org/
@@ -68,4 +70,5 @@ Crystal playground includes the following libraries, which have their own licens
 [Octicons]: https://octicons.github.com/
 [OpenSSL]: https://www.openssl.org/
 [PCRE]: http://pcre.org/
+[readline]: https://tiswww.case.edu/php/chet/readline/rltop.html
 [Zlib]: http://www.zlib.net/

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -39,12 +39,12 @@ Crystal standard library uses the following libraries, which have their own lice
 Crystal playground includes the following libraries, which have their own licenses.
 (There are these files under [/src/compiler/crystal/tools/playground/public/vendor](/src/compiler/crystal/tools/playground/public/vendor)):
 
-   * [jQuery](https://jquery.com/) - [MIT][]
+   * [jQuery][] - [MIT][]
      `Copyright JS Foundation and other contributors, https://js.foundation/`
-   * [Octicons](https://octicons.github.com/) - [MIT][] (for codes) or [OFL-1.1][] (for fonts) `(c) 2012-2016 GitHub, Inc.`
-   * [Materialize](http://materializecss.com/) - [MIT][] `Copyright (c) 2014-2015 Materialize`
-   * [CodeMirror](https://codemirror.net/) - [MIT][] `Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others`
-   * [ansi\_up](https://github.com/drudru/ansi\_up) - [MIT][] `Copyright (c) 2011 Dru Nelson`
+   * [Octicons][] - [MIT][] (for codes) or [OFL-1.1][] (for fonts) `(c) 2012-2016 GitHub, Inc.`
+   * [Materialize][] - [MIT][] `Copyright (c) 2014-2015 Materialize`
+   * [CodeMirror][] - [MIT][] `Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others`
+   * [ansi\_up][] - [MIT][] `Copyright (c) 2011 Dru Nelson`
 
 <!-- licenses -->
 [BSD-3]: https://opensource.org/licenses/BSD-3-Clause
@@ -55,12 +55,17 @@ Crystal playground includes the following libraries, which have their own licens
 [OFL-1.1]: https://opensource.org/licenses/OFL-1.1
 [Zlib-license]: https://opensource.org/licenses/Zlib
 <!-- libraries -->
+[ansi\_up]: https://github.com/drudru/ansi\_up
 [bdwgc]: http://www.hboehm.info/gc/
+[Codemirror]: https://codemirror.net/
+[jQuery]: https://jquery.com/
 [libevent2]: http://libevent.org/
 [libiconv]: https://www.gnu.org/software/libiconv/
 [Libxml2]: http://xmlsoft.org/
 [LibYAML]: http://pyyaml.org/wiki/LibYAML
 [LLVM]: http://llvm.org/
+[Materialize]: http://materializecss.com/
+[Octicons]: https://octicons.github.com/
 [OpenSSL]: https://www.openssl.org/
 [PCRE]: http://pcre.org/
 [Zlib]: http://www.zlib.net/

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,65 @@
+# Crystal Programmig Language
+
+Copyright 2012-2017 Manas Technology Solutions.
+
+This product includes software developed at Manas Technology Solutions (<https://manas.tech/>).
+
+Apache License v2.0 applies to all works.
+
+Please see [LICENSE](/LICENSE) for additional copyright and licensing information.
+
+## External libraries information
+
+Crystal compiler links these libraries, which have their own license:
+
+  * [LLVM](http://llvm.org/)
+    - [BSD-3, effectively](http://releases.llvm.org/2.8/LICENSE.TXT)
+  * [PCRE](http://pcre.org/)
+    - [BSD-3](https://opensource.org/licenses/BSD-3-Clause)
+  * [libevent2](http://libevent.org/)
+    - BSD-3
+  * [libiconv](https://www.gnu.org/software/libiconv/)
+    - [LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.en.html)
+  * [bdwgc](http://www.hboehm.info/gc/)
+    - [MIT](https://opensource.org/licenses/MIT)
+  * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
+    - [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+Crystal standard library uses these libraries, which have their own licenses:
+
+  * LLVM
+  * PCRE
+  * libevent2
+  * libiconv
+  * bdwgc
+  * [Zlib](http://www.zlib.net/)
+    - [Zlib](https://opensource.org/licenses/Zlib)
+  * [OpenSSL](https://www.openssl.org/)
+    - Apache License 1.0 and 4-clauses BSD
+  * [Libxml2](http://xmlsoft.org/)
+    - MIT
+  * [LibYAML](http://pyyaml.org/wiki/LibYAML)
+    - MIT
+  * [readline](https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html)
+    - GPLv3
+  * [GMP](https://gmplib.org/)
+    - LGPLv3
+
+Crystal playground includes these libraries, which have their own licenses.
+(There are these files under [/src/compiler/crystal/tools/playground/public/vendor](/src/compiler/crystal/tools/playground/public/vendor)):
+
+   * [jQuery](https://jquery.com/)
+     - MIT
+     - `Copyright JS Foundation and other contributors, https://js.foundation/`
+   * [Octicons](https://octicons.github.com/)
+     - MIT (for codes) or [OFL-1.1](https://opensource.org/licenses/OFL-1.1) (for fonts)
+     - `(c) 2012-2016 GitHub, Inc.`
+   * [Materialize](http://materializecss.com/)
+     - MIT
+     - `Copyright (c) 2014-2016 Materialize`
+   * [CodeMirror](https://codemirror.net/)
+     - MIT
+     - `Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others`
+   * [ansi\_up](https://github.com/drudru/ansi\_up)
+     - MIT
+     - `Copyright (c) 2011 Dru Nelson`

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -58,7 +58,7 @@ Crystal playground includes the following libraries, which have their own licens
 <!-- libraries -->
 [ansi\_up]: https://github.com/drudru/ansi\_up
 [bdwgc]: http://www.hboehm.info/gc/
-[Codemirror]: https://codemirror.net/
+[CodeMirror]: https://codemirror.net/
 [jQuery]: https://jquery.com/
 [GMP]: https://gmplib.org/
 [libevent2]: http://libevent.org/

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 # Crystal Programming Language
 
-Copyright 2012-2017 Manas Technology Solutions.
+Copyright 2012-2020 Manas Technology Solutions.
 
 This product includes software developed at Manas Technology Solutions (<https://manas.tech/>).
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-# Crystal Programmig Language
+# Crystal Programming Language
 
 Copyright 2012-2017 Manas Technology Solutions.
 
@@ -22,10 +22,10 @@ Crystal compiler links these libraries, which have their own license:
     - [LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.en.html)
   * [bdwgc](http://www.hboehm.info/gc/)
     - [MIT](https://opensource.org/licenses/MIT)
-  * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
-    - [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
-Crystal standard library uses these libraries, which have their own licenses:
+And [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) is used, which is licensed by [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+Parts of the Crystal standard library use the following libraries, which have their own licenses:
 
   * LLVM
   * PCRE

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -10,56 +10,57 @@ Please see [LICENSE](/LICENSE) for additional copyright and licensing informatio
 
 ## External libraries information
 
-Crystal compiler links these libraries, which have their own license:
+Crystal compiler links the following libraries, which have their own license:
 
-  * [LLVM](http://llvm.org/)
-    - [BSD-3, effectively](http://releases.llvm.org/2.8/LICENSE.TXT)
-  * [PCRE](http://pcre.org/)
-    - [BSD-3](https://opensource.org/licenses/BSD-3-Clause)
-  * [libevent2](http://libevent.org/)
-    - BSD-3
-  * [libiconv](https://www.gnu.org/software/libiconv/)
-    - [LGPLv3](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-  * [bdwgc](http://www.hboehm.info/gc/)
-    - [MIT](https://opensource.org/licenses/MIT)
+  * [LLVM][] - [BSD-3, effectively][]
+  * [PCRE][] - [BSD-3][]
+  * [libevent2][] - [BSD-3][]
+  * [libiconv][] - [LGPLv3][]
+  * [bdwgc][] - [MIT][]
 
-And [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) is used, which is licensed by [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
+Crystal compiler calls the following tools as external process on compiling, which have their own license:
 
-Parts of the Crystal standard library use the following libraries, which have their own licenses:
+  * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) - [GPLv3]
 
-  * LLVM
-  * PCRE
-  * libevent2
-  * libiconv
-  * bdwgc
-  * [Zlib](http://www.zlib.net/)
-    - [Zlib](https://opensource.org/licenses/Zlib)
-  * [OpenSSL](https://www.openssl.org/)
-    - Apache License 1.0 and 4-clauses BSD
-  * [Libxml2](http://xmlsoft.org/)
-    - MIT
-  * [LibYAML](http://pyyaml.org/wiki/LibYAML)
-    - MIT
-  * [readline](https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html)
-    - GPLv3
-  * [GMP](https://gmplib.org/)
-    - LGPLv3
+Crystal standard library uses the following libraries, which have their own licenses:
 
-Crystal playground includes these libraries, which have their own licenses.
+  * [LLVM][] - [BSD-3, effectively][]
+  * [PCRE][] - [BSD-3][]
+  * [libevent2][] - [BSD-3][]
+  * [libiconv][] - [LGPLv3][]
+  * [bdwgc][] - [MIT][]
+  * [Zlib][] - [Zlib][Zlib-license]
+  * [OpenSSL][] - [Apache License v2.0](https://www.openssl.org/source/apache-license-2.0.txt)
+  * [Libxml2][] - [MIT][]
+  * [LibYAML][] - [MIT][]
+  * [readline](https://tiswww.case.edu/php/chet/readline/rltop.html) - [GPLv3][]
+  * [GMP](https://gmplib.org/) - [LGPLv3][]
+
+Crystal playground includes the following libraries, which have their own licenses.
 (There are these files under [/src/compiler/crystal/tools/playground/public/vendor](/src/compiler/crystal/tools/playground/public/vendor)):
 
-   * [jQuery](https://jquery.com/)
-     - MIT
-     - `Copyright JS Foundation and other contributors, https://js.foundation/`
-   * [Octicons](https://octicons.github.com/)
-     - MIT (for codes) or [OFL-1.1](https://opensource.org/licenses/OFL-1.1) (for fonts)
-     - `(c) 2012-2016 GitHub, Inc.`
-   * [Materialize](http://materializecss.com/)
-     - MIT
-     - `Copyright (c) 2014-2016 Materialize`
-   * [CodeMirror](https://codemirror.net/)
-     - MIT
-     - `Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others`
-   * [ansi\_up](https://github.com/drudru/ansi\_up)
-     - MIT
-     - `Copyright (c) 2011 Dru Nelson`
+   * [jQuery](https://jquery.com/) - [MIT][]
+     `Copyright JS Foundation and other contributors, https://js.foundation/`
+   * [Octicons](https://octicons.github.com/) - [MIT][] (for codes) or [OFL-1.1][] (for fonts) `(c) 2012-2016 GitHub, Inc.`
+   * [Materialize](http://materializecss.com/) - [MIT][] `Copyright (c) 2014-2015 Materialize`
+   * [CodeMirror](https://codemirror.net/) - [MIT][] `Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others`
+   * [ansi\_up](https://github.com/drudru/ansi\_up) - [MIT][] `Copyright (c) 2011 Dru Nelson`
+
+<!-- licenses -->
+[BSD-3]: https://opensource.org/licenses/BSD-3-Clause
+[BSD-3, effectively]: http://releases.llvm.org/2.8/LICENSE.TXT
+[GPLv3]: https://www.gnu.org/licenses/gpl-3.0.en.html
+[LGPLv3]: https://www.gnu.org/licenses/lgpl-3.0.en.html
+[MIT]: https://opensource.org/licenses/MIT
+[OFL-1.1]: https://opensource.org/licenses/OFL-1.1
+[Zlib-license]: https://opensource.org/licenses/Zlib
+<!-- libraries -->
+[bdwgc]: http://www.hboehm.info/gc/
+[libevent2]: http://libevent.org/
+[libiconv]: https://www.gnu.org/software/libiconv/
+[Libxml2]: http://xmlsoft.org/
+[LibYAML]: http://pyyaml.org/wiki/LibYAML
+[LLVM]: http://llvm.org/
+[OpenSSL]: https://www.openssl.org/
+[PCRE]: http://pcre.org/
+[Zlib]: http://www.zlib.net/


### PR DESCRIPTION
See [Applying the Apache License](http://www.apache.org/dev/apply-license.html), section "Applying the license to new software". It says:

> To apply the ALv2 to a new software distribution, include one copy of the license text by copying the file:
>
> http://www.apache.org/licenses/LICENSE-2.0.txt
> 
> into a file called LICENSE in the top directory of your distribution. If the distribution is a jar or tar file, try to add the LICENSE file first in order to place it at the top of the archive. This covers the collective licensing for the distribution.

So I update `LICENSE` to Apache License 2.0 content. (Old `LICENSE` is the content of Apache License 2.0's Appendix, which is for file header. This contains the phrase "this file". We can  understand Apache 2.0 is applied to only `LICENSE` file, not project. It is ambiguous, I think.)

Also I added `Runtime Library Exception to the Apache 2.0 License` section to `LICENSE`, because Apache License 2.0 effects the binary using the library. In short, when we distribute the binary using  Crystal standard library, we must contains the copy of Apache License 2.0 and copyright of Crystal. I think it is confusing and not so important.

Finally, I added `NOTICE` file, which explains licenses of the libraries used by Crystal. I think such a file creation is responsibility of the library user, and Crystal repository contains some JS/CSS library. We should explain about them, especially Octicons files didn't include copyright information.

- - -

And bonus point, GitHub will detect our project's license if this pull request is merged, like:

![2017-01-16 20 34 56](https://cloud.githubusercontent.com/assets/6679325/21981542/484d4e90-dc2b-11e6-864b-d51ddb4e3da7.png)

I wish you don't think this pull request is blah.

I want you to add Apache License 2.0 header to all source codes in this repository, but this change is too large, so I couldn't decide apply it.

References:

  - [Swift's LICENSE](https://github.com/apple/swift/blob/master/LICENSE.txt) I was heavily inspired `Runtime Library Exception to the Apache 2.0 License` by this.
  - [Julia's LICENSE](https://github.com/JuliaLang/julia/blob/master/LICENSE.md)
  - [Apache Software Foundation's repositories](https://github.com/apache)

Thanks!