### PR TITLE
Fix TCPSocket segfault on missing host and 0 port

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -542,6 +542,12 @@ describe TCPSocket do
       TCPSocket.new("localhostttttt", 12345)
     end
   end
+
+  it "fails (rather than segfault on darwin) when host doesn't exist and port is 0" do
+    expect_raises(Socket::Error, /No address found for localhostttttt:0/) do
+      TCPSocket.new("localhostttttt", 0)
+    end
+  end
 end
 
 describe UDPSocket do

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -86,6 +86,15 @@ class Socket
         hints.ai_flags |= LibC::AI_NUMERICSERV
       end
 
+      # On OS X < 10.12, the libsystem implementation of getaddrinfo segfaults
+      # if AI_NUMERICSERV is set, and servname is NULL or 0.
+      {% if flag?(:darwin) %}
+        if (service == 0 || service == nil) && (hints.ai_flags & LibC::AI_NUMERICSERV)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+          service = "00"
+        end
+      {% end %}
+
       case ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
       when 0
         # success


### PR DESCRIPTION
Prior to this patch, `TCPSocket.new("whatever", 0)` would cause
    Invalid memory access (signal 11) at address 0x0

```
~ ➤ crystal --version
Crystal 0.21.1 (2017-03-14) LLVM 4.0.0
~ ➤ crystal eval 'require "socket"; require "socket/tcp_socket"; TCPSocket.new("hello", 0)'
Invalid memory access (signal 11) at address 0x0
[4486190123] *CallStack::print_backtrace:Int32 +107
[4486161591] __crystal_sigfault_handler +55
[140735515010346] _sigtramp +26
[140735492457349] _gai_simple +88
[140735492434315] search_addrinfo +179
[140735492419567] si_addrinfo +2255
[140735492417147] getaddrinfo +179
[4486349509] *TCPSocket#initialize<String, Int32, Nil, Nil>:Nil +709
[4486348787] *TCPSocket#initialize<String, Int32>:Nil +35
[4486348727] *TCPSocket::new<String, Int32>:TCPSocket +183
[4486139052] __crystal_main +1228
[4486161336] main +40
~ ➤ bcrystal eval 'require "socket"; require "socket/tcp_socket"; TCPSocket.new("hello", 0)'
Using compiled compiler at .build/crystal
No address found for hello:0 over TCP (Socket::Error)
0x104379885: *CallStack::unwind:Array(Pointer(Void)) at ??
0x104379821: *CallStack#initialize:Array(Pointer(Void)) at ??
0x1043797f8: *CallStack::new:CallStack at ??
0x104378631: *raise<Socket::Error>:NoReturn at ??
0x1043a6272: *TCPSocket#initialize<String, Int32, Nil, Nil>:Nil at ??
0x1043a5f53: *TCPSocket#initialize<String, Int32>:Nil at ??
0x1043a5f17: *TCPSocket::new<String, Int32>:TCPSocket at ??
0x104372bec: __crystal_main at ??
0x104378308: main at ??
~ ➤
```