### PR TITLE
Don't find in CRYSTAL_PATH if required path is relative

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -90,4 +90,9 @@ describe Crystal::CrystalPath do
   assert_doesnt_find "test_folder/*", relative_to: "#{__DIR__}/test_files/file_one.cr"
   assert_doesnt_find "test_files/missing_file.cr"
   assert_doesnt_find __FILE__[1..-1], path: ":"
+
+  # Don't find in CRYSTAL_PATH if the path is relative (#4742)
+  assert_doesnt_find "./crystal_path_spec", relative_to: "test_files/file_one.cr"
+  assert_doesnt_find "./crystal_path_spec.cr", relative_to: "test_files/file_one.cr"
+  assert_doesnt_find "../crystal_path/test_files/file_one"
 end

--- a/spec/std/openssl/digest_io_spec.cr
+++ b/spec/std/openssl/digest_io_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "../src/openssl"
+require "../../../src/openssl"
 
 describe OpenSSL::DigestIO do
   it "calculates digest from reading" do

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "../src/openssl"
+require "../../../src/openssl"
 
 describe OpenSSL::Digest do
   [

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -1,5 +1,5 @@
 require "c/string"
-require "./big"
+require "big"
 
 # A `BigFloat` can represent arbitrarily large floats.
 #

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -1,5 +1,5 @@
 require "c/string"
-require "./big"
+require "big"
 
 # A `BigInt` can represent arbitrarily large integers.
 #

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -1,4 +1,4 @@
-require "./big"
+require "big"
 
 # Rational numbers are represented as the quotient of arbitrarily large
 # numerators and denominators. Rationals are canonicalized such that the

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -1,5 +1,5 @@
 require "json"
-require "./big"
+require "big"
 
 def BigInt.new(pull : JSON::PullParser)
   pull.read_int

--- a/src/big/yaml.cr
+++ b/src/big/yaml.cr
@@ -1,5 +1,5 @@
 require "yaml"
-require "./big"
+require "big"
 
 def BigInt.new(pull : YAML::PullParser)
   BigInt.new(pull.read_scalar)

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -50,16 +50,20 @@ module Crystal
 
     def find(filename, relative_to = nil) : Array(String)?
       relative_to = File.dirname(relative_to) if relative_to.is_a?(String)
+
       if filename.starts_with? '.'
         result = find_in_path_relative_to_dir(filename, relative_to)
       else
-        result = find_in_crystal_path(filename, relative_to)
+        result = find_in_crystal_path(filename)
       end
+
+      cant_find_file filename, relative_to unless result
+
       result = [result] if result.is_a?(String)
       result
     end
 
-    private def find_in_path_relative_to_dir(filename, relative_to, check_crystal_path = true)
+    private def find_in_path_relative_to_dir(filename, relative_to)
       if relative_to.is_a?(String)
         # Check if it's a wildcard.
         if filename.ends_with?("/*") || (recursive = filename.ends_with?("/**"))
@@ -116,11 +120,7 @@ module Crystal
         end
       end
 
-      if check_crystal_path
-        find_in_crystal_path filename, relative_to
-      else
-        nil
-      end
+      nil
     end
 
     private def gather_dir_files(dir, files_accumulator, recursive)
@@ -158,12 +158,16 @@ module Crystal
       File.expand_path(filename)
     end
 
-    private def find_in_crystal_path(filename, relative_to)
+    private def find_in_crystal_path(filename)
       @crystal_path.each do |path|
-        required = find_in_path_relative_to_dir(filename, path, check_crystal_path: false)
+        required = find_in_path_relative_to_dir(filename, path)
         return required if required
       end
 
+      nil
+    end
+
+    private def cant_find_file(filename, relative_to)
       if relative_to
         raise Error.new("can't find file '#{filename}' relative to '#{relative_to}'")
       else

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -1,4 +1,4 @@
-require "./csv"
+require "csv"
 
 # A CSV Builder writes CSV to an `IO`.
 #

--- a/src/csv/error.cr
+++ b/src/csv/error.cr
@@ -1,4 +1,4 @@
-require "./csv"
+require "csv"
 
 class CSV
   # Raises when an error related to a CSV is found.

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -1,4 +1,4 @@
-require "./csv"
+require "csv"
 
 # A CSV lexer lets you consume a CSV token by token. You can use this to efficiently
 # parse a CSV without the need to allocate intermediate arrays.

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -1,4 +1,4 @@
-require "./csv"
+require "csv"
 
 # A CSV parser. It lets you consume a CSV row by row.
 #

--- a/src/csv/token.cr
+++ b/src/csv/token.cr
@@ -1,4 +1,4 @@
-require "./csv"
+require "csv"
 
 # A token in a CSV. It consists of a `Kind` and a value.
 # The value only makes sense when the *kind* is `Cell`.

--- a/src/ecr/processor.cr
+++ b/src/ecr/processor.cr
@@ -1,4 +1,4 @@
-require "./ecr/lexer"
+require "./lexer"
 
 module ECR
   extend self

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -1,4 +1,4 @@
-require "./openssl"
+require "openssl"
 
 class OpenSSL::Cipher
   class Error < OpenSSL::Error

--- a/src/openssl/pkcs5.cr
+++ b/src/openssl/pkcs5.cr
@@ -1,4 +1,4 @@
-require "./openssl"
+require "openssl"
 
 module OpenSSL::PKCS5
   def self.pbkdf2_hmac_sha1(secret, salt, iterations = 2**16, key_size = 64) : Bytes


### PR DESCRIPTION
Close #4742 

There were 15 sources depending on this bug, so I also fixed these files. 

This is not only a bug fix but also a breaking change.