### PR TITLE
Avoid redundant builds of OSX with xcode7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     - env: ARCH=x86_64 ARCH_CMD=linux64 DEPLOY=true
       os: linux
     - os: osx
-    - os: osx
-      osx_image: xcode7.3
 before_install:
   - bin/ci prepare_system
 install:


### PR DESCRIPTION
xcode7.3 is now the default OS X version in TravisCI, so we're building the project twice with the same configuration.

The second build was added in #2595, when xcode6.1 was the default. It doesn't make sense anymore.

I'm currently working on the project's build matrix for a long-term solution - I'll probably explicitly state each OSX version -, but this should speed builds up in the mean time.

https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version now says:
> Travis CI uses OS X 10.11.6 (and Xcode 7.3.1) by default .