### PR TITLE
Correct nilable variable type inference after exception handler

### DIFF
--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2526,6 +2526,7 @@ module Crystal
       exception_handler_vars = @exception_handler_vars = @vars.dup
       exception_handler_vars.each do |name, var|
         new_var = new_meta_var(name)
+        new_var.nil_if_read = var.nil_if_read?
         new_var.bind_to(var)
         exception_handler_vars[name] = new_var
       end


### PR DESCRIPTION
Fixed #4723 

Old implementation loses variable's `nil_if_read` flag after exception handler, so scope variables (i.e. meta vars) type inference is broken when reading such a variable after exception handler.

To need more information, see [these comments in spec](https://github.com/MakeNowJust/crystal/blob/9d37b6ee30b4b6215bc7917082f89c443c69709d/spec/compiler/semantic/exception_spec.cr#L460-L474). Thank you.