### PR TITLE
[bugfix] insure proper handling of multiple Content-Length headers in http

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -347,5 +347,33 @@ module HTTP
         request.host_with_port.should eq("host.example.org:3000")
       end
     end
+
+    it "doesn't raise on request with multiple Content_length headers" do
+      io = IO::Memory.new <<-REQ
+        GET / HTTP/1.1
+        Host: host
+        Content-Length: 5
+        Content-Length: 5
+        Content-Type: text/plain
+
+        abcde
+        REQ
+      HTTP::Request.from_io(io)
+    end
+
+    it "raises if request has multiple and differing content-length headers" do
+      io = IO::Memory.new <<-REQ
+        GET / HTTP/1.1
+        Host: host
+        Content-Length: 5
+        Content-Length: 6
+        Content-Type: text/plain
+
+        abcde
+        REQ
+      expect_raises(ArgumentError) do
+        HTTP::Request.from_io(io)
+      end
+    end
   end
 end


### PR DESCRIPTION
When multiple Content-Length headers are received, error out if all received values do not match.
Return a single Content-Length header value.

This seems kind of an odd case, but it was the first thing that happened when adding Crystal to my stack today.
Multiple Content-Length headers, each of the same value, were added.
I've added a spec which fails using the earlier behavior.
