### PR TITLE
Pretty-print objects in playground inspector

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -47,10 +47,10 @@ describe Playground::Agent do
   it "should send json messages and return inspected value" do
     agent = TestAgent.new(".", 32)
     agent.i(1) { 5 }.should eq(5)
-    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"5",html_value:"5","value_type":"Int32"}))
+    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"5","html_value":"5","value_type":"Int32"}))
     x, y = 3, 4
     agent.i(1, ["x", "y"]) { {x, y} }.should eq({3, 4})
-    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"{3, 4}","value_type":"Tuple(Int32, Int32)","data":{"x":"3","y":"4"}}))
+    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"{3, 4}","html_value":"{3, 4}","value_type":"Tuple(Int32, Int32)","data":{"x":"3","y":"4"}}))
   end
 end
 

--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -47,7 +47,7 @@ describe Playground::Agent do
   it "should send json messages and return inspected value" do
     agent = TestAgent.new(".", 32)
     agent.i(1) { 5 }.should eq(5)
-    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"5","value_type":"Int32"}))
+    agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"5",html_value:"5","value_type":"Int32"}))
     x, y = 3, 4
     agent.i(1, ["x", "y"]) { {x, y} }.should eq({3, 4})
     agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"{3, 4}","value_type":"Tuple(Int32, Int32)","data":{"x":"3","y":"4"}}))

--- a/src/compiler/crystal/tools/playground/agent.cr
+++ b/src/compiler/crystal/tools/playground/agent.cr
@@ -55,10 +55,7 @@ class Crystal::Playground::Agent
   end
 
   def to_html_value(value)
-    value
-      .pretty_inspect
-      .gsub("&", "&amp;") # HTML-sanitize
-      .gsub("<", "&lt;")
+    HTML.escape(value.pretty_inspect)
   end
 
   private def send(message_type)

--- a/src/compiler/crystal/tools/playground/agent.cr
+++ b/src/compiler/crystal/tools/playground/agent.cr
@@ -25,6 +25,7 @@ class Crystal::Playground::Agent
     send "value" do |json|
       json.field "line", line
       json.field "value", safe_to_value(value)
+      json.field "html_value", safe_to_html_value(value)
       json.field "value_type", typeof(value).to_s
 
       if names && value.is_a?(Tuple)
@@ -45,8 +46,21 @@ class Crystal::Playground::Agent
     to_value(value) rescue "(error)"
   end
 
+  def safe_to_html_value(value)
+    to_html_value(value) rescue "(error)"
+  end
+
   def to_value(value)
     value.inspect
+  end
+
+  def to_html_value(value)
+    value
+      .pretty_inspect
+      .gsub("&", "&amp;") # HTML-sanitize
+      .gsub("<", "&lt;")
+      .gsub(/\n/, "<br/>")
+      .gsub(/ /, "&nbsp;")
   end
 
   private def send(message_type)

--- a/src/compiler/crystal/tools/playground/agent.cr
+++ b/src/compiler/crystal/tools/playground/agent.cr
@@ -59,8 +59,6 @@ class Crystal::Playground::Agent
       .pretty_inspect
       .gsub("&", "&amp;") # HTML-sanitize
       .gsub("<", "&lt;")
-      .gsub(/\n/, "<br/>")
-      .gsub(/ /, "&nbsp;")
   end
 
   private def send(message_type)

--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -190,7 +190,7 @@ Playground.Inspector = function(session, line) {
       row.append($("<td>").text(message.data[labels[j]]));
     }
 
-    row.append($("<td>").text(message.value));
+    row.append($("<td>").html("<pre><code>" + message.html_value + "</code></pre>"));
     row.append($("<td>").text(message.value_type));
     tableBody.append(row);
   }


### PR DESCRIPTION
I'd noticed that complex objects in the playground inspector weren't very easy to read:

![Screenshot before this PR](https://user-images.githubusercontent.com/108205/27366041-a5036a42-5611-11e7-9e02-5679bb6c4821.png)

So I hacked out something quickly to make them a bit easier on the eyes:

![Screenshot with this PR](https://user-images.githubusercontent.com/108205/27366045-a844ede8-5611-11e7-9b83-d9d3c3423fbc.png)

Known issues:
- This introduces a horizontal scroll to that table for very complex objects like the one I posted
  - Possible solutions:
    - Reduce the pretty-print width
    - Make only that column of the table scroll horizontally (I think this is possible, anyway)
- Syntax highlighting (even just for class names, ivars, numbers, and strings, similar to Pry) would improve readability even further

I noticed that the contribution guide says I should open an issue before a PR, but I'd already written the code by then. :-) I did want to get feedback on this before I go much further with it, though.