### PR TITLE
Change Spec::JUnitFormatter to use XML::Builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,18 @@
 
 LLVM_CONFIG ?= ## llvm-config command path to use
 
-release ?= ## Compile in release mode
-stats ?=   ## Enable statistics output
-threads ?= ## Maximum number of threads to use
-debug ?=   ## Add symbolic debug info
-verbose ?= ## Run specs in verbose mode
+release ?=      ## Compile in release mode
+stats ?=        ## Enable statistics output
+threads ?=      ## Maximum number of threads to use
+debug ?=        ## Add symbolic debug info
+verbose ?=      ## Run specs in verbose mode
+junit_output ?= ## Directory to output junit results
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
 FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )$(if $(debug),-d )
-VERBOSE := $(if $(verbose),-v )
+SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 SHELL = bash
 LLVM_CONFIG_FINDER := \
@@ -73,15 +74,15 @@ help: ## Show this help
 
 .PHONY: spec
 spec: $(O)/all_spec ## Run all specs
-	$(O)/all_spec $(VERBOSE)
+	$(O)/all_spec $(SPEC_FLAGS)
 
 .PHONY: std_spec
 std_spec: $(O)/std_spec ## Run standard library specs
-	$(O)/std_spec $(VERBOSE)
+	$(O)/std_spec $(SPEC_FLAGS)
 
 .PHONY: compiler_spec
 compiler_spec: $(O)/compiler_spec ## Run compiler specs
-	$(O)/compiler_spec $(VERBOSE)
+	$(O)/compiler_spec $(SPEC_FLAGS)
 
 .PHONY: doc
 doc: ## Generate standard library documentation

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -8,15 +8,14 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
+                 <?xml version="1.0"?>
                  <testsuite tests="2" errors="0" failed="0">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else">
-                 </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something"/>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else"/>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports failures" do
@@ -25,14 +24,15 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
+                 <?xml version="1.0"?>
                  <testsuite tests="1" errors="0" failed="1">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 <failure />
-                 </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                     <failure/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports errors" do
@@ -41,14 +41,15 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
+                 <?xml version="1.0"?>
                  <testsuite tests="1" errors="1" failed="0">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 <error />
-                 </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                     <error/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports mixed results" do
@@ -60,22 +61,22 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
+                 <?xml version="1.0"?>
                  <testsuite tests="4" errors="2" failed="1">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1">
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
-                 <failure />
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
-                 <error />
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
-                 <error />
-                 </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1"/>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
+                     <failure/>
+                   </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
+                     <error/>
+                   </testcase>
+                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
+                     <error/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "escapes spec names" do


### PR DESCRIPTION
This means that the generated XML will be properly indented, and always valid. It's also neater.

I've also included a commit which edits the Makefile to allow `make spec junit_output=path/to/dir` to pass `--junit_output` to the built spec binary.

These changes are required for displaying spec results on jenkins, along with removing some characters which cannot be represented in XML from the spec names: https://github.com/crystal-lang/crystal/blob/master/spec/std/uri_spec.cr#L199.