### PR TITLE
[WIP] Added --include and --exclude options to format tool

### DIFF
--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -15,6 +15,8 @@ class Crystal::Command
 
   private def format
     @format = "text"
+    excludes = ["lib"] of String
+    includes = [] of String
     check = nil
 
     option_parser =
@@ -27,6 +29,14 @@ class Crystal::Command
 
         opts.on("-f text|json", "--format text|json", "Output format text (default) or json") do |f|
           @format = f
+        end
+
+        opts.on("-i <path>", "--include <path>", "Include path") do |f|
+          includes << f
+        end
+
+        opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
+          excludes << f
         end
 
         opts.on("-h", "--help", "Show this message") do
@@ -51,9 +61,17 @@ class Crystal::Command
       end
     end
 
-    files = Dir["./**/*.cr"] if files.empty?
+    includes = normalize_paths includes
+    excludes = normalize_paths excludes
+    excludes = excludes - includes
 
-    format_many files, check_files
+    if files.empty?
+      files = Dir["./**/*.cr"]
+    else
+      files = normalize_paths files
+    end
+
+    format_many files, check_files, excludes
 
     if check_files
       if check_files.empty?
@@ -73,6 +91,14 @@ class Crystal::Command
         end
         exit 1
       end
+    end
+  end
+
+  private def normalize_paths(paths)
+    path_start = ".#{File::SEPARATOR}"
+    paths.map do |path|
+      path = path_start + path unless path.starts_with?(path_start)
+      path.rstrip(File::SEPARATOR)
     end
   end
 
@@ -133,19 +159,21 @@ class Crystal::Command
     end
   end
 
-  private def format_many(files, check_files)
+  private def format_many(files, check_files, excludes)
     files.each do |filename|
-      format_file_or_directory filename, check_files
+      format_file_or_directory filename, check_files, excludes
     end
   end
 
-  private def format_file_or_directory(filename, check_files)
+  private def format_file_or_directory(filename, check_files, excludes)
     if File.file?(filename)
-      format_file filename, check_files
+      unless excludes.any? { |exclude| filename.starts_with?(exclude) }
+        format_file filename, check_files
+      end
     elsif Dir.exists?(filename)
       filename = filename.chomp('/')
       filenames = Dir["#{filename}/**/*.cr"]
-      format_many filenames, check_files
+      format_many filenames, check_files, excludes
     else
       error "file or directory does not exist: #{filename}"
     end


### PR DESCRIPTION
Solves #3267 by adding `--include` and `--exclude` options to `´tool format`. `exclude` is by default populated with `lib`, so that files in `./lib` folder will not be formatted. This can be enabled by providing `--include lib` as commandline option.