### PR TITLE
Make Tuple and NamedTuples .types to return tuples of metaclasses

### DIFF
--- a/spec/compiler/codegen/named_tuple_spec.cr
+++ b/spec/compiler/codegen/named_tuple_spec.cr
@@ -310,4 +310,27 @@ describe "Code gen: named tuple" do
       x = {a: 0, b: z}
       ))
   end
+
+  it "accesses T and creates instance from it" do
+    run("
+      struct NamedTuple
+        def named_args
+          T
+        end
+      end
+
+      class Foo
+        def initialize(@x : Int32)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      t = {a: Foo.new(1)}
+      f = t.named_args[:a].new(2)
+      f.x
+      ").to_i.should eq(2)
+  end
 end

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -35,10 +35,10 @@ describe "Code gen: tuple" do
       ").to_i.should eq(2)
   end
 
-  it "accesses a tuple type and creates instance from it" do
+  it "accesses T and creates instance from it" do
     run("
       struct Tuple
-        def types
+        def type_args
           T
         end
       end
@@ -53,7 +53,7 @@ describe "Code gen: tuple" do
       end
 
       t = {Foo.new(1)}
-      f = t.types[0].new(2)
+      f = t.type_args[0].new(2)
       f.x
       ").to_i.should eq(2)
   end

--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -294,4 +294,21 @@ describe "Semantic: named tuples" do
       ),
       "Can't convert an empty NamedTuple to a Hash"
   end
+
+  it "types T as a tuple of metaclasses" do
+    assert_type("
+      struct NamedTuple
+        def named_args
+          T
+        end
+      end
+
+      x = {a: 1, b: 1.5, c: 'a'}
+      x.named_args
+      ") do
+      meta = named_tuple_of({"a": int32, "b": float64, "c": char}).metaclass
+      meta.metaclass?.should be_true
+      meta
+    end
+  end
 end

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -89,16 +89,16 @@ describe "Semantic: tuples" do
     assert_type("Tuple(Int32, Float64)") { tuple_of([int32, float64]).metaclass }
   end
 
-  it "types T as a tuple of metalcasses" do
+  it "types T as a tuple of metaclasses" do
     assert_type("
       struct Tuple
-        def types
+        def type_args
           T
         end
       end
 
       x = {1, 1.5, 'a'}
-      x.types
+      x.type_args
       ") do
       meta = tuple_of([int32, float64, char]).metaclass
       meta.metaclass?.should be_true

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -296,4 +296,9 @@ describe "NamedTuple" do
     tup = {a: 1, b: 'a'}
     tup.values.should eq({1, 'a'})
   end
+
+  it "does types" do
+    tuple = {a: 1, b: 'a', c: "hello"}
+    tuple.class.types.to_s.should eq("{a: Int32, b: Char, c: String}")
+  end
 end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -283,7 +283,7 @@ describe "Tuple" do
 
   it "does types" do
     tuple = {1, 'a', "hello"}
-    tuple.types.to_s.should eq("Tuple(Int32, Char, String)")
+    tuple.class.types.to_s.should eq("{Int32, Char, String}")
   end
 
   it "does ===" do

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -783,8 +783,15 @@ class Crystal::CodeGenVisitor
       ptr = aggregate_index value, index
       to_lhs ptr, type.entries[index].type
     else
-      type = (type.instance_type.as(TupleInstanceType))
-      type_id(type.tuple_types[index].as(Type).metaclass)
+      type = type.instance_type
+      case type
+      when TupleInstanceType
+        type_id(type.tuple_types[index].as(Type).metaclass)
+      when NamedTupleInstanceType
+        type_id(type.entries[index].type.as(Type).metaclass)
+      else
+        raise "BUG: unsupported codegen for tuple_indexer"
+      end
     end
   end
 

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -440,9 +440,14 @@ class Crystal::Call
         instance_type.tuple_metaclass_indexer(index)
       end
     elsif owner.is_a?(NamedTupleInstanceType)
-      # Check named tuple inexer
+      # Check named tuple indexer
       named_tuple_indexer_helper(args, arg_types, owner, owner, nilable) do |instance_type, index|
         instance_type.tuple_indexer(index)
+      end
+    elsif owner.metaclass? && (instance_type = owner.instance_type).is_a?(NamedTupleInstanceType)
+      # Check named tuple metaclass indexer
+      named_tuple_indexer_helper(args, arg_types, owner, instance_type, nilable) do |instance_type, index|
+        instance_type.tuple_metaclass_indexer(index)
       end
     end
   end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2703,8 +2703,12 @@ module Crystal
         node.type = scope.tuple_types[node.index].as(Type)
       elsif scope.is_a?(NamedTupleInstanceType)
         node.type = scope.entries[node.index].type
-      elsif scope
-        node.type = (scope.instance_type.as(TupleInstanceType).tuple_types[node.index].as(Type)).metaclass
+      elsif scope && (instance_type = scope.instance_type).is_a?(TupleInstanceType)
+        node.type = instance_type.tuple_types[node.index].as(Type).metaclass
+      elsif scope && (instance_type = scope.instance_type).is_a?(NamedTupleInstanceType)
+        node.type = instance_type.entries[node.index].type.metaclass
+      else
+        node.raise "unsupported TupleIndexer scope"
       end
       false
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2179,6 +2179,11 @@ module Crystal
       tuple_indexer(indexers, index)
     end
 
+    def tuple_metaclass_indexer(index)
+      indexers = @tuple_metaclass_indexers ||= {} of Int32 => Def
+      tuple_indexer(indexers, index)
+    end
+
     private def tuple_indexer(indexers, index)
       indexers[index] ||= begin
         body = index == -1 ? NilLiteral.new : TupleIndexer.new(index)

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -168,6 +168,16 @@ struct NamedTuple
     hasher
   end
 
+  # Returns the types of this named tuple type.
+  #
+  # ```
+  # tuple = {a: 1, b: "hello", c: 'x'}
+  # tuple.class.types # => {a: Int32, b: String, c: Char}
+  # ```
+  def self.types
+    NamedTuple.new(**{{T}})
+  end
+
   # Same as `to_s`.
   def inspect
     to_s

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -361,14 +361,14 @@ struct Tuple
     {{T.size}}
   end
 
-  # Returns the types of this tuple.
+  # Returns the types of this tuple type.
   #
   # ```
   # tuple = {1, "hello", 'x'}
-  # tuple.types # => Tuple(Int32, String, Char)
+  # tuple.class.types # => {Int32, String, Char}
   # ```
-  def types
-    T
+  def self.types
+    Tuple.new(*{{T}})
   end
 
   # Same as `to_s`.


### PR DESCRIPTION
Fixes #4737

`Tuple#types` return a tuple value now. Instead of a tuple type.
An analogous `NamedTuple#types` is added.
Since this methods depends only on the generic argument they can be class methods also/instead(?).

There is a small duplication hard to track in the compiler specs.
I am not sure if the specs should have some conditional like the one that was added [before](https://github.com/crystal-lang/crystal/blame/fe4ee06d6e92fc814dd572478eff1b1afaaec3c8/spec/std/tuple_spec.cr#L274)