### PR TITLE
Markdown support mulit blockquotes

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -71,11 +71,11 @@ describe Markdown do
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
   assert_render "> This spawns\nmultiple\nlines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
-  assert_render "> Hello World\n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
+  assert_render "> Hello World\n> and Crystal", "<blockquote>Hello World\nand Crystal</blockquote>"
   assert_render "> Hello World\n     \n>     and Crystal", "<blockquote>Hello World</blockquote>\n\n<blockquote>and Crystal</blockquote>"
-  assert_render "> Hello World\n>\n> \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
-  assert_render "> This spawns\n> multiple\n> lines\n\ntext", "<blockquote>This spawns multiple lines</blockquote>\n\n<p>text</p>"
-  assert_render "> This spawns\nmultiple \n> lines\n\ntext", "<blockquote>This spawns\nmultiple lines</blockquote>\n\n<p>text</p>"
+  assert_render "> Hello World\n>\n> \n> and Crystal", "<blockquote>Hello World\nand Crystal</blockquote>"
+  assert_render "> This spawns\n> multiple\n> lines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
+  assert_render "> This spawns\nmultiple \n> lines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
 
   assert_render "* Hello", "<ul><li>Hello</li></ul>"
   assert_render "* Hello\n* World", "<ul><li>Hello</li><li>World</li></ul>"

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -71,6 +71,10 @@ describe Markdown do
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
   assert_render "> This spawns\nmultiple\nlines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
+  assert_render "> Hello World \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
+  assert_render "> Hello World \n>\n> \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
+  assert_render "> This spawns \n> multiple \n> lines\n\ntext", "<blockquote>This spawns multiple lines</blockquote>\n\n<p>text</p>"
+  assert_render "> This spawns\nmultiple \n> lines\n\ntext", "<blockquote>This spawns\nmultiple lines</blockquote>\n\n<p>text</p>"
 
   assert_render "* Hello", "<ul><li>Hello</li></ul>"
   assert_render "* Hello\n* World", "<ul><li>Hello</li><li>World</li></ul>"

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -71,9 +71,10 @@ describe Markdown do
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
   assert_render "> This spawns\nmultiple\nlines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
-  assert_render "> Hello World \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
-  assert_render "> Hello World \n>\n> \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
-  assert_render "> This spawns \n> multiple \n> lines\n\ntext", "<blockquote>This spawns multiple lines</blockquote>\n\n<p>text</p>"
+  assert_render "> Hello World\n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
+  assert_render "> Hello World\n     \n>     and Crystal", "<blockquote>Hello World</blockquote>\n\n<blockquote>and Crystal</blockquote>"
+  assert_render "> Hello World\n>\n> \n> and Crystal", "<blockquote>Hello World and Crystal</blockquote>"
+  assert_render "> This spawns\n> multiple\n> lines\n\ntext", "<blockquote>This spawns multiple lines</blockquote>\n\n<p>text</p>"
   assert_render "> This spawns\nmultiple \n> lines\n\ntext", "<blockquote>This spawns\nmultiple lines</blockquote>\n\n<p>text</p>"
 
   assert_render "* Hello", "<ul><li>Hello</li></ul>"

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -195,14 +195,17 @@ class Markdown::Parser
   def render_quote
     @renderer.begin_quote
 
+    oneline_quote = true
     while true
       break unless @lines[@line].starts_with? ">"
 
       join_next_lines continue_on: :none, stop_on: :quote
 
       line = @lines[@line]
+      text = line.byte_slice(Math.min(line.bytesize, 2)).strip
+      text = " " + text unless oneline_quote
 
-      if empty? line
+      if empty? text
         @line += 1
 
         if @line == @lines.size
@@ -212,12 +215,15 @@ class Markdown::Parser
         next
       end
 
-      @renderer.text line.byte_slice(Math.min(line.bytesize, 2))
+      @renderer.text text
+
       @line += 1
 
       if @line == @lines.size
         break
       end
+
+      oneline_quote = false
     end
 
     @renderer.end_quote

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -203,7 +203,6 @@ class Markdown::Parser
 
       line = @lines[@line]
       text = line.byte_slice(Math.min(line.bytesize, 2)).strip
-      text = "\n" + text unless oneline_quote
 
       if empty? text
         @line += 1
@@ -214,6 +213,8 @@ class Markdown::Parser
 
         next
       end
+
+      text = "\n" + text unless oneline_quote
 
       @renderer.text text
 

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -195,11 +195,30 @@ class Markdown::Parser
   def render_quote
     @renderer.begin_quote
 
-    join_next_lines continue_on: :quote
-    line = @lines[@line]
+    while true
+      break unless @lines[@line].starts_with? ">"
 
-    @renderer.text line.byte_slice(Math.min(line.bytesize, 2))
-    @line += 1
+      join_next_lines continue_on: :none, stop_on: :quote
+
+      line = @lines[@line]
+
+      if empty? line
+        @line += 1
+
+        if @line == @lines.size
+          break
+        end
+
+        next
+      end
+
+      @renderer.text line.byte_slice(Math.min(line.bytesize, 2))
+      @line += 1
+
+      if @line == @lines.size
+        break
+      end
+    end
 
     @renderer.end_quote
 

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -203,7 +203,7 @@ class Markdown::Parser
 
       line = @lines[@line]
       text = line.byte_slice(Math.min(line.bytesize, 2)).strip
-      text = " " + text unless oneline_quote
+      text = "\n" + text unless oneline_quote
 
       if empty? text
         @line += 1


### PR DESCRIPTION
fix broken blockquote style with [multi blockquote](https://daringfireball.net/projects/markdown/syntax#blockquote):

```markdown
> This spawns
> multiple
> lines
> text
```

before:
```html
<blockquote>This spawns\n> multiple\n> lines\n> text</blockquote>
```

after:
```html
<blockquote>This spawns multiple lines text</blockquote>
```