### PR TITLE
Process markdown in block quotes

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -72,6 +72,7 @@ describe Markdown do
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
+  assert_render "> __Hello World__", "<blockquote><strong>Hello World</strong></blockquote>"
   assert_render "> This spawns\nmultiple\nlines\n\ntext", "<blockquote>This spawns\nmultiple\nlines</blockquote>\n\n<p>text</p>"
 
   assert_render "* Hello", "<ul><li>Hello</li></ul>"

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -198,7 +198,8 @@ class Markdown::Parser
     join_next_lines continue_on: :quote
     line = @lines[@line]
 
-    @renderer.text line.byte_slice(Math.min(line.bytesize, 2))
+    process_line line.byte_slice(line.index('>').not_nil! + 1)
+
     @line += 1
 
     @renderer.end_quote


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/4924

This commit makes it so that block quotes process the markdown inside of it, instead of just rendering it like plain text.