### PR TITLE
Support windows linker

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -82,6 +82,24 @@ module Crystal
 
   class Program
     def lib_flags
+      has_flag?("windows") ? lib_flags_windows : lib_flags_posix
+    end
+
+    private def lib_flags_windows
+      String.build do |flags|
+        link_attributes.reverse_each do |attr|
+          if ldflags = attr.ldflags
+            flags << " " << ldflags
+          end
+
+          if libname = attr.lib
+            flags << " " << libname << ".lib"
+          end
+        end
+      end
+    end
+
+    private def lib_flags_posix
       library_path = ["/usr/lib", "/usr/local/lib"]
       has_pkg_config = nil
 


### PR DESCRIPTION
This PR allows the crystal compiler to emit correct linker commands for `--cross-compile` for windows machines. This allows complication of simple `--prelude=empty` windows executables. Hopefully this is the first part of a gradual merge of windows support for crystal.

Using the below test case and crystal command, crystal emits a `cl` (equivalent of `cc` on windows) command to link the object file. Please test this out yourself if you have a machine with visual studio installed.
```cr
@[Link("kernel32")]
@[Link("libcmt")]
lib LibWindows
  STD_INPUT_HANDLE  = 0xFFFFFFF6_u32
  STD_OUTPUT_HANDLE = 0xFFFFFFF5_u32
  STD_ERROR_HANDLE  = 0xFFFFFFF4_u32

  alias DWord = UInt32
  alias Handle = Void*
  alias SizeT = UInt64 # FIXME

  struct Overlapped
    internal : SizeT*
    internal_high : SizeT*
    pointer : Void*
    event : Handle
  end

  fun get_std_handle = GetStdHandle(std_handle : DWord) : Handle
  fun get_file_type = GetFileType(file : Handle) : DWord
  fun write_file = WriteFile(file : Handle, buffer : UInt8*, size : DWord, written : DWord*, overlapped : Overlapped*) : Bool
  fun close_handle = CloseHandle(file : Handle) : Bool
end

handle = LibWindows.get_std_handle(LibWindows::STD_OUTPUT_HANDLE)

str = "Hello World!\n"
written = 0_u32
LibWindows.write_file(handle, pointerof(str.@c), str.@bytesize, pointerof(written), nil)
```
```
$ bin/crystal build foo.cr --cross-compile --target x86_64-pc-windows-msvc --prelude=empty
Using compiled compiler at `.build/crystal'
cl "foo.o" "/Fefoo"  libcmt.lib kernel32.lib
```

One question is whether we want to emit `libcmt.lib` by default as part of every linker command: it is windows' libc implementation which calls the executables' `main` function. On linux, `ld` includes the equivalent of this automatically.