### PR TITLE
Fix current-stage compiler stats output

### DIFF
--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -15,6 +15,7 @@ module Crystal
     def stage(name)
       @current_stage_name = name
 
+      print_stats
       print_progress
 
       start_time = Time.now
@@ -37,13 +38,17 @@ module Crystal
       print "\r"
     end
 
-    def print_stats(time_taken)
+    def print_stats(time_taken = nil)
       return unless @stats
 
-      memory_usage_mb = GC.stats.heap_size / 1024.0 / 1024.0
-      memory_usage_str = " (%7.2fMB)" % {memory_usage_mb} if true # display_memory?
       justified_name = "#{current_stage_name}:".ljust(STAGE_PADDING)
-      puts "#{justified_name} #{time_taken}#{memory_usage_str}"
+      if time_taken
+        memory_usage_mb = GC.stats.heap_size / 1024.0 / 1024.0
+        memory_usage_str = " (%7.2fMB)" % {memory_usage_mb} if true # display_memory?
+        puts "#{justified_name} #{time_taken}#{memory_usage_str}"
+      else
+        print "#{justified_name}\r" unless @progress
+      end
     end
 
     def print_progress


### PR DESCRIPTION
Before be945b573, `--stats` output would print the current stage name while it was executing. This is useful for debugging compiler hangs and tracking the progress of the compiler without `--progress`. After that commit, the progress output would only print after the stage had fully completed, meaning you had to rely on `--progress` to track compiler progress.

This patch fixes this regression by printing the stage name (with no times or memory figures) before the stage starts and resetting the cursor to the beginning of the line. If both `--progress` and `--stats` are specified, this pre-stage line isn't printed as it would just be overwritten by `--progress` output anyway.