### PR TITLE
Compiler: fixed is_a? transform may cause an exception

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -706,4 +706,13 @@ describe "Codegen: is_a?" do
       1 || i.is_a?(Int32) ? "" : i
       ))
   end
+
+  it "visits 1.to_s twice, may trigger enclosing_call (#4364)" do
+    run(%(
+      require "prelude"
+
+      B = String
+      1.to_s.is_a?(B)
+      )).to_b.should be_true
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1660,7 +1660,9 @@ module Crystal
       # When doing x.is_a?(A) and A turns out to be a constant (not a type),
       # replace it with a === comparison. Most usually this happens in a case expression.
       if const.is_a?(Path) && const.target_const
-        comp = Call.new(const, "===", node.obj).at(node.location)
+        obj = node.obj.clone.at(node.obj)
+        const = node.const.clone.at(node.const)
+        comp = Call.new(const, "===", obj).at(node.location)
         comp.accept self
         node.syntax_replacement = comp
         node.bind_to comp


### PR DESCRIPTION
Fixed #4364 

``` crystal
Something.some_method.is_a?(Const)
``` 
This code may trigger an exception about **enclosing call**.
This will be transformed to below:
```crystal
Const === Something.some_method
```

The compiler checks **enclosing call** of `Something.some_method` twice, and causes an exception.
So, cloning the `ASTNode` could solve this bug.
