### PR TITLE
[WIP] Fix memset, memcpy, memmove calls on Pointer type.

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -242,7 +242,7 @@ struct Pointer(T)
     raise ArgumentError.new("Negative count") if count < 0
 
     if self.class == source.class
-      Intrinsics.memcpy(self.as(Void*), source.as(Void*), (count * sizeof(T)).to_u32, 0_u32, false)
+      Intrinsics.memcpy(self.as(Void*), source.as(Void*), count * sizeof(T), 0_u32, false)
     else
       while (count -= 1) >= 0
         self[count] = source[count]
@@ -255,7 +255,7 @@ struct Pointer(T)
     raise ArgumentError.new("Negative count") if count < 0
 
     if self.class == source.class
-      Intrinsics.memmove(self.as(Void*), source.as(Void*), (count * sizeof(T)).to_u32, 0_u32, false)
+      Intrinsics.memmove(self.as(Void*), source.as(Void*), count * sizeof(T), 0_u32, false)
     else
       if source.address < address
         copy_from source, count
@@ -496,7 +496,7 @@ struct Pointer(T)
   # ```
   def clear(count = 1)
     ptr = self.as(Pointer(Void))
-    Intrinsics.memset(self.as(Void*), 0_u8, (count * sizeof(T)).to_u32, 0_u32, false)
+    Intrinsics.memset(self.as(Void*), 0_u8, count * sizeof(T), 0_u32, false)
   end
 
   def clone


### PR DESCRIPTION
Just note that it's short fix for #4589 only.

No generic SizeT, OffsetT introduced here.