### PR TITLE
Compiler: use Colorize.on_tty_only!

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -115,8 +115,13 @@ __has_colors() {
     return 1
   fi
 }
+if __has_colors && [ -t 1 ] && [ -t 2 ]; then
+  SUPPORTS_COLORS=true
+else
+  SUPPORTS_COLORS=false
+fi
 __error_msg() {
-  if __has_colors; then
+  if $SUPPORTS_COLORS; then
     # bold red coloring
     printf '%b\n' "\033[31;1m$@\033[0m" 1>&2
   else
@@ -124,7 +129,7 @@ __error_msg() {
   fi
 }
 __warning_msg() {
-  if __has_colors; then
+  if $SUPPORTS_COLORS; then
     # brown coloring
     printf '%b\n' "\033[33m$@\033[0m" 1>&2
   else

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -115,8 +115,8 @@ Dump LLVM assembly file to output directory.
 Pass additional flags to the linker. Though you can specify those flags on the source code, this is useful for passing environment specific information directly to the linker, like non-standard library paths or names. For more information on specifying linker flags on source, you can read the "C bindings" section of the documentation available on the official web site.
 .It Fl -mcpu Ar CPU
 Specify the name of the processor. This will pass a --mcpu flag to LLVM, and is only intended to be used for cross-compilation.
-.It Fl -color Ar [auto|always|never]
-Enable colored output. --color (i.e. without [auto|always|never]) is the same as --color=always.
+.It Fl -color Ar auto|always|never
+Enable colored output.
 .It Fl -no-color
 Disable colored output. It is the same as --color=never.
 .It Fl -no-codegen

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -111,12 +111,14 @@ Comma separated list of types of output for the compiler to emit. You can use th
 Format of output. Defaults to text. The json format can be used to get a more parser-friendly output.
 .It Fl -ll
 Dump LLVM assembly file to output directory.
-.It Fl -link-flags FLAGS
+.It Fl -link-flags Ar FLAGS
 Pass additional flags to the linker. Though you can specify those flags on the source code, this is useful for passing environment specific information directly to the linker, like non-standard library paths or names. For more information on specifying linker flags on source, you can read the "C bindings" section of the documentation available on the official web site.
-.It Fl -mcpu CPU
-Specify the name of the processor. This will pass a -mcpu flag to LLVM, and is only intended to be used for cross-compilation.
+.It Fl -mcpu Ar CPU
+Specify the name of the processor. This will pass a --mcpu flag to LLVM, and is only intended to be used for cross-compilation.
+.It Fl -color Ar [auto|always|never]
+Enable colored output. --color (i.e. without [auto|always|never]) is the same as --color=always.
 .It Fl -no-color
-Disable colored output.
+Disable colored output. It is the same as --color=never.
 .It Fl -no-codegen
 Don't do code generation, just parse the file.
 .It Fl o

--- a/spec/compiler/semantic/did_you_mean_spec.cr
+++ b/spec/compiler/semantic/did_you_mean_spec.cr
@@ -237,8 +237,6 @@ describe "Semantic: did you mean" do
   end
 
   it "suggests a better alternative to logical operators (#2715)" do
-    message = "undefined method 'and'"
-    message = " (did you mean '&&'?)".colorize.yellow.bold.to_s
     assert_error %(
       def rand(x : Int32)
       end
@@ -252,7 +250,7 @@ describe "Semantic: did you mean" do
       if "a".bytes and 1
         1
       end
-      ), message
+      ), "did you mean '&&'"
   end
 
   it "says did you mean in instance var declaration" do

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -636,7 +636,9 @@ describe "Semantic: generic class" do
     begin
       semantic(nodes)
     rescue ex : TypeException
+      old_enabled, Colorize.enabled = Colorize.enabled?, false
       msg = ex.to_s.lines.map(&.strip)
+      Colorize.enabled = old_enabled
       msg.count("- Foo(T).foo(x : Int32)").should eq(1)
     end
   end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -520,8 +520,7 @@ class Crystal::Command
   end
 
   private def color_option(opts)
-    opts.on("--color [auto|always|never]", "Enable colored output") do |color|
-      color = "always" if color.empty?
+    opts.on("--color auto|always|never", "Enable colored output") do |color|
       case color
       when "auto"
         Colorize.on_tty_only!

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -359,13 +359,7 @@ class Crystal::Command
         end
       end
 
-      opts.on("--color", "Enable colored output") do
-        Colorize.enabled = true
-      end
-
-      opts.on("--no-color", "Disable colored output") do
-        Colorize.enabled = false
-      end
+      color_option opts
 
       unless no_codegen
         opts.on("--no-codegen", "Don't do code generation") do
@@ -512,12 +506,7 @@ class Crystal::Command
       puts opts
       exit
     end
-    opts.on("--color", "Enable colored output") do
-      Colorize.enabled = true
-    end
-    opts.on("--no-color", "Disable colored output") do
-      Colorize.enabled = false
-    end
+    color_option opts
     opts.invalid_option { }
   end
 
@@ -530,6 +519,26 @@ class Crystal::Command
     values
   end
 
+  private def color_option(opts)
+    opts.on("--color [auto|always|never]", "Enable colored output") do |color|
+      color = "always" if color.empty?
+      case color
+      when "auto"
+        Colorize.on_tty_only!
+      when "always"
+        Colorize.enabled = true
+      when "never"
+        Colorize.enabled = false
+      else
+        error "invalid color option: #{color}"
+      end
+    end
+
+    opts.on("--no-color", "Disable colored output") do
+      Colorize.enabled = false
+    end
+  end
+
   private def error(msg, exit_code = 1)
     # This is for the case where the main command is wrong
     ARGV.each do |arg|
@@ -538,7 +547,7 @@ class Crystal::Command
         break
       when "--color"
         Colorize.enabled = true
-      when "--no-color"
+      when "--no-color", "--color=never"
         Colorize.enabled = false
       end
     end

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -34,8 +34,12 @@ class Crystal::Command
           exit
         end
 
+        opts.on("--color", "Enable colored output") do
+          Colorize.enabled = true
+        end
+
         opts.on("--no-color", "Disable colored output") do
-          @color = false
+          Colorize.enabled = false
         end
       end
 
@@ -85,8 +89,8 @@ class Crystal::Command
 
       print result
     rescue ex : InvalidByteSequenceError
-      STDERR.print "Error: ".colorize.toggle(@color).red.bold
-      STDERR.print "source is not a valid Crystal source file: ".colorize.toggle(@color).bold
+      STDERR.print "Error: ".colorize.red.bold
+      STDERR.print "source is not a valid Crystal source file: ".colorize.bold
       STDERR.puts ex.message
       exit 1
     rescue ex : Crystal::SyntaxException
@@ -112,8 +116,8 @@ class Crystal::Command
 
       File.write(filename, result)
     rescue ex : InvalidByteSequenceError
-      STDERR.print "Error: ".colorize.toggle(@color).red.bold
-      STDERR.print "file '#{Crystal.relative_filename(filename)}' is not a valid Crystal source file: ".colorize.toggle(@color).bold
+      STDERR.print "Error: ".colorize.red.bold
+      STDERR.print "file '#{Crystal.relative_filename(filename)}' is not a valid Crystal source file: ".colorize.bold
       STDERR.puts ex.message
       exit 1
     rescue ex : Crystal::SyntaxException
@@ -159,21 +163,21 @@ class Crystal::Command
         check_files << FormatResult.new(filename, FormatResult::Code::FORMAT)
       else
         File.write(filename, result)
-        STDOUT << "Format".colorize(:green).toggle(@color) << " " << filename << "\n"
+        STDOUT << "Format".colorize(:green) << " " << filename << "\n"
       end
     rescue ex : InvalidByteSequenceError
       if check_files
         check_files << FormatResult.new(filename, FormatResult::Code::INVALID_BYTE_SEQUENCE)
       else
-        STDERR.print "Error: ".colorize.toggle(@color).red.bold
-        STDERR.print "file '#{Crystal.relative_filename(filename)}' is not a valid Crystal source file: ".colorize.toggle(@color).bold
+        STDERR.print "Error: ".colorize.red.bold
+        STDERR.print "file '#{Crystal.relative_filename(filename)}' is not a valid Crystal source file: ".colorize.bold
         STDERR.puts ex.message
       end
     rescue ex : Crystal::SyntaxException
       if check_files
         check_files << FormatResult.new(filename, FormatResult::Code::SYNTAX)
       else
-        STDERR << "Syntax Error:".colorize(:yellow).toggle(@color) << " " << ex.message << " at " << filename << ":" << ex.line_number << ":" << ex.column_number << "\n"
+        STDERR << "Syntax Error:".colorize(:yellow) << " " << ex.message << " at " << filename << ":" << ex.line_number << ":" << ex.column_number << "\n"
       end
     rescue ex
       if check_files
@@ -186,7 +190,7 @@ class Crystal::Command
   end
 
   private def couldnt_format(file, ex = nil)
-    STDERR << "Error: ".colorize(:red).toggle(@color)
+    STDERR << "Error: ".colorize(:red)
 
     if ex
       STDERR.puts "couldn't format #{file}, please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues"

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -60,7 +60,7 @@ class Crystal::Command
       end
     end
 
-    unless @color
+    unless Colorize.enabled?
       options << "--no-color"
     end
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -58,9 +58,6 @@ module Crystal
     # Sets the mattr (features). Check LLVM docs to learn about this.
     property mattr : String?
 
-    # If `false`, color won't be used in output messages.
-    property? color = true
-
     # If `true`, skip cleanup process on semantic analysis.
     property? no_cleanup = false
 
@@ -183,7 +180,6 @@ module Crystal
       program.flags << "static" if static?
       program.flags.concat @flags
       program.wants_doc = wants_doc?
-      program.color = color?
       program.stdout = stdout
       program.show_error_trace = show_error_trace?
       program.progress_tracker = @progress_tracker
@@ -215,8 +211,8 @@ module Crystal
       parser.wants_doc = wants_doc?
       parser.parse
     rescue ex : InvalidByteSequenceError
-      stderr.print colorize("Error: ").red.bold
-      stderr.print colorize("file '#{Crystal.relative_filename(source.filename)}' is not a valid Crystal source file: ").bold
+      stderr.print "Error: ".colorize.red.bold
+      stderr.print "file '#{Crystal.relative_filename(source.filename)}' is not a valid Crystal source file: ".colorize.bold
       stderr.puts ex.message
       exit 1
     end
@@ -468,7 +464,7 @@ module Crystal
         TargetMachine.create(triple, @mcpu || "", @mattr || "", @release)
       end
     rescue ex : ArgumentError
-      stderr.print colorize("Error: ").red.bold
+      stderr.print "Error: ".colorize.red.bold
       stderr.print "llc: "
       stderr.puts ex.message
       exit 1
@@ -518,11 +514,7 @@ module Crystal
     end
 
     private def error(msg, exit_code = 1)
-      Crystal.error msg, @color, exit_code, stderr: stderr
-    end
-
-    private def colorize(obj)
-      obj.colorize.toggle(@color)
+      Crystal.error msg, exit_code, stderr: stderr
     end
 
     # An LLVM::Module with information to compile it.

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -3,8 +3,6 @@ require "colorize"
 
 module Crystal
   abstract class Exception < ::Exception
-    property? color = false
-
     @filename : String | VirtualFile | Nil
 
     def to_s(io)
@@ -44,14 +42,6 @@ module Crystal
 
     def relative_filename(filename)
       Crystal.relative_filename(filename)
-    end
-
-    def colorize(obj)
-      obj.colorize.toggle(@color)
-    end
-
-    def with_color
-      ::with_color.toggle(@color)
     end
 
     def replace_leading_tabs_with_spaces(line)

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -67,9 +67,6 @@ module Crystal
     # If `true`, doc comments are attached to types and methods.
     property? wants_doc = false
 
-    # If `true`, error messages can be colorized
-    property? color = true
-
     # All required files. The set stores absolute files. This way
     # files loaded by `require` nodes are only processed once.
     getter requires = Set(String).new
@@ -499,12 +496,6 @@ module Crystal
     def new_temp_var_name
       @temp_var_counter += 1
       "__temp_#{@temp_var_counter}"
-    end
-
-    # Colorizes the given object, depending on whether this program
-    # is configured to use colors.
-    def colorize(obj)
-      obj.colorize.toggle(@color)
     end
 
     private def abstract_value_type(type)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -29,7 +29,7 @@ class Crystal::Path
 
     similar_name = type.lookup_similar_path(self)
     if similar_name
-      self.raise("undefined constant #{self} #{type.program.colorize("(did you mean '#{similar_name}')").yellow.bold}")
+      self.raise("undefined constant #{self} #{"(did you mean '#{similar_name}')".colorize.yellow.bold}")
     else
       self.raise("undefined constant #{self}")
     end
@@ -101,15 +101,15 @@ class Crystal::Call
         end
 
         if obj && obj.type != owner
-          msg << colorize(" (compile-time type is #{obj.type})").yellow.bold
+          msg << " (compile-time type is #{obj.type})".colorize.yellow.bold
         end
 
         if similar_name
           if similar_name == def_name
             # This check is for the case `a if a = 1`
-            msg << colorize(" (If you declared '#{def_name}' in a suffix if, declare it in a regular if for this to work. If the variable was declared in a macro it's not visible outside it)").yellow.bold
+            msg << " (If you declared '#{def_name}' in a suffix if, declare it in a regular if for this to work. If the variable was declared in a macro it's not visible outside it)".colorize.yellow.bold
           else
-            msg << colorize(" (did you mean '#{similar_name}'?)").yellow.bold
+            msg << " (did you mean '#{similar_name}'?)".colorize.yellow.bold
           end
         end
 
@@ -121,9 +121,9 @@ class Crystal::Call
           if deps && deps.size == 1 && deps.first.same?(program.nil_var)
             similar_name = scope.lookup_similar_instance_var_name(ivar.name)
             if similar_name
-              msg << colorize(" (#{ivar.name} was never assigned a value, did you mean #{similar_name}?)").yellow.bold
+              msg << " (#{ivar.name} was never assigned a value, did you mean #{similar_name}?)".colorize.yellow.bold
             else
-              msg << colorize(" (#{ivar.name} was never assigned a value)").yellow.bold
+              msg << " (#{ivar.name} was never assigned a value)".colorize.yellow.bold
             end
           end
         end
@@ -135,7 +135,7 @@ class Crystal::Call
 
     # If it's on an initialize method and there's a similar method name, it's probably a typo
     if (def_name == "initialize" || def_name == "new") && (similar_def = owner.instance_type.lookup_similar_def("initialize", self.args.size, block))
-      inner_msg = colorize("do you maybe have a typo in this '#{similar_def.name}' method?").yellow.bold.to_s
+      inner_msg = "do you maybe have a typo in this '#{similar_def.name}' method?".colorize.yellow.bold.to_s
       inner_exception = TypeException.for_node(similar_def, inner_msg)
     end
 
@@ -387,10 +387,10 @@ class Crystal::Call
       str << "\n - "
       append_def_full_name a_def.owner, a_def, arg_types, str
       if defs.size > 1 && a_def.same?(matched_def)
-        str << colorize(" (trying this one)").blue
+        str << " (trying this one)".colorize.blue
       end
       if a_def.args.any? { |arg| arg.default_value && arg.external_name == argument_name }
-        str << colorize(" (did you mean this one?)").yellow.bold
+        str << " (did you mean this one?)".colorize.yellow.bold
       end
     end
   end
@@ -550,7 +550,7 @@ class Crystal::Call
           str << named_arg.name
           str << "'"
           if similar_name
-            str << colorize(" (did you mean '#{similar_name}'?)").yellow.bold
+            str << " (did you mean '#{similar_name}'?)".colorize.yellow.bold
           end
 
           defs = owner.lookup_defs(a_def.name)
@@ -651,9 +651,5 @@ class Crystal::Call
     else
       "#{owner}##{method_name}"
     end
-  end
-
-  private def colorize(obj)
-    program.colorize(obj)
   end
 end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -9,11 +9,6 @@ module Crystal
     @column : Int32
     @size : Int32
 
-    def color=(color)
-      @color = !!color
-      inner.try &.color=(color)
-    end
-
     def self.for_node(node, message, inner = nil)
       location = node.location
       if location
@@ -104,7 +99,7 @@ module Crystal
         end
       when VirtualFile
         io << "in macro '#{filename.macro.name}' #{filename.macro.location.try &.filename}:#{filename.macro.location.try &.line_number}, line #{@line}:\n\n"
-        io << Crystal.with_line_numbers(filename.source, @line, @color)
+        io << Crystal.with_line_numbers(filename.source, @line)
         is_macro = true
       else
         lines = source ? source.lines.to_a : nil
@@ -141,7 +136,7 @@ module Crystal
       if @inner
         io << msg
       else
-        io << colorize(msg).bold
+        io << msg.colorize.bold
       end
     end
 
@@ -224,14 +219,14 @@ module Crystal
     end
 
     def print_nil_reason(nil_reason, io)
-      io << colorize("Error: ").bold
+      io << "Error: ".colorize.bold
       case nil_reason.reason
       when :used_before_initialized
-        io << colorize("instance variable '#{nil_reason.name}' was used before it was initialized in one of the 'initialize' methods, rendering it nilable").bold
+        io << "instance variable '#{nil_reason.name}' was used before it was initialized in one of the 'initialize' methods, rendering it nilable".colorize.bold
       when :used_self_before_initialized
-        io << colorize("'self' was used before initializing instance variable '#{nil_reason.name}', rendering it nilable").bold
+        io << "'self' was used before initializing instance variable '#{nil_reason.name}', rendering it nilable".colorize.bold
       when :initialized_in_rescue
-        io << colorize("instance variable '#{nil_reason.name}' is initialized inside a begin-rescue, so it can potentially be left uninitialized if an exception is raised and rescued").bold
+        io << "instance variable '#{nil_reason.name}' is initialized inside a begin-rescue, so it can potentially be left uninitialized if an exception is raised and rescued".colorize.bold
       end
     end
 
@@ -307,7 +302,7 @@ module Crystal
       common = String.build do |str|
         str << "Can't infer the type of global variable '#{node.name}'"
         if similar_name
-          str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
+          str << " (did you mean #{similar_name}?)".colorize.yellow.bold.to_s
         end
       end
 
@@ -325,7 +320,7 @@ module Crystal
       common = String.build do |str|
         str << "Can't infer the type of class variable '#{node.name}' of #{owner.devirtualize}"
         if similar_name
-          str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
+          str << " (did you mean #{similar_name}?)".colorize.yellow.bold.to_s
         end
       end
 
@@ -343,7 +338,7 @@ module Crystal
       common = String.build do |str|
         str << "Can't infer the type of instance variable '#{node.name}' of #{owner.devirtualize}"
         if similar_name
-          str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
+          str << " (did you mean #{similar_name}?)".colorize.yellow.bold.to_s
         end
       end
 

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -27,9 +27,9 @@ module Crystal
 
     def append_to_s(source, io)
       if @filename
-        io << "Syntax error in #{relative_filename(@filename)}:#{@line_number}: #{colorize(@message).bold}"
+        io << "Syntax error in #{relative_filename(@filename)}:#{@line_number}: #{@message.colorize.bold}"
       else
-        io << "Syntax error in line #{@line_number}: #{colorize(@message).bold}"
+        io << "Syntax error in line #{@line_number}: #{@message.colorize.bold}"
       end
 
       source = fetch_source(source)

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -54,7 +54,6 @@ module Crystal::Playground
 
       output_filename = tempfile "play-#{@session_key}-#{tag}"
       compiler = Compiler.new
-      compiler.color = false
       begin
         @logger.info "Instrumented code compilation started (session=#{@session_key}, tag=#{tag})."
         result = compiler.compile sources, output_filename

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -261,10 +261,6 @@ module Crystal
       yield
       @indents.pop
     end
-
-    def with_color
-      ::with_color.toggle(@program.color?)
-    end
   end
 
   class JSONHierarchyPrinter < HierarchyPrinter

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -17,9 +17,9 @@ module Crystal
     filename
   end
 
-  def self.error(msg, color, exit_code = 1, stderr = STDERR)
-    stderr.print "Error: ".colorize.toggle(color).red.bold
-    stderr.puts msg.colorize.toggle(color).bright
+  def self.error(msg, exit_code = 1, stderr = STDERR)
+    stderr.print "Error: ".colorize.red.bold
+    stderr.puts msg.colorize.bright
     exit(exit_code) if exit_code
   end
 
@@ -27,16 +27,12 @@ module Crystal
     CacheDir.instance.join("crystal-run-#{basename}.tmp")
   end
 
-  def self.with_line_numbers(source : String, highlight_line_number = nil, color = false)
+  def self.with_line_numbers(source : String, highlight_line_number = nil)
     source.lines.map_with_index do |line, i|
       str = "#{"%4d" % (i + 1)}. #{line.to_s.chomp}"
       target = i + 1 == highlight_line_number
       if target
-        if color
-          str = ">".colorize.green.bold.to_s + str[1..-1].colorize.bold.to_s
-        else
-          str = ">" + str[1..-1]
-        end
+        str = ">".colorize.green.bold.to_s + str[1..-1].colorize.bold.to_s
       end
       str
     end.join "\n"


### PR DESCRIPTION
`Colorize.on_tty_only!` is introduced in #4271, but it is not used in compiler. I think it is useful that colorize is turned on/off depending on tty detection result.

In addition, I fixed `bin/crystal` wrapper script to detect TTY. `bin/crystal` script's `SUPPORTS_COLORS` is really buggy, at least it isn't working correct now.