### PR TITLE
Removes `assert do ... end`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -686,7 +686,7 @@ describe "Array" do
   end
 
   describe "inspect" do
-    assert { [1, 2, 3].inspect.should eq("[1, 2, 3]") }
+    it { [1, 2, 3].inspect.should eq("[1, 2, 3]") }
   end
 
   describe "last" do
@@ -1089,7 +1089,7 @@ describe "Array" do
 
   describe "to_s" do
     it "does to_s" do
-      assert { [1, 2, 3].to_s.should eq("[1, 2, 3]") }
+      it { [1, 2, 3].to_s.should eq("[1, 2, 3]") }
     end
 
     it "does with recursive" do
@@ -1444,34 +1444,34 @@ describe "Array" do
       a.rotate.should eq([2, 3, 1])
     end
 
-    assert { a = [1, 2, 3]; a.rotate!(0); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate!(1); a.should eq([2, 3, 1]) }
-    assert { a = [1, 2, 3]; a.rotate!(2); a.should eq([3, 1, 2]) }
-    assert { a = [1, 2, 3]; a.rotate!(3); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate!(4); a.should eq([2, 3, 1]) }
-    assert { a = [1, 2, 3]; a.rotate!(3001); a.should eq([2, 3, 1]) }
-    assert { a = [1, 2, 3]; a.rotate!(-1); a.should eq([3, 1, 2]) }
-    assert { a = [1, 2, 3]; a.rotate!(-3001); a.should eq([3, 1, 2]) }
+    it { a = [1, 2, 3]; a.rotate!(0); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate!(1); a.should eq([2, 3, 1]) }
+    it { a = [1, 2, 3]; a.rotate!(2); a.should eq([3, 1, 2]) }
+    it { a = [1, 2, 3]; a.rotate!(3); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate!(4); a.should eq([2, 3, 1]) }
+    it { a = [1, 2, 3]; a.rotate!(3001); a.should eq([2, 3, 1]) }
+    it { a = [1, 2, 3]; a.rotate!(-1); a.should eq([3, 1, 2]) }
+    it { a = [1, 2, 3]; a.rotate!(-3001); a.should eq([3, 1, 2]) }
 
-    assert { a = [1, 2, 3]; a.rotate(0).should eq([1, 2, 3]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(1).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(2).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(3).should eq([1, 2, 3]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(4).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(3001).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(-1).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
-    assert { a = [1, 2, 3]; a.rotate(-3001).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(0).should eq([1, 2, 3]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(1).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(2).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(3).should eq([1, 2, 3]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(4).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(3001).should eq([2, 3, 1]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(-1).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
+    it { a = [1, 2, 3]; a.rotate(-3001).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
   end
 
   describe "permutations" do
-    assert { [1, 2, 2].permutations.should eq([[1, 2, 2], [1, 2, 2], [2, 1, 2], [2, 2, 1], [2, 1, 2], [2, 2, 1]]) }
-    assert { [1, 2, 3].permutations.should eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]) }
-    assert { [1, 2, 3].permutations(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].permutations(2).should eq([[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]) }
-    assert { [1, 2, 3].permutations(3).should eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]) }
-    assert { [1, 2, 3].permutations(0).should eq([[] of Int32]) }
-    assert { [1, 2, 3].permutations(4).should eq([] of Array(Int32)) }
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].permutations(-1) } }
+    it { [1, 2, 2].permutations.should eq([[1, 2, 2], [1, 2, 2], [2, 1, 2], [2, 2, 1], [2, 1, 2], [2, 2, 1]]) }
+    it { [1, 2, 3].permutations.should eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]) }
+    it { [1, 2, 3].permutations(1).should eq([[1], [2], [3]]) }
+    it { [1, 2, 3].permutations(2).should eq([[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]) }
+    it { [1, 2, 3].permutations(3).should eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]) }
+    it { [1, 2, 3].permutations(0).should eq([[] of Int32]) }
+    it { [1, 2, 3].permutations(4).should eq([] of Array(Int32)) }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].permutations(-1) } }
 
     it "accepts a block" do
       sums = [] of Int32
@@ -1502,7 +1502,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].each_permutation(-1) { } } }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].each_permutation(-1) { } } }
 
     it "returns iterator" do
       a = [1, 2, 3]
@@ -1546,16 +1546,16 @@ describe "Array" do
   end
 
   describe "combinations" do
-    assert { [1, 2, 2].combinations.should eq([[1, 2, 2]]) }
-    assert { [1, 2, 3].combinations.should eq([[1, 2, 3]]) }
-    assert { [1, 2, 3].combinations(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].combinations(2).should eq([[1, 2], [1, 3], [2, 3]]) }
-    assert { [1, 2, 3].combinations(3).should eq([[1, 2, 3]]) }
-    assert { [1, 2, 3].combinations(0).should eq([[] of Int32]) }
-    assert { [1, 2, 3].combinations(4).should eq([] of Array(Int32)) }
-    assert { [1, 2, 3, 4].combinations(3).should eq([[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]) }
-    assert { [1, 2, 3, 4].combinations(2).should eq([[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]) }
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].combinations(-1) } }
+    it { [1, 2, 2].combinations.should eq([[1, 2, 2]]) }
+    it { [1, 2, 3].combinations.should eq([[1, 2, 3]]) }
+    it { [1, 2, 3].combinations(1).should eq([[1], [2], [3]]) }
+    it { [1, 2, 3].combinations(2).should eq([[1, 2], [1, 3], [2, 3]]) }
+    it { [1, 2, 3].combinations(3).should eq([[1, 2, 3]]) }
+    it { [1, 2, 3].combinations(0).should eq([[] of Int32]) }
+    it { [1, 2, 3].combinations(4).should eq([] of Array(Int32)) }
+    it { [1, 2, 3, 4].combinations(3).should eq([[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]) }
+    it { [1, 2, 3, 4].combinations(2).should eq([[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]) }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].combinations(-1) } }
 
     it "accepts a block" do
       sums = [] of Int32
@@ -1595,7 +1595,7 @@ describe "Array" do
       sums.should eq([3, 4, 5])
     end
 
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].each_combination(-1) { } } }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].each_combination(-1) { } } }
 
     it "returns iterator" do
       a = [1, 2, 3, 4]
@@ -1639,14 +1639,14 @@ describe "Array" do
   end
 
   describe "repeated_combinations" do
-    assert { [1, 2, 2].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2], [1, 2, 2], [1, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2]]) }
-    assert { [1, 2, 3].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], [1, 3, 3], [2, 2, 2], [2, 2, 3], [2, 3, 3], [3, 3, 3]]) }
-    assert { [1, 2, 3].repeated_combinations(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].repeated_combinations(2).should eq([[1, 1], [1, 2], [1, 3], [2, 2], [2, 3], [3, 3]]) }
-    assert { [1, 2, 3].repeated_combinations(3).should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], [1, 3, 3], [2, 2, 2], [2, 2, 3], [2, 3, 3], [3, 3, 3]]) }
-    assert { [1, 2, 3].repeated_combinations(0).should eq([[] of Int32]) }
-    assert { [1, 2, 3].repeated_combinations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 3], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 3], [1, 3, 3, 3], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 3], [2, 3, 3, 3], [3, 3, 3, 3]]) }
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].repeated_combinations(-1) } }
+    it { [1, 2, 2].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2], [1, 2, 2], [1, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2]]) }
+    it { [1, 2, 3].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], [1, 3, 3], [2, 2, 2], [2, 2, 3], [2, 3, 3], [3, 3, 3]]) }
+    it { [1, 2, 3].repeated_combinations(1).should eq([[1], [2], [3]]) }
+    it { [1, 2, 3].repeated_combinations(2).should eq([[1, 1], [1, 2], [1, 3], [2, 2], [2, 3], [3, 3]]) }
+    it { [1, 2, 3].repeated_combinations(3).should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], [1, 3, 3], [2, 2, 2], [2, 2, 3], [2, 3, 3], [3, 3, 3]]) }
+    it { [1, 2, 3].repeated_combinations(0).should eq([[] of Int32]) }
+    it { [1, 2, 3].repeated_combinations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 3], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 3], [1, 3, 3, 3], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 3], [2, 3, 3, 3], [3, 3, 3, 3]]) }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].repeated_combinations(-1) } }
 
     it "accepts a block" do
       sums = [] of Int32
@@ -1665,7 +1665,7 @@ describe "Array" do
       sums.should eq([6, 7, 8, 8, 9, 10, 9, 10, 11, 12])
     end
 
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].each_repeated_combination(-1) { } } }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].each_repeated_combination(-1) { } } }
 
     it "yields with reuse = true" do
       sums = [] of Int32
@@ -1732,14 +1732,14 @@ describe "Array" do
   end
 
   describe "repeated_permutations" do
-    assert { [1, 2, 2].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2]]) }
-    assert { [1, 2, 3].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 1], [1, 2, 2], [1, 2, 3], [1, 3, 1], [1, 3, 2], [1, 3, 3], [2, 1, 1], [2, 1, 2], [2, 1, 3], [2, 2, 1], [2, 2, 2], [2, 2, 3], [2, 3, 1], [2, 3, 2], [2, 3, 3], [3, 1, 1], [3, 1, 2], [3, 1, 3], [3, 2, 1], [3, 2, 2], [3, 2, 3], [3, 3, 1], [3, 3, 2], [3, 3, 3]]) }
-    assert { [1, 2, 3].repeated_permutations(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].repeated_permutations(2).should eq([[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]]) }
-    assert { [1, 2, 3].repeated_permutations(3).should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 1], [1, 2, 2], [1, 2, 3], [1, 3, 1], [1, 3, 2], [1, 3, 3], [2, 1, 1], [2, 1, 2], [2, 1, 3], [2, 2, 1], [2, 2, 2], [2, 2, 3], [2, 3, 1], [2, 3, 2], [2, 3, 3], [3, 1, 1], [3, 1, 2], [3, 1, 3], [3, 2, 1], [3, 2, 2], [3, 2, 3], [3, 3, 1], [3, 3, 2], [3, 3, 3]]) }
-    assert { [1, 2, 3].repeated_permutations(0).should eq([[] of Int32]) }
-    assert { [1, 2, 3].repeated_permutations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 1], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 1], [1, 1, 3, 2], [1, 1, 3, 3], [1, 2, 1, 1], [1, 2, 1, 2], [1, 2, 1, 3], [1, 2, 2, 1], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 1], [1, 2, 3, 2], [1, 2, 3, 3], [1, 3, 1, 1], [1, 3, 1, 2], [1, 3, 1, 3], [1, 3, 2, 1], [1, 3, 2, 2], [1, 3, 2, 3], [1, 3, 3, 1], [1, 3, 3, 2], [1, 3, 3, 3], [2, 1, 1, 1], [2, 1, 1, 2], [2, 1, 1, 3], [2, 1, 2, 1], [2, 1, 2, 2], [2, 1, 2, 3], [2, 1, 3, 1], [2, 1, 3, 2], [2, 1, 3, 3], [2, 2, 1, 1], [2, 2, 1, 2], [2, 2, 1, 3], [2, 2, 2, 1], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 1], [2, 2, 3, 2], [2, 2, 3, 3], [2, 3, 1, 1], [2, 3, 1, 2], [2, 3, 1, 3], [2, 3, 2, 1], [2, 3, 2, 2], [2, 3, 2, 3], [2, 3, 3, 1], [2, 3, 3, 2], [2, 3, 3, 3], [3, 1, 1, 1], [3, 1, 1, 2], [3, 1, 1, 3], [3, 1, 2, 1], [3, 1, 2, 2], [3, 1, 2, 3], [3, 1, 3, 1], [3, 1, 3, 2], [3, 1, 3, 3], [3, 2, 1, 1], [3, 2, 1, 2], [3, 2, 1, 3], [3, 2, 2, 1], [3, 2, 2, 2], [3, 2, 2, 3], [3, 2, 3, 1], [3, 2, 3, 2], [3, 2, 3, 3], [3, 3, 1, 1], [3, 3, 1, 2], [3, 3, 1, 3], [3, 3, 2, 1], [3, 3, 2, 2], [3, 3, 2, 3], [3, 3, 3, 1], [3, 3, 3, 2], [3, 3, 3, 3]]) }
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].repeated_permutations(-1) } }
+    it { [1, 2, 2].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2]]) }
+    it { [1, 2, 3].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 1], [1, 2, 2], [1, 2, 3], [1, 3, 1], [1, 3, 2], [1, 3, 3], [2, 1, 1], [2, 1, 2], [2, 1, 3], [2, 2, 1], [2, 2, 2], [2, 2, 3], [2, 3, 1], [2, 3, 2], [2, 3, 3], [3, 1, 1], [3, 1, 2], [3, 1, 3], [3, 2, 1], [3, 2, 2], [3, 2, 3], [3, 3, 1], [3, 3, 2], [3, 3, 3]]) }
+    it { [1, 2, 3].repeated_permutations(1).should eq([[1], [2], [3]]) }
+    it { [1, 2, 3].repeated_permutations(2).should eq([[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]]) }
+    it { [1, 2, 3].repeated_permutations(3).should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 1], [1, 2, 2], [1, 2, 3], [1, 3, 1], [1, 3, 2], [1, 3, 3], [2, 1, 1], [2, 1, 2], [2, 1, 3], [2, 2, 1], [2, 2, 2], [2, 2, 3], [2, 3, 1], [2, 3, 2], [2, 3, 3], [3, 1, 1], [3, 1, 2], [3, 1, 3], [3, 2, 1], [3, 2, 2], [3, 2, 3], [3, 3, 1], [3, 3, 2], [3, 3, 3]]) }
+    it { [1, 2, 3].repeated_permutations(0).should eq([[] of Int32]) }
+    it { [1, 2, 3].repeated_permutations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 1], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 1], [1, 1, 3, 2], [1, 1, 3, 3], [1, 2, 1, 1], [1, 2, 1, 2], [1, 2, 1, 3], [1, 2, 2, 1], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 1], [1, 2, 3, 2], [1, 2, 3, 3], [1, 3, 1, 1], [1, 3, 1, 2], [1, 3, 1, 3], [1, 3, 2, 1], [1, 3, 2, 2], [1, 3, 2, 3], [1, 3, 3, 1], [1, 3, 3, 2], [1, 3, 3, 3], [2, 1, 1, 1], [2, 1, 1, 2], [2, 1, 1, 3], [2, 1, 2, 1], [2, 1, 2, 2], [2, 1, 2, 3], [2, 1, 3, 1], [2, 1, 3, 2], [2, 1, 3, 3], [2, 2, 1, 1], [2, 2, 1, 2], [2, 2, 1, 3], [2, 2, 2, 1], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 1], [2, 2, 3, 2], [2, 2, 3, 3], [2, 3, 1, 1], [2, 3, 1, 2], [2, 3, 1, 3], [2, 3, 2, 1], [2, 3, 2, 2], [2, 3, 2, 3], [2, 3, 3, 1], [2, 3, 3, 2], [2, 3, 3, 3], [3, 1, 1, 1], [3, 1, 1, 2], [3, 1, 1, 3], [3, 1, 2, 1], [3, 1, 2, 2], [3, 1, 2, 3], [3, 1, 3, 1], [3, 1, 3, 2], [3, 1, 3, 3], [3, 2, 1, 1], [3, 2, 1, 2], [3, 2, 1, 3], [3, 2, 2, 1], [3, 2, 2, 2], [3, 2, 2, 3], [3, 2, 3, 1], [3, 2, 3, 2], [3, 2, 3, 3], [3, 3, 1, 1], [3, 3, 1, 2], [3, 3, 1, 3], [3, 3, 2, 1], [3, 3, 2, 2], [3, 3, 2, 3], [3, 3, 3, 1], [3, 3, 3, 2], [3, 3, 3, 3]]) }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].repeated_permutations(-1) } }
 
     it "accepts a block" do
       sums = [] of Int32
@@ -1781,7 +1781,7 @@ describe "Array" do
       sums.should eq([6, 7, 8, 7, 8, 9, 8, 9, 10, 7, 8, 9, 8, 9, 10, 9, 10, 11, 8, 9, 10, 9, 10, 11, 10, 11, 12])
     end
 
-    assert { expect_raises(ArgumentError, "size must be positive") { [1].each_repeated_permutation(-1) { } } }
+    it { expect_raises(ArgumentError, "size must be positive") { [1].each_repeated_permutation(-1) { } } }
   end
 
   describe "Array.each_product" do

--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -68,24 +68,24 @@ private def h_mean(mean)
 end
 
 describe Benchmark::IPS::Entry, "#human_mean" do
-  assert { h_mean(0.01234567890123).should eq("  0.01 ") }
-  assert { h_mean(0.12345678901234).should eq("  0.12 ") }
+  it { h_mean(0.01234567890123).should eq("  0.01 ") }
+  it { h_mean(0.12345678901234).should eq("  0.12 ") }
 
-  assert { h_mean(1.23456789012345).should eq("  1.23 ") }
-  assert { h_mean(12.3456789012345).should eq(" 12.35 ") }
-  assert { h_mean(123.456789012345).should eq("123.46 ") }
+  it { h_mean(1.23456789012345).should eq("  1.23 ") }
+  it { h_mean(12.3456789012345).should eq(" 12.35 ") }
+  it { h_mean(123.456789012345).should eq("123.46 ") }
 
-  assert { h_mean(1234.56789012345).should eq("  1.23k") }
-  assert { h_mean(12345.6789012345).should eq(" 12.35k") }
-  assert { h_mean(123456.789012345).should eq("123.46k") }
+  it { h_mean(1234.56789012345).should eq("  1.23k") }
+  it { h_mean(12345.6789012345).should eq(" 12.35k") }
+  it { h_mean(123456.789012345).should eq("123.46k") }
 
-  assert { h_mean(1234567.89012345).should eq("  1.23M") }
-  assert { h_mean(12345678.9012345).should eq(" 12.35M") }
-  assert { h_mean(123456789.012345).should eq("123.46M") }
+  it { h_mean(1234567.89012345).should eq("  1.23M") }
+  it { h_mean(12345678.9012345).should eq(" 12.35M") }
+  it { h_mean(123456789.012345).should eq("123.46M") }
 
-  assert { h_mean(1234567890.12345).should eq("  1.23G") }
-  assert { h_mean(12345678901.2345).should eq(" 12.35G") }
-  assert { h_mean(123456789012.345).should eq("123.46G") }
+  it { h_mean(1234567890.12345).should eq("  1.23G") }
+  it { h_mean(12345678901.2345).should eq(" 12.35G") }
+  it { h_mean(123456789012.345).should eq("123.46G") }
 end
 
 private def h_ips(seconds)
@@ -94,21 +94,21 @@ private def h_ips(seconds)
 end
 
 describe Benchmark::IPS::Entry, "#human_iteration_time" do
-  assert { h_ips(1234.567_890_123).should eq("1234.57s ") }
-  assert { h_ips(123.456_789_012_3).should eq("123.46s ") }
-  assert { h_ips(12.345_678_901_23).should eq(" 12.35s ") }
-  assert { h_ips(1.234_567_890_123).should eq("  1.23s ") }
+  it { h_ips(1234.567_890_123).should eq("1234.57s ") }
+  it { h_ips(123.456_789_012_3).should eq("123.46s ") }
+  it { h_ips(12.345_678_901_23).should eq(" 12.35s ") }
+  it { h_ips(1.234_567_890_123).should eq("  1.23s ") }
 
-  assert { h_ips(0.123_456_789_012).should eq("123.46ms") }
-  assert { h_ips(0.012_345_678_901).should eq(" 12.35ms") }
-  assert { h_ips(0.001_234_567_890).should eq("  1.23ms") }
+  it { h_ips(0.123_456_789_012).should eq("123.46ms") }
+  it { h_ips(0.012_345_678_901).should eq(" 12.35ms") }
+  it { h_ips(0.001_234_567_890).should eq("  1.23ms") }
 
-  assert { h_ips(0.000_123_456_789).should eq("123.46µs") }
-  assert { h_ips(0.000_012_345_678).should eq(" 12.35µs") }
-  assert { h_ips(0.000_001_234_567).should eq("  1.23µs") }
+  it { h_ips(0.000_123_456_789).should eq("123.46µs") }
+  it { h_ips(0.000_012_345_678).should eq(" 12.35µs") }
+  it { h_ips(0.000_001_234_567).should eq("  1.23µs") }
 
-  assert { h_ips(0.000_000_123_456).should eq("123.46ns") }
-  assert { h_ips(0.000_000_012_345).should eq(" 12.35ns") }
-  assert { h_ips(0.000_000_001_234).should eq("  1.23ns") }
-  assert { h_ips(0.000_000_000_123).should eq("  0.12ns") }
+  it { h_ips(0.000_000_123_456).should eq("123.46ns") }
+  it { h_ips(0.000_000_012_345).should eq(" 12.35ns") }
+  it { h_ips(0.000_000_001_234).should eq("  1.23ns") }
+  it { h_ips(0.000_000_000_123).should eq("  0.12ns") }
 end

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -4,94 +4,94 @@ require "big_float"
 describe "BigFloat" do
   describe "-@" do
     bf = "0.12345".to_big_f
-    assert { (-bf).to_s.should eq("-0.12345") }
+    it { (-bf).to_s.should eq("-0.12345") }
 
     bf = "61397953.0005354".to_big_f
-    assert { (-bf).to_s.should eq("-61397953.0005354") }
+    it { (-bf).to_s.should eq("-61397953.0005354") }
 
     bf = "395.009631567315769036".to_big_f
-    assert { (-bf).to_s.should eq("-395.009631567315769036") }
+    it { (-bf).to_s.should eq("-395.009631567315769036") }
   end
 
   describe "+" do
-    assert { ("1.0".to_big_f + "2.0".to_big_f).to_s.should eq("3") }
-    assert { ("0.04".to_big_f + "89.0001".to_big_f).to_s.should eq("89.0401") }
-    assert { ("-5.5".to_big_f + "5.5".to_big_f).to_s.should eq("0") }
-    assert { ("5.5".to_big_f + "-5.5".to_big_f).to_s.should eq("0") }
+    it { ("1.0".to_big_f + "2.0".to_big_f).to_s.should eq("3") }
+    it { ("0.04".to_big_f + "89.0001".to_big_f).to_s.should eq("89.0401") }
+    it { ("-5.5".to_big_f + "5.5".to_big_f).to_s.should eq("0") }
+    it { ("5.5".to_big_f + "-5.5".to_big_f).to_s.should eq("0") }
   end
 
   describe "-" do
-    assert { ("1.0".to_big_f - "2.0".to_big_f).to_s.should eq("-1") }
-    assert { ("0.04".to_big_f - "89.0001".to_big_f).to_s.should eq("-88.9601") }
-    assert { ("-5.5".to_big_f - "5.5".to_big_f).to_s.should eq("-11") }
-    assert { ("5.5".to_big_f - "-5.5".to_big_f).to_s.should eq("11") }
+    it { ("1.0".to_big_f - "2.0".to_big_f).to_s.should eq("-1") }
+    it { ("0.04".to_big_f - "89.0001".to_big_f).to_s.should eq("-88.9601") }
+    it { ("-5.5".to_big_f - "5.5".to_big_f).to_s.should eq("-11") }
+    it { ("5.5".to_big_f - "-5.5".to_big_f).to_s.should eq("11") }
   end
 
   describe "*" do
-    assert { ("1.0".to_big_f * "2.0".to_big_f).to_s.should eq("2") }
-    assert { ("0.04".to_big_f * "89.0001".to_big_f).to_s.should eq("3.560004") }
-    assert { ("-5.5".to_big_f * "5.5".to_big_f).to_s.should eq("-30.25") }
-    assert { ("5.5".to_big_f * "-5.5".to_big_f).to_s.should eq("-30.25") }
+    it { ("1.0".to_big_f * "2.0".to_big_f).to_s.should eq("2") }
+    it { ("0.04".to_big_f * "89.0001".to_big_f).to_s.should eq("3.560004") }
+    it { ("-5.5".to_big_f * "5.5".to_big_f).to_s.should eq("-30.25") }
+    it { ("5.5".to_big_f * "-5.5".to_big_f).to_s.should eq("-30.25") }
   end
 
   describe "/" do
-    assert { ("1.0".to_big_f / "2.0".to_big_f).to_s.should eq("0.5") }
-    assert { ("0.04".to_big_f / "89.0001".to_big_f).to_s.should eq("0.000449437697261014313467") }
-    assert { ("-5.5".to_big_f / "5.5".to_big_f).to_s.should eq("-1") }
-    assert { ("5.5".to_big_f / "-5.5".to_big_f).to_s.should eq("-1") }
+    it { ("1.0".to_big_f / "2.0".to_big_f).to_s.should eq("0.5") }
+    it { ("0.04".to_big_f / "89.0001".to_big_f).to_s.should eq("0.000449437697261014313467") }
+    it { ("-5.5".to_big_f / "5.5".to_big_f).to_s.should eq("-1") }
+    it { ("5.5".to_big_f / "-5.5".to_big_f).to_s.should eq("-1") }
     expect_raises(DivisionByZero) { 0.1.to_big_f / 0 }
   end
 
   describe "**" do
     # TODO: investigate why in travis this gives ""1.79559999999999999991"
-    # assert { ("1.34".to_big_f ** 2).to_s.should eq("1.79559999999999999994") }
-    assert { ("-0.05".to_big_f ** 10).to_s.should eq("0.00000000000009765625") }
-    assert { (0.1234567890.to_big_f ** 3).to_s.should eq("0.00188167637178915473909") }
+    # it { ("1.34".to_big_f ** 2).to_s.should eq("1.79559999999999999994") }
+    it { ("-0.05".to_big_f ** 10).to_s.should eq("0.00000000000009765625") }
+    it { (0.1234567890.to_big_f ** 3).to_s.should eq("0.00188167637178915473909") }
   end
 
   describe "abs" do
-    assert { -5.to_big_f.abs.should eq(5) }
-    assert { 5.to_big_f.abs.should eq(5) }
-    assert { "-0.00001".to_big_f.abs.to_s.should eq("0.00001") }
-    assert { "0.00000000001".to_big_f.abs.to_s.should eq("0.00000000001") }
+    it { -5.to_big_f.abs.should eq(5) }
+    it { 5.to_big_f.abs.should eq(5) }
+    it { "-0.00001".to_big_f.abs.to_s.should eq("0.00001") }
+    it { "0.00000000001".to_big_f.abs.to_s.should eq("0.00000000001") }
   end
 
   describe "ceil" do
-    assert { 2.0.to_big_f.ceil.should eq(2) }
-    assert { 2.1.to_big_f.ceil.should eq(3) }
-    assert { 2.9.to_big_f.ceil.should eq(3) }
+    it { 2.0.to_big_f.ceil.should eq(2) }
+    it { 2.1.to_big_f.ceil.should eq(3) }
+    it { 2.9.to_big_f.ceil.should eq(3) }
   end
 
   describe "floor" do
-    assert { 2.1.to_big_f.floor.should eq(2) }
-    assert { 2.9.to_big_f.floor.should eq(2) }
+    it { 2.1.to_big_f.floor.should eq(2) }
+    it { 2.9.to_big_f.floor.should eq(2) }
   end
 
   describe "to_f" do
-    assert { 1.34.to_big_f.to_f.should eq(1.34) }
-    assert { 0.0001304.to_big_f.to_f.should eq(0.0001304) }
-    assert { 1.234567.to_big_f.to_f32.should eq(1.234567_f32) }
+    it { 1.34.to_big_f.to_f.should eq(1.34) }
+    it { 0.0001304.to_big_f.to_f.should eq(0.0001304) }
+    it { 1.234567.to_big_f.to_f32.should eq(1.234567_f32) }
   end
 
   describe "to_i" do
-    assert { 1.34.to_big_f.to_i.should eq(1) }
-    assert { 123.to_big_f.to_i.should eq(123) }
-    assert { -4321.to_big_f.to_i.should eq(-4321) }
+    it { 1.34.to_big_f.to_i.should eq(1) }
+    it { 123.to_big_f.to_i.should eq(123) }
+    it { -4321.to_big_f.to_i.should eq(-4321) }
   end
 
   describe "to_u" do
-    assert { 1.34.to_big_f.to_u.should eq(1) }
-    assert { 123.to_big_f.to_u.should eq(123) }
-    assert { 4321.to_big_f.to_u.should eq(4321) }
+    it { 1.34.to_big_f.to_u.should eq(1) }
+    it { 123.to_big_f.to_u.should eq(123) }
+    it { 4321.to_big_f.to_u.should eq(4321) }
   end
 
   describe "to_s" do
-    assert { "0".to_big_f.to_s.should eq("0") }
-    assert { "0.000001".to_big_f.to_s.should eq("0.000001") }
-    assert { "48600000".to_big_f.to_s.should eq("48600000") }
-    assert { "12345678.87654321".to_big_f.to_s.should eq("12345678.87654321") }
-    assert { "9.000000000000987".to_big_f.to_s.should eq("9.000000000000987") }
-    assert { "12345678901234567".to_big_f.to_s.should eq("12345678901234567") }
+    it { "0".to_big_f.to_s.should eq("0") }
+    it { "0.000001".to_big_f.to_s.should eq("0.000001") }
+    it { "48600000".to_big_f.to_s.should eq("48600000") }
+    it { "12345678.87654321".to_big_f.to_s.should eq("12345678.87654321") }
+    it { "9.000000000000987".to_big_f.to_s.should eq("9.000000000000987") }
+    it { "12345678901234567".to_big_f.to_s.should eq("12345678901234567") }
   end
 
   it "#hash" do

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -2,43 +2,43 @@ require "spec"
 
 describe "Bool" do
   describe "!" do
-    assert { (!true).should be_false }
-    assert { (!false).should be_true }
+    it { (!true).should be_false }
+    it { (!false).should be_true }
   end
 
   describe "|" do
-    assert { (false | false).should be_false }
-    assert { (false | true).should be_true }
-    assert { (true | false).should be_true }
-    assert { (true | true).should be_true }
+    it { (false | false).should be_false }
+    it { (false | true).should be_true }
+    it { (true | false).should be_true }
+    it { (true | true).should be_true }
   end
 
   describe "&" do
-    assert { (false & false).should be_false }
-    assert { (false & true).should be_false }
-    assert { (true & false).should be_false }
-    assert { (true & true).should be_true }
+    it { (false & false).should be_false }
+    it { (false & true).should be_false }
+    it { (true & false).should be_false }
+    it { (true & true).should be_true }
   end
 
   describe "^" do
-    assert { (false ^ false).should be_false }
-    assert { (false ^ true).should be_true }
-    assert { (true ^ false).should be_true }
-    assert { (true ^ true).should be_false }
+    it { (false ^ false).should be_false }
+    it { (false ^ true).should be_true }
+    it { (true ^ false).should be_true }
+    it { (true ^ true).should be_false }
   end
 
   describe "hash" do
-    assert { true.hash.should eq(1) }
-    assert { false.hash.should eq(0) }
+    it { true.hash.should eq(1) }
+    it { false.hash.should eq(0) }
   end
 
   describe "to_s" do
-    assert { true.to_s.should eq("true") }
-    assert { false.to_s.should eq("false") }
+    it { true.to_s.should eq("true") }
+    it { false.to_s.should eq("false") }
   end
 
   describe "clone" do
-    assert { true.clone.should be_true }
-    assert { false.clone.should be_false }
+    it { true.clone.should be_true }
+    it { false.clone.should be_false }
   end
 end

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -2,100 +2,100 @@ require "spec"
 
 describe "Char" do
   describe "upcase" do
-    assert { 'a'.upcase.should eq('A') }
-    assert { '1'.upcase.should eq('1') }
+    it { 'a'.upcase.should eq('A') }
+    it { '1'.upcase.should eq('1') }
   end
 
   describe "downcase" do
-    assert { 'A'.downcase.should eq('a') }
-    assert { '1'.downcase.should eq('1') }
+    it { 'A'.downcase.should eq('a') }
+    it { '1'.downcase.should eq('1') }
   end
 
   describe "succ" do
-    assert { 'a'.succ.should eq('b') }
-    assert { 'あ'.succ.should eq('ぃ') }
+    it { 'a'.succ.should eq('b') }
+    it { 'あ'.succ.should eq('ぃ') }
   end
 
   describe "pred" do
-    assert { 'b'.pred.should eq('a') }
-    assert { 'ぃ'.pred.should eq('あ') }
+    it { 'b'.pred.should eq('a') }
+    it { 'ぃ'.pred.should eq('あ') }
   end
 
   describe "+" do
-    assert { ('a' + 2).should eq('c') }
+    it { ('a' + 2).should eq('c') }
   end
 
   describe "-" do
-    assert { ('c' - 2).should eq('a') }
+    it { ('c' - 2).should eq('a') }
   end
 
   describe "ascii_uppercase?" do
-    assert { 'a'.ascii_uppercase?.should be_false }
-    assert { 'A'.ascii_uppercase?.should be_true }
-    assert { '1'.ascii_uppercase?.should be_false }
-    assert { ' '.ascii_uppercase?.should be_false }
+    it { 'a'.ascii_uppercase?.should be_false }
+    it { 'A'.ascii_uppercase?.should be_true }
+    it { '1'.ascii_uppercase?.should be_false }
+    it { ' '.ascii_uppercase?.should be_false }
   end
 
   describe "uppercase?" do
-    assert { 'A'.uppercase?.should be_true }
-    assert { 'Á'.uppercase?.should be_true }
-    assert { 'Ā'.uppercase?.should be_true }
-    assert { 'Ą'.uppercase?.should be_true }
-    assert { 'ā'.uppercase?.should be_false }
-    assert { 'á'.uppercase?.should be_false }
-    assert { 'a'.uppercase?.should be_false }
-    assert { '1'.uppercase?.should be_false }
-    assert { ' '.uppercase?.should be_false }
+    it { 'A'.uppercase?.should be_true }
+    it { 'Á'.uppercase?.should be_true }
+    it { 'Ā'.uppercase?.should be_true }
+    it { 'Ą'.uppercase?.should be_true }
+    it { 'ā'.uppercase?.should be_false }
+    it { 'á'.uppercase?.should be_false }
+    it { 'a'.uppercase?.should be_false }
+    it { '1'.uppercase?.should be_false }
+    it { ' '.uppercase?.should be_false }
   end
 
   describe "ascii_lowercase?" do
-    assert { 'a'.ascii_lowercase?.should be_true }
-    assert { 'A'.ascii_lowercase?.should be_false }
-    assert { '1'.ascii_lowercase?.should be_false }
-    assert { ' '.ascii_lowercase?.should be_false }
+    it { 'a'.ascii_lowercase?.should be_true }
+    it { 'A'.ascii_lowercase?.should be_false }
+    it { '1'.ascii_lowercase?.should be_false }
+    it { ' '.ascii_lowercase?.should be_false }
   end
 
   describe "lowercase?" do
-    assert { 'a'.lowercase?.should be_true }
-    assert { 'á'.lowercase?.should be_true }
-    assert { 'ā'.lowercase?.should be_true }
-    assert { 'ă'.lowercase?.should be_true }
-    assert { 'A'.lowercase?.should be_false }
-    assert { 'Á'.lowercase?.should be_false }
-    assert { '1'.lowercase?.should be_false }
-    assert { ' '.lowercase?.should be_false }
+    it { 'a'.lowercase?.should be_true }
+    it { 'á'.lowercase?.should be_true }
+    it { 'ā'.lowercase?.should be_true }
+    it { 'ă'.lowercase?.should be_true }
+    it { 'A'.lowercase?.should be_false }
+    it { 'Á'.lowercase?.should be_false }
+    it { '1'.lowercase?.should be_false }
+    it { ' '.lowercase?.should be_false }
   end
 
   describe "ascii_letter?" do
-    assert { 'a'.ascii_letter?.should be_true }
-    assert { 'A'.ascii_letter?.should be_true }
-    assert { '1'.ascii_letter?.should be_false }
-    assert { ' '.ascii_letter?.should be_false }
+    it { 'a'.ascii_letter?.should be_true }
+    it { 'A'.ascii_letter?.should be_true }
+    it { '1'.ascii_letter?.should be_false }
+    it { ' '.ascii_letter?.should be_false }
   end
 
   describe "alphanumeric?" do
-    assert { 'a'.alphanumeric?.should be_true }
-    assert { 'A'.alphanumeric?.should be_true }
-    assert { '1'.alphanumeric?.should be_true }
-    assert { ' '.alphanumeric?.should be_false }
+    it { 'a'.alphanumeric?.should be_true }
+    it { 'A'.alphanumeric?.should be_true }
+    it { '1'.alphanumeric?.should be_true }
+    it { ' '.alphanumeric?.should be_false }
   end
 
   describe "ascii_whitespace?" do
     [' ', '\t', '\n', '\v', '\f', '\r'].each do |char|
-      assert { char.ascii_whitespace?.should be_true }
+      it { char.ascii_whitespace?.should be_true }
     end
-    assert { 'A'.ascii_whitespace?.should be_false }
+    it { 'A'.ascii_whitespace?.should be_false }
   end
 
   describe "hex?" do
     "0123456789abcdefABCDEF".each_char do |char|
-      assert { char.hex?.should be_true }
+      it { char.hex?.should be_true }
     end
     ('g'..'z').each do |char|
-      assert { char.hex?.should be_false }
+      it { char.hex?.should be_false }
     end
     [' ', '-', '\0'].each do |char|
-      assert { char.hex?.should be_false }
+      it { char.hex?.should be_false }
     end
   end
 
@@ -248,8 +248,8 @@ describe "Char" do
   end
 
   describe "index" do
-    assert { "foo".index('o').should eq(1) }
-    assert { "foo".index('x').should be_nil }
+    it { "foo".index('o').should eq(1) }
+    it { "foo".index('x').should be_nil }
   end
 
   it "does <=>" do
@@ -290,41 +290,41 @@ describe "Char" do
   end
 
   describe "in_set?" do
-    assert { 'a'.in_set?("a").should be_true }
-    assert { 'a'.in_set?("b").should be_false }
-    assert { 'a'.in_set?("a-c").should be_true }
-    assert { 'b'.in_set?("a-c").should be_true }
-    assert { 'c'.in_set?("a-c").should be_true }
-    assert { 'c'.in_set?("a-bc").should be_true }
-    assert { 'b'.in_set?("a-bc").should be_true }
-    assert { 'd'.in_set?("a-c").should be_false }
-    assert { 'b'.in_set?("^a-c").should be_false }
-    assert { 'd'.in_set?("^a-c").should be_true }
-    assert { 'a'.in_set?("ab-c").should be_true }
-    assert { 'a'.in_set?("\\^ab-c").should be_true }
-    assert { '^'.in_set?("\\^ab-c").should be_true }
-    assert { '^'.in_set?("a^b-c").should be_true }
-    assert { '^'.in_set?("ab-c^").should be_true }
-    assert { '^'.in_set?("a0-^").should be_true }
-    assert { '^'.in_set?("^-c").should be_true }
-    assert { '^'.in_set?("a^-c").should be_true }
-    assert { '\\'.in_set?("ab-c\\").should be_true }
-    assert { '\\'.in_set?("a\\b-c").should be_false }
-    assert { '\\'.in_set?("a0-\\c").should be_true }
-    assert { '\\'.in_set?("a\\-c").should be_false }
-    assert { '-'.in_set?("a-c").should be_false }
-    assert { '-'.in_set?("a-c").should be_false }
-    assert { '-'.in_set?("a\\-c").should be_true }
-    assert { '-'.in_set?("-c").should be_true }
-    assert { '-'.in_set?("a-").should be_true }
-    assert { '-'.in_set?("^-c").should be_false }
-    assert { '-'.in_set?("^\\-c").should be_false }
-    assert { 'b'.in_set?("^\\-c").should be_true }
-    assert { '-'.in_set?("a^-c").should be_false }
-    assert { 'a'.in_set?("a", "ab").should be_true }
-    assert { 'a'.in_set?("a", "^b").should be_true }
-    assert { 'a'.in_set?("a", "b").should be_false }
-    assert { 'a'.in_set?("ab", "ac", "ad").should be_true }
+    it { 'a'.in_set?("a").should be_true }
+    it { 'a'.in_set?("b").should be_false }
+    it { 'a'.in_set?("a-c").should be_true }
+    it { 'b'.in_set?("a-c").should be_true }
+    it { 'c'.in_set?("a-c").should be_true }
+    it { 'c'.in_set?("a-bc").should be_true }
+    it { 'b'.in_set?("a-bc").should be_true }
+    it { 'd'.in_set?("a-c").should be_false }
+    it { 'b'.in_set?("^a-c").should be_false }
+    it { 'd'.in_set?("^a-c").should be_true }
+    it { 'a'.in_set?("ab-c").should be_true }
+    it { 'a'.in_set?("\\^ab-c").should be_true }
+    it { '^'.in_set?("\\^ab-c").should be_true }
+    it { '^'.in_set?("a^b-c").should be_true }
+    it { '^'.in_set?("ab-c^").should be_true }
+    it { '^'.in_set?("a0-^").should be_true }
+    it { '^'.in_set?("^-c").should be_true }
+    it { '^'.in_set?("a^-c").should be_true }
+    it { '\\'.in_set?("ab-c\\").should be_true }
+    it { '\\'.in_set?("a\\b-c").should be_false }
+    it { '\\'.in_set?("a0-\\c").should be_true }
+    it { '\\'.in_set?("a\\-c").should be_false }
+    it { '-'.in_set?("a-c").should be_false }
+    it { '-'.in_set?("a-c").should be_false }
+    it { '-'.in_set?("a\\-c").should be_true }
+    it { '-'.in_set?("-c").should be_true }
+    it { '-'.in_set?("a-").should be_true }
+    it { '-'.in_set?("^-c").should be_false }
+    it { '-'.in_set?("^\\-c").should be_false }
+    it { 'b'.in_set?("^\\-c").should be_true }
+    it { '-'.in_set?("a^-c").should be_false }
+    it { 'a'.in_set?("a", "ab").should be_true }
+    it { 'a'.in_set?("a", "^b").should be_true }
+    it { 'a'.in_set?("a", "b").should be_false }
+    it { 'a'.in_set?("ab", "ac", "ad").should be_true }
 
     it "rejects invalid ranges" do
       expect_raises do
@@ -374,10 +374,10 @@ describe "Char" do
   end
 
   it "does number?" do
-    assert { '1'.number?.should be_true }
-    assert { '٠'.number?.should be_true }
-    assert { '٢'.number?.should be_true }
-    assert { 'a'.number?.should be_false }
+    it { '1'.number?.should be_true }
+    it { '٠'.number?.should be_true }
+    it { '٢'.number?.should be_true }
+    it { 'a'.number?.should be_false }
   end
 
   it "does ascii_control?" do
@@ -398,6 +398,6 @@ describe "Char" do
   end
 
   describe "clone" do
-    assert { 'a'.clone.should eq('a') }
+    it { 'a'.clone.should eq('a') }
   end
 end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -374,7 +374,7 @@ describe "Deque" do
   end
 
   describe "inspect" do
-    assert { Deque{1, 2, 3}.inspect.should eq("Deque{1, 2, 3}") }
+    it { Deque{1, 2, 3}.inspect.should eq("Deque{1, 2, 3}") }
   end
 
   describe "last" do
@@ -537,7 +537,7 @@ describe "Deque" do
 
   describe "to_s" do
     it "does to_s" do
-      assert { Deque{1, 2, 3}.to_s.should eq("Deque{1, 2, 3}") }
+      it { Deque{1, 2, 3}.to_s.should eq("Deque{1, 2, 3}") }
     end
 
     it "does with recursive" do

--- a/spec/std/double_spec.cr
+++ b/spec/std/double_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 describe "Double" do
   describe "**" do
-    assert { (2.5 ** 2).should be_close(6.25, 0.0001) }
-    assert { (2.5 ** 2.5_f32).should be_close(9.882117688026186, 0.0001) }
-    assert { (2.5 ** 2.5).should be_close(9.882117688026186, 0.0001) }
+    it { (2.5 ** 2).should be_close(6.25, 0.0001) }
+    it { (2.5 ** 2.5_f32).should be_close(9.882117688026186, 0.0001) }
+    it { (2.5 ** 2.5).should be_close(9.882117688026186, 0.0001) }
   end
 end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -52,7 +52,7 @@ describe "Enumerable" do
   end
 
   describe "compact map" do
-    assert { Set{1, nil, 2, nil, 3}.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
+    it { Set{1, nil, 2, nil, 3}.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
   end
 
   describe "size without block" do
@@ -410,7 +410,7 @@ describe "Enumerable" do
       end
     end
 
-    assert { [-1, -2, -3].first.should eq(-1) }
+    it { [-1, -2, -3].first.should eq(-1) }
   end
 
   describe "first?" do
@@ -456,7 +456,7 @@ describe "Enumerable" do
   end
 
   describe "group_by" do
-    assert { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
+    it { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
 
     it "groups can group by size (like the doc example)" do
       %w(Alice Bob Ary).group_by { |e| e.size }.should eq({3 => ["Bob", "Ary"],
@@ -465,11 +465,11 @@ describe "Enumerable" do
   end
 
   describe "in_groups_of" do
-    assert { [1, 2, 3].in_groups_of(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].in_groups_of(2).should eq([[1, 2], [3, nil]]) }
-    assert { [1, 2, 3, 4].in_groups_of(3).should eq([[1, 2, 3], [4, nil, nil]]) }
-    assert { ([] of Int32).in_groups_of(2).should eq([] of Array(Array(Int32 | Nil))) }
-    assert { [1, 2, 3].in_groups_of(2, "x").should eq([[1, 2], [3, "x"]]) }
+    it { [1, 2, 3].in_groups_of(1).should eq([[1], [2], [3]]) }
+    it { [1, 2, 3].in_groups_of(2).should eq([[1, 2], [3, nil]]) }
+    it { [1, 2, 3, 4].in_groups_of(3).should eq([[1, 2, 3], [4, nil, nil]]) }
+    it { ([] of Int32).in_groups_of(2).should eq([] of Array(Array(Int32 | Nil))) }
+    it { [1, 2, 3].in_groups_of(2, "x").should eq([[1, 2], [3, "x"]]) }
 
     it "raises argument error if size is less than 0" do
       expect_raises ArgumentError, "size must be positive" do
@@ -548,8 +548,8 @@ describe "Enumerable" do
   end
 
   describe "reduce" do
-    assert { [1, 2, 3].reduce { |memo, i| memo + i }.should eq(6) }
-    assert { [1, 2, 3].reduce(10) { |memo, i| memo + i }.should eq(16) }
+    it { [1, 2, 3].reduce { |memo, i| memo + i }.should eq(6) }
+    it { [1, 2, 3].reduce(10) { |memo, i| memo + i }.should eq(16) }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
@@ -612,7 +612,7 @@ describe "Enumerable" do
   end
 
   describe "max" do
-    assert { [1, 2, 3].max.should eq(3) }
+    it { [1, 2, 3].max.should eq(3) }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
@@ -628,7 +628,7 @@ describe "Enumerable" do
   end
 
   describe "max_by" do
-    assert { [-1, -2, -3].max_by { |x| -x }.should eq(-3) }
+    it { [-1, -2, -3].max_by { |x| -x }.should eq(-3) }
   end
 
   describe "max_by?" do
@@ -638,7 +638,7 @@ describe "Enumerable" do
   end
 
   describe "max_of" do
-    assert { [-1, -2, -3].max_of { |x| -x }.should eq(3) }
+    it { [-1, -2, -3].max_of { |x| -x }.should eq(3) }
   end
 
   describe "max_of?" do
@@ -648,7 +648,7 @@ describe "Enumerable" do
   end
 
   describe "min" do
-    assert { [1, 2, 3].min.should eq(1) }
+    it { [1, 2, 3].min.should eq(1) }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
@@ -664,7 +664,7 @@ describe "Enumerable" do
   end
 
   describe "min_by" do
-    assert { [1, 2, 3].min_by { |x| -x }.should eq(3) }
+    it { [1, 2, 3].min_by { |x| -x }.should eq(3) }
   end
 
   describe "min_by?" do
@@ -674,7 +674,7 @@ describe "Enumerable" do
   end
 
   describe "min_of" do
-    assert { [1, 2, 3].min_of { |x| -x }.should eq(-3) }
+    it { [1, 2, 3].min_of { |x| -x }.should eq(-3) }
   end
 
   describe "min_of?" do
@@ -684,7 +684,7 @@ describe "Enumerable" do
   end
 
   describe "minmax" do
-    assert { [1, 2, 3].minmax.should eq({1, 3}) }
+    it { [1, 2, 3].minmax.should eq({1, 3}) }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
@@ -700,7 +700,7 @@ describe "Enumerable" do
   end
 
   describe "minmax_by" do
-    assert { [-1, -2, -3].minmax_by { |x| -x }.should eq({-1, -3}) }
+    it { [-1, -2, -3].minmax_by { |x| -x }.should eq({-1, -3}) }
   end
 
   describe "minmax_by?" do
@@ -710,7 +710,7 @@ describe "Enumerable" do
   end
 
   describe "minmax_of" do
-    assert { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
+    it { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
   end
 
   describe "minmax_of?" do
@@ -720,24 +720,24 @@ describe "Enumerable" do
   end
 
   describe "none?" do
-    assert { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
-    assert { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
+    it { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
+    it { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
   end
 
   describe "none? without block" do
-    assert { [nil, false].none?.should be_true }
-    assert { [nil, false, true].none?.should be_false }
+    it { [nil, false].none?.should be_true }
+    it { [nil, false, true].none?.should be_false }
   end
 
   describe "one?" do
-    assert { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
-    assert { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
-    assert { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
+    it { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
+    it { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
+    it { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
   end
 
   describe "partition" do
-    assert { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
-    assert { [1, 2, 3, 4, 5, 6].partition(&.even?).should eq({[2, 4, 6], [1, 3, 5]}) }
+    it { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
+    it { [1, 2, 3, 4, 5, 6].partition(&.even?).should eq({[2, 4, 6], [1, 3, 5]}) }
   end
 
   describe "reject" do
@@ -793,12 +793,12 @@ describe "Enumerable" do
   end
 
   describe "sum" do
-    assert { ([] of Int32).sum.should eq(0) }
-    assert { [1, 2, 3].sum.should eq(6) }
-    assert { [1, 2, 3].sum(4).should eq(10) }
-    assert { [1, 2, 3].sum(4.5).should eq(10.5) }
-    assert { (1..3).sum { |x| x * 2 }.should eq(12) }
-    assert { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
+    it { ([] of Int32).sum.should eq(0) }
+    it { [1, 2, 3].sum.should eq(6) }
+    it { [1, 2, 3].sum(4).should eq(10) }
+    it { [1, 2, 3].sum(4.5).should eq(10.5) }
+    it { (1..3).sum { |x| x * 2 }.should eq(12) }
+    it { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
 
     it "uses zero from type" do
       typeof([1, 2, 3].sum).should eq(Int32)
@@ -808,12 +808,12 @@ describe "Enumerable" do
   end
 
   describe "product" do
-    assert { ([] of Int32).product.should eq(1) }
-    assert { [1, 2, 3].product.should eq(6) }
-    assert { [1, 2, 3].product(4).should eq(24) }
-    assert { [1, 2, 3].product(4.5).should eq(27) }
-    assert { (1..3).product { |x| x * 2 }.should eq(48) }
-    assert { (1..3).product(1.5) { |x| x * 2 }.should eq(72) }
+    it { ([] of Int32).product.should eq(1) }
+    it { [1, 2, 3].product.should eq(6) }
+    it { [1, 2, 3].product(4).should eq(24) }
+    it { [1, 2, 3].product(4.5).should eq(27) }
+    it { (1..3).product { |x| x * 2 }.should eq(48) }
+    it { (1..3).product(1.5) { |x| x * 2 }.should eq(72) }
 
     it "uses zero from type" do
       typeof([1, 2, 3].product).should eq(Int32)
@@ -823,8 +823,8 @@ describe "Enumerable" do
   end
 
   describe "first" do
-    assert { (1..3).first(1).should eq([1]) }
-    assert { (1..3).first(4).should eq([1, 2, 3]) }
+    it { (1..3).first(1).should eq([1]) }
+    it { (1..3).first(4).should eq([1, 2, 3]) }
 
     it "raises if count is negative" do
       expect_raises(ArgumentError) do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -241,7 +241,7 @@ describe "File" do
     File.join(["/foo/", "/bar/", "/baz/"]).should eq("/foo/bar/baz/")
   end
 
-  assert "chown" do
+  it "chown" do
     # changing owners requires special privileges, so we test that method calls do compile
     typeof(File.chown("/tmp/test"))
     typeof(File.chown("/tmp/test", uid: 1001, gid: 100, follow_symlinks: true))
@@ -361,8 +361,8 @@ describe "File" do
   end
 
   describe "size" do
-    assert { File.size("#{__DIR__}/data/test_file.txt").should eq(240) }
-    assert do
+    it { File.size("#{__DIR__}/data/test_file.txt").should eq(240) }
+    it do
       File.open("#{__DIR__}/data/test_file.txt", "r") do |file|
         file.size.should eq(240)
       end

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -2,19 +2,19 @@ require "spec"
 
 describe "Float" do
   describe "**" do
-    assert { (2.5_f32 ** 2_i32).should be_close(6.25_f32, 0.0001) }
-    assert { (2.5_f32 ** 2).should be_close(6.25_f32, 0.0001) }
-    assert { (2.5_f32 ** 2.5_f32).should be_close(9.882117688026186_f32, 0.0001) }
-    assert { (2.5_f32 ** 2.5).should be_close(9.882117688026186_f32, 0.0001) }
-    assert { (2.5_f64 ** 2_i32).should be_close(6.25_f64, 0.0001) }
-    assert { (2.5_f64 ** 2).should be_close(6.25_f64, 0.0001) }
-    assert { (2.5_f64 ** 2.5_f64).should be_close(9.882117688026186_f64, 0.0001) }
-    assert { (2.5_f64 ** 2.5).should be_close(9.882117688026186_f64, 0.001) }
+    it { (2.5_f32 ** 2_i32).should be_close(6.25_f32, 0.0001) }
+    it { (2.5_f32 ** 2).should be_close(6.25_f32, 0.0001) }
+    it { (2.5_f32 ** 2.5_f32).should be_close(9.882117688026186_f32, 0.0001) }
+    it { (2.5_f32 ** 2.5).should be_close(9.882117688026186_f32, 0.0001) }
+    it { (2.5_f64 ** 2_i32).should be_close(6.25_f64, 0.0001) }
+    it { (2.5_f64 ** 2).should be_close(6.25_f64, 0.0001) }
+    it { (2.5_f64 ** 2.5_f64).should be_close(9.882117688026186_f64, 0.0001) }
+    it { (2.5_f64 ** 2.5).should be_close(9.882117688026186_f64, 0.001) }
   end
 
   describe "%" do
     it "uses modulo behavior, not remainder behavior" do
-      assert { ((-11.5) % 4.0).should eq(0.5) }
+      it { ((-11.5) % 4.0).should eq(0.5) }
     end
   end
 
@@ -23,14 +23,14 @@ describe "Float" do
       expect_raises(DivisionByZero) { 1.2.modulo 0.0 }
     end
 
-    assert { (13.0.modulo 4.0).should eq(1.0) }
-    assert { (13.0.modulo -4.0).should eq(-3.0) }
-    assert { (-13.0.modulo 4.0).should eq(3.0) }
-    assert { (-13.0.modulo -4.0).should eq(-1.0) }
-    assert { (11.5.modulo 4.0).should eq(3.5) }
-    assert { (11.5.modulo -4.0).should eq(-0.5) }
-    assert { (-11.5.modulo 4.0).should eq(0.5) }
-    assert { (-11.5.modulo -4.0).should eq(-3.5) }
+    it { (13.0.modulo 4.0).should eq(1.0) }
+    it { (13.0.modulo -4.0).should eq(-3.0) }
+    it { (-13.0.modulo 4.0).should eq(3.0) }
+    it { (-13.0.modulo -4.0).should eq(-1.0) }
+    it { (11.5.modulo 4.0).should eq(3.5) }
+    it { (11.5.modulo -4.0).should eq(-0.5) }
+    it { (-11.5.modulo 4.0).should eq(0.5) }
+    it { (-11.5.modulo -4.0).should eq(-3.5) }
   end
 
   describe "remainder" do
@@ -38,14 +38,14 @@ describe "Float" do
       expect_raises(DivisionByZero) { 1.2.remainder 0.0 }
     end
 
-    assert { (13.0.remainder 4.0).should eq(1.0) }
-    assert { (13.0.remainder -4.0).should eq(1.0) }
-    assert { (-13.0.remainder 4.0).should eq(-1.0) }
-    assert { (-13.0.remainder -4.0).should eq(-1.0) }
-    assert { (11.5.remainder 4.0).should eq(3.5) }
-    assert { (11.5.remainder -4.0).should eq(3.5) }
-    assert { (-11.5.remainder 4.0).should eq(-3.5) }
-    assert { (-11.5.remainder -4.0).should eq(-3.5) }
+    it { (13.0.remainder 4.0).should eq(1.0) }
+    it { (13.0.remainder -4.0).should eq(1.0) }
+    it { (-13.0.remainder 4.0).should eq(-1.0) }
+    it { (-13.0.remainder -4.0).should eq(-1.0) }
+    it { (11.5.remainder 4.0).should eq(3.5) }
+    it { (11.5.remainder -4.0).should eq(3.5) }
+    it { (-11.5.remainder 4.0).should eq(-3.5) }
+    it { (-11.5.remainder -4.0).should eq(-3.5) }
 
     it "preserves type" do
       r = 1.5_f32.remainder(1)
@@ -54,70 +54,70 @@ describe "Float" do
   end
 
   describe "round" do
-    assert { 2.5.round.should eq(3) }
-    assert { 2.4.round.should eq(2) }
+    it { 2.5.round.should eq(3) }
+    it { 2.4.round.should eq(2) }
   end
 
   describe "floor" do
-    assert { 2.1.floor.should eq(2) }
-    assert { 2.9.floor.should eq(2) }
+    it { 2.1.floor.should eq(2) }
+    it { 2.9.floor.should eq(2) }
   end
 
   describe "ceil" do
-    assert { 2.0_f32.ceil.should eq(2) }
-    assert { 2.0.ceil.should eq(2) }
+    it { 2.0_f32.ceil.should eq(2) }
+    it { 2.0.ceil.should eq(2) }
 
-    assert { 2.1_f32.ceil.should eq(3_f32) }
-    assert { 2.1.ceil.should eq(3) }
+    it { 2.1_f32.ceil.should eq(3_f32) }
+    it { 2.1.ceil.should eq(3) }
 
-    assert { 2.9_f32.ceil.should eq(3) }
-    assert { 2.9.ceil.should eq(3) }
+    it { 2.9_f32.ceil.should eq(3) }
+    it { 2.9.ceil.should eq(3) }
   end
 
   describe "fdiv" do
-    assert { 1.0.fdiv(1).should eq 1.0 }
-    assert { 1.0.fdiv(2).should eq 0.5 }
-    assert { 1.0.fdiv(0.5).should eq 2.0 }
-    assert { 0.0.fdiv(1).should eq 0.0 }
-    assert { 1.0.fdiv(0).should eq 1.0/0.0 }
+    it { 1.0.fdiv(1).should eq 1.0 }
+    it { 1.0.fdiv(2).should eq 0.5 }
+    it { 1.0.fdiv(0.5).should eq 2.0 }
+    it { 0.0.fdiv(1).should eq 0.0 }
+    it { 1.0.fdiv(0).should eq 1.0/0.0 }
   end
 
   describe "divmod" do
-    assert { 1.2.divmod(0.3)[0].should eq(4) }
-    assert { 1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
+    it { 1.2.divmod(0.3)[0].should eq(4) }
+    it { 1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
 
-    assert { 1.3.divmod(0.3)[0].should eq(4) }
-    assert { 1.3.divmod(0.3)[1].should be_close(0.1, 0.00001) }
+    it { 1.3.divmod(0.3)[0].should eq(4) }
+    it { 1.3.divmod(0.3)[1].should be_close(0.1, 0.00001) }
 
-    assert { 1.4.divmod(0.3)[0].should eq(4) }
-    assert { 1.4.divmod(0.3)[1].should be_close(0.2, 0.00001) }
+    it { 1.4.divmod(0.3)[0].should eq(4) }
+    it { 1.4.divmod(0.3)[1].should be_close(0.2, 0.00001) }
 
-    assert { -1.2.divmod(0.3)[0].should eq(-4) }
-    assert { -1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
+    it { -1.2.divmod(0.3)[0].should eq(-4) }
+    it { -1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
 
-    assert { -1.3.divmod(0.3)[0].should eq(-5) }
-    assert { -1.3.divmod(0.3)[1].should be_close(0.2, 0.00001) }
+    it { -1.3.divmod(0.3)[0].should eq(-5) }
+    it { -1.3.divmod(0.3)[1].should be_close(0.2, 0.00001) }
 
-    assert { -1.4.divmod(0.3)[0].should eq(-5) }
-    assert { -1.4.divmod(0.3)[1].should be_close(0.1, 0.00001) }
+    it { -1.4.divmod(0.3)[0].should eq(-5) }
+    it { -1.4.divmod(0.3)[1].should be_close(0.1, 0.00001) }
 
-    assert { 1.2.divmod(-0.3)[0].should eq(-4) }
-    assert { 1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
+    it { 1.2.divmod(-0.3)[0].should eq(-4) }
+    it { 1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
 
-    assert { 1.3.divmod(-0.3)[0].should eq(-5) }
-    assert { 1.3.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
+    it { 1.3.divmod(-0.3)[0].should eq(-5) }
+    it { 1.3.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
 
-    assert { 1.4.divmod(-0.3)[0].should eq(-5) }
-    assert { 1.4.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
+    it { 1.4.divmod(-0.3)[0].should eq(-5) }
+    it { 1.4.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
 
-    assert { -1.2.divmod(-0.3)[0].should eq(4) }
-    assert { -1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
+    it { -1.2.divmod(-0.3)[0].should eq(4) }
+    it { -1.2.divmod(-0.3)[1].should be_close(0.0, 0.00001) }
 
-    assert { -1.3.divmod(-0.3)[0].should eq(4) }
-    assert { -1.3.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
+    it { -1.3.divmod(-0.3)[0].should eq(4) }
+    it { -1.3.divmod(-0.3)[1].should be_close(-0.1, 0.00001) }
 
-    assert { -1.4.divmod(-0.3)[0].should eq(4) }
-    assert { -1.4.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
+    it { -1.4.divmod(-0.3)[0].should eq(4) }
+    it { -1.4.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
   end
 
   describe "to_s" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -62,7 +62,7 @@ describe "Hash" do
   end
 
   describe "==" do
-    assert do
+    it do
       a = {1 => 2, 3 => 4}
       b = {3 => 4, 1 => 2}
       c = {2 => 3}
@@ -75,7 +75,7 @@ describe "Hash" do
       d.should_not eq(a)
     end
 
-    assert do
+    it do
       a = {1 => nil}
       b = {3 => 4}
       a.should_not eq(b)
@@ -295,9 +295,9 @@ describe "Hash" do
   end
 
   describe "to_s" do
-    assert { {1 => 2, 3 => 4}.to_s.should eq("{1 => 2, 3 => 4}") }
+    it { {1 => 2, 3 => 4}.to_s.should eq("{1 => 2, 3 => 4}") }
 
-    assert do
+    it do
       h = {} of RecursiveHash => RecursiveHash
       h[h] = h
       h.to_s.should eq("{{...} => {...}}")
@@ -755,9 +755,9 @@ describe "Hash" do
   end
 
   describe "reject" do
-    assert { {:a => 2, :b => 3}.reject(:b, :d).should eq({:a => 2}) }
-    assert { {:a => 2, :b => 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
-    assert { {:a => 2, :b => 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.reject(:b, :d).should eq({:a => 2}) }
+    it { {:a => 2, :b => 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
     it "does not change currrent hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h2 = h.reject(:b, :c)
@@ -766,9 +766,9 @@ describe "Hash" do
   end
 
   describe "reject!" do
-    assert { {:a => 2, :b => 3}.reject!(:b, :d).should eq({:a => 2}) }
-    assert { {:a => 2, :b => 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
-    assert { {:a => 2, :b => 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.reject!(:b, :d).should eq({:a => 2}) }
+    it { {:a => 2, :b => 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
     it "changes currrent hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h.reject!(:b, :c)
@@ -777,10 +777,10 @@ describe "Hash" do
   end
 
   describe "select" do
-    assert { {:a => 2, :b => 3}.select(:b, :d).should eq({:b => 3}) }
-    assert { {:a => 2, :b => 3}.select.should eq({} of Symbol => Int32) }
-    assert { {:a => 2, :b => 3}.select(:b, :a).should eq({:a => 2, :b => 3}) }
-    assert { {:a => 2, :b => 3}.select([:b, :a]).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select(:b, :d).should eq({:b => 3}) }
+    it { {:a => 2, :b => 3}.select.should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.select(:b, :a).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select([:b, :a]).should eq({:a => 2, :b => 3}) }
     it "does not change currrent hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h2 = h.select(:b, :c)
@@ -789,10 +789,10 @@ describe "Hash" do
   end
 
   describe "select!" do
-    assert { {:a => 2, :b => 3}.select!(:b, :d).should eq({:b => 3}) }
-    assert { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
-    assert { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
-    assert { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select!(:b, :d).should eq({:b => 3}) }
+    it { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
+    it { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
     it "does change currrent hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h.select!(:b, :c)

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -40,44 +40,44 @@ describe "Int" do
     end
 
     describe "with float" do
-      assert { (2 ** 2.0).should be_close(4, 0.0001) }
-      assert { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }
-      assert { (2 ** 2.5).should be_close(5.656854249492381, 0.0001) }
+      it { (2 ** 2.0).should be_close(4, 0.0001) }
+      it { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }
+      it { (2 ** 2.5).should be_close(5.656854249492381, 0.0001) }
     end
   end
 
   describe "#===(:Char)" do
-    assert { (99 === 'c').should be_true }
-    assert { (99_u8 === 'c').should be_true }
-    assert { (99 === 'z').should be_false }
-    assert { (37202 === '酒').should be_true }
+    it { (99 === 'c').should be_true }
+    it { (99_u8 === 'c').should be_true }
+    it { (99 === 'z').should be_false }
+    it { (37202 === '酒').should be_true }
   end
 
   describe "divisible_by?" do
-    assert { 10.divisible_by?(5).should be_true }
-    assert { 10.divisible_by?(3).should be_false }
+    it { 10.divisible_by?(5).should be_true }
+    it { 10.divisible_by?(3).should be_false }
   end
 
   describe "even?" do
-    assert { 2.even?.should be_true }
-    assert { 3.even?.should be_false }
+    it { 2.even?.should be_true }
+    it { 3.even?.should be_false }
   end
 
   describe "odd?" do
-    assert { 2.odd?.should be_false }
-    assert { 3.odd?.should be_true }
+    it { 2.odd?.should be_false }
+    it { 3.odd?.should be_true }
   end
 
   describe "succ" do
-    assert { 8.succ.should eq(9) }
-    assert { -2147483648.succ.should eq(-2147483647) }
-    assert { 2147483646.succ.should eq(2147483647) }
+    it { 8.succ.should eq(9) }
+    it { -2147483648.succ.should eq(-2147483647) }
+    it { 2147483646.succ.should eq(2147483647) }
   end
 
   describe "pred" do
-    assert { 9.pred.should eq(8) }
-    assert { -2147483647.pred.should eq(-2147483648) }
-    assert { 2147483647.pred.should eq(2147483646) }
+    it { 9.pred.should eq(8) }
+    it { -2147483647.pred.should eq(-2147483648) }
+    it { 2147483647.pred.should eq(2147483646) }
   end
 
   describe "abs" do
@@ -101,38 +101,38 @@ describe "Int" do
   end
 
   describe "lcm" do
-    assert { 2.lcm(2).should eq(2) }
-    assert { 3.lcm(-7).should eq(21) }
-    assert { 4.lcm(6).should eq(12) }
-    assert { 0.lcm(2).should eq(0) }
-    assert { 2.lcm(0).should eq(0) }
+    it { 2.lcm(2).should eq(2) }
+    it { 3.lcm(-7).should eq(21) }
+    it { 4.lcm(6).should eq(12) }
+    it { 0.lcm(2).should eq(0) }
+    it { 2.lcm(0).should eq(0) }
   end
 
   describe "to_s in base" do
-    assert { 12.to_s(2).should eq("1100") }
-    assert { -12.to_s(2).should eq("-1100") }
-    assert { -123456.to_s(2).should eq("-11110001001000000") }
-    assert { 1234.to_s(16).should eq("4d2") }
-    assert { -1234.to_s(16).should eq("-4d2") }
-    assert { 1234.to_s(36).should eq("ya") }
-    assert { -1234.to_s(36).should eq("-ya") }
-    assert { 1234.to_s(16, upcase: true).should eq("4D2") }
-    assert { -1234.to_s(16, upcase: true).should eq("-4D2") }
-    assert { 1234.to_s(36, upcase: true).should eq("YA") }
-    assert { -1234.to_s(36, upcase: true).should eq("-YA") }
-    assert { 0.to_s(2).should eq("0") }
-    assert { 0.to_s(16).should eq("0") }
-    assert { 1.to_s(2).should eq("1") }
-    assert { 1.to_s(16).should eq("1") }
-    assert { 0.to_s(62).should eq("0") }
-    assert { 1.to_s(62).should eq("1") }
-    assert { 10.to_s(62).should eq("a") }
-    assert { 35.to_s(62).should eq("z") }
-    assert { 36.to_s(62).should eq("A") }
-    assert { 61.to_s(62).should eq("Z") }
-    assert { 62.to_s(62).should eq("10") }
-    assert { 97.to_s(62).should eq("1z") }
-    assert { 3843.to_s(62).should eq("ZZ") }
+    it { 12.to_s(2).should eq("1100") }
+    it { -12.to_s(2).should eq("-1100") }
+    it { -123456.to_s(2).should eq("-11110001001000000") }
+    it { 1234.to_s(16).should eq("4d2") }
+    it { -1234.to_s(16).should eq("-4d2") }
+    it { 1234.to_s(36).should eq("ya") }
+    it { -1234.to_s(36).should eq("-ya") }
+    it { 1234.to_s(16, upcase: true).should eq("4D2") }
+    it { -1234.to_s(16, upcase: true).should eq("-4D2") }
+    it { 1234.to_s(36, upcase: true).should eq("YA") }
+    it { -1234.to_s(36, upcase: true).should eq("-YA") }
+    it { 0.to_s(2).should eq("0") }
+    it { 0.to_s(16).should eq("0") }
+    it { 1.to_s(2).should eq("1") }
+    it { 1.to_s(16).should eq("1") }
+    it { 0.to_s(62).should eq("0") }
+    it { 1.to_s(62).should eq("1") }
+    it { 10.to_s(62).should eq("a") }
+    it { 35.to_s(62).should eq("z") }
+    it { 36.to_s(62).should eq("A") }
+    it { 61.to_s(62).should eq("Z") }
+    it { 62.to_s(62).should eq("10") }
+    it { 97.to_s(62).should eq("1z") }
+    it { 3843.to_s(62).should eq("ZZ") }
 
     it "raises on base 1" do
       expect_raises { 123.to_s(1) }
@@ -146,30 +146,30 @@ describe "Int" do
       expect_raises { 123.to_s(62, upcase: true) }
     end
 
-    assert { to_s_with_io(12, 2).should eq("1100") }
-    assert { to_s_with_io(-12, 2).should eq("-1100") }
-    assert { to_s_with_io(-123456, 2).should eq("-11110001001000000") }
-    assert { to_s_with_io(1234, 16).should eq("4d2") }
-    assert { to_s_with_io(-1234, 16).should eq("-4d2") }
-    assert { to_s_with_io(1234, 36).should eq("ya") }
-    assert { to_s_with_io(-1234, 36).should eq("-ya") }
-    assert { to_s_with_io(1234, 16, upcase: true).should eq("4D2") }
-    assert { to_s_with_io(-1234, 16, upcase: true).should eq("-4D2") }
-    assert { to_s_with_io(1234, 36, upcase: true).should eq("YA") }
-    assert { to_s_with_io(-1234, 36, upcase: true).should eq("-YA") }
-    assert { to_s_with_io(0, 2).should eq("0") }
-    assert { to_s_with_io(0, 16).should eq("0") }
-    assert { to_s_with_io(1, 2).should eq("1") }
-    assert { to_s_with_io(1, 16).should eq("1") }
-    assert { to_s_with_io(0, 62).should eq("0") }
-    assert { to_s_with_io(1, 62).should eq("1") }
-    assert { to_s_with_io(10, 62).should eq("a") }
-    assert { to_s_with_io(35, 62).should eq("z") }
-    assert { to_s_with_io(36, 62).should eq("A") }
-    assert { to_s_with_io(61, 62).should eq("Z") }
-    assert { to_s_with_io(62, 62).should eq("10") }
-    assert { to_s_with_io(97, 62).should eq("1z") }
-    assert { to_s_with_io(3843, 62).should eq("ZZ") }
+    it { to_s_with_io(12, 2).should eq("1100") }
+    it { to_s_with_io(-12, 2).should eq("-1100") }
+    it { to_s_with_io(-123456, 2).should eq("-11110001001000000") }
+    it { to_s_with_io(1234, 16).should eq("4d2") }
+    it { to_s_with_io(-1234, 16).should eq("-4d2") }
+    it { to_s_with_io(1234, 36).should eq("ya") }
+    it { to_s_with_io(-1234, 36).should eq("-ya") }
+    it { to_s_with_io(1234, 16, upcase: true).should eq("4D2") }
+    it { to_s_with_io(-1234, 16, upcase: true).should eq("-4D2") }
+    it { to_s_with_io(1234, 36, upcase: true).should eq("YA") }
+    it { to_s_with_io(-1234, 36, upcase: true).should eq("-YA") }
+    it { to_s_with_io(0, 2).should eq("0") }
+    it { to_s_with_io(0, 16).should eq("0") }
+    it { to_s_with_io(1, 2).should eq("1") }
+    it { to_s_with_io(1, 16).should eq("1") }
+    it { to_s_with_io(0, 62).should eq("0") }
+    it { to_s_with_io(1, 62).should eq("1") }
+    it { to_s_with_io(10, 62).should eq("a") }
+    it { to_s_with_io(35, 62).should eq("z") }
+    it { to_s_with_io(36, 62).should eq("A") }
+    it { to_s_with_io(61, 62).should eq("Z") }
+    it { to_s_with_io(62, 62).should eq("10") }
+    it { to_s_with_io(97, 62).should eq("1z") }
+    it { to_s_with_io(3843, 62).should eq("ZZ") }
 
     it "raises on base 1 with io" do
       expect_raises { to_s_with_io(123, 1) }
@@ -185,45 +185,45 @@ describe "Int" do
   end
 
   describe "bit" do
-    assert { 5.bit(0).should eq(1) }
-    assert { 5.bit(1).should eq(0) }
-    assert { 5.bit(2).should eq(1) }
-    assert { 5.bit(3).should eq(0) }
-    assert { 0.bit(63).should eq(0) }
-    assert { Int64::MAX.bit(63).should eq(0) }
-    assert { UInt64::MAX.bit(63).should eq(1) }
-    assert { UInt64::MAX.bit(64).should eq(0) }
+    it { 5.bit(0).should eq(1) }
+    it { 5.bit(1).should eq(0) }
+    it { 5.bit(2).should eq(1) }
+    it { 5.bit(3).should eq(0) }
+    it { 0.bit(63).should eq(0) }
+    it { Int64::MAX.bit(63).should eq(0) }
+    it { UInt64::MAX.bit(63).should eq(1) }
+    it { UInt64::MAX.bit(64).should eq(0) }
   end
 
   describe "divmod" do
-    assert { 5.divmod(3).should eq({1, 2}) }
+    it { 5.divmod(3).should eq({1, 2}) }
   end
 
   describe "fdiv" do
-    assert { 1.fdiv(1).should eq 1.0 }
-    assert { 1.fdiv(2).should eq 0.5 }
-    assert { 1.fdiv(0.5).should eq 2.0 }
-    assert { 0.fdiv(1).should eq 0.0 }
-    assert { 1.fdiv(0).should eq 1.0/0.0 }
+    it { 1.fdiv(1).should eq 1.0 }
+    it { 1.fdiv(2).should eq 0.5 }
+    it { 1.fdiv(0.5).should eq 2.0 }
+    it { 0.fdiv(1).should eq 0.0 }
+    it { 1.fdiv(0).should eq 1.0/0.0 }
   end
 
   describe "~" do
-    assert { (~1).should eq(-2) }
-    assert { (~1_u32).should eq(4294967294) }
+    it { (~1).should eq(-2) }
+    it { (~1_u32).should eq(4294967294) }
   end
 
   describe ">>" do
-    assert { (8000 >> 1).should eq(4000) }
-    assert { (8000 >> 2).should eq(2000) }
-    assert { (8000 >> 32).should eq(0) }
-    assert { (8000 >> -1).should eq(16000) }
+    it { (8000 >> 1).should eq(4000) }
+    it { (8000 >> 2).should eq(2000) }
+    it { (8000 >> 32).should eq(0) }
+    it { (8000 >> -1).should eq(16000) }
   end
 
   describe "<<" do
-    assert { (8000 << 1).should eq(16000) }
-    assert { (8000 << 2).should eq(32000) }
-    assert { (8000 << 32).should eq(0) }
-    assert { (8000 << -1).should eq(4000) }
+    it { (8000 << 1).should eq(16000) }
+    it { (8000 << 2).should eq(32000) }
+    it { (8000 << 32).should eq(0) }
+    it { (8000 << -1).should eq(4000) }
   end
 
   describe "to" do
@@ -467,25 +467,25 @@ describe "Int" do
   end
 
   describe "#popcount" do
-    assert { 5_i8.popcount.should eq(2) }
-    assert { 127_i8.popcount.should eq(7) }
-    assert { -1_i8.popcount.should eq(8) }
-    assert { -128_i8.popcount.should eq(1) }
+    it { 5_i8.popcount.should eq(2) }
+    it { 127_i8.popcount.should eq(7) }
+    it { -1_i8.popcount.should eq(8) }
+    it { -128_i8.popcount.should eq(1) }
 
-    assert { 0_u8.popcount.should eq(0) }
-    assert { 255_u8.popcount.should eq(8) }
+    it { 0_u8.popcount.should eq(0) }
+    it { 255_u8.popcount.should eq(8) }
 
-    assert { 5_i16.popcount.should eq(2) }
-    assert { -6_i16.popcount.should eq(14) }
-    assert { 65535_u16.popcount.should eq(16) }
+    it { 5_i16.popcount.should eq(2) }
+    it { -6_i16.popcount.should eq(14) }
+    it { 65535_u16.popcount.should eq(16) }
 
-    assert { 0_i32.popcount.should eq(0) }
-    assert { 2147483647_i32.popcount.should eq(31) }
-    assert { 4294967295_u32.popcount.should eq(32) }
+    it { 0_i32.popcount.should eq(0) }
+    it { 2147483647_i32.popcount.should eq(31) }
+    it { 4294967295_u32.popcount.should eq(32) }
 
-    assert { 5_i64.popcount.should eq(2) }
-    assert { 9223372036854775807_i64.popcount.should eq(63) }
-    assert { 18446744073709551615_u64.popcount.should eq(64) }
+    it { 5_i64.popcount.should eq(2) }
+    it { 9223372036854775807_i64.popcount.should eq(63) }
+    it { 18446744073709551615_u64.popcount.should eq(64) }
   end
 
   it "compares signed vs. unsigned integers" do

--- a/spec/std/levenshtein_spec.cr
+++ b/spec/std/levenshtein_spec.cr
@@ -2,18 +2,18 @@ require "spec"
 require "levenshtein"
 
 describe "levenshtein" do
-  assert { Levenshtein.distance("algorithm", "altruistic").should eq(6) }
-  assert { Levenshtein.distance("1638452297", "444488444").should eq(9) }
-  assert { Levenshtein.distance("", "").should eq(0) }
-  assert { Levenshtein.distance("", "a").should eq(1) }
-  assert { Levenshtein.distance("aaapppp", "").should eq(7) }
-  assert { Levenshtein.distance("frog", "fog").should eq(1) }
-  assert { Levenshtein.distance("fly", "ant").should eq(3) }
-  assert { Levenshtein.distance("elephant", "hippo").should eq(7) }
-  assert { Levenshtein.distance("hippo", "elephant").should eq(7) }
-  assert { Levenshtein.distance("hippo", "zzzzzzzz").should eq(8) }
-  assert { Levenshtein.distance("hello", "hallo").should eq(1) }
-  assert { Levenshtein.distance("こんにちは", "こんちは").should eq(1) }
+  it { Levenshtein.distance("algorithm", "altruistic").should eq(6) }
+  it { Levenshtein.distance("1638452297", "444488444").should eq(9) }
+  it { Levenshtein.distance("", "").should eq(0) }
+  it { Levenshtein.distance("", "a").should eq(1) }
+  it { Levenshtein.distance("aaapppp", "").should eq(7) }
+  it { Levenshtein.distance("frog", "fog").should eq(1) }
+  it { Levenshtein.distance("fly", "ant").should eq(3) }
+  it { Levenshtein.distance("elephant", "hippo").should eq(7) }
+  it { Levenshtein.distance("hippo", "elephant").should eq(7) }
+  it { Levenshtein.distance("hippo", "zzzzzzzz").should eq(8) }
+  it { Levenshtein.distance("hello", "hallo").should eq(1) }
+  it { Levenshtein.distance("こんにちは", "こんちは").should eq(1) }
 
   it "finds with finder" do
     finder = Levenshtein::Finder.new "hallo"

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -149,7 +149,7 @@ describe "Pointer" do
   end
 
   describe "memcmp" do
-    assert do
+    it do
       p1 = Pointer.malloc(4) { |i| i }
       p2 = Pointer.malloc(4) { |i| i }
       p3 = Pointer.malloc(4) { |i| i + 1 }

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -128,7 +128,7 @@ describe Socket::Addrinfo do
   end
 
   describe "#ip_address" do
-    assert do
+    it do
       addrinfos = Socket::Addrinfo.udp("localhost", 80)
       typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
     end

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -193,7 +193,7 @@ describe StringScanner, "#[]?" do
 end
 
 describe StringScanner, "#string" do
-  assert { StringScanner.new("foo").string.should eq("foo") }
+  it { StringScanner.new("foo").string.should eq("foo") }
 end
 
 describe StringScanner, "#offset" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -46,7 +46,7 @@ describe "String" do
       end
     end
 
-    assert { "foo"[3..-10].should eq("") }
+    it { "foo"[3..-10].should eq("") }
 
     it "gets when index is last and count is negative at last with utf-8" do
       expect_raises(ArgumentError) do
@@ -121,14 +121,14 @@ describe "String" do
     end
 
     describe "with a regex" do
-      assert { "FooBar"[/o+/].should eq "oo" }
-      assert { "FooBar"[/([A-Z])/, 1].should eq "F" }
-      assert { "FooBar"[/x/]?.should be_nil }
-      assert { "FooBar"[/x/, 1]?.should be_nil }
-      assert { "FooBar"[/(x)/, 1]?.should be_nil }
-      assert { "FooBar"[/o(o)/, 2]?.should be_nil }
-      assert { "FooBar"[/o(?<this>o)/, "this"].should eq "o" }
-      assert { "FooBar"[/(?<this>x)/, "that"]?.should be_nil }
+      it { "FooBar"[/o+/].should eq "oo" }
+      it { "FooBar"[/([A-Z])/, 1].should eq "F" }
+      it { "FooBar"[/x/]?.should be_nil }
+      it { "FooBar"[/x/, 1]?.should be_nil }
+      it { "FooBar"[/(x)/, 1]?.should be_nil }
+      it { "FooBar"[/o(o)/, 2]?.should be_nil }
+      it { "FooBar"[/o(?<this>o)/, "this"].should eq "o" }
+      it { "FooBar"[/(?<this>x)/, "that"]?.should be_nil }
     end
 
     it "gets with a string" do
@@ -186,153 +186,153 @@ describe "String" do
   end
 
   describe "i" do
-    assert { "1234".to_i.should eq(1234) }
-    assert { "   +1234   ".to_i.should eq(1234) }
-    assert { "   -1234   ".to_i.should eq(-1234) }
-    assert { "   +1234   ".to_i.should eq(1234) }
-    assert { "   -00001234".to_i.should eq(-1234) }
-    assert { "1_234".to_i(underscore: true).should eq(1234) }
-    assert { "1101".to_i(base: 2).should eq(13) }
-    assert { "12ab".to_i(16).should eq(4779) }
-    assert { "0x123abc".to_i(prefix: true).should eq(1194684) }
-    assert { "0b1101".to_i(prefix: true).should eq(13) }
-    assert { "0b001101".to_i(prefix: true).should eq(13) }
-    assert { "0123".to_i(prefix: true).should eq(83) }
-    assert { "123hello".to_i(strict: false).should eq(123) }
-    assert { "99 red balloons".to_i(strict: false).should eq(99) }
-    assert { "   99 red balloons".to_i(strict: false).should eq(99) }
-    assert { expect_raises(ArgumentError) { "hello".to_i } }
-    assert { expect_raises(ArgumentError) { "1__234".to_i } }
-    assert { expect_raises(ArgumentError) { "1_234".to_i } }
-    assert { expect_raises(ArgumentError) { "   1234   ".to_i(whitespace: false) } }
-    assert { expect_raises(ArgumentError) { "0x123".to_i } }
-    assert { expect_raises(ArgumentError) { "0b123".to_i } }
-    assert { expect_raises(ArgumentError) { "000b123".to_i(prefix: true) } }
-    assert { expect_raises(ArgumentError) { "000x123".to_i(prefix: true) } }
-    assert { expect_raises(ArgumentError) { "123hello".to_i } }
-    assert { "z".to_i(36).should eq(35) }
-    assert { "Z".to_i(36).should eq(35) }
-    assert { "0".to_i(62).should eq(0) }
-    assert { "1".to_i(62).should eq(1) }
-    assert { "a".to_i(62).should eq(10) }
-    assert { "z".to_i(62).should eq(35) }
-    assert { "A".to_i(62).should eq(36) }
-    assert { "Z".to_i(62).should eq(61) }
-    assert { "10".to_i(62).should eq(62) }
-    assert { "1z".to_i(62).should eq(97) }
-    assert { "ZZ".to_i(62).should eq(3843) }
+    it { "1234".to_i.should eq(1234) }
+    it { "   +1234   ".to_i.should eq(1234) }
+    it { "   -1234   ".to_i.should eq(-1234) }
+    it { "   +1234   ".to_i.should eq(1234) }
+    it { "   -00001234".to_i.should eq(-1234) }
+    it { "1_234".to_i(underscore: true).should eq(1234) }
+    it { "1101".to_i(base: 2).should eq(13) }
+    it { "12ab".to_i(16).should eq(4779) }
+    it { "0x123abc".to_i(prefix: true).should eq(1194684) }
+    it { "0b1101".to_i(prefix: true).should eq(13) }
+    it { "0b001101".to_i(prefix: true).should eq(13) }
+    it { "0123".to_i(prefix: true).should eq(83) }
+    it { "123hello".to_i(strict: false).should eq(123) }
+    it { "99 red balloons".to_i(strict: false).should eq(99) }
+    it { "   99 red balloons".to_i(strict: false).should eq(99) }
+    it { expect_raises(ArgumentError) { "hello".to_i } }
+    it { expect_raises(ArgumentError) { "1__234".to_i } }
+    it { expect_raises(ArgumentError) { "1_234".to_i } }
+    it { expect_raises(ArgumentError) { "   1234   ".to_i(whitespace: false) } }
+    it { expect_raises(ArgumentError) { "0x123".to_i } }
+    it { expect_raises(ArgumentError) { "0b123".to_i } }
+    it { expect_raises(ArgumentError) { "000b123".to_i(prefix: true) } }
+    it { expect_raises(ArgumentError) { "000x123".to_i(prefix: true) } }
+    it { expect_raises(ArgumentError) { "123hello".to_i } }
+    it { "z".to_i(36).should eq(35) }
+    it { "Z".to_i(36).should eq(35) }
+    it { "0".to_i(62).should eq(0) }
+    it { "1".to_i(62).should eq(1) }
+    it { "a".to_i(62).should eq(10) }
+    it { "z".to_i(62).should eq(35) }
+    it { "A".to_i(62).should eq(36) }
+    it { "Z".to_i(62).should eq(61) }
+    it { "10".to_i(62).should eq(62) }
+    it { "1z".to_i(62).should eq(97) }
+    it { "ZZ".to_i(62).should eq(3843) }
 
     describe "to_i8" do
-      assert { "127".to_i8.should eq(127) }
-      assert { "-128".to_i8.should eq(-128) }
-      assert { expect_raises(ArgumentError) { "128".to_i8 } }
-      assert { expect_raises(ArgumentError) { "-129".to_i8 } }
+      it { "127".to_i8.should eq(127) }
+      it { "-128".to_i8.should eq(-128) }
+      it { expect_raises(ArgumentError) { "128".to_i8 } }
+      it { expect_raises(ArgumentError) { "-129".to_i8 } }
 
-      assert { "127".to_i8?.should eq(127) }
-      assert { "128".to_i8?.should be_nil }
-      assert { "128".to_i8 { 0 }.should eq(0) }
+      it { "127".to_i8?.should eq(127) }
+      it { "128".to_i8?.should be_nil }
+      it { "128".to_i8 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_i8 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_i8 } }
     end
 
     describe "to_u8" do
-      assert { "255".to_u8.should eq(255) }
-      assert { "0".to_u8.should eq(0) }
-      assert { expect_raises(ArgumentError) { "256".to_u8 } }
-      assert { expect_raises(ArgumentError) { "-1".to_u8 } }
+      it { "255".to_u8.should eq(255) }
+      it { "0".to_u8.should eq(0) }
+      it { expect_raises(ArgumentError) { "256".to_u8 } }
+      it { expect_raises(ArgumentError) { "-1".to_u8 } }
 
-      assert { "255".to_u8?.should eq(255) }
-      assert { "256".to_u8?.should be_nil }
-      assert { "256".to_u8 { 0 }.should eq(0) }
+      it { "255".to_u8?.should eq(255) }
+      it { "256".to_u8?.should be_nil }
+      it { "256".to_u8 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_u8 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_u8 } }
     end
 
     describe "to_i16" do
-      assert { "32767".to_i16.should eq(32767) }
-      assert { "-32768".to_i16.should eq(-32768) }
-      assert { expect_raises(ArgumentError) { "32768".to_i16 } }
-      assert { expect_raises(ArgumentError) { "-32769".to_i16 } }
+      it { "32767".to_i16.should eq(32767) }
+      it { "-32768".to_i16.should eq(-32768) }
+      it { expect_raises(ArgumentError) { "32768".to_i16 } }
+      it { expect_raises(ArgumentError) { "-32769".to_i16 } }
 
-      assert { "32767".to_i16?.should eq(32767) }
-      assert { "32768".to_i16?.should be_nil }
-      assert { "32768".to_i16 { 0 }.should eq(0) }
+      it { "32767".to_i16?.should eq(32767) }
+      it { "32768".to_i16?.should be_nil }
+      it { "32768".to_i16 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_i16 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_i16 } }
     end
 
     describe "to_u16" do
-      assert { "65535".to_u16.should eq(65535) }
-      assert { "0".to_u16.should eq(0) }
-      assert { expect_raises(ArgumentError) { "65536".to_u16 } }
-      assert { expect_raises(ArgumentError) { "-1".to_u16 } }
+      it { "65535".to_u16.should eq(65535) }
+      it { "0".to_u16.should eq(0) }
+      it { expect_raises(ArgumentError) { "65536".to_u16 } }
+      it { expect_raises(ArgumentError) { "-1".to_u16 } }
 
-      assert { "65535".to_u16?.should eq(65535) }
-      assert { "65536".to_u16?.should be_nil }
-      assert { "65536".to_u16 { 0 }.should eq(0) }
+      it { "65535".to_u16?.should eq(65535) }
+      it { "65536".to_u16?.should be_nil }
+      it { "65536".to_u16 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_u16 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_u16 } }
     end
 
     describe "to_i32" do
-      assert { "2147483647".to_i32.should eq(2147483647) }
-      assert { "-2147483648".to_i32.should eq(-2147483648) }
-      assert { expect_raises(ArgumentError) { "2147483648".to_i32 } }
-      assert { expect_raises(ArgumentError) { "-2147483649".to_i32 } }
+      it { "2147483647".to_i32.should eq(2147483647) }
+      it { "-2147483648".to_i32.should eq(-2147483648) }
+      it { expect_raises(ArgumentError) { "2147483648".to_i32 } }
+      it { expect_raises(ArgumentError) { "-2147483649".to_i32 } }
 
-      assert { "2147483647".to_i32?.should eq(2147483647) }
-      assert { "2147483648".to_i32?.should be_nil }
-      assert { "2147483648".to_i32 { 0 }.should eq(0) }
+      it { "2147483647".to_i32?.should eq(2147483647) }
+      it { "2147483648".to_i32?.should be_nil }
+      it { "2147483648".to_i32 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_i32 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_i32 } }
     end
 
     describe "to_u32" do
-      assert { "4294967295".to_u32.should eq(4294967295) }
-      assert { "0".to_u32.should eq(0) }
-      assert { expect_raises(ArgumentError) { "4294967296".to_u32 } }
-      assert { expect_raises(ArgumentError) { "-1".to_u32 } }
+      it { "4294967295".to_u32.should eq(4294967295) }
+      it { "0".to_u32.should eq(0) }
+      it { expect_raises(ArgumentError) { "4294967296".to_u32 } }
+      it { expect_raises(ArgumentError) { "-1".to_u32 } }
 
-      assert { "4294967295".to_u32?.should eq(4294967295) }
-      assert { "4294967296".to_u32?.should be_nil }
-      assert { "4294967296".to_u32 { 0 }.should eq(0) }
+      it { "4294967295".to_u32?.should eq(4294967295) }
+      it { "4294967296".to_u32?.should be_nil }
+      it { "4294967296".to_u32 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_u32 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_u32 } }
     end
 
     describe "to_i64" do
-      assert { "9223372036854775807".to_i64.should eq(9223372036854775807) }
-      assert { "-9223372036854775808".to_i64.should eq(-9223372036854775808) }
-      assert { expect_raises(ArgumentError) { "9223372036854775808".to_i64 } }
-      assert { expect_raises(ArgumentError) { "-9223372036854775809".to_i64 } }
+      it { "9223372036854775807".to_i64.should eq(9223372036854775807) }
+      it { "-9223372036854775808".to_i64.should eq(-9223372036854775808) }
+      it { expect_raises(ArgumentError) { "9223372036854775808".to_i64 } }
+      it { expect_raises(ArgumentError) { "-9223372036854775809".to_i64 } }
 
-      assert { "9223372036854775807".to_i64?.should eq(9223372036854775807) }
-      assert { "9223372036854775808".to_i64?.should be_nil }
-      assert { "9223372036854775808".to_i64 { 0 }.should eq(0) }
+      it { "9223372036854775807".to_i64?.should eq(9223372036854775807) }
+      it { "9223372036854775808".to_i64?.should be_nil }
+      it { "9223372036854775808".to_i64 { 0 }.should eq(0) }
 
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_i64 } }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_i64 } }
     end
 
     describe "to_u64" do
-      assert { "18446744073709551615".to_u64.should eq(18446744073709551615) }
-      assert { "0".to_u64.should eq(0) }
-      assert { expect_raises(ArgumentError) { "18446744073709551616".to_u64 } }
-      assert { expect_raises(ArgumentError) { "-1".to_u64 } }
+      it { "18446744073709551615".to_u64.should eq(18446744073709551615) }
+      it { "0".to_u64.should eq(0) }
+      it { expect_raises(ArgumentError) { "18446744073709551616".to_u64 } }
+      it { expect_raises(ArgumentError) { "-1".to_u64 } }
 
-      assert { "18446744073709551615".to_u64?.should eq(18446744073709551615) }
-      assert { "18446744073709551616".to_u64?.should be_nil }
-      assert { "18446744073709551616".to_u64 { 0 }.should eq(0) }
+      it { "18446744073709551615".to_u64?.should eq(18446744073709551615) }
+      it { "18446744073709551616".to_u64?.should be_nil }
+      it { "18446744073709551616".to_u64 { 0 }.should eq(0) }
     end
 
-    assert { "1234".to_i32.should eq(1234) }
-    assert { "1234123412341234".to_i64.should eq(1234123412341234_i64) }
-    assert { "9223372036854775808".to_u64.should eq(9223372036854775808_u64) }
+    it { "1234".to_i32.should eq(1234) }
+    it { "1234123412341234".to_i64.should eq(1234123412341234_i64) }
+    it { "9223372036854775808".to_u64.should eq(9223372036854775808_u64) }
 
-    assert { expect_raises(ArgumentError, "invalid base 1") { "12ab".to_i(1) } }
-    assert { expect_raises(ArgumentError, "invalid base 37") { "12ab".to_i(37) } }
+    it { expect_raises(ArgumentError, "invalid base 1") { "12ab".to_i(1) } }
+    it { expect_raises(ArgumentError, "invalid base 37") { "12ab".to_i(37) } }
 
-    assert { expect_raises { "1Y2P0IJ32E8E7".to_i(36) } }
-    assert { "1Y2P0IJ32E8E7".to_i64(36).should eq(9223372036854775807) }
+    it { expect_raises { "1Y2P0IJ32E8E7".to_i(36) } }
+    it { "1Y2P0IJ32E8E7".to_i64(36).should eq(9223372036854775807) }
   end
 
   it "does to_f" do
@@ -463,211 +463,211 @@ describe "String" do
   end
 
   describe "downcase" do
-    assert { "HELLO!".downcase.should eq("hello!") }
-    assert { "HELLO MAN!".downcase.should eq("hello man!") }
-    assert { "ÁÉÍÓÚĀ".downcase.should eq("áéíóúā") }
-    assert { "AEIİOU".downcase(Unicode::CaseOptions::Turkic).should eq("aeıiou") }
-    assert { "ÁEÍOÚ".downcase(Unicode::CaseOptions::ASCII).should eq("ÁeÍoÚ") }
-    assert { "İ".downcase.should eq("i̇") }
+    it { "HELLO!".downcase.should eq("hello!") }
+    it { "HELLO MAN!".downcase.should eq("hello man!") }
+    it { "ÁÉÍÓÚĀ".downcase.should eq("áéíóúā") }
+    it { "AEIİOU".downcase(Unicode::CaseOptions::Turkic).should eq("aeıiou") }
+    it { "ÁEÍOÚ".downcase(Unicode::CaseOptions::ASCII).should eq("ÁeÍoÚ") }
+    it { "İ".downcase.should eq("i̇") }
   end
 
   describe "upcase" do
-    assert { "hello!".upcase.should eq("HELLO!") }
-    assert { "hello man!".upcase.should eq("HELLO MAN!") }
-    assert { "áéíóúā".upcase.should eq("ÁÉÍÓÚĀ") }
-    assert { "aeıiou".upcase(Unicode::CaseOptions::Turkic).should eq("AEIİOU") }
-    assert { "áeíoú".upcase(Unicode::CaseOptions::ASCII).should eq("áEíOú") }
-    assert { "aeiou".upcase(Unicode::CaseOptions::Turkic).should eq("AEİOU") }
-    assert { "baﬄe".upcase.should eq("BAFFLE") }
-    assert { "ﬀ".upcase.should eq("FF") }
+    it { "hello!".upcase.should eq("HELLO!") }
+    it { "hello man!".upcase.should eq("HELLO MAN!") }
+    it { "áéíóúā".upcase.should eq("ÁÉÍÓÚĀ") }
+    it { "aeıiou".upcase(Unicode::CaseOptions::Turkic).should eq("AEIİOU") }
+    it { "áeíoú".upcase(Unicode::CaseOptions::ASCII).should eq("áEíOú") }
+    it { "aeiou".upcase(Unicode::CaseOptions::Turkic).should eq("AEİOU") }
+    it { "baﬄe".upcase.should eq("BAFFLE") }
+    it { "ﬀ".upcase.should eq("FF") }
   end
 
   describe "capitalize" do
-    assert { "HELLO!".capitalize.should eq("Hello!") }
-    assert { "HELLO MAN!".capitalize.should eq("Hello man!") }
-    assert { "".capitalize.should eq("") }
-    assert { "ﬄİ".capitalize.should eq("FFLi̇") }
-    assert { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
+    it { "HELLO!".capitalize.should eq("Hello!") }
+    it { "HELLO MAN!".capitalize.should eq("Hello man!") }
+    it { "".capitalize.should eq("") }
+    it { "ﬄİ".capitalize.should eq("FFLi̇") }
+    it { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
   end
 
   describe "lchomp" do
-    assert { "hello".lchomp('g').should eq("hello") }
-    assert { "hello".lchomp('h').should eq("ello") }
-    assert { "かたな".lchomp('か').should eq("たな") }
+    it { "hello".lchomp('g').should eq("hello") }
+    it { "hello".lchomp('h').should eq("ello") }
+    it { "かたな".lchomp('か').should eq("たな") }
 
-    assert { "hello".lchomp("good").should eq("hello") }
-    assert { "hello".lchomp("hel").should eq("lo") }
-    assert { "かたな".lchomp("かた").should eq("な") }
+    it { "hello".lchomp("good").should eq("hello") }
+    it { "hello".lchomp("hel").should eq("lo") }
+    it { "かたな".lchomp("かた").should eq("な") }
 
-    assert { "\n\n\n\nhello".lchomp("").should eq("\n\n\n\nhello") }
+    it { "\n\n\n\nhello".lchomp("").should eq("\n\n\n\nhello") }
   end
 
   describe "chomp" do
-    assert { "hello\n".chomp.should eq("hello") }
-    assert { "hello\r".chomp.should eq("hello") }
-    assert { "hello\r\n".chomp.should eq("hello") }
-    assert { "hello".chomp.should eq("hello") }
-    assert { "hello".chomp.should eq("hello") }
-    assert { "かたな\n".chomp.should eq("かたな") }
-    assert { "かたな\r".chomp.should eq("かたな") }
-    assert { "かたな\r\n".chomp.should eq("かたな") }
-    assert { "hello\n\n".chomp.should eq("hello\n") }
-    assert { "hello\r\n\n".chomp.should eq("hello\r\n") }
-    assert { "hello\r\n".chomp('\n').should eq("hello") }
+    it { "hello\n".chomp.should eq("hello") }
+    it { "hello\r".chomp.should eq("hello") }
+    it { "hello\r\n".chomp.should eq("hello") }
+    it { "hello".chomp.should eq("hello") }
+    it { "hello".chomp.should eq("hello") }
+    it { "かたな\n".chomp.should eq("かたな") }
+    it { "かたな\r".chomp.should eq("かたな") }
+    it { "かたな\r\n".chomp.should eq("かたな") }
+    it { "hello\n\n".chomp.should eq("hello\n") }
+    it { "hello\r\n\n".chomp.should eq("hello\r\n") }
+    it { "hello\r\n".chomp('\n').should eq("hello") }
 
-    assert { "hello".chomp('a').should eq("hello") }
-    assert { "hello".chomp('o').should eq("hell") }
-    assert { "かたな".chomp('な').should eq("かた") }
+    it { "hello".chomp('a').should eq("hello") }
+    it { "hello".chomp('o').should eq("hell") }
+    it { "かたな".chomp('な').should eq("かた") }
 
-    assert { "hello".chomp("good").should eq("hello") }
-    assert { "hello".chomp("llo").should eq("he") }
-    assert { "かたな".chomp("たな").should eq("か") }
+    it { "hello".chomp("good").should eq("hello") }
+    it { "hello".chomp("llo").should eq("he") }
+    it { "かたな".chomp("たな").should eq("か") }
 
-    assert { "hello\n\n\n\n".chomp("").should eq("hello\n\n\n\n") }
+    it { "hello\n\n\n\n".chomp("").should eq("hello\n\n\n\n") }
   end
 
   describe "chop" do
-    assert { "foo".chop.should eq("fo") }
-    assert { "foo\n".chop.should eq("foo") }
-    assert { "foo\r".chop.should eq("foo") }
-    assert { "foo\r\n".chop.should eq("foo") }
-    assert { "\r\n".chop.should eq("") }
-    assert { "かたな".chop.should eq("かた") }
-    assert { "かたな\n".chop.should eq("かたな") }
-    assert { "かたな\r\n".chop.should eq("かたな") }
+    it { "foo".chop.should eq("fo") }
+    it { "foo\n".chop.should eq("foo") }
+    it { "foo\r".chop.should eq("foo") }
+    it { "foo\r\n".chop.should eq("foo") }
+    it { "\r\n".chop.should eq("") }
+    it { "かたな".chop.should eq("かた") }
+    it { "かたな\n".chop.should eq("かたな") }
+    it { "かたな\r\n".chop.should eq("かたな") }
   end
 
   describe "strip" do
-    assert { "  hello  \n\t\f\v\r".strip.should eq("hello") }
-    assert { "hello".strip.should eq("hello") }
-    assert { "かたな \n\f\v".strip.should eq("かたな") }
-    assert { "  \n\t かたな \n\f\v".strip.should eq("かたな") }
-    assert { "  \n\t かたな".strip.should eq("かたな") }
-    assert { "かたな".strip.should eq("かたな") }
-    assert { "".strip.should eq("") }
-    assert { "\n".strip.should eq("") }
-    assert { "\n\t  ".strip.should eq("") }
+    it { "  hello  \n\t\f\v\r".strip.should eq("hello") }
+    it { "hello".strip.should eq("hello") }
+    it { "かたな \n\f\v".strip.should eq("かたな") }
+    it { "  \n\t かたな \n\f\v".strip.should eq("かたな") }
+    it { "  \n\t かたな".strip.should eq("かたな") }
+    it { "かたな".strip.should eq("かたな") }
+    it { "".strip.should eq("") }
+    it { "\n".strip.should eq("") }
+    it { "\n\t  ".strip.should eq("") }
 
     # TODO: add spec tags so this can be run with tag:slow
-    # assert { (" " * 167772160).strip.should eq("") }
+    # it { (" " * 167772160).strip.should eq("") }
   end
 
   describe "rstrip" do
-    assert { "  hello  ".rstrip.should eq("  hello") }
-    assert { "hello".rstrip.should eq("hello") }
-    assert { "  かたな \n\f\v".rstrip.should eq("  かたな") }
-    assert { "かたな".rstrip.should eq("かたな") }
+    it { "  hello  ".rstrip.should eq("  hello") }
+    it { "hello".rstrip.should eq("hello") }
+    it { "  かたな \n\f\v".rstrip.should eq("  かたな") }
+    it { "かたな".rstrip.should eq("かたな") }
   end
 
   describe "lstrip" do
-    assert { "  hello  ".lstrip.should eq("hello  ") }
-    assert { "hello".lstrip.should eq("hello") }
-    assert { "  \n\v かたな  ".lstrip.should eq("かたな  ") }
-    assert { "  かたな".lstrip.should eq("かたな") }
+    it { "  hello  ".lstrip.should eq("hello  ") }
+    it { "hello".lstrip.should eq("hello") }
+    it { "  \n\v かたな  ".lstrip.should eq("かたな  ") }
+    it { "  かたな".lstrip.should eq("かたな") }
   end
 
   describe "empty?" do
-    assert { "a".empty?.should be_false }
-    assert { "".empty?.should be_true }
+    it { "a".empty?.should be_false }
+    it { "".empty?.should be_true }
   end
 
   describe "blank?" do
-    assert { " \t\n".blank?.should be_true }
-    assert { "\u{1680}\u{2029}".blank?.should be_true }
-    assert { "hello".blank?.should be_false }
+    it { " \t\n".blank?.should be_true }
+    it { "\u{1680}\u{2029}".blank?.should be_true }
+    it { "hello".blank?.should be_false }
   end
 
   describe "index" do
     describe "by char" do
-      assert { "foo".index('o').should eq(1) }
-      assert { "foo".index('g').should be_nil }
-      assert { "bar".index('r').should eq(2) }
-      assert { "日本語".index('本').should eq(1) }
-      assert { "bar".index('あ').should be_nil }
-      assert { "あいう_えお".index('_').should eq(3) }
+      it { "foo".index('o').should eq(1) }
+      it { "foo".index('g').should be_nil }
+      it { "bar".index('r').should eq(2) }
+      it { "日本語".index('本').should eq(1) }
+      it { "bar".index('あ').should be_nil }
+      it { "あいう_えお".index('_').should eq(3) }
 
       describe "with offset" do
-        assert { "foobarbaz".index('a', 5).should eq(7) }
-        assert { "foobarbaz".index('a', -4).should eq(7) }
-        assert { "foo".index('g', 1).should be_nil }
-        assert { "foo".index('g', -20).should be_nil }
-        assert { "日本語日本語".index('本', 2).should eq(4) }
+        it { "foobarbaz".index('a', 5).should eq(7) }
+        it { "foobarbaz".index('a', -4).should eq(7) }
+        it { "foo".index('g', 1).should be_nil }
+        it { "foo".index('g', -20).should be_nil }
+        it { "日本語日本語".index('本', 2).should eq(4) }
       end
     end
 
     describe "by string" do
-      assert { "foo bar".index("o b").should eq(2) }
-      assert { "foo".index("fg").should be_nil }
-      assert { "foo".index("").should eq(0) }
-      assert { "foo".index("foo").should eq(0) }
-      assert { "日本語日本語".index("本語").should eq(1) }
+      it { "foo bar".index("o b").should eq(2) }
+      it { "foo".index("fg").should be_nil }
+      it { "foo".index("").should eq(0) }
+      it { "foo".index("foo").should eq(0) }
+      it { "日本語日本語".index("本語").should eq(1) }
 
       describe "with offset" do
-        assert { "foobarbaz".index("ba", 4).should eq(6) }
-        assert { "foobarbaz".index("ba", -5).should eq(6) }
-        assert { "foo".index("ba", 1).should be_nil }
-        assert { "foo".index("ba", -20).should be_nil }
-        assert { "foo".index("", 3).should eq(3) }
-        assert { "foo".index("", 4).should be_nil }
-        assert { "日本語日本語".index("本語", 2).should eq(4) }
+        it { "foobarbaz".index("ba", 4).should eq(6) }
+        it { "foobarbaz".index("ba", -5).should eq(6) }
+        it { "foo".index("ba", 1).should be_nil }
+        it { "foo".index("ba", -20).should be_nil }
+        it { "foo".index("", 3).should eq(3) }
+        it { "foo".index("", 4).should be_nil }
+        it { "日本語日本語".index("本語", 2).should eq(4) }
       end
     end
 
     describe "by regex" do
-      assert { "string 12345".index(/\d+/).should eq(7) }
-      assert { "12345".index(/\d/).should eq(0) }
-      assert { "Hello, world!".index(/\d/).should be_nil }
-      assert { "abcdef".index(/[def]/).should eq(3) }
-      assert { "日本語日本語".index(/本語/).should eq(1) }
+      it { "string 12345".index(/\d+/).should eq(7) }
+      it { "12345".index(/\d/).should eq(0) }
+      it { "Hello, world!".index(/\d/).should be_nil }
+      it { "abcdef".index(/[def]/).should eq(3) }
+      it { "日本語日本語".index(/本語/).should eq(1) }
 
       describe "with offset" do
-        assert { "abcDef".index(/[A-Z]/).should eq(3) }
-        assert { "foobarbaz".index(/ba/, -5).should eq(6) }
-        assert { "Foo".index(/[A-Z]/, 1).should be_nil }
-        assert { "foo".index(/o/, 2).should eq(2) }
-        assert { "foo".index(//, 3).should eq(3) }
-        assert { "foo".index(//, 4).should be_nil }
-        assert { "日本語日本語".index(/本語/, 2).should eq(4) }
+        it { "abcDef".index(/[A-Z]/).should eq(3) }
+        it { "foobarbaz".index(/ba/, -5).should eq(6) }
+        it { "Foo".index(/[A-Z]/, 1).should be_nil }
+        it { "foo".index(/o/, 2).should eq(2) }
+        it { "foo".index(//, 3).should eq(3) }
+        it { "foo".index(//, 4).should be_nil }
+        it { "日本語日本語".index(/本語/, 2).should eq(4) }
       end
     end
   end
 
   describe "rindex" do
     describe "by char" do
-      assert { "foobar".rindex('a').should eq(4) }
-      assert { "foobar".rindex('g').should be_nil }
-      assert { "日本語日本語".rindex('本').should eq(4) }
-      assert { "あいう_えお".rindex('_').should eq(3) }
+      it { "foobar".rindex('a').should eq(4) }
+      it { "foobar".rindex('g').should be_nil }
+      it { "日本語日本語".rindex('本').should eq(4) }
+      it { "あいう_えお".rindex('_').should eq(3) }
 
       describe "with offset" do
-        assert { "faobar".rindex('a', 3).should eq(1) }
-        assert { "faobarbaz".rindex('a', -3).should eq(4) }
-        assert { "日本語日本語".rindex('本', 3).should eq(1) }
+        it { "faobar".rindex('a', 3).should eq(1) }
+        it { "faobarbaz".rindex('a', -3).should eq(4) }
+        it { "日本語日本語".rindex('本', 3).should eq(1) }
       end
     end
 
     describe "by string" do
-      assert { "foo baro baz".rindex("o b").should eq(7) }
-      assert { "foo baro baz".rindex("fg").should be_nil }
-      assert { "日本語日本語".rindex("日本").should eq(3) }
+      it { "foo baro baz".rindex("o b").should eq(7) }
+      it { "foo baro baz".rindex("fg").should be_nil }
+      it { "日本語日本語".rindex("日本").should eq(3) }
 
       describe "with offset" do
-        assert { "foo baro baz".rindex("o b", 6).should eq(2) }
-        assert { "foo".rindex("", 3).should eq(3) }
-        assert { "foo".rindex("", 4).should eq(3) }
-        assert { "日本語日本語".rindex("日本", 2).should eq(0) }
+        it { "foo baro baz".rindex("o b", 6).should eq(2) }
+        it { "foo".rindex("", 3).should eq(3) }
+        it { "foo".rindex("", 4).should eq(3) }
+        it { "日本語日本語".rindex("日本", 2).should eq(0) }
       end
     end
 
     describe "by regex" do
-      assert { "bbbb".rindex(/b/).should eq(3) }
-      assert { "a43b53".rindex(/\d+/).should eq(4) }
-      assert { "bbbb".rindex(/\d/).should be_nil }
+      it { "bbbb".rindex(/b/).should eq(3) }
+      it { "a43b53".rindex(/\d+/).should eq(4) }
+      it { "bbbb".rindex(/\d/).should be_nil }
 
       describe "with offset" do
-        assert { "bbbb".rindex(/b/, -3).should eq(2) }
-        assert { "bbbb".rindex(/b/, -1235).should be_nil }
-        assert { "日本語日本語".rindex(/日本/, 2).should eq(0) }
+        it { "bbbb".rindex(/b/, -3).should eq(2) }
+        it { "bbbb".rindex(/b/, -1235).should be_nil }
+        it { "日本語日本語".rindex(/日本/, 2).should eq(0) }
       end
     end
   end
@@ -729,9 +729,9 @@ describe "String" do
   end
 
   describe "byte_index" do
-    assert { "foo".byte_index('o'.ord).should eq(1) }
-    assert { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
-    assert { "foo".byte_index('a'.ord).should be_nil }
+    it { "foo".byte_index('o'.ord).should eq(1) }
+    it { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
+    it { "foo".byte_index('a'.ord).should be_nil }
 
     it "gets byte index of string" do
       "hello world".byte_index("lo").should eq(3)
@@ -740,87 +740,87 @@ describe "String" do
 
   describe "includes?" do
     describe "by char" do
-      assert { "foo".includes?('o').should be_true }
-      assert { "foo".includes?('g').should be_false }
+      it { "foo".includes?('o').should be_true }
+      it { "foo".includes?('g').should be_false }
     end
 
     describe "by string" do
-      assert { "foo bar".includes?("o b").should be_true }
-      assert { "foo".includes?("fg").should be_false }
-      assert { "foo".includes?("").should be_true }
+      it { "foo bar".includes?("o b").should be_true }
+      it { "foo".includes?("fg").should be_false }
+      it { "foo".includes?("").should be_true }
     end
   end
 
   describe "split" do
     describe "by char" do
-      assert { "".split(',').should eq([""]) }
-      assert { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz", ""]) }
-      assert { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo".split(',').should eq(["foo"]) }
-      assert { "foo".split(' ').should eq(["foo"]) }
-      assert { "   foo".split(' ').should eq(["", "", "", "foo"]) }
-      assert { "foo   ".split(' ').should eq(["foo", "", "", ""]) }
-      assert { "   foo  bar".split(' ').should eq(["", "", "", "foo", "", "bar"]) }
-      assert { "   foo   bar\n\t  baz   ".split(' ').should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
-      assert { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
-      assert { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
-      assert { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
-      assert { "   foo   bar\n\t  baz   ".split(" ").should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
-      assert { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(',', 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(',', 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "foo bar baz qux".split(' ', 1).should eq(["foo bar baz qux"]) }
-      assert { "foo bar baz qux".split(' ', 3).should eq(["foo", "bar", "baz qux"]) }
-      assert { "foo bar baz qux".split(' ', 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "a,b,".split(',', 3).should eq(["a", "b", ""]) }
-      assert { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
-      assert { "日本ん語日本ん語".split('ん').should eq(["日本", "語日本", "語"]) }
-      assert { "=".split('=').should eq(["", ""]) }
-      assert { "a=".split('=').should eq(["a", ""]) }
-      assert { "=b".split('=').should eq(["", "b"]) }
-      assert { "=".split('=', 2).should eq(["", ""]) }
+      it { "".split(',').should eq([""]) }
+      it { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz", ""]) }
+      it { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
+      it { "foo".split(',').should eq(["foo"]) }
+      it { "foo".split(' ').should eq(["foo"]) }
+      it { "   foo".split(' ').should eq(["", "", "", "foo"]) }
+      it { "foo   ".split(' ').should eq(["foo", "", "", ""]) }
+      it { "   foo  bar".split(' ').should eq(["", "", "", "foo", "", "bar"]) }
+      it { "   foo   bar\n\t  baz   ".split(' ').should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
+      it { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
+      it { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
+      it { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
+      it { "   foo   bar\n\t  baz   ".split(" ").should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
+      it { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }
+      it { "foo,bar,baz,qux".split(',', 3).should eq(["foo", "bar", "baz,qux"]) }
+      it { "foo,bar,baz,qux".split(',', 30).should eq(["foo", "bar", "baz", "qux"]) }
+      it { "foo bar baz qux".split(' ', 1).should eq(["foo bar baz qux"]) }
+      it { "foo bar baz qux".split(' ', 3).should eq(["foo", "bar", "baz qux"]) }
+      it { "foo bar baz qux".split(' ', 30).should eq(["foo", "bar", "baz", "qux"]) }
+      it { "a,b,".split(',', 3).should eq(["a", "b", ""]) }
+      it { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
+      it { "日本ん語日本ん語".split('ん').should eq(["日本", "語日本", "語"]) }
+      it { "=".split('=').should eq(["", ""]) }
+      it { "a=".split('=').should eq(["a", ""]) }
+      it { "=b".split('=').should eq(["", "b"]) }
+      it { "=".split('=', 2).should eq(["", ""]) }
     end
 
     describe "by string" do
-      assert { "".split(",").should eq([""]) }
-      assert { "".split(":-").should eq([""]) }
-      assert { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz", ""]) }
-      assert { "foo:-bar:-:-baz".split(":-").should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo".split(":-").should eq(["foo"]) }
-      assert { "foo".split("").should eq(["f", "o", "o"]) }
-      assert { "日本さん語日本さん語".split("さん").should eq(["日本", "語日本", "語"]) }
-      assert { "foo,bar,baz,qux".split(",", 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(",", 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(",", 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "a b c".split(" ", 2).should eq(["a", "b c"]) }
-      assert { "=".split("=").should eq(["", ""]) }
-      assert { "a=".split("=").should eq(["a", ""]) }
-      assert { "=b".split("=").should eq(["", "b"]) }
-      assert { "=".split("=", 2).should eq(["", ""]) }
+      it { "".split(",").should eq([""]) }
+      it { "".split(":-").should eq([""]) }
+      it { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz", ""]) }
+      it { "foo:-bar:-:-baz".split(":-").should eq(["foo", "bar", "", "baz"]) }
+      it { "foo".split(":-").should eq(["foo"]) }
+      it { "foo".split("").should eq(["f", "o", "o"]) }
+      it { "日本さん語日本さん語".split("さん").should eq(["日本", "語日本", "語"]) }
+      it { "foo,bar,baz,qux".split(",", 1).should eq(["foo,bar,baz,qux"]) }
+      it { "foo,bar,baz,qux".split(",", 3).should eq(["foo", "bar", "baz,qux"]) }
+      it { "foo,bar,baz,qux".split(",", 30).should eq(["foo", "bar", "baz", "qux"]) }
+      it { "a b c".split(" ", 2).should eq(["a", "b c"]) }
+      it { "=".split("=").should eq(["", ""]) }
+      it { "a=".split("=").should eq(["a", ""]) }
+      it { "=b".split("=").should eq(["", "b"]) }
+      it { "=".split("=", 2).should eq(["", ""]) }
     end
 
     describe "by regex" do
-      assert { "".split(/\n\t/).should eq([""] of String) }
-      assert { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo\n\tbar\n\t\n\tbaz".split(/(?:\n\t)+/).should eq(["foo", "bar", "baz"]) }
-      assert { "foo,bar".split(/,/, 1).should eq(["foo,bar"]) }
-      assert { "foo,bar,".split(/,/).should eq(["foo", "bar", ""]) }
-      assert { "foo,bar,baz,qux".split(/,/, 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(/,/, 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(/,/, 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "a b c".split(Regex.new(" "), 2).should eq(["a", "b c"]) }
-      assert { "日本ん語日本ん語".split(/ん/).should eq(["日本", "語日本", "語"]) }
-      assert { "九十九十九".split(/(?=十)/).should eq(["九", "十九", "十九"]) }
-      assert { "hello world".split(/\b/).should eq(["hello", " ", "world", ""]) }
-      assert { "hello world".split(/\w+|(?= )/).should eq(["", " ", ""]) }
-      assert { "abc".split(//).should eq(["a", "b", "c"]) }
-      assert { "hello".split(/\w+/).should eq(["", ""]) }
-      assert { "foo".split(/o/).should eq(["f", "", ""]) }
-      assert { "=".split(/\=/).should eq(["", ""]) }
-      assert { "a=".split(/\=/).should eq(["a", ""]) }
-      assert { "=b".split(/\=/).should eq(["", "b"]) }
-      assert { "=".split(/\=/, 2).should eq(["", ""]) }
-      assert { ",".split(/(?:(x)|(,))/).should eq(["", ",", ""]) }
+      it { "".split(/\n\t/).should eq([""] of String) }
+      it { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
+      it { "foo\n\tbar\n\t\n\tbaz".split(/(?:\n\t)+/).should eq(["foo", "bar", "baz"]) }
+      it { "foo,bar".split(/,/, 1).should eq(["foo,bar"]) }
+      it { "foo,bar,".split(/,/).should eq(["foo", "bar", ""]) }
+      it { "foo,bar,baz,qux".split(/,/, 1).should eq(["foo,bar,baz,qux"]) }
+      it { "foo,bar,baz,qux".split(/,/, 3).should eq(["foo", "bar", "baz,qux"]) }
+      it { "foo,bar,baz,qux".split(/,/, 30).should eq(["foo", "bar", "baz", "qux"]) }
+      it { "a b c".split(Regex.new(" "), 2).should eq(["a", "b c"]) }
+      it { "日本ん語日本ん語".split(/ん/).should eq(["日本", "語日本", "語"]) }
+      it { "九十九十九".split(/(?=十)/).should eq(["九", "十九", "十九"]) }
+      it { "hello world".split(/\b/).should eq(["hello", " ", "world", ""]) }
+      it { "hello world".split(/\w+|(?= )/).should eq(["", " ", ""]) }
+      it { "abc".split(//).should eq(["a", "b", "c"]) }
+      it { "hello".split(/\w+/).should eq(["", ""]) }
+      it { "foo".split(/o/).should eq(["f", "", ""]) }
+      it { "=".split(/\=/).should eq(["", ""]) }
+      it { "a=".split(/\=/).should eq(["a", ""]) }
+      it { "=b".split(/\=/).should eq(["", "b"]) }
+      it { "=".split(/\=/, 2).should eq(["", ""]) }
+      it { ",".split(/(?:(x)|(,))/).should eq(["", ",", ""]) }
 
       it "keeps groups" do
         s = "split on the word on okay?"
@@ -830,26 +830,26 @@ describe "String" do
   end
 
   describe "starts_with?" do
-    assert { "foobar".starts_with?("foo").should be_true }
-    assert { "foobar".starts_with?("").should be_true }
-    assert { "foobar".starts_with?("foobarbaz").should be_false }
-    assert { "foobar".starts_with?("foox").should be_false }
-    assert { "foobar".starts_with?('f').should be_true }
-    assert { "foobar".starts_with?('g').should be_false }
-    assert { "よし".starts_with?('よ').should be_true }
-    assert { "よし!".starts_with?("よし").should be_true }
+    it { "foobar".starts_with?("foo").should be_true }
+    it { "foobar".starts_with?("").should be_true }
+    it { "foobar".starts_with?("foobarbaz").should be_false }
+    it { "foobar".starts_with?("foox").should be_false }
+    it { "foobar".starts_with?('f').should be_true }
+    it { "foobar".starts_with?('g').should be_false }
+    it { "よし".starts_with?('よ').should be_true }
+    it { "よし!".starts_with?("よし").should be_true }
   end
 
   describe "ends_with?" do
-    assert { "foobar".ends_with?("bar").should be_true }
-    assert { "foobar".ends_with?("").should be_true }
-    assert { "foobar".ends_with?("foobarbaz").should be_false }
-    assert { "foobar".ends_with?("xbar").should be_false }
-    assert { "foobar".ends_with?('r').should be_true }
-    assert { "foobar".ends_with?('x').should be_false }
-    assert { "よし".ends_with?('し').should be_true }
-    assert { "よし".ends_with?('な').should be_false }
-    assert { "あいう_".ends_with?('_').should be_true }
+    it { "foobar".ends_with?("bar").should be_true }
+    it { "foobar".ends_with?("").should be_true }
+    it { "foobar".ends_with?("foobarbaz").should be_false }
+    it { "foobar".ends_with?("xbar").should be_false }
+    it { "foobar".ends_with?('r').should be_true }
+    it { "foobar".ends_with?('x').should be_false }
+    it { "よし".ends_with?('し').should be_true }
+    it { "よし".ends_with?('な').should be_false }
+    it { "あいう_".ends_with?('_').should be_true }
   end
 
   describe "=~" do
@@ -869,16 +869,16 @@ describe "String" do
   end
 
   describe "delete" do
-    assert { "foobar".delete { |char| char == 'o' }.should eq("fbar") }
-    assert { "hello world".delete("lo").should eq("he wrd") }
-    assert { "hello world".delete("lo", "o").should eq("hell wrld") }
-    assert { "hello world".delete("hello", "^l").should eq("ll wrld") }
-    assert { "hello world".delete("ej-m").should eq("ho word") }
-    assert { "hello^world".delete("\\^aeiou").should eq("hllwrld") }
-    assert { "hello-world".delete("a\\-eo").should eq("hllwrld") }
-    assert { "hello world\\r\\n".delete("\\").should eq("hello worldrn") }
-    assert { "hello world\\r\\n".delete("\\A").should eq("hello world\\r\\n") }
-    assert { "hello world\\r\\n".delete("X-\\w").should eq("hello orldrn") }
+    it { "foobar".delete { |char| char == 'o' }.should eq("fbar") }
+    it { "hello world".delete("lo").should eq("he wrd") }
+    it { "hello world".delete("lo", "o").should eq("hell wrld") }
+    it { "hello world".delete("hello", "^l").should eq("ll wrld") }
+    it { "hello world".delete("ej-m").should eq("ho word") }
+    it { "hello^world".delete("\\^aeiou").should eq("hllwrld") }
+    it { "hello-world".delete("a\\-eo").should eq("hllwrld") }
+    it { "hello world\\r\\n".delete("\\").should eq("hello worldrn") }
+    it { "hello world\\r\\n".delete("\\A").should eq("hello world\\r\\n") }
+    it { "hello world\\r\\n".delete("X-\\w").should eq("hello orldrn") }
 
     it "deletes one char" do
       deleted = "foobar".delete('o')
@@ -1721,39 +1721,39 @@ describe "String" do
   end
 
   describe "count" do
-    assert { "hello world".count("lo").should eq(5) }
-    assert { "hello world".count("lo", "o").should eq(2) }
-    assert { "hello world".count("hello", "^l").should eq(4) }
-    assert { "hello world".count("ej-m").should eq(4) }
-    assert { "hello^world".count("\\^aeiou").should eq(4) }
-    assert { "hello-world".count("a\\-eo").should eq(4) }
-    assert { "hello world\\r\\n".count("\\").should eq(2) }
-    assert { "hello world\\r\\n".count("\\A").should eq(0) }
-    assert { "hello world\\r\\n".count("X-\\w").should eq(3) }
-    assert { "aabbcc".count('a').should eq(2) }
-    assert { "aabbcc".count { |c| ['a', 'b'].includes?(c) }.should eq(4) }
+    it { "hello world".count("lo").should eq(5) }
+    it { "hello world".count("lo", "o").should eq(2) }
+    it { "hello world".count("hello", "^l").should eq(4) }
+    it { "hello world".count("ej-m").should eq(4) }
+    it { "hello^world".count("\\^aeiou").should eq(4) }
+    it { "hello-world".count("a\\-eo").should eq(4) }
+    it { "hello world\\r\\n".count("\\").should eq(2) }
+    it { "hello world\\r\\n".count("\\A").should eq(0) }
+    it { "hello world\\r\\n".count("X-\\w").should eq(3) }
+    it { "aabbcc".count('a').should eq(2) }
+    it { "aabbcc".count { |c| ['a', 'b'].includes?(c) }.should eq(4) }
   end
 
   describe "squeeze" do
-    assert { "aaabbbccc".squeeze { |c| ['a', 'b'].includes?(c) }.should eq("abccc") }
-    assert { "aaabbbccc".squeeze { |c| ['a', 'c'].includes?(c) }.should eq("abbbc") }
-    assert { "a       bbb".squeeze.should eq("a b") }
-    assert { "a    bbb".squeeze(' ').should eq("a bbb") }
-    assert { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
+    it { "aaabbbccc".squeeze { |c| ['a', 'b'].includes?(c) }.should eq("abccc") }
+    it { "aaabbbccc".squeeze { |c| ['a', 'c'].includes?(c) }.should eq("abbbc") }
+    it { "a       bbb".squeeze.should eq("a b") }
+    it { "a    bbb".squeeze(' ').should eq("a bbb") }
+    it { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
   end
 
   describe "ljust" do
-    assert { "123".ljust(2).should eq("123") }
-    assert { "123".ljust(5).should eq("123  ") }
-    assert { "12".ljust(7, '-').should eq("12-----") }
-    assert { "12".ljust(7, 'あ').should eq("12あああああ") }
+    it { "123".ljust(2).should eq("123") }
+    it { "123".ljust(5).should eq("123  ") }
+    it { "12".ljust(7, '-').should eq("12-----") }
+    it { "12".ljust(7, 'あ').should eq("12あああああ") }
   end
 
   describe "rjust" do
-    assert { "123".rjust(2).should eq("123") }
-    assert { "123".rjust(5).should eq("  123") }
-    assert { "12".rjust(7, '-').should eq("-----12") }
-    assert { "12".rjust(7, 'あ').should eq("あああああ12") }
+    it { "123".rjust(2).should eq("123") }
+    it { "123".rjust(5).should eq("  123") }
+    it { "12".rjust(7, '-').should eq("-----12") }
+    it { "12".rjust(7, 'あ').should eq("あああああ12") }
   end
 
   describe "succ" do

--- a/spec/std/symbol_spec.cr
+++ b/spec/std/symbol_spec.cr
@@ -25,6 +25,6 @@ describe Symbol do
   end
 
   describe "clone" do
-    assert { :foo.clone.should eq(:foo) }
+    it { :foo.clone.should eq(:foo) }
   end
 end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -370,49 +370,49 @@ describe Time do
     t.millisecond.should eq(0)
   end
 
-  assert { Time.parse("2014", "%Y").year.should eq(2014) }
-  assert { Time.parse("19", "%C").year.should eq(1900) }
-  assert { Time.parse("14", "%y").year.should eq(2014) }
-  assert { Time.parse("09", "%m").month.should eq(9) }
-  assert { Time.parse(" 9", "%_m").month.should eq(9) }
-  assert { Time.parse("9", "%-m").month.should eq(9) }
-  assert { Time.parse("February", "%B").month.should eq(2) }
-  assert { Time.parse("March", "%B").month.should eq(3) }
-  assert { Time.parse("MaRcH", "%B").month.should eq(3) }
-  assert { Time.parse("MaR", "%B").month.should eq(3) }
-  assert { Time.parse("MARCH", "%^B").month.should eq(3) }
-  assert { Time.parse("Mar", "%b").month.should eq(3) }
-  assert { Time.parse("Mar", "%^b").month.should eq(3) }
-  assert { Time.parse("MAR", "%^b").month.should eq(3) }
-  assert { Time.parse("MAR", "%h").month.should eq(3) }
-  assert { Time.parse("MAR", "%^h").month.should eq(3) }
-  assert { Time.parse("2", "%d").day.should eq(2) }
-  assert { Time.parse("02", "%d").day.should eq(2) }
-  assert { Time.parse("02", "%-d").day.should eq(2) }
-  assert { Time.parse(" 2", "%e").day.should eq(2) }
-  assert { Time.parse("9", "%H").hour.should eq(9) }
-  assert { Time.parse(" 9", "%k").hour.should eq(9) }
-  assert { Time.parse("09", "%I").hour.should eq(9) }
-  assert { Time.parse(" 9", "%l").hour.should eq(9) }
-  assert { Time.parse("9pm", "%l%p").hour.should eq(21) }
-  assert { Time.parse("9PM", "%l%P").hour.should eq(21) }
-  assert { Time.parse("09", "%M").minute.should eq(9) }
-  assert { Time.parse("09", "%S").second.should eq(9) }
-  assert { Time.parse("123", "%L").millisecond.should eq(123) }
-  assert { Time.parse("Fri Oct 31 23:00:24 2014", "%c").to_s.should eq("2014-10-31 23:00:24") }
-  assert { Time.parse("10/31/14", "%D").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("10/31/69", "%D").to_s.should eq("1969-10-31 00:00:00") }
-  assert { Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("10/31/14", "%x").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("10:11:12", "%X").to_s.should eq("0001-01-01 10:11:12") }
-  assert { Time.parse("11:14:01 PM", "%r").to_s.should eq("0001-01-01 23:14:01") }
-  assert { Time.parse("11:14", "%R").to_s.should eq("0001-01-01 11:14:00") }
-  assert { Time.parse("11:12:13", "%T").to_s.should eq("0001-01-01 11:12:13") }
-  assert { Time.parse("This was done on Friday, October 31, 2014", "This was done on %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("今は Friday, October 31, 2014", "今は %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00") }
-  assert { Time.parse("epoch: 1459864667", "epoch: %s").epoch.should eq(1459864667) }
-  assert { Time.parse("epoch: -1459864667", "epoch: %s").epoch.should eq(-1459864667) }
+  it { Time.parse("2014", "%Y").year.should eq(2014) }
+  it { Time.parse("19", "%C").year.should eq(1900) }
+  it { Time.parse("14", "%y").year.should eq(2014) }
+  it { Time.parse("09", "%m").month.should eq(9) }
+  it { Time.parse(" 9", "%_m").month.should eq(9) }
+  it { Time.parse("9", "%-m").month.should eq(9) }
+  it { Time.parse("February", "%B").month.should eq(2) }
+  it { Time.parse("March", "%B").month.should eq(3) }
+  it { Time.parse("MaRcH", "%B").month.should eq(3) }
+  it { Time.parse("MaR", "%B").month.should eq(3) }
+  it { Time.parse("MARCH", "%^B").month.should eq(3) }
+  it { Time.parse("Mar", "%b").month.should eq(3) }
+  it { Time.parse("Mar", "%^b").month.should eq(3) }
+  it { Time.parse("MAR", "%^b").month.should eq(3) }
+  it { Time.parse("MAR", "%h").month.should eq(3) }
+  it { Time.parse("MAR", "%^h").month.should eq(3) }
+  it { Time.parse("2", "%d").day.should eq(2) }
+  it { Time.parse("02", "%d").day.should eq(2) }
+  it { Time.parse("02", "%-d").day.should eq(2) }
+  it { Time.parse(" 2", "%e").day.should eq(2) }
+  it { Time.parse("9", "%H").hour.should eq(9) }
+  it { Time.parse(" 9", "%k").hour.should eq(9) }
+  it { Time.parse("09", "%I").hour.should eq(9) }
+  it { Time.parse(" 9", "%l").hour.should eq(9) }
+  it { Time.parse("9pm", "%l%p").hour.should eq(21) }
+  it { Time.parse("9PM", "%l%P").hour.should eq(21) }
+  it { Time.parse("09", "%M").minute.should eq(9) }
+  it { Time.parse("09", "%S").second.should eq(9) }
+  it { Time.parse("123", "%L").millisecond.should eq(123) }
+  it { Time.parse("Fri Oct 31 23:00:24 2014", "%c").to_s.should eq("2014-10-31 23:00:24") }
+  it { Time.parse("10/31/14", "%D").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("10/31/69", "%D").to_s.should eq("1969-10-31 00:00:00") }
+  it { Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("10/31/14", "%x").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("10:11:12", "%X").to_s.should eq("0001-01-01 10:11:12") }
+  it { Time.parse("11:14:01 PM", "%r").to_s.should eq("0001-01-01 23:14:01") }
+  it { Time.parse("11:14", "%R").to_s.should eq("0001-01-01 11:14:00") }
+  it { Time.parse("11:12:13", "%T").to_s.should eq("0001-01-01 11:12:13") }
+  it { Time.parse("This was done on Friday, October 31, 2014", "This was done on %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("今は Friday, October 31, 2014", "今は %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00") }
+  it { Time.parse("epoch: 1459864667", "epoch: %s").epoch.should eq(1459864667) }
+  it { Time.parse("epoch: -1459864667", "epoch: %s").epoch.should eq(-1459864667) }
 
   # TODO %N
   # TODO %Z
@@ -427,37 +427,37 @@ describe Time do
   # TODO %%
   # TODO %v
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 Z hi", "%F %T %z hi")
     time.utc?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 10:11:12 UTC")
   end
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 UTC hi", "%F %T %z hi")
     time.utc?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 10:11:12 UTC")
   end
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 -06:00 hi", "%F %T %z hi")
     time.local?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 16:11:12 UTC")
   end
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 +05:00 hi", "%F %T %z hi")
     time.local?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 05:11:12 UTC")
   end
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 -06:00:00 hi", "%F %T %z hi")
     time.local?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 16:11:12 UTC")
   end
 
-  assert do
+  it do
     time = Time.parse("2014-10-31 10:11:12 -060000 hi", "%F %T %z hi")
     time.local?.should be_true
     time.to_utc.to_s.should eq("2014-10-31 16:11:12 UTC")

--- a/spec/std/uri/uri_parser_spec.cr
+++ b/spec/std/uri/uri_parser_spec.cr
@@ -267,6 +267,6 @@ describe URI::Parser, "#run" do
   end
 
   context "bad urls" do
-    assert { expect_raises(URI::Error) { URI::Parser.new("http://some.com:8f80/path").run } }
+    it { expect_raises(URI::Error) { URI::Parser.new("http://some.com:8f80/path").run } }
   end
 end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -32,12 +32,12 @@ describe "URI" do
   assert_uri("/foo?q=1", path: "/foo", query: "q=1")
   assert_uri("mailto:foo@example.org", scheme: "mailto", path: nil, opaque: "foo@example.org")
 
-  assert { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
-  assert { URI.parse("http://www.example.com").full_path.should eq("/") }
-  assert { URI.parse("http://www.example.com/foo?q=1").full_path.should eq("/foo?q=1") }
-  assert { URI.parse("http://www.example.com/?q=1").full_path.should eq("/?q=1") }
-  assert { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
-  assert { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
+  it { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
+  it { URI.parse("http://www.example.com").full_path.should eq("/") }
+  it { URI.parse("http://www.example.com/foo?q=1").full_path.should eq("/foo?q=1") }
+  it { URI.parse("http://www.example.com/?q=1").full_path.should eq("/?q=1") }
+  it { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
+  it { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
 
   describe "normalize" do
     it "removes dot notation from path" do
@@ -76,34 +76,34 @@ describe "URI" do
   end
 
   describe "userinfo" do
-    assert { URI.parse("http://www.example.com").userinfo.should be_nil }
-    assert { URI.parse("http://foo@www.example.com").userinfo.should eq("foo") }
-    assert { URI.parse("http://foo:bar@www.example.com").userinfo.should eq("foo:bar") }
+    it { URI.parse("http://www.example.com").userinfo.should be_nil }
+    it { URI.parse("http://foo@www.example.com").userinfo.should eq("foo") }
+    it { URI.parse("http://foo:bar@www.example.com").userinfo.should eq("foo:bar") }
   end
 
   describe "to_s" do
-    assert { URI.new("http", "www.example.com").to_s.should eq("http://www.example.com") }
-    assert { URI.new("http", "www.example.com", 80).to_s.should eq("http://www.example.com") }
-    assert do
+    it { URI.new("http", "www.example.com").to_s.should eq("http://www.example.com") }
+    it { URI.new("http", "www.example.com", 80).to_s.should eq("http://www.example.com") }
+    it do
       u = URI.new("http", "www.example.com")
       u.user = "alice"
       u.to_s.should eq("http://alice@www.example.com")
       u.password = "s3cr3t"
       u.to_s.should eq("http://alice:s3cr3t@www.example.com")
     end
-    assert do
+    it do
       u = URI.new("http", "www.example.com")
       u.user = ":D"
       u.to_s.should eq("http://%3AD@www.example.com")
       u.password = "@_@"
       u.to_s.should eq("http://%3AD:%40_%40@www.example.com")
     end
-    assert { URI.new("http", "www.example.com", user: "@al:ce", password: "s/cr3t").to_s.should eq("http://%40al%3Ace:s%2Fcr3t@www.example.com") }
-    assert { URI.new("http", "www.example.com", fragment: "top").to_s.should eq("http://www.example.com#top") }
-    assert { URI.new("http", "www.example.com", 1234).to_s.should eq("http://www.example.com:1234") }
-    assert { URI.new("http", "www.example.com", 80, "/hello").to_s.should eq("http://www.example.com/hello") }
-    assert { URI.new("http", "www.example.com", 80, "/hello", "a=1").to_s.should eq("http://www.example.com/hello?a=1") }
-    assert { URI.new("mailto", opaque: "foo@example.com").to_s.should eq("mailto:foo@example.com") }
+    it { URI.new("http", "www.example.com", user: "@al:ce", password: "s/cr3t").to_s.should eq("http://%40al%3Ace:s%2Fcr3t@www.example.com") }
+    it { URI.new("http", "www.example.com", fragment: "top").to_s.should eq("http://www.example.com#top") }
+    it { URI.new("http", "www.example.com", 1234).to_s.should eq("http://www.example.com:1234") }
+    it { URI.new("http", "www.example.com", 80, "/hello").to_s.should eq("http://www.example.com/hello") }
+    it { URI.new("http", "www.example.com", 80, "/hello", "a=1").to_s.should eq("http://www.example.com/hello?a=1") }
+    it { URI.new("mailto", opaque: "foo@example.com").to_s.should eq("mailto:foo@example.com") }
   end
 
   describe ".unescape" do

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -3,12 +3,12 @@ require "yaml"
 
 describe "YAML" do
   describe "parser" do
-    assert { YAML.parse("foo").should eq("foo") }
-    assert { YAML.parse("- foo\n- bar").should eq(["foo", "bar"]) }
-    assert { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
-    assert { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
-    assert { YAML.parse("--- []\n").should eq([] of YAML::Type) }
-    assert { YAML.parse("---\n...").should eq("") }
+    it { YAML.parse("foo").should eq("foo") }
+    it { YAML.parse("- foo\n- bar").should eq(["foo", "bar"]) }
+    it { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
+    it { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
+    it { YAML.parse("--- []\n").should eq([] of YAML::Type) }
+    it { YAML.parse("---\n...").should eq("") }
 
     it "parses recursive sequence" do
       doc = YAML.parse("--- &foo\n- *foo\n")

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -36,6 +36,7 @@ module Spec::Methods
     Spec::RootContext.report(:pending, description, file, line)
   end
 
+  # DEPRECATED: Use `#it`
   def assert(file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     it("assert", file, line, end_line, &block)
   end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -7,7 +7,7 @@ module Spec::Methods
     describe(description.to_s, file, line, &block)
   end
 
-  def it(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     return unless Spec.matches?(description, file, line, end_line)
 
     Spec.formatters.each(&.before_example(description))
@@ -28,7 +28,7 @@ module Spec::Methods
     end
   end
 
-  def pending(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     return unless Spec.matches?(description, file, line, end_line)
 
     Spec.formatters.each(&.before_example(description))


### PR DESCRIPTION
Discussion on #3921.

`it do ... end` provides a drop-in replacement for `assert do ... end`, ergo it is replaced in all areas where it is used.