### PR TITLE
Refactor time platform specific implementation

### DIFF
--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -6,7 +6,7 @@ module Crystal
       # Returns the number of seconds that you must add to UTC to get local time.
       # def self.compute_utc_offset(second)
 
-      # Returns the current utc time meassured from unix epoch in `{seconds, tenth_microsecond}`
+      # Returns the current utc time meassured in absolute `{seconds, tenth_microsecond}`
       # def self.compute_utc_second_and_tenth_microsecond
     end
   end

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -1,0 +1,22 @@
+# :nodoc:
+module Crystal
+  # :nodoc:
+  module System
+    # :nodoc:
+    module Time
+      TicksPerMillisecond = 10_000_i64
+      TicksPerSecond      = TicksPerMillisecond * 1000
+      TicksPerMinute      = TicksPerSecond * 60
+      TicksPerHour        = TicksPerMinute * 60
+      TicksPerDay         = TicksPerHour * 24
+
+      # Returns the number of ticks that you must add to UTC to get local time.
+      # def self.compute_offset(second)
+
+      # Returns the current system time meassured from unix epoch.
+      # def self.compute_second_and_tenth_microsecond
+    end
+  end
+end
+
+require "./unix/time"

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -4,7 +4,8 @@ module Crystal
     # :nodoc:
     module Time
       # Returns the number of seconds that you must add to UTC to get local time.
-      # def self.compute_utc_offset(second)
+      # *seconds* are absolutes.
+      # def self.compute_utc_offset(seconds)
 
       # Returns the current utc time meassured in absolute `{seconds, tenth_microsecond}`
       # def self.compute_utc_second_and_tenth_microsecond

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -1,20 +1,13 @@
-# :nodoc:
 module Crystal
   # :nodoc:
   module System
     # :nodoc:
     module Time
-      TicksPerMillisecond = 10_000_i64
-      TicksPerSecond      = TicksPerMillisecond * 1000
-      TicksPerMinute      = TicksPerSecond * 60
-      TicksPerHour        = TicksPerMinute * 60
-      TicksPerDay         = TicksPerHour * 24
+      # Returns the number of seconds that you must add to UTC to get local time.
+      # def self.compute_utc_offset(second)
 
-      # Returns the number of ticks that you must add to UTC to get local time.
-      # def self.compute_offset(second)
-
-      # Returns the current system time meassured from unix epoch.
-      # def self.compute_second_and_tenth_microsecond
+      # Returns the current utc time meassured from unix epoch in `{seconds, tenth_microsecond}`
+      # def self.compute_utc_second_and_tenth_microsecond
     end
   end
 end

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -5,11 +5,11 @@ module Crystal
     module Time
       # Returns the number of seconds that you must add to UTC to get local time.
       # *seconds* are measured from `0001-01-01 00:00:00`.
-      # def self.compute_utc_offset(seconds)
+      # def self.compute_utc_offset(seconds : Int64) : Int64
 
       # Returns the current UTC time measured in `{seconds, tenth_microsecond}`
       # since `0001-01-01 00:00:00`.
-      # def self.compute_utc_second_and_tenth_microsecond
+      # def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
     end
   end
 end

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -4,10 +4,11 @@ module Crystal
     # :nodoc:
     module Time
       # Returns the number of seconds that you must add to UTC to get local time.
-      # *seconds* are absolutes.
+      # *seconds* are measured from `0001-01-01 00:00:00`.
       # def self.compute_utc_offset(seconds)
 
-      # Returns the current utc time meassured in absolute `{seconds, tenth_microsecond}`
+      # Returns the current UTC time measured in `{seconds, tenth_microsecond}`
+      # since `0001-01-01 00:00:00`.
       # def self.compute_utc_second_and_tenth_microsecond
     end
   end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -2,7 +2,7 @@ require "c/sys/time"
 require "c/time"
 
 module Crystal::System::Time
-  def self.compute_offset(second)
+  def self.compute_utc_offset(second)
     LibC.tzset
     offset = nil
 
@@ -20,10 +20,10 @@ module Crystal::System::Time
       offset = tm.tm_gmtoff.to_i64
     end
 
-    offset / 60 * TicksPerMinute
+    offset
   end
 
-  def self.compute_second_and_tenth_microsecond
+  def self.compute_utc_second_and_tenth_microsecond
     {% if flag?(:darwin) %}
       ret = LibC.gettimeofday(out timeval, nil)
       raise Errno.new("gettimeofday") unless ret == 0

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -27,14 +27,14 @@ module Crystal::System::Time
   end
 
   def self.compute_utc_second_and_tenth_microsecond
-    {% if flag?(:darwin) %}
-      ret = LibC.gettimeofday(out timeval, nil)
-      raise Errno.new("gettimeofday") unless ret == 0
-      {timeval.tv_sec + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
-    {% else %}
+    {% if LibC.methods.includes?("clock_gettime".id) %}
       ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
       raise Errno.new("clock_gettime") unless ret == 0
       {timespec.tv_sec.to_i64 + UnixEpochInSeconds, timespec.tv_nsec / 100}
+    {% else %}
+      ret = LibC.gettimeofday(out timeval, nil)
+      raise Errno.new("gettimeofday") unless ret == 0
+      {timeval.tv_sec + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
     {% end %}
   end
 end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -4,7 +4,7 @@ require "c/time"
 module Crystal::System::Time
   UnixEpochInSeconds = 62135596800_i64
 
-  def self.compute_utc_offset(seconds)
+  def self.compute_utc_offset(seconds : Int64) : Int64
     LibC.tzset
     offset = nil
 
@@ -26,7 +26,7 @@ module Crystal::System::Time
     offset
   end
 
-  def self.compute_utc_second_and_tenth_microsecond
+  def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
     {% if LibC.methods.includes?("clock_gettime".id) %}
       ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
       raise Errno.new("clock_gettime") unless ret == 0
@@ -34,7 +34,7 @@ module Crystal::System::Time
     {% else %}
       ret = LibC.gettimeofday(out timeval, nil)
       raise Errno.new("gettimeofday") unless ret == 0
-      {timeval.tv_sec + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
+      {timeval.tv_sec.to_i64 + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
     {% end %}
   end
 end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -2,6 +2,8 @@ require "c/sys/time"
 require "c/time"
 
 module Crystal::System::Time
+  UnixEpochInSeconds = 62135596800_i64
+
   def self.compute_utc_offset(second)
     LibC.tzset
     offset = nil
@@ -27,11 +29,11 @@ module Crystal::System::Time
     {% if flag?(:darwin) %}
       ret = LibC.gettimeofday(out timeval, nil)
       raise Errno.new("gettimeofday") unless ret == 0
-      {timeval.tv_sec, timeval.tv_usec.to_i64 * 10}
+      {timeval.tv_sec + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
     {% else %}
       ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
       raise Errno.new("clock_gettime") unless ret == 0
-      {timespec.tv_sec, timespec.tv_nsec / 100}
+      {timespec.tv_sec + UnixEpochInSeconds, timespec.tv_nsec / 100}
     {% end %}
   end
 end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -1,0 +1,37 @@
+require "c/sys/time"
+require "c/time"
+
+module Crystal::System::Time
+  def self.compute_offset(second)
+    LibC.tzset
+    offset = nil
+
+    {% if LibC.methods.includes?("daylight".id) %}
+      if LibC.daylight == 0
+        # current TZ doesn't have any DST, neither in past, present or future
+        offset = -LibC.timezone.to_i64
+      end
+    {% end %}
+
+    unless offset
+      # current TZ may have DST, either in past, present or future
+      ret = LibC.localtime_r(pointerof(second), out tm)
+      raise Errno.new("localtime_r") if ret.null?
+      offset = tm.tm_gmtoff.to_i64
+    end
+
+    offset / 60 * TicksPerMinute
+  end
+
+  def self.compute_second_and_tenth_microsecond
+    {% if flag?(:darwin) %}
+      ret = LibC.gettimeofday(out timeval, nil)
+      raise Errno.new("gettimeofday") unless ret == 0
+      {timeval.tv_sec, timeval.tv_usec.to_i64 * 10}
+    {% else %}
+      ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
+      raise Errno.new("clock_gettime") unless ret == 0
+      {timespec.tv_sec, timespec.tv_nsec / 100}
+    {% end %}
+  end
+end

--- a/src/time.cr
+++ b/src/time.cr
@@ -1,5 +1,4 @@
-require "c/sys/time"
-require "c/time"
+require "crystal/system/time"
 
 # `Time` represents an instance in time. Here are some examples:
 #
@@ -602,36 +601,11 @@ struct Time
   end
 
   private def self.compute_offset(second)
-    LibC.tzset
-    offset = nil
-
-    {% if LibC.methods.includes?("daylight".id) %}
-      if LibC.daylight == 0
-        # current TZ doesn't have any DST, neither in past, present or future
-        offset = -LibC.timezone.to_i64
-      end
-    {% end %}
-
-    unless offset
-      # current TZ may have DST, either in past, present or future
-      ret = LibC.localtime_r(pointerof(second), out tm)
-      raise Errno.new("localtime_r") if ret.null?
-      offset = tm.tm_gmtoff.to_i64
-    end
-
-    offset / 60 * Span::TicksPerMinute
+    Crystal::System::Time.compute_offset(second)
   end
 
   private def self.compute_second_and_tenth_microsecond
-    {% if flag?(:darwin) %}
-      ret = LibC.gettimeofday(out timeval, nil)
-      raise Errno.new("gettimeofday") unless ret == 0
-      {timeval.tv_sec, timeval.tv_usec.to_i64 * 10}
-    {% else %}
-      ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
-      raise Errno.new("clock_gettime") unless ret == 0
-      {timespec.tv_sec, timespec.tv_nsec / 100}
-    {% end %}
+    Crystal::System::Time.compute_second_and_tenth_microsecond
   end
 end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -601,11 +601,11 @@ struct Time
   end
 
   private def self.compute_offset(second)
-    Crystal::System::Time.compute_offset(second)
+    Crystal::System::Time.compute_utc_offset(second) / 60 * Span::TicksPerMinute
   end
 
   private def self.compute_second_and_tenth_microsecond
-    Crystal::System::Time.compute_second_and_tenth_microsecond
+    Crystal::System::Time.compute_utc_second_and_tenth_microsecond
   end
 end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -590,8 +590,7 @@ struct Time
   end
 
   private def self.compute_ticks(second, tenth_microsecond)
-    UnixEpoch +
-      second.to_i64 * Span::TicksPerSecond +
+    second.to_i64 * Span::TicksPerSecond +
       tenth_microsecond.to_i64
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -42,11 +42,11 @@ struct Time::Span
 
   include Comparable(self)
 
-  TicksPerMillisecond = 10_000_i64
-  TicksPerSecond      = TicksPerMillisecond * 1000
-  TicksPerMinute      = TicksPerSecond * 60
-  TicksPerHour        = TicksPerMinute * 60
-  TicksPerDay         = TicksPerHour * 24
+  TicksPerMillisecond = Crystal::System::Time::TicksPerMillisecond
+  TicksPerSecond      = Crystal::System::Time::TicksPerSecond
+  TicksPerMinute      = Crystal::System::Time::TicksPerMinute
+  TicksPerHour        = Crystal::System::Time::TicksPerHour
+  TicksPerDay         = Crystal::System::Time::TicksPerDay
 
   MaxValue = new Int64::MAX
   MinValue = new Int64::MIN

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -42,11 +42,11 @@ struct Time::Span
 
   include Comparable(self)
 
-  TicksPerMillisecond = Crystal::System::Time::TicksPerMillisecond
-  TicksPerSecond      = Crystal::System::Time::TicksPerSecond
-  TicksPerMinute      = Crystal::System::Time::TicksPerMinute
-  TicksPerHour        = Crystal::System::Time::TicksPerHour
-  TicksPerDay         = Crystal::System::Time::TicksPerDay
+  TicksPerMillisecond = 10_000_i64
+  TicksPerSecond      = TicksPerMillisecond * 1000
+  TicksPerMinute      = TicksPerSecond * 60
+  TicksPerHour        = TicksPerMinute * 60
+  TicksPerDay         = TicksPerHour * 24
 
   MaxValue = new Int64::MAX
   MinValue = new Int64::MIN


### PR DESCRIPTION
`Time::Span` ticks constants where moved to avoid circular dependency.