### PR TITLE
Fix #4600: missing debug location

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -104,4 +104,28 @@ describe "Code gen: debug" do
       ONE.three
       ), debug: Crystal::Debug::All)
   end
+
+  it "has correct debug location after constant initialization in call with block (#4719)" do
+    codegen(%(
+      fun __crystal_malloc_atomic(size : UInt32) : Void*
+        x = uninitialized Void*
+        x
+      end
+
+      class Foo
+      end
+
+      class Bar
+        def initialize
+          yield
+        end
+      end
+
+      A = Foo.new
+
+      Bar.new { }
+
+      A
+      ), debug: Crystal::Debug::All)
+  end
 end

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -247,6 +247,8 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_call_with_block(node, block, self_type, call_args)
+    set_current_debug_location node if @debug.line_numbers?
+
     with_cloned_context do |old_block_context|
       context.vars = old_block_context.vars.dup
       context.closure_parent_context = old_block_context


### PR DESCRIPTION
There was a missing debug location...

This bug was also present when trying to compile a simple app with [toro](https://github.com/soveran/toro) in release mode.