### PR TITLE
Semantic: report block result mismatch on method instantiate

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -245,6 +245,21 @@ describe "Block inference" do
       "type must be Float64"
   end
 
+  it "reports error on method instantiate (#4543)" do
+    assert_error %(
+      class Foo
+        @foo = 42
+
+        def initialize(&block : -> Int32)
+          @foo = yield
+        end
+      end
+
+      Foo.new { 42u32 }
+      ),
+      "expected block to return Int32, not UInt32"
+  end
+
   it "matches block arg return type" do
     assert_type("
       class Foo(T)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -870,7 +870,7 @@ class Crystal::Call
           match.context.def_free_vars = match.def.free_vars
           matched = block_type.restrict(output, match.context)
           if (!matched || (matched && !block_type.implements?(matched))) && !void_return_type?(match.context, output)
-            if output.is_a?(ASTNode) && !output.is_a?(Underscore)
+            if output.is_a?(ASTNode) && !output.is_a?(Underscore) && block_type.no_return?
               begin
                 block_type = lookup_node_type(match.context, output).virtual_type
               rescue ex : Crystal::Exception


### PR DESCRIPTION
It's a bug in point of error message.

Fixed #4543