### PR TITLE
GIT_REMOTE_PATTERNS regexes are being overly greedy

### DIFF
--- a/spec/compiler/crystal/tools/doc_spec.cr
+++ b/spec/compiler/crystal/tools/doc_spec.cr
@@ -1,0 +1,42 @@
+require "../../../spec_helper"
+
+private def assert_matches_pattern(url, **options)
+  match = Crystal::Doc::Generator::GIT_REMOTE_PATTERNS.each_key.compact_map(&.match(url)).first?
+  if match
+    options.each { |k, v| match[k.to_s].should eq(v) }
+  end
+end
+
+describe Crystal::Doc::Generator do
+  describe "GIT_REMOTE_PATTERNS" do
+    it "matches github repos" do
+      assert_matches_pattern "https://www.github.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "http://www.github.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "http://github.com/foo/bar", user: "foo", repo: "bar"
+
+      assert_matches_pattern "https://github.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "https://github.com/foo/bar.git", user: "foo", repo: "bar"
+      assert_matches_pattern "https://github.com/foo/bar.cr", user: "foo", repo: "bar.cr"
+      assert_matches_pattern "https://github.com/foo/bar.cr.git", user: "foo", repo: "bar.cr"
+
+      assert_matches_pattern "https://github.com/fOO-Bar/w00den-baRK.ab.cd", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
+      assert_matches_pattern "https://github.com/fOO-Bar/w00den-baRK.ab.cd.git", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
+      assert_matches_pattern "https://github.com/foo_bar/_baz-buzz.cx", user: "foo_bar", repo: "_baz-buzz.cx"
+    end
+
+    it "matches gitlab repos" do
+      assert_matches_pattern "https://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "http://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "http://gitlab.com/foo/bar", user: "foo", repo: "bar"
+
+      assert_matches_pattern "https://gitlab.com/foo/bar", user: "foo", repo: "bar"
+      assert_matches_pattern "https://gitlab.com/foo/bar.git", user: "foo", repo: "bar"
+      assert_matches_pattern "https://gitlab.com/foo/bar.cr", user: "foo", repo: "bar.cr"
+      assert_matches_pattern "https://gitlab.com/foo/bar.cr.git", user: "foo", repo: "bar.cr"
+
+      assert_matches_pattern "https://gitlab.com/fOO-Bar/w00den-baRK.ab.cd", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
+      assert_matches_pattern "https://gitlab.com/fOO-Bar/w00den-baRK.ab.cd.git", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
+      assert_matches_pattern "https://gitlab.com/foo_bar/_baz-buzz.cx", user: "foo_bar", repo: "_baz-buzz.cx"
+    end
+  end
+end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -18,11 +18,11 @@ class Crystal::Doc::Generator
   FLAGS = FLAG_COLORS.keys
 
   GIT_REMOTE_PATTERNS = {
-    /github\.com(?:\:|\/)(?<user>(?:\w|-|_)+)\/(?<repo>(?:\w|-|_|\.)+?)(?:.git)?\b/ => {
+    /github\.com(?:\:|\/)(?<user>(?:\w|-|_)+)\/(?<repo>(?:\w|-|_|\.)+?)(?:\.git)?$/ => {
       repository: "https://github.com/%{user}/%{repo}/blob/%{rev}",
       repo_name:  "github.com/%{user}/%{repo}",
     },
-    /gitlab\.com(?:\:|\/)(?<user>(?:\w|-|_|\.)+)\/(?<repo>(?:\w|-|_|\.)+?)(?:.git)?\b/ => {
+    /gitlab\.com(?:\:|\/)(?<user>(?:\w|-|_|\.)+)\/(?<repo>(?:\w|-|_|\.)+?)(?:\.git)?$/ => {
       repository: "https://gitlab.com/%{user}/%{repo}/blob/%{rev}",
       repo_name:  "gitlab.com/%{user}/%{repo}",
     },


### PR DESCRIPTION
This PR fixes overly greedy regexes found in `Crystal::Doc::Generator::GIT_REMOTE_PATTERNS`, which atm are stripping last part after (and including) special character given as a part of the repo name.

With given remote url: "https://github.com/foo/bar.cr.git" they would incorrectly return `bar` as a `repo` key, despite of `.cr` suffix being legitimate part of the repository name.