### PR TITLE
Introduce crystal --stdin-filename source flag

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -137,6 +137,8 @@ Maximum number of threads to use for code generation. The default is 8 threads.
 Enable target triple; intended to use for cross-compilation. See llvm documentation for more information about target triple.
 .It Fl -verbose
 Display the commands executed by the system.
+.It Fl -stdin-filename Ar FILENAME
+Source file name to be read from STDIN.
 .El
 
 .Pp


### PR DESCRIPTION
 to compile source from STDIN, closes #4561.

## Synopsys

```bash
cat src/math/math.cr | ./bin/crystal build --no-codegen --no-color -o /dev/null -f json --stdin-filename src/math/math.cr
```

```javascript
[{"file":"src/math/math.cr","line":6,"column":3,"size":2,"message":"already initialized constant Math::PI"}]
```
