### PR TITLE
Tool: refactor context/expand/implementation in point of traversaling typed defs

### DIFF
--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -385,4 +385,26 @@ describe "context" do
     foo(1 < 0 ? nil : "s")
     ), "c", ["String"]
   end
+
+  it "can get context in file private method" do
+    assert_context_keys %(
+    private def foo(a)
+      ‸
+    end
+
+    foo 100
+    ), "a"
+  end
+
+  it "can get context in file private module" do
+    assert_context_keys %(
+    private module Foo
+      def self.foo(a)
+        ‸
+      end
+    end
+
+    Foo.foo 100
+    ), "self", "a"
+  end
 end

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -340,4 +340,32 @@ describe "implementations" do
     Bar::Foo.bar_foo
     )
   end
+
+  it "find implementation inside contained file private method" do
+    assert_implementations %(
+    private ༓def foo
+    end
+
+    private def bar
+      f‸oo
+    end
+
+    bar
+    )
+  end
+
+  it "find implementation inside contained file private class' class method" do
+    assert_implementations %(
+    private ༓def foo
+    end
+
+    private class Bar
+      def self.bar
+        f‸oo
+      end
+    end
+
+    Bar.bar
+    )
+  end
 end

--- a/src/compiler/crystal/tools/typed_def_processor.cr
+++ b/src/compiler/crystal/tools/typed_def_processor.cr
@@ -1,0 +1,53 @@
+# `TypeDefProcessor` is a mixin to provide a visitor for typed defs
+# and some utilities.
+#
+# It is used for `crystal tool context/expand/implementation`.
+module Crystal::TypedDefProcessor
+  private def process_typed_def(typed_def : Def)
+    typed_def.accept self
+  end
+
+  private getter target_location
+
+  private def process_result(result : Compiler::Result)
+    process_type result.program
+    if file_module = result.program.file_module? target_location.original_filename
+      process_type file_module
+    end
+  end
+
+  private def process_type(type : Type) : Nil
+    if type.is_a?(NamedType) || type.is_a?(Program) || type.is_a?(FileModule)
+      type.types?.try &.each_value do |inner_type|
+        process_type inner_type
+      end
+    end
+
+    if type.is_a?(GenericType)
+      type.generic_types.each_value do |instanced_type|
+        process_type instanced_type
+      end
+    end
+
+    process_type type.metaclass if type.metaclass != type
+
+    if type.is_a?(DefInstanceContainer)
+      type.def_instances.each_value do |typed_def|
+        process_typed_def typed_def
+      end
+    end
+  end
+
+  private def contains_target(node)
+    if loc_start = node.location
+      loc_end = node.end_location || loc_start
+      # if it is not between, it could be the case that node is the top level Expressions
+      # in which the (start) location might be in one file and the end location in another.
+      @target_location.between?(loc_start, loc_end) || loc_start.filename != loc_end.filename
+    else
+      # if node has no location, assume they may contain the target.
+      # for example with the main expressions ast node this matters
+      true
+    end
+  end
+end


### PR DESCRIPTION
In point of traversaling typed defs, context/expand/implementation has duplicate code. This PR refactored it.

Another effect, we can look up context/implementation inside file private classes and defs now.