### PR TITLE
Wrapper script has some bashisms left

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 ################## https://github.com/mkropat/sh-realpath #####################
 #
@@ -94,19 +94,14 @@ _canonicalize_file_path() {
 
 ##############################################################################
 
-# Based on http://stackoverflow.com/a/2108540/2199687
+# Based on http://stackoverflow.com/q/370047/641451
 remove_path_item() {
-  local path item work
+  local path item
 
   path="$1"
   item="$2"
 
-  work=":$path:"
-  work="${work/:$item:/:}"
-  work="${work%:}"
-  work="${work#:}"
-
-  echo "$work"
+  echo -n $path | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
 }
 
 ##############################################################################

--- a/bin/crystal
+++ b/bin/crystal
@@ -114,7 +114,7 @@ remove_path_item() {
 __has_colors() {
   local num_colors=$(tput colors 2>/dev/null)
 
-  if [ "$num_colors" -gt 2 ]; then
+  if [ "0$num_colors" -gt 2 ]; then
     return 0
   else
     return 1

--- a/bin/crystal
+++ b/bin/crystal
@@ -109,7 +109,7 @@ remove_path_item() {
 __has_colors() {
   local num_colors=$(tput colors 2>/dev/null)
 
-  if [ "0$num_colors" -gt 2 ]; then
+  if [ -n "$num_colors" ] && [ "$num_colors" -gt 2 ]; then
     return 0
   else
     return 1


### PR DESCRIPTION
In #3809, the `bin/crystal` wrapper script changed from bash to sh, but there were some bashisms left. I've removed them (and the dependency on `tput`) so we can better support Alpine and any toaster brand that doesn't have Bash built-in :)

In particular, running `docker build .` stopped working, because it went through the `if` branch that used `remove_path_item` - and that was Bash-dependent.