### PR TITLE
Add NamedTuple#update(other : NamedTuple) to merge values but keep type

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -296,4 +296,10 @@ describe "NamedTuple" do
     tup = {a: 1, b: 'a'}
     tup.values.should eq({1, 'a'})
   end
+
+  it "updates with values from other named tuple" do
+    a = {one: 1, two: 2, three: 3, four: 4, five: 5, "im \"string": "works"}
+    b = {two: 22, three: 33, "im \"string": "ok"}
+    c = a.update(b).update(three: 333, four: 44).should eq({one: 1, two: 22, three: 333, four: 44, five: 5, "im \"string": "ok"})
+  end
 end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -159,6 +159,35 @@ struct NamedTuple
     yield
   end
 
+  # Merges values from *other* into `self`, returning a new named tuple of the same type.
+  #
+  # ```
+  # a = {foo: "Hello", bar: "Old"}
+  # b = {bar: "New"}
+  # a.update(b) # => {foo: "Hello", bar: "New"}
+  # ```
+  #
+  # Adding keys or changing types will fail at compile time:
+  # ```
+  # {one: 1}.update(three: 3)
+  # {one: 1}.update(one: true)
+  # ```
+  def update(other : NamedTuple)
+    update(**other)
+  end
+
+  def update(**other : **U) forall U
+    {% begin %}
+      self.class.new(
+      {% for key, value in U %}
+        {{key.stringify}}: other[:{{key.stringify}}].as({{value.id}}),
+      {% end %}{% for key, value in T %}{% unless U.keys.includes?(key) %}
+        {{key.stringify}}: self[:{{key.stringify}}],
+      {% end %}{% end %}
+      )
+    {% end %}
+  end
+
   # Returns a hash value based on this name tuple's size, keys and values.
   #
   # See also: `Object#hash`.


### PR DESCRIPTION
This method is similar to #4688 and #2634 with different semantics as proposed in [#4688 (comment)](4688#issuecomment-315546785):

`NamedTuple#update(other : NamedTuple)` creates a new instance of self's NamedTupe type with values of `self` updated with those of `other`. `other`'s keys need to be a subset of `self`'s keys. Inversion is only valid if the key sets are identical. The behavior is similar to `#merge` but it ensures that no additional keys are added and preserves the types from `self`.

A typical use case would be merging a fixed set of options with default values while disallowing additional keys (in contrast to `#merge`)
```crystal
def do_something(*options)
  default_options = {foo: "bar", baz: 15.5 }
  updated_options = default_options.update(options) #=> {foo: "bar", baz: 2 }
  # ...
end

do_something baz: 2
```

I am not super happy with the name, because it does not actually *update* `self` but returns a new NamedTuple. So if there are any suggestions...