### PR TITLE
Show attribute name when JSON::ParseException occurs

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -3,8 +3,9 @@ require "json"
 
 private class JSONPerson
   JSON.mapping({
-    name: {type: String},
-    age:  {type: Int32, nilable: true},
+    name:    {type: String},
+    age:     {type: Int32, nilable: true},
+    user_id: {type: Int32 | String, nilable: true},
   })
 
   def_equals name, age
@@ -450,6 +451,45 @@ describe "JSON mapping" do
       json.first_name_present?.should be_true
       json.last_name.should be_nil
       json.last_name_present?.should be_false
+    end
+  end
+
+  describe "parses JSON with unexpected types" do
+    it "raises exception when String is expected but Int32 is given" do
+      ex = expect_raises JSON::ParseException do
+        JSONPerson.from_json <<-JSON
+          {
+            "name": 42,
+            "age": 30,
+          }
+          JSON
+      end
+      ex.message.should eq "Error parsing attribute JSONPerson.name: Expected string but was int at 2:13"
+    end
+
+    it "raises exception when Int32 is expected but String is given" do
+      ex = expect_raises JSON::ParseException do
+        JSONPerson.from_json <<-JSON
+          {
+            "name": "John",
+            "age": "30",
+          }
+          JSON
+      end
+      ex.message.should eq "Error parsing attribute JSONPerson.age: Expected int but was string at 3:14"
+    end
+
+    it "raises exception when (Int32 | String) is expected but Bool is given" do
+      ex = expect_raises JSON::ParseException do
+        JSONPerson.from_json <<-JSON
+          {
+            "name": "John",
+            "age": 30,
+            "user_id": true
+          }
+          JSON
+      end
+      ex.message.should eq "Error parsing attribute JSONPerson.user_id: Couldn't parse (Int32 | String) from true at 4:14"
     end
   end
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -162,6 +162,13 @@ describe "JSON serialization" do
         end
         ex.location.should eq({2, 3})
       end
+
+      it "shows which attribute causes an exception" do
+        ex = expect_raises(JSON::ParseException) do
+          NamedTuple(foo: Int32, bar: String).from_json(%({"foo":1,"bar":42}))
+        end
+        ex.message.should eq "Error parsing attribute bar of NamedTuple(foo: Int32, bar: String): Expected string but was int at 1:18"
+      end
     end
   end
 

--- a/src/json.cr
+++ b/src/json.cr
@@ -66,8 +66,12 @@ module JSON
     getter line_number : Int32
     getter column_number : Int32
 
-    def initialize(message, @line_number, @column_number)
-      super "#{message} at #{@line_number}:#{@column_number}"
+    def initialize(message, @line_number, @column_number, with_location = true)
+      if with_location
+        super "#{message} at #{@line_number}:#{@column_number}"
+      else
+        super "#{message}"
+      end
     end
 
     def location

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -154,13 +154,17 @@ def NamedTuple.new(pull : JSON::PullParser)
     location = pull.location
 
     pull.read_object do |key|
-      case key
-        {% for key, type in T %}
-          when {{key.stringify}}
-            %var{key.id} = {{type}}.new(pull)
-        {% end %}
-      else
-        pull.skip
+      begin
+        case key
+          {% for key, type in T %}
+            when {{key.stringify}}
+              %var{key.id} = {{type}}.new(pull)
+          {% end %}
+        else
+          pull.skip
+        end
+      rescue ex : JSON::ParseException
+        raise ::JSON::ParseException.new("Error parsing attribute #{key} of #{self}: #{ex.message}", *location, false)
       end
     end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -112,13 +112,17 @@ module JSON
                 %pull.on_key!({{value[:root]}}) do
               {% end %}
 
-              {% if value[:converter] %}
-                {{value[:converter]}}.from_json(%pull)
-              {% elsif value[:type].is_a?(Path) || value[:type].is_a?(Generic) %}
-                {{value[:type]}}.new(%pull)
-              {% else %}
-                ::Union({{value[:type]}}).new(%pull)
-              {% end %}
+              begin
+                {% if value[:converter] %}
+                  {{value[:converter]}}.from_json(%pull)
+                {% elsif value[:type].is_a?(Path) || value[:type].is_a?(Generic) %}
+                  {{value[:type]}}.new(%pull)
+                {% else %}
+                  ::Union({{value[:type]}}).new(%pull)
+                {% end %}
+              rescue ex : JSON::ParseException
+                raise ::JSON::ParseException.new("Error parsing attribute #{self.class}.{{key.id}}: #{ex.message}", *%key_location, false)
+              end
 
               {% if value[:root] %}
                 end


### PR DESCRIPTION
When `JSON.mapping` raises a `JSON::ParseException`, we can see messages like below. Currently it is a bit hard to find which attribute leads to the exception.

```
Expected bool but was null at 1:866 (JSON::ParseException)
0x4ccad7: *CallStack::unwind:Array(Pointer(Void)) at ??
0x5f456d: parse_exception at /opt/crystal/src/json/pull_parser.cr 495:5
0x5f470e: expect_kind at /opt/crystal/src/json/pull_parser.cr 488:5
0x5f67d3: read_bool at /opt/crystal/src/json/pull_parser.cr 101:5
0x542ab6: new at /opt/crystal/src/json/from_json.cr 66:3

...

```

This Pull Request is to improve the message like this:

```
Expected bool but was null for attribute: activated at 1:866 (JSON::ParseException)
0x4ca1e7: *CallStack::unwind:Array(Pointer(Void)) at ??
0x5f1b6d: parse_exception at /home/kenta-s/Repositories/crystal/src/json/pull_parser.cr 518:5
0x5f1d69: expect_kind at /home/kenta-s/Repositories/crystal/src/json/pull_parser.cr 511:5
0x5f3e23: read_bool at /home/kenta-s/Repositories/crystal/src/json/pull_parser.cr 102:5
0x5400c6: new at /home/kenta-s/Repositories/crystal/src/json/from_json.cr 66:3

...

```
