### PR TITLE
Convert MatchData into a struct

### DIFF
--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -15,7 +15,7 @@ class Regex
   # argument to select the desired capture group. Capture groups are numbered
   # starting from `1`, so that `0` can be used to refer to the entire regular
   # expression without needing to capture it explicitly.
-  class MatchData
+  struct MatchData
     # Returns the original regular expression.
     #
     # ```


### PR DESCRIPTION
MatchData is immutable, so making it into a struct eases GC pressure.

Fixes #3256.