### PR TITLE
Add Array#to_slice and Array#bytesize

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1414,6 +1414,14 @@ describe "Array" do
     end
   end
 
+  describe "bytesize" do
+    it "returns the size of the array in bytes" do
+      [1, 2, 3].bytesize.should eq(3 * sizeof(Int32))
+      ["1", "2", "3"].bytesize.should eq(3 * sizeof(String))
+      [Pointer(Int32).null].bytesize.should eq(sizeof(Pointer(Int32)))
+    end
+  end
+
   describe "transpose" do
     it "transeposes elements" do
       [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1404,6 +1404,16 @@ describe "Array" do
     end
   end
 
+  describe "to_unsafe_slice" do
+    it "returns a slice" do
+      ary = [1, 2, 3]
+      ary.to_unsafe_slice.should be_a(Slice(Int32))
+      ary.to_unsafe_slice.to_unsafe.should eq(ary.to_unsafe)
+      ary.to_unsafe_slice.size.should eq(3)
+      ary.to_unsafe_slice[0].should eq(1)
+    end
+  end
+
   describe "transpose" do
     it "transeposes elements" do
       [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1398,6 +1398,12 @@ describe "Array" do
     end
   end
 
+  describe "to_unsafe" do
+    it "returns the internal buffer" do
+      [2, 3, 4].to_unsafe[1].should eq 3
+    end
+  end
+
   describe "transpose" do
     it "transeposes elements" do
       [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])

--- a/src/array.cr
+++ b/src/array.cr
@@ -1633,6 +1633,19 @@ class Array(T)
     @buffer.to_slice(size)
   end
 
+  # Returns the total size in bytes of the array.
+  #
+  # The returned value is equivalent to the `#size` multiplied by the size of `T`.
+  #
+  # ```
+  # ary = [1, 2, 3]
+  # ary.bytesize # => 12 (3 elements, each using sizeof(Int32) bytes)
+  # ary.size     # => 3
+  # ```
+  def bytesize
+    size * sizeof(T)
+  end
+
   # Assumes that `self` is an array of arrays and transposes the rows and columns.
   #
   # ```

--- a/src/array.cr
+++ b/src/array.cr
@@ -1611,6 +1611,28 @@ class Array(T)
     @buffer
   end
 
+  # Returns the internal buffer as slice, pointing to the `self`'s elements.
+  #
+  # This method is **unsafe** because when the array shrinks or grows, it might
+  # change the position of the internal buffer. The slice would then point to an
+  # uninitialized memory region.
+  #
+  # ```
+  # # Safe usage
+  # ary = [1, 2, 3]
+  # ary.to_unsafe_slice[0] # => 1
+  # ary.to_unsafe_slice[1] = 4
+  # ary.to_unsafe_slice.size # => 3
+  #
+  # # Dangerous, will crash the program or introduce security issues
+  # slice = ary.to_unsafe_slice
+  # ary << 4
+  # # `slice` must not be used here anymore
+  # ```
+  def to_unsafe_slice : Slice(T)
+    @buffer.to_slice(size)
+  end
+
   # Assumes that `self` is an array of arrays and transposes the rows and columns.
   #
   # ```


### PR DESCRIPTION
Hi,

This PR adds `Array#to_slice` and `Array#bytesize` including specs, and also adds a simple spec for `Array#to_unsafe`.

Use-cases are commonly found in I/O code, e.g., to quickly write an array of data into an `IO`:

```crystal
player_positions_ary = Game.player_positions # Array(Int32)
client_socket.write player_positions_ary.to_slice
```

I think it's much better to offer a canonical way of turning an array into a slice for a moment, than having the user to fiddle with `ary.to_unsafe.to_slice(ary.size)`. It may not be obvious to some if `to_slice` in this case requires the byte size, or the count of elements.

Sometimes you also just want to know the current size in memory of the whole array. `Array#bytesize` mirrors `Slice#bytesize`, and is much nicer to read than `ary.size * sizeof(MyT)`, especially as the user has to figure out the `T`.  This also makes it easier to write generic code.

Cheers!