### PR TITLE
Fix: compilation against OpenSSL 1.1.0

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -1,4 +1,13 @@
 abstract class OpenSSL::SSL::Context
+  # :nodoc:
+  def self.default_method
+    {% if LibSSL::OPENSSL_110 %}
+      LibSSL.tls_method
+    {% else %}
+      LibSSL.sslv23_method
+    {% end %}
+  end
+
   # The list of secure ciphers (intermediate security) as of May 2016 as per
   # https://wiki.mozilla.org/Security/Server_Side_TLS
   CIPHERS = %w(
@@ -47,8 +56,8 @@ abstract class OpenSSL::SSL::Context
   class Client < Context
     # Generates a new TLS client context with sane defaults for a client connection.
     #
-    # By default it defaults to the `SSLv23_method` which actually means that
-    # OpenSSL will negotiate the TLS or SSL protocol to use with the remote
+    # Defaults to `TLS_method` or `SSLv23_method` (depending on OpenSSL version)
+    # which tells OpenSSL to negotiate the TLS or SSL protocol with the remote
     # endpoint.
     #
     # Don't change the method unless you must restrict a specific protocol to be
@@ -63,7 +72,7 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Client.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3)
     # ```
-    def initialize(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
+    def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
@@ -76,7 +85,7 @@ abstract class OpenSSL::SSL::Context
     #
     # For everything else this uses the defaults of your OpenSSL.
     # Use this only if undoing the defaults that `new` sets is too much hassle.
-    def self.insecure(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
+    def self.insecure(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
     end
 
@@ -102,8 +111,8 @@ abstract class OpenSSL::SSL::Context
   class Server < Context
     # Generates a new TLS server context with sane defaults for a server connection.
     #
-    # By default it defaults to the `SSLv23_method` which actually means that
-    # OpenSSL will negotiate the TLS or SSL protocol to use with the remote
+    # Defaults to `TLS_method` or `SSLv23_method` (depending on OpenSSL version)
+    # which tells OpenSSL to negotiate the TLS or SSL protocol with the remote
     # endpoint.
     #
     # Don't change the method unless you must restrict a specific protocol to be
@@ -116,7 +125,7 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Server.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSLV2 | OpenSSL::SSL::Options::NO_SSLV3)
     # ```
-    def initialize(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
+    def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
@@ -129,7 +138,7 @@ abstract class OpenSSL::SSL::Context
     #
     # For everything else this uses the defaults of your OpenSSL.
     # Use this only if undoing the defaults that `new` sets is too much hassle.
-    def self.insecure(method : LibSSL::SSLMethod = LibSSL.sslv23_method)
+    def self.insecure(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
     end
   end


### PR DESCRIPTION
OpenSSL 1.1.0 introduced some breaking changes:

- Initialization is now automatically handled (and init/load strings methods removed or renamed);
- `TLS_method` has been added while `SSLv23_method` was removed.

fixes #4204 