### PR TITLE
Reduce formatter's spec requires

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1,4 +1,5 @@
-require "../../spec_helper"
+require "spec"
+require "../../../src/compiler/crystal/formatter"
 
 private def assert_format(input, output = input, strict = false, file = __FILE__, line = __LINE__)
   it "formats #{input.inspect}", file, line do


### PR DESCRIPTION
`./spec/compiler/formatter/formatter_spec.cr` is dependent only with `spec` and `compiler/crystal/formatter`. This pull request removed `spec_helper` require from formatter's spec.

Now `./bin/crystal run spec/compiler/formatter/formatter_spec.cr` is 7.5x faster than old.

Old:

```console
$ rm ~/.cache/crystal
$ time ./bin/crystal run --stats spec/compiler/formatter/formatter_spec.cr
Using compiled compiler at .build/crystal
Parse:                             00:00:00.0196690 (   1.29MB)
Semantic (top level):              00:00:01.5114960 (  87.50MB)
Semantic (new):                    00:00:00.0078730 (  87.50MB)
Semantic (type declarations):      00:00:00.1385150 (  95.50MB)
Semantic (abstract def check):     00:00:00.0039040 (  95.50MB)
Semantic (ivars initializers):     00:00:00.2146060 ( 103.56MB)
Semantic (cvars initializers):     00:00:00.0149110 ( 103.56MB)
Semantic (main):                   00:00:12.6752770 ( 751.68MB)
Semantic (cleanup):                00:00:00.0025690 ( 751.68MB)
Semantic (recursive struct check): 00:00:00.0030880 ( 751.68MB)
Codegen (crystal):                 00:00:12.1741550 (1031.93MB)
Codegen (bc+obj):                  00:00:14.7028860 (1031.93MB)
Codegen (linking):                 00:00:02.4825040 (1031.93MB)

Codegen (bc+obj):
 - no previous .o files were reused
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 169.09 milliseconds
901 examples, 0 failures, 0 errors, 0 pending
Execute:                           00:00:00.3010950 (1031.93MB)
./bin/crystal run --stats spec/compiler/formatter/formatter_spec.cr  68.42s user 4.37s system 163% cpu 44.632 total
```

Now:

```console
$ rm ~/.cache/crystal
$ time ./bin/crystal run --stats spec/compiler/formatter/formatter_spec.cr
Using compiled compiler at .build/crystal
Parse:                             00:00:00.0189450 (   1.29MB)
Semantic (top level):              00:00:00.6362590 (  47.60MB)
Semantic (new):                    00:00:00.0032400 (  47.60MB)
Semantic (type declarations):      00:00:00.0618490 (  47.60MB)
Semantic (abstract def check):     00:00:00.0032140 (  47.60MB)
Semantic (ivars initializers):     00:00:00.0059740 (  47.60MB)
Semantic (cvars initializers):     00:00:00.0364030 (  47.60MB)
Semantic (main):                   00:00:01.3966960 ( 144.04MB)
Semantic (cleanup):                00:00:00.0015930 ( 144.04MB)
Semantic (recursive struct check): 00:00:00.0013040 ( 144.04MB)
Codegen (crystal):                 00:00:00.9237940 ( 176.04MB)
Codegen (bc+obj):                  00:00:02.0412920 ( 176.04MB)
Codegen (linking):                 00:00:00.1510850 ( 176.04MB)

Codegen (bc+obj):
 - no previous .o files were reused
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 143.04 milliseconds
901 examples, 0 failures, 0 errors, 0 pending
Execute:                           00:00:00.1630650 ( 176.04MB)
./bin/crystal run --stats spec/compiler/formatter/formatter_spec.cr  9.12s user 0.72s system 175% cpu 5.616 total
```

I believe this fix helps accelerating `crystal tool format` development.