### PR TITLE
Make sdl samples work on Linux

### DIFF
--- a/samples/sdl/sdl/lib_sdl.cr
+++ b/samples/sdl/sdl/lib_sdl.cr
@@ -149,17 +149,9 @@ lib LibSDL
   fun show_cursor = SDL_ShowCursor(toggle : Int32) : Int32
   fun get_ticks = SDL_GetTicks : UInt32
   fun flip = SDL_Flip(screen : Surface*) : Int32
-
-  {% if flag?(:linux) %}
-    fun main = SDL_main(argc : Int32, argv : UInt8**) : Int32
-  {% end %}
 end
 
-{% if flag?(:linux) %}
-  fun main(argc : Int32, argv : UInt8**) : Int32
-    return LibSDL.main(argc, argv)
-  end
-{% elsif flag?(:darwin) %}
+{% if flag?(:darwin) %}
   redefine_main(SDL_main) do |main|
     \{{main}}
   end


### PR DESCRIPTION
This PR add temporally fix to sdl samples, because these samples don't work currently.

I say temporally because it was discused multiples times before https://github.com/crystal-lang/crystal/pull/3678 https://github.com/crystal-lang/crystal/issues/381 https://github.com/crystal-lang/crystal/pull/388 https://github.com/crystal-lang/crystal/pull/387

Also I think if this change make that sdl samples works again on Linux, Ain't better a working sample that a failing sample?

Currently on master:

![screenshot_20170721_213857](https://user-images.githubusercontent.com/3067335/28487807-048540a2-6e5f-11e7-83c7-19aea4cd51ec.png)

With this PR:

![screenshot_20170721_215050](https://user-images.githubusercontent.com/3067335/28487808-097f06f6-6e5f-11e7-9671-c240a432ac27.png)

![screenshot_20170721_214247](https://user-images.githubusercontent.com/3067335/28487809-0f791e5c-6e5f-11e7-9f3f-282a4348b78e.png)



