### PR TITLE
Use 0xdeadbeef pointer format in CallStack.print_frame

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -131,15 +131,15 @@ struct CallStack
     if frame
       offset, sname = frame
       if repeated_frame.count == 0
-        LibC.dprintf 2, "[%ld] %s +%ld\n", repeated_frame.ip, sname, offset
+        LibC.dprintf 2, "[0x%lx] %s +%ld\n", repeated_frame.ip, sname, offset
       else
-        LibC.dprintf 2, "[%ld] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
+        LibC.dprintf 2, "[0x%lx] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
       end
     else
       if repeated_frame.count == 0
-        LibC.dprintf 2, "[%ld] ???\n", repeated_frame.ip
+        LibC.dprintf 2, "[0x%lx] ???\n", repeated_frame.ip
       else
-        LibC.dprintf 2, "[%ld] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
+        LibC.dprintf 2, "[0x%lx] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
       end
     end
   end


### PR DESCRIPTION
Before:

```
Invalid memory access (signal 11) at address 0x20
[4385788459] *CallStack::print_backtrace:Int32 +107
[4385717580] __crystal_sigfault_handler +60
[140735821145386] _sigtramp +26
[4391097761] GC_realloc +50
[4385645403] __crystal_realloc +11
[4385960268] *Pointer(UInt8)@Pointer(T)#realloc<Int32>:Pointer(UInt8) +28
[4387606531] *Foo::Bar#bar!:Nil +195
[4385744993] *naughty_bar:Nil +17
[4385744969] *naughty_foo:Nil +9
[4385645324] __crystal_main +2940
[4385715144] main +40
```

now:

```
Invalid memory access (signal 11) at address 0x20
[0x1057a9fab] *CallStack::print_backtrace:Int32 +107
[0x105798aac] __crystal_sigfault_handler +60
[0x7fff9ca0652a] _sigtramp +26
[0x105cb35a1] GC_realloc +50
[0x1057870bb] __crystal_realloc +11
[0x1057d3ecc] *Pointer(UInt8)@Pointer(T)#realloc<Int32>:Pointer(UInt8) +28
[0x105965e03] *Foo::Bar#bar!:Nil +195
[0x10579f5c1] *naughty_bar:Nil +17
[0x10579f5a9] *naughty_foo:Nil +9
[0x10578706c] __crystal_main +2940
[0x105798128] main +40
```