### PR TITLE
Adds non-allocating random_bytes method to SecureRandom. Fixes #4049

### DIFF
--- a/spec/std/secure_random_spec.cr
+++ b/spec/std/secure_random_spec.cr
@@ -68,6 +68,13 @@ describe SecureRandom do
       bytes = SecureRandom.random_bytes(10000)
       bytes[9990, 10].should_not eq(Bytes.new(10))
     end
+
+    it "fills given buffer with random bytes" do
+      bytes = Bytes.new(2000)
+      SecureRandom.random_bytes(bytes)
+      bytes.size.should eq 2000
+      bytes[1990, 10].should_not eq(Bytes.new(10))
+    end
   end
 
   describe "uuid" do


### PR DESCRIPTION
Fixes #4049.
I thought that there is a #3434 so i should wait until it is checked, but now i spotted labels so i think this PR should be done.