### PR TITLE
Improve JSON::ParseException message for empty string

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -161,6 +161,7 @@ describe JSON::PullParser do
   assert_pull_parse_error %({"foo": {})
   assert_pull_parse_error %({"name": "John", "age", 1})
   assert_pull_parse_error %({"name": "John", "age": "foo", "bar"})
+  assert_pull_parse_error ""
 
   it "prevents stack overflow for arrays" do
     parser = JSON::PullParser.new(("[" * 513) + ("]" * 513))

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -46,6 +46,8 @@ class JSON::PullParser
       begin_array
     when :"{"
       begin_object
+    when :EOF
+      empty_string_given
     else
       unexpected_token
     end
@@ -508,6 +510,10 @@ class JSON::PullParser
 
   private def expect_kind(kind)
     parse_exception "Expected #{kind} but was #{@kind}" unless @kind == kind
+  end
+
+  private def empty_string_given
+    parse_exception "Expected JSON object but an empty string given"
   end
 
   private def unexpected_token


### PR DESCRIPTION
When `JSON::PullParse` receives an empty string, it raises a `JSON::ParseException` with a message like:
```
Unexpected token: EOF at 1:1 (JSON::ParseException)
```

I think it is better to tell that `JSON::PullParse` got an empty string, and that's why the exception was raised.