### PR TITLE
Remove backtrace from ECR errors

### DIFF
--- a/src/ecr/process.cr
+++ b/src/ecr/process.cr
@@ -1,2 +1,15 @@
 require "ecr/processor"
-puts ECR.process_file(ARGV[0], ARGV[1])
+
+filename = ARGV[0]
+buffer_name = ARGV[1]
+
+begin
+  puts ECR.process_file(filename, buffer_name)
+rescue ex : Errno
+  if {Errno::ENOENT, Errno::EISDIR}.includes?(ex.errno)
+    STDERR.puts ex.message
+    exit 1
+  else
+    raise ex
+  end
+end


### PR DESCRIPTION
Beautify ECR errors for issues like #4577, by removing the stacktrace.

Before: 
![before](https://user-images.githubusercontent.com/9730330/29472901-e6a7a9aa-8455-11e7-98a0-d6815dbc0da9.png)
After: 
![after](https://user-images.githubusercontent.com/9730330/29472916-ebce1130-8455-11e7-91c8-4db6b4a6683f.png)
