### PR TITLE
OSX builds on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  timezone:
+    America/New_York
+  environment:
+    TRAVIS_BRANCH: $CIRCLE_BRANCH
+    TRAVIS_OS_NAME: $CIRCLE_BUILD_IMAGE
+    TRAVIS_PULL_REQUEST: $CI_PULL_REQUEST || "false"
+dependencies:
+  override:
+    - bin/ci prepare_system
+compile:
+  override:
+    - bin/ci prepare_build
+test:
+  override:
+    - bin/ci build


### PR DESCRIPTION
TravisCI has some delays for bringing up OSX nodes, so we are moving OSX builds to CircleCI.

CircleCI gave us a free seed project to build on OSX. It has some limits - mainly, monthly builds minutes -, so we should run this along with Travis for now, to check how close to that limit we are.

If everything goes well, we'll stop building OSX on Travis. If not, we can talk with Circle once again to check if we can upgrade the plan.

This would _eventually_ get superseded by the CI infrastructure that @RX14 is doing in #3721.