### PR TITLE
Context: show more helpful message for never called method

### DIFF
--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -408,14 +408,14 @@ describe "context" do
     ), "self", "a"
   end
 
-  it "can't get a context from never called method" do
+  it "can't get context from uncalled method" do
     run_context_tool %(
     def foo(value)
       ‸
     end
     ) do |result|
       result.status.should eq("failed")
-      result.message.should match(/never called method/)
+      result.message.should match(/never called/)
     end
   end
 end

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -407,4 +407,15 @@ describe "context" do
     Foo.foo 100
     ), "self", "a"
   end
+
+  it "can't get a context from never called method" do
+    run_context_tool %(
+    def foo(value)
+      ‸
+    end
+    ) do |result|
+      result.status.should eq("failed")
+      result.message.should match(/never called method/)
+    end
+  end
 end

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -165,7 +165,7 @@ module Crystal
 
       if @contexts.empty?
         if @found_untyped_def
-          return ContextResult.new("failed", "no context information found (never called method has no context anytime)")
+          return ContextResult.new("failed", "no context information found (methods which are never called don't have a context)")
         else
           return ContextResult.new("failed", "no context information found")
         end

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -82,7 +82,9 @@ module Crystal
         defs.each do |typed_def|
           typed_def.accept(self)
           next unless @context_visitor.def_with_yield.not_nil!.location == typed_def.location
-          typed_def.accept(@context_visitor)
+          @context_visitor.inside_typed_def do
+            typed_def.accept(@context_visitor)
+          end
         end
       end
       true
@@ -109,6 +111,13 @@ module Crystal
       @contexts = Array(HashStringType).new
       @context = HashStringType.new
       @def_with_yield = nil
+      @inside_typed_def = false
+      @found_untyped_def = false
+    end
+
+    def inside_typed_def
+      @inside_typed_def = true
+      yield.tap { @inside_typed_def = false }
     end
 
     def process_typed_def(typed_def)
@@ -130,7 +139,7 @@ module Crystal
           add_context ivar.name, ivar.type
         end
       end
-      typed_def.accept(self)
+      inside_typed_def { typed_def.accept(self) }
 
       @contexts << @context unless @context.empty?
     end
@@ -155,7 +164,11 @@ module Crystal
       end
 
       if @contexts.empty?
-        return ContextResult.new("failed", "no context information found")
+        if @found_untyped_def
+          return ContextResult.new("failed", "no context information found (never called method has no context anytime)")
+        else
+          return ContextResult.new("failed", "no context information found")
+        end
       else
         res = ContextResult.new("ok", "#{@contexts.size} possible context#{@contexts.size > 1 ? "s" : ""} found")
         res.contexts = @contexts
@@ -168,6 +181,11 @@ module Crystal
 
       if @def_with_yield.nil? && !node.yields.nil?
         @def_with_yield = node
+        return false
+      end
+
+      unless @inside_typed_def
+        @found_untyped_def = true
         return false
       end
 


### PR DESCRIPTION
Close #4158
Close #4804

We cannot get a context from the method which is never called. But current implementation yields an error in such a case, this behavior seems wrong.

This fixes it to show additional information when user tried to get a context from never called method.

```console
$ cat foo.cr
class Foo
  def foo(env)
    puts env
  end
end

$ # Old:
$ crystal tool context -c foo.cr:3:10 foo.cr
BUG: `env` at foo.cr:2:11 has no type
0x10b72f3f3: *raise<String>:NoReturn at ??
0x10ba34c6c: *Crystal::Arg@Crystal::ASTNode#type:Crystal::Type+ at ??
0x10c246f85: *Crystal::ContextVisitor#visit<Crystal::Def+>:Bool at ??
0x10c2470f9: *Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::ContextVisitor>:Nil at ??
0x10c247f00: *Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::ContextVisitor>:Nil at ??
0x10c2485fb: *Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::ContextVisitor>:Nil at ??
0x10c241116: *Crystal::Command#tool:(Bool | IO::FileDescriptor | Nil) at ??
0x10b78dc0f: *Crystal::Command#run:(Bool | Crystal::Compiler::Result | IO::FileDescriptor | Nil) at ??
0x10b75eb86: main at ??

Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues

$ # Now:
$ ./bin/crystal tool context -c foo.cr:3:10 foo.cr
no context information found (never called method has no context anytime)
```