### PR TITLE
Macros: try call for unknown var

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -15,8 +15,7 @@ module Crystal::Macros
   end
 
   # Outputs the current macro's buffer to the standard output. Useful for debugging
-  # a macro to see what's being generated. Use it like `{{debug()}}`, the parenthesis
-  # are mandatory.
+  # a macro to see what's being generated.
   #
   # By default, the output is tried to be formatted using Crystal's
   # formatter, but you can disable this by passing `false` to this method.
@@ -107,7 +106,7 @@ module Crystal::Macros
   #
   # ```
   # # sth_for_osx.cr
-  # {% skip() unless flag?(:darwin) %}
+  # {% skip unless flag?(:darwin) %}
   #
   # # Class FooForMac will only be defined if we're compiling on OS X
   # class FooForMac

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -5,6 +5,11 @@ require "semantic_version"
 module Crystal
   class MacroInterpreter
     def interpret_top_level_call(node)
+      interpret_top_level_call?(node) ||
+        node.raise("undefined macro method: '#{node.name}'")
+    end
+
+    def interpret_top_level_call?(node)
       # Please order method names in lexicographical order, because OCD
       case node.name
       when "compare_versions"
@@ -28,7 +33,7 @@ module Crystal
       when "run"
         interpret_run(node)
       else
-        node.raise "undefined macro method: '#{node.name}'"
+        nil
       end
     end
 


### PR DESCRIPTION
This allows one to write `{% debug %}` or `{% skip_file %}` instead of `{% debug() %}`

Read the comments in the commit to understand why it's not done at the parsing level (I tried it but it doesn't work in all cases).

This is a small thing that has always bugged me just a bit :-P