### PR TITLE
Fix: Check return pointer of LLVMGetStructName [#4078]

### DIFF
--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -65,8 +65,8 @@ struct LLVM::Type
 
   def struct_name
     raise "not a Struct" unless kind == Kind::Struct
-
-    String.new(LibLLVM.get_struct_name(self))
+    name = LibLLVM.get_struct_name(self)
+    name ? String.new(name) : ""
   end
 
   def struct_element_types


### PR DESCRIPTION
WIP: fixes the segfault of #4078, so the compiler won't crash, but doesn't fix the root cause.