### PR TITLE
Refactor Colorize#surround

### DIFF
--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -338,7 +338,7 @@ struct Colorize::Object(T)
 
   private def self.append_start(io, color)
     last_color_is_default =
-      @@last_color[:fore] == ColorANSI::Default  &&
+      @@last_color[:fore] == ColorANSI::Default &&
         @@last_color[:back] == ColorANSI::Default &&
         @@last_color[:mode] == 0
 

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -296,64 +296,88 @@ struct Colorize::Object(T)
   end
 
   def surround(io = STDOUT)
-    must_append_end = append_start(io)
-    yield io
-    append_end(io) if must_append_end
-  end
+    return yield io unless @enabled
 
-  STACK = [] of Colorize::Object(String)
-
-  def push(io = STDOUT)
-    last_color = STACK.last?
-
-    append_start(io, !!last_color)
-
-    STACK.push self
-    yield io
-    STACK.pop
-
-    if last_color
-      last_color.append_start(io, true)
-    else
-      append_end(io)
+    Object.surround(io, to_named_tuple) do |io|
+      yield io
     end
   end
 
-  protected def append_start(io, reset = false)
-    return false unless @enabled
+  # DEPRECATED: Use `#surround`.
+  def push(io = STDOUT)
+    {{ puts "Warning: `Colorize::Object#push` is deprecated and will be removed, use `Colorize::Object#surround` instead".id }}
+    surround(io) { |io| yield io }
+  end
 
-    fore_is_default = @fore == ColorANSI::Default
-    back_is_default = @back == ColorANSI::Default
-    mode_is_default = @mode == 0
+  private def to_named_tuple
+    {
+      fore: @fore,
+      back: @back,
+      mode: @mode,
+    }
+  end
 
-    if fore_is_default && back_is_default && mode_is_default && !reset
+  @@last_color = {
+    fore: ColorANSI::Default.as(Color),
+    back: ColorANSI::Default.as(Color),
+    mode: 0,
+  }
+
+  protected def self.surround(io, color)
+    last_color = @@last_color
+    must_append_end = append_start(io, color)
+    @@last_color = color
+
+    begin
+      yield io
+    ensure
+      append_start(io, last_color) if must_append_end
+      @@last_color = last_color
+    end
+  end
+
+  private def self.append_start(io, color)
+    last_color_is_default =
+      @@last_color[:fore] == ColorANSI::Default  &&
+        @@last_color[:back] == ColorANSI::Default &&
+        @@last_color[:mode] == 0
+
+    fore = color[:fore]
+    back = color[:back]
+    mode = color[:mode]
+
+    fore_is_default = fore == ColorANSI::Default
+    back_is_default = back == ColorANSI::Default
+    mode_is_default = mode == 0
+
+    if fore_is_default && back_is_default && mode_is_default && last_color_is_default || @@last_color == color
       false
     else
       io << "\e["
 
       printed = false
 
-      if reset
+      unless last_color_is_default
         io << MODE_DEFAULT
         printed = true
       end
 
       unless fore_is_default
         io << ';' if printed
-        @fore.fore io
+        fore.fore io
         printed = true
       end
 
       unless back_is_default
         io << ';' if printed
-        @back.back io
+        back.back io
         printed = true
       end
 
       unless mode_is_default
         # Can't reuse MODES constant because it has bold/bright duplicated
         {% for name in %w(bold dim underline blink reverse hidden) %}
-          if @mode.bits_set? MODE_{{name.upcase.id}}_FLAG
+          if mode.bits_set? MODE_{{name.upcase.id}}_FLAG
             io << ';' if printed
             io << MODE_{{name.upcase.id}}
             printed = true
@@ -365,9 +389,5 @@ struct Colorize::Object(T)
 
       true
     end
-  end
-
-  protected def append_end(io)
-    Colorize.reset(io)
   end
 end

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -303,12 +303,6 @@ struct Colorize::Object(T)
     end
   end
 
-  # DEPRECATED: Use `#surround`.
-  def push(io = STDOUT)
-    {{ puts "Warning: `Colorize::Object#push` is deprecated and will be removed, use `Colorize::Object#surround` instead".id }}
-    surround(io) { |io| yield io }
-  end
-
   private def to_named_tuple
     {
       fore: @fore,

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -27,7 +27,7 @@ module Crystal
         compute_targets(@program.types, exp, false)
       end
 
-      with_color.light_gray.bold.push(STDOUT) do
+      with_color.light_gray.bold.surround(STDOUT) do
         print_type @program.object
       end
     end
@@ -126,7 +126,7 @@ module Crystal
       if (type.is_a?(NonGenericClassType) || type.is_a?(GenericClassInstanceType)) &&
          !type.is_a?(PointerInstanceType) && !type.is_a?(ProcInstanceType)
         size = @llvm_typer.size_of(@llvm_typer.llvm_struct_type(type))
-        with_color.light_gray.push(STDOUT) do
+        with_color.light_gray.surround(STDOUT) do
           print " ("
           print size.to_s
           print " bytes)"
@@ -176,7 +176,7 @@ module Crystal
           print "      "
         end
 
-        with_color.light_gray.push(STDOUT) do
+        with_color.light_gray.surround(STDOUT) do
           print name.ljust(max_name_size)
           print " : "
           print var
@@ -211,13 +211,13 @@ module Crystal
           print "      "
         end
 
-        with_color.light_gray.push(STDOUT) do
+        with_color.light_gray.surround(STDOUT) do
           print ivar.name.ljust(max_name_size)
           print " : "
           if ivar_type = ivar.type?
             print ivar_type.to_s.ljust(max_type_size)
             size = @llvm_typer.size_of(@llvm_typer.llvm_embedded_type(ivar_type))
-            with_color.light_gray.push(STDOUT) do
+            with_color.light_gray.surround(STDOUT) do
               print " ("
               print size.to_s.rjust(max_bytes_size)
               print " bytes)"


### PR DESCRIPTION
This is one of the separations of #3925.

Remove `surround` and rename `push` to `surround`, now `push` is derecated.
(This reason is described in https://github.com/crystal-lang/crystal/pull/3925#issuecomment-275852281)

As side effect, this fix make it possible to use colorize in `to_s` on colorize methods. For example:

```crystal
require "colorize"

class Foo
  def to_s(io)
    io << "foo"
    io << "bar".colorize.red
    io << "baz"
  end
end

puts Foo.new.colorize.white.on_black
```

This script cannot work on current colorize because `Colorize::Object#to_s` uses `surround` but it doesn't support nesting of colorize methods. But now, `surround` keeps colorize stack for nesting internally, so this script works fine.