### PR TITLE
Fix '--release' flag place in man page's example

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -44,8 +44,8 @@ Note that by default the generated executables are not fully optimized.
 To turn optimizations on, use the --release flag:
 .Bd -offset indent-two
 .Nm
---release
 build
+--release
 some_program.cr
 .Ed
 


### PR DESCRIPTION
`crystal --release build some_program.cr` does not work. `--release` should be placed after `build` sub-command.