### PR TITLE
MatchData: raise KeyError instead of ArgumentError by #[](key: String)

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -34,7 +34,7 @@ describe "Regex::MatchData" do
 
     it "raises exception when named group doesn't exist" do
       ("foo" =~ /foo/).should eq(0)
-      expect_raises(ArgumentError) { $~["group"] }
+      expect_raises(KeyError) { $~["group"] }
     end
 
     it "raises if outside match range with []" do

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -148,16 +148,16 @@ class Regex
     end
 
     # Returns the match of the capture group named by *group_name*, or
-    # raises an `ArgumentError` if there is no such named capture group.
+    # raises an `KeyError` if there is no such named capture group.
     #
     # ```
     # "Crystal".match(/r(?<ok>ys)/).not_nil!["ok"] # => "ys"
-    # "Crystal".match(/r(?<ok>ys)/).not_nil!["ng"] # raises ArgumentError
+    # "Crystal".match(/r(?<ok>ys)/).not_nil!["ng"] # raises KeyError
     # ```
     def [](group_name : String)
       match = self[group_name]?
       unless match
-        raise ArgumentError.new("Match group named '#{group_name}' does not exist")
+        raise KeyError.new("Match group named '#{group_name}' does not exist")
       end
       match
     end


### PR DESCRIPTION
Currently `#[](key: String)` raises `ArgumentError`. Why? I think it should raise `KeyError` because it looks like `Hash` operation.