### PR TITLE
add YAML::Any method to_json

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -2,6 +2,7 @@ require "spec"
 require "json"
 require "big"
 require "big/json"
+require "yaml"
 
 enum JSONSpecEnum
   Zero
@@ -231,6 +232,25 @@ describe "JSON serialization" do
     it "does for BigFloat" do
       big = BigFloat.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
+    end
+
+    it "does for YAML::Any" do
+      doc = YAML.parse(%(---
+        string: hello crystal
+        integer: 10
+        float: 1.0
+        true: true
+        false: false
+        array:
+          - item1
+          - item2
+        hash:
+          key1: value1
+          key2: value2
+        empty_value:
+      ))
+
+      doc.to_json.should eq("{\"string\":\"hello crystal\",\"integer\":10,\"float\":1.0,\"true\":true,\"false\":false,\"array\":[\"item1\",\"item2\"],\"hash\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"empty_value\":null}")
     end
   end
 

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -128,6 +128,37 @@ struct Time
   end
 end
 
+struct YAML::Any
+  def to_json(json : JSON::Builder)
+    case object = @raw
+    when Array
+      json.array do
+        each &.to_json(json)
+      end
+    when Hash
+      json.object do
+        each do |key, value|
+          json.field key do
+            value.to_json(json)
+          end
+        end
+      end
+    when "true"
+      json.bool(true)
+    when "false"
+      json.bool(false)
+    when ""
+      json.null
+    when Nil
+      json.null
+    when /^[+-]?([0-9]*[.])?[0-9]+$/
+      object.includes?(".") ? json.number(object.to_f) : json.number(object.to_i)
+    else
+      json.string(object)
+    end
+  end
+end
+
 # Converter to be used with `JSON.mapping` and `YAML.mapping`
 # to serialize a `Time` instance as the number of seconds
 # since the unix epoch. See `Time.epoch`.


### PR DESCRIPTION
Add method .to_json for YAML::Any

```crystal
doc = YAML.parse(%(---
        string: hello crystal
        integer: 10
        float: 1.0
        true: true
        false: false
        array:
          - item1
          - item2
        hash:
          key1: value1
          key2: value2
        empty_value:
      ))

puts doc.to_json
```

output: 

```json
{"string":"hello crystal","integer":10,"float":1.0,"true":true,"false":false,"array":["item1","item2"],"hash":{"key1":"value1","key2":"value2"},"empty_value":null}
```

Is this can be add to std method, and how about to_yaml for JSON::Any add too?