### PR TITLE
User-Agent should be properly capitalized in exec

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -332,7 +332,7 @@ class HTTP::Client
     #
     # ```
     # client = HTTP::Client.new("www.example.com")
-    # response = client.{{method.id}}("/", headers: HTTP::Headers{"User-agent" => "AwesomeApp"}, body: "Hello!")
+    # response = client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!")
     # response.body #=> "..."
     # ```
     def {{method.id}}(path, headers : HTTP::Headers? = nil, body : BodyType = nil) : HTTP::Client::Response
@@ -344,7 +344,7 @@ class HTTP::Client
     #
     # ```
     # client = HTTP::Client.new("www.example.com")
-    # client.{{method.id}}("/", headers: HTTP::Headers{"User-agent" => "AwesomeApp"}, body: "Hello!") do |response|
+    # client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!") do |response|
     #   response.body_io.gets #=> "..."
     # end
     # ```
@@ -358,7 +358,7 @@ class HTTP::Client
     # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
     #
     # ```
-    # response = HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-agent" => "AwesomeApp"}, body: "Hello!")
+    # response = HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!")
     # response.body #=> "..."
     # ```
     def self.{{method.id}}(url : String | URI, headers : HTTP::Headers? = nil, body : BodyType = nil, tls = nil) : HTTP::Client::Response
@@ -369,7 +369,7 @@ class HTTP::Client
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     #
     # ```
-    # HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-agent" => "AwesomeApp"}, body: "Hello!") do |response|
+    # HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!") do |response|
     #   response.body_io.gets #=> "..."
     # end
     # ```
@@ -561,7 +561,7 @@ class HTTP::Client
   end
 
   private def set_defaults(request)
-    request.headers["User-agent"] ||= "Crystal"
+    request.headers["User-Agent"] ||= "Crystal"
     {% if flag?(:without_zlib) %}
       false
     {% else %}


### PR DESCRIPTION
As per the [HTTP spec](https://tools.ietf.org/html/rfc7231#section-5.5.3), `User-Agent` is supposed to be capitalized per-word. Today, the `Agent` part is [simply missing](https://github.com/crystal-lang/crystal/blob/master/src/http/client.cr#L564) a capital `A` in the defaults set by `exec`. 

```cr
require "http"
client = HTTP::Client.new "www.google.com"
req = HTTP::Request.new("GET", "/")
response = client.exec req
puts req.headers #=> HTTP::Headers{"User-agent" => "Crystal", "Accept-Encoding" => "gzip, deflate"}
```