### PR TITLE
Use {% begin %} instead of {% if true %}

### DIFF
--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -133,7 +133,7 @@ def Hash.new(pull : JSON::PullParser)
 end
 
 def Tuple.new(pull : JSON::PullParser)
-  {% if true %}
+  {% begin %}
     pull.read_begin_array
     value = Tuple.new(
       {% for i in 0...T.size %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -320,7 +320,7 @@ struct Tuple
 
   # Returns a tuple containing cloned elements of this tuple using the `clone` method.
   def clone
-    {% if true %}
+    {% begin %}
       Tuple.new(
         {% for i in 0...T.size %}
           self[{{i}}].clone,
@@ -402,7 +402,7 @@ struct Tuple
   # tuple.map &.to_s # => {"1", "2.5", "a"}
   # ```
   def map
-    {% if true %}
+    {% begin %}
       Tuple.new(
         {% for i in 0...T.size %}
           (yield self[{{i}}]),
@@ -418,7 +418,7 @@ struct Tuple
   # tuple.reverse # => {"a", 2.5, 1}
   # ```
   def reverse
-    {% if true %}
+    {% begin %}
       Tuple.new(
         {% for i in 1..T.size %}
           self[{{T.size - i}}],
@@ -487,7 +487,7 @@ struct Tuple
   # tuple.last # => 2.5
   # ```
   def last
-    {% if true %}
+    {% begin %}
       self[{{T.size - 1}}]
     {% end %}
   end

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -88,7 +88,7 @@ def Hash.new(pull : YAML::PullParser)
 end
 
 def Tuple.new(pull : YAML::PullParser)
-  {% if true %}
+  {% begin %}
     pull.read_sequence_start
     value = Tuple.new(
       {% for i in 0...T.size %}


### PR DESCRIPTION
`{% begin %}` is introduced by Crystal 0.17.0, but `{% if true %}` still remains in stdlib. These can be replaced to `{% begin %}`.