### PR TITLE
Remove travis OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: generic
-sudo: required
+
 dist: trusty
+sudo: required
+
 services:
   - docker
+
 matrix:
   fast_finish: true
   include:
@@ -15,18 +18,29 @@ matrix:
       osx_image: xcode8.2
   allow_failures:
     - os: osx
+
 before_install:
   - bin/ci prepare_system
+
 install:
   - bin/ci prepare_build
+
 script:
   - bin/ci build
+
 after_success:
   - bin/ci deploy
+
 branches:
   only:
     - master
     - /\Arelease\/.+\z/
+
+env:
+  global:
+    - AWS_ACCESS_KEY_ID=AKIAIRL4BWFPN7P54TBQ
+    - secure: Zd/tZVmV2dRMao9z+ky5BywSKuWOF3MiKsZetwd1upZ+uj9qzfbOZMnWFW9dlA+Co4MyYqP/I6ADzRpoKLINUqEIPcAPNYQB1qG79SafrRAvTqcjtEHTn2wXh2ZGu3f1T+SCK0ZD3xx1ML8502ENzXjvq+dEmi4kknqmPudkb6k=
+
 notifications:
   irc:
     channels:
@@ -37,7 +51,3 @@ notifications:
       - "%{repository_slug}#%{commit} (%{branch} - %{commit_subject}): %{message} %{build_url}"
   slack:
     secure: Ng3nTqGWY+9p1pS6yjGqDhmRvdgbIZgTNpMWbO/ngwpCyicmD3jafZkShqqXbULZTJJr3OxIGzi6GHGusT0Ic/Pi9JCM3X3v/xuBruKIR+EnNyPo7IL4ZYAlwnXyJHlCHHDBq0gSHGvGJwsXn6IgZBPRfeIq+CCyQHVPyvc9EHE=
-env:
-  global:
-    - AWS_ACCESS_KEY_ID=AKIAIRL4BWFPN7P54TBQ
-    - secure: Zd/tZVmV2dRMao9z+ky5BywSKuWOF3MiKsZetwd1upZ+uj9qzfbOZMnWFW9dlA+Co4MyYqP/I6ADzRpoKLINUqEIPcAPNYQB1qG79SafrRAvTqcjtEHTn2wXh2ZGu3f1T+SCK0ZD3xx1ML8502ENzXjvq+dEmi4kknqmPudkb6k=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ matrix:
       os: linux
     - env: ARCH=x86_64 ARCH_CMD=linux64 DEPLOY=true
       os: linux
-    - os: osx
-    - os: osx
-      osx_image: xcode8.2
-  allow_failures:
-    - os: osx
 
 before_install:
   - bin/ci prepare_system


### PR DESCRIPTION
Travis's OSX infastructure is extremely overloaded. We think that the excess of OSX jobs is filling up our travis "build slots" and causing linux builds not to run. To remedy this we've recided to remove OSX from travis, as we already have circleci.