### PR TITLE
[WIP] update freebsd vagrant box to lastest release (11.1)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,9 +26,11 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.define "freebsd" do |c|
+  config.vm.define "freebsd11" do |c|
     c.ssh.shell = "csh"
-    c.vm.box = "freebsd/FreeBSD-10.2-RELEASE"
+    c.vm.box = "freebsd/FreeBSD-11.1-RELEASE"
+    c.vm.guest = :freebsd
+    c.vm.hostname = "freebsd11"
 
     c.vm.network "private_network", type: "dhcp"
     c.vm.synced_folder ".", "/vagrant", type: "nfs"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,12 @@ clone_crystal_from_vagrant = lambda do |config|
   )
 end
 
+clone_crystal_from_upstream = lambda do |config|
+  config.vm.provision :shell, privileged: false, inline: %(
+    git clone https://github.com/crystal-lang/crystal
+  )
+end
+
 Vagrant.configure("2") do |config|
   %w(precise trusty xenial).product([32, 64]).each do |dist, bits|
     box_name = "#{dist}#{bits}"
@@ -33,7 +39,7 @@ Vagrant.configure("2") do |config|
     c.vm.hostname = "freebsd11"
 
     c.vm.network "private_network", type: "dhcp"
-    c.vm.synced_folder ".", "/vagrant", type: "nfs"
+    c.vm.synced_folder ".", "/vagrant", disabled: true
 
     # to build boehm-gc from git repository:
     #c.vm.provision :shell, inline: %(
@@ -44,7 +50,7 @@ Vagrant.configure("2") do |config|
       pkg install -qy git bash gmake pkgconf pcre libunwind clang35 libyaml gmp libevent boehm-gc-threaded
     )
 
-    clone_crystal_from_vagrant.call(c)
+    clone_crystal_from_upstream.call(c)
   end
 
   config.vm.provider "virtualbox" do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,6 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "freebsd11" do |c|
-    c.ssh.shell = "csh"
     c.vm.box = "freebsd/FreeBSD-11.1-RELEASE"
     c.vm.guest = :freebsd
     c.vm.hostname = "freebsd11"
@@ -41,10 +40,7 @@ Vagrant.configure("2") do |config|
     c.vm.network "private_network", type: "dhcp"
     c.vm.synced_folder ".", "/vagrant", disabled: true
 
-    # to build boehm-gc from git repository:
-    #c.vm.provision :shell, inline: %(
-    #  pkg install -y libtool automake autoconf libatomic_ops
-    #)
+    c.ssh.shell = "sh"
 
     c.vm.provision :shell, inline: %(
       pkg install -qy git bash gmake pkgconf pcre libunwind clang35 libyaml gmp libevent boehm-gc-threaded

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
     c.vm.box = "freebsd/FreeBSD-11.1-RELEASE"
     c.vm.guest = :freebsd
     c.vm.hostname = "freebsd11"
-
+    c.vm.base_mac = "6658695E16F0"
     c.vm.network "private_network", type: "dhcp"
     c.vm.synced_folder ".", "/vagrant", disabled: true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
     #)
 
     c.vm.provision :shell, inline: %(
-      pkg install -y git gmake pkgconf pcre libunwind clang36 libyaml gmp libevent2
+      pkg install -qy git bash gmake pkgconf pcre libunwind clang35 libyaml gmp libevent boehm-gc-threaded
     )
 
     clone_crystal_from_vagrant.call(c)


### PR DESCRIPTION
This PR updates the Vagrantfile for building crystal with FreeBSD 11.1 and fixes #4802. The following changes are implement

- bump box version to FreeBSD 11.1
- change shell from /bin/csh to /bin/sh to avoid warnings
- set base_mac, otherwise you have to run vagrant up twice as the upstream box does not set base_mac
- update the package list
- use -q (quiet) for install packages
- disable folder sharing and just clone the upstream crystal repo. IMHO this makes the box easier to use as most people are not running NFSD on their machines. Git is installed inside the box so updating the crystal repos from inside the box is not a problem.