### PR TITLE
Fix: incorrect to_s for Attribute AST node #4098

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -95,4 +95,5 @@ describe "ASTNode#to_s" do
   expect_to_s "# doc\ndef foo\nend", emit_doc: true
   expect_to_s "foo[x, y, a: 1, b: 2]"
   expect_to_s "foo[x, y, a: 1, b: 2] = z"
+  expect_to_s %(@[Foo(1, 2, a: 1, b: 2)])
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1414,8 +1414,8 @@ module Crystal
           printed_arg = true
         end
         if named_args = node.named_args
-          @str << ", " if printed_arg
           named_args.each do |named_arg|
+            @str << ", " if printed_arg
             visit_named_arg_name(named_arg.name)
             @str << ": "
             named_arg.value.accept self


### PR DESCRIPTION
Commas are missing in the result of the `to_s` method of Attribute nodes so the output is invalid (i.e. `@[Foo(a: 1b: 2)]`).

```bash
$ cat test.cr
require "compiler/crystal/syntax"
ast = Crystal::Parser.parse(%{@[Test(1, 2, n1: 1, n2: 2)]})
puts code = ast.to_s
Crystal::Parser.parse(code)

$ crystal run test.cr
@[Test(1, 2, n1: 1, n2: 2)]
```
