### PR TITLE
debug: don't set end_location at function exit

### DIFF
--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -24,7 +24,14 @@ describe "Backtrace" do
 
     # resolved file line:column
     output.should match(/#{sample}:3:10 in 'callee1'/)
-    output.should match(/#{sample}:15:3 in 'callee3'/)
+
+    # The first line is the old (incorrect) behaviour,
+    # the second line is the new (correct) behaviour.
+    # TODO: keep only the second one after Crystal 0.23.1
+    unless output =~ /#{sample}:15:3 in 'callee3'/ ||
+           output =~ /#{sample}:13:5 in 'callee3'/
+      fail "didn't find callee3 in the backtrace"
+    end
 
     # skipped internal details
     output.should_not match(/src\/callstack\.cr/)

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -137,10 +137,6 @@ class Crystal::CodeGenVisitor
 
         accept target_def.body
 
-        if @debug.line_numbers?
-          set_current_debug_location target_def.end_location
-        end
-
         codegen_return(target_def)
 
         br_from_alloca_to_entry


### PR DESCRIPTION
The codegen was setting the end location of a method for the last `return` LLVM instruction. 

So for example for this code:

```crystal
def foo
  bar
end

def bar
  a = [1]
  a[2]
end

foo
```

we would get:

```
Index out of bounds (IndexError)
0x10d77753e: at at /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 0:17
0x10d7774d9: [] at /usr/local/Cellar/crystal-lang/0.23.1/src/indexable.cr 74:5
0x10d75da51: bar at /Users/asterite/Projects/crystal/foo.cr 8:3
0x10d75d9d9: foo at /Users/asterite/Projects/crystal/foo.cr 3:3
0x10d74d807: __crystal_main at /Users/asterite/Projects/crystal/foo.cr 10:1
0x10d75d8b8: main at /usr/local/Cellar/crystal-lang/0.23.1/src/main.cr 12:15
```

foo.cr at line 3 is the `end`, but it should be foo.cr at line 2, `bar`.

The same goes for indexable.cr at line 74, it points to the `end` where it should point to the last expression (one line above it).

The solution is to leave the debug info for the last `return` LLVM instruction as the location of the previously executed expression.

The indexable.cr line 0 is still a mistery, but it must be an unrelated issue.