### PR TITLE
p: not display if no object is given

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -112,7 +112,7 @@ end
 #
 # See `Object#pretty_print(pp)`
 def p(**objects)
-  p(objects)
+  p(objects) unless objects.empty?
 end
 
 # :nodoc:


### PR DESCRIPTION
Currently `p` (invoke `p` with no argument) shows `{}` because `def p(**objects)` handles it. But in this case it should not display anything and return `nil`.