### PR TITLE
[RFC] Add Sysctl interface support for OSX/Linux/FreeBSD

### DIFF
--- a/spec/std/sysctl_spec.cr
+++ b/spec/std/sysctl_spec.cr
@@ -1,0 +1,54 @@
+require "spec"
+require "sysctl"
+
+describe Sysctl do
+  describe "get_int" do
+    it "returns the sysctl value as an int" do
+      keys = {% if flag?(:darwin) %}
+        ["hw.ncpu", "hw.byteorder"]
+      {% elsif flag?(:linux) %}
+        ["net.ipv4.ip_forward", "kernel.pty.max"]
+      {% else %}
+        []
+      {% end %}
+
+      keys.each do |key|
+        real_value = `sysctl #{key}`.split(": ")[1].to_i32
+        value = Sysctl.get_i32(key)
+        value.should eq(real_value)
+      end
+    end
+
+    it "raises on invalid key" do
+      expect_raises do
+        key = "this.is.an.invalid.sysctl.key"
+        Sysctl.get_i32 key
+      end
+    end
+  end
+
+  describe "get_str" do
+    it "returns the sysctl value as a string" do
+      keys = {% if flag?(:darwin) %}
+          ["kern.version", "kern.corefile"]
+        {% elsif flag?(:linux) %}
+          []
+        {% else %}
+          []
+        {% end %}
+
+      keys.each do |key|
+        real_value = `sysctl #{key}`.gsub("#{key}: ", "").chomp
+        value = Sysctl.get_str(key, 512)
+        value.should eq(real_value)
+      end
+    end
+
+    it "raises on invalid key" do
+      expect_raises do
+        key = "this.is.an.invalid.sysctl.key"
+        Sysctl.get_str key, 1
+      end
+    end
+  end
+end

--- a/spec/std/sysctl_spec.cr
+++ b/spec/std/sysctl_spec.cr
@@ -9,7 +9,7 @@ describe Sysctl do
       {% elsif flag?(:linux) %}
         ["net.ipv4.ip_forward", "kernel.pty.max"]
       {% else %}
-        []
+        [] of String
       {% end %}
 
       keys.each do |key|
@@ -32,9 +32,9 @@ describe Sysctl do
       keys = {% if flag?(:darwin) %}
           ["kern.version", "kern.corefile"]
         {% elsif flag?(:linux) %}
-          []
+          [] of String
         {% else %}
-          []
+          [] of String
         {% end %}
 
       keys.each do |key|

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -94,11 +94,6 @@ end
 
 # Raised when a feature is not implemented yet or when it cannot be implemented
 # on a certain system or platform
-#
-# ```
-# Sysctl.get_int("net.ipv4.forward") # raises NotImplemented ("Sysctl is not implemented on that platform")
-# ````
-#
 class NotImplemented < Exception
   def initialize(what : String, reason = "is not implemented")
     super {what, reason}.join(" ")

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -96,11 +96,11 @@ end
 # on a certain system or platform
 #
 # ```
-# Sysctl.get_int("net.ipv4.forward") # Sysctl doesn't exist on Windows
+# Sysctl.get_int("net.ipv4.forward") # raises NotImplemented ("Sysctl is not implemented on that platform")
 # ````
 #
 class NotImplemented < Exception
   def initialize(what : String, reason = "is not implemented")
-    super [what, reason].join(" ")
+    super {what, reason}.join(" ")
   end
 end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -91,3 +91,16 @@ class DivisionByZero < Exception
     super(message)
   end
 end
+
+# Raised when a feature is not implemented yet or when it cannot be implemented
+# on a certain system or platform
+#
+# ```
+# Sysctl.get_int("net.ipv4.forward") # Sysctl doesn't exist on Windows
+# ````
+#
+class NotImplemented < Exception
+  def initialize(what : String, reason = "is not implemented")
+    super [what, reason].join(" ")
+  end
+end

--- a/src/sysctl.cr
+++ b/src/sysctl.cr
@@ -1,3 +1,5 @@
+{% if flag?(:darwin) || flag?(:freebsd) | flag?(:linux) %}
+
 lib LibC
   {% if flag?(:darwin) || flag?(:freebsd) %}
     fun sysctlbyname(LibC::Char*, Void*, LibC::SizeT*, Void*, LibC::SizeT) : Int32
@@ -34,8 +36,6 @@ module Sysctl
     {% elsif flag?(:linux) %}
       path = name_to_path name
       read_proc_sys(path).to_i32
-    {% else %}
-      raise NotImplemented.new("Sysctl", "is not supported on this platform")
     {% end %}
   end
 
@@ -64,8 +64,6 @@ module Sysctl
     {% elsif flag?(:linux) %}
       path = name_to_path name
       read_proc_sys(path)
-    {% else %}
-      raise NotImplemented.new("Sysctl", "is not supported on this platform")
     {% end %}
   end
 
@@ -85,3 +83,5 @@ module Sysctl
     end
   {% end %}
 end
+
+{% end %}

--- a/src/sysctl.cr
+++ b/src/sysctl.cr
@@ -17,7 +17,7 @@ module Sysctl
   # Sysctl.get_int("hw.ncpu") # => 8
   # ```
   #
-  def get_i32(name : String) : Int32
+  def i32(name : String) : Int32
     {% if flag?(:darwin) || flag?(:freebsd) %}
       value = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
       value_len = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
@@ -35,7 +35,7 @@ module Sysctl
       path = name_to_path name
       read_proc_sys(path).to_i32
     {% else %}
-      raise NotImplemented("Sysctl", "is not supported on this platform")
+      raise NotImplemented.new("Sysctl", "is not supported on this platform")
     {% end %}
   end
 
@@ -47,7 +47,7 @@ module Sysctl
   # Sysctl.get_str("kernel.random.boot_id", 42) # => "1c629298-a60b-48df-bba1-9ea77f6b37ba"
   # ```
   #
-  def get_str(name : String, max_size : Int32) : String
+  def str(name : String, max_size : Int32) : String
     {% if flag?(:darwin) || flag?(:freebsd) %}
       value = GC.malloc_atomic(max_size).as(LibC::Char*)
       value_len = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
@@ -65,7 +65,7 @@ module Sysctl
       path = name_to_path name
       read_proc_sys(path)
     {% else %}
-      raise NotImplemented("Sysctl", "is not supported on this platform")
+      raise NotImplemented.new("Sysctl", "is not supported on this platform")
     {% end %}
   end
 

--- a/src/sysctl.cr
+++ b/src/sysctl.cr
@@ -1,0 +1,87 @@
+lib LibC
+  {% if flag?(:darwin) || flag?(:freebsd) %}
+    fun sysctlbyname(LibC::Char*, Void*, LibC::SizeT*, Void*, LibC::SizeT) : Int32
+  {% end %}
+end
+
+# Provides access to UNIX kernels state using the `sysctl` system call
+module Sysctl
+  extend self
+
+  # Returns the sysctl named *name* as an integer. Will raise `NotImplemented`
+  # if the sysctl interface doesn't exist on your system (Windows) or isn't
+  # supported yet. Will raise the appropriate `Errno` exception in case of
+  # error.
+  #
+  # ```
+  # Sysctl.get_int("hw.ncpu") # => 8
+  # ```
+  #
+  def get_i32(name : String) : Int32
+    {% if flag?(:darwin) || flag?(:freebsd) %}
+      value = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
+      value_len = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
+      value_len.value = sizeof(Int32)
+
+      res = LibC.sysctlbyname(name.to_unsafe, value.as(Void*),
+        value_len.as(LibC::SizeT*), Pointer(Void).null, 0)
+
+      if res == 0
+        value.value
+      else
+        raise Errno.new("Unable to fetch sysctl value #{name}")
+      end
+    {% elsif flag?(:linux) %}
+      path = name_to_path name
+      read_proc_sys(path).to_i32
+    {% else %}
+      raise NotImplemented("Sysctl", "is not supported on this platform")
+    {% end %}
+  end
+
+  # Returns a sysctl value named *name* as a `String`. Will raise
+  # `NotImplemented` on systems where the sysctl interface doesn't exists or
+  # isn't supported. Will also raise the appropriate `Errno` in case of error.
+  #
+  # ```
+  # Sysctl.get_str("kernel.random.boot_id", 42) # => "1c629298-a60b-48df-bba1-9ea77f6b37ba"
+  # ```
+  #
+  def get_str(name : String, max_size : Int32) : String
+    {% if flag?(:darwin) || flag?(:freebsd) %}
+      value = GC.malloc_atomic(max_size).as(LibC::Char*)
+      value_len = GC.malloc_atomic(sizeof(Int32)).as(Int32*)
+      value_len.value = max_size
+
+      res = LibC.sysctlbyname(name.to_unsafe, value.as(Void*),
+        value_len.as(LibC::SizeT*), Pointer(Void).null, 0)
+
+      if res == 0
+        String.new(value, value_len.value - 1, 1)
+      else
+        raise Errno.new("Unable to fetch sysctl value #{name}")
+      end
+    {% elsif flag?(:linux) %}
+      path = name_to_path name
+      read_proc_sys(path)
+    {% else %}
+      raise NotImplemented("Sysctl", "is not supported on this platform")
+    {% end %}
+  end
+
+  {% if flag?(:linux) %}
+    # :nodoc:
+    def name_to_path(name : String)
+      "/proc/sys/" + name.gsub(".", "/")
+    end
+
+    # :nodoc:
+    def read_proc_sys(path : String) : String
+      if File.readable?(path)
+        File.read(path)
+      else
+        raise Errno.new("Unable to read #{path}", Errno::ENOENT)
+      end
+    end
+  {% end %}
+end


### PR DESCRIPTION
Hi,

This is an attempt at defining an interface to the `sysctl` API of the various UNIXes. OpenBSD is not yet supported as they don't have an easy way to get a sysctl by name (that I'm aware of). We could implement it by spawning a `sysctl` process or define a static map somewhere.

The underlying goal of this is to have a way to query the number of CPUs on OSX to provide a better default for the number of default threads on the multithread support branch(es). In addition to that we could use it for `System.hostname`, and I think this would be useful for many folks out there.

This has only been tested on OSX yet. I'll soon test it on Linux but I'll need help for FreeBSD. Any comment on this would be greatly appreciated, especially regarding general usefulness, design and method naming.

Unicornly yours,
Lta.

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>