### PR TITLE
Missing !dbg locations in generated LLVM IR

### DIFF
--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -425,7 +425,7 @@ module Crystal
                 end
               end
             else
-              comp = case_when_comparison(TupleLiteral.new(temp_vars.not_nil!.clone), cond)
+              comp = case_when_comparison(TupleLiteral.new(temp_vars.not_nil!.clone), cond).at(cond)
             end
           else
             temp_var = temp_vars.try &.first
@@ -638,7 +638,7 @@ module Crystal
         end
       end
 
-      Call.new(cond, "===", right_side).at(obj)
+      Call.new(cond, "===", right_side)
     end
 
     macro check_implicit_obj(type)

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -69,7 +69,7 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
       if type.lookup_instance_var?(var.name)
         node.raise "struct #{included_type} has a field named '#{field_name}', which #{type} already defines"
       end
-      declare_c_struct_or_union_field type, field_name, var
+      declare_c_struct_or_union_field(type, field_name, var, var.location || node.location)
     end
   end
 
@@ -189,12 +189,12 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     end
     ivar = MetaTypeVar.new(var_name, field_type)
     ivar.owner = type
-    declare_c_struct_or_union_field type, field_name, ivar
+    declare_c_struct_or_union_field(type, field_name, ivar, node.location)
   end
 
-  def declare_c_struct_or_union_field(type, field_name, var)
+  def declare_c_struct_or_union_field(type, field_name, var, location)
     type.instance_vars[var.name] = var
-    type.add_def Def.new("#{field_name}=", [Arg.new("value")], Primitive.new("struct_or_union_set"))
+    type.add_def Def.new("#{field_name}=", [Arg.new("value")], Primitive.new("struct_or_union_set").at(location))
     type.add_def Def.new(field_name, body: InstanceVar.new(var.name))
   end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -138,6 +138,10 @@ module Crystal
       @expressions.last
     end
 
+    def location
+      @location || @expressions.first?.try &.location
+    end
+
     def end_location
       @end_location || @expressions.last?.try &.end_location
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1594,7 +1594,7 @@ module Crystal
 
       unexpected_token "(" if @token.type == :"("
 
-      node = Expressions.new exps
+      node = Expressions.new(exps)
       node.keyword = :"("
       node
     end
@@ -3186,7 +3186,7 @@ module Crystal
             else
               exps.push body
             end
-            body = Expressions.from exps
+            body = Expressions.from(exps)
           end
           body, end_location = parse_exception_handler body, implicit: true
         end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1780,7 +1780,7 @@ module Crystal
             value.is_a?(String) ? StringLiteral.new(value) : value
           end
         end
-        result = StringInterpolation.new(pieces)
+        result = StringInterpolation.new(pieces).at(location)
       else
         if needs_heredoc_indent_removed?(delimiter_state)
           pieces = remove_heredoc_indent(pieces, delimiter_state.heredoc_indent)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2310,6 +2310,7 @@ module Crystal
         when :IDENT
           case @token.value
           when :when
+            location = @token.location
             slash_is_regex!
             next_token_skip_space_or_newline
             when_conds = [] of ASTNode
@@ -2337,7 +2338,7 @@ module Crystal
                     raise "wrong number of tuple elements (given #{tuple_elements.size}, expected #{cond.elements.size})", curly_location
                   end
 
-                  tuple = TupleLiteral.new(tuple_elements)
+                  tuple = TupleLiteral.new(tuple_elements).at(curly_location)
                   when_conds << tuple
 
                   check :"}"
@@ -2360,7 +2361,7 @@ module Crystal
             slash_is_regex!
             when_body = parse_expressions
             skip_space_or_newline
-            whens << When.new(when_conds, when_body)
+            whens << When.new(when_conds, when_body).at(location)
           when :else
             if whens.size == 0
               unexpected_token @token.to_s, "expecting when"


### PR DESCRIPTION
This allows to compile the Crystal compiler itself using Crystal 0.20.4 with the default debug configuration (always generate line numbers) against LLVM 3.9, which requires a `!dbg` location to be defined for every inlinable calls (among other cases).

I separated each commit, so each correction can be reviewed more easily.

fixes #3890