### PR TITLE
YAML | JSON.mapping presence: true option.

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -146,6 +146,13 @@ private class JSONWithNilableUnion2
   })
 end
 
+private class JSONWithPresence
+  JSON.mapping({
+    first_name: {type: String?, presence: true, nilable: true},
+    last_name:  {type: String?, presence: true, nilable: true},
+  })
+end
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -426,5 +433,15 @@ describe "JSON mapping" do
     obj = JSONWithNilableUnion2.from_json(%({}))
     obj.value.should be_nil
     obj.to_json.should eq(%({}))
+  end
+
+  describe "parses JSON with presence markers" do
+    it "parses person with absent attributes" do
+      json = JSONWithPresence.from_json(%({"first_name": null}))
+      json.first_name.should be_nil
+      json.first_name_present?.should be_true
+      json.last_name.should be_nil
+      json.last_name_present?.should be_false
+    end
   end
 end

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -89,6 +89,13 @@ private class YAMLWithTimeEpochMillis
   })
 end
 
+private class YAMLWithPresence
+  YAML.mapping({
+    first_name: {type: String?, presence: true, nilable: true},
+    last_name:  {type: String?, presence: true, nilable: true},
+  })
+end
+
 describe "YAML mapping" do
   it "parses person" do
     person = YAMLPerson.from_yaml("---\nname: John\nage: 30\n")
@@ -287,5 +294,15 @@ describe "YAML mapping" do
     yaml.value.should be_a(Time)
     yaml.value.should eq(Time.epoch_ms(1459860483856))
     yaml.to_yaml.should eq("---\nvalue: 1459860483856\n")
+  end
+
+  describe "parses YAML with presence markers" do
+    it "parses person with absent attributes" do
+      yaml = YAMLWithPresence.from_yaml("---\nfirst_name:\n")
+      yaml.first_name.should be_nil
+      yaml.first_name_present?.should be_true
+      yaml.last_name.should be_nil
+      yaml.last_name_present?.should be_false
+    end
   end
 end

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -45,6 +45,7 @@ module JSON
   # * **root**: assume the value is inside a JSON object with a given key (see `Object.from_json(string_or_io, root)`)
   # * **setter**: if `true`, will generate a setter for the variable, `true` by default
   # * **getter**: if `true`, will generate a getter for the variable, `true` by default
+  # * **presence**: if `true`, a `{{key}}_present?` method will be generated when the key was present (even if it has a `null` value), `false` by default
   #
   # This macro by default defines getters and setters for each variable (this can be overrided with *setter* and *getter*).
   # The mapping doesn't define a constructor accepting these variables as arguments, but you can provide an overload.
@@ -76,6 +77,14 @@ module JSON
       {% if value[:getter] == nil ? true : value[:getter] %}
         def {{key.id}}
           @{{key.id}}
+        end
+      {% end %}
+
+      {% if value[:presence] %}
+        @{{key.id}}_present : Bool = false
+
+        def {{key.id}}_present?
+          @{{key.id}}_present
         end
       {% end %}
     {% end %}
@@ -142,6 +151,12 @@ module JSON
           @{{key.id}} = %var{key.id}.nil? ? {{value[:default]}} : %var{key.id}
         {% else %}
           @{{key.id}} = (%var{key.id}).as({{value[:type]}})
+        {% end %}
+      {% end %}
+
+      {% for key, value in properties %}
+        {% if value[:presence] %}
+          @{{key.id}}_present = %found{key.id}
         {% end %}
       {% end %}
     end


### PR DESCRIPTION
Allows to distinguish absence of key-value pairs vs null values.

Fixes #4840.

Proposed by @asterite, I just added the specs.