### PR TITLE
Fix macro run error for multi-line outputs

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -233,6 +233,7 @@ module Crystal
             result.stdout.each_line do |line|
               message << "    "
               message << line
+              message << '\n'
             end
             message << '\n'
           end
@@ -245,6 +246,7 @@ module Crystal
             result.stderr.each_line do |line|
               message << "    "
               message << line
+              message << '\n'
             end
             message << '\n'
           end


### PR DESCRIPTION
Quickfix for #4614
Before:
![before](https://user-images.githubusercontent.com/9730330/29472490-570e5ff6-8454-11e7-8dea-2c052b0b2ce0.png)

After:
![after](https://user-images.githubusercontent.com/9730330/29472495-5c9881cc-8454-11e7-9b10-21b7b2a457b7.png)
