### PR TITLE
Skip macro method

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -988,4 +988,40 @@ describe "Semantic: macro" do
       foo(a)
       )) { int32 }
   end
+
+  it "skip_file skips expanding the rest of the current file" do
+    res = semantic(%(
+      class A
+      end
+
+      {% skip_file() %}
+
+      class B
+      end
+    ))
+
+    res.program.types.has_key?("A").should be_true
+    res.program.types.has_key?("B").should be_false
+  end
+
+  it "skips file inside an if macro expression" do
+    res = semantic(%(
+      class A
+      end
+
+      {% if true %}
+        class C; end
+        {% skip_file() %}
+        class D; end
+      {% end %}
+
+      class B
+      end
+    ))
+
+    res.program.types.has_key?("A").should be_true
+    res.program.types.has_key?("B").should be_false
+    res.program.types.has_key?("C").should be_true
+    res.program.types.has_key?("D").should be_false
+  end
 end

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -989,39 +989,41 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "skip_file skips expanding the rest of the current file" do
-    res = semantic(%(
-      class A
-      end
+  describe "skip macro directive" do
+    it "skips expanding the rest of the current file" do
+      res = semantic(%(
+        class A
+        end
 
-      {% skip_file() %}
+        {% skip() %}
 
-      class B
-      end
-    ))
+        class B
+        end
+      ))
 
-    res.program.types.has_key?("A").should be_true
-    res.program.types.has_key?("B").should be_false
-  end
+      res.program.types.has_key?("A").should be_true
+      res.program.types.has_key?("B").should be_false
+    end
 
-  it "skips file inside an if macro expression" do
-    res = semantic(%(
-      class A
-      end
+    it "skips file inside an if macro expression" do
+      res = semantic(%(
+        class A
+        end
 
-      {% if true %}
-        class C; end
-        {% skip_file() %}
-        class D; end
-      {% end %}
+        {% if true %}
+          class C; end
+          {% skip() %}
+          class D; end
+        {% end %}
 
-      class B
-      end
-    ))
+        class B
+        end
+      ))
 
-    res.program.types.has_key?("A").should be_true
-    res.program.types.has_key?("B").should be_false
-    res.program.types.has_key?("C").should be_true
-    res.program.types.has_key?("D").should be_false
+      res.program.types.has_key?("A").should be_true
+      res.program.types.has_key?("B").should be_false
+      res.program.types.has_key?("C").should be_true
+      res.program.types.has_key?("D").should be_false
+    end
   end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -91,6 +91,23 @@ module Crystal::Macros
   def run(filename, *args) : MacroId
   end
 
+  # Skips the rest of the file from which it is executed.
+  # Typical usage is to skip files that have platform specific code,
+  # without having to surround the most relevant code in `{%...%}` macro blocks.
+  #
+  # Example:
+  #
+  # ```
+  # # sth_for_osx.cr
+  # {% skip() unless flag?(:darwin) %}
+  #
+  # # Class FooForMac will only be defined if we're compiling on OS X
+  # class FooForMac
+  # end
+  # ```
+  def skip : Nop
+  end
+
   # This is the base class of all AST nodes. This methods are
   # available to all AST nodes.
   abstract class ASTNode

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -5,6 +5,7 @@ require "semantic_version"
 module Crystal
   class MacroInterpreter
     def interpret_top_level_call(node)
+      # Please order method names in lexicographical order, because OCD
       case node.name
       when "compare_versions"
         interpret_compare_versions(node)
@@ -18,6 +19,8 @@ module Crystal
         interpret_puts(node)
       when "pp"
         interpret_pp(node)
+      when "skip_file"
+        interpret_skip_file(node)
       when "system", "`"
         interpret_system(node)
       when "raise"
@@ -128,6 +131,10 @@ module Crystal
       end
 
       @last = Nop.new
+    end
+
+    def interpret_skip_file(node)
+      raise SkipFileException.new(@str.to_s)
     end
 
     def interpret_system(node)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -19,8 +19,8 @@ module Crystal
         interpret_puts(node)
       when "pp"
         interpret_pp(node)
-      when "skip_file"
-        interpret_skip_file(node)
+      when "skip"
+        interpret_skip(node)
       when "system", "`"
         interpret_system(node)
       when "raise"
@@ -133,8 +133,8 @@ module Crystal
       @last = Nop.new
     end
 
-    def interpret_skip_file(node)
-      raise SkipFileException.new(@str.to_s)
+    def interpret_skip(node)
+      raise SkipMacroException.new(@str.to_s)
     end
 
     def interpret_system(node)

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -294,6 +294,14 @@ module Crystal
   class MacroRaiseException < TypeException
   end
 
+  class SkipFileException < ::Exception
+    getter expanded_before_skip : String
+
+    def initialize(@expanded_before_skip)
+      super()
+    end
+  end
+
   class Program
     def undefined_global_variable(node, similar_name)
       common = String.build do |str|

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -294,7 +294,7 @@ module Crystal
   class MacroRaiseException < TypeException
   end
 
-  class SkipFileException < ::Exception
+  class SkipMacroException < ::Exception
     getter expanded_before_skip : String
 
     def initialize(@expanded_before_skip)

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -369,12 +369,22 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
     the_macro = Macro.new("macro_#{node.object_id}", [] of Arg, node).at(node.location)
 
+    skip_file_exception = nil
+
     generated_nodes = expand_macro(the_macro, node, mode: mode) do
-      @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
+      begin
+        @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
+      rescue ex : SkipFileException
+        #node.expanded = NilLiteral.new
+        skip_file_exception = ex
+        ex.expanded_before_skip
+      end
     end
 
     node.expanded = generated_nodes
     node.bind_to generated_nodes
+
+    raise skip_file_exception if skip_file_exception
 
     generated_nodes
   end

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -369,14 +369,13 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
     the_macro = Macro.new("macro_#{node.object_id}", [] of Arg, node).at(node.location)
 
-    skip_file_exception = nil
+    skip_macro_exception = nil
 
     generated_nodes = expand_macro(the_macro, node, mode: mode) do
       begin
         @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
-      rescue ex : SkipFileException
-        #node.expanded = NilLiteral.new
-        skip_file_exception = ex
+      rescue ex : SkipMacroException
+        skip_macro_exception = ex
         ex.expanded_before_skip
       end
     end
@@ -384,7 +383,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     node.expanded = generated_nodes
     node.bind_to generated_nodes
 
-    raise skip_file_exception if skip_file_exception
+    raise skip_macro_exception if skip_macro_exception
 
     generated_nodes
   end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -600,6 +600,18 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     enum_type.add_def a_def
   end
 
+  def visit(node : Expressions)
+    node.expressions.each_with_index do |child, i|
+      begin
+        child.accept self
+      rescue SkipFileException
+        node.expressions.delete_at(i..-1)
+        break
+      end
+    end
+    false
+  end
+
   def visit(node : Assign)
     type_assign(node.target, node.value, node)
     false

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -604,7 +604,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     node.expressions.each_with_index do |child, i|
       begin
         child.accept self
-      rescue SkipFileException
+      rescue SkipMacroException
         node.expressions.delete_at(i..-1)
         break
       end


### PR DESCRIPTION
This PR introduces a `skip` macro method. When called, it stops macro expansion of the rest of the file. This is meant to be used to support Windows (and other target combinations) more cleanly: instead of interleaving code with different targets in the same file through `{% if ... %}`, diverging code can be kept in different files. 