### PR TITLE
Improve playground specs

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -571,3 +571,14 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 end
+
+private def assert_compile(source)
+  sources = Playground::Session.instrument_and_prelude("", "", 0, source, Logger.new(nil))
+  compiler = Compiler.new
+  compiler.no_codegen = true
+  result = compiler.compile sources, "fake-no-build"
+end
+
+describe Playground::Session do
+  it { assert_compile %(puts "1") }
+end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -13,25 +13,17 @@ module Crystal::Playground
       @tag = 0
     end
 
-    def run(source, tag)
-      @logger.info "Request to run code (session=#{@session_key}, tag=#{tag}).\n#{source}"
-
-      @tag = tag
-      begin
-        ast = Parser.new(source).parse
-      rescue ex : Crystal::Exception
-        send_exception ex, tag
-        return
-      end
+    def self.instrument_and_prelude(session_key, port, tag, source, logger)
+      ast = Parser.new(source).parse
 
       instrumented = Playground::AgentInstrumentorTransformer.transform(ast).to_s
-      @logger.info "Code instrumentation (session=#{@session_key}, tag=#{tag}).\n#{instrumented}"
+      logger.info "Code instrumentation (session=#{session_key}, tag=#{tag}).\n#{instrumented}"
 
       prelude = %(
         require "compiler/crystal/tools/playground/agent"
 
         class Crystal::Playground::Agent
-          @@instance = Crystal::Playground::Agent.new("ws://localhost:#{@port}/agent/#{@session_key}/#{tag}", #{tag})
+          @@instance = Crystal::Playground::Agent.new("ws://localhost:#{port}/agent/#{session_key}/#{tag}", #{tag})
 
           def self.instance
             @@instance
@@ -43,10 +35,23 @@ module Crystal::Playground
         end
         )
 
-      sources = [
+      [
         Compiler::Source.new("playground_prelude", prelude),
         Compiler::Source.new("play", instrumented),
       ]
+    end
+
+    def run(source, tag)
+      @logger.info "Request to run code (session=#{@session_key}, tag=#{tag}).\n#{source}"
+
+      @tag = tag
+      begin
+        sources = self.class.instrument_and_prelude(@session_key, @port, tag, source, @logger)
+      rescue ex : Crystal::Exception
+        send_exception ex, tag
+        return
+      end
+
       output_filename = tempfile "play-#{@session_key}-#{tag}"
       compiler = Compiler.new
       compiler.color = false


### PR DESCRIPTION
Playground: refactor instrumentation to allow specs
* ensure instrumented code with prelude is able to compile.