### PR TITLE
Added compile progress tracker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 
 ## Build the compiler
 ##   $ make
+## Build the compiler with progress output
+##   $ make progress=true
 ## Clean up built files then build the compiler
 ##   $ make clean crystal
 ## Build the compiler in release mode
@@ -15,6 +17,7 @@ LLVM_CONFIG ?= ## llvm-config command path to use
 
 release ?=      ## Compile in release mode
 stats ?=        ## Enable statistics output
+progress ?=     ## Enable progress output
 threads ?=      ## Maximum number of threads to use
 debug ?=        ## Add symbolic debug info
 verbose ?=      ## Run specs in verbose mode
@@ -23,7 +26,7 @@ junit_output ?= ## Directory to output junit results
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
-FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )$(if $(debug),-d )
+FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 SHELL = bash

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -53,7 +53,7 @@ class Crystal::Command
 
   def initialize(@options : Array(String))
     @color = true
-    @stats = @time = false
+    @progress_tracker = ProgressTracker.new
   end
 
   def run
@@ -177,7 +177,7 @@ class Crystal::Command
 
   private def hierarchy
     config, result = compile_no_codegen "tool hierarchy", hierarchy: true, top_level: true
-    Crystal.timing("Tool (hierarchy)", @stats, delay: true) do
+    @progress_tracker.stage("Tool (hierarchy)") do
       Crystal.print_hierarchy result.program, config.hierarchy_exp, config.output_format
     end
   end
@@ -197,7 +197,7 @@ class Crystal::Command
 
   private def types
     config, result = compile_no_codegen "tool types"
-    Crystal.timing("Tool (types)", @stats, delay: true) do
+    @progress_tracker.stage("Tool (types)") do
       Crystal.print_types result.node
     end
   end
@@ -212,18 +212,23 @@ class Crystal::Command
   end
 
   private def execute(output_filename, run_args)
-    stats = @stats || !@time
-    status = Crystal.timing("Execute", @stats || @time, delay: true, display_memory: stats, padding_size: stats ? 34 : 0) do
+    time? = @time && !@progress_tracker.stats?
+    status, elapsed_time = @progress_tracker.stage("Execute") do
       begin
+        start_time = Time.now
         Process.run(output_filename, args: run_args, input: true, output: true, error: true) do |process|
           # Ignore the signal so we don't exit the running process
           # (the running process can still handle this signal)
           Signal::INT.ignore # do
         end
-        $?
+        {$?, Time.now - start_time}
       ensure
         File.delete(output_filename) rescue nil
       end
+    end
+
+    if time?
+      puts "Execute: #{elapsed_time}"
     end
 
     if status.normal_exit?
@@ -268,6 +273,8 @@ class Crystal::Command
                               hierarchy = false, cursor_command = false,
                               single_file = false)
     compiler = Compiler.new
+    compiler.progress_tracker = @progress_tracker
+    @progress_tracker.progress = true
     link_flags = [] of String
     opt_filenames = nil
     opt_arguments = nil
@@ -370,8 +377,11 @@ class Crystal::Command
       end
 
       opts.on("-s", "--stats", "Enable statistics output") do
-        @stats = true
-        compiler.stats = true
+        @progress_tracker.stats = true
+      end
+
+      opts.on("--no-progress", "Disable progress output") do
+        @progress_tracker.progress = false
       end
 
       opts.on("-t", "--time", "Enable execution time output") do
@@ -451,6 +461,7 @@ class Crystal::Command
   end
 
   private def setup_simple_compiler_options(compiler, opts)
+    compiler.progress_tracker.progress = true
     opts.on("-d", "--debug", "Add full symbolic debug info") do
       compiler.debug = Crystal::Debug::All
     end
@@ -467,8 +478,10 @@ class Crystal::Command
       compiler.release = true
     end
     opts.on("-s", "--stats", "Enable statistics output") do
-      @stats = true
-      compiler.stats = true
+      compiler.progress_tracker.stats = true
+    end
+    opts.on("--no-progress", "Disable progress output") do
+      compiler.progress_tracker.progress = false
     end
     opts.on("-t", "--time", "Enable execution time output") do
       @time = true

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -274,7 +274,6 @@ class Crystal::Command
                               single_file = false)
     compiler = Compiler.new
     compiler.progress_tracker = @progress_tracker
-    @progress_tracker.progress = true
     link_flags = [] of String
     opt_filenames = nil
     opt_arguments = nil
@@ -380,8 +379,8 @@ class Crystal::Command
         @progress_tracker.stats = true
       end
 
-      opts.on("--no-progress", "Disable progress output") do
-        @progress_tracker.progress = false
+      opts.on("-p", "--progress", "Enable progress output") do
+        @progress_tracker.progress = true
       end
 
       opts.on("-t", "--time", "Enable execution time output") do
@@ -461,7 +460,6 @@ class Crystal::Command
   end
 
   private def setup_simple_compiler_options(compiler, opts)
-    compiler.progress_tracker.progress = true
     opts.on("-d", "--debug", "Add full symbolic debug info") do
       compiler.debug = Crystal::Debug::All
     end
@@ -480,8 +478,8 @@ class Crystal::Command
     opts.on("-s", "--stats", "Enable statistics output") do
       compiler.progress_tracker.stats = true
     end
-    opts.on("--no-progress", "Disable progress output") do
-      compiler.progress_tracker.progress = false
+    opts.on("-p", "--progress", "Enable progress output") do
+      compiler.progress_tracker.progress = true
     end
     opts.on("-t", "--time", "Enable execution time output") do
       @time = true

--- a/src/compiler/crystal/command/cursor.cr
+++ b/src/compiler/crystal/command/cursor.cr
@@ -51,7 +51,7 @@ class Crystal::Command
 
     file = File.expand_path(file)
 
-    result = Crystal.timing("Tool (#{command.split(' ')[1]})", @stats) do
+    result = @progress_tracker.stage("Tool (#{command.split(' ')[1]})") do
       yield Location.new(file, line_number, column_number), config, result
     end
 

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -101,7 +101,7 @@ class Crystal::Program
   end
 
   def macro_compile(filename)
-    time = wants_stats? ? Time.now : Time.epoch(0)
+    time = Time.now
 
     source = File.read(filename)
 
@@ -124,7 +124,7 @@ class Crystal::Program
     File.utime(now, now, program_dir)
 
     if can_reuse_previous_compilation?(filename, executable_path, recorded_requires_path, requires_path)
-      elapsed_time = wants_stats? ? (Time.now - time) : Time::Span.zero
+      elapsed_time = Time.now - time
       return CompiledMacroRun.new(executable_path, elapsed_time, true)
     end
 
@@ -163,8 +163,7 @@ class Crystal::Program
       requires_with_timestamps.to_json(file)
     end
 
-    elapsed_time = wants_stats? ? (Time.now - time) : Time::Span.zero
-
+    elapsed_time = Time.now - time
     CompiledMacroRun.new(executable_path, elapsed_time, false)
   end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -110,8 +110,8 @@ module Crystal
     # The main filename of this program
     property filename : String?
 
-    # If `true`, prints time and memory stats to `stdout`.
-    property? wants_stats = false
+    # Set to a `ProgressTracker` object which tracks compilation progress.
+    property progress_tracker = ProgressTracker.new
 
     def initialize
       super(self, self, "main")

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -1,0 +1,68 @@
+module Crystal
+  class ProgressTracker
+    # FIXME: This assumption is not always true
+    STAGES        = 13
+    STAGE_PADDING = 34
+
+    property? stats = false
+    property? progress = false
+
+    getter current_stage = 1
+    getter current_stage_name : String?
+    getter stage_progress = 0
+    getter stage_progress_total : Int32?
+
+    def stage(name)
+      @current_stage_name = name
+
+      print_progress
+
+      start_time = Time.now
+      retval = yield
+      time_taken = Time.now - start_time
+
+      print_stats(time_taken)
+      print_progress
+
+      @current_stage += 1
+      @stage_progress = 0
+      @stage_progress_total = nil
+
+      retval
+    end
+
+    def clear
+      return unless @progress
+      print " " * (STAGE_PADDING + 5)
+      print "\r"
+    end
+
+    def print_stats(time_taken)
+      return unless @stats
+
+      memory_usage_mb = GC.stats.heap_size / 1024.0 / 1024.0
+      memory_usage_str = " (%7.2fMB)" % {memory_usage_mb} if true # display_memory?
+      justified_name = "#{current_stage_name}:".ljust(STAGE_PADDING)
+      puts "#{justified_name} #{time_taken}#{memory_usage_str}"
+    end
+
+    def print_progress
+      return unless @progress
+
+      if stage_progress_total = @stage_progress_total
+        progress = " [#{@stage_progress}/#{stage_progress_total}]"
+      end
+
+      stage_name = @current_stage_name.try(&.ljust(STAGE_PADDING))
+      print "[#{@current_stage}/#{STAGES}]#{progress} #{stage_name}\r"
+    end
+
+    def stage_progress=(@stage_progress)
+      print_progress
+    end
+
+    def stage_progress_total=(@stage_progress_total)
+      print_progress
+    end
+  end
+end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -23,26 +23,6 @@ module Crystal
     exit(exit_code) if exit_code
   end
 
-  def self.timing(label, stats, delay = false, display_memory = true, padding_size = 34)
-    if stats
-      print "%-*s" % {padding_size, "#{label}:"} unless delay
-      time = Time.now
-      value = yield
-      elapsed_time = Time.now - time
-      LibGC.get_heap_usage_safe(out heap_size, out free_bytes, out unmapped_bytes, out bytes_since_gc, out total_bytes)
-      mb = heap_size / 1024.0 / 1024.0
-      print "%-*s" % {padding_size, "#{label}:"} if delay
-      if display_memory
-        puts " %s (%7.2fMB)" % {elapsed_time, mb}
-      else
-        puts " %s" % elapsed_time
-      end
-      value
-    else
-      yield
-    end
-  end
-
   def self.tempfile(basename)
     CacheDir.instance.join("crystal-run-#{basename}.tmp")
   end


### PR DESCRIPTION
This PR adds a compile progress indicator to crystal. A new `ProgressTracker` class has been added which controls both stats and progress options. This is WIP, as there are a few things left to figure out such as the current assumption of the number of compiler stages run.

Demo:
![](https://aww.moe/cclo2s.gif)