### PR TITLE
Fix: OpenSSL 1.1.0

### DIFF
--- a/spec/std/openssl/hmac_spec.cr
+++ b/spec/std/openssl/hmac_spec.cr
@@ -3,8 +3,6 @@ require "openssl/hmac"
 
 describe OpenSSL::HMAC do
   [
-    {:dss, "46b4ec586117154dacd49d664e5d63fdc88efb51"},
-    {:dss1, "46b4ec586117154dacd49d664e5d63fdc88efb51"},
     {:md4, "f3593b56f00b25c8af31d02ddef6d2d0"},
     {:md5, "0c7a250281315ab863549f66cd8a3a53"},
     {:sha1, "46b4ec586117154dacd49d664e5d63fdc88efb51"},

--- a/src/openssl/digest/digest.cr
+++ b/src/openssl/digest/digest.cr
@@ -15,12 +15,12 @@ module OpenSSL
       raise Error.new("Invalid EVP_MD_CTX") unless @ctx
     end
 
-    protected def self.create_evp_mt_ctx(name)
+    protected def self.new_evp_mt_ctx(name)
       md = LibCrypto.evp_get_digestbyname(name)
       unless md
         raise UnsupportedError.new("Unsupported digest algorithm: #{name}")
       end
-      ctx = LibCrypto.evp_md_ctx_create
+      ctx = LibCrypto.evp_md_ctx_new
       unless ctx
         raise Error.new "Digest initialization failed."
       end
@@ -31,17 +31,17 @@ module OpenSSL
     end
 
     def self.new(name)
-      new(name, create_evp_mt_ctx(name))
+      new(name, new_evp_mt_ctx(name))
     end
 
     def finalize
-      LibCrypto.evp_md_ctx_destroy(self)
+      LibCrypto.evp_md_ctx_free(self)
     end
 
     def clone
-      ctx = LibCrypto.evp_md_ctx_create
+      ctx = LibCrypto.evp_md_ctx_new
       if LibCrypto.evp_md_ctx_copy(ctx, @ctx) == 0
-        LibCrypto.evp_md_ctx_destroy(ctx)
+        LibCrypto.evp_md_ctx_free(ctx)
         raise Error.new("Unable to clone digest")
       end
       Digest.new(@name, ctx)

--- a/src/openssl/hmac.cr
+++ b/src/openssl/hmac.cr
@@ -3,8 +3,6 @@ require "./lib_crypto"
 class OpenSSL::HMAC
   def self.digest(algorithm : Symbol, key, data) : Bytes
     evp = case algorithm
-          when :dss       then LibCrypto.evp_dss
-          when :dss1      then LibCrypto.evp_dss1
           when :md4       then LibCrypto.evp_md4
           when :md5       then LibCrypto.evp_md5
           when :ripemd160 then LibCrypto.evp_ripemd160

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -132,15 +132,21 @@ lib LibCrypto
   fun hmac_ctx_copy = HMAC_CTX_copy(dst : HMAC_CTX, src : HMAC_CTX) : Int32
 
   fun evp_get_digestbyname = EVP_get_digestbyname(name : UInt8*) : EVP_MD
-  fun evp_md_ctx_create = EVP_MD_CTX_create : EVP_MD_CTX
   fun evp_digestinit_ex = EVP_DigestInit_ex(ctx : EVP_MD_CTX, type : EVP_MD, engine : Void*) : Int32
   fun evp_digestupdate = EVP_DigestUpdate(ctx : EVP_MD_CTX, data : UInt8*, count : LibC::SizeT) : Int32
-  fun evp_md_ctx_destroy = EVP_MD_CTX_destroy(ctx : EVP_MD_CTX)
   fun evp_md_ctx_copy = EVP_MD_CTX_copy(dst : EVP_MD_CTX, src : EVP_MD_CTX) : Int32
   fun evp_md_ctx_md = EVP_MD_CTX_md(ctx : EVP_MD_CTX) : EVP_MD
   fun evp_md_size = EVP_MD_size(md : EVP_MD) : Int32
   fun evp_md_block_size = EVP_MD_block_size(md : EVP_MD) : LibC::Int
   fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx : EVP_MD_CTX, md : UInt8*, size : UInt32*) : Int32
+
+  {% if OPENSSL_110 %}
+    fun evp_md_ctx_new = EVP_MD_CTX_new : EVP_MD_CTX
+    fun evp_md_ctx_free = EVP_MD_CTX_free(ctx : EVP_MD_CTX)
+  {% else %}
+    fun evp_md_ctx_new = EVP_MD_CTX_create : EVP_MD_CTX
+    fun evp_md_ctx_free = EVP_MD_CTX_destroy(ctx : EVP_MD_CTX)
+  {% end %}
 
   fun evp_get_cipherbyname = EVP_get_cipherbyname(name : UInt8*) : EVP_CIPHER
   fun evp_cipher_name = EVP_CIPHER_name(cipher : EVP_CIPHER) : UInt8*
@@ -202,10 +208,17 @@ lib LibCrypto
   NID_commonName       = 13
   NID_subject_alt_name = 85
 
-  fun sk_free(st : Void*)
-  fun sk_num = sk_num(x0 : Void*) : Int
-  fun sk_pop_free(st : Void*, callback : (Void*) ->)
-  fun sk_value = sk_value(x0 : Void*, x1 : Int) : Void*
+  {% if OPENSSL_110 %}
+    fun sk_free = OPENSSL_sk_free(st : Void*)
+    fun sk_num = OPENSSL_sk_num(x0 : Void*) : Int
+    fun sk_pop_free = OPENSSL_sk_pop_free(st : Void*, callback : (Void*) ->)
+    fun sk_value = OPENSSL_sk_value(x0 : Void*, x1 : Int) : Void*
+  {% else %}
+    fun sk_free(st : Void*)
+    fun sk_num(x0 : Void*) : Int
+    fun sk_pop_free(st : Void*, callback : (Void*) ->)
+    fun sk_value(x0 : Void*, x1 : Int) : Void*
+  {% end %}
 
   fun x509_dup = X509_dup(a : X509) : X509
   fun x509_free = X509_free(a : X509)

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -74,8 +74,6 @@ lib LibCrypto
 
   type EVP_MD = Void*
 
-  fun evp_dss = EVP_dss : EVP_MD
-  fun evp_dss1 = EVP_dss1 : EVP_MD
   fun evp_md4 = EVP_md4 : EVP_MD
   fun evp_md5 = EVP_md5 : EVP_MD
   fun evp_ripemd160 = EVP_ripemd160 : EVP_MD


### PR DESCRIPTION
OpenSSL 1.1.0 renamed some libcrypto symbols (eg: `sk_*` to `OPENSSL_sk_*`), and dropped support for DSS. I chose to drop DSS, too, for the principle of least suprise —a binary built against OpenSSL 1.0 would fail to run if OpenSSL is upgraded to 1.1.

This allows to build the Crystal test suite against OpenSSL 1.1.0.

 closes #4204 