### PR TITLE
Makefile: add 'clean_crystal' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,11 @@ $(LIB_CRYSTAL_TARGET): $(LIB_CRYSTAL_OBJS)
 	$(AR) -rcs $@ $^
 
 .PHONY: clean
-clean: ## Clean up built directories and files
-	rm -rf $(O)
-	rm -rf ./doc
+clean: clean_crystal ## Clean up built directories and files
 	rm -rf $(LLVM_EXT_OBJ)
 	rm -rf $(LIB_CRYSTAL_OBJS) $(LIB_CRYSTAL_TARGET)
+
+.PHONY: clean_crystal
+clean_crystal: ## Clean up crystal built files
+	rm -rf $(O)
+	rm -rf ./doc


### PR DESCRIPTION
It is useful in compiler development cycle.

```console
$ vim src/...  # edit compiler sources (but incomplete)
$ make crystal # oops! maked incompilable compiler...
$ make crystal # failed because compiler does not work
```

At such time I don't want to use `make clean` because it removes `libcrystal` and `llvmext` also. I don't want to build C++ files again, so I added `clean-crystal` target in Makefile. It removes the files built by `crystal` command. Now, we can use `make clean_crystal crystal` to recompile `crystal` after removing compiler itself.