### PR TITLE
Fix `Enum#to_s` to wrap flag enums with parens

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -28,8 +28,9 @@ describe Enum do
 
     it "for flags enum" do
       SpecEnumFlags::None.to_s.should eq("None")
-      SpecEnumFlags::All.to_s.should eq("One, Two, Three")
-      (SpecEnumFlags::One | SpecEnumFlags::Two).to_s.should eq("One, Two")
+      SpecEnumFlags::One.to_s.should eq("One")
+      SpecEnumFlags::All.to_s.should eq("(One, Two, Three)")
+      (SpecEnumFlags::One | SpecEnumFlags::Two).to_s.should eq("(One, Two)")
     end
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -97,17 +97,34 @@ struct Enum
       if value == 0
         io << "None"
       else
-        found = false
+        found = nil
+        first = true
         {% for member in @type.constants %}
           {% if member.stringify != "All" %}
             if {{@type}}::{{member}}.value != 0 && (value & {{@type}}::{{member}}.value) == {{@type}}::{{member}}.value
-              io << ", " if found
-              io << {{member.stringify}}
-              found = true
+              if found
+                if first
+                  io << "("
+                  io << found
+                end
+                io << ", "
+                io << {{member.stringify}}
+                first = false
+              else
+                found = {{member.stringify}}
+              end
             end
           {% end %}
         {% end %}
-        io << value unless found
+        if found
+          if first
+            io << found
+          else
+            io << ")"
+          end
+        else
+          io << value
+        end
       end
     {% else %}
       io << to_s


### PR DESCRIPTION
This fixes is to display multiple enum flags in collection. For example:

```crystal
@[Flags]
enum Foo
  A
  B
end

p [Foo::A, Foo::B, Foo::A | Foo::B]
```

It outpus:

```
[A, B, A, B]
```

This output is ambigious, so this commit fixes it to wrap multiple flag enums with parens. Then, it outputs:

```
[A, B, (A, B)]
```

It looks good. Thanks.