### PR TITLE
Parser: correct accept_with_maybe_begin_end to wrap control expression

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -104,4 +104,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(enum Foo\n  A = 0\n  B\nend)
   expect_to_s %(alias Foo = Void)
   expect_to_s %(type(Foo = Void))
+  expect_to_s %(return true ? 1 : 2), %(return begin\n  if true\n    1\n  else\n    2\n  end\nend)
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1522,7 +1522,8 @@ module Crystal
     end
 
     def accept_with_maybe_begin_end(node)
-      if node.is_a?(Expressions)
+      case node
+      when Expressions
         if node.expressions.size == 1
           @str << "("
           node.expressions.first.accept self
@@ -1534,6 +1535,12 @@ module Crystal
           append_indent
           @str << keyword("end")
         end
+      when If, Unless, While, Until
+        @str << keyword("begin")
+        newline
+        accept_with_indent(node)
+        append_indent
+        @str << keyword("end")
       else
         node.accept self
       end


### PR DESCRIPTION
Fixed #4488 

#4488's example:

```crystal
record Foo do
  def foo
    return true ? 1 : 2
  end
end
```

is expanded to:

```crystal
struct Foo
  # ...

  def foo
    return if true
      1
    else
      2
    end
  end
end
```

So it causes parse error.

This PR fixes it by wrapping control expression with `begin` and `end`.

```crystal
struct Foo
  # ...

  def foo
    return begin
      if true
        1
      else
        2
      end
    end
  end
end
```