### PR TITLE
Add documentation for CallStack "caller" method

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -17,6 +17,19 @@ require "callstack/lib_unwind"
   require "debug/dwarf"
 {% end %}
 
+# `caller` returns the current execution stack (a backtrace) in the form
+# of an Array of strings:
+#
+# ```
+# ["0x102902805: *CallStack::unwind:Array(Pointer(Void)) at ??",
+#  "0x1029027a1: *CallStack#initialize:Array(Pointer(Void)) at ??",
+#  "0x102902778: *CallStack::new:CallStack at ??",
+#  "0x102901845: *caller:Array(String) at ??",
+#  "0x102901829: *__icr_exec__:Array(String) at ??",
+#  "0x1028f1612: __crystal_main at ??",
+#  "0x102901708: main at ??"]
+# ```
+#
 def caller
   CallStack.new.printable_backtrace
 end

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -17,7 +17,7 @@ require "callstack/lib_unwind"
   require "debug/dwarf"
 {% end %}
 
-# Returns the current execution stack (a backtrace) of the current
+# Returns the execution stack (a backtrace) of the current
 # `Fiber` as `Array(String)`.
 #
 # Formatting and content detail may vary between debug and release builds.

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -17,10 +17,10 @@ require "callstack/lib_unwind"
   require "debug/dwarf"
 {% end %}
 
-# Returns the current execution stack (a backtrace) as `Array(String)`.
+# Returns the current execution stack (a backtrace) of the current
+# `Fiber` as `Array(String)`.
 #
-# Formatting and content detail can vary between debug and release builds.
-#
+# Formatting and content detail may vary between debug and release builds.
 def caller
   CallStack.new.printable_backtrace
 end

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -17,18 +17,9 @@ require "callstack/lib_unwind"
   require "debug/dwarf"
 {% end %}
 
-# `caller` returns the current execution stack (a backtrace) in the form
-# of an Array of strings:
+# Returns the current execution stack (a backtrace) as `Array(String)`.
 #
-# ```
-# ["0x102902805: *CallStack::unwind:Array(Pointer(Void)) at ??",
-#  "0x1029027a1: *CallStack#initialize:Array(Pointer(Void)) at ??",
-#  "0x102902778: *CallStack::new:CallStack at ??",
-#  "0x102901845: *caller:Array(String) at ??",
-#  "0x102901829: *__icr_exec__:Array(String) at ??",
-#  "0x1028f1612: __crystal_main at ??",
-#  "0x102901708: main at ??"]
-# ```
+# Formatting and content detail can vary between debug and release builds.
 #
 def caller
   CallStack.new.printable_backtrace

--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -3,6 +3,7 @@
 # the fictitious API for the Crystal::Macros module.
 
 require "./big"
+require "./callstack"
 require "./compiler/crystal/macros"
 require "./crypto/**"
 require "./csv"


### PR DESCRIPTION
Per convo in gitter, it would be helpful to have this method (`caller`) exposed in the API documentation.

This PR adds a short method explanation and adds `callstack.cr` to the documentation build process.