### PR TITLE
Codegen: don't incorrectly share metadata across llvm modules

### DIFF
--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -38,8 +38,14 @@ module Crystal
       di_builder.create_subroutine_type(nil, int1)
     end
 
-    def debug_type_cache
-      @debug_types ||= {} of Type => LibLLVMExt::Metadata?
+    def debug_type_cache(llvm_module = @llvm_mod)
+      # We must cache debug types per module so metadata of a type
+      # from one module isn't incorrectly used in another module.
+      debug_types_per_module =
+        @debug_types_per_module ||=
+          {} of LLVM::Module => Hash(Type, LibLLVMExt::Metadata?)
+
+      debug_types_per_module[llvm_module] ||= {} of Type => LibLLVMExt::Metadata?
     end
 
     def get_debug_type(type)


### PR DESCRIPTION
Fixes #4973

(or so I think)

At least I tried to reproduce the invalid memory access with this code and it didn't happen anymore.

I'm 99% sure this was the cause: metadata nodes, which belong to an LLVM::Module, were also being used in other modules. I confirmed this by changing the code a bit and adding checks (leaving the checks would be very inefficient, so I left them out). So when a module was disposed its metadata was disposed, and then when a second module was disposed that same metadata would be disposed again, leading to a crash.

We'll know for sure if we don't see those awful crashes in CI anymore :-)