### PR TITLE
Extract OpenSSL::Error to separate source file, document it

### DIFF
--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -64,27 +64,6 @@ require "./openssl/lib_ssl"
 # end
 # ```
 module OpenSSL
-  class Error < Exception
-    getter! code : LibCrypto::ULong
-
-    def initialize(message = nil, fetched = false)
-      @code ||= LibCrypto::ULong.new(0)
-
-      if fetched
-        super(message)
-      else
-        @code, error = fetch_error_details
-        super(message ? "#{message}: #{error}" : error)
-      end
-    end
-
-    protected def fetch_error_details
-      code = LibCrypto.err_get_error
-      message = String.new(LibCrypto.err_error_string(code, nil)) unless code == 0
-      {code, message || "Unknown or no error"}
-    end
-  end
-
   module SSL
     alias Modes = LibSSL::Modes
     alias Options = LibSSL::Options

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -1,3 +1,4 @@
+require "./openssl/error"
 require "./openssl/lib_ssl"
 
 # ## OpenSSL Integration

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -1,4 +1,5 @@
-require "./openssl"
+require "./lib_crypto"
+require "./error"
 
 class OpenSSL::Cipher
   class Error < OpenSSL::Error

--- a/src/openssl/digest/digest.cr
+++ b/src/openssl/digest/digest.cr
@@ -1,4 +1,5 @@
 require "../lib_crypto"
+require "../error"
 require "./digest_base"
 
 module OpenSSL

--- a/src/openssl/error.cr
+++ b/src/openssl/error.cr
@@ -1,0 +1,29 @@
+require "./lib_crypto"
+
+module OpenSSL
+  # Raised when OpenSSL informs about error.
+  class Error < Exception
+    getter! code : LibCrypto::ULong
+
+    # Initializes OpenSSL error.
+    # Will fetch error details from OpenSSL error queue
+    # unless `already_fetched` specified.
+    def initialize(message = nil, already_fetched = false)
+      @code ||= LibCrypto::ULong.new(0)
+
+      if already_fetched
+        super(message)
+      else
+        @code, error = fetch_error_details
+        super(message ? "#{message}: #{error}" : error)
+      end
+    end
+
+    # Fetches OpenSSL {code, message} from libcrypto.
+    protected def fetch_error_details
+      code = LibCrypto.err_get_error
+      message = String.new(LibCrypto.err_error_string(code, nil)) unless code == 0
+      {code, message || "Unknown or no error"}
+    end
+  end
+end

--- a/src/openssl/pkcs5.cr
+++ b/src/openssl/pkcs5.cr
@@ -1,4 +1,5 @@
-require "./openssl"
+require "./lib_crypto"
+require "./error"
 
 module OpenSSL::PKCS5
   def self.pbkdf2_hmac_sha1(secret, salt, iterations = 2**16, key_size = 64) : Bytes

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -1,3 +1,6 @@
+require "../lib_ssl"
+require "../error"
+
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method

--- a/src/openssl/ssl/hostname_validation.cr
+++ b/src/openssl/ssl/hostname_validation.cr
@@ -1,5 +1,5 @@
 require "socket"
-require "openssl"
+require "../lib_crypto"
 
 # :nodoc:
 module OpenSSL::SSL::HostnameValidation

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -1,3 +1,6 @@
+require "../lib_ssl"
+require "../error"
+
 abstract class OpenSSL::SSL::Socket
   class Client < Socket
     def initialize(io, context : Context::Client = Context::Client.new, sync_close : Bool = false, hostname : String? = nil)


### PR DESCRIPTION
and reorder requires in source files of openssl just to allow
syntax check on the fly in editor.