### PR TITLE
kernel: Refactor after_fork_child_callbacks

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -182,10 +182,10 @@ class Process
   # Hooks are defined here due to load order problems.
   def self.after_fork_child_callbacks
     @@after_fork_child_callbacks ||= [
-      ->{ Scheduler.after_fork; nil },
-      ->{ Event::SignalHandler.after_fork; nil },
-      ->{ Event::SignalChildHandler.instance.after_fork; nil },
-      ->{ Random::DEFAULT.new_seed; nil },
+      ->Scheduler.after_fork,
+      ->Event::SignalHandler.after_fork,
+      ->{ Event::SignalChildHandler.instance.after_fork },
+      ->Random::DEFAULT.new_seed,
     ] of -> Nil
   end
 end


### PR DESCRIPTION
The `nil`s were probably needed, when the type inference wasn't powerful enough. They are not necessary anymore.