### PR TITLE
Fix String#insert not working with non-ascii Char

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2240,6 +2240,11 @@ describe "String" do
 
     "barbar".insert(0, "foo").size.should eq(9)
     "ともだち".insert(0, "ねこ").size.should eq(6)
+
+    "foo".insert(0, 'a').ascii_only?.should be_true
+    "foo".insert(0, 'あ').ascii_only?.should be_false
+    "".insert(0, 'a').ascii_only?.should be_true
+    "".insert(0, 'あ').ascii_only?.should be_false
   end
 
   it "hexbytes" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -1257,7 +1257,7 @@ class String
     bytes, count = String.char_bytes_and_bytesize(other)
 
     new_bytesize = bytesize + count
-    new_size = ascii_only? ? new_bytesize : 0
+    new_size = (ascii_only? && other.ascii?) ? new_bytesize : 0
 
     insert_impl(byte_index, bytes.to_unsafe, count, new_bytesize, new_size)
   end


### PR DESCRIPTION
Previously, String#insert did not check if the Char to insert was ASCII
or not.  This resulted in a String which thought it was `ascii_only?`

Example:
```crystal
good = "ä"
broken = "".insert(0, 'ä')

pp good == broken #=> true, as expected
pp good.ascii_only? == broken.ascii_only? #=> false, but expected true
pp good.size, broken.size, good.bytesize, broken.bytesize
# As bytesize == size, ascii_only? returns true for the broken one
```