### PR TITLE
HTTP: respect gzip in serialization

### DIFF
--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -139,6 +139,13 @@ module HTTP
   end
 
   def self.serialize_headers_and_string_body(io, headers, body)
+    if headers.includes_word?("Content-Encoding", "gzip")
+      body = IO::Memory.new.tap do |buf|
+        gzip = Gzip::Writer.new(buf)
+        gzip.print body
+        gzip.close
+      end
+    end
     headers["Content-Length"] = body.bytesize.to_s
     serialize_headers(io, headers)
     io << body


### PR DESCRIPTION
This allows `HTTP::Client::Response` to provide transparent transformations between ` to_io` and `from_io` about gzip.

#### case of `Content-Encoding: gzip`

Assume that API server returned a http response with `binary(gzipped data)` body.

|command | source (body) | operation | generated (body) |
|---------|---------|------|-----|
| 1st `from_io` | binary | decodes binary| text |
| 1st `to_io`     | text     | just combines header and body | text |
| 2nd `from_io` | text   | decodes `text`| `Invalid gzip header` | 

`to_io` can't restore original response data.

#### This PR
`to_io` generates gzipped `binary` when `Content-Encoding: gzip`, otherwise generates `text` in the same way as before.

|command | source (body) | operation | generated (body) |
|---------|---------|------|-----|
| 1st `from_io` | binary | decodes `binary`| text |
| 1st `to_io`     | text     | combines header and gzipped body | `binary` |
| 2nd `from_io` | `binary` | decodes `binary`| text | 
| 2nd `to_io`     | text     | combines header and gzipped body | `binary` |
| 3rd ... | ... | ... | ... |

Thanks.