### PR TITLE
Fix: String#underscore with non-letter char #4278

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1672,6 +1672,8 @@ describe "String" do
     "C_".underscore.should eq("c_")
     "HTTP".underscore.should eq("http")
     "HTTP_CLIENT".underscore.should eq("http_client")
+    "Foo123".underscore.should eq("foo123")
+    "FOO123".underscore.should eq("foo123")
   end
 
   it "does camelcase" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -3314,7 +3314,7 @@ class String
           if mem
             if char == '_'
               # case 3
-            else
+            elsif upcase || downcase
               # case 1
               str << '_'
             end


### PR DESCRIPTION
The String#underscore method does not behave correctly when handling
strings containing non-letter characters such as digits (i.e. "FOO123")