### PR TITLE
Fixes initialization of ISAAC PRNG without explicit seed

### DIFF
--- a/spec/std/random/isaac_spec.cr
+++ b/spec/std/random/isaac_spec.cr
@@ -345,4 +345,8 @@ describe "Random::ISAAC" do
       m.next_u.should eq(n)
     end
   end
+
+  it "can be initialized without explicit seed" do
+    Random::ISAAC.new.should be_a Random::ISAAC
+  end
 end

--- a/spec/std/random/pcg32_spec.cr
+++ b/spec/std/random/pcg32_spec.cr
@@ -231,4 +231,8 @@ describe "Random::PCG32" do
     m1.jump(-10)
     m1.next_u.should eq m2.next_u
   end
+
+  it "can be initialized without explicit seed" do
+    Random::PCG32.new.should be_a Random::PCG32
+  end
 end

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -12,13 +12,16 @@ class Random::ISAAC
   private getter bb
   private getter cc
 
-  private def self.random_seeds
-    (uninitialized StaticArray(UInt32, 8)).tap do |seeds|
-      System::Random.random_bytes(seeds.to_slice)
-    end
+  private alias Seeds = StaticArray(UInt32, 8)
+
+  private def random_seeds
+    result = uninitialized Seeds
+    result_slice = result.unsafe_as(StaticArray(UInt8, sizeof(Seeds))).to_slice
+    Crystal::System::Random.random_bytes(result_slice)
+    result
   end
 
-  def initialize(seeds = self.random_seeds)
+  def initialize(seeds = random_seeds)
     @rsl = StaticArray(UInt32, 256).new { 0_u32 }
     @mm = StaticArray(UInt32, 256).new { 0_u32 }
     @counter = 0
@@ -26,7 +29,7 @@ class Random::ISAAC
     init_by_array(seeds)
   end
 
-  def new_seed(seeds = self.random_seeds)
+  def new_seed(seeds = random_seeds)
     @aa = @bb = @cc = 0_u32
     init_by_array(seeds)
   end


### PR DESCRIPTION
#4789 introduced a problem - there is no spec ensuring that PRNG can be actually created without seed. So "seeding" it added for ISAAC was a piece of code that don't even compiles.

This PR fixes it and adds spec that ensures that initialization at least compiles. I don't know what else can be checked in spec (i think we can compare that `next_u` of two created instances aren't equal, but this means that there will be 1/2^32 chance that they will match and spec fails).