### PR TITLE
Remove empty string as alias for --no-debug

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -295,7 +295,7 @@ class Crystal::Command
         opts.on("-d", "--debug", "Add full symbolic debug info") do
           compiler.debug = Crystal::Debug::All
         end
-        opts.on("", "--no-debug", "Skip any symbolic debug info") do
+        opts.on("--no-debug", "Skip any symbolic debug info") do
           compiler.debug = Crystal::Debug::None
         end
       end
@@ -466,7 +466,7 @@ class Crystal::Command
     opts.on("-d", "--debug", "Add full symbolic debug info") do
       compiler.debug = Crystal::Debug::All
     end
-    opts.on("", "--no-debug", "Skip any symbolic debug info") do
+    opts.on("--no-debug", "Skip any symbolic debug info") do
       compiler.debug = Crystal::Debug::None
     end
     opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|


### PR DESCRIPTION
This is a pretty dumb fix. Before this change:

```
$ crystal build --help
Usage: crystal build [options] [programfile] [--] [arguments]

Options:
    --cross-compile                  cross-compile
    -d, --debug                      Add full symbolic debug info
    , --no-debug                     Skip any symbolic debug info
   -D FLAG, --define FLAG           Define a compile-time flag
   (...)
```

After this change:

```
$ crystal build --help
Usage: crystal build [options] [programfile] [--] [arguments]

Options:
    --cross-compile                  cross-compile
    -d, --debug                      Add full symbolic debug info
    --no-debug                     Skip any symbolic debug info
   -D FLAG, --define FLAG           Define a compile-time flag
   (...)
```

Apart from that, calling `crystal build ""` would set the `--no-debug` flag.
