### PR TITLE
Add --static compiler option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,12 @@ threads ?=      ## Maximum number of threads to use
 debug ?=        ## Add symbolic debug info
 verbose ?=      ## Run specs in verbose mode
 junit_output ?= ## Directory to output junit results
+static ?=       ## Enable static linking
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
-FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )
+FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 SHELL = bash

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -402,6 +402,9 @@ class Crystal::Command
         opts.on("--verbose", "Display executed commands") do
           compiler.verbose = true
         end
+        opts.on("--static", "Link statically") do
+          compiler.static = true
+        end
       end
 
       opts.unknown_args do |before, after|

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -123,6 +123,9 @@ module Crystal
     # Whether to show error trace
     property? show_error_trace = false
 
+    # Whether to link statically
+    property? static = false
+
     # Compiles the given *source*, with *output_filename* as the name
     # of the generated executable.
     #
@@ -174,6 +177,7 @@ module Crystal
       program.target_machine = target_machine
       program.flags << "release" if release?
       program.flags << "debug" unless debug.none?
+      program.flags << "static" if static?
       program.flags.concat @flags
       program.wants_doc = wants_doc?
       program.color = color?
@@ -289,7 +293,11 @@ module Crystal
           object_name = %("${@}")
         end
 
-        %(#{CC} #{object_name} -o '#{output_filename}' #{@link_flags} -rdynamic #{program.lib_flags})
+        link_flags = @link_flags || ""
+        link_flags += " -rdynamic"
+        link_flags += " -static" if static?
+
+        %(#{CC} #{object_name} -o '#{output_filename}' #{link_flags} #{program.lib_flags})
       end
     end
 

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -16,7 +16,11 @@ end
 
 {% begin %}
   @[Link("stdc++")]
-  @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
+  {% if flag?(:static) %}
+    @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags --link-static 2> /dev/null`")]
+  {% else %}
+    @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
+  {% end %}
   lib LibLLVM
     VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}
     BUILT_TARGETS = {{ `#{LibLLVM::LLVM_CONFIG} --targets-built`.strip.downcase.split(' ').map(&.id.symbolize) }}


### PR DESCRIPTION
When attempting to statically link the compiler, we need to statically link llvm. This means we need to pass `--link-static` to `llvm-config`. This is achieved by adding an official `--static` compiler option, which both adds `-static` to the `cc` invocation, and sets a "static" compiler flag. This is utilised in `lib_llvm.cr` to add `--link-static` to our `llvm-config` invocation.