### PR TITLE
Improve #4708

### DIFF
--- a/spec/compiler/normalize/chained_comparisons_spec.cr
+++ b/spec/compiler/normalize/chained_comparisons_spec.cr
@@ -20,4 +20,8 @@ describe "Normalize: chained comparisons" do
   it "normalizes two comparisons with calls" do
     assert_normalize "1 <= a <= b <= 4", "((1 <= (__temp_2 = a)) && (__temp_2 <= (__temp_1 = b))) && (__temp_1 <= 4)"
   end
+
+  it "keeps parenthesis enclosing comparison receiver" do
+    assert_normalize "(1 <= 2) <= 3", "(1 <= 2) <= 3"
+  end
 end

--- a/spec/compiler/normalize/chained_comparisons_spec.cr
+++ b/spec/compiler/normalize/chained_comparisons_spec.cr
@@ -2,22 +2,22 @@ require "../../spec_helper"
 
 describe "Normalize: chained comparisons" do
   it "normalizes one comparison with literal" do
-    assert_normalize "1 <= 2 <= 3", "1 <= 2 && 2 <= 3"
+    assert_normalize "1 <= 2 <= 3", "(1 <= 2) && (2 <= 3)"
   end
 
   it "normalizes one comparison with var" do
-    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n1 <= b && b <= 3"
+    assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n(1 <= b) && (b <= 3)"
   end
 
   it "normalizes one comparison with call" do
-    assert_normalize "1 <= b <= 3", "1 <= (__temp_1 = b) && __temp_1 <= 3"
+    assert_normalize "1 <= b <= 3", "(1 <= (__temp_1 = b)) && (__temp_1 <= 3)"
   end
 
   it "normalizes two comparisons with literal" do
-    assert_normalize "1 <= 2 <= 3 <= 4", "(1 <= 2 && 2 <= 3) && 3 <= 4"
+    assert_normalize "1 <= 2 <= 3 <= 4", "((1 <= 2) && (2 <= 3)) && (3 <= 4)"
   end
 
   it "normalizes two comparisons with calls" do
-    assert_normalize "1 <= a <= b <= 4", "(1 <= (__temp_2 = a) && __temp_2 <= (__temp_1 = b)) && __temp_1 <= 4"
+    assert_normalize "1 <= a <= b <= 4", "((1 <= (__temp_2 = a)) && (__temp_2 <= (__temp_1 = b))) && (__temp_1 <= 4)"
   end
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -299,7 +299,7 @@ module Crystal
 
       node_obj = ignore_obj ? nil : node.obj
 
-      need_parens = need_parens(node_obj)
+      need_parens = need_parens(node_obj, node)
       call_args_need_parens = false
 
       @str << "::" if node.global?
@@ -417,7 +417,7 @@ module Crystal
       end
     end
 
-    private def need_parens(obj)
+    private def need_parens(obj, parent = nil)
       case obj
       when Call
         case obj.args.size
@@ -425,8 +425,15 @@ module Crystal
           !letter_or_underscore?(obj.name)
         else
           case obj.name
-          when "[]", "[]?", "<", "<=", ">", ">="
+          when "[]", "[]?"
             false
+          when "<", "<=", ">", ">="
+            # to keep chained comparisions
+            if parent.is_a?(Call) && {"<", "<=", ">", ">="}.includes?(parent.name)
+              false
+            else
+              true
+            end
           else
             true
           end


### PR DESCRIPTION
Fix #4849

By this fix, `ToSVisitor` uses parent node information to decide to wrap receiver with parens, so we can detect chained comparison correctly!
`to_s` with `1 <= 2 <= 3` AST yields itself, and now `to_s` with `(1 <= 2).as(Bool)` AST yields itself too.