### PR TITLE
Get backtrace function names from DWARF sections

### DIFF
--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -17,9 +17,9 @@ describe "Backtrace" do
     output = `#{tempfile.path}`
 
     # resolved file line:column
-    output.should match(/#{sample} 3:10/) # callee1
-    output.should match(/#{sample} 15:3/) # callee3
-    output.should match(/#{sample} 17:1/) # ???
+    output.should match(/callee1 at #{sample} 3:10/)
+    output.should match(/callee3 at #{sample} 15:3/)
+    output.should match(/__crystal_main at #{sample} 17:1/)
 
     # skipped internal details
     output.should_not match(/src\/callstack\.cr/)

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -146,7 +146,9 @@ struct CallStack
 
   private def decode_backtrace
     @callstack.compact_map do |ip|
-      file, line, column = CallStack.decode_line_number(ip)
+      pc = CallStack.decode_address(ip)
+
+      file, line, column = CallStack.decode_line_number(pc)
       if file == "??"
         file_line_column = "??"
       else
@@ -154,7 +156,9 @@ struct CallStack
         file_line_column = "#{file} #{line}:#{column}"
       end
 
-      if frame = CallStack.decode_frame(ip)
+      if name = CallStack.decode_function_name(pc)
+        function = name
+      elsif frame = CallStack.decode_frame(ip)
         _, sname = frame
         function = String.new(sname)
       else
@@ -167,10 +171,12 @@ struct CallStack
 
   {% if flag?(:darwin) || flag?(:freebsd) || flag?(:linux) || flag?(:openbsd) %}
     @@dwarf_line_numbers : Debug::DWARF::LineNumbers?
+    @@dwarf_function_names : Array(Tuple(LibC::SizeT, LibC::SizeT, String))?
 
-    protected def self.decode_line_number(ip)
-      if ln = dwarf_line_numbers
-        if row = ln.find(decode_address(ip))
+    protected def self.decode_line_number(pc)
+      read_dwarf_sections unless @@dwarf_line_numbers
+      if ln = @@dwarf_line_numbers
+        if row = ln.find(pc)
           path = ln.files[row.file]?
           if dirname = ln.directories[row.directory]?
             path = "#{dirname}/#{path}"
@@ -181,13 +187,72 @@ struct CallStack
       {"??", 0, 0}
     end
 
+    protected def self.decode_function_name(pc)
+      read_dwarf_sections unless @@dwarf_function_names
+      if fn = @@dwarf_function_names
+        fn.each do |(low_pc, high_pc, function_name)|
+          return function_name if low_pc <= pc <= high_pc
+        end
+      end
+    end
+
+    protected def self.parse_function_names_from_dwarf(info, strings)
+      info.each do |code, abbrev, attributes|
+        next unless abbrev && abbrev.tag.subprogram?
+        name = low_pc = high_pc = nil
+
+        attributes.each do |(at, form, value)|
+          case at
+          when Debug::DWARF::AT::DW_AT_name
+            value = strings.try(&.decode(value.as(UInt32 | UInt64))) if form.strp?
+            name = value.as(String)
+          when Debug::DWARF::AT::DW_AT_low_pc
+            low_pc = value.as(LibC::SizeT)
+          when Debug::DWARF::AT::DW_AT_high_pc
+            if form.addr?
+              high_pc = value.as(LibC::SizeT)
+            elsif value.responds_to?(:to_i)
+              high_pc = low_pc.as(LibC::SizeT) + value.to_i
+            end
+          end
+        end
+
+        if low_pc && high_pc && name
+          yield low_pc, high_pc, name
+        end
+      end
+    end
+
     {% if flag?(:darwin) %}
       @@image_slide : LibC::Long?
 
-      protected def self.dwarf_line_numbers
-        @@dwarf_line_numbers ||= locate_dsym_bundle do |mach_o|
+      protected def self.read_dwarf_sections
+        locate_dsym_bundle do |mach_o|
           mach_o.read_section?("__debug_line") do |sh, io|
-            Debug::DWARF::LineNumbers.new(io, sh.size)
+            @@dwarf_line_numbers = Debug::DWARF::LineNumbers.new(io, sh.size)
+          end
+
+          strings = mach_o.read_section?("__debug_str") do |sh, io|
+            Debug::DWARF::Strings.new(io, sh.offset)
+          end
+
+          mach_o.read_section?("__debug_info") do |sh, io|
+            names = [] of {LibC::SizeT, LibC::SizeT, String}
+
+            while io.tell - sh.offset < sh.size
+              offset = io.tell - sh.offset
+              info = Debug::DWARF::Info.new(io, offset)
+
+              mach_o.read_section?("__debug_abbrev") do |sh, io|
+                info.read_abbreviations(io)
+              end
+
+              parse_function_names_from_dwarf(info, strings) do |name, low_pc, high_pc|
+                names << {name, low_pc, high_pc}
+              end
+            end
+
+            @@dwarf_function_names = names
           end
         end
       end
@@ -259,14 +324,37 @@ struct CallStack
     {% else %}
       @@base_address : UInt64|UInt32|Nil
 
-      protected def self.dwarf_line_numbers
-        @@dwarf_line_numbers ||= Debug::ELF.open(PROGRAM_NAME) do |elf|
+      protected def self.read_dwarf_sections
+        Debug::ELF.open(PROGRAM_NAME) do |elf|
           elf.read_section?(".text") do |sh, _|
             @@base_address = sh.addr - sh.offset
           end
 
           elf.read_section?(".debug_line") do |sh, io|
-            Debug::DWARF::LineNumbers.new(io, sh.size)
+            @@dwarf_line_numbers = Debug::DWARF::LineNumbers.new(io, sh.size)
+          end
+
+          strings = elf.read_section?(".debug_str") do |sh, io|
+            Debug::DWARF::Strings.new(io, sh.offset)
+          end
+
+          elf.read_section?(".debug_info") do |sh, io|
+            names = [] of {LibC::SizeT, LibC::SizeT, String}
+
+            while io.tell - sh.offset < sh.size
+              offset = io.tell - sh.offset
+              info = Debug::DWARF::Info.new(io, offset)
+
+              elf.read_section?(".debug_abbrev") do |sh, io|
+                info.read_abbreviations(io)
+              end
+
+              parse_function_names_from_dwarf(info, strings) do |name, low_pc, high_pc|
+                names << {name, low_pc, high_pc}
+              end
+            end
+
+            @@dwarf_function_names = names
           end
         end
       end
@@ -287,8 +375,16 @@ struct CallStack
       end
     {% end %}
   {% else %}
-    def self.decode_line_number(ip)
+    def self.decode_address(ip)
+      ip
+    end
+
+    def self.decode_line_number(pc)
       {"??", 0, 0}
+    end
+
+    def self.decode_function_name(pc)
+      nil
     end
   {% end %}
 

--- a/src/debug/dwarf.cr
+++ b/src/debug/dwarf.cr
@@ -1,4 +1,7 @@
+require "./dwarf/abbrev"
+require "./dwarf/info"
 require "./dwarf/line_numbers"
+require "./dwarf/strings"
 
 module Debug
   module DWARF

--- a/src/debug/dwarf/abbrev.cr
+++ b/src/debug/dwarf/abbrev.cr
@@ -1,0 +1,237 @@
+require "../dwarf"
+
+module Debug
+  module DWARF
+    enum TAG : UInt32
+      ArrayType       = 0x01
+      ClassType       = 0x02
+      EntryPoint      = 0x03
+      EnumerationType = 0x04
+      FormalParameter = 0x05
+
+      ImportedDeclaration    = 0x08
+      Label                  = 0x0a
+      LexicalBlock           = 0x0b
+      Member                 = 0x0d
+      PointerType            = 0x0f
+      ReferenceType          = 0x10
+      CompileUnit            = 0x11
+      StringType             = 0x12
+      StructureType          = 0x13
+      SubroutineType         = 0x15
+      Typedef                = 0x16
+      UnionType              = 0x17
+      UnspecifiedParameters  = 0x18
+      Variant                = 0x19
+      CommonBlock            = 0x1a
+      CommonInclusion        = 0x1b
+      Inheritance            = 0x1c
+      InlinedSubroutine      = 0x1d
+      Module                 = 0x1e
+      PtrToMemberType        = 0x1f
+      SetType                = 0x20
+      SubrangeType           = 0x21
+      WithStmt               = 0x22
+      AccessDeclaration      = 0x23
+      BaseType               = 0x24
+      CatchBlock             = 0x25
+      ConstType              = 0x26
+      Constant               = 0x27
+      Enumerator             = 0x28
+      FileType               = 0x29
+      Friend                 = 0x2a
+      Namelist               = 0x2b
+      NamelistItem           = 0x2c
+      PackedType             = 0x2d
+      Subprogram             = 0x2e
+      TemplateTypeParameter  = 0x2f
+      TemplateValueParameter = 0x30
+      ThrownType             = 0x31
+      TryBlock               = 0x32
+      VariantPart            = 0x33
+      Variable               = 0x34
+      VolatileType           = 0x35
+      DwarfProcedure         = 0x36
+      RestrictType           = 0x37
+      InterfaceType          = 0x38
+      Namespace              = 0x39
+      ImportedModule         = 0x3a
+      UnspecifiedType        = 0x3b
+      PartialUnit            = 0x3c
+      ImportedUnit           = 0x3d
+      Condition              = 0x3f
+      SharedType             = 0x40
+      TypeUnit               = 0x41
+      RvalueReferenceType    = 0x42
+      TemplateAlias          = 0x43
+    end
+
+    enum AT : UInt32
+      DW_AT_sibling              = 0x01 # reference
+      DW_AT_location             = 0x02 # exprloc, loclistptr
+      DW_AT_name                 = 0x03 # string
+      DW_AT_ordering             = 0x09 # constant
+      DW_AT_byte_size            = 0x0b # constant, exprloc, reference
+      DW_AT_bit_offset           = 0x0c # constant, exprloc, reference
+      DW_AT_bit_size             = 0x0d # constant, exprloc, reference
+      DW_AT_stmt_list            = 0x10 # lineptr
+      DW_AT_low_pc               = 0x11 # address
+      DW_AT_high_pc              = 0x12 # address, constant
+      DW_AT_language             = 0x13 # constant
+      DW_AT_discr                = 0x15 # reference
+      DW_AT_discr_value          = 0x16 # constant
+      DW_AT_visibility           = 0x17 # constant
+      DW_AT_import               = 0x18 # reference
+      DW_AT_string_length        = 0x19 # exprloc, loclistptr
+      DW_AT_common_reference     = 0x1a # reference
+      DW_AT_comp_dir             = 0x1b # string
+      DW_AT_const_value          = 0x1c # block, constant, string
+      DW_AT_containing_type      = 0x1d # reference
+      DW_AT_default_value        = 0x1e # reference
+      DW_AT_inline               = 0x20 # constant
+      DW_AT_is_optional          = 0x21 # flag
+      DW_AT_lower_bound          = 0x22 # constant, exprloc, reference
+      DW_AT_producer             = 0x25 # string
+      DW_AT_prototyped           = 0x27 # flag
+      DW_AT_return_addr          = 0x2a # exprloc, loclistptr
+      DW_AT_start_scope          = 0x2c # constant, rangelistptr
+      DW_AT_bit_stride           = 0x2e # constant, exprloc, reference
+      DW_AT_upper_bound          = 0x2f # constant, exprloc, reference
+      DW_AT_abstract_origin      = 0x31 # reference
+      DW_AT_accessibility        = 0x32 # constant
+      DW_AT_address_class        = 0x33 # constant
+      DW_AT_artificial           = 0x34 # flag
+      DW_AT_base_types           = 0x35 # reference
+      DW_AT_calling_convention   = 0x36 # constant
+      DW_AT_count                = 0x37 # constant, exprloc, reference
+      DW_AT_data_member_location = 0x38 # constant, exprloc, loclistptr
+      DW_AT_decl_column          = 0x39 # constant
+      DW_AT_decl_file            = 0x3a # constant
+      DW_AT_decl_line            = 0x3b # constant
+      DW_AT_declaration          = 0x3c # flag
+      DW_AT_discr_list           = 0x3d # block
+      DW_AT_encoding             = 0x3e # constant
+      DW_AT_external             = 0x3f # flag
+      DW_AT_frame_base           = 0x40 # exprloc, loclistptr
+      DW_AT_friend               = 0x41 # reference
+      DW_AT_identifier_case      = 0x42 # constant
+      DW_AT_macro_info           = 0x43 # macptr
+      DW_AT_namelist_item        = 0x44 # reference
+      DW_AT_priority             = 0x45 # reference
+      DW_AT_segment              = 0x46 # exprloc, loclistptr
+      DW_AT_specification        = 0x47 # reference
+      DW_AT_static_link          = 0x48 # exprloc, loclistptr
+      DW_AT_type                 = 0x49 # reference
+      DW_AT_use_location         = 0x4a # exprloc, loclistptr
+      DW_AT_variable_parameter   = 0x4b # flag
+      DW_AT_virtuality           = 0x4c # constant
+      DW_AT_vtable_elem_location = 0x4d # exprloc, loclistptr
+      DW_AT_allocated            = 0x4e # constant, exprloc, reference
+      DW_AT_associated           = 0x4f # constant, exprloc, reference
+      DW_AT_data_location        = 0x50 # exprloc
+      DW_AT_byte_stride          = 0x51 # constant, exprloc, reference
+      DW_AT_entry_pc             = 0x52 # address
+      DW_AT_use_UTF8             = 0x53 # flag
+      DW_AT_extension            = 0x54 # reference
+      DW_AT_ranges               = 0x55 # rangelistptr
+      DW_AT_trampoline           = 0x56 # address, flag, reference, string
+      DW_AT_call_column          = 0x57 # constant
+      DW_AT_call_file            = 0x58 # constant
+      DW_AT_call_line            = 0x59 # constant
+      DW_AT_description          = 0x5a # string
+      DW_AT_binary_scale         = 0x5b # constant
+      DW_AT_decimal_scale        = 0x5c # constant
+      DW_AT_small                = 0x5d # reference
+      DW_AT_decimal_sign         = 0x5e # constant
+      DW_AT_digit_count          = 0x5f # constant
+      DW_AT_picture_string       = 0x60 # string
+      DW_AT_mutable              = 0x61 # flag
+      DW_AT_threads_scaled       = 0x62 # flag
+      DW_AT_explicit             = 0x63 # flag
+      DW_AT_object_pointer       = 0x64 # reference
+      DW_AT_endianity            = 0x65 # constant
+      DW_AT_elemental            = 0x66 # flag
+      DW_AT_pure                 = 0x67 # flag
+      DW_AT_recursive            = 0x68 # flag
+      DW_AT_signature            = 0x69 # reference
+      DW_AT_main_subprogram      = 0x6a # flag
+      DW_AT_data_bit_offset      = 0x6b # constant
+      DW_AT_const_expr           = 0x6c # flag
+      DW_AT_enum_class           = 0x6d # flag
+      DW_AT_linkage_name         = 0x6e # string
+
+      def unknown?
+        AT.from_value?(value).nil?
+      end
+    end
+
+    enum FORM : UInt32
+      Addr        = 0x01 # address
+      Block2      = 0x03 # block
+      Block4      = 0x04 # block
+      Data2       = 0x05 # constant
+      Data4       = 0x06 # constant
+      Data8       = 0x07 # constant
+      String      = 0x08 # string
+      Block       = 0x09 # block
+      Block1      = 0x0a # block
+      Data1       = 0x0b # constant
+      Flag        = 0x0c # flag
+      Sdata       = 0x0d # constant
+      Strp        = 0x0e # string
+      Udata       = 0x0f # constant
+      RefAddr     = 0x10 # reference
+      Ref1        = 0x11 # reference
+      Ref2        = 0x12 # reference
+      Ref4        = 0x13 # reference
+      Ref8        = 0x14 # reference
+      RefUdata    = 0x15 # reference
+      Indirect    = 0x16 # (see Section 7.5.3)
+      SecOffset   = 0x17 # lineptr, loclistptr, macptr, rangelistptr
+      Exprloc     = 0x18 # exprloc
+      FlagPresent = 0x19 # flag
+      RefSig8     = 0x20 # reference
+    end
+
+    struct Abbrev
+      record Attribute, at : AT, form : FORM
+
+      property code : UInt32
+      property tag : TAG
+      property attributes : Array(Attribute)
+
+      def initialize(@code, @tag, @children : Bool)
+        @attributes = [] of Attribute
+      end
+
+      def children?
+        @children
+      end
+
+      def self.read(io : IO::FileDescriptor, offset)
+        abbreviations = [] of Abbrev
+
+        io.seek(io.tell + offset)
+        loop do
+          code = DWARF.read_unsigned_leb128(io)
+          break if code == 0
+
+          tag = TAG.new(DWARF.read_unsigned_leb128(io))
+          children = io.read_byte == 1
+          abbrev = Abbrev.new(code, tag, children)
+
+          loop do
+            at = AT.new(DWARF.read_unsigned_leb128(io))
+            form = FORM.new(DWARF.read_unsigned_leb128(io))
+            break if at.value == 0 && form.value == 0
+            abbrev.attributes << Attribute.new(at, form)
+          end
+
+          abbreviations << abbrev
+        end
+
+        abbreviations
+      end
+    end
+  end
+end

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -1,0 +1,141 @@
+require "../dwarf"
+require "./abbrev"
+
+module Debug
+  module DWARF
+    struct Info
+      property unit_length : UInt32 | UInt64
+      property version : UInt16
+      property debug_abbrev_offset : UInt32 | UInt64
+      property address_size : UInt8
+      property! abbreviations : Array(Abbrev)
+
+      property dwarf64 : Bool
+      @offset : Int64
+      @ref_offset : UInt64
+
+      def initialize(@io : IO::FileDescriptor, @offset)
+        @ref_offset = offset.to_u64
+
+        @unit_length = @io.read_bytes(UInt32)
+        if @unit_length == 0xffffffff
+          @dwarf64 = true
+          @unit_length = @io.read_bytes(UInt64)
+        else
+          @dwarf64 = false
+        end
+
+        @offset = @io.tell
+        @version = @io.read_bytes(UInt16)
+        @debug_abbrev_offset = read_ulong
+        @address_size = @io.read_byte.not_nil!
+      end
+
+      alias Value = Bool | Int32 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8
+
+      def read_abbreviations(io)
+        @abbreviations = Abbrev.read(io, debug_abbrev_offset)
+      end
+
+      def each
+        end_offset = @offset + @unit_length
+        attributes = [] of {AT, FORM, Value}
+
+        while @io.tell < end_offset
+          code = DWARF.read_unsigned_leb128(@io)
+          attributes.clear
+
+          if abbrev = abbreviations[code - 1]? # abbreviations.find { |a| a.code == abbrev }
+            abbrev.attributes.each do |attr|
+              value = read_attribute_value(attr.form)
+              attributes << {attr.at, attr.form, value}
+            end
+            yield code, abbrev, attributes
+          else
+            yield code, nil, attributes
+          end
+        end
+      end
+
+      private def read_attribute_value(form)
+        case form
+        when FORM::Addr
+          case address_size
+          when 4 then @io.read_bytes(UInt32)
+          when 8 then @io.read_bytes(UInt64)
+          else        raise "Invalid address size: #{address_size}"
+          end
+        when FORM::Block1
+          len = @io.read_byte.not_nil!
+          @io.read_fully(bytes = Bytes.new(len.to_i))
+          bytes
+        when FORM::Block2
+          len = @io.read_bytes(UInt16)
+          @io.read_fully(bytes = Bytes.new(len.to_i))
+          bytes
+        when FORM::Block4
+          len = @io.read_bytes(UInt32)
+          @io.read_fully(bytes = Bytes.new(len.to_i64))
+          bytes
+        when FORM::Block
+          len = DWARF.read_unsigned_leb128(@io)
+          @io.read_fully(bytes = Bytes.new(len))
+          bytes
+        when FORM::Data1
+          @io.read_byte.not_nil!
+        when FORM::Data2
+          @io.read_bytes(UInt16)
+        when FORM::Data4
+          @io.read_bytes(UInt32)
+        when FORM::Data8
+          @io.read_bytes(UInt64)
+        when FORM::Sdata
+          DWARF.read_signed_leb128(@io)
+        when FORM::Udata
+          DWARF.read_unsigned_leb128(@io)
+        when FORM::Exprloc
+          len = DWARF.read_unsigned_leb128(@io)
+          @io.read_fully(bytes = Bytes.new(len))
+          bytes
+        when FORM::Flag
+          @io.read_byte == 1
+        when FORM::FlagPresent
+          true
+        when FORM::SecOffset
+          read_ulong
+        when FORM::Ref1
+          @ref_offset + @io.read_byte.not_nil!.to_u64
+        when FORM::Ref2
+          @ref_offset + @io.read_bytes(UInt16).to_u64
+        when FORM::Ref4
+          @ref_offset + @io.read_bytes(UInt32).to_u64
+        when FORM::Ref8
+          @ref_offset + @io.read_bytes(UInt64).to_u64
+        when FORM::RefUdata
+          @ref_offset + DWARF.read_unsigned_leb128(@io)
+        when FORM::RefAddr
+          read_ulong
+        when FORM::RefSig8
+          @io.read_bytes(UInt64)
+        when FORM::String
+          @io.gets('\0').to_s.chomp('\0')
+        when FORM::Strp
+          read_ulong
+        when FORM::Indirect
+          form = FORM.new(DWARF.read_unsigned_leb128(@io))
+          read_attribute_value(form)
+        else
+          raise "Unknown DW_FORM_#{form.to_s.underscore}"
+        end
+      end
+
+      private def read_ulong
+        if @dwarf64
+          @io.read_bytes(UInt64)
+        else
+          @io.read_bytes(UInt32)
+        end
+      end
+    end
+  end
+end

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -11,11 +11,11 @@ module Debug
       property! abbreviations : Array(Abbrev)
 
       property dwarf64 : Bool
-      @offset : Int64
-      @ref_offset : UInt64
+      @offset : LibC::OffT
+      @ref_offset : LibC::OffT
 
       def initialize(@io : IO::FileDescriptor, @offset)
-        @ref_offset = offset.to_u64
+        @ref_offset = offset
 
         @unit_length = @io.read_bytes(UInt32)
         if @unit_length == 0xffffffff
@@ -31,7 +31,7 @@ module Debug
         @address_size = @io.read_byte.not_nil!
       end
 
-      alias Value = Bool | Int32 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8
+      alias Value = Bool | Int32 | Int64 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8
 
       def read_abbreviations(io)
         @abbreviations = Abbrev.read(io, debug_abbrev_offset)

--- a/src/debug/dwarf/strings.cr
+++ b/src/debug/dwarf/strings.cr
@@ -1,0 +1,14 @@
+module Debug
+  module DWARF
+    struct Strings
+      def initialize(@io : IO::FileDescriptor, @offset : UInt32 | UInt64)
+      end
+
+      def decode(strp)
+        @io.seek(@offset + strp) do
+          @io.gets('\0').to_s.chomp('\0')
+        end
+      end
+    end
+  end
+end

--- a/src/debug/mach_o.cr
+++ b/src/debug/mach_o.cr
@@ -203,6 +203,10 @@ module Debug
       def ==(other : UUID)
         bytes == other.bytes
       end
+
+      def inspect(io)
+        io << bytes.to_slice.hexstring
+      end
     end
 
     struct Section64
@@ -490,8 +494,9 @@ module Debug
 
     def read_section?(name)
       if sh = sections.find { |s| s.sectname == name }
-        @io.seek(sh.offset)
-        yield sh, @io
+        @io.seek(sh.offset) do
+          yield sh, @io
+        end
       end
     end
   end


### PR DESCRIPTION
Parses the `.debug_info` section of executables to get the original function name instead of raw symbols (that sometimes can't be found on Linux) in backtraces. Function names (just like line numbers) will always be displayed, unless the program is compiled with `--no-debug`. For Example:

**Before:**
```
0x45a8fa: *Kls#callee1:Nil at /home/github/crystal/spec/std/data/backtrace_sample 3:10
0x432d4e: *callee3:Nil at /home/github/crystal/spec/std/data/backtrace_sample 15:3
0x42f03f: ??? at /home/github/crystal/spec/std/data/backtrace_sample 17:1
0x432c29: main at /home/julien/.cache/crystal/macro70621728.cr 12:15
0x7f2ab0c52f45: __libc_start_main at ??
```

**After**:
```
0x47e65a: callee1 at /home/github/crystal/spec/std/data/backtrace_sample 3:10
0x445dce: callee3 at /home/github/crystal/spec/std/data/backtrace_sample 15:3
0x43825d: __crystal_main at /home/github/crystal/spec/std/data/backtrace_sample 17:1
0x445ca9: main at /home/julien/.cache/crystal/macro85348592.cr 12:15
0x7f9e86ef4f45: __libc_start_main at ??
```