### PR TITLE
`crystal --version` reports LLVM_VERSION

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -8,12 +8,16 @@ module Crystal
       version_and_sha.first
     end
 
+    def self.llvm_version
+      LibLLVM::VERSION
+    end
+
     def self.description
       version, sha = version_and_sha
       if sha
-        "Crystal #{version} [#{sha}] (#{date})"
+        "Crystal #{version} [#{sha}] (#{date}) LLVM #{llvm_version}"
       else
-        "Crystal #{version} (#{date})"
+        "Crystal #{version} (#{date}) LLVM #{llvm_version}"
       end
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -242,6 +242,7 @@ module Crystal
       define_crystal_string_constant "DESCRIPTION", Crystal::Config.description
       define_crystal_string_constant "PATH", Crystal::CrystalPath.default_path
       define_crystal_string_constant "VERSION", version
+      define_crystal_string_constant "LLVM_VERSION", Crystal::Config.llvm_version
     end
 
     private def define_crystal_string_constant(name, value)


### PR DESCRIPTION
This PR makes `crystal --version` report the LLVM version the compiler is using. It also adds a `Crystal::LLVM_VERSION` constant that user code can access, analogous to `Crystal::VERSION`.

Hopefully, it will help troubleshoot compiler bugs that are related to changes in LLVM versions.