### PR TITLE
YAML revamp

### DIFF
--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -24,6 +24,67 @@ describe YAML::Any do
       YAML.parse("foo: bar").as_h?.should eq({"foo" => "bar"})
       YAML.parse("foo: bar")["foo"].as_h?.should be_nil
     end
+
+    it "gets int64" do
+      value = YAML.parse("1").as_i64
+      value.should eq(1)
+      value.should be_a(Int64)
+
+      value = YAML.parse("1").as_i64?
+      value.should eq(1)
+      value.should be_a(Int64)
+
+      value = YAML.parse("true").as_i64?
+      value.should be_nil
+    end
+
+    it "gets int32" do
+      value = YAML.parse("1").as_i
+      value.should eq(1)
+      value.should be_a(Int32)
+
+      value = YAML.parse("1").as_i?
+      value.should eq(1)
+      value.should be_a(Int32)
+
+      value = YAML.parse("true").as_i?
+      value.should be_nil
+    end
+
+    it "gets float64" do
+      value = YAML.parse("1.2").as_f
+      value.should eq(1.2)
+      value.should be_a(Float64)
+
+      value = YAML.parse("1.2").as_f?
+      value.should eq(1.2)
+      value.should be_a(Float64)
+
+      value = YAML.parse("true").as_f?
+      value.should be_nil
+    end
+
+    it "gets time" do
+      value = YAML.parse("2010-01-02").as_time
+      value.should eq(Time.new(2010, 1, 2, kind: Time::Kind::Utc))
+
+      value = YAML.parse("2010-01-02").as_time?
+      value.should eq(Time.new(2010, 1, 2, kind: Time::Kind::Utc))
+
+      value = YAML.parse("hello").as_time?
+      value.should be_nil
+    end
+
+    it "gets bytes" do
+      value = YAML.parse("!!binary aGVsbG8=").as_bytes
+      value.should eq("hello".to_slice)
+
+      value = YAML.parse("!!binary aGVsbG8=").as_bytes?
+      value.should eq("hello".to_slice)
+
+      value = YAML.parse("1").as_bytes?
+      value.should be_nil
+    end
   end
 
   describe "#size" do
@@ -44,6 +105,10 @@ describe YAML::Any do
     it "of hash" do
       YAML.parse("foo: bar")["foo"].raw.should eq("bar")
     end
+
+    it "of hash with integer keys" do
+      YAML.parse("1: bar")[1].raw.should eq("bar")
+    end
   end
 
   describe "#[]?" do
@@ -55,6 +120,11 @@ describe YAML::Any do
     it "of hash" do
       YAML.parse("foo: bar")["foo"]?.not_nil!.raw.should eq("bar")
       YAML.parse("foo: bar")["fox"]?.should be_nil
+    end
+
+    it "of hash with integer keys" do
+      YAML.parse("1: bar")[1]?.not_nil!.raw.should eq("bar")
+      YAML.parse("1: bar")[2]?.should be_nil
     end
   end
 
@@ -94,7 +164,7 @@ describe YAML::Any do
   end
 
   it "can compare with ===" do
-    ("1" === YAML.parse("1")).should be_truthy
+    (1 === YAML.parse("1")).should be_truthy
   end
 
   it "exposes $~ when doing Regex#===" do
@@ -106,7 +176,7 @@ describe YAML::Any do
     nums = YAML.parse("[1, 2, 3]")
     nums.each_with_index do |x, i|
       x.should be_a(YAML::Any)
-      x.raw.should eq((i + 1).to_s)
+      x.raw.should eq(i + 1)
     end
   end
 end

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -15,6 +15,24 @@ describe YAML::Builder do
     end
   end
 
+  it "writes scalar with style" do
+    assert_built(%(--- "1"\n)) do
+      scalar(1, style: YAML::ScalarStyle::DOUBLE_QUOTED)
+    end
+  end
+
+  it "writes scalar with tag" do
+    assert_built(%(--- !foo 1\n...\n)) do
+      scalar(1, tag: "!foo")
+    end
+  end
+
+  it "writes scalar with anchor" do
+    assert_built(%(--- &foo 1\n...\n)) do
+      scalar(1, anchor: "foo")
+    end
+  end
+
   it "writes sequence" do
     assert_built("---\n- 1\n- 2\n- 3\n") do
       sequence do
@@ -25,9 +43,72 @@ describe YAML::Builder do
     end
   end
 
+  it "writes sequence with tag" do
+    assert_built("--- !foo\n- 1\n- 2\n- 3\n") do
+      sequence(tag: "!foo") do
+        scalar(1)
+        scalar(2)
+        scalar(3)
+      end
+    end
+  end
+
+  it "writes sequence with anchor" do
+    assert_built("--- &foo\n- 1\n- 2\n- 3\n") do
+      sequence(anchor: "foo") do
+        scalar(1)
+        scalar(2)
+        scalar(3)
+      end
+    end
+  end
+
+  it "writes sequence with style" do
+    assert_built("--- [1, 2, 3]\n") do
+      sequence(style: YAML::SequenceStyle::FLOW) do
+        scalar(1)
+        scalar(2)
+        scalar(3)
+      end
+    end
+  end
+
   it "writes mapping" do
     assert_built("---\nfoo: 1\nbar: 2\n") do
       mapping do
+        scalar("foo")
+        scalar(1)
+        scalar("bar")
+        scalar(2)
+      end
+    end
+  end
+
+  it "writes mapping with tag" do
+    assert_built("--- !foo\nfoo: 1\nbar: 2\n") do
+      mapping(tag: "!foo") do
+        scalar("foo")
+        scalar(1)
+        scalar("bar")
+        scalar(2)
+      end
+    end
+  end
+
+  it "writes mapping with anchor" do
+    assert_built("--- &foo\nfoo: 1\nbar: 2\n") do
+      mapping(anchor: "foo") do
+        scalar("foo")
+        scalar(1)
+        scalar("bar")
+        scalar(2)
+      end
+    end
+  end
+
+  it "writes mapping with style" do
+    assert_built("--- {foo: 1, bar: 2}\n") do
+      mapping(style: YAML::MappingStyle::FLOW) do
         scalar("foo")
         scalar(1)
         scalar("bar")

--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -1,0 +1,202 @@
+require "spec"
+require "yaml"
+
+private def it_parses(string, expected, file = __FILE__, line = __LINE__)
+  it "parses #{string.inspect}", file, line do
+    YAML::Schema::Core.parse(string).should eq(expected)
+  end
+end
+
+private def it_raises_on_parse(string, message, file = __FILE__, line = __LINE__)
+  it "raises on parse #{string.inspect}", file, line do
+    expect_raises(YAML::ParseException, message) do
+      YAML::Schema::Core.parse(string)
+    end
+  end
+end
+
+private def it_parses_scalar(string, expected, file = __FILE__, line = __LINE__)
+  it "parses #{string.inspect}", file, line do
+    YAML::Schema::Core.parse_scalar(string).should eq(expected)
+  end
+end
+
+private def it_parses_string(string, file = __FILE__, line = __LINE__)
+  it_parses_scalar(string, string, file, line)
+end
+
+private def it_parses_scalar_from_pull(string, expected, file = __FILE__, line = __LINE__)
+  it_parses_scalar_from_pull(string, file, line) do |value|
+    value.should eq(expected)
+  end
+end
+
+private def it_parses_scalar_from_pull(string, file = __FILE__, line = __LINE__, &block : YAML::Type ->)
+  it "parses #{string.inspect}", file, line do
+    pull = YAML::PullParser.new(%(value: #{string}))
+    pull.read_stream_start
+    pull.read_document_start
+    pull.read_mapping_start
+    pull.read_scalar # key
+
+    block.call(YAML::Schema::Core.parse_scalar(pull).as(YAML::Type))
+  end
+end
+
+describe YAML::Schema::Core do
+  # nil
+  it_parses_scalar "~", nil
+  it_parses_scalar "null", nil
+  it_parses_scalar "Null", nil
+  it_parses_scalar "NULL", nil
+
+  # true
+  it_parses_scalar "yes", true
+  it_parses_scalar "Yes", true
+  it_parses_scalar "YES", true
+  it_parses_scalar "true", true
+  it_parses_scalar "True", true
+  it_parses_scalar "TRUE", true
+  it_parses_scalar "on", true
+  it_parses_scalar "On", true
+  it_parses_scalar "ON", true
+
+  # false
+  it_parses_scalar "no", false
+  it_parses_scalar "No", false
+  it_parses_scalar "NO", false
+  it_parses_scalar "false", false
+  it_parses_scalar "False", false
+  it_parses_scalar "FALSE", false
+  it_parses_scalar "off", false
+  it_parses_scalar "Off", false
+  it_parses_scalar "OFF", false
+
+  # +infinity
+  it_parses_scalar ".inf", Float64::INFINITY
+  it_parses_scalar ".Inf", Float64::INFINITY
+  it_parses_scalar ".INF", Float64::INFINITY
+  it_parses_scalar "+.inf", Float64::INFINITY
+  it_parses_scalar "+.Inf", Float64::INFINITY
+  it_parses_scalar "+.INF", Float64::INFINITY
+
+  # -infinity
+  it_parses_scalar "-.inf", -Float64::INFINITY
+  it_parses_scalar "-.Inf", -Float64::INFINITY
+  it_parses_scalar "-.INF", -Float64::INFINITY
+
+  # nan
+  it "parses nan" do
+    {".nan", ".NaN", ".NAN"}.each do |string|
+      value = YAML::Schema::Core.parse_scalar(string)
+      value.as(Float64).nan?.should be_true
+    end
+  end
+
+  # integer (base 10)
+  it_parses_scalar "123", 123
+  it_parses_scalar "+123", 123
+  it_parses_scalar "-123", -123
+
+  # integer (binary)
+  it_parses_scalar "0b10110", 0b10110
+
+  # integer (octal)
+  it_parses_scalar "0123", 0o123
+
+  # integer (hex)
+  it_parses_scalar "0x123abc", 0x123abc
+  it_parses_scalar "-0x123abc", -0x123abc
+
+  # time
+  it_parses_scalar "2002-12-14", Time.new(2002, 12, 14, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2", Time.new(2002, 1, 2, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12", Time.new(2002, 1, 2, 10, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2   10:11:12", Time.new(2002, 1, 2, 10, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2   1:11:12", Time.new(2002, 1, 2, 1, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12.3", Time.new(2002, 1, 2, 10, 11, 12, 300, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12.34", Time.new(2002, 1, 2, 10, 11, 12, 340, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12.345", Time.new(2002, 1, 2, 10, 11, 12, 345, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12.3456", Time.new(2002, 1, 2, 10, 11, 12, 345, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12Z", Time.new(2002, 1, 2, 10, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 Z", Time.new(2002, 1, 2, 10, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 +3", Time.new(2002, 1, 2, 7, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 +03:00", Time.new(2002, 1, 2, 7, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 -03:00", Time.new(2002, 1, 2, 13, 11, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 -03:31", Time.new(2002, 1, 2, 13, 42, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12-03:31", Time.new(2002, 1, 2, 13, 42, 12, kind: Time::Kind::Utc)
+  it_parses_scalar "2002-1-2T10:11:12 +0300", Time.new(2002, 1, 2, 7, 11, 12, kind: Time::Kind::Utc)
+
+  # invalid time
+  it_parses_string "2002-34-45"
+  it_parses_string "2002-12-14 x"
+  it_parses_string "2002-1-2T10:11:12x"
+  it_parses_string "2002-1-2T10:11:12Zx"
+  it_parses_string "2002-1-2T10:11:12+03x"
+
+  # non-plain style
+  it_parses_scalar_from_pull %("1"), "1"
+
+  # bools according to the spec, but parsed as strings in Python and Ruby,
+  # so we do the same in Crystal for "compatibility"
+  it_parses_scalar "y", "y"
+  it_parses_scalar "Y", "Y"
+  it_parses_scalar "n", "n"
+  it_parses_scalar "N", "N"
+
+  # !!map
+  it_parses "!!map {1: 2}", {1 => 2}
+  it_raises_on_parse "!!map 1", "Expected MAPPING_START"
+
+  # !!omap
+  it_parses "!!omap {1: 2}", {1 => 2}
+  it_raises_on_parse "!!omap 1", "Expected MAPPING_START"
+
+  # !!pairs
+  it_parses "!!pairs [{1: 2}, {3: 4}]", [{1 => 2}, {3 => 4}]
+  it_raises_on_parse "!!pairs 1", "Expected SEQUENCE_START"
+  it_raises_on_parse "!!pairs [{1: 2, 3: 4}]", "Expected MAPPING_END"
+
+  # !!set
+  it_parses "!!set { 1, 2, 3 }", Set{1, 2, 3}
+  it_raises_on_parse "!!set 1", "Expected MAPPING_START"
+
+  # !!seq
+  it_parses "!!seq [ 1, 2, 3 ]", [1, 2, 3]
+  it_raises_on_parse "!!seq 1", "Expected SEQUENCE_START"
+
+  # !!binary
+  it_parses "!!binary aGVsbG8=", "hello".to_slice
+  it_raises_on_parse "!!binary [1]", "Expected SCALAR"
+  it_raises_on_parse "!!binary 1", "Error decoding Base64"
+
+  # !!bool
+  it_parses "!!bool yes", true
+  it_raises_on_parse "!!bool 1", "Invalid bool"
+
+  # !!float
+  it_parses "!!float '1.2'", 1.2
+  it_parses "!!float '1_234.2'", 1_234.2
+  it_parses "!!float .inf", Float64::INFINITY
+  it_raises_on_parse "!!float 'hello'", "Invalid float"
+
+  # !!int
+  it_parses "!!int 123", 123
+  it_parses "!!int 0b10", 0b10
+  it_parses "!!int 0123", 0o123
+  it_parses "!!int 0xabc", 0xabc
+  it_parses "!!int -123", -123
+  it_raises_on_parse "!!int 'hello'", "Invalid int"
+
+  # !!null
+  it_parses "!!null ~", nil
+  it_raises_on_parse "!!null 1", "Invalid null"
+
+  # !!str
+  it_parses "!!str 1", "1"
+  it_raises_on_parse "!!str [1]", "Expected SCALAR"
+
+  # # !!timestamp
+  it_parses "!!timestamp 2010-01-02", Time.new(2010, 1, 2, kind: Time::Kind::Utc)
+  it_raises_on_parse "!!timestamp foo", "Invalid timestamp"
+end

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -1,17 +1,6 @@
 require "spec"
 require "yaml"
 
-private def assert_raw(string, expected = string, file = __FILE__, line = __LINE__)
-  it "parses raw #{string.inspect}", file, line do
-    pull = YAML::PullParser.new(string)
-    pull.read_stream do
-      pull.read_document do
-        pull.read_raw.should eq(expected)
-      end
-    end
-  end
-end
-
 module YAML
   describe PullParser do
     it "reads empty stream" do
@@ -115,12 +104,6 @@ module YAML
         end
       end
     end
-
-    assert_raw %(hello)
-    assert_raw %("hello"), %(hello)
-    assert_raw %(["hello"])
-    assert_raw %(["hello","world"])
-    assert_raw %({"hello":"world"})
 
     it "raises exception at correct location" do
       parser = PullParser.new("[1]")

--- a/src/big/yaml.cr
+++ b/src/big/yaml.cr
@@ -1,10 +1,18 @@
 require "yaml"
 require "big"
 
-def BigInt.new(pull : YAML::PullParser)
-  BigInt.new(pull.read_scalar)
+def BigInt.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Scalar)
+    node.raise "Expected scalar, not #{node.class}"
+  end
+
+  BigInt.new(node.value)
 end
 
-def BigFloat.new(pull : YAML::PullParser)
-  BigFloat.new(pull.read_scalar)
+def BigFloat.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Scalar)
+    node.raise "Expected scalar, not #{node.class}"
+  end
+
+  BigFloat.new(node.value)
 end

--- a/src/yaml/enums.cr
+++ b/src/yaml/enums.cr
@@ -1,0 +1,36 @@
+module YAML
+  enum EventKind
+    NONE
+    STREAM_START
+    STREAM_END
+    DOCUMENT_START
+    DOCUMENT_END
+    ALIAS
+    SCALAR
+    SEQUENCE_START
+    SEQUENCE_END
+    MAPPING_START
+    MAPPING_END
+  end
+
+  enum ScalarStyle
+    ANY
+    PLAIN
+    SINGLE_QUOTED
+    DOUBLE_QUOTED
+    LITERAL
+    FOLDED
+  end
+
+  enum SequenceStyle
+    ANY
+    BLOCK
+    FLOW
+  end
+
+  enum MappingStyle
+    ANY
+    BLOCK
+    FLOW
+  end
+end

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -1,132 +1,160 @@
-def Object.from_yaml(string_or_io) : self
-  YAML::PullParser.new(string_or_io) do |parser|
-    parser.read_stream do
-      parser.read_document do
-        new parser
-      end
-    end
+def Object.from_yaml(string_or_io : String | IO) : self
+  new(YAML::ParseContext.new, parse_yaml(string_or_io))
+end
+
+def Array.from_yaml(string_or_io : String | IO)
+  new(YAML::ParseContext.new, parse_yaml(string_or_io)) do |element|
+    yield element
   end
 end
 
-def Array.from_yaml(string_or_io)
-  YAML::PullParser.new(string_or_io) do |parser|
-    parser.read_stream do
-      parser.read_document do
-        new(parser) do |element|
-          yield element
-        end
-      end
-    end
+private def parse_yaml(string_or_io)
+  document = YAML::Nodes.parse(string_or_io)
+
+  # If the document is empty we simulate an empty scalar with
+  # plain style, that parses to Nil
+  document.nodes.first? || begin
+    scalar = YAML::Nodes::Scalar.new("")
+    scalar.style = YAML::ScalarStyle::PLAIN
+    scalar
   end
 end
 
-def Nil.new(pull : YAML::PullParser)
-  location = pull.location
-  value = pull.read_scalar
-  if value.empty?
-    nil
+private def parse_scalar(ctx, node, type : T.class) forall T
+  ctx.read_alias(node, T) do |obj|
+    return obj
+  end
+
+  if node.is_a?(YAML::Nodes::Scalar)
+    value = YAML::Schema::Core.parse_scalar(node)
+    if value.is_a?(T)
+      ctx.record_anchor(node, value)
+      value
+    else
+      node.raise "Expected #{T}, not #{node.value}"
+    end
   else
-    raise YAML::ParseException.new("Expected nil, not #{value}", *location)
+    node.raise "Expected #{T}, not #{node.class.name}"
   end
 end
 
-def Bool.new(pull : YAML::PullParser)
-  pull.read_scalar == "true"
+def Nil.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, self)
+end
+
+def Bool.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, self)
 end
 
 {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
-  def {{type.id}}.new(pull : YAML::PullParser)
-    location = pull.location
-    begin
-      {{type.id}}.new(pull.read_scalar)
-    rescue ex
-      raise YAML::ParseException.new(ex.message.not_nil!, *location)
-    end
+  def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    {{type.id}}.new parse_scalar(ctx, node, Int64)
   end
 {% end %}
 
-def String.new(pull : YAML::PullParser)
-  pull.read_scalar
+def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, self)
 end
 
-def Float32.new(pull : YAML::PullParser)
-  pull.read_scalar.to_f32
+def Float32.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, Float64).to_f32
 end
 
-def Float64.new(pull : YAML::PullParser)
-  pull.read_scalar.to_f64
+def Float64.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, self)
 end
 
-def Array.new(pull : YAML::PullParser)
+def Array.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  ctx.read_alias(node, self) do |obj|
+    return obj
+  end
+
   ary = new
-  new(pull) do |element|
+
+  ctx.record_anchor(node, ary)
+
+  new(ctx, node) do |element|
     ary << element
   end
   ary
 end
 
-def Array.new(pull : YAML::PullParser)
-  pull.read_sequence_start
-  while pull.kind != YAML::EventKind::SEQUENCE_END
-    yield T.new(pull)
+def Array.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Sequence)
+    node.raise "Expected sequence, not #{node.class}"
   end
-  pull.read_next
+
+  node.each do |value|
+    yield T.new(ctx, value)
+  end
 end
 
-def Hash.new(pull : YAML::PullParser)
+def Hash.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  ctx.read_alias(node, self) do |obj|
+    return obj
+  end
+
   hash = new
-  new(pull) do |key, value|
+
+  ctx.record_anchor(node, hash)
+
+  new(ctx, node) do |key, value|
     hash[key] = value
   end
   hash
 end
 
-def Hash.new(pull : YAML::PullParser)
-  pull.read_mapping_start
-  while pull.kind != YAML::EventKind::MAPPING_END
-    yield K.new(pull), V.new(pull)
+def Hash.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Mapping)
+    node.raise "Expected mapping, not #{node.class}"
   end
-  pull.read_next
+
+  YAML::Schema::Core.each(node) do |key, value|
+    yield K.new(ctx, key), V.new(ctx, value)
+  end
 end
 
-def Tuple.new(pull : YAML::PullParser)
+def Tuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Sequence)
+    node.raise "Expected sequence, not #{node.class}"
+  end
+
+  if node.nodes.size != {{T.size}}
+    node.raise "Expected #{{{T.size}}} elements, not #{node.nodes.size}"
+  end
+
   {% begin %}
-    pull.read_sequence_start
-    value = Tuple.new(
+    Tuple.new(
       {% for i in 0...T.size %}
-        (self[{{i}}].new(pull)),
+        (self[{{i}}].new(ctx, node.nodes[{{i}}])),
       {% end %}
     )
-    pull.read_sequence_end
-    value
  {% end %}
 end
 
-def NamedTuple.new(pull : YAML::PullParser)
+def NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Mapping)
+    node.raise "Expected mapping, not #{node.class}"
+  end
+
   {% begin %}
     {% for key in T.keys %}
       %var{key.id} = nil
     {% end %}
 
-    location = pull.location
-
-    pull.read_mapping_start
-    while pull.kind != YAML::EventKind::MAPPING_END
-      key = pull.read_scalar
+    YAML::Schema::Core.each(node) do |key, value|
+      key = String.new(ctx, key)
       case key
         {% for key, type in T %}
           when {{key.stringify}}
-            %var{key.id} = {{type}}.new(pull)
+            %var{key.id} = {{type}}.new(ctx, value)
         {% end %}
-      else
-        pull.skip
       end
     end
-    pull.read_mapping_end
 
     {% for key in T.keys %}
       if %var{key.id}.nil?
-        raise YAML::ParseException.new("Missing yaml attribute: {{key}}", *location)
+        node.raise "Missing yaml attribute: {{key}}"
       end
     {% end %}
 
@@ -138,8 +166,12 @@ def NamedTuple.new(pull : YAML::PullParser)
   {% end %}
 end
 
-def Enum.new(pull : YAML::PullParser)
-  string = pull.read_scalar
+def Enum.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  unless node.is_a?(YAML::Nodes::Scalar)
+    node.raise "Expected scalar, not #{node.class}"
+  end
+
+  string = node.value
   if value = string.to_i64?
     from_value(value)
   else
@@ -147,38 +179,70 @@ def Enum.new(pull : YAML::PullParser)
   end
 end
 
-def Union.new(pull : YAML::PullParser)
-  location = pull.location
-  string = pull.read_raw
+def Union.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  if node.is_a?(YAML::Nodes::Alias)
+    {% for type in T %}
+      {% if type < ::Reference %}
+        ctx.read_alias?(node, {{type}}) do |obj|
+          return obj
+        end
+      {% end %}
+    {% end %}
+
+    node.raise("Error deserailizing alias")
+  end
+
   {% for type in T %}
     begin
-      return {{type}}.from_yaml(string)
+      return {{type}}.new(ctx, node)
     rescue YAML::ParseException
       # Ignore
     end
   {% end %}
-  raise YAML::ParseException.new("Couldn't parse #{self} from #{string}", *location)
+
+  node.raise "Couldn't parse #{self}"
 end
 
-def Time.new(pull : YAML::PullParser)
-  Time::Format::ISO_8601_DATE_TIME.parse(pull.read_scalar)
+def Time.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  parse_scalar(ctx, node, Time)
 end
 
 struct Time::Format
-  def from_yaml(pull : YAML::PullParser)
-    string = pull.read_scalar
-    parse(string)
+  def from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+
+    parse(node.value)
   end
 end
 
 module Time::EpochConverter
-  def self.from_yaml(value : YAML::PullParser) : Time
-    Time.epoch(value.read_scalar.to_i)
+  def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+
+    Time.epoch(node.value.to_i)
   end
 end
 
 module Time::EpochMillisConverter
-  def self.from_yaml(value : YAML::PullParser) : Time
-    Time.epoch_ms(value.read_scalar.to_i64)
+  def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+
+    Time.epoch_ms(node.value.to_i64)
+  end
+end
+
+struct Slice
+  def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    {% if T != UInt8 %}
+      {% raise "Can only deserialize Slice(UInt8), not #{@type}}" %}
+    {% end %}
+
+    parse_scalar(ctx, node, self)
   end
 end

--- a/src/yaml/lib_yaml.cr
+++ b/src/yaml/lib_yaml.cr
@@ -1,3 +1,5 @@
+require "./enums"
+
 @[Link("yaml")]
 lib LibYAML
   alias Int = LibC::Int
@@ -42,27 +44,6 @@ lib LibYAML
     prefix : UInt8*
   end
 
-  enum ScalarStyle
-    ANY
-    PLAIN
-    SINGLE_QUOTED
-    DOUBLE_QUOTED
-    LITERAL
-    FOLDED
-  end
-
-  enum SequenceStyle
-    ANY
-    BLOCK
-    FLOW
-  end
-
-  enum MappingStyle
-    ANY
-    BLOCK
-    FLOW
-  end
-
   struct StreamStartEvent
     encoding : Int32
   end
@@ -89,21 +70,21 @@ lib LibYAML
     length : LibC::SizeT
     plain_implicit : Int
     quoted_implicit : Int
-    style : ScalarStyle
+    style : YAML::ScalarStyle
   end
 
   struct SequenceStartEvent
     anchor : UInt8*
     tag : UInt8*
     implicit : Int
-    style : SequenceStyle
+    style : YAML::SequenceStyle
   end
 
   struct MappingStartEvent
     anchor : UInt8*
     tag : UInt8*
     implicit : Int
-    style : MappingStyle
+    style : YAML::MappingStyle
   end
 
   union EventData
@@ -116,20 +97,6 @@ lib LibYAML
     mapping_start : MappingStartEvent
   end
 
-  enum EventType
-    NONE
-    STREAM_START
-    STREAM_END
-    DOCUMENT_START
-    DOCUMENT_END
-    ALIAS
-    SCALAR
-    SEQUENCE_START
-    SEQUENCE_END
-    MAPPING_START
-    MAPPING_END
-  end
-
   struct Mark
     index : LibC::SizeT
     line : LibC::SizeT
@@ -137,7 +104,7 @@ lib LibYAML
   end
 
   struct Event
-    type : EventType
+    type : YAML::EventKind
     data : EventData
     start_mark : Mark
     end_mark : Mark
@@ -167,11 +134,11 @@ lib LibYAML
   fun yaml_document_end_event_initialize(event : Event*, implicit : Int) : Int
   fun yaml_scalar_event_initialize(event : Event*, anchor : LibC::Char*,
                                    tag : LibC::Char*, value : LibC::Char*, length : Int,
-                                   plain_implicit : Int, quoted_implicit : Int, style : ScalarStyle) : Int
+                                   plain_implicit : Int, quoted_implicit : Int, style : YAML::ScalarStyle) : Int
   fun yaml_alias_event_initialize(event : Event*, anchor : LibC::Char*) : Int
-  fun yaml_sequence_start_event_initialize(event : Event*, anchor : LibC::Char*, tag : LibC::Char*, implicit : Int, style : SequenceStyle) : Int
+  fun yaml_sequence_start_event_initialize(event : Event*, anchor : LibC::Char*, tag : LibC::Char*, implicit : Int, style : YAML::SequenceStyle) : Int
   fun yaml_sequence_end_event_initialize(event : Event*)
-  fun yaml_mapping_start_event_initialize(event : Event*, anchor : LibC::Char*, tag : LibC::Char*, implicit : Int, style : MappingStyle) : Int
+  fun yaml_mapping_start_event_initialize(event : Event*, anchor : LibC::Char*, tag : LibC::Char*, implicit : Int, style : YAML::MappingStyle) : Int
   fun yaml_mapping_end_event_initialize(event : Event*) : Int
   fun yaml_emitter_emit(emitter : Emitter*, event : Event*) : Int
   fun yaml_emitter_delete(emitter : Emitter*)

--- a/src/yaml/nodes.cr
+++ b/src/yaml/nodes.cr
@@ -1,0 +1,15 @@
+require "./parser"
+
+# The YAML::Nodes module provides an implementation of an
+# in-memory YAML document tree. This tree can be generated
+# with the `YAML::Nodes.parse` method or created with a
+# `YAML::Nodes::Builder`.
+#
+# This document tree can then be converted to YAML be
+# invoking `to_yaml` on the document object.
+module YAML::Nodes
+  # Parses a `String` or `IO` into a `YAML::Document`.
+  def self.parse(string_or_io : String | IO) : Document
+    Parser.new string_or_io, &.parse
+  end
+end

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -1,0 +1,121 @@
+# Builds a tree of YAML nodes.
+#
+# This builder is similar to `YAML::Builder`, but instead of
+# directly emitting the output to an IO it builds a YAML document
+# tree in memory.
+#
+# All "emitting" methods support specifying a "reference" object
+# that will be associated to the emitted object,
+# so that when that reference object is emitted again an anchor
+# and an alias will be created. This generates both more compact
+# documents and allows handling recursive data structures.
+class YAML::Nodes::Builder
+  @current : Node
+
+  # The document this builder builds.
+  getter document : Document
+
+  def initialize
+    @document = Document.new
+    @current = @document
+    @object_id_to_node = {} of UInt64 => Node
+    @anchor_count = 0
+  end
+
+  def scalar(value, anchor : String? = nil, tag : String? = nil,
+             style : YAML::ScalarStyle = YAML::ScalarStyle::ANY,
+             reference = nil) : Nil
+    node = Scalar.new(value.to_s)
+    node.anchor = anchor
+    node.tag = tag
+    node.style = style
+
+    if register(reference, node)
+      return
+    end
+
+    push_node(node)
+  end
+
+  def sequence(anchor : String? = nil, tag : String? = nil,
+               style : YAML::SequenceStyle = YAML::SequenceStyle::ANY,
+               reference = nil) : Nil
+    node = Sequence.new
+    node.anchor = anchor
+    node.tag = tag
+    node.style = style
+
+    if register(reference, node)
+      return
+    end
+
+    push_to_stack(node) do
+      yield
+    end
+  end
+
+  def mapping(anchor : String? = nil, tag : String? = nil,
+              style : YAML::MappingStyle = YAML::MappingStyle::ANY,
+              reference = nil) : Nil
+    node = Mapping.new
+    node.anchor = anchor
+    node.tag = tag
+    node.style = style
+
+    if register(reference, node)
+      return
+    end
+
+    push_to_stack(node) do
+      yield
+    end
+  end
+
+  private def push_node(node)
+    case current = @current
+    when Document
+      current << node
+    when Sequence
+      current << node
+    when Mapping
+      current << node
+    end
+  end
+
+  private def push_to_stack(node)
+    push_node(node)
+
+    old_current = @current
+    @current = node
+
+    yield
+
+    @current = old_current
+  end
+
+  private def register(object, current_node)
+    if object.is_a?(Reference)
+      register_object_id(object.object_id, current_node)
+    else
+      false
+    end
+  end
+
+  private def register_object_id(object_id, current_node)
+    node = @object_id_to_node[object_id]?
+
+    if node
+      anchor = node.anchor ||= begin
+        @anchor_count += 1
+        @anchor_count.to_s
+      end
+
+      node = Alias.new(anchor)
+      push_node(node)
+      true
+    else
+      @object_id_to_node[object_id] = current_node
+      false
+    end
+  end
+end

--- a/src/yaml/nodes/nodes.cr
+++ b/src/yaml/nodes/nodes.cr
@@ -1,0 +1,150 @@
+module YAML::Nodes
+  # Abstract class of all YAML tree nodes.
+  abstract class Node
+    # The optional tag of a node.
+    property tag : String?
+
+    # The optional anchor of a node.
+    property anchor : String?
+
+    # The line where this node starts.
+    property start_line = 0
+
+    # The column where this node starts.
+    property start_column = 0
+
+    # The line where this node ends.
+    property end_line = 0
+
+    # The column where this node ends.
+    property end_column = 0
+
+    # Returns a tuple of `start_line` and `start_column`.
+    def location : {Int32, Int32}
+      {start_line, start_column}
+    end
+
+    # Raises a `YAML::ParseException` with the given message
+    # located at this node's `location`.
+    def raise(message)
+      ::raise YAML::ParseException.new(message, *location)
+    end
+  end
+
+  # A YAML document.
+  class Document < Node
+    # The nodes inside this document.
+    #
+    # A document can hold at most one node.
+    getter nodes = [] of Node
+
+    # Appends a node to this document. Raises if more
+    # than one node is appended.
+    def <<(node)
+      if nodes.empty?
+        nodes << node
+      else
+        raise ArgumentError.new("Attempted to append more than one node")
+      end
+    end
+
+    def to_yaml(builder : YAML::Builder)
+      nodes.each &.to_yaml(builder)
+    end
+  end
+
+  # A scalar value.
+  class Scalar < Node
+    # The style of this scalar.
+    property style : ScalarStyle = ScalarStyle::ANY
+
+    # The value of this scalar.
+    property value : String
+
+    # Creates a scalar with the given *value*.
+    def initialize(@value : String)
+    end
+
+    def to_yaml(builder : YAML::Builder)
+      builder.scalar(value, anchor, tag, style)
+    end
+  end
+
+  # A sequence of nodes.
+  class Sequence < Node
+    include Enumerable(Node)
+
+    # The nodes in this sequence.
+    getter nodes = [] of Node
+
+    # The style of this sequence.
+    property style : SequenceStyle = SequenceStyle::ANY
+
+    # Appends a node into this sequence.
+    def <<(node)
+      @nodes << node
+    end
+
+    def each
+      @nodes.each do |node|
+        yield node
+      end
+    end
+
+    def to_yaml(builder : YAML::Builder)
+      builder.sequence(anchor, tag, style) do
+        each &.to_yaml(builder)
+      end
+    end
+  end
+
+  # A mapping of nodes.
+  class Mapping < Node
+    property style : MappingStyle = MappingStyle::ANY
+
+    # The nodes inside this mapping, stored linearly
+    # as key1 - value1 - key2 - value2 - etc.
+    getter nodes = [] of Node
+
+    # Appends two nodes into this mapping.
+    def []=(key, value)
+      @nodes << key << value
+    end
+
+    # Appends a single node into this mapping.
+    def <<(node)
+      @nodes << node
+    end
+
+    # Yields each key-value pair in this mapping.
+    def each
+      0.step(by: 2, to: @nodes.size - 1) do |i|
+        yield({@nodes[i], @nodes[i + 1]})
+      end
+    end
+
+    def to_yaml(builder : YAML::Builder)
+      builder.mapping(anchor, tag, style) do
+        each do |key, value|
+          key.to_yaml(builder)
+          value.to_yaml(builder)
+        end
+      end
+    end
+  end
+
+  # An alias.
+  class Alias < Node
+    # The node this alias points to.
+    # This is set by `YAML::Nodes.parse`, and is `nil` by default.
+    property value : Node?
+
+    # Creates an alias with tha given *anchor*.
+    def initialize(@anchor : String)
+    end
+
+    def to_yaml(builder : YAML::Builder)
+      builder.alias(anchor.not_nil!)
+    end
+  end
+end

--- a/src/yaml/nodes/parser.cr
+++ b/src/yaml/nodes/parser.cr
@@ -1,0 +1,70 @@
+# :nodoc:
+class YAML::Nodes::Parser < YAML::Parser
+  def initialize(content : String | IO)
+    super
+    @anchors = {} of String => Node
+  end
+
+  def self.new(content)
+    parser = new(content)
+    yield parser ensure parser.close
+  end
+
+  def new_documents
+    [] of Array(Node)
+  end
+
+  def new_document
+    Document.new
+  end
+
+  def new_sequence
+    sequence = Sequence.new
+    set_common_properties(sequence)
+    sequence.style = @pull_parser.sequence_style
+    sequence
+  end
+
+  def new_mapping
+    mapping = Mapping.new
+    set_common_properties(mapping)
+    mapping.style = @pull_parser.mapping_style
+    mapping
+  end
+
+  def new_scalar
+    scalar = Scalar.new(@pull_parser.value)
+    set_common_properties(scalar)
+    scalar.style = @pull_parser.scalar_style
+    scalar
+  end
+
+  private def set_common_properties(node)
+    node.tag = @pull_parser.tag
+    node.anchor = @pull_parser.anchor
+    node.start_line = @pull_parser.start_line.to_i
+    node.start_column = @pull_parser.start_column.to_i
+  end
+
+  def end_value(node)
+    node.end_line = @pull_parser.end_line.to_i
+    node.end_column = @pull_parser.end_column.to_i
+  end
+
+  def put_anchor(anchor, value)
+    @anchors[anchor] = value
+  end
+
+  def get_anchor(anchor)
+    value = @anchors.fetch(anchor) do
+      @pull_parser.raise("Unknown anchor '#{anchor}'")
+    end
+    node = Alias.new(anchor)
+    node.value = value
+    set_common_properties(node)
+    node
+  end
+
+  def process_tag(tag, &block)
+  end
+end

--- a/src/yaml/parse_context.cr
+++ b/src/yaml/parse_context.cr
@@ -1,0 +1,63 @@
+# Parsing context that holds anchors and what they refer to.
+#
+# When implementing `new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)`
+# to deserialize an object from a node, `Reference` types must invoke
+# both `read_alias` and `record_anchor` in order to support parsing
+# recursive data structures.
+#
+# - `read_alias` must be invoked before an instance is created
+# - `record_anchor` must be invoked after an instance is created and
+#   before its members are deserialized.
+class YAML::ParseContext
+  def initialize
+    # Recorded anchors: anchor => {object_id, crystal_type_id}
+    @anchors = {} of String => {UInt64, Int32}
+  end
+
+  # Associates an object with an anchor.
+  def record_anchor(node, object : T) : Nil forall T
+    return unless object.is_a?(Reference)
+
+    record_anchor(node.anchor, object.object_id, object.crystal_type_id)
+  end
+
+  private def record_anchor(anchor, object_id, crystal_type_id)
+    return unless anchor
+
+    @anchors[anchor] = {object_id, crystal_type_id}
+  end
+
+  # Tries to read an alias from `node` of type `T`. Invokes
+  # the block if successful, and invokers must return this object
+  # instead of deserializing their members.
+  def read_alias(node, type : T.class) forall T
+    if ptr = read_alias_impl(node, T.crystal_instance_type_id, raise_on_alias: true)
+      yield ptr.unsafe_as(T)
+    end
+  end
+
+  # Similar to `read_alias` but doesn't raise if an alias exists
+  # but an instance of type T isn't associated with the current anchor.
+  def read_alias?(node, type : T.class) forall T
+    if ptr = read_alias_impl(node, T.crystal_instance_type_id, raise_on_alias: false)
+      yield ptr.unsafe_as(T)
+    end
+  end
+
+  private def read_alias_impl(node, expected_crystal_type_id, raise_on_alias)
+    if node.is_a?(YAML::Nodes::Alias)
+      value = @anchors[node.anchor]?
+
+      if value
+        object_id, crystal_type_id = value
+        if crystal_type_id == expected_crystal_type_id
+          return Pointer(Void).new(object_id)
+        end
+      end
+
+      raise("Error deserailizing alias") if raise_on_alias
+    end
+
+    nil
+  end
+end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -1,7 +1,7 @@
-class YAML::Parser
+# :nodoc:
+abstract class YAML::Parser
   def initialize(content : String | IO)
     @pull_parser = PullParser.new(content)
-    @anchors = {} of String => YAML::Type
   end
 
   def self.new(content)
@@ -9,99 +9,165 @@ class YAML::Parser
     yield parser ensure parser.close
   end
 
-  def close
-    @pull_parser.close
+  abstract def new_documents
+  abstract def new_document
+  abstract def new_sequence
+  abstract def new_mapping
+  abstract def new_scalar
+  abstract def put_anchor(anchor, value)
+  abstract def get_anchor(anchor)
+
+  def end_value(value)
   end
 
+  def process_tag(tag, &block)
+  end
+
+  protected def cast_value(value)
+    value
+  end
+
+  protected def cast_document(document)
+    document
+  end
+
+  # Deserializes multiple YAML document.
   def parse_all
-    documents = [] of YAML::Any
+    documents = new_documents
+
+    @pull_parser.read_next
     loop do
-      case @pull_parser.read_next
-      when EventKind::STREAM_END
+      case @pull_parser.kind
+      when .stream_end?
         return documents
-      when EventKind::DOCUMENT_START
-        documents << YAML::Any.new(parse_document)
+      when .document_start?
+        documents << cast_value(parse_document)
       else
         unexpected_event
       end
     end
   end
 
+  # Deserializes a YAML document.
   def parse
-    value = case @pull_parser.read_next
-            when EventKind::STREAM_END
-              nil
-            when EventKind::DOCUMENT_START
-              parse_document
-            else
-              unexpected_event
-            end
-    YAML::Any.new(value)
-  end
-
-  def parse_document
     @pull_parser.read_next
-    value = parse_node
-    unless @pull_parser.read_next == EventKind::DOCUMENT_END
-      raise "Expected DOCUMENT_END"
+
+    document = new_document
+
+    case @pull_parser.kind
+    when .stream_end?
+    when .document_start?
+      parse_document(document)
+    else
+      unexpected_event
     end
-    value
+
+    cast_value(cast_document(document))
   end
 
-  def parse_node
+  private def parse_document
+    document = new_document
+    parse_document(document)
+    cast_document(document)
+  end
+
+  private def parse_document(document)
+    @pull_parser.read_next
+    document << parse_node
+    end_value(document)
+    @pull_parser.read_document_end
+  end
+
+  protected def parse_node
+    tag = @pull_parser.tag
+    if tag
+      process_tag(tag) do |value|
+        return value
+      end
+    end
+
     case @pull_parser.kind
-    when EventKind::SCALAR
-      anchor @pull_parser.value, @pull_parser.scalar_anchor
-    when EventKind::ALIAS
-      @anchors[@pull_parser.alias_anchor]
-    when EventKind::SEQUENCE_START
+    when .scalar?
+      parse_scalar
+    when .alias?
+      parse_alias
+    when .sequence_start?
       parse_sequence
-    when EventKind::MAPPING_START
+    when .mapping_start?
       parse_mapping
     else
       unexpected_event
     end
   end
 
-  def parse_sequence
-    sequence = [] of YAML::Type
-    anchor sequence, @pull_parser.sequence_anchor
-
-    loop do
-      case @pull_parser.read_next
-      when EventKind::SEQUENCE_END
-        return sequence
-      else
-        sequence << parse_node
-      end
-    end
-  end
-
-  def parse_mapping
-    mapping = {} of YAML::Type => YAML::Type
-    anchor mapping, @pull_parser.mapping_anchor
-
-    loop do
-      case @pull_parser.read_next
-      when EventKind::MAPPING_END
-        return mapping
-      else
-        key = parse_node
-        tag = @pull_parser.tag
-        @pull_parser.read_next
-        value = parse_node
-        if key == "<<" && value.is_a?(Hash) && tag != "tag:yaml.org,2002:str"
-          mapping.merge!(value)
-        else
-          mapping[key] = value
-        end
-      end
-    end
-  end
-
-  def anchor(value, anchor)
-    @anchors[anchor] = value if anchor
+  protected def parse_scalar
+    value = anchor(@pull_parser.anchor, new_scalar)
+    @pull_parser.read_next
     value
+  end
+
+  protected def parse_alias
+    value = get_anchor(@pull_parser.anchor.not_nil!)
+    @pull_parser.read_next
+    value
+  end
+
+  protected def parse_sequence
+    sequence = anchor new_sequence
+
+    parse_sequence(sequence) do
+      sequence << parse_node
+    end
+
+    sequence
+  end
+
+  protected def parse_sequence(sequence)
+    @pull_parser.read_sequence_start
+
+    until @pull_parser.kind.sequence_end?
+      yield
+    end
+
+    end_value(sequence)
+
+    @pull_parser.read_next
+  end
+
+  protected def parse_mapping
+    mapping = anchor new_mapping
+
+    parse_mapping(mapping) do
+      mapping[parse_node] = parse_node
+    end
+
+    mapping
+  end
+
+  protected def parse_mapping(mapping)
+    @pull_parser.read_mapping_start
+
+    until @pull_parser.kind.mapping_end?
+      yield
+    end
+
+    end_value(mapping)
+
+    @pull_parser.read_next
+  end
+
+  # Closes this parser, freeing up resources.
+  def close
+    @pull_parser.close
+  end
+
+  private def anchor(anchor, value)
+    put_anchor(anchor, value) if anchor
+    value
+  end
+
+  private def anchor(value)
+    anchor(@pull_parser.anchor, value)
   end
 
   private def unexpected_event

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -1,3 +1,12 @@
+# A pull parser allows parsing a YAML document by events.
+#
+# When creating an instance, the parser is positioned in
+# the first event. To get the event kind invoke `kind`.
+# If the event is a scalar you can invoke `value` to get
+# its **string** value. Other methods like `tag`, `anchor`
+# and `scalar_style` let you inspect other information from events.
+#
+# Invoking `read_next` reads the next event.
 class YAML::PullParser
   protected getter content
 
@@ -22,58 +31,84 @@ class YAML::PullParser
     end
 
     read_next
-    raise "Expected STREAM_START" unless kind == LibYAML::EventType::STREAM_START
+    raise "Expected STREAM_START" unless kind.stream_start?
   end
 
+  # Creates a parser, yields it to the block, and closes
+  # the parser at the end of it.
   def self.new(content)
     parser = new(content)
     yield parser ensure parser.close
   end
 
-  def kind
+  # The current event kind.
+  def kind : EventKind
     @event.type
   end
 
-  def tag
-    ptr = @event.data.scalar.tag
+  # Returns the tag associated to the current event, or `nil`
+  # if there's no tag.
+  def tag : String?
+    case kind
+    when .mapping_start?
+      ptr = @event.data.mapping_start.tag
+    when .sequence_start?
+      ptr = @event.data.sequence_start.tag
+    when .scalar?
+      ptr = @event.data.scalar.tag
+    end
     ptr ? String.new(ptr) : nil
   end
 
-  def value
+  # Returns the scalar value, assuming the pull parser
+  # is located at a scalar. Raises otherwise.
+  def value : String
+    expect_kind EventKind::SCALAR
+
     ptr = @event.data.scalar.value
-    ptr ? String.new(ptr, @event.data.scalar.length) : nil
+    ptr ? String.new(ptr, @event.data.scalar.length) : ""
   end
 
+  # Returns the anchor associated to the current event, or `nil`
+  # if there's no anchor.
   def anchor
     case kind
-    when LibYAML::EventType::SCALAR
-      scalar_anchor
-    when LibYAML::EventType::SEQUENCE_START
-      sequence_anchor
-    when LibYAML::EventType::MAPPING_START
-      mapping_anchor
+    when .scalar?
+      read_anchor @event.data.scalar.anchor
+    when .sequence_start?
+      read_anchor @event.data.sequence_start.anchor
+    when .mapping_start?
+      read_anchor @event.data.mapping_start.anchor
+    when .alias?
+      read_anchor @event.data.alias.anchor
     else
       nil
     end
   end
 
-  def scalar_anchor
-    read_anchor @event.data.scalar.anchor
+  # Returns the sequence style, assuming the pull parser is located
+  # at a sequence begin event. Raises otherwise.
+  def sequence_style : SequenceStyle
+    expect_kind EventKind::SEQUENCE_START
+    @event.data.sequence_start.style
   end
 
-  def sequence_anchor
-    read_anchor @event.data.sequence_start.anchor
+  # Returns the mapping style, assuming the pull parser is located
+  # at a mapping begin event. Raises otherwise.
+  def mapping_style : MappingStyle
+    expect_kind EventKind::MAPPING_START
+    @event.data.mapping_start.style
   end
 
-  def mapping_anchor
-    read_anchor @event.data.mapping_start.anchor
+  # Returns the scalar style, assuming the pull parser is located
+  # at a scalar event. Raises otherwise.
+  def scalar_style : ScalarStyle
+    expect_kind EventKind::SCALAR
+    @event.data.scalar.style
   end
 
-  def alias_anchor
-    read_anchor @event.data.alias.anchor
-  end
-
-  def read_next
+  # Reads the next event.
+  def read_next : EventKind
     LibYAML.yaml_event_delete(pointerof(@event))
     LibYAML.yaml_parser_parse(@parser, pointerof(@event))
     if problem = problem?
@@ -87,6 +122,8 @@ class YAML::PullParser
     kind
   end
 
+  # Reads a "stream start" event, yields to the block,
+  # and then reads a "stream end" event.
   def read_stream
     read_stream_start
     value = yield
@@ -94,6 +131,8 @@ class YAML::PullParser
     value
   end
 
+  # Reads a "document start" event, yields to the block,
+  # and then reads a "document end" event.
   def read_document
     read_document_start
     value = yield
@@ -101,6 +140,8 @@ class YAML::PullParser
     value
   end
 
+  # Reads a "sequence start" event, yields to the block,
+  # and then reads a "sequence end" event.
   def read_sequence
     read_sequence_start
     value = yield
@@ -108,6 +149,8 @@ class YAML::PullParser
     value
   end
 
+  # Reads a "mapping start" event, yields to the block,
+  # and then reads a "mapping end" event.
   def read_mapping
     read_mapping_start
     value = yield
@@ -115,126 +158,83 @@ class YAML::PullParser
     value
   end
 
+  # Reads an alias event, returning its anchor.
   def read_alias
     expect_kind EventKind::ALIAS
-    anchor = alias_anchor
+    anchor = self.anchor
     read_next
     anchor
   end
 
+  # Reads a scalar, returning its value.
   def read_scalar
     expect_kind EventKind::SCALAR
-    value = self.value.not_nil!
+    value = self.value
     read_next
     value
   end
 
+  # Reads a "stream start" event.
   def read_stream_start
     read EventKind::STREAM_START
   end
 
+  # Reads a "stream end" event.
   def read_stream_end
     read EventKind::STREAM_END
   end
 
+  # Reads a "document start" event.
   def read_document_start
     read EventKind::DOCUMENT_START
   end
 
+  # Reads a "document end" event.
   def read_document_end
     read EventKind::DOCUMENT_END
   end
 
+  # Reads a "sequence start" event.
   def read_sequence_start
     read EventKind::SEQUENCE_START
   end
 
+  # Reads a "sequence end" event.
   def read_sequence_end
     read EventKind::SEQUENCE_END
   end
 
+  # Reads a "mapping start" event.
   def read_mapping_start
     read EventKind::MAPPING_START
   end
 
+  # Reads a "mapping end" event.
   def read_mapping_end
     read EventKind::MAPPING_END
   end
 
-  def read_null_or
-    if kind == EventKind::SCALAR && (value = self.value).nil? || (value && value.empty?)
-      read_next
-      nil
-    else
-      yield
-    end
-  end
-
-  def read(expected_kind)
+  # Reads an expected event kind.
+  def read(expected_kind : EventKind) : EventKind
     expect_kind expected_kind
     read_next
   end
 
-  def read_raw
-    case kind
-    when EventKind::SCALAR
-      self.value.not_nil!.tap { read_next }
-    when EventKind::SEQUENCE_START, EventKind::MAPPING_START
-      String.build { |io| read_raw(io) }
-    else
-      raise "Unexpected kind: #{kind}"
-    end
-  end
-
-  def read_raw(io)
-    case kind
-    when EventKind::SCALAR
-      self.value.not_nil!.inspect(io)
-      read_next
-    when EventKind::SEQUENCE_START
-      io << "["
-      read_next
-      first = true
-      while kind != EventKind::SEQUENCE_END
-        io << "," unless first
-        read_raw(io)
-        first = false
-      end
-      io << "]"
-      read_next
-    when EventKind::MAPPING_START
-      io << "{"
-      read_next
-      first = true
-      while kind != EventKind::MAPPING_END
-        io << "," unless first
-        read_raw(io)
-        io << ":"
-        read_raw(io)
-        first = false
-      end
-      io << "}"
-      read_next
-    else
-      raise "Unexpected kind: #{kind}"
-    end
-  end
-
   def skip
     case kind
-    when EventKind::SCALAR
+    when .scalar?
       read_next
-    when EventKind::ALIAS
+    when .alias?
       read_next
-    when EventKind::SEQUENCE_START
+    when .sequence_start?
       read_next
-      while kind != EventKind::SEQUENCE_END
+      until kind.sequence_end?
         skip
       end
       read_next
-    when EventKind::MAPPING_START
+    when .mapping_start?
       read_next
-      while kind != EventKind::MAPPING_END
+      until kind.mapping_end?
         skip
         skip
       end
@@ -245,23 +245,31 @@ class YAML::PullParser
   # Note: YAML starts counting from 0, we want to count from 1
 
   def location
-    {line_number, column_number}
+    {start_line, start_column}
   end
 
-  def line_number
+  def start_line
     @event.start_mark.line + 1
   end
 
-  def column_number
+  def start_column
     @event.start_mark.column + 1
   end
 
+  def end_line
+    @event.end_mark.line + 1
+  end
+
+  def end_column
+    @event.end_mark.column + 1
+  end
+
   private def problem_line_number
-    (problem? ? problem_mark?.line : line_number) + 1
+    (problem? ? problem_mark?.line : start_line) + 1
   end
 
   private def problem_column_number
-    (problem? ? problem_mark?.column : column_number) + 1
+    (problem? ? problem_mark?.column : start_column) + 1
   end
 
   private def problem_mark?
@@ -302,7 +310,8 @@ class YAML::PullParser
     @closed = true
   end
 
-  private def expect_kind(kind)
+  # Raises if the current kind is not the expected one.
+  def expect_kind(kind : EventKind)
     raise "Expected #{kind} but was #{self.kind}" unless kind == self.kind
   end
 
@@ -310,7 +319,7 @@ class YAML::PullParser
     anchor ? String.new(anchor) : nil
   end
 
-  def raise(msg : String, line_number = self.line_number, column_number = self.column_number, context_info = nil)
+  def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil)
     ::raise ParseException.new(msg, line_number, column_number, context_info)
   end
 end

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -1,0 +1,335 @@
+# Provides utility methods for the YAML 1.1 core schema
+# with the additional independent types specified in http://yaml.org/type/
+module YAML::Schema::Core
+  # Deserializes a YAML document.
+  #
+  # Same as `YAML.parse`.
+  def self.parse(data : String | IO)
+    Parser.new data, &.parse
+  end
+
+  # Deserializes multiple YAML documents.
+  #
+  # Same as `YAML.parse_all`.
+  def self.parse_all(data : String | IO)
+    Parser.new data, &.parse_all
+  end
+
+  # Assuming the *pull_parser* is positioned in a scalar,
+  # parses it according to the core schema, taking the
+  # scalar's style and tag into account, then advances
+  # the pull parser.
+  def self.parse_scalar(pull_parser : YAML::PullParser) : Type
+    string = pull_parser.value
+
+    # Check for core schema tags
+    process_scalar_tag(pull_parser, pull_parser.tag) do |value|
+      return value
+    end
+
+    # Non-plain scalar is always a string
+    unless pull_parser.scalar_style.plain?
+      return string
+    end
+
+    parse_scalar(string)
+  end
+
+  # Parses a scalar value from the given *node*.
+  def self.parse_scalar(node : YAML::Nodes::Scalar) : Type
+    string = node.value
+
+    # Check for core schema tags
+    process_scalar_tag(node) do |value|
+      return value
+    end
+
+    # Non-plain scalar is always a string
+    unless node.style.plain?
+      return string
+    end
+
+    parse_scalar(string)
+  end
+
+  # Parses a string according to the core schema, assuming
+  # the string had a plain style.
+  #
+  # ```
+  # YAML::Schema::Core.parse_scalar("hello") # => "hello"
+  # YAML::Schema::Core.parse_scalar("1.2")   # => 1.2
+  # YAML::Schema::Core.parse_scalar("false") # => false
+  # ```
+  def self.parse_scalar(string : String) : Type
+    if parse_null?(string)
+      return nil
+    end
+
+    value = parse_bool?(string)
+    return value unless value.nil?
+
+    value = parse_float_infinity_and_nan?(string)
+    return value if value
+
+    # Optimizations for prefixes that either parse to
+    # a number or are strings otherwise
+    case string
+    when .starts_with?("0x"),
+         .starts_with?("+0x"),
+         .starts_with?("-0x")
+      value = string.to_i64?(base: 16, prefix: true)
+      return value || string
+    when .starts_with?('0')
+      value = string.to_i64?(base: 8, prefix: true)
+      return value || string
+    when .starts_with?('-'),
+         .starts_with?('+')
+      value = parse_number?(string)
+      return value || string
+    end
+
+    if string[0].ascii_number?
+      value = parse_number?(string)
+      return value if value
+
+      value = parse_time?(string)
+      return value if value
+    end
+
+    string
+  end
+
+  # Returns whether a string is reserved and must non be output
+  # with a plain style, according to the core schema.
+  #
+  # ```
+  # YAML::Schema::Core.reserved_string?("hello") # => false
+  # YAML::Schema::Core.reserved_string?("1.2")   # => true
+  # YAML::Schema::Core.reserved_string?("false") # => true
+  # ```
+  def self.reserved_string?(string) : Bool
+    # There's simply no other way than parsing the string and
+    # checking what we got.
+    #
+    # The performance loss is minimal because `parse_scalar`
+    # doesn't allocate memory: it can only return primitive
+    # types, or `Time`, which is a struct.
+    !parse_scalar(string).is_a?(String)
+  end
+
+  # If `node` parses to a null value, returns `nil`, otherwise
+  # invokes the given block.
+  def self.parse_null_or(node : YAML::Nodes::Node)
+    if node.is_a?(YAML::Nodes::Scalar) && parse_null?(node.value)
+      nil
+    else
+      yield
+    end
+  end
+
+  # Invokes the block for each of the given *node*s keys and
+  # values, resolving merge keys (<<) when found (keys and
+  # values of the resolved merge mappings are yielded,
+  # recursively).
+  def self.each(node : YAML::Nodes::Mapping)
+    # We can't just traverse the nodes and invoke yield because
+    # yield can't recurse. So, we use a stack of {Mapping, index}.
+    # We pop from the stack and traverse the mapping values.
+    # When we find a merge, we stop (put back in the stack with
+    # that mapping and next index) and add solved mappings from
+    # the merge to the stack, and continue processing.
+
+    stack = [{node, 0}]
+
+    # Mappings that we already visited. In case of a recursion
+    # we want to stop. For example:
+    #
+    # foo: &foo
+    #   <<: *foo
+    #
+    # When we traverse &foo we'll put it in visited,
+    # and when we find it in *foo we'll skip it.
+    #
+    # This has no use case, but we don't want to hang the program.
+    visited = Set(YAML::Nodes::Mapping).new
+
+    until stack.empty?
+      mapping, index = stack.pop
+
+      visited << mapping
+
+      while index < mapping.nodes.size
+        key = mapping.nodes[index]
+        index += 1
+
+        value = mapping.nodes[index]
+        index += 1
+
+        if key.is_a?(YAML::Nodes::Scalar) &&
+           key.value == "<<" &&
+           key.tag != "tag:yaml.org,2002:str" &&
+           solve_merge(stack, mapping, index, value, visited)
+          break
+        else
+          yield({key, value})
+        end
+      end
+    end
+  end
+
+  private def self.solve_merge(stack, mapping, index, value, visited)
+    value = value.value if value.is_a?(YAML::Nodes::Alias)
+
+    case value
+    when YAML::Nodes::Mapping
+      stack.push({mapping, index})
+
+      unless visited.includes?(value)
+        stack.push({value, 0})
+      end
+
+      true
+    when YAML::Nodes::Sequence
+      all_mappings = value.nodes.all? do |elem|
+        elem = elem.value if elem.is_a?(YAML::Nodes::Alias)
+        elem.is_a?(YAML::Nodes::Mapping)
+      end
+
+      if all_mappings
+        stack.push({mapping, index})
+
+        value.each do |elem|
+          elem = elem.value if elem.is_a?(YAML::Nodes::Alias)
+          mapping = elem.as(YAML::Nodes::Mapping)
+
+          unless visited.includes?(mapping)
+            stack.push({mapping, 0})
+          end
+        end
+
+        true
+      else
+        false
+      end
+    else
+      false
+    end
+  end
+
+  protected def self.parse_binary(string, location) : Bytes
+    Base64.decode(string)
+  rescue ex : Base64::Error
+    raise YAML::ParseException.new("Error decoding Base64: #{ex.message}", *location)
+  end
+
+  protected def self.parse_bool(string, location) : Bool
+    value = parse_bool?(string)
+    unless value.nil?
+      return value
+    end
+
+    raise YAML::ParseException.new("Invalid bool", *location)
+  end
+
+  protected def self.parse_int(string, location) : Int64
+    string.to_i64?(underscore: true, prefix: true) ||
+      raise(YAML::ParseException.new("Invalid int", *location))
+  end
+
+  protected def self.parse_float(string, location) : Float64
+    parse_float_infinity_and_nan?(string) ||
+      parse_float?(string) ||
+      raise(YAML::ParseException.new("Invalid float", *location))
+  end
+
+  protected def self.parse_null(string, location) : Nil
+    if parse_null?(string)
+      return nil
+    end
+
+    raise YAML::ParseException.new("Invalid null", *location)
+  end
+
+  protected def self.parse_time(string, location) : Time
+    parse_time?(string) ||
+      raise(YAML::ParseException.new("Invalid timestamp", *location))
+  end
+
+  protected def self.process_scalar_tag(scalar)
+    process_scalar_tag(scalar, scalar.tag) do |value|
+      yield value
+    end
+  end
+
+  protected def self.process_scalar_tag(source, tag)
+    case tag
+    when "tag:yaml.org,2002:binary"
+      yield parse_binary(source.value, source.location)
+    when "tag:yaml.org,2002:bool"
+      yield parse_bool(source.value, source.location)
+    when "tag:yaml.org,2002:float"
+      yield parse_float(source.value, source.location)
+    when "tag:yaml.org,2002:int"
+      yield parse_int(source.value, source.location)
+    when "tag:yaml.org,2002:null"
+      yield parse_null(source.value, source.location)
+    when "tag:yaml.org,2002:str"
+      yield source.value
+    when "tag:yaml.org,2002:timestamp"
+      yield parse_time(source.value, source.location)
+    end
+  end
+
+  private def self.parse_null?(string)
+    case string
+    when .empty?, "~", "null", "Null", "NULL"
+      true
+    else
+      false
+    end
+  end
+
+  private def self.parse_bool?(string)
+    case string
+    when "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON"
+      true
+    when "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF"
+      false
+    else
+      nil
+    end
+  end
+
+  private def self.parse_number?(string)
+    parse_int?(string) || parse_float?(string)
+  end
+
+  private def self.parse_int?(string)
+    string.to_i64?(underscore: true)
+  end
+
+  private def self.parse_float?(string)
+    string = string.delete('_') if string.includes?('_')
+    string.to_f64?
+  end
+
+  private def self.parse_float_infinity_and_nan?(string)
+    case string
+    when ".inf", ".Inf", ".INF", "+.inf", "+.Inf", "+.INF"
+      Float64::INFINITY
+    when "-.inf", "-.Inf", "-.INF"
+      -Float64::INFINITY
+    when ".nan", ".NaN", ".NAN"
+      Float64::NAN
+    else
+      nil
+    end
+  end
+
+  private def self.parse_time?(string)
+    # Minimum length is that of YYYY-M-D
+    return nil if string.size < 8
+
+    TimeParser.new(string).parse
+  end
+end

--- a/src/yaml/schema/core/parser.cr
+++ b/src/yaml/schema/core/parser.cr
@@ -1,0 +1,134 @@
+# :nodoc:
+class YAML::Schema::Core::Parser < YAML::Parser
+  @anchors = {} of String => Type
+
+  def put_anchor(anchor, value)
+    @anchors[anchor] = value
+  end
+
+  def get_anchor(anchor)
+    @anchors.fetch(anchor) do
+      @pull_parser.raise("Unknown anchor '#{anchor}'")
+    end
+  end
+
+  def new_documents
+    [] of YAML::Any
+  end
+
+  def new_document
+    [] of Type
+  end
+
+  def cast_document(document)
+    document.first?
+  end
+
+  def new_sequence
+    [] of Type
+  end
+
+  def new_mapping
+    {} of Type => Type
+  end
+
+  def new_scalar
+    Core.parse_scalar(@pull_parser)
+  end
+
+  def cast_value(value)
+    YAML::Any.new(value)
+  end
+
+  protected def parse_mapping
+    mapping = anchor new_mapping
+
+    parse_mapping(mapping) do
+      tag = @pull_parser.tag
+      key = parse_node
+
+      location = @pull_parser.location
+      value = parse_node
+
+      if key == "<<" && tag != "tag:yaml.org,2002:str"
+        case value
+        when Hash
+          mapping.merge!(value)
+        when Array
+          if value.all? &.is_a?(Hash)
+            value.each do |elem|
+              mapping.merge!(elem.as(Hash))
+            end
+          else
+            mapping[key] = value
+          end
+        else
+          mapping[key] = value
+        end
+      else
+        mapping[key] = value
+      end
+    end
+
+    mapping
+  end
+
+  def process_tag(tag)
+    if value = process_collection_tag(@pull_parser, tag)
+      yield value
+    end
+
+    Core.process_scalar_tag(@pull_parser, tag) do |value|
+      @pull_parser.read_next
+      yield value
+    end
+  end
+
+  private def process_collection_tag(pull_parser, tag)
+    case tag
+    when "tag:yaml.org,2002:map",
+         "tag:yaml.org,2002:omap"
+      parse_mapping
+    when "tag:yaml.org,2002:pairs"
+      parse_pairs
+    when "tag:yaml.org,2002:set"
+      parse_set
+    when "tag:yaml.org,2002:seq"
+      parse_sequence
+    else
+      nil
+    end
+  end
+
+  private def parse_pairs
+    @pull_parser.expect_kind EventKind::SEQUENCE_START
+
+    pairs = [] of Type
+
+    parse_sequence(pairs) do
+      @pull_parser.expect_kind EventKind::MAPPING_START
+      @pull_parser.read_next
+
+      pairs << {parse_node => parse_node} of Type => Type
+
+      @pull_parser.expect_kind EventKind::MAPPING_END
+      @pull_parser.read_next
+    end
+
+    pairs
+  end
+
+  private def parse_set
+    @pull_parser.expect_kind EventKind::MAPPING_START
+
+    set = Set(Type).new
+
+    parse_mapping(set) do
+      set << parse_node
+
+      parse_node # discard value
+    end
+
+    set
+  end
+end

--- a/src/yaml/schema/core/time_parser.cr
+++ b/src/yaml/schema/core/time_parser.cr
@@ -1,0 +1,199 @@
+# :nodoc:
+struct YAML::Schema::Core::TimeParser
+  # Even though the standard library has Time parsers given a *fixed* format,
+  # the format in YAML, http://yaml.org/type/timestamp.html,
+  # can consist of just the date part, and following it any number of spaces,
+  # or 't', or 'T' can follow, with many optional components. So, we implement
+  # this in a more efficient way to avoid parsing the same string with many
+  # possible formats (there's also no way to specify any number of spaces
+  # with Time::Format, or an "or" like in a Regex).
+  #
+  # As an additional note, Ruby's Psych YAML parser also implements a
+  # custom time parser, probably for this same reason.
+  def initialize(string)
+    @reader = Char::Reader.new(string)
+  end
+
+  def current_char
+    @reader.current_char
+  end
+
+  def next_char
+    @reader.next_char
+  end
+
+  def parse
+    year = parse_number(4)
+    return nil unless year
+
+    return nil unless dash?
+
+    month = parse_number_1_or_2
+    return nil unless month
+
+    return nil unless dash?
+
+    day = parse_number_1_or_2
+    return nil unless day
+
+    case current_char
+    when 'T', 't'
+      next_char
+      parse_after_date(year, month, day)
+    when .ascii_whitespace?
+      skip_space
+
+      if @reader.has_next?
+        parse_after_date(year, month, day)
+      else
+        new_time(year, month, day)
+      end
+    else
+      if @reader.has_next?
+        nil
+      else
+        new_time(year, month, day)
+      end
+    end
+  end
+
+  def parse_after_date(year, month, day)
+    hour = parse_number_1_or_2
+    return nil unless hour
+
+    return nil unless colon?
+
+    minute = parse_number(2)
+    return nil unless minute
+
+    return nil unless colon?
+
+    second = parse_number(2)
+    return nil unless second
+
+    unless @reader.has_next?
+      return new_time(year, month, day, hour, minute, second)
+    end
+
+    millisecond = 0
+
+    if current_char == '.'
+      next_char
+
+      millisecond = parse_milliseconds
+      return nil unless millisecond
+    end
+
+    skip_space
+
+    case current_char
+    when 'Z'
+      next_char
+    when '+', '-'
+      tz_sign = current_char == '+' ? 1 : -1
+      next_char
+
+      tz_hour = parse_number_1_or_2
+      return nil unless tz_hour
+
+      if colon?
+        tz_minute = parse_number(2)
+        return nil unless tz_minute
+      else
+        tz_minute = parse_number(2)
+        tz_minute = 0 unless tz_minute
+      end
+
+      tz_offset = tz_sign * (tz_hour * 60 + tz_minute)
+    end
+
+    return nil if @reader.has_next?
+
+    time = new_time(year, month, day, hour, minute, second, millisecond)
+    if time && tz_offset
+      time = time - tz_offset.minutes
+    end
+    time
+  end
+
+  def parse_milliseconds
+    return nil unless current_char.ascii_number?
+
+    multiplier = 100
+    number = current_char.to_i
+
+    next_char
+
+    2.times do
+      break unless current_char.ascii_number?
+
+      number *= 10
+      number += current_char.to_i
+      multiplier /= 10
+
+      next_char
+    end
+
+    while current_char.ascii_number?
+      next_char
+    end
+
+    number * multiplier
+  end
+
+  def parse_number(n)
+    number = 0
+
+    n.times do
+      return nil unless current_char.ascii_number?
+
+      number *= 10
+      number += current_char.to_i
+
+      next_char
+    end
+
+    number
+  end
+
+  def parse_number_1_or_2
+    return nil unless current_char.ascii_number?
+
+    number = current_char.to_i
+    next_char
+
+    if current_char.ascii_number?
+      number *= 10
+      number += current_char.to_i
+      next_char
+    end
+
+    number
+  end
+
+  def skip_space
+    while current_char.ascii_whitespace?
+      next_char
+    end
+  end
+
+  def dash?
+    return false unless current_char == '-'
+
+    next_char
+    true
+  end
+
+  def colon?
+    return false unless current_char == ':'
+
+    next_char
+    true
+  end
+
+  def new_time(*args)
+    Time.new(*args, kind: Time::Kind::Utc)
+  rescue
+    nil
+  end
+end

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -1,0 +1,56 @@
+# Provides a way to parse a YAML document according to the
+# fail-safe schema, as specified in http://www.yaml.org/spec/1.2/spec.html#id2802346,
+# where all scalar values are considered strings.
+module YAML::Schema::FailSafe
+  # All possible types according to the failsafe schema
+  alias Type = String | Hash(Type, Type) | Array(Type) | Nil
+
+  # Deserializes a YAML document.
+  def self.parse(data : String | IO) : Type
+    Parser.new data, &.parse
+  end
+
+  # Deserializes multiple YAML documents.
+  def self.parse_all(data : String | IO) : Type
+    Parser.new data, &.parse_all
+  end
+
+  # :nodoc:
+  class Parser < YAML::Parser
+    @anchors = {} of String => Type
+
+    def put_anchor(anchor, value)
+      @anchors[anchor] = value
+    end
+
+    def get_anchor(anchor)
+      @anchors.fetch(anchor) do
+        @pull_parser.raise("Unknown anchor '#{anchor}'")
+      end
+    end
+
+    def new_documents
+      [] of Type
+    end
+
+    def new_document
+      [] of Type
+    end
+
+    def cast_document(doc)
+      doc.first?
+    end
+
+    def new_sequence
+      [] of Type
+    end
+
+    def new_mapping
+      {} of Type => Type
+    end
+
+    def new_scalar
+      @pull_parser.value
+    end
+  end
+end

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -6,15 +6,23 @@ class Object
   end
 
   def to_yaml(io : IO)
-    YAML.build(io) do |yaml|
-      to_yaml(yaml)
+    # First convert the object to an in-memory tree.
+    # With this, `to_yaml` will be invoked just once
+    # on every object and we can use anchors and aliases
+    # for objects that are serialized multiple times.
+    nodes_builder = YAML::Nodes::Builder.new
+    to_yaml(nodes_builder)
+
+    # Then we convert the tree to YAML.
+    YAML.build(io) do |builder|
+      nodes_builder.document.to_yaml(builder)
     end
   end
 end
 
 class Hash
-  def to_yaml(yaml : YAML::Builder)
-    yaml.mapping do
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    yaml.mapping(reference: self) do
       each do |key, value|
         key.to_yaml(yaml)
         value.to_yaml(yaml)
@@ -24,15 +32,15 @@ class Hash
 end
 
 class Array
-  def to_yaml(yaml : YAML::Builder)
-    yaml.sequence do
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    yaml.sequence(reference: self) do
       each &.to_yaml(yaml)
     end
   end
 end
 
 struct Tuple
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.sequence do
       each &.to_yaml(yaml)
     end
@@ -40,7 +48,7 @@ struct Tuple
 end
 
 struct NamedTuple
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.mapping do
       {% for key in T.keys %}
         {{key.symbolize}}.to_yaml(yaml)
@@ -51,31 +59,35 @@ struct NamedTuple
 end
 
 class String
-  def to_yaml(yaml : YAML::Builder)
-    yaml.scalar self
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    if YAML::Schema::Core.reserved_string?(self)
+      yaml.scalar self, style: YAML::ScalarStyle::DOUBLE_QUOTED
+    else
+      yaml.scalar self
+    end
   end
 end
 
 struct Number
-  def to_yaml(yaml : YAML::Builder)
-    yaml.scalar self
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    yaml.scalar self.to_s
   end
 end
 
 struct Nil
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.scalar ""
   end
 end
 
 struct Bool
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.scalar self
   end
 end
 
 struct Set
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.sequence do
       each &.to_yaml(yaml)
     end
@@ -83,37 +95,59 @@ struct Set
 end
 
 struct Symbol
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.scalar self
   end
 end
 
 struct Enum
-  def to_yaml(yaml : YAML::Builder)
+  def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.scalar value
   end
 end
 
 struct Time
-  def to_yaml(yaml : YAML::Builder)
-    yaml.scalar Time::Format::ISO_8601_DATE_TIME.format(self)
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    if kind.utc? || kind.unspecified?
+      if hour == 0 && minute == 0 && second == 0 && millisecond == 0
+        yaml.scalar Time::Format.new("%F").format(self)
+      elsif millisecond == 0
+        yaml.scalar Time::Format.new("%F %X").format(self)
+      else
+        yaml.scalar Time::Format.new("%F %X.%L").format(self)
+      end
+    elsif millisecond == 0
+      yaml.scalar Time::Format.new("%F %X %:z").format(self)
+    else
+      yaml.scalar Time::Format.new("%F %X.%L %:z").format(self)
+    end
   end
 end
 
 struct Time::Format
-  def to_yaml(value : Time, yaml : YAML::Builder)
-    format(value).to_yaml(yaml)
+  def to_yaml(value : Time, yaml : YAML::Nodes::Builder)
+    yaml.scalar format(value)
   end
 end
 
 module Time::EpochConverter
-  def self.to_yaml(value : Time, yaml : YAML::Builder)
+  def self.to_yaml(value : Time, yaml : YAML::Nodes::Builder)
     yaml.scalar value.epoch
   end
 end
 
 module Time::EpochMillisConverter
-  def self.to_yaml(value : Time, yaml : YAML::Builder)
+  def self.to_yaml(value : Time, yaml : YAML::Nodes::Builder)
     yaml.scalar value.epoch_ms
+  end
+end
+
+struct Slice
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    {% if T != UInt8 %}
+      {% raise "Can only serialize Slice(UInt8), not #{@type}}" %}
+    {% end %}
+
+    yaml.scalar Base64.encode(self), tag: "tag:yaml.org,2002:binary"
   end
 end


### PR DESCRIPTION
This is a big PR so I'll explain everything in detail.

## What's wrong with the current YAML implementation?

Several things:

1. `YAML.parse`, `YAML.dump` and `YAML.mapping` only support the failsafe schema, when the core schema is used by default in every other programming language. The core schema supports many things, for example "null" will parse to `nil`, "0b01" will parse as a binary integer, and "2010-01-02" will parse as a time.
2. Parsing with `YAML.mapping`, and dumping via `YAML.dump`/`#to_yaml` fails on recursive types: anchors and aliases are simply ignored.
3. Some APIs were missing arguments, notably `YAML::Builder` to adjust the style, anchors and tags of sequences, mappings and scalars.
4. Most of the API was undocumented.

This PR fixes all of that.

I'll explain what changed in each of the files in this PR, but first I'll give a general overview.

## General overview

- `YAML.parse` now delegates to `YAML::Schema::Core::Parser.parse`. The idea is that all logic related to the core schema is under `YAML::Schema::Core`. This lets `YAML::PullParser` keep its simplicity. 
- `YAML::Builder` and `YAML::PullParser` can track anchors, aliases and recursive data structures. At first I thought about making a layer on top of these types. However, anchors, aliases and recursive types are a core part of the YAML specification, and an implementation can't simply ignore that. That's why parsing and emitting YAML must take that into account.

## File by file explanation

You can use this explanation as you traverse [the diff](https://github.com/crystal-lang/crystal/pull/5007/files) (same order as there).

### `spec/std/yaml/any_spec.cr `

`YAML::Any` now wraps more types, for example `Int64`, `Float64` and time, so methods to access these values need to be tested.

Additionally, YAML mappings (`Hash` in Crystal) can have complex keys, not just strings. That's why we should be able to index with `1` into a `Hash`.

A few specs changed because what previously returned a String now returns an Int.

### `spec/std/yaml/builder_spec.cr`

`YAML::Builder` can now be specified the styles, anchors and tags of mappings, sequences and scalars, and this is tested.

### `spec/std/yaml/mapping_spec.cr`

`YAML.mapping` can now serialize and deserialize recursive structures, and this is tested

### `spec/std/yaml/schema/core_spec.cr`

Here we test parsing scalars into the different types (`Nil`, `Bool`, `Int64`, `Float64`, `Time`, etc.) according to the core schema. The nice thing about this is that this can almost be tested independently of the other YAML classes and structs.

### `spec/std/yaml/serialization_spec.cr`

`#to_yaml` and `YAML.dump` now use the core schema by default, so some variants of the different types (like `null` and `Null` for `nil`) are tested. Not every variant is tested because this is already covered in `core_spec.cr`.

Additionally we test that recursive arrays and hashes can be serialized.

### `spec/std/yaml/yaml_spec.cr`

Some tests changed because of the core schema. I didn't add more specs to test that, for example, "~" parses into `nil` because that is covered in `core_spec.cr`. If we assume the parsing delegates to the core schema parser it's a bit redundant to test this twice.

### `src/yaml.cr`

Clarify in the docs that the core schema is used, and change `YAML::Type` accordingly.

### `src/yaml/any.cr`

See the explanation for `any_spec.cr`

### `src/yaml/builder.cr`

See the explanation for `builder_spec.cr`.

Additionally, the builder now tracks info to be able to dump recursive data. This is all explained in the comments.

If you implement `to_yaml` for a `Reference` type you need to use `register` when needed. **However**, `to_yaml` is implemented for the basic Crystal types, and `YAML.mapping` provides a correct implementation, so needing to learn this should be pretty rare (but it's still explained).

### `src/yaml/enums.cr`

I moved the enums from `LibYAML` into the `YAML` namespace, so that wan can more easily use them without needing to know about `LibYAML`.

### `src/yaml/from_yaml.cr`

Implementation of `from_yaml` for many Crystal types.

Most of this is done with the helper method `parse_scalar` in that same file. We simply parse a scalar according to the core schema from the pull parser, and if it's of the type we were trying to deserialize, we return it. Otherwise it's an error.

This might seem a bit slow, to parse a scalar for example to deserialize `nil`. However, `parse_scalar` doesn't allocate memory, so it's fast. I include some benchmarks at the end.

Some other changes include tracking of types to allow recursiveness.

### `src/yaml/lib_yaml.cr`

Changed because the enums were moved to the `YAML` schema.

### `src/yaml/mapping.cr`

Changed to support recursion.

To implement this is a bit tricky. First, we can't implement this just with `initialize` because we want to return a different object if we find it in the anchors. So, we need to define a `new` method. However, right now the compiler doesn't allow both a `new` and an `initialize` with the same argument "overloadness": the `initialize` wins and the `new` is hidden. This might be fixed later. For now, to make them different overloads, I added a `_dummy` argument at the end.

### `src/yaml/parser.cr`

Now the Parser is an abstract class to possibly support more schemas. Reads the docs to understand how. There are also two implementations with this: failsafe and core.

According to [YAML's spec](http://www.yaml.org/spec/1.2/spec.html#Schema) there are three recommended schemas:
- [Failsafe](http://www.yaml.org/spec/1.2/spec.html#id2802346)
- [JSON](http://www.yaml.org/spec/1.2/spec.html#id2803231)
- [Core](http://www.yaml.org/spec/1.2/spec.html#id2804923)

For Failsafe the spec says:

> A YAML processor should therefore support this schema, at least as an option.

That's why I see no reason **not** to support this, specially since it's so easy with how `YAML::Parser` was refactored.

Ideally I'd like to support `JSON` schema too, shouldn't be that hard, except I don't understand well the spec 😊 

### `src/yaml/pull_parser.cr`

This type had a few changes, some breaking changes too:

- Added doc comments for almost every method
- Added support for tracking recursive types
- Unified a few methods (like `anchor`)
- Use `.foo?` instead of the long enum name when possible

To support recursive types I use a a bit of low-level knowledge of Crystal, mainly `object_id` and `crystal_type_id`.

### `src/yaml/schema/core.cr`

This implements all the logic related to the core schema. Provides a few public methods, and a parser.

To parse a scalar no Regex is used. And no memory is allocated. It's fast. I'll show a benchmark in the end.

### `src/yaml/schema/core/time_parser.cr`

Specialized time parser. See the docs for why I didn't use `Time.parse`.

### `src/yaml/schema/fail_safe.cr`

Failsafe implementation. Doesn't use `YAML::Any`. Might be useful to some (for example `shards` could use this if it previously didn't need the core schema).

### `src/yaml/to_yaml.cr`

Updated to support recursive types. Also changed `String` to emit double quoted for reserved scalars in the core schema. And for `Time` there's custom logic to use the nicest output format.

## How is this different than #4838

First, I'd like to thank you, @jwaldrip, because you was the first who decided to start doing something about this missing YAML feature. The code is great, but I personally imagined it organized a bit differently. In the process I looked at your code (I even copied most of `YAML::Any` from it).

So, this PR is similar to #4838 but with a few differences:
- Code organization (code, but also types) is better (in my opinion) and more extensible (for example allowing to support other schemas)
- #4838 doesn't support the full core schema (for example only ISO8601 timestamps are supported, while this PR supports all variants)
- #4838 is just a bit slower (it's actually pretty fast, but this PR is a bit faster)

I'd still like to thank @jwaldrip in the changelog entry because without it, I wouldn't have done anything (no pressure to provide an implementation).

## Benchmarks

I used this benchmark:

```crystal
require "yaml"

yaml = %(
int: 1
int2: -123
int3: +456
int4: 123_456
int5: -123_456
octal: 0123
hex: 0xabCDef
binary: 0b101011
float: 1.2
float: -1.3e10
float2: +12.34e2
float3: .inf
float4: -.INF
float5: .nan
float6: .NaN
float7: -1_234.567_891
bool: true
another_bool: false
date: 2002-12-14
time: 2002-1-2T10:11:12
str: hello world
str2: 1234567890hello
tag_str: !!str 1
)

value = YAML.parse(yaml)

time = Time.now
1_000.times do
  YAML.dump(value)
end
print "Time to dump 1_000 times: "
puts Time.now - time

time = Time.now
10_000.times do
  value = YAML.parse(yaml)
end
print "Time to parse 10_000 times: "
puts Time.now - time
```

I get:

```
Time to dump 1_000 times: 00:00:00.0341950
Time to parse 10_000 times: 00:00:00.5267270
```

We can run almost the same code in Ruby. **Make sure to change `parse` to `load`** because `parse` just builds a YAML nodes tree. In Ruby I get:

```
Time to dump 1_000 times: 0.58858
Time to parse 10_000 times: 4.720954
```

So more than 10x faster to dump and parse.

Can we do it faster? Maybe. But for me, if we are already much faster than Ruby it's enough (if this parsing speed is good-enough for Ruby, for us it's more than good-enough)

Fixes #4384
Fixes #1745
Fixes #2873
Fixes #3101
Fixes #4929
Closes #4838