### PR TITLE
Flate: try to inflate even if @stream.avail_in is 0

### DIFF
--- a/spec/std/flate/flate_spec.cr
+++ b/spec/std/flate/flate_spec.cr
@@ -2,6 +2,26 @@ require "spec"
 require "flate"
 
 module Flate
+  describe Reader do
+    it "should read byte by byte (#4192)" do
+      io = IO::Memory.new
+      "cbc9cc4b350402ae1c20c30808b800".scan(/../).each do |match|
+        io.write_byte match[0].to_u8(16)
+      end
+      io.rewind
+
+      reader = Reader.new(io)
+
+      str = String::Builder.build do |builder|
+        while b = reader.read_byte
+          builder.write_byte b
+        end
+      end
+
+      str.should eq("line1111\nline2222\n")
+    end
+  end
+
   describe Writer do
     it "should be able to write" do
       message = "this is a test string !!!!\n"

--- a/src/flate/reader.cr
+++ b/src/flate/reader.cr
@@ -77,7 +77,6 @@ class Flate::Reader
           @stream.next_in = @buf.to_unsafe
           @stream.avail_in = @io.read(@buf.to_slice).to_u32
         end
-        return 0 if @stream.avail_in == 0
       end
 
       old_avail_in = @stream.avail_in


### PR DESCRIPTION
Fix #4192

We cannot assume the end of a stream even if `@stream.avail_in` is `0`. `z_stream`'s internal state may have more outputs, #4192 for example. Probably `LibZ::Error::STREAM_END` is only way to detect the end of a stream.