### PR TITLE
Remove bare array creation from multi assign

### DIFF
--- a/spec/compiler/normalize/multi_assign_spec.cr
+++ b/spec/compiler/normalize/multi_assign_spec.cr
@@ -9,10 +9,6 @@ describe "Normalize: multi assign" do
     assert_expand_second "d = 1\na, b, c = d", "__temp_1 = d\na = __temp_1[0]\nb = __temp_1[1]\nc = __temp_1[2]"
   end
 
-  it "normalizes n to 1" do
-    assert_expand "a = 1, 2", "a = [1, 2]"
-  end
-
   it "normalizes n to n with []" do
     assert_expand_third "a = 1; b = 2; a[0], b[1] = 2, 3", "__temp_1 = 2\n__temp_2 = 3\na[0] = __temp_1\nb[1] = __temp_2"
   end
@@ -21,19 +17,11 @@ describe "Normalize: multi assign" do
     assert_expand_third "a = 1; b = 2; a[0], b[1] = 2", "__temp_1 = 2\na[0] = __temp_1[0]\nb[1] = __temp_1[1]"
   end
 
-  it "normalizes n to 1 with []" do
-    assert_expand_second "a = 1; a[0] = 1, 2, 3", "a[0] = [1, 2, 3]"
-  end
-
   it "normalizes n to n with call" do
     assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2, 3", "__temp_1 = 2\n__temp_2 = 3\na.foo = __temp_1\nb.bar = __temp_2"
   end
 
   it "normalizes 1 to n with call" do
     assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2", "__temp_1 = 2\na.foo = __temp_1[0]\nb.bar = __temp_1[1]"
-  end
-
-  it "normalizes n to 1 with call" do
-    assert_expand_second "a = 1; a.foo = 1, 2, 3", "a.foo = [1, 2, 3]"
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -122,11 +122,9 @@ describe "Parser" do
   it_parses "a = 1", Assign.new("a".var, 1.int32)
   it_parses "a = b = 2", Assign.new("a".var, Assign.new("b".var, 2.int32))
 
-  it_parses "a = 1, 2", MultiAssign.new(["a".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "a, b = 1, 2", MultiAssign.new(["a".var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "a, b = 1", MultiAssign.new(["a".var, "b".var] of ASTNode, [1.int32] of ASTNode)
   it_parses "_, _ = 1, 2", MultiAssign.new([Underscore.new, Underscore.new] of ASTNode, [1.int32, 2.int32] of ASTNode)
-  it_parses "a[0] = 1, 2", MultiAssign.new([Call.new("a".call, "[]", 0.int32)] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "a[0], a[1] = 1, 2", MultiAssign.new([Call.new("a".call, "[]", 0.int32), Call.new("a".call, "[]", 1.int32)] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "a.foo, a.bar = 1, 2", MultiAssign.new([Call.new("a".call, "foo"), Call.new("a".call, "bar")] of ASTNode, [1.int32, 2.int32] of ASTNode)
   it_parses "x = 0; a, b = x += 1", [Assign.new("x".var, 0.int32), MultiAssign.new(["a".var, "b".var] of ASTNode, [OpAssign.new("x".var, "+", 1.int32)] of ASTNode)] of ASTNode
@@ -138,6 +136,8 @@ describe "Parser" do
   assert_syntax_error "1 == 2, a = 4"
   assert_syntax_error "x : String, a = 4"
   assert_syntax_error "b, 1 == 2, a = 4"
+  assert_syntax_error "a = 1, 2, 3", "Multiple assignment count mismatch"
+  assert_syntax_error "a = 1, b = 2", "Multiple assignment count mismatch"
 
   it_parses "def foo\n1\nend", Def.new("foo", body: 1.int32)
   it_parses "def downto(n)\n1\nend", Def.new("downto", ["n".arg], 1.int32)

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -555,18 +555,6 @@ module Crystal
 
         # From:
         #
-        #     a = 1, 2, 3
-        #
-        # To:
-        #
-        #     a = [1, 2, 3]
-      elsif node.targets.size == 1
-        target = node.targets.first
-        array = ArrayLiteral.new(node.values)
-        exps = transform_multi_assign_target(target, array)
-
-        # From:
-        #
         #     a, b = c, d
         #
         # To:
@@ -576,6 +564,8 @@ module Crystal
         #     a = temp1
         #     b = temp2
       else
+        raise "BUG: multiple assignment count mismatch" unless node.targets.size == node.values.size
+
         temp_vars = node.values.map { new_temp_var }
 
         assign_to_temps = [] of ASTNode

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -180,7 +180,7 @@ module Crystal
       end
 
       values.concat exps[assign_index + 1..-1]
-      if values.size != 1 && targets.size != 1 && targets.size != values.size
+      if values.size != 1 && targets.size != values.size
         raise "Multiple assignment count mismatch", location
       end
 


### PR DESCRIPTION
Previously, `a = 1, 2, 3` was parsed as `a = [1, 2, 3]`. This is a weird special case with strange side-effects such as `a = 1, b = 2` being parsed as `a = [1, b = 2]` which is... not optimal. The previous statement can happen easily as a syntax error:
```cr
a = 1,
b = 2
```

This doesn't effect swapping expressions (`a, foo.bar = foo.bar, 2`) or destructuring (`a, b, c = method()`).