### PR TITLE
Add Path#resolve? macro method

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1566,6 +1566,21 @@ describe "macro methods" do
     end
   end
 
+  describe "path methods" do
+    it "executes resolve" do
+      assert_macro "x", %({{x.resolve}}), [Path.new("String")] of ASTNode, %(String)
+
+      expect_raises(Crystal::TypeException, "undefined constant Foo") do
+        assert_macro "x", %({{x.resolve}}), [Path.new("Foo")] of ASTNode, %(Foo)
+      end
+    end
+
+    it "executes resolve?" do
+      assert_macro "x", %({{x.resolve?}}), [Path.new("String")] of ASTNode, %(String)
+      assert_macro "x", %({{x.resolve?}}), [Path.new("Foo")] of ASTNode, %(nil)
+    end
+  end
+
   describe "env" do
     it "has key" do
       ENV["FOO"] = "foo"

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1140,6 +1140,12 @@ module Crystal::Macros
     # gives a compile-time error.
     def resolve : ASTNode
     end
+
+    # Resolves this path to a `TypeNode` if it denotes a type, to
+    # the value of a constant if it denotes a constant, or otherwise
+    # returns a `NilLiteral`.
+    def resolve? : ASTNode | NilLiteral
+    end
   end
 
   # A class definition.

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -371,15 +371,17 @@ module Crystal
     end
 
     def resolve(node : Path)
+      resolve?(node) || node.raise_undefined_constant(@path_lookup)
+    end
+
+    def resolve?(node : Path)
       if node.names.size == 1 && (match = @free_vars.try &.[node.names.first]?)
         matched_type = match
       else
         matched_type = @path_lookup.lookup_path(node)
       end
 
-      unless matched_type
-        node.raise_undefined_constant(@path_lookup)
-      end
+      return unless matched_type
 
       case matched_type
       when Const

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1740,14 +1740,7 @@ module Crystal
       when "resolve"
         interpret_argless_method(method, args) { interpreter.resolve(self) }
       when "resolve?"
-        interpret_argless_method(method, args) do
-          begin
-            interpreter.resolve(self)
-          rescue ex : Crystal::TypeException
-            ::raise ex unless ex.message.try &.includes? "undefined constant"
-            NilLiteral.new
-          end
-        end
+        interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1739,6 +1739,15 @@ module Crystal
         interpret_argless_method(method, args) { BoolLiteral.new(@global) }
       when "resolve"
         interpret_argless_method(method, args) { interpreter.resolve(self) }
+      when "resolve?"
+        interpret_argless_method(method, args) do
+          begin
+            interpreter.resolve(self)
+          rescue ex : Crystal::TypeException
+            ::raise ex unless ex.message.try &.includes? "undefined constant"
+            NilLiteral.new
+          end
+        end
       else
         super
       end


### PR DESCRIPTION
I think this is a useful feature, as most `ASTNodes` allow you to assert in  some way whether the call you're about to make will raise, however `Path#resolve` does not.

Closes #4370.