### PR TITLE
Use an Enum for process stdio redirections

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -37,7 +37,7 @@ describe Process do
 
   it "redirects output to /dev/null" do
     # This doesn't test anything but no output should be seen while running tests
-    Process.run("/bin/ls", output: false).exit_code.should eq(0)
+    Process.run("/bin/ls", output: Process::Redirect::Close).exit_code.should eq(0)
   end
 
   it "gets output" do
@@ -83,7 +83,7 @@ describe Process do
 
   it "sets working directory" do
     parent = File.dirname(Dir.current)
-    value = Process.run("pwd", shell: true, chdir: parent, output: nil) do |proc|
+    value = Process.run("pwd", shell: true, chdir: parent, output: Process::Redirect::Pipe) do |proc|
       proc.output.gets_to_end
     end
     value.should eq "#{parent}\n"
@@ -96,19 +96,19 @@ describe Process do
   end
 
   it "looks up programs in the $PATH with a shell" do
-    proc = Process.run("uname", {"-a"}, shell: true, output: false)
+    proc = Process.run("uname", {"-a"}, shell: true, output: Process::Redirect::Close)
     proc.exit_code.should eq(0)
   end
 
   it "allows passing huge argument lists to a shell" do
-    proc = Process.new(%(echo "${@}"), {"a", "b"}, shell: true, output: nil)
+    proc = Process.new(%(echo "${@}"), {"a", "b"}, shell: true, output: Process::Redirect::Pipe)
     output = proc.output.gets_to_end
     proc.wait
     output.should eq "a b\n"
   end
 
   it "does not run shell code in the argument list" do
-    proc = Process.new("echo", {"`echo hi`"}, shell: true, output: nil)
+    proc = Process.new("echo", {"`echo hi`"}, shell: true, output: Process::Redirect::Pipe)
     output = proc.output.gets_to_end
     proc.wait
     output.should eq "`echo hi`\n"

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -111,7 +111,7 @@ module Crystal
 
           if libname = attr.lib
             if has_pkg_config.nil?
-              has_pkg_config = Process.run("which", {"pkg-config"}, output: false).success?
+              has_pkg_config = Process.run("which", {"pkg-config"}, output: Process::Redirect::Close).success?
             end
 
             if has_pkg_config && (libflags = pkg_config_flags(libname, attr.static?, library_path))

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -216,7 +216,7 @@ class Crystal::Command
     status, elapsed_time = @progress_tracker.stage("Execute") do
       begin
         start_time = Time.now
-        Process.run(output_filename, args: run_args, input: true, output: true, error: true) do |process|
+        Process.run(output_filename, args: run_args, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) do |process|
           # Ignore the signal so we don't exit the running process
           # (the running process can still handle this signal)
           Signal::INT.ignore # do

--- a/src/compiler/crystal/command/deps.cr
+++ b/src/compiler/crystal/command/deps.cr
@@ -8,7 +8,7 @@ class Crystal::Command
       error "`shards` executable is missing. Please install shards: https://github.com/crystal-lang/shards"
     end
 
-    status = Process.run(path_to_shards, args: options, output: true, error: true)
+    status = Process.run(path_to_shards, args: options, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
     exit status.exit_code unless status.success?
   end
 end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -150,7 +150,7 @@ module Crystal::Playground
       stop_process
 
       @logger.info "Code execution started (session=#{@session_key}, tag=#{tag}, filename=#{output_filename})."
-      process = @process = Process.new(output_filename, args: [] of String, input: nil, output: nil, error: nil)
+      process = @process = Process.new(output_filename, args: [] of String, input: Process::Redirect::Pipe, output: Process::Redirect::Pipe, error: Process::Redirect::Pipe)
       @running_process_filename = output_filename
 
       spawn do


### PR DESCRIPTION
Implements a `Process:Redirect` enum as per #3084 to define the standard input, output and error IO of spawned processes. This patch replaces the inexplicit and confusing `nil`, `true` and `false` values for the explicitness of `PIPE`, `CLOSE` and `INHERIT`.

closes #3084 