### PR TITLE
Makefile: fix to work 'make help' when using Makefile.local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,17 +62,17 @@ all: crystal ## Build all files (currently crystal only) [default]
 help: ## Show this help
 	@echo
 	@printf '\033[34mtargets:\033[0m\n'
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
 		sort |\
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo
 	@printf '\033[34moptional variables:\033[0m\n'
-	@grep -E '^[a-zA-Z_-]+ \?=.*?## .*$$' $(MAKEFILE_LIST) |\
+	@grep -hE '^[a-zA-Z_-]+ \?=.*?## .*$$' $(MAKEFILE_LIST) |\
 		sort |\
 		awk 'BEGIN {FS = " \\?=.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo
 	@printf '\033[34mrecipes:\033[0m\n'
-	@grep -E '^##.*$$' $(MAKEFILE_LIST) |\
+	@grep -hE '^##.*$$' $(MAKEFILE_LIST) |\
 		awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'
 
 .PHONY: spec


### PR DESCRIPTION
When using `Makefile.local`, `make help` output seems buggy:

```
$ touch Makefile.local
$ make help
Using /usr/local/opt/llvm/bin/llvm-config [version=4.0.1]

targets:
  Makefile        Build all files (currently crystal only) [default]
  Makefile        Clean up built directories and files
  Makefile        Clean up crystal built files
  Makefile        Run compiler specs
  Makefile        Build the compiler
  Makefile        Build dependencies
  Makefile        Generate standard library documentation
  Makefile        Show this help
  Makefile        Run all specs
  Makefile        Run standard library specs

optional variables:
  Makefile:LLVM_CONFIG llvm-config command path to use
  Makefile:debug  Add symbolic debug info
  Makefile:junit_output Directory to output junit results
  Makefile:progress Enable progress output
  Makefile:release Compile in release mode
  Makefile:stats  Enable statistics output
  Makefile:threads Maximum number of threads to use
  Makefile:verbose Run specs in verbose mode

recipes:
```

This reason is I assumed `$MAKEFILE_LIST` is expanded to single file name, but when `-include Makefile.local` succeed, `$MAKEFILE_LIST` is expanded to `Makefile Makefile.local`, so it is broken.