### PR TITLE
String: implement Rabin-Karp algorithm for #byte_index

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -797,7 +797,12 @@ describe "String" do
     it { "foo".byte_index('a'.ord).should be_nil }
 
     it "gets byte index of string" do
+      "hello world".byte_index("he").should eq(0)
       "hello world".byte_index("lo").should eq(3)
+      "hello world".byte_index("world", 7).should be_nil
+      "foo foo".byte_index("oo").should eq(1)
+      "foo foo".byte_index("oo", 2).should eq(5)
+      "こんにちは世界".byte_index("ちは").should eq(9)
     end
   end
 


### PR DESCRIPTION
@asterite My tomorrow comes after five months! (https://github.com/crystal-lang/crystal/pull/3876#issuecomment-272176357) Sorry.

Benchmark is here: https://gist.github.com/MakeNowJust/363ae118b266e77e576a828acaad59a0

And my result:

```
$ crystal run --release byte_index_bench.cr
For long string:
     naive 641.16  (  1.56ms) (± 7.60%)  2.06× slower
rabin_karp   1.32k (757.07µs) (± 7.69%)       fastest
For short string:
     naive   3.33M (299.87ns) (±12.33%)  1.78× slower
rabin_karp   5.95M (168.18ns) (±14.56%)       fastest
```

`String#index`: #3873 
`String#rindex`: #3876 
