### PR TITLE
Parser: allow trailing comma after named arguments in index notation

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -341,6 +341,7 @@ describe "Parser" do
   it_parses "x.foo a: 1, b: 2 ", Call.new("x".call, "foo", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])
 
   it_parses "x[a: 1, b: 2]", Call.new("x".call, "[]", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])
+  it_parses "x[a: 1, b: 2,]", Call.new("x".call, "[]", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])
   it_parses "x[{1}]", Call.new("x".call, "[]", TupleLiteral.new([1.int32] of ASTNode))
   it_parses "x[+ 1]", Call.new("x".call, "[]", Call.new(1.int32, "+"))
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4081,7 +4081,7 @@ module Crystal
         skip_space_or_newline if allow_newline
         if @token.type == :","
           next_token_skip_space_or_newline
-          if @token.type == :")" || @token.type == :"&"
+          if @token.type == :")" || @token.type == :"&" || @token.type == :"]"
             break
           end
         else


### PR DESCRIPTION
Fix #4782

For example, current compiler cannot compile this:

```crystal
a = [1, 2, 3]
a[
  index: 1,
]
# Syntax error in foo.cr:4: expected named argument, not ]
````

Because the compiler does not allow trailing comma after named arguments in index notation. This fixes it so above is now working.

- - -

`Crystal::Parser#parse_named_args` misses checking `:"]"` token following `:","` token (this means the case of trailing comma in index notation.). I fixed this correctly.