### PR TITLE
Print sigfaults and exceptions to STDERR

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -131,15 +131,15 @@ struct CallStack
     if frame
       offset, sname = frame
       if repeated_frame.count == 0
-        LibC.printf "[%ld] %s +%ld\n", repeated_frame.ip, sname, offset
+        LibC.dprintf 2, "[%ld] %s +%ld\n", repeated_frame.ip, sname, offset
       else
-        LibC.printf "[%ld] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
+        LibC.dprintf 2, "[%ld] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
       end
     else
       if repeated_frame.count == 0
-        LibC.printf "[%ld] ???\n", repeated_frame.ip
+        LibC.dprintf 2, "[%ld] ???\n", repeated_frame.ip
       else
-        LibC.printf "[%ld] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
+        LibC.dprintf 2, "[%ld] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
       end
     end
   end

--- a/src/lib_c/aarch64-linux-gnu/c/stdio.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(format : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
   fun snprintf(s : Char*, maxlen : SizeT, format : Char*, ...) : Int
 end

--- a/src/lib_c/amd64-unknown-openbsd/c/stdio.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(x0 : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(x0 : Char*, x1 : Char*) : Int
   fun snprintf(x0 : Char*, x1 : SizeT, x2 : Char*, ...) : Int
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/stdio.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(format : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
   fun snprintf(s : Char*, maxlen : SizeT, format : Char*, ...) : Int
 end

--- a/src/lib_c/i686-linux-gnu/c/stdio.cr
+++ b/src/lib_c/i686-linux-gnu/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(format : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
   fun snprintf(s : Char*, maxlen : SizeT, format : Char*, ...) : Int
 end

--- a/src/lib_c/i686-linux-musl/c/stdio.cr
+++ b/src/lib_c/i686-linux-musl/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(x0 : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(x0 : Char*, x1 : Char*) : Int
   fun snprintf(x0 : Char*, x1 : SizeT, x2 : Char*, ...) : Int
 end

--- a/src/lib_c/x86_64-linux-gnu/c/stdio.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(format : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
   fun snprintf(s : Char*, maxlen : SizeT, format : Char*, ...) : Int
 end

--- a/src/lib_c/x86_64-linux-musl/c/stdio.cr
+++ b/src/lib_c/x86_64-linux-musl/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(x0 : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(x0 : Char*, x1 : Char*) : Int
   fun snprintf(x0 : Char*, x1 : SizeT, x2 : Char*, ...) : Int
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/stdio.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(x0 : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(x0 : Char*, x1 : Char*) : Int
   fun snprintf(x0 : Char*, x1 : SizeT, x2 : Char*, ...) : Int
 end

--- a/src/lib_c/x86_64-portbld-freebsd/c/stdio.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/stdio.cr
@@ -3,6 +3,7 @@ require "./stddef"
 
 lib LibC
   fun printf(x0 : Char*, ...) : Int
+  fun dprintf(fd : Int, format : Char*, ...) : Int
   fun rename(x0 : Char*, x1 : Char*) : Int
   fun snprintf(x0 : Char*, x1 : SizeT, x2 : Char*, ...) : Int
 end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -165,7 +165,7 @@ end
 @[Raises]
 fun __crystal_raise(unwind_ex : LibUnwind::Exception*) : NoReturn
   ret = LibUnwind.raise_exception(unwind_ex)
-  LibC.printf "Failed to raise an exception: %s\n", ret.to_s
+  LibC.dprintf 2, "Failed to raise an exception: %s\n", ret.to_s
   CallStack.print_backtrace
   LibC.exit(ret)
 end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -121,7 +121,7 @@ end
 # :nodoc:
 fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
   # Capture fault signals (SEGV, BUS) and finish the process printing a backtrace first
-  LibC.printf "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
+  LibC.dprintf 2, "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
   CallStack.print_backtrace
   LibC._exit sig
 end


### PR DESCRIPTION
While working on [raven.cr](https://github.com/Sija/raven.cr) I've stumbled upon the problem of intercepting exceptions and sigfaults thrown by Crystal code and to my surprise I was unable to do so. After several hours of debugging I've found the problem in using `LibC.printf`.

This PR changes `__crystal_raise`, `__crystal_sigfault_handler` and `CallStack.print_frame` to use `LibC.dprintf` instead.