### PR TITLE
Fix negative digit precision for `Number#round`

### DIFF
--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -60,6 +60,7 @@ describe "Number" do
       523.round(-3).should eq(1000)
 
       123.456.round(-2).should eq(100)
+      123_456.123456.round(-5).should eq(100_000)
       753.155.round(-5, base: 2).should eq(768)
     end
   end

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -53,6 +53,15 @@ describe "Number" do
       123.round(2).should eq(123)
       123.round(2).should be_a(Int32)
     end
+
+    it "accepts negative precision" do
+      123.round(-2).should eq(100)
+      123.round(-3).should eq(0)
+      523.round(-3).should eq(1000)
+
+      123.456.round(-2).should eq(100)
+      753.155.round(-5, base: 2).should eq(768)
+    end
   end
 
   describe "clamp" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -13,15 +13,15 @@ describe "Number" do
     end
 
     it "2 base " do
-      -1763.116.significant(2, base = 2).should eq(-1536.0)
-      753.155.significant(3, base = 2).should eq(768.0)
-      15.159.significant(1, base = 2).should eq(16.0)
+      -1763.116.significant(2, base: 2).should eq(-1536.0)
+      753.155.significant(3, base: 2).should eq(768.0)
+      15.159.significant(1, base: 2).should eq(16.0)
     end
 
     it "8 base " do
-      -1763.116.significant(2, base = 8).should eq(-1792.0)
-      753.155.significant(3, base = 8).should eq(752.0)
-      15.159.significant(1, base = 8).should eq(16.0)
+      -1763.116.significant(2, base: 8).should eq(-1792.0)
+      753.155.significant(3, base: 8).should eq(752.0)
+      15.159.significant(1, base: 8).should eq(16.0)
     end
 
     it "preserves type" do
@@ -38,15 +38,15 @@ describe "Number" do
     end
 
     it "2 base " do
-      -1763.116.round(2, base = 2).should eq(-1763.0)
-      753.155.round(2, base = 2).should eq(753.25)
-      15.159.round(2, base = 2).should eq(15.25)
+      -1763.116.round(2, base: 2).should eq(-1763.0)
+      753.155.round(2, base: 2).should eq(753.25)
+      15.159.round(2, base: 2).should eq(15.25)
     end
 
     it "8 base " do
-      -1763.116.round(2, base = 8).should eq(-1763.109375)
-      753.155.round(1, base = 8).should eq(753.125)
-      15.159.round(0, base = 8).should eq(15.0)
+      -1763.116.round(2, base: 8).should eq(-1763.109375)
+      753.155.round(1, base: 8).should eq(753.125)
+      15.159.round(0, base: 8).should eq(15.0)
     end
 
     it "preserves type" do

--- a/src/number.cr
+++ b/src/number.cr
@@ -211,9 +211,13 @@ struct Number
   # ```
   def round(digits, base = 10)
     x = self.to_f
-    base = base.to_f if digits < 0
-    y = base ** digits
-    self.class.new((x * y).round / y)
+    if digits < 0
+      y = base ** (digits * -1)
+      self.class.new((x / y).round * y)
+    else
+      y = base ** digits
+      self.class.new((x * y).round / y)
+    end
   end
 
   # Clamps a value within *range*.

--- a/src/number.cr
+++ b/src/number.cr
@@ -212,7 +212,7 @@ struct Number
   def round(digits, base = 10)
     x = self.to_f
     if digits < 0
-      y = base ** (digits * -1)
+      y = base ** (-digits)
       self.class.new((x / y).round * y)
     else
       y = base ** digits

--- a/src/number.cr
+++ b/src/number.cr
@@ -211,6 +211,7 @@ struct Number
   # ```
   def round(digits, base = 10)
     x = self.to_f
+    base = base.to_f if digits < 0
     y = base ** digits
     self.class.new((x * y).round / y)
   end


### PR DESCRIPTION
It is custom to call `Number#round` with a negative *digits* precision to round the integer part.

Calling `11.round(-1)` resulted in an error: `Cannot raise an integer to a negative integer power, use floats for that (ArgumentError)`.