### PR TITLE
Fixed docs for gzip/writer

### DIFF
--- a/src/gzip/writer.cr
+++ b/src/gzip/writer.cr
@@ -9,7 +9,7 @@
 # ### Example: compress a file
 #
 # ```
-# require "zlib"
+# require "gzip"
 #
 # File.write("file.txt", "abc")
 #


### PR DESCRIPTION
Docs for gzip writer used to say `require "zlib"`
Took me a bit to figure out why it wasn't working.