### PR TITLE
Format: raise an error if unclosed paren is found on finish

### DIFF
--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4330,6 +4330,8 @@ module Crystal
     end
 
     def finish
+      raise "BUG: unclosed parenthesis" if @paren_count > 0
+
       skip_space
       write_line
       skip_space_or_newline last: true


### PR DESCRIPTION
Related issue: #4685 

One of #4685's confusing points is `crystal tool format` command is succeeded in spite of invalid result. To prevent false negative, we should raise an error in such a case.