### PR TITLE
Semantic: specify Void alias type as yiled output restriction

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -766,6 +766,20 @@ describe "Block inference" do
       )) { int32 }
   end
 
+  it "ignores void return type (4)" do
+    assert_type(%(
+      alias Alias = Void
+
+      def foo(&block : -> Alias)
+        yield
+      end
+
+      foo do
+        1
+      end
+      )) { int32 }
+  end
+
   it "uses block return type as return type, even if can't infer block type" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -917,7 +917,7 @@ class Crystal::Call
 
   private def void_return_type?(match_context, output)
     if output.is_a?(Path)
-      type = match_context.defining_type.lookup_path(output)
+      type = lookup_node_type(match_context, output)
     else
       type = output
     end


### PR DESCRIPTION
You'll see Crystal's bizarre behavior.

These examples can work:

1. ```crystal
   def foo(&block : -> Void)
     yield
   end

   foo { 1 }
    ```

2. ```crystal
   def foo(&block : -> Void)
     block.call
   end

   foo { 1 }
   ```

3. ```crystal
   alias Foo = Void
   def foo(&block : -> Foo)
     block.call
   end

   foo { 1 }
   ```

However, this example fails with an error: "expected block to return Void, not Int32".

```crystal
alias Foo = Void
def foo(&block : -> Foo)
  yield
end

foo { 1 }
```

This PR fixes it.