### PR TITLE
Hash should not default to 11 if it is specified

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -323,6 +323,12 @@ describe "Hash" do
     h1["bar"].should eq([2])
   end
 
+  it "raises on initialize if set to a non-postive value" do
+    expect_raises ArgumentError, "Hash capacity must be positive" do
+      Hash(Int32, Int32).new(initial_capacity: -1) { 1234 }
+    end
+  end
+
   it "initializes with default value" do
     h = Hash(Int32, Int32).new(10)
     h[0].should eq(10)

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -324,7 +324,7 @@ describe "Hash" do
   end
 
   it "raises on initialize if set to a non-postive value" do
-    expect_raises ArgumentError, "Hash capacity must be positive" do
+    expect_raises ArgumentError, "Hash capacity cannot be negative" do
       Hash(Int32, Int32).new(initial_capacity: -1) { 1234 }
     end
   end
@@ -811,20 +811,25 @@ describe "Hash" do
     items.uniq.size
   end
 
-  it "creates with initial capacity" do
+  it "sets the initial capacity when not passed" do
+    hash = Hash(Int32, Int32).new
+    hash.@buckets_size.should eq(Hash::PRIMES[0])
+  end
+
+  it "creates the initial capacity from next largest prime of passed capacity" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234)
-    hash.@buckets_size.should eq(1234)
+    hash.@buckets_size.should eq(2053)
   end
 
   it "creates with initial capacity and default value" do
     hash = Hash(Int32, Int32).new(default_value: 3, initial_capacity: 1234)
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash.@buckets_size.should eq(2053)
   end
 
   it "creates with initial capacity and block" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234) { |h, k| h[k] = 3 }
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash.@buckets_size.should eq(2053)
   end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -13,8 +13,8 @@ class Hash(K, V)
 
   def initialize(block : (Hash(K, V), K -> V)? = nil, initial_capacity = nil)
     initial_capacity ||= 11
-    initial_capacity = 11 if initial_capacity < 11
     initial_capacity = initial_capacity.to_i
+    raise ArgumentError.new("Hash capacity must be positive") if initial_capacity <= 0
     @buckets = Pointer(Entry(K, V)?).malloc(initial_capacity)
     @buckets_size = initial_capacity
     @size = 0


### PR DESCRIPTION
`Hash#new` has some strange behavior of setting the initial capacity, ignoring what is specified, if the specified value is less than 11. Instead, it should let the user set the capacity to whatever they want, but complain if a non-positive value is specified.