### PR TITLE
OpenSSL server socket fixes

### DIFF
--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -190,10 +190,10 @@ module IO::Buffered
   end
 
   # Flushes and closes the underlying `IO`.
-  def close
+  def close : Nil
     flush if @out_count > 0
+  ensure
     unbuffered_close
-    nil
   end
 
   # Rewinds the underlying `IO`. Returns `self`.

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -52,6 +52,7 @@ abstract class OpenSSL::SSL::Socket
 
       ret = LibSSL.ssl_accept(@ssl)
       unless ret == 1
+        io.close if sync_close
         raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
       end
     end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -96,8 +96,9 @@ abstract class OpenSSL::SSL::Socket
 
     count = slice.size
     return 0 if count == 0
+
     LibSSL.ssl_read(@ssl, slice.pointer(count), count).tap do |bytes|
-      unless bytes > 0
+      if bytes <= 0 && !LibSSL.ssl_get_error(@ssl, bytes).zero_return?
         raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_read")
       end
     end


### PR DESCRIPTION
1. Close underlying IO on SSL accept errors.
2. Report EOF instead of raising SSL_ERROR_ZERO_RETURN (the socket was normally closed). This happens to me all the time with cURL making requests to `HTTP::Server` that waits for another request (keepalive).