### PR TITLE
[WIP] Add ThinLTO for LLVM >= 4.0

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -310,7 +310,7 @@ class Crystal::Command
         opts.on("--no-debug", "Skip any symbolic debug info") do
           compiler.debug = Crystal::Debug::None
         end
-        {% if LibLLVM::IS_40 %}
+        {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
         opts.on("--lto=FLAG", "Use ThinLTO --lto=thin") do |flag|
           error "--lto=thin is the only lto supported option" unless flag == "thin"
           compiler.thin_lto = true

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -310,6 +310,12 @@ class Crystal::Command
         opts.on("--no-debug", "Skip any symbolic debug info") do
           compiler.debug = Crystal::Debug::None
         end
+        {% if LibLLVM::IS_40 %}
+        opts.on("--lto=FLAG", "Use ThinLTO --lto=thin") do |flag|
+          error "--lto=thin is the only lto supported option" unless flag == "thin"
+          compiler.thin_lto = true
+        end
+        {% end %}
       end
 
       opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -561,7 +561,7 @@ module Crystal
         bc_name = self.bc_name
         object_name = self.object_name
 
-        {% if LibLLVM::IS_40 %}
+        {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
         if compiler.thin_lto
           @llvm_mod.write_bitcode_with_summary_to_file(object_name)
           @reused_previous_compilation = false

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -304,12 +304,13 @@ module Crystal
         %(#{CL} #{object_name} "/Fe#{output_filename}" #{program.lib_flags} #{link_flags})
       else
         if thin_lto
+          clang = ENV["CLANG"]? || "clang"
           lto_cache_dir = "#{output_dir}/lto.cache"
           Dir.mkdir_p(lto_cache_dir)
           {% if flag?(:darwin) %}
-            cc = ENV["CC"]? || "clang-4.0 -flto=thin -Wl,-mllvm,-threads=#{n_threads},-cache_path_lto,#{lto_cache_dir},#{@release ? "-mllvm,-O2" : "-mllvm,-O0"}"
+            cc = ENV["CC"]? || "#{clang} -flto=thin -Wl,-mllvm,-threads=#{n_threads},-cache_path_lto,#{lto_cache_dir},#{@release ? "-mllvm,-O2" : "-mllvm,-O0"}"
           {% else %}
-            cc = ENV["CC"]? || "clang-4.0 -flto=thin -Wl,-plugin-opt,jobs=#{n_threads},-plugin-opt,cache-dir=#{lto_cache_dir} #{@release ? "-O2" : "-O0"}"
+            cc = ENV["CC"]? || "#{clang} -flto=thin -Wl,-plugin-opt,jobs=#{n_threads},-plugin-opt,cache-dir=#{lto_cache_dir} #{@release ? "-O2" : "-O0"}"
           {% end %}
         else
           cc = CC

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -134,4 +134,8 @@ lib LibLLVMExt
                                         then : LibLLVM::BasicBlockRef, catch : LibLLVM::BasicBlockRef,
                                         bundle : LibLLVMExt::OperandBundleDefRef,
                                         name : LibC::Char*) : LibLLVM::ValueRef
+
+  {% if LibLLVM::IS_40 %}
+    fun write_bitcode_with_summary_to_file = LLVMWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
+  {% end %}
 end

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -135,7 +135,7 @@ lib LibLLVMExt
                                         bundle : LibLLVMExt::OperandBundleDefRef,
                                         name : LibC::Char*) : LibLLVM::ValueRef
 
-  {% if LibLLVM::IS_40 %}
+  {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
     fun write_bitcode_with_summary_to_file = LLVMWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
   {% end %}
 end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -57,6 +57,12 @@ class LLVM::Module
     LibLLVM.write_bitcode_to_file self, filename
   end
 
+  {% if LibLLVM::IS_40 %}
+    def write_bitcode_with_summary_to_file(filename : String)
+      LibLLVMExt.write_bitcode_with_summary_to_file self, filename
+    end
+  {% end %}
+
   def write_bitcode_to_memory_buffer
     MemoryBuffer.new(LibLLVM.write_bitcode_to_memory_buffer self)
   end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -57,7 +57,7 @@ class LLVM::Module
     LibLLVM.write_bitcode_to_file self, filename
   end
 
-  {% if LibLLVM::IS_40 %}
+  {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
     def write_bitcode_with_summary_to_file(filename : String)
       LibLLVMExt.write_bitcode_with_summary_to_file self, filename
     end


### PR DESCRIPTION
TL;DR This is one attempt to reduce compiling time. It's effect seems to be only useful in `--release` builds so far.

---

Adds `--lto=thin` as compiler option.
Currently it's only tested in osx. In linux the gold plugin or lld seems to be required.

### Changes for ThinLTO mode

* Emits .bc with summary metadata as .o as result of the codegen phase.
* Replace linker with clang with lto_cache_dir enabling ThinLTO default cache for incremental builds.
* Forward n_threads compiler option to ThinLTO `-mllvm,-threads=N`
* Turn off implicit --single-module on release build with ThinLTO so the proper compilation steps can be run in parallel.

### Basic usage

`$ ./bin/crystal build --lto=thin main.cr`

* The `--release` can be used.
* The `--no-debug` is sometimes needed to due to some llvm metadata unsupported scenarios.

### Results

In release mode, the compilation of the compiler is reduced from ~7mins to ~2mins. ⚡️  The runtime performance of the seems to be same.

In non release mode, the overall first compile time is not shorter. It seems to double. 🐢 .

But for successive builds (3rd rebuild) the cache reduces the compile/linking from 1:33 to 0:04 (compiler_spec). Yet, there is no noticeable time reduction comparing compilation with/without LTO in the last rebuild stages.

The tests were compiling the compiler, the compiler specs and std specs.

The tests were un on a macOS 10.12.3, 2.7 GHz Intel Core i7, 16 GB 1600 MHz DDR3.

### Note

The compiler stats are a bit misleading in ThinLTO since the "Codegen (bc+obj)" is just "Codegen (bc)". And the cache inform no reuse of .o files just because the cache is managed by llvm and not crystal. Maybe the compiler stats should be adapted to ThinLTO.

`--lto=thin` is used so in the future `--lto=full` could be supported if needed and we keep the same configuration option as llvm tools.

ThinLTO is still under improvements/development. Specially regarding debug information.

When adding [ThinLTO to D](http://johanengelen.github.io/ldc/2016/11/10/Link-Time-Optimization-LDC.html) some nice scenarios appears from the benefit that C and D can be compiled to .bc. It would requiere some changes but it could be something good to keep in the radar.

### References

* http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
* http://clang.llvm.org/docs/ThinLTO.html
* http://johanengelen.github.io/ldc/2016/11/10/Link-Time-Optimization-LDC.html