### PR TITLE
Add warnings to MD5 and SHA1 hash documentation

### DIFF
--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -1,6 +1,9 @@
 require "./base"
 
 # Implements the MD5 digest algorithm.
+#
+# Warning: MD5 is no longer a cryptograpically safe hash, and should not be
+# used for secure applications.
 class Digest::MD5 < Digest::Base
   def initialize
     @i = StaticArray(UInt32, 2).new(0_u32)

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -2,7 +2,7 @@ require "./base"
 
 # Implements the MD5 digest algorithm.
 #
-# Warning: MD5 is no longer a cryptograpically safe hash, and should not be
+# Warning: MD5 is no longer a cryptographically safe hash, and should not be
 # used for secure applications.
 class Digest::MD5 < Digest::Base
   def initialize

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -2,8 +2,10 @@ require "./base"
 
 # Implements the MD5 digest algorithm.
 #
-# Warning: MD5 is no longer a cryptographically safe hash, and should not be
-# used for secure applications.
+# Warning: MD5 is no longer a cryptographically secure hash, and should not be
+# used in security-related components, like password hashing. For passwords, see
+# `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
+# `OpenSSL::Digest.new("SHA256")`.
 class Digest::MD5 < Digest::Base
   def initialize
     @i = StaticArray(UInt32, 2).new(0_u32)

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -2,8 +2,10 @@ require "./base"
 
 # Implements the SHA1 digest algorithm.
 #
-# Warning: SHA1 is no longer a cryptographically safe hash, and should not be
-# used for secure applications.
+# Warning: SHA1 is no longer a cryptographically secure hash, and should not be
+# used in security-related components, like password hashing. For passwords, see
+# `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
+# `OpenSSL::Digest.new("SHA256")`.
 class Digest::SHA1 < Digest::Base
   # This is a direct translation of https://tools.ietf.org/html/rfc3174#section-7
   # but we use loop unrolling for faster execution (about 1.07x slower than OpenSSL::SHA1).

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -2,7 +2,7 @@ require "./base"
 
 # Implements the SHA1 digest algorithm.
 #
-# Warning: SHA1 is no longer a cryptograpically safe hash, and should not be
+# Warning: SHA1 is no longer a cryptographically safe hash, and should not be
 # used for secure applications.
 class Digest::SHA1 < Digest::Base
   # This is a direct translation of https://tools.ietf.org/html/rfc3174#section-7

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -1,6 +1,9 @@
 require "./base"
 
 # Implements the SHA1 digest algorithm.
+#
+# Warning: SHA1 is no longer a cryptograpically safe hash, and should not be
+# used for secure applications.
 class Digest::SHA1 < Digest::Base
   # This is a direct translation of https://tools.ietf.org/html/rfc3174#section-7
   # but we use loop unrolling for faster execution (about 1.07x slower than OpenSSL::SHA1).

--- a/src/openssl/md5.cr
+++ b/src/openssl/md5.cr
@@ -2,8 +2,10 @@ require "./lib_crypto"
 
 # Binds the OpenSSL MD5 hash functions.
 #
-# Warning: MD5 is no longer a cryptographically safe hash, and should not be
-# used for secure applications.
+# Warning: MD5 is no longer a cryptographically secure hash, and should not be
+# used in security-related components, like password hashing. For passwords, see
+# `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
+# `OpenSSL::Digest.new("SHA256")`.
 class OpenSSL::MD5
   def self.hash(data : String) : UInt8[16]
     hash(data.to_unsafe, data.bytesize)

--- a/src/openssl/md5.cr
+++ b/src/openssl/md5.cr
@@ -1,5 +1,9 @@
 require "./lib_crypto"
 
+# Binds the OpenSSL MD5 hash functions.
+#
+# Warning: MD5 is no longer a cryptograpically safe hash, and should not be
+# used for secure applications.
 class OpenSSL::MD5
   def self.hash(data : String) : UInt8[16]
     hash(data.to_unsafe, data.bytesize)

--- a/src/openssl/md5.cr
+++ b/src/openssl/md5.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 # Binds the OpenSSL MD5 hash functions.
 #
-# Warning: MD5 is no longer a cryptograpically safe hash, and should not be
+# Warning: MD5 is no longer a cryptographically safe hash, and should not be
 # used for secure applications.
 class OpenSSL::MD5
   def self.hash(data : String) : UInt8[16]

--- a/src/openssl/sha1.cr
+++ b/src/openssl/sha1.cr
@@ -2,8 +2,10 @@ require "./lib_crypto"
 
 # Binds the OpenSSL SHA1 hash functions.
 #
-# Warning: SHA1 is no longer a cryptographically safe hash, and should not be
-# used for secure applications.
+# Warning: SHA1 is no longer a cryptographically secure hash, and should not be
+# used in security-related components, like password hashing. For passwords, see
+# `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
+# `OpenSSL::Digest.new("SHA256")`.
 class OpenSSL::SHA1
   def self.hash(data : String)
     hash(data.to_unsafe, LibC::SizeT.new(data.bytesize))

--- a/src/openssl/sha1.cr
+++ b/src/openssl/sha1.cr
@@ -1,5 +1,9 @@
 require "./lib_crypto"
 
+# Binds the OpenSSL SHA1 hash functions.
+#
+# Warning: SHA1 is no longer a cryptograpically safe hash, and should not be
+# used for secure applications.
 class OpenSSL::SHA1
   def self.hash(data : String)
     hash(data.to_unsafe, LibC::SizeT.new(data.bytesize))

--- a/src/openssl/sha1.cr
+++ b/src/openssl/sha1.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 # Binds the OpenSSL SHA1 hash functions.
 #
-# Warning: SHA1 is no longer a cryptograpically safe hash, and should not be
+# Warning: SHA1 is no longer a cryptographically safe hash, and should not be
 # used for secure applications.
 class OpenSSL::SHA1
   def self.hash(data : String)


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/2743.

I'm not 100% on the wording of the warnings.