### PR TITLE
Disallow to assign instance/class variable outside method dynamically

### DIFF
--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -515,4 +515,15 @@ describe "Semantic: class var" do
       Bar.x
       )) { nilable(int32) }
   end
+
+  it "errors when assigning class variable inside nested expression" do
+    assert_error %(
+      class Foo
+        if true
+          @@foo = 1
+        end
+      end
+      ),
+      "can't assign class variables outside method dynamically"
+  end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4732,4 +4732,15 @@ describe "Semantic: instance var" do
       Container.new(container, "foo2")
       )) { types["Container"] }
   end
+
+  it "errors when assigning instance variable inside nested expression" do
+    assert_error %(
+      class Foo
+        if true
+          @foo = 1
+        end
+      end
+      ),
+      "can't assign instance variables outside method dynamically"
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -646,7 +646,17 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def type_assign(target, value, node)
+    @exp_nest -= 1
     value.accept self
+    if inside_exp?
+      if target.is_a?(InstanceVar)
+        node.raise "can't assign instance variables outside method dynamically"
+      end
+      if target.is_a?(ClassVar)
+        node.raise "can't assign class variables outside method dynamically"
+      end
+    end
+    @exp_nest += 1
     false
   end
 


### PR DESCRIPTION
This code can be compiled currently:

```crystal
class Foo
  if true
    @foo = [] of Int32
  end
end

p Foo.new
```

but it is crashed at run time.

```console
$ crystal run foo.cr
Invalid memory access (signal 11) at address 0x4
```

This fix prevents it.