### PR TITLE
Adding put_form to HTTP::Client. Fixes #4181

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -39,6 +39,8 @@ module HTTP
 
     typeof(Client.post_form "url", {"a" => "b"})
     typeof(Client.post_form("url", {"a" => "b"}) { })
+    typeof(Client.put_form "url", {"a" => "b"})
+    typeof(Client.put_form("url", {"a" => "b"}) { })
     typeof(Client.new("host").basic_auth("username", "password"))
     typeof(Client.new("host").before_request { |req| })
     typeof(Client.new("host").close)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -380,7 +380,7 @@ class HTTP::Client
     end
   {% end %}
 
-  {% for http_method in ["post", "put"] %}
+  {% for http_method in %w(post put patch) %}
     # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
     # to "application/x-www-form-urlencoded".
     #

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -394,7 +394,7 @@ class HTTP::Client
       exec request
     end
 
-    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -381,7 +381,7 @@ class HTTP::Client
   {% end %}
 
   {% for http_method in %w(post put patch) %}
-    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
@@ -390,13 +390,13 @@ class HTTP::Client
     # ```
     def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil) : HTTP::Client::Response
       request = new_request({{http_method.upcase}}, path, headers, form)
-      request.headers["Content-type"] = "application/x-www-form-urlencoded"
+      request.headers["Content-Type"] = "application/x-www-form-urlencoded"
       exec request
     end
 
     # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
-    # The "Content-type" header is set to "application/x-www-form-urlencoded".
+    # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
     # client = HTTP::Client.new "www.example.com"
@@ -406,13 +406,13 @@ class HTTP::Client
     # ```
     def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil)
       request = new_request({{http_method.upcase}}, path, headers, form)
-      request.headers["Content-type"] = "application/x-www-form-urlencoded"
+      request.headers["Content-Type"] = "application/x-www-form-urlencoded"
       exec(request) do |response|
         yield response
       end
     end
 
-    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
@@ -424,7 +424,7 @@ class HTTP::Client
       {{http_method.id}}_form path, body, headers
     end
 
-    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     # The "Content-type" header is set to "application/x-www-form-urlencoded".
     #
@@ -441,7 +441,7 @@ class HTTP::Client
       end
     end
 
-    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
@@ -453,9 +453,9 @@ class HTTP::Client
       end
     end
 
-    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
-    # The "Content-type" header is set to "application/x-www-form-urlencoded".
+    # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
     # HTTP::Client.{{http_method.id}}_form("http://www.example.com", "foo=bar") do |response|

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -420,7 +420,7 @@ class HTTP::Client
     # response = client.{{http_method.id}}_form "/", {"foo" => "bar"}
     # ```
     def {{http_method.id}}_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-      body = HTTP::Params.from_hash(form)
+      body = HTTP::Params.encode(form)
       {{http_method.id}}_form path, body, headers
     end
 
@@ -435,7 +435,7 @@ class HTTP::Client
     # end
     # ```
     def {{http_method.id}}_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil)
-      body = HTTP::Params.from_hash(form)
+      body = HTTP::Params.encode(form)
       {{http_method.id}}_form(path, body, headers) do |response|
         yield response
       end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -380,94 +380,96 @@ class HTTP::Client
     end
   {% end %}
 
-  # Executes a POST with form data. The "Content-type" header is set
-  # to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # client = HTTP::Client.new "www.example.com"
-  # response = client.post_form "/", "foo=bar"
-  # ```
-  def post_form(path, form : String | IO, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-    request = new_request("POST", path, headers, form)
-    request.headers["Content-type"] = "application/x-www-form-urlencoded"
-    exec request
-  end
-
-  # Executes a POST with form data and yields the response to the block.
-  # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
-  # The "Content-type" header is set to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # client = HTTP::Client.new "www.example.com"
-  # client.post_form("/", "foo=bar") do |response|
-  #   response.body_io.gets
-  # end
-  # ```
-  def post_form(path, form : String | IO, headers : HTTP::Headers? = nil)
-    request = new_request("POST", path, headers, form)
-    request.headers["Content-type"] = "application/x-www-form-urlencoded"
-    exec(request) do |response|
-      yield response
+  {% for http_method in ["post", "put"] %}
+    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # client = HTTP::Client.new "www.example.com"
+    # response = client.{{http_method.id}}_form "/", "foo=bar"
+    # ```
+    def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+      request = new_request({{http_method.upcase}}, path, headers, form)
+      request.headers["Content-type"] = "application/x-www-form-urlencoded"
+      exec request
     end
-  end
 
-  # Executes a POST with form data. The "Content-type" header is set
-  # to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # client = HTTP::Client.new "www.example.com"
-  # response = client.post_form "/", {"foo" => "bar"}
-  # ```
-  def post_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-    body = HTTP::Params.encode(form)
-    post_form path, body, headers
-  end
-
-  # Executes a POST with form data and yields the response to the block.
-  # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
-  # The "Content-type" header is set to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # client = HTTP::Client.new "www.example.com"
-  # client.post_form("/", {"foo" => "bar"}) do |response|
-  #   response.body_io.gets
-  # end
-  # ```
-  def post_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil)
-    body = HTTP::Params.encode(form)
-    post_form(path, body, headers) do |response|
-      yield response
-    end
-  end
-
-  # Executes a POST with form data. The "Content-type" header is set
-  # to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # response = HTTP::Client.post_form "http://www.example.com", "foo=bar"
-  # ```
-  def self.post_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil) : HTTP::Client::Response
-    exec(url, tls) do |client, path|
-      client.post_form(path, form, headers)
-    end
-  end
-
-  # Executes a POST with form data and yields the response to the block.
-  # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
-  # The "Content-type" header is set to "application/x-www-form-urlencoded".
-  #
-  # ```
-  # HTTP::Client.post_form("http://www.example.com", "foo=bar") do |response|
-  #   response.body_io.gets
-  # end
-  # ```
-  def self.post_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil)
-    exec(url, tls) do |client, path|
-      client.post_form(path, form, headers) do |response|
+    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
+    # The "Content-type" header is set to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # client = HTTP::Client.new "www.example.com"
+    # client.{{http_method.id}}_form("/", "foo=bar") do |response|
+    #   response.body_io.gets
+    # end
+    # ```
+    def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil)
+      request = new_request({{http_method.upcase}}, path, headers, form)
+      request.headers["Content-type"] = "application/x-www-form-urlencoded"
+      exec(request) do |response|
         yield response
       end
     end
-  end
+
+    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # client = HTTP::Client.new "www.example.com"
+    # response = client.{{http_method.id}}_form "/", {"foo" => "bar"}
+    # ```
+    def {{http_method.id}}_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+      body = HTTP::Params.from_hash(form)
+      {{http_method.id}}_form path, body, headers
+    end
+
+    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
+    # The "Content-type" header is set to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # client = HTTP::Client.new "www.example.com"
+    # client.{{http_method.id}}_form("/", {"foo" => "bar"}) do |response|
+    #   response.body_io.gets
+    # end
+    # ```
+    def {{http_method.id}}_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil)
+      body = HTTP::Params.from_hash(form)
+      {{http_method.id}}_form(path, body, headers) do |response|
+        yield response
+      end
+    end
+
+    # Executes a {{http_method.id.upcase}} with form data. The "Content-type" header is set
+    # to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # response = HTTP::Client.{{http_method.id}}_form "http://www.example.com", "foo=bar"
+    # ```
+    def self.{{http_method.id}}_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil) : HTTP::Client::Response
+      exec(url, tls) do |client, path|
+        client.{{http_method.id}}_form(path, form, headers)
+      end
+    end
+
+    # Executes a {{http_method.id.upcase}} with form data and yields the response to the block.
+    # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
+    # The "Content-type" header is set to "application/x-www-form-urlencoded".
+    #
+    # ```
+    # HTTP::Client.{{http_method.id}}_form("http://www.example.com", "foo=bar") do |response|
+    #   response.body_io.gets
+    # end
+    # ```
+    def self.{{http_method.id}}_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil)
+      exec(url, tls) do |client, path|
+        client.{{http_method.id}}_form(path, form, headers) do |response|
+          yield response
+        end
+      end
+    end
+  {% end %}
 
   # Executes a request.
   # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.


### PR DESCRIPTION
This commit adds in a helper `put_form` method for `HTTP::Client`. The only real change is that it submits a "PUT" request instead of "POST". Since the code seems to be almost identical to the `post_form` methods, I put it in a macro which would allow for a `patch_form` later if that's wanted.

```crystal
client = HTTP::Client.new "www.example.com"
response = client.put_form "/", "foo=bar"
```