### PR TITLE
String: rename `split` without separator to `words`

### DIFF
--- a/scripts/generate_unicode_data.cr
+++ b/scripts/generate_unicode_data.cr
@@ -145,7 +145,7 @@ body.each_line do |line|
   pieces = line.split(';')
   codepoint = pieces[0].to_i(16)
   status = pieces[1].strip[0]
-  casefold = pieces[2].split.map(&.to_i(16))
+  casefold = pieces[2].words.map(&.to_i(16))
   next if status != 'C' && status != 'F' # casefold uses full case folding (C and F)
   if casefold.size == 1
     casefold_mapping[codepoint] = casefold[0]
@@ -185,8 +185,8 @@ body.each_line do |line|
 
   pieces = line.split(';')
   codepoint = pieces[0].to_i(16)
-  downcase = pieces[1].split.map(&.to_i(16))
-  upcase = pieces[3].split.map(&.to_i(16))
+  downcase = pieces[1].words.map(&.to_i(16))
+  upcase = pieces[3].words.map(&.to_i(16))
   downcase = nil if downcase.size == 1
   upcase = nil if upcase.size == 1
   if downcase

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -247,8 +247,8 @@ describe "macro methods" do
       assert_macro "", %({{"foo" != "bar"}}), [] of ASTNode, %(true)
     end
 
-    it "executes split without arguments" do
-      assert_macro "", %({{"1 2 3".split}}), [] of ASTNode, %(["1", "2", "3"])
+    it "executes words" do
+      assert_macro "", %({{"1 2 3".words}}), [] of ASTNode, %(["1", "2", "3"])
     end
 
     it "executes split with argument" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -814,6 +814,15 @@ describe "String" do
     end
   end
 
+  describe "words" do
+    it { "   foo   bar\n\t  baz   ".words.should eq(["foo", "bar", "baz"]) }
+    it { "   foo   bar\n\t  baz   ".words(1).should eq(["   foo   bar\n\t  baz   "]) }
+    it { "   foo   bar\n\t  baz   ".words(2).should eq(["foo", "bar\n\t  baz   "]) }
+    it { "日本語 \n\t 日本 \n\n 語".words.should eq(["日本語", "日本", "語"]) }
+    it { "".words.should eq([] of String) }
+    it { "   \n  \t\n\r".words.should eq([] of String) }
+  end
+
   describe "split" do
     describe "by char" do
       it { "".split(',').should eq([""]) }
@@ -825,9 +834,6 @@ describe "String" do
       it { "foo   ".split(' ').should eq(["foo", "", "", ""]) }
       it { "   foo  bar".split(' ').should eq(["", "", "", "foo", "", "bar"]) }
       it { "   foo   bar\n\t  baz   ".split(' ').should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
-      it { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
-      it { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
-      it { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
       it { "   foo   bar\n\t  baz   ".split(" ").should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
       it { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }
       it { "foo,bar,baz,qux".split(',', 3).should eq(["foo", "bar", "baz,qux"]) }
@@ -836,7 +842,6 @@ describe "String" do
       it { "foo bar baz qux".split(' ', 3).should eq(["foo", "bar", "baz qux"]) }
       it { "foo bar baz qux".split(' ', 30).should eq(["foo", "bar", "baz", "qux"]) }
       it { "a,b,".split(',', 3).should eq(["a", "b", ""]) }
-      it { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
       it { "日本ん語日本ん語".split('ん').should eq(["日本", "語日本", "語"]) }
       it { "=".split('=').should eq(["", ""]) }
       it { "a=".split('=').should eq(["a", ""]) }

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -146,7 +146,7 @@ module Crystal
       if system("pkg-config #{libname}")
         if static
           flags = [] of String
-          `pkg-config #{libname} --libs --static`.split.each do |cfg|
+          `pkg-config #{libname} --libs --static`.words.each do |cfg|
             if cfg.starts_with?("-L")
               library_path << cfg[2..-1]
             elsif cfg.starts_with?("-l")

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -381,7 +381,11 @@ module Crystal::Macros
     def lines : ArrayLiteral(StringLiteral)
     end
 
-    # Similar to `String#split`.
+    # Similar to `String#words`.
+    def words : ArrayLiteral(StringLiteral)
+    end
+
+    # DEPRECATED: Use `#words`
     def split : ArrayLiteral(StringLiteral)
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -618,24 +618,22 @@ module Crystal
         interpret_argless_method(method, args) { NumberLiteral.new(@value.size) }
       when "lines"
         interpret_argless_method(method, args) { ArrayLiteral.map(@value.lines) { |value| StringLiteral.new(value) } }
+      when "words"
+        interpret_argless_method(method, args) { ArrayLiteral.map(@value.words) { |value| StringLiteral.new(value) } }
       when "split"
-        case args.size
-        when 0
-          ArrayLiteral.map(@value.split) { |value| StringLiteral.new(value) }
-        when 1
-          first_arg = args.first
-          case first_arg
+        raise "StringLiteral#split without separator was removed: use StringLiteral#words instead" if args.empty?
+
+        interpret_one_arg_method(method, args) do |arg|
+          case arg
           when CharLiteral
-            splitter = first_arg.value
+            splitter = arg.value
           when StringLiteral
-            splitter = first_arg.value
+            splitter = arg.value
           else
-            splitter = first_arg.to_s
+            splitter = arg.to_s
           end
 
           ArrayLiteral.map(@value.split(splitter)) { |value| StringLiteral.new(value) }
-        else
-          wrong_number_of_arguments "StringLiteral#split", args.size, "0..1"
         end
       when "starts_with?"
         interpret_one_arg_method(method, args) do |arg|

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -13,7 +13,7 @@ class Crystal::Program
 
   # Overrides the default flags with the given ones.
   def flags=(flags : String)
-    @flags = parse_flags(flags.split)
+    @flags = parse_flags(flags.words)
   end
 
   # Returns `true` if *name* is in the program's flags.

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -119,7 +119,7 @@ class HTTP::Client::Response
     line = io.gets(4096, chomp: true)
     return yield nil unless line
 
-    pieces = line.split(3)
+    pieces = line.words(3)
     http_version = pieces[0]
     status_code = pieces[1].to_i
     status_message = pieces[2]? ? pieces[2].chomp : ""

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -91,7 +91,7 @@ class HTTP::Request
     request_line = io.gets(4096, chomp: true)
     return unless request_line
 
-    parts = request_line.split
+    parts = request_line.words
     return BadRequest.new unless parts.size == 3
 
     method, resource, http_version = parts

--- a/src/string.cr
+++ b/src/string.cr
@@ -2891,8 +2891,8 @@ class String
     !!index(search)
   end
 
-  # Makes an array by splitting the string on any ASCII whitespace characters
-  # (and removing that whitespace).
+  # Makes an array of words, it means splitting the string
+  # on any ASCII whitespace characters (and removing that whitespace).
   #
   # If *limit* is present, up to *limit* new strings will be created,
   # with the entire remainder added to the last string.
@@ -2903,18 +2903,18 @@ class String
   #   a frog leaps in
   #   water's sound
   # "
-  # old_pond.split    # => ["Old", "pond", "a", "frog", "leaps", "in", "water's", "sound"]
-  # old_pond.split(3) # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
+  # old_pond.words    # => ["Old", "pond", "a", "frog", "leaps", "in", "water's", "sound"]
+  # old_pond.words(3) # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
   # ```
-  def split(limit : Int32? = nil)
+  def words(limit : Int32? = nil)
     ary = Array(String).new
-    split(limit) do |string|
+    each_word(limit) do |string|
       ary << string
     end
     ary
   end
 
-  # Splits the string after any ASCII whitespace character and yields each part to a block.
+  # Splits the string by words and yields each part to a block.
   #
   # If *limit* is present, up to *limit* new strings will be created,
   # with the entire remainder added to the last string.
@@ -2927,14 +2927,14 @@ class String
   #   water's sound
   # "
   #
-  # old_pond.split { |s| ary << s }
+  # old_pond.each_word { |s| ary << s }
   # ary # => ["Old", "pond", "a", "frog", "leaps", "in", "water's", "sound"]
   # ary.clear
   #
-  # old_pond.split(3) { |s| ary << s }
+  # old_pond.each_word(3) { |s| ary << s }
   # ary # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
   # ```
-  def split(limit : Int32? = nil, &block : String -> _)
+  def each_word(limit : Int32? = nil, &block : String -> _)
     if limit && limit <= 1
       yield self
       return
@@ -2984,6 +2984,16 @@ class String
       piece_size = single_byte_optimizable ? piece_bytesize : 0
       yield String.new(to_unsafe + index, piece_bytesize, piece_size)
     end
+  end
+
+  # DEPRECATED: Use `#words`
+  def split(limit : Int32? = nil)
+    {{ raise "'split' without separator was removed: use 'words' instead".id }}
+  end
+
+  # DEPRECATED: Use `#each_word`
+  def split(limit : Int32? = nil, &block : String ->)
+    {{ raise "'split' without separator was removed: use 'each_word' instead".id }}
   end
 
   # Makes an `Array` by splitting the string on the given character *separator*


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/issues/4644#issuecomment-312295584

Now, `String#split` without separator is deprecated (breaking change).