### PR TITLE
Added Int32 and Float32 to JSON::Type

### DIFF
--- a/src/json.cr
+++ b/src/json.cr
@@ -54,7 +54,7 @@ module JSON
   end
 
   # All valid JSON types
-  alias Type = Nil | Bool | Int64 | Float64 | String | Array(Type) | Hash(String, Type)
+  alias Type = Nil | Bool | Int32 | Int64 | Float32 | Float64 | String | Array(Type) | Hash(String, Type)
 
   # Parses a JSON document as a `JSON::Any`.
   def self.parse(input : String | IO) : Any


### PR DESCRIPTION
Added Int32 and Float32 types to JSON::Type.

I am working on implementing JSON type field for `crystal-mysql` and faced a problem that type checking fails then it gets Int32 or Float32 values even if normal `to_json` works perfectly fine.