### PR TITLE
Implement `Exception#inspect`

### DIFF
--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -13,4 +13,9 @@ describe "Exception" do
     ex.to_s.should eq("foo? -- bar!")
     ex.inspect_with_backtrace.should contain("foo? -- bar!")
   end
+
+  it "inspects" do
+    ex = FooError.new("foo?")
+    ex.inspect.should eq("#<FooError:foo? -- bar!>")
+  end
 end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -39,6 +39,10 @@ class Exception
     io << message
   end
 
+  def inspect(io : IO)
+    io << "#<" << self.class.name << ":" << message << ">"
+  end
+
   def inspect_with_backtrace
     String.build do |io|
       inspect_with_backtrace io


### PR DESCRIPTION
Code:

```crystal
begin
  raise "OH NO!"
rescue ex
  p ex
end
```

Output before:

```
#<Exception:0x108379d40
 @callstack=
  CallStack(
   @backtrace=nil,
   @callstack=
    [Pointer(Void)@0x107f36525,
     Pointer(Void)@0x107f364c1,
     Pointer(Void)@0x107f36498,
     Pointer(Void)@0x107f25955,
     Pointer(Void)@0x107f25901,
     Pointer(Void)@0x107f253bd,
     Pointer(Void)@0x107f354d8]),
 @cause=nil,
 @message="OH NO">
```

Output after:

```
#<Exception:OH NO>
```

Ruby also uses the same format.

I considered showing the backtrace here but I think it's not relevant to `inspect` (that's probably why Ruby doesn't show it either).