### PR TITLE
Use `TypeNode#union_types` where possible

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -132,11 +132,11 @@ describe "JSON serialization" do
       Union(Bool, Array(Int32)).from_json(%(true)).should be_true
     end
 
-    {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64).map(&.id) %}
-        it "deserializes union with {{type}} (fast path)" do
-          Union({{type}}, Array(Int32)).from_json(%(#{ {{type}}::MAX })).should eq({{type}}::MAX)
-        end
-      {% end %}
+    {% for type in Int::Primitive.union_types %}
+      it "deserializes union with {{type}} (fast path)" do
+        Union({{type}}, Array(Int32)).from_json(%(#{ {{type}}::MAX })).should eq({{type}}::MAX)
+      end
+    {% end %}
 
     it "deserializes union with Float32 (fast path)" do
       Union(Float32, Array(Int32)).from_json(%(1)).should eq(1)

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -66,7 +66,7 @@ def Bool.new(pull : JSON::PullParser)
   pull.read_bool
 end
 
-{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+{% for type in Int::Primitive.union_types %}
   def {{type.id}}.new(pull : JSON::PullParser)
     {{type.id}}.new(pull.read_int)
   end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -67,8 +67,8 @@ def Bool.new(pull : JSON::PullParser)
 end
 
 {% for type in Int::Primitive.union_types %}
-  def {{type.id}}.new(pull : JSON::PullParser)
-    {{type.id}}.new(pull.read_int)
+  def {{type}}.new(pull : JSON::PullParser)
+    {{type}}.new(pull.read_int)
   end
 {% end %}
 

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -273,7 +273,7 @@ end
   {% binaries = {"+" => "adding", "-" => "subtracting", "*" => "multiplying", "/" => "dividing"} %}
 
   {% for num in nums %}
-    struct {{num.id}}
+    struct {{num}}
       {% for name, type in {
                              to_i: Int32, to_u: UInt32, to_f: Float64,
                              to_i8: Int8, to_i16: Int16, to_i32: Int32, to_i64: Int64, to_i128: Int128,
@@ -297,7 +297,7 @@ end
                            } %}
           # Returns `true` if `self` is {{desc.id}} *other*.
           @[Primitive(:binary)]
-          def {{op.id}}(other : {{num2.id}}) : Bool
+          def {{op.id}}(other : {{num2}}) : Bool
           end
         {% end %}
       {% end %}
@@ -305,7 +305,7 @@ end
   {% end %}
 
   {% for int in ints %}
-    struct {{int.id}}
+    struct {{int}}
       # Returns a `Char` that has the unicode codepoint of `self`,
       # without checking if this integer is in the range valid for
       # chars (`0..0x10ffff`).
@@ -325,44 +325,44 @@ end
           {% if op != "/" %}
             # Returns the result of {{desc.id}} `self` and *other*.
             @[Primitive(:binary)]
-            def {{op.id}}(other : {{int2.id}}) : self
+            def {{op.id}}(other : {{int2}}) : self
             end
           {% end %}
         {% end %}
 
         # Returns the result of performing a bitwise OR of `self`'s and *other*'s bits.
         @[Primitive(:binary)]
-        def |(other : {{int2.id}}) : self
+        def |(other : {{int2}}) : self
         end
 
         # Returns the result of performing a bitwise AND of `self`'s and *other*'s bits.
         @[Primitive(:binary)]
-        def &(other : {{int2.id}}) : self
+        def &(other : {{int2}}) : self
         end
 
         # Returns the result of performing a bitwise XOR of `self`'s and *other*'s bits.
         @[Primitive(:binary)]
-        def ^(other : {{int2.id}}) : self
+        def ^(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[Primitive(:binary)]
-        def unsafe_shl(other : {{int2.id}}) : self
+        def unsafe_shl(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[Primitive(:binary)]
-        def unsafe_shr(other : {{int2.id}}) : self
+        def unsafe_shr(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[Primitive(:binary)]
-        def unsafe_div(other : {{int2.id}}) : self
+        def unsafe_div(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[Primitive(:binary)]
-        def unsafe_mod(other : {{int2.id}}) : self
+        def unsafe_mod(other : {{int2}}) : self
         end
       {% end %}
 
@@ -370,7 +370,7 @@ end
         {% for op, desc in binaries %}
           # Returns the result of {{desc.id}} `self` and *other*.
           @[Primitive(:binary)]
-          def {{op.id}}(other : {{float.id}}) : {{float.id}}
+          def {{op.id}}(other : {{float}}) : {{float}}
           end
         {% end %}
       {% end %}
@@ -378,12 +378,12 @@ end
   {% end %}
 
   {% for float in floats %}
-    struct {{float.id}}
+    struct {{float}}
       {% for num in nums %}
         {% for op, desc in binaries %}
           # Returns the result of {{desc.id}} `self` and *other*.
           @[Primitive(:binary)]
-          def {{op.id}}(other : {{num.id}}) : self
+          def {{op.id}}(other : {{num}}) : self
           end
         {% end %}
       {% end %}

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -267,9 +267,9 @@ end
 # unions.
 
 {% begin %}
-  {% ints = %w(Int8 Int16 Int32 Int64 Int128 UInt8 UInt16 UInt32 UInt64 UInt128) %}
-  {% floats = %w(Float32 Float64) %}
-  {% nums = %w(Int8 Int16 Int32 Int64 Int128 UInt8 UInt16 UInt32 UInt64 UInt128 Float32 Float64) %}
+  {% ints = Int::Primitive.union_types %}
+  {% floats = Float::Primitive.union_types %}
+  {% nums = Number::Primitive.union_types %}
   {% binaries = {"+" => "adding", "-" => "subtracting", "*" => "multiplying", "/" => "dividing"} %}
 
   {% for num in nums %}

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -22,7 +22,7 @@ module Random::Secure
     Crystal::System::Random.random_bytes(buf)
   end
 
-  {% for type in [UInt8, UInt16, UInt32, UInt64] %}
+  {% for type in Int::Unsigned.union_types %}
     # Generates a random integer of a given type. The number of bytes to
     # generate can be limited; by default it will generate as many bytes as
     # needed to fill the integer size.
@@ -50,7 +50,7 @@ module Random::Secure
     end
   {% end %}
 
-  {% for type in [Int8, Int16, Int32, Int64] %}
+  {% for type in Int::Signed.union_types %}
     private def rand_type(type : {{type}}.class, needed_bytes = sizeof({{type}})) : {{type}}
       result = rand_type({{"U#{type}".id}}, needed_bytes)
       {{type}}.new(result)

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -47,8 +47,8 @@ def Bool.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
 end
 
 {% for type in Int::Primitive.union_types %}
-  def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-    {{type.id}}.new parse_scalar(ctx, node, Int64)
+  def {{type}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    {{type}}.new parse_scalar(ctx, node, Int64)
   end
 {% end %}
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -46,7 +46,7 @@ def Bool.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   parse_scalar(ctx, node, self)
 end
 
-{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+{% for type in Int::Primitive.union_types %}
   def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     {{type.id}}.new parse_scalar(ctx, node, Int64)
   end


### PR DESCRIPTION
Follow-up to #4995.

Meant to be merged after `v0.24.0` release.
~~All specs are passing on current `master`.~~