### PR TITLE
Use well known non-existent name for socket specs

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -538,14 +538,14 @@ describe TCPSocket do
   end
 
   it "fails when host doesn't exist" do
-    expect_raises(Socket::Error, /No address found for localhostttttt:12345/) do
-      TCPSocket.new("localhostttttt", 12345)
+    expect_raises(Socket::Error, /No address found for doesnotexist.example.org.:12345/) do
+      TCPSocket.new("doesnotexist.example.org.", 12345)
     end
   end
 
   it "fails (rather than segfault on darwin) when host doesn't exist and port is 0" do
-    expect_raises(Socket::Error, /No address found for localhostttttt:0/) do
-      TCPSocket.new("localhostttttt", 0)
+    expect_raises(Socket::Error, /No address found for doesnotexist.example.org.:0/) do
+      TCPSocket.new("doesnotexist.example.org.", 0)
     end
   end
 end


### PR DESCRIPTION
Should fix #4130

Not giving a FQDN makes us rely on environment configuration too much, for example there might a search domain configured where the host becomes valid in some way.