### PR TITLE
Fix: select generic ARM C bindings when target triple is armv6, armv7l, ...

### DIFF
--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -20,8 +20,13 @@ module Crystal
       triple = target_triple.split('-')
       triple.delete(triple[1]) if triple.size == 4 # skip vendor
 
-      if %w(i386 i486 i586).includes?(triple[0])
+      case triple[0]
+      when "i386", "i486", "i586"
         triple[0] = "i686"
+      when .starts_with?("armv8")
+        triple[0] = "aarch64"
+      when .starts_with?("arm")
+        triple[0] = "arm"
       end
 
       target = if triple.any?(&.includes?("macosx")) || triple.any?(&.includes?("darwin"))


### PR DESCRIPTION
We don't have specific C bindings for the armv6, armv7l and other specific architectures (e.g. the `armhf` Debian packages use a `armv7l-unknown-linux-gnueabihf` triple). We only have bindings for the generic `arm` target, and this fix tells Crystal to always use these.

Reference: https://github.com/crystal-lang/crystal/pull/3424#issuecomment-287180454