### PR TITLE
Add a explicit exception message when a nil regex capture group is accessed.

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -39,7 +39,13 @@ describe "Regex::MatchData" do
 
     it "raises if outside match range with []" do
       "foo" =~ /foo/
-      expect_raises(IndexError) { $~[1] }
+      expect_raises(IndexError, "Invalid capture group index: 1") { $~[1] }
+    end
+
+    it "raises if special variable accessed on invalid capture group" do
+      "spice" =~ /spice(s)?/
+      expect_raises(IndexError, "Invalid capture group index: 1") { $1 }
+      expect_raises(IndexError, "Invalid capture group index: 3") { $3 }
     end
   end
 

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -129,8 +129,9 @@ class Regex
     # ```
     def [](n)
       check_index_out_of_bounds n
-
-      self[n]?.not_nil!
+      value = self[n]?
+      raise_invalid_group_index(n) if value.nil?
+      value
     end
 
     # Returns the match of the capture group named by *group_name*, or
@@ -219,11 +220,15 @@ class Regex
     end
 
     private def check_index_out_of_bounds(index)
-      raise IndexError.new unless valid_group?(index)
+      raise_invalid_group_index(index) unless valid_group?(index)
     end
 
     private def valid_group?(index)
       index <= @size
+    end
+
+    private def raise_invalid_group_index(index)
+      raise IndexError.new("Invalid capture group index: #{index}")
     end
   end
 end


### PR DESCRIPTION
addresses: https://github.com/crystal-lang/crystal/issues/3978