### PR TITLE
MatchData: support negative index

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -32,6 +32,14 @@ describe "Regex::MatchData" do
       $~["g2"].should eq("ba")
     end
 
+    it "can use negative index" do
+      "foo" =~ /(f)(oo)/
+      $~[-1].should eq("oo")
+      $~[-2].should eq("f")
+      $~[-3].should eq("foo")
+      expect_raises(IndexError, "Invalid capture group index: -4") { $~[-4] }
+    end
+
     it "raises exception when named group doesn't exist" do
       ("foo" =~ /foo/).should eq(0)
       expect_raises(KeyError, "Capture group 'group' does not exist") { $~["group"] }
@@ -72,6 +80,14 @@ describe "Regex::MatchData" do
       ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
       $~["g1"]?.should eq("oo")
       $~["g2"]?.should eq("ba")
+    end
+
+    it "can use negative index" do
+      "foo" =~ /(b)?(f)(oo)/
+      $~[-1]?.should eq("oo")
+      $~[-2]?.should eq("f")
+      $~[-3]?.should be_nil
+      $~[-4]?.should eq("foo")
     end
 
     it "returns nil exception when named group doesn't exist" do

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -94,6 +94,7 @@ class Regex
     # ```
     def byte_begin(n = 0)
       check_index_out_of_bounds n
+      n += size if n < 0
       @ovector[n * 2]
     end
 
@@ -109,6 +110,7 @@ class Regex
     # ```
     def byte_end(n = 0)
       check_index_out_of_bounds n
+      n += size if n < 0
       @ovector[n * 2 + 1]
     end
 
@@ -125,6 +127,7 @@ class Regex
     def []?(n)
       return unless valid_group?(n)
 
+      n += size if n < 0
       start = @ovector[n * 2]
       finish = @ovector[n * 2 + 1]
       return if start < 0
@@ -140,6 +143,8 @@ class Regex
     # ```
     def [](n)
       check_index_out_of_bounds n
+      n += size if n < 0
+
       value = self[n]?
       raise_capture_group_was_not_matched n if value.nil?
       value
@@ -324,7 +329,7 @@ class Regex
     end
 
     private def valid_group?(index)
-      index < size
+      -size <= index < size
     end
 
     private def raise_invalid_group_index(index)


### PR DESCRIPTION
Now it works:

```crystal
m = "foo".match(/(f)(oo)/).not_nil!
m[-1] # => "oo"
m[-2] # => "f"
m[-3] # => "foo"
```