### PR TITLE
Fix WeakRef specs in release mode

### DIFF
--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -79,5 +79,8 @@ describe WeakRef do
     State.count(:weak_foo_ref).should be > 0
     instances.select { |wr| wr.value.nil? }.size.should be > 0
     instances[-1].value.should_not be_nil
+
+    # Use `last` to stop the variable from being optimised away in release mode.
+    last.to_s
   end
 end


### PR DESCRIPTION
`last` wasn't used in the spec after assignment, so it was optimised away in release mode. Use it later to ensure the spec passes.