### PR TITLE
Use default Type::STREAM for type.

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -25,7 +25,7 @@ class Socket
     # ```
     # addrinfos = Socket::Addrinfo.resolve("example.org", "http", type: Socket::Type::STREAM, protocol: Socket::Protocol::TCP)
     # ```
-    def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
+    def self.resolve(domain, service, family : Family? = nil, type : Type? = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
       addrinfos = [] of Addrinfo
 
       getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
@@ -51,7 +51,7 @@ class Socket
     #
     # The iteration will be stopped once the block returns something that isn't
     # an `Exception` (e.g. a `Socket` or `nil`).
-    def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil)
+    def self.resolve(domain, service, family : Family? = nil, type : Type? = nil, protocol : Protocol = Protocol::IP, timeout = nil)
       getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
         error = nil
 
@@ -78,7 +78,7 @@ class Socket
     private def self.getaddrinfo(domain, service, family, type, protocol, timeout)
       hints = LibC::Addrinfo.new
       hints.ai_family = (family || Family::UNSPEC).to_i32
-      hints.ai_socktype = type
+      hints.ai_socktype = (type || Type::STREAM).to_i32
       hints.ai_protocol = protocol
       hints.ai_flags = 0
 


### PR DESCRIPTION
It can't be nil, it has to be an integer value.

```crystal
require "socket"

puts Socket::Addrinfo.resolve("localhost", 27015).first.ip_address.address
```

throws

```
Error in info.cr:3: instantiating 'Socket::Addrinfo:Class#resolve(String, Int32)'

puts Socket::Addrinfo.resolve("localhost", 27015).first.ip_address.address
                      ^~~~~~~

in /opt/crystal/src/socket/addrinfo.cr:28: can't restrict Nil to Type

    def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
```
which is defined [here](
https://github.com/crystal-lang/crystal/blob/f1a1adb27ed02ac05a580732a856dcbf47db3a0c/src/socket/addrinfo.cr#L28)

I changed the type to Type? and made sure it would use a default value further down.

