### PR TITLE
Add JSON.def_to_json

### DIFF
--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -6,8 +6,8 @@ private class JSONPerson
   getter age : String?
 
   JSON.def_to_json({
-    name: true,
-    age:  true,
+    name: _,
+    age:  _,
   })
 
   def initialize(@name, @age = nil)
@@ -20,7 +20,7 @@ end
 
 private class JSONPersonEmittingNull < JSONPerson
   JSON.def_to_json({
-    name: true,
+    name: _,
     age:  {emit_null: true},
   })
 end
@@ -47,13 +47,6 @@ private class JSONWithNilableTimeEmittingNull
     value: {converter: Time::Format.new("%F"), emit_null: true},
   })
   getter value : Time? = nil
-end
-
-private class JSONSimpleSyntax
-  JSON.def_to_json([name, :age])
-
-  getter name = "John"
-  getter age = 12
 end
 
 private class JSONKeywordProperties
@@ -133,7 +126,7 @@ end
 private class Location
   getter lat : Float64
   getter long : Float64
-  JSON.def_to_json([lat, long])
+  JSON.def_to_json({lat: _, long: _})
 
   def initialize(@lat, @long)
   end
@@ -144,10 +137,10 @@ private class House
   getter street_number : Int32
   getter location : Location
   JSON.def_to_json(
-    address: true,
-    loc: {value: location},
+    address: _,
+    loc: location,
     empty_field: {emit_null: true},
-    next_number: {value: street_number + 1},
+    next_number: street_number + 1,
   )
 
   def initialize(@street, @street_number, @location)
@@ -164,7 +157,7 @@ end
 
 private module NeighborhoodConverter
   extend self
-  JSON.def_to_json(HouseInNeighborhood, {street_number: true})
+  JSON.def_to_json(HouseInNeighborhood, {street_number: _})
 end
 
 private class HouseInNeighborhood
@@ -173,7 +166,7 @@ private class HouseInNeighborhood
   getter neighbor : self? = nil
 
   JSON.def_to_json(
-    address: true,
+    address: _,
     neighbor: {converter: NeighborhoodConverter}
   )
 
@@ -259,10 +252,6 @@ describe "JSON.def_to_json" do
   it "uses root and emit null" do
     result = JSONWithNilableRootEmitNull.new
     result.to_json.should eq(%({"result":null}))
-  end
-
-  it "supports simple array syntax" do
-    JSONSimpleSyntax.new.to_json.should eq(%({"name":"John","age":12}))
   end
 
   it "supports keywords with alternate properties" do

--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -58,8 +58,8 @@ end
 
 private class JSONKeywordProperties
   JSON.def_to_json(
-    end: {property: end_value},
-    abstract: {property: :abstract_value}
+    end: {value: end_value},
+    abstract: {value: :abstract_value}
   )
 
   getter end_value = "end"
@@ -145,8 +145,9 @@ private class House
   getter location : Location
   JSON.def_to_json(
     address: true,
-    loc: {property: location},
+    loc: {value: location},
     empty_field: {emit_null: true},
+    next_number: {value: street_number + 1},
   )
 
   def initialize(@street, @street_number, @location)
@@ -186,7 +187,7 @@ end
 
 private class FooBar
   JSON.def_to_json({
-    foo: {property: foo("BAR") }
+    foo: {value: foo("BAR")},
   })
 
   def foo(prefix)
@@ -275,7 +276,7 @@ describe "JSON.def_to_json" do
 
   it "base example works" do
     house = House.new("Crystal Road", 1234, Location.new(12.3, 34.5))
-    house.to_json.should eq(%({"address":"Crystal Road 1234","loc":{"lat":12.3,"long":34.5},"empty_field":null}))
+    house.to_json.should eq(%({"address":"Crystal Road 1234","loc":{"lat":12.3,"long":34.5},"empty_field":null,"next_number":1235}))
   end
 
   it "converter example works" do
@@ -284,7 +285,7 @@ describe "JSON.def_to_json" do
     house.to_json.should eq(%({"address":"Crystal Road 1234","neighbor":{"street_number":1235}}))
   end
 
-  it "accepts macro expression as property" do
+  it "accepts macro expression as value" do
     foo = FooBar.new
     foo.to_json.should eq (%({"foo":"BAR"}))
   end

--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -125,6 +125,7 @@ private class JSONStringConverted
   JSON.def_to_json({
     value: {converter: JSON::StringConverter},
   })
+
   def initialize(@value)
   end
 end

--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -184,6 +184,16 @@ private class HouseInNeighborhood
   end
 end
 
+private class FooBar
+  JSON.def_to_json({
+    foo: {property: foo("BAR") }
+  })
+
+  def foo(prefix)
+    prefix
+  end
+end
+
 describe "JSON.def_to_json" do
   it "doesn't emit null by default when doing to_json" do
     person = JSONPerson.new("John")
@@ -272,5 +282,10 @@ describe "JSON.def_to_json" do
     neighbor = HouseInNeighborhood.new("Crystal Road", 1235)
     house = HouseInNeighborhood.new("Crystal Road", 1234, neighbor)
     house.to_json.should eq(%({"address":"Crystal Road 1234","neighbor":{"street_number":1235}}))
+  end
+
+  it "accepts macro expression as property" do
+    foo = FooBar.new
+    foo.to_json.should eq (%({"foo":"BAR"}))
   end
 end

--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -1,26 +1,28 @@
 require "spec"
 require "json"
 
-private record JSONPerson, name : String, age : String? = nil do
+private class JSONPerson
+  getter name : String
+  getter age : String?
+
   JSON.def_to_json({
     name: true,
     age:  true,
   })
+
+  def initialize(@name, @age = nil)
+  end
 
   def to_s(io : IO)
     io << name << " (age " << (age || "unknown") << ")"
   end
 end
 
-private record JSONPersonEmittingNull, name : String, age : String? = nil do
+private class JSONPersonEmittingNull < JSONPerson
   JSON.def_to_json({
     name: true,
     age:  {emit_null: true},
   })
-end
-
-private record JSONWithBool, value : Bool do
-  JSON.def_to_json value: Bool
 end
 
 private class JSONWithTime
@@ -64,28 +66,44 @@ private class JSONKeywordProperties
   getter abstract_value = "abstract"
 end
 
-private record JSONWithTimeEpoch, value : Time do
+private class JSONWithTimeEpoch
+  getter value : Time
   JSON.def_to_json({
     value: {converter: Time::EpochConverter},
   })
+
+  def initialize(@value)
+  end
 end
 
-private record JSONWithTimeEpochMillis, value : Time do
+private class JSONWithTimeEpochMillis
+  getter value : Time
   JSON.def_to_json({
     value: {converter: Time::EpochMillisConverter},
   })
+
+  def initialize(@value)
+  end
 end
 
-private record JSONWithRaw, value : String do
+private class JSONWithRaw
+  getter value : String
   JSON.def_to_json({
     value: {converter: String::RawConverter},
   })
+
+  def initialize(@value)
+  end
 end
 
-private record JSONWithRoot, result : Array(JSONPerson) do
+private class JSONWithRoot
+  getter result : Array(JSONPerson)
   JSON.def_to_json({
     result: {root: "heroes"},
   })
+
+  def initialize(@result)
+  end
 end
 
 private class JSONWithNilableRoot
@@ -102,22 +120,36 @@ private class JSONWithNilableRootEmitNull
   getter result : String? = nil
 end
 
-private record JSONStringConverted, value : JSONPerson do
+private class JSONStringConverted
+  getter value : JSONPerson
   JSON.def_to_json({
     value: {converter: JSON::StringConverter},
   })
+  def initialize(@value)
+  end
 end
 
-private record Location, lat : Float64, long : Float64 do
+private class Location
+  getter lat : Float64
+  getter long : Float64
   JSON.def_to_json([lat, long])
+
+  def initialize(@lat, @long)
+  end
 end
 
-private record House, street : String, street_number : Int32, location : Location do
+private class House
+  getter street : String
+  getter street_number : Int32
+  getter location : Location
   JSON.def_to_json(
     address: true,
     loc: {property: location},
     empty_field: {emit_null: true},
   )
+
+  def initialize(@street, @street_number, @location)
+  end
 
   def address
     "#{street} #{street_number}"

--- a/spec/std/json/def_to_json_spec.cr
+++ b/spec/std/json/def_to_json_spec.cr
@@ -1,0 +1,243 @@
+require "spec"
+require "json"
+
+private record JSONPerson, name : String, age : String? = nil do
+  JSON.def_to_json({
+    name: true,
+    age:  true,
+  })
+
+  def to_s(io : IO)
+    io << name << " (age " << (age || "unknown") << ")"
+  end
+end
+
+private record JSONPersonEmittingNull, name : String, age : String? = nil do
+  JSON.def_to_json({
+    name: true,
+    age:  {emit_null: true},
+  })
+end
+
+private record JSONWithBool, value : Bool do
+  JSON.def_to_json value: Bool
+end
+
+private class JSONWithTime
+  JSON.def_to_json({
+    value: {converter: Time::Format.new("%F %T")},
+  })
+
+  def value
+    Time.now
+  end
+end
+
+private class JSONWithNilableTime
+  JSON.def_to_json({
+    value: {converter: Time::Format.new("%F")},
+  })
+  getter value : Time? = nil
+end
+
+private class JSONWithNilableTimeEmittingNull
+  JSON.def_to_json({
+    value: {converter: Time::Format.new("%F"), emit_null: true},
+  })
+  getter value : Time? = nil
+end
+
+private class JSONSimpleSyntax
+  JSON.def_to_json([name, :age])
+
+  getter name = "John"
+  getter age = 12
+end
+
+private class JSONKeywordProperties
+  JSON.def_to_json(
+    end: {property: end_value},
+    abstract: {property: :abstract_value}
+  )
+
+  getter end_value = "end"
+  getter abstract_value = "abstract"
+end
+
+private record JSONWithTimeEpoch, value : Time do
+  JSON.def_to_json({
+    value: {converter: Time::EpochConverter},
+  })
+end
+
+private record JSONWithTimeEpochMillis, value : Time do
+  JSON.def_to_json({
+    value: {converter: Time::EpochMillisConverter},
+  })
+end
+
+private record JSONWithRaw, value : String do
+  JSON.def_to_json({
+    value: {converter: String::RawConverter},
+  })
+end
+
+private record JSONWithRoot, result : Array(JSONPerson) do
+  JSON.def_to_json({
+    result: {root: "heroes"},
+  })
+end
+
+private class JSONWithNilableRoot
+  JSON.def_to_json({
+    result: {root: "heroes"},
+  })
+  getter result : String? = nil
+end
+
+private class JSONWithNilableRootEmitNull
+  JSON.def_to_json({
+    result: {root: "heroes", emit_null: true},
+  })
+  getter result : String? = nil
+end
+
+private record JSONStringConverted, value : JSONPerson do
+  JSON.def_to_json({
+    value: {converter: JSON::StringConverter},
+  })
+end
+
+private record Location, lat : Float64, long : Float64 do
+  JSON.def_to_json([lat, long])
+end
+
+private record House, street : String, street_number : Int32, location : Location do
+  JSON.def_to_json(
+    address: true,
+    loc: {property: location},
+    empty_field: {emit_null: true},
+  )
+
+  def address
+    "#{street} #{street_number}"
+  end
+
+  def empty_field
+    nil
+  end
+end
+
+private module NeighborhoodConverter
+  extend self
+  JSON.def_to_json(HouseInNeighborhood, {street_number: true})
+end
+
+private class HouseInNeighborhood
+  getter street : String
+  getter street_number : Int32
+  getter neighbor : self? = nil
+
+  JSON.def_to_json(
+    address: true,
+    neighbor: {converter: NeighborhoodConverter}
+  )
+
+  def initialize(@street, @street_number, @neighbor = nil)
+  end
+
+  def address
+    "#{street} #{street_number}"
+  end
+end
+
+describe "JSON.def_to_json" do
+  it "doesn't emit null by default when doing to_json" do
+    person = JSONPerson.new("John")
+    person.to_json.should_not contain(%("age"))
+  end
+
+  it "emits null on request when doing to_json" do
+    person = JSONPersonEmittingNull.new("John")
+    person.to_json.should contain(%("age"))
+  end
+
+  it "outputs with converter when nilable" do
+    json = JSONWithNilableTime.new
+    json.to_json.should eq("{}")
+  end
+
+  it "outputs with converter when nilable when emit_null is true" do
+    json = JSONWithNilableTimeEmittingNull.new
+    json.to_json.should eq(%({"value":null}))
+  end
+
+  it "uses arbitrary method" do
+    time = JSONWithTime.new
+    time.to_json.should contain(%("value"))
+  end
+
+  it "uses Time::EpochConverter" do
+    json = JSONWithTimeEpoch.new(Time.epoch(1459859781))
+    json.to_json.should eq(%({"value":1459859781}))
+  end
+
+  it "uses Time::EpochMillisConverter" do
+    json = JSONWithTimeEpochMillis.new(Time.epoch_ms(1459860483856))
+    json.to_json.should eq(%({"value":1459860483856}))
+  end
+
+  it "uses raw value int" do
+    json = JSONWithRaw.new("123456789123456789123456789123456789")
+    json.to_json.should eq(%({"value":123456789123456789123456789123456789}))
+  end
+
+  it "uses raw value float" do
+    json = JSONWithRaw.new("123456789123456789.123456789123456789")
+    json.to_json.should eq(%({"value":123456789123456789.123456789123456789}))
+  end
+
+  it "uses raw value object" do
+    json = JSONWithRaw.new(%([null,true,false,{"x":[1,1.5]}]))
+    json.to_json.should eq(%({"value":[null,true,false,{"x":[1,1.5]}]}))
+  end
+
+  it "uses root" do
+    result = JSONWithRoot.new([JSONPerson.new("Batman")])
+    result.to_json.should eq(%({"result":{"heroes":[{"name":"Batman"}]}}))
+  end
+
+  it "uses nilable root" do
+    result = JSONWithNilableRoot.new
+    result.to_json.should eq("{}")
+  end
+
+  it "uses root and emit null" do
+    result = JSONWithNilableRootEmitNull.new
+    result.to_json.should eq(%({"result":null}))
+  end
+
+  it "supports simple array syntax" do
+    JSONSimpleSyntax.new.to_json.should eq(%({"name":"John","age":12}))
+  end
+
+  it "supports keywords with alternate properties" do
+    JSONKeywordProperties.new.to_json.should eq(%({"end":"end","abstract":"abstract"}))
+  end
+
+  it "uses string converter" do
+    person = JSONStringConverted.new(JSONPerson.new("John"))
+    person.to_json.should eq %({"value":"John (age unknown)"})
+  end
+
+  it "base example works" do
+    house = House.new("Crystal Road", 1234, Location.new(12.3, 34.5))
+    house.to_json.should eq(%({"address":"Crystal Road 1234","loc":{"lat":12.3,"long":34.5},"empty_field":null}))
+  end
+
+  it "converter example works" do
+    neighbor = HouseInNeighborhood.new("Crystal Road", 1235)
+    house = HouseInNeighborhood.new("Crystal Road", 1234, neighbor)
+    house.to_json.should eq(%({"address":"Crystal Road 1234","neighbor":{"street_number":1235}}))
+  end
+end

--- a/src/json/def_to_json.cr
+++ b/src/json/def_to_json.cr
@@ -3,8 +3,8 @@ module JSON
   #
   # It is a lightweight alternative to `JSON.mapping` if you don't need to declare instance variables and a parser.
   #
-  # The generated method invoks `to_json(JSON::Builder)` on each of the values returned
-  # by `self`'s properties from *mappings*, or - if a converter is specified - `to_json(value, JSON::Builder)` on the converter.
+  # The generated method invoks `to_json(JSON::Builder)` on each of the values returned by the *property* expression,
+  # or - if a converter is specified - `to_json(value, JSON::Builder)` on the converter.
   #
   # ### Example
   #
@@ -41,7 +41,8 @@ module JSON
   # whose keys will define JSON properties.
   #
   # The value of each key can either be `true` or a hash or named tuple literal with the following options:
-  # * **property**: the property name on the Crystal object (as opposed to the key in the JSON document)
+  # * **property**: the Crystal expression to determine the value. By default it is equal to the property name of the current  *key*
+  #   on the Crystal object (as opposed to the key in the JSON document)
   # * **emit_null**: if `true`, emits a `null` value if the property value is nil (by default nulls are not emitted)
   # * **converter**: specify an alternate type for generation. The converter must define `to_json(value, JSON::Builder)` as class methods. Examples of converters are `Time::Format` and `Time::EpochConverter` for `Time`.
   # * **root**: assume the value is inside a JSON object with a given key

--- a/src/json/def_to_json.cr
+++ b/src/json/def_to_json.cr
@@ -41,7 +41,7 @@ module JSON
   # whose keys will define JSON properties.
   #
   # The value of each key can either be `true` or a hash or named tuple literal with the following options:
-  # * **property**: the property name on the Crystal object (as opposed to the key in the in the JSON document)
+  # * **property**: the property name on the Crystal object (as opposed to the key in the JSON document)
   # * **emit_null**: if `true`, emits a `null` value if the property value is nil (by default nulls are not emitted)
   # * **converter**: specify an alternate type for generation. The converter must define `to_json(value, JSON::Builder)` as class methods. Examples of converters are `Time::Format` and `Time::EpochConverter` for `Time`.
   # * **root**: assume the value is inside a JSON object with a given key
@@ -121,7 +121,7 @@ module JSON
     ::JSON.def_to_json({{type}}, {{mappings}})
   end
 
-  # The `StringConverter` has a class method `to_json` wich can be used as a converter for `JSON.def_to_json`. The value is added
+  # The `StringConverter` has a class method `to_json` which can be used as a converter for `JSON.def_to_json`. The value is added
   # to the builder as a string.
   module StringConverter
     def self.to_json(value, builder)

--- a/src/json/def_to_json.cr
+++ b/src/json/def_to_json.cr
@@ -52,7 +52,7 @@ module JSON
           {% unless options.is_a?(HashLiteral) || options.is_a?(NamedTupleLiteral) %}
             {% options = {nil: nil} %}
           {% end %}
-          ::JSON.field_to_json({{(options[:property] || key).id}}, {{key.id.stringify}}, {{options}})
+          ::JSON.emit_value_to_json({{(options[:property] || key).id}}, {{key.id.stringify}}, {{options}})
         {% end %}
       end
     end
@@ -109,7 +109,7 @@ module JSON
           {% unless options.is_a?(HashLiteral) || options.is_a?(NamedTupleLiteral) %}
             {% options = {nil: nil} %}
           {% end %}
-          ::JSON.field_to_json(value.{{(options[:property] || key).id}}, {{key.id.stringify}}, {{options}})
+          ::JSON.emit_value_to_json(value.{{(options[:property] || key).id}}, {{key.id.stringify}}, {{options}})
         {% end %}
       end
     end
@@ -130,19 +130,19 @@ module JSON
   end
 
   # :nodoc:
-  macro field_to_json(value_name, field_name, options)
+  macro emit_value_to_json(value_expression, json_key, options)
     # this macro is used by `.mapping` and `.def_to_json`
     # TODO: Remove wrapping branch keywords in macro expressions after #4769 is included in the next release (after 0.23.1)
-    # TODO: Replace {{value_name.id}} with %value in unwrapped keywords
-    %value = {{value_name.id}}
+    # TODO: Replace {{value_expression.id}} with %value in unwrapped keywords
+    %value = {{value_expression.id}}
     {% unless options[:emit_null] %}
-      {{ "unless #{value_name.id}.nil?".id }}
+      {{ "unless #{value_expression.id}.nil?".id }}
     {% end %}
 
-      json.field({{field_name}}) do
+      json.field({{json_key}}) do
         {% if options[:root] %}
           {% if options[:emit_null] %}
-            {{ "if #{value_name.id}.nil?".id }}
+            {{ "if #{value_expression.id}.nil?".id }}
               nil.to_json(json)
             {{ "else".id }}
           {% end %}

--- a/src/json/def_to_json.cr
+++ b/src/json/def_to_json.cr
@@ -132,21 +132,23 @@ module JSON
   # :nodoc:
   macro field_to_json(value_name, field_name, options)
     # this macro is used by `.mapping` and `.def_to_json`
+    # TODO: Remove wrapping branch keywords in macro expressions after #4769 is included in the next release (after 0.23.1)
+    # TODO: Replace {{value_name.id}} with %value in unwrapped keywords
     %value = {{value_name.id}}
     {% unless options[:emit_null] %}
-      unless %value.nil?
+      {{ "unless #{value_name.id}.nil?".id }}
     {% end %}
 
-       json.field({{field_name}}) do
+      json.field({{field_name}}) do
         {% if options[:root] %}
           {% if options[:emit_null] %}
-            if %value.nil?
+            {{ "if #{value_name.id}.nil?".id }}
               nil.to_json(json)
-            else
+            {{ "else".id }}
           {% end %}
 
-          json.object do
-            json.field({{options[:root]}}) do
+          {{ "json.object do".id }}
+            {{ "json.field(#{options[:root]}) do".id }}
         {% end %}
 
         {% if options[:converter] %}
@@ -161,16 +163,15 @@ module JSON
 
         {% if options[:root] %}
           {% if options[:emit_null] %}
-            # TODO: Remove workarounds when #4769 is resolved
-            {{"end".id}}
+            {{ "end".id }}
           {% end %}
-            {{"end".id}}
-          {{"end".id}}
+            {{ "end".id }}
+          {{ "end".id }}
         {% end %}
-       end
+      end
 
     {% unless options[:emit_null] %}
-      {{"end".id}}
+      {{ "end".id }}
     {% end %}
   end
 end

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -169,7 +169,7 @@ module JSON
     def to_json(json : ::JSON::Builder)
       json.object do
         {% for key, value in _properties_ %}
-          ::JSON.field_to_json("@{{key.id}}", {{value[:key] || key.stringify}}, {{value}})
+          ::JSON.emit_value_to_json("@{{key.id}}", {{value[:key] || key.stringify}}, {{value}})
         {% end %}
       end
     end

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -169,46 +169,7 @@ module JSON
     def to_json(json : ::JSON::Builder)
       json.object do
         {% for key, value in _properties_ %}
-          _{{key.id}} = @{{key.id}}
-
-          {% unless value[:emit_null] %}
-            unless _{{key.id}}.nil?
-          {% end %}
-
-            json.field({{value[:key] || key.id.stringify}}) do
-              {% if value[:root] %}
-                {% if value[:emit_null] %}
-                  if _{{key.id}}.nil?
-                    nil.to_json(json)
-                  else
-                {% end %}
-
-                json.object do
-                  json.field({{value[:root]}}) do
-              {% end %}
-
-              {% if value[:converter] %}
-                if _{{key.id}}
-                  {{ value[:converter] }}.to_json(_{{key.id}}, json)
-                else
-                  nil.to_json(json)
-                end
-              {% else %}
-                _{{key.id}}.to_json(json)
-              {% end %}
-
-              {% if value[:root] %}
-                {% if value[:emit_null] %}
-                  end
-                {% end %}
-                  end
-                end
-              {% end %}
-            end
-
-          {% unless value[:emit_null] %}
-            end
-          {% end %}
+          ::JSON.field_to_json("@{{key.id}}", {{value[:key] || key.stringify}}, {{value}})
         {% end %}
       end
     end


### PR DESCRIPTION
This puts the `def to_json` generator from `JSON.mapping` in a separate macro to make it individually accessible where automatically declared instance variables and parser are not needed. This comes in two flavors: one for converting `self` to JSON (this is the same as `JSON.mapping` without the extra features) and one which accepts the object-to-be-converted as an argument - this is useful to define JSON converters.
Further documentation and specs are included.

This PR was extracted from #4746 which also shows an exemplary usecase.