### PR TITLE
Explosive birth of 'case!'

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -484,6 +484,8 @@ describe Crystal::Formatter do
   assert_format "a = case 1\n    when 1, # 1\n         2, # 2\n         3  # 3\n      1\n    end"
   assert_format "a = 1\ncase\nwhen 2\nelse\n  a /= 3\nend"
 
+  assert_format "case! 1\nwhen 2\n  3\nend", "case! 1\nwhen  2\n  3\nend"
+
   assert_format "select   \n when  foo \n 2 \n end", "select\nwhen foo\n  2\nend"
   assert_format "select   \n when  foo \n 2 \n when bar \n 3 \n end", "select\nwhen foo\n  2\nwhen bar\n  3\nend"
   assert_format "select   \n when  foo  then  2 \n end", "select\nwhen foo then 2\nend"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -977,6 +977,10 @@ describe "Parser" do
   assert_syntax_error "case 1; end", "unexpected token: end (expecting when or else)", 1, 9
   it_parses "a = 1\ncase 1\nwhen a then 1\nend", [Assign.new("a".var, 1.int32), Case.new(1.int32, [When.new(["a".var] of ASTNode, 1.int32)])] of ASTNode
 
+  it_parses "case! a\nwhen Int32\n1\nend", Case.new("a".call, [When.new(["Int32".path] of ASTNode, 1.int32)], check_exhaustiveness: true)
+  assert_syntax_error "case!\nwhen Int32\n1\nend", "unexpected token: when ('case!' must have a condition)", 2, 1
+  assert_syntax_error "case! a\nelse\n1\nend", "unexpected token: else ('case!' cannot have 'else', use 'when _' instead)", 2, 1
+
   it_parses "select\nwhen foo\n2\nend", Select.new([Select::When.new("foo".call, 2.int32)])
   it_parses "select\nwhen foo\n2\nwhen bar\n4\nend", Select.new([Select::When.new("foo".call, 2.int32), Select::When.new("bar".call, 4.int32)])
   it_parses "select\nwhen foo\n2\nelse\n3\nend", Select.new([Select::When.new("foo".call, 2.int32)], 3.int32)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -979,7 +979,6 @@ describe "Parser" do
 
   it_parses "case! a\nwhen Int32\n1\nend", Case.new("a".call, [When.new(["Int32".path] of ASTNode, 1.int32)], check_exhaustiveness: true)
   assert_syntax_error "case!\nwhen Int32\n1\nend", "unexpected token: when ('case!' must have a condition)", 2, 1
-  assert_syntax_error "case! a\nelse\n1\nend", "unexpected token: else ('case!' cannot have 'else', use 'when _' instead)", 2, 1
 
   it_parses "select\nwhen foo\n2\nend", Select.new([Select::When.new("foo".call, 2.int32)])
   it_parses "select\nwhen foo\n2\nwhen bar\n4\nend", Select.new([Select::When.new("foo".call, 2.int32), Select::When.new("bar".call, 4.int32)])

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -131,4 +131,8 @@ describe "ASTNode#to_s" do
   expect_to_s %q(%r{#{1}\/\0}), %q(/#{1}\/\0/)
   expect_to_s %q(`\n\0`), %q(`\n\u0000`)
   expect_to_s %q(`#{1}\n\0`), %q(`#{1}\n\u0000`)
+  expect_to_s %(case\nwhen 1\nwhen 2\nend)
+  expect_to_s %(case a\nwhen 1\nwhen 2\nend)
+  expect_to_s %(case a\nwhen 1\nwhen 2\nelse\nend)
+  expect_to_s %(case! a\nwhen Int32\nwhen String\nend)
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -143,7 +143,7 @@ describe "Semantic: case" do
       ), "found non-exhaustive patterns: nil, false, FooBar::Bar"
   end
 
-  it "passes exhaustivness check if 'case' has 'when _' block" do
+  it "passes exhaustivness check if 'case' has 'else' block" do
     assert_type %(
       require "prelude"
 
@@ -151,7 +151,7 @@ describe "Semantic: case" do
 
       case! foo
       when  String
-      when  _
+      else
       end
       ) { nil_type }
   end
@@ -216,7 +216,7 @@ describe "Semantic: case" do
       ) { symbol }
   end
 
-  it "passes tuple exhaustivness check if 'case' has 'when _' block" do
+  it "passes tuple exhaustivness check if 'case' has 'else' block" do
     assert_type %(
       require "prelude"
 
@@ -225,7 +225,7 @@ describe "Semantic: case" do
 
       case! foo
       when  {String, Float64}
-      when  _
+      else
       end
       ) { nil_type }
   end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -1,0 +1,248 @@
+require "../../spec_helper"
+
+describe "Semantic: case" do
+  it "check exhaustiveness for neither enum nor union types (ok)" do
+    assert_type %(
+      require "prelude"
+
+      a = 42
+
+      case! a
+      when  Int32
+        1
+      end
+    ) { int32 }
+  end
+
+  it "check exhaustiveness for neither enum nor union types (error)" do
+    assert_error %(
+      require "prelude"
+
+      a = 42
+
+      case! a
+      when  1
+        1
+      end
+    ), "found non-exhaustive pattern: Int32"
+  end
+
+  it "check exhaustiveness for union types (Path)" do
+    assert_error %(
+      foo = true ? 42 : "foo"
+
+      case! foo
+      when  String
+      end
+      ), "found non-exhaustive pattern: Int32"
+  end
+
+  it "check exhaustiveness for union types (IsA)" do
+    assert_error %(
+      foo = true ? 42 : "foo"
+
+      case! foo
+      when  .is_a?(String)
+      end
+      ), "found non-exhaustive pattern: Int32"
+  end
+
+  it "checks exhaustiveness for enum types (Path)" do
+    assert_error %(
+      require "prelude"
+
+      enum FooBar
+        Foo
+        Bar
+      end
+
+      foo = FooBar::Foo
+
+      case! foo
+      when  FooBar::Foo
+      end
+      ), "found non-exhaustive pattern: Bar"
+  end
+
+  it "checks exhaustiveness for enum types (Call)" do
+    assert_error %(
+      require "prelude"
+
+      enum FooBar
+        Foo
+        Bar
+      end
+
+      foo = FooBar::Foo
+
+      case! foo
+      when  .foo?
+      end
+      ), "found non-exhaustive pattern: Bar"
+  end
+
+  it "checks exhaustiveness for enum types (Call but overrided)" do
+    assert_error %(
+      require "prelude"
+
+      enum FooBar
+        Foo
+        Bar
+
+        def foo?
+          false
+        end
+      end
+
+      foo = FooBar::Foo
+
+      case! foo
+      when  .foo?
+      end
+      ), "found non-exhaustive patterns: Bar, Foo"
+  end
+
+  it "checks exhaustiveness for bool type (BoolLiteral)" do
+    assert_error %(
+      require "prelude"
+
+      foo = true
+
+      case! foo
+      when  true
+      end
+      ), "found non-exhaustive pattern: false"
+  end
+
+  it "checks exhaustiveness for nilable types (NilLiteral)" do
+    assert_error %(
+      foo = true ? "foo" : nil
+
+      case! foo
+      when  nil
+      end
+      ), "found non-exhaustive pattern: String"
+  end
+
+  it "checks exhaustiveness for complex type" do
+    assert_error %(
+      require "prelude"
+
+      foo = true ? "foo" : nil
+      enum FooBar
+        Foo
+        Bar
+      end
+
+      foo = nil.as(Nil | Bool | FooBar)
+
+      case! foo
+      when  FooBar::Foo
+      when  true
+      end
+      ), "found non-exhaustive patterns: nil, false, FooBar::Bar"
+  end
+
+  it "passes exhaustivness check if 'case' has 'when _' block" do
+    assert_type %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+
+      case! foo
+      when  String
+      when  _
+      end
+      ) { nil_type }
+  end
+
+  it "passes exhaustiveness check if all values are exhausted" do
+    assert_type %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+
+      case! foo
+      when  String
+        :string
+      when  Int32
+        :int32
+      end
+      ) { symbol }
+  end
+
+  it "checks tuple exhaustiveness" do
+    assert_error %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+      bar = true ? 3.14 : :bar
+
+      case! {foo, bar}
+      when  {String, _}
+      when  {_, Float64}
+      end
+      ), "found non-exhaustive pattern: {Int32, Symbol}"
+  end
+
+  it "checks tuple exhaustiveness (multiple non-exhaustive patterns)" do
+    assert_error %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+      bar = true ? 3.14 : :bar
+
+      case! {foo, bar}
+      when  {String, _}
+      end
+      ), "found non-exhaustive patterns: {Int32, Float64}, {Int32, Symbol}"
+  end
+
+  it "passes tuple exhaustiveness check if all values are exhausted" do
+    assert_type %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+      bar = true ? 3.14 : :bar
+
+      case! {foo, bar}
+      when  {String, _}
+        :left_string
+      when  {_, Float64}
+        :right_float64
+      when  {Int32, Symbol}
+        :int32_string
+      end
+      ) { symbol }
+  end
+
+  it "passes tuple exhaustivness check if 'case' has 'when _' block" do
+    assert_type %(
+      require "prelude"
+
+      foo = true ? 42 : "foo"
+      bar = true ? 3.14 : :bar
+
+      case! foo
+      when  {String, Float64}
+      when  _
+      end
+      ) { nil_type }
+  end
+
+  it "checks exhaustiveness after loop" do
+    assert_error %(
+      require "prelude"
+
+      a = 42
+
+      while true
+        case! a
+        when  Int32
+        end
+
+        a = :foo
+      end
+    ), "found non-exhaustive pattern: Symbol"
+  end
+end

--- a/src/compiler/crystal/semantic/case.cr
+++ b/src/compiler/crystal/semantic/case.cr
@@ -31,7 +31,7 @@ class Crystal::Case
   def update(from = nil)
     super
 
-    return unless check_exhaustiveness?
+    return if !check_exhaustiveness? || self.else
 
     expansion = expanded.not_nil!
     self.unbind_from expansion

--- a/src/compiler/crystal/semantic/case.cr
+++ b/src/compiler/crystal/semantic/case.cr
@@ -1,0 +1,333 @@
+class Crystal::Case
+  property! scope : Type
+  property! parent_visitor : MainVisitor
+
+  # `nil` means 'not checked'. `true` means 'this case is exhaustive'. `false` means 'it cannot check exhaustiveness'.
+  property? exhaustive : Bool? = nil
+
+  def program
+    scope.program
+  end
+
+  alias Pattern = Nil | Bool | Type
+
+  # Run exhaustiveness-check and fix up expanded node.
+  #
+  # To define it as `#update` is needed to follow updating type after `case` statement.
+  # For example:
+  #
+  # ```
+  # a = 42
+  #
+  # loop do
+  #   case! a
+  #   when  Int32
+  #   when  String
+  #   end
+  #
+  #   a = "foo"
+  # end
+  # ```
+  def update(from = nil)
+    super
+
+    return unless check_exhaustiveness?
+
+    expansion = expanded.not_nil!
+    self.unbind_from expansion
+
+    is_exhaustive = check_exhaustiveness
+
+    if exhaustive? != is_exhaustive
+      last = expansion
+      last = last.last if last.is_a?(Expressions)
+
+      last_if = last.as(If)
+      while (last_if_else = last_if.else).is_a?(If)
+        last_if = last_if_else
+      end
+
+      last_if.unbind_from last_if.else
+
+      if is_exhaustive
+        new_last_if_else = Call.new(nil, "raise", args: [StringLiteral.new("BUG: invalid exhaustivness check")] of ASTNode, global: true).at(self)
+      else
+        new_last_if_else = Nop.new.at(self)
+      end
+      new_last_if_else.accept parent_visitor
+
+      last_if.else = new_last_if_else
+      last_if.bind_to new_last_if_else
+      last_if.propagate
+    end
+
+    self.exhaustive = is_exhaustive
+    self.bind_to expansion
+  end
+
+  # Here is an entry point of exhaustiveness-check implemtation.
+  #
+  # This result value meaning is:
+  #
+  #    - `true` means 'this case is exhaustive surely'.
+  #    - `false` means 'it cannot check exhaustiveness of this case'.
+  #
+  # And, it raises compilation error when the compuler found non-exhaustive pattern(s).
+  def check_exhaustiveness
+    case_cond = self.cond.not_nil!
+
+    if case_cond.is_a?(TupleLiteral)
+      check_exhaustiveness_tuple case_cond
+    else
+      check_exhaustiveness_simple case_cond
+    end
+  end
+
+  # Exhaustiveness-check for tuple e.g.
+  #
+  # ```
+  # foo = true ? 42 : "foo"
+  # bar = true ? 3.14 : :bar
+  #
+  # case! {foo, bar}
+  # when  {Int32, _}
+  #   p :left_int32
+  # when  {_, Float64}
+  #   p :right_float64
+  # when  {String, Symbol}
+  #   p :string_symbol
+  # end
+  # ```
+  def check_exhaustiveness_tuple(case_tuple)
+    element_patterns = case_tuple.elements.map do |case_cond|
+      patterns = [] of Pattern
+      return false unless calculate_patterns(case_cond) { |pattern| patterns << pattern }
+      patterns
+    end
+
+    tuple_patterns = Set(Array(Pattern)).new
+    Array.each_product(element_patterns) do |tuple_pattern|
+      tuple_patterns << tuple_pattern
+    end
+
+    self.whens.each &.conds.each do |when_cond|
+      case when_cond
+      when Underscore
+        # TODO: we really need this special case?
+        return true
+      when TupleLiteral
+        next unless when_cond.elements.size == case_tuple.elements.size
+
+        when_element_patterns = when_cond.elements.map_with_index do |when_cond, i|
+          patterns = [] of Pattern
+          check_exhaustiveness_step(element_patterns[i], when_cond) { |pattern| patterns << pattern }
+          patterns
+        end
+
+        Array.each_product(when_element_patterns) do |tuple_pattern|
+          tuple_patterns.delete tuple_pattern
+        end
+      else
+        next
+      end
+    end
+
+    return true if tuple_patterns.empty?
+
+    message = String.build do |builder|
+      builder << "found non-exhaustive pattern#{tuple_patterns.size > 1 ? "s" : ""}: "
+
+      sorted_tuple_patterns = tuple_patterns.to_a.sort_by do |tuple_pattern|
+        tuple_pattern.map do |pattern|
+          case pattern
+          when nil
+            "0"
+          when true
+            "1"
+          when false
+            "2"
+          else
+            pattern.to_s
+          end
+        end
+      end
+
+      sorted_tuple_patterns.join(", ", builder) do |tuple_pattern|
+        builder << "{"
+        tuple_pattern.join(", ", builder) do |pattern|
+          case pattern
+          when Const
+            builder << pattern
+          when nil, Bool, Type
+            builder << pattern.inspect
+          end
+        end
+        builder << "}"
+      end
+    end
+
+    case_tuple.raise message
+  end
+
+  # Exhaustiveness-check for simple condition e.g.
+  #
+  # ```
+  # foo = true ? 42 : "foo"
+  #
+  # case! foo
+  # when  Int32
+  #   p :int32
+  # when  String
+  #   p :string
+  # end
+  # ```
+  def check_exhaustiveness_simple(case_cond)
+    patterns = Set(Pattern).new
+    return false unless calculate_patterns(case_cond) { |pattern| patterns << pattern }
+
+    self.whens.each &.conds.each do |when_cond|
+      check_exhaustiveness_step(patterns, when_cond) do |pattern|
+        patterns.delete pattern
+      end
+    end
+
+    return true if patterns.empty?
+
+    union = case_cond.type.is_a?(UnionType)
+
+    message = String.build do |builder|
+      builder << "found non-exhaustive pattern#{patterns.size > 1 ? "s" : ""}: "
+
+      sorted_patterns = patterns.to_a.sort_by do |pattern|
+        case pattern
+        when nil
+          "0"
+        when true
+          "1"
+        when false
+          "2"
+        else
+          pattern.to_s
+        end
+      end
+
+      sorted_patterns.join(", ", builder) do |pattern|
+        case pattern
+        when Const
+          builder << (union ? pattern : pattern.name)
+        when nil, Bool, Type
+          builder << pattern.inspect
+        end
+      end
+    end
+
+    case_cond.raise message
+  end
+
+  def calculate_patterns(case_cond)
+    if (case_cond.is_a?(Var) || case_cond.is_a?(InstanceVar)) && !case_cond.type?
+      case_cond.accept parent_visitor
+      # Observe `case_cond` to follow updating variable type
+      case_cond.add_observer self
+    end
+    return false unless case_cond_type = case_cond.type?
+
+    case case_cond_type
+    when UnionType
+      # 'dup' is important to prevent changing this array value by mutable methods.
+      types = case_cond_type.union_types.dup
+    when EnumType
+      types = [case_cond_type] of Type
+    when program.bool, program.nil_type
+      types = [case_cond_type] of Type
+    else
+      types = [case_cond_type] of Type
+    end
+
+    types.each do |type|
+      case type
+      when EnumType
+        # A @[Flags] enum means a set of flags, so exhaustiveness check does not make sense.
+        if type.flags?
+          yield type
+        else
+          type.types.each_value do |t|
+            yield t if t.is_a?(Const)
+          end
+        end
+      when program.nil_type
+        yield nil
+      when program.bool
+        yield true
+        yield false
+      else
+        yield type
+      end
+    end
+
+    true
+  end
+
+  def check_exhaustiveness_step(patterns, when_cond)
+    case when_cond
+    when Path
+      type_or_const = scope.lookup_type_var?(when_cond, free_vars: parent_visitor.free_vars)
+      if type_or_const.is_a?(Const)
+        patterns.each do |const|
+          if const.is_a?(Const) && const == type_or_const
+            yield const
+          end
+        end
+      elsif type_or_const.is_a?(Type)
+        check_exhaustiveness_step_type(patterns, type_or_const) { |pattern| yield pattern }
+      end
+    when Generic
+      if type = scope.lookup_type?(when_cond, free_vars: parent_visitor.free_vars)
+        check_exhaustiveness_step_type(patterns, type) { |pattern| yield pattern }
+      end
+    when IsA
+      if when_cond.obj.is_a?(ImplicitObj)
+        if type = scope.lookup_type?(when_cond.const, free_vars: parent_visitor.free_vars)
+          check_exhaustiveness_step_type(patterns, type) { |pattern| yield pattern }
+        end
+      end
+    when Call
+      if when_cond.obj.is_a?(ImplicitObj)
+        name = when_cond.name[0..-2] # strip '?'
+        patterns.each do |const|
+          next unless const.is_a?(Const)
+          type = const.namespace.as(EnumType)
+          next unless const.name.underscore == name && type.question_methods.includes?(when_cond.name)
+          yield const
+        end
+      end
+    when NilLiteral
+      yield nil if patterns.includes?(nil)
+    when BoolLiteral
+      value = when_cond.value
+      yield value if patterns.includes?(value)
+    when Underscore
+      patterns.each { |pattern| yield pattern }
+    else
+      # nothing
+    end
+  end
+
+  def check_exhaustiveness_step_type(patterns, type)
+    case type
+    when EnumType
+      patterns.each do |const|
+        yield const if const.is_a?(Const) && const.namespace == type
+      end
+    when program.bool
+      yield true if patterns.includes?(true)
+      yield false if patterns.includes?(false)
+    when program.nil_type
+      yield nil if patterns.includes?(nil)
+    else
+      patterns.each do |case_type|
+        yield case_type if case_type.is_a?(Type) && case_type.implements?(type)
+      end
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2862,7 +2862,18 @@ module Crystal
     end
 
     def visit(node : Case)
-      expand(node)
+      expand node
+
+      if node.check_exhaustiveness?
+        if case_cond = node.cond
+          case_cond.add_observer node
+        end
+
+        node.scope = @path_lookup || @scope || @current_type
+        node.parent_visitor = self
+        node.update
+      end
+
       false
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -624,13 +624,13 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     method_name = is_flags ? "includes?" : "=="
     body = Call.new(Var.new("self").at(member), method_name, Path.new(member.name).at(member)).at(member)
     a_def = Def.new("#{member.name.underscore}?", body: body).at(member)
-    enum_type.add_def a_def
+    enum_type.add_def a_def, question_method: true
   end
 
   def define_enum_none_question_method(enum_type, node)
     body = Call.new(Call.new(nil, "value").at(node), "==", NumberLiteral.new(0)).at(node)
     a_def = Def.new("none?", body: body).at(node)
-    enum_type.add_def a_def
+    enum_type.add_def a_def, question_method: true
   end
 
   def visit(node : Expressions)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1137,8 +1137,9 @@ module Crystal
     property cond : ASTNode?
     property whens : Array(When)
     property else : ASTNode?
+    property? check_exhaustiveness : Bool
 
-    def initialize(@cond, @whens, @else = nil)
+    def initialize(@cond, @whens, @else = nil, @check_exhaustiveness = false)
     end
 
     def accept_children(visitor)
@@ -1147,7 +1148,7 @@ module Crystal
     end
 
     def clone_without_location
-      Case.new(@cond.clone, @whens.clone, @else.clone)
+      Case.new(@cond.clone, @whens.clone, @else.clone, @check_exhaustiveness)
     end
 
     def_equals_and_hash @cond, @whens, @else

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -755,6 +755,10 @@ module Crystal
         case next_char
         when 'a'
           if next_char == 's' && next_char == 'e'
+            if peek_next_char == '!'
+              next_char
+              return check_ident_or_keyword(:case!, start)
+            end
             return check_ident_or_keyword(:case, start)
           end
         when 'l'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2499,9 +2499,6 @@ module Crystal
             skip_space_or_newline
             whens << When.new(when_conds, when_body).at(location)
           when :else
-            if check_exhaustiveness
-              unexpected_token @token.to_s, "'case!' cannot have 'else', use 'when _' instead"
-            end
             if whens.size == 0
               unexpected_token @token.to_s, "expecting when"
             end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1265,7 +1265,12 @@ module Crystal
     end
 
     def visit(node : Case)
-      @str << keyword("case")
+      if node.check_exhaustiveness?
+        @str << keyword("case!")
+      else
+        @str << keyword("case")
+      end
+
       if cond = node.cond
         @str << ' '
         cond.accept self

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3284,7 +3284,11 @@ module Crystal
 
     def visit(node : Case)
       slash_is_regex!
-      write_keyword :case
+      if node.check_exhaustiveness?
+        write_keyword :case!
+      else
+        write_keyword :case
+      end
       skip_space
 
       if cond = node.cond
@@ -3335,7 +3339,7 @@ module Crystal
 
       slash_is_regex!
       write_indent
-      write_keyword :when, " "
+      write_keyword :when, case_node.check_exhaustiveness? ? "  " : " "
       base_indent = @column
       when_start_line = @line
       when_start_column = @column

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2423,10 +2423,13 @@ module Crystal
     getter base_type : IntegerType
     getter? flags : Bool
 
+    getter question_methods
+
     def initialize(program, namespace, name, @base_type, flags)
       super(program, namespace, name)
 
       @flags = !!flags
+      @question_methods = Set(String).new
 
       add_def Def.new("value", [] of Arg, Primitive.new("enum_value", @base_type))
       metaclass.as(ModuleType).add_def Def.new("new", [Arg.new("value", type: @base_type)], Primitive.new("enum_new", self))
@@ -2440,6 +2443,16 @@ module Crystal
       types[constant.name] = const = Const.new(program, self, constant.name, constant.default_value.not_nil!)
       program.class_var_and_const_initializers << const
       const
+    end
+
+    def add_def(a_def, question_method = false)
+      if question_method
+        question_methods.add(a_def.name)
+      else
+        question_methods.delete(a_def.name)
+      end
+
+      super(a_def)
     end
 
     def has_attribute?(name)


### PR DESCRIPTION
`case!` looks like `case`, but it checks exhaustiveness like Scala and Rust.

`case!` spec:

1. `case!` checks exhaustiveness for enums, union types, `Bool` (`true` or `false`) and `nil`.

    ```crystal
    foo = true ? 42 : "foo"

    case! foo
    when  Int32
      p :int32
    end

    # Error in foo.cr:3: found non-exhaustive pattern: String
    ```

2. Not such a type (e.g. `Int32`, `String`) cannot check exhaustiveness, but `case!` raises a compilation error in this case. It means:

    ```crystal
    foo = 42

    case! foo
    when  42
      p :foo
    end
    
    # Error in foo.cr:3: found non-exhaustive pattern: Int32
    ```

    But, this case can be compiled:

    ```crystal
    foo = 42

    case! foo
    when  Int32
      p :foo
    end
    ```

3. Of course tuple conditions can be checked:

   ```crystal
   foo = true ? 42 : "foo"
   bar = true ? 3.14 : :bar

   case! {foo, bar}
   when  {String, _}
     p :left_string
   when  {_, Symbol}
     p :right_symbol
   end

   # Error in foo.cr:4: found non-exhaustive pattern: {Int32, Float64}
   ```

4. `case!` must have a condition, it's a syntax error:

    ```crystal
    case!
    when  true
    end
    
    # Syntax error in foo.cr:2: unexpected token: when ('case!' must have a condition)
    ```

5. `case!` must not have `else` clause, and can use `when _` instead:

    ```crystal
    # foo = true ? 42 : "foo"
    #
    # case! foo
    # when  Int32
    #   p :int32
    # else
    #   p :others
    # end
    #
    # # Syntax error in foo.cr:6: unexpected token: else ('case!' cannot have 'else', use 'when _' instead)

    foo = true ? 42 : "foo"

    case! foo
    when  Int32
      p :int32
    when  _
      p :others
    end
    ```

6. `crystal tool format` appends 2 spaces after `when` of `case!` to align `when` conditions. For example:

    ```crystal
    foo = true ? 42 : "foo"
    case! foo
    when  Int32
      p :int32
    when  String
      p :string
    end
    ```

    It is my preference, but I believe this is more beautiful than that:

    ```crystal
    foo = true ? 42 : "foo"
    case! foo
    when Int32
      p :int32
    when String
      p :string
    end
    ```