### PR TITLE
Parser: correct to parse '/' following do as regex

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -358,6 +358,10 @@ describe "Parser" do
   it_parses "1.x; foo do\nend", [Call.new(1.int32, "x"), Call.new(nil, "foo", block: Block.new)] of ASTNode
   it_parses "x = 1; foo.bar x do\nend", [Assign.new("x".var, 1.int32), Call.new("foo".call, "bar", ["x".var] of ASTNode, Block.new)]
 
+  it_parses "foo do\n//\nend", Call.new(nil, "foo", [] of ASTNode, Block.new(body: regex("")))
+  it_parses "foo x do\n//\nend", Call.new(nil, "foo", ["x".call] of ASTNode, Block.new(body: regex("")))
+  it_parses "foo(x) do\n//\nend", Call.new(nil, "foo", ["x".call] of ASTNode, Block.new(body: regex("")))
+
   it_parses "foo !false", Call.new(nil, "foo", [Not.new(false.bool)] of ASTNode)
   it_parses "!a && b", And.new(Not.new("a".call), "b".call)
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3743,6 +3743,7 @@ module Crystal
       arg_index = 0
       splat_index = nil
 
+      slash_is_regex!
       next_token_skip_space
       if @token.type == :"|"
         next_token_skip_space_or_newline


### PR DESCRIPTION
Fixed #4547 

#4547 is a mere parser bug. This example is failed on 0.22.0:

```crystal
def foo(x)
  yield
end

foo(1) do
  //
end
```

Thank you.