### PR TITLE
Statically link stdc++

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -15,7 +15,7 @@ end
 {% end %}
 
 {% begin %}
-  @[Link("stdc++")]
+  @[Link("stdc++", ldflags: "-Wl,-Bstatic -lstdc++ -Wl,-Bdynamic")]
   @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
   lib LibLLVM
     VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}


### PR DESCRIPTION
So we get better compatibility with older OSes.

Thanks to @ysbaddaden in #4647