### PR TITLE
Rescue IO errors from input.close in HTTP request processor

### DIFF
--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -62,7 +62,11 @@ class HTTP::Server::RequestProcessor
     rescue ex : Errno
       # IO-related error, nothing to do
     ensure
-      input.close if must_close
+      begin
+        input.close if must_close
+      rescue ex : Errno
+        # IO-related error, nothing to do
+      end
     end
   end
 end


### PR DESCRIPTION
Closing the request IO calls IO#flush, which often can raise EPIPE or ECONNRESET
errors, causing erroneous logging in HTTP servers.