### PR TITLE
Fixes a very minor comment typo in file_utils

### DIFF
--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -14,7 +14,7 @@ module FileUtils
     Dir.cd(path)
   end
 
-  # Changes the current working firectory of the process to the given string *path*
+  # Changes the current working directory of the process to the given string *path*
   # and invoked the block, restoring the original working directory when the block exits.
   #
   # ```


### PR DESCRIPTION
"directory" was misspelled as "firectory", and it was bugging me, so here's the most insignificant pull request of my career 👍 