### PR TITLE
YAML: correctly parse scalar value having null character

### DIFF
--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -39,6 +39,15 @@ module YAML
       end
     end
 
+    it "reads a scalar having a null character" do
+      parser = PullParser.new(%(--- "foo\\0bar"\n...\n))
+      parser.read_stream do
+        parser.read_document do
+          parser.read_scalar.should eq("foo\0bar")
+        end
+      end
+    end
+
     it "reads a sequence" do
       parser = PullParser.new("---\n- 1\n- 2\n- 3\n")
       parser.read_stream do

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -41,7 +41,7 @@ class YAML::PullParser
 
   def value
     ptr = @event.data.scalar.value
-    ptr ? String.new(ptr) : nil
+    ptr ? String.new(ptr, @event.data.scalar.length) : nil
   end
 
   def anchor


### PR DESCRIPTION
Old implementation ignores the scalar value after null character because it ignores scalar value length reported by libyaml. So I fix to use it, then this example works well now:

```crystal
require "yaml"

s = String.from_yaml %q(--- "foo\0bar")
p s # => "foo\u0000bar"
```