### PR TITLE
Fix LibC.accept segfault

### DIFF
--- a/src/socket.cr
+++ b/src/socket.cr
@@ -216,7 +216,7 @@ class Socket < IO::FileDescriptor
 
   protected def accept_impl
     loop do
-      client_fd = LibC.accept(fd, out client_addr, out client_addrlen)
+      client_fd = LibC.accept(fd, nil, nil)
       if client_fd == -1
         if closed?
           return


### PR DESCRIPTION
Neither `client_addr` or `client_addrlen` are used in the following function, but `out` params were used. The man page says these two arguments should be `NULL` if they're unused. Once I made this change, compiling `spec/std/http/client/client_spec.cr` in release mode stopped segfaulting.

I'm not *entirely* sure why this segfaulted in the first place, but it's likely to do with how `client_addrlen` is used by the kernel as the length of the `sockaddr*`. I think `out client_addrlen` is sending a random number on the top of the stack to the kernel. @oprypin raised the point that this shouldn't matter, since we allocated `sizeof(struct sockaddr)` for `client_addr`, and *surely* the kernel wouldn't write more than that? Who knows, this commit fixes it at least.