### PR TITLE
Fix example for NamedTuple.from

### DIFF
--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -46,7 +46,7 @@ struct NamedTuple
   # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # => {name: "number", val: 42}
   #
   # num_or_str = "a string"
-  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # =>  can't cast String to Int32
+  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # => can't cast String to Int32
   # ```
   # See also: `#from`.
   def self.from(hash : Hash)

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -38,13 +38,16 @@ struct NamedTuple
   end
 
   # Creates a named tuple from the given hash, with elements casted to the given types.
+  # Here the Int32 | String union is cast to Int32.
   #
   # ```
-  # NamedTuple(foo: String, bar: Int64).from({:foo => "world", :bar => 2})       # => {foo: "world", bar: 2}
-  # NamedTuple(foo: String, bar: Int64).from({"foo" => "world", "bar" => 2})     # => {foo: "world", bar: 2}
-  # NamedTuple(foo: String, bar: Int64).from({:foo => "world", :bar => 2}).class # => {foo: String, bar: Int64}
-  # ```
+  # num_or_str : Int32 | String
+  # num_or_str = 42
+  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # => {name: "number", val: 42}
   #
+  # num_or_str = "a string"
+  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # =>  can't cast String to Int32
+  # ```
   # See also: `#from`.
   def self.from(hash : Hash)
     {% begin %}

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -41,12 +41,11 @@ struct NamedTuple
   # Here the Int32 | String union is cast to Int32.
   #
   # ```
-  # num_or_str : Int32 | String
-  # num_or_str = 42
+  # num_or_str = 42.as(Int32 | String)
   # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # => {name: "number", val: 42}
   #
-  # num_or_str = "a string"
-  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # => can't cast String to Int32
+  # num_or_str = "a string".as(Int32 | String)
+  # NamedTuple(name: String, val: Int32).from({"name" => "number", "val" => num_or_str}) # raises TypeCastError (cast from String to Int32 failed)
   # ```
   # See also: `#from`.
   def self.from(hash : Hash)


### PR DESCRIPTION
This is a fix to the NamedTuple.from example which should close #3792 