### PR TITLE
Allow to init a crystal app/lib in an empty directory

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -157,20 +157,7 @@ class Crystal::Command
   end
 
   private def init
-    begin
-      Init.run(options)
-    rescue ex : Init::FilesConflictError
-      STDERR.puts "Cannot initialize Crystal project, the following files would be overwritten:"
-      ex.conflicting_files.each do |path|
-        STDERR.puts "   #{"file".colorize(:red)} #{path} #{"already exist".colorize(:red)}"
-      end
-      STDERR.puts "You can use --force to overwrite those files,"
-      STDERR.puts "or --skip-existing to skip existing files and generate the others."
-      exit 1
-    rescue ex : Init::Error
-      STDERR.puts "Cannot initialize Crystal project: #{ex}"
-      exit 1
-    end
+    Init.run(options)
   end
 
   private def build

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -159,8 +159,16 @@ class Crystal::Command
   private def init
     begin
       Init.run(options)
+    rescue ex : Init::FilesConflictError
+      STDERR.puts "Cannot initialize Crystal project, the following files would be overwritten:"
+      ex.conflicting_files.each do |path|
+        STDERR.puts "   #{"file".colorize(:red)} #{path} #{"already exist".colorize(:red)}"
+      end
+      STDERR.puts "You can use --force to overwrite those files,"
+      STDERR.puts "or --skip-existing to skip existing files and generate the others."
+      exit 1
     rescue ex : Init::Error
-      STDERR.puts ex
+      STDERR.puts "Cannot initialize Crystal project: #{ex}"
       exit 1
     end
   end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -13,6 +13,14 @@ module Crystal
       end
     end
 
+    class FilesConflictError < Error
+      getter conflicting_files : Array(String)
+
+      def initialize(@conflicting_files)
+        super("Some files would be overwritten: #{conflicting_files.join(", ")}")
+      end
+    end
+
     def self.run(args)
       config = parse_args(args)
       InitProject.new(config).run
@@ -36,9 +44,17 @@ module Crystal
 
           USAGE
 
-        opts.on("--help", "show this help") do
+        opts.on("-h", "--help", "show this help") do
           puts opts
           exit
+        end
+
+        opts.on("-f", "--force", "force overwrite existing files") do
+          config.force = true
+        end
+
+        opts.on("-s", "--skip-existing", "skip existing files") do
+          config.skip_existing = true
         end
 
         opts.unknown_args do |args, after_dash|
@@ -46,6 +62,10 @@ module Crystal
           config.name = fetch_name(opts, args)
           config.dir = fetch_directory(args, config.name)
         end
+      end
+
+      if config.force && config.skip_existing
+        raise Error.new "Cannot use --force and --skip-existing together"
       end
 
       config.author = fetch_author
@@ -84,9 +104,11 @@ module Crystal
 
     def self.fetch_directory(args, project_name)
       directory = args.empty? ? project_name : args.shift
-      if Dir.exists?(directory) || File.exists?(directory)
-        raise Error.new "File or directory #{directory} already exists"
+
+      if File.file?(directory)
+        raise Error.new "#{directory.inspect} is a file"
       end
+
       directory
     end
 
@@ -113,6 +135,8 @@ module Crystal
       property email : String
       property github_name : String
       property silent : Bool
+      property force : Bool
+      property skip_existing : Bool
 
       def initialize(
         @skeleton_type = "none",
@@ -121,7 +145,9 @@ module Crystal
         @author = "none",
         @email = "none",
         @github_name = "none",
-        @silent = false
+        @silent = false,
+        @force = false,
+        @skip_existing = false
       )
       end
     end
@@ -143,13 +169,19 @@ module Crystal
       end
 
       def render
+        overwriting = File.exists?(full_path)
+
         Dir.mkdir_p(File.dirname(full_path))
         File.write(full_path, to_s)
-        puts log_message unless config.silent
+        puts log_message(overwriting) unless config.silent
       end
 
-      def log_message
-        "      #{"create".colorize(:light_green)}  #{full_path}"
+      def log_message(overwriting = false)
+        if overwriting
+          " #{"overwrite".colorize(:light_green)}  #{full_path}"
+        else
+          "    #{"create".colorize(:light_green)}  #{full_path}"
+        end
       end
 
       def module_name
@@ -161,18 +193,34 @@ module Crystal
 
     class InitProject
       getter config : Config
+      getter views : Array(View)?
 
       def initialize(@config : Config)
       end
 
-      def run
-        views.each do |view|
-          view.new(config).render
+      def overwrite_checks
+        overwriting_files = views.compact_map do |view|
+          path = view.full_path
+          File.exists?(path) ? path : nil
+        end
+
+        if overwriting_files.any?
+          if config.skip_existing
+            views.reject! { |view| File.exists?(view.full_path) }
+          else
+            raise FilesConflictError.new overwriting_files
+          end
         end
       end
 
+      def run
+        overwrite_checks unless config.force
+
+        views.each &.render
+      end
+
       def views
-        View.views
+        @views ||= View.views.map(&.new(config))
       end
     end
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -22,8 +22,21 @@ module Crystal
     end
 
     def self.run(args)
-      config = parse_args(args)
-      InitProject.new(config).run
+      begin
+        config = parse_args(args)
+        InitProject.new(config).run
+      rescue ex : Init::FilesConflictError
+        STDERR.puts "Cannot initialize Crystal project, the following files would be overwritten:"
+        ex.conflicting_files.each do |path|
+          STDERR.puts "   #{"file".colorize(:red)} #{path} #{"already exist".colorize(:red)}"
+        end
+        STDERR.puts "You can use --force to overwrite those files,"
+        STDERR.puts "or --skip-existing to skip existing files and generate the others."
+        exit 1
+      rescue ex : Init::Error
+        STDERR.puts "Cannot initialize Crystal project: #{ex}"
+        exit 1
+      end
     end
 
     def self.parse_args(args)


### PR DESCRIPTION
I usually create a github repository, then clone it and finally want to use `crystal init lib my_lib .` to initialize a lib project in the current directory. 
This previously failed with error `file or directory . already exists`.

This PR simply allow the directory to be `.` (the current directory).