### PR TITLE
Implement Time#clone

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -63,6 +63,11 @@ describe Time do
     time.epoch_ms.should eq(milliseconds)
   end
 
+  it "clones" do
+    time = Time.now
+    (time == time.clone).should be_true
+  end
+
   it "fields" do
     Time::MaxValue.ticks.should eq(3155378975999999999)
     Time::MinValue.ticks.should eq(0)

--- a/src/time.cr
+++ b/src/time.cr
@@ -164,7 +164,7 @@ struct Time
   end
 
   def clone
-    dup
+    self
   end
 
   def +(other : Span)

--- a/src/time.cr
+++ b/src/time.cr
@@ -163,6 +163,10 @@ struct Time
     new(UnixEpoch + milliseconds.to_i64 * Span::TicksPerMillisecond, Kind::Utc)
   end
 
+  def clone
+    dup
+  end
+
   def +(other : Span)
     add_ticks other.ticks
   end


### PR DESCRIPTION
ATM you can't `#clone` any `Tuple` or `NamedTuple` including `Time` instance.
This PR adds `#clone` method to `Time` (calls `#dup` internally).