### PR TITLE
Add option to HTTP::StaticFileHandler initializer to disable directory listing

### DIFF
--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -1,11 +1,11 @@
 require "spec"
 require "http/server"
 
-private def handle(request, fallthrough = true)
+private def handle(request, fallthrough = true, directory_listing = true)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
-  handler = HTTP::StaticFileHandler.new "#{__DIR__}/static", fallthrough
+  handler = HTTP::StaticFileHandler.new "#{__DIR__}/static", fallthrough, directory_listing
   handler.call context
   response.close
   io.rewind
@@ -25,6 +25,11 @@ describe HTTP::StaticFileHandler do
     response = handle HTTP::Request.new("GET", "/")
     response.status_code.should eq(200)
     response.body.should match(/test.txt/)
+  end
+
+  it "should not list directory's entries when directory_listing is set to false" do
+    response = handle HTTP::Request.new("GET", "/"), directory_listing: false
+    response.status_code.should eq(404)
   end
 
   it "should not serve a not found file" do


### PR DESCRIPTION
This PR follows the discussion on #4398.

**Reason**:

At this time, using `HTTP::StaticFileHandler` one can configure which directory to serve static files from by passing its path to the constructor:

```crystal
HTTP::StaticFileHandler.new("public/")
```

This will serve files from `public/` in the root path `/` and currently there is no way to change it. Additionally, it will display by default a directory list if a path to a directory is given.

In some cases, such as web frameworks, it's preferable not to let the user list files under a public directory for reasons like security.

In this sense, this PR adds an option to `HTTP::StaticFileHandler` that enables the user to turn off directory listing, preserving the default behaviour.

**Code Changes**:
- Removed duplicate `Dir.exists?` call, resulting in one less system call.
- Added an optional argument to `HTTP::StaticFileHandler`. The name of the argument is `directory_listing` and defaults to true, as it was before.
- Added a test case to ensure this option prevents directory listing.

The default behaviour remains the same.