### PR TITLE
Add Hash#transform_keys and Hash#transform_values

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -512,13 +512,6 @@ describe "Hash" do
     h2.empty?.should be_true
   end
 
-  it "transform keys in place" do
-    h = {"a" => 1, "b" => 2, "c" => 3}
-
-    h.transform_keys!(&.succ)
-    h.should eq({"b" => 1, "c" => 2, "d" => 3})
-  end
-
   it "transform values in place" do
     h = {:a => 1, :b => 2, :c => 3}
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -466,6 +466,52 @@ describe "Hash" do
     h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
+  it "transforms keys" do
+    h1 = {1 => :a, 2 => :b, 3 => :c}
+
+    h2 = h1.transform_keys { |x| x + 1 }
+    h2.should eq({2 => :a, 3 => :b, 4 => :c})
+  end
+
+  it "transforms keys with type casting keys" do
+    h1 = {:a => 1, :b => 2, :c => 3}
+
+    h2 = h1.transform_keys { |x| x.to_s.upcase }
+    h2.should be_a(Hash(String, Int32))
+    h2.should eq({"A" => 1, "B" => 2, "C" => 3})
+  end
+
+  it "returns empty hash when transforming keys of an empty hash" do
+    h1 = {} of Int32 => Symbol
+
+    h2 = h1.transform_keys { |x| x + 1 }
+    h2.should be_a(Hash(Int32, Symbol))
+    h2.empty?.should be_true
+  end
+
+  it "transforms values" do
+    h1 = {:a => 1, :b => 2, :c => 3}
+
+    h2 = h1.transform_values { |x| x + 1 }
+    h2.should eq({:a => 2, :b => 3, :c => 4})
+  end
+
+  it "transforms values with type casting values" do
+    h1 = {:a => 1, :b => 2, :c => 3}
+
+    h2 = h1.transform_values { |x| x.to_s }
+    h2.should be_a(Hash(Symbol, String))
+    h2.should eq({:a => "1", :b => "2", :c => "3"})
+  end
+
+  it "returns empty hash when transforming values of an empty hash" do
+    h1 = {} of Symbol => Int32
+
+    h2 = h1.transform_values { |x| x + 1 }
+    h2.should be_a(Hash(Symbol, Int32))
+    h2.empty?.should be_true
+  end
+
   it "zips" do
     ary1 = [1, 2, 3]
     ary2 = ['a', 'b', 'c']

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -473,7 +473,7 @@ describe "Hash" do
     h2.should eq({2 => :a, 3 => :b, 4 => :c})
   end
 
-  it "transforms keys with type casting keys" do
+  it "transforms keys with type casting" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.transform_keys { |x| x.to_s.upcase }
@@ -510,6 +510,20 @@ describe "Hash" do
     h2 = h1.transform_values { |x| x + 1 }
     h2.should be_a(Hash(Symbol, Int32))
     h2.empty?.should be_true
+  end
+
+  it "transform keys in place" do
+    h = {"a" => 1, "b" => 2, "c" => 3}
+
+    h.transform_keys!(&.succ)
+    h.should eq({"b" => 1, "c" => 2, "d" => 3})
+  end
+
+  it "transform values in place" do
+    h = {:a => 1, :b => 2, :c => 3}
+
+    h.transform_values!(&.+(1))
+    h.should eq({:a => 2, :b => 3, :c => 4})
   end
 
   it "zips" do

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -590,6 +590,29 @@ class Hash(K, V)
     reject! { |key, value| value.nil? }
   end
 
+  # Returns a new hash with all keys converted using the block operation.
+  #
+  # ```
+  # hash = {:a => 1, :b => 2, :c => 3}
+  # hash.transform_keys { |key| key.to_s } # => {"A" => 1, "B" => 2, "C" => 3}
+  # ```
+  def transform_keys(&block : K -> K2) forall K2
+    each_with_object({} of K2 => V) do |(key, value), memo|
+      memo[yield(key)] = value
+    end
+  end
+
+  # Returns a new hash with the results of running block once for every value.
+  #
+  # ```
+  # hash = {:a => 1, :b => 2, :c => 3}
+  # hash.transform_values { |value| value + 1 } # => {:a => 2, :b => 3, :c => 4}
+  def transform_values(&block : V -> V2) forall V2
+    each_with_object({} of K => V2) do |(key, value), memo|
+      memo[key] = yield(value)
+    end
+  end
+
   # Zips two arrays into a `Hash`, taking keys from *ary1* and values from *ary2*.
   #
   # ```

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -591,6 +591,7 @@ class Hash(K, V)
   end
 
   # Returns a new hash with all keys converted using the block operation.
+  # The block can change a type of keys.
   #
   # ```
   # hash = {:a => 1, :b => 2, :c => 3}
@@ -603,6 +604,7 @@ class Hash(K, V)
   end
 
   # Returns a new hash with the results of running block once for every value.
+  # The block can change a type of values.
   #
   # ```
   # hash = {:a => 1, :b => 2, :c => 3}
@@ -610,6 +612,36 @@ class Hash(K, V)
   def transform_values(&block : V -> V2) forall V2
     each_with_object({} of K => V2) do |(key, value), memo|
       memo[key] = yield(value)
+    end
+  end
+
+  # Destructively transforms all keys using a block. Same as transform_keys but modifies in place.
+  # The block cannot change a type of keys.
+  #
+  # ```
+  # hash = {"a" => 1, "b" => 2, "c" => 3}
+  # hash.transform_key! { |key| key.succ }
+  # hash # => {"b" => 1, "c" => 2, "d" => 3}
+  def transform_keys!(&block : K -> K)
+    current = @first
+    while current
+      current.key = yield(current.key)
+      current = current.fore
+    end
+  end
+
+  # Destructively transforms all values using a block. Same as transform_values but modifies in place.
+  # The block cannot change a type of values.
+  #
+  # ```
+  # hash = {:a => 1, :b => 2, :c => 3}
+  # hash.transform_values! { |value| value + 1 }
+  # hash # => {:a => 2, :b => 3, :c => 4}
+  def transform_values!(&block : V -> V)
+    current = @first
+    while current
+      current.value = yield(current.value)
+      current = current.fore
     end
   end
 
@@ -952,7 +984,7 @@ class Hash(K, V)
   end
 
   private class Entry(K, V)
-    getter key : K
+    property key : K
     property value : V
 
     # Next in the linked list of each bucket

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -615,21 +615,6 @@ class Hash(K, V)
     end
   end
 
-  # Destructively transforms all keys using a block. Same as transform_keys but modifies in place.
-  # The block cannot change a type of keys.
-  #
-  # ```
-  # hash = {"a" => 1, "b" => 2, "c" => 3}
-  # hash.transform_key! { |key| key.succ }
-  # hash # => {"b" => 1, "c" => 2, "d" => 3}
-  def transform_keys!(&block : K -> K)
-    current = @first
-    while current
-      current.key = yield(current.key)
-      current = current.fore
-    end
-  end
-
   # Destructively transforms all values using a block. Same as transform_values but modifies in place.
   # The block cannot change a type of values.
   #
@@ -984,7 +969,7 @@ class Hash(K, V)
   end
 
   private class Entry(K, V)
-    property key : K
+    getter key : K
     property value : V
 
     # Next in the linked list of each bucket


### PR DESCRIPTION
This PR adds similar functionality in Ruby 2.4 which is`Hash#transform_keys` and `Hash#transform_values`. 

`Hash#transform_keys` returns a new hash with all keys converted using the block operation.

```crystal
hash = {:a => 1, :b => 2, :c => 3}
hash.transform_keys { |key| key.to_s } # => {"A" => 1, "B" => 2, "C" => 3}
```

`Hash#transform_values` returns a new hash with the results of running block once for every value.

```crystal
hash = {:a => 1, :b => 2, :c => 3}
hash.transform_values { |value| value + 1 } # => {:a => 2, :b => 3, :c => 4}
```

I haven't added bang equivalents since what I know it's not possible to modify types of keys/values in self.