### PR TITLE
Disallow to assign instance variabls inside nested expressions

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4732,4 +4732,15 @@ describe "Semantic: instance var" do
       Container.new(container, "foo2")
       )) { types["Container"] }
   end
+
+  it "errors when assigning instance variable inside nested expression" do
+    assert_error %(
+      class Foo
+        if true
+          @foo = 1
+        end
+      end
+      ),
+      "can't use instance variables at the top level"
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -647,6 +647,14 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def type_assign(target, value, node)
     value.accept self
+
+    # Prevent to assign instance variables inside nested expressions.
+    # `@exp_nest > 1` is to check nested expressions. We cannot use `inside_exp?` simply
+    # because `@exp_nest` is increased when `node` is `Assign`.
+    if @exp_nest > 1 && target.is_a?(InstanceVar)
+      node.raise "can't use instance variables at the top level"
+    end
+
     false
   end
 


### PR DESCRIPTION
This code can be compiled currently:

```crystal
class Foo
  if true
    @foo = [] of Int32
  end
end

p Foo.new
```

 but it is crashed at run time:

```console
$ crystal run foo.cr
Invalid memory access (signal 11) at address 0x4
... (stack trace)
```

This fix prevents it.