### PR TITLE
Increase the precision of Time and Time::Span to nanoseconds

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -8,8 +8,8 @@ end
 
 describe Time::Span do
   it "initializes" do
-    t1 = Time::Span.new 1234567890
-    t1.to_s.should eq("00:02:03.4567890")
+    t1 = Time::Span.new nanoseconds: 123_456_789_123
+    t1.to_s.should eq("00:02:03.456789123")
 
     t1 = Time::Span.new 1, 2, 3
     t1.to_s.should eq("01:02:03")
@@ -17,11 +17,11 @@ describe Time::Span do
     t1 = Time::Span.new 1, 2, 3, 4
     t1.to_s.should eq("1.02:03:04")
 
-    t1 = Time::Span.new 1, 2, 3, 4, 5
-    t1.to_s.should eq("1.02:03:04.0050000")
+    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1.to_s.should eq("1.02:03:04.005000000")
 
-    t1 = Time::Span.new -1, 2, -3, 4, -5
-    t1.to_s.should eq("-22:02:56.0050000")
+    t1 = Time::Span.new -1, 2, -3, 4, -5_000_000
+    t1.to_s.should eq("-22:02:56.005000000")
 
     t1 = Time::Span.new 0, 25, 0, 0, 0
     t1.to_s.should eq("1.01:00:00")
@@ -29,20 +29,20 @@ describe Time::Span do
 
   it "days overflows" do
     expect_overflow do
-      days = (Int64::MAX / Time::Span::TicksPerDay).to_i32 + 1
+      days = 106751991167301
       Time::Span.new days, 0, 0, 0, 0
     end
   end
 
   it "max days" do
     expect_overflow do
-      Int32::MAX.days
+      Int64::MAX.days
     end
   end
 
   it "min days" do
     expect_overflow do
-      Int32::MIN.days
+      Int64::MIN.days
     end
   end
 
@@ -53,7 +53,6 @@ describe Time::Span do
     ts.minutes.should eq(14)
     ts.seconds.should eq(7)
     ts.milliseconds.should eq(0)
-    ts.ticks.should eq(21474836470000000)
   end
 
   it "min seconds" do
@@ -63,7 +62,6 @@ describe Time::Span do
     ts.minutes.should eq(-14)
     ts.seconds.should eq(-8)
     ts.milliseconds.should eq(0)
-    ts.ticks.should eq(-21474836480000000)
   end
 
   it "max milliseconds" do
@@ -73,7 +71,6 @@ describe Time::Span do
     ts.minutes.should eq(31)
     ts.seconds.should eq(23)
     ts.milliseconds.should eq(647)
-    ts.ticks.should eq(21474836470000)
   end
 
   it "min milliseconds" do
@@ -83,7 +80,6 @@ describe Time::Span do
     ts.minutes.should eq(-31)
     ts.seconds.should eq(-23)
     ts.milliseconds.should eq(-648)
-    ts.ticks.should eq(-21474836480000)
   end
 
   it "negative timespan" do
@@ -93,11 +89,10 @@ describe Time::Span do
     ts.minutes.should eq(-59)
     ts.seconds.should eq(-59)
     ts.milliseconds.should eq(0)
-    ts.ticks.should eq(-863990000000)
   end
 
   it "test properties" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
     t2 = -t1
 
     t1.days.should eq(1)
@@ -105,17 +100,19 @@ describe Time::Span do
     t1.minutes.should eq(3)
     t1.seconds.should eq(4)
     t1.milliseconds.should eq(5)
+    t1.nanoseconds.should eq(5_000_000)
 
     t2.days.should eq(-1)
     t2.hours.should eq(-2)
     t2.minutes.should eq(-3)
     t2.seconds.should eq(-4)
     t2.milliseconds.should eq(-5)
+    t2.nanoseconds.should eq(-5_000_000)
   end
 
   it "test add" do
-    t1 = Time::Span.new 2, 3, 4, 5, 6
-    t2 = Time::Span.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 2, 3, 4, 5, 6_000_000
+    t2 = Time::Span.new 1, 2, 3, 4, 5_000_000
     t3 = t1 + t2
 
     t3.days.should eq(3)
@@ -123,19 +120,20 @@ describe Time::Span do
     t3.minutes.should eq(7)
     t3.seconds.should eq(9)
     t3.milliseconds.should eq(11)
-    t3.to_s.should eq("3.05:07:09.0110000")
+    t3.nanoseconds.should eq(11_000_000)
+    t3.to_s.should eq("3.05:07:09.011000000")
 
     # TODO check overflow
   end
 
   it "test compare" do
-    t1 = Time::Span.new -1
-    t2 = Time::Span.new 1
+    t1 = Time::Span.new nanoseconds: -1
+    t2 = Time::Span.new nanoseconds: 1
 
     (t1 <=> t2).should eq(-1)
     (t2 <=> t1).should eq(1)
     (t2 <=> t2).should eq(0)
-    (Time::Span::MinValue <=> Time::Span::MaxValue).should eq(-1)
+    (Time::Span::MIN <=> Time::Span::MAX).should eq(-1)
 
     (t1 == t2).should be_false
     (t1 > t2).should be_false
@@ -146,65 +144,71 @@ describe Time::Span do
   end
 
   it "test equals" do
-    t1 = Time::Span.new 1
-    t2 = Time::Span.new 2
+    t1 = Time::Span.new nanoseconds: 1
+    t2 = Time::Span.new nanoseconds: 2
 
     (t1 == t1).should be_true
     (t1 == t2).should be_false
     (t1 == "hello").should be_false
   end
 
+  it "test int extension methods" do
+    1_000_000.days.to_s.should eq("1000000.00:00:00")
+  end
+
   it "test float extension methods" do
     12.345.days.to_s.should eq("12.08:16:48")
     12.345.hours.to_s.should eq("12:20:42")
-    12.345.minutes.to_s.should eq("00:12:20.7000000")
-    12.345.seconds.to_s.should eq("00:00:12.3450000")
-    12.345.milliseconds.to_s.should eq("00:00:00.0120000")
-    -0.5.milliseconds.to_s.should eq("-00:00:00.0010000")
-    0.5.milliseconds.to_s.should eq("00:00:00.0010000")
-    -2.5.milliseconds.to_s.should eq("-00:00:00.0030000")
-    2.5.milliseconds.to_s.should eq("00:00:00.0030000")
-    0.0005.seconds.to_s.should eq("00:00:00.0010000")
+    12.345.minutes.to_s.should eq("00:12:20.700000000")
+    12.345.seconds.to_s.should eq("00:00:12.345000000")
+    12.345.milliseconds.to_s.should eq("00:00:00.012345000")
+    -0.5.milliseconds.to_s.should eq("-00:00:00.000500000")
+    0.5.milliseconds.to_s.should eq("00:00:00.000500000")
+    -2.5.milliseconds.to_s.should eq("-00:00:00.002500000")
+    2.5.milliseconds.to_s.should eq("00:00:00.002500000")
+    0.0005.seconds.to_s.should eq("00:00:00.000500000")
+
+    1_000_000.5.days.to_s.should eq("1000000.12:00:00")
   end
 
   it "test negate and duration" do
-    (-Time::Span.new(12345)).to_s.should eq("-00:00:00.0012345")
-    Time::Span.new(-12345).duration.to_s.should eq("00:00:00.0012345")
-    Time::Span.new(-12345).abs.to_s.should eq("00:00:00.0012345")
-    (-Time::Span.new(77)).to_s.should eq("-00:00:00.0000077")
-    (+Time::Span.new(77)).to_s.should eq("00:00:00.0000077")
+    (-Time::Span.new(nanoseconds: 1234500)).to_s.should eq("-00:00:00.001234500")
+    Time::Span.new(nanoseconds: -1234500).duration.to_s.should eq("00:00:00.001234500")
+    Time::Span.new(nanoseconds: -1234500).abs.to_s.should eq("00:00:00.001234500")
+    (-Time::Span.new(nanoseconds: 7700)).to_s.should eq("-00:00:00.000007700")
+    (+Time::Span.new(nanoseconds: 7700)).to_s.should eq("00:00:00.000007700")
   end
 
   it "test hash code" do
-    t1 = Time::Span.new(77)
-    t2 = Time::Span.new(77)
+    t1 = Time::Span.new(nanoseconds: 77)
+    t2 = Time::Span.new(nanoseconds: 77)
     t1.hash.should eq(t2.hash)
   end
 
   it "test subtract" do
-    t1 = Time::Span.new 2, 3, 4, 5, 6
-    t2 = Time::Span.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 2, 3, 4, 5, 6_000_000
+    t2 = Time::Span.new 1, 2, 3, 4, 5_000_000
     t3 = t1 - t2
 
-    t3.to_s.should eq("1.01:01:01.0010000")
+    t3.to_s.should eq("1.01:01:01.001000000")
 
     # TODO check overflow
   end
 
   it "test multiply" do
-    t1 = Time::Span.new 5, 4, 3, 2, 1
+    t1 = Time::Span.new 5, 4, 3, 2, 1_000_000
     t2 = t1 * 61
 
-    t2.should eq(Time::Span.new 315, 7, 5, 2, 61)
+    t2.should eq(Time::Span.new 315, 7, 5, 2, 61_000_000)
 
     # TODO check overflow
   end
 
   it "test divide" do
-    t1 = Time::Span.new 3, 3, 3, 3, 3
+    t1 = Time::Span.new 3, 3, 3, 3, 3_000_000
     t2 = t1 / 2
 
-    t2.should eq(Time::Span.new(1, 13, 31, 31, 501) + Time::Span.new(5000))
+    t2.should eq(Time::Span.new(1, 13, 31, 31, 501_000_000) + Time::Span.new(nanoseconds: 500_000))
 
     # TODO check overflow
   end
@@ -218,18 +222,18 @@ describe Time::Span do
   end
 
   it "test to_s" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
     t2 = -t1
 
-    t1.to_s.should eq("1.02:03:04.0050000")
-    t2.to_s.should eq("-1.02:03:04.0050000")
-    Time::Span::MaxValue.to_s.should eq("10675199.02:48:05.4775807")
-    Time::Span::MinValue.to_s.should eq("-10675199.02:48:05.4775808")
-    Time::Span::Zero.to_s.should eq("00:00:00")
+    t1.to_s.should eq("1.02:03:04.005000000")
+    t2.to_s.should eq("-1.02:03:04.005000000")
+    Time::Span::MAX.to_s.should eq("106751991167300.15:30:07.999999999")
+    Time::Span::MIN.to_s.should eq("-106751991167300.15:30:08.999999999")
+    Time::Span::ZERO.to_s.should eq("00:00:00")
   end
 
   it "test totals" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
     t1.total_days.should be_close(1.08546, 1e-05)
     t1.total_hours.should be_close(26.0511, 1e-04)
     t1.total_minutes.should be_close(1563.07, 1e-02)
@@ -237,6 +241,9 @@ describe Time::Span do
     t1.total_milliseconds.should be_close(9.3784e+07, 1e+01)
     t1.to_f.should be_close(93784, 1e-01)
     t1.to_i.should eq(93784)
+
+    t2 = Time::Span.new nanoseconds: 123456
+    t2.total_seconds.should be_close(0.000123456, 1e-06)
   end
 
   it "should sum" do
@@ -244,7 +251,7 @@ describe Time::Span do
   end
 
   it "test zero?" do
-    Time::Span.new(0).zero?.should eq true
-    Time::Span.new(123456789).zero?.should eq false
+    Time::Span.new(nanoseconds: 0).zero?.should eq true
+    Time::Span.new(nanoseconds: 123456789).zero?.should eq false
   end
 end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -1,11 +1,5 @@
 require "spec"
 
-private TimeSpecTicks = [
-  631501920000000000_i64, # 25 Feb 2002 - 00:00:00
-  631502475130080000_i64, # 25 Feb 2002 - 15:25:13,8
-  631502115130080000_i64, # 25 Feb 2002 - 05:25:13,8
-]
-
 def Time.expect_invalid
   expect_raises ArgumentError, "Invalid time" do
     yield
@@ -15,26 +9,29 @@ end
 describe Time do
   it "initialize" do
     t1 = Time.new 2002, 2, 25
-    t1.ticks.should eq(TimeSpecTicks[0])
+    t1.year.should eq(2002)
+    t1.month.should eq(2)
+    t1.day.should eq(25)
 
     t2 = Time.new 2002, 2, 25, 15, 25, 13, 8
-    t2.ticks.should eq(TimeSpecTicks[1])
-
-    t2.date.ticks.should eq(TimeSpecTicks[0])
     t2.year.should eq(2002)
     t2.month.should eq(2)
     t2.day.should eq(25)
     t2.hour.should eq(15)
     t2.minute.should eq(25)
     t2.second.should eq(13)
-    t2.millisecond.should eq(8)
-
-    t3 = Time.new 2002, 2, 25, 5, 25, 13, 8
-    t3.ticks.should eq(TimeSpecTicks[2])
+    t2.nanosecond.should eq(8)
   end
 
   it "initialize max" do
-    Time.new(9999, 12, 31, 23, 59, 59, 999).ticks.should eq(3155378975999990000)
+    time = Time.new(9999, 12, 31, 23, 59, 59, 999_999_999)
+    time.year.should eq(9999)
+    time.month.should eq(12)
+    time.day.should eq(31)
+    time.hour.should eq(23)
+    time.minute.should eq(59)
+    time.second.should eq(59)
+    time.nanosecond.should eq(999_999_999)
   end
 
   it "initialize millisecond negative" do
@@ -43,9 +40,9 @@ describe Time do
     end
   end
 
-  it "initialize millisecond 1000" do
+  it "initialize nanoseconds 1_000_000_000" do
     Time.expect_invalid do
-      Time.new(9999, 12, 31, 23, 59, 59, 1000)
+      Time.new(9999, 12, 31, 23, 59, 59, 1_000_000_000)
     end
   end
 
@@ -68,13 +65,8 @@ describe Time do
     (time == time.clone).should be_true
   end
 
-  it "fields" do
-    Time::MaxValue.ticks.should eq(3155378975999999999)
-    Time::MinValue.ticks.should eq(0)
-  end
-
   it "add" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     span = Time::Span.new 3, 54, 1
     t2 = t1 + span
 
@@ -90,23 +82,23 @@ describe Time do
   end
 
   it "add out of range 1" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(9980, 2, 25, 15, 25, 13)
 
     expect_raises ArgumentError do
-      t1 + Time::Span::MaxValue
+      t1 + Time::Span.new(nanoseconds: Int64::MAX)
     end
   end
 
   it "add out of range 2" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(1, 2, 25, 15, 25, 13)
 
     expect_raises ArgumentError do
-      t1 + Time::Span::MinValue
+      t1 + Time::Span.new(nanoseconds: Int64::MIN)
     end
   end
 
   it "add days" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     t1 = t1 + 3.days
 
     t1.day.should eq(28)
@@ -128,14 +120,14 @@ describe Time do
   end
 
   it "add days out of range 1" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     expect_raises ArgumentError do
       t1 + 10000000.days
     end
   end
 
   it "add days out of range 2" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     expect_raises ArgumentError do
       t1 - 10000000.days
     end
@@ -173,7 +165,7 @@ describe Time do
   end
 
   it "add hours" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     t1 = t1 + 10.hours
 
     t1.day.should eq(26)
@@ -195,7 +187,7 @@ describe Time do
   end
 
   it "add milliseconds" do
-    t1 = Time.new TimeSpecTicks[1]
+    t1 = Time.new(2002, 2, 25, 15, 25, 13)
     t1 = t1 + 1e10.milliseconds
 
     t1.day.should eq(21)
@@ -273,9 +265,9 @@ describe Time do
   end
 
   it "formats" do
-    t = Time.new 2014, 1, 2, 3, 4, 5, 6
-    t2 = Time.new 2014, 1, 2, 15, 4, 5, 6
-    t3 = Time.new 2014, 1, 2, 12, 4, 5, 6
+    t = Time.new 2014, 1, 2, 3, 4, 5, 6_000_000
+    t2 = Time.new 2014, 1, 2, 15, 4, 5, 6_000_000
+    t3 = Time.new 2014, 1, 2, 12, 4, 5, 6_000_000
 
     t.to_s("%Y").should eq("2014")
     Time.new(1, 1, 2, 3, 4, 5, 6).to_s("%Y").should eq("0001")
@@ -578,14 +570,15 @@ describe Time do
   end
 
   it "does time span units" do
-    1.millisecond.ticks.should eq(Time::Span::TicksPerMillisecond)
-    1.milliseconds.ticks.should eq(Time::Span::TicksPerMillisecond)
-    1.second.ticks.should eq(Time::Span::TicksPerSecond)
-    1.seconds.ticks.should eq(Time::Span::TicksPerSecond)
-    1.minute.ticks.should eq(Time::Span::TicksPerMinute)
-    1.minutes.ticks.should eq(Time::Span::TicksPerMinute)
-    1.hour.ticks.should eq(Time::Span::TicksPerHour)
-    1.hours.ticks.should eq(Time::Span::TicksPerHour)
+    1.nanoseconds.should eq(Time::Span.new(nanoseconds: 1))
+    1.millisecond.should eq(1_000_000.nanoseconds)
+    1.milliseconds.should eq(1_000_000.nanoseconds)
+    1.second.should eq(1000.milliseconds)
+    1.seconds.should eq(1000.milliseconds)
+    1.minute.should eq(60.seconds)
+    1.minutes.should eq(60.seconds)
+    1.hour.should eq(60.minutes)
+    1.hours.should eq(60.minutes)
     1.week.should eq(7.days)
     2.weeks.should eq(14.days)
   end

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -124,7 +124,7 @@ module Benchmark
       t1.stime - t0.stime,
       t1.cutime - t0.cutime,
       t1.cstime - t0.cstime,
-      (r1.ticks - r0.ticks).to_f / Time::Span::TicksPerSecond,
+      (r1 - r0).total_seconds,
       label)
   end
 

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -1,11 +1,11 @@
 module Crystal::System::Time
   # Returns the number of seconds that you must add to UTC to get local time.
   # *seconds* are measured from `0001-01-01 00:00:00`.
-  # def self.compute_utc_offset(seconds : Int64) : Int64
+  # def self.compute_utc_offset(seconds : Int64) : Int32
 
-  # Returns the current UTC time measured in `{seconds, tenth_microsecond}`
+  # Returns the current UTC time measured in `{seconds, nanoseconds}`
   # since `0001-01-01 00:00:00`.
-  # def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
+  # def self.compute_utc_seconds_and_nanoseconds : {Int64, Int32}
 end
 
 require "./unix/time"

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -4,14 +4,14 @@ require "c/time"
 module Crystal::System::Time
   UnixEpochInSeconds = 62135596800_i64
 
-  def self.compute_utc_offset(seconds : Int64) : Int64
+  def self.compute_utc_offset(seconds : Int64) : Int32
     LibC.tzset
     offset = nil
 
     {% if LibC.methods.includes?("daylight".id) %}
       if LibC.daylight == 0
         # current TZ doesn't have any DST, neither in past, present or future
-        offset = -LibC.timezone.to_i64
+        offset = -LibC.timezone.to_i
       end
     {% end %}
 
@@ -20,21 +20,21 @@ module Crystal::System::Time
       # current TZ may have DST, either in past, present or future
       ret = LibC.localtime_r(pointerof(seconds_from_epoch), out tm)
       raise Errno.new("localtime_r") if ret.null?
-      offset = tm.tm_gmtoff.to_i64
+      offset = tm.tm_gmtoff.to_i
     end
 
     offset
   end
 
-  def self.compute_utc_second_and_tenth_microsecond : {Int64, Int64}
+  def self.compute_utc_seconds_and_nanoseconds : {Int64, Int32}
     {% if LibC.methods.includes?("clock_gettime".id) %}
       ret = LibC.clock_gettime(LibC::CLOCK_REALTIME, out timespec)
       raise Errno.new("clock_gettime") unless ret == 0
-      {timespec.tv_sec.to_i64 + UnixEpochInSeconds, timespec.tv_nsec / 100}
+      {timespec.tv_sec.to_i64 + UnixEpochInSeconds, timespec.tv_nsec.to_i}
     {% else %}
       ret = LibC.gettimeofday(out timeval, nil)
       raise Errno.new("gettimeofday") unless ret == 0
-      {timeval.tv_sec.to_i64 + UnixEpochInSeconds, timeval.tv_usec.to_i64 * 10}
+      {timeval.tv_sec.to_i64 + UnixEpochInSeconds, timeval.tv_usec.to_i * 1_000}
     {% end %}
   end
 end

--- a/src/event.cr
+++ b/src/event.cr
@@ -24,9 +24,10 @@ module Event
     end
 
     def add(timeout : Time::Span)
-      seconds, remainder_ticks = timeout.ticks.divmod(Time::Span::TicksPerSecond)
-      timeval = LibC::Timeval.new(tv_sec: seconds, tv_usec: remainder_ticks / Time::Span::TicksPerMicrosecond)
-      add(timeval)
+      add LibC::Timeval.new(
+        tv_sec: timeout.total_seconds.to_i,
+        tv_usec: timeout.nanoseconds / 1_000
+      )
     end
 
     def free

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -13,7 +13,7 @@ struct Time::Format
       @hour = 0
       @minute = 0
       @second = 0
-      @millisecond = 0
+      @nanosecond = 0
       @pm = false
     end
 
@@ -26,7 +26,7 @@ struct Time::Format
         return Time.epoch(epoch)
       end
 
-      time = Time.new @year, @month, @day, @hour, @minute, @second, @millisecond, time_kind
+      time = Time.new @year, @month, @day, @hour, @minute, @second, @nanosecond, time_kind
 
       if offset_in_minutes = @offset_in_minutes
         time -= offset_in_minutes.minutes if offset_in_minutes != 0
@@ -168,11 +168,12 @@ struct Time::Format
       # and later just use the first 3 digits because Time
       # only has microsecond precision.
       pos = @reader.pos
-      @millisecond = consume_number(12)
+      millisecond = consume_number(12)
       digits = @reader.pos - pos
       if digits > 3
-        @millisecond /= 10 ** (digits - 3)
+        millisecond /= 10 ** (digits - 3)
       end
+      @nanosecond = millisecond * Time::NANOSECONDS_PER_MILLISECOND
     end
 
     def am_pm


### PR DESCRIPTION
This PR fixes the issue that the current `Time` and `Time::Span` types cannot hold nanosecond resolution times.

Internally, `Time` is now stored as:

```crystal
struct Time
  @seconds : Int64
  @nanoseconds : Int32
  @kind : Kind # Int32
end
```

and `Time::Span` is now:

```crystal
struct Time::Span
  @seconds : Int64
  @nanoseconds : Int32
end
```

so `Time` occupies 128 bits and `Time::Span` 92 bits (though because of padding it will probably occupy 128 bits too).

However, **I don't intend this to be the final representation**, but I'd like to start sending PRs fixing issues one by one (for example, I can imagine `@kind` ceasing to exist). 

This also gets rid of the `ticks` property of both `Time` and `Time::Span` which leaks information about the internal representation. I also refactored the code a bit so if later we want to change the internal representation it should be easier to do. The idea is to finish shaping the API and later being able to improve the internals without needing to change the API again.

Note: on OSX, even though `Time` can now have nanosecond precision, it won't be the case because of the C calls we are making. This should be improved in a separate PR.