### PR TITLE
Configurable DNS resolvers

### DIFF
--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -1,0 +1,111 @@
+require "spec"
+require "socket"
+require "socket/addrinfo/threaded"
+require "socket/addrinfo/evented"
+
+describe Socket::Addrinfo do
+  describe ".resolve" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::STREAM)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+
+    it "eventually raises returned error" do
+      expect_raises(Socket::Error) do |addrinfo|
+        Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
+          Socket::Error.new("please fail")
+        end
+      end
+    end
+  end
+
+  describe ".tcp" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.tcp("localhost", 80)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.tcp("localhost", 80) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+  end
+
+  describe ".udp" do
+    it "returns an array" do
+      addrinfos = Socket::Addrinfo.udp("localhost", 80)
+      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
+      addrinfos.size.should_not eq(0)
+    end
+
+    it "yields each result" do
+      Socket::Addrinfo.udp("localhost", 80) do |addrinfo|
+        typeof(addrinfo).should eq(Socket::Addrinfo)
+      end
+    end
+  end
+
+  describe "#ip_address" do
+    it do
+      addrinfos = Socket::Addrinfo.udp("localhost", 80)
+      typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
+    end
+  end
+
+  describe "Blocking resolver" do
+    resolver = Socket::Addrinfo::Blocking.new
+
+    it "resolves domain" do
+      resolver.getaddrinfo("localhost", 80, Socket::Family::UNSPEC, Socket::Type::STREAM) do |addrinfo|
+        addrinfo.ip_address.to_s.should eq("127.0.0.1:80")
+      end
+    end
+
+    it "fails to resolve unknown domain" do
+      expect_raises(Socket::Error) do
+        resolver.getaddrinfo("unknown.example.org", 21, Socket::Family::UNSPEC, Socket::Type::STREAM) { }
+      end
+    end
+  end
+
+  describe "Threaded resolver" do
+    resolver = Socket::Addrinfo::Threaded.new(size: 2)
+
+    it "resolves domain" do
+      resolver.getaddrinfo("localhost", 80, Socket::Family::UNSPEC, Socket::Type::STREAM) do |addrinfo|
+        addrinfo.ip_address.to_s.should eq("127.0.0.1:80")
+      end
+    end
+
+    it "fails to resolve unknown domain" do
+      expect_raises(Socket::Error) do
+        resolver.getaddrinfo("unknown.example.org", 21, Socket::Family::UNSPEC, Socket::Type::STREAM) { }
+      end
+    end
+  end
+
+  describe "Evented resolver" do
+    resolver = Socket::Addrinfo::Evented.new
+
+    it "resolves domain" do
+      resolver.getaddrinfo("localhost", 80, Socket::Family::UNSPEC, Socket::Type::STREAM) do |addrinfo|
+        addrinfo.ip_address.to_s.should eq("127.0.0.1:80")
+      end
+    end
+
+    it "fails to resolve unknown domain" do
+      expect_raises(Socket::Error) do
+        resolver.getaddrinfo("unknown.example.org", 21, Socket::Family::UNSPEC, Socket::Type::STREAM) { }
+      end
+    end
+  end
+end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -76,65 +76,6 @@ describe Socket do
   end
 end
 
-describe Socket::Addrinfo do
-  describe ".resolve" do
-    it "returns an array" do
-      addrinfos = Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::STREAM)
-      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
-      addrinfos.size.should_not eq(0)
-    end
-
-    it "yields each result" do
-      Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
-        typeof(addrinfo).should eq(Socket::Addrinfo)
-      end
-    end
-
-    it "eventually raises returned error" do
-      expect_raises(Socket::Error) do |addrinfo|
-        Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
-          Socket::Error.new("please fail")
-        end
-      end
-    end
-  end
-
-  describe ".tcp" do
-    it "returns an array" do
-      addrinfos = Socket::Addrinfo.tcp("localhost", 80)
-      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
-      addrinfos.size.should_not eq(0)
-    end
-
-    it "yields each result" do
-      Socket::Addrinfo.tcp("localhost", 80) do |addrinfo|
-        typeof(addrinfo).should eq(Socket::Addrinfo)
-      end
-    end
-  end
-
-  describe ".udp" do
-    it "returns an array" do
-      addrinfos = Socket::Addrinfo.udp("localhost", 80)
-      typeof(addrinfos).should eq(Array(Socket::Addrinfo))
-      addrinfos.size.should_not eq(0)
-    end
-
-    it "yields each result" do
-      Socket::Addrinfo.udp("localhost", 80) do |addrinfo|
-        typeof(addrinfo).should eq(Socket::Addrinfo)
-      end
-    end
-  end
-
-  describe "#ip_address" do
-    it do
-      addrinfos = Socket::Addrinfo.udp("localhost", 80)
-      typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
-    end
-  end
-end
-
 describe Socket::IPAddress do
   it "transforms an IPv4 address into a C struct and back" do
     addr1 = Socket::IPAddress.new("127.0.0.1", 8080)

--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -76,4 +76,8 @@ class Scheduler
   def self.enqueue(fibers : Enumerable(Fiber))
     @@runnables.concat fibers
   end
+
+  def self.new_dns_base
+    Event::DnsBase.new(@@eb)
+  end
 end

--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -69,16 +69,6 @@ class Scheduler
     event
   end
 
-  @@dns_base : Event::DnsBase?
-
-  private def self.dns_base
-    @@dns_base ||= @@eb.new_dns_base
-  end
-
-  def self.create_dns_request(nodename, servname, hints, data, &callback : LibEvent2::DnsGetAddrinfoCallback)
-    dns_base.getaddrinfo(nodename, servname, hints, data, &callback)
-  end
-
   def self.enqueue(fiber : Fiber)
     @@runnables << fiber
   end

--- a/src/event.cr
+++ b/src/event.cr
@@ -79,28 +79,5 @@ module Event
     def loop_break
       LibEvent2.event_base_loopbreak(@base)
     end
-
-    def new_dns_base(init = true)
-      DnsBase.new LibEvent2.evdns_base_new(@base, init ? 1 : 0)
-    end
-  end
-
-  struct DnsBase
-    def initialize(@dns_base : LibEvent2::DnsBase)
-    end
-
-    def getaddrinfo(nodename, servname, hints, data, &callback : LibEvent2::DnsGetAddrinfoCallback)
-      request = LibEvent2.evdns_getaddrinfo(@dns_base, nodename, servname, hints, callback, data.as(Void*))
-      GetAddrInfoRequest.new request if request
-    end
-
-    struct GetAddrInfoRequest
-      def initialize(@request : LibEvent2::DnsGetAddrinfoRequest)
-      end
-
-      def cancel
-        LibEvent2.evdns_getaddrinfo_cancel(@request)
-      end
-    end
   end
 end

--- a/src/event.cr
+++ b/src/event.cr
@@ -79,5 +79,76 @@ module Event
     def loop_break
       LibEvent2.event_base_loopbreak(@base)
     end
+
+    def to_unsafe
+      @base
+    end
+  end
+
+  # :nodoc:
+  class DnsBase
+    # :nodoc:
+    # TODO: consider using a struct & pass pointer
+    class Response
+      property result : Int32?
+      property addrinfo : Pointer(LibEvent2::EvutilAddrinfo)?
+
+      def initialize(@fiber : Fiber)
+      end
+
+      def resume
+        @fiber.resume
+      end
+
+      def cancelled?
+        @result == LibEvent2::EVUTIL_EAI_CANCEL
+      end
+    end
+
+    def initialize(base : Base)
+      @dns_base = LibEvent2.evdns_base_new(base, 1)
+    end
+
+    def finalize
+      LibEvent2.evdns_base_free(@dns_base, 1)
+    end
+
+    def getaddrinfo(domain, service, hints, timeout = nil, &block)
+      response = Response.new(Fiber.current)
+
+      request = LibEvent2.evdns_getaddrinfo(@dns_base, domain, service, hints, ->(result, addrinfo, data) {
+        r = Box(Response).unbox(data)
+        r.result = result
+        r.addrinfo = addrinfo
+        r.resume
+      }, Box.box(response))
+
+      # evdns returns a request only if the request is pending, otherwise the
+      # callback was already called.
+      if request
+        # TODO: consider configuring DNS timeout globally: evdns_base_set_option("timeout", "5")
+        if timeout
+          spawn do
+            sleep timeout.not_nil!
+            LibEvent2.evdns_getaddrinfo_cancel(request)
+          end
+        end
+
+        sleep # until explicitly resumed
+      end
+
+      if addrinfo = response.addrinfo
+        yield addrinfo
+      elsif response.cancelled?
+        raise IO::Timeout.new("Failed to resolve #{domain} in #{timeout} seconds")
+      else
+        error = response.result.not_nil!
+        raise Socket::Error.new("evdns_getaddrinfo: #{error}")
+      end
+    ensure
+      if addrinfo = response.try(&.addrinfo)
+        LibEvent2.evutil_freeaddrinfo(addrinfo)
+      end
+    end
   end
 end

--- a/src/event/lib_event2.cr
+++ b/src/event/lib_event2.cr
@@ -52,17 +52,4 @@ lib LibEvent2
   fun event_free(event : Event)
   fun event_add(event : Event, timeout : LibC::Timeval*) : Int
   fun event_del(event : Event) : Int
-
-  type DnsBase = Void*
-  type DnsGetAddrinfoRequest = Void*
-
-  EVUTIL_EAI_CANCEL = -90001
-
-  alias DnsGetAddrinfoCallback = (Int32, LibC::Addrinfo*, Void*) ->
-
-  fun evdns_base_new(base : EventBase, init : Int32) : DnsBase
-  fun evdns_base_free(base : DnsBase, fail_requests : Int32)
-  fun evdns_getaddrinfo(base : DnsBase, nodename : UInt8*, servname : UInt8*, hints : LibC::Addrinfo*, cb : DnsGetAddrinfoCallback, arg : Void*) : DnsGetAddrinfoRequest
-  fun evdns_getaddrinfo_cancel(DnsGetAddrinfoRequest)
-  fun evutil_freeaddrinfo(ai : LibC::Addrinfo*)
 end

--- a/src/event/lib_event2.cr
+++ b/src/event/lib_event2.cr
@@ -11,6 +11,7 @@ require "c/netdb"
 @[Link("event")]
 {% end %}
 lib LibEvent2
+  alias Char = LibC::Char
   alias Int = LibC::Int
 
   {% if flag?(:windows) %}
@@ -52,4 +53,37 @@ lib LibEvent2
   fun event_free(event : Event)
   fun event_add(event : Event, timeout : LibC::Timeval*) : Int
   fun event_del(event : Event) : Int
+
+  {% if flag?(:windows) %}
+    struct EvutilAddrinfo
+      ai_flags : Int
+      ai_family : Int
+      ai_socktype : Int
+      ai_protocol : Int
+      ai_addrlen : LibC::SizeT
+      ai_canonname : Char*
+      ai_addr : LibC::Sockaddr*
+      ai_next : EvutilAddrinfo*
+    end
+
+    EVUTIL_AI_NUMERICSERV = 0x8000
+  {% else %}
+    alias EvutilAddrinfo = LibC::Addrinfo
+
+    EVUTIL_AI_NUMERICSERV = LibC::AI_NUMERICSERV
+  {% end %}
+
+  EVUTIL_EAI_CANCEL = -90001
+
+  type EvdnsBase = Void*
+  type EvdnsGetaddrinfoRequest = Void*
+
+  alias EvdnsGetaddrinfoCallback = (Int, EvutilAddrinfo*, Void*) ->
+
+  fun evdns_base_new(event_base : EventBase, initialize : Int) : EvdnsBase
+  fun evdns_base_free(base : EvdnsBase, fail_requests : Int)
+  fun evdns_getaddrinfo(dns_base : EvdnsBase, nodename : Char*, servname : Char*, hints_in : EvutilAddrinfo*, cb : EvdnsGetaddrinfoCallback, arg : Void*) : EvdnsGetaddrinfoRequest
+  fun evdns_getaddrinfo_cancel(req : EvdnsGetaddrinfoRequest) : Void
+  fun evutil_freeaddrinfo(ai : EvutilAddrinfo*) : Void
+  fun evutil_gai_strerror(err : Int) : Char*
 end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -11,7 +11,7 @@ class Socket
     getter size : Int32
 
     @addr : LibC::SockaddrIn6
-    @next : LibC::Addrinfo*
+    @next : LibC::Addrinfo* | LibEvent2::EvutilAddrinfo*
 
     # Resolves a domain that best matches the given options.
     #
@@ -115,7 +115,7 @@ class Socket
       resolve(domain, service, family, Type::DGRAM, Protocol::UDP) { |addrinfo| yield addrinfo }
     end
 
-    protected def initialize(addrinfo : LibC::Addrinfo*)
+    protected def initialize(addrinfo : LibC::Addrinfo* | LibEvent2::EvutilAddrinfo*)
       @family = Family.from_value(addrinfo.value.ai_family)
       @type = Type.from_value(addrinfo.value.ai_socktype)
       @protocol = Protocol.from_value(addrinfo.value.ai_protocol)

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -1,6 +1,10 @@
+require "./addrinfo/blocking"
+
 class Socket
   # Domain name resolver.
   struct Addrinfo
+    alias Service = String | Int32
+
     getter family : Family
     getter type : Type
     getter protocol : Protocol
@@ -28,7 +32,7 @@ class Socket
     def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
       addrinfos = [] of Addrinfo
 
-      getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
+      resolver.getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
         loop do
           addrinfos << addrinfo.not_nil!
           unless addrinfo = addrinfo.next?
@@ -36,6 +40,8 @@ class Socket
           end
         end
       end
+
+      return addrinfos
     end
 
     # Resolves a domain that best matches the given options.
@@ -52,7 +58,7 @@ class Socket
     # The iteration will be stopped once the block returns something that isn't
     # an `Exception` (e.g. a `Socket` or `nil`).
     def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil)
-      getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
+      resolver.getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
         error = nil
 
         loop do
@@ -72,42 +78,6 @@ class Socket
             end
           end
         end
-      end
-    end
-
-    private def self.getaddrinfo(domain, service, family, type, protocol, timeout)
-      hints = LibC::Addrinfo.new
-      hints.ai_family = (family || Family::UNSPEC).to_i32
-      hints.ai_socktype = type
-      hints.ai_protocol = protocol
-      hints.ai_flags = 0
-
-      if service.is_a?(Int)
-        hints.ai_flags |= LibC::AI_NUMERICSERV
-      end
-
-      # On OS X < 10.12, the libsystem implementation of getaddrinfo segfaults
-      # if AI_NUMERICSERV is set, and servname is NULL or 0.
-      {% if flag?(:darwin) %}
-        if (service == 0 || service == nil) && (hints.ai_flags & LibC::AI_NUMERICSERV)
-          hints.ai_flags |= LibC::AI_NUMERICSERV
-          service = "00"
-        end
-      {% end %}
-
-      case ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
-      when 0
-        # success
-      when LibC::EAI_NONAME
-        raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
-      else
-        raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}")
-      end
-
-      begin
-        yield new(ptr)
-      ensure
-        LibC.freeaddrinfo(ptr)
       end
     end
 

--- a/src/socket/addrinfo/blocking.cr
+++ b/src/socket/addrinfo/blocking.cr
@@ -1,0 +1,45 @@
+require "./resolver"
+
+class Socket
+  struct Addrinfo
+    # Calls the system `getaddrinfo` function directly from the current thread.
+    # Blocks the event loop until the domain is resolved by the system.
+    #
+    # The `timeout` parameter is discarded.
+    class Blocking < Resolver
+      def getaddrinfo(domain, service, family, type, protocol = Protocol::IP, timeout = nil, &block) : Nil
+        hints = LibC::Addrinfo.new
+        hints.ai_family = (family || Family::UNSPEC).to_i32
+        hints.ai_socktype = type
+        hints.ai_protocol = protocol
+        hints.ai_flags = 0
+
+        if service.is_a?(Int)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+
+          {% if flag?(:darwin) %}
+            # avoid a segfault on macOS < 10.12
+            if service == 0 || service == nil
+              service = "00"
+            end
+          {% end %}
+        end
+
+        case ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
+        when 0
+          # success
+        when LibC::EAI_NONAME
+          raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
+        else
+          raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}")
+        end
+
+        begin
+          yield Addrinfo.new(ptr)
+        ensure
+          LibC.freeaddrinfo(ptr)
+        end
+      end
+    end
+  end
+end

--- a/src/socket/addrinfo/evented.cr
+++ b/src/socket/addrinfo/evented.cr
@@ -1,0 +1,25 @@
+class Socket
+  struct Addrinfo
+    class Evented < Resolver
+      def getaddrinfo(domain, service, family, type, protocol = Protocol::IP, timeout = nil, &block) : Nil
+        hints = LibEvent2::EvutilAddrinfo.new
+        hints.ai_family = (family || Family::UNSPEC).to_i32
+        hints.ai_socktype = type
+        hints.ai_protocol = protocol
+        hints.ai_flags = 0
+
+        if service.is_a?(Int)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+        end
+
+        dns_base.getaddrinfo(domain, service.to_s, pointerof(hints)) do |addrinfo|
+          yield Addrinfo.new(addrinfo)
+        end
+      end
+
+      private def dns_base
+        @dns_base ||= Scheduler.new_dns_base
+      end
+    end
+  end
+end

--- a/src/socket/addrinfo/resolver.cr
+++ b/src/socket/addrinfo/resolver.cr
@@ -1,0 +1,13 @@
+class Socket
+  struct Addrinfo
+    abstract class Resolver
+      abstract def getaddrinfo(domain, service, family, type, protocol, timeout = nil, &block) : Nil
+    end
+
+    class_setter resolver : Resolver?
+
+    def self.resolver
+      @@resolver ||= Blocking.new
+    end
+  end
+end

--- a/src/socket/addrinfo/threaded.cr
+++ b/src/socket/addrinfo/threaded.cr
@@ -1,0 +1,106 @@
+require "mutex"
+require "thread/queue"
+require "./resolver"
+
+class Socket
+  struct Addrinfo
+    # Threaded DNS resolver.
+    #
+    # Calls the system `getaddrinfo` function in a thread pool, blocking only
+    # the current `Fiber`, not the event loop (unlike the `Blocking` resolver).
+    #
+    # The threaded resolver only starts a single thread. You'll may want to
+    # start many, depending on your need for concurrential resolves.
+    #
+    # A `timeout` (in seconds) may be specified; an `IO::Timeout` exception will
+    # be raised if the system can't resolve the domain until the timeout is
+    # reached. The resolver thread will still be blocked until `getaddrinfo`
+    # returns thought, and not available to resolve more domains in the
+    # meantime.
+    #
+    # Example:
+    # ```
+    # Socket::Addrinfo.resolver = Socket::Addrinfo::Threaded.new(size: 5)
+    # ```
+    class Threaded < Resolver
+      # :nodoc:
+      alias Request = Tuple(String, Service, Socket::Family, Socket::Type, Socket::Protocol, Deque(Response))
+
+      # :nodoc:
+      alias Response = Pointer(LibC::Addrinfo) | Int32
+
+      def initialize(@size = 1, @timeout : Int32? = nil)
+        @started = false
+        @requests = Thread::Queue(Request).new
+        @mutex = Mutex.new
+      end
+
+      def getaddrinfo(domain, service, family, type, protocol = Protocol::IP, timeout = @timeout, &block) : Nil
+        @mutex.synchronize { start_workers }
+        start = Time.now
+
+        queue = Deque(Response).new(1)
+        @requests.push({domain, service, family || Family::UNSPEC, type, protocol, queue})
+
+        loop do
+          case response = queue.first?
+          when Pointer(LibC::Addrinfo)
+            begin
+              yield Addrinfo.new(response)
+              break
+            ensure
+              LibC.freeaddrinfo(response)
+            end
+          when Int32
+            if response == LibC::EAI_NONAME
+              raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
+            end
+            raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(response))}")
+          else
+            if timeout && ((Time.now - start.not_nil!) > timeout.seconds)
+              raise IO::Timeout.new("Failed to resolve #{domain} in #{timeout} #seconds")
+            end
+            Fiber.yield
+          end
+        end
+      end
+
+      private def start_workers
+        return if @started
+        @started = true
+
+        @size.times do
+          Thread.new do
+            loop do
+              domain, service, family, type, protocol, queue = @requests.pop
+              response = resolve(domain, service, family, type, protocol)
+              queue.push(response)
+            end
+          end
+        end
+      end
+
+      private def resolve(domain, service, family, type, protocol)
+        hints = LibC::Addrinfo.new
+        hints.ai_family = (family || Family::UNSPEC).to_i32
+        hints.ai_socktype = type
+        hints.ai_protocol = protocol
+        hints.ai_flags = 0
+
+        if service.is_a?(Int)
+          hints.ai_flags |= LibC::AI_NUMERICSERV
+
+          {% if flag?(:darwin) %}
+            # avoid a segfault on macOS < 10.12
+            if service == 0 || service == nil
+              service = "00"
+            end
+          {% end %}
+        end
+
+        code = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
+        code == 0 ? ptr : code
+      end
+    end
+  end
+end

--- a/src/thread/queue.cr
+++ b/src/thread/queue.cr
@@ -1,0 +1,53 @@
+# Based on rubysl-thread ruby gem implementation
+# Copyright (c) 2013, Brian Shirai
+# Licensed under the BSD 3-clause
+
+# :nodoc:
+class Thread
+  # :nodoc:
+  class Queue(T)
+    class Error < Exception; end
+
+    def initialize
+      @que = Deque(T).new(16)
+      @mutex = Thread::Mutex.new
+      @resource = Thread::ConditionVariable.new
+    end
+
+    def push(item : T)
+      @mutex.synchronize do
+        @que.push(item)
+        @resource.signal
+      end
+    end
+
+    def pop(blocking = true)
+      loop do
+        @mutex.synchronize do
+          if @que.empty?
+            raise Error.new("queue is empty") unless blocking
+            @resource.wait(@mutex)
+          else
+            item = @que.shift
+            @resource.signal
+            return item
+          end
+        end
+      end
+    end
+
+    def clear
+      @mutex.synchronize do
+        @que.clear
+      end
+    end
+
+    def empty?
+      size == 0
+    end
+
+    def size
+      @que.size
+    end
+  end
+end


### PR DESCRIPTION
This pull request is a rework of #2829 with an alternative solution: introduce a configurable resolver. The initial issue is that we may have either:

- a system call (`getaddrinfo`), which resolves everything but blocks the event loop;
- an evented resolver (libevent), which is fully evented, but limited compared to the syscall (e.g. Docker, NSS, ...).

An usual solution to this problem is to have worker threads that will resolve domains asynchronously using the system call, whilst not blocking the event loop. This is okayish, but requires to have dedicated threads and communication.

This pull request doesn't choose one solution, but instead allows the developer to chose which one is the best for its application: a blocking resolver (default), an evented resolver or a threaded resolver, or any other solution.

---
There is one last thing I'd like to change: drop the per-request DNS timeout. It should be configured globally, either on the system, or when creating the resolver, if it's configurable. Actually, only the evented resolver has a DNS timeout configuration (global).