### PR TITLE
Compiler: fixed VirtualMetaclassType#metaclass

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -715,4 +715,16 @@ describe "Codegen: is_a?" do
       1.to_s.is_a?(B)
       )).to_b.should be_true
   end
+
+  it "says true for Class.is_a?(Class.class) (#4374)" do
+    run("
+      Class.is_a?(Class.class)
+    ").to_b.should be_true
+  end
+
+  it "says true for Class.is_a?(Class.class.class) (#4374)" do
+    run("
+      Class.is_a?(Class.class.class)
+    ").to_b.should be_true
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -179,7 +179,6 @@ module Crystal
       string.declare_instance_var("@c", uint8)
 
       types["Class"] = klass = @class = MetaclassType.new(self, object, value, "Class")
-      klass.metaclass = klass
       klass.allowed_in_generics = false
 
       types["Struct"] = struct_t = @struct_t = NonGenericClassType.new self, self, "Struct", value

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2900,6 +2900,10 @@ module Crystal
       super(program)
     end
 
+    def metaclass
+      program.class_type
+    end
+
     def parents
       @parents ||= [instance_type.superclass.try(&.metaclass) || program.class_type] of Type
     end


### PR DESCRIPTION
Fixed #4374 

`VirtualMetaclassType#metaclass` will use `super` , find in `Type#metaclass` ,
but it should override this method like what `MetaclassType#metaclass` does.