### PR TITLE
Fix: configurable SO_REUSEPORT socket setting (disabled by default)

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -221,6 +221,17 @@ module HTTP
 
       server.listen
     end
+
+    it "reuses the TCP port (SO_REUSEPORT)" do
+      s1 = Server.new(0) { |ctx| }
+      s1.bind(reuse_port: true)
+
+      s2 = Server.new(s1.port) { |ctx| }
+      s2.bind(reuse_port: true)
+
+      s1.close
+      s2.close
+    end
   end
 
   describe HTTP::Server::RequestProcessor do

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -424,9 +424,17 @@ describe TCPServer do
     end
   end
 
-  it "allows to share the same port (SO_REUSEPORT)" do
+  it "doesn't reuse the TCP port by default (SO_REUSEPORT)" do
     TCPServer.open("::", 0) do |server|
-      TCPServer.open("::", server.local_address.port) { }
+      expect_raises(Errno) do
+        TCPServer.open("::", server.local_address.port) { }
+      end
+    end
+  end
+
+  it "reuses the TCP port (SO_REUSEPORT)" do
+    TCPServer.open("::", 0, reuse_port: true) do |server|
+      TCPServer.open("::", server.local_address.port, reuse_port: true) { }
     end
   end
 end


### PR DESCRIPTION
This led to confusing behavior when starting different TCP services that default to the same default ports. They didn't fail to start, but were failing to receive some requests.

I propose here to allow the setting to be easily configured and to disable it by default. You may enable it by setting the `reuse_port` named argument to true. For example:

```crystal
TCPServer.open(9292, reuse_port: true) { }
```

```crystal
server = HTTP::Server.new(9292) { |ctx| }
server.listen(reuse_port: true)
```

~~Maybe `#listen` could accept the `reuse_port` but I think `#bind` is a better place. Same for `#new` which would require to memoize the choice until we call `#bind`. I favored explicitness.~~ Both `HTTP::Server#bind` and `HTTP::Server#listen` now accept the `reuse_port` method.

fixes #4019