### PR TITLE
Fix: use platform specific Pointer sizes

### DIFF
--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -1,6 +1,6 @@
 lib Intrinsics
   fun debugtrap = "llvm.debugtrap"
-  {% if flag?(:x86_64) %}
+  {% if flag?(:x86_64) || flag?(:aarch64) %}
     fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)


### PR DESCRIPTION
The current implementation uses UInt64 for pointer allocation sizes, but UInt32 for operating on pointer sizes (memcpy, memmove, memset) despite using the 64 bit LLVM intrinsics; and was illogical: if we allocate a large section of memory, we must be able to zero and copy/move it, whereas 32bit platforms should deal with UInt32, the maximum possible value, not larger ones.

This patch proposes to constraint to a platform specific size only (i.e. `LibC::SizeT`) in order to always use UInt32 on 32 bit platforms, and UInt64 on 64 bit platforms.

We cannot clamp sizes to Int32::MAX, because some allocations (e.g. `Array(Int32).new(Int32::MAX))` can be larger than allowed.

Alternatively we could disallow such allocations, thus allowing to clamp the allocation sizes? I mean, that's 2 million entries; the example array above with `T=Int32` would be 8GB; with `T=Int32|Int64` that's 32GB... Yet, since it could end up being an issue with external C programs, I (reluctantly) admit we should allow a platform specific sizes.

This patch also fixes the use of 64bit variants of LLVM intrinsics on AArch64 (memcpy, memmove, memset).

Fixes #4589 