### PR TITLE
Display type when inspecting numbers

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -94,6 +94,10 @@ describe "BigFloat" do
     it { "12345678901234567".to_big_f.to_s.should eq("12345678901234567") }
   end
 
+  describe "#inspect" do
+    it { "2.3".to_big_f.inspect.should eq("2.3_big_f") }
+  end
+
   it "#hash" do
     b = 123.to_big_f
     b.hash.should eq(b.to_f64.hash)

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -222,6 +222,10 @@ describe "BigInt" do
     a.to_s(32).should eq(d)
   end
 
+  describe "#inspect" do
+    it { "2".to_big_i.inspect.should eq("2_big_i") }
+  end
+
   it "does gcd and lcm" do
     # 3 primes
     a = BigInt.new("48112959837082048697")

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -184,6 +184,26 @@ describe "Float" do
     end
   end
 
+  describe "#inspect" do
+    it "does inspect for f64" do
+      3.2.inspect.should eq("3.2")
+    end
+
+    it "does inspect for f32" do
+      3.2_f32.inspect.should eq("3.2_f32")
+    end
+
+    it "does inspect for f64 with IO" do
+      str = String.build { |io| 3.2.inspect(io) }
+      str.should eq("3.2")
+    end
+
+    it "does inspect for f32" do
+      str = String.build { |io| 3.2_f32.inspect(io) }
+      str.should eq("3.2_f32")
+    end
+  end
+
   describe "hash" do
     it "does for Float32" do
       1.2_f32.hash.should_not eq(0)

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -184,6 +184,27 @@ describe "Int" do
     end
   end
 
+  describe "#inspect" do
+    it "appends the type" do
+      23.inspect.should eq("23")
+      23_i8.inspect.should eq("23_i8")
+      23_i16.inspect.should eq("23_i16")
+      -23_i64.inspect.should eq("-23_i64")
+      23_u8.inspect.should eq("23_u8")
+      23_u16.inspect.should eq("23_u16")
+      23_u32.inspect.should eq("23_u32")
+      23_u64.inspect.should eq("23_u64")
+    end
+
+    it "appends the type using IO" do
+      str = String.build { |io| 23.inspect(io) }
+      str.should eq("23")
+
+      str = String.build { |io| -23_i64.inspect(io) }
+      str.should eq("-23_i64")
+    end
+  end
+
   describe "bit" do
     it { 5.bit(0).should eq(1) }
     it { 5.bit(1).should eq(0) }

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -162,6 +162,7 @@ struct BigFloat < Float
 
   def inspect(io)
     to_s(io)
+    io << "_big_f"
   end
 
   def to_s(io : IO)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -259,12 +259,9 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
-  def inspect
-    to_s
-  end
-
   def inspect(io)
     to_s io
+    io << "_big_i"
   end
 
   def hash

--- a/src/float.cr
+++ b/src/float.cr
@@ -148,6 +148,11 @@ struct Float32
     Printer.print(self, io)
   end
 
+  def inspect(io)
+    to_s(io)
+    io << "_f32"
+  end
+
   def hash
     unsafe_as(Int32)
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -429,6 +429,8 @@ struct Int
   end
 
   private def internal_to_s(base, upcase = false)
+    # Given sizeof(self) <= 64 bits, we need at most 64 bytes for a base 2
+    # representation, plus one byte for the trailing 0.
     chars = uninitialized UInt8[65]
     ptr_end = chars.to_unsafe + 64
     ptr = ptr_end
@@ -451,6 +453,23 @@ struct Int
 
     count = (ptr_end - ptr).to_i32
     yield ptr, count
+  end
+
+  def inspect(io)
+    type = case self
+           when Int8   then "_i8"
+           when Int16  then "_i16"
+           when Int32  then ""
+           when Int64  then "_i64"
+           when UInt8  then "_u8"
+           when UInt16 then "_u16"
+           when UInt32 then "_u32"
+           when UInt64 then "_u64"
+           else             raise "BUG: impossible"
+           end
+
+    to_s(io)
+    io << type
   end
 
   # Writes this integer to the given *io* in the given *format*.

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -437,12 +437,16 @@ struct Slice(T)
   def to_s(io)
     if T == UInt8
       io << "Bytes"
+      io << "["
+      # Inspect using to_s because we know this is a UInt8.
+      join ", ", io, &.to_s(io)
+      io << "]"
     else
       io << "Slice"
+      io << "["
+      join ", ", io, &.inspect(io)
+      io << "]"
     end
-    io << "["
-    join ", ", io, &.inspect(io)
-    io << "]"
   end
 
   def pretty_print(pp) : Nil


### PR DESCRIPTION
When inspecting, it's useful to know the type. As far as I can see, numbers are the only literal types where you can't work out the type when inspecting, and most non-literals use the default inspect format which includes the type name. I don't show type information on `Int32` or `Float64` as they are the default types.