### PR TITLE
Remove reduntant “?” from type definitions in bang accessors!

### DIFF
--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -6,7 +6,7 @@ require "./type_lookup"
 class Crystal::Call
   property! scope : Type
   property with_scope : Type?
-  property! parent_visitor : MainVisitor?
+  property! parent_visitor : MainVisitor
   property target_defs : Array(Def)?
   property expanded : ASTNode?
   property? uses_with_scope = false

--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -51,7 +51,7 @@ module Crystal
 
     alias RowTypes = Array(Cell) | Separator
 
-    property! last_string_row : Array(Cell)?
+    property! last_string_row : Array(Cell)
     property columns : Array(Column)
 
     def initialize(@io : IO)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -83,7 +83,7 @@ class HTTP::Client
   {% if flag?(:without_openssl) %}
     getter! tls : Nil
   {% else %}
-    getter! tls : OpenSSL::SSL::Context::Client?
+    getter! tls : OpenSSL::SSL::Context::Client
   {% end %}
 
   # Whether automatic compression/decompression is enabled.

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -56,7 +56,7 @@ require "./openssl/lib_ssl"
 # ```
 module OpenSSL
   class Error < Exception
-    getter! code : LibCrypto::ULong?
+    getter! code : LibCrypto::ULong
 
     def initialize(message = nil, fetched = false)
       @code ||= LibCrypto::ULong.new(0)


### PR DESCRIPTION
This PR removes redundant nilable `?` symbol from `getter/setter/accessor!` type declarations throughout the code since [they're added in macro definition](https://github.com/crystal-lang/crystal/blob/d1f8c42f82d3e6491cb7b3b536984c19a51b94ba/src/object.cr#L398) already.