### PR TITLE
Normalize Flate's block interface to `.open`

### DIFF
--- a/spec/std/flate/flate_spec.cr
+++ b/spec/std/flate/flate_spec.cr
@@ -20,6 +20,19 @@ module Flate
 
       str.should eq("line1111\nline2222\n")
     end
+
+    describe ".open" do
+      it "yields itself to block" do
+        # Hello Crystal!
+        message = Bytes[243, 72, 205, 201, 201, 87, 112, 46, 170, 44, 46, 73,
+          204, 81, 4, 0]
+
+        io = IO::Memory.new(message)
+        Reader.open(io) do |reader|
+          reader.gets_to_end.should eq("Hello Crystal!")
+        end
+      end
+    end
   end
 
   describe Writer do
@@ -62,6 +75,19 @@ module Flate
       writer.close
       writer.closed?.should be_true
       io.closed?.should be_true
+    end
+
+    describe ".open" do
+      it "yields itself to block" do
+        io = IO::Memory.new
+        Writer.open(io) do |writer|
+          writer.write "Hello Crystal!".to_slice
+        end
+
+        io.rewind
+        io.to_slice.should eq(Bytes[243, 72, 205, 201, 201, 87, 112, 46, 170, 44, 46, 73,
+          204, 81, 4, 0])
+      end
     end
   end
 end

--- a/src/flate/reader.cr
+++ b/src/flate/reader.cr
@@ -29,10 +29,10 @@ class Flate::Reader
     @end = false
   end
 
-  # Creates an instance of Flate::Reader, yields it to the given block, and closes
-  # it at its end.
-  def self.new(input : IO, sync_close : Bool = false, dict : Bytes? = nil)
-    reader = new input, sync_close: sync_close, dict: dict
+  # Creates a new reader from the given *io*, yields it to the given block,
+  # and closes it at its end.
+  def self.open(io : IO, sync_close : Bool = false, dict : Bytes? = nil)
+    reader = new(io, sync_close: sync_close, dict: dict)
     yield reader ensure reader.close
   end
 

--- a/src/flate/writer.cr
+++ b/src/flate/writer.cr
@@ -32,12 +32,12 @@ class Flate::Writer
     end
   end
 
-  # Creates an instance of Flate::Writer, yields it to the given block, and closes
-  # it at its end.
-  def self.new(output : IO, level : Int32 = Flate::DEFAULT_COMPRESSION,
-               strategy : Flate::Strategy = Flate::Strategy::DEFAULT,
-               sync_close : Bool = false, dict : Bytes? = nil)
-    writer = new(output, level: level, strategy: strategy, sync_close: sync_close, dict: dict)
+  # Creates a new writer for the given *io*, yields it to the given block,
+  # and closes it at its end.
+  def self.open(io : IO, level : Int32 = Flate::DEFAULT_COMPRESSION,
+                strategy : Flate::Strategy = Flate::Strategy::DEFAULT,
+                sync_close : Bool = false, dict : Bytes? = nil)
+    writer = new(io, level: level, strategy: strategy, sync_close: sync_close, dict: dict)
     yield writer ensure writer.close
   end
 


### PR DESCRIPTION
Adjust both `Flate::Reader` and `Flate::Writer` interfaces for block method `.open`, offering auto-close of reader/writer instance, respectively.

This follows the interface defined by `Gzip::Reader` and `Gzip::Writer`, ensuring a uniform API for these compression methods.

Add specs to ensure these block methods are covered and adjust documentation to highlight `io` parameter.

Closes #4630

Thank you :heart: :heart: :heart: 