### PR TITLE
Parser: correctly lex the prefix of keyword in macro

### DIFF
--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -596,4 +596,12 @@ describe "Lexer macro" do
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(:MACRO_EXPRESSION_START)
   end
+
+  it "keeps correct line number after lexes the part of keyword and newline (#4656)" do
+    lexer = Lexer.new(%(ab\ncd)) # 'ab' means the part of 'abstract'
+    token = lexer.next_macro_token(Token::MacroState.default, false)
+    token.type.should eq(:MACRO_LITERAL)
+    token.value.should eq("ab\ncd")
+    lexer.line_number.should eq(2)
+  end
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2139,18 +2139,12 @@ module Crystal
             @macro_curly_count -= 1
           end
         else
-          # In the following codes `check_macro_opening_keyword(beginning_of_line)` and some `next_char` may let `@rader` forward.
-          # When `@reader` is forwarded and `@reader` points valuable character (i.e. `'\n'`),
-          # however this character is ignored by `char = next_char` on the last line of this loop.
-          # To prevent it, we must save `@reader.pos` to detect `@reader` is forwarded when below `if` conditions are failed.
-          old_pos = @reader.pos
-
-          if !delimiter_state && whitespace && char == 'y' && next_char == 'i' && next_char == 'e' && next_char == 'l' && next_char == 'd' && !ident_part_or_end?(peek_next_char)
+          if !delimiter_state && whitespace && lookahead { char == 'y' && next_char == 'i' && next_char == 'e' && next_char == 'l' && next_char == 'd' && !ident_part_or_end?(peek_next_char) }
             yields = true
             char = current_char
             whitespace = true
             beginning_of_line = false
-          elsif !delimiter_state && whitespace && (keyword = check_macro_opening_keyword(beginning_of_line))
+          elsif !delimiter_state && whitespace && (keyword = lookahead { check_macro_opening_keyword(beginning_of_line) })
             char = current_char
 
             if keyword == :macro && char.ascii_whitespace?
@@ -2191,13 +2185,6 @@ module Crystal
                 beginning_of_line = false
               end
             end
-
-            # As explained above, when `@reader` is forwarded, it must keep `char` as `current_char`.
-            if old_pos == @reader.pos
-              char = next_char
-            end
-
-            next
           end
         end
         char = next_char
@@ -2209,6 +2196,18 @@ module Crystal
       set_token_raw_from_start(start)
 
       @token
+    end
+
+    def lookahead
+      old_pos = @reader.pos
+      old_line_number, old_column_number = @line_number, @column_number
+
+      result = yield
+      unless result
+        @reader.pos = old_pos
+        @line_number, @column_number = old_line_number, old_column_number
+      end
+      result
     end
 
     def skip_macro_whitespace

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2139,6 +2139,12 @@ module Crystal
             @macro_curly_count -= 1
           end
         else
+          # In the following codes `check_macro_opening_keyword(beginning_of_line)` and some `next_char` may let `@rader` forward.
+          # When `@reader` is forwarded and `@reader` points valuable character (i.e. `'\n'`),
+          # however this character is ignored by `char = next_char` on the last line of this loop.
+          # To prevent it, we must save `@reader.pos` to detect `@reader` is forwarded when below `if` conditions are failed.
+          old_pos = @reader.pos
+
           if !delimiter_state && whitespace && char == 'y' && next_char == 'i' && next_char == 'e' && next_char == 'l' && next_char == 'd' && !ident_part_or_end?(peek_next_char)
             yields = true
             char = current_char
@@ -2185,6 +2191,13 @@ module Crystal
                 beginning_of_line = false
               end
             end
+
+            # As explained above, when `@reader` is forwarded, it must keep `char` as `current_char`.
+            if old_pos == @reader.pos
+              char = next_char
+            end
+
+            next
           end
         end
         char = next_char


### PR DESCRIPTION
Fixed #4656 

I'll explain why this fix is related to #4656. Following code is minified #4656 example:

```crystal
{% begin %}
  {{ :foo }}s
{% end %}

foo({
  foo: 1,
  foo_bar: 42,
})
```

This example produces formatting error because of `IndexError` which is raised from `align_infos`. In other words, #4656's reason is the formatter try to align incorrect line (If this **incorrect** line has enough columns to align, it produces incorrect result like #4656 gif, otherwise if it doesn't have, it raises `IndexError`).

Then, why the formatter try to align incorrect line, is the lexer is buggy. The lexer will report incorrect line number when a newline follows the part of some keywords inside macro (for example `s` is the part of `struct`). This bug is explained in detail on the source code comments, see them. And so, the formatter mistakes line number by this bug.

- - -

@sdogruyol expected me good thing, this helped me really. Thank you 😊 