### PR TITLE
Allow `JSON::Builder#field` to accept non-scalar values.

### DIFF
--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -8,6 +8,12 @@ private def assert_built(expected)
   string.should eq(expected)
 end
 
+private class TestObject
+  def to_json(builder)
+    {"int" => 12}.to_json(builder)
+  end
+end
+
 describe JSON::Builder do
   it "writes null" do
     assert_built("null") do
@@ -249,6 +255,27 @@ describe JSON::Builder do
     json.start_object
     expect_raises JSON::Error, "Unterminated JSON object" do
       json.end_document
+    end
+  end
+
+  it "writes field with scalar in object" do
+    assert_built(%<{"int":42,"float":0.815,"null":null,"bool":true,"string":"string"}>) do
+      object do
+        field "int", 42
+        field "float", 0.815
+        field "null", nil
+        field "bool", true
+        field "string", "string"
+      end
+    end
+  end
+
+  it "writes field with arbitrary value in object" do
+    assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do
+      object do
+        field "hash", {"hash" => "value"}
+	field "object", TestObject.new
+      end
     end
   end
 end

--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -274,7 +274,7 @@ describe JSON::Builder do
     assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do
       object do
         field "hash", {"hash" => "value"}
-	field "object", TestObject.new
+        field "object", TestObject.new
       end
     end
   end

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -220,10 +220,10 @@ class JSON::Builder
 
   # Writes an object's field and value.
   # The field's name is first converted to a `String` by invoking
-  # `to_s` on it. The field's value can only be a `scalar`.
+  # `to_s` on it.
   def field(name, value)
     string(name)
-    scalar(value)
+    value.to_json(self)
   end
 
   # Writes an object's field and then invokes the block.


### PR DESCRIPTION
This simplifies writing complex values in json fields:
Instead of `json.field "field" { value.to_json(json) }` you can simply
write `json.field "field", value`.