### PR TITLE
Fix: sanity check /dev/urandom

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -6,6 +6,7 @@ require "c/sys/syscall"
 module Crystal::System::Random
   @@initialized = false
   @@getrandom_available = false
+  @@urandom : File?
 
   private def self.init
     @@initialized = true
@@ -13,8 +14,12 @@ module Crystal::System::Random
     if sys_getrandom(Bytes.new(16)) >= 0
       @@getrandom_available = true
     else
-      @@urandom = urandom = File.open("/dev/urandom", "r")
+      urandom = File.open("/dev/urandom", "r")
+      return unless urandom.stat.chardev?
+
+      urandom.close_on_exec = true
       urandom.sync = true # don't buffer bytes
+      @@urandom = urandom
     end
   end
 

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -3,11 +3,17 @@
 
 module Crystal::System::Random
   @@initialized = false
+  @@urandom : File?
 
   private def self.init
     @@initialized = true
-    @@urandom = urandom = File.open("/dev/urandom", "r")
+
+    urandom = File.open("/dev/urandom", "r")
+    return unless urandom.stat.chardev?
+
+    urandom.close_on_exec = true
     urandom.sync = true # don't buffer bytes
+    @@urandom = urandom
   end
 
   def self.random_bytes(buf : Bytes) : Nil


### PR DESCRIPTION
Sanity checks `/dev/urandom` to be character device, not a tempered file, a socket or whatever. Also makes sure that `FD_CLOEXEC` is set.

closes #4752