### PR TITLE
use GC.malloc_atomic to allocate objects without pointers

### DIFF
--- a/src/base64.cr
+++ b/src/base64.cr
@@ -160,7 +160,7 @@ module Base64
   # This will decode either the normal or urlsafe alphabets.
   def decode(data) : Bytes
     slice = data.to_slice
-    buf = Pointer(UInt8).malloc(decode_size(slice.size))
+    buf = GC.malloc_atomic(decode_size(slice.size)).as(UInt8*)
     appender = buf.appender
     from_base64(slice) { |byte| appender << byte }
     Slice.new(buf, appender.size.to_i32)


### PR DESCRIPTION
bdwgc recommend to use malloc_atomic (https://github.com/ivmai/bdwgc#the-c-interface-to-the-allocator) to allocate binary data. I apply this to some places, but there is actually much more places, that can be optimized. `Bytes.new` for example, or better `Pointer(T).malloc` choose to use atomic if T is not reference.