### PR TITLE
Remove useless loc in Signal

### DIFF
--- a/src/signal.cr
+++ b/src/signal.cr
@@ -115,7 +115,6 @@ enum Signal
       # don't ignore by default.  send events to a waitpid service
       trap do
         Event::SignalChildHandler.instance.trigger
-        nil
       end
     else
       del_handler Proc(Int32, Void).new(Pointer(Void).new(0_u64), Pointer(Void).null)


### PR DESCRIPTION
It was there probably for the same reasons as in #4692.