### PR TITLE
Parser: fix #4590, correct to parse empty parenthesis "()"

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -32,6 +32,9 @@ describe Crystal::Formatter do
   assert_format ":foo"
   assert_format ":\"foo\""
 
+  assert_format "()"
+  assert_format "(())"
+
   assert_format "1"
   assert_format "1   ;    2", "1; 2"
   assert_format "1   ;\n    2", "1\n2"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -960,7 +960,7 @@ describe "Parser" do
   it_parses "@a = uninitialized Foo", UninitializedVar.new("@a".instance_var, "Foo".path)
   it_parses "@@a = uninitialized Foo", UninitializedVar.new("@@a".class_var, "Foo".path)
 
-  it_parses "()", NilLiteral.new
+  it_parses "()", Expressions.new([Nop.new] of ASTNode)
   it_parses "(1; 2; 3)", [1.int32, 2.int32, 3.int32] of ASTNode
 
   it_parses "begin; rescue; end", ExceptionHandler.new(Nop.new, [Rescue.new])

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1581,7 +1581,9 @@ module Crystal
       next_token_skip_space_or_newline
 
       if @token.type == :")"
-        return node_and_next_token NilLiteral.new
+        node = Expressions.new([Nop.new] of ASTNode)
+        node.keyword = :"("
+        return node_and_next_token node
       end
 
       exps = [] of ASTNode


### PR DESCRIPTION
Currently "()" is parsed as `NilLiteral`, but it loses parenthesis information and it produces a formatter bug (#4590).

Correct to parse "()" as `Expressions` whose keyword property is `:"("` and which contains `Nop` only. This looks like empty begin block. Also formatter works fine.