### PR TITLE
Enum.to_sym for regular enums.

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -33,6 +33,26 @@ describe Enum do
     end
   end
 
+  describe "to_sym" do
+    it "for simple enum" do
+      SpecEnum::One.to_sym.should eq(:one)
+      SpecEnum::Two.to_sym.should eq(:two)
+      SpecEnum::Three.to_sym.should eq(:three)
+      SpecEnum.new(Int8::MAX).to_sym.should eq(:unknown)
+    end
+
+    it "for enum with complex identifiers" do
+      SpecEnum2::FourtyTwo.to_sym.should eq(:fourty_two)
+      SpecEnum2::FOURTY_FOUR.to_sym.should eq(:fourty_four)
+    end
+
+    it "for flags enum" do
+      SpecEnumFlags::None.to_sym.should eq(:flags)
+      SpecEnumFlags::All.to_sym.should eq(:flags)
+      (SpecEnumFlags::One | SpecEnumFlags::Two).to_sym.should eq(:flags)
+    end
+  end
+
   it "gets value" do
     SpecEnum::Two.value.should eq(1)
     SpecEnum::Two.value.should be_a(Int8)

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -145,6 +145,36 @@ struct Enum
     {% end %}
   end
 
+  # Returns a `Symbol` representation of this enum member.
+  # This is just the symbol of the underscored name of the member.
+  # In the case of flag enums, the :flags is returned as a symbol.
+  #
+  # If an enum's value doesn't match a member's value, the :unknown
+  # is returned as a symbol.
+  #
+  # ```
+  # Color::Red.to_sym                     # => :red
+  # Color::Green.to_sym                   # => :green
+  # IOMode::None.to_sym                   # => :flags
+  # (IOMode::Read | IOMode::Write).to_sym # => :flags
+  #
+  # Color.new(10).to_sym # => :unknown
+  # ```
+  def to_sym : Symbol
+    {% if @type.has_attribute?("Flags") %}
+      :flags
+    {% else %}
+      case value
+        {% for member in @type.constants %}
+        when {{@type}}::{{member}}.value
+          :{{member.stringify.underscore}}
+        {% end %}
+        else
+          :unknown
+      end
+    {% end %}
+  end
+
   # Returns the value of this enum member as an `Int32`.
   #
   # ```


### PR DESCRIPTION
It's useful to write expressions like that: 

```crystal
value = Color::Red

case value.to_sym
  when :red
     "wine"
  when :green
     "absinthe"
end
```

I wanted it to simplify expressions like

```crystal
when Cldr::Core::CalendarSystem::Lunisolar
   "oh no"
end
``` 

P.S.: There is no easy way to apply this to flags.