### PR TITLE
Fix `YAML::PullParser#read_raw`

### DIFF
--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -315,4 +315,11 @@ describe "YAML mapping" do
       yaml.last_name_present?.should be_false
     end
   end
+
+  it "handles extra whitespace properly" do
+    person = YAMLPerson.from_yaml("name: |\n  John\n  \n  X\n\n  Doe\n")
+    person.name.should eq("John\n\nX\n\nDoe\n")
+    yaml = YAMLWithAny.from_yaml( %<obj: "   \n  \\ x\n"\n>)
+    yaml.obj.should eq("  x ")
+  end
 end

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -319,7 +319,7 @@ describe "YAML mapping" do
   it "handles extra whitespace properly" do
     person = YAMLPerson.from_yaml("name: |\n  John\n  \n  X\n\n  Doe\n")
     person.name.should eq("John\n\nX\n\nDoe\n")
-    yaml = YAMLWithAny.from_yaml( %<obj: "   \n  \\ x\n"\n>)
+    yaml = YAMLWithAny.from_yaml(%<obj: "   \n  \\ x\n"\n>)
     yaml.obj.should eq("  x ")
   end
 end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -111,7 +111,8 @@ describe "YAML serialization" do
     end
 
     it "deserializes union" do
-      Array(Int32 | String).from_yaml(%([1, "hello"])).should eq([1, "hello"])
+      Array(Int32 | String).from_yaml(%([1, "hello\n\n"])).should eq([1, "hello\n"])
+      (Int32 | YAML::Any).from_yaml(%(" hello ")).should eq(" hello ")
     end
 
     it "deserializes time" do

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -1,12 +1,12 @@
 require "spec"
 require "yaml"
 
-private def assert_raw(string, expected = string, file = __FILE__, line = __LINE__)
+private def assert_raw(string, file = __FILE__, line = __LINE__)
   it "parses raw #{string.inspect}", file, line do
     pull = YAML::PullParser.new(string)
     pull.read_stream do
       pull.read_document do
-        pull.read_raw.should eq(expected)
+        YAML.parse(pull.read_raw).should eq(YAML.parse(string))
       end
     end
   end
@@ -117,10 +117,11 @@ module YAML
     end
 
     assert_raw %(hello)
-    assert_raw %("hello"), %(hello)
+    assert_raw %(" hello ")
     assert_raw %(["hello"])
     assert_raw %(["hello","world"])
     assert_raw %({"hello":"world"})
+    assert_raw %q(hello #{world})
 
     it "raises exception at correct location" do
       parser = PullParser.new("[1]")

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -6,7 +6,8 @@ private def assert_raw(string, file = __FILE__, line = __LINE__)
     pull = YAML::PullParser.new(string)
     pull.read_stream do
       pull.read_document do
-        YAML.parse(pull.read_raw).should eq(YAML.parse(string))
+        raw = pull.read_raw
+        YAML.parse(raw).should eq(YAML.parse(string))
       end
     end
   end


### PR DESCRIPTION
Currently, there are a number of cases where `read_raw` returns a string that doesn't actually represent the content fed into the parser. This uses `Builder` to make sure that what comes out represents the same as what went in.

Example of bad behavior:
https://carc.in/#/r/2o8f
```crystal
require "yaml"

struct Good
  YAML.mapping(
    foo: { type: String, nilable: true }
  )
end

struct Bad1
  YAML.mapping(
    foo: String?
  )
end

alias Bad2 = Hash(String, String | Int32)?

yamls = [
  %q(foo: " x "),
  %q(foo: "x #{y} z"),
  %q(foo: "- oops")
]

yamls.each do |yaml|
  pp Good.from_yaml yaml
  begin
    pp Bad1.from_yaml yaml
  rescue ex
    pp ex.message
  end
  begin
    pp Bad2.from_yaml yaml
  rescue ex
    pp ex.message
  end
  puts "-----"
end
```