### PR TITLE
Seperate Socket and FileDescriptor IO

### DIFF
--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -36,8 +36,7 @@ class Scheduler
       if flags.includes?(LibEvent2::EventFlags::Write)
         fd_io.resume_write
       elsif flags.includes?(LibEvent2::EventFlags::Timeout)
-        fd_io.write_timed_out = true
-        fd_io.resume_write
+        fd_io.resume_write(timed_out: true)
       end
     end
     event
@@ -51,8 +50,7 @@ class Scheduler
       if flags.includes?(LibEvent2::EventFlags::Read)
         fd_io.resume_read
       elsif flags.includes?(LibEvent2::EventFlags::Timeout)
-        fd_io.read_timed_out = true
-        fd_io.resume_read
+        fd_io.resume_read(timed_out: true)
       end
     end
     event

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -265,10 +265,14 @@ class Fiber
     {% end %}
   end
 
-  def sleep(time)
+  def sleep(time : Time::Span)
     event = @resume_event ||= Scheduler.create_resume_event(self)
     event.add(time)
     Scheduler.reschedule
+  end
+
+  def sleep(time : Number)
+    sleep(time.seconds)
   end
 
   def yield

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -9,17 +9,11 @@ class IO::FileDescriptor
   @read_event : Event::Event?
   @write_event : Event::Event?
 
-  def initialize(@fd : Int32, blocking = false, edge_triggerable = false)
-    @edge_triggerable = !!edge_triggerable
+  def initialize(@fd : Int32, blocking = false)
     @closed = false
-    @fd = fd
 
     unless blocking
       self.blocking = false
-      if @edge_triggerable
-        @read_event = Scheduler.create_fd_read_event(self, @edge_triggerable)
-        @write_event = Scheduler.create_fd_write_event(self, @edge_triggerable)
-      end
     end
   end
 
@@ -205,14 +199,12 @@ class IO::FileDescriptor
   end
 
   private def add_read_event(timeout = @read_timeout)
-    return if @edge_triggerable
     event = @read_event ||= Scheduler.create_fd_read_event(self)
     event.add timeout
     nil
   end
 
   private def add_write_event(timeout = @write_timeout)
-    return if @edge_triggerable
     event = @write_event ||= Scheduler.create_fd_write_event(self)
     event.add timeout
     nil

--- a/src/io/syscall.cr
+++ b/src/io/syscall.cr
@@ -1,0 +1,151 @@
+module IO::Syscall
+  @read_timed_out = false
+  @write_timed_out = false
+
+  @read_timeout : Time::Span?
+  @write_timeout : Time::Span?
+
+  @readers : Deque(Fiber)?
+  @writers : Deque(Fiber)?
+
+  # Returns the time to wait when reading before raising an `IO::Timeout`.
+  def read_timeout : Time::Span?
+    @read_timeout
+  end
+
+  # Sets the time to wait when reading before raising an `IO::Timeout`.
+  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @read_timeout = timeout
+  end
+
+  # Set the number of seconds to wait when reading before raising an `IO::Timeout`.
+  def read_timeout=(read_timeout : Number) : Number
+    self.read_timeout = read_timeout.seconds
+    read_timeout
+  end
+
+  # Returns the time to wait when writing before raising an `IO::Timeout`.
+  def write_timeout : Time::Span?
+    @write_timeout
+  end
+
+  # Sets the time to wait when writing before raising an `IO::Timeout`.
+  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @write_timeout = timeout
+  end
+
+  # Set the number of seconds to wait when writing before raising an `IO::Timeout`.
+  def write_timeout=(write_timeout : Number) : Number
+    self.write_timeout = write_timeout.seconds
+    write_timeout
+  end
+
+  def read_syscall_helper(slice : Bytes, errno_msg : String) : Int32
+    loop do
+      bytes_read = yield
+      if bytes_read != -1
+        return bytes_read
+      end
+
+      if Errno.value == Errno::EAGAIN
+        wait_readable
+      else
+        raise Errno.new(errno_msg)
+      end
+    end
+  ensure
+    if (readers = @readers) && !readers.empty?
+      add_read_event
+    end
+  end
+
+  def write_syscall_helper(slice : Bytes, errno_msg : String) : Nil
+    loop do
+      bytes_written = yield slice
+      if bytes_written != -1
+        slice += bytes_written
+        return if slice.size == 0
+      else
+        if Errno.value == Errno::EAGAIN
+          wait_writable
+        else
+          raise Errno.new(errno_msg)
+        end
+      end
+    end
+  ensure
+    if (writers = @writers) && !writers.empty?
+      add_write_event
+    end
+  end
+
+  # :nodoc:
+  def resume_read(timed_out = false)
+    @read_timed_out = timed_out
+
+    if reader = @readers.try &.shift?
+      reader.resume
+    end
+  end
+
+  # :nodoc:
+  def resume_write(timed_out = false)
+    @write_timed_out = timed_out
+
+    if writer = @writers.try &.shift?
+      writer.resume
+    end
+  end
+
+  private def wait_readable(timeout = @read_timeout)
+    wait_readable(timeout: timeout) { |err| raise err }
+  end
+
+  private def wait_readable(timeout = @read_timeout)
+    readers = (@readers ||= Deque(Fiber).new)
+    readers << Fiber.current
+    add_read_event(timeout)
+    Scheduler.reschedule
+
+    if @read_timed_out
+      @read_timed_out = false
+      yield Timeout.new("Read timed out")
+    end
+
+    nil
+  end
+
+  private abstract def add_read_event(timeout = @read_timeout)
+
+  private def wait_writable(timeout = @write_timeout)
+    wait_writable(timeout: timeout) { |err| raise err }
+  end
+
+  private def wait_writable(timeout = @write_timeout)
+    writers = (@writers ||= Deque(Fiber).new)
+    writers << Fiber.current
+    add_write_event(timeout)
+    Scheduler.reschedule
+
+    if @write_timed_out
+      @write_timed_out = false
+      yield Timeout.new("Write timed out")
+    end
+
+    nil
+  end
+
+  private abstract def add_write_event(timeout = @write_timeout)
+
+  private def reschedule_waiting
+    if readers = @readers
+      Scheduler.enqueue readers
+      readers.clear
+    end
+
+    if writers = @writers
+      Scheduler.enqueue writers
+      writers.clear
+    end
+  end
+end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -5,7 +5,10 @@ require "c/netinet/tcp"
 require "c/sys/socket"
 require "c/sys/un"
 
-class Socket < IO::FileDescriptor
+class Socket
+  include IO::Buffered
+  include IO::Syscall
+
   class Error < Exception
   end
 
@@ -34,6 +37,13 @@ class Socket < IO::FileDescriptor
   # :nodoc:
   SOMAXCONN = 128
 
+  getter fd : Int32
+
+  @read_event : Event::Event?
+  @write_event : Event::Event?
+
+  @closed = false
+
   getter family : Family
   getter type : Type
   getter protocol : Protocol
@@ -60,14 +70,21 @@ class Socket < IO::FileDescriptor
     fd = LibC.socket(family, type, protocol)
     raise Errno.new("failed to create socket:") if fd == -1
     init_close_on_exec(fd)
-    super(fd, blocking)
+    @fd = fd
+
     self.sync = true
+    unless blocking
+      self.blocking = false
+    end
   end
 
-  protected def initialize(fd : Int32, @family, @type, @protocol = Protocol::IP)
-    init_close_on_exec(fd)
-    super fd, blocking: false
+  protected def initialize(@fd : Int32, @family, @type, @protocol = Protocol::IP, blocking = false)
+    init_close_on_exec(@fd)
+
     self.sync = true
+    unless blocking
+      self.blocking = false
+    end
   end
 
   # Force opened sockets to be closed on `exec(2)`. Only for platforms that don't
@@ -456,6 +473,112 @@ class Socket < IO::FileDescriptor
     addr = LibC::In6Addr.new
     ptr = pointerof(addr).as(Void*)
     LibC.inet_pton(LibC::AF_INET, string, ptr) > 0 || LibC.inet_pton(LibC::AF_INET6, string, ptr) > 0
+  end
+
+  def blocking
+    fcntl(LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+  end
+
+  def blocking=(value)
+    flags = fcntl(LibC::F_GETFL)
+    if value
+      flags &= ~LibC::O_NONBLOCK
+    else
+      flags |= LibC::O_NONBLOCK
+    end
+    fcntl(LibC::F_SETFL, flags)
+  end
+
+  def close_on_exec?
+    flags = fcntl(LibC::F_GETFD)
+    (flags & LibC::FD_CLOEXEC) == LibC::FD_CLOEXEC
+  end
+
+  def close_on_exec=(arg : Bool)
+    fcntl(LibC::F_SETFD, arg ? LibC::FD_CLOEXEC : 0)
+    arg
+  end
+
+  def self.fcntl(fd, cmd, arg = 0)
+    r = LibC.fcntl fd, cmd, arg
+    raise Errno.new("fcntl() failed") if r == -1
+    r
+  end
+
+  def fcntl(cmd, arg = 0)
+    self.class.fcntl @fd, cmd, arg
+  end
+
+  def finalize
+    return if closed?
+
+    close rescue nil
+  end
+
+  def closed?
+    @closed
+  end
+
+  def tty?
+    LibC.isatty(fd) == 1
+  end
+
+  private def unbuffered_read(slice : Bytes)
+    read_syscall_helper(slice, "Error reading socket") do
+      # `to_i32` is acceptable because `Slice#size` is a Int32
+      LibC.recv(@fd, slice, slice.size, 0).to_i32
+    end
+  end
+
+  private def unbuffered_write(slice : Bytes)
+    write_syscall_helper(slice, "Error writing to socket") do |slice|
+      LibC.send(@fd, slice, slice.size, 0)
+    end
+  end
+
+  private def add_read_event(timeout = @read_timeout)
+    event = @read_event ||= Scheduler.create_fd_read_event(self)
+    event.add timeout
+    nil
+  end
+
+  private def add_write_event(timeout = @write_timeout)
+    event = @write_event ||= Scheduler.create_fd_write_event(self)
+    event.add timeout
+    nil
+  end
+
+  private def unbuffered_rewind
+    raise IO::Error.new("Can't rewind")
+  end
+
+  private def unbuffered_close
+    return if @closed
+
+    err = nil
+    if LibC.close(@fd) != 0
+      case Errno.value
+      when Errno::EINTR, Errno::EINPROGRESS
+        # ignore
+      else
+        err = Errno.new("Error closing socket")
+      end
+    end
+
+    @closed = true
+
+    @read_event.try &.free
+    @read_event = nil
+    @write_event.try &.free
+    @write_event = nil
+
+    reschedule_waiting
+
+    raise err if err
+  end
+
+  private def unbuffered_flush
+    # Nothing
   end
 end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -42,7 +42,8 @@ struct Time::Span
 
   include Comparable(self)
 
-  TicksPerMillisecond = 10_000_i64
+  TicksPerMicrosecond = 10_i64
+  TicksPerMillisecond = TicksPerMicrosecond * 1000
   TicksPerSecond      = TicksPerMillisecond * 1000
   TicksPerMinute      = TicksPerSecond * 60
   TicksPerHour        = TicksPerMinute * 60
@@ -52,7 +53,7 @@ struct Time::Span
   MinValue = new Int64::MIN
   Zero     = new 0
 
-  # 1 tick is a tenth of a millisecond
+  # 1 tick is a tenth of a microsecond
   @ticks : Int64
 
   getter ticks


### PR DESCRIPTION
On some platforms - notably windows - socket descriptors are different from file
descriptors so it makes little sense for them to be shared under a common hierarchy.

This is done in 3 stages:
- Firstly I refactored out the common logic for dealing with nonblocking IO using `read`/`write` like functions from `IO::FileDescriptor` into `IO::Syscall`. It takes care of checking for EAGAIN and managing the lists of waiting fibers.
- Then, I removed the `edge_triggerable` option from `IO::FileDescriptor`, it doesn't seem to be used anywhere and it seems to me like it would cause hangs and other weird behaviour if used.
- Finally, I changed `Socket` not to inherit `IO::FileDescriptor`. This involved quite a lot of copy-pasting code, which seems like a step backwards, but it means we can refactor `File` and `Socket` to use `Crystal::System` separately. Once these refactors are done both `File` and `Socket` class hierarchies will likely end up much cleaner.