### PR TITLE
Remove unused filename parameter from Formatter

### DIFF
--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -107,7 +107,7 @@ class Crystal::Command
     source = File.read(filename)
 
     begin
-      result = Crystal.format(source, filename: filename)
+      result = Crystal.format(source)
       exit(result == source ? 0 : 1) if check_files
 
       File.write(filename, result)
@@ -152,7 +152,7 @@ class Crystal::Command
     source = File.read(filename)
 
     begin
-      result = Crystal.format(source, filename: filename)
+      result = Crystal.format(source)
       return if result == source
 
       if check_files

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1,14 +1,13 @@
 require "../syntax"
 
 module Crystal
-  def self.format(source, filename = nil)
-    Crystal::Formatter.format(source, filename: filename)
+  def self.format(source)
+    Crystal::Formatter.format(source)
   end
 
   class Formatter < Visitor
-    def self.format(source, filename = nil)
+    def self.format(source)
       parser = Parser.new(source)
-      parser.filename = filename
       nodes = parser.parse
 
       formatter = new(source)


### PR DESCRIPTION
The Parser inherits #filename from Lexer, and since Formatter only
needs `source`, it's not used outside of the Command.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>