### PR TITLE
Correctly work formatting double splat argument with trailing comma

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -185,6 +185,8 @@ describe Crystal::Formatter do
   assert_format "def `(x)\n  1\nend"
   assert_format "def /(x)\n  1\nend"
   assert_format "def foo(x : X)  forall   X ,   Y; end", "def foo(x : X) forall X, Y; end"
+  assert_format "def foo(**x,       )\n  1\nend", "def foo(**x)\n  1\nend"
+  assert_format "def foo(  x,  **y, )\n  1\nend", "def foo(x, **y)\n  1\nend"
 
   assert_format "def foo(a : T) forall T \n  #\nend", "def foo(a : T) forall T\n  #\nend"
   assert_format "def foo(a : T, b : U) forall T, U\n  #\nend", "def foo(a : T, b : U) forall T, U\n  #\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1411,18 +1411,18 @@ module Crystal
             write_token :"**"
             double_splat.accept self
             skip_space_or_newline
-          end
-
-          if block_arg
-            if double_splat
-              write_token :","
-              found_comment = skip_space_or_newline
+            if @token.type == :","
+              write "," if block_arg
+              found_comment = next_token_skip_space_or_newline
               if found_comment
                 write_indent(prefix_size)
               else
-                write " "
+                write " " if block_arg
               end
             end
+          end
+
+          if block_arg
             write_token :"&"
             skip_space
             to_skip += 1 if at_skip?
@@ -1521,15 +1521,16 @@ module Crystal
           write_token :"**"
           double_splat.accept self
           skip_space_or_newline
-          if block_arg
-            check :","
-            write ","
-            comma_written = true
+          if @token.type == :","
+            if block_arg
+              write ","
+              comma_written = true
+            end
             found_comment = next_token_skip_space
             if found_comment
               next_needs_indent = true
               found_comment = false
-            else
+            elsif block_arg
               if @token.type == :NEWLINE
                 indent(prefix_size) { consume_newlines }
                 next_needs_indent = true
@@ -1537,6 +1538,7 @@ module Crystal
                 write " "
               end
             end
+            skip_space_or_newline
           end
         end
 


### PR DESCRIPTION
Below code is correct Crystal program, but `crystal tool format` cannot format it.

```crystal
def foo(**x,)
end
```

```console
$ crystal tool format foo.cr
Error:, couldn't format 'foo.cr', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues
```