### PR TITLE
Rename skip() macro method to skip_file()

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -989,13 +989,13 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  describe "skip macro directive" do
+  describe "skip_file macro directive" do
     it "skips expanding the rest of the current file" do
       res = semantic(%(
         class A
         end
 
-        {% skip() %}
+        {% skip_file() %}
 
         class B
         end
@@ -1012,7 +1012,7 @@ describe "Semantic: macro" do
 
         {% if true %}
           class C; end
-          {% skip() %}
+          {% skip_file() %}
           class D; end
         {% end %}
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -19,8 +19,8 @@ module Crystal
         interpret_puts(node)
       when "pp"
         interpret_pp(node)
-      when "skip"
-        interpret_skip(node)
+      when "skip_file"
+        interpret_skip_file(node)
       when "system", "`"
         interpret_system(node)
       when "raise"
@@ -133,7 +133,7 @@ module Crystal
       @last = Nop.new
     end
 
-    def interpret_skip(node)
+    def interpret_skip_file(node)
       raise SkipMacroException.new(@str.to_s)
     end
 

--- a/src/crystal/system/unix/arc4random.cr
+++ b/src/crystal/system/unix/arc4random.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:openbsd) %}
+{% skip_file() unless flag?(:openbsd) %}
 
 require "c/stdlib"
 

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:linux) %}
+{% skip_file() unless flag?(:linux) %}
 
 require "c/unistd"
 require "c/sys/syscall"

--- a/src/crystal/system/unix/sysconf_cpucount.cr
+++ b/src/crystal/system/unix/sysconf_cpucount.cr
@@ -1,4 +1,4 @@
-{% skip_file if flag?(:openbsd) || flag?(:freebsd) %}
+{% skip_file() if flag?(:openbsd) || flag?(:freebsd) %}
 
 require "c/unistd"
 

--- a/src/crystal/system/unix/sysctl_cpucount.cr
+++ b/src/crystal/system/unix/sysctl_cpucount.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:openbsd) || flag?(:freebsd) %}
+{% skip_file() unless flag?(:openbsd) || flag?(:freebsd) %}
 
 require "c/sysctl"
 

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -1,5 +1,5 @@
 # TODO: replace with `flag?(:unix) && !flag?(:openbsd) && !flag?(:linux)` after crystal > 0.22.0 is released
-{% skip_file if flag?(:openbsd) && flag?(:linux) %}
+{% skip_file() if flag?(:openbsd) && flag?(:linux) %}
 
 module Crystal::System::Random
   @@initialized = false


### PR DESCRIPTION
There was a miscommunication in the macro's name when implementing Crystal::System, meaning that skip_file was used but the method was implemented as skip. In addition, add parens to skip_file to make it parse as a function call.