### PR TITLE
Minor macro interpreter "identify". tr("c", "x") is always slower than gsubs.

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -601,7 +601,7 @@ module Crystal
           StringLiteral.new(value.gsub(regex, second.value))
         end
       when "identify"
-        interpret_argless_method(method, args) { StringLiteral.new(@value.tr(":", "_")) }
+        interpret_argless_method(method, args) { StringLiteral.new(@value.gsub(":", "_")) }
       when "includes?"
         interpret_one_arg_method(method, args) do |arg|
           case arg


### PR DESCRIPTION
```
  tr single char string   4.38M (228.22ns) (± 1.14%)  1.50× slower
       gsub single char    5.0M (200.19ns) (± 2.18%)  1.31× slower
gsub single char string   6.56M (152.52ns) (± 4.08%)       fastest
```

String.gsub("c", "x") faster in all cases (nonexistent character to replace etc.).