### PR TITLE
Fix malloc and realloc for 64 bits platforms

### DIFF
--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -52,6 +52,15 @@ describe "Pointer" do
     end
   end
 
+  describe "realloc" do
+    it "raises on negative count" do
+      p1 = Pointer(Int32).new(123)
+      expect_raises(ArgumentError) do
+        p1.realloc(-1)
+      end
+    end
+  end
+
   describe "copy_to" do
     it "performs" do
       p1 = Pointer.malloc(4) { |i| i }

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -318,4 +318,30 @@ describe "Pointer" do
     ptr = Pointer(Int32).new(123)
     ptr.clone.should eq(ptr)
   end
+
+  {% if flag?(:bits32) %}
+    it "raises on copy_from with size bigger than UInt32::MAX" do
+      ptr = Pointer(Int32).new(123)
+
+      expect_raises(ArgumentError) do
+        ptr.copy_from(ptr, UInt32::MAX.to_u64 + 1)
+      end
+    end
+
+    it "raises on move_from with size bigger than UInt32::MAX" do
+      ptr = Pointer(Int32).new(123)
+
+      expect_raises(ArgumentError) do
+        ptr.move_from(ptr, UInt32::MAX.to_u64 + 1)
+      end
+    end
+
+    it "raises on clear with size bigger than UInt32::MAX" do
+      ptr = Pointer(Int32).new(123)
+
+      expect_raises(ArgumentError) do
+        ptr.clear(UInt32::MAX.to_u64 + 1)
+      end
+    end
+  {% end %}
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -334,7 +334,6 @@ module Crystal
         mod = info.mod
         push_debug_info_metadata(mod) unless @debug.none?
 
-        # puts mod
         mod.dump if dump_all_llvm || name =~ dump_llvm_regex
 
         # Always run verifications so we can catch bugs earlier and more often.

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -564,7 +564,7 @@ module Crystal
     end
 
     def size_t
-      if @program.has_flag?("x86_64") || @program.has_flag?("aarch64")
+      if @program.bits64?
         @llvm_context.int64
       else
         @llvm_context.int32

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -858,7 +858,7 @@ class Crystal::CodeGenVisitor
     when CharType
       inst.alignment = 4
     else
-      inst.alignment = @program.has_flag?("x86_64") || @program.has_flag?("aarch64") ? 8 : 4
+      inst.alignment = @program.bits64? ? 8 : 4
     end
   end
 

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -21,6 +21,10 @@ class Crystal::Program
     flags.includes?(name)
   end
 
+  def bits64?
+    has_flag?("x86_64") || has_flag?("aarch64")
+  end
+
   private def parse_flags(flags_name)
     set = flags_name.map(&.downcase).to_set
     set.add "darwin" if set.any?(&.starts_with?("macosx")) || set.any?(&.starts_with?("darwin"))

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -22,7 +22,7 @@ class Crystal::Program
   end
 
   def bits64?
-    has_flag?("x86_64") || has_flag?("aarch64")
+    has_flag?("bits64")
   end
 
   private def parse_flags(flags_name)
@@ -39,6 +39,12 @@ class Crystal::Program
     if set.any?(&.starts_with?("arm"))
       set.add "arm"
       set.add "armhf" if set.includes?("gnueabihf")
+    end
+
+    if set.includes?("x86_64") || set.includes?("aarch64")
+      set.add "bits64"
+    else
+      set.add "bits32"
     end
 
     set

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -78,7 +78,7 @@ end
 fun __crystal_malloc64(size : UInt64) : Void*
   {% if flag?(:bits32) %}
     if size > UInt32::MAX
-      raise ArgumentError.new("Negative size")
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
     end
   {% end %}
 
@@ -89,7 +89,7 @@ end
 fun __crystal_malloc_atomic64(size : UInt64) : Void*
   {% if flag?(:bits32) %}
     if size > UInt32::MAX
-      raise ArgumentError.new("Negative size")
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
     end
   {% end %}
 
@@ -100,7 +100,7 @@ end
 fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
   {% if flag?(:bits32) %}
     if size > UInt32::MAX
-      raise ArgumentError.new("Negative size")
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
     end
   {% end %}
 

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -74,6 +74,21 @@ fun __crystal_realloc(ptr : Void*, size : UInt32) : Void*
   LibGC.realloc(ptr, size)
 end
 
+# :nodoc:
+fun __crystal_malloc64(size : UInt64) : Void*
+  LibGC.malloc(size)
+end
+
+# :nodoc:
+fun __crystal_malloc_atomic64(size : UInt64) : Void*
+  LibGC.malloc_atomic(size)
+end
+
+# :nodoc:
+fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
+  LibGC.realloc(ptr, size)
+end
+
 module GC
   def self.init
     LibGC.set_handle_fork(1)

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -76,16 +76,34 @@ end
 
 # :nodoc:
 fun __crystal_malloc64(size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Negative size")
+    end
+  {% end %}
+
   LibGC.malloc(size)
 end
 
 # :nodoc:
 fun __crystal_malloc_atomic64(size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Negative size")
+    end
+  {% end %}
+
   LibGC.malloc_atomic(size)
 end
 
 # :nodoc:
 fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Negative size")
+    end
+  {% end %}
+
   LibGC.realloc(ptr, size)
 end
 

--- a/src/gc/null.cr
+++ b/src/gc/null.cr
@@ -13,6 +13,21 @@ fun __crystal_realloc(ptr : Void*, size : UInt32) : Void*
   LibC.realloc(ptr, size)
 end
 
+# :nodoc:
+fun __crystal_malloc64(size : UInt64) : Void*
+  LibC.malloc(size)
+end
+
+# :nodoc:
+fun __crystal_malloc_atomic64(size : UInt64) : Void*
+  LibC.malloc(size)
+end
+
+# :nodoc:
+fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
+  LibC.realloc(ptr, size)
+end
+
 module GC
   def self.init
   end

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -101,7 +101,7 @@ class IO::Memory
     slice.copy_to(@buffer + @pos, count)
 
     if @pos > @bytesize
-      Intrinsics.memset((@buffer + @bytesize).as(Void*), 0_u8, (@pos - @bytesize).to_u32, 0_u32, false)
+      (@buffer + @bytesize).clear(@pos - @bytesize)
     end
 
     @pos += count
@@ -125,7 +125,7 @@ class IO::Memory
     (@buffer + @pos).value = byte
 
     if @pos > @bytesize
-      Intrinsics.memset((@buffer + @bytesize).as(Void*), 0_u8, (@pos - @bytesize).to_u32, 0_u32, false)
+      (@buffer + @bytesize).clear(@pos - @bytesize)
     end
 
     @pos += 1

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -89,19 +89,6 @@ class LLVM::Builder
     Value.new LibLLVM.build_load(self, ptr, name)
   end
 
-  def malloc(type, name = "")
-    # check_type("malloc", type)
-
-    Value.new LibLLVM.build_malloc(self, type, name)
-  end
-
-  def array_malloc(type, value, name = "")
-    # check_type("array_malloc", type)
-    # check_value(value)
-
-    Value.new LibLLVM.build_array_malloc(self, type, value, name)
-  end
-
   {% for method_name in %w(gep inbounds_gep) %}
     def {{method_name.id}}(value, indices : Array(LLVM::ValueRef), name = "")
       # check_value(value)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -511,7 +511,7 @@ struct Pointer(T)
       count.to_u64 * sizeof(T)
     {% else %}
       if count > UInt32::MAX
-        raise ArgumentError.new("Negative count")
+        raise ArgumentError.new("Given count is bigger than UInt32::MAX")
       end
 
       count.to_u32 * sizeof(T)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -503,7 +503,7 @@ struct Pointer(T)
   end
 
   private def bytesize(count)
-    {% if flag?(:x86_64) %}
+    {% if flag?(:bits64) %}
       count.to_u64 * sizeof(T)
     {% else %}
       count.to_u32 * sizeof(T)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -506,6 +506,10 @@ struct Pointer(T)
     {% if flag?(:bits64) %}
       count.to_u64 * sizeof(T)
     {% else %}
+      if count > UInt32::MAX
+        raise ArgumentError.new("Negative count")
+      end
+
       count.to_u32 * sizeof(T)
     {% end %}
   end

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -345,6 +345,10 @@ struct Pointer(T)
   # ptr # [1, 2, 3, 4, 0, 0, 0, 0]
   # ```
   def realloc(size : Int)
+    if size < 0
+      raise ArgumentError.new("Negative size")
+    end
+
     realloc(size.to_u64)
   end
 


### PR DESCRIPTION
Fixes #4589

There were several issues:

1. `Pointer#copy_from` and others would cast the given `size` with `to_u32`, which would not work well in 64 bits
2. Even fixing 1 this was not enough to fix the whole problem. The main issue is that `__crystal_malloc` and `__crysta_realloc` had `UInt32` hardcoded.

For 1, the `LLVM::Builder` type had a `malloc` call that would define and call C's `malloc` call. However, it generated `malloc(i32)`. We used that at the beginning when we didn't have a GC and eventually replaced it with our own `__crystal_malloc` and carried the `i32` type. So, I removed the buggy `LLVM::Builder#malloc` method and instead define `malloc` (if it's not already defined) with the proper type (though this is only used in tests, there's a comment about this in the diff).

1 it's tricky because we can't simply change `__crystal_malloc`'s type because current code will stop compiling. The solution is to define another function, `__crystal_malloc64`, and at the same time change the compiler to search for this method. 

Just as a note, `Pointer#malloc` is implemented as a primitive that invokes `__crystal_malloc` or `__crystal_malloc_atomic`. Also, when you write `SomeClass.new`, `__crystal_malloc` is invoked.

After the next release we can change `__crystal_malloc`'s type and change the compiler to use `__crystal_malloc`, and in a next release we can remove the function with the 64 name suffix (though this is not a big deal as this name is internal and only used by crystal and some core std stuff). 

All failing code in this comment https://github.com/crystal-lang/crystal/issues/4589#issuecomment-328838892 now pass with a newly compiled compiler.

I don't pretend this to solve all the problems regarding pointers and memory allocation, but it's a start.
