### PR TITLE
Fix formatting of String Array literals containing right parens

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -336,6 +336,14 @@ describe Crystal::Formatter do
 
   assert_format "%w(one   two  three)", "%w(one two three)"
   assert_format "%i(one   two  three)", "%i(one two three)"
+  assert_format "%w(one\n   two\n  three)", "%w(one\n  two\n  three)"
+  assert_format "%i(one\n   two\n  three)", "%i(one\n  two\n  three)"
+  assert_format "%w(\n   one\n   two\n  three\n)", "%w(\n  one\n  two\n  three\n)"
+  assert_format "%i(\n   one\n   two\n  three\n)", "%i(\n  one\n  two\n  three\n)"
+  assert_format "%w{one   two  three}", "%w(one two three)"
+  assert_format "%i{one   two  three}", "%i(one two three)"
+  assert_format "%w{one)   two)  three)}", "%w{one) two) three)}"
+  assert_format "%i{one)   two)  three)}", "%i{one) two) three)}"
 
   assert_format "/foo/"
   assert_format "/foo/imx"


### PR DESCRIPTION
This fixes a bug where the formatter will automatically replace the
String Array literal tokens with parens regardless of whether the content
already contains a `)`.  In the case where a `)` already exists, the
resultant code is not compilable.  This patch keeps the author's original
choice of token if a `)` exists in the content, as they made a conscious
decision to choose that alternate token so that the code can compile.
Otherwise, the formatter will choose parens for code consistency as was
done previously.

For example,

```
%w{
  one)
  two)
}
```

would have previously had the curly braces replaced with parens, which
would no longer compile.  Now, it will stay with curly braces, and be
properly formatted.