### PR TITLE
Adds includes? macro method to string, symbol and macroid.

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -398,6 +398,37 @@ describe "macro methods" do
     it "executes to_i(base)" do
       assert_macro "", %({{"1234".to_i(16)}}), [] of ASTNode, %(4660)
     end
+
+    it "executes string includes? char (true)" do
+      assert_macro "", %({{"spice".includes?('s')}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?('p')}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?('i')}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?('c')}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?('e')}}), [] of ASTNode, %(true)
+    end
+
+    it "executes string includes? char (false)" do
+      assert_macro "", %({{"spice".includes?('S')}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?(' ')}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?('!')}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?('b')}}), [] of ASTNode, %(false)
+    end
+
+    it "executes string includes? string (true)" do
+      assert_macro "", %({{"spice".includes?("s")}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?("e")}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?("sp")}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?("ce")}}), [] of ASTNode, %(true)
+      assert_macro "", %({{"spice".includes?("pic")}}), [] of ASTNode, %(true)
+    end
+
+    it "executes string includes? string (false)" do
+      assert_macro "", %({{"spice".includes?("Spi")}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?(" spi")}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?("ce ")}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?("b")}}), [] of ASTNode, %(false)
+      assert_macro "", %({{"spice".includes?("spice ")}}), [] of ASTNode, %(false)
+    end
   end
 
   describe "macro id methods" do
@@ -407,6 +438,10 @@ describe "macro methods" do
       assert_macro "x", %({{x.starts_with?("hel")}}), [MacroId.new("hello")] of ASTNode, %(true)
       assert_macro "x", %({{x.chomp}}), [MacroId.new("hello\n")] of ASTNode, %(hello)
       assert_macro "x", %({{x.upcase}}), [MacroId.new("hello")] of ASTNode, %(HELLO)
+      assert_macro "x", %({{x.includes?("el")}}), [MacroId.new("hello")] of ASTNode, %(true)
+      assert_macro "x", %({{x.includes?("he")}}), [MacroId.new("hello")] of ASTNode, %(true)
+      assert_macro "x", %({{x.includes?("EL")}}), [MacroId.new("hello")] of ASTNode, %(false)
+      assert_macro "x", %({{x.includes?("cat")}}), [MacroId.new("hello")] of ASTNode, %(false)
     end
 
     it "compares with string" do
@@ -445,6 +480,10 @@ describe "macro methods" do
       assert_macro "x", %({{x.starts_with?("hel")}}), ["hello".symbol] of ASTNode, %(true)
       assert_macro "x", %({{x.chomp}}), [SymbolLiteral.new("hello\n")] of ASTNode, %(:hello)
       assert_macro "x", %({{x.upcase}}), ["hello".symbol] of ASTNode, %(:HELLO)
+      assert_macro "x", %({{x.includes?("el")}}), ["hello".symbol] of ASTNode, %(true)
+      assert_macro "x", %({{x.includes?("he")}}), ["hello".symbol] of ASTNode, %(true)
+      assert_macro "x", %({{x.includes?("EL")}}), ["hello".symbol] of ASTNode, %(false)
+      assert_macro "x", %({{x.includes?("cat")}}), ["hello".symbol] of ASTNode, %(false)
     end
 
     it "executes symbol == symbol" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -352,6 +352,10 @@ module Crystal::Macros
     def gsub(regex : RegexLiteral, replacement : StringLiteral) : StringLiteral
     end
 
+    # Similar to `String#includes?`.
+    def includes?(search : StringLiteral | CharLiteral) : BoolLiteral
+    end
+
     # Similar to `String#size`.
     def size : NumberLiteral
     end
@@ -447,6 +451,10 @@ module Crystal::Macros
 
     # Similar to `String#gsub`.
     def gsub(regex : RegexLiteral, replacement : StringLiteral) : SymbolLiteral
+    end
+
+    # Similar to `String#includes?`.
+    def includes?(search : StringLiteral | CharLiteral) : BoolLiteral
     end
 
     # Similar to `String#size`.
@@ -1402,6 +1410,10 @@ module Crystal::Macros
 
     # Similar to `String#gsub`.
     def gsub(regex : RegexLiteral, replacement : StringLiteral) : MacroId
+    end
+
+    # Similar to `String#includes?`.
+    def includes?(search : StringLiteral | CharLiteral) : BoolLiteral
     end
 
     # Similar to `String#size`.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -595,6 +595,18 @@ module Crystal
         end
       when "identify"
         interpret_argless_method(method, args) { StringLiteral.new(@value.tr(":", "_")) }
+      when "includes?"
+        interpret_one_arg_method(method, args) do |arg|
+          case arg
+          when CharLiteral
+            piece = arg.value
+          when StringLiteral
+            piece = arg.value
+          else
+            raise "StringLiteral#includes? expects char or string, not #{arg.class_desc}"
+          end
+          BoolLiteral.new(@value.includes?(piece))
+        end
       when "size"
         interpret_argless_method(method, args) { NumberLiteral.new(@value.size) }
       when "lines"


### PR DESCRIPTION
This is similar to the existing `ends_with?` and `starts_with?` macro methods.