### PR TITLE
Fix 3988

### DIFF
--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -497,4 +497,22 @@ describe "Semantic: class var" do
       ),
       "class variable '@@foo' of Foo is not nilable (it's Int32) so it must have an initializer"
   end
+
+  it "instance variables initializers are used in class variables initialized objects (#3988)" do
+    assert_type(%(
+      class Foo
+        @@foo = Foo.new
+
+        @never_nil = 1
+
+        def initialize
+          if false
+            @never_nil = 2
+          end
+        end
+      end
+
+      Foo.new.@never_nil
+      )) { int32 }
+  end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4625,4 +4625,31 @@ describe "Semantic: instance var" do
       ),
       "Can't infer the type of instance variable '@bar' of Foo"
   end
+
+  it "allow usage of instance variable initializer from instance variable initializer" do
+    assert_type(%(
+      class Foo
+        @bar = Bar.new
+        @never_nil = 1
+
+        def initialize
+          if false
+            @never_nil = 2
+          end
+        end
+      end
+
+      class Bar
+        @never_nil = 1
+
+        def initialize
+          if false
+            @never_nil = 2
+          end
+        end
+      end
+
+      {Foo.new.@never_nil, Bar.new.@never_nil}
+    )) { tuple_of([int32, int32]) }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -120,8 +120,12 @@ module Crystal
     def scope=(value)
       super
 
+      # TODO tidy up the design of how to grab the instance variable initializers.
+      # currently the LazyInstanceVarInitializer serves for collecting them
+      # and when the MainVisitor is used to expand the #initialize method
+      # the following code will convert lazy to proper instance variable initializer.
       if value.is_a?(InstanceVarInitializerContainer)
-        value.convert_lazy_initializers @meta_vars
+        value.convert_lazy_initializers MetaVars.new
       end
     end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -117,6 +117,14 @@ module Crystal
       @meta_vars = meta_vars
     end
 
+    def scope=(value)
+      super
+
+      if value.is_a?(InstanceVarInitializerContainer)
+        value.convert_lazy_initializers @meta_vars
+      end
+    end
+
     def visit_any(node)
       @unreachable = false
       @or_left_type_filters = nil

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -599,6 +599,14 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def visit(node : Assign)
     type_assign(node.target, node.value, node)
+
+    target = node.target
+    type = current_type
+
+    if target.is_a?(InstanceVar) && type.is_a?(InstanceVarInitializerContainer)
+      type.lazy_add_instance_var_initializer target.name, node.value
+    end
+
     false
   end
 


### PR DESCRIPTION
This PR improves some scenarios regarding instance variables initializers.
The solution is a workaround that collect & expand later the initializers.

A better long term solution would be to decouple analyze ivar initializers and the instantiation of `#initialize` methods. Like adding a phase that will remove syntactic ivar initializers in the class lexical scope and expand them in the initialize body, before the codegen. Hence in the codegen or further phases there is no need to track the concept of ivar initializers since they could be just a syntax sugar. NB: currently (before PR) ivar initializers are used in `#allocate` as well.

Fixes #3988 