### PR TITLE
Fix Formatter ::Tuple(T)

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -97,6 +97,11 @@ describe Crystal::Formatter do
   assert_format "Foo( x:  Int32  )", "Foo(x: Int32)"
   assert_format "Foo( x:  Int32  ,  y: Float64 )", "Foo(x: Int32, y: Float64)"
 
+  assert_format "::Tuple(T)"
+  assert_format "::NamedTuple(T)"
+  assert_format "::Pointer(T)"
+  assert_format "::StaticArray(T)"
+
   %w(if unless).each do |keyword|
     assert_format "#{keyword} a\n2\nend", "#{keyword} a\n  2\nend"
     assert_format "#{keyword} a\n2\n3\nend", "#{keyword} a\n  2\n  3\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -986,6 +986,11 @@ module Crystal
       name = node.name
       first_name = name.global? && name.names.size == 1 && name.names.first
 
+      if name.global? && @token.type == :"::"
+        write "::"
+        next_token_skip_space_or_newline
+      end
+
       if node.question?
         node.type_vars[0].accept self
         write_token :"?"


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/4416

When formatting `::Tuple(T)` we need to write the `:"::"` token first.  This also affects `::Pointer(T)`, `::NamedTuple(T)`, and `::StaticArray(T)`