### PR TITLE
Don't show compiler bug message on invalid target machine

### DIFF
--- a/src/compiler/crystal/codegen/target_machine.cr
+++ b/src/compiler/crystal/codegen/target_machine.cr
@@ -3,6 +3,9 @@ require "../program"
 
 module Crystal
   module TargetMachine
+    class Error < Crystal::LocationlessException
+    end
+
     def self.create(target_triple, cpu = "", features = "", release = false) : LLVM::TargetMachine
       case target_triple
       when /^(x86_64|i[3456]86|amd64)/
@@ -19,7 +22,7 @@ module Crystal
           features += "+vfp2"
         end
       else
-        raise "Unsupported arch for target triple: #{target_triple}"
+        raise TargetMachine::Error.new("Unsupported architecture for target triple: #{target_triple}")
       end
 
       opt_level = release ? LLVM::CodeGenOptLevel::Aggressive : LLVM::CodeGenOptLevel::None

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -111,7 +111,7 @@ class Crystal::Command
       puts USAGE
       exit
     end
-  rescue ex : Crystal::ToolException
+  rescue ex : Crystal::LocationlessException
     error ex.message
   rescue ex : Crystal::Exception
     ex.color = @color

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -71,7 +71,7 @@ module Crystal
     end
   end
 
-  class ToolException < Exception
+  class LocationlessException < Exception
     def to_s_with_source(source, io)
       io << @message
     end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -424,6 +424,9 @@ module Crystal::Playground
     end
   end
 
+  class Error < Crystal::LocationlessException
+  end
+
   class Server
     @sessions = {} of Int32 => Session
     @sessions_key = 0
@@ -516,7 +519,7 @@ module Crystal::Playground
       begin
         server.listen
       rescue ex
-        raise ToolException.new(ex.message)
+        raise Playground::Error.new(ex.message)
       end
     end
 


### PR DESCRIPTION
Fixes #4842.

I've also done a bit of refactoring around of the locationless compiler errors, hopefully my refactor makes sense.