### PR TITLE
change computation of hash value.

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -165,8 +165,26 @@ describe "BigFloat" do
   end
 
   it "#hash" do
-    b = 123.to_big_f
-    b.hash.should eq(b.to_f64.hash)
+    big_float = 123.to_big_f
+    big_float.hash.should eq(123.hash)
+    big_float.hash.should eq(big_float.to_f64.hash)
+
+    big_integer = "123456789012345678901".to_big_i
+    big_float = big_integer.to_big_f
+    big_float.should eq(big_integer)
+    big_float.hash_normalize.should eq(big_integer.hash_normalize)
+    big_float.hash.should eq(big_integer.hash)
+
+    float = 123.06125
+    big_float = float.to_big_f
+    big_float.hash.should eq(float.hash)
+
+    big_float = 1.to_big_f
+    big_float = big_float * 0x80000000 * 0x80000000 * 0x80000000
+    float = 1.0_f64
+    float = float * 0x80000000 * 0x80000000 * 0x80000000
+    big_float.hash_normalize.should eq(float.hash_normalize)
+    big_float.hash.should eq(float.hash)
   end
 
   it "clones" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -325,12 +325,35 @@ describe "BigInt" do
 
   it "#hash" do
     hash = 5.to_big_i.hash
-    hash.should eq(5)
-    typeof(hash).should eq(UInt64)
+    hash.should eq(5.hash)
+  end
+
+  it "#hash_normalize" do
+    hn = 5.to_big_i.hash_normalize
+    hn.should eq(5.hash_normalize)
+    hn = (-5).to_big_i.hash_normalize
+    hn.should eq((-5).hash_normalize)
+    hn = 500000000000000_u64.to_big_i.hash_normalize
+    hn.should eq(500000000000000_u64.hash_normalize)
+    hn = (-500000000000000_i64).to_big_i.hash_normalize
+    hn.should eq((-500000000000000_i64).hash_normalize)
+
+    bi = 1.to_big_i
+    bi = bi << 93
+    f = 1.0_f64
+    f = f * 0x80000000 * 0x80000000 * 0x80000000
+    bi.hash_normalize.should eq(f.hash_normalize)
+    (-bi).hash_normalize.should eq((-f).hash_normalize)
   end
 
   it "clones" do
     x = 1.to_big_i
     x.clone.should eq(x)
+  end
+
+  it "#to_big_f" do
+    s = "123456789012345678901"
+    x = BigInt.new(s)
+    x.to_big_f.should eq BigFloat.new(s)
   end
 end

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -163,7 +163,25 @@ describe BigRational do
   it "#hash" do
     b = br(10, 3)
     hash = b.hash
-    hash.should eq(b.to_f64.hash)
+    hash.should eq(b.to_big_f.hash)
+  end
+
+  it "#hash_normalize" do
+    hn = 5.to_big_i.hash_normalize
+    hn.should eq(5.hash_normalize)
+    hn = (-5).to_big_i.hash_normalize
+    hn.should eq((-5).hash_normalize)
+    hn = 500000000000000_u64.to_big_i.hash_normalize
+    hn.should eq(500000000000000_u64.hash_normalize)
+    hn = (-500000000000000_i64).to_big_i.hash_normalize
+    hn.should eq((-500000000000000_i64).hash_normalize)
+
+    bi = 1.to_big_r
+    bi = bi << 93
+    f = 1.0_f64
+    f = f * 0x80000000 * 0x80000000 * 0x80000000
+    bi.hash_normalize.should eq(f.hash_normalize)
+    (-bi).hash_normalize.should eq((-f).hash_normalize)
   end
 
   it "is a number" do
@@ -173,5 +191,11 @@ describe BigRational do
   it "clones" do
     x = br(10, 3)
     x.clone.should eq(x)
+  end
+
+  it "#to_big_f" do
+    x = br(10, 3)
+    f = BigFloat.new(10) / BigFloat.new(3)
+    x.to_big_f.should eq(f)
   end
 end

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -28,8 +28,9 @@ describe "Bool" do
   end
 
   describe "hash" do
-    it { true.hash.should eq(1) }
-    it { false.hash.should eq(0) }
+    it { true.hash.should eq(true.hash) }
+    it { false.hash.should eq(false.hash) }
+    it { true.hash.should_not eq(false.hash) }
   end
 
   describe "to_s" do

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -142,7 +142,7 @@ describe Enum do
   end
 
   it "has hash" do
-    SpecEnum::Two.hash.should eq(1.hash)
+    SpecEnum::Two.hash.should_not eq(SpecEnum::One.hash)
   end
 
   it "parses" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -145,8 +145,8 @@ describe "Hash" do
       end
     end
 
-    it "works with mixed types" do
-      {1 => :a, "a" => 1, 1.0 => "a", :a => 1.0}.values_at(1, "a", 1.0, :a).should eq({:a, 1, "a", 1.0})
+    it "works with mixed types and normalized numbers" do
+      {1 => :a, "a" => 1, 2.0 => "a", :a => 1.0}.values_at(1, 2, "a", 1.0, 2.0, :a).should eq({:a, "a", 1, :a, "a", 1.0})
     end
   end
 

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -42,11 +42,14 @@ describe "Struct" do
 
   it "does hash" do
     s = StructSpec::TestClass.new(1, "hello")
-    s.hash.should eq(31 + "hello".hash)
+    hasher = Hash::Hasher.new
+    hasher << 1
+    hasher << "hello"
+    s.hash.should eq(hasher.digest)
   end
 
   it "does hash for struct wrapper (#1940)" do
-    StructSpec::BigIntWrapper.new(BigInt.new(0)).hash.should eq(0)
+    StructSpec::BigIntWrapper.new(BigInt.new(0)).hash.should eq(BigInt.new(0).hash)
   end
 
   it "does dup" do

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -176,7 +176,7 @@ describe Time::Span do
   end
 
   it "test hash code" do
-    Time::Span.new(77).hash.should eq(77)
+    Time::Span.new(77).hash.should eq(77.hash)
   end
 
   it "test subtract" do

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -76,8 +76,19 @@ struct BigFloat < Float
     new(mpf)
   end
 
-  def hash
-    to_f64.hash
+  def hash_normalize
+    # more exact version of `remainder(HASH_MODULUS).to_f.hash_normalize`
+    LibGMP.mpf_get_d_2exp(out exp, self)
+    frac = BigFloat.new { |mpf|
+      if exp >= 0
+        LibGMP.mpf_div_2exp(mpf, self, exp)
+      else
+        LibGMP.mpf_mul_2exp(mpf, self, -exp)
+      end
+    }
+    float_normalize_wrap do
+      float_normalize_reference(frac, exp)
+    end
   end
 
   def self.default_precision

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -343,8 +343,19 @@ struct BigInt < Int
     io << "_big_i"
   end
 
-  def hash
-    to_u64
+  private HASH_MODULUS_INT_P = BigInt.new((1_u64 << HASH_BITS) - 1)
+  private HASH_MODULUS_INT_N = -BigInt.new((1_u64 << HASH_BITS) - 1)
+
+  def hash_normalize
+    # it should calculate `remainder(HASH_MODULUS)`
+    if LibGMP::ULong == UInt64
+      v = int_to_hashnorm(LibGMP.tdiv_ui(self, HASH_MODULUS))
+      self < 0 ? -v : v
+    elsif self >= HASH_MODULUS_INT_P || self <= HASH_MODULUS_INT_N
+      unsafe_truncated_mod(HASH_MODULUS_INT_P).to_i64
+    else
+      self.to_i64
+    end
   end
 
   # Returns a string representation of self.

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -161,8 +161,20 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_abs(mpq, self) }
   end
 
-  def hash
-    to_f64.hash
+  private HASH_MODULUS_RAT_P = BigRational.new((1_u64 << HASH_BITS) - 1)
+  private HASH_MODULUS_RAT_N = -BigRational.new((1_u64 << HASH_BITS) - 1)
+
+  def hash_normalize
+    # more exact version of `remainder(HASH_MODULUS).to_f.hash_normalize`
+    rem = self
+    if self >= HASH_MODULUS_RAT_P || self <= HASH_MODULUS_RAT_N
+      num = numerator
+      denom = denominator
+      div = num.tdiv(denom)
+      floor = div.tdiv(HASH_MODULUS)
+      rem -= floor * HASH_MODULUS
+    end
+    rem.to_big_f.hash_normalize
   end
 
   # Returns the `Float64` representing this rational.

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -41,9 +41,10 @@ struct Bool
     self != other
   end
 
-  # Returns a hash value for this boolean: 0 for `false`, 1 for `true`.
-  def hash
-    self ? 1 : 0
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher << (self ? 1 : 0)
+    hasher
   end
 
   # Returns `"true"` for `true` and `"false"` for `false`.

--- a/src/char.cr
+++ b/src/char.cr
@@ -419,6 +419,12 @@ struct Char
     ord
   end
 
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw ord
+    hasher
+  end
+
   # Returns a Char that is one codepoint bigger than this char's codepoint.
   #
   # ```

--- a/src/class.cr
+++ b/src/class.cr
@@ -3,8 +3,9 @@ class Class
     to_s(io)
   end
 
-  def hash
-    crystal_type_id
+  def hash(hasher)
+    hasher.raw(crystal_type_id)
+    hasher
   end
 
   def ==(other : Class)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1175,8 +1175,9 @@ module Crystal
       self
     end
 
-    def hash
-      0
+    def hash(hasher)
+      hasher << 0
+      hasher
     end
   end
 
@@ -1545,8 +1546,9 @@ module Crystal
       Self.new
     end
 
-    def hash
-      0
+    def hash(hasher)
+      hasher << 0
+      hasher
     end
   end
 
@@ -2025,8 +2027,9 @@ module Crystal
       Underscore.new
     end
 
-    def hash
-      0
+    def hash(hasher)
+      hasher << 0
+      hasher
     end
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -274,9 +274,10 @@ struct Enum
     value == other.value
   end
 
-  # Returns a hash value. This is the hash of the underlying value.
-  def hash
-    value.hash
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw(value)
+    hasher
   end
 
   # Iterates each values in a Flags Enum.

--- a/src/event/signal_handler.cr
+++ b/src/event/signal_handler.cr
@@ -1,5 +1,6 @@
 require "c/signal"
 require "c/unistd"
+require "signal"
 
 # :nodoc:
 # Singleton that runs Signal events (libevent2) in it's own Fiber.

--- a/src/hash/hasher.cr
+++ b/src/hash/hasher.cr
@@ -1,0 +1,188 @@
+require "crystal/system/random"
+
+# Hasher usable for `def hash(hasher)` should satisfy protocol:
+# ```
+# class MyHasher
+#   # Value should implement commutative `+` for `Hash#hash(hasher)`
+#   alias Value
+#
+#   # must be implemented to mix sizes of collections, and pointers (object_id)
+#   def raw(v : Int::Primitive)
+#     # mutate
+#     nil
+#   end
+#
+#   # must be implemented for Hash#hash
+#   def raw(v : Value)
+#     # mutate
+#     nil
+#   end
+#
+#   def <<(b : Bytes)
+#     # mutate
+#     nil
+#   end
+#
+#   def <<(n : Nil)
+#     # mutate
+#     nil
+#   end
+#
+#   def <<(v)
+#     # v.hash will return hasher
+#     # if hasher is a struct, then it will be copy
+#     copy_from v.hash(self)
+#     nil
+#   end
+#
+#   # digest returns hashsum for current state without state mutation
+#   def digest : Value
+#   end
+#
+#   # should be implemented for `Hash#hash(hasher)`
+#   def clone
+#     copy_of_current_state
+#   end
+# end
+# ```
+
+class Hash
+  # Hasher used as standard hasher in `Object#hash`
+  struct Hasher
+    # Type for Hash::Hasher#digest
+    alias Value = UInt32
+
+    @@seed = uninitialized StaticArray(UInt32, 1)
+    buf = pointerof(@@seed).as(Pointer(UInt8))
+    Crystal::System::Random.random_bytes(buf.to_slice(sizeof(typeof(@@seed))))
+
+    protected getter a : UInt32 = 0_u32
+
+    # Construct hasher with per-process seed.
+    def initialize
+      @a = @@seed[0]
+    end
+
+    # Construct hasher with custom seed.
+    def initialize(@a : UInt32)
+    end
+
+    # Calculate hashsum for value
+    def self.hashit(value) : Value
+      s = new(@@seed[0])
+      s << value
+      s.digest
+    end
+
+    # Make copy of self.
+    #
+    # Primary usage is for `Hash#hash` calculation.
+    def clone : self
+      self.class.new(@a)
+    end
+
+    # Mix nil to state
+    def <<(v : Nil) : Nil
+      permute_nil()
+      nil
+    end
+
+    # Mix raw value without number normalizing
+    def raw(v : Int8 | UInt8) : Nil
+      permute(v.to_u8)
+      nil
+    end
+
+    # Mix raw value without number normalizing
+    def raw(v : Int16 | Int32 | UInt16 | UInt32) : Nil
+      permute(v.to_u32)
+      nil
+    end
+
+    # Mix raw value without number normalizing
+    def raw(v : Int64 | UInt64) : Nil
+      high = (v >> 32).to_u32
+      # This condition here cause of some 32bit issue in LLVM binding,
+      # so compiler_spec doesn't pass without it.
+      # Feel free to comment and debug.
+      if high != 0_u32
+        permute(high)
+      end
+      permute(v.to_u32)
+      nil
+    end
+
+    # Mix slice of bytes to state (for string hashing)
+    def <<(b : Bytes) : Nil
+      permute(b)
+      nil
+    end
+
+    # Mix any value to state. `value` should implement `hash(hasher)` method.
+    #
+    # Numbers implement this method in a way equal numbers are hashed
+    # to same hashsum.
+    def <<(value) : Nil
+      cp = value.hash(self)
+      @a = cp.a
+      nil
+    end
+
+    # Returns hashsum for current state.
+    # It doesn't mutate hasher itself.
+    def digest : Value
+      a = @a
+      a ^= a >> 17
+      a *= 0xb8b34b2d_u32
+      a ^= a >> 16
+      a
+    end
+
+    # String representaion.
+    #
+    # It is overloaded to protect against occasional output.
+    # `inspect` is not overloaded, though.
+    def to_s(io : IO)
+      io << "Hash::Hasher()"
+    end
+
+    protected def permute_nil
+      # LFSR
+      mx = (@a.to_i32 >> 31).to_u32 & 0xa8888eef_u32
+      @a = (@a << 1) ^ mx
+    end
+
+    protected def permute(v : UInt8)
+      @a = @a * 31 + v
+    end
+
+    protected def permute(v : UInt32)
+      @a = @a * 31 + v
+    end
+
+    protected def permute(buf : Bytes)
+      buf.each do |b|
+        @a = @a * 31 + b
+      end
+    end
+
+    # unseeded is used for types that are used in early startup
+    def self.unseeded(v : Int8 | Int16 | UInt8 | UInt16 | Int32 | UInt32)
+      h = v.to_u32
+      h ^= h >> 16
+      h *= 0x52c6a2d9_u32
+      h ^ (h >> 16)
+    end
+
+    # unseeded is used for types that are used in early startup
+    def self.unseeded(v : Int64 | UInt64)
+      h = (v >> 32).to_u32
+      h ^= h >> 16
+      h *= 0xb8b34b2d_u32
+      h += v.to_u32
+      h ^= h >> 16
+      h *= 0x52c6a2d9_u32
+      h ^ (h >> 16)
+    end
+  end
+end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -9,13 +9,12 @@ struct HTTP::Headers
   record Key, name : String do
     forward_missing_to @name
 
-    def hash
-      h = 0
-      name.each_byte do |c|
-        c = normalize_byte(c)
-        h = 31 * h + c
+    def hash(hasher)
+      hasher.raw(bytesize.to_u32)
+      name.each_byte do |b|
+        hasher.raw normalize_byte(b)
       end
-      h
+      hasher
     end
 
     def ==(key2)
@@ -44,7 +43,7 @@ struct HTTP::Headers
 
       return byte if char.ascii_lowercase? || char == '-' # Optimize the common case
       return byte + 32 if char.ascii_uppercase?
-      return '-'.ord if char == '_'
+      return '-'.ord.to_u8 if char == '_'
 
       byte
     end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -271,13 +271,13 @@ module Indexable(T)
     first { nil }
   end
 
-  # Returns a hash code based on `self`'s size and elements.
-  #
-  # See also: `Object#hash`.
-  def hash
-    reduce(31 * size) do |memo, elem|
-      31 * memo + elem.hash
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw(size.to_u32)
+    each do |elem|
+      hasher << elem
     end
+    hasher
   end
 
   # Returns the index of the first appearance of *value* in `self`

--- a/src/int.cr
+++ b/src/int.cr
@@ -316,10 +316,6 @@ struct Int
     !even?
   end
 
-  def hash
-    self
-  end
-
   def succ
     self + 1
   end
@@ -594,6 +590,10 @@ struct Int8
   def clone
     self
   end
+
+  def hash_normalize
+    self
+  end
 end
 
 struct Int16
@@ -614,6 +614,10 @@ struct Int16
   end
 
   def clone
+    self
+  end
+
+  def hash_normalize
     self
   end
 end
@@ -638,6 +642,10 @@ struct Int32
   def clone
     self
   end
+
+  def hash_normalize
+    self
+  end
 end
 
 struct Int64
@@ -660,6 +668,10 @@ struct Int64
   def clone
     self
   end
+
+  def hash_normalize
+    unsafe_mod(HASH_MODULUS)
+  end
 end
 
 struct UInt8
@@ -680,6 +692,10 @@ struct UInt8
   end
 
   def clone
+    self
+  end
+
+  def hash_normalize
     self
   end
 end
@@ -704,6 +720,10 @@ struct UInt16
   def clone
     self
   end
+
+  def hash_normalize
+    self
+  end
 end
 
 struct UInt32
@@ -724,6 +744,10 @@ struct UInt32
   end
 
   def clone
+    self
+  end
+
+  def hash_normalize
     self
   end
 end
@@ -747,5 +771,9 @@ struct UInt64
 
   def clone
     self
+  end
+
+  def hash_normalize
+    unsafe_mod(HASH_MODULUS)
   end
 end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -262,11 +262,6 @@ struct JSON::Any
   end
 
   # :nodoc:
-  def hash
-    raw.hash
-  end
-
-  # :nodoc:
   def to_json(json : JSON::Builder)
     raw.to_json(json)
   end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -159,16 +159,14 @@ struct NamedTuple
     yield
   end
 
-  # Returns a hash value based on this name tuple's size, keys and values.
-  #
-  # See also: `Object#hash`.
-  def hash
-    hash = 31 * size
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw(size)
     {% for key in T.keys.sort %}
-      hash = 31 * hash + {{key.symbolize}}.hash
-      hash = 31 * hash + self[{{key.symbolize}}].hash
+      hasher << {{key.symbolize}}
+      hasher << self[{{key.symbolize}}]
     {% end %}
-    hash
+    hasher
   end
 
   # Same as `to_s`.

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -67,9 +67,10 @@ struct Nil
     false
   end
 
-  # Returns `0`.
-  def hash
-    0
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher << nil
+    hasher
   end
 
   # Returns an empty string.

--- a/src/number.cr
+++ b/src/number.cr
@@ -1,3 +1,5 @@
+require "./number/hash_normalize"
+
 # The top-level number type.
 struct Number
   include Comparable(Number)
@@ -253,6 +255,22 @@ struct Number
   # ```
   def zero? : Bool
     self == 0
+  end
+
+  include Number::HashNormalize
+
+  # Protocol method for generic hashing
+  # All number types should define `hash_normalize`, so equal number will
+  # produce equal normalized value.
+  # Integer numbers should calculate `self.remainder(HASH_MODULUS)`
+  # Float64 and Float32 version generalize it for numbers with fractional part.
+  # BigFloat and BigRational should calculate it as equivalent to
+  # `(v.remainder HASH_MODULUS).to_f.hash_normalize`, though more precise
+  # calculation used.
+  # See comments in "number/hash_normalize.cr"
+  def hash(hasher)
+    hasher.raw hash_normalize.to_i64
+    hasher
   end
 
   private class StepIterator(T, L, B)

--- a/src/number/hash_normalize.cr
+++ b/src/number/hash_normalize.cr
@@ -1,0 +1,88 @@
+module Number::HashNormalize
+  # Based on https://github.com/python/cpython/blob/f051e43/Python/pyhash.c#L34
+  #
+  # For numeric types, the hash of a number x is based on the reduction
+  # of x modulo the Mersen Prime P = 2**HASH_BITS - 1.  It's designed
+  # so that hash(x) == hash(y) whenever x and y are numerically equal,
+  # even if x and y have different types.
+  # A quick summary of the hashing strategy:
+  # (1) First define the 'reduction of x modulo P' for any rational
+  # number x; this is a standard extension of the usual notion of
+  # reduction modulo P for integers.  If x == p/q (written in lowest
+  # terms), the reduction is interpreted as the reduction of p times
+  # the inverse of the reduction of q, all modulo P; if q is exactly
+  # divisible by P then define the reduction to be infinity.  So we've
+  # got a well-defined map
+  #   reduce : { rational numbers } -> { 0, 1, 2, ..., P-1, infinity }.
+  # (2) Now for a rational number x, define hash(x) by:
+  #   reduce(x)   if x >= 0
+  #   -reduce(-x) if x < 0
+  # If the result of the reduction is infinity (this is impossible for
+  # integers, floats and Decimals) then use the predefined hash value
+  # HASH_INF for x >= 0, or -HASH_INF for x < 0, instead.
+  # HASH_INF, -HASH_INF and HASH_NAN are also used for the
+  # hashes of float and Decimal infinities and nans.
+  # A selling point for the above strategy is that it makes it possible
+  # to compute hashes of decimal and binary floating-point numbers
+  # efficiently, even if the exponent of the binary or decimal number
+  # is large.  The key point is that
+  #   reduce(x * y) == reduce(x) * reduce(y) (modulo HASH_MODULUS)
+  # provided that {reduce(x), reduce(y)} != {0, infinity}.  The reduction of a
+  # binary or decimal float is never infinity, since the denominator is a power
+  # of 2 (for binary) or a divisor of a power of 10 (for decimal).  So we have,
+  # for nonnegative x,
+  #   reduce(x * 2**e) == reduce(x) * reduce(2**e) % HASH_MODULUS
+  #   reduce(x * 10**e) == reduce(x) * reduce(10**e) % HASH_MODULUS
+  # and reduce(10**e) can be computed efficiently by the usual modular
+  # exponentiation algorithm.  For reduce(2**e) it's even better: since
+  # P is of the form 2**n-1, reduce(2**e) is 2**(e mod n), and multiplication
+  # by 2**(e mod n) modulo 2**n-1 just amounts to a rotation of bits.
+
+  private HASH_BITS     = 61
+  private HASH_MODULUS  = (1_i64 << HASH_BITS) - 1
+  private HASH_NAN      =      0_i64
+  private HASH_INFINITY = 314159_i64
+
+  private def int_to_hashnorm(v)
+    v.to_i64
+  end
+
+  # This function is for reference implementation, and it is used for BigFloat.
+  # For Float64 and Float32 all supported architectures allows more effective
+  # bitwise calculation.
+  # Arguments `frac` and `exp` are result of equivalent `Math.frexp`, though
+  # for `BigFloat` custom calculation used for more precision.
+  private def float_normalize_reference(frac, exp)
+    if self < 0
+      frac = -frac
+    end
+    # process 28 bits at a time;  this should work well both for binary
+    # and hexadecimal floating point.
+    x = 0_i64
+    while frac > 0
+      x = ((x << 28) & HASH_MODULUS) | x >> (HASH_BITS - 28)
+      frac *= 268435456.0 # 2**28
+      exp -= 28
+      y = frac.to_u32 # pull out integer part
+      frac -= y
+      x += y
+      x -= HASH_MODULUS if x >= HASH_MODULUS
+    end
+    {x, exp}
+  end
+
+  private def float_normalize_wrap
+    return HASH_NAN if nan?
+    if infinite?
+      return self > 0 ? +HASH_INFINITY : -HASH_INFINITY
+    end
+
+    x, exp = yield
+
+    # adjust for the exponent;  first reduce it modulo HASH_BITS
+    exp = exp >= 0 ? exp % HASH_BITS : HASH_BITS - 1 - ((-1 - exp) % HASH_BITS)
+    x = ((x << exp) & HASH_MODULUS) | x >> (HASH_BITS - exp)
+
+    x * (self < 0 ? -1 : 1)
+  end
+end

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -17,6 +17,7 @@ require "iterable"
 require "iterator"
 require "indexable"
 require "string"
+require "hash/hasher"
 
 # Alpha-sorted list
 require "array"

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -181,8 +181,9 @@ struct Proc
     call(other)
   end
 
-  def hash
-    internal_representation.hash
+  def hash(hasher)
+    hasher << internal_representation
+    hasher
   end
 
   def clone

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -50,9 +50,10 @@ class Reference
     {% end %}
   end
 
-  # Returns this reference's `object_id` as the hash value.
-  def hash
-    object_id
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw object_id
+    hasher
   end
 
   def inspect(io : IO) : Nil

--- a/src/set.cr
+++ b/src/set.cr
@@ -308,10 +308,6 @@ struct Set(T)
     pp.list("Set{", self, "}")
   end
 
-  def hash
-    @hash.hash
-  end
-
   # Returns `true` if the set and the given set have at least one element in
   # common.
   #

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -141,6 +141,17 @@ enum Signal
     Signal::PIPE.ignore
     Signal::CHLD.reset
   end
+
+  # There is no much of signals, so don't bother with hashing.
+  # And we couldn't use seeded hash, because seed is not filled yet.
+  # :nodoc:
+  def hash
+    value
+  end
+
+  def hash(hasher)
+    hasher.raw value
+  end
 end
 
 # :nodoc:

--- a/src/string.cr
+++ b/src/string.cr
@@ -3929,15 +3929,10 @@ class String
     sprintf self, other
   end
 
-  # Returns a hash based on this string’s size and content.
-  #
-  # See also: `Object#hash`.
-  def hash
-    h = 0
-    each_byte do |c|
-      h = 31 * h + c
-    end
-    h
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher << to_slice
+    hasher
   end
 
   # Returns the number of unicode codepoints in this string.

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -26,7 +26,9 @@ class StringPool
 
   # Creates a new empty string pool.
   def initialize
-    @buckets = Array(Array(String)?).new(11, nil)
+    @capacity = 8
+    @hashes = Pointer(Hash::Hasher::Value).malloc(@capacity, 0_u32)
+    @values = Pointer(String).malloc(@capacity, "")
     @size = 0
   end
 
@@ -70,24 +72,43 @@ class StringPool
   # pool.size # => 1
   # ```
   def get(str : UInt8*, len)
-    rehash if @size > 5 * @buckets.size
+    hash = hash(str, len)
+    get(hash, str, len)
+  end
 
-    index = bucket_index str, len
-    bucket = @buckets[index]
+  private def get(hash : Hash::Hasher::Value, str : UInt8*, len)
+    rehash if @size >= @capacity / 4 * 3
 
-    if bucket
-      entry = find_entry_in_bucket(bucket, str, len)
-      if entry
-        return entry
+    mask = (@capacity - 1).to_u32
+    index, d = hash & mask, 1
+    while (h = @hashes[index]) != 0
+      if h == hash && @values[index].bytesize == len
+        if str.memcmp(@values[index].to_unsafe, len) == 0
+          return @values[index]
+        end
       end
-    else
-      @buckets[index] = bucket = Array(String).new
+      index = (index + d) & mask
+      d += 1
     end
 
     @size += 1
     entry = String.new(str, len)
-    bucket.push entry
+    @hashes[index] = hash
+    @values[index] = entry
     entry
+  end
+
+  private def put_on_rehash(hash : Hash::Hasher::Value, entry : String)
+    mask = (@capacity - 1).to_u32
+    index, d = hash & mask, 1
+    while @hashes[index] != 0
+      index = (index + d) & mask
+      d += 1
+    end
+
+    @size += 1
+    @hashes[index] = hash
+    @values[index] = entry
   end
 
   # Returns a `String` with the contents of the given `IO::Memory`.
@@ -127,48 +148,30 @@ class StringPool
   #
   # Call this method if you modified a string submitted to the pool.
   def rehash
-    new_size = calculate_new_size(@size)
-    old_buckets = @buckets
-    @buckets = Array(Array(String)?).new(new_size, nil)
+    if @capacity * 2 <= 0
+      raise "Hash table too big"
+    end
+
+    old_capacity = @capacity
+    old_hashes = @hashes
+    old_values = @values
+
+    @capacity *= 2
+    @hashes = Pointer(Hash::Hasher::Value).malloc(@capacity, 0_u32)
+    @values = Pointer(String).malloc(@capacity, "")
     @size = 0
 
-    old_buckets.each do |bucket|
-      bucket.try &.each do |entry|
-        get(entry.to_unsafe, entry.size)
+    0.upto(old_capacity - 1) do |i|
+      if old_hashes[i] != 0
+        put_on_rehash(old_hashes[i], old_values[i])
       end
     end
-  end
-
-  private def bucket_index(str, len)
-    hash = hash(str, len)
-    (hash % @buckets.size).to_i
-  end
-
-  private def find_entry_in_bucket(bucket, str, len)
-    bucket.each do |entry|
-      if entry.size == len
-        if str.memcmp(entry.to_unsafe, len) == 0
-          return entry
-        end
-      end
-    end
-    nil
   end
 
   private def hash(str, len)
-    h = 0
-    str.to_slice(len).each do |c|
-      h = 31 * h + c
-    end
-    h
-  end
-
-  private def calculate_new_size(size)
-    new_size = 8
-    Hash::HASH_PRIMES.each do |hash_size|
-      return hash_size if new_size > size
-      new_size <<= 1
-    end
-    raise "Hash table too big"
+    hasher = Hash::Hasher.new
+    hasher << str.to_slice(len)
+    # hash should be non-zero, so `or` it with high bit
+    hasher.digest | 0x80000000_u32
   end
 end

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -73,12 +73,13 @@ struct Struct
   # Returns a hash value based on this struct's instance variables hash values.
   #
   # See also: `Object#hash`
-  def hash : Int32
-    hash = 0
+
+  # Protocol method for generic hashing.
+  def hash(hasher)
     {% for ivar in @type.instance_vars %}
-      hash = 31 * hash + @{{ivar.id}}.hash.to_i32
+      hasher << @{{ivar.id}}
     {% end %}
-    hash
+    hasher
   end
 
   # Appends this struct's name and instance variables names and values

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -15,11 +15,10 @@
 struct Symbol
   include Comparable(Symbol)
 
-  # Generates an `Int32` hash value for this symbol.
-  #
-  # See also: `Object#hash`.
-  def hash : Int32
-    to_i
+  # Protocol method for generic hashing.
+  def hash(hasher)
+    hasher.raw to_i
+    hasher
   end
 
   # Compares symbol with other based on `String#<=>` method. Returns `-1`, `0`

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -48,6 +48,12 @@ class Thread
     end
   end
 
+  # override, cause Hash::Hasher's seed is not initialized yet
+  # :nodoc:
+  def hash
+    Hash::Hasher.unseeded object_id
+  end
+
   # All threads, so the GC can see them (GC doesn't scan thread locals)
   # and we can find the current thread on platforms that don't support
   # thread local storage (eg: OpenBSD)

--- a/src/time.cr
+++ b/src/time.cr
@@ -309,10 +309,6 @@ struct Time
     end
   end
 
-  def hash
-    @encoded
-  end
-
   def self.days_in_month(year, month) : Int32
     unless 1 <= month <= 12
       raise ArgumentError.new "Invalid month"

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -307,15 +307,12 @@ struct Tuple
     size <=> other.size
   end
 
-  # Returns a hash value based on this tuple's length and contents.
-  #
-  # See also: `Object#hash`.
-  def hash
-    hash = 31 * size
+  # Protocol method for generic hashing.
+  def hash(hasher)
     {% for i in 0...T.size %}
-      hash = 31 * hash + self[{{i}}].hash
+      hasher << self[{{i}}]
     {% end %}
-    hash
+    hasher
   end
 
   # Returns a tuple containing cloned elements of this tuple using the `clone` method.

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -4,8 +4,9 @@ struct XML::Namespace
   def initialize(@document : Node, @ns : LibXML::NS*)
   end
 
-  def hash
-    object_id
+  def hash(hasher)
+    hasher.raw object_id
+    hasher
   end
 
   def href

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -160,8 +160,9 @@ struct XML::Node
   end
 
   # Returns this node's `#object_id` as the hash value.
-  def hash
-    object_id
+  def hash(hasher)
+    hasher.raw object_id
+    hasher
   end
 
   # Returns the content for this Node.

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -28,8 +28,9 @@ struct XML::NodeSet
     size == 0
   end
 
-  def hash
-    object_id
+  def hash(hasher)
+    hasher.raw object_id
+    hasher
   end
 
   def inspect(io)

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -195,11 +195,6 @@ struct YAML::Any
   end
 
   # :nodoc:
-  def hash
-    raw.hash
-  end
-
-  # :nodoc:
   def to_yaml(io)
     raw.to_yaml(io)
   end


### PR DESCRIPTION
To protect against Hash DoS, change the way hash value is computed.
Class|Struct should define method `def hash(hasher)` and call
`hasher << @ivar` inside.

As an option, for speed, and for backward compatibility, `def hash`
still could be implemented. It will be used for Hash of matched type.
`Thread#hash` and `Signal#hash` is implemented as unseeded cause they are
 used before `StdHasher @@seed` is initialized.

But it is better to implement `def hash(hasher)`.

StdHasher is default hasher that uses `hash(hasher)` and it is used as default
seeded hasher. It also implements `unseeded` for `Enums`.

Also, number normalization for hashing introduced, ie rule 'equality
forces hash equality' is forced (`a == b` => `a.hash == b.hash`).
Normalization idea is borrowed from Python implementation.
(idea by Akzhan Abdulin @akzhan)

Fixes #4578
Prerequisite for #4557
Replaces #4581