### PR TITLE
Add codecov reporting to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - bin/ci build
 after_success:
   - bin/ci deploy
+  - bash <(curl -s https://codecov.io/bash) -s .build/coverage
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,14 @@
 
 LLVM_CONFIG ?= ## llvm-config command path to use
 
-release ?=      ## Compile in release mode
-stats ?=        ## Enable statistics output
-progress ?=     ## Enable progress output
-threads ?=      ## Maximum number of threads to use
-debug ?=        ## Add symbolic debug info
-verbose ?=      ## Run specs in verbose mode
-junit_output ?= ## Directory to output junit results
+release ?=         ## Compile in release mode
+stats ?=           ## Enable statistics output
+progress ?=        ## Enable progress output
+threads ?=         ## Maximum number of threads to use
+debug ?=           ## Add symbolic debug info
+verbose ?=         ## Run specs in verbose mode
+junit_output ?=    ## Directory to output junit results
+coverage_output ?= ## Directory to output coverage results
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
@@ -48,6 +49,7 @@ LIB_CRYSTAL_TARGET = src/ext/libcrystal.a
 DEPS = $(LLVM_EXT_OBJ) $(LIB_CRYSTAL_TARGET)
 CFLAGS += -fPIC $(if $(debug),-g -O0)
 CXXFLAGS += $(if $(debug),-g -O0)
+COVERAGE := $(if $(coverage_output),kcov --verify --include-path=. $(coverage_output) )
 
 ifeq (${LLVM_CONFIG},)
   $(error Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
@@ -77,15 +79,15 @@ help: ## Show this help
 
 .PHONY: spec
 spec: $(O)/all_spec ## Run all specs
-	$(O)/all_spec $(SPEC_FLAGS)
+	$(COVERAGE)$(O)/all_spec $(SPEC_FLAGS)
 
 .PHONY: std_spec
 std_spec: $(O)/std_spec ## Run standard library specs
-	$(O)/std_spec $(SPEC_FLAGS)
+	$(COVERAGE)$(O)/std_spec $(SPEC_FLAGS)
 
 .PHONY: compiler_spec
 compiler_spec: $(O)/compiler_spec ## Run compiler specs
-	$(O)/compiler_spec $(SPEC_FLAGS)
+	$(COVERAGE)$(O)/compiler_spec $(SPEC_FLAGS)
 
 .PHONY: doc
 doc: ## Generate standard library documentation

--- a/bin/ci
+++ b/bin/ci
@@ -84,7 +84,11 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean'
-  with_build_env 'make crystal std_spec compiler_spec doc'
+
+  with_build_env 'make crystal doc'
+  on_linux with_build_env 'make std_spec compiler_spec coverage_output=.build/coverage'
+  on_osx with_build_env 'make spec'
+
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check samples spec src'
 }
@@ -147,7 +151,7 @@ EOF
 prepare_build() {
   on_linux verify_linux_environment
 
-  on_linux docker pull "jhass/crystal-build-$ARCH"
+  on_linux docker pull "rx14/crystal-build-$ARCH"
 
   on_osx brew install llvm crystal-lang
 }
@@ -166,7 +170,7 @@ with_build_env() {
     -w /mnt \
     -e LIBRARY_PATH="/opt/crystal/embedded/lib/" \
     -e CRYSTAL_CACHE_DIR="/tmp/crystal" \
-    "jhass/crystal-build-$ARCH" \
+    "rx14/crystal-build-$ARCH" \
     "$ARCH_CMD" /bin/bash -c "'$command'"
 
   on_osx PATH="/usr/local/opt/llvm/bin:\$PATH" \


### PR DESCRIPTION
This is currently WIP. Depends on https://github.com/jhass/crystal-build-docker/pull/2. Doesn't currently work on OSX. Displays loads of errors to the build log.

This PR uses the [`kcov`](https://github.com/SimonKagstrom/kcov) tool to provide coverage reports on crystal code. Example output [here](https://codecov.io/gh/RX14/crystal/tree/b4f605866b03a7df40b5096f1649b47c9efcd8e4). I think there are bugs with the crystal debug line information, for example [this empty line of documentation](https://codecov.io/gh/RX14/crystal/src/b4f605866b03a7df40b5096f1649b47c9efcd8e4/src/string.cr#L28) got 37 hits. I've seen similar impossible debug information when profiling using callgrind + kcachegrind so I suspect the issue is with crystal not kcov. I will shortly create an issue in the kcov repo reporting the ld errors in the build log.