### PR TITLE
Compiler: use return type of method with Primitive if available

### DIFF
--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -29,7 +29,7 @@ class Object
 
   # :nodoc:
   @[Primitive(:object_crystal_type_id)]
-  def crystal_type_id
+  def crystal_type_id : Int32
   end
 end
 
@@ -54,7 +54,7 @@ end
 class Class
   # :nodoc:
   @[Primitive(:class_crystal_instance_type_id)]
-  def crystal_instance_type_id
+  def crystal_instance_type_id : Int32
   end
 end
 


### PR DESCRIPTION
Some time ago primitives were totally hardcoded in the compiler. After we introduced the `@[Primitive]` attribute some of the hardcoded logic can be removed, for example computing their return type. This isn't possible in all cases because some primitive need additional logic, or their type is impossible to express.