### PR TITLE
Improve JSON and YAML exception locations

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -84,7 +84,7 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean'
-  with_build_env 'make crystal spec doc'
+  with_build_env 'make crystal std_spec compiler_spec doc'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check samples spec src'
 }

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -188,15 +188,23 @@ describe "JSON mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    expect_raises JSON::ParseException, "Unknown json attribute: foo" do
-      StrictJSONPerson.from_json(%({"name": "John", "age": 30, "foo": "bar"}))
+    ex = expect_raises JSON::ParseException, "Unknown json attribute: foo" do
+      StrictJSONPerson.from_json <<-JSON
+        {
+          "name": "John",
+          "age": 30,
+          "foo": "bar"
+        }
+        JSON
     end
+    ex.location.should eq({4, 3})
   end
 
   it "raises if non-nilable attribute is nil" do
-    expect_raises JSON::ParseException, "Missing json attribute: name" do
+    ex = expect_raises JSON::ParseException, "Missing json attribute: name" do
       JSONPerson.from_json(%({"age": 30}))
     end
+    ex.location.should eq({1, 1})
   end
 
   it "doesn't emit null by default when doing to_json" do

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -139,6 +139,30 @@ describe "JSON serialization" do
     it "deserializes Time" do
       Time.from_json(%("2016-11-16T09:55:48-0300")).to_utc.should eq(Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc))
     end
+
+    describe "parse exceptions" do
+      it "has correct location when raises in NamedTuple#from_json" do
+        ex = expect_raises(JSON::ParseException) do
+          Array({foo: Int32, bar: String}).from_json <<-JSON
+            [
+              {"foo": 1}
+            ]
+            JSON
+        end
+        ex.location.should eq({2, 3})
+      end
+
+      it "has correct location when raises in Union#from_json" do
+        ex = expect_raises(JSON::ParseException) do
+          Array(Int32 | Bool).from_json <<-JSON
+            [
+              {"foo": "bar"}
+            ]
+            JSON
+        end
+        ex.location.should eq({2, 3})
+      end
+    end
   end
 
   describe "to_json" do

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -135,9 +135,15 @@ describe "YAML mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    expect_raises YAML::ParseException, "Unknown yaml attribute: foo" do
-      StrictYAMLPerson.from_yaml("---\nname: John\nfoo: [1, 2, 3]\nage: 30\n")
+    ex = expect_raises YAML::ParseException, "Unknown yaml attribute: foo" do
+      StrictYAMLPerson.from_yaml <<-YAML
+        ---
+        name: John
+        foo: [1, 2, 3]
+        age: 30
+        YAML
     end
+    ex.location.should eq({3, 1})
   end
 
   it "does to_yaml" do
@@ -152,9 +158,13 @@ describe "YAML mapping" do
   end
 
   it "raises if non-nilable attribute is nil" do
-    expect_raises YAML::ParseException, "Missing yaml attribute: name" do
-      YAMLPerson.from_yaml("---\nage: 30\n")
+    ex = expect_raises YAML::ParseException, "Missing yaml attribute: name" do
+      YAMLPerson.from_yaml <<-YAML
+        ---
+        age: 30
+        YAML
     end
+    ex.location.should eq({2, 1})
   end
 
   it "doesn't raises on false value when not-nil" do

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -121,5 +121,22 @@ module YAML
     assert_raw %(["hello"])
     assert_raw %(["hello","world"])
     assert_raw %({"hello":"world"})
+
+    it "raises exception at correct location" do
+      parser = PullParser.new("[1]")
+      parser.read_stream do
+        parser.read_document do
+          parser.read_sequence do
+            ex = expect_raises(YAML::ParseException) do
+              parser.read_mapping do
+              end
+            end
+            ex.location.should eq({1, 2})
+
+            parser.read_scalar
+          end
+        end
+      end
+    end
   end
 end

--- a/src/json.cr
+++ b/src/json.cr
@@ -69,6 +69,10 @@ module JSON
     def initialize(message, @line_number, @column_number)
       super "#{message} at #{@line_number}:#{@column_number}"
     end
+
+    def location
+      {line_number, column_number}
+    end
   end
 
   # All valid JSON types.

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -151,6 +151,8 @@ def NamedTuple.new(pull : JSON::PullParser)
       %var{key.id} = nil
     {% end %}
 
+    location = pull.location
+
     pull.read_object do |key|
       case key
         {% for key, type in T %}
@@ -164,7 +166,7 @@ def NamedTuple.new(pull : JSON::PullParser)
 
     {% for key in T.keys %}
       if %var{key.id}.nil?
-        raise JSON::ParseException.new("Missing json attribute: {{key}}", 0, 0)
+        raise JSON::ParseException.new("Missing json attribute: {{key}}", *location)
       end
     {% end %}
 
@@ -188,6 +190,8 @@ def Enum.new(pull : JSON::PullParser)
 end
 
 def Union.new(pull : JSON::PullParser)
+  location = pull.location
+
   # Optimization: use fast path for primitive types
   {% begin %}
     # Here we store types that are not primitive types
@@ -223,7 +227,7 @@ def Union.new(pull : JSON::PullParser)
       # Ignore
     end
   {% end %}
-  raise JSON::ParseException.new("Couldn't parse #{self} from #{string}", 0, 0)
+  raise JSON::ParseException.new("Couldn't parse #{self} from #{string}", *location)
 end
 
 def Time.new(pull : JSON::PullParser)

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -19,6 +19,7 @@ class JSON::PullParser
     @raw_value = ""
     @object_stack = [] of Symbol
     @skip_count = 0
+    @location = {0, 0}
 
     next_token
     case token.type
@@ -396,6 +397,18 @@ class JSON::PullParser
     @lexer.skip = false
   end
 
+  def line_number
+    @location[0]
+  end
+
+  def column_number
+    @location[1]
+  end
+
+  def location
+    @location
+  end
+
   private def skip_internal
     @skip_count += 1
     case @kind
@@ -450,9 +463,19 @@ class JSON::PullParser
     @object_stack.last?
   end
 
-  private delegate token, to: @lexer
-  private delegate next_token, to: @lexer
-  private delegate next_token_expect_object_key, to: @lexer
+  private def token
+    @lexer.token
+  end
+
+  private def next_token
+    @location = {@lexer.token.line_number, @lexer.token.column_number}
+    @lexer.next_token
+  end
+
+  private def next_token_expect_object_key
+    @location = {@lexer.token.line_number, @lexer.token.column_number}
+    @lexer.next_token_expect_object_key
+  end
 
   private def next_token_after_value
     case next_token.type

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -68,10 +68,19 @@ module YAML
     getter line_number : Int32
     getter column_number : Int32
 
-    def initialize(message, line_number, column_number)
+    def initialize(message, line_number, column_number, context_info = nil)
       @line_number = line_number.to_i
       @column_number = column_number.to_i
-      super(message)
+      if context_info
+        context_msg, context_line, context_column = context_info
+        super("#{message} at line #{line_number}, column #{column_number}, #{context_msg} at line #{context_line}, column #{context_column}")
+      else
+        super("#{message} at line #{line_number}, column #{column_number}")
+      end
+    end
+
+    def location
+      {line_number, column_number}
     end
   end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -21,11 +21,12 @@ def Array.from_yaml(string_or_io)
 end
 
 def Nil.new(pull : YAML::PullParser)
+  location = pull.location
   value = pull.read_scalar
   if value.empty?
     nil
   else
-    raise YAML::ParseException.new("Expected nil, not #{value}", 0, 0)
+    raise YAML::ParseException.new("Expected nil, not #{value}", *location)
   end
 end
 
@@ -35,10 +36,11 @@ end
 
 {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
   def {{type.id}}.new(pull : YAML::PullParser)
+    location = pull.location
     begin
       {{type.id}}.new(pull.read_scalar)
     rescue ex
-      raise YAML::ParseException.new(ex.message.not_nil!, 0, 0)
+      raise YAML::ParseException.new(ex.message.not_nil!, *location)
     end
   end
 {% end %}
@@ -106,6 +108,8 @@ def NamedTuple.new(pull : YAML::PullParser)
       %var{key.id} = nil
     {% end %}
 
+    location = pull.location
+
     pull.read_mapping_start
     while pull.kind != YAML::EventKind::MAPPING_END
       key = pull.read_scalar
@@ -122,7 +126,7 @@ def NamedTuple.new(pull : YAML::PullParser)
 
     {% for key in T.keys %}
       if %var{key.id}.nil?
-        raise YAML::ParseException.new("Missing yaml attribute: {{key}}", 0, 0)
+        raise YAML::ParseException.new("Missing yaml attribute: {{key}}", *location)
       end
     {% end %}
 
@@ -144,6 +148,7 @@ def Enum.new(pull : YAML::PullParser)
 end
 
 def Union.new(pull : YAML::PullParser)
+  location = pull.location
   string = pull.read_raw
   {% for type in T %}
     begin
@@ -152,7 +157,7 @@ def Union.new(pull : YAML::PullParser)
       # Ignore
     end
   {% end %}
-  raise YAML::ParseException.new("Couldn't parse #{self} from #{string}", 0, 0)
+  raise YAML::ParseException.new("Couldn't parse #{self} from #{string}", *location)
 end
 
 def Time.new(pull : YAML::PullParser)

--- a/src/yaml/mapping.cr
+++ b/src/yaml/mapping.cr
@@ -102,8 +102,11 @@ module YAML
         %found{key.id} = false
       {% end %}
 
+      %mapping_location = %pull.location
+
       %pull.read_mapping_start
       while %pull.kind != ::YAML::EventKind::MAPPING_END
+        %key_location = %pull.location
         key = %pull.read_scalar.not_nil!
         case key
         {% for key, value in properties %}
@@ -125,7 +128,7 @@ module YAML
         {% end %}
         else
           {% if strict %}
-            raise ::YAML::ParseException.new("Unknown yaml attribute: #{key}", 0, 0)
+            raise ::YAML::ParseException.new("Unknown yaml attribute: #{key}", *%key_location)
           {% else %}
             %pull.skip
           {% end %}
@@ -136,7 +139,7 @@ module YAML
       {% for key, value in properties %}
         {% unless value[:nilable] || value[:default] != nil %}
           if %var{key.id}.nil? && !%found{key.id} && !::Union({{value[:type]}}).nilable?
-            raise ::YAML::ParseException.new("Missing yaml attribute: {{(value[:key] || key).id}}", 0, 0)
+            raise ::YAML::ParseException.new("Missing yaml attribute: {{(value[:key] || key).id}}", *%mapping_location)
           end
         {% end %}
       {% end %}

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -77,12 +77,12 @@ class YAML::PullParser
     LibYAML.yaml_event_delete(pointerof(@event))
     LibYAML.yaml_parser_parse(@parser, pointerof(@event))
     if problem = problem?
+      msg = String.new(problem)
+      location = {problem_line_number, problem_column_number}
       if context = context?
-        msg = "#{String.new(problem)} at line #{problem_line_number}, column #{problem_column_number}, #{String.new(context)} at line #{context_line_number}, column #{context_column_number}"
-      else
-        msg = "#{String.new(problem)} at line #{problem_line_number}, column #{problem_column_number}"
+        context_info = {String.new(context), context_line_number, context_column_number}
       end
-      raise msg
+      raise msg, *location, context_info
     end
     kind
   end
@@ -242,21 +242,25 @@ class YAML::PullParser
     end
   end
 
+  # Note: YAML starts counting from 0, we want to count from 1
+
+  def location
+    {line_number, column_number}
+  end
+
   def line_number
-    @event.start_mark.line
+    @event.start_mark.line + 1
   end
 
   def column_number
-    @event.start_mark.column
+    @event.start_mark.column + 1
   end
 
-  def problem_line_number
-    # YAML starts counting from 0, we want to count from 1
+  private def problem_line_number
     (problem? ? problem_mark?.line : line_number) + 1
   end
 
-  def problem_column_number
-    # YAML starts counting from 0, we want to count from 1
+  private def problem_column_number
     (problem? ? problem_mark?.column : column_number) + 1
   end
 
@@ -306,7 +310,7 @@ class YAML::PullParser
     anchor ? String.new(anchor) : nil
   end
 
-  def raise(msg : String)
-    ::raise ParseException.new(msg, problem_line_number, problem_column_number)
+  def raise(msg : String, line_number = self.line_number, column_number = self.column_number, context_info = nil)
+    ::raise ParseException.new(msg, line_number, column_number, context_info)
   end
 end


### PR DESCRIPTION
This PR improves the error location reported when parsing invalid or unexpected JSON/YAML sources. Many places in the current code were using `{0, 0}` as a location, which probably made debugging invalid sources a bit hard.

For example, in this snippet:

```crystal
require "yaml"

class Foo
  YAML.mapping({
    foo: Int32,
  })
end

source = <<-YAML
  foo: hello
  YAML

Foo.from_yaml(source)
```

Before we got:

```
Invalid Int32: hello (YAML::ParseException)
```

Now we get:

```
Invalid Int32: hello at line 1, column 6 (YAML::ParseException)
```

Similarly, when an attribute is missing or it's unknown (in strict mode) the reported error will be correct this time.