### PR TITLE
Fail the Travis check as soon as one of the jobs fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - os: osx
     - os: osx
       osx_image: xcode8.2
+  fast_finish: true
 before_install:
   - bin/ci prepare_system
 install:


### PR DESCRIPTION
[Fast-Finish Builds with Allowed Failures](https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)

I just noticed in [this build](https://travis-ci.org/crystal-lang/crystal/builds/227189680) - the Mac jobs were done in 5 minutes so it was already clear that the check does not pass, but the status on GitHub still showed that the build was in progress until the other, delayed, jobs were done.
So... this fixes that