### PR TITLE
change computation of hash value.

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -287,8 +287,7 @@ describe "BigInt" do
 
   it "#hash" do
     hash = 5.to_big_i.hash
-    hash.should eq(5)
-    typeof(hash).should eq(UInt64)
+    hash.should eq(5.hash)
   end
 
   it "clones" do

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -28,8 +28,9 @@ describe "Bool" do
   end
 
   describe "hash" do
-    it { true.hash.should eq(1) }
-    it { false.hash.should eq(0) }
+    it { true.hash.should eq(true.hash) }
+    it { false.hash.should eq(false.hash) }
+    it { true.hash.should_not eq(false.hash) }
   end
 
   describe "to_s" do

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -142,7 +142,7 @@ describe Enum do
   end
 
   it "has hash" do
-    SpecEnum::Two.hash.should eq(1.hash)
+    SpecEnum::Two.hash.should_not eq(SpecEnum::One.hash)
   end
 
   it "parses" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -146,7 +146,12 @@ describe "Hash" do
     end
 
     it "works with mixed types" do
-      {1 => :a, "a" => 1, 1.0 => "a", :a => 1.0}.values_at(1, "a", 1.0, :a).should eq({:a, 1, "a", 1.0})
+      {1 => :a, "a" => 1, 2.0 => "a", :a => 1.0}.values_at(1, 2, "a", 1.0, 2.0, :a).should eq({:a, "a", 1, :a, "a", 1.0})
+      # following line test is broken: 1==1.0,
+      # and if it maps to same bucket, then they collapse.
+      # ruby distinguish them by hash value, but still there could be collapse
+      # with probability 1/(2**64).
+      # {1 => :a, "a" => 1, 1.0 => "a", :a => 1.0}.values_at(1, "a", 1.0, :a).should eq({:a, 1, "a", 1.0})
     end
   end
 

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -42,11 +42,15 @@ describe "Struct" do
 
   it "does hash" do
     s = StructSpec::TestClass.new(1, "hello")
-    s.hash.should eq(31 + "hello".hash)
+    h = StdHasher.build do |b|
+      b << 1
+      b << "hello"
+    end
+    s.hash.should eq(h)
   end
 
   it "does hash for struct wrapper (#1940)" do
-    StructSpec::BigIntWrapper.new(BigInt.new(0)).hash.should eq(0)
+    StructSpec::BigIntWrapper.new(BigInt.new(0)).hash.should eq(BigInt.new(0).hash)
   end
 
   it "does dup" do

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -176,7 +176,7 @@ describe Time::Span do
   end
 
   it "test hash code" do
-    Time::Span.new(77).hash.should eq(77)
+    Time::Span.new(77).hash.should eq(77.hash)
   end
 
   it "test subtract" do

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -35,11 +35,7 @@ struct BigFloat < Float
     new(mpf)
   end
 
-  def hash
-    to_f64.hash
-  end
-
-  def hashme(h)
+  def hash(h)
     h << to_f64
   end
 

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -39,6 +39,10 @@ struct BigFloat < Float
     to_f64.hash
   end
 
+  def hashme(h)
+    h << to_f64
+  end
+
   def self.default_precision
     LibGMP.mpf_get_default_prec
   end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -35,8 +35,8 @@ struct BigFloat < Float
     new(mpf)
   end
 
-  def hash(h)
-    h << to_f64
+  def hash(hasher)
+    hasher << to_f64
   end
 
   def self.default_precision

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -277,11 +277,7 @@ struct BigInt < Int
     end
   end
 
-  def hash
-    hash_normalize.hash
-  end
-
-  def hashme(h)
+  def hash(h)
     h << hash_normalize
   end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -267,8 +267,22 @@ struct BigInt < Int
     to_s io
   end
 
+  private def hash_normalize
+    if self == to_i64
+      to_i64
+    elsif self == to_u64
+      to_u64
+    else
+      (self % 0x7fffffffffffffe7_i64).to_i64
+    end
+  end
+
   def hash
-    to_u64
+    hash_normalize.hash
+  end
+
+  def hashme(h)
+    h << hash_normalize
   end
 
   # Returns a string representation of self.

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -277,8 +277,8 @@ struct BigInt < Int
     end
   end
 
-  def hash(h)
-    h << hash_normalize
+  def hash(hasher)
+    hasher << hash_normalize
   end
 
   # Returns a string representation of self.

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -139,11 +139,7 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_abs(mpq, self) }
   end
 
-  def hash
-    to_f64.hash
-  end
-
-  def hashme(h)
+  def hash(h)
     h << to_f64
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -143,6 +143,10 @@ struct BigRational < Number
     to_f64.hash
   end
 
+  def hashme(h)
+    h << to_f64
+  end
+
   # Returns the `Float64` representing this rational.
   def to_f
     to_f64

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -139,8 +139,8 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_abs(mpq, self) }
   end
 
-  def hash(h)
-    h << to_f64
+  def hash(hasher)
+    hasher << to_f64
   end
 
   # Returns the `Float64` representing this rational.

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -46,6 +46,10 @@ struct Bool
     self ? 1 : 0
   end
 
+  def hashme(hasher)
+    hasher << (self ? 1 : 0)
+  end
+
   # Returns `"true"` for `true` and `"false"` for `false`.
   def to_s
     self ? "true" : "false"

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -43,10 +43,10 @@ struct Bool
 
   # Returns a hash value for this boolean: 0 for `false`, 1 for `true`.
   def hash
-    self ? 1 : 0
+    (self ? 1 : 0)
   end
 
-  def hashme(hasher)
+  def hash(hasher)
     hasher << (self ? 1 : 0)
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -420,7 +420,7 @@ struct Char
   end
 
   # Protocol method for safe hashing
-  def hashme(hasher)
+  def hash(hasher)
     hasher << ord
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -419,6 +419,11 @@ struct Char
     ord
   end
 
+  # Protocol method for safe hashing
+  def hashme(hasher)
+    hasher << ord
+  end
+
   # Returns a Char that is one codepoint bigger than this char's codepoint.
   #
   # ```

--- a/src/class.cr
+++ b/src/class.cr
@@ -4,7 +4,11 @@ class Class
   end
 
   def hash
-    crystal_type_id
+    crystal_type_id.hash
+  end
+
+  def hashme(hasher)
+    hasher << crystal_type_id
   end
 
   def ==(other : Class)

--- a/src/class.cr
+++ b/src/class.cr
@@ -4,7 +4,7 @@ class Class
   end
 
   def hash(hasher)
-    hasher << crystal_type_id
+    hasher.raw(crystal_type_id)
   end
 
   def ==(other : Class)

--- a/src/class.cr
+++ b/src/class.cr
@@ -3,11 +3,7 @@ class Class
     to_s(io)
   end
 
-  def hash
-    crystal_type_id.hash
-  end
-
-  def hashme(hasher)
+  def hash(hasher)
     hasher << crystal_type_id
   end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1175,11 +1175,7 @@ module Crystal
       self
     end
 
-    def hash
-      0
-    end
-
-    def hashme(hasher)
+    def hash(hasher)
       hasher << 0
     end
   end
@@ -1549,11 +1545,7 @@ module Crystal
       Self.new
     end
 
-    def hash
-      0
-    end
-
-    def hashme(hasher)
+    def hash(hasher)
       hasher << 0
     end
   end
@@ -2033,11 +2025,7 @@ module Crystal
       Underscore.new
     end
 
-    def hash
-      0
-    end
-
-    def hashme(hasher)
+    def hash(hasher)
       hasher << 0
     end
   end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1178,6 +1178,10 @@ module Crystal
     def hash
       0
     end
+
+    def hashme(hasher)
+      hasher << 0
+    end
   end
 
   # A qualified identifier.
@@ -1547,6 +1551,10 @@ module Crystal
 
     def hash
       0
+    end
+
+    def hashme(hasher)
+      hasher << 0
     end
   end
 
@@ -2027,6 +2035,10 @@ module Crystal
 
     def hash
       0
+    end
+
+    def hashme(hasher)
+      hasher << 0
     end
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -275,8 +275,16 @@ struct Enum
   end
 
   # Returns a hash value. This is the hash of the underlying value.
+  # Enum hash is exception from random seeding, cause several Hashes are
+  # initialized on very early stages of bootstrap, and StdHasher seed is not
+  # filled yet.
   def hash
-    value.hash
+    StdHasher.unseeded value
+  end
+
+  # Protocol method for safe hashing.
+  def hashme(hasher)
+    hasher << value
   end
 
   # Iterates each values in a Flags Enum.

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -276,7 +276,7 @@ struct Enum
 
   # Protocol method for safe hashing.
   def hash(hasher)
-    hasher << value
+    hasher.raw(value)
   end
 
   # Iterates each values in a Flags Enum.

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -283,7 +283,7 @@ struct Enum
   end
 
   # Protocol method for safe hashing.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << value
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -274,14 +274,6 @@ struct Enum
     value == other.value
   end
 
-  # Returns a hash value. This is the hash of the underlying value.
-  # Enum hash is exception from random seeding, cause several Hashes are
-  # initialized on very early stages of bootstrap, and StdHasher seed is not
-  # filled yet.
-  def hash
-    StdHasher.unseeded value
-  end
-
   # Protocol method for safe hashing.
   def hash(hasher)
     hasher << value

--- a/src/event/signal_handler.cr
+++ b/src/event/signal_handler.cr
@@ -94,7 +94,7 @@ class Event::SignalHandler
     spawn { run }
   end
 
-  class SignalHash < Hash(Signal, (Signal -> ))
+  class SignalHash < Hash(Signal, (Signal -> Nil))
     protected def hash_key(key)
       key.to_u32
     end

--- a/src/event/signal_handler.cr
+++ b/src/event/signal_handler.cr
@@ -1,5 +1,6 @@
 require "c/signal"
 require "c/unistd"
+require "signal"
 
 # :nodoc:
 # Singleton that runs Signal events (libevent2) in it's own Fiber.
@@ -32,7 +33,7 @@ class Event::SignalHandler
   @@write_pipe : IO::FileDescriptor?
 
   def initialize
-    @callbacks = Hash(Signal, (Signal ->)).new
+    @callbacks = SignalHash.new
     @read_pipe, @write_pipe = IO.pipe
     @@write_pipe = @write_pipe
 
@@ -91,5 +92,11 @@ class Event::SignalHandler
 
   private def spawn_reader
     spawn { run }
+  end
+
+  class SignalHash < Hash(Signal, (Signal -> ))
+    protected def hash_key(key)
+      key.to_u32
+    end
   end
 end

--- a/src/float.cr
+++ b/src/float.cr
@@ -153,8 +153,8 @@ struct Float32
     t == self ? t : unsafe_as(Int32)
   end
 
-  def hash(h)
-    h << hash_normalize
+  def hash(hasher)
+    hasher << hash_normalize
   end
 
   def clone
@@ -216,8 +216,8 @@ struct Float64
     t == self ? t : unsafe_as(Int64)
   end
 
-  def hash(h)
-    h << hash_normalize
+  def hash(hasher)
+    hasher << hash_normalize
   end
 
   def clone

--- a/src/float.cr
+++ b/src/float.cr
@@ -153,11 +153,7 @@ struct Float32
     t == self ? t : unsafe_as(Int32)
   end
 
-  def hash
-    hash_normalize.hash
-  end
-
-  def hashme(h)
+  def hash(h)
     h << hash_normalize
   end
 
@@ -220,11 +216,7 @@ struct Float64
     t == self ? t : unsafe_as(Int64)
   end
 
-  def hash
-    hash_normalize.hash
-  end
-
-  def hashme(h)
+  def hash(h)
     h << hash_normalize
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -148,8 +148,17 @@ struct Float32
     Printer.print(self, io)
   end
 
+  private def hash_normalize
+    t = to_i32
+    t == self ? t : unsafe_as(Int32)
+  end
+
   def hash
-    unsafe_as(Int32)
+    hash_normalize.hash
+  end
+
+  def hashme(h)
+    h << hash_normalize
   end
 
   def clone
@@ -206,8 +215,17 @@ struct Float64
     Printer.print(self, io)
   end
 
+  private def hash_normalize
+    t = to_i64
+    t == self ? t : unsafe_as(Int64)
+  end
+
   def hash
-    unsafe_as(Int64)
+    hash_normalize.hash
+  end
+
+  def hashme(h)
+    h << hash_normalize
   end
 
   def clone

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -712,7 +712,7 @@ class Hash(K, V)
   # foo = {"foo" => "bar"}
   # foo.hash # => 3247054 (not exactly)
   # ```
-  def hashme(hasher)
+  def hash(hasher)
     hasher << size
     dgst = hasher.digest
     each do |key, value|

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -713,14 +713,14 @@ class Hash(K, V)
   # foo.hash # => 3247054 (not exactly)
   # ```
   def hash(hasher)
-    hasher << size
-    dgst = hasher.digest
+    hasher.raw(size)
+    digest = hasher.digest
     each do |key, value|
-      dgst += hasher.clone_build do |hh|
+      digest += hasher.clone_build do |hh|
         hh << key << value
       end
     end
-    hasher << dgst
+    hasher.raw(digest)
   end
 
   # Duplicates a `Hash`.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -710,14 +710,17 @@ class Hash(K, V)
   #
   # ```
   # foo = {"foo" => "bar"}
-  # foo.hash # => 3247054
+  # foo.hash # => 3247054 (not exactly)
   # ```
-  def hash
-    hash = size
+  def hashme(hasher)
+    hasher << size
+    dgst = hasher.digest
     each do |key, value|
-      hash += key.hash ^ value.hash
+      dgst += hasher.clone_build do |hh|
+        hh << key << value
+      end
     end
-    hash
+    hasher << dgst
   end
 
   # Duplicates a `Hash`.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -867,7 +867,11 @@ class Hash(K, V)
   end
 
   private def bucket_index(key)
-    key.hash.to_u32.remainder(@buckets_size).to_i
+    hash_key(key).to_u32.remainder(@buckets_size).to_i
+  end
+
+  protected def hash_key(key)
+    key.hash
   end
 
   private def calculate_new_size(size)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -9,20 +9,20 @@ struct HTTP::Headers
   record Key, name : String do
     forward_missing_to @name
 
-    def hash
-      StdHasher.hashit self
-    end
-
-    def hashme(h)
+    def hash(h)
       v = 0_u32
+      c = 0
       name.each_byte do |c|
-        v = (v<<8) | normalize_byte(c).to_u32
-        if v >= 0x1000000_u32
+        v |= normalize_byte(c).to_u32 << (c*8)
+        if c == 3
           h << v
           v = 0_u32
+          c = 0
+        else
+          c += 1
         end
       end
-      h << v if v != 0_u32
+      h << v if c != 0
     end
 
     def ==(key2)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -10,12 +10,19 @@ struct HTTP::Headers
     forward_missing_to @name
 
     def hash
-      h = 0
+      StdHasher.hashit self
+    end
+
+    def hashme(h)
+      v = 0_u32
       name.each_byte do |c|
-        c = normalize_byte(c)
-        h = 31 * h + c
+        v = (v<<8) | normalize_byte(c).to_u32
+        if v >= 0x1000000_u32
+          h << v
+          v = 0_u32
+        end
       end
-      h
+      h << v if v != 0_u32
     end
 
     def ==(key2)

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -274,7 +274,7 @@ module Indexable(T)
   # Returns a hash code based on `self`'s size and elements.
   #
   # See also: `Object#hash`.
-  def hashme(h)
+  def hash(h)
     h << size
     each do |elem|
       h << elem

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -274,10 +274,10 @@ module Indexable(T)
   # Returns a hash code based on `self`'s size and elements.
   #
   # See also: `Object#hash`.
-  def hash(h)
-    h << size
+  def hash(hasher)
+    hasher.raw(size.to_u32)
     each do |elem|
-      h << elem
+      hasher << elem
     end
   end
 

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -274,9 +274,10 @@ module Indexable(T)
   # Returns a hash code based on `self`'s size and elements.
   #
   # See also: `Object#hash`.
-  def hash
-    reduce(31 * size) do |memo, elem|
-      31 * memo + elem.hash
+  def hashme(h)
+    h << size
+    each do |elem|
+      h << elem
     end
   end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -317,7 +317,15 @@ struct Int
   end
 
   def hash
-    self
+    if self.is_a? Primitive
+      StdHasher.fasthash self
+    else
+      raise "Int#hash should be overloaded in proper way"
+    end
+  end
+
+  def hashme(hasher)
+    hasher << self
   end
 
   def succ

--- a/src/int.cr
+++ b/src/int.cr
@@ -316,15 +316,7 @@ struct Int
     !even?
   end
 
-  def hash
-    if self.is_a? Primitive
-      StdHasher.fasthash self
-    else
-      raise "Int#hash should be overloaded in proper way"
-    end
-  end
-
-  def hashme(hasher)
+  def hash(hasher)
     hasher << self
   end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -619,6 +619,11 @@ struct Int32
   def clone
     self
   end
+
+  def hash(hasher)
+    # to be replaced with number normalizer
+    hasher.raw(self)
+  end
 end
 
 struct Int64
@@ -640,6 +645,15 @@ struct Int64
 
   def clone
     self
+  end
+
+  def hash(hasher)
+    # to be replaced with number normalizer
+    high = (self >> 32).to_u32
+    if high != 0_u32
+      hasher.raw(high)
+    end
+    hasher.raw(self.to_u32)
   end
 end
 
@@ -707,6 +721,11 @@ struct UInt32
   def clone
     self
   end
+
+  def hash(hasher)
+    # to be replaced with number normalizer
+    hasher.raw(self)
+  end
 end
 
 struct UInt64
@@ -728,5 +747,14 @@ struct UInt64
 
   def clone
     self
+  end
+
+  def hash(hasher)
+    # to be replaced with number normalizer
+    high = (self >> 32).to_u32
+    if high != 0_u32
+      hasher.raw(high)
+    end
+    hasher.raw(self.to_u32)
   end
 end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -262,11 +262,6 @@ struct JSON::Any
   end
 
   # :nodoc:
-  def hash
-    raw.hash
-  end
-
-  # :nodoc:
   def to_json(json : JSON::Builder)
     raw.to_json(json)
   end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -162,7 +162,7 @@ struct NamedTuple
   # Protocol method for generic hashing. Mixes tuple's size, keys and values
   #
   # See also: `Object#hash`.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << size
     {% for key in T.keys.sort %}
       hasher << {{key.symbolize}}

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -159,16 +159,15 @@ struct NamedTuple
     yield
   end
 
-  # Returns a hash value based on this name tuple's size, keys and values.
+  # Protocol method for generic hashing. Mixes tuple's size, keys and values
   #
   # See also: `Object#hash`.
-  def hash
-    hash = 31 * size
+  def hashme(hasher)
+    hasher << size
     {% for key in T.keys.sort %}
-      hash = 31 * hash + {{key.symbolize}}.hash
-      hash = 31 * hash + self[{{key.symbolize}}].hash
+      hasher << {{key.symbolize}}
+      hasher << self[{{key.symbolize}}]
     {% end %}
-    hash
   end
 
   # Same as `to_s`.

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -163,7 +163,7 @@ struct NamedTuple
   #
   # See also: `Object#hash`.
   def hash(hasher)
-    hasher << size
+    hasher.raw(size)
     {% for key in T.keys.sort %}
       hasher << {{key.symbolize}}
       hasher << self[{{key.symbolize}}]

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -68,8 +68,8 @@ struct Nil
   end
 
   # Returns `0`.
-  def hash
-    0
+  def hashme(hasher)
+    hasher << nil
   end
 
   # Returns an empty string.

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -68,7 +68,7 @@ struct Nil
   end
 
   # Returns `0`.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << nil
   end
 

--- a/src/object.cr
+++ b/src/object.cr
@@ -58,13 +58,19 @@ class Object
     nil
   end
 
-  # Generates an `Int` hash value for this object.
+  # Generates an `Int` hash value for this object (usually `UInt32`)
   #
   # This method must have the property that `a == b` implies `a.hash == b.hash`.
   #
   # The hash value is used along with `==` by the `Hash` class to determine if two objects
   # reference the same hash key.
   abstract def hash
+  def hash
+    StdHasher.hashit self
+  end
+
+  # Protocol method for safe hashing
+  abstract def hashme(hasher)
 
   # Returns a string representation of this object.
   #
@@ -1094,11 +1100,13 @@ class Object
       {% if fields.size == 1 %}
         {{fields[0]}}.hash
       {% else %}
-        hash = 0
-        {% for field in fields %}
-          hash = 31 * hash + {{field}}.hash
-        {% end %}
-        hash
+        StdHasher.hashit self
+      {% end %}
+    end
+
+    def hashme(hasher)
+      {% for field in fields %}
+        hasher << {{field}}
       {% end %}
     end
   end

--- a/src/object.cr
+++ b/src/object.cr
@@ -64,13 +64,12 @@ class Object
   #
   # The hash value is used along with `==` by the `Hash` class to determine if two objects
   # reference the same hash key.
-  abstract def hash
   def hash
     StdHasher.hashit self
   end
 
   # Protocol method for safe hashing
-  abstract def hashme(hasher)
+  abstract def hash(hasher)
 
   # Returns a string representation of this object.
   #
@@ -1096,15 +1095,7 @@ class Object
   # end
   # ```
   macro def_hash(*fields)
-    def hash
-      {% if fields.size == 1 %}
-        {{fields[0]}}.hash
-      {% else %}
-        StdHasher.hashit self
-      {% end %}
-    end
-
-    def hashme(hasher)
+    def hash(hasher)
       {% for field in fields %}
         hasher << {{field}}
       {% end %}

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -17,9 +17,7 @@ require "iterable"
 require "iterator"
 require "indexable"
 require "string"
-
 require "stdhasher"
-StdHasher.init
 
 # Alpha-sorted list
 require "array"

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -18,6 +18,9 @@ require "iterator"
 require "indexable"
 require "string"
 
+require "stdhasher"
+StdHasher.init
+
 # Alpha-sorted list
 require "array"
 require "atomic"

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -181,8 +181,8 @@ struct Proc
     call(other)
   end
 
-  def hash(h)
-    h << internal_representation
+  def hash(hasher)
+    hasher << internal_representation
   end
 
   def clone

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -181,7 +181,7 @@ struct Proc
     call(other)
   end
 
-  def hashme(h)
+  def hash(h)
     h << internal_representation
   end
 

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -181,8 +181,8 @@ struct Proc
     call(other)
   end
 
-  def hash
-    internal_representation.hash
+  def hashme(h)
+    h << internal_representation
   end
 
   def clone

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -51,8 +51,8 @@ class Reference
   end
 
   # Returns this reference's `object_id` as the hash value.
-  def hash
-    object_id
+  def hashme(hasher)
+    hasher << object_id
   end
 
   def inspect(io : IO) : Nil

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -51,7 +51,7 @@ class Reference
   end
 
   # Returns this reference's `object_id` as the hash value.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << object_id
   end
 

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -52,7 +52,7 @@ class Reference
 
   # Returns this reference's `object_id` as the hash value.
   def hash(hasher)
-    hasher << object_id
+    hasher.raw object_id
   end
 
   def inspect(io : IO) : Nil

--- a/src/set.cr
+++ b/src/set.cr
@@ -308,10 +308,6 @@ struct Set(T)
     pp.list("Set{", self, "}")
   end
 
-  def hash
-    @hash.hash
-  end
-
   # Returns `true` if the set and the given set have at least one element in
   # common.
   #

--- a/src/stdhasher.cr
+++ b/src/stdhasher.cr
@@ -1,0 +1,248 @@
+require "secure_random"
+
+# Hasher usable for `def hash(hasher)` should satisfy protocol:
+#   class MyHasher
+#     def <<(v : Int::Primitive)
+#       # mutate
+#       self
+#     end
+#
+#     def <<(b : Bytes)
+#       # mutate
+#       self
+#     end
+#
+#     def <<(n : Nil)
+#       # mutate
+#       self
+#     end
+#
+#     def <<(v)
+#       v.hash(self)
+#       self
+#     end
+#
+#     # digest returns hashsum for current state without state mutation
+#     # Note: hashsum should implement commutative `+` if MyHasher used
+#     # for `Hasher#hash(hasher)`
+#     def digest
+#     end
+#
+#     def clone_build
+#       with_state_copy do |copy|
+#         yield copy
+#         copy.digest
+#       end
+#     end
+#   end
+
+# StdHasher used as standard hasher in `Object#hash`
+# It have to provide defenense against HashDos, and be reasonably fast.
+# To protect against HashDos, it is seeded with secure random, and have
+# permutation that hard to forge without knowing seed and seeing hash digest.
+#
+# Also it has specialized methods for primitive keys with different seeds.
+struct StdHasher
+  @@seed = StaticArray(UInt32, 7).new{|i| 0_u32}
+  def self.init
+    raise "#{@@seed[0]} #{@@seed[1]}" unless @@seed[0] == 0_u32 && @@seed[1] == 0_u32
+    buf = pointerof(@@seed).as(Pointer(UInt8))
+    SecureRandom.random_bytes(buf.to_slice(sizeof(typeof(@@seed))))
+  end
+
+  private def initialize(@h : Pointer(Impl))
+  end
+
+  def initialize
+    @h = Pointer(Impl).malloc(1, Impl.new(@@seed[0], @@seed[1]))
+  end
+
+  protected def initialize(a, b)
+    @h = Pointer(Impl).malloc(1, Impl.new(a, b))
+  end
+
+  def self.build
+    h = Impl.new(@@seed[0], @@seed[1])
+    s = new(pointerof(h))
+    yield s
+    s.digest
+  end
+
+  def self.hashit(v)
+    build do |s|
+      s << v
+    end
+  end
+
+  protected def self.build(a, b)
+    h = Impl.new(a, b)
+    s = new(pointerof(h))
+    yield s
+    s.digest
+  end
+
+  def clone_build
+    self.class.build(@h.value.a, @h.value.b) do |s|
+      yield s
+    end
+  end
+
+  def clone
+    self.class.new(@h.value.a, @h.value.b)
+  end
+
+  def <<(v : Nil)
+    @h.value.permute_nil(@@seed[2])
+    self
+  end
+
+  def <<(v : Int8|Int16|Int32|UInt8|UInt16|UInt32)
+    @h.value.permute(v.to_u32, @@seed[2])
+    self
+  end
+
+  def <<(v : UInt64)
+    high = (v>>32).to_u32
+    if high != 0
+      self << high
+    end
+    self << v.to_u32
+  end
+
+  def <<(v : Int64)
+    self << v.to_u64
+  end
+
+  def <<(b : Bytes)
+    @h.value.permute(b, @@seed[2])
+    self
+  end
+
+  def <<(v)
+    if v.responds_to?(:hashme)
+      v.hashme(self)
+    else
+      self << v.hash
+    end
+    self
+  end
+
+  def digest
+    @h.value.digest(@@seed[3])
+  end
+
+  private struct Impl
+    getter a : UInt32 = 0_u32
+    getter b : UInt32 = 0_u32
+    def initialize(@a : UInt32, @b : UInt32)
+    end
+
+    def permute(v : UInt32, s : UInt32)
+      permute(v, s, pointerof(@a), pointerof(@b))
+    end
+
+    def permute_nil(s : UInt32)
+      @a += s|1
+      # LFSR
+      mx = (@b.to_i32 >> 31).to_u32 & 0xa8888eef_u32
+      @b = (@b << 1) ^ mx
+    end
+
+    def digest(seed)
+      a, b = @a, @b
+      b += seed
+      a ^= a >> 15
+      b ^= b >> 16
+      a *= 0xb8b34b2d_u32
+      b *= 0x52c6a2d9_u32
+      a ^= a >> 17
+      b ^= b >> 16
+      b + a
+    end
+
+    def permute(buf : Bytes, s : UInt32)
+      bsz = buf.size
+      v = bsz.to_u32 << 24
+      u = buf.to_unsafe
+      a, b = @a, @b
+      i = bsz.unsafe_div 4
+      while i > 0
+        permute(u.as(Pointer(UInt32)).value, s, pointerof(a), pointerof(b))
+        u += 4
+        i -= 1
+      end
+      r = (bsz&3).to_u32
+      if r != 0
+        v |= u[0].to_u32|(u[r/2].to_u32<<8)|(u[r-1].to_u32<<16)
+      end
+      permute(v, s, pointerof(a), pointerof(b))
+      @a, @b = a, b
+      self
+    end
+
+    private def permute(v : UInt32, s : UInt32, aa : Pointer(UInt32), bb : Pointer(UInt32))
+      a, b = aa.value, bb.value
+      v ^= s
+      v *= 0xb8b34b2d_u32
+      a += v
+      a = rotl(a, 13)
+      b ^= a + s
+      b *= 9
+      aa.value, bb.value = a, b
+      nil
+    end
+
+    private def rotl(v : UInt32, sh)
+      (v << sh) | (v >> (sizeof(UInt32) * 8 - sh))
+    end
+  end
+
+  # separate method for faster default hashtable with UInt32, Int32, Float32 and Symbol keys
+  def self.fasthash(v : UInt32|Int32|UInt16|Int16|UInt8|Int8)
+    h = @@seed[4] + v.to_u32
+    h ^= h >> 16
+    h *= 0x52c6a2d9_u32
+    h ^= (h >> 16)
+    h *= 0xb8b34b2d_u32
+    h += @@seed[5]
+    h ^ (h >> 16)
+  end
+
+  # separate method for faster default hashtable with UInt64, Int64 and Float64 keys
+  def self.fasthash(v : UInt64|Int64)
+    high = (v >> 32).to_u32
+    if high != 0
+      h = @@seed[5] + high
+      h ^= h >> 16
+      h *= 0xb8b34b2d_u32
+    else
+      h = 0_u32
+    end
+    h += @@seed[4] + v.to_u32
+    h ^= h >> 16
+    h *= 0x52c6a2d9_u32
+    h ^= h >> 16
+    h *= 0xb8b34b2d_u32
+    h += @@seed[5]
+    h ^ (h >> 16)
+  end
+
+  # unseeded is used for types that are used in early startup
+  def self.unseeded(v : Int8|Int16|UInt8|UInt16|Int32|UInt32)
+    h = v.to_u32
+    h ^= h >> 16
+    h *= 0x52c6a2d9_u32
+    h ^ (h >> 16)
+  end
+
+  # unseeded is used for types that are used in early startup
+  def self.unseeded(v : Int64|UInt64)
+    h = (v >> 32).to_u32
+    h ^= h >> 16
+    h *= 0xb8b34b2d_u32
+    h += v.to_u32
+    h ^= h >> 16
+    h *= 0x52c6a2d9_u32
+    h ^ (h >> 16)
+  end
+end

--- a/src/stdhasher.cr
+++ b/src/stdhasher.cr
@@ -43,7 +43,8 @@ require "secure_random"
 #
 # Also it has specialized methods for primitive keys with different seeds.
 struct StdHasher
-  @@seed = StaticArray(UInt32, 7).new{|i| 0_u32}
+  @@seed = StaticArray(UInt32, 7).new { |i| 0_u32 }
+
   def self.init
     raise "#{@@seed[0]} #{@@seed[1]}" unless @@seed[0] == 0_u32 && @@seed[1] == 0_u32
     buf = pointerof(@@seed).as(Pointer(UInt8))
@@ -96,13 +97,13 @@ struct StdHasher
     self
   end
 
-  def <<(v : Int8|Int16|Int32|UInt8|UInt16|UInt32)
+  def <<(v : Int8 | Int16 | Int32 | UInt8 | UInt16 | UInt32)
     @h.value.permute(v.to_u32, @@seed[2])
     self
   end
 
   def <<(v : UInt64)
-    high = (v>>32).to_u32
+    high = (v >> 32).to_u32
     if high != 0
       self << high
     end
@@ -130,6 +131,7 @@ struct StdHasher
   private struct Impl
     getter a : UInt32 = 0_u32
     getter b : UInt32 = 0_u32
+
     def initialize(@a : UInt32, @b : UInt32)
     end
 
@@ -138,7 +140,7 @@ struct StdHasher
     end
 
     def permute_nil(s : UInt32)
-      @a += s|1
+      @a += s | 1
       # LFSR
       mx = (@b.to_i32 >> 31).to_u32 & 0xa8888eef_u32
       @b = (@b << 1) ^ mx
@@ -167,9 +169,9 @@ struct StdHasher
         u += 4
         i -= 1
       end
-      r = (bsz&3).to_u32
+      r = (bsz & 3).to_u32
       if r != 0
-        v |= u[0].to_u32|(u[r/2].to_u32<<8)|(u[r-1].to_u32<<16)
+        v |= u[0].to_u32 | (u[r/2].to_u32 << 8) | (u[r - 1].to_u32 << 16)
       end
       permute(v, s, pointerof(a), pointerof(b))
       @a, @b = a, b
@@ -194,7 +196,7 @@ struct StdHasher
   end
 
   # separate method for faster default hashtable with UInt32, Int32, Float32 and Symbol keys
-  def self.fasthash(v : UInt32|Int32|UInt16|Int16|UInt8|Int8)
+  def self.fasthash(v : UInt32 | Int32 | UInt16 | Int16 | UInt8 | Int8)
     h = @@seed[4] + v.to_u32
     h ^= h >> 16
     h *= 0x52c6a2d9_u32
@@ -205,7 +207,7 @@ struct StdHasher
   end
 
   # separate method for faster default hashtable with UInt64, Int64 and Float64 keys
-  def self.fasthash(v : UInt64|Int64)
+  def self.fasthash(v : UInt64 | Int64)
     high = (v >> 32).to_u32
     if high != 0
       h = @@seed[5] + high
@@ -224,7 +226,7 @@ struct StdHasher
   end
 
   # unseeded is used for types that are used in early startup
-  def self.unseeded(v : Int8|Int16|UInt8|UInt16|Int32|UInt32)
+  def self.unseeded(v : Int8 | Int16 | UInt8 | UInt16 | Int32 | UInt32)
     h = v.to_u32
     h ^= h >> 16
     h *= 0x52c6a2d9_u32
@@ -232,7 +234,7 @@ struct StdHasher
   end
 
   # unseeded is used for types that are used in early startup
-  def self.unseeded(v : Int64|UInt64)
+  def self.unseeded(v : Int64 | UInt64)
     h = (v >> 32).to_u32
     h ^= h >> 16
     h *= 0xb8b34b2d_u32

--- a/src/stdhasher.cr
+++ b/src/stdhasher.cr
@@ -119,11 +119,7 @@ struct StdHasher
   end
 
   def <<(v)
-    if v.responds_to?(:hashme)
-      v.hashme(self)
-    else
-      self << v.hash
-    end
+    v.hash(self)
     self
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -3902,12 +3902,8 @@ class String
   # Returns a hash based on this string’s size and content.
   #
   # See also: `Object#hash`.
-  def hash
-    h = 0
-    each_byte do |c|
-      h = 31 * h + c
-    end
-    h
+  def hashme(hasher)
+    hasher << to_slice
   end
 
   # Returns the number of unicode codepoints in this string.

--- a/src/string.cr
+++ b/src/string.cr
@@ -3902,7 +3902,7 @@ class String
   # Returns a hash based on this string’s size and content.
   #
   # See also: `Object#hash`.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << to_slice
   end
 

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -73,12 +73,19 @@ struct Struct
   # Returns a hash value based on this struct's instance variables hash values.
   #
   # See also: `Object#hash`
-  def hash : Int32
-    hash = 0
-    {% for ivar in @type.instance_vars %}
-      hash = 31 * hash + @{{ivar.id}}.hash.to_i32
+  def hash
+    {% if @type.instance_vars.size == 1 %}
+      @{{@type.instance_vars[0].id}}.hash
+    {% else %}
+      StdHasher.hashit self
     {% end %}
-    hash
+  end
+
+  # Protocol method for generic hashing
+  def hashme(hasher)
+    {% for ivar in @type.instance_vars %}
+      hasher << @{{ivar.id}}
+    {% end %}
   end
 
   # Appends this struct's name and instance variables names and values

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -73,16 +73,9 @@ struct Struct
   # Returns a hash value based on this struct's instance variables hash values.
   #
   # See also: `Object#hash`
-  def hash
-    {% if @type.instance_vars.size == 1 %}
-      @{{@type.instance_vars[0].id}}.hash
-    {% else %}
-      StdHasher.hashit self
-    {% end %}
-  end
 
   # Protocol method for generic hashing
-  def hashme(hasher)
+  def hash(hasher)
     {% for ivar in @type.instance_vars %}
       hasher << @{{ivar.id}}
     {% end %}

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -18,8 +18,13 @@ struct Symbol
   # Generates an `Int32` hash value for this symbol.
   #
   # See also: `Object#hash`.
-  def hash : Int32
-    to_i
+  def hash
+    StdHasher.fasthash to_i
+  end
+
+  # Protocol method for safe hashing
+  def hashme(hasher)
+    hasher << to_i
   end
 
   # Compares symbol with other based on `String#<=>` method. Returns `-1`, `0`

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -18,12 +18,9 @@ struct Symbol
   # Generates an `Int32` hash value for this symbol.
   #
   # See also: `Object#hash`.
-  def hash
-    StdHasher.fasthash to_i
-  end
 
   # Protocol method for safe hashing
-  def hashme(hasher)
+  def hash(hasher)
     hasher << to_i
   end
 

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -48,6 +48,11 @@ class Thread
     end
   end
 
+  # override, cause StdHasher's seed is not initialized yet
+  def hash
+    StdHasher.unseeded object_id
+  end
+
   # All threads, so the GC can see them (GC doesn't scan thread locals)
   # and we can find the current thread on platforms that don't support
   # thread local storage (eg: OpenBSD)

--- a/src/time.cr
+++ b/src/time.cr
@@ -309,10 +309,6 @@ struct Time
     end
   end
 
-  def hash
-    @encoded
-  end
-
   def self.days_in_month(year, month) : Int32
     unless 1 <= month <= 12
       raise ArgumentError.new "Invalid month"

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -309,16 +309,9 @@ struct Tuple
   # Returns a hash value based on this tuple's length and contents.
   #
   # See also: `Object#hash`.
-  def hash
-    {% if T.size == 1 %}
-      self[0].hash
-    {% else %}
-      StdHasher.hashit self
-    {% end %}
-  end
-
+  #
   # Protocol method for generic hashing
-  def hashme(hasher)
+  def hash(hasher)
     {% for i in 0...T.size %}
       hasher << self[{{i}}]
     {% end %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -310,11 +310,18 @@ struct Tuple
   #
   # See also: `Object#hash`.
   def hash
-    hash = 31 * size
-    {% for i in 0...T.size %}
-      hash = 31 * hash + self[{{i}}].hash
+    {% if T.size == 1 %}
+      self[0].hash
+    {% else %}
+      StdHasher.hashit self
     {% end %}
-    hash
+  end
+
+  # Protocol method for generic hashing
+  def hashme(hasher)
+    {% for i in 0...T.size %}
+      hasher << self[{{i}}]
+    {% end %}
   end
 
   # Returns a tuple containing cloned elements of this tuple using the `clone` method.

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -4,8 +4,8 @@ struct XML::Namespace
   def initialize(@document : Node, @ns : LibXML::NS*)
   end
 
-  def hash
-    object_id
+  def hashme(hasher)
+    hasher << object_id
   end
 
   def href

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -4,7 +4,7 @@ struct XML::Namespace
   def initialize(@document : Node, @ns : LibXML::NS*)
   end
 
-  def hashme(hasher)
+  def hash(hasher)
     hasher << object_id
   end
 

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -160,8 +160,8 @@ struct XML::Node
   end
 
   # Returns this node's `#object_id` as the hash value.
-  def hash
-    object_id
+  def hashme(hasher)
+    hasher << object_id
   end
 
   # Returns the content for this Node.

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -161,7 +161,7 @@ struct XML::Node
 
   # Returns this node's `#object_id` as the hash value.
   def hash(hasher)
-    hasher << object_id
+    hasher.raw object_id
   end
 
   # Returns the content for this Node.

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -160,7 +160,7 @@ struct XML::Node
   end
 
   # Returns this node's `#object_id` as the hash value.
-  def hashme(hasher)
+  def hash(hasher)
     hasher << object_id
   end
 

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -29,7 +29,7 @@ struct XML::NodeSet
   end
 
   def hash(hasher)
-    hasher << object_id
+    hasher.raw object_id
   end
 
   def inspect(io)

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -28,8 +28,8 @@ struct XML::NodeSet
     size == 0
   end
 
-  def hash
-    object_id
+  def hashme(hasher)
+    hasher << object_id
   end
 
   def inspect(io)

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -28,7 +28,7 @@ struct XML::NodeSet
     size == 0
   end
 
-  def hashme(hasher)
+  def hash(hasher)
     hasher << object_id
   end
 

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -195,11 +195,6 @@ struct YAML::Any
   end
 
   # :nodoc:
-  def hash
-    raw.hash
-  end
-
-  # :nodoc:
   def to_yaml(io)
     raw.to_yaml(io)
   end


### PR DESCRIPTION
To protect against Hash DoS, change the way hash value is computed.
Class|Struct should define method `def hashme(hasher)` and call
`hasher << @ivar` inside.

As an option, for speed, and for backward compatibility, `def hash`
still could be implemented. It will be used for Hash of matched type.
`Thread#hash` and `Enum#hash` is implemented as unseeded cause they are
 used before `StdHasher @@seed` is initialized.

But it is better to implement `def hashme(hasher)`.

StdHasher is default hasher that uses `hashme` and it is used as default
seeded hasher. It also implements `fasthash` used for fast hash of
primitive types, and `unseeded` for `Enums`.

Fixes #4578
Prerequisite for #4557