### PR TITLE
Expose alt_name for redefine_main

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -3,9 +3,9 @@ lib LibCrystalMain
   fun __crystal_main(argc : Int32, argv : UInt8**)
 end
 
-macro redefine_main(name = main)
+macro redefine_main(name = main, alt_name = main)
   # :nodoc:
-  fun main = {{name}}(argc : Int32, argv : UInt8**) : Int32
+  fun {{alt_name.id}} = {{name.id}}(argc : Int32, argv : UInt8**) : Int32
     %ex = nil
     %status = begin
       GC.init


### PR DESCRIPTION
This changes `redefine_main` to expose the alternate name as a parameter.  The purpose of this is to allow an author to create the crystal main function without literally naming it `main`.

In my case, as described in #4793, I am writing a binding to [Allegro](http://liballeg.org/).  Allegro requires that you pass your "main" function to theirs as a callback.  So, I need to pass Crystal's main function to Allegro's main function handler, which means I need to get a reference to it.  With the change in this PR, I can avoid copy-pasting all of redefine_main just to avoid the `fun main =` part.

I had debated renaming `redefine_main` to `define_main`, and writing a separate `redefine_main` that would call `define_main`, but I couldn't seem to embed one macro in another without getting a `unterminated macro` error.

Closes #4793 