### PR TITLE
Print spec arg errors to stderr

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -83,8 +83,8 @@ OptionParser.parse! do |opts|
     if location =~ /\A(.+?)\:(\d+)\Z/
       Spec.add_location $1, $2.to_i
     else
-      puts "location #{location} must be file:line"
-      exit
+      STDERR.puts "location #{location} must be file:line"
+      exit 1
     end
   end
   opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
@@ -106,7 +106,7 @@ OptionParser.parse! do |opts|
 end
 
 unless ARGV.empty?
-  puts "Error: unknown argument '#{ARGV.first}'"
+  STDERR.puts "Error: unknown argument '#{ARGV.first}'"
   exit 1
 end
 


### PR DESCRIPTION
This PR aims to finish the work started in #4494 to print all errors on stderr instead of stdout.

I'd spotted some errors in spec that needed to be on stderr (https://github.com/crystal-lang/crystal/pull/4494#issuecomment-314764158), but it wasn't in the scope of the ongoing pr, this one is here to finish it!