### PR TITLE
Nicer output when an exception bubbles through main

### DIFF
--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -7,6 +7,12 @@ describe "Backtrace" do
     tempfile.close
     sample = "#{__DIR__}/data/backtrace_sample"
 
+    # CallStack tries to make files relative to the current dir,
+    # so we do the same for tests
+    current_dir = Dir.current
+    current_dir += '/' unless current_dir.ends_with?('/')
+    sample = sample.lchop(current_dir)
+
     `bin/crystal build --debug #{sample.inspect} -o #{tempfile.path.inspect}`
     File.exists?(tempfile.path).should be_true
 
@@ -17,9 +23,8 @@ describe "Backtrace" do
     output = `#{tempfile.path}`
 
     # resolved file line:column
-    output.should match(/callee1 at #{sample} 3:10/)
-    output.should match(/callee3 at #{sample} 15:3/)
-    output.should match(/__crystal_main at #{sample} 17:1/)
+    output.should match(/#{sample} 3:10 in 'callee1'/)
+    output.should match(/#{sample} 15:3 in 'callee3'/)
 
     # skipped internal details
     output.should_not match(/src\/callstack\.cr/)

--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -23,8 +23,8 @@ describe "Backtrace" do
     output = `#{tempfile.path}`
 
     # resolved file line:column
-    output.should match(/#{sample} 3:10 in 'callee1'/)
-    output.should match(/#{sample} 15:3 in 'callee3'/)
+    output.should match(/#{sample}:3:10 in 'callee1'/)
+    output.should match(/#{sample}:15:3 in 'callee3'/)
 
     # skipped internal details
     output.should_not match(/src\/callstack\.cr/)

--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -10,7 +10,7 @@ describe "Backtrace" do
     # CallStack tries to make files relative to the current dir,
     # so we do the same for tests
     current_dir = Dir.current
-    current_dir += '/' unless current_dir.ends_with?('/')
+    current_dir += File::SEPARATOR unless current_dir.ends_with?(File::SEPARATOR)
     sample = sample.lchop(current_dir)
 
     `bin/crystal build --debug #{sample.inspect} -o #{tempfile.path.inspect}`

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -174,25 +174,25 @@ struct CallStack
       elsif frame = CallStack.decode_frame(ip)
         _, sname = frame
         function = String.new(sname)
+
+        # We ignore these because they are part of `raise`'s internals,
+        # and we can't rely on a correct filename being available
+        # (for example if on Mac and without running `dsymutil`)
+        #
+        # We also ignore `main` because it's always at the same place
+        # and adds no info.
+        if function.starts_with?("*raise<") ||
+           function.starts_with?("*CallStack::") ||
+           function.starts_with?("*CallStack#")
+          next
+        end
+
+        # Crystal methods (their mangled name) start with `*`, so
+        # we remove that to have less clutter in the output.
+        function = function.lchop('*')
       else
         function = "???"
       end
-
-      # We ignore these because they are part of `raise`'s internals,
-      # and we can't rely on a correct filename being available
-      # (for example if on Mac and without running `dsymutil`)
-      #
-      # We also ignore `main` because it's always at the same place
-      # and adds no info.
-      if function.starts_with?("*raise<") ||
-         function.starts_with?("*CallStack::") ||
-         function.starts_with?("*CallStack#")
-        next
-      end
-
-      # Crystal methods (their mangled name) start with `*`, so
-      # we remove that to have less clutter in the output.
-      function = function.lchop('*')
 
       line = if file_line_column
                "#{file_line_column} in '#{function}'"

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -159,7 +159,7 @@ struct CallStack
         # Turn to relative to the current dir, if possible
         file = file.lchop(current_dir)
 
-        file_line_column = "#{file} #{line}:#{column}"
+        file_line_column = "#{file}:#{line}:#{column}"
       end
 
       if name = CallStack.decode_function_name(pc)

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -25,11 +25,7 @@ end
 struct CallStack
   # Compute current directory at the beginning so filenames
   # are always shown relative to the *starting* working directory.
-  CURRENT_DIR = begin
-    current_dir = Dir.current
-    current_dir += '/' unless current_dir.ends_with?('/')
-    current_dir
-  end
+  CURRENT_DIR = Process::INITIAL_PWD + '/'
 
   @@skip = [] of String
 

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -184,14 +184,9 @@ struct CallStack
       # and adds no info.
       if function.starts_with?("*raise<") ||
          function.starts_with?("*CallStack::") ||
-         function.starts_with?("*CallStack#") ||
-         function == "main"
+         function.starts_with?("*CallStack#")
         next
       end
-
-      # We rename __crystal_main to main as this the the "main"
-      # Crystal function that's always invoked from main.
-      function = "main" if function == "__crystal_main"
 
       # Crystal methods (their mangled name) start with `*`, so
       # we remove that to have less clutter in the output.

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -149,6 +149,8 @@ struct CallStack
   end
 
   private def decode_backtrace
+    show_full_info = ENV["CRYSTAL_CALLSTACK_FULL_INFO"]? == "1"
+
     @callstack.compact_map do |ip|
       pc = CallStack.decode_address(ip)
 
@@ -188,11 +190,17 @@ struct CallStack
       # we remove that to have less clutter in the output.
       function = function.lchop('*')
 
-      if file_line_column
-        "#{file_line_column} in '#{function}'"
-      else
-        "0x#{ip.address.to_s(16)} | #{function}"
+      line = if file_line_column
+               "#{file_line_column} in '#{function}'"
+             else
+               function
+             end
+
+      if show_full_info
+        line = "#{line} at 0x#{ip.address.to_s(16)}"
       end
+
+      line
     end
   end
 

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -25,7 +25,11 @@ end
 struct CallStack
   # Compute current directory at the beginning so filenames
   # are always shown relative to the *starting* working directory.
-  CURRENT_DIR = Process::INITIAL_PWD + '/'
+  CURRENT_DIR = begin
+    dir = Process::INITIAL_PWD
+    dir += File::SEPARATOR unless dir.ends_with?(File::SEPARATOR)
+    dir
+  end
 
   @@skip = [] of String
 

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -195,7 +195,7 @@ struct CallStack
       if file_line_column
         "#{file_line_column} in '#{function}'"
       else
-        function
+        "0x#{ip.address.to_s(16)} | #{function}"
       end
     end
   end

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -194,11 +194,16 @@ struct CallStack
         function = "???"
       end
 
-      line = if file_line_column
-               "#{file_line_column} in '#{function}'"
-             else
-               function
-             end
+      if file_line_column
+        if show_full_info && (frame = CallStack.decode_frame(ip))
+          _, sname = frame
+          line = "#{file_line_column} in '#{String.new(sname)}'"
+        else
+          line = "#{file_line_column} in '#{function}'"
+        end
+      else
+        line = function
+      end
 
       if show_full_info
         line = "#{line} at 0x#{ip.address.to_s(16)}"

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -23,6 +23,14 @@ end
 
 # :nodoc:
 struct CallStack
+  # Compute current directory at the beginning so filenames
+  # are always shown relative to the *starting* working directory.
+  CURRENT_DIR = begin
+    current_dir = Dir.current
+    current_dir += '/' unless current_dir.ends_with?('/')
+    current_dir
+  end
+
   @@skip = [] of String
 
   def self.skip(filename)
@@ -145,9 +153,6 @@ struct CallStack
   end
 
   private def decode_backtrace
-    current_dir = Dir.current
-    current_dir += '/' unless current_dir.ends_with?('/')
-
     @callstack.compact_map do |ip|
       pc = CallStack.decode_address(ip)
 
@@ -157,7 +162,7 @@ struct CallStack
         next if @@skip.includes?(file)
 
         # Turn to relative to the current dir, if possible
-        file = file.lchop(current_dir)
+        file = file.lchop(CURRENT_DIR)
 
         file_line_column = "#{file}:#{line}:#{column}"
       end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -48,7 +48,7 @@ class Exception
   def inspect_with_backtrace(io : IO)
     io << message << " (" << self.class << ")\n"
     backtrace?.try &.each do |frame|
-      io.print "        from "
+      io.print "  from "
       io.puts frame
     end
     io.flush

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -48,6 +48,7 @@ class Exception
   def inspect_with_backtrace(io : IO)
     io << message << " (" << self.class << ")\n"
     backtrace?.try &.each do |frame|
+      io.print "        from "
       io.puts frame
     end
     io.flush


### PR DESCRIPTION
When an exception happens in a program and isn't catched, what's printed is a bit hard to digest. For example, for this program:

```crystal
def foo
  bar
end

def bar
  a = [1]
  a[2]
end

foo
```

The output is:

```
Index out of bounds (IndexError)
0x1025cc715: *CallStack::unwind:Array(Pointer(Void)) at ??
0x1025cc6b1: *CallStack#initialize:Array(Pointer(Void)) at ??
0x1025cc688: *CallStack::new:CallStack at ??
0x1025c62a5: *raise<IndexError>:NoReturn at ??
0x1025e553e: *Array(Int32)@Indexable(T)#at<Int32>:Int32 at ??
0x1025e54d9: *Array(Int32)@Indexable(T)#[]<Int32>:Int32 at ??
0x1025cba51: *bar:Int32 at ??
0x1025cb9d9: *foo:Int32 at ??
0x1025bb807: __crystal_main at ??
0x1025cb8b8: main at ??
```

That's at least on Mac without running `dsymutil`. On linux, or on Mac when running `dsymutil`, this is the output:

```
Index out of bounds (IndexError)
0x104c6d53e: at at /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 0:17
0x104c6d4d9: [] at /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 74:5
0x104c53a51: bar at /Users/asterite/Projects/crystal/foo.cr 8:3
0x104c539d9: foo at /Users/asterite/Projects/crystal/foo.cr 3:3
0x104c43807: __crystal_main at /Users/asterite/Projects/crystal/foo.cr 10:1
0x104c538b8: main at /usr/local/Cellar/crystal-lang/0.23.1/src/main.cr 12:15
```

That's a bit better: we can see `raise` and `CallStack` are removed from the trace.

So I see a few things to improve:
1. The numbers at the left are super hardcore. They are memory addresses of the functions inside the executable (I think). Not very useful unless you will debug at a lower level (but maybe for that one can use `gdb` or `lldb`)
1. For the trace where I didn't run `dsymutil` on Mac, `CallStack` and `raise` are still there, and also all names have an annoying `*` prefix (this is part of the function mangling in Crystal)
1. For the trace where I didn't run `dsymutil` on Mac, filenames are shown as "??" which clutters the output
1. Filenames are always absolute
1. `main` is always in the trace but adds little info because it's always the same and adds no info

This PR improves all of that:
1. The cryptic numbers are removed
1. `CallStack` and `raise` are always removed from the trace
1. "??" filenames are not shown anymore
1. Files are shown relative to the current directory if possible
1. We keep `__crystal_main` but we show it as `main`, because that will have the line number in the "main" file, and we remove the actual `main` from the trace.

I also formatted the output a bit more like how Ruby shows it.

The result, without running `dsymutil` on Mac, is:

```
Index out of bounds (IndexError)
        from Array(Int32)@Indexable(T)#at<Int32>:Int32
        from Array(Int32)@Indexable(T)#[]<Int32>:Int32
        from bar:Int32
        from foo:Int32
        from main
```

With `dsymutil`, or in linux, the output is:

```
Index out of bounds (IndexError)
        from /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 0:17 in 'at'
        from /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 74:5 in '[]'
        from foo.cr 8:3 in 'bar'
        from foo.cr 3:3 in 'foo'
        from foo.cr 10:1 in 'main'
```

I think it's a bit better than before.

As a comparison, this code in Ruby:

```ruby
def foo
  bar
end

def bar
  raise "oh no"
end

foo
```

Gives this output:

```
foo.cr:6:in `bar': oh no (RuntimeError)
	from foo.cr:2:in `foo'
	from foo.cr:9:in `<main>'
```

I'll send a separate PR to always try to execute `dsymutil` on Mac so we always get files and line numbers (tracked in #4186).

We should also investigate why line numbers are incorrect, but probably in a different issue.

