### PR TITLE
On macro run error: show status, stdout and stderr

### DIFF
--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -95,6 +95,10 @@ module Colorize
   def self.on_tty_only!
     self.enabled = STDOUT.tty? && STDERR.tty?
   end
+
+  def self.reset(io = STDOUT)
+    io << "\e[0m" if enabled?
+  end
 end
 
 def with_color
@@ -329,6 +333,6 @@ struct Colorize::Object(T)
   end
 
   protected def append_end(io)
-    io << "\e[0m"
+    Colorize.reset(io)
   end
 end

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -87,13 +87,16 @@ class Crystal::Program
     end
   end
 
+  record MacroRunResult, stdout : String, stderr : String, status : Process::Status
+
   def macro_run(filename, args)
     compiled_macro_run = @compiled_macros_cache[filename] ||= macro_compile(filename)
     compiled_file = compiled_macro_run.filename
 
-    io = IO::Memory.new
-    Process.run(compiled_file, args: args, shell: true, output: io)
-    {$?.success?, io.to_s}
+    out_io = IO::Memory.new
+    err_io = IO::Memory.new
+    Process.run(compiled_file, args: args, shell: true, output: out_io, error: err_io)
+    MacroRunResult.new(out_io.to_s, err_io.to_s, $?)
   end
 
   record RequireWithTimestamp, filename : String, epoch : Int64 do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -211,11 +211,46 @@ module Crystal
         run_args << @last.to_macro_id
       end
 
-      success, result = @program.macro_run(filename, run_args)
-      if success
-        @last = MacroId.new(result)
+      result = @program.macro_run(filename, run_args)
+      if result.status.success?
+        @last = MacroId.new(result.stdout)
       else
-        node.raise "Error executing run: #{original_filename} #{run_args.map(&.inspect).join " "}\n\nGot:\n\n#{result}\n"
+        command = "#{original_filename} #{run_args.map(&.inspect).join " "}"
+
+        message = IO::Memory.new
+        message << "Error executing run (exit code: #{result.status.exit_code}): #{command}\n"
+
+        if result.stdout.empty? && result.stderr.empty?
+          message << "\nGot no output."
+        else
+          Colorize.reset(message)
+
+          unless result.stdout.empty?
+            message.puts
+            message << "stdout:".colorize.mode(:bold)
+            message.puts
+            message.puts
+            result.stdout.each_line do |line|
+              message << "    "
+              message << line
+            end
+            message << '\n'
+          end
+
+          unless result.stderr.empty?
+            message.puts
+            message << "stderr:".colorize.mode(:bold)
+            message.puts
+            message.puts
+            result.stderr.each_line do |line|
+              message << "    "
+              message << line
+            end
+            message << '\n'
+          end
+        end
+
+        node.raise message.to_s
       end
     end
   end


### PR DESCRIPTION
First PR to display more information about a failing macro run.
Another PR might come to display the errors without the backtrace from `ecr/processor` to properly resolve #4577 

Given thoses files:
```cr
# processor.cr

def func
  raise "Some exception happened" # This will always fail
end

puts %(puts "some stuff on stdout")

begin
  func
rescue e
  STDERR.puts "ERROR: #{e}"
  exit 1
end
```
```cr
# test_run.cr

{{ run "./processor" }}
```
Compilation will give:
```
$ crystal ./test_run.cr
Error in test_run.cr:1: expanding macro

{{ run "./processor" }}
^

in test_run.cr:1: Error executing run (exit code: 1): ./processor 

---- Got on stdout: ----

puts "some stuff on stdout"


---- Got on stderr: ----

ERROR: Some exception happened



{{ run "./processor" }}
   ^~~
```

If you have any other ideas how to present stdout & stderr, I'm open to suggestion.

There is currently no specs on the macro method `run`, should I try to make one for this?