### PR TITLE
Allow passing non heap objects to WeakRef

### DIFF
--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -31,13 +31,13 @@ describe WeakRef do
     foo = Foo.new :foo
     ref = WeakRef.new(foo)
     ref.should_not be_nil
-    ref.target.should be(foo)
+    ref.value.should be(foo)
   end
 
   it "should get dereferenced object in data section" do
     foo = "foo"
     ref = WeakRef.new(foo)
-    ref.target.should be(foo)
+    ref.value.should be(foo)
   end
 
   it "should not crash with object in data section during GC" do
@@ -77,7 +77,7 @@ describe WeakRef do
     end
     GC.collect
     State.count(:weak_foo_ref).should be > 0
-    instances.select { |wr| wr.target.nil? }.size.should be > 0
-    instances[-1].target.should_not be_nil
+    instances.select { |wr| wr.value.nil? }.size.should be > 0
+    instances[-1].value.should_not be_nil
   end
 end

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -27,11 +27,23 @@ private class Foo
 end
 
 describe WeakRef do
-  it "should get dereference object" do
+  it "should get dereferenced object" do
     foo = Foo.new :foo
     ref = WeakRef.new(foo)
     ref.should_not be_nil
     ref.target.should be(foo)
+  end
+
+  it "should get dereferenced object in data section" do
+    foo = "foo"
+    ref = WeakRef.new(foo)
+    ref.target.should be(foo)
+  end
+
+  it "should not crash with object in data section during GC" do
+    foo = "foo"
+    ref = WeakRef.new(foo)
+    GC.collect
   end
 
   it "State counts released objects" do

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -23,6 +23,7 @@ lib LibGC
   fun set_handle_fork = GC_set_handle_fork(value : Int)
 
   fun base = GC_base(displaced_pointer : Void*) : Void*
+  fun is_heap_ptr = GC_is_heap_ptr(pointer : Void*) : Int
   fun general_register_disappearing_link = GC_general_register_disappearing_link(link : Void**, obj : Void*) : Int
 
   type Finalizer = Void*, Void* ->
@@ -118,6 +119,10 @@ module GC
   def self.register_disappearing_link(pointer : Void**)
     base = LibGC.base(pointer.value)
     LibGC.general_register_disappearing_link(pointer, base)
+  end
+
+  def self.is_heap_ptr(pointer : Void*)
+    LibGC.is_heap_ptr(pointer) != 0
   end
 
   record Stats,

--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -5,7 +5,9 @@ class WeakRef(T)
 
   def initialize(target : T)
     @target = target.as(Void*)
-    GC.register_disappearing_link(pointerof(@target))
+    if GC.is_heap_ptr(@target)
+      GC.register_disappearing_link(pointerof(@target))
+    end
   end
 
   def self.allocate

--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -17,7 +17,7 @@ class WeakRef(T)
   end
 
   # Returns the referenced object or `Nil` if it has been garbage-collected.
-  def target
+  def value
     @target.as(T?)
   end
 end


### PR DESCRIPTION
This should allow at least pointers to the data section to work seamlessly with WeakRef and in some cases even allow stack pointers to be passed, for the crazy. This should increase the usability of WeakRef since it allows passing static data for testing or other purposes.

This also renames WeakRef#target to <del>WeakRef#get</del> WeakRef#value. <del>get seems to be the more general, more widely used and shorter name.</del> value is consistent with Pointer. Additionally target feels like it's leaking implementation details as
that's the name of the internal instance variable too.

As expected this is slightly slower for the heap case, given the additional check, and slightly faster for the non-heap case, given the check is less expensive than registering a pointer with GC. A quick benchmark with collection disabled so the second testcase wouldn't crash:

```
            WeakRef heap  14.42M ( 69.36ns) (±11.41%)       fastest
        WeakRef constant  10.55M (  94.8ns) (±45.52%)  1.37× slower
    CheckingWeakRef heap   9.14M ( 109.4ns) (±45.29%)  1.58× slower
CheckingWeakRef constant  11.48M ( 87.07ns) (±83.27%)  1.26× slower
```