### PR TITLE
Regex - Optional Unicode properties support, and prefer brewed libpcre on MacOS

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -82,9 +82,18 @@ describe "Regex" do
     $2.should eq("ba")
   end
 
-  it "matches with Unicode properties for \d, \w, etc." do
-    (/(*UCP)[[:alnum:]]/.match "à").should be_truthy
-    (/(*UCP)\w/.match "à").should be_truthy
+  if LibPCRE::HAS_UCP
+    it "matches with Unicode properties for alnum character class with UCP flag" do
+      (/(*UCP)[[:alnum:]]/.match "à").should be_truthy
+    end
+
+    it "matches with Unicode properties for \w with UCP option" do
+      (Regex.new("\\w", Regex::Options::UCP).match "à").should be_truthy
+    end
+  else
+    pending "PCRE built without Unicode properties support" do
+      nothing
+    end
   end
 
   describe "name_table" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -82,6 +82,11 @@ describe "Regex" do
     $2.should eq("ba")
   end
 
+  it "matches with Unicode properties for \d, \w, etc." do
+    (/[[:alnum:]]/.match "à").should be_true
+    (/\w/.match "à").should be_true
+  end
+
   describe "name_table" do
     it "is a map of capture group number to name" do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -83,8 +83,8 @@ describe "Regex" do
   end
 
   it "matches with Unicode properties for \d, \w, etc." do
-    (/[[:alnum:]]/.match "à").should be_true
-    (/\w/.match "à").should be_true
+    (/(*UCP)[[:alnum:]]/.match "à").should be_truthy
+    (/(*UCP)\w/.match "à").should be_truthy
   end
 
   describe "name_table" do

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -210,6 +210,8 @@ class Regex
     UTF_8 = 0x00000800
     # :nodoc:
     NO_UTF8_CHECK = 0x00002000
+    # :nodoc:
+    PCRE_UCP = 0x20000000
   end
 
   # Return a `Regex::Options` representing the optional flags applied to this `Regex`.
@@ -240,7 +242,7 @@ class Regex
     source = source.gsub('\u{0}', "\\0")
     @source = source
 
-    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK), out errptr, out erroffset, nil)
+    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::PCRE_UCP), out errptr, out erroffset, nil)
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, 0, out studyerrptr)
     raise ArgumentError.new("#{String.new(studyerrptr)}") if @extra.null? && studyerrptr
@@ -255,7 +257,7 @@ class Regex
   # Regex.error?("(foo|bar")  # => "missing ) at 8"
   # ```
   def self.error?(source)
-    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK), out errptr, out erroffset, nil)
+    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::PCRE_UCP), out errptr, out erroffset, nil)
     if re
       nil
     else

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -211,7 +211,7 @@ class Regex
     # :nodoc:
     NO_UTF8_CHECK = 0x00002000
     # :nodoc:
-    PCRE_UCP = 0x20000000
+    UCP = 0x20000000
   end
 
   # Return a `Regex::Options` representing the optional flags applied to this `Regex`.
@@ -242,7 +242,7 @@ class Regex
     source = source.gsub('\u{0}', "\\0")
     @source = source
 
-    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::PCRE_UCP), out errptr, out erroffset, nil)
+    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK), out errptr, out erroffset, nil)
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, 0, out studyerrptr)
     raise ArgumentError.new("#{String.new(studyerrptr)}") if @extra.null? && studyerrptr
@@ -257,7 +257,7 @@ class Regex
   # Regex.error?("(foo|bar")  # => "missing ) at 8"
   # ```
   def self.error?(source)
-    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::PCRE_UCP), out errptr, out erroffset, nil)
+    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK), out errptr, out erroffset, nil)
     if re
       nil
     else

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,4 +1,4 @@
-@[Link("pcre")]
+@[Link("libpcre")]
 lib LibPCRE
   alias Int = LibC::Int
 

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,4 +1,4 @@
-@[Link("libpcre")]
+@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs libpcre || printf %s '-lpcre'`")]
 lib LibPCRE
   alias Int = LibC::Int
 

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,4 +1,11 @@
-@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs libpcre || printf %s '-lpcre'`")]
+{% begin %}
+  lib LibPCRE
+    PCRE_810 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=8.10 libpcre || pkg-config --atleast-version=8.10 pcre || printf %s false`.stringify != "false" }}
+    HAS_UCP  = PCRE_810 && {{ `command -v pcretest > /dev/null && command -v grep > /dev/null && pcretest -C | grep 'Unicode properties support' || printf %s false`.stringify != "false" }}
+  end
+{% end %}
+
+@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs libpcre || pkg-config --libs pcre || printf %s '-lpcre'`")]
 lib LibPCRE
   alias Int = LibC::Int
 


### PR DESCRIPTION
Current crystal depends on `pcre` instead of `libpcre`. It breaks linking to newest PCRE under MacOS. 

I have changed link attribute and add specs for UCP support.

```crystal
/(*UCP)[[:alnum:]]/.match "à"
```

UCP support disabled by default due to bad performance, but can be used by "(*UCP)" flag or by `Regex::Options::UCP` option.

This pull request depends on PCRE 8.10 or above.

Fixes #4704.