### PR TITLE
OAuth2::Client sends Accept headers by default

### DIFF
--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -140,7 +140,11 @@ class OAuth2::Client
       yield form
     end
 
-    response = HTTP::Client.post_form(token_uri, body)
+    headers = HTTP::Headers{
+      "Accept" => "application/json",
+    }
+
+    response = HTTP::Client.post_form(token_uri, body, headers)
     case response.status_code
     when 200, 201
       OAuth2::AccessToken.from_json(response.body)


### PR DESCRIPTION
Since the client expects to parse a JSON response, it makes sense to ask for it on the request.

See crystal-lang/crystal#4029