### PR TITLE
Add configurable default target

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -427,7 +427,7 @@ module Crystal
 
     protected def target_machine
       @target_machine ||= begin
-        triple = @target_triple || LLVM.default_target_triple
+        triple = @target_triple || Crystal::Config.default_target_triple
         TargetMachine.create(triple, @mcpu || "", @mattr || "", @release)
       end
     rescue ex : ArgumentError

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -14,11 +14,13 @@ module Crystal
 
     def self.description
       version, sha = version_and_sha
-      if sha
-        "Crystal #{version} [#{sha}] (#{date}) LLVM #{llvm_version}"
-      else
-        "Crystal #{version} (#{date}) LLVM #{llvm_version}"
-      end
+      formatted_sha = "[#{sha}] " if sha
+      <<-DOC
+        Crystal #{version} #{formatted_sha}(#{date})
+
+        LLVM: #{llvm_version}
+        Default target: #{self.default_target_triple}
+        DOC
     end
 
     @@version_and_sha : {String, String?}?
@@ -53,6 +55,10 @@ module Crystal
 
     def self.date
       {{ `date "+%Y-%m-%d"`.stringify.chomp }}
+    end
+
+    def self.default_target_triple
+      {{env("CRYSTAL_CONFIG_TARGET")}} || LLVM.default_target_triple
     end
   end
 end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -11,12 +11,12 @@ module Crystal
 
     @crystal_path : Array(String)
 
-    def initialize(path = CrystalPath.default_path, target_triple = LLVM.default_target_triple)
+    def initialize(path = CrystalPath.default_path, target_triple = Crystal::Config.default_target_triple)
       @crystal_path = path.split(':').reject &.empty?
       add_target_path(target_triple)
     end
 
-    private def add_target_path(target_triple = LLVM.default_target_triple)
+    private def add_target_path(target_triple = Crystal::Config.default_target_triple)
       triple = target_triple.split('-')
       triple.delete(triple[1]) if triple.size == 4 # skip vendor
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -258,7 +258,7 @@ module Crystal
 
     setter target_machine : LLVM::TargetMachine?
 
-    getter(target_machine) { TargetMachine.create(LLVM.default_target_triple) }
+    getter(target_machine) { TargetMachine.create(Crystal::Config.default_target_triple) }
 
     # Returns the `Type` for `Array(type)`
     def array_of(type)


### PR DESCRIPTION
This supports, for example, a compiler compiled for the `x86_64-unknown-linux-musl` architecture which doesn't require the `--target` command-line option to be set when ran on `x86_64-unknown-linux-gnu`. This is equivalent to the `--target` configure option in autoconf.