### PR TITLE
Fix 12hr time formatting

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -275,6 +275,7 @@ describe Time do
   it "formats" do
     t = Time.new 2014, 1, 2, 3, 4, 5, 6
     t2 = Time.new 2014, 1, 2, 15, 4, 5, 6
+    t3 = Time.new 2014, 1, 2, 12, 4, 5, 6
 
     t.to_s("%Y").should eq("2014")
     Time.new(1, 1, 2, 3, 4, 5, 6).to_s("%Y").should eq("0001")
@@ -304,9 +305,11 @@ describe Time do
 
     t.to_s("%I").should eq("03")
     t2.to_s("%I").should eq("03")
+    t3.to_s("%I").should eq("12")
 
     t.to_s("%l").should eq(" 3")
     t2.to_s("%l").should eq(" 3")
+    t3.to_s("%l").should eq("12")
 
     # Note: we purposely match %p to am/pm and %P to AM/PM (makes more sense)
     t.to_s("%p").should eq("am")

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -92,11 +92,13 @@ struct Time::Format
     end
 
     def hour_12_zero_padded
-      pad2 (time.hour % 12), '0'
+      h = (time.hour % 12)
+      pad2 (h == 0 ? 12 : h), '0'
     end
 
     def hour_12_blank_padded
-      pad2 (time.hour % 12), ' '
+      h = (time.hour % 12)
+      pad2 (h == 0 ? 12 : h), ' '
     end
 
     def minute


### PR DESCRIPTION
Currently, the time formatting directives `%I` and `%l` return `0` (zero) for midnight/midday, yet in most locales `12` would be preferred. This PR adds a simple ternary check to return `12` when `time.hour % 12` resolves as zero.