### PR TITLE
Remember STDIN, STDOUT and STDERR blocking state when program begins and restore it at the end

### DIFF
--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -12,6 +12,10 @@ def _crystal_main(argc : Int32, argv : UInt8**)
 end
 
 module Crystal
+  @@stdin_is_blocking = false
+  @@stdout_is_blocking = false
+  @@stderr_is_blocking = false
+
   # Defines the main routine run by normal Crystal programs:
   #
   # - Initializes the GC
@@ -41,6 +45,8 @@ module Crystal
   def self.main(&block)
     GC.init
 
+    remember_blocking_state
+
     status =
       begin
         yield
@@ -53,6 +59,9 @@ module Crystal
     ex.inspect_with_backtrace STDERR if ex
     STDOUT.flush
     STDERR.flush
+
+    restore_blocking_state
+
     status
   end
 
@@ -100,6 +109,20 @@ module Crystal
   # more details.
   def self.main_user_code(argc : Int32, argv : UInt8**)
     _crystal_main(argc, argv)
+  end
+
+  # :nodoc:
+  def self.remember_blocking_state
+    @@stdin_is_blocking = IO::FileDescriptor.fcntl(0, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+    @@stdout_is_blocking = IO::FileDescriptor.fcntl(1, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+    @@stderr_is_blocking = IO::FileDescriptor.fcntl(2, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+  end
+
+  # :nodoc:
+  def self.restore_blocking_state
+    STDIN.blocking = @@stdin_is_blocking
+    STDOUT.blocking = @@stdout_is_blocking
+    STDERR.blocking = @@stderr_is_blocking
   end
 end
 

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -145,6 +145,8 @@ end
 
 # :nodoc:
 fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
+  Crystal.restore_blocking_state
+
   # Capture fault signals (SEGV, BUS) and finish the process printing a backtrace first
   LibC.dprintf 2, "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
   CallStack.print_backtrace


### PR DESCRIPTION
**Doesn't fix #2713** because if you change the program to do `sleep 1` you can see the same bad behaviour. A [different approach](https://github.com/crystal-lang/crystal/issues/2713#issuecomment-331330481) is needed, but it's still a good idea to restore the original state. 
