### PR TITLE
Fix HTTP::Params.parse query string with two '='

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -17,6 +17,7 @@ module HTTP
         {"foo", {"foo" => [""]}},
         {"foo=&bar", {"foo" => [""], "bar" => [""]}},
         {"bar&foo", {"bar" => [""], "foo" => [""]}},
+        {"foo=bar=qux", {"foo" => ["bar=qux"]}},
       }.each do |(from, to)|
         it "parses #{from}" do
           Params.parse(from).should eq(Params.new(to))

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -35,6 +35,7 @@ module HTTP
       buffer = IO::Memory.new
 
       i = 0
+      first_equal = true
       bytesize = query.bytesize
       while i < bytesize
         byte = query.unsafe_byte_at(i)
@@ -42,9 +43,14 @@ module HTTP
 
         case char
         when '='
-          key = buffer.to_s
-          buffer.clear
-          i += 1
+          if first_equal
+            key = buffer.to_s
+            buffer.clear
+            i += 1
+            first_equal = false
+          else
+            i = decode_one_www_form_component query, bytesize, i, byte, char, buffer
+          end
         when '&', ';'
           value = buffer.to_s
           buffer.clear
@@ -56,6 +62,7 @@ module HTTP
           end
 
           key = nil
+          first_equal = true
           i += 1
         else
           i = decode_one_www_form_component query, bytesize, i, byte, char, buffer


### PR DESCRIPTION
Fix #4388 