### PR TITLE
pp: fixed to return value like 'p'

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -99,17 +99,25 @@ macro pp(*exps)
     {% exp = exps.first %}
     %prefix = "#{{{ exp.stringify }}} # => "
     ::print %prefix
-    PrettyPrint.format({{exp}}, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
+    %object = {{exp}}
+    PrettyPrint.format(%object, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
     ::puts
+    %object
   {% else %}
     %names = { {{*exps.map(&.stringify)}} }
     %max_size = %names.max_of &.size
-    {% for exp, i in exps %}
-      %prefix = "#{%names[{{i}}].ljust(%max_size)} # => "
-      ::print %prefix
-      PrettyPrint.format({{exp}}, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
-      ::puts
-    {% end %}
+    {
+      {% for exp, i in exps %}
+        begin
+          %prefix = "#{%names[{{i}}].ljust(%max_size)} # => "
+          ::print %prefix
+          %object = {{exp}}
+          PrettyPrint.format(%object, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
+          ::puts
+          %object
+        end,
+      {% end %}
+    }
   {% end %}
 end
 


### PR DESCRIPTION
Current implementation of `pp` returns `nil` always, but `p` returns printed value. It fixes to return printed value of 'pp' like `p`. I think its usability equals to `p` result value's.