### PR TITLE
Semantic: don't find type parameter in alias

### DIFF
--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -288,4 +288,13 @@ describe "Semantic: alias" do
       Baz.new.test
       )) { int32 }
   end
+
+  it "doesn't find type parameter in alias (#3502)" do
+    assert_error %(
+      class A(T)
+        alias B = A(T)
+      end
+      ),
+      "undefined constant T"
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2375,7 +2375,9 @@ module Crystal
     def process_value
       return if @value_processed
       @value_processed = true
-      @aliased_type = namespace.lookup_type(@value, allow_typeof: false)
+      @aliased_type = namespace.lookup_type(@value,
+        allow_typeof: false,
+        find_root_generic_type_parameters: false)
     end
 
     def includes_type?(other)


### PR DESCRIPTION
Fixes #3502

Similar to #4974

When we have code like:

```crystal
class Gen(T)
end

class A(T)
  alias B = Gen(T) # here
end
```

In the "here" line, `T` shouldn't be the same as the `T` from `A(T)`. Types in Crystal simply don't work like that. An alias must be solved from the current type (`A(T)` in this case) but without considering type parameters. `alias` is not generic. And nested types don't know about type parameters of parent types.
