### PR TITLE
MatchData: implement specialized pretty_print

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -13,6 +13,17 @@ describe "Regex::MatchData" do
     /fox/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox">))
   end
 
+  it "does pretty_print" do
+    /f(o)(x)/.match("the fox").pretty_inspect.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
+    /(?<first>f)(?<second>o(?<third>o(?<fourth>o(?<fifth>o))))/.match("fooooo").pretty_inspect.should eq(%(#<Regex::MatchData
+ "foooo"
+ first:"f"
+ second:"oooo"
+ third:"ooo"
+ fourth:"oo"
+ fifth:"o">))
+  end
+
   it "does size" do
     "Crystal".match(/[p-s]/).not_nil!.size.should eq(1)
     "Crystal".match(/r(ys)/).not_nil!.size.should eq(2)

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -303,6 +303,27 @@ class Regex
       io << ">"
     end
 
+    def pretty_print(pp) : Nil
+      name_table = @regex.name_table
+
+      pp.surround("#<Regex::MatchData", ">", left_break: nil, right_break: nil) do
+        size.times do |i|
+          pp.breakable
+          pp.group do
+            if i == 0
+              self[i].pretty_print pp
+            else
+              pp.text "#{name_table.fetch(i) { i }}:"
+              pp.nest do
+                pp.breakable ""
+                self[i].pretty_print pp
+              end
+            end
+          end
+        end
+      end
+    end
+
     def dup
       self
     end


### PR DESCRIPTION
`Regex::MatchData#inspect` is overriding `Struct#inspect` and it have structural output, so I think `pretty_print` should be overriding also.