### PR TITLE
Macros: automatically resolve alias in types

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1690,4 +1690,12 @@ describe "Code gen: macro" do
       end
     ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
   end
+
+  it "resolves alias in macro" do
+    run(%(
+      alias Foo = Int32 | String
+
+      {{ Foo.union_types.size }}
+      )).to_i.should eq(2)
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -402,6 +402,8 @@ module Crystal
       when Const
         matched_type.value
       when Type
+        matched_type = matched_type.remove_alias
+
         # If it's the T of a variadic generic type, produce tuple literals
         # or named tuple literals. The compiler has them as a type
         # (a tuple type, or a named tuple type) but the user should see


### PR DESCRIPTION
Fixes #4301

This makes is so that if `T` is a (non-recursive) alias type, using `T` in macros automatically resolved to the aliased type. With this we can now do (for example):

```crystal
puts "All primitive integers"
{% for type in Int::Primitive.union_types %}
  puts {{type}}
{% end %}
```

This can greatly simply code. For example here: https://github.com/crystal-lang/crystal/blob/74050a429050f31c48cb438574b41d77691fbbce/src/json/from_json.cr#L69

An alternative implementation would be to add a macro method to solve an alias type. But alias types in regular code can never be reached by the user: trying to use one immediately uses the underlying type. So doing the same thing in macros is consistent. For example:

```crystal
alias Foo = Int32
```

There's simply now way to make a program print "Foo" at runtime by using that alias, because trying to use it will solve to `Int32`.

