### PR TITLE
Collapse modules in Crystal::System

### DIFF
--- a/src/crystal/system.cr
+++ b/src/crystal/system.cr
@@ -1,13 +1,11 @@
-module Crystal
-  # :nodoc
-  module System
-    # Returns the hostname
-    # def self.hostname
+# :nodoc:
+module Crystal::System
+  # Returns the hostname
+  # def self.hostname
 
-    # Returns the number of logical processors available to the system.
-    #
-    # def self.cpu_count
-  end
+  # Returns the number of logical processors available to the system.
+  #
+  # def self.cpu_count
 end
 
 require "./system/unix/hostname"

--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -1,19 +1,13 @@
-module Crystal
-  # :nodoc:
-  module System
-    # :nodoc:
-    module Random
-      # Fills *buffer* with random bytes from a secure source.
-      # def self.random_bytes(buffer : Bytes) : Nil
+module Crystal::System::Random
+  # Fills *buffer* with random bytes from a secure source.
+  # def self.random_bytes(buffer : Bytes) : Nil
 
-      # Returns a random unsigned integer from a secure source. Implementations
-      # may choose the integer size to return based on what the system source
-      # provides. They may choose to return a single byte (UInt8) in which case
-      # `::Random` will prefer `#random_bytes` to read as many bytes as required
-      # at once, avoiding multiple reads or reading too many bytes.
-      # def self.next_u
-    end
-  end
+  # Returns a random unsigned integer from a secure source. Implementations
+  # may choose the integer size to return based on what the system source
+  # provides. They may choose to return a single byte (UInt8) in which case
+  # `::Random` will prefer `#random_bytes` to read as many bytes as required
+  # at once, avoiding multiple reads or reading too many bytes.
+  # def self.next_u
 end
 
 {% if flag?(:linux) %}

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -1,17 +1,11 @@
-module Crystal
-  # :nodoc:
-  module System
-    # :nodoc:
-    module Time
-      # Returns the number of seconds that you must add to UTC to get local time.
-      # *seconds* are measured from `0001-01-01 00:00:00`.
-      # def self.compute_utc_offset(seconds : Int64) : Int64
+module Crystal::System::Time
+  # Returns the number of seconds that you must add to UTC to get local time.
+  # *seconds* are measured from `0001-01-01 00:00:00`.
+  # def self.compute_utc_offset(seconds : Int64) : Int64
 
-      # Returns the current UTC time measured in `{seconds, tenth_microsecond}`
-      # since `0001-01-01 00:00:00`.
-      # def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
-    end
-  end
+  # Returns the current UTC time measured in `{seconds, tenth_microsecond}`
+  # since `0001-01-01 00:00:00`.
+  # def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
 end
 
 require "./unix/time"


### PR DESCRIPTION
Just a simple rather pointless cleanup. Only one :nodoc: comment is required on Crystal::System.