### PR TITLE
Add XML::Node.normalized_text

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -234,6 +234,12 @@ describe XML do
     doc.children.first.content.should eq("")
   end
 
+  it "gets the content" do
+    doc = XML.parse("<foo>foo<bar>bar</bar></foo>")
+    doc.children.first.normalized_text.should eq("foo")
+    doc.children.first.content.should eq("foobar")
+  end
+
   it "sets node name" do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -152,6 +152,11 @@ struct XML::Node
     content
   end
 
+  # Returns only this node's text
+  def normalized_text
+    children.select(&.text?).join("", &.to_s)
+  end
+
   # Returns detailed information for this node including node type, name, attributes and children.
   def inspect(io)
     io << "#<XML::"


### PR DESCRIPTION
XML::Node has three text functions that all return the same thing: `#content`, `#text`, `#inner_text`.
However they all return the current node's text including the text from its children.

This function only returns the text that the current node has

Example:
```crystal
node = XML.parse("<foo>foo<bar>bar</bar></foo>")

node.children.first.content # => foobar
node.children.first.normalized_text # => foo
``` 

