### PR TITLE
Tuple: support negative index

### DIFF
--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -21,6 +21,14 @@ describe "Semantic: tuples" do
     assert_type("{1, 'a'}[1]") { char }
   end
 
+  it "types tuple [-1]" do
+    assert_type("{1, 'a'}[-1]") { char }
+  end
+
+  it "types tuple [-2]" do
+    assert_type("{1, 'a'}[-2]") { int32 }
+  end
+
   it "types tuple [0]?" do
     assert_type("{1, 'a'}[0]?") { int32 }
   end
@@ -33,6 +41,18 @@ describe "Semantic: tuples" do
     assert_type("{1, 'a'}[2]?") { nil_type }
   end
 
+  it "types tuple [-1]?" do
+    assert_type("{1, 'a'}[-1]?") { char }
+  end
+
+  it "types tuple [-2]?" do
+    assert_type("{1, 'a'}[-2]?") { int32 }
+  end
+
+  it "types tuple [-3]?" do
+    assert_type("{1, 'a'}[-3]?") { nil_type }
+  end
+
   it "types tuple metaclass [0]" do
     assert_type("{1, 'a'}.class[0]") { int32.metaclass }
   end
@@ -41,9 +61,17 @@ describe "Semantic: tuples" do
     assert_type("{1, 'a'}.class[1]") { char.metaclass }
   end
 
+  it "types tuple metaclass [-1]" do
+    assert_type("{1, 'a'}.class[-1]") { char.metaclass }
+  end
+
+  it "types tuple metaclass [-2]" do
+    assert_type("{1, 'a'}.class[-2]") { int32.metaclass }
+  end
+
   it "gives error when indexing out of range" do
     assert_error "{1, 'a'}[2]",
-      "index out of bounds for Tuple(Int32, Char) (2 not in 0..1)"
+      "index out of bounds for Tuple(Int32, Char) (2 not in -2..1)"
   end
 
   it "gives error when indexing out of range on empty tuple" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -27,29 +27,42 @@ describe "Tuple" do
     a[i].should eq(1)
     i = 1
     a[i].should eq(2.5)
+    i = -1
+    a[i].should eq(2.5)
+    i = -2
+    a[i].should eq(1)
   end
 
   it "does [] raises index out of bounds" do
     a = {1, 2.5}
     i = 2
     expect_raises(IndexError) { a[i] }
-    i = -1
+    i = -3
     expect_raises(IndexError) { a[i] }
   end
 
   it "does []?" do
     a = {1, 2}
-    a[1]?.should eq(2)
-    a[2]?.should be_nil
+    i = 1
+    a[i]?.should eq(2)
+    i = -1
+    a[i]?.should eq(2)
+    i = 2
+    a[i]?.should be_nil
+    i = -3
+    a[i]?.should be_nil
   end
 
   it "does at" do
     a = {1, 2}
     a.at(1).should eq(2)
+    a.at(-1).should eq(2)
 
     expect_raises(IndexError) { a.at(2) }
+    expect_raises(IndexError) { a.at(-3) }
 
     a.at(2) { 3 }.should eq(3)
+    a.at(-3) { 3 }.should eq(3)
   end
 
   describe "values_at" do

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -450,6 +450,7 @@ class Crystal::Call
     arg = args.first
     if arg.is_a?(NumberLiteral) && arg.kind == :i32
       index = arg.value.to_i
+      index += instance_type.size if index < 0
       in_bounds = (0 <= index < instance_type.size)
       if nilable || in_bounds
         indexer_def = yield instance_type, (in_bounds ? index : -1)
@@ -458,7 +459,7 @@ class Crystal::Call
       elsif instance_type.size == 0
         raise "index '#{arg}' out of bounds for empty tuple"
       else
-        raise "index out of bounds for #{owner} (#{arg} not in 0..#{instance_type.size - 1})"
+        raise "index out of bounds for #{owner} (#{arg} not in #{-instance_type.size}..#{instance_type.size - 1})"
       end
     end
     nil

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -175,6 +175,7 @@ struct Tuple
   # tuple.at(3) { 10 } # => 10
   # ```
   def at(index : Int)
+    index += size if index < 0
     {% for i in 0...T.size %}
       return self[{{i}}] if {{i}} == index
     {% end %}


### PR DESCRIPTION
Close #4714 

Now, it works:

```crystal
tuple = {42, "foo", true}
p typeof(tuple[-1]) # => Bool
p typeof(tuple[-2]) # => String
p typeof(tuple[-3]) # => Int32

i = -1
p typeof(tuple[i]) # => (Bool | String | Int32)
p tuple[i]         # => true

# And, `tuple[-4]` causes a compile error:
# index out of bounds for Tuple(Int32, String, Bool) (-4 not in -3..2)
```