### PR TITLE
Add helpful error message for invalid number literal like '.42'

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -321,6 +321,9 @@ describe "Lexer" do
   assert_syntax_error "4F64", "unexpected token: F64"
   assert_syntax_error "0F32", "unexpected token: F32"
 
+  assert_syntax_error ".42", ".1 style number literal is not supported, put 0 before dot"
+  assert_syntax_error "-.42", ".1 style number literal is not supported, put 0 before dot"
+
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -636,6 +636,8 @@ module Crystal
       when '~'
         next_char :"~"
       when '.'
+        line = @line_number
+        column = @column_number
         case next_char
         when '.'
           case next_char
@@ -644,6 +646,8 @@ module Crystal
           else
             @token.type = :".."
           end
+        when .ascii_number?
+          raise ".1 style number literal is not supported, put 0 before dot", line, column
         else
           @token.type = :"."
         end


### PR DESCRIPTION
Dot-started floating-point number like '.42' is not supported on Crystal. However compiler does not tell us this, so this fix adds to detect such a literal and to show helpful error message.

For example, old compiler shows an error message:

```console
$ crystal run foo.cr
Syntax error in foo.cr:1: unexpected token: .

foo = .42
      ^
```

And this PR compiler shows:

```console
$ ./bin/crystal run foo.cr
Using compiled compiler at `.build/crystal'
Syntax error in foo.cr:1: .1 style number literal is not supported, put 0 before dot

foo = .42
      ^
```

If you have more helpful error message text, please tell me. You know, my English is not good.