### PR TITLE
Fixed invalid File.link behaviour

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -176,6 +176,7 @@ describe "File" do
       begin
         File.link("#{__DIR__}/data/test_file.txt", out_path)
         File.exists?(out_path).should be_true
+        File.symlink?(out_path).should be_false
       ensure
         File.delete(out_path) if File.exists?(out_path)
       end

--- a/src/file.cr
+++ b/src/file.cr
@@ -390,7 +390,7 @@ class File < IO::FileDescriptor
   # Creates a new link (also known as a hard link) at *new_path* to an existing file
   # given by *old_path*.
   def self.link(old_path, new_path)
-    ret = LibC.symlink(old_path.check_no_null_byte, new_path.check_no_null_byte)
+    ret = LibC.link(old_path.check_no_null_byte, new_path.check_no_null_byte)
     raise Errno.new("Error creating link from #{old_path} to #{new_path}") if ret != 0
     ret
   end


### PR DESCRIPTION
`File.link` wrongly called `LibC.symlink`.

This commit closes #4115 