### PR TITLE
Add support for SHA512

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -64,6 +64,7 @@ lib LibCrypto
   fun bio_free = BIO_free(bio : Bio*) : Int
 
   fun sha1 = SHA1(data : Char*, length : SizeT, md : Char*) : Char*
+  fun sha512 = SHA512(data : Char*, length : SizeT, md : Char*) : Char*
 
   type EVP_MD = Void*
 

--- a/src/openssl/sha512.cr
+++ b/src/openssl/sha512.cr
@@ -1,0 +1,13 @@
+require "./lib_crypto"
+
+class OpenSSL::SHA512
+  def self.hash(data : String) : UInt8[64]
+    hash(data.to_unsafe, LibC::SizeT.new(data.bytesize))
+  end
+
+  def self.hash(data : UInt8*, bytesize : LibC::SizeT) : UInt8[64]
+    buffer = uninitialized UInt8[64]
+    LibCrypto.sha512(data, bytesize, buffer)
+    buffer
+  end
+end


### PR DESCRIPTION
```crystal
puts OpenSSL::SHA512.hash("test").to_slice.hexstring #ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff
```