### PR TITLE
Makefile: allow overriding AR the same way CC/CXX can be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(CXX) -c $(CXXFLAGS) -o $@ $< `$(LLVM_CONFIG) --cxxflags`
 
 $(LIB_CRYSTAL_TARGET): $(LIB_CRYSTAL_OBJS)
-	ar -rcs $@ $^
+	$(AR) -rcs $@ $^
 
 .PHONY: clean
 clean: ## Clean up built directories and files


### PR DESCRIPTION
Reported-by: Michał Górny
Bug: https://bugs.gentoo.org/607468
Signed-off-by: Sergei Trofimovich <siarheit@google.com>