### PR TITLE
Rename HTTP::Params.from_hash to HTTP::Params.encode and add an overload for NamedTuple

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -49,6 +49,18 @@ module HTTP
       end
     end
 
+    describe ".encode" do
+      it "builds from hash" do
+        encoded = Params.encode({"foo" => "bar", "baz" => "quux"})
+        encoded.should eq("foo=bar&baz=quux")
+      end
+
+      it "builds from named tuple" do
+        encoded = Params.encode({foo: "bar", baz: "quux"})
+        encoded.should eq("foo=bar&baz=quux")
+      end
+    end
+
     describe "#to_s" do
       it "serializes params to http form" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -418,8 +418,8 @@ class HTTP::Client
   # client = HTTP::Client.new "www.example.com"
   # response = client.post_form "/", {"foo" => "bar"}
   # ```
-  def post_form(path, form : Hash, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-    body = HTTP::Params.from_hash(form)
+  def post_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+    body = HTTP::Params.encode(form)
     post_form path, body, headers
   end
 
@@ -433,8 +433,8 @@ class HTTP::Client
   #   response.body_io.gets
   # end
   # ```
-  def post_form(path, form : Hash, headers : HTTP::Headers? = nil)
-    body = HTTP::Params.from_hash(form)
+  def post_form(path, form : Hash(String, _) | NamedTuple, headers : HTTP::Headers? = nil)
+    body = HTTP::Params.encode(form)
     post_form(path, body, headers) do |response|
       yield response
     end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -69,12 +69,21 @@ module HTTP
       end
     end
 
-    # Creates an `HTTP::Params` instance from the key-value
-    # pairs of the given *hash*.
-    def self.from_hash(hash : Hash)
+    # Returns the given key value pairs as a
+    # url-encoded HTTP form/query.
+    def self.encode(hash : Hash(String, _))
       build do |builder|
         hash.each do |key, value|
           builder.add key, value
+        end
+      end
+    end
+
+    # ditto
+    def self.encode(named_tuple : NamedTuple)
+      build do |builder|
+        named_tuple.each do |key, value|
+          builder.add key.to_s, value
         end
       end
     end


### PR DESCRIPTION
Also allow passing NamedTuple to the corresponding post_form overloads
on HTTP::Client

That should make passing some static form data (or even some data with static keys) more pleasant without sacrificing on performance as much.