### PR TITLE
Don't check call of non-self instance when computing read instance vars

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4707,4 +4707,29 @@ describe "Semantic: instance var" do
       ),
       "can't use instance variables at the top level"
   end
+
+  it "doesn't check call of non-self instance (#4830)" do
+    assert_type(%(
+      class Container
+        def initialize(other : Container, x)
+          initialize(other)
+          @foo = "x"
+        end
+
+        def initialize(other : Container)
+          @foo = other.foo
+        end
+
+        def initialize(@foo : String, bar)
+        end
+
+        def foo
+          @foo
+        end
+      end
+
+      container = Container.new("foo", nil)
+      Container.new(container, "foo2")
+      )) { types["Container"] }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1578,6 +1578,11 @@ module Crystal
           return false
         end
 
+        if obj && !(obj.is_a?(Var) && obj.name == "self")
+          # not a self-instance method: only verify arguments
+          return true
+        end
+
         visited = @visited
 
         node.target_defs.try &.each do |target_def|


### PR DESCRIPTION
Fixes #4830

(I think, let's see what CI says)

[This comment](https://github.com/crystal-lang/crystal/issues/4830#issuecomment-322492010) was the reason it was failing.