### PR TITLE
Fix Travis ci

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -149,7 +149,7 @@ prepare_build() {
 
   on_linux docker pull "jhass/crystal-build-$ARCH"
 
-  on_osx brew install llvm libevent pcre crystal-lang
+  on_osx brew install llvm pcre crystal-lang
 }
 
 with_build_env() {


### PR DESCRIPTION
Libevent is now installed by default on travis, so I removed it from the brew install command.

Feel free to rebase your PR onto this one if you want to test your PR on osx.