### PR TITLE
Drop XSS escaping because it should be aside HTML escaping. 

### DIFF
--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -10,9 +10,9 @@ describe "HTML" do
     end
 
     it "escapes dangerous characters from a string" do
-      str = HTML.escape("< & >")
+      str = HTML.escape("< & > \"")
 
-      str.should eq("&lt; &amp; &gt;")
+      str.should eq("&lt; &amp; &gt; &quot;")
     end
 
     it "escapes as documented in default mode" do
@@ -21,20 +21,14 @@ describe "HTML" do
       str.should eq("Crystal &amp; You")
     end
 
-    it "escapes characters according CGI mode" do
-      str = HTML.escape("< & '", HTML::EscapeMode::CGI)
+    it "escapes characters according no escape_quotes mode" do
+      str = HTML.escape("< & ' \"", escape_quotes: false)
 
-      str.should eq("&lt; &amp; '")
-    end
-
-    it "escapes characters according Default mode" do
-      str = HTML.escape("< & '")
-
-      str.should eq("&lt; &amp; &#27;")
+      str.should eq("&lt; &amp; ' \"")
     end
 
     it "escapes characters according OWASP recommendation" do
-      str = HTML.escape("\\/", HTML::EscapeMode::OWASP)
+      str = HTML.escape("\\/")
 
       str.should eq("\\&#2F;")
     end

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -22,15 +22,9 @@ describe "HTML" do
     end
 
     it "escapes characters according no escape_quotes mode" do
-      str = HTML.escape("< & ' \"", escape_quotes: false)
+      str = HTML.escape("< & ' \" \\", escape_quotes: false)
 
-      str.should eq("&lt; &amp; ' \"")
-    end
-
-    it "escapes characters according OWASP recommendation" do
-      str = HTML.escape("\\/")
-
-      str.should eq("\\&#2F;")
+      str.should eq("&lt; &amp; ' \" \\")
     end
   end
 

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -28,6 +28,26 @@ describe "HTML" do
     end
   end
 
+  describe ".escape_javascript" do
+    it "does not change a safe string" do
+      str = HTML.escape_javascript("safe_string")
+
+      str.should eq("safe_string")
+    end
+
+    it "escapes dangerous characters from a string" do
+      str = HTML.escape_javascript("</tag> \r\n \r \n \u2028 \u2029")
+
+      str.should eq("<\\/tag> \\n \\n \\n &#x2028; &#x2029;")
+    end
+
+    it "escapes dangerous characters from an IO" do
+      io = IO::Memory.new
+      HTML.escape_javascript("</tag> \r\n \r \n \u2028 \u2029", io).should be_nil
+      io.to_s.should eq("<\\/tag> \\n \\n \\n &#x2028; &#x2029;")
+    end
+  end
+
   describe ".unescape" do
     it "does not change a safe string" do
       str = HTML.unescape("safe_string")

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -9,7 +9,7 @@ describe "HTML" do
       str.should eq("safe_string")
     end
 
-    it "escapes dangerous characters from a string" do
+    it "escapes special characters from an HTML string" do
       str = HTML.escape("< & > \"")
 
       str.should eq("&lt; &amp; &gt; &quot;")
@@ -35,13 +35,13 @@ describe "HTML" do
       str.should eq("safe_string")
     end
 
-    it "escapes dangerous characters from a string" do
+    it "escapes special characters from a JavaScript string" do
       str = HTML.escape_javascript("</tag> \r\n \r \n \u2028 \u2029")
 
       str.should eq("<\\/tag> \\n \\n \\n &#x2028; &#x2029;")
     end
 
-    it "escapes dangerous characters from an IO" do
+    it "escapes special characters from a JavaScript IO" do
       io = IO::Memory.new
       HTML.escape_javascript("</tag> \r\n \r \n \u2028 \u2029", io).should be_nil
       io.to_s.should eq("<\\/tag> \\n \\n \\n &#x2028; &#x2029;")

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -15,14 +15,26 @@ describe "HTML" do
       str.should eq("&lt; &amp; &gt;")
     end
 
-    it "escapes javascript example from a string" do
-      str = HTML.escape("<script>alert('You are being hacked')</script>")
+    it "escapes as documented in default mode" do
+      str = HTML.escape("Crystal & You")
 
-      str.should eq("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;/script&gt;")
+      str.should eq("Crystal &amp; You")
+    end
+
+    it "escapes as documented in XSS mode" do
+      str = HTML.escape("Crystal = Me", HTML::EscapeMode::XSS)
+
+      str.should eq("Crystal &#61; Me")
+    end
+
+    it "escapes javascript example from a string" do
+      str = HTML.escape("<script>alert('You are being hacked')</script>", HTML::EscapeMode::XSS)
+
+      str.should eq("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;&#2F;script&gt;")
     end
 
     it "escapes nonbreakable space but not normal space" do
-      str = HTML.escape("nbsp space ")
+      str = HTML.escape("nbsp space ", HTML::EscapeMode::XSS)
 
       str.should eq("nbsp&nbsp;space ")
     end

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -21,22 +21,22 @@ describe "HTML" do
       str.should eq("Crystal &amp; You")
     end
 
-    it "escapes as documented in XSS mode" do
-      str = HTML.escape("Crystal = Me", HTML::EscapeMode::XSS)
+    it "escapes characters according CGI mode" do
+      str = HTML.escape("< & '", HTML::EscapeMode::CGI)
 
-      str.should eq("Crystal &#61; Me")
+      str.should eq("&lt; &amp; '")
     end
 
-    it "escapes javascript example from a string" do
-      str = HTML.escape("<script>alert('You are being hacked')</script>", HTML::EscapeMode::XSS)
+    it "escapes characters according Default mode" do
+      str = HTML.escape("< & '")
 
-      str.should eq("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;&#2F;script&gt;")
+      str.should eq("&lt; &amp; &#27;")
     end
 
-    it "escapes nonbreakable space but not normal space" do
-      str = HTML.escape("nbsp space ", HTML::EscapeMode::XSS)
+    it "escapes characters according OWASP recommendation" do
+      str = HTML.escape("\\/", HTML::EscapeMode::OWASP)
 
-      str.should eq("nbsp&nbsp;space ")
+      str.should eq("\\&#2F;")
     end
   end
 

--- a/src/html.cr
+++ b/src/html.cr
@@ -19,11 +19,11 @@ module HTML
     },
     # Like Python html.escape, Phoenix Phoenix.HTML, Go html.EscapeString, Django, Jinja, W3C recommendation.
     EscapeMode::Default => {
-      '&' => "&amp;",
-      '"' => "&quot;",
+      '&'  => "&amp;",
+      '"'  => "&quot;",
       '\'' => "&#27;",
-      '<' => "&lt;",
-      '>' => "&gt;",
+      '<'  => "&lt;",
+      '>'  => "&gt;",
     },
     # Like Ruby CGI.escape, PHP htmlspecialchars (with ENT_QUOTES), Rack::Utils.escape_html, OWASP recommendation.
     #

--- a/src/html.cr
+++ b/src/html.cr
@@ -10,6 +10,8 @@ module HTML
       '<' => "&lt;",
       '>' => "&gt;",
     },
+    # Escapes '&', '<' and '>', '"' and '\'' chars.
+    #
     # Like Ruby CGI.escape, PHP htmlspecialchars (with ENT_QUOTES), Rack::Utils.escape_html.
     true => {
       '&'  => "&amp;",

--- a/src/html.cr
+++ b/src/html.cr
@@ -1,34 +1,19 @@
 # Handles encoding and decoding of HTML entities.
 module HTML
   # `HTML.escape` escaping mode.
-  enum EscapeMode
-    # Escapes '&', '<' and '>' chars.
-    CGI,
-    # Escapes '&', '"', '\'', '<' and '>' chars.
-    Default,
-    # Escapes a XSS chars according to OWASP recommendation, rule 1.
-    OWASP,
-  end
-
   ESCAPE_SUBST = {
+    # Escapes '&', '<' and '>' chars.
+    #
     # Like PHP htmlspecialchars (with ENT_NOQUOTES), Python cgi.escape, W3C recommendation.
-    EscapeMode::CGI => {
+    false => {
       '&' => "&amp;",
       '<' => "&lt;",
       '>' => "&gt;",
     },
-    # Like Python html.escape, Phoenix Phoenix.HTML, Go html.EscapeString, Django, Jinja, W3C recommendation.
-    EscapeMode::Default => {
-      '&'  => "&amp;",
-      '"'  => "&quot;",
-      '\'' => "&#27;",
-      '<'  => "&lt;",
-      '>'  => "&gt;",
-    },
     # Like Ruby CGI.escape, PHP htmlspecialchars (with ENT_QUOTES), Rack::Utils.escape_html, OWASP recommendation.
     #
     # https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
-    EscapeMode::OWASP => {
+    true => {
       '&'  => "&amp;",
       '"'  => "&quot;",
       '<'  => "&lt;",
@@ -45,8 +30,8 @@ module HTML
   #
   # HTML.escape("Crystal & You") # => "Crystal &amp; You"
   # ```
-  def self.escape(string : String, mode : EscapeMode = EscapeMode::Default) : String
-    string.gsub(ESCAPE_SUBST[mode])
+  def self.escape(string : String, escape_quotes : Bool = true) : String
+    string.gsub(ESCAPE_SUBST[escape_quotes])
   end
 
   # Encodes a string to HTML, but writes to the `IO` instance provided.
@@ -56,8 +41,8 @@ module HTML
   # HTML.escape("Crystal & You", io) # => nil
   # io.to_s                          # => "Crystal &amp; You"
   # ```
-  def self.escape(string : String, io : IO, mode : EscapeMode = EscapeMode::Default)
-    subst = ESCAPE_SUBST[mode]
+  def self.escape(string : String, io : IO, escape_quotes : Bool = true)
+    subst = ESCAPE_SUBST[escape_quotes]
     string.each_char do |char|
       io << subst.fetch(char, char)
     end

--- a/src/html.cr
+++ b/src/html.cr
@@ -10,16 +10,13 @@ module HTML
       '<' => "&lt;",
       '>' => "&gt;",
     },
-    # Like Ruby CGI.escape, PHP htmlspecialchars (with ENT_QUOTES), Rack::Utils.escape_html, OWASP recommendation.
-    #
-    # https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
+    # Like Ruby CGI.escape, PHP htmlspecialchars (with ENT_QUOTES), Rack::Utils.escape_html.
     true => {
       '&'  => "&amp;",
       '"'  => "&quot;",
       '<'  => "&lt;",
       '>'  => "&gt;",
       '\'' => "&#27;",
-      '/'  => "&#2F;",
     },
   }
 

--- a/src/html.cr
+++ b/src/html.cr
@@ -61,7 +61,7 @@ module HTML
   # ```
   # require "html"
   #
-  # HTML.escape_javascript("</crystal> \u2028") # => ""<\\/crystal> &#x2028;""
+  # HTML.escape_javascript("</crystal> \u2028") # => "<\\/crystal> &#x2028;"
   # ```
   def self.escape_javascript(string : String) : String
     string.gsub("\r\n", "\n").gsub(ESCAPE_JAVASCRIPT_SUBST).gsub("</", "<\\/")


### PR DESCRIPTION
Introduce escape_quotes mode.

Fixes #3233, refs #2175.

Thanks to @straight-shoota for clarification. Cite:

> The current implementation is not escaping HTML, but rather Javascript (inside HTML). Therefore it should be named differently (like escape_xss or escape_javascript like in Phoenix and Rails). Whether and how this should be in stdlib is a different issue.