### PR TITLE
Fix: IO::FileDescriptor#seek from current position

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -621,6 +621,13 @@ describe "File" do
     file.gets(4).should eq("ello")
   end
 
+  it "seeks from the current position" do
+    file = File.new("#{__DIR__}/data/test_file.txt")
+    file.gets(5)
+    file.seek(-4, IO::Seek::Current)
+    file.tell.should eq(1)
+  end
+
   it "raises if invoking seek with a closed file" do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.close

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -131,7 +131,9 @@ class IO::FileDescriptor
     check_open
 
     flush
+    offset -= @in_buffer_rem.size if whence.current?
     seek_value = LibC.lseek(@fd, offset, whence)
+
     if seek_value == -1
       raise Errno.new "Unable to seek"
     end


### PR DESCRIPTION
Trying to seek from the current position failed because the system position of a buffered IO is different from the actual position in Crystal land. For example reading 4 bytes from a File actually reads up to BUFFER_SIZE bytes. Seeking back 4 bytes should return to position `0`, but since the system read more bytes, it ended up at an unexpected place.