### PR TITLE
Calling an NamedTuple#to_h on an empty now has meaningful error message

### DIFF
--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -285,4 +285,13 @@ describe "Semantic: named tuples" do
       a[0]
       )) { named_tuple_of({"x": types["Foo"].virtual_type!, "y": types["Foo"].virtual_type!}) }
   end
+
+  it "does not compile to_h of empty tuples" do
+    # TODO change the location of this spec upon #2391
+    assert_error %(
+      require "prelude"
+      NamedTuple.new.to_h
+      ),
+      "Can't convert an empty NamedTuple to a Hash"
+  end
 end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -399,7 +399,9 @@ struct NamedTuple
   # tuple.to_h # => {:name => "Crystal", :year => 2011}
   # ```
   def to_h
-    {% begin %}
+    {% if T.size == 0 %}
+      {% raise "Can't convert an empty NamedTuple to a Hash" %}
+    {% else %}
       {
         {% for key in T %}
           {{key.symbolize}} => self[{{key.symbolize}}].clone,


### PR DESCRIPTION
switched from making it return {} => Nil to just improving the compile-time error message