### PR TITLE
CSV#each_row add support for separator, quote_char

### DIFF
--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -95,6 +95,14 @@ describe CSV do
     sum.should eq(10)
   end
 
+  it "does CSV.each_row with separator and quotes" do
+    sum = 0
+    CSV.each_row("1\t'2'\n3\t4\n", '\t', '\'') do |row|
+      sum += row.map(&.to_i).sum
+    end.should be_nil
+    sum.should eq(10)
+  end
+
   it "gets row iterator" do
     iter = CSV.each_row("1,2\n3,4\n")
     iter.next.should eq(["1", "2"])

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -91,7 +91,7 @@ class CSV
   # ["three"]
   # ```
   def self.each_row(string_or_io : String | IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
-    Parser.new(string_or_io).each_row do |row|
+    Parser.new(string_or_io, separator, quote_char).each_row do |row|
       yield row
     end
   end
@@ -106,7 +106,7 @@ class CSV
   # rows.next # => ["three"]
   # ```
   def self.each_row(string_or_io : String | IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
-    Parser.new(string_or_io).each_row
+    Parser.new(string_or_io, separator, quote_char).each_row
   end
 
   # Builds a CSV. This yields a `CSV::Builder` to the given block.


### PR DESCRIPTION
Currently CSV#each_row ignores the separator and quote_char variables that are passed in.