### PR TITLE
Remove unnecessary parenthesis from `Cast#to_s` result

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -18,9 +18,9 @@ describe "ASTNode#to_s" do
   expect_to_s "1 && (a = 2)"
   expect_to_s "(a = 2) && 1"
   expect_to_s "foo(a.as(Int32))"
-  expect_to_s "(1 + 2).as(Int32)", "((1 + 2)).as(Int32)"
+  expect_to_s "(1 + 2).as(Int32)", "(1 + 2).as(Int32)"
   expect_to_s "a.as?(Int32)"
-  expect_to_s "(1 + 2).as?(Int32)", "((1 + 2)).as?(Int32)"
+  expect_to_s "(1 + 2).as?(Int32)", "(1 + 2).as?(Int32)"
   expect_to_s "@foo.bar"
   expect_to_s %(:foo)
   expect_to_s %(:"{")
@@ -47,7 +47,7 @@ describe "ASTNode#to_s" do
   expect_to_s %({% for foo in bar %}\n  {{ foo }}\n{% end %})
   expect_to_s %(macro foo\n  {% for foo in bar %}\n    {{ foo }}\n  {% end %}\nend)
   expect_to_s %[1.as(Int32)]
-  expect_to_s %[(1 || 1.1).as(Int32)], %[((1 || 1.1)).as(Int32)]
+  expect_to_s %[(1 || 1.1).as(Int32)], %[(1 || 1.1).as(Int32)]
   expect_to_s %[1 & 2 & (3 | 4)], %[(1 & 2) & (3 | 4)]
   expect_to_s %[(1 & 2) & (3 | 4)]
   expect_to_s "def foo(x : T = 1)\nend"

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1247,9 +1247,7 @@ module Crystal
 
     def visit_cast(node, keyword)
       need_parens = need_parens(node.obj)
-      @str << "(" if need_parens
-      accept_with_maybe_begin_end node.obj
-      @str << ")" if need_parens
+      in_parenthesis(need_parens, node.obj)
       @str << "."
       @str << keyword(keyword)
       @str << "("


### PR DESCRIPTION
Fix https://github.com/crystal-lang/crystal/pull/4861#discussion_r134116050

```crystal
pp (1 < 2).as(Bool)

# Before:
#     ((1 < 2)).as(Bool) # => true
# After:
#     (1 < 2).as(Bool) # => false
```