### PR TITLE
Fix window.sessionStorage being not accessible in local paths

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -1,5 +1,8 @@
 document.addEventListener('DOMContentLoaded', function() {
-  var sessionStorage = window.sessionStorage;
+  var sessionStorage;
+  try {
+    sessionStorage = window.sessionStorage;
+  } catch (e) { }
   if(!sessionStorage) {
     sessionStorage = {
       setItem: function() {},


### PR DESCRIPTION
This PR fixes error thrown (Chrome 56, macOS) when accessing docs through local `file:///` paths:

```
Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
```