### PR TITLE
Don't mark ivar as nilable if super present and non-nilable (fix #4764)

### DIFF
--- a/spec/compiler/semantic/initialize_spec.cr
+++ b/spec/compiler/semantic/initialize_spec.cr
@@ -731,4 +731,23 @@ describe "Semantic: initialize" do
       ),
       "no argument named 'x'"
   end
+
+  it "doesn't type ivar as nilable if super call present and parent has already typed ivar (#4764)" do
+    assert_type(%(
+      class Foo
+        def initialize(@a = 1)
+        end
+      end
+
+      class Bar < Foo
+        def initialize
+          super
+        end
+        def initialize(@a)
+        end
+      end
+
+      Bar.new
+    )) { types["Bar"] }
+  end
 end

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -498,6 +498,10 @@ struct Crystal::TypeDeclarationProcessor
         # It's non-nilable if it's initialized outside
         next if initialized_outside?(owner, instance_var)
 
+        # If an initialize with an ivar calls super and an ancestor has already
+        # typed the instance var as non-nilable
+        next if info.def.calls_super? && ancestor_non_nilable.try(&.includes?(instance_var))
+
         unless info.try(&.instance_vars.try(&.includes?(instance_var)))
           all_assigned = false
           # Rememebr that this variable wasn't initialized here, and later error


### PR DESCRIPTION
If initialize calls super and declares instance var that has already
been typed as non-nilable by an ancestor, it'll be non-nilable in the
child class.

Fixes #4764