### PR TITLE
Fix self restriction with including generic module

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -775,6 +775,22 @@ describe "Semantic: macro" do
       )) { int32.metaclass }
   end
 
+  it "finds generic type argument of included module with self" do
+    assert_type(%(
+      module Bar(T)
+        def t
+          {{ T }}
+        end
+      end
+
+      class Foo(U)
+        include Bar(self)
+      end
+
+      Foo(Int32).new.t
+      )) { generic_class("Foo", int32).metaclass }
+  end
+
   it "finds free type vars" do
     assert_type(%(
       module Foo(T)

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -418,6 +418,9 @@ module Crystal
         end
 
         TypeNode.new(matched_type)
+      when Self
+        target = @scope == @program.class_type ? @scope : @scope.instance_type
+        TypeNode.new(target)
       when ASTNode
         matched_type
       else

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -220,8 +220,8 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     end
   end
 
-  def lookup_type(node : ASTNode, free_vars = nil)
-    current_type.lookup_type(node, free_vars: free_vars, allow_typeof: false)
+  def lookup_type(node : ASTNode, free_vars = nil, lazy_self = false)
+    current_type.lookup_type(node, free_vars: free_vars, allow_typeof: false, lazy_self: lazy_self)
   end
 
   def check_outside_exp(node, op)

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -811,7 +811,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def include_in(current_type, node, kind)
     node_name = node.name
 
-    type = lookup_type(node_name)
+    type = lookup_type(node_name, lazy_self: true)
     case type
     when GenericModuleType
       node.raise "wrong number of type vars for #{type} (given 0, expected #{type.type_vars.size})"

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -38,28 +38,28 @@ class Crystal::Type
   # ```
   #
   # If `self` is `Foo` and `Bar(Baz)` is given, the result will be `Foo::Bar(Baz)`.
-  def lookup_type(node : ASTNode, self_type = self.instance_type, allow_typeof = true, free_vars : Hash(String, TypeVar)? = nil) : Type
-    TypeLookup.new(self, self_type, true, allow_typeof, free_vars).lookup(node).not_nil!
+  def lookup_type(node : ASTNode, self_type = self.instance_type, allow_typeof = true, lazy_self = false, free_vars : Hash(String, TypeVar)? = nil) : Type
+    TypeLookup.new(self, self_type, true, allow_typeof, lazy_self, free_vars).lookup(node).not_nil!
   end
 
   # Similar to `lookup_type`, but returns `nil` if a type can't be found.
-  def lookup_type?(node : ASTNode, self_type = self.instance_type, allow_typeof = true, free_vars : Hash(String, TypeVar)? = nil) : Type?
-    TypeLookup.new(self, self_type, false, allow_typeof, free_vars).lookup(node)
+  def lookup_type?(node : ASTNode, self_type = self.instance_type, allow_typeof = true, lazy_self = false, free_vars : Hash(String, TypeVar)? = nil) : Type?
+    TypeLookup.new(self, self_type, false, allow_typeof, lazy_self, free_vars).lookup(node)
   end
 
   # Similar to `lookup_type`, but the result might also be an ASTNode, for example when
   # looking `N` relative to a StaticArray.
   def lookup_type_var(node : Path, free_vars : Hash(String, TypeVar)? = nil) : Type | ASTNode
-    TypeLookup.new(self, self.instance_type, true, false, free_vars).lookup_type_var(node).not_nil!
+    TypeLookup.new(self, self.instance_type, true, false, false, free_vars).lookup_type_var(node).not_nil!
   end
 
   # Similar to `lookup_type_var`, but might return `nil`.
   def lookup_type_var?(node : Path, free_vars : Hash(String, TypeVar)? = nil, raise = false) : Type | ASTNode | Nil
-    TypeLookup.new(self, self.instance_type, raise, false, free_vars).lookup_type_var?(node)
+    TypeLookup.new(self, self.instance_type, raise, false, false, free_vars).lookup_type_var?(node)
   end
 
   private struct TypeLookup
-    def initialize(@root : Type, @self_type : Type, @raise : Bool, @allow_typeof : Bool, @free_vars : Hash(String, TypeVar)? = nil)
+    def initialize(@root : Type, @self_type : Type, @raise : Bool, @allow_typeof : Bool, @lazy_self : Bool, @free_vars : Hash(String, TypeVar)? = nil)
       @in_generic_args = 0
 
       # If we are looking types inside a non-instantiated generic type,
@@ -88,6 +88,8 @@ class Crystal::Type
         end
       when Type
         return type_var
+      when Self
+        return lookup(type_var)
       end
 
       if @raise
@@ -215,8 +217,14 @@ class Crystal::Type
       type_vars = Array(TypeVar).new(node.type_vars.size + 1)
       node.type_vars.each do |type_var|
         case type_var
+        when Self
+          if @lazy_self
+            type_vars << type_var
+            next
+          end
         when NumberLiteral
           type_vars << type_var
+          next
         when Splat
           type = in_generic_args { lookup(type_var.exp) }
           return if !@raise && !type
@@ -234,37 +242,38 @@ class Crystal::Type
 
             type_var.raise "can only splat tuple type, not #{splat_type}"
           end
-        else
-          # Check the case of T resolving to a number
-          if type_var.is_a?(Path) && type_var.names.size == 1
-            type = @root.lookup_path(type_var)
-            case type
-            when Const
-              interpreter = MathInterpreter.new(@root)
-              begin
-                num = interpreter.interpret(type.value)
-                type_vars << NumberLiteral.new(num)
-              rescue ex : Crystal::Exception
-                type_var.raise "expanding constant value for a number value", inner: ex
-              end
-              next
-            when ASTNode
-              type_vars << type
-              next
-            end
-          end
-
-          type = in_generic_args { lookup(type_var) }
-          return if !@raise && !type
-          type = type.not_nil!
-
-          case instance_type
-          when GenericUnionType, PointerType, StaticArrayType, TupleType, ProcType
-            check_type_allowed_in_generics(type_var, type, "can't use #{type} as a generic type argument")
-          end
-
-          type_vars << type.virtual_type
+          next
         end
+
+        # Check the case of T resolving to a number
+        if type_var.is_a?(Path) && type_var.names.size == 1
+          type = @root.lookup_path(type_var)
+          case type
+          when Const
+            interpreter = MathInterpreter.new(@root)
+            begin
+              num = interpreter.interpret(type.value)
+              type_vars << NumberLiteral.new(num)
+            rescue ex : Crystal::Exception
+              type_var.raise "expanding constant value for a number value", inner: ex
+            end
+            next
+            # when ASTNode
+            #   type_vars << type
+            #   next
+          end
+        end
+
+        type = in_generic_args { lookup(type_var) }
+        return if !@raise && !type
+        type = type.not_nil!
+
+        case instance_type
+        when GenericUnionType, PointerType, StaticArrayType, TupleType, ProcType
+          check_type_allowed_in_generics(type_var, type, "can't use #{type} as a generic type argument")
+        end
+
+        type_vars << type.virtual_type
       end
 
       begin

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -237,6 +237,8 @@ struct Enum
     value <=> other.value
   end
 
+  # TODO: Remove `#==` after release next version. It is no longer needed.
+
   # :nodoc:
   def ==(other)
     false


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/pull/3847#issuecomment-270888186

Now, we can get a compile error with such a code:

```crystal
module Foo(T)
  def foo(x : T)
    x
  end
end

abstract struct Bar
  include Foo(self)
end

struct Baz1 < Bar
end

struct Baz2 < Bar
end

Baz1.new.foo Baz2.new # => no overload matches 'Baz1#foo' with type Baz2
```

This pull request adds `lazy_self` parameter to `lookup_type`. When `lazy_self` is `true`, `lookup_type` keeps `self` in generics type. It is used to look up type for `include` and `extend`.