### PR TITLE
Expand: show expanded macro name and its location

### DIFF
--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -9,6 +9,7 @@ class Crystal::Call
   property! parent_visitor : MainVisitor
   property target_defs : Array(Def)?
   property expanded : ASTNode?
+  property expanded_macro : Macro?
   property? uses_with_scope = false
   getter? raises = false
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -280,6 +280,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     @exp_nest += 1
 
     node.expanded = generated_nodes
+    node.expanded_macro = the_macro
     node.bind_to generated_nodes
 
     true


### PR DESCRIPTION
Close #4766

This change will be help to debug a macro.

Example 1:

![2017-08-01 21 36 34](https://user-images.githubusercontent.com/6679325/28825519-86085be6-7701-11e7-8b7e-427d2e13e503.png)

Example 2 (nested expansion is supported):

![2017-08-01 21 37 12](https://user-images.githubusercontent.com/6679325/28825539-9bead70e-7701-11e7-9e74-a52013011390.png)

You can focus the line "# expand macro ...".