### PR TITLE
MatchData: improve error message when refer no matched existed capture group

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -28,13 +28,13 @@ describe "Regex::MatchData" do
 
     it "raises exception when named group doesn't exist" do
       ("foo" =~ /foo/).should eq(0)
-      expect_raises(KeyError, "'group' does not exist") { $~["group"] }
+      expect_raises(KeyError, "Capture group 'group' does not exist") { $~["group"] }
     end
 
     it "raises exception on optional empty group" do
       ("foo" =~ /(?<g1>z)?foo/).should eq(0)
-      expect_raises(IndexError, "Not matched capture group index: 1") { $~[1] }
-      expect_raises(KeyError, "'g1' is not matched") { $~["g1"] }
+      expect_raises(IndexError, "Capture group 1 was not matched") { $~[1] }
+      expect_raises(KeyError, "Capture group 'g1' was not matched") { $~["g1"] }
     end
 
     it "raises if outside match range with []" do
@@ -44,7 +44,7 @@ describe "Regex::MatchData" do
 
     it "raises if special variable accessed on invalid capture group" do
       "spice" =~ /spice(s)?/
-      expect_raises(IndexError, "Not matched capture group index: 1") { $1 }
+      expect_raises(IndexError, "Capture group 1 was not matched") { $1 }
       expect_raises(IndexError, "Invalid capture group index: 3") { $3 }
     end
   end

--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -26,15 +26,15 @@ describe "Regex::MatchData" do
       $~["g2"].should eq("ba")
     end
 
-    it "raises exception on optional empty group" do
-      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
-      expect_raises(Exception) { $~[1] }
-      expect_raises(Exception) { $~["g1"] }
-    end
-
     it "raises exception when named group doesn't exist" do
       ("foo" =~ /foo/).should eq(0)
-      expect_raises(ArgumentError) { $~["group"] }
+      expect_raises(ArgumentError, "'group' does not exist") { $~["group"] }
+    end
+
+    it "raises exception on optional empty group" do
+      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
+      expect_raises(IndexError, "Not matched capture group index: 1") { $~[1] }
+      expect_raises(ArgumentError, "'g1' is not matched") { $~["g1"] }
     end
 
     it "raises if outside match range with []" do
@@ -44,7 +44,7 @@ describe "Regex::MatchData" do
 
     it "raises if special variable accessed on invalid capture group" do
       "spice" =~ /spice(s)?/
-      expect_raises(IndexError, "Invalid capture group index: 1") { $1 }
+      expect_raises(IndexError, "Not matched capture group index: 1") { $1 }
       expect_raises(IndexError, "Invalid capture group index: 3") { $3 }
     end
   end

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -130,7 +130,7 @@ class Regex
     def [](n)
       check_index_out_of_bounds n
       value = self[n]?
-      raise_invalid_group_index(n) if value.nil?
+      raise_not_matched_group_index(n) if value.nil?
       value
     end
 
@@ -157,7 +157,12 @@ class Regex
     def [](group_name : String)
       match = self[group_name]?
       unless match
-        raise ArgumentError.new("Match group named '#{group_name}' does not exist")
+        ret = LibPCRE.get_stringnumber(@code, group_name)
+        if ret < 0
+          raise ArgumentError.new("Capture group named '#{group_name}' does not exist")
+        else
+          raise ArgumentError.new("Capture group named '#{group_name}' is not matched")
+        end
       end
       match
     end
@@ -229,6 +234,10 @@ class Regex
 
     private def raise_invalid_group_index(index)
       raise IndexError.new("Invalid capture group index: #{index}")
+    end
+
+    private def raise_not_matched_group_index(index)
+      raise IndexError.new("Not matched capture group index: #{index}")
     end
   end
 end

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -130,7 +130,7 @@ class Regex
     def [](n)
       check_index_out_of_bounds n
       value = self[n]?
-      raise_not_matched_group_index(n) if value.nil?
+      raise_capture_group_was_not_matched n if value.nil?
       value
     end
 
@@ -159,9 +159,9 @@ class Regex
       unless match
         ret = LibPCRE.get_stringnumber(@code, group_name)
         if ret < 0
-          raise KeyError.new("Capture group named '#{group_name}' does not exist")
+          raise KeyError.new("Capture group '#{group_name}' does not exist")
         else
-          raise KeyError.new("Capture group named '#{group_name}' is not matched")
+          raise KeyError.new("Capture group '#{group_name}' was not matched")
         end
       end
       match
@@ -321,8 +321,8 @@ class Regex
       raise IndexError.new("Invalid capture group index: #{index}")
     end
 
-    private def raise_not_matched_group_index(index)
-      raise IndexError.new("Not matched capture group index: #{index}")
+    private def raise_capture_group_was_not_matched(index)
+      raise IndexError.new("Capture group #{index} was not matched")
     end
   end
 end


### PR DESCRIPTION
For example, `"foo".match(/(?<g1>x)?foo/).not_nil!["g1"]` raises an exception with message `"Match group 'g1' does not exist"`, but group `"g1"` exists surely and it isn't matched on this matching. I think we can improve such an error message.