### PR TITLE
Extend known HTTP default status messages by RFC's

### DIFF
--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -295,6 +295,7 @@ module HTTP
     case status_code
     when 100 then "Continue"
     when 101 then "Switching Protocols"
+    when 102 then "Processing" # RFC 2518 (WebDAV)
     when 200 then "OK"
     when 201 then "Created"
     when 202 then "Accepted"
@@ -302,6 +303,8 @@ module HTTP
     when 204 then "No Content"
     when 205 then "Reset Content"
     when 206 then "Partial Content"
+    when 207 then "Multi-Status"     # RFC 2518 (WebDAV)
+    when 208 then "Already Reported" # RFC 5842
     when 226 then "IM Used"
     when 300 then "Multiple Choices"
     when 301 then "Moved Permanently"
@@ -310,7 +313,7 @@ module HTTP
     when 304 then "Not Modified"
     when 305 then "Use Proxy"
     when 307 then "Temporary Redirect"
-    when 308 then "Permanent Redirect"
+    when 308 then "Permanent Redirect" # RFC 7238
     when 400 then "Bad Request"
     when 401 then "Unauthorized"
     when 402 then "Payment Required"
@@ -329,12 +332,16 @@ module HTTP
     when 415 then "Unsupported Media Type"
     when 416 then "Requested Range Not Satisfiable"
     when 417 then "Expectation Failed"
+    when 418 then "I'm a teapot" # RFC 2324
     when 421 then "Misdirected Request"
-    when 423 then "Locked"
-    when 426 then "Upgrade Required"
+    when 422 then "Unprocessable Entity" # RFC 2518 (WebDAV)
+    when 423 then "Locked"               # RFC 2518 (WebDAV)
+    when 424 then "Failed Dependency"    # RFC 2518 (WebDAV)
+    when 426 then "Upgrade Required"     # RFC 2817
     when 428 then "Precondition Required"
     when 429 then "Too Many Requests"
     when 431 then "Request Header Fields Too Large"
+    when 449 then "Retry With" # unofficial Microsoft
     when 451 then "Unavailable For Legal Reasons"
     when 500 then "Internal Server Error"
     when 501 then "Not Implemented"
@@ -342,8 +349,11 @@ module HTTP
     when 503 then "Service Unavailable"
     when 504 then "Gateway Timeout"
     when 505 then "HTTP Version Not Supported"
-    when 506 then "Variant Also Negotiates"
-    when 510 then "Not Extended"
+    when 506 then "Variant Also Negotiates"  # RFC 2295
+    when 507 then "Insufficient Storage"     # RFC 2518 (WebDAV)
+    when 509 then "Bandwidth Limit Exceeded" # unofficial
+    when 510 then "Not Extended"             # RFC 2774
+    when 511 then "Network Authentication Required"
     else          ""
     end
   end


### PR DESCRIPTION
RFC 2518, RFC 5842, RFC 2324 etc.

Heavily inspired by CPAN HTTP::Status module.