### PR TITLE
Don't consider instance var as nilable if assigned before self access

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4758,4 +4758,25 @@ describe "Semantic: instance var" do
       ),
       "can't use Gen(T) as the type of instance variable @x of Foo"
   end
+
+  it "doesn't consider instance var as nilable if assigned before self access (#4981)" do
+    assert_type(%(
+      def f(x)
+      end
+
+      class A
+        def initialize
+          @a = 0
+          f(self)
+          @a = 0
+        end
+
+        def a
+          @a
+        end
+      end
+
+      A.new.a
+      )) { int32 }
+  end
 end


### PR DESCRIPTION
Fixes #4981

If an instance variable was already assigned (present in `@vars`) there's no need to check if `self` was used before that.