### PR TITLE
Support LLVM 4.0 postfixed versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 SHELL = bash
 LLVM_CONFIG_FINDER := \
   [ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+  command -v llvm-config-4.0 || command -v llvm-config40 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 4.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-3.9 || command -v llvm-config39 || \
     (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.9*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-3.8 || command -v llvm-config38 || \

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -2,6 +2,8 @@
 lib LibLLVM
   LLVM_CONFIG = {{
                   `[ -n "$LLVM_CONFIG" ] && command -v "$LLVM_CONFIG" || \
+                   command -v llvm-config-4.0 || command -v llvm-config40 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 4.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-3.9 || command -v llvm-config39 || \
                    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 3.9*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-3.8 || command -v llvm-config38 || \


### PR DESCRIPTION
Debian-based distributions allow you to install multiple versions of LLVM in parallel, allowing you to access them individually using postfixed `llvm-config` versions (ie `llvm-config-3.8` or `llvm-config-3.9`).

Ubuntu (Xenial) added packages for LLVM 4.0 with `-4.0` postfix (under `llvm-4.0` package).

Crystal supports and uses 3.9 or 3.8, but no option for 4.0.

This change makes sure LLVM 4.0 is also tried first.

Before this change (with LLVM 4.0 installed):

```
$ make crystal
Using /usr/bin/llvm-config-3.8 [version=3.8.0]
...

$ bin/crystal --version
Using compiled compiler at `.build/crystal'
Crystal 0.23.0+177 [12ed6df] (2017-09-20)

LLVM: 3.8.0
Default target: x86_64-pc-linux-gnu
```

After this change (with LLVM 4.0 installed)

```
$ make crystal
Using /usr/bin/llvm-config-4.0 [version=4.0.0]
...

$ bin/crystal --version
Using compiled compiler at `.build/crystal'
Crystal 0.23.0+177 [12ed6df] (2017-09-20)

LLVM: 4.0.0
Default target: x86_64-pc-linux-gnu
```

Thank you for the continuous support and work on Crystal and looking forward your comments!
❤️ ❤️ ❤️ 