### PR TITLE
Implement HTML.escape(string) in terms of HTML.escape(string, io)

### DIFF
--- a/src/html.cr
+++ b/src/html.cr
@@ -30,7 +30,9 @@ module HTML
   # HTML.escape("Crystal & You") # => "Crystal &amp; You"
   # ```
   def self.escape(string : String) : String
-    string.gsub(SUBSTITUTIONS)
+    io = IO::Memory.new
+    escape(string, io)
+    io.to_s
   end
 
   # Encodes a string to HTML, but writes to the `IO` instance provided.


### PR DESCRIPTION
While working on my PolyConf slides :wink: I discovered that `HTML.escape(string)` is implemeted in terms of `String#gsub`, rather than in terms of `HTML.escape(string, io)`. The below benchmark (with string examples [straight from this wonderful source](https://lise-henry.github.io/articles/optimising_strings.html)) suggests implementing `HTML.escape(string)` in terms of `HTML.escape(string, io)` is significantly faster while not sacrificing much readability.

```crystal
require "benchmark"
require "html"

strings = {
  no_html_short: "A paragraph without HTML characters that need to be escaped.",
  no_html_long: "Another paragraph without characters that need to be escaped. This paragraph is a bit longer, as sometimes there can be large paragraphs that don't any special characters, e.g., in novels or whatever.",
  html_short: "Here->An <<example>> of rust codefn foo(u: &u32) -> &u32 {u}",
  html_long: "A somewhat longer paragraph containing a character that needs to be escaped, because e.g. the author mentions the movie Fast&Furious in it. This paragraph is also quite long to match the non-html one.",
}

strings.each do |name, string|
  Benchmark.ips do |bench|
    bench.report("HTML.escape_io #{name}") do
      io = IO::Memory.new
      HTML.escape(string, io)
      io.to_s
    end
    bench.report("HTML.escape #{name}") do
      HTML.escape(string)
    end
  end
end
```

On current master (d24f79ca0), realigned for readability:

```
HTML.escape_io no_html_short   1.34M (743.83ns) (± 2.78%)       fastest
   HTML.escape no_html_short   1.02M (976.64ns) (± 3.55%)  1.31× slower
HTML.escape_io no_html_long  373.33k (  2.68µs) (± 1.70%)       fastest
   HTML.escape no_html_long  312.29k (   3.2µs) (± 1.73%)  1.20× slower
HTML.escape_io html_short      1.26M (793.38ns) (± 3.16%)       fastest
   HTML.escape html_short      1.03M (970.21ns) (± 2.64%)  1.22× slower
HTML.escape_io html_long     369.11k (  2.71µs) (± 2.09%)       fastest
   HTML.escape html_long     322.86k (   3.1µs) (± 1.50%)  1.14× slower
```

I’m not 100% sure what are the ramifications of choosing `IO::Memory#to_s` over `String#gsub`’s solution based on `String.build(bytesize)` (I’d guess potentially using up to twice the memory?), though, so do feel free to correct me on the usefulness of this, of course. :heart: 