### PR TITLE
Fix chained comparisons `to_s` to work #4663

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -98,6 +98,10 @@ describe Playground::AgentInstrumentorTransformer do
     assert_agent %(a || b), %(_p.i(1) { a || b })
   end
 
+  it "instrument chained comparisons (#4663)" do
+    assert_agent %(1 <= 2 <= 3), %(_p.i(1) { 1 <= 2 <= 3 })
+  end
+
   it "instrument unary expressions" do
     assert_agent %(pointerof(x)), %(_p.i(1) { pointerof(x) })
   end

--- a/spec/compiler/normalize/chained_comparisons_spec.cr
+++ b/spec/compiler/normalize/chained_comparisons_spec.cr
@@ -2,22 +2,22 @@ require "../../spec_helper"
 
 describe "Normalize: chained comparisons" do
   it "normalizes one comparison with literal" do
-    assert_normalize "1 <= 2 <= 3", "(1 <= 2) && (2 <= 3)"
+    assert_normalize "1 <= 2 <= 3", "1 <= 2 && 2 <= 3"
   end
 
   it "normalizes one comparison with var" do
-    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n(1 <= b) && (b <= 3)"
+    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n1 <= b && b <= 3"
   end
 
   it "normalizes one comparison with call" do
-    assert_normalize "1 <= b <= 3", "(1 <= (__temp_1 = b)) && (__temp_1 <= 3)"
+    assert_normalize "1 <= b <= 3", "1 <= (__temp_1 = b) && __temp_1 <= 3"
   end
 
   it "normalizes two comparisons with literal" do
-    assert_normalize "1 <= 2 <= 3 <= 4", "((1 <= 2) && (2 <= 3)) && (3 <= 4)"
+    assert_normalize "1 <= 2 <= 3 <= 4", "(1 <= 2 && 2 <= 3) && 3 <= 4"
   end
 
   it "normalizes two comparisons with calls" do
-    assert_normalize "1 <= a <= b <= 4", "((1 <= (__temp_2 = a)) && (__temp_2 <= (__temp_1 = b))) && (__temp_1 <= 4)"
+    assert_normalize "1 <= a <= b <= 4", "(1 <= (__temp_2 = a) && __temp_2 <= (__temp_1 = b)) && __temp_1 <= 4"
   end
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -105,4 +105,7 @@ describe "ASTNode#to_s" do
   expect_to_s %(alias Foo = Void)
   expect_to_s %(type(Foo = Void))
   expect_to_s %(return true ? 1 : 2), %(return begin\n  if true\n    1\n  else\n    2\n  end\nend)
+  expect_to_s %(1 <= 2 <= 3)
+  expect_to_s %((1 <= 2) <= 3)
+  expect_to_s %(1 <= (2 <= 3))
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -425,7 +425,7 @@ module Crystal
           !letter_or_underscore?(obj.name)
         else
           case obj.name
-          when "[]", "[]?"
+          when "[]", "[]?", "<", "<=", ">", ">="
             false
           else
             true


### PR DESCRIPTION
Fixed #4663

The ASTNode of `1 <= 2 <= 3` is `to_s`-ed to `(1 <= 2) <= 3`. Right side parenthesis is not required and it causes #4653 error.