### PR TITLE
Add option `--output` to `crystal docs` generator

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -5,6 +5,27 @@
 
 class Crystal::Command
   private def docs
+    output_directory = File.join(".", "docs")
+
+    OptionParser.parse(options) do |opts|
+      opts.banner = <<-'BANNER'
+        Usage: crystal docs [options]
+
+        Generates API documentation from inline docstrings in all Crystal files inside ./src directory.
+
+        Options:
+        BANNER
+
+      opts.on("--output=DIR", "-o DIR", "Set the output directory (default: #{output_directory})") do |value|
+        output_directory = value
+      end
+
+      opts.on("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
     if options.empty?
       sources = [Compiler::Source.new("require", %(require "./src/**"))]
       included_dirs = [] of String
@@ -20,6 +41,6 @@ class Crystal::Command
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 
-    Doc::Generator.new(result.program, included_dirs).run
+    Doc::Generator.new(result.program, included_dirs, output_directory).run
   end
 end


### PR DESCRIPTION
Allows to configure output directory for `crystal docs` as command line argument.
Fixes #4918 in part.

There is also the debate whether the default location should be `doc` (current) or `docs`. A change could be incorporated into this PR if desired, but discussion should take place in #4918.