### PR TITLE
Pass the filename in the codegen debug spec

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -13,7 +13,7 @@ describe "Code gen: debug" do
       end
 
       x = Foo.new || Bar.new
-      ), debug: Crystal::Debug::All)
+      ), debug: Crystal::Debug::All, filename: "foo.cr")
   end
 
   it "inlines instance var access through getter in debug mode" do
@@ -61,7 +61,7 @@ describe "Code gen: debug" do
       else
           puts int
       end
-      ), debug: Crystal::Debug::All)
+      ), debug: Crystal::Debug::All, filename: "foo.cr")
   end
 
   it "codegens correct debug info for new with custom allocate (#3945)" do
@@ -76,6 +76,6 @@ describe "Code gen: debug" do
       end
 
       Foo.new
-      ), debug: Crystal::Debug::All)
+      ), debug: Crystal::Debug::All, filename: "foo.cr")
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -269,15 +269,16 @@ def assert_macro_internal(program, sub_node, macro_args, macro_body, expected)
   result.should eq(expected)
 end
 
-def parse(string, wants_doc = false)
+def parse(string, filename = nil, wants_doc = false)
   parser = Parser.new(string)
+  parser.filename = filename
   parser.wants_doc = wants_doc
   parser.parse
 end
 
-def codegen(code, inject_primitives = true, debug = Crystal::Debug::None)
+def codegen(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None)
   code = inject_primitives(code) if inject_primitives
-  node = parse code
+  node = parse(code, filename: filename)
   result = semantic node
   result.program.codegen(result.node, single_module: false, debug: debug)[""].mod
 end


### PR DESCRIPTION
Not setting the filename on all nodes makes LLVM die with an assertion error:

```
Code gen: debug
  codegens abstract struct (#3578)Assertion failed: (!Filename.empty() && "Unable to create file without name"), function createFilePathPair, file DIBuilder.cpp, line 130.
make: *** [spec] Abort trap: 6
```

See https://github.com/crystal-lang/crystal/issues/4073 for more details.