### PR TITLE
Prevent parsing block follow '---' or '===' as setext headers

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -58,6 +58,7 @@ describe Markdown do
   assert_render "####### Hello", "<h6># Hello</h6>"
 
   assert_render "# Hello\nWorld", "<h1>Hello</h1>\n\n<p>World</p>"
+  assert_render "# Hello\n---", "<h1>Hello</h1>\n\n<hr/>"
 
   assert_render "    Hello", "<pre><code>Hello</code></pre>"
   assert_render "    Hello\n    World", "<pre><code>Hello\nWorld</code></pre>"
@@ -68,6 +69,7 @@ describe Markdown do
 
   assert_render "```crystal\nHello\nWorld\n```", "<pre><code class='language-crystal'>Hello\nWorld</code></pre>"
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
+  assert_render "```\n---\n```", "<pre><code>---</code></pre>"
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
   assert_render "> This spawns\nmultiple\nlines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -49,14 +49,6 @@ class Markdown::Parser
       return :empty
     end
 
-    if next_line_is_all?('=')
-      return :header1
-    end
-
-    if next_line_is_all?('-')
-      return :header2
-    end
-
     if pounds = count_pounds line
       return PrefixHeader.new(pounds)
     end
@@ -91,6 +83,14 @@ class Markdown::Parser
 
     if line.starts_with? ">"
       return :quote
+    end
+
+    if next_line_is_all?('=')
+      return :header1
+    end
+
+    if next_line_is_all?('-')
+      return :header2
     end
 
     nil


### PR DESCRIPTION
Fix #4839

Changes the prior of setext headers to fix it, I think it is better.