### PR TITLE
Fully honor no color option when running specs

### DIFF
--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -95,7 +95,7 @@ module Spec
 
             if ex.is_a?(AssertionFailed)
               puts
-              puts "     # #{Spec.relative_file(ex.file)}:#{ex.line}".colorize.cyan
+              puts Spec.color("     # #{Spec.relative_file(ex.file)}:#{ex.line}", :comment)
             end
           end
         end
@@ -137,8 +137,8 @@ module Spec
         puts "Failed examples:"
         puts
         failures_and_errors.each do |fail|
-          print "crystal spec #{Spec.relative_file(fail.file)}:#{fail.line}".colorize.red
-          puts " # #{fail.description}".colorize.cyan
+          print Spec.color("crystal spec #{Spec.relative_file(fail.file)}:#{fail.line}", :error)
+          puts Spec.color(" # #{fail.description}", :comment)
         end
       end
     end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -8,6 +8,7 @@ module Spec
     fail:    :red,
     error:   :red,
     pending: :yellow,
+    comment: :cyan,
   }
 
   private LETTERS = {


### PR DESCRIPTION
Spec runner have the option to disable colored output (ANSI codes) when `--no-color` option is used, example:

```
$ crystal spec -- --no-color
```

However, certain elements in the output didn't fully support that option, resulting in a mix of non-color and color:

![screenshot from 2017-04-17 16-45-31](https://cloud.githubusercontent.com/assets/4182/25102115/6c8dedd8-238d-11e7-9ac8-b292fe11b1a5.png)

This change unifies that setting and ensures that `--no-color` usage is fully honored by the output:

![screenshot from 2017-04-17 16-46-18](https://cloud.githubusercontent.com/assets/4182/25102129/755ea010-238d-11e7-8497-657de8be0689.png)

Ref #4292

Thank you. :heart: :heart: :heart: 