### PR TITLE
Add | as a string delimiter

### DIFF
--- a/spec/compiler/lexer/lexer_string_array_spec.cr
+++ b/spec/compiler/lexer/lexer_string_array_spec.cr
@@ -77,4 +77,12 @@ describe "Lexer string array" do
       it_should_be_valid_string_array_lexer(lexer)
     end
   end
+
+  context "using | as delimiter" do
+    it "lexes simple string array" do
+      lexer = Lexer.new("%w|one two|")
+
+      it_should_be_valid_string_array_lexer(lexer)
+    end
+  end
 end

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -132,6 +132,15 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
+  it "lexes simple string with %|" do
+    lexer = Lexer.new("%|hello|")
+    tester = LexerObjects::Strings.new(lexer)
+
+    tester.string_should_be_delimited_by('|', '|')
+    tester.next_string_token_should_be("hello")
+    tester.string_should_end_correctly
+  end
+
   [['(', ')'], ['[', ']'], ['{', '}'], ['<', '>']].each do |(left, right)|
     it "lexes simple string with nested %#{left}" do
       lexer = Lexer.new("%#{left}hello #{left}world#{right}#{right}")

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -289,11 +289,11 @@ module Crystal
         case next_char
         when '='
           next_char :"%="
-        when '(', '[', '{', '<'
+        when '(', '[', '{', '<', '|'
           delimited_pair :string, current_char, closing_char, start
         when 'i'
           case peek_next_char
-          when '(', '{', '[', '<'
+          when '(', '{', '[', '<', '|'
             start_char = next_char
             next_char :SYMBOL_ARRAY_START
             @token.raw = "%i#{start_char}" if @wants_raw
@@ -303,7 +303,7 @@ module Crystal
           end
         when 'q'
           case peek_next_char
-          when '(', '{', '[', '<'
+          when '(', '{', '[', '<', '|'
             next_char
             delimited_pair :string, current_char, closing_char, start, allow_escapes: false
           else
@@ -311,7 +311,7 @@ module Crystal
           end
         when 'Q'
           case peek_next_char
-          when '(', '{', '[', '<'
+          when '(', '{', '[', '<', '|'
             next_char
             delimited_pair :string, current_char, closing_char, start
           else
@@ -319,21 +319,21 @@ module Crystal
           end
         when 'r'
           case next_char
-          when '(', '[', '{', '<'
+          when '(', '[', '{', '<', '|'
             delimited_pair :regex, current_char, closing_char, start
           else
             raise "unknown %r char"
           end
         when 'x'
           case next_char
-          when '(', '[', '{', '<'
+          when '(', '[', '{', '<', '|'
             delimited_pair :command, current_char, closing_char, start
           else
             raise "unknown %x char"
           end
         when 'w'
           case peek_next_char
-          when '(', '{', '[', '<'
+          when '(', '{', '[', '<', '|'
             start_char = next_char
             next_char :STRING_ARRAY_START
             @token.raw = "%w#{start_char}" if @wants_raw


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/3467.

I won't be sad if this doesn't get merged but it's a tiny patch and it works through the issue backlog.