### PR TITLE
Force calls with blocks to have their arguments parenthesised

### DIFF
--- a/samples/http_server.cr
+++ b/samples/http_server.cr
@@ -1,6 +1,6 @@
 require "http/server"
 
-server = HTTP::Server.new "0.0.0.0", 8080 do |context|
+server = HTTP::Server.new("0.0.0.0", 8080) do |context|
   context.response.headers["Content-Type"] = "text/plain"
   context.response.print("Hello world!")
 end

--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -234,7 +234,7 @@ class Points
   end
 end
 
-record Rectangle, x : Int32, y : Int32 do
+record(Rectangle, x : Int32, y : Int32) do
   def contains?(p)
     contains? p.x, p.y
   end

--- a/samples/text_raytracer.cr
+++ b/samples/text_raytracer.cr
@@ -1,6 +1,6 @@
 # Ported from Rust from https://gist.github.com/joshmarinacci/c84d0979e100d107f685 http://joshondesign.com/2014/09/17/rustlang
 
-record Vector, x : Float64, y : Float64, z : Float64 do
+record(Vector, x : Float64, y : Float64, z : Float64) do
   def scale(s)
     Vector.new(x * s, y * s, z * s)
   end
@@ -28,7 +28,7 @@ end
 
 record Ray, orig : Vector, dir : Vector
 
-record Color, r : Float64, g : Float64, b : Float64 do
+record(Color, r : Float64, g : Float64, b : Float64) do
   def scale(s)
     Color.new(r * s, g * s, b * s)
   end
@@ -38,7 +38,7 @@ record Color, r : Float64, g : Float64, b : Float64 do
   end
 end
 
-record Sphere, center : Vector, radius : Float64, color : Color do
+record(Sphere, center : Vector, radius : Float64, color : Color) do
   def get_normal(pt)
     (pt - center).normalize
   end

--- a/spec/compiler/codegen/alias_spec.cr
+++ b/spec/compiler/codegen/alias_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: alias" do
-  it "invokes methods on empty array of recursive alias (1)" do
+describe("Code gen: alias") do
+  it("invokes methods on empty array of recursive alias (1)") do
     run(%(
       require "prelude"
 
@@ -12,7 +12,7 @@ describe "Code gen: alias" do
       )).to_string.should eq("")
   end
 
-  it "invokes methods on empty array of recursive alias (2)" do
+  it("invokes methods on empty array of recursive alias (2)") do
     run(%(
       require "prelude"
 
@@ -23,7 +23,7 @@ describe "Code gen: alias" do
       )).to_string.should eq("")
   end
 
-  it "invokes methods on empty array of recursive alias (3)" do
+  it("invokes methods on empty array of recursive alias (3)") do
     run(%(
       require "prelude"
 
@@ -34,7 +34,7 @@ describe "Code gen: alias" do
       )).to_string.should eq("")
   end
 
-  it "casts to recursive alias" do
+  it("casts to recursive alias") do
     run(%(
       require "prelude"
 
@@ -49,7 +49,7 @@ describe "Code gen: alias" do
       )).to_i.should eq(1)
   end
 
-  it "casts to recursive alias" do
+  it("casts to recursive alias") do
     run(%(
       class Bar(T)
         def self.new(&block : -> T)
@@ -74,7 +74,7 @@ describe "Code gen: alias" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't break with alias for link attributes" do
+  it("doesn't break with alias for link attributes") do
     result = semantic(%(
       alias Foo = Int32
 
@@ -86,7 +86,7 @@ describe "Code gen: alias" do
     result.program.link_attributes
   end
 
-  it "doesn't crash on cast to as recursive alias (#639)" do
+  it("doesn't crash on cast to as recursive alias (#639)") do
     codegen(%(
       class Foo(T)
       end
@@ -101,7 +101,7 @@ describe "Code gen: alias" do
       ))
   end
 
-  it "lazyly solves aliases (#1346)" do
+  it("lazyly solves aliases (#1346)") do
     run(%(
       class Session; end
 
@@ -124,7 +124,7 @@ describe "Code gen: alias" do
       ))
   end
 
-  it "codegens cast to alias that includes bool" do
+  it("codegens cast to alias that includes bool") do
     run(%(
       alias Foo = Bool | Array(Foo)
 
@@ -137,7 +137,7 @@ describe "Code gen: alias" do
       )).to_i.should eq(2)
   end
 
-  it "overloads alias against generic (1) (#3261)" do
+  it("overloads alias against generic (1) (#3261)") do
     run(%(
       class Foo(T)
       end
@@ -156,7 +156,7 @@ describe "Code gen: alias" do
       ), inject_primitives: false).to_i.should eq(2)
   end
 
-  it "overloads alias against generic (2) (#3261)" do
+  it("overloads alias against generic (2) (#3261)") do
     run(%(
       class Foo(T)
       end

--- a/spec/compiler/codegen/and_spec.cr
+++ b/spec/compiler/codegen/and_spec.cr
@@ -1,46 +1,46 @@
 require "../../spec_helper"
 
-describe "Code gen: and" do
-  it "codegens and with bool false and false" do
+describe("Code gen: and") do
+  it("codegens and with bool false and false") do
     run("false && false").to_b.should be_false
   end
 
-  it "codegens and with bool false and true" do
+  it("codegens and with bool false and true") do
     run("false && true").to_b.should be_false
   end
 
-  it "codegens and with bool true and true" do
+  it("codegens and with bool true and true") do
     run("true && true").to_b.should be_true
   end
 
-  it "codegens and with bool true and false" do
+  it("codegens and with bool true and false") do
     run("true && false").to_b.should be_false
   end
 
-  it "codegens and with bool and int 1" do
+  it("codegens and with bool and int 1") do
     run("struct Bool; def to_i; 0; end; end; (false && 2).to_i").to_i.should eq(0)
   end
 
-  it "codegens and with bool and int 2" do
+  it("codegens and with bool and int 2") do
     run("struct Bool; def to_i; 0; end; end; (true && 2).to_i").to_i.should eq(2)
   end
 
-  it "codegens and with primitive type other than bool" do
+  it("codegens and with primitive type other than bool") do
     run("1 && 2").to_i.should eq(2)
   end
 
-  it "codegens and with primitive type other than bool with union" do
+  it("codegens and with primitive type other than bool with union") do
     run("(1 && 1.5).to_f").to_f64.should eq(1.5)
   end
 
-  it "codegens and with primitive type other than bool" do
+  it("codegens and with primitive type other than bool") do
     run(%(
       struct Nil; def to_i; 0; end; end
       (nil && 2).to_i
       )).to_i.should eq(0)
   end
 
-  it "codegens and with nilable as left node 1" do
+  it("codegens and with nilable as left node 1") do
     run("
       struct Nil; def to_i; 0; end; end
       class Object; def to_i; -1; end; end
@@ -50,7 +50,7 @@ describe "Code gen: and" do
     ").to_i.should eq(0)
   end
 
-  it "codegens and with nilable as left node 2" do
+  it("codegens and with nilable as left node 2") do
     run("
       class Object; def to_i; -1; end; end
       a = nil
@@ -59,7 +59,7 @@ describe "Code gen: and" do
     ").to_i.should eq(2)
   end
 
-  it "codegens and with non-false union as left node" do
+  it("codegens and with non-false union as left node") do
     run("
       a = 1.5
       a = 1
@@ -67,7 +67,7 @@ describe "Code gen: and" do
     ").to_i.should eq(2)
   end
 
-  it "codegens and with nil union as left node 1" do
+  it("codegens and with nil union as left node 1") do
     run("
       require \"nil\"
       a = nil
@@ -76,7 +76,7 @@ describe "Code gen: and" do
     ").to_i.should eq(2)
   end
 
-  it "codegens and with nil union as left node 2" do
+  it("codegens and with nil union as left node 2") do
     run("
       struct Nil; def to_i; 0; end; end
       a = 1
@@ -85,7 +85,7 @@ describe "Code gen: and" do
     ").to_i.should eq(0)
   end
 
-  it "codegens and with bool union as left node 1" do
+  it("codegens and with bool union as left node 1") do
     run("
       struct Bool; def to_i; 0; end; end
       a = false
@@ -94,7 +94,7 @@ describe "Code gen: and" do
     ").to_i.should eq(2)
   end
 
-  it "codegens and with bool union as left node 2" do
+  it("codegens and with bool union as left node 2") do
     run("
       struct Bool; def to_i; 0; end; end
       a = 1
@@ -103,7 +103,7 @@ describe "Code gen: and" do
     ").to_i.should eq(0)
   end
 
-  it "codegens and with bool union as left node 3" do
+  it("codegens and with bool union as left node 3") do
     run("
       struct Bool; def to_i; 0; end; end
       a = 1
@@ -112,7 +112,7 @@ describe "Code gen: and" do
     ").to_i.should eq(2)
   end
 
-  it "codegens and with bool union as left node 1" do
+  it("codegens and with bool union as left node 1") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -123,7 +123,7 @@ describe "Code gen: and" do
     ").to_i.should eq(3)
   end
 
-  it "codegens and with bool union as left node 2" do
+  it("codegens and with bool union as left node 2") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -134,7 +134,7 @@ describe "Code gen: and" do
     ").to_i.should eq(1)
   end
 
-  it "codegens and with bool union as left node 3" do
+  it("codegens and with bool union as left node 3") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -145,7 +145,7 @@ describe "Code gen: and" do
     ").to_i.should eq(3)
   end
 
-  it "codegens and with bool union as left node 4" do
+  it("codegens and with bool union as left node 4") do
     run("
       struct Nil; def to_i; 0; end; end
       struct Bool; def to_i; 1; end; end
@@ -156,14 +156,14 @@ describe "Code gen: and" do
     ").to_i.should eq(0)
   end
 
-  it "codegens assign in right node, after must be nilable" do
+  it("codegens assign in right node, after must be nilable") do
     run("
       a = 1 == 2 && (b = Reference.new)
       b.nil?
       ").to_b.should be_true
   end
 
-  it "codegens assign in right node, inside if must not be nil" do
+  it("codegens assign in right node, inside if must not be nil") do
     run("
       struct Nil; end
       class Foo; def foo; 1; end; end
@@ -176,7 +176,7 @@ describe "Code gen: and" do
       ").to_i.should eq(1)
   end
 
-  it "codegens assign in right node, after if must be nilable" do
+  it("codegens assign in right node, after if must be nilable") do
     run("
       if 1 == 2 && (b = Reference.new)
       end

--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: array literal spec" do
-  it "creates custom non-generic array" do
+describe("Code gen: array literal spec") do
+  it("creates custom non-generic array") do
     run(%(
       class Custom
         def initialize
@@ -22,7 +22,7 @@ describe "Code gen: array literal spec" do
       )).to_i.should eq(6)
   end
 
-  it "creates custom generic array" do
+  it("creates custom generic array") do
     run(%(
       class Custom(T)
         def initialize
@@ -43,7 +43,7 @@ describe "Code gen: array literal spec" do
       )).to_i.should eq(6)
   end
 
-  it "creates custom generic array with type var" do
+  it("creates custom generic array with type var") do
     run(%(
       class Custom(T)
         def initialize
@@ -64,7 +64,7 @@ describe "Code gen: array literal spec" do
       )).to_i.should eq(6)
   end
 
-  it "creates custom generic array via alias" do
+  it("creates custom generic array via alias") do
     run(%(
       class Custom(T)
         def initialize
@@ -87,7 +87,7 @@ describe "Code gen: array literal spec" do
       )).to_i.should eq(6)
   end
 
-  it "creates custom generic array via alias (2)" do
+  it("creates custom generic array via alias (2)") do
     run(%(
       class Custom(T)
         def initialize
@@ -110,7 +110,7 @@ describe "Code gen: array literal spec" do
       )).to_i.should eq(6)
   end
 
-  it "creates custom non-generic array in nested module" do
+  it("creates custom non-generic array in nested module") do
     run(%(
       class Foo::Custom
         def initialize

--- a/spec/compiler/codegen/asm_spec.cr
+++ b/spec/compiler/codegen/asm_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: asm" do
-  it "codegens without inputs" do
+describe("Code gen: asm") do
+  it("codegens without inputs") do
     run(%(
       dst = uninitialized Int32
       asm("mov $$1234, $0" : "=r"(dst))
@@ -9,7 +9,7 @@ describe "Code gen: asm" do
       )).to_i.should eq(1234)
   end
 
-  it "codegens with one input" do
+  it("codegens with one input") do
     run(%(
       src = 1234
       dst = uninitialized Int32
@@ -18,7 +18,7 @@ describe "Code gen: asm" do
       )).to_i.should eq(1234)
   end
 
-  it "codegens with two inputs" do
+  it("codegens with two inputs") do
     run(%(
       c = uninitialized Int32
       a = 20

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: block" do
-  it "generate inline" do
+describe("Code gen: block") do
+  it("generate inline") do
     run("
       def foo
         yield
@@ -13,7 +13,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "passes yield arguments" do
+  it("passes yield arguments") do
     run("
       def foo
         yield 1
@@ -25,7 +25,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "pass arguments to yielder function" do
+  it("pass arguments to yielder function") do
     run("
       def foo(a)
         yield a
@@ -37,7 +37,7 @@ describe "Code gen: block" do
     ").to_i.should eq(4)
   end
 
-  it "pass self to yielder function" do
+  it("pass self to yielder function") do
     run("
       struct Int
         def foo
@@ -51,7 +51,7 @@ describe "Code gen: block" do
     ").to_i.should eq(4)
   end
 
-  it "pass self and arguments to yielder function" do
+  it("pass self and arguments to yielder function") do
     run("
       struct Int
         def foo(i)
@@ -65,7 +65,7 @@ describe "Code gen: block" do
     ").to_i.should eq(5)
   end
 
-  it "allows access to local variables" do
+  it("allows access to local variables") do
     run("
       def foo
         yield
@@ -78,7 +78,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "can access instance vars from yielder function" do
+  it("can access instance vars from yielder function") do
     run("
       class Foo
         def initialize
@@ -95,7 +95,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "can set instance vars from yielder function" do
+  it("can set instance vars from yielder function") do
     run("
       class Foo
         def initialize
@@ -116,7 +116,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "can use instance methods from yielder function" do
+  it("can use instance methods from yielder function") do
     run("
       class Foo
         def foo
@@ -131,7 +131,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "can call methods from block when yielder is an instance method" do
+  it("can call methods from block when yielder is an instance method") do
     run("
       class Foo
         def foo
@@ -147,7 +147,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "nested yields" do
+  it("nested yields") do
     run("
       def bar
         yield
@@ -161,7 +161,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "assigns yield to argument" do
+  it("assigns yield to argument") do
     run("
       def foo(x)
         yield
@@ -172,7 +172,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "can use global constant" do
+  it("can use global constant") do
     run("
       FOO = 1
       def foo
@@ -183,7 +183,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "return from yielder function" do
+  it("return from yielder function") do
     run("
       def foo
         yield
@@ -195,7 +195,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "return from block" do
+  it("return from block") do
     run("
       def foo
         yield
@@ -210,7 +210,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "return from yielder function (2)" do
+  it("return from yielder function (2)") do
     run("
       def foo
         yield
@@ -226,7 +226,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "union value of yielder function" do
+  it("union value of yielder function") do
     run("
       def foo
         yield
@@ -239,7 +239,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "allow return from function called from yielder function" do
+  it("allow return from function called from yielder function") do
     run("
       def foo
         return 2
@@ -255,7 +255,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "" do
+  it("") do
     run("
       def foo
         yield
@@ -266,7 +266,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "return from block that always returns from function that always yields inside if block" do
+  it("return from block that always returns from function that always yields inside if block") do
     run("
       def bar
         yield
@@ -285,7 +285,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "return from block that always returns from function that conditionally yields" do
+  it("return from block that always returns from function that conditionally yields") do
     run("
       def bar
         if true
@@ -302,7 +302,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "call block from dispatch" do
+  it("call block from dispatch") do
     run("
       def bar(y)
         yield y
@@ -318,7 +318,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "call block from dispatch and use local vars" do
+  it("call block from dispatch and use local vars") do
     run("
       def bar(y)
         yield y
@@ -339,7 +339,7 @@ describe "Code gen: block" do
     ").to_i.should eq(4)
   end
 
-  it "break without value returns nil" do
+  it("break without value returns nil") do
     run("
       require \"nil\"
       require \"value\"
@@ -357,7 +357,7 @@ describe "Code gen: block" do
     ").to_b.should be_true
   end
 
-  it "break block with yielder inside while" do
+  it("break block with yielder inside while") do
     run("
       require \"prelude\"
       a = 0
@@ -369,7 +369,7 @@ describe "Code gen: block" do
     ").to_i.should eq(6)
   end
 
-  it "break from block returns from yielder" do
+  it("break from block returns from yielder") do
     run("
       def foo
         yield
@@ -382,7 +382,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "break from block with value" do
+  it("break from block with value") do
     run("
       def foo
         while true
@@ -397,7 +397,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "returns from block with value" do
+  it("returns from block with value") do
     run("
       require \"prelude\"
 
@@ -418,7 +418,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "doesn't codegen after while that always yields and breaks" do
+  it("doesn't codegen after while that always yields and breaks") do
     run("
       def foo
         while true
@@ -433,14 +433,14 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "break from block with value" do
+  it("break from block with value") do
     run("
       require \"prelude\"
       10.times { break 20 }
     ").to_i.should eq(20)
   end
 
-  it "doesn't codegen call if arg yields and always breaks" do
+  it("doesn't codegen call if arg yields and always breaks") do
     run("
       require \"nil\"
 
@@ -452,7 +452,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "codegens nested return" do
+  it("codegens nested return") do
     run("
       def bar
         yield
@@ -471,7 +471,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "codegens nested break" do
+  it("codegens nested break") do
     run("
       def bar
         yield
@@ -486,7 +486,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "codegens call with block with call with arg that yields" do
+  it("codegens call with block with call with arg that yields") do
     run("
       def bar
         yield
@@ -501,7 +501,7 @@ describe "Code gen: block" do
     ").to_i.should eq(3)
   end
 
-  it "can break without value from yielder that returns nilable (1)" do
+  it("can break without value from yielder that returns nilable (1)") do
     run(%(
       require "prelude"
 
@@ -518,7 +518,7 @@ describe "Code gen: block" do
     )).to_b.should be_true
   end
 
-  it "can break without value from yielder that returns nilable (2)" do
+  it("can break without value from yielder that returns nilable (2)") do
     run(%(
       require "prelude"
 
@@ -535,7 +535,7 @@ describe "Code gen: block" do
     )).to_b.should be_true
   end
 
-  it "break with value from yielder that returns a nilable" do
+  it("break with value from yielder that returns a nilable") do
     run(%(
       require "prelude"
 
@@ -553,7 +553,7 @@ describe "Code gen: block" do
     )).to_b.should be_false
   end
 
-  it "can use self inside a block called from dispatch" do
+  it("can use self inside a block called from dispatch") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -587,7 +587,7 @@ describe "Code gen: block" do
     ").to_i.should eq(123)
   end
 
-  it "return from block called from dispatch" do
+  it("return from block called from dispatch") do
     run("
       class Foo
         def do; yield; end
@@ -606,7 +606,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "breaks from while in function called from block" do
+  it("breaks from while in function called from block") do
     run("
       def foo
         yield
@@ -625,7 +625,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "allows modifying yielded value (with literal)" do
+  it("allows modifying yielded value (with literal)") do
     run("
       def foo
         yield 1
@@ -635,7 +635,7 @@ describe "Code gen: block" do
     ").to_i.should eq(2)
   end
 
-  it "allows modifying yielded value (with variable)" do
+  it("allows modifying yielded value (with variable)") do
     run("
       def foo
         a = 1
@@ -647,7 +647,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "it yields nil from another call" do
+  it("it yields nil from another call") do
     run("
       require \"bool\"
 
@@ -666,7 +666,7 @@ describe "Code gen: block" do
     ")
   end
 
-  it "allows yield from dispatch call" do
+  it("allows yield from dispatch call") do
     run("
       def foo(x : Value)
         yield 1
@@ -689,7 +689,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "block with nilable type" do
+  it("block with nilable type") do
     run("
       class Foo
         def foo
@@ -709,7 +709,7 @@ describe "Code gen: block" do
     ")
   end
 
-  it "block with nilable type 2" do
+  it("block with nilable type 2") do
     run("
       class Foo
         def foo
@@ -730,7 +730,7 @@ describe "Code gen: block" do
     ")
   end
 
-  it "codegens block with nilable type with return (1)" do
+  it("codegens block with nilable type with return (1)") do
     run("
       def foo
         if yield
@@ -743,7 +743,7 @@ describe "Code gen: block" do
       ").to_b.should be_true
   end
 
-  it "codegens block with nilable type with return (2)" do
+  it("codegens block with nilable type with return (2)") do
     run("
       def foo
         if yield
@@ -756,7 +756,7 @@ describe "Code gen: block" do
       ").to_b.should be_false
   end
 
-  it "codegens block with union with return" do
+  it("codegens block with union with return") do
     run("
       def foo
         yield
@@ -771,7 +771,7 @@ describe "Code gen: block" do
       ")
   end
 
-  it "codegens if with call with block (ssa issue)" do
+  it("codegens if with call with block (ssa issue)") do
     run("
       def bar
         yield
@@ -791,7 +791,7 @@ describe "Code gen: block" do
       ").to_i.should eq(3)
   end
 
-  it "codegens block with return and yield and no return" do
+  it("codegens block with return and yield and no return") do
     run("
       lib LibC
         fun exit : NoReturn
@@ -812,7 +812,7 @@ describe "Code gen: block" do
       ").to_i.should eq(2)
   end
 
-  it "codegens while/break inside block" do
+  it("codegens while/break inside block") do
     run("
       def foo
         yield
@@ -827,7 +827,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "codegens block with union arg (1)" do
+  it("codegens block with union arg (1)") do
     run("
       def foo
         yield 1 || 1.5
@@ -837,7 +837,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "codegens block with union arg (2)" do
+  it("codegens block with union arg (2)") do
     run("
       struct Number
         def abs
@@ -862,7 +862,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "codegens block with virtual type arg" do
+  it("codegens block with virtual type arg") do
     run("
       class Var(T)
         def initialize(x : T)
@@ -893,7 +893,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "codegens call with blocks of different type without args" do
+  it("codegens call with blocks of different type without args") do
     run("
       def foo
         yield
@@ -904,7 +904,7 @@ describe "Code gen: block" do
     ").to_i.should eq(1)
   end
 
-  it "codegens dispatch with block and break (1)" do
+  it("codegens dispatch with block and break (1)") do
     run("
       class Foo(T)
         def initialize(@x : T)
@@ -925,7 +925,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "codegens dispatch with block and break (2)" do
+  it("codegens dispatch with block and break (2)") do
     run("
       require \"prelude\"
 
@@ -939,7 +939,7 @@ describe "Code gen: block" do
       ").to_i.should eq(3)
   end
 
-  it "codegens block call when argument type changes" do
+  it("codegens block call when argument type changes") do
     run("
       def foo(x)
         while 1 == 2
@@ -953,7 +953,7 @@ describe "Code gen: block" do
       ")
   end
 
-  it "returns void when called with block" do
+  it("returns void when called with block") do
     run("
       fun foo : Void
       end
@@ -967,7 +967,7 @@ describe "Code gen: block" do
       ")
   end
 
-  it "executes yield expression if no arg is given for block" do
+  it("executes yield expression if no arg is given for block") do
     run("
       def foo
         a = 1
@@ -979,7 +979,7 @@ describe "Code gen: block" do
       ").to_i.should eq(2)
   end
 
-  it "codegens bug with block and arg and var" do
+  it("codegens bug with block and arg and var") do
     run("
       def foo
         yield 1
@@ -994,7 +994,7 @@ describe "Code gen: block" do
       ").to_i.should eq(65)
   end
 
-  it "allows using var as block arg with outer var" do
+  it("allows using var as block arg with outer var") do
     run("
       def foo
         yield 'a'
@@ -1006,7 +1006,7 @@ describe "Code gen: block" do
       ").to_i.should eq(1)
   end
 
-  it "allows initialize with yield (#224)" do
+  it("allows initialize with yield (#224)") do
     run(%(
       class Foo
         @x : Int32
@@ -1027,7 +1027,7 @@ describe "Code gen: block" do
       )).to_i.should eq(2)
   end
 
-  it "uses block inside array literal (bug)" do
+  it("uses block inside array literal (bug)") do
     run(%(
       require "prelude"
 
@@ -1040,7 +1040,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "codegens method invocation on a object of a captured block with a type that was never instantiated" do
+  it("codegens method invocation on a object of a captured block with a type that was never instantiated") do
     codegen(%(
       require "prelude"
 
@@ -1070,7 +1070,7 @@ describe "Code gen: block" do
       ))
   end
 
-  it "codegens method invocation on a object of a captured block with a type that was never instantiated (2)" do
+  it("codegens method invocation on a object of a captured block with a type that was never instantiated (2)") do
     codegen(%(
       require "prelude"
 
@@ -1100,7 +1100,7 @@ describe "Code gen: block" do
       ))
   end
 
-  it "codegens bug with yield not_nil! that is never not nil" do
+  it("codegens bug with yield not_nil! that is never not nil") do
     run(%(
       lib LibC
         fun exit(Int32) : NoReturn
@@ -1143,7 +1143,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "uses block var with same name as local var" do
+  it("uses block var with same name as local var") do
     run(%(
       def foo
         yield "hello"
@@ -1157,7 +1157,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't crash on untyped array to_s" do
+  it("doesn't crash on untyped array to_s") do
     run(%(
       require "prelude"
 
@@ -1176,7 +1176,7 @@ describe "Code gen: block" do
       )).to_string.should eq("[]")
   end
 
-  it "codegens block which always breaks but never enters (#494)" do
+  it("codegens block which always breaks but never enters (#494)") do
     run(%(
       def foo
         while 1 == 2
@@ -1191,7 +1191,7 @@ describe "Code gen: block" do
       )).to_i.should eq(3)
   end
 
-  it "codegens block bug with conditional next and unconditional break (1)" do
+  it("codegens block bug with conditional next and unconditional break (1)") do
     run(%(
       def foo
         yield 1
@@ -1209,7 +1209,7 @@ describe "Code gen: block" do
       )).to_i.should eq(6)
   end
 
-  it "codegens block bug with conditional next and unconditional break (2)" do
+  it("codegens block bug with conditional next and unconditional break (2)") do
     run(%(
       def foo
         yield 1
@@ -1227,7 +1227,7 @@ describe "Code gen: block" do
       )).to_i.should eq(6)
   end
 
-  it "codegens block bug with conditional next and unconditional break (3)" do
+  it("codegens block bug with conditional next and unconditional break (3)") do
     run(%(
       class Global
         @@x = 0
@@ -1255,7 +1255,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "codegens block bug with conditional next and unconditional break (4)" do
+  it("codegens block bug with conditional next and unconditional break (4)") do
     run(%(
       class Global
         @@x = 0
@@ -1284,7 +1284,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "returns from proc literal" do
+  it("returns from proc literal") do
     run(%(
       foo = ->{
         if 1 == 1
@@ -1298,7 +1298,7 @@ describe "Code gen: block" do
       )).to_i.should eq(10)
   end
 
-  it "does next from captured block" do
+  it("does next from captured block") do
     run(%(
       def foo(&block : -> T) forall T
         block
@@ -1316,7 +1316,7 @@ describe "Code gen: block" do
       )).to_i.should eq(10)
   end
 
-  it "codegens captured block with next inside yielded block (#2097)" do
+  it("codegens captured block with next inside yielded block (#2097)") do
     run(%(
       def foo
         yield
@@ -1335,7 +1335,7 @@ describe "Code gen: block" do
       )).to_i.should eq(123)
   end
 
-  it "codegens captured block that returns union, but proc only returns a single type" do
+  it("codegens captured block that returns union, but proc only returns a single type") do
     run(%(
       def run_callbacks(&block : -> Int32 | String)
         block.call
@@ -1350,7 +1350,7 @@ describe "Code gen: block" do
       )).to_string.should eq("foo")
   end
 
-  it "yields inside yield (#682)" do
+  it("yields inside yield (#682)") do
     run(%(
       def foo
         yield(1, (yield 3))
@@ -1364,7 +1364,7 @@ describe "Code gen: block" do
       )).to_i.should eq(4)
   end
 
-  it "yields splat" do
+  it("yields splat") do
     run(%(
       def foo
         tup = {1, 2, 3}
@@ -1377,7 +1377,7 @@ describe "Code gen: block" do
       )).to_i.should eq(6)
   end
 
-  it "yields more exps than block arg, through splat" do
+  it("yields more exps than block arg, through splat") do
     run(%(
       def foo
         yield *{1, 2}
@@ -1389,7 +1389,7 @@ describe "Code gen: block" do
       )).to_i.should eq(1)
   end
 
-  it "uses splat in block argument" do
+  it("uses splat in block argument") do
     run(%(
       def foo
         yield 1, 2, 3
@@ -1401,7 +1401,7 @@ describe "Code gen: block" do
       )).to_i.should eq(6)
   end
 
-  it "uses splat in block argument, many args" do
+  it("uses splat in block argument, many args") do
     run(%(
       def foo
         yield 1, 2, 3, 4, 5, 6
@@ -1413,7 +1413,7 @@ describe "Code gen: block" do
       )).to_i.should eq(((((1 + 2) * 3) - 4) * 5) - 6)
   end
 
-  it "uses block splat argument with union types" do
+  it("uses block splat argument with union types") do
     run(%(
       def foo
         yield 1
@@ -1428,7 +1428,7 @@ describe "Code gen: block" do
       )).to_i.should eq(3)
   end
 
-  it "auto-unpacks tuple" do
+  it("auto-unpacks tuple") do
     run(%(
       def foo
         tup = {1, 2, 4}
@@ -1441,7 +1441,7 @@ describe "Code gen: block" do
       )).to_i.should eq((1 + 2) * 4)
   end
 
-  it "unpacks tuple but doesn't override local variables" do
+  it("unpacks tuple but doesn't override local variables") do
     run(%(
       def foo
         yield({10, 20}, {30, 40})
@@ -1457,7 +1457,7 @@ describe "Code gen: block" do
       )).to_i.should eq(10)
   end
 
-  it "codegens block with multiple underscores (#3054)" do
+  it("codegens block with multiple underscores (#3054)") do
     run(%(
       def foo(&block : Int32, Int32 -> Int32)
         block.call(1, 2)
@@ -1469,7 +1469,7 @@ describe "Code gen: block" do
       )).to_i.should eq(3)
   end
 
-  it "breaks in var assignment (#3364)" do
+  it("breaks in var assignment (#3364)") do
     run(%(
       def foo
         yield
@@ -1482,7 +1482,7 @@ describe "Code gen: block" do
       )).to_i.should eq(123)
   end
 
-  it "nexts in var assignment (#3364)" do
+  it("nexts in var assignment (#3364)") do
     run(%(
       def foo
         yield
@@ -1494,7 +1494,7 @@ describe "Code gen: block" do
       )).to_i.should eq(123)
   end
 
-  it "dispatches with captured and non-captured block (#3969)" do
+  it("dispatches with captured and non-captured block (#3969)") do
     run(%(
       def fn(x : Int32, &block)
         x

--- a/spec/compiler/codegen/c_enum_spec.cr
+++ b/spec/compiler/codegen/c_enum_spec.cr
@@ -2,20 +2,20 @@ require "../../spec_helper"
 
 CodeGenCEnumString = "lib LibFoo; enum Bar; X, Y, Z = 10, W; end end"
 
-describe "Code gen: c enum" do
-  it "codegens enum value" do
+describe("Code gen: c enum") do
+  it("codegens enum value") do
     run("#{CodeGenCEnumString}; LibFoo::Bar::X").to_i.should eq(0)
   end
 
-  it "codegens enum value 2" do
+  it("codegens enum value 2") do
     run("#{CodeGenCEnumString}; LibFoo::Bar::Y").to_i.should eq(1)
   end
 
-  it "codegens enum value 3" do
+  it("codegens enum value 3") do
     run("#{CodeGenCEnumString}; LibFoo::Bar::Z").to_i.should eq(10)
   end
 
-  it "codegens enum value 4" do
+  it("codegens enum value 4") do
     run("#{CodeGenCEnumString}; LibFoo::Bar::W").to_i.should eq(11)
   end
 
@@ -31,7 +31,7 @@ describe "Code gen: c enum" do
     {"(1 + 2) * 3", 9},
     {"10 % 3", 1},
   ].each do |(code, expected)|
-    it "codegens enum with #{code} " do
+    it("codegens enum with #{code} ") do
       run("
         lib LibFoo
           enum Bar
@@ -44,7 +44,7 @@ describe "Code gen: c enum" do
     end
   end
 
-  it "codegens enum that refers to another enum constant" do
+  it("codegens enum that refers to another enum constant") do
     run("
       lib LibFoo
         enum Bar
@@ -58,7 +58,7 @@ describe "Code gen: c enum" do
       ").to_i.should eq(3)
   end
 
-  it "codegens enum that refers to another constant" do
+  it("codegens enum that refers to another constant") do
     run("
       lib LibFoo
         X = 10

--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -2,28 +2,28 @@ require "../../spec_helper"
 
 CodeGenStructString = "lib LibFoo; struct Bar; x : Int32; y : Float32; end; end"
 
-describe "Code gen: struct" do
-  it "codegens struct property default value" do
+describe("Code gen: struct") do
+  it("codegens struct property default value") do
     run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
   end
 
-  it "codegens struct property setter" do
+  it("codegens struct property setter") do
     run("#{CodeGenStructString}; bar = LibFoo::Bar.new; bar.y = 2.5_f32; bar.y").to_f32.should eq(2.5)
   end
 
-  it "codegens struct property setter via pointer" do
+  it("codegens struct property setter via pointer") do
     run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
   end
 
-  it "codegens struct property setter via pointer" do
+  it("codegens struct property setter via pointer") do
     run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
   end
 
-  it "codegens set struct value with constant" do
+  it("codegens set struct value with constant") do
     run("#{CodeGenStructString}; CONST = 1; bar = LibFoo::Bar.new; bar.x = CONST; bar.x").to_i.should eq(1)
   end
 
-  it "codegens union inside struct" do
+  it("codegens union inside struct") do
     run("
       lib LibFoo
         union Bar
@@ -42,7 +42,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(10)
   end
 
-  it "codegens struct get inside struct" do
+  it("codegens struct get inside struct") do
     run("
       lib LibC
         struct Bar
@@ -62,7 +62,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "codegens struct set inside struct" do
+  it("codegens struct set inside struct") do
     run("
       lib LibC
         struct Bar
@@ -84,7 +84,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "codegens pointer malloc of struct" do
+  it("codegens pointer malloc of struct") do
     run("
       lib LibC
         struct Foo
@@ -98,7 +98,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "passes struct to method (1)" do
+  it("passes struct to method (1)") do
     run("
       lib LibC
         struct Foo
@@ -120,7 +120,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "passes struct to method (2)" do
+  it("passes struct to method (2)") do
     run("
       lib LibC
         struct Foo
@@ -141,7 +141,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "codegens struct access with -> and then ." do
+  it("codegens struct access with -> and then .") do
     run("
       lib LibC
         struct ScalarEvent
@@ -162,7 +162,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(0)
   end
 
-  it "yields struct via ->" do
+  it("yields struct via ->") do
     run("
       lib LibC
         struct ScalarEvent
@@ -189,7 +189,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(0)
   end
 
-  it "codegens assign struct to union" do
+  it("codegens assign struct to union") do
     run("
       lib LibFoo
         struct Coco
@@ -203,7 +203,7 @@ describe "Code gen: struct" do
     ").to_b.should be_true
   end
 
-  it "codegens passing pointerof(struct) to fun" do
+  it("codegens passing pointerof(struct) to fun") do
     run("
       lib LibC
         struct Foo
@@ -222,7 +222,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "builds struct setter with fun type (1)" do
+  it("builds struct setter with fun type (1)") do
     codegen(%(
       require "prelude"
 
@@ -237,7 +237,7 @@ describe "Code gen: struct" do
       ))
   end
 
-  it "builds struct setter with fun type (2)" do
+  it("builds struct setter with fun type (2)") do
     codegen(%(
       require "prelude"
 
@@ -252,7 +252,7 @@ describe "Code gen: struct" do
       ))
   end
 
-  it "allows using named arguments for new" do
+  it("allows using named arguments for new") do
     run(%(
       lib LibC
         struct Point
@@ -265,7 +265,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(3)
   end
 
-  it "does to_s" do
+  it("does to_s") do
     run(%(
       require "prelude"
 
@@ -280,7 +280,7 @@ describe "Code gen: struct" do
       )).to_string.should eq("LibFoo::Point(@x=1, @y=2)")
   end
 
-  it "can access instance var from the outside (#1092)" do
+  it("can access instance var from the outside (#1092)") do
     run(%(
       lib LibFoo
         struct Foo
@@ -293,7 +293,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(123)
   end
 
-  it "automatically converts numeric type in struct field assignment" do
+  it("automatically converts numeric type in struct field assignment") do
     run(%(
       lib LibFoo
         struct Foo
@@ -307,7 +307,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(123)
   end
 
-  it "automatically converts numeric union type in struct field assignment" do
+  it("automatically converts numeric union type in struct field assignment") do
     run(%(
       lib LibFoo
         struct Foo
@@ -323,7 +323,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(57)
   end
 
-  it "automatically converts nil to pointer" do
+  it("automatically converts nil to pointer") do
     run(%(
       lib LibFoo
         struct Foo
@@ -338,7 +338,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(0)
   end
 
-  it "automatically converts by invoking to_unsafe" do
+  it("automatically converts by invoking to_unsafe") do
     run(%(
       lib LibFoo
         struct Foo
@@ -358,7 +358,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(123)
   end
 
-  it "sets instance var to proc" do
+  it("sets instance var to proc") do
     run(%(
       require "prelude"
 

--- a/spec/compiler/codegen/c_union_spec.cr
+++ b/spec/compiler/codegen/c_union_spec.cr
@@ -2,32 +2,32 @@ require "../../spec_helper"
 
 CodeGenUnionString = "lib LibFoo; union Bar; x : Int32; y : Int64; z : Float32; end; end"
 
-describe "Code gen: c union" do
-  it "codegens union property default value" do
+describe("Code gen: c union") do
+  it("codegens union property default value") do
     run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
   end
 
-  it "codegens union property default value 2" do
+  it("codegens union property default value 2") do
     run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z").to_f32.should eq(0)
   end
 
-  it "codegens union property setter 1" do
+  it("codegens union property setter 1") do
     run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.x = 42; bar.x").to_i.should eq(42)
   end
 
-  it "codegens union property setter 2" do
+  it("codegens union property setter 2") do
     run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.z = 42.0_f32; bar.z").to_f32.should eq(42.0)
   end
 
-  it "codegens union property setter 1 via pointer" do
+  it("codegens union property setter 1 via pointer") do
     run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 42; bar.value.x").to_i.should eq(42)
   end
 
-  it "codegens union property setter 2 via pointer" do
+  it("codegens union property setter 2 via pointer") do
     run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z = 42.0_f32; bar.value.z").to_f32.should eq(42.0)
   end
 
-  it "codegens struct inside union" do
+  it("codegens struct inside union") do
     run("
       lib LibFoo
         struct Baz
@@ -49,7 +49,7 @@ describe "Code gen: c union" do
       ").to_i.should eq(10)
   end
 
-  it "codegens assign c union to union" do
+  it("codegens assign c union to union") do
     run("
       lib LibFoo
         union Bar
@@ -68,7 +68,7 @@ describe "Code gen: c union" do
       ").to_i.should eq(10)
   end
 
-  it "builds union setter with fun type" do
+  it("builds union setter with fun type") do
     codegen(%(
       require "prelude"
 
@@ -83,7 +83,7 @@ describe "Code gen: c union" do
       ))
   end
 
-  it "does to_s" do
+  it("does to_s") do
     run(%(
       require "prelude"
 
@@ -98,7 +98,7 @@ describe "Code gen: c union" do
       )).to_string.should eq("LibNVG::Color(@array=0)")
   end
 
-  it "automatically converts numeric type in field assignment" do
+  it("automatically converts numeric type in field assignment") do
     run(%(
       lib LibFoo
         union Foo
@@ -114,7 +114,7 @@ describe "Code gen: c union" do
       )).to_i.should eq(57)
   end
 
-  it "automatically converts numeric union type in field assignment" do
+  it("automatically converts numeric union type in field assignment") do
     run(%(
       lib LibFoo
         union Foo
@@ -130,7 +130,7 @@ describe "Code gen: c union" do
       )).to_i.should eq(57)
   end
 
-  it "automatically converts by invoking to_unsafe" do
+  it("automatically converts by invoking to_unsafe") do
     run(%(
       lib LibFoo
         union Foo
@@ -150,7 +150,7 @@ describe "Code gen: c union" do
       )).to_i.should eq(123)
   end
 
-  it "aligns to the member with biggest align requirements" do
+  it("aligns to the member with biggest align requirements") do
     run(%(
       lib LibFoo
         union Foo
@@ -176,7 +176,7 @@ describe "Code gen: c union" do
       )).to_i.should eq(0x5858)
   end
 
-  it "fills union type to the max size" do
+  it("fills union type to the max size") do
     run(%(
       lib LibFoo
         union Foo
@@ -194,7 +194,7 @@ describe "Code gen: c union" do
       )).to_i.should eq(6)
   end
 
-  it "reads union instance var" do
+  it("reads union instance var") do
     run(%(
       lib LibFoo
         union Foo

--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -1,19 +1,19 @@
 require "../../spec_helper"
 
-describe "Code gen: case" do
-  it "codegens case with one condition" do
+describe("Code gen: case") do
+  it("codegens case with one condition") do
     run("require \"prelude\"; case 1; when 1; 2; else; 3; end").to_i.should eq(2)
   end
 
-  it "codegens case with two conditions" do
+  it("codegens case with two conditions") do
     run("require \"prelude\"; case 1; when 0, 1; 2; else; 3; end").to_i.should eq(2)
   end
 
-  it "codegens case with else" do
+  it("codegens case with else") do
     run("require \"prelude\"; case 1; when 0; 2; else; 3; end").to_i.should eq(3)
   end
 
-  it "codegens case that always returns" do
+  it("codegens case that always returns") do
     run("
       require \"prelude\"
       def foo
@@ -30,7 +30,7 @@ describe "Code gen: case" do
     ").to_i.should eq(3)
   end
 
-  it "codegens case when cond is a call" do
+  it("codegens case when cond is a call") do
     run("
       require \"prelude\"
 
@@ -49,7 +49,7 @@ describe "Code gen: case" do
     ").to_i.should eq(2)
   end
 
-  it "codegens case with class" do
+  it("codegens case with class") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -69,7 +69,7 @@ describe "Code gen: case" do
       ").to_i.should eq(-1)
   end
 
-  it "codegens value-less case" do
+  it("codegens value-less case") do
     run("
       case
       when 1 == 2
@@ -82,7 +82,7 @@ describe "Code gen: case" do
       ").to_i.should eq(2)
   end
 
-  it "codegens case when constant bug (#1028)" do
+  it("codegens case when constant bug (#1028)") do
     run(%(
       struct Nil
         def ===(other)
@@ -100,7 +100,7 @@ describe "Code gen: case" do
       )).to_i.should eq(2)
   end
 
-  it "does case when with metaclass" do
+  it("does case when with metaclass") do
     run(%(
       class Foo
         def self.foo

--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: cast" do
-  it "allows casting object to pointer and back" do
+describe("Code gen: cast") do
+  it("allows casting object to pointer and back") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -19,7 +19,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from int to int" do
+  it("casts from int to int") do
     run(%(
       require "prelude"
 
@@ -29,7 +29,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from union to single type" do
+  it("casts from union to single type") do
     run(%(
       require "prelude"
 
@@ -39,7 +39,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from union to single type raises TypeCastError" do
+  it("casts from union to single type raises TypeCastError") do
     run(%(
       require "prelude"
 
@@ -53,7 +53,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts from union to another union" do
+  it("casts from union to another union") do
     run(%(
       require "prelude"
 
@@ -63,7 +63,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from union to another union raises TypeCastError" do
+  it("casts from union to another union raises TypeCastError") do
     run(%(
       require "prelude"
 
@@ -77,7 +77,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts from virtual to single type" do
+  it("casts from virtual to single type") do
     run(%(
       require "prelude"
 
@@ -99,7 +99,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from virtual to single type raises TypeCastError" do
+  it("casts from virtual to single type raises TypeCastError") do
     run(%(
       require "prelude"
 
@@ -125,7 +125,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts from pointer to pointer" do
+  it("casts from pointer to pointer") do
     run(%(
       require "prelude"
 
@@ -134,7 +134,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts to module" do
+  it("casts to module") do
     run(%(
       require "prelude"
 
@@ -168,7 +168,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(2)
   end
 
-  it "casts from nilable to nil" do
+  it("casts from nilable to nil") do
     run(%(
       require "prelude"
 
@@ -178,7 +178,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts from nilable to nil raises TypeCastError" do
+  it("casts from nilable to nil raises TypeCastError") do
     run(%(
       require "prelude"
 
@@ -192,7 +192,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts to base class making it virtual" do
+  it("casts to base class making it virtual") do
     run(%(
       class Foo
         def foo
@@ -212,34 +212,34 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts to bigger union" do
+  it("casts to bigger union") do
     run(%(
       x = 1.5.as(Int32 | Float64)
       x.to_i
       )).to_i.should eq(1)
   end
 
-  it "allows casting nil to Void*" do
+  it("allows casting nil to Void*") do
     run(%(
       nil.as(Void*).address
       )).to_i.should eq(0)
   end
 
-  it "allows casting nilable type to Void* (1)" do
+  it("allows casting nilable type to Void* (1)") do
     run(%(
       a = 1 == 1 ? Reference.new : nil
       a.as(Void*).address
       )).to_i.should_not eq(0)
   end
 
-  it "allows casting nilable type to Void* (2)" do
+  it("allows casting nilable type to Void* (2)") do
     run(%(
       a = 1 == 2 ? Reference.new : nil
       a.as(Void*).address
       )).to_i.should eq(0)
   end
 
-  it "allows casting nilable type to Void* (3)" do
+  it("allows casting nilable type to Void* (3)") do
     run(%(
       class Foo
       end
@@ -248,7 +248,7 @@ describe "Code gen: cast" do
       )).to_i.should_not eq(0)
   end
 
-  it "casts (bug)" do
+  it("casts (bug)") do
     run(%(
       require "prelude"
       (1 || 1.1).as(Int32)
@@ -256,7 +256,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(123)
   end
 
-  it "can cast from Void* to virtual type (#3014)" do
+  it("can cast from Void* to virtual type (#3014)") do
     run(%(
       abstract class Foo
         abstract def hi
@@ -272,7 +272,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts from non-generic to generic" do
+  it("upcasts from non-generic to generic") do
     run(%(
       class Foo(T)
         def foo
@@ -290,7 +290,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(2)
   end
 
-  it "upcasts type to virtual (#3304)" do
+  it("upcasts type to virtual (#3304)") do
     run(%(
       class Foo
         def foo
@@ -308,7 +308,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "upcasts type to virtual (2) (#3304)" do
+  it("upcasts type to virtual (2) (#3304)") do
     run(%(
       class Foo
         def foo
@@ -332,7 +332,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts with block var that changes type (#3341)" do
+  it("casts with block var that changes type (#3341)") do
     codegen(%(
       require "prelude"
 
@@ -350,7 +350,7 @@ describe "Code gen: cast" do
       ))
   end
 
-  it "casts between union types, where union has a tuple type (#3377)" do
+  it("casts between union types, where union has a tuple type (#3377)") do
     codegen(%(
       require "prelude"
 
@@ -359,7 +359,7 @@ describe "Code gen: cast" do
       ))
   end
 
-  it "codegens class method when type id is available but not a virtual type (#3490)" do
+  it("codegens class method when type id is available but not a virtual type (#3490)") do
     run(%(
       class Class
         def name : String
@@ -390,7 +390,7 @@ describe "Code gen: cast" do
       )).to_string.should eq("A")
   end
 
-  it "casts from nilable type to virtual type (#3512)" do
+  it("casts from nilable type to virtual type (#3512)") do
     run(%(
       require "prelude"
 

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: class" do
-  it "codegens call to same instance" do
+describe("Code gen: class") do
+  it("codegens call to same instance") do
     run(%(
       class Foo
         def foo
@@ -17,7 +17,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "codegens instance var" do
+  it("codegens instance var") do
     run("
       class Foo
         def initialize(@coco : Int32)
@@ -33,7 +33,7 @@ describe "Code gen: class" do
       ").to_i.should eq(42)
   end
 
-  it "codegens recursive type" do
+  it("codegens recursive type") do
     run("
       class Foo
         def next=(@next : Foo)
@@ -45,7 +45,7 @@ describe "Code gen: class" do
       ")
   end
 
-  it "codegens method call of instance var" do
+  it("codegens method call of instance var") do
     run("
       class List
         def initialize
@@ -63,7 +63,7 @@ describe "Code gen: class" do
       ").to_f64.should eq(1.0)
   end
 
-  it "codegens new which calls initialize" do
+  it("codegens new which calls initialize") do
     run("
       class Foo
         def initialize(value : Int32)
@@ -80,7 +80,7 @@ describe "Code gen: class" do
     ").to_i.should eq(1)
   end
 
-  it "codegens method from another method without obj and accesses instance vars" do
+  it("codegens method from another method without obj and accesses instance vars") do
     run("
       class Foo
         def foo
@@ -97,7 +97,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "codegens virtual call that calls another method" do
+  it("codegens virtual call that calls another method") do
     run("
       class Foo
         def foo
@@ -116,7 +116,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "codgens virtual method of generic class" do
+  it("codgens virtual method of generic class") do
     run("
       require \"char\"
 
@@ -140,7 +140,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "changes instance variable in method (ssa bug)" do
+  it("changes instance variable in method (ssa bug)") do
     run("
       class Foo
         def initialize
@@ -168,7 +168,7 @@ describe "Code gen: class" do
   #   program.run("Reference.object_id").to_i.should eq(program.reference.metaclass.type_id)
   # end
 
-  it "calls method on Class class" do
+  it("calls method on Class class") do
     run("
       class Class
         def foo
@@ -183,7 +183,7 @@ describe "Code gen: class" do
     ").to_i.should eq(1)
   end
 
-  it "uses number type var" do
+  it("uses number type var") do
     run("
       class Foo(T)
         def self.foo
@@ -195,7 +195,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "calls class method without self" do
+  it("calls class method without self") do
     run("
       class Foo
         def self.coco
@@ -208,7 +208,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "calls class method without self (2)" do
+  it("calls class method without self (2)") do
     run("
       class Foo
         def self.coco
@@ -231,7 +231,7 @@ describe "Code gen: class" do
       ").to_i.should eq(2)
   end
 
-  it "assigns type to reference union type" do
+  it("assigns type to reference union type") do
     run("
       class Foo
         def initialize(@x : Bar)
@@ -248,7 +248,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "does to_s for class" do
+  it("does to_s for class") do
     run(%(
       require "prelude"
 
@@ -256,7 +256,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Reference")
   end
 
-  it "allows fixing an instance variable's type" do
+  it("allows fixing an instance variable's type") do
     run(%(
       class Foo
         @x : Bool
@@ -273,7 +273,7 @@ describe "Code gen: class" do
       )).to_b.should be_true
   end
 
-  it "codegens initialize with instance var" do
+  it("codegens initialize with instance var") do
     run(%(
       class Foo
         @x : Nil
@@ -288,7 +288,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "reads other instance var" do
+  it("reads other instance var") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -300,7 +300,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "reads a virtual type instance var" do
+  it("reads a virtual type instance var") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -315,7 +315,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "runs with nilable instance var" do
+  it("runs with nilable instance var") do
     run("
       struct Nil
         def to_i
@@ -340,7 +340,7 @@ describe "Code gen: class" do
       ").to_i.should eq(0)
   end
 
-  it "runs with nil instance var when inheriting" do
+  it("runs with nil instance var when inheriting") do
     run("
       struct Nil
         def to_i
@@ -370,7 +370,7 @@ describe "Code gen: class" do
       ").to_i.should eq(0)
   end
 
-  it "codegens bug #168" do
+  it("codegens bug #168") do
     run("
       class Foo
         @x : Foo?
@@ -394,7 +394,7 @@ describe "Code gen: class" do
       ").to_i.should eq(1)
   end
 
-  it "allows initializing var with constant" do
+  it("allows initializing var with constant") do
     run(%(
       class Foo
         A = 1
@@ -409,13 +409,13 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "codegens class method" do
+  it("codegens class method") do
     codegen(%(
       Int32.class
       ))
   end
 
-  it "codegens virtual class method" do
+  it("codegens virtual class method") do
     codegen(%(
       class Foo
       end
@@ -427,7 +427,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "allows using self in class scope" do
+  it("allows using self in class scope") do
     run(%(
       class Foo
         def self.foo
@@ -445,7 +445,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "allows using self in class scope" do
+  it("allows using self in class scope") do
     run(%(
       class Foo
         def self.foo
@@ -463,7 +463,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "makes .class always be a virtual type even if no subclasses" do
+  it("makes .class always be a virtual type even if no subclasses") do
     codegen(%(
       class Foo
       end
@@ -476,7 +476,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "does to_s for virtual metaclass type (1)" do
+  it("does to_s for virtual metaclass type (1)") do
     run(%(
       require "prelude"
 
@@ -489,7 +489,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Foo")
   end
 
-  it "does to_s for virtual metaclass type (2)" do
+  it("does to_s for virtual metaclass type (2)") do
     run(%(
       require "prelude"
 
@@ -502,7 +502,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Bar")
   end
 
-  it "does to_s for virtual metaclass type (3)" do
+  it("does to_s for virtual metaclass type (3)") do
     run(%(
       require "prelude"
 
@@ -515,7 +515,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Baz")
   end
 
-  it "builds generic class bug" do
+  it("builds generic class bug") do
     codegen(%(
       abstract class Base
         def initialize
@@ -541,7 +541,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "resolves type declaration when accessing instance var (#348)" do
+  it("resolves type declaration when accessing instance var (#348)") do
     codegen(%(
       require "prelude"
 
@@ -559,7 +559,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "gets class of virtual type" do
+  it("gets class of virtual type") do
     run(%(
       class Foo
         def self.foo
@@ -578,7 +578,7 @@ describe "Code gen: class" do
       )).to_i.should eq(2)
   end
 
-  it "notifies superclass recursively on inheritance (#576)" do
+  it("notifies superclass recursively on inheritance (#576)") do
     run(%(
       class Class
         def name : String
@@ -611,7 +611,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Qux")
   end
 
-  it "works with array in variable initializer in non-generic type (#855)" do
+  it("works with array in variable initializer in non-generic type (#855)") do
     run(%(
       require "prelude"
 
@@ -627,7 +627,7 @@ describe "Code gen: class" do
       )).to_i.should eq(6)
   end
 
-  it "works with array in variable initializer in generic type (#855)" do
+  it("works with array in variable initializer in generic type (#855)") do
     run(%(
       require "prelude"
 
@@ -643,7 +643,7 @@ describe "Code gen: class" do
       )).to_i.should eq(6)
   end
 
-  it "doesn't crash on instance variable assigned a proc, and never instantiated (#923)" do
+  it("doesn't crash on instance variable assigned a proc, and never instantiated (#923)") do
     codegen(%(
       class Klass
         def f(arg)
@@ -654,7 +654,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "does to_s on class" do
+  it("does to_s on class") do
     run(%(
       require "prelude"
 
@@ -665,7 +665,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Class")
   end
 
-  it "invokes class method inside instance method (#1119)" do
+  it("invokes class method inside instance method (#1119)") do
     run(%(
       class Class
         def bar
@@ -684,7 +684,7 @@ describe "Code gen: class" do
       )).to_i.should eq(123)
   end
 
-  it "codegens method of class union including Int (#1476)" do
+  it("codegens method of class union including Int (#1476)") do
     run(%(
       class Class
         def foo
@@ -697,7 +697,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "can use a Main class (#1628)" do
+  it("can use a Main class (#1628)") do
     run(%(
       require "prelude"
 
@@ -711,7 +711,7 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
-  it "codegens singleton (#718)" do
+  it("codegens singleton (#718)") do
     run(%(
       class Singleton
         @@instance = new
@@ -733,7 +733,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Hello")
   end
 
-  it "doesn't crash if not using undefined instance variable in superclass" do
+  it("doesn't crash if not using undefined instance variable in superclass") do
     run(%(
       class Foo
         def initialize(@x)
@@ -754,7 +754,7 @@ describe "Code gen: class" do
       )).to_i.should eq(42)
   end
 
-  it "codegens virtual metaclass union bug (#2597)" do
+  it("codegens virtual metaclass union bug (#2597)") do
     run(%(
 
       class Foo
@@ -797,7 +797,7 @@ describe "Code gen: class" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't crash on #1216" do
+  it("doesn't crash on #1216") do
     codegen(%(
       class Foo
         def initialize(@ivar : Int32)
@@ -814,7 +814,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "doesn't crash on #1216 with pointerof" do
+  it("doesn't crash on #1216 with pointerof") do
     codegen(%(
       class Foo
         def initialize(@ivar : Int32)
@@ -831,7 +831,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "doesn't crash on #1216 (reduced)" do
+  it("doesn't crash on #1216 (reduced)") do
     codegen(%(
       class Foo
         def foo
@@ -849,7 +849,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "doesn't crash on abstract class never instantiated (#2840)" do
+  it("doesn't crash on abstract class never instantiated (#2840)") do
     codegen(%(
       require "prelude"
 
@@ -864,7 +864,7 @@ describe "Code gen: class" do
       ))
   end
 
-  it "can assign virtual metaclass to virtual metaclass (#3007)" do
+  it("can assign virtual metaclass to virtual metaclass (#3007)") do
     run(%(
       class Foo
         def self.foo
@@ -895,7 +895,7 @@ describe "Code gen: class" do
       )).to_i.should eq(2)
   end
 
-  it "transfers initializer from module to generic class" do
+  it("transfers initializer from module to generic class") do
     run(%(
       module Moo
         @x = 123
@@ -913,7 +913,7 @@ describe "Code gen: class" do
       )).to_i.should eq(123)
   end
 
-  it "transfers initializer from generic module to non-generic class" do
+  it("transfers initializer from generic module to non-generic class") do
     run(%(
       module Moo(T)
         @x = 123
@@ -931,7 +931,7 @@ describe "Code gen: class" do
       )).to_i.should eq(123)
   end
 
-  it "transfers initializer from generic module to generic class" do
+  it("transfers initializer from generic module to generic class") do
     run(%(
       module Moo(T)
         @x = 123
@@ -949,7 +949,7 @@ describe "Code gen: class" do
       )).to_i.should eq(123)
   end
 
-  it "doesn't skip false initializers (#3272)" do
+  it("doesn't skip false initializers (#3272)") do
     run(%(
       class Parent
         @foo = true
@@ -967,7 +967,7 @@ describe "Code gen: class" do
       )).to_i.should eq(20)
   end
 
-  it "doesn't skip zero initializers (#3272)" do
+  it("doesn't skip zero initializers (#3272)") do
     run(%(
       class Parent
         @foo = 123
@@ -985,7 +985,7 @@ describe "Code gen: class" do
       )).to_i.should eq(0)
   end
 
-  it "codegens virtual generic class instance metaclass (#3819)" do
+  it("codegens virtual generic class instance metaclass (#3819)") do
     run(%(
       module Core
       end
@@ -1010,7 +1010,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Foo")
   end
 
-  it "codegens class with recursive tuple to class (#4520)" do
+  it("codegens class with recursive tuple to class (#4520)") do
     run(%(
       class Foo
         @foo : {Foo, Foo}?

--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Codegen: class var" do
-  it "codegens class var" do
+describe("Codegen: class var") do
+  it("codegens class var") do
     run("
       class Foo
         @@foo = 1
@@ -15,7 +15,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(1)
   end
 
-  it "codegens class var as nil" do
+  it("codegens class var as nil") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -31,7 +31,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(0)
   end
 
-  it "codegens class var inside instance method" do
+  it("codegens class var inside instance method") do
     run("
       class Foo
         @@foo = 1
@@ -45,7 +45,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(1)
   end
 
-  it "codegens class var as nil if assigned for the first time inside method" do
+  it("codegens class var as nil if assigned for the first time inside method") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -60,7 +60,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(1)
   end
 
-  it "codegens class var inside module" do
+  it("codegens class var inside module") do
     run("
       module Foo
         @@foo = 1
@@ -74,7 +74,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(1)
   end
 
-  it "accesses class var from proc literal" do
+  it("accesses class var from proc literal") do
     run("
       class Foo
         @@a = 1
@@ -88,7 +88,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(1)
   end
 
-  it "reads class var before initializing it (hoisting)" do
+  it("reads class var before initializing it (hoisting)") do
     run(%(
       x = Foo.var
 
@@ -104,7 +104,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(42)
   end
 
-  it "uses var in class var initializer" do
+  it("uses var in class var initializer") do
     run(%(
       class Foo
         @@var : Int32
@@ -126,7 +126,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(6)
   end
 
-  it "reads simple class var before another complex one" do
+  it("reads simple class var before another complex one") do
     run(%(
       class Foo
         @@var2 : Int32
@@ -143,7 +143,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(42)
   end
 
-  it "initializes class var of union with single type" do
+  it("initializes class var of union with single type") do
     run(%(
       class Foo
         @@var : Int32 | String
@@ -163,7 +163,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(42)
   end
 
-  it "initializes class var with array literal" do
+  it("initializes class var with array literal") do
     run(%(
       require "prelude"
 
@@ -179,7 +179,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(3)
   end
 
-  it "codegens second class var initializer" do
+  it("codegens second class var initializer") do
     run(%(
       class Foo
         @@var = 1
@@ -194,7 +194,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(2)
   end
 
-  it "initializes dependent constant before class var" do
+  it("initializes dependent constant before class var") do
     run(%(
       def foo
         a = 1
@@ -217,7 +217,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(3)
   end
 
-  it "declares and initializes" do
+  it("declares and initializes") do
     run(%(
       class Foo
         @@x : Int32 = 42
@@ -231,7 +231,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(42)
   end
 
-  it "doesn't use nilable type for initializer" do
+  it("doesn't use nilable type for initializer") do
     run(%(
       class Foo
         @@foo : Int32?
@@ -249,7 +249,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(42)
   end
 
-  it "codegens class var with begin and vars" do
+  it("codegens class var with begin and vars") do
     run("
       class Foo
         @@foo : Int32
@@ -268,7 +268,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(3)
   end
 
-  it "codegens class var with type declaration begin and vars" do
+  it("codegens class var with type declaration begin and vars") do
     run("
       class Foo
         @@foo : Int32 = begin
@@ -286,7 +286,7 @@ describe "Codegen: class var" do
       ").to_i.should eq(3)
   end
 
-  it "codegens class var with nilable reference type" do
+  it("codegens class var with nilable reference type") do
     run(%(
       class Foo
         @@foo : String? = nil
@@ -300,7 +300,7 @@ describe "Codegen: class var" do
       )).to_string.should eq("hello")
   end
 
-  it "initializes class var the moment it reaches it" do
+  it("initializes class var the moment it reaches it") do
     run(%(
       require "prelude"
 
@@ -320,7 +320,7 @@ describe "Codegen: class var" do
       )).to_string.should eq("BAR")
   end
 
-  it "gets pointerof class var" do
+  it("gets pointerof class var") do
     run(%(
       z = Foo.foo
 
@@ -336,7 +336,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(10)
   end
 
-  it "gets pointerof class var complex constant" do
+  it("gets pointerof class var complex constant") do
     run(%(
       z = Foo.foo
 
@@ -356,7 +356,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(10)
   end
 
-  it "doesn't inherit class var value in subclass" do
+  it("doesn't inherit class var value in subclass") do
     run(%(
       class Foo
         @@var = 1
@@ -378,7 +378,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't inherit class var value in module" do
+  it("doesn't inherit class var value in module") do
     run(%(
       module Moo
         @@var = 1
@@ -401,7 +401,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(1)
   end
 
-  it "reads class var from virtual type" do
+  it("reads class var from virtual type") do
     run(%(
       class Foo
         @@var = 1
@@ -429,7 +429,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(2)
   end
 
-  it "reads class var from virtual type metaclass" do
+  it("reads class var from virtual type metaclass") do
     run(%(
       class Foo
         @@var = 1
@@ -453,7 +453,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(2)
   end
 
-  it "writes class var from virtual type" do
+  it("writes class var from virtual type") do
     run(%(
       class Foo
         @@var = 1
@@ -480,7 +480,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(2)
   end
 
-  it "declares var as uninitialized and initializes it unsafely" do
+  it("declares var as uninitialized and initializes it unsafely") do
     run(%(
       class Foo
         @@x = uninitialized Int32
@@ -503,7 +503,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(10)
   end
 
-  it "doesn't crash with pointerof from another module" do
+  it("doesn't crash with pointerof from another module") do
     run(%(
       require "prelude"
 
@@ -526,7 +526,7 @@ describe "Codegen: class var" do
       )).to_i.should eq(1)
   end
 
-  it "codegens generic class class var" do
+  it("codegens generic class class var") do
     run(%(
       class Foo(T)
         @@bar = 1

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: closure" do
-  it "codegens simple closure at global scope" do
+describe("Code gen: closure") do
+  it("codegens simple closure at global scope") do
     run("
       a = 1
       foo = ->{ a }
@@ -9,7 +9,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(1)
   end
 
-  it "codegens simple closure in function" do
+  it("codegens simple closure in function") do
     run("
       def foo
         a = 1
@@ -20,7 +20,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(1)
   end
 
-  it "codegens simple closure in function with argument" do
+  it("codegens simple closure in function with argument") do
     run("
       def foo(a)
         ->{ a }
@@ -30,7 +30,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(1)
   end
 
-  it "codegens simple closure in block" do
+  it("codegens simple closure in block") do
     run("
       def foo
         yield
@@ -45,7 +45,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(1)
   end
 
-  it "codegens closured nested in block" do
+  it("codegens closured nested in block") do
     run("
       def foo
         yield
@@ -60,7 +60,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(3)
   end
 
-  it "codegens closured nested in block with a call with a closure with same names" do
+  it("codegens closured nested in block with a call with a closure with same names") do
     run("
       def foo
         a = 3
@@ -76,7 +76,7 @@ describe "Code gen: closure" do
     ").to_i.should eq(4)
   end
 
-  it "codegens closure with block that declares same var" do
+  it("codegens closure with block that declares same var") do
     run("
       def foo
         a = 1
@@ -91,7 +91,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(3)
   end
 
-  it "codegens closure with def that has an if" do
+  it("codegens closure with def that has an if") do
     run("
       def foo
         yield 1 if 1
@@ -105,7 +105,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "codegens multiple nested blocks" do
+  it("codegens multiple nested blocks") do
     run("
       def foo
         yield 1
@@ -125,7 +125,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(9)
   end
 
-  it "codegens closure with nested context without new closured vars" do
+  it("codegens closure with nested context without new closured vars") do
     run("
       def foo
         yield
@@ -139,7 +139,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(1)
   end
 
-  it "codegens closure with nested context without new closured vars" do
+  it("codegens closure with nested context without new closured vars") do
     run("
       def foo
         yield
@@ -160,7 +160,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "codegens closure with nested context without new closured vars but with block arg" do
+  it("codegens closure with nested context without new closured vars but with block arg") do
     run("
       def foo
         yield
@@ -182,7 +182,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "unifies types of closured var" do
+  it("unifies types of closured var") do
     run("
       a = 1
       f = -> { a }
@@ -191,7 +191,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "codegens closure with block" do
+  it("codegens closure with block") do
     run("
       def foo
         yield
@@ -202,7 +202,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(1)
   end
 
-  it "codegens closure with self and var" do
+  it("codegens closure with self and var") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -222,7 +222,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(3)
   end
 
-  it "codegens closure with implicit self and var" do
+  it("codegens closure with implicit self and var") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -242,7 +242,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(3)
   end
 
-  it "codegens closure with instance var and var" do
+  it("codegens closure with instance var and var") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -258,7 +258,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(3)
   end
 
-  it "codegens closure with instance var" do
+  it("codegens closure with instance var") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -273,7 +273,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(1)
   end
 
-  it "codegens closure with instance var and block" do
+  it("codegens closure with instance var and block") do
     run("
       def bar
         yield
@@ -295,7 +295,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(3)
   end
 
-  it "codegen closure in instance method without self closured" do
+  it("codegen closure in instance method without self closured") do
     run("
       class Foo
         def foo
@@ -307,7 +307,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(1)
   end
 
-  it "codegens closure inside initialize inside block with self" do
+  it("codegens closure inside initialize inside block with self") do
     run("
       def foo
         yield
@@ -325,7 +325,7 @@ describe "Code gen: closure" do
       ")
   end
 
-  it "doesn't free closure memory (bug)" do
+  it("doesn't free closure memory (bug)") do
     run(%(
       require "prelude"
 
@@ -351,21 +351,21 @@ describe "Code gen: closure" do
       )).to_i.should eq(1249975000_i64)
   end
 
-  it "codegens nested closure" do
+  it("codegens nested closure") do
     run(%(
       a = 1
       ->{ ->{ a } }.call.call
       )).to_i.should eq(1)
   end
 
-  it "codegens super nested closure" do
+  it("codegens super nested closure") do
     run(%(
       a = 1
       ->{ ->{ -> { -> { a } } } }.call.call.call.call
       )).to_i.should eq(1)
   end
 
-  it "codegens nested closure with block (1)" do
+  it("codegens nested closure with block (1)") do
     run(%(
       def foo
         yield
@@ -376,7 +376,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(1)
   end
 
-  it "codegens nested closure with block (2)" do
+  it("codegens nested closure with block (2)") do
     run(%(
       def foo
         yield
@@ -387,7 +387,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(1)
   end
 
-  it "codegens nested closure with nested closured variable" do
+  it("codegens nested closure with nested closured variable") do
     run(%(
       a = 1
       ->{
@@ -397,7 +397,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(3)
   end
 
-  it "codegens super nested closure with nested closured variable" do
+  it("codegens super nested closure with nested closured variable") do
     run(%(
       def foo
         yield 4
@@ -422,7 +422,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(10)
   end
 
-  it "codegens proc literal with struct" do
+  it("codegens proc literal with struct") do
     run(%(
       struct Foo
         def initialize(@x : Int32)
@@ -440,7 +440,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(2)
   end
 
-  it "codegens closure with struct" do
+  it("codegens closure with struct") do
     run(%(
       struct Foo
         def initialize(@x : Int32)
@@ -461,7 +461,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(3)
   end
 
-  it "codegens closure with self and arguments" do
+  it("codegens closure with self and arguments") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -481,7 +481,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(3)
   end
 
-  it "codegens nested closure that mentions var in both contexts" do
+  it("codegens nested closure that mentions var in both contexts") do
     run(%(
       a = 1
       f = ->{
@@ -492,7 +492,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(1)
   end
 
-  it "transforms block to proc literal" do
+  it("transforms block to proc literal") do
     run("
       def foo(&block : Int32 -> Int32)
         block.call(1)
@@ -505,7 +505,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "transforms block to proc literal with free var" do
+  it("transforms block to proc literal with free var") do
     run("
       def foo(&block : Int32 -> U) forall U
         block
@@ -518,7 +518,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(10)
   end
 
-  it "allows passing block as proc literal to new and to initialize" do
+  it("allows passing block as proc literal to new and to initialize") do
     run("
       class Foo
         def initialize(&block : Int32 -> Float64)
@@ -536,7 +536,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "allows giving less block args when transforming block to proc literal" do
+  it("allows giving less block args when transforming block to proc literal") do
     run("
       def foo(&block : Int32 -> U) forall U
         block.call(1)
@@ -550,7 +550,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "allows passing proc literal to def that captures block with &" do
+  it("allows passing proc literal to def that captures block with &") do
     run("
       def foo(&block : Int32 -> Int32)
         block.call(1)
@@ -562,7 +562,7 @@ describe "Code gen: closure" do
       ").to_i.should eq(2)
   end
 
-  it "allows mixing yield and block.call" do
+  it("allows mixing yield and block.call") do
     run(%(
       def foo(&block : Int32 ->)
         yield 1
@@ -575,7 +575,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(3)
   end
 
-  it "closures struct self" do
+  it("closures struct self") do
     run(%(
       struct Foo
         def initialize(@x : Int32)
@@ -590,7 +590,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't form a closure if invoking class method" do
+  it("doesn't form a closure if invoking class method") do
     run(%(
       require "prelude"
 
@@ -607,7 +607,7 @@ describe "Code gen: closure" do
       )).to_b.should be_false
   end
 
-  it "doesn't form a closure if invoking class method with self" do
+  it("doesn't form a closure if invoking class method with self") do
     run(%(
       require "prelude"
 
@@ -624,7 +624,7 @@ describe "Code gen: closure" do
       )).to_b.should be_false
   end
 
-  it "captures block and accesses local variable (#2050)" do
+  it("captures block and accesses local variable (#2050)") do
     run(%(
       require "prelude"
 
@@ -640,7 +640,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(1)
   end
 
-  it "codegens closured self in block (#3388)" do
+  it("codegens closured self in block (#3388)") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -662,7 +662,7 @@ describe "Code gen: closure" do
       )).to_i.should eq(42)
   end
 
-  it "doesn't incorrectly consider local as closured (#4948)" do
+  it("doesn't incorrectly consider local as closured (#4948)") do
     codegen(%(
       arg = 1
 

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Codegen: const" do
-  it "define a constant" do
+describe("Codegen: const") do
+  it("define a constant") do
     run("CONST = 1; CONST").to_i.should eq(1)
   end
 
-  it "support nested constant" do
+  it("support nested constant") do
     run("class Foo; A = 1; end; Foo::A").to_i.should eq(1)
   end
 
-  it "support constant inside a def" do
+  it("support constant inside a def") do
     run("
       class Foo
         A = 1
@@ -23,7 +23,7 @@ describe "Codegen: const" do
     ").to_i.should eq(1)
   end
 
-  it "finds nearest constant first" do
+  it("finds nearest constant first") do
     run("
       CONST = 1
 
@@ -39,7 +39,7 @@ describe "Codegen: const" do
     ").to_f32.should eq(2.5)
   end
 
-  it "allows constants with same name" do
+  it("allows constants with same name") do
     run("
       CONST = 1
 
@@ -56,14 +56,14 @@ describe "Codegen: const" do
     ").to_f32.should eq(2.5)
   end
 
-  it "constants with expression" do
+  it("constants with expression") do
     run("
       CONST = 1 + 1
       CONST
     ").to_i.should eq(2)
   end
 
-  it "finds global constant" do
+  it("finds global constant") do
     run("
       CONST = 1
 
@@ -77,15 +77,15 @@ describe "Codegen: const" do
     ").to_i.should eq(1)
   end
 
-  it "define a constant in lib" do
+  it("define a constant in lib") do
     run("lib LibFoo; A = 1; end; LibFoo::A").to_i.should eq(1)
   end
 
-  it "invokes block in const" do
+  it("invokes block in const") do
     run("require \"prelude\"; CONST = [\"1\"].map { |x| x.to_i }; CONST[0]").to_i.should eq(1)
   end
 
-  it "declare constants in right order" do
+  it("declare constants in right order") do
     run(%(
       CONST1 = 1 + 1
       CONST2 = true ? CONST1 : 0
@@ -93,7 +93,7 @@ describe "Codegen: const" do
       )).to_i.should eq(2)
   end
 
-  it "uses correct types lookup" do
+  it("uses correct types lookup") do
     run("
       module Moo
         class B
@@ -113,7 +113,7 @@ describe "Codegen: const" do
       ").to_i.should eq(1)
   end
 
-  it "codegens variable assignment in const" do
+  it("codegens variable assignment in const") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -137,7 +137,7 @@ describe "Codegen: const" do
       ").to_i.should eq(1)
   end
 
-  it "declaring var" do
+  it("declaring var") do
     run("
       BAR = begin
         a = 1
@@ -156,7 +156,7 @@ describe "Codegen: const" do
       ").to_i.should eq(1)
   end
 
-  it "initialize const that might raise an exception" do
+  it("initialize const that might raise an exception") do
     run("
       require \"prelude\"
       CONST = (raise \"OH NO\" if 1 == 2)
@@ -170,7 +170,7 @@ describe "Codegen: const" do
     ").to_b.should be_true
   end
 
-  it "allows implicit self in constant, called from another class (bug)" do
+  it("allows implicit self in constant, called from another class (bug)") do
     run("
       module Foo
         def self.foo
@@ -190,7 +190,7 @@ describe "Codegen: const" do
       ").to_i.should eq(1)
   end
 
-  it "codegens two consts with same variable name" do
+  it("codegens two consts with same variable name") do
     run("
       CONST1 = begin
             a = 1
@@ -204,7 +204,7 @@ describe "Codegen: const" do
       ").to_i.should eq(3)
   end
 
-  it "works with variable declared inside if" do
+  it("works with variable declared inside if") do
     run(%(
       FOO = begin
         if 1 == 2
@@ -218,7 +218,7 @@ describe "Codegen: const" do
       )).to_i.should eq(4)
   end
 
-  it "codegens constant that refers to another constant that is a struct" do
+  it("codegens constant that refers to another constant that is a struct") do
     run(%(
       struct Foo
         X = Foo.new(1)
@@ -236,7 +236,7 @@ describe "Codegen: const" do
       )).to_i.should eq(1)
   end
 
-  it "codegens constant that is declared later because of virtual dispatch" do
+  it("codegens constant that is declared later because of virtual dispatch") do
     run(%(
       class Base
         def base
@@ -263,7 +263,7 @@ describe "Codegen: const" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't crash if constant is used, but class is never instantiated (#1106)" do
+  it("doesn't crash if constant is used, but class is never instantiated (#1106)") do
     codegen(%(
       require "prelude"
 
@@ -279,7 +279,7 @@ describe "Codegen: const" do
       ))
   end
 
-  it "uses const before declaring it (hoisting)" do
+  it("uses const before declaring it (hoisting)") do
     run(%(
       x = CONST
 
@@ -295,7 +295,7 @@ describe "Codegen: const" do
       )).to_i.should eq(3)
   end
 
-  it "uses const before declaring it in another module" do
+  it("uses const before declaring it in another module") do
     run(%(
       require "prelude"
 
@@ -319,14 +319,14 @@ describe "Codegen: const" do
       )).to_i.should eq(3)
   end
 
-  it "initializes simple const" do
+  it("initializes simple const") do
     run(%(
       FOO = 10
       FOO
       )).to_i.should eq(10)
   end
 
-  it "initializes simple const via another const" do
+  it("initializes simple const via another const") do
     run(%(
       BAR = 10
       FOO = BAR
@@ -334,13 +334,13 @@ describe "Codegen: const" do
       )).to_i.should eq(10)
   end
 
-  it "initializes ARGC_UNSAFE" do
+  it("initializes ARGC_UNSAFE") do
     run(%(
       ARGC_UNSAFE
       )).to_i.should eq(0)
   end
 
-  it "gets pointerof constant" do
+  it("gets pointerof constant") do
     run(%(
       z = pointerof(FOO).value
       FOO = 10
@@ -348,7 +348,7 @@ describe "Codegen: const" do
       )).to_i.should eq(10)
   end
 
-  it "gets pointerof complex constant" do
+  it("gets pointerof complex constant") do
     run(%(
       z = pointerof(FOO).value
       FOO = begin
@@ -359,7 +359,7 @@ describe "Codegen: const" do
       )).to_i.should eq(10)
   end
 
-  it "gets pointerof constant inside class" do
+  it("gets pointerof constant inside class") do
     run(%(
       require "prelude"
 
@@ -381,7 +381,7 @@ describe "Codegen: const" do
       )).to_i.should eq(42)
   end
 
-  it "inlines simple const" do
+  it("inlines simple const") do
     mod = codegen(%(
       CONST = 1
       CONST
@@ -390,7 +390,7 @@ describe "Codegen: const" do
     mod.to_s.should_not contain("CONST")
   end
 
-  it "inlines enum value" do
+  it("inlines enum value") do
     mod = codegen(%(
       enum Foo
         CONST
@@ -402,7 +402,7 @@ describe "Codegen: const" do
     mod.to_s.should_not contain("CONST")
   end
 
-  it "inlines const with math" do
+  it("inlines const with math") do
     mod = codegen(%(
       CONST = (1 + 2) * 3
       ))
@@ -410,7 +410,7 @@ describe "Codegen: const" do
     mod.to_s.should_not contain("CONST")
   end
 
-  it "inlines const referencing another const" do
+  it("inlines const referencing another const") do
     mod = codegen(%(
       OTHER = 1
 
@@ -422,7 +422,7 @@ describe "Codegen: const" do
     mod.to_s.should_not contain("OTHER")
   end
 
-  it "inlines bool const" do
+  it("inlines bool const") do
     mod = codegen(%(
       CONST = true
       CONST
@@ -431,7 +431,7 @@ describe "Codegen: const" do
     mod.to_s.should_not contain("CONST")
   end
 
-  it "inlines char const" do
+  it("inlines char const") do
     mod = codegen(%(
       CONST = 'a'
       CONST

--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: debug" do
-  it "codegens abstract struct (#3578)" do
+describe("Code gen: debug") do
+  it("codegens abstract struct (#3578)") do
     codegen(%(
       abstract struct Base
       end
@@ -16,7 +16,7 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
-  it "inlines instance var access through getter in debug mode" do
+  it("inlines instance var access through getter in debug mode") do
     run(%(
       struct Bar
         @x = 1
@@ -48,7 +48,7 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All, filename: "foo.cr").to_i.should eq(2)
   end
 
-  it "codegens correct debug info for untyped expression (#4007 and #4008)" do
+  it("codegens correct debug info for untyped expression (#4007 and #4008)") do
     codegen(%(
       require "prelude"
 
@@ -64,7 +64,7 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
-  it "codegens correct debug info for new with custom allocate (#3945)" do
+  it("codegens correct debug info for new with custom allocate (#3945)") do
     codegen(%(
       class Foo
         def initialize
@@ -79,7 +79,7 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
-  it "correctly restores debug location after fun change (#4254)" do
+  it("correctly restores debug location after fun change (#4254)") do
     codegen(%(
       require "prelude"
 
@@ -105,7 +105,7 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
-  it "has correct debug location after constant initialization in call with block (#4719)" do
+  it("has correct debug location after constant initialization in call with block (#4719)") do
     codegen(%(
       fun __crystal_malloc_atomic(size : UInt32) : Void*
         x = uninitialized Void*

--- a/spec/compiler/codegen/def_default_value_spec.cr
+++ b/spec/compiler/codegen/def_default_value_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: def with default value" do
-  it "codegens def with one default value" do
+describe("Code gen: def with default value") do
+  it("codegens def with one default value") do
     run(%(
       def foo(x = 1)
         x
@@ -11,7 +11,7 @@ describe "Code gen: def with default value" do
       )).to_i.should eq(1)
   end
 
-  it "codegens def new with one default value" do
+  it("codegens def new with one default value") do
     run(%(
       class Foo
         def initialize(@x = 1)
@@ -26,7 +26,7 @@ describe "Code gen: def with default value" do
       )).to_i.should eq(1)
   end
 
-  it "considers first the one with more arguments" do
+  it("considers first the one with more arguments") do
     run(%(
       def foo(x, y = 1)
         1
@@ -40,7 +40,7 @@ describe "Code gen: def with default value" do
       )).to_i.should eq(2)
   end
 
-  it "considers first the one with a restriction" do
+  it("considers first the one with a restriction") do
     run(%(
       def foo(x : String, y = "")
         1
@@ -54,7 +54,7 @@ describe "Code gen: def with default value" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't mix types of instance vars with initialize and new" do
+  it("doesn't mix types of instance vars with initialize and new") do
     assert_type(%(
       class Foo
         def initialize(x = 1)
@@ -76,7 +76,7 @@ describe "Code gen: def with default value" do
       )) { int32 }
   end
 
-  it "resolves expanded call to current type, not to virtual type" do
+  it("resolves expanded call to current type, not to virtual type") do
     assert_type(%(
       class Foo
         def foo(x = 1)

--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Code gen: def" do
-  it "codegens empty def" do
+describe("Code gen: def") do
+  it("codegens empty def") do
     run("def foo; end; foo")
   end
 
-  it "codegens call without args" do
+  it("codegens call without args") do
     run("def foo; 1; end; 2; foo").to_i.should eq(1)
   end
 
-  it "call functions defined in any order" do
+  it("call functions defined in any order") do
     run("def foo; bar; end; def bar; 1; end; foo").to_i.should eq(1)
   end
 
-  it "codegens call with args" do
+  it("codegens call with args") do
     run("def foo(x); x; end; foo 1").to_i.should eq(1)
   end
 
-  it "call external function 'putchar'" do
+  it("call external function 'putchar'") do
     run("
       lib LibC
         fun putchar(c : Char) : Char
@@ -26,11 +26,11 @@ describe "Code gen: def" do
       ").to_i.should eq(0)
   end
 
-  it "uses self" do
+  it("uses self") do
     run("struct Int; def foo; self + 1; end; end; 3.foo").to_i.should eq(4)
   end
 
-  it "uses var after external" do
+  it("uses var after external") do
     run("
       lib LibC
         fun putchar(c : Char) : Char
@@ -42,19 +42,19 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "allows to change argument values" do
+  it("allows to change argument values") do
     run("def foo(x); x = 1; x; end; foo(2)").to_i.should eq(1)
   end
 
-  it "runs empty def" do
+  it("runs empty def") do
     run("def foo; end; foo")
   end
 
-  it "builds infinite recursive function" do
+  it("builds infinite recursive function") do
     codegen "def foo; foo; end; foo"
   end
 
-  it "unifies all calls to same def" do
+  it("unifies all calls to same def") do
     run("
       require \"prelude\"
 
@@ -86,7 +86,7 @@ describe "Code gen: def" do
     ").to_i.should eq(1)
   end
 
-  it "codegens recursive type with union" do
+  it("codegens recursive type with union") do
     run("
       class Foo
         @next : Foo?
@@ -106,7 +106,7 @@ describe "Code gen: def" do
       ")
   end
 
-  it "codegens with related types" do
+  it("codegens with related types") do
     run("
       class Foo
         @next : Foo | Bar | Nil
@@ -150,7 +150,7 @@ describe "Code gen: def" do
       ")
   end
 
-  it "codegens and doesn't break if obj is int and there's a mutation" do
+  it("codegens and doesn't break if obj is int and there's a mutation") do
     run("
       require \"prelude\"
 
@@ -164,7 +164,7 @@ describe "Code gen: def" do
     ")
   end
 
-  it "codegens with and witout default arguments" do
+  it("codegens with and witout default arguments") do
     run("
       def foo(x = 1)
         x + 1
@@ -174,7 +174,7 @@ describe "Code gen: def" do
       ").to_i.should eq(5)
   end
 
-  it "codegens with and witout many default arguments" do
+  it("codegens with and witout many default arguments") do
     run("
       def foo(x = 1, y = 2, z = 3)
         x + y + z
@@ -184,7 +184,7 @@ describe "Code gen: def" do
       ").to_i.should eq(40)
   end
 
-  it "codegens with interesting default argument" do
+  it("codegens with interesting default argument") do
     run("
       class Foo
         def foo(x = self.bar)
@@ -202,7 +202,7 @@ describe "Code gen: def" do
       ").to_i.should eq(5)
   end
 
-  it "codegens dispatch on static method" do
+  it("codegens dispatch on static method") do
     run("
       def Object.foo(x)
         1
@@ -214,7 +214,7 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "use target def type as return type" do
+  it("use target def type as return type") do
     run("
       require \"prelude\"
 
@@ -228,7 +228,7 @@ describe "Code gen: def" do
     ").to_i.should eq(1)
   end
 
-  it "codegens recursive nasty code" do
+  it("codegens recursive nasty code") do
     codegen("
       class Foo
         def initialize(x)
@@ -264,7 +264,7 @@ describe "Code gen: def" do
       ")
   end
 
-  it "looks up matches in super classes and merges them with subclasses" do
+  it("looks up matches in super classes and merges them with subclasses") do
     run("
       class Foo
         def foo(other)
@@ -283,7 +283,7 @@ describe "Code gen: def" do
       ").to_i.should eq(2)
   end
 
-  it "codegens def which changes type of arg" do
+  it("codegens def which changes type of arg") do
     run("
       def foo(x)
         while x >= 0
@@ -296,7 +296,7 @@ describe "Code gen: def" do
     ").to_i.should eq(0)
   end
 
-  it "codegens return nil when nilable type (1)" do
+  it("codegens return nil when nilable type (1)") do
     run("
       def foo
         return if 1 == 1
@@ -307,7 +307,7 @@ describe "Code gen: def" do
       ").to_b.should be_true
   end
 
-  it "codegens return nil when nilable type (2)" do
+  it("codegens return nil when nilable type (2)") do
     run("
       def foo
         return nil if 1 == 1
@@ -318,7 +318,7 @@ describe "Code gen: def" do
       ").to_b.should be_true
   end
 
-  it "codegens dispatch with nilable reference union type" do
+  it("codegens dispatch with nilable reference union type") do
     run("
       struct Nil; def object_id; 0_u64; end; end
       class Foo; end
@@ -329,7 +329,7 @@ describe "Code gen: def" do
       ").to_i.should eq(0)
   end
 
-  it "codegens dispatch without obj, bug 1" do
+  it("codegens dispatch without obj, bug 1") do
     run("
       def coco(x : Int32)
         2
@@ -349,7 +349,7 @@ describe "Code gen: def" do
       ").to_i.should eq(2)
   end
 
-  it "codegens dispatch without obj, bug 1" do
+  it("codegens dispatch without obj, bug 1") do
     run("
       def coco(x : Int32)
         2
@@ -372,7 +372,7 @@ describe "Code gen: def" do
       ").to_i.should eq(2)
   end
 
-  it "codegens dispatch with single def when discarding unallocated ones (1)" do
+  it("codegens dispatch with single def when discarding unallocated ones (1)") do
     run("
       class Foo
         def bar
@@ -391,7 +391,7 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "codegens dispatch with single def when discarding unallocated ones (2)" do
+  it("codegens dispatch with single def when discarding unallocated ones (2)") do
     run("
       class Foo
       end
@@ -412,7 +412,7 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "codegens bug #119" do
+  it("codegens bug #119") do
     run(%(
       require "prelude"
 
@@ -421,7 +421,7 @@ describe "Code gen: def" do
       )).to_b.should be_false
   end
 
-  it "puts union before single type in matches preferences" do
+  it("puts union before single type in matches preferences") do
     run("
       abstract class Foo
       end
@@ -445,7 +445,7 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "dispatches on virtual type implementing generic module (related to bug #165)" do
+  it("dispatches on virtual type implementing generic module (related to bug #165)") do
     run("
       module Moo(T)
         def moo
@@ -476,7 +476,7 @@ describe "Code gen: def" do
       ").to_i.should eq(1)
   end
 
-  it "fixes #230: include original owner in mangled def" do
+  it("fixes #230: include original owner in mangled def") do
     run(%(
       class Base
         def some(other : self)
@@ -503,14 +503,14 @@ describe "Code gen: def" do
       )).to_b.should be_true
   end
 
-  it "doesn't crash on private def as last expression" do
+  it("doesn't crash on private def as last expression") do
     codegen(%(
       private def foo
       end
       ))
   end
 
-  it "uses previous argument in default value (#1062)" do
+  it("uses previous argument in default value (#1062)") do
     run(%(
       def foo(x = 123, y = x + 456)
         x + y
@@ -520,7 +520,7 @@ describe "Code gen: def" do
       )).to_i.should eq(123 * 2 + 456)
   end
 
-  it "can match N type argument of static array (#1203)" do
+  it("can match N type argument of static array (#1203)") do
     run(%(
       def fn(a : StaticArray(T, N)) forall T, N
         N
@@ -531,7 +531,7 @@ describe "Code gen: def" do
       )).to_i.should eq(10)
   end
 
-  it "uses dispatch call type for phi (#3529)" do
+  it("uses dispatch call type for phi (#3529)") do
     codegen(%(
       def foo(x : Int32)
         yield
@@ -549,7 +549,7 @@ describe "Code gen: def" do
       ), inject_primitives: false)
   end
 
-  it "codegens union to union assignment of mutable arg (#3691)" do
+  it("codegens union to union assignment of mutable arg (#3691)") do
     codegen(%(
       def foo(arg)
         arg = ""

--- a/spec/compiler/codegen/double_splat_spec.cr
+++ b/spec/compiler/codegen/double_splat_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Codegen: double splat" do
-  it "double splats named argument into arguments (1)" do
+describe("Codegen: double splat") do
+  it("double splats named argument into arguments (1)") do
     run(%(
       def foo(x, y)
         x - y
@@ -12,7 +12,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(32 - 10)
   end
 
-  it "double splats named argument into arguments (2)" do
+  it("double splats named argument into arguments (2)") do
     run(%(
       def foo(x, y)
         x - y
@@ -23,7 +23,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(32 - 10)
   end
 
-  it "double splats named argument with positional arguments" do
+  it("double splats named argument with positional arguments") do
     run(%(
       def foo(x, y, z)
         x - y*z
@@ -34,7 +34,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(1000 - 20*30)
   end
 
-  it "double splats named argument with named args (1)" do
+  it("double splats named argument with named args (1)") do
     run(%(
       def foo(x, y, z)
         x - y*z
@@ -45,7 +45,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(1000 - 20*30)
   end
 
-  it "double splats named argument with named args (2)" do
+  it("double splats named argument with named args (2)") do
     run(%(
       def foo(x, y, z)
         x - y*z
@@ -56,7 +56,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(1000 - 20*30)
   end
 
-  it "double splats twice " do
+  it("double splats twice ") do
     run(%(
       def foo(x, y, z, w)
         (x - y*z) * w
@@ -68,7 +68,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq((1000 - 20*30) * 40)
   end
 
-  it "matches double splat on method with named args" do
+  it("matches double splat on method with named args") do
     run(%(
       def foo(**options)
         options[:x] - options[:y]
@@ -78,7 +78,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(7)
   end
 
-  it "matches double splat on method with named args and regular args" do
+  it("matches double splat on method with named args and regular args") do
     run(%(
       def foo(x, **args)
         x - args[:y]*args[:z]
@@ -88,7 +88,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq(1000 - 20*30)
   end
 
-  it "matches double splat with regular splat" do
+  it("matches double splat with regular splat") do
     run(%(
       def foo(*args, **options)
         (args[0] - args[1]*options[:z]) * options[:w]
@@ -98,7 +98,7 @@ describe "Codegen: double splat" do
       )).to_i.should eq((1000 - 20*30) * 40)
   end
 
-  it "evaluates double splat argument just once (#2677)" do
+  it("evaluates double splat argument just once (#2677)") do
     run(%(
       class Global
         @@x = 0

--- a/spec/compiler/codegen/enum_spec.cr
+++ b/spec/compiler/codegen/enum_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: enum" do
-  it "codegens enum" do
+describe("Code gen: enum") do
+  it("codegens enum") do
     run(%(
       enum Foo
         A = 1
@@ -11,7 +11,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "codegens enum without explicit value" do
+  it("codegens enum without explicit value") do
     run(%(
       enum Foo
         A
@@ -23,7 +23,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(2)
   end
 
-  it "codegens enum value" do
+  it("codegens enum value") do
     run(%(
       enum Foo
         A = 1
@@ -33,7 +33,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "creates enum from value" do
+  it("creates enum from value") do
     run(%(
       enum Foo
         A
@@ -44,7 +44,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "codegens enum bitflags (1)" do
+  it("codegens enum bitflags (1)") do
     run(%(
       @[Flags]
       enum Foo
@@ -55,7 +55,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "codegens enum bitflags (2)" do
+  it("codegens enum bitflags (2)") do
     run(%(
       @[Flags]
       enum Foo
@@ -67,7 +67,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(2)
   end
 
-  it "codegens enum bitflags (4)" do
+  it("codegens enum bitflags (4)") do
     run(%(
       @[Flags]
       enum Foo
@@ -80,7 +80,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(4)
   end
 
-  it "codegens enum bitflags None" do
+  it("codegens enum bitflags None") do
     run(%(
       @[Flags]
       enum Foo
@@ -91,7 +91,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(0)
   end
 
-  it "codegens enum bitflags All" do
+  it("codegens enum bitflags All") do
     run(%(
       @[Flags]
       enum Foo
@@ -104,7 +104,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1 + 2 + 4)
   end
 
-  it "codegens enum None redefined" do
+  it("codegens enum None redefined") do
     run(%(
       lib Lib
         @[Flags]
@@ -118,7 +118,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(10)
   end
 
-  it "codegens enum All redefined" do
+  it("codegens enum All redefined") do
     run(%(
       lib Lib
         @[Flags]
@@ -132,7 +132,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(10)
   end
 
-  it "allows class vars in enum" do
+  it("allows class vars in enum") do
     run(%(
       enum Foo
         A
@@ -148,7 +148,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "automatically defines question method for each enum member (false case)" do
+  it("automatically defines question method for each enum member (false case)") do
     run(%(
       struct Enum
         def ==(other : self)
@@ -166,7 +166,7 @@ describe "Code gen: enum" do
       )).to_b.should be_false
   end
 
-  it "automatically defines question method for each enum member (true case)" do
+  it("automatically defines question method for each enum member (true case)") do
     run(%(
       struct Enum
         def ==(other : self)
@@ -184,7 +184,7 @@ describe "Code gen: enum" do
       )).to_b.should be_true
   end
 
-  it "automatically defines question method for each enum member (flags, false case)" do
+  it("automatically defines question method for each enum member (flags, false case)") do
     run(%(
       struct Enum
         def includes?(other : self)
@@ -204,7 +204,7 @@ describe "Code gen: enum" do
       )).to_b.should be_false
   end
 
-  it "automatically defines question method for each enum member (flags, true case)" do
+  it("automatically defines question method for each enum member (flags, true case)") do
     run(%(
       struct Enum
         def includes?(other : self)
@@ -224,7 +224,7 @@ describe "Code gen: enum" do
       )).to_b.should be_true
   end
 
-  it "does ~ at compile time for enum member" do
+  it("does ~ at compile time for enum member") do
     run(%(
       enum Foo
         Bar = ~1
@@ -234,7 +234,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(~1)
   end
 
-  it "uses enum value before declaration (hoisting)" do
+  it("uses enum value before declaration (hoisting)") do
     run(%(
       x = Bar.bar
 
@@ -252,7 +252,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(1)
   end
 
-  it "casts All value to base type" do
+  it("casts All value to base type") do
     run(%(
       @[Flags]
       enum Foo
@@ -264,7 +264,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(-1073741824)
   end
 
-  it "can use macro calls inside enum value (#424)" do
+  it("can use macro calls inside enum value (#424)") do
     run(%(
       enum Foo
         macro bar
@@ -278,7 +278,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(30)
   end
 
-  it "can use macro calls inside enum value, macro defined outside enum (#424)" do
+  it("can use macro calls inside enum value, macro defined outside enum (#424)") do
     run(%(
       macro bar
         10 + 20
@@ -292,7 +292,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(30)
   end
 
-  it "can use macro calls inside enum value, with receiver (#424)" do
+  it("can use macro calls inside enum value, with receiver (#424)") do
     run(%(
       module Moo
         macro bar
@@ -308,7 +308,7 @@ describe "Code gen: enum" do
       )).to_i.should eq(30)
   end
 
-  it "adds a none? method to flags enum" do
+  it("adds a none? method to flags enum") do
     run(%(
       @[Flags]
       enum Foo

--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: exception" do
-  it "codegens rescue specific leaf exception" do
+describe("Code gen: exception") do
+  it("codegens rescue specific leaf exception") do
     run(%(
       require "prelude"
 
@@ -25,7 +25,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "codegens exception handler with return" do
+  it("codegens exception handler with return") do
     run(%(
       require "prelude"
 
@@ -41,7 +41,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "does ensure after rescue which returns (#171)" do
+  it("does ensure after rescue which returns (#171)") do
     run(%(
       require "prelude"
 
@@ -71,7 +71,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "executes body if nothing raised (1)" do
+  it("executes body if nothing raised (1)") do
     run(%(
       require "prelude"
 
@@ -85,7 +85,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "executes rescue if something is raised conditionally" do
+  it("executes rescue if something is raised conditionally") do
     run(%(
       require "prelude"
 
@@ -102,7 +102,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(8)
   end
 
-  it "executes rescue if something is raised unconditionally" do
+  it("executes rescue if something is raised unconditionally") do
     run(%(
       require "prelude"
 
@@ -118,7 +118,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(6)
   end
 
-  it "can result into union (1)" do
+  it("can result into union (1)") do
     run(%(
       require "prelude"
 
@@ -131,7 +131,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "can result into union (2)" do
+  it("can result into union (2)") do
     run(%(
       require "prelude"
 
@@ -144,7 +144,7 @@ describe "Code gen: exception" do
     )).to_i.should eq(2)
   end
 
-  it "handles nested exceptions" do
+  it("handles nested exceptions") do
     run(%(
       require "prelude"
 
@@ -164,7 +164,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "executes ensure when no exception is raised (1)" do
+  it("executes ensure when no exception is raised (1)") do
     run(%(
       require "prelude"
 
@@ -180,7 +180,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(10)
   end
 
-  it "executes ensure when no exception is raised (2)" do
+  it("executes ensure when no exception is raised (2)") do
     run(%(
       require "prelude"
 
@@ -196,7 +196,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure when exception is raised (1)" do
+  it("executes ensure when exception is raised (1)") do
     run(%(
       require "prelude"
 
@@ -213,7 +213,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "executes ensure when exception is raised (2)" do
+  it("executes ensure when exception is raised (2)") do
     run(%(
       require "prelude"
 
@@ -230,7 +230,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "executes ensure when exception is unhandled (1)" do
+  it("executes ensure when exception is unhandled (1)") do
     run(%(
       require "prelude"
 
@@ -253,7 +253,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "executes ensure when exception is unhandled (2)" do
+  it("executes ensure when exception is unhandled (2)") do
     run(%(
       require "prelude"
 
@@ -276,7 +276,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(4)
   end
 
-  it "ensure without rescue" do
+  it("ensure without rescue") do
     run(%(
       require "prelude"
 
@@ -294,7 +294,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure when the main block returns" do
+  it("executes ensure when the main block returns") do
     run(%(
       require "prelude"
 
@@ -313,7 +313,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(0)
   end
 
-  it "executes ensure when the main block returns" do
+  it("executes ensure when the main block returns") do
     run(%(
       require "prelude"
 
@@ -331,7 +331,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure when the main block yields and returns" do
+  it("executes ensure when the main block yields and returns") do
     run(%(
       require "prelude"
 
@@ -355,7 +355,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "rescues with type" do
+  it("rescues with type") do
     run(%(
       require "prelude"
 
@@ -374,7 +374,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "rescues with types defaults to generic rescue" do
+  it("rescues with types defaults to generic rescue") do
     run(%(
       require "prelude"
 
@@ -395,7 +395,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "handles exception in outer block (1)" do
+  it("handles exception in outer block (1)") do
     run(%(
       require "prelude"
 
@@ -418,7 +418,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "handles exception in outer block (2)" do
+  it("handles exception in outer block (2)") do
     run(%(
       require "prelude"
 
@@ -441,7 +441,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(0)
   end
 
-  it "handles subclass" do
+  it("handles subclass") do
     run(%(
       require "prelude"
 
@@ -459,7 +459,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "handle multiple exception types (1)" do
+  it("handle multiple exception types (1)") do
     run(%(
       require "prelude"
 
@@ -476,7 +476,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "handle multiple exception types (2)" do
+  it("handle multiple exception types (2)") do
     run(%(
       require "prelude"
 
@@ -493,7 +493,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "receives exception object" do
+  it("receives exception object") do
     run(%(
       require "prelude"
 
@@ -514,7 +514,7 @@ describe "Code gen: exception" do
       )).to_string.should eq("Ex1")
   end
 
-  it "executes else if no exception is raised (1)" do
+  it("executes else if no exception is raised (1)") do
     run(%(
       require "prelude"
 
@@ -529,7 +529,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "executes else if no exception is raised (2)" do
+  it("executes else if no exception is raised (2)") do
     run(%(
       require "prelude"
 
@@ -544,7 +544,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(3)
   end
 
-  it "doesn't execute else if exception is raised (1)" do
+  it("doesn't execute else if exception is raised (1)") do
     run(%(
       require "prelude"
 
@@ -562,7 +562,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't execute else if exception is raised (2)" do
+  it("doesn't execute else if exception is raised (2)") do
     run(%(
       require "prelude"
 
@@ -580,7 +580,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't execute else if exception is raised conditionally (1)" do
+  it("doesn't execute else if exception is raised conditionally (1)") do
     run(%(
       require "prelude"
 
@@ -598,7 +598,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't execute else if exception is raised conditionally (2)" do
+  it("doesn't execute else if exception is raised conditionally (2)") do
     run(%(
       require "prelude"
 
@@ -616,7 +616,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "handle exception raised by proc literal" do
+  it("handle exception raised by proc literal") do
     run(%(
       require "prelude"
 
@@ -631,7 +631,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "codegens issue #118 (1)" do
+  it("codegens issue #118 (1)") do
     codegen(%(
       require "prelude"
 
@@ -644,7 +644,7 @@ describe "Code gen: exception" do
       ))
   end
 
-  it "codegens issue #118 (2)" do
+  it("codegens issue #118 (2)") do
     codegen(%(
       require "prelude"
 
@@ -658,7 +658,7 @@ describe "Code gen: exception" do
       ))
   end
 
-  it "captures exception thrown from proc" do
+  it("captures exception thrown from proc") do
     run(%(
       require "prelude"
 
@@ -676,7 +676,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "uses exception after rescue" do
+  it("uses exception after rescue") do
     run(%(
       require "prelude"
 
@@ -688,7 +688,7 @@ describe "Code gen: exception" do
       )).to_string.should eq("OH NO")
   end
 
-  it "doesn't codegen duplicated ensure if unreachable (#709)" do
+  it("doesn't codegen duplicated ensure if unreachable (#709)") do
     codegen(%(
       require "prelude"
 
@@ -710,7 +710,7 @@ describe "Code gen: exception" do
       ))
   end
 
-  it "executes ensure when raising inside rescue" do
+  it("executes ensure when raising inside rescue") do
     run(%(
       require "prelude"
 
@@ -731,7 +731,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "executes ensure of break inside while inside body" do
+  it("executes ensure of break inside while inside body") do
     run(%(
       require "prelude"
 
@@ -747,7 +747,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "executes ensure of break inside while inside body with nested handlers" do
+  it("executes ensure of break inside while inside body with nested handlers") do
     run(%(
       require "prelude"
 
@@ -769,7 +769,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure of break inside while inside body with block" do
+  it("executes ensure of break inside while inside body with block") do
     run(%(
       require "prelude"
 
@@ -811,7 +811,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(0)
   end
 
-  it "executes ensure of break inside while inside rescue" do
+  it("executes ensure of break inside while inside rescue") do
     run(%(
       require "prelude"
 
@@ -829,7 +829,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "executes ensure of break inside while inside else" do
+  it("executes ensure of break inside while inside else") do
     run(%(
       require "prelude"
 
@@ -847,7 +847,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "executes ensure of next inside while inside body" do
+  it("executes ensure of next inside while inside body") do
     run(%(
       require "prelude"
 
@@ -865,7 +865,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "executes return inside rescue, executing ensure" do
+  it("executes return inside rescue, executing ensure") do
     run(%(
       require "prelude"
 
@@ -899,7 +899,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "executes ensure from return until target" do
+  it("executes ensure from return until target") do
     run(%(
       require "prelude"
 
@@ -920,7 +920,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure from return until target" do
+  it("executes ensure from return until target") do
     run(%(
       require "prelude"
 
@@ -959,7 +959,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "executes ensure of next inside block" do
+  it("executes ensure of next inside block") do
     run(%(
       require "prelude"
 
@@ -987,7 +987,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure of next inside block" do
+  it("executes ensure of next inside block") do
     run(%(
       require "prelude"
 
@@ -1035,7 +1035,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure of break inside block" do
+  it("executes ensure of break inside block") do
     run(%(
       require "prelude"
 
@@ -1063,7 +1063,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(1)
   end
 
-  it "executes ensure of calling method when doing break inside block (#1233)" do
+  it("executes ensure of calling method when doing break inside block (#1233)") do
     run(%(
       require "prelude"
 
@@ -1092,7 +1092,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "propagates raise status (#2074)" do
+  it("propagates raise status (#2074)") do
     run(%(
       require "prelude"
 
@@ -1136,7 +1136,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't crash on #1988" do
+  it("doesn't crash on #1988") do
     run(%(
       require "prelude"
 
@@ -1153,7 +1153,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(42)
   end
 
-  it "runs #2441" do
+  it("runs #2441") do
     run(%(
       require "prelude"
 
@@ -1169,7 +1169,7 @@ describe "Code gen: exception" do
       )).to_string.should eq("foo")
   end
 
-  it "can rescue TypeCastError (#2607)" do
+  it("can rescue TypeCastError (#2607)") do
     run(%(
       require "prelude"
 
@@ -1184,7 +1184,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(42)
   end
 
-  it "can use argument in rescue (#2844)" do
+  it("can use argument in rescue (#2844)") do
     run(%(
       require "prelude"
 
@@ -1202,7 +1202,7 @@ describe "Code gen: exception" do
       )).to_string.should eq("foo")
   end
 
-  it "can use argument in rescue, with a different type (1) (#2844)" do
+  it("can use argument in rescue, with a different type (1) (#2844)") do
     run(%(
       require "prelude"
 
@@ -1220,7 +1220,7 @@ describe "Code gen: exception" do
       )).to_string.should eq("foo")
   end
 
-  it "can use argument in rescue, with a different type (2) (#2844)" do
+  it("can use argument in rescue, with a different type (2) (#2844)") do
     run(%(
       require "prelude"
 
@@ -1237,7 +1237,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(10)
   end
 
-  it "runs NoReturn ensure (#3082)" do
+  it("runs NoReturn ensure (#3082)") do
     run(%(
       require "prelude"
 
@@ -1256,7 +1256,7 @@ describe "Code gen: exception" do
       )).to_i.should eq(123)
   end
 
-  it "catches exception thrown by as inside method (#4030)" do
+  it("catches exception thrown by as inside method (#4030)") do
     run(%(
       require "prelude"
 

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Codegen: extern struct" do
-  it "declares extern struct with no constructor" do
+describe("Codegen: extern struct") do
+  it("declares extern struct with no constructor") do
     run(%(
       @[Extern]
       struct Foo
@@ -16,7 +16,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(0)
   end
 
-  it "declares extern struct with no constructor, assigns var" do
+  it("declares extern struct with no constructor, assigns var") do
     run(%(
       @[Extern]
       struct Foo
@@ -36,7 +36,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(10)
   end
 
-  it "declares extern union with no constructor" do
+  it("declares extern union with no constructor") do
     run(%(
       @[Extern(union: true)]
       struct Foo
@@ -61,7 +61,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(1069547520)
   end
 
-  it "declares extern struct, sets and gets instance var" do
+  it("declares extern struct, sets and gets instance var") do
     run(%(
       @[Extern]
       struct Foo
@@ -78,7 +78,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(42)
   end
 
-  it "declares extern union, sets and gets instance var" do
+  it("declares extern union, sets and gets instance var") do
     run(%(
       @[Extern(union: true)]
       struct Foo
@@ -96,7 +96,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(1069547520)
   end
 
-  it "sets callback on extern struct" do
+  it("sets callback on extern struct") do
     run(%(
       require "prelude"
 
@@ -119,7 +119,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(42)
   end
 
-  it "sets callback on extern union" do
+  it("sets callback on extern union") do
     run(%(
       require "prelude"
 
@@ -143,7 +143,7 @@ describe "Codegen: extern struct" do
       )).to_i.should eq(42)
   end
 
-  it "codegens extern proc call twice (#4982)" do
+  it("codegens extern proc call twice (#4982)") do
     run(%(
       @[Extern]
       struct Data

--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: generic class type" do
-  it "codegens inherited generic class instance var" do
+describe("Code gen: generic class type") do
+  it("codegens inherited generic class instance var") do
     run(%(
       class Foo(T)
         def initialize(@x : T)
@@ -19,7 +19,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(2)
   end
 
-  it "instantiates generic class with default argument in initialize (#394)" do
+  it("instantiates generic class with default argument in initialize (#394)") do
     run(%(
       class Foo(T)
         def initialize(@x = 1)
@@ -34,7 +34,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(2)
   end
 
-  it "allows initializing instance variable (#665)" do
+  it("allows initializing instance variable (#665)") do
     run(%(
       class SomeType(T)
         @x = 1
@@ -48,7 +48,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(1)
   end
 
-  it "allows initializing instance variable in inherited generic type" do
+  it("allows initializing instance variable in inherited generic type") do
     run(%(
       class Foo(T)
         @x = 1
@@ -66,7 +66,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(1)
   end
 
-  it "declares instance var with virtual T (#1675)" do
+  it("declares instance var with virtual T (#1675)") do
     run(%(
       class Foo
         def foo
@@ -96,7 +96,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(1)
   end
 
-  it "codegens statis array size after instantiating" do
+  it("codegens statis array size after instantiating") do
     run(%(
       struct StaticArray(T, N)
         def size
@@ -111,7 +111,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(3)
   end
 
-  it "inherited instance var initialize from generic to concrete (#2128)" do
+  it("inherited instance var initialize from generic to concrete (#2128)") do
     run(%(
       class Foo(T)
         @x = 42
@@ -128,7 +128,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(42)
   end
 
-  it "inherited instance var initialize from generic to generic to concrete (#2128)" do
+  it("inherited instance var initialize from generic to generic to concrete (#2128)") do
     run(%(
       class Foo(T)
         @x = 10
@@ -154,7 +154,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(42)
   end
 
-  it "invokes super in generic class (#2354)" do
+  it("invokes super in generic class (#2354)") do
     run(%(
       class Global
         @@x = 1
@@ -186,7 +186,7 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(2)
   end
 
-  it "uses big integer as generic type argument (#2353)" do
+  it("uses big integer as generic type argument (#2353)") do
     run(%(
       require "prelude"
 
@@ -203,7 +203,7 @@ describe "Code gen: generic class type" do
       )).to_u64.should eq(2374623294237463578)
   end
 
-  it "doesn't use virtual + in type arguments (#2839)" do
+  it("doesn't use virtual + in type arguments (#2839)") do
     run(%(
       class Class
         def name : String
@@ -224,7 +224,7 @@ describe "Code gen: generic class type" do
       )).to_string.should eq("Gen(Foo)")
   end
 
-  it "doesn't use virtual + in type arguments for Tuple (#2839)" do
+  it("doesn't use virtual + in type arguments for Tuple (#2839)") do
     run(%(
       class Class
         def name : String
@@ -245,7 +245,7 @@ describe "Code gen: generic class type" do
       )).to_string.should eq("Tuple(Foo)")
   end
 
-  it "doesn't use virtual + in type arguments for NamedTuple (#2839)" do
+  it("doesn't use virtual + in type arguments for NamedTuple (#2839)") do
     run(%(
       class Class
         def name : String
@@ -266,7 +266,7 @@ describe "Code gen: generic class type" do
       )).to_string.should eq("NamedTuple(x: Foo)")
   end
 
-  it "codegens virtual generic metaclass macro method call" do
+  it("codegens virtual generic metaclass macro method call") do
     run(%(
       class Class
         def name : String

--- a/spec/compiler/codegen/hash_literal_spec.cr
+++ b/spec/compiler/codegen/hash_literal_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: hash literal spec" do
-  it "creates custom non-generic hash" do
+describe("Code gen: hash literal spec") do
+  it("creates custom non-generic hash") do
     run(%(
       class Custom
         def initialize
@@ -28,7 +28,7 @@ describe "Code gen: hash literal spec" do
       )).to_i.should eq(90)
   end
 
-  it "creates custom generic hash" do
+  it("creates custom generic hash") do
     run(%(
       class Custom(K, V)
         def initialize
@@ -55,7 +55,7 @@ describe "Code gen: hash literal spec" do
       )).to_i.should eq(90)
   end
 
-  it "creates custom generic hash with type vars" do
+  it("creates custom generic hash with type vars") do
     run(%(
       class Custom(K, V)
         def initialize
@@ -82,7 +82,7 @@ describe "Code gen: hash literal spec" do
       )).to_i.should eq(90)
   end
 
-  it "creates custom generic hash via alias (1)" do
+  it("creates custom generic hash via alias (1)") do
     run(%(
       class Custom(K, V)
         def initialize
@@ -111,7 +111,7 @@ describe "Code gen: hash literal spec" do
       )).to_i.should eq(90)
   end
 
-  it "creates custom generic hash via alias (2)" do
+  it("creates custom generic hash via alias (2)") do
     run(%(
       class Custom(K, V)
         def initialize
@@ -140,7 +140,7 @@ describe "Code gen: hash literal spec" do
       )).to_i.should eq(90)
   end
 
-  it "doesn't crash on hash literal with proc pointer (#646)" do
+  it("doesn't crash on hash literal with proc pointer (#646)") do
     run(%(
       require "prelude"
 

--- a/spec/compiler/codegen/hooks_spec.cr
+++ b/spec/compiler/codegen/hooks_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: hooks" do
-  it "does inherited macro" do
+describe("Code gen: hooks") do
+  it("does inherited macro") do
     run("
       class Foo
         macro inherited
@@ -20,7 +20,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(1)
   end
 
-  it "does included macro" do
+  it("does included macro") do
     run("
       module Foo
         macro included
@@ -40,7 +40,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(1)
   end
 
-  it "does extended macro" do
+  it("does extended macro") do
     run("
       module Foo
         macro extended
@@ -60,7 +60,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(1)
   end
 
-  it "does added method macro" do
+  it("does added method macro") do
     run("
       class Global
         @@x = 0
@@ -85,7 +85,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(1)
   end
 
-  it "does inherited macro recursively" do
+  it("does inherited macro recursively") do
     run("
       class Global
         @@x = 0
@@ -114,7 +114,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(2)
   end
 
-  it "does inherited macro before class body" do
+  it("does inherited macro before class body") do
     run("
       class Global
         @@x = 123
@@ -145,7 +145,7 @@ describe "Code gen: hooks" do
       ").to_i.should eq(123)
   end
 
-  it "does finished" do
+  it("does finished") do
     run(%(
       class Foo
         A = [1]
@@ -169,7 +169,7 @@ describe "Code gen: hooks" do
       )).to_i.should eq(4)
   end
 
-  it "fixes empty types in hooks (#3946)" do
+  it("fixes empty types in hooks (#3946)") do
     codegen(%(
       lib LibC
         fun exit(x : Int32) : NoReturn

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -1,75 +1,75 @@
 require "../../spec_helper"
 
-describe "Code gen: if" do
-  it "codegens if without an else with true" do
+describe("Code gen: if") do
+  it("codegens if without an else with true") do
     run("a = 1; if true; a = 2; end; a").to_i.should eq(2)
   end
 
-  it "codegens if without an else with false" do
+  it("codegens if without an else with false") do
     run("a = 1; if false; a = 2; end; a").to_i.should eq(1)
   end
 
-  it "codegens if with an else with false" do
+  it("codegens if with an else with false") do
     run("a = 1; if false; a = 2; else; a = 3; end; a").to_i.should eq(3)
   end
 
-  it "codegens if with an else with true" do
+  it("codegens if with an else with true") do
     run("a = 1; if true; a = 2; else; a = 3; end; a").to_i.should eq(2)
   end
 
-  it "codegens if inside def without an else with true" do
+  it("codegens if inside def without an else with true") do
     run("def foo; a = 1; if true; a = 2; end; a; end; foo").to_i.should eq(2)
   end
 
-  it "codegen if inside if" do
+  it("codegen if inside if") do
     run("a = 1; if false; a = 1; elsif false; a = 2; else; a = 3; end; a").to_i.should eq(3)
   end
 
-  it "codegens if value from then" do
+  it("codegens if value from then") do
     run("if true; 1; else 2; end").to_i.should eq(1)
   end
 
-  it "codegens if with union" do
+  it("codegens if with union") do
     run("a = if true; 2.5_f32; else; 1; end; a.to_f").to_f64.should eq(2.5)
   end
 
-  it "codes if with two whiles" do
+  it("codes if with two whiles") do
     run("if true; while false; end; else; while false; end; end")
   end
 
-  it "codegens if with int" do
+  it("codegens if with int") do
     run("if 1; 2; else 3; end").to_i.should eq(2)
   end
 
-  it "codegens if with nil" do
+  it("codegens if with nil") do
     run("require \"nil\"; if nil; 2; else 3; end").to_i.should eq(3)
   end
 
-  it "codegens if of nilable type in then" do
+  it("codegens if of nilable type in then") do
     run("if false; nil; else; \"foo\"; end").to_string.should eq("foo")
   end
 
-  it "codegens if of nilable type in then 2" do
+  it("codegens if of nilable type in then 2") do
     run("if 1 == 2; nil; else; \"foo\"; end").to_string.should eq("foo")
   end
 
-  it "codegens if of nilable type in else" do
+  it("codegens if of nilable type in else") do
     run("if true; \"foo\"; else; nil; end").to_string.should eq("foo")
   end
 
-  it "codegens if of nilable type in else 3" do
+  it("codegens if of nilable type in else 3") do
     run("if 1 == 1; \"foo\"; else; nil; end").to_string.should eq("foo")
   end
 
-  it "codegens if with return and no else" do
+  it("codegens if with return and no else") do
     run("def foo; if true; return 1; end; 2; end; foo").to_i.should eq(1)
   end
 
-  it "codegens if with return in both branches" do
+  it("codegens if with return in both branches") do
     run("def foo; if true; return 1; else; return 2; end; end; foo").to_i.should eq(1)
   end
 
-  it "codegen if with nested if that returns" do
+  it("codegen if with nested if that returns") do
     run("
       def foo
         if true
@@ -86,7 +86,7 @@ describe "Code gen: if" do
     ").to_i.should eq(1)
   end
 
-  it "codegen if with union type and then without type" do
+  it("codegen if with union type and then without type") do
     run("
       def foo
         if true
@@ -101,7 +101,7 @@ describe "Code gen: if" do
     ").to_i.should eq(1)
   end
 
-  it "codegen if with union type and else without type" do
+  it("codegen if with union type and else without type") do
     run("
       def foo
         if false
@@ -116,7 +116,7 @@ describe "Code gen: if" do
     ").to_i.should eq(1)
   end
 
-  it "codegens if with virtual" do
+  it("codegens if with virtual") do
     run("
       class Foo
       end
@@ -133,7 +133,7 @@ describe "Code gen: if" do
       ").to_i.should eq(1)
   end
 
-  it "codegens nested if with var (ssa bug)" do
+  it("codegens nested if with var (ssa bug)") do
     run("
       foo = 1
       if 1 == 2
@@ -147,7 +147,7 @@ describe "Code gen: if" do
       ").to_i.should eq(1)
   end
 
-  it "codegens if with nested if that raises" do
+  it("codegens if with nested if that raises") do
     run("
       require \"prelude\"
 
@@ -164,7 +164,7 @@ describe "Code gen: if" do
       ").to_i.should eq(1)
   end
 
-  it "codegens if with return in else preserves type filter" do
+  it("codegens if with return in else preserves type filter") do
     run("
       require \"prelude\"
 
@@ -182,7 +182,7 @@ describe "Code gen: if" do
       ").to_i.should eq(2)
   end
 
-  it "codegens bug #1729" do
+  it("codegens bug #1729") do
     run(%(
       n = true ? 3 : 3.2
       z = if n.is_a?(Float64) || false
@@ -207,7 +207,7 @@ describe "Code gen: if" do
     end
   {% end %}
 
-  it "doesn't crash with if !var using var in else" do
+  it("doesn't crash with if !var using var in else") do
     run(%(
       foo = nil
       if !foo
@@ -219,7 +219,7 @@ describe "Code gen: if" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't crash with if !is_a? using var in then" do
+  it("doesn't crash with if !is_a? using var in then") do
     run(%(
       foo = 1
       if !foo.is_a?(Int32)
@@ -231,7 +231,7 @@ describe "Code gen: if" do
       )).to_i.should eq(1)
   end
 
-  it "restricts with || always falsey" do
+  it("restricts with || always falsey") do
     run(%(
       t = 1
       if t.is_a?(String) || t.is_a?(String)
@@ -242,7 +242,7 @@ describe "Code gen: if" do
       )).to_i.should eq(2)
   end
 
-  it "considers or truthy/falsey right" do
+  it("considers or truthy/falsey right") do
     run(%(
       t = 1 || 'a'
       if t.is_a?(Char) || t.is_a?(Char)
@@ -253,7 +253,7 @@ describe "Code gen: if" do
       )).to_i.should eq(2)
   end
 
-  it "codegens #3104" do
+  it("codegens #3104") do
     codegen(%(
       def foo
         yield
@@ -268,7 +268,7 @@ describe "Code gen: if" do
       ))
   end
 
-  it "doesn't generate truthy if branch if doesn't need value (bug)" do
+  it("doesn't generate truthy if branch if doesn't need value (bug)") do
     codegen(%(
       class Foo
       end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -1,55 +1,55 @@
 require "../../spec_helper"
 
-describe "Codegen: is_a?" do
-  it "codegens is_a? true for simple type" do
+describe("Codegen: is_a?") do
+  it("codegens is_a? true for simple type") do
     run("1.is_a?(Int)").to_b.should be_true
   end
 
-  it "codegens is_a? false for simple type" do
+  it("codegens is_a? false for simple type") do
     run("1.is_a?(Bool)").to_b.should be_false
   end
 
-  it "codegens is_a? with union gives true" do
+  it("codegens is_a? with union gives true") do
     run("(1 == 1 ? 1 : 'a').is_a?(Int)").to_b.should be_true
   end
 
-  it "codegens is_a? with union gives false" do
+  it("codegens is_a? with union gives false") do
     run("(1 == 1 ? 1 : 'a').is_a?(Char)").to_b.should be_false
   end
 
-  it "codegens is_a? with union gives false" do
+  it("codegens is_a? with union gives false") do
     run("(1 == 1 ? 1 : 'a').is_a?(Float)").to_b.should be_false
   end
 
-  it "codegens is_a? with union gives true" do
+  it("codegens is_a? with union gives true") do
     run("(1 == 1 ? 1 : 'a').is_a?(Object)").to_b.should be_true
   end
 
-  it "codegens is_a? with nilable gives true" do
+  it("codegens is_a? with nilable gives true") do
     run("(1 == 1 ? nil : Reference.new).is_a?(Nil)").to_b.should be_true
   end
 
-  it "codegens is_a? with nilable gives false because other type 1" do
+  it("codegens is_a? with nilable gives false because other type 1") do
     run("(1 == 1 ? nil : Reference.new).is_a?(Reference)").to_b.should be_false
   end
 
-  it "codegens is_a? with nilable gives false because other type 2" do
+  it("codegens is_a? with nilable gives false because other type 2") do
     run("(1 == 2 ? nil : Reference.new).is_a?(Reference)").to_b.should be_true
   end
 
-  it "codegens is_a? with nilable gives false because no type" do
+  it("codegens is_a? with nilable gives false because no type") do
     run("(1 == 2 ? nil : Reference.new).is_a?(String)").to_b.should be_false
   end
 
-  it "codegens is_a? with nilable gives false because no type" do
+  it("codegens is_a? with nilable gives false because no type") do
     run("1.is_a?(Object)").to_b.should be_true
   end
 
-  it "evaluate method on filtered type" do
+  it("evaluate method on filtered type") do
     run("a = 1; a = 'a'; if a.is_a?(Char); a.ord; else; 0; end").to_i.chr.should eq('a')
   end
 
-  it "evaluate method on filtered type nilable type not-nil" do
+  it("evaluate method on filtered type nilable type not-nil") do
     run("
       class Foo
         def foo
@@ -67,7 +67,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "evaluate method on filtered type nilable type nil" do
+  it("evaluate method on filtered type nilable type nil") do
     run("
       struct Nil
         def foo
@@ -88,7 +88,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "evaluates method on filtered union type" do
+  it("evaluates method on filtered union type") do
     run("
       class Foo
         def initialize(x : Int32)
@@ -111,7 +111,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "evaluates method on filtered union type 2" do
+  it("evaluates method on filtered union type 2") do
     run("
       class Foo
         def initialize(x : Int32)
@@ -145,7 +145,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(3)
   end
 
-  it "evaluates method on filtered union type 3" do
+  it("evaluates method on filtered union type 3") do
     run("
       require \"prelude\"
       a = 1
@@ -160,7 +160,7 @@ describe "Codegen: is_a?" do
     ").to_i.should eq(5)
   end
 
-  it "codegens when is_a? is always false but properties are used" do
+  it("codegens when is_a? is always false but properties are used") do
     run("
       require \"prelude\"
 
@@ -173,7 +173,7 @@ describe "Codegen: is_a?" do
     ").to_b.should be_false
   end
 
-  it "codegens is_a? on right side of and" do
+  it("codegens is_a? on right side of and") do
     run("
       class Foo
         def bar
@@ -190,7 +190,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "codegens is_a? with virtual" do
+  it("codegens is_a? with virtual") do
     run("
       class Foo
       end
@@ -203,7 +203,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "codegens is_a? with virtual and nil" do
+  it("codegens is_a? with virtual and nil") do
     run("
       class Foo
       end
@@ -216,7 +216,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "codegens is_a? with virtual and module" do
+  it("codegens is_a? with virtual and module") do
     run("
       module Bar
       end
@@ -239,7 +239,7 @@ describe "Codegen: is_a?" do
       ").to_b.should be_true
   end
 
-  it "restricts simple type with union" do
+  it("restricts simple type with union") do
     run("
       a = 1
       if a.is_a?(Int32 | Char)
@@ -250,7 +250,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "restricts union with union" do
+  it("restricts union with union") do
     run("
       struct Char
         def +(other : Int32)
@@ -273,7 +273,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(3)
   end
 
-  it "codegens is_a? with a Const does comparison and gives true" do
+  it("codegens is_a? with a Const does comparison and gives true") do
     run("
       require \"prelude\"
       CONST = 1
@@ -281,7 +281,7 @@ describe "Codegen: is_a?" do
       ").to_b.should be_true
   end
 
-  it "codegens is_a? with a Const does comparison and gives false" do
+  it("codegens is_a? with a Const does comparison and gives false") do
     run("
       require \"prelude\"
       CONST = 1
@@ -289,7 +289,7 @@ describe "Codegen: is_a?" do
       ").to_b.should be_false
   end
 
-  it "gives false if generic type doesn't match exactly" do
+  it("gives false if generic type doesn't match exactly") do
     run("
       class Foo(T)
       end
@@ -299,7 +299,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "does is_a? with more strict virtual type" do
+  it("does is_a? with more strict virtual type") do
     run("
       class Foo
       end
@@ -319,7 +319,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "codegens is_a? casts union to nilable" do
+  it("codegens is_a? casts union to nilable") do
     run("
       class Foo; end
 
@@ -333,7 +333,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "codegens is_a? casts union to nilable in method" do
+  it("codegens is_a? casts union to nilable in method") do
     run("
       class Foo; end
 
@@ -351,7 +351,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "codegens is_a? from virtual type to module" do
+  it("codegens is_a? from virtual type to module") do
     run("
       module Moo
       end
@@ -377,7 +377,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "codegens is_a? from nilable reference union type to nil" do
+  it("codegens is_a? from nilable reference union type to nil") do
     run("
       class Foo
       end
@@ -395,7 +395,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "codegens is_a? from nilable reference union type to type" do
+  it("codegens is_a? from nilable reference union type to type") do
     run("
       class Foo
       end
@@ -413,13 +413,13 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(1)
   end
 
-  it "says false for value.is_a?(Class)" do
+  it("says false for value.is_a?(Class)") do
     run("
       1.is_a?(Class)
       ").to_b.should be_false
   end
 
-  it "restricts type in else but lazily" do
+  it("restricts type in else but lazily") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -442,7 +442,7 @@ describe "Codegen: is_a?" do
       ").to_i.should eq(2)
   end
 
-  it "works with inherited generic class against an instantiation" do
+  it("works with inherited generic class against an instantiation") do
     run(%(
       class Foo(T)
       end
@@ -455,7 +455,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "works with inherited generic class against an instantiation (2)" do
+  it("works with inherited generic class against an instantiation (2)") do
     run(%(
       class Class1
       end
@@ -474,7 +474,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "works with inherited generic class against an instantiation (3)" do
+  it("works with inherited generic class against an instantiation (3)") do
     run(%(
       class Foo(T)
       end
@@ -487,7 +487,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_false
   end
 
-  it "doesn't type merge (1) (#548)" do
+  it("doesn't type merge (1) (#548)") do
     run(%(
       class Base; end
       class Base1 < Base; end
@@ -498,7 +498,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_false
   end
 
-  it "doesn't type merge (2) (#548)" do
+  it("doesn't type merge (2) (#548)") do
     run(%(
       class Base; end
       class Base1 < Base; end
@@ -509,7 +509,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "doesn't skip assignment when used in combination with .is_a? (true case, then) (#1121)" do
+  it("doesn't skip assignment when used in combination with .is_a? (true case, then) (#1121)") do
     run(%(
       a = 123
       if (b = a).is_a?(Int32)
@@ -520,7 +520,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(124)
   end
 
-  it "doesn't skip assignment when used in combination with .is_a? (true case, else) (#1121)" do
+  it("doesn't skip assignment when used in combination with .is_a? (true case, else) (#1121)") do
     run(%(
       a = 123
       if (b = a).is_a?(Int32)
@@ -531,7 +531,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(125)
   end
 
-  it "doesn't skip assignment when used in combination with .is_a? (false case) (#1121)" do
+  it("doesn't skip assignment when used in combination with .is_a? (false case) (#1121)") do
     run(%(
       a = 123
       if (b = a).is_a?(Char)
@@ -542,7 +542,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(124)
   end
 
-  it "doesn't skip assignment when used in combination with .is_a? and && (#1121)" do
+  it("doesn't skip assignment when used in combination with .is_a? and && (#1121)") do
     run(%(
       a = 123
       if (1 == 1) && (b = a).is_a?(Char)
@@ -554,7 +554,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(124)
   end
 
-  it "transforms then if condition is always truthy" do
+  it("transforms then if condition is always truthy") do
     run(%(
       def foo
         123 && 456
@@ -568,7 +568,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(456)
   end
 
-  it "transforms else if condition is always falsey" do
+  it("transforms else if condition is always falsey") do
     run(%(
       def foo
         123 && 456
@@ -582,7 +582,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(456)
   end
 
-  it "resets truthy state after visiting nodes (bug)" do
+  it("resets truthy state after visiting nodes (bug)") do
     run(%(
       require "prelude"
 
@@ -594,7 +594,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(123)
   end
 
-  it "does is_a? with generic class metaclass" do
+  it("does is_a? with generic class metaclass") do
     run(%(
       class Foo(T)
       end
@@ -603,7 +603,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "says false for GenericChild(Base).is_a?(GenericBase(Child)) (#1294)" do
+  it("says false for GenericChild(Base).is_a?(GenericBase(Child)) (#1294)") do
     run(%(
       class Base
       end
@@ -621,7 +621,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_false
   end
 
-  it "does is_a?/responds_to? twice (#1451)" do
+  it("does is_a?/responds_to? twice (#1451)") do
     run(%(
       a = 1 == 2 ? 1 : false
       if a.is_a?(Int32) && a.is_a?(Int32)
@@ -632,7 +632,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(4)
   end
 
-  it "does is_a? with && and true condition" do
+  it("does is_a? with && and true condition") do
     run(%(
       a = 1 == 1 ? 1 : false
       if a.is_a?(Int32) && 1 == 1
@@ -643,7 +643,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(3)
   end
 
-  it "does is_a? for union of module and type" do
+  it("does is_a? for union of module and type") do
     run(%(
       module Moo
         def moo
@@ -672,7 +672,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(2)
   end
 
-  it "does is_a? for virtual generic instance type against generic" do
+  it("does is_a? for virtual generic instance type against generic") do
     run(%(
       class Foo(T)
       end
@@ -687,7 +687,7 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't consider generic type to be a generic type of a recursive alias (#3524)" do
+  it("doesn't consider generic type to be a generic type of a recursive alias (#3524)") do
     run(%(
       class Gen(T)
       end
@@ -698,7 +698,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_false
   end
 
-  it "codegens untyped var (#4009)" do
+  it("codegens untyped var (#4009)") do
     codegen(%(
       require "prelude"
 
@@ -707,7 +707,7 @@ describe "Codegen: is_a?" do
       ))
   end
 
-  it "visits 1.to_s twice, may trigger enclosing_call (#4364)" do
+  it("visits 1.to_s twice, may trigger enclosing_call (#4364)") do
     run(%(
       require "prelude"
 
@@ -716,13 +716,13 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "says true for Class.is_a?(Class.class) (#4374)" do
+  it("says true for Class.is_a?(Class.class) (#4374)") do
     run("
       Class.is_a?(Class.class)
     ").to_b.should be_true
   end
 
-  it "says true for Class.is_a?(Class.class.class) (#4374)" do
+  it("says true for Class.is_a?(Class.class.class) (#4374)") do
     run("
       Class.is_a?(Class.class.class)
     ").to_b.should be_true

--- a/spec/compiler/codegen/lib_spec.cr
+++ b/spec/compiler/codegen/lib_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: lib" do
-  pending "codegens lib var set and get" do
+describe("Code gen: lib") do
+  pending("codegens lib var set and get") do
     run("
       lib LibC
         $errno : Int32
@@ -12,7 +12,7 @@ describe "Code gen: lib" do
       ").to_i.should eq(1)
   end
 
-  it "call to void function" do
+  it("call to void function") do
     run("
       lib LibC
         fun srandom(x : UInt32) : Void
@@ -26,7 +26,7 @@ describe "Code gen: lib" do
     ")
   end
 
-  it "allows passing type to LibC if it has a coverter with to_unsafe" do
+  it("allows passing type to LibC if it has a coverter with to_unsafe") do
     codegen("
       lib LibC
         fun foo(x : Int32) : Int32
@@ -42,7 +42,7 @@ describe "Code gen: lib" do
       ")
   end
 
-  it "allows passing type to LibC if it has a coverter with to_unsafe (bug)" do
+  it("allows passing type to LibC if it has a coverter with to_unsafe (bug)") do
     codegen(%(
       require "prelude"
 
@@ -58,7 +58,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "allows setting/getting external variable as function pointer" do
+  it("allows setting/getting external variable as function pointer") do
     codegen(%(
       require "prelude"
 
@@ -71,7 +71,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "can use enum as fun argument" do
+  it("can use enum as fun argument") do
     codegen(%(
       enum Foo
         A
@@ -85,7 +85,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "can use enum as fun return" do
+  it("can use enum as fun return") do
     codegen(%(
       enum Foo
         A
@@ -99,7 +99,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "can use tuple as fun return" do
+  it("can use tuple as fun return") do
     test_c(
       %(
         struct s {
@@ -122,7 +122,7 @@ describe "Code gen: lib" do
       ), &.to_i.should eq(3))
   end
 
-  it "get fun field from struct (#672)" do
+  it("get fun field from struct (#672)") do
     run(%(
       require "prelude"
 
@@ -138,7 +138,7 @@ describe "Code gen: lib" do
       )).to_i.should eq(10)
   end
 
-  it "get fun field from union (#672)" do
+  it("get fun field from union (#672)") do
     run(%(
       require "prelude"
 
@@ -154,7 +154,7 @@ describe "Code gen: lib" do
       )).to_i.should eq(10)
   end
 
-  it "refers to lib type (#960)" do
+  it("refers to lib type (#960)") do
     codegen(%(
       lib Thing
       end
@@ -163,7 +163,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "allows invoking out with underscore " do
+  it("allows invoking out with underscore ") do
     codegen(%(
       lib Lib
         fun foo(x : Int32*) : Float64
@@ -173,7 +173,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "passes int as another float type in literal" do
+  it("passes int as another float type in literal") do
     codegen(%(
       lib LibFoo
         fun foo(x : Int32)
@@ -183,7 +183,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "passes nil to varargs (#1570)" do
+  it("passes nil to varargs (#1570)") do
     codegen(%(
       lib LibFoo
         fun foo(...)
@@ -193,7 +193,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "casts C fun to Crystal proc when accessing instance var (#2515)" do
+  it("casts C fun to Crystal proc when accessing instance var (#2515)") do
     codegen(%(
       require "prelude"
 
@@ -207,7 +207,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "doesn't crash when casting -1 to UInt32 (#3594)" do
+  it("doesn't crash when casting -1 to UInt32 (#3594)") do
     codegen(%(
       lib LibFoo
         fun foo(x : UInt32) : Nil
@@ -217,7 +217,7 @@ describe "Code gen: lib" do
       ))
   end
 
-  it "doesn't crash with nil and varargs (#4414)" do
+  it("doesn't crash with nil and varargs (#4414)") do
     codegen(%(
       lib LibFoo
         fun foo(Void*, ...)

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Code gen: macro" do
-  it "expands macro" do
+describe("Code gen: macro") do
+  it("expands macro") do
     run("macro foo; 1 + 2; end; foo").to_i.should eq(3)
   end
 
-  it "expands macro with arguments" do
+  it("expands macro with arguments") do
     run(%(
       macro foo(n)
         {{n}} + 2
@@ -15,7 +15,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands macro that invokes another macro" do
+  it("expands macro that invokes another macro") do
     run(%(
       macro foo
         def x
@@ -32,7 +32,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands macro defined in class" do
+  it("expands macro defined in class") do
     run(%(
       class Foo
         macro foo
@@ -49,7 +49,7 @@ describe "Code gen: macro" do
     )).to_i.should eq(1)
   end
 
-  it "expands macro defined in base class" do
+  it("expands macro defined in base class") do
     run(%(
       class Object
         macro foo
@@ -68,14 +68,14 @@ describe "Code gen: macro" do
     )).to_i.should eq(1)
   end
 
-  it "expands inline macro" do
+  it("expands inline macro") do
     run(%(
       a = {{ 1 }}
       a
       )).to_i.should eq(1)
   end
 
-  it "expands inline macro for" do
+  it("expands inline macro for") do
     run(%(
       a = 0
       {% for i in [1, 2, 3] %}
@@ -85,7 +85,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(6)
   end
 
-  it "expands inline macro if (true)" do
+  it("expands inline macro if (true)") do
     run(%(
       a = 0
       {% if 1 == 1 %}
@@ -95,7 +95,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands inline macro if (false)" do
+  it("expands inline macro if (false)") do
     run(%(
       a = 0
       {% if 1 == 2 %}
@@ -105,7 +105,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(0)
   end
 
-  it "finds macro in class" do
+  it("finds macro in class") do
     run(%(
       class Foo
         macro foo
@@ -121,7 +121,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands def macro" do
+  it("expands def macro") do
     run(%(
       def bar_baz
         1
@@ -137,7 +137,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands def macro with var" do
+  it("expands def macro with var") do
     run(%(
       macro def foo : Int32
         a = {{ 1 }}
@@ -147,7 +147,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands def macro with @type.instance_vars" do
+  it("expands def macro with @type.instance_vars") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -163,7 +163,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("x")
   end
 
-  it "expands def macro with @type.instance_vars with subclass" do
+  it("expands def macro with @type.instance_vars with subclass") do
     run(%(
       class Reference
         def to_s : String
@@ -185,7 +185,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("y")
   end
 
-  it "expands def macro with @type.instance_vars with virtual" do
+  it("expands def macro with @type.instance_vars with virtual") do
     run(%(
       class Reference
         def to_s : String
@@ -207,7 +207,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("y")
   end
 
-  it "expands def macro with @type.name" do
+  it("expands def macro with @type.name") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -223,7 +223,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "expands macro and resolves type correctly" do
+  it("expands macro and resolves type correctly") do
     run(%(
       class Foo
         macro def foo : Int32
@@ -239,7 +239,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands def macro with @type.name with virtual" do
+  it("expands def macro with @type.name with virtual") do
     run(%(
       class Reference
         def to_s : String
@@ -257,7 +257,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Bar")
   end
 
-  it "expands def macro with @type.name with virtual (2)" do
+  it("expands def macro with @type.name with virtual (2)") do
     run(%(
       class Reference
         def to_s : String
@@ -275,7 +275,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "allows overriding macro definition when redefining base class" do
+  it("allows overriding macro definition when redefining base class") do
     run(%(
       class Foo
         def inspect : String
@@ -296,7 +296,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("OH NO")
   end
 
-  it "uses invocation context" do
+  it("uses invocation context") do
     run(%(
       macro foo
         def bar
@@ -312,7 +312,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "allows macro with default arguments" do
+  it("allows macro with default arguments") do
     run(%(
       def bar
         2
@@ -326,7 +326,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands def macro with instance var and method call (bug)" do
+  it("expands def macro with instance var and method call (bug)") do
     run(%(
       struct Nil
         def to_i
@@ -347,7 +347,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands @type.name in virtual metaclass (1)" do
+  it("expands @type.name in virtual metaclass (1)") do
     run(%(
       class Class
         def to_s : String
@@ -368,7 +368,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "expands @type.name in virtual metaclass (2)" do
+  it("expands @type.name in virtual metaclass (2)") do
     run(%(
       class Class
         def to_s : String
@@ -389,7 +389,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Bar")
   end
 
-  it "doesn't skip abstract classes when defining macro methods" do
+  it("doesn't skip abstract classes when defining macro methods") do
     run(%(
       class Object
         macro def foo : Int32
@@ -417,7 +417,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't reuse macro nodes (bug)" do
+  it("doesn't reuse macro nodes (bug)") do
     run(%(
       def foo(x)
         {% for y in [1, 2] %}
@@ -430,14 +430,14 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "can use constants" do
+  it("can use constants") do
     run(%(
       CONST = 1
       {{ CONST }}
       )).to_i.should eq(1)
   end
 
-  it "can refer to types" do
+  it("can refer to types") do
     run(%(
       class Foo
         def initialize(@x : Int32, @y : Int32)
@@ -453,7 +453,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("y")
   end
 
-  it "runs macro with splat" do
+  it("runs macro with splat") do
     run(%(
       macro foo(*args)
         {{args.size}}
@@ -463,7 +463,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "runs macro with arg and splat" do
+  it("runs macro with arg and splat") do
     run(%(
       macro foo(name, *args)
         {{args.size}}
@@ -473,7 +473,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands macro that yields" do
+  it("expands macro that yields") do
     run(%(
       def foo
         {% for i in 0 .. 2 %}
@@ -489,7 +489,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "can refer to abstract (1)" do
+  it("can refer to abstract (1)") do
     run(%(
       class Foo
       end
@@ -498,7 +498,7 @@ describe "Code gen: macro" do
       )).to_b.should be_false
   end
 
-  it "can refer to abstract (2)" do
+  it("can refer to abstract (2)") do
     run(%(
       abstract class Foo
       end
@@ -507,7 +507,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "can refer to @type" do
+  it("can refer to @type") do
     run(%(
       class Foo
         def foo : String
@@ -519,13 +519,13 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "can refer to union (1)" do
+  it("can refer to union (1)") do
     run(%(
       {{Int32.union?}}
     )).to_b.should be_false
   end
 
-  it "can refer to union (2)" do
+  it("can refer to union (2)") do
     run(%(
       class Foo
         def initialize
@@ -539,7 +539,7 @@ describe "Code gen: macro" do
     )).to_b.should be_true
   end
 
-  it "can iterate union types" do
+  it("can iterate union types") do
     run(%(
       require "prelude"
       class Foo
@@ -554,7 +554,7 @@ describe "Code gen: macro" do
     )).to_string.should eq("Float64-Int32")
   end
 
-  it "can access type variables" do
+  it("can access type variables") do
     run(%(
       class Foo(T)
         def foo
@@ -565,7 +565,7 @@ describe "Code gen: macro" do
     )).to_string.should eq("Int32")
   end
 
-  it "can acccess type variables that are not types" do
+  it("can acccess type variables that are not types") do
     run(%(
       class Foo(T)
         def foo
@@ -576,7 +576,7 @@ describe "Code gen: macro" do
     )).to_b.should eq(true)
   end
 
-  it "can acccess type variables of a tuple" do
+  it("can acccess type variables of a tuple") do
     run(%(
       struct Tuple
         def foo
@@ -587,7 +587,7 @@ describe "Code gen: macro" do
     )).to_string.should eq("Int32")
   end
 
-  it "can access type variables of a generic type" do
+  it("can access type variables of a generic type") do
     run(%(
       require "prelude"
       class Foo(T, K)
@@ -599,7 +599,7 @@ describe "Code gen: macro" do
     )).to_string.should eq("T-K")
   end
 
-  it "receives &block" do
+  it("receives &block") do
     run(%(
       macro foo(&block)
         bar {{block}}
@@ -615,7 +615,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "executes with named arguments" do
+  it("executes with named arguments") do
     run(%(
       macro foo(x = 1)
         {{x}} + 1
@@ -625,7 +625,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "gets correct class name when there are classes in the middle" do
+  it("gets correct class name when there are classes in the middle") do
     run(%(
       class Foo
         def class_desc : String
@@ -648,7 +648,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Qux")
   end
 
-  it "transforms hooks (bug)" do
+  it("transforms hooks (bug)") do
     codegen(%(
       module GC
         def self.add_finalizer(object : T)
@@ -669,7 +669,7 @@ describe "Code gen: macro" do
       ))
   end
 
-  it "executes subclasses" do
+  it("executes subclasses") do
     run(%(
       require "prelude"
 
@@ -690,7 +690,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Bar-Baz")
   end
 
-  it "executes all_subclasses" do
+  it("executes all_subclasses") do
     run(%(
       require "prelude"
 
@@ -708,7 +708,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Bar-Baz")
   end
 
-  it "gets enum members with @type.constants" do
+  it("gets enum members with @type.constants") do
     run(%(
       enum Color
         Red
@@ -732,7 +732,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(0 + 1 + 2)
   end
 
-  it "gets enum members as constants" do
+  it("gets enum members as constants") do
     run(%(
       enum Color
         Red
@@ -744,7 +744,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Green")
   end
 
-  it "says that enum has Flags attribute" do
+  it("says that enum has Flags attribute") do
     run(%(
       @[Flags]
       enum Color
@@ -757,7 +757,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "says that enum doesn't have Flags attribute" do
+  it("says that enum doesn't have Flags attribute") do
     run(%(
       enum Color
         Red
@@ -769,7 +769,7 @@ describe "Code gen: macro" do
       )).to_b.should be_false
   end
 
-  it "gets methods" do
+  it("gets methods") do
     run(%(
       class Foo
         def bar
@@ -785,7 +785,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("bar")
   end
 
-  it "copies base macro def to sub-subtype even after it was copied to a subtype (#448)" do
+  it("copies base macro def to sub-subtype even after it was copied to a subtype (#448)") do
     run(%(
       class Object
         def class_name : String
@@ -816,7 +816,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Baz")
   end
 
-  it "recalculates method when virtual metaclass type is added" do
+  it("recalculates method when virtual metaclass type is added") do
     run(%(
       require "prelude"
 
@@ -868,7 +868,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Test, RunnableTest")
   end
 
-  it "correctly recomputes call (bug)" do
+  it("correctly recomputes call (bug)") do
     run(%(
       class Object
         def in_object
@@ -903,7 +903,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Baz")
   end
 
-  it "doesn't override local variable when using macro variable" do
+  it("doesn't override local variable when using macro variable") do
     run(%(
       macro foo(x)
         %a = {{x}}
@@ -917,7 +917,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "doesn't override local variable when using macro variable (2)" do
+  it("doesn't override local variable when using macro variable (2)") do
     run(%(
       macro foo(x)
         %a = {{x}} + 10
@@ -931,7 +931,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(26)
   end
 
-  it "uses indexed macro variable" do
+  it("uses indexed macro variable") do
     run(%(
       macro foo(*elems)
         {% for elem, i in elems %}
@@ -952,7 +952,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(4 + 5 + 6 + 40 + 50 + 60)
   end
 
-  it "uses indexed macro variable with many keys" do
+  it("uses indexed macro variable with many keys") do
     run(%(
       macro foo(*elems)
         {% for elem, i in elems %}
@@ -971,7 +971,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(4 + 5 + 6)
   end
 
-  it "codegens macro def with splat (#496)" do
+  it("codegens macro def with splat (#496)") do
     run(%(
       class Foo
         macro def bar(*args) : Int32
@@ -983,7 +983,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(6)
   end
 
-  it "codegens macro def with default arg (similar to #496)" do
+  it("codegens macro def with default arg (similar to #496)") do
     run(%(
       class Foo
         macro def bar(foo = 1) : Int32
@@ -995,7 +995,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "expands macro with default arg and splat (#784)" do
+  it("expands macro with default arg and splat (#784)") do
     run(%(
       macro some_macro(a=5, *args)
         {{a.stringify}}
@@ -1005,7 +1005,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("5")
   end
 
-  it "expands macro with default arg and splat (2) (#784)" do
+  it("expands macro with default arg and splat (2) (#784)") do
     run(%(
       macro some_macro(a=5, *args)
         {{a.stringify}}
@@ -1015,7 +1015,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("1")
   end
 
-  it "expands macro with default arg and splat (3) (#784)" do
+  it("expands macro with default arg and splat (3) (#784)") do
     run(%(
       macro some_macro(a=5, *args)
         {{args.size}}
@@ -1025,7 +1025,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "checks if macro expansion returns (#821)" do
+  it("checks if macro expansion returns (#821)") do
     run(%(
       macro pass
         return 123
@@ -1040,7 +1040,7 @@ describe "Code gen: macro" do
       ), inject_primitives: false).to_i.should eq(123)
   end
 
-  it "passes #826" do
+  it("passes #826") do
     run(%(
       macro foo
         macro bar
@@ -1056,7 +1056,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "declares constant in macro (#838)" do
+  it("declares constant in macro (#838)") do
     run(%(
       macro foo
         {{yield}}
@@ -1070,7 +1070,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "errors if dynamic constant assignment after macro expansion" do
+  it("errors if dynamic constant assignment after macro expansion") do
     assert_error %(
       macro foo
         X = 123
@@ -1085,7 +1085,7 @@ describe "Code gen: macro" do
       "dynamic constant assignment. Constants can only be declared at the top level or inside other types."
   end
 
-  it "finds macro from virtual type" do
+  it("finds macro from virtual type") do
     run(%(
       class Foo
         macro foo
@@ -1106,7 +1106,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "expands macro with escaped quotes (#895)" do
+  it("expands macro with escaped quotes (#895)") do
     run(%(
       macro foo(x)
         "{{x}}\\""
@@ -1116,7 +1116,7 @@ describe "Code gen: macro" do
       )).to_string.should eq(%(hello"))
   end
 
-  it "expands macro def with return (#1040)" do
+  it("expands macro def with return (#1040)") do
     run(%(
       macro def a : Int32
         return 123
@@ -1126,7 +1126,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "fixes empty types of macro expansions (#1379)" do
+  it("fixes empty types of macro expansions (#1379)") do
     run(%(
       macro lala(exp)
         {{exp}}
@@ -1146,7 +1146,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "expands macro as class method" do
+  it("expands macro as class method") do
     run(%(
       class Foo
         macro bar
@@ -1158,7 +1158,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands macro as class method and accesses @type" do
+  it("expands macro as class method and accesses @type") do
     run(%(
       class Foo
         macro bar
@@ -1170,7 +1170,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Foo")
   end
 
-  it "codegens macro with comment (bug) (#1396)" do
+  it("codegens macro with comment (bug) (#1396)") do
     run(%(
       macro my_macro
         # {{ 1 }}
@@ -1181,7 +1181,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "correctly resolves constant inside block in macro def" do
+  it("correctly resolves constant inside block in macro def") do
     run(%(
       def foo
         yield
@@ -1199,7 +1199,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(123)
   end
 
-  it "can access free variables" do
+  it("can access free variables") do
     run(%(
       def foo(x : T) forall T
         {{ T.stringify }}
@@ -1209,7 +1209,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Int32")
   end
 
-  it "types macro expansion bug (#1734)" do
+  it("types macro expansion bug (#1734)") do
     run(%(
       class Foo
         macro def foo : Int32
@@ -1225,7 +1225,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "expands Path with resolve method" do
+  it("expands Path with resolve method") do
     run(%(
       CONST = 1
 
@@ -1237,7 +1237,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "solves macro expression arguments before macro expansion (type)" do
+  it("solves macro expression arguments before macro expansion (type)") do
     run(%(
       macro name(x)
         {{x.name.stringify}}
@@ -1247,7 +1247,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("String")
   end
 
-  it "solves macro expression arguments before macro expansion (constant)" do
+  it("solves macro expression arguments before macro expansion (constant)") do
     run(%(
       CONST = 1
 
@@ -1259,7 +1259,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "can use macro inside array literal" do
+  it("can use macro inside array literal") do
     run(%(
       require "prelude"
 
@@ -1272,7 +1272,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(42)
   end
 
-  it "can use macro inside hash literal" do
+  it("can use macro inside hash literal") do
     run(%(
       require "prelude"
 
@@ -1285,7 +1285,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(42)
   end
 
-  it "executes with named arguments for positional arg (1)" do
+  it("executes with named arguments for positional arg (1)") do
     run(%(
       macro foo(x)
         {{x}} + 1
@@ -1295,7 +1295,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(3)
   end
 
-  it "executes with named arguments for positional arg (2)" do
+  it("executes with named arguments for positional arg (2)") do
     run(%(
       macro foo(x, y)
         {{x}} + {{y}} + 1
@@ -1305,7 +1305,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(6)
   end
 
-  it "executes with named arguments for positional arg (3)" do
+  it("executes with named arguments for positional arg (3)") do
     run(%(
       class String
         def bytesize
@@ -1321,7 +1321,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(6)
   end
 
-  it "stringifies type without virtual marker" do
+  it("stringifies type without virtual marker") do
     run(%(
       class Foo
         def foo_m : Int32
@@ -1343,7 +1343,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "uses tuple T in method with free vars" do
+  it("uses tuple T in method with free vars") do
     run(%(
       struct Tuple
         def foo(x : U) forall U
@@ -1355,7 +1355,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "implicitly marks method as macro def when using @type" do
+  it("implicitly marks method as macro def when using @type") do
     run(%(
       class Foo
         def method
@@ -1370,7 +1370,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Bar")
   end
 
-  it "doesn't replace %s in string (#2178)" do
+  it("doesn't replace %s in string (#2178)") do
     run(%(
       {% begin %}
         "hello %s"
@@ -1378,7 +1378,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("hello %s")
   end
 
-  it "doesn't replace %q() (#2178)" do
+  it("doesn't replace %q() (#2178)") do
     run(%(
       {% begin %}
         %q(hello)
@@ -1386,7 +1386,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("hello")
   end
 
-  it "replaces %s inside string inside interpolation (#2178)" do
+  it("replaces %s inside string inside interpolation (#2178)") do
     run(%(
       require "prelude"
 
@@ -1397,7 +1397,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("hello world")
   end
 
-  it "replaces %s inside string inside interpolation, with braces (#2178)" do
+  it("replaces %s inside string inside interpolation, with braces (#2178)") do
     run(%(
       require "prelude"
 
@@ -1408,7 +1408,7 @@ describe "Code gen: macro" do
       )).to_string.should eq(%(hello [{"world", "world"}, "world"]))
   end
 
-  it "retains original yield expression (#2923)" do
+  it("retains original yield expression (#2923)") do
     run(%(
       macro foo
         def bar(baz)
@@ -1424,7 +1424,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("hi")
   end
 
-  it "surrounds {{yield}} with begin/end" do
+  it("surrounds {{yield}} with begin/end") do
     run(%(
       macro foo
         a = {{yield}}
@@ -1439,7 +1439,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(2)
   end
 
-  it "initializes instance var in macro" do
+  it("initializes instance var in macro") do
     run(%(
       class Foo
         {% begin %}
@@ -1451,7 +1451,7 @@ describe "Code gen: macro" do
       ), inject_primitives: false).to_i.should eq(1)
   end
 
-  it "initializes class var in macro" do
+  it("initializes class var in macro") do
     run(%(
       class Foo
         {% begin %}
@@ -1467,7 +1467,7 @@ describe "Code gen: macro" do
       ), inject_primitives: false).to_i.should eq(1)
   end
 
-  it "expands @def in inline macro" do
+  it("expands @def in inline macro") do
     run(%(
       def foo
         {{@def.name.stringify}}
@@ -1477,7 +1477,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("foo")
   end
 
-  it "expands @def in macro" do
+  it("expands @def in macro") do
     run(%(
       macro foo
         {{@def.name.stringify}}
@@ -1491,7 +1491,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("bar")
   end
 
-  it "gets constant" do
+  it("gets constant") do
     run(%(
       class Foo
         Bar = 42
@@ -1501,7 +1501,7 @@ describe "Code gen: macro" do
       )).to_i.should eq(42)
   end
 
-  it "determines if overrides (false)" do
+  it("determines if overrides (false)") do
     run(%(
       class Foo
         def foo
@@ -1516,7 +1516,7 @@ describe "Code gen: macro" do
       )).to_b.should be_false
   end
 
-  it "determines if overrides (true)" do
+  it("determines if overrides (true)") do
     run(%(
       class Foo
         def foo
@@ -1534,7 +1534,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "determines if overrides, through another class (true)" do
+  it("determines if overrides, through another class (true)") do
     run(%(
       class Foo
         def foo
@@ -1555,7 +1555,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "determines if overrides, through module (true)" do
+  it("determines if overrides, through module (true)") do
     run(%(
       class Foo
         def foo
@@ -1580,7 +1580,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "determines if overrides, with macro method (false)" do
+  it("determines if overrides, with macro method (false)") do
     run(%(
       class Foo
         def foo
@@ -1601,7 +1601,7 @@ describe "Code gen: macro" do
       )).to_b.should be_false
   end
 
-  it "determines if method exists (true)" do
+  it("determines if method exists (true)") do
     run(%(
       class Foo
         def foo
@@ -1613,7 +1613,7 @@ describe "Code gen: macro" do
       )).to_b.should be_true
   end
 
-  it "determines if method exists (false)" do
+  it("determines if method exists (false)") do
     run(%(
       class Foo
         def foo
@@ -1625,7 +1625,7 @@ describe "Code gen: macro" do
       )).to_b.should be_false
   end
 
-  it "forwards file location" do
+  it("forwards file location") do
     run(%(
       macro foo
         bar
@@ -1639,7 +1639,7 @@ describe "Code gen: macro" do
       ), filename: "bar.cr").to_string.should eq("bar.cr")
   end
 
-  it "forwards dir location" do
+  it("forwards dir location") do
     run(%(
       macro foo
         bar
@@ -1653,7 +1653,7 @@ describe "Code gen: macro" do
       ), filename: "somedir/bar.cr").to_string.should eq("somedir")
   end
 
-  it "forwards line number" do
+  it("forwards line number") do
     run(%(
       macro foo
         bar
@@ -1667,7 +1667,7 @@ describe "Code gen: macro" do
       ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(10)
   end
 
-  it "keeps line number with no block" do
+  it("keeps line number with no block") do
     run(%(
       macro foo
         {{ yield }}
@@ -1678,7 +1678,7 @@ describe "Code gen: macro" do
     ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
   end
 
-  it "keeps line number with a block" do
+  it("keeps line number with a block") do
     run(%(
       macro foo
         {{ yield }}
@@ -1691,7 +1691,7 @@ describe "Code gen: macro" do
     ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
   end
 
-  it "resolves alias in macro" do
+  it("resolves alias in macro") do
     run(%(
       alias Foo = Int32 | String
 

--- a/spec/compiler/codegen/magic_constants_spec.cr
+++ b/spec/compiler/codegen/magic_constants_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: magic constants" do
-  it "does __LINE__" do
+describe("Code gen: magic constants") do
+  it("does __LINE__") do
     run(%(
       def foo(x = __LINE__)
         x
@@ -11,7 +11,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(6)
   end
 
-  it "does __FILE__" do
+  it("does __FILE__") do
     run(%(
       def foo(x = __FILE__)
         x
@@ -21,7 +21,7 @@ describe "Code gen: magic constants" do
       ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
   end
 
-  it "does __DIR__" do
+  it("does __DIR__") do
     run(%(
       def foo(x = __DIR__)
         x
@@ -31,7 +31,7 @@ describe "Code gen: magic constants" do
       ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
   end
 
-  it "does __LINE__ with dispatch" do
+  it("does __LINE__ with dispatch") do
     run(%(
       def foo(z : Int32, x = __LINE__)
         x
@@ -46,7 +46,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(11)
   end
 
-  it "does __LINE__ when specifying one default arg with __FILE__" do
+  it("does __LINE__ when specifying one default arg with __FILE__") do
     run(%(
       def foo(x, file = __FILE__, line = __LINE__)
         line
@@ -56,7 +56,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(6)
   end
 
-  it "does __LINE__ when specifying one normal default arg" do
+  it("does __LINE__ when specifying one normal default arg") do
     run(%(
       require "primitives"
 
@@ -68,7 +68,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(28)
   end
 
-  it "does __LINE__ when specifying one middle argument" do
+  it("does __LINE__ when specifying one middle argument") do
     run(%(
       require "primitives"
 
@@ -80,7 +80,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(28)
   end
 
-  it "does __LINE__ in macro" do
+  it("does __LINE__ in macro") do
     run(%(
       macro foo(line = __LINE__)
         {{line}}
@@ -90,7 +90,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(6)
   end
 
-  it "does __FILE__ in macro" do
+  it("does __FILE__ in macro") do
     run(%(
       macro foo(file = __FILE__)
         {{file}}
@@ -100,7 +100,7 @@ describe "Code gen: magic constants" do
       ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
   end
 
-  it "does __DIR__ in macro" do
+  it("does __DIR__ in macro") do
     run(%(
       macro foo(dir = __DIR__)
         {{dir}}
@@ -110,7 +110,7 @@ describe "Code gen: magic constants" do
       ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
   end
 
-  it "does __END_LINE__ without block" do
+  it("does __END_LINE__ without block") do
     run(%(
       def foo(x = __END_LINE__)
         x
@@ -120,7 +120,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(6)
   end
 
-  it "does __END_LINE__ with block" do
+  it("does __END_LINE__ with block") do
     run(%(
       def foo(x = __END_LINE__)
         yield
@@ -133,7 +133,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(9)
   end
 
-  it "does __END_LINE__ in macro without block" do
+  it("does __END_LINE__ in macro without block") do
     run(%(
       macro foo(line = __END_LINE__)
         {{line}}
@@ -143,7 +143,7 @@ describe "Code gen: magic constants" do
       ), inject_primitives: false).to_i.should eq(6)
   end
 
-  it "does __END_LINE__ in macro with block" do
+  it("does __END_LINE__ in macro with block") do
     run(%(
       macro foo(line = __END_LINE__)
         {{line}}

--- a/spec/compiler/codegen/method_missing_spec.cr
+++ b/spec/compiler/codegen/method_missing_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: method_missing" do
-  it "does method_missing macro without args" do
+describe("Code gen: method_missing") do
+  it("does method_missing macro without args") do
     run("
       class Foo
         def foo_something
@@ -17,7 +17,7 @@ describe "Code gen: method_missing" do
       ").to_i.should eq(1)
   end
 
-  it "does method_missing macro with args" do
+  it("does method_missing macro with args") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -29,7 +29,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(6)
   end
 
-  it "does method_missing macro with block" do
+  it("does method_missing macro with block") do
     run(%(
       class Foo
         def foo_something
@@ -51,7 +51,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(6)
   end
 
-  it "does method_missing macro with block but not using it" do
+  it("does method_missing macro with block but not using it") do
     run(%(
       class Foo
         def foo_something
@@ -67,7 +67,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(3)
   end
 
-  it "does method_missing macro with virtual type (1)" do
+  it("does method_missing macro with virtual type (1)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -83,7 +83,7 @@ describe "Code gen: method_missing" do
       )).to_string.should eq("Foococo")
   end
 
-  it "does method_missing macro with virtual type (2)" do
+  it("does method_missing macro with virtual type (2)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -99,7 +99,7 @@ describe "Code gen: method_missing" do
       )).to_string.should eq("Barcoco")
   end
 
-  it "does method_missing macro with virtual type (3)" do
+  it("does method_missing macro with virtual type (3)") do
     run(%(
       class Foo
         def lala
@@ -119,7 +119,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(1)
   end
 
-  it "does method_missing macro with virtual type (4)" do
+  it("does method_missing macro with virtual type (4)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -138,7 +138,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(2)
   end
 
-  it "does method_missing macro with virtual type (5)" do
+  it("does method_missing macro with virtual type (5)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -163,7 +163,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(3)
   end
 
-  it "does method_missing macro with virtual type (6)" do
+  it("does method_missing macro with virtual type (6)") do
     run(%(
       abstract class Foo
       end
@@ -185,7 +185,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(2)
   end
 
-  it "does method_missing macro with virtual type (7)" do
+  it("does method_missing macro with virtual type (7)") do
     run(%(
       abstract class Foo
       end
@@ -207,7 +207,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(3)
   end
 
-  it "does method_missing macro with virtual type (8)" do
+  it("does method_missing macro with virtual type (8)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -226,7 +226,7 @@ describe "Code gen: method_missing" do
       )).to_string.should eq("Bar")
   end
 
-  it "does method_missing macro with module involved" do
+  it("does method_missing macro with module involved") do
     run("
       module Moo
         def lala
@@ -246,7 +246,7 @@ describe "Code gen: method_missing" do
       ").to_i.should eq(1)
   end
 
-  it "does method_missing macro with top level method involved" do
+  it("does method_missing macro with top level method involved") do
     run("
       def lala
         1
@@ -267,7 +267,7 @@ describe "Code gen: method_missing" do
       ").to_i.should eq(1)
   end
 
-  it "does method_missing macro with included module" do
+  it("does method_missing macro with included module") do
     run("
       module Moo
         macro method_missing(call)
@@ -283,7 +283,7 @@ describe "Code gen: method_missing" do
       ").to_string.should eq("Foo")
   end
 
-  it "does method_missing with assignment (bug)" do
+  it("does method_missing with assignment (bug)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -297,7 +297,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(1)
   end
 
-  it "does method_missing with assignment (2) (bug)" do
+  it("does method_missing with assignment (2) (bug)") do
     run(%(
       struct Nil
         def to_i
@@ -319,7 +319,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(1)
   end
 
-  it "does method_missing macro without args (with call)" do
+  it("does method_missing macro without args (with call)") do
     run("
       class Foo
         def foo_something
@@ -335,7 +335,7 @@ describe "Code gen: method_missing" do
       ").to_i.should eq(1)
   end
 
-  it "does method_missing macro with args (with call)" do
+  it("does method_missing macro with args (with call)") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -347,7 +347,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(6)
   end
 
-  it "forwards" do
+  it("forwards") do
     run(%(
       class Wrapped
         def foo(x, y, z)
@@ -368,7 +368,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(6)
   end
 
-  it "does method_missing generating method" do
+  it("does method_missing generating method") do
     run(%(
       class Foo
         macro method_missing(call)
@@ -382,7 +382,7 @@ describe "Code gen: method_missing" do
       )).to_string.should eq("bar")
   end
 
-  it "works with named arguments, using names (#3654)" do
+  it("works with named arguments, using names (#3654)") do
     run(%(
       class A
         macro method_missing(call)
@@ -395,7 +395,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(3)
   end
 
-  it "works with named arguments, named args in call (#3654)" do
+  it("works with named arguments, named args in call (#3654)") do
     run(%(
       class A
         macro method_missing(call)
@@ -409,7 +409,7 @@ describe "Code gen: method_missing" do
       )).to_i.should eq(3)
   end
 
-  it "finds method_missing with 'with ... yield'" do
+  it("finds method_missing with 'with ... yield'") do
     run(%(
       class Foo
         def initialize(@x : Int32)

--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: module" do
-  it "codegens pointer of module with method" do
+describe("Code gen: module") do
+  it("codegens pointer of module with method") do
     run("
       module Moo
       end
@@ -20,7 +20,7 @@ describe "Code gen: module" do
       ").to_i.should eq(1)
   end
 
-  it "codegens pointer of module with method with two including types" do
+  it("codegens pointer of module with method with two including types") do
     run("
       module Moo
       end
@@ -48,7 +48,7 @@ describe "Code gen: module" do
       ").to_i.should eq(2)
   end
 
-  it "codegens pointer of module with method with two including types with one struct" do
+  it("codegens pointer of module with method with two including types with one struct") do
     run("
       module Foo
       end
@@ -76,7 +76,7 @@ describe "Code gen: module" do
       ").to_i.should eq(2)
   end
 
-  it "codegens pointer of module with method with two including types with one struct (2)" do
+  it("codegens pointer of module with method with two including types with one struct (2)") do
     run("
       module Foo
       end
@@ -105,7 +105,7 @@ describe "Code gen: module" do
       ").to_i.should eq(2)
   end
 
-  it "codegens pointer of module and pass value to method" do
+  it("codegens pointer of module and pass value to method") do
     run(%(
       module Foo
       end
@@ -128,7 +128,7 @@ describe "Code gen: module" do
       )).to_i.should eq(1)
   end
 
-  it "codegens pointer of module with block" do
+  it("codegens pointer of module with block") do
     run(%(
       require "prelude"
 
@@ -159,7 +159,7 @@ describe "Code gen: module" do
       )).to_i.should eq(1)
   end
 
-  it "codegens module with virtual type" do
+  it("codegens module with virtual type") do
     run(%(
       module Moo
       end
@@ -184,7 +184,7 @@ describe "Code gen: module" do
       )).to_i.should eq(2)
   end
 
-  it "declares proc with module type" do
+  it("declares proc with module type") do
     run(%(
       module Moo
         def moo
@@ -205,7 +205,7 @@ describe "Code gen: module" do
       )).to_i.should eq(1)
   end
 
-  it "declares proc with module type and invoke it with two different types that return themselves" do
+  it("declares proc with module type and invoke it with two different types that return themselves") do
     codegen(%(
       module Moo
         def moo
@@ -227,7 +227,7 @@ describe "Code gen: module" do
       ))
   end
 
-  it "codegens proc of a module that was never included" do
+  it("codegens proc of a module that was never included") do
     codegen(%(
       require "prelude"
 
@@ -239,7 +239,7 @@ describe "Code gen: module" do
       ))
   end
 
-  it "codegens proc of module when generic type includes it" do
+  it("codegens proc of module when generic type includes it") do
     run(%(
       module Moo
       end
@@ -257,7 +257,7 @@ describe "Code gen: module" do
       )).to_i.should eq(3)
   end
 
-  it "invokes method on yielded module that has no instances (#1079)" do
+  it("invokes method on yielded module that has no instances (#1079)") do
     run(%(
       require "prelude"
 
@@ -276,7 +276,7 @@ describe "Code gen: module" do
       )).to_i.should eq(456)
   end
 
-  it "expands modules to its including types (#1916)" do
+  it("expands modules to its including types (#1916)") do
     run(%(
       class Reference
         def method(other : Reference)
@@ -306,7 +306,7 @@ describe "Code gen: module" do
       )).to_i.should eq(1)
   end
 
-  it "expands modules to its including types (2) (#1916)" do
+  it("expands modules to its including types (2) (#1916)") do
     run(%(
       class Reference
         def method(other : Reference)
@@ -336,7 +336,7 @@ describe "Code gen: module" do
       )).to_i.should eq(1)
   end
 
-  it "expands modules to its including types (3) (#1916)" do
+  it("expands modules to its including types (3) (#1916)") do
     run(%(
       class Object
         def method(other : Reference)
@@ -366,7 +366,7 @@ describe "Code gen: module" do
       )).to_i.should eq(2)
   end
 
-  it "codegens cast to module with class and struct to nilable module" do
+  it("codegens cast to module with class and struct to nilable module") do
     run(%(
       module Moo
         def bar
@@ -396,7 +396,7 @@ describe "Code gen: module" do
       )).to_i.should eq(10)
   end
 
-  it "codegens cast to module that includes bool" do
+  it("codegens cast to module that includes bool") do
     run(%(
       module Moo
       end
@@ -419,7 +419,7 @@ describe "Code gen: module" do
       )).to_i.should eq(2)
   end
 
-  it "declares and includes generic module, in macros T is a tuple literal" do
+  it("declares and includes generic module, in macros T is a tuple literal") do
     run(%(
       module Moo(*T)
         def t
@@ -435,7 +435,7 @@ describe "Code gen: module" do
       )).to_string.should eq("TupleLiteral")
   end
 
-  it "can instantiate generic module" do
+  it("can instantiate generic module") do
     run(%(
       struct Int32
         def self.foo
@@ -453,7 +453,7 @@ describe "Code gen: module" do
       )).to_i.should eq(10)
   end
 
-  it "can use generic module as instance variable type" do
+  it("can use generic module as instance variable type") do
     run(%(
       module Moo(T)
         def foo
@@ -492,7 +492,7 @@ describe "Code gen: module" do
       )).to_i.should eq(3)
   end
 
-  it "can use generic module as instance variable type (2)" do
+  it("can use generic module as instance variable type (2)") do
     run(%(
       module Moo(T)
         def foo
@@ -531,7 +531,7 @@ describe "Code gen: module" do
       )).to_i.should eq(3)
   end
 
-  it "casts to union of module that is included in other module (#3323)" do
+  it("casts to union of module that is included in other module (#3323)") do
     run(%(
       require "prelude"
 
@@ -564,7 +564,7 @@ describe "Code gen: module" do
       )).to_i.should eq(10)
   end
 
-  it "casts to union of generic module that is included in other module (#3323)" do
+  it("casts to union of generic module that is included in other module (#3323)") do
     run(%(
       require "prelude"
 
@@ -597,7 +597,7 @@ describe "Code gen: module" do
       )).to_i.should eq(10)
   end
 
-  it "codegend dispatch of union with module (#3647)" do
+  it("codegend dispatch of union with module (#3647)") do
     run(%(
       module Moo
       end

--- a/spec/compiler/codegen/named_args_spec.cr
+++ b/spec/compiler/codegen/named_args_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: named args" do
-  it "calls with named arg" do
+describe("Code gen: named args") do
+  it("calls with named arg") do
     run(%(
       def foo(y = 2)
         y
@@ -11,7 +11,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(10)
   end
 
-  it "calls with named arg and other args" do
+  it("calls with named arg and other args") do
     run(%(
       def foo(x, y = 2, z = 3)
         x + y + z
@@ -21,7 +21,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(13)
   end
 
-  it "calls with named arg as object method" do
+  it("calls with named arg as object method") do
     run(%(
       class Foo
         def foo(x, y = 2, z = 3)
@@ -33,7 +33,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(13)
   end
 
-  it "calls twice with different types" do
+  it("calls twice with different types") do
     run(%(
       def add(x, y = 1)
         x + y
@@ -46,7 +46,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(5)
   end
 
-  it "calls new with named arg" do
+  it("calls new with named arg") do
     run(%(
       class Foo
         @value : Int32
@@ -64,7 +64,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(13)
   end
 
-  it "uses named args in dispatch" do
+  it("uses named args in dispatch") do
     run(%(
       class Foo
         def foo(x, z = 2)
@@ -83,7 +83,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(22)
   end
 
-  it "sends one regular argument as named argument" do
+  it("sends one regular argument as named argument") do
     run(%(
       def foo(x)
         x
@@ -93,7 +93,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(42)
   end
 
-  it "sends two regular arguments as named arguments" do
+  it("sends two regular arguments as named arguments") do
     run(%(
       def foo(x, y)
         x + y
@@ -103,7 +103,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(42)
   end
 
-  it "sends two regular arguments as named arguments in inverted position (1)" do
+  it("sends two regular arguments as named arguments in inverted position (1)") do
     run(%(
       def foo(x, y)
         x
@@ -113,7 +113,7 @@ describe "Code gen: named args" do
       )).to_string.should eq("foo")
   end
 
-  it "sends two regular arguments as named arguments in inverted position (2)" do
+  it("sends two regular arguments as named arguments in inverted position (2)") do
     run(%(
       def foo(x, y)
         y
@@ -123,7 +123,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(42)
   end
 
-  it "overloads based on required named args" do
+  it("overloads based on required named args") do
     run(%(
       def foo(x, *, y)
         x + y
@@ -139,7 +139,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(10 + 20 + 30*40)
   end
 
-  it "overloads based on required named args, with restrictions" do
+  it("overloads based on required named args, with restrictions") do
     run(%(
       def foo(x, *, z : Int32)
         x + z
@@ -155,7 +155,7 @@ describe "Code gen: named args" do
       )).to_i.should eq(10 + 20 + 30*40)
   end
 
-  it "uses bare splat in new (2)" do
+  it("uses bare splat in new (2)") do
     run(%(
       class Foo
         def initialize(*, y = 22)

--- a/spec/compiler/codegen/named_tuple_spec.cr
+++ b/spec/compiler/codegen/named_tuple_spec.cr
@@ -1,42 +1,42 @@
 require "../../spec_helper"
 
-describe "Code gen: named tuple" do
-  it "codegens tuple index" do
+describe("Code gen: named tuple") do
+  it("codegens tuple index") do
     run(%(
       t = {x: 42, y: 'a'}
       t[:x]
       )).to_i.should eq(42)
   end
 
-  it "codegens tuple index another order" do
+  it("codegens tuple index another order") do
     run(%(
       t = {y: 'a', x: 42}
       t[:x]
       )).to_i.should eq(42)
   end
 
-  it "codegens tuple nilable index (1)" do
+  it("codegens tuple nilable index (1)") do
     run(%(
       t = {x: 42, y: 'a'}
       t[:x]? || 84
       )).to_i.should eq(42)
   end
 
-  it "codegens tuple nilable index (2)" do
+  it("codegens tuple nilable index (2)") do
     run(%(
       t = {x: 'a', y: 42}
       t[:y]? || 84
       )).to_i.should eq(42)
   end
 
-  it "codegens tuple nilable index (3)" do
+  it("codegens tuple nilable index (3)") do
     run(%(
       t = {x: 'a', y: 42}
       t[:z]? || 84
       )).to_i.should eq(84)
   end
 
-  it "passes named tuple to def" do
+  it("passes named tuple to def") do
     run("
       def foo(t)
         t[:x]
@@ -46,7 +46,7 @@ describe "Code gen: named tuple" do
       ").to_i.should eq(42)
   end
 
-  it "gets size at compile time" do
+  it("gets size at compile time") do
     run(%(
       struct NamedTuple
         def my_size
@@ -58,7 +58,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(2)
   end
 
-  it "gets keys at compile time (1)" do
+  it("gets keys at compile time (1)") do
     run(%(
       struct NamedTuple
         def keys
@@ -70,7 +70,7 @@ describe "Code gen: named tuple" do
       )).to_string.should eq("x")
   end
 
-  it "gets keys at compile time (2)" do
+  it("gets keys at compile time (2)") do
     run(%(
       struct NamedTuple
         def keys
@@ -82,7 +82,7 @@ describe "Code gen: named tuple" do
       )).to_string.should eq("y")
   end
 
-  it "doesn't crash when overload doesn't match" do
+  it("doesn't crash when overload doesn't match") do
     codegen(%(
       struct NamedTuple
         def foo(other : self)
@@ -98,7 +98,7 @@ describe "Code gen: named tuple" do
       ))
   end
 
-  it "assigns named tuple to compatible named tuple" do
+  it("assigns named tuple to compatible named tuple") do
     run(%(
       ptr = Pointer({x: Int32, y: String}).malloc(1_u64)
 
@@ -110,7 +110,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts named tuple inside compatible named tuple" do
+  it("upcasts named tuple inside compatible named tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -126,7 +126,7 @@ describe "Code gen: named tuple" do
       )).to_string.should eq("Bar")
   end
 
-  it "assigns named tuple union to compatible named tuple" do
+  it("assigns named tuple union to compatible named tuple") do
     run(%(
       tup1 = {x: 1, y: "foo"}
       tup2 = {x: 3}
@@ -142,7 +142,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts named tuple union to compatible named tuple" do
+  it("upcasts named tuple union to compatible named tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -156,7 +156,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "assigns named tuple inside union to union with compatible named tuple" do
+  it("assigns named tuple inside union to union with compatible named tuple") do
     run(%(
       tup1 = {x: 21, y: "foo"}
       tup2 = {x: 3}
@@ -178,7 +178,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts named tuple inside union to union with compatible named tuple" do
+  it("upcasts named tuple inside union to union with compatible named tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -201,7 +201,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "allows named tuple covariance" do
+  it("allows named tuple covariance") do
     run(%(
        class Obj
          def initialize
@@ -234,7 +234,7 @@ describe "Code gen: named tuple" do
        )).to_i.should eq(42)
   end
 
-  it "merges two named tuple types with same keys but different types (1)" do
+  it("merges two named tuple types with same keys but different types (1)") do
     run(%(
        def foo
          if 1 == 2
@@ -249,7 +249,7 @@ describe "Code gen: named tuple" do
        )).to_i.should eq(20)
   end
 
-  it "merges two named tuple types with same keys but different types (2)" do
+  it("merges two named tuple types with same keys but different types (2)") do
     run(%(
        def foo
          if 1 == 1
@@ -264,7 +264,7 @@ describe "Code gen: named tuple" do
        )).to_i.should eq(10)
   end
 
-  it "codegens union of tuple of float with tuple of tuple of float" do
+  it("codegens union of tuple of float with tuple of tuple of float") do
     run(%(
       a = {x: 1.5}
       b = {x: {22.0, 20.0} }
@@ -278,7 +278,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(42)
   end
 
-  it "provides T as a named tuple literal" do
+  it("provides T as a named tuple literal") do
     run(%(
       struct NamedTuple
         def self.foo
@@ -289,7 +289,7 @@ describe "Code gen: named tuple" do
       )).to_string.should eq("NamedTupleLiteral")
   end
 
-  it "assigns two same-size named tuple types to a same var (#3132)" do
+  it("assigns two same-size named tuple types to a same var (#3132)") do
     run(%(
       t = {x: true}
       t
@@ -298,7 +298,7 @@ describe "Code gen: named tuple" do
       )).to_i.should eq(2)
   end
 
-  it "downcasts union inside tuple to value (#3907)" do
+  it("downcasts union inside tuple to value (#3907)") do
     codegen(%(
       struct Foo
       end
@@ -311,7 +311,7 @@ describe "Code gen: named tuple" do
       ))
   end
 
-  it "accesses T and creates instance from it" do
+  it("accesses T and creates instance from it") do
     run("
       struct NamedTuple
         def named_args

--- a/spec/compiler/codegen/new_spec.cr
+++ b/spec/compiler/codegen/new_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: new" do
-  it "codegens instance method with allocate" do
+describe("Code gen: new") do
+  it("codegens instance method with allocate") do
     run(%(
       class Foo
         def coco
@@ -13,7 +13,7 @@ describe "Code gen: new" do
       )).to_i.should eq(1)
   end
 
-  it "codegens instance method with new and instance var" do
+  it("codegens instance method with new and instance var") do
     run(%(
       class Foo
         def initialize
@@ -31,7 +31,7 @@ describe "Code gen: new" do
       )).to_i.should eq(1)
   end
 
-  it "codegens instance method with new" do
+  it("codegens instance method with new") do
     run(%(
       class Foo
         def coco
@@ -43,13 +43,13 @@ describe "Code gen: new" do
       )).to_i.should eq(1)
   end
 
-  it "can create Reference" do
+  it("can create Reference") do
     run(%(
       Reference.new.object_id == 0
       )).to_b.should be_false
   end
 
-  it "inherits initialize" do
+  it("inherits initialize") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -67,7 +67,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "inherits initialize for generic type" do
+  it("inherits initialize for generic type") do
     run(%(
       class Foo(T)
         def initialize(@x : Int32)
@@ -84,7 +84,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "overloads new and initialize, 1 (#2489)" do
+  it("overloads new and initialize, 1 (#2489)") do
     run(%(
       class String
         def size
@@ -113,7 +113,7 @@ describe "Code gen: new" do
       )).to_i.should eq(10)
   end
 
-  it "overloads new and initialize, 2 (#2489)" do
+  it("overloads new and initialize, 2 (#2489)") do
     run(%(
       class Global
         @@x = 0
@@ -144,7 +144,7 @@ describe "Code gen: new" do
       )).to_i.should eq(6)
   end
 
-  it "overloads new and initialize, 3 (#2489)" do
+  it("overloads new and initialize, 3 (#2489)") do
     run(%(
       class Global
         @@x = 0
@@ -173,7 +173,7 @@ describe "Code gen: new" do
       )).to_i.should eq(6)
   end
 
-  it "defines new for module" do
+  it("defines new for module") do
     run(%(
       module Moo
         @x : Int32
@@ -195,7 +195,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "finds super in deep hierarchy" do
+  it("finds super in deep hierarchy") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -222,7 +222,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "finds new in superclass if no initialize is defined (1)" do
+  it("finds new in superclass if no initialize is defined (1)") do
     run(%(
       class Foo
         def self.new
@@ -237,7 +237,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "finds new in superclass if no initialize is defined (2)" do
+  it("finds new in superclass if no initialize is defined (2)") do
     run(%(
       class Foo
         def self.new
@@ -255,7 +255,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "finds new in superclass for Enum" do
+  it("finds new in superclass for Enum") do
     run(%(
       struct Enum
         def self.new(x : String)
@@ -274,7 +274,7 @@ describe "Code gen: new" do
       )).to_i.should eq(1)
   end
 
-  it "can create Tuple with Tuple.new" do
+  it("can create Tuple with Tuple.new") do
     run(%(
       require "prelude"
 
@@ -282,7 +282,7 @@ describe "Code gen: new" do
       )).to_i.should eq(0)
   end
 
-  it "evaluates initialize default value at the instance scope (1) (#731)" do
+  it("evaluates initialize default value at the instance scope (1) (#731)") do
     run(%(
       class Foo
         @x : Int32
@@ -303,7 +303,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "evaluates initialize default value at the instance scope (2) (#731)" do
+  it("evaluates initialize default value at the instance scope (2) (#731)") do
     run(%(
       class Foo
         @x : Int32
@@ -329,7 +329,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "evaluates initialize default value at the instance scope (3) (#731)" do
+  it("evaluates initialize default value at the instance scope (3) (#731)") do
     run(%(
       class Foo
         @x : Int32
@@ -357,7 +357,7 @@ describe "Code gen: new" do
       )).to_i.should eq(42)
   end
 
-  it "evaluates initialize default value at the instance scope (4) (#731)" do
+  it("evaluates initialize default value at the instance scope (4) (#731)") do
     run(%(
       class Foo
         @x : Int32

--- a/spec/compiler/codegen/next_spec.cr
+++ b/spec/compiler/codegen/next_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: next" do
-  it "codegens next" do
+describe("Code gen: next") do
+  it("codegens next") do
     run("
       def foo
         yield
@@ -13,7 +13,7 @@ describe "Code gen: next" do
       ").to_i.should eq(1)
   end
 
-  it "codegens next conditionally" do
+  it("codegens next conditionally") do
     run("
       def foo
         yield 1
@@ -31,7 +31,7 @@ describe "Code gen: next" do
       ").to_i.should eq(4)
   end
 
-  it "codegens next conditionally with int type (2)" do
+  it("codegens next conditionally with int type (2)") do
     run("
       def foo
         x = 0
@@ -55,7 +55,7 @@ describe "Code gen: next" do
       ").to_i.should eq(100)
   end
 
-  it "codegens next with break (1)" do
+  it("codegens next with break (1)") do
     run("
       def foo
         yield 1
@@ -71,7 +71,7 @@ describe "Code gen: next" do
       ").to_i.should eq(20)
   end
 
-  it "codegens next with break (2)" do
+  it("codegens next with break (2)") do
     run("
       def foo
         a = 0
@@ -91,7 +91,7 @@ describe "Code gen: next" do
       ").to_i.should eq(40)
   end
 
-  it "codegens next with break (3)" do
+  it("codegens next with break (3)") do
     run("
       def foo
         a = 0
@@ -111,7 +111,7 @@ describe "Code gen: next" do
       ").to_i.should eq(20)
   end
 
-  it "codegens next with while inside block" do
+  it("codegens next with while inside block") do
     run("
       def foo
         a = 0
@@ -136,7 +136,7 @@ describe "Code gen: next" do
       ").to_i.should eq(30)
   end
 
-  it "codegens next without expressions" do
+  it("codegens next without expressions") do
     run("
       struct Nil; def to_i; 0; end; end
 

--- a/spec/compiler/codegen/nilable_cast_spec.cr
+++ b/spec/compiler/codegen/nilable_cast_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: nilable cast" do
-  it "does nilable cast (true)" do
+describe("Code gen: nilable cast") do
+  it("does nilable cast (true)") do
     run(%(
       x = 42 || "hello"
       y = x.as?(Int32)
@@ -9,7 +9,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(42)
   end
 
-  it "does nilable cast (false)" do
+  it("does nilable cast (false)") do
     run(%(
       x = "hello" || 42
       y = x.as?(Int32)
@@ -17,7 +17,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(84)
   end
 
-  it "does nilable cast (always true)" do
+  it("does nilable cast (always true)") do
     run(%(
       x = 42
       y = x.as?(Int32)
@@ -25,7 +25,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(42)
   end
 
-  it "does upcast" do
+  it("does upcast") do
     run(%(
       class Foo
         def bar
@@ -48,7 +48,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(2)
   end
 
-  it "does cast to nil (1)" do
+  it("does cast to nil (1)") do
     run(%(
       x = 1
       y = x.as?(Nil)
@@ -56,7 +56,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(3)
   end
 
-  it "does cast to nil (2)" do
+  it("does cast to nil (2)") do
     run(%(
       x = nil
       y = x.as?(Nil)
@@ -64,14 +64,14 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(3)
   end
 
-  it "types as? with wrong type (#2775)" do
+  it("types as? with wrong type (#2775)") do
     run(%(
       x = 1.as?(String)
       x ? 10 : 20
       )).to_i.should eq(20)
   end
 
-  it "codegens with NoReturn" do
+  it("codegens with NoReturn") do
     codegen(%(
       lib LibC
         fun exit : NoReturn
@@ -86,7 +86,7 @@ describe "Code gen: nilable cast" do
       ))
   end
 
-  it "upcasts type to virtual (#3304)" do
+  it("upcasts type to virtual (#3304)") do
     run(%(
       class Foo
         def foo
@@ -105,7 +105,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(1)
   end
 
-  it "upcasts type to virtual (2) (#3304)" do
+  it("upcasts type to virtual (2) (#3304)") do
     run(%(
       class Foo
         def foo
@@ -130,7 +130,7 @@ describe "Code gen: nilable cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts with block var that changes type (#3341)" do
+  it("casts with block var that changes type (#3341)") do
     codegen(%(
       require "prelude"
 

--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Code gen: no return" do
-  it "codegens if with NoReturn on then and union on else" do
+describe("Code gen: no return") do
+  it("codegens if with NoReturn on then and union on else") do
     run("lib LibC; fun exit(c : Int32) : NoReturn; end; (if 1 == 2; LibC.exit(1); else; 1 || 2.5; end).to_i").to_i.should eq(1)
   end
 
-  it "codegens Pointer(NoReturn).malloc" do
+  it("codegens Pointer(NoReturn).malloc") do
     run("Pointer(NoReturn).malloc(1_u64); 1").to_i.should eq(1)
   end
 
-  it "codegens if with no reutrn and variable used afterwards" do
+  it("codegens if with no reutrn and variable used afterwards") do
     codegen(%(
       require "prelude"
 
@@ -22,7 +22,7 @@ describe "Code gen: no return" do
       ))
   end
 
-  it "codegen types exception handler as NoReturn if ensure is NoReturn" do
+  it("codegen types exception handler as NoReturn if ensure is NoReturn") do
     codegen(%(
       require "prelude"
 
@@ -38,14 +38,14 @@ describe "Code gen: no return" do
       ))
   end
 
-  it "codegens no return variable declaration (#1508)" do
+  it("codegens no return variable declaration (#1508)") do
     run(%(
       foo = uninitialized NoReturn
       1
       )).to_i.should eq(1)
   end
 
-  it "codegens no return instance variable declaration (#1508)" do
+  it("codegens no return instance variable declaration (#1508)") do
     run(%(
       class Foo
         def initialize
@@ -62,7 +62,7 @@ describe "Code gen: no return" do
       )).to_i.should eq(1)
   end
 
-  it "codegens call with no return because of falsey if (#3661)" do
+  it("codegens call with no return because of falsey if (#3661)") do
     codegen(%(
       lib LibC
         fun exit(Int32) : NoReturn

--- a/spec/compiler/codegen/not_spec.cr
+++ b/spec/compiler/codegen/not_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Code gen: not" do
-  it "codegens not number" do
+describe("Code gen: not") do
+  it("codegens not number") do
     run("!1").to_b.should be_false
   end
 
-  it "codegens not true" do
+  it("codegens not true") do
     run("!true").to_b.should be_false
   end
 
-  it "codegens not false" do
+  it("codegens not false") do
     run("!false").to_b.should be_true
   end
 
-  it "codegens not nil" do
+  it("codegens not nil") do
     run("!nil").to_b.should be_true
   end
 
-  it "codegens not nilable type (true)" do
+  it("codegens not nilable type (true)") do
     run(%(
       class Foo
       end
@@ -27,7 +27,7 @@ describe "Code gen: not" do
       )).to_b.should be_true
   end
 
-  it "codegens not nilable type (false)" do
+  it("codegens not nilable type (false)") do
     run(%(
       class Foo
       end
@@ -37,19 +37,19 @@ describe "Code gen: not" do
       )).to_b.should be_false
   end
 
-  it "codegens not pointer (true)" do
+  it("codegens not pointer (true)") do
     run(%(
       !Pointer(Int32).new(0_u64)
       )).to_b.should be_true
   end
 
-  it "codegens not pointer (false)" do
+  it("codegens not pointer (false)") do
     run(%(
       !Pointer(Int32).new(1_u64)
       )).to_b.should be_false
   end
 
-  it "doesn't crash" do
+  it("doesn't crash") do
     run(%(
       a = 1
       !a.is_a?(String) && !a

--- a/spec/compiler/codegen/op_assign_spec.cr
+++ b/spec/compiler/codegen/op_assign_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: op assign" do
-  it "evaluates exps once (#3398)" do
+describe("Code gen: op assign") do
+  it("evaluates exps once (#3398)") do
     run(%(
       class Global
         @@value = 0
@@ -34,7 +34,7 @@ describe "Code gen: op assign" do
       )).to_i.should eq(1)
   end
 
-  it "evaluates exps once, [] (#3398)" do
+  it("evaluates exps once, [] (#3398)") do
     run(%(
       class Global
         @@value = 0

--- a/spec/compiler/codegen/or_spec.cr
+++ b/spec/compiler/codegen/or_spec.cr
@@ -1,43 +1,43 @@
 require "../../spec_helper"
 
-describe "Code gen: or" do
-  it "codegens or with bool false and false" do
+describe("Code gen: or") do
+  it("codegens or with bool false and false") do
     run("false || false").to_b.should be_false
   end
 
-  it "codegens or with bool false and true" do
+  it("codegens or with bool false and true") do
     run("false || true").to_b.should be_true
   end
 
-  it "codegens or with bool true and true" do
+  it("codegens or with bool true and true") do
     run("true || true").to_b.should be_true
   end
 
-  it "codegens or with bool true and false" do
+  it("codegens or with bool true and false") do
     run("true || false").to_b.should be_true
   end
 
-  it "codegens or with bool and int 1" do
+  it("codegens or with bool and int 1") do
     run("struct Bool; def to_i; 0; end; end; (false || 2).to_i").to_i.should eq(2)
   end
 
-  it "codegens or with bool and int 2" do
+  it("codegens or with bool and int 2") do
     run("struct Bool; def to_i; 0; end; end; (true || 2).to_i").to_i.should eq(0)
   end
 
-  it "codegens or with primitive type other than bool" do
+  it("codegens or with primitive type other than bool") do
     run("1 || 2").to_i.should eq(1)
   end
 
-  it "codegens or with primitive type other than bool with union" do
+  it("codegens or with primitive type other than bool with union") do
     run("(1 || 1.5).to_f").to_f64.should eq(1)
   end
 
-  it "codegens or with primitive type other than bool" do
+  it("codegens or with primitive type other than bool") do
     run("require \"nil\"; (nil || 2).to_i").to_i.should eq(2)
   end
 
-  it "codegens or with nilable as left node 1" do
+  it("codegens or with nilable as left node 1") do
     run("
       require \"nil\"
       class Object; def to_i; -1; end; end
@@ -47,7 +47,7 @@ describe "Code gen: or" do
     ").to_i.should eq(2)
   end
 
-  it "codegens or with nilable as left node 2" do
+  it("codegens or with nilable as left node 2") do
     run("
       class Object; def to_i; -1; end; end
       a = nil
@@ -56,7 +56,7 @@ describe "Code gen: or" do
     ").to_i.should eq(-1)
   end
 
-  it "codegens or with non-false union as left node" do
+  it("codegens or with non-false union as left node") do
     run("
       a = 1.5
       a = 1
@@ -64,7 +64,7 @@ describe "Code gen: or" do
     ").to_i.should eq(1)
   end
 
-  it "codegens or with nil union as left node 1" do
+  it("codegens or with nil union as left node 1") do
     run("
       require \"nil\"
       a = nil
@@ -73,7 +73,7 @@ describe "Code gen: or" do
     ").to_i.should eq(1)
   end
 
-  it "codegens or with nil union as left node 2" do
+  it("codegens or with nil union as left node 2") do
     run("
       require \"nil\"
       a = 1
@@ -82,7 +82,7 @@ describe "Code gen: or" do
     ").to_i.should eq(2)
   end
 
-  it "codegens or with bool union as left node 1" do
+  it("codegens or with bool union as left node 1") do
     run("
       struct Bool; def to_i; 0; end; end
       a = false
@@ -91,7 +91,7 @@ describe "Code gen: or" do
     ").to_i.should eq(1)
   end
 
-  it "codegens or with bool union as left node 2" do
+  it("codegens or with bool union as left node 2") do
     run("
       struct Bool; def to_i; 0; end; end
       a = 1
@@ -100,7 +100,7 @@ describe "Code gen: or" do
     ").to_i.should eq(2)
   end
 
-  it "codegens or with bool union as left node 3" do
+  it("codegens or with bool union as left node 3") do
     run("
       struct Bool; def to_i; 0; end; end
       a = 1
@@ -109,7 +109,7 @@ describe "Code gen: or" do
     ").to_i.should eq(0)
   end
 
-  it "codegens or with bool union as left node 1" do
+  it("codegens or with bool union as left node 1") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -120,7 +120,7 @@ describe "Code gen: or" do
     ").to_i.should eq(2)
   end
 
-  it "codegens or with bool union as left node 2" do
+  it("codegens or with bool union as left node 2") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -131,7 +131,7 @@ describe "Code gen: or" do
     ").to_i.should eq(3)
   end
 
-  it "codegens or with bool union as left node 3" do
+  it("codegens or with bool union as left node 3") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
@@ -142,7 +142,7 @@ describe "Code gen: or" do
     ").to_i.should eq(1)
   end
 
-  it "codegens or with bool union as left node 4" do
+  it("codegens or with bool union as left node 4") do
     run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Code gen: pointer" do
-  it "get pointer and value of it" do
+describe("Code gen: pointer") do
+  it("get pointer and value of it") do
     run("a = 1; b = pointerof(a); b.value").to_i.should eq(1)
   end
 
-  it "get pointer of instance var" do
+  it("get pointer of instance var") do
     run("
       class Foo
         def initialize(value : Int32)
@@ -23,19 +23,19 @@ describe "Code gen: pointer" do
       ").to_i.should eq(10)
   end
 
-  it "set pointer value" do
+  it("set pointer value") do
     run("a = 1; b = pointerof(a); b.value = 2; a").to_i.should eq(2)
   end
 
-  it "get value of pointer to union" do
+  it("get value of pointer to union") do
     run("a = 1.1; a = 1; b = pointerof(a); b.value.to_i").to_i.should eq(1)
   end
 
-  it "sets value of pointer to union" do
+  it("sets value of pointer to union") do
     run("p = Pointer(Int32|Float64).malloc(1_u64); a = 1; a = 2.5; p.value = a; p.value.to_i").to_i.should eq(2)
   end
 
-  it "increments pointer" do
+  it("increments pointer") do
     run("
       class Foo
         def initialize
@@ -52,27 +52,27 @@ describe "Code gen: pointer" do
     ").to_i.should eq(2)
   end
 
-  it "codegens malloc" do
+  it("codegens malloc") do
     run("p = Pointer(Int32).malloc(10_u64); p.value = 1; p.value + 1_i64").to_i.should eq(2)
   end
 
-  it "codegens realloc" do
+  it("codegens realloc") do
     run("p = Pointer(Int32).malloc(10_u64); p.value = 1; x = p.realloc(20_u64); x.value + 1_i64").to_i.should eq(2)
   end
 
-  it "codegens pointer cast" do
+  it("codegens pointer cast") do
     run("a = 1_i64; pointerof(a).as(Int32*).value").to_i.should eq(1)
   end
 
-  it "codegens pointer as if condition" do
+  it("codegens pointer as if condition") do
     run("a = 0; pointerof(a) ? 1 : 2").to_i.should eq(1)
   end
 
-  it "codegens null pointer as if condition" do
+  it("codegens null pointer as if condition") do
     run("Pointer(Int32).new(0_u64) ? 1 : 2").to_i.should eq(2)
   end
 
-  it "gets pointer of instance variable in virtual type" do
+  it("gets pointer of instance variable in virtual type") do
     run("
       class Foo
         def initialize
@@ -93,7 +93,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(1)
   end
 
-  it "sets value of pointer to struct" do
+  it("sets value of pointer to struct") do
     run("
       lib LibC
         struct Color
@@ -113,7 +113,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(20)
   end
 
-  it "changes through var and reads from pointer" do
+  it("changes through var and reads from pointer") do
     run("
       x = 1
       px = pointerof(x)
@@ -122,21 +122,21 @@ describe "Code gen: pointer" do
       ").to_i.should eq(2)
   end
 
-  it "creates pointer by address" do
+  it("creates pointer by address") do
     run("
       x = Pointer(Int32).new(123_u64)
       x.address
     ").to_i.should eq(123)
   end
 
-  it "calculates pointer diff" do
+  it("calculates pointer diff") do
     run("
       x = 1
       (pointerof(x) + 1_i64) - pointerof(x)
     ").to_i.should eq(1)
   end
 
-  it "can dereference pointer to func" do
+  it("can dereference pointer to func") do
     run("
       def foo; 1; end
       x = ->foo
@@ -145,7 +145,7 @@ describe "Code gen: pointer" do
     ").to_i.should eq(1)
   end
 
-  it "gets pointer of argument that is never assigned to" do
+  it("gets pointer of argument that is never assigned to") do
     run("
       def foo(x)
         pointerof(x)
@@ -156,7 +156,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(1)
   end
 
-  it "codegens nilable pointer type (1)" do
+  it("codegens nilable pointer type (1)") do
     run("
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
@@ -169,7 +169,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(3)
   end
 
-  it "codegens nilable pointer type (2)" do
+  it("codegens nilable pointer type (2)") do
     run("
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
@@ -182,7 +182,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(4)
   end
 
-  it "codegens nilable pointer type dispatch (1)" do
+  it("codegens nilable pointer type dispatch (1)") do
     run("
       def foo(x : Pointer)
         x.value
@@ -199,7 +199,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(3)
   end
 
-  it "codegens nilable pointer type dispatch (2)" do
+  it("codegens nilable pointer type dispatch (2)") do
     run("
       def foo(x : Pointer)
         x.value
@@ -216,7 +216,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(0)
   end
 
-  it "assigns nil and pointer to nilable pointer type" do
+  it("assigns nil and pointer to nilable pointer type") do
     run("
       class Foo
         def initialize
@@ -245,14 +245,14 @@ describe "Code gen: pointer" do
       ").to_i.should eq(3)
   end
 
-  it "gets pointer to constant" do
+  it("gets pointer to constant") do
     run("
       FOO = 1
       pointerof(FOO).value
     ").to_i.should eq(1)
   end
 
-  it "passes pointer of pointer to method" do
+  it("passes pointer of pointer to method") do
     run("
       def foo(x)
         x.value.value
@@ -265,7 +265,7 @@ describe "Code gen: pointer" do
       ").to_i.should eq(1)
   end
 
-  it "codgens pointer as if condition inside union (1)" do
+  it("codgens pointer as if condition inside union (1)") do
     run(%(
       ptr = Pointer(Int32).new(0_u64) || Pointer(Float64).new(0_u64)
       if ptr
@@ -276,7 +276,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(2)
   end
 
-  it "codgens pointer as if condition inside union (2)" do
+  it("codgens pointer as if condition inside union (2)") do
     run(%(
       if 1 == 1
         ptr = Pointer(Int32).new(0_u64)
@@ -287,7 +287,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(30)
   end
 
-  it "can use typedef pointer value get and set (#630)" do
+  it("can use typedef pointer value get and set (#630)") do
     codegen(%(
       lib LibFoo
         type MyObj = Int32*
@@ -299,7 +299,7 @@ describe "Code gen: pointer" do
       ))
   end
 
-  it "does pointerof class variable" do
+  it("does pointerof class variable") do
     run(%(
       class Foo
         @@a = 1
@@ -318,7 +318,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(2)
   end
 
-  it "does pointerof class variable with class" do
+  it("does pointerof class variable with class") do
     run(%(
       class Bar
         def initialize(@x : Int32)
@@ -346,7 +346,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(2)
   end
 
-  it "does pointerof read variable" do
+  it("does pointerof read variable") do
     run(%(
       class Foo
         def initialize
@@ -364,7 +364,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(123)
   end
 
-  it "can assign nil to void pointer" do
+  it("can assign nil to void pointer") do
     codegen(%(
       require "prelude"
 
@@ -373,7 +373,7 @@ describe "Code gen: pointer" do
       ))
   end
 
-  it "can pass any pointer to something expecting void* in lib call" do
+  it("can pass any pointer to something expecting void* in lib call") do
     codegen(%(
       lib LibFoo
         fun foo(x : Void*) : Float64
@@ -383,7 +383,7 @@ describe "Code gen: pointer" do
       ))
   end
 
-  it "can pass any pointer to something expecting void* in lib call, with to_unsafe" do
+  it("can pass any pointer to something expecting void* in lib call, with to_unsafe") do
     codegen(%(
       lib LibFoo
         fun foo(x : Void*) : Float64
@@ -399,7 +399,7 @@ describe "Code gen: pointer" do
       ))
   end
 
-  it "uses correct llvm module for typedef metaclass (#2877)" do
+  it("uses correct llvm module for typedef metaclass (#2877)") do
     run(%(
       require "prelude"
 
@@ -431,7 +431,7 @@ describe "Code gen: pointer" do
       ))
   end
 
-  it "generates correct code for Pointer.malloc(0) (#2905)" do
+  it("generates correct code for Pointer.malloc(0) (#2905)") do
     run(%(
       require "prelude"
 
@@ -450,7 +450,7 @@ describe "Code gen: pointer" do
       )).to_i.should eq(3)
   end
 
-  it "compares pointers through typedef" do
+  it("compares pointers through typedef") do
     run(%(
       module Comparable(T)
         def ==(other : T)

--- a/spec/compiler/codegen/previous_def_spec.cr
+++ b/spec/compiler/codegen/previous_def_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "codegen: previous_def" do
-  it "codegens previous def" do
+describe("codegen: previous_def") do
+  it("codegens previous def") do
     run(%(
       def foo
         1
@@ -15,7 +15,7 @@ describe "codegen: previous_def" do
       )).to_i.should eq(2)
   end
 
-  it "codeges previous def when inside fun and forwards args" do
+  it("codeges previous def when inside fun and forwards args") do
     run(%(
       def foo(z)
         z + 1
@@ -30,7 +30,7 @@ describe "codegen: previous_def" do
       )).to_i.should eq(6)
   end
 
-  it "codegens previous def when inside fun with self" do
+  it("codegens previous def when inside fun with self") do
     run(%(
       class Foo
         def initialize

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -1,68 +1,68 @@
 require "../../spec_helper"
 
-describe "Code gen: primitives" do
-  it "codegens bool" do
+describe("Code gen: primitives") do
+  it("codegens bool") do
     run("true").to_b.should be_true
     run("false").to_b.should be_false
   end
 
-  it "codegens int" do
+  it("codegens int") do
     run("1").to_i.should eq(1)
   end
 
-  it "codegens long" do
+  it("codegens long") do
     run("1_i64").to_i.should eq(1)
   end
 
-  it "codegens char" do
+  it("codegens char") do
     run("'a'").to_i.should eq('a'.ord)
   end
 
-  it "codegens char ord" do
+  it("codegens char ord") do
     run("'a'.ord").to_i.should eq('a'.ord)
   end
 
-  it "codegens f32" do
+  it("codegens f32") do
     run("2.5_f32").to_f32.should eq(2.5_f32)
   end
 
-  it "codegens f64" do
+  it("codegens f64") do
     run("2.5_f64").to_f64.should eq(2.5_f64)
   end
 
-  it "codegens string" do
+  it("codegens string") do
     run(%("foo")).to_string.should eq("foo")
   end
 
-  it "codegens 1 + 2" do
+  it("codegens 1 + 2") do
     run(%(1 + 2)).to_i.should eq(3)
   end
 
-  it "codegens 1 + 2" do
+  it("codegens 1 + 2") do
     run(%(1 - 2)).to_i.should eq(-1)
   end
 
-  it "codegens 2 * 3" do
+  it("codegens 2 * 3") do
     run(%(2 * 3)).to_i.should eq(6)
   end
 
-  it "codegens 8.unsafe_div 3" do
+  it("codegens 8.unsafe_div 3") do
     run(%(8.unsafe_div 3)).to_i.should eq(2)
   end
 
-  it "codegens 8.unsafe_mod 3" do
+  it("codegens 8.unsafe_mod 3") do
     run(%(10.unsafe_mod 3)).to_i.should eq(1)
   end
 
-  it "codegens 16.unsafe_shr 2" do
+  it("codegens 16.unsafe_shr 2") do
     run(%(16.unsafe_shr 2)).to_i.should eq(4)
   end
 
-  it "codegens 16.unsafe_shl 2" do
+  it("codegens 16.unsafe_shl 2") do
     run(%(16.unsafe_shl 2)).to_i.should eq(64)
   end
 
-  it "defined method that calls primitive (bug)" do
+  it("defined method that calls primitive (bug)") do
     run("
       struct Int64
         def foo
@@ -75,14 +75,14 @@ describe "Code gen: primitives" do
       ").to_i.should eq(1)
   end
 
-  it "codegens __LINE__" do
+  it("codegens __LINE__") do
     run("
 
       __LINE__
       ", inject_primitives: false).to_i.should eq(3)
   end
 
-  it "codeges crystal_type_id with union type" do
+  it("codeges crystal_type_id with union type") do
     run("
       class Foo
       end
@@ -95,15 +95,15 @@ describe "Code gen: primitives" do
       ").to_b.should be_true
   end
 
-  it "doesn't treat `(1 == 1) == true` as `1 == 1 == true` (#328)" do
+  it("doesn't treat `(1 == 1) == true` as `1 == 1 == true` (#328)") do
     run("(1 == 1) == true").to_b.should be_true
   end
 
-  it "passes issue #328" do
+  it("passes issue #328") do
     run("((1 == 1) != (2 == 2))").to_b.should be_false
   end
 
-  pending "codegens pointer of int" do
+  pending("codegens pointer of int") do
     run(%(
       ptr = Pointer(Int).malloc(1_u64)
       ptr.value = 1
@@ -114,7 +114,7 @@ describe "Code gen: primitives" do
       )).to_i.should eq(5)
   end
 
-  pending "sums two numbers out of an [] of Number" do
+  pending("sums two numbers out of an [] of Number") do
     run(%(
       p = Pointer(Number).malloc(2_u64)
       p.value = 1
@@ -124,11 +124,11 @@ describe "Code gen: primitives" do
       )).to_f32.should eq(2.5)
   end
 
-  it "codegens crystal_type_id for class" do
+  it("codegens crystal_type_id for class") do
     codegen(%(String.crystal_type_id))
   end
 
-  it "can invoke cast on primitive typedef (#614)" do
+  it("can invoke cast on primitive typedef (#614)") do
     codegen(%(
       lib Test
         type K = Int32
@@ -139,7 +139,7 @@ describe "Code gen: primitives" do
       ))
   end
 
-  it "can invoke binary on primitive typedef (#614)" do
+  it("can invoke binary on primitive typedef (#614)") do
     codegen(%(
       lib Test
         type K = Int32
@@ -150,7 +150,7 @@ describe "Code gen: primitives" do
       ))
   end
 
-  it "allows redefining a primitive method" do
+  it("allows redefining a primitive method") do
     run(%(
       struct Int32
         def *(other : Int32)
@@ -162,7 +162,7 @@ describe "Code gen: primitives" do
       )).to_i.should eq(42)
   end
 
-  it "doesn't optimize away call whose obj is not passed as self (#2226)" do
+  it("doesn't optimize away call whose obj is not passed as self (#2226)") do
     run(%(
       class Global
         @@x = 0
@@ -186,7 +186,7 @@ describe "Code gen: primitives" do
       )).to_i.should eq(2)
   end
 
-  it "uses built-in llvm function that returns a tuple" do
+  it("uses built-in llvm function that returns a tuple") do
     run(%(
       lib Intrinsics
         fun sadd_i32_with_overlow = "llvm.sadd.with.overflow.i32"(a : Int32, b : Int32) : {Int32, Bool}
@@ -197,7 +197,7 @@ describe "Code gen: primitives" do
       )).to_i.should eq(3)
   end
 
-  it "gets crystal class instance type id" do
+  it("gets crystal class instance type id") do
     run(%(
       class Foo
       end

--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 require "tempfile"
 
-describe "Codegen: private" do
-  it "codegens private def in same file" do
+describe("Codegen: private") do
+  it("codegens private def in same file") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -22,7 +22,7 @@ describe "Codegen: private" do
     compiler.compile sources, output_filename
   end
 
-  it "codegens overloaded private def in same file" do
+  it("codegens overloaded private def in same file") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -47,7 +47,7 @@ describe "Codegen: private" do
     compiler.compile sources, output_filename
   end
 
-  it "doesn't include filename for private types" do
+  it("doesn't include filename for private types") do
     run(%(
       private class Foo
         def foo

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -1,19 +1,19 @@
 require "../../spec_helper"
 
-describe "Code gen: proc" do
-  it "call simple proc literal" do
+describe("Code gen: proc") do
+  it("call simple proc literal") do
     run("x = -> { 1 }; x.call").to_i.should eq(1)
   end
 
-  it "call proc literal with arguments" do
+  it("call proc literal with arguments") do
     run("f = ->(x : Int32) { x + 1 }; f.call(41)").to_i.should eq(42)
   end
 
-  it "call proc pointer" do
+  it("call proc pointer") do
     run("def foo; 1; end; x = ->foo; x.call").to_i.should eq(1)
   end
 
-  it "call proc pointer with args" do
+  it("call proc pointer with args") do
     run("
       def foo(x, y)
         x + y
@@ -24,7 +24,7 @@ describe "Code gen: proc" do
     ").to_i.should eq(3)
   end
 
-  it "call proc pointer of instance method" do
+  it("call proc pointer of instance method") do
     run(%(
       class Foo
         def initialize
@@ -42,7 +42,7 @@ describe "Code gen: proc" do
     )).to_i.should eq(1)
   end
 
-  it "call proc pointer of instance method that raises" do
+  it("call proc pointer of instance method that raises") do
     run(%(
       require "prelude"
       class Foo
@@ -57,7 +57,7 @@ describe "Code gen: proc" do
     )).to_i.should eq(1)
   end
 
-  it "codegens proc with another var" do
+  it("codegens proc with another var") do
     run("
       def foo(x)
         bar(x, -> {})
@@ -70,7 +70,7 @@ describe "Code gen: proc" do
       ")
   end
 
-  it "codegens proc that returns a virtual type" do
+  it("codegens proc that returns a virtual type") do
     run("
       class Foo
         def coco; 1; end
@@ -85,14 +85,14 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "codegens proc that accepts a union and is called with a single type" do
+  it("codegens proc that accepts a union and is called with a single type") do
     run("
       f = ->(x : Int32 | Float64) { x + 1 }
       f.call(1).to_i
       ").to_i.should eq(2)
   end
 
-  it "makes sure that proc pointer is transformed after type inference" do
+  it("makes sure that proc pointer is transformed after type inference") do
     run("
       require \"prelude\"
 
@@ -121,7 +121,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "binds function pointer to associated call" do
+  it("binds function pointer to associated call") do
     run("
       class Foo
         def initialize(@e : Int32)
@@ -144,11 +144,11 @@ describe "Code gen: proc" do
       ").to_i.should eq(12)
   end
 
-  it "call simple proc literal with return" do
+  it("call simple proc literal with return") do
     run("x = -> { return 1 }; x.call").to_i.should eq(1)
   end
 
-  it "calls proc pointer with union (passed by value) arg" do
+  it("calls proc pointer with union (passed by value) arg") do
     run("
       struct Number
         def abs; self; end
@@ -159,7 +159,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "allows passing proc type to C automatically" do
+  it("allows passing proc type to C automatically") do
     run(%(
       require "prelude"
 
@@ -177,7 +177,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "allows proc pointer where self is a class" do
+  it("allows proc pointer where self is a class") do
     run("
       class Foo
         def self.bla
@@ -190,7 +190,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "codegens proc literal hard type inference (1)" do
+  it("codegens proc literal hard type inference (1)") do
     run(%(
       require "prelude"
 
@@ -217,7 +217,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "automatically casts proc that returns something to proc that returns void" do
+  it("automatically casts proc that returns something to proc that returns void") do
     run("
       class Global
         @@x = 0
@@ -240,7 +240,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "allows proc type of enum type" do
+  it("allows proc type of enum type") do
     run("
       lib LibFoo
         enum MyEnum
@@ -254,7 +254,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "allows proc type of enum type with base type" do
+  it("allows proc type of enum type with base type") do
     run("
       lib LibFoo
         enum MyEnum : UInt16
@@ -268,7 +268,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "codegens nilable proc type (1)" do
+  it("codegens nilable proc type (1)") do
     run("
       a = 1 == 2 ? nil : ->{ 3 }
       if a
@@ -279,7 +279,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(3)
   end
 
-  it "codegens nilable proc type (2)" do
+  it("codegens nilable proc type (2)") do
     run("
       a = 1 == 1 ? nil : ->{ 3 }
       if a
@@ -290,7 +290,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(4)
   end
 
-  it "codegens nilable proc type dispatch (1)" do
+  it("codegens nilable proc type dispatch (1)") do
     run("
       def foo(x : -> U) forall U
         x.call
@@ -305,7 +305,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(3)
   end
 
-  it "codegens nilable proc type dispatch (2)" do
+  it("codegens nilable proc type dispatch (2)") do
     run("
       def foo(x : -> U) forall U
         x.call
@@ -320,7 +320,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(0)
   end
 
-  it "builds proc type from fun" do
+  it("builds proc type from fun") do
     codegen("
       lib LibC
         fun foo : ->
@@ -331,7 +331,7 @@ describe "Code gen: proc" do
       ")
   end
 
-  it "builds nilable proc type from fun" do
+  it("builds nilable proc type from fun") do
     codegen("
       lib LibC
         fun foo : (->)?
@@ -344,7 +344,7 @@ describe "Code gen: proc" do
       ")
   end
 
-  it "assigns nil and proc to nilable proc type" do
+  it("assigns nil and proc to nilable proc type") do
     run("
       class Foo
         def initialize
@@ -370,7 +370,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "allows invoking proc literal with smaller type" do
+  it("allows invoking proc literal with smaller type") do
     run("
       struct Nil
         def to_i
@@ -385,7 +385,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(1)
   end
 
-  it "does new on proc type" do
+  it("does new on proc type") do
     run("
       alias Func = Int32 -> Int32
 
@@ -395,7 +395,7 @@ describe "Code gen: proc" do
       ").to_i.should eq(3)
   end
 
-  it "allows invoking a function with a subtype" do
+  it("allows invoking a function with a subtype") do
     run(%(
       class Foo
         def x
@@ -414,7 +414,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "allows invoking a function with a subtype when defined as block spec" do
+  it("allows invoking a function with a subtype when defined as block spec") do
     run(%(
       class Foo
         def x
@@ -437,7 +437,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "allows redefining fun" do
+  it("allows redefining fun") do
     run(%(
       fun foo : Int32
         1
@@ -451,7 +451,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "passes block to another function (bug: mangling of both methods was the same)" do
+  it("passes block to another function (bug: mangling of both methods was the same)") do
     run(%(
       def foo(&block : ->)
         foo(block)
@@ -465,7 +465,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "codegens proc with union type that returns itself" do
+  it("codegens proc with union type that returns itself") do
     run(%(
       a = 1 || 1.5
 
@@ -475,7 +475,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "codegens issue with missing byval in proc literal inside struct" do
+  it("codegens issue with missing byval in proc literal inside struct") do
     run(%(
       require "prelude"
 
@@ -493,7 +493,7 @@ describe "Code gen: proc" do
       )).to_string.should eq("bar")
   end
 
-  it "codegens proc that references struct (bug)" do
+  it("codegens proc that references struct (bug)") do
     run(%(
       class Ref
       end
@@ -529,7 +529,7 @@ describe "Code gen: proc" do
       )).to_i.should_not eq(42)
   end
 
-  it "codegens captured block that returns tuple" do
+  it("codegens captured block that returns tuple") do
     codegen(%(
       def foo(&block)
         block
@@ -542,7 +542,7 @@ describe "Code gen: proc" do
       ))
   end
 
-  it "allows using proc arg name shadowing local variable" do
+  it("allows using proc arg name shadowing local variable") do
     run(%(
       a = 1
       f = ->(a : String) { }
@@ -550,7 +550,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "codegens proc that accepts array of type" do
+  it("codegens proc that accepts array of type") do
     run(%(
       require "prelude"
 
@@ -577,7 +577,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "gets proc to lib fun (#504)" do
+  it("gets proc to lib fun (#504)") do
     codegen(%(
       lib LibFoo
         fun bar
@@ -587,7 +587,7 @@ describe "Code gen: proc" do
       ))
   end
 
-  it "codegens proc to implicit self in constant (#647)" do
+  it("codegens proc to implicit self in constant (#647)") do
     run(%(
       module Foo
         def self.blah
@@ -600,7 +600,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  it "passes proc as &-> to method that yields" do
+  it("passes proc as &-> to method that yields") do
     run(%(
       def foo
         yield
@@ -610,7 +610,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(123)
   end
 
-  it "mangles strings in such a way they don't conflict with funs (#1006)" do
+  it("mangles strings in such a way they don't conflict with funs (#1006)") do
     run(%(
       a = :foo
 
@@ -622,7 +622,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(123)
   end
 
-  it "gets proc pointer using virtual type (#1337)" do
+  it("gets proc pointer using virtual type (#1337)") do
     run(%(
       class Foo
         def foo
@@ -645,7 +645,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "uses alias of proc with virtual type (#1347)" do
+  it("uses alias of proc with virtual type (#1347)") do
     run(%(
       require "prelude"
 
@@ -694,7 +694,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't crash on #2196" do
+  it("doesn't crash on #2196") do
     run(%(
       x = 42
       z = if x.is_a?(Int32)
@@ -707,7 +707,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(42)
   end
 
-  it "accesses T in macros as a TupleLiteral" do
+  it("accesses T in macros as a TupleLiteral") do
     run(%(
       struct Proc
         def t
@@ -719,7 +719,7 @@ describe "Code gen: proc" do
       )).to_string.should eq("TupleLiteral")
   end
 
-  it "codegens proc in instance var initialize (#3016)" do
+  it("codegens proc in instance var initialize (#3016)") do
     run(%(
       class Foo
         @f : -> Int32 = ->foo
@@ -733,7 +733,7 @@ describe "Code gen: proc" do
       )).to_i.should eq(42)
   end
 
-  it "codegens proc of generic type" do
+  it("codegens proc of generic type") do
     codegen(%(
       class Gen(T)
       end

--- a/spec/compiler/codegen/responds_to_spec.cr
+++ b/spec/compiler/codegen/responds_to_spec.cr
@@ -1,35 +1,35 @@
 require "../../spec_helper"
 
-describe "Codegen: responds_to?" do
-  it "codegens responds_to? true for simple type" do
+describe("Codegen: responds_to?") do
+  it("codegens responds_to? true for simple type") do
     run("1.responds_to?(:\"+\")").to_b.should be_true
   end
 
-  it "codegens responds_to? false for simple type" do
+  it("codegens responds_to? false for simple type") do
     run("1.responds_to?(:foo)").to_b.should be_false
   end
 
-  it "codegens responds_to? with union gives true" do
+  it("codegens responds_to? with union gives true") do
     run("(1 == 1 ? 1 : 'a').responds_to?(:\"+\")").to_b.should be_true
   end
 
-  it "codegens responds_to? with union gives false" do
+  it("codegens responds_to? with union gives false") do
     run("(1 == 1 ? 1 : 'a').responds_to?(:\"foo\")").to_b.should be_false
   end
 
-  it "codegens responds_to? with nilable gives true" do
+  it("codegens responds_to? with nilable gives true") do
     run("struct Nil; def foo; end; end; (1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_true
   end
 
-  it "codegens responds_to? with nilable gives false because other type 1" do
+  it("codegens responds_to? with nilable gives false because other type 1") do
     run("(1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_false
   end
 
-  it "codegens responds_to? with nilable gives false because other type 2" do
+  it("codegens responds_to? with nilable gives false because other type 2") do
     run("class Reference; def foo; end; end; (1 == 2 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_true
   end
 
-  it "codegends responds_to? with generic class (1)" do
+  it("codegends responds_to? with generic class (1)") do
     run(%(
       class Foo(T)
         def foo
@@ -40,7 +40,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_true
   end
 
-  it "codegends responds_to? with generic class (2)" do
+  it("codegends responds_to? with generic class (2)") do
     run(%(
       class Foo(T)
         def foo
@@ -51,7 +51,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_false
   end
 
-  it "works with virtual type" do
+  it("works with virtual type") do
     run(%(
       class Foo
       end
@@ -67,7 +67,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_true
   end
 
-  it "works with two virtual types" do
+  it("works with two virtual types") do
     run(%(
       class Foo
       end
@@ -101,7 +101,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_true
   end
 
-  it "works with virtual class type (1) (#1926)" do
+  it("works with virtual class type (1) (#1926)") do
     run(%(
       class Foo
       end
@@ -117,7 +117,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_true
   end
 
-  it "works with virtual class type (2) (#1926)" do
+  it("works with virtual class type (2) (#1926)") do
     run(%(
       class Foo
       end
@@ -133,7 +133,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_false
   end
 
-  it "works with module" do
+  it("works with module") do
     run(%(
       module Moo
       end
@@ -163,7 +163,7 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_true
   end
 
-  it "does for generic instance type metaclass (#4353)" do
+  it("does for generic instance type metaclass (#4353)") do
     run(%(
       class MyGeneric(T)
         def self.hallo

--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -1,35 +1,35 @@
 require "../../spec_helper"
 
-describe "Code gen: return" do
-  it "codegens return" do
+describe("Code gen: return") do
+  it("codegens return") do
     run("def foo; return 1; end; foo").to_i.should eq(1)
   end
 
-  it "codegens return followed by another expression" do
+  it("codegens return followed by another expression") do
     run("def foo; return 1; 2; end; foo").to_i.should eq(1)
   end
 
-  it "codegens return inside if" do
+  it("codegens return inside if") do
     run("def foo; if 1 == 1; return 1; end; 2; end; foo").to_i.should eq(1)
   end
 
-  it "return from function with union type" do
+  it("return from function with union type") do
     run("struct Char; def to_i; 2; end; end; def foo; return 1 if 1 == 1; 'a'; end; foo.to_i").to_i.should eq(1)
   end
 
-  it "return union" do
+  it("return union") do
     run("struct Char; def to_i; 2; end; end; def foo; 1 == 2 ? return 1 : return 'a'; end; foo.to_i").to_i.should eq(2)
   end
 
-  it "return from function with nilable type" do
+  it("return from function with nilable type") do
     run(%(require "prelude"; def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
   end
 
-  it "return from function with nilable type 2" do
+  it("return from function with nilable type 2") do
     run(%(require "prelude"; def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
   end
 
-  it "returns empty from function" do
+  it("returns empty from function") do
     run("
       struct Nil; def to_i; 0; end; end
       def foo(x)
@@ -41,7 +41,7 @@ describe "Code gen: return" do
     ").to_i.should eq(1)
   end
 
-  it "codegens bug with return if true" do
+  it("codegens bug with return if true") do
     run(%(
       def bar
         return if true
@@ -52,7 +52,7 @@ describe "Code gen: return" do
       )).to_b.should be_true
   end
 
-  it "codegens assign with if with two returns" do
+  it("codegens assign with if with two returns") do
     run(%(
       def test
         a = 1 ? return 2 : return 3
@@ -62,7 +62,7 @@ describe "Code gen: return" do
       )).to_i.should eq(2)
   end
 
-  it "doesn't crash when method returns nil and can be inlined" do
+  it("doesn't crash when method returns nil and can be inlined") do
     codegen(%(
       def foo : Nil
         1
@@ -72,7 +72,7 @@ describe "Code gen: return" do
       ))
   end
 
-  it "returns in var assignment (#3364)" do
+  it("returns in var assignment (#3364)") do
     run(%(
       def bar
         a = nil || return 123

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Code gen: sizeof" do
-  it "gets sizeof int" do
+describe("Code gen: sizeof") do
+  it("gets sizeof int") do
     run("sizeof(Int32)").to_i.should eq(4)
   end
 
-  it "gets sizeof struct" do
+  it("gets sizeof struct") do
     run("
       struct Foo
         def initialize(@x : Int32, @y : Int32, @z : Int32)
@@ -18,7 +18,7 @@ describe "Code gen: sizeof" do
       ").to_i.should eq(12)
   end
 
-  it "gets sizeof class" do
+  it("gets sizeof class") do
     # A class is represented as a pointer to its data
     run("
       class Foo
@@ -32,7 +32,7 @@ describe "Code gen: sizeof" do
       ").to_i.should eq(sizeof(Void*))
   end
 
-  it "gets sizeof union" do
+  it("gets sizeof union") do
     size = run("
       sizeof(Int32 | Float64)
       ").to_i
@@ -55,7 +55,7 @@ describe "Code gen: sizeof" do
     {% end %}
   end
 
-  it "gets instance_sizeof class" do
+  it("gets instance_sizeof class") do
     run("
       class Foo
         def initialize(@x : Int32, @y : Int32, @z : Int32)
@@ -68,21 +68,21 @@ describe "Code gen: sizeof" do
       ").to_i.should eq(16)
   end
 
-  it "gives error if using instance_sizeof on something that's not a class" do
+  it("gives error if using instance_sizeof on something that's not a class") do
     assert_error "instance_sizeof(Int32)", "Int32 is not a class, it's a struct"
   end
 
-  it "gets sizeof Void" do
+  it("gets sizeof Void") do
     # Same as the size of a byte
     run("sizeof(Void)").to_i.should eq(1)
   end
 
-  it "gets sizeof NoReturn" do
+  it("gets sizeof NoReturn") do
     # Same as the size of a byte
     run("sizeof(NoReturn)").to_i.should eq(1)
   end
 
-  it "can use sizeof in type argument (1)" do
+  it("can use sizeof in type argument (1)") do
     run(%(
       struct StaticArray
         def size
@@ -95,7 +95,7 @@ describe "Code gen: sizeof" do
       )).to_i.should eq(4)
   end
 
-  it "can use sizeof in type argument (2)" do
+  it("can use sizeof in type argument (2)") do
     run(%(
       struct StaticArray
         def size
@@ -108,7 +108,7 @@ describe "Code gen: sizeof" do
       )).to_i.should eq(8)
   end
 
-  it "can use sizeof of virtual type" do
+  it("can use sizeof of virtual type") do
     size = run(%(
       class Foo
         @x = 1
@@ -129,7 +129,7 @@ describe "Code gen: sizeof" do
     {% end %}
   end
 
-  it "can use instance_sizeof of virtual type" do
+  it("can use instance_sizeof of virtual type") do
     run(%(
       class Foo
         @x = 1
@@ -148,7 +148,7 @@ describe "Code gen: sizeof" do
       )).to_i.should eq(12)
   end
 
-  it "can use instance_sizeof in type argument" do
+  it("can use instance_sizeof in type argument") do
     run(%(
       struct StaticArray
         def size

--- a/spec/compiler/codegen/special_vars_spec.cr
+++ b/spec/compiler/codegen/special_vars_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 
-describe "Codegen: special vars" do
+describe("Codegen: special vars") do
   ["$~", "$?"].each do |name|
-    it "codegens #{name}" do
+    it("codegens #{name}") do
       run(%(
         class Object; def not_nil!; self; end; end
 
@@ -15,7 +15,7 @@ describe "Codegen: special vars" do
         )).to_string.should eq("hey")
     end
 
-    it "codegens #{name} with nilable (1)" do
+    it("codegens #{name} with nilable (1)") do
       run(%(
         require "prelude"
 
@@ -35,7 +35,7 @@ describe "Codegen: special vars" do
         )).to_string.should eq("ouch")
     end
 
-    it "codegens #{name} with nilable (2)" do
+    it("codegens #{name} with nilable (2)") do
       run(%(
         require "prelude"
 
@@ -56,7 +56,7 @@ describe "Codegen: special vars" do
     end
   end
 
-  it "codegens $~ two levels" do
+  it("codegens $~ two levels") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -74,7 +74,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("hey")
   end
 
-  it "works lazily" do
+  it("works lazily") do
     run(%(
       require "prelude"
 
@@ -101,7 +101,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("bar")
   end
 
-  it "codegens in block" do
+  it("codegens in block") do
     run(%(
       require "prelude"
 
@@ -120,7 +120,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("hey")
   end
 
-  it "codegens in block with nested block" do
+  it("codegens in block with nested block") do
     run(%(
       require "prelude"
 
@@ -145,7 +145,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("hey")
   end
 
-  it "codegens after block" do
+  it("codegens after block") do
     run(%(
       require "prelude"
 
@@ -162,7 +162,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("hey")
   end
 
-  it "codegens after block 2" do
+  it("codegens after block 2") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -181,7 +181,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("bye")
   end
 
-  it "codegens with default argument" do
+  it("codegens with default argument") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -194,7 +194,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("bye")
   end
 
-  it "preserves special vars in macro expansion with call with default arguments (#824)" do
+  it("preserves special vars in macro expansion with call with default arguments (#824)") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -211,7 +211,7 @@ describe "Codegen: special vars" do
       )).to_string.should eq("yes")
   end
 
-  it "allows with primitive" do
+  it("allows with primitive") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -226,7 +226,7 @@ describe "Codegen: special vars" do
     )).to_i.should eq(123)
   end
 
-  it "allows with struct" do
+  it("allows with struct") do
     run(%(
       class Object; def not_nil!; self; end; end
 
@@ -254,7 +254,7 @@ describe "Codegen: special vars" do
     )).to_i.should eq(123)
   end
 
-  it "preserves special vars if initialized inside block (#2194)" do
+  it("preserves special vars if initialized inside block (#2194)") do
     run(%(
       class Object; def not_nil!; self; end; end
 

--- a/spec/compiler/codegen/splat_spec.cr
+++ b/spec/compiler/codegen/splat_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: splat" do
-  it "splats" do
+describe("Code gen: splat") do
+  it("splats") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -15,7 +15,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(3)
   end
 
-  it "splats with another arg" do
+  it("splats with another arg") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -29,7 +29,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(12)
   end
 
-  it "splats on call" do
+  it("splats on call") do
     run(%(
       def foo(x, y)
         x + y
@@ -40,7 +40,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(3)
   end
 
-  it "splats without args" do
+  it("splats without args") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -54,7 +54,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(0)
   end
 
-  it "splats with default value" do
+  it("splats with default value") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -68,7 +68,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(100)
   end
 
-  it "splats with default value (2)" do
+  it("splats with default value (2)") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -82,7 +82,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(110)
   end
 
-  it "splats with default value (3)" do
+  it("splats with default value (3)") do
     run(%(
       struct Tuple
         def size; {{T.size}}; end
@@ -96,7 +96,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(32)
   end
 
-  it "splats in initialize" do
+  it("splats in initialize") do
     run(%(
       class Foo
         @x : Int32
@@ -120,7 +120,7 @@ describe "Code gen: splat" do
       )).to_i.should eq(3)
   end
 
-  it "does #2407" do
+  it("does #2407") do
     codegen(%(
       lib LibC
         fun exit(Int32) : NoReturn
@@ -143,7 +143,7 @@ describe "Code gen: splat" do
       ))
   end
 
-  it "evaluates splat argument just once (#2677)" do
+  it("evaluates splat argument just once (#2677)") do
     run(%(
       class Global
         @@x = 0

--- a/spec/compiler/codegen/ssa_spec.cr
+++ b/spec/compiler/codegen/ssa_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: ssa" do
-  it "codegens a redefined var" do
+describe("Code gen: ssa") do
+  it("codegens a redefined var") do
     run("
       a = 1.5
       a = 1
@@ -9,7 +9,7 @@ describe "Code gen: ssa" do
       ").to_i.should eq(1)
   end
 
-  it "codegens a redefined var inside method" do
+  it("codegens a redefined var inside method") do
     run("
       def foo
         a = 1.5
@@ -21,7 +21,7 @@ describe "Code gen: ssa" do
       ").to_i.should eq(1)
   end
 
-  it "codegens a redefined var inside method with argument" do
+  it("codegens a redefined var inside method with argument") do
     run("
       def foo(a)
         a = 1
@@ -32,7 +32,7 @@ describe "Code gen: ssa" do
       ").to_i.should eq(1)
   end
 
-  it "codegens declaration of var inside then when false" do
+  it("codegens declaration of var inside then when false") do
     run("
       struct Nil
         def to_i
@@ -47,7 +47,7 @@ describe "Code gen: ssa" do
       ").to_i.should eq(0)
   end
 
-  it "codegens declaration of var inside then when true" do
+  it("codegens declaration of var inside then when true") do
     run("
       struct Nil
         def to_i
@@ -62,7 +62,7 @@ describe "Code gen: ssa" do
       ").to_i.should eq(2)
   end
 
-  it "codegens a var that is re-assigned in a block" do
+  it("codegens a var that is re-assigned in a block") do
     run(%(
       struct Char
         def to_i
@@ -82,7 +82,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(10)
   end
 
-  it "codegens a var that is re-assigned in a block (1)" do
+  it("codegens a var that is re-assigned in a block (1)") do
     run(%(
       struct Char
         def to_i
@@ -98,7 +98,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(10)
   end
 
-  it "codegens a var that is re-assigned in a block (2)" do
+  it("codegens a var that is re-assigned in a block (2)") do
     run(%(
       struct Char
         def to_i
@@ -114,7 +114,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(1)
   end
 
-  it "codegens a var that is declared in a block (1)" do
+  it("codegens a var that is declared in a block (1)") do
     run(%(
       struct Nil
         def to_i
@@ -129,7 +129,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(0)
   end
 
-  it "codegens a var that is declared in a block (2)" do
+  it("codegens a var that is declared in a block (2)") do
     run(%(
       struct Nil
         def to_i
@@ -146,7 +146,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(1)
   end
 
-  it "codegens ssa bug with if/else on var" do
+  it("codegens ssa bug with if/else on var") do
     run(%(
       a = 1 || nil
       if a && false
@@ -160,7 +160,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(3)
   end
 
-  it "codegens ssa bug (1)" do
+  it("codegens ssa bug (1)") do
     run(%(
       struct Nil
         def to_i
@@ -185,7 +185,7 @@ describe "Code gen: ssa" do
       )).to_i.should eq(1)
   end
 
-  it "codegens ssa bug (2)" do
+  it("codegens ssa bug (2)") do
     # This shows a bug where a block variable (coconio in this case)
     # wasn't reset to nil before each block iteration.
     run(%(

--- a/spec/compiler/codegen/struct_spec.cr
+++ b/spec/compiler/codegen/struct_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: struct" do
-  it "creates structs" do
+describe("Code gen: struct") do
+  it("creates structs") do
     run("
       struct Foo
       end
@@ -11,7 +11,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "creates structs with instance var" do
+  it("creates structs with instance var") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -27,7 +27,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "assigning a struct makes a copy (1)" do
+  it("assigning a struct makes a copy (1)") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -50,7 +50,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "assigning a struct makes a copy (2)" do
+  it("assigning a struct makes a copy (2)") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -73,7 +73,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "passes a struct as a parameter makes a copy" do
+  it("passes a struct as a parameter makes a copy") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -99,7 +99,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "passes a generic struct as a parameter makes a copy" do
+  it("passes a generic struct as a parameter makes a copy") do
     run("
       struct Foo(T)
         def initialize(@x : T)
@@ -125,7 +125,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "returns struct as a copy" do
+  it("returns struct as a copy") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -151,7 +151,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "creates struct in def" do
+  it("creates struct in def") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -170,7 +170,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "declares const struct" do
+  it("declares const struct") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -187,7 +187,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "uses struct in if" do
+  it("uses struct in if") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -209,7 +209,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "uses nilable struct" do
+  it("uses nilable struct") do
     run("
       struct Foo
       end
@@ -219,7 +219,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "returns self" do
+  it("returns self") do
     run("
       struct Foo
         def initialize(@x)
@@ -241,7 +241,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "returns self with block" do
+  it("returns self with block") do
     run("
       struct Foo
         def initialize(@x)
@@ -264,7 +264,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "does phi of struct" do
+  it("does phi of struct") do
     run("
       struct Foo
         def initialize(@x : Int32)
@@ -284,7 +284,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(1)
   end
 
-  it "allows assinging to struct argument (bug)" do
+  it("allows assinging to struct argument (bug)") do
     run("
       struct Foo
         def bar
@@ -300,7 +300,7 @@ describe "Code gen: struct" do
       ").to_i.should eq(2)
   end
 
-  it "codegens struct assigned to underscore (#1842)" do
+  it("codegens struct assigned to underscore (#1842)") do
     run(%(
       struct Foo
         def initialize
@@ -320,7 +320,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(123)
   end
 
-  it "codegens virtual struct" do
+  it("codegens virtual struct") do
     run(%(
       abstract struct Foo
       end
@@ -350,7 +350,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(1)
   end
 
-  it "codegens virtual struct with pointer" do
+  it("codegens virtual struct with pointer") do
     run(%(
       abstract struct Foo
       end
@@ -382,7 +382,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(1)
   end
 
-  it "codegens virtual struct metaclass (#2551) (1)" do
+  it("codegens virtual struct metaclass (#2551) (1)") do
     run(%(
       abstract struct Foo
         def initialize
@@ -408,7 +408,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(42)
   end
 
-  it "codegens virtual struct metaclass (#2551) (2)" do
+  it("codegens virtual struct metaclass (#2551) (2)") do
     run(%(
       abstract struct Foo
         def initialize
@@ -429,7 +429,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(42)
   end
 
-  it "codegens virtual struct metaclass (#2551) (3)" do
+  it("codegens virtual struct metaclass (#2551) (3)") do
     run(%(
       abstract struct Foo
         def initialize
@@ -454,7 +454,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(42)
   end
 
-  it "codegens virtual struct metaclass (#2551) (4)" do
+  it("codegens virtual struct metaclass (#2551) (4)") do
     run(%(
       abstract struct Foo
         def initialize
@@ -480,7 +480,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(42)
   end
 
-  it "mutates a  virtual struct" do
+  it("mutates a  virtual struct") do
     run(%(
       abstract struct Foo
         def initialize
@@ -510,7 +510,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(84)
   end
 
-  it "codegens virtual structs union (1)" do
+  it("codegens virtual structs union (1)") do
     run(%(
       abstract struct Foo
       end
@@ -546,7 +546,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(42)
   end
 
-  it "codegens virtual structs union (2)" do
+  it("codegens virtual structs union (2)") do
     run(%(
       abstract struct Foo
       end
@@ -582,7 +582,7 @@ describe "Code gen: struct" do
       )).to_i.should eq(84)
   end
 
-  it "can cast virtual struct to specific struct" do
+  it("can cast virtual struct to specific struct") do
     run(%(
        require "prelude"
 
@@ -606,7 +606,7 @@ describe "Code gen: struct" do
        )).to_i.should eq(1)
   end
 
-  it "casts virtual struct to base type, only one subclass (#2885)" do
+  it("casts virtual struct to base type, only one subclass (#2885)") do
     run(%(
       abstract struct Entry
         def initialize(@uid : String, @country : String)

--- a/spec/compiler/codegen/super_spec.cr
+++ b/spec/compiler/codegen/super_spec.cr
@@ -1,19 +1,19 @@
 require "../../spec_helper"
 
-describe "Codegen: super" do
-  it "codegens super without arguments" do
+describe("Codegen: super") do
+  it("codegens super without arguments") do
     run("class Foo; def foo; 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i.should eq(1)
   end
 
-  it "codegens super without arguments but parent has arguments" do
+  it("codegens super without arguments but parent has arguments") do
     run("class Foo; def foo(x); x + 1; end; end; class Bar < Foo; def foo(x); super; end; end; Bar.new.foo(1)").to_i.should eq(2)
   end
 
-  it "codegens super without arguments and instance variable" do
+  it("codegens super without arguments and instance variable") do
     run("class Foo; def foo; @x = 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i.should eq(1)
   end
 
-  it "codegens super that calls subclass method" do
+  it("codegens super that calls subclass method") do
     run("
       class Foo
         def foo
@@ -40,7 +40,7 @@ describe "Codegen: super" do
       ").to_i.should eq(2)
   end
 
-  it "codegens super that calls subclass method 2" do
+  it("codegens super that calls subclass method 2") do
     run("
       class Foo
         def foo
@@ -67,7 +67,7 @@ describe "Codegen: super" do
       ").to_i.should eq(2)
   end
 
-  it "codegens super that calls subclass method 3" do
+  it("codegens super that calls subclass method 3") do
     run("
       class Foo
         def foo
@@ -94,7 +94,7 @@ describe "Codegen: super" do
       ").to_i.should eq(1)
   end
 
-  it "codegens super that calls subclass method 4" do
+  it("codegens super that calls subclass method 4") do
     run("
       class Foo
         def foo
@@ -121,7 +121,7 @@ describe "Codegen: super" do
       ").to_i.should eq(2)
   end
 
-  it "codegens super that calls subclass method 5" do
+  it("codegens super that calls subclass method 5") do
     run("
       module Mod
         def add_def
@@ -157,7 +157,7 @@ describe "Codegen: super" do
       ").to_i.should eq(2)
   end
 
-  it "codegens super that calls subclass method 6" do
+  it("codegens super that calls subclass method 6") do
     run("
       module Mod
         def add_def
@@ -193,7 +193,7 @@ describe "Codegen: super" do
       ").to_i.should eq(3)
   end
 
-  it "codegens super inside closure" do
+  it("codegens super inside closure") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -215,7 +215,7 @@ describe "Codegen: super" do
       )).to_i.should eq(1)
   end
 
-  it "codegens super inside closure forwarding args" do
+  it("codegens super inside closure forwarding args") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -237,7 +237,7 @@ describe "Codegen: super" do
       )).to_i.should eq(6)
   end
 
-  it "build super on generic class (bug)" do
+  it("build super on generic class (bug)") do
     codegen(%(
       class Base
         def foo(x)
@@ -255,7 +255,7 @@ describe "Codegen: super" do
       ))
   end
 
-  it "calls super in module method (#556)" do
+  it("calls super in module method (#556)") do
     run(%(
       class Parent
         def a
@@ -277,7 +277,7 @@ describe "Codegen: super" do
       )).to_i.should eq(1)
   end
 
-  it "calls super in generic module method" do
+  it("calls super in generic module method") do
     run(%(
       class Parent
         def a
@@ -299,7 +299,7 @@ describe "Codegen: super" do
       )).to_i.should eq(1)
   end
 
-  it "does super in virtual type including module" do
+  it("does super in virtual type including module") do
     run(%(
       module Bar
         def bar
@@ -326,7 +326,7 @@ describe "Codegen: super" do
       )).to_i.should eq(123)
   end
 
-  it "doesn't invoke super twice in inherited generic types (#942)" do
+  it("doesn't invoke super twice in inherited generic types (#942)") do
     run(%(
       class Global
         @@x = 0
@@ -358,7 +358,7 @@ describe "Codegen: super" do
       )).to_i.should eq(1)
   end
 
-  it "calls super in metaclass (#1522)" do
+  it("calls super in metaclass (#1522)") do
     # We include the prelude so this is codegened for real, because that's where the issue lies
     run(%(
       require "prelude"
@@ -392,7 +392,7 @@ describe "Codegen: super" do
       )).to_i.should eq(5)
   end
 
-  it "calls super with dispatch (#2318)" do
+  it("calls super with dispatch (#2318)") do
     run(%(
       class Foo
         def foo(x : Int32)
@@ -415,7 +415,7 @@ describe "Codegen: super" do
       )).to_i.should eq(3)
   end
 
-  it "calls super from virtual metaclass type (#2841)" do
+  it("calls super from virtual metaclass type (#2841)") do
     run(%(
       require "prelude"
 

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -1,31 +1,31 @@
 require "../../spec_helper"
 
-describe "Code gen: tuple" do
-  it "codegens tuple [0]" do
+describe("Code gen: tuple") do
+  it("codegens tuple [0]") do
     run("{1, true}[0]").to_i.should eq(1)
   end
 
-  it "codegens tuple [1]" do
+  it("codegens tuple [1]") do
     run("{1, true}[1]").to_b.should be_true
   end
 
-  it "codegens tuple [1] (2)" do
+  it("codegens tuple [1] (2)") do
     run("{true, 3}[1]").to_i.should eq(3)
   end
 
-  it "codegens tuple [0]?" do
+  it("codegens tuple [0]?") do
     run("{42, 'a'}[0]? || 84").to_i.should eq(42)
   end
 
-  it "codegens tuple [1]?" do
+  it("codegens tuple [1]?") do
     run("{'a', 42}[1]? || 84").to_i.should eq(42)
   end
 
-  it "codegens tuple [2]?" do
+  it("codegens tuple [2]?") do
     run("{'a', 42}[2]? || 84").to_i.should eq(84)
   end
 
-  it "passed tuple to def" do
+  it("passed tuple to def") do
     run("
       def foo(t)
         t[1]
@@ -35,7 +35,7 @@ describe "Code gen: tuple" do
       ").to_i.should eq(2)
   end
 
-  it "accesses T and creates instance from it" do
+  it("accesses T and creates instance from it") do
     run("
       struct Tuple
         def type_args
@@ -58,7 +58,7 @@ describe "Code gen: tuple" do
       ").to_i.should eq(2)
   end
 
-  it "allows malloc pointer of tuple" do
+  it("allows malloc pointer of tuple") do
     run("
       struct Pointer
         def self.malloc(size : Int)
@@ -77,7 +77,7 @@ describe "Code gen: tuple" do
       ").to_i.should eq(3)
   end
 
-  it "codegens tuple union (bug because union size was computed incorrectly)" do
+  it("codegens tuple union (bug because union size was computed incorrectly)") do
     run(%(
       require "prelude"
       x = 1 == 1 ? {1, 1, 1} : {1}
@@ -86,7 +86,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(1)
   end
 
-  it "codegens tuple class" do
+  it("codegens tuple class") do
     run(%(
       class Foo
         def initialize(@x : Int32)
@@ -111,7 +111,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(2)
   end
 
-  it "gets size at compile time" do
+  it("gets size at compile time") do
     run(%(
       struct Tuple
         def my_size
@@ -123,7 +123,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(2)
   end
 
-  it "allows tuple covariance" do
+  it("allows tuple covariance") do
     run(%(
        class Obj
          def initialize
@@ -156,7 +156,7 @@ describe "Code gen: tuple" do
        )).to_i.should eq(42)
   end
 
-  it "merges two tuple types of same size (1)" do
+  it("merges two tuple types of same size (1)") do
     run(%(
        def foo
          if 1 == 2
@@ -171,7 +171,7 @@ describe "Code gen: tuple" do
        )).to_i.should eq(20)
   end
 
-  it "merges two tuple types of same size (2)" do
+  it("merges two tuple types of same size (2)") do
     run(%(
        def foo
          if 1 == 1
@@ -186,7 +186,7 @@ describe "Code gen: tuple" do
        )).to_i.should eq(10)
   end
 
-  it "assigns tuple to compatible tuple" do
+  it("assigns tuple to compatible tuple") do
     run(%(
       ptr = Pointer({Int32 | String, Bool | Char}).malloc(1_u64)
 
@@ -198,7 +198,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts tuple inside compatible tuple" do
+  it("upcasts tuple inside compatible tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -213,7 +213,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "assigns tuple union to compatible tuple" do
+  it("assigns tuple union to compatible tuple") do
     run(%(
       tup1 = {"hello", false}
       tup2 = {3}
@@ -226,7 +226,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts tuple union to compatible tuple" do
+  it("upcasts tuple union to compatible tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -241,7 +241,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "assigns tuple inside union to union with compatible tuple" do
+  it("assigns tuple inside union to union with compatible tuple") do
     run(%(
       tup1 = {"hello", false}
       tup2 = {3}
@@ -260,7 +260,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "upcasts tuple inside union to union with compatible tuple" do
+  it("upcasts tuple inside union to union with compatible tuple") do
     run(%(
       def foo
         if 1 == 2
@@ -281,7 +281,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "codegens union of tuple of float with tuple of tuple of float" do
+  it("codegens union of tuple of float with tuple of tuple of float") do
     run(%(
       a = {1.5}
       b = { {22.0, 20.0} }
@@ -295,7 +295,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(42)
   end
 
-  it "provides T as a tuple literal" do
+  it("provides T as a tuple literal") do
     run(%(
       struct Tuple
         def self.foo
@@ -306,7 +306,7 @@ describe "Code gen: tuple" do
       )).to_string.should eq("TupleLiteral")
   end
 
-  it "passes empty tuple and empty named tuple to a method (#2852)" do
+  it("passes empty tuple and empty named tuple to a method (#2852)") do
     codegen(%(
       def foo(*binds)
         baz(binds)
@@ -325,7 +325,7 @@ describe "Code gen: tuple" do
       ))
   end
 
-  it "assigns two same-size tuple types to a same var (#3132)" do
+  it("assigns two same-size tuple types to a same var (#3132)") do
     run(%(
       t = {true}
       t
@@ -334,7 +334,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(2)
   end
 
-  it "downcasts union to mixed tuple type" do
+  it("downcasts union to mixed tuple type") do
     run(%(
       t = {1} || 2 || {true}
       t = {1}
@@ -342,7 +342,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(1)
   end
 
-  it "downcasts union to mixed union with mixed tuple types" do
+  it("downcasts union to mixed union with mixed tuple types") do
     run(%(
       require "prelude"
 
@@ -352,7 +352,7 @@ describe "Code gen: tuple" do
       )).to_i.should eq(1)
   end
 
-  it "downcasts union inside tuple to value (#3907)" do
+  it("downcasts union inside tuple to value (#3907)") do
     codegen(%(
       struct Foo
       end

--- a/spec/compiler/codegen/type_declaration_spec.cr
+++ b/spec/compiler/codegen/type_declaration_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: type declaration" do
-  it "codegens initialize instance var" do
+describe("Code gen: type declaration") do
+  it("codegens initialize instance var") do
     run("
       class Foo
         @x = 1
@@ -15,7 +15,7 @@ describe "Code gen: type declaration" do
       ").to_i.should eq(1)
   end
 
-  it "codegens initialize instance var of superclass" do
+  it("codegens initialize instance var of superclass") do
     run("
       class Foo
         @x = 1
@@ -32,7 +32,7 @@ describe "Code gen: type declaration" do
       ").to_i.should eq(1)
   end
 
-  it "codegens initialize instance var with var declaration" do
+  it("codegens initialize instance var with var declaration") do
     run("
       class Foo
         @x : Int32 = begin
@@ -49,7 +49,7 @@ describe "Code gen: type declaration" do
       ").to_i.should eq(1)
   end
 
-  it "declares and initializes" do
+  it("declares and initializes") do
     run(%(
       class Foo
         @x : Int32 = 42
@@ -63,7 +63,7 @@ describe "Code gen: type declaration" do
       )).to_i.should eq(42)
   end
 
-  it "declares and initializes var" do
+  it("declares and initializes var") do
     run(%(
       a : Int32 = 42
       a

--- a/spec/compiler/codegen/uninitialized_spec.cr
+++ b/spec/compiler/codegen/uninitialized_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Code gen: uninitialized" do
-  it "codegens declare var and read it" do
+describe("Code gen: uninitialized") do
+  it("codegens declare var and read it") do
     run("a = uninitialized Int32; a")
   end
 
-  it "codegens declare var and changes it" do
+  it("codegens declare var and changes it") do
     run("a = uninitialized Int32; while a != 10; a = 10; end; a").to_i.should eq(10)
   end
 
-  it "codegens declare instance var" do
+  it("codegens declare instance var") do
     run("
       class Foo
         def initialize
@@ -25,7 +25,7 @@ describe "Code gen: uninitialized" do
       ").to_i.should eq(0)
   end
 
-  it "codegens declare instance var with static array type" do
+  it("codegens declare instance var with static array type") do
     run("
       class Foo
         def initialize
@@ -42,7 +42,7 @@ describe "Code gen: uninitialized" do
       ")
   end
 
-  it "doesn't break on inherited declared var (#390)" do
+  it("doesn't break on inherited declared var (#390)") do
     run(%(
       class Foo
         def initialize
@@ -71,7 +71,7 @@ describe "Code gen: uninitialized" do
       )).to_i.should eq(3)
   end
 
-  it "works inside while/begin/rescue (bug inside #759)" do
+  it("works inside while/begin/rescue (bug inside #759)") do
     run(%(
       require "prelude"
 
@@ -88,7 +88,7 @@ describe "Code gen: uninitialized" do
       )).to_i.should eq(3)
   end
 
-  it "works with uninitialized NoReturn (#3314)" do
+  it("works with uninitialized NoReturn (#3314)") do
     codegen(%(
       def foo
         x = uninitialized NoReturn
@@ -106,7 +106,7 @@ describe "Code gen: uninitialized" do
       ), inject_primitives: false)
   end
 
-  it "codegens value (#3641)" do
+  it("codegens value (#3641)") do
     run(%(
       x = y = uninitialized Int32
       x == y

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -1,35 +1,35 @@
 require "../../spec_helper"
 
-describe "Code gen: union type" do
-  it "codegens union type when obj is union and no args" do
+describe("Code gen: union type") do
+  it("codegens union type when obj is union and no args") do
     run("a = 1; a = 2.5_f32; a.to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type when obj is union and arg is union" do
+  it("codegens union type when obj is union and arg is union") do
     run("a = 1; a = 1.5_f32; (a + a).to_f").to_f64.should eq(3)
   end
 
-  it "codegens union type when obj is not union but arg is" do
+  it("codegens union type when obj is not union but arg is") do
     run("a = 1; b = 2; b = 1.5_f32; (a + b).to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type when obj union but arg is not" do
+  it("codegens union type when obj union but arg is not") do
     run("a = 1; b = 2; b = 1.5_f32; (b + a).to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type when no obj" do
+  it("codegens union type when no obj") do
     run("def foo(x); x; end; a = 1; a = 2.5_f32; foo(a).to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type when no obj and restrictions" do
+  it("codegens union type when no obj and restrictions") do
     run("def foo(x : Int); 1.5; end; def foo(x : Float); 2.5; end; a = 1; a = 3.5_f32; foo(a).to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type as return value" do
+  it("codegens union type as return value") do
     run("def foo; a = 1; a = 2.5_f32; a; end; foo.to_f").to_f64.should eq(2.5)
   end
 
-  it "codegens union type for instance var" do
+  it("codegens union type for instance var") do
     run("
       class Foo
         @value : Int32 | Float32
@@ -47,7 +47,7 @@ describe "Code gen: union type" do
     ").to_f64.should eq(3)
   end
 
-  it "codegens if with same nested union" do
+  it("codegens if with same nested union") do
     run("
       if true
         if true
@@ -65,7 +65,7 @@ describe "Code gen: union type" do
     ").to_i.should eq(1)
   end
 
-  it "assigns union to union" do
+  it("assigns union to union") do
     run("
       require \"prelude\"
 
@@ -97,7 +97,7 @@ describe "Code gen: union type" do
       ").to_i.should eq(97)
   end
 
-  it "assigns union to larger union" do
+  it("assigns union to larger union") do
     run("
       require \"prelude\"
       a = 1
@@ -109,7 +109,7 @@ describe "Code gen: union type" do
     ").to_string.should eq("d")
   end
 
-  it "assigns union to larger union when source is nilable 1" do
+  it("assigns union to larger union when source is nilable 1") do
     value = run("
       require \"prelude\"
       a = 1
@@ -121,7 +121,7 @@ describe "Code gen: union type" do
     value.includes?("Reference").should be_true
   end
 
-  it "assigns union to larger union when source is nilable 2" do
+  it("assigns union to larger union when source is nilable 2") do
     run("
       require \"prelude\"
       a = 1
@@ -132,7 +132,7 @@ describe "Code gen: union type" do
     ").to_string.should eq("")
   end
 
-  it "dispatch call to object method on nilable" do
+  it("dispatch call to object method on nilable") do
     run("
       require \"prelude\"
       class Foo
@@ -144,7 +144,7 @@ describe "Code gen: union type" do
     ")
   end
 
-  it "sorts restrictions when there are unions" do
+  it("sorts restrictions when there are unions") do
     run("
       class Middle
       end
@@ -179,7 +179,7 @@ describe "Code gen: union type" do
       ").to_i.should eq(2)
   end
 
-  it "codegens union to_s" do
+  it("codegens union to_s") do
     str = run(%(
       require "prelude"
 
@@ -193,7 +193,7 @@ describe "Code gen: union type" do
     (str == "(Int32 | Float64)" || str == "(Float64 | Int32)").should be_true
   end
 
-  it "provides T as a tuple literal" do
+  it("provides T as a tuple literal") do
     run(%(
       struct Union
         def self.foo

--- a/spec/compiler/codegen/until_spec.cr
+++ b/spec/compiler/codegen/until_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Codegen: until" do
-  it "codegens until" do
+describe("Codegen: until") do
+  it("codegens until") do
     run(%(
       a = 1
       until a == 10

--- a/spec/compiler/codegen/var_spec.cr
+++ b/spec/compiler/codegen/var_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Code gen: var" do
-  it "codegens var" do
+describe("Code gen: var") do
+  it("codegens var") do
     run("a = 1; 1.5; a").to_i.should eq(1)
   end
 
-  it "codegens ivar assignment when not-nil type filter applies" do
+  it("codegens ivar assignment when not-nil type filter applies") do
     run("
       class Foo
         def foo
@@ -21,7 +21,7 @@ describe "Code gen: var" do
       ").to_i.should eq(2)
   end
 
-  it "codegens bug with instance vars and ssa" do
+  it("codegens bug with instance vars and ssa") do
     run("
       class Foo
         def initialize
@@ -42,7 +42,7 @@ describe "Code gen: var" do
       ").to_i.should eq(-1)
   end
 
-  it "codegens bug with var, while, if, break and ssa" do
+  it("codegens bug with var, while, if, break and ssa") do
     run("
       a = 1
       a = 2
@@ -59,7 +59,7 @@ describe "Code gen: var" do
       ").to_i.should eq(2)
   end
 
-  it "codegens bug with union of int, nil and string (1): assigning nil to union must fill all zeros" do
+  it("codegens bug with union of int, nil and string (1): assigning nil to union must fill all zeros") do
     run(%(
       struct Nil
         def foo
@@ -83,7 +83,7 @@ describe "Code gen: var" do
       )).to_i.should eq(1)
   end
 
-  it "codegens bug with union of int, nil and string (2): assigning nil to union must fill all zeros" do
+  it("codegens bug with union of int, nil and string (2): assigning nil to union must fill all zeros") do
     run(%(
       struct Nil
         def foo
@@ -107,7 +107,7 @@ describe "Code gen: var" do
       )).to_i.should eq(1)
   end
 
-  it "codegens assignment that can never be reached" do
+  it("codegens assignment that can never be reached") do
     codegen(%(
       require "prelude"
 
@@ -117,7 +117,7 @@ describe "Code gen: var" do
       ))
   end
 
-  it "works with typeof with assignment (#828)" do
+  it("works with typeof with assignment (#828)") do
     run(%(
       class String; def to_i; 0; end; end
 
@@ -127,7 +127,7 @@ describe "Code gen: var" do
       )).to_i.should eq(123)
   end
 
-  it "assigns to underscore" do
+  it("assigns to underscore") do
     run(%(
       _ = (b = 2)
       b

--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: virtual type" do
-  it "call base method" do
+describe("Code gen: virtual type") do
+  it("call base method") do
     run("
       class Foo
         def coco
@@ -18,7 +18,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(1)
   end
 
-  it "call overwritten method" do
+  it("call overwritten method") do
     run("
       class Foo
         def coco
@@ -38,7 +38,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(2)
   end
 
-  it "call base overwritten method" do
+  it("call base overwritten method") do
     run("
       class Foo
         def coco
@@ -58,7 +58,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(1)
   end
 
-  it "dispatch call with virtual type argument" do
+  it("dispatch call with virtual type argument") do
     run("
       class Foo
       end
@@ -80,7 +80,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(2)
   end
 
-  it "can belong to union" do
+  it("can belong to union") do
     run("
       class Foo
         def foo; 1; end
@@ -97,7 +97,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(2)
   end
 
-  it "lookup instance variables in parent types" do
+  it("lookup instance variables in parent types") do
     run("
       class Foo
         def initialize
@@ -119,7 +119,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(2)
   end
 
-  it "assign instance variable in virtual type" do
+  it("assign instance variable in virtual type") do
     run("
       class Foo
         def foo
@@ -135,7 +135,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(1)
   end
 
-  it "codegens non-virtual call that calls virtual call to another virtual call" do
+  it("codegens non-virtual call that calls virtual call to another virtual call") do
     run("
       class Foo
         def foo
@@ -158,7 +158,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "casts virtual type to base virtual type" do
+  it("casts virtual type to base virtual type") do
     run("
       class Object
         def bar
@@ -180,7 +180,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "codegens call to Object#to_s from virtual type" do
+  it("codegens call to Object#to_s from virtual type") do
     run("
       require \"prelude\"
 
@@ -195,7 +195,7 @@ describe "Code gen: virtual type" do
       ")
   end
 
-  it "codegens call to Object#to_s from nilable type" do
+  it("codegens call to Object#to_s from nilable type") do
     run("
       require \"prelude\"
 
@@ -207,7 +207,7 @@ describe "Code gen: virtual type" do
       ")
   end
 
-  it "codegens virtual call with explicit self" do
+  it("codegens virtual call with explicit self") do
     run("
       class Foo
         def foo
@@ -227,7 +227,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "codegens virtual call with explicit self and nilable type" do
+  it("codegens virtual call with explicit self and nilable type") do
     run("
       class Foo
         def foo
@@ -253,7 +253,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "initializes ivars to nil even if object never instantiated" do
+  it("initializes ivars to nil even if object never instantiated") do
     run("
       require \"prelude\"
 
@@ -291,7 +291,7 @@ describe "Code gen: virtual type" do
       ")
   end
 
-  it "doesn't lookup in Value+ when virtual type is Object+" do
+  it("doesn't lookup in Value+ when virtual type is Object+") do
     run(%(
       require "prelude"
 
@@ -309,7 +309,7 @@ describe "Code gen: virtual type" do
       )).to_b.should be_true
   end
 
-  it "correctly dispatch call with block when the obj is a virtual type" do
+  it("correctly dispatch call with block when the obj is a virtual type") do
     run("
       class Foo
         def each
@@ -336,7 +336,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(2)
   end
 
-  it "dispatch call with nilable virtual arg" do
+  it("dispatch call with nilable virtual arg") do
     run("
       class Foo
       end
@@ -361,7 +361,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(1)
   end
 
-  it "calls class method 1" do
+  it("calls class method 1") do
     run("
       class Foo
         def self.foo
@@ -379,7 +379,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "calls class method 2" do
+  it("calls class method 2") do
     run("
       class Foo
         def self.foo
@@ -397,7 +397,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(2)
   end
 
-  it "calls class method 3" do
+  it("calls class method 3") do
     run("
       class Base
         def self.foo
@@ -418,7 +418,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "dispatches on virtual metaclass (1)" do
+  it("dispatches on virtual metaclass (1)") do
     run("
       class Foo
         def self.coco
@@ -437,7 +437,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "dispatches on virtual metaclass (2)" do
+  it("dispatches on virtual metaclass (2)") do
     run("
       class Foo
         def self.coco
@@ -456,7 +456,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(2)
   end
 
-  it "dispatches on virtual metaclass (3)" do
+  it("dispatches on virtual metaclass (3)") do
     run("
       class Foo
         def self.coco
@@ -478,7 +478,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(2)
   end
 
-  it "codegens new for simple type, then for virtual" do
+  it("codegens new for simple type, then for virtual") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -498,7 +498,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "codegens new twice for virtual" do
+  it("codegens new twice for virtual") do
     run("
       class Foo
         def initialize(@x : Int32)
@@ -518,7 +518,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(1)
   end
 
-  it "codegens allocate for virtual type with custom new" do
+  it("codegens allocate for virtual type with custom new") do
     run("
       class Foo
         def self.new
@@ -541,7 +541,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(2)
   end
 
-  it "returns type with virtual type def type" do
+  it("returns type with virtual type def type") do
     run("
       class Foo
         def foo
@@ -564,7 +564,7 @@ describe "Code gen: virtual type" do
     ").to_i.should eq(1)
   end
 
-  it "casts virtual type to union" do
+  it("casts virtual type to union") do
     run("
       class Foo
       end
@@ -594,7 +594,7 @@ describe "Code gen: virtual type" do
       ").to_i.should eq(3)
   end
 
-  it "casts union to virtual" do
+  it("casts union to virtual") do
     run("
       module Moo
       end
@@ -625,7 +625,7 @@ describe "Code gen: virtual type" do
       ").to_b.should be_true
   end
 
-  it "codegens virtual method of abstract metaclass" do
+  it("codegens virtual method of abstract metaclass") do
     run(%(
       class Foo
         def self.foo
@@ -649,7 +649,7 @@ describe "Code gen: virtual type" do
       )).to_i.should eq(2)
   end
 
-  it "codegens new for virtual class with one type" do
+  it("codegens new for virtual class with one type") do
     run(%(
       abstract class Foo
       end
@@ -666,7 +666,7 @@ describe "Code gen: virtual type" do
       )).to_i.should eq(123)
   end
 
-  it "codegens new for virtual class with two types" do
+  it("codegens new for virtual class with two types") do
     run(%(
       abstract class Foo
       end

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Code gen: void" do
-  it "codegens void assignment" do
+describe("Code gen: void") do
+  it("codegens void assignment") do
     run("
       fun foo : Void
       end
@@ -12,7 +12,7 @@ describe "Code gen: void" do
       ").to_i.should eq(1)
   end
 
-  it "codegens void assignment in case" do
+  it("codegens void assignment in case") do
     run("
       require \"prelude\"
 
@@ -33,7 +33,7 @@ describe "Code gen: void" do
       ").to_i.should eq(1)
   end
 
-  it "codegens void assignment in case with local variable" do
+  it("codegens void assignment in case with local variable") do
     run("
       require \"prelude\"
 
@@ -55,7 +55,7 @@ describe "Code gen: void" do
       ").to_i.should eq(1)
   end
 
-  it "codegens unreachable code" do
+  it("codegens unreachable code") do
     run(%(
       a = nil
       if a
@@ -64,7 +64,7 @@ describe "Code gen: void" do
       ))
   end
 
-  it "codegens no return assignment" do
+  it("codegens no return assignment") do
     codegen("
       lib LibC
         fun exit : NoReturn
@@ -75,7 +75,7 @@ describe "Code gen: void" do
       ")
   end
 
-  it "allows passing void as argument to method" do
+  it("allows passing void as argument to method") do
     codegen(%(
       lib LibC
         fun foo
@@ -92,7 +92,7 @@ describe "Code gen: void" do
     ))
   end
 
-  it "returns void from nil functions, doesn't crash when passing value" do
+  it("returns void from nil functions, doesn't crash when passing value") do
     run(%(
       def baz(x)
         1

--- a/spec/compiler/codegen/while_spec.cr
+++ b/spec/compiler/codegen/while_spec.cr
@@ -1,31 +1,31 @@
 require "../../spec_helper"
 
-describe "Codegen: while" do
-  it "codegens def with while" do
+describe("Codegen: while") do
+  it("codegens def with while") do
     run("def foo; while false; 1; end; end; foo")
   end
 
-  it "codegens while with false" do
+  it("codegens while with false") do
     run("a = 1; while false; a = 2; end; a").to_i.should eq(1)
   end
 
-  it "codegens while with non-false condition" do
+  it("codegens while with non-false condition") do
     run("a = 1; while a < 10; a = a + 1; end; a").to_i.should eq(10)
   end
 
-  it "break without value" do
+  it("break without value") do
     run("a = 0; while a < 10; a += 1; break; end; a").to_i.should eq(1)
   end
 
-  it "conditional break without value" do
+  it("conditional break without value") do
     run("a = 0; while a < 10; a += 1; break if a > 5; end; a").to_i.should eq(6)
   end
 
-  it "codegens endless while" do
+  it("codegens endless while") do
     codegen "while true; end"
   end
 
-  it "codegens while with declared var 1" do
+  it("codegens while with declared var 1") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -36,7 +36,7 @@ describe "Codegen: while" do
       ").to_i.should eq(0)
   end
 
-  it "codegens while with declared var 2" do
+  it("codegens while with declared var 2") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -51,7 +51,7 @@ describe "Codegen: while" do
       ").to_i.should eq(3)
   end
 
-  it "codegens while with declared var 3" do
+  it("codegens while with declared var 3") do
     run("
       struct Nil; def to_i; 0; end; end
 
@@ -67,7 +67,7 @@ describe "Codegen: while" do
       ").to_i.should eq(1)
   end
 
-  it "skip block with next" do
+  it("skip block with next") do
     run("
       i = 0
       x = 0
@@ -81,7 +81,7 @@ describe "Codegen: while" do
     ").to_i.should eq(25)
   end
 
-  it "doesn't crash on a = NoReturn" do
+  it("doesn't crash on a = NoReturn") do
     codegen(%(
       lib LibFoo
         fun foo : NoReturn
@@ -93,7 +93,7 @@ describe "Codegen: while" do
       ))
   end
 
-  it "doesn't crash on #2767" do
+  it("doesn't crash on #2767") do
     run(%(
       lib LibC
         fun exit(Int32) : NoReturn
@@ -110,7 +110,7 @@ describe "Codegen: while" do
       )).to_i.should eq(10)
   end
 
-  it "doesn't crash on #2767 (2)" do
+  it("doesn't crash on #2767 (2)") do
     run(%(
       lib LibC
         fun exit(Int32) : NoReturn
@@ -125,7 +125,7 @@ describe "Codegen: while" do
       )).to_i.should eq(10)
   end
 
-  it "doesn't crash on #2767 (3)" do
+  it("doesn't crash on #2767 (3)") do
     run(%(
       lib LibC
         fun exit(Int32) : NoReturn
@@ -146,7 +146,7 @@ describe "Codegen: while" do
       )).to_i.should eq(10)
   end
 
-  it "doesn't crash on #2767 (4)" do
+  it("doesn't crash on #2767 (4)") do
     run(%(
       lib LibC
         fun exit(Int32) : NoReturn

--- a/spec/compiler/codegen/yield_with_scope_spec.cr
+++ b/spec/compiler/codegen/yield_with_scope_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: yield with scope" do
-  it "uses scope in global method" do
+describe("Semantic: yield with scope") do
+  it("uses scope in global method") do
     run("
       require \"prelude\"
       def foo; with 1 yield; end
@@ -12,7 +12,7 @@ describe "Semantic: yield with scope" do
     ").to_i.should eq(2)
   end
 
-  it "uses scope in instance method" do
+  it("uses scope in instance method") do
     run("
       require \"prelude\"
       def foo; with 1 yield; end
@@ -33,7 +33,7 @@ describe "Semantic: yield with scope" do
     ").to_i.should eq(2)
   end
 
-  it "it uses self for instance method" do
+  it("it uses self for instance method") do
     run("
       require \"prelude\"
       def foo; with 1 yield; end
@@ -54,7 +54,7 @@ describe "Semantic: yield with scope" do
     ").to_i.should eq(10)
   end
 
-  it "it invokes global method inside block of yield scope" do
+  it("it invokes global method inside block of yield scope") do
     run("
       require \"prelude\"
 
@@ -72,7 +72,7 @@ describe "Semantic: yield with scope" do
     ").to_i.should eq(3)
   end
 
-  it "generate right code when yielding struct as scope" do
+  it("generate right code when yielding struct as scope") do
     run("
       struct Foo
         def bar; end
@@ -87,7 +87,7 @@ describe "Semantic: yield with scope" do
     ").to_i.should eq(1)
   end
 
-  it "doesn't explode if specifying &block but never using it (#181)" do
+  it("doesn't explode if specifying &block but never using it (#181)") do
     codegen(%(
       class Foo
         def a(&block)
@@ -102,7 +102,7 @@ describe "Semantic: yield with scope" do
       ))
   end
 
-  it "uses instance variable of enclosing scope" do
+  it("uses instance variable of enclosing scope") do
     run(%(
       class Foo
         def foo
@@ -126,7 +126,7 @@ describe "Semantic: yield with scope" do
       )).to_i.should eq(2)
   end
 
-  it "uses method of enclosing scope" do
+  it("uses method of enclosing scope") do
     run(%(
       class Foo
         def foo
@@ -150,7 +150,7 @@ describe "Semantic: yield with scope" do
       )).to_i.should eq(2)
   end
 
-  it "uses method of with object" do
+  it("uses method of with object") do
     run(%(
       class Foo
         def initialize
@@ -178,7 +178,7 @@ describe "Semantic: yield with scope" do
       )).to_i.should eq(2)
   end
 
-  it "yields with dispatch (#2171) (1)" do
+  it("yields with dispatch (#2171) (1)") do
     run(%(
       class Foo
         def method(x : Int32)
@@ -200,7 +200,7 @@ describe "Semantic: yield with scope" do
       )).to_i.should eq(10)
   end
 
-  it "yields virtual type (#2171) (2)" do
+  it("yields virtual type (#2171) (2)") do
     run(%(
       class Foo
         def method

--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 require "tempfile"
 
-describe "Compiler" do
-  it "compiles a file" do
+describe("Compiler") do
+  it("compiles a file") do
     tempfile = Tempfile.new "compiler_spec_output"
     tempfile.close
 
@@ -13,8 +13,8 @@ describe "Compiler" do
     `#{tempfile.path}`.should eq("Hello!")
   end
 
-  it "runs subcommand in preference to a filename " do
-    Dir.cd "#{__DIR__}/data/" do
+  it("runs subcommand in preference to a filename ") do
+    Dir.cd("#{__DIR__}/data/") do
       tempfile = Tempfile.new "compiler_spec_output"
       tempfile.close
 

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -51,8 +51,8 @@ end
 #
 #   ‸ marks location of the cursor to use
 #
-describe "context" do
-  it "includes args" do
+describe("context") do
+  it("includes args") do
     assert_context_includes %(
       def foo(a)
         ‸
@@ -63,7 +63,7 @@ describe "context" do
     ), "a", ["Int64"]
   end
 
-  it "consider different instances of def" do
+  it("consider different instances of def") do
     assert_context_includes %(
       def foo(a)
         ‸
@@ -75,7 +75,7 @@ describe "context" do
     ), "a", ["Int64", "String"]
   end
 
-  it "includes assignments" do
+  it("includes assignments") do
     assert_context_includes %(
       def foo(a)
         b = a
@@ -88,7 +88,7 @@ describe "context" do
     ), "b", ["Int64", "String"]
   end
 
-  it "includes block args" do
+  it("includes block args") do
     assert_context_includes %(
       def bar(x)
         yield x
@@ -107,7 +107,7 @@ describe "context" do
     ), "b", ["Int64", "String"]
   end
 
-  it "includes top level vars" do
+  it("includes top level vars") do
     assert_context_includes %(
       a = 0i64
       ‸
@@ -115,7 +115,7 @@ describe "context" do
     ), "a", ["Int64"]
   end
 
-  it "includes last call" do
+  it("includes last call") do
     assert_context_includes %(
       class Foo
         property lorem
@@ -131,7 +131,7 @@ describe "context" do
     ), "f.lorem", ["Int64"]
   end
 
-  it "does not includes temp variables" do
+  it("does not includes temp variables") do
     assert_context_keys %(
       a = 0i64
       ‸
@@ -139,7 +139,7 @@ describe "context" do
     ), "a"
   end
 
-  it "does includes regex special variables" do
+  it("does includes regex special variables") do
     assert_context_keys %(
       def foo
         s = "string"
@@ -152,7 +152,7 @@ describe "context" do
     ), "s", "$~"
   end
 
-  it "does includes self on classes" do
+  it("does includes self on classes") do
     assert_context_includes %(
       class Foo
         def foo
@@ -167,7 +167,7 @@ describe "context" do
     ), "self", ["Foo"]
   end
 
-  it "does includes args, instance vars, local variables and expressions on instance methods" do
+  it("does includes args, instance vars, local variables and expressions on instance methods") do
     assert_context_keys %(
       class Foo
         def foo(the_arg)
@@ -183,7 +183,7 @@ describe "context" do
     ), "self", "@ivar", "the_arg", "the_arg.foo(self)"
   end
 
-  it "can handle union types" do
+  it("can handle union types") do
     assert_context_includes %(
     a = if rand() > 0
       1i64
@@ -195,7 +195,7 @@ describe "context" do
     ), "a", ["(Int64 | String)"]
   end
 
-  it "can display text output" do
+  it("can display text output") do
     run_context_tool(%(
     a = if rand() > 0
       1i64
@@ -216,7 +216,7 @@ describe "context" do
     end
   end
 
-  it "can display json output" do
+  it("can display json output") do
     run_context_tool(%(
     a = if rand() > 0
       1i64
@@ -232,7 +232,7 @@ describe "context" do
     end
   end
 
-  it "can get context of empty def" do
+  it("can get context of empty def") do
     assert_context_includes %(
     def foo(a)
       ‸
@@ -242,7 +242,7 @@ describe "context" do
     ), "a", ["Int64"]
   end
 
-  it "can get context of empty yielded block" do
+  it("can get context of empty yielded block") do
     assert_context_includes %(
     def it_like
       yield
@@ -254,7 +254,7 @@ describe "context" do
     ), "a", ["Int64"]
   end
 
-  it "can get context of yielded block" do
+  it("can get context of yielded block") do
     assert_context_keys %(
     def foo(a)
       b = a + 1
@@ -267,7 +267,7 @@ describe "context" do
     ), "a", "b"
   end
 
-  it "can get context of nested yielded block" do
+  it("can get context of nested yielded block") do
     assert_context_keys %(
     def foo(a)
       b = a + 1
@@ -286,7 +286,7 @@ describe "context" do
     ), "a", "b"
   end
 
-  it "can get context inside a module" do
+  it("can get context inside a module") do
     assert_context_includes %(
     module Foo
       class Bar
@@ -300,7 +300,7 @@ describe "context" do
     ), "o", ["String"]
   end
 
-  it "can get context inside class methods" do
+  it("can get context inside class methods") do
     assert_context_includes %(
     class Bar
       def self.bar(o)
@@ -312,7 +312,7 @@ describe "context" do
     ), "o", ["String"]
   end
 
-  it "can get context inside initialize" do
+  it("can get context inside initialize") do
     assert_context_keys %(
     class Bar
       def initialize(@ivar : String)
@@ -324,7 +324,7 @@ describe "context" do
     ), "self", "@ivar", "ivar"
   end
 
-  it "can get context in generic class" do
+  it("can get context in generic class") do
     assert_context_keys %(
     class Foo(T, S)
       def foo(a)
@@ -346,7 +346,7 @@ describe "context" do
     ), "T", ["String"]
   end
 
-  it "can get context in contained class' class method" do
+  it("can get context in contained class' class method") do
     assert_context_keys %(
     module Baz
       class Bar(T)
@@ -362,7 +362,7 @@ describe "context" do
     ), "self", "a"
   end
 
-  it "use type filters from is_a?" do
+  it("use type filters from is_a?") do
     assert_context_includes %(
     def foo(c)
       if c.is_a?(String)
@@ -374,7 +374,7 @@ describe "context" do
     ), "c", ["String"]
   end
 
-  it "use type filters from if var" do
+  it("use type filters from if var") do
     assert_context_includes %(
     def foo(c)
       if c
@@ -386,7 +386,7 @@ describe "context" do
     ), "c", ["String"]
   end
 
-  it "can get context in file private method" do
+  it("can get context in file private method") do
     assert_context_keys %(
     private def foo(a)
       ‸
@@ -396,7 +396,7 @@ describe "context" do
     ), "a"
   end
 
-  it "can get context in file private module" do
+  it("can get context in file private module") do
     assert_context_keys %(
     private module Foo
       def self.foo(a)
@@ -408,12 +408,12 @@ describe "context" do
     ), "self", "a"
   end
 
-  it "can't get context from uncalled method" do
-    run_context_tool %(
+  it("can't get context from uncalled method") do
+    run_context_tool(%(
     def foo(value)
       ‸
     end
-    ) do |result|
+    )) do |result|
       result.status.should eq("failed")
       result.message.should match(/never called/)
     end

--- a/spec/compiler/crystal/tools/doc_spec.cr
+++ b/spec/compiler/crystal/tools/doc_spec.cr
@@ -7,9 +7,9 @@ private def assert_matches_pattern(url, **options)
   end
 end
 
-describe Crystal::Doc::Generator do
-  describe "GIT_REMOTE_PATTERNS" do
-    it "matches github repos" do
+describe(Crystal::Doc::Generator) do
+  describe("GIT_REMOTE_PATTERNS") do
+    it("matches github repos") do
       assert_matches_pattern "https://www.github.com/foo/bar", user: "foo", repo: "bar"
       assert_matches_pattern "http://www.github.com/foo/bar", user: "foo", repo: "bar"
       assert_matches_pattern "http://github.com/foo/bar", user: "foo", repo: "bar"
@@ -27,7 +27,7 @@ describe Crystal::Doc::Generator do
       assert_matches_pattern "https://github.com/foo_bar/_baz-buzz.cx", user: "foo_bar", repo: "_baz-buzz.cx"
     end
 
-    it "matches gitlab repos" do
+    it("matches gitlab repos") do
       assert_matches_pattern "https://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
       assert_matches_pattern "http://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
       assert_matches_pattern "http://gitlab.com/foo/bar", user: "foo", repo: "bar"

--- a/spec/compiler/crystal/tools/expand_spec.cr
+++ b/spec/compiler/crystal/tools/expand_spec.cr
@@ -42,7 +42,7 @@ private def assert_expand(code, expected_result)
 end
 
 private def assert_expand(code, expected_result)
-  run_expand_tool code do |result|
+  run_expand_tool(code) do |result|
     result.status.should eq("ok")
     result.message.should eq("#{expected_result.size} expansion#{expected_result.size >= 2 ? "s" : ""} found")
     result.expansions.not_nil!.zip(expected_result) do |expansion, expected_result|
@@ -64,44 +64,44 @@ private def assert_expand_simple(code, expanded, original = code.gsub('‸', "")
 end
 
 private def assert_expand_fail(code, message = "no expansion found")
-  run_expand_tool code do |result|
+  run_expand_tool(code) do |result|
     result.status.should eq("failed")
     result.message.should eq(message)
   end
 end
 
-describe "expand" do
-  it "expands macro expression {{ ... }}" do
+describe("expand") do
+  it("expands macro expression {{ ... }}") do
     code = "‸{{ 1 + 2 }}"
 
     assert_expand_simple code, "3"
   end
 
-  it "expands macro expression {{ ... }} with cursor inside it" do
+  it("expands macro expression {{ ... }} with cursor inside it") do
     code = "{{ 1 ‸+ 2 }}"
 
     assert_expand_simple code, "3"
   end
 
-  it "expands macro expression {{ ... }} with cursor end of it" do
+  it("expands macro expression {{ ... }} with cursor end of it") do
     code = "{{ 1 + 2 }‸}"
 
     assert_expand_simple code, "3"
   end
 
-  it "expands macro expression {% ... %}" do
+  it("expands macro expression {% ... %}") do
     code = %(‸{% "test" %})
 
     assert_expand_simple code, ""
   end
 
-  it "expands macro expression {% ... %} with cursor at end of it" do
+  it("expands macro expression {% ... %} with cursor at end of it") do
     code = %({% "test" ‸%})
 
     assert_expand_simple code, ""
   end
 
-  it "expands macro control {% if %}" do
+  it("expands macro control {% if %}") do
     code = <<-CODE
     {%‸ if 1 == 1 %}
       true
@@ -111,7 +111,7 @@ describe "expand" do
     assert_expand_simple code, "true"
   end
 
-  it "expands macro control {% if %} with cursor inside it" do
+  it("expands macro control {% if %} with cursor inside it") do
     code = <<-CODE
     {% if 1 == 1 %}
       tr‸ue
@@ -121,7 +121,7 @@ describe "expand" do
     assert_expand_simple code, "true"
   end
 
-  it "expands macro control {% if %} with cursor at end of it" do
+  it("expands macro control {% if %} with cursor at end of it") do
     code = <<-CODE
     {% if 1 == 1 %}
       true
@@ -131,7 +131,7 @@ describe "expand" do
     assert_expand_simple code, "true"
   end
 
-  it "expands macro control {% if %} with indent" do
+  it("expands macro control {% if %} with indent") do
     code = <<-CODE
     begin
       {% if 1 == 1 %}
@@ -149,7 +149,7 @@ describe "expand" do
     assert_expand_simple code, original: original, expanded: "true"
   end
 
-  it "expands macro control {% for %}" do
+  it("expands macro control {% for %}") do
     code = <<-CODE
     {% f‸or x in 1..3 %}
       {{ x }}
@@ -159,7 +159,7 @@ describe "expand" do
     assert_expand_simple code, "1\n2\n3\n"
   end
 
-  it "expands macro control {% for %} with cursor inside it" do
+  it("expands macro control {% for %} with cursor inside it") do
     code = <<-CODE
     {% for x in 1..3 %}
      ‸ {{ x }}
@@ -169,7 +169,7 @@ describe "expand" do
     assert_expand_simple code, "1\n2\n3\n"
   end
 
-  it "expands macro control {% for %} with cursor at end of it" do
+  it("expands macro control {% for %} with cursor at end of it") do
     code = <<-CODE
     {% for x in 1..3 %}
       {{ x }}
@@ -179,7 +179,7 @@ describe "expand" do
     assert_expand_simple code, "1\n2\n3\n"
   end
 
-  it "expands macro control {% for %} with indent" do
+  it("expands macro control {% for %} with indent") do
     code = <<-CODE
     begin
       {% f‸or x in 1..3 %}
@@ -197,7 +197,7 @@ describe "expand" do
     assert_expand_simple code, original: original, expanded: "1\n2\n3\n"
   end
 
-  it "expands simple macro" do
+  it("expands simple macro") do
     code = <<-CODE
     macro foo
       1
@@ -206,7 +206,7 @@ describe "expand" do
     ‸foo
     CODE
 
-    assert_expand_simple code, original: "foo", expanded: "1" do |expansion|
+    assert_expand_simple(code, original: "foo", expanded: "1") do |expansion|
       expansion.expanded_macros.size.should eq(1)
       macros = expansion.expanded_macros[0]
       macros.size.should eq(1)
@@ -219,7 +219,7 @@ describe "expand" do
     end
   end
 
-  it "expands simple macro with cursor inside it" do
+  it("expands simple macro with cursor inside it") do
     code = <<-CODE
     macro foo
       1
@@ -231,7 +231,7 @@ describe "expand" do
     assert_expand_simple code, original: "foo", expanded: "1"
   end
 
-  it "expands simple macro with cursor at end of it" do
+  it("expands simple macro with cursor at end of it") do
     code = <<-CODE
     macro foo
       1
@@ -243,7 +243,7 @@ describe "expand" do
     assert_expand_simple code, original: "foo", expanded: "1"
   end
 
-  it "expands complex macro" do
+  it("expands complex macro") do
     code = <<-CODE
     macro foo
       {% if true %}
@@ -260,7 +260,7 @@ describe "expand" do
     assert_expand_simple code, original: "foo", expanded: %("if true"\n"1"\n"2"\n"3"\n)
   end
 
-  it "expands macros with 2 level" do
+  it("expands macros with 2 level") do
     code = <<-CODE
     macro foo
       :foo
@@ -274,7 +274,7 @@ describe "expand" do
     b‸ar
     CODE
 
-    assert_expand code, [["bar", "foo\n:bar\n", ":foo\n:bar\n"]] do |result|
+    assert_expand(code, [["bar", "foo\n:bar\n", ":foo\n:bar\n"]]) do |result|
       expansion = result.expansions.not_nil![0]
 
       macros = expansion.expanded_macros
@@ -296,7 +296,7 @@ describe "expand" do
     end
   end
 
-  it "expands macros with 3 level" do
+  it("expands macros with 3 level") do
     code = <<-CODE
     macro foo
       :foo
@@ -316,7 +316,7 @@ describe "expand" do
     ba‸z
     CODE
 
-    assert_expand code, [["baz", "foo\nbar\n:baz\n", ":foo\nfoo\n:bar\n:baz\n", ":foo\n:foo\n:bar\n:baz\n"]] do |result|
+    assert_expand(code, [["baz", "foo\nbar\n:baz\n", ":foo\nfoo\n:bar\n:baz\n", ":foo\n:foo\n:bar\n:baz\n"]]) do |result|
       expansion = result.expansions.not_nil![0]
 
       macros = expansion.expanded_macros
@@ -351,7 +351,7 @@ describe "expand" do
     end
   end
 
-  it "expands macro of module" do
+  it("expands macro of module") do
     code = <<-CODE
     module Foo
       macro foo
@@ -363,7 +363,7 @@ describe "expand" do
     Foo.f‸oo
     CODE
 
-    assert_expand_simple code, original: "Foo.foo", expanded: ":Foo\n:foo\n" do |expansion|
+    assert_expand_simple(code, original: "Foo.foo", expanded: ":Foo\n:foo\n") do |expansion|
       expansion.expanded_macros.size.should eq(1)
       macros = expansion.expanded_macros[0]
       macros.size.should eq(1)
@@ -376,7 +376,7 @@ describe "expand" do
     end
   end
 
-  it "expands macro of module with cursor at module name" do
+  it("expands macro of module with cursor at module name") do
     code = <<-CODE
     module Foo
       macro foo
@@ -391,7 +391,7 @@ describe "expand" do
     assert_expand_simple code, original: "Foo.foo", expanded: ":Foo\n:foo\n"
   end
 
-  it "expands macro of module with cursor at dot" do
+  it("expands macro of module with cursor at dot") do
     code = <<-CODE
     module Foo
       macro foo
@@ -406,7 +406,7 @@ describe "expand" do
     assert_expand_simple code, original: "Foo.foo", expanded: ":Foo\n:foo\n"
   end
 
-  it "expands macro of module inside module" do
+  it("expands macro of module inside module") do
     code = <<-CODE
     module Foo
       macro foo
@@ -422,7 +422,7 @@ describe "expand" do
   end
 
   %w(module class struct enum lib).each do |keyword|
-    it "expands macro expression inside #{keyword}" do
+    it("expands macro expression inside #{keyword}") do
       code = <<-CODE
       #{keyword} Foo
         ‸{{ "Foo = 1".id }}
@@ -432,7 +432,7 @@ describe "expand" do
       assert_expand_simple code, original: %({{ "Foo = 1".id }}), expanded: "Foo = 1"
     end
 
-    it "expands macro expression inside private #{keyword}" do
+    it("expands macro expression inside private #{keyword}") do
       code = <<-CODE
       private #{keyword} Foo
         ‸{{ "Foo = 1".id }}
@@ -443,7 +443,7 @@ describe "expand" do
     end
 
     unless keyword == "lib"
-      it "expands macro expression inside def of private #{keyword}" do
+      it("expands macro expression inside def of private #{keyword}") do
         code = <<-CODE
         private #{keyword} Foo
           Foo = 1
@@ -461,7 +461,7 @@ describe "expand" do
   end
 
   %w(struct union).each do |keyword|
-    it "expands macro expression inside C #{keyword}" do
+    it("expands macro expression inside C #{keyword}") do
       code = <<-CODE
       lib Foo
         #{keyword} Foo
@@ -473,7 +473,7 @@ describe "expand" do
       assert_expand_simple code, original: %({{ "Foo = 1".id }}), expanded: "Foo = 1"
     end
 
-    it "expands macro expression inside C #{keyword} of private lib" do
+    it("expands macro expression inside C #{keyword} of private lib") do
       code = <<-CODE
       private lib Foo
         #{keyword} Foo
@@ -487,7 +487,7 @@ describe "expand" do
   end
 
   ["", "private "].each do |prefix|
-    it "expands macro expression inside #{prefix}def" do
+    it("expands macro expression inside #{prefix}def") do
       code = <<-CODE
       #{prefix}def foo(x : T) forall T
         ‸{{ T }}
@@ -503,7 +503,7 @@ describe "expand" do
       ]
     end
 
-    it "expands macro expression inside def of #{prefix}module" do
+    it("expands macro expression inside def of #{prefix}module") do
       code = <<-CODE
       #{prefix}module Foo(T)
         def self.foo
@@ -523,7 +523,7 @@ describe "expand" do
       ]
     end
 
-    it "expands macro expression inside def of nested #{prefix}module" do
+    it("expands macro expression inside def of nested #{prefix}module") do
       code = <<-CODE
       #{prefix}module Foo
         #{prefix}module Bar(T)
@@ -546,7 +546,7 @@ describe "expand" do
     end
   end
 
-  it "expands macro expression inside fun" do
+  it("expands macro expression inside fun") do
     code = <<-CODE
     fun foo
       {{ :foo‸ }}
@@ -556,7 +556,7 @@ describe "expand" do
     assert_expand_simple code, original: "{{ :foo }}", expanded: ":foo"
   end
 
-  it "doesn't expand macro expression" do
+  it("doesn't expand macro expression") do
     code = <<-CODE
     {{ 1 + 2 }}
     ‸
@@ -565,7 +565,7 @@ describe "expand" do
     assert_expand_fail code
   end
 
-  it "doesn't expand macro expression with cursor out of end" do
+  it("doesn't expand macro expression with cursor out of end") do
     code = <<-CODE
     {{ 1 + 2 }}‸
     CODE
@@ -573,7 +573,7 @@ describe "expand" do
     assert_expand_fail code
   end
 
-  it "doesn't expand macro expression" do
+  it("doesn't expand macro expression") do
     code = <<-CODE
     ‸  {{ 1 + 2 }}
     CODE
@@ -581,7 +581,7 @@ describe "expand" do
     assert_expand_fail code
   end
 
-  it "doesn't expand normal call" do
+  it("doesn't expand normal call") do
     code = <<-CODE
     def foo
       1
@@ -593,7 +593,7 @@ describe "expand" do
     assert_expand_fail code, "no expansion found: foo may not be a macro"
   end
 
-  it "expands macro with doc" do
+  it("expands macro with doc") do
     code = <<-CODE
     macro foo(x)
       # string of {{ x }}

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -43,8 +43,8 @@ end
 #   ༓ marks the expected implementations to be found
 #   ‸ marks the method call which implementations wants to be found
 #
-describe "implementations" do
-  it "find top level method calls" do
+describe("implementations") do
+  it("find top level method calls") do
     assert_implementations %(
       ༓def foo
         1
@@ -54,7 +54,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementors of different classes" do
+  it("find implementors of different classes") do
     assert_implementations %(
       class Foo
         ༓def foo
@@ -75,7 +75,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementors of classes that are only used" do
+  it("find implementors of classes that are only used") do
     assert_implementations %(
       class Foo
         ༓def foo
@@ -96,7 +96,7 @@ describe "implementations" do
     )
   end
 
-  it "find method calls inside while" do
+  it("find method calls inside while") do
     assert_implementations %(
       ༓def foo
         1
@@ -108,7 +108,7 @@ describe "implementations" do
     )
   end
 
-  it "find method calls inside while cond" do
+  it("find method calls inside while cond") do
     assert_implementations %(
       ༓def foo
         1
@@ -120,7 +120,7 @@ describe "implementations" do
     )
   end
 
-  it "find method calls inside if" do
+  it("find method calls inside if") do
     assert_implementations %(
       ༓def foo
         1
@@ -132,7 +132,7 @@ describe "implementations" do
     )
   end
 
-  it "find method calls inside trailing if" do
+  it("find method calls inside trailing if") do
     assert_implementations %(
       ༓def foo
         1
@@ -142,7 +142,7 @@ describe "implementations" do
     )
   end
 
-  it "find method calls inside rescue" do
+  it("find method calls inside rescue") do
     assert_implementations %(
       ༓def foo
         1
@@ -156,7 +156,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation from macro expansions" do
+  it("find implementation from macro expansions") do
     assert_implementations %(
       macro foo
         def bar
@@ -172,7 +172,7 @@ describe "implementations" do
     )
   end
 
-  it "find full trace for macro expansions" do
+  it("find full trace for macro expansions") do
     visitor, result = processed_implementation_visitor(%(
       macro foo
         def bar
@@ -210,7 +210,7 @@ describe "implementations" do
     exp.filename.should eq(".")
   end
 
-  it "can display text output" do
+  it("can display text output") do
     visitor, result = processed_implementation_visitor(%(
       macro foo
         def bar
@@ -234,7 +234,7 @@ describe "implementations" do
 )
   end
 
-  it "can display json output" do
+  it("can display json output") do
     _, result = processed_implementation_visitor(%(
       macro foo
         def bar
@@ -254,7 +254,7 @@ describe "implementations" do
     end.should eq %({"status":"ok","message":"1 implementation found","implementations":[{"line":11,"column":7,"filename":".","expands":{"line":8,"column":9,"filename":".","macro":"baz","expands":{"line":3,"column":9,"filename":".","macro":"foo"}}}]})
   end
 
-  it "find implementation in class methods" do
+  it("find implementation in class methods") do
     assert_implementations %(
     ༓def foo
     end
@@ -268,7 +268,7 @@ describe "implementations" do
     Bar.bar)
   end
 
-  it "find implementation in generic class" do
+  it("find implementation in generic class") do
     assert_implementations %(
     class Foo
       ༓def self.foo
@@ -291,7 +291,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation in generic class methods" do
+  it("find implementation in generic class methods") do
     assert_implementations %(
     ༓def foo
     end
@@ -306,7 +306,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation inside a module class" do
+  it("find implementation inside a module class") do
     assert_implementations %(
     ༓def foo
     end
@@ -323,7 +323,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation inside contained class' class method" do
+  it("find implementation inside contained class' class method") do
     assert_implementations %(
     ༓def foo
 
@@ -341,7 +341,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation inside contained file private method" do
+  it("find implementation inside contained file private method") do
     assert_implementations %(
     private ༓def foo
     end
@@ -354,7 +354,7 @@ describe "implementations" do
     )
   end
 
-  it "find implementation inside contained file private class' class method" do
+  it("find implementation inside contained file private class' class method") do
     assert_implementations %(
     private ༓def foo
     end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -5,8 +5,8 @@ require "compiler/crystal/config"
 require "compiler/crystal/tools/init"
 
 private def describe_file(name, &block : String ->)
-  describe name do
-    it "has proper contents" do
+  describe(name) do
+    it("has proper contents") do
       block.call(File.read("tmp/#{name}"))
     end
   end
@@ -19,7 +19,7 @@ private def run_init_project(skeleton_type, name, dir, author, email, github_nam
 end
 
 module Crystal
-  describe Init::InitProject do
+  describe(Init::InitProject) do
     `[ -d tmp/example ] && rm -r tmp/example`
     `[ -d tmp/example_app ] && rm -r tmp/example_app`
 
@@ -29,28 +29,28 @@ module Crystal
     run_init_project("lib", "camel_example-camel_lib", "tmp/camel_example-camel_lib", "John Smith", "john@smith.com", "jsmith")
     run_init_project("lib", "example", "tmp/other-example-directory", "John Smith", "john@smith.com", "jsmith")
 
-    describe_file "example-lib/src/example-lib.cr" do |file|
+    describe_file("example-lib/src/example-lib.cr") do |file|
       file.should contain("Example::Lib")
     end
 
-    describe_file "camel_example-camel_lib/src/camel_example-camel_lib.cr" do |file|
+    describe_file("camel_example-camel_lib/src/camel_example-camel_lib.cr") do |file|
       file.should contain("CamelExample::CamelLib")
     end
 
-    describe_file "example/.gitignore" do |gitignore|
+    describe_file("example/.gitignore") do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should contain("/shard.lock")
       gitignore.should contain("/lib/")
     end
 
-    describe_file "example_app/.gitignore" do |gitignore|
+    describe_file("example_app/.gitignore") do |gitignore|
       gitignore.should contain("/.shards/")
       gitignore.should_not contain("/shard.lock")
       gitignore.should contain("/lib/")
     end
 
     ["example", "example_app", "example-lib", "camel_example-camel_lib"].each do |name|
-      describe_file "#{name}/.editorconfig" do |editorconfig|
+      describe_file("#{name}/.editorconfig") do |editorconfig|
         parsed = INI.parse(editorconfig)
         cr_ext = parsed["*.cr"]
         cr_ext["charset"].should eq("utf-8")
@@ -62,11 +62,11 @@ module Crystal
       end
     end
 
-    describe_file "example/LICENSE" do |license|
+    describe_file("example/LICENSE") do |license|
       license.should match %r{Copyright \(c\) \d+ John Smith}
     end
 
-    describe_file "example/README.md" do |readme|
+    describe_file("example/README.md") do |readme|
       readme.should contain("# example")
 
       readme.should contain(%{```yaml
@@ -82,7 +82,7 @@ dependencies:
       readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
     end
 
-    describe_file "example_app/README.md" do |readme|
+    describe_file("example_app/README.md") do |readme|
       readme.should contain("# example")
 
       readme.should_not contain(%{```yaml
@@ -98,7 +98,7 @@ dependencies:
       readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
     end
 
-    describe_file "example/shard.yml" do |shard_yml|
+    describe_file("example/shard.yml") do |shard_yml|
       parsed = YAML.parse(shard_yml)
       parsed["name"].should eq("example")
       parsed["version"].should eq("0.1.0")
@@ -108,18 +108,18 @@ dependencies:
       parsed["targets"]?.should be_nil
     end
 
-    describe_file "example_app/shard.yml" do |shard_yml|
+    describe_file("example_app/shard.yml") do |shard_yml|
       parsed = YAML.parse(shard_yml)
       parsed["targets"].should eq({"example_app" => {"main" => "src/example_app.cr"}})
     end
 
-    describe_file "example/.travis.yml" do |travis|
+    describe_file("example/.travis.yml") do |travis|
       parsed = YAML.parse(travis)
 
       parsed["language"].should eq("crystal")
     end
 
-    describe_file "example/src/example.cr" do |example|
+    describe_file("example/src/example.cr") do |example|
       example.should eq(%{require "./example/*"
 
 # TODO: Write documentation for `Example`
@@ -129,20 +129,20 @@ end
 })
     end
 
-    describe_file "example/src/example/version.cr" do |version|
+    describe_file("example/src/example/version.cr") do |version|
       version.should eq(%{module Example
   VERSION = "0.1.0"
 end
 })
     end
 
-    describe_file "example/spec/spec_helper.cr" do |example|
+    describe_file("example/spec/spec_helper.cr") do |example|
       example.should eq(%{require "spec"
 require "../src/example"
 })
     end
 
-    describe_file "example/spec/example_spec.cr" do |example|
+    describe_file("example/spec/example_spec.cr") do |example|
       example.should eq(%{require "./spec_helper"
 
 describe Example do
@@ -155,13 +155,13 @@ end
 })
     end
 
-    describe_file "example/.git/config" { }
+    describe_file("example/.git/config") { }
 
-    describe_file "other-example-directory/.git/config" { }
+    describe_file("other-example-directory/.git/config") { }
   end
 
-  describe Init do
-    it "prints error if a directory already present" do
+  describe(Init) do
+    it("prints error if a directory already present") do
       Dir.mkdir_p("#{__DIR__}/tmp")
 
       `bin/crystal init lib "#{__DIR__}/tmp" 2>&1 >/dev/null`.should contain("file or directory #{__DIR__}/tmp already exists")
@@ -169,7 +169,7 @@ end
       `rm -rf #{__DIR__}/tmp`
     end
 
-    it "prints error if a file already present" do
+    it("prints error if a file already present") do
       File.open("#{__DIR__}/tmp", "w")
 
       `bin/crystal init lib "#{__DIR__}/tmp" 2>&1 >/dev/null`.should contain("file or directory #{__DIR__}/tmp already exists")
@@ -177,7 +177,7 @@ end
       File.delete("#{__DIR__}/tmp")
     end
 
-    it "honors the custom set directory name" do
+    it("honors the custom set directory name") do
       Dir.mkdir_p("tmp")
 
       `bin/crystal init lib tmp 2>&1 >/dev/null`.should contain("file or directory tmp already exists")

--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -43,8 +43,8 @@ private class TestAgent < Playground::Agent
   end
 end
 
-describe Playground::Agent do
-  it "should send json messages and return inspected value" do
+describe(Playground::Agent) do
+  it("should send json messages and return inspected value") do
     agent = TestAgent.new(".", 32)
     agent.i(1) { 5 }.should eq(5)
     agent.last_message.should eq(%({"tag":32,"type":"value","line":1,"value":"5","value_type":"Int32"}))
@@ -54,8 +54,8 @@ describe Playground::Agent do
   end
 end
 
-describe Playground::AgentInstrumentorTransformer do
-  it "instrument literals" do
+describe(Playground::AgentInstrumentorTransformer) do
+  it("instrument literals") do
     assert_agent %(nil), %(_p.i(1) { nil })
     assert_agent %(5), %(_p.i(1) { 5 })
     assert_agent %(5.0), %(_p.i(1) { 5.0 })
@@ -67,60 +67,60 @@ describe Playground::AgentInstrumentorTransformer do
     assert_agent %(/a/), %(_p.i(1) { /a/ })
   end
 
-  it "instrument literals with expression names" do
+  it("instrument literals with expression names") do
     assert_agent %({1, 2}), %(_p.i(1, ["1", "2"]) { {1, 2} })
     assert_agent %({x, x + y}), %(_p.i(1, ["x", "x + y"]) { {x, x + y} })
     assert_agent %(a = {x, x + y}), %(a = _p.i(1, ["x", "x + y"]) { {x, x + y} })
   end
 
-  it "instrument single variables expressions" do
+  it("instrument single variables expressions") do
     assert_agent %(x), %(_p.i(1) { x })
   end
 
-  it "instrument string interpolations" do
+  it("instrument string interpolations") do
     assert_agent %("lorem \#{a} \#{b}"), %(_p.i(1) { "lorem \#{a} \#{b}" })
   end
 
-  it "instrument assignments in the rhs" do
+  it("instrument assignments in the rhs") do
     assert_agent %(a = 4), %(a = _p.i(1) { 4 })
   end
 
-  it "do not instrument constants assignments" do
+  it("do not instrument constants assignments") do
     assert_agent %(A = 4), %(A = 4)
   end
 
-  it "instrument not expressions" do
+  it("instrument not expressions") do
     assert_agent %(!true), %(_p.i(1) { !true })
   end
 
-  it "instrument binary expressions" do
+  it("instrument binary expressions") do
     assert_agent %(a && b), %(_p.i(1) { a && b })
     assert_agent %(a || b), %(_p.i(1) { a || b })
   end
 
-  it "instrument chained comparisons (#4663)" do
+  it("instrument chained comparisons (#4663)") do
     assert_agent %(1 <= 2 <= 3), %(_p.i(1) { 1 <= 2 <= 3 })
   end
 
-  it "instrument unary expressions" do
+  it("instrument unary expressions") do
     assert_agent %(pointerof(x)), %(_p.i(1) { pointerof(x) })
   end
 
-  it "instrument is_a? expressions" do
+  it("instrument is_a? expressions") do
     assert_agent %(x.is_a?(Foo)), %(_p.i(1) { x.is_a?(Foo) })
   end
 
-  it "instrument ivar with obj" do
+  it("instrument ivar with obj") do
     assert_agent %(x.@foo), %(_p.i(1) { x.@foo })
   end
 
-  it "instrument multi assignments in the rhs" do
+  it("instrument multi assignments in the rhs") do
     assert_agent %(a, b = t), %(a, b = _p.i(1) { t })
     assert_agent %(a, b = d, f), %(a, b = _p.i(1, ["d", "f"]) { {d, f} })
     assert_agent %(a, b = {d, f}), %(a, b = _p.i(1, ["d", "f"]) { {d, f} })
   end
 
-  it "instrument puts with args" do
+  it("instrument puts with args") do
     assert_agent %(puts 3), %(puts(_p.i(1) { 3 }))
     assert_agent %(puts a, 2, b), %(puts(*_p.i(1, ["a", "2", "b"]) { {a, 2, b} }))
     assert_agent %(puts *{3}), %(puts(*_p.i(1, ["3"]) { {3} }))
@@ -128,13 +128,13 @@ describe Playground::AgentInstrumentorTransformer do
     assert_agent_eq %(puts), %(puts)
   end
 
-  it "instrument print with args" do
+  it("instrument print with args") do
     assert_agent %(print 3), %(print(_p.i(1) { 3 }))
     assert_agent %(print a, 2, b), %(print(*_p.i(1, ["a", "2", "b"]) { {a, 2, b} }))
     assert_agent_eq %(print), %(print)
   end
 
-  it "instrument single statement def" do
+  it("instrument single statement def") do
     assert_agent %(
     def foo
       4
@@ -145,7 +145,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument single statement var def" do
+  it("instrument single statement var def") do
     assert_agent %(
     def foo(x)
       x
@@ -156,7 +156,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument multi statement def" do
+  it("instrument multi statement def") do
     assert_agent %(
     def foo
       2
@@ -169,7 +169,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument returns inside def" do
+  it("instrument returns inside def") do
     assert_agent %(
     def foo
       return 4
@@ -180,7 +180,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument class defs" do
+  it("instrument class defs") do
     assert_agent %(
     class Foo
       def initialize
@@ -209,7 +209,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument instance variable and class variables reads and writes" do
+  it("instrument instance variable and class variables reads and writes") do
     assert_agent %(
     class Foo
       def initialize
@@ -238,7 +238,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "do not instrument class initializing arguments" do
+  it("do not instrument class initializing arguments") do
     assert_agent %(
     class Foo
       def initialize(@x, @y)
@@ -256,7 +256,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "allow visibility modifiers" do
+  it("allow visibility modifiers") do
     assert_agent %(
     class Foo
       private def bar
@@ -277,7 +277,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "do not instrument macro calls in class" do
+  it("do not instrument macro calls in class") do
     assert_agent %(
     class Foo
       property foo
@@ -288,7 +288,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument nested class defs" do
+  it("instrument nested class defs") do
     assert_agent %(
     class Bar
       class Foo
@@ -307,7 +307,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "do not instrument records class" do
+  it("do not instrument records class") do
     assert_agent %(
     record Foo, x, y
     ), <<-CR
@@ -315,7 +315,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "do not instrument top level macro calls" do
+  it("do not instrument top level macro calls") do
     assert_agent(<<-CR
     macro bar
       def foo
@@ -337,7 +337,7 @@ describe Playground::AgentInstrumentorTransformer do
     )
   end
 
-  it "do not instrument class/module declared macro" do
+  it("do not instrument class/module declared macro") do
     assert_agent(<<-CR
     module Bar
       macro bar
@@ -371,7 +371,7 @@ describe Playground::AgentInstrumentorTransformer do
     )
   end
 
-  it "instrument inside modules" do
+  it("instrument inside modules") do
     assert_agent %(
     module Bar
       class Baz
@@ -394,7 +394,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument if statement" do
+  it("instrument if statement") do
     assert_agent %(
     if a
       b
@@ -410,7 +410,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument unless statement" do
+  it("instrument unless statement") do
     assert_agent %(
     unless a
       b
@@ -426,7 +426,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument while statement" do
+  it("instrument while statement") do
     assert_agent %(
     while a
       b
@@ -440,7 +440,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument case statement" do
+  it("instrument case statement") do
     # mind multi cond cases and non-cond cases before instrumenting single-cond cases
     assert_agent %(
     case a
@@ -463,7 +463,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument blocks and single yields" do
+  it("instrument blocks and single yields") do
     assert_agent %(
     def foo(x)
       yield x
@@ -483,7 +483,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument blocks and but non multi yields" do
+  it("instrument blocks and but non multi yields") do
     assert_agent %(
     def foo(x)
       yield x, 1
@@ -503,7 +503,7 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument nested blocks unless in same line" do
+  it("instrument nested blocks unless in same line") do
     assert_agent %(
     a = foo do
       'a'
@@ -531,11 +531,11 @@ describe Playground::AgentInstrumentorTransformer do
     CR
   end
 
-  it "instrument typeof" do
+  it("instrument typeof") do
     assert_agent %(typeof(5)), %(_p.i(1) { typeof(5) })
   end
 
-  it "instrument exceptions" do
+  it("instrument exceptions") do
     assert_agent %(
     begin
       raise "The exception"
@@ -583,6 +583,6 @@ private def assert_compile(source)
   result = compiler.compile sources, "fake-no-build"
 end
 
-describe Playground::Session do
+describe(Playground::Session) do
   it { assert_compile %(puts "1") }
 end

--- a/spec/compiler/crystal/tools/table_print_spec.cr
+++ b/spec/compiler/crystal/tools/table_print_spec.cr
@@ -11,19 +11,19 @@ private def assert_table(expected)
   actual.should eq(expected[1..-1])
 end
 
-describe Crystal::TablePrint do
-  it "single cell" do
-    assert_table %(
-| A |) do
+describe(Crystal::TablePrint) do
+  it("single cell") do
+    assert_table(%(
+| A |)) do
       row do
         cell "A"
       end
     end
   end
 
-  it "single row with separator" do
-    assert_table %(
-| A | B |) do
+  it("single row with separator") do
+    assert_table(%(
+| A | B |)) do
       row do
         cell "A"
         cell "B"
@@ -31,10 +31,10 @@ describe Crystal::TablePrint do
     end
   end
 
-  it "multiple rows with separator" do
-    assert_table %(
+  it("multiple rows with separator") do
+    assert_table(%(
 | A | B |
-| C | D |) do
+| C | D |)) do
       row do
         cell "A"
         cell "B"
@@ -46,11 +46,11 @@ describe Crystal::TablePrint do
     end
   end
 
-  it "rows with horizontal separators" do
-    assert_table %(
+  it("rows with horizontal separators") do
+    assert_table(%(
 | A | B |
 ---------
-| C | D |) do
+| C | D |)) do
       row do
         cell "A"
         cell "B"
@@ -63,11 +63,11 @@ describe Crystal::TablePrint do
     end
   end
 
-  it "aligns columns borders" do
-    assert_table %(
+  it("aligns columns borders") do
+    assert_table(%(
 | A   | Foo |
 -------------
-| Bar | D   |) do
+| Bar | D   |)) do
       row do
         cell "A"
         cell "Foo"
@@ -80,11 +80,11 @@ describe Crystal::TablePrint do
     end
   end
 
-  it "aligns cell content" do
-    assert_table %(
+  it("aligns cell content") do
+    assert_table(%(
 |  A  | Fooo |
 --------------
-| Bar |    D |) do
+| Bar |    D |)) do
       row do
         cell "A", align: :center
         cell "Fooo"
@@ -97,10 +97,10 @@ describe Crystal::TablePrint do
     end
   end
 
-  it "colspan a cell that fits the available size" do
-    assert_table %(
+  it("colspan a cell that fits the available size") do
+    assert_table(%(
 |   A   |
-| B | C |) do
+| B | C |)) do
       row do
         cell "A", align: :center, colspan: 2
       end

--- a/spec/compiler/crystal/types_spec.cr
+++ b/spec/compiler/crystal/types_spec.cr
@@ -6,8 +6,8 @@ private def assert_type_to_s(expected)
   t.to_s.should eq(expected)
 end
 
-describe "types to_s of" do
-  it "does for type contained in generic class" do
+describe("types to_s of") do
+  it("does for type contained in generic class") do
     result = semantic(%(
       class Bar(T)
         class Foo
@@ -17,7 +17,7 @@ describe "types to_s of" do
     result.program.types["Bar"].types["Foo"].to_s.should eq("Bar::Foo")
   end
 
-  it "does for type contained in generic module" do
+  it("does for type contained in generic module") do
     result = semantic(%(
       module Bar(T)
         class Foo
@@ -27,52 +27,52 @@ describe "types to_s of" do
     result.program.types["Bar"].types["Foo"].to_s.should eq("Bar::Foo")
   end
 
-  it "non-instantiated array" do
-    assert_type_to_s "Array(T)" { array }
+  it("non-instantiated array") do
+    assert_type_to_s("Array(T)") { array }
   end
 
-  it "array of simple types" do
-    assert_type_to_s "Array(Int32)" { array_of(int32) }
+  it("array of simple types") do
+    assert_type_to_s("Array(Int32)") { array_of(int32) }
   end
 
-  it "union of simple types" do
-    assert_type_to_s "(Int32 | String)" { union_of(string, int32) }
+  it("union of simple types") do
+    assert_type_to_s("(Int32 | String)") { union_of(string, int32) }
   end
 
-  it "nilable reference type" do
-    assert_type_to_s "(String | Nil)" { nilable string }
+  it("nilable reference type") do
+    assert_type_to_s("(String | Nil)") { nilable string }
   end
 
-  it "nilable value type" do
-    assert_type_to_s "(Int32 | Nil)" { nilable int32 }
+  it("nilable value type") do
+    assert_type_to_s("(Int32 | Nil)") { nilable int32 }
   end
 
-  it "nilable type with more than two elements, Nil at the end" do
-    assert_type_to_s "(Int32 | String | Nil)" { union_of(string, int32, nil_type) }
+  it("nilable type with more than two elements, Nil at the end") do
+    assert_type_to_s("(Int32 | String | Nil)") { union_of(string, int32, nil_type) }
   end
 
-  describe "union types" do
-    describe "should not have extra parens" do
-      it "in arrays" do
-        assert_type_to_s "Array(Int32 | String)" { array_of(union_of(string, int32)) }
+  describe("union types") do
+    describe("should not have extra parens") do
+      it("in arrays") do
+        assert_type_to_s("Array(Int32 | String)") { array_of(union_of(string, int32)) }
       end
 
-      it "in pointers" do
-        assert_type_to_s "Pointer(Int32 | String)" { pointer_of(union_of(string, int32)) }
+      it("in pointers") do
+        assert_type_to_s("Pointer(Int32 | String)") { pointer_of(union_of(string, int32)) }
       end
 
-      it "in tuples" do
-        assert_type_to_s "Tuple(String, Int32 | String)" { tuple_of [string, union_of(string, int32)] }
+      it("in tuples") do
+        assert_type_to_s("Tuple(String, Int32 | String)") { tuple_of [string, union_of(string, int32)] }
       end
     end
 
-    describe "should have parens" do
-      it "as return type" do
-        assert_type_to_s "Proc((Int32 | String))" { proc_of union_of(string, int32) }
+    describe("should have parens") do
+      it("as return type") do
+        assert_type_to_s("Proc((Int32 | String))") { proc_of union_of(string, int32) }
       end
 
-      it "as arg type" do
-        assert_type_to_s "Proc((Int32 | String), Int32)" { proc_of union_of(string, int32), int32 }
+      it("as arg type") do
+        assert_type_to_s("Proc((Int32 | String), Int32)") { proc_of union_of(string, int32), int32 }
       end
     end
   end

--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
 private def assert_finds(search, results, relative_to = nil, path = __DIR__, file = __FILE__, line = __LINE__)
-  it "finds #{search.inspect}", file, line do
+  it("finds #{search.inspect}", file, line) do
     crystal_path = Crystal::CrystalPath.new(path)
     relative_to = "#{__DIR__}/#{relative_to}" if relative_to
     results = results.map { |result| "#{__DIR__}/#{result}" }
@@ -11,16 +11,16 @@ private def assert_finds(search, results, relative_to = nil, path = __DIR__, fil
 end
 
 private def assert_doesnt_find(search, relative_to = nil, path = __DIR__, file = __FILE__, line = __LINE__)
-  it "doesn't finds #{search.inspect}", file, line do
+  it("doesn't finds #{search.inspect}", file, line) do
     crystal_path = Crystal::CrystalPath.new(path)
     relative_to = "#{__DIR__}/#{relative_to}" if relative_to
-    expect_raises Exception, /can't find file/ do
+    expect_raises(Exception, /can't find file/) do
       crystal_path.find search, relative_to: relative_to
     end
   end
 end
 
-describe Crystal::CrystalPath do
+describe(Crystal::CrystalPath) do
   assert_finds "test_files/file_one.cr", ["test_files/file_one.cr"]
   assert_finds "test_files/file_one", ["test_files/file_one.cr"]
   assert_finds "test_files/*", [

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -244,7 +244,7 @@ describe Crystal::Formatter do
   assert_format "foo(\n  1, 2, &block)", "foo(\n  1, 2, &block)"
   assert_format "foo(\n  1, 2,\n&block)", "foo(\n  1, 2,\n  &block)"
   assert_format "foo 1, a: 1,\nb: 2,\nc: 3,\n&block", "foo 1, a: 1,\n  b: 2,\n  c: 3,\n  &block"
-  assert_format "foo 1, do\n2\nend", "foo 1 do\n  2\nend"
+  assert_format "foo 1, do\n2\nend", "foo(1) do\n  2\nend"
   assert_format "a.b &.[c]?\n1"
   assert_format "a.b &.[c]\n1"
   assert_format "foo(1, 2,)", "foo(1, 2)"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "../../../src/compiler/crystal/formatter"
 
 private def assert_format(input, output = input, strict = false, file = __FILE__, line = __LINE__)
-  it "formats #{input.inspect}", file, line do
+  it("formats #{input.inspect}", file, line) do
     output = "#{output}\n" unless strict
     result = Crystal.format(input)
     unless result == output
@@ -17,7 +17,7 @@ private def assert_format(input, output = input, strict = false, file = __FILE__
   end
 end
 
-describe Crystal::Formatter do
+describe(Crystal::Formatter) do
   assert_format "", "", strict: true
 
   assert_format "nil"

--- a/spec/compiler/lexer/lexer_comment_spec.cr
+++ b/spec/compiler/lexer/lexer_comment_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
-describe "Lexer comments" do
-  it "lexes without comments enabled" do
+describe("Lexer comments") do
+  it("lexes without comments enabled") do
     lexer = Lexer.new(%(# Hello\n1))
 
     token = lexer.next_token
@@ -11,7 +11,7 @@ describe "Lexer comments" do
     token.type.should eq(:NUMBER)
   end
 
-  it "lexes with comments enabled" do
+  it("lexes with comments enabled") do
     lexer = Lexer.new(%(# Hello\n1))
     lexer.comments_enabled = true
 
@@ -26,7 +26,7 @@ describe "Lexer comments" do
     token.type.should eq(:NUMBER)
   end
 
-  it "lexes with comments enabled (2)" do
+  it("lexes with comments enabled (2)") do
     lexer = Lexer.new(%(1 # Hello))
     lexer.comments_enabled = true
 
@@ -44,7 +44,7 @@ describe "Lexer comments" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes correct number of spaces" do
+  it("lexes correct number of spaces") do
     lexer = Lexer.new(%(1   2))
     lexer.count_whitespace = true
 

--- a/spec/compiler/lexer/lexer_doc_spec.cr
+++ b/spec/compiler/lexer/lexer_doc_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
-describe "Lexer doc" do
-  it "lexes without doc enabled" do
+describe("Lexer doc") do
+  it("lexes without doc enabled") do
     lexer = Lexer.new(%(1))
     lexer.doc_enabled = true
 
@@ -10,7 +10,7 @@ describe "Lexer doc" do
     token.doc.should be_nil
   end
 
-  it "lexes with doc enabled but without docs" do
+  it("lexes with doc enabled but without docs") do
     lexer = Lexer.new(%(1))
     lexer.doc_enabled = true
 
@@ -19,7 +19,7 @@ describe "Lexer doc" do
     token.doc.should be_nil
   end
 
-  it "lexes with doc enabled and docs" do
+  it("lexes with doc enabled and docs") do
     lexer = Lexer.new(%(# hello\n1))
     lexer.doc_enabled = true
 
@@ -32,7 +32,7 @@ describe "Lexer doc" do
     token.doc.should eq("hello")
   end
 
-  it "lexes with doc enabled and docs, two line comment" do
+  it("lexes with doc enabled and docs, two line comment") do
     lexer = Lexer.new(%(# hello\n# world\n1))
     lexer.doc_enabled = true
 
@@ -45,7 +45,7 @@ describe "Lexer doc" do
     token.doc.should eq("hello\nworld")
   end
 
-  it "lexes with doc enabled and docs, two line comment with leading whitespace" do
+  it("lexes with doc enabled and docs, two line comment with leading whitespace") do
     lexer = Lexer.new(%(# hello\n    # world\n1))
     lexer.doc_enabled = true
 
@@ -66,7 +66,7 @@ describe "Lexer doc" do
     token.doc.should eq("hello\nworld")
   end
 
-  it "lexes with doc enabled and docs, one line comment with two newlines and another comment" do
+  it("lexes with doc enabled and docs, one line comment with two newlines and another comment") do
     lexer = Lexer.new(%(# hello\n\n    # world\n1))
     lexer.doc_enabled = true
 
@@ -87,7 +87,7 @@ describe "Lexer doc" do
     token.doc.should eq("world")
   end
 
-  it "resets doc after non newline or space token" do
+  it("resets doc after non newline or space token") do
     lexer = Lexer.new(%(# hello\n1 2))
     lexer.doc_enabled = true
 

--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
-describe "Lexer macro" do
-  it "lexes simple macro" do
+describe("Lexer macro") do
+  it("lexes simple macro") do
     lexer = Lexer.new(%(hello end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -12,7 +12,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with expression" do
+  it("lexes macro with expression") do
     lexer = Lexer.new(%(hello {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -40,7 +40,7 @@ describe "Lexer macro" do
   end
 
   ["begin", "do", "if", "unless", "class", "struct", "module", "def", "while", "until", "case", "macro", "fun", "lib", "union", "macro def"].each do |keyword|
-    it "lexes macro with nested #{keyword}" do
+    it("lexes macro with nested #{keyword}") do
       lexer = Lexer.new(%(hello\n  #{keyword} {{world}} end end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -73,7 +73,7 @@ describe "Lexer macro" do
     end
   end
 
-  it "lexes macro with nested enum" do
+  it("lexes macro with nested enum") do
     lexer = Lexer.new(%(hello enum {{world}} end end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -109,7 +109,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro without nested if" do
+  it("lexes macro without nested if") do
     lexer = Lexer.new(%(helloif {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -137,7 +137,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with nested abstract def" do
+  it("lexes macro with nested abstract def") do
     lexer = Lexer.new(%(hello\n  abstract def {{world}} end end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -166,7 +166,7 @@ describe "Lexer macro" do
   end
 
   {"class", "struct"}.each do |keyword|
-    it "lexes macro with nested abstract #{keyword}" do
+    it("lexes macro with nested abstract #{keyword}") do
       lexer = Lexer.new(%(hello\n  abstract #{keyword} Foo; end; end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -183,7 +183,7 @@ describe "Lexer macro" do
     end
   end
 
-  it "reaches end" do
+  it("reaches end") do
     lexer = Lexer.new(%(fail))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -194,7 +194,7 @@ describe "Lexer macro" do
     token.type.should eq(:EOF)
   end
 
-  it "keeps correct column and line numbers" do
+  it("keeps correct column and line numbers") do
     lexer = Lexer.new("\nfoo\nbarf{{var}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -223,7 +223,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with control" do
+  it("lexes macro with control") do
     lexer = Lexer.new("foo{% if ")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -234,7 +234,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_CONTROL_START)
   end
 
-  it "skips whitespace" do
+  it("skips whitespace") do
     lexer = Lexer.new("   \n    coco")
 
     token = lexer.next_macro_token(Token::MacroState.default, true)
@@ -242,7 +242,7 @@ describe "Lexer macro" do
     token.value.should eq("coco")
   end
 
-  it "lexes macro with embedded string" do
+  it("lexes macro with embedded string") do
     lexer = Lexer.new(%(good " end " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -253,7 +253,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with embedded string and backslash" do
+  it("lexes macro with embedded string and backslash") do
     lexer = Lexer.new("good \" end \\\" \" day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -264,7 +264,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with embedded string and expression" do
+  it("lexes macro with embedded string and expression") do
     lexer = Lexer.new(%(good " end {{foo}} " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -292,7 +292,7 @@ describe "Lexer macro" do
   end
 
   [{"(", ")"}, {"[", "]"}, {"<", ">"}].each do |(left, right)|
-    it "lexes macro with embedded string with %#{left}" do
+    it("lexes macro with embedded string with %#{left}") do
       lexer = Lexer.new("good %#{left} end #{right} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -303,7 +303,7 @@ describe "Lexer macro" do
       token.type.should eq(:MACRO_END)
     end
 
-    it "lexes macro with embedded string with %#{left} ignores begin" do
+    it("lexes macro with embedded string with %#{left} ignores begin") do
       lexer = Lexer.new("good %#{left} begin #{right} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -315,7 +315,7 @@ describe "Lexer macro" do
     end
   end
 
-  it "lexes macro with nested embedded string with %(" do
+  it("lexes macro with nested embedded string with %(") do
     lexer = Lexer.new("good %( ( ) end ) day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -326,7 +326,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with comments" do
+  it("lexes macro with comments") do
     lexer = Lexer.new("good # end\n day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -349,7 +349,7 @@ describe "Lexer macro" do
     token.line_number.should eq(2)
   end
 
-  it "lexes macro with comments and expressions" do
+  it("lexes macro with comments and expressions") do
     lexer = Lexer.new("good # {{name}} end\n day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -389,7 +389,7 @@ describe "Lexer macro" do
     token.line_number.should eq(2)
   end
 
-  it "lexes macro with curly escape" do
+  it("lexes macro with curly escape") do
     lexer = Lexer.new("good \\{{world}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -408,7 +408,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with if as suffix" do
+  it("lexes macro with if as suffix") do
     lexer = Lexer.new("foo if bar end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -419,7 +419,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with if as suffix after return" do
+  it("lexes macro with if as suffix after return") do
     lexer = Lexer.new("return if @end end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -430,7 +430,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with semicolon before end" do
+  it("lexes macro with semicolon before end") do
     lexer = Lexer.new(";end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -441,7 +441,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with if after assign" do
+  it("lexes macro with if after assign") do
     lexer = Lexer.new("x = if 1; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -461,7 +461,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro var" do
+  it("lexes macro var") do
     lexer = Lexer.new("x = if %var; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -489,7 +489,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "doesn't lex macro var if escaped" do
+  it("doesn't lex macro var if escaped") do
     lexer = Lexer.new(%(" \\%var " end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -508,7 +508,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes macro with embedded char and sharp" do
+  it("lexes macro with embedded char and sharp") do
     lexer = Lexer.new(%(good '#' day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -519,7 +519,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_END)
   end
 
-  it "lexes bug #654" do
+  it("lexes bug #654") do
     lexer = Lexer.new(%(l {{op}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -534,7 +534,7 @@ describe "Lexer macro" do
     token.value.should eq("op")
   end
 
-  it "lexes escaped quote inside string (#895)" do
+  it("lexes escaped quote inside string (#895)") do
     lexer = Lexer.new(%("\\"" end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -542,7 +542,7 @@ describe "Lexer macro" do
     token.value.should eq(%("\\"" ))
   end
 
-  it "lexes with if/end inside escaped macro (#1029)" do
+  it("lexes with if/end inside escaped macro (#1029)") do
     lexer = Lexer.new(%(\\{%    if true %} 2 \\{% end %} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -564,7 +564,7 @@ describe "Lexer macro" do
     token.macro_state.nest.should eq(0)
   end
 
-  it "lexes with for inside escaped macro (#1029)" do
+  it("lexes with for inside escaped macro (#1029)") do
     lexer = Lexer.new(%(\\{%    for true %} 2 \\{% end %} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -574,7 +574,7 @@ describe "Lexer macro" do
     token.macro_state.nest.should eq(1)
   end
 
-  it "lexes begin end" do
+  it("lexes begin end") do
     lexer = Lexer.new(%(begin\nend end))
     token = lexer.next_macro_token(Token::MacroState.default, false)
     token.type.should eq(:MACRO_LITERAL)
@@ -586,7 +586,7 @@ describe "Lexer macro" do
     token.line_number.should eq(2)
   end
 
-  it "lexes macro with string interpolation and double curly brace" do
+  it("lexes macro with string interpolation and double curly brace") do
     lexer = Lexer.new(%("\#{{{1}}}"))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
@@ -597,7 +597,7 @@ describe "Lexer macro" do
     token.type.should eq(:MACRO_EXPRESSION_START)
   end
 
-  it "keeps correct line number after lexes the part of keyword and newline (#4656)" do
+  it("keeps correct line number after lexes the part of keyword and newline (#4656)") do
     lexer = Lexer.new(%(ab\ncd)) # 'ab' means the part of 'abstract'
     token = lexer.next_macro_token(Token::MacroState.default, false)
     token.type.should eq(:MACRO_LITERAL)

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
 private def it_lexes(string, type)
-  it "lexes #{string.inspect}" do
+  it("lexes #{string.inspect}") do
     lexer = Lexer.new string
     token = lexer.next_token
     token.type.should eq(type)
@@ -9,7 +9,7 @@ private def it_lexes(string, type)
 end
 
 private def it_lexes(string, type, value)
-  it "lexes #{string.inspect}" do
+  it("lexes #{string.inspect}") do
     lexer = Lexer.new string
     token = lexer.next_token
     token.type.should eq(type)
@@ -18,7 +18,7 @@ private def it_lexes(string, type, value)
 end
 
 private def it_lexes(string, type, value, number_kind)
-  it "lexes #{string.inspect}" do
+  it("lexes #{string.inspect}") do
     lexer = Lexer.new string
     token = lexer.next_token
     token.type.should eq(type)
@@ -74,7 +74,7 @@ private def it_lexes_number(number_kind, value : String)
 end
 
 private def it_lexes_char(string, value)
-  it "lexes #{string}" do
+  it("lexes #{string}") do
     lexer = Lexer.new string
     token = lexer.next_token
     token.type.should eq(:CHAR)
@@ -83,7 +83,7 @@ private def it_lexes_char(string, value)
 end
 
 private def it_lexes_string(string, value)
-  it "lexes #{string}" do
+  it("lexes #{string}") do
     lexer = Lexer.new string
     token = lexer.next_token
     token.type.should eq(:DELIMITER_START)
@@ -129,7 +129,7 @@ private def it_lexes_global_match_data_index(globals)
   end
 end
 
-describe "Lexer" do
+describe("Lexer") do
   it_lexes "", :EOF
   it_lexes " ", :SPACE
   it_lexes "\t", :SPACE
@@ -287,7 +287,7 @@ describe "Lexer" do
   assert_syntax_error "00", "octal constants should be prefixed with 0o"
   assert_syntax_error "01_i64", "octal constants should be prefixed with 0o"
 
-  it "lexes not instance var" do
+  it("lexes not instance var") do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token
     token.type.should eq(:"!")
@@ -296,7 +296,7 @@ describe "Lexer" do
     token.value.should eq("@foo")
   end
 
-  it "lexes space after keyword" do
+  it("lexes space after keyword") do
     lexer = Lexer.new "end 1"
     token = lexer.next_token
     token.type.should eq(:IDENT)
@@ -305,7 +305,7 @@ describe "Lexer" do
     token.type.should eq(:SPACE)
   end
 
-  it "lexes space after char" do
+  it("lexes space after char") do
     lexer = Lexer.new "'a' "
     token = lexer.next_token
     token.type.should eq(:CHAR)
@@ -314,7 +314,7 @@ describe "Lexer" do
     token.type.should eq(:SPACE)
   end
 
-  it "lexes comment and token" do
+  it("lexes comment and token") do
     lexer = Lexer.new "# comment\n="
     token = lexer.next_token
     token.type.should eq(:NEWLINE)
@@ -322,32 +322,32 @@ describe "Lexer" do
     token.type.should eq(:"=")
   end
 
-  it "lexes comment at the end" do
+  it("lexes comment at the end") do
     lexer = Lexer.new "# comment"
     token = lexer.next_token
     token.type.should eq(:EOF)
   end
 
-  it "lexes __LINE__" do
+  it("lexes __LINE__") do
     lexer = Lexer.new "__LINE__"
     token = lexer.next_token
     token.type.should eq(:__LINE__)
   end
 
-  it "lexes __FILE__" do
+  it("lexes __FILE__") do
     lexer = Lexer.new "__FILE__"
     lexer.filename = "foo"
     token = lexer.next_token
     token.type.should eq(:__FILE__)
   end
 
-  it "lexes __DIR__" do
+  it("lexes __DIR__") do
     lexer = Lexer.new "__DIR__"
     token = lexer.next_token
     token.type.should eq(:__DIR__)
   end
 
-  it "lexes dot and ident" do
+  it("lexes dot and ident") do
     lexer = Lexer.new ".read"
     token = lexer.next_token
     token.type.should eq(:".")
@@ -361,21 +361,21 @@ describe "Lexer" do
   assert_syntax_error "/foo", "unterminated regular expression"
   assert_syntax_error ":\"foo", "unterminated quoted symbol"
 
-  it "lexes utf-8 char" do
+  it("lexes utf-8 char") do
     lexer = Lexer.new "'á'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(225)
   end
 
-  it "lexes utf-8 multibyte char" do
+  it("lexes utf-8 multibyte char") do
     lexer = Lexer.new "'日'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(26085)
   end
 
-  it "doesn't raise if slash r with slash n" do
+  it("doesn't raise if slash r with slash n") do
     lexer = Lexer.new("\r\n1")
     token = lexer.next_token
     token.type.should eq(:NEWLINE)
@@ -383,7 +383,7 @@ describe "Lexer" do
     token.type.should eq(:NUMBER)
   end
 
-  it "doesn't raise if many slash r with slash n" do
+  it("doesn't raise if many slash r with slash n") do
     lexer = Lexer.new("\r\n\r\n\r\n1")
     token = lexer.next_token
     token.type.should eq(:NEWLINE)
@@ -393,35 +393,35 @@ describe "Lexer" do
 
   assert_syntax_error "\r1", "expected '\\n' after '\\r'"
 
-  it "lexes char with unicode codepoint" do
+  it("lexes char with unicode codepoint") do
     lexer = Lexer.new "'\\uFEDA'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(0xFEDA)
   end
 
-  it "lexes char with unicode codepoint and curly with zeros" do
+  it("lexes char with unicode codepoint and curly with zeros") do
     lexer = Lexer.new "'\\u{0}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(0)
   end
 
-  it "lexes char with unicode codepoint and curly" do
+  it("lexes char with unicode codepoint and curly") do
     lexer = Lexer.new "'\\u{A5}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(0xA5)
   end
 
-  it "lexes char with unicode codepoint and curly with six hex digits" do
+  it("lexes char with unicode codepoint and curly with six hex digits") do
     lexer = Lexer.new "'\\u{10FFFF}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
     token.value.as(Char).ord.should eq(0x10FFFF)
   end
 
-  it "lexes float then zero (bug)" do
+  it("lexes float then zero (bug)") do
     lexer = Lexer.new "2.5 0"
     lexer.next_token.number_kind.should eq(:f64)
     lexer.next_token.type.should eq(:SPACE)
@@ -430,28 +430,28 @@ describe "Lexer" do
     token.number_kind.should eq(:i32)
   end
 
-  it "lexes symbol with quote" do
+  it("lexes symbol with quote") do
     lexer = Lexer.new %(:"\\"")
     token = lexer.next_token
     token.type.should eq(:SYMBOL)
     token.value.should eq("\"")
   end
 
-  it "lexes symbol with backslash (#2187)" do
+  it("lexes symbol with backslash (#2187)") do
     lexer = Lexer.new %(:"\\\\")
     token = lexer.next_token
     token.type.should eq(:SYMBOL)
     token.value.should eq("\\")
   end
 
-  it "lexes /=" do
+  it("lexes /=") do
     lexer = Lexer.new("/=")
     lexer.slash_is_regex = false
     token = lexer.next_token
     token.type.should eq(:"/=")
   end
 
-  it "lexes != after identifier (#4815)" do
+  it("lexes != after identifier (#4815)") do
     lexer = Lexer.new("some_method!=5")
     token = lexer.next_token
     token.type.should eq(:IDENT)

--- a/spec/compiler/lexer/lexer_string_array_spec.cr
+++ b/spec/compiler/lexer/lexer_string_array_spec.cr
@@ -16,14 +16,14 @@ private def it_should_be_valid_string_array_lexer(lexer)
   token.type.should eq(:STRING_ARRAY_END)
 end
 
-describe "Lexer string array" do
-  it "lexes simple string array" do
+describe("Lexer string array") do
+  it("lexes simple string array") do
     lexer = Lexer.new("%w(one two)")
 
     it_should_be_valid_string_array_lexer(lexer)
   end
 
-  it "lexes string array with new line" do
+  it("lexes string array with new line") do
     lexer = Lexer.new("%w(one \n two)")
 
     token = lexer.next_token
@@ -41,7 +41,7 @@ describe "Lexer string array" do
     token.type.should eq(:STRING_ARRAY_END)
   end
 
-  it "lexes string array with new line gives correct column for next token" do
+  it("lexes string array with new line gives correct column for next token") do
     lexer = Lexer.new("%w(one \n two).")
 
     lexer.next_token
@@ -54,32 +54,32 @@ describe "Lexer string array" do
     token.column_number.should eq(6)
   end
 
-  context "using { as delimiter" do
-    it "lexes simple string array" do
+  context("using { as delimiter") do
+    it("lexes simple string array") do
       lexer = Lexer.new("%w{one two}")
 
       it_should_be_valid_string_array_lexer(lexer)
     end
   end
 
-  context "using [ as delimiter" do
-    it "lexes simple string array" do
+  context("using [ as delimiter") do
+    it("lexes simple string array") do
       lexer = Lexer.new("%w[one two]")
 
       it_should_be_valid_string_array_lexer(lexer)
     end
   end
 
-  context "using < as delimiter" do
-    it "lexes simple string array" do
+  context("using < as delimiter") do
+    it("lexes simple string array") do
       lexer = Lexer.new("%w<one two>")
 
       it_should_be_valid_string_array_lexer(lexer)
     end
   end
 
-  context "using | as delimiter" do
-    it "lexes simple string array" do
+  context("using | as delimiter") do
+    it("lexes simple string array") do
       lexer = Lexer.new("%w|one two|")
 
       it_should_be_valid_string_array_lexer(lexer)

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -1,8 +1,8 @@
 require "../../support/syntax"
 require "./lexer_objects/strings"
 
-describe "Lexer string" do
-  it "lexes simple string" do
+describe("Lexer string") do
+  it("lexes simple string") do
     lexer = Lexer.new(%("hello"))
     tester = LexerObjects::Strings.new(lexer)
 
@@ -11,7 +11,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with newline" do
+  it("lexes string with newline") do
     lexer = Lexer.new("\"hello\\nworld\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -22,7 +22,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with slash" do
+  it("lexes string with slash") do
     lexer = Lexer.new("\"hello\\\\world\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -33,7 +33,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with slash quote" do
+  it("lexes string with slash quote") do
     lexer = Lexer.new("\"\\\"\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -42,7 +42,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with slash t" do
+  it("lexes string with slash t") do
     lexer = Lexer.new("\"\\t\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -51,7 +51,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with interpolation" do
+  it("lexes string with interpolation") do
     lexer = Lexer.new("\"hello \#{world}\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -61,7 +61,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with numeral" do
+  it("lexes string with numeral") do
     lexer = Lexer.new("\"hello#world\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -72,7 +72,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with literal newline" do
+  it("lexes string with literal newline") do
     lexer = Lexer.new("\"hello\nworld\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -84,7 +84,7 @@ describe "Lexer string" do
     tester.next_token_should_be_at(line: 2, column: 7)
   end
 
-  it "lexes string with only newline" do
+  it("lexes string with only newline") do
     lexer = Lexer.new("\"\n\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -93,7 +93,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes double numeral" do
+  it("lexes double numeral") do
     lexer = Lexer.new("\"##\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -103,7 +103,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with interpolation with double numeral" do
+  it("lexes string with interpolation with double numeral") do
     lexer = Lexer.new("\"hello \#\#{world}\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -114,7 +114,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes slash with no-escape char" do
+  it("lexes slash with no-escape char") do
     lexer = Lexer.new("\"\\h\"")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -123,7 +123,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes simple string with %(" do
+  it("lexes simple string with %(") do
     lexer = Lexer.new("%(hello)")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -132,7 +132,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes simple string with %|" do
+  it("lexes simple string with %|") do
     lexer = Lexer.new("%|hello|")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -142,7 +142,7 @@ describe "Lexer string" do
   end
 
   [['(', ')'], ['[', ']'], ['{', '}'], ['<', '>']].each do |(left, right)|
-    it "lexes simple string with nested %#{left}" do
+    it("lexes simple string with nested %#{left}") do
       lexer = Lexer.new("%#{left}hello #{left}world#{right}#{right}")
       tester = LexerObjects::Strings.new(lexer)
 
@@ -155,7 +155,7 @@ describe "Lexer string" do
     end
   end
 
-  it "lexes heredoc" do
+  it("lexes heredoc") do
     string = "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY"
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE")
     tester = LexerObjects::Strings.new(lexer)
@@ -168,7 +168,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes heredoc with empty line" do
+  it("lexes heredoc with empty line") do
     lexer = Lexer.new("<<-XML\nfoo\n\nXML")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -178,7 +178,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes heredoc with \\r\\n" do
+  it("lexes heredoc with \\r\\n") do
     lexer = Lexer.new("<<-XML\r\nfoo\r\n\nXML")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -188,7 +188,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes heredoc with spaces before close tag" do
+  it("lexes heredoc with spaces before close tag") do
     lexer = Lexer.new("<<-XML\nfoo\n   XML")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -197,7 +197,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "assigns correct location after heredoc (#346)" do
+  it("assigns correct location after heredoc (#346)") do
     string = "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK."
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE\n1")
     tester = LexerObjects::Strings.new(lexer)
@@ -216,7 +216,7 @@ describe "Lexer string" do
     tester.token_should_be_at(line: 6, column: 1)
   end
 
-  it "lexes interpolations in heredocs" do
+  it("lexes interpolations in heredocs") do
     lexer = Lexer.new("<<-HERE\n\abc\#{foo}\nHERE")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -226,12 +226,12 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "raises on unterminated heredoc" do
+  it("raises on unterminated heredoc") do
     lexer = Lexer.new("<<-HERE\nHello")
     token = lexer.next_token
     state = token.delimiter_state
 
-    expect_raises Crystal::SyntaxException, /unterminated heredoc/ do
+    expect_raises(Crystal::SyntaxException, /unterminated heredoc/) do
       loop do
         token = lexer.next_string_token state
         break if token.type == :DELIMITER_END
@@ -239,55 +239,55 @@ describe "Lexer string" do
     end
   end
 
-  it "raises on invalid heredoc identifier (<<-HERE A)" do
+  it("raises on invalid heredoc identifier (<<-HERE A)") do
     lexer = Lexer.new("<<-HERE A\ntest\nHERE\n")
 
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+    expect_raises(Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/) do
       lexer.next_token
     end
   end
 
-  it "raises on invalid heredoc identifier (<<-HERE\\n)" do
+  it("raises on invalid heredoc identifier (<<-HERE\\n)") do
     lexer = Lexer.new("<<-HERE\\ntest\nHERE\n")
 
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+    expect_raises(Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/) do
       lexer.next_token
     end
   end
 
-  it "raises when identifier doesn't start with a leter" do
+  it("raises when identifier doesn't start with a leter") do
     lexer = Lexer.new("<<-123\\ntest\n123\n")
 
-    expect_raises Crystal::SyntaxException, /heredoc identifier starts with invalid character/ do
+    expect_raises(Crystal::SyntaxException, /heredoc identifier starts with invalid character/) do
       lexer.next_token
     end
   end
 
-  it "raises when identifier contains a character not for identifier" do
+  it("raises when identifier contains a character not for identifier") do
     lexer = Lexer.new("<<-aaa.bbb?\\ntest\naaa.bbb?\n")
 
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+    expect_raises(Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/) do
       lexer.next_token
     end
   end
 
-  it "raises when identifier contains spaces" do
+  it("raises when identifier contains spaces") do
     lexer = Lexer.new("<<-aaa  bbb\\ntest\naaabbb\n")
 
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+    expect_raises(Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/) do
       lexer.next_token
     end
   end
 
-  it "raises on unexpected EOF while lexing heredoc" do
+  it("raises on unexpected EOF while lexing heredoc") do
     lexer = Lexer.new("<<-aaa")
 
-    expect_raises Crystal::SyntaxException, /unexpected EOF on heredoc identifier/ do
+    expect_raises(Crystal::SyntaxException, /unexpected EOF on heredoc identifier/) do
       lexer.next_token
     end
   end
 
-  it "lexes string with unicode codepoint" do
+  it("lexes string with unicode codepoint") do
     lexer = Lexer.new "\"\\uFEDA\""
     tester = LexerObjects::Strings.new(lexer)
 
@@ -295,7 +295,7 @@ describe "Lexer string" do
     tester.next_unicode_tokens_should_be(0xFEDA)
   end
 
-  it "lexes string with unicode codepoint in curly" do
+  it("lexes string with unicode codepoint in curly") do
     lexer = Lexer.new "\"\\u{A5}\""
     tester = LexerObjects::Strings.new(lexer)
 
@@ -303,7 +303,7 @@ describe "Lexer string" do
     tester.next_unicode_tokens_should_be(0xA5)
   end
 
-  it "lexes string with unicode codepoint in curly multiple times" do
+  it("lexes string with unicode codepoint in curly multiple times") do
     lexer = Lexer.new "\"\\u{A5 A6 10FFFF}\""
     tester = LexerObjects::Strings.new(lexer)
 
@@ -315,7 +315,7 @@ describe "Lexer string" do
   assert_syntax_error "\"\\u{}\"", "expected hexadecimal character in unicode escape"
   assert_syntax_error "\"\\u{110000}\"", "invalid unicode codepoint (too large)"
 
-  it "lexes backtick string" do
+  it("lexes backtick string") do
     lexer = Lexer.new(%(`hello`))
     tester = LexerObjects::Strings.new(lexer)
 
@@ -324,7 +324,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes regex string" do
+  it("lexes regex string") do
     lexer = Lexer.new(%(/hello/))
     tester = LexerObjects::Strings.new(lexer)
 
@@ -333,7 +333,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes regex string with special chars with /.../" do
+  it("lexes regex string with special chars with /.../") do
     lexer = Lexer.new(%(/\\w/))
     tester = LexerObjects::Strings.new(lexer)
 
@@ -342,7 +342,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes regex string with special chars with %r(...)" do
+  it("lexes regex string with special chars with %r(...)") do
     lexer = Lexer.new(%(%r(\\w)))
 
     tester = LexerObjects::Strings.new(lexer)
@@ -352,7 +352,7 @@ describe "Lexer string" do
     tester.string_should_end_correctly
   end
 
-  it "lexes string with backslash" do
+  it("lexes string with backslash") do
     lexer = Lexer.new(%("hello \\\n    world"1))
     tester = LexerObjects::Strings.new(lexer)
 

--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -6,8 +6,8 @@ private def assert_token_column_number(lexer, type, column_number)
   token.column_number.should eq(column_number)
 end
 
-describe "Lexer: location" do
-  it "stores line numbers" do
+describe("Lexer: location") do
+  it("stores line numbers") do
     lexer = Lexer.new "1\n2"
     token = lexer.next_token
     token.type.should eq(:NUMBER)
@@ -22,7 +22,7 @@ describe "Lexer: location" do
     token.line_number.should eq(2)
   end
 
-  it "stores column numbers" do
+  it("stores column numbers") do
     lexer = Lexer.new "1;  ident; def;\n4"
     assert_token_column_number lexer, :NUMBER, 1
     assert_token_column_number lexer, :";", 2
@@ -36,7 +36,7 @@ describe "Lexer: location" do
     assert_token_column_number lexer, :NUMBER, 1
   end
 
-  it "overrides location with pragma" do
+  it("overrides location with pragma") do
     lexer = Lexer.new %(1 + #<loc:"foo",12,34>2)
     lexer.filename = "bar"
 
@@ -68,7 +68,7 @@ describe "Lexer: location" do
     token.filename.should eq("foo")
   end
 
-  it "pushes and pops its location" do
+  it("pushes and pops its location") do
     lexer = Lexer.new %(#<loc:push>#<loc:"foo",12,34>1 + #<loc:pop>2)
     lexer.filename = "bar"
 
@@ -100,7 +100,7 @@ describe "Lexer: location" do
     token.filename.should eq("bar")
   end
 
-  it "uses two consecutive loc pragma " do
+  it("uses two consecutive loc pragma ") do
     lexer = Lexer.new %(1#<loc:"foo",12,34>#<loc:"foo",56,78>2)
     lexer.filename = "bar"
 
@@ -117,7 +117,7 @@ describe "Lexer: location" do
     token.filename.should eq("foo")
   end
 
-  it "assigns correct loc location to node" do
+  it("assigns correct loc location to node") do
     exps = Parser.parse(%[(#<loc:"foo.txt",2,3>1 + 2)]).as(Expressions)
     node = exps.expressions.first
     location = node.location.not_nil!
@@ -126,13 +126,13 @@ describe "Lexer: location" do
     location.filename.should eq("foo.txt")
   end
 
-  it "parses var/call right after loc (#491)" do
+  it("parses var/call right after loc (#491)") do
     exps = Parser.parse(%[(#<loc:"foo.txt",2,3>msg)]).as(Expressions)
     exp = exps.expressions.first.as(Call)
     exp.name.should eq("msg")
   end
 
-  it "locations in different files have no order" do
+  it("locations in different files have no order") do
     loc1 = Location.new("file1", 1, 1)
     loc2 = Location.new("file2", 2, 2)
 
@@ -143,7 +143,7 @@ describe "Lexer: location" do
     (loc1 >= loc2).should be_false
   end
 
-  it "locations in same files are comparable based on line" do
+  it("locations in same files are comparable based on line") do
     loc1 = Location.new("file1", 1, 1)
     loc2 = Location.new("file1", 2, 1)
     loc3 = Location.new("file1", 1, 1)
@@ -164,7 +164,7 @@ describe "Lexer: location" do
     (loc3 == loc1).should be_true
   end
 
-  it "locations with virtual files shoud be comparable" do
+  it("locations with virtual files shoud be comparable") do
     loc1 = Location.new("file1", 1, 1)
     loc2 = Location.new(VirtualFile.new(Macro.new("macro", [] of Arg, Nop.new), "", Location.new("f", 1, 1)), 2, 1)
     (loc1 < loc2).should be_false

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -1,155 +1,155 @@
 require "../../spec_helper"
 
-describe "MacroExpander" do
-  it "expands simple macro" do
+describe("MacroExpander") do
+  it("expands simple macro") do
     assert_macro "", "1 + 2", [] of ASTNode, "1 + 2"
   end
 
-  it "expands macro with string sustitution" do
+  it("expands macro with string sustitution") do
     assert_macro "x", "{{x}}", ["hello".string] of ASTNode, %("hello")
   end
 
-  it "expands macro with symbol sustitution" do
+  it("expands macro with symbol sustitution") do
     assert_macro "x", "{{x}}", ["hello".symbol] of ASTNode, ":hello"
   end
 
-  it "expands macro with argument-less call sustitution" do
+  it("expands macro with argument-less call sustitution") do
     assert_macro "x", "{{x}}", ["hello".call] of ASTNode, "hello"
   end
 
-  it "expands macro with boolean" do
+  it("expands macro with boolean") do
     assert_macro "", "{{true}}", [] of ASTNode, "true"
   end
 
-  it "expands macro with integer" do
+  it("expands macro with integer") do
     assert_macro "", "{{1}}", [] of ASTNode, "1"
   end
 
-  it "expands macro with char" do
+  it("expands macro with char") do
     assert_macro "", "{{'a'}}", [] of ASTNode, "'a'"
   end
 
-  it "expands macro with string" do
+  it("expands macro with string") do
     assert_macro "", %({{"hello"}}), [] of ASTNode, %("hello")
   end
 
-  it "expands macro with symbol" do
+  it("expands macro with symbol") do
     assert_macro "", %({{:foo}}), [] of ASTNode, %(:foo)
   end
 
-  it "expands macro with nil" do
+  it("expands macro with nil") do
     assert_macro "", %({{nil}}), [] of ASTNode, %(nil)
   end
 
-  it "expands macro with array" do
+  it("expands macro with array") do
     assert_macro "", %({{[1, 2, 3]}}), [] of ASTNode, %([1, 2, 3])
   end
 
-  it "expands macro with hash" do
+  it("expands macro with hash") do
     assert_macro "", %({{{:a => 1, :b => 2}}}), [] of ASTNode, "{:a => 1, :b => 2}"
   end
 
-  it "expands macro with tuple" do
+  it("expands macro with tuple") do
     assert_macro "", %({{{1, 2, 3}}}), [] of ASTNode, %({1, 2, 3})
   end
 
-  it "expands macro with range" do
+  it("expands macro with range") do
     assert_macro "", %({{1..3}}), [] of ASTNode, %(1..3)
   end
 
-  it "expands macro with string interpolation" do
+  it("expands macro with string interpolation") do
     assert_macro "", "{{ \"hello\#{1 == 1}world\" }}", [] of ASTNode, %("hellotrueworld")
   end
 
-  it "expands macro with var sustitution" do
+  it("expands macro with var sustitution") do
     assert_macro "x", "{{x}}", ["hello".var] of ASTNode, "hello"
   end
 
-  it "expands macro with or (1)" do
+  it("expands macro with or (1)") do
     assert_macro "x", "{{x || 1}}", [NilLiteral.new] of ASTNode, "1"
   end
 
-  it "expands macro with or (2)" do
+  it("expands macro with or (2)") do
     assert_macro "x", "{{x || 1}}", ["hello".var] of ASTNode, "hello"
   end
 
-  it "expands macro with and (1)" do
+  it("expands macro with and (1)") do
     assert_macro "x", "{{x && 1}}", [NilLiteral.new] of ASTNode, "nil"
   end
 
-  it "expands macro with and (2)" do
+  it("expands macro with and (2)") do
     assert_macro "x", "{{x && 1}}", ["hello".var] of ASTNode, "1"
   end
 
-  describe "if" do
-    it "expands macro with if when truthy" do
+  describe("if") do
+    it("expands macro with if when truthy") do
       assert_macro "", "{%if true%}hello{%end%}", [] of ASTNode, "hello"
     end
 
-    it "expands macro with if when falsey" do
+    it("expands macro with if when falsey") do
       assert_macro "", "{%if false%}hello{%end%}", [] of ASTNode, ""
     end
 
-    it "expands macro with if else when falsey" do
+    it("expands macro with if else when falsey") do
       assert_macro "", "{%if false%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "expands macro with if with nop" do
+    it("expands macro with if with nop") do
       assert_macro "x", "{%if x%}hello{%else%}bye{%end%}", [Nop.new] of ASTNode, "bye"
     end
 
-    it "expands macro with if with not" do
+    it("expands macro with if with not") do
       assert_macro "", "{%if !true%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
   end
 
-  describe "for" do
-    it "expands macro with for over array literal" do
+  describe("for") do
+    it("expands macro with for over array literal") do
       assert_macro "x", "{%for e in x %}{{e}}{%end%}", [ArrayLiteral.new(["hello".var, "world".var] of ASTNode)] of ASTNode, "helloworld"
     end
 
-    it "expands macro with for over array literal with index" do
+    it("expands macro with for over array literal with index") do
       assert_macro "x", "{%for e, i in x%}{{e}}{{i}}{%end%}", [ArrayLiteral.new(["hello".var, "world".var] of ASTNode)] of ASTNode, "hello0world1"
     end
 
-    it "expands macro with for over embedded array literal" do
+    it("expands macro with for over embedded array literal") do
       assert_macro "", "{%for e in [1, 2]%}{{e}}{%end%}", [] of ASTNode, "12"
     end
 
-    it "expands macro with for over hash literal" do
+    it("expands macro with for over hash literal") do
       assert_macro "x", "{%for k, v in x%}{{k}}{{v}}{%end%}", [HashLiteral.new([HashLiteral::Entry.new("a".var, "c".var), HashLiteral::Entry.new("b".var, "d".var)])] of ASTNode, "acbd"
     end
 
-    it "expands macro with for over hash literal with index" do
+    it("expands macro with for over hash literal with index") do
       assert_macro "x", "{%for k, v, i in x%}{{k}}{{v}}{{i}}{%end%}", [HashLiteral.new([HashLiteral::Entry.new("a".var, "c".var), HashLiteral::Entry.new("b".var, "d".var)])] of ASTNode, "ac0bd1"
     end
 
-    it "expands macro with for over tuple literal" do
+    it("expands macro with for over tuple literal") do
       assert_macro "x", "{%for e, i in x%}{{e}}{{i}}{%end%}", [TupleLiteral.new(["a".var, "b".var] of ASTNode)] of ASTNode, "a0b1"
     end
 
-    it "expands macro with for over range literal" do
+    it("expands macro with for over range literal") do
       assert_macro "", "{%for e in 1..3 %}{{e}}{%end%}", [] of ASTNode, "123"
     end
 
-    it "expands macro with for over range literal, evaluating elements" do
+    it("expands macro with for over range literal, evaluating elements") do
       assert_macro "x, y", "{%for e in x..y %}{{e}}{%end%}", [3.int32, 6.int32] of ASTNode, "3456"
     end
 
-    it "expands macro with for over range literal, evaluating elements (exclusive)" do
+    it("expands macro with for over range literal, evaluating elements (exclusive)") do
       assert_macro "x, y", "{%for e in x...y %}{{e}}{%end%}", [3.int32, 6.int32] of ASTNode, "345"
     end
   end
 
-  it "does regular if" do
+  it("does regular if") do
     assert_macro "", %({{1 == 2 ? 3 : 4}}), [] of ASTNode, "4"
   end
 
-  it "does regular unless" do
+  it("does regular unless") do
     assert_macro "", %({{unless 1 == 2; 3; else; 4; end}}), [] of ASTNode, "3"
   end
 
-  it "does not expand when macro expression is {% ... %}" do
+  it("does not expand when macro expression is {% ... %}") do
     assert_macro "", %({% 1 %}), [] of ASTNode, ""
   end
 end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1,234 +1,234 @@
 require "../../spec_helper"
 
-describe "macro methods" do
-  describe "node methods" do
-    describe "location" do
+describe("macro methods") do
+  describe("node methods") do
+    describe("location") do
       location = Location.new("foo.cr", 1, 2)
 
-      it "filename" do
+      it("filename") do
         assert_macro "x", "{{x.filename}}", ["hello".string.tap { |n| n.location = location }] of ASTNode, %("foo.cr")
       end
 
-      it "line_number" do
+      it("line_number") do
         assert_macro "x", "{{x.line_number}}", ["hello".string.tap { |n| n.location = location }] of ASTNode, %(1)
       end
 
-      it "column number" do
+      it("column number") do
         assert_macro "x", "{{x.column_number}}", ["hello".string.tap { |n| n.location = location }] of ASTNode, %(2)
       end
 
-      it "end line_number" do
+      it("end line_number") do
         assert_macro "x", "{{x.end_line_number}}", ["hello".string.tap { |n| n.end_location = location }] of ASTNode, %(1)
       end
 
-      it "end column number" do
+      it("end column number") do
         assert_macro "x", "{{x.end_column_number}}", ["hello".string.tap { |n| n.end_location = location }] of ASTNode, %(2)
       end
     end
 
-    describe "stringify" do
-      it "expands macro with stringify call on string" do
+    describe("stringify") do
+      it("expands macro with stringify call on string") do
         assert_macro "x", "{{x.stringify}}", ["hello".string] of ASTNode, "\"\\\"hello\\\"\""
       end
 
-      it "expands macro with stringify call on symbol" do
+      it("expands macro with stringify call on symbol") do
         assert_macro "x", "{{x.stringify}}", ["hello".symbol] of ASTNode, %(":hello")
       end
 
-      it "expands macro with stringify call on call" do
+      it("expands macro with stringify call on call") do
         assert_macro "x", "{{x.stringify}}", ["hello".call] of ASTNode, %("hello")
       end
 
-      it "expands macro with stringify call on number" do
+      it("expands macro with stringify call on number") do
         assert_macro "x", "{{x.stringify}}", [1.int32] of ASTNode, %("1")
       end
     end
 
-    describe "symbolize" do
-      it "expands macro with symbolize call on string" do
+    describe("symbolize") do
+      it("expands macro with symbolize call on string") do
         assert_macro "x", "{{x.symbolize}}", ["hello".string] of ASTNode, ":\"\\\"hello\\\"\""
       end
 
-      it "expands macro with symbolize call on symbol" do
+      it("expands macro with symbolize call on symbol") do
         assert_macro "x", "{{x.symbolize}}", ["hello".symbol] of ASTNode, ":\":hello\""
       end
 
-      it "expands macro with symbolize call on id" do
+      it("expands macro with symbolize call on id") do
         assert_macro "x", "{{x.id.symbolize}}", ["hello".string] of ASTNode, ":hello"
       end
     end
 
-    describe "id" do
-      it "expands macro with id call on string" do
+    describe("id") do
+      it("expands macro with id call on string") do
         assert_macro "x", "{{x.id}}", ["hello".string] of ASTNode, "hello"
       end
 
-      it "expands macro with id call on symbol" do
+      it("expands macro with id call on symbol") do
         assert_macro "x", "{{x.id}}", ["hello".symbol] of ASTNode, "hello"
       end
 
-      it "expands macro with id call on char" do
+      it("expands macro with id call on char") do
         assert_macro "x", "{{x.id}}", [CharLiteral.new('є')] of ASTNode, "є"
       end
 
-      it "expands macro with id call on call" do
+      it("expands macro with id call on call") do
         assert_macro "x", "{{x.id}}", ["hello".call] of ASTNode, "hello"
       end
 
-      it "expands macro with id call on number" do
+      it("expands macro with id call on number") do
         assert_macro "x", "{{x.id}}", [1.int32] of ASTNode, %(1)
       end
     end
 
-    it "executes == on numbers (true)" do
+    it("executes == on numbers (true)") do
       assert_macro "", "{%if 1 == 1%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes == on numbers (false)" do
+    it("executes == on numbers (false)") do
       assert_macro "", "{%if 1 == 2%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes != on numbers (true)" do
+    it("executes != on numbers (true)") do
       assert_macro "", "{%if 1 != 2%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes != on numbers (false)" do
+    it("executes != on numbers (false)") do
       assert_macro "", "{%if 1 != 1%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes == on symbols (true) (#240)" do
+    it("executes == on symbols (true) (#240)") do
       assert_macro "", "{{:foo == :foo}}", [] of ASTNode, "true"
     end
 
-    it "executes == on symbols (false) (#240)" do
+    it("executes == on symbols (false) (#240)") do
       assert_macro "", "{{:foo == :bar}}", [] of ASTNode, "false"
     end
 
-    describe "class_name" do
-      it "executes class_name" do
+    describe("class_name") do
+      it("executes class_name") do
         assert_macro "", "{{:foo.class_name}}", [] of ASTNode, "\"SymbolLiteral\""
       end
 
-      it "executes class_name" do
+      it("executes class_name") do
         assert_macro "x", "{{x.class_name}}", [MacroId.new("hello")] of ASTNode, "\"MacroId\""
       end
 
-      it "executes class_name" do
+      it("executes class_name") do
         assert_macro "x", "{{x.class_name}}", ["hello".string] of ASTNode, "\"StringLiteral\""
       end
 
-      it "executes class_name" do
+      it("executes class_name") do
         assert_macro "x", "{{x.class_name}}", ["hello".symbol] of ASTNode, "\"SymbolLiteral\""
       end
 
-      it "executes class_name" do
+      it("executes class_name") do
         assert_macro "x", "{{x.class_name}}", [1.int32] of ASTNode, "\"NumberLiteral\""
       end
 
-      it "executes class_name" do
+      it("executes class_name") do
         assert_macro "x", "{{x.class_name}}", [ArrayLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "\"ArrayLiteral\""
       end
     end
   end
 
-  describe "number methods" do
-    it "executes > (true)" do
+  describe("number methods") do
+    it("executes > (true)") do
       assert_macro "", "{%if 2 > 1%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes > (false)" do
+    it("executes > (false)") do
       assert_macro "", "{%if 2 > 3%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes >= (true)" do
+    it("executes >= (true)") do
       assert_macro "", "{%if 1 >= 1%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes >= (false)" do
+    it("executes >= (false)") do
       assert_macro "", "{%if 2 >= 3%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes < (true)" do
+    it("executes < (true)") do
       assert_macro "", "{%if 1 < 2%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes < (false)" do
+    it("executes < (false)") do
       assert_macro "", "{%if 3 < 2%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes <= (true)" do
+    it("executes <= (true)") do
       assert_macro "", "{%if 1 <= 1%}hello{%else%}bye{%end%}", [] of ASTNode, "hello"
     end
 
-    it "executes <= (false)" do
+    it("executes <= (false)") do
       assert_macro "", "{%if 3 <= 2%}hello{%else%}bye{%end%}", [] of ASTNode, "bye"
     end
 
-    it "executes <=>" do
+    it("executes <=>") do
       assert_macro "", "{{1 <=> -1}}", [] of ASTNode, "1"
     end
 
-    it "executes +" do
+    it("executes +") do
       assert_macro "", "{{1 + 2}}", [] of ASTNode, "3"
     end
 
-    it "executes -" do
+    it("executes -") do
       assert_macro "", "{{1 - 2}}", [] of ASTNode, "-1"
     end
 
-    it "executes *" do
+    it("executes *") do
       assert_macro "", "{{2 * 3}}", [] of ASTNode, "6"
     end
 
-    it "executes /" do
+    it("executes /") do
       assert_macro "", "{{5 / 3}}", [] of ASTNode, "1"
     end
 
-    it "executes %" do
+    it("executes %") do
       assert_macro "", "{{5 % 3}}", [] of ASTNode, "2"
     end
 
-    it "executes &" do
+    it("executes &") do
       assert_macro "", "{{5 & 3}}", [] of ASTNode, "1"
     end
 
-    it "executes |" do
+    it("executes |") do
       assert_macro "", "{{5 | 3}}", [] of ASTNode, "7"
     end
 
-    it "executes ^" do
+    it("executes ^") do
       assert_macro "", "{{5 ^ 3}}", [] of ASTNode, "6"
     end
 
-    it "executes **" do
+    it("executes **") do
       assert_macro "", "{{2 ** 3}}", [] of ASTNode, "8"
     end
 
-    it "executes <<" do
+    it("executes <<") do
       assert_macro "", "{{1 << 2}}", [] of ASTNode, "4"
     end
 
-    it "executes >>" do
+    it("executes >>") do
       assert_macro "", "{{4 >> 2}}", [] of ASTNode, "1"
     end
 
-    it "executes + with float" do
+    it("executes + with float") do
       assert_macro "", "{{1.5 + 2.6}}", [] of ASTNode, "4.1"
     end
 
-    it "executes unary +" do
+    it("executes unary +") do
       assert_macro "", "{{+3}}", [] of ASTNode, "+3"
     end
 
-    it "executes unary -" do
+    it("executes unary -") do
       assert_macro "", "{{-(3)}}", [] of ASTNode, "-3"
     end
 
-    it "executes unary ~" do
+    it("executes unary ~") do
       assert_macro "", "{{~1}}", [] of ASTNode, "-2"
     end
 
-    it "exetutes kind" do
+    it("exetutes kind") do
       assert_macro "", "{{-128i8.kind}}", [] of ASTNode, ":i8"
       assert_macro "", "{{1e-123_f32.kind}}", [] of ASTNode, ":f32"
       assert_macro "", "{{1.0.kind}}", [] of ASTNode, ":f64"
@@ -236,170 +236,170 @@ describe "macro methods" do
     end
   end
 
-  describe "string methods" do
-    it "executes string == string" do
+  describe("string methods") do
+    it("executes string == string") do
       assert_macro "", %({{"foo" == "foo"}}), [] of ASTNode, %(true)
       assert_macro "", %({{"foo" == "bar"}}), [] of ASTNode, %(false)
     end
 
-    it "executes string != string" do
+    it("executes string != string") do
       assert_macro "", %({{"foo" != "foo"}}), [] of ASTNode, %(false)
       assert_macro "", %({{"foo" != "bar"}}), [] of ASTNode, %(true)
     end
 
-    it "executes split without arguments" do
+    it("executes split without arguments") do
       assert_macro "", %({{"1 2 3".split}}), [] of ASTNode, %(["1", "2", "3"])
     end
 
-    it "executes split with argument" do
+    it("executes split with argument") do
       assert_macro "", %({{"1-2-3".split("-")}}), [] of ASTNode, %(["1", "2", "3"])
     end
 
-    it "executes split with char argument" do
+    it("executes split with char argument") do
       assert_macro "", %({{"1-2-3".split('-')}}), [] of ASTNode, %(["1", "2", "3"])
     end
 
-    it "executes strip" do
+    it("executes strip") do
       assert_macro "", %({{"  hello   ".strip}}), [] of ASTNode, %("hello")
     end
 
-    it "executes downcase" do
+    it("executes downcase") do
       assert_macro "", %({{"HELLO".downcase}}), [] of ASTNode, %("hello")
     end
 
-    it "executes upcase" do
+    it("executes upcase") do
       assert_macro "", %({{"hello".upcase}}), [] of ASTNode, %("HELLO")
     end
 
-    it "executes capitalize" do
+    it("executes capitalize") do
       assert_macro "", %({{"hello".capitalize}}), [] of ASTNode, %("Hello")
     end
 
-    it "executes chars" do
+    it("executes chars") do
       assert_macro "x", %({{x.chars}}), [StringLiteral.new("123")] of ASTNode, %(['1', '2', '3'])
     end
 
-    it "executes lines" do
+    it("executes lines") do
       assert_macro "x", %({{x.lines}}), [StringLiteral.new("1\n2\n3")] of ASTNode, %(["1", "2", "3"])
     end
 
-    it "executes size" do
+    it("executes size") do
       assert_macro "", %({{"hello".size}}), [] of ASTNode, "5"
     end
 
-    it "executes empty" do
+    it("executes empty") do
       assert_macro "", %({{"hello".empty?}}), [] of ASTNode, "false"
     end
 
-    it "executes string [Range] inclusive" do
+    it("executes string [Range] inclusive") do
       assert_macro "", %({{"hello"[1..-2]}}), [] of ASTNode, %("ell")
     end
 
-    it "executes string [Range] exclusive" do
+    it("executes string [Range] exclusive") do
       assert_macro "", %({{"hello"[1...-2]}}), [] of ASTNode, %("el")
     end
 
-    it "executes string [Range] inclusive (computed)" do
+    it("executes string [Range] inclusive (computed)") do
       assert_macro "", %({{"hello"[[1].size..-2]}}), [] of ASTNode, %("ell")
     end
 
-    it "executes string chomp" do
+    it("executes string chomp") do
       assert_macro "", %({{"hello\n".chomp}}), [] of ASTNode, %("hello")
     end
 
-    it "executes string starts_with? char (true)" do
+    it("executes string starts_with? char (true)") do
       assert_macro "", %({{"hello".starts_with?('h')}}), [] of ASTNode, %(true)
     end
 
-    it "executes string starts_with? char (false)" do
+    it("executes string starts_with? char (false)") do
       assert_macro "", %({{"hello".starts_with?('e')}}), [] of ASTNode, %(false)
     end
 
-    it "executes string starts_with? string (true)" do
+    it("executes string starts_with? string (true)") do
       assert_macro "", %({{"hello".starts_with?("hel")}}), [] of ASTNode, %(true)
     end
 
-    it "executes string starts_with? string (false)" do
+    it("executes string starts_with? string (false)") do
       assert_macro "", %({{"hello".starts_with?("hi")}}), [] of ASTNode, %(false)
     end
 
-    it "executes string ends_with? char (true)" do
+    it("executes string ends_with? char (true)") do
       assert_macro "", %({{"hello".ends_with?('o')}}), [] of ASTNode, %(true)
     end
 
-    it "executes string ends_with? char (false)" do
+    it("executes string ends_with? char (false)") do
       assert_macro "", %({{"hello".ends_with?('e')}}), [] of ASTNode, %(false)
     end
 
-    it "executes string ends_with? string (true)" do
+    it("executes string ends_with? string (true)") do
       assert_macro "", %({{"hello".ends_with?("llo")}}), [] of ASTNode, %(true)
     end
 
-    it "executes string ends_with? string (false)" do
+    it("executes string ends_with? string (false)") do
       assert_macro "", %({{"hello".ends_with?("tro")}}), [] of ASTNode, %(false)
     end
 
-    it "executes string + string" do
+    it("executes string + string") do
       assert_macro "", %({{"hello" + " world"}}), [] of ASTNode, %("hello world")
     end
 
-    it "executes string + char" do
+    it("executes string + char") do
       assert_macro "", %({{"hello" + 'w'}}), [] of ASTNode, %("hellow")
     end
 
-    it "executes string =~ (false)" do
+    it("executes string =~ (false)") do
       assert_macro "", %({{"hello" =~ /hei/}}), [] of ASTNode, %(false)
     end
 
-    it "executes string =~ (true)" do
+    it("executes string =~ (true)") do
       assert_macro "", %({{"hello" =~ /ell/}}), [] of ASTNode, %(true)
     end
 
-    it "executes string > string" do
+    it("executes string > string") do
       assert_macro "", %({{"fooa" > "foo"}}), [] of ASTNode, %(true)
       assert_macro "", %({{"foo" > "fooa"}}), [] of ASTNode, %(false)
     end
 
-    it "executes string > macroid" do
+    it("executes string > macroid") do
       assert_macro "", %({{"fooa" > "foo".id}}), [] of ASTNode, %(true)
       assert_macro "", %({{"foo" > "fooa".id}}), [] of ASTNode, %(false)
     end
 
-    it "executes string < string" do
+    it("executes string < string") do
       assert_macro "", %({{"fooa" < "foo"}}), [] of ASTNode, %(false)
       assert_macro "", %({{"foo" < "fooa"}}), [] of ASTNode, %(true)
     end
 
-    it "executes string < macroid" do
+    it("executes string < macroid") do
       assert_macro "", %({{"fooa" < "foo".id}}), [] of ASTNode, %(false)
       assert_macro "", %({{"foo" < "fooa".id}}), [] of ASTNode, %(true)
     end
 
-    it "executes tr" do
+    it("executes tr") do
       assert_macro "", %({{"hello".tr("e", "o")}}), [] of ASTNode, %("hollo")
     end
 
-    it "executes gsub" do
+    it("executes gsub") do
       assert_macro "", %({{"hello".gsub(/e|o/, "a")}}), [] of ASTNode, %("halla")
     end
 
-    it "executes camelcase" do
+    it("executes camelcase") do
       assert_macro "", %({{"foo_bar".camelcase}}), [] of ASTNode, %("FooBar")
     end
 
-    it "executes underscore" do
+    it("executes underscore") do
       assert_macro "", %({{"FooBar".underscore}}), [] of ASTNode, %("foo_bar")
     end
 
-    it "executes to_i" do
+    it("executes to_i") do
       assert_macro "", %({{"1234".to_i}}), [] of ASTNode, %(1234)
     end
 
-    it "executes to_i(base)" do
+    it("executes to_i(base)") do
       assert_macro "", %({{"1234".to_i(16)}}), [] of ASTNode, %(4660)
     end
 
-    it "executes string includes? char (true)" do
+    it("executes string includes? char (true)") do
       assert_macro "", %({{"spice".includes?('s')}}), [] of ASTNode, %(true)
       assert_macro "", %({{"spice".includes?('p')}}), [] of ASTNode, %(true)
       assert_macro "", %({{"spice".includes?('i')}}), [] of ASTNode, %(true)
@@ -407,14 +407,14 @@ describe "macro methods" do
       assert_macro "", %({{"spice".includes?('e')}}), [] of ASTNode, %(true)
     end
 
-    it "executes string includes? char (false)" do
+    it("executes string includes? char (false)") do
       assert_macro "", %({{"spice".includes?('S')}}), [] of ASTNode, %(false)
       assert_macro "", %({{"spice".includes?(' ')}}), [] of ASTNode, %(false)
       assert_macro "", %({{"spice".includes?('!')}}), [] of ASTNode, %(false)
       assert_macro "", %({{"spice".includes?('b')}}), [] of ASTNode, %(false)
     end
 
-    it "executes string includes? string (true)" do
+    it("executes string includes? string (true)") do
       assert_macro "", %({{"spice".includes?("s")}}), [] of ASTNode, %(true)
       assert_macro "", %({{"spice".includes?("e")}}), [] of ASTNode, %(true)
       assert_macro "", %({{"spice".includes?("sp")}}), [] of ASTNode, %(true)
@@ -422,7 +422,7 @@ describe "macro methods" do
       assert_macro "", %({{"spice".includes?("pic")}}), [] of ASTNode, %(true)
     end
 
-    it "executes string includes? string (false)" do
+    it("executes string includes? string (false)") do
       assert_macro "", %({{"spice".includes?("Spi")}}), [] of ASTNode, %(false)
       assert_macro "", %({{"spice".includes?(" spi")}}), [] of ASTNode, %(false)
       assert_macro "", %({{"spice".includes?("ce ")}}), [] of ASTNode, %(false)
@@ -431,8 +431,8 @@ describe "macro methods" do
     end
   end
 
-  describe "macro id methods" do
-    it "forwards methods to string" do
+  describe("macro id methods") do
+    it("forwards methods to string") do
       assert_macro "x", %({{x.ends_with?("llo")}}), [MacroId.new("hello")] of ASTNode, %(true)
       assert_macro "x", %({{x.ends_with?("tro")}}), [MacroId.new("hello")] of ASTNode, %(false)
       assert_macro "x", %({{x.starts_with?("hel")}}), [MacroId.new("hello")] of ASTNode, %(true)
@@ -444,7 +444,7 @@ describe "macro methods" do
       assert_macro "x", %({{x.includes?("cat")}}), [MacroId.new("hello")] of ASTNode, %(false)
     end
 
-    it "compares with string" do
+    it("compares with string") do
       assert_macro "x", %({{x == "foo"}}), [MacroId.new("foo")] of ASTNode, %(true)
       assert_macro "x", %({{"foo" == x}}), [MacroId.new("foo")] of ASTNode, %(true)
 
@@ -458,7 +458,7 @@ describe "macro methods" do
       assert_macro "x", %({{"bar" != x}}), [MacroId.new("foo")] of ASTNode, %(true)
     end
 
-    it "compares with symbol" do
+    it("compares with symbol") do
       assert_macro "x", %({{x == :foo}}), [MacroId.new("foo")] of ASTNode, %(true)
       assert_macro "x", %({{:foo == x}}), [MacroId.new("foo")] of ASTNode, %(true)
 
@@ -473,8 +473,8 @@ describe "macro methods" do
     end
   end
 
-  describe "symbol methods" do
-    it "forwards methods to string" do
+  describe("symbol methods") do
+    it("forwards methods to string") do
       assert_macro "x", %({{x.ends_with?("llo")}}), ["hello".symbol] of ASTNode, %(true)
       assert_macro "x", %({{x.ends_with?("tro")}}), ["hello".symbol] of ASTNode, %(false)
       assert_macro "x", %({{x.starts_with?("hel")}}), ["hello".symbol] of ASTNode, %(true)
@@ -486,574 +486,574 @@ describe "macro methods" do
       assert_macro "x", %({{x.includes?("cat")}}), ["hello".symbol] of ASTNode, %(false)
     end
 
-    it "executes symbol == symbol" do
+    it("executes symbol == symbol") do
       assert_macro "", %({{:foo == :foo}}), [] of ASTNode, %(true)
       assert_macro "", %({{:foo == :bar}}), [] of ASTNode, %(false)
     end
 
-    it "executes symbol != symbol" do
+    it("executes symbol != symbol") do
       assert_macro "", %({{:foo != :foo}}), [] of ASTNode, %(false)
       assert_macro "", %({{:foo != :bar}}), [] of ASTNode, %(true)
     end
   end
 
-  describe "and methods" do
-    it "executes left" do
+  describe("and methods") do
+    it("executes left") do
       assert_macro "x", %({{x.left}}), [And.new(1.int32, 2.int32)] of ASTNode, %(1)
     end
 
-    it "executes right" do
+    it("executes right") do
       assert_macro "x", %({{x.right}}), [And.new(1.int32, 2.int32)] of ASTNode, %(2)
     end
   end
 
-  describe "or methods" do
-    it "executes left" do
+  describe("or methods") do
+    it("executes left") do
       assert_macro "x", %({{x.left}}), [Or.new(1.int32, 2.int32)] of ASTNode, %(1)
     end
 
-    it "executes right" do
+    it("executes right") do
       assert_macro "x", %({{x.right}}), [Or.new(1.int32, 2.int32)] of ASTNode, %(2)
     end
   end
 
-  describe "array methods" do
-    it "executes index 0" do
+  describe("array methods") do
+    it("executes index 0") do
       assert_macro "", %({{[1, 2, 3][0]}}), [] of ASTNode, "1"
     end
 
-    it "executes index 1" do
+    it("executes index 1") do
       assert_macro "", %({{[1, 2, 3][1]}}), [] of ASTNode, "2"
     end
 
-    it "executes index out of bounds" do
+    it("executes index out of bounds") do
       assert_macro "", %({{[1, 2, 3][3]}}), [] of ASTNode, "nil"
     end
 
-    it "executes size" do
+    it("executes size") do
       assert_macro "", %({{[1, 2, 3].size}}), [] of ASTNode, "3"
     end
 
-    it "executes empty?" do
+    it("executes empty?") do
       assert_macro "", %({{[1, 2, 3].empty?}}), [] of ASTNode, "false"
     end
 
-    it "executes identify" do
+    it("executes identify") do
       assert_macro "", %({{"A::B".identify}}), [] of ASTNode, "\"A__B\""
       assert_macro "", %({{"A".identify}}), [] of ASTNode, "\"A\""
     end
 
-    it "executes join" do
+    it("executes join") do
       assert_macro "", %({{[1, 2, 3].join ", "}}), [] of ASTNode, %("1, 2, 3")
     end
 
-    it "executes join with strings" do
+    it("executes join with strings") do
       assert_macro "", %({{["a", "b"].join ", "}}), [] of ASTNode, %("a, b")
     end
 
-    it "executes map" do
+    it("executes map") do
       assert_macro "", %({{[1, 2, 3].map { |e| e == 2 }}}), [] of ASTNode, "[false, true, false]"
     end
 
-    it "executes map with constants" do
+    it("executes map with constants") do
       assert_macro "x", %({{x.map { |e| e.id }}}), [ArrayLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "[Foo, Bar]"
     end
 
-    it "executes map with arg" do
+    it("executes map with arg") do
       assert_macro "x", %({{x.map { |e| e.id }}}), [ArrayLiteral.new(["hello".call] of ASTNode)] of ASTNode, "[hello]"
     end
 
-    it "executes select" do
+    it("executes select") do
       assert_macro "", %({{[1, 2, 3].select { |e| e == 1 }}}), [] of ASTNode, "[1]"
     end
 
-    it "executes reject" do
+    it("executes reject") do
       assert_macro "", %({{[1, 2, 3].reject { |e| e == 1 }}}), [] of ASTNode, "[2, 3]"
     end
 
-    it "executes find (finds)" do
+    it("executes find (finds)") do
       assert_macro "", %({{[1, 2, 3].find { |e| e == 2 }}}), [] of ASTNode, "2"
     end
 
-    it "executes find (doesn't find)" do
+    it("executes find (doesn't find)") do
       assert_macro "", %({{[1, 2, 3].find { |e| e == 4 }}}), [] of ASTNode, "nil"
     end
 
-    it "executes any? (true)" do
+    it("executes any? (true)") do
       assert_macro "", %({{[1, 2, 3].any? { |e| e == 1 }}}), [] of ASTNode, "true"
     end
 
-    it "executes any? (false)" do
+    it("executes any? (false)") do
       assert_macro "", %({{[1, 2, 3].any? { |e| e == 4 }}}), [] of ASTNode, "false"
     end
 
-    it "executes all? (true)" do
+    it("executes all? (true)") do
       assert_macro "", %({{[1, 1, 1].all? { |e| e == 1 }}}), [] of ASTNode, "true"
     end
 
-    it "executes all? (false)" do
+    it("executes all? (false)") do
       assert_macro "", %({{[1, 2, 1].all? { |e| e == 1 }}}), [] of ASTNode, "false"
     end
 
-    it "executes first" do
+    it("executes first") do
       assert_macro "", %({{[1, 2, 3].first}}), [] of ASTNode, "1"
     end
 
-    it "executes last" do
+    it("executes last") do
       assert_macro "", %({{[1, 2, 3].last}}), [] of ASTNode, "3"
     end
 
-    it "executes splat" do
+    it("executes splat") do
       assert_macro "", %({{[1, 2, 3].splat}}), [] of ASTNode, "1, 2, 3"
     end
 
-    it "executes splat with symbols and strings" do
+    it("executes splat with symbols and strings") do
       assert_macro "", %({{[:foo, "hello", 3].splat}}), [] of ASTNode, %(:foo, "hello", 3)
     end
 
-    it "executes splat with splat" do
+    it("executes splat with splat") do
       assert_macro "", %({{*[1, 2, 3]}}), [] of ASTNode, "1, 2, 3"
     end
 
-    it "executes is_a?" do
+    it("executes is_a?") do
       assert_macro "", %({{[1, 2, 3].is_a?(ArrayLiteral)}}), [] of ASTNode, "true"
       assert_macro "", %({{[1, 2, 3].is_a?(NumberLiteral)}}), [] of ASTNode, "false"
     end
 
-    it "creates an array literal with a var" do
+    it("creates an array literal with a var") do
       assert_macro "x", %({% a = [x] %}{{a[0]}}), [1.int32] of ASTNode, "1"
     end
 
-    it "executes sort with numbers" do
+    it("executes sort with numbers") do
       assert_macro "", %({{[3, 2, 1].sort}}), [] of ASTNode, "[1, 2, 3]"
     end
 
-    it "executes sort with strings" do
+    it("executes sort with strings") do
       assert_macro "", %({{["c", "b", "a"].sort}}), [] of ASTNode, %(["a", "b", "c"])
     end
 
-    it "executes sort with ids" do
+    it("executes sort with ids") do
       assert_macro "", %({{["c".id, "b".id, "a".id].sort}}), [] of ASTNode, %([a, b, c])
     end
 
-    it "executes sort with ids and strings" do
+    it("executes sort with ids and strings") do
       assert_macro "", %({{["c".id, "b", "a".id].sort}}), [] of ASTNode, %([a, "b", c])
     end
 
-    it "executes uniq" do
+    it("executes uniq") do
       assert_macro "", %({{[1, 1, 1, 2, 3, 1, 2, 3, 4].uniq}}), [] of ASTNode, %([1, 2, 3, 4])
     end
 
-    it "executes unshift" do
+    it("executes unshift") do
       assert_macro "", %({% x = [1]; x.unshift(2); %}{{x}}), [] of ASTNode, %([2, 1])
     end
 
-    it "executes push" do
+    it("executes push") do
       assert_macro "", %({% x = [1]; x.push(2); x << 3 %}{{x}}), [] of ASTNode, %([1, 2, 3])
     end
 
-    it "executes includes?" do
+    it("executes includes?") do
       assert_macro "", %({{ [1, 2, 3].includes?(1) }}), [] of ASTNode, %(true)
       assert_macro "", %({{ [1, 2, 3].includes?(4) }}), [] of ASTNode, %(false)
     end
 
-    it "executes +" do
+    it("executes +") do
       assert_macro "", %({{ [1, 2] + [3, 4, 5] }}), [] of ASTNode, %([1, 2, 3, 4, 5])
     end
 
-    it "executes [] with range" do
+    it("executes [] with range") do
       assert_macro "", %({{ [1, 2, 3, 4][1...-1] }}), [] of ASTNode, %([2, 3])
     end
 
-    it "executes [] with computed range" do
+    it("executes [] with computed range") do
       assert_macro "", %({{ [1, 2, 3, 4][[1].size...-1] }}), [] of ASTNode, %([2, 3])
     end
 
-    it "executes [] with two numbers" do
+    it("executes [] with two numbers") do
       assert_macro "", %({{ [1, 2, 3, 4, 5][1, 3] }}), [] of ASTNode, %([2, 3, 4])
     end
 
-    it "executes []=" do
+    it("executes []=") do
       assert_macro "", %({% a = [0]; a[0] = 2 %}{{a[0]}}), [] of ASTNode, "2"
     end
 
-    it "executes of" do
+    it("executes of") do
       assert_macro "x", %({{ x.of }}), [ArrayLiteral.new([] of ASTNode, of: Path.new(["Int64"]))] of ASTNode, %(Int64)
     end
 
-    it "executes of (nop)" do
+    it("executes of (nop)") do
       assert_macro "", %({{ [1, 2, 3].of }}), [] of ASTNode, %()
     end
 
-    it "executes type" do
+    it("executes type") do
       assert_macro "x", %({{ x.type }}), [ArrayLiteral.new([] of ASTNode, name: Path.new(["Deque"]))] of ASTNode, %(Deque)
     end
 
-    it "executes type (nop)" do
+    it("executes type (nop)") do
       assert_macro "", %({{ [1, 2, 3].type }}), [] of ASTNode, %()
     end
   end
 
-  describe "hash methods" do
-    it "executes size" do
+  describe("hash methods") do
+    it("executes size") do
       assert_macro "", %({{{:a => 1, :b => 3}.size}}), [] of ASTNode, "2"
     end
 
-    it "executes empty?" do
+    it("executes empty?") do
       assert_macro "", %({{{:a => 1}.empty?}}), [] of ASTNode, "false"
     end
 
-    it "executes []" do
+    it("executes []") do
       assert_macro "", %({{{:a => 1}[:a]}}), [] of ASTNode, "1"
     end
 
-    it "executes [] not found" do
+    it("executes [] not found") do
       assert_macro "", %({{{:a => 1}[:b]}}), [] of ASTNode, "nil"
     end
 
-    it "executes keys" do
+    it("executes keys") do
       assert_macro "", %({{{:a => 1, :b => 2}.keys}}), [] of ASTNode, "[:a, :b]"
     end
 
-    it "executes values" do
+    it("executes values") do
       assert_macro "", %({{{:a => 1, :b => 2}.values}}), [] of ASTNode, "[1, 2]"
     end
 
-    it "executes map" do
+    it("executes map") do
       assert_macro "", %({{{:a => 1, :b => 2}.map {|k, v| k == :a && v == 1}}}), [] of ASTNode, "[true, false]"
     end
 
-    it "executes is_a?" do
+    it("executes is_a?") do
       assert_macro "", %({{{:a => 1}.is_a?(HashLiteral)}}), [] of ASTNode, "true"
       assert_macro "", %({{{:a => 1}.is_a?(RangeLiteral)}}), [] of ASTNode, "false"
     end
 
-    it "executes []=" do
+    it("executes []=") do
       assert_macro "", %({% a = {} of Nil => Nil; a[1] = 2 %}{{a[1]}}), [] of ASTNode, "2"
     end
 
-    it "creates a hash literal with a var" do
+    it("creates a hash literal with a var") do
       assert_macro "x", %({% a = {:a => x} %}{{a[:a]}}), [1.int32] of ASTNode, "1"
     end
 
-    it "executes to_a" do
+    it("executes to_a") do
       assert_macro "", %({{{:a => 1, :b => 3}.to_a}}), [] of ASTNode, "[{:a, 1}, {:b, 3}]"
     end
 
-    it "executes of_key" do
+    it("executes of_key") do
       of = HashLiteral::Entry.new(Path.new(["String"]), Path.new(["UInt8"]))
       assert_macro "x", %({{ x.of_key }}), [HashLiteral.new([] of HashLiteral::Entry, of: of)] of ASTNode, %(String)
     end
 
-    it "executes of_key (nop)" do
+    it("executes of_key (nop)") do
       assert_macro "", %({{ {'z' => 6, 'a' => 9}.of_key }}), [] of ASTNode, %()
     end
 
-    it "executes of_value" do
+    it("executes of_value") do
       of = HashLiteral::Entry.new(Path.new(["String"]), Path.new(["UInt8"]))
       assert_macro "x", %({{ x.of_value }}), [HashLiteral.new([] of HashLiteral::Entry, of: of)] of ASTNode, %(UInt8)
     end
 
-    it "executes of_value (nop)" do
+    it("executes of_value (nop)") do
       assert_macro "", %({{ {'z' => 6, 'a' => 9}.of_value }}), [] of ASTNode, %()
     end
 
-    it "executes type" do
+    it("executes type") do
       assert_macro "x", %({{ x.type }}), [HashLiteral.new([] of HashLiteral::Entry, name: Path.new(["Headers"]))] of ASTNode, %(Headers)
     end
 
-    it "executes type (nop)" do
+    it("executes type (nop)") do
       assert_macro "", %({{ {'z' => 6, 'a' => 9}.type }}), [] of ASTNode, %()
     end
 
-    it "executes double splat" do
+    it("executes double splat") do
       assert_macro "", %({{**{1 => 2, 3 => 4}}}), [] of ASTNode, "1 => 2, 3 => 4"
     end
 
-    it "executes double splat" do
+    it("executes double splat") do
       assert_macro "", %({{{1 => 2, 3 => 4}.double_splat}}), [] of ASTNode, "1 => 2, 3 => 4"
     end
 
-    it "executes double splat with arg" do
+    it("executes double splat with arg") do
       assert_macro "", %({{{1 => 2, 3 => 4}.double_splat(", ")}}), [] of ASTNode, "1 => 2, 3 => 4, "
     end
   end
 
-  describe "named tuple literal methods" do
-    it "executes size" do
+  describe("named tuple literal methods") do
+    it("executes size") do
       assert_macro "", %({{{a: 1, b: 3}.size}}), [] of ASTNode, "2"
     end
 
-    it "executes empty?" do
+    it("executes empty?") do
       assert_macro "", %({{{a: 1}.empty?}}), [] of ASTNode, "false"
     end
 
-    it "executes []" do
+    it("executes []") do
       assert_macro "", %({{{a: 1}[:a]}}), [] of ASTNode, "1"
       assert_macro "", %({{{a: 1}["a"]}}), [] of ASTNode, "1"
     end
 
-    it "executes [] not found" do
+    it("executes [] not found") do
       assert_macro "", %({{{a: 1}[:b]}}), [] of ASTNode, "nil"
       assert_macro "", %({{{a: 1}["b"]}}), [] of ASTNode, "nil"
     end
 
-    it "executes keys" do
+    it("executes keys") do
       assert_macro "", %({{{a: 1, b: 2}.keys}}), [] of ASTNode, "[a, b]"
     end
 
-    it "executes values" do
+    it("executes values") do
       assert_macro "", %({{{a: 1, b: 2}.values}}), [] of ASTNode, "[1, 2]"
     end
 
-    it "executes map" do
+    it("executes map") do
       assert_macro "", %({{{a: 1, b: 2}.map {|k, v| k.stringify == "a" && v == 1}}}), [] of ASTNode, "[true, false]"
     end
 
-    it "executes is_a?" do
+    it("executes is_a?") do
       assert_macro "", %({{{a: 1}.is_a?(NamedTupleLiteral)}}), [] of ASTNode, "true"
       assert_macro "", %({{{a: 1}.is_a?(RangeLiteral)}}), [] of ASTNode, "false"
     end
 
-    it "executes []=" do
+    it("executes []=") do
       assert_macro "", %({% a = {a: 1}; a[:a] = 2 %}{{a[:a]}}), [] of ASTNode, "2"
       assert_macro "", %({% a = {a: 1}; a["a"] = 2 %}{{a["a"]}}), [] of ASTNode, "2"
     end
 
-    it "creates a named tuple literal with a var" do
+    it("creates a named tuple literal with a var") do
       assert_macro "x", %({% a = {a: x} %}{{a[:a]}}), [1.int32] of ASTNode, "1"
     end
 
-    it "executes to_a" do
+    it("executes to_a") do
       assert_macro "", %({{{a: 1, b: 3}.to_a}}), [] of ASTNode, "[{a, 1}, {b, 3}]"
     end
 
-    it "executes double splat" do
+    it("executes double splat") do
       assert_macro "", %({{**{a: 1, "foo bar": 2}}}), [] of ASTNode, %(a: 1, "foo bar": 2)
     end
 
-    it "executes double splat" do
+    it("executes double splat") do
       assert_macro "", %({{{a: 1, "foo bar": 2}.double_splat}}), [] of ASTNode, %(a: 1, "foo bar": 2)
     end
 
-    it "executes double splat with arg" do
+    it("executes double splat with arg") do
       assert_macro "", %({{{a: 1, "foo bar": 2}.double_splat(", ")}}), [] of ASTNode, %(a: 1, "foo bar": 2, )
     end
   end
 
-  describe "tuple methods" do
-    it "executes index 0" do
+  describe("tuple methods") do
+    it("executes index 0") do
       assert_macro "", %({{ {1, 2, 3}[0] }}), [] of ASTNode, "1"
     end
 
-    it "executes index 1" do
+    it("executes index 1") do
       assert_macro "", %({{ {1, 2, 3}[1] }}), [] of ASTNode, "2"
     end
 
-    it "executes index out of bounds" do
+    it("executes index out of bounds") do
       assert_macro "", %({{ {1, 2, 3}[3] }}), [] of ASTNode, "nil"
     end
 
-    it "executes size" do
+    it("executes size") do
       assert_macro "", %({{ {1, 2, 3}.size }}), [] of ASTNode, "3"
     end
 
-    it "executes empty?" do
+    it("executes empty?") do
       assert_macro "", %({{ {1, 2, 3}.empty? }}), [] of ASTNode, "false"
     end
 
-    it "executes join" do
+    it("executes join") do
       assert_macro "", %({{ {1, 2, 3}.join ", " }}), [] of ASTNode, %("1, 2, 3")
     end
 
-    it "executes join with strings" do
+    it("executes join with strings") do
       assert_macro "", %({{ {"a", "b"}.join ", " }}), [] of ASTNode, %("a, b")
     end
 
-    it "executes map" do
+    it("executes map") do
       assert_macro "", %({{ {1, 2, 3}.map { |e| e == 2 } }}), [] of ASTNode, "{false, true, false}"
     end
 
-    it "executes map with constants" do
+    it("executes map with constants") do
       assert_macro "x", %({{x.map { |e| e.id }}}), [TupleLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "{Foo, Bar}"
     end
 
-    it "executes map with arg" do
+    it("executes map with arg") do
       assert_macro "x", %({{x.map { |e| e.id }}}), [TupleLiteral.new(["hello".call] of ASTNode)] of ASTNode, "{hello}"
     end
 
-    it "executes select" do
+    it("executes select") do
       assert_macro "", %({{ {1, 2, 3}.select { |e| e == 1 } }}), [] of ASTNode, "{1}"
     end
 
-    it "executes reject" do
+    it("executes reject") do
       assert_macro "", %({{ {1, 2, 3}.reject { |e| e == 1 } }}), [] of ASTNode, "{2, 3}"
     end
 
-    it "executes find (finds)" do
+    it("executes find (finds)") do
       assert_macro "", %({{ {1, 2, 3}.find { |e| e == 2 } }}), [] of ASTNode, "2"
     end
 
-    it "executes find (doesn't find)" do
+    it("executes find (doesn't find)") do
       assert_macro "", %({{ {1, 2, 3}.find { |e| e == 4 } }}), [] of ASTNode, "nil"
     end
 
-    it "executes any? (true)" do
+    it("executes any? (true)") do
       assert_macro "", %({{ {1, 2, 3}.any? { |e| e == 1 } }}), [] of ASTNode, "true"
     end
 
-    it "executes any? (false)" do
+    it("executes any? (false)") do
       assert_macro "", %({{ {1, 2, 3}.any? { |e| e == 4 } }}), [] of ASTNode, "false"
     end
 
-    it "executes all? (true)" do
+    it("executes all? (true)") do
       assert_macro "", %({{ {1, 1, 1}.all? { |e| e == 1 } }}), [] of ASTNode, "true"
     end
 
-    it "executes all? (false)" do
+    it("executes all? (false)") do
       assert_macro "", %({{ {1, 2, 1}.all? { |e| e == 1 } }}), [] of ASTNode, "false"
     end
 
-    it "executes first" do
+    it("executes first") do
       assert_macro "", %({{ {1, 2, 3}.first }}), [] of ASTNode, "1"
     end
 
-    it "executes last" do
+    it("executes last") do
       assert_macro "", %({{ {1, 2, 3}.last }}), [] of ASTNode, "3"
     end
 
-    it "executes splat" do
+    it("executes splat") do
       assert_macro "", %({{ {1, 2, 3}.splat }}), [] of ASTNode, "1, 2, 3"
     end
 
-    it "executes splat with arg" do
+    it("executes splat with arg") do
       assert_macro "", %({{ {1, 2, 3}.splat(", ") }}), [] of ASTNode, "1, 2, 3, "
     end
 
-    it "executes splat with symbols and strings" do
+    it("executes splat with symbols and strings") do
       assert_macro "", %({{ {:foo, "hello", 3}.splat }}), [] of ASTNode, %(:foo, "hello", 3)
     end
 
-    it "executes splat with splat" do
+    it("executes splat with splat") do
       assert_macro "", %({{ *{1, 2, 3} }}), [] of ASTNode, "1, 2, 3"
     end
 
-    it "executes is_a?" do
+    it("executes is_a?") do
       assert_macro "", %({{ {1, 2, 3}.is_a?(TupleLiteral) }}), [] of ASTNode, "true"
       assert_macro "", %({{ {1, 2, 3}.is_a?(ArrayLiteral) }}), [] of ASTNode, "false"
     end
 
-    it "creates a tuple literal with a var" do
+    it("creates a tuple literal with a var") do
       assert_macro "x", %({% a = {x} %}{{a[0]}}), [1.int32] of ASTNode, "1"
     end
 
-    it "executes sort with numbers" do
+    it("executes sort with numbers") do
       assert_macro "", %({{ {3, 2, 1}.sort }}), [] of ASTNode, "{1, 2, 3}"
     end
 
-    it "executes sort with strings" do
+    it("executes sort with strings") do
       assert_macro "", %({{ {"c", "b", "a"}.sort }}), [] of ASTNode, %({"a", "b", "c"})
     end
 
-    it "executes sort with ids" do
+    it("executes sort with ids") do
       assert_macro "", %({{ {"c".id, "b".id, "a".id}.sort }}), [] of ASTNode, %({a, b, c})
     end
 
-    it "executes sort with ids and strings" do
+    it("executes sort with ids and strings") do
       assert_macro "", %({{ {"c".id, "b", "a".id}.sort }}), [] of ASTNode, %({a, "b", c})
     end
 
-    it "executes uniq" do
+    it("executes uniq") do
       assert_macro "", %({{ {1, 1, 1, 2, 3, 1, 2, 3, 4}.uniq }}), [] of ASTNode, %({1, 2, 3, 4})
     end
 
-    it "executes unshift" do
+    it("executes unshift") do
       assert_macro "", %({% x = {1}; x.unshift(2); %}{{x}}), [] of ASTNode, %({2, 1})
     end
 
-    it "executes push" do
+    it("executes push") do
       assert_macro "", %({% x = {1}; x.push(2); x << 3 %}{{x}}), [] of ASTNode, %({1, 2, 3})
     end
 
-    it "executes includes?" do
+    it("executes includes?") do
       assert_macro "", %({{ {1, 2, 3}.includes?(1) }}), [] of ASTNode, %(true)
       assert_macro "", %({{ {1, 2, 3}.includes?(4) }}), [] of ASTNode, %(false)
     end
 
-    it "executes +" do
+    it("executes +") do
       assert_macro "", %({{ {1, 2} + {3, 4, 5} }}), [] of ASTNode, %({1, 2, 3, 4, 5})
     end
   end
 
-  describe "regex methods" do
-    it "executes source" do
+  describe("regex methods") do
+    it("executes source") do
       assert_macro "", %({{ /rëgéx/i.source }}), [] of ASTNode, %("rëgéx")
     end
 
-    it "executes options" do
+    it("executes options") do
       assert_macro "", %({{ //.options }}), [] of ASTNode, %([])
       assert_macro "", %({{ /a/i.options }}), [] of ASTNode, %([:i])
       assert_macro "", %({{ /re/mix.options }}), [] of ASTNode, %([:i, :m, :x])
     end
   end
 
-  describe "metavar methods" do
-    it "executes nothing" do
+  describe("metavar methods") do
+    it("executes nothing") do
       assert_macro "x", %({{x}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
     end
 
-    it "executes name" do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
     end
 
-    it "executes id" do
+    it("executes id") do
       assert_macro "x", %({{x.id}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
     end
   end
 
-  describe "block methods" do
-    it "executes body" do
+  describe("block methods") do
+    it("executes body") do
       assert_macro "x", %({{x.body}}), [Block.new(body: 1.int32)] of ASTNode, "1"
     end
 
-    it "executes args" do
+    it("executes args") do
       assert_macro "x", %({{x.args}}), [Block.new(["x".var, "y".var])] of ASTNode, "[x, y]"
     end
 
-    it "executes splat_index" do
+    it("executes splat_index") do
       assert_macro "x", %({{x.splat_index}}), [Block.new(["x".var, "y".var], splat_index: 1)] of ASTNode, "1"
       assert_macro "x", %({{x.splat_index}}), [Block.new(["x".var, "y".var])] of ASTNode, "nil"
     end
   end
 
-  describe "expressions methods" do
-    it "executes expressions" do
+  describe("expressions methods") do
+    it("executes expressions") do
       assert_macro "x", %({{x.body.expressions[0]}}), [Block.new(body: Expressions.new(["some_call".call, "some_other_call".call] of ASTNode))] of ASTNode, "some_call"
     end
   end
 
-  it "executes assign" do
+  it("executes assign") do
     assert_macro "", %({{a = 1}}{{a}}), [] of ASTNode, "11"
   end
 
-  it "executes assign without output" do
+  it("executes assign without output") do
     assert_macro "", %({% a = 1 %}{{a}}), [] of ASTNode, "1"
   end
 
-  describe "type methods" do
-    it "executes name" do
+  describe("type methods") do
+    it("executes name") do
       assert_macro("x", "{{x.name}}", "String") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
     end
 
-    it "executes instance_vars" do
+    it("executes instance_vars") do
       assert_macro("x", "{{x.instance_vars.map &.stringify}}", %(["bytesize", "length", "c"])) do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
     end
 
-    it "executes ancestors" do
+    it("executes ancestors") do
       assert_macro("x", "{{x.ancestors}}", %([SomeModule, Reference, Object])) do |program|
         mod = NonGenericModuleType.new(program, program, "SomeModule")
         klass = NonGenericClassType.new(program, program, "SomeType", program.reference)
@@ -1063,7 +1063,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes ancestors (with generic)" do
+    it("executes ancestors (with generic)") do
       assert_macro("x", "{{x.ancestors}}", %([SomeGenericModule(String), SomeGenericType(String), Reference, Object])) do |program|
         generic_type = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
         generic_mod = GenericModuleType.new(program, program, "SomeGenericModule", ["T"])
@@ -1078,43 +1078,43 @@ describe "macro methods" do
       end
     end
 
-    it "executes superclass" do
+    it("executes superclass") do
       assert_macro("x", "{{x.superclass}}", %(Reference)) do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
     end
 
-    it "executes size of tuple" do
+    it("executes size of tuple") do
       assert_macro("x", "{{x.size}}", "2") do |program|
         [TypeNode.new(program.tuple_of([program.int32, program.string] of TypeVar))] of ASTNode
       end
     end
 
-    it "executes size of tuple metaclass" do
+    it("executes size of tuple metaclass") do
       assert_macro("x", "{{x.size}}", "2") do |program|
         [TypeNode.new(program.tuple_of([program.int32, program.string] of TypeVar).metaclass)] of ASTNode
       end
     end
 
-    it "executes type_vars" do
+    it("executes type_vars") do
       assert_macro("x", "{{x.type_vars.map &.stringify}}", %(["A", "B"])) do |program|
         [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
       end
     end
 
-    it "executes class" do
+    it("executes class") do
       assert_macro("x", "{{x.class.name}}", "String:Class") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
     end
 
-    it "executes instance" do
+    it("executes instance") do
       assert_macro("x", "{{x.class.instance}}", "String") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
     end
 
-    it "executes ==" do
+    it("executes ==") do
       assert_macro("x", "{{x == Reference}}", "false") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
@@ -1123,7 +1123,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes !=" do
+    it("executes !=") do
       assert_macro("x", "{{x != Reference}}", "true") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
@@ -1132,7 +1132,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes <" do
+    it("executes <") do
       assert_macro("x", "{{x < Reference}}", "true") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
@@ -1141,7 +1141,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes <=" do
+    it("executes <=") do
       assert_macro("x", "{{x <= Reference}}", "true") do |program|
         [TypeNode.new(program.string)] of ASTNode
       end
@@ -1150,7 +1150,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes >" do
+    it("executes >") do
       assert_macro("x", "{{x > Reference}}", "false") do |program|
         [TypeNode.new(program.reference)] of ASTNode
       end
@@ -1159,7 +1159,7 @@ describe "macro methods" do
       end
     end
 
-    it "executes >=" do
+    it("executes >=") do
       assert_macro("x", "{{x >= Reference}}", "true") do |program|
         [TypeNode.new(program.reference)] of ASTNode
       end
@@ -1169,405 +1169,405 @@ describe "macro methods" do
     end
   end
 
-  describe "type declaration methods" do
-    it "executes var" do
+  describe("type declaration methods") do
+    it("executes var") do
       assert_macro "x", %({{x.var}}), [TypeDeclaration.new(Var.new("some_name"), Path.new("SomeType"))] of ASTNode, "some_name"
     end
 
-    it "executes var when instance var" do
+    it("executes var when instance var") do
       assert_macro "x", %({{x.var}}), [TypeDeclaration.new(InstanceVar.new("@some_name"), Path.new("SomeType"))] of ASTNode, "@some_name"
     end
 
-    it "executes type" do
+    it("executes type") do
       assert_macro "x", %({{x.type}}), [TypeDeclaration.new(Var.new("some_name"), Path.new("SomeType"))] of ASTNode, "SomeType"
     end
 
-    it "executes value" do
+    it("executes value") do
       assert_macro "x", %({{x.value}}), [TypeDeclaration.new(Var.new("some_name"), Path.new("SomeType"), 1.int32)] of ASTNode, "1"
     end
   end
 
-  describe "uninitialized var methods" do
-    it "executes var" do
+  describe("uninitialized var methods") do
+    it("executes var") do
       assert_macro "x", %({{x.var}}), [UninitializedVar.new(Var.new("some_name"), Path.new("SomeType"))] of ASTNode, "some_name"
     end
 
-    it "executes type" do
+    it("executes type") do
       assert_macro "x", %({{x.type}}), [UninitializedVar.new(Var.new("some_name"), Path.new("SomeType"))] of ASTNode, "SomeType"
     end
   end
 
-  describe "def methods" do
-    it "executes name" do
+  describe("def methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [Def.new("some_def")] of ASTNode, "some_def"
     end
 
-    it "executes body" do
+    it("executes body") do
       assert_macro "x", %({{x.body}}), [Def.new("some_def", body: 1.int32)] of ASTNode, "1"
     end
 
-    it "executes args" do
+    it("executes args") do
       assert_macro "x", %({{x.args}}), [Def.new("some_def", args: [Arg.new("z")])] of ASTNode, "[z]"
     end
 
-    it "executes splat_index" do
+    it("executes splat_index") do
       assert_macro "x", %({{x.splat_index}}), [Def.new("some_def", ["x".arg, "y".arg], splat_index: 1)] of ASTNode, "1"
       assert_macro "x", %({{x.splat_index}}), [Def.new("some_def")] of ASTNode, "nil"
     end
 
-    it "executes double_splat" do
+    it("executes double_splat") do
       assert_macro "x", %({{x.double_splat}}), [Def.new("some_def", ["x".arg, "y".arg], double_splat: "s".arg)] of ASTNode, "s"
       assert_macro "x", %({{x.double_splat}}), [Def.new("some_def")] of ASTNode, ""
     end
 
-    it "executes block_arg" do
+    it("executes block_arg") do
       assert_macro "x", %({{x.block_arg}}), [Def.new("some_def", ["x".arg, "y".arg], block_arg: "b".arg)] of ASTNode, "b"
       assert_macro "x", %({{x.block_arg}}), [Def.new("some_def")] of ASTNode, ""
     end
 
-    it "executes return_type" do
+    it("executes return_type") do
       assert_macro "x", %({{x.return_type}}), [Def.new("some_def", ["x".arg, "y".arg], return_type: "b".arg)] of ASTNode, "b"
       assert_macro "x", %({{x.return_type}}), [Def.new("some_def")] of ASTNode, ""
     end
 
-    it "executes receiver" do
+    it("executes receiver") do
       assert_macro "x", %({{x.receiver}}), [Def.new("some_def", receiver: Var.new("self"))] of ASTNode, "self"
     end
 
-    it "executes visibility" do
+    it("executes visibility") do
       assert_macro "x", %({{x.visibility}}), [Def.new("some_def")] of ASTNode, ":public"
       assert_macro "x", %({{x.visibility}}), [Def.new("some_def").tap { |d| d.visibility = Visibility::Private }] of ASTNode, ":private"
     end
   end
 
-  describe "macro methods" do
-    it "executes name" do
+  describe("macro methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [Macro.new("some_macro")] of ASTNode, "some_macro"
     end
 
-    it "executes body" do
+    it("executes body") do
       assert_macro "x", %({{x.body}}), [Macro.new("some_macro", body: 1.int32)] of ASTNode, "1"
     end
 
-    it "executes args" do
+    it("executes args") do
       assert_macro "x", %({{x.args}}), [Macro.new("some_macro", args: [Arg.new("z")])] of ASTNode, "[z]"
     end
 
-    it "executes splat_index" do
+    it("executes splat_index") do
       assert_macro "x", %({{x.splat_index}}), [Macro.new("some_macro", ["x".arg, "y".arg], splat_index: 1)] of ASTNode, "1"
       assert_macro "x", %({{x.splat_index}}), [Macro.new("some_macro")] of ASTNode, "nil"
     end
 
-    it "executes double_splat" do
+    it("executes double_splat") do
       assert_macro "x", %({{x.double_splat}}), [Macro.new("some_macro", ["x".arg, "y".arg], double_splat: "s".arg)] of ASTNode, "s"
       assert_macro "x", %({{x.double_splat}}), [Macro.new("some_macro")] of ASTNode, ""
     end
 
-    it "executes block_arg" do
+    it("executes block_arg") do
       assert_macro "x", %({{x.block_arg}}), [Macro.new("some_macro", ["x".arg, "y".arg], block_arg: "b".arg)] of ASTNode, "b"
       assert_macro "x", %({{x.block_arg}}), [Macro.new("some_macro")] of ASTNode, ""
     end
 
-    it "executes visibility" do
+    it("executes visibility") do
       assert_macro "x", %({{x.visibility}}), [Macro.new("some_macro")] of ASTNode, ":public"
       assert_macro "x", %({{x.visibility}}), [Macro.new("some_macro").tap { |d| d.visibility = Visibility::Private }] of ASTNode, ":private"
     end
   end
 
-  describe "unary expression methods" do
-    it "executes exp" do
+  describe("unary expression methods") do
+    it("executes exp") do
       assert_macro "x", %({{x.exp}}), [Not.new("some_call".call)] of ASTNode, "some_call"
     end
   end
 
-  describe "visibility modifier methods" do
+  describe("visibility modifier methods") do
     node = VisibilityModifier.new(Visibility::Protected, Def.new("some_def"))
 
-    it "executes visibility" do
+    it("executes visibility") do
       assert_macro "x", %({{x.visibility}}), [node] of ASTNode, ":protected"
     end
 
-    it "executes exp" do
+    it("executes exp") do
       assert_macro "x", %({{x.exp}}), [node] of ASTNode, "def some_def\nend"
     end
   end
 
-  describe "is_a methods" do
+  describe("is_a methods") do
     node = IsA.new("var".var, Path.new("Int32"))
 
-    it "executes receiver" do
+    it("executes receiver") do
       assert_macro "x", %({{x.receiver}}), [node] of ASTNode, "var"
     end
 
-    it "executes arg" do
+    it("executes arg") do
       assert_macro "x", %({{x.arg}}), [node] of ASTNode, "Int32"
     end
   end
 
-  describe "responds_to methods" do
+  describe("responds_to methods") do
     node = RespondsTo.new("var".var, "to_i")
 
-    it "executes receiver" do
+    it("executes receiver") do
       assert_macro "x", %({{x.receiver}}), [node] of ASTNode, "var"
     end
 
-    it "executes name" do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [node] of ASTNode, %("to_i")
     end
   end
 
-  describe "require methods" do
-    it "executes path" do
+  describe("require methods") do
+    it("executes path") do
       assert_macro "x", %({{x.path}}), [Require.new("json")] of ASTNode, %("json")
     end
   end
 
-  describe "call methods" do
-    it "executes name" do
+  describe("call methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), ["some_call".call] of ASTNode, "some_call"
     end
 
-    it "executes args" do
+    it("executes args") do
       assert_macro "x", %({{x.args}}), [Call.new(nil, "some_call", [1.int32, 3.int32] of ASTNode)] of ASTNode, "[1, 3]"
     end
 
-    it "executes receiver" do
+    it("executes receiver") do
       assert_macro "x", %({{x.receiver}}), [Call.new(1.int32, "some_call")] of ASTNode, "1"
     end
 
-    it "executes block" do
+    it("executes block") do
       assert_macro "x", %({{x.block}}), [Call.new(1.int32, "some_call", block: Block.new)] of ASTNode, "do\nend"
     end
 
-    it "executes block arg" do
+    it("executes block arg") do
       assert_macro "x", %({{x.block_arg}}), [Call.new(1.int32, "some_call", block_arg: "bl".arg)] of ASTNode, "bl"
     end
 
-    it "executes block arg (nop)" do
+    it("executes block arg (nop)") do
       assert_macro "x", %({{x.block_arg}}), [Call.new(1.int32, "some_call")] of ASTNode, ""
     end
 
-    it "executes named args" do
+    it("executes named args") do
       assert_macro "x", %({{x.named_args}}), [Call.new(1.int32, "some_call", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])] of ASTNode, "[a: 1, b: 2]"
     end
 
-    it "executes named args name" do
+    it("executes named args name") do
       assert_macro "x", %({{x.named_args[0].name}}), [Call.new(1.int32, "some_call", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])] of ASTNode, "a"
     end
 
-    it "executes named args value" do
+    it("executes named args value") do
       assert_macro "x", %({{x.named_args[0].value}}), [Call.new(1.int32, "some_call", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])] of ASTNode, "1"
     end
   end
 
-  describe "arg methods" do
-    it "executes name" do
+  describe("arg methods") do
+    it("executes name") do
       arg = "into".arg
       assert_macro "x", %({{x.name}}), [arg] of ASTNode, "into"
       arg.name = "array" # internal
       assert_macro "x", %({{x.name}}), [arg] of ASTNode, "into"
     end
 
-    it "executes internal_name" do
+    it("executes internal_name") do
       arg = "into".arg
       assert_macro "x", %({{x.internal_name}}), [arg] of ASTNode, "into"
       arg.name = "array"
       assert_macro "x", %({{x.internal_name}}), [arg] of ASTNode, "array"
     end
 
-    it "executes default_value" do
+    it("executes default_value") do
       assert_macro "x", %({{x.default_value}}), ["some_arg".arg(default_value: 1.int32)] of ASTNode, "1"
     end
 
-    it "executes restriction" do
+    it("executes restriction") do
       assert_macro "x", %({{x.restriction}}), ["some_arg".arg(restriction: "T".path)] of ASTNode, "T"
     end
   end
 
-  describe "cast methods" do
-    it "executes obj" do
+  describe("cast methods") do
+    it("executes obj") do
       assert_macro "x", %({{x.obj}}), [Cast.new("x".call, "Int32".path)] of ASTNode, "x"
     end
 
-    it "executes to" do
+    it("executes to") do
       assert_macro "x", %({{x.to}}), [Cast.new("x".call, "Int32".path)] of ASTNode, "Int32"
     end
   end
 
-  describe "nilable cast methods" do
-    it "executes obj" do
+  describe("nilable cast methods") do
+    it("executes obj") do
       assert_macro "x", %({{x.obj}}), [NilableCast.new("x".call, "Int32".path)] of ASTNode, "x"
     end
 
-    it "executes to" do
+    it("executes to") do
       assert_macro "x", %({{x.to}}), [NilableCast.new("x".call, "Int32".path)] of ASTNode, "Int32"
     end
   end
 
-  describe "case methods" do
+  describe("case methods") do
     case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32)
 
-    it "executes cond" do
+    it("executes cond") do
       assert_macro "x", %({{x.cond}}), [case_node] of ASTNode, "1"
     end
 
-    it "executes whens" do
+    it("executes whens") do
       assert_macro "x", %({{x.whens}}), [case_node] of ASTNode, "[when 2, 3\n  4\n]"
     end
 
-    it "executes when conds" do
+    it("executes when conds") do
       assert_macro "x", %({{x.whens[0].conds}}), [case_node] of ASTNode, "[2, 3]"
     end
 
-    it "executes when body" do
+    it("executes when body") do
       assert_macro "x", %({{x.whens[0].body}}), [case_node] of ASTNode, "4"
     end
 
-    it "executes else" do
+    it("executes else") do
       assert_macro "x", %({{x.else}}), [case_node] of ASTNode, "5"
     end
   end
 
-  describe "if methods" do
+  describe("if methods") do
     if_node = If.new(1.int32, 2.int32, 3.int32)
 
-    it "executes cond" do
+    it("executes cond") do
       assert_macro "x", %({{x.cond}}), [if_node] of ASTNode, "1"
     end
 
-    it "executes then" do
+    it("executes then") do
       assert_macro "x", %({{x.then}}), [if_node] of ASTNode, "2"
     end
 
-    it "executes else" do
+    it("executes else") do
       assert_macro "x", %({{x.else}}), [if_node] of ASTNode, "3"
     end
 
-    it "executes else (nop)" do
+    it("executes else (nop)") do
       assert_macro "x", %({{x.else}}), [If.new(1.int32, 2.int32)] of ASTNode, ""
     end
   end
 
-  describe "while methods" do
+  describe("while methods") do
     while_node = While.new(1.int32, 2.int32)
 
-    it "executes cond" do
+    it("executes cond") do
       assert_macro "x", %({{x.cond}}), [while_node] of ASTNode, "1"
     end
 
-    it "executes body" do
+    it("executes body") do
       assert_macro "x", %({{x.body}}), [while_node] of ASTNode, "2"
     end
   end
 
-  describe "assign methods" do
-    it "executes target" do
+  describe("assign methods") do
+    it("executes target") do
       assert_macro "x", %({{x.target}}), [Assign.new("foo".var, 2.int32)] of ASTNode, "foo"
     end
 
-    it "executes value" do
+    it("executes value") do
       assert_macro "x", %({{x.value}}), [Assign.new("foo".var, 2.int32)] of ASTNode, "2"
     end
   end
 
-  describe "multiassign methods" do
+  describe("multiassign methods") do
     multiassign_node = MultiAssign.new(["foo".var, "bar".var] of ASTNode, [2.int32, "a".string] of ASTNode)
 
-    it "executes targets" do
+    it("executes targets") do
       assert_macro "x", %({{x.targets}}), [multiassign_node] of ASTNode, %([foo, bar])
     end
 
-    it "executes values" do
+    it("executes values") do
       assert_macro "x", %({{x.values}}), [multiassign_node] of ASTNode, %([2, "a"])
     end
   end
 
-  describe "instancevar methods" do
-    it "executes name" do
+  describe("instancevar methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [InstanceVar.new("ivar")] of ASTNode, %(ivar)
     end
   end
 
-  describe "instancevar methods" do
-    it "executes name" do
+  describe("instancevar methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [InstanceVar.new("ivar")] of ASTNode, %(ivar)
     end
   end
 
-  describe "readinstancevar methods" do
-    it "executes obj" do
+  describe("readinstancevar methods") do
+    it("executes obj") do
       assert_macro "x", %({{x.obj}}), [ReadInstanceVar.new("obj".var, "ivar")] of ASTNode, %(obj)
     end
 
-    it "executes name" do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [ReadInstanceVar.new("obj".var, "ivar")] of ASTNode, %(ivar)
     end
   end
 
-  describe "classvar methods" do
-    it "executes name" do
+  describe("classvar methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [ClassVar.new("cvar")] of ASTNode, %(cvar)
     end
   end
 
-  describe "global methods" do
-    it "executes name" do
+  describe("global methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [Global.new("gvar")] of ASTNode, %(gvar)
     end
   end
 
-  describe "splat methods" do
-    it "executes exp" do
+  describe("splat methods") do
+    it("executes exp") do
       assert_macro "x", %({{x.exp}}), [2.int32.splat] of ASTNode, "2"
     end
   end
 
-  describe "generic methods" do
-    it "executes name" do
+  describe("generic methods") do
+    it("executes name") do
       assert_macro "x", %({{x.name}}), [Generic.new("Foo".path, ["T".path] of ASTNode)] of ASTNode, "Foo"
     end
 
-    it "executes type_vars" do
+    it("executes type_vars") do
       assert_macro "x", %({{x.type_vars}}), [Generic.new("Foo".path, ["T".path, "U".path] of ASTNode)] of ASTNode, "[T, U]"
     end
 
-    it "executes named_args" do
+    it("executes named_args") do
       assert_macro "x", %({{x.named_args}}), [Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("x", "U".path), NamedArgument.new("y", "V".path)])] of ASTNode, "{x: U, y: V}"
     end
   end
 
-  describe "union methods" do
-    it "executes types" do
+  describe("union methods") do
+    it("executes types") do
       assert_macro "x", %({{x.types}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "[Int32, String]"
     end
   end
 
-  describe "range methods" do
-    it "executes begin" do
+  describe("range methods") do
+    it("executes begin") do
       assert_macro "x", %({{x.begin}}), [RangeLiteral.new(1.int32, 2.int32, true)] of ASTNode, "1"
     end
 
-    it "executes end" do
+    it("executes end") do
       assert_macro "x", %({{x.end}}), [RangeLiteral.new(1.int32, 2.int32, true)] of ASTNode, "2"
     end
 
-    it "executes excludes_end?" do
+    it("executes excludes_end?") do
       assert_macro "x", %({{x.excludes_end?}}), [RangeLiteral.new(1.int32, 2.int32, true)] of ASTNode, "true"
     end
 
-    it "executes map" do
+    it("executes map") do
       assert_macro "x", %({{x.map(&.stringify)}}), [RangeLiteral.new(1.int32, 3.int32, false)] of ASTNode, %(["1", "2", "3"])
       assert_macro "x", %({{x.map(&.stringify)}}), [RangeLiteral.new(1.int32, 3.int32, true)] of ASTNode, %(["1", "2"])
     end
 
-    it "executes to_a" do
+    it("executes to_a") do
       assert_macro "x", %({{x.to_a}}), [RangeLiteral.new(1.int32, 3.int32, false)] of ASTNode, %([1, 2, 3])
       assert_macro "x", %({{x.to_a}}), [RangeLiteral.new(1.int32, 3.int32, true)] of ASTNode, %([1, 2])
     end
   end
 
-  describe "path methods" do
-    it "executes resolve" do
+  describe("path methods") do
+    it("executes resolve") do
       assert_macro "x", %({{x.resolve}}), [Path.new("String")] of ASTNode, %(String)
 
       expect_raises(Crystal::TypeException, "undefined constant Foo") do
@@ -1575,36 +1575,36 @@ describe "macro methods" do
       end
     end
 
-    it "executes resolve?" do
+    it("executes resolve?") do
       assert_macro "x", %({{x.resolve?}}), [Path.new("String")] of ASTNode, %(String)
       assert_macro "x", %({{x.resolve?}}), [Path.new("Foo")] of ASTNode, %(nil)
     end
   end
 
-  describe "env" do
-    it "has key" do
+  describe("env") do
+    it("has key") do
       ENV["FOO"] = "foo"
       assert_macro "", %({{env("FOO")}}), [] of ASTNode, %("foo")
       ENV.delete "FOO"
     end
 
-    it "doesn't have key" do
+    it("doesn't have key") do
       ENV.delete "FOO"
       assert_macro "", %({{env("FOO")}}), [] of ASTNode, %(nil)
     end
   end
 
-  describe "flag?" do
-    it "has flag" do
+  describe("flag?") do
+    it("has flag") do
       assert_macro "", %({{flag?(:foo)}}), [] of ASTNode, %(true), flags: "foo"
     end
 
-    it "doesn't have flag" do
+    it("doesn't have flag") do
       assert_macro "", %({{flag?(:foo)}}), [] of ASTNode, %(false)
     end
   end
 
-  it "compares versions" do
+  it("compares versions") do
     assert_macro "", %({{compare_versions("1.10.3", "1.2.3")}}), [] of ASTNode, %(1)
   end
 end

--- a/spec/compiler/normalize/and_spec.cr
+++ b/spec/compiler/normalize/and_spec.cr
@@ -1,31 +1,31 @@
 require "../../spec_helper"
 
-describe "Normalize: and" do
-  it "normalizes and without variable" do
+describe("Normalize: and") do
+  it("normalizes and without variable") do
     assert_expand "a && b", "if __temp_1 = a\n  b\nelse\n  __temp_1\nend"
   end
 
-  it "normalizes and with variable on the left" do
+  it("normalizes and with variable on the left") do
     assert_expand_second "a = 1; a && b", "if a\n  b\nelse\n  a\nend"
   end
 
-  it "normalizes and with is_a? on var" do
+  it("normalizes and with is_a? on var") do
     assert_expand_second "a = 1; a.is_a?(Foo) && b", "if a.is_a?(Foo)\n  b\nelse\n  a.is_a?(Foo)\nend"
   end
 
-  it "normalizes and with ! on var" do
+  it("normalizes and with ! on var") do
     assert_expand_second "a = 1; !a && b", "if !a\n  b\nelse\n  !a\nend"
   end
 
-  it "normalizes and with ! on var.is_a?(...)" do
+  it("normalizes and with ! on var.is_a?(...)") do
     assert_expand_second "a = 1; !a.is_a?(Int32) && b", "if !(a.is_a?(Int32))\n  b\nelse\n  !(a.is_a?(Int32))\nend"
   end
 
-  it "normalizes and with is_a? on exp" do
+  it("normalizes and with is_a? on exp") do
     assert_expand_second "a = 1; 1.is_a?(Foo) && b", "if __temp_1 = 1.is_a?(Foo)\n  b\nelse\n  __temp_1\nend"
   end
 
-  it "normalizes and with assignment" do
+  it("normalizes and with assignment") do
     assert_expand "(a = 1) && b", "if a = 1\n  b\nelse\n  a\nend"
   end
 end

--- a/spec/compiler/normalize/array_literal_spec.cr
+++ b/spec/compiler/normalize/array_literal_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Normalize: array literal" do
-  it "normalizes empty with of" do
+describe("Normalize: array literal") do
+  it("normalizes empty with of") do
     assert_expand "[] of Int", "::Array(Int).new"
   end
 
-  it "normalizes non-empty with of" do
+  it("normalizes non-empty with of") do
     assert_expand "[1, 2] of Int", "::Array(Int).build(2) do |__temp_1|\n  __temp_1[0] = 1\n  __temp_1[1] = 2\n  2\nend"
   end
 
-  it "normalizes non-empty without of" do
+  it("normalizes non-empty without of") do
     assert_expand "[1, 2]", "::Array(typeof(1, 2)).build(2) do |__temp_1|\n  __temp_1[0] = 1\n  __temp_1[1] = 2\n  2\nend"
   end
 end

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -1,103 +1,103 @@
 require "../../spec_helper"
 
-describe "Normalize: case" do
-  it "normalizes case with call" do
+describe("Normalize: case") do
+  it("normalizes case with call") do
     assert_expand "case x; when 1; 'b'; when 2; 'c'; else; 'd'; end", "__temp_1 = x\nif 1 === __temp_1\n  'b'\nelse\n  if 2 === __temp_1\n    'c'\n  else\n    'd'\n  end\nend"
   end
 
-  it "normalizes case with var in cond" do
+  it("normalizes case with var in cond") do
     assert_expand_second "x = 1; case x; when 1; 'b'; end", "if 1 === x\n  'b'\nend"
   end
 
-  it "normalizes case with Path to is_a?" do
+  it("normalizes case with Path to is_a?") do
     assert_expand_second "x = 1; case x; when Foo; 'b'; end", "if x.is_a?(Foo)\n  'b'\nend"
   end
 
-  it "normalizes case with generic to is_a?" do
+  it("normalizes case with generic to is_a?") do
     assert_expand_second "x = 1; case x; when Foo(T); 'b'; end", "if x.is_a?(Foo(T))\n  'b'\nend"
   end
 
-  it "normalizes case with Path.class to is_a?" do
+  it("normalizes case with Path.class to is_a?") do
     assert_expand_second "x = 1; case x; when Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nend"
   end
 
-  it "normalizes case with Generic.class to is_a?" do
+  it("normalizes case with Generic.class to is_a?") do
     assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
   end
 
-  it "normalizes case with many expressions in when" do
+  it("normalizes case with many expressions in when") do
     assert_expand_second "x = 1; case x; when 1, 2; 'b'; end", "if (1 === x) || (2 === x)\n  'b'\nend"
   end
 
-  it "normalizes case with implicit call" do
+  it("normalizes case with implicit call") do
     assert_expand "case x; when .foo(1); 2; end", "__temp_1 = x\nif __temp_1.foo(1)\n  2\nend"
   end
 
-  it "normalizes case with implicit responds_to? (#3040)" do
+  it("normalizes case with implicit responds_to? (#3040)") do
     assert_expand "case x; when .responds_to?(:foo); 2; end", "__temp_1 = x\nif __temp_1.responds_to?(:foo)\n  2\nend"
   end
 
-  it "normalizes case with implicit is_a? (#3040)" do
+  it("normalizes case with implicit is_a? (#3040)") do
     assert_expand "case x; when .is_a?(T); 2; end", "__temp_1 = x\nif __temp_1.is_a?(T)\n  2\nend"
   end
 
-  it "normalizes case with implicit as (#3040)" do
+  it("normalizes case with implicit as (#3040)") do
     assert_expand "case x; when .as(T); 2; end", "__temp_1 = x\nif __temp_1.as(T)\n  2\nend"
   end
 
-  it "normalizes case with implicit as? (#3040)" do
+  it("normalizes case with implicit as? (#3040)") do
     assert_expand "case x; when .as?(T); 2; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
   end
 
-  it "normalizes case with assignment" do
+  it("normalizes case with assignment") do
     assert_expand "case x = 1; when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
   end
 
-  it "normalizes case without value" do
+  it("normalizes case without value") do
     assert_expand "case when 2; 3; when 4; 5; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
-  it "normalizes case without value with many expressions in when" do
+  it("normalizes case without value with many expressions in when") do
     assert_expand "case when 2, 9; 3; when 4; 5; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
-  it "normalizes case with nil to is_a?" do
+  it("normalizes case with nil to is_a?") do
     assert_expand_second "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
   end
 
-  it "normalizes case with multiple expressions" do
+  it("normalizes case with multiple expressions") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; end", "if (2 === x) && (3 === y)\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions and types" do
+  it("normalizes case with multiple expressions and types") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if (x.is_a?(Int32)) && (y.is_a?(Float64))\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions and implicit obj" do
+  it("normalizes case with multiple expressions and implicit obj") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; end", "if x.foo && y.bar\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions and comma" do
+  it("normalizes case with multiple expressions and comma") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
   end
 
-  it "normalizes case with multiple expressions with underscore" do
+  it("normalizes case with multiple expressions with underscore") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; end", "if 2 === x\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions with all underscores" do
+  it("normalizes case with multiple expressions with all underscores") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; end", "if true\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions with all underscores twice" do
+  it("normalizes case with multiple expressions with all underscores twice") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; end", "if true\n  4\nend"
   end
 
-  it "normalizes case with multiple expressions and non-tuple" do
+  it("normalizes case with multiple expressions and non-tuple") do
     assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === ({x, y})\n  4\nend"
   end
 
-  it "normalizes case with single expressions with underscore" do
+  it("normalizes case with single expressions with underscore") do
     assert_expand_second "x = 1; case x; when _; 2; end", "if true\n  2\nend"
   end
 end

--- a/spec/compiler/normalize/chained_comparisons_spec.cr
+++ b/spec/compiler/normalize/chained_comparisons_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Normalize: chained comparisons" do
-  it "normalizes one comparison with literal" do
+describe("Normalize: chained comparisons") do
+  it("normalizes one comparison with literal") do
     assert_normalize "1 <= 2 <= 3", "1 <= 2 && 2 <= 3"
   end
 
-  it "normalizes one comparison with var" do
+  it("normalizes one comparison with var") do
     assert_normalize "b = 1; 1 <= b <= 3", "b = 1\n1 <= b && b <= 3"
   end
 
-  it "normalizes one comparison with call" do
+  it("normalizes one comparison with call") do
     assert_normalize "1 <= b <= 3", "1 <= (__temp_1 = b) && __temp_1 <= 3"
   end
 
-  it "normalizes two comparisons with literal" do
+  it("normalizes two comparisons with literal") do
     assert_normalize "1 <= 2 <= 3 <= 4", "(1 <= 2 && 2 <= 3) && 3 <= 4"
   end
 
-  it "normalizes two comparisons with calls" do
+  it("normalizes two comparisons with calls") do
     assert_normalize "1 <= a <= b <= 4", "(1 <= (__temp_2 = a) && __temp_2 <= (__temp_1 = b)) && __temp_1 <= 4"
   end
 end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -1,35 +1,35 @@
 require "../../spec_helper"
 
-describe "Normalize: def" do
-  it "expands a def on request with default arguments" do
+describe("Normalize: def") do
+  it("expands a def on request with default arguments") do
     a_def = parse("def foo(x, y = 1, z = 2); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x); y = 1; z = 2; foo(x, y, z); end")
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments (2)" do
+  it("expands a def on request with default arguments (2)") do
     a_def = parse("def foo(x, y = 1, z = 2); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
     expected = parse("def foo(x, y); z = 2; foo(x, y, z); end")
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments that yields" do
+  it("expands a def on request with default arguments that yields") do
     a_def = parse("def foo(x, y = 1, z = 2); yield x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x); y = 1; z = 2; yield x + y + z; end")
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments that yields (2)" do
+  it("expands a def on request with default arguments that yields (2)") do
     a_def = parse("def foo(x, y = 1, z = 2); yield x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
     expected = parse("def foo(x, y); z = 2; yield x + y + z; end")
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments and type restrictions" do
+  it("expands a def on request with default arguments and type restrictions") do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x); y = 1; z = 2i64; x + y + z; end").as(Def)
@@ -38,7 +38,7 @@ describe "Normalize: def" do
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments and type restrictions (2)" do
+  it("expands a def on request with default arguments and type restrictions (2)") do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
     expected = parse("def foo(x, y : Int32); z = 2i64; x + y + z; end").as(Def)
@@ -46,167 +46,167 @@ describe "Normalize: def" do
     actual.should eq(expected)
   end
 
-  it "expands with splat" do
+  it("expands with splat") do
     a_def = parse("def foo(*args); args; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 3)
     expected = parse("def foo(__temp_1, __temp_2, __temp_3)\n  args = {__temp_1, __temp_2, __temp_3}\n  args\nend")
     actual.should eq(expected)
   end
 
-  it "expands with splat with one arg before" do
+  it("expands with splat with one arg before") do
     a_def = parse("def foo(x, *args); args; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 3)
     expected = parse("def foo(x, __temp_1, __temp_2)\n  args = {__temp_1, __temp_2}\n  args\nend")
     actual.should eq(expected)
   end
 
-  it "expands with splat and zero" do
+  it("expands with splat and zero") do
     a_def = parse("def foo(*args); args; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0)
     actual.to_s.should eq("def foo\n  args = {}\n  args\nend")
   end
 
-  it "expands with splat and default argument" do
+  it("expands with splat and default argument") do
     a_def = parse("def foo(x = 1, *args); args; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0)
     actual.to_s.should eq("def foo\n  x = 1\n  args = {}\n  args\nend")
   end
 
-  it "expands with named argument" do
+  it("expands with named argument") do
     a_def = parse("def foo(x = 1, y = 2); x + y; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0, ["y"])
     actual.to_s.should eq("def foo:y(y)\n  x = 1\n  foo(x, y)\nend")
   end
 
-  it "expands with two named argument" do
+  it("expands with two named argument") do
     a_def = parse("def foo(x = 1, y = 2); x + y; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0, ["y", "x"])
     actual.to_s.should eq("def foo:y:x(y, x)\n  foo(x, y)\nend")
   end
 
-  it "expands with two named argument and one not" do
+  it("expands with two named argument and one not") do
     a_def = parse("def foo(x, y = 2, z = 3); x + y; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1, ["z"])
     actual.to_s.should eq("def foo:z(x, z)\n  y = 2\n  foo(x, y, z)\nend")
   end
 
-  it "expands with named argument and yield" do
+  it("expands with named argument and yield") do
     a_def = parse("def foo(x = 1, y = 2); yield x + y; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0, ["y"])
     actual.to_s.should eq("def foo:y(y)\n  x = 1\n  yield x + y\nend")
   end
 
   # Small optimizations: no need to create a separate def in these cases
-  it "expands with one named arg that is the only one (1)" do
+  it("expands with one named arg that is the only one (1)") do
     a_def = parse("def foo(x = 1); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0, ["x"])
     other_def.should be(a_def)
   end
 
-  it "expands with one named arg that is the only one (2)" do
+  it("expands with one named arg that is the only one (2)") do
     a_def = parse("def foo(x, y = 1); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1, ["y"])
     other_def.should be(a_def)
   end
 
-  it "expands with more named arg which come in the correct order" do
+  it("expands with more named arg which come in the correct order") do
     a_def = parse("def foo(x, y = 1, z = 2); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1, ["y", "z"])
     other_def.should be(a_def)
   end
 
-  it "expands with magic constant" do
+  it("expands with magic constant") do
     a_def = parse("def foo(x, y = __LINE__); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1)
     other_def.should be(a_def)
   end
 
-  it "expands with magic constant specifying one when all are magic" do
+  it("expands with magic constant specifying one when all are magic") do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 2)
     other_def.should be(a_def)
   end
 
-  it "expands with magic constant specifying one when not all are magic" do
+  it("expands with magic constant specifying one when not all are magic") do
     a_def = parse("def foo(x, z = 1, line = __LINE__); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 2)
     other_def.should be(a_def)
   end
 
-  it "expands with magic constant with named arg" do
+  it("expands with magic constant with named arg") do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1, ["line"])
     other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  foo(x, file, line)\nend")
   end
 
-  it "expands with magic constant with named arg with yield" do
+  it("expands with magic constant with named arg with yield") do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); yield x, file, line; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1, ["line"])
     other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  yield x, file, line\nend")
   end
 
-  it "expands a def with double splat and no args" do
+  it("expands a def with double splat and no args") do
     a_def = parse("def foo(**options); options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0)
     other_def.to_s.should eq("def foo\n  options = {}\n  options\nend")
   end
 
-  it "expands a def with double splat and two named args" do
+  it("expands a def with double splat and two named args") do
     a_def = parse("def foo(**options); options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0, ["x", "y"])
     other_def.to_s.should eq("def foo:x:y(x, y)\n  options = {x: x, y: y}\n  options\nend")
   end
 
-  it "expands a def with double splat and two named args and regular args" do
+  it("expands a def with double splat and two named args and regular args") do
     a_def = parse("def foo(y, **options); y + options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0, ["x", "y", "z"])
     other_def.to_s.should eq("def foo:x:y:z(x, y, z)\n  options = {x: x, z: z}\n  y + options\nend")
   end
 
-  it "expands a def with splat and double splat" do
+  it("expands a def with splat and double splat") do
     a_def = parse("def foo(*args, **options); args + options; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 2, ["x", "y"])
     other_def.to_s.should eq("def foo:x:y(__temp_1, __temp_2, x, y)\n  args = {__temp_1, __temp_2}\n  options = {x: x, y: y}\n  args + options\nend")
   end
 
-  it "expands arg with default value after splat" do
+  it("expands arg with default value after splat") do
     a_def = parse("def foo(*args, x = 10); args + x; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0)
     other_def.to_s.should eq("def foo\n  x = 10\n  args = {}\n  args + x\nend")
   end
 
-  it "expands default value after splat index" do
+  it("expands default value after splat index") do
     a_def = parse("def foo(x, *y, z = 10); x + y + z; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 3)
     other_def.to_s.should eq("def foo(x, __temp_1, __temp_2)\n  z = 10\n  y = {__temp_1, __temp_2}\n  (x + y) + z\nend")
   end
 
-  it "uses bare *" do
+  it("uses bare *") do
     a_def = parse("def foo(x, *, y); x + y; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 1, ["y"])
     other_def.to_s.should eq("def foo:y(x, y)\n  x + y\nend")
   end
 
-  it "expands a def with external names (1)" do
+  it("expands a def with external names (1)") do
     a_def = parse("def foo(x y); y; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 0, ["x"])
     actual.should be(a_def)
   end
 
-  it "expands a def with external names (2)" do
+  it("expands a def with external names (2)") do
     a_def = parse("def foo(x x1, y y1); x1 + y1; end").as(Def)
     other_def = a_def.expand_default_arguments(Program.new, 0, ["y", "x"])
     other_def.to_s.should eq("def foo:y:x(y y1, x x1)\n  foo(x1, y1)\nend")
   end
 
-  it "expands a def on request with default arguments (external names)" do
+  it("expands a def on request with default arguments (external names)") do
     a_def = parse("def foo(x x1, y y1 = 1, z z1 = 2); x1 + y1 + z1; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x x1); y1 = 1; z1 = 2; foo(x1, y1, z1); end")
     actual.should eq(expected)
   end
 
-  it "expands a def on request with default arguments that yields (external names)" do
+  it("expands a def on request with default arguments that yields (external names)") do
     a_def = parse("def foo(x x1, y y1 = 1, z z1 = 2); yield x1 + y1 + z1; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x x1); y1 = 1; z1 = 2; yield x1 + y1 + z1; end")

--- a/spec/compiler/normalize/hash_literal_spec.cr
+++ b/spec/compiler/normalize/hash_literal_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Normalize: hash literal" do
-  it "normalizes empty with of" do
+describe("Normalize: hash literal") do
+  it("normalizes empty with of") do
     assert_expand "{} of Int => Float", "::Hash(Int, Float).new"
   end
 
-  it "normalizes non-empty with of" do
+  it("normalizes non-empty with of") do
     assert_expand "{1 => 2, 3 => 4} of Int => Float", "__temp_1 = ::Hash(Int, Float).new\n__temp_1[1] = 2\n__temp_1[3] = 4\n__temp_1"
   end
 
-  it "normalizes non-empty without of" do
+  it("normalizes non-empty without of") do
     assert_expand "{1 => 2, 3 => 4}", "__temp_1 = ::Hash(typeof(1, 3), typeof(2, 4)).new\n__temp_1[1] = 2\n__temp_1[3] = 4\n__temp_1"
   end
 end

--- a/spec/compiler/normalize/multi_assign_spec.cr
+++ b/spec/compiler/normalize/multi_assign_spec.cr
@@ -1,27 +1,27 @@
 require "../../spec_helper"
 
-describe "Normalize: multi assign" do
-  it "normalizes n to n" do
+describe("Normalize: multi assign") do
+  it("normalizes n to n") do
     assert_expand "a, b, c = 1, 2, 3", "__temp_1 = 1\n__temp_2 = 2\n__temp_3 = 3\na = __temp_1\nb = __temp_2\nc = __temp_3"
   end
 
-  it "normalizes 1 to n" do
+  it("normalizes 1 to n") do
     assert_expand_second "d = 1\na, b, c = d", "__temp_1 = d\na = __temp_1[0]\nb = __temp_1[1]\nc = __temp_1[2]"
   end
 
-  it "normalizes n to n with []" do
+  it("normalizes n to n with []") do
     assert_expand_third "a = 1; b = 2; a[0], b[1] = 2, 3", "__temp_1 = 2\n__temp_2 = 3\na[0] = __temp_1\nb[1] = __temp_2"
   end
 
-  it "normalizes 1 to n with []" do
+  it("normalizes 1 to n with []") do
     assert_expand_third "a = 1; b = 2; a[0], b[1] = 2", "__temp_1 = 2\na[0] = __temp_1[0]\nb[1] = __temp_1[1]"
   end
 
-  it "normalizes n to n with call" do
+  it("normalizes n to n with call") do
     assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2, 3", "__temp_1 = 2\n__temp_2 = 3\na.foo = __temp_1\nb.bar = __temp_2"
   end
 
-  it "normalizes 1 to n with call" do
+  it("normalizes 1 to n with call") do
     assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2", "__temp_1 = 2\na.foo = __temp_1[0]\nb.bar = __temp_1[1]"
   end
 end

--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -1,67 +1,67 @@
 require "../../spec_helper"
 
-describe "Normalize: op assign" do
-  it "normalizes var +=" do
+describe("Normalize: op assign") do
+  it("normalizes var +=") do
     assert_normalize "a = 1; a += 2", "a = 1\na = a + 2"
   end
 
-  it "normalizes var ||=" do
+  it("normalizes var ||=") do
     assert_normalize "a = 1; a ||= 2", "a = 1\na || (a = 2)"
   end
 
-  it "normalizes var &&=" do
+  it("normalizes var &&=") do
     assert_normalize "a = 1; a &&= 2", "a = 1\na && (a = 2)"
   end
 
-  it "normalizes exp.value +=" do
+  it("normalizes exp.value +=") do
     assert_normalize "a.b += 1", "__temp_1 = a\n__temp_1.b = __temp_1.b + 1"
   end
 
-  it "normalizes exp.value ||=" do
+  it("normalizes exp.value ||=") do
     assert_normalize "a.b ||= 1", "__temp_1 = a\n__temp_1.b || (__temp_1.b = 1)"
   end
 
-  it "normalizes exp.value &&=" do
+  it("normalizes exp.value &&=") do
     assert_normalize "a.b &&= 1", "__temp_1 = a\n__temp_1.b && (__temp_1.b = 1)"
   end
 
-  it "normalizes var.value +=" do
+  it("normalizes var.value +=") do
     assert_normalize "a = 1; a.b += 2", "a = 1\na.b = a.b + 2"
   end
 
-  it "normalizes @var.value +=" do
+  it("normalizes @var.value +=") do
     assert_normalize "@a.b += 2", "@a.b = @a.b + 2"
   end
 
-  it "normalizes @@var.value +=" do
+  it("normalizes @@var.value +=") do
     assert_normalize "@@a.b += 2", "@@a.b = @@a.b + 2"
   end
 
-  it "normalizes exp[value] +=" do
+  it("normalizes exp[value] +=") do
     assert_normalize "a[b, c] += 1", "__temp_1 = b\n__temp_2 = c\n__temp_3 = a\n__temp_3[__temp_1, __temp_2] = __temp_3[__temp_1, __temp_2] + 1"
   end
 
-  it "normalizes exp[value] ||=" do
+  it("normalizes exp[value] ||=") do
     assert_normalize "a[b, c] ||= 1", "__temp_1 = b\n__temp_2 = c\n__temp_3 = a\n__temp_3[__temp_1, __temp_2]? || (__temp_3[__temp_1, __temp_2] = 1)"
   end
 
-  it "normalizes exp[value] &&=" do
+  it("normalizes exp[value] &&=") do
     assert_normalize "a[b, c] &&= 1", "__temp_1 = b\n__temp_2 = c\n__temp_3 = a\n__temp_3[__temp_1, __temp_2]? && (__temp_3[__temp_1, __temp_2] = 1)"
   end
 
-  it "normalizes exp[0] +=" do
+  it("normalizes exp[0] +=") do
     assert_normalize "a[0] += 1", "__temp_2 = a\n__temp_2[0] = __temp_2[0] + 1"
   end
 
-  it "normalizes var[0] +=" do
+  it("normalizes var[0] +=") do
     assert_normalize "a = 1; a[0] += 1", "a = 1\na[0] = a[0] + 1"
   end
 
-  it "normalizes @var[0] +=" do
+  it("normalizes @var[0] +=") do
     assert_normalize "@a[0] += 1", "@a[0] = @a[0] + 1"
   end
 
-  it "normalizes @@var[0] +=" do
+  it("normalizes @@var[0] +=") do
     assert_normalize "@@a[0] += 1", "@@a[0] = @@a[0] + 1"
   end
 end

--- a/spec/compiler/normalize/or_spec.cr
+++ b/spec/compiler/normalize/or_spec.cr
@@ -1,27 +1,27 @@
 require "../../spec_helper"
 
-describe "Normalize: or" do
-  it "normalizes or without variable" do
+describe("Normalize: or") do
+  it("normalizes or without variable") do
     assert_expand "a || b", "if __temp_1 = a\n  __temp_1\nelse\n  b\nend"
   end
 
-  it "normalizes or with variable on the left" do
+  it("normalizes or with variable on the left") do
     assert_expand_second "a = 1; a || b", "if a\n  a\nelse\n  b\nend"
   end
 
-  it "normalizes or with assignment on the left" do
+  it("normalizes or with assignment on the left") do
     assert_expand "(a = 1) || b", "if a = 1\n  a\nelse\n  b\nend"
   end
 
-  it "normalizes or with is_a? on var" do
+  it("normalizes or with is_a? on var") do
     assert_expand_second "a = 1; a.is_a?(Foo) || b", "if a.is_a?(Foo)\n  a.is_a?(Foo)\nelse\n  b\nend"
   end
 
-  it "normalizes or with ! on var" do
+  it("normalizes or with ! on var") do
     assert_expand_second "a = 1; !a || b", "if !a\n  !a\nelse\n  b\nend"
   end
 
-  it "normalizes or with ! on var.is_a?(...)" do
+  it("normalizes or with ! on var.is_a?(...)") do
     assert_expand_second "a = 1; !a.is_a?(Int32) || b", "if !(a.is_a?(Int32))\n  !(a.is_a?(Int32))\nelse\n  b\nend"
   end
 end

--- a/spec/compiler/normalize/range_literal_spec.cr
+++ b/spec/compiler/normalize/range_literal_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Normalize: range literal" do
-  it "normalizes not exclusive" do
+describe("Normalize: range literal") do
+  it("normalizes not exclusive") do
     assert_expand "1..2", "::Range.new(1, 2, false)"
   end
 
-  it "normalizes exclusive" do
+  it("normalizes exclusive") do
     assert_expand "1...2", "::Range.new(1, 2, true)"
   end
 end

--- a/spec/compiler/normalize/return_next_break_spec.cr
+++ b/spec/compiler/normalize/return_next_break_spec.cr
@@ -1,21 +1,21 @@
 require "../../spec_helper"
 
-describe "Normalize: return next break" do
+describe("Normalize: return next break") do
   ["return", "next", "break"].each do |keyword|
-    it "removes nodes after #{keyword}" do
+    it("removes nodes after #{keyword}") do
       assert_normalize "#{keyword} 1; 2", "#{keyword} 1"
     end
   end
 
-  it "doesn't remove after return when there's an unless" do
+  it("doesn't remove after return when there's an unless") do
     assert_normalize "return 1 unless 2; 3", "if 2\nelse\n  return 1\nend\n3"
   end
 
-  it "removes nodes after if that returns in both branches" do
+  it("removes nodes after if that returns in both branches") do
     assert_normalize "if true; break; else; return; end; 1", "if true\n  break\nelse\n  return\nend"
   end
 
-  it "doesn't remove nodes after if that returns in one branch" do
+  it("doesn't remove nodes after if that returns in one branch") do
     assert_normalize "if true; 1; else; return; end; 1", "if true\n  1\nelse\n  return\nend\n1"
   end
 end

--- a/spec/compiler/normalize/select_spec.cr
+++ b/spec/compiler/normalize/select_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Normalize: case" do
-  it "normalizes select with call" do
+describe("Normalize: case") do
+  it("normalizes select with call") do
     assert_expand "select; when foo; body; when bar; baz; end", <<-CODE
       __temp_1, __temp_2 = ::Channel.select({foo_select_action, bar_select_action})
       case __temp_1
@@ -15,7 +15,7 @@ describe "Normalize: case" do
       CODE
   end
 
-  it "normalizes select with assign" do
+  it("normalizes select with assign") do
     assert_expand "select; when x = foo; x + 1; end", <<-CODE
       __temp_1, __temp_2 = ::Channel.select({foo_select_action})
       case __temp_1
@@ -28,7 +28,7 @@ describe "Normalize: case" do
       CODE
   end
 
-  it "normalizes select with else" do
+  it("normalizes select with else") do
     assert_expand "select; when foo; body; else; baz; end", <<-CODE
       __temp_1, __temp_2 = ::Channel.select({foo_select_action}, true)
       case __temp_1
@@ -40,7 +40,7 @@ describe "Normalize: case" do
       CODE
   end
 
-  it "normalizes select with assign and question method" do
+  it("normalizes select with assign and question method") do
     assert_expand "select; when x = foo?; x + 1; end", <<-CODE
       __temp_1, __temp_2 = ::Channel.select({foo_select_action?})
       case __temp_1
@@ -53,7 +53,7 @@ describe "Normalize: case" do
       CODE
   end
 
-  it "normalizes select with assign and bang method" do
+  it("normalizes select with assign and bang method") do
     assert_expand "select; when x = foo!; x + 1; end", <<-CODE
       __temp_1, __temp_2 = ::Channel.select({foo_select_action!})
       case __temp_1

--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Normalize: string interpolation" do
-  it "normalizes string interpolation" do
+describe("Normalize: string interpolation") do
+  it("normalizes string interpolation") do
     assert_expand "\"foo\#{bar}baz\"", "(((::String::Builder.new << \"foo\") << bar) << \"baz\").to_s"
   end
 
-  it "normalizes string interpolation with long string" do
+  it("normalizes string interpolation with long string") do
     s = "*" * 200
     assert_expand "\"foo\#{bar}#{s}\"",
       "((((::String::Builder.new(218)) << \"foo\") << bar) << \"#{s}\").to_s"

--- a/spec/compiler/normalize/unless_spec.cr
+++ b/spec/compiler/normalize/unless_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Normalize: unless" do
-  it "normalizes unless" do
+describe("Normalize: unless") do
+  it("normalizes unless") do
     assert_normalize "unless 1; 2; end", "if 1\nelse\n  2\nend"
   end
 end

--- a/spec/compiler/normalize/until_spec.cr
+++ b/spec/compiler/normalize/until_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Normalize: until" do
-  it "normalizes until" do
+describe("Normalize: until") do
+  it("normalizes until") do
     assert_normalize "until 1; 2; end", "while !1\n  2\nend"
   end
 end

--- a/spec/compiler/parser/parser_doc_spec.cr
+++ b/spec/compiler/parser/parser_doc_spec.cr
@@ -1,6 +1,6 @@
 require "../../support/syntax"
 
-describe "Parser doc" do
+describe("Parser doc") do
   [
     {"class", "class Foo\nend"},
     {"abstract class", "abstract class Foo\nend"},
@@ -18,7 +18,7 @@ describe "Parser doc" do
     {"attribute", "@[Some]"},
     {"private def", "private def foo\nend"},
   ].each do |(desc, code)|
-    it "includes doc for #{desc}" do
+    it("includes doc for #{desc}") do
       parser = Parser.new(%(
         # This is Foo.
         # Use it well.
@@ -30,7 +30,7 @@ describe "Parser doc" do
     end
   end
 
-  it "disables doc parsing inside defs" do
+  it("disables doc parsing inside defs") do
     parser = Parser.new(%(
       # doc 1
       def foo

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -5,7 +5,7 @@ private def regex(string, options = Regex::Options::None)
 end
 
 private def it_parses(string, expected_node, file = __FILE__, line = __LINE__)
-  it "parses #{string}", file, line do
+  it("parses #{string}", file, line) do
     parser = Parser.new(string)
     parser.filename = "/foo/bar/baz.cr"
     node = parser.parse
@@ -14,7 +14,7 @@ private def it_parses(string, expected_node, file = __FILE__, line = __LINE__)
 end
 
 private def assert_end_location(source, line_number = 1, column_number = source.size, file = __FILE__, line = __LINE__)
-  it "gets corrects end location for #{source.inspect}", file, line do
+  it("gets corrects end location for #{source.inspect}", file, line) do
     parser = Parser.new("#{source}; 1")
     node = parser.parse.as(Expressions).expressions[0]
     end_loc = node.end_location.not_nil!
@@ -23,7 +23,7 @@ private def assert_end_location(source, line_number = 1, column_number = source.
   end
 end
 
-describe "Parser" do
+describe("Parser") do
   it_parses "nil", NilLiteral.new
 
   it_parses "true", true.bool
@@ -1518,7 +1518,7 @@ describe "Parser" do
 
   assert_syntax_error %(def foo("bar");end), "expected argument internal name"
 
-  describe "end locations" do
+  describe("end locations") do
     assert_end_location "nil"
     assert_end_location "false"
     assert_end_location "123"
@@ -1578,14 +1578,14 @@ describe "Parser" do
     assert_syntax_error %({"a" : 1}), "space not allowed between named argument name and ':'"
     assert_syntax_error %({"a": 1, "b" : 2}), "space not allowed between named argument name and ':'"
 
-    it "gets corrects of ~" do
+    it("gets corrects of ~") do
       node = Parser.parse("\n  ~1")
       loc = node.location.not_nil!
       loc.line_number.should eq(2)
       loc.column_number.should eq(3)
     end
 
-    it "gets corrects end location for var" do
+    it("gets corrects end location for var") do
       parser = Parser.new("foo = 1\nfoo; 1")
       node = parser.parse.as(Expressions).expressions[1]
       end_loc = node.end_location.not_nil!
@@ -1593,7 +1593,7 @@ describe "Parser" do
       end_loc.column_number.should eq(3)
     end
 
-    it "gets corrects end location for block with { ... }" do
+    it("gets corrects end location for block with { ... }") do
       parser = Parser.new("foo { 1 + 2 }; 1")
       node = parser.parse.as(Expressions).expressions[0].as(Call)
       block = node.block.not_nil!
@@ -1603,7 +1603,7 @@ describe "Parser" do
       node.end_location.should eq(end_loc)
     end
 
-    it "gets corrects end location for block with do ... end" do
+    it("gets corrects end location for block with do ... end") do
       parser = Parser.new("foo do\n  1 + 2\nend; 1")
       node = parser.parse.as(Expressions).expressions[0].as(Call)
       block = node.block.not_nil!
@@ -1613,7 +1613,7 @@ describe "Parser" do
       node.end_location.should eq(end_loc)
     end
 
-    it "gets correct location after macro with yield" do
+    it("gets correct location after macro with yield") do
       parser = Parser.new(%(
         macro foo
           yield
@@ -1626,14 +1626,14 @@ describe "Parser" do
       loc.line_number.should eq(6)
     end
 
-    it "gets correct location with \r\n (#1558)" do
+    it("gets correct location with \r\n (#1558)") do
       nodes = Parser.parse("class Foo\r\nend\r\n\r\n1").as(Expressions)
       loc = nodes.last.location.not_nil!
       loc.line_number.should eq(4)
       loc.column_number.should eq(1)
     end
 
-    it "sets location of enum method" do
+    it("sets location of enum method") do
       parser = Parser.new("enum Foo; A; def bar; end; end")
       node = parser.parse.as(EnumDef).members[1].as(Def)
       loc = node.location.not_nil!
@@ -1641,7 +1641,7 @@ describe "Parser" do
       loc.column_number.should eq(14)
     end
 
-    it "gets correct location after macro with yield" do
+    it("gets correct location after macro with yield") do
       parser = Parser.new(%(\n  1 ? 2 : 3))
       node = parser.parse
       loc = node.location.not_nil!

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
 private def expect_to_s(original, expected = original, emit_doc = false, file = __FILE__, line = __LINE__)
-  it "does to_s of #{original.inspect}", file, line do
+  it("does to_s of #{original.inspect}", file, line) do
     str = IO::Memory.new expected.bytesize
     parser = Parser.new original
     parser.wants_doc = emit_doc
@@ -10,7 +10,7 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
   end
 end
 
-describe "ASTNode#to_s" do
+describe("ASTNode#to_s") do
   expect_to_s "([] of T).foo"
   expect_to_s "({} of K => V).foo"
   expect_to_s "foo(bar)"

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: abstract def" do
-  it "errors if using abstract def on subclass" do
+describe("Semantic: abstract def") do
+  it("errors if using abstract def on subclass") do
     assert_error %(
       abstract class Foo
         abstract def foo
@@ -20,8 +20,8 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo()` must be implemented by Baz"
   end
 
-  it "works on abstract method on abstract class" do
-    assert_type %(
+  it("works on abstract method on abstract class") do
+    assert_type(%(
       abstract class Foo
         abstract def foo
       end
@@ -40,10 +40,10 @@ describe "Semantic: abstract def" do
 
       b = Bar.new || Baz.new
       b.foo
-      ) { int32 }
+      )) { int32 }
   end
 
-  it "works on abstract def on sub-subclass" do
+  it("works on abstract def on sub-subclass") do
     assert_type(%(
       abstract class Foo
         abstract def foo
@@ -65,7 +65,7 @@ describe "Semantic: abstract def" do
       )) { int32 }
   end
 
-  it "errors if using abstract def on subclass that also defines it as abstract" do
+  it("errors if using abstract def on subclass that also defines it as abstract") do
     assert_error %(
       abstract class Foo
         abstract def foo
@@ -80,7 +80,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo()` must be implemented by Baz"
   end
 
-  it "gives correct error when no overload matches, when an abstract method is implemented (#1406)" do
+  it("gives correct error when no overload matches, when an abstract method is implemented (#1406)") do
     assert_error %(
       abstract class Foo
         abstract def foo(x : Int32)
@@ -97,7 +97,7 @@ describe "Semantic: abstract def" do
       "no overload matches"
   end
 
-  it "errors if using abstract def on non-abstract class" do
+  it("errors if using abstract def on non-abstract class") do
     assert_error %(
       class Foo
         abstract def foo
@@ -106,7 +106,7 @@ describe "Semantic: abstract def" do
       "can't define abstract def on non-abstract class"
   end
 
-  it "errors if using abstract def on metaclass" do
+  it("errors if using abstract def on metaclass") do
     assert_error %(
       class Foo
         abstract def self.foo
@@ -115,7 +115,7 @@ describe "Semantic: abstract def" do
       "can't define abstract def on metaclass"
   end
 
-  it "errors if abstract method is not implemented by subclass" do
+  it("errors if abstract method is not implemented by subclass") do
     assert_error %(
       abstract class Foo
         abstract def foo
@@ -127,7 +127,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo()` must be implemented by Bar"
   end
 
-  it "errors if abstract method with arguments is not implemented by subclass" do
+  it("errors if abstract method with arguments is not implemented by subclass") do
     assert_error %(
       abstract class Foo
         abstract def foo(x, y)
@@ -139,7 +139,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo(x, y)` must be implemented by Bar"
   end
 
-  it "errors if abstract method with arguments is not implemented by subclass (wrong number of arguments)" do
+  it("errors if abstract method with arguments is not implemented by subclass (wrong number of arguments)") do
     assert_error %(
       abstract class Foo
         abstract def foo(x)
@@ -153,7 +153,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo(x)` must be implemented by Bar"
   end
 
-  it "errors if abstract method with arguments is not implemented by subclass (wrong type)" do
+  it("errors if abstract method with arguments is not implemented by subclass (wrong type)") do
     assert_error %(
       abstract class Foo
         abstract def foo(x, y : Int32)
@@ -167,7 +167,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo(x, y : Int32)` must be implemented by Bar"
   end
 
-  it "errors if abstract method with arguments is not implemented by subclass (block difference)" do
+  it("errors if abstract method with arguments is not implemented by subclass (block difference)") do
     assert_error %(
       abstract class Foo
         abstract def foo
@@ -182,7 +182,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo()` must be implemented by Bar"
   end
 
-  it "doesn't error if abstract method is implemented by subclass" do
+  it("doesn't error if abstract method is implemented by subclass") do
     semantic %(
       abstract class Foo
         abstract def foo
@@ -195,7 +195,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if abstract method with args is implemented by subclass" do
+  it("doesn't error if abstract method with args is implemented by subclass") do
     semantic %(
       abstract class Foo
         abstract def foo(x, y)
@@ -208,7 +208,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if abstract method with args is implemented by subclass (restriction -> no restriction)" do
+  it("doesn't error if abstract method with args is implemented by subclass (restriction -> no restriction)") do
     semantic %(
       abstract class Foo
         abstract def foo(x, y : Int32)
@@ -221,7 +221,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if abstract method with args is implemented by subclass (don't check subclasses)" do
+  it("doesn't error if abstract method with args is implemented by subclass (don't check subclasses)") do
     semantic %(
       abstract class Foo
         abstract def foo
@@ -237,7 +237,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "errors if abstract method is not implemented by subclass of subclass" do
+  it("errors if abstract method is not implemented by subclass of subclass") do
     assert_error %(
       abstract class Foo
         abstract def foo
@@ -252,7 +252,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo()` must be implemented by Baz"
   end
 
-  it "doesn't error if abstract method is implemented by subclass via module inclusion" do
+  it("doesn't error if abstract method is implemented by subclass via module inclusion") do
     semantic %(
       abstract class Foo
         abstract def foo
@@ -269,7 +269,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "errors if abstract method is not implemented by including class" do
+  it("errors if abstract method is not implemented by including class") do
     assert_error %(
       module Foo
         abstract def foo
@@ -282,7 +282,7 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo()` must be implemented by Bar"
   end
 
-  it "doesn't error if abstract method is implemented by including class" do
+  it("doesn't error if abstract method is implemented by including class") do
     semantic %(
       module Foo
         abstract def foo
@@ -297,7 +297,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if abstract method is not implemented by including module" do
+  it("doesn't error if abstract method is not implemented by including module") do
     semantic %(
       module Foo
         abstract def foo
@@ -309,7 +309,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "errors if abstract method is not implemented by subclass (nested in module)" do
+  it("errors if abstract method is not implemented by subclass (nested in module)") do
     assert_error %(
       module Moo
         abstract class Foo
@@ -323,7 +323,7 @@ describe "Semantic: abstract def" do
       "abstract `def Moo::Foo#foo()` must be implemented by Bar"
   end
 
-  it "doesn't error if abstract method with args is implemented by subclass (with one default arg)" do
+  it("doesn't error if abstract method with args is implemented by subclass (with one default arg)") do
     semantic %(
       abstract class Foo
         abstract def foo(x)
@@ -336,7 +336,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if implements with parent class" do
+  it("doesn't error if implements with parent class") do
     semantic %(
       class Parent; end
       class Child < Parent; end
@@ -352,7 +352,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "doesn't error if implements with parent module" do
+  it("doesn't error if implements with parent module") do
     semantic %(
       module Moo
       end
@@ -376,7 +376,7 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "finds implements in included module in disorder (#4052)" do
+  it("finds implements in included module in disorder (#4052)") do
     semantic %(
       module B
         abstract def x

--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -1,14 +1,14 @@
 require "../../spec_helper"
 
-describe "Semantic: alias" do
-  it "resolves alias type" do
+describe("Semantic: alias") do
+  it("resolves alias type") do
     assert_type("
       alias Alias = Int32
       Alias
       ") { types["Int32"].metaclass }
   end
 
-  it "works with alias type as restriction" do
+  it("works with alias type as restriction") do
     assert_type("
       alias Alias = Int32
 
@@ -20,7 +20,7 @@ describe "Semantic: alias" do
       ") { int32 }
   end
 
-  it "allows using alias type as generic type" do
+  it("allows using alias type as generic type") do
     assert_type("
       class Foo(T)
         def initialize(x : T)
@@ -40,7 +40,7 @@ describe "Semantic: alias" do
       ") { int32 }
   end
 
-  it "allows defining recursive aliases" do
+  it("allows defining recursive aliases") do
     result = assert_type("
       class Foo(T)
       end
@@ -61,7 +61,7 @@ describe "Semantic: alias" do
     union_types[1].should eq(mod.int32)
   end
 
-  it "allows defining recursive fun aliases" do
+  it("allows defining recursive fun aliases") do
     result = assert_type(%(
       alias Alias = Alias -> Alias
       1
@@ -75,7 +75,7 @@ describe "Semantic: alias" do
     aliased_type.should eq(mod.proc_of(a, a))
   end
 
-  it "allows recursive array with alias" do
+  it("allows recursive array with alias") do
     assert_type(%(
       alias Type = Nil | Pointer(Type)
       p = Pointer(Type).malloc(1_u64)
@@ -83,7 +83,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "errors if alias already defined" do
+  it("errors if alias already defined") do
     assert_error %(
       alias Alias = String
       alias Alias = Int32
@@ -91,14 +91,14 @@ describe "Semantic: alias" do
       "alias Alias is already defined"
   end
 
-  it "errors if alias is already defined as another type" do
+  it("errors if alias is already defined as another type") do
     assert_error %(
       alias String = Int32
       ),
       "can't alias String because it's already defined as a class"
   end
 
-  it "errors if defining infinite recursive alias" do
+  it("errors if defining infinite recursive alias") do
     assert_error %(
       alias Alias = Alias
       Alias
@@ -106,7 +106,7 @@ describe "Semantic: alias" do
       "infinite recursive definition of alias Alias"
   end
 
-  it "errors if defining infinite recursive alias in union" do
+  it("errors if defining infinite recursive alias in union") do
     assert_error %(
       alias Alias = Int32 | Alias
       Alias
@@ -114,7 +114,7 @@ describe "Semantic: alias" do
       "infinite recursive definition of alias Alias"
   end
 
-  it "allows using generic type of recursive alias as restriction (#488)" do
+  it("allows using generic type of recursive alias as restriction (#488)") do
     assert_type(%(
       class Foo(T)
       end
@@ -130,7 +130,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "resolves type through alias (#563)" do
+  it("resolves type through alias (#563)") do
     assert_type(%(
       module Moo
         Foo = 1
@@ -141,7 +141,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "errors if trying to resolve type of recursive alias" do
+  it("errors if trying to resolve type of recursive alias") do
     assert_error %(
       class Foo(T)
         A = 1
@@ -155,7 +155,7 @@ describe "Semantic: alias" do
   end
 
   %w(class module struct).each do |type|
-    it "reopens #{type} through alias" do
+    it("reopens #{type} through alias") do
       assert_type(%(
         #{type} Foo
         end
@@ -174,7 +174,7 @@ describe "Semantic: alias" do
   end
 
   %w(class struct).each do |type|
-    it "inherits #{type} through alias" do
+    it("inherits #{type} through alias") do
       assert_type(%(
         abstract #{type} Parent
         end
@@ -192,7 +192,7 @@ describe "Semantic: alias" do
     end
   end
 
-  it "includes module through alias" do
+  it("includes module through alias") do
     assert_type(%(
       module Moo
         def bar
@@ -210,7 +210,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "errors if declares alias inside if" do
+  it("errors if declares alias inside if") do
     assert_error %(
       if 1 == 2
         alias Foo = Int32
@@ -219,21 +219,21 @@ describe "Semantic: alias" do
       "can't declare alias dynamically"
   end
 
-  it "errors if trying to use typeof in alias" do
+  it("errors if trying to use typeof in alias") do
     assert_error %(
       alias Foo = typeof(1)
       ),
       "can't use 'typeof' here"
   end
 
-  it "can use .class in alias (#2835)" do
+  it("can use .class in alias (#2835)") do
     assert_type(%(
       alias Foo = Int32.class | String.class
       Foo
       )) { union_of(int32.metaclass, string.metaclass).metaclass }
   end
 
-  it "uses constant in alias (#3259)" do
+  it("uses constant in alias (#3259)") do
     assert_type(%(
       CONST = 10
       alias Alias = UInt8[CONST]
@@ -241,7 +241,7 @@ describe "Semantic: alias" do
       )) { static_array_of(uint8, 10).metaclass }
   end
 
-  it "uses constant in alias with math (#3259)" do
+  it("uses constant in alias with math (#3259)") do
     assert_type(%(
       CONST = 2*3 + 4
       alias Alias = UInt8[CONST]
@@ -249,7 +249,7 @@ describe "Semantic: alias" do
       )) { static_array_of(uint8, 10).metaclass }
   end
 
-  it "looks up alias for macro resolution (#3548)" do
+  it("looks up alias for macro resolution (#3548)") do
     assert_type(%(
       class Foo
         class Bar
@@ -265,7 +265,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "finds type through alias (#4645)" do
+  it("finds type through alias (#4645)") do
     assert_type(%(
       module FooBar
         module Foo
@@ -289,7 +289,7 @@ describe "Semantic: alias" do
       )) { int32 }
   end
 
-  it "doesn't find type parameter in alias (#3502)" do
+  it("doesn't find type parameter in alias (#3502)") do
     assert_error %(
       class A(T)
         alias B = A(T)

--- a/spec/compiler/semantic/array_spec.cr
+++ b/spec/compiler/semantic/array_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Semantic: array" do
-  it "types array literal of int" do
+describe("Semantic: array") do
+  it("types array literal of int") do
     assert_type("require \"prelude\"; [1, 2, 3]") { array_of(int32) }
   end
 
-  it "types array literal of union" do
+  it("types array literal of union") do
     assert_type("require \"prelude\"; [1, 2.5]") { array_of(union_of int32, float64) }
   end
 
-  it "types empty typed array literal of int" do
+  it("types empty typed array literal of int") do
     assert_type("require \"prelude\"; [] of Int32") { array_of(int32) }
   end
 
-  it "types non-empty typed array literal of int" do
+  it("types non-empty typed array literal of int") do
     assert_type("require \"prelude\"; [1, 2, 3] of Int32") { array_of(int32) }
   end
 
-  it "types array literal size correctly" do
+  it("types array literal size correctly") do
     assert_type("require \"prelude\"; [1].size") { int32 }
   end
 end

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Block inference" do
-  it "infer type of empty block body" do
+describe("Block inference") do
+  it("infer type of empty block body") do
     assert_type("
       def foo; yield; end
 
@@ -10,7 +10,7 @@ describe "Block inference" do
     ") { nil_type }
   end
 
-  it "infer type of block body" do
+  it("infer type of block body") do
     input = parse("
       def foo; yield; end
 
@@ -22,7 +22,7 @@ describe "Block inference" do
     input.last.as(Call).block.not_nil!.body.type.should eq(result.program.int32)
   end
 
-  it "infer type of block argument" do
+  it("infer type of block argument") do
     input = parse("
       def foo
         yield 1
@@ -37,7 +37,7 @@ describe "Block inference" do
     input.last.as(Call).block.not_nil!.args[0].type.should eq(mod.int32)
   end
 
-  it "infer type of local variable" do
+  it("infer type of local variable") do
     assert_type("
       def foo
         yield 1
@@ -51,7 +51,7 @@ describe "Block inference" do
     ") { union_of(char, int32) }
   end
 
-  it "infer type of yield" do
+  it("infer type of yield") do
     assert_type("
       def foo
         yield
@@ -63,7 +63,7 @@ describe "Block inference" do
     ") { int32 }
   end
 
-  it "infer type with union" do
+  it("infer type with union") do
     assert_type("
       require \"prelude\"
       a = [1] || [1.1]
@@ -71,7 +71,7 @@ describe "Block inference" do
     ") { union_of(array_of(int32), array_of(float64)) }
   end
 
-  it "uses block arg, too many arguments" do
+  it("uses block arg, too many arguments") do
     assert_error %(
       def foo
         yield
@@ -84,7 +84,7 @@ describe "Block inference" do
       "too many block arguments (given 1, expected maximum 0)"
   end
 
-  it "yields with different types" do
+  it("yields with different types") do
     assert_type(%(
       def foo
         yield 1
@@ -97,7 +97,7 @@ describe "Block inference" do
       )) { union_of(int32, char) }
   end
 
-  it "break from block without value" do
+  it("break from block without value") do
     assert_type("
       def foo; yield; end
 
@@ -107,7 +107,7 @@ describe "Block inference" do
     ") { nil_type }
   end
 
-  it "break without value has nil type" do
+  it("break without value has nil type") do
     assert_type("
       def foo; yield; 1; end
       foo do
@@ -116,7 +116,7 @@ describe "Block inference" do
     ") { nilable int32 }
   end
 
-  it "infers type of block before call" do
+  it("infers type of block before call") do
     result = assert_type("
       struct Int32
         def foo
@@ -142,7 +142,7 @@ describe "Block inference" do
     type.instance_vars["@x"].type.should eq(mod.float64)
   end
 
-  it "infers type of block before call taking other args free vars into account" do
+  it("infers type of block before call taking other args free vars into account") do
     assert_type("
       class Foo(X)
         def initialize(x : X)
@@ -160,7 +160,7 @@ describe "Block inference" do
       ") { generic_class "Foo", float64 }
   end
 
-  it "reports error if yields a type that's not that one in the block specification" do
+  it("reports error if yields a type that's not that one in the block specification") do
     assert_error "
       def foo(&block: Int32 -> )
         yield 10.5
@@ -171,7 +171,7 @@ describe "Block inference" do
       "argument #1 of yield expected to be Int32, not Float64"
   end
 
-  it "reports error if yields a type that's not that one in the block specification" do
+  it("reports error if yields a type that's not that one in the block specification") do
     assert_error "
       def foo(&block: Int32 -> )
         yield (1 || 1.5)
@@ -182,7 +182,7 @@ describe "Block inference" do
       "argument #1 of yield expected to be Int32, not (Float64 | Int32)"
   end
 
-  it "reports error if yields a type that later changes and that's not that one in the block specification" do
+  it("reports error if yields a type that later changes and that's not that one in the block specification") do
     assert_error "
       def foo(&block: Int32 -> )
         a = 1
@@ -197,7 +197,7 @@ describe "Block inference" do
       "argument #1 of yield expected to be Int32, not (Float64 | Int32)"
   end
 
-  it "reports error if missing arguments to yield" do
+  it("reports error if missing arguments to yield") do
     assert_error "
       def foo(&block: Int32, Int32 -> )
         yield 1
@@ -208,7 +208,7 @@ describe "Block inference" do
       "wrong number of yield arguments (given 1, expected 2)"
   end
 
-  it "reports error if block didn't return expected type" do
+  it("reports error if block didn't return expected type") do
     assert_error "
       def foo(&block: Int32 -> Float64)
         yield 1
@@ -219,7 +219,7 @@ describe "Block inference" do
       "expected block to return Float64, not Char"
   end
 
-  it "reports error if block type doesn't match" do
+  it("reports error if block type doesn't match") do
     assert_error "
       def foo(&block: Int32 -> Float64)
         yield 1
@@ -230,7 +230,7 @@ describe "Block inference" do
       "expected block to return Float64, not (Float64 | Int32)"
   end
 
-  it "reports error if block changes type" do
+  it("reports error if block changes type") do
     assert_error "
       def foo(&block: Int32 -> Float64)
         yield 1
@@ -245,7 +245,7 @@ describe "Block inference" do
       "type must be Float64"
   end
 
-  it "reports error on method instantiate (#4543)" do
+  it("reports error on method instantiate (#4543)") do
     assert_error %(
       class Foo
         @foo = 42
@@ -260,7 +260,7 @@ describe "Block inference" do
       "expected block to return Int32, not UInt32"
   end
 
-  it "matches block arg return type" do
+  it("matches block arg return type") do
     assert_type("
       class Foo(T)
       end
@@ -274,7 +274,7 @@ describe "Block inference" do
       ") { generic_class "Foo", float64 }
   end
 
-  it "infers type of block with generic type" do
+  it("infers type of block with generic type") do
     assert_type("
       class Foo(T)
       end
@@ -289,7 +289,7 @@ describe "Block inference" do
       ") { float64 }
   end
 
-  it "infer type with self block arg" do
+  it("infer type with self block arg") do
     assert_type("
       class Foo
         def foo(&block : self -> )
@@ -306,7 +306,7 @@ describe "Block inference" do
       ") { nilable types["Foo"] }
   end
 
-  it "error with self input type doesn't match" do
+  it("error with self input type doesn't match") do
     assert_error "
       class Foo
         def foo(&block : self -> )
@@ -320,7 +320,7 @@ describe "Block inference" do
       "argument #1 of yield expected to be Foo, not Int32"
   end
 
-  it "error with self output type doesn't match" do
+  it("error with self output type doesn't match") do
     assert_error "
       class Foo
         def foo(&block : Int32 -> self )
@@ -334,12 +334,12 @@ describe "Block inference" do
       "expected block to return Foo, not Int32"
   end
 
-  it "errors when using local variable with block argument name" do
+  it("errors when using local variable with block argument name") do
     assert_error "def foo; yield 1; end; foo { |a| }; a",
       "undefined local variable or method 'a'"
   end
 
-  it "types empty block" do
+  it("types empty block") do
     assert_type("
       def foo
         ret = yield
@@ -350,7 +350,7 @@ describe "Block inference" do
     ") { nil_type }
   end
 
-  it "preserves type filters in block" do
+  it("preserves type filters in block") do
     assert_type("
       class Foo
         def bar
@@ -373,7 +373,7 @@ describe "Block inference" do
       ") { char }
   end
 
-  it "checks block type with virtual type" do
+  it("checks block type with virtual type") do
     assert_type("
       require \"prelude\"
 
@@ -392,7 +392,7 @@ describe "Block inference" do
       ") { int32 }
   end
 
-  it "maps block of union types to union types" do
+  it("maps block of union types to union types") do
     assert_type("
       require \"prelude\"
 
@@ -413,7 +413,7 @@ describe "Block inference" do
       ") { array_of(union_of(types["Foo1"].virtual_type, types["Foo2"].virtual_type)) }
   end
 
-  it "does next from block without value" do
+  it("does next from block without value") do
     assert_type("
       def foo; yield; end
 
@@ -423,7 +423,7 @@ describe "Block inference" do
     ") { nil_type }
   end
 
-  it "does next from block with value" do
+  it("does next from block with value") do
     assert_type("
       def foo; yield; end
 
@@ -433,7 +433,7 @@ describe "Block inference" do
     ") { int32 }
   end
 
-  it "does next from block with value 2" do
+  it("does next from block with value 2") do
     assert_type("
       def foo; yield; end
 
@@ -446,7 +446,7 @@ describe "Block inference" do
     ") { union_of(int32, bool) }
   end
 
-  it "ignores block parameter if not used" do
+  it("ignores block parameter if not used") do
     assert_type(%(
       def foo(&block)
         yield 1
@@ -458,7 +458,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "allows yielding multiple types when a union is expected" do
+  it("allows yielding multiple types when a union is expected") do
     assert_type(%(
       require "prelude"
 
@@ -476,7 +476,7 @@ describe "Block inference" do
       )) { array_of(float64) }
   end
 
-  it "allows initialize with yield (#224)" do
+  it("allows initialize with yield (#224)") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -497,7 +497,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "passes #233: block with initialize with default args" do
+  it("passes #233: block with initialize with default args") do
     assert_type(%(
       class Foo
         def initialize(x = nil)
@@ -509,7 +509,7 @@ describe "Block inference" do
       )) { types["Foo"] }
   end
 
-  it "errors if declares def inside block" do
+  it("errors if declares def inside block") do
     assert_error %(
       def foo
         yield
@@ -523,7 +523,7 @@ describe "Block inference" do
       "can't declare def dynamically"
   end
 
-  it "errors if declares macro inside block" do
+  it("errors if declares macro inside block") do
     assert_error %(
       def foo
         yield
@@ -537,7 +537,7 @@ describe "Block inference" do
       "can't declare macro dynamically"
   end
 
-  it "errors if declares fun inside block" do
+  it("errors if declares fun inside block") do
     assert_error %(
       def foo
         yield
@@ -551,7 +551,7 @@ describe "Block inference" do
       "can't declare fun dynamically"
   end
 
-  it "errors if declares class inside block" do
+  it("errors if declares class inside block") do
     assert_error %(
       def foo
         yield
@@ -565,7 +565,7 @@ describe "Block inference" do
       "can't declare class dynamically"
   end
 
-  it "errors if declares module inside block" do
+  it("errors if declares module inside block") do
     assert_error %(
       def foo
         yield
@@ -579,7 +579,7 @@ describe "Block inference" do
       "can't declare module dynamically"
   end
 
-  it "errors if declares lib inside block" do
+  it("errors if declares lib inside block") do
     assert_error %(
       def foo
         yield
@@ -593,7 +593,7 @@ describe "Block inference" do
       "can't declare lib dynamically"
   end
 
-  it "errors if declares alias inside block" do
+  it("errors if declares alias inside block") do
     assert_error %(
       def foo
         yield
@@ -606,7 +606,7 @@ describe "Block inference" do
       "can't declare alias dynamically"
   end
 
-  it "errors if declares include inside block" do
+  it("errors if declares include inside block") do
     assert_error %(
       def foo
         yield
@@ -619,7 +619,7 @@ describe "Block inference" do
       "can't include dynamically"
   end
 
-  it "errors if declares extend inside block" do
+  it("errors if declares extend inside block") do
     assert_error %(
       def foo
         yield
@@ -632,7 +632,7 @@ describe "Block inference" do
       "can't extend dynamically"
   end
 
-  it "errors if declares enum inside block" do
+  it("errors if declares enum inside block") do
     assert_error %(
       def foo
         yield
@@ -647,7 +647,7 @@ describe "Block inference" do
       "can't declare enum dynamically"
   end
 
-  it "allows alias as block fun type" do
+  it("allows alias as block fun type") do
     assert_type(%(
       alias Alias = Int32 -> Int32
 
@@ -661,7 +661,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "errors if alias is not a fun type" do
+  it("errors if alias is not a fun type") do
     assert_error %(
       alias Alias = Int32
 
@@ -676,7 +676,7 @@ describe "Block inference" do
       "expected block type to be a function type, not Int32"
   end
 
-  it "passes #262" do
+  it("passes #262") do
     assert_type(%(
       require "prelude"
 
@@ -685,7 +685,7 @@ describe "Block inference" do
       )) { array_of(bool) }
   end
 
-  it "allows invoking method on a object of a captured block with a type that was never instantiated" do
+  it("allows invoking method on a object of a captured block with a type that was never instantiated") do
     assert_type(%(
       require "prelude"
 
@@ -712,7 +712,7 @@ describe "Block inference" do
       )) { proc_of(types["Bar"], void) }
   end
 
-  it "types bug with yield not_nil! that is never not nil" do
+  it("types bug with yield not_nil! that is never not nil") do
     assert_type(%(
       lib LibC
         fun exit : NoReturn
@@ -739,7 +739,7 @@ describe "Block inference" do
       )) { nilable(int32) }
   end
 
-  it "ignores void return type (#427)" do
+  it("ignores void return type (#427)") do
     assert_type(%(
       lib Fake
         fun foo(func : -> Void)
@@ -755,7 +755,7 @@ describe "Block inference" do
       )) { nil_type }
   end
 
-  it "ignores void return type (2) (#427)" do
+  it("ignores void return type (2) (#427)") do
     assert_type(%(
       def foo(&block : Int32 -> Void)
         yield 1
@@ -767,7 +767,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "ignores void return type (3) (#427)" do
+  it("ignores void return type (3) (#427)") do
     assert_type(%(
       alias Alias = Int32 -> Void
 
@@ -781,7 +781,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "ignores void return type (4)" do
+  it("ignores void return type (4)") do
     assert_type(%(
       alias Alias = Void
 
@@ -795,7 +795,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "uses block return type as return type, even if can't infer block type" do
+  it("uses block return type as return type, even if can't infer block type") do
     assert_type(%(
       class Foo
         def initialize(@foo : Int32)
@@ -820,7 +820,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "uses block var with same name as local var" do
+  it("uses block var with same name as local var") do
     assert_type(%(
       def foo
         yield true
@@ -834,7 +834,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "types recursive hash assignment" do
+  it("types recursive hash assignment") do
     assert_type(%(
       require "prelude"
 
@@ -855,7 +855,7 @@ describe "Block inference" do
       )) { array_of int32 }
   end
 
-  it "errors if invoking new with block when no initialize is defined" do
+  it("errors if invoking new with block when no initialize is defined") do
     assert_error %(
       class Foo
       end
@@ -865,7 +865,7 @@ describe "Block inference" do
       "'Foo.new' is not expected to be invoked with a block, but a block was given"
   end
 
-  it "recalculates call that uses block arg output as free var" do
+  it("recalculates call that uses block arg output as free var") do
     assert_type(%(
       def foo(&block : Int32 -> U) forall U
         block
@@ -893,7 +893,7 @@ describe "Block inference" do
       )) { union_of(char, int32).metaclass }
   end
 
-  it "finds type inside module in block" do
+  it("finds type inside module in block") do
     assert_type(%(
       module Moo
         class Foo
@@ -914,7 +914,7 @@ describe "Block inference" do
       )) { types["Moo"].types["Bar"] }
   end
 
-  it "passes &->f" do
+  it("passes &->f") do
     assert_type(%(
       def foo
       end
@@ -928,7 +928,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "errors if declares class inside captured block" do
+  it("errors if declares class inside captured block") do
     assert_error %(
       def foo(&block)
         block.call
@@ -942,7 +942,7 @@ describe "Block inference" do
       "can't declare class dynamically"
   end
 
-  it "doesn't assign block variable type to last value (#694)" do
+  it("doesn't assign block variable type to last value (#694)") do
     assert_type(%(
       def foo
         yield 1
@@ -957,14 +957,14 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "errors if yields from top level" do
+  it("errors if yields from top level") do
     assert_error %(
       yield
       ),
       "can't use `yield` outside a method"
   end
 
-  it "errors on recursive yield" do
+  it("errors on recursive yield") do
     assert_error %(
       def foo
         yield
@@ -978,7 +978,7 @@ describe "Block inference" do
       "recursive block expansion"
   end
 
-  it "binds to proc, not only to its body (#1796)" do
+  it("binds to proc, not only to its body (#1796)") do
     assert_type(%(
       def yielder(&block : Int32 -> U) forall U
         yield 1
@@ -989,7 +989,7 @@ describe "Block inference" do
       )) { union_of(int32, char).metaclass }
   end
 
-  it "binds block return type free variable even if there are no block arguments (#1797)" do
+  it("binds block return type free variable even if there are no block arguments (#1797)") do
     assert_type(%(
       def yielder(&block : -> U) forall U
         yield
@@ -1000,7 +1000,7 @@ describe "Block inference" do
       )) { int32.metaclass }
   end
 
-  it "returns from proc literal" do
+  it("returns from proc literal") do
     assert_type(%(
       foo = ->{
         if 1 == 1
@@ -1014,7 +1014,7 @@ describe "Block inference" do
       )) { union_of int32, float64 }
   end
 
-  it "errors if returns from captured block" do
+  it("errors if returns from captured block") do
     assert_error %(
       def foo(&block)
         block
@@ -1031,7 +1031,7 @@ describe "Block inference" do
       "can't return from captured block, use next"
   end
 
-  it "errors if breaks from captured block" do
+  it("errors if breaks from captured block") do
     assert_error %(
       def foo(&block)
         block
@@ -1048,7 +1048,7 @@ describe "Block inference" do
       "can't break from captured block"
   end
 
-  it "errors if doing next in proc literal" do
+  it("errors if doing next in proc literal") do
     assert_error %(
       foo = ->{
         next
@@ -1058,7 +1058,7 @@ describe "Block inference" do
       "Invalid next"
   end
 
-  it "does next from captured block" do
+  it("does next from captured block") do
     assert_type(%(
       def foo(&block : -> T) forall T
         block
@@ -1076,7 +1076,7 @@ describe "Block inference" do
       )) { union_of int32, float64 }
   end
 
-  it "sets captured block type to that of restriction" do
+  it("sets captured block type to that of restriction") do
     assert_type(%(
       def foo(&block : -> Int32 | String)
         block
@@ -1086,7 +1086,7 @@ describe "Block inference" do
       )) { proc_of(union_of(int32, string)) }
   end
 
-  it "sets captured block type to that of restriction with alias" do
+  it("sets captured block type to that of restriction with alias") do
     assert_type(%(
       alias Alias = -> Int32 | String
       def foo(&block : Alias)
@@ -1097,7 +1097,7 @@ describe "Block inference" do
       )) { proc_of(union_of(int32, string)) }
   end
 
-  it "matches block with generic type and free var" do
+  it("matches block with generic type and free var") do
     assert_type(%(
       class Foo(T)
       end
@@ -1111,7 +1111,7 @@ describe "Block inference" do
       )) { int32.metaclass }
   end
 
-  it "doesn't mix local var with block var, using break (#2314)" do
+  it("doesn't mix local var with block var, using break (#2314)") do
     assert_type(%(
       def foo
         yield 1
@@ -1125,7 +1125,7 @@ describe "Block inference" do
       )) { bool }
   end
 
-  it "doesn't mix local var with block var, using next (#2314)" do
+  it("doesn't mix local var with block var, using next (#2314)") do
     assert_type(%(
       def foo
         yield 1
@@ -1140,7 +1140,7 @@ describe "Block inference" do
   end
 
   ["Object", "Bar | Object", "(Object ->)", "( -> Object)"].each do |string|
-    it "errors if using #{string} as block return type (#2358)" do
+    it("errors if using #{string} as block return type (#2358)") do
       assert_error %(
         class Foo(T)
         end
@@ -1158,7 +1158,7 @@ describe "Block inference" do
     end
   end
 
-  it "yields splat" do
+  it("yields splat") do
     assert_type(%(
       def foo
         tup = {1, 'a'}
@@ -1171,7 +1171,7 @@ describe "Block inference" do
       )) { tuple_of([char, int32]) }
   end
 
-  it "yields splat and non splat" do
+  it("yields splat and non splat") do
     assert_type(%(
       def foo
         tup = {1, 'a'}
@@ -1186,7 +1186,7 @@ describe "Block inference" do
       )) { tuple_of([nilable(char), union_of(int32, bool)]) }
   end
 
-  it "uses splat in block argument" do
+  it("uses splat in block argument") do
     assert_type(%(
       def foo
         yield 1, 'a'
@@ -1198,7 +1198,7 @@ describe "Block inference" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "uses splat in block argument, many args" do
+  it("uses splat in block argument, many args") do
     assert_type(%(
       def foo
         yield 1, 'a', true, nil, 1.5, "hello"
@@ -1210,7 +1210,7 @@ describe "Block inference" do
       )) { tuple_of([int32, tuple_of([char, bool, nil_type]), float64, string]) }
   end
 
-  it "uses splat in block argument, but not enough yield expressions" do
+  it("uses splat in block argument, but not enough yield expressions") do
     assert_error %(
       def foo
         yield 1
@@ -1223,7 +1223,7 @@ describe "Block inference" do
       "too many block arguments (given 3+, expected maximum 1+)"
   end
 
-  it "errors if splat argument becomes a union" do
+  it("errors if splat argument becomes a union") do
     assert_error %(
       def foo
         yield 1
@@ -1236,7 +1236,7 @@ describe "Block inference" do
       "block splat argument must be a tuple type"
   end
 
-  it "auto-unpacks tuple" do
+  it("auto-unpacks tuple") do
     assert_type(%(
       def foo
         tup = {1, 'a'}
@@ -1249,7 +1249,7 @@ describe "Block inference" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "auto-unpacks tuple, less than max" do
+  it("auto-unpacks tuple, less than max") do
     assert_type(%(
       def foo
         tup = {1, 'a', true}
@@ -1262,7 +1262,7 @@ describe "Block inference" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "auto-unpacks with block arg type" do
+  it("auto-unpacks with block arg type") do
     assert_type(%(
       def foo(&block : {Int32, Int32} -> _)
         yield({1, 2})
@@ -1274,7 +1274,7 @@ describe "Block inference" do
       )) { int32 }
   end
 
-  it "doesn't auto-unpacks tuple, more args" do
+  it("doesn't auto-unpacks tuple, more args") do
     assert_error %(
       def foo
         tup = {1, 'a'}
@@ -1287,7 +1287,7 @@ describe "Block inference" do
       "too many block arguments (given 3, expected maximum 2)"
   end
 
-  it "auto-unpacks tuple, too many args" do
+  it("auto-unpacks tuple, too many args") do
     assert_error %(
       def foo
         tup = {1, 'a'}
@@ -1300,7 +1300,7 @@ describe "Block inference" do
       "too many block arguments (given 3, expected maximum 2)"
   end
 
-  it "doesn't crash on #2531" do
+  it("doesn't crash on #2531") do
     run(%(
       def foo
         yield
@@ -1314,7 +1314,7 @@ describe "Block inference" do
       )).to_i.should eq(10)
   end
 
-  it "yields in overload, matches type" do
+  it("yields in overload, matches type") do
     assert_type(%(
       struct Int
         def foo(&block : self ->)
@@ -1328,7 +1328,7 @@ describe "Block inference" do
       )) { union_of(int32, int64) }
   end
 
-  it "uses free var in return type in captured block" do
+  it("uses free var in return type in captured block") do
     assert_type(%(
       class U
       end
@@ -1342,7 +1342,7 @@ describe "Block inference" do
       )) { int32.metaclass }
   end
 
-  it "uses free var in return type with tuple type" do
+  it("uses free var in return type with tuple type") do
     assert_type(%(
       class T; end
 
@@ -1361,7 +1361,7 @@ describe "Block inference" do
       )) { tuple_of([tuple_of([int32, int32]), tuple_of([int32, int32]).metaclass]) }
   end
 
-  it "correctly types unpacked tuple block arg after block (#3339)" do
+  it("correctly types unpacked tuple block arg after block (#3339)") do
     assert_type(%(
       def foo
         yield({""})

--- a/spec/compiler/semantic/c_enum_spec.cr
+++ b/spec/compiler/semantic/c_enum_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Semantic: c enum" do
-  it "types enum value" do
+describe("Semantic: c enum") do
+  it("types enum value") do
     assert_type("lib LibFoo; enum Bar; X, Y, Z = 10, W; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
   end
 
-  it "allows using an enum as a type in a fun" do
+  it("allows using an enum as a type in a fun") do
     assert_type("
       lib LibC
         enum Foo
@@ -18,7 +18,7 @@ describe "Semantic: c enum" do
     ") { types["LibC"].types["Foo"] }
   end
 
-  it "allows using an enum as a type in a struct" do
+  it("allows using an enum as a type in a struct") do
     assert_type("
       lib LibC
         enum Foo
@@ -35,16 +35,16 @@ describe "Semantic: c enum" do
     ") { types["LibC"].types["Foo"] }
   end
 
-  it "types enum value with base type" do
+  it("types enum value with base type") do
     assert_type("lib LibFoo; enum Bar : Int16; X; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
   end
 
-  it "errors if enum base type is not an integer" do
+  it("errors if enum base type is not an integer") do
     assert_error "lib LibFoo; enum Bar : Float32; X; end; end; LibFoo::Bar::X",
       "enum base type must be an integer type"
   end
 
-  it "errors if enum value is different from default (Int32) (#194)" do
+  it("errors if enum value is different from default (Int32) (#194)") do
     assert_error "lib LibFoo; enum Bar; X = 0x00000001_u32; end; end; LibFoo::Bar::X",
       "enum value must be an Int32"
   end

--- a/spec/compiler/semantic/c_struct_spec.cr
+++ b/spec/compiler/semantic/c_struct_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: struct" do
-  it "types struct" do
+describe("Semantic: struct") do
+  it("types struct") do
     result = assert_type("lib LibFoo; struct Bar; x : Int32; y : Float64; end; end; LibFoo::Bar") { types["LibFoo"].types["Bar"].metaclass }
     mod = result.program
 
@@ -12,21 +12,21 @@ describe "Semantic: struct" do
     bar.instance_vars["@y"].type.should eq(mod.float64)
   end
 
-  it "types Struct#new" do
+  it("types Struct#new") do
     assert_type("lib LibFoo; struct Bar; x : Int32; y : Float64; end; end; LibFoo::Bar.new") do
       types["LibFoo"].types["Bar"]
     end
   end
 
-  it "types struct setter" do
+  it("types struct setter") do
     assert_type("lib LibFoo; struct Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x = 1") { int32 }
   end
 
-  it "types struct getter" do
+  it("types struct getter") do
     assert_type("lib LibFoo; struct Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x") { int32 }
   end
 
-  it "types struct getter to struct" do
+  it("types struct getter to struct") do
     assert_type("
       lib LibFoo
         struct Baz
@@ -41,7 +41,7 @@ describe "Semantic: struct" do
     ") { types["LibFoo"].types["Baz"] }
   end
 
-  it "types struct getter multiple levels via new" do
+  it("types struct getter multiple levels via new") do
     assert_type("
       lib LibFoo
         struct Baz
@@ -56,30 +56,30 @@ describe "Semantic: struct" do
     ") { int32 }
   end
 
-  it "types struct getter with keyword name" do
+  it("types struct getter with keyword name") do
     assert_type("lib LibFoo; struct Bar; type : Int32; end; end; bar = LibFoo::Bar.new; bar.type") { int32 }
   end
 
-  it "errors on struct if no field" do
+  it("errors on struct if no field") do
     assert_error "lib LibFoo; struct Bar; x : Int32; end; end; f = LibFoo::Bar.new; f.y = 'a'",
       "undefined method 'y=' for LibFoo::Bar"
   end
 
-  it "errors on struct setter if different type" do
+  it("errors on struct setter if different type") do
     assert_error "lib LibFoo; struct Bar; x : Int32; end; end; f = LibFoo::Bar.new; f.x = 'a'",
       "field 'x' of struct LibFoo::Bar has type Int32, not Char"
   end
 
-  it "errors on struct setter if different type via new" do
+  it("errors on struct setter if different type via new") do
     assert_error "lib LibFoo; struct Bar; x : Int32; end; end; f = Pointer(LibFoo::Bar).malloc(1_u64); f.value.x = 'a'",
       "field 'x' of struct LibFoo::Bar has type Int32, not Char"
   end
 
-  it "types struct getter on pointer type" do
+  it("types struct getter on pointer type") do
     assert_type("lib LibFoo; struct Bar; x : Int32*; end; end; b = LibFoo::Bar.new; b.x") { pointer_of(int32) }
   end
 
-  it "errors if setting closure" do
+  it("errors if setting closure") do
     assert_error %(
       lib LibFoo
         struct Bar
@@ -95,7 +95,7 @@ describe "Semantic: struct" do
       "can't set closure as C struct member"
   end
 
-  it "errors if already defined" do
+  it("errors if already defined") do
     assert_error %(
       lib LibC
         struct Foo
@@ -109,7 +109,7 @@ describe "Semantic: struct" do
       "Foo is already defined"
   end
 
-  it "errors if already defined with another type" do
+  it("errors if already defined with another type") do
     assert_error %(
       lib LibC
         enum Foo
@@ -123,7 +123,7 @@ describe "Semantic: struct" do
       "Foo is already defined as enum"
   end
 
-  it "errors if already defined with another type (2)" do
+  it("errors if already defined with another type (2)") do
     assert_error %(
       lib LibC
         union Foo
@@ -137,7 +137,7 @@ describe "Semantic: struct" do
       "Foo is already defined as union"
   end
 
-  it "allows inline forward declaration" do
+  it("allows inline forward declaration") do
     assert_type(%(
       lib LibC
         struct Node
@@ -150,7 +150,7 @@ describe "Semantic: struct" do
       )) { pointer_of(types["LibC"].types["Node"]) }
   end
 
-  it "supports macro if inside struct" do
+  it("supports macro if inside struct") do
     assert_type(%(
       lib LibC
         struct Foo
@@ -166,7 +166,7 @@ describe "Semantic: struct" do
       ), flags: "some_flag") { int32 }
   end
 
-  it "includes another struct" do
+  it("includes another struct") do
     assert_type(%(
       lib LibC
         struct Foo
@@ -182,7 +182,7 @@ describe "Semantic: struct" do
       )) { int32 }
   end
 
-  it "errors if includes non-cstruct type" do
+  it("errors if includes non-cstruct type") do
     assert_error %(
       lib LibC
         union Foo
@@ -199,7 +199,7 @@ describe "Semantic: struct" do
       "can only include C struct, not union"
   end
 
-  it "errors if includes unknown type" do
+  it("errors if includes unknown type") do
     assert_error %(
       lib LibC
         struct Bar
@@ -212,7 +212,7 @@ describe "Semantic: struct" do
       "undefined constant Foo"
   end
 
-  it "errors if includes and field already exists" do
+  it("errors if includes and field already exists") do
     assert_error %(
       lib LibC
         struct Foo
@@ -230,7 +230,7 @@ describe "Semantic: struct" do
       "struct LibC::Foo has a field named 'a', which LibC::Bar already defines"
   end
 
-  it "errors if includes and field already exists, the other way around" do
+  it("errors if includes and field already exists, the other way around") do
     assert_error %(
       lib LibC
         struct Foo
@@ -248,7 +248,7 @@ describe "Semantic: struct" do
       "struct LibC::Bar already defines a field named 'a'"
   end
 
-  it "marks as packed" do
+  it("marks as packed") do
     result = semantic(%(
       lib LibFoo
         @[Packed]
@@ -261,7 +261,7 @@ describe "Semantic: struct" do
     foo_struct.packed?.should be_true
   end
 
-  it "errors on empty c struct (#633)" do
+  it("errors on empty c struct (#633)") do
     assert_error %(
       lib LibFoo
         struct Struct
@@ -271,7 +271,7 @@ describe "Semantic: struct" do
       "empty structs are disallowed"
   end
 
-  it "errors if using void in struct field type" do
+  it("errors if using void in struct field type") do
     assert_error %(
       lib LibFoo
         struct Struct
@@ -282,7 +282,7 @@ describe "Semantic: struct" do
       "can't use Void as a struct field type"
   end
 
-  it "errors if using void via typedef in struct field type" do
+  it("errors if using void via typedef in struct field type") do
     assert_error %(
       lib LibFoo
         type MyVoid = Void
@@ -295,7 +295,7 @@ describe "Semantic: struct" do
       "can't use Void as a struct field type"
   end
 
-  it "can access instance var from the outside (#1092)" do
+  it("can access instance var from the outside (#1092)") do
     assert_type(%(
       lib LibFoo
         struct Foo
@@ -308,7 +308,7 @@ describe "Semantic: struct" do
       )) { int32 }
   end
 
-  it "automatically converts numeric type in struct field assignment" do
+  it("automatically converts numeric type in struct field assignment") do
     assert_type(%(
       lib LibFoo
         struct Foo
@@ -322,7 +322,7 @@ describe "Semantic: struct" do
       )) { int32 }
   end
 
-  it "errors if invoking to_i32 and got error in that call" do
+  it("errors if invoking to_i32 and got error in that call") do
     assert_error %(
       lib LibFoo
         struct Foo
@@ -342,7 +342,7 @@ describe "Semantic: struct" do
       "converting from Foo to Int32 by invoking 'to_i32'"
   end
 
-  it "errors if invoking to_i32 and got wrong type" do
+  it("errors if invoking to_i32 and got wrong type") do
     assert_error %(
       lib LibFoo
         struct Foo
@@ -362,7 +362,7 @@ describe "Semantic: struct" do
       "invoked 'to_i32' to convert from Foo to Int32, but got Char"
   end
 
-  it "errors if invoking to_unsafe and got error in that call" do
+  it("errors if invoking to_unsafe and got error in that call") do
     assert_error %(
       lib LibFoo
         struct Foo
@@ -382,7 +382,7 @@ describe "Semantic: struct" do
       "no overload matches 'Int32#+' with type Char"
   end
 
-  it "errors if invoking to_unsafe and got different type" do
+  it("errors if invoking to_unsafe and got different type") do
     assert_error %(
       lib LibFoo
         struct Foo

--- a/spec/compiler/semantic/c_type_spec.cr
+++ b/spec/compiler/semantic/c_type_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: type" do
-  it "can call methods of original type" do
+describe("Semantic: type") do
+  it("can call methods of original type") do
     assert_type("
       lib Lib
         type X = Void*
@@ -12,7 +12,7 @@ describe "Semantic: type" do
     ") { uint64 }
   end
 
-  it "can call methods of parent type" do
+  it("can call methods of parent type") do
     assert_error("
       lib Lib
         type X = Void*

--- a/spec/compiler/semantic/c_union_spec.cr
+++ b/spec/compiler/semantic/c_union_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: c union" do
-  it "types c union" do
+describe("Semantic: c union") do
+  it("types c union") do
     result = assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; LibFoo::Bar") { types["LibFoo"].types["Bar"].metaclass }
     mod = result.program
     bar = mod.types["LibFoo"].types["Bar"].as(NonGenericClassType)
@@ -11,29 +11,29 @@ describe "Semantic: c union" do
     bar.instance_vars["@y"].type.should eq(mod.float64)
   end
 
-  it "types Union#new" do
+  it("types Union#new") do
     assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; LibFoo::Bar.new") do
       types["LibFoo"].types["Bar"]
     end
   end
 
-  it "types union setter" do
+  it("types union setter") do
     assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x = 1") { int32 }
   end
 
-  it "types union getter" do
+  it("types union getter") do
     assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x") { int32 }
   end
 
-  it "types union setter via pointer" do
+  it("types union setter via pointer") do
     assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 1") { int32 }
   end
 
-  it "types union getter via pointer" do
+  it("types union getter via pointer") do
     assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x") { int32 }
   end
 
-  it "errors if setting closure" do
+  it("errors if setting closure") do
     assert_error %(
       lib LibFoo
         union Bar
@@ -49,7 +49,7 @@ describe "Semantic: c union" do
       "can't set closure as C union member"
   end
 
-  it "errors on empty c union (#633)" do
+  it("errors on empty c union (#633)") do
     assert_error %(
       lib LibFoo
         union Struct
@@ -59,7 +59,7 @@ describe "Semantic: c union" do
       "empty unions are disallowed"
   end
 
-  it "errors if using void in union field type" do
+  it("errors if using void in union field type") do
     assert_error %(
       lib LibFoo
         union Struct
@@ -70,7 +70,7 @@ describe "Semantic: c union" do
       "can't use Void as a union field type"
   end
 
-  it "errors if using void via typedef in union field type" do
+  it("errors if using void via typedef in union field type") do
     assert_error %(
       lib LibFoo
         type MyVoid = Void

--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -1,21 +1,21 @@
 require "../../spec_helper"
 
-describe "Semantic: cast" do
-  it "casts to same type is ok" do
+describe("Semantic: cast") do
+  it("casts to same type is ok") do
     assert_type("1.as(Int32)") { int32 }
   end
 
-  it "casts to incompatible type gives error" do
+  it("casts to incompatible type gives error") do
     assert_error "1.as(Float64)",
       "can't cast Int32 to Float64"
   end
 
-  pending "casts from union to incompatible union gives error" do
+  pending("casts from union to incompatible union gives error") do
     assert_error "(1 || 1.5).as(Int32 | Char)",
       "can't cast Int32 | Float64 to Int32 | Char"
   end
 
-  it "casts from pointer to generic class gives error" do
+  it("casts from pointer to generic class gives error") do
     assert_error "
       class Foo(T)
       end
@@ -26,11 +26,11 @@ describe "Semantic: cast" do
       "can't cast Pointer(Int32) to Foo(T)"
   end
 
-  it "casts from union to compatible union" do
+  it("casts from union to compatible union") do
     assert_type("(1 || 1.5 || 'a').as(Int32 | Float64)") { union_of(int32, float64) }
   end
 
-  it "casts to compatible type and use it" do
+  it("casts to compatible type and use it") do
     assert_type("
       class Foo
       end
@@ -47,7 +47,7 @@ describe "Semantic: cast" do
     ") { int32 }
   end
 
-  it "casts pointer of one type to another type" do
+  it("casts pointer of one type to another type") do
     assert_type("
       a = 1
       p = pointerof(a)
@@ -55,7 +55,7 @@ describe "Semantic: cast" do
     ") { pointer_of(float64) }
   end
 
-  it "casts pointer to another type" do
+  it("casts pointer to another type") do
     assert_type("
       a = 1
       p = pointerof(a)
@@ -63,7 +63,7 @@ describe "Semantic: cast" do
     ") { types["String"] }
   end
 
-  it "casts to module" do
+  it("casts to module") do
     assert_type("
       module Moo
       end
@@ -84,7 +84,7 @@ describe "Semantic: cast" do
       ") { union_of(types["Bar"].virtual_type, types["Baz"].virtual_type) }
   end
 
-  it "allows casting object to void pointer" do
+  it("allows casting object to void pointer") do
     assert_type("
       class Foo
       end
@@ -93,7 +93,7 @@ describe "Semantic: cast" do
       ") { pointer_of(void) }
   end
 
-  it "allows casting reference union to void pointer" do
+  it("allows casting reference union to void pointer") do
     assert_type("
       class Foo
       end
@@ -106,14 +106,14 @@ describe "Semantic: cast" do
       ") { pointer_of(void) }
   end
 
-  it "disallows casting int to pointer" do
+  it("disallows casting int to pointer") do
     assert_error %(
       1.as(Void*)
       ),
       "can't cast Int32 to Pointer(Void)"
   end
 
-  it "disallows casting fun to pointer" do
+  it("disallows casting fun to pointer") do
     assert_error %(
       f = ->{ 1 }
       f.as(Void*)
@@ -121,7 +121,7 @@ describe "Semantic: cast" do
       "can't cast Proc(Int32) to Pointer(Void)"
   end
 
-  it "disallows casting pointer to fun" do
+  it("disallows casting pointer to fun") do
     assert_error %(
       a = uninitialized Void*
       a.as(-> Int32)
@@ -129,7 +129,7 @@ describe "Semantic: cast" do
       "can't cast Pointer(Void) to Proc(Int32)"
   end
 
-  it "doesn't error if casting to a generic type" do
+  it("doesn't error if casting to a generic type") do
     assert_type(%(
       class Foo(T)
       end
@@ -139,7 +139,7 @@ describe "Semantic: cast" do
       )) { generic_class "Foo", int32 }
   end
 
-  it "casts to base class making it virtual (1)" do
+  it("casts to base class making it virtual (1)") do
     assert_type(%(
       class Foo
       end
@@ -151,7 +151,7 @@ describe "Semantic: cast" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "casts to base class making it virtual (2)" do
+  it("casts to base class making it virtual (2)") do
     assert_type(%(
       class Foo
         def foo
@@ -170,13 +170,13 @@ describe "Semantic: cast" do
       )) { union_of(int32, char) }
   end
 
-  it "casts to bigger union" do
+  it("casts to bigger union") do
     assert_type(%(
       1.as(Int32 | Char)
       )) { union_of(int32, char) }
   end
 
-  it "errors on cast inside a call that can't be instantiated" do
+  it("errors on cast inside a call that can't be instantiated") do
     assert_error %(
       def foo(x)
       end
@@ -186,7 +186,7 @@ describe "Semantic: cast" do
       "can't cast Int32 to Bool"
   end
 
-  it "casts to target type even if can't infer casted value type (obsolete)" do
+  it("casts to target type even if can't infer casted value type (obsolete)") do
     assert_type(%(
       require "prelude"
 
@@ -202,7 +202,7 @@ describe "Semantic: cast" do
       )) { array_of(int32) }
   end
 
-  it "should error if can't cast even if not instantiated" do
+  it("should error if can't cast even if not instantiated") do
     assert_error %(
       class Foo
       end
@@ -215,7 +215,7 @@ describe "Semantic: cast" do
       "can't cast Foo to Bar"
   end
 
-  it "can cast to metaclass (bug)" do
+  it("can cast to metaclass (bug)") do
     assert_type(%(
       Int32.as(Int32.class)
       )) { int32.metaclass }
@@ -223,14 +223,14 @@ describe "Semantic: cast" do
 
   # Later we might want casting something to Object to have a meaning
   # similar to casting to Void*, but for now it's useless.
-  it "disallows casting to Object (#815)" do
+  it("disallows casting to Object (#815)") do
     assert_error %(
       nil.as(Object)
       ),
       "can't cast to Object yet"
   end
 
-  it "doesn't allow upcast of generic type var (#996)" do
+  it("doesn't allow upcast of generic type var (#996)") do
     assert_error %(
       class Foo
       end
@@ -246,7 +246,7 @@ describe "Semantic: cast" do
       ), "can't cast Gen(Bar) to Gen(Foo)"
   end
 
-  it "allows casting NoReturn to any type (#2132)" do
+  it("allows casting NoReturn to any type (#2132)") do
     assert_type(%(
       def foo
         foo
@@ -256,7 +256,7 @@ describe "Semantic: cast" do
       )) { no_return }
   end
 
-  it "errors if casting nil to Object inside typeof (#2403)" do
+  it("errors if casting nil to Object inside typeof (#2403)") do
     assert_error %(
       require "prelude"
 
@@ -265,21 +265,21 @@ describe "Semantic: cast" do
       "can't cast to Object yet"
   end
 
-  it "disallows casting to Reference" do
+  it("disallows casting to Reference") do
     assert_error %(
       "foo".as(Reference)
       ),
       "can't cast to Reference yet"
   end
 
-  it "disallows casting to Class" do
+  it("disallows casting to Class") do
     assert_error %(
       nil.as(Class)
       ),
       "can't cast to Class yet"
   end
 
-  it "can cast from Void* to virtual type (#3014)" do
+  it("can cast from Void* to virtual type (#3014)") do
     assert_type(%(
       abstract class Foo
       end
@@ -291,7 +291,7 @@ describe "Semantic: cast" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "casts to generic virtual type" do
+  it("casts to generic virtual type") do
     assert_type(%(
       class Foo(T)
       end
@@ -303,7 +303,7 @@ describe "Semantic: cast" do
       )) { generic_class("Foo", int32).virtual_type! }
   end
 
-  it "doesn't cast to virtual primitive (bug)" do
+  it("doesn't cast to virtual primitive (bug)") do
     assert_type(%(
       1.as(Int)
       )) { int32 }

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Semantic: class" do
-  it "types Const#allocate" do
+describe("Semantic: class") do
+  it("types Const#allocate") do
     assert_type("class Foo; end; Foo.allocate") { types["Foo"].as(NonGenericClassType) }
   end
 
-  it "types Const#new" do
+  it("types Const#new") do
     assert_type("class Foo; end; Foo.new") { types["Foo"].as(NonGenericClassType) }
   end
 
-  it "types Const#new#method" do
+  it("types Const#new#method") do
     assert_type("class Foo; def coco; 1; end; end; Foo.new.coco") { int32 }
   end
 
-  it "types class inside class" do
+  it("types class inside class") do
     assert_type("class Foo; class Bar; end; end; Foo::Bar.allocate") { types["Foo"].types["Bar"] }
   end
 
-  it "types instance variable" do
+  it("types instance variable") do
     result = assert_type("
       class Foo(T)
         def set
@@ -34,7 +34,7 @@ describe "Semantic: class" do
     type.instance_vars["@coco"].type.should eq(mod.nilable(mod.int32))
   end
 
-  it "types generic of generic type" do
+  it("types generic of generic type") do
     result = assert_type("
       class Foo(T)
         def set
@@ -52,7 +52,7 @@ describe "Semantic: class" do
     end
   end
 
-  it "types instance variable" do
+  it("types instance variable") do
     input = parse "
       class Foo(T)
         def set(value : T)
@@ -78,7 +78,7 @@ describe "Semantic: class" do
     node[3].type.instance_vars["@coco"].type.should eq(mod.nilable(mod.float64))
   end
 
-  it "types instance variable on getter" do
+  it("types instance variable on getter") do
     input = parse("
       class Foo(T)
         def set(value : T)
@@ -105,7 +105,7 @@ describe "Semantic: class" do
     input.last.type.should eq(mod.nilable(mod.float64))
   end
 
-  it "types recursive type" do
+  it("types recursive type") do
     input = parse("
       class Node
         def add
@@ -129,7 +129,7 @@ describe "Semantic: class" do
     input.last.type.should eq(node)
   end
 
-  it "types self inside method call without obj" do
+  it("types self inside method call without obj") do
     assert_type("
       class Foo
         def foo
@@ -145,7 +145,7 @@ describe "Semantic: class" do
     ") { types["Foo"] }
   end
 
-  it "types type var union" do
+  it("types type var union") do
     assert_type("
       class Foo(T)
       end
@@ -154,7 +154,7 @@ describe "Semantic: class" do
       ") { generic_class "Foo", union_of(int32, float64) }
   end
 
-  it "types class and subclass as one type" do
+  it("types class and subclass as one type") do
     assert_type("
       class Foo
       end
@@ -166,7 +166,7 @@ describe "Semantic: class" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "types class and subclass as one type" do
+  it("types class and subclass as one type") do
     assert_type("
       class Foo
       end
@@ -181,7 +181,7 @@ describe "Semantic: class" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "types class and subclass as one type" do
+  it("types class and subclass as one type") do
     assert_type("
       class Foo
       end
@@ -196,7 +196,7 @@ describe "Semantic: class" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "does automatic inference of new for generic types" do
+  it("does automatic inference of new for generic types") do
     result = assert_type("
       class Box(T)
         def initialize(value : T)
@@ -212,7 +212,7 @@ describe "Semantic: class" do
     type.instance_vars["@value"].type.should eq(mod.int32)
   end
 
-  it "does automatic type inference of new for generic types 2" do
+  it("does automatic type inference of new for generic types 2") do
     result = assert_type("
       class Box(T)
         def initialize(x, value : T)
@@ -229,7 +229,7 @@ describe "Semantic: class" do
     type.instance_vars["@value"].type.should eq(mod.bool)
   end
 
-  it "does automatic type inference of new for nested generic type" do
+  it("does automatic type inference of new for nested generic type") do
     nodes = parse("
       class Foo
         class Bar(T)
@@ -248,32 +248,32 @@ describe "Semantic: class" do
     type.instance_vars["@x"].type.should eq(mod.int32)
   end
 
-  it "reports uninitialized constant" do
+  it("reports uninitialized constant") do
     assert_error "Foo.new",
       "undefined constant Foo"
   end
 
-  it "reports undefined method when method inside a class" do
+  it("reports undefined method when method inside a class") do
     assert_error "struct Int; def foo; 1; end; end; foo",
       "undefined local variable or method 'foo'"
   end
 
-  it "reports undefined instance method" do
+  it("reports undefined instance method") do
     assert_error "1.foo",
       "undefined method 'foo' for Int"
   end
 
-  it "reports unknown class when extending" do
+  it("reports unknown class when extending") do
     assert_error "class Foo < Bar; end",
       "undefined constant Bar"
   end
 
-  it "reports superclass mismatch" do
+  it("reports superclass mismatch") do
     assert_error "class Foo; end; class Bar; end; class Foo < Bar; end",
       "superclass mismatch for class Foo (Bar for Reference)"
   end
 
-  it "reports wrong number of arguments for initialize" do
+  it("reports wrong number of arguments for initialize") do
     assert_error "
       class Foo
         def initialize(x, y)
@@ -285,7 +285,7 @@ describe "Semantic: class" do
       "wrong number of arguments"
   end
 
-  it "reports can't instantiate abstract class on new" do
+  it("reports can't instantiate abstract class on new") do
     assert_error "
       abstract class Foo; end
       Foo.new
@@ -293,7 +293,7 @@ describe "Semantic: class" do
       "can't instantiate abstract class Foo"
   end
 
-  it "reports can't instantiate abstract class on allocate" do
+  it("reports can't instantiate abstract class on allocate") do
     assert_error "
       abstract class Foo; end
       Foo.allocate
@@ -301,7 +301,7 @@ describe "Semantic: class" do
       "can't instantiate abstract class Foo"
   end
 
-  it "doesn't lookup new in supermetaclass" do
+  it("doesn't lookup new in supermetaclass") do
     assert_type("
       class Foo(T)
       end
@@ -311,12 +311,12 @@ describe "Semantic: class" do
       ") { generic_class "Foo", int32 }
   end
 
-  it "errors when wrong arguments for new" do
+  it("errors when wrong arguments for new") do
     assert_error "Reference.new 1",
       "wrong number of arguments"
   end
 
-  it "types virtual method of generic class" do
+  it("types virtual method of generic class") do
     assert_type("
       require \"char\"
 
@@ -340,7 +340,7 @@ describe "Semantic: class" do
       ") { int32 }
   end
 
-  it "allows defining classes inside modules or classes with ::" do
+  it("allows defining classes inside modules or classes with ::") do
     input = parse("
       class Foo
       end
@@ -353,7 +353,7 @@ describe "Semantic: class" do
     mod.types["Foo"].types["Bar"].as(NonGenericClassType)
   end
 
-  it "doesn't lookup type in parents' namespaces, and lookups and in program" do
+  it("doesn't lookup type in parents' namespaces, and lookups and in program") do
     code = "
       class Bar
       end
@@ -385,7 +385,7 @@ describe "Semantic: class" do
       ") { char }
   end
 
-  it "finds in global scope if includes module" do
+  it("finds in global scope if includes module") do
     assert_type("
       class Baz
       end
@@ -402,7 +402,7 @@ describe "Semantic: class" do
     ") { int32 }
   end
 
-  it "allows instantiating generic class with number" do
+  it("allows instantiating generic class with number") do
     assert_type("
       class Foo(T)
       end
@@ -411,7 +411,7 @@ describe "Semantic: class" do
       ") { generic_class "Foo", 1.int32 }
   end
 
-  it "uses number type var in class method" do
+  it("uses number type var in class method") do
     assert_type("
       class Foo(T)
         def self.foo
@@ -423,7 +423,7 @@ describe "Semantic: class" do
       ") { int32 }
   end
 
-  it "uses self as type var" do
+  it("uses self as type var") do
     assert_type("
       class Foo(T)
       end
@@ -438,7 +438,7 @@ describe "Semantic: class" do
       ") { generic_class "Foo", types["Bar"] }
   end
 
-  it "uses self as type var" do
+  it("uses self as type var") do
     assert_type("
       class Foo(T)
       end
@@ -456,7 +456,7 @@ describe "Semantic: class" do
       ") { generic_class "Foo", types["Baz"] }
   end
 
-  it "infers generic type after instance was created with explicit type" do
+  it("infers generic type after instance was created with explicit type") do
     assert_type("
       class Foo(T)
         def initialize(@x : T)
@@ -473,15 +473,15 @@ describe "Semantic: class" do
       ") { int32 }
   end
 
-  it "errors when creating Value" do
+  it("errors when creating Value") do
     assert_error "Value.allocate", "can't instantiate abstract struct Value"
   end
 
-  it "errors when creating Number" do
+  it("errors when creating Number") do
     assert_error "Number.allocate", "can't instantiate abstract struct Number"
   end
 
-  it "reads an object instance var" do
+  it("reads an object instance var") do
     assert_type(%(
       class Foo
         def initialize(@x : Int32)
@@ -493,7 +493,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "reads a virtual type instance var" do
+  it("reads a virtual type instance var") do
     assert_type(%(
       class Foo
         def initialize(@x : Int32)
@@ -508,7 +508,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "errors if reading non-existent ivar" do
+  it("errors if reading non-existent ivar") do
     assert_error %(
       class Foo
       end
@@ -519,14 +519,14 @@ describe "Semantic: class" do
       "Can't infer the type of instance variable '@y' of Foo"
   end
 
-  it "errors if reading ivar from non-ivar container" do
+  it("errors if reading ivar from non-ivar container") do
     assert_error %(
       1.@y
       ),
       "can't use instance variables inside primitive types (at Int32)"
   end
 
-  it "says that instance vars are not allowed in metaclass" do
+  it("says that instance vars are not allowed in metaclass") do
     assert_error %(
       module Foo
         def self.foo
@@ -539,7 +539,7 @@ describe "Semantic: class" do
       "@instance_vars are not yet allowed in metaclasses: use @@class_vars instead"
   end
 
-  it "doesn't use initialize from base class" do
+  it("doesn't use initialize from base class") do
     assert_error %(
       class Foo
         def initialize(x)
@@ -556,7 +556,7 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Bar.new' (given 1, expected 2)"
   end
 
-  it "doesn't use initialize from base class with virtual type" do
+  it("doesn't use initialize from base class with virtual type") do
     assert_error %(
       class Foo
         def initialize(x)
@@ -574,7 +574,7 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Bar#initialize' (given 1, expected 2)"
   end
 
-  it "errors if using underscore in generic class" do
+  it("errors if using underscore in generic class") do
     assert_error %(
       class Foo(T)
       end
@@ -583,7 +583,7 @@ describe "Semantic: class" do
       ), "can't use underscore as generic type argument"
   end
 
-  it "types bug #168 (it inherits instance var even if not mentioned in initialize)" do
+  it("types bug #168 (it inherits instance var even if not mentioned in initialize)") do
     assert_error "
       class Foo
         def foo
@@ -606,7 +606,7 @@ describe "Semantic: class" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "doesn't mark instance variable as nilable if calling another initialize" do
+  it("doesn't mark instance variable as nilable if calling another initialize") do
     assert_type(%(
       class Foo
         def initialize(x, y)
@@ -626,7 +626,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "says wrong number of arguments for abstract class new" do
+  it("says wrong number of arguments for abstract class new") do
     assert_error %(
       abstract class Foo
       end
@@ -636,7 +636,7 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Foo.new' (given 1, expected 0)"
   end
 
-  it "says wrong number of arguments for abstract class new (2)" do
+  it("says wrong number of arguments for abstract class new (2)") do
     assert_error %(
       abstract class Foo
         def initialize(x)
@@ -648,7 +648,7 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Foo.new' (given 0, expected 1)"
   end
 
-  it "errors if reopening non-generic class as generic" do
+  it("errors if reopening non-generic class as generic") do
     assert_error %(
       class Foo
       end
@@ -659,7 +659,7 @@ describe "Semantic: class" do
       "Foo is not a generic class"
   end
 
-  it "errors if reopening generic class with different type vars" do
+  it("errors if reopening generic class with different type vars") do
     assert_error %(
       class Foo(T)
       end
@@ -670,7 +670,7 @@ describe "Semantic: class" do
       "type var must be T, not U"
   end
 
-  it "errors if reopening generic class with different type vars (2)" do
+  it("errors if reopening generic class with different type vars (2)") do
     assert_error %(
       class Foo(A, B)
       end
@@ -681,7 +681,7 @@ describe "Semantic: class" do
       "type vars must be A, B, not C"
   end
 
-  it "allows declaring a variable in an initialize and using it" do
+  it("allows declaring a variable in an initialize and using it") do
     assert_type(%(
       class Foo
         def initialize
@@ -698,7 +698,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "allows using self in class scope" do
+  it("allows using self in class scope") do
     assert_type(%(
       class Foo
         def self.foo
@@ -716,7 +716,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "cant't use implicit initialize if defined in parent" do
+  it("cant't use implicit initialize if defined in parent") do
     assert_error %(
       class Foo
         def initialize(x)
@@ -731,7 +731,7 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Bar.new' (given 0, expected 1)"
   end
 
-  it "doesn't error on new on abstract virtual type class" do
+  it("doesn't error on new on abstract virtual type class") do
     assert_type(%(
       abstract class Foo
       end
@@ -752,7 +752,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "says no overload matches for class new" do
+  it("says no overload matches for class new") do
     assert_error %(
       class Foo
         def self.new(x : Int32)
@@ -764,7 +764,7 @@ describe "Semantic: class" do
       "no overload matches"
   end
 
-  it "correctly types #680" do
+  it("correctly types #680") do
     assert_type(%(
       class Foo
         def initialize(@method : Int32?)
@@ -785,7 +785,7 @@ describe "Semantic: class" do
       )) { nilable int32 }
   end
 
-  it "correctly types #680 (2)" do
+  it("correctly types #680 (2)") do
     assert_error %(
       class Foo
         def initialize(@method : Int32)
@@ -807,7 +807,7 @@ describe "Semantic: class" do
       "instance variable '@method' of Foo must be Int32, not Nil"
   end
 
-  it "can invoke method on abstract type without subclasses nor instances" do
+  it("can invoke method on abstract type without subclasses nor instances") do
     assert_type(%(
       require "prelude"
 
@@ -820,7 +820,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "can invoke method on abstract generic type without subclasses nor instances" do
+  it("can invoke method on abstract generic type without subclasses nor instances") do
     assert_type(%(
       require "prelude"
 
@@ -833,7 +833,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "can invoke method on abstract generic type with subclasses but no instances" do
+  it("can invoke method on abstract generic type with subclasses but no instances") do
     assert_type(%(
       require "prelude"
 
@@ -851,7 +851,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "doesn't crash on instance variable assigned a proc, and never instantiated (#923)" do
+  it("doesn't crash on instance variable assigned a proc, and never instantiated (#923)") do
     assert_type(%(
       class Klass
         def f(arg)
@@ -862,7 +862,7 @@ describe "Semantic: class" do
       )) { nil_type }
   end
 
-  it "errors if declares class inside if" do
+  it("errors if declares class inside if") do
     assert_error %(
       if 1 == 2
         class Foo; end
@@ -871,7 +871,7 @@ describe "Semantic: class" do
       "can't declare class dynamically"
   end
 
-  it "can mark initialize as private" do
+  it("can mark initialize as private") do
     assert_error %(
       class Foo
         private def initialize
@@ -883,7 +883,7 @@ describe "Semantic: class" do
       "private method 'new' called for Foo"
   end
 
-  it "errors if creating instance before typing instance variable" do
+  it("errors if creating instance before typing instance variable") do
     assert_error %(
       class Foo
         Foo.new
@@ -898,7 +898,7 @@ describe "Semantic: class" do
       "instance variable '@x' of Foo must be Int32"
   end
 
-  it "errors if assigning superclass to declared instance var" do
+  it("errors if assigning superclass to declared instance var") do
     assert_error %(
       class Foo
       end
@@ -919,7 +919,7 @@ describe "Semantic: class" do
       "instance variable '@bar' of Main must be Bar"
   end
 
-  it "hoists instance variable initializer" do
+  it("hoists instance variable initializer") do
     assert_type(%(
       a = Foo.new.bar + 1
 
@@ -935,7 +935,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "doesn't mix classes on definition (#2352)" do
+  it("doesn't mix classes on definition (#2352)") do
     assert_type(%(
       class Baz
       end
@@ -950,7 +950,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "errors if using read-instance-var with non-typed variable" do
+  it("errors if using read-instance-var with non-typed variable") do
     assert_error %(
       class Foo
         def foo
@@ -964,7 +964,7 @@ describe "Semantic: class" do
       "Can't infer the type of instance variable '@foo' of Foo"
   end
 
-  it "doesn't crash with top-level initialize (#2601)" do
+  it("doesn't crash with top-level initialize (#2601)") do
     assert_type(%(
       def initialize
         1
@@ -974,7 +974,7 @@ describe "Semantic: class" do
       )) { int32 }
   end
 
-  it "inherits self (#2890)" do
+  it("inherits self (#2890)") do
     assert_type(%(
       class Foo
         class Bar < self
@@ -985,7 +985,7 @@ describe "Semantic: class" do
       )) { types["Foo"].metaclass }
   end
 
-  it "inherits Gen(self) (#2890)" do
+  it("inherits Gen(self) (#2890)") do
     assert_type(%(
       class Gen(T)
         def self.t
@@ -1002,7 +1002,7 @@ describe "Semantic: class" do
       )) { types["Foo"].metaclass }
   end
 
-  it "errors if inheriting Gen(self) and there's no self (#2890)" do
+  it("errors if inheriting Gen(self) and there's no self (#2890)") do
     assert_error %(
       class Gen(T)
         def self.t
@@ -1018,7 +1018,7 @@ describe "Semantic: class" do
       "there's no self in this scope"
   end
 
-  it "preserves order of instance vars (#3050)" do
+  it("preserves order of instance vars (#3050)") do
     result = semantic("
       class Foo
         @x = uninitialized Int32
@@ -1032,7 +1032,7 @@ describe "Semantic: class" do
     instance_vars.should eq(%w(@x @y))
   end
 
-  it "errors if inherits from module" do
+  it("errors if inherits from module") do
     assert_error %(
       module Moo
       end
@@ -1043,7 +1043,7 @@ describe "Semantic: class" do
       "Moo is not a class, it's a module"
   end
 
-  it "can use short name for top-level type" do
+  it("can use short name for top-level type") do
     assert_type(%(
       class T
       end
@@ -1052,7 +1052,7 @@ describe "Semantic: class" do
       )) { types["T"] }
   end
 
-  it "errors on no method found on abstract class, class method (#2241)" do
+  it("errors on no method found on abstract class, class method (#2241)") do
     assert_error %(
       abstract class Foo
       end

--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: class var" do
-  it "declares class variable" do
+describe("Semantic: class var") do
+  it("declares class variable") do
     assert_error %(
       class Foo
         @@x : Int32
@@ -17,7 +17,7 @@ describe "Semantic: class var" do
       "class variable '@@x' of Foo must be Int32, not Bool"
   end
 
-  it "declares class variable (2)" do
+  it("declares class variable (2)") do
     assert_error %(
       class Foo
         @@x : Int32
@@ -31,7 +31,7 @@ describe "Semantic: class var" do
       ),
       "class variable '@@x' of Foo is not nilable (it's Int32) so it must have an initializer"
   end
-  it "types class var" do
+  it("types class var") do
     assert_type("
       class Foo
         @@foo = 1
@@ -45,7 +45,7 @@ describe "Semantic: class var" do
       ") { int32 }
   end
 
-  it "types class var as nil if not assigned at the top level" do
+  it("types class var as nil if not assigned at the top level") do
     assert_type("
       class Foo
         def self.foo
@@ -58,7 +58,7 @@ describe "Semantic: class var" do
       ") { nilable int32 }
   end
 
-  it "types class var inside instance method" do
+  it("types class var inside instance method") do
     assert_type("
       class Foo
         @@foo = 1
@@ -72,7 +72,7 @@ describe "Semantic: class var" do
       ") { int32 }
   end
 
-  it "types class var inside proc literal inside class" do
+  it("types class var inside proc literal inside class") do
     assert_type("
       class Foo
         @@foo = 1
@@ -82,7 +82,7 @@ describe "Semantic: class var" do
       ") { int32 }
   end
 
-  it "says illegal attribute for class var" do
+  it("says illegal attribute for class var") do
     assert_error %(
       class Foo
         @[Foo]
@@ -92,7 +92,7 @@ describe "Semantic: class var" do
       "illegal attribute"
   end
 
-  it "says illegal attribute for class var assignment" do
+  it("says illegal attribute for class var assignment") do
     assert_error %(
       class Foo
         @[Foo]
@@ -102,7 +102,7 @@ describe "Semantic: class var" do
       "illegal attribute"
   end
 
-  it "allows self.class as type var in class body (#537)" do
+  it("allows self.class as type var in class body (#537)") do
     assert_type(%(
       class Bar(T)
       end
@@ -119,7 +119,7 @@ describe "Semantic: class var" do
       )) { generic_class "Bar", types["Foo"].virtual_type.metaclass }
   end
 
-  it "errors if using self as type var but there's no self" do
+  it("errors if using self as type var but there's no self") do
     assert_error %(
       class Bar(T)
       end
@@ -129,7 +129,7 @@ describe "Semantic: class var" do
       "there's no self in this scope"
   end
 
-  it "allows class var in primitive types (#612)" do
+  it("allows class var in primitive types (#612)") do
     assert_type("
       struct Int64
         @@foo = 1
@@ -143,7 +143,7 @@ describe "Semantic: class var" do
       ") { int32 }
   end
 
-  it "declares class var in generic class" do
+  it("declares class var in generic class") do
     assert_type(%(
       class Foo(T)
         @@bar = 1
@@ -157,7 +157,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "declares class var in generic module" do
+  it("declares class var in generic module") do
     assert_type(%(
       module Foo(T)
         @@bar = 1
@@ -171,7 +171,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "types class var as nil if assigned for the first time inside method (#2059)" do
+  it("types class var as nil if assigned for the first time inside method (#2059)") do
     assert_type("
       class Foo
         def self.foo
@@ -184,7 +184,7 @@ describe "Semantic: class var" do
       ") { nilable int32 }
   end
 
-  it "redefines class variable type" do
+  it("redefines class variable type") do
     assert_type(%(
       class Foo
         @@x : Int32
@@ -200,7 +200,7 @@ describe "Semantic: class var" do
       )) { union_of int32, float64 }
   end
 
-  it "infers type from number literal" do
+  it("infers type from number literal") do
     assert_type(%(
       class Foo
         @@x = 1
@@ -214,7 +214,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "infers type from T.new" do
+  it("infers type from T.new") do
     assert_type(%(
       class Foo
         class Bar
@@ -231,7 +231,7 @@ describe "Semantic: class var" do
       )) { types["Foo"].types["Bar"] }
   end
 
-  it "says undefined class variable" do
+  it("says undefined class variable") do
     assert_error "
       class Foo
         def self.foo
@@ -244,7 +244,7 @@ describe "Semantic: class var" do
       "Can't infer the type of class variable '@@foo' of Foo"
   end
 
-  it "errors if using class variable at the top level" do
+  it("errors if using class variable at the top level") do
     assert_error "
       @@foo = 1
       @@foo
@@ -252,7 +252,7 @@ describe "Semantic: class var" do
       "can't use class variables at the top level"
   end
 
-  it "errors when typing a class variable inside a method" do
+  it("errors when typing a class variable inside a method") do
     assert_error %(
       def foo
         @@x : Int32
@@ -263,7 +263,7 @@ describe "Semantic: class var" do
       "declaring the type of a class variable must be done at the class level"
   end
 
-  it "errors if using local variable in initializer" do
+  it("errors if using local variable in initializer") do
     assert_error %(
       class Foo
         @@x : Int32
@@ -275,7 +275,7 @@ describe "Semantic: class var" do
       "undefined local variable or method 'a'"
   end
 
-  it "errors on undefined constant (1)" do
+  it("errors on undefined constant (1)") do
     assert_error %(
       class Foo
         def self.foo
@@ -288,7 +288,7 @@ describe "Semantic: class var" do
       "undefined constant Bar"
   end
 
-  it "errors on undefined constant (2)" do
+  it("errors on undefined constant (2)") do
     assert_error %(
       class Foo
         @@x = Bar.new
@@ -299,7 +299,7 @@ describe "Semantic: class var" do
       "undefined constant Bar"
   end
 
-  it "infers in multiple assign for tuple type (1)" do
+  it("infers in multiple assign for tuple type (1)") do
     assert_type(%(
       class Foo
         def self.foo
@@ -321,7 +321,7 @@ describe "Semantic: class var" do
       )) { nilable int32 }
   end
 
-  it "errors when using Class (#2605)" do
+  it("errors when using Class (#2605)") do
     assert_error %(
       class Foo
         def foo(@@class : Class)
@@ -331,7 +331,7 @@ describe "Semantic: class var" do
       "can't use Class as the type of class variable @@class of Foo, use a more specific type"
   end
 
-  it "gives correct error when trying to use Int as a class variable type" do
+  it("gives correct error when trying to use Int as a class variable type") do
     assert_error %(
       class Foo
         @@x : Int
@@ -340,7 +340,7 @@ describe "Semantic: class var" do
       "can't use Int as the type of a class variable yet, use a more specific type"
   end
 
-  it "can find class var in subclass" do
+  it("can find class var in subclass") do
     assert_type(%(
       class Foo
         @@var = 1
@@ -356,7 +356,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "can find class var through included module" do
+  it("can find class var through included module") do
     assert_type(%(
       module Moo
         @@var = 1
@@ -374,7 +374,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "errors if redefining class var type in subclass" do
+  it("errors if redefining class var type in subclass") do
     assert_error %(
       class Foo
         @@x : Int32
@@ -387,7 +387,7 @@ describe "Semantic: class var" do
       "class variable '@@x' of Bar is already defined as Int32 in Foo"
   end
 
-  it "errors if redefining class var type in subclass, with guess" do
+  it("errors if redefining class var type in subclass, with guess") do
     assert_error %(
       class Foo
         @@x = 1
@@ -400,7 +400,7 @@ describe "Semantic: class var" do
       "class variable '@@x' of Bar is already defined as Int32 in Foo"
   end
 
-  it "errors if redefining class var type in included module" do
+  it("errors if redefining class var type in included module") do
     assert_error %(
       module Moo
         @@x : Int32
@@ -415,7 +415,7 @@ describe "Semantic: class var" do
       "class variable '@@x' of Bar is already defined as Int32 in Moo"
   end
 
-  it "declares uninitialized (#2935)" do
+  it("declares uninitialized (#2935)") do
     assert_type(%(
       class Foo
         @@x = uninitialized Int32
@@ -429,7 +429,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "doesn't error if accessing class variable before defined (#2941)" do
+  it("doesn't error if accessing class variable before defined (#2941)") do
     assert_type(%(
       class Bar
         @@x : Baz = Foo.x
@@ -457,7 +457,7 @@ describe "Semantic: class var" do
       )) { int32 }
   end
 
-  it "doesn't error on recursive depdendency if var is nilable (#2943)" do
+  it("doesn't error on recursive depdendency if var is nilable (#2943)") do
     assert_type(%(
       class Foo
         @@foo : Int32?
@@ -476,7 +476,7 @@ describe "Semantic: class var" do
       )) { nilable int32 }
   end
 
-  it "types as nilable if doesn't have initializer" do
+  it("types as nilable if doesn't have initializer") do
     assert_type(%(
       class Foo
         def self.x
@@ -489,7 +489,7 @@ describe "Semantic: class var" do
       )) { nilable int32 }
   end
 
-  it "errors if class variable not nilable without initializer" do
+  it("errors if class variable not nilable without initializer") do
     assert_error %(
       class Foo
         @@foo : Int32
@@ -498,7 +498,7 @@ describe "Semantic: class var" do
       "class variable '@@foo' of Foo is not nilable (it's Int32) so it must have an initializer"
   end
 
-  it "can assign to class variable if this type can be up-casted to ancestors class variable type (#4869)" do
+  it("can assign to class variable if this type can be up-casted to ancestors class variable type (#4869)") do
     assert_type(%(
       class Foo
         @@x : Int32?

--- a/spec/compiler/semantic/cleanup_spec.cr
+++ b/spec/compiler/semantic/cleanup_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "cleanup" do
-  it "errors if assigning var to itself" do
+describe("cleanup") do
+  it("errors if assigning var to itself") do
     assert_error "a = 1; a = a", "expression has no effect"
   end
 
-  it "errors if assigning instance var to itself" do
+  it("errors if assigning instance var to itself") do
     assert_error %(
       class Foo
         def initialize

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -1,29 +1,29 @@
 require "../../spec_helper"
 
-describe "Semantic: closure" do
-  it "gives error when doing yield inside proc literal" do
+describe("Semantic: closure") do
+  it("gives error when doing yield inside proc literal") do
     assert_error "-> { yield }", "can't use `yield` outside a method"
   end
 
-  it "gives error when doing yield inside proc literal" do
+  it("gives error when doing yield inside proc literal") do
     assert_error "def foo; -> { yield }; end; foo {}", "can't use `yield` inside a proc literal or captured block"
   end
 
-  it "marks variable as closured in program" do
+  it("marks variable as closured in program") do
     result = assert_type("x = 1; -> { x }; x") { int32 }
     program = result.program
     var = program.vars["x"]
     var.closured?.should be_true
   end
 
-  it "marks variable as closured in program on assign" do
+  it("marks variable as closured in program on assign") do
     result = assert_type("x = 1; -> { x = 1 }; x") { int32 }
     program = result.program
     var = program.vars["x"]
     var.closured?.should be_true
   end
 
-  it "marks variable as closured in def" do
+  it("marks variable as closured in def") do
     result = assert_type("def foo; x = 1; -> { x }; 1; end; foo") { int32 }
     node = result.node.as(Expressions)
     call = node.expressions.last.as(Call)
@@ -32,7 +32,7 @@ describe "Semantic: closure" do
     var.closured?.should be_true
   end
 
-  it "marks variable as closured in block" do
+  it("marks variable as closured in block") do
     result = assert_type("
       def foo
         yield
@@ -51,7 +51,7 @@ describe "Semantic: closure" do
     var.closured?.should be_true
   end
 
-  it "unifies types of closured var (1)" do
+  it("unifies types of closured var (1)") do
     assert_type("
       a = 1
       f = -> { a }
@@ -60,7 +60,7 @@ describe "Semantic: closure" do
       ") { union_of(int32, float64) }
   end
 
-  it "unifies types of closured var (2)" do
+  it("unifies types of closured var (2)") do
     assert_type("
       a = 1
       f = -> { a }
@@ -69,7 +69,7 @@ describe "Semantic: closure" do
       ") { union_of(int32, float64) }
   end
 
-  it "marks variable as closured inside block in fun" do
+  it("marks variable as closured inside block in fun") do
     result = assert_type("
       def foo
         yield
@@ -84,7 +84,7 @@ describe "Semantic: closure" do
     var.closured?.should be_true
   end
 
-  it "doesn't mark var as closured if only used in block" do
+  it("doesn't mark var as closured if only used in block") do
     result = assert_type("
       x = 1
 
@@ -99,7 +99,7 @@ describe "Semantic: closure" do
     var.closured?.should be_false
   end
 
-  it "doesn't mark var as closured if only used in two block" do
+  it("doesn't mark var as closured if only used in two block") do
     result = assert_type("
       def foo
         yield
@@ -119,7 +119,7 @@ describe "Semantic: closure" do
     var.closured?.should be_false
   end
 
-  it "doesn't mark self var as closured, but marks method as self closured" do
+  it("doesn't mark self var as closured, but marks method as self closured") do
     result = assert_type("
       class Foo
         def foo
@@ -138,7 +138,7 @@ describe "Semantic: closure" do
     target_def.self_closured?.should be_true
   end
 
-  it "marks method as self closured if instance var is read" do
+  it("marks method as self closured if instance var is read") do
     result = assert_type("
       class Foo
         @x : Int32?
@@ -156,7 +156,7 @@ describe "Semantic: closure" do
     call.target_def.self_closured?.should be_true
   end
 
-  it "marks method as self closured if instance var is written" do
+  it("marks method as self closured if instance var is written") do
     result = assert_type("
       class Foo
         def foo
@@ -172,7 +172,7 @@ describe "Semantic: closure" do
     call.target_def.self_closured?.should be_true
   end
 
-  it "marks method as self closured if explicit self call is made" do
+  it("marks method as self closured if explicit self call is made") do
     result = assert_type("
       class Foo
         def foo
@@ -191,7 +191,7 @@ describe "Semantic: closure" do
     call.target_def.self_closured?.should be_true
   end
 
-  it "marks method as self closured if implicit self call is made" do
+  it("marks method as self closured if implicit self call is made") do
     result = assert_type("
       class Foo
         def foo
@@ -210,7 +210,7 @@ describe "Semantic: closure" do
     call.target_def.self_closured?.should be_true
   end
 
-  it "marks method as self closured if used inside a block" do
+  it("marks method as self closured if used inside a block") do
     result = assert_type("
       def bar
         yield
@@ -230,7 +230,7 @@ describe "Semantic: closure" do
     call.target_def.self_closured?.should be_true
   end
 
-  it "errors if sending closured proc literal to C" do
+  it("errors if sending closured proc literal to C") do
     assert_error %(
       lib LibC
         fun foo(callback : ->)
@@ -242,7 +242,7 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: a)"
   end
 
-  it "errors if sending closured proc pointer to C (1)" do
+  it("errors if sending closured proc pointer to C (1)") do
     assert_error %(
       lib LibC
         fun foo(callback : ->)
@@ -262,7 +262,7 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: self)"
   end
 
-  it "errors if sending closured proc pointer to C (2)" do
+  it("errors if sending closured proc pointer to C (2)") do
     assert_error %(
       lib LibC
         fun foo(callback : ->)
@@ -279,7 +279,7 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: self)"
   end
 
-  it "errors if sending closured proc pointer to C (3)" do
+  it("errors if sending closured proc pointer to C (3)") do
     assert_error %(
       lib LibC
         fun foo(callback : ->)
@@ -300,7 +300,7 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: @a)"
   end
 
-  it "transforms block to proc literal" do
+  it("transforms block to proc literal") do
     assert_type("
       def foo(&block : Int32 -> Float64)
         block.call(1)
@@ -312,7 +312,7 @@ describe "Semantic: closure" do
       ") { float64 }
   end
 
-  it "transforms block to proc literal with void type" do
+  it("transforms block to proc literal with void type") do
     assert_type("
       def foo(&block : Int32 -> )
         block.call(1)
@@ -324,7 +324,7 @@ describe "Semantic: closure" do
       ") { nil_type }
   end
 
-  it "errors when transforming block to proc literal if type mismatch" do
+  it("errors when transforming block to proc literal if type mismatch") do
     assert_error "
       def foo(&block : Int32 -> Int32)
         block.call(1)
@@ -337,7 +337,7 @@ describe "Semantic: closure" do
       "expected block to return Int32, not Float64"
   end
 
-  it "transforms block to proc literal with free var" do
+  it("transforms block to proc literal with free var") do
     assert_type("
       def foo(&block : Int32 -> U) forall U
         block.call(1)
@@ -349,7 +349,7 @@ describe "Semantic: closure" do
       ") { float64 }
   end
 
-  it "transforms block to proc literal without arguments" do
+  it("transforms block to proc literal without arguments") do
     assert_type("
       def foo(&block : -> U) forall U
         block.call
@@ -361,7 +361,7 @@ describe "Semantic: closure" do
       ") { float64 }
   end
 
-  it "errors if giving more block args when transforming block to proc literal" do
+  it("errors if giving more block args when transforming block to proc literal") do
     assert_error "
       def foo(&block : -> U)
         block.call
@@ -374,7 +374,7 @@ describe "Semantic: closure" do
       "wrong number of block arguments (given 1, expected 0)"
   end
 
-  it "allows giving less block args when transforming block to proc literal" do
+  it("allows giving less block args when transforming block to proc literal") do
     assert_type("
       def foo(&block : Int32 -> U) forall U
         block.call(1)
@@ -386,7 +386,7 @@ describe "Semantic: closure" do
       ") { float64 }
   end
 
-  it "allows passing block as proc literal to new and to initialize" do
+  it("allows passing block as proc literal to new and to initialize") do
     assert_type("
       class Foo
         def initialize(&block : Int32 -> Float64)
@@ -403,7 +403,7 @@ describe "Semantic: closure" do
       ") { proc_of(int32, float64) }
   end
 
-  it "errors if forwaring block arg doesn't match input type" do
+  it("errors if forwaring block arg doesn't match input type") do
     assert_error "
       def foo(&block : Int32 -> U)
         block
@@ -415,7 +415,7 @@ describe "Semantic: closure" do
       "expected block argument's argument #1 to be Int32, not Int64"
   end
 
-  it "errors if forwaring block arg doesn't match input type size" do
+  it("errors if forwaring block arg doesn't match input type size") do
     assert_error "
       def foo(&block : Int32, Int32 -> U)
         block
@@ -427,7 +427,7 @@ describe "Semantic: closure" do
       "wrong number of block argument's arguments (given 1, expected 2)"
   end
 
-  it "lookups return type in correct scope" do
+  it("lookups return type in correct scope") do
     assert_type("
       module Mod
         def foo(&block : Int32 -> T) forall T
@@ -443,7 +443,7 @@ describe "Semantic: closure" do
       ") { proc_of(int32, float64) }
   end
 
-  it "passes #227" do
+  it("passes #227") do
     result = assert_type(%(
       ->{ a = 1; ->{ a } }
       ), inject_primitives: false) { proc_of(proc_of(int32)) }
@@ -451,7 +451,7 @@ describe "Semantic: closure" do
     fn.def.closure?.should be_false
   end
 
-  it "marks outer fun inside a block as closured" do
+  it("marks outer fun inside a block as closured") do
     result = assert_type(%(
       def foo
         yield
@@ -464,7 +464,7 @@ describe "Semantic: closure" do
     fn.def.closure?.should be_true
   end
 
-  it "marks outer fun as closured when using self" do
+  it("marks outer fun as closured when using self") do
     result = assert_type(%(
       class Foo
         def foo
@@ -481,7 +481,7 @@ describe "Semantic: closure" do
     fn.def.closure?.should be_true
   end
 
-  it "can use fun typedef as block type" do
+  it("can use fun typedef as block type") do
     assert_type(%(
       lib LibC
         alias F = Int32 -> Int32
@@ -495,7 +495,7 @@ describe "Semantic: closure" do
       )) { proc_of(int32, int32) }
   end
 
-  it "says can't send closure to C with new notation" do
+  it("says can't send closure to C with new notation") do
     assert_error %(
       lib LibC
         fun foo(x : ->)
@@ -509,7 +509,7 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: a)"
   end
 
-  it "doesn't crash for non-existing variable (#3789)" do
+  it("doesn't crash for non-existing variable (#3789)") do
     assert_error %(
       lib LibFoo
         fun foo(->)

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -1,22 +1,22 @@
 require "../../spec_helper"
 
-describe "Semantic: const" do
-  it "types a constant" do
+describe("Semantic: const") do
+  it("types a constant") do
     input = parse("CONST = 1").as(Assign)
     result = semantic input
     mod = result.program
     input.target.type?.should be_nil # Don't type value until needed
   end
 
-  it "types a constant reference" do
+  it("types a constant reference") do
     assert_type("CONST = 1; CONST") { int32 }
   end
 
-  it "types a nested constant" do
+  it("types a nested constant") do
     assert_type("class Foo; A = 1; end; Foo::A") { int32 }
   end
 
-  it "types a constant inside a def" do
+  it("types a constant inside a def") do
     assert_type("
       class Foo
         A = 1
@@ -30,7 +30,7 @@ describe "Semantic: const" do
       ") { int32 }
   end
 
-  it "finds nearest constant first" do
+  it("finds nearest constant first") do
     assert_type("
       CONST = 1
 
@@ -46,7 +46,7 @@ describe "Semantic: const" do
       ") { float64 }
   end
 
-  it "finds current type first" do
+  it("finds current type first") do
     assert_type("
       class Foo
         class Bar
@@ -64,7 +64,7 @@ describe "Semantic: const" do
       ") { int32 }
   end
 
-  it "types a global constant reference in method" do
+  it("types a global constant reference in method") do
     assert_type("
       FOO = 2.5
 
@@ -80,7 +80,7 @@ describe "Semantic: const" do
       ") { float64 }
   end
 
-  it "types a global constant reference in static method" do
+  it("types a global constant reference in static method") do
     assert_type("
       CONST = 2.5
 
@@ -96,12 +96,12 @@ describe "Semantic: const" do
       ") { int32 }
   end
 
-  it "doesn't share variables with global scope" do
+  it("doesn't share variables with global scope") do
     assert_error "a = 1; CONST = a; CONST",
       "undefined local variable or method 'a'"
   end
 
-  it "finds const from restriction" do
+  it("finds const from restriction") do
     assert_type("
       struct Int32
         FOO = 'a'
@@ -115,7 +115,7 @@ describe "Semantic: const" do
       ") { char }
   end
 
-  it "doesn't crash with const used in initialize (bug)" do
+  it("doesn't crash with const used in initialize (bug)") do
     assert_type("
       COCO = init_coco
 
@@ -135,7 +135,7 @@ describe "Semantic: const" do
       ") { int32 }
   end
 
-  it "finds constant in module that includes module (#205)" do
+  it("finds constant in module that includes module (#205)") do
     assert_type(%(
       module Foo
         CONSTANT = true
@@ -149,7 +149,7 @@ describe "Semantic: const" do
       )) { bool }
   end
 
-  it "finds constant in class that extends class (#205)" do
+  it("finds constant in class that extends class (#205)") do
     assert_type(%(
       class Foo
         CONSTANT = true
@@ -163,7 +163,7 @@ describe "Semantic: const" do
   end
 
   ["nil", "true", "1", "'a'", %("foo"), "+ 1", "- 2", "~ 2", "1 + 2", "1 + ZED"].each do |node|
-    it "doesn't errors if constant depends on another one defined later through method, but constant is simple (#{node})" do
+    it("doesn't errors if constant depends on another one defined later through method, but constant is simple (#{node})") do
       semantic(%(
         ZED = 10
 
@@ -185,7 +185,7 @@ describe "Semantic: const" do
     end
   end
 
-  it "doesn't error if using c enum" do
+  it("doesn't error if using c enum") do
     assert_type(%(
       lib LibC
         enum Foo
@@ -197,7 +197,7 @@ describe "Semantic: const" do
       )) { types["LibC"].types["Foo"] }
   end
 
-  it "errors on dynamic constant assignment inside block" do
+  it("errors on dynamic constant assignment inside block") do
     assert_error %(
       def foo
         yield
@@ -210,7 +210,7 @@ describe "Semantic: const" do
       "can't declare constant dynamically"
   end
 
-  it "errors on dynamic constant assignment inside if" do
+  it("errors on dynamic constant assignment inside if") do
     assert_error %(
       if 1 == 1
         CONST = 1
@@ -219,7 +219,7 @@ describe "Semantic: const" do
       "can't declare constant dynamically"
   end
 
-  it "can use constant defined later (#2906)" do
+  it("can use constant defined later (#2906)") do
     assert_type(%(
       FOO = Foo.new
 
@@ -238,7 +238,7 @@ describe "Semantic: const" do
       )) { types["Foo"] }
   end
 
-  it "errors if can't infer constant type (#3240, #3948)" do
+  it("errors if can't infer constant type (#3240, #3948)") do
     assert_error %(
       A = A.b
       A
@@ -246,7 +246,7 @@ describe "Semantic: const" do
       "can't infer type of constant A"
   end
 
-  it "errors if using constant as generic type (#3240)" do
+  it("errors if using constant as generic type (#3240)") do
     assert_error %(
       Foo = Foo(Int32).new
       Foo
@@ -254,7 +254,7 @@ describe "Semantic: const" do
       "Foo is not a type, it's a constant"
   end
 
-  it "errors if using const in type declaration" do
+  it("errors if using const in type declaration") do
     assert_error %(
       A = 1
 
@@ -265,7 +265,7 @@ describe "Semantic: const" do
       "A is not a type, it's a constant"
   end
 
-  it "errors if using const in unintialized" do
+  it("errors if using const in unintialized") do
     assert_error %(
       A = 1
 
@@ -274,7 +274,7 @@ describe "Semantic: const" do
       "A is not a type, it's a constant"
   end
 
-  it "errors if using const in var declaration" do
+  it("errors if using const in var declaration") do
     assert_error %(
       A = 1
 
@@ -283,7 +283,7 @@ describe "Semantic: const" do
       "A is not a type, it's a constant"
   end
 
-  it "errors if using const in restriction" do
+  it("errors if using const in restriction") do
     assert_error %(
       A = 1
 

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Semantic: def overload" do
-  it "types a call with overload" do
+describe("Semantic: def overload") do
+  it("types a call with overload") do
     assert_type("def foo; 1; end; def foo(x); 2.5; end; foo") { int32 }
   end
 
-  it "types a call with overload with yield" do
+  it("types a call with overload with yield") do
     assert_type("def foo; yield; 1; end; def foo; 2.5; end; foo") { float64 }
   end
 
-  it "types a call with overload with yield after typing another call without yield" do
+  it("types a call with overload with yield after typing another call without yield") do
     assert_type("
       def foo; yield; 1; end
       def foo; 2.5; end
@@ -18,19 +18,19 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "types a call with overload with yield the other way" do
+  it("types a call with overload with yield the other way") do
     assert_type("def foo; yield; 1; end; def foo; 2.5; end; foo { 1 }") { int32 }
   end
 
-  it "types a call with overload type first overload" do
+  it("types a call with overload type first overload") do
     assert_type("def foo(x : Int); 2.5; end; def foo(x : Float); 1; end; foo(1)") { float64 }
   end
 
-  it "types a call with overload type second overload" do
+  it("types a call with overload type second overload") do
     assert_type("def foo(x : Int); 2.5; end; def foo(x : Float); 1; end; foo(1.5)") { int32 }
   end
 
-  it "types a call with overload Object type first overload" do
+  it("types a call with overload Object type first overload") do
     assert_type("
       class Foo
       end
@@ -50,11 +50,11 @@ describe "Semantic: def overload" do
       ") { float64 }
   end
 
-  it "types a call with overload selecting the most restrictive" do
+  it("types a call with overload selecting the most restrictive") do
     assert_type("def foo(x); 1; end; def foo(x : Float); 1.1; end; foo(1.5)") { float64 }
   end
 
-  it "types a call with overload selecting the most restrictive 2" do
+  it("types a call with overload selecting the most restrictive 2") do
     assert_type("
       def foo(x, y : Int)
         1
@@ -72,7 +72,7 @@ describe "Semantic: def overload" do
     ") { char }
   end
 
-  it "types a call with overload matches virtual" do
+  it("types a call with overload matches virtual") do
     assert_type("
       class Foo; end
 
@@ -84,7 +84,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "types a call with overload matches virtual 2" do
+  it("types a call with overload matches virtual 2") do
     assert_type("
       class Foo
       end
@@ -104,7 +104,7 @@ describe "Semantic: def overload" do
     ") { float64 }
   end
 
-  it "types a call with overload matches virtual 3" do
+  it("types a call with overload matches virtual 3") do
     assert_type("
       class Foo
       end
@@ -124,7 +124,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "types a call with overload self" do
+  it("types a call with overload self") do
     assert_type("
       class Foo
         def foo(x : self)
@@ -141,7 +141,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "types a call with overload self other match" do
+  it("types a call with overload self other match") do
     assert_type("
       class Foo
         def foo(x : self)
@@ -158,7 +158,7 @@ describe "Semantic: def overload" do
     ") { float64 }
   end
 
-  it "types a call with overload self in included module" do
+  it("types a call with overload self in included module") do
     assert_type("
       module Foo
         def foo(x : self)
@@ -181,7 +181,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "types a call with overload self in included module other type" do
+  it("types a call with overload self in included module other type") do
     assert_type("
       module Foo
         def foo(x : self)
@@ -204,7 +204,7 @@ describe "Semantic: def overload" do
     ") { float64 }
   end
 
-  it "types a call with overload self with inherited type" do
+  it("types a call with overload self with inherited type") do
     assert_type("
       class Foo
         def foo(x : self)
@@ -220,7 +220,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "matches types with free variables" do
+  it("matches types with free variables") do
     assert_type("
       require \"prelude\"
       def foo(x : Array(T), y : T) forall T
@@ -235,7 +235,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "prefers more specifc overload than one with free variables" do
+  it("prefers more specifc overload than one with free variables") do
     assert_type("
       require \"prelude\"
       def foo(x : Array(T), y : T)
@@ -250,7 +250,7 @@ describe "Semantic: def overload" do
     ") { float64 }
   end
 
-  it "accepts overload with nilable type restriction" do
+  it("accepts overload with nilable type restriction") do
     assert_type("
       def foo(x : Int?)
         1
@@ -260,7 +260,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "dispatch call to def with restrictions" do
+  it("dispatch call to def with restrictions") do
     assert_type("
       def foo(x : Value)
         1.1
@@ -275,7 +275,7 @@ describe "Semantic: def overload" do
     ") { union_of(int32, float64) }
   end
 
-  it "dispatch call to def with restrictions" do
+  it("dispatch call to def with restrictions") do
     assert_type("
       class Foo(T)
       end
@@ -288,7 +288,7 @@ describe "Semantic: def overload" do
     ") { generic_class "Foo", int32 }
   end
 
-  it "can call overload with generic restriction" do
+  it("can call overload with generic restriction") do
     assert_type("
       class Foo(T)
       end
@@ -301,7 +301,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "can call overload with aliased generic restriction" do
+  it("can call overload with aliased generic restriction") do
     assert_type("
       class Foo(T)
       end
@@ -316,7 +316,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "restrict matches to minimum necessary 1" do
+  it("restrict matches to minimum necessary 1") do
     assert_type("
       def coco(x : Int, y); 1; end
       def coco(x, y : Int); 1.5; end
@@ -326,7 +326,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "single type restriction wins over union" do
+  it("single type restriction wins over union") do
     assert_type("
       class Foo; end
       class Bar < Foo ;end
@@ -343,7 +343,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "compare self type with others" do
+  it("compare self type with others") do
     assert_type("
       class Foo
         def foo(x : Int)
@@ -359,7 +359,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "uses method defined in base class if the restriction doesn't match" do
+  it("uses method defined in base class if the restriction doesn't match") do
     assert_type("
       class Foo
         def foo(x)
@@ -377,7 +377,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "lookup matches in virtual type inside union" do
+  it("lookup matches in virtual type inside union") do
     assert_type("
       class Foo
         def foo
@@ -399,7 +399,7 @@ describe "Semantic: def overload" do
     ") { union_of(int32, char) }
   end
 
-  it "filter union type with virtual" do
+  it("filter union type with virtual") do
     assert_type("
       class Foo
       end
@@ -422,7 +422,7 @@ describe "Semantic: def overload" do
     ") { union_of(int32, float64) }
   end
 
-  it "restrict virtual type with virtual type" do
+  it("restrict virtual type with virtual type") do
     assert_type("
       def foo(x : T, y : T) forall T
         1
@@ -439,7 +439,7 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
-  it "restricts union to generic class" do
+  it("restricts union to generic class") do
     assert_type("
       class Foo(T)
       end
@@ -457,7 +457,7 @@ describe "Semantic: def overload" do
     ") { union_of(int32, char) }
   end
 
-  it "matches on partial union" do
+  it("matches on partial union") do
     assert_type("
       require \"prelude\"
 
@@ -475,7 +475,7 @@ describe "Semantic: def overload" do
     ") { union_of(int32, char) }
   end
 
-  pending "restricts on generic type with free type arg" do
+  pending("restricts on generic type with free type arg") do
     assert_type("
       require \"reference\"
 
@@ -496,7 +496,7 @@ describe "Semantic: def overload" do
       ") { union_of(bool, int32) }
   end
 
-  pending "restricts on generic type without type arg" do
+  pending("restricts on generic type without type arg") do
     assert_type("
       require \"reference\"
 
@@ -517,7 +517,7 @@ describe "Semantic: def overload" do
     ") { union_of(bool, int32) }
   end
 
-  it "matches generic class instance type with another one" do
+  it("matches generic class instance type with another one") do
     assert_type("
       require \"prelude\"
       class Foo
@@ -532,7 +532,7 @@ describe "Semantic: def overload" do
       ") { int32 }
   end
 
-  it "errors if generic type doesn't match" do
+  it("errors if generic type doesn't match") do
     assert_error "
       class Foo(T)
       end
@@ -545,7 +545,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "gets free variable from union restriction" do
+  it("gets free variable from union restriction") do
     assert_type("
       def foo(x : Nil | U) forall U
         U
@@ -555,7 +555,7 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
-  it "gets free variable from union restriction (2)" do
+  it("gets free variable from union restriction (2)") do
     assert_type("
       def foo(x : Nil | U) forall U
         U
@@ -565,7 +565,7 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
-  it "gets free variable from union restriction without a union" do
+  it("gets free variable from union restriction without a union") do
     assert_type("
       def foo(x : Nil | U) forall U
         U
@@ -575,7 +575,7 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
-  it "matches a generic module argument" do
+  it("matches a generic module argument") do
     assert_type("
       module Bar(T)
       end
@@ -592,7 +592,7 @@ describe "Semantic: def overload" do
       ") { int32 }
   end
 
-  it "matches a generic module argument with free var" do
+  it("matches a generic module argument with free var") do
     assert_type("
       module Bar(T)
       end
@@ -609,7 +609,7 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
-  it "matches a generic module argument with free var (2)" do
+  it("matches a generic module argument with free var (2)") do
     assert_type("
       module Bar(T)
       end
@@ -626,7 +626,7 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
-  it "matches virtual type to union" do
+  it("matches virtual type to union") do
     assert_type("
       abstract class Foo
       end
@@ -646,7 +646,7 @@ describe "Semantic: def overload" do
       ") { int32 }
   end
 
-  it "doesn't match tuples of different sizes" do
+  it("doesn't match tuples of different sizes") do
     assert_error "
       def foo(x : {X, Y, Z})
         'a'
@@ -657,7 +657,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "matches tuples of different sizes" do
+  it("matches tuples of different sizes") do
     assert_type("
       def foo(x : {X, Y}) forall X, Y
         1
@@ -672,7 +672,7 @@ describe "Semantic: def overload" do
       ") { union_of(int32, char) }
   end
 
-  it "matches tuples and uses free var" do
+  it("matches tuples and uses free var") do
     assert_type("
       def foo(x : {X, Y}) forall X, Y
         Y
@@ -682,7 +682,7 @@ describe "Semantic: def overload" do
       ") { float64.metaclass }
   end
 
-  it "matches tuple with underscore" do
+  it("matches tuple with underscore") do
     assert_type("
       def foo(x : {_, _})
         x
@@ -692,7 +692,7 @@ describe "Semantic: def overload" do
       ") { tuple_of([int32, float64] of Type) }
   end
 
-  it "gives correct error message, looking up parent defs, when no overload matches" do
+  it("gives correct error message, looking up parent defs, when no overload matches") do
     assert_error %(
       class Foo
         def foo(x : Int32)
@@ -709,7 +709,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "doesn't match with wrong number of type arguments (#313)" do
+  it("doesn't match with wrong number of type arguments (#313)") do
     assert_error %(
       class Foo(A, B)
       end
@@ -722,7 +722,7 @@ describe "Semantic: def overload" do
       "wrong number of type vars for Foo(A, B) (given 1, expected 2)"
   end
 
-  it "includes splat symbol in error message" do
+  it("includes splat symbol in error message") do
     assert_error %(
       def foo(x : Int32, *bar)
       end
@@ -732,7 +732,7 @@ describe "Semantic: def overload" do
       "foo(x : Int32, *bar)"
   end
 
-  it "says `no overload matches` instead of `can't instantiate abstract class` on wrong argument in new method" do
+  it("says `no overload matches` instead of `can't instantiate abstract class` on wrong argument in new method") do
     assert_error %(
       abstract class Foo
         def self.new(x : Int)
@@ -744,7 +744,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "finds method after including module in generic module (#1201)" do
+  it("finds method after including module in generic module (#1201)") do
     assert_type(%(
       module Bar
         def foo
@@ -771,7 +771,7 @@ describe "Semantic: def overload" do
       )) { char }
   end
 
-  it "reports no overload matches with correct method owner (#2083)" do
+  it("reports no overload matches with correct method owner (#2083)") do
     assert_error %(
       class Foo
         def foo(x : Int32)
@@ -793,7 +793,7 @@ describe "Semantic: def overload" do
       MSG
   end
 
-  it "gives better error message with consecutive arguments sizes" do
+  it("gives better error message with consecutive arguments sizes") do
     assert_error %(
       def foo
       end
@@ -809,7 +809,7 @@ describe "Semantic: def overload" do
       "wrong number of arguments for 'foo' (given 3, expected 0..2)"
   end
 
-  it "errors if no overload matches on union against named arg (#2640)" do
+  it("errors if no overload matches on union against named arg (#2640)") do
     assert_error %(
       def f(a : Int32)
       end
@@ -820,7 +820,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "dispatches with named arg" do
+  it("dispatches with named arg") do
     assert_type(%(
       def f(a : Int32, b : Int32)
         true
@@ -835,7 +835,7 @@ describe "Semantic: def overload" do
       )) { union_of bool, char }
   end
 
-  it "uses long name when no overload matches and name is the same (#1030)" do
+  it("uses long name when no overload matches and name is the same (#1030)") do
     assert_error %(
       module Moo::String
         def self.foo(a : String, b : Bool)
@@ -848,7 +848,7 @@ describe "Semantic: def overload" do
       " - Moo::String.foo(a : Moo::String, b : Bool)"
   end
 
-  it "overloads on metaclass (#2916)" do
+  it("overloads on metaclass (#2916)") do
     assert_type(%(
       def foo(x : String.class)
         1
@@ -862,7 +862,7 @@ describe "Semantic: def overload" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "overloads on metaclass (2) (#2916)" do
+  it("overloads on metaclass (2) (#2916)") do
     assert_type(%(
       def foo(x : String.class)
         1
@@ -876,7 +876,7 @@ describe "Semantic: def overload" do
       )) { char }
   end
 
-  it "overloads on metaclass (3) (#2916)" do
+  it("overloads on metaclass (3) (#2916)") do
     assert_type(%(
       class Foo
       end
@@ -896,7 +896,7 @@ describe "Semantic: def overload" do
       )) { tuple_of([char, int32]) }
   end
 
-  it "doesn't crash on unknown metaclass" do
+  it("doesn't crash on unknown metaclass") do
     assert_type(%(
       def foo(x : Foo.class)
       end
@@ -908,7 +908,7 @@ describe "Semantic: def overload" do
       )) { int32 }
   end
 
-  it "overloads union against non-union (#2904)" do
+  it("overloads union against non-union (#2904)") do
     assert_type(%(
       def foo(x : Int32?)
         true
@@ -922,7 +922,7 @@ describe "Semantic: def overload" do
       )) { tuple_of([char, bool]) }
   end
 
-  it "errors when binding free variable to different types" do
+  it("errors when binding free variable to different types") do
     assert_error %(
       def foo(x : T, y : T) forall T
       end
@@ -932,7 +932,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "errors when binding free variable to different types (2)" do
+  it("errors when binding free variable to different types (2)") do
     assert_error %(
       class Gen(T)
       end
@@ -945,7 +945,7 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
-  it "overloads with named argument (#4465)" do
+  it("overloads with named argument (#4465)") do
     assert_type(%(
 			def do_something(value : Int32)
 			  value + 1

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Semantic: def" do
-  it "types a call with an int" do
+describe("Semantic: def") do
+  it("types a call with an int") do
     assert_type("def foo; 1; end; foo") { int32 }
   end
 
-  it "types a call with a float" do
+  it("types a call with a float") do
     assert_type("def foo; 2.3f32; end; foo") { float32 }
   end
 
-  it "types a call with a double" do
+  it("types a call with a double") do
     assert_type("def foo; 2.3; end; foo") { float64 }
   end
 
-  it "types a call with an argument" do
+  it("types a call with an argument") do
     assert_type("def foo(x); x; end; foo 1") { int32 }
   end
 
-  it "types a call with an argument" do
+  it("types a call with an argument") do
     input = parse "def foo(x); x; end; foo 1; foo 2.3"
     result = semantic input
     mod, input = result.program, result.node.as(Expressions)
@@ -26,70 +26,70 @@ describe "Semantic: def" do
     input[2].type.should eq(mod.float64)
   end
 
-  it "types a call with an argument uses a new scope" do
+  it("types a call with an argument uses a new scope") do
     assert_type("x = 2.3; def foo(x); x; end; foo 1; x") { float64 }
   end
 
-  it "assigns def owner" do
+  it("assigns def owner") do
     input = parse "struct Int; def foo; 2.5; end; end; 1.foo"
     result = semantic input
     mod, input = result.program, result.node.as(Expressions)
     input.last.as(Call).target_def.owner.should eq(mod.int32)
   end
 
-  it "types putchar with Char" do
+  it("types putchar with Char") do
     assert_type("lib LibC; fun putchar(c : Char) : Char; end; LibC.putchar 'a'") { char }
   end
 
-  it "types getchar with Char" do
+  it("types getchar with Char") do
     assert_type("lib LibC; fun getchar : Char; end; LibC.getchar") { char }
   end
 
-  it "allows recursion" do
+  it("allows recursion") do
     assert_type("def foo; foo; end; foo") { no_return }
   end
 
-  it "allows recursion with arg" do
+  it("allows recursion with arg") do
     assert_type("def foo(x); foo(x); end; foo 1") { no_return }
   end
 
-  it "types simple recursion" do
+  it("types simple recursion") do
     assert_type("def foo(x); if x > 0; foo(x - 1) + 1; else; 1; end; end; foo(5)") { int32 }
   end
 
-  it "types simple recursion 2" do
+  it("types simple recursion 2") do
     assert_type("def foo(x); if x > 0; 1 + foo(x - 1); else; 1; end; end; foo(5)") { int32 }
   end
 
-  it "types mutual recursion" do
+  it("types mutual recursion") do
     assert_type("def foo(x); if 1 == 1; bar(x); else; 1; end; end; def bar(x); foo(x); end; foo(5)") { int32 }
   end
 
-  it "types empty body def" do
+  it("types empty body def") do
     assert_type("def foo; end; foo") { nil_type }
   end
 
-  it "types mutual infinite recursion" do
+  it("types mutual infinite recursion") do
     assert_type("def foo; bar; end; def bar; foo; end; foo") { no_return }
   end
 
-  it "types call with union argument" do
+  it("types call with union argument") do
     assert_type("def foo(x); x; end; a = 1 || 1.1; foo(a)") { union_of(int32, float64) }
   end
 
-  it "defines class method" do
+  it("defines class method") do
     assert_type("def Int.foo; 2.5; end; Int.foo") { float64 }
   end
 
-  it "defines class method with self" do
+  it("defines class method with self") do
     assert_type("struct Int; def self.foo; 2.5; end; end; Int.foo") { float64 }
   end
 
-  it "calls with default argument" do
+  it("calls with default argument") do
     assert_type("def foo(x = 1); x; end; foo") { int32 }
   end
 
-  it "do not use body for the def type" do
+  it("do not use body for the def type") do
     input = parse %(
       require "primitives"
 
@@ -109,12 +109,12 @@ describe "Semantic: def" do
     call.target_def.body.type.should eq(mod.nil)
   end
 
-  it "reports undefined method" do
+  it("reports undefined method") do
     assert_error "foo()",
       "undefined method 'foo'"
   end
 
-  it "reports no overload matches" do
+  it("reports no overload matches") do
     assert_error "
       def foo(x : Int)
       end
@@ -124,7 +124,7 @@ describe "Semantic: def" do
       "no overload matches"
   end
 
-  it "reports no overload matches 2" do
+  it("reports no overload matches 2") do
     assert_error "
       def foo(x : Int, y : Int)
       end
@@ -137,7 +137,7 @@ describe "Semantic: def" do
       "no overload matches"
   end
 
-  it "reports no block given" do
+  it("reports no block given") do
     assert_error "
       def foo
         yield
@@ -148,7 +148,7 @@ describe "Semantic: def" do
       "'foo' is expected to be invoked with a block, but no block was given"
   end
 
-  it "reports block given" do
+  it("reports block given") do
     assert_error "
       def foo
       end
@@ -158,7 +158,7 @@ describe "Semantic: def" do
       "'foo' is not expected to be invoked with a block, but a block was given"
   end
 
-  it "errors when calling two functions with nil type" do
+  it("errors when calling two functions with nil type") do
     assert_error "
       def bar
       end
@@ -171,7 +171,7 @@ describe "Semantic: def" do
       "undefined method"
   end
 
-  it "errors when default value is incompatible with type restriction" do
+  it("errors when default value is incompatible with type restriction") do
     assert_error "
       def foo(x : Int64 = 1)
       end
@@ -181,7 +181,7 @@ describe "Semantic: def" do
       "can't restrict Int32 to Int64"
   end
 
-  it "types call with global scope" do
+  it("types call with global scope") do
     assert_type("
       def bar
         1
@@ -201,7 +201,7 @@ describe "Semantic: def" do
       ") { int32 }
   end
 
-  it "lookups methods in super modules" do
+  it("lookups methods in super modules") do
     assert_type("
       require \"prelude\"
 
@@ -238,7 +238,7 @@ describe "Semantic: def" do
       ") { int32 }
   end
 
-  it "fixes bug #165" do
+  it("fixes bug #165") do
     assert_error %(
       abstract class Node
       end
@@ -252,7 +252,7 @@ describe "Semantic: def" do
       ), "no overload matches"
   end
 
-  it "says can only defined def on types and self" do
+  it("says can only defined def on types and self") do
     assert_error %(
       class Foo
       end
@@ -264,7 +264,7 @@ describe "Semantic: def" do
       "def receiver can only be a Type or self"
   end
 
-  it "errors if return type doesn't match" do
+  it("errors if return type doesn't match") do
     assert_error %(
       def foo : Int32
         'a'
@@ -275,7 +275,7 @@ describe "Semantic: def" do
       "type must be Int32, not Char"
   end
 
-  it "errors if return type doesn't match on instance method" do
+  it("errors if return type doesn't match on instance method") do
     assert_error %(
       class Foo
         def foo : Int32
@@ -288,7 +288,7 @@ describe "Semantic: def" do
       "type must be Int32, not Char"
   end
 
-  it "errors if return type doesn't match on class method" do
+  it("errors if return type doesn't match on class method") do
     assert_error %(
       class Foo
         def self.foo : Int32
@@ -301,7 +301,7 @@ describe "Semantic: def" do
       "type must be Int32, not Char"
   end
 
-  it "is ok if returns Int32? with explicit return" do
+  it("is ok if returns Int32? with explicit return") do
     assert_type(%(
       def foo : Int32?
         if 1 == 2
@@ -314,7 +314,7 @@ describe "Semantic: def" do
       )) { nilable int32 }
   end
 
-  it "says compile-time type on error" do
+  it("says compile-time type on error") do
     assert_error %(
       abstract class Foo
       end
@@ -334,7 +334,7 @@ describe "Semantic: def" do
       "compile-time type is Foo+"
   end
 
-  it "gives correct error for wrong number of arguments for program call inside type (#1024)" do
+  it("gives correct error for wrong number of arguments for program call inside type (#1024)") do
     assert_error %(
       def foo
       end
@@ -350,7 +350,7 @@ describe "Semantic: def" do
       "wrong number of arguments for 'foo' (given 1, expected 0)"
   end
 
-  it "gives correct error for wrong number of arguments for program call inside type (2) (#1024)" do
+  it("gives correct error for wrong number of arguments for program call inside type (2) (#1024)") do
     assert_error %(
       def foo(x : String)
       end
@@ -366,7 +366,7 @@ describe "Semantic: def" do
       "no overload matches 'foo'"
   end
 
-  it "errors if declares def inside if" do
+  it("errors if declares def inside if") do
     assert_error %(
       if 1 == 2
         def foo; end
@@ -375,7 +375,7 @@ describe "Semantic: def" do
       "can't declare def dynamically"
   end
 
-  it "accesses free var of default argument (#1101)" do
+  it("accesses free var of default argument (#1101)") do
     assert_type(%(
       def foo(x, y : U = nil) forall U
         U
@@ -385,7 +385,7 @@ describe "Semantic: def" do
       )) { nil_type.metaclass }
   end
 
-  it "clones regex literal value (#2384)" do
+  it("clones regex literal value (#2384)") do
     assert_type(%(
       require "prelude"
 
@@ -399,7 +399,7 @@ describe "Semantic: def" do
       )) { int32 }
   end
 
-  it "doesn't find type in namespace through free var" do
+  it("doesn't find type in namespace through free var") do
     assert_error %(
       def foo(x : T) forall T
         T::String
@@ -410,7 +410,7 @@ describe "Semantic: def" do
       "undefined constant T::String"
   end
 
-  it "errors if trying to declare method on generic class instance" do
+  it("errors if trying to declare method on generic class instance") do
     assert_error %(
       class Foo(T)
       end
@@ -423,7 +423,7 @@ describe "Semantic: def" do
       "can't define method in generic instance"
   end
 
-  it "uses free variable" do
+  it("uses free variable") do
     assert_type(%(
       def foo(x : Free) forall Free
         Free
@@ -433,7 +433,7 @@ describe "Semantic: def" do
       )) { int32.metaclass }
   end
 
-  it "uses free variable with metaclass" do
+  it("uses free variable with metaclass") do
     assert_type(%(
       def foo(x : Free.class) forall Free
         Free
@@ -443,7 +443,7 @@ describe "Semantic: def" do
       )) { int32.metaclass }
   end
 
-  it "uses free variable with metaclass and default value" do
+  it("uses free variable with metaclass and default value") do
     assert_type(%(
       def foo(x : Free.class = Int32) forall Free
         Free
@@ -453,7 +453,7 @@ describe "Semantic: def" do
       )) { int32.metaclass }
   end
 
-  it "uses free variable as block return type" do
+  it("uses free variable as block return type") do
     assert_type(%(
       def foo(&block : -> Free) forall Free
         yield
@@ -464,7 +464,7 @@ describe "Semantic: def" do
       )) { int32.metaclass }
   end
 
-  it "uses free variable and doesn't conflict with top-level type" do
+  it("uses free variable and doesn't conflict with top-level type") do
     assert_type(%(
       class Free
       end

--- a/spec/compiler/semantic/did_you_mean_spec.cr
+++ b/spec/compiler/semantic/did_you_mean_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: did you mean" do
-  it "says did you mean for one mistake in short word in instance method" do
+describe("Semantic: did you mean") do
+  it("says did you mean for one mistake in short word in instance method") do
     assert_error "
       class Foo
         def bar
@@ -13,7 +13,7 @@ describe "Semantic: did you mean" do
       "did you mean 'bar'"
   end
 
-  it "says did you mean for two mistakes in long word in instance method" do
+  it("says did you mean for two mistakes in long word in instance method") do
     assert_error "
       class Foo
         def barbara
@@ -25,7 +25,7 @@ describe "Semantic: did you mean" do
       "did you mean 'barbara'"
   end
 
-  it "says did you mean for global method with parenthesis" do
+  it("says did you mean for global method with parenthesis") do
     assert_error "
       def bar
       end
@@ -35,7 +35,7 @@ describe "Semantic: did you mean" do
       "did you mean 'bar'"
   end
 
-  it "says did you mean for global method without parenthesis" do
+  it("says did you mean for global method without parenthesis") do
     assert_error "
       def bar
       end
@@ -45,7 +45,7 @@ describe "Semantic: did you mean" do
       "did you mean 'bar'"
   end
 
-  it "says did you mean for variable" do
+  it("says did you mean for variable") do
     assert_error "
       bar = 1
       baz
@@ -53,7 +53,7 @@ describe "Semantic: did you mean" do
       "did you mean 'bar'"
   end
 
-  it "says did you mean for class" do
+  it("says did you mean for class") do
     assert_error "
       class Foo
       end
@@ -63,7 +63,7 @@ describe "Semantic: did you mean" do
       "did you mean 'Foo'"
   end
 
-  it "says did you mean for nested class" do
+  it("says did you mean for nested class") do
     assert_error "
       class Foo
         class Bar
@@ -75,7 +75,7 @@ describe "Semantic: did you mean" do
       "did you mean 'Foo::Bar'"
   end
 
-  it "says did you mean finds most similar in def" do
+  it("says did you mean finds most similar in def") do
     assert_error "
       def barbaza
       end
@@ -88,7 +88,7 @@ describe "Semantic: did you mean" do
       "did you mean 'barbara'"
   end
 
-  it "says did you mean finds most similar in type" do
+  it("says did you mean finds most similar in type") do
     assert_error "
       class Barbaza
       end
@@ -101,7 +101,7 @@ describe "Semantic: did you mean" do
       "did you mean 'Barbara'"
   end
 
-  it "doesn't suggest for operator" do
+  it("doesn't suggest for operator") do
     nodes = parse %(
       class Foo
         def +
@@ -118,7 +118,7 @@ describe "Semantic: did you mean" do
     end
   end
 
-  it "says did you mean for named argument" do
+  it("says did you mean for named argument") do
     assert_error "
       def foo(barbara = 1)
       end
@@ -128,7 +128,7 @@ describe "Semantic: did you mean" do
       "did you mean 'barbara'"
   end
 
-  it "says did you mean for instance var" do
+  it("says did you mean for instance var") do
     assert_error %(
       class Foo
         def initialize
@@ -145,7 +145,7 @@ describe "Semantic: did you mean" do
       "did you mean @barbara"
   end
 
-  it "says did you mean for instance var in subclass" do
+  it("says did you mean for instance var in subclass") do
     assert_error %(
       class Foo
         def initialize
@@ -164,14 +164,14 @@ describe "Semantic: did you mean" do
       "did you mean @barbara"
   end
 
-  it "doesn't suggest when declaring var with suffix if and using it (#946)" do
+  it("doesn't suggest when declaring var with suffix if and using it (#946)") do
     assert_error %(
       a if a = 1
       ),
       "If you declared 'a' in a suffix if, declare it in a regular if for this to work"
   end
 
-  it "doesn't suggest when declaring var inside macro (#466)" do
+  it("doesn't suggest when declaring var inside macro (#466)") do
     assert_error %(
       macro foo
         a = 1
@@ -183,7 +183,7 @@ describe "Semantic: did you mean" do
       "If the variable was declared in a macro it's not visible outside it"
   end
 
-  it "suggest that there might be a type for an initialize method" do
+  it("suggest that there might be a type for an initialize method") do
     assert_error %(
       class Foo
         def intialize(x)
@@ -195,7 +195,7 @@ describe "Semantic: did you mean" do
       "do you maybe have a typo in this 'intialize' method?"
   end
 
-  it "suggest that there might be a type for an initialize method in inherited class" do
+  it("suggest that there might be a type for an initialize method in inherited class") do
     assert_error %(
       class Foo
         def initialize
@@ -212,7 +212,7 @@ describe "Semantic: did you mean" do
       "do you maybe have a typo in this 'intialize' method?"
   end
 
-  it "suggest that there might be a type for an initialize method with overload" do
+  it("suggest that there might be a type for an initialize method with overload") do
     assert_error %(
       class Foo
         def initialize(x : Int32)
@@ -227,7 +227,7 @@ describe "Semantic: did you mean" do
       "do you maybe have a typo in this 'intialize' method?"
   end
 
-  it "suggests for class variable" do
+  it("suggests for class variable") do
     assert_error %(
       class Foo
         @@foobar = 1
@@ -236,7 +236,7 @@ describe "Semantic: did you mean" do
       ), "did you mean @@foobar"
   end
 
-  it "suggests a better alternative to logical operators (#2715)" do
+  it("suggests a better alternative to logical operators (#2715)") do
     message = "undefined method 'and'"
     message = " (did you mean '&&'?)".colorize.yellow.bold.to_s
     assert_error %(
@@ -255,7 +255,7 @@ describe "Semantic: did you mean" do
       ), message
   end
 
-  it "says did you mean in instance var declaration" do
+  it("says did you mean in instance var declaration") do
     assert_error %(
       class FooBar
       end

--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: doc" do
-  it "stores doc for class" do
+describe("Semantic: doc") do
+  it("stores doc for class") do
     result = semantic %(
       # Hello
       class Foo
@@ -13,7 +13,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for abstract class" do
+  it("stores doc for abstract class") do
     result = semantic %(
       # Hello
       abstract class Foo
@@ -24,7 +24,7 @@ describe "Semantic: doc" do
     foo.doc.should eq("Hello")
   end
 
-  it "stores doc for struct" do
+  it("stores doc for struct") do
     result = semantic %(
       # Hello
       struct Foo
@@ -36,7 +36,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for module" do
+  it("stores doc for module") do
     result = semantic %(
       # Hello
       module Foo
@@ -48,7 +48,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for def" do
+  it("stores doc for def") do
     result = semantic %(
       class Foo
         # Hello
@@ -62,7 +62,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for def when using ditto" do
+  it("stores doc for def when using ditto") do
     result = semantic %(
       class Foo
         # Hello
@@ -80,7 +80,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for def with visibility" do
+  it("stores doc for def with visibility") do
     result = semantic %(
       class Foo
         # Hello
@@ -94,7 +94,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for def with attribute" do
+  it("stores doc for def with attribute") do
     result = semantic %(
       class Foo
         # Hello
@@ -109,7 +109,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for def with attribute" do
+  it("stores doc for def with attribute") do
     result = semantic %(
       # Hello
       @[AlwaysInline]
@@ -122,7 +122,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for abstract def" do
+  it("stores doc for abstract def") do
     result = semantic %(
       abstract class Foo
         # Hello
@@ -162,7 +162,7 @@ describe "Semantic: doc" do
     end
   {% end %}
 
-  it "stores doc for macro" do
+  it("stores doc for macro") do
     result = semantic %(
       class Foo
         # Hello
@@ -176,7 +176,7 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
-  it "stores doc for fun def" do
+  it("stores doc for fun def") do
     result = semantic %(
       # Hello
       fun foo : Int32
@@ -188,7 +188,7 @@ describe "Semantic: doc" do
     foo.doc.should eq("Hello")
   end
 
-  it "stores doc for enum" do
+  it("stores doc for enum") do
     result = semantic %(
       # Hello
       enum Foo
@@ -201,7 +201,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for flags enum with base type" do
+  it("stores doc for flags enum with base type") do
     result = semantic %(
       # Hello
       @[Flags]
@@ -216,7 +216,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for enum and doesn't mix with value" do
+  it("stores doc for enum and doesn't mix with value") do
     result = semantic %(
       # Hello
       enum Foo
@@ -230,7 +230,7 @@ describe "Semantic: doc" do
     foo.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for enum with @[Flags]" do
+  it("stores doc for enum with @[Flags]") do
     result = semantic %(
       # Hello
       @[Flags]
@@ -243,7 +243,7 @@ describe "Semantic: doc" do
     foo.doc.should eq("Hello")
   end
 
-  it "stores doc for enum member" do
+  it("stores doc for enum member") do
     result = semantic %(
       enum Foo
         # Hello
@@ -257,7 +257,7 @@ describe "Semantic: doc" do
     a.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for constant" do
+  it("stores doc for constant") do
     result = semantic %(
       # Hello
       CONST = 1
@@ -268,7 +268,7 @@ describe "Semantic: doc" do
     a.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for alias" do
+  it("stores doc for alias") do
     result = semantic %(
       # Hello
       alias Alias = Int32
@@ -279,7 +279,7 @@ describe "Semantic: doc" do
     a.locations.not_nil!.size.should eq(1)
   end
 
-  it "stores doc for nodes defined in macro call" do
+  it("stores doc for nodes defined in macro call") do
     result = semantic %(
       class Object
         macro property(name)
@@ -307,7 +307,7 @@ describe "Semantic: doc" do
     bar_assign.doc.should eq("Hello")
   end
 
-  it "stores doc for nodes defined in macro call (2)" do
+  it("stores doc for nodes defined in macro call (2)") do
     result = semantic %(
       macro foo
         class Foo
@@ -359,7 +359,7 @@ describe "Semantic: doc" do
     end
   {% end %}
 
-  it "stores locations for auto-generated module" do
+  it("stores locations for auto-generated module") do
     result = semantic %(
       class Foo::Bar
       end

--- a/spec/compiler/semantic/double_splat_spec.cr
+++ b/spec/compiler/semantic/double_splat_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: double splat" do
-  it "double splats named argument into arguments (1)" do
+describe("Semantic: double splat") do
+  it("double splats named argument into arguments (1)") do
     assert_type(%(
       def foo(x, y)
         x
@@ -12,7 +12,7 @@ describe "Semantic: double splat" do
       )) { int32 }
   end
 
-  it "double splats named argument into arguments (2)" do
+  it("double splats named argument into arguments (2)") do
     assert_type(%(
       def foo(x, y)
         x
@@ -23,7 +23,7 @@ describe "Semantic: double splat" do
       )) { int32 }
   end
 
-  it "errors if duplicate keys on call side with two double splats" do
+  it("errors if duplicate keys on call side with two double splats") do
     assert_error %(
       def foo(**args)
       end
@@ -35,7 +35,7 @@ describe "Semantic: double splat" do
       "duplicate key: x"
   end
 
-  it "errors if duplicate keys on call side with double splat and named args" do
+  it("errors if duplicate keys on call side with double splat and named args") do
     assert_error %(
       def foo(**args)
       end
@@ -46,7 +46,7 @@ describe "Semantic: double splat" do
       "duplicate key: x"
   end
 
-  it "errors missing argument with double splat" do
+  it("errors missing argument with double splat") do
     assert_error %(
       def foo(x, y)
       end
@@ -57,7 +57,7 @@ describe "Semantic: double splat" do
       "missing argument: y"
   end
 
-  it "matches double splat on method (empty)" do
+  it("matches double splat on method (empty)") do
     assert_type(%(
       def foo(**args)
         args
@@ -67,7 +67,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({} of String => Type) }
   end
 
-  it "matches double splat on method with named args" do
+  it("matches double splat on method with named args") do
     assert_type(%(
       def foo(**args)
         args
@@ -77,7 +77,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({"x": int32, "y": char}) }
   end
 
-  it "matches double splat on method with named args and regular args" do
+  it("matches double splat on method with named args and regular args") do
     assert_type(%(
       def foo(x, **args)
         args
@@ -87,7 +87,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({"y": char, "z": int32}) }
   end
 
-  it "matches double splat with regular splat" do
+  it("matches double splat with regular splat") do
     assert_type(%(
       def foo(*args, **options)
         {args, options}
@@ -97,7 +97,7 @@ describe "Semantic: double splat" do
       )) { tuple_of([tuple_of([int32, char]), named_tuple_of({"x": string, "y": bool})]) }
   end
 
-  it "uses double splat in new" do
+  it("uses double splat in new") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -115,7 +115,7 @@ describe "Semantic: double splat" do
       )) { int32 }
   end
 
-  it "uses restriction on double splat, doesn't match with empty named tuple" do
+  it("uses restriction on double splat, doesn't match with empty named tuple") do
     assert_error %(
       def foo(**options : Int32)
       end
@@ -125,7 +125,7 @@ describe "Semantic: double splat" do
       "no overload matches"
   end
 
-  it "uses restriction on double splat, doesn't match with empty named tuple (2)" do
+  it("uses restriction on double splat, doesn't match with empty named tuple (2)") do
     assert_error %(
       def foo(x, **options : Int32)
       end
@@ -135,7 +135,7 @@ describe "Semantic: double splat" do
       "no overload matches"
   end
 
-  it "uses restriction on double splat, means all types must be that type" do
+  it("uses restriction on double splat, means all types must be that type") do
     assert_error %(
       def foo(**options : Int32)
       end
@@ -145,7 +145,7 @@ describe "Semantic: double splat" do
       "no overload matches"
   end
 
-  it "overloads based on double splat restriction" do
+  it("overloads based on double splat restriction") do
     assert_type(%(
       def foo(**options : Int32)
         true
@@ -161,7 +161,7 @@ describe "Semantic: double splat" do
       )) { tuple_of([string, bool]) }
   end
 
-  it "uses double splat restriction" do
+  it("uses double splat restriction") do
     assert_type(%(
       def foo(**options : **T) forall T
         T
@@ -171,7 +171,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({"x" => int32, "y" => char}).metaclass }
   end
 
-  it "uses double splat restriction, matches empty" do
+  it("uses double splat restriction, matches empty") do
     assert_type(%(
       def foo(**options : **T) forall T
         T
@@ -181,7 +181,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({} of String => Type).metaclass }
   end
 
-  it "uses double splat restriction with concrete type" do
+  it("uses double splat restriction with concrete type") do
     assert_error %(
       struct NamedTuple(T)
         def self.foo(**options : **T)
@@ -193,7 +193,7 @@ describe "Semantic: double splat" do
       "no overload matches"
   end
 
-  it "matches named args producing an empty double splat (#2678)" do
+  it("matches named args producing an empty double splat (#2678)") do
     assert_type(%(
       def test(x, **kwargs)
         kwargs
@@ -203,7 +203,7 @@ describe "Semantic: double splat" do
       )) { named_tuple_of({} of String => Type) }
   end
 
-  it "matches typed before non-typed (1) (#3134)" do
+  it("matches typed before non-typed (1) (#3134)") do
     assert_type(%(
       def bar(**args)
         "free"
@@ -217,7 +217,7 @@ describe "Semantic: double splat" do
       )) { tuple_of([int32, string]) }
   end
 
-  it "matches typed before non-typed (1) (#3134)" do
+  it("matches typed before non-typed (1) (#3134)") do
     assert_type(%(
       def bar(**args : Int32)
         1

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: enum" do
-  it "types enum" do
+describe("Semantic: enum") do
+  it("types enum") do
     assert_type(%(
       enum Foo
         A = 1
@@ -10,7 +10,7 @@ describe "Semantic: enum" do
       )) { types["Foo"] }
   end
 
-  it "types enum value" do
+  it("types enum value") do
     assert_type(%(
       enum Foo
         A = 1
@@ -19,7 +19,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "disallows implicit conversion of int to enum" do
+  it("disallows implicit conversion of int to enum") do
     assert_error %(
       enum Foo
         A = 1
@@ -32,7 +32,7 @@ describe "Semantic: enum" do
       ), "no overload matches 'foo' with type Int32"
   end
 
-  it "finds method in enum type" do
+  it("finds method in enum type") do
     assert_type(%(
       struct Enum
         def foo
@@ -48,7 +48,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "finds class method in enum type" do
+  it("finds class method in enum type") do
     assert_type(%(
       struct Enum
         def self.foo
@@ -64,7 +64,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "errors if using a name twice" do
+  it("errors if using a name twice") do
     assert_error %(
       enum Foo
         A
@@ -74,7 +74,7 @@ describe "Semantic: enum" do
       "enum 'Foo' already contains a member named 'A'"
   end
 
-  it "creates enum from value" do
+  it("creates enum from value") do
     assert_type(%(
       enum Foo
         A
@@ -85,7 +85,7 @@ describe "Semantic: enum" do
       )) { types["Foo"] }
   end
 
-  it "defines method on enum" do
+  it("defines method on enum") do
     assert_type(%(
       enum Foo
         A
@@ -100,7 +100,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "defines class method on enum" do
+  it("defines class method on enum") do
     assert_type(%(
       enum Foo
         A
@@ -115,7 +115,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "reopens an enum" do
+  it("reopens an enum") do
     assert_type(%(
       enum Foo
         A
@@ -132,7 +132,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "errors if reopen but not enum" do
+  it("errors if reopen but not enum") do
     assert_error %(
       class Foo
       end
@@ -145,7 +145,7 @@ describe "Semantic: enum" do
       "Foo is not a enum, it's a class"
   end
 
-  it "errors if reopen and tries to define constant" do
+  it("errors if reopen and tries to define constant") do
     assert_error %(
       enum Foo
         A
@@ -159,7 +159,7 @@ describe "Semantic: enum" do
       "can't reopen enum and add more constants to it"
   end
 
-  it "has None value when defined as @[Flags]" do
+  it("has None value when defined as @[Flags]") do
     assert_type(%(
       @[Flags]
       enum Foo
@@ -171,7 +171,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "has All value when defined as @[Flags]" do
+  it("has All value when defined as @[Flags]") do
     assert_type(%(
       @[Flags]
       enum Foo
@@ -183,7 +183,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "disallows None value when defined with @[Flags]" do
+  it("disallows None value when defined with @[Flags]") do
     assert_error %(
       @[Flags]
       enum Foo
@@ -193,7 +193,7 @@ describe "Semantic: enum" do
       "flags enum can't contain None or All members"
   end
 
-  it "disallows All value when defined with @[Flags]" do
+  it("disallows All value when defined with @[Flags]") do
     assert_error %(
       @[Flags]
       enum Foo
@@ -203,7 +203,7 @@ describe "Semantic: enum" do
       "flags enum can't contain None or All members"
   end
 
-  it "doesn't error when defining a non-flags enum with None or All" do
+  it("doesn't error when defining a non-flags enum with None or All") do
     assert_type(%(
       enum Foo
         None
@@ -214,7 +214,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "doesn't error when defining a flags enum in a lib with None or All" do
+  it("doesn't error when defining a flags enum in a lib with None or All") do
     assert_type(%(
       lib Lib
         @[Flags]
@@ -228,7 +228,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "doesn't error when defining a method for an enum with flags" do
+  it("doesn't error when defining a method for an enum with flags") do
     assert_type(%(
       @[Flags]
       enum Foo
@@ -244,7 +244,7 @@ describe "Semantic: enum" do
       )) { types["Foo"] }
   end
 
-  it "allows class vars in enum" do
+  it("allows class vars in enum") do
     assert_type(%(
       enum Foo
         A
@@ -260,7 +260,7 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
-  it "errors if invoking private enum method" do
+  it("errors if invoking private enum method") do
     assert_error %(
       enum Foo
         A
@@ -275,7 +275,7 @@ describe "Semantic: enum" do
       "private method 'foo' called for Foo"
   end
 
-  it "errors if enum value is too big for type (#678)" do
+  it("errors if enum value is too big for type (#678)") do
     assert_error %(
       enum Foo
         A = 2147486719
@@ -284,7 +284,7 @@ describe "Semantic: enum" do
       "invalid Int32: 2147486719"
   end
 
-  it "errors if using instance var inside enum (#991)" do
+  it("errors if using instance var inside enum (#991)") do
     assert_error %(
       enum Foo
         A
@@ -299,7 +299,7 @@ describe "Semantic: enum" do
       "can't use instance variables inside enums (at enum Foo)"
   end
 
-  it "marks as flags with base type (#2185)" do
+  it("marks as flags with base type (#2185)") do
     result = semantic(%(
       @[Flags]
       enum SomeFacts : UInt8
@@ -314,7 +314,7 @@ describe "Semantic: enum" do
     enum_type.has_attribute?("Flags").should be_true
   end
 
-  it "can use macro expression inside enum" do
+  it("can use macro expression inside enum") do
     assert_type(%(
       enum Foo
         {{ "A".id }}
@@ -324,7 +324,7 @@ describe "Semantic: enum" do
       )) { types["Foo"] }
   end
 
-  it "can use macro for inside enum" do
+  it("can use macro for inside enum") do
     assert_type(%(
       enum Foo
         {% for name in %w(A B C) %}
@@ -336,7 +336,7 @@ describe "Semantic: enum" do
       )) { types["Foo"] }
   end
 
-  it "errors if inheriting Enum (#3592)" do
+  it("errors if inheriting Enum (#3592)") do
     assert_error %(
       struct Foo < Enum
       end
@@ -344,7 +344,7 @@ describe "Semantic: enum" do
       "can't inherit Enum. Use the enum keyword to define enums"
   end
 
-  it "errors on enum without members (#3447)" do
+  it("errors on enum without members (#3447)") do
     assert_error %(
       enum Foo
       end
@@ -352,7 +352,7 @@ describe "Semantic: enum" do
       "enum Foo must have at least one member"
   end
 
-  it "errors if declaring type inside enum (#3127)" do
+  it("errors if declaring type inside enum (#3127)") do
     assert_error %(
       enum Foo
         A
@@ -364,7 +364,7 @@ describe "Semantic: enum" do
       "can't declare type inside enum Foo"
   end
 
-  it "errors if declaring type inside enum, nested (#3127)" do
+  it("errors if declaring type inside enum, nested (#3127)") do
     assert_error %(
       enum Foo
         A

--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: exception" do
-  it "type is union of main and rescue blocks" do
+describe("Semantic: exception") do
+  it("type is union of main and rescue blocks") do
     assert_type("
       begin
         1
@@ -11,7 +11,7 @@ describe "Semantic: exception" do
     ") { union_of(int32, char) }
   end
 
-  it "type union with empty main block" do
+  it("type union with empty main block") do
     assert_type("
       begin
       rescue
@@ -20,7 +20,7 @@ describe "Semantic: exception" do
     ") { nilable int32 }
   end
 
-  it "type union with empty rescue block" do
+  it("type union with empty rescue block") do
     assert_type("
       begin
         1
@@ -29,7 +29,7 @@ describe "Semantic: exception" do
     ") { nilable int32 }
   end
 
-  it "type for exception handler for explicit types" do
+  it("type for exception handler for explicit types") do
     assert_type("
       require \"prelude\"
 
@@ -44,7 +44,7 @@ describe "Semantic: exception" do
     ") { int32 }
   end
 
-  it "marks method calling method that raises as raises" do
+  it("marks method calling method that raises as raises") do
     result = assert_type("
       lib LibFoo
         @[Raises]
@@ -63,7 +63,7 @@ describe "Semantic: exception" do
     def_instance.not_nil!.raises?.should be_true
   end
 
-  it "marks method calling lib fun that raises as raises" do
+  it("marks method calling lib fun that raises as raises") do
     result = assert_type("
       @[Raises]
       fun some_fun : Int32; 1; end
@@ -80,7 +80,7 @@ describe "Semantic: exception" do
     def_instance.not_nil!.raises?.should be_true
   end
 
-  it "types exception var with no types" do
+  it("types exception var with no types") do
     assert_type("
       a = nil
       begin
@@ -91,7 +91,7 @@ describe "Semantic: exception" do
     ") { union_of(nil_type, exception.virtual_type) }
   end
 
-  it "types exception with type" do
+  it("types exception with type") do
     assert_type("
       class Ex < Exception
       end
@@ -105,7 +105,7 @@ describe "Semantic: exception" do
     ") { union_of(nil_type, types["Ex"].virtual_type) }
   end
 
-  it "types var as not nil if defined inside begin and defined inside rescue" do
+  it("types var as not nil if defined inside begin and defined inside rescue") do
     assert_type("
       begin
         a = 1
@@ -116,7 +116,7 @@ describe "Semantic: exception" do
       ") { int32 }
   end
 
-  it "types var as nialble if previously nilable (1)" do
+  it("types var as nialble if previously nilable (1)") do
     assert_type("
       if 1 == 2
         a = 1
@@ -130,7 +130,7 @@ describe "Semantic: exception" do
       ") { nilable int32 }
   end
 
-  it "types var as nialble if previously nilable (2)" do
+  it("types var as nialble if previously nilable (2)") do
     assert_type("
       if 1 == 2
         a = 1
@@ -144,11 +144,11 @@ describe "Semantic: exception" do
       ") { nilable int32 }
   end
 
-  it "errors if catched exception is not a subclass of Exception" do
+  it("errors if catched exception is not a subclass of Exception") do
     assert_error "begin; rescue ex : Int32; end", "Int32 is not a subclass of Exception"
   end
 
-  it "errors if catched exception is not a subclass of Exception without var" do
+  it("errors if catched exception is not a subclass of Exception without var") do
     assert_error "begin; rescue Int32; end", "Int32 is not a subclass of Exception"
   end
 
@@ -161,7 +161,7 @@ describe "Semantic: exception" do
   assert_syntax_error "begin; else; 1; end",
     "'else' is useless without 'rescue'"
 
-  it "types code with abstract exception that delegates method" do
+  it("types code with abstract exception that delegates method") do
     assert_type(%(
       require "prelude"
 
@@ -193,7 +193,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "transform nodes in else block" do
+  it("transform nodes in else block") do
     assert_type(%(
       begin
       rescue
@@ -203,7 +203,7 @@ describe "Semantic: exception" do
     )) { nilable int32 }
   end
 
-  it "types var as nilable inside ensure (1)" do
+  it("types var as nilable inside ensure (1)") do
     result = assert_type(%(
       require "prelude"
 
@@ -222,7 +222,7 @@ describe "Semantic: exception" do
     call_p_n.args.first.type.should eq(mod.nilable(mod.int32))
   end
 
-  it "types var as nilable inside ensure (2)" do
+  it("types var as nilable inside ensure (2)") do
     result = assert_type(%(
       require "prelude"
 
@@ -240,7 +240,7 @@ describe "Semantic: exception" do
     call_p_n.args.first.type.should eq(mod.nilable(mod.int32))
   end
 
-  it "marks fun as raises" do
+  it("marks fun as raises") do
     result = assert_type(%(
       @[Raises]
       fun foo : Int32; 1; end
@@ -251,7 +251,7 @@ describe "Semantic: exception" do
     a_def.not_nil!.raises?.should be_true
   end
 
-  it "marks def as raises" do
+  it("marks def as raises") do
     result = assert_type(%(
       @[Raises]
       def foo
@@ -265,13 +265,13 @@ describe "Semantic: exception" do
     a_def.not_nil!.raises?.should be_true
   end
 
-  it "marks proc literal as raises" do
+  it("marks proc literal as raises") do
     result = assert_type("->{ 1 }.call", inject_primitives: true) { int32 }
     call = result.node.as(Expressions).last.as(Call)
     call.target_def.raises?.should be_true
   end
 
-  it "shadows local variable (1)" do
+  it("shadows local variable (1)") do
     assert_type(%(
       require "prelude"
 
@@ -285,7 +285,7 @@ describe "Semantic: exception" do
       )) { union_of(int32, types["Exception"].virtual_type) }
   end
 
-  it "remains nilable after rescue" do
+  it("remains nilable after rescue") do
     assert_type(%(
       require "prelude"
 
@@ -298,7 +298,7 @@ describe "Semantic: exception" do
       )) { nilable types["Exception"].virtual_type }
   end
 
-  it "doesn't consider vars as nilable inside else (#610)" do
+  it("doesn't consider vars as nilable inside else (#610)") do
     assert_type(%(
       require "prelude"
 
@@ -313,7 +313,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "types instance variable as nilable if assigned inside an exception handler (#1845)" do
+  it("types instance variable as nilable if assigned inside an exception handler (#1845)") do
     assert_error %(
       class Foo
         def initialize
@@ -334,7 +334,7 @@ describe "Semantic: exception" do
       "instance variable '@bar' of Foo must be Int32, not Nil"
   end
 
-  it "doesn't type instance variable as nilable if assigned inside an exception handler after being assigned" do
+  it("doesn't type instance variable as nilable if assigned inside an exception handler after being assigned") do
     assert_type(%(
       class Foo
         def initialize
@@ -355,7 +355,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "correctly types #1988" do
+  it("correctly types #1988") do
     assert_type(%(
       begin
         x = 1
@@ -370,7 +370,7 @@ describe "Semantic: exception" do
       )) { nilable int32 }
   end
 
-  it "doesn't crash on break inside rescue, in while (#2441)" do
+  it("doesn't crash on break inside rescue, in while (#2441)") do
     assert_type(%(
       while true
         begin
@@ -383,7 +383,7 @@ describe "Semantic: exception" do
       )) { nilable types["Exception"].virtual_type }
   end
 
-  it "types var assignment inside block inside exception handler (#3324)" do
+  it("types var assignment inside block inside exception handler (#3324)") do
     assert_type(%(
       def foo
         yield
@@ -400,7 +400,7 @@ describe "Semantic: exception" do
       )) { union_of(int32, string) }
   end
 
-  it "marks instance variable as nilable if assigned inside rescue inside initialize" do
+  it("marks instance variable as nilable if assigned inside rescue inside initialize") do
     assert_error %(
       require "prelude"
 
@@ -422,7 +422,7 @@ describe "Semantic: exception" do
       "instance variable '@x' of Foo must be Int32, not Nil"
   end
 
-  it "assigns var inside ensure (1) (#3919)" do
+  it("assigns var inside ensure (1) (#3919)") do
     assert_type(%(
       begin
       ensure
@@ -432,7 +432,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "assigns var inside ensure (2) (#3919)" do
+  it("assigns var inside ensure (2) (#3919)") do
     assert_type(%(
       a = true
       begin
@@ -443,7 +443,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "doesn't infect type to variable before handler (#4002)" do
+  it("doesn't infect type to variable before handler (#4002)") do
     assert_type(%(
       a = 1
       b = a
@@ -455,7 +455,7 @@ describe "Semantic: exception" do
       )) { int32 }
   end
 
-  it "detects reading nil-if-read variable after exception handler (#4723)" do
+  it("detects reading nil-if-read variable after exception handler (#4723)") do
     result = assert_type(%(
       if true
         foo = 42
@@ -477,7 +477,7 @@ describe "Semantic: exception" do
     program.vars["foo"].type.should be(program.nilable program.int32)
   end
 
-  it "can't return from ensure (#4470)" do
+  it("can't return from ensure (#4470)") do
     assert_error(%(
       def foo
         return 1
@@ -489,7 +489,7 @@ describe "Semantic: exception" do
     ), "can't return from ensure")
   end
 
-  it "can't return from block inside ensure (#4470)" do
+  it("can't return from block inside ensure (#4470)") do
     assert_error(%(
       def once
         yield
@@ -507,7 +507,7 @@ describe "Semantic: exception" do
     ), "can't return from ensure")
   end
 
-  it "can't return from while inside ensure (#4470)" do
+  it("can't return from while inside ensure (#4470)") do
     assert_error(%(
       def foo
         return 1
@@ -521,7 +521,7 @@ describe "Semantic: exception" do
     ), "can't return from ensure")
   end
 
-  it "can't use break inside while inside ensure (#4470)" do
+  it("can't use break inside while inside ensure (#4470)") do
     assert_error(%(
       while true
         begin
@@ -533,7 +533,7 @@ describe "Semantic: exception" do
     ), "can't use break inside ensure")
   end
 
-  it "can use break inside while inside ensure (#4470)" do
+  it("can use break inside while inside ensure (#4470)") do
     assert_type(%(
       while true
         begin
@@ -547,7 +547,7 @@ describe "Semantic: exception" do
     )) { nil_type }
   end
 
-  it "can't use break inside block inside ensure (#4470)" do
+  it("can't use break inside block inside ensure (#4470)") do
     assert_error(%(
       def loop
         while true
@@ -565,7 +565,7 @@ describe "Semantic: exception" do
     ), "can't use break inside ensure")
   end
 
-  it "can use break inside block inside ensure (#4470)" do
+  it("can use break inside block inside ensure (#4470)") do
     assert_type(%(
       def loop
         while true
@@ -585,7 +585,7 @@ describe "Semantic: exception" do
     )) { nil_type }
   end
 
-  it "can't use next inside while inside ensure (#4470)" do
+  it("can't use next inside while inside ensure (#4470)") do
     assert_error(%(
       while true
         begin
@@ -597,7 +597,7 @@ describe "Semantic: exception" do
     ), "can't use next inside ensure")
   end
 
-  it "can't use next inside block inside ensure (#4470)" do
+  it("can't use next inside block inside ensure (#4470)") do
     assert_error(%(
       def loop
         while true
@@ -615,7 +615,7 @@ describe "Semantic: exception" do
     ), "can't use next inside ensure")
   end
 
-  it "can use next inside while inside ensure (#4470)" do
+  it("can use next inside while inside ensure (#4470)") do
     assert_type(%(
       while true
         begin
@@ -631,7 +631,7 @@ describe "Semantic: exception" do
     )) { nil_type }
   end
 
-  it "can use next inside block inside ensure (#4470)" do
+  it("can use next inside block inside ensure (#4470)") do
     assert_type(%(
       def loop
         while true

--- a/spec/compiler/semantic/extern_spec.cr
+++ b/spec/compiler/semantic/extern_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: extern struct" do
-  it "declares extern struct with no constructor" do
+describe("Semantic: extern struct") do
+  it("declares extern struct with no constructor") do
     assert_type(%(
       @[Extern]
       struct Foo
@@ -16,7 +16,7 @@ describe "Semantic: extern struct" do
       )) { int32 }
   end
 
-  it "declares with constructor" do
+  it("declares with constructor") do
     assert_type(%(
       @[Extern]
       struct Foo
@@ -34,7 +34,7 @@ describe "Semantic: extern struct" do
       )) { int32 }
   end
 
-  it "overrides getter" do
+  it("overrides getter") do
     assert_type(%(
       @[Extern]
       struct Foo
@@ -49,7 +49,7 @@ describe "Semantic: extern struct" do
       )) { char }
   end
 
-  it "can be passed to C fun" do
+  it("can be passed to C fun") do
     assert_type(%(
       @[Extern]
       struct Foo
@@ -64,7 +64,7 @@ describe "Semantic: extern struct" do
       )) { float64 }
   end
 
-  it "can include module" do
+  it("can include module") do
     assert_type(%(
       module Moo
         @x = uninitialized Int32
@@ -83,7 +83,7 @@ describe "Semantic: extern struct" do
       )) { int32 }
   end
 
-  it "errors if using non-primitive for field type" do
+  it("errors if using non-primitive for field type") do
     assert_error %(
       class Bar
       end
@@ -96,7 +96,7 @@ describe "Semantic: extern struct" do
       "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
   end
 
-  it "errors if using non-primitive for field type via module" do
+  it("errors if using non-primitive for field type via module") do
     assert_error %(
       class Bar
       end
@@ -113,7 +113,7 @@ describe "Semantic: extern struct" do
       "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
   end
 
-  it "errors if using non-primitive type in constructor" do
+  it("errors if using non-primitive type in constructor") do
     assert_error %(
       class Bar
       end
@@ -128,7 +128,7 @@ describe "Semantic: extern struct" do
       "only primitive types, pointers, structs, unions, enums and tuples are allowed in extern struct declarations"
   end
 
-  it "declares extern union with no constructor" do
+  it("declares extern union with no constructor") do
     assert_type(%(
       @[Extern(union: true)]
       struct Foo
@@ -143,7 +143,7 @@ describe "Semantic: extern struct" do
       )) { int32 }
   end
 
-  it "can use extern struct in lib" do
+  it("can use extern struct in lib") do
     assert_type(%(
       @[Extern]
       struct Foo
@@ -158,7 +158,7 @@ describe "Semantic: extern struct" do
       )) { types["Foo"] }
   end
 
-  it "can new with named args" do
+  it("can new with named args") do
     assert_type(%(
       @[Extern]
       struct A

--- a/spec/compiler/semantic/external_internal_spec.cr
+++ b/spec/compiler/semantic/external_internal_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: external/internal" do
-  it "can call with external name and use with internal" do
+describe("Semantic: external/internal") do
+  it("can call with external name and use with internal") do
     assert_type(%(
       def foo(x y)
         y
@@ -11,7 +11,7 @@ describe "Semantic: external/internal" do
       )) { int32 }
   end
 
-  it "can call positionally" do
+  it("can call positionally") do
     assert_type(%(
       def foo(x y)
         y
@@ -21,7 +21,7 @@ describe "Semantic: external/internal" do
       )) { int32 }
   end
 
-  it "can call with external name and use with internal, after splat" do
+  it("can call with external name and use with internal, after splat") do
     assert_type(%(
       def foo(*, x y)
         y
@@ -31,7 +31,7 @@ describe "Semantic: external/internal" do
       )) { int32 }
   end
 
-  it "overloads based on external name (#2610)" do
+  it("overloads based on external name (#2610)") do
     assert_type(%(
       def foo(*, bar foo)
         1
@@ -45,8 +45,8 @@ describe "Semantic: external/internal" do
       )) { int32 }
   end
 
-  context "macros" do
-    it "can call with external name and use with internal" do
+  context("macros") do
+    it("can call with external name and use with internal") do
       assert_type(%(
         macro foo(x y)
           {{y}}
@@ -56,7 +56,7 @@ describe "Semantic: external/internal" do
         )) { int32 }
     end
 
-    it "can call positionally" do
+    it("can call positionally") do
       assert_type(%(
         macro foo(x y)
           {{y}}
@@ -66,7 +66,7 @@ describe "Semantic: external/internal" do
         )) { int32 }
     end
 
-    it "can call with external name and use with internal, after splat" do
+    it("can call with external name and use with internal, after splat") do
       assert_type(%(
         macro foo(*, x y)
           {{y}}

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: generic class" do
-  it "errors if inheriting from generic when it is non-generic" do
+describe("Semantic: generic class") do
+  it("errors if inheriting from generic when it is non-generic") do
     assert_error %(
       class Foo
       end
@@ -12,7 +12,7 @@ describe "Semantic: generic class" do
       "Foo is not a generic type, it's a class"
   end
 
-  it "errors if inheriting from generic and incorrect number of type vars" do
+  it("errors if inheriting from generic and incorrect number of type vars") do
     assert_error %(
       class Foo(T)
       end
@@ -23,7 +23,7 @@ describe "Semantic: generic class" do
       "wrong number of type vars for Foo(T) (given 2, expected 1)"
   end
 
-  it "inhertis from generic with instantiation" do
+  it("inhertis from generic with instantiation") do
     assert_type(%(
       class Foo(T)
         def t
@@ -38,7 +38,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "inhertis from generic with forwarding (1)" do
+  it("inhertis from generic with forwarding (1)") do
     assert_type(%(
       class Foo(T)
         def t
@@ -53,7 +53,7 @@ describe "Semantic: generic class" do
       ), inject_primitives: false) { int32.metaclass }
   end
 
-  it "inhertis from generic with forwarding (2)" do
+  it("inhertis from generic with forwarding (2)") do
     assert_type(%(
       class Foo(T)
       end
@@ -68,7 +68,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "inhertis from generic with instantiation with instance var" do
+  it("inhertis from generic with instantiation with instance var") do
     assert_type(%(
       class Foo(T)
         def initialize(@x : T)
@@ -86,7 +86,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "inherits twice" do
+  it("inherits twice") do
     assert_type(%(
       class Foo
         def initialize
@@ -123,7 +123,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "inherits non-generic to generic (1)" do
+  it("inherits non-generic to generic (1)") do
     assert_type(%(
       class Foo(T)
         def t1
@@ -142,7 +142,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "inherits non-generic to generic (2)" do
+  it("inherits non-generic to generic (2)") do
     assert_type(%(
       class Foo(T)
         def t1
@@ -164,7 +164,7 @@ describe "Semantic: generic class" do
       )) { float64.metaclass }
   end
 
-  it "defines empty initialize on inherited generic class" do
+  it("defines empty initialize on inherited generic class") do
     assert_type(%(
       class Maybe(T)
       end
@@ -178,7 +178,7 @@ describe "Semantic: generic class" do
       )) { types["Nothing"] }
   end
 
-  it "restricts non-generic to generic" do
+  it("restricts non-generic to generic") do
     assert_type(%(
       class Foo(T)
       end
@@ -194,7 +194,7 @@ describe "Semantic: generic class" do
       )) { types["Bar"] }
   end
 
-  it "restricts non-generic to generic with free var" do
+  it("restricts non-generic to generic with free var") do
     assert_type(%(
       class Foo(T)
       end
@@ -210,7 +210,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "restricts generic to generic with free var" do
+  it("restricts generic to generic with free var") do
     assert_type(%(
       class Foo(T)
       end
@@ -226,7 +226,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "allows T::Type with T a generic type" do
+  it("allows T::Type with T a generic type") do
     assert_type(%(
       class MyType
         class Bar
@@ -243,7 +243,7 @@ describe "Semantic: generic class" do
       )) { types["MyType"].types["Bar"] }
   end
 
-  it "error on T::Type with T a generic type that's a union" do
+  it("error on T::Type with T a generic type that's a union") do
     assert_error %(
       class Foo(T)
         def self.bar
@@ -256,7 +256,7 @@ describe "Semantic: generic class" do
       "undefined constant T::Bar"
   end
 
-  it "instantiates generic class with default argument in initialize (#394)" do
+  it("instantiates generic class with default argument in initialize (#394)") do
     assert_type(%(
       class Foo(T)
         def initialize(x = 1)
@@ -267,7 +267,7 @@ describe "Semantic: generic class" do
       )) { generic_class "Foo", int32 }
   end
 
-  it "inherits class methods from generic class" do
+  it("inherits class methods from generic class") do
     assert_type(%(
       class Foo(T)
         def self.foo
@@ -282,7 +282,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "creates pointer of generic type and uses it" do
+  it("creates pointer of generic type and uses it") do
     assert_type(%(
       abstract class Foo(T)
       end
@@ -299,7 +299,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "creates pointer of generic type and uses it (2)" do
+  it("creates pointer of generic type and uses it (2)") do
     assert_type(%(
       abstract class Foo(T)
       end
@@ -316,7 +316,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "errors if inheriting generic type and not specifying type vars (#460)" do
+  it("errors if inheriting generic type and not specifying type vars (#460)") do
     assert_error %(
       class Foo(T)
       end
@@ -328,7 +328,7 @@ describe "Semantic: generic class" do
   end
 
   %w(Object Value Reference Number Int Float Struct Class Proc Tuple Enum StaticArray Pointer).each do |type|
-    it "errors if using #{type} in a generic type" do
+    it("errors if using #{type} in a generic type") do
       assert_error %(
         Pointer(#{type})
         ),
@@ -336,14 +336,14 @@ describe "Semantic: generic class" do
     end
   end
 
-  it "errors if using Number | String in a generic type" do
+  it("errors if using Number | String in a generic type") do
     assert_error %(
       Pointer(Number | String)
       ),
       "can't use Number in unions yet, use a more specific type"
   end
 
-  it "errors if using Number in alias" do
+  it("errors if using Number in alias") do
     assert_error %(
       alias Alias = Number | String
       Alias
@@ -351,7 +351,7 @@ describe "Semantic: generic class" do
       "can't use Number in unions yet, use a more specific type"
   end
 
-  it "errors if using Number in recursive alias" do
+  it("errors if using Number in recursive alias") do
     assert_error %(
       alias Alias = Number | Pointer(Alias)
       Alias
@@ -359,7 +359,7 @@ describe "Semantic: generic class" do
       "can't use Number in unions yet, use a more specific type"
   end
 
-  it "finds generic type argument from method with default value" do
+  it("finds generic type argument from method with default value") do
     assert_type(%(
       module It(T)
         def foo(x = 0)
@@ -375,7 +375,7 @@ describe "Semantic: generic class" do
       )) { int32.metaclass }
   end
 
-  it "allows initializing instance variable (#665)" do
+  it("allows initializing instance variable (#665)") do
     assert_type(%(
       class SomeType(T)
         @x = 0
@@ -389,7 +389,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "allows initializing instance variable in inherited generic type" do
+  it("allows initializing instance variable in inherited generic type") do
     assert_type(%(
       class Foo(T)
         @x = 1
@@ -407,7 +407,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "calls super on generic type when superclass has no initialize (#933)" do
+  it("calls super on generic type when superclass has no initialize (#933)") do
     assert_type(%(
       class Foo(T)
       end
@@ -422,7 +422,7 @@ describe "Semantic: generic class" do
     )) { generic_class "Bar", float32 }
   end
 
-  it "initializes instance variable of generic type using type var (#961)" do
+  it("initializes instance variable of generic type using type var (#961)") do
     assert_type(%(
       class Bar(T)
       end
@@ -439,21 +439,21 @@ describe "Semantic: generic class" do
       )) { generic_class "Bar", int32 }
   end
 
-  it "errors if passing integer literal to Proc as generic argument (#1120)" do
+  it("errors if passing integer literal to Proc as generic argument (#1120)") do
     assert_error %(
       Proc(32)
       ),
       "argument to Proc must be a type, not 32"
   end
 
-  it "errors if passing integer literal to Tuple as generic argument (#1120)" do
+  it("errors if passing integer literal to Tuple as generic argument (#1120)") do
     assert_error %(
       Tuple(32)
       ),
       "argument to Tuple must be a type, not 32"
   end
 
-  it "disallow using a non-instantiated generic type as a generic type argument" do
+  it("disallow using a non-instantiated generic type as a generic type argument") do
     assert_error %(
       class Foo(T)
       end
@@ -466,7 +466,7 @@ describe "Semantic: generic class" do
       "use a more specific type"
   end
 
-  it "disallow using a non-instantiated module type as a generic type argument" do
+  it("disallow using a non-instantiated module type as a generic type argument") do
     assert_error %(
       module Moo(T)
       end
@@ -479,7 +479,7 @@ describe "Semantic: generic class" do
       "use a more specific type"
   end
 
-  it "errors on too nested generic instance" do
+  it("errors on too nested generic instance") do
     assert_error %(
       class Foo(T)
       end
@@ -493,7 +493,7 @@ describe "Semantic: generic class" do
       "generic type too nested"
   end
 
-  it "errors on too nested generic instance, with union type" do
+  it("errors on too nested generic instance, with union type") do
     assert_error %(
       class Foo(T)
       end
@@ -507,7 +507,7 @@ describe "Semantic: generic class" do
       "generic type too nested"
   end
 
-  it "errors on too nested tuple instance" do
+  it("errors on too nested tuple instance") do
     assert_error %(
       def foo
         {typeof(foo)}
@@ -518,7 +518,7 @@ describe "Semantic: generic class" do
       "tuple type too nested"
   end
 
-  it "gives helpful error message when generic type var is missing (#1526)" do
+  it("gives helpful error message when generic type var is missing (#1526)") do
     assert_error %(
       class Foo(T)
         def initialize(x)
@@ -530,7 +530,7 @@ describe "Semantic: generic class" do
       "can't infer the type parameter T for the generic class Foo(T). Please provide it explicitly"
   end
 
-  it "gives helpful error message when generic type var is missing in block spec (#1526)" do
+  it("gives helpful error message when generic type var is missing in block spec (#1526)") do
     assert_error %(
       class Foo(T)
         def initialize(&block : T -> )
@@ -543,7 +543,7 @@ describe "Semantic: generic class" do
       "can't infer the type parameter T for the generic class Foo(T). Please provide it explicitly"
   end
 
-  it "can define instance var forward declared (#962)" do
+  it("can define instance var forward declared (#962)") do
     assert_type(%(
       class ClsA
         @c : ClsB(Int32)
@@ -570,7 +570,7 @@ describe "Semantic: generic class" do
       )) { int64 }
   end
 
-  it "inherits instance var type annotation from generic to concrete" do
+  it("inherits instance var type annotation from generic to concrete") do
     assert_type(%(
       class Foo(T)
         @x : Int32?
@@ -587,7 +587,7 @@ describe "Semantic: generic class" do
       )) { nilable int32 }
   end
 
-  it "inherits instance var type annotation from generic to concrete with T" do
+  it("inherits instance var type annotation from generic to concrete with T") do
     assert_type(%(
       class Foo(T)
         @x : T?
@@ -604,7 +604,7 @@ describe "Semantic: generic class" do
       )) { nilable int32 }
   end
 
-  it "inherits instance var type annotation from generic to generic to concrete" do
+  it("inherits instance var type annotation from generic to generic to concrete") do
     assert_type(%(
       class Foo(T)
         @x : Int32?
@@ -624,7 +624,7 @@ describe "Semantic: generic class" do
       )) { nilable int32 }
   end
 
-  it "doesn't duplicate overload on generic class class method (#2385)" do
+  it("doesn't duplicate overload on generic class class method (#2385)") do
     nodes = parse(%(
       class Foo(T)
         def self.foo(x : Int32)
@@ -669,7 +669,7 @@ describe "Semantic: generic class" do
   #
   # However, here we will be inserting a `Child2` inside a `Child1`,
   # which is totally incorrect.
-  it "doesn't allow union of generic class with module to be assigned to a generic class with module (#2425)" do
+  it("doesn't allow union of generic class with module to be assigned to a generic class with module (#2425)") do
     assert_error %(
       module Plugin
       end
@@ -693,7 +693,7 @@ describe "Semantic: generic class" do
       "instance variable '@value' of Bar must be PluginContainer(Plugin), not PluginContainer(Foo)"
   end
 
-  it "instantiates generic variadic class, accesses T from class method" do
+  it("instantiates generic variadic class, accesses T from class method") do
     assert_type(%(
       class Foo(*T)
         def self.t
@@ -705,7 +705,7 @@ describe "Semantic: generic class" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
-  it "instantiates generic variadic class, accesses T from instance method" do
+  it("instantiates generic variadic class, accesses T from instance method") do
     assert_type(%(
       class Foo(*T)
         def t
@@ -717,7 +717,7 @@ describe "Semantic: generic class" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
-  it "splats generic type var" do
+  it("splats generic type var") do
     assert_type(%(
       class Foo(X, Y)
         def self.vars
@@ -729,7 +729,7 @@ describe "Semantic: generic class" do
       )) { tuple_of([int32.metaclass, char.metaclass]) }
   end
 
-  it "instantiates generic variadic class, accesses T from instance method, more args" do
+  it("instantiates generic variadic class, accesses T from instance method, more args") do
     assert_type(%(
       class Foo(*T, R)
         def t
@@ -741,7 +741,7 @@ describe "Semantic: generic class" do
       )) { tuple_of([tuple_of([int32, float64]).metaclass, char.metaclass]) }
   end
 
-  it "instantiates generic variadic class, accesses T from instance method, more args (2)" do
+  it("instantiates generic variadic class, accesses T from instance method, more args (2)") do
     assert_type(%(
       class Foo(A, *T, R)
         def t
@@ -753,7 +753,7 @@ describe "Semantic: generic class" do
       )) { tuple_of([int32.metaclass, tuple_of([float64]).metaclass, char.metaclass]) }
   end
 
-  it "virtual metaclass type implements super virtual metaclass type (#3007)" do
+  it("virtual metaclass type implements super virtual metaclass type (#3007)") do
     assert_type(%(
       class Base
       end
@@ -784,7 +784,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "can use virtual type for generic class" do
+  it("can use virtual type for generic class") do
     assert_type(%(
       class Foo(T)
         def foo
@@ -812,7 +812,7 @@ describe "Semantic: generic class" do
       )) { union_of int32, char }
   end
 
-  it "recomputes on new subclass" do
+  it("recomputes on new subclass") do
     assert_type(%(
       class Foo(T)
         def foo
@@ -849,7 +849,7 @@ describe "Semantic: generic class" do
       )) { union_of(int32, char) }
   end
 
-  it "types macro def with generic instance" do
+  it("types macro def with generic instance") do
     assert_type(%(
       class Reference
         def foo
@@ -869,7 +869,7 @@ describe "Semantic: generic class" do
       )) { string }
   end
 
-  it "unifies generic metaclass types" do
+  it("unifies generic metaclass types") do
     assert_type(%(
       class Foo(T)
       end
@@ -881,7 +881,7 @@ describe "Semantic: generic class" do
       )) { generic_class("Foo", int32).metaclass.virtual_type! }
   end
 
-  it "doesn't crash when matching restriction against number literal (#3157)" do
+  it("doesn't crash when matching restriction against number literal (#3157)") do
     assert_error %(
       class Gen(T)
         @value : String?
@@ -895,7 +895,7 @@ describe "Semantic: generic class" do
       "no overload matches"
   end
 
-  it "doesn't crash when matching restriction against number literal (2) (#3157)" do
+  it("doesn't crash when matching restriction against number literal (2) (#3157)") do
     assert_error %(
       class Cls(T)
         @a : T?
@@ -906,7 +906,7 @@ describe "Semantic: generic class" do
       "expected type, not NumberLiteral"
   end
 
-  it "replaces type parameters for virtual types (#3235)" do
+  it("replaces type parameters for virtual types (#3235)") do
     assert_type(%(
       abstract class Packet(T)
       end
@@ -931,7 +931,7 @@ describe "Semantic: generic class" do
       )) { generic_class "Array", generic_class("OutgoingPacket", types["Client"]).virtual_type! }
   end
 
-  it "nests generics with the same type var (#3297)" do
+  it("nests generics with the same type var (#3297)") do
     assert_type(%(
       class Foo(A)
         @a : A
@@ -951,7 +951,7 @@ describe "Semantic: generic class" do
       ), inject_primitives: false) { symbol }
   end
 
-  it "restricts virtual generic instance type against generic (#3351)" do
+  it("restricts virtual generic instance type against generic (#3351)") do
     assert_type(%(
       class Gen(T)
       end
@@ -967,7 +967,7 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
-  it "subclasses twice with same generic class (#3423)" do
+  it("subclasses twice with same generic class (#3423)") do
     assert_type(%(
       class Foo(T)
       end
@@ -982,7 +982,7 @@ describe "Semantic: generic class" do
       )) { generic_class "Bar", int32 }
   end
 
-  it "errors if invoking new on private new in generic type (#3485)" do
+  it("errors if invoking new on private new in generic type (#3485)") do
     assert_error %(
       class Foo(T)
         private def self.new
@@ -995,7 +995,7 @@ describe "Semantic: generic class" do
       "private method 'new' called"
   end
 
-  it "never types Path as virtual outside generic type parameter (#3989)" do
+  it("never types Path as virtual outside generic type parameter (#3989)") do
     assert_type(%(
       class Base
       end
@@ -1019,7 +1019,7 @@ describe "Semantic: generic class" do
     )) { types["Base"].metaclass }
   end
 
-  it "never types Generic as virtual outside generic type parameter (#3989)" do
+  it("never types Generic as virtual outside generic type parameter (#3989)") do
     assert_type(%(
       class Base(T)
       end
@@ -1043,7 +1043,7 @@ describe "Semantic: generic class" do
     )) { generic_class("Base", int32).metaclass }
   end
 
-  it "doesn't find T type parameter of current type in superclass (#4604)" do
+  it("doesn't find T type parameter of current type in superclass (#4604)") do
     assert_error %(
       class X(T)
         abstract class A(T); end

--- a/spec/compiler/semantic/hooks_spec.cr
+++ b/spec/compiler/semantic/hooks_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: hooks" do
-  it "does inherited macro" do
+describe("Semantic: hooks") do
+  it("does inherited macro") do
     assert_type("
       class Foo
         macro inherited
@@ -18,7 +18,7 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
-  it "does included macro" do
+  it("does included macro") do
     assert_type("
       module Foo
         macro included
@@ -36,7 +36,7 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
-  it "does extended macro" do
+  it("does extended macro") do
     assert_type("
       module Foo
         macro extended
@@ -54,7 +54,7 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
-  it "does added method macro" do
+  it("does added method macro") do
     assert_type("
       class Foo
         macro method_added(d)
@@ -70,7 +70,7 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
-  it "errors if wrong inherited args size" do
+  it("errors if wrong inherited args size") do
     assert_error %(
       class Foo
         macro inherited(x)
@@ -79,7 +79,7 @@ describe "Semantic: hooks" do
       ), "macro 'inherited' must not have arguments"
   end
 
-  it "errors if wrong included args size" do
+  it("errors if wrong included args size") do
     assert_error %(
       module Foo
         macro included(x)
@@ -88,7 +88,7 @@ describe "Semantic: hooks" do
       ), "macro 'included' must not have arguments"
   end
 
-  it "errors if wrong extended args size" do
+  it("errors if wrong extended args size") do
     assert_error %(
       module Foo
         macro extended(x)
@@ -97,7 +97,7 @@ describe "Semantic: hooks" do
       ), "macro 'extended' must not have arguments"
   end
 
-  it "types initializer in inherited" do
+  it("types initializer in inherited") do
     assert_type(%(
       abstract class Foo
         macro inherited
@@ -122,7 +122,7 @@ describe "Semantic: hooks" do
       )) { string }
   end
 
-  it "errors if wrong extended args length" do
+  it("errors if wrong extended args length") do
     assert_error %(
       class Foo
         macro method_added
@@ -131,7 +131,7 @@ describe "Semantic: hooks" do
       ), "macro 'method_added' must have a argument"
   end
 
-  it "includes error message in included hook (#889)" do
+  it("includes error message in included hook (#889)") do
     assert_error %(
       module Doable
         macro included
@@ -148,7 +148,7 @@ describe "Semantic: hooks" do
       "undefined macro method 'MacroId#unknown'"
   end
 
-  it "does included macro for generic module" do
+  it("does included macro for generic module") do
     assert_type(%(
       module Mod(T)
         macro included
@@ -166,7 +166,7 @@ describe "Semantic: hooks" do
       )) { int32 }
   end
 
-  it "does inherited macro for generic class" do
+  it("does inherited macro for generic class") do
     assert_type(%(
       class Foo(T)
         macro inherited
@@ -183,7 +183,7 @@ describe "Semantic: hooks" do
       )) { int32 }
   end
 
-  it "types macro finished hook bug regarding initialize (#3964)" do
+  it("types macro finished hook bug regarding initialize (#3964)") do
     assert_type(%(
       class A1
         macro finished

--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -1,19 +1,19 @@
 require "../../spec_helper"
 
-describe "Semantic: if" do
-  it "types an if without else" do
+describe("Semantic: if") do
+  it("types an if without else") do
     assert_type("if 1 == 1; 1; end") { nilable int32 }
   end
 
-  it "types an if with else of same type" do
+  it("types an if with else of same type") do
     assert_type("if 1 == 1; 1; else; 2; end") { int32 }
   end
 
-  it "types an if with else of different type" do
+  it("types an if with else of different type") do
     assert_type("if 1 == 1; 1; else; 'a'; end") { union_of(int32, char) }
   end
 
-  it "types and if with and and assignment" do
+  it("types and if with and and assignment") do
     assert_type("
       struct Number
         def abs
@@ -34,7 +34,7 @@ describe "Semantic: if" do
       ") { nilable int32 }
   end
 
-  it "can invoke method on var that is declared on the right hand side of an and" do
+  it("can invoke method on var that is declared on the right hand side of an and") do
     assert_type("
       if 1 == 2 && (b = 1)
         b + 1
@@ -42,7 +42,7 @@ describe "Semantic: if" do
       ") { nilable int32 }
   end
 
-  it "errors if requires inside if" do
+  it("errors if requires inside if") do
     assert_error %(
       if 1 == 2
         require "foo"
@@ -51,7 +51,7 @@ describe "Semantic: if" do
       "can't require dynamically"
   end
 
-  it "correctly filters type of variable if there's a raise with an interpolation that can't be typed" do
+  it("correctly filters type of variable if there's a raise with an interpolation that can't be typed") do
     assert_type(%(
       require "prelude"
 
@@ -71,7 +71,7 @@ describe "Semantic: if" do
       )) { int32 }
   end
 
-  it "passes bug (related to #1729)" do
+  it("passes bug (related to #1729)") do
     assert_type(%(
       n = true ? 3 : 3.2
       if n.is_a?(Float64)
@@ -81,28 +81,28 @@ describe "Semantic: if" do
       )) { union_of(int32, float64) }
   end
 
-  it "restricts the type of the right hand side of an || when using is_a? (#1728)" do
+  it("restricts the type of the right hand side of an || when using is_a? (#1728)") do
     assert_type(%(
       n = 3 || "foobar"
       n.is_a?(String) || (n + 1 == 2)
       )) { bool }
   end
 
-  it "restricts type with !var and ||" do
+  it("restricts type with !var and ||") do
     assert_type(%(
       a = 1 == 1 ? 1 : nil
       !a || a + 2
       )) { union_of bool, int32 }
   end
 
-  it "restricts type with !var.is_a?(...) and ||" do
+  it("restricts type with !var.is_a?(...) and ||") do
     assert_type(%(
       a = 1 == 1 ? 1 : nil
       !a.is_a?(Int32) || a + 2
       )) { union_of bool, int32 }
   end
 
-  it "restricts with || (#2464)" do
+  it("restricts with || (#2464)") do
     assert_type(%(
       struct Int32
         def foo
@@ -125,7 +125,7 @@ describe "Semantic: if" do
       )) { int32 }
   end
 
-  it "doesn't restrict with || on different vars" do
+  it("doesn't restrict with || on different vars") do
     assert_error %(
       struct Int32
         def foo
@@ -148,7 +148,7 @@ describe "Semantic: if" do
       "undefined method"
   end
 
-  it "doesn't restrict with || on var and non-restricting condition" do
+  it("doesn't restrict with || on var and non-restricting condition") do
     assert_error %(
       struct Int32
         def foo
@@ -164,7 +164,7 @@ describe "Semantic: if" do
       "undefined method"
   end
 
-  it "restricts with || but doesn't unify types to base class" do
+  it("restricts with || but doesn't unify types to base class") do
     assert_type(%(
       class Foo
       end
@@ -190,7 +190,7 @@ describe "Semantic: if" do
       )) { union_of(nil_type, int32, char) }
   end
 
-  it "restricts with && always falsey" do
+  it("restricts with && always falsey") do
     assert_type(%(
       x = 1
       if (x.is_a?(String) && x.is_a?(String)) && x.is_a?(String)
@@ -201,7 +201,7 @@ describe "Semantic: if" do
       )) { union_of(bool, int32) }
   end
 
-  it "doesn't filter and recombine when variables don't change in if" do
+  it("doesn't filter and recombine when variables don't change in if") do
     assert_type(%(
       module Moo
       end
@@ -228,7 +228,7 @@ describe "Semantic: if" do
       )) { int32 }
   end
 
-  it "types variable after unreachable else of && (#3360)" do
+  it("types variable after unreachable else of && (#3360)") do
     assert_type(%(
       def test
         foo = 1 if 1
@@ -240,7 +240,7 @@ describe "Semantic: if" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "restricts || else (1) (#3266)" do
+  it("restricts || else (1) (#3266)") do
     assert_type(%(
       a = 1 || nil
       b = 1 || nil
@@ -252,7 +252,7 @@ describe "Semantic: if" do
       ), inject_primitives: false) { tuple_of([int32, int32]) }
   end
 
-  it "restricts || else (2) (#3266)" do
+  it("restricts || else (2) (#3266)") do
     assert_type(%(
       a = 1 || nil
       if !a || 1
@@ -263,7 +263,7 @@ describe "Semantic: if" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "restricts || else (3) (#3266)" do
+  it("restricts || else (3) (#3266)") do
     assert_type(%(
       a = 1 || nil
       if 1 || !a
@@ -274,7 +274,7 @@ describe "Semantic: if" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "doesn't restrict || else in sub && (right)" do
+  it("doesn't restrict || else in sub && (right)") do
     assert_type(%(
       def foo
         a = 1 || nil
@@ -290,7 +290,7 @@ describe "Semantic: if" do
       )) { nilable int32 }
   end
 
-  it "doesn't restrict || else in sub && (left)" do
+  it("doesn't restrict || else in sub && (left)") do
     assert_type(%(
       def foo
         a = 1 || nil
@@ -306,7 +306,7 @@ describe "Semantic: if" do
       )) { nilable int32 }
   end
 
-  it "doesn't restrict || else in sub || (right)" do
+  it("doesn't restrict || else in sub || (right)") do
     assert_type(%(
       def foo
         a = 1 || nil
@@ -322,7 +322,7 @@ describe "Semantic: if" do
       )) { nilable int32 }
   end
 
-  it "doesn't restrict || else in sub || (left)" do
+  it("doesn't restrict || else in sub || (left)") do
     assert_type(%(
       def foo
         a = 1 || nil

--- a/spec/compiler/semantic/initialize_spec.cr
+++ b/spec/compiler/semantic/initialize_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: initialize" do
-  it "types instance vars as nilable if doesn't invoke super in initialize" do
+describe("Semantic: initialize") do
+  it("types instance vars as nilable if doesn't invoke super in initialize") do
     assert_error %(
       class Foo
         def initialize
@@ -25,7 +25,7 @@ describe "Semantic: initialize" do
       "this 'initialize' doesn't initialize instance variable '@baz' of Foo, with Bar < Foo, rendering it nilable"
   end
 
-  it "types instance vars as nilable if doesn't invoke super in initialize with deep subclass" do
+  it("types instance vars as nilable if doesn't invoke super in initialize with deep subclass") do
     assert_error %(
       class Foo
         def initialize
@@ -55,7 +55,7 @@ describe "Semantic: initialize" do
       "this 'initialize' doesn't initialize instance variable '@baz' of Foo, with BarBar < Foo, rendering it nilable"
   end
 
-  it "types instance vars as nilable if doesn't invoke super with default arguments" do
+  it("types instance vars as nilable if doesn't invoke super with default arguments") do
     node = parse("
       class Foo
         def initialize
@@ -83,7 +83,7 @@ describe "Semantic: initialize" do
     foo.instance_vars["@another"].type.should eq(mod.int32)
   end
 
-  it "checks instance vars of included modules" do
+  it("checks instance vars of included modules") do
     assert_error %(
       module Lala
         def lala
@@ -110,7 +110,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' of Foo must be (Char | Nil), not Int32"
   end
 
-  it "types instance var as nilable if not always assigned" do
+  it("types instance var as nilable if not always assigned") do
     assert_error %(
       class Foo
         def initialize
@@ -130,7 +130,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' of Foo must be Int32, not Nil"
   end
 
-  it "types instance var as nilable if assigned in block" do
+  it("types instance var as nilable if assigned in block") do
     assert_error %(
       def bar
         yield if 1 == 2
@@ -154,7 +154,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "types instance var as not-nilable if assigned in block but previosly assigned" do
+  it("types instance var as not-nilable if assigned in block but previosly assigned") do
     assert_type(%(
       def bar
         yield if 1 == 2
@@ -178,7 +178,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types instance var as nilable if used before assignment" do
+  it("types instance var as nilable if used before assignment") do
     assert_error %(
       class Foo
         def initialize
@@ -197,7 +197,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "types instance var as non-nilable if calls super and super defines it" do
+  it("types instance var as non-nilable if calls super and super defines it") do
     assert_type(%(
       class Parent
         def initialize
@@ -221,7 +221,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types instance var as non-nilable if calls super and super defines it, with one level of indirection" do
+  it("types instance var as non-nilable if calls super and super defines it, with one level of indirection") do
     assert_type(%(
       class Parent
         def initialize
@@ -248,7 +248,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "doesn't type instance var as nilable if out" do
+  it("doesn't type instance var as nilable if out") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32*)
@@ -270,7 +270,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types instance var as nilable if used after method call that reads var" do
+  it("types instance var as nilable if used after method call that reads var") do
     assert_error %(
       class Foo
         def initialize
@@ -293,7 +293,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "types instance var as nilable if used after method call that reads var (2)" do
+  it("types instance var as nilable if used after method call that reads var (2)") do
     assert_error %(
       class Bar
         def bar
@@ -321,7 +321,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "doesn't type instance var as nilable if used after global method call" do
+  it("doesn't type instance var as nilable if used after global method call") do
     assert_type(%(
       def foo
       end
@@ -342,7 +342,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "doesn't type instance var as nilable if used after method call inside typeof" do
+  it("doesn't type instance var as nilable if used after method call inside typeof") do
     assert_type(%(
       class Foo
         def initialize
@@ -364,7 +364,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "doesn't type instance var as nilable if used after method call that doesn't read var" do
+  it("doesn't type instance var as nilable if used after method call that doesn't read var") do
     assert_type(%(
       class Foo
         def initialize
@@ -385,7 +385,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types instance var as nilable if used after method call that reads var through other calls" do
+  it("types instance var as nilable if used after method call that reads var through other calls") do
     assert_error %(
       class Foo
         def initialize
@@ -420,7 +420,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "doesn't type instance var as nilable if used after method call that assigns var" do
+  it("doesn't type instance var as nilable if used after method call that assigns var") do
     assert_type(%(
       class Foo
         def initialize
@@ -442,7 +442,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "finishes when analyzing recursive calls" do
+  it("finishes when analyzing recursive calls") do
     assert_type(%(
       class Foo
         def initialize
@@ -468,7 +468,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "doesn't type instance var as nilable if not used in method call" do
+  it("doesn't type instance var as nilable if not used in method call") do
     assert_type(%(
       class Foo
         def initialize
@@ -491,7 +491,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types instance var as nilable if used in first of two method calls" do
+  it("types instance var as nilable if used in first of two method calls") do
     assert_error %(
       class Foo
         def initialize
@@ -514,7 +514,7 @@ describe "Semantic: initialize" do
       "instance variable '@x' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "doesn't type instance var as nilable if assigned before method call" do
+  it("doesn't type instance var as nilable if assigned before method call") do
     assert_type(%(
       class Foo
         def initialize
@@ -537,7 +537,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "marks instance variable as nilable in initialize if using self in method" do
+  it("marks instance variable as nilable in initialize if using self in method") do
     assert_error "
       class Foo
         def initialize
@@ -564,7 +564,7 @@ describe "Semantic: initialize" do
       "'self' was used before initializing instance variable '@foo', rendering it nilable"
   end
 
-  it "marks instance variable as nilable in initialize if using self" do
+  it("marks instance variable as nilable in initialize if using self") do
     assert_type("
       class Foo
         def initialize
@@ -586,7 +586,7 @@ describe "Semantic: initialize" do
       ") { nilable int32 }
   end
 
-  it "marks instance variable as nilable in initialize if assigning self" do
+  it("marks instance variable as nilable in initialize if assigning self") do
     assert_type(%(
       class Foo
         def initialize
@@ -608,7 +608,7 @@ describe "Semantic: initialize" do
       )) { nilable int32 }
   end
 
-  it "marks instance variable as nilable when using self in super" do
+  it("marks instance variable as nilable when using self in super") do
     assert_type("
       class Parent
         def initialize(foo)
@@ -630,7 +630,7 @@ describe "Semantic: initialize" do
       ") { nilable int32 }
   end
 
-  it "errors if found matches for initialize but doesn't cover all (bug #204)" do
+  it("errors if found matches for initialize but doesn't cover all (bug #204)") do
     assert_error "
       class Foo
         def initialize(x : Int32)
@@ -643,7 +643,7 @@ describe "Semantic: initialize" do
       "no overload matches"
   end
 
-  it "doesn't mark instance variable as nilable when using self.class" do
+  it("doesn't mark instance variable as nilable when using self.class") do
     assert_type("
       class Foo
         def initialize
@@ -663,7 +663,7 @@ describe "Semantic: initialize" do
       ") { int32 }
   end
 
-  it "doesn't mark instance variable as nilable when using self.class in method" do
+  it("doesn't mark instance variable as nilable when using self.class in method") do
     assert_type("
       class Foo
         def initialize
@@ -687,7 +687,7 @@ describe "Semantic: initialize" do
       ") { int32 }
   end
 
-  it "types initializer of recursive generic type" do
+  it("types initializer of recursive generic type") do
     assert_type(%(
       class Foo(T)
         @x = 1
@@ -703,7 +703,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "types initializer of generic type after instantiated" do
+  it("types initializer of generic type after instantiated") do
     assert_type(%(
       class Foo(T)
       end
@@ -722,7 +722,7 @@ describe "Semantic: initialize" do
       )) { int32 }
   end
 
-  it "errors on default new when using named arguments (#2245)" do
+  it("errors on default new when using named arguments (#2245)") do
     assert_error %(
       class Foo
       end
@@ -732,7 +732,7 @@ describe "Semantic: initialize" do
       "no argument named 'x'"
   end
 
-  it "doesn't type ivar as nilable if super call present and parent has already typed ivar (#4764)" do
+  it("doesn't type ivar as nilable if super call present and parent has already typed ivar (#4764)") do
     assert_type(%(
       class Foo
         def initialize(@a = 1)

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: instance var" do
-  it "declares instance var" do
+describe("Semantic: instance var") do
+  it("declares instance var") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -20,7 +20,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var multiple times, last one wins" do
+  it("declares instance var multiple times, last one wins") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -40,7 +40,7 @@ describe "Semantic: instance var" do
       )) { union_of(int32, float64) }
   end
 
-  it "doesn't error when redeclaring subclass variable with the same type" do
+  it("doesn't error when redeclaring subclass variable with the same type") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -63,7 +63,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "errors when redeclaring subclass variable with a different type" do
+  it("errors when redeclaring subclass variable with a different type") do
     assert_error %(
       class Foo
         @x : Int32
@@ -87,7 +87,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo, with Bar < Foo, is already declared as Int32"
   end
 
-  it "declares instance var in module, inherits to type" do
+  it("declares instance var in module, inherits to type") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -110,7 +110,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var in module, inherits to type recursively" do
+  it("declares instance var in module, inherits to type recursively") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -137,7 +137,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic type" do
+  it("declares instance var of generic type") do
     assert_type(%(
       class Foo(T)
         @x : T
@@ -154,7 +154,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic type, with no type parameter" do
+  it("declares instance var of generic type, with no type parameter") do
     assert_type(%(
       class Foo(T)
         @x : Int32
@@ -171,7 +171,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic type, with generic type" do
+  it("declares instance var of generic type, with generic type") do
     assert_type(%(
       class Gen(T)
       end
@@ -191,7 +191,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Gen", int32 }
   end
 
-  it "declares instance var of generic type, with union" do
+  it("declares instance var of generic type, with union") do
     assert_type(%(
       class Foo(T)
         @x : T | Char
@@ -208,7 +208,7 @@ describe "Semantic: instance var" do
       )) { union_of int32, char }
   end
 
-  it "declares instance var of generic type, with proc" do
+  it("declares instance var of generic type, with proc") do
     assert_type(%(
       class Foo(T)
         @x : T, T -> Int32
@@ -225,7 +225,7 @@ describe "Semantic: instance var" do
       )) { proc_of([char, char, int32]) }
   end
 
-  it "declares instance var of generic type, with tuple" do
+  it("declares instance var of generic type, with tuple") do
     assert_type(%(
       class Foo(T)
         @x : {T, Int32, T}
@@ -242,7 +242,7 @@ describe "Semantic: instance var" do
       )) { tuple_of([char, int32, char]) }
   end
 
-  it "declares instance var of generic type, with metaclass" do
+  it("declares instance var of generic type, with metaclass") do
     assert_type(%(
       class Foo(T)
         @x : T.class
@@ -259,7 +259,7 @@ describe "Semantic: instance var" do
       )) { int32.metaclass }
   end
 
-  it "declares instance var of generic type, with virtual metaclass" do
+  it("declares instance var of generic type, with virtual metaclass") do
     assert_type(%(
       class Bar; end
       class Baz < Bar; end
@@ -279,7 +279,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"].virtual_type!.metaclass }
   end
 
-  it "declares instance var of generic type, with static array" do
+  it("declares instance var of generic type, with static array") do
     assert_type(%(
       class Foo(T)
         @x : UInt8[T]
@@ -297,7 +297,7 @@ describe "Semantic: instance var" do
       )) { static_array_of(uint8, 3) }
   end
 
-  it "declares instance var with self, on generic" do
+  it("declares instance var with self, on generic") do
     assert_type(%(
       class Foo(T)
         @x : self | Nil
@@ -311,7 +311,7 @@ describe "Semantic: instance var" do
       )) { nilable generic_class("Foo", int32) }
   end
 
-  it "errors if declaring variable with number" do
+  it("errors if declaring variable with number") do
     assert_error %(
       class Foo(T)
         @x : T
@@ -329,7 +329,7 @@ describe "Semantic: instance var" do
       "can't declare variable with NumberLiteral"
   end
 
-  it "declares instance var of generic type through module" do
+  it("declares instance var of generic type through module") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -352,7 +352,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic type subclass" do
+  it("declares instance var of generic type subclass") do
     assert_type(%(
       class Foo(T)
         @x : T
@@ -372,7 +372,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic module" do
+  it("declares instance var of generic module") do
     assert_type(%(
       module Moo(T)
         @x : T
@@ -395,7 +395,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic module (2)" do
+  it("declares instance var of generic module (2)") do
     assert_type(%(
       module Moo(U)
         @x : U
@@ -418,7 +418,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "declares instance var of generic module from non-generic module" do
+  it("declares instance var of generic module from non-generic module") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -449,7 +449,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from number literal" do
+  it("infers type from number literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -465,7 +465,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from char literal" do
+  it("infers type from char literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -481,7 +481,7 @@ describe "Semantic: instance var" do
       )) { char }
   end
 
-  it "infers type from bool literal" do
+  it("infers type from bool literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -497,7 +497,7 @@ describe "Semantic: instance var" do
       )) { bool }
   end
 
-  it "infers type from string literal" do
+  it("infers type from string literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -513,7 +513,7 @@ describe "Semantic: instance var" do
       )) { string }
   end
 
-  it "infers type from string interpolation" do
+  it("infers type from string interpolation") do
     assert_type(%(
       require "prelude"
 
@@ -531,7 +531,7 @@ describe "Semantic: instance var" do
       )) { string }
   end
 
-  it "infers type from symbol literal" do
+  it("infers type from symbol literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -547,7 +547,7 @@ describe "Semantic: instance var" do
       )) { symbol }
   end
 
-  it "infers type from array literal with of" do
+  it("infers type from array literal with of") do
     assert_type(%(
       class Foo
         def initialize
@@ -563,7 +563,7 @@ describe "Semantic: instance var" do
       )) { array_of int32 }
   end
 
-  it "infers type from array literal with of metaclass" do
+  it("infers type from array literal with of metaclass") do
     assert_type(%(
       class Foo
         def initialize
@@ -579,7 +579,7 @@ describe "Semantic: instance var" do
       )) { array_of int32.metaclass }
   end
 
-  it "infers type from array literal from its literals" do
+  it("infers type from array literal from its literals") do
     assert_type(%(
       require "prelude"
 
@@ -597,7 +597,7 @@ describe "Semantic: instance var" do
       )) { array_of union_of(int32, char) }
   end
 
-  it "infers type from hash literal with of" do
+  it("infers type from hash literal with of") do
     assert_type(%(
       class Foo
         def initialize
@@ -613,7 +613,7 @@ describe "Semantic: instance var" do
       )) { hash_of int32, string }
   end
 
-  it "infers type from hash literal from elements" do
+  it("infers type from hash literal from elements") do
     assert_type(%(
       require "prelude"
 
@@ -631,7 +631,7 @@ describe "Semantic: instance var" do
       )) { hash_of(union_of(int32, char), union_of(string, bool)) }
   end
 
-  it "infers type from range literal" do
+  it("infers type from range literal") do
     assert_type(%(
       require "prelude"
 
@@ -649,7 +649,7 @@ describe "Semantic: instance var" do
       )) { range_of(int32, char) }
   end
 
-  it "infers type from regex literal" do
+  it("infers type from regex literal") do
     assert_type(%(
       require "prelude"
 
@@ -667,7 +667,7 @@ describe "Semantic: instance var" do
       )) { types["Regex"] }
   end
 
-  it "infers type from regex literal with interpolation" do
+  it("infers type from regex literal with interpolation") do
     assert_type(%(
       require "prelude"
 
@@ -685,7 +685,7 @@ describe "Semantic: instance var" do
       )) { types["Regex"] }
   end
 
-  it "infers type from tuple literal" do
+  it("infers type from tuple literal") do
     assert_type(%(
       require "prelude"
 
@@ -703,7 +703,7 @@ describe "Semantic: instance var" do
       )) { tuple_of([int32, string]) }
   end
 
-  it "infers type from named tuple literal" do
+  it("infers type from named tuple literal") do
     assert_type(%(
       require "prelude"
 
@@ -721,7 +721,7 @@ describe "Semantic: instance var" do
       )) { named_tuple_of({"x": int32, "y": string}) }
   end
 
-  it "infers type from new expression" do
+  it("infers type from new expression") do
     assert_type(%(
       class Bar
       end
@@ -740,7 +740,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers type from as" do
+  it("infers type from as") do
     assert_type(%(
       class Foo
         def initialize
@@ -756,7 +756,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from as?" do
+  it("infers type from as?") do
     assert_type(%(
       class Foo
         def initialize
@@ -772,7 +772,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from argument restriction" do
+  it("infers type from argument restriction") do
     assert_type(%(
       class Foo
         def x=(@x : Int32)
@@ -787,7 +787,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from argument default value" do
+  it("infers type from argument default value") do
     assert_type(%(
       class Foo
         def set(@x = 1)
@@ -802,7 +802,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from lib fun call" do
+  it("infers type from lib fun call") do
     assert_type(%(
       lib LibFoo
         struct Bar
@@ -826,7 +826,7 @@ describe "Semantic: instance var" do
       )) { types["LibFoo"].types["Bar"] }
   end
 
-  it "infers type from lib variable" do
+  it("infers type from lib variable") do
     assert_type(%(
       lib LibFoo
         struct Bar
@@ -850,7 +850,7 @@ describe "Semantic: instance var" do
       )) { types["LibFoo"].types["Bar"] }
   end
 
-  it "infers type from ||" do
+  it("infers type from ||") do
     assert_type(%(
       class Foo
         def initialize
@@ -866,7 +866,7 @@ describe "Semantic: instance var" do
       )) { union_of(int32, bool) }
   end
 
-  it "infers type from &&" do
+  it("infers type from &&") do
     assert_type(%(
       class Foo
         def initialize
@@ -882,7 +882,7 @@ describe "Semantic: instance var" do
       )) { union_of(int32, bool) }
   end
 
-  it "infers type from ||=" do
+  it("infers type from ||=") do
     assert_type(%(
       class Foo
         def x
@@ -894,7 +894,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from ||= inside another assignemnt" do
+  it("infers type from ||= inside another assignemnt") do
     assert_type(%(
       class Foo
         def x
@@ -906,7 +906,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from if" do
+  it("infers type from if") do
     assert_type(%(
       class Foo
         def initialize
@@ -922,7 +922,7 @@ describe "Semantic: instance var" do
       )) { union_of(int32, bool) }
   end
 
-  it "infers type from case" do
+  it("infers type from case") do
     assert_type(%(
       require "prelude"
 
@@ -945,7 +945,7 @@ describe "Semantic: instance var" do
       )) { union_of(char, bool) }
   end
 
-  it "infers type from unless" do
+  it("infers type from unless") do
     assert_type(%(
       class Foo
         def initialize
@@ -965,7 +965,7 @@ describe "Semantic: instance var" do
       )) { union_of(int32, bool) }
   end
 
-  it "infers type from begin" do
+  it("infers type from begin") do
     assert_type(%(
       class Foo
         def initialize
@@ -984,7 +984,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from assign (1)" do
+  it("infers type from assign (1)") do
     assert_type(%(
       class Foo
         def initialize
@@ -1000,7 +1000,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from assign (2)" do
+  it("infers type from assign (2)") do
     assert_type(%(
       class Foo
         def initialize
@@ -1016,7 +1016,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from block argument" do
+  it("infers type from block argument") do
     assert_type(%(
       class Foo
         def set(&@x : Int32 -> Int32)
@@ -1031,7 +1031,7 @@ describe "Semantic: instance var" do
       )) { nilable proc_of(int32, int32) }
   end
 
-  it "infers type from block argument without restriction" do
+  it("infers type from block argument without restriction") do
     assert_type(%(
       class Foo
         def set(&@x)
@@ -1046,7 +1046,7 @@ describe "Semantic: instance var" do
       )) { nilable proc_of(void) }
   end
 
-  it "infers type from !" do
+  it("infers type from !") do
     assert_type(%(
       class Foo
         def initialize
@@ -1062,7 +1062,7 @@ describe "Semantic: instance var" do
       )) { bool }
   end
 
-  it "infers type from is_a?" do
+  it("infers type from is_a?") do
     assert_type(%(
       class Foo
         def initialize
@@ -1078,7 +1078,7 @@ describe "Semantic: instance var" do
       )) { bool }
   end
 
-  it "infers type from responds_to?" do
+  it("infers type from responds_to?") do
     assert_type(%(
       class Foo
         def initialize
@@ -1094,7 +1094,7 @@ describe "Semantic: instance var" do
       )) { bool }
   end
 
-  it "infers type from sizeof" do
+  it("infers type from sizeof") do
     assert_type(%(
       class Foo
         def initialize
@@ -1110,7 +1110,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from instance_sizeof" do
+  it("infers type from instance_sizeof") do
     assert_type(%(
       class Foo
         def initialize
@@ -1126,7 +1126,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from path that is a type" do
+  it("infers type from path that is a type") do
     assert_type(%(
       class Bar; end
       class Baz < Bar; end
@@ -1145,7 +1145,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"].virtual_type!.metaclass }
   end
 
-  it "infers type from path that is a constant" do
+  it("infers type from path that is a constant") do
     assert_type(%(
       CONST = 1
 
@@ -1163,7 +1163,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't infer type from redefined method" do
+  it("doesn't infer type from redefined method") do
     assert_type(%(
       class Foo
         def foo
@@ -1183,7 +1183,7 @@ describe "Semantic: instance var" do
       )) { nilable char }
   end
 
-  it "infers type from redefined method if calls previous_def" do
+  it("infers type from redefined method if calls previous_def") do
     assert_type(%(
       class Foo
         def foo
@@ -1204,7 +1204,7 @@ describe "Semantic: instance var" do
       )) { union_of(nil_type, int32, char) }
   end
 
-  it "infers type in multi assign" do
+  it("infers type in multi assign") do
     assert_type(%(
       class Foo
         def initialize
@@ -1224,7 +1224,7 @@ describe "Semantic: instance var" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "infers type from enum member" do
+  it("infers type from enum member") do
     assert_type(%(
       enum Color
         Red, Green, Blue
@@ -1244,7 +1244,7 @@ describe "Semantic: instance var" do
       )) { types["Color"] }
   end
 
-  it "infers type from two literals" do
+  it("infers type from two literals") do
     assert_type(%(
       class Foo
         def initialize
@@ -1261,7 +1261,7 @@ describe "Semantic: instance var" do
       )) { union_of int32, float64 }
   end
 
-  it "infers type from literal outside def" do
+  it("infers type from literal outside def") do
     assert_type(%(
       class Foo
         @x = 1
@@ -1275,7 +1275,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from literal outside def with initialize and type restriction" do
+  it("infers type from literal outside def with initialize and type restriction") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -1293,7 +1293,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from lib out (1)" do
+  it("infers type from lib out (1)") do
     assert_type(%(
       lib LibFoo
         struct Bar
@@ -1317,7 +1317,7 @@ describe "Semantic: instance var" do
       )) { types["LibFoo"].types["Bar"] }
   end
 
-  it "infers type from lib out (2)" do
+  it("infers type from lib out (2)") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32, y : Float64*) : Int32
@@ -1337,7 +1337,7 @@ describe "Semantic: instance var" do
       )) { float64 }
   end
 
-  it "infers type from lib out (3)" do
+  it("infers type from lib out (3)") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32, y : Float64*) : Int32
@@ -1357,7 +1357,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from uninitialized" do
+  it("infers type from uninitialized") do
     assert_type(%(
       class Foo
         def initialize
@@ -1373,7 +1373,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't infer for subclass if assigns another type (1)" do
+  it("doesn't infer for subclass if assigns another type (1)") do
     assert_error %(
       class Foo
         def initialize
@@ -1396,7 +1396,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo must be Int32, not Float64"
   end
 
-  it "doesn't infer for subclass if assigns another type (2)" do
+  it("doesn't infer for subclass if assigns another type (2)") do
     assert_error %(
       class Foo
       end
@@ -1422,7 +1422,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo must be Int32, not Float64"
   end
 
-  it "infers type from included module" do
+  it("infers type from included module") do
     assert_type(%(
       module Moo
         def initialize
@@ -1442,7 +1442,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from included module, outside def" do
+  it("infers type from included module, outside def") do
     assert_type(%(
       module Moo
         @x = 1
@@ -1460,7 +1460,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type from included module recursively" do
+  it("infers type from included module recursively") do
     assert_type(%(
       module Moo
         def initialize
@@ -1484,7 +1484,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type for generic class, with literal" do
+  it("infers type for generic class, with literal") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -1500,7 +1500,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type for generic class, with T.new" do
+  it("infers type for generic class, with T.new") do
     assert_type(%(
       class Bar
       end
@@ -1519,7 +1519,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers type for generic class, with T.new and literal" do
+  it("infers type for generic class, with T.new and literal") do
     assert_type(%(
       class Bar
       end
@@ -1539,7 +1539,7 @@ describe "Semantic: instance var" do
       )) { union_of types["Bar"], int32 }
   end
 
-  it "infers type for generic class, with lib call" do
+  it("infers type for generic class, with lib call") do
     assert_type(%(
       lib LibFoo
         struct Bar
@@ -1563,7 +1563,7 @@ describe "Semantic: instance var" do
       )) { types["LibFoo"].types["Bar"] }
   end
 
-  it "infers type for generic class, with &&" do
+  it("infers type for generic class, with &&") do
     assert_type(%(
       class Foo
       end
@@ -1585,7 +1585,7 @@ describe "Semantic: instance var" do
       )) { union_of(types["Foo"], types["Bar"]) }
   end
 
-  it "infers type for generic class, with begin" do
+  it("infers type for generic class, with begin") do
     assert_type(%(
       class Foo
       end
@@ -1607,7 +1607,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type for generic class, with if" do
+  it("infers type for generic class, with if") do
     assert_type(%(
       class Foo
       end
@@ -1629,7 +1629,7 @@ describe "Semantic: instance var" do
       )) { union_of(types["Foo"], types["Bar"]) }
   end
 
-  it "infers type for generic class, with case" do
+  it("infers type for generic class, with case") do
     assert_type(%(
       class Object
         def ===(other)
@@ -1660,7 +1660,7 @@ describe "Semantic: instance var" do
       )) { union_of(types["Foo"], types["Bar"]) }
   end
 
-  it "infers type for generic class, with assign (1)" do
+  it("infers type for generic class, with assign (1)") do
     assert_type(%(
       class Foo
       end
@@ -1679,7 +1679,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type for generic class, with assign (2)" do
+  it("infers type for generic class, with assign (2)") do
     assert_type(%(
       class Foo
       end
@@ -1698,7 +1698,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type for non-generic class, with assign" do
+  it("infers type for non-generic class, with assign") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -1717,7 +1717,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers type for generic module" do
+  it("infers type for generic module") do
     assert_type(%(
       class Foo
       end
@@ -1740,7 +1740,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type to be nilable if not initialized" do
+  it("infers type to be nilable if not initialized") do
     assert_type(%(
       class Foo
         def x
@@ -1753,7 +1753,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type to be non-nilable if initialized in all initialize" do
+  it("infers type to be non-nilable if initialized in all initialize") do
     assert_type(%(
       class Foo
         def initialize
@@ -1772,7 +1772,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "errors if not initialized in all initialize" do
+  it("errors if not initialized in all initialize") do
     assert_error %(
       class Foo
         def initialize
@@ -1792,7 +1792,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't explicitly initialize instance variable '@x' of Foo, rendering it nilable"
   end
 
-  it "doesn't error if not initializes in all initialize because declared as nilable" do
+  it("doesn't error if not initializes in all initialize because declared as nilable") do
     assert_type(%(
       class Foo
         @x : Int32?
@@ -1813,7 +1813,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type from argument with restriction, in generic" do
+  it("infers type from argument with restriction, in generic") do
     assert_type(%(
       class Foo(T)
         def initialize(@x : T)
@@ -1828,7 +1828,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "says undefined instance variable on read" do
+  it("says undefined instance variable on read") do
     assert_error %(
       class Foo
         def x
@@ -1841,7 +1841,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "says undefined instance variable on assign" do
+  it("says undefined instance variable on assign") do
     assert_error %(
       class Foo
         def x
@@ -1855,7 +1855,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "errors if declaring instance var and turns out to be nilable" do
+  it("errors if declaring instance var and turns out to be nilable") do
     assert_error %(
       class Foo
         @x : Int32
@@ -1864,7 +1864,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "doesn't if declaring nilable instance var and turns out to be nilable" do
+  it("doesn't if declaring nilable instance var and turns out to be nilable") do
     assert_type(%(
       class Foo
         @x : Int32?
@@ -1878,7 +1878,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "errors if declaring instance var and turns out to be nilable, in generic type" do
+  it("errors if declaring instance var and turns out to be nilable, in generic type") do
     assert_error %(
       class Foo(T)
         @x : T
@@ -1887,7 +1887,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo(T) was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "errors if declaring instance var and turns out to be nilable, in generic module type" do
+  it("errors if declaring instance var and turns out to be nilable, in generic module type") do
     assert_error %(
       module Moo(T)
         @x : T
@@ -1900,7 +1900,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "doesn't error if declaring instance var and doesn't out to be nilable, in generic module type" do
+  it("doesn't error if declaring instance var and doesn't out to be nilable, in generic module type") do
     assert_type(%(
       module Moo(T)
         @x : T
@@ -1922,7 +1922,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "errors if declaring instance var and turns out to be nilable, in generic module type in generic type" do
+  it("errors if declaring instance var and turns out to be nilable, in generic module type in generic type") do
     assert_error %(
       module Moo(T)
         @x : T
@@ -1935,7 +1935,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo(T) was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "doesn't error if not initializing variables but calling super" do
+  it("doesn't error if not initializing variables but calling super") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -1959,7 +1959,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing variables but calling previous_def (#3210)" do
+  it("doesn't error if not initializing variables but calling previous_def (#3210)") do
     assert_type(%(
       class Some
         def initialize
@@ -1979,7 +1979,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing variables but calling previous_def (2) (#3210)" do
+  it("doesn't error if not initializing variables but calling previous_def (2) (#3210)") do
     assert_type(%(
       class Some
         def initialize
@@ -2005,7 +2005,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "errors if not initializing super variables" do
+  it("errors if not initializing super variables") do
     assert_error %(
       class Foo
         @x : Int32
@@ -2023,7 +2023,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't initialize instance variable '@x' of Foo, with Bar < Foo, rendering it nilable"
   end
 
-  it "errors if not initializing super variables (2)" do
+  it("errors if not initializing super variables (2)") do
     assert_error %(
       class Foo
         @x : Int32
@@ -2042,7 +2042,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't initialize instance variable '@x' of Foo, with Bar < Foo, rendering it nilable"
   end
 
-  it "errors if not initializing super variables (3)" do
+  it("errors if not initializing super variables (3)") do
     assert_error %(
       class Foo
         def initialize
@@ -2059,7 +2059,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't initialize instance variable '@x' of Foo, with Bar < Foo, rendering it nilable"
   end
 
-  it "errors if not initializing super variable in generic" do
+  it("errors if not initializing super variable in generic") do
     assert_error %(
       class Foo(T)
         def initialize
@@ -2076,7 +2076,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't initialize instance variable '@x' of Foo(T), with Bar(T) < Foo(T), rendering it nilable"
   end
 
-  it "doesn't error if not calling super but initializing all variables" do
+  it("doesn't error if not calling super but initializing all variables") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -2100,7 +2100,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing variables but calling super in parent parent" do
+  it("doesn't error if not initializing variables but calling super in parent parent") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -2127,7 +2127,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing variables but calling super for module" do
+  it("doesn't error if not initializing variables but calling super for module") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -2153,7 +2153,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing variables but calling super for generic module" do
+  it("doesn't error if not initializing variables but calling super for generic module") do
     assert_type(%(
       module Moo(T)
         @x : T
@@ -2178,7 +2178,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "ignores redefined initialize (#456)" do
+  it("ignores redefined initialize (#456)") do
     assert_type(%(
       class Foo
         def initialize
@@ -2204,7 +2204,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "ignores super module initialize (#456)" do
+  it("ignores super module initialize (#456)") do
     assert_type(%(
       module Moo
         def initialize
@@ -2234,7 +2234,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "obeys super module initialize (#456)" do
+  it("obeys super module initialize (#456)") do
     assert_type(%(
       module Moo
         def initialize
@@ -2264,7 +2264,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if initializing var in superclass, and then empty initialize" do
+  it("doesn't error if initializing var in superclass, and then empty initialize") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -2284,7 +2284,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if calling initialize from another initialize (1)" do
+  it("doesn't error if calling initialize from another initialize (1)") do
     assert_type(%(
       class Foo
         def initialize(@x : Int32)
@@ -2303,7 +2303,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if calling initialize from another initialize (2)" do
+  it("doesn't error if calling initialize from another initialize (2)") do
     assert_type(%(
       class Foo
         def initialize(@x : Int32)
@@ -2324,7 +2324,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers nilable instance var of generic type" do
+  it("infers nilable instance var of generic type") do
     assert_type(%(
       class Foo(T)
         def set
@@ -2341,7 +2341,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers nilable instance var of generic module" do
+  it("infers nilable instance var of generic module") do
     assert_type(%(
       module Moo(T)
         def set
@@ -2362,7 +2362,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type to be nilable if self is used before assigning to a variable" do
+  it("infers type to be nilable if self is used before assigning to a variable") do
     assert_type(%(
       class Foo
         def initialize
@@ -2379,7 +2379,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "infers type to be nilable if self is used in same assign" do
+  it("infers type to be nilable if self is used in same assign") do
     assert_type(%(
       def foo(x)
       end
@@ -2398,7 +2398,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "doesn't infer type to be nilable if using self.class" do
+  it("doesn't infer type to be nilable if using self.class") do
     assert_type(%(
       class Foo
         def initialize
@@ -2415,7 +2415,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  pending "doesn't infer type to be nilable if using self.class in call in assign" do
+  pending("doesn't infer type to be nilable if using self.class in call in assign") do
     assert_type(%(
       def foo(x)
       end
@@ -2434,7 +2434,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't error if not initializing nilable var in subclass" do
+  it("doesn't error if not initializing nilable var in subclass") do
     assert_type(%(
       class Foo
         @x : Int32?
@@ -2456,7 +2456,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "considers var as assigned in multi-assign" do
+  it("considers var as assigned in multi-assign") do
     assert_type(%(
       def some
         {1, 2}
@@ -2484,7 +2484,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from another instance var" do
+  it("infers from another instance var") do
     assert_type(%(
       class Foo
         def initialize
@@ -2501,7 +2501,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from another instance var with type declaration" do
+  it("infers from another instance var with type declaration") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -2519,7 +2519,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from another instance var in generic type" do
+  it("infers from another instance var in generic type") do
     assert_type(%(
       class Bar
       end
@@ -2539,7 +2539,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from another instance var in generic type with type declaration" do
+  it("infers from another instance var in generic type with type declaration") do
     assert_type(%(
       class Bar
       end
@@ -2560,7 +2560,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "errors on udefined instance var and subclass calling super" do
+  it("errors on udefined instance var and subclass calling super") do
     assert_error %(
       class Foo
         def initialize(@x)
@@ -2584,7 +2584,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Bar"
   end
 
-  it "infers type from array literal in generic type" do
+  it("infers type from array literal in generic type") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -2600,7 +2600,7 @@ describe "Semantic: instance var" do
       )) { array_of(int32) }
   end
 
-  it "infers type from hash literal in generic type" do
+  it("infers type from hash literal in generic type") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -2616,7 +2616,7 @@ describe "Semantic: instance var" do
       )) { hash_of(int32, float64) }
   end
 
-  it "infers type from array literal with literals in generic type" do
+  it("infers type from array literal with literals in generic type") do
     assert_type(%(
       require "prelude"
 
@@ -2634,7 +2634,7 @@ describe "Semantic: instance var" do
       )) { array_of(int32) }
   end
 
-  it "infers type from hash literal with literals in generic type" do
+  it("infers type from hash literal with literals in generic type") do
     assert_type(%(
       require "prelude"
 
@@ -2652,7 +2652,7 @@ describe "Semantic: instance var" do
       )) { hash_of(int32, symbol) }
   end
 
-  it "infers from restriction using virtual type" do
+  it("infers from restriction using virtual type") do
     assert_type(%(
       class Foo; end
       class Bar < Foo; end
@@ -2670,7 +2670,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "doesn't duplicate instance var in subclass" do
+  it("doesn't duplicate instance var in subclass") do
     result = semantic(%(
       class Foo
         def initialize(@x : Int32)
@@ -2693,7 +2693,7 @@ describe "Semantic: instance var" do
     bar.instance_vars.empty?.should be_true
   end
 
-  it "infers type from custom array literal" do
+  it("infers type from custom array literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -2717,7 +2717,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type from custom generic array literal" do
+  it("infers type from custom generic array literal") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -2741,7 +2741,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Foo", int32 }
   end
 
-  it "infers type from custom hash literal" do
+  it("infers type from custom hash literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -2765,7 +2765,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type from custom generic hash literal" do
+  it("infers type from custom generic hash literal") do
     assert_type(%(
       class Foo(K, V)
         def initialize
@@ -2789,7 +2789,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Foo", int32, string }
   end
 
-  it "infers type from custom array literal in generic" do
+  it("infers type from custom array literal in generic") do
     assert_type(%(
       class Foo
         def initialize
@@ -2813,7 +2813,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type from custom hash literal in generic" do
+  it("infers type from custom hash literal in generic") do
     assert_type(%(
       class Foo
         def initialize
@@ -2837,7 +2837,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "says can't infer type if only nil was assigned" do
+  it("says can't infer type if only nil was assigned") do
     assert_error %(
       class Foo
         def initialize
@@ -2854,7 +2854,7 @@ describe "Semantic: instance var" do
       "instance variable @x of Foo was inferred to be Nil, but Nil alone provides no information"
   end
 
-  it "says can't infer type if only nil was assigned, in generic type" do
+  it("says can't infer type if only nil was assigned, in generic type") do
     assert_error %(
       class Foo(T)
         def initialize
@@ -2871,7 +2871,7 @@ describe "Semantic: instance var" do
       "instance variable @x of Foo(T) was inferred to be Nil, but Nil alone provides no information"
   end
 
-  it "allows nil instance var because it's a generic type" do
+  it("allows nil instance var because it's a generic type") do
     assert_type(%(
       class Foo(T)
         def initialize(@x : T)
@@ -2886,7 +2886,7 @@ describe "Semantic: instance var" do
       )) { nil_type }
   end
 
-  it "uses virtual types in fun" do
+  it("uses virtual types in fun") do
     assert_type(%(
       class Node; end
       class SubNode < Node; end
@@ -2904,7 +2904,7 @@ describe "Semantic: instance var" do
       )) { proc_of(types["Node"].virtual_type, types["Node"].virtual_type) }
   end
 
-  it "uses virtual types in union" do
+  it("uses virtual types in union") do
     assert_type(%(
       class Node; end
       class SubNode < Node; end
@@ -2922,7 +2922,7 @@ describe "Semantic: instance var" do
       )) { union_of(types["Node"].virtual_type, int32) }
   end
 
-  it "uses virtual types in self" do
+  it("uses virtual types in self") do
     assert_type(%(
       class Node
         def initialize
@@ -2943,7 +2943,7 @@ describe "Semantic: instance var" do
       )) { nilable types["Node"].virtual_type }
   end
 
-  it "infers from Pointer.malloc" do
+  it("infers from Pointer.malloc") do
     assert_type(%(
       class Foo
         def initialize
@@ -2959,7 +2959,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(int32) }
   end
 
-  it "infers from Pointer.malloc with two arguments" do
+  it("infers from Pointer.malloc with two arguments") do
     assert_type(%(
       require "prelude"
 
@@ -2977,7 +2977,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(uint8) }
   end
 
-  it "infers from Pointer.null" do
+  it("infers from Pointer.null") do
     assert_type(%(
       require "prelude"
 
@@ -2995,7 +2995,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(int32) }
   end
 
-  it "infers from Pointer.malloc in generic type" do
+  it("infers from Pointer.malloc in generic type") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -3011,7 +3011,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(int32) }
   end
 
-  it "infers from Pointer.null in generic type" do
+  it("infers from Pointer.null in generic type") do
     assert_type(%(
       require "prelude"
 
@@ -3029,7 +3029,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(int32) }
   end
 
-  it "infers from Pointer.malloc with two arguments in generic type" do
+  it("infers from Pointer.malloc with two arguments in generic type") do
     assert_type(%(
       require "prelude"
 
@@ -3047,7 +3047,7 @@ describe "Semantic: instance var" do
       )) { pointer_of(uint8) }
   end
 
-  it "doesn't infer generic type without type argument inside generic" do
+  it("doesn't infer generic type without type argument inside generic") do
     assert_error %(
       class Bar(T)
       end
@@ -3067,7 +3067,7 @@ describe "Semantic: instance var" do
       "can't use Bar(T) as the type of instance variable @bar of Foo(T), use a more specific type"
   end
 
-  it "doesn't crash on missing var on subclass, with superclass not specifying a type" do
+  it("doesn't crash on missing var on subclass, with superclass not specifying a type") do
     assert_error %(
       class Foo
         def initialize(@x)
@@ -3084,7 +3084,7 @@ describe "Semantic: instance var" do
       "this 'initialize' doesn't initialize instance variable '@x', rendering it nilable"
   end
 
-  it "doesn't complain if not initliazed in one initialize, but has initializer (#2465)" do
+  it("doesn't complain if not initliazed in one initialize, but has initializer (#2465)") do
     assert_type(%(
       class Foo
         @x = 1
@@ -3104,7 +3104,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "can declare type even if included module has a guessed var" do
+  it("can declare type even if included module has a guessed var") do
     assert_type(%(
       module Moo
         def foo
@@ -3130,7 +3130,7 @@ describe "Semantic: instance var" do
       )) { union_of int32, float64 }
   end
 
-  it "doesn't complain if declared type is recursive alias that's nilable" do
+  it("doesn't complain if declared type is recursive alias that's nilable") do
     assert_type(%(
       class Bar(T)
       end
@@ -3149,7 +3149,7 @@ describe "Semantic: instance var" do
       )) { types["Rec"] }
   end
 
-  it "infers from assign to local var (#2467)" do
+  it("infers from assign to local var (#2467)") do
     assert_type(%(
       class Foo
         def initialize
@@ -3165,7 +3165,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from assign to local var in generic type (#2467)" do
+  it("infers from assign to local var in generic type (#2467)") do
     assert_type(%(
       class Foo(T)
         def initialize
@@ -3181,7 +3181,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from class method that has type annotation" do
+  it("infers from class method that has type annotation") do
     assert_type(%(
       class Bar
         def self.bar : Bar
@@ -3203,7 +3203,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from class method that has type annotation, in generic class" do
+  it("infers from class method that has type annotation, in generic class") do
     assert_type(%(
       class Bar
         def self.bar : Bar
@@ -3225,7 +3225,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from generic class method that has type annotation" do
+  it("infers from generic class method that has type annotation") do
     assert_type(%(
       class Bar(T)
         def self.bar : self
@@ -3247,7 +3247,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Bar", int32 }
   end
 
-  it "infers from generic class method that has type annotation, without instantiating" do
+  it("infers from generic class method that has type annotation, without instantiating") do
     assert_type(%(
       class Bar(T)
         def self.bar : Int32
@@ -3269,7 +3269,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from class method that has type annotation, with overload" do
+  it("infers from class method that has type annotation, with overload") do
     assert_type(%(
       class Baz
       end
@@ -3303,7 +3303,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from class method that has type annotation, with multiple overloads matching, all with the same type" do
+  it("infers from class method that has type annotation, with multiple overloads matching, all with the same type") do
     assert_type(%(
       class Bar
         def self.bar(x : Int32) : Bar
@@ -3329,7 +3329,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from new with return type" do
+  it("infers from new with return type") do
     assert_type(%(
       class Foo
         def self.new : Int32
@@ -3351,7 +3351,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from new with return type in generic type" do
+  it("infers from new with return type in generic type") do
     assert_type(%(
       class Foo
         def self.new : Int32
@@ -3373,7 +3373,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from new with return type returning generic" do
+  it("infers from new with return type returning generic") do
     assert_type(%(
       class Foo(T)
         def self.new : Bar(T)
@@ -3398,7 +3398,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Bar", int32 }
   end
 
-  it "guesses from new on abstract class" do
+  it("guesses from new on abstract class") do
     assert_type(%(
       abstract class Foo
         def self.new : Bar
@@ -3425,7 +3425,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "errors on undefined constant" do
+  it("errors on undefined constant") do
     assert_error %(
       class Foo
         def initialize
@@ -3438,7 +3438,7 @@ describe "Semantic: instance var" do
       "undefined constant Bar"
   end
 
-  it "infers from class method that invokes new" do
+  it("infers from class method that invokes new") do
     assert_type(%(
       class Foo
         def initialize
@@ -3460,7 +3460,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infers from class method that has number literal" do
+  it("infers from class method that has number literal") do
     assert_type(%(
       class Foo
         def initialize
@@ -3482,7 +3482,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "infers from class method that refers to constant" do
+  it("infers from class method that refers to constant") do
     assert_type(%(
       class Foo
         def initialize
@@ -3506,7 +3506,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "infer from class method with multiple statements and return" do
+  it("infer from class method with multiple statements and return") do
     assert_type(%(
       class Foo
         def initialize
@@ -3531,7 +3531,7 @@ describe "Semantic: instance var" do
       )) { nilable int32 }
   end
 
-  it "doesn't infer from class method with multiple statements and return, on non-easy return" do
+  it("doesn't infer from class method with multiple statements and return, on non-easy return") do
     assert_error %(
       class Foo
         def initialize
@@ -3558,7 +3558,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "doesn't infer from class method with multiple statements and return, on non-easy return (2)" do
+  it("doesn't infer from class method with multiple statements and return, on non-easy return (2)") do
     assert_error %(
       class Foo
         def initialize
@@ -3586,7 +3586,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "infer from class method where new is redefined" do
+  it("infer from class method where new is redefined") do
     assert_type(%(
       class Foo
         def initialize
@@ -3612,7 +3612,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't crash on recursive method call" do
+  it("doesn't crash on recursive method call") do
     assert_error %(
       class Foo
         def initialize
@@ -3639,7 +3639,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "infers in multiple assign for tuple type (1)" do
+  it("infers in multiple assign for tuple type (1)") do
     assert_type(%(
       class Foo
         def initialize
@@ -3661,7 +3661,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "says can't infer (#2536)" do
+  it("says can't infer (#2536)") do
     assert_error %(
       require "prelude"
 
@@ -3685,7 +3685,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@foo' of Foo(Int32)"
   end
 
-  it "doesn't crash when inferring from new without matches (#2538)" do
+  it("doesn't crash when inferring from new without matches (#2538)") do
     assert_error %(
       class Foo
         @@default = Foo.new
@@ -3699,7 +3699,7 @@ describe "Semantic: instance var" do
       "wrong number of arguments for 'Foo.new'"
   end
 
-  it "guesses inside macro if" do
+  it("guesses inside macro if") do
     assert_type(%(
       {% if true %}
         class Foo
@@ -3717,7 +3717,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "guesses inside macro expression" do
+  it("guesses inside macro expression") do
     assert_type(%(
       {{ "class Foo; def initialize; @x = 1; end; def x; @x; end; end".id }}
 
@@ -3725,7 +3725,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "guesses inside macro for" do
+  it("guesses inside macro for") do
     assert_type(%(
       {% for name in %w(Foo) %}
         class {{name.id}}
@@ -3743,7 +3743,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "can't infer type from initializer" do
+  it("can't infer type from initializer") do
     assert_error %(
       class Foo
         @x = 1 + 2
@@ -3758,7 +3758,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo"
   end
 
-  it "can't infer type from initializer in non-generic module" do
+  it("can't infer type from initializer in non-generic module") do
     assert_error %(
       module Moo
         @x = 1 + 2
@@ -3777,7 +3777,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Moo"
   end
 
-  it "can't infer type from initializer in generic module type" do
+  it("can't infer type from initializer in generic module type") do
     assert_error %(
       module Moo(T)
         @x = 1 + 2
@@ -3796,7 +3796,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Moo(T)"
   end
 
-  it "can't infer type from initializer in generic class type" do
+  it("can't infer type from initializer in generic class type") do
     assert_error %(
       class Foo(T)
         @x = 1 + 2
@@ -3811,7 +3811,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@x' of Foo(T)"
   end
 
-  it "infers type from self (#2575)" do
+  it("infers type from self (#2575)") do
     assert_type(%(
       class Foo
         def initialize
@@ -3827,7 +3827,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "infers type from self as virtual type (#2575)" do
+  it("infers type from self as virtual type (#2575)") do
     assert_type(%(
       class Foo
         def initialize
@@ -3846,7 +3846,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "declares as named tuple" do
+  it("declares as named tuple") do
     assert_type(%(
       class Foo
         @x : NamedTuple(x: Int32, y: Char)
@@ -3865,7 +3865,7 @@ describe "Semantic: instance var" do
       )) { named_tuple_of({"x": int32, "y": char}) }
   end
 
-  it "doesn't complain in second part of #2575" do
+  it("doesn't complain in second part of #2575") do
     assert_type(%(
       class Foo
         @a : Int32
@@ -3890,7 +3890,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "guesses from as.(typeof(...))" do
+  it("guesses from as.(typeof(...))") do
     assert_type(%(
       class Foo
         def initialize(x : Int32)
@@ -3907,7 +3907,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "guesses from as.(typeof(...)) in generic type" do
+  it("guesses from as.(typeof(...)) in generic type") do
     assert_type(%(
       class Foo(T)
         def initialize(x : Int32)
@@ -3924,7 +3924,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "errors if can't find lib call, before erroring on instance var (#2579)" do
+  it("errors if can't find lib call, before erroring on instance var (#2579)") do
     assert_error %(
       lib LibFoo
       end
@@ -3940,7 +3940,7 @@ describe "Semantic: instance var" do
       "undefined fun 'nope' for LibFoo"
   end
 
-  it "errors when using Class (#2605)" do
+  it("errors when using Class (#2605)") do
     assert_error %(
       class Foo
         def initialize(@class : Class)
@@ -3950,7 +3950,7 @@ describe "Semantic: instance var" do
       "can't use Class as the type of instance variable @class of Foo, use a more specific type"
   end
 
-  it "errors when using Class in generic type" do
+  it("errors when using Class in generic type") do
     assert_error %(
       class Foo(T)
         def initialize(@class : Class)
@@ -3960,7 +3960,7 @@ describe "Semantic: instance var" do
       "can't use Class as the type of instance variable @class of Foo(T), use a more specific type"
   end
 
-  it "doesn't error when using Class but specifying type" do
+  it("doesn't error when using Class but specifying type") do
     assert_type(%(
       class Foo
         @x : Foo.class
@@ -3977,7 +3977,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"].metaclass }
   end
 
-  it "doesn't error when using generic because guessed elsewhere" do
+  it("doesn't error when using generic because guessed elsewhere") do
     assert_type(%(
       class Foo
         @x = Bar(Int32).new
@@ -4003,7 +4003,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Bar", int32 }
   end
 
-  it "doesn't error when using generic in generic type because guessed elsewhere" do
+  it("doesn't error when using generic in generic type because guessed elsewhere") do
     assert_type(%(
       class Foo(T)
         @x = Bar(Int32).new
@@ -4030,7 +4030,7 @@ describe "Semantic: instance var" do
   end
 
   %w(Object Reference).each do |type|
-    it "errors if declaring var in #{type}" do
+    it("errors if declaring var in #{type}") do
       assert_error %(
         class #{type}
           @x : Int32?
@@ -4041,7 +4041,7 @@ describe "Semantic: instance var" do
   end
 
   %w(Value Number Int Float Int32).each do |type|
-    it "errors if declaring var in #{type}" do
+    it("errors if declaring var in #{type}") do
       assert_error %(
         struct #{type}
           @x : Int32?
@@ -4051,7 +4051,7 @@ describe "Semantic: instance var" do
     end
   end
 
-  it "errors if declaring instance variable in module included in Object" do
+  it("errors if declaring instance variable in module included in Object") do
     assert_error %(
       module Moo
         @x : Int32?
@@ -4064,7 +4064,7 @@ describe "Semantic: instance var" do
       "can't declare instance variables in Object"
   end
 
-  it "errors if adds instance variable to Object via guess" do
+  it("errors if adds instance variable to Object via guess") do
     assert_error %(
       class Object
         def foo(@foo : Int32)
@@ -4074,7 +4074,7 @@ describe "Semantic: instance var" do
       "can't declare instance variables in Object"
   end
 
-  it "errors if adds instance variable to Object via guess via included module" do
+  it("errors if adds instance variable to Object via guess via included module") do
     assert_error %(
       module Moo
         def foo(@foo : Int32)
@@ -4088,7 +4088,7 @@ describe "Semantic: instance var" do
       "can't declare instance variables in Object"
   end
 
-  it "gives correct error when trying to use Int as an instance variable type" do
+  it("gives correct error when trying to use Int as an instance variable type") do
     assert_error %(
       class Foo
         @x : Int
@@ -4097,7 +4097,7 @@ describe "Semantic: instance var" do
       "can't use Int as the type of an instance variable yet, use a more specific type"
   end
 
-  it "shouldn't error when accessing instance var in initialized that's always initialized (#2953)" do
+  it("shouldn't error when accessing instance var in initialized that's always initialized (#2953)") do
     assert_type(%(
       class Foo
         @baz = Baz.new
@@ -4134,7 +4134,7 @@ describe "Semantic: instance var" do
   # ||| OLD SPECS |||
   # vvv           vvv
 
-  it "declares instance var which appears in initialize" do
+  it("declares instance var which appears in initialize") do
     result = assert_type("
       class Foo
         @x : Int32
@@ -4153,7 +4153,7 @@ describe "Semantic: instance var" do
     foo.instance_vars["@x"].type.should eq(mod.int32)
   end
 
-  it "declares instance var of generic class" do
+  it("declares instance var of generic class") do
     result = assert_type("
       class Foo(T)
         @x : T
@@ -4171,7 +4171,7 @@ describe "Semantic: instance var" do
     end
   end
 
-  it "declares instance var of generic class after reopen" do
+  it("declares instance var of generic class after reopen") do
     result = assert_type("
       class Foo(T)
       end
@@ -4193,7 +4193,7 @@ describe "Semantic: instance var" do
     end
   end
 
-  it "declares instance var with initial value" do
+  it("declares instance var with initial value") do
     assert_type("
       class Foo
         @x = 0
@@ -4207,7 +4207,7 @@ describe "Semantic: instance var" do
       ") { int32 }
   end
 
-  it "declares instance var with initial value, with subclass" do
+  it("declares instance var with initial value, with subclass") do
     assert_type("
       class Foo
         @x = 0
@@ -4228,7 +4228,7 @@ describe "Semantic: instance var" do
       ") { int32 }
   end
 
-  it "errors if declaring generic type without type vars" do
+  it("errors if declaring generic type without type vars") do
     assert_error %(
       class Foo(T)
       end
@@ -4240,7 +4240,7 @@ describe "Semantic: instance var" do
       "can't declare variable of generic non-instantiated type Foo"
   end
 
-  it "errors when typing an instance variable inside a method" do
+  it("errors when typing an instance variable inside a method") do
     assert_error %(
       def foo
         @x : Int32
@@ -4251,7 +4251,7 @@ describe "Semantic: instance var" do
       "declaring the type of an instance variable must be done at the class level"
   end
 
-  it "declares instance var with union type with a virtual member" do
+  it("declares instance var with union type with a virtual member") do
     assert_type("
       class Parent; end
       class Child < Parent; end
@@ -4267,7 +4267,7 @@ describe "Semantic: instance var" do
       Foo.new.x") { nilable types["Parent"].virtual_type! }
   end
 
-  it "declares with `self`" do
+  it("declares with `self`") do
     assert_type(%(
       class Foo
         @foo : self
@@ -4285,7 +4285,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "guesses from array literal with of, with subclass" do
+  it("guesses from array literal with of, with subclass") do
     assert_type(%(
       class Foo(T)
       end
@@ -4305,7 +4305,7 @@ describe "Semantic: instance var" do
       )) { array_of(generic_class("Foo", int32).virtual_type!) }
   end
 
-  it "guesses from hash literal with of, with subclass" do
+  it("guesses from hash literal with of, with subclass") do
     assert_type(%(
       class Foo(T)
       end
@@ -4325,7 +4325,7 @@ describe "Semantic: instance var" do
       )) { hash_of(generic_class("Foo", int32).virtual_type!, generic_class("Foo", int32).virtual_type!) }
   end
 
-  it "guesses from splat (#3149)" do
+  it("guesses from splat (#3149)") do
     assert_type(%(
       class Args(*T)
         def initialize(*@args : *T)
@@ -4336,7 +4336,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Args", int32, char }
   end
 
-  it "guesses from splat (2) (#3149)" do
+  it("guesses from splat (2) (#3149)") do
     assert_type(%(
       class Args(*T)
         def initialize(*@args : *T)
@@ -4351,7 +4351,7 @@ describe "Semantic: instance var" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "transfers initializer from generic module to class" do
+  it("transfers initializer from generic module to class") do
     assert_type(%(
       module Moo(T)
         @x = 1
@@ -4369,7 +4369,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "transfers initializer from module to generic class" do
+  it("transfers initializer from module to generic class") do
     assert_type(%(
       module Moo
         @x = 1
@@ -4387,7 +4387,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "doesn't consider self.initialize as initializer (#3239)" do
+  it("doesn't consider self.initialize as initializer (#3239)") do
     assert_error %(
       class Foo
         def self.initialize
@@ -4404,7 +4404,7 @@ describe "Semantic: instance var" do
       "@instance_vars are not yet allowed in metaclasses: use @@class_vars instead"
   end
 
-  it "doesn't crash on #3580" do
+  it("doesn't crash on #3580") do
     assert_error %(
       class Hoge
         @hoge_dir : String = "~/.hoge" ? "~/.hoge" : default_hoge_dir
@@ -4413,7 +4413,7 @@ describe "Semantic: instance var" do
       "undefined local variable or method"
   end
 
-  it "is more permissive with macro def initialize" do
+  it("is more permissive with macro def initialize") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -4429,7 +4429,7 @@ describe "Semantic: instance var" do
       ), inject_primitives: false) { types["Foo"] }
   end
 
-  it "is more permissive with macro def initialize, other initialize" do
+  it("is more permissive with macro def initialize, other initialize") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -4449,7 +4449,7 @@ describe "Semantic: instance var" do
       ), inject_primitives: false) { types["Foo"] }
   end
 
-  it "errors with macro def but another def doesn't initialize all" do
+  it("errors with macro def but another def doesn't initialize all") do
     assert_error %(
       class Foo
         @x : Int32
@@ -4470,7 +4470,7 @@ describe "Semantic: instance var" do
       "instance variable '@y' of Foo was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "errors if finally not initialized in macro def" do
+  it("errors if finally not initialized in macro def") do
     assert_error %(
       class Foo
         @x : Int32
@@ -4486,7 +4486,7 @@ describe "Semantic: instance var" do
       "instance variable '@x' of Foo was not initialized in this 'initialize', rendering it nilable"
   end
 
-  it "doesn't error if initializes via super in macro def" do
+  it("doesn't error if initializes via super in macro def") do
     assert_type(%(
       class Foo
         def initialize(@x : Int32)
@@ -4505,7 +4505,7 @@ describe "Semantic: instance var" do
       )) { types["Bar"] }
   end
 
-  it "doesn't error if uses typeof(@var)" do
+  it("doesn't error if uses typeof(@var)") do
     assert_type(%(
       struct Int32
         def self.zero
@@ -4525,7 +4525,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "doesn't error if not initiliazed in macro def but outside it" do
+  it("doesn't error if not initiliazed in macro def but outside it") do
     assert_type(%(
       class Foo
         @x = 1
@@ -4539,7 +4539,7 @@ describe "Semantic: instance var" do
       )) { types["Foo"] }
   end
 
-  it "doesn't error if inheriting generic instance (#3635)" do
+  it("doesn't error if inheriting generic instance (#3635)") do
     assert_type(%(
       module Core(T)
         @a : Bool
@@ -4561,7 +4561,7 @@ describe "Semantic: instance var" do
       )) { bool }
   end
 
-  it "doesn't consider var as nilable if conditionally assigned inside initialize, but has initializer (#3669)" do
+  it("doesn't consider var as nilable if conditionally assigned inside initialize, but has initializer (#3669)") do
     assert_type(%(
       class Foo
         @x = 0
@@ -4579,7 +4579,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "types generic instance as virtual type if generic type has subclasses (#3805)" do
+  it("types generic instance as virtual type if generic type has subclasses (#3805)") do
     assert_type(%(
       class Foo(T)
       end
@@ -4602,7 +4602,7 @@ describe "Semantic: instance var" do
       )) { types["Qux"] }
   end
 
-  it "errors if unknown ivar through macro (#4050)" do
+  it("errors if unknown ivar through macro (#4050)") do
     assert_error %(
       class Foo
         def initialize(**attributes)
@@ -4626,7 +4626,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@bar' of Foo"
   end
 
-  it "can't infer type when using operation on const (#4054)" do
+  it("can't infer type when using operation on const (#4054)") do
     assert_error %(
       class Foo
         BAR = 5
@@ -4641,7 +4641,7 @@ describe "Semantic: instance var" do
       "Can't infer the type of instance variable '@baz' of Foo"
   end
 
-  it "instance variables initializers are used in class variables initialized objects (#3988)" do
+  it("instance variables initializers are used in class variables initialized objects (#3988)") do
     assert_type(%(
        class Foo
          @@foo = Foo.new
@@ -4659,7 +4659,7 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
-  it "allow usage of instance variable initializer from instance variable initializer" do
+  it("allow usage of instance variable initializer from instance variable initializer") do
     assert_type(%(
       class Foo
         @bar = Bar.new
@@ -4686,7 +4686,7 @@ describe "Semantic: instance var" do
     )) { tuple_of([int32, int32]) }
   end
 
-  it "errors when assigning instance variable at top level block" do
+  it("errors when assigning instance variable at top level block") do
     assert_error %(
       def foo
         yield
@@ -4699,7 +4699,7 @@ describe "Semantic: instance var" do
       "can't use instance variables at the top level"
   end
 
-  it "errors when assigning instance variable at top level control block" do
+  it("errors when assigning instance variable at top level control block") do
     assert_error %(
       if true
         @foo = 1
@@ -4708,7 +4708,7 @@ describe "Semantic: instance var" do
       "can't use instance variables at the top level"
   end
 
-  it "doesn't check call of non-self instance (#4830)" do
+  it("doesn't check call of non-self instance (#4830)") do
     assert_type(%(
       class Container
         def initialize(other : Container, x)
@@ -4733,7 +4733,7 @@ describe "Semantic: instance var" do
       )) { types["Container"] }
   end
 
-  it "errors when assigning instance variable inside nested expression" do
+  it("errors when assigning instance variable inside nested expression") do
     assert_error %(
       class Foo
         if true
@@ -4744,7 +4744,7 @@ describe "Semantic: instance var" do
       "can't use instance variables at the top level"
   end
 
-  it "doesn't find T in generic type that's not the current type (#4460)" do
+  it("doesn't find T in generic type that's not the current type (#4460)") do
     assert_error %(
       class Gen(T)
         def self.new
@@ -4759,7 +4759,7 @@ describe "Semantic: instance var" do
       "can't use Gen(T) as the type of instance variable @x of Foo"
   end
 
-  it "doesn't consider instance var as nilable if assigned before self access (#4981)" do
+  it("doesn't consider instance var as nilable if assigned before self access (#4981)") do
     assert_type(%(
       def f(x)
       end

--- a/spec/compiler/semantic/is_a_spec.cr
+++ b/spec/compiler/semantic/is_a_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Semantic: is_a?" do
-  it "is bool" do
+describe("Semantic: is_a?") do
+  it("is bool") do
     assert_type("1.is_a?(Bool)") { bool }
   end
 
-  it "restricts type inside if scope 1" do
+  it("restricts type inside if scope 1") do
     nodes = parse "
       a = 1 || 'a'
       if a.is_a?(Int)
@@ -17,7 +17,7 @@ describe "Semantic: is_a?" do
     nodes.last.as(If).then.type.should eq(mod.int32)
   end
 
-  it "restricts type inside if scope 2" do
+  it("restricts type inside if scope 2") do
     nodes = parse "
       module Bar
       end
@@ -39,7 +39,7 @@ describe "Semantic: is_a?" do
     nodes.last.as(If).then.type.should eq(foo.instantiate([mod.int32] of TypeVar))
   end
 
-  it "restricts type inside if scope 3" do
+  it("restricts type inside if scope 3") do
     nodes = parse "
       class Foo
         def initialize(@x : Int32)
@@ -57,7 +57,7 @@ describe "Semantic: is_a?" do
     nodes.last.as(If).then.type.should eq(mod.types["Foo"])
   end
 
-  it "restricts other types inside if else" do
+  it("restricts other types inside if else") do
     assert_type("
       a = 1 || 'a'
       if a.is_a?(Int32)
@@ -68,7 +68,7 @@ describe "Semantic: is_a?" do
       ") { int32 }
   end
 
-  it "applies filter inside block" do
+  it("applies filter inside block") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -96,7 +96,7 @@ describe "Semantic: is_a?" do
       ") { union_of(char, int32) }
   end
 
-  it "applies negative condition filter if then is no return" do
+  it("applies negative condition filter if then is no return") do
     assert_type("
       require \"prelude\"
 
@@ -120,7 +120,7 @@ describe "Semantic: is_a?" do
       ") { int32 }
   end
 
-  it "checks simple type with union" do
+  it("checks simple type with union") do
     assert_type("
       a = 1
       if a.is_a?(Int32 | Char)
@@ -131,7 +131,7 @@ describe "Semantic: is_a?" do
       ") { int32 }
   end
 
-  it "checks union with union" do
+  it("checks union with union") do
     assert_type("
       struct Char
         def +(other : Int32)
@@ -154,7 +154,7 @@ describe "Semantic: is_a?" do
       ") { union_of(int32, char) }
   end
 
-  it "restricts in assignment" do
+  it("restricts in assignment") do
     assert_type("
       a = 1 || 'a'
       if (b = a).is_a?(Int32)
@@ -165,7 +165,7 @@ describe "Semantic: is_a?" do
       ") { int32 }
   end
 
-  it "restricts type in else but lazily" do
+  it("restricts type in else but lazily") do
     assert_type("
       class Foo
         def initialize(@x : Int32)
@@ -188,7 +188,7 @@ describe "Semantic: is_a?" do
       ") { int32 }
   end
 
-  it "types if is_a? preceded by return if (preserves nops)" do
+  it("types if is_a? preceded by return if (preserves nops)") do
     assert_type(%(
       def coco
         return if 1 == 1
@@ -201,7 +201,7 @@ describe "Semantic: is_a?" do
       )) { nil_type }
   end
 
-  it "restricts type inside if else when used with module type" do
+  it("restricts type inside if else when used with module type") do
     assert_type(%(
       module Moo
       end

--- a/spec/compiler/semantic/lib_spec.cr
+++ b/spec/compiler/semantic/lib_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Semantic: lib" do
-  it "types a varargs external" do
+describe("Semantic: lib") do
+  it("types a varargs external") do
     assert_type("lib LibFoo; fun bar(x : Int32, ...) : Int32; end; LibFoo.bar(1, 1.5, 'a')") { int32 }
   end
 
-  it "raises on undefined fun" do
+  it("raises on undefined fun") do
     assert_error %(
       lib LibC
       end
@@ -15,7 +15,7 @@ describe "Semantic: lib" do
       "undefined fun 'foo' for LibC"
   end
 
-  it "raises wrong number of arguments" do
+  it("raises wrong number of arguments") do
     assert_error %(
       lib LibC
         fun foo : Int32
@@ -26,7 +26,7 @@ describe "Semantic: lib" do
       "wrong number of arguments for 'LibC#foo' (given 1, expected 0)"
   end
 
-  it "raises wrong argument type" do
+  it("raises wrong argument type") do
     assert_error %(
       lib LibC
         fun foo(x : Int32) : Int32
@@ -37,7 +37,7 @@ describe "Semantic: lib" do
       "argument 'x' of 'LibC#foo' must be Int32, not Char"
   end
 
-  it "reports error when changing var type and something breaks" do
+  it("reports error when changing var type and something breaks") do
     assert_error %(
       class LibFoo
         def initialize
@@ -59,7 +59,7 @@ describe "Semantic: lib" do
       "undefined method '+' for Char"
   end
 
-  it "reports error when changing instance var type and something breaks" do
+  it("reports error when changing instance var type and something breaks") do
     assert_error "
       lib Lib
         fun bar(c : Char)
@@ -87,42 +87,42 @@ describe "Semantic: lib" do
       "argument 'c' of 'Lib#bar' must be Char"
   end
 
-  it "reports error on fun argument type not primitive like" do
+  it("reports error on fun argument type not primitive like") do
     assert_error "lib LibFoo; fun foo(x : Reference); end",
       "only primitive types"
   end
 
-  it "reports error on fun argument type not primitive like, Nil (#2994)" do
+  it("reports error on fun argument type not primitive like, Nil (#2994)") do
     assert_error "lib LibFoo; fun foo(x : Nil); end",
       "only primitive types"
   end
 
-  it "reports error on fun return type not primitive like" do
+  it("reports error on fun return type not primitive like") do
     assert_error "lib LibFoo; fun foo : Reference; end",
       "only primitive types"
   end
 
-  it "reports error on struct field type not primitive like" do
+  it("reports error on struct field type not primitive like") do
     assert_error "lib LibFoo; struct Foo; x : Reference; end; end",
       "only primitive types"
   end
 
-  it "reports error on typedef type not primitive like" do
+  it("reports error on typedef type not primitive like") do
     assert_error "lib LibFoo; type Foo = Reference; end",
       "only primitive types"
   end
 
-  it "reports error out can only be used with lib funs" do
+  it("reports error out can only be used with lib funs") do
     assert_error "foo(out x)",
       "out can only be used with lib funs"
   end
 
-  it "reports error out can only be used with lib funs in named argument" do
+  it("reports error out can only be used with lib funs in named argument") do
     assert_error "foo(x: out x)",
       "out can only be used with lib funs"
   end
 
-  it "reports error if using out with an already declared variable" do
+  it("reports error if using out with an already declared variable") do
     assert_error %(
       lib Lib
         fun foo(x : Int32*)
@@ -134,7 +134,7 @@ describe "Semantic: lib" do
       "variable 'x' is already defined, `out` must be used to define a variable, use another name"
   end
 
-  it "allows invoking out with underscore " do
+  it("allows invoking out with underscore ") do
     assert_type(%(
       lib Lib
         fun foo(x : Int32*) : Float64
@@ -144,7 +144,7 @@ describe "Semantic: lib" do
       )) { float64 }
   end
 
-  it "reports redefinition of fun with different signature" do
+  it("reports redefinition of fun with different signature") do
     assert_error "
       lib LibC
         fun foo : Int32
@@ -154,7 +154,7 @@ describe "Semantic: lib" do
       "fun redefinition with different signature"
   end
 
-  it "types lib var get" do
+  it("types lib var get") do
     assert_type("
       lib LibC
         $errno : Int32
@@ -164,7 +164,7 @@ describe "Semantic: lib" do
       ") { int32 }
   end
 
-  it "types lib var set" do
+  it("types lib var set") do
     assert_type("
       lib LibC
         $errno : Int32
@@ -174,7 +174,7 @@ describe "Semantic: lib" do
       ") { int32 }
   end
 
-  it "types lib var get with forward declaration" do
+  it("types lib var get with forward declaration") do
     assert_type("
       lib LibC
         $errno : A
@@ -186,7 +186,7 @@ describe "Semantic: lib" do
       ") { int32 }
   end
 
-  it "defined fun with aliased type" do
+  it("defined fun with aliased type") do
     assert_type("
       lib LibC
         alias SizeT = Int32
@@ -197,7 +197,7 @@ describe "Semantic: lib" do
       ") { int32 }
   end
 
-  it "overrides definition of fun" do
+  it("overrides definition of fun") do
     result = assert_type("
       lib LibC
         fun foo(x : Int32) : Float64
@@ -215,7 +215,7 @@ describe "Semantic: lib" do
     foo.real_name.should eq("bar")
   end
 
-  it "error if passing type to LibC with to_unsafe but type doesn't match" do
+  it("error if passing type to LibC with to_unsafe but type doesn't match") do
     assert_error "
       lib LibC
         fun foo(x : Int32) : Int32
@@ -231,7 +231,7 @@ describe "Semantic: lib" do
       ", "argument 'x' of 'LibC#foo' must be Int32, not Foo (nor Char returned by 'Foo#to_unsafe')"
   end
 
-  it "error if passing non primitive type as varargs" do
+  it("error if passing non primitive type as varargs") do
     assert_error "
       lib LibC
         fun foo(x : Int32, ...)
@@ -244,7 +244,7 @@ describe "Semantic: lib" do
       ", "argument #2 of 'LibC#foo' is not a primitive type and no Foo#to_unsafe method found"
   end
 
-  it "error if passing non primitive type as varargs invoking to_unsafe" do
+  it("error if passing non primitive type as varargs invoking to_unsafe") do
     assert_error "
       lib LibC
         fun foo(x : Int32, ...)
@@ -263,7 +263,7 @@ describe "Semantic: lib" do
       ", "converted Foo invoking to_unsafe, but Bar is not a primitive type"
   end
 
-  it "allows passing splat to LibC fun" do
+  it("allows passing splat to LibC fun") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32, y : Float64, ...) : Float64
@@ -274,7 +274,7 @@ describe "Semantic: lib" do
       )) { float64 }
   end
 
-  it "allows passing double splat to LibC fun" do
+  it("allows passing double splat to LibC fun") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32, y : Float64) : Float64
@@ -285,7 +285,7 @@ describe "Semantic: lib" do
       )) { float64 }
   end
 
-  it "errors if applying wrong attribute" do
+  it("errors if applying wrong attribute") do
     assert_error %(
       @[Bar]
       lib LibFoo
@@ -294,7 +294,7 @@ describe "Semantic: lib" do
       "illegal attribute for lib, valid attributes are: Link"
   end
 
-  it "errors if missing link arguments" do
+  it("errors if missing link arguments") do
     assert_error %(
       @[Link]
       lib LibFoo
@@ -303,7 +303,7 @@ describe "Semantic: lib" do
       "missing link arguments: must at least specify a library name"
   end
 
-  it "errors if first argument is not a string" do
+  it("errors if first argument is not a string") do
     assert_error %(
       @[Link(1)]
       lib LibFoo
@@ -312,7 +312,7 @@ describe "Semantic: lib" do
       "'lib' link argument must be a String"
   end
 
-  it "errors if second argument is not a string" do
+  it("errors if second argument is not a string") do
     assert_error %(
       @[Link("foo", 1)]
       lib LibFoo
@@ -321,7 +321,7 @@ describe "Semantic: lib" do
       "'ldflags' link argument must be a String"
   end
 
-  it "errors if third argument is not a bool" do
+  it("errors if third argument is not a bool") do
     assert_error %(
       @[Link("foo", "bar", 1)]
       lib LibFoo
@@ -330,7 +330,7 @@ describe "Semantic: lib" do
       "'static' link argument must be a Bool"
   end
 
-  it "errors if foruth argument is not a bool" do
+  it("errors if foruth argument is not a bool") do
     assert_error %(
       @[Link("foo", "bar", true, 1)]
       lib LibFoo
@@ -339,7 +339,7 @@ describe "Semantic: lib" do
       "'framework' link argument must be a String"
   end
 
-  it "errors if too many link arguments" do
+  it("errors if too many link arguments") do
     assert_error %(
       @[Link("foo", "bar", true, "Cocoa", 1)]
       lib LibFoo
@@ -348,7 +348,7 @@ describe "Semantic: lib" do
       "wrong number of link arguments (given 5, expected 1..4)"
   end
 
-  it "errors if unknown named arg" do
+  it("errors if unknown named arg") do
     assert_error %(
       @[Link(boo: "bar")]
       lib LibFoo
@@ -357,7 +357,7 @@ describe "Semantic: lib" do
       "unknown link argument: 'boo' (valid arguments are 'lib', 'ldflags', 'static' and 'framework')"
   end
 
-  it "errors if lib already specified with positional argument" do
+  it("errors if lib already specified with positional argument") do
     assert_error %(
       @[Link("foo", lib: "bar")]
       lib LibFoo
@@ -366,7 +366,7 @@ describe "Semantic: lib" do
       "'lib' link argument already specified"
   end
 
-  it "errors if lib named arg is not a String" do
+  it("errors if lib named arg is not a String") do
     assert_error %(
       @[Link(lib: 1)]
       lib LibFoo
@@ -375,7 +375,7 @@ describe "Semantic: lib" do
       "'lib' link argument must be a String"
   end
 
-  it "clears attributes after lib" do
+  it("clears attributes after lib") do
     assert_type(%(
       @[Link("foo")]
       lib LibFoo
@@ -385,7 +385,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "allows invoking lib call without obj inside lib" do
+  it("allows invoking lib call without obj inside lib") do
     assert_type(%(
       lib LibFoo
         fun foo : Int32
@@ -397,7 +397,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "errors if lib fun call is part of dispatch" do
+  it("errors if lib fun call is part of dispatch") do
     assert_error %(
       lib LibFoo
         fun foo : Int32
@@ -413,7 +413,7 @@ describe "Semantic: lib" do
       "lib fun call is not supported in dispatch"
   end
 
-  it "allows passing nil or pointer to arg expecting pointer" do
+  it("allows passing nil or pointer to arg expecting pointer") do
     assert_type(%(
       lib Foo
         fun foo(x : Int32*) : Int64
@@ -424,7 +424,7 @@ describe "Semantic: lib" do
       )) { int64 }
   end
 
-  it "correctly attached link flags if there's a macro if" do
+  it("correctly attached link flags if there's a macro if") do
     result = semantic(%(
       @[Link("SDL")]
       @[Link("SDLMain")]
@@ -444,7 +444,7 @@ describe "Semantic: lib" do
     attrs[1].lib.should eq("SDLMain")
   end
 
-  it "supports forward references (#399)" do
+  it("supports forward references (#399)") do
     assert_type(%(
       lib LibFoo
         fun foo() : Bar*
@@ -458,7 +458,7 @@ describe "Semantic: lib" do
       )) { pointer_of(types["LibFoo"].types["Bar"]) }
   end
 
-  it "supports forward references with struct inside struct (#399)" do
+  it("supports forward references with struct inside struct (#399)") do
     assert_type(%(
       lib LibFoo
         struct Bar
@@ -474,7 +474,7 @@ describe "Semantic: lib" do
       )) { pointer_of(types["LibFoo"].types["Foo"]) }
   end
 
-  it "errors if defines def on lib" do
+  it("errors if defines def on lib") do
     assert_error %(
       lib LibC
       end
@@ -485,7 +485,7 @@ describe "Semantic: lib" do
       "can't define method in lib LibC"
   end
 
-  it "reopens lib and adds more link attributes" do
+  it("reopens lib and adds more link attributes") do
     result = semantic(%(
       @[Link("SDL")]
       lib LibSDL
@@ -505,7 +505,7 @@ describe "Semantic: lib" do
     attrs[1].lib.should eq("SDLMain")
   end
 
-  it "reopens lib and adds same link attributes" do
+  it("reopens lib and adds same link attributes") do
     result = semantic(%(
       @[Link("SDL")]
       lib LibSDL
@@ -524,7 +524,7 @@ describe "Semantic: lib" do
     attrs[0].lib.should eq("SDL")
   end
 
-  it "gathers link attributes from macro expression" do
+  it("gathers link attributes from macro expression") do
     result = semantic(%(
       {% begin %}
         @[Link("SDL")]
@@ -541,7 +541,7 @@ describe "Semantic: lib" do
     attrs[0].lib.should eq("SDL")
   end
 
-  it "errors if using void as argument (related to #508)" do
+  it("errors if using void as argument (related to #508)") do
     assert_error %(
       lib LibFoo
         fun foo(x : Void)
@@ -550,7 +550,7 @@ describe "Semantic: lib" do
       "can't use Void as argument type"
   end
 
-  it "errors if using void via typedef as argument (related to #508)" do
+  it("errors if using void via typedef as argument (related to #508)") do
     assert_error %(
       lib LibFoo
         type Foo = Void
@@ -560,7 +560,7 @@ describe "Semantic: lib" do
       "can't use Void as argument type"
   end
 
-  it "can use tuple as fun return" do
+  it("can use tuple as fun return") do
     assert_type(%(
       lib LibC
         fun foo : {Int32, Int32}
@@ -570,7 +570,7 @@ describe "Semantic: lib" do
       )) { tuple_of([int32, int32] of TypeVar) }
   end
 
-  it "doesn't try to invoke unsafe for c struct/union (#1362)" do
+  it("doesn't try to invoke unsafe for c struct/union (#1362)") do
     assert_error %(
       lib LibFoo
         struct Bar
@@ -585,7 +585,7 @@ describe "Semantic: lib" do
       "argument 'x' of 'LibFoo#foo' must be Pointer(LibFoo::Bar), not LibFoo::Bar"
   end
 
-  it "passes int as another integer type in variable" do
+  it("passes int as another integer type in variable") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32) : Float64
@@ -596,7 +596,7 @@ describe "Semantic: lib" do
       )) { float64 }
   end
 
-  it "passes float as another integer type in variable" do
+  it("passes float as another integer type in variable") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Float32) : Int32
@@ -607,7 +607,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "passes int as another integer type with literal" do
+  it("passes int as another integer type with literal") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32) : Float64
@@ -617,7 +617,7 @@ describe "Semantic: lib" do
       )) { float64 }
   end
 
-  it "errors if invoking to_i32 and got error in that call" do
+  it("errors if invoking to_i32 and got error in that call") do
     assert_error %(
       lib LibFoo
         fun foo(x : Int32) : Float64
@@ -634,7 +634,7 @@ describe "Semantic: lib" do
       "converting from Foo to Int32 by invoking 'to_i32'"
   end
 
-  it "errors if invoking to_i32 and got wrong type" do
+  it("errors if invoking to_i32 and got wrong type") do
     assert_error %(
       lib LibFoo
         fun foo(x : Int32) : Float64
@@ -651,7 +651,7 @@ describe "Semantic: lib" do
       "invoked 'to_i32' to convert from Foo to Int32, but got Char"
   end
 
-  it "defines lib funs before funs with body" do
+  it("defines lib funs before funs with body") do
     assert_type(%(
       fun foo : Int32
         LibX.x
@@ -665,7 +665,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "errors if using out with varargs" do
+  it("errors if using out with varargs") do
     assert_error %(
       lib LibX
         fun x(...)
@@ -676,7 +676,7 @@ describe "Semantic: lib" do
       "can't use out at varargs position: declare the variable with `z = uninitialized ...` and pass it with `pointerof(z)`"
   end
 
-  it "errors if using out with void pointer (#2424)" do
+  it("errors if using out with void pointer (#2424)") do
     assert_error %(
       lib LibFoo
         fun foo(x : Void*)
@@ -687,7 +687,7 @@ describe "Semantic: lib" do
       "can't use out with Void* (argument 'x' of LibFoo.foo is Void*)"
   end
 
-  it "errors if using out with void pointer through type" do
+  it("errors if using out with void pointer through type") do
     assert_error %(
       lib LibFoo
         type Foo = Void
@@ -699,7 +699,7 @@ describe "Semantic: lib" do
       "can't use out with Void* (argument 'x' of LibFoo.foo is Void*)"
   end
 
-  it "errors if using out with non-pointer" do
+  it("errors if using out with non-pointer") do
     assert_error %(
       lib LibFoo
         fun foo(x : Int32)
@@ -710,7 +710,7 @@ describe "Semantic: lib" do
       "argument 'x' of LibFoo.foo cannot be passed as 'out' because it is not a pointer"
   end
 
-  it "errors if redefining fun with different signature (#2468)" do
+  it("errors if redefining fun with different signature (#2468)") do
     assert_error %(
       fun foo
       end
@@ -721,7 +721,7 @@ describe "Semantic: lib" do
       "fun redefinition with different signature"
   end
 
-  it "errors if using named args with variadic function" do
+  it("errors if using named args with variadic function") do
     assert_error %(
       lib LibC
         fun foo(x : Int32, y : UInt8, ...) : Int32
@@ -732,7 +732,7 @@ describe "Semantic: lib" do
       "can't use named args with variadic function"
   end
 
-  it "errors if using unknown named arg" do
+  it("errors if using unknown named arg") do
     assert_error %(
       lib LibC
         fun foo(x : Int32, y : UInt8) : Int32
@@ -743,7 +743,7 @@ describe "Semantic: lib" do
       "no argument named 'z'"
   end
 
-  it "errors if argument already specified" do
+  it("errors if argument already specified") do
     assert_error %(
       lib LibC
         fun foo(x : Int32, y : UInt8) : Int32
@@ -754,7 +754,7 @@ describe "Semantic: lib" do
       "argument 'x' already specified"
   end
 
-  it "errors if missing arugment" do
+  it("errors if missing arugment") do
     assert_error %(
       lib LibC
         fun foo(x : Int32, y : UInt8) : Int32
@@ -765,7 +765,7 @@ describe "Semantic: lib" do
       "missing argument: y"
   end
 
-  it "errors if missing arugments" do
+  it("errors if missing arugments") do
     assert_error %(
       lib LibC
         fun foo(x : Int32, y : UInt8, z: Int32) : Int32
@@ -776,7 +776,7 @@ describe "Semantic: lib" do
       "missing arguments: x, z"
   end
 
-  it "can use named args" do
+  it("can use named args") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32, y : UInt8) : Int32
@@ -786,7 +786,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "can use out with named args" do
+  it("can use out with named args") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32*)
@@ -797,7 +797,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "types fun returning nothing as nil" do
+  it("types fun returning nothing as nil") do
     assert_type(%(
       lib LibFoo
         fun foo
@@ -807,7 +807,7 @@ describe "Semantic: lib" do
       )) { nil_type }
   end
 
-  it "types fun returning void as nil" do
+  it("types fun returning void as nil") do
     assert_type(%(
       lib LibFoo
         fun foo : Void
@@ -817,7 +817,7 @@ describe "Semantic: lib" do
       )) { nil_type }
   end
 
-  it "types fun returning nil as nil" do
+  it("types fun returning nil as nil") do
     assert_type(%(
       lib LibFoo
         fun foo : Nil
@@ -827,7 +827,7 @@ describe "Semantic: lib" do
       )) { nil_type }
   end
 
-  it "can use macros inside lib" do
+  it("can use macros inside lib") do
     assert_type(%(
       lib LibFoo
         {% begin %}
@@ -839,7 +839,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "can use macros inside struct" do
+  it("can use macros inside struct") do
     assert_type(%(
       lib LibFoo
         struct Foo
@@ -853,7 +853,7 @@ describe "Semantic: lib" do
       )) { int32 }
   end
 
-  it "errors if defining incompatible funs with the same name in the same lib (#3045)" do
+  it("errors if defining incompatible funs with the same name in the same lib (#3045)") do
     assert_error %(
       lib LibFoo
         fun foo1 = foo
@@ -863,7 +863,7 @@ describe "Semantic: lib" do
       "fun redefinition with different signature"
   end
 
-  it "errors if defining incompatible funs with the same name in different libs (#3045)" do
+  it("errors if defining incompatible funs with the same name in different libs (#3045)") do
     assert_error %(
       lib LibFoo1
         fun foo1 = foo
@@ -876,7 +876,7 @@ describe "Semantic: lib" do
       "fun redefinition with different signature"
   end
 
-  it "specifies a call convention" do
+  it("specifies a call convention") do
     result = semantic(%(
       lib LibFoo
         @[CallConvention("X86_StdCall")]
@@ -887,7 +887,7 @@ describe "Semantic: lib" do
     foo.call_convention.should eq(LLVM::CallConvention::X86_StdCall)
   end
 
-  it "specifies a call convention to a lib" do
+  it("specifies a call convention to a lib") do
     result = semantic(%(
       @[CallConvention("X86_StdCall")]
       lib LibFoo
@@ -898,7 +898,7 @@ describe "Semantic: lib" do
     foo.call_convention.should eq(LLVM::CallConvention::X86_StdCall)
   end
 
-  it "errors if wrong number of arguments for CallConvention" do
+  it("errors if wrong number of arguments for CallConvention") do
     assert_error %(
       lib LibFoo
         @[CallConvention("X86_StdCall", "bar")]
@@ -908,7 +908,7 @@ describe "Semantic: lib" do
       "wrong number of arguments for attribute CallConvention (given 2, expected 1)"
   end
 
-  it "errors if CallConvention argument is not a string" do
+  it("errors if CallConvention argument is not a string") do
     assert_error %(
       lib LibFoo
         @[CallConvention(1)]
@@ -918,7 +918,7 @@ describe "Semantic: lib" do
       "argument to CallConvention must be a string"
   end
 
-  it "errors if CallConvention argument is not a valid string" do
+  it("errors if CallConvention argument is not a valid string") do
     assert_error %(
       lib LibFoo
         @[CallConvention("foo")]
@@ -928,7 +928,7 @@ describe "Semantic: lib" do
       "invalid call convention. Valid values are #{LLVM::CallConvention.values.join ", "}"
   end
 
-  it "errors if assigning void lib call to var (#4414)" do
+  it("errors if assigning void lib call to var (#4414)") do
     assert_error %(
       lib LibFoo
         fun foo
@@ -939,7 +939,7 @@ describe "Semantic: lib" do
       "assigning Void return value of lib fun call has no effect"
   end
 
-  it "errors if passing void lib call to call argument (#4414)" do
+  it("errors if passing void lib call to call argument (#4414)") do
     assert_error %(
       lib LibFoo
         fun foo

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: macro" do
-  it "types macro" do
+describe("Semantic: macro") do
+  it("types macro") do
     assert_type(%(
       macro foo
         1
@@ -11,12 +11,12 @@ describe "Semantic: macro" do
     )) { int32 }
   end
 
-  it "errors if macro uses undefined variable" do
+  it("errors if macro uses undefined variable") do
     assert_error "macro foo(x) {{y}} end; foo(1)",
       "undefined macro variable 'y'"
   end
 
-  it "types macro def" do
+  it("types macro def") do
     assert_type(%(
       macro def foo : Int32
         1
@@ -26,17 +26,17 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors if macro def type not found" do
+  it("errors if macro def type not found") do
     assert_error "macro def foo : Foo; end; foo",
       "undefined constant Foo"
   end
 
-  it "errors if macro def type doesn't match found" do
+  it("errors if macro def type doesn't match found") do
     assert_error "macro def foo : Int32; 'a'; end; foo",
       "type must be Int32, not Char"
   end
 
-  it "allows subclasses of return type for macro def" do
+  it("allows subclasses of return type for macro def") do
     run(%{
       class Foo
         def foo
@@ -58,7 +58,7 @@ describe "Semantic: macro" do
     }).to_i.should eq(2)
   end
 
-  it "allows return values that include the return type of the macro def" do
+  it("allows return values that include the return type of the macro def") do
     run(%{
       module Foo
         def foo
@@ -82,7 +82,7 @@ describe "Semantic: macro" do
     }).to_i.should eq(2)
   end
 
-  it "allows generic return types for macro def" do
+  it("allows generic return types for macro def") do
     run(%{
       class Foo(T)
         def foo
@@ -115,7 +115,7 @@ describe "Semantic: macro" do
       inject_primitives: false
   end
 
-  it "allows union return types for macro def" do
+  it("allows union return types for macro def") do
     assert_type(%{
       macro def foo : String | Int32
         1
@@ -125,7 +125,7 @@ describe "Semantic: macro" do
     }) { int32 }
   end
 
-  it "types macro def that calls another method" do
+  it("types macro def that calls another method") do
     assert_type(%(
       def bar_baz
         1
@@ -141,7 +141,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "types macro def that calls another method inside a class" do
+  it("types macro def that calls another method inside a class") do
     assert_type(%(
       class Foo
         def bar_baz
@@ -159,7 +159,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "types macro def that calls another method inside a class" do
+  it("types macro def that calls another method inside a class") do
     assert_type(%(
       class Foo
         macro def foo : Int32
@@ -179,7 +179,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "types macro def with argument" do
+  it("types macro def with argument") do
     assert_type(%(
       macro def foo(x) : Int32
         x
@@ -189,7 +189,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "expands macro with block" do
+  it("expands macro with block") do
     assert_type(%(
       macro foo
         {{yield}}
@@ -205,7 +205,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "expands macro with block and argument to yield" do
+  it("expands macro with block and argument to yield") do
     assert_type(%(
       macro foo
         {{yield 1}}
@@ -221,7 +221,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors if find macros but wrong arguments" do
+  it("errors if find macros but wrong arguments") do
     assert_error %(
       macro foo
         1
@@ -231,7 +231,7 @@ describe "Semantic: macro" do
       ), "wrong number of arguments for macro 'foo' (given 1, expected 0)"
   end
 
-  it "executes raise inside macro" do
+  it("executes raise inside macro") do
     assert_error %(
       macro foo
         {{ raise "OH NO" }}
@@ -241,7 +241,7 @@ describe "Semantic: macro" do
       ), "OH NO"
   end
 
-  it "can specify tuple as return type" do
+  it("can specify tuple as return type") do
     assert_type(%(
       macro def foo : {Int32, Int32}
         {1, 2}
@@ -251,7 +251,7 @@ describe "Semantic: macro" do
       )) { tuple_of([int32, int32] of Type) }
   end
 
-  it "allows specifying self as macro def return type" do
+  it("allows specifying self as macro def return type") do
     assert_type(%(
       class Foo
         macro def foo : self
@@ -263,7 +263,7 @@ describe "Semantic: macro" do
       )) { types["Foo"] }
   end
 
-  it "allows specifying self as macro def return type (2)" do
+  it("allows specifying self as macro def return type (2)") do
     assert_type(%(
       class Foo
         macro def foo : self
@@ -278,7 +278,7 @@ describe "Semantic: macro" do
       )) { types["Bar"] }
   end
 
-  it "errors if non-existent named arg" do
+  it("errors if non-existent named arg") do
     assert_error %(
       macro foo(x = 1)
         {{x}} + 1
@@ -289,7 +289,7 @@ describe "Semantic: macro" do
       "no argument named 'y'"
   end
 
-  it "errors if named arg already specified" do
+  it("errors if named arg already specified") do
     assert_error %(
       macro foo(x = 1)
         {{x}} + 1
@@ -300,7 +300,7 @@ describe "Semantic: macro" do
       "argument 'x' already specified"
   end
 
-  it "finds macro in included module" do
+  it("finds macro in included module") do
     assert_type(%(
       module Moo
         macro bar
@@ -320,7 +320,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors when trying to define def inside def with macro expansion" do
+  it("errors when trying to define def inside def with macro expansion") do
     assert_error %(
       macro foo
         def bar; end
@@ -335,7 +335,7 @@ describe "Semantic: macro" do
       "can't define def inside def"
   end
 
-  it "gives precise location info when doing yield inside macro" do
+  it("gives precise location info when doing yield inside macro") do
     assert_error %(
       macro foo
         {{yield}}
@@ -348,7 +348,7 @@ describe "Semantic: macro" do
       "in line 7"
   end
 
-  it "transforms with {{yield}} and call" do
+  it("transforms with {{yield}} and call") do
     assert_type(%(
       macro foo
         bar({{yield}})
@@ -364,7 +364,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "can return class type in macro def" do
+  it("can return class type in macro def") do
     assert_type(%(
       macro def foo : Int32.class
         Int32
@@ -374,7 +374,7 @@ describe "Semantic: macro" do
       )) { types["Int32"].metaclass }
   end
 
-  it "can return virtual class type in macro def" do
+  it("can return virtual class type in macro def") do
     assert_type(%(
       class Foo
       end
@@ -390,7 +390,7 @@ describe "Semantic: macro" do
       )) { types["Foo"].metaclass.virtual_type }
   end
 
-  it "can't define new variables (#466)" do
+  it("can't define new variables (#466)") do
     nodes = parse(%(
       macro foo
         hello = 1
@@ -406,7 +406,7 @@ describe "Semantic: macro" do
     end
   end
 
-  it "finds macro in included generic module" do
+  it("finds macro in included generic module") do
     assert_type(%(
       module Moo(T)
         macro moo
@@ -426,7 +426,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "finds macro in inherited generic class" do
+  it("finds macro in inherited generic class") do
     assert_type(%(
       class Moo(T)
         macro moo
@@ -444,7 +444,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "doesn't die on && inside if (bug)" do
+  it("doesn't die on && inside if (bug)") do
     assert_type(%(
       macro foo
         1 && 2
@@ -454,7 +454,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "checks if macro expansion returns (#821)" do
+  it("checks if macro expansion returns (#821)") do
     assert_type(%(
       macro pass
         return :pass
@@ -469,7 +469,7 @@ describe "Semantic: macro" do
       )) { nilable symbol }
   end
 
-  it "errors if declares macro inside if" do
+  it("errors if declares macro inside if") do
     assert_error %(
       if 1 == 2
         macro foo; end
@@ -478,7 +478,7 @@ describe "Semantic: macro" do
       "can't declare macro dynamically"
   end
 
-  it "allows declaring class with macro if" do
+  it("allows declaring class with macro if") do
     assert_type(%(
       {% if true %}
         class Foo; end
@@ -488,7 +488,7 @@ describe "Semantic: macro" do
       )) { types["Foo"] }
   end
 
-  it "allows declaring class with macro for" do
+  it("allows declaring class with macro for") do
     assert_type(%(
       {% for i in 0..0 %}
         class Foo; end
@@ -498,7 +498,7 @@ describe "Semantic: macro" do
       )) { types["Foo"] }
   end
 
-  it "allows declaring class with macro expression" do
+  it("allows declaring class with macro expression") do
     assert_type(%(
       {{ `echo "class Foo; end"` }}
 
@@ -506,7 +506,7 @@ describe "Semantic: macro" do
       )) { types["Foo"] }
   end
 
-  it "errors if requires inside class through macro expansion" do
+  it("errors if requires inside class through macro expansion") do
     assert_error %(
       macro req
         require "bar"
@@ -519,7 +519,7 @@ describe "Semantic: macro" do
       "can't require inside type declarations"
   end
 
-  it "errors if requires inside if through macro expansion" do
+  it("errors if requires inside if through macro expansion") do
     assert_error %(
       macro req
         require "bar"
@@ -532,7 +532,7 @@ describe "Semantic: macro" do
       "can't require dynamically"
   end
 
-  it "can define constant via macro included" do
+  it("can define constant via macro included") do
     assert_type(%(
       module Mod
         macro included
@@ -547,7 +547,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors if applying protected modifier to macro" do
+  it("errors if applying protected modifier to macro") do
     assert_error %(
       class Foo
         protected macro foo
@@ -559,7 +559,7 @@ describe "Semantic: macro" do
     ), "can only use 'private' for macros"
   end
 
-  it "expands macro with break inside while (#1852)" do
+  it("expands macro with break inside while (#1852)") do
     assert_type(%(
       macro test
         foo = "bar"
@@ -572,7 +572,7 @@ describe "Semantic: macro" do
       )) { nil_type }
   end
 
-  it "can access variable inside macro expansion (#2057)" do
+  it("can access variable inside macro expansion (#2057)") do
     assert_type(%(
       macro foo
         x
@@ -588,7 +588,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "declares variable for macro with out" do
+  it("declares variable for macro with out") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32*)
@@ -603,7 +603,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "show macro trace in errors (1)" do
+  it("show macro trace in errors (1)") do
     assert_error %(
       macro foo
         Bar
@@ -615,7 +615,7 @@ describe "Semantic: macro" do
       inject_primitives: false
   end
 
-  it "show macro trace in errors (2)" do
+  it("show macro trace in errors (2)") do
     assert_error %(
       {% begin %}
         Bar
@@ -625,7 +625,7 @@ describe "Semantic: macro" do
       inject_primitives: false
   end
 
-  it "errors if using macro that is defined later" do
+  it("errors if using macro that is defined later") do
     assert_error %(
       class Bar
         foo
@@ -637,7 +637,7 @@ describe "Semantic: macro" do
       "macro 'foo' must be defined before this point but is defined later"
   end
 
-  it "looks up argument types in macro owner, not in subclass (#2395)" do
+  it("looks up argument types in macro owner, not in subclass (#2395)") do
     assert_type(%(
       struct Nil
         def method(x : Problem)
@@ -670,7 +670,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "doesn't error when adding macro call to constant (#2457)" do
+  it("doesn't error when adding macro call to constant (#2457)") do
     assert_type(%(
       macro foo
       end
@@ -688,7 +688,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "errors if named arg matches single splat argument" do
+  it("errors if named arg matches single splat argument") do
     assert_error %(
       macro foo(*y)
       end
@@ -698,7 +698,7 @@ describe "Semantic: macro" do
       "no argument named 'x'"
   end
 
-  it "errors if named arg matches splat argument" do
+  it("errors if named arg matches splat argument") do
     assert_error %(
       macro foo(x, *y)
       end
@@ -708,7 +708,7 @@ describe "Semantic: macro" do
       "wrong number of arguments for macro 'foo' (given 0, expected 1+)"
   end
 
-  it "says missing argument because positional args don't match past splat" do
+  it("says missing argument because positional args don't match past splat") do
     assert_error %(
       macro foo(x, *y, z)
       end
@@ -718,7 +718,7 @@ describe "Semantic: macro" do
       "missing argument: z"
   end
 
-  it "allows named args after splat" do
+  it("allows named args after splat") do
     assert_type(%(
       macro foo(*y, x)
         { {{y}}, {{x}} }
@@ -728,7 +728,7 @@ describe "Semantic: macro" do
       )) { tuple_of([tuple_of([int32]), char]) }
   end
 
-  it "errors if missing one argument" do
+  it("errors if missing one argument") do
     assert_error %(
       macro foo(x, y, z)
       end
@@ -738,7 +738,7 @@ describe "Semantic: macro" do
       "missing argument: z"
   end
 
-  it "errors if missing two arguments" do
+  it("errors if missing two arguments") do
     assert_error %(
       macro foo(x, y, z)
       end
@@ -748,7 +748,7 @@ describe "Semantic: macro" do
       "missing arguments: x, z"
   end
 
-  it "doesn't include arguments with default values in missing arguments error" do
+  it("doesn't include arguments with default values in missing arguments error") do
     assert_error %(
 
       macro foo(x, z, y = 1)
@@ -759,7 +759,7 @@ describe "Semantic: macro" do
       "missing argument: z"
   end
 
-  it "finds generic type argument of included module" do
+  it("finds generic type argument of included module") do
     assert_type(%(
       module Bar(T)
         def t
@@ -775,7 +775,7 @@ describe "Semantic: macro" do
       )) { int32.metaclass }
   end
 
-  it "finds generic type argument of included module with self" do
+  it("finds generic type argument of included module with self") do
     assert_type(%(
       module Bar(T)
         def t
@@ -791,7 +791,7 @@ describe "Semantic: macro" do
       )) { generic_class("Foo", int32).metaclass }
   end
 
-  it "finds free type vars" do
+  it("finds free type vars") do
     assert_type(%(
       module Foo(T)
         def self.foo(foo : U) forall U
@@ -803,7 +803,7 @@ describe "Semantic: macro" do
     )) { tuple_of([int32.metaclass, string.metaclass]) }
   end
 
-  it "gets named arguments in double splat" do
+  it("gets named arguments in double splat") do
     assert_type(%(
       macro foo(**options)
         {{options}}
@@ -813,7 +813,7 @@ describe "Semantic: macro" do
       )) { named_tuple_of({"x": string, "y": bool}) }
   end
 
-  it "uses splat and double splat" do
+  it("uses splat and double splat") do
     assert_type(%(
       macro foo(*args, **options)
         { {{args}}, {{options}} }
@@ -823,7 +823,7 @@ describe "Semantic: macro" do
       )) { tuple_of([tuple_of([int32, char]), named_tuple_of({"x": string, "y": bool})]) }
   end
 
-  it "double splat and regular args" do
+  it("double splat and regular args") do
     assert_type(%(
       macro foo(x, y, **options)
         { {{x}}, {{y}}, {{options}} }
@@ -833,7 +833,7 @@ describe "Semantic: macro" do
       )) { tuple_of([int32, bool, named_tuple_of({"w": char, "z": string})]) }
   end
 
-  it "declares multi-assign vars for macro" do
+  it("declares multi-assign vars for macro") do
     assert_type(%(
       macro id(x, y)
         {{x}}
@@ -846,7 +846,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "declares rescue variable inside for macro" do
+  it("declares rescue variable inside for macro") do
     assert_type(%(
       macro id(x)
         {{x}}
@@ -861,7 +861,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "matches with default value after splat" do
+  it("matches with default value after splat") do
     assert_type(%(
       macro foo(x, *y, z = true)
         { {{x}}, {{y}}, {{z}} }
@@ -871,7 +871,7 @@ describe "Semantic: macro" do
       )) { tuple_of([int32, tuple_of([char]), bool]) }
   end
 
-  it "uses bare *" do
+  it("uses bare *") do
     assert_type(%(
       macro foo(x, *, y)
         { {{x}}, {{y}} }
@@ -881,7 +881,7 @@ describe "Semantic: macro" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "uses bare *, doesn't let more args" do
+  it("uses bare *, doesn't let more args") do
     assert_error %(
       macro foo(x, *, y)
       end
@@ -891,7 +891,7 @@ describe "Semantic: macro" do
       "wrong number of arguments for macro 'foo' (given 2, expected 1)"
   end
 
-  it "uses bare *, doesn't let more args" do
+  it("uses bare *, doesn't let more args") do
     assert_error %(
       def foo(x, *, y)
       end
@@ -901,7 +901,7 @@ describe "Semantic: macro" do
       "no overload matches"
   end
 
-  it "finds macro through alias (#2706)" do
+  it("finds macro through alias (#2706)") do
     assert_type(%(
       module Moo
         macro bar
@@ -915,7 +915,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "can override macro (#2773)" do
+  it("can override macro (#2773)") do
     assert_type(%(
       macro foo
         1
@@ -929,7 +929,7 @@ describe "Semantic: macro" do
       )) { char }
   end
 
-  it "works inside proc literal (#2984)" do
+  it("works inside proc literal (#2984)") do
     assert_type(%(
       macro foo
         1
@@ -939,7 +939,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "finds var in proc for macros" do
+  it("finds var in proc for macros") do
     assert_type(%(
       macro foo(x)
         {{x}}
@@ -949,7 +949,7 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  it "applies visibility modifier only to first level" do
+  it("applies visibility modifier only to first level") do
     assert_type(%(
       macro foo
         class Foo
@@ -965,7 +965,7 @@ describe "Semantic: macro" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "gives correct error when method is invoked but macro exists at the same scope" do
+  it("gives correct error when method is invoked but macro exists at the same scope") do
     assert_error %(
       macro foo(x)
       end
@@ -978,7 +978,7 @@ describe "Semantic: macro" do
       "undefined method 'foo'"
   end
 
-  it "uses uninitialized variable with macros" do
+  it("uses uninitialized variable with macros") do
     assert_type(%(
       macro foo(x)
         {{x}}
@@ -989,8 +989,8 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
-  describe "skip_file macro directive" do
-    it "skips expanding the rest of the current file" do
+  describe("skip_file macro directive") do
+    it("skips expanding the rest of the current file") do
       res = semantic(%(
         class A
         end
@@ -1005,7 +1005,7 @@ describe "Semantic: macro" do
       res.program.types.has_key?("B").should be_false
     end
 
-    it "skips file inside an if macro expression" do
+    it("skips file inside an if macro expression") do
       res = semantic(%(
         class A
         end
@@ -1027,7 +1027,7 @@ describe "Semantic: macro" do
     end
   end
 
-  it "finds method before macro (#236)" do
+  it("finds method before macro (#236)") do
     assert_type(%(
       macro global
         1
@@ -1047,7 +1047,7 @@ describe "Semantic: macro" do
       )) { char }
   end
 
-  it "finds macro and method at the same scope" do
+  it("finds macro and method at the same scope") do
     assert_type(%(
       macro global(x)
         1
@@ -1061,7 +1061,7 @@ describe "Semantic: macro" do
       )) { tuple_of [int32, char] }
   end
 
-  it "finds macro and method at the same scope inside included module" do
+  it("finds macro and method at the same scope inside included module") do
     assert_type(%(
       module Moo
         macro global(x)
@@ -1085,7 +1085,7 @@ describe "Semantic: macro" do
       )) { tuple_of [int32, char] }
   end
 
-  it "finds macro in included module at class level (#4639)" do
+  it("finds macro in included module at class level (#4639)") do
     assert_type(%(
       module Moo
         macro foo
@@ -1105,7 +1105,7 @@ describe "Semantic: macro" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "finds macro in module in Object" do
+  it("finds macro in module in Object") do
     assert_type(%(
       class Object
         macro foo
@@ -1123,7 +1123,7 @@ describe "Semantic: macro" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "finds metaclass instance of instance method (#4739)" do
+  it("finds metaclass instance of instance method (#4739)") do
     assert_type(%(
       class Parent
         macro foo
@@ -1146,7 +1146,7 @@ describe "Semantic: macro" do
     )) { int32 }
   end
 
-  it "finds metaclass instance of instance method (#4639)" do
+  it("finds metaclass instance of instance method (#4639)") do
     assert_type(%(
       module Include
         macro foo

--- a/spec/compiler/semantic/method_missing_spec.cr
+++ b/spec/compiler/semantic/method_missing_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: method_missing" do
-  it "does error in method_missing macro with virtual type" do
+describe("Semantic: method_missing") do
+  it("does error in method_missing macro with virtual type") do
     assert_error %(
       abstract class Foo
       end
@@ -20,7 +20,7 @@ describe "Semantic: method_missing" do
       ), "undefined method 'lala' for Baz"
   end
 
-  it "does error in method_missing if wrong number of args" do
+  it("does error in method_missing if wrong number of args") do
     assert_error %(
       class Foo
         macro method_missing(call, foo)
@@ -29,7 +29,7 @@ describe "Semantic: method_missing" do
       ), "macro 'method_missing' expects 1 argument (call)"
   end
 
-  it "does method missing for generic type" do
+  it("does method missing for generic type") do
     assert_type(%(
       class Foo(T)
         macro method_missing(call)
@@ -41,7 +41,7 @@ describe "Semantic: method_missing" do
       )) { int32 }
   end
 
-  it "errors if method_missing expands to an incorrect method" do
+  it("errors if method_missing expands to an incorrect method") do
     assert_error %(
       class Foo
         macro method_missing(call)
@@ -56,7 +56,7 @@ describe "Semantic: method_missing" do
       "wrong method_missing expansion"
   end
 
-  it "errors if method_missing expands to multiple methods" do
+  it("errors if method_missing expands to multiple methods") do
     assert_error %(
       class Foo
         macro method_missing(call)
@@ -74,7 +74,7 @@ describe "Semantic: method_missing" do
       "wrong method_missing expansion"
   end
 
-  it "finds method_missing with 'with ... yield'" do
+  it("finds method_missing with 'with ... yield'") do
     assert_type(%(
       class Foo
         macro method_missing(call)

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1,16 +1,16 @@
 require "../../spec_helper"
 
-describe "Semantic: module" do
-  it "includes but not a module" do
+describe("Semantic: module") do
+  it("includes but not a module") do
     assert_error "class Foo; end; class Bar; include Foo; end",
       "Foo is not a module"
   end
 
-  it "includes module in a class" do
+  it("includes module in a class") do
     assert_type("module Foo; def foo; 1; end; end; class Bar; include Foo; end; Bar.new.foo") { int32 }
   end
 
-  it "includes module in a module" do
+  it("includes module in a module") do
     assert_type("
       module Moo
         def foo
@@ -30,7 +30,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "finds in module when included" do
+  it("finds in module when included") do
     assert_type("
       module Moo
         class B
@@ -44,7 +44,7 @@ describe "Semantic: module" do
     ") { int32 }
   end
 
-  it "includes generic module with type" do
+  it("includes generic module with type") do
     assert_type("
       module Foo(T)
         def foo(x : T)
@@ -60,7 +60,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "includes generic module and errors in call" do
+  it("includes generic module and errors in call") do
     assert_error "
       module Foo(T)
         def foo(x : T)
@@ -77,7 +77,7 @@ describe "Semantic: module" do
       "no overload matches"
   end
 
-  it "includes module but not generic" do
+  it("includes module but not generic") do
     assert_error "
       module Foo
       end
@@ -89,7 +89,7 @@ describe "Semantic: module" do
       "Foo is not a generic type"
   end
 
-  it "includes module but wrong number of arguments" do
+  it("includes module but wrong number of arguments") do
     assert_error "
       module Foo(T, U)
       end
@@ -101,7 +101,7 @@ describe "Semantic: module" do
       "wrong number of type vars for Foo(T, U) (given 1, expected 2)"
   end
 
-  it "includes generic module but wrong number of arguments 2" do
+  it("includes generic module but wrong number of arguments 2") do
     assert_error "
       module Foo(T)
       end
@@ -113,7 +113,7 @@ describe "Semantic: module" do
       "wrong number of type vars for Foo(T) (given 0, expected 1)"
   end
 
-  it "includes generic module explicitly" do
+  it("includes generic module explicitly") do
     assert_type("
       module Foo(T)
         def foo(x : T)
@@ -129,7 +129,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "includes generic module explicitly and errors" do
+  it("includes generic module explicitly and errors") do
     assert_error "
       module Foo(T)
         def foo(x : T)
@@ -146,12 +146,12 @@ describe "Semantic: module" do
       "no overload matches"
   end
 
-  it "reports can't use instance variables inside module" do
+  it("reports can't use instance variables inside module") do
     assert_error "def foo; @a = 1; end; foo",
       "can't use instance variables at the top level"
   end
 
-  it "works with int including enumerable" do
+  it("works with int including enumerable") do
     assert_type("
       require \"prelude\"
 
@@ -168,14 +168,14 @@ describe "Semantic: module" do
       ") { array_of(float64) }
   end
 
-  it "works with range and map" do
+  it("works with range and map") do
     assert_type("
       require \"prelude\"
       (1..3).map { |x| x * 0.5 }
       ") { array_of(float64) }
   end
 
-  it "declares module automatically if not previously declared when declaring a class" do
+  it("declares module automatically if not previously declared when declaring a class") do
     assert_type("
       class Foo::Bar
       end
@@ -187,7 +187,7 @@ describe "Semantic: module" do
     end
   end
 
-  it "declares module automatically if not previously declared when declaring a module" do
+  it("declares module automatically if not previously declared when declaring a module") do
     assert_type("
       module Foo::Bar
       end
@@ -199,7 +199,7 @@ describe "Semantic: module" do
     end
   end
 
-  it "includes generic module with another generic type" do
+  it("includes generic module with another generic type") do
     assert_type("
       module Foo(T)
         def foo
@@ -218,7 +218,7 @@ describe "Semantic: module" do
       ") { generic_class("Baz", int32).metaclass }
   end
 
-  it "includes generic module with self" do
+  it("includes generic module with self") do
     assert_type("
       module Foo(T)
         def foo
@@ -234,7 +234,7 @@ describe "Semantic: module" do
       ") { generic_class("Bar", int32).metaclass }
   end
 
-  it "includes generic module with self, and inherits it" do
+  it("includes generic module with self, and inherits it") do
     assert_type("
       module Foo(T)
         def foo
@@ -253,7 +253,7 @@ describe "Semantic: module" do
       ") { types["Baz"].metaclass }
   end
 
-  it "includes generic module with self (check argument type, success)" do
+  it("includes generic module with self (check argument type, success)") do
     assert_type("
       module Foo(T)
         def foo(x : T)
@@ -269,7 +269,7 @@ describe "Semantic: module" do
       ") { generic_class("Bar", int32) }
   end
 
-  it "includes generic module with self (check argument superclass type, success)" do
+  it("includes generic module with self (check argument superclass type, success)") do
     assert_type("
       module Foo(T)
         def foo(x : T)
@@ -288,7 +288,7 @@ describe "Semantic: module" do
       ") { types["Baz"] }
   end
 
-  it "includes generic module with self (check argument type, error)" do
+  it("includes generic module with self (check argument type, error)") do
     assert_error "
       module Foo(T)
         def foo(x : T)
@@ -310,7 +310,7 @@ describe "Semantic: module" do
       ", "no overload matches"
   end
 
-  it "includes generic module with self (check argument superclass type, error)" do
+  it("includes generic module with self (check argument superclass type, error)") do
     assert_error "
       module Foo(T)
         def foo(x : T)
@@ -329,7 +329,7 @@ describe "Semantic: module" do
       ", "no overload matches"
   end
 
-  it "includes generic module with self (check return type, success)" do
+  it("includes generic module with self (check return type, success)") do
     assert_type("
       module Foo(T)
         def foo : T
@@ -345,7 +345,7 @@ describe "Semantic: module" do
       ") { generic_class("Bar", int32) }
   end
 
-  it "includes generic module with self (check return subclass type, success)" do
+  it("includes generic module with self (check return subclass type, success)") do
     assert_type("
       module Foo(T)
         def foo : T
@@ -364,7 +364,7 @@ describe "Semantic: module" do
       ") { types["Baz"] }
   end
 
-  it "includes generic module with self (check return type, error)" do
+  it("includes generic module with self (check return type, error)") do
     assert_error "
       module Foo(T)
         def foo : T
@@ -383,7 +383,7 @@ describe "Semantic: module" do
       ", "type must be Baz, not Bar(Int32)"
   end
 
-  it "includes generic module with self (check return subclass type, error)" do
+  it("includes generic module with self (check return subclass type, error)") do
     assert_error "
       module Foo(T)
         def foo : T
@@ -405,7 +405,7 @@ describe "Semantic: module" do
       ", "type must be Baz1, not Baz2"
   end
 
-  it "includes module but can't access metaclass methods" do
+  it("includes module but can't access metaclass methods") do
     assert_error "
       module Foo
         def self.foo
@@ -421,7 +421,7 @@ describe "Semantic: module" do
       ", "undefined method 'foo'"
   end
 
-  it "extends a module" do
+  it("extends a module") do
     assert_type("
       module Foo
         def foo
@@ -437,7 +437,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "extends self" do
+  it("extends self") do
     assert_type("
       module Foo
         extend self
@@ -451,7 +451,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "gives error when including self" do
+  it("gives error when including self") do
     assert_error "
       module Foo
         include self
@@ -459,7 +459,7 @@ describe "Semantic: module" do
       ", "cyclic include detected"
   end
 
-  it "gives error with cyclic include" do
+  it("gives error with cyclic include") do
     assert_error "
       module Foo
       end
@@ -474,7 +474,7 @@ describe "Semantic: module" do
       ", "cyclic include detected"
   end
 
-  it "finds types close to included module" do
+  it("finds types close to included module") do
     assert_type("
       module Foo
         class T
@@ -496,7 +496,7 @@ describe "Semantic: module" do
       ") { types["Foo"].types["T"].metaclass }
   end
 
-  it "finds nested type inside method in block inside module" do
+  it("finds nested type inside method in block inside module") do
     assert_type("
       def foo
         yield
@@ -517,7 +517,7 @@ describe "Semantic: module" do
       ") { types["Foo"].types["Bar"].metaclass }
   end
 
-  it "finds class method in block" do
+  it("finds class method in block") do
     assert_type("
       def foo
         yield
@@ -540,7 +540,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "types pointer of module" do
+  it("types pointer of module") do
     assert_type("
       module Moo
       end
@@ -559,7 +559,7 @@ describe "Semantic: module" do
       ") { types["Moo"] }
   end
 
-  it "types pointer of module with method" do
+  it("types pointer of module with method") do
     assert_type("
       module Moo
       end
@@ -578,7 +578,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "types pointer of module with method with two including types" do
+  it("types pointer of module with method with two including types") do
     assert_type("
       module Moo
       end
@@ -606,7 +606,7 @@ describe "Semantic: module" do
       ") { union_of(int32, char) }
   end
 
-  it "types pointer of module with generic type" do
+  it("types pointer of module with generic type") do
     assert_type("
       module Moo
       end
@@ -625,7 +625,7 @@ describe "Semantic: module" do
       ") { int32 }
   end
 
-  it "types pointer of module with generic type" do
+  it("types pointer of module with generic type") do
     assert_type("
       module Moo
       end
@@ -660,7 +660,7 @@ describe "Semantic: module" do
       ") { union_of(int32, char) }
   end
 
-  it "allows overloading with included generic module" do
+  it("allows overloading with included generic module") do
     assert_type(%(
       module Foo(T)
         def foo(x : T)
@@ -685,7 +685,7 @@ describe "Semantic: module" do
       )) { union_of(int32, string) }
   end
 
-  it "finds constant in generic module included in another module" do
+  it("finds constant in generic module included in another module") do
     assert_type(%(
       module Foo(T)
         def foo
@@ -705,7 +705,7 @@ describe "Semantic: module" do
       )) { int32.metaclass }
   end
 
-  it "calls super on included generic module" do
+  it("calls super on included generic module") do
     assert_type(%(
       module Foo(T)
         def foo
@@ -725,7 +725,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "calls super on included generic module and finds type var" do
+  it("calls super on included generic module and finds type var") do
     assert_type(%(
       module Foo(T)
         def foo
@@ -745,7 +745,7 @@ describe "Semantic: module" do
       )) { int32.metaclass }
   end
 
-  it "calls super on included generic module and finds type var (2)" do
+  it("calls super on included generic module and finds type var (2)") do
     assert_type(%(
       module Foo(T)
         def foo
@@ -769,7 +769,7 @@ describe "Semantic: module" do
       )) { int32.metaclass }
   end
 
-  it "types union of module and class that includes it" do
+  it("types union of module and class that includes it") do
     assert_type(%(
       module Moo
         def self.foo
@@ -789,7 +789,7 @@ describe "Semantic: module" do
       )) { union_of(types["Bar"].metaclass, types["Moo"].metaclass) }
   end
 
-  it "works ok in a case where a typed-def type has un underlying type that has an included generic module (bug)" do
+  it("works ok in a case where a typed-def type has un underlying type that has an included generic module (bug)") do
     assert_type(%(
       lib LibC
         type X = Void*
@@ -817,7 +817,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "finds inner class from inherited one (#476)" do
+  it("finds inner class from inherited one (#476)") do
     assert_type(%(
       class Foo
         class Bar
@@ -833,7 +833,7 @@ describe "Semantic: module" do
       )) { types["Foo"].types["Bar"].types["Baz"].metaclass }
   end
 
-  it "correctly types type var in included module, with a restriction with a free var (bug)" do
+  it("correctly types type var in included module, with a restriction with a free var (bug)") do
     assert_type(%(
       module Moo(T)
       end
@@ -850,7 +850,7 @@ describe "Semantic: module" do
       )) { int32.metaclass }
   end
 
-  it "types proc of module after type changes" do
+  it("types proc of module after type changes") do
     assert_type(%(
       module Moo
       end
@@ -868,7 +868,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "types proc of module with generic class" do
+  it("types proc of module with generic class") do
     assert_type(%(
       module Moo
       end
@@ -886,7 +886,7 @@ describe "Semantic: module" do
       )) { char }
   end
 
-  it "errors if declares module inside if" do
+  it("errors if declares module inside if") do
     assert_error %(
       if 1 == 2
         module Foo; end
@@ -895,7 +895,7 @@ describe "Semantic: module" do
       "can't declare module dynamically"
   end
 
-  it "uses :Module name for modules in errors" do
+  it("uses :Module name for modules in errors") do
     assert_error %(
       module Moo; end
 
@@ -904,7 +904,7 @@ describe "Semantic: module" do
       "undefined method 'new' for Moo:Module"
   end
 
-  it "uses type declaration inside module" do
+  it("uses type declaration inside module") do
     assert_type(%(
       module Moo
         @x : Int32
@@ -926,7 +926,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "uses type declaration inside module and gives error" do
+  it("uses type declaration inside module and gives error") do
     assert_error %(
       module Moo
         @x : Int32
@@ -953,7 +953,7 @@ describe "Semantic: module" do
       "instance variable '@x' of Foo must be Int32, not Bool"
   end
 
-  it "uses type declaration inside module, recursive, and gives error" do
+  it("uses type declaration inside module, recursive, and gives error") do
     assert_error %(
       module Moo
         @x : Int32
@@ -984,7 +984,7 @@ describe "Semantic: module" do
       "instance variable '@x' of Foo must be Int32"
   end
 
-  it "initializes variable in module" do
+  it("initializes variable in module") do
     assert_type(%(
       module Moo
         @x = 1
@@ -1002,7 +1002,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "initializes variable in module, recursive" do
+  it("initializes variable in module, recursive") do
     assert_type(%(
       module Moo
         @x = 1
@@ -1024,7 +1024,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "inherits instance var type annotation from generic to concrete" do
+  it("inherits instance var type annotation from generic to concrete") do
     assert_type(%(
       module Foo(T)
         @x : Int32?
@@ -1042,7 +1042,7 @@ describe "Semantic: module" do
       )) { nilable int32 }
   end
 
-  it "inherits instance var type annotation from generic to concrete with T" do
+  it("inherits instance var type annotation from generic to concrete with T") do
     assert_type(%(
       module Foo(T)
         @x : T?
@@ -1060,7 +1060,7 @@ describe "Semantic: module" do
       )) { nilable int32 }
   end
 
-  it "inherits instance var type annotation from generic to generic to concrete" do
+  it("inherits instance var type annotation from generic to generic to concrete") do
     assert_type(%(
       module Foo(T)
         @x : Int32?
@@ -1082,7 +1082,7 @@ describe "Semantic: module" do
       )) { nilable int32 }
   end
 
-  it "declares and includes generic module" do
+  it("declares and includes generic module") do
     assert_type(%(
       module Moo(*T)
         def t
@@ -1098,7 +1098,7 @@ describe "Semantic: module" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
-  it "declares and includes generic module, more args" do
+  it("declares and includes generic module, more args") do
     assert_type(%(
       module Moo(A, *T, B)
         def t
@@ -1114,7 +1114,7 @@ describe "Semantic: module" do
       )) { tuple_of([int32.metaclass, tuple_of([float64, char]).metaclass, string.metaclass]) }
   end
 
-  it "includes module with Union(T*)" do
+  it("includes module with Union(T*)") do
     assert_type(%(
       module Foo(U)
         def u
@@ -1130,7 +1130,7 @@ describe "Semantic: module" do
       )) { union_of(int32, char).metaclass }
   end
 
-  it "doesn't lookup type in ancestor when matches in current type (#2982)" do
+  it("doesn't lookup type in ancestor when matches in current type (#2982)") do
     assert_error %(
       module Foo
         module Qux
@@ -1149,7 +1149,7 @@ describe "Semantic: module" do
       "undefined constant Qux::Bar"
   end
 
-  it "can restrict module with module (#3029)" do
+  it("can restrict module with module (#3029)") do
     assert_type(%(
       module Foo
       end
@@ -1165,7 +1165,7 @@ describe "Semantic: module" do
       )) { int32 }
   end
 
-  it "can instantiate generic module" do
+  it("can instantiate generic module") do
     assert_type(%(
       module Foo(T)
       end
@@ -1174,7 +1174,7 @@ describe "Semantic: module" do
       )) { generic_module("Foo", int32).metaclass }
   end
 
-  it "can use generic module as instance variable type" do
+  it("can use generic module as instance variable type") do
     assert_type(%(
       module Moo(T)
         def foo
@@ -1208,7 +1208,7 @@ describe "Semantic: module" do
       )) { union_of int32, char }
   end
 
-  it "can use generic module as instance variable type (2)" do
+  it("can use generic module as instance variable type (2)") do
     assert_type(%(
       module Moo(T)
         def foo
@@ -1243,7 +1243,7 @@ describe "Semantic: module" do
       )) { union_of int32, char }
   end
 
-  it "errors when extending module that defines instance vars (#4065)" do
+  it("errors when extending module that defines instance vars (#4065)") do
     assert_error %(
       module Foo
         @foo : Int32?

--- a/spec/compiler/semantic/named_args_spec.cr
+++ b/spec/compiler/semantic/named_args_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: named args" do
-  it "errors if named arg not found" do
+describe("Semantic: named args") do
+  it("errors if named arg not found") do
     assert_error %(
       def foo(x, y = 1, z = 2)
       end
@@ -11,7 +11,7 @@ describe "Semantic: named args" do
       "no argument named 'w'"
   end
 
-  it "errors if named arg already specified" do
+  it("errors if named arg already specified") do
     assert_error %(
       def foo(x, y = 1, z = 2)
       end
@@ -21,7 +21,7 @@ describe "Semantic: named args" do
       "argument 'x' already specified"
   end
 
-  it "errors if named arg not found in new" do
+  it("errors if named arg not found in new") do
     assert_error %(
       class Foo
         def initialize(x, y = 1, z = 2)
@@ -33,7 +33,7 @@ describe "Semantic: named args" do
       "no argument named 'w'"
   end
 
-  it "errors if named arg already specified" do
+  it("errors if named arg already specified") do
     assert_error %(
       class Foo
         def initialize(x, y = 1, z = 2)
@@ -45,7 +45,7 @@ describe "Semantic: named args" do
       "argument 'x' already specified"
   end
 
-  it "errors if doesn't pass named arg restriction" do
+  it("errors if doesn't pass named arg restriction") do
     assert_error %(
       def foo(x : Int32 = 1)
       end
@@ -55,7 +55,7 @@ describe "Semantic: named args" do
       "no overload matches"
   end
 
-  it "errors if named arg already specified but in same position" do
+  it("errors if named arg already specified but in same position") do
     assert_error %(
       def foo(headers = nil)
       end
@@ -65,7 +65,7 @@ describe "Semantic: named args" do
       "argument 'headers' already specified"
   end
 
-  it "sends one regular argument as named argument" do
+  it("sends one regular argument as named argument") do
     assert_type(%(
       def foo(x)
         x
@@ -75,7 +75,7 @@ describe "Semantic: named args" do
       )) { int32 }
   end
 
-  it "sends two regular arguments as named arguments" do
+  it("sends two regular arguments as named arguments") do
     assert_type(%(
       def foo(x, y)
         x + y
@@ -85,7 +85,7 @@ describe "Semantic: named args" do
       )) { int32 }
   end
 
-  it "sends two regular arguments as named arguments in inverted position (1)" do
+  it("sends two regular arguments as named arguments in inverted position (1)") do
     assert_type(%(
       def foo(x, y)
         x
@@ -95,7 +95,7 @@ describe "Semantic: named args" do
       )) { string }
   end
 
-  it "sends two regular arguments as named arguments in inverted position (2)" do
+  it("sends two regular arguments as named arguments in inverted position (2)") do
     assert_type(%(
       def foo(x, y)
         y
@@ -105,7 +105,7 @@ describe "Semantic: named args" do
       )) { int32 }
   end
 
-  it "errors if named arg matches single splat argument" do
+  it("errors if named arg matches single splat argument") do
     assert_error %(
       def foo(*y)
       end
@@ -115,7 +115,7 @@ describe "Semantic: named args" do
       "no argument named 'x'"
   end
 
-  it "errors if named arg matches splat argument" do
+  it("errors if named arg matches splat argument") do
     assert_error %(
       def foo(x, *y)
       end
@@ -125,7 +125,7 @@ describe "Semantic: named args" do
       "no overload matches"
   end
 
-  it "allows named arg if there's a splat" do
+  it("allows named arg if there's a splat") do
     assert_type(%(
       def foo(*y, x)
         { x, y }
@@ -135,7 +135,7 @@ describe "Semantic: named args" do
       )) { tuple_of([char, tuple_of([int32])]) }
   end
 
-  it "errors if missing one argument" do
+  it("errors if missing one argument") do
     assert_error %(
       def foo(x, y, z)
       end
@@ -145,7 +145,7 @@ describe "Semantic: named args" do
       "missing argument: z"
   end
 
-  it "errors if missing two arguments" do
+  it("errors if missing two arguments") do
     assert_error %(
       def foo(x, y, z)
       end
@@ -155,7 +155,7 @@ describe "Semantic: named args" do
       "missing arguments: x, z"
   end
 
-  it "doesn't include arguments with default values in missing arguments error" do
+  it("doesn't include arguments with default values in missing arguments error") do
     assert_error %(
 
       def foo(x, z, y = 1)
@@ -166,7 +166,7 @@ describe "Semantic: named args" do
       "missing argument: z"
   end
 
-  it "says no overload matches with named arg" do
+  it("says no overload matches with named arg") do
     assert_error %(
       def foo(x, y)
       end
@@ -179,7 +179,7 @@ describe "Semantic: named args" do
       "no overload matches"
   end
 
-  it "gives correct error message for missing args after *" do
+  it("gives correct error message for missing args after *") do
     assert_error %(
       def foo(*, x, y)
       end
@@ -189,7 +189,7 @@ describe "Semantic: named args" do
       "missing arguments: x, y"
   end
 
-  it "overloads based on required named args" do
+  it("overloads based on required named args") do
     assert_type(%(
       def foo(x, *, y)
         1
@@ -206,7 +206,7 @@ describe "Semantic: named args" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "overloads based on required named args, with restrictions" do
+  it("overloads based on required named args, with restrictions") do
     assert_type(%(
       def foo(x, *, z : Int32)
         1
@@ -223,7 +223,7 @@ describe "Semantic: named args" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "uses bare splat in new" do
+  it("uses bare splat in new") do
     assert_type(%(
       class Foo
         def initialize(*, y = nil)
@@ -234,7 +234,7 @@ describe "Semantic: named args" do
       )) { types["Foo"] }
   end
 
-  it "passes #2696" do
+  it("passes #2696") do
     assert_type(%(
       class Bar
         def bar
@@ -253,7 +253,7 @@ describe "Semantic: named args" do
       )) { types["Bar"] }
   end
 
-  it "matches specific overload with named arguments (#2753)" do
+  it("matches specific overload with named arguments (#2753)") do
     assert_type(%(
       def foo(x : Nil, y)
         foo 1, y
@@ -269,7 +269,7 @@ describe "Semantic: named args" do
       )) { bool }
   end
 
-  it "matches specific overload with named arguments (2) (#2753)" do
+  it("matches specific overload with named arguments (2) (#2753)") do
     assert_type(%(
       def foo(x : Nil, y, z)
         foo 1, y, z
@@ -285,7 +285,7 @@ describe "Semantic: named args" do
       )) { bool }
   end
 
-  it "gives correct error message with external names (#3934)" do
+  it("gives correct error message with external names (#3934)") do
     assert_error %(
       def foo(*, arg a : String)
         a

--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -1,100 +1,100 @@
 require "../../spec_helper"
 
-describe "Semantic: named tuples" do
-  it "types named tuple of one element" do
+describe("Semantic: named tuples") do
+  it("types named tuple of one element") do
     assert_type("{x: 1}") { named_tuple_of({"x": int32}) }
   end
 
-  it "types named tuple of two elements" do
+  it("types named tuple of two elements") do
     assert_type("{x: 1, y: 'a'}") { named_tuple_of({"x": int32, "y": char}) }
   end
 
-  it "types named tuple of two elements, follows names order" do
+  it("types named tuple of two elements, follows names order") do
     assert_type("{y: 'a', x: 1}") { named_tuple_of({"y": char, "x": int32}) }
   end
 
-  it "types named tuple access (1)" do
+  it("types named tuple access (1)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t[:x]
       )) { int32 }
   end
 
-  it "types named tuple access (2)" do
+  it("types named tuple access (2)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t[:y]
       )) { char }
   end
 
-  it "types named tuple access (3)" do
+  it("types named tuple access (3)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t["x"]
       )) { int32 }
   end
 
-  it "types named tuple access (4)" do
+  it("types named tuple access (4)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t["y"]
       )) { char }
   end
 
-  it "types nilable named tuple access (1)" do
+  it("types nilable named tuple access (1)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t[:x]?
       )) { int32 }
   end
 
-  it "types nilable named tuple access (2)" do
+  it("types nilable named tuple access (2)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t[:y]?
       )) { char }
   end
 
-  it "types nilable named tuple access (3)" do
+  it("types nilable named tuple access (3)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t[:foo]?
       )) { nil_type }
   end
 
-  it "types nilable named tuple access (4)" do
+  it("types nilable named tuple access (4)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t["x"]?
       )) { int32 }
   end
 
-  it "types nilable named tuple access (5)" do
+  it("types nilable named tuple access (5)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t["y"]?
       )) { char }
   end
 
-  it "types nilable named tuple access (6)" do
+  it("types nilable named tuple access (6)") do
     assert_type(%(
       t = {x: 1, y: 'a'}
       t["foo"]?
       )) { nil_type }
   end
 
-  it "gives error when indexing with an unknown name" do
+  it("gives error when indexing with an unknown name") do
     assert_error "{x: 1, y: 'a'}[:z]",
       "missing key 'z' for named tuple NamedTuple(x: Int32, y: Char)"
   end
 
-  it "can write generic type for NamedTuple" do
+  it("can write generic type for NamedTuple") do
     assert_type(%(
       NamedTuple(x: Int32, y: Char)
       )) { named_tuple_of({"x": int32, "y": char}).metaclass }
   end
 
-  it "gives error when using named args on a type other than NamedTuple" do
+  it("gives error when using named args on a type other than NamedTuple") do
     assert_error %(
       class Foo(T)
       end
@@ -104,21 +104,21 @@ describe "Semantic: named tuples" do
       "can only use named arguments with NamedTuple"
   end
 
-  it "gives error when using named args on Tuple" do
+  it("gives error when using named args on Tuple") do
     assert_error %(
       Tuple(x: Int32, y: Char)
       ),
       "can only use named arguments with NamedTuple"
   end
 
-  it "gives error when not using named args with NamedTuple" do
+  it("gives error when not using named args with NamedTuple") do
     assert_error %(
       NamedTuple(Int32, Char)
       ),
       "can only instantiate NamedTuple with named arguments"
   end
 
-  it "gets type at compile time" do
+  it("gets type at compile time") do
     assert_type(%(
       struct NamedTuple
         def y
@@ -130,7 +130,7 @@ describe "Semantic: named tuples" do
       )) { char.metaclass }
   end
 
-  it "matches in type restriction" do
+  it("matches in type restriction") do
     assert_type(%(
       def foo(x : {x: Int32, y: Char})
         1
@@ -140,7 +140,7 @@ describe "Semantic: named tuples" do
       )) { int32 }
   end
 
-  it "matches in type restriction, different order (1)" do
+  it("matches in type restriction, different order (1)") do
     assert_type(%(
       def foo(x : {y: Char, x: Int32})
         1
@@ -150,7 +150,7 @@ describe "Semantic: named tuples" do
       )) { int32 }
   end
 
-  it "matches in type restriction, different order (2)" do
+  it("matches in type restriction, different order (2)") do
     assert_type(%(
       def foo(x : {x: Int32, y: Char})
         1
@@ -160,7 +160,7 @@ describe "Semantic: named tuples" do
       )) { int32 }
   end
 
-  it "doesn't match in type restriction" do
+  it("doesn't match in type restriction") do
     assert_error %(
       def foo(x : {x: Int32, y: Int32})
         1
@@ -171,7 +171,7 @@ describe "Semantic: named tuples" do
       "no overload matches"
   end
 
-  it "doesn't match type restriction with instance" do
+  it("doesn't match type restriction with instance") do
     assert_error %(
       class Foo(T)
         def self.foo(x : T)
@@ -183,7 +183,7 @@ describe "Semantic: named tuples" do
       "no overload matches"
   end
 
-  it "matches in type restriction and gets free var" do
+  it("matches in type restriction and gets free var") do
     assert_type(%(
       def foo(x : {x: T, y: T}) forall T
         T
@@ -193,7 +193,7 @@ describe "Semantic: named tuples" do
       )) { int32.metaclass }
   end
 
-  it "merges two named tuples with the same keys and types" do
+  it("merges two named tuples with the same keys and types") do
     assert_type(%(
       t1 = {x: 1, y: 'a'}
       t2 = {y: 'a', x: 1}
@@ -201,7 +201,7 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"x": int32, "y": char}) }
   end
 
-  it "can assign to union of compatible named tuple" do
+  it("can assign to union of compatible named tuple") do
     assert_type(%(
       tup1 = {x: 1, y: "foo"}
       tup2 = {x: 3}
@@ -213,7 +213,7 @@ describe "Semantic: named tuples" do
       )) { union_of(named_tuple_of({"x": int32}), named_tuple_of({"x": int32, "y": string})) }
   end
 
-  it "allows tuple covariance" do
+  it("allows tuple covariance") do
     assert_type(%(
       class Obj
         def initialize
@@ -240,7 +240,7 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"foo": types["Foo"].virtual_type!}) }
   end
 
-  it "merges two named tuple with same keys but different types" do
+  it("merges two named tuple with same keys but different types") do
     assert_type(%(
       def foo
         if 1 == 2
@@ -254,7 +254,7 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"x": union_of(char, string), "y": nilable(int32)}) }
   end
 
-  it "accept named tuple in type restriction" do
+  it("accept named tuple in type restriction") do
     assert_type(%(
       class Foo
       end
@@ -270,7 +270,7 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"foo": types["Bar"]}) }
   end
 
-  it "accepts named tuple covariance in array" do
+  it("accepts named tuple covariance in array") do
     assert_type(%(
       require "prelude"
 
@@ -286,7 +286,7 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"x": types["Foo"].virtual_type!, "y": types["Foo"].virtual_type!}) }
   end
 
-  it "does not compile to_h of empty tuples" do
+  it("does not compile to_h of empty tuples") do
     # TODO change the location of this spec upon #2391
     assert_error %(
       require "prelude"
@@ -295,7 +295,7 @@ describe "Semantic: named tuples" do
       "Can't convert an empty NamedTuple to a Hash"
   end
 
-  it "types T as a tuple of metaclasses" do
+  it("types T as a tuple of metaclasses") do
     assert_type("
       struct NamedTuple
         def named_args

--- a/spec/compiler/semantic/new_spec.cr
+++ b/spec/compiler/semantic/new_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: new" do
-  it "doesn't incorrectly redefines new for generic class" do
+describe("Semantic: new") do
+  it("doesn't incorrectly redefines new for generic class") do
     assert_type(%(
       class Foo(T)
         def self.new
@@ -13,7 +13,7 @@ describe "Semantic: new" do
       )) { int32 }
   end
 
-  it "evaluates initialize default value at the instance scope (1) (#731)" do
+  it("evaluates initialize default value at the instance scope (1) (#731)") do
     assert_type(%(
       class Foo
         def initialize(@x = self)
@@ -28,7 +28,7 @@ describe "Semantic: new" do
       )) { types["Foo"] }
   end
 
-  it "evaluates initialize default value at the instance scope (2) (#731)" do
+  it("evaluates initialize default value at the instance scope (2) (#731)") do
     assert_type(%(
       class Foo
         def initialize(@x = self, @y = 'a')
@@ -43,7 +43,7 @@ describe "Semantic: new" do
       )) { char }
   end
 
-  it "evaluates initialize default value at the instance scope (3) (#731)" do
+  it("evaluates initialize default value at the instance scope (3) (#731)") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -67,7 +67,7 @@ describe "Semantic: new" do
       )) { int32 }
   end
 
-  it "evaluates initialize default value at the instance scope (4) (#731)" do
+  it("evaluates initialize default value at the instance scope (4) (#731)") do
     assert_type(%(
       class Foo
         @x : Int32
@@ -90,7 +90,7 @@ describe "Semantic: new" do
       )) { int32 }
   end
 
-  it "evaluates initialize default value at the instance scope (5) (#731)" do
+  it("evaluates initialize default value at the instance scope (5) (#731)") do
     assert_type(%(
       class Foo(R)
         @x : Int32
@@ -111,7 +111,7 @@ describe "Semantic: new" do
       )) { int32 }
   end
 
-  it "evaluates initialize default value at the instance scope (6) (#731)" do
+  it("evaluates initialize default value at the instance scope (6) (#731)") do
     assert_type(%(
       class Foo(R)
         @x : Int32
@@ -132,7 +132,7 @@ describe "Semantic: new" do
       )) { int32 }
   end
 
-  it "errors if using self call in default argument (1)" do
+  it("errors if using self call in default argument (1)") do
     assert_error %(
       class My
         @name : String
@@ -153,7 +153,7 @@ describe "Semantic: new" do
       "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "errors if using self call in default argument (2)" do
+  it("errors if using self call in default argument (2)") do
     assert_error %(
       class My
         @name : String
@@ -173,7 +173,7 @@ describe "Semantic: new" do
       "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "errors if using self call in default argument (3)" do
+  it("errors if using self call in default argument (3)") do
     assert_error %(
       class My
         @name : String
@@ -192,7 +192,7 @@ describe "Semantic: new" do
       "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "inherits initialize and new methods if doesn't define new (#3238)" do
+  it("inherits initialize and new methods if doesn't define new (#3238)") do
     assert_type(%(
       class Foo(T)
         def initialize(x : Int32)
@@ -210,7 +210,7 @@ describe "Semantic: new" do
       )) { types["Bar"] }
   end
 
-  it "doesn't have default new for inherited class from generic type" do
+  it("doesn't have default new for inherited class from generic type") do
     assert_error %(
       class Foo(T)
         def initialize(x : Int32)

--- a/spec/compiler/semantic/nil_spec.cr
+++ b/spec/compiler/semantic/nil_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Semantic: nil" do
-  it "types empty" do
+describe("Semantic: nil") do
+  it("types empty") do
     assert_type("") { nil_type }
   end
 
-  it "types nil" do
+  it("types nil") do
     assert_type("nil") { nil_type }
   end
 
-  it "can call a fun with nil for pointer" do
+  it("can call a fun with nil for pointer") do
     assert_type("lib LibA; fun a(c : Char*) : Int32; end; LibA.a(nil)") { int32 }
   end
 
-  it "can call a fun with nil for typedef pointer" do
+  it("can call a fun with nil for typedef pointer") do
     assert_type("lib LibA; type Foo = Char*; fun a(c : Foo) : Int32; end; LibA.a(nil)") { int32 }
   end
 
-  it "marks instance variables as nil but doesn't explode on macros" do
+  it("marks instance variables as nil but doesn't explode on macros") do
     assert_type("
       require \"prelude\"
 
@@ -35,7 +35,7 @@ describe "Semantic: nil" do
     ") { int32 }
   end
 
-  it "marks instance variables as nil when not in initialize" do
+  it("marks instance variables as nil when not in initialize") do
     assert_type("
       class Foo
         def initialize
@@ -57,7 +57,7 @@ describe "Semantic: nil" do
       ") { nilable int32 }
   end
 
-  it "marks instance variables as nil when not in initialize 2" do
+  it("marks instance variables as nil when not in initialize 2") do
     assert_type("
       class Foo
         def initialize
@@ -83,7 +83,7 @@ describe "Semantic: nil" do
       ") { int32 }
   end
 
-  it "restricts type of 'if foo'" do
+  it("restricts type of 'if foo'") do
     assert_type("
       class Foo
         def bar
@@ -96,7 +96,7 @@ describe "Semantic: nil" do
       ") { int32 }
   end
 
-  it "restricts type of 'if foo' on assign" do
+  it("restricts type of 'if foo' on assign") do
     assert_type("
       class Foo
         def bar
@@ -112,7 +112,7 @@ describe "Semantic: nil" do
       ") { int32 }
   end
 
-  it "restricts type of 'while foo'" do
+  it("restricts type of 'while foo'") do
     assert_type("
       class Foo
         def bar
@@ -128,7 +128,7 @@ describe "Semantic: nil" do
       ") { int32 }
   end
 
-  it "restricts type of 'while foo' on assign" do
+  it("restricts type of 'while foo' on assign") do
     assert_type("
       class Foo
         def bar
@@ -143,7 +143,7 @@ describe "Semantic: nil" do
       ") { int32 }
   end
 
-  it "doesn't check return type for nil" do
+  it("doesn't check return type for nil") do
     assert_type(%(
       def foo : Nil
         1
@@ -153,7 +153,7 @@ describe "Semantic: nil" do
       )) { nil_type }
   end
 
-  it "doesn't check return type for void" do
+  it("doesn't check return type for void") do
     assert_type(%(
       def foo : Void
         1

--- a/spec/compiler/semantic/nilable_cast_spec.cr
+++ b/spec/compiler/semantic/nilable_cast_spec.cr
@@ -1,25 +1,25 @@
 require "../../spec_helper"
 
-describe "Semantic: nilable cast" do
-  it "types as?" do
+describe("Semantic: nilable cast") do
+  it("types as?") do
     assert_type(%(
       1.as?(Float64)
       )) { nilable float64 }
   end
 
-  it "types as? with union" do
+  it("types as? with union") do
     assert_type(%(
       (1 || 'a').as?(Int32)
       )) { nilable int32 }
   end
 
-  it "types as? with nil" do
+  it("types as? with nil") do
     assert_type(%(
       1.as?(Nil)
       )) { nil_type }
   end
 
-  it "does upcast" do
+  it("does upcast") do
     assert_type(%(
       class Foo
         def bar

--- a/spec/compiler/semantic/nilable_instance_var_spec.cr
+++ b/spec/compiler/semantic/nilable_instance_var_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: nilable instance var" do
-  it "says instance var was not initialized in all of the initialize methods" do
+describe("Semantic: nilable instance var") do
+  it("says instance var was not initialized in all of the initialize methods") do
     assert_error %(
       class Foo
         def initialize
@@ -21,7 +21,7 @@ describe "Semantic: nilable instance var" do
       "this 'initialize' doesn't explicitly initialize instance variable '@foo' of Foo, rendering it nilable"
   end
 
-  it "says instance var was not initialized in all of the initialize methods (2)" do
+  it("says instance var was not initialized in all of the initialize methods (2)") do
     assert_error %(
       abstract class Foo
         def foo
@@ -46,7 +46,7 @@ describe "Semantic: nilable instance var" do
       "Can't infer the type of instance variable '@foo' of Foo"
   end
 
-  it "says instance var was not initialized in all of the initialize methods, with var declaration" do
+  it("says instance var was not initialized in all of the initialize methods, with var declaration") do
     assert_error %(
       class Foo
         @foo : Int32
@@ -61,7 +61,7 @@ describe "Semantic: nilable instance var" do
       "instance variable '@foo' of Foo was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
   end
 
-  it "says instance var was used before initialized" do
+  it("says instance var was used before initialized") do
     assert_error %(
       class Foo
         def initialize
@@ -79,7 +79,7 @@ describe "Semantic: nilable instance var" do
       "instance variable '@foo' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "says instance var was used before initialized (2)" do
+  it("says instance var was used before initialized (2)") do
     assert_error %(
       class Foo
         def initialize
@@ -97,7 +97,7 @@ describe "Semantic: nilable instance var" do
       "instance variable '@foo' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "says self was used before instance var was initialized" do
+  it("says self was used before instance var was initialized") do
     assert_error %(
       def baz(x)
       end
@@ -118,7 +118,7 @@ describe "Semantic: nilable instance var" do
       "'self' was used before initializing instance variable '@foo', rendering it nilable"
   end
 
-  it "says self was used before instance var was initialized (2)" do
+  it("says self was used before instance var was initialized (2)") do
     assert_error %(
       class Baz
         def self.baz(x)
@@ -141,7 +141,7 @@ describe "Semantic: nilable instance var" do
       "'self' was used before initializing instance variable '@foo', rendering it nilable"
   end
 
-  it "says self was used before instance var was initialized (3)" do
+  it("says self was used before instance var was initialized (3)") do
     assert_error %(
       class Foo
         def initialize
@@ -159,7 +159,7 @@ describe "Semantic: nilable instance var" do
       "'self' was used before initializing instance variable '@foo', rendering it nilable"
   end
 
-  it "finds type that doesn't initialize instance var (#1222)" do
+  it("finds type that doesn't initialize instance var (#1222)") do
     assert_error %(
       class Base
         def initialize
@@ -188,7 +188,7 @@ describe "Semantic: nilable instance var" do
       "this 'initialize' doesn't initialize instance variable '@x' of Base, with Unreferenced < Base, rendering it nilable"
   end
 
-  it "doesn't consider as nil if initialized with catch-all" do
+  it("doesn't consider as nil if initialized with catch-all") do
     assert_type(%(
       class Test
         @a = 0
@@ -206,7 +206,7 @@ describe "Semantic: nilable instance var" do
       )) { int32 }
   end
 
-  it "marks instance var as nilable if assigned inside captured block (#1696)" do
+  it("marks instance var as nilable if assigned inside captured block (#1696)") do
     assert_error %(
       def capture(&block)
         block
@@ -227,7 +227,7 @@ describe "Semantic: nilable instance var" do
       "instance variable '@foo' was used before it was initialized in one of the 'initialize' methods, rendering it nilable"
   end
 
-  it "marks instance var as nilable if assigned inside proc literal" do
+  it("marks instance var as nilable if assigned inside proc literal") do
     assert_error %(
       class Foo
         def initialize

--- a/spec/compiler/semantic/no_return_spec.cr
+++ b/spec/compiler/semantic/no_return_spec.cr
@@ -1,27 +1,27 @@
 require "../../spec_helper"
 
-describe "Semantic: NoReturn" do
-  it "types call to LibC.exit as NoReturn" do
+describe("Semantic: NoReturn") do
+  it("types call to LibC.exit as NoReturn") do
     assert_type("lib LibC; fun exit : NoReturn; end; LibC.exit") { no_return }
   end
 
-  it "types raise as NoReturn" do
+  it("types raise as NoReturn") do
     assert_type("require \"prelude\"; raise \"foo\"") { no_return }
   end
 
-  it "types union of NoReturn and something else" do
+  it("types union of NoReturn and something else") do
     assert_type("lib LibC; fun exit : NoReturn; end; 1 == 1 ? LibC.exit : 1") { int32 }
   end
 
-  it "types union of NoReturns" do
+  it("types union of NoReturns") do
     assert_type("lib LibC; fun exit : NoReturn; end; 1 == 2 ? LibC.exit : LibC.exit") { no_return }
   end
 
-  it "types with no return even if code follows" do
+  it("types with no return even if code follows") do
     assert_type("lib LibC; fun exit : NoReturn; end; LibC.exit; 1") { no_return }
   end
 
-  it "assumes if condition's type filters when else is no return" do
+  it("assumes if condition's type filters when else is no return") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -40,7 +40,7 @@ describe "Semantic: NoReturn" do
     ") { int32 }
   end
 
-  it "computes NoReturn in a lazy way inside if then (#314) (1)" do
+  it("computes NoReturn in a lazy way inside if then (#314) (1)") do
     assert_type(%(
       require "prelude"
 
@@ -62,7 +62,7 @@ describe "Semantic: NoReturn" do
       )) { union_of(int32, string) }
   end
 
-  it "computes NoReturn in a lazy way inside if then (#314) (2)" do
+  it("computes NoReturn in a lazy way inside if then (#314) (2)") do
     assert_type(%(
       require "prelude"
 
@@ -83,7 +83,7 @@ describe "Semantic: NoReturn" do
       )) { int32 }
   end
 
-  it "computes NoReturn in a lazy way inside if then (#314) (3)" do
+  it("computes NoReturn in a lazy way inside if then (#314) (3)") do
     assert_type(%(
       require "prelude"
 
@@ -109,7 +109,7 @@ describe "Semantic: NoReturn" do
       )) { nilable(string) }
   end
 
-  it "computes NoReturn in a lazy way inside if then (#314) (4)" do
+  it("computes NoReturn in a lazy way inside if then (#314) (4)") do
     assert_type(%(
       require "prelude"
 
@@ -134,7 +134,7 @@ describe "Semantic: NoReturn" do
       )) { nil_type }
   end
 
-  it "computes NoReturn in a lazy way inside if then (#314) (5)" do
+  it("computes NoReturn in a lazy way inside if then (#314) (5)") do
     assert_error %(
       require "prelude"
 
@@ -159,7 +159,7 @@ describe "Semantic: NoReturn" do
       "undefined method 'size' for Nil"
   end
 
-  it "computes NoReturn in a lazy way inside if else (#314) (1)" do
+  it("computes NoReturn in a lazy way inside if else (#314) (1)") do
     assert_type(%(
       require "prelude"
 
@@ -182,7 +182,7 @@ describe "Semantic: NoReturn" do
       )) { union_of(int32, string) }
   end
 
-  it "computes NoReturn in a lazy way inside if else (#314) (2)" do
+  it("computes NoReturn in a lazy way inside if else (#314) (2)") do
     assert_type(%(
       require "prelude"
 
@@ -204,7 +204,7 @@ describe "Semantic: NoReturn" do
       )) { int32 }
   end
 
-  it "computes NoReturn in a lazy way inside if else (#314) (3)" do
+  it("computes NoReturn in a lazy way inside if else (#314) (3)") do
     assert_type(%(
       require "prelude"
 
@@ -231,7 +231,7 @@ describe "Semantic: NoReturn" do
       )) { nilable(string) }
   end
 
-  it "computes NoReturn in a lazy way inside if else (#314) (4)" do
+  it("computes NoReturn in a lazy way inside if else (#314) (4)") do
     assert_type(%(
       require "prelude"
 
@@ -257,7 +257,7 @@ describe "Semantic: NoReturn" do
       )) { nil_type }
   end
 
-  it "computes NoReturn in a lazy way inside if else (#314) (5)" do
+  it("computes NoReturn in a lazy way inside if else (#314) (5)") do
     assert_error %(
       require "prelude"
 
@@ -282,7 +282,7 @@ describe "Semantic: NoReturn" do
       "undefined method 'size' for Nil"
   end
 
-  it "types exception handler as NoReturn if ensure is NoReturn" do
+  it("types exception handler as NoReturn if ensure is NoReturn") do
     assert_type(%(
       lib LibC
         fun foo : NoReturn
@@ -296,7 +296,7 @@ describe "Semantic: NoReturn" do
       )) { no_return }
   end
 
-  it "types as NoReturn even if Nil return type is forced (#3096)" do
+  it("types as NoReturn even if Nil return type is forced (#3096)") do
     assert_type(%(
       lib LibC
         fun exit(Int32) : NoReturn

--- a/spec/compiler/semantic/not_spec.cr
+++ b/spec/compiler/semantic/not_spec.cr
@@ -1,13 +1,13 @@
 require "../../spec_helper"
 
-describe "Semantic: not" do
-  it "types not" do
+describe("Semantic: not") do
+  it("types not") do
     assert_type(%(
       !1
       )) { bool }
   end
 
-  it "types not as NoReturn if exp is NoReturn" do
+  it("types not as NoReturn if exp is NoReturn") do
     assert_type(%(
       lib LibC
         fun exit : NoReturn
@@ -17,7 +17,7 @@ describe "Semantic: not" do
       )) { no_return }
   end
 
-  it "filters types inside if" do
+  it("filters types inside if") do
     assert_type(%(
       a = 1 || nil
       z = nil
@@ -28,7 +28,7 @@ describe "Semantic: not" do
       )) { nil_type }
   end
 
-  it "filters types inside if/else" do
+  it("filters types inside if/else") do
     assert_type(%(
       a = 1 || nil
       z = 2
@@ -40,7 +40,7 @@ describe "Semantic: not" do
       )) { int32 }
   end
 
-  it "filters types with !is_a?" do
+  it("filters types with !is_a?") do
     assert_type(%(
       a = 1 == 2 ? "x" : 1
       z = 0
@@ -51,7 +51,7 @@ describe "Semantic: not" do
       )) { int32 }
   end
 
-  it "doesn't restrict and" do
+  it("doesn't restrict and") do
     assert_type(%(
       a = 1 || nil
       z = nil
@@ -62,7 +62,7 @@ describe "Semantic: not" do
       )) { nilable int32 }
   end
 
-  it "doesn't restrict and in while (#4243)" do
+  it("doesn't restrict and in while (#4243)") do
     assert_type(%(
       x = nil
       y = nil

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -1,43 +1,43 @@
 require "../../spec_helper"
 
-describe "Semantic: pointer" do
-  it "types int pointer" do
+describe("Semantic: pointer") do
+  it("types int pointer") do
     assert_type("a = 1; pointerof(a)") { pointer_of(int32) }
   end
 
-  it "types pointer value" do
+  it("types pointer value") do
     assert_type("a = 1; b = pointerof(a); b.value") { int32 }
   end
 
-  it "types pointer add" do
+  it("types pointer add") do
     assert_type("a = 1; pointerof(a) + 1_i64") { pointer_of(int32) }
   end
 
-  it "types pointer diff" do
+  it("types pointer diff") do
     assert_type("a = 1; b = 2; pointerof(a) - pointerof(b)") { int64 }
   end
 
-  it "types Pointer.malloc" do
+  it("types Pointer.malloc") do
     assert_type("p = Pointer(Int32).malloc(10_u64); p.value = 1; p") { pointer_of(int32) }
   end
 
-  it "types realloc" do
+  it("types realloc") do
     assert_type("p = Pointer(Int32).malloc(10_u64); p.value = 1; x = p.realloc(20_u64); x") { pointer_of(int32) }
   end
 
-  it "type pointer casting" do
+  it("type pointer casting") do
     assert_type("a = 1; pointerof(a).as(Char*)") { pointer_of(char) }
   end
 
-  it "type pointer casting of object type" do
+  it("type pointer casting of object type") do
     assert_type("a = 1; pointerof(a).as(String)") { string }
   end
 
-  it "pointer malloc creates new type" do
+  it("pointer malloc creates new type") do
     assert_type("p = Pointer(Int32).malloc(1_u64); p.value = 1; p2 = Pointer(Float64).malloc(1_u64); p2.value = 1.5; p2.value") { float64 }
   end
 
-  pending "allows using pointer with subclass" do
+  pending("allows using pointer with subclass") do
     assert_type("
       a = Pointer(Object).malloc(1_u64)
       a.value = 1
@@ -45,22 +45,22 @@ describe "Semantic: pointer" do
     ") { union_of(object.virtual_type, int32) }
   end
 
-  it "can't do Pointer.malloc without type var" do
+  it("can't do Pointer.malloc without type var") do
     assert_error "
       Pointer.malloc(1_u64)
     ", "can't malloc pointer without type, use Pointer(Type).malloc(size)"
   end
 
-  it "create pointer by address" do
+  it("create pointer by address") do
     assert_type("Pointer(Int32).new(123_u64)") { pointer_of(int32) }
   end
 
-  it "types nil or pointer type" do
+  it("types nil or pointer type") do
     result = assert_type("1 == 1 ? nil : Pointer(Int32).new(0_u64)") { nilable pointer_of(int32) }
     result.node.type.should be_a(NilablePointerType)
   end
 
-  it "types nil or pointer type with typedef" do
+  it("types nil or pointer type with typedef") do
     result = assert_type(%(
       lib LibC
         type T = Void*
@@ -71,22 +71,22 @@ describe "Semantic: pointer" do
     result.node.type.should be_a(NilablePointerType)
   end
 
-  it "types pointer of constant" do
+  it("types pointer of constant") do
     result = assert_type("
       FOO = 1
       pointerof(FOO)
     ") { pointer_of(int32) }
   end
 
-  it "pointer of class raises error" do
+  it("pointer of class raises error") do
     assert_error "pointerof(Int32)", "can't take address of Int32"
   end
 
-  it "pointer of value error" do
+  it("pointer of value error") do
     assert_error "pointerof(1)", "can't take address of 1"
   end
 
-  it "types pointer value on typedef" do
+  it("types pointer value on typedef") do
     assert_type(%(
       lib LibC
         type Foo = Int32*
@@ -97,7 +97,7 @@ describe "Semantic: pointer" do
       )) { int32 }
   end
 
-  it "detects recursive pointerof expansion (#551) (#553)" do
+  it("detects recursive pointerof expansion (#551) (#553)") do
     assert_error %(
       x = 1
       x = pointerof(x)
@@ -105,7 +105,7 @@ describe "Semantic: pointer" do
       "recursive pointerof expansion"
   end
 
-  it "detects recursive pointerof expansion (2) (#1654)" do
+  it("detects recursive pointerof expansion (2) (#1654)") do
     assert_error %(
       x = 1
       pointer = pointerof(x)
@@ -114,7 +114,7 @@ describe "Semantic: pointer" do
       "recursive pointerof expansion"
   end
 
-  it "errors if using nil? on pointer type" do
+  it("errors if using nil? on pointer type") do
     assert_error %(
       a = 1
       pointerof(a).nil?
@@ -122,7 +122,7 @@ describe "Semantic: pointer" do
       "use `null?`"
   end
 
-  it "errors if using nil? on union including pointer type" do
+  it("errors if using nil? on union including pointer type") do
     assert_error %(
       a = 1
       (1 || pointerof(a)).nil?
@@ -130,14 +130,14 @@ describe "Semantic: pointer" do
       "use `null?`"
   end
 
-  it "can assign nil to void pointer" do
+  it("can assign nil to void pointer") do
     assert_type(%(
       ptr = Pointer(Void).malloc(1_u64)
       ptr.value = ptr.value
       )) { nil_type }
   end
 
-  it "can pass any pointer to something expecting void* in lib call" do
+  it("can pass any pointer to something expecting void* in lib call") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Void*) : Float64
@@ -147,7 +147,7 @@ describe "Semantic: pointer" do
       )) { float64 }
   end
 
-  it "can pass any pointer to something expecting void* in lib call, with to_unsafe" do
+  it("can pass any pointer to something expecting void* in lib call, with to_unsafe") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Void*) : Float64
@@ -163,7 +163,7 @@ describe "Semantic: pointer" do
       )) { float64 }
   end
 
-  it "errors if doing Pointer.allocate" do
+  it("errors if doing Pointer.allocate") do
     assert_error %(
       Pointer(Int32).allocate
       ),

--- a/spec/compiler/semantic/previous_def_spec.cr
+++ b/spec/compiler/semantic/previous_def_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: previous_def" do
-  it "errors if there's no previous def" do
+describe("Semantic: previous_def") do
+  it("errors if there's no previous def") do
     assert_error %(
       def foo
         previous_def
@@ -11,7 +11,7 @@ describe "Semantic: previous_def" do
       ), "there is no previous definition of 'foo'"
   end
 
-  it "types previous def" do
+  it("types previous def") do
     assert_type(%(
       def foo
         1
@@ -25,7 +25,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "types previous def in generic class" do
+  it("types previous def in generic class") do
     assert_type(%(
       class Foo(T)
         def foo
@@ -41,7 +41,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "types previous def with arguments" do
+  it("types previous def with arguments") do
     assert_type(%(
       def foo(x)
         x
@@ -55,7 +55,7 @@ describe "Semantic: previous_def" do
       )) { float64 }
   end
 
-  it "types previous def with arguments but without parenthesis" do
+  it("types previous def with arguments but without parenthesis") do
     assert_type(%(
       def foo(x)
         x
@@ -69,7 +69,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "types previous def with restrictions" do
+  it("types previous def with restrictions") do
     assert_type(%(
       def foo(x : Int32)
         x
@@ -83,7 +83,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "types previous def when inside fun" do
+  it("types previous def when inside fun") do
     assert_type(%(
       def foo
         1
@@ -98,7 +98,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "types previous def when inside fun and forwards args" do
+  it("types previous def when inside fun and forwards args") do
     assert_type(%(
       def foo(z)
         z
@@ -113,7 +113,7 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
-  it "says wrong number of arguments for previous_def (#1223)" do
+  it("says wrong number of arguments for previous_def (#1223)") do
     assert_error %(
       class Foo
         def x

--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -1,67 +1,67 @@
 require "../../spec_helper"
 
-describe "Semantic: primitives" do
-  it "types a bool" do
+describe("Semantic: primitives") do
+  it("types a bool") do
     assert_type("false") { bool }
   end
 
-  it "types an int32" do
+  it("types an int32") do
     assert_type("1") { int32 }
   end
 
-  it "types a int64" do
+  it("types a int64") do
     assert_type("1_i64") { int64 }
   end
 
-  it "types a float32" do
+  it("types a float32") do
     assert_type("2.3_f32") { float32 }
   end
 
-  it "types a float64" do
+  it("types a float64") do
     assert_type("2.3_f64") { float64 }
   end
 
-  it "types a char" do
+  it("types a char") do
     assert_type("'a'") { char }
   end
 
-  it "types char ord" do
+  it("types char ord") do
     assert_type("'a'.ord") { int32 }
   end
 
-  it "types a symbol" do
+  it("types a symbol") do
     assert_type(":foo") { symbol }
   end
 
-  it "types a string" do
+  it("types a string") do
     assert_type("\"foo\"") { string }
   end
 
-  it "types nil" do
+  it("types nil") do
     assert_type("nil") { nil_type }
   end
 
-  it "types nop" do
+  it("types nop") do
     assert_type("") { nil_type }
   end
 
-  it "types an expression" do
+  it("types an expression") do
     assert_type("1; 'a'") { char }
   end
 
-  it "types 1 + 2" do
+  it("types 1 + 2") do
     assert_type("1 + 2") { int32 }
   end
 
-  it "types sizeof" do
+  it("types sizeof") do
     assert_type("sizeof(Float64)") { int32 }
   end
 
-  it "types instance_sizeof" do
+  it("types instance_sizeof") do
     assert_type("instance_sizeof(Reference)") { int32 }
   end
 
-  it "errors when comparing void (#225)" do
+  it("errors when comparing void (#225)") do
     assert_error %(
       lib LibFoo
         fun foo
@@ -71,7 +71,7 @@ describe "Semantic: primitives" do
       ), "undefined method '==' for Nil"
   end
 
-  it "correctly types first hash from type vars (bug)" do
+  it("correctly types first hash from type vars (bug)") do
     assert_type(%(
       class Hash(K, V)
       end
@@ -86,7 +86,7 @@ describe "Semantic: primitives" do
       )) { generic_class "Hash", int32, char }
   end
 
-  it "computes correct hash value type if it's a function literal (#320)" do
+  it("computes correct hash value type if it's a function literal (#320)") do
     assert_type(%(
       require "prelude"
 
@@ -94,7 +94,7 @@ describe "Semantic: primitives" do
       )) { generic_class "Hash", string, proc_of(bool) }
   end
 
-  it "extends from Number and doesn't find + method" do
+  it("extends from Number and doesn't find + method") do
     assert_error %(
       struct Foo < Number
       end
@@ -104,7 +104,7 @@ describe "Semantic: primitives" do
       "undefined method"
   end
 
-  it "extends from Number and doesn't find >= method" do
+  it("extends from Number and doesn't find >= method") do
     assert_error %(
       struct Foo < Number
       end
@@ -114,7 +114,7 @@ describe "Semantic: primitives" do
       "undefined method"
   end
 
-  it "extends from Number and doesn't find to_i method" do
+  it("extends from Number and doesn't find to_i method") do
     assert_error %(
       struct Foo < Number
       end
@@ -124,7 +124,7 @@ describe "Semantic: primitives" do
       "undefined method"
   end
 
-  pending "types pointer of int" do
+  pending("types pointer of int") do
     assert_type("
       p = Pointer(Int).malloc(1_u64)
       p.value = 1
@@ -132,7 +132,7 @@ describe "Semantic: primitives" do
       ") { types["Int"] }
   end
 
-  it "can invoke cast on primitive typedef (#614)" do
+  it("can invoke cast on primitive typedef (#614)") do
     assert_type(%(
       lib Test
         type K = Int32
@@ -143,7 +143,7 @@ describe "Semantic: primitives" do
       )) { int32 }
   end
 
-  it "can invoke binary on primitive typedef (#614)" do
+  it("can invoke binary on primitive typedef (#614)") do
     assert_type(%(
       lib Test
         type K = Int32
@@ -154,7 +154,7 @@ describe "Semantic: primitives" do
       )) { types["Test"].types["K"] }
   end
 
-  it "can invoke binary on primitive typedef (2) (#614)" do
+  it("can invoke binary on primitive typedef (2) (#614)") do
     assert_type(%(
       lib Test
         type K = Int32
@@ -165,7 +165,7 @@ describe "Semantic: primitives" do
       )) { types["Test"].types["K"] }
   end
 
-  it "errors if using instance variable inside primitive type" do
+  it("errors if using instance variable inside primitive type") do
     assert_error %(
       struct Int32
         def meth
@@ -178,7 +178,7 @@ describe "Semantic: primitives" do
       "can't use instance variables inside primitive types (at Int32)"
   end
 
-  it "types @[Primitive] method" do
+  it("types @[Primitive] method") do
     assert_type(%(
       struct Int32
         @[Primitive(:binary)]
@@ -190,7 +190,7 @@ describe "Semantic: primitives" do
       )) { int32 }
   end
 
-  it "errors if @[Primitive] has no args" do
+  it("errors if @[Primitive] has no args") do
     assert_error %(
       struct Int32
         @[Primitive]
@@ -201,7 +201,7 @@ describe "Semantic: primitives" do
       "expected Primitive attribute to have one argument"
   end
 
-  it "errors if @[Primitive] has non-symbol arg" do
+  it("errors if @[Primitive] has non-symbol arg") do
     assert_error %(
       struct Int32
         @[Primitive("foo")]
@@ -212,7 +212,7 @@ describe "Semantic: primitives" do
       "expected Primitive argument to be a symbol literal"
   end
 
-  it "errors if @[Primitive] method has body" do
+  it("errors if @[Primitive] method has body") do
     assert_error %(
       struct Int32
         @[Primitive(:binary)]

--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 
-describe "Semantic: private" do
-  it "doesn't find private def in another file" do
-    expect_raises Crystal::TypeException, "undefined local variable or method 'foo'" do
+describe("Semantic: private") do
+  it("doesn't find private def in another file") do
+    expect_raises(Crystal::TypeException, "undefined local variable or method 'foo'") do
       compiler = Compiler.new
       sources = [
         Compiler::Source.new("foo.cr", %(
@@ -20,7 +20,7 @@ describe "Semantic: private" do
     end
   end
 
-  it "finds private def in same file" do
+  it("finds private def in same file") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -36,7 +36,7 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
-  it "finds private def in same file that invokes another def" do
+  it("finds private def in same file that invokes another def") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -56,7 +56,7 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
-  it "types private def correctly" do
+  it("types private def correctly") do
     assert_type(%(
       private def foo
         1
@@ -70,8 +70,8 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "doesn't find private macro in another file" do
-    expect_raises Crystal::TypeException, "undefined local variable or method 'foo'" do
+  it("doesn't find private macro in another file") do
+    expect_raises(Crystal::TypeException, "undefined local variable or method 'foo'") do
       compiler = Compiler.new
       sources = [
         Compiler::Source.new("foo.cr", %(
@@ -89,7 +89,7 @@ describe "Semantic: private" do
     end
   end
 
-  it "finds private macro in same file" do
+  it("finds private macro in same file") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -105,7 +105,7 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
-  it "finds private macro in same file, invoking from another macro (#1265)" do
+  it("finds private macro in same file, invoking from another macro (#1265)") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -125,7 +125,7 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
-  it "find module private macro inside the module" do
+  it("find module private macro inside the module") do
     assert_type(%(
       class Foo
         private macro foo
@@ -141,7 +141,7 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "find module private macro inside a module, which is inherited by the module" do
+  it("find module private macro inside a module, which is inherited by the module") do
     assert_type(%(
       class Foo
         private macro foo
@@ -159,7 +159,7 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "doesn't find module private macro outside the module" do
+  it("doesn't find module private macro outside the module") do
     assert_error %(
       class Foo
         private macro foo
@@ -171,7 +171,7 @@ describe "Semantic: private" do
     ), "private macro 'foo' called for Foo"
   end
 
-  it "finds private def when invoking from inside macro (#2082)" do
+  it("finds private def when invoking from inside macro (#2082)") do
     assert_type(%(
       private def foo
         42
@@ -183,8 +183,8 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "doesn't find private class in another file" do
-    expect_raises Crystal::TypeException, "undefined constant Foo" do
+  it("doesn't find private class in another file") do
+    expect_raises(Crystal::TypeException, "undefined constant Foo") do
       compiler = Compiler.new
       sources = [
         Compiler::Source.new("foo.cr", %(
@@ -201,7 +201,7 @@ describe "Semantic: private" do
     end
   end
 
-  it "finds private type in same file" do
+  it("finds private type in same file") do
     compiler = Compiler.new
     sources = [
       Compiler::Source.new("foo.cr", %(
@@ -219,7 +219,7 @@ describe "Semantic: private" do
     compiler.compile sources, "output"
   end
 
-  it "can use types in private type" do
+  it("can use types in private type") do
     assert_type(%(
       private class Foo
         def initialize(@x : Int32)
@@ -234,7 +234,7 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "can use class var initializer in private type" do
+  it("can use class var initializer in private type") do
     assert_type(%(
       private class Foo
         @@x = 1
@@ -248,7 +248,7 @@ describe "Semantic: private" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "can use instance var initializer in private type" do
+  it("can use instance var initializer in private type") do
     assert_type(%(
       private class Foo
         @x = 1
@@ -262,7 +262,7 @@ describe "Semantic: private" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "finds private class in macro expansion" do
+  it("finds private class in macro expansion") do
     assert_type(%(
       private class Foo
         @x = 1
@@ -280,7 +280,7 @@ describe "Semantic: private" do
       ), inject_primitives: false) { int32 }
   end
 
-  it "doesn't find private class from outside namespace" do
+  it("doesn't find private class from outside namespace") do
     assert_error %(
       class Foo
         private class Bar
@@ -292,7 +292,7 @@ describe "Semantic: private" do
       "private constant Foo::Bar referenced"
   end
 
-  it "doesn't find private module from outside namespace" do
+  it("doesn't find private module from outside namespace") do
     assert_error %(
       class Foo
         private module Bar
@@ -304,7 +304,7 @@ describe "Semantic: private" do
       "private constant Foo::Bar referenced"
   end
 
-  it "doesn't find private enum from outside namespace" do
+  it("doesn't find private enum from outside namespace") do
     assert_error %(
       class Foo
         private enum Bar
@@ -317,7 +317,7 @@ describe "Semantic: private" do
       "private constant Foo::Bar referenced"
   end
 
-  it "doesn't find private alias from outside namespace" do
+  it("doesn't find private alias from outside namespace") do
     assert_error %(
       class Foo
         private alias Bar = Int32
@@ -328,7 +328,7 @@ describe "Semantic: private" do
       "private constant Foo::Bar referenced"
   end
 
-  it "doesn't find private lib from outside namespace" do
+  it("doesn't find private lib from outside namespace") do
     assert_error %(
       class Foo
         private lib LibBar
@@ -340,7 +340,7 @@ describe "Semantic: private" do
       "private constant Foo::LibBar referenced"
   end
 
-  it "doesn't find private constant from outside namespace" do
+  it("doesn't find private constant from outside namespace") do
     assert_error %(
       class Foo
         private Bar = 1
@@ -351,7 +351,7 @@ describe "Semantic: private" do
       "private constant Foo::Bar referenced"
   end
 
-  it "finds private type from inside namespace" do
+  it("finds private type from inside namespace") do
     assert_type(%(
       class Foo
         private class Bar
@@ -367,7 +367,7 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "finds private type from inside namespace in subclass" do
+  it("finds private type from inside namespace in subclass") do
     assert_type(%(
       class Foo
         private class Bar
@@ -385,7 +385,7 @@ describe "Semantic: private" do
       )) { int32 }
   end
 
-  it "gives private constant error in macro" do
+  it("gives private constant error in macro") do
     assert_error %(
       class Foo
         private class Bar

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -1,39 +1,39 @@
 require "../../spec_helper"
 
-describe "Semantic: proc" do
-  it "types empty proc literal" do
+describe("Semantic: proc") do
+  it("types empty proc literal") do
     assert_type("-> {}") { proc_of(nil_type) }
   end
 
-  it "types int proc literal" do
+  it("types int proc literal") do
     assert_type("-> { 1 }") { proc_of(int32) }
   end
 
-  it "types proc call" do
+  it("types proc call") do
     assert_type("x = -> { 1 }; x.call()") { int32 }
   end
 
-  it "types int -> int proc literal" do
+  it("types int -> int proc literal") do
     assert_type("->(x : Int32) { x }") { proc_of(int32, int32) }
   end
 
-  it "types int -> int proc call" do
+  it("types int -> int proc call") do
     assert_type("f = ->(x : Int32) { x }; f.call(1)") { int32 }
   end
 
-  it "types proc pointer" do
+  it("types proc pointer") do
     assert_type("def foo; 1; end; ->foo") { proc_of(int32) }
   end
 
-  it "types proc pointer with types" do
+  it("types proc pointer with types") do
     assert_type("def foo(x); x; end; ->foo(Int32)") { proc_of(int32, int32) }
   end
 
-  it "types a proc pointer with generic types" do
+  it("types a proc pointer with generic types") do
     assert_type("def foo(x); end; ->foo(Pointer(Int32))") { proc_of(pointer_of(int32), nil_type) }
   end
 
-  it "types proc pointer to instance method" do
+  it("types proc pointer to instance method") do
     assert_type("
       class Foo
         def initialize
@@ -50,11 +50,11 @@ describe "Semantic: proc" do
     ") { proc_of(int32) }
   end
 
-  it "types proc type spec" do
+  it("types proc type spec") do
     assert_type("a = Pointer(Int32 -> Int64).malloc(1_u64)") { pointer_of(proc_of(int32, int64)) }
   end
 
-  it "allows passing proc type if it is typedefed" do
+  it("allows passing proc type if it is typedefed") do
     assert_type("
       lib LibC
         type Callback = Int32 -> Int32
@@ -66,12 +66,12 @@ describe "Semantic: proc" do
       ") { float64 }
   end
 
-  it "errors when using local variable with proc argument name" do
+  it("errors when using local variable with proc argument name") do
     assert_error "->(a : Int32) { }; a",
       "undefined local variable or method 'a'"
   end
 
-  it "allows implicit cast of proc to return void in LibC function" do
+  it("allows implicit cast of proc to return void in LibC function") do
     assert_type("
       lib LibC
         fun atexit(fun : -> ) : Int32
@@ -81,7 +81,7 @@ describe "Semantic: proc" do
       ") { int32 }
   end
 
-  it "passes proc pointer as block" do
+  it("passes proc pointer as block") do
     assert_type("
       def foo
         yield
@@ -92,7 +92,7 @@ describe "Semantic: proc" do
       ") { int32 }
   end
 
-  it "passes proc pointer as block with arguments" do
+  it("passes proc pointer as block with arguments") do
     assert_type("
       def foo
         yield 1
@@ -103,7 +103,7 @@ describe "Semantic: proc" do
       ") { float64 }
   end
 
-  it "binds proc literal to arguments and body" do
+  it("binds proc literal to arguments and body") do
     assert_type("
       x = 1
       f = -> { x }
@@ -112,7 +112,7 @@ describe "Semantic: proc" do
     ") { proc_of(union_of(int32, char)) }
   end
 
-  it "has proc literal as restriction and works" do
+  it("has proc literal as restriction and works") do
     assert_type("
       def foo(x : Int32 -> Float64)
         x.call(1)
@@ -122,7 +122,7 @@ describe "Semantic: proc" do
       ") { float64 }
   end
 
-  it "has proc literal as restriction and works when output not specified" do
+  it("has proc literal as restriction and works when output not specified") do
     assert_type("
       def foo(x : Int32 -> )
         x.call(1)
@@ -132,7 +132,7 @@ describe "Semantic: proc" do
       ") { nil_type }
   end
 
-  it "has proc literal as restriction and errors if output is different" do
+  it("has proc literal as restriction and errors if output is different") do
     assert_error "
       def foo(x : Int32 -> Float64)
         x.call(1)
@@ -143,7 +143,7 @@ describe "Semantic: proc" do
       "no overload matches"
   end
 
-  it "has proc literal as restriction and errors if input is different" do
+  it("has proc literal as restriction and errors if input is different") do
     assert_error "
       def foo(x : Int32 -> Float64)
         x.call(1)
@@ -154,7 +154,7 @@ describe "Semantic: proc" do
       "no overload matches"
   end
 
-  it "has proc literal as restriction and errors if sizes are different" do
+  it("has proc literal as restriction and errors if sizes are different") do
     assert_error "
       def foo(x : Int32 -> Float64)
         x.call(1)
@@ -165,7 +165,7 @@ describe "Semantic: proc" do
       "no overload matches"
   end
 
-  it "allows passing nil as proc callback" do
+  it("allows passing nil as proc callback") do
     assert_type("
       lib LibC
         type Cb = Int32 ->
@@ -176,7 +176,7 @@ describe "Semantic: proc" do
       ") { int32 }
   end
 
-  it "disallows casting a proc type to one accepting more arguments" do
+  it("disallows casting a proc type to one accepting more arguments") do
     assert_error("
       f = ->(x : Int32) { x.to_f }
       f.as(Int32, Int32 -> Float64)
@@ -184,14 +184,14 @@ describe "Semantic: proc" do
       "can't cast")
   end
 
-  it "allows casting a proc type to one with void argument" do
+  it("allows casting a proc type to one with void argument") do
     assert_type("
       f = ->(x : Int32) { x.to_f }
       f.as(Int32 -> Void)
       ") { proc_of [int32, void] }
   end
 
-  it "disallows casting a proc type to one accepting less arguments" do
+  it("disallows casting a proc type to one accepting less arguments") do
     assert_error "
       f = ->(x : Int32) { x.to_f }
       f.as(-> Float64)
@@ -199,7 +199,7 @@ describe "Semantic: proc" do
       "can't cast Proc(Int32, Float64) to Proc(Float64)"
   end
 
-  it "disallows casting a proc type to one accepting same size argument but different output" do
+  it("disallows casting a proc type to one accepting same size argument but different output") do
     assert_error "
       f = ->(x : Int32) { x.to_f }
       f.as(Int32 -> Int32)
@@ -207,7 +207,7 @@ describe "Semantic: proc" do
       "can't cast Proc(Int32, Float64) to Proc(Int32, Int32)"
   end
 
-  it "disallows casting a proc type to one accepting same size argument but different input" do
+  it("disallows casting a proc type to one accepting same size argument but different input") do
     assert_error "
       f = ->(x : Int32) { x.to_f }
       f.as(Float64 -> Float64)
@@ -215,7 +215,7 @@ describe "Semantic: proc" do
       "can't cast Proc(Int32, Float64) to Proc(Float64, Float64)"
   end
 
-  it "types proc literal hard type inference (1)" do
+  it("types proc literal hard type inference (1)") do
     assert_type(%(
       require "prelude"
 
@@ -234,7 +234,7 @@ describe "Semantic: proc" do
       )) { proc_of(types["Foo"], tuple_of([types["Foo"], int32])) }
   end
 
-  it "allows implicit cast of proc to return void in non-generic restriction" do
+  it("allows implicit cast of proc to return void in non-generic restriction") do
     assert_type("
       def foo(x : ->)
         x
@@ -244,7 +244,7 @@ describe "Semantic: proc" do
       ") { proc_of(void) }
   end
 
-  it "allows implicit cast of proc to return void in generic restriction" do
+  it("allows implicit cast of proc to return void in generic restriction") do
     assert_type("
       class Foo(T)
         def foo(x : T)
@@ -257,12 +257,12 @@ describe "Semantic: proc" do
       ") { proc_of(void) }
   end
 
-  it "types nil or proc type" do
+  it("types nil or proc type") do
     result = assert_type("1 == 1 ? nil : ->{}") { nilable proc_of(nil_type) }
     result.node.type.should be_a(NilableProcType)
   end
 
-  it "allows passing NoReturn type for any return type (1)" do
+  it("allows passing NoReturn type for any return type (1)") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -276,7 +276,7 @@ describe "Semantic: proc" do
       ") { no_return }
   end
 
-  it "allows passing NoReturn type for any return type (2)" do
+  it("allows passing NoReturn type for any return type (2)") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -287,7 +287,7 @@ describe "Semantic: proc" do
       ") { int32 }
   end
 
-  it "allows passing NoReturn type for any return type (3)" do
+  it("allows passing NoReturn type for any return type (3)") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -302,14 +302,14 @@ describe "Semantic: proc" do
       ") { proc_of(int32) }
   end
 
-  it "allows new on proc type" do
+  it("allows new on proc type") do
     assert_type("
       alias Func = Int32 -> Int32
       Func.new { |x| x + 1 }
       ") { proc_of(int32, int32) }
   end
 
-  it "allows new on proc type that is a typedef" do
+  it("allows new on proc type that is a typedef") do
     assert_type("
       lib LibC
         type F = Int32 -> Int32
@@ -319,14 +319,14 @@ describe "Semantic: proc" do
       ") { proc_of(int32, int32) }
   end
 
-  it "allows new on proc type with less block args" do
+  it("allows new on proc type with less block args") do
     assert_type("
       alias Func = Int32 -> Int32
       Func.new { 1 }
       ") { proc_of(int32, int32) }
   end
 
-  it "says wrong number of block args in new on proc type" do
+  it("says wrong number of block args in new on proc type") do
     assert_error "
       alias Alias = Int32 -> Int32
       Alias.new { |x, y| }
@@ -334,7 +334,7 @@ describe "Semantic: proc" do
       "wrong number of block arguments for Proc(Int32, Int32)#new (given 2, expected 1)"
   end
 
-  it "says wrong return type in new on proc type" do
+  it("says wrong return type in new on proc type") do
     assert_error "
       alias Alias = Int32 -> Int32
       Alias.new &.to_f
@@ -342,12 +342,12 @@ describe "Semantic: proc" do
       "expected block to return Int32, not Float64"
   end
 
-  it "errors if missing argument type in proc literal" do
+  it("errors if missing argument type in proc literal") do
     assert_error "->(x) { x }",
       "function argument 'x' must have a type"
   end
 
-  it "allows passing function to LibC without specifying types" do
+  it("allows passing function to LibC without specifying types") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32 -> Int32) : Float64
@@ -357,7 +357,7 @@ describe "Semantic: proc" do
       )) { float64 }
   end
 
-  it "allows passing function to LibC without specifying types, using a global method" do
+  it("allows passing function to LibC without specifying types, using a global method") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32 -> Int32) : Float64
@@ -371,7 +371,7 @@ describe "Semantic: proc" do
       )) { float64 }
   end
 
-  it "allows passing function to LibC without specifying types, using a class method" do
+  it("allows passing function to LibC without specifying types, using a class method") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32 -> Int32) : Float64
@@ -387,13 +387,13 @@ describe "Semantic: proc" do
       )) { float64 }
   end
 
-  it "allows writing a function type with Proc" do
+  it("allows writing a function type with Proc") do
     assert_type(%(
       Proc(Int32, Int32)
       )) { proc_of(int32, int32).metaclass }
   end
 
-  it "allows using Proc as restriction (1)" do
+  it("allows using Proc as restriction (1)") do
     assert_type(%(
       def foo(x : Proc(Int32, Int32))
         x.call(2)
@@ -403,7 +403,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "allows using Proc as restriction (2)" do
+  it("allows using Proc as restriction (2)") do
     assert_type(%(
       def foo(x : Proc)
         x.call(2)
@@ -413,7 +413,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "allows using Proc as restriction (3)" do
+  it("allows using Proc as restriction (3)") do
     assert_type(%(
       def foo(x : Proc(T, U)) forall T, U
         T
@@ -423,7 +423,7 @@ describe "Semantic: proc" do
       )) { int32.metaclass }
   end
 
-  it "forwards block and computes correct type (bug)" do
+  it("forwards block and computes correct type (bug)") do
     assert_type(%(
       def foo(&block : -> _)
         bar &block
@@ -438,7 +438,7 @@ describe "Semantic: proc" do
       )) { string }
   end
 
-  it "doesn't need to deduce type of block if return is void" do
+  it("doesn't need to deduce type of block if return is void") do
     assert_type(%(
       class Foo
         def initialize
@@ -460,7 +460,7 @@ describe "Semantic: proc" do
       )) { proc_of(types["Foo"], nil_type) }
   end
 
-  it "gives correct error message when proc return type is incorrect (#219)" do
+  it("gives correct error message when proc return type is incorrect (#219)") do
     assert_error %(
       lib LibFoo
         fun bar(f : Int32 -> Int32)
@@ -471,7 +471,7 @@ describe "Semantic: proc" do
       "argument 'f' of 'LibFoo#bar' must be a Proc returning Int32, not Float64"
   end
 
-  it "doesn't capture closured var if using typeof" do
+  it("doesn't capture closured var if using typeof") do
     assert_type(%(
       lib LibFoo
         fun foo(x : ->) : Int32
@@ -485,7 +485,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "types proc literal with a type that was never instantiated" do
+  it("types proc literal with a type that was never instantiated") do
     assert_type(%(
       require "prelude"
 
@@ -502,7 +502,7 @@ describe "Semantic: proc" do
       )) { proc_of(types["Foo"], int32) }
   end
 
-  it "types proc pointer with a type that was never instantiated" do
+  it("types proc pointer with a type that was never instantiated") do
     assert_type(%(
       require "prelude"
 
@@ -523,7 +523,7 @@ describe "Semantic: proc" do
       )) { proc_of(types["Foo"], types["Foo"]) }
   end
 
-  it "allows using proc arg name shadowing local variable" do
+  it("allows using proc arg name shadowing local variable") do
     assert_type(%(
       a = 1
       f = ->(a : String) { }
@@ -531,7 +531,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "uses array argument of proc arg (1)" do
+  it("uses array argument of proc arg (1)") do
     assert_type(%(
       require "prelude"
 
@@ -550,7 +550,7 @@ describe "Semantic: proc" do
       )) { nil_type }
   end
 
-  it "uses array argument of proc arg (2)" do
+  it("uses array argument of proc arg (2)") do
     assert_type(%(
       require "prelude"
 
@@ -570,7 +570,7 @@ describe "Semantic: proc" do
       )) { proc_of(array_of(types["Foo"].virtual_type), types["Foo"].virtual_type) }
   end
 
-  it "uses array argument of proc arg (3)" do
+  it("uses array argument of proc arg (3)") do
     assert_type(%(
       require "prelude"
 
@@ -594,7 +594,7 @@ describe "Semantic: proc" do
       )) { proc_of(array_of(types["Foo"].virtual_type), types["Foo"].virtual_type) }
   end
 
-  it "uses array argument of proc arg (4)" do
+  it("uses array argument of proc arg (4)") do
     assert_error %(
       require "prelude"
 
@@ -614,7 +614,7 @@ describe "Semantic: proc" do
       "expected block to return Foo, not Int32"
   end
 
-  it "doesn't let passing an non-covariant generic argument" do
+  it("doesn't let passing an non-covariant generic argument") do
     assert_error %(
       require "prelude"
 
@@ -634,7 +634,7 @@ describe "Semantic: proc" do
       "no overload matches"
   end
 
-  it "allows invoking a function with a generic subtype" do
+  it("allows invoking a function with a generic subtype") do
     assert_type(%(
       module Moo
         def foo
@@ -656,7 +656,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "gets pointer to lib fun without specifying types" do
+  it("gets pointer to lib fun without specifying types") do
     assert_type(%(
       lib LibFoo
         fun foo(x : Int32) : Float64
@@ -666,7 +666,7 @@ describe "Semantic: proc" do
       )) { proc_of(int32, float64) }
   end
 
-  it "allows passing union including module to proc" do
+  it("allows passing union including module to proc") do
     assert_type(%(
       module Moo
         def moo
@@ -689,7 +689,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "allows passing virtual type including module to proc" do
+  it("allows passing virtual type including module to proc") do
     assert_type(%(
       module Moo
         def moo
@@ -712,14 +712,14 @@ describe "Semantic: proc" do
   end
 
   %w(Object Value Reference Number Int Float Struct Class Proc Tuple Enum StaticArray Pointer).each do |type|
-    it "disallows #{type} in procs" do
+    it("disallows #{type} in procs") do
       assert_error %(
         ->(x : #{type}) { }
         ),
         "as a Proc argument type"
     end
 
-    it "disallows #{type} in captured block" do
+    it("disallows #{type} in captured block") do
       assert_error %(
         def foo(&block : #{type} ->)
         end
@@ -729,7 +729,7 @@ describe "Semantic: proc" do
         "as a Proc argument type"
     end
 
-    it "disallows #{type} in proc pointer" do
+    it("disallows #{type} in proc pointer") do
       assert_error %(
         def foo(x)
         end
@@ -740,7 +740,7 @@ describe "Semantic: proc" do
     end
   end
 
-  it "..." do
+  it("...") do
     assert_type(%(
       def foo
         ->{ a = 1; return 0 }.call
@@ -750,7 +750,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "doesn't crash on constant to proc pointer" do
+  it("doesn't crash on constant to proc pointer") do
     assert_type(%(
       lib LibC
         fun foo
@@ -761,13 +761,13 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "sets proc type as void if explicitly told so, when using new" do
+  it("sets proc type as void if explicitly told so, when using new") do
     assert_type(%(
       Proc(Int32, Void).new { 1 }
       )) { proc_of(int32, nil_type) }
   end
 
-  it "accesses T and R" do
+  it("accesses T and R") do
     assert_type(%(
       struct Proc
         def t
@@ -779,7 +779,7 @@ describe "Semantic: proc" do
       )) { tuple_of([tuple_of([int32]).metaclass, char.metaclass]) }
   end
 
-  it "can match *T in block argument" do
+  it("can match *T in block argument") do
     assert_type(%(
       struct Tuple
         def foo(&block : *T -> U) forall T, U
@@ -792,14 +792,14 @@ describe "Semantic: proc" do
       )) { bool.metaclass }
   end
 
-  it "says wrong number of arguments" do
+  it("says wrong number of arguments") do
     assert_error %(
       ->(x : Int32) { }.call
       ),
       "no overload matches"
   end
 
-  it "finds method of object" do
+  it("finds method of object") do
     assert_type(%(
       class Object
         def foo
@@ -811,7 +811,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  it "accesses T inside variadic generic" do
+  it("accesses T inside variadic generic") do
     assert_type(%(
       def foo(proc : Proc(*T, R)) forall T, R
         {T, R}
@@ -821,7 +821,7 @@ describe "Semantic: proc" do
       )) { tuple_of([tuple_of([int32, float64]).metaclass, char.metaclass]) }
   end
 
-  it "accesses T inside variadic generic (2)" do
+  it("accesses T inside variadic generic (2)") do
     assert_type(%(
       def foo(proc : Proc(*T, R)) forall T, R
         {T, R}
@@ -831,7 +831,7 @@ describe "Semantic: proc" do
       )) { tuple_of([tuple_of([int32]).metaclass, char.metaclass]) }
   end
 
-  it "accesses T inside variadic generic, in proc notation" do
+  it("accesses T inside variadic generic, in proc notation") do
     assert_type(%(
       def foo(proc : *T -> R) forall T, R
         {T, R}
@@ -841,7 +841,7 @@ describe "Semantic: proc" do
       )) { tuple_of([tuple_of([int32, float64]).metaclass, char.metaclass]) }
   end
 
-  it "declares an instance variable with splat in proc notation" do
+  it("declares an instance variable with splat in proc notation") do
     assert_type(%(
       class Foo
         @x : *{Int32, Char} -> String
@@ -859,7 +859,7 @@ describe "Semantic: proc" do
       )) { proc_of([int32, char, string]) }
   end
 
-  it "can assign NoReturn proc to other proc (#3032)" do
+  it("can assign NoReturn proc to other proc (#3032)") do
     assert_type(%(
       lib LibC
         fun exit : NoReturn

--- a/spec/compiler/semantic/reflection_spec.cr
+++ b/spec/compiler/semantic/reflection_spec.cr
@@ -1,25 +1,25 @@
 require "../../spec_helper"
 
-describe "Semantic: reflection" do
-  it "types Object class" do
+describe("Semantic: reflection") do
+  it("types Object class") do
     assert_type("Object") { types["Object"].metaclass }
   end
 
-  it "types Class class" do
+  it("types Class class") do
     assert_type("Class") { types["Class"] }
   end
 
-  it "types Object and Class metaclases" do
+  it("types Object and Class metaclases") do
     assert_type("Object.class") { types["Class"] }
     assert_type("Class.class") { types["Class"] }
   end
 
-  it "types Reference metaclass" do
+  it("types Reference metaclass") do
     assert_type("Reference") { types["Reference"].metaclass }
     assert_type("Reference.class") { types["Class"] }
   end
 
-  it "types metaclass parent" do
+  it("types metaclass parent") do
     input = parse("
       class Foo; end
       class Bar < Foo; end

--- a/spec/compiler/semantic/responds_to_spec.cr
+++ b/spec/compiler/semantic/responds_to_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Semantic: responds_to?" do
-  it "is bool" do
+describe("Semantic: responds_to?") do
+  it("is bool") do
     assert_type("1.responds_to?(:foo)") { bool }
   end
 
-  it "restricts type inside if scope 1" do
+  it("restricts type inside if scope 1") do
     nodes = parse %(
       require "primitives"
 
@@ -19,7 +19,7 @@ describe "Semantic: responds_to?" do
     nodes.last.as(If).then.type.should eq(mod.int32)
   end
 
-  it "restricts other types inside if else" do
+  it("restricts other types inside if else") do
     assert_type("
       a = 1 || 'a'
       if a.responds_to?(:\"+\")
@@ -30,7 +30,7 @@ describe "Semantic: responds_to?" do
       ") { int32 }
   end
 
-  it "restricts in assignment" do
+  it("restricts in assignment") do
     assert_type("
       a = 1 || 'a'
       if (b = a).responds_to?(:abs)

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -6,24 +6,24 @@ class Crystal::Program
   end
 end
 
-describe "Restrictions" do
-  describe "restrict" do
-    it "restricts type with same type" do
+describe("Restrictions") do
+  describe("restrict") do
+    it("restricts type with same type") do
       mod = Program.new
       mod.int32.restrict(mod.int32, MatchContext.new(mod, mod)).should eq(mod.int32)
     end
 
-    it "restricts type with another type" do
+    it("restricts type with another type") do
       mod = Program.new
       mod.int32.restrict(mod.int16, MatchContext.new(mod, mod)).should be_nil
     end
 
-    it "restricts type with superclass" do
+    it("restricts type with superclass") do
       mod = Program.new
       mod.int32.restrict(mod.value, MatchContext.new(mod, mod)).should eq(mod.int32)
     end
 
-    it "restricts type with included module" do
+    it("restricts type with included module") do
       mod = Program.new
       mod.semantic parse("
         module Mod
@@ -37,7 +37,7 @@ describe "Restrictions" do
       mod.types["Foo"].restrict(mod.types["Mod"], MatchContext.new(mod, mod)).should eq(mod.types["Foo"])
     end
 
-    it "restricts virtual type with included module 1" do
+    it("restricts virtual type with included module 1") do
       mod = Program.new
       mod.semantic parse("
         module Moo; end
@@ -47,7 +47,7 @@ describe "Restrictions" do
       mod.t("Foo+").restrict(mod.t("Moo"), MatchContext.new(mod, mod)).should eq(mod.t("Foo+"))
     end
 
-    it "restricts virtual type with included module 2" do
+    it("restricts virtual type with included module 2") do
       mod = Program.new
       mod.semantic parse("
         module Mxx; end
@@ -62,7 +62,7 @@ describe "Restrictions" do
     end
   end
 
-  it "self always matches instance type in restriction" do
+  it("self always matches instance type in restriction") do
     assert_type(%(
       class Foo
         def self.foo(x : self)
@@ -74,7 +74,7 @@ describe "Restrictions" do
       )) { types["Foo"] }
   end
 
-  it "self always matches instance type in return type" do
+  it("self always matches instance type in return type") do
     assert_type(%(
       class Foo
         macro def self.foo : self
@@ -85,7 +85,7 @@ describe "Restrictions" do
       )) { types["Foo"] }
   end
 
-  it "allows typeof as restriction" do
+  it("allows typeof as restriction") do
     assert_type(%(
       struct Int32
         def self.foo(x : typeof(self))
@@ -97,7 +97,7 @@ describe "Restrictions" do
       )) { int32 }
   end
 
-  it "passes #278" do
+  it("passes #278") do
     assert_error %(
       def bar(x : String, y : String = nil)
       end
@@ -107,7 +107,7 @@ describe "Restrictions" do
       "no overload matches"
   end
 
-  it "errors on T::Type that's union when used from type restriction" do
+  it("errors on T::Type that's union when used from type restriction") do
     assert_error %(
       def foo(x : T) forall T
         T::Baz
@@ -118,7 +118,7 @@ describe "Restrictions" do
       "undefined constant T::Baz"
   end
 
-  it "errors on T::Type that's a union when used from block type restriction" do
+  it("errors on T::Type that's a union when used from block type restriction") do
     assert_error %(
       class Foo(T)
         def self.foo(&block : T::Baz ->)
@@ -130,7 +130,7 @@ describe "Restrictions" do
       "undefined constant T::Baz"
   end
 
-  it "errors if can't find type on lookup" do
+  it("errors if can't find type on lookup") do
     assert_error %(
       def foo(x : Something)
       end
@@ -139,7 +139,7 @@ describe "Restrictions" do
       ), "undefined constant Something"
   end
 
-  it "errors if can't find type on lookup with nested type" do
+  it("errors if can't find type on lookup with nested type") do
     assert_error %(
       def foo(x : Foo::Bar)
       end
@@ -148,7 +148,7 @@ describe "Restrictions" do
       ), "undefined constant Foo::Bar"
   end
 
-  it "works with static array (#637)" do
+  it("works with static array (#637)") do
     assert_type(%(
       def foo(x : UInt8[1])
         1
@@ -163,7 +163,7 @@ describe "Restrictions" do
       )) { char }
   end
 
-  it "works with static array that uses underscore" do
+  it("works with static array that uses underscore") do
     assert_type(%(
       def foo(x : UInt8[_])
         'a'
@@ -174,7 +174,7 @@ describe "Restrictions" do
       )) { char }
   end
 
-  it "works with generic compared to fixed (primitive) type" do
+  it("works with generic compared to fixed (primitive) type") do
     assert_type(%(
       class Foo(T)
       end
@@ -189,7 +189,7 @@ describe "Restrictions" do
       )) { char }
   end
 
-  it "works with generic class metaclass vs. generic instance class metaclass" do
+  it("works with generic class metaclass vs. generic instance class metaclass") do
     assert_type(%(
       class Foo(T)
       end
@@ -202,7 +202,7 @@ describe "Restrictions" do
       )) { int32 }
   end
 
-  it "works with generic class metaclass vs. generic class metaclass" do
+  it("works with generic class metaclass vs. generic class metaclass") do
     assert_type(%(
       class Foo(T)
       end
@@ -215,7 +215,7 @@ describe "Restrictions" do
       )) { int32 }
   end
 
-  it "works with union against unions of generics" do
+  it("works with union against unions of generics") do
     assert_type(%(
       class Foo(T)
       end
@@ -228,7 +228,7 @@ describe "Restrictions" do
       )) { union_of(generic_class("Foo", int32), generic_class("Foo", float64)) }
   end
 
-  it "should not let GenericChild(Base) pass as a GenericBase(Child) (#1294)" do
+  it("should not let GenericChild(Base) pass as a GenericBase(Child) (#1294)") do
     assert_error %(
       class Base
       end
@@ -250,7 +250,7 @@ describe "Restrictions" do
       "no overload matches"
   end
 
-  it "allows passing recursive type to free var (#1076)" do
+  it("allows passing recursive type to free var (#1076)") do
     assert_type(%(
       class Foo(T)
       end
@@ -269,7 +269,7 @@ describe "Restrictions" do
       )) { char }
   end
 
-  it "restricts class union type to overloads with classes" do
+  it("restricts class union type to overloads with classes") do
     assert_type(%(
       def foo(x : Int32.class)
         1_u8
@@ -288,7 +288,7 @@ describe "Restrictions" do
       )) { union_of([uint8, uint16, uint32] of Type) }
   end
 
-  it "restricts class union type to overloads with classes (2)" do
+  it("restricts class union type to overloads with classes (2)") do
     assert_type(%(
       def foo(x : Int32.class)
         1_u8
@@ -307,7 +307,7 @@ describe "Restrictions" do
       )) { union_of([uint8, uint16] of Type) }
   end
 
-  it "makes metaclass subclass pass parent metaclass restriction (#2079)" do
+  it("makes metaclass subclass pass parent metaclass restriction (#2079)") do
     assert_type(%(
       class Foo; end
 
@@ -321,7 +321,7 @@ describe "Restrictions" do
       )) { types["Bar"].metaclass }
   end
 
-  it "matches virtual type against alias" do
+  it("matches virtual type against alias") do
     assert_type(%(
       module Moo
       end
@@ -346,7 +346,7 @@ describe "Restrictions" do
       )) { int32 }
   end
 
-  it "matches alias against alias in block type" do
+  it("matches alias against alias in block type") do
     assert_type(%(
       class Foo(T)
         def self.new(&block : -> T)
@@ -367,7 +367,7 @@ describe "Restrictions" do
       )) { types["Rec"].metaclass }
   end
 
-  it "matches free variable for type variable" do
+  it("matches free variable for type variable") do
     assert_type(%(
       class Foo(Type)
         def initialize(x : Type)
@@ -378,7 +378,7 @@ describe "Restrictions" do
       )) { generic_class "Foo", int32 }
   end
 
-  it "restricts virtual metaclass type against metaclass (#3438)" do
+  it("restricts virtual metaclass type against metaclass (#3438)") do
     assert_type(%(
       class Parent
       end
@@ -394,7 +394,7 @@ describe "Restrictions" do
       )) { types["Parent"].metaclass.virtual_type! }
   end
 
-  it "doesn't crash on invalid splat restriction (#3698)" do
+  it("doesn't crash on invalid splat restriction (#3698)") do
     assert_error %(
       def foo(arg : *String)
       end
@@ -404,7 +404,7 @@ describe "Restrictions" do
       "no overload matches"
   end
 
-  it "errors if using free var without forall" do
+  it("errors if using free var without forall") do
     assert_error %(
       def foo(x : T)
         T

--- a/spec/compiler/semantic/return_spec.cr
+++ b/spec/compiler/semantic/return_spec.cr
@@ -1,24 +1,24 @@
 require "../../spec_helper"
 
-describe "Semantic: return" do
-  it "infers return type" do
+describe("Semantic: return") do
+  it("infers return type") do
     assert_type("def foo; return 1; end; foo") { int32 }
   end
 
-  it "infers return type with many returns (1)" do
+  it("infers return type with many returns (1)") do
     assert_type("def foo; if true; return 1; end; 'a'; end; foo") { union_of(int32, char) }
   end
 
-  it "infers return type with many returns (2)" do
+  it("infers return type with many returns (2)") do
     assert_type("def foo; if 1 == 1; return 1; end; 'a'; end; foo") { union_of(int32, char) }
   end
 
-  it "errors on return in top level" do
+  it("errors on return in top level") do
     assert_error "return",
       "can't return from top level"
   end
 
-  it "types return if true" do
+  it("types return if true") do
     assert_type(%(
       def bar
         return if true
@@ -29,7 +29,7 @@ describe "Semantic: return" do
       )) { nilable int32 }
   end
 
-  it "can use type var as return type (#1226)" do
+  it("can use type var as return type (#1226)") do
     assert_type(%(
       module Moo(T)
       end
@@ -47,7 +47,7 @@ describe "Semantic: return" do
       )) { int32 }
   end
 
-  it "can use type var as return type with an included generic module" do
+  it("can use type var as return type with an included generic module") do
     assert_type(%(
       module Moo(T)
         def moo : T
@@ -66,7 +66,7 @@ describe "Semantic: return" do
       )) { float64 }
   end
 
-  it "can use type var as return type with an inherited generic class" do
+  it("can use type var as return type with an inherited generic class") do
     assert_type(%(
       class Moo(T)
         def moo : T
@@ -83,7 +83,7 @@ describe "Semantic: return" do
       )) { float64 }
   end
 
-  it "doesn't confuse return type from base class" do
+  it("doesn't confuse return type from base class") do
     assert_type(%(
       class Foo
         class Baz
@@ -106,7 +106,7 @@ describe "Semantic: return" do
       )) { int32 }
   end
 
-  it "allows returning NoReturn instead of the wanted type" do
+  it("allows returning NoReturn instead of the wanted type") do
     assert_type(%(
       lib LibC
         fun exit : NoReturn
@@ -133,7 +133,7 @@ describe "Semantic: return" do
       )) { int32 }
   end
 
-  it "types bug (#1823)" do
+  it("types bug (#1823)") do
     assert_type(%(
       def test
         b = nil
@@ -149,7 +149,7 @@ describe "Semantic: return" do
       test)) { nilable int32 }
   end
 
-  it "allows nilable return type to match subclasses (#1735)" do
+  it("allows nilable return type to match subclasses (#1735)") do
     assert_type(%(
       class Foo
       end
@@ -169,7 +169,7 @@ describe "Semantic: return" do
       )) { nilable types["Bar"] }
   end
 
-  it "can use free var in return type (#2492)" do
+  it("can use free var in return type (#2492)") do
     assert_type(%(
       def self.demo(a : A, &block : A -> B) : B forall A, B
         block.call(a)

--- a/spec/compiler/semantic/special_vars_spec.cr
+++ b/spec/compiler/semantic/special_vars_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 
-describe "Semantic: special vars" do
+describe("Semantic: special vars") do
   ["$~", "$?"].each do |name|
-    it "infers #{name}" do
+    it("infers #{name}") do
       assert_type(%(
         class Object; def not_nil!; self; end; end
 
@@ -15,7 +15,7 @@ describe "Semantic: special vars" do
         )) { nilable string }
     end
 
-    it "types #{name} when not defined as no return" do
+    it("types #{name} when not defined as no return") do
       assert_type(%(
         require "prelude"
 
@@ -23,7 +23,7 @@ describe "Semantic: special vars" do
         )) { no_return }
     end
 
-    it "types #{name} when not defined as no return (2)" do
+    it("types #{name} when not defined as no return (2)") do
       assert_type(%(
         class Object; def not_nil!; self; end; end
 
@@ -36,7 +36,7 @@ describe "Semantic: special vars" do
         )) { nilable string }
     end
 
-    it "errors if assigning #{name} at top level" do
+    it("errors if assigning #{name} at top level") do
       assert_error %(
         #{name} = "hey"
         ),
@@ -44,7 +44,7 @@ describe "Semantic: special vars" do
     end
   end
 
-  it "infers when assigning inside block" do
+  it("infers when assigning inside block") do
     assert_type(%(
       class Object; def not_nil!; self; end; end
 
@@ -63,7 +63,7 @@ describe "Semantic: special vars" do
       )) { nilable string }
   end
 
-  it "infers in block" do
+  it("infers in block") do
     assert_type(%(
       class Object; def not_nil!; self; end; end
 
@@ -80,7 +80,7 @@ describe "Semantic: special vars" do
       )) { nilable string }
   end
 
-  it "infers in block with nested block" do
+  it("infers in block with nested block") do
     assert_type(%(
       class Object; def not_nil!; self; end; end
 
@@ -103,7 +103,7 @@ describe "Semantic: special vars" do
       )) { nilable string }
   end
 
-  it "infers after block" do
+  it("infers after block") do
     assert_type(%(
       class Object; def not_nil!; self; end; end
 

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -7,8 +7,8 @@ private macro expect_splat(e_arg, e_arg_index, e_obj, e_obj_index)
   obj_index.should eq({{e_obj_index}})
 end
 
-describe "Semantic: splat" do
-  it "splats" do
+describe("Semantic: splat") do
+  it("splats") do
     assert_type(%(
       def foo(*args)
         args
@@ -18,7 +18,7 @@ describe "Semantic: splat" do
       )) { tuple_of([int32, float64, char] of Type) }
   end
 
-  it "errors on zero args with named arg and splat" do
+  it("errors on zero args with named arg and splat") do
     assert_error %(
       def foo(x, y = 1, *z)
       end
@@ -28,7 +28,7 @@ describe "Semantic: splat" do
       "wrong number of arguments"
   end
 
-  it "redefines method with splat (bug #248)" do
+  it("redefines method with splat (bug #248)") do
     assert_type(%(
       class Foo
         def bar(*x)
@@ -46,7 +46,7 @@ describe "Semantic: splat" do
       )) { char }
   end
 
-  it "errors if splatting union" do
+  it("errors if splatting union") do
     assert_error %(
       a = {1} || {1, 2}
       foo *a
@@ -54,14 +54,14 @@ describe "Semantic: splat" do
       "not yet supported"
   end
 
-  it "errors if splatting non-tuple type" do
+  it("errors if splatting non-tuple type") do
     assert_error %(
       foo *1
       ),
       "argument to splat must be a tuple, not Int32"
   end
 
-  it "forwards tuple with an extra argument" do
+  it("forwards tuple with an extra argument") do
     assert_type(%(
       def foo(*args)
         bar 1, *args
@@ -76,7 +76,7 @@ describe "Semantic: splat" do
       )) { tuple_of [int32] of TypeVar }
   end
 
-  it "can splat after type filter left it as a tuple (#442)" do
+  it("can splat after type filter left it as a tuple (#442)") do
     assert_type(%(
       def output(x, y)
         x + y
@@ -91,7 +91,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "errors if doesn't match splat with type restriction" do
+  it("errors if doesn't match splat with type restriction") do
     assert_error %(
       def foo(*args : Int32)
       end
@@ -101,7 +101,7 @@ describe "Semantic: splat" do
       "no overload matches"
   end
 
-  it "works if matches splat with type restriction" do
+  it("works if matches splat with type restriction") do
     assert_type(%(
       def foo(*args : Int32)
         args[0]
@@ -111,7 +111,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "overloads with type restriction and splat (1)" do
+  it("overloads with type restriction and splat (1)") do
     assert_type(%(
       def foo(arg : Int32)
         1
@@ -125,7 +125,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "overloads with type restriction and splat (2)" do
+  it("overloads with type restriction and splat (2)") do
     assert_type(%(
       def foo(arg : Int32)
         1
@@ -139,7 +139,7 @@ describe "Semantic: splat" do
       )) { char }
   end
 
-  it "errors if doesn't match splat with type restriction because of zero arguments" do
+  it("errors if doesn't match splat with type restriction because of zero arguments") do
     assert_error %(
       def foo(*args : Int32)
       end
@@ -149,7 +149,7 @@ describe "Semantic: splat" do
       "no overload matches"
   end
 
-  it "overloads with type restriction and splat (3)" do
+  it("overloads with type restriction and splat (3)") do
     assert_type(%(
       def foo(*args : Char)
         "hello"
@@ -163,7 +163,7 @@ describe "Semantic: splat" do
       )) { string }
   end
 
-  it "overloads with type restriction and splat (4)" do
+  it("overloads with type restriction and splat (4)") do
     assert_type(%(
       def foo(*args : Char)
         "hello"
@@ -177,7 +177,7 @@ describe "Semantic: splat" do
       )) { float64 }
   end
 
-  it "overloads with type restriction and splat (5)" do
+  it("overloads with type restriction and splat (5)") do
     assert_type(%(
       def foo(*args : Int32)
         "hello"
@@ -191,7 +191,7 @@ describe "Semantic: splat" do
       )) { string }
   end
 
-  it "overloads with type restriction and splat (6)" do
+  it("overloads with type restriction and splat (6)") do
     assert_type(%(
       def foo(*args : Int32)
         "hello"
@@ -205,7 +205,7 @@ describe "Semantic: splat" do
       )) { float64 }
   end
 
-  it "overloads with type restriction and splat (7)" do
+  it("overloads with type restriction and splat (7)") do
     assert_type(%(
       def foo(*args)
         foo args
@@ -219,7 +219,7 @@ describe "Semantic: splat" do
       )) { char }
   end
 
-  it "overloads with splat against method with two arguments (#986) (1)" do
+  it("overloads with splat against method with two arguments (#986) (1)") do
     assert_type(%(
       def foo(a, b)
         1
@@ -233,7 +233,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "overloads with splat against method with two arguments (#986) (2)" do
+  it("overloads with splat against method with two arguments (#986) (2)") do
     assert_type(%(
       def foo(a, b)
         1
@@ -247,7 +247,7 @@ describe "Semantic: splat" do
       )) { char }
   end
 
-  it "calls super with implicit splat arg (#1001)" do
+  it("calls super with implicit splat arg (#1001)") do
     assert_type(%(
       class Foo
         def foo(name)
@@ -265,7 +265,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "splats arg and splat against splat (1) (#1042)" do
+  it("splats arg and splat against splat (1) (#1042)") do
     assert_type(%(
       def foo(a : Bool, *b : Int32)
         1
@@ -279,7 +279,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "splats arg and splat against splat (2) (#1042)" do
+  it("splats arg and splat against splat (2) (#1042)") do
     assert_type(%(
       def foo(a : Bool, *b : Int32)
         1
@@ -293,7 +293,7 @@ describe "Semantic: splat" do
       )) { char }
   end
 
-  it "gives correct error when forwarding splat" do
+  it("gives correct error when forwarding splat") do
     assert_error %(
       def foo(x : Int)
       end
@@ -307,7 +307,7 @@ describe "Semantic: splat" do
       "wrong number of arguments for 'foo' (given 2, expected 1)"
   end
 
-  it "gives correct error when forwarding splat (2)" do
+  it("gives correct error when forwarding splat (2)") do
     assert_error %(
       def foo(x : Int, y : Int, z : Int, w : Int)
       end
@@ -321,7 +321,7 @@ describe "Semantic: splat" do
       "no overload matches 'foo' with types Char, Int32, String, Float64"
   end
 
-  it "doesn't crash on non-match (#2521)" do
+  it("doesn't crash on non-match (#2521)") do
     assert_error %(
       def test_func(a : String, *b, c, d)
       end
@@ -335,7 +335,7 @@ describe "Semantic: splat" do
       "missing arguments: c, d"
   end
 
-  it "says no overload matches on type restrictions past the splat arg" do
+  it("says no overload matches on type restrictions past the splat arg") do
     assert_error %(
       def foo(*z, a : String, b : String)
       end
@@ -345,7 +345,7 @@ describe "Semantic: splat" do
       "missing arguments: a, b"
   end
 
-  it "says missing argument because positional args don't match past splat" do
+  it("says missing argument because positional args don't match past splat") do
     assert_error %(
       def foo(x, *y, z)
       end
@@ -355,7 +355,7 @@ describe "Semantic: splat" do
       "missing argument: z"
   end
 
-  it "allows default value after splat index" do
+  it("allows default value after splat index") do
     assert_type(%(
       def foo(x, *y, z = 10)
         {x, y, z}
@@ -365,7 +365,7 @@ describe "Semantic: splat" do
       )) { tuple_of([char, tuple_of([bool, float64]), int32]) }
   end
 
-  it "uses bare *" do
+  it("uses bare *") do
     assert_type(%(
       def foo(x, *, y)
         {x, y}
@@ -375,7 +375,7 @@ describe "Semantic: splat" do
       )) { tuple_of([int32, char]) }
   end
 
-  it "uses bare *, doesn't let more args" do
+  it("uses bare *, doesn't let more args") do
     assert_error %(
       def foo(x, *, y)
       end
@@ -385,7 +385,7 @@ describe "Semantic: splat" do
       "no overload matches"
   end
 
-  it "uses splat restriction" do
+  it("uses splat restriction") do
     assert_type(%(
       def foo(*args : *T) forall T
         T
@@ -395,7 +395,7 @@ describe "Semantic: splat" do
       )) { tuple_of([int32, char, bool]).metaclass }
   end
 
-  it "uses splat restriction, matches empty" do
+  it("uses splat restriction, matches empty") do
     assert_type(%(
       def foo(*args : *T) forall T
         T
@@ -405,7 +405,7 @@ describe "Semantic: splat" do
       )) { tuple_of([] of Type).metaclass }
   end
 
-  it "uses splat restriction with concrete type" do
+  it("uses splat restriction with concrete type") do
     assert_error %(
       struct Tuple(T)
         def self.foo(*args : *T)
@@ -417,7 +417,7 @@ describe "Semantic: splat" do
       "no overload matches"
   end
 
-  it "method with splat and optional named argument matches zero args call (#2746)" do
+  it("method with splat and optional named argument matches zero args call (#2746)") do
     assert_type(%(
       def foo(*args, k1 = nil)
         args
@@ -427,7 +427,7 @@ describe "Semantic: splat" do
       )) { tuple_of([] of Type) }
   end
 
-  it "method with default arguments and splat matches call with one arg (#2766)" do
+  it("method with default arguments and splat matches call with one arg (#2766)") do
     assert_type(%(
       def foo(a = nil, b = nil, *, c = nil)
         a
@@ -437,7 +437,7 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
-  it "accesses T when empty, via module" do
+  it("accesses T when empty, via module") do
     assert_type(%(
       module Moo(T)
         def t
@@ -457,7 +457,7 @@ describe "Semantic: splat" do
       )) { no_return.metaclass }
   end
 
-  it "matches splat in geneic type" do
+  it("matches splat in geneic type") do
     assert_type(%(
       class Foo(*T)
       end
@@ -471,7 +471,7 @@ describe "Semantic: splat" do
       )) { tuple_of([int32.metaclass, tuple_of([char, string]).metaclass, bool.metaclass]) }
   end
 
-  it "errors if using two splat indices on restriction" do
+  it("errors if using two splat indices on restriction") do
     assert_error %(
       class Foo(*T)
       end
@@ -486,7 +486,7 @@ describe "Semantic: splat" do
       "can't specify more than one splat in restriction"
   end
 
-  it "matches with splat" do
+  it("matches with splat") do
     assert_type(%(
     def foo(&block : *{Int32, Int32} -> U) forall U
       tup = {1, 2}
@@ -499,7 +499,7 @@ describe "Semantic: splat" do
     )) { tuple_of([int32, int32]) }
   end
 
-  it "matches typed before non-typed (1) (#3134)" do
+  it("matches typed before non-typed (1) (#3134)") do
     assert_type(%(
       def bar(*args)
         "free"
@@ -513,7 +513,7 @@ describe "Semantic: splat" do
       )) { tuple_of([int32, string]) }
   end
 
-  it "matches typed before non-typed (1) (#3134)" do
+  it("matches typed before non-typed (1) (#3134)") do
     assert_type(%(
       def bar(*args : Int32)
         1
@@ -527,8 +527,8 @@ describe "Semantic: splat" do
       )) { tuple_of([int32, string]) }
   end
 
-  describe Splat do
-    it "without splat" do
+  describe(Splat) do
+    it("without splat") do
       a_def = Def.new("foo", args: [Arg.new("x"), Arg.new("y")])
       objs = [10, 20]
 
@@ -549,7 +549,7 @@ describe "Semantic: splat" do
       end
     end
 
-    it "with splat" do
+    it("with splat") do
       a_def = Def.new("foo", args: [Arg.new("a1"), Arg.new("a2"), Arg.new("a3"), Arg.new("a4")], splat_index: 2)
       objs = [10, 20, 30, 40, 50, 60]
 

--- a/spec/compiler/semantic/ssa_spec.cr
+++ b/spec/compiler/semantic/ssa_spec.cr
@@ -2,8 +2,8 @@ require "../../spec_helper"
 
 include Crystal
 
-describe "Semantic: ssa" do
-  it "types a redefined variable" do
+describe("Semantic: ssa") do
+  it("types a redefined variable") do
     assert_type("
       a = 1
       a = 'a'
@@ -11,7 +11,7 @@ describe "Semantic: ssa" do
       ") { char }
   end
 
-  it "types a var inside an if without previous definition" do
+  it("types a var inside an if without previous definition") do
     assert_type("
       if 1 == 1
         a = 1
@@ -22,7 +22,7 @@ describe "Semantic: ssa" do
       ") { union_of(int32, char) }
   end
 
-  it "types a var inside an if with previous definition" do
+  it("types a var inside an if with previous definition") do
     assert_type(%(
       a = "hello"
       if 1 == 1
@@ -34,7 +34,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var inside an if without change in then" do
+  it("types a var inside an if without change in then") do
     assert_type(%(
       a = 1
       if 1 == 1
@@ -45,7 +45,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var inside an if without change in else" do
+  it("types a var inside an if without change in else") do
     assert_type(%(
       a = 1
       if 1 == 1
@@ -56,7 +56,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var inside an if without definition in else" do
+  it("types a var inside an if without definition in else") do
     assert_type(%(
       if 1 == 1
         a = 'a'
@@ -66,7 +66,7 @@ describe "Semantic: ssa" do
       )) { nilable char }
   end
 
-  it "types a var inside an if without definition in then" do
+  it("types a var inside an if without definition in then") do
     assert_type(%(
       if 1 == 1
       else
@@ -76,7 +76,7 @@ describe "Semantic: ssa" do
       )) { nilable char }
   end
 
-  it "types a var with an if but without change" do
+  it("types a var with an if but without change") do
     assert_type(%(
       a = 1
       if 1 == 1
@@ -86,7 +86,7 @@ describe "Semantic: ssa" do
       )) { int32 }
   end
 
-  it "types a var with an if with nested if" do
+  it("types a var with an if with nested if") do
     assert_type(%(
       if 1 == 2
         a = 1
@@ -99,7 +99,7 @@ describe "Semantic: ssa" do
       )) { int32 }
   end
 
-  it "types a var that is re-assigned in a block" do
+  it("types a var that is re-assigned in a block") do
     assert_type(%(
       def foo
         yield
@@ -113,7 +113,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var that is re-assigned in a while" do
+  it("types a var that is re-assigned in a while") do
     assert_type(%(
       a = 1
       while 1 == 2
@@ -123,7 +123,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var that is re-assigned in a while and used in condition" do
+  it("types a var that is re-assigned in a while and used in condition") do
     assert_type(%(
       a = 1
       while b = a
@@ -133,7 +133,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var that is re-assigned in a while in next and used in condition" do
+  it("types a var that is re-assigned in a while in next and used in condition") do
     assert_type(%(
       a = 1
       while b = a
@@ -147,7 +147,7 @@ describe "Semantic: ssa" do
       )) { union_of(int32, char) }
   end
 
-  it "types a var that is declared in a while" do
+  it("types a var that is declared in a while") do
     assert_type(%(
       while 1 == 2
         a = 1
@@ -156,7 +156,7 @@ describe "Semantic: ssa" do
       )) { nilable int32 }
   end
 
-  it "types a var that is re-assigned in a while condition" do
+  it("types a var that is re-assigned in a while condition") do
     assert_type(%(
       a = 1
       while a = 'a'
@@ -166,7 +166,7 @@ describe "Semantic: ssa" do
       )) { char }
   end
 
-  it "types a var that is declared in a while condition" do
+  it("types a var that is declared in a while condition") do
     assert_type(%(
       while a = 'a'
         a = "hello"
@@ -175,7 +175,7 @@ describe "Semantic: ssa" do
       )) { char }
   end
 
-  it "types a var that is declared in a while with out" do
+  it("types a var that is declared in a while with out") do
     assert_type(%(
       lib LibC
         fun foo(x : Int32*)
@@ -190,7 +190,7 @@ describe "Semantic: ssa" do
       )) { union_of(char, int32) }
   end
 
-  it "types a var after begin ensure as having last type" do
+  it("types a var after begin ensure as having last type") do
     assert_type(%(
       a = 1.5
       begin
@@ -203,7 +203,7 @@ describe "Semantic: ssa" do
       )) { string }
   end
 
-  it "types a var after begin ensure as having last type (2)" do
+  it("types a var after begin ensure as having last type (2)") do
     assert_type(%(
       begin
         a = 2
@@ -214,7 +214,7 @@ describe "Semantic: ssa" do
       )) { char }
   end
 
-  it "types a var after begin rescue as having all possible types and nil in begin if read (2)" do
+  it("types a var after begin rescue as having all possible types and nil in begin if read (2)") do
     assert_type(%(
       begin
         a = 2
@@ -225,7 +225,7 @@ describe "Semantic: ssa" do
       )) { union_of [int32, char, nil_type] of Type }
   end
 
-  it "types a var after begin rescue as having all possible types in begin and rescue" do
+  it("types a var after begin rescue as having all possible types in begin and rescue") do
     assert_type(%(
       a = 1.5
       begin
@@ -239,7 +239,7 @@ describe "Semantic: ssa" do
       )) { union_of [float64, int32, char, string, bool] of Type }
   end
 
-  it "types a var after begin rescue as having all possible types in begin and rescue (2)" do
+  it("types a var after begin rescue as having all possible types in begin and rescue (2)") do
     assert_type(%(
       b = 2
       begin
@@ -253,7 +253,7 @@ describe "Semantic: ssa" do
       )) { union_of [int32, char, string, nil_type] of Type }
   end
 
-  it "types a var after begin rescue with no-return in rescue" do
+  it("types a var after begin rescue with no-return in rescue") do
     assert_type(%(
       lib LibC
         fun exit : NoReturn
@@ -270,7 +270,7 @@ describe "Semantic: ssa" do
       )) { union_of [int32, char, string] of Type }
   end
 
-  it "types a var after rescue as being nilable" do
+  it("types a var after rescue as being nilable") do
     assert_type(%(
       begin
       rescue
@@ -280,7 +280,7 @@ describe "Semantic: ssa" do
       )) { nilable int32 }
   end
 
-  it "doesn't change type to nilable inside if" do
+  it("doesn't change type to nilable inside if") do
     assert_type("
       def foo
         yield
@@ -300,7 +300,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with return in then" do
+  it("types if with return in then") do
     assert_type("
       def foo
         if 1 == 1
@@ -315,7 +315,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with return in then with assign" do
+  it("types if with return in then with assign") do
     assert_type("
       def foo
         if 1 == 1
@@ -331,7 +331,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with return in else" do
+  it("types if with return in else") do
     assert_type("
       def foo
         if 1 == 1
@@ -346,7 +346,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with return in else with assign" do
+  it("types if with return in else with assign") do
     assert_type("
       def foo
         if 1 == 1
@@ -362,7 +362,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with return in both branches" do
+  it("types if with return in both branches") do
     assert_type("
       def foo
         if 1 == 1
@@ -383,7 +383,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with unreachable in then" do
+  it("types if with unreachable in then") do
     assert_type("
       lib LibC
         fun exit : NoReturn
@@ -400,7 +400,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with break in then" do
+  it("types if with break in then") do
     assert_type("
       b = 1
 
@@ -418,7 +418,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if with next in then" do
+  it("types if with next in then") do
     assert_type("
       b = 1
 
@@ -436,7 +436,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types while with break" do
+  it("types while with break") do
     assert_type("
       a = 1
 
@@ -452,7 +452,7 @@ describe "Semantic: ssa" do
       ") { union_of(int32, char) }
   end
 
-  it "types while with break with new var" do
+  it("types while with break with new var") do
     assert_type("
       while 1 == 2
         if 1 == 1
@@ -465,7 +465,7 @@ describe "Semantic: ssa" do
       ") { nilable char }
   end
 
-  it "types while with break doesn't infect initial vas" do
+  it("types while with break doesn't infect initial vas") do
     assert_type("
       a = 1
       b = 1
@@ -483,7 +483,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types while with next" do
+  it("types while with next") do
     assert_type("
       a = 1
       b = 1
@@ -500,7 +500,7 @@ describe "Semantic: ssa" do
       ") { union_of(int32, char) }
   end
 
-  it "types block with break" do
+  it("types block with break") do
     assert_type("
       def foo
         yield
@@ -520,7 +520,7 @@ describe "Semantic: ssa" do
       ") { union_of(int32, char) }
   end
 
-  it "types block with break doesn't infect initial vars" do
+  it("types block with break doesn't infect initial vars") do
     assert_type("
       def foo
         yield
@@ -542,7 +542,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types block with next" do
+  it("types block with next") do
     assert_type("
       def foo
         yield
@@ -564,7 +564,7 @@ describe "Semantic: ssa" do
       ") { union_of(int32, char) }
   end
 
-  it "types if with restricted type in then" do
+  it("types if with restricted type in then") do
     assert_type("
       a = 1 || 'a'
       if a.is_a?(Int32)
@@ -576,7 +576,7 @@ describe "Semantic: ssa" do
       ") { char }
   end
 
-  it "types if with restricted type in else" do
+  it("types if with restricted type in else") do
     assert_type("
       a = 1 || 'a'
       if a.is_a?(Int32)
@@ -588,7 +588,7 @@ describe "Semantic: ssa" do
       ") { int32 }
   end
 
-  it "types if/else with var (bug)" do
+  it("types if/else with var (bug)") do
     assert_type("
       a = 1 || nil
       d = nil
@@ -601,7 +601,7 @@ describe "Semantic: ssa" do
       ") { nilable int32 }
   end
 
-  it "types re-assign inside if (bug)" do
+  it("types re-assign inside if (bug)") do
     assert_type("
       struct Nil
         def to_i
@@ -622,7 +622,7 @@ describe "Semantic: ssa" do
       ") { nilable int32 }
   end
 
-  it "types re-assign inside while (bug)" do
+  it("types re-assign inside while (bug)") do
     assert_type("
       struct Nil
         def to_i
@@ -643,7 +643,7 @@ describe "Semantic: ssa" do
       ") { nilable int32 }
   end
 
-  it "preserves type filters after block (bug)" do
+  it("preserves type filters after block (bug)") do
     assert_type("
       def foo
         yield

--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Semantic: static array" do
-  it "types static array with var declaration" do
+describe("Semantic: static array") do
+  it("types static array with var declaration") do
     assert_type("x = uninitialized Char[3]") { static_array_of(char, 3) }
   end
 
-  it "types static array new" do
+  it("types static array new") do
     assert_type("x = StaticArray(Char, 3).new; x") { static_array_of(char, 3) }
   end
 
-  it "types static array with type as size" do
+  it("types static array with type as size") do
     assert_type("
       class Foo(N)
         def self.foo
@@ -22,14 +22,14 @@ describe "Semantic: static array" do
       ") { static_array_of(char, 1) }
   end
 
-  it "errors if trying to instantiate static array with N not an integer" do
+  it("errors if trying to instantiate static array with N not an integer") do
     assert_error %(
       x = uninitialized Char[Int32]
       ),
       "can't instantiate StaticArray(T, N) with N = Int32 (N must be an integer)"
   end
 
-  it "allows instantiating static array instance var in initialize of generic type" do
+  it("allows instantiating static array instance var in initialize of generic type") do
     assert_type("
       class Foo(N)
         def initialize
@@ -45,14 +45,14 @@ describe "Semantic: static array" do
       ") { static_array_of(char, 1) }
   end
 
-  it "errors on negative static array size" do
+  it("errors on negative static array size") do
     assert_error %(
       x = uninitialized Int32[-1]
       ),
       "can't instantiate StaticArray(T, N) with N = -1 (N must be positive)"
   end
 
-  it "types static array new with size being a constant" do
+  it("types static array new with size being a constant") do
     assert_type(%(
       SIZE = 3
       x = StaticArray(Char, SIZE).new
@@ -60,7 +60,7 @@ describe "Semantic: static array" do
       )) { static_array_of(char, 3) }
   end
 
-  it "types static array new with size being a computed constant" do
+  it("types static array new with size being a computed constant") do
     assert_type(%(
       OTHER = 10
       SIZE = OTHER * 20
@@ -69,7 +69,7 @@ describe "Semantic: static array" do
       )) { static_array_of(char, 200) }
   end
 
-  it "types staic array new with size being a computed constant, and use N (bug)" do
+  it("types staic array new with size being a computed constant, and use N (bug)") do
     assert_type(%(
       struct StaticArray(T, N)
         def size
@@ -84,7 +84,7 @@ describe "Semantic: static array" do
       )) { int32 }
   end
 
-  it "doesn't crash on restriction (#584)" do
+  it("doesn't crash on restriction (#584)") do
     assert_error %(
       def foo(&block : Int32[Int32] -> Int32)
         block.call([0])
@@ -95,7 +95,7 @@ describe "Semantic: static array" do
       "can't instantiate StaticArray(T, N) with N = Int32 (N must be an integer)"
   end
 
-  it "can match N type argument of static array (#1203)" do
+  it("can match N type argument of static array (#1203)") do
     assert_type(%(
       def fn(a : StaticArray(T, N)) forall T, N
         N
@@ -106,7 +106,7 @@ describe "Semantic: static array" do
       )) { int32 }
   end
 
-  it "can match number type argument of static array (#1203)" do
+  it("can match number type argument of static array (#1203)") do
     assert_type(%(
       def fn(a : StaticArray(T, 10)) forall T
         10
@@ -117,7 +117,7 @@ describe "Semantic: static array" do
       )) { int32 }
   end
 
-  it "doesn't match other number type argument of static array (#1203)" do
+  it("doesn't match other number type argument of static array (#1203)") do
     assert_error %(
       def fn(a : StaticArray(T, 11)) forall T
         10

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: struct" do
-  it "types struct declaration" do
+describe("Semantic: struct") do
+  it("types struct declaration") do
     assert_type("
       struct Foo
       end
@@ -13,7 +13,7 @@ describe "Semantic: struct" do
     end
   end
 
-  it "types generic struct declaration" do
+  it("types generic struct declaration") do
     assert_type("
       struct Foo(T)
       end
@@ -28,7 +28,7 @@ describe "Semantic: struct" do
     end
   end
 
-  it "allows struct to participate in virtual" do
+  it("allows struct to participate in virtual") do
     assert_type("
       abstract struct Foo
       end
@@ -44,7 +44,7 @@ describe "Semantic: struct" do
   end
 
   %w(Value Struct Int Float).each do |type|
-    it "doesn't make virtual for #{type}" do
+    it("doesn't make virtual for #{type}") do
       assert_type("
         struct Foo < #{type}
         end
@@ -57,7 +57,7 @@ describe "Semantic: struct" do
     end
   end
 
-  it "can't be nilable" do
+  it("can't be nilable") do
     assert_type("
       struct Foo
       end
@@ -70,14 +70,14 @@ describe "Semantic: struct" do
     end
   end
 
-  it "can't extend struct from class" do
+  it("can't extend struct from class") do
     assert_error "
       struct Foo < Reference
       end
       ", "can't make struct 'Foo' inherit class 'Reference'"
   end
 
-  it "can't extend class from struct" do
+  it("can't extend class from struct") do
     assert_error "
       struct Foo
       end
@@ -87,7 +87,7 @@ describe "Semantic: struct" do
       ", "can't make class 'Bar' inherit struct 'Foo'"
   end
 
-  it "can't reopen as different type" do
+  it("can't reopen as different type") do
     assert_error "
       struct Foo
       end
@@ -97,7 +97,7 @@ describe "Semantic: struct" do
       ", "Foo is not a class, it's a struct"
   end
 
-  it "errors on recursive struct" do
+  it("errors on recursive struct") do
     assert_error %(
       struct Test
         def initialize(@test : Test?)
@@ -109,7 +109,7 @@ describe "Semantic: struct" do
       "recursive struct Test detected: `@test : (Test | Nil)`"
   end
 
-  it "errors on recursive struct inside module" do
+  it("errors on recursive struct inside module") do
     assert_error %(
       struct Foo::Test
         def initialize(@test : Foo::Test?)
@@ -121,7 +121,7 @@ describe "Semantic: struct" do
       "recursive struct Foo::Test detected: `@test : (Foo::Test | Nil)`"
   end
 
-  it "errors on recursive generic struct inside module" do
+  it("errors on recursive generic struct inside module") do
     assert_error %(
       struct Foo::Test(T)
         def initialize(@test : Foo::Test(T)?)
@@ -133,7 +133,7 @@ describe "Semantic: struct" do
       "recursive struct Foo::Test(T) detected: `@test : (Foo::Test(T) | Nil)`"
   end
 
-  it "errors on mutually recursive struct" do
+  it("errors on mutually recursive struct") do
     assert_error %(
       struct Foo
         def initialize(@bar : Bar?)
@@ -151,7 +151,7 @@ describe "Semantic: struct" do
       "recursive struct Foo detected: `@bar : (Bar | Nil)` -> `@foo : (Foo | Nil)`"
   end
 
-  it "can't extend struct from non-abstract struct" do
+  it("can't extend struct from non-abstract struct") do
     assert_error %(
       struct Foo
       end
@@ -162,7 +162,7 @@ describe "Semantic: struct" do
       "can't extend non-abstract struct Foo"
   end
 
-  it "unifies type to virtual type" do
+  it("unifies type to virtual type") do
     assert_type(%(
       abstract struct Foo
       end
@@ -176,7 +176,7 @@ describe "Semantic: struct" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "doesn't error if method is not found in abstract type" do
+  it("doesn't error if method is not found in abstract type") do
     assert_type(%(
       abstract struct Foo
       end
@@ -200,7 +200,7 @@ describe "Semantic: struct" do
       )) { union_of(int32, char) }
   end
 
-  it "can cast to base abstract struct" do
+  it("can cast to base abstract struct") do
     assert_type(%(
       abstract struct Foo
       end
@@ -215,7 +215,7 @@ describe "Semantic: struct" do
       )) { types["Foo"].virtual_type! }
   end
 
-  it "detects recursive struct through module" do
+  it("detects recursive struct through module") do
     assert_error %(
       module Moo
       end
@@ -230,7 +230,7 @@ describe "Semantic: struct" do
       "recursive struct Foo detected: `@moo : Moo` -> `Moo` -> `Foo`"
   end
 
-  it "detects recursive struct through inheritance (#3071)" do
+  it("detects recursive struct through inheritance (#3071)") do
     assert_error %(
       abstract struct Foo
       end
@@ -242,7 +242,7 @@ describe "Semantic: struct" do
       "recursive struct Bar detected: `@value : Foo` -> `Foo` -> `Bar`"
   end
 
-  it "errors if defining finalize for struct (#3840)" do
+  it("errors if defining finalize for struct (#3840)") do
     assert_error %(
       struct Foo
         def finalize

--- a/spec/compiler/semantic/super_spec.cr
+++ b/spec/compiler/semantic/super_spec.cr
@@ -1,11 +1,11 @@
 require "../../spec_helper"
 
-describe "Semantic: super" do
-  it "types super without arguments" do
+describe("Semantic: super") do
+  it("types super without arguments") do
     assert_type("class Foo; def foo; 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo") { int32 }
   end
 
-  it "types super without arguments and instance variable" do
+  it("types super without arguments and instance variable") do
     result = assert_type("class Foo; def foo; @x = 1; end; end; class Bar < Foo; def foo; super; end; end; bar = Bar.new; bar.foo; bar") do
       types["Bar"]
     end
@@ -15,11 +15,11 @@ describe "Semantic: super" do
     superclass.instance_vars["@x"].type.should eq(mod.nilable(mod.int32))
   end
 
-  it "types super without arguments but parent has arguments" do
+  it("types super without arguments but parent has arguments") do
     assert_type("class Foo; def foo(x); x; end; end; class Bar < Foo; def foo(x); super; end; end; Bar.new.foo(1)") { int32 }
   end
 
-  it "types super when container method is defined in parent class" do
+  it("types super when container method is defined in parent class") do
     nodes = parse "
       class Foo
         def initialize
@@ -45,7 +45,7 @@ describe "Semantic: super" do
     superclass2.instance_vars["@x"].type.should eq(mod.int32)
   end
 
-  it "types super when container method is defined in parent class two levels up" do
+  it("types super when container method is defined in parent class two levels up") do
     assert_type("
       class Base
         def foo
@@ -66,7 +66,7 @@ describe "Semantic: super" do
       ") { int32 }
   end
 
-  it "types super when inside fun" do
+  it("types super when inside fun") do
     assert_type(%(
       class Foo
         def foo
@@ -85,7 +85,7 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "types super when inside fun and forwards args" do
+  it("types super when inside fun and forwards args") do
     assert_type(%(
       class Foo
         def foo(z)
@@ -104,13 +104,13 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "errors no superclass method in top-level" do
+  it("errors no superclass method in top-level") do
     assert_error %(
       super
       ), "there's no superclass in this scope"
   end
 
-  it "errors no superclass method in top-level def" do
+  it("errors no superclass method in top-level def") do
     assert_error %(
       def foo
         super
@@ -120,7 +120,7 @@ describe "Semantic: super" do
       ), "there's no superclass in this scope"
   end
 
-  it "errors no superclass method" do
+  it("errors no superclass method") do
     assert_error %(
       require "prelude"
 
@@ -134,7 +134,7 @@ describe "Semantic: super" do
       ), "undefined method 'foo'"
   end
 
-  it "finds super initialize if not explicitly defined in superclass, 1 (#273)" do
+  it("finds super initialize if not explicitly defined in superclass, 1 (#273)") do
     assert_type(%(
       class Foo
         def initialize
@@ -146,7 +146,7 @@ describe "Semantic: super" do
       )) { types["Foo"] }
   end
 
-  it "finds super initialize if not explicitly defined in superclass, 2 (#273)" do
+  it("finds super initialize if not explicitly defined in superclass, 2 (#273)") do
     assert_type(%(
       class Base
       end
@@ -161,7 +161,7 @@ describe "Semantic: super" do
       )) { types["Foo"] }
   end
 
-  it "says correct error message when no overload matches in super call (#272)" do
+  it("says correct error message when no overload matches in super call (#272)") do
     assert_error %(
       abstract class Foo
         def initialize(x : Char)
@@ -179,7 +179,7 @@ describe "Semantic: super" do
       "no overload matches 'Foo#initialize'"
   end
 
-  it "calls super in module method (1) (#556)" do
+  it("calls super in module method (1) (#556)") do
     assert_type(%(
       class Parent
         def a
@@ -201,7 +201,7 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "calls super in module method (2) (#556)" do
+  it("calls super in module method (2) (#556)") do
     assert_type(%(
       class Parent
         def a
@@ -230,7 +230,7 @@ describe "Semantic: super" do
       )) { char }
   end
 
-  it "calls super in module method (3) (#556)" do
+  it("calls super in module method (3) (#556)") do
     assert_type(%(
       class Parent
         def a
@@ -256,7 +256,7 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "errors if calling super on module method and not found" do
+  it("errors if calling super on module method and not found") do
     assert_error %(
       module Mod
         def a
@@ -273,7 +273,7 @@ describe "Semantic: super" do
       "undefined method 'a'"
   end
 
-  it "calls super in generic module method" do
+  it("calls super in generic module method") do
     assert_type(%(
       class Parent
         def a
@@ -295,7 +295,7 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "doesn't error if invoking super and match isn't found in direct superclass (even though it's find in one superclass)" do
+  it("doesn't error if invoking super and match isn't found in direct superclass (even though it's find in one superclass)") do
     assert_type(%(
       class Foo
         def foo
@@ -319,7 +319,7 @@ describe "Semantic: super" do
       )) { int32 }
   end
 
-  it "errors if invoking super and match isn't found in direct superclass in initialize (even though it's find in one superclass)" do
+  it("errors if invoking super and match isn't found in direct superclass in initialize (even though it's find in one superclass)") do
     assert_error %(
       class Foo
         def initialize
@@ -341,7 +341,7 @@ describe "Semantic: super" do
       ), "wrong number of argument"
   end
 
-  it "gives correct error when calling super and target is abstract method (#2675)" do
+  it("gives correct error when calling super and target is abstract method (#2675)") do
     assert_error %(
       abstract class Base
         abstract def method
@@ -358,7 +358,7 @@ describe "Semantic: super" do
       "undefined method 'Base#method()'"
   end
 
-  it "errors on super outside method (#4481)" do
+  it("errors on super outside method (#4481)") do
     assert_error %(
       class Foo
         super

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -1,80 +1,80 @@
 require "../../spec_helper"
 
-describe "Semantic: tuples" do
-  it "types tuple of one element" do
+describe("Semantic: tuples") do
+  it("types tuple of one element") do
     assert_type("{1}") { tuple_of([int32] of TypeVar) }
   end
 
-  it "types tuple of three elements" do
+  it("types tuple of three elements") do
     assert_type("{1, 2.5, 'a'}") { tuple_of([int32, float64, char] of TypeVar) }
   end
 
-  it "types tuple of one element and then two elements" do
+  it("types tuple of one element and then two elements") do
     assert_type("{1}; {1, 2}") { tuple_of([int32, int32] of TypeVar) }
   end
 
-  it "types tuple [0]" do
+  it("types tuple [0]") do
     assert_type("{1, 'a'}[0]") { int32 }
   end
 
-  it "types tuple [1]" do
+  it("types tuple [1]") do
     assert_type("{1, 'a'}[1]") { char }
   end
 
-  it "types tuple [-1]" do
+  it("types tuple [-1]") do
     assert_type("{1, 'a'}[-1]") { char }
   end
 
-  it "types tuple [-2]" do
+  it("types tuple [-2]") do
     assert_type("{1, 'a'}[-2]") { int32 }
   end
 
-  it "types tuple [0]?" do
+  it("types tuple [0]?") do
     assert_type("{1, 'a'}[0]?") { int32 }
   end
 
-  it "types tuple [1]?" do
+  it("types tuple [1]?") do
     assert_type("{1, 'a'}[1]?") { char }
   end
 
-  it "types tuple [2]?" do
+  it("types tuple [2]?") do
     assert_type("{1, 'a'}[2]?") { nil_type }
   end
 
-  it "types tuple [-1]?" do
+  it("types tuple [-1]?") do
     assert_type("{1, 'a'}[-1]?") { char }
   end
 
-  it "types tuple [-2]?" do
+  it("types tuple [-2]?") do
     assert_type("{1, 'a'}[-2]?") { int32 }
   end
 
-  it "types tuple [-3]?" do
+  it("types tuple [-3]?") do
     assert_type("{1, 'a'}[-3]?") { nil_type }
   end
 
-  it "types tuple metaclass [0]" do
+  it("types tuple metaclass [0]") do
     assert_type("{1, 'a'}.class[0]") { int32.metaclass }
   end
 
-  it "types tuple metaclass [1]" do
+  it("types tuple metaclass [1]") do
     assert_type("{1, 'a'}.class[1]") { char.metaclass }
   end
 
-  it "types tuple metaclass [-1]" do
+  it("types tuple metaclass [-1]") do
     assert_type("{1, 'a'}.class[-1]") { char.metaclass }
   end
 
-  it "types tuple metaclass [-2]" do
+  it("types tuple metaclass [-2]") do
     assert_type("{1, 'a'}.class[-2]") { int32.metaclass }
   end
 
-  it "gives error when indexing out of range" do
+  it("gives error when indexing out of range") do
     assert_error "{1, 'a'}[2]",
       "index out of bounds for Tuple(Int32, Char) (2 not in -2..1)"
   end
 
-  it "gives error when indexing out of range on empty tuple" do
+  it("gives error when indexing out of range on empty tuple") do
     assert_error %(
       def tuple(*args)
         args
@@ -85,11 +85,11 @@ describe "Semantic: tuples" do
       "index '0' out of bounds for empty tuple"
   end
 
-  it "can name a tuple type" do
+  it("can name a tuple type") do
     assert_type("Tuple(Int32, Float64)") { tuple_of([int32, float64]).metaclass }
   end
 
-  it "types T as a tuple of metaclasses" do
+  it("types T as a tuple of metaclasses") do
     assert_type("
       struct Tuple
         def type_args
@@ -106,7 +106,7 @@ describe "Semantic: tuples" do
     end
   end
 
-  it "errors on recursive splat expansion (#218)" do
+  it("errors on recursive splat expansion (#218)") do
     assert_error %(
       def foo(*a)
         foo(a)
@@ -120,7 +120,7 @@ describe "Semantic: tuples" do
       "recursive splat expansion"
   end
 
-  it "errors on recusrive splat expansion (1) (#361)" do
+  it("errors on recusrive splat expansion (1) (#361)") do
     assert_error %(
       require "prelude"
 
@@ -133,7 +133,7 @@ describe "Semantic: tuples" do
       "recursive splat expansion"
   end
 
-  it "errors on recursive splat expansion (2) (#361)" do
+  it("errors on recursive splat expansion (2) (#361)") do
     assert_error %(
       class Foo(T)
       end
@@ -147,7 +147,7 @@ describe "Semantic: tuples" do
       "recursive splat expansion"
   end
 
-  it "allows tuple covariance" do
+  it("allows tuple covariance") do
     assert_type(%(
       class Obj
         def initialize
@@ -174,7 +174,7 @@ describe "Semantic: tuples" do
       )) { tuple_of [types["Foo"].virtual_type!] }
   end
 
-  it "merges two tuple types of same size" do
+  it("merges two tuple types of same size") do
     assert_type(%(
       def foo
         if 1 == 2
@@ -188,7 +188,7 @@ describe "Semantic: tuples" do
       )) { tuple_of [string, nilable(int32)] }
   end
 
-  it "accept tuple in type restriction" do
+  it("accept tuple in type restriction") do
     assert_type(%(
       class Foo
       end
@@ -204,7 +204,7 @@ describe "Semantic: tuples" do
       )) { tuple_of [types["Bar"]] }
   end
 
-  it "accepts tuple covariance in array" do
+  it("accepts tuple covariance in array") do
     assert_type(%(
       require "prelude"
 
@@ -220,7 +220,7 @@ describe "Semantic: tuples" do
       )) { tuple_of [types["Foo"].virtual_type!, types["Foo"].virtual_type!] }
   end
 
-  it "can iterate T" do
+  it("can iterate T") do
     assert_type(%(
       struct Tuple
         def self.types
@@ -237,7 +237,7 @@ describe "Semantic: tuples" do
       )) { tuple_of([int32.metaclass, string.metaclass]) }
   end
 
-  it "can call [] on T" do
+  it("can call [] on T") do
     assert_type(%(
       struct Tuple
         def self.types
@@ -248,7 +248,7 @@ describe "Semantic: tuples" do
       )) { nil_type.metaclass }
   end
 
-  it "matches tuple with splat (#2932)" do
+  it("matches tuple with splat (#2932)") do
     assert_type(%(
       def foo(x : Tuple(*T)) forall T
         T
@@ -258,7 +258,7 @@ describe "Semantic: tuples" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
-  it "matches tuple with splat (2) (#2932)" do
+  it("matches tuple with splat (2) (#2932)") do
     assert_type(%(
       def foo(x : Tuple(A, *B, C)) forall A, B, C
         {A, B, C}
@@ -268,7 +268,7 @@ describe "Semantic: tuples" do
       )) { tuple_of([int32.metaclass, tuple_of([char, bool]).metaclass, float64.metaclass]) }
   end
 
-  it "errors if using two splat indices on restriction" do
+  it("errors if using two splat indices on restriction") do
     assert_error %(
       def foo(x : Tuple(*A, *B)) forall A, B
       end
@@ -278,7 +278,7 @@ describe "Semantic: tuples" do
       "can't specify more than one splat in restriction"
   end
 
-  it "errors on tuple too big (#3816)" do
+  it("errors on tuple too big (#3816)") do
     assert_error %(
       require "prelude"
 

--- a/spec/compiler/semantic/uninitialized_spec.cr
+++ b/spec/compiler/semantic/uninitialized_spec.cr
@@ -1,15 +1,15 @@
 require "../../spec_helper"
 
-describe "Semantic: uninitialized" do
-  it "declares as uninitialized" do
+describe("Semantic: uninitialized") do
+  it("declares as uninitialized") do
     assert_type("a = uninitialized Int32") { int32 }
   end
 
-  it "declares as uninitialized and reads it" do
+  it("declares as uninitialized and reads it") do
     assert_type("a = uninitialized Int32; a") { int32 }
   end
 
-  it "declares an instance variable in initialize as uninitialized" do
+  it("declares an instance variable in initialize as uninitialized") do
     assert_type("
       class Foo
         def initialize
@@ -25,7 +25,7 @@ describe "Semantic: uninitialized" do
       ") { int32 }
   end
 
-  it "errors if declaring generic type without type vars (with instance var)" do
+  it("errors if declaring generic type without type vars (with instance var)") do
     assert_error %(
       class Foo(T)
       end
@@ -41,7 +41,7 @@ describe "Semantic: uninitialized" do
       "can't declare variable of generic non-instantiated type Foo"
   end
 
-  it "errors if declaring generic type without type vars (with class var)" do
+  it("errors if declaring generic type without type vars (with class var)") do
     assert_error %(
       class Foo(T)
       end
@@ -55,7 +55,7 @@ describe "Semantic: uninitialized" do
       "can't declare variable of generic non-instantiated type Foo"
   end
 
-  it "errors if declares var and then assigns other type" do
+  it("errors if declares var and then assigns other type") do
     assert_error %(
       x = uninitialized Int32
       x = 1_i64
@@ -63,7 +63,7 @@ describe "Semantic: uninitialized" do
       "type must be Int32, not (Int32 | Int64)"
   end
 
-  it "errors if declaring variable multiple times with different types (#917)" do
+  it("errors if declaring variable multiple times with different types (#917)") do
     assert_error %(
       if 1 == 0
         buf = uninitialized Int32
@@ -74,7 +74,7 @@ describe "Semantic: uninitialized" do
       "variable 'buf' already declared with type Int32"
   end
 
-  it "can uninitialize variable outside initialize (#2828)" do
+  it("can uninitialize variable outside initialize (#2828)") do
     assert_type(%(
       class Foo
         @x = uninitialized Int32
@@ -88,7 +88,7 @@ describe "Semantic: uninitialized" do
       )) { int32 }
   end
 
-  it "can uninitialize variable outside initialize, generic (#2828)" do
+  it("can uninitialize variable outside initialize, generic (#2828)") do
     assert_type(%(
       class Foo(T)
         @x = uninitialized T
@@ -102,7 +102,7 @@ describe "Semantic: uninitialized" do
       )) { int32 }
   end
 
-  it "can use uninitialized with class type (#2940)" do
+  it("can use uninitialized with class type (#2940)") do
     assert_type(%(
       class Foo(U)
         def initialize
@@ -119,7 +119,7 @@ describe "Semantic: uninitialized" do
   end
 
   %w(Object Value Reference Number Int Float Struct Class Enum).each do |type|
-    it "disallows declaring var of type #{type}" do
+    it("disallows declaring var of type #{type}") do
       assert_error %(
         x = uninitialized #{type}
         ),
@@ -127,7 +127,7 @@ describe "Semantic: uninitialized" do
     end
   end
 
-  it "works with uninitialized NoReturn (#3314)" do
+  it("works with uninitialized NoReturn (#3314)") do
     assert_type(%(
       def foo
         x = uninitialized typeof(yield)
@@ -141,7 +141,7 @@ describe "Semantic: uninitialized" do
       )) { nil_type }
   end
 
-  it "has type (#3641)" do
+  it("has type (#3641)") do
     assert_type(%(
       x = uninitialized Int32
       )) { int32 }

--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -1,23 +1,23 @@
 require "../../spec_helper"
 
-describe "Semantic: union" do
-  it "types union when obj is union" do
+describe("Semantic: union") do
+  it("types union when obj is union") do
     assert_type("struct Char; def +(other); self; end; end; a = 1 || 'a'; a + 1") { union_of(int32, char) }
   end
 
-  it "types union when arg is union" do
+  it("types union when arg is union") do
     assert_type("struct Int; def +(x : Char); x; end; end; a = 1 || 'a'; 1 + a") { union_of(int32, char) }
   end
 
-  it "types union when both obj and arg are union" do
+  it("types union when both obj and arg are union") do
     assert_type("struct Char; def +(other); self; end; end; struct Int; def +(x : Char); x; end; end; a = 1 || 'a'; a + a") { union_of(int32, char) }
   end
 
-  it "types union of classes" do
+  it("types union of classes") do
     assert_type("class Foo; end; class Bar; end; a = Foo.new || Bar.new; a") { union_of(types["Foo"], types["Bar"]) }
   end
 
-  it "assigns to union and keeps new union type in call" do
+  it("assigns to union and keeps new union type in call") do
     assert_type("
       def foo(x)
         while false
@@ -30,7 +30,7 @@ describe "Semantic: union" do
       ") { union_of(int32, bool, char) }
   end
 
-  it "looks up type in union type with free var" do
+  it("looks up type in union type with free var") do
     assert_type("
       class Bar(T)
       end
@@ -43,7 +43,7 @@ describe "Semantic: union" do
     ") { generic_class "Bar", union_of(int32, char) }
   end
 
-  it "supports macro if inside union" do
+  it("supports macro if inside union") do
     assert_type(%(
       lib LibC
         union Foo
@@ -59,19 +59,19 @@ describe "Semantic: union" do
       ), flags: "some_flag") { int32 }
   end
 
-  it "types union" do
+  it("types union") do
     assert_type(%(
       Union(Int32, String)
       )) { union_of(int32, string).metaclass }
   end
 
-  it "types union of same type" do
+  it("types union of same type") do
     assert_type(%(
       Union(Int32, Int32, Int32)
       )) { int32.metaclass }
   end
 
-  it "can reopen Union" do
+  it("can reopen Union") do
     assert_type(%(
       struct Union
         def self.foo
@@ -82,7 +82,7 @@ describe "Semantic: union" do
       )) { int32 }
   end
 
-  it "can reopen Union and access T" do
+  it("can reopen Union and access T") do
     assert_type(%(
       struct Union
         def self.types
@@ -93,7 +93,7 @@ describe "Semantic: union" do
       )) { tuple_of([int32, string]).metaclass }
   end
 
-  it "can iterate T" do
+  it("can iterate T") do
     assert_type(%(
       struct Union
         def self.types
@@ -110,14 +110,14 @@ describe "Semantic: union" do
       )) { tuple_of([int32.metaclass, string.metaclass]) }
   end
 
-  it "errors if instantiates union" do
+  it("errors if instantiates union") do
     assert_error %(
       Union(Int32, String).new
       ),
       "can't create instance of a union type"
   end
 
-  it "finds method in Object" do
+  it("finds method in Object") do
     assert_type(%(
       class Object
         def self.foo
@@ -129,7 +129,7 @@ describe "Semantic: union" do
       )) { int32 }
   end
 
-  it "finds method in Value" do
+  it("finds method in Value") do
     assert_type(%(
       struct Value
         def self.foo
@@ -141,7 +141,7 @@ describe "Semantic: union" do
       )) { int32 }
   end
 
-  it "merges types in the same hierarchy with Union" do
+  it("merges types in the same hierarchy with Union") do
     assert_type(%(
       class Foo; end
       class Bar < Foo; end
@@ -150,13 +150,13 @@ describe "Semantic: union" do
       )) { types["Foo"].virtual_type!.metaclass }
   end
 
-  it "treats void as nil in union" do
+  it("treats void as nil in union") do
     assert_type(%(
       nil.as(Void?)
       )) { nil_type }
   end
 
-  it "can use Union in type restriction (#2988)" do
+  it("can use Union in type restriction (#2988)") do
     assert_type(%(
       def foo(x : Union(Int32, String))
         x

--- a/spec/compiler/semantic/var_spec.cr
+++ b/spec/compiler/semantic/var_spec.cr
@@ -2,8 +2,8 @@ require "../../spec_helper"
 
 include Crystal
 
-describe "Semantic: var" do
-  it "types an assign" do
+describe("Semantic: var") do
+  it("types an assign") do
     input = parse "a = 1"
     result = semantic input
     mod = result.program
@@ -13,7 +13,7 @@ describe "Semantic: var" do
     node.type.should eq(mod.int32)
   end
 
-  it "types a variable" do
+  it("types a variable") do
     input = parse "a = 1; a"
     result = semantic input
     mod = result.program
@@ -22,7 +22,7 @@ describe "Semantic: var" do
     node.type.should eq(mod.int32)
   end
 
-  it "reports undefined local variable or method" do
+  it("reports undefined local variable or method") do
     assert_error "
       def foo
         a = something
@@ -36,23 +36,23 @@ describe "Semantic: var" do
     ", "undefined local variable or method 'something'"
   end
 
-  it "reports there's no self" do
+  it("reports there's no self") do
     assert_error "self", "there's no self in this scope"
   end
 
-  it "reports variable always nil" do
+  it("reports variable always nil") do
     assert_error "1 == 2 ? (a = 1) : a",
       "read before assignment to local variable 'a'"
   end
 
-  it "lets type on else side of if with a Bool | Nil union" do
+  it("lets type on else side of if with a Bool | Nil union") do
     assert_type(%(
       a = (1 == 1) || nil
       a ? nil : a
       )) { nilable bool }
   end
 
-  it "errors if declaring var that is already declared" do
+  it("errors if declaring var that is already declared") do
     assert_error %(
       a = 1
       a = uninitialized Float64
@@ -60,21 +60,21 @@ describe "Semantic: var" do
       "variable 'a' already declared"
   end
 
-  it "errors if reads from underscore" do
+  it("errors if reads from underscore") do
     assert_error %(
       _
       ),
       "can't read from _"
   end
 
-  it "declares local variable with value" do
+  it("declares local variable with value") do
     assert_type(%(
       a : Int32 = 0
       a
       )) { int32 }
   end
 
-  it "declares local variable and then assigns it" do
+  it("declares local variable and then assigns it") do
     assert_type(%(
       a : Int32
       a = 0
@@ -82,7 +82,7 @@ describe "Semantic: var" do
       )) { int32 }
   end
 
-  it "declares local variable and immediately reads it" do
+  it("declares local variable and immediately reads it") do
     assert_error %(
       a : Int32
       a
@@ -90,7 +90,7 @@ describe "Semantic: var" do
       "read before assignment to local variable 'a'"
   end
 
-  it "declares local variable and assigns it with if" do
+  it("declares local variable and assigns it with if") do
     assert_type(%(
       a : Int32
       if 1 == 2
@@ -102,7 +102,7 @@ describe "Semantic: var" do
       )) { int32 }
   end
 
-  it "declares local variable but doesn't assign it in all branches" do
+  it("declares local variable but doesn't assign it in all branches") do
     assert_error %(
       a : Int32
       if 1 == 2
@@ -113,7 +113,7 @@ describe "Semantic: var" do
       "type must be Int32"
   end
 
-  it "declares local variable and assigns wrong type" do
+  it("declares local variable and assigns wrong type") do
     assert_error %(
       a : Int32
       a = true
@@ -121,7 +121,7 @@ describe "Semantic: var" do
       "type must be Int32"
   end
 
-  it "parse local variable as method call even if local variable is declared in call arguments" do
+  it("parse local variable as method call even if local variable is declared in call arguments") do
     assert_error %(
       macro foo(x)
         {{x}}
@@ -132,7 +132,7 @@ describe "Semantic: var" do
       "undefined local variable or method 'a'"
   end
 
-  it "errors if variable already exists" do
+  it("errors if variable already exists") do
     assert_error %(
       a = true
       a : Int32
@@ -140,7 +140,7 @@ describe "Semantic: var" do
       "variable 'a' already declared"
   end
 
-  it "errors if declaring generic type without type vars (with local var)" do
+  it("errors if declaring generic type without type vars (with local var)") do
     assert_error %(
       class Foo(T)
       end

--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: virtual metaclass" do
-  it "types virtual metaclass" do
+describe("Semantic: virtual metaclass") do
+  it("types virtual metaclass") do
     assert_type("
       class Foo
       end
@@ -14,7 +14,7 @@ describe "Semantic: virtual metaclass" do
     ") { types["Foo"].virtual_type.metaclass }
   end
 
-  it "types virtual metaclass method" do
+  it("types virtual metaclass method") do
     assert_type("
       class Foo
         def self.foo
@@ -33,7 +33,7 @@ describe "Semantic: virtual metaclass" do
     ") { union_of(int32, float64) }
   end
 
-  it "allows allocating virtual type when base class is abstract" do
+  it("allows allocating virtual type when base class is abstract") do
     assert_type("
       abstract class Foo
       end
@@ -49,7 +49,7 @@ describe "Semantic: virtual metaclass" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "yields virtual type in block arg if class is abstract" do
+  it("yields virtual type in block arg if class is abstract") do
     assert_type("
       require \"prelude\"
 
@@ -80,7 +80,7 @@ describe "Semantic: virtual metaclass" do
       ") { array_of(types["Foo"].virtual_type) }
   end
 
-  it "merges metaclass types" do
+  it("merges metaclass types") do
     assert_type("
       class Foo
       end
@@ -92,7 +92,7 @@ describe "Semantic: virtual metaclass" do
       ") { types["Foo"].virtual_type.metaclass }
   end
 
-  it "merges metaclass types with 3 types" do
+  it("merges metaclass types with 3 types") do
     assert_type("
       class Foo
       end
@@ -107,7 +107,7 @@ describe "Semantic: virtual metaclass" do
       ") { types["Foo"].virtual_type.metaclass }
   end
 
-  it "types metaclass node" do
+  it("types metaclass node") do
     assert_type("
       class Foo
       end
@@ -120,7 +120,7 @@ describe "Semantic: virtual metaclass" do
       ") { types["Foo"].virtual_type.metaclass }
   end
 
-  it "allows passing metaclass to virtual metaclass restriction" do
+  it("allows passing metaclass to virtual metaclass restriction") do
     assert_type("
       class Foo
       end
@@ -133,7 +133,7 @@ describe "Semantic: virtual metaclass" do
       ") { types["Foo"].metaclass }
   end
 
-  it "allows passing metaclass to virtual metaclass restriction" do
+  it("allows passing metaclass to virtual metaclass restriction") do
     assert_type("
       class Foo
       end

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: virtual" do
-  it "types two classes without a shared virtual" do
+describe("Semantic: virtual") do
+  it("types two classes without a shared virtual") do
     assert_type("
       class Foo
       end
@@ -13,7 +13,7 @@ describe "Semantic: virtual" do
       ") { union_of(types["Foo"], types["Bar"]) }
   end
 
-  it "types class and subclass as one type" do
+  it("types class and subclass as one type") do
     assert_type("
       class Foo
       end
@@ -25,7 +25,7 @@ describe "Semantic: virtual" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "types two subclasses" do
+  it("types two subclasses") do
     assert_type("
       class Foo
       end
@@ -40,7 +40,7 @@ describe "Semantic: virtual" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "types class and two subclasses" do
+  it("types class and two subclasses") do
     assert_type("
       class Foo
       end
@@ -55,7 +55,7 @@ describe "Semantic: virtual" do
       ") { types["Foo"].virtual_type }
   end
 
-  it "types method call of virtual type" do
+  it("types method call of virtual type") do
     assert_type("
       class Foo
         def foo
@@ -71,7 +71,7 @@ describe "Semantic: virtual" do
       ") { int32 }
   end
 
-  it "types method call of virtual type with override" do
+  it("types method call of virtual type with override") do
     assert_type("
       class Foo
         def foo
@@ -90,7 +90,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64) }
   end
 
-  it "dispatches virtual method" do
+  it("dispatches virtual method") do
     nodes = parse("
       class Foo
         def foo
@@ -111,7 +111,7 @@ describe "Semantic: virtual" do
     nodes.last.as(Call).target_defs.not_nil!.size.should eq(1)
   end
 
-  it "dispatches virtual method with overload" do
+  it("dispatches virtual method with overload") do
     nodes = parse("
       class Foo
         def foo
@@ -134,7 +134,7 @@ describe "Semantic: virtual" do
     nodes.last.as(Call).target_defs.not_nil!.size.should eq(2)
   end
 
-  it "works with restriction alpha" do
+  it("works with restriction alpha") do
     nodes = parse("
       require \"prelude\"
 
@@ -158,7 +158,7 @@ describe "Semantic: virtual" do
     semantic nodes
   end
 
-  it "doesn't check cover for subclasses" do
+  it("doesn't check cover for subclasses") do
     assert_type("
       class Foo
         def foo(other)
@@ -177,7 +177,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64) }
   end
 
-  it "removes instance var from subclasses" do
+  it("removes instance var from subclasses") do
     nodes = parse "
       class Base
       end
@@ -208,7 +208,7 @@ describe "Semantic: virtual" do
     base.instance_vars["@x"].type.should eq(mod.nilable(mod.int32))
   end
 
-  it "types inspect" do
+  it("types inspect") do
     assert_type("
       require \"prelude\"
 
@@ -219,7 +219,7 @@ describe "Semantic: virtual" do
       ") { string }
   end
 
-  it "reports no matches for virtual type" do
+  it("reports no matches for virtual type") do
     assert_error "
       class Foo
       end
@@ -235,7 +235,7 @@ describe "Semantic: virtual" do
       "undefined method 'foo' for Foo"
   end
 
-  it "doesn't check methods on abstract classes" do
+  it("doesn't check methods on abstract classes") do
     assert_type("
       abstract class Foo
       end
@@ -257,7 +257,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64) }
   end
 
-  it "doesn't check methods on abstract classes 2" do
+  it("doesn't check methods on abstract classes 2") do
     assert_type("
       abstract class Foo
       end
@@ -288,7 +288,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64, char) }
   end
 
-  it "reports undefined method in subclass of abstract class" do
+  it("reports undefined method in subclass of abstract class") do
     assert_error "
       abstract class Foo
       end
@@ -317,7 +317,7 @@ describe "Semantic: virtual" do
       "undefined method 'foo' for Bar3"
   end
 
-  it "doesn't check cover for abstract classes" do
+  it("doesn't check cover for abstract classes") do
     assert_type("
       abstract class Foo
         def foo(other)
@@ -354,7 +354,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64, char) }
   end
 
-  it "reports missing cover for subclass of abstract class" do
+  it("reports missing cover for subclass of abstract class") do
     assert_error "
       abstract class Foo
         def foo(other)
@@ -388,7 +388,7 @@ describe "Semantic: virtual" do
       "no overload matches"
   end
 
-  it "checks cover in every concrete subclass" do
+  it("checks cover in every concrete subclass") do
     assert_type("
       abstract class Foo
       end
@@ -419,7 +419,7 @@ describe "Semantic: virtual" do
       ") { nil_type }
   end
 
-  it "checks cover in every concrete subclass 2" do
+  it("checks cover in every concrete subclass 2") do
     assert_error "
       abstract class Foo
       end
@@ -450,7 +450,7 @@ describe "Semantic: virtual" do
       "no overload matches"
   end
 
-  it "checks cover in every concrete subclass 3" do
+  it("checks cover in every concrete subclass 3") do
     assert_type("
       abstract class Foo
       end
@@ -478,7 +478,7 @@ describe "Semantic: virtual" do
       ") { nil_type }
   end
 
-  it "checks method in every concrete subclass but method in Object" do
+  it("checks method in every concrete subclass but method in Object") do
     assert_type("
       class Object
         def foo
@@ -529,7 +529,7 @@ describe "Semantic: virtual" do
   #     ") { union_of(nil_type, int32, char) }
   # end
 
-  it "finds overloads of union of virtual, class and nil" do
+  it("finds overloads of union of virtual, class and nil") do
     assert_type("
       class Foo
       end
@@ -550,7 +550,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64) }
   end
 
-  it "finds overloads of union of virtual, class and nil with abstract class" do
+  it("finds overloads of union of virtual, class and nil with abstract class") do
     assert_type("
       abstract class Foo
       end
@@ -574,7 +574,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, float64) }
   end
 
-  it "restricts with union and doesn't merge to super type" do
+  it("restricts with union and doesn't merge to super type") do
     assert_type("
       abstract class Foo
       end
@@ -607,7 +607,7 @@ describe "Semantic: virtual" do
       ") { union_of(int32, char, string) }
   end
 
-  it "uses virtual type as generic type if class is abstract" do
+  it("uses virtual type as generic type if class is abstract") do
     result = assert_type("
       abstract class Foo
       end
@@ -619,7 +619,7 @@ describe "Semantic: virtual" do
       ") { generic_class "Bar", types["Foo"].virtual_type }
   end
 
-  it "uses virtual type as generic type if class is abstract even in union" do
+  it("uses virtual type as generic type if class is abstract even in union") do
     result = assert_type("
       abstract class Foo
       end
@@ -634,7 +634,7 @@ describe "Semantic: virtual" do
       ") { generic_class "Bar", union_of(types["Foo"].virtual_type, int32) }
   end
 
-  it "automatically does virtual for generic type if there are subclasses" do
+  it("automatically does virtual for generic type if there are subclasses") do
     assert_type("
       class Foo; end
       class Bar < Foo; end
@@ -643,7 +643,7 @@ describe "Semantic: virtual" do
       ") { pointer_of(types["Foo"].virtual_type) }
   end
 
-  it "types instance var as virtual when using type declaration and has subclasses" do
+  it("types instance var as virtual when using type declaration and has subclasses") do
     assert_type(%(
       class Foo
       end

--- a/spec/compiler/semantic/visibility_modifiers_spec.cr
+++ b/spec/compiler/semantic/visibility_modifiers_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Visibility modifiers" do
-  it "disallows invoking private method" do
+describe("Visibility modifiers") do
+  it("disallows invoking private method") do
     assert_error %(
       class Foo
         private def foo
@@ -14,7 +14,7 @@ describe "Visibility modifiers" do
       "private method 'foo' called for Foo"
   end
 
-  it "allows setting visibility modifier to macro" do
+  it("allows setting visibility modifier to macro") do
     assert_error %(
       class Object
         macro x
@@ -32,7 +32,7 @@ describe "Visibility modifiers" do
       "private method 'foo' called for Foo"
   end
 
-  it "allows setting visibility modifier to macro that generates many methods (1)" do
+  it("allows setting visibility modifier to macro that generates many methods (1)") do
     assert_error %(
       class Object
         macro x
@@ -53,7 +53,7 @@ describe "Visibility modifiers" do
       "private method 'foo' called for Foo"
   end
 
-  it "allows setting visibility modifier to macro that generates many methods (2)" do
+  it("allows setting visibility modifier to macro that generates many methods (2)") do
     assert_error %(
       class Object
         macro x
@@ -74,7 +74,7 @@ describe "Visibility modifiers" do
       "private method 'bar' called for Foo"
   end
 
-  it "allows invoking protected method from the same class" do
+  it("allows invoking protected method from the same class") do
     assert_type(%(
       class Foo
         protected def foo
@@ -90,7 +90,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method from subclass" do
+  it("allows invoking protected method from subclass") do
     assert_type(%(
       class Foo
         protected def foo
@@ -108,7 +108,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method from subclass (2)" do
+  it("allows invoking protected method from subclass (2)") do
     assert_type(%(
       class Foo
         protected def foo
@@ -129,7 +129,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "errors if invoking protected method from top-level" do
+  it("errors if invoking protected method from top-level") do
     assert_error %(
       class Foo
         protected def foo
@@ -141,7 +141,7 @@ describe "Visibility modifiers" do
       "protected method 'foo' called for Foo"
   end
 
-  it "errors if invoking protected method from non-subclass" do
+  it("errors if invoking protected method from non-subclass") do
     assert_error %(
       class Foo
         protected def foo
@@ -159,7 +159,7 @@ describe "Visibility modifiers" do
       "protected method 'foo' called for Foo"
   end
 
-  it "errors if invoking protected method from non-subclass, generated with macro that generates a macro" do
+  it("errors if invoking protected method from non-subclass, generated with macro that generates a macro") do
     assert_error %(
       class Object
         macro y
@@ -181,7 +181,7 @@ describe "Visibility modifiers" do
       "protected method 'foo' called for Foo"
   end
 
-  it "errors if applying visibility modifier to non-def or non-call" do
+  it("errors if applying visibility modifier to non-def or non-call") do
     assert_error %(
       class Foo
         private 1
@@ -190,7 +190,7 @@ describe "Visibility modifiers" do
       "can't apply visibility modifier"
   end
 
-  it "allows invoking protected from instance to class" do
+  it("allows invoking protected from instance to class") do
     assert_type(%(
       class Foo
         def instance_foo
@@ -206,7 +206,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "automatically makes initialize be protected" do
+  it("automatically makes initialize be protected") do
     assert_error %(
       class Foo
         def initialize(x)
@@ -219,7 +219,7 @@ describe "Visibility modifiers" do
       "protected method 'initialize' called for Foo"
   end
 
-  it "allows invoking private setter with self" do
+  it("allows invoking private setter with self") do
     assert_type(%(
       class Foo
         private def x=(x)
@@ -235,7 +235,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method from namespace to namespaced type" do
+  it("allows invoking protected method from namespace to namespaced type") do
     assert_type(%(
       class Foo
         def foo
@@ -253,7 +253,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method from namespaced type to namespace" do
+  it("allows invoking protected method from namespaced type to namespace") do
     assert_type(%(
       class Foo
         protected def foo
@@ -271,7 +271,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method between types in the same namespace" do
+  it("allows invoking protected method between types in the same namespace") do
     assert_type(%(
       module NS1
         class NS2
@@ -293,7 +293,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method between types in the same namespace when inheriting" do
+  it("allows invoking protected method between types in the same namespace when inheriting") do
     assert_type(%(
       module NS1
         class NS2
@@ -318,7 +318,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows invoking protected method from virtual type" do
+  it("allows invoking protected method from virtual type") do
     assert_type(%(
       abstract class Foo
         def foo
@@ -342,7 +342,7 @@ describe "Visibility modifiers" do
       )) { union_of int32, float64 }
   end
 
-  it "allows calling protected method from nested generic class (1)" do
+  it("allows calling protected method from nested generic class (1)") do
     assert_type(%(
       class Foo
         class Bar(U)
@@ -360,7 +360,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "allows calling protected method from nested generic class (2)" do
+  it("allows calling protected method from nested generic class (2)") do
     assert_type(%(
       class Foo(T)
         class Bar(U)
@@ -378,7 +378,7 @@ describe "Visibility modifiers" do
       )) { int32 }
   end
 
-  it "gives correct error on unknown call (#2838)" do
+  it("gives correct error on unknown call (#2838)") do
     assert_error %(
       private foo
       ),

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -1,33 +1,33 @@
 require "../../spec_helper"
 
-describe "Semantic: while" do
-  it "types while" do
+describe("Semantic: while") do
+  it("types while") do
     assert_type("while 1; 1; end") { nil_type }
   end
 
-  it "types while with break without value" do
+  it("types while with break without value") do
     assert_type("while true; break; end") { nil_type }
   end
 
-  it "types while with break with value" do
+  it("types while with break with value") do
     assert_type("while true; break 1; end") { nil_type }
   end
 
-  it "reports break cannot be used outside a while" do
+  it("reports break cannot be used outside a while") do
     assert_error "break",
       "Invalid break"
   end
 
-  it "types while true as NoReturn" do
+  it("types while true as NoReturn") do
     assert_type("while true; end") { no_return }
   end
 
-  it "reports next cannot be used outside a while" do
+  it("reports next cannot be used outside a while") do
     assert_error "next",
       "Invalid next"
   end
 
-  it "uses var type inside while if endless loop" do
+  it("uses var type inside while if endless loop") do
     assert_type(%(
       a = nil
       while true
@@ -38,7 +38,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "uses var type inside while if endless loop (2)" do
+  it("uses var type inside while if endless loop (2)") do
     assert_type(%(
       while true
         a = 1
@@ -48,7 +48,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "marks variable as nil if breaking before assigning to it in an endless loop" do
+  it("marks variable as nil if breaking before assigning to it in an endless loop") do
     assert_type(%(
       a = nil
       while true
@@ -59,7 +59,7 @@ describe "Semantic: while" do
       )) { nilable int32 }
   end
 
-  it "marks variable as nil if breaking before assigning to it in an endless loop (2)" do
+  it("marks variable as nil if breaking before assigning to it in an endless loop (2)") do
     assert_type(%(
       while true
         break if 1 == 2
@@ -69,7 +69,7 @@ describe "Semantic: while" do
       )) { nilable int32 }
   end
 
-  it "types while with && (#1425)" do
+  it("types while with && (#1425)") do
     assert_type(%(
       a = 1
       while a.is_a?(Int32) && (1 == 1)
@@ -79,7 +79,7 @@ describe "Semantic: while" do
       )) { nilable int32 }
   end
 
-  it "types while with assignment" do
+  it("types while with assignment") do
     assert_type(%(
       while a = 1
         break
@@ -88,7 +88,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "types while with assignment and &&" do
+  it("types while with assignment and &&") do
     assert_type(%(
       while (a = 1) && (1 == 1)
         break
@@ -97,7 +97,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "types while with assignment and call" do
+  it("types while with assignment and call") do
     assert_type(%(
       while (a = 1) > 0
         break
@@ -106,7 +106,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "doesn't modify var's type before while" do
+  it("doesn't modify var's type before while") do
     assert_type(%(
       x = 'x'
       x.ord
@@ -117,7 +117,7 @@ describe "Semantic: while" do
       )) { union_of(int32, char) }
   end
 
-  it "restricts type after while (#4242)" do
+  it("restricts type after while (#4242)") do
     assert_type(%(
       a = nil
       while a.nil?
@@ -127,7 +127,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "restricts type after while with not (#4242)" do
+  it("restricts type after while with not (#4242)") do
     assert_type(%(
       a = nil
       while !a
@@ -137,7 +137,7 @@ describe "Semantic: while" do
       )) { int32 }
   end
 
-  it "restricts type after while with not and and (#4242)" do
+  it("restricts type after while with not and and (#4242)") do
     assert_type(%(
       a = nil
       b = nil
@@ -149,7 +149,7 @@ describe "Semantic: while" do
       )) { tuple_of [int32, char] }
   end
 
-  it "doesn't restrict type after while if there's a break (#4242)" do
+  it("doesn't restrict type after while if there's a break (#4242)") do
     assert_type(%(
       a = nil
       while a.nil?

--- a/spec/compiler/semantic/yield_with_scope_spec.cr
+++ b/spec/compiler/semantic/yield_with_scope_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
-describe "Semantic: yield with scope" do
-  it "infer type of empty block body" do
+describe("Semantic: yield with scope") do
+  it("infer type of empty block body") do
     assert_type("
       def foo; with 1 yield; end
 
@@ -10,7 +10,7 @@ describe "Semantic: yield with scope" do
     ") { nil_type }
   end
 
-  it "infer type of block body" do
+  it("infer type of block body") do
     input = parse "
       def foo; with 1 yield; end
 
@@ -25,7 +25,7 @@ describe "Semantic: yield with scope" do
     assign.target.type.should eq(mod.int32)
   end
 
-  it "infer type of block body with yield scope" do
+  it("infer type of block body with yield scope") do
     input = parse %(
       require "primitives"
 
@@ -40,7 +40,7 @@ describe "Semantic: yield with scope" do
     input.last.as(Call).block.not_nil!.body.type.should eq(mod.int64)
   end
 
-  it "infer type of block body with yield scope and arguments" do
+  it("infer type of block body with yield scope and arguments") do
     input = parse %(
       require "primitives"
 
@@ -55,7 +55,7 @@ describe "Semantic: yield with scope" do
     input.last.as(Call).block.not_nil!.body.type.should eq(mod.float64)
   end
 
-  it "passes #229" do
+  it("passes #229") do
     assert_type(%(
       class Foo
         def foo
@@ -74,7 +74,7 @@ describe "Semantic: yield with scope" do
       )) { int32 }
   end
 
-  it "invokes nested calls" do
+  it("invokes nested calls") do
     assert_type(%(
       class Foo
         def x
@@ -101,7 +101,7 @@ describe "Semantic: yield with scope" do
       )) { int32 }
   end
 
-  it "finds macro" do
+  it("finds macro") do
     assert_type(%(
       class Foo
         def x
@@ -124,7 +124,7 @@ describe "Semantic: yield with scope" do
       )) { int32 }
   end
 
-  it "errors if using instance variable at top level" do
+  it("errors if using instance variable at top level") do
     assert_error %(
       class Foo
         def foo
@@ -139,7 +139,7 @@ describe "Semantic: yield with scope" do
       "can't use instance variables at the top level"
   end
 
-  it "uses instance variable of enclosing scope" do
+  it("uses instance variable of enclosing scope") do
     assert_type(%(
       class Foo
         def foo
@@ -163,7 +163,7 @@ describe "Semantic: yield with scope" do
       )) { int32 }
   end
 
-  it "uses method of enclosing scope" do
+  it("uses method of enclosing scope") do
     assert_type(%(
       class Foo
         def foo

--- a/spec/manual/badssl_spec.cr
+++ b/spec/manual/badssl_spec.cr
@@ -13,7 +13,7 @@ ensure
   socket.close if socket
 end
 
-describe "OpenSSL::SSL::Context has sane client defaults" do
+describe("OpenSSL::SSL::Context has sane client defaults") do
   {
     "expired.badssl.com",
     "wrong.host.badssl.com",
@@ -24,13 +24,13 @@ describe "OpenSSL::SSL::Context has sane client defaults" do
     "dsdtestprovider.badssl.com",
     "subdomain.preloaded-hsts.badssl.com",
   }.each do |host|
-    it "shouldn't connect to #{host}" do
+    it("shouldn't connect to #{host}") do
       expect_raises(OpenSSL::SSL::Error) do
         connect_to(host)
       end
     end
 
-    it "should connect to #{host} with verification disabled" do
+    it("should connect to #{host} with verification disabled") do
       context = OpenSSL::SSL::Context::Client.new
       context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
       connect_to(host, context).should be_true
@@ -42,13 +42,13 @@ describe "OpenSSL::SSL::Context has sane client defaults" do
     "10000-sans.badssl.com",
     "dh480.badssl.com",
   }.each do |host|
-    it "shouldn't connect to #{host}" do
+    it("shouldn't connect to #{host}") do
       expect_raises(OpenSSL::SSL::Error) do
         connect_to(host)
       end
     end
 
-    it "shouldn't connect to #{host} with verification disabled" do
+    it("shouldn't connect to #{host} with verification disabled") do
       context = OpenSSL::SSL::Context::Client.new
       context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
 
@@ -81,7 +81,7 @@ describe "OpenSSL::SSL::Context has sane client defaults" do
     "upgrade.badssl.com",
     "preloaded-hsts.badssl.com",
   }.each do |host|
-    it "should connect to #{host} successfully" do
+    it("should connect to #{host} successfully") do
       connect_to(host).should be_true
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -103,7 +103,7 @@ end
 def assert_error(str, message, inject_primitives = true)
   str = inject_primitives(str) if inject_primitives
   nodes = parse str
-  expect_raises TypeException, message do
+  expect_raises(TypeException, message) do
     semantic nodes
   end
 end

--- a/spec/std/adler32_spec.cr
+++ b/spec/std/adler32_spec.cr
@@ -1,13 +1,13 @@
 require "spec"
 require "adler32"
 
-describe Adler32 do
-  it "should be able to calculate adler32" do
+describe(Adler32) do
+  it("should be able to calculate adler32") do
     adler = Adler32.checksum("foo").to_s(16)
     adler.should eq("2820145")
   end
 
-  it "should be able to calculate adler32 combined" do
+  it("should be able to calculate adler32 combined") do
     adler1 = Adler32.checksum("hello")
     adler2 = Adler32.checksum(" world!")
     combined = Adler32.combine(adler1, adler2, " world!".size)

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -10,14 +10,14 @@ private class BadSortingClass
   end
 end
 
-describe "Array" do
-  describe "new" do
-    it "creates with default value" do
+describe("Array") do
+  describe("new") do
+    it("creates with default value") do
       ary = Array.new(5, 3)
       ary.should eq([3, 3, 3, 3, 3])
     end
 
-    it "creates with default value in block" do
+    it("creates with default value in block") do
       ary = Array.new(5) { |i| i * 2 }
       ary.should eq([0, 2, 4, 6, 8])
 
@@ -25,32 +25,32 @@ describe "Array" do
       ary.should eq([0, 2, 4, 6, 8])
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       expect_raises(ArgumentError, "Negative array size") do
         Array.new(-1, 3)
       end
     end
 
-    it "raises on negative capacity" do
+    it("raises on negative capacity") do
       expect_raises(ArgumentError, "Negative array size") do
         Array(Int32).new(-1)
       end
     end
   end
 
-  describe "==" do
-    it "compares empty" do
+  describe("==") do
+    it("compares empty") do
       ([] of Int32).should eq([] of Int32)
       [1].should_not eq([] of Int32)
       ([] of Int32).should_not eq([1])
     end
 
-    it "compares elements" do
+    it("compares elements") do
       [1, 2, 3].should eq([1, 2, 3])
       [1, 2, 3].should_not eq([3, 2, 1])
     end
 
-    it "compares other" do
+    it("compares other") do
       a = [1, 2, 3]
       b = [1, 2, 3]
       c = [1, 2, 3, 4]
@@ -61,7 +61,7 @@ describe "Array" do
     end
   end
 
-  it "does &" do
+  it("does &") do
     ([1, 2, 3] & [] of Int32).should eq([] of Int32)
     ([] of Int32 & [1, 2, 3]).should eq([] of Int32)
     ([1, 2, 3] & [3, 2, 4]).should eq([2, 3])
@@ -69,12 +69,12 @@ describe "Array" do
     ([1, 2, 3, 1, 2, 3, nil, nil] & [3, 2, 4, 3, 2, 4, nil]).should eq([2, 3, nil])
   end
 
-  it "does |" do
+  it("does |") do
     ([1, 2, 3] | [5, 3, 2, 4]).should eq([1, 2, 3, 5, 4])
     ([1, 1, 2, 3, 3] | [4, 5, 5, 6]).should eq([1, 2, 3, 4, 5, 6])
   end
 
-  it "does +" do
+  it("does +") do
     a = [1, 2, 3]
     b = [4, 5]
     c = a + b
@@ -82,160 +82,160 @@ describe "Array" do
     0.upto(4) { |i| c[i].should eq(i + 1) }
   end
 
-  it "does + with empty tuple converted to array (#909)" do
+  it("does + with empty tuple converted to array (#909)") do
     ([1, 2] + Tuple.new.to_a).should eq([1, 2])
     (Tuple.new.to_a + [1, 2]).should eq([1, 2])
   end
 
-  describe "-" do
-    it "does it" do
+  describe("-") do
+    it("does it") do
       ([1, 2, 3, 4, 5] - [4, 2]).should eq([1, 3, 5])
     end
 
-    it "does with larger array coming second" do
+    it("does with larger array coming second") do
       ([4, 2] - [1, 2, 3]).should eq([4])
     end
   end
 
-  it "does *" do
+  it("does *") do
     ([1, 2, 3] * 3).should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
   end
 
-  describe "[]" do
-    it "gets on positive index" do
+  describe("[]") do
+    it("gets on positive index") do
       [1, 2, 3][1].should eq(2)
     end
 
-    it "gets on negative index" do
+    it("gets on negative index") do
       [1, 2, 3][-1].should eq(3)
     end
 
-    it "gets on inclusive range" do
+    it("gets on inclusive range") do
       [1, 2, 3, 4, 5, 6][1..4].should eq([2, 3, 4, 5])
     end
 
-    it "gets on inclusive range with negative indices" do
+    it("gets on inclusive range with negative indices") do
       [1, 2, 3, 4, 5, 6][-5..-2].should eq([2, 3, 4, 5])
     end
 
-    it "gets on exclusive range" do
+    it("gets on exclusive range") do
       [1, 2, 3, 4, 5, 6][1...4].should eq([2, 3, 4])
     end
 
-    it "gets on exclusive range with negative indices" do
+    it("gets on exclusive range with negative indices") do
       [1, 2, 3, 4, 5, 6][-5...-2].should eq([2, 3, 4])
     end
 
-    it "gets on range with start higher than end" do
+    it("gets on range with start higher than end") do
       [1, 2, 3][2..1].should eq([] of Int32)
       [1, 2, 3][3..1].should eq([] of Int32)
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         [1, 2, 3][4..1]
       end
     end
 
-    it "gets on range with start higher than negative end" do
+    it("gets on range with start higher than negative end") do
       [1, 2, 3][1..-1].should eq([2, 3] of Int32)
       [1, 2, 3][2..-2].should eq([] of Int32)
     end
 
-    it "raises on index out of bounds with range" do
-      expect_raises IndexError do
+    it("raises on index out of bounds with range") do
+      expect_raises(IndexError) do
         [1, 2, 3][4..6]
       end
     end
 
-    it "gets with start and count" do
+    it("gets with start and count") do
       [1, 2, 3, 4, 5, 6][1, 3].should eq([2, 3, 4])
     end
 
-    it "gets with start and count exceeding size" do
+    it("gets with start and count exceeding size") do
       [1, 2, 3][1, 3].should eq([2, 3])
     end
 
-    it "gets with negative start" do
+    it("gets with negative start") do
       [1, 2, 3, 4, 5, 6][-4, 2].should eq([3, 4])
     end
 
-    it "raises on index out of bounds with start and count" do
-      expect_raises IndexError do
+    it("raises on index out of bounds with start and count") do
+      expect_raises(IndexError) do
         [1, 2, 3][4, 0]
       end
     end
 
-    it "raises on negative count" do
-      expect_raises ArgumentError do
+    it("raises on negative count") do
+      expect_raises(ArgumentError) do
         [1, 2, 3][3, -1]
       end
     end
 
-    it "raises on index out of bounds" do
-      expect_raises IndexError do
+    it("raises on index out of bounds") do
+      expect_raises(IndexError) do
         [1, 2, 3][-4, 2]
       end
     end
 
-    it "raises on negative count" do
-      expect_raises ArgumentError, /Negative count: -1/ do
+    it("raises on negative count") do
+      expect_raises(ArgumentError, /Negative count: -1/) do
         [1, 2, 3][1, -1]
       end
     end
 
-    it "raises on negative count on empty Array" do
-      expect_raises ArgumentError, /Negative count: -1/ do
+    it("raises on negative count on empty Array") do
+      expect_raises(ArgumentError, /Negative count: -1/) do
         Array(Int32).new[0, -1]
       end
     end
 
-    it "gets 0, 0 on empty array" do
+    it("gets 0, 0 on empty array") do
       a = [] of Int32
       a[0, 0].should eq(a)
     end
 
-    it "gets 0 ... 0 on empty array" do
+    it("gets 0 ... 0 on empty array") do
       a = [] of Int32
       a[0..0].should eq(a)
     end
 
-    it "gets nilable" do
+    it("gets nilable") do
       [1, 2, 3][2]?.should eq(3)
       [1, 2, 3][3]?.should be_nil
     end
 
-    it "same access by at" do
+    it("same access by at") do
       [1, 2, 3][1].should eq([1, 2, 3].at(1))
     end
 
-    it "doesn't exceed limits" do
+    it("doesn't exceed limits") do
       [1][0..3].should eq([1])
     end
 
-    it "returns empty if at end" do
+    it("returns empty if at end") do
       [1][1, 0].should eq([] of Int32)
       [1][1, 10].should eq([] of Int32)
     end
 
-    it "raises on too negative left bound" do
-      expect_raises IndexError do
+    it("raises on too negative left bound") do
+      expect_raises(IndexError) do
         [1, 2, 3][-4..0]
       end
     end
   end
 
-  describe "[]=" do
-    it "sets on positive index" do
+  describe("[]=") do
+    it("sets on positive index") do
       a = [1, 2, 3]
       a[1] = 4
       a[1].should eq(4)
     end
 
-    it "sets on negative index" do
+    it("sets on negative index") do
       a = [1, 2, 3]
       a[-1] = 4
       a[2].should eq(4)
     end
 
-    it "replaces a subrange with a single value" do
+    it("replaces a subrange with a single value") do
       a = [1, 2, 3, 4, 5]
       a[1, 3] = 6
       a.should eq([1, 6, 5])
@@ -260,7 +260,7 @@ describe "Array" do
       a[1, 3] = 6
       a.should eq([1, 6, 5, 6, 7, 8])
 
-      expect_raises ArgumentError, "Negative count" do
+      expect_raises(ArgumentError, "Negative count") do
         [1, 2, 3][0, -1]
       end
 
@@ -277,7 +277,7 @@ describe "Array" do
       a.should eq([1, 6, 2, 3, 4, 5])
     end
 
-    it "replaces a subrange with an array" do
+    it("replaces a subrange with an array") do
       a = [1, 2, 3, 4, 5]
       a[1, 3] = [6, 7, 8]
       a.should eq([1, 6, 7, 8, 5])
@@ -304,28 +304,28 @@ describe "Array" do
     end
   end
 
-  describe "values_at" do
-    it "returns the given indexes" do
+  describe("values_at") do
+    it("returns the given indexes") do
       ["a", "b", "c", "d"].values_at(1, 0, 2).should eq({"b", "a", "c"})
     end
 
-    it "raises when passed an invalid index" do
-      expect_raises IndexError do
+    it("raises when passed an invalid index") do
+      expect_raises(IndexError) do
         ["a"].values_at(10)
       end
     end
 
-    it "works with mixed types" do
+    it("works with mixed types") do
       [1, "a", 1.0, :a].values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
     end
   end
 
-  it "find the element by using binary search" do
+  it("find the element by using binary search") do
     [2, 5, 7, 10].bsearch { |x| x >= 4 }.should eq 5
     [2, 5, 7, 10].bsearch { |x| x > 10 }.should be_nil
   end
 
-  it "find the index by using binary search" do
+  it("find the index by using binary search") do
     [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 }.should eq 1
     [2, 5, 7, 10].bsearch_index { |x, i| x > 10 }.should be_nil
 
@@ -333,13 +333,13 @@ describe "Array" do
     [2, 5, 7, 10].bsearch_index { |x, i| i > 3 }.should be_nil
   end
 
-  it "does clear" do
+  it("does clear") do
     a = [1, 2, 3]
     a.clear
     a.should eq([] of Int32)
   end
 
-  it "does clone" do
+  it("does clone") do
     x = {1 => 2}
     a = [x]
     b = a.clone
@@ -348,46 +348,46 @@ describe "Array" do
     a[0].should_not be(b[0])
   end
 
-  it "does compact" do
+  it("does compact") do
     a = [1, nil, 2, nil, 3]
     b = a.compact.should eq([1, 2, 3])
     a.should eq([1, nil, 2, nil, 3])
   end
 
-  describe "compact!" do
-    it "returns true if removed" do
+  describe("compact!") do
+    it("returns true if removed") do
       a = [1, nil, 2, nil, 3]
       b = a.compact!.should be_true
       a.should eq([1, 2, 3])
     end
 
-    it "returns false if not removed" do
+    it("returns false if not removed") do
       a = [1]
       b = a.compact!.should be_false
       a.should eq([1])
     end
   end
 
-  describe "concat" do
-    it "concats small arrays" do
+  describe("concat") do
+    it("concats small arrays") do
       a = [1, 2, 3]
       a.concat([4, 5, 6])
       a.should eq([1, 2, 3, 4, 5, 6])
     end
 
-    it "concats large arrays" do
+    it("concats large arrays") do
       a = [1, 2, 3]
       a.concat((4..1000).to_a)
       a.should eq((1..1000).to_a)
     end
 
-    it "concats enumerable" do
+    it("concats enumerable") do
       a = [1, 2, 3]
       a.concat((4..1000))
       a.should eq((1..1000).to_a)
     end
 
-    it "concats enumerable to empty array (#2047)" do
+    it("concats enumerable to empty array (#2047)") do
       a = [] of Int32
       a.concat(1..1)
       a.@capacity.should eq(3)
@@ -397,35 +397,35 @@ describe "Array" do
       a.@capacity.should eq(6)
     end
 
-    it "concats a union of arrays" do
+    it("concats a union of arrays") do
       a = [1, '2']
       a.concat([3] || ['4'])
       a.should eq([1, '2', 3])
     end
   end
 
-  describe "delete" do
-    it "deletes many" do
+  describe("delete") do
+    it("deletes many") do
       a = [1, 2, 3, 1, 2, 3]
       a.delete(2).should eq(2)
       a.should eq([1, 3, 1, 3])
     end
 
-    it "delete not found" do
+    it("delete not found") do
       a = [1, 2]
       a.delete(4).should be_nil
       a.should eq([1, 2])
     end
   end
 
-  describe "delete_at" do
-    it "deletes positive index" do
+  describe("delete_at") do
+    it("deletes positive index") do
       a = [1, 2, 3, 4]
       a.delete_at(1).should eq(2)
       a.should eq([1, 3, 4])
     end
 
-    it "deletes use range" do
+    it("deletes use range") do
       a = [1, 2, 3]
       a.delete_at(1).should eq(2)
       a.should eq([1, 3])
@@ -456,7 +456,7 @@ describe "Array" do
       a.should eq([1, 4, 5, 6, 7])
     end
 
-    it "deletes with index and count" do
+    it("deletes with index and count") do
       a = [1, 2, 3, 4, 5]
       a.delete_at(1, 2)
       a.should eq([1, 4, 5])
@@ -466,7 +466,7 @@ describe "Array" do
       a.should eq([1, 4, 5, 6, 7])
     end
 
-    it "returns empty if at end" do
+    it("returns empty if at end") do
       a = [1]
       a.delete_at(1, 0).should eq([] of Int32)
       a.delete_at(1, 10).should eq([] of Int32)
@@ -475,29 +475,29 @@ describe "Array" do
       a.should eq([1])
     end
 
-    it "deletes negative index" do
+    it("deletes negative index") do
       a = [1, 2, 3, 4]
       a.delete_at(-3).should eq(2)
       a.should eq([1, 3, 4])
     end
 
-    it "deletes out of bounds" do
-      expect_raises IndexError do
+    it("deletes out of bounds") do
+      expect_raises(IndexError) do
         [1].delete_at(2)
       end
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         [1].delete_at(2, 1)
       end
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         [1].delete_at(2..3)
       end
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         [1].delete_at(-2..-1)
       end
     end
   end
 
-  it "does dup" do
+  it("does dup") do
     x = {1 => 2}
     a = [x]
     b = a.dup
@@ -508,24 +508,24 @@ describe "Array" do
     a.should eq([x])
   end
 
-  it "does each_index" do
+  it("does each_index") do
     a = [1, 1, 1]
     b = 0
     a.each_index { |i| b += i }.should be_nil
     b.should eq(3)
   end
 
-  describe "empty" do
-    it "is empty" do
+  describe("empty") do
+    it("is empty") do
       ([] of Int32).empty?.should be_true
     end
 
-    it "is not empty" do
+    it("is not empty") do
       [1].empty?.should be_false
     end
   end
 
-  it "does equals? with custom block" do
+  it("does equals? with custom block") do
     a = [1, 3, 2]
     b = [3, 9, 4]
     c = [5, 7, 3]
@@ -536,56 +536,56 @@ describe "Array" do
     a.equals?(d, &f).should be_false
   end
 
-  describe "fill" do
-    it "replaces all values" do
+  describe("fill") do
+    it("replaces all values") do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'x']
       a.fill('x').should eq(expected)
     end
 
-    it "replaces only values between index and size" do
+    it("replaces only values between index and size") do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', 0, 2).should eq(expected)
     end
 
-    it "replaces only values between index and size (2)" do
+    it("replaces only values between index and size (2)") do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', 1, 2).should eq(expected)
     end
 
-    it "replaces all values from index onwards" do
+    it("replaces all values from index onwards") do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', -2).should eq(expected)
     end
 
-    it "raises when given big negative number (#4539)" do
+    it("raises when given big negative number (#4539)") do
       expect_raises(IndexError) do
         ['a', 'b', 'c'].fill('x', -4)
       end
     end
 
-    it "replaces only values between negative index and size" do
+    it("replaces only values between negative index and size") do
       a = ['a', 'b', 'c']
       expected = ['a', 'b', 'x']
       a.fill('x', -1, 1).should eq(expected)
     end
 
-    it "raises when given big negative number in from/count (#4539)" do
+    it("raises when given big negative number in from/count (#4539)") do
       expect_raises(IndexError) do
         ['a', 'b', 'c'].fill('x', -4, 1)
       end
     end
 
-    it "replaces only values in range" do
+    it("replaces only values in range") do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', -3..1).should eq(expected)
     end
 
-    it "works with a block" do
+    it("works with a block") do
       a = [3, 6, 9]
       a.clone.fill { 0 }.should eq([0, 0, 0])
       a.clone.fill { |i| i }.should eq([0, 1, 2])
@@ -595,19 +595,19 @@ describe "Array" do
     end
   end
 
-  describe "first" do
-    it "gets first when non empty" do
+  describe("first") do
+    it("gets first when non empty") do
       a = [1, 2, 3]
       a.first.should eq(1)
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         ([] of Int32).first
       end
     end
 
-    it "returns a sub array with given number of elements" do
+    it("returns a sub array with given number of elements") do
       arr = [1, 2, 3]
       arr.first(0).should eq([] of Int32)
       arr.first(1).should eq [1]
@@ -617,103 +617,103 @@ describe "Array" do
     end
   end
 
-  describe "first?" do
-    it "gets first? when non empty" do
+  describe("first?") do
+    it("gets first? when non empty") do
       a = [1, 2, 3]
       a.first?.should eq(1)
     end
 
-    it "gives nil when empty" do
+    it("gives nil when empty") do
       ([] of Int32).first?.should be_nil
     end
   end
 
-  it "does hash" do
+  it("does hash") do
     a = [1, 2, [3]]
     b = [1, 2, [3]]
     a.hash.should eq(b.hash)
   end
 
-  describe "index" do
-    it "performs without a block" do
+  describe("index") do
+    it("performs without a block") do
       a = [1, 2, 3]
       a.index(3).should eq(2)
       a.index(4).should be_nil
     end
 
-    it "performs without a block and offset" do
+    it("performs without a block and offset") do
       a = [1, 2, 3, 1, 2, 3]
       a.index(3, offset: 3).should eq(5)
       a.index(3, offset: -3).should eq(5)
     end
 
-    it "performs with a block" do
+    it("performs with a block") do
       a = [1, 2, 3]
       a.index { |i| i > 1 }.should eq(1)
       a.index { |i| i > 3 }.should be_nil
     end
 
-    it "performs with a block and offset" do
+    it("performs with a block and offset") do
       a = [1, 2, 3, 1, 2, 3]
       a.index(offset: 3) { |i| i > 1 }.should eq(4)
       a.index(offset: -3) { |i| i > 1 }.should eq(4)
     end
 
-    it "raises if out of bounds" do
-      expect_raises IndexError do
+    it("raises if out of bounds") do
+      expect_raises(IndexError) do
         [1, 2, 3][4]
       end
     end
   end
 
-  describe "insert" do
-    it "inserts with positive index" do
+  describe("insert") do
+    it("inserts with positive index") do
       a = [1, 3, 4]
       expected = [1, 2, 3, 4]
       a.insert(1, 2).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts with negative index" do
+    it("inserts with negative index") do
       a = [1, 2, 3]
       expected = [1, 2, 3, 4]
       a.insert(-1, 4).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts with negative index (2)" do
+    it("inserts with negative index (2)") do
       a = [1, 2, 3]
       expected = [4, 1, 2, 3]
       a.insert(-4, 4).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts out of range" do
+    it("inserts out of range") do
       a = [1, 3, 4]
 
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.insert(4, 1)
       end
     end
   end
 
-  describe "inspect" do
+  describe("inspect") do
     it { [1, 2, 3].inspect.should eq("[1, 2, 3]") }
   end
 
-  describe "last" do
-    it "gets last when non empty" do
+  describe("last") do
+    it("gets last when non empty") do
       a = [1, 2, 3]
       a.last.should eq(3)
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         ([] of Int32).last
       end
     end
 
-    it "returns a sub array with given number of elements" do
+    it("returns a sub array with given number of elements") do
       arr = [1, 2, 3]
       arr.last(0).should eq([] of Int32)
       arr.last(1).should eq [3]
@@ -723,138 +723,138 @@ describe "Array" do
     end
   end
 
-  describe "size" do
-    it "has size 0" do
+  describe("size") do
+    it("has size 0") do
       ([] of Int32).size.should eq(0)
     end
 
-    it "has size 2" do
+    it("has size 2") do
       [1, 2].size.should eq(2)
     end
   end
 
-  it "does map" do
+  it("does map") do
     a = [1, 2, 3]
     a.map { |x| x * 2 }.should eq([2, 4, 6])
     a.should eq([1, 2, 3])
   end
 
-  it "does map!" do
+  it("does map!") do
     a = [1, 2, 3]
     a.map! { |x| x * 2 }
     a.should eq([2, 4, 6])
   end
 
-  describe "pop" do
-    it "pops when non empty" do
+  describe("pop") do
+    it("pops when non empty") do
       a = [1, 2, 3]
       a.pop.should eq(3)
       a.should eq([1, 2])
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         ([] of Int32).pop
       end
     end
 
-    it "pops many elements" do
+    it("pops many elements") do
       a = [1, 2, 3, 4, 5]
       b = a.pop(3)
       b.should eq([3, 4, 5])
       a.should eq([1, 2])
     end
 
-    it "pops more elements that what is available" do
+    it("pops more elements that what is available") do
       a = [1, 2, 3, 4, 5]
       b = a.pop(10)
       b.should eq([1, 2, 3, 4, 5])
       a.should eq([] of Int32)
     end
 
-    it "pops negative count raises" do
+    it("pops negative count raises") do
       a = [1, 2]
-      expect_raises ArgumentError do
+      expect_raises(ArgumentError) do
         a.pop(-1)
       end
     end
   end
 
-  it "does product with block" do
+  it("does product with block") do
     r = [] of Int32
     [1, 2, 3].product([5, 6]) { |a, b| r << a; r << b }
     r.should eq([1, 5, 1, 6, 2, 5, 2, 6, 3, 5, 3, 6])
   end
 
-  it "does product without block" do
+  it("does product without block") do
     [1, 2, 3].product(['a', 'b']).should eq([{1, 'a'}, {1, 'b'}, {2, 'a'}, {2, 'b'}, {3, 'a'}, {3, 'b'}])
   end
 
-  describe "push" do
-    it "pushes one element" do
+  describe("push") do
+    it("pushes one element") do
       a = [1, 2]
       a.push(3).should be(a)
       a.should eq [1, 2, 3]
     end
 
-    it "pushes multiple elements" do
+    it("pushes multiple elements") do
       a = [1, 2]
       a.push(3, 4).should be(a)
       a.should eq [1, 2, 3, 4]
     end
 
-    it "pushes multiple elements to an empty array" do
+    it("pushes multiple elements to an empty array") do
       a = [] of Int32
       a.push(1, 2, 3).should be(a)
       a.should eq([1, 2, 3])
     end
 
-    it "has the << alias" do
+    it("has the << alias") do
       a = [1, 2]
       a << 3
       a.should eq [1, 2, 3]
     end
   end
 
-  it "does replace" do
+  it("does replace") do
     a = [1, 2, 3]
     b = [1]
     b.replace a
     b.should eq(a)
   end
 
-  it "does reverse with an odd number of elements" do
+  it("does reverse with an odd number of elements") do
     a = [1, 2, 3]
     a.reverse.should eq([3, 2, 1])
     a.should eq([1, 2, 3])
   end
 
-  it "does reverse with an even number of elements" do
+  it("does reverse with an even number of elements") do
     a = [1, 2, 3, 4]
     a.reverse.should eq([4, 3, 2, 1])
     a.should eq([1, 2, 3, 4])
   end
 
-  it "does reverse! with an odd number of elements" do
+  it("does reverse! with an odd number of elements") do
     a = [1, 2, 3, 4, 5]
     a.reverse!
     a.should eq([5, 4, 3, 2, 1])
   end
 
-  it "does reverse! with an even number of elements" do
+  it("does reverse! with an even number of elements") do
     a = [1, 2, 3, 4, 5, 6]
     a.reverse!
     a.should eq([6, 5, 4, 3, 2, 1])
   end
 
-  describe "rindex" do
-    it "performs without a block" do
+  describe("rindex") do
+    it("performs without a block") do
       a = [1, 2, 3, 4, 5, 3, 6]
       a.rindex(3).should eq(5)
       a.rindex(7).should be_nil
     end
 
-    it "performs without a block and an offset" do
+    it("performs without a block and an offset") do
       a = [1, 2, 3, 4, 5, 3, 6]
       a.rindex(3, offset: 4).should eq(2)
       a.rindex(6, offset: 4).should be_nil
@@ -863,13 +863,13 @@ describe "Array" do
       a.rindex(3, offset: -100).should be_nil
     end
 
-    it "performs with a block" do
+    it("performs with a block") do
       a = [1, 2, 3, 4, 5, 3, 6]
       a.rindex { |i| i > 1 }.should eq(6)
       a.rindex { |i| i > 6 }.should be_nil
     end
 
-    it "performs with a block and offset" do
+    it("performs with a block and offset") do
       a = [1, 2, 3, 4, 5, 3, 6]
       a.rindex { |i| i > 1 }.should eq(6)
       a.rindex { |i| i > 6 }.should be_nil
@@ -878,30 +878,30 @@ describe "Array" do
     end
   end
 
-  describe "sample" do
-    it "sample" do
+  describe("sample") do
+    it("sample") do
       [1].sample.should eq(1)
 
       x = [1, 2, 3].sample
       [1, 2, 3].includes?(x).should be_true
     end
 
-    it "sample with random" do
+    it("sample with random") do
       x = [1, 2, 3]
       x.sample(Random.new(1)).should eq(2)
     end
 
-    it "gets sample of negative count elements raises" do
-      expect_raises ArgumentError do
+    it("gets sample of negative count elements raises") do
+      expect_raises(ArgumentError) do
         [1].sample(-1)
       end
     end
 
-    it "gets sample of 0 elements" do
+    it("gets sample of 0 elements") do
       [1].sample(0).should eq([] of Int32)
     end
 
-    it "gets sample of 1 elements" do
+    it("gets sample of 1 elements") do
       [1].sample(1).should eq([1])
 
       x = [1, 2, 3].sample(1)
@@ -910,7 +910,7 @@ describe "Array" do
       [1, 2, 3].includes?(x).should be_true
     end
 
-    it "gets sample of k elements out of n" do
+    it("gets sample of k elements out of n") do
       a = [1, 2, 3, 4, 5]
       b = a.sample(3)
       set = Set.new(b)
@@ -921,7 +921,7 @@ describe "Array" do
       end
     end
 
-    it "gets sample of k elements out of n, where k > n" do
+    it("gets sample of k elements out of n, where k > n") do
       a = [1, 2, 3, 4, 5]
       b = a.sample(10)
       b.size.should eq(5)
@@ -933,57 +933,57 @@ describe "Array" do
       end
     end
 
-    it "gets sample of k elements out of n, with random" do
+    it("gets sample of k elements out of n, with random") do
       a = [1, 2, 3, 4, 5]
       b = a.sample(3, Random.new(1))
       b.should eq([4, 3, 1])
     end
   end
 
-  describe "shift" do
-    it "shifts when non empty" do
+  describe("shift") do
+    it("shifts when non empty") do
       a = [1, 2, 3]
       a.shift.should eq(1)
       a.should eq([2, 3])
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         ([] of Int32).shift
       end
     end
 
-    it "shifts many elements" do
+    it("shifts many elements") do
       a = [1, 2, 3, 4, 5]
       b = a.shift(3)
       b.should eq([1, 2, 3])
       a.should eq([4, 5])
     end
 
-    it "shifts more than what is available" do
+    it("shifts more than what is available") do
       a = [1, 2, 3, 4, 5]
       b = a.shift(10)
       b.should eq([1, 2, 3, 4, 5])
       a.should eq([] of Int32)
     end
 
-    it "shifts negative count raises" do
+    it("shifts negative count raises") do
       a = [1, 2]
-      expect_raises ArgumentError do
+      expect_raises(ArgumentError) do
         a.shift(-1)
       end
     end
   end
 
-  describe "shuffle" do
-    it "shuffle!" do
+  describe("shuffle") do
+    it("shuffle!") do
       a = [1, 2, 3]
       a.shuffle!
       b = [1, 2, 3]
       3.times { a.includes?(b.shift).should be_true }
     end
 
-    it "shuffle" do
+    it("shuffle") do
       a = [1, 2, 3]
       b = a.shuffle
       a.same?(b).should be_false
@@ -992,69 +992,69 @@ describe "Array" do
       3.times { b.includes?(a.shift).should be_true }
     end
 
-    it "shuffle! with random" do
+    it("shuffle! with random") do
       a = [1, 2, 3]
       a.shuffle!(Random.new(1))
       a.should eq([1, 3, 2])
     end
 
-    it "shuffle with random" do
+    it("shuffle with random") do
       a = [1, 2, 3]
       b = a.shuffle(Random.new(1))
       b.should eq([1, 3, 2])
     end
   end
 
-  describe "sort" do
-    it "sort without block" do
+  describe("sort") do
+    it("sort without block") do
       a = [3, 4, 1, 2, 5, 6]
       b = a.sort
       b.should eq([1, 2, 3, 4, 5, 6])
       a.should_not eq(b)
     end
 
-    it "sort with a block" do
+    it("sort with a block") do
       a = ["foo", "a", "hello"]
       b = a.sort { |x, y| x.size <=> y.size }
       b.should eq(["a", "foo", "hello"])
       a.should_not eq(b)
     end
 
-    it "doesn't crash on special situations" do
+    it("doesn't crash on special situations") do
       [1, 2, 3].sort { 1 }
       Array.new(10) { BadSortingClass.new }.sort
     end
   end
 
-  describe "sort!" do
-    it "sort! without block" do
+  describe("sort!") do
+    it("sort! without block") do
       a = [3, 4, 1, 2, 5, 6]
       a.sort!
       a.should eq([1, 2, 3, 4, 5, 6])
     end
 
-    it "sort! with a block" do
+    it("sort! with a block") do
       a = ["foo", "a", "hello"]
       a.sort! { |x, y| x.size <=> y.size }
       a.should eq(["a", "foo", "hello"])
     end
 
-    it "sorts with invalid block (#4379)" do
+    it("sorts with invalid block (#4379)") do
       a = [1] * 17
       b = a.sort { -1 }
       a.should eq(b)
     end
   end
 
-  describe "sort_by" do
-    it "sorts by" do
+  describe("sort_by") do
+    it("sorts by") do
       a = ["foo", "a", "hello"]
       b = a.sort_by &.size
       b.should eq(["a", "foo", "hello"])
       a.should_not eq(b)
     end
 
-    it "unpacks tuple" do
+    it("unpacks tuple") do
       a = [{"d", 4}, {"a", 1}, {"c", 3}, {"e", 5}, {"b", 2}]
       b = a.sort_by { |x, y| y }
       b.should eq([{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}, {"e", 5}])
@@ -1062,14 +1062,14 @@ describe "Array" do
     end
   end
 
-  describe "sort_by!" do
-    it "sorts by!" do
+  describe("sort_by!") do
+    it("sorts by!") do
       a = ["foo", "a", "hello"]
       a.sort_by! &.size
       a.should eq(["a", "foo", "hello"])
     end
 
-    it "calls given block exactly once for each element" do
+    it("calls given block exactly once for each element") do
       calls = Hash(String, Int32).new(0)
       a = ["foo", "a", "hello"]
       a.sort_by! { |e| calls[e] += 1; e.size }
@@ -1077,62 +1077,62 @@ describe "Array" do
     end
   end
 
-  describe "swap" do
-    it "swaps" do
+  describe("swap") do
+    it("swaps") do
       a = [1, 2, 3]
       a.swap(0, 2)
       a.should eq([3, 2, 1])
     end
 
-    it "swaps with negative indices" do
+    it("swaps with negative indices") do
       a = [1, 2, 3]
       a.swap(-3, -1)
       a.should eq([3, 2, 1])
     end
 
-    it "swaps but raises out of bounds on left" do
+    it("swaps but raises out of bounds on left") do
       a = [1, 2, 3]
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.swap(3, 0)
       end
     end
 
-    it "swaps but raises out of bounds on right" do
+    it("swaps but raises out of bounds on right") do
       a = [1, 2, 3]
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.swap(0, 3)
       end
     end
   end
 
-  describe "to_s" do
-    it "does to_s" do
+  describe("to_s") do
+    it("does to_s") do
       it { [1, 2, 3].to_s.should eq("[1, 2, 3]") }
     end
 
-    it "does with recursive" do
+    it("does with recursive") do
       ary = [] of RecursiveArray
       ary << ary
       ary.to_s.should eq("[[...]]")
     end
   end
 
-  describe "uniq" do
-    it "uniqs without block" do
+  describe("uniq") do
+    it("uniqs without block") do
       a = [1, 2, 2, 3, 1, 4, 5, 3]
       b = a.uniq
       b.should eq([1, 2, 3, 4, 5])
       a.same?(b).should be_false
     end
 
-    it "uniqs with block" do
+    it("uniqs with block") do
       a = [-1, 1, 0, 2, -2]
       b = a.uniq &.abs
       b.should eq([-1, 0, 2])
       a.same?(b).should be_false
     end
 
-    it "uniqs with true" do
+    it("uniqs with true") do
       a = [1, 2, 3]
       b = a.uniq { true }
       b.should eq([1])
@@ -1140,53 +1140,53 @@ describe "Array" do
     end
   end
 
-  describe "uniq!" do
-    it "uniqs without block" do
+  describe("uniq!") do
+    it("uniqs without block") do
       a = [1, 2, 2, 3, 1, 4, 5, 3]
       a.uniq!
       a.should eq([1, 2, 3, 4, 5])
     end
 
-    it "uniqs with block" do
+    it("uniqs with block") do
       a = [-1, 1, 0, 2, -2]
       a.uniq! &.abs
       a.should eq([-1, 0, 2])
     end
 
-    it "uniqs with true" do
+    it("uniqs with true") do
       a = [1, 2, 3]
       a.uniq! { true }
       a.should eq([1])
     end
   end
 
-  describe "unshift" do
-    it "unshifts one element" do
+  describe("unshift") do
+    it("unshifts one element") do
       a = [1, 2]
       a.unshift(3).should be(a)
       a.should eq [3, 1, 2]
     end
 
-    it "unshifts multiple elements" do
+    it("unshifts multiple elements") do
       a = [1, 2]
       a.unshift(3, 4).should be(a)
       a.should eq [3, 4, 1, 2]
     end
 
-    it "unshifts multiple elements to an empty array" do
+    it("unshifts multiple elements to an empty array") do
       a = [] of Int32
       a.unshift(1, 2, 3).should be(a)
       a.should eq([1, 2, 3])
     end
   end
 
-  it "does update" do
+  it("does update") do
     a = [1, 2, 3]
     a.update(1) { |x| x * 2 }
     a.should eq([1, 4, 3])
   end
 
-  it "does <=>" do
+  it("does <=>") do
     a = [1, 2, 3]
     b = [4, 5, 6]
     c = [1, 2]
@@ -1205,7 +1205,7 @@ describe "Array" do
     [[1, 2, 3], [4, 5], [8], [1, 2, 3, 4]].sort.should eq([[1, 2, 3], [1, 2, 3, 4], [4, 5], [8]])
   end
 
-  it "does each while modifying array" do
+  it("does each while modifying array") do
     a = [1, 2, 3]
     count = 0
     a.each do
@@ -1215,7 +1215,7 @@ describe "Array" do
     count.should eq(1)
   end
 
-  it "does each index while modifying array" do
+  it("does each index while modifying array") do
     a = [1, 2, 3]
     count = 0
     a.each_index do
@@ -1225,18 +1225,18 @@ describe "Array" do
     count.should eq(1)
   end
 
-  describe "zip" do
-    describe "when a block is provided" do
-      it "yields pairs of self's elements and passed array" do
+  describe("zip") do
+    describe("when a block is provided") do
+      it("yields pairs of self's elements and passed array") do
         a, b, r = [1, 2, 3], [4, 5, 6], ""
         a.zip(b) { |x, y| r += "#{x}:#{y}," }
         r.should eq("1:4,2:5,3:6,")
       end
     end
 
-    describe "when no block is provided" do
-      describe "and the arrays have different typed elements" do
-        it "returns an array of paired elements (tuples)" do
+    describe("when no block is provided") do
+      describe("and the arrays have different typed elements") do
+        it("returns an array of paired elements (tuples)") do
           a, b = [1, 2, 3], ["a", "b", "c"]
           r = a.zip(b)
           r.should eq([{1, "a"}, {2, "b"}, {3, "c"}])
@@ -1245,10 +1245,10 @@ describe "Array" do
     end
   end
 
-  describe "zip?" do
-    describe "when a block is provided" do
-      describe "and size of an arg is less than receiver" do
-        it "yields pairs of self's elements and passed array (with nil)" do
+  describe("zip?") do
+    describe("when a block is provided") do
+      describe("and size of an arg is less than receiver") do
+        it("yields pairs of self's elements and passed array (with nil)") do
           a, b, r = [1, 2, 3], [4, 5], ""
           a.zip?(b) { |x, y| r += "#{x}:#{y}," }
           r.should eq("1:4,2:5,3:,")
@@ -1256,10 +1256,10 @@ describe "Array" do
       end
     end
 
-    describe "when no block is provided" do
-      describe "and the arrays have different typed elements" do
-        describe "and size of an arg is less than receiver" do
-          it "returns an array of paired elements (tuples with nil)" do
+    describe("when no block is provided") do
+      describe("and the arrays have different typed elements") do
+        describe("and size of an arg is less than receiver") do
+          it("returns an array of paired elements (tuples with nil)") do
             a, b = [1, 2, 3], ["a", "b"]
             r = a.zip?(b)
             r.should eq([{1, "a"}, {2, "b"}, {3, nil}])
@@ -1269,14 +1269,14 @@ describe "Array" do
     end
   end
 
-  it "does compact_map" do
+  it("does compact_map") do
     a = [1, 2, 3, 4, 5]
     b = a.compact_map { |e| e.divisible_by?(2) ? e : nil }
     b.size.should eq(2)
     b.should eq([2, 4])
   end
 
-  it "does compact_map with false" do
+  it("does compact_map with false") do
     a = [1, 2, 3]
     b = a.compact_map do |e|
       case e
@@ -1289,7 +1289,7 @@ describe "Array" do
     b.should eq([1, false])
   end
 
-  it "builds from buffer" do
+  it("builds from buffer") do
     ary = Array(Int32).build(4) do |buffer|
       buffer[0] = 1
       buffer[1] = 2
@@ -1299,7 +1299,7 @@ describe "Array" do
     ary.should eq([1, 2])
   end
 
-  it "selects!" do
+  it("selects!") do
     ary1 = [1, 2, 3, 4, 5]
 
     ary2 = ary1.select! { |elem| elem % 2 == 0 }
@@ -1307,7 +1307,7 @@ describe "Array" do
     ary2.should be(ary1)
   end
 
-  it "returns nil when using select! and no changes were made" do
+  it("returns nil when using select! and no changes were made") do
     ary1 = [1, 2, 3, 4, 5]
 
     ary2 = ary1.select! { true }
@@ -1315,7 +1315,7 @@ describe "Array" do
     ary1.should eq([1, 2, 3, 4, 5])
   end
 
-  it "rejects!" do
+  it("rejects!") do
     ary1 = [1, 2, 3, 4, 5]
 
     ary2 = ary1.reject! { |elem| elem % 2 == 0 }
@@ -1323,7 +1323,7 @@ describe "Array" do
     ary2.should be(ary1)
   end
 
-  it "returns nil when using reject! and no changes were made" do
+  it("returns nil when using reject! and no changes were made") do
     ary1 = [1, 2, 3, 4, 5]
 
     ary2 = ary1.reject! { false }
@@ -1331,13 +1331,13 @@ describe "Array" do
     ary1.should eq([1, 2, 3, 4, 5])
   end
 
-  it "does map_with_index" do
+  it("does map_with_index") do
     ary = [1, 1, 2, 2]
     ary2 = ary.map_with_index { |e, i| e + i }
     ary2.should eq([1, 2, 4, 5])
   end
 
-  it "does map_with_index!" do
+  it("does map_with_index!") do
     ary = [0, 1, 2]
     ary2 = ary.map_with_index! { |e, i| i * 2 }
     ary[0].should eq(0)
@@ -1346,14 +1346,14 @@ describe "Array" do
     ary2.should be(ary)
   end
 
-  it "does + with different types (#568)" do
+  it("does + with different types (#568)") do
     a = [1, 2, 3]
     a += ["hello"]
     a.should eq([1, 2, 3, "hello"])
   end
 
-  describe "each iterator" do
-    it "does next" do
+  describe("each iterator") do
+    it("does next") do
       a = [1, 2, 3]
       iter = a.each
       iter.next.should eq(1)
@@ -1365,13 +1365,13 @@ describe "Array" do
       iter.next.should eq(1)
     end
 
-    it "cycles" do
+    it("cycles") do
       [1, 2, 3].cycle.first(8).join.should eq("12312312")
     end
   end
 
-  describe "each_index iterator" do
-    it "does next" do
+  describe("each_index iterator") do
+    it("does next") do
       a = [1, 2, 3]
       iter = a.each_index
       iter.next.should eq(0)
@@ -1384,8 +1384,8 @@ describe "Array" do
     end
   end
 
-  describe "reverse_each iterator" do
-    it "does next" do
+  describe("reverse_each iterator") do
+    it("does next") do
       a = [1, 2, 3]
       iter = a.reverse_each
       iter.next.should eq(3)
@@ -1398,8 +1398,8 @@ describe "Array" do
     end
   end
 
-  describe "cycle" do
-    it "cycles" do
+  describe("cycle") do
+    it("cycles") do
       a = [] of Int32
       [1, 2, 3].cycle do |x|
         a << x
@@ -1408,7 +1408,7 @@ describe "Array" do
       a.should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
     end
 
-    it "cycles N times" do
+    it("cycles N times") do
       a = [] of Int32
       [1, 2, 3].cycle(2) do |x|
         a << x
@@ -1416,23 +1416,23 @@ describe "Array" do
       a.should eq([1, 2, 3, 1, 2, 3])
     end
 
-    it "cycles with iterator" do
+    it("cycles with iterator") do
       [1, 2, 3].cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
     end
 
-    it "cycles with N and iterator" do
+    it("cycles with N and iterator") do
       [1, 2, 3].cycle(2).to_a.should eq([1, 2, 3, 1, 2, 3])
     end
   end
 
-  describe "transpose" do
-    it "transeposes elements" do
+  describe("transpose") do
+    it("transeposes elements") do
       [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])
       [[:a, :c, :e], [:b, :d, :f]].transpose.should eq([[:a, :b], [:c, :d], [:e, :f]])
       [[:a]].transpose.should eq([[:a]])
     end
 
-    it "transposes union of arrays" do
+    it("transposes union of arrays") do
       [[1, 2], [1.0, 2.0]].transpose.should eq([[1, 1.0], [2, 2.0]])
       [[1, 2.0], [1, 2.0]].transpose.should eq([[1, 1], [2.0, 2.0]])
       [[1, 1.0], ['a', "aaa"]].transpose.should eq([[1, 'a'], [1.0, "aaa"]])
@@ -1441,21 +1441,21 @@ describe "Array" do
       typeof([[1, 1.0], ['a', "aaa"]].transpose).should eq(Array(Array(String | Int32 | Float64 | Char)))
     end
 
-    it "transposes empty array" do
+    it("transposes empty array") do
       e = [] of Array(Int32)
       e.transpose.empty?.should be_true
       [e].transpose.empty?.should be_true
       [e, e, e].transpose.empty?.should be_true
     end
 
-    it "raises IndexError error when size of element is invalid" do
+    it("raises IndexError error when size of element is invalid") do
       expect_raises(IndexError) { [[1], [1, 2]].transpose }
       expect_raises(IndexError) { [[1, 2], [1]].transpose }
     end
   end
 
-  describe "rotate" do
-    it "rotate!" do
+  describe("rotate") do
+    it("rotate!") do
       a = [1, 2, 3]
       a.rotate!; a.should eq([2, 3, 1])
       a.rotate!; a.should eq([3, 1, 2])
@@ -1464,7 +1464,7 @@ describe "Array" do
       a.rotate!.should eq(a)
     end
 
-    it "rotate" do
+    it("rotate") do
       a = [1, 2, 3]
       a.rotate.should eq([2, 3, 1])
       a.should eq([1, 2, 3])
@@ -1490,7 +1490,7 @@ describe "Array" do
     it { a = [1, 2, 3]; a.rotate(-3001).should eq([3, 1, 2]); a.should eq([1, 2, 3]) }
   end
 
-  describe "permutations" do
+  describe("permutations") do
     it { [1, 2, 2].permutations.should eq([[1, 2, 2], [1, 2, 2], [2, 1, 2], [2, 2, 1], [2, 1, 2], [2, 2, 1]]) }
     it { [1, 2, 3].permutations.should eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]) }
     it { [1, 2, 3].permutations(1).should eq([[1], [2], [3]]) }
@@ -1500,7 +1500,7 @@ describe "Array" do
     it { [1, 2, 3].permutations(4).should eq([] of Array(Int32)) }
     it { expect_raises(ArgumentError, "Size must be positive") { [1].permutations(-1) } }
 
-    it "accepts a block" do
+    it("accepts a block") do
       sums = [] of Int32
       [1, 2, 3].each_permutation(2) do |perm|
         sums << perm.sum
@@ -1508,7 +1508,7 @@ describe "Array" do
       sums.should eq([3, 4, 3, 5, 4, 5])
     end
 
-    it "yielding dup of arrays" do
+    it("yielding dup of arrays") do
       sums = [] of Int32
       [1, 2, 3].each_permutation(3) do |perm|
         perm.map! &.+(1)
@@ -1517,7 +1517,7 @@ describe "Array" do
       sums.should eq([9, 9, 9, 9, 9, 9])
     end
 
-    it "yields with reuse = true" do
+    it("yields with reuse = true") do
       sums = [] of Int32
       object_ids = Set(UInt64).new
       [1, 2, 3].each_permutation(3, reuse: true) do |perm|
@@ -1531,7 +1531,7 @@ describe "Array" do
 
     it { expect_raises(ArgumentError, "Size must be positive") { [1].each_permutation(-1) { } } }
 
-    it "returns iterator" do
+    it("returns iterator") do
       a = [1, 2, 3]
       perms = a.permutations
       iter = a.each_permutation
@@ -1544,7 +1544,7 @@ describe "Array" do
       iter.next.should eq(perms[0])
     end
 
-    it "returns iterator with given size" do
+    it("returns iterator with given size") do
       a = [1, 2, 3]
       perms = a.permutations(2)
       iter = a.each_permutation(2)
@@ -1557,7 +1557,7 @@ describe "Array" do
       iter.next.should eq(perms[0])
     end
 
-    it "returns iterator with reuse = true" do
+    it("returns iterator with reuse = true") do
       a = [1, 2, 3]
       object_ids = Set(UInt64).new
       perms = a.permutations
@@ -1572,7 +1572,7 @@ describe "Array" do
     end
   end
 
-  describe "combinations" do
+  describe("combinations") do
     it { [1, 2, 2].combinations.should eq([[1, 2, 2]]) }
     it { [1, 2, 3].combinations.should eq([[1, 2, 3]]) }
     it { [1, 2, 3].combinations(1).should eq([[1], [2], [3]]) }
@@ -1584,7 +1584,7 @@ describe "Array" do
     it { [1, 2, 3, 4].combinations(2).should eq([[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]) }
     it { expect_raises(ArgumentError, "Size must be positive") { [1].combinations(-1) } }
 
-    it "accepts a block" do
+    it("accepts a block") do
       sums = [] of Int32
       [1, 2, 3].each_combination(2) do |comb|
         sums << comb.sum
@@ -1592,7 +1592,7 @@ describe "Array" do
       sums.should eq([3, 4, 5])
     end
 
-    it "yielding dup of arrays" do
+    it("yielding dup of arrays") do
       sums = [] of Int32
       [1, 2, 3].each_combination(3) do |comb|
         comb.map! &.+(1)
@@ -1601,7 +1601,7 @@ describe "Array" do
       sums.should eq([9])
     end
 
-    it "does with reuse = true" do
+    it("does with reuse = true") do
       sums = [] of Int32
       object_ids = Set(UInt64).new
       [1, 2, 3].each_combination(2, reuse: true) do |comb|
@@ -1612,7 +1612,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "does with reuse = array" do
+    it("does with reuse = array") do
       sums = [] of Int32
       reuse = [] of Int32
       [1, 2, 3].each_combination(2, reuse: reuse) do |comb|
@@ -1624,7 +1624,7 @@ describe "Array" do
 
     it { expect_raises(ArgumentError, "Size must be positive") { [1].each_combination(-1) { } } }
 
-    it "returns iterator" do
+    it("returns iterator") do
       a = [1, 2, 3, 4]
       combs = a.combinations(2)
       iter = a.each_combination(2)
@@ -1637,7 +1637,7 @@ describe "Array" do
       iter.next.should eq(combs[0])
     end
 
-    it "returns iterator with reuse = true" do
+    it("returns iterator with reuse = true") do
       a = [1, 2, 3, 4]
       combs = a.combinations(2)
       object_ids = Set(UInt64).new
@@ -1651,7 +1651,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "returns iterator with reuse = array" do
+    it("returns iterator with reuse = array") do
       a = [1, 2, 3, 4]
       reuse = [] of Int32
       combs = a.combinations(2)
@@ -1665,7 +1665,7 @@ describe "Array" do
     end
   end
 
-  describe "repeated_combinations" do
+  describe("repeated_combinations") do
     it { [1, 2, 2].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2], [1, 2, 2], [1, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2]]) }
     it { [1, 2, 3].repeated_combinations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], [1, 3, 3], [2, 2, 2], [2, 2, 3], [2, 3, 3], [3, 3, 3]]) }
     it { [1, 2, 3].repeated_combinations(1).should eq([[1], [2], [3]]) }
@@ -1675,7 +1675,7 @@ describe "Array" do
     it { [1, 2, 3].repeated_combinations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 3], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 3], [1, 3, 3, 3], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 3], [2, 3, 3, 3], [3, 3, 3, 3]]) }
     it { expect_raises(ArgumentError, "Size must be positive") { [1].repeated_combinations(-1) } }
 
-    it "accepts a block" do
+    it("accepts a block") do
       sums = [] of Int32
       [1, 2, 3].each_repeated_combination(2) do |comb|
         sums << comb.sum
@@ -1683,7 +1683,7 @@ describe "Array" do
       sums.should eq([2, 3, 4, 4, 5, 6])
     end
 
-    it "yielding dup of arrays" do
+    it("yielding dup of arrays") do
       sums = [] of Int32
       [1, 2, 3].each_repeated_combination(3) do |comb|
         comb.map! &.+(1)
@@ -1694,7 +1694,7 @@ describe "Array" do
 
     it { expect_raises(ArgumentError, "Size must be positive") { [1].each_repeated_combination(-1) { } } }
 
-    it "yields with reuse = true" do
+    it("yields with reuse = true") do
       sums = [] of Int32
       object_ids = Set(UInt64).new
       [1, 2, 3].each_repeated_combination(3, reuse: true) do |comb|
@@ -1706,7 +1706,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "yields with reuse = array" do
+    it("yields with reuse = array") do
       sums = [] of Int32
       reuse = [] of Int32
       [1, 2, 3].each_repeated_combination(3, reuse: reuse) do |comb|
@@ -1717,7 +1717,7 @@ describe "Array" do
       sums.should eq([6, 7, 8, 8, 9, 10, 9, 10, 11, 12])
     end
 
-    it "returns iterator" do
+    it("returns iterator") do
       a = [1, 2, 3, 4]
       combs = a.repeated_combinations(2)
       iter = a.each_repeated_combination(2)
@@ -1730,7 +1730,7 @@ describe "Array" do
       iter.next.should eq(combs[0])
     end
 
-    it "returns iterator with reuse = true" do
+    it("returns iterator with reuse = true") do
       a = [1, 2, 3, 4]
       object_ids = Set(UInt64).new
       combs = a.repeated_combinations(2)
@@ -1744,7 +1744,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "returns iterator with reuse = array" do
+    it("returns iterator with reuse = array") do
       a = [1, 2, 3, 4]
       reuse = [] of Int32
       combs = a.repeated_combinations(2)
@@ -1758,7 +1758,7 @@ describe "Array" do
     end
   end
 
-  describe "repeated_permutations" do
+  describe("repeated_permutations") do
     it { [1, 2, 2].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [1, 2, 1], [1, 2, 2], [1, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 1, 1], [2, 1, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2]]) }
     it { [1, 2, 3].repeated_permutations.should eq([[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 1], [1, 2, 2], [1, 2, 3], [1, 3, 1], [1, 3, 2], [1, 3, 3], [2, 1, 1], [2, 1, 2], [2, 1, 3], [2, 2, 1], [2, 2, 2], [2, 2, 3], [2, 3, 1], [2, 3, 2], [2, 3, 3], [3, 1, 1], [3, 1, 2], [3, 1, 3], [3, 2, 1], [3, 2, 2], [3, 2, 3], [3, 3, 1], [3, 3, 2], [3, 3, 3]]) }
     it { [1, 2, 3].repeated_permutations(1).should eq([[1], [2], [3]]) }
@@ -1768,7 +1768,7 @@ describe "Array" do
     it { [1, 2, 3].repeated_permutations(4).should eq([[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 1, 3], [1, 1, 2, 1], [1, 1, 2, 2], [1, 1, 2, 3], [1, 1, 3, 1], [1, 1, 3, 2], [1, 1, 3, 3], [1, 2, 1, 1], [1, 2, 1, 2], [1, 2, 1, 3], [1, 2, 2, 1], [1, 2, 2, 2], [1, 2, 2, 3], [1, 2, 3, 1], [1, 2, 3, 2], [1, 2, 3, 3], [1, 3, 1, 1], [1, 3, 1, 2], [1, 3, 1, 3], [1, 3, 2, 1], [1, 3, 2, 2], [1, 3, 2, 3], [1, 3, 3, 1], [1, 3, 3, 2], [1, 3, 3, 3], [2, 1, 1, 1], [2, 1, 1, 2], [2, 1, 1, 3], [2, 1, 2, 1], [2, 1, 2, 2], [2, 1, 2, 3], [2, 1, 3, 1], [2, 1, 3, 2], [2, 1, 3, 3], [2, 2, 1, 1], [2, 2, 1, 2], [2, 2, 1, 3], [2, 2, 2, 1], [2, 2, 2, 2], [2, 2, 2, 3], [2, 2, 3, 1], [2, 2, 3, 2], [2, 2, 3, 3], [2, 3, 1, 1], [2, 3, 1, 2], [2, 3, 1, 3], [2, 3, 2, 1], [2, 3, 2, 2], [2, 3, 2, 3], [2, 3, 3, 1], [2, 3, 3, 2], [2, 3, 3, 3], [3, 1, 1, 1], [3, 1, 1, 2], [3, 1, 1, 3], [3, 1, 2, 1], [3, 1, 2, 2], [3, 1, 2, 3], [3, 1, 3, 1], [3, 1, 3, 2], [3, 1, 3, 3], [3, 2, 1, 1], [3, 2, 1, 2], [3, 2, 1, 3], [3, 2, 2, 1], [3, 2, 2, 2], [3, 2, 2, 3], [3, 2, 3, 1], [3, 2, 3, 2], [3, 2, 3, 3], [3, 3, 1, 1], [3, 3, 1, 2], [3, 3, 1, 3], [3, 3, 2, 1], [3, 3, 2, 2], [3, 3, 2, 3], [3, 3, 3, 1], [3, 3, 3, 2], [3, 3, 3, 3]]) }
     it { expect_raises(ArgumentError, "Size must be positive") { [1].repeated_permutations(-1) } }
 
-    it "accepts a block" do
+    it("accepts a block") do
       sums = [] of Int32
       [1, 2, 3].each_repeated_permutation(2) do |a|
         sums << a.sum
@@ -1776,7 +1776,7 @@ describe "Array" do
       sums.should eq([2, 3, 4, 3, 4, 5, 4, 5, 6])
     end
 
-    it "yielding dup of arrays" do
+    it("yielding dup of arrays") do
       sums = [] of Int32
       [1, 2, 3].each_repeated_permutation(3) do |a|
         a.map! &.+(1)
@@ -1785,7 +1785,7 @@ describe "Array" do
       sums.should eq([6, 7, 8, 7, 8, 9, 8, 9, 10, 7, 8, 9, 8, 9, 10, 9, 10, 11, 8, 9, 10, 9, 10, 11, 10, 11, 12])
     end
 
-    it "yields with reuse = true" do
+    it("yields with reuse = true") do
       sums = [] of Int32
       object_ids = Set(UInt64).new
       [1, 2, 3].each_repeated_permutation(3, reuse: true) do |a|
@@ -1797,7 +1797,7 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "yields with reuse = array" do
+    it("yields with reuse = array") do
       sums = [] of Int32
       reuse = [] of Int32
       [1, 2, 3].each_repeated_permutation(3, reuse: reuse) do |a|
@@ -1811,8 +1811,8 @@ describe "Array" do
     it { expect_raises(ArgumentError, "Size must be positive") { [1].each_repeated_permutation(-1) { } } }
   end
 
-  describe "Array.each_product" do
-    it "one empty array" do
+  describe("Array.each_product") do
+    it("one empty array") do
       empty = [] of Int32
       res = [] of Array(Int32)
       Array.each_product([empty, [1, 2, 3]]) { |r| res << r }
@@ -1820,31 +1820,31 @@ describe "Array" do
       res.size.should eq(0)
     end
 
-    it "single array" do
+    it("single array") do
       res = [] of Array(Int32)
       Array.each_product([[1]]) { |r| res << r }
       res.should eq([[1]])
     end
 
-    it "2 arrays" do
+    it("2 arrays") do
       res = [] of Array(Int32)
       Array.each_product([[1, 2], [3, 4]]) { |r| res << r }
       res.should eq([[1, 3], [1, 4], [2, 3], [2, 4]])
     end
 
-    it "2 arrays different types" do
+    it("2 arrays different types") do
       res = [] of Array(Int32 | Char)
       Array.each_product([[1, 2], ['a', 'b']]) { |r| res << r }
       res.should eq([[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']])
     end
 
-    it "more arrays" do
+    it("more arrays") do
       res = [] of Array(Int32)
       Array.each_product([[1, 2], [3], [5, 6]]) { |r| res << r }
       res.should eq([[1, 3, 5], [1, 3, 6], [2, 3, 5], [2, 3, 6]])
     end
 
-    it "more arrays, reuse = true" do
+    it("more arrays, reuse = true") do
       res = [] of Array(Int32)
       object_ids = Set(UInt64).new
       Array.each_product([[1, 2], [3], [5, 6]], reuse: true) do |r|
@@ -1855,24 +1855,24 @@ describe "Array" do
       object_ids.size.should eq(1)
     end
 
-    it "with splat" do
+    it("with splat") do
       res = [] of Array(Int32 | Char)
       Array.each_product([1, 2], ['a', 'b']) { |r| res << r }
       res.should eq([[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']])
     end
   end
 
-  describe "Array.product" do
-    it "with array" do
+  describe("Array.product") do
+    it("with array") do
       Array.product([[1, 2], ['a', 'b']]).should eq([[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']])
     end
 
-    it "with splat" do
+    it("with splat") do
       Array.product([1, 2], ['a', 'b']).should eq([[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']])
     end
   end
 
-  it "doesn't overflow buffer with Array.new(size, value) (#1209)" do
+  it("doesn't overflow buffer with Array.new(size, value) (#1209)") do
     a = Array.new(1, 1_i64)
     b = Array.new(1, 1_i64)
     b << 2_i64 << 3_i64
@@ -1880,7 +1880,7 @@ describe "Array" do
     b.should eq([1, 2, 3])
   end
 
-  it "flattens" do
+  it("flattens") do
     [[1, 'a'], [[[[true], "hi"]]]].flatten.should eq([1, 'a', true, "hi"])
 
     s = [1, 2, 3]

--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -13,8 +13,8 @@ enum AtomicEnumFlags
   Three
 end
 
-describe Atomic do
-  it "compares and sets with integer" do
+describe(Atomic) do
+  it("compares and sets with integer") do
     atomic = Atomic.new(1)
 
     atomic.compare_and_set(2, 3).should eq({1, false})
@@ -24,7 +24,7 @@ describe Atomic do
     atomic.get.should eq(3)
   end
 
-  it "compares and set with enum" do
+  it("compares and set with enum") do
     atomic = Atomic(AtomicEnum).new(AtomicEnum::One)
 
     atomic.compare_and_set(AtomicEnum::Two, AtomicEnum::Three).should eq({AtomicEnum::One, false})
@@ -34,7 +34,7 @@ describe Atomic do
     atomic.get.should eq(AtomicEnum::Three)
   end
 
-  it "compares and set with flags enum" do
+  it("compares and set with flags enum") do
     atomic = Atomic(AtomicEnumFlags).new(AtomicEnumFlags::One)
 
     atomic.compare_and_set(AtomicEnumFlags::Two, AtomicEnumFlags::Three).should eq({AtomicEnumFlags::One, false})
@@ -44,7 +44,7 @@ describe Atomic do
     atomic.get.should eq(AtomicEnumFlags::Three)
   end
 
-  it "compares and sets with nilable type" do
+  it("compares and sets with nilable type") do
     atomic = Atomic(String?).new(nil)
     string = "hello"
 
@@ -58,7 +58,7 @@ describe Atomic do
     atomic.get.should be_nil
   end
 
-  it "compares and sets with reference type" do
+  it("compares and sets with reference type") do
     str1 = "hello"
     str2 = "bye"
 
@@ -74,43 +74,43 @@ describe Atomic do
     atomic.get.should be(str1)
   end
 
-  it "#adds" do
+  it("#adds") do
     atomic = Atomic.new(1)
     atomic.add(2).should eq(1)
     atomic.get.should eq(3)
   end
 
-  it "#sub" do
+  it("#sub") do
     atomic = Atomic.new(1)
     atomic.sub(2).should eq(1)
     atomic.get.should eq(-1)
   end
 
-  it "#and" do
+  it("#and") do
     atomic = Atomic.new(5)
     atomic.and(3).should eq(5)
     atomic.get.should eq(1)
   end
 
-  it "#nand" do
+  it("#nand") do
     atomic = Atomic.new(5)
     atomic.nand(3).should eq(5)
     atomic.get.should eq(-2)
   end
 
-  it "#or" do
+  it("#or") do
     atomic = Atomic.new(5)
     atomic.or(2).should eq(5)
     atomic.get.should eq(7)
   end
 
-  it "#xor" do
+  it("#xor") do
     atomic = Atomic.new(5)
     atomic.xor(3).should eq(5)
     atomic.get.should eq(6)
   end
 
-  it "#max with signed" do
+  it("#max with signed") do
     atomic = Atomic.new(5)
     atomic.max(2).should eq(5)
     atomic.get.should eq(5)
@@ -118,7 +118,7 @@ describe Atomic do
     atomic.get.should eq(10)
   end
 
-  it "#max with unsigned" do
+  it("#max with unsigned") do
     atomic = Atomic.new(5_u32)
     atomic.max(2_u32).should eq(5_u32)
     atomic.get.should eq(5_u32)
@@ -126,7 +126,7 @@ describe Atomic do
     atomic.get.should eq(UInt32::MAX)
   end
 
-  it "#min with signed" do
+  it("#min with signed") do
     atomic = Atomic.new(5)
     atomic.min(10).should eq(5)
     atomic.get.should eq(5)
@@ -134,7 +134,7 @@ describe Atomic do
     atomic.get.should eq(2)
   end
 
-  it "#min with unsigned" do
+  it("#min with unsigned") do
     atomic = Atomic.new(UInt32::MAX)
     atomic.min(10_u32).should eq(UInt32::MAX)
     atomic.get.should eq(10_u32)
@@ -142,13 +142,13 @@ describe Atomic do
     atomic.get.should eq(10_u32)
   end
 
-  it "#set" do
+  it("#set") do
     atomic = Atomic.new(1)
     atomic.set(2).should eq(2)
     atomic.get.should eq(2)
   end
 
-  it "#set with nil (#4062)" do
+  it("#set with nil (#4062)") do
     atomic = Atomic(String?).new(nil)
 
     atomic.set("foo")
@@ -158,13 +158,13 @@ describe Atomic do
     atomic.get.should eq(nil)
   end
 
-  it "#lazy_set" do
+  it("#lazy_set") do
     atomic = Atomic.new(1)
     atomic.lazy_set(2).should eq(2)
     atomic.get.should eq(2)
   end
 
-  it "#swap" do
+  it("#swap") do
     atomic = Atomic.new(1)
     atomic.swap(2).should eq(1)
     atomic.get.should eq(2)

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -2,68 +2,68 @@ require "spec"
 require "base64"
 require "digest/md5"
 
-describe "Base64" do
-  context "simple test" do
+describe("Base64") do
+  context("simple test") do
     eqs = {"" => "", "a" => "YQ==\n", "ab" => "YWI=\n", "abc" => "YWJj\n",
            "abcd" => "YWJjZA==\n", "abcde" => "YWJjZGU=\n", "abcdef" => "YWJjZGVm\n",
            "abcdefg" => "YWJjZGVmZw==\n"}
     eqs.each do |a, b|
-      it "encode #{a.inspect} to #{b.inspect}" do
+      it("encode #{a.inspect} to #{b.inspect}") do
         Base64.encode(a).should eq(b)
       end
-      it "decode from #{b.inspect} to #{a.inspect}" do
+      it("decode from #{b.inspect} to #{a.inspect}") do
         Base64.decode(b).should eq(a.to_slice)
         Base64.decode_string(b).should eq(a)
       end
     end
   end
 
-  context "\n in multiple places" do
+  context("\n in multiple places") do
     eqs = {"abcd" => "YWJj\nZA==\n", "abcde" => "YWJj\nZGU=\n", "abcdef" => "YWJj\nZGVm\n",
            "abcdefg" => "YWJj\nZGVmZw==\n", "abcdefg" => "YWJj\nZGVm\nZw==\n",
     }
     eqs.each do |a, b|
-      it "decode from #{b.inspect} to #{a.inspect}" do
+      it("decode from #{b.inspect} to #{a.inspect}") do
         Base64.decode(b).should eq(a.to_slice)
         Base64.decode_string(b).should eq(a)
       end
     end
   end
 
-  it "encodes byte slice" do
+  it("encodes byte slice") do
     slice = Bytes.new(5) { 1_u8 }
     Base64.encode(slice).should eq("AQEBAQE=\n")
     Base64.strict_encode(slice).should eq("AQEBAQE=")
   end
 
-  it "encodes static array" do
+  it("encodes static array") do
     array = uninitialized StaticArray(UInt8, 5)
     (0...5).each { |i| array[i] = 1_u8 }
     Base64.encode(array).should eq("AQEBAQE=\n")
     Base64.strict_encode(array).should eq("AQEBAQE=")
   end
 
-  describe "base" do
+  describe("base") do
     eqs = {"Send reinforcements"                                                    => "U2VuZCByZWluZm9yY2VtZW50cw==\n",
            "Now is the time for all good coders\nto learn Crystal"                  => "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nQ3J5c3RhbA==\n",
            "This is line one\nThis is line two\nThis is line three\nAnd so on...\n" => "VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGlu\nZSB0aHJlZQpBbmQgc28gb24uLi4K\n",
            "hahah⊙ⓧ⊙"                                                               => "aGFoYWjiipnik6fiipk=\n"}
     eqs.each do |a, b|
-      it "encode #{a.inspect} to #{b.inspect}" do
+      it("encode #{a.inspect} to #{b.inspect}") do
         Base64.encode(a).should eq(b)
       end
-      it "decode from #{b.inspect} to #{a.inspect}" do
+      it("decode from #{b.inspect} to #{a.inspect}") do
         Base64.decode(b).should eq(a.to_slice)
         Base64.decode_string(b).should eq(a)
       end
     end
 
-    it "decode from strict form" do
+    it("decode from strict form") do
       Base64.decode_string("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
         "Now is the time for all good coders\nto learn Crystal")
     end
 
-    it "encode to stream" do
+    it("encode to stream") do
       io = IO::Memory.new
       count = Base64.encode("Now is the time for all good coders\nto learn Crystal", io)
       count.should eq 74
@@ -71,7 +71,7 @@ describe "Base64" do
       io.gets_to_end.should eq "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nQ3J5c3RhbA==\n"
     end
 
-    it "decode from stream" do
+    it("decode from stream") do
       io = IO::Memory.new
       count = Base64.decode("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==", io)
       count.should eq 52
@@ -79,13 +79,13 @@ describe "Base64" do
       io.gets_to_end.should eq "Now is the time for all good coders\nto learn Crystal"
     end
 
-    it "big message" do
+    it("big message") do
       a = "a" * 100000
       b = Base64.encode(a)
       Digest::MD5.hexdigest(Base64.decode_string(b)).should eq(Digest::MD5.hexdigest(a))
     end
 
-    it "works for most characters" do
+    it("works for most characters") do
       a = String.build(65536 * 4) do |buf|
         65536.times { |i| buf << (i + 1).chr }
       end
@@ -94,8 +94,8 @@ describe "Base64" do
     end
   end
 
-  describe "decode cases" do
-    it "decode \r\n" do
+  describe("decode cases") do
+    it("decode \r\n") do
       decoded = "hahah⊙ⓧ⊙"
       {"aGFo\r\nYWjiipnik6fiipk=\r\n", "aGFo\r\nYWjiipnik6fiipk=\r\n\r\n"}.each do |encoded|
         Base64.decode(encoded).should eq(decoded.to_slice)
@@ -103,7 +103,7 @@ describe "Base64" do
       end
     end
 
-    it "decode \n in multiple places" do
+    it("decode \n in multiple places") do
       decoded = "hahah⊙ⓧ⊙"
       {"aGFoYWjiipnik6fiipk=", "aGFo\nYWjiipnik6fiipk=", "aGFo\nYWji\nipnik6fiipk=",
        "aGFo\nYWji\nipni\nk6fiipk=", "aGFo\nYWji\nipni\nk6fi\nipk=",
@@ -113,54 +113,54 @@ describe "Base64" do
       end
     end
 
-    it "raise error when \n in incorrect place" do
-      expect_raises Base64::Error do
+    it("raise error when \n in incorrect place") do
+      expect_raises(Base64::Error) do
         Base64.decode("aG\nFoYWjiipnik6fiipk=")
       end
 
-      expect_raises Base64::Error do
+      expect_raises(Base64::Error) do
         Base64.decode_string("aG\nFoYWjiipnik6fiipk=")
       end
     end
 
-    it "raise error when incorrect symbol" do
-      expect_raises Base64::Error do
+    it("raise error when incorrect symbol") do
+      expect_raises(Base64::Error) do
         Base64.decode("()")
       end
 
-      expect_raises Base64::Error do
+      expect_raises(Base64::Error) do
         Base64.decode_string("()")
       end
     end
 
-    it "raise error when incorrect size" do
-      expect_raises Base64::Error do
+    it("raise error when incorrect size") do
+      expect_raises(Base64::Error) do
         Base64.decode("a")
       end
 
-      expect_raises Base64::Error do
+      expect_raises(Base64::Error) do
         Base64.decode_string("a")
       end
     end
 
-    it "decode small tail after last \n, was a bug" do
+    it("decode small tail after last \n, was a bug") do
       s = "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nnA==\n"
       Base64.decode(s).should eq Bytes[78, 111, 119, 32, 105, 115, 32, 116, 104, 101, 32, 116, 105, 109, 101, 32, 102, 111, 114, 32, 97, 108, 108, 32, 103, 111, 111, 100, 32, 99, 111, 100, 101, 114, 115, 10, 116, 111, 32, 108, 101, 97, 114, 110, 32, 156]
     end
   end
 
-  describe "scrict" do
-    it "encode" do
+  describe("scrict") do
+    it("encode") do
       Base64.strict_encode("Now is the time for all good coders\nto learn Crystal").should eq(
         "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")
     end
-    it "with spec symbols" do
+    it("with spec symbols") do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
       Base64.strict_encode(s).should eq(se)
     end
 
-    it "encode to stream" do
+    it("encode to stream") do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
       io = IO::Memory.new
@@ -170,14 +170,14 @@ describe "Base64" do
     end
   end
 
-  describe "urlsafe" do
-    it "work" do
+  describe("urlsafe") do
+    it("work") do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw=="
       Base64.urlsafe_encode(s).should eq(se)
     end
 
-    it "encode to stream" do
+    it("encode to stream") do
       s = String.build { |b| (160..179).each { |i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw=="
       io = IO::Memory.new

--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -8,8 +8,8 @@ typeof(begin
   end
 end)
 
-describe Benchmark::IPS::Job do
-  it "works in general / integration test" do
+describe(Benchmark::IPS::Job) do
+  it("works in general / integration test") do
     # test several things to avoid running a benchmark over and over again in
     # the specs
     j = Benchmark::IPS::Job.new(0.001, 0.001, interactive: false)
@@ -34,8 +34,8 @@ private def create_entry
   Benchmark::IPS::Entry.new("label", ->{ 1 + 1 })
 end
 
-describe Benchmark::IPS::Entry, "#set_cycles" do
-  it "sets the number of cycles needed to make 100ms" do
+describe(Benchmark::IPS::Entry, "#set_cycles") do
+  it("sets the number of cycles needed to make 100ms") do
     e = create_entry
     e.set_cycles(2.seconds, 100)
     e.cycles.should eq(5)
@@ -44,15 +44,15 @@ describe Benchmark::IPS::Entry, "#set_cycles" do
     e.cycles.should eq(1)
   end
 
-  it "sets the cycles to 1 no matter what" do
+  it("sets the cycles to 1 no matter what") do
     e = create_entry
     e.set_cycles(2.seconds, 1)
     e.cycles.should eq(1)
   end
 end
 
-describe Benchmark::IPS::Entry, "#calculate_stats" do
-  it "correctly caculates basic stats" do
+describe(Benchmark::IPS::Entry, "#calculate_stats") do
+  it("correctly caculates basic stats") do
     e = create_entry
     e.calculate_stats([2, 4, 4, 4, 5, 5, 7, 9])
 
@@ -67,7 +67,7 @@ private def h_mean(mean)
   create_entry.tap { |e| e.mean = mean }.human_mean
 end
 
-describe Benchmark::IPS::Entry, "#human_mean" do
+describe(Benchmark::IPS::Entry, "#human_mean") do
   it { h_mean(0.01234567890123).should eq("  0.01 ") }
   it { h_mean(0.12345678901234).should eq("  0.12 ") }
 
@@ -93,7 +93,7 @@ private def h_ips(seconds)
   create_entry.tap { |e| e.mean = mean }.human_iteration_time
 end
 
-describe Benchmark::IPS::Entry, "#human_iteration_time" do
+describe(Benchmark::IPS::Entry, "#human_iteration_time") do
   it { h_ips(1234.567_890_123).should eq("1234.57s ") }
   it { h_ips(123.456_789_012_3).should eq("123.46s ") }
   it { h_ips(12.345_678_901_23).should eq(" 12.35s ") }

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -1,35 +1,35 @@
 require "spec"
 require "big_float"
 
-describe "BigFloat" do
-  describe "new" do
+describe("BigFloat") do
+  describe("new") do
     string_of_integer_value = "123456789012345678901"
     bigfloat_of_integer_value = BigFloat.new(string_of_integer_value)
     string_of_float_value = "1234567890.12345678901"
     bigfloat_of_float_value = BigFloat.new(string_of_float_value)
 
-    it "new(String)" do
+    it("new(String)") do
       bigfloat_of_integer_value.to_s.should eq(string_of_integer_value)
       bigfloat_of_float_value.to_s.should eq(string_of_float_value)
     end
 
-    it "new(BigInt)" do
+    it("new(BigInt)") do
       bigfloat_on_bigint_value = BigFloat.new(BigInt.new(string_of_integer_value))
       bigfloat_on_bigint_value.should eq(bigfloat_of_integer_value)
       bigfloat_on_bigint_value.to_s.should eq(string_of_integer_value)
     end
 
-    it "new(BigRational)" do
+    it("new(BigRational)") do
       bigfloat_on_bigrational_value = BigFloat.new(BigRational.new(1, 3))
       bigfloat_on_bigrational_value.should eq(BigFloat.new(1) / BigFloat.new(3))
     end
 
-    it "new(BigFloat)" do
+    it("new(BigFloat)") do
       BigFloat.new(bigfloat_of_integer_value).should eq(bigfloat_of_integer_value)
       BigFloat.new(bigfloat_of_float_value).should eq(bigfloat_of_float_value)
     end
 
-    it "new(Int)" do
+    it("new(Int)") do
       BigFloat.new(1_u8).to_s.should eq("1")
       BigFloat.new(1_u16).to_s.should eq("1")
       BigFloat.new(1_u32).to_s.should eq("1")
@@ -58,7 +58,7 @@ describe "BigFloat" do
     end
   end
 
-  describe "-@" do
+  describe("-@") do
     bf = "0.12345".to_big_f
     it { (-bf).to_s.should eq("-0.12345") }
 
@@ -69,28 +69,28 @@ describe "BigFloat" do
     it { (-bf).to_s.should eq("-395.009631567315769036") }
   end
 
-  describe "+" do
+  describe("+") do
     it { ("1.0".to_big_f + "2.0".to_big_f).to_s.should eq("3") }
     it { ("0.04".to_big_f + "89.0001".to_big_f).to_s.should eq("89.0401") }
     it { ("-5.5".to_big_f + "5.5".to_big_f).to_s.should eq("0") }
     it { ("5.5".to_big_f + "-5.5".to_big_f).to_s.should eq("0") }
   end
 
-  describe "-" do
+  describe("-") do
     it { ("1.0".to_big_f - "2.0".to_big_f).to_s.should eq("-1") }
     it { ("0.04".to_big_f - "89.0001".to_big_f).to_s.should eq("-88.9601") }
     it { ("-5.5".to_big_f - "5.5".to_big_f).to_s.should eq("-11") }
     it { ("5.5".to_big_f - "-5.5".to_big_f).to_s.should eq("11") }
   end
 
-  describe "*" do
+  describe("*") do
     it { ("1.0".to_big_f * "2.0".to_big_f).to_s.should eq("2") }
     it { ("0.04".to_big_f * "89.0001".to_big_f).to_s.should eq("3.560004") }
     it { ("-5.5".to_big_f * "5.5".to_big_f).to_s.should eq("-30.25") }
     it { ("5.5".to_big_f * "-5.5".to_big_f).to_s.should eq("-30.25") }
   end
 
-  describe "/" do
+  describe("/") do
     it { ("1.0".to_big_f / "2.0".to_big_f).to_s.should eq("0.5") }
     it { ("0.04".to_big_f / "89.0001".to_big_f).to_s.should eq("0.000449437697261014313467") }
     it { ("-5.5".to_big_f / "5.5".to_big_f).to_s.should eq("-1") }
@@ -100,57 +100,57 @@ describe "BigFloat" do
     it { ("5.5".to_big_f / 16_u8).to_s.should eq("0.34375") }
   end
 
-  describe "**" do
+  describe("**") do
     # TODO: investigate why in travis this gives ""1.79559999999999999991"
     # it { ("1.34".to_big_f ** 2).to_s.should eq("1.79559999999999999994") }
     it { ("-0.05".to_big_f ** 10).to_s.should eq("0.00000000000009765625") }
     it { (0.1234567890.to_big_f ** 3).to_s.should eq("0.00188167637178915473909") }
   end
 
-  describe "abs" do
+  describe("abs") do
     it { -5.to_big_f.abs.should eq(5) }
     it { 5.to_big_f.abs.should eq(5) }
     it { "-0.00001".to_big_f.abs.to_s.should eq("0.00001") }
     it { "0.00000000001".to_big_f.abs.to_s.should eq("0.00000000001") }
   end
 
-  describe "ceil" do
+  describe("ceil") do
     it { 2.0.to_big_f.ceil.should eq(2) }
     it { 2.1.to_big_f.ceil.should eq(3) }
     it { 2.9.to_big_f.ceil.should eq(3) }
   end
 
-  describe "floor" do
+  describe("floor") do
     it { 2.1.to_big_f.floor.should eq(2) }
     it { 2.9.to_big_f.floor.should eq(2) }
     it { -2.9.to_big_f.floor.should eq(-3) }
   end
 
-  describe "trunc" do
+  describe("trunc") do
     it { 2.1.to_big_f.trunc.should eq(2) }
     it { 2.9.to_big_f.trunc.should eq(2) }
     it { -2.9.to_big_f.trunc.should eq(-2) }
   end
 
-  describe "to_f" do
+  describe("to_f") do
     it { 1.34.to_big_f.to_f.should eq(1.34) }
     it { 0.0001304.to_big_f.to_f.should eq(0.0001304) }
     it { 1.234567.to_big_f.to_f32.should eq(1.234567_f32) }
   end
 
-  describe "to_i" do
+  describe("to_i") do
     it { 1.34.to_big_f.to_i.should eq(1) }
     it { 123.to_big_f.to_i.should eq(123) }
     it { -4321.to_big_f.to_i.should eq(-4321) }
   end
 
-  describe "to_u" do
+  describe("to_u") do
     it { 1.34.to_big_f.to_u.should eq(1) }
     it { 123.to_big_f.to_u.should eq(123) }
     it { 4321.to_big_f.to_u.should eq(4321) }
   end
 
-  describe "to_s" do
+  describe("to_s") do
     it { "0".to_big_f.to_s.should eq("0") }
     it { "0.000001".to_big_f.to_s.should eq("0.000001") }
     it { "48600000".to_big_f.to_s.should eq("48600000") }
@@ -160,23 +160,23 @@ describe "BigFloat" do
     it { "1234567890123456789".to_big_f.to_s.should eq("1234567890123456789") }
   end
 
-  describe "#inspect" do
+  describe("#inspect") do
     it { "2.3".to_big_f.inspect.should eq("2.3_big_f") }
   end
 
-  it "#hash" do
+  it("#hash") do
     b = 123.to_big_f
     b.hash.should eq(b.to_f64.hash)
   end
 
-  it "clones" do
+  it("clones") do
     x = 1.to_big_f
     x.clone.should eq(x)
   end
 end
 
-describe "BigFloat Math" do
-  it "frexp" do
+describe("BigFloat Math") do
+  it("frexp") do
     Math.frexp(0.2.to_big_f).should eq({0.8, -2})
   end
 end

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -1,40 +1,40 @@
 require "spec"
 require "big_int"
 
-describe "BigInt" do
-  it "creates with a value of zero" do
+describe("BigInt") do
+  it("creates with a value of zero") do
     BigInt.new.to_s.should eq("0")
   end
 
-  it "creates from signed ints" do
+  it("creates from signed ints") do
     BigInt.new(-1_i8).to_s.should eq("-1")
     BigInt.new(-1_i16).to_s.should eq("-1")
     BigInt.new(-1_i32).to_s.should eq("-1")
     BigInt.new(-1_i64).to_s.should eq("-1")
   end
 
-  it "creates from unsigned ints" do
+  it("creates from unsigned ints") do
     BigInt.new(1_u8).to_s.should eq("1")
     BigInt.new(1_u16).to_s.should eq("1")
     BigInt.new(1_u32).to_s.should eq("1")
     BigInt.new(1_u64).to_s.should eq("1")
   end
 
-  it "creates from string" do
+  it("creates from string") do
     BigInt.new("12345678").to_s.should eq("12345678")
   end
 
-  it "raises if creates from string but invalid" do
-    expect_raises ArgumentError, "Invalid BigInt: 123 hello 456" do
+  it("raises if creates from string but invalid") do
+    expect_raises(ArgumentError, "Invalid BigInt: 123 hello 456") do
       BigInt.new("123 hello 456")
     end
   end
 
-  it "creates from float" do
+  it("creates from float") do
     BigInt.new(12.3).to_s.should eq("12")
   end
 
-  it "compares" do
+  it("compares") do
     1.to_big_i.should eq(1.to_big_i)
     1.to_big_i.should eq(1)
     1.to_big_i.should eq(1_u8)
@@ -42,7 +42,7 @@ describe "BigInt" do
     [3.to_big_i, 2.to_big_i, 10.to_big_i, 4, 8_u8].sort.should eq([2, 3, 4, 8, 10])
   end
 
-  it "compares against float" do
+  it("compares against float") do
     1.to_big_i.should eq(1.0)
     1.to_big_i.should eq(1.0_f32)
     1.to_big_i.should_not eq(1.1)
@@ -53,7 +53,7 @@ describe "BigInt" do
     [1.1, 1.to_big_i, 3.to_big_i, 2.2].sort.should eq([1, 1.1, 2.2, 3])
   end
 
-  it "divides and calculs the modulo" do
+  it("divides and calculs the modulo") do
     11.to_big_i.divmod(3.to_big_i).should eq({3, 2})
     11.to_big_i.divmod(-3.to_big_i).should eq({-4, -1})
 
@@ -76,7 +76,7 @@ describe "BigInt" do
     -11.to_big_i.divmod(-2).should eq({5, -1})
   end
 
-  it "adds" do
+  it("adds") do
     (1.to_big_i + 2.to_big_i).should eq(3.to_big_i)
     (1.to_big_i + 2).should eq(3.to_big_i)
     (1.to_big_i + 2_u8).should eq(3.to_big_i)
@@ -87,7 +87,7 @@ describe "BigInt" do
     (2 + 1.to_big_i).should eq(3.to_big_i)
   end
 
-  it "subs" do
+  it("subs") do
     (5.to_big_i - 2.to_big_i).should eq(3.to_big_i)
     (5.to_big_i - 2).should eq(3.to_big_i)
     (5.to_big_i - 2_u8).should eq(3.to_big_i)
@@ -99,11 +99,11 @@ describe "BigInt" do
     (-5 - 1.to_big_i).should eq(-6.to_big_i)
   end
 
-  it "negates" do
+  it("negates") do
     (-(-123.to_big_i)).should eq(123.to_big_i)
   end
 
-  it "multiplies" do
+  it("multiplies") do
     (2.to_big_i * 3.to_big_i).should eq(6.to_big_i)
     (2.to_big_i * 3).should eq(6.to_big_i)
     (2.to_big_i * 3_u8).should eq(6.to_big_i)
@@ -112,18 +112,18 @@ describe "BigInt" do
     (2.to_big_i * Int64::MAX).should eq(2.to_big_i * Int64::MAX.to_big_i)
   end
 
-  it "gets absolute value" do
+  it("gets absolute value") do
     (-10.to_big_i.abs).should eq(10.to_big_i)
   end
 
-  it "divides" do
+  it("divides") do
     (10.to_big_i / 3.to_big_i).should eq(3.to_big_i)
     (10.to_big_i / 3).should eq(3.to_big_i)
     (10 / 3.to_big_i).should eq(3.to_big_i)
     ((Int64::MAX.to_big_i * 2.to_big_i) / Int64::MAX).should eq(2.to_big_i)
   end
 
-  it "divides with negative numbers" do
+  it("divides with negative numbers") do
     (7.to_big_i / 2).should eq(3.to_big_i)
     (7.to_big_i / 2.to_big_i).should eq(3.to_big_i)
     (7.to_big_i / -2).should eq(-4.to_big_i)
@@ -138,20 +138,20 @@ describe "BigInt" do
     (-6.to_big_i / -2).should eq(3.to_big_i)
   end
 
-  it "tdivs" do
+  it("tdivs") do
     5.to_big_i.tdiv(3).should eq(1)
     -5.to_big_i.tdiv(3).should eq(-1)
     5.to_big_i.tdiv(-3).should eq(-1)
     -5.to_big_i.tdiv(-3).should eq(1)
   end
 
-  it "does modulo" do
+  it("does modulo") do
     (10.to_big_i % 3.to_big_i).should eq(1.to_big_i)
     (10.to_big_i % 3).should eq(1.to_big_i)
     (10 % 3.to_big_i).should eq(1.to_big_i)
   end
 
-  it "does modulo with negative numbers" do
+  it("does modulo with negative numbers") do
     (7.to_big_i % 2).should eq(1.to_big_i)
     (7.to_big_i % 2.to_big_i).should eq(1.to_big_i)
     (7.to_big_i % -2).should eq(-1.to_big_i)
@@ -167,29 +167,29 @@ describe "BigInt" do
     (-6.to_big_i % -2).should eq(0.to_big_i)
   end
 
-  it "does remainder with negative numbers" do
+  it("does remainder with negative numbers") do
     5.to_big_i.remainder(3).should eq(2)
     -5.to_big_i.remainder(3).should eq(-2)
     5.to_big_i.remainder(-3).should eq(2)
     -5.to_big_i.remainder(-3).should eq(-2)
   end
 
-  it "does bitwise and" do
+  it("does bitwise and") do
     (123.to_big_i & 321).should eq(65)
     (BigInt.new("96238761238973286532") & 86325735648).should eq(69124358272)
   end
 
-  it "does bitwise or" do
+  it("does bitwise or") do
     (123.to_big_i | 4).should eq(127)
     (BigInt.new("96238761238986532") | 8632573).should eq(96238761247506429)
   end
 
-  it "does bitwise xor" do
+  it("does bitwise xor") do
     (123.to_big_i ^ 50).should eq(73)
     (BigInt.new("96238761238986532") ^ 8632573).should eq(96238761247393753)
   end
 
-  it "does bitwise not" do
+  it("does bitwise not") do
     (~123).should eq(-124)
 
     a = BigInt.new("192623876123689865327")
@@ -197,51 +197,51 @@ describe "BigInt" do
     (~a).should eq(b)
   end
 
-  it "does bitwise right shift" do
+  it("does bitwise right shift") do
     (123.to_big_i >> 4).should eq(7)
     (123456.to_big_i >> 8).should eq(482)
   end
 
-  it "does bitwise left shift" do
+  it("does bitwise left shift") do
     (123.to_big_i << 4).should eq(1968)
     (123456.to_big_i << 8).should eq(31604736)
   end
 
-  it "raises if divides by zero" do
-    expect_raises DivisionByZero do
+  it("raises if divides by zero") do
+    expect_raises(DivisionByZero) do
       10.to_big_i / 0.to_big_i
     end
 
-    expect_raises DivisionByZero do
+    expect_raises(DivisionByZero) do
       10.to_big_i / 0
     end
 
-    expect_raises DivisionByZero do
+    expect_raises(DivisionByZero) do
       10 / 0.to_big_i
     end
   end
 
-  it "raises if mods by zero" do
-    expect_raises DivisionByZero do
+  it("raises if mods by zero") do
+    expect_raises(DivisionByZero) do
       10.to_big_i % 0.to_big_i
     end
 
-    expect_raises DivisionByZero do
+    expect_raises(DivisionByZero) do
       10.to_big_i % 0
     end
 
-    expect_raises DivisionByZero do
+    expect_raises(DivisionByZero) do
       10 % 0.to_big_i
     end
   end
 
-  it "exponentiates" do
+  it("exponentiates") do
     result = (2.to_big_i ** 1000)
     result.should be_a(BigInt)
     result.to_s.should eq("10715086071862673209484250490600018105614048117055336074437503883703510511249361224931983788156958581275946729175531468251871452856923140435984577574698574803934567774824230985421074605062371141877954182153046474983581941267398767559165543946077062914571196477686542167660429831652624386837205668069376")
   end
 
-  it "does to_s in the given base" do
+  it("does to_s in the given base") do
     a = BigInt.new("1234567890123456789")
     b = "1000100100010000100001111010001111101111010011000000100010101"
     c = "112210f47de98115"
@@ -251,16 +251,16 @@ describe "BigInt" do
     a.to_s(32).should eq(d)
   end
 
-  it "does to_big_f" do
+  it("does to_big_f") do
     a = BigInt.new("1234567890123456789")
     a.to_big_f.should eq(BigFloat.new("1234567890123456789.0"))
   end
 
-  describe "#inspect" do
+  describe("#inspect") do
     it { "2".to_big_i.inspect.should eq("2_big_i") }
   end
 
-  it "does gcd and lcm" do
+  it("does gcd and lcm") do
     # 3 primes
     a = BigInt.new("48112959837082048697")
     b = BigInt.new("12764787846358441471")
@@ -284,13 +284,13 @@ describe "BigInt" do
     (17).lcm(a_17).should eq(a_17)
   end
 
-  it "can use Number::[]" do
+  it("can use Number::[]") do
     a = BigInt[146, "3464", 97, "545"]
     b = [BigInt.new(146), BigInt.new(3464), BigInt.new(97), BigInt.new(545)]
     a.should eq(b)
   end
 
-  it "can be casted into other Number types" do
+  it("can be casted into other Number types") do
     big = BigInt.new(1234567890)
     big.to_i.should eq(1234567890)
     big.to_i8.should eq(-46)
@@ -314,16 +314,16 @@ describe "BigInt" do
     end
   {% end %}
 
-  it "does String#to_big_i" do
+  it("does String#to_big_i") do
     "123456789123456789".to_big_i.should eq(BigInt.new("123456789123456789"))
     "abcabcabcabcabcabc".to_big_i(base: 16).should eq(BigInt.new("3169001976782853491388"))
   end
 
-  it "does popcount" do
+  it("does popcount") do
     5.to_big_i.popcount.should eq(2)
   end
 
-  it "#hash" do
+  it("#hash") do
     b1 = 5.to_big_i
     b2 = 5.to_big_i
     b3 = 6.to_big_i
@@ -332,7 +332,7 @@ describe "BigInt" do
     b1.hash.should_not eq(b3.hash)
   end
 
-  it "clones" do
+  it("clones") do
     x = 1.to_big_i
     x.clone.should eq(x)
   end

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -22,8 +22,8 @@ private def test_comp(val, less, equal, greater, file = __FILE__, line = __LINE_
   (less <=> val).should eq(-1), file, line
 end
 
-describe BigRational do
-  it "initialize" do
+describe(BigRational) do
+  it("initialize") do
     BigRational.new(BigInt.new(10), BigInt.new(3))
                .should eq(BigRational.new(10, 3))
 
@@ -36,15 +36,15 @@ describe BigRational do
     end
   end
 
-  it "#numerator" do
+  it("#numerator") do
     br(10, 3).numerator.should eq(BigInt.new(10))
   end
 
-  it "#denominator" do
+  it("#denominator") do
     br(10, 3).denominator.should eq(BigInt.new(3))
   end
 
-  it "#to_s" do
+  it("#to_s") do
     br(10, 3).to_s.should eq("10/3")
     br(90, 3).to_s.should eq("30")
     br(1, 98).to_s.should eq("1/98")
@@ -54,43 +54,43 @@ describe BigRational do
     r.to_s(36).should eq("4woiz/9b3djm")
   end
 
-  it "#to_f64" do
+  it("#to_f64") do
     r = br(10, 3)
     f = 10.to_f64 / 3.to_f64
     r.to_f64.should be_close(f, 0.001)
   end
 
-  it "#to_f" do
+  it("#to_f") do
     r = br(10, 3)
     f = 10.to_f64 / 3.to_f64
     r.to_f.should be_close(f, 0.001)
   end
 
-  it "#to_f32" do
+  it("#to_f32") do
     r = br(10, 3)
     f = 10.to_f32 / 3.to_f32
     r.to_f32.should be_close(f, 0.001)
   end
 
-  it "#to_big_f" do
+  it("#to_big_f") do
     r = br(10, 3)
     f = 10.to_big_f / 3.to_big_f
     r.to_big_f.should be_close(f, 0.001)
   end
 
-  it "Int#to_big_r" do
+  it("Int#to_big_r") do
     3.to_big_r.should eq(br(3, 1))
   end
 
-  it "Float32#to_big_r" do
+  it("Float32#to_big_r") do
     0.3333333333333333333333_f32.to_big_r.should eq(br(11184811, 33554432))
   end
 
-  it "Float64#to_big_r" do
+  it("Float64#to_big_r") do
     0.3333333333333333333333_f64.to_big_r.should eq(br(6004799503160661, 18014398509481984))
   end
 
-  it "#<=>(:BigRational) and Comparable" do
+  it("#<=>(:BigRational) and Comparable") do
     a = br(11, 3)
     l = br(10, 3)
     e = a
@@ -102,75 +102,75 @@ describe BigRational do
     test_comp(a, l, e, g)
   end
 
-  it "#<=>(:Int) and Comparable" do
+  it("#<=>(:Int) and Comparable") do
     test_comp(br(10, 2), 4_i32, 5_i32, 6_i32)
     test_comp(br(10, 2), 4_i64, 5_i64, 6_i64)
   end
 
-  it "#<=>(:BigInt) and Comparable" do
+  it("#<=>(:BigInt) and Comparable") do
     test_comp(br(10, 2), BigInt.new(4), BigInt.new(5), BigInt.new(6))
   end
 
-  it "#<=>(:Float) and Comparable" do
+  it("#<=>(:Float) and Comparable") do
     test_comp(br(10, 2), 4.0_f32, 5.0_f32, 6.0_f32)
     test_comp(br(10, 2), 4.0_f64, 5.0_f64, 6.0_f64)
   end
 
-  it "#+" do
+  it("#+") do
     (br(10, 7) + br(3, 7)).should eq(br(13, 7))
     (0 + br(10, 7) + 3).should eq(br(31, 7))
   end
 
-  it "#-" do
+  it("#-") do
     (br(10, 7) - br(3, 7)).should eq(br(7, 7))
     (br(10, 7) - 3).should eq(br(-11, 7))
     (0 - br(10, 7)).should eq(br(-10, 7))
   end
 
-  it "#*" do
+  it("#*") do
     (br(10, 7) * br(3, 7)).should eq(br(30, 49))
     (1 * br(10, 7) * 3).should eq(br(30, 7))
   end
 
-  it "#/" do
+  it("#/") do
     (br(10, 7) / br(3, 7)).should eq(br(10, 3))
     expect_raises(DivisionByZero) { br(10, 7) / br(0, 10) }
     (br(10, 7) / 3).should eq(br(10, 21))
     (1 / br(10, 7)).should eq(br(7, 10))
   end
 
-  it "#- (negation)" do
+  it("#- (negation)") do
     (-br(10, 3)).should eq(br(-10, 3))
   end
 
-  it "#inv" do
+  it("#inv") do
     (br(10, 3).inv).should eq(br(3, 10))
     expect_raises(DivisionByZero) { br(0, 3).inv }
   end
 
-  it "#abs" do
+  it("#abs") do
     (br(-10, 3).abs).should eq(br(10, 3))
   end
 
-  it "#<<" do
+  it("#<<") do
     (br(10, 3) << 2).should eq(br(40, 3))
   end
 
-  it "#>>" do
+  it("#>>") do
     (br(10, 3) >> 2).should eq(br(5, 6))
   end
 
-  it "#hash" do
+  it("#hash") do
     b = br(10, 3)
     hash = b.hash
     hash.should eq(b.to_f64.hash)
   end
 
-  it "is a number" do
+  it("is a number") do
     br(10, 3).is_a?(Number).should be_true
   end
 
-  it "clones" do
+  it("clones") do
     x = br(10, 3)
     x.clone.should eq(x)
   end

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -7,65 +7,65 @@ private def from_int(size : Int32, int : Int)
   ba
 end
 
-describe "BitArray" do
-  it "has size" do
+describe("BitArray") do
+  it("has size") do
     ary = BitArray.new(100)
     ary.size.should eq(100)
   end
 
-  it "is initially empty" do
+  it("is initially empty") do
     ary = BitArray.new(100)
     100.times do |i|
       ary[i].should be_false
     end
   end
 
-  it "sets first bit to true" do
+  it("sets first bit to true") do
     ary = BitArray.new(100)
     ary[0] = true
     ary[0].should be_true
   end
 
-  it "sets second bit to true" do
+  it("sets second bit to true") do
     ary = BitArray.new(100)
     ary[1] = true
     ary[1].should be_true
   end
 
-  it "sets first bit to false" do
+  it("sets first bit to false") do
     ary = BitArray.new(100)
     ary[0] = true
     ary[0] = false
     ary[0].should be_false
   end
 
-  it "sets second bit to false" do
+  it("sets second bit to false") do
     ary = BitArray.new(100)
     ary[1] = true
     ary[1] = false
     ary[1].should be_false
   end
 
-  it "sets last bit to true with negative index" do
+  it("sets last bit to true with negative index") do
     ary = BitArray.new(100)
     ary[-1] = true
     ary[-1].should be_true
     ary[99].should be_true
   end
 
-  describe "==" do
-    it "compares empty" do
+  describe("==") do
+    it("compares empty") do
       (BitArray.new(0)).should eq(BitArray.new(0))
       from_int(1, 0b1).should_not eq(BitArray.new(0))
       (BitArray.new(0)).should_not eq(from_int(1, 0b1))
     end
 
-    it "compares elements" do
+    it("compares elements") do
       from_int(3, 0b101).should eq(from_int(3, 0b101))
       from_int(3, 0b101).should_not eq(from_int(3, 0b010))
     end
 
-    it "compares other" do
+    it("compares other") do
       a = from_int(3, 0b101)
       b = from_int(3, 0b101)
       c = from_int(4, 0b1111)
@@ -76,111 +76,111 @@ describe "BitArray" do
     end
   end
 
-  describe "[]" do
-    it "gets on inclusive range" do
+  describe("[]") do
+    it("gets on inclusive range") do
       from_int(6, 0b011110)[1..4].should eq(from_int(4, 0b1111))
     end
 
-    it "gets on inclusive range with negative indices" do
+    it("gets on inclusive range with negative indices") do
       from_int(6, 0b011110)[-5..-2].should eq(from_int(4, 0b1111))
     end
 
-    it "gets on exclusive range" do
+    it("gets on exclusive range") do
       from_int(6, 0b010100)[1...4].should eq(from_int(3, 0b101))
     end
 
-    it "gets on exclusive range with negative indices" do
+    it("gets on exclusive range with negative indices") do
       from_int(6, 0b010100)[-5...-2].should eq(from_int(3, 0b101))
     end
 
-    it "gets on range with start higher than end" do
+    it("gets on range with start higher than end") do
       from_int(3, 0b101)[2..1].should eq(BitArray.new(0))
       from_int(3, 0b101)[3..1].should eq(BitArray.new(0))
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         from_int(3, 0b101)[4..1]
       end
     end
 
-    it "gets on range with start higher than negative end" do
+    it("gets on range with start higher than negative end") do
       from_int(3, 0b011)[1..-1].should eq(from_int(2, 0b11))
       from_int(3, 0b011)[2..-2].should eq(BitArray.new(0))
     end
 
-    it "raises on index out of bounds with range" do
-      expect_raises IndexError do
+    it("raises on index out of bounds with range") do
+      expect_raises(IndexError) do
         from_int(3, 0b111)[4..6]
       end
     end
 
-    it "gets with start and count" do
+    it("gets with start and count") do
       from_int(6, 0b011100)[1, 3].should eq(from_int(3, 0b111))
     end
 
-    it "gets with start and count exceeding size" do
+    it("gets with start and count exceeding size") do
       from_int(3, 0b011)[1, 3].should eq(from_int(2, 0b11))
     end
 
-    it "gets with negative start" do
+    it("gets with negative start") do
       from_int(6, 0b001100)[-4, 2].should eq(from_int(2, 0b11))
     end
 
-    it "raises on index out of bounds with start and count" do
-      expect_raises IndexError do
+    it("raises on index out of bounds with start and count") do
+      expect_raises(IndexError) do
         from_int(3, 0b101)[4, 0]
       end
     end
 
-    it "raises on negative count" do
-      expect_raises ArgumentError do
+    it("raises on negative count") do
+      expect_raises(ArgumentError) do
         from_int(3, 0b101)[3, -1]
       end
     end
 
-    it "raises on index out of bounds" do
-      expect_raises IndexError do
+    it("raises on index out of bounds") do
+      expect_raises(IndexError) do
         from_int(3, 0b101)[-4, 2]
       end
     end
 
-    it "raises on negative count" do
-      expect_raises ArgumentError, /Negative count: -1/ do
+    it("raises on negative count") do
+      expect_raises(ArgumentError, /Negative count: -1/) do
         from_int(3, 0b101)[1, -1]
       end
     end
 
-    it "raises on negative count on empty Array" do
+    it("raises on negative count on empty Array") do
       ba = BitArray.new(0)
-      expect_raises ArgumentError, /Negative count: -1/ do
+      expect_raises(ArgumentError, /Negative count: -1/) do
         ba[0, -1]
       end
     end
 
-    it "gets 0, 0 on empty array" do
+    it("gets 0, 0 on empty array") do
       a = BitArray.new(0)
       a[0, 0].should eq(a)
     end
 
-    it "gets (0..0) on empty array" do
+    it("gets (0..0) on empty array") do
       a = BitArray.new(0)
       a[0..0].should eq(a)
     end
 
-    it "doesn't exceed limits" do
+    it("doesn't exceed limits") do
       from_int(1, 0b1)[0..3].should eq(from_int(1, 0b1))
     end
 
-    it "returns empty if at end" do
+    it("returns empty if at end") do
       from_int(1, 0b1)[1, 0].should eq(BitArray.new(0))
       from_int(1, 0b1)[1, 10].should eq(BitArray.new(0))
     end
 
-    it "raises on too negative left bound" do
-      expect_raises IndexError do
+    it("raises on too negative left bound") do
+      expect_raises(IndexError) do
         from_int(3, 0b101)[-4..0]
       end
     end
 
-    it "gets on medium bitarrays" do
+    it("gets on medium bitarrays") do
       ba = BitArray.new(40)
       ba[30] = true
       ba[31] = true
@@ -191,7 +191,7 @@ describe "BitArray" do
       ba[28..-1].should eq(from_int(12, 0b001110100100))
     end
 
-    it "gets on large bitarrays" do
+    it("gets on large bitarrays") do
       ba = BitArray.new(100)
       ba[30] = true
       ba[31] = true
@@ -211,7 +211,7 @@ describe "BitArray" do
       ba[28..72].should eq(from_int(45, 0b001110100100000000000000000000000011101001000_u64))
     end
 
-    it "preserves equality" do
+    it("preserves equality") do
       ba = BitArray.new(100)
       25.upto(42) { |i| ba[i] = true }
 
@@ -219,7 +219,7 @@ describe "BitArray" do
     end
   end
 
-  it "toggles a bit" do
+  it("toggles a bit") do
     ary = BitArray.new(32)
     ary[3].should be_false
 
@@ -230,7 +230,7 @@ describe "BitArray" do
     ary[3].should be_false
   end
 
-  it "inverts all bits" do
+  it("inverts all bits") do
     ary = BitArray.new(100)
     ary.none?.should be_true
 
@@ -245,14 +245,14 @@ describe "BitArray" do
     ary.count { |b| b }.should eq(2)
   end
 
-  it "raises when out of bounds" do
+  it("raises when out of bounds") do
     ary = BitArray.new(10)
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       ary[10] = true
     end
   end
 
-  it "does to_s and inspect" do
+  it("does to_s and inspect") do
     ary = BitArray.new(8)
     ary[0] = true
     ary[2] = true
@@ -261,12 +261,12 @@ describe "BitArray" do
     ary.inspect.should eq("BitArray[10101000]")
   end
 
-  it "initializes with true by default" do
+  it("initializes with true by default") do
     ary = BitArray.new(64, true)
     ary.size.times { |i| ary[i].should be_true }
   end
 
-  it "reads bits from slice" do
+  it("reads bits from slice") do
     ary = BitArray.new(43) # 5 bytes 3 bits
     # 11010000_00000000_00001011_00000000_00000000_101xxxxx
     ary[0] = true
@@ -288,7 +288,7 @@ describe "BitArray" do
     slice[5].should eq(0b00000101_u8)
   end
 
-  it "read bits written from slice" do
+  it("read bits written from slice") do
     ary = BitArray.new(43) # 5 bytes 3 bits
     slice = ary.to_slice
     slice[0] = 0b10101010_u8
@@ -299,7 +299,7 @@ describe "BitArray" do
     end
   end
 
-  it "provides an iterator" do
+  it("provides an iterator") do
     ary = BitArray.new(2)
     ary[0] = true
     ary[1] = false
@@ -316,7 +316,7 @@ describe "BitArray" do
     iter.cycle.first(3).to_a.should eq([true, false, true])
   end
 
-  it "provides an index iterator" do
+  it("provides an index iterator") do
     ary = BitArray.new(2)
 
     iter = ary.each_index
@@ -328,7 +328,7 @@ describe "BitArray" do
     iter.next.should eq(0)
   end
 
-  it "provides a reverse iterator" do
+  it("provides a reverse iterator") do
     ary = BitArray.new(2)
     ary[0] = true
     ary[1] = false

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -1,42 +1,42 @@
 require "spec"
 
-describe "Bool" do
-  describe "!" do
+describe("Bool") do
+  describe("!") do
     it { (!true).should be_false }
     it { (!false).should be_true }
   end
 
-  describe "|" do
+  describe("|") do
     it { (false | false).should be_false }
     it { (false | true).should be_true }
     it { (true | false).should be_true }
     it { (true | true).should be_true }
   end
 
-  describe "&" do
+  describe("&") do
     it { (false & false).should be_false }
     it { (false & true).should be_false }
     it { (true & false).should be_false }
     it { (true & true).should be_true }
   end
 
-  describe "^" do
+  describe("^") do
     it { (false ^ false).should be_false }
     it { (false ^ true).should be_true }
     it { (true ^ false).should be_true }
     it { (true ^ true).should be_false }
   end
 
-  describe "hash" do
+  describe("hash") do
     it { true.hash.should_not eq(false.hash) }
   end
 
-  describe "to_s" do
+  describe("to_s") do
     it { true.to_s.should eq("true") }
     it { false.to_s.should eq("false") }
   end
 
-  describe "clone" do
+  describe("clone") do
     it { true.clone.should be_true }
     it { false.clone.should be_false }
   end

--- a/spec/std/box_spec.cr
+++ b/spec/std/box_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "Box" do
-  it "boxes and unboxes" do
+describe("Box") do
+  it("boxes and unboxes") do
     a = 1
     box = Box.box(a)
     Box(Int32).unbox(box).should eq(1)

--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "tempfile"
 
-describe "Backtrace" do
-  it "prints file line:colunm" do
+describe("Backtrace") do
+  it("prints file line:colunm") do
     tempfile = Tempfile.new("compiler_spec_output")
     tempfile.close
     sample = "#{__DIR__}/data/backtrace_sample"
@@ -39,7 +39,7 @@ describe "Backtrace" do
     output.should_not match(/src\/raise\.cr/)
   end
 
-  it "prints exception backtrace to stderr" do
+  it("prints exception backtrace to stderr") do
     tempfile = Tempfile.new("compiler_spec_output")
     tempfile.close
     sample = "#{__DIR__}/data/exception_backtrace_sample"
@@ -55,7 +55,7 @@ describe "Backtrace" do
     error.to_s.should contain("IndexError")
   end
 
-  it "prints crash backtrace to stderr" do
+  it("prints crash backtrace to stderr") do
     tempfile = Tempfile.new("compiler_spec_output")
     tempfile.close
     sample = "#{__DIR__}/data/crash_backtrace_sample"

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -1,26 +1,26 @@
 require "spec"
 
-describe Channel do
-  it "creates unbuffered with no arguments" do
+describe(Channel) do
+  it("creates unbuffered with no arguments") do
     Channel(Int32).new.should be_a(Channel::Unbuffered(Int32))
   end
 
-  it "creates buffered with capacity argument" do
+  it("creates buffered with capacity argument") do
     Channel(Int32).new(32).should be_a(Channel::Buffered(Int32))
   end
 
-  it "send returns channel" do
+  it("send returns channel") do
     channel = Channel(Int32).new(1)
     channel.send(1).should be(channel)
   end
 
-  it "does receive_first" do
+  it("does receive_first") do
     channel = Channel(Int32).new(1)
     channel.send(1)
     Channel.receive_first(Channel(Int32).new, channel).should eq 1
   end
 
-  it "does send_first" do
+  it("does send_first") do
     ch1 = Channel(Int32).new(1)
     ch2 = Channel(Int32).new(1)
     ch1.send(1)
@@ -29,15 +29,15 @@ describe Channel do
   end
 end
 
-describe Channel::Unbuffered do
-  it "pings" do
+describe(Channel::Unbuffered) do
+  it("pings") do
     ch = Channel::Unbuffered(Int32).new
     spawn { ch.send(ch.receive) }
     ch.send 123
     ch.receive.should eq(123)
   end
 
-  it "blocks if there is no receiver" do
+  it("blocks if there is no receiver") do
     ch = Channel::Unbuffered(Int32).new
     state = 0
     spawn do
@@ -54,7 +54,7 @@ describe Channel::Unbuffered do
     state.should eq(2)
   end
 
-  it "deliver many senders" do
+  it("deliver many senders") do
     ch = Channel::Unbuffered(Int32).new
     spawn { ch.send 1; ch.send 4 }
     spawn { ch.send 2; ch.send 5 }
@@ -63,7 +63,7 @@ describe Channel::Unbuffered do
     (1..6).map { ch.receive }.sort.should eq([1, 2, 3, 4, 5, 6])
   end
 
-  it "gets not full when there is a sender" do
+  it("gets not full when there is a sender") do
     ch = Channel::Unbuffered(Int32).new
     ch.full?.should be_true
     ch.empty?.should be_true
@@ -74,19 +74,19 @@ describe Channel::Unbuffered do
     ch.receive.should eq(123)
   end
 
-  it "works with select" do
+  it("works with select") do
     ch1 = Channel::Unbuffered(Int32).new
     ch2 = Channel::Unbuffered(Int32).new
     spawn { ch1.send 123 }
     Channel.select(ch1.receive_select_action, ch2.receive_select_action).should eq({0, 123})
   end
 
-  it "works with select else" do
+  it("works with select else") do
     ch1 = Channel::Unbuffered(Int32).new
     Channel.select({ch1.receive_select_action}, true).should eq({1, nil})
   end
 
-  it "can send and receive nil" do
+  it("can send and receive nil") do
     ch = Channel::Unbuffered(Nil).new
     spawn { ch.send nil }
     Fiber.yield
@@ -95,7 +95,7 @@ describe Channel::Unbuffered do
     ch.empty?.should be_true
   end
 
-  it "can be closed" do
+  it("can be closed") do
     ch = Channel::Unbuffered(Int32).new
     ch.closed?.should be_false
     ch.close.should be_nil
@@ -103,14 +103,14 @@ describe Channel::Unbuffered do
     expect_raises(Channel::ClosedError) { ch.receive }
   end
 
-  it "can be closed after sending" do
+  it("can be closed after sending") do
     ch = Channel::Unbuffered(Int32).new
     spawn { ch.send 123; ch.close }
     ch.receive.should eq(123)
     expect_raises(Channel::ClosedError) { ch.receive }
   end
 
-  it "can be closed from different fiber" do
+  it("can be closed from different fiber") do
     ch = Channel::Unbuffered(Int32).new
     received = false
     spawn { expect_raises(Channel::ClosedError) { ch.receive }; received = true }
@@ -120,34 +120,34 @@ describe Channel::Unbuffered do
     received.should be_true
   end
 
-  it "cannot send if closed" do
+  it("cannot send if closed") do
     ch = Channel::Unbuffered(Int32).new
     ch.close
     expect_raises(Channel::ClosedError) { ch.send 123 }
   end
 
-  it "can receive? when closed" do
+  it("can receive? when closed") do
     ch = Channel::Unbuffered(Int32).new
     ch.close
     ch.receive?.should be_nil
   end
 
-  it "can receive? when not empty" do
+  it("can receive? when not empty") do
     ch = Channel::Unbuffered(Int32).new
     spawn { ch.send 123 }
     ch.receive?.should eq(123)
   end
 end
 
-describe Channel::Buffered do
-  it "pings" do
+describe(Channel::Buffered) do
+  it("pings") do
     ch = Channel::Buffered(Int32).new
     spawn { ch.send(ch.receive) }
     ch.send 123
     ch.receive.should eq(123)
   end
 
-  it "blocks when full" do
+  it("blocks when full") do
     ch = Channel::Buffered(Int32).new(2)
     freed = false
     spawn { 2.times { ch.receive }; freed = true }
@@ -165,7 +165,7 @@ describe Channel::Buffered do
     freed.should be_true
   end
 
-  it "doesn't block when not full" do
+  it("doesn't block when not full") do
     ch = Channel::Buffered(Int32).new
     done = false
     spawn { ch.send 123; done = true }
@@ -174,21 +174,21 @@ describe Channel::Buffered do
     done.should be_true
   end
 
-  it "gets ready with data" do
+  it("gets ready with data") do
     ch = Channel::Buffered(Int32).new
     ch.empty?.should be_true
     ch.send 123
     ch.empty?.should be_false
   end
 
-  it "works with select" do
+  it("works with select") do
     ch1 = Channel::Buffered(Int32).new
     ch2 = Channel::Buffered(Int32).new
     spawn { ch1.send 123 }
     Channel.select(ch1.receive_select_action, ch2.receive_select_action).should eq({0, 123})
   end
 
-  it "can send and receive nil" do
+  it("can send and receive nil") do
     ch = Channel::Buffered(Nil).new
     spawn { ch.send nil }
     Fiber.yield
@@ -197,7 +197,7 @@ describe Channel::Buffered do
     ch.empty?.should be_true
   end
 
-  it "can be closed" do
+  it("can be closed") do
     ch = Channel::Buffered(Int32).new
     ch.closed?.should be_false
     ch.close
@@ -205,14 +205,14 @@ describe Channel::Buffered do
     expect_raises(Channel::ClosedError) { ch.receive }
   end
 
-  it "can be closed after sending" do
+  it("can be closed after sending") do
     ch = Channel::Buffered(Int32).new
     spawn { ch.send 123; ch.close }
     ch.receive.should eq(123)
     expect_raises(Channel::ClosedError) { ch.receive }
   end
 
-  it "can be closed from different fiber" do
+  it("can be closed from different fiber") do
     ch = Channel::Buffered(Int32).new
     received = false
     spawn { expect_raises(Channel::ClosedError) { ch.receive }; received = true }
@@ -222,40 +222,40 @@ describe Channel::Buffered do
     received.should be_true
   end
 
-  it "cannot send if closed" do
+  it("cannot send if closed") do
     ch = Channel::Buffered(Int32).new
     ch.close
     expect_raises(Channel::ClosedError) { ch.send 123 }
   end
 
-  it "can receive? when closed" do
+  it("can receive? when closed") do
     ch = Channel::Buffered(Int32).new
     ch.close
     ch.receive?.should be_nil
   end
 
-  it "can receive? when not empty" do
+  it("can receive? when not empty") do
     ch = Channel::Buffered(Int32).new
     spawn { ch.send 123 }
     ch.receive?.should eq(123)
   end
 
-  it "does inspect on unbuffered channel" do
+  it("does inspect on unbuffered channel") do
     ch = Channel::Unbuffered(Int32).new
     ch.inspect.should eq("#<Channel::Unbuffered(Int32):0x#{ch.object_id.to_s(16)}>")
   end
 
-  it "does inspect on buffered channel" do
+  it("does inspect on buffered channel") do
     ch = Channel::Buffered(Int32).new(10)
     ch.inspect.should eq("#<Channel::Buffered(Int32):0x#{ch.object_id.to_s(16)}>")
   end
 
-  it "does pretty_inspect on unbuffered channel" do
+  it("does pretty_inspect on unbuffered channel") do
     ch = Channel::Unbuffered(Int32).new
     ch.pretty_inspect.should eq("#<Channel::Unbuffered(Int32):0x#{ch.object_id.to_s(16)}>")
   end
 
-  it "does pretty_inspect on buffered channel" do
+  it("does pretty_inspect on buffered channel") do
     ch = Channel::Buffered(Int32).new(10)
     ch.pretty_inspect.should eq("#<Channel::Buffered(Int32):0x#{ch.object_id.to_s(16)}>")
   end

--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -8,20 +8,20 @@ private def assert_invalid_byte_sequence(bytes, width)
   reader.error.should eq(bytes[0])
 end
 
-describe "Char::Reader" do
-  it "iterates through empty string" do
+describe("Char::Reader") do
+  it("iterates through empty string") do
     reader = Char::Reader.new("")
     reader.pos.should eq(0)
     reader.current_char.ord.should eq(0)
     reader.error.should be_nil
     reader.has_next?.should be_false
 
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       reader.next_char
     end
   end
 
-  it "iterates through string of size one" do
+  it("iterates through string of size one") do
     reader = Char::Reader.new("a")
     reader.pos.should eq(0)
     reader.current_char.should eq('a')
@@ -29,12 +29,12 @@ describe "Char::Reader" do
     reader.next_char.ord.should eq(0)
     reader.has_next?.should be_false
 
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       reader.next_char
     end
   end
 
-  it "iterates through chars" do
+  it("iterates through chars") do
     reader = Char::Reader.new("há日本語")
     reader.pos.should eq(0)
     reader.current_char.ord.should eq(104)
@@ -53,24 +53,24 @@ describe "Char::Reader" do
     reader.next_char.ord.should eq(0)
     reader.has_next?.should be_false
 
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       reader.next_char
     end
   end
 
-  it "peeks next char" do
+  it("peeks next char") do
     reader = Char::Reader.new("há日本語")
     reader.peek_next_char.ord.should eq(225)
   end
 
-  it "sets pos" do
+  it("sets pos") do
     reader = Char::Reader.new("há日本語")
     reader.pos = 1
     reader.pos.should eq(1)
     reader.current_char.ord.should eq(225)
   end
 
-  it "is an Enumerable(Char)" do
+  it("is an Enumerable(Char)") do
     reader = Char::Reader.new("abc")
     sum = 0
     reader.each do |char|
@@ -79,21 +79,21 @@ describe "Char::Reader" do
     sum.should eq(294)
   end
 
-  it "is an Enumerable(Char) but doesn't yield if empty" do
+  it("is an Enumerable(Char) but doesn't yield if empty") do
     reader = Char::Reader.new("")
     reader.each do |char|
       fail "reader each shouldn't yield on empty string"
     end.should be_nil
   end
 
-  it "starts at end" do
+  it("starts at end") do
     reader = Char::Reader.new(at_end: "")
     reader.pos.should eq(0)
     reader.current_char.ord.should eq(0)
     reader.has_previous?.should be_false
   end
 
-  it "gets previous char (ascii)" do
+  it("gets previous char (ascii)") do
     reader = Char::Reader.new(at_end: "hello")
     reader.pos.should eq(4)
     reader.current_char.should eq('o')
@@ -105,12 +105,12 @@ describe "Char::Reader" do
     reader.previous_char.should eq('h')
     reader.has_previous?.should be_false
 
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       reader.previous_char
     end
   end
 
-  it "gets previous char (unicode)" do
+  it("gets previous char (unicode)") do
     reader = Char::Reader.new(at_end: "há日本語")
     reader.pos.should eq(9)
     reader.current_char.should eq('語')
@@ -123,46 +123,46 @@ describe "Char::Reader" do
     reader.has_previous?.should be_false
   end
 
-  it "starts at pos" do
+  it("starts at pos") do
     reader = Char::Reader.new("há日本語", pos: 9)
     reader.pos.should eq(9)
     reader.current_char.should eq('語')
   end
 
-  it "errors if 0x80 <= first_byte < 0xC2" do
+  it("errors if 0x80 <= first_byte < 0xC2") do
     assert_invalid_byte_sequence Bytes[0x80], 1
     assert_invalid_byte_sequence Bytes[0xC1], 1
   end
 
-  it "errors if (second_byte & 0xC0) != 0x80" do
+  it("errors if (second_byte & 0xC0) != 0x80") do
     assert_invalid_byte_sequence Bytes[0xd0], 1
   end
 
-  it "errors if first_byte == 0xE0 && second_byte < 0xA0" do
+  it("errors if first_byte == 0xE0 && second_byte < 0xA0") do
     assert_invalid_byte_sequence Bytes[0xe0, 0x9F, 0xA0], 3
   end
 
-  it "errors if first_byte == 0xED && second_byte >= 0xA0" do
+  it("errors if first_byte == 0xED && second_byte >= 0xA0") do
     assert_invalid_byte_sequence Bytes[0xed, 0xB0, 0xA0], 3
   end
 
-  it "errors if first_byte < 0xF0 && (third_byte & 0xC0) != 0x80" do
+  it("errors if first_byte < 0xF0 && (third_byte & 0xC0) != 0x80") do
     assert_invalid_byte_sequence Bytes[0xe0, 0xA0, 0], 2
   end
 
-  it "errors if first_byte == 0xF0 && second_byte < 0x90" do
+  it("errors if first_byte == 0xF0 && second_byte < 0x90") do
     assert_invalid_byte_sequence Bytes[0xf0, 0x8F, 0xA0], 3
   end
 
-  it "errors if first_byte == 0xF4 && second_byte >= 0x90" do
+  it("errors if first_byte == 0xF4 && second_byte >= 0x90") do
     assert_invalid_byte_sequence Bytes[0xf4, 0x90, 0xA0], 3
   end
 
-  it "errors if first_byte < 0xF5 && (fourth_byte & 0xC0) != 0x80" do
+  it("errors if first_byte < 0xF5 && (fourth_byte & 0xC0) != 0x80") do
     assert_invalid_byte_sequence Bytes[0xf4, 0x8F, 0xA0, 0], 4
   end
 
-  it "errors if first_byte >= 0xF5" do
+  it("errors if first_byte >= 0xF5") do
     assert_invalid_byte_sequence Bytes[0xf5, 0x8F, 0xA0, 0xA0], 4
   end
 end

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -1,13 +1,13 @@
 require "spec"
 require "unicode"
 
-describe "Char" do
-  describe "upcase" do
+describe("Char") do
+  describe("upcase") do
     it { 'a'.upcase.should eq('A') }
     it { '1'.upcase.should eq('1') }
   end
 
-  describe "downcase" do
+  describe("downcase") do
     it { 'A'.downcase.should eq('a') }
     it { '1'.downcase.should eq('1') }
     it do
@@ -18,32 +18,32 @@ describe "Char" do
     it { 'Ń'.downcase(Unicode::CaseOptions::Fold).should eq('ń') }
   end
 
-  describe "succ" do
+  describe("succ") do
     it { 'a'.succ.should eq('b') }
     it { 'あ'.succ.should eq('ぃ') }
   end
 
-  describe "pred" do
+  describe("pred") do
     it { 'b'.pred.should eq('a') }
     it { 'ぃ'.pred.should eq('あ') }
   end
 
-  describe "+" do
+  describe("+") do
     it { ('a' + 2).should eq('c') }
   end
 
-  describe "-" do
+  describe("-") do
     it { ('c' - 2).should eq('a') }
   end
 
-  describe "ascii_uppercase?" do
+  describe("ascii_uppercase?") do
     it { 'a'.ascii_uppercase?.should be_false }
     it { 'A'.ascii_uppercase?.should be_true }
     it { '1'.ascii_uppercase?.should be_false }
     it { ' '.ascii_uppercase?.should be_false }
   end
 
-  describe "uppercase?" do
+  describe("uppercase?") do
     it { 'A'.uppercase?.should be_true }
     it { 'Á'.uppercase?.should be_true }
     it { 'Ā'.uppercase?.should be_true }
@@ -55,14 +55,14 @@ describe "Char" do
     it { ' '.uppercase?.should be_false }
   end
 
-  describe "ascii_lowercase?" do
+  describe("ascii_lowercase?") do
     it { 'a'.ascii_lowercase?.should be_true }
     it { 'A'.ascii_lowercase?.should be_false }
     it { '1'.ascii_lowercase?.should be_false }
     it { ' '.ascii_lowercase?.should be_false }
   end
 
-  describe "lowercase?" do
+  describe("lowercase?") do
     it { 'a'.lowercase?.should be_true }
     it { 'á'.lowercase?.should be_true }
     it { 'ā'.lowercase?.should be_true }
@@ -73,28 +73,28 @@ describe "Char" do
     it { ' '.lowercase?.should be_false }
   end
 
-  describe "ascii_letter?" do
+  describe("ascii_letter?") do
     it { 'a'.ascii_letter?.should be_true }
     it { 'A'.ascii_letter?.should be_true }
     it { '1'.ascii_letter?.should be_false }
     it { ' '.ascii_letter?.should be_false }
   end
 
-  describe "alphanumeric?" do
+  describe("alphanumeric?") do
     it { 'a'.alphanumeric?.should be_true }
     it { 'A'.alphanumeric?.should be_true }
     it { '1'.alphanumeric?.should be_true }
     it { ' '.alphanumeric?.should be_false }
   end
 
-  describe "ascii_whitespace?" do
+  describe("ascii_whitespace?") do
     [' ', '\t', '\n', '\v', '\f', '\r'].each do |char|
       it { char.ascii_whitespace?.should be_true }
     end
     it { 'A'.ascii_whitespace?.should be_false }
   end
 
-  describe "hex?" do
+  describe("hex?") do
     "0123456789abcdefABCDEF".each_char do |char|
       it { char.hex?.should be_true }
     end
@@ -106,7 +106,7 @@ describe "Char" do
     end
   end
 
-  it "dumps" do
+  it("dumps") do
     'a'.dump.should eq("'a'")
     '\\'.dump.should eq("'\\\\'")
     '\e'.dump.should eq("'\\e'")
@@ -119,7 +119,7 @@ describe "Char" do
     '\u{81}'.dump.should eq("'\\u{81}'")
   end
 
-  it "inspects" do
+  it("inspects") do
     'a'.inspect.should eq("'a'")
     '\\'.inspect.should eq("'\\\\'")
     '\e'.inspect.should eq("'\\e'")
@@ -132,7 +132,7 @@ describe "Char" do
     '\u{81}'.inspect.should eq("'\\u{81}'")
   end
 
-  it "escapes" do
+  it("escapes") do
     '\b'.ord.should eq(8)
     '\t'.ord.should eq(9)
     '\n'.ord.should eq(10)
@@ -144,13 +144,13 @@ describe "Char" do
     '\\'.ord.should eq(92)
   end
 
-  it "escapes with unicode" do
+  it("escapes with unicode") do
     '\u{12}'.ord.should eq(1 * 16 + 2)
     '\u{A}'.ord.should eq(10)
     '\u{AB}'.ord.should eq(10 * 16 + 11)
   end
 
-  it "does to_i without a base" do
+  it("does to_i without a base") do
     ('0'..'9').each_with_index do |c, i|
       c.to_i.should eq(i)
     end
@@ -188,7 +188,7 @@ describe "Char" do
     'a'.to_u64?.should be_nil
   end
 
-  it "does to_i with 16 base" do
+  it("does to_i with 16 base") do
     ('0'..'9').each_with_index do |c, i|
       c.to_i(16).should eq(i)
     end
@@ -202,7 +202,7 @@ describe "Char" do
     'Z'.to_i?(16).should be_nil
   end
 
-  it "does to_i with base 36" do
+  it("does to_i with base 36") do
     letters = ('0'..'9').each.chain(('a'..'z').each).chain(('A'..'Z').each)
     nums = (0..9).each.chain((10..35).each).chain((10..35).each)
     letters.zip(nums).each do |(letter, num)|
@@ -210,19 +210,19 @@ describe "Char" do
     end
   end
 
-  it "to_i rejects unsupported base (1)" do
-    expect_raises ArgumentError, "Invalid base 1" do
+  it("to_i rejects unsupported base (1)") do
+    expect_raises(ArgumentError, "Invalid base 1") do
       '0'.to_i(1)
     end
   end
 
-  it "to_i rejects unsupported base (37)" do
-    expect_raises ArgumentError, "Invalid base 37" do
+  it("to_i rejects unsupported base (37)") do
+    expect_raises(ArgumentError, "Invalid base 37") do
       '0'.to_i(37)
     end
   end
 
-  it "does to_f" do
+  it("does to_f") do
     ('0'..'9').each.zip((0..9).each).each do |c, i|
       c.to_f.should eq(i.to_f)
     end
@@ -234,61 +234,61 @@ describe "Char" do
     'a'.to_f64?.should be_nil
   end
 
-  it "does ord for multibyte char" do
+  it("does ord for multibyte char") do
     '日'.ord.should eq(26085)
   end
 
-  it "does to_s for single-byte char" do
+  it("does to_s for single-byte char") do
     'a'.to_s.should eq("a")
   end
 
-  it "does to_s for multibyte char" do
+  it("does to_s for multibyte char") do
     '日'.to_s.should eq("日")
   end
 
-  describe "index" do
+  describe("index") do
     it { "foo".index('o').should eq(1) }
     it { "foo".index('x').should be_nil }
   end
 
-  it "does <=>" do
+  it("does <=>") do
     ('a' <=> 'b').should be < 0
     ('a' <=> 'a').should eq(0)
     ('b' <=> 'a').should be > 0
   end
 
-  describe "+" do
-    it "does for both ascii" do
+  describe("+") do
+    it("does for both ascii") do
       str = 'f' + "oo"
       str.bytesize.should eq(3)
       str.@length.should eq(3)
       str.should eq("foo")
     end
 
-    it "does for both unicode" do
+    it("does for both unicode") do
       str = '青' + "旅路"
       str.@length.should eq(3)
       str.should eq("青旅路")
     end
   end
 
-  describe "bytesize" do
-    it "does for ascii" do
+  describe("bytesize") do
+    it("does for ascii") do
       'a'.bytesize.should eq(1)
     end
 
-    it "does for unicode" do
+    it("does for unicode") do
       '青'.bytesize.should eq(3)
     end
 
-    it "raises on codepoint bigger than 0x10ffff" do
-      expect_raises InvalidByteSequenceError do
+    it("raises on codepoint bigger than 0x10ffff") do
+      expect_raises(InvalidByteSequenceError) do
         (0x10ffff + 1).unsafe_chr.bytesize
       end
     end
   end
 
-  describe "in_set?" do
+  describe("in_set?") do
     it { 'a'.in_set?("a").should be_true }
     it { 'a'.in_set?("b").should be_false }
     it { 'a'.in_set?("a-c").should be_true }
@@ -325,28 +325,28 @@ describe "Char" do
     it { 'a'.in_set?("a", "b").should be_false }
     it { 'a'.in_set?("ab", "ac", "ad").should be_true }
 
-    it "rejects invalid ranges" do
+    it("rejects invalid ranges") do
       expect_raises do
         'a'.in_set?("c-a")
       end
     end
   end
 
-  it "raises on codepoint bigger than 0x10ffff when doing each_byte" do
-    expect_raises InvalidByteSequenceError do
+  it("raises on codepoint bigger than 0x10ffff when doing each_byte") do
+    expect_raises(InvalidByteSequenceError) do
       (0x10ffff + 1).unsafe_chr.each_byte { |b| }
     end
   end
 
-  it "does each_byte" do
+  it("does each_byte") do
     'a'.each_byte(&.should eq('a'.ord)).should be_nil
   end
 
-  it "does bytes" do
+  it("does bytes") do
     '\u{FF}'.bytes.should eq([195, 191])
   end
 
-  it "#===(:Int)" do
+  it("#===(:Int)") do
     ('c'.ord).should eq(99)
     ('c' === 99_u8).should be_true
     ('c' === 99).should be_true
@@ -356,7 +356,7 @@ describe "Char" do
     ('酒' === 37202).should be_true
   end
 
-  it "does ascii_number?" do
+  it("does ascii_number?") do
     256.times do |i|
       chr = i.chr
       ("01".chars.includes?(chr) == chr.ascii_number?(2)).should be_true
@@ -365,38 +365,38 @@ describe "Char" do
       ("0123456789".chars.includes?(chr) == chr.ascii_number?(10)).should be_true
       ("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".includes?(chr) == chr.ascii_number?(36)).should be_true
       unless 2 <= i <= 36
-        expect_raises ArgumentError do
+        expect_raises(ArgumentError) do
           '0'.ascii_number?(i)
         end
       end
     end
   end
 
-  it "does number?" do
+  it("does number?") do
     it { '1'.number?.should be_true }
     it { '٠'.number?.should be_true }
     it { '٢'.number?.should be_true }
     it { 'a'.number?.should be_false }
   end
 
-  it "does ascii_control?" do
+  it("does ascii_control?") do
     'ù'.ascii_control?.should be_false
     'a'.ascii_control?.should be_false
     '\u0019'.ascii_control?.should be_true
   end
 
-  it "does mark?" do
+  it("does mark?") do
     0x300.chr.mark?.should be_true
   end
 
-  it "does ascii?" do
+  it("does ascii?") do
     'a'.ascii?.should be_true
     127.chr.ascii?.should be_true
     128.chr.ascii?.should be_false
     '酒'.ascii?.should be_false
   end
 
-  describe "clone" do
+  describe("clone") do
     it { 'a'.clone.should eq('a') }
   end
 end

--- a/spec/std/class_spec.cr
+++ b/spec/std/class_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe Class do
-  it "does ===" do
+describe(Class) do
+  it("does ===") do
     (Int32 === 1).should be_true
     (Int32 === 1.5).should be_false
     (Array === [1]).should be_true
@@ -9,7 +9,7 @@ describe Class do
     (Array(Int32) === ['a']).should be_false
   end
 
-  it "casts, allowing the class to be passed in at runtime" do
+  it("casts, allowing the class to be passed in at runtime") do
     ar = [99, "something"]
     cl = {Int32, String}
     casted = {cl[0].cast(ar[0]), cl[1].cast(ar[1])}
@@ -18,20 +18,20 @@ describe Class do
     typeof(casted[1]).should eq(String)
   end
 
-  it "does |" do
+  it("does |") do
     (Int32 | Char).should eq(typeof(1, 'a'))
     (Int32 | Char | Float64).should eq(typeof(1, 'a', 1.0))
   end
 
-  it "dups" do
+  it("dups") do
     Int32.dup.should eq(Int32)
   end
 
-  it "clones" do
+  it("clones") do
     Int32.clone.should eq(Int32)
   end
 
-  it "#nilable" do
+  it("#nilable") do
     Int32.nilable?.should be_false
     Nil.nilable?.should be_true
     (Int32 | String).nilable?.should be_false

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -9,12 +9,12 @@ private def with_color_wrap(*args)
   with_color(*args).toggle(true)
 end
 
-describe "colorize" do
-  it "colorizes without change" do
+describe("colorize") do
+  it("colorizes without change") do
     colorize("hello").to_s.should eq("hello")
   end
 
-  it "colorizes foreground" do
+  it("colorizes foreground") do
     colorize("hello").black.to_s.should eq("\e[30mhello\e[0m")
     colorize("hello").red.to_s.should eq("\e[31mhello\e[0m")
     colorize("hello").green.to_s.should eq("\e[32mhello\e[0m")
@@ -33,7 +33,7 @@ describe "colorize" do
     colorize("hello").white.to_s.should eq("\e[97mhello\e[0m")
   end
 
-  it "colorizes background" do
+  it("colorizes background") do
     colorize("hello").on_black.to_s.should eq("\e[40mhello\e[0m")
     colorize("hello").on_red.to_s.should eq("\e[41mhello\e[0m")
     colorize("hello").on_green.to_s.should eq("\e[42mhello\e[0m")
@@ -52,7 +52,7 @@ describe "colorize" do
     colorize("hello").on_white.to_s.should eq("\e[107mhello\e[0m")
   end
 
-  it "colorizes mode" do
+  it("colorizes mode") do
     colorize("hello").bold.to_s.should eq("\e[1mhello\e[0m")
     colorize("hello").bright.to_s.should eq("\e[1mhello\e[0m")
     colorize("hello").dim.to_s.should eq("\e[2mhello\e[0m")
@@ -62,50 +62,50 @@ describe "colorize" do
     colorize("hello").hidden.to_s.should eq("\e[8mhello\e[0m")
   end
 
-  it "colorizes mode combination" do
+  it("colorizes mode combination") do
     colorize("hello").bold.dim.underline.blink.reverse.hidden.to_s.should eq("\e[1;2;4;5;7;8mhello\e[0m")
   end
 
-  it "colorizes foreground with background" do
+  it("colorizes foreground with background") do
     colorize("hello").blue.on_green.to_s.should eq("\e[34;42mhello\e[0m")
   end
 
-  it "colorizes foreground with background with mode" do
+  it("colorizes foreground with background with mode") do
     colorize("hello").blue.on_green.bold.to_s.should eq("\e[34;42;1mhello\e[0m")
   end
 
-  it "colorizes foreground with symbol" do
+  it("colorizes foreground with symbol") do
     colorize("hello", :red).to_s.should eq("\e[31mhello\e[0m")
     colorize("hello").fore(:red).to_s.should eq("\e[31mhello\e[0m")
   end
 
-  it "colorizes mode with symbol" do
+  it("colorizes mode with symbol") do
     colorize("hello").mode(:bold).to_s.should eq("\e[1mhello\e[0m")
   end
 
-  it "raises on unknown foreground color" do
-    expect_raises ArgumentError, "Unknown color: brown" do
+  it("raises on unknown foreground color") do
+    expect_raises(ArgumentError, "Unknown color: brown") do
       colorize("hello", :brown)
     end
   end
 
-  it "raises on unknown background color" do
-    expect_raises ArgumentError, "Unknown color: brown" do
+  it("raises on unknown background color") do
+    expect_raises(ArgumentError, "Unknown color: brown") do
       colorize("hello").back(:brown)
     end
   end
 
-  it "raises on unknown mode" do
-    expect_raises ArgumentError, "Unknown mode: bad" do
+  it("raises on unknown mode") do
+    expect_raises(ArgumentError, "Unknown mode: bad") do
       colorize("hello").mode(:bad)
     end
   end
 
-  it "inspects" do
+  it("inspects") do
     colorize("hello", :red).inspect.should eq("\e[31m\"hello\"\e[0m")
   end
 
-  it "colorizes io with method" do
+  it("colorizes io with method") do
     io = IO::Memory.new
     with_color_wrap.red.surround(io) do
       io << "hello"
@@ -113,7 +113,7 @@ describe "colorize" do
     io.to_s.should eq("\e[31mhello\e[0m")
   end
 
-  it "colorizes io with symbol" do
+  it("colorizes io with symbol") do
     io = IO::Memory.new
     with_color_wrap(:red).surround(io) do
       io << "hello"
@@ -121,7 +121,7 @@ describe "colorize" do
     io.to_s.should eq("\e[31mhello\e[0m")
   end
 
-  it "colorizes with push and pop" do
+  it("colorizes with push and pop") do
     io = IO::Memory.new
     with_color_wrap.red.push(io) do
       io << "hello"
@@ -133,7 +133,7 @@ describe "colorize" do
     io.to_s.should eq("\e[31mhello\e[0;32mworld\e[0;31mbye\e[0m")
   end
 
-  it "colorizes with push and pop resets" do
+  it("colorizes with push and pop resets") do
     io = IO::Memory.new
     with_color_wrap.red.push(io) do
       io << "hello"
@@ -145,12 +145,12 @@ describe "colorize" do
     io.to_s.should eq("\e[31mhello\e[0;32;1mworld\e[0;31mbye\e[0m")
   end
 
-  it "toggles off" do
+  it("toggles off") do
     colorize("hello").black.toggle(false).to_s.should eq("hello")
     colorize("hello").toggle(false).black.to_s.should eq("hello")
   end
 
-  it "toggles off and on" do
+  it("toggles off and on") do
     colorize("hello").toggle(false).black.toggle(true).to_s.should eq("\e[30mhello\e[0m")
   end
 end

--- a/spec/std/comparable_spec.cr
+++ b/spec/std/comparable_spec.cr
@@ -11,8 +11,8 @@ private class ComparableTestClass
   end
 end
 
-describe Comparable do
-  it "can compare against Int (#2461)" do
+describe(Comparable) do
+  it("can compare against Int (#2461)") do
     obj = ComparableTestClass.new(4)
     (obj == 3).should be_false
     (obj < 3).should be_false

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "complex"
 
-describe "Complex" do
-  it "i" do
+describe("Complex") do
+  it("i") do
     a = 4.5 + 6.7.i
     b = Complex.new(4.5, 6.7)
     c = Complex.new(4.5, 9.6)
@@ -10,8 +10,8 @@ describe "Complex" do
     a.should_not eq(c)
   end
 
-  describe "==" do
-    it "complex == complex" do
+  describe("==") do
+    it("complex == complex") do
       a = Complex.new(1.5, 2)
       b = Complex.new(1.5, 2)
       c = Complex.new(2.25, 3)
@@ -19,7 +19,7 @@ describe "Complex" do
       (a == c).should be_false
     end
 
-    it "complex == number" do
+    it("complex == number") do
       a = Complex.new(5.3, 0)
       b = 5.3
       c = 4.2
@@ -27,7 +27,7 @@ describe "Complex" do
       (a == c).should be_false
     end
 
-    it "number == complex" do
+    it("number == complex") do
       a = -1.75
       b = Complex.new(-1.75, 0)
       c = Complex.new(7.2, 0)
@@ -36,140 +36,140 @@ describe "Complex" do
     end
   end
 
-  it "to_s" do
+  it("to_s") do
     Complex.new(1.25, 8.2).to_s.should eq("1.25 + 8.2i")
     Complex.new(1.25, -8.2).to_s.should eq("1.25 - 8.2i")
   end
 
-  it "inspect" do
+  it("inspect") do
     Complex.new(1.25, 8.2).inspect.should eq("(1.25 + 8.2i)")
     Complex.new(1.25, -8.2).inspect.should eq("(1.25 - 8.2i)")
   end
 
-  it "abs" do
+  it("abs") do
     Complex.new(5.1, 9.7).abs.should eq(10.959014554237985)
   end
 
-  it "abs2" do
+  it("abs2") do
     Complex.new(-1.1, 9).abs2.should eq(82.21)
   end
 
-  it "sign" do
+  it("sign") do
     Complex.new(-1.4, 7.7).sign.should eq(Complex.new(-0.17888543819998315, 0.9838699100999074))
   end
 
-  it "phase" do
+  it("phase") do
     Complex.new(11.5, -6.25).phase.should eq(-0.4978223326170012)
   end
 
-  it "polar" do
+  it("polar") do
     Complex.new(7.25, -13.1).polar.should eq({14.972391258579906, -1.0653196179316864})
   end
 
-  it "cis" do
+  it("cis") do
     2.4.cis.should eq(Complex.new(-0.7373937155412454, 0.675463180551151))
   end
 
-  it "conj" do
+  it("conj") do
     Complex.new(10.1, 3.7).conj.should eq(Complex.new(10.1, -3.7))
   end
 
-  it "inv" do
+  it("inv") do
     Complex.new(1.5, -2.5).inv.should eq(Complex.new(0.17647058823529413, 0.29411764705882354))
   end
 
-  it "sqrt" do
+  it("sqrt") do
     Complex.new(1.32, 7.25).sqrt.should be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
     Complex.new(7.11, -0.9).sqrt.should be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
     Complex.new(-2.2, 6.22).sqrt.should be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
     Complex.new(-8.3, -1.11).sqrt.should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
   end
 
-  it "exp" do
+  it("exp") do
     Complex.new(1.15, -5.1).exp.should be_close(Complex.new(1.1937266270566773, 2.923901365414129), 1e-15)
   end
 
-  describe "logarithms" do
-    it "log" do
+  describe("logarithms") do
+    it("log") do
       Complex.new(1.25, -4.7).log.should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
     end
 
-    it "log2" do
+    it("log2") do
       Complex.new(-9.1, 3.2).log2.should eq(Complex.new(3.2699671225858946, +4.044523592551345))
     end
 
-    it "log10" do
+    it("log10") do
       Complex.new(2.11, 1.21).log10.should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
     end
   end
 
-  describe "+" do
-    it "complex + complex" do
+  describe("+") do
+    it("complex + complex") do
       (Complex.new(2.2, 7) + Complex.new(10.1, 1.34)).should eq(Complex.new(12.3, 8.34))
     end
 
-    it "complex + number" do
+    it("complex + number") do
       (Complex.new(0.3, 5.5) + 15).should eq(Complex.new(15.3, 5.5))
     end
 
-    it "number + complex" do
+    it("number + complex") do
       (-1.7 + Complex.new(7, 4.1)).should eq(Complex.new(5.3, 4.1))
     end
   end
 
-  describe "-" do
-    it "- complex" do
+  describe("-") do
+    it("- complex") do
       (-Complex.new(5.43, 27.12)).should eq(Complex.new(-5.43, -27.12))
     end
 
-    it "complex - complex" do
+    it("complex - complex") do
       (Complex.new(21.7, 2.0) - Complex.new(0.15, 3.4)).should eq(Complex.new(21.55, -1.4))
     end
 
-    it "complex - number" do
+    it("complex - number") do
       (Complex.new(8.1, 6.15) - 15).should eq(Complex.new(-6.9, 6.15))
     end
 
-    it "number - complex" do
+    it("number - complex") do
       (-3.27 - Complex.new(7, 5.1)).should eq(Complex.new(-10.27, -5.1))
     end
   end
 
-  describe "*" do
-    it "complex * complex" do
+  describe("*") do
+    it("complex * complex") do
       (Complex.new(12.2, 9.8)*Complex.new(4.78, 2.86)).should eq(Complex.new(30.288, 81.736))
     end
 
-    it "complex * number" do
+    it("complex * number") do
       (Complex.new(11.3, 15.25)*1.2).should eq(Complex.new(13.56, 18.3))
     end
 
-    it "number * complex" do
+    it("number * complex") do
       (-1.7*Complex.new(9.7, 3.22)).should eq(Complex.new(-16.49, -5.474))
     end
   end
 
-  describe "/" do
-    it "complex / complex" do
+  describe("/") do
+    it("complex / complex") do
       ((Complex.new(4, 6.2))/(Complex.new(0.5, 2.7))).should eq(Complex.new(2.485411140583554, -1.0212201591511936))
       ((Complex.new(4.1, 6.0))/(Complex.new(10, 2.2))).should eq(Complex.new(0.5169782525753529, 0.48626478443342236))
     end
 
-    it "complex / number" do
+    it("complex / number") do
       ((Complex.new(21.3, 5.8))/1.9).should eq(Complex.new(11.210526315789474, 3.0526315789473686))
     end
 
-    it "number / complex" do
+    it("number / complex") do
       (-5.7/(Complex.new(2.27, 8.92))).should eq(Complex.new(-0.1527278908111847, 0.6001466017778712))
     end
   end
 
-  it "clones" do
+  it("clones") do
     c = Complex.new(4, 6.2)
     c.clone.should eq(c)
   end
 
-  it "test zero?" do
+  it("test zero?") do
     Complex.new(0, 0).zero?.should eq true
     Complex.new(0, 3.4).zero?.should eq false
     Complex.new(1.2, 0).zero?.should eq false

--- a/spec/std/concurrent/future_spec.cr
+++ b/spec/std/concurrent/future_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 
-describe Concurrent::Future do
-  describe "delay" do
-    it "computes a value" do
+describe(Concurrent::Future) do
+  describe("delay") do
+    it("computes a value") do
       chan = Channel(Int32).new(1)
 
       d = delay(0.05) { chan.receive }
@@ -14,7 +14,7 @@ describe Concurrent::Future do
       d.completed?.should be_true
     end
 
-    it "cancels" do
+    it("cancels") do
       d = delay(1) { 42 }
       d.delayed?.should be_true
 
@@ -24,7 +24,7 @@ describe Concurrent::Future do
       expect_raises(Concurrent::CanceledError) { d.get }
     end
 
-    it "raises" do
+    it("raises") do
       d = delay(0.001) { raise IndexError.new("test error") }
 
       expect_raises(IndexError) { d.get }
@@ -32,8 +32,8 @@ describe Concurrent::Future do
     end
   end
 
-  describe "future" do
-    it "computes a value" do
+  describe("future") do
+    it("computes a value") do
       chan = Channel(Int32).new(1)
 
       f = future { chan.receive }
@@ -47,7 +47,7 @@ describe Concurrent::Future do
       f.completed?.should be_true
     end
 
-    it "can't cancel a completed computation" do
+    it("can't cancel a completed computation") do
       f = future { 42 }
       f.running?.should be_true
 
@@ -58,7 +58,7 @@ describe Concurrent::Future do
       f.canceled?.should be_false
     end
 
-    it "raises" do
+    it("raises") do
       f = future { raise IndexError.new("test error") }
       f.running?.should be_true
 
@@ -70,8 +70,8 @@ describe Concurrent::Future do
     end
   end
 
-  describe "lazy" do
-    it "computes a value" do
+  describe("lazy") do
+    it("computes a value") do
       chan = Channel(Int32).new(1)
 
       f = lazy { chan.receive }
@@ -85,7 +85,7 @@ describe Concurrent::Future do
       f.completed?.should be_true
     end
 
-    it "cancels" do
+    it("cancels") do
       l = lazy { 42 }
       l.idle?.should be_true
 
@@ -95,7 +95,7 @@ describe Concurrent::Future do
       expect_raises(Concurrent::CanceledError) { l.get }
     end
 
-    it "raises" do
+    it("raises") do
       f = lazy { raise IndexError.new("test error") }
       f.idle?.should be_true
 

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "select" do
-  it "select many receviers" do
+describe("select") do
+  it("select many receviers") do
     ch1 = Channel(Int32).new
     ch2 = Channel(Int32).new
     res = [] of Int32
@@ -22,7 +22,7 @@ describe "select" do
     res.should eq (0...10).to_a
   end
 
-  it "select many senders" do
+  it("select many senders") do
     ch1 = Channel(Int32).new
     ch2 = Channel(Int32).new
     res = [] of Int32
@@ -43,7 +43,7 @@ describe "select" do
     res.should eq (0...10).to_a
   end
 
-  it "select many receivers, senders" do
+  it("select many receivers, senders") do
     ch1 = Channel(Int32).new
     ch2 = Channel(Int32).new
     res = [] of Int32
@@ -67,7 +67,7 @@ describe "select" do
     res.should eq (0...10).to_a
   end
 
-  it "select should work with send which started before receive, fixed #3862" do
+  it("select should work with send which started before receive, fixed #3862") do
     ch1 = Channel(Int32).new
     ch2 = Channel(Int32).new
 

--- a/spec/std/concurrent_spec.cr
+++ b/spec/std/concurrent_spec.cr
@@ -8,8 +8,8 @@ private def method_named(expected_named)
   Fiber.current.name.should eq(expected_named)
 end
 
-describe "concurrent" do
-  it "does four things concurrently" do
+describe("concurrent") do
+  it("does four things concurrently") do
     a, b, c, d = parallel(1 + 2, "hello".size, [1, 2, 3, 4].size, nil)
     a.should eq(3)
     b.should eq(5)
@@ -17,7 +17,7 @@ describe "concurrent" do
     d.should be_nil
   end
 
-  it "uses spawn macro" do
+  it("uses spawn macro") do
     chan = Channel(Int32).new
 
     spawn method_with_named_args(chan)
@@ -30,14 +30,14 @@ describe "concurrent" do
     chan.receive.should eq(30)
   end
 
-  it "spawns named" do
+  it("spawns named") do
     spawn(name: "sub") do
       Fiber.current.name.should eq("sub")
     end
     Fiber.yield
   end
 
-  it "spawns named with macro" do
+  it("spawns named with macro") do
     spawn method_named("foo"), name: "foo"
     Fiber.yield
   end

--- a/spec/std/crc32_spec.cr
+++ b/spec/std/crc32_spec.cr
@@ -1,13 +1,13 @@
 require "spec"
 require "crc32"
 
-describe CRC32 do
-  it "should be able to calculate crc32" do
+describe(CRC32) do
+  it("should be able to calculate crc32") do
     crc = CRC32.checksum("foo").to_s(16)
     crc.should eq("8c736521")
   end
 
-  it "should be able to calculate crc32 combined" do
+  it("should be able to calculate crc32 combined") do
     crc1 = CRC32.checksum("hello")
     crc2 = CRC32.checksum(" world!")
     combined = CRC32.combine(crc1, crc2, " world!".size)

--- a/spec/std/crypto/bcrypt/base64_spec.cr
+++ b/spec/std/crypto/bcrypt/base64_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "crypto/bcrypt/base64"
 
-describe "Crypto::Bcrypt::Base64" do
+describe("Crypto::Bcrypt::Base64") do
   vectors = [
     {UInt8[0x25], "HO"},
     {UInt8[0x6b, 0x11], "YvC"},
@@ -28,14 +28,14 @@ describe "Crypto::Bcrypt::Base64" do
     {UInt8[0xe1, 0x2a, 0x52, 0x02, 0xeb, 0x8a, 0x40, 0x85, 0x5f, 0xba, 0xdb, 0x13, 0x1e, 0x94, 0x9b, 0xb9, 0x55, 0x54, 0xe9, 0x9c, 0x87, 0x9c, 0xbf], "2QnQ.ssIOGTdsrqRFnQZsTTS4XwFlJ6"},
   ]
 
-  it "encodes" do
+  it("encodes") do
     vectors.each do |vector|
       decoded, encoded = vector
       Crypto::Bcrypt::Base64.encode(decoded, decoded.size).should eq(encoded)
     end
   end
 
-  it "decodes" do
+  it("decodes") do
     vectors.each do |vector|
       decoded, encoded = vector
       Crypto::Bcrypt::Base64.decode(encoded, decoded.size).to_a.should eq(decoded)

--- a/spec/std/crypto/bcrypt/password_spec.cr
+++ b/spec/std/crypto/bcrypt/password_spec.cr
@@ -1,51 +1,51 @@
 require "spec"
 require "crypto/bcrypt/password"
 
-describe "Crypto::Bcrypt::Password" do
-  describe "new" do
+describe("Crypto::Bcrypt::Password") do
+  describe("new") do
     password = Crypto::Bcrypt::Password.new("$2a$08$K8y0i4Wyqyei3SiGHLEd.OweXJt7sno2HdPVrMvVf06kGgAZvPkga")
 
-    it "parses version" do
+    it("parses version") do
       password.version.should eq("2a")
     end
 
-    it "parses cost" do
+    it("parses cost") do
       password.cost.should eq(8)
     end
 
-    it "parses salt" do
+    it("parses salt") do
       password.salt.should eq("K8y0i4Wyqyei3SiGHLEd.O")
     end
 
-    it "parses digest" do
+    it("parses digest") do
       password.digest.should eq("weXJt7sno2HdPVrMvVf06kGgAZvPkga")
     end
   end
 
-  describe "create" do
+  describe("create") do
     password = Crypto::Bcrypt::Password.create("super secret", 5)
 
-    it "uses cost" do
+    it("uses cost") do
       password.cost.should eq(5)
     end
 
-    it "generates salt" do
+    it("generates salt") do
       password.salt.should_not be_nil
     end
 
-    it "generates digest" do
+    it("generates digest") do
       password.digest.should_not be_nil
     end
   end
 
-  describe "==" do
+  describe("==") do
     password = Crypto::Bcrypt::Password.create("secret", 4)
 
-    it "verifies password is incorrect" do
+    it("verifies password is incorrect") do
       (password == "wrong").should be_false
     end
 
-    it "verifies password is correct" do
+    it("verifies password is correct") do
       (password == "secret").should be_true
     end
   end

--- a/spec/std/crypto/bcrypt_spec.cr
+++ b/spec/std/crypto/bcrypt_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "crypto/bcrypt"
 
-describe "Crypto::Bcrypt" do
+describe("Crypto::Bcrypt") do
   latin1_pound_sign = String.new(Bytes.new(1, 0xa3_u8))
   utf8_pound_sign = String.new(Bytes.new(2) { |i| i == 0 ? 0xc2_u8 : 0xa3_u8 })
   bit8_unicode_pound_sign = "\u00A3"
@@ -18,7 +18,7 @@ describe "Crypto::Bcrypt" do
     {5, bit8_unicode_pound_sign, "CCCCCCCCCCCCCCCCCCCCC.", "CAzSxlf0FLW7g1A5q7W/ZCj1xsN6A.e"},
   ]
 
-  it "computes digest vectors" do
+  it("computes digest vectors") do
     vectors.each_with_index do |vector, index|
       cost, password, salt, digest = vector
       bc = Crypto::Bcrypt.new(password, salt, cost)
@@ -26,7 +26,7 @@ describe "Crypto::Bcrypt" do
     end
   end
 
-  it "validates salt size" do
+  it("validates salt size") do
     expect_raises(Crypto::Bcrypt::Error, /Invalid salt size/) do
       Crypto::Bcrypt.new("abcd", SecureRandom.hex(7))
     end
@@ -36,7 +36,7 @@ describe "Crypto::Bcrypt" do
     end
   end
 
-  it "validates cost" do
+  it("validates cost") do
     salt = SecureRandom.hex(8)
 
     expect_raises(Crypto::Bcrypt::Error, /Invalid cost/) do
@@ -48,7 +48,7 @@ describe "Crypto::Bcrypt" do
     end
   end
 
-  it "validates password size" do
+  it("validates password size") do
     salt = SecureRandom.random_bytes(16)
 
     expect_raises(Crypto::Bcrypt::Error, /Invalid password size/) do
@@ -61,7 +61,7 @@ describe "Crypto::Bcrypt" do
   end
 
   # Read http://lwn.net/Articles/448699/
-  it "doesn't have the sign expansion (high 8bit) security flaw" do
+  it("doesn't have the sign expansion (high 8bit) security flaw") do
     salt = "OK.fbVrR/bpIqNJ5ianF.C"
     hash1 = Crypto::Bcrypt.new("ab#{latin1_pound_sign}", salt, 5)
     hash2 = Crypto::Bcrypt.new(latin1_pound_sign, salt, 5)

--- a/spec/std/crypto/blowfish_spec.cr
+++ b/spec/std/crypto/blowfish_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "crypto/blowfish"
 
-describe "Crypto::Blowfish" do
+describe("Crypto::Blowfish") do
   vectors = [
     {UInt8[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], UInt32[0x00000000, 0x00000000], UInt32[0x4EF99745, 0x6198DD78]},
     {UInt8[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], UInt32[0xFFFFFFFF, 0xFFFFFFFF], UInt32[0x51866FD5, 0xB85ECB8A]},
@@ -39,7 +39,7 @@ describe "Crypto::Blowfish" do
     {UInt8[0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10], UInt32[0xFFFFFFFF, 0xFFFFFFFF], UInt32[0x6B5C5A9C, 0x5D9E0A5A]},
   ]
 
-  it "encrypt and decrypt pair" do
+  it("encrypt and decrypt pair") do
     vectors.each_with_index do |(key, text, cipher), index|
       bf = Crypto::Blowfish.new(16)
       bf.expand_key(key)

--- a/spec/std/crypto/subtle_spec.cr
+++ b/spec/std/crypto/subtle_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "crypto/subtle"
 
-describe "Subtle" do
-  it "compares constant times" do
+describe("Subtle") do
+  it("compares constant times") do
     data = [
       {"a" => Slice.new(1, 0x11), "b" => Slice.new(1, 0x11), "result" => true},
       {"a" => Slice.new(1, 0x12), "b" => Slice.new(1, 0x11), "result" => false},
@@ -15,7 +15,7 @@ describe "Subtle" do
     end
   end
 
-  it "compares constant time bytes on equality" do
+  it("compares constant time bytes on equality") do
     data = [
       {"a" => 0x00_u8, "b" => 0x00_u8, "result" => 1},
       {"a" => 0x00_u8, "b" => 0x01_u8, "result" => 0},
@@ -29,13 +29,13 @@ describe "Subtle" do
     end
   end
 
-  it "compares constant time bytes bug" do
+  it("compares constant time bytes bug") do
     h1 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOa9lH9zigNKnksVaDwViFNgPU4WkrD53J"
     h2 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOaHlSGFuDDwMuVg6gOzdxQ0xN4rFOwMUn"
     Crypto::Subtle.constant_time_compare(h1, h2).should eq(false)
   end
 
-  it "compares constant time and slices strings" do
+  it("compares constant time and slices strings") do
     h1 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOa9lH9zigNKnksVaDwViFNgPU4WkrD53J"
     h2 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOaHlSGFuDDwMuVg6gOzdxQ0xN4rFOwMUn"
 

--- a/spec/std/csv/csv_build_spec.cr
+++ b/spec/std/csv/csv_build_spec.cr
@@ -1,9 +1,9 @@
 require "spec"
 require "csv"
 
-describe CSV do
-  describe "build" do
-    it "builds two rows" do
+describe(CSV) do
+  describe("build") do
+    it("builds two rows") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << "one"
@@ -17,7 +17,7 @@ describe CSV do
       string.should eq("one,two\nthree,four\n")
     end
 
-    it "builds with numbers" do
+    it("builds with numbers") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << 1
@@ -31,7 +31,7 @@ describe CSV do
       string.should eq("1,2\n3,4\n")
     end
 
-    it "builds with commas" do
+    it("builds with commas") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << %(hello,world)
@@ -40,7 +40,7 @@ describe CSV do
       string.should eq(%("hello,world"\n))
     end
 
-    it "builds with quotes" do
+    it("builds with quotes") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << %(he said "no")
@@ -49,21 +49,21 @@ describe CSV do
       string.should eq(%("he said ""no"""\n))
     end
 
-    it "builds row from enumerable" do
+    it("builds row from enumerable") do
       string = CSV.build do |csv|
         csv.row [1, 2, 3]
       end
       string.should eq("1,2,3\n")
     end
 
-    it "builds row from splat" do
+    it("builds row from splat") do
       string = CSV.build do |csv|
         csv.row 1, 2, 3
       end
       string.should eq("1,2,3\n")
     end
 
-    it "skips inside row" do
+    it("skips inside row") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << 1
@@ -74,7 +74,7 @@ describe CSV do
       string.should eq("1,,2\n")
     end
 
-    it "concats enumerable to row" do
+    it("concats enumerable to row") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << 1
@@ -85,7 +85,7 @@ describe CSV do
       string.should eq("1,2,3,4,5\n")
     end
 
-    it "concats splat to row" do
+    it("concats splat to row") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << 1
@@ -96,7 +96,7 @@ describe CSV do
       string.should eq("1,2,3,4,5\n")
     end
 
-    it "builds with commas" do
+    it("builds with commas") do
       string = CSV.build do |csv|
         csv.row do |row|
           row << " , "

--- a/spec/std/csv/csv_lex_spec.cr
+++ b/spec/std/csv/csv_lex_spec.cr
@@ -17,16 +17,16 @@ class CSV::Lexer
   end
 end
 
-describe CSV do
-  describe "lex" do
-    it "lexes two columns" do
+describe(CSV) do
+  describe("lex") do
+    it("lexes two columns") do
       lexer = CSV::Lexer.new("hello,world")
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
       lexer.expect_eof
     end
 
-    it "lexes two columns with two rows" do
+    it("lexes two columns with two rows") do
       lexer = CSV::Lexer.new("hello,world\nfoo,bar")
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
@@ -36,7 +36,7 @@ describe CSV do
       lexer.expect_eof
     end
 
-    it "lexes two columns with two rows with \r\n" do
+    it("lexes two columns with two rows with \r\n") do
       lexer = CSV::Lexer.new("hello,world\r\nfoo,bar")
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
@@ -46,21 +46,21 @@ describe CSV do
       lexer.expect_eof
     end
 
-    it "lexes two empty columns" do
+    it("lexes two empty columns") do
       lexer = CSV::Lexer.new(",")
       lexer.expect_cell ""
       lexer.expect_cell ""
       lexer.expect_eof
     end
 
-    it "lexes last empty column" do
+    it("lexes last empty column") do
       lexer = CSV::Lexer.new("foo,")
       lexer.expect_cell "foo"
       lexer.expect_cell ""
       lexer.expect_eof
     end
 
-    it "lexes with empty columns" do
+    it("lexes with empty columns") do
       lexer = CSV::Lexer.new("foo,,bar")
       lexer.expect_cell "foo"
       lexer.expect_cell ""
@@ -68,75 +68,75 @@ describe CSV do
       lexer.expect_eof
     end
 
-    it "lexes with whitespace" do
+    it("lexes with whitespace") do
       lexer = CSV::Lexer.new("  foo  ,  bar  ")
       lexer.expect_cell "  foo  "
       lexer.expect_cell "  bar  "
       lexer.expect_eof
     end
 
-    it "lexes two with quotes" do
+    it("lexes two with quotes") do
       lexer = CSV::Lexer.new(%("hello","world"))
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
       lexer.expect_eof
     end
 
-    it "lexes two with inner quotes" do
+    it("lexes two with inner quotes") do
       lexer = CSV::Lexer.new(%("hel""lo","wor""ld"))
       lexer.expect_cell %(hel"lo)
       lexer.expect_cell %(wor"ld)
       lexer.expect_eof
     end
 
-    it "lexes with comma inside quote" do
+    it("lexes with comma inside quote") do
       lexer = CSV::Lexer.new(%("foo,bar"))
       lexer.expect_cell "foo,bar"
       lexer.expect_eof
     end
 
-    it "lexes with newline inside quote" do
+    it("lexes with newline inside quote") do
       lexer = CSV::Lexer.new(%("foo\nbar"))
       lexer.expect_cell "foo\nbar"
       lexer.expect_eof
     end
 
-    it "lexes newline and eof as a single eof" do
+    it("lexes newline and eof as a single eof") do
       lexer = CSV::Lexer.new("hello,world\n")
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
       lexer.expect_eof
     end
 
-    it "lexes with a given separator" do
+    it("lexes with a given separator") do
       lexer = CSV::Lexer.new("hello;world\n", separator: ';')
       lexer.expect_cell "hello"
       lexer.expect_cell "world"
       lexer.expect_eof
     end
 
-    it "lexes with a given quote char" do
+    it("lexes with a given quote char") do
       lexer = CSV::Lexer.new("'hello,world'\n", quote_char: '\'')
       lexer.expect_cell "hello,world"
       lexer.expect_eof
     end
 
-    it "raises if single quote in the middle" do
-      expect_raises CSV::MalformedCSVError, "Unexpected quote at 1:4" do
+    it("raises if single quote in the middle") do
+      expect_raises(CSV::MalformedCSVError, "Unexpected quote at 1:4") do
         lexer = CSV::Lexer.new %(hel"lo)
         lexer.next_token
       end
     end
 
-    it "raises if command, newline or end doesn't follow quote" do
-      expect_raises CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 1:6" do
+    it("raises if command, newline or end doesn't follow quote") do
+      expect_raises(CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 1:6") do
         lexer = CSV::Lexer.new %("hel"a)
         lexer.next_token
       end
     end
 
-    it "raises on unclosed quote" do
-      expect_raises CSV::MalformedCSVError, "Unclosed quote at 1:5" do
+    it("raises on unclosed quote") do
+      expect_raises(CSV::MalformedCSVError, "Unclosed quote at 1:5") do
         lexer = CSV::Lexer.new %("foo)
         lexer.next_token
       end

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -1,93 +1,93 @@
 require "spec"
 require "csv"
 
-describe CSV do
-  describe "parse" do
-    it "parses empty string" do
+describe(CSV) do
+  describe("parse") do
+    it("parses empty string") do
       CSV.parse("").should eq([] of String)
     end
 
-    it "parses one simple row" do
+    it("parses one simple row") do
       CSV.parse("hello,world").should eq([["hello", "world"]])
     end
 
-    it "parses one row with spaces" do
+    it("parses one row with spaces") do
       CSV.parse("   hello   ,   world  ").should eq([["   hello   ", "   world  "]])
     end
 
-    it "parses two rows" do
+    it("parses two rows") do
       CSV.parse("hello,world\ngood,bye").should eq([
         ["hello", "world"],
         ["good", "bye"],
       ])
     end
 
-    it "parses two rows with the last one having a newline" do
+    it("parses two rows with the last one having a newline") do
       CSV.parse("hello,world\ngood,bye\n").should eq([
         ["hello", "world"],
         ["good", "bye"],
       ])
     end
 
-    it "parses with quote" do
+    it("parses with quote") do
       CSV.parse(%("hello","world")).should eq([["hello", "world"]])
     end
 
-    it "parses with quote and newline" do
+    it("parses with quote and newline") do
       CSV.parse(%("hello","world"\nfoo)).should eq([["hello", "world"], ["foo"]])
     end
 
-    it "parses with double quote" do
+    it("parses with double quote") do
       CSV.parse(%("hel""lo","wor""ld")).should eq([[%(hel"lo), %(wor"ld)]])
     end
 
-    it "parses some commas" do
+    it("parses some commas") do
       CSV.parse(%(,,)).should eq([["", "", ""]])
     end
 
-    it "parses empty quoted string" do
+    it("parses empty quoted string") do
       CSV.parse(%("","")).should eq([["", ""]])
     end
 
-    it "raises if single quote in the middle" do
-      expect_raises CSV::MalformedCSVError, "Unexpected quote at 1:4" do
+    it("raises if single quote in the middle") do
+      expect_raises(CSV::MalformedCSVError, "Unexpected quote at 1:4") do
         CSV.parse(%(hel"lo))
       end
     end
 
-    it "raises if command, newline or end doesn't follow quote" do
-      expect_raises CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 2:6" do
+    it("raises if command, newline or end doesn't follow quote") do
+      expect_raises(CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 2:6") do
         CSV.parse(%(foo\n"hel"a))
       end
     end
 
-    it "raises if command, newline or end doesn't follow quote (2)" do
-      expect_raises CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 2:6" do
+    it("raises if command, newline or end doesn't follow quote (2)") do
+      expect_raises(CSV::MalformedCSVError, "Expecting comma, newline or end, not 'a' at 2:6") do
         CSV.parse(%(\n"hel"a))
       end
     end
 
-    it "parses from IO" do
+    it("parses from IO") do
       CSV.parse(IO::Memory.new(%("hel""lo",world))).should eq([[%(hel"lo), %(world)]])
     end
 
-    it "takes an optional separator argument" do
+    it("takes an optional separator argument") do
       CSV.parse("foo;bar", separator: ';').should eq([["foo", "bar"]])
     end
 
-    it "takes an optional quote char argument" do
+    it("takes an optional quote char argument") do
       CSV.parse("'foo,bar'", quote_char: '\'').should eq([["foo,bar"]])
     end
   end
 
-  it "parses row by row" do
+  it("parses row by row") do
     parser = CSV::Parser.new("hello,world\ngood,bye\n")
     parser.next_row.should eq(%w(hello world))
     parser.next_row.should eq(%w(good bye))
     parser.next_row.should be_nil
   end
 
-  it "does CSV.each_row" do
+  it("does CSV.each_row") do
     sum = 0
     CSV.each_row("1,2\n3,4\n") do |row|
       sum += row.map(&.to_i).sum
@@ -95,7 +95,7 @@ describe CSV do
     sum.should eq(10)
   end
 
-  it "does CSV.each_row with separator and quotes" do
+  it("does CSV.each_row with separator and quotes") do
     sum = 0
     CSV.each_row("1\t'2'\n3\t4\n", '\t', '\'') do |row|
       sum += row.map(&.to_i).sum
@@ -103,7 +103,7 @@ describe CSV do
     sum.should eq(10)
   end
 
-  it "gets row iterator" do
+  it("gets row iterator") do
     iter = CSV.each_row("1,2\n3,4\n")
     iter.next.should eq(["1", "2"])
     iter.next.should eq(["3", "4"])

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -5,25 +5,25 @@ private def new_csv(headers = false, strip = false)
   CSV.new %(one, two\n1, 2\n3, 4\n5), headers: headers, strip: strip
 end
 
-describe CSV do
-  it "gets headers" do
+describe(CSV) do
+  it("gets headers") do
     csv = new_csv headers: true
     csv.headers.should eq(%w(one two))
   end
 
-  it "works without headers" do
+  it("works without headers") do
     csv = CSV.new("", headers: true)
     csv.headers.empty?.should be_true
   end
 
-  it "raises if trying to access before first row" do
+  it("raises if trying to access before first row") do
     csv = new_csv headers: true
     expect_raises(CSV::Error, "Before first row") do
       csv["one"]
     end
   end
 
-  it "gets row values with string" do
+  it("gets row values with string") do
     csv = new_csv headers: true
     csv.next.should be_true
     csv["one"].should eq("1")
@@ -48,7 +48,7 @@ describe CSV do
     end
   end
 
-  it "gets row values with integer" do
+  it("gets row values with integer") do
     csv = new_csv headers: true
     csv.next.should be_true
     csv[0].should eq("1")
@@ -70,7 +70,7 @@ describe CSV do
     csv[-1].should eq("")
   end
 
-  it "gets row values with regex" do
+  it("gets row values with regex") do
     csv = new_csv headers: true
     csv.next.should be_true
 
@@ -82,7 +82,7 @@ describe CSV do
     end
   end
 
-  it "gets current row" do
+  it("gets current row") do
     csv = new_csv headers: true
     csv.next.should be_true
 
@@ -96,7 +96,7 @@ describe CSV do
     row.to_h.should eq({"one" => "1", "two" => " 2"})
   end
 
-  it "strips" do
+  it("strips") do
     csv = new_csv headers: true, strip: true
     csv.next.should be_true
 
@@ -107,13 +107,13 @@ describe CSV do
     csv.row.to_h.should eq({"one" => "1", "two" => "2"})
   end
 
-  it "works without headers" do
+  it("works without headers") do
     csv = new_csv headers: false
     csv.next.should be_true
     csv[0].should eq("one")
   end
 
-  it "can do each" do
+  it("can do each") do
     csv = new_csv headers: true
     csv.each do
       csv["one"].should eq("1")
@@ -121,7 +121,7 @@ describe CSV do
     end.should be_nil
   end
 
-  it "can do new with block" do
+  it("can do new with block") do
     CSV.new(%(one, two\n1, 2\n3, 4\n5), headers: true, strip: true) do |csv|
       csv["one"].should eq("1")
       csv["two"].should eq("2")
@@ -129,28 +129,28 @@ describe CSV do
     end
   end
 
-  it "returns a Tuple(String, String) for current row with indices" do
+  it("returns a Tuple(String, String) for current row with indices") do
     CSV.new("John,20\nPeter,30") do |csv|
       csv.values_at(0, -1).should eq({"John", "20"})
       break
     end
   end
 
-  it "returns a Tuple(String, String) for current row with headers" do
+  it("returns a Tuple(String, String) for current row with headers") do
     CSV.new("Name,Age\nJohn,20\nPeter,30", headers: true) do |csv|
       csv.values_at("Name", "Age").should eq({"John", "20"})
       break
     end
   end
 
-  it "returns a Tuple(String, String) for this row with indices" do
+  it("returns a Tuple(String, String) for this row with indices") do
     CSV.new("John,20\nPeter,30") do |csv|
       csv.row.values_at(0, -1).should eq({"John", "20"})
       break
     end
   end
 
-  it "returns a Tuple(String, String) for this row with headers" do
+  it("returns a Tuple(String, String) for this row with headers") do
     CSV.new("Name,Age\nJohn,20\nPeter,30", headers: true) do |csv|
       csv.row.values_at("Name", "Age").should eq({"John", "20"})
       break

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -36,9 +36,9 @@ end
 
 private alias RecursiveDeque = Deque(RecursiveDeque)
 
-describe "Deque" do
-  describe "implementation" do
-    it "works the same as array" do
+describe("Deque") do
+  describe("implementation") do
+    it("works the same as array") do
       DequeTester.new.test do
         step { c.unshift i }
         step { c.pop }
@@ -72,7 +72,7 @@ describe "Deque" do
       end
     end
 
-    it "works the same as array when inserting at 1/8 size and deleting at 3/4 size" do
+    it("works the same as array when inserting at 1/8 size and deleting at 3/4 size") do
       DequeTester.new.test do
         1000.times do
           step { c.insert(c.size / 8, i) }
@@ -83,7 +83,7 @@ describe "Deque" do
       end
     end
 
-    it "works the same as array when inserting at 3/4 size and deleting at 1/8 size" do
+    it("works the same as array when inserting at 3/4 size and deleting at 1/8 size") do
       DequeTester.new.test do
         1000.times do
           step { c.insert(c.size * 3 / 4, i) }
@@ -95,48 +95,48 @@ describe "Deque" do
     end
   end
 
-  describe "new" do
-    it "creates with default value" do
+  describe("new") do
+    it("creates with default value") do
       deq = Deque.new(5, 3)
       deq.should eq(Deque{3, 3, 3, 3, 3})
     end
 
-    it "creates with default value in block" do
+    it("creates with default value in block") do
       deq = Deque.new(5) { |i| i * 2 }
       deq.should eq(Deque{0, 2, 4, 6, 8})
     end
 
-    it "creates from an array" do
+    it("creates from an array") do
       deq = Deque(Int32).new([1, 2, 3, 4, 5])
       deq.should eq(Deque{1, 2, 3, 4, 5})
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       expect_raises(ArgumentError, "Negative deque size") do
         Deque.new(-1, 3)
       end
     end
 
-    it "raises on negative capacity" do
+    it("raises on negative capacity") do
       expect_raises(ArgumentError, "Negative deque capacity") do
         Deque(Int32).new(-1)
       end
     end
   end
 
-  describe "==" do
-    it "compares empty" do
+  describe("==") do
+    it("compares empty") do
       Deque(Int32).new.should eq(Deque(Int32).new)
       Deque{1}.should_not eq(Deque(Int32).new)
       Deque(Int32).new.should_not eq(Deque{1})
     end
 
-    it "compares elements" do
+    it("compares elements") do
       Deque{1, 2, 3}.should eq(Deque{1, 2, 3})
       Deque{1, 2, 3}.should_not eq(Deque{3, 2, 1})
     end
 
-    it "compares other" do
+    it("compares other") do
       a = Deque{1, 2, 3}
       b = Deque{1, 2, 3}
       c = Deque{1, 2, 3, 4}
@@ -147,8 +147,8 @@ describe "Deque" do
     end
   end
 
-  describe "+" do
-    it "does +" do
+  describe("+") do
+    it("does +") do
       a = Deque{1, 2, 3}
       b = Deque{4, 5}
       c = a + b
@@ -156,53 +156,53 @@ describe "Deque" do
       0.upto(4) { |i| c[i].should eq(i + 1) }
     end
 
-    it "does + with different types" do
+    it("does + with different types") do
       a = Deque{1, 2, 3}
       a += Deque{"hello"}
       a.should eq(Deque{1, 2, 3, "hello"})
     end
   end
 
-  describe "[]" do
-    it "gets on positive index" do
+  describe("[]") do
+    it("gets on positive index") do
       Deque{1, 2, 3}[1].should eq(2)
     end
 
-    it "gets on negative index" do
+    it("gets on negative index") do
       Deque{1, 2, 3}[-1].should eq(3)
     end
 
-    it "gets nilable" do
+    it("gets nilable") do
       Deque{1, 2, 3}[2]?.should eq(3)
       Deque{1, 2, 3}[3]?.should be_nil
     end
 
-    it "same access by at" do
+    it("same access by at") do
       Deque{1, 2, 3}[1].should eq(Deque{1, 2, 3}.at(1))
     end
   end
 
-  describe "[]=" do
-    it "sets on positive index" do
+  describe("[]=") do
+    it("sets on positive index") do
       a = Deque{1, 2, 3}
       a[1] = 4
       a[1].should eq(4)
     end
 
-    it "sets on negative index" do
+    it("sets on negative index") do
       a = Deque{1, 2, 3}
       a[-1] = 4
       a[2].should eq(4)
     end
   end
 
-  it "does clear" do
+  it("does clear") do
     a = Deque{1, 2, 3}
     a.clear
     a.should eq(Deque(Int32).new)
   end
 
-  it "does clone" do
+  it("does clone") do
     x = {1 => 2}
     a = Deque{x}
     b = a.clone
@@ -211,62 +211,62 @@ describe "Deque" do
     a[0].should_not be(b[0])
   end
 
-  describe "concat" do
-    it "concats deque" do
+  describe("concat") do
+    it("concats deque") do
       a = Deque{1, 2, 3}
       a.concat(Deque{4, 5, 6})
       a.should eq(Deque{1, 2, 3, 4, 5, 6})
     end
 
-    it "concats large deques" do
+    it("concats large deques") do
       a = Deque{1, 2, 3}
       a.concat((4..1000).to_a)
       a.should eq(Deque.new((1..1000).to_a))
     end
 
-    it "concats enumerable" do
+    it("concats enumerable") do
       a = Deque{1, 2, 3}
       a.concat((4..1000))
       a.should eq(Deque.new((1..1000).to_a))
     end
   end
 
-  describe "delete" do
-    it "deletes many" do
+  describe("delete") do
+    it("deletes many") do
       a = Deque{1, 2, 3, 1, 2, 3}
       a.delete(2).should be_true
       a.should eq(Deque{1, 3, 1, 3})
     end
 
-    it "delete not found" do
+    it("delete not found") do
       a = Deque{1, 2}
       a.delete(4).should be_false
       a.should eq(Deque{1, 2})
     end
   end
 
-  describe "delete_at" do
-    it "deletes positive index" do
+  describe("delete_at") do
+    it("deletes positive index") do
       a = Deque{1, 2, 3, 4, 5}
       a.delete_at(3).should eq(4)
       a.should eq(Deque{1, 2, 3, 5})
     end
 
-    it "deletes negative index" do
+    it("deletes negative index") do
       a = Deque{1, 2, 3, 4, 5}
       a.delete_at(-4).should eq(2)
       a.should eq(Deque{1, 3, 4, 5})
     end
 
-    it "deletes out of bounds" do
+    it("deletes out of bounds") do
       a = Deque{1, 2, 3, 4}
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.delete_at(4)
       end
     end
   end
 
-  it "does dup" do
+  it("does dup") do
     x = {1 => 2}
     a = Deque{x}
     b = a.dup
@@ -277,31 +277,31 @@ describe "Deque" do
     a.should eq(Deque{x})
   end
 
-  it "does each" do
+  it("does each") do
     a = Deque{1, 1, 1}
     b = 0
     a.each { |i| b += i }.should be_nil
     b.should eq(3)
   end
 
-  it "does each_index" do
+  it("does each_index") do
     a = Deque{1, 1, 1}
     b = 0
     a.each_index { |i| b += i }.should be_nil
     b.should eq(3)
   end
 
-  describe "empty" do
-    it "is empty" do
+  describe("empty") do
+    it("is empty") do
       (Deque(Int32).new.empty?).should be_true
     end
 
-    it "is not empty" do
+    it("is not empty") do
       Deque{1}.empty?.should be_false
     end
   end
 
-  it "does equals? with custom block" do
+  it("does equals? with custom block") do
     a = Deque{1, 3, 2}
     b = Deque{3, 9, 4}
     c = Deque{5, 7, 3}
@@ -312,148 +312,148 @@ describe "Deque" do
     a.equals?(d, &f).should be_false
   end
 
-  describe "first" do
-    it "gets first when non empty" do
+  describe("first") do
+    it("gets first when non empty") do
       a = Deque{1, 2, 3}
       a.first.should eq(1)
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         Deque(Int32).new.first
       end
     end
   end
 
-  describe "first?" do
-    it "gets first? when non empty" do
+  describe("first?") do
+    it("gets first? when non empty") do
       a = Deque{1, 2, 3}
       a.first?.should eq(1)
     end
 
-    it "gives nil when empty" do
+    it("gives nil when empty") do
       Deque(Int32).new.first?.should be_nil
     end
   end
 
-  it "does hash" do
+  it("does hash") do
     a = Deque{1, 2, Deque{3}}
     b = Deque{1, 2, Deque{3}}
     a.hash.should eq(b.hash)
   end
 
-  describe "insert" do
-    it "inserts with positive index" do
+  describe("insert") do
+    it("inserts with positive index") do
       a = Deque{1, 3, 4}
       expected = Deque{1, 2, 3, 4}
       a.insert(1, 2).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts with negative index" do
+    it("inserts with negative index") do
       a = Deque{1, 2, 3}
       expected = Deque{1, 2, 3, 4}
       a.insert(-1, 4).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts with negative index (2)" do
+    it("inserts with negative index (2)") do
       a = Deque{1, 2, 3}
       expected = Deque{4, 1, 2, 3}
       a.insert(-4, 4).should eq(expected)
       a.should eq(expected)
     end
 
-    it "inserts out of range" do
+    it("inserts out of range") do
       a = Deque{1, 3, 4}
 
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.insert(4, 1)
       end
     end
   end
 
-  describe "inspect" do
+  describe("inspect") do
     it { Deque{1, 2, 3}.inspect.should eq("Deque{1, 2, 3}") }
   end
 
-  describe "last" do
-    it "gets last when non empty" do
+  describe("last") do
+    it("gets last when non empty") do
       a = Deque{1, 2, 3}
       a.last.should eq(3)
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         Deque(Int32).new.last
       end
     end
   end
 
-  describe "size" do
-    it "has size 0" do
+  describe("size") do
+    it("has size 0") do
       Deque(Int32).new.size.should eq(0)
     end
 
-    it "has size 2" do
+    it("has size 2") do
       Deque{1, 2}.size.should eq(2)
     end
   end
 
-  describe "pop" do
-    it "pops when non empty" do
+  describe("pop") do
+    it("pops when non empty") do
       a = Deque{1, 2, 3}
       a.pop.should eq(3)
       a.should eq(Deque{1, 2})
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         Deque(Int32).new.pop
       end
     end
 
-    it "pops many elements" do
+    it("pops many elements") do
       a = Deque{1, 2, 3, 4, 5}
       a.pop(3)
       a.should eq(Deque{1, 2})
     end
 
-    it "pops more elements than what is available" do
+    it("pops more elements than what is available") do
       a = Deque{1, 2, 3, 4, 5}
       a.pop(10)
       a.should eq(Deque(Int32).new)
     end
 
-    it "pops negative count raises" do
+    it("pops negative count raises") do
       a = Deque{1, 2}
-      expect_raises ArgumentError do
+      expect_raises(ArgumentError) do
         a.pop(-1)
       end
     end
   end
 
-  describe "push" do
-    it "adds one element to the deque" do
+  describe("push") do
+    it("adds one element to the deque") do
       a = Deque{"a", "b"}
       a.push("c")
       a.should eq Deque{"a", "b", "c"}
     end
 
-    it "returns the deque" do
+    it("returns the deque") do
       a = Deque{"a", "b"}
       a.push("c").should eq Deque{"a", "b", "c"}
     end
 
-    it "has the << alias" do
+    it("has the << alias") do
       a = Deque{"a", "b"}
       a << "c"
       a.should eq Deque{"a", "b", "c"}
     end
   end
 
-  describe "rotate!" do
-    it "rotates" do
+  describe("rotate!") do
+    it("rotates") do
       a = Deque{1, 2, 3, 4, 5}
       a.rotate!
       a.should eq(Deque{2, 3, 4, 5, 1})
@@ -463,7 +463,7 @@ describe "Deque" do
       a.should eq(Deque{5, 1, 2, 3, 4})
     end
 
-    it "rotates with size=capacity" do
+    it("rotates with size=capacity") do
       a = Deque{1, 2, 3, 4}
       a.rotate!
       a.should eq(Deque{2, 3, 4, 1})
@@ -474,88 +474,88 @@ describe "Deque" do
     end
   end
 
-  describe "shift" do
-    it "shifts when non empty" do
+  describe("shift") do
+    it("shifts when non empty") do
       a = Deque{1, 2, 3}
       a.shift.should eq(1)
       a.should eq(Deque{2, 3})
     end
 
-    it "raises when empty" do
-      expect_raises IndexError do
+    it("raises when empty") do
+      expect_raises(IndexError) do
         Deque(Int32).new.shift
       end
     end
 
-    it "shifts many elements" do
+    it("shifts many elements") do
       a = Deque{1, 2, 3, 4, 5}
       a.shift(3)
       a.should eq(Deque{4, 5})
     end
 
-    it "shifts more than what is available" do
+    it("shifts more than what is available") do
       a = Deque{1, 2, 3, 4, 5}
       a.shift(10)
       a.should eq(Deque(Int32).new)
     end
 
-    it "shifts negative count raises" do
+    it("shifts negative count raises") do
       a = Deque{1, 2}
-      expect_raises ArgumentError do
+      expect_raises(ArgumentError) do
         a.shift(-1)
       end
     end
   end
 
-  describe "swap" do
-    it "swaps" do
+  describe("swap") do
+    it("swaps") do
       a = Deque{1, 2, 3}
       a.swap(0, 2)
       a.should eq(Deque{3, 2, 1})
     end
 
-    it "swaps with negative indices" do
+    it("swaps with negative indices") do
       a = Deque{1, 2, 3}
       a.swap(-3, -1)
       a.should eq(Deque{3, 2, 1})
     end
 
-    it "swaps but raises out of bounds on left" do
+    it("swaps but raises out of bounds on left") do
       a = Deque{1, 2, 3}
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.swap(3, 0)
       end
     end
 
-    it "swaps but raises out of bounds on right" do
+    it("swaps but raises out of bounds on right") do
       a = Deque{1, 2, 3}
-      expect_raises IndexError do
+      expect_raises(IndexError) do
         a.swap(0, 3)
       end
     end
   end
 
-  describe "to_s" do
-    it "does to_s" do
+  describe("to_s") do
+    it("does to_s") do
       it { Deque{1, 2, 3}.to_s.should eq("Deque{1, 2, 3}") }
     end
 
-    it "does with recursive" do
+    it("does with recursive") do
       deq = Deque(RecursiveDeque).new
       deq << deq
       deq.to_s.should eq("Deque{Deque{...}}")
     end
   end
 
-  it "does unshift" do
+  it("does unshift") do
     a = Deque{2, 3}
     expected = Deque{1, 2, 3}
     a.unshift(1).should eq(expected)
     a.should eq(expected)
   end
 
-  describe "each iterator" do
-    it "does next" do
+  describe("each iterator") do
+    it("does next") do
       a = Deque{1, 2, 3}
       iter = a.each
       iter.next.should eq(1)
@@ -567,11 +567,11 @@ describe "Deque" do
       iter.next.should eq(1)
     end
 
-    it "cycles" do
+    it("cycles") do
       Deque{1, 2, 3}.cycle.first(8).join.should eq("12312312")
     end
 
-    it "works while modifying deque" do
+    it("works while modifying deque") do
       a = Deque{1, 2, 3}
       count = 0
       it = a.each
@@ -583,8 +583,8 @@ describe "Deque" do
     end
   end
 
-  describe "each_index iterator" do
-    it "does next" do
+  describe("each_index iterator") do
+    it("does next") do
       a = Deque{1, 2, 3}
       iter = a.each_index
       iter.next.should eq(0)
@@ -596,7 +596,7 @@ describe "Deque" do
       iter.next.should eq(0)
     end
 
-    it "works while modifying deque" do
+    it("works while modifying deque") do
       a = Deque{1, 2, 3}
       count = 0
       it = a.each_index
@@ -608,8 +608,8 @@ describe "Deque" do
     end
   end
 
-  describe "reverse each iterator" do
-    it "does next" do
+  describe("reverse each iterator") do
+    it("does next") do
       a = Deque{1, 2, 3}
       iter = a.reverse_each
       iter.next.should eq(3)
@@ -622,8 +622,8 @@ describe "Deque" do
     end
   end
 
-  describe "cycle" do
-    it "cycles" do
+  describe("cycle") do
+    it("cycles") do
       a = [] of Int32
       Deque{1, 2, 3}.cycle do |x|
         a << x
@@ -632,7 +632,7 @@ describe "Deque" do
       a.should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
     end
 
-    it "cycles N times" do
+    it("cycles N times") do
       a = [] of Int32
       Deque{1, 2, 3}.cycle(2) do |x|
         a << x
@@ -640,11 +640,11 @@ describe "Deque" do
       a.should eq([1, 2, 3, 1, 2, 3])
     end
 
-    it "cycles with iterator" do
+    it("cycles with iterator") do
       Deque{1, 2, 3}.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
     end
 
-    it "cycles with N and iterator" do
+    it("cycles with N and iterator") do
       Deque{1, 2, 3}.cycle(2).to_a.should eq([1, 2, 3, 1, 2, 3])
     end
   end

--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -1,33 +1,33 @@
 require "spec"
 require "digest/md5"
 
-describe Digest::MD5 do
-  it "calculates digest from string" do
+describe(Digest::MD5) do
+  it("calculates digest from string") do
     Digest::MD5.digest("foo").to_slice.should eq Bytes[0xac, 0xbd, 0x18, 0xdb, 0x4c, 0xc2, 0xf8, 0x5c, 0xed, 0xef, 0x65, 0x4f, 0xcc, 0xc4, 0xa4, 0xd8]
   end
 
-  it "calculates hash from string" do
+  it("calculates hash from string") do
     Digest::MD5.hexdigest("foo").should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
-  it "calculates hash from UInt8 slices" do
+  it("calculates hash from UInt8 slices") do
     s = Bytes[0x66, 0x6f, 0x6f] # f,o,o
     Digest::MD5.hexdigest(s).should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
-  it "calculates hash of #to_slice" do
+  it("calculates hash of #to_slice") do
     buffer = StaticArray(UInt8, 1).new(1_u8)
     Digest::MD5.hexdigest(buffer).should eq("55a54008ad1ba589aa210d2629c1df41")
   end
 
-  it "can take a block" do
+  it("can take a block") do
     Digest::MD5.hexdigest do |ctx|
       ctx.update "f"
       ctx.update Bytes[0x6f, 0x6f]
     end.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
-  it "calculates base64'd hash from string" do
+  it("calculates base64'd hash from string") do
     Digest::MD5.base64digest("foo").should eq("rL0Y20zC+Fzt72VPzMSk2A==")
   end
 end

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "digest/sha1"
 
-describe Digest::SHA1 do
+describe(Digest::SHA1) do
   [
     {"", "da39a3ee5e6b4b0d3255bfef95601890afd80709", "2jmj7l5rSw0yVb/vlWAYkK/YBwk="},
     {"The quick brown fox jumps over the lazy dog", "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", "L9ThxnotKPzthJ7hu3bnORuT6xI="},
@@ -10,12 +10,12 @@ describe Digest::SHA1 do
     {"a", "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8", "hvfkN/qlp/zhXR3cuerq6jd2Z7g="},
     {"0123456701234567012345670123456701234567012345670123456701234567", "e0c094e867ef46c350ef54a7f59dd60bed92ae83", "4MCU6GfvRsNQ71Sn9Z3WC+2SroM="},
   ].each do |(string, hexdigest, base64digest)|
-    it "does digest for #{string.inspect}" do
+    it("does digest for #{string.inspect}") do
       bytes = Digest::SHA1.digest(string)
       bytes.to_slice.hexstring.should eq(hexdigest)
     end
 
-    it "does digest for #{string.inspect} in a block" do
+    it("does digest for #{string.inspect} in a block") do
       bytes = Digest::SHA1.digest do |ctx|
         string.each_char do |chr|
           ctx.update chr.to_s
@@ -25,11 +25,11 @@ describe Digest::SHA1 do
       bytes.to_slice.hexstring.should eq(hexdigest)
     end
 
-    it "does hexdigest for #{string.inspect}" do
+    it("does hexdigest for #{string.inspect}") do
       Digest::SHA1.hexdigest(string).should eq(hexdigest)
     end
 
-    it "does base64digest for #{string.inspect}" do
+    it("does base64digest for #{string.inspect}") do
       Digest::SHA1.base64digest(string).should eq(base64digest)
     end
   end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -6,49 +6,49 @@ private def assert_dir_glob(expected_result, *patterns)
 end
 
 private def it_raises_on_null_byte(operation, &block)
-  it "errors on #{operation}" do
+  it("errors on #{operation}") do
     expect_raises(ArgumentError, "String contains null byte") do
       block.call
     end
   end
 end
 
-describe "Dir" do
-  it "tests exists? on existing directory" do
+describe("Dir") do
+  it("tests exists? on existing directory") do
     Dir.exists?(File.join([__DIR__, "../"])).should be_true
   end
 
-  it "tests exists? on existing file" do
+  it("tests exists? on existing file") do
     Dir.exists?(__FILE__).should be_false
   end
 
-  it "tests exists? on nonexistent directory" do
+  it("tests exists? on nonexistent directory") do
     Dir.exists?(File.join([__DIR__, "/foo/bar/"])).should be_false
   end
 
-  it "tests exists? on a directory path to a file" do
+  it("tests exists? on a directory path to a file") do
     Dir.exists?("#{__FILE__}/").should be_false
   end
 
-  describe "empty?" do
-    it "tests empty? on a full directory" do
+  describe("empty?") do
+    it("tests empty? on a full directory") do
       Dir.empty?(File.join([__DIR__, "../"])).should be_false
     end
 
-    it "tests empty? on an empty directory" do
+    it("tests empty? on an empty directory") do
       path = "/tmp/crystal_empty_test_#{Process.pid}/"
       Dir.mkdir(path, 0o700).should eq(0)
       Dir.empty?(path).should be_true
     end
 
-    it "tests empty? on nonexistent directory" do
-      expect_raises Errno do
+    it("tests empty? on nonexistent directory") do
+      expect_raises(Errno) do
         Dir.empty?(File.join([__DIR__, "/foo/bar/"]))
       end
     end
   end
 
-  it "tests mkdir and rmdir with a new path" do
+  it("tests mkdir and rmdir with a new path") do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
     Dir.mkdir(path, 0o700).should eq(0)
     Dir.exists?(path).should be_true
@@ -56,13 +56,13 @@ describe "Dir" do
     Dir.exists?(path).should be_false
   end
 
-  it "tests mkdir with an existing path" do
-    expect_raises Errno do
+  it("tests mkdir with an existing path") do
+    expect_raises(Errno) do
       Dir.mkdir(__DIR__, 0o700)
     end
   end
 
-  it "tests mkdir_p with a new path" do
+  it("tests mkdir_p with a new path") do
     path = "/tmp/crystal_mkdir_ptest_#{Process.pid}/"
     Dir.mkdir_p(path).should eq(0)
     Dir.exists?(path).should be_true
@@ -71,27 +71,27 @@ describe "Dir" do
     Dir.exists?(path).should be_true
   end
 
-  it "tests mkdir_p with an existing path" do
+  it("tests mkdir_p with an existing path") do
     Dir.mkdir_p(__DIR__).should eq(0)
-    expect_raises Errno do
+    expect_raises(Errno) do
       Dir.mkdir_p(__FILE__)
     end
   end
 
-  it "tests rmdir with an nonexistent path" do
-    expect_raises Errno do
+  it("tests rmdir with an nonexistent path") do
+    expect_raises(Errno) do
       Dir.rmdir("/tmp/crystal_mkdir_test_#{Process.pid}/")
     end
   end
 
-  it "tests rmdir with a path that cannot be removed" do
-    expect_raises Errno do
+  it("tests rmdir with a path that cannot be removed") do
+    expect_raises(Errno) do
       Dir.rmdir(__DIR__)
     end
   end
 
-  describe "glob" do
-    it "tests glob with a single pattern" do
+  describe("glob") do
+    it("tests glob with a single pattern") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -99,7 +99,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/*.txt"
     end
 
-    it "tests glob with multiple patterns" do
+    it("tests glob with multiple patterns") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -108,7 +108,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/*.txt", "#{__DIR__}/data/dir/subdir/*.txt"
     end
 
-    it "tests glob with a single pattern with block" do
+    it("tests glob with a single pattern with block") do
       result = [] of String
       Dir.glob("#{__DIR__}/data/dir/*.txt") do |filename|
         result << filename
@@ -120,7 +120,7 @@ describe "Dir" do
       ].sort)
     end
 
-    it "tests a recursive glob" do
+    it("tests a recursive glob") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -130,7 +130,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/**/*.txt"
     end
 
-    it "tests a recursive glob with '?'" do
+    it("tests a recursive glob with '?'") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -138,7 +138,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/f?.tx?"
     end
 
-    it "tests a recursive glob with alternation" do
+    it("tests a recursive glob with alternation") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -147,7 +147,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/{dir,dir/subdir}/*.txt"
     end
 
-    it "tests a glob with recursion inside alternation" do
+    it("tests a glob with recursion inside alternation") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -158,7 +158,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/{**/*.txt,**/*.txx}"
     end
 
-    it "tests a recursive glob with nested alternations" do
+    it("tests a recursive glob with nested alternations") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -166,7 +166,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/{?1.*,{f,g}2.txt}"
     end
 
-    it "tests with *" do
+    it("tests with *") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -177,7 +177,7 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/*"
     end
 
-    it "tests with ** (same as *)" do
+    it("tests with ** (same as *)") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -188,14 +188,14 @@ describe "Dir" do
       ], "#{__DIR__}/data/dir/**"
     end
 
-    it "tests with */" do
+    it("tests with */") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/subdir/",
         "#{__DIR__}/data/dir/subdir2/",
       ], "#{__DIR__}/data/dir/*/"
     end
 
-    it "tests glob with a single pattern with extra slashes" do
+    it("tests glob with a single pattern with extra slashes") do
       assert_dir_glob [
         "#{__DIR__}/data/dir/f1.txt",
         "#{__DIR__}/data/dir/f2.txt",
@@ -204,8 +204,8 @@ describe "Dir" do
     end
   end
 
-  describe "cd" do
-    it "should work" do
+  describe("cd") do
+    it("should work") do
       cwd = Dir.current
       Dir.cd("..")
       Dir.current.should_not eq(cwd)
@@ -213,13 +213,13 @@ describe "Dir" do
       Dir.current.should eq(cwd)
     end
 
-    it "raises" do
+    it("raises") do
       expect_raises do
         Dir.cd("/nope")
       end
     end
 
-    it "accepts a block" do
+    it("accepts a block") do
       cwd = Dir.current
 
       Dir.cd("..") do
@@ -230,7 +230,7 @@ describe "Dir" do
     end
   end
 
-  it "opens with new" do
+  it("opens with new") do
     filenames = [] of String
 
     dir = Dir.new(__DIR__)
@@ -242,7 +242,7 @@ describe "Dir" do
     filenames.includes?("dir_spec.cr").should be_true
   end
 
-  it "opens with open" do
+  it("opens with open") do
     filenames = [] of String
 
     Dir.open(__DIR__) do |dir|
@@ -254,22 +254,22 @@ describe "Dir" do
     filenames.includes?("dir_spec.cr").should be_true
   end
 
-  it "lists entries" do
+  it("lists entries") do
     filenames = Dir.entries(__DIR__)
     filenames.includes?(".").should be_true
     filenames.includes?("..").should be_true
     filenames.includes?("dir_spec.cr").should be_true
   end
 
-  it "lists children" do
+  it("lists children") do
     Dir.children(__DIR__).should eq(Dir.entries(__DIR__) - %w(. ..))
   end
 
-  it "does to_s" do
+  it("does to_s") do
     Dir.new(__DIR__).to_s.should eq("#<Dir:#{__DIR__}>")
   end
 
-  it "gets dir iterator" do
+  it("gets dir iterator") do
     filenames = [] of String
 
     iter = Dir.new(__DIR__).each_entry
@@ -282,7 +282,7 @@ describe "Dir" do
     filenames.includes?("dir_spec.cr").should be_true
   end
 
-  it "gets child iterator" do
+  it("gets child iterator") do
     filenames = [] of String
 
     iter = Dir.new(__DIR__).each_child
@@ -295,35 +295,35 @@ describe "Dir" do
     filenames.includes?("dir_spec.cr").should be_true
   end
 
-  it "double close doesn't error" do
+  it("double close doesn't error") do
     dir = Dir.open(__DIR__) do |dir|
       dir.close
       dir.close
     end
   end
 
-  describe "raises on null byte" do
-    it_raises_on_null_byte "new" do
+  describe("raises on null byte") do
+    it_raises_on_null_byte("new") do
       Dir.new("foo\0bar")
     end
 
-    it_raises_on_null_byte "cd" do
+    it_raises_on_null_byte("cd") do
       Dir.cd("foo\0bar")
     end
 
-    it_raises_on_null_byte "exists?" do
+    it_raises_on_null_byte("exists?") do
       Dir.exists?("foo\0bar")
     end
 
-    it_raises_on_null_byte "mkdir" do
+    it_raises_on_null_byte("mkdir") do
       Dir.mkdir("foo\0bar")
     end
 
-    it_raises_on_null_byte "mkdir_p" do
+    it_raises_on_null_byte("mkdir_p") do
       Dir.mkdir_p("foo\0bar")
     end
 
-    it_raises_on_null_byte "rmdir" do
+    it_raises_on_null_byte("rmdir") do
       Dir.rmdir("foo\0bar")
     end
   end

--- a/spec/std/double_spec.cr
+++ b/spec/std/double_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "Double" do
-  describe "**" do
+describe("Double") do
+  describe("**") do
     it { (2.5 ** 2).should be_close(6.25, 0.0001) }
     it { (2.5 ** 2.5_f32).should be_close(9.882117688026186, 0.0001) }
     it { (2.5 ** 2.5).should be_close(9.882117688026186, 0.0001) }

--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "ecr/lexer"
 
-describe "ECR::Lexer" do
-  it "lexes without interpolation" do
+describe("ECR::Lexer") do
+  it("lexes without interpolation") do
     lexer = ECR::Lexer.new("hello")
 
     token = lexer.next_token
@@ -15,7 +15,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <% %>" do
+  it("lexes with <% %>") do
     lexer = ECR::Lexer.new("hello <% foo %> bar")
 
     token = lexer.next_token
@@ -42,7 +42,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <%- %>" do
+  it("lexes with <%- %>") do
     lexer = ECR::Lexer.new("<%- foo %>")
 
     token = lexer.next_token
@@ -54,7 +54,7 @@ describe "ECR::Lexer" do
     token.supress_trailing?.should be_false
   end
 
-  it "lexes with <% -%>" do
+  it("lexes with <% -%>") do
     lexer = ECR::Lexer.new("<% foo -%>")
 
     token = lexer.next_token
@@ -66,7 +66,7 @@ describe "ECR::Lexer" do
     token.supress_trailing?.should be_true
   end
 
-  it "lexes with -% inside string" do
+  it("lexes with -% inside string") do
     lexer = ECR::Lexer.new("<% \"-%\" %>")
 
     token = lexer.next_token
@@ -74,7 +74,7 @@ describe "ECR::Lexer" do
     token.value.should eq(" \"-%\" ")
   end
 
-  it "lexes with <%= %>" do
+  it("lexes with <%= %>") do
     lexer = ECR::Lexer.new("hello <%= foo %> bar")
 
     token = lexer.next_token
@@ -101,7 +101,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <%= -%>" do
+  it("lexes with <%= -%>") do
     lexer = ECR::Lexer.new("<%= foo -%>")
 
     token = lexer.next_token
@@ -113,7 +113,7 @@ describe "ECR::Lexer" do
     token.supress_trailing?.should be_true
   end
 
-  it "lexes with <%# %>" do
+  it("lexes with <%# %>") do
     lexer = ECR::Lexer.new("hello <%# foo %> bar")
 
     token = lexer.next_token
@@ -140,7 +140,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <%# -%>" do
+  it("lexes with <%# -%>") do
     lexer = ECR::Lexer.new("<%# foo -%>")
 
     token = lexer.next_token
@@ -152,7 +152,7 @@ describe "ECR::Lexer" do
     token.supress_trailing?.should be_true
   end
 
-  it "lexes with <%% %>" do
+  it("lexes with <%% %>") do
     lexer = ECR::Lexer.new("hello <%% foo %> bar")
 
     token = lexer.next_token
@@ -179,7 +179,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <%%= %>" do
+  it("lexes with <%%= %>") do
     lexer = ECR::Lexer.new("hello <%%= foo %> bar")
 
     token = lexer.next_token
@@ -206,7 +206,7 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
-  it "lexes with <% %> and correct location info" do
+  it("lexes with <% %> and correct location info") do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 
     token = lexer.next_token

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -11,8 +11,8 @@ private class ECRSpecHelloView
   ECR.def_to_s "#{__DIR__}/../data/test_template.ecr"
 end
 
-describe "ECR" do
-  it "builds a crystal program from a source" do
+describe("ECR") do
+  it("builds a crystal program from a source") do
     program = ECR.process_string "hello <%= 1 %> wor\nld <% while true %> 2 <% end %>\n<%# skip %> <%% \"string\" %>", "foo.cr"
 
     pieces = [
@@ -30,36 +30,36 @@ describe "ECR" do
     program.should eq(pieces.join("\n") + "\n")
   end
 
-  it "does ECR.def_to_s" do
+  it("does ECR.def_to_s") do
     view = ECRSpecHelloView.new("world!")
     view.to_s.strip.should eq("Hello world! 012")
   end
 
-  it "does with <%= -%>" do
+  it("does with <%= -%>") do
     io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template2.ecr", io
     io.to_s.should eq("123")
   end
 
-  it "does with <%- %> (1)" do
+  it("does with <%- %> (1)") do
     io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template3.ecr", io
     io.to_s.should eq("01")
   end
 
-  it "does with <%- %> (2)" do
+  it("does with <%- %> (2)") do
     io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template4.ecr", io
     io.to_s.should eq("hi\n01")
   end
 
-  it "does with <% -%>" do
+  it("does with <% -%>") do
     io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template5.ecr", io
     io.to_s.should eq("hi\n      0\n      1\n  ")
   end
 
-  it "does with -% inside string" do
+  it("does with -% inside string") do
     io = IO::Memory.new
     ECR.embed "#{__DIR__}/../data/test_template6.ecr", io
     io.to_s.should eq("string with -%")

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -18,27 +18,27 @@ enum SpecEnumFlags
   Three
 end
 
-describe Enum do
-  describe "to_s" do
-    it "for simple enum" do
+describe(Enum) do
+  describe("to_s") do
+    it("for simple enum") do
       SpecEnum::One.to_s.should eq("One")
       SpecEnum::Two.to_s.should eq("Two")
       SpecEnum::Three.to_s.should eq("Three")
     end
 
-    it "for flags enum" do
+    it("for flags enum") do
       SpecEnumFlags::None.to_s.should eq("None")
       SpecEnumFlags::All.to_s.should eq("One | Two | Three")
       (SpecEnumFlags::One | SpecEnumFlags::Two).to_s.should eq("One | Two")
     end
   end
 
-  it "gets value" do
+  it("gets value") do
     SpecEnum::Two.value.should eq(1)
     SpecEnum::Two.value.should be_a(Int8)
   end
 
-  it "gets value with to_i" do
+  it("gets value with to_i") do
     SpecEnum::Two.to_i.should eq(1)
     SpecEnum::Two.to_i.should be_a(Int32)
 
@@ -46,37 +46,37 @@ describe Enum do
     SpecEnum::Two.to_i64.should be_a(Int64)
   end
 
-  it "does +" do
+  it("does +") do
     (SpecEnum::One + 1).should eq(SpecEnum::Two)
   end
 
-  it "does -" do
+  it("does -") do
     (SpecEnum::Two - 1).should eq(SpecEnum::One)
   end
 
-  it "sorts" do
+  it("sorts") do
     [SpecEnum::Three, SpecEnum::One, SpecEnum::Two].sort.should eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
   end
 
-  it "does includes?" do
+  it("does includes?") do
     (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::One).should be_true
     (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::Three).should be_false
   end
 
-  describe "each" do
-    it "won't yield None" do
+  describe("each") do
+    it("won't yield None") do
       SpecEnumFlags::None.each do |name|
         raise "unexpected yield"
       end
     end
 
-    it "won't yield All" do
+    it("won't yield All") do
       SpecEnumFlags::All.each do |name|
         raise "unexpected yield" if name == SpecEnumFlags::All
       end
     end
 
-    it "yields each member" do
+    it("yields each member") do
       names = [] of SpecEnumFlags
       values = [] of Int32
       SpecEnumFlags.flags(One, Three).each do |name, value|
@@ -88,35 +88,35 @@ describe Enum do
     end
   end
 
-  describe "names" do
-    it "for simple enum" do
+  describe("names") do
+    it("for simple enum") do
       SpecEnum.names.should eq(%w(One Two Three))
     end
 
-    it "for flags enum" do
+    it("for flags enum") do
       SpecEnumFlags.names.should eq(%w(One Two Three))
     end
   end
 
-  describe "values" do
-    it "for simple enum" do
+  describe("values") do
+    it("for simple enum") do
       SpecEnum.values.should eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
     end
 
-    it "for flags enum" do
+    it("for flags enum") do
       SpecEnumFlags.values.should eq([SpecEnumFlags::One, SpecEnumFlags::Two, SpecEnumFlags::Three])
     end
   end
 
-  describe "from_value?" do
-    it "for simple enum" do
+  describe("from_value?") do
+    it("for simple enum") do
       SpecEnum.from_value?(0).should eq(SpecEnum::One)
       SpecEnum.from_value?(1).should eq(SpecEnum::Two)
       SpecEnum.from_value?(2).should eq(SpecEnum::Three)
       SpecEnum.from_value?(3).should be_nil
     end
 
-    it "for flags enum" do
+    it("for flags enum") do
       SpecEnumFlags.from_value?(0).should be_nil
       SpecEnumFlags.from_value?(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value?(2).should eq(SpecEnumFlags::Two)
@@ -125,15 +125,15 @@ describe Enum do
     end
   end
 
-  describe "from_value" do
-    it "for simple enum" do
+  describe("from_value") do
+    it("for simple enum") do
       SpecEnum.from_value(0).should eq(SpecEnum::One)
       SpecEnum.from_value(1).should eq(SpecEnum::Two)
       SpecEnum.from_value(2).should eq(SpecEnum::Three)
       expect_raises { SpecEnum.from_value(3) }
     end
 
-    it "for flags enum" do
+    it("for flags enum") do
       expect_raises { SpecEnumFlags.from_value(0) }
       SpecEnumFlags.from_value(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value(2).should eq(SpecEnumFlags::Two)
@@ -141,11 +141,11 @@ describe Enum do
     end
   end
 
-  it "has hash" do
+  it("has hash") do
     SpecEnum::Two.hash.should_not eq(SpecEnum::Three.hash)
   end
 
-  it "parses" do
+  it("parses") do
     SpecEnum.parse("Two").should eq(SpecEnum::Two)
     SpecEnum2.parse("FourtyTwo").should eq(SpecEnum2::FourtyTwo)
     SpecEnum2.parse("fourty_two").should eq(SpecEnum2::FourtyTwo)
@@ -162,17 +162,17 @@ describe Enum do
     SpecEnum2.parse("fourtyfour").should eq(SpecEnum2::FOURTY_FOUR)
   end
 
-  it "parses?" do
+  it("parses?") do
     SpecEnum.parse?("Two").should eq(SpecEnum::Two)
     SpecEnum.parse?("Four").should be_nil
   end
 
-  it "clones" do
+  it("clones") do
     SpecEnum::One.clone.should eq(SpecEnum::One)
   end
 
-  describe "each" do
-    it "iterates each member" do
+  describe("each") do
+    it("iterates each member") do
       keys = [] of SpecEnum
       values = [] of Int8
 
@@ -185,7 +185,7 @@ describe Enum do
       values.should eq([SpecEnum::One.value, SpecEnum::Two.value, SpecEnum::Three.value])
     end
 
-    it "iterates each flag" do
+    it("iterates each flag") do
       keys = [] of SpecEnumFlags
       values = [] of Int32
 
@@ -199,7 +199,7 @@ describe Enum do
     end
   end
 
-  it "different enums classes not eq always" do
+  it("different enums classes not eq always") do
     SpecEnum::One.should_not eq SpecEnum2::FourtyTwo
   end
 end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -10,65 +10,65 @@ private class SpecEnumerable
   end
 end
 
-describe "Enumerable" do
-  describe "all? with block" do
-    it "returns true" do
+describe("Enumerable") do
+  describe("all? with block") do
+    it("returns true") do
       ["ant", "bear", "cat"].all? { |word| word.size >= 3 }.should be_true
     end
 
-    it "returns false" do
+    it("returns false") do
       ["ant", "bear", "cat"].all? { |word| word.size >= 4 }.should be_false
     end
   end
 
-  describe "all? without block" do
-    it "returns true" do
+  describe("all? without block") do
+    it("returns true") do
       [15].all?.should be_true
     end
 
-    it "returns false" do
+    it("returns false") do
       [nil, true, 99].all?.should be_false
     end
   end
 
-  describe "any? with block" do
-    it "returns true if at least one element fulfills the condition" do
+  describe("any? with block") do
+    it("returns true if at least one element fulfills the condition") do
       ["ant", "bear", "cat"].any? { |word| word.size >= 4 }.should be_true
     end
 
-    it "returns false if all elements does not fulfill the condition" do
+    it("returns false if all elements does not fulfill the condition") do
       ["ant", "bear", "cat"].any? { |word| word.size > 4 }.should be_false
     end
   end
 
-  describe "any? without block" do
-    it "returns true if at least one element is truthy" do
+  describe("any? without block") do
+    it("returns true if at least one element is truthy") do
       [nil, true, 99].any?.should be_true
     end
 
-    it "returns false if all elements are falsey" do
+    it("returns false if all elements are falsey") do
       [nil, false].any?.should be_false
     end
   end
 
-  describe "compact map" do
+  describe("compact map") do
     it { Set{1, nil, 2, nil, 3}.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
   end
 
-  describe "size without block" do
-    it "returns the number of elements in the Enumerable" do
+  describe("size without block") do
+    it("returns the number of elements in the Enumerable") do
       SpecEnumerable.new.size.should eq 3
     end
   end
 
-  describe "count with block" do
-    it "returns the number of the times the item is present" do
+  describe("count with block") do
+    it("returns the number of the times the item is present") do
       %w(a b c a d A).count("a").should eq 2
     end
   end
 
-  describe "cycle" do
-    it "calls forever if we don't break" do
+  describe("cycle") do
+    it("calls forever if we don't break") do
       called = 0
       elements = [] of Int32
       (1..2).cycle do |e|
@@ -80,7 +80,7 @@ describe "Enumerable" do
       elements.should eq [1, 2, 1, 2, 1, 2]
     end
 
-    it "calls the block n times given the optional argument" do
+    it("calls the block n times given the optional argument") do
       called = 0
       elements = [] of Int32
       (1..2).cycle(3) do |e|
@@ -92,8 +92,8 @@ describe "Enumerable" do
     end
   end
 
-  describe "chunk" do
-    it "works" do
+  describe("chunk") do
+    it("works") do
       [1].chunk { true }.to_a.should eq [{true, [1]}]
       [1, 2].chunk { false }.to_a.should eq [{false, [1, 2]}]
       [1, 1, 2, 3, 3].chunk(&.itself).to_a.should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
@@ -101,17 +101,17 @@ describe "Enumerable" do
       (0..10).chunk(&./(3)).to_a.should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
     end
 
-    it "work with class" do
+    it("work with class") do
       [1, 1, 2, 3, 3].chunk(&.class).to_a.should eq [{Int32, [1, 1, 2, 3, 3]}]
     end
 
-    it "works with block" do
+    it("works with block") do
       res = [] of Tuple(Bool, Array(Int32))
       [1, 2, 3].chunk { |x| x < 3 }.each { |(k, v)| res << {k, v} }
       res.should eq [{true, [1, 2]}, {false, [3]}]
     end
 
-    it "rewind" do
+    it("rewind") do
       i = (0..10).chunk(&./(3))
       i.next.should eq({0, [0, 1, 2]})
       i.next.should eq({1, [3, 4, 5]})
@@ -120,42 +120,42 @@ describe "Enumerable" do
       i.next.should eq({1, [3, 4, 5]})
     end
 
-    it "returns elements of the Enumerable in an Array of Tuple, {v, ary}, where 'ary' contains the consecutive elements for which the block returned the value 'v'" do
+    it("returns elements of the Enumerable in an Array of Tuple, {v, ary}, where 'ary' contains the consecutive elements for which the block returned the value 'v'") do
       result = [1, 2, 3, 2, 3, 2, 1].chunk { |x| x < 3 ? 1 : 0 }.to_a
       result.should eq [{1, [1, 2]}, {0, [3]}, {1, [2]}, {0, [3]}, {1, [2, 1]}]
     end
 
-    it "returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays" do
+    it("returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays") do
       result = [1, 2, 3, 2, 1].chunk { |x| x < 2 ? Enumerable::Chunk::Alone : false }.to_a
       result.should eq [{Enumerable::Chunk::Alone, [1]}, {false, [2, 3, 2]}, {Enumerable::Chunk::Alone, [1]}]
     end
 
-    it "alone all" do
+    it("alone all") do
       result = [1, 2].chunk { Enumerable::Chunk::Alone }.to_a
       result.should eq [{Enumerable::Chunk::Alone, [1]}, {Enumerable::Chunk::Alone, [2]}]
     end
 
-    it "does not return elements for which the block returns Enumerable::Chunk::Drop" do
+    it("does not return elements for which the block returns Enumerable::Chunk::Drop") do
       result = [1, 2, 3, 3, 2, 1].chunk { |x| x == 2 ? Enumerable::Chunk::Drop : 1 }.to_a
       result.should eq [{1, [1]}, {1, [3, 3]}, {1, [1]}]
     end
 
-    it "drop all" do
+    it("drop all") do
       result = [1, 2].chunk { Enumerable::Chunk::Drop }.to_a
       result.size.should eq 0
     end
 
-    it "nil allowed as value" do
+    it("nil allowed as value") do
       result = [1, 2, 3, 2, 1].chunk { |x| x == 2 ? nil : 1 }.to_a
       result.should eq [{1, [1]}, {nil, [2]}, {1, [3]}, {nil, [2]}, {1, [1]}]
     end
 
-    it "nil 2 case" do
+    it("nil 2 case") do
       result = [nil, nil, 1, 1, nil].chunk(&.itself).to_a
       result.should eq [{nil, [nil, nil]}, {1, [1, 1]}, {nil, [nil]}]
     end
 
-    it "reuses true" do
+    it("reuses true") do
       iter = [1, 1, 2, 3, 3].chunk(reuse: true, &.itself)
       a = iter.next.as(Tuple)
       a.should eq({1, [1, 1]})
@@ -175,8 +175,8 @@ describe "Enumerable" do
     end
   end
 
-  describe "chunks" do
-    it "works" do
+  describe("chunks") do
+    it("works") do
       [1].chunks { true }.should eq [{true, [1]}]
       [1, 2].chunks { false }.should eq [{false, [1, 2]}]
       [1, 1, 2, 3, 3].chunks(&.itself).should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
@@ -184,59 +184,59 @@ describe "Enumerable" do
       (0..10).chunks(&./(3)).should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
     end
 
-    it "work with class" do
+    it("work with class") do
       [1, 1, 2, 3, 3].chunks(&.class).should eq [{Int32, [1, 1, 2, 3, 3]}]
     end
 
-    it "work with pure enumerable" do
+    it("work with pure enumerable") do
       SpecEnumerable.new.chunks(&./(2)).should eq [{0, [1]}, {1, [2, 3]}]
     end
 
-    it "returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays" do
+    it("returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays") do
       result = [1, 2, 3, 2, 1].chunks { |x| x < 2 ? Enumerable::Chunk::Alone : false }
       result.should eq [{Enumerable::Chunk::Alone, [1]}, {false, [2, 3, 2]}, {Enumerable::Chunk::Alone, [1]}]
     end
 
-    it "alone all" do
+    it("alone all") do
       result = [1, 2].chunks { Enumerable::Chunk::Alone }
       result.should eq [{Enumerable::Chunk::Alone, [1]}, {Enumerable::Chunk::Alone, [2]}]
     end
 
-    it "does not return elements for which the block returns Enumerable::Chunk::Drop" do
+    it("does not return elements for which the block returns Enumerable::Chunk::Drop") do
       result = [1, 2, 3, 3, 2, 1].chunks { |x| x == 2 ? Enumerable::Chunk::Drop : 1 }
       result.should eq [{1, [1]}, {1, [3, 3]}, {1, [1]}]
     end
 
-    it "drop all" do
+    it("drop all") do
       result = [1, 2].chunks { Enumerable::Chunk::Drop }
       result.size.should eq 0
     end
 
-    it "nil allowed as value" do
+    it("nil allowed as value") do
       result = [1, 2, 3, 2, 1].chunks { |x| x == 2 ? nil : 1 }
       result.should eq [{1, [1]}, {nil, [2]}, {1, [3]}, {nil, [2]}, {1, [1]}]
     end
 
-    it "nil 2 case" do
+    it("nil 2 case") do
       result = [nil, nil, 1, 1, nil].chunks(&.itself)
       result.should eq [{nil, [nil, nil]}, {1, [1, 1]}, {nil, [nil]}]
     end
   end
 
-  describe "each_cons" do
-    it "returns running pairs" do
+  describe("each_cons") do
+    it("returns running pairs") do
       array = [] of Array(Int32)
       [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
       array.should eq([[1, 2], [2, 3], [3, 4]])
     end
 
-    it "returns running triples" do
+    it("returns running triples") do
       array = [] of Array(Int32)
       [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
       array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     end
 
-    it "returns each_cons iterator" do
+    it("returns each_cons iterator") do
       iter = [1, 2, 3, 4, 5].each_cons(3)
       iter.next.should eq([1, 2, 3])
       iter.next.should eq([2, 3, 4])
@@ -247,7 +247,7 @@ describe "Enumerable" do
       iter.next.should eq([1, 2, 3])
     end
 
-    it "returns each_cons iterator with reuse = true" do
+    it("returns each_cons iterator with reuse = true") do
       iter = [1, 2, 3, 4, 5].each_cons(3, reuse: true)
 
       a = iter.next
@@ -257,7 +257,7 @@ describe "Enumerable" do
       b.should be(a)
     end
 
-    it "returns each_cons iterator with reuse = array" do
+    it("returns each_cons iterator with reuse = array") do
       reuse = [] of Int32
       iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
 
@@ -266,7 +266,7 @@ describe "Enumerable" do
       a.should be(reuse)
     end
 
-    it "returns running pairs with reuse = true" do
+    it("returns running pairs with reuse = true") do
       array = [] of Array(Int32)
       object_ids = Set(UInt64).new
       [1, 2, 3, 4].each_cons(2, reuse: true) do |pair|
@@ -277,7 +277,7 @@ describe "Enumerable" do
       object_ids.size.should eq(1)
     end
 
-    it "returns running pairs with reuse = array" do
+    it("returns running pairs with reuse = array") do
       array = [] of Array(Int32)
       reuse = [] of Int32
       [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
@@ -288,22 +288,22 @@ describe "Enumerable" do
     end
   end
 
-  describe "each_slice" do
-    it "returns partial slices" do
+  describe("each_slice") do
+    it("returns partial slices") do
       array = [] of Array(Int32)
       [1, 2, 3].each_slice(2) { |slice| array << slice }
       array.should eq([[1, 2], [3]])
       array[0].should_not be(array[1])
     end
 
-    it "returns full slices" do
+    it("returns full slices") do
       array = [] of Array(Int32)
       [1, 2, 3, 4].each_slice(2) { |slice| array << slice }
       array.should eq([[1, 2], [3, 4]])
       array[0].should_not be(array[1])
     end
 
-    it "reuses with true" do
+    it("reuses with true") do
       array = [] of Array(Int32)
       object_ids = Set(UInt64).new
       [1, 2, 3, 4].each_slice(2, reuse: true) do |slice|
@@ -314,7 +314,7 @@ describe "Enumerable" do
       object_ids.size.should eq(1)
     end
 
-    it "reuses with existing array" do
+    it("reuses with existing array") do
       array = [] of Array(Int32)
       reuse = [] of Int32
       [1, 2, 3, 4].each_slice(2, reuse: reuse) do |slice|
@@ -324,7 +324,7 @@ describe "Enumerable" do
       array.should eq([[1, 2], [3, 4]])
     end
 
-    it "returns each_slice iterator" do
+    it("returns each_slice iterator") do
       iter = [1, 2, 3, 4, 5].each_slice(2)
       iter.next.should eq([1, 2])
       iter.next.should eq([3, 4])
@@ -336,8 +336,8 @@ describe "Enumerable" do
     end
   end
 
-  describe "each_with_index" do
-    it "yields the element and the index" do
+  describe("each_with_index") do
+    it("yields the element and the index") do
       collection = [] of {String, Int32}
       ["a", "b", "c"].each_with_index do |e, i|
         collection << {e, i}
@@ -345,7 +345,7 @@ describe "Enumerable" do
       collection.should eq [{"a", 0}, {"b", 1}, {"c", 2}]
     end
 
-    it "accepts an optional offset parameter" do
+    it("accepts an optional offset parameter") do
       collection = [] of {String, Int32}
       ["Alice", "Bob"].each_with_index(1) do |e, i|
         collection << {e, i}
@@ -353,7 +353,7 @@ describe "Enumerable" do
       collection.should eq [{"Alice", 1}, {"Bob", 2}]
     end
 
-    it "gets each_with_index iterator" do
+    it("gets each_with_index iterator") do
       iter = [1, 2].each_with_index
       iter.next.should eq({1, 0})
       iter.next.should eq({2, 1})
@@ -364,8 +364,8 @@ describe "Enumerable" do
     end
   end
 
-  describe "each_with_object" do
-    it "yields the element and the given object" do
+  describe("each_with_object") do
+    it("yields the element and the given object") do
       collection = [] of {Int32, String}
       object = "a"
       (1..3).each_with_object(object) do |e, o|
@@ -374,7 +374,7 @@ describe "Enumerable" do
       collection.should eq [{1, object}, {2, object}, {3, object}]
     end
 
-    it "gets each_with_object iterator" do
+    it("gets each_with_object iterator") do
       iter = [1, 2].each_with_object("a")
       iter.next.should eq({1, "a"})
       iter.next.should eq({2, "a"})
@@ -385,27 +385,27 @@ describe "Enumerable" do
     end
   end
 
-  describe "find" do
-    it "finds" do
+  describe("find") do
+    it("finds") do
       [1, 2, 3].find { |x| x > 2 }.should eq(3)
     end
 
-    it "doesn't find" do
+    it("doesn't find") do
       [1, 2, 3].find { |x| x > 3 }.should be_nil
     end
 
-    it "doesn't find with default value" do
+    it("doesn't find with default value") do
       [1, 2, 3].find(-1) { |x| x > 3 }.should eq(-1)
     end
   end
 
-  describe "first" do
-    it "gets first" do
+  describe("first") do
+    it("gets first") do
       (1..3).first.should eq(1)
     end
 
-    it "raises if enumerable empty" do
-      expect_raises Enumerable::EmptyError do
+    it("raises if enumerable empty") do
+      expect_raises(Enumerable::EmptyError) do
         (1...1).first
       end
     end
@@ -413,77 +413,77 @@ describe "Enumerable" do
     it { [-1, -2, -3].first.should eq(-1) }
   end
 
-  describe "first?" do
-    it "gets first?" do
+  describe("first?") do
+    it("gets first?") do
       (1..3).first?.should eq(1)
     end
 
-    it "returns nil if enumerable empty" do
+    it("returns nil if enumerable empty") do
       (1...1).first?.should be_nil
     end
   end
 
-  describe "flat_map" do
-    it "does example 1" do
+  describe("flat_map") do
+    it("does example 1") do
       [1, 2, 3, 4].flat_map { |e| [e, -e] }.should eq([1, -1, 2, -2, 3, -3, 4, -4])
     end
 
-    it "does example 2" do
+    it("does example 2") do
       [[1, 2], [3, 4]].flat_map { |e| e + [100] }.should eq([1, 2, 100, 3, 4, 100])
     end
 
-    it "does example 3" do
+    it("does example 3") do
       [[1, 2, 3], 4, 5].flat_map { |e| e }.should eq([1, 2, 3, 4, 5])
     end
 
-    it "does example 4" do
+    it("does example 4") do
       [{1 => 2}, {3 => 4}].flat_map { |e| e }.should eq([{1 => 2}, {3 => 4}])
     end
 
-    it "flattens iterators" do
+    it("flattens iterators") do
       [[1, 2], [3, 4]].flat_map(&.each).should eq([1, 2, 3, 4])
     end
   end
 
-  describe "grep" do
-    it "works with regexes for instance" do
+  describe("grep") do
+    it("works with regexes for instance") do
       ["Alice", "Bob", "Cipher", "Anna"].grep(/^A/).should eq ["Alice", "Anna"]
     end
 
-    it "returns empty array if nothing matches" do
+    it("returns empty array if nothing matches") do
       %w(Alice Bob Mallory).grep(/nothing/).should eq [] of String
     end
   end
 
-  describe "group_by" do
+  describe("group_by") do
     it { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
 
-    it "groups can group by size (like the doc example)" do
+    it("groups can group by size (like the doc example)") do
       %w(Alice Bob Ary).group_by { |e| e.size }.should eq({3 => ["Bob", "Ary"],
                                                            5 => ["Alice"]})
     end
   end
 
-  describe "in_groups_of" do
+  describe("in_groups_of") do
     it { [1, 2, 3].in_groups_of(1).should eq([[1], [2], [3]]) }
     it { [1, 2, 3].in_groups_of(2).should eq([[1, 2], [3, nil]]) }
     it { [1, 2, 3, 4].in_groups_of(3).should eq([[1, 2, 3], [4, nil, nil]]) }
     it { ([] of Int32).in_groups_of(2).should eq([] of Array(Array(Int32 | Nil))) }
     it { [1, 2, 3].in_groups_of(2, "x").should eq([[1, 2], [3, "x"]]) }
 
-    it "raises argument error if size is less than 0" do
-      expect_raises ArgumentError, "Size must be positive" do
+    it("raises argument error if size is less than 0") do
+      expect_raises(ArgumentError, "Size must be positive") do
         [1, 2, 3].in_groups_of(0)
       end
     end
 
-    it "takes a block" do
+    it("takes a block") do
       sums = [] of Int32
       [1, 2, 4, 5].in_groups_of(3, 10) { |a| sums << a.sum }
       sums.should eq([7, 25])
     end
 
-    it "reuses with true" do
+    it("reuses with true") do
       array = [] of Array(Int32)
       object_ids = Set(UInt64).new
       [1, 2, 4, 5].in_groups_of(3, 10, reuse: true) do |group|
@@ -494,7 +494,7 @@ describe "Enumerable" do
       object_ids.size.should eq(1)
     end
 
-    it "reuses with existing array" do
+    it("reuses with existing array") do
       array = [] of Array(Int32)
       reuse = [] of Int32
       [1, 2, 4, 5].in_groups_of(3, 10, reuse: reuse) do |slice|
@@ -505,284 +505,284 @@ describe "Enumerable" do
     end
   end
 
-  describe "includes?" do
-    it "is true if the object exists in the collection" do
+  describe("includes?") do
+    it("is true if the object exists in the collection") do
       [1, 2, 3].includes?(2).should be_true
     end
 
-    it "is false if the object is not part of the collection" do
+    it("is false if the object is not part of the collection") do
       [1, 2, 3].includes?(5).should be_false
     end
   end
 
-  describe "index with a block" do
-    it "returns the index of the first element where the blcok returns true" do
+  describe("index with a block") do
+    it("returns the index of the first element where the blcok returns true") do
       ["Alice", "Bob"].index { |name| name.size < 4 }.should eq 1
     end
 
-    it "returns nil if no object could be found" do
+    it("returns nil if no object could be found") do
       ["Alice", "Bob"].index { |name| name.size < 3 }.should eq nil
     end
   end
 
-  describe "index with an object" do
-    it "returns the index of that object if found" do
+  describe("index with an object") do
+    it("returns the index of that object if found") do
       ["Alice", "Bob"].index("Alice").should eq 0
     end
 
-    it "returns nil if the object was not found" do
+    it("returns nil if the object was not found") do
       ["Alice", "Bob"].index("Mallory").should be_nil
     end
   end
 
-  describe "index_by" do
-    it "creates a hash indexed by the value returned by the block" do
+  describe("index_by") do
+    it("creates a hash indexed by the value returned by the block") do
       hash = ["Anna", "Ary", "Alice"].index_by { |e| e.size }
       hash.should eq({4 => "Anna", 3 => "Ary", 5 => "Alice"})
     end
 
-    it "overrides values if a value is returned twice" do
+    it("overrides values if a value is returned twice") do
       hash = ["Anna", "Ary", "Alice", "Bob"].index_by { |e| e.size }
       hash.should eq({4 => "Anna", 3 => "Bob", 5 => "Alice"})
     end
   end
 
-  describe "reduce" do
+  describe("reduce") do
     it { [1, 2, 3].reduce { |memo, i| memo + i }.should eq(6) }
     it { [1, 2, 3].reduce(10) { |memo, i| memo + i }.should eq(16) }
 
-    it "raises if empty" do
-      expect_raises Enumerable::EmptyError do
+    it("raises if empty") do
+      expect_raises(Enumerable::EmptyError) do
         ([] of Int32).reduce { |memo, i| memo + i }
       end
     end
 
-    it "does not raise if empty if there is a memo argument" do
+    it("does not raise if empty if there is a memo argument") do
       result = ([] of Int32).reduce(10) { |memo, i| memo + i }
       result.should eq 10
     end
   end
 
-  describe "join" do
-    it "joins with separator and block" do
+  describe("join") do
+    it("joins with separator and block") do
       str = [1, 2, 3].join(", ") { |x| x + 1 }
       str.should eq("2, 3, 4")
     end
 
-    it "joins without separator and block" do
+    it("joins without separator and block") do
       str = [1, 2, 3].join { |x| x + 1 }
       str.should eq("234")
     end
 
-    it "joins with io and block" do
+    it("joins with io and block") do
       str = IO::Memory.new
       [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
       str.to_s.should eq("2, 3, 4")
     end
 
-    it "joins with only separator" do
+    it("joins with only separator") do
       ["Ruby", "Crystal", "Python"].join(", ").should eq "Ruby, Crystal, Python"
     end
   end
 
-  describe "map" do
-    it "applies the function to each element and returns a new array" do
+  describe("map") do
+    it("applies the function to each element and returns a new array") do
       result = [1, 2, 3].map { |i| i * 10 }
       result.should eq [10, 20, 30]
     end
 
-    it "leaves the original unmodified" do
+    it("leaves the original unmodified") do
       original = [1, 2, 3]
       original.map { |i| i * 10 }
       original.should eq [1, 2, 3]
     end
   end
 
-  describe "map_with_index" do
-    it "yields the element and the index" do
+  describe("map_with_index") do
+    it("yields the element and the index") do
       result = ["Alice", "Bob"].map_with_index { |name, i| "User ##{i}: #{name}" }
       result.should eq ["User #0: Alice", "User #1: Bob"]
     end
 
-    it "yields the element and the index of an iterator" do
+    it("yields the element and the index of an iterator") do
       str = "hello"
       result = str.each_char.map_with_index { |char, i| "#{char}#{i}" }
       result.should eq ["h0", "e1", "l2", "l3", "o4"]
     end
   end
 
-  describe "max" do
+  describe("max") do
     it { [1, 2, 3].max.should eq(3) }
 
-    it "raises if empty" do
-      expect_raises Enumerable::EmptyError do
+    it("raises if empty") do
+      expect_raises(Enumerable::EmptyError) do
         ([] of Int32).max
       end
     end
   end
 
-  describe "max?" do
-    it "returns nil if empty" do
+  describe("max?") do
+    it("returns nil if empty") do
       ([] of Int32).max?.should be_nil
     end
   end
 
-  describe "max_by" do
+  describe("max_by") do
     it { [-1, -2, -3].max_by { |x| -x }.should eq(-3) }
   end
 
-  describe "max_by?" do
-    it "returns nil if empty" do
+  describe("max_by?") do
+    it("returns nil if empty") do
       ([] of Int32).max_by? { |x| -x }.should be_nil
     end
   end
 
-  describe "max_of" do
+  describe("max_of") do
     it { [-1, -2, -3].max_of { |x| -x }.should eq(3) }
   end
 
-  describe "max_of?" do
-    it "returns nil if empty" do
+  describe("max_of?") do
+    it("returns nil if empty") do
       ([] of Int32).max_of? { |x| -x }.should be_nil
     end
   end
 
-  describe "min" do
+  describe("min") do
     it { [1, 2, 3].min.should eq(1) }
 
-    it "raises if empty" do
-      expect_raises Enumerable::EmptyError do
+    it("raises if empty") do
+      expect_raises(Enumerable::EmptyError) do
         ([] of Int32).min
       end
     end
   end
 
-  describe "min?" do
-    it "returns nil if empty" do
+  describe("min?") do
+    it("returns nil if empty") do
       ([] of Int32).min?.should be_nil
     end
   end
 
-  describe "min_by" do
+  describe("min_by") do
     it { [1, 2, 3].min_by { |x| -x }.should eq(3) }
   end
 
-  describe "min_by?" do
-    it "returns nil if empty" do
+  describe("min_by?") do
+    it("returns nil if empty") do
       ([] of Int32).max_by? { |x| -x }.should be_nil
     end
   end
 
-  describe "min_of" do
+  describe("min_of") do
     it { [1, 2, 3].min_of { |x| -x }.should eq(-3) }
   end
 
-  describe "min_of?" do
-    it "returns nil if empty" do
+  describe("min_of?") do
+    it("returns nil if empty") do
       ([] of Int32).min_of? { |x| -x }.should be_nil
     end
   end
 
-  describe "minmax" do
+  describe("minmax") do
     it { [1, 2, 3].minmax.should eq({1, 3}) }
 
-    it "raises if empty" do
-      expect_raises Enumerable::EmptyError do
+    it("raises if empty") do
+      expect_raises(Enumerable::EmptyError) do
         ([] of Int32).minmax
       end
     end
   end
 
-  describe "minmax?" do
-    it "returns two nils if empty" do
+  describe("minmax?") do
+    it("returns two nils if empty") do
       ([] of Int32).minmax?.should eq({nil, nil})
     end
   end
 
-  describe "minmax_by" do
+  describe("minmax_by") do
     it { [-1, -2, -3].minmax_by { |x| -x }.should eq({-1, -3}) }
   end
 
-  describe "minmax_by?" do
-    it "returns two nils if empty" do
+  describe("minmax_by?") do
+    it("returns two nils if empty") do
       ([] of Int32).minmax_by? { |x| -x }.should eq({nil, nil})
     end
   end
 
-  describe "minmax_of" do
+  describe("minmax_of") do
     it { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
   end
 
-  describe "minmax_of?" do
-    it "returns two nils if empty" do
+  describe("minmax_of?") do
+    it("returns two nils if empty") do
       ([] of Int32).minmax_of? { |x| -x }.should eq({nil, nil})
     end
   end
 
-  describe "none?" do
+  describe("none?") do
     it { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
     it { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
   end
 
-  describe "none? without block" do
+  describe("none? without block") do
     it { [nil, false].none?.should be_true }
     it { [nil, false, true].none?.should be_false }
   end
 
-  describe "one?" do
+  describe("one?") do
     it { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
     it { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
     it { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
   end
 
-  describe "partition" do
+  describe("partition") do
     it { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
     it { [1, 2, 3, 4, 5, 6].partition(&.even?).should eq({[2, 4, 6], [1, 3, 5]}) }
   end
 
-  describe "reject" do
-    it "rejects the values for which the block returns true" do
+  describe("reject") do
+    it("rejects the values for which the block returns true") do
       [1, 2, 3, 4].reject(&.even?).should eq([1, 3])
     end
   end
 
-  describe "select" do
-    it "selects the values for which the block returns true" do
+  describe("select") do
+    it("selects the values for which the block returns true") do
       [1, 2, 3, 4].select(&.even?).should eq([2, 4])
     end
   end
 
-  describe "skip" do
-    it "returns an array without the skipped elements" do
+  describe("skip") do
+    it("returns an array without the skipped elements") do
       [1, 2, 3, 4, 5, 6].skip(3).should eq [4, 5, 6]
     end
 
-    it "returns an empty array when skipping more elements than array size" do
+    it("returns an empty array when skipping more elements than array size") do
       [1, 2].skip(3).should eq [] of Int32
     end
 
-    it "raises if count is negative" do
+    it("raises if count is negative") do
       expect_raises(ArgumentError) do
         [1, 2].skip(-1)
       end
     end
   end
 
-  describe "skip_while" do
-    it "skips elements while the condition holds true" do
+  describe("skip_while") do
+    it("skips elements while the condition holds true") do
       result = [1, 2, 3, 4, 5, 0].skip_while { |i| i < 3 }
       result.should eq [3, 4, 5, 0]
     end
 
-    it "returns an empty array if the condition is always true" do
+    it("returns an empty array if the condition is always true") do
       [1, 2, 3].skip_while { true }.should eq [] of Int32
     end
 
-    it "returns the full Array if the the first check is false" do
+    it("returns the full Array if the the first check is false") do
       [5, 0, 1, 2, 3].skip_while { |x| x < 4 }.should eq [5, 0, 1, 2, 3]
     end
 
-    it "does not yield to the block anymore once it returned false" do
+    it("does not yield to the block anymore once it returned false") do
       called = 0
       [1, 2, 3, 4, 4].skip_while do |i|
         called += 1
@@ -792,7 +792,7 @@ describe "Enumerable" do
     end
   end
 
-  describe "sum" do
+  describe("sum") do
     it { ([] of Int32).sum.should eq(0) }
     it { [1, 2, 3].sum.should eq(6) }
     it { [1, 2, 3].sum(4).should eq(10) }
@@ -800,14 +800,14 @@ describe "Enumerable" do
     it { (1..3).sum { |x| x * 2 }.should eq(12) }
     it { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
 
-    it "uses zero from type" do
+    it("uses zero from type") do
       typeof([1, 2, 3].sum).should eq(Int32)
       typeof([1.5, 2.5, 3.5].sum).should eq(Float64)
       typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
     end
   end
 
-  describe "product" do
+  describe("product") do
     it { ([] of Int32).product.should eq(1) }
     it { [1, 2, 3].product.should eq(6) }
     it { [1, 2, 3].product(4).should eq(24) }
@@ -815,38 +815,38 @@ describe "Enumerable" do
     it { (1..3).product { |x| x * 2 }.should eq(48) }
     it { (1..3).product(1.5) { |x| x * 2 }.should eq(72) }
 
-    it "uses zero from type" do
+    it("uses zero from type") do
       typeof([1, 2, 3].product).should eq(Int32)
       typeof([1.5, 2.5, 3.5].product).should eq(Float64)
       typeof([1, 2, 3].product(&.to_f)).should eq(Float64)
     end
   end
 
-  describe "first" do
+  describe("first") do
     it { (1..3).first(1).should eq([1]) }
     it { (1..3).first(4).should eq([1, 2, 3]) }
 
-    it "raises if count is negative" do
+    it("raises if count is negative") do
       expect_raises(ArgumentError) do
         (1..2).first(-1)
       end
     end
   end
 
-  describe "take_while" do
-    it "keeps elements while the block returns true" do
+  describe("take_while") do
+    it("keeps elements while the block returns true") do
       [1, 2, 3, 4, 5, 0].take_while { |i| i < 3 }.should eq [1, 2]
     end
 
-    it "returns the full Array if the condition is always true" do
+    it("returns the full Array if the condition is always true") do
       [1, 2, 3, -3].take_while { true }.should eq [1, 2, 3, -3]
     end
 
-    it "returns an empty Array if the block is false for the first element" do
+    it("returns an empty Array if the block is false for the first element") do
       [1, 2, -1, 0].take_while { |i| i <= 0 }.should eq [] of Int32
     end
 
-    it "does not call the block again once it returned false" do
+    it("does not call the block again once it returned false") do
       called = 0
       [1, 2, 3, 4, 0].take_while do |i|
         called += 1
@@ -856,20 +856,20 @@ describe "Enumerable" do
     end
   end
 
-  describe "to_a" do
-    it "converts to an Array" do
+  describe("to_a") do
+    it("converts to an Array") do
       (1..3).to_a.should eq [1, 2, 3]
     end
   end
 
-  describe "to_h" do
-    it "for tuples" do
+  describe("to_h") do
+    it("for tuples") do
       hash = Tuple.new({:a, 1}, {:c, 2}).to_h
       hash.should be_a(Hash(Symbol, Int32))
       hash.should eq({:a => 1, :c => 2})
     end
 
-    it "for array" do
+    it("for array") do
       [[:a, :b], [:c, :d]].to_h.should eq({:a => :b, :c => :d})
     end
   end

--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -1,76 +1,76 @@
 require "spec"
 
-describe "ENV" do
-  it "gets non existent key raises" do
-    expect_raises KeyError, "Missing ENV key: \"NON-EXISTENT\"" do
+describe("ENV") do
+  it("gets non existent key raises") do
+    expect_raises(KeyError, "Missing ENV key: \"NON-EXISTENT\"") do
       ENV["NON-EXISTENT"]
     end
   end
 
-  it "gets non existent key as nilable" do
+  it("gets non existent key as nilable") do
     ENV["NON-EXISTENT"]?.should be_nil
   end
 
-  it "set and gets" do
+  it("set and gets") do
     (ENV["FOO"] = "1").should eq("1")
     ENV["FOO"].should eq("1")
     ENV["FOO"]?.should eq("1")
   end
 
-  it "sets to nil (same as delete)" do
+  it("sets to nil (same as delete)") do
     ENV["FOO"] = "1"
     ENV["FOO"]?.should_not be_nil
     ENV["FOO"] = nil
     ENV["FOO"]?.should be_nil
   end
 
-  it "does has_key?" do
+  it("does has_key?") do
     ENV["FOO"] = "1"
     ENV.has_key?("BAR").should be_false
     ENV.has_key?("FOO").should be_true
   end
 
-  it "deletes a key" do
+  it("deletes a key") do
     ENV["FOO"] = "1"
     ENV.delete("FOO").should eq("1")
     ENV.delete("FOO").should be_nil
     ENV.has_key?("FOO").should be_false
   end
 
-  it "does .keys" do
+  it("does .keys") do
     %w(FOO BAR).each { |k| ENV.keys.should_not contain(k) }
     ENV["FOO"] = ENV["BAR"] = "1"
     %w(FOO BAR).each { |k| ENV.keys.should contain(k) }
   end
 
-  it "does .values" do
+  it("does .values") do
     [1, 2].each { |i| ENV.values.should_not contain("SOMEVALUE_#{i}") }
     ENV["FOO"] = "SOMEVALUE_1"
     ENV["BAR"] = "SOMEVALUE_2"
     [1, 2].each { |i| ENV.values.should contain("SOMEVALUE_#{i}") }
   end
 
-  describe "fetch" do
-    it "fetches with one argument" do
+  describe("fetch") do
+    it("fetches with one argument") do
       ENV["1"] = "2"
       ENV.fetch("1").should eq("2")
     end
 
-    it "fetches with default value" do
+    it("fetches with default value") do
       ENV["1"] = "2"
       ENV.fetch("1", "3").should eq("2")
       ENV.fetch("2", "3").should eq("3")
     end
 
-    it "fetches with block" do
+    it("fetches with block") do
       ENV["1"] = "2"
       ENV.fetch("1") { |k| k + "block" }.should eq("2")
       ENV.fetch("2") { |k| k + "block" }.should eq("2block")
     end
 
-    it "fetches and raises" do
+    it("fetches and raises") do
       ENV["1"] = "2"
-      expect_raises KeyError, "Missing ENV key: \"2\"" do
+      expect_raises(KeyError, "Missing ENV key: \"2\"") do
         ENV.fetch("2")
       end
     end

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -6,15 +6,15 @@ private class FooError < Exception
   end
 end
 
-describe "Exception" do
-  it "allows subclassing #message" do
+describe("Exception") do
+  it("allows subclassing #message") do
     ex = FooError.new("foo?")
     ex.message.should eq("foo? -- bar!")
     ex.to_s.should eq("foo? -- bar!")
     ex.inspect_with_backtrace.should contain("foo? -- bar!")
   end
 
-  it "inspects" do
+  it("inspects") do
     ex = FooError.new("foo?")
     ex.inspect.should eq("#<FooError:foo? -- bar!>")
   end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -21,21 +21,21 @@ private def home
 end
 
 private def it_raises_on_null_byte(operation, &block)
-  it "errors on #{operation}" do
+  it("errors on #{operation}") do
     expect_raises(ArgumentError, "String contains null byte") do
       block.call
     end
   end
 end
 
-describe "File" do
-  it "gets path" do
+describe("File") do
+  it("gets path") do
     path = "#{__DIR__}/data/test_file.txt"
     file = File.new path
     file.path.should eq(path)
   end
 
-  it "reads entire file" do
+  it("reads entire file") do
     str = File.read "#{__DIR__}/data/test_file.txt"
     str.should eq("Hello World\n" * 20)
   end
@@ -49,19 +49,19 @@ describe "File" do
     end
   {% end %}
 
-  it "reads lines from file" do
+  it("reads lines from file") do
     lines = File.read_lines "#{__DIR__}/data/test_file.txt"
     lines.size.should eq(20)
     lines.first.should eq("Hello World")
   end
 
-  it "reads lines from file with chomp = false" do
+  it("reads lines from file with chomp = false") do
     lines = File.read_lines "#{__DIR__}/data/test_file.txt", chomp: false
     lines.size.should eq(20)
     lines.first.should eq("Hello World\n")
   end
 
-  it "reads lines from file with each" do
+  it("reads lines from file with each") do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt") do |line|
       if idx == 0
@@ -72,7 +72,7 @@ describe "File" do
     idx.should eq(20)
   end
 
-  it "reads lines from file with each, chomp = false" do
+  it("reads lines from file with each, chomp = false") do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt", chomp: false) do |line|
       if idx == 0
@@ -83,7 +83,7 @@ describe "File" do
     idx.should eq(20)
   end
 
-  it "reads lines from file with each as iterator" do
+  it("reads lines from file with each as iterator") do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt").each do |line|
       if idx == 0
@@ -94,7 +94,7 @@ describe "File" do
     idx.should eq(20)
   end
 
-  it "reads lines from file with each as iterator, chomp = false" do
+  it("reads lines from file with each as iterator, chomp = false") do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt", chomp: false).each do |line|
       if idx == 0
@@ -105,73 +105,73 @@ describe "File" do
     idx.should eq(20)
   end
 
-  describe "empty?" do
-    it "gives true when file is empty" do
+  describe("empty?") do
+    it("gives true when file is empty") do
       File.empty?("#{__DIR__}/data/blank_test_file.txt").should be_true
     end
 
-    it "gives false when file is not empty" do
+    it("gives false when file is not empty") do
       File.empty?("#{__DIR__}/data/test_file.txt").should be_false
     end
 
-    it "raises an error when the file does not exist" do
+    it("raises an error when the file does not exist") do
       filename = "#{__DIR__}/data/non_existing_file.txt"
-      expect_raises Errno do
+      expect_raises(Errno) do
         File.empty?(filename)
       end
     end
   end
 
-  describe "exists?" do
-    it "gives true" do
+  describe("exists?") do
+    it("gives true") do
       File.exists?("#{__DIR__}/data/test_file.txt").should be_true
     end
 
-    it "gives false" do
+    it("gives false") do
       File.exists?("#{__DIR__}/data/non_existing_file.txt").should be_false
     end
   end
 
-  describe "executable?" do
-    it "gives false" do
+  describe("executable?") do
+    it("gives false") do
       File.executable?("#{__DIR__}/data/test_file.txt").should be_false
     end
   end
 
-  describe "readable?" do
-    it "gives true" do
+  describe("readable?") do
+    it("gives true") do
       File.readable?("#{__DIR__}/data/test_file.txt").should be_true
     end
   end
 
-  describe "writable?" do
-    it "gives true" do
+  describe("writable?") do
+    it("gives true") do
       File.writable?("#{__DIR__}/data/test_file.txt").should be_true
     end
   end
 
-  describe "file?" do
-    it "gives true" do
+  describe("file?") do
+    it("gives true") do
       File.file?("#{__DIR__}/data/test_file.txt").should be_true
     end
 
-    it "gives false" do
+    it("gives false") do
       File.file?("#{__DIR__}/data").should be_false
     end
   end
 
-  describe "directory?" do
-    it "gives true" do
+  describe("directory?") do
+    it("gives true") do
       File.directory?("#{__DIR__}/data").should be_true
     end
 
-    it "gives false" do
+    it("gives false") do
       File.directory?("#{__DIR__}/data/test_file.txt").should be_false
     end
   end
 
-  describe "link" do
-    it "creates a hard link" do
+  describe("link") do
+    it("creates a hard link") do
       out_path = "#{__DIR__}/data/test_file_link.txt"
       begin
         File.link("#{__DIR__}/data/test_file.txt", out_path)
@@ -183,8 +183,8 @@ describe "File" do
     end
   end
 
-  describe "symlink" do
-    it "creates a symbolic link" do
+  describe("symlink") do
+    it("creates a symbolic link") do
       out_path = "#{__DIR__}/data/test_file_symlink.txt"
       begin
         File.symlink("#{__DIR__}/data/test_file.txt", out_path)
@@ -195,24 +195,24 @@ describe "File" do
     end
   end
 
-  describe "symlink?" do
-    it "gives true" do
+  describe("symlink?") do
+    it("gives true") do
       File.symlink?("#{__DIR__}/data/symlink.txt").should be_true
     end
 
-    it "gives false" do
+    it("gives false") do
       File.symlink?("#{__DIR__}/data/test_file.txt").should be_false
       File.symlink?("#{__DIR__}/data/unknown_file.txt").should be_false
     end
   end
 
-  it "gets dirname" do
+  it("gets dirname") do
     File.dirname("/Users/foo/bar.cr").should eq("/Users/foo")
     File.dirname("foo").should eq(".")
     File.dirname("").should eq(".")
   end
 
-  it "gets basename" do
+  it("gets basename") do
     File.basename("/foo/bar/baz.cr").should eq("baz.cr")
     File.basename("/foo/").should eq("foo")
     File.basename("foo").should eq("foo")
@@ -220,11 +220,11 @@ describe "File" do
     File.basename("/").should eq("/")
   end
 
-  it "gets basename removing suffix" do
+  it("gets basename removing suffix") do
     File.basename("/foo/bar/baz.cr", ".cr").should eq("baz")
   end
 
-  it "gets extname" do
+  it("gets extname") do
     File.extname("/foo/bar/baz.cr").should eq(".cr")
     File.extname("/foo/bar/baz.cr.cz").should eq(".cz")
     File.extname("/foo/bar/.profile").should eq("")
@@ -233,7 +233,7 @@ describe "File" do
     File.extname("test").should eq("")
   end
 
-  it "constructs a path from parts" do
+  it("constructs a path from parts") do
     File.join(["///foo", "bar"]).should eq("///foo/bar")
     File.join(["///foo", "//bar"]).should eq("///foo//bar")
     File.join(["/foo/", "/bar"]).should eq("/foo/bar")
@@ -242,14 +242,14 @@ describe "File" do
     File.join(["/foo/", "/bar/", "/baz/"]).should eq("/foo/bar/baz/")
   end
 
-  it "chown" do
+  it("chown") do
     # changing owners requires special privileges, so we test that method calls do compile
     typeof(File.chown("/tmp/test"))
     typeof(File.chown("/tmp/test", uid: 1001, gid: 100, follow_symlinks: true))
   end
 
-  describe "chmod" do
-    it "changes file permissions" do
+  describe("chmod") do
+    it("changes file permissions") do
       path = "#{__DIR__}/data/chmod.txt"
       begin
         File.write(path, "")
@@ -260,7 +260,7 @@ describe "File" do
       end
     end
 
-    it "changes dir permissions" do
+    it("changes dir permissions") do
       path = "#{__DIR__}/data/chmod"
       begin
         Dir.mkdir(path, 0o775)
@@ -271,7 +271,7 @@ describe "File" do
       end
     end
 
-    it "follows symlinks" do
+    it("follows symlinks") do
       path = "#{__DIR__}/data/chmod_destination.txt"
       link = "#{__DIR__}/data/chmod.txt"
       begin
@@ -285,14 +285,14 @@ describe "File" do
       end
     end
 
-    it "raises when destination doesn't exist" do
+    it("raises when destination doesn't exist") do
       expect_raises(Errno) do
         File.chmod("#{__DIR__}/data/unknown_chmod_path.txt", 0o664)
       end
     end
   end
 
-  it "gets stat for this file" do
+  it("gets stat for this file") do
     stat = File.stat(__FILE__)
     stat.blockdev?.should be_false
     stat.chardev?.should be_false
@@ -302,7 +302,7 @@ describe "File" do
     stat.socket?.should be_false
   end
 
-  it "gets stat for this directory" do
+  it("gets stat for this directory") do
     stat = File.stat(__DIR__)
     stat.blockdev?.should be_false
     stat.chardev?.should be_false
@@ -312,7 +312,7 @@ describe "File" do
     stat.socket?.should be_false
   end
 
-  it "gets stat for a character device" do
+  it("gets stat for a character device") do
     stat = File.stat("/dev/null")
     stat.blockdev?.should be_false
     stat.chardev?.should be_true
@@ -322,7 +322,7 @@ describe "File" do
     stat.socket?.should be_false
   end
 
-  it "gets stat for a symlink" do
+  it("gets stat for a symlink") do
     stat = File.lstat("#{__DIR__}/data/symlink.txt")
     stat.blockdev?.should be_false
     stat.chardev?.should be_false
@@ -332,7 +332,7 @@ describe "File" do
     stat.socket?.should be_false
   end
 
-  it "gets stat for open file" do
+  it("gets stat for open file") do
     File.open(__FILE__, "r") do |file|
       stat = file.stat
       stat.blockdev?.should be_false
@@ -345,20 +345,20 @@ describe "File" do
     end
   end
 
-  it "gets stat for pipe" do
+  it("gets stat for pipe") do
     IO.pipe do |r, w|
       r.stat.pipe?.should be_true
       w.stat.pipe?.should be_true
     end
   end
 
-  it "gets stat for non-existent file and raises" do
-    expect_raises Errno do
+  it("gets stat for non-existent file and raises") do
+    expect_raises(Errno) do
       File.stat("non-existent")
     end
   end
 
-  it "gets stat mtime for new file" do
+  it("gets stat mtime for new file") do
     tmp = Tempfile.new "tmp"
     begin
       (tmp.stat.atime - Time.utc_now).total_seconds.should be < 5
@@ -369,7 +369,7 @@ describe "File" do
     end
   end
 
-  describe "size" do
+  describe("size") do
     it { File.size("#{__DIR__}/data/test_file.txt").should eq(240) }
     it do
       File.open("#{__DIR__}/data/test_file.txt", "r") do |file|
@@ -378,8 +378,8 @@ describe "File" do
     end
   end
 
-  describe "delete" do
-    it "deletes a file" do
+  describe("delete") do
+    it("deletes a file") do
       filename = "#{__DIR__}/data/temp1.txt"
       File.open(filename, "w") { }
       File.exists?(filename).should be_true
@@ -387,16 +387,16 @@ describe "File" do
       File.exists?(filename).should be_false
     end
 
-    it "raises errno when file doesn't exist" do
+    it("raises errno when file doesn't exist") do
       filename = "#{__DIR__}/data/temp1.txt"
-      expect_raises Errno do
+      expect_raises(Errno) do
         File.delete(filename)
       end
     end
   end
 
-  describe "rename" do
-    it "renames a file" do
+  describe("rename") do
+    it("renames a file") do
       filename = "#{__DIR__}/data/temp1.txt"
       filename2 = "#{__DIR__}/data/temp2.txt"
       File.open(filename, "w") { |f| f.puts "hello" }
@@ -407,53 +407,53 @@ describe "File" do
       File.delete(filename2)
     end
 
-    it "raises if old file doesn't exist" do
+    it("raises if old file doesn't exist") do
       filename = "#{__DIR__}/data/temp1.txt"
-      expect_raises Errno do
+      expect_raises(Errno) do
         File.rename(filename, "#{filename}.new")
       end
     end
   end
 
-  describe "expand_path" do
-    it "converts a pathname to an absolute pathname" do
+  describe("expand_path") do
+    it("converts a pathname to an absolute pathname") do
       File.expand_path("").should eq(base)
       File.expand_path("a").should eq(File.join([base, "a"]))
       File.expand_path("a", nil).should eq(File.join([base, "a"]))
     end
 
-    it "converts a pathname to an absolute pathname, Ruby-Talk:18512" do
+    it("converts a pathname to an absolute pathname, Ruby-Talk:18512") do
       File.expand_path(".a").should eq(File.join([base, ".a"]))
       File.expand_path("..a").should eq(File.join([base, "..a"]))
       File.expand_path("a../b").should eq(File.join([base, "a../b"]))
     end
 
-    it "keeps trailing dots on absolute pathname" do
+    it("keeps trailing dots on absolute pathname") do
       File.expand_path("a.").should eq(File.join([base, "a."]))
       File.expand_path("a..").should eq(File.join([base, "a.."]))
     end
 
-    it "converts a pathname to an absolute pathname, using a complete path" do
+    it("converts a pathname to an absolute pathname, using a complete path") do
       File.expand_path("", "#{tmpdir}").should eq("#{tmpdir}")
       File.expand_path("a", "#{tmpdir}").should eq("#{tmpdir}/a")
       File.expand_path("../a", "#{tmpdir}/xxx").should eq("#{tmpdir}/a")
       File.expand_path(".", "#{rootdir}").should eq("#{rootdir}")
     end
 
-    it "expands a path with multi-byte characters" do
+    it("expands a path with multi-byte characters") do
       File.expand_path("Ångström").should eq("#{base}/Ångström")
     end
 
-    it "expands /./dir to /dir" do
+    it("expands /./dir to /dir") do
       File.expand_path("/./dir").should eq("/dir")
     end
 
-    it "replaces multiple / with a single /" do
+    it("replaces multiple / with a single /") do
       File.expand_path("////some/path").should eq("/some/path")
       File.expand_path("/some////path").should eq("/some/path")
     end
 
-    it "expand path with" do
+    it("expand path with") do
       File.expand_path("../../bin", "/tmp/x").should eq("/bin")
       File.expand_path("../../bin", "/tmp").should eq("/bin")
       File.expand_path("../../bin", "/").should eq("/bin")
@@ -461,7 +461,7 @@ describe "File" do
       File.expand_path("../bin", "x/../tmp").should eq(File.join([base, "bin"]))
     end
 
-    it "expand_path for commoms unix path  give a full path" do
+    it("expand_path for commoms unix path  give a full path") do
       File.expand_path("/tmp/").should eq("/tmp")
       File.expand_path("/tmp/../../../tmp").should eq("/tmp")
       File.expand_path("").should eq(base)
@@ -470,7 +470,7 @@ describe "File" do
       File.expand_path(base).should eq(base)
     end
 
-    it "converts a pathname to an absolute pathname, using ~ (home) as base" do
+    it("converts a pathname to an absolute pathname, using ~ (home) as base") do
       File.expand_path("~/").should eq(home)
       File.expand_path("~/..badfilename").should eq(File.join(home, "..badfilename"))
       File.expand_path("..").should eq("/#{base.split("/")[0...-1].join("/")}".gsub(%r{\A//}, "/"))
@@ -480,7 +480,7 @@ describe "File" do
       File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))
     end
 
-    it "converts a pathname to an absolute pathname, using ~ (home) as base (trailing /)" do
+    it("converts a pathname to an absolute pathname, using ~ (home) as base (trailing /)") do
       prev_home = home
       begin
         ENV["HOME"] = __DIR__ + "/"
@@ -496,7 +496,7 @@ describe "File" do
       end
     end
 
-    it "converts a pathname to an absolute pathname, using ~ (home) as base (HOME=/)" do
+    it("converts a pathname to an absolute pathname, using ~ (home) as base (HOME=/)") do
       prev_home = home
       begin
         ENV["HOME"] = "/"
@@ -513,19 +513,19 @@ describe "File" do
     end
   end
 
-  describe "real_path" do
-    it "expands paths for normal files" do
+  describe("real_path") do
+    it("expands paths for normal files") do
       File.real_path("/usr/share").should eq("/usr/share")
       File.real_path("/usr/share/..").should eq("/usr")
     end
 
-    it "raises Errno if file doesn't exist" do
-      expect_raises Errno do
+    it("raises Errno if file doesn't exist") do
+      expect_raises(Errno) do
         File.real_path("/usr/share/foo/bar")
       end
     end
 
-    it "expands paths of symlinks" do
+    it("expands paths of symlinks") do
       symlink_path = "/tmp/test_file_symlink.txt"
       file_path = "#{__DIR__}/data/test_file.txt"
       begin
@@ -539,22 +539,22 @@ describe "File" do
     end
   end
 
-  describe "write" do
-    it "can write to a file" do
+  describe("write") do
+    it("can write to a file") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello")
       File.read(filename).should eq("hello")
       File.delete(filename)
     end
 
-    it "writes bytes" do
+    it("writes bytes") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello".to_slice)
       File.read(filename).should eq("hello")
       File.delete(filename)
     end
 
-    it "writes io" do
+    it("writes io") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.open("#{__DIR__}/data/test_file.txt") do |file|
         File.write(filename, file)
@@ -563,7 +563,7 @@ describe "File" do
       File.delete(filename)
     end
 
-    it "raises if trying to write to a file not opened for writing" do
+    it("raises if trying to write to a file not opened for writing") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello")
       expect_raises(IO::Error, "File not open for writing") do
@@ -573,31 +573,31 @@ describe "File" do
     end
   end
 
-  it "does to_s" do
+  it("does to_s") do
     file = File.new(__FILE__)
     file.to_s.should eq("#<File:0x#{file.object_id.to_s(16)}>")
     File.new(__FILE__).inspect.should eq("#<File:#{__FILE__}>")
   end
 
-  describe "close" do
-    it "is not closed when opening" do
+  describe("close") do
+    it("is not closed when opening") do
       file = File.new(__FILE__)
       file.closed?.should be_false
     end
 
-    it "is closed when closed" do
+    it("is closed when closed") do
       file = File.new(__FILE__)
       file.close
       file.closed?.should be_true
     end
 
-    it "should not raise when closing twice" do
+    it("should not raise when closing twice") do
       file = File.new(__FILE__)
       file.close
       file.close
     end
 
-    it "does to_s when closed" do
+    it("does to_s when closed") do
       file = File.new(__FILE__)
       file.close
       file.to_s.should eq("#<File:0x#{file.object_id.to_s(16)}>")
@@ -605,7 +605,7 @@ describe "File" do
     end
   end
 
-  it "opens with perm" do
+  it("opens with perm") do
     filename = "#{__DIR__}/data/temp_write.txt"
     perm = 0o600
     File.open(filename, "w", perm) do |file|
@@ -614,27 +614,27 @@ describe "File" do
     File.delete filename
   end
 
-  it "clears the read buffer after a seek" do
+  it("clears the read buffer after a seek") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.gets(5).should eq("Hello")
     file.seek(1)
     file.gets(4).should eq("ello")
   end
 
-  it "seeks from the current position" do
+  it("seeks from the current position") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.gets(5)
     file.seek(-4, IO::Seek::Current)
     file.tell.should eq(1)
   end
 
-  it "raises if invoking seek with a closed file" do
+  it("raises if invoking seek with a closed file") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.close
     expect_raises(IO::Error, "Closed stream") { file.seek(1) }
   end
 
-  it "returns the current read position with tell" do
+  it("returns the current read position with tell") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.tell.should eq(0)
     file.gets(5).should eq("Hello")
@@ -643,7 +643,7 @@ describe "File" do
     file.tell.should eq(5)
   end
 
-  it "can navigate with pos" do
+  it("can navigate with pos") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.pos = 3
     file.gets(2).should eq("lo")
@@ -651,13 +651,13 @@ describe "File" do
     file.gets(4).should eq("ello")
   end
 
-  it "raises if invoking tell with a closed file" do
+  it("raises if invoking tell with a closed file") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     file.close
     expect_raises(IO::Error, "Closed stream") { file.tell }
   end
 
-  it "iterates with each_char" do
+  it("iterates with each_char") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     i = 0
     file.each_char do |char|
@@ -671,7 +671,7 @@ describe "File" do
     end
   end
 
-  it "iterates with each_byte" do
+  it("iterates with each_byte") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     i = 0
     file.each_byte do |byte|
@@ -685,7 +685,7 @@ describe "File" do
     end
   end
 
-  it "rewinds" do
+  it("rewinds") do
     file = File.new("#{__DIR__}/data/test_file.txt")
     content = file.gets_to_end
     content.size.should_not eq(0)
@@ -693,8 +693,8 @@ describe "File" do
     file.gets_to_end.should eq(content)
   end
 
-  describe "truncate" do
-    it "truncates" do
+  describe("truncate") do
+    it("truncates") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "0123456789")
       File.open(filename, "r+") do |f|
@@ -708,7 +708,7 @@ describe "File" do
       File.delete filename
     end
 
-    it "truncates completely when no size is passed" do
+    it("truncates completely when no size is passed") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "0123456789")
       File.open(filename, "r+") do |f|
@@ -720,7 +720,7 @@ describe "File" do
       File.delete filename
     end
 
-    it "requires a file opened for writing" do
+    it("requires a file opened for writing") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "0123456789")
       File.open(filename, "r") do |f|
@@ -732,8 +732,8 @@ describe "File" do
     end
   end
 
-  describe "flock" do
-    it "exlusively locks a file" do
+  describe("flock") do
+    it("exlusively locks a file") do
       File.open(__FILE__) do |file1|
         File.open(__FILE__) do |file2|
           file1.flock_exclusive do
@@ -746,7 +746,7 @@ describe "File" do
       end
     end
 
-    it "shared locks a file" do
+    it("shared locks a file") do
       File.open(__FILE__) do |file1|
         File.open(__FILE__) do |file2|
           file1.flock_shared do
@@ -757,7 +757,7 @@ describe "File" do
     end
   end
 
-  it "reads at offset" do
+  it("reads at offset") do
     filename = "#{__DIR__}/data/test_file.txt"
     file = File.open(filename)
     file.read_at(6, 100) do |io|
@@ -768,7 +768,7 @@ describe "File" do
     end
   end
 
-  it "raises when reading at offset outside of bounds" do
+  it("raises when reading at offset outside of bounds") do
     filename = "#{__DIR__}/data/temp_write.txt"
     File.write(filename, "hello world")
 
@@ -791,128 +791,128 @@ describe "File" do
     end
   end
 
-  describe "raises on null byte" do
-    it_raises_on_null_byte "new" do
+  describe("raises on null byte") do
+    it_raises_on_null_byte("new") do
       File.new("foo\0bar")
     end
 
-    it_raises_on_null_byte "join" do
+    it_raises_on_null_byte("join") do
       File.join("foo", "\0bar")
     end
 
-    it_raises_on_null_byte "size" do
+    it_raises_on_null_byte("size") do
       File.size("foo\0bar")
     end
 
-    it_raises_on_null_byte "rename (first arg)" do
+    it_raises_on_null_byte("rename (first arg)") do
       File.rename("foo\0bar", "baz")
     end
 
-    it_raises_on_null_byte "rename (second arg)" do
+    it_raises_on_null_byte("rename (second arg)") do
       File.rename("baz", "foo\0bar")
     end
 
-    it_raises_on_null_byte "stat" do
+    it_raises_on_null_byte("stat") do
       File.stat("foo\0bar")
     end
 
-    it_raises_on_null_byte "lstat" do
+    it_raises_on_null_byte("lstat") do
       File.lstat("foo\0bar")
     end
 
-    it_raises_on_null_byte "exists?" do
+    it_raises_on_null_byte("exists?") do
       File.exists?("foo\0bar")
     end
 
-    it_raises_on_null_byte "readable?" do
+    it_raises_on_null_byte("readable?") do
       File.readable?("foo\0bar")
     end
 
-    it_raises_on_null_byte "writable?" do
+    it_raises_on_null_byte("writable?") do
       File.writable?("foo\0bar")
     end
 
-    it_raises_on_null_byte "executable?" do
+    it_raises_on_null_byte("executable?") do
       File.executable?("foo\0bar")
     end
 
-    it_raises_on_null_byte "file?" do
+    it_raises_on_null_byte("file?") do
       File.file?("foo\0bar")
     end
 
-    it_raises_on_null_byte "directory?" do
+    it_raises_on_null_byte("directory?") do
       File.directory?("foo\0bar")
     end
 
-    it_raises_on_null_byte "dirname" do
+    it_raises_on_null_byte("dirname") do
       File.dirname("foo\0bar")
     end
 
-    it_raises_on_null_byte "basename" do
+    it_raises_on_null_byte("basename") do
       File.basename("foo\0bar")
     end
 
-    it_raises_on_null_byte "basename 2, first arg" do
+    it_raises_on_null_byte("basename 2, first arg") do
       File.basename("foo\0bar", "baz")
     end
 
-    it_raises_on_null_byte "basename 2, second arg" do
+    it_raises_on_null_byte("basename 2, second arg") do
       File.basename("foobar", "baz\0")
     end
 
-    it_raises_on_null_byte "delete" do
+    it_raises_on_null_byte("delete") do
       File.delete("foo\0bar")
     end
 
-    it_raises_on_null_byte "extname" do
+    it_raises_on_null_byte("extname") do
       File.extname("foo\0bar")
     end
 
-    it_raises_on_null_byte "expand_path, first arg" do
+    it_raises_on_null_byte("expand_path, first arg") do
       File.expand_path("foo\0bar")
     end
 
-    it_raises_on_null_byte "expand_path, second arg" do
+    it_raises_on_null_byte("expand_path, second arg") do
       File.expand_path("baz", "foo\0bar")
     end
 
-    it_raises_on_null_byte "link, first arg" do
+    it_raises_on_null_byte("link, first arg") do
       File.link("foo\0bar", "baz")
     end
 
-    it_raises_on_null_byte "link, second arg" do
+    it_raises_on_null_byte("link, second arg") do
       File.link("baz", "foo\0bar")
     end
 
-    it_raises_on_null_byte "symlink, first arg" do
+    it_raises_on_null_byte("symlink, first arg") do
       File.symlink("foo\0bar", "baz")
     end
 
-    it_raises_on_null_byte "symlink, second arg" do
+    it_raises_on_null_byte("symlink, second arg") do
       File.symlink("baz", "foo\0bar")
     end
 
-    it_raises_on_null_byte "symlink?" do
+    it_raises_on_null_byte("symlink?") do
       File.symlink?("foo\0bar")
     end
   end
 
-  describe "encoding" do
-    it "writes with encoding" do
+  describe("encoding") do
+    it("writes with encoding") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello", encoding: "UCS-2LE")
       File.read(filename).to_slice.should eq("hello".encode("UCS-2LE"))
       File.delete(filename)
     end
 
-    it "reads with encoding" do
+    it("reads with encoding") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello", encoding: "UCS-2LE")
       File.read(filename, encoding: "UCS-2LE").should eq("hello")
       File.delete(filename)
     end
 
-    it "opens with encoding" do
+    it("opens with encoding") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello", encoding: "UCS-2LE")
       File.open(filename, encoding: "UCS-2LE") do |file|
@@ -921,7 +921,7 @@ describe "File" do
       File.delete filename
     end
 
-    it "does each line with encoding" do
+    it("does each line with encoding") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello", encoding: "UCS-2LE")
       File.each_line(filename, encoding: "UCS-2LE") do |line|
@@ -930,7 +930,7 @@ describe "File" do
       File.delete filename
     end
 
-    it "reads lines with encoding" do
+    it("reads lines with encoding") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "hello", encoding: "UCS-2LE")
       File.read_lines(filename, encoding: "UCS-2LE").should eq(["hello"])
@@ -938,8 +938,8 @@ describe "File" do
     end
   end
 
-  describe "closed stream" do
-    it "raises if writing on a closed stream" do
+  describe("closed stream") do
+    it("raises if writing on a closed stream") do
       io = File.open(__FILE__, "r")
       io.close
 
@@ -953,8 +953,8 @@ describe "File" do
     end
   end
 
-  describe "utime" do
-    it "sets times with utime" do
+  describe("utime") do
+    it("sets times with utime") do
       filename = "#{__DIR__}/data/temp_write.txt"
       File.write(filename, "")
 
@@ -970,18 +970,18 @@ describe "File" do
       File.delete filename
     end
 
-    it "raises if file not found" do
+    it("raises if file not found") do
       atime = Time.new(2000, 1, 2)
       mtime = Time.new(2000, 3, 4)
 
-      expect_raises Errno, "Error setting time to file" do
+      expect_raises(Errno, "Error setting time to file") do
         File.utime(atime, mtime, "#{__DIR__}/nonexistent_file")
       end
     end
   end
 
-  describe "touch" do
-    it "creates file if it doesn't exists" do
+  describe("touch") do
+    it("creates file if it doesn't exists") do
       filename = "#{__DIR__}/data/temp_touch.txt"
       begin
         File.exists?(filename).should be_false
@@ -992,7 +992,7 @@ describe "File" do
       end
     end
 
-    it "sets file times to given time" do
+    it("sets file times to given time") do
       filename = "#{__DIR__}/data/temp_touch.txt"
       time = Time.new(2000, 3, 4)
       begin
@@ -1006,7 +1006,7 @@ describe "File" do
       end
     end
 
-    it "sets file times to Time.now if no time argument given" do
+    it("sets file times to Time.now if no time argument given") do
       filename = "#{__DIR__}/data/temp_touch.txt"
       time = Time.now
       begin
@@ -1020,14 +1020,14 @@ describe "File" do
       end
     end
 
-    it "raises if path contains non-existent directory" do
-      expect_raises Errno, "Error opening file" do
+    it("raises if path contains non-existent directory") do
+      expect_raises(Errno, "Error opening file") do
         File.touch("/tmp/non/existent/directory/test.tmp")
       end
     end
 
-    it "raises if file cannot be accessed" do
-      expect_raises Errno, "Operation not permitted" do
+    it("raises if file cannot be accessed") do
+      expect_raises(Errno, "Operation not permitted") do
         File.touch("/bin/ls")
       end
     end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -24,9 +24,9 @@ private class OneByOneIO
   end
 end
 
-describe "FileUtils" do
-  describe "cd" do
-    it "should work" do
+describe("FileUtils") do
+  describe("cd") do
+    it("should work") do
       cwd = Dir.current
       FileUtils.cd("..")
       Dir.current.should_not eq(cwd)
@@ -34,13 +34,13 @@ describe "FileUtils" do
       Dir.current.should eq(cwd)
     end
 
-    it "raises" do
+    it("raises") do
       expect_raises do
         FileUtils.cd("/nope")
       end
     end
 
-    it "accepts a block" do
+    it("accepts a block") do
       cwd = Dir.current
 
       FileUtils.cd("..") do
@@ -51,54 +51,54 @@ describe "FileUtils" do
     end
   end
 
-  describe "pwd" do
-    it "returns the current working directory" do
+  describe("pwd") do
+    it("returns the current working directory") do
       FileUtils.pwd.should eq(Dir.current)
     end
   end
 
-  describe "cmp" do
-    it "compares two equal files" do
+  describe("cmp") do
+    it("compares two equal files") do
       FileUtils.cmp(
         File.join(__DIR__, "data/test_file.txt"),
         File.join(__DIR__, "data/test_file.txt")
       ).should be_true
     end
 
-    it "compares two different files" do
+    it("compares two different files") do
       FileUtils.cmp(
         File.join(__DIR__, "data/test_file.txt"),
         File.join(__DIR__, "data/test_file.ini")
       ).should be_false
     end
 
-    it "compares two ios, one way (true)" do
+    it("compares two ios, one way (true)") do
       io1 = OneByOneIO.new("hello")
       io2 = IO::Memory.new("hello")
       FileUtils.cmp(io1, io2).should be_true
     end
 
-    it "compares two ios, second way (true)" do
+    it("compares two ios, second way (true)") do
       io1 = OneByOneIO.new("hello")
       io2 = IO::Memory.new("hello")
       FileUtils.cmp(io2, io1).should be_true
     end
 
-    it "compares two ios, one way (false)" do
+    it("compares two ios, one way (false)") do
       io1 = OneByOneIO.new("hello")
       io2 = IO::Memory.new("hella")
       FileUtils.cmp(io1, io2).should be_false
     end
 
-    it "compares two ios, second way (false)" do
+    it("compares two ios, second way (false)") do
       io1 = OneByOneIO.new("hello")
       io2 = IO::Memory.new("hella")
       FileUtils.cmp(io2, io1).should be_false
     end
   end
 
-  describe "touch" do
-    it "creates file if it doesn't exists" do
+  describe("touch") do
+    it("creates file if it doesn't exists") do
       filename = File.join(__DIR__, "data/test_touch.txt")
       begin
         File.exists?(filename).should be_false
@@ -109,7 +109,7 @@ describe "FileUtils" do
       end
     end
 
-    it "creates multiple files if they doesn't exists" do
+    it("creates multiple files if they doesn't exists") do
       paths = [
         File.join(__DIR__, "data/test_touch_1.txt"),
         File.join(__DIR__, "data/test_touch_2.txt"),
@@ -125,8 +125,8 @@ describe "FileUtils" do
     end
   end
 
-  describe "cp" do
-    it "copies a file" do
+  describe("cp") do
+    it("copies a file") do
       src_path = File.join(__DIR__, "data/test_file.txt")
       out_path = File.join(__DIR__, "data/test_file_cp.txt")
       begin
@@ -138,13 +138,13 @@ describe "FileUtils" do
       end
     end
 
-    it "raises an error if the directory doesn't exists" do
+    it("raises an error if the directory doesn't exists") do
       expect_raises(ArgumentError, "No such directory : not_existing_dir") do
         FileUtils.cp({File.join(__DIR__, "data/test_file.text")}, "not_existing_dir")
       end
     end
 
-    it "copies multiple files" do
+    it("copies multiple files") do
       src_name1 = "test_file.txt"
       src_name2 = "test_file.ini"
       src_path = File.join(__DIR__, "data")
@@ -163,8 +163,8 @@ describe "FileUtils" do
     end
   end
 
-  describe "cp_r" do
-    it "copies a directory recursively" do
+  describe("cp_r") do
+    it("copies a directory recursively") do
       path = File.join(__DIR__, "data")
       src_path = File.join(path, "cp_r_test")
       dest_path = File.join(path, "cp_r_test_copied")
@@ -185,8 +185,8 @@ describe "FileUtils" do
     end
   end
 
-  describe "rm_r" do
-    it "deletes a directory recursively" do
+  describe("rm_r") do
+    it("deletes a directory recursively") do
       data_path = File.join(__DIR__, "data")
       path = File.join(data_path, "rm_r_test")
 
@@ -206,7 +206,7 @@ describe "FileUtils" do
       end
     end
 
-    it "doesn't follow symlinks" do
+    it("doesn't follow symlinks") do
       data_path = File.join(__DIR__, "data")
       removed_path = File.join(data_path, "rm_r_test_removed")
       linked_path = File.join(data_path, "rm_r_test_linked")
@@ -232,8 +232,8 @@ describe "FileUtils" do
     end
   end
 
-  describe "rm_rf" do
-    it "delete recursively a directory" do
+  describe("rm_rf") do
+    it("delete recursively a directory") do
       path = "/tmp/crystal_rm_rftest_#{Process.pid}/"
       FileUtils.mkdir(path)
       File.write(File.join(path, "a"), "")
@@ -242,7 +242,7 @@ describe "FileUtils" do
       Dir.exists?(path).should be_false
     end
 
-    it "delete recursively multiple directory" do
+    it("delete recursively multiple directory") do
       path1 = "/tmp/crystal_rm_rftest_#{Process.pid}/"
       path2 = "/tmp/crystal_rm_rftest_#{Process.pid + 1}/"
       FileUtils.mkdir(path1)
@@ -256,7 +256,7 @@ describe "FileUtils" do
       Dir.exists?(path2).should be_false
     end
 
-    it "doesn't return error on non existing file" do
+    it("doesn't return error on non existing file") do
       path1 = "/tmp/crystal_rm_rftest_#{Process.pid}/"
       path2 = File.join(path1, "a")
       FileUtils.mkdir(path1)
@@ -264,8 +264,8 @@ describe "FileUtils" do
     end
   end
 
-  describe "mv" do
-    it "moves a file from one place to another" do
+  describe("mv") do
+    it("moves a file from one place to another") do
       begin
         path1 = "/tmp/crystal_rm_rftest_#{Process.pid}/"
         path2 = "/tmp/crystal_rm_rftest_#{Process.pid + 1}/"
@@ -283,13 +283,13 @@ describe "FileUtils" do
       end
     end
 
-    it "raises an error if non correct arguments" do
-      expect_raises Errno do
+    it("raises an error if non correct arguments") do
+      expect_raises(Errno) do
         FileUtils.mv("/tmp/crystal_mv_test/a", "/tmp/crystal_mv_test/b")
       end
     end
 
-    it "moves multiple files to one place" do
+    it("moves multiple files to one place") do
       begin
         path1 = "/tmp/crystal_rm_rftest_#{Process.pid}/"
         path2 = "/tmp/crystal_rm_rftest_#{Process.pid + 1}/"
@@ -312,13 +312,13 @@ describe "FileUtils" do
       end
     end
 
-    it "raises an error if dest is non correct" do
-      expect_raises ArgumentError do
+    it("raises an error if dest is non correct") do
+      expect_raises(ArgumentError) do
         FileUtils.mv(["/tmp/crystal_mv_test/a", "/tmp/crystal_mv_test/b"], "/tmp/crystal_not_here")
       end
     end
 
-    it "moves all existing files to destination" do
+    it("moves all existing files to destination") do
       begin
         path1 = "/tmp/crystal_rm_rftest_#{Process.pid}/"
         path2 = "/tmp/crystal_rm_rftest_#{Process.pid + 1}/"
@@ -343,7 +343,7 @@ describe "FileUtils" do
     end
   end
 
-  it "tests mkdir and rmdir with a new path" do
+  it("tests mkdir and rmdir with a new path") do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
     FileUtils.mkdir(path, 0o700).should be_nil
     Dir.exists?(path).should be_true
@@ -351,7 +351,7 @@ describe "FileUtils" do
     Dir.exists?(path).should be_false
   end
 
-  it "tests mkdir and rmdir with multiple new paths" do
+  it("tests mkdir and rmdir with multiple new paths") do
     path1 = "/tmp/crystal_mkdir_test_#{Process.pid}/"
     path2 = "/tmp/crystal_mkdir_test_#{Process.pid + 1}/"
     FileUtils.mkdir([path1, path2], 0o700).should be_nil
@@ -362,22 +362,22 @@ describe "FileUtils" do
     Dir.exists?(path2).should be_false
   end
 
-  it "tests mkdir with an existing path" do
-    expect_raises Errno do
+  it("tests mkdir with an existing path") do
+    expect_raises(Errno) do
       Dir.mkdir(__DIR__, 0o700)
     end
   end
 
-  it "tests mkdir with multiples existing paths" do
-    expect_raises Errno do
+  it("tests mkdir with multiples existing paths") do
+    expect_raises(Errno) do
       FileUtils.mkdir([__DIR__, __DIR__], 0o700)
     end
-    expect_raises Errno do
+    expect_raises(Errno) do
       FileUtils.mkdir(["/tmp/crystal_mkdir_test_#{Process.pid}/", __DIR__], 0o700)
     end
   end
 
-  it "tests mkdir_p with a new path" do
+  it("tests mkdir_p with a new path") do
     path = "/tmp/crystal_mkdir_ptest_#{Process.pid}/"
     FileUtils.mkdir_p(path).should be_nil
     Dir.exists?(path).should be_true
@@ -386,7 +386,7 @@ describe "FileUtils" do
     Dir.exists?(path).should be_true
   end
 
-  it "tests mkdir_p with multiples new path" do
+  it("tests mkdir_p with multiples new path") do
     path1 = "/tmp/crystal_mkdir_ptest_#{Process.pid}/"
     path2 = "/tmp/crystal_mkdir_ptest_#{Process.pid + 1}"
     FileUtils.mkdir_p([path1, path2]).should be_nil
@@ -399,58 +399,58 @@ describe "FileUtils" do
     Dir.exists?(path2).should be_true
   end
 
-  it "tests mkdir_p with an existing path" do
+  it("tests mkdir_p with an existing path") do
     FileUtils.mkdir_p(__DIR__).should be_nil
-    expect_raises Errno do
+    expect_raises(Errno) do
       FileUtils.mkdir_p(__FILE__)
     end
   end
 
-  it "tests mkdir_p with multiple existing path" do
+  it("tests mkdir_p with multiple existing path") do
     FileUtils.mkdir_p([__DIR__, __DIR__]).should be_nil
-    expect_raises Errno do
+    expect_raises(Errno) do
       FileUtils.mkdir_p([__FILE__, "/tmp/crystal_mkdir_ptest_#{Process.pid}/"])
     end
   end
 
-  it "tests rmdir with an non existing path" do
-    expect_raises Errno do
+  it("tests rmdir with an non existing path") do
+    expect_raises(Errno) do
       FileUtils.rmdir("/tmp/crystal_mkdir_test_#{Process.pid}/tmp/")
     end
   end
 
-  it "tests rmdir with multiple non existing path" do
-    expect_raises Errno do
+  it("tests rmdir with multiple non existing path") do
+    expect_raises(Errno) do
       FileUtils.rmdir(["/tmp/crystal_mkdir_test_#{Process.pid}/tmp/", "/tmp/crystal_mkdir_test_#{Process.pid + 1}/tmp/"])
     end
   end
 
-  it "tests rmdir with a path that cannot be removed" do
-    expect_raises Errno do
+  it("tests rmdir with a path that cannot be removed") do
+    expect_raises(Errno) do
       FileUtils.rmdir(__DIR__)
     end
   end
 
-  it "tests rmdir with multiple path that cannot be removed" do
-    expect_raises Errno do
+  it("tests rmdir with multiple path that cannot be removed") do
+    expect_raises(Errno) do
       FileUtils.rmdir([__DIR__, __DIR__])
     end
   end
 
-  it "tests rm with an existing path" do
+  it("tests rm with an existing path") do
     path = "/tmp/crystal_rm_test_#{Process.pid}"
     File.write(path, "")
     FileUtils.rm(path).should be_nil
     File.exists?(path).should be_false
   end
 
-  it "tests rm with non existing path" do
-    expect_raises Errno do
+  it("tests rm with non existing path") do
+    expect_raises(Errno) do
       FileUtils.rm("/tmp/crystal_rm_test_#{Process.pid}")
     end
   end
 
-  it "tests rm with multiple existing paths" do
+  it("tests rm with multiple existing paths") do
     path1 = "/tmp/crystal_rm_test_#{Process.pid}"
     path2 = "/tmp/crystal_rm_test_#{Process.pid + 1}"
     File.write(path1, "")
@@ -460,8 +460,8 @@ describe "FileUtils" do
     File.exists?(path2).should be_false
   end
 
-  it "tests rm with some non existing paths" do
-    expect_raises Errno do
+  it("tests rm with some non existing paths") do
+    expect_raises(Errno) do
       path1 = "/tmp/crystal_rm_test_#{Process.pid}"
       path2 = "/tmp/crystal_rm_test_#{Process.pid + 1}"
       File.write(path1, "")

--- a/spec/std/flate/flate_spec.cr
+++ b/spec/std/flate/flate_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "flate"
 
 module Flate
-  describe Reader do
-    it "should read byte by byte (#4192)" do
+  describe(Reader) do
+    it("should read byte by byte (#4192)") do
       io = IO::Memory.new
       "cbc9cc4b350402ae1c20c30808b800".scan(/../).each do |match|
         io.write_byte match[0].to_u8(16)
@@ -21,8 +21,8 @@ module Flate
       str.should eq("line1111\nline2222\n")
     end
 
-    describe ".open" do
-      it "yields itself to block" do
+    describe(".open") do
+      it("yields itself to block") do
         # Hello Crystal!
         message = Bytes[243, 72, 205, 201, 201, 87, 112, 46, 170, 44, 46, 73,
           204, 81, 4, 0]
@@ -35,8 +35,8 @@ module Flate
     end
   end
 
-  describe Writer do
-    it "should be able to write" do
+  describe(Writer) do
+    it("should be able to write") do
       message = "this is a test string !!!!\n"
       io = IO::Memory.new
       writer = Writer.new(io)
@@ -48,19 +48,19 @@ module Flate
       reader.gets_to_end.should eq(message)
     end
 
-    it "can be closed without sync" do
+    it("can be closed without sync") do
       io = IO::Memory.new
       writer = Writer.new(io)
       writer.close
       writer.closed?.should be_true
       io.closed?.should be_false
 
-      expect_raises IO::Error, "Closed stream" do
+      expect_raises(IO::Error, "Closed stream") do
         writer.print "a"
       end
     end
 
-    it "can be closed with sync (1)" do
+    it("can be closed with sync (1)") do
       io = IO::Memory.new
       writer = Writer.new(io, sync_close: true)
       writer.close
@@ -68,7 +68,7 @@ module Flate
       io.closed?.should be_true
     end
 
-    it "can be closed with sync (2)" do
+    it("can be closed with sync (2)") do
       io = IO::Memory.new
       writer = Writer.new(io)
       writer.sync_close = true
@@ -77,8 +77,8 @@ module Flate
       io.closed?.should be_true
     end
 
-    describe ".open" do
-      it "yields itself to block" do
+    describe(".open") do
+      it("yields itself to block") do
         io = IO::Memory.new
         Writer.open(io) do |writer|
           writer.write "Hello Crystal!".to_slice

--- a/spec/std/float_printer/diy_fp_spec.cr
+++ b/spec/std/float_printer/diy_fp_spec.cr
@@ -30,8 +30,8 @@ require "spec"
 
 private alias DiyFP = Float::Printer::DiyFP
 
-describe DiyFP do
-  it "multiply" do
+describe(DiyFP) do
+  it("multiply") do
     fp1 = DiyFP.new(3_u64, 0)
     fp2 = DiyFP.new(2_u64, 0)
     prod = fp1 * fp2
@@ -40,7 +40,7 @@ describe DiyFP do
     prod.exp.should eq 64
   end
 
-  it "multiply" do
+  it("multiply") do
     fp1 = DiyFP.new(0x8000000000000000, 11)
     fp2 = DiyFP.new(2_u64, 13)
     prod = fp1 * fp2
@@ -49,7 +49,7 @@ describe DiyFP do
     prod.exp.should eq 11 + 13 + 64
   end
 
-  it "multiply rounding" do
+  it("multiply rounding") do
     fp1 = DiyFP.new(0x8000000000000001_u64, 11)
     fp2 = DiyFP.new(1_u64, 13)
     prod = fp1 * fp2
@@ -58,7 +58,7 @@ describe DiyFP do
     prod.exp.should eq 11 + 13 + 64
   end
 
-  it "multiply rounding" do
+  it("multiply rounding") do
     fp1 = DiyFP.new(0x7fffffffffffffff_u64, 11)
     fp2 = DiyFP.new(1_u64, 13)
     prod = fp1 * fp2
@@ -67,7 +67,7 @@ describe DiyFP do
     prod.exp.should eq 11 + 13 + 64
   end
 
-  it "multiply big numbers" do
+  it("multiply big numbers") do
     fp1 = DiyFP.new(0xffffffffffffffff_u64, 11)
     fp2 = DiyFP.new(0xffffffffffffffff_u64, 13)
     prod = fp1 * fp2
@@ -76,7 +76,7 @@ describe DiyFP do
     prod.exp.should eq 11 + 13 + 64
   end
 
-  it "converts ordered 64" do
+  it("converts ordered 64") do
     ordered = 0x0123456789ABCDEF_u64
     f = ordered.unsafe_as(Float64)
     f.should eq 3512700564088504e-318 # ensure byte order
@@ -88,7 +88,7 @@ describe DiyFP do
     fp.frac.should eq 0x0013456789ABCDEF
   end
 
-  it "converts ordered 32" do
+  it("converts ordered 32") do
     ordered = 0x01234567_u32
     f = ordered.unsafe_as(Float32)
     f.should eq(2.9988165487136453e-38_f32)
@@ -101,7 +101,7 @@ describe DiyFP do
     fp.frac.should eq 0xA34567
   end
 
-  it "converts min f64" do
+  it("converts min f64") do
     min = 0x0000000000000001_u64
     f = min.unsafe_as(Float64)
     f.should eq 5e-324 # ensure byte order
@@ -113,7 +113,7 @@ describe DiyFP do
     fp.frac.should eq 1
   end
 
-  it "converts min f32" do
+  it("converts min f32") do
     min = 0x00000001_u32
     f = min.unsafe_as(Float32)
     fp = DiyFP.from_f(f)
@@ -123,7 +123,7 @@ describe DiyFP do
     fp.frac.should eq 1
   end
 
-  it "converts max f64" do
+  it("converts max f64") do
     max = 0x7fefffffffffffff_u64
     f = max.unsafe_as(Float64)
     f.should eq 1.7976931348623157e308 # ensure byte order
@@ -134,7 +134,7 @@ describe DiyFP do
     fp.frac.should eq 0x001fffffffffffff_u64
   end
 
-  it "converts max f32" do
+  it("converts max f32") do
     max = 0x7f7fffff_u64
     f = max.unsafe_as(Float32)
     f.should eq 3.4028234e38_f32 # ensure byte order
@@ -145,7 +145,7 @@ describe DiyFP do
     fp.frac.should eq 0x00ffffff_u64
   end
 
-  it "normalizes ordered" do
+  it("normalizes ordered") do
     ordered = 0x0123456789ABCDEF_u64
     f = ordered.unsafe_as(Float64)
 
@@ -155,7 +155,7 @@ describe DiyFP do
     fp.frac.should eq 0x0013456789ABCDEF_u64 << 11
   end
 
-  it "normalizes min f64" do
+  it("normalizes min f64") do
     min = 0x0000000000000001_u64
     f = min.unsafe_as(Float64)
 
@@ -166,7 +166,7 @@ describe DiyFP do
     fp.frac.should eq 0x8000000000000000
   end
 
-  it "normalizes max f64" do
+  it("normalizes max f64") do
     max = 0x7fefffffffffffff_u64
     f = max.unsafe_as(Float64)
 

--- a/spec/std/float_printer/grisu3_spec.cr
+++ b/spec/std/float_printer/grisu3_spec.cr
@@ -43,51 +43,51 @@ private def test_grisu(v : Float64 | Float32)
   return status, point, String.new(buffer.to_unsafe)
 end
 
-describe "grisu3" do
-  context "float64" do
-    it "min float" do
+describe("grisu3") do
+  context("float64") do
+    it("min float") do
       status, point, str = test_grisu 5e-324
       status.should eq true
       str.should eq "5"
       point.should eq -323
     end
 
-    it "max float" do
+    it("max float") do
       status, point, str = test_grisu 1.7976931348623157e308
       status.should eq true
       str.should eq "17976931348623157"
       point.should eq 309
     end
 
-    it "point at end" do
+    it("point at end") do
       status, point, str = test_grisu 4294967272.0
       status.should eq true
       str.should eq "4294967272"
       point.should eq 10
     end
 
-    it "large number" do
+    it("large number") do
       status, point, str = test_grisu 4.1855804968213567e298
       status.should eq true
       str.should eq "4185580496821357"
       point.should eq 299
     end
 
-    it "small number" do
+    it("small number") do
       status, point, str = test_grisu 5.5626846462680035e-309
       status.should eq true
       str.should eq "5562684646268003"
       point.should eq -308
     end
 
-    it "another no point move" do
+    it("another no point move") do
       status, point, str = test_grisu 2147483648.0
       status.should eq true
       str.should eq "2147483648"
       point.should eq 10
     end
 
-    it "failure case" do
+    it("failure case") do
       # grisu should not be able to do this number
       # this number is reused to ensure the fallback works
       status, point, str = test_grisu 3.5844466002796428e+298
@@ -95,14 +95,14 @@ describe "grisu3" do
       str.should_not eq "35844466002796428"
     end
 
-    it "smallest normal" do
+    it("smallest normal") do
       status, point, str = test_grisu 0x0010000000000000_u64
       status.should eq true
       str.should eq "22250738585072014"
       point.should eq -307
     end
 
-    it "largest denormal" do
+    it("largest denormal") do
       status, point, str = test_grisu 0x000FFFFFFFFFFFFF_u64
       status.should eq true
       str.should eq "2225073858507201"
@@ -110,78 +110,78 @@ describe "grisu3" do
     end
   end
 
-  context "float32" do
-    it "min" do
+  context("float32") do
+    it("min") do
       status, point, str = test_grisu 1e-45_f32
       status.should eq true
       str.should eq "1"
       point.should eq -44
     end
 
-    it "max" do
+    it("max") do
       status, point, str = test_grisu 3.4028234e38_f32
       status.should eq true
       str.should eq "34028235"
       point.should eq 39
     end
 
-    it "general whole number, rounding" do
+    it("general whole number, rounding") do
       status, point, str = test_grisu 4294967272.0_f32
       status.should eq true
       str.should eq "42949673"
       point.should eq 10
     end
 
-    it "general whole number, rounding" do
+    it("general whole number, rounding") do
       status, point, str = test_grisu 4294967272.0_f32
       status.should eq true
       str.should eq "42949673"
       point.should eq 10
     end
 
-    it "large number, rounding" do
+    it("large number, rounding") do
       status, point, str = test_grisu 3.32306998946228968226e35_f32
       status.should eq true
       str.should eq "332307"
       point.should eq 36
     end
 
-    it "small number" do
+    it("small number") do
       status, point, str = test_grisu 1.2341e-41_f32
       status.should eq true
       str.should eq "12341"
       point.should eq -40
     end
 
-    it "general no rounding" do
+    it("general no rounding") do
       status, point, str = test_grisu 3.3554432e7_f32
       status.should eq true
       str.should eq "33554432"
       point.should eq 8
     end
 
-    it "general with rounding up" do
+    it("general with rounding up") do
       status, point, str = test_grisu 3.26494756798464e14_f32
       status.should eq true
       str.should eq "32649476"
       point.should eq 15
     end
 
-    it "general with rounding down" do
+    it("general with rounding down") do
       status, point, str = test_grisu 3.91132223637771935344e37_f32
       status.should eq true
       str.should eq "39113222"
       point.should eq 38
     end
 
-    it "smallest normal" do
+    it("smallest normal") do
       status, point, str = test_grisu 0x00800000_u32
       status.should eq true
       str.should eq "11754944"
       point.should eq -37
     end
 
-    it "largest denormal" do
+    it("largest denormal") do
       status, point, str = test_grisu 0x007FFFFF_u32
       status.should eq true
       str.should eq "11754942"

--- a/spec/std/float_printer/ieee_spec.cr
+++ b/spec/std/float_printer/ieee_spec.cr
@@ -47,8 +47,8 @@ private def gen_bound(v : Float64 | Float32)
   return fp.frac, b[:minus].frac, b[:plus].frac
 end
 
-describe "Float64 boundaires" do
-  it "boundaries 1.5" do
+describe("Float64 boundaires") do
+  it("boundaries 1.5") do
     fp, mi, pl = gen_bound(1.5)
     # 1.5 does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.
@@ -56,7 +56,7 @@ describe "Float64 boundaires" do
     (fp - mi).should eq(1 << 10)
   end
 
-  it "boundaries 1.0" do
+  it("boundaries 1.0") do
     fp, mi, pl = gen_bound(1.0)
     # 1.0 does have a significand of the form 2^p (for some p).
     # Therefore its lower boundary is twice as close as the upper boundary.
@@ -65,7 +65,7 @@ describe "Float64 boundaires" do
     (pl - fp).should eq 1 << 10
   end
 
-  it "boundaries min float64" do
+  it("boundaries min float64") do
     fp, mi, pl = gen_bound(0x0000000000000001_u64)
     # min-value does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.
@@ -73,7 +73,7 @@ describe "Float64 boundaires" do
     (fp - mi).should eq 1_u64 << 62
   end
 
-  it "boundaries min normal f64" do
+  it("boundaries min normal f64") do
     fp, mi, pl = gen_bound(0x0010000000000000_u64)
     # Even though the significand is of the form 2^p (for some p), its boundaries
     # are at the same distance. (This is the only exception).
@@ -81,14 +81,14 @@ describe "Float64 boundaires" do
     (fp - mi).should eq(1 << 10)
   end
 
-  it "boundaries max denormal f64" do
+  it("boundaries max denormal f64") do
     fp, mi, pl = gen_bound(0x000FFFFFFFFFFFFF_u64)
 
     (fp - mi).should eq(pl - fp)
     (fp - mi).should eq(1 << 11)
   end
 
-  it "boundaries max f64" do
+  it("boundaries max f64") do
     fp, mi, pl = gen_bound(0x7fEFFFFFFFFFFFFF_u64)
     # max-value does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.
@@ -97,8 +97,8 @@ describe "Float64 boundaires" do
   end
 end
 
-describe "Float32 boundaires" do
-  it "boundaries 1.5" do
+describe("Float32 boundaires") do
+  it("boundaries 1.5") do
     fp, mi, pl = gen_bound(1.5_f32)
     # 1.5 does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.
@@ -108,7 +108,7 @@ describe "Float32 boundaires" do
     (fp - mi).should eq(1_u64 << 39)
   end
 
-  it "boundaries 1.0" do
+  it("boundaries 1.0") do
     fp, mi, pl = gen_bound(1.0_f32)
     # 1.0 does have a significand of the form 2^p (for some p).
     # Therefore its lower boundary is twice as close as the upper boundary.
@@ -117,7 +117,7 @@ describe "Float32 boundaires" do
     (pl - fp).should eq(1_u64 << 39)
   end
 
-  it "min Float32" do
+  it("min Float32") do
     fp, mi, pl = gen_bound(0x00000001_u32)
     #  min-value does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.
@@ -126,7 +126,7 @@ describe "Float32 boundaires" do
     (fp - mi).should eq(1_u64 << 62)
   end
 
-  it "smallest normal 32" do
+  it("smallest normal 32") do
     fp, mi, pl = gen_bound(0x00800000_u32)
     # Even though the significand is of the form 2^p (for some p), its boundaries
     # are at the same distance. (This is the only exception).
@@ -134,13 +134,13 @@ describe "Float32 boundaires" do
     (fp - mi).should eq(1_u64 << 39)
   end
 
-  it "largest denormal 32" do
+  it("largest denormal 32") do
     fp, mi, pl = gen_bound(0x007FFFFF_u32)
     (pl - fp).should eq(fp - mi)
     (fp - mi).should eq(1_u64 << 40)
   end
 
-  it "max Float32" do
+  it("max Float32") do
     fp, mi, pl = gen_bound(0x7F7FFFFF_u32)
     # max-value does not have a significand of the form 2^p (for some p).
     # Therefore its boundaries are at the same distance.

--- a/spec/std/float_printer_spec.cr
+++ b/spec/std/float_printer_spec.cr
@@ -54,7 +54,7 @@ private def test_pair(v : Float64 | Float32, str, file = __FILE__, line = __LINE
   float_to_s(v).should eq(str), file, line
 end
 
-describe "#print Float64" do
+describe("#print Float64") do
   it { test_str "0.0" }
 
   it { test_str "Infinity" }
@@ -90,37 +90,37 @@ describe "#print Float64" do
   it { test_pair 1000000000000000.0, "1.0e+15" }
   it { test_pair 1111111111111111.0, "1.111111111111111e+15" }
 
-  it "min float64" do
+  it("min float64") do
     test_pair 5e-324, "5.0e-324"
   end
 
-  it "max float64" do
+  it("max float64") do
     test_pair 1.7976931348623157e308, "1.7976931348623157e+308"
   end
 
-  it "large number, rounded" do
+  it("large number, rounded") do
     test_pair 4.1855804968213567e298, "4.185580496821357e+298"
   end
 
-  it "small number, rounded" do
+  it("small number, rounded") do
     test_pair 5.5626846462680035e-309, "5.562684646268003e-309"
   end
 
-  it "falure case" do
+  it("falure case") do
     # grisu cannot do this number, so it should fall back to libc
     test_pair 3.5844466002796428e+298, "3.5844466002796428e+298"
   end
 
-  it "smallest normal" do
+  it("smallest normal") do
     test_pair 0x0010000000000000_u64, "2.2250738585072014e-308"
   end
 
-  it "largest denormal" do
+  it("largest denormal") do
     test_pair 0x000FFFFFFFFFFFFF_u64, "2.225073858507201e-308"
   end
 end
 
-describe "#print Float32" do
+describe("#print Float32") do
   it { test_pair 0_f32, "0.0" }
   it { test_pair -0_f32, "-0.0" }
   it { test_pair Float32::INFINITY, "Infinity" }
@@ -136,23 +136,23 @@ describe "#print Float32" do
   it { test_pair 1111111111111111.0_f32, "1.1111111e+15" }
   it { test_pair -3.9292015898194142585311918e-10_f32, "-3.9292017e-10" }
 
-  it "largest float" do
+  it("largest float") do
     test_pair 3.4028234e38_f32, "3.4028235e+38"
   end
 
-  it "largest normal" do
+  it("largest normal") do
     test_pair 0x7f7fffff_u32, "3.4028235e+38"
   end
 
-  it "smallest positive normal" do
+  it("smallest positive normal") do
     test_pair 0x00800000_u32, "1.1754944e-38"
   end
 
-  it "largest denormal" do
+  it("largest denormal") do
     test_pair 0x007fffff_u32, "1.1754942e-38"
   end
 
-  it "smallest positive denormal" do
+  it("smallest positive denormal") do
     test_pair 0x00000001_u32, "1.0e-45"
   end
 end

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "Float" do
-  describe "**" do
+describe("Float") do
+  describe("**") do
     it { (2.5_f32 ** 2_i32).should be_close(6.25_f32, 0.0001) }
     it { (2.5_f32 ** 2).should be_close(6.25_f32, 0.0001) }
     it { (2.5_f32 ** 2.5_f32).should be_close(9.882117688026186_f32, 0.0001) }
@@ -12,14 +12,14 @@ describe "Float" do
     it { (2.5_f64 ** 2.5).should be_close(9.882117688026186_f64, 0.001) }
   end
 
-  describe "%" do
-    it "uses modulo behavior, not remainder behavior" do
+  describe("%") do
+    it("uses modulo behavior, not remainder behavior") do
       it { ((-11.5) % 4.0).should eq(0.5) }
     end
   end
 
-  describe "modulo" do
-    it "raises when mods by zero" do
+  describe("modulo") do
+    it("raises when mods by zero") do
       expect_raises(DivisionByZero) { 1.2.modulo 0.0 }
     end
 
@@ -33,8 +33,8 @@ describe "Float" do
     it { (-11.5.modulo -4.0).should eq(-3.5) }
   end
 
-  describe "remainder" do
-    it "raises when mods by zero" do
+  describe("remainder") do
+    it("raises when mods by zero") do
       expect_raises(DivisionByZero) { 1.2.remainder 0.0 }
     end
 
@@ -47,23 +47,23 @@ describe "Float" do
     it { (-11.5.remainder 4.0).should eq(-3.5) }
     it { (-11.5.remainder -4.0).should eq(-3.5) }
 
-    it "preserves type" do
+    it("preserves type") do
       r = 1.5_f32.remainder(1)
       typeof(r).should eq(Float32)
     end
   end
 
-  describe "round" do
+  describe("round") do
     it { 2.5.round.should eq(3) }
     it { 2.4.round.should eq(2) }
   end
 
-  describe "floor" do
+  describe("floor") do
     it { 2.1.floor.should eq(2) }
     it { 2.9.floor.should eq(2) }
   end
 
-  describe "ceil" do
+  describe("ceil") do
     it { 2.0_f32.ceil.should eq(2) }
     it { 2.0.ceil.should eq(2) }
 
@@ -74,7 +74,7 @@ describe "Float" do
     it { 2.9.ceil.should eq(3) }
   end
 
-  describe "fdiv" do
+  describe("fdiv") do
     it { 1.0.fdiv(1).should eq 1.0 }
     it { 1.0.fdiv(2).should eq 0.5 }
     it { 1.0.fdiv(0.5).should eq 2.0 }
@@ -82,7 +82,7 @@ describe "Float" do
     it { 1.0.fdiv(0).should eq 1.0/0.0 }
   end
 
-  describe "divmod" do
+  describe("divmod") do
     it { 1.2.divmod(0.3)[0].should eq(4) }
     it { 1.2.divmod(0.3)[1].should be_close(0.0, 0.00001) }
 
@@ -120,8 +120,8 @@ describe "Float" do
     it { -1.4.divmod(-0.3)[1].should be_close(-0.2, 0.00001) }
   end
 
-  describe "to_s" do
-    it "does to_s for f64" do
+  describe("to_s") do
+    it("does to_s for f64") do
       12.34.to_s.should eq("12.34")
       1.2.to_s.should eq("1.2")
       1.23.to_s.should eq("1.23")
@@ -167,7 +167,7 @@ describe "Float" do
       (0.999999999999999989).to_s.should eq("1.0")
     end
 
-    it "does to_s for f32" do
+    it("does to_s for f32") do
       12.34_f32.to_s.should eq("12.34")
       1.2_f32.to_s.should eq("1.2")
       1.23_f32.to_s.should eq("1.23")
@@ -184,37 +184,37 @@ describe "Float" do
     end
   end
 
-  describe "#inspect" do
-    it "does inspect for f64" do
+  describe("#inspect") do
+    it("does inspect for f64") do
       3.2.inspect.should eq("3.2")
     end
 
-    it "does inspect for f32" do
+    it("does inspect for f32") do
       3.2_f32.inspect.should eq("3.2_f32")
     end
 
-    it "does inspect for f64 with IO" do
+    it("does inspect for f64 with IO") do
       str = String.build { |io| 3.2.inspect(io) }
       str.should eq("3.2")
     end
 
-    it "does inspect for f32" do
+    it("does inspect for f32") do
       str = String.build { |io| 3.2_f32.inspect(io) }
       str.should eq("3.2_f32")
     end
   end
 
-  describe "hash" do
-    it "does for Float32" do
+  describe("hash") do
+    it("does for Float32") do
       1.2_f32.hash.should eq(1.2_f32.hash)
     end
 
-    it "does for Float64" do
+    it("does for Float64") do
       1.2.hash.should eq(1.2.hash)
     end
   end
 
-  it "casts" do
+  it("casts") do
     Float32.new(1_f64).should be_a(Float32)
     Float32.new(1_f64).should eq(1)
 
@@ -222,12 +222,12 @@ describe "Float" do
     Float64.new(1_f32).should eq(1)
   end
 
-  it "does nan?" do
+  it("does nan?") do
     1.5.nan?.should be_false
     (0.0 / 0.0).nan?.should be_true
   end
 
-  it "does infinite?" do
+  it("does infinite?") do
     (0.0).infinite?.should be_nil
     (-1.0/0.0).infinite?.should eq(-1)
     (1.0/0.0).infinite?.should eq(1)
@@ -237,7 +237,7 @@ describe "Float" do
     (1.0_f32/0.0_f32).infinite?.should eq(1)
   end
 
-  it "does finite?" do
+  it("does finite?") do
     0.0.finite?.should be_true
     1.5.finite?.should be_true
     (1.0/0.0).finite?.should be_false
@@ -245,7 +245,7 @@ describe "Float" do
     (-0.0/0.0).finite?.should be_false
   end
 
-  it "does unary -" do
+  it("does unary -") do
     f = -(1.5)
     f.should eq(-1.5)
     f.should be_a(Float64)
@@ -255,7 +255,7 @@ describe "Float" do
     f.should be_a(Float32)
   end
 
-  it "clones" do
+  it("clones") do
     1.0.clone.should eq(1.0)
     1.0_f32.clone.should eq(1.0_f32)
   end

--- a/spec/std/gc_spec.cr
+++ b/spec/std/gc_spec.cr
@@ -1,11 +1,11 @@
 require "spec"
 
-describe "GC" do
-  it "compiles GC.stats" do
+describe("GC") do
+  it("compiles GC.stats") do
     typeof(GC.stats).should eq(GC::Stats)
   end
 
-  it "raises if calling enable when not disabled" do
+  it("raises if calling enable when not disabled") do
     expect_raises do
       GC.enable
     end

--- a/spec/std/gzip/gzip_spec.cr
+++ b/spec/std/gzip/gzip_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "gzip"
 
-describe Gzip do
-  it "writes and reads to memory" do
+describe(Gzip) do
+  it("writes and reads to memory") do
     io = IO::Memory.new
 
     time = Time.new(2016, 1, 2)

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -14,38 +14,38 @@ end
 
 private alias RecursiveType = String | Int32 | Array(RecursiveType) | Hash(Symbol, RecursiveType)
 
-describe "Hash" do
-  describe "empty" do
-    it "size should be zero" do
+describe("Hash") do
+  describe("empty") do
+    it("size should be zero") do
       h = {} of Int32 => Int32
       h.size.should eq(0)
       h.empty?.should be_true
     end
   end
 
-  it "sets and gets" do
+  it("sets and gets") do
     a = {} of Int32 => Int32
     a[1] = 2
     a[1].should eq(2)
   end
 
-  it "gets from literal" do
+  it("gets from literal") do
     a = {1 => 2}
     a[1].should eq(2)
   end
 
-  it "gets from union" do
+  it("gets from union") do
     a = {1 => 2, :foo => 1.1}
     a[1].should eq(2)
   end
 
-  it "gets nilable" do
+  it("gets nilable") do
     a = {1 => 2}
     a[1]?.should eq(2)
     a[2]?.should be_nil
   end
 
-  it "gets array of keys" do
+  it("gets array of keys") do
     a = {} of Symbol => Int32
     a.keys.should eq([] of Symbol)
     a[:foo] = 1
@@ -53,7 +53,7 @@ describe "Hash" do
     a.keys.should eq([:foo, :bar])
   end
 
-  it "gets array of values" do
+  it("gets array of values") do
     a = {} of Symbol => Int32
     a.values.should eq([] of Int32)
     a[:foo] = 1
@@ -61,7 +61,7 @@ describe "Hash" do
     a.values.should eq([1, 2])
   end
 
-  describe "==" do
+  describe("==") do
     it do
       a = {1 => 2, 3 => 4}
       b = {3 => 4, 1 => 2}
@@ -81,15 +81,15 @@ describe "Hash" do
       a.should_not eq(b)
     end
 
-    it "compares hash of nested hash" do
+    it("compares hash of nested hash") do
       a = { {1 => 2} => 3 }
       b = { {1 => 2} => 3 }
       a.should eq(b)
     end
   end
 
-  describe "[]" do
-    it "gets" do
+  describe("[]") do
+    it("gets") do
       a = {1 => 2}
       a[1].should eq(2)
       # a[2].should raise_exception
@@ -97,125 +97,125 @@ describe "Hash" do
     end
   end
 
-  describe "[]=" do
-    it "overrides value" do
+  describe("[]=") do
+    it("overrides value") do
       a = {1 => 2}
       a[1] = 3
       a[1].should eq(3)
     end
   end
 
-  describe "fetch" do
-    it "fetches with one argument" do
+  describe("fetch") do
+    it("fetches with one argument") do
       a = {1 => 2}
       a.fetch(1).should eq(2)
       a.should eq({1 => 2})
     end
 
-    it "fetches with default value" do
+    it("fetches with default value") do
       a = {1 => 2}
       a.fetch(1, 3).should eq(2)
       a.fetch(2, 3).should eq(3)
       a.should eq({1 => 2})
     end
 
-    it "fetches with block" do
+    it("fetches with block") do
       a = {1 => 2}
       a.fetch(1) { |k| k * 3 }.should eq(2)
       a.fetch(2) { |k| k * 3 }.should eq(6)
       a.should eq({1 => 2})
     end
 
-    it "fetches and raises" do
+    it("fetches and raises") do
       a = {1 => 2}
-      expect_raises KeyError, "Missing hash key: 2" do
+      expect_raises(KeyError, "Missing hash key: 2") do
         a.fetch(2)
       end
     end
   end
 
-  describe "values_at" do
-    it "returns the given keys" do
+  describe("values_at") do
+    it("returns the given keys") do
       {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.values_at("b", "a", "c").should eq({2, 1, 3})
     end
 
-    it "raises when passed an invalid key" do
-      expect_raises KeyError do
+    it("raises when passed an invalid key") do
+      expect_raises(KeyError) do
         {"a" => 1}.values_at("b")
       end
     end
 
-    it "works with mixed types" do
+    it("works with mixed types") do
       {1 => :a, "a" => 1, 2.0 => "a", :a => 1.0}.values_at(1, "a", 2.0, :a).should eq({:a, 1, "a", 1.0})
     end
   end
 
-  describe "key" do
-    it "returns the first key with the given value" do
+  describe("key") do
+    it("returns the first key with the given value") do
       hash = {"foo" => "bar", "baz" => "qux"}
       hash.key("bar").should eq("foo")
       hash.key("qux").should eq("baz")
     end
 
-    it "raises when no key pairs with the given value" do
-      expect_raises KeyError do
+    it("raises when no key pairs with the given value") do
+      expect_raises(KeyError) do
         {"foo" => "bar"}.key("qux")
       end
     end
 
-    describe "if block is given," do
-      it "returns the first key with the given value" do
+    describe("if block is given,") do
+      it("returns the first key with the given value") do
         hash = {"foo" => "bar", "baz" => "bar"}
         hash.key("bar") { |value| value.upcase }.should eq("foo")
       end
 
-      it "yields the argument if no hash key pairs with the value" do
+      it("yields the argument if no hash key pairs with the value") do
         hash = {"foo" => "bar"}
         hash.key("qux") { |value| value.upcase }.should eq("QUX")
       end
     end
   end
 
-  describe "key?" do
-    it "returns the first key with the given value" do
+  describe("key?") do
+    it("returns the first key with the given value") do
       hash = {"foo" => "bar", "baz" => "qux"}
       hash.key?("bar").should eq("foo")
       hash.key?("qux").should eq("baz")
     end
 
-    it "returns nil if no key pairs with the given value" do
+    it("returns nil if no key pairs with the given value") do
       hash = {"foo" => "bar", "baz" => "qux"}
       hash.key?("foobar").should eq nil
       hash.key?("bazqux").should eq nil
     end
   end
 
-  describe "has_key?" do
-    it "doesn't have key" do
+  describe("has_key?") do
+    it("doesn't have key") do
       a = {1 => 2}
       a.has_key?(2).should be_false
     end
 
-    it "has key" do
+    it("has key") do
       a = {1 => 2}
       a.has_key?(1).should be_true
     end
   end
 
-  describe "has_value?" do
-    it "returns true if contains the value" do
+  describe("has_value?") do
+    it("returns true if contains the value") do
       a = {1 => 2, 3 => 4, 5 => 6}
       a.has_value?(4).should be_true
     end
 
-    it "returns false if does not contain the value" do
+    it("returns false if does not contain the value") do
       a = {1 => 2, 3 => 4, 5 => 6}
       a.has_value?(3).should be_false
     end
   end
 
-  describe "delete" do
-    it "deletes key in the beginning" do
+  describe("delete") do
+    it("deletes key in the beginning") do
       a = {1 => 2, 3 => 4, 5 => 6}
       a.delete(1).should eq(2)
       a.has_key?(1).should be_false
@@ -225,7 +225,7 @@ describe "Hash" do
       a.should eq({3 => 4, 5 => 6})
     end
 
-    it "deletes key in the middle" do
+    it("deletes key in the middle") do
       a = {1 => 2, 3 => 4, 5 => 6}
       a.delete(3).should eq(4)
       a.has_key?(1).should be_true
@@ -235,7 +235,7 @@ describe "Hash" do
       a.should eq({1 => 2, 5 => 6})
     end
 
-    it "deletes key in the end" do
+    it("deletes key in the end") do
       a = {1 => 2, 3 => 4, 5 => 6}
       a.delete(5).should eq(6)
       a.has_key?(1).should be_true
@@ -245,7 +245,7 @@ describe "Hash" do
       a.should eq({1 => 2, 3 => 4})
     end
 
-    it "deletes only remaining entry" do
+    it("deletes only remaining entry") do
       a = {1 => 2}
       a.delete(1).should eq(2)
       a.has_key?(1).should be_false
@@ -253,30 +253,30 @@ describe "Hash" do
       a.should eq({} of Int32 => Int32)
     end
 
-    it "deletes not found" do
+    it("deletes not found") do
       a = {1 => 2}
       a.delete(2).should be_nil
     end
 
-    describe "with block" do
-      it "returns the value if a key is found" do
+    describe("with block") do
+      it("returns the value if a key is found") do
         a = {1 => 2}
         a.delete(1) { 5 }.should eq(2)
       end
 
-      it "returns the value of the block if key is not found" do
+      it("returns the value of the block if key is not found") do
         a = {1 => 2}
         a.delete(3) { |key| key }.should eq(3)
       end
 
-      it "returns nil if key is found and value is nil" do
+      it("returns nil if key is found and value is nil") do
         {3 => nil}.delete(3) { 7 }.should be_nil
       end
     end
   end
 
-  describe "size" do
-    it "is the same as size" do
+  describe("size") do
+    it("is the same as size") do
       a = {} of Int32 => Int32
       a.size.should eq(a.size)
 
@@ -288,13 +288,13 @@ describe "Hash" do
     end
   end
 
-  it "maps" do
+  it("maps") do
     hash = {1 => 2, 3 => 4}
     array = hash.map { |k, v| k + v }
     array.should eq([3, 7])
   end
 
-  describe "to_s" do
+  describe("to_s") do
     it { {1 => 2, 3 => 4}.to_s.should eq("{1 => 2, 3 => 4}") }
 
     it do
@@ -304,26 +304,26 @@ describe "Hash" do
     end
   end
 
-  it "does to_h" do
+  it("does to_h") do
     h = {:a => 1}
     h.to_h.should be(h)
   end
 
-  it "clones" do
+  it("clones") do
     h1 = {1 => 2, 3 => 4}
     h2 = h1.clone
     h1.should_not be(h2)
     h1.should eq(h2)
   end
 
-  it "initializes with block" do
+  it("initializes with block") do
     h1 = Hash(String, Array(Int32)).new { |h, k| h[k] = [] of Int32 }
     h1["foo"].should eq([] of Int32)
     h1["bar"].push 2
     h1["bar"].should eq([2])
   end
 
-  it "initializes with default value" do
+  it("initializes with default value") do
     h = Hash(Int32, Int32).new(10)
     h[0].should eq(10)
     h.has_key?(0).should be_false
@@ -332,7 +332,7 @@ describe "Hash" do
     h.has_key?(1).should be_true
   end
 
-  it "merges" do
+  it("merges") do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}
     h3 = {"1" => "5", "2" => "3"}
@@ -346,7 +346,7 @@ describe "Hash" do
     h5.should eq({1 => 2, 3 => 4, "1" => "5", "2" => "3"})
   end
 
-  it "merges with block" do
+  it("merges with block") do
     h1 = {1 => 5, 2 => 3}
     h2 = {1 => 5, 3 => 4, 2 => 3}
 
@@ -355,13 +355,13 @@ describe "Hash" do
     h3.should eq({1 => 11, 3 => 4, 2 => 8})
   end
 
-  it "merges recursive type (#1693)" do
+  it("merges recursive type (#1693)") do
     hash = {:foo => "bar"} of Symbol => RecursiveType
     result = hash.merge({:foobar => "foo"})
     result.should eq({:foo => "bar", :foobar => "foo"})
   end
 
-  it "merges!" do
+  it("merges!") do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}
 
@@ -370,7 +370,7 @@ describe "Hash" do
     h3.should eq({1 => 5, 3 => 4, 2 => 3})
   end
 
-  it "merges! with block" do
+  it("merges! with block") do
     h1 = {1 => 5, 2 => 3}
     h2 = {1 => 5, 3 => 4, 2 => 3}
 
@@ -379,7 +379,7 @@ describe "Hash" do
     h3.should eq({1 => 11, 3 => 4, 2 => 8})
   end
 
-  it "merges! with block and nilable keys" do
+  it("merges! with block and nilable keys") do
     h1 = {1 => nil, 2 => 4, 3 => "x"}
     h2 = {1 => 2, 2 => nil, 3 => "y"}
 
@@ -388,7 +388,7 @@ describe "Hash" do
     h3.should eq({1 => "2", 2 => "4", 3 => "x"})
   end
 
-  it "selects" do
+  it("selects") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.select { |k, v| k == :b }
@@ -396,7 +396,7 @@ describe "Hash" do
     h2.should_not be(h1)
   end
 
-  it "selects!" do
+  it("selects!") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.select! { |k, v| k == :b }
@@ -404,7 +404,7 @@ describe "Hash" do
     h2.should be(h1)
   end
 
-  it "returns nil when using select! and no changes were made" do
+  it("returns nil when using select! and no changes were made") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.select! { true }
@@ -412,7 +412,7 @@ describe "Hash" do
     h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
-  it "rejects" do
+  it("rejects") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.reject { |k, v| k == :b }
@@ -420,7 +420,7 @@ describe "Hash" do
     h2.should_not be(h1)
   end
 
-  it "rejects!" do
+  it("rejects!") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.reject! { |k, v| k == :b }
@@ -428,7 +428,7 @@ describe "Hash" do
     h2.should be(h1)
   end
 
-  it "returns nil when using reject! and no changes were made" do
+  it("returns nil when using reject! and no changes were made") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.reject! { false }
@@ -436,7 +436,7 @@ describe "Hash" do
     h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
-  it "compacts" do
+  it("compacts") do
     h1 = {:a => 1, :b => 2, :c => nil}
 
     h2 = h1.compact
@@ -444,7 +444,7 @@ describe "Hash" do
     h2.should eq({:a => 1, :b => 2})
   end
 
-  it "compacts!" do
+  it("compacts!") do
     h1 = {:a => 1, :b => 2, :c => nil}
 
     h2 = h1.compact!
@@ -452,7 +452,7 @@ describe "Hash" do
     h2.should be(h1)
   end
 
-  it "returns nil when using compact! and no changes were made" do
+  it("returns nil when using compact! and no changes were made") do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.compact!
@@ -460,29 +460,29 @@ describe "Hash" do
     h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
-  it "zips" do
+  it("zips") do
     ary1 = [1, 2, 3]
     ary2 = ['a', 'b', 'c']
     hash = Hash.zip(ary1, ary2)
     hash.should eq({1 => 'a', 2 => 'b', 3 => 'c'})
   end
 
-  it "gets first" do
+  it("gets first") do
     h = {1 => 2, 3 => 4}
     h.first.should eq({1, 2})
   end
 
-  it "gets first key" do
+  it("gets first key") do
     h = {1 => 2, 3 => 4}
     h.first_key.should eq(1)
   end
 
-  it "gets first value" do
+  it("gets first value") do
     h = {1 => 2, 3 => 4}
     h.first_value.should eq(2)
   end
 
-  it "shifts" do
+  it("shifts") do
     h = {1 => 2, 3 => 4}
     h.shift.should eq({1, 2})
     h.should eq({3 => 4})
@@ -490,20 +490,20 @@ describe "Hash" do
     h.empty?.should be_true
   end
 
-  it "shifts?" do
+  it("shifts?") do
     h = {1 => 2}
     h.shift?.should eq({1, 2})
     h.empty?.should be_true
     h.shift?.should be_nil
   end
 
-  it "gets key index" do
+  it("gets key index") do
     h = {1 => 2, 3 => 4}
     h.key_index(3).should eq(1)
     h.key_index(2).should be_nil
   end
 
-  it "inserts many" do
+  it("inserts many") do
     times = 1000
     h = {} of Int32 => Int32
     times.times do |i|
@@ -522,26 +522,26 @@ describe "Hash" do
     end
   end
 
-  it "inserts in one bucket and deletes from the same one" do
+  it("inserts in one bucket and deletes from the same one") do
     h = {11 => 1}
     h.delete(0).should be_nil
     h.has_key?(11).should be_true
     h.size.should eq(1)
   end
 
-  it "does to_a" do
+  it("does to_a") do
     h = {1 => "hello", 2 => "bye"}
     h.to_a.should eq([{1, "hello"}, {2, "bye"}])
   end
 
-  it "clears" do
+  it("clears") do
     h = {1 => 2, 3 => 4}
     h.clear
     h.empty?.should be_true
     h.to_a.size.should eq(0)
   end
 
-  it "computes hash" do
+  it("computes hash") do
     h1 = { {1 => 2} => {3 => 4} }
     h2 = { {1 => 2} => {3 => 4} }
     h1.hash.should eq(h2.hash)
@@ -552,18 +552,18 @@ describe "Hash" do
     h3.hash.should eq(h4.hash)
   end
 
-  it "fetches from empty hash with default value" do
+  it("fetches from empty hash with default value") do
     x = {} of Int32 => HashBreaker
     breaker = x.fetch(10) { HashBreaker.new(1) }
     breaker.x.should eq(1)
   end
 
-  it "does to to_s with instance that was never instantiated" do
+  it("does to to_s with instance that was never instantiated") do
     x = {} of Int32 => NeverInstantiated
     x.to_s.should eq("{}")
   end
 
-  it "inverts" do
+  it("inverts") do
     h1 = {"one" => 1, "two" => 2, "three" => 3}
     h2 = {"a" => 1, "b" => 2, "c" => 1}
 
@@ -574,7 +574,7 @@ describe "Hash" do
     %w(a c).should contain h3[1]
   end
 
-  it "does each" do
+  it("does each") do
     hash = {"foo" => 1, "bar" => 2}
     ks = [] of String
     vs = [] of Int32
@@ -586,7 +586,7 @@ describe "Hash" do
     vs.should eq([1, 2])
   end
 
-  it "does each_key" do
+  it("does each_key") do
     hash = {"foo" => 1, "bar" => 2}
     ks = [] of String
     hash.each_key do |k|
@@ -595,7 +595,7 @@ describe "Hash" do
     ks.should eq(["foo", "bar"])
   end
 
-  it "does each_value" do
+  it("does each_value") do
     hash = {"foo" => 1, "bar" => 2}
     vs = [] of Int32
     hash.each_value do |v|
@@ -604,7 +604,7 @@ describe "Hash" do
     vs.should eq([1, 2])
   end
 
-  it "gets each iterator" do
+  it("gets each iterator") do
     iter = {:a => 1, :b => 2}.each
     iter.next.should eq({:a, 1})
     iter.next.should eq({:b, 2})
@@ -614,7 +614,7 @@ describe "Hash" do
     iter.next.should eq({:a, 1})
   end
 
-  it "gets each key iterator" do
+  it("gets each key iterator") do
     iter = {:a => 1, :b => 2}.each_key
     iter.next.should eq(:a)
     iter.next.should eq(:b)
@@ -624,7 +624,7 @@ describe "Hash" do
     iter.next.should eq(:a)
   end
 
-  it "gets each value iterator" do
+  it("gets each value iterator") do
     iter = {:a => 1, :b => 2}.each_value
     iter.next.should eq(1)
     iter.next.should eq(2)
@@ -634,15 +634,15 @@ describe "Hash" do
     iter.next.should eq(1)
   end
 
-  describe "each_with_index" do
-    it "pass key, value, index values into block" do
+  describe("each_with_index") do
+    it("pass key, value, index values into block") do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
       hash.each_with_index { |(k, v), i| results << k + v + i }.should be_nil
       results.should eq [6, 16, 23]
     end
 
-    it "can be used with offset" do
+    it("can be used with offset") do
       hash = {2 => 4, 5 => 10, 7 => 14}
       results = [] of Int32
       hash.each_with_index(3) { |(k, v), i| results << k + v + i }.should be_nil
@@ -650,8 +650,8 @@ describe "Hash" do
     end
   end
 
-  describe "each_with_object" do
-    it "passes memo, key and value into block" do
+  describe("each_with_object") do
+    it("passes memo, key and value into block") do
       hash = {:a => 'b'}
       hash.each_with_object(:memo) do |(k, v), memo|
         memo.should eq(:memo)
@@ -660,7 +660,7 @@ describe "Hash" do
       end
     end
 
-    it "reduces the hash to the accumulated value of memo" do
+    it("reduces the hash to the accumulated value of memo") do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
       result = nil
       result = hash.each_with_object({} of Char => Symbol) do |(k, v), memo|
@@ -670,8 +670,8 @@ describe "Hash" do
     end
   end
 
-  describe "all?" do
-    it "passes key and value into block" do
+  describe("all?") do
+    it("passes key and value into block") do
       hash = {:a => 'b'}
       hash.all? do |k, v|
         k.should eq(:a)
@@ -679,7 +679,7 @@ describe "Hash" do
       end
     end
 
-    it "returns true if the block evaluates truthy for every kv pair" do
+    it("returns true if the block evaluates truthy for every kv pair") do
       hash = {:a => 'b', :c => 'd'}
       result = hash.all? { |k, v| v < 'e' ? "truthy" : nil }
       result.should be_true
@@ -688,7 +688,7 @@ describe "Hash" do
       result.should be_false
     end
 
-    it "evaluates the block for only for as many kv pairs as necessary" do
+    it("evaluates the block for only for as many kv pairs as necessary") do
       hash = {:a => 'b', :c => 'd'}
       hash.all? do |k, v|
         raise Exception.new("continued iterating") if v == 'd'
@@ -697,8 +697,8 @@ describe "Hash" do
     end
   end
 
-  describe "any?" do
-    it "passes key and value into block" do
+  describe("any?") do
+    it("passes key and value into block") do
       hash = {:a => 'b'}
       hash.any? do |k, v|
         k.should eq(:a)
@@ -706,7 +706,7 @@ describe "Hash" do
       end
     end
 
-    it "returns true if the block evaluates truthy for at least one kv pair" do
+    it("returns true if the block evaluates truthy for at least one kv pair") do
       hash = {:a => 'b', :c => 'd'}
       result = hash.any? { |k, v| v > 'b' ? "truthy" : nil }
       result.should be_true
@@ -715,7 +715,7 @@ describe "Hash" do
       result.should be_false
     end
 
-    it "evaluates the block for only for as many kv pairs as necessary" do
+    it("evaluates the block for only for as many kv pairs as necessary") do
       hash = {:a => 'b', :c => 'd'}
       hash.any? do |k, v|
         raise Exception.new("continued iterating") if v == 'd'
@@ -723,7 +723,7 @@ describe "Hash" do
       end
     end
 
-    it "returns true if the hash contains at least one kv pair and no block is given" do
+    it("returns true if the hash contains at least one kv pair and no block is given") do
       hash = {:a => 'b'}
       result = hash.any?
       result.should be_true
@@ -734,8 +734,8 @@ describe "Hash" do
     end
   end
 
-  describe "reduce" do
-    it "passes memo, key and value into block" do
+  describe("reduce") do
+    it("passes memo, key and value into block") do
       hash = {:a => 'b'}
       hash.reduce(:memo) do |memo, (k, v)|
         memo.should eq(:memo)
@@ -744,7 +744,7 @@ describe "Hash" do
       end
     end
 
-    it "reduces the hash to the accumulated value of memo" do
+    it("reduces the hash to the accumulated value of memo") do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
       result = hash.reduce("") do |memo, (k, v)|
         memo + v
@@ -753,69 +753,69 @@ describe "Hash" do
     end
   end
 
-  describe "reject" do
+  describe("reject") do
     it { {:a => 2, :b => 3}.reject(:b, :d).should eq({:a => 2}) }
     it { {:a => 2, :b => 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
-    it "does not change currrent hash" do
+    it("does not change currrent hash") do
       h = {:a => 3, :b => 6, :c => 9}
       h2 = h.reject(:b, :c)
       h.should eq({:a => 3, :b => 6, :c => 9})
     end
   end
 
-  describe "reject!" do
+  describe("reject!") do
     it { {:a => 2, :b => 3}.reject!(:b, :d).should eq({:a => 2}) }
     it { {:a => 2, :b => 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
-    it "changes currrent hash" do
+    it("changes currrent hash") do
       h = {:a => 3, :b => 6, :c => 9}
       h.reject!(:b, :c)
       h.should eq({:a => 3})
     end
   end
 
-  describe "select" do
+  describe("select") do
     it { {:a => 2, :b => 3}.select(:b, :d).should eq({:b => 3}) }
     it { {:a => 2, :b => 3}.select.should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.select(:b, :a).should eq({:a => 2, :b => 3}) }
     it { {:a => 2, :b => 3}.select([:b, :a]).should eq({:a => 2, :b => 3}) }
-    it "does not change currrent hash" do
+    it("does not change currrent hash") do
       h = {:a => 3, :b => 6, :c => 9}
       h2 = h.select(:b, :c)
       h.should eq({:a => 3, :b => 6, :c => 9})
     end
   end
 
-  describe "select!" do
+  describe("select!") do
     it { {:a => 2, :b => 3}.select!(:b, :d).should eq({:b => 3}) }
     it { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
     it { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
-    it "does change currrent hash" do
+    it("does change currrent hash") do
       h = {:a => 3, :b => 6, :c => 9}
       h.select!(:b, :c)
       h.should eq({:b => 6, :c => 9})
     end
   end
 
-  it "doesn't generate a negative index for the bucket index (#2321)" do
+  it("doesn't generate a negative index for the bucket index (#2321)") do
     items = (0..100000).map { rand(100000).to_i16 }
     items.uniq.size
   end
 
-  it "creates with initial capacity" do
+  it("creates with initial capacity") do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234)
     hash.@buckets_size.should eq(1234)
   end
 
-  it "creates with initial capacity and default value" do
+  it("creates with initial capacity and default value") do
     hash = Hash(Int32, Int32).new(default_value: 3, initial_capacity: 1234)
     hash[1].should eq(3)
     hash.@buckets_size.should eq(1234)
   end
 
-  it "creates with initial capacity and block" do
+  it("creates with initial capacity and block") do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234) { |h, k| h[k] = 3 }
     hash[1].should eq(3)
     hash.@buckets_size.should eq(1234)

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -1,65 +1,65 @@
 require "spec"
 require "html"
 
-describe "HTML" do
-  describe ".escape" do
-    it "does not change a safe string" do
+describe("HTML") do
+  describe(".escape") do
+    it("does not change a safe string") do
       str = HTML.escape("safe_string")
 
       str.should eq("safe_string")
     end
 
-    it "escapes dangerous characters from a string" do
+    it("escapes dangerous characters from a string") do
       str = HTML.escape("< & > ' \"")
 
       str.should eq("&lt; &amp; &gt; &#39; &quot;")
     end
   end
 
-  describe ".unescape" do
-    it "does not change a safe string" do
+  describe(".unescape") do
+    it("does not change a safe string") do
       str = HTML.unescape("safe_string")
 
       str.should eq("safe_string")
     end
 
-    it "unescapes dangerous characters from a string" do
+    it("unescapes dangerous characters from a string") do
       str = HTML.unescape("&lt; &amp; &gt;")
 
       str.should eq("< & >")
     end
 
-    it "unescapes javascript example from a string" do
+    it("unescapes javascript example from a string") do
       str = HTML.unescape("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;/script&gt;")
 
       str.should eq("<script>alert('You are being hacked')</script>")
     end
 
-    it "unescapes decimal encoded chars" do
+    it("unescapes decimal encoded chars") do
       str = HTML.unescape("&lt;&#104;&#101;llo world&gt;")
 
       str.should eq("<hello world>")
     end
 
-    it "unescapes with invalid entities" do
+    it("unescapes with invalid entities") do
       str = HTML.unescape("&&lt;&amp&gt;&quot&abcdefghijklmn")
 
       str.should eq("&<&amp>&quot&abcdefghijklmn")
     end
 
-    it "unescapes hex encoded chars" do
+    it("unescapes hex encoded chars") do
       str = HTML.unescape("3 &#x0002B; 2 &#x0003D; 5")
 
       str.should eq("3 + 2 = 5")
     end
 
-    it "unescapes &nbsp;" do
+    it("unescapes &nbsp;") do
       str = HTML.unescape("nbsp&nbsp;space ")
 
       str.should eq("nbsp space ")
     end
 
-    it "unescapes Char::MAX_CODEPOINT" do
+    it("unescapes Char::MAX_CODEPOINT") do
       str = HTML.unescape("limit &#x10FFFF;")
       str.should eq("limit 􏿿")
 

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http/content"
 
-describe HTTP::ChunkedContent do
-  it "delays reading the next chunk as soon as one is consumed (#3270)" do
+describe(HTTP::ChunkedContent) do
+  it("delays reading the next chunk as soon as one is consumed (#3270)") do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
     bytes = uninitialized UInt8[4]
@@ -12,14 +12,14 @@ describe HTTP::ChunkedContent do
     mem.pos.should eq(7) # only this chunk was read
   end
 
-  it "peeks" do
+  it("peeks") do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
     content.peek.should eq("123\n".to_slice)
   end
 
-  it "peeks into next chunk" do
+  it("peeks into next chunk") do
     mem = IO::Memory.new("4\r\n123\n\r\n3\r\n456\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
@@ -28,7 +28,7 @@ describe HTTP::ChunkedContent do
     content.gets_to_end.should eq("456")
   end
 
-  it "skips" do
+  it("skips") do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
@@ -40,7 +40,7 @@ describe HTTP::ChunkedContent do
     end
   end
 
-  it "skips (2)" do
+  it("skips (2)") do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
@@ -48,7 +48,7 @@ describe HTTP::ChunkedContent do
     content.gets_to_end.should eq("3\n")
   end
 
-  it "skips (3)" do
+  it("skips (3)") do
     mem = IO::Memory.new("4\r\n123\n\r\n3\r\n456\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -23,7 +23,7 @@ private class TestServer < TCPServer
 end
 
 module HTTP
-  describe Client do
+  describe(Client) do
     typeof(Client.new("host"))
     typeof(Client.new("host", port: 8080))
     typeof(Client.new("host", tls: true))
@@ -54,8 +54,8 @@ module HTTP
     typeof(Client.post("http://www.example.com", body: Bytes[65]))
     typeof(Client.new("host").post("/", body: Bytes[65]))
 
-    describe "from URI" do
-      it "has sane defaults" do
+    describe("from URI") do
+      it("has sane defaults") do
         cl = Client.new(URI.parse("http://example.com"))
         cl.tls?.should be_nil
         cl.port.should eq(80)
@@ -94,34 +94,34 @@ module HTTP
         end
       {% end %}
 
-      it "raises error if not http schema" do
+      it("raises error if not http schema") do
         expect_raises(ArgumentError, "Unsupported scheme: ssh") do
           Client.new(URI.parse("ssh://example.com"))
         end
       end
 
-      it "raises error if URI is missing host" do
+      it("raises error if URI is missing host") do
         expect_raises(ArgumentError, "must have host") do
           Client.new(URI.parse("http:/"))
         end
       end
 
-      it "yields to a block" do
+      it("yields to a block") do
         Client.new(URI.parse("http://example.com")) do |client|
           typeof(client)
         end
       end
     end
 
-    context "from a host" do
-      it "yields to a block" do
+    context("from a host") do
+      it("yields to a block") do
         Client.new("example.com") do |client|
           typeof(client)
         end
       end
     end
 
-    it "doesn't read the body if request was HEAD" do
+    it("doesn't read the body if request was HEAD") do
       resp_get = TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         break client.get("/")
@@ -135,19 +135,19 @@ module HTTP
       end
     end
 
-    it "raises if URI is missing scheme" do
+    it("raises if URI is missing scheme") do
       expect_raises(ArgumentError, "Missing scheme") do
         HTTP::Client.get URI.parse("www.example.com")
       end
     end
 
-    it "raises if URI is missing host" do
+    it("raises if URI is missing host") do
       expect_raises(ArgumentError, "must have host") do
         HTTP::Client.get URI.parse("http://")
       end
     end
 
-    it "tests read_timeout" do
+    it("tests read_timeout") do
       TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.read_timeout = 1.second
@@ -163,7 +163,7 @@ module HTTP
       end
     end
 
-    it "tests connect_timeout" do
+    it("tests connect_timeout") do
       TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.connect_timeout = 0.5

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "http/client/response"
 
 class HTTP::Client
-  describe Response do
-    it "parses response with body" do
+  describe(Response) do
+    it("parses response with body") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
@@ -13,7 +13,7 @@ class HTTP::Client
       response.body.should eq("hello")
     end
 
-    it "parses response with streamed body" do
+    it("parses response with streamed body") do
       Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld")) do |response|
         response.version.should eq("HTTP/1.1")
         response.status_code.should eq(200)
@@ -25,13 +25,13 @@ class HTTP::Client
       end
     end
 
-    it "parses response with streamed body, huge content-length" do
+    it("parses response with streamed body, huge content-length") do
       Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: #{UInt64::MAX}\r\n\r\nhelloworld")) do |response|
         response.headers["content-length"].should eq("#{UInt64::MAX}")
       end
     end
 
-    it "parses response with body without \\r" do
+    it("parses response with body without \\r") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 5\n\nhelloworld"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
@@ -41,7 +41,7 @@ class HTTP::Client
       response.body.should eq("hello")
     end
 
-    it "parses response with body but without content-length" do
+    it("parses response with body but without content-length") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\n\r\nhelloworld"))
       response.status_code.should eq(200)
       response.status_message.should eq("OK")
@@ -49,7 +49,7 @@ class HTTP::Client
       response.body.should eq("helloworld")
     end
 
-    it "parses response with empty body but without content-length" do
+    it("parses response with empty body but without content-length") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 404 Not Found\r\n\r\n"))
       response.status_code.should eq(404)
       response.status_message.should eq("Not Found")
@@ -57,7 +57,7 @@ class HTTP::Client
       response.body.should eq("")
     end
 
-    it "parses response without body" do
+    it("parses response without body") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 100 Continue\r\n\r\n"))
       response.status_code.should eq(100)
       response.status_message.should eq("Continue")
@@ -65,7 +65,7 @@ class HTTP::Client
       response.body?.should be_nil
     end
 
-    it "parses response without status message" do
+    it("parses response without status message") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200\r\n\r\n"))
       response.status_code.should eq(200)
       response.status_message.should eq("")
@@ -73,37 +73,37 @@ class HTTP::Client
       response.body.should eq("")
     end
 
-    it "parses response with duplicated headers" do
+    it("parses response with duplicated headers") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nWarning: 111 Revalidation failed\r\nWarning: 110 Response is stale\r\n\r\nhelloworld"))
       response.headers.get("Warning").should eq(["111 Revalidation failed", "110 Response is stale"])
     end
 
-    it "parses response with cookies" do
+    it("parses response with cookies") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: a=b\r\nSet-Cookie: c=d\r\n\r\nhelloworld"))
       response.cookies["a"].value.should eq("b")
       response.cookies["c"].value.should eq("d")
     end
 
-    it "parses response with chunked body" do
+    it("parses response with chunked body") do
       response = Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n"))
       response.body.should eq("abcde0123456789")
       io.gets.should be_nil
     end
 
-    it "parses response with streamed chunked body" do
+    it("parses response with streamed chunked body") do
       Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n\r\n")) do |response|
         response.body_io.gets_to_end.should eq("abcde0123456789")
         io.gets.should be_nil
       end
     end
 
-    it "parses response with chunked body of size 0" do
+    it("parses response with chunked body of size 0") do
       response = Response.from_io(io = IO::Memory.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"))
       response.body.should eq("")
       io.gets.should be_nil
     end
 
-    it "parses response ignoring body" do
+    it("parses response ignoring body") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"), true)
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(200)
@@ -113,7 +113,7 @@ class HTTP::Client
       response.body.should eq("")
     end
 
-    it "parses 204 response without body but Content-Length == 0 (#2512)" do
+    it("parses 204 response without body but Content-Length == 0 (#2512)") do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 204 OK\r\nContent-Type: text/plain\r\nContent-Length: 0\r\n\r\n"))
       response.version.should eq("HTTP/1.1")
       response.status_code.should eq(204)
@@ -123,32 +123,32 @@ class HTTP::Client
       response.body.should eq("")
     end
 
-    it "parses long request lines" do
+    it("parses long request lines") do
       request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 #{"OK" * 16000}\r\n\r\n"))
       request.should eq(nil)
     end
 
-    it "parses long headers" do
+    it("parses long headers") do
       request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 OK\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
       request.should eq(nil)
     end
 
-    it "doesn't sets content length for 1xx, 204 or 304" do
+    it("doesn't sets content length for 1xx, 204 or 304") do
       [100, 101, 204, 304].each do |status|
         response = Response.new(status)
         response.headers.size.should eq(0)
       end
     end
 
-    it "raises when creating 1xx, 204 or 304 with body" do
+    it("raises when creating 1xx, 204 or 304 with body") do
       [100, 101, 204, 304].each do |status|
-        expect_raises ArgumentError do
+        expect_raises(ArgumentError) do
           Response.new(status, "hello")
         end
       end
     end
 
-    it "serialize with body" do
+    it("serialize with body") do
       headers = HTTP::Headers.new
       headers["Content-Type"] = "text/plain"
       headers["Content-Length"] = "5"
@@ -159,7 +159,7 @@ class HTTP::Client
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello")
     end
 
-    it "serialize with body and cookies" do
+    it("serialize with body and cookies") do
       headers = HTTP::Headers.new
       headers["Content-Type"] = "text/plain"
       headers["Content-Length"] = "5"
@@ -185,78 +185,78 @@ class HTTP::Client
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: foo=baz; path=/\r\nSet-Cookie: quux=baz; path=/\r\n\r\nhello")
     end
 
-    it "sets content length from body" do
+    it("sets content length from body") do
       response = Response.new(200, "hello")
       io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
     end
 
-    it "sets content length even without body" do
+    it("sets content length even without body") do
       response = Response.new(200)
       io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
     end
 
-    it "serialize as chunked with body_io" do
+    it("serialize as chunked with body_io") do
       response = Response.new(200, body_io: IO::Memory.new("hello"))
       io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")
     end
 
-    it "serialize as not chunked with body_io if HTTP/1.0" do
+    it("serialize as not chunked with body_io if HTTP/1.0") do
       response = Response.new(200, version: "HTTP/1.0", body_io: IO::Memory.new("hello"))
       io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello")
     end
 
-    it "returns no content_type when header is missing" do
+    it("returns no content_type when header is missing") do
       response = Response.new(200, "")
       response.content_type.should be_nil
       response.charset.should be_nil
     end
 
-    it "returns content type and no charset" do
+    it("returns content type and no charset") do
       response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain"})
       response.content_type.should eq("text/plain")
       response.charset.should be_nil
     end
 
-    it "returns content type and charset, removes semicolon" do
+    it("returns content type and charset, removes semicolon") do
       response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; charset=UTF-8"})
       response.content_type.should eq("text/plain")
       response.charset.should eq("UTF-8")
     end
 
-    it "returns content type and no charset, other parameter (#2520)" do
+    it("returns content type and no charset, other parameter (#2520)") do
       response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; colenc=U"})
       response.content_type.should eq("text/plain")
       response.charset.should be_nil
     end
 
-    it "returns content type and charset, removes semicolon, with multiple parameters (#2520)" do
+    it("returns content type and charset, removes semicolon, with multiple parameters (#2520)") do
       response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; colenc=U ; charset=UTF-8"})
       response.content_type.should eq("text/plain")
       response.charset.should eq("UTF-8")
     end
 
-    it "creates Response with status code 204, no body and Content-Length == 0 (#2512)" do
+    it("creates Response with status code 204, no body and Content-Length == 0 (#2512)") do
       response = Response.new(204, version: "HTTP/1.0", body: "", headers: HTTP::Headers{"Content-Length" => "0"})
       response.status_code.should eq(204)
       response.body.should eq("")
     end
 
-    describe "success?" do
-      it "returns true for the 2xx" do
+    describe("success?") do
+      it("returns true for the 2xx") do
         response = Response.new(200)
 
         response.success?.should eq(true)
       end
 
-      it "returns false for other ranges" do
+      it("returns false for other ranges") do
         response = Response.new(500)
 
         response.success?.should eq(false)

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -14,44 +14,44 @@ private def parse_set_cookie(header)
 end
 
 module HTTP
-  describe Cookie::Parser do
-    describe "parse_cookies" do
-      it "parses key=value" do
+  describe(Cookie::Parser) do
+    describe("parse_cookies") do
+      it("parses key=value") do
         cookie = parse_first_cookie("key=value")
         cookie.name.should eq("key")
         cookie.value.should eq("value")
         cookie.to_set_cookie_header.should eq("key=value; path=/")
       end
 
-      it "parses key=" do
+      it("parses key=") do
         cookie = parse_first_cookie("key=")
         cookie.name.should eq("key")
         cookie.value.should eq("")
         cookie.to_set_cookie_header.should eq("key=; path=/")
       end
 
-      it "parses key=key=value" do
+      it("parses key=key=value") do
         cookie = parse_first_cookie("key=key=value")
         cookie.name.should eq("key")
         cookie.value.should eq("key=value")
         cookie.to_set_cookie_header.should eq("key=key%3Dvalue; path=/")
       end
 
-      it "parses key=key%3Dvalue" do
+      it("parses key=key%3Dvalue") do
         cookie = parse_first_cookie("key=key%3Dvalue")
         cookie.name.should eq("key")
         cookie.value.should eq("key=value")
         cookie.to_set_cookie_header.should eq("key=key%3Dvalue; path=/")
       end
 
-      it "parses key%3Dvalue=value" do
+      it("parses key%3Dvalue=value") do
         cookie = parse_first_cookie("key%3Dvalue=value")
         cookie.name.should eq("key=value")
         cookie.value.should eq("value")
         cookie.to_set_cookie_header.should eq("key%3Dvalue=value; path=/")
       end
 
-      it "parses multiple cookies" do
+      it("parses multiple cookies") do
         cookies = Cookie::Parser.parse_cookies("foo=bar; foobar=baz")
         cookies.size.should eq(2)
         first, second = cookies
@@ -62,8 +62,8 @@ module HTTP
       end
     end
 
-    describe "parse_set_cookie" do
-      it "parses path" do
+    describe("parse_set_cookie") do
+      it("parses path") do
         cookie = parse_set_cookie("key=value; path=/test")
         cookie.name.should eq("key")
         cookie.value.should eq("value")
@@ -71,7 +71,7 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; path=/test")
       end
 
-      it "parses Secure" do
+      it("parses Secure") do
         cookie = parse_set_cookie("key=value; Secure")
         cookie.name.should eq("key")
         cookie.value.should eq("value")
@@ -79,7 +79,7 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; path=/; Secure")
       end
 
-      it "parses HttpOnly" do
+      it("parses HttpOnly") do
         cookie = parse_set_cookie("key=value; HttpOnly")
         cookie.name.should eq("key")
         cookie.value.should eq("value")
@@ -87,7 +87,7 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; path=/; HttpOnly")
       end
 
-      it "parses domain" do
+      it("parses domain") do
         cookie = parse_set_cookie("key=value; domain=www.example.com")
         cookie.name.should eq("key")
         cookie.value.should eq("value")
@@ -95,7 +95,7 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; domain=www.example.com; path=/")
       end
 
-      it "parses expires rfc1123" do
+      it("parses expires rfc1123") do
         cookie = parse_set_cookie("key=value; expires=Sun, 06 Nov 1994 08:49:37 GMT")
         time = Time.new(1994, 11, 6, 8, 49, 37)
 
@@ -104,7 +104,7 @@ module HTTP
         cookie.expires.should eq(time)
       end
 
-      it "parses expires rfc1036" do
+      it("parses expires rfc1036") do
         cookie = parse_set_cookie("key=value; expires=Sunday, 06-Nov-94 08:49:37 GMT")
         time = Time.new(1994, 11, 6, 8, 49, 37)
 
@@ -113,7 +113,7 @@ module HTTP
         cookie.expires.should eq(time)
       end
 
-      it "parses expires ansi c" do
+      it("parses expires ansi c") do
         cookie = parse_set_cookie("key=value; expires=Sun Nov  6 08:49:37 1994")
         time = Time.new(1994, 11, 6, 8, 49, 37)
 
@@ -122,12 +122,12 @@ module HTTP
         cookie.expires.should eq(time)
       end
 
-      it "parses expires ansi c, variant with zone" do
+      it("parses expires ansi c, variant with zone") do
         cookie = parse_set_cookie("bla=; expires=Thu, 01 Jan 1970 00:00:00 -0000")
         cookie.expires.should eq(Time.new(1970, 1, 1, 0, 0, 0))
       end
 
-      it "parses full" do
+      it("parses full") do
         cookie = parse_set_cookie("key=value; path=/test; domain=www.example.com; HttpOnly; Secure; expires=Sun, 06 Nov 1994 08:49:37 GMT")
         time = Time.new(1994, 11, 6, 8, 49, 37)
 
@@ -140,11 +140,11 @@ module HTTP
         cookie.expires.should eq(time)
       end
 
-      it "parse domain as IP" do
+      it("parse domain as IP") do
         parse_set_cookie("a=1; domain=127.0.0.1; path=/; HttpOnly").domain.should eq "127.0.0.1"
       end
 
-      it "parse max-age as seconds from Time.now" do
+      it("parse max-age as seconds from Time.now") do
         cookie = parse_set_cookie("a=1; max-age=10")
         delta = cookie.expires.not_nil! - Time.now
         delta.should be > 9.seconds
@@ -157,31 +157,31 @@ module HTTP
       end
     end
 
-    describe "expired?" do
-      it "by max-age=0" do
+    describe("expired?") do
+      it("by max-age=0") do
         parse_set_cookie("bla=1; max-age=0").expired?.should eq true
       end
 
-      it "by old date" do
+      it("by old date") do
         parse_set_cookie("bla=1; expires=Thu, 01 Jan 1970 00:00:00 -0000").expired?.should eq true
       end
 
-      it "not expired" do
+      it("not expired") do
         parse_set_cookie("bla=1; max-age=1").expired?.should eq false
       end
 
-      it "not expired" do
+      it("not expired") do
         parse_set_cookie("bla=1; expires=Thu, 01 Jan 2020 00:00:00 -0000").expired?.should eq false
       end
 
-      it "not expired" do
+      it("not expired") do
         parse_set_cookie("bla=1").expired?.should eq false
       end
     end
   end
 
-  describe Cookies do
-    it "allows adding cookies and retrieving" do
+  describe(Cookies) do
+    it("allows adding cookies and retrieving") do
       cookies = Cookies.new
       cookies << Cookie.new("a", "b")
       cookies["c"] = Cookie.new("c", "d")
@@ -195,8 +195,8 @@ module HTTP
       cookies.has_key?("a").should be_true
     end
 
-    describe "adding request headers" do
-      it "overwrites a pre-existing Cookie header" do
+    describe("adding request headers") do
+      it("overwrites a pre-existing Cookie header") do
         headers = Headers.new
         headers["Cookie"] = "some_key=some_value"
 
@@ -210,7 +210,7 @@ module HTTP
         headers["Cookie"].should eq "a=b"
       end
 
-      it "merges multiple cookies into one Cookie header" do
+      it("merges multiple cookies into one Cookie header") do
         headers = Headers.new
         cookies = Cookies.new
         cookies << Cookie.new("a", "b")
@@ -221,8 +221,8 @@ module HTTP
         headers["Cookie"].should eq "a=b; c=d"
       end
 
-      describe "when no cookies are set" do
-        it "does not set a Cookie header" do
+      describe("when no cookies are set") do
+        it("does not set a Cookie header") do
           headers = Headers.new
           headers["Cookie"] = "a=b"
           cookies = Cookies.new
@@ -234,8 +234,8 @@ module HTTP
       end
     end
 
-    describe "adding response headers" do
-      it "overwrites all pre-existing Set-Cookie headers" do
+    describe("adding response headers") do
+      it("overwrites all pre-existing Set-Cookie headers") do
         headers = Headers.new
         headers.add("Set-Cookie", "a=b; path=/")
         headers.add("Set-Cookie", "c=d; path=/")
@@ -253,7 +253,7 @@ module HTTP
         headers.get("Set-Cookie")[0].should eq "x=y; path=/"
       end
 
-      it "sets one Set-Cookie header per cookie" do
+      it("sets one Set-Cookie header per cookie") do
         headers = Headers.new
         cookies = Cookies.new
         cookies << Cookie.new("a", "b")
@@ -267,8 +267,8 @@ module HTTP
         headers.get("Set-Cookie").includes?("c=d; path=/").should be_true
       end
 
-      describe "when no cookies are set" do
-        it "does not set a Set-Cookie header" do
+      describe("when no cookies are set") do
+        it("does not set a Set-Cookie header") do
           headers = Headers.new
           headers.add("Set-Cookie", "a=b; path=/")
           cookies = Cookies.new
@@ -280,15 +280,15 @@ module HTTP
       end
     end
 
-    it "disallows adding inconsistent state" do
+    it("disallows adding inconsistent state") do
       cookies = Cookies.new
 
-      expect_raises ArgumentError do
+      expect_raises(ArgumentError) do
         cookies["a"] = Cookie.new("b", "c")
       end
     end
 
-    it "allows to iterate over the cookies" do
+    it("allows to iterate over the cookies") do
       cookies = Cookies.new
       cookies["a"] = "b"
       cookies.each do |cookie|
@@ -300,7 +300,7 @@ module HTTP
       cookie.should eq Cookie.new("a", "b")
     end
 
-    it "allows transform to hash" do
+    it("allows transform to hash") do
       cookies = Cookies.new
       cookies << Cookie.new("a", "b")
       cookies["c"] = Cookie.new("c", "d")

--- a/spec/std/http/formdata/builder_spec.cr
+++ b/spec/std/http/formdata/builder_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http"
 
-describe HTTP::FormData::Builder do
-  it "builds valid form-data messages" do
+describe(HTTP::FormData::Builder) do
+  it("builds valid form-data messages") do
     io = IO::Memory.new
     HTTP::FormData.build(io, "fixed-boundary") do |g|
       g.field("foo", "bar")
@@ -38,15 +38,15 @@ describe HTTP::FormData::Builder do
     generated.should eq(expected.gsub("\n", "\r\n"))
   end
 
-  describe "#content_type" do
-    it "calculates the content type" do
+  describe("#content_type") do
+    it("calculates the content type") do
       builder = HTTP::FormData::Builder.new(IO::Memory.new, "a delimiter string with a quote in \"")
       builder.content_type.should eq(%q(multipart/form-data; boundary="a\ delimiter\ string\ with\ a\ quote\ in\ \""))
     end
   end
 
-  describe "#file" do
-    it "fails after finish" do
+  describe("#file") do
+    it("fails after finish") do
       builder = HTTP::FormData::Builder.new(IO::Memory.new)
       builder.field("foo", "bar")
       builder.finish
@@ -56,8 +56,8 @@ describe HTTP::FormData::Builder do
     end
   end
 
-  describe "#finish" do
-    it "fails after finish" do
+  describe("#finish") do
+    it("fails after finish") do
       builder = HTTP::FormData::Builder.new(IO::Memory.new)
       builder.field("foo", "bar")
       builder.finish
@@ -66,7 +66,7 @@ describe HTTP::FormData::Builder do
       end
     end
 
-    it "fails when no body parts" do
+    it("fails when no body parts") do
       builder = HTTP::FormData::Builder.new(IO::Memory.new)
       expect_raises(HTTP::FormData::Error, "Cannot finish form-data: no body parts") do
         builder.finish

--- a/spec/std/http/formdata/parser_spec.cr
+++ b/spec/std/http/formdata/parser_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http"
 
-describe HTTP::FormData::Parser do
-  it "parses formdata" do
+describe(HTTP::FormData::Parser) do
+  it("parses formdata") do
     formdata = <<-FORMDATA
       -----------------------------735323031399963166993862150
       Content-Disposition: form-data; name="text"

--- a/spec/std/http/formdata_spec.cr
+++ b/spec/std/http/formdata_spec.cr
@@ -1,9 +1,9 @@
 require "spec"
 require "http"
 
-describe HTTP::FormData do
-  describe ".parse(IO, String)" do
-    it "parses formdata" do
+describe(HTTP::FormData) do
+  describe(".parse(IO, String)") do
+    it("parses formdata") do
       formdata = <<-FORMDATA
         --foo
         Content-Disposition: form-data; name="foo"
@@ -20,8 +20,8 @@ describe HTTP::FormData do
     end
   end
 
-  describe ".parse(HTTP::Request)" do
-    it "parses formdata" do
+  describe(".parse(HTTP::Request)") do
+    it("parses formdata") do
       formdata = <<-FORMDATA
         --foo
         Content-Disposition: form-data; name="foo"
@@ -39,7 +39,7 @@ describe HTTP::FormData do
       res.should eq("bar")
     end
 
-    it "raises on empty body" do
+    it("raises on empty body") do
       headers = HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=foo"}
       req = HTTP::Request.new("GET", "/", headers)
       expect_raises(HTTP::FormData::Error, "body is empty") do
@@ -47,14 +47,14 @@ describe HTTP::FormData do
       end
     end
 
-    it "raises on no Content-Type" do
+    it("raises on no Content-Type") do
       req = HTTP::Request.new("GET", "/", body: "")
       expect_raises(HTTP::FormData::Error, "could not find boundary in Content-Type") do
         HTTP::FormData.parse(req) { }
       end
     end
 
-    it "raises on invalid Content-Type" do
+    it("raises on invalid Content-Type") do
       headers = HTTP::Headers{"Content-Type" => "multipart/form-data; boundary="}
       req = HTTP::Request.new("GET", "/", headers, body: "")
       expect_raises(HTTP::FormData::Error, "could not find boundary in Content-Type") do
@@ -63,8 +63,8 @@ describe HTTP::FormData do
     end
   end
 
-  describe ".parse_content_disposition(String)" do
-    it "parses all Content-Disposition fields" do
+  describe(".parse_content_disposition(String)") do
+    it("parses all Content-Disposition fields") do
       name, meta = HTTP::FormData.parse_content_disposition %q(form-data; name=foo; filename="foo\"\\bar\ baz\\"; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"; modification-date="12 Feb 1997 16:29:51 -0500"; read-date="Wed, 12 Feb 1997 16:29:51 -0500"; size=432334)
 
       name.should eq("foo")
@@ -76,8 +76,8 @@ describe HTTP::FormData do
     end
   end
 
-  describe ".build(IO, String)" do
-    it "builds a message" do
+  describe(".build(IO, String)") do
+    it("builds a message") do
       io = IO::Memory.new
       HTTP::FormData.build(io, "boundary") do |g|
         g.field("foo", "bar")
@@ -94,8 +94,8 @@ describe HTTP::FormData do
     end
   end
 
-  describe ".build(HTTP::Response, String)" do
-    it "builds a message" do
+  describe(".build(HTTP::Response, String)") do
+    it("builds a message") do
       io = IO::Memory.new
       response = HTTP::Server::Response.new(io)
       HTTP::FormData.build(response, "boundary") do |g|

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -1,30 +1,30 @@
 require "spec"
 require "http/headers"
 
-describe HTTP::Headers do
-  it "is empty" do
+describe(HTTP::Headers) do
+  it("is empty") do
     headers = HTTP::Headers.new
     headers.empty?.should be_true
   end
 
-  it "is case insensitive" do
+  it("is case insensitive") do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers["foo"].should eq("bar")
   end
 
-  it "it allows indifferent access for underscore and dash separated keys" do
+  it("it allows indifferent access for underscore and dash separated keys") do
     headers = HTTP::Headers{"foo_Bar" => "bar", "Foobar-foo" => "baz"}
     headers["foo-bar"].should eq("bar")
     headers["foobar_foo"].should eq("baz")
   end
 
-  it "raises an error if header value contains invalid character" do
-    expect_raises ArgumentError do
+  it("raises an error if header value contains invalid character") do
+    expect_raises(ArgumentError) do
       headers = HTTP::Headers{"invalid-header" => "\r\nLocation: http://example.com"}
     end
   end
 
-  it "should retain the input casing" do
+  it("should retain the input casing") do
     headers = HTTP::Headers{"FOO_BAR" => "bar", "Foobar-foo" => "baz"}
     serialized = String.build do |io|
       headers.each do |name, values|
@@ -35,7 +35,7 @@ describe HTTP::Headers do
     serialized.should eq("FOO_BAR: bar;Foobar-foo: baz;")
   end
 
-  it "is gets with []?" do
+  it("is gets with []?") do
     headers = HTTP::Headers.new
     headers["foo"]?.should be_nil
 
@@ -43,12 +43,12 @@ describe HTTP::Headers do
     headers["foo"]?.should eq("bar")
   end
 
-  it "fetches" do
+  it("fetches") do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers.fetch("foo").should eq("bar")
   end
 
-  it "fetches with default value" do
+  it("fetches with default value") do
     headers = HTTP::Headers.new
     headers.fetch("foo", "baz").should eq("baz")
 
@@ -56,7 +56,7 @@ describe HTTP::Headers do
     headers.fetch("foo", "baz").should eq("bar")
   end
 
-  it "fetches with block" do
+  it("fetches with block") do
     headers = HTTP::Headers.new
     headers.fetch("foo") { |k| "#{k}baz" }.should eq("foobaz")
 
@@ -64,24 +64,24 @@ describe HTTP::Headers do
     headers.fetch("foo") { "baz" }.should eq("bar")
   end
 
-  it "has key" do
+  it("has key") do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers.has_key?("foo").should be_true
     headers.has_key?("bar").should be_false
   end
 
-  it "deletes" do
+  it("deletes") do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers.delete("foo").should eq("bar")
     headers.empty?.should be_true
   end
 
-  it "equals another hash" do
+  it("equals another hash") do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers.should eq({"foo" => "bar"})
   end
 
-  it "dups" do
+  it("dups") do
     headers = HTTP::Headers{"Foo" => "bar"}
     other = headers.dup
     other.should be_a(HTTP::Headers)
@@ -91,7 +91,7 @@ describe HTTP::Headers do
     headers["baz"]?.should be_nil
   end
 
-  it "clones" do
+  it("clones") do
     headers = HTTP::Headers{"Foo" => "bar"}
     other = headers.clone
     other.should be_a(HTTP::Headers)
@@ -101,21 +101,21 @@ describe HTTP::Headers do
     headers["baz"]?.should be_nil
   end
 
-  it "adds string" do
+  it("adds string") do
     headers = HTTP::Headers.new
     headers.add("foo", "bar")
     headers.add("foo", "baz")
     headers["foo"].should eq("bar,baz")
   end
 
-  it "adds array of string" do
+  it("adds array of string") do
     headers = HTTP::Headers.new
     headers.add("foo", "bar")
     headers.add("foo", ["baz", "qux"])
     headers["foo"].should eq("bar,baz,qux")
   end
 
-  it "gets all values" do
+  it("gets all values") do
     headers = HTTP::Headers{"foo" => "bar"}
     headers.get("foo").should eq(["bar"])
 
@@ -123,31 +123,31 @@ describe HTTP::Headers do
     headers.get?("qux").should be_nil
   end
 
-  it "does to_s" do
+  it("does to_s") do
     headers = HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}
     headers.to_s.should eq(%(HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}))
   end
 
-  it "merges and return self" do
+  it("merges and return self") do
     headers = HTTP::Headers.new
     headers.should be headers.merge!({"foo" => "bar"})
   end
 
-  it "matches word" do
+  it("matches word") do
     headers = HTTP::Headers{"foo" => "bar"}
     headers.includes_word?("foo", "bar").should be_true
     headers.includes_word?("foo", "ba").should be_false
     headers.includes_word?("foo", "ar").should be_false
   end
 
-  it "matches word with comma separated value" do
+  it("matches word with comma separated value") do
     headers = HTTP::Headers{"foo" => "bar, baz"}
     headers.includes_word?("foo", "bar").should be_true
     headers.includes_word?("foo", "baz").should be_true
     headers.includes_word?("foo", "ba").should be_false
   end
 
-  it "matches word with comma separated value, case insensitive (#3626)" do
+  it("matches word with comma separated value, case insensitive (#3626)") do
     headers = HTTP::Headers{"foo" => "BaR, BAZ"}
     headers.includes_word?("foo", "bar").should be_true
     headers.includes_word?("foo", "baz").should be_true
@@ -155,17 +155,17 @@ describe HTTP::Headers do
     headers.includes_word?("foo", "ba").should be_false
   end
 
-  it "doesn't match empty string" do
+  it("doesn't match empty string") do
     headers = HTTP::Headers{"foo" => "bar, baz"}
     headers.includes_word?("foo", "").should be_false
   end
 
-  it "matches word with comma separated value, partial match" do
+  it("matches word with comma separated value, partial match") do
     headers = HTTP::Headers{"foo" => "bar, bazo, baz"}
     headers.includes_word?("foo", "baz").should be_true
   end
 
-  it "matches word among headers" do
+  it("matches word among headers") do
     headers = HTTP::Headers.new
     headers.add("foo", "bar")
     headers.add("foo", "baz")
@@ -173,13 +173,13 @@ describe HTTP::Headers do
     headers.includes_word?("foo", "baz").should be_true
   end
 
-  it "does not matches word if missing header" do
+  it("does not matches word if missing header") do
     headers = HTTP::Headers.new
     headers.includes_word?("foo", "bar").should be_false
     headers.includes_word?("foo", "").should be_false
   end
 
-  it "can create header value with all US-ASCII visible chars (#2999)" do
+  it("can create header value with all US-ASCII visible chars (#2999)") do
     headers = HTTP::Headers.new
     value = (32..126).map(&.chr).join
     headers.add("foo", value)

--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -1,49 +1,49 @@
 require "spec"
 require "http"
 
-describe HTTP do
-  it "parses RFC 1123" do
+describe(HTTP) do
+  it("parses RFC 1123") do
     time = Time.new(1994, 11, 6, 8, 49, 37)
     HTTP.parse_time("Sun, 06 Nov 1994 08:49:37 GMT").should eq(time)
   end
 
-  it "parses RFC 1123 without day name" do
+  it("parses RFC 1123 without day name") do
     time = Time.new(1994, 11, 6, 8, 49, 37)
     HTTP.parse_time("06 Nov 1994 08:49:37 GMT").should eq(time)
   end
 
-  it "parses RFC 1036" do
+  it("parses RFC 1036") do
     time = Time.new(1994, 11, 6, 8, 49, 37)
     HTTP.parse_time("Sunday, 06-Nov-94 08:49:37 GMT").should eq(time)
   end
 
-  it "parses ANSI C" do
+  it("parses ANSI C") do
     time = Time.new(1994, 11, 6, 8, 49, 37)
     HTTP.parse_time("Sun Nov  6 08:49:37 1994").should eq(time)
     time2 = Time.new(1994, 11, 16, 8, 49, 37)
     HTTP.parse_time("Sun Nov 16 08:49:37 1994").should eq(time2)
   end
 
-  it "parses and is UTC (#2744)" do
+  it("parses and is UTC (#2744)") do
     date = "Mon, 09 Sep 2011 23:36:00 GMT"
     parsed_time = HTTP.parse_time(date).not_nil!
     parsed_time.kind.should eq(Time::Kind::Utc)
   end
 
-  it "parses and is local (#2744)" do
+  it("parses and is local (#2744)") do
     date = "Mon, 09 Sep 2011 23:36:00 -0300"
     parsed_time = HTTP.parse_time(date).not_nil!
     parsed_time.kind.should eq(Time::Kind::Local)
     parsed_time.to_utc.to_s.should eq("2011-09-10 02:36:00 UTC")
   end
 
-  describe "generates RFC 1123" do
-    it "without time zone" do
+  describe("generates RFC 1123") do
+    it("without time zone") do
       time = Time.new(1994, 11, 6, 8, 49, 37, 0, Time::Kind::Utc)
       HTTP.rfc1123_date(time).should eq("Sun, 06 Nov 1994 08:49:37 GMT")
     end
 
-    it "with local time zone" do
+    it("with local time zone") do
       tz = ENV["TZ"]?
       ENV["TZ"] = "Europe/Berlin"
       LibC.tzset
@@ -57,21 +57,21 @@ describe HTTP do
     end
   end
 
-  describe ".dequote_string" do
-    it "dequotes a string" do
+  describe(".dequote_string") do
+    it("dequotes a string") do
       HTTP.dequote_string(%q(foo\"\\bar\ baz\\)).should eq(%q(foo"\bar baz\))
     end
   end
 
-  describe ".quote_string" do
-    it "quotes a string" do
+  describe(".quote_string") do
+    it("quotes a string") do
       HTTP.quote_string("foo!#():;?~").should eq("foo!#():;?~")
       HTTP.quote_string(%q(foo"bar\baz)).should eq(%q(foo\"bar\\baz))
       HTTP.quote_string("\t ").should eq("\\\t\\ ")
       HTTP.quote_string("it works 😂😂😂👌👌👌😂😂😂").should eq("it\\ works\\ 😂😂😂👌👌👌😂😂😂")
     end
 
-    it "raises on invalid characters" do
+    it("raises on invalid characters") do
       expect_raises(ArgumentError, "String contained invalid character") do
         HTTP.quote_string("foo\0bar")
       end
@@ -86,12 +86,12 @@ describe HTTP do
     end
   end
 
-  describe ".default_status_message_for" do
-    it "returns a default message for status 200" do
+  describe(".default_status_message_for") do
+    it("returns a default message for status 200") do
       HTTP.default_status_message_for(200).should eq("OK")
     end
 
-    it "returns an empty string on non-existent status" do
+    it("returns an empty string on non-existent status") do
       HTTP.default_status_message_for(0).should eq("")
     end
   end

--- a/spec/std/http/multipart/builder_spec.cr
+++ b/spec/std/http/multipart/builder_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http"
 
-describe HTTP::Multipart::Builder do
-  it "generates valid multipart messages" do
+describe(HTTP::Multipart::Builder) do
+  it("generates valid multipart messages") do
     io = IO::Memory.new
     builder = HTTP::Multipart::Builder.new(io, "fixed-boundary")
 
@@ -28,7 +28,7 @@ describe HTTP::Multipart::Builder do
     io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
   end
 
-  it "generates valid multipart messages with preamble and epilogue" do
+  it("generates valid multipart messages with preamble and epilogue") do
     io = IO::Memory.new
     builder = HTTP::Multipart::Builder.new(io, "fixed-boundary")
 
@@ -62,15 +62,15 @@ describe HTTP::Multipart::Builder do
     io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
   end
 
-  describe "#content_type" do
-    it "calculates the content type" do
+  describe("#content_type") do
+    it("calculates the content type") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new, "a delimiter string with a quote in \"")
       builder.content_type("alternative").should eq(%q(multipart/alternative; boundary="a\ delimiter\ string\ with\ a\ quote\ in\ \""))
     end
   end
 
-  describe ".preamble" do
-    it "accepts different data types" do
+  describe(".preamble") do
+    it("accepts different data types") do
       io = IO::Memory.new
       builder = HTTP::Multipart::Builder.new(io, "boundary")
 
@@ -102,7 +102,7 @@ describe HTTP::Multipart::Builder do
       generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
     end
 
-    it "raises when called after starting the body" do
+    it("raises when called after starting the body") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       builder.body_part HTTP::Headers.new, "test"
@@ -112,8 +112,8 @@ describe HTTP::Multipart::Builder do
     end
   end
 
-  describe ".body_part" do
-    it "accepts different data types" do
+  describe(".body_part") do
+    it("accepts different data types") do
       io = IO::Memory.new
       builder = HTTP::Multipart::Builder.new(io, "boundary")
 
@@ -159,7 +159,7 @@ describe HTTP::Multipart::Builder do
       generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
     end
 
-    it "raises when called after finishing" do
+    it("raises when called after finishing") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       builder.body_part HTTP::Headers.new, "test"
@@ -169,7 +169,7 @@ describe HTTP::Multipart::Builder do
       end
     end
 
-    it "raises when called after epilogue" do
+    it("raises when called after epilogue") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       builder.body_part HTTP::Headers.new, "test"
@@ -180,8 +180,8 @@ describe HTTP::Multipart::Builder do
     end
   end
 
-  describe ".epilogue" do
-    it "accepts different data types" do
+  describe(".epilogue") do
+    it("accepts different data types") do
       io = IO::Memory.new
       builder = HTTP::Multipart::Builder.new(io, "boundary")
 
@@ -214,7 +214,7 @@ describe HTTP::Multipart::Builder do
       generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
     end
 
-    it "raises when called after finishing" do
+    it("raises when called after finishing") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       builder.body_part HTTP::Headers.new, "test"
@@ -225,7 +225,7 @@ describe HTTP::Multipart::Builder do
       end
     end
 
-    it "raises when called with no body parts" do
+    it("raises when called with no body parts") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       expect_raises(HTTP::Multipart::Error, "Cannot generate epilogue: no body parts") do
@@ -240,8 +240,8 @@ describe HTTP::Multipart::Builder do
     end
   end
 
-  describe ".finish" do
-    it "raises if no body exists" do
+  describe(".finish") do
+    it("raises if no body exists") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       expect_raises(HTTP::Multipart::Error, "Cannot finish multipart: no body parts") do
@@ -255,7 +255,7 @@ describe HTTP::Multipart::Builder do
       end
     end
 
-    it "raises if already finished" do
+    it("raises if already finished") do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new)
 
       builder.body_part HTTP::Headers.new, "test"

--- a/spec/std/http/multipart/parser_spec.cr
+++ b/spec/std/http/multipart/parser_spec.cr
@@ -12,8 +12,8 @@ private def parse(delim, data, *, gsub = true)
   parsed
 end
 
-describe HTTP::Multipart::Parser do
-  it "parses basic multipart messages" do
+describe(HTTP::Multipart::Parser) do
+  it("parses basic multipart messages") do
     data = parse "AaB03x", <<-MULTIPART
       --AaB03x
       Content-Disposition: form-data; name="submit-name"
@@ -35,7 +35,7 @@ describe HTTP::Multipart::Parser do
     data[1][:headers]["Content-Type"].should eq("text/plain")
   end
 
-  it "parses messages with preambles and epilogues" do
+  it("parses messages with preambles and epilogues") do
     data = parse "AaB03x", <<-MULTIPART
       preamble
       AaB03x
@@ -59,7 +59,7 @@ describe HTTP::Multipart::Parser do
     data[1][:headers]["Content-Disposition"].should eq("form-data; name=\"bar\"")
   end
 
-  it "handles invalid multipart data" do
+  it("handles invalid multipart data") do
     expect_raises(HTTP::Multipart::Error, "EOF reading delimiter") do
       parse "AaB03x", "--AaB03x", gsub: false
     end
@@ -77,12 +77,12 @@ describe HTTP::Multipart::Parser do
     end
   end
 
-  it "handles padding" do
+  it("handles padding") do
     data = parse "AaB03x", "--AaB03x  \t\t  \r\n\r\n--AaB03x--", gsub: false
     data[0][:body].should eq("")
   end
 
-  it "raises calling #next after finished" do
+  it("raises calling #next after finished") do
     input = <<-MULTIPART
       --AaB03x
 
@@ -99,7 +99,7 @@ describe HTTP::Multipart::Parser do
     end
   end
 
-  it "raises calling #next after errored" do
+  it("raises calling #next after errored") do
     parser = HTTP::Multipart::Parser.new(IO::Memory.new("--AaB03x--"), "AaB03x")
 
     expect_raises(HTTP::Multipart::Error, "no parts") do
@@ -113,7 +113,7 @@ describe HTTP::Multipart::Parser do
     end
   end
 
-  it "handles break/next in blocks" do
+  it("handles break/next in blocks") do
     input = <<-MULTIPART
       --b
 

--- a/spec/std/http/multipart_spec.cr
+++ b/spec/std/http/multipart_spec.cr
@@ -1,9 +1,9 @@
 require "spec"
 require "http"
 
-describe HTTP::Multipart do
-  describe ".parse" do
-    it "parses multipart messages" do
+describe(HTTP::Multipart) do
+  describe(".parse") do
+    it("parses multipart messages") do
       multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nabcd\r\n--aA40--"
       HTTP::Multipart.parse(IO::Memory.new(multipart), "aA40") do |headers, io|
         headers["Content-Type"].should eq("text/plain")
@@ -12,20 +12,20 @@ describe HTTP::Multipart do
     end
   end
 
-  describe ".parse_boundary" do
-    it "parses unquoted boundaries" do
+  describe(".parse_boundary") do
+    it("parses unquoted boundaries") do
       content_type = "multipart/mixed; boundary=a_-47HDS"
       HTTP::Multipart.parse_boundary(content_type).should eq("a_-47HDS")
     end
 
-    it "parses quoted boundaries" do
+    it("parses quoted boundaries") do
       content_type = %{multipart/mixed; boundary="aA_-<>()"}
       HTTP::Multipart.parse_boundary(content_type).should eq(%{aA_-<>()})
     end
   end
 
-  describe ".parse" do
-    it "parses multipart messages" do
+  describe(".parse") do
+    it("parses multipart messages") do
       headers = HTTP::Headers{"Content-Type" => "multipart/mixed; boundary=aA40"}
       body = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
       request = HTTP::Request.new("POST", "/", headers, body)

--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "http/params"
 
 module HTTP
-  describe Params do
-    describe ".parse" do
+  describe(Params) do
+    describe(".parse") do
       {
         {"", {} of String => Array(String)},
         {"   ", {"   " => [""]}},
@@ -19,13 +19,13 @@ module HTTP
         {"bar&foo", {"bar" => [""], "foo" => [""]}},
         {"foo=bar=qux", {"foo" => ["bar=qux"]}},
       }.each do |(from, to)|
-        it "parses #{from}" do
+        it("parses #{from}") do
           Params.parse(from).should eq(Params.new(to))
         end
       end
     end
 
-    describe ".build" do
+    describe(".build") do
       {
         {"foo=bar", {"foo" => ["bar"]}},
         {"foo=bar&foo=baz", {"foo" => ["bar", "baz"]}},
@@ -36,7 +36,7 @@ module HTTP
         {"foo=&bar=", {"foo" => [""], "bar" => [""]}},
         {"bar=&foo=", {"bar" => [""], "foo" => [""]}},
       }.each do |(to, from)|
-        it "builds form from #{from}" do
+        it("builds form from #{from}") do
           encoded = Params.build do |form|
             from.each do |key, values|
               values.each do |value|
@@ -50,123 +50,123 @@ module HTTP
       end
     end
 
-    describe ".encode" do
-      it "builds from hash" do
+    describe(".encode") do
+      it("builds from hash") do
         encoded = Params.encode({"foo" => "bar", "baz" => "quux"})
         encoded.should eq("foo=bar&baz=quux")
       end
 
-      it "builds from named tuple" do
+      it("builds from named tuple") do
         encoded = Params.encode({foo: "bar", baz: "quux"})
         encoded.should eq("foo=bar&baz=quux")
       end
     end
 
-    describe "#to_s" do
-      it "serializes params to http form" do
+    describe("#to_s") do
+      it("serializes params to http form") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.to_s.should eq("foo=bar&foo=baz&baz=qux")
       end
     end
 
-    describe "#[](name)" do
-      it "returns first value for provided param name" do
+    describe("#[](name)") do
+      it("returns first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["foo"].should eq("bar")
         params["baz"].should eq("qux")
       end
 
-      it "raises KeyError when there is no such param" do
+      it("raises KeyError when there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
-        expect_raises KeyError do
+        expect_raises(KeyError) do
           params["non_existent_param"]
         end
       end
     end
 
-    describe "#[]?(name)" do
-      it "returns first value for provided param name" do
+    describe("#[]?(name)") do
+      it("returns first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["foo"]?.should eq("bar")
         params["baz"]?.should eq("qux")
       end
 
-      it "return nil when there is no such param" do
+      it("return nil when there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["non_existent_param"]?.should eq(nil)
       end
     end
 
-    describe "#has_key?(name)" do
-      it "returns true if param with provided name exists" do
+    describe("#has_key?(name)") do
+      it("returns true if param with provided name exists") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.has_key?("foo").should eq(true)
         params.has_key?("baz").should eq(true)
       end
 
-      it "return false if param with provided name does not exist" do
+      it("return false if param with provided name does not exist") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.has_key?("non_existent_param").should eq(false)
       end
     end
 
-    describe "#[]=(name, value)" do
-      it "sets first value for provided param name" do
+    describe("#[]=(name, value)") do
+      it("sets first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["foo"] = "notfoo"
         params.fetch_all("foo").should eq(["notfoo", "baz"])
       end
 
-      it "adds new name => value pair if there is no such param" do
+      it("adds new name => value pair if there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["non_existent_param"] = "test"
         params.fetch_all("non_existent_param").should eq(["test"])
       end
     end
 
-    describe "#fetch(name)" do
-      it "returns first value for provided param name" do
+    describe("#fetch(name)") do
+      it("returns first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.fetch("foo").should eq("bar")
         params.fetch("baz").should eq("qux")
       end
 
-      it "raises KeyError when there is no such param" do
+      it("raises KeyError when there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
-        expect_raises KeyError do
+        expect_raises(KeyError) do
           params.fetch("non_existent_param")
         end
       end
     end
 
-    describe "#fetch(name, default)" do
-      it "returns first value for provided param name" do
+    describe("#fetch(name, default)") do
+      it("returns first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.fetch("foo", "aDefault").should eq("bar")
         params.fetch("baz", "aDefault").should eq("qux")
       end
 
-      it "return default value when there is no such param" do
+      it("return default value when there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.fetch("non_existent_param", "aDefault").should eq("aDefault")
       end
     end
 
-    describe "#fetch(name, &block)" do
-      it "returns first value for provided param name" do
+    describe("#fetch(name, &block)") do
+      it("returns first value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.fetch("foo") { "fromBlock" }.should eq("bar")
         params.fetch("baz") { "fromBlock" }.should eq("qux")
       end
 
-      it "return default value when there is no such param" do
+      it("return default value when there is no such param") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params.fetch("non_existent_param") { "fromBlock" }.should eq("fromBlock")
       end
     end
 
-    describe "#fetch_all(name)" do
-      it "fetches list of all values for provided param name" do
+    describe("#fetch_all(name)") do
+      it("fetches list of all values for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux&iamempty")
         params.fetch_all("foo").should eq(["bar", "baz"])
         params.fetch_all("baz").should eq(["qux"])
@@ -175,8 +175,8 @@ module HTTP
       end
     end
 
-    describe "#add(name, value)" do
-      it "appends new value for provided param name" do
+    describe("#add(name, value)") do
+      it("appends new value for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux&iamempty")
 
         params.add("foo", "zeit")
@@ -193,8 +193,8 @@ module HTTP
       end
     end
 
-    describe "#set_all(name, values)" do
-      it "sets values for provided param name" do
+    describe("#set_all(name, values)") do
+      it("sets values for provided param name") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
 
         params.set_all("baz", ["hello", "world"])
@@ -208,8 +208,8 @@ module HTTP
       end
     end
 
-    describe "#each" do
-      it "calls provided proc for each name, value pair, including multiple values per one param name" do
+    describe("#each") do
+      it("calls provided proc for each name, value pair, including multiple values per one param name") do
         received = [] of {String, String}
 
         params = Params.parse("foo=bar&foo=baz&baz=qux")
@@ -225,26 +225,26 @@ module HTTP
       end
     end
 
-    describe "#delete" do
-      it "deletes first value for provided param name and returns it" do
+    describe("#delete") do
+      it("deletes first value for provided param name and returns it") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
 
         params.delete("foo").should eq("bar")
         params.fetch_all("foo").should eq(["baz"])
 
         params.delete("baz").should eq("qux")
-        expect_raises KeyError do
+        expect_raises(KeyError) do
           params.fetch("baz")
         end
       end
     end
 
-    describe "#delete_all" do
-      it "deletes all values for provided param name and returns them" do
+    describe("#delete_all") do
+      it("deletes all values for provided param name and returns them") do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
 
         params.delete_all("foo").should eq(["bar", "baz"])
-        expect_raises KeyError do
+        expect_raises(KeyError) do
           params.fetch("foo")
         end
       end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "http/request"
 
 module HTTP
-  describe Request do
-    it "serialize GET" do
+  describe(Request) do
+    it("serialize GET") do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
       orignal_headers = headers.dup
@@ -15,7 +15,7 @@ module HTTP
       headers.should eq(orignal_headers)
     end
 
-    it "serialize GET (with query params)" do
+    it("serialize GET (with query params)") do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
       orignal_headers = headers.dup
@@ -27,7 +27,7 @@ module HTTP
       headers.should eq(orignal_headers)
     end
 
-    it "serialize GET (with cookie)" do
+    it("serialize GET (with cookie)") do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
       orignal_headers = headers.dup
@@ -40,7 +40,7 @@ module HTTP
       headers.should eq(orignal_headers)
     end
 
-    it "serialize GET (with cookies, from headers)" do
+    it("serialize GET (with cookies, from headers)") do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
       headers["Cookie"] = "foo=bar"
@@ -67,28 +67,28 @@ module HTTP
       headers.should eq(orignal_headers)
     end
 
-    it "serialize POST (with body)" do
+    it("serialize POST (with body)") do
       request = Request.new "POST", "/", body: "thisisthebody"
       io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
     end
 
-    it "serialize POST (with bytes body)" do
+    it("serialize POST (with bytes body)") do
       request = Request.new "POST", "/", body: Bytes['a'.ord, 'b'.ord]
       io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nab")
     end
 
-    it "serialize POST (with io body, without content-length header)" do
+    it("serialize POST (with io body, without content-length header)") do
       request = Request.new "POST", "/", body: IO::Memory.new("thisisthebody")
       io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nd\r\nthisisthebody\r\n0\r\n\r\n")
     end
 
-    it "serialize POST (with io body, with content-length header)" do
+    it("serialize POST (with io body, with content-length header)") do
       string = "thisisthebody"
       request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize
@@ -97,7 +97,7 @@ module HTTP
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
     end
 
-    it "raises if serializing POST body with incorrect content-length (less then real)" do
+    it("raises if serializing POST body with incorrect content-length (less then real)") do
       string = "thisisthebody"
       request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize - 1
@@ -107,7 +107,7 @@ module HTTP
       end
     end
 
-    it "raises if serializing POST body with incorrect content-length (more then real)" do
+    it("raises if serializing POST body with incorrect content-length (more then real)") do
       string = "thisisthebody"
       request = Request.new "POST", "/", body: IO::Memory.new(string)
       request.content_length = string.bytesize + 1
@@ -117,35 +117,35 @@ module HTTP
       end
     end
 
-    it "parses GET" do
+    it("parses GET") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
-    it "parses GET with query params" do
+    it("parses GET with query params") do
       request = Request.from_io(IO::Memory.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/greet")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
-    it "parses GET without \\r" do
+    it("parses GET without \\r") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
-    it "parses empty header" do
+    it("parses empty header") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
       request.headers.should eq({"Host" => "host.example.org", "Referer" => ""})
     end
 
-    it "parses GET with cookie" do
+    it("parses GET with cookie") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: a=b\r\n\r\n")).as(Request)
       request.method.should eq("GET")
       request.path.should eq("/")
@@ -155,7 +155,7 @@ module HTTP
       request.headers.should eq({"Host" => "host.example.org", "Cookie" => "a=b"})
     end
 
-    it "headers are case insensitive" do
+    it("headers are case insensitive") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
       headers = request.headers.not_nil!
       headers["HOST"].should eq("host.example.org")
@@ -163,7 +163,7 @@ module HTTP
       headers["Host"].should eq("host.example.org")
     end
 
-    it "parses POST (with body)" do
+    it("parses POST (with body)") do
       request = Request.from_io(IO::Memory.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).as(Request)
       request.method.should eq("POST")
       request.path.should eq("/foo")
@@ -171,28 +171,28 @@ module HTTP
       request.body.not_nil!.gets_to_end.should eq("thisisthebody")
     end
 
-    it "handles malformed request" do
+    it("handles malformed request") do
       request = Request.from_io(IO::Memory.new("nonsense"))
       request.should be_a(Request::BadRequest)
     end
 
-    it "handles long request lines" do
+    it("handles long request lines") do
       request = Request.from_io(IO::Memory.new("GET /#{"a" * 4096} HTTP/1.1\r\n\r\n"))
       request.should be_a(Request::BadRequest)
     end
 
-    it "handles long headers" do
+    it("handles long headers") do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
       request.should be_a(Request::BadRequest)
     end
 
-    describe "keep-alive" do
-      it "is false by default in HTTP/1.0" do
+    describe("keep-alive") do
+      it("is false by default in HTTP/1.0") do
         request = Request.new "GET", "/", version: "HTTP/1.0"
         request.keep_alive?.should be_false
       end
 
-      it "is true in HTTP/1.0 if `Connection: keep-alive` header is present" do
+      it("is true in HTTP/1.0 if `Connection: keep-alive` header is present") do
         headers = HTTP::Headers.new
         headers["Connection"] = "keep-alive"
         orignal_headers = headers.dup
@@ -201,12 +201,12 @@ module HTTP
         headers.should eq(orignal_headers)
       end
 
-      it "is true by default in HTTP/1.1" do
+      it("is true by default in HTTP/1.1") do
         request = Request.new "GET", "/", version: "HTTP/1.1"
         request.keep_alive?.should be_true
       end
 
-      it "is false in HTTP/1.1 if `Connection: close` header is present" do
+      it("is false in HTTP/1.1 if `Connection: close` header is present") do
         headers = HTTP::Headers.new
         headers["Connection"] = "close"
         orignal_headers = headers.dup
@@ -216,33 +216,33 @@ module HTTP
       end
     end
 
-    describe "#path" do
-      it "returns parsed path" do
+    describe("#path") do
+      it("returns parsed path") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path.should eq("/api/v3/some/resource")
       end
 
-      it "falls back to /" do
+      it("falls back to /") do
         request = Request.new("GET", "/foo")
         request.path = nil
         request.path.should eq("/")
       end
     end
 
-    describe "#path=" do
-      it "sets path" do
+    describe("#path=") do
+      it("sets path") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
         request.path.should eq("/api/v2/greet")
       end
 
-      it "updates @resource" do
+      it("updates @resource") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
         request.resource.should eq("/api/v2/greet?filter=hello&world=test")
       end
 
-      it "updates serialized form" do
+      it("updates serialized form") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.path = "/api/v2/greet"
 
@@ -252,27 +252,27 @@ module HTTP
       end
     end
 
-    describe "#query" do
-      it "returns request's query" do
+    describe("#query") do
+      it("returns request's query") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query.should eq("filter=hello&world=test")
       end
     end
 
-    describe "#query=" do
-      it "sets query" do
+    describe("#query=") do
+      it("sets query") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
         request.query.should eq("q=isearchforsomething&locale=de")
       end
 
-      it "updates @resource" do
+      it("updates @resource") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
         request.resource.should eq("/api/v3/some/resource?q=isearchforsomething&locale=de")
       end
 
-      it "updates serialized form" do
+      it("updates serialized form") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query = "q=isearchforsomething&locale=de"
 
@@ -282,8 +282,8 @@ module HTTP
       end
     end
 
-    describe "#query_params" do
-      it "returns parsed HTTP::Params" do
+    describe("#query_params") do
+      it("returns parsed HTTP::Params") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
@@ -292,14 +292,14 @@ module HTTP
         params["baz"].should eq("qux")
       end
 
-      it "happily parses when query is not a canonical url-encoded string" do
+      it("happily parses when query is not a canonical url-encoded string") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?{\"hello\":\"world\"} HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
         params["{\"hello\":\"world\"}"].should eq("")
         params.to_s.should eq("%7B%22hello%22%3A%22world%22%7D=")
       end
 
-      it "affects #query when modified" do
+      it("affects #query when modified") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
@@ -307,7 +307,7 @@ module HTTP
         request.query.should eq("foo=not-bar&foo=baz&baz=qux")
       end
 
-      it "updates @resource when modified" do
+      it("updates @resource when modified") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
@@ -315,7 +315,7 @@ module HTTP
         request.resource.should eq("/api/v3/some/resource?foo=not-bar&foo=baz&baz=qux")
       end
 
-      it "updates serialized form when modified" do
+      it("updates serialized form when modified") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
@@ -326,7 +326,7 @@ module HTTP
         io.to_s.should eq("GET /api/v3/some/resource?foo=not-bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")
       end
 
-      it "is affected when #query is modified" do
+      it("is affected when #query is modified") do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
         params = request.query_params
 
@@ -335,12 +335,12 @@ module HTTP
         request.query_params.to_s.should eq(new_query)
       end
 
-      it "gets request host from the headers" do
+      it("gets request host from the headers") do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
         request.host.should eq("host.example.org")
       end
 
-      it "gets request host with port from the headers" do
+      it("gets request host with port from the headers") do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
         request.host_with_port.should eq("host.example.org:3000")
       end

--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http/server"
 
-describe HTTP::CompressHandler do
-  it "doesn't deflates if doesn't have 'deflate' in Accept-Encoding header" do
+describe(HTTP::CompressHandler) do
+  it("doesn't deflates if doesn't have 'deflate' in Accept-Encoding header") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
@@ -19,7 +19,7 @@ describe HTTP::CompressHandler do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello")
   end
 
-  it "deflates if has deflate in 'deflate' Accept-Encoding header" do
+  it("deflates if has deflate in 'deflate' Accept-Encoding header") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, deflate, other"
@@ -47,7 +47,7 @@ describe HTTP::CompressHandler do
     body.to_slice.should eq(io2.to_slice)
   end
 
-  it "deflates gzip if has deflate in 'deflate' Accept-Encoding header" do
+  it("deflates gzip if has deflate in 'deflate' Accept-Encoding header") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     request.headers["Accept-Encoding"] = "foo, gzip, other"

--- a/spec/std/http/server/handlers/error_handler_spec.cr
+++ b/spec/std/http/server/handlers/error_handler_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http/server"
 
-describe HTTP::ErrorHandler do
-  it "rescues from exception" do
+describe(HTTP::ErrorHandler) do
+  it("rescues from exception") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
@@ -21,7 +21,7 @@ describe HTTP::ErrorHandler do
     (response2.body =~ /ERROR: OH NO!/).should be_truthy
   end
 
-  it "can return a generic error message" do
+  it("can return a generic error message") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)

--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -9,8 +9,8 @@ private class EmptyHTTPHandler
   end
 end
 
-describe HTTP::Handler do
-  it "responds with not found if there's no next handler" do
+describe(HTTP::Handler) do
+  it("responds with not found if there's no next handler") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http/server"
 
-describe HTTP::LogHandler do
-  it "logs" do
+describe(HTTP::LogHandler) do
+  it("logs") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
@@ -17,7 +17,7 @@ describe HTTP::LogHandler do
     called.should be_true
   end
 
-  it "does log errors" do
+  it("does log errors") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -12,42 +12,42 @@ private def handle(request, fallthrough = true, directory_listing = true)
   HTTP::Client::Response.from_io(io)
 end
 
-describe HTTP::StaticFileHandler do
+describe(HTTP::StaticFileHandler) do
   file_text = File.read "#{__DIR__}/static/test.txt"
 
-  it "should serve a file" do
+  it("should serve a file") do
     response = handle HTTP::Request.new("GET", "/test.txt")
     response.status_code.should eq(200)
     response.body.should eq(File.read("#{__DIR__}/static/test.txt"))
   end
 
-  it "should list directory's entries" do
+  it("should list directory's entries") do
     response = handle HTTP::Request.new("GET", "/")
     response.status_code.should eq(200)
     response.body.should match(/test.txt/)
   end
 
-  it "should not list directory's entries when directory_listing is set to false" do
+  it("should not list directory's entries when directory_listing is set to false") do
     response = handle HTTP::Request.new("GET", "/"), directory_listing: false
     response.status_code.should eq(404)
   end
 
-  it "should not serve a not found file" do
+  it("should not serve a not found file") do
     response = handle HTTP::Request.new("GET", "/not_found_file.txt")
     response.status_code.should eq(404)
   end
 
-  it "should not serve a not found directory" do
+  it("should not serve a not found directory") do
     response = handle HTTP::Request.new("GET", "/not_found_dir/")
     response.status_code.should eq(404)
   end
 
-  it "should not serve a file as directory" do
+  it("should not serve a file as directory") do
     response = handle HTTP::Request.new("GET", "/test.txt/")
     response.status_code.should eq(404)
   end
 
-  it "should handle only GET and HEAD method" do
+  it("should handle only GET and HEAD method") do
     %w(GET HEAD).each do |method|
       response = handle HTTP::Request.new(method, "/test.txt")
       response.status_code.should eq(200)
@@ -62,7 +62,7 @@ describe HTTP::StaticFileHandler do
     end
   end
 
-  it "should expand a request path" do
+  it("should expand a request path") do
     %w(../test.txt ../../test.txt test.txt/../test.txt a/./b/../c/../../test.txt).each do |path|
       response = handle HTTP::Request.new("GET", "/#{path}")
       response.status_code.should eq(302)
@@ -77,7 +77,7 @@ describe HTTP::StaticFileHandler do
     end
   end
 
-  it "should unescape a request path" do
+  it("should unescape a request path") do
     %w(test%2Etxt %74%65%73%74%2E%74%78%74).each do |path|
       response = handle HTTP::Request.new("GET", "/#{path}")
       response.status_code.should eq(200)
@@ -91,7 +91,7 @@ describe HTTP::StaticFileHandler do
     end
   end
 
-  it "should return 400" do
+  it("should return 400") do
     %w(%00 test.txt%00).each do |path|
       response = handle HTTP::Request.new("GET", "/#{path}")
       response.status_code.should eq(400)

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "http/server"
 
-describe HTTP::WebSocketHandler do
-  it "returns not found if the request is not an websocket upgrade" do
+describe(HTTP::WebSocketHandler) do
+  it("returns not found if the request is not an websocket upgrade") do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")
     response = HTTP::Server::Response.new(io)
@@ -18,7 +18,7 @@ describe HTTP::WebSocketHandler do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello")
   end
 
-  it "returns not found if the request Upgrade is invalid" do
+  it("returns not found if the request Upgrade is invalid") do
     io = IO::Memory.new
 
     headers = HTTP::Headers{
@@ -67,7 +67,7 @@ describe HTTP::WebSocketHandler do
     end
   {% end %}
 
-  it "gives upgrade response for case-insensitive 'WebSocket' upgrade request" do
+  it("gives upgrade response for case-insensitive 'WebSocket' upgrade request") do
     io = IO::Memory.new
     headers = HTTP::Headers{
       "Upgrade"           => "WebSocket",

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -46,15 +46,15 @@ end
 
 module HTTP
   class Server
-    describe Response do
-      it "closes" do
+    describe(Response) do
+      it("closes") do
         io = IO::Memory.new
         response = Response.new(io)
         response.close
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
       end
 
-      it "prints less then buffer's size" do
+      it("prints less then buffer's size") do
         io = IO::Memory.new
         response = Response.new(io)
         response.print("Hello")
@@ -62,7 +62,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello")
       end
 
-      it "prints less then buffer's size to output" do
+      it("prints less then buffer's size to output") do
         io = IO::Memory.new
         response = Response.new(io)
         response.output.print("Hello")
@@ -70,7 +70,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHello")
       end
 
-      it "prints more then buffer's size" do
+      it("prints more then buffer's size") do
         io = IO::Memory.new
         response = Response.new(io)
         str = "1234567890"
@@ -83,7 +83,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1ffe\r\n#{first_chunk}\r\n712\r\n#{second_chunk}\r\n0\r\n\r\n")
       end
 
-      it "prints with content length" do
+      it("prints with content length") do
         io = IO::Memory.new
         response = Response.new(io)
         response.headers["Content-Length"] = "10"
@@ -93,7 +93,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n1234567890")
       end
 
-      it "prints with content length (method)" do
+      it("prints with content length (method)") do
         io = IO::Memory.new
         response = Response.new(io)
         response.content_length = 10
@@ -103,7 +103,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n1234567890")
       end
 
-      it "adds header" do
+      it("adds header") do
         io = IO::Memory.new
         response = Response.new(io)
         response.headers["Content-Type"] = "text/plain"
@@ -112,7 +112,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nHello")
       end
 
-      it "sets content type" do
+      it("sets content type") do
         io = IO::Memory.new
         response = Response.new(io)
         response.content_type = "text/plain"
@@ -121,7 +121,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nHello")
       end
 
-      it "changes status and others" do
+      it("changes status and others") do
         io = IO::Memory.new
         response = Response.new(io)
         response.status_code = 404
@@ -130,7 +130,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.0 404 Not Found\r\nContent-Length: 0\r\n\r\n")
       end
 
-      it "flushes" do
+      it("flushes") do
         io = IO::Memory.new
         response = Response.new(io)
         response.print("Hello")
@@ -140,7 +140,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHello\r\n0\r\n\r\n")
       end
 
-      it "wraps output" do
+      it("wraps output") do
         io = IO::Memory.new
         response = Response.new(io)
         response.output = ReverseResponseOutput.new(response.output)
@@ -149,7 +149,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n4321")
       end
 
-      it "writes and flushes with HTTP 1.0" do
+      it("writes and flushes with HTTP 1.0") do
         io = IO::Memory.new
         response = Response.new(io, "HTTP/1.0")
         response.print("1234")
@@ -157,7 +157,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.0 200 OK\r\n\r\n1234")
       end
 
-      it "resets and clears headers and cookies" do
+      it("resets and clears headers and cookies") do
         io = IO::Memory.new
         response = Response.new(io)
         response.headers["Foo"] = "Bar"
@@ -167,7 +167,7 @@ module HTTP
         response.cookies.empty?.should be_true
       end
 
-      it "writes cookie headers" do
+      it("writes cookie headers") do
         io = IO::Memory.new
         response = Response.new(io)
         response.cookies["Bar"] = "Foo"
@@ -182,7 +182,7 @@ module HTTP
         io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\nHello")
       end
 
-      it "responds with an error" do
+      it("responds with an error") do
         io = IO::Memory.new
         response = Response.new(io)
         response.content_type = "text/html"
@@ -197,21 +197,21 @@ module HTTP
     end
   end
 
-  describe HTTP::Server do
-    it "re-sets special port zero after bind" do
+  describe(HTTP::Server) do
+    it("re-sets special port zero after bind") do
       server = Server.new(0) { |ctx| }
       server.bind
       server.port.should_not eq(0)
     end
 
-    it "re-sets port to zero after close" do
+    it("re-sets port to zero after close") do
       server = Server.new(0) { |ctx| }
       server.bind
       server.close
       server.port.should eq(0)
     end
 
-    it "doesn't raise on accept after close #2692" do
+    it("doesn't raise on accept after close #2692") do
       server = Server.new("0.0.0.0", 0) { }
 
       spawn do
@@ -222,7 +222,7 @@ module HTTP
       server.listen
     end
 
-    it "reuses the TCP port (SO_REUSEPORT)" do
+    it("reuses the TCP port (SO_REUSEPORT)") do
       s1 = Server.new(0) { |ctx| }
       s1.bind(reuse_port: true)
 
@@ -234,8 +234,8 @@ module HTTP
     end
   end
 
-  describe HTTP::Server::RequestProcessor do
-    it "works" do
+  describe(HTTP::Server::RequestProcessor) do
+    it("works") do
       processor = HTTP::Server::RequestProcessor.new do |context|
         context.response.content_type = "text/plain"
         context.response.print "Hello world"
@@ -256,7 +256,7 @@ module HTTP
       ))
     end
 
-    it "skips body between requests" do
+    it("skips body between requests") do
       processor = HTTP::Server::RequestProcessor.new do |context|
         context.response.content_type = "text/plain"
         context.response.puts "Hello world\r"
@@ -294,7 +294,7 @@ module HTTP
       ))
     end
 
-    it "handles Errno" do
+    it("handles Errno") do
       processor = HTTP::Server::RequestProcessor.new { }
       input = RaiseErrno.new(Errno::ECONNRESET)
       output = IO::Memory.new
@@ -302,7 +302,7 @@ module HTTP
       output.rewind.gets_to_end.empty?.should be_true
     end
 
-    it "catches raised error on handler" do
+    it("catches raised error on handler") do
       processor = HTTP::Server::RequestProcessor.new { raise "OH NO" }
       input = IO::Memory.new("GET / HTTP/1.1\r\n\r\n")
       output = IO::Memory.new

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -23,9 +23,9 @@ private def assert_packet(packet, opcode, size, final = false)
   packet.final.should eq(final)
 end
 
-describe HTTP::WebSocket do
-  describe "receive" do
-    it "can read a small text packet" do
+describe(HTTP::WebSocket) do
+  describe("receive") do
+    it("can read a small text packet") do
       data = Bytes[0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
       io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
@@ -36,7 +36,7 @@ describe HTTP::WebSocket do
       String.new(buffer[0, result.size]).should eq("Hello")
     end
 
-    it "can read partial packets" do
+    it("can read partial packets") do
       data = Bytes[0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
         0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
       io = IO::Memory.new(data)
@@ -55,7 +55,7 @@ describe HTTP::WebSocket do
       end
     end
 
-    it "can read masked text message" do
+    it("can read masked text message") do
       data = Bytes[0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58,
         0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58]
       io = IO::Memory.new(data)
@@ -74,7 +74,7 @@ describe HTTP::WebSocket do
       end
     end
 
-    it "can read fragmented packets" do
+    it("can read fragmented packets") do
       data = Bytes[0x01, 0x03, 0x48, 0x65, 0x6c, 0x80, 0x02, 0x6c, 0x6f,
         0x01, 0x03, 0x48, 0x65, 0x6c, 0x80, 0x02, 0x6c, 0x6f]
 
@@ -94,7 +94,7 @@ describe HTTP::WebSocket do
       end
     end
 
-    it "read ping packet" do
+    it("read ping packet") do
       data = Bytes[0x89, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
       io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
@@ -105,7 +105,7 @@ describe HTTP::WebSocket do
       String.new(buffer[0, result.size]).should eq("Hello")
     end
 
-    it "read ping packet in between fragmented packet" do
+    it("read ping packet in between fragmented packet") do
       data = Bytes[0x01, 0x03, 0x48, 0x65, 0x6c,
         0x89, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f,
         0x80, 0x02, 0x6c, 0x6f]
@@ -127,7 +127,7 @@ describe HTTP::WebSocket do
       String.new(buffer[0, 2]).should eq("lo")
     end
 
-    it "read long packet" do
+    it("read long packet") do
       data = File.read("#{__DIR__}/../data/websocket_longpacket.bin")
       io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
@@ -139,7 +139,7 @@ describe HTTP::WebSocket do
       String.new(buffer[0, 1023]).should eq("x" * 1023)
     end
 
-    it "read very long packet" do
+    it("read very long packet") do
       data = Bytes.new(10 + 0x010000)
 
       header = Bytes[0x82, 127_u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0]
@@ -154,7 +154,7 @@ describe HTTP::WebSocket do
       assert_binary_packet result, 0x010000, final: true
     end
 
-    it "can read a close packet" do
+    it("can read a close packet") do
       data = Bytes[0x88, 0x00]
       io = IO::Memory.new(data)
       ws = HTTP::WebSocket::Protocol.new(io)
@@ -165,8 +165,8 @@ describe HTTP::WebSocket do
     end
   end
 
-  describe "send" do
-    it "sends long data with correct header" do
+  describe("send") do
+    it("sends long data with correct header") do
       size = UInt16::MAX.to_u64 + 1
       big_string = "a" * size
       io = IO::Memory.new
@@ -183,7 +183,7 @@ describe HTTP::WebSocket do
       end
     end
 
-    it "sets binary opcode if used with slice" do
+    it("sets binary opcode if used with slice") do
       sent_bytes = uninitialized UInt8[4]
 
       io = IO::Memory.new
@@ -194,8 +194,8 @@ describe HTTP::WebSocket do
     end
   end
 
-  describe "stream" do
-    it "sends continuous data and splits it to frames" do
+  describe("stream") do
+    it("sends continuous data and splits it to frames") do
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.stream do |io| # default frame size of 1024
@@ -226,7 +226,7 @@ describe HTTP::WebSocket do
       end
     end
 
-    it "sets opcode of first frame to binary if stream is called with binary = true" do
+    it("sets opcode of first frame to binary if stream is called with binary = true") do
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.stream(binary: true) { |io| }
@@ -236,8 +236,8 @@ describe HTTP::WebSocket do
     end
   end
 
-  describe "send_masked" do
-    it "sends the data with a bitmask" do
+  describe("send_masked") do
+    it("sends the data with a bitmask") do
       sent_string = "hello"
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io, masked: true)
@@ -253,7 +253,7 @@ describe HTTP::WebSocket do
       (bytes[2] ^ bytes[10]).should eq('o'.ord)
     end
 
-    it "sends long data with correct header" do
+    it("sends long data with correct header") do
       size = UInt16::MAX.to_u64 + 1
       big_string = "a" * size
       io = IO::Memory.new
@@ -272,8 +272,8 @@ describe HTTP::WebSocket do
     end
   end
 
-  describe "close" do
-    it "closes with message" do
+  describe("close") do
+    it("closes with message") do
       message = "bye"
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
@@ -283,7 +283,7 @@ describe HTTP::WebSocket do
       String.new(bytes[2, bytes[1]]).should eq(message)
     end
 
-    it "closes without message" do
+    it("closes without message") do
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.close
@@ -293,7 +293,7 @@ describe HTTP::WebSocket do
     end
   end
 
-  it "negotiates over HTTP correctly" do
+  it("negotiates over HTTP correctly") do
     port_chan = Channel(Int32).new
 
     spawn do
@@ -330,7 +330,7 @@ describe HTTP::WebSocket do
     ws2.run
   end
 
-  it "negotiates over HTTPS correctly" do
+  it("negotiates over HTTPS correctly") do
     port_chan = Channel(Int32).new
 
     spawn do

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -14,28 +14,28 @@ private class SafeIndexable
   end
 end
 
-describe Indexable do
-  it "does index with big negative offset" do
+describe(Indexable) do
+  it("does index with big negative offset") do
     indexable = SafeIndexable.new(3)
     indexable.index(0, -100).should be_nil
   end
 
-  it "does index with big offset" do
+  it("does index with big offset") do
     indexable = SafeIndexable.new(3)
     indexable.index(0, 100).should be_nil
   end
 
-  it "does rindex with big negative offset" do
+  it("does rindex with big negative offset") do
     indexable = SafeIndexable.new(3)
     indexable.rindex(0, -100).should be_nil
   end
 
-  it "does rindex with big offset" do
+  it("does rindex with big offset") do
     indexable = SafeIndexable.new(3)
     indexable.rindex(0, 100).should be_nil
   end
 
-  it "does each" do
+  it("does each") do
     indexable = SafeIndexable.new(3)
     is = [] of Int32
     indexable.each do |i|
@@ -44,7 +44,7 @@ describe Indexable do
     is.should eq([0, 1, 2])
   end
 
-  it "does each_index" do
+  it("does each_index") do
     indexable = SafeIndexable.new(3)
     is = [] of Int32
     indexable.each_index do |i|

--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -1,25 +1,25 @@
 require "spec"
 require "ini"
 
-describe "INI" do
-  describe "parse from string" do
-    it "parses key = value" do
+describe("INI") do
+  describe("parse from string") do
+    it("parses key = value") do
       INI.parse("key = value").should eq({"" => {"key" => "value"}})
     end
 
-    it "ignores whitespaces" do
+    it("ignores whitespaces") do
       INI.parse("   key   =   value  ").should eq({"" => {"key" => "value"}})
     end
 
-    it "parses sections" do
+    it("parses sections") do
       INI.parse("[section]\na = 1").should eq({"section" => {"a" => "1"}})
     end
 
-    it "empty section" do
+    it("empty section") do
       INI.parse("[section]").should eq({"section" => {} of String => String})
     end
 
-    it "parse file" do
+    it("parse file") do
       INI.parse(File.read "#{__DIR__}/data/test_file.ini").should eq({
         "general" => {
           "log_level" => "DEBUG",

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -9,9 +9,9 @@ private def to_s_with_io(num, base, upcase = false)
   String.build { |str| num.to_s(base, str, upcase) }
 end
 
-describe "Int" do
-  describe "**" do
-    it "with positive Int32" do
+describe("Int") do
+  describe("**") do
+    it("with positive Int32") do
       x = 2 ** 2
       x.should eq(4)
       x.should be_a(Int32)
@@ -21,67 +21,67 @@ describe "Int" do
       x.should be_a(Int32)
     end
 
-    it "with positive UInt8" do
+    it("with positive UInt8") do
       x = 2_u8 ** 2
       x.should eq(4)
       x.should be_a(UInt8)
     end
 
-    it "raises with negative exponent" do
+    it("raises with negative exponent") do
       expect_raises(ArgumentError, "Cannot raise an integer to a negative integer power, use floats for that") do
         2 ** -1
       end
     end
 
-    it "should work with large integers" do
+    it("should work with large integers") do
       x = 51_i64 ** 11
       x.should eq(6071163615208263051_i64)
       x.should be_a(Int64)
     end
 
-    describe "with float" do
+    describe("with float") do
       it { (2 ** 2.0).should be_close(4, 0.0001) }
       it { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }
       it { (2 ** 2.5).should be_close(5.656854249492381, 0.0001) }
     end
   end
 
-  describe "#===(:Char)" do
+  describe("#===(:Char)") do
     it { (99 === 'c').should be_true }
     it { (99_u8 === 'c').should be_true }
     it { (99 === 'z').should be_false }
     it { (37202 === '酒').should be_true }
   end
 
-  describe "divisible_by?" do
+  describe("divisible_by?") do
     it { 10.divisible_by?(5).should be_true }
     it { 10.divisible_by?(3).should be_false }
   end
 
-  describe "even?" do
+  describe("even?") do
     it { 2.even?.should be_true }
     it { 3.even?.should be_false }
   end
 
-  describe "odd?" do
+  describe("odd?") do
     it { 2.odd?.should be_false }
     it { 3.odd?.should be_true }
   end
 
-  describe "succ" do
+  describe("succ") do
     it { 8.succ.should eq(9) }
     it { -2147483648.succ.should eq(-2147483647) }
     it { 2147483646.succ.should eq(2147483647) }
   end
 
-  describe "pred" do
+  describe("pred") do
     it { 9.pred.should eq(8) }
     it { -2147483647.pred.should eq(-2147483648) }
     it { 2147483647.pred.should eq(2147483646) }
   end
 
-  describe "abs" do
-    it "does for signed" do
+  describe("abs") do
+    it("does for signed") do
       1_i8.abs.should eq(1_i8)
       -1_i8.abs.should eq(1_i8)
       1_i16.abs.should eq(1_i16)
@@ -92,7 +92,7 @@ describe "Int" do
       -1_i64.abs.should eq(1_i64)
     end
 
-    it "does for unsigned" do
+    it("does for unsigned") do
       1_u8.abs.should eq(1_u8)
       1_u16.abs.should eq(1_u16)
       1_u32.abs.should eq(1_u32)
@@ -100,7 +100,7 @@ describe "Int" do
     end
   end
 
-  describe "lcm" do
+  describe("lcm") do
     it { 2.lcm(2).should eq(2) }
     it { 3.lcm(-7).should eq(21) }
     it { 4.lcm(6).should eq(12) }
@@ -108,7 +108,7 @@ describe "Int" do
     it { 2.lcm(0).should eq(0) }
   end
 
-  describe "to_s in base" do
+  describe("to_s in base") do
     it { 12.to_s(2).should eq("1100") }
     it { -12.to_s(2).should eq("-1100") }
     it { -123456.to_s(2).should eq("-11110001001000000") }
@@ -134,15 +134,15 @@ describe "Int" do
     it { 97.to_s(62).should eq("1z") }
     it { 3843.to_s(62).should eq("ZZ") }
 
-    it "raises on base 1" do
+    it("raises on base 1") do
       expect_raises { 123.to_s(1) }
     end
 
-    it "raises on base 37" do
+    it("raises on base 37") do
       expect_raises { 123.to_s(37) }
     end
 
-    it "raises on base 62 with upcase" do
+    it("raises on base 62 with upcase") do
       expect_raises { 123.to_s(62, upcase: true) }
     end
 
@@ -171,21 +171,21 @@ describe "Int" do
     it { to_s_with_io(97, 62).should eq("1z") }
     it { to_s_with_io(3843, 62).should eq("ZZ") }
 
-    it "raises on base 1 with io" do
+    it("raises on base 1 with io") do
       expect_raises { to_s_with_io(123, 1) }
     end
 
-    it "raises on base 37 with io" do
+    it("raises on base 37 with io") do
       expect_raises { to_s_with_io(123, 37) }
     end
 
-    it "raises on base 62 with upcase with io" do
+    it("raises on base 62 with upcase with io") do
       expect_raises { to_s_with_io(12, 62, upcase: true) }
     end
   end
 
-  describe "#inspect" do
-    it "appends the type" do
+  describe("#inspect") do
+    it("appends the type") do
       23.inspect.should eq("23")
       23_i8.inspect.should eq("23_i8")
       23_i16.inspect.should eq("23_i16")
@@ -196,7 +196,7 @@ describe "Int" do
       23_u64.inspect.should eq("23_u64")
     end
 
-    it "appends the type using IO" do
+    it("appends the type using IO") do
       str = String.build { |io| 23.inspect(io) }
       str.should eq("23")
 
@@ -205,7 +205,7 @@ describe "Int" do
     end
   end
 
-  describe "bit" do
+  describe("bit") do
     it { 5.bit(0).should eq(1) }
     it { 5.bit(1).should eq(0) }
     it { 5.bit(2).should eq(1) }
@@ -216,11 +216,11 @@ describe "Int" do
     it { UInt64::MAX.bit(64).should eq(0) }
   end
 
-  describe "divmod" do
+  describe("divmod") do
     it { 5.divmod(3).should eq({1, 2}) }
   end
 
-  describe "fdiv" do
+  describe("fdiv") do
     it { 1.fdiv(1).should eq 1.0 }
     it { 1.fdiv(2).should eq 0.5 }
     it { 1.fdiv(0.5).should eq 2.0 }
@@ -228,47 +228,47 @@ describe "Int" do
     it { 1.fdiv(0).should eq 1.0/0.0 }
   end
 
-  describe "~" do
+  describe("~") do
     it { (~1).should eq(-2) }
     it { (~1_u32).should eq(4294967294) }
   end
 
-  describe ">>" do
+  describe(">>") do
     it { (8000 >> 1).should eq(4000) }
     it { (8000 >> 2).should eq(2000) }
     it { (8000 >> 32).should eq(0) }
     it { (8000 >> -1).should eq(16000) }
   end
 
-  describe "<<" do
+  describe("<<") do
     it { (8000 << 1).should eq(16000) }
     it { (8000 << 2).should eq(32000) }
     it { (8000 << 32).should eq(0) }
     it { (8000 << -1).should eq(4000) }
   end
 
-  describe "to" do
-    it "does upwards" do
+  describe("to") do
+    it("does upwards") do
       a = 0
       1.to(3) { |i| a += i }.should be_nil
       a.should eq(6)
     end
 
-    it "does downards" do
+    it("does downards") do
       a = 0
       4.to(2) { |i| a += i }.should be_nil
       a.should eq(9)
     end
 
-    it "does when same" do
+    it("does when same") do
       a = 0
       2.to(2) { |i| a += i }.should be_nil
       a.should eq(2)
     end
   end
 
-  describe "to_s" do
-    it "does to_s for various int sizes" do
+  describe("to_s") do
+    it("does to_s for various int sizes") do
       0.to_s.should eq("0")
       1.to_s.should eq("1")
 
@@ -291,7 +291,7 @@ describe "Int" do
       18446744073709551615_u64.to_s.should eq("18446744073709551615")
     end
 
-    it "does to_s for various int sizes with IO" do
+    it("does to_s for various int sizes with IO") do
       to_s_with_io(0).should eq("0")
       to_s_with_io(1).should eq("1")
 
@@ -315,15 +315,15 @@ describe "Int" do
     end
   end
 
-  describe "step" do
-    it "steps through limit" do
+  describe("step") do
+    it("steps through limit") do
       passed = false
       1.step(to: 1) { |x| passed = true }
       fail "expected step to pass through 1" unless passed
     end
   end
 
-  it "casts" do
+  it("casts") do
     Int8.new(1).should be_a(Int8)
     Int8.new(1).should eq(1)
 
@@ -349,7 +349,7 @@ describe "Int" do
     UInt64.new(1).should eq(1)
   end
 
-  it "divides negative numbers" do
+  it("divides negative numbers") do
     (7 / 2).should eq(3)
     (-7 / 2).should eq(-4)
     (7 / -2).should eq(-4)
@@ -361,14 +361,14 @@ describe "Int" do
     (-6 / -2).should eq(3)
   end
 
-  it "tdivs" do
+  it("tdivs") do
     5.tdiv(3).should eq(1)
     -5.tdiv(3).should eq(-1)
     5.tdiv(-3).should eq(-1)
     -5.tdiv(-3).should eq(1)
   end
 
-  it "holds true that x == q*y + r" do
+  it("holds true that x == q*y + r") do
     [5, -5, 6, -6, 10, -10].each do |x|
       [3, -3].each do |y|
         q = x / y
@@ -378,12 +378,12 @@ describe "Int" do
     end
   end
 
-  it "raises when divides by zero" do
+  it("raises when divides by zero") do
     expect_raises(DivisionByZero) { 1 / 0 }
     (4 / 2).should eq(2)
   end
 
-  it "raises when divides Int::MIN by -1" do
+  it("raises when divides Int::MIN by -1") do
     expect_raises(ArgumentError) { Int8::MIN / -1 }
     expect_raises(ArgumentError) { Int16::MIN / -1 }
     expect_raises(ArgumentError) { Int32::MIN / -1 }
@@ -392,12 +392,12 @@ describe "Int" do
     (UInt8::MIN / -1).should eq(0)
   end
 
-  it "raises when mods by zero" do
+  it("raises when mods by zero") do
     expect_raises(DivisionByZero) { 1 % 0 }
     (4 % 2).should eq(0)
   end
 
-  it "does times" do
+  it("does times") do
     i = sum = 0
     3.times do |n|
       i += 1
@@ -407,7 +407,7 @@ describe "Int" do
     sum.should eq(3)
   end
 
-  it "gets times iterator" do
+  it("gets times iterator") do
     iter = 3.times
     iter.next.should eq(0)
     iter.next.should eq(1)
@@ -418,7 +418,7 @@ describe "Int" do
     iter.next.should eq(0)
   end
 
-  it "does %" do
+  it("does %") do
     (7 % 5).should eq(2)
     (-7 % 5).should eq(3)
 
@@ -426,7 +426,7 @@ describe "Int" do
     (-13 % -4).should eq(-1)
   end
 
-  it "does remainder" do
+  it("does remainder") do
     7.remainder(5).should eq(2)
     -7.remainder(5).should eq(-2)
 
@@ -434,7 +434,7 @@ describe "Int" do
     -13.remainder(-4).should eq(-1)
   end
 
-  it "does upto" do
+  it("does upto") do
     i = sum = 0
     1.upto(3) do |n|
       i += 1
@@ -444,7 +444,7 @@ describe "Int" do
     sum.should eq(6)
   end
 
-  it "gets upto iterator" do
+  it("gets upto iterator") do
     iter = 1.upto(3)
     iter.next.should eq(1)
     iter.next.should eq(2)
@@ -455,7 +455,7 @@ describe "Int" do
     iter.next.should eq(1)
   end
 
-  it "does downto" do
+  it("does downto") do
     i = sum = 0
     3.downto(1) do |n|
       i += 1
@@ -465,7 +465,7 @@ describe "Int" do
     sum.should eq(6)
   end
 
-  it "gets downto iterator" do
+  it("gets downto iterator") do
     iter = 3.downto(1)
     iter.next.should eq(3)
     iter.next.should eq(2)
@@ -476,7 +476,7 @@ describe "Int" do
     iter.next.should eq(3)
   end
 
-  it "gets to iterator" do
+  it("gets to iterator") do
     iter = 1.to(3)
     iter.next.should eq(1)
     iter.next.should eq(2)
@@ -487,7 +487,7 @@ describe "Int" do
     iter.next.should eq(1)
   end
 
-  describe "#popcount" do
+  describe("#popcount") do
     it { 5_i8.popcount.should eq(2) }
     it { 127_i8.popcount.should eq(7) }
     it { -1_i8.popcount.should eq(8) }
@@ -509,7 +509,7 @@ describe "Int" do
     it { 18446744073709551615_u64.popcount.should eq(64) }
   end
 
-  it "compares signed vs. unsigned integers" do
+  it("compares signed vs. unsigned integers") do
     signed_ints = [Int8::MAX, Int16::MAX, Int32::MAX, Int64::MAX, Int8::MIN, Int16::MIN, Int32::MIN, Int64::MIN, 0_i8, 0_i16, 0_i32, 0_i64]
     unsigned_ints = [UInt8::MAX, UInt16::MAX, UInt32::MAX, UInt64::MAX, 0_u8, 0_u16, 0_u32, 0_u64]
 
@@ -527,13 +527,13 @@ describe "Int" do
     end
   end
 
-  it "clones" do
+  it("clones") do
     [1_u8, 2_u16, 3_u32, 4_u64, 5_i8, 6_i16, 7_i32, 8_i64].each do |value|
       value.clone.should eq(value)
     end
   end
 
-  it "#chr" do
+  it("#chr") do
     65.chr.should eq('A')
 
     expect_raises(ArgumentError, "#{0x10ffff + 1} out of char range") do
@@ -541,7 +541,7 @@ describe "Int" do
     end
   end
 
-  it "#unsafe_chr" do
+  it("#unsafe_chr") do
     65.unsafe_chr.should eq('A')
     (0x10ffff + 1).unsafe_chr.ord.should eq(0x10ffff + 1)
   end

--- a/spec/std/io/argf_spec.cr
+++ b/spec/std/io/argf_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe IO::ARGF do
-  it "reads from STDIN if ARGV isn't specified" do
+describe(IO::ARGF) do
+  it("reads from STDIN if ARGV isn't specified") do
     argv = [] of String
     stdin = IO::Memory.new("hello")
 
@@ -11,7 +11,7 @@ describe IO::ARGF do
     argf.read_byte.should be_nil
   end
 
-  it "reads from ARGV if specified" do
+  it("reads from ARGV if specified") do
     path1 = "#{__DIR__}/../data/argf_test_file_1.txt"
     path2 = "#{__DIR__}/../data/argf_test_file_2.txt"
     stdin = IO::Memory.new("")
@@ -38,8 +38,8 @@ describe IO::ARGF do
     str.should eq("12345")
   end
 
-  describe "gets" do
-    it "reads from STDIN if ARGV isn't specified" do
+  describe("gets") do
+    it("reads from STDIN if ARGV isn't specified") do
       argv = [] of String
       stdin = IO::Memory.new("hello\nworld\n")
 
@@ -49,7 +49,7 @@ describe IO::ARGF do
       argf.gets.should be_nil
     end
 
-    it "reads from STDIN if ARGV isn't specified, chomp = false" do
+    it("reads from STDIN if ARGV isn't specified, chomp = false") do
       argv = [] of String
       stdin = IO::Memory.new("hello\nworld\n")
 
@@ -59,7 +59,7 @@ describe IO::ARGF do
       argf.gets(chomp: false).should be_nil
     end
 
-    it "reads from ARGV if specified" do
+    it("reads from ARGV if specified") do
       path1 = "#{__DIR__}/../data/argf_test_file_1.txt"
       path2 = "#{__DIR__}/../data/argf_test_file_2.txt"
       stdin = IO::Memory.new("")
@@ -82,8 +82,8 @@ describe IO::ARGF do
     end
   end
 
-  describe "peek" do
-    it "peeks from STDIN if ARGV isn't specified" do
+  describe("peek") do
+    it("peeks from STDIN if ARGV isn't specified") do
       argv = [] of String
       stdin = IO::Memory.new("1234")
 
@@ -93,7 +93,7 @@ describe IO::ARGF do
       argf.gets_to_end.should eq("1234")
     end
 
-    it "peeks from ARGV if specified" do
+    it("peeks from ARGV if specified") do
       path1 = "#{__DIR__}/../data/argf_test_file_1.txt"
       path2 = "#{__DIR__}/../data/argf_test_file_2.txt"
       stdin = IO::Memory.new("")

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -49,40 +49,40 @@ private class BufferedWrapper
   end
 end
 
-describe "IO::Buffered" do
-  it "does gets" do
+describe("IO::Buffered") do
+  it("does gets") do
     io = BufferedWrapper.new(IO::Memory.new("hello\r\nworld\n"))
     io.gets.should eq("hello")
     io.gets.should eq("world")
     io.gets.should be_nil
   end
 
-  it "does gets with chomp = false" do
+  it("does gets with chomp = false") do
     io = BufferedWrapper.new(IO::Memory.new("hello\nworld\n"))
     io.gets(chomp: false).should eq("hello\n")
     io.gets(chomp: false).should eq("world\n")
     io.gets(chomp: false).should be_nil
   end
 
-  it "does gets with big line" do
+  it("does gets with big line") do
     big_line = "a" * 20_000
     io = BufferedWrapper.new(IO::Memory.new("#{big_line}\nworld\n"))
     io.gets.should eq(big_line)
   end
 
-  it "does gets with big line and \\r\\n" do
+  it("does gets with big line and \\r\\n") do
     big_line = "a" * 20_000
     io = BufferedWrapper.new(IO::Memory.new("#{big_line}\r\nworld\n"))
     io.gets.should eq(big_line)
   end
 
-  it "does gets with big line and chomp = false" do
+  it("does gets with big line and chomp = false") do
     big_line = "a" * 20_000
     io = BufferedWrapper.new(IO::Memory.new("#{big_line}\nworld\n"))
     io.gets(chomp: false).should eq("#{big_line}\n")
   end
 
-  it "does gets with char delimiter" do
+  it("does gets with char delimiter") do
     io = BufferedWrapper.new(IO::Memory.new("hello world"))
     io.gets('w').should eq("hello w")
     io.gets('r').should eq("or")
@@ -90,14 +90,14 @@ describe "IO::Buffered" do
     io.gets('r').should be_nil
   end
 
-  it "does gets with unicode char delimiter" do
+  it("does gets with unicode char delimiter") do
     io = BufferedWrapper.new(IO::Memory.new("こんにちは"))
     io.gets('ち').should eq("こんにち")
     io.gets('ち').should eq("は")
     io.gets('ち').should be_nil
   end
 
-  it "does gets with limit" do
+  it("does gets with limit") do
     io = BufferedWrapper.new(IO::Memory.new("hello\nworld\n"))
     io.gets(3).should eq("hel")
     io.gets(10_000).should eq("lo\n")
@@ -105,7 +105,7 @@ describe "IO::Buffered" do
     io.gets(3).should be_nil
   end
 
-  it "does gets with char and limit" do
+  it("does gets with char and limit") do
     io = BufferedWrapper.new(IO::Memory.new("hello\nworld\n"))
     io.gets('o', 2).should eq("he")
     io.gets('w', 10_000).should eq("llo\nw")
@@ -113,32 +113,32 @@ describe "IO::Buffered" do
     io.gets('a', 3).should be_nil
   end
 
-  it "does gets with char and limit without off-by-one" do
+  it("does gets with char and limit without off-by-one") do
     io = BufferedWrapper.new(IO::Memory.new("test\nabc"))
     io.gets('a', 5).should eq("test\n")
     io = BufferedWrapper.new(IO::Memory.new("test\nabc"))
     io.gets('a', 6).should eq("test\na")
   end
 
-  it "does gets with char and limit when not found in buffer" do
+  it("does gets with char and limit when not found in buffer") do
     io = BufferedWrapper.new(IO::Memory.new(("a" * (IO::Buffered::BUFFER_SIZE + 10)) + "b"))
     io.gets('b', 2).should eq("aa")
   end
 
-  it "does gets with char and limit when not found in buffer (2)" do
+  it("does gets with char and limit when not found in buffer (2)") do
     base = "a" * (IO::Buffered::BUFFER_SIZE + 10)
     io = BufferedWrapper.new(IO::Memory.new(base + "aabaaa"))
     io.gets('b', IO::Buffered::BUFFER_SIZE + 11).should eq(base + "a")
   end
 
-  it "raises if invoking gets with negative limit" do
+  it("raises if invoking gets with negative limit") do
     io = BufferedWrapper.new(IO::Memory.new("hello\nworld\n"))
-    expect_raises ArgumentError, "Negative limit" do
+    expect_raises(ArgumentError, "Negative limit") do
       io.gets(-1)
     end
   end
 
-  it "writes bytes" do
+  it("writes bytes") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     10_000.times { io.write_byte 'a'.ord.to_u8 }
@@ -146,7 +146,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("a" * 10_000)
   end
 
-  it "reads char" do
+  it("reads char") do
     io = BufferedWrapper.new(IO::Memory.new("hi 世界"))
     io.read_char.should eq('h')
     io.read_char.should eq('i')
@@ -173,7 +173,7 @@ describe "IO::Buffered" do
     end
   end
 
-  it "reads byte" do
+  it("reads byte") do
     io = BufferedWrapper.new(IO::Memory.new("hello"))
     io.read_byte.should eq('h'.ord)
     io.read_byte.should eq('e'.ord)
@@ -183,14 +183,14 @@ describe "IO::Buffered" do
     io.read_char.should be_nil
   end
 
-  it "does new with block" do
+  it("does new with block") do
     str = IO::Memory.new
     res = BufferedWrapper.new str, &.print "Hello"
     res.should be(str)
     str.to_s.should eq("Hello")
   end
 
-  it "rewinds" do
+  it("rewinds") do
     str = IO::Memory.new("hello\nworld\n")
     io = BufferedWrapper.new str
     io.gets.should eq("hello")
@@ -198,7 +198,7 @@ describe "IO::Buffered" do
     io.gets.should eq("hello")
   end
 
-  it "reads more than the buffer's internal capacity" do
+  it("reads more than the buffer's internal capacity") do
     s = String.build do |str|
       900.times do
         10.times do |i|
@@ -219,7 +219,7 @@ describe "IO::Buffered" do
     end
   end
 
-  it "writes more than the buffer's internal capacity" do
+  it("writes more than the buffer's internal capacity") do
     s = String.build do |str|
       900.times do
         10.times do |i|
@@ -235,7 +235,7 @@ describe "IO::Buffered" do
     strio.rewind.gets_to_end.should eq(s)
   end
 
-  it "does puts" do
+  it("does puts") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     io.puts "Hello"
@@ -244,7 +244,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("Hello\n")
   end
 
-  it "does puts with big string" do
+  it("does puts with big string") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     s = "*" * 20_000
@@ -254,7 +254,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("hello#{s}")
   end
 
-  it "does puts many times" do
+  it("does puts many times") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     10_000.times { io << "hello" }
@@ -262,7 +262,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("hello" * 10_000)
   end
 
-  it "flushes on \n" do
+  it("flushes on \n") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     io.flush_on_newline = true
@@ -273,7 +273,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("hello\nworld")
   end
 
-  it "doesn't write past count" do
+  it("doesn't write past count") do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
     io.flush_on_newline = true
@@ -284,7 +284,7 @@ describe "IO::Buffered" do
     str.to_s.should eq("abcd")
   end
 
-  it "syncs" do
+  it("syncs") do
     str = IO::Memory.new
 
     io = BufferedWrapper.new(str)
@@ -299,14 +299,14 @@ describe "IO::Buffered" do
     str.read_byte.should eq(1_u8)
   end
 
-  it "shouldn't call unbuffered read if reading to an empty slice" do
+  it("shouldn't call unbuffered read if reading to an empty slice") do
     str = IO::Memory.new("foo")
     io = BufferedWrapper.new(str)
     io.read(Bytes.new(0))
     io.called_unbuffered_read.should be_false
   end
 
-  it "peeks" do
+  it("peeks") do
     str = IO::Memory.new("foo")
     io = BufferedWrapper.new(str)
 
@@ -319,23 +319,23 @@ describe "IO::Buffered" do
     io.peek.should eq(Bytes.empty)
   end
 
-  it "skips" do
+  it("skips") do
     str = IO::Memory.new("123456789")
     io = BufferedWrapper.new(str)
     io.skip(3)
     io.read_char.should eq('4')
   end
 
-  it "skips big" do
+  it("skips big") do
     str = IO::Memory.new(("a" * 10_000) + "b")
     io = BufferedWrapper.new(str)
     io.skip(10_000)
     io.read_char.should eq('b')
   end
 
-  describe "encoding" do
-    describe "decode" do
-      it "gets_to_end" do
+  describe("encoding") do
+    describe("decode") do
+      it("gets_to_end") do
         str = "Hello world" * 200
         base_io = IO::Memory.new(str.encode("UCS-2LE"))
         io = BufferedWrapper.new(base_io)
@@ -343,7 +343,7 @@ describe "IO::Buffered" do
         io.gets_to_end.should eq(str)
       end
 
-      it "gets" do
+      it("gets") do
         str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
         base_io = IO::Memory.new(str.encode("UCS-2LE"))
         io = BufferedWrapper.new(base_io)
@@ -353,7 +353,7 @@ describe "IO::Buffered" do
         io.gets.should eq("Bar")
       end
 
-      it "gets with chomp = false" do
+      it("gets with chomp = false") do
         str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
         base_io = IO::Memory.new(str.encode("UCS-2LE"))
         io = BufferedWrapper.new(base_io)
@@ -363,7 +363,7 @@ describe "IO::Buffered" do
         io.gets(chomp: false).should eq("Bar\n")
       end
 
-      it "gets big string" do
+      it("gets big string") do
         str = "Hello\nWorld\n" * 10_000
         base_io = IO::Memory.new(str.encode("UCS-2LE"))
         io = BufferedWrapper.new(base_io)
@@ -374,7 +374,7 @@ describe "IO::Buffered" do
         end
       end
 
-      it "gets big GB2312 string" do
+      it("gets big GB2312 string") do
         str = ("你好我是人\n" * 1000).encode("GB2312")
         base_io = IO::Memory.new(str)
         io = BufferedWrapper.new(base_io)
@@ -384,7 +384,7 @@ describe "IO::Buffered" do
         end
       end
 
-      it "reads char" do
+      it("reads char") do
         str = "x\nHello world" + ("1234567890" * 1000)
         base_io = IO::Memory.new(str.encode("UCS-2LE"))
         io = BufferedWrapper.new(base_io)

--- a/spec/std/io/byte_format_spec.cr
+++ b/spec/std/io/byte_format_spec.cr
@@ -19,67 +19,67 @@ private def new_string_io(*bytes)
   io
 end
 
-describe IO::ByteFormat do
-  describe "little endian" do
-    describe "encode" do
-      describe "to io" do
-        it "writes int8" do
+describe(IO::ByteFormat) do
+  describe("little endian") do
+    describe("encode") do
+      describe("to io") do
+        it("writes int8") do
           io = IO::Memory.new
           io.write_bytes 0x12_i8, IO::ByteFormat::LittleEndian
           assert_bytes io, 0x12
         end
 
-        it "writes int16" do
+        it("writes int16") do
           io = IO::Memory.new
           io.write_bytes 0x1234_i16, IO::ByteFormat::LittleEndian
           assert_bytes io, 0x34, 0x12
         end
 
-        it "writes uint16" do
+        it("writes uint16") do
           io = IO::Memory.new
           io.write_bytes 0x1234_u16, IO::ByteFormat::LittleEndian
           assert_bytes io, 0x34, 0x12
         end
 
-        it "writes int32" do
+        it("writes int32") do
           io = IO::Memory.new
           io.write_bytes 0x12345678_i32, IO::ByteFormat::LittleEndian
           assert_bytes io, 0x78, 0x56, 0x34, 0x12
         end
 
-        it "writes int64" do
+        it("writes int64") do
           io = IO::Memory.new
           io.write_bytes 0x123456789ABCDEF0_i64, IO::ByteFormat::LittleEndian
           assert_bytes io, 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12
         end
 
-        it "writes float32" do
+        it("writes float32") do
           io = IO::Memory.new
           io.write_bytes 1.234_f32, IO::ByteFormat::LittleEndian
           assert_bytes io, 0xB6, 0xF3, 0x9D, 0x3F
         end
 
-        it "writes float64" do
+        it("writes float64") do
           io = IO::Memory.new
           io.write_bytes 1.234, IO::ByteFormat::LittleEndian
           assert_bytes io, 0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F
         end
       end
 
-      describe "to slice" do
-        it "writes int8" do
+      describe("to slice") do
+        it("writes int8") do
           bytes = Bytes[0]
           IO::ByteFormat::LittleEndian.encode(0x12_i8, bytes)
           bytes.should eq(Bytes[0x12_i8])
         end
 
-        it "writes int16" do
+        it("writes int16") do
           bytes = Bytes[0, 0]
           IO::ByteFormat::LittleEndian.encode(0x1234_i16, bytes)
           bytes.should eq(Bytes[0x34, 0x12])
         end
 
-        it "writes int16 to larger slice" do
+        it("writes int16 to larger slice") do
           bytes = Bytes[0, 0, 0, 0]
           IO::ByteFormat::LittleEndian.encode(0x1234_i16, bytes)
           bytes.should eq(Bytes[0x34, 0x12, 0, 0])
@@ -87,77 +87,77 @@ describe IO::ByteFormat do
       end
     end
 
-    describe "decode" do
-      describe "from io" do
-        it "reads int8" do
+    describe("decode") do
+      describe("from io") do
+        it("reads int8") do
           io = new_string_io(0x12)
           int = io.read_bytes Int8, IO::ByteFormat::LittleEndian
           int.should eq(0x12_i8)
         end
 
-        it "reads int16" do
+        it("reads int16") do
           io = new_string_io(0x34, 0x12)
           int = io.read_bytes Int16, IO::ByteFormat::LittleEndian
           int.should eq(0x1234_i16)
         end
 
-        it "reads unt16" do
+        it("reads unt16") do
           io = new_string_io(0x34, 0x12)
           int = io.read_bytes UInt16, IO::ByteFormat::LittleEndian
           int.should eq(0x1234_u16)
         end
 
-        it "reads int32" do
+        it("reads int32") do
           io = new_string_io(0x78, 0x56, 0x34, 0x12)
           int = io.read_bytes Int32, IO::ByteFormat::LittleEndian
           int.should eq(0x12345678_i32)
         end
 
-        it "reads int64" do
+        it("reads int64") do
           io = new_string_io(0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12)
           int = io.read_bytes Int64, IO::ByteFormat::LittleEndian
           int.should eq(0x123456789ABCDEF0_i64)
         end
 
-        it "reads float32" do
+        it("reads float32") do
           io = new_string_io(0xB6, 0xF3, 0x9D, 0x3F)
           float = io.read_bytes Float32, IO::ByteFormat::LittleEndian
           float.should be_close(1.234, 0.0001)
         end
 
-        it "reads float64" do
+        it("reads float64") do
           io = new_string_io(0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F)
           float = io.read_bytes Float64, IO::ByteFormat::LittleEndian
           float.should be_close(1.234, 0.0001)
         end
       end
 
-      describe "from slice" do
-        it "reads int8" do
+      describe("from slice") do
+        it("reads int8") do
           bytes = Bytes[0x12]
           int = IO::ByteFormat::LittleEndian.decode(Int8, bytes)
           int.should eq(0x12_i8)
         end
 
-        it "reads int16" do
+        it("reads int16") do
           bytes = Bytes[0x34, 0x12]
           int = IO::ByteFormat::LittleEndian.decode(Int16, bytes)
           int.should eq(0x1234_i16)
         end
 
-        it "reads int16 from larger slice" do
+        it("reads int16 from larger slice") do
           bytes = Bytes[0x34, 0x12, 0, 0]
           int = IO::ByteFormat::LittleEndian.decode(Int16, bytes)
           int.should eq(0x1234_i16)
         end
 
-        it "reads float32" do
+        it("reads float32") do
           bytes = Bytes[0xB6, 0xF3, 0x9D, 0x3F]
           float = IO::ByteFormat::LittleEndian.decode(Float32, bytes)
           float.should be_close(1.234, 0.0001)
         end
 
-        it "reads float64" do
+        it("reads float64") do
           bytes = Bytes[0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F]
           float = IO::ByteFormat::LittleEndian.decode(Float64, bytes)
           float.should be_close(1.234, 0.0001)
@@ -166,110 +166,110 @@ describe IO::ByteFormat do
     end
   end
 
-  describe "big endian" do
-    describe "encode" do
-      it "writes int8" do
+  describe("big endian") do
+    describe("encode") do
+      it("writes int8") do
         io = IO::Memory.new
         io.write_bytes 0x12_i8, IO::ByteFormat::BigEndian
         assert_bytes io, 0x12
       end
 
-      it "writes int16" do
+      it("writes int16") do
         io = IO::Memory.new
         io.write_bytes 0x1234_i16, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x34, 0x12
       end
 
-      it "writes int32" do
+      it("writes int32") do
         io = IO::Memory.new
         io.write_bytes 0x12345678_i32, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x78, 0x56, 0x34, 0x12
       end
 
-      it "writes int64" do
+      it("writes int64") do
         io = IO::Memory.new
         io.write_bytes 0x123456789ABCDEF0_i64, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12
       end
 
-      it "writes float32" do
+      it("writes float32") do
         io = IO::Memory.new
         io.write_bytes 1.234_f32, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0xB6, 0xF3, 0x9D, 0x3F
       end
 
-      it "writes float64" do
+      it("writes float64") do
         io = IO::Memory.new
         io.write_bytes 1.234, IO::ByteFormat::BigEndian
         assert_bytes_reversed io, 0x58, 0x39, 0xB4, 0xC8, 0x76, 0xBE, 0xF3, 0x3F
       end
     end
 
-    describe "decode" do
-      describe "from io" do
-        it "reads int8" do
+    describe("decode") do
+      describe("from io") do
+        it("reads int8") do
           io = new_string_io(0x12)
           int = io.read_bytes Int8, IO::ByteFormat::BigEndian
           int.should eq(0x12_i8)
         end
 
-        it "reads int16" do
+        it("reads int16") do
           io = new_string_io(0x12, 0x34)
           int = io.read_bytes Int16, IO::ByteFormat::BigEndian
           int.should eq(0x1234_i16)
         end
 
-        it "reads unt16" do
+        it("reads unt16") do
           io = new_string_io(0x12, 0x34)
           int = io.read_bytes UInt16, IO::ByteFormat::BigEndian
           int.should eq(0x1234_u16)
         end
 
-        it "reads int32" do
+        it("reads int32") do
           io = new_string_io(0x12, 0x34, 0x56, 0x78)
           int = io.read_bytes Int32, IO::ByteFormat::BigEndian
           int.should eq(0x12345678_i32)
         end
 
-        it "reads int64" do
+        it("reads int64") do
           io = new_string_io(0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0)
           int = io.read_bytes Int64, IO::ByteFormat::BigEndian
           int.should eq(0x123456789ABCDEF0_i64)
         end
 
-        it "reads float32" do
+        it("reads float32") do
           io = new_string_io(0x3F, 0x9D, 0xF3, 0xB6)
           float = io.read_bytes Float32, IO::ByteFormat::BigEndian
           float.should be_close(1.234, 0.0001)
         end
 
-        it "reads float64" do
+        it("reads float64") do
           io = new_string_io(0x3F, 0xF3, 0xBE, 0x76, 0xC8, 0xB4, 0x39, 0x58)
           float = io.read_bytes Float64, IO::ByteFormat::BigEndian
           float.should be_close(1.234, 0.0001)
         end
       end
 
-      describe "from slice" do
-        it "reads int8" do
+      describe("from slice") do
+        it("reads int8") do
           bytes = Bytes[0x12]
           int = IO::ByteFormat::BigEndian.decode(Int8, bytes)
           int.should eq(0x12_i8)
         end
 
-        it "reads int16" do
+        it("reads int16") do
           bytes = Bytes[0x12, 0x34]
           int = IO::ByteFormat::BigEndian.decode(Int16, bytes)
           int.should eq(0x1234_i16)
         end
 
-        it "reads float32" do
+        it("reads float32") do
           bytes = Bytes[0x3F, 0x9D, 0xF3, 0xB6]
           float = IO::ByteFormat::BigEndian.decode(Float32, bytes)
           float.should be_close(1.234, 0.0001)
         end
 
-        it "reads float64" do
+        it("reads float64") do
           bytes = Bytes[0x3F, 0xF3, 0xBE, 0x76, 0xC8, 0xB4, 0x39, 0x58]
           float = IO::ByteFormat::BigEndian.decode(Float64, bytes)
           float.should be_close(1.234, 0.0001)

--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -23,9 +23,9 @@ private class PartialReaderIO
   end
 end
 
-describe "IO::Delimited" do
-  describe "#read" do
-    it "doesn't read past the limit" do
+describe("IO::Delimited") do
+  describe("#read") do
+    it("doesn't read past the limit") do
       io = IO::Memory.new("abcderzzrfgzr")
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
@@ -33,7 +33,7 @@ describe "IO::Delimited" do
       io.gets_to_end.should eq("fgzr")
     end
 
-    it "doesn't read past the limit (char-by-char)" do
+    it("doesn't read past the limit (char-by-char)") do
       io = IO::Memory.new("abcderzzrfg")
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
@@ -53,42 +53,42 @@ describe "IO::Delimited" do
       io.read_char.should eq('g')
     end
 
-    it "doesn't clobber active_delimiter_buffer" do
+    it("doesn't clobber active_delimiter_buffer") do
       io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "12345")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
-    it "handles the delimiter at the start" do
+    it("handles the delimiter at the start") do
       io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "ab1")
 
       delimited.read_char.should eq(nil)
     end
 
-    it "handles the delimiter at the end" do
+    it("handles the delimiter at the end") do
       io = IO::Memory.new("ab12312z")
       delimited = IO::Delimited.new(io, read_delimiter: "z")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
-    it "handles nearly a delimiter at the end" do
+    it("handles nearly a delimiter at the end") do
       io = IO::Memory.new("ab12312")
       delimited = IO::Delimited.new(io, read_delimiter: "122")
 
       delimited.gets_to_end.should eq("ab12312")
     end
 
-    it "doesn't clobber the buffer on closely-offset partial matches" do
+    it("doesn't clobber the buffer on closely-offset partial matches") do
       io = IO::Memory.new("abab1234abcdefgh")
       delimited = IO::Delimited.new(io, read_delimiter: "abcdefgh")
 
       delimited.gets_to_end.should eq("abab1234")
     end
 
-    it "handles partial reads" do
+    it("handles partial reads") do
       io = PartialReaderIO.new("abab1234abcdefgh")
       delimited = IO::Delimited.new(io, read_delimiter: "abcdefgh")
 
@@ -96,8 +96,8 @@ describe "IO::Delimited" do
     end
   end
 
-  describe "#write" do
-    it "raises" do
+  describe("#write") do
+    it("raises") do
       delimited = IO::Delimited.new(IO::Memory.new, read_delimiter: "zr")
       expect_raises(IO::Error, "Can't write to IO::Delimited") do
         delimited.puts "test string"
@@ -105,8 +105,8 @@ describe "IO::Delimited" do
     end
   end
 
-  describe "#close" do
-    it "stops reading" do
+  describe("#close") do
+    it("stops reading") do
       io = IO::Memory.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr")
 
@@ -120,7 +120,7 @@ describe "IO::Delimited" do
       end
     end
 
-    it "closes the underlying stream if sync_close is true" do
+    it("closes the underlying stream if sync_close is true") do
       io = IO::Memory.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr", sync_close: true)
       delimited.sync_close?.should eq(true)

--- a/spec/std/io/hexdump_spec.cr
+++ b/spec/std/io/hexdump_spec.cr
@@ -1,9 +1,9 @@
 require "spec"
 require "io/hexdump"
 
-describe IO::Hexdump do
-  describe "read" do
-    it "prints hexdump" do
+describe(IO::Hexdump) do
+  describe("read") do
+    it("prints hexdump") do
       ascii_table = <<-EOF
         00000000  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
         00000010  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?
@@ -30,8 +30,8 @@ describe IO::Hexdump do
     end
   end
 
-  describe "write" do
-    it "prints hexdump" do
+  describe("write") do
+    it("prints hexdump") do
       ascii_table = <<-EOF
         00000000  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
         00000010  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -80,9 +80,9 @@ private class SimpleIOMemory
   end
 end
 
-describe IO do
-  describe "partial read" do
-    it "doesn't block on first read.  blocks on 2nd read" do
+describe(IO) do
+  describe("partial read") do
+    it("doesn't block on first read.  blocks on 2nd read") do
       IO.pipe do |read, write|
         write.puts "hello"
         slice = Bytes.new 1024
@@ -98,8 +98,8 @@ describe IO do
     end
   end
 
-  describe "IO iterators" do
-    it "iterates by line" do
+  describe("IO iterators") do
+    it("iterates by line") do
       io = SimpleIOMemory.new("hello\nbye\n")
       lines = io.each_line
       lines.next.should eq("hello")
@@ -110,7 +110,7 @@ describe IO do
       lines.next.should eq("hello")
     end
 
-    it "iterates by line with chomp false" do
+    it("iterates by line with chomp false") do
       io = SimpleIOMemory.new("hello\nbye\n")
       lines = io.each_line(chomp: false)
       lines.next.should eq("hello\n")
@@ -121,7 +121,7 @@ describe IO do
       lines.next.should eq("hello\n")
     end
 
-    it "iterates by char" do
+    it("iterates by char") do
       io = SimpleIOMemory.new("abあぼ")
       chars = io.each_char
       chars.next.should eq('a')
@@ -134,7 +134,7 @@ describe IO do
       chars.next.should eq('a')
     end
 
-    it "iterates by byte" do
+    it("iterates by byte") do
       io = SimpleIOMemory.new("ab")
       bytes = io.each_byte
       bytes.next.should eq('a'.ord)
@@ -146,7 +146,7 @@ describe IO do
     end
   end
 
-  it "copies" do
+  it("copies") do
     string = "abあぼ"
     src = SimpleIOMemory.new(string)
     dst = SimpleIOMemory.new
@@ -154,7 +154,7 @@ describe IO do
     dst.to_s.should eq(string)
   end
 
-  it "copies with limit" do
+  it("copies with limit") do
     string = "abcあぼ"
     src = SimpleIOMemory.new(string)
     dst = SimpleIOMemory.new
@@ -162,7 +162,7 @@ describe IO do
     dst.to_s.should eq("abc")
   end
 
-  it "raises on copy with negative limit" do
+  it("raises on copy with negative limit") do
     string = "abcあぼ"
     src = SimpleIOMemory.new(string)
     dst = SimpleIOMemory.new
@@ -171,7 +171,7 @@ describe IO do
     end
   end
 
-  it "reopens" do
+  it("reopens") do
     File.open("#{__DIR__}/../data/test_file.txt") do |file1|
       File.open("#{__DIR__}/../data/test_file.ini") do |file2|
         file2.reopen(file1)
@@ -180,15 +180,15 @@ describe IO do
     end
   end
 
-  describe "read operations" do
-    it "does gets" do
+  describe("read operations") do
+    it("does gets") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.gets.should eq("hello")
       io.gets.should eq("world")
       io.gets.should be_nil
     end
 
-    it "does gets with \\r\\n" do
+    it("does gets with \\r\\n") do
       io = SimpleIOMemory.new("hello\r\nworld\r\nfoo\rbar\n")
       io.gets.should eq("hello")
       io.gets.should eq("world")
@@ -196,20 +196,20 @@ describe IO do
       io.gets.should be_nil
     end
 
-    it "does gets with chomp false" do
+    it("does gets with chomp false") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.gets(chomp: false).should eq("hello\n")
       io.gets(chomp: false).should eq("world\n")
       io.gets(chomp: false).should be_nil
     end
 
-    it "does gets with big line" do
+    it("does gets with big line") do
       big_line = "a" * 20_000
       io = SimpleIOMemory.new("#{big_line}\nworld\n")
       io.gets.should eq(big_line)
     end
 
-    it "does gets with char delimiter" do
+    it("does gets with char delimiter") do
       io = SimpleIOMemory.new("hello world")
       io.gets('w').should eq("hello w")
       io.gets('r').should eq("or")
@@ -217,40 +217,40 @@ describe IO do
       io.gets('r').should be_nil
     end
 
-    it "does gets with unicode char delimiter" do
+    it("does gets with unicode char delimiter") do
       io = SimpleIOMemory.new("こんにちは")
       io.gets('ち').should eq("こんにち")
       io.gets('ち').should eq("は")
       io.gets('ち').should be_nil
     end
 
-    it "gets with string as delimiter" do
+    it("gets with string as delimiter") do
       io = SimpleIOMemory.new("hello world")
       io.gets("lo").should eq("hello")
       io.gets("rl").should eq(" worl")
       io.gets("foo").should eq("d")
     end
 
-    it "gets with string as delimiter and chomp = true" do
+    it("gets with string as delimiter and chomp = true") do
       io = SimpleIOMemory.new("hello world")
       io.gets("lo", chomp: true).should eq("hel")
       io.gets("rl", chomp: true).should eq(" wo")
       io.gets("foo", chomp: true).should eq("d")
     end
 
-    it "gets with empty string as delimiter" do
+    it("gets with empty string as delimiter") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.gets("").should eq("hello\nworld\n")
     end
 
-    it "gets with single byte string as delimiter" do
+    it("gets with single byte string as delimiter") do
       io = SimpleIOMemory.new("hello\nworld\nbye")
       io.gets("\n").should eq("hello\n")
       io.gets("\n").should eq("world\n")
       io.gets("\n").should eq("bye")
     end
 
-    it "does gets with limit" do
+    it("does gets with limit") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.gets(3).should eq("hel")
       io.gets(10_000).should eq("lo\n")
@@ -258,7 +258,7 @@ describe IO do
       io.gets(3).should be_nil
     end
 
-    it "does gets with char and limit" do
+    it("does gets with char and limit") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.gets('o', 2).should eq("he")
       io.gets('w', 10_000).should eq("llo\nw")
@@ -266,14 +266,14 @@ describe IO do
       io.gets('a', 3).should be_nil
     end
 
-    it "raises if invoking gets with negative limit" do
+    it("raises if invoking gets with negative limit") do
       io = SimpleIOMemory.new("hello\nworld\n")
-      expect_raises ArgumentError, "Negative limit" do
+      expect_raises(ArgumentError, "Negative limit") do
         io.gets(-1)
       end
     end
 
-    it "does read_line with limit" do
+    it("does read_line with limit") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.read_line(3).should eq("hel")
       io.read_line(10_000).should eq("lo\n")
@@ -281,7 +281,7 @@ describe IO do
       expect_raises(IO::EOFError) { io.read_line(3) }
     end
 
-    it "does read_line with char and limit" do
+    it("does read_line with char and limit") do
       io = SimpleIOMemory.new("hello\nworld\n")
       io.read_line('o', 2).should eq("he")
       io.read_line('w', 10_000).should eq("llo\nw")
@@ -289,13 +289,13 @@ describe IO do
       expect_raises(IO::EOFError) { io.read_line('a', 3) }
     end
 
-    it "reads all remaining content" do
+    it("reads all remaining content") do
       io = SimpleIOMemory.new("foo\nbar\nbaz\n")
       io.gets.should eq("foo")
       io.gets_to_end.should eq("bar\nbaz\n")
     end
 
-    it "reads char" do
+    it("reads char") do
       io = SimpleIOMemory.new("hi 世界")
       io.read_char.should eq('h')
       io.read_char.should eq('i')
@@ -315,7 +315,7 @@ describe IO do
       end
     end
 
-    it "reads byte" do
+    it("reads byte") do
       io = SimpleIOMemory.new("hello")
       io.read_byte.should eq('h'.ord)
       io.read_byte.should eq('e'.ord)
@@ -325,7 +325,7 @@ describe IO do
       io.read_char.should be_nil
     end
 
-    it "reads string" do
+    it("reads string") do
       io = SimpleIOMemory.new("hello world")
       io.read_string(5).should eq("hello")
       io.read_string(1).should eq(" ")
@@ -335,7 +335,7 @@ describe IO do
       end
     end
 
-    it "does each_line" do
+    it("does each_line") do
       io = SimpleIOMemory.new("a\nbb\ncc")
       counter = 0
       io.each_line do |line|
@@ -352,7 +352,7 @@ describe IO do
       counter.should eq(3)
     end
 
-    it "does each_char" do
+    it("does each_char") do
       io = SimpleIOMemory.new("あいう")
       counter = 0
       io.each_char do |c|
@@ -369,7 +369,7 @@ describe IO do
       counter.should eq(3)
     end
 
-    it "does each_byte" do
+    it("does each_byte") do
       io = SimpleIOMemory.new("abc")
       counter = 0
       io.each_byte do |b|
@@ -386,26 +386,26 @@ describe IO do
       counter.should eq(3)
     end
 
-    it "raises on EOF with read_line" do
+    it("raises on EOF with read_line") do
       str = SimpleIOMemory.new("hello")
       str.read_line.should eq("hello")
 
-      expect_raises IO::EOFError, "End of file reached" do
+      expect_raises(IO::EOFError, "End of file reached") do
         str.read_line
       end
     end
 
-    it "raises on EOF with readline and delimiter" do
+    it("raises on EOF with readline and delimiter") do
       str = SimpleIOMemory.new("hello")
       str.read_line('e').should eq("he")
       str.read_line('e').should eq("llo")
 
-      expect_raises IO::EOFError, "End of file reached" do
+      expect_raises(IO::EOFError, "End of file reached") do
         str.read_line
       end
     end
 
-    it "does read_fully" do
+    it("does read_fully") do
       str = SimpleIOMemory.new("hello")
       slice = Bytes.new(4)
       str.read_fully(slice).should eq(4)
@@ -416,7 +416,7 @@ describe IO do
       end
     end
 
-    it "does read_fully?" do
+    it("does read_fully?") do
       str = SimpleIOMemory.new("hello")
       slice = Bytes.new(4)
       str.read_fully?(slice).should eq(4)
@@ -426,14 +426,14 @@ describe IO do
     end
   end
 
-  describe "write operations" do
-    it "does puts" do
+  describe("write operations") do
+    it("does puts") do
       io = SimpleIOMemory.new
       io.puts "Hello"
       io.gets_to_end.should eq("Hello\n")
     end
 
-    it "does puts with big string" do
+    it("does puts with big string") do
       io = SimpleIOMemory.new
       s = "*" * 20_000
       io << "hello"
@@ -441,56 +441,56 @@ describe IO do
       io.gets_to_end.should eq("hello#{s}")
     end
 
-    it "does puts many times" do
+    it("does puts many times") do
       io = SimpleIOMemory.new
       10_000.times { io << "hello" }
       io.gets_to_end.should eq("hello" * 10_000)
     end
 
-    it "puts several arguments" do
+    it("puts several arguments") do
       io = SimpleIOMemory.new
       io.puts(1, "aaa", "\n")
       io.gets_to_end.should eq("1\naaa\n\n")
     end
 
-    it "prints" do
+    it("prints") do
       io = SimpleIOMemory.new
       io.print "foo"
       io.gets_to_end.should eq("foo")
     end
 
-    it "prints several arguments" do
+    it("prints several arguments") do
       io = SimpleIOMemory.new
       io.print "foo", "bar", "baz"
       io.gets_to_end.should eq("foobarbaz")
     end
 
-    it "writes bytes" do
+    it("writes bytes") do
       io = SimpleIOMemory.new
       10_000.times { io.write_byte 'a'.ord.to_u8 }
       io.gets_to_end.should eq("a" * 10_000)
     end
 
-    it "writes with printf" do
+    it("writes with printf") do
       io = SimpleIOMemory.new
       io.printf "Hello %d", 123
       io.gets_to_end.should eq("Hello 123")
     end
 
-    it "writes with printf as an array" do
+    it("writes with printf as an array") do
       io = SimpleIOMemory.new
       io.printf "Hello %d", [123]
       io.gets_to_end.should eq("Hello 123")
     end
 
-    it "skips a few bytes" do
+    it("skips a few bytes") do
       io = SimpleIOMemory.new
       io << "hello world"
       io.skip(6)
       io.gets_to_end.should eq("world")
     end
 
-    it "skips but raises if not enough bytes" do
+    it("skips but raises if not enough bytes") do
       io = SimpleIOMemory.new
       io << "hello"
       expect_raises(IO::EOFError) do
@@ -498,14 +498,14 @@ describe IO do
       end
     end
 
-    it "skips more than 4096 bytes" do
+    it("skips more than 4096 bytes") do
       io = SimpleIOMemory.new
       io << "a" * 4100
       io.skip(4099)
       io.gets_to_end.should eq("a")
     end
 
-    it "skips to end" do
+    it("skips to end") do
       io = SimpleIOMemory.new
       io << "hello"
       io.skip_to_end
@@ -513,16 +513,16 @@ describe IO do
     end
   end
 
-  describe "encoding" do
-    describe "decode" do
-      it "gets_to_end" do
+  describe("encoding") do
+    describe("decode") do
+      it("gets_to_end") do
         str = "Hello world" * 200
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets_to_end.should eq(str)
       end
 
-      it "gets" do
+      it("gets") do
         str = "Hello world\r\nFoo\nBar"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -532,7 +532,7 @@ describe IO do
         io.gets.should be_nil
       end
 
-      it "gets with chomp = false" do
+      it("gets with chomp = false") do
         str = "Hello world\r\nFoo\nBar"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -542,7 +542,7 @@ describe IO do
         io.gets(chomp: false).should be_nil
       end
 
-      it "gets big string" do
+      it("gets big string") do
         str = "Hello\nWorld\n" * 10_000
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -552,7 +552,7 @@ describe IO do
         end
       end
 
-      it "gets big GB2312 string" do
+      it("gets big GB2312 string") do
         2.times do
           str = ("你好我是人\n" * 1000).encode("GB2312")
           io = SimpleIOMemory.new(str)
@@ -563,7 +563,7 @@ describe IO do
         end
       end
 
-      it "does gets on unicode with char and limit without off-by-one" do
+      it("does gets on unicode with char and limit without off-by-one") do
         io = SimpleIOMemory.new("test\nabc".encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets('a', 5).should eq("test\n")
@@ -572,42 +572,42 @@ describe IO do
         io.gets('a', 6).should eq("test\na")
       end
 
-      it "gets with limit" do
+      it("gets with limit") do
         str = "Hello\nWorld\n"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(3).should eq("Hel")
       end
 
-      it "gets with limit (small, no newline)" do
+      it("gets with limit (small, no newline)") do
         str = "Hello world" * 10_000
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(3).should eq("Hel")
       end
 
-      it "gets with non-ascii" do
+      it("gets with non-ascii") do
         str = "你好我是人"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets('人').should eq("你好我是人")
       end
 
-      it "gets with non-ascii and chomp: false" do
+      it("gets with non-ascii and chomp: false") do
         str = "你好我是人"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets('人', chomp: true).should eq("你好我是")
       end
 
-      it "gets with limit (big)" do
+      it("gets with limit (big)") do
         str = "Hello world" * 10_000
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets(20_000).should eq(str[0, 20_000])
       end
 
-      it "gets with string delimiter" do
+      it("gets with string delimiter") do
         str = "Hello world\nFoo\nBar"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -617,7 +617,7 @@ describe IO do
         io.gets("zz").should be_nil
       end
 
-      it "reads char" do
+      it("reads char") do
         str = "Hello world"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -627,7 +627,7 @@ describe IO do
         io.read_char.should be_nil
       end
 
-      it "reads utf8 byte" do
+      it("reads utf8 byte") do
         str = "Hello world"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -637,7 +637,7 @@ describe IO do
         io.read_utf8_byte.should be_nil
       end
 
-      it "reads utf8" do
+      it("reads utf8") do
         io = IO::Memory.new("你".encode("GB2312"))
         io.set_encoding("GB2312")
 
@@ -647,23 +647,23 @@ describe IO do
         buffer.to_slice[0, bytes_read].to_a.should eq("你".bytes)
       end
 
-      it "raises on incomplete byte sequence" do
+      it("raises on incomplete byte sequence") do
         io = SimpleIOMemory.new("好".byte_slice(0, 1))
         io.set_encoding("GB2312")
-        expect_raises ArgumentError, "Incomplete multibyte sequence" do
+        expect_raises(ArgumentError, "Incomplete multibyte sequence") do
           io.read_char
         end
       end
 
-      it "says invalid byte sequence" do
+      it("says invalid byte sequence") do
         io = SimpleIOMemory.new(Slice.new(1, 140_u8))
         io.set_encoding("GB2312")
-        expect_raises ArgumentError, "Invalid multibyte sequence" do
+        expect_raises(ArgumentError, "Invalid multibyte sequence") do
           io.read_char
         end
       end
 
-      it "skips invalid byte sequences" do
+      it("skips invalid byte sequences") do
         string = String.build do |str|
           str.write "好".encode("GB2312")
           str.write_byte 140_u8
@@ -676,49 +676,49 @@ describe IO do
         io.read_char.should be_nil
       end
 
-      it "says invalid 'invalid' option" do
+      it("says invalid 'invalid' option") do
         io = SimpleIOMemory.new
-        expect_raises ArgumentError, "Valid values for `invalid` option are `nil` and `:skip`, not :foo" do
+        expect_raises(ArgumentError, "Valid values for `invalid` option are `nil` and `:skip`, not :foo") do
           io.set_encoding("GB2312", invalid: :foo)
         end
       end
 
-      it "says invalid encoding" do
+      it("says invalid encoding") do
         io = SimpleIOMemory.new("foo")
         io.set_encoding("FOO")
-        expect_raises ArgumentError, "Invalid encoding: FOO" do
+        expect_raises(ArgumentError, "Invalid encoding: FOO") do
           io.gets_to_end
         end
       end
 
-      it "does skips when converting to UTF-8" do
+      it("does skips when converting to UTF-8") do
         io = SimpleIOMemory.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
         io.set_encoding("UTF-8", invalid: :skip)
         io.gets_to_end.should eq "{/*  */}"
       end
 
-      it "decodes incomplete multibyte sequence with skip (#3285)" do
+      it("decodes incomplete multibyte sequence with skip (#3285)") do
         bytes = Bytes[195, 229, 237, 229, 240, 224, 246, 232, 255, 32, 241, 234, 240, 232, 239, 242, 224, 32, 48, 46, 48, 49, 50, 54, 32, 241, 229, 234, 243, 237, 228, 10]
         m = IO::Memory.new(bytes)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.should eq("  0.0126 \n")
       end
 
-      it "decodes incomplete multibyte sequence with skip (2) (#3285)" do
+      it("decodes incomplete multibyte sequence with skip (2) (#3285)") do
         str = File.read("#{__DIR__}/../data/io_data_incomplete_multibyte_sequence.txt")
         m = IO::Memory.new(Base64.decode_string str)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.bytesize.should eq(4277)
       end
 
-      it "decodes incomplete multibyte sequence with skip (3) (#3285)" do
+      it("decodes incomplete multibyte sequence with skip (3) (#3285)") do
         str = File.read("#{__DIR__}/../data/io_data_incomplete_multibyte_sequence_2.txt")
         m = IO::Memory.new(Base64.decode_string str)
         m.set_encoding("UTF-8", invalid: :skip)
         m.gets_to_end.bytesize.should eq(8977)
       end
 
-      it "reads string" do
+      it("reads string") do
         str = "Hello world\r\nFoo\nBar"
         io = SimpleIOMemory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -727,8 +727,8 @@ describe IO do
       end
     end
 
-    describe "encode" do
-      it "prints a string" do
+    describe("encode") do
+      it("prints a string") do
         str = "Hello world"
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
@@ -737,7 +737,7 @@ describe IO do
         slice.should eq(str.encode("UCS-2LE"))
       end
 
-      it "prints numbers" do
+      it("prints numbers") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 0
@@ -755,7 +755,7 @@ describe IO do
         slice.should eq("0123456789.110.11".encode("UCS-2LE"))
       end
 
-      it "prints bool" do
+      it("prints bool") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print true
@@ -764,7 +764,7 @@ describe IO do
         slice.should eq("truefalse".encode("UCS-2LE"))
       end
 
-      it "prints char" do
+      it("prints char") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 'a'
@@ -772,7 +772,7 @@ describe IO do
         slice.should eq("a".encode("UCS-2LE"))
       end
 
-      it "prints symbol" do
+      it("prints symbol") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print :foo
@@ -780,7 +780,7 @@ describe IO do
         slice.should eq("foo".encode("UCS-2LE"))
       end
 
-      it "prints big int" do
+      it("prints big int") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.print 123_456.to_big_i
@@ -788,7 +788,7 @@ describe IO do
         slice.should eq("123456".encode("UCS-2LE"))
       end
 
-      it "puts" do
+      it("puts") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.puts 1
@@ -797,7 +797,7 @@ describe IO do
         slice.should eq("1\n\n".encode("UCS-2LE"))
       end
 
-      it "printf" do
+      it("printf") do
         io = SimpleIOMemory.new
         io.set_encoding("UCS-2LE")
         io.printf "%s-%d-%.2f", "hi", 123, 45.67
@@ -805,44 +805,44 @@ describe IO do
         slice.should eq("hi-123-45.67".encode("UCS-2LE"))
       end
 
-      it "raises on invalid byte sequence" do
+      it("raises on invalid byte sequence") do
         io = SimpleIOMemory.new
         io.set_encoding("GB2312")
-        expect_raises ArgumentError, "Invalid multibyte sequence" do
+        expect_raises(ArgumentError, "Invalid multibyte sequence") do
           io.print "ñ"
         end
       end
 
-      it "skips on invalid byte sequence" do
+      it("skips on invalid byte sequence") do
         io = SimpleIOMemory.new
         io.set_encoding("GB2312", invalid: :skip)
         io.print "ñ"
         io.print "foo"
       end
 
-      it "raises on incomplete byte sequence" do
+      it("raises on incomplete byte sequence") do
         io = SimpleIOMemory.new
         io.set_encoding("GB2312")
-        expect_raises ArgumentError, "Incomplete multibyte sequence" do
+        expect_raises(ArgumentError, "Incomplete multibyte sequence") do
           io.print "好".byte_slice(0, 1)
         end
       end
 
-      it "says invalid encoding" do
+      it("says invalid encoding") do
         io = SimpleIOMemory.new
         io.set_encoding("FOO")
-        expect_raises ArgumentError, "Invalid encoding: FOO" do
+        expect_raises(ArgumentError, "Invalid encoding: FOO") do
           io.puts "a"
         end
       end
     end
 
-    describe "#encoding" do
-      it "returns \"UTF-8\" if the encoding is not manually set" do
+    describe("#encoding") do
+      it("returns \"UTF-8\" if the encoding is not manually set") do
         SimpleIOMemory.new.encoding.should eq("UTF-8")
       end
 
-      it "returns the name of the encoding set via #set_encoding" do
+      it("returns the name of the encoding set via #set_encoding") do
         io = SimpleIOMemory.new
         io.set_encoding("UTF-16LE")
         io.encoding.should eq("UTF-16LE")

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe IO::Memory do
-  it "writes" do
+describe(IO::Memory) do
+  it("writes") do
     io = IO::Memory.new
     io.bytesize.should eq(0)
     io.write Slice.new("hello".to_unsafe, 3)
@@ -10,7 +10,7 @@ describe IO::Memory do
     io.gets_to_end.should eq("hel")
   end
 
-  it "writes big" do
+  it("writes big") do
     s = "hi" * 100
     io = IO::Memory.new
     io.write Slice.new(s.to_unsafe, s.bytesize)
@@ -18,7 +18,7 @@ describe IO::Memory do
     io.gets_to_end.should eq(s)
   end
 
-  it "reads byte" do
+  it("reads byte") do
     io = IO::Memory.new("abc")
     io.read_byte.should eq('a'.ord)
     io.read_byte.should eq('b'.ord)
@@ -26,7 +26,7 @@ describe IO::Memory do
     io.read_byte.should be_nil
   end
 
-  it "raises if reading when closed" do
+  it("raises if reading when closed") do
     io = IO::Memory.new("abc")
     io.close
     expect_raises(IO::Error, "Closed stream") do
@@ -34,7 +34,7 @@ describe IO::Memory do
     end
   end
 
-  it "raises if clearing when closed" do
+  it("raises if clearing when closed") do
     io = IO::Memory.new("abc")
     io.close
     expect_raises(IO::Error, "Closed stream") do
@@ -42,7 +42,7 @@ describe IO::Memory do
     end
   end
 
-  it "appends to another buffer" do
+  it("appends to another buffer") do
     s1 = IO::Memory.new
     s1 << "hello"
 
@@ -51,26 +51,26 @@ describe IO::Memory do
     s2.to_s.should eq("hello")
   end
 
-  it "reads single line content" do
+  it("reads single line content") do
     io = IO::Memory.new("foo")
     io.gets.should eq("foo")
   end
 
-  it "reads each line" do
+  it("reads each line") do
     io = IO::Memory.new("foo\r\nbar\n")
     io.gets.should eq("foo")
     io.gets.should eq("bar")
     io.gets.should eq(nil)
   end
 
-  it "reads each line with chomp = false" do
+  it("reads each line with chomp = false") do
     io = IO::Memory.new("foo\r\nbar\r\n")
     io.gets(chomp: false).should eq("foo\r\n")
     io.gets(chomp: false).should eq("bar\r\n")
     io.gets(chomp: false).should eq(nil)
   end
 
-  it "gets with char as delimiter" do
+  it("gets with char as delimiter") do
     io = IO::Memory.new("hello world")
     io.gets('w').should eq("hello w")
     io.gets('r').should eq("or")
@@ -78,7 +78,7 @@ describe IO::Memory do
     io.gets('r').should eq(nil)
   end
 
-  it "does gets with char and limit" do
+  it("does gets with char and limit") do
     io = IO::Memory.new("hello\nworld\n")
     io.gets('o', 2).should eq("he")
     io.gets('w', 10_000).should eq("llo\nw")
@@ -86,7 +86,7 @@ describe IO::Memory do
     io.gets('a', 3).should be_nil
   end
 
-  it "does gets with limit" do
+  it("does gets with limit") do
     io = IO::Memory.new("hello\nworld")
     io.gets(3).should eq("hel")
     io.gets(3).should eq("lo\n")
@@ -95,34 +95,34 @@ describe IO::Memory do
     io.gets(3).should be_nil
   end
 
-  it "does gets with char and limit without off-by-one" do
+  it("does gets with char and limit without off-by-one") do
     io = IO::Memory.new("test\nabc")
     io.gets('a', 5).should eq("test\n")
     io = IO::Memory.new("test\nabc")
     io.gets('a', 6).should eq("test\na")
   end
 
-  it "raises if invoking gets with negative limit" do
+  it("raises if invoking gets with negative limit") do
     io = IO::Memory.new("hello\nworld\n")
-    expect_raises ArgumentError, "Negative limit" do
+    expect_raises(ArgumentError, "Negative limit") do
       io.gets(-1)
     end
   end
 
-  it "write single byte" do
+  it("write single byte") do
     io = IO::Memory.new
     io.write_byte 97_u8
     io.to_s.should eq("a")
   end
 
-  it "writes and reads" do
+  it("writes and reads") do
     io = IO::Memory.new
     io << "foo" << "bar"
     io.rewind
     io.gets.should eq("foobar")
   end
 
-  it "can be converted to slice" do
+  it("can be converted to slice") do
     str = IO::Memory.new
     str.write_byte 0_u8
     str.write_byte 1_u8
@@ -132,13 +132,13 @@ describe IO::Memory do
     slice[1].should eq(1_u8)
   end
 
-  it "reads more than available (#1229)" do
+  it("reads more than available (#1229)") do
     s = "h" * (10 * 1024)
     str = IO::Memory.new(s)
     str.gets(11 * 1024).should eq(s)
   end
 
-  it "writes after reading" do
+  it("writes after reading") do
     io = IO::Memory.new
     io << "abcdefghi"
     io.rewind
@@ -148,32 +148,32 @@ describe IO::Memory do
     io.gets_to_end.should eq("abcxyzghi")
   end
 
-  it "has a size" do
+  it("has a size") do
     IO::Memory.new("foo").size.should eq(3)
   end
 
-  it "can tell" do
+  it("can tell") do
     io = IO::Memory.new("foo")
     io.tell.should eq(0)
     io.gets(2)
     io.tell.should eq(2)
   end
 
-  it "can seek set" do
+  it("can seek set") do
     io = IO::Memory.new("abcdef")
     io.seek(3)
     io.tell.should eq(3)
     io.gets(1).should eq("d")
   end
 
-  it "raises if seek set is negative" do
+  it("raises if seek set is negative") do
     io = IO::Memory.new("abcdef")
     expect_raises(ArgumentError, "Negative pos") do
       io.seek(-1)
     end
   end
 
-  it "can seek past the end" do
+  it("can seek past the end") do
     io = IO::Memory.new
     io << "abc"
     io.rewind
@@ -184,14 +184,14 @@ describe IO::Memory do
     io.gets_to_end.should eq("abc\u{0}\u{0}\u{0}xyz")
   end
 
-  it "can seek current" do
+  it("can seek current") do
     io = IO::Memory.new("abcdef")
     io.seek(2)
     io.seek(1, IO::Seek::Current)
     io.gets(1).should eq("d")
   end
 
-  it "raises if seek current leads to negative value" do
+  it("raises if seek current leads to negative value") do
     io = IO::Memory.new("abcdef")
     io.seek(2)
     expect_raises(ArgumentError, "Negative pos") do
@@ -199,13 +199,13 @@ describe IO::Memory do
     end
   end
 
-  it "can seek from the end" do
+  it("can seek from the end") do
     io = IO::Memory.new("abcdef")
     io.seek(-2, IO::Seek::End)
     io.gets(1).should eq("e")
   end
 
-  it "can be closed" do
+  it("can be closed") do
     io = IO::Memory.new
     io << "abc"
     io.close
@@ -218,7 +218,7 @@ describe IO::Memory do
     expect_raises(IO::Error, "Closed stream") { io.read_byte }
   end
 
-  it "seeks with pos and pos=" do
+  it("seeks with pos and pos=") do
     io = IO::Memory.new("abcdef")
     io.pos = 4
     io.gets(1).should eq("e")
@@ -226,7 +226,7 @@ describe IO::Memory do
     io.gets(1).should eq("d")
   end
 
-  it "clears" do
+  it("clears") do
     io = IO::Memory.new
     io << "abc"
     io.rewind
@@ -236,19 +236,19 @@ describe IO::Memory do
     io.gets_to_end.should eq("")
   end
 
-  it "raises if negative capacity" do
+  it("raises if negative capacity") do
     expect_raises(ArgumentError, "Negative capacity") do
       IO::Memory.new(-1)
     end
   end
 
-  it "raises if capacity too big" do
+  it("raises if capacity too big") do
     expect_raises(ArgumentError, "Capacity too big") do
       IO::Memory.new(UInt32::MAX)
     end
   end
 
-  it "creates from string" do
+  it("creates from string") do
     io = IO::Memory.new "abcdef"
     io.gets(2).should eq("ab")
     io.gets(3).should eq("cde")
@@ -258,7 +258,7 @@ describe IO::Memory do
     end
   end
 
-  it "creates from slice" do
+  it("creates from slice") do
     slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
     io = IO::Memory.new slice
     io.gets(2).should eq("ab")
@@ -272,7 +272,7 @@ describe IO::Memory do
     end
   end
 
-  it "creates from slice, non-writeable" do
+  it("creates from slice, non-writeable") do
     slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
     io = IO::Memory.new slice, writeable: false
 
@@ -281,21 +281,21 @@ describe IO::Memory do
     end
   end
 
-  it "writes past end" do
+  it("writes past end") do
     io = IO::Memory.new
     io.pos = 1000
     io.print 'a'
     io.to_slice.to_a.should eq([0] * 1000 + [97])
   end
 
-  it "writes past end with write_byte" do
+  it("writes past end with write_byte") do
     io = IO::Memory.new
     io.pos = 1000
     io.write_byte 'a'.ord.to_u8
     io.to_slice.to_a.should eq([0] * 1000 + [97])
   end
 
-  it "reads at offset" do
+  it("reads at offset") do
     io = IO::Memory.new("hello world")
 
     io.read_at(6, 3) do |sub|
@@ -315,7 +315,7 @@ describe IO::Memory do
     end
   end
 
-  it "raises when reading at offset outside of bounds" do
+  it("raises when reading at offset outside of bounds") do
     io = IO::Memory.new("hello world")
 
     expect_raises(ArgumentError, "Negative bytesize") do
@@ -331,13 +331,13 @@ describe IO::Memory do
     end
   end
 
-  it "consumes with gets_to_end" do
+  it("consumes with gets_to_end") do
     io = IO::Memory.new("hello world")
     io.gets_to_end.should eq("hello world")
     io.gets_to_end.should eq("")
   end
 
-  it "peeks" do
+  it("peeks") do
     str = "hello world"
     io = IO::Memory.new(str)
 
@@ -351,7 +351,7 @@ describe IO::Memory do
     io.peek.should eq(Bytes.empty)
   end
 
-  it "skips" do
+  it("skips") do
     io = IO::Memory.new("hello")
     io.skip(2)
     io.gets_to_end.should eq("llo")
@@ -367,22 +367,22 @@ describe IO::Memory do
     end
   end
 
-  it "skips_to_end" do
+  it("skips_to_end") do
     io = IO::Memory.new("hello")
     io.skip_to_end
     io.gets_to_end.should eq("")
   end
 
-  describe "encoding" do
-    describe "decode" do
-      it "gets_to_end" do
+  describe("encoding") do
+    describe("decode") do
+      it("gets_to_end") do
         str = "Hello world" * 200
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
         io.gets_to_end.should eq(str)
       end
 
-      it "gets" do
+      it("gets") do
         str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -391,7 +391,7 @@ describe IO::Memory do
         io.gets(chomp: false).should eq("Bar\n")
       end
 
-      it "gets with chomp = false" do
+      it("gets with chomp = false") do
         str = "Hello world\nFoo\nBar\n" + ("1234567890" * 1000)
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")
@@ -400,7 +400,7 @@ describe IO::Memory do
         io.gets.should eq("Bar")
       end
 
-      it "reads char" do
+      it("reads char") do
         str = "x\nHello world" + ("1234567890" * 1000)
         io = IO::Memory.new(str.encode("UCS-2LE"))
         io.set_encoding("UCS-2LE")

--- a/spec/std/io/multi_writer_spec.cr
+++ b/spec/std/io/multi_writer_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 
-describe "IO::MultiWriter" do
-  describe "#write" do
-    it "writes to multiple IOs" do
+describe("IO::MultiWriter") do
+  describe("#write") do
+    it("writes to multiple IOs") do
       io1 = IO::Memory.new
       io2 = IO::Memory.new
 
@@ -15,8 +15,8 @@ describe "IO::MultiWriter" do
     end
   end
 
-  describe "#read" do
-    it "raises" do
+  describe("#read") do
+    it("raises") do
       writer = IO::MultiWriter.new(Array(IO).new)
 
       expect_raises(IO::Error, "Can't read from IO::MultiWriter") do
@@ -25,8 +25,8 @@ describe "IO::MultiWriter" do
     end
   end
 
-  describe "#close" do
-    it "stops reading" do
+  describe("#close") do
+    it("stops reading") do
       io = IO::Memory.new
       writer = IO::MultiWriter.new(io)
 
@@ -40,7 +40,7 @@ describe "IO::MultiWriter" do
       io.to_s.should eq("")
     end
 
-    it "closes the underlying stream if sync_close is true" do
+    it("closes the underlying stream if sync_close is true") do
       io = IO::Memory.new
       writer = IO::MultiWriter.new(io, sync_close: true)
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -16,9 +16,9 @@ private class NoPeekIO
   end
 end
 
-describe "IO::Sized" do
-  describe "#read" do
-    it "doesn't read past the limit when reading char-by-char" do
+describe("IO::Sized") do
+  describe("#read") do
+    it("doesn't read past the limit when reading char-by-char") do
       io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)
 
@@ -34,7 +34,7 @@ describe "IO::Sized" do
       sized.read_char.should be_nil
     end
 
-    it "doesn't read past the limit when reading the correct size" do
+    it("doesn't read past the limit when reading the correct size") do
       io = IO::Memory.new("1234567")
       sized = IO::Sized.new(io, read_size: 5)
       slice = Bytes.new(5)
@@ -46,7 +46,7 @@ describe "IO::Sized" do
       String.new(slice).should eq("12345")
     end
 
-    it "reads partially when supplied with a larger slice" do
+    it("reads partially when supplied with a larger slice") do
       io = IO::Memory.new("1234567")
       sized = IO::Sized.new(io, read_size: 5)
       slice = Bytes.new(10)
@@ -55,7 +55,7 @@ describe "IO::Sized" do
       String.new(slice).should eq("12345\0\0\0\0\0")
     end
 
-    it "raises on negative numbers" do
+    it("raises on negative numbers") do
       io = IO::Memory.new
       expect_raises(ArgumentError, "Negative read_size") do
         IO::Sized.new(io, read_size: -1)
@@ -63,8 +63,8 @@ describe "IO::Sized" do
     end
   end
 
-  describe "#write" do
-    it "raises" do
+  describe("#write") do
+    it("raises") do
       sized = IO::Sized.new(IO::Memory.new, read_size: 5)
       expect_raises(IO::Error, "Can't write to IO::Sized") do
         sized.puts "test string"
@@ -72,8 +72,8 @@ describe "IO::Sized" do
     end
   end
 
-  describe "#close" do
-    it "stops reading" do
+  describe("#close") do
+    it("stops reading") do
       io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5)
 
@@ -87,7 +87,7 @@ describe "IO::Sized" do
       end
     end
 
-    it "closes the underlying stream if sync_close is true" do
+    it("closes the underlying stream if sync_close is true") do
       io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5, sync_close: true)
       sized.sync_close?.should eq(true)
@@ -98,7 +98,7 @@ describe "IO::Sized" do
     end
   end
 
-  it "read_byte" do
+  it("read_byte") do
     io = IO::Memory.new "abcdefg"
     sized = IO::Sized.new(io, read_size: 3)
     sized.read_byte.should eq('a'.ord)
@@ -107,7 +107,7 @@ describe "IO::Sized" do
     sized.read_byte.should be_nil
   end
 
-  it "gets" do
+  it("gets") do
     io = IO::Memory.new "foo\nbar\nbaz"
     sized = IO::Sized.new(io, read_size: 9)
     sized.gets.should eq("foo")
@@ -116,7 +116,7 @@ describe "IO::Sized" do
     sized.gets.should be_nil
   end
 
-  it "gets with chomp = false" do
+  it("gets with chomp = false") do
     io = IO::Memory.new "foo\nbar\nbaz"
     sized = IO::Sized.new(io, read_size: 9)
     sized.gets(chomp: false).should eq("foo\n")
@@ -125,7 +125,7 @@ describe "IO::Sized" do
     sized.gets(chomp: false).should be_nil
   end
 
-  it "peeks" do
+  it("peeks") do
     io = IO::Memory.new "123456789"
     sized = IO::Sized.new(io, read_size: 6)
     sized.peek.should eq("123456".to_slice)
@@ -133,12 +133,12 @@ describe "IO::Sized" do
     sized.peek.should eq(Bytes.empty)
   end
 
-  it "doesn't peek when remaining = 0 (#4261)" do
+  it("doesn't peek when remaining = 0 (#4261)") do
     sized = IO::Sized.new(NoPeekIO.new, read_size: 0)
     sized.peek.should eq(Bytes.empty)
   end
 
-  it "skips" do
+  it("skips") do
     io = IO::Memory.new "123456789"
     sized = IO::Sized.new(io, read_size: 6)
     sized.skip(3)

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -1,20 +1,20 @@
 require "spec"
 require "iterator"
 
-describe Iterator do
-  describe "Iterator.of" do
-    it "creates singleton" do
+describe(Iterator) do
+  describe("Iterator.of") do
+    it("creates singleton") do
       iter = Iterator.of(42)
       iter.first(3).to_a.should eq([42, 42, 42])
     end
 
-    it "creates singleton from block" do
+    it("creates singleton from block") do
       a = 0
       iter = Iterator.of { a += 1 }
       iter.first(3).to_a.should eq([1, 2, 3])
     end
 
-    it "creates singleton from block can call Iterator.stop" do
+    it("creates singleton from block can call Iterator.stop") do
       a = 0
       iter = Iterator.of do
         if a >= 5
@@ -28,8 +28,8 @@ describe Iterator do
     end
   end
 
-  describe "compact_map" do
-    it "applies the function and removes nil values" do
+  describe("compact_map") do
+    it("applies the function and removes nil values") do
       iter = (1..3).each.compact_map { |e| e.odd? ? e : nil }
       iter.next.should eq(1)
       iter.next.should eq(3)
@@ -39,13 +39,13 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "sums after compact_map to_a" do
+    it("sums after compact_map to_a") do
       (1..3).each.compact_map { |e| e.odd? ? e : nil }.to_a.sum.should eq(4)
     end
   end
 
-  describe "chain" do
-    it "chains" do
+  describe("chain") do
+    it("chains") do
       iter = (1..2).each.chain(('a'..'b').each)
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -61,8 +61,8 @@ describe Iterator do
     end
   end
 
-  describe "compact_map" do
-    it "does not return nil values" do
+  describe("compact_map") do
+    it("does not return nil values") do
       iter = [1, nil, 2, nil].each.compact_map { |e| e.try &.*(2) }
       iter.next.should eq 2
       iter.next.should eq 4
@@ -70,8 +70,8 @@ describe Iterator do
     end
   end
 
-  describe "cons" do
-    it "conses" do
+  describe("cons") do
+    it("conses") do
       iter = (1..5).each.cons(3)
       iter.next.should eq([1, 2, 3])
       iter.next.should eq([2, 3, 4])
@@ -83,8 +83,8 @@ describe Iterator do
     end
   end
 
-  describe "cycle" do
-    it "does cycle from range" do
+  describe("cycle") do
+    it("does cycle from range") do
       iter = (1..3).each.cycle
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -96,13 +96,13 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "cycles an empty array" do
+    it("cycles an empty array") do
       ary = [] of Int32
       values = ary.each.cycle.to_a
       values.empty?.should be_true
     end
 
-    it "cycles N times" do
+    it("cycles N times") do
       iter = (1..2).each.cycle(2)
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -114,19 +114,19 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "does not cycle provided 0" do
+    it("does not cycle provided 0") do
       iter = (1..2).each.cycle(0)
       iter.next.should be_a(Iterator::Stop)
     end
 
-    it "does not cycle provided a negative size" do
+    it("does not cycle provided a negative size") do
       iter = (1..2).each.cycle(-1)
       iter.next.should be_a(Iterator::Stop)
     end
   end
 
-  describe "each" do
-    it "yields the individual elements to the block" do
+  describe("each") do
+    it("yields the individual elements to the block") do
       iter = ["a", "b", "c"].each
       concatinated = ""
       iter.each { |e| concatinated += e }.should be_nil
@@ -134,8 +134,8 @@ describe Iterator do
     end
   end
 
-  describe "each_slice" do
-    it "gets all the slices of the size n" do
+  describe("each_slice") do
+    it("gets all the slices of the size n") do
       iter = (1..9).each.each_slice(3)
       iter.next.should eq [1, 2, 3]
       iter.next.should eq [4, 5, 6]
@@ -143,14 +143,14 @@ describe Iterator do
       iter.next.should be_a Iterator::Stop
     end
 
-    it "also works if it does not add up" do
+    it("also works if it does not add up") do
       iter = (1..4).each.each_slice(3)
       iter.next.should eq [1, 2, 3]
       iter.next.should eq [4]
       iter.next.should be_a Iterator::Stop
     end
 
-    it "returns each_slice iterator with reuse = true" do
+    it("returns each_slice iterator with reuse = true") do
       iter = (1..5).each.each_slice(2, reuse: true)
 
       a = iter.next
@@ -161,7 +161,7 @@ describe Iterator do
       b.should be(a)
     end
 
-    it "returns each_slice iterator with reuse = array" do
+    it("returns each_slice iterator with reuse = array") do
       reuse = [] of Int32
       iter = (1..5).each.each_slice(2, reuse: reuse)
 
@@ -175,8 +175,8 @@ describe Iterator do
     end
   end
 
-  describe "in_groups_of" do
-    it "creats groups of one" do
+  describe("in_groups_of") do
+    it("creats groups of one") do
       iter = (1..3).each.in_groups_of(1)
       iter.next.should eq([1])
       iter.next.should eq([2])
@@ -187,7 +187,7 @@ describe Iterator do
       iter.next.should eq [1]
     end
 
-    it "creats a group of two" do
+    it("creats a group of two") do
       iter = (1..3).each.in_groups_of(2)
       iter.next.should eq([1, 2])
       iter.next.should eq([3, nil])
@@ -197,7 +197,7 @@ describe Iterator do
       iter.next.should eq [1, 2]
     end
 
-    it "fills up with the fill up argument" do
+    it("fills up with the fill up argument") do
       iter = (1..3).each.in_groups_of(2, 'z')
       iter.next.should eq([1, 2])
       iter.next.should eq([3, 'z'])
@@ -207,18 +207,18 @@ describe Iterator do
       iter.next.should eq [1, 2]
     end
 
-    it "raises argument error if size is less than 0" do
-      expect_raises ArgumentError, "Size must be positive" do
+    it("raises argument error if size is less than 0") do
+      expect_raises(ArgumentError, "Size must be positive") do
         [1, 2, 3].each.in_groups_of(0)
       end
     end
 
-    it "still works with other iterator methods like to_a" do
+    it("still works with other iterator methods like to_a") do
       iter = (1..3).each.in_groups_of(2, 'z')
       iter.to_a.should eq [[1, 2], [3, 'z']]
     end
 
-    it "creats a group of two with reuse = true" do
+    it("creats a group of two with reuse = true") do
       iter = (1..3).each.in_groups_of(2, reuse: true)
 
       a = iter.next
@@ -235,8 +235,8 @@ describe Iterator do
     end
   end
 
-  describe "map" do
-    it "does map with Range iterator" do
+  describe("map") do
+    it("does map with Range iterator") do
       iter = (1..3).each.map &.*(2)
       iter.next.should eq(2)
       iter.next.should eq(4)
@@ -248,8 +248,8 @@ describe Iterator do
     end
   end
 
-  describe "reject" do
-    it "does reject with Range iterator" do
+  describe("reject") do
+    it("does reject with Range iterator") do
       iter = (1..3).each.reject &.>=(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
@@ -259,8 +259,8 @@ describe Iterator do
     end
   end
 
-  describe "select" do
-    it "does select with Range iterator" do
+  describe("select") do
+    it("does select with Range iterator") do
       iter = (1..3).each.select &.>=(2)
       iter.next.should eq(2)
       iter.next.should eq(3)
@@ -271,8 +271,8 @@ describe Iterator do
     end
   end
 
-  describe "skip" do
-    it "does skip with Range iterator" do
+  describe("skip") do
+    it("does skip with Range iterator") do
       iter = (1..3).each.skip(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
@@ -281,19 +281,19 @@ describe Iterator do
       iter.next.should eq(3)
     end
 
-    it "is cool to skip 0 elements" do
+    it("is cool to skip 0 elements") do
       (1..3).each.skip(0).to_a.should eq [1, 2, 3]
     end
 
-    it "raises ArgumentError if negative size is provided" do
+    it("raises ArgumentError if negative size is provided") do
       expect_raises(ArgumentError) do
         (1..3).each.skip(-1)
       end
     end
   end
 
-  describe "skip_while" do
-    it "does skip_while with an array" do
+  describe("skip_while") do
+    it("does skip_while with an array") do
       iter = [1, 2, 3, 4, 0].each.skip_while { |i| i < 3 }
       iter.next.should eq(3)
       iter.next.should eq(4)
@@ -304,17 +304,17 @@ describe Iterator do
       iter.next.should eq(3)
     end
 
-    it "can skip everything" do
+    it("can skip everything") do
       iter = (1..3).each.skip_while { true }
       iter.to_a.should eq [] of Int32
     end
 
-    it "returns the full array if the condition is false for the first item" do
+    it("returns the full array if the condition is false for the first item") do
       iter = (1..2).each.skip_while { false }
       iter.to_a.should eq [1, 2]
     end
 
-    it "only calls the block as much as needed" do
+    it("only calls the block as much as needed") do
       called = 0
       iter = (1..5).each.skip_while do |i|
         called += 1
@@ -325,8 +325,8 @@ describe Iterator do
     end
   end
 
-  describe "slice" do
-    it "slices" do
+  describe("slice") do
+    it("slices") do
       iter = (1..8).each.slice(3)
       iter.next.should eq([1, 2, 3])
       iter.next.should eq([4, 5, 6])
@@ -338,8 +338,8 @@ describe Iterator do
     end
   end
 
-  describe "step" do
-    it "returns every element" do
+  describe("step") do
+    it("returns every element") do
       iter = (1..3).each.step(1)
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -347,7 +347,7 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
-    it "returns every other element" do
+    it("returns every other element") do
       iter = (1..5).each.step(2)
       iter.next.should eq(1)
       iter.next.should eq(3)
@@ -355,7 +355,7 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
-    it "returns every third element" do
+    it("returns every third element") do
       iter = (1..12).each.step(3)
       iter.next.should eq(1)
       iter.next.should eq(4)
@@ -364,7 +364,7 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
-    it "raises with nonsensical steps" do
+    it("raises with nonsensical steps") do
       expect_raises(ArgumentError) do
         (1..2).each.step(0)
       end
@@ -375,8 +375,8 @@ describe Iterator do
     end
   end
 
-  describe "first" do
-    it "does first with Range iterator" do
+  describe("first") do
+    it("does first with Range iterator") do
       iter = (1..3).each.first(2)
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -386,24 +386,24 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "does first with more than available" do
+    it("does first with more than available") do
       (1..3).each.first(10).to_a.should eq([1, 2, 3])
     end
 
-    it "is cool to first 0 elements" do
+    it("is cool to first 0 elements") do
       iter = (1..3).each.first(0)
       iter.next.should be_a Iterator::Stop
     end
 
-    it "raises ArgumentError if negative size is provided" do
+    it("raises ArgumentError if negative size is provided") do
       expect_raises(ArgumentError) do
         (1..3).each.first(-1)
       end
     end
   end
 
-  describe "take_while" do
-    it "does take_while with Range iterator" do
+  describe("take_while") do
+    it("does take_while with Range iterator") do
       iter = (1..5).each.take_while { |i| i < 3 }
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -413,11 +413,11 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "does take_while with more than available" do
+    it("does take_while with more than available") do
       (1..3).each.take_while { true }.to_a.should eq([1, 2, 3])
     end
 
-    it "only calls the block as much as needed" do
+    it("only calls the block as much as needed") do
       called = 0
       iter = (1..5).each.take_while do |i|
         called += 1
@@ -428,8 +428,8 @@ describe Iterator do
     end
   end
 
-  describe "tap" do
-    it "taps" do
+  describe("tap") do
+    it("taps") do
       a = 0
 
       iter = (1..3).each.tap { |x| a += x }
@@ -449,8 +449,8 @@ describe Iterator do
     end
   end
 
-  describe "uniq" do
-    it "without block" do
+  describe("uniq") do
+    it("without block") do
       iter = (1..8).each.map { |x| x % 3 }.uniq
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -461,7 +461,7 @@ describe Iterator do
       iter.next.should eq(1)
     end
 
-    it "with block" do
+    it("with block") do
       iter = (1..8).each.uniq { |x| (x % 3).to_s }
       iter.next.should eq(1)
       iter.next.should eq(2)
@@ -473,8 +473,8 @@ describe Iterator do
     end
   end
 
-  describe "with_index" do
-    it "does with_index from range" do
+  describe("with_index") do
+    it("does with_index from range") do
       iter = (1..3).each.with_index
       iter.next.should eq({1, 0})
       iter.next.should eq({2, 1})
@@ -485,7 +485,7 @@ describe Iterator do
       iter.next.should eq({1, 0})
     end
 
-    it "does with_index with offset from range" do
+    it("does with_index with offset from range") do
       iter = (1..3).each.with_index(10)
       iter.next.should eq({1, 10})
       iter.next.should eq({2, 11})
@@ -496,7 +496,7 @@ describe Iterator do
       iter.next.should eq({1, 10})
     end
 
-    it "does with_index from range, with block" do
+    it("does with_index from range, with block") do
       tuples = [] of {Int32, Int32}
       (1..3).each.with_index do |value, index|
         tuples << {value, index}
@@ -504,7 +504,7 @@ describe Iterator do
       tuples.should eq([{1, 0}, {2, 1}, {3, 2}])
     end
 
-    it "does with_index from range, with block with offset" do
+    it("does with_index from range, with block with offset") do
       tuples = [] of {Int32, Int32}
       (1..3).each.with_index(10) do |value, index|
         tuples << {value, index}
@@ -513,8 +513,8 @@ describe Iterator do
     end
   end
 
-  describe "with object" do
-    it "does with object" do
+  describe("with object") do
+    it("does with object") do
       iter = (1..3).each.with_object("a")
       iter.next.should eq({1, "a"})
       iter.next.should eq({2, "a"})
@@ -526,8 +526,8 @@ describe Iterator do
     end
   end
 
-  describe "zip" do
-    it "does skip with Range iterator" do
+  describe("zip") do
+    it("does skip with Range iterator") do
       r1 = (1..3).each
       r2 = ('a'..'c').each
       iter = r1.zip(r2)
@@ -544,8 +544,8 @@ describe Iterator do
     end
   end
 
-  describe "integreation" do
-    it "combines many iterators" do
+  describe("integreation") do
+    it("combines many iterators") do
       (1..100).each
               .select { |x| 50 <= x < 60 }
               .map { |x| x * 2 }
@@ -555,8 +555,8 @@ describe Iterator do
     end
   end
 
-  describe "flatten" do
-    it "flattens an iterator of mixed-type iterators" do
+  describe("flatten") do
+    it("flattens an iterator of mixed-type iterators") do
       iter = [(1..2).each, ('a'..'b').each, {:c => 3}.each].each.flatten
 
       iter.next.should eq(1)
@@ -574,7 +574,7 @@ describe Iterator do
       iter.to_a.should eq([1, 2, 'a', 'b', {:c, 3}])
     end
 
-    it "flattens an iterator of mixed-type elements and iterators" do
+    it("flattens an iterator of mixed-type elements and iterators") do
       iter = [(1..2).each, 'a'].each.flatten
 
       iter.next.should eq(1)
@@ -590,7 +590,7 @@ describe Iterator do
       iter.to_a.should eq([1, 2, 'a'])
     end
 
-    it "flattens an iterator of mixed-type elements and iterators and iterators of iterators" do
+    it("flattens an iterator of mixed-type elements and iterators and iterators of iterators") do
       iter = [(1..2).each, [['a', 'b'].each].each, "foo"].each.flatten
 
       iter.next.should eq(1)
@@ -608,7 +608,7 @@ describe Iterator do
       iter.to_a.should eq([1, 2, 'a', 'b', "foo"])
     end
 
-    it "flattens deeply-nested and mixed type iterators" do
+    it("flattens deeply-nested and mixed type iterators") do
       iter = [[[1], 2], [3, [[4, 5], 6], 7], "a"].each.flatten
 
       iter.next.should eq(1)
@@ -629,13 +629,13 @@ describe Iterator do
       iter.to_a.should eq([1, 2, 3, 4, 5, 6, 7, "a"])
     end
 
-    it "flattens a variety of edge cases" do
+    it("flattens a variety of edge cases") do
       ([] of Nil).each.flatten.to_a.should eq([] of Nil)
       ['a'].each.flatten.to_a.should eq(['a'])
       [[[[[["hi"]]]]]].each.flatten.to_a.should eq(["hi"])
     end
 
-    it "flattens a deeply-nested iterables and arrays (#3703)" do
+    it("flattens a deeply-nested iterables and arrays (#3703)") do
       iter = [[1, {2, 3}, 4], [{5 => 6}, 7]].each.flatten
 
       iter.next.should eq(1)
@@ -646,7 +646,7 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
-    it "return iterator itself by rewind" do
+    it("return iterator itself by rewind") do
       iter = [1, [2, 3], 4].each.flatten
 
       iter.to_a.should eq([1, 2, 3, 4])
@@ -654,8 +654,8 @@ describe Iterator do
     end
   end
 
-  describe "#flat_map" do
-    it "flattens returned arrays" do
+  describe("#flat_map") do
+    it("flattens returned arrays") do
       iter = [1, 2, 3].each.flat_map { |x| [x, x] }
 
       iter.next.should eq(1)
@@ -668,7 +668,7 @@ describe Iterator do
       iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
     end
 
-    it "flattens returned items" do
+    it("flattens returned items") do
       iter = [1, 2, 3].each.flat_map { |x| x }
 
       iter.next.should eq(1)
@@ -678,7 +678,7 @@ describe Iterator do
       iter.rewind.to_a.should eq([1, 2, 3])
     end
 
-    it "flattens returned iterators" do
+    it("flattens returned iterators") do
       iter = [1, 2, 3].each.flat_map { |x| [x, x].each }
 
       iter.next.should eq(1)
@@ -691,7 +691,7 @@ describe Iterator do
       iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
     end
 
-    it "flattens returned values" do
+    it("flattens returned values") do
       iter = [1, 2, 3].each.flat_map do |x|
         case x
         when 1

--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -1,13 +1,13 @@
 require "spec"
 require "json"
 
-describe JSON::Any do
-  describe "casts" do
-    it "gets nil" do
+describe(JSON::Any) do
+  describe("casts") do
+    it("gets nil") do
       JSON.parse("null").as_nil.should be_nil
     end
 
-    it "gets bool" do
+    it("gets bool") do
       JSON.parse("true").as_bool.should be_true
       JSON.parse("false").as_bool.should be_false
       JSON.parse("true").as_bool?.should be_true
@@ -15,7 +15,7 @@ describe JSON::Any do
       JSON.parse("2").as_bool?.should be_nil
     end
 
-    it "gets int" do
+    it("gets int") do
       JSON.parse("123").as_i.should eq(123)
       JSON.parse("123456789123456").as_i64.should eq(123456789123456)
       JSON.parse("123").as_i?.should eq(123)
@@ -24,7 +24,7 @@ describe JSON::Any do
       JSON.parse("true").as_i64?.should be_nil
     end
 
-    it "gets float" do
+    it("gets float") do
       JSON.parse("123.45").as_f.should eq(123.45)
       JSON.parse("123.45").as_f32.should eq(123.45_f32)
       JSON.parse("123.45").as_f?.should eq(123.45)
@@ -33,61 +33,61 @@ describe JSON::Any do
       JSON.parse("true").as_f32?.should be_nil
     end
 
-    it "gets string" do
+    it("gets string") do
       JSON.parse(%("hello")).as_s.should eq("hello")
       JSON.parse(%("hello")).as_s?.should eq("hello")
       JSON.parse("true").as_s?.should be_nil
     end
 
-    it "gets array" do
+    it("gets array") do
       JSON.parse(%([1, 2, 3])).as_a.should eq([1, 2, 3])
       JSON.parse(%([1, 2, 3])).as_a?.should eq([1, 2, 3])
       JSON.parse("true").as_a?.should be_nil
     end
 
-    it "gets hash" do
+    it("gets hash") do
       JSON.parse(%({"foo": "bar"})).as_h.should eq({"foo" => "bar"})
       JSON.parse(%({"foo": "bar"})).as_h?.should eq({"foo" => "bar"})
       JSON.parse("true").as_h?.should be_nil
     end
   end
 
-  describe "#size" do
-    it "of array" do
+  describe("#size") do
+    it("of array") do
       JSON.parse("[1, 2, 3]").size.should eq(3)
     end
 
-    it "of hash" do
+    it("of hash") do
       JSON.parse(%({"foo": "bar"})).size.should eq(1)
     end
   end
 
-  describe "#[]" do
-    it "of array" do
+  describe("#[]") do
+    it("of array") do
       JSON.parse("[1, 2, 3]")[1].raw.should eq(2)
     end
 
-    it "of hash" do
+    it("of hash") do
       JSON.parse(%({"foo": "bar"}))["foo"].raw.should eq("bar")
     end
   end
 
-  describe "#[]?" do
-    it "of array" do
+  describe("#[]?") do
+    it("of array") do
       JSON.parse("[1, 2, 3]")[1]?.not_nil!.raw.should eq(2)
       JSON.parse("[1, 2, 3]")[3]?.should be_nil
       JSON.parse("[true, false]")[1]?.should eq false
     end
 
-    it "of hash" do
+    it("of hash") do
       JSON.parse(%({"foo": "bar"}))["foo"]?.not_nil!.raw.should eq("bar")
       JSON.parse(%({"foo": "bar"}))["fox"]?.should be_nil
       JSON.parse(%q<{"foo": false}>)["foo"]?.should eq false
     end
   end
 
-  describe "each" do
-    it "of array" do
+  describe("each") do
+    it("of array") do
       elems = [] of Int32
       JSON.parse("[1, 2, 3]").each do |any|
         elems << any.as_i
@@ -95,7 +95,7 @@ describe JSON::Any do
       elems.should eq([1, 2, 3])
     end
 
-    it "of hash" do
+    it("of hash") do
       elems = [] of String
       JSON.parse(%({"foo": "bar"})).each do |key, value|
         elems << key.to_s << value.to_s
@@ -104,27 +104,27 @@ describe JSON::Any do
     end
   end
 
-  it "traverses big structure" do
+  it("traverses big structure") do
     obj = JSON.parse(%({"foo": [1, {"bar": [2, 3]}]}))
     obj["foo"][1]["bar"][1].as_i.should eq(3)
   end
 
-  it "compares to other objects" do
+  it("compares to other objects") do
     obj = JSON.parse(%([1, 2]))
     obj.should eq([1, 2])
     obj[0].should eq(1)
   end
 
-  it "can compare with ===" do
+  it("can compare with ===") do
     (1 === JSON.parse("1")).should be_truthy
   end
 
-  it "exposes $~ when doing Regex#===" do
+  it("exposes $~ when doing Regex#===") do
     (/o+/ === JSON.parse(%("foo"))).should be_truthy
     $~[0].should eq("oo")
   end
 
-  it "is enumerable" do
+  it("is enumerable") do
     nums = JSON.parse("[1, 2, 3]")
     nums.each_with_index do |x, i|
       x.should be_a(JSON::Any)

--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -14,76 +14,76 @@ private class TestObject
   end
 end
 
-describe JSON::Builder do
-  it "writes null" do
+describe(JSON::Builder) do
+  it("writes null") do
     assert_built("null") do
       null
     end
   end
 
-  it "writes bool" do
+  it("writes bool") do
     assert_built("true") do
       bool(true)
     end
   end
 
-  it "writes integer" do
+  it("writes integer") do
     assert_built("123") do
       number(123)
     end
   end
 
-  it "writes float" do
+  it("writes float") do
     assert_built("123.45") do
       number(123.45)
     end
   end
 
-  it "errors on nan" do
+  it("errors on nan") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
-    expect_raises JSON::Error, "NaN not allowed in JSON" do
+    expect_raises(JSON::Error, "NaN not allowed in JSON") do
       json.number(0.0/0.0)
     end
   end
 
-  it "errors on infinity" do
+  it("errors on infinity") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
-    expect_raises JSON::Error, "Infinity not allowed in JSON" do
+    expect_raises(JSON::Error, "Infinity not allowed in JSON") do
       json.number(1.0/0.0)
     end
   end
 
-  it "writes string" do
+  it("writes string") do
     assert_built(%<"hello">) do
       string("hello")
     end
   end
 
-  it "writes string with controls and slashes " do
+  it("writes string with controls and slashes ") do
     assert_built("\" \\\" \\\\ \\b \\f \\n \\r \\t \\u0019 \"") do
       string(" \" \\ \b \f \n \r \t \u{19} ")
     end
   end
 
-  it "errors if writing before document start" do
+  it("errors if writing before document start") do
     json = JSON::Builder.new(IO::Memory.new)
-    expect_raises JSON::Error, "Write before start_document" do
+    expect_raises(JSON::Error, "Write before start_document") do
       json.number(1)
     end
   end
 
-  it "errors if writing two scalars" do
+  it("errors if writing two scalars") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
     json.number(1)
-    expect_raises JSON::Error, "Write past end_document and before start_document" do
+    expect_raises(JSON::Error, "Write past end_document and before start_document") do
       json.number(2)
     end
   end
 
-  it "writes array" do
+  it("writes array") do
     assert_built(%<[1,"hello",true]>) do
       array do
         number(1)
@@ -93,7 +93,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes nested array" do
+  it("writes nested array") do
     assert_built(%<[1,["hello",true],2]>) do
       array do
         number(1)
@@ -106,7 +106,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes object" do
+  it("writes object") do
     assert_built(%<{"foo":1,"bar":2}>) do
       object do
         string("foo")
@@ -117,7 +117,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes nested object" do
+  it("writes nested object") do
     assert_built(%<{"foo":{"bar":2,"baz":3},"another":{"baz":3}}>) do
       object do
         string("foo")
@@ -136,7 +136,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes array with indent level" do
+  it("writes array with indent level") do
     assert_built(%<[\n  1,\n  2,\n  3\n]>) do |json|
       json.indent = 2
       array do
@@ -147,7 +147,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes array with indent string" do
+  it("writes array with indent string") do
     assert_built(%<[\n\t1,\n\t2,\n\t3\n]>) do |json|
       json.indent = "\t"
       array do
@@ -158,7 +158,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes object with indent level" do
+  it("writes object with indent level") do
     assert_built(%<{\n  "foo": 1,\n  "bar": 2\n}>) do |json|
       json.indent = 2
       object do
@@ -170,7 +170,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes empty array with indent level" do
+  it("writes empty array with indent level") do
     assert_built(%<[]>) do |json|
       json.indent = 2
       array do
@@ -178,7 +178,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes empty object with indent level" do
+  it("writes empty object with indent level") do
     assert_built(%<{}>) do |json|
       json.indent = 2
       object do
@@ -186,7 +186,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes nested array" do
+  it("writes nested array") do
     assert_built(%<[\n  []\n]>) do |json|
       json.indent = 2
       array do
@@ -196,7 +196,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes object with scalar and indent" do
+  it("writes object with scalar and indent") do
     assert_built(%<{\n  "foo": 1\n}>) do |json|
       json.indent = 2
       object do
@@ -206,7 +206,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes object with array and scalar and indent" do
+  it("writes object with array and scalar and indent") do
     assert_built(%<{\n  "foo": [\n    1\n  ]\n}>) do |json|
       json.indent = 2
       object do
@@ -218,7 +218,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes raw" do
+  it("writes raw") do
     assert_built(%<{\n  "foo": [1, 2, 3],\n  "bar": [\n    [4, 5, 6]\n  ]\n}>) do |json|
       json.indent = 2
       object do
@@ -232,33 +232,33 @@ describe JSON::Builder do
     end
   end
 
-  it "raises if nothing written" do
+  it("raises if nothing written") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
-    expect_raises JSON::Error, "Empty JSON" do
+    expect_raises(JSON::Error, "Empty JSON") do
       json.end_document
     end
   end
 
-  it "raises if array is left open" do
+  it("raises if array is left open") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
     json.start_array
-    expect_raises JSON::Error, "Unterminated JSON array" do
+    expect_raises(JSON::Error, "Unterminated JSON array") do
       json.end_document
     end
   end
 
-  it "raises if object is left open" do
+  it("raises if object is left open") do
     json = JSON::Builder.new(IO::Memory.new)
     json.start_document
     json.start_object
-    expect_raises JSON::Error, "Unterminated JSON object" do
+    expect_raises(JSON::Error, "Unterminated JSON object") do
       json.end_document
     end
   end
 
-  it "writes field with scalar in object" do
+  it("writes field with scalar in object") do
     assert_built(%<{"int":42,"float":0.815,"null":null,"bool":true,"string":"string"}>) do
       object do
         field "int", 42
@@ -270,7 +270,7 @@ describe JSON::Builder do
     end
   end
 
-  it "writes field with arbitrary value in object" do
+  it("writes field with arbitrary value in object") do
     assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do
       object do
         field "hash", {"hash" => "value"}

--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -2,13 +2,13 @@ require "spec"
 require "json"
 
 private def it_lexes(string, expected_type, file = __FILE__, line = __LINE__)
-  it "lexes #{string} from string", file, line do
+  it("lexes #{string} from string", file, line) do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
     token.type.should eq(expected_type)
   end
 
-  it "lexes #{string} from IO", file, line do
+  it("lexes #{string} from IO", file, line) do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(expected_type)
@@ -16,14 +16,14 @@ private def it_lexes(string, expected_type, file = __FILE__, line = __LINE__)
 end
 
 private def it_lexes_string(string, string_value, file = __FILE__, line = __LINE__)
-  it "lexes #{string} from String", file, line do
+  it("lexes #{string} from String", file, line) do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
     token.type.should eq(:STRING)
     token.string_value.should eq(string_value)
   end
 
-  it "lexes #{string} from IO", file, line do
+  it("lexes #{string} from IO", file, line) do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:STRING)
@@ -32,7 +32,7 @@ private def it_lexes_string(string, string_value, file = __FILE__, line = __LINE
 end
 
 private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
-  it "lexes #{string} from String", file, line do
+  it("lexes #{string} from String", file, line) do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
     token.type.should eq(:INT)
@@ -40,7 +40,7 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
     token.raw_value.should eq(string)
   end
 
-  it "lexes #{string} from IO", file, line do
+  it("lexes #{string} from IO", file, line) do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:INT)
@@ -50,7 +50,7 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
 end
 
 private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__)
-  it "lexes #{string} from String", file, line do
+  it("lexes #{string} from String", file, line) do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
     token.type.should eq(:FLOAT)
@@ -58,7 +58,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
     token.raw_value.should eq(string)
   end
 
-  it "lexes #{string} from IO", file, line do
+  it("lexes #{string} from IO", file, line) do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
     token.type.should eq(:FLOAT)
@@ -67,7 +67,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
   end
 end
 
-describe JSON::Lexer do
+describe(JSON::Lexer) do
   it_lexes "", :EOF
   it_lexes "{", :"{"
   it_lexes "}", :"}"

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -153,15 +153,15 @@ private class JSONWithPresence
   })
 end
 
-describe "JSON mapping" do
-  it "parses person" do
+describe("JSON mapping") do
+  it("parses person") do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
     person.should be_a(JSONPerson)
     person.name.should eq("John")
     person.age.should eq(30)
   end
 
-  it "parses person without age" do
+  it("parses person without age") do
     person = JSONPerson.from_json(%({"name": "John"}))
     person.should be_a(JSONPerson)
     person.name.should eq("John")
@@ -169,26 +169,26 @@ describe "JSON mapping" do
     person.age.should be_nil
   end
 
-  it "parses array of people" do
+  it("parses array of people") do
     people = Array(JSONPerson).from_json(%([{"name": "John"}, {"name": "Doe"}]))
     people.size.should eq(2)
   end
 
-  it "does to_json" do
+  it("does to_json") do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
     person2 = JSONPerson.from_json(person.to_json)
     person2.should eq(person)
   end
 
-  it "parses person with unknown attributes" do
+  it("parses person with unknown attributes") do
     person = JSONPerson.from_json(%({"name": "John", "age": 30, "foo": "bar"}))
     person.should be_a(JSONPerson)
     person.name.should eq("John")
     person.age.should eq(30)
   end
 
-  it "parses strict person with unknown attributes" do
-    ex = expect_raises JSON::ParseException, "Unknown json attribute: foo" do
+  it("parses strict person with unknown attributes") do
+    ex = expect_raises(JSON::ParseException, "Unknown json attribute: foo") do
       StrictJSONPerson.from_json <<-JSON
         {
           "name": "John",
@@ -200,83 +200,83 @@ describe "JSON mapping" do
     ex.location.should eq({4, 3})
   end
 
-  it "raises if non-nilable attribute is nil" do
-    ex = expect_raises JSON::ParseException, "Missing json attribute: name" do
+  it("raises if non-nilable attribute is nil") do
+    ex = expect_raises(JSON::ParseException, "Missing json attribute: name") do
       JSONPerson.from_json(%({"age": 30}))
     end
     ex.location.should eq({1, 1})
   end
 
-  it "doesn't emit null by default when doing to_json" do
+  it("doesn't emit null by default when doing to_json") do
     person = JSONPerson.from_json(%({"name": "John"}))
     (person.to_json =~ /age/).should be_falsey
   end
 
-  it "emits null on request when doing to_json" do
+  it("emits null on request when doing to_json") do
     person = JSONPersonEmittingNull.from_json(%({"name": "John"}))
     (person.to_json =~ /age/).should be_truthy
   end
 
-  it "doesn't raises on false value when not-nil" do
+  it("doesn't raises on false value when not-nil") do
     json = JSONWithBool.from_json(%({"value": false}))
     json.value.should be_false
   end
 
-  it "parses json with Time::Format converter" do
+  it("parses json with Time::Format converter") do
     json = JSONWithTime.from_json(%({"value": "2014-10-31 23:37:16"}))
     json.value.should be_a(Time)
     json.value.to_s.should eq("2014-10-31 23:37:16")
     json.to_json.should eq(%({"value":"2014-10-31 23:37:16"}))
   end
 
-  it "allows setting a nilable property to nil" do
+  it("allows setting a nilable property to nil") do
     person = JSONPerson.new("John")
     person.age = 1
     person.age = nil
   end
 
-  it "parses simple mapping" do
+  it("parses simple mapping") do
     person = JSONWithSimpleMapping.from_json(%({"name": "John", "age": 30}))
     person.should be_a(JSONWithSimpleMapping)
     person.name.should eq("John")
     person.age.should eq(30)
   end
 
-  it "outputs with converter when nilable" do
+  it("outputs with converter when nilable") do
     json = JSONWithNilableTime.new
     json.to_json.should eq("{}")
   end
 
-  it "outputs with converter when nilable when emit_null is true" do
+  it("outputs with converter when nilable when emit_null is true") do
     json = JSONWithNilableTimeEmittingNull.new
     json.to_json.should eq(%({"value":null}))
   end
 
-  it "parses json with keywords" do
+  it("parses json with keywords") do
     json = JSONWithKeywordsMapping.from_json(%({"end": 1, "abstract": 2}))
     json.end.should eq(1)
     json.abstract.should eq(2)
   end
 
-  it "parses json with any" do
+  it("parses json with any") do
     json = JSONWithAny.from_json(%({"name": "Hi", "any": [{"x": 1}, 2, "hey", true, false, 1.5, null]}))
     json.name.should eq("Hi")
     json.any.raw.should eq([{"x" => 1}, 2, "hey", true, false, 1.5, nil])
     json.to_json.should eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
   end
 
-  it "parses json with problematic keys" do
+  it("parses json with problematic keys") do
     json = JsonWithProblematicKeys.from_json(%({"key": 1, "pull": 2}))
     json.key.should eq(1)
     json.pull.should eq(2)
   end
 
-  it "parses json array as set" do
+  it("parses json array as set") do
     json = JsonWithSet.from_json(%({"set": ["a", "a", "b"]}))
     json.set.should eq(Set(String){"a", "b"})
   end
 
-  it "allows small types of integer" do
+  it("allows small types of integer") do
     json = JSONWithSmallIntegers.from_json(%({"foo": 23, "bar": 7}))
 
     json.foo.should eq(23)
@@ -286,8 +286,8 @@ describe "JSON mapping" do
     typeof(json.bar).should eq(Int8)
   end
 
-  describe "parses json with defaults" do
-    it "mixed" do
+  describe("parses json with defaults") do
+    it("mixed") do
       json = JsonWithDefaults.from_json(%({"a":1,"b":"bla"}))
       json.a.should eq 1
       json.b.should eq "bla"
@@ -309,7 +309,7 @@ describe "JSON mapping" do
       json.b.should eq "Haha"
     end
 
-    it "bool" do
+    it("bool") do
       json = JsonWithDefaults.from_json(%({}))
       json.c.should eq true
       typeof(json.c).should eq Bool
@@ -327,7 +327,7 @@ describe "JSON mapping" do
       json.d.should eq true
     end
 
-    it "with nilable" do
+    it("with nilable") do
       json = JsonWithDefaults.from_json(%({}))
 
       json.e.should eq false
@@ -345,7 +345,7 @@ describe "JSON mapping" do
       json.e.should eq true
     end
 
-    it "create new array every time" do
+    it("create new array every time") do
       json = JsonWithDefaults.from_json(%({}))
       json.h.should eq [1, 2, 3]
       json.h << 4
@@ -356,7 +356,7 @@ describe "JSON mapping" do
     end
   end
 
-  it "uses Time::EpochConverter" do
+  it("uses Time::EpochConverter") do
     string = %({"value":1459859781})
     json = JSONWithTimeEpoch.from_json(string)
     json.value.should be_a(Time)
@@ -364,7 +364,7 @@ describe "JSON mapping" do
     json.to_json.should eq(string)
   end
 
-  it "uses Time::EpochMillisConverter" do
+  it("uses Time::EpochMillisConverter") do
     string = %({"value":1459860483856})
     json = JSONWithTimeEpochMillis.from_json(string)
     json.value.should be_a(Time)
@@ -372,28 +372,28 @@ describe "JSON mapping" do
     json.to_json.should eq(string)
   end
 
-  it "parses raw value from int" do
+  it("parses raw value from int") do
     string = %({"value":123456789123456789123456789123456789})
     json = JSONWithRaw.from_json(string)
     json.value.should eq("123456789123456789123456789123456789")
     json.to_json.should eq(string)
   end
 
-  it "parses raw value from float" do
+  it("parses raw value from float") do
     string = %({"value":123456789123456789.123456789123456789})
     json = JSONWithRaw.from_json(string)
     json.value.should eq("123456789123456789.123456789123456789")
     json.to_json.should eq(string)
   end
 
-  it "parses raw value from object" do
+  it("parses raw value from object") do
     string = %({"value":[null,true,false,{"x":[1,1.5]}]})
     json = JSONWithRaw.from_json(string)
     json.value.should eq(%([null,true,false,{"x":[1,1.5]}]))
     json.to_json.should eq(string)
   end
 
-  it "parses with root" do
+  it("parses with root") do
     json = %({"result":{"heroes":[{"name":"Batman"}]}})
     result = JSONWithRoot.from_json(json)
     result.result.should be_a(Array(JSONPerson))
@@ -401,21 +401,21 @@ describe "JSON mapping" do
     result.to_json.should eq(json)
   end
 
-  it "parses with nilable root" do
+  it("parses with nilable root") do
     json = %({"result":null})
     result = JSONWithNilableRoot.from_json(json)
     result.result.should be_nil
     result.to_json.should eq("{}")
   end
 
-  it "parses with nilable root and emit null" do
+  it("parses with nilable root and emit null") do
     json = %({"result":null})
     result = JSONWithNilableRootEmitNull.from_json(json)
     result.result.should be_nil
     result.to_json.should eq(json)
   end
 
-  it "parses nilable union" do
+  it("parses nilable union") do
     obj = JSONWithNilableUnion.from_json(%({"value": 1}))
     obj.value.should eq(1)
     obj.to_json.should eq(%({"value":1}))
@@ -429,7 +429,7 @@ describe "JSON mapping" do
     obj.to_json.should eq(%({}))
   end
 
-  it "parses nilable union2" do
+  it("parses nilable union2") do
     obj = JSONWithNilableUnion2.from_json(%({"value": 1}))
     obj.value.should eq(1)
     obj.to_json.should eq(%({"value":1}))
@@ -443,8 +443,8 @@ describe "JSON mapping" do
     obj.to_json.should eq(%({}))
   end
 
-  describe "parses JSON with presence markers" do
-    it "parses person with absent attributes" do
+  describe("parses JSON with presence markers") do
+    it("parses person with absent attributes") do
       json = JSONWithPresence.from_json(%({"first_name": null}))
       json.first_name.should be_nil
       json.first_name_present?.should be_true

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -2,20 +2,20 @@ require "spec"
 require "json"
 
 private def it_parses(string, expected_value, file = __FILE__, line = __LINE__)
-  it "parses #{string}", file, line do
+  it("parses #{string}", file, line) do
     JSON.parse(string).raw.should eq(expected_value)
   end
 end
 
 private def it_raises_on_parse(string, file = __FILE__, line = __LINE__)
-  it "raises on parse #{string}", file, line do
-    expect_raises JSON::ParseException do
+  it("raises on parse #{string}", file, line) do
+    expect_raises(JSON::ParseException) do
       JSON.parse(string)
     end
   end
 end
 
-describe JSON::Parser do
+describe(JSON::Parser) do
   it_parses "1", 1
   it_parses "2.5", 2.5
   it_parses %("hello"), "hello"
@@ -62,19 +62,19 @@ describe JSON::Parser do
 
   it_raises_on_parse "1\u{0}"
 
-  it "prevents stack overflow for arrays" do
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+  it("prevents stack overflow for arrays") do
+    expect_raises(JSON::ParseException, "Nesting of 513 is too deep") do
       JSON.parse(("[" * 513) + ("]" * 513))
     end
   end
 
-  it "prevents stack overflow for hashes" do
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+  it("prevents stack overflow for hashes") do
+    expect_raises(JSON::ParseException, "Nesting of 513 is too deep") do
       JSON.parse((%({"x": ) * 513) + ("}" * 513))
     end
   end
 
-  it "returns raw" do
+  it("returns raw") do
     value = JSON.parse_raw("1")
     value.should eq(1)
     value.should be_a(Int64)

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -86,14 +86,14 @@ class JSON::PullParser
   end
 
   def assert_error
-    expect_raises JSON::ParseException do
+    expect_raises(JSON::ParseException) do
       read_next
     end
   end
 end
 
 private def assert_pull_parse(string)
-  it "parses #{string}" do
+  it("parses #{string}") do
     parser = JSON::PullParser.new string
     parser.assert JSON.parse(string).raw
     parser.kind.should eq(:EOF)
@@ -101,8 +101,8 @@ private def assert_pull_parse(string)
 end
 
 private def assert_pull_parse_error(string)
-  it "errors on #{string}" do
-    expect_raises JSON::ParseException do
+  it("errors on #{string}") do
+    expect_raises(JSON::ParseException) do
       parser = JSON::PullParser.new string
       while parser.kind != :EOF
         parser.read_next
@@ -112,13 +112,13 @@ private def assert_pull_parse_error(string)
 end
 
 private def assert_raw(string, file = __FILE__, line = __LINE__)
-  it "parses raw #{string.inspect}", file, line do
+  it("parses raw #{string.inspect}", file, line) do
     pull = JSON::PullParser.new(string)
     pull.read_raw.should eq(string)
   end
 end
 
-describe JSON::PullParser do
+describe(JSON::PullParser) do
   assert_pull_parse "null"
   assert_pull_parse "false"
   assert_pull_parse "true"
@@ -162,9 +162,9 @@ describe JSON::PullParser do
   assert_pull_parse_error %({"name": "John", "age", 1})
   assert_pull_parse_error %({"name": "John", "age": "foo", "bar"})
 
-  it "prevents stack overflow for arrays" do
+  it("prevents stack overflow for arrays") do
     parser = JSON::PullParser.new(("[" * 513) + ("]" * 513))
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises(JSON::ParseException, "Nesting of 513 is too deep") do
       while true
         break if parser.kind == :EOF
         parser.read_next
@@ -172,9 +172,9 @@ describe JSON::PullParser do
     end
   end
 
-  it "prevents stack overflow for hashes" do
+  it("prevents stack overflow for hashes") do
     parser = JSON::PullParser.new((%({"x": ) * 513) + ("}" * 513))
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises(JSON::ParseException, "Nesting of 513 is too deep") do
       while true
         break if parser.kind == :EOF
         parser.read_next
@@ -186,7 +186,7 @@ describe JSON::PullParser do
   assert_pull_parse_error(("[" * 513) + ("]" * 513))
   assert_pull_parse_error(("{" * 513) + ("}" * 513))
 
-  describe "skip" do
+  describe("skip") do
     [
       {"null", "null"},
       {"bool", "false"},
@@ -196,7 +196,7 @@ describe JSON::PullParser do
       {"array", %([10, 20, [30], [40]])},
       {"object", %({"foo": [1, 2], "bar": {"baz": [3]}})},
     ].each do |(desc, obj)|
-      it "skips #{desc}" do
+      it("skips #{desc}") do
         pull = JSON::PullParser.new("[1, #{obj}, 2]")
         pull.read_array do
           pull.read_int.should eq(1)
@@ -207,27 +207,27 @@ describe JSON::PullParser do
     end
   end
 
-  it "reads bool or null" do
+  it("reads bool or null") do
     JSON::PullParser.new("null").read_bool_or_null.should be_nil
     JSON::PullParser.new("false").read_bool_or_null.should be_false
   end
 
-  it "reads int or null" do
+  it("reads int or null") do
     JSON::PullParser.new("null").read_int_or_null.should be_nil
     JSON::PullParser.new("1").read_int_or_null.should eq(1)
   end
 
-  it "reads float or null" do
+  it("reads float or null") do
     JSON::PullParser.new("null").read_float_or_null.should be_nil
     JSON::PullParser.new("1.5").read_float_or_null.should eq(1.5)
   end
 
-  it "reads string or null" do
+  it("reads string or null") do
     JSON::PullParser.new("null").read_string_or_null.should be_nil
     JSON::PullParser.new(%("hello")).read_string_or_null.should eq("hello")
   end
 
-  it "reads array or null" do
+  it("reads array or null") do
     JSON::PullParser.new("null").read_array_or_null { fail "expected block not to be called" }
 
     pull = JSON::PullParser.new(%([1]))
@@ -236,7 +236,7 @@ describe JSON::PullParser do
     end
   end
 
-  it "reads object or null" do
+  it("reads object or null") do
     JSON::PullParser.new("null").read_object_or_null { fail "expected block not to be called" }
 
     pull = JSON::PullParser.new(%({"foo": 1}))
@@ -246,8 +246,8 @@ describe JSON::PullParser do
     end
   end
 
-  describe "on key" do
-    it "finds key" do
+  describe("on key") do
+    it("finds key") do
       pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
 
       bar = nil
@@ -258,7 +258,7 @@ describe JSON::PullParser do
       bar.should eq(2)
     end
 
-    it "finds key" do
+    it("finds key") do
       pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
 
       bar = nil
@@ -269,7 +269,7 @@ describe JSON::PullParser do
       bar.should eq(2)
     end
 
-    it "doesn't find key" do
+    it("doesn't find key") do
       pull = JSON::PullParser.new(%({"foo": 1, "baz": 2}))
 
       bar = nil
@@ -280,7 +280,7 @@ describe JSON::PullParser do
       bar.should be_nil
     end
 
-    it "finds key with bang" do
+    it("finds key with bang") do
       pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
 
       bar = nil
@@ -291,16 +291,16 @@ describe JSON::PullParser do
       bar.should eq(2)
     end
 
-    it "doesn't find key with bang" do
+    it("doesn't find key with bang") do
       pull = JSON::PullParser.new(%({"foo": 1, "baz": 2}))
 
-      expect_raises Exception, "JSON key not found: bar" do
+      expect_raises(Exception, "JSON key not found: bar") do
         pull.on_key!("bar") do
         end
       end
     end
 
-    it "reads float when it is an int" do
+    it("reads float when it is an int") do
       pull = JSON::PullParser.new(%(1))
       f = pull.read_float
       f.should be_a(Float64)
@@ -308,7 +308,7 @@ describe JSON::PullParser do
     end
 
     ["1", "[1]", %({"x": [1]})].each do |value|
-      it "yields all keys when skipping #{value}" do
+      it("yields all keys when skipping #{value}") do
         pull = JSON::PullParser.new(%({"foo": #{value}, "bar": 2}))
         pull.read_object do |key|
           key.should_not eq("")
@@ -318,7 +318,7 @@ describe JSON::PullParser do
     end
   end
 
-  describe "raw" do
+  describe("raw") do
     assert_raw "null"
     assert_raw "true"
     assert_raw "false"

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -9,50 +9,50 @@ enum JSONSpecEnum
   Two
 end
 
-describe "JSON serialization" do
-  describe "from_json" do
-    it "does Array(Nil)#from_json" do
+describe("JSON serialization") do
+  describe("from_json") do
+    it("does Array(Nil)#from_json") do
       Array(Nil).from_json("[null, null]").should eq([nil, nil])
     end
 
-    it "does Array(Bool)#from_json" do
+    it("does Array(Bool)#from_json") do
       Array(Bool).from_json("[true, false]").should eq([true, false])
     end
 
-    it "does Array(Int32)#from_json" do
+    it("does Array(Int32)#from_json") do
       Array(Int32).from_json("[1, 2, 3]").should eq([1, 2, 3])
     end
 
-    it "does Array(Int64)#from_json" do
+    it("does Array(Int64)#from_json") do
       Array(Int64).from_json("[1, 2, 3]").should eq([1, 2, 3])
     end
 
-    it "does Array(Float32)#from_json" do
+    it("does Array(Float32)#from_json") do
       Array(Float32).from_json("[1.5, 2, 3.5]").should eq([1.5, 2.0, 3.5])
     end
 
-    it "does Array(Float64)#from_json" do
+    it("does Array(Float64)#from_json") do
       Array(Float64).from_json("[1.5, 2, 3.5]").should eq([1.5, 2, 3.5])
     end
 
-    it "does Hash(String, String)#from_json" do
+    it("does Hash(String, String)#from_json") do
       Hash(String, String).from_json(%({"foo": "x", "bar": "y"})).should eq({"foo" => "x", "bar" => "y"})
     end
 
-    it "does Hash(String, Int32)#from_json" do
+    it("does Hash(String, Int32)#from_json") do
       Hash(String, Int32).from_json(%({"foo": 1, "bar": 2})).should eq({"foo" => 1, "bar" => 2})
     end
 
-    it "does Hash(String, Int32)#from_json and skips null" do
+    it("does Hash(String, Int32)#from_json and skips null") do
       Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null})).should eq({"foo" => 1, "bar" => 2})
     end
 
-    it "does for Array(Int32) from IO" do
+    it("does for Array(Int32) from IO") do
       io = IO::Memory.new "[1, 2, 3]"
       Array(Int32).from_json(io).should eq([1, 2, 3])
     end
 
-    it "does for Array(Int32) with block" do
+    it("does for Array(Int32) with block") do
       elements = [] of Int32
       ret = Array(Int32).from_json("[1, 2, 3]") do |element|
         elements << element
@@ -61,37 +61,37 @@ describe "JSON serialization" do
       elements.should eq([1, 2, 3])
     end
 
-    it "does for tuple" do
+    it("does for tuple") do
       tuple = Tuple(Int32, String).from_json(%([1, "hello"]))
       tuple.should eq({1, "hello"})
       tuple.should be_a(Tuple(Int32, String))
     end
 
-    it "does for named tuple" do
+    it("does for named tuple") do
       tuple = NamedTuple(x: Int32, y: String).from_json(%({"y": "hello", "x": 1}))
       tuple.should eq({x: 1, y: "hello"})
       tuple.should be_a(NamedTuple(x: Int32, y: String))
     end
 
-    it "does for BigInt" do
+    it("does for BigInt") do
       big = BigInt.from_json("123456789123456789123456789123456789123456789")
       big.should be_a(BigInt)
       big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
     end
 
-    it "does for BigFloat" do
+    it("does for BigFloat") do
       big = BigFloat.from_json("1234.567891011121314")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
-    it "does for BigFloat from int" do
+    it("does for BigFloat from int") do
       big = BigFloat.from_json("1234")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234"))
     end
 
-    it "does for Enum with number" do
+    it("does for Enum with number") do
       JSONSpecEnum.from_json("1").should eq(JSONSpecEnum::One)
 
       expect_raises do
@@ -99,7 +99,7 @@ describe "JSON serialization" do
       end
     end
 
-    it "does for Enum with string" do
+    it("does for Enum with string") do
       JSONSpecEnum.from_json(%("One")).should eq(JSONSpecEnum::One)
 
       expect_raises do
@@ -107,16 +107,16 @@ describe "JSON serialization" do
       end
     end
 
-    it "deserializes with root" do
+    it("deserializes with root") do
       Int32.from_json(%({"foo": 1}), root: "foo").should eq(1)
       Array(Int32).from_json(%({"foo": [1, 2]}), root: "foo").should eq([1, 2])
     end
 
-    it "deserializes union" do
+    it("deserializes union") do
       Array(Int32 | String).from_json(%([1, "hello"])).should eq([1, "hello"])
     end
 
-    it "deserializes union with bool (fast path)" do
+    it("deserializes union with bool (fast path)") do
       Union(Bool, Array(Int32)).from_json(%(true)).should be_true
     end
 
@@ -126,22 +126,22 @@ describe "JSON serialization" do
         end
       {% end %}
 
-    it "deserializes union with Float32 (fast path)" do
+    it("deserializes union with Float32 (fast path)") do
       Union(Float32, Array(Int32)).from_json(%(1)).should eq(1)
       Union(Float32, Array(Int32)).from_json(%(1.23)).should eq(1.23_f32)
     end
 
-    it "deserializes union with Float64 (fast path)" do
+    it("deserializes union with Float64 (fast path)") do
       Union(Float64, Array(Int32)).from_json(%(1)).should eq(1)
       Union(Float64, Array(Int32)).from_json(%(1.23)).should eq(1.23)
     end
 
-    it "deserializes Time" do
+    it("deserializes Time") do
       Time.from_json(%("2016-11-16T09:55:48-0300")).to_utc.should eq(Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc))
     end
 
-    describe "parse exceptions" do
-      it "has correct location when raises in NamedTuple#from_json" do
+    describe("parse exceptions") do
+      it("has correct location when raises in NamedTuple#from_json") do
         ex = expect_raises(JSON::ParseException) do
           Array({foo: Int32, bar: String}).from_json <<-JSON
             [
@@ -152,7 +152,7 @@ describe "JSON serialization" do
         ex.location.should eq({2, 3})
       end
 
-      it "has correct location when raises in Union#from_json" do
+      it("has correct location when raises in Union#from_json") do
         ex = expect_raises(JSON::ParseException) do
           Array(Int32 | Bool).from_json <<-JSON
             [
@@ -165,48 +165,48 @@ describe "JSON serialization" do
     end
   end
 
-  describe "to_json" do
-    it "does for Nil" do
+  describe("to_json") do
+    it("does for Nil") do
       nil.to_json.should eq("null")
     end
 
-    it "does for Bool" do
+    it("does for Bool") do
       true.to_json.should eq("true")
     end
 
-    it "does for Int32" do
+    it("does for Int32") do
       1.to_json.should eq("1")
     end
 
-    it "does for Float64" do
+    it("does for Float64") do
       1.5.to_json.should eq("1.5")
     end
 
-    it "raises if Float is NaN" do
-      expect_raises JSON::Error, "NaN not allowed in JSON" do
+    it("raises if Float is NaN") do
+      expect_raises(JSON::Error, "NaN not allowed in JSON") do
         (0.0/0.0).to_json
       end
     end
 
-    it "raises if Float is infinity" do
-      expect_raises JSON::Error, "Infinity not allowed in JSON" do
+    it("raises if Float is infinity") do
+      expect_raises(JSON::Error, "Infinity not allowed in JSON") do
         Float64::INFINITY.to_json
       end
     end
 
-    it "does for String" do
+    it("does for String") do
       "hello".to_json.should eq("\"hello\"")
     end
 
-    it "does for String with quote" do
+    it("does for String with quote") do
       "hel\"lo".to_json.should eq("\"hel\\\"lo\"")
     end
 
-    it "does for String with slash" do
+    it("does for String with slash") do
       "hel\\lo".to_json.should eq("\"hel\\\\lo\"")
     end
 
-    it "does for String with control codes" do
+    it("does for String with control codes") do
       "\b".to_json.should eq("\"\\b\"")
       "\f".to_json.should eq("\"\\f\"")
       "\n".to_json.should eq("\"\\n\"")
@@ -215,103 +215,103 @@ describe "JSON serialization" do
       "\u{19}".to_json.should eq("\"\\u0019\"")
     end
 
-    it "does for Array" do
+    it("does for Array") do
       [1, 2, 3].to_json.should eq("[1,2,3]")
     end
 
-    it "does for Set" do
+    it("does for Set") do
       Set(Int32).new([1, 1, 2]).to_json.should eq("[1,2]")
     end
 
-    it "does for Hash" do
+    it("does for Hash") do
       {"foo" => 1, "bar" => 2}.to_json.should eq(%({"foo":1,"bar":2}))
     end
 
-    it "does for Hash with non-string keys" do
+    it("does for Hash with non-string keys") do
       {:foo => 1, :bar => 2}.to_json.should eq(%({"foo":1,"bar":2}))
     end
 
-    it "does for Hash with newlines" do
+    it("does for Hash with newlines") do
       {"foo\nbar" => "baz\nqux"}.to_json.should eq(%({"foo\\nbar":"baz\\nqux"}))
     end
 
-    it "does for Tuple" do
+    it("does for Tuple") do
       {1, "hello"}.to_json.should eq(%([1,"hello"]))
     end
 
-    it "does for NamedTuple" do
+    it("does for NamedTuple") do
       {x: 1, y: "hello"}.to_json.should eq(%({"x":1,"y":"hello"}))
     end
 
-    it "does for Enum" do
+    it("does for Enum") do
       JSONSpecEnum::One.to_json.should eq("1")
     end
 
-    it "does for BigInt" do
+    it("does for BigInt") do
       big = BigInt.new("123456789123456789123456789123456789123456789")
       big.to_json.should eq("123456789123456789123456789123456789123456789")
     end
 
-    it "does for BigFloat" do
+    it("does for BigFloat") do
       big = BigFloat.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
     end
   end
 
-  describe "to_pretty_json" do
-    it "does for Nil" do
+  describe("to_pretty_json") do
+    it("does for Nil") do
       nil.to_pretty_json.should eq("null")
     end
 
-    it "does for Bool" do
+    it("does for Bool") do
       true.to_pretty_json.should eq("true")
     end
 
-    it "does for Int32" do
+    it("does for Int32") do
       1.to_pretty_json.should eq("1")
     end
 
-    it "does for Float64" do
+    it("does for Float64") do
       1.5.to_pretty_json.should eq("1.5")
     end
 
-    it "does for String" do
+    it("does for String") do
       "hello".to_pretty_json.should eq("\"hello\"")
     end
 
-    it "does for Array" do
+    it("does for Array") do
       [1, 2, 3].to_pretty_json.should eq("[\n  1,\n  2,\n  3\n]")
     end
 
-    it "does for nested Array" do
+    it("does for nested Array") do
       [[1, 2, 3]].to_pretty_json.should eq("[\n  [\n    1,\n    2,\n    3\n  ]\n]")
     end
 
-    it "does for empty Array" do
+    it("does for empty Array") do
       ([] of Nil).to_pretty_json.should eq("[]")
     end
 
-    it "does for Hash" do
+    it("does for Hash") do
       {"foo" => 1, "bar" => 2}.to_pretty_json.should eq(%({\n  "foo": 1,\n  "bar": 2\n}))
     end
 
-    it "does for nested Hash" do
+    it("does for nested Hash") do
       {"foo" => {"bar" => 1}}.to_pretty_json.should eq(%({\n  "foo": {\n    "bar": 1\n  }\n}))
     end
 
-    it "does for empty Hash" do
+    it("does for empty Hash") do
       ({} of Nil => Nil).to_pretty_json.should eq(%({}))
     end
 
-    it "does for Array with indent" do
+    it("does for Array with indent") do
       [1, 2, 3].to_pretty_json(indent: " ").should eq("[\n 1,\n 2,\n 3\n]")
     end
 
-    it "does for nested Hash with indent" do
+    it("does for nested Hash with indent") do
       {"foo" => {"bar" => 1}}.to_pretty_json(indent: " ").should eq(%({\n "foo": {\n  "bar": 1\n }\n}))
     end
 
-    it "does for time" do
+    it("does for time") do
       Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc).to_json.should eq(%("2016-11-16T12:55:48+0000"))
     end
   end

--- a/spec/std/levenshtein_spec.cr
+++ b/spec/std/levenshtein_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "levenshtein"
 
-describe "levenshtein" do
+describe("levenshtein") do
   it { Levenshtein.distance("algorithm", "altruistic").should eq(6) }
   it { Levenshtein.distance("1638452297", "444488444").should eq(9) }
   it { Levenshtein.distance("", "").should eq(0) }
@@ -15,7 +15,7 @@ describe "levenshtein" do
   it { Levenshtein.distance("hello", "hallo").should eq(1) }
   it { Levenshtein.distance("こんにちは", "こんちは").should eq(1) }
 
-  it "finds with finder" do
+  it("finds with finder") do
     finder = Levenshtein::Finder.new "hallo"
     finder.test "hay"
     finder.test "hall"
@@ -23,7 +23,7 @@ describe "levenshtein" do
     finder.best_match.should eq("hall")
   end
 
-  it "finds with finder and other values" do
+  it("finds with finder and other values") do
     finder = Levenshtein::Finder.new "hallo"
     finder.test "hay", "HAY"
     finder.test "hall", "HALL"

--- a/spec/std/llvm/aarch64_spec.cr
+++ b/spec/std/llvm/aarch64_spec.cr
@@ -13,7 +13,7 @@ private def abi
 end
 
 private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
-  it msg do
+  it(msg) do
     abi = abi()
     ctx = LLVM::Context.new
     block.call(abi, ctx)
@@ -21,7 +21,7 @@ private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
 end
 
 class LLVM::ABI
-  describe AArch64 do
+  describe(AArch64) do
     {% if LibLLVM::BUILT_TARGETS.includes?(:aarch64) %}
     describe "align" do
       test "for integer" do |abi, ctx|

--- a/spec/std/llvm/arm_abi_spec.cr
+++ b/spec/std/llvm/arm_abi_spec.cr
@@ -13,7 +13,7 @@ private def abi
 end
 
 private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
-  it msg do
+  it(msg) do
     abi = abi()
     ctx = LLVM::Context.new
     block.call(abi, ctx)
@@ -21,7 +21,7 @@ private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
 end
 
 class LLVM::ABI
-  describe ARM do
+  describe(ARM) do
     {% if LibLLVM::BUILT_TARGETS.includes?(:arm) %}
     describe "align" do
       test "for integer" do |abi, ctx|

--- a/spec/std/llvm/x86_64_abi_spec.cr
+++ b/spec/std/llvm/x86_64_abi_spec.cr
@@ -13,7 +13,7 @@ private def abi
 end
 
 private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
-  it msg do
+  it(msg) do
     abi = abi()
     ctx = LLVM::Context.new
     block.call(abi, ctx)
@@ -21,7 +21,7 @@ private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
 end
 
 class LLVM::ABI
-  describe X86_64 do
+  describe(X86_64) do
     {% if LibLLVM::BUILT_TARGETS.includes?(:x86) %}
     describe "align" do
       test "for integer" do |abi, ctx|

--- a/spec/std/llvm/x86_abi_spec.cr
+++ b/spec/std/llvm/x86_abi_spec.cr
@@ -17,7 +17,7 @@ private def abi
 end
 
 private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
-  it msg do
+  it(msg) do
     abi = abi()
     ctx = LLVM::Context.new
     block.call(abi, ctx)
@@ -25,7 +25,7 @@ private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
 end
 
 class LLVM::ABI
-  describe X86 do
+  describe(X86) do
     {% if LibLLVM::BUILT_TARGETS.includes?(:x86) %}
     describe "align" do
       test "for integer" do |abi, ctx|

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "logger"
 
-describe "Logger" do
-  it "logs messages" do
+describe("Logger") do
+  it("logs messages") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.debug "debug:skip"
@@ -22,7 +22,7 @@ describe "Logger" do
     end
   end
 
-  it "logs any object" do
+  it("logs any object") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.info 12345
@@ -31,7 +31,7 @@ describe "Logger" do
     end
   end
 
-  it "formats message" do
+  it("formats message") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.progname = "crystal"
@@ -41,7 +41,7 @@ describe "Logger" do
     end
   end
 
-  it "uses custom formatter" do
+  it("uses custom formatter") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
@@ -53,7 +53,7 @@ describe "Logger" do
     end
   end
 
-  it "yields message" do
+  it("yields message") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.error { "message" }
@@ -64,7 +64,7 @@ describe "Logger" do
     end
   end
 
-  it "yields message with progname" do
+  it("yields message with progname") do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.error("crystal") { "message" }
@@ -75,19 +75,19 @@ describe "Logger" do
     end
   end
 
-  it "can create a logger with nil (#3065)" do
+  it("can create a logger with nil (#3065)") do
     logger = Logger.new(nil)
     logger.error("ouch")
   end
 
-  it "doesn't yield to the block with nil" do
+  it("doesn't yield to the block with nil") do
     a = 0
     logger = Logger.new(nil)
     logger.info { a = 1 }
     a.should eq(0)
   end
 
-  it "closes" do
+  it("closes") do
     IO.pipe do |r, w|
       Logger.new(w).close
       w.closed?.should be_true

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -2,12 +2,12 @@ require "spec"
 require "markdown"
 
 private def assert_render(input, output, file = __FILE__, line = __LINE__)
-  it "renders #{input.inspect}", file, line do
+  it("renders #{input.inspect}", file, line) do
     Markdown.to_html(input).should eq(output), file, line
   end
 end
 
-describe Markdown do
+describe(Markdown) do
   assert_render "", ""
   assert_render "Hello", "<p>Hello</p>"
   assert_render "Hello\nWorld", "<p>Hello\nWorld</p>"

--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -1,19 +1,19 @@
 require "spec"
 
-describe "Regex::MatchData" do
-  it "does inspect" do
+describe("Regex::MatchData") do
+  it("does inspect") do
     /f(o)(x)/.match("the fox").inspect.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
     /f(o)(x)?/.match("the fort").inspect.should eq(%(#<Regex::MatchData "fo" 1:"o" 2:nil>))
     /fox/.match("the fox").inspect.should eq(%(#<Regex::MatchData "fox">))
   end
 
-  it "does to_s" do
+  it("does to_s") do
     /f(o)(x)/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
     /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox" lettero:"o" letterx:"x">))
     /fox/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox">))
   end
 
-  it "does pretty_print" do
+  it("does pretty_print") do
     /f(o)(x)/.match("the fox").pretty_inspect.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
     /(?<first>f)(?<second>o(?<third>o(?<fourth>o(?<fifth>o))))/.match("fooooo").pretty_inspect.should eq(%(#<Regex::MatchData
  "foooo"
@@ -24,26 +24,26 @@ describe "Regex::MatchData" do
  fifth:"o">))
   end
 
-  it "does size" do
+  it("does size") do
     "Crystal".match(/[p-s]/).not_nil!.size.should eq(1)
     "Crystal".match(/r(ys)/).not_nil!.size.should eq(2)
     "Crystal".match(/r(ys)(?<ok>ta)/).not_nil!.size.should eq(3)
   end
 
-  describe "#[]" do
-    it "captures empty group" do
+  describe("#[]") do
+    it("captures empty group") do
       ("foo" =~ /(?<g1>z?)foo/).should eq(0)
       $~[1].should eq("")
       $~["g1"].should eq("")
     end
 
-    it "capture named group" do
+    it("capture named group") do
       ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
       $~["g1"].should eq("oo")
       $~["g2"].should eq("ba")
     end
 
-    it "can use negative index" do
+    it("can use negative index") do
       "foo" =~ /(f)(oo)/
       $~[-1].should eq("oo")
       $~[-2].should eq("f")
@@ -51,49 +51,49 @@ describe "Regex::MatchData" do
       expect_raises(IndexError, "Invalid capture group index: -4") { $~[-4] }
     end
 
-    it "raises exception when named group doesn't exist" do
+    it("raises exception when named group doesn't exist") do
       ("foo" =~ /foo/).should eq(0)
       expect_raises(KeyError, "Capture group 'group' does not exist") { $~["group"] }
     end
 
-    it "raises exception on optional empty group" do
+    it("raises exception on optional empty group") do
       ("foo" =~ /(?<g1>z)?foo/).should eq(0)
       expect_raises(IndexError, "Capture group 1 was not matched") { $~[1] }
       expect_raises(KeyError, "Capture group 'g1' was not matched") { $~["g1"] }
     end
 
-    it "raises if outside match range with []" do
+    it("raises if outside match range with []") do
       "foo" =~ /foo/
       expect_raises(IndexError, "Invalid capture group index: 1") { $~[1] }
     end
 
-    it "raises if special variable accessed on invalid capture group" do
+    it("raises if special variable accessed on invalid capture group") do
       "spice" =~ /spice(s)?/
       expect_raises(IndexError, "Capture group 1 was not matched") { $1 }
       expect_raises(IndexError, "Invalid capture group index: 3") { $3 }
     end
   end
 
-  describe "#[]?" do
-    it "capture empty group" do
+  describe("#[]?") do
+    it("capture empty group") do
       ("foo" =~ /(?<g1>z?)foo/).should eq(0)
       $~[1]?.should eq("")
       $~["g1"]?.should eq("")
     end
 
-    it "capture optional empty group" do
+    it("capture optional empty group") do
       ("foo" =~ /(?<g1>z)?foo/).should eq(0)
       $~[1]?.should be_nil
       $~["g1"]?.should be_nil
     end
 
-    it "capture named group" do
+    it("capture named group") do
       ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
       $~["g1"]?.should eq("oo")
       $~["g2"]?.should eq("ba")
     end
 
-    it "can use negative index" do
+    it("can use negative index") do
       "foo" =~ /(b)?(f)(oo)/
       $~[-1]?.should eq("oo")
       $~[-2]?.should eq("f")
@@ -101,83 +101,83 @@ describe "Regex::MatchData" do
       $~[-4]?.should eq("foo")
     end
 
-    it "returns nil exception when named group doesn't exist" do
+    it("returns nil exception when named group doesn't exist") do
       ("foo" =~ /foo/).should eq(0)
       $~["group"]?.should be_nil
     end
 
-    it "returns nil if outside match range with []" do
+    it("returns nil if outside match range with []") do
       "foo" =~ /foo/
       $~[1]?.should be_nil
     end
   end
 
-  describe "#post_match" do
-    it "returns an empty string when there's nothing after" do
+  describe("#post_match") do
+    it("returns an empty string when there's nothing after") do
       "Crystal".match(/ystal/).not_nil!.post_match.should eq ""
     end
 
-    it "returns the part of the string after the match" do
+    it("returns the part of the string after the match") do
       "Crystal".match(/yst/).not_nil!.post_match.should eq "al"
     end
 
-    it "works with unicode" do
+    it("works with unicode") do
       "há日本語".match(/本/).not_nil!.post_match.should eq "語"
     end
   end
 
-  describe "#pre_match" do
-    it "returns an empty string when there's nothing before" do
+  describe("#pre_match") do
+    it("returns an empty string when there's nothing before") do
       "Crystal".match(/Cryst/).not_nil!.pre_match.should eq ""
     end
 
-    it "returns the part of the string before the match" do
+    it("returns the part of the string before the match") do
       "Crystal".match(/yst/).not_nil!.pre_match.should eq "Cr"
     end
 
-    it "works with unicode" do
+    it("works with unicode") do
       "há日本語".match(/本/).not_nil!.pre_match.should eq "há日"
     end
   end
 
-  describe "#captures" do
-    it "gets an array of unnamed captures" do
+  describe("#captures") do
+    it("gets an array of unnamed captures") do
       "Crystal".match(/(Cr)y/).not_nil!.captures.should eq(["Cr"])
       "Crystal".match(/(Cr)(?<name1>y)(st)(?<name2>al)/).not_nil!.captures.should eq(["Cr", "st"])
     end
 
-    it "gets an array of unnamed captures with optional" do
+    it("gets an array of unnamed captures with optional") do
       "Crystal".match(/(Cr)(s)?/).not_nil!.captures.should eq(["Cr", nil])
       "Crystal".match(/(Cr)(?<name1>s)?(tal)?/).not_nil!.captures.should eq(["Cr", nil])
     end
   end
 
-  describe "#named_captures" do
-    it "gets a hash of named captures" do
+  describe("#named_captures") do
+    it("gets a hash of named captures") do
       "Crystal".match(/(?<name1>Cr)y/).not_nil!.named_captures.should eq({"name1" => "Cr"})
       "Crystal".match(/(Cr)(?<name1>y)(st)(?<name2>al)/).not_nil!.named_captures.should eq({"name1" => "y", "name2" => "al"})
     end
 
-    it "gets a hash of named captures with optional" do
+    it("gets a hash of named captures with optional") do
       "Crystal".match(/(?<name1>Cr)(?<name2>s)?/).not_nil!.named_captures.should eq({"name1" => "Cr", "name2" => nil})
       "Crystal".match(/(Cr)(?<name1>s)?(t)?(?<name2>al)?/).not_nil!.named_captures.should eq({"name1" => nil, "name2" => nil})
     end
   end
 
-  describe "#to_a" do
-    it "converts into an array" do
+  describe("#to_a") do
+    it("converts into an array") do
       "Crystal".match(/(?<name1>Cr)(y)/).not_nil!.to_a.should eq(["Cry", "Cr", "y"])
       "Crystal".match(/(Cr)(?<name1>y)(st)(?<name2>al)/).not_nil!.to_a.should eq(["Crystal", "Cr", "y", "st", "al"])
     end
 
-    it "converts into an array having nil" do
+    it("converts into an array having nil") do
       "Crystal".match(/(?<name1>Cr)(s)?/).not_nil!.to_a.should eq(["Cr", "Cr", nil])
       "Crystal".match(/(Cr)(?<name1>s)?(yst)?(?<name2>al)?/).not_nil!.to_a.should eq(["Crystal", "Cr", nil, "yst", "al"])
     end
   end
 
-  describe "#to_h" do
-    it "converts into a hash" do
+  describe("#to_h") do
+    it("converts into a hash") do
       "Crystal".match(/(?<name1>Cr)(y)/).not_nil!.to_h.should eq({
               0 => "Cry",
         "name1" => "Cr",
@@ -192,7 +192,7 @@ describe "Regex::MatchData" do
       })
     end
 
-    it "converts into a hash having nil" do
+    it("converts into a hash having nil") do
       "Crystal".match(/(?<name1>Cr)(s)?/).not_nil!.to_h.should eq({
               0 => "Cr",
         "name1" => "Cr",
@@ -208,7 +208,7 @@ describe "Regex::MatchData" do
     end
   end
 
-  it "can check equality" do
+  it("can check equality") do
     re = /((?<hello>he)llo)/
     m1 = re.match("hello")
     m2 = re.match("hello")

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -1,41 +1,41 @@
 require "spec"
 
-describe "Math" do
-  describe "Mathematical constants" do
-    it "E" do
+describe("Math") do
+  describe("Mathematical constants") do
+    it("E") do
       Math::E.should be_close(2.718281828459045, 1e-7)
     end
 
-    it "LOG2" do
+    it("LOG2") do
       Math::LOG2.should be_close(0.6931471805599453, 1e-7)
     end
 
-    it "LOG10" do
+    it("LOG10") do
       Math::LOG10.should be_close(2.302585092994046, 1e-7)
     end
   end
 
-  describe "Functions manipulating signs" do
-    it "copysign" do
+  describe("Functions manipulating signs") do
+    it("copysign") do
       Math.copysign(6.9, -0.2).should eq(-6.9)
     end
   end
 
-  describe "Order-related functions" do
+  describe("Order-related functions") do
     Math.min(2.1, 2.11).should eq(2.1)
     Math.max(3.2, 3.11).should eq(3.2)
   end
 
-  pending "Functions for computing quotient and remainder" do
+  pending("Functions for computing quotient and remainder") do
   end
 
-  describe "Roots" do
-    it "cbrt" do
+  describe("Roots") do
+    it("cbrt") do
       Math.cbrt(6.5_f32).should be_close(1.866255578408624, 1e-7)
       Math.cbrt(6.5).should be_close(1.866255578408624, 1e-7)
     end
 
-    it "sqrt" do
+    it("sqrt") do
       Math.sqrt(5.2_f32).should be_close(2.280350850198276, 1e-7)
       Math.sqrt(5.2).should be_close(2.280350850198276, 1e-7)
       Math.sqrt(4_f32).should eq(2)
@@ -43,165 +43,165 @@ describe "Math" do
     end
   end
 
-  describe "Exponents" do
-    it "exp" do
+  describe("Exponents") do
+    it("exp") do
       Math.exp(0.211_f32).should be_close(1.2349123550613943, 1e-7)
       Math.exp(0.211).should be_close(1.2349123550613943, 1e-7)
     end
 
-    it "exp2" do
+    it("exp2") do
       Math.exp2(0.41_f32).should be_close(1.3286858140965117, 1e-7)
       Math.exp2(0.41).should be_close(1.3286858140965117, 1e-7)
     end
 
-    it "expm1" do
+    it("expm1") do
       Math.expm1(0.99_f32).should be_close(1.6912344723492623, 1e-7)
       Math.expm1(0.99).should be_close(1.6912344723492623, 1e-7)
     end
 
-    it "ilogb" do
+    it("ilogb") do
       Math.ilogb(0.5_f32).should eq(-1)
       Math.ilogb(0.5).should eq(-1)
     end
 
-    it "ldexp" do
+    it("ldexp") do
       Math.ldexp(0.27_f32, 2).should be_close(1.08, 1e-7)
       Math.ldexp(0.27, 2).should be_close(1.08, 1e-7)
     end
 
-    it "logb" do
+    it("logb") do
       Math.logb(10_f32).should be_close(3.0, 1e-7)
       Math.logb(10.0).should be_close(3.0, 1e-7)
     end
 
-    it "scalbn" do
+    it("scalbn") do
       Math.scalbn(0.2_f32, 3).should be_close(1.6, 1e-7)
       Math.scalbn(0.2, 3).should be_close(1.6, 1e-7)
     end
 
-    it "scalbln" do
+    it("scalbln") do
       Math.scalbln(0.11_f32, 2).should be_close(0.44, 1e-7)
       Math.scalbln(0.11, 2).should be_close(0.44, 1e-7)
     end
 
-    it "frexp" do
+    it("frexp") do
       Math.frexp(0.2_f32).should eq({0.8_f32, -2})
       Math.frexp(0.2).should eq({0.8, -2})
     end
   end
 
-  describe "Logarithms" do
-    it "log" do
+  describe("Logarithms") do
+    it("log") do
       Math.log(3.24_f32).should be_close(1.1755733298042381, 1e-7)
       Math.log(3.24).should be_close(1.1755733298042381, 1e-7)
       Math.log(0.3_f32, 3).should be_close(-1.0959032742893848, 1e-7)
       Math.log(0.3, 3).should be_close(-1.0959032742893848, 1e-7)
     end
 
-    it "log2" do
+    it("log2") do
       Math.log2(1.2_f32).should be_close(0.2630344058337938, 1e-7)
       Math.log2(1.2).should be_close(0.2630344058337938, 1e-7)
     end
 
-    it "log10" do
+    it("log10") do
       Math.log10(0.5_f32).should be_close(-0.3010299956639812, 1e-7)
       Math.log10(0.5).should be_close(-0.3010299956639812, 1e-7)
     end
 
-    it "log1p" do
+    it("log1p") do
       Math.log1p(0.67_f32).should be_close(0.5128236264286637, 1e-7)
       Math.log1p(0.67).should be_close(0.5128236264286637, 1e-7)
     end
   end
 
-  describe "Trigonometric functions" do
-    it "cos" do
+  describe("Trigonometric functions") do
+    it("cos") do
       Math.cos(2.23_f32).should be_close(-0.6124875656583851, 1e-7)
       Math.cos(2.23).should be_close(-0.6124875656583851, 1e-7)
     end
 
-    it "sin" do
+    it("sin") do
       Math.sin(3.3_f32).should be_close(-0.1577456941432482, 1e-7)
       Math.sin(3.3).should be_close(-0.1577456941432482, 1e-7)
     end
 
-    it "tan" do
+    it("tan") do
       Math.tan(0.91_f32).should be_close(1.2863693807208076, 1e-7)
       Math.tan(0.91).should be_close(1.2863693807208076, 1e-7)
     end
 
-    it "hypot" do
+    it("hypot") do
       Math.hypot(2.1_f32, 1.5_f32).should be_close(2.5806975801127883, 1e-7)
       Math.hypot(2.1, 1.5).should be_close(2.5806975801127883, 1e-7)
     end
   end
 
-  describe "Inverse trigonometric functions" do
-    it "acos" do
+  describe("Inverse trigonometric functions") do
+    it("acos") do
       Math.acos(0.125_f32).should be_close(1.445468495626831, 1e-7)
       Math.acos(0.125).should be_close(1.445468495626831, 1e-7)
     end
 
-    it "asin" do
+    it("asin") do
       Math.asin(-0.4_f32).should be_close(-0.41151684606748806, 1e-7)
       Math.asin(-0.4).should be_close(-0.41151684606748806, 1e-7)
     end
 
-    it "atan" do
+    it("atan") do
       Math.atan(4.3_f32).should be_close(1.3422996875030344, 1e-7)
       Math.atan(4.3).should be_close(1.3422996875030344, 1e-7)
     end
 
-    it "atan2" do
+    it("atan2") do
       Math.atan2(3.5_f32, 2.1_f32).should be_close(1.0303768265243125, 1e-7)
       Math.atan2(3.5, 2.1).should be_close(1.0303768265243125, 1e-7)
       Math.atan2(1, 0).should eq(Math.atan2(1.0, 0.0))
     end
   end
 
-  describe "Hyperbolic functions" do
-    it "cosh" do
+  describe("Hyperbolic functions") do
+    it("cosh") do
       Math.cosh(0.79_f32).should be_close(1.3286206107691463, 1e-7)
       Math.cosh(0.79).should be_close(1.3286206107691463, 1e-7)
     end
 
-    it "sinh" do
+    it("sinh") do
       Math.sinh(0.12_f32).should be_close(0.12028820743110909, 1e-7)
       Math.sinh(0.12).should be_close(0.12028820743110909, 1e-7)
     end
 
-    it "tanh" do
+    it("tanh") do
       Math.tanh(4.1_f32).should be_close(0.9994508436877974, 1e-7)
       Math.tanh(4.1).should be_close(0.9994508436877974, 1e-7)
     end
   end
 
-  describe "Inverse hyperbolic functions" do
-    it "acosh" do
+  describe("Inverse hyperbolic functions") do
+    it("acosh") do
       Math.acosh(1.1_f32).should be_close(0.4435682543851154, 1e-7)
       Math.acosh(1.1).should be_close(0.4435682543851154, 1e-7)
     end
 
-    it "asinh" do
+    it("asinh") do
       Math.asinh(-2.3_f32).should be_close(-1.570278543484978, 1e-7)
       Math.asinh(-2.3).should be_close(-1.570278543484978, 1e-7)
     end
 
-    it "atanh" do
+    it("atanh") do
       Math.atanh(0.13_f32).should be_close(0.13073985002887845, 1e-7)
       Math.atanh(0.13).should be_close(0.13073985002887845, 1e-7)
     end
   end
 
-  describe "Gamma functions" do
-    it "gamma" do
+  describe("Gamma functions") do
+    it("gamma") do
       Math.gamma(3.2_f32).should be_close(2.4239654799353683, 1e-6)
       Math.gamma(3.2).should be_close(2.4239654799353683, 1e-7)
       Math.gamma(5).should eq 24
       Math.gamma(5_i8).should eq 24
     end
 
-    it "lgamma" do
+    it("lgamma") do
       Math.lgamma(2.96_f32).should be_close(0.6565534110944214, 1e-7)
       Math.lgamma(2.96).should be_close(0.6565534110944214, 1e-7)
       Math.lgamma(3).should be_close(0.6931471805599454, 1e-7)
@@ -209,45 +209,45 @@ describe "Math" do
     end
   end
 
-  describe "Bessel functions" do
-    it "besselj0" do
+  describe("Bessel functions") do
+    it("besselj0") do
       Math.besselj0(9.1_f32).should be_close(-0.11423923268319867, 1e-7)
       Math.besselj0(9.1).should be_close(-0.11423923268319867, 1e-7)
     end
 
-    it "besselj1" do
+    it("besselj1") do
       Math.besselj1(-2.1_f32).should be_close(-0.5682921357570385, 1e-7)
       Math.besselj1(-2.1).should be_close(-0.5682921357570385, 1e-7)
     end
 
-    it "besselj" do
+    it("besselj") do
       Math.besselj(4, -6.4_f32).should be_close(0.2945338623574655, 1e-7)
       Math.besselj(4, -6.4).should be_close(0.2945338623574655, 1e-7)
     end
 
-    it "bessely0" do
+    it("bessely0") do
       Math.bessely0(2.14_f32).should be_close(0.5199289108068015, 1e-7)
       Math.bessely0(2.14).should be_close(0.5199289108068015, 1e-7)
     end
 
-    it "bessely1" do
+    it("bessely1") do
       Math.bessely1(7.7_f32).should be_close(-0.2243184743430081, 1e-7)
       Math.bessely1(7.7).should be_close(-0.2243184743430081, 1e-7)
     end
 
-    it "bessely" do
+    it("bessely") do
       Math.bessely(3, 2.7_f32).should be_close(-0.6600575162477298, 1e-7)
       Math.bessely(3, 2.7).should be_close(-0.6600575162477298, 1e-7)
     end
   end
 
-  describe "Gauss error functions" do
-    it "erf" do
+  describe("Gauss error functions") do
+    it("erf") do
       Math.erf(0.72_f32).should be_close(0.6914331231387512, 1e-7)
       Math.erf(0.72).should be_close(0.6914331231387512, 1e-7)
     end
 
-    it "erfc" do
+    it("erfc") do
       Math.erfc(-0.66_f32).should be_close(1.6493766879629543, 1e-7)
       Math.erfc(-0.66).should be_close(1.6493766879629543, 1e-7)
     end
@@ -257,8 +257,8 @@ describe "Math" do
 
   # pw2ceil
 
-  describe "Rounding up to powers of 2" do
-    it "pw2ceil" do
+  describe("Rounding up to powers of 2") do
+    it("pw2ceil") do
       Math.pw2ceil(33).should eq(64)
       Math.pw2ceil(128).should eq(128)
     end

--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -1,20 +1,20 @@
 require "spec"
 
-describe Mutex do
-  it "locks and unlocks" do
+describe(Mutex) do
+  it("locks and unlocks") do
     mutex = Mutex.new
     mutex.lock
     mutex.unlock
   end
 
-  it "raises if unlocks without lock" do
+  it("raises if unlocks without lock") do
     mutex = Mutex.new
     expect_raises(Exception, "Attempt to unlock a mutex which is not locked") do
       mutex.unlock
     end
   end
 
-  it "can be locked many times from the same fiber" do
+  it("can be locked many times from the same fiber") do
     mutex = Mutex.new
     mutex.lock
     mutex.lock
@@ -22,7 +22,7 @@ describe Mutex do
     mutex.unlock
   end
 
-  it "can lock and unlock from multiple fibers" do
+  it("can lock and unlock from multiple fibers") do
     mutex = Mutex.new
 
     a = 1

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -1,11 +1,11 @@
 require "spec"
 
-describe "NamedTuple" do
-  it "does new" do
+describe("NamedTuple") do
+  it("does new") do
     NamedTuple.new(x: 1, y: 2).should eq({x: 1, y: 2})
   end
 
-  it "does NamedTuple.from" do
+  it("does NamedTuple.from") do
     t = NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :bar => 2})
     t.should eq({foo: 1, bar: 2})
     t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
@@ -18,11 +18,11 @@ describe "NamedTuple" do
     t.should eq({"foo bar": 1, "baz qux": 2})
     t.class.should eq(NamedTuple("foo bar": Int32, "baz qux": Int32))
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       NamedTuple(foo: Int32, bar: Int32).from({:foo => 1})
     end
 
-    expect_raises KeyError do
+    expect_raises(KeyError) do
       NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :baz => 2})
     end
 
@@ -31,7 +31,7 @@ describe "NamedTuple" do
     end
   end
 
-  it "does NamedTuple#from" do
+  it("does NamedTuple#from") do
     t = {foo: Int32, bar: Int32}.from({:foo => 1, :bar => 2})
     t.should eq({foo: 1, bar: 2})
     t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
@@ -40,11 +40,11 @@ describe "NamedTuple" do
     t.should eq({foo: 1, bar: 2})
     t.class.should eq(NamedTuple(foo: Int32, bar: Int32))
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       {foo: Int32, bar: Int32}.from({:foo => 1})
     end
 
-    expect_raises KeyError do
+    expect_raises(KeyError) do
       {foo: Int32, bar: Int32}.from({:foo => 1, :baz => 2})
     end
 
@@ -53,11 +53,11 @@ describe "NamedTuple" do
     end
   end
 
-  it "gets size" do
+  it("gets size") do
     {a: 1, b: 3}.size.should eq(2)
   end
 
-  it "does [] with runtime key" do
+  it("does [] with runtime key") do
     tup = {a: 1, b: 'a'}
 
     key = :a
@@ -76,7 +76,7 @@ describe "NamedTuple" do
     end
   end
 
-  it "does []? with runtime key" do
+  it("does []? with runtime key") do
     tup = {a: 1, b: 'a'}
 
     key = :a
@@ -95,7 +95,7 @@ describe "NamedTuple" do
     typeof(val).should eq(Int32 | Char | Nil)
   end
 
-  it "does [] with string" do
+  it("does [] with string") do
     tup = {a: 1, b: 'a'}
 
     key = "a"
@@ -114,7 +114,7 @@ describe "NamedTuple" do
     end
   end
 
-  it "does []? with string" do
+  it("does []? with string") do
     tup = {a: 1, b: 'a'}
 
     key = "a"
@@ -133,7 +133,7 @@ describe "NamedTuple" do
     typeof(val).should eq(Int32 | Char | Nil)
   end
 
-  it "computes a hash value" do
+  it("computes a hash value") do
     tup1 = {a: 1, b: 'a'}
     tup1.hash.should eq(tup1.dup.hash)
 
@@ -141,7 +141,7 @@ describe "NamedTuple" do
     tup2.hash.should eq(tup1.hash)
   end
 
-  it "does each" do
+  it("does each") do
     tup = {a: 1, b: "hello"}
     i = 0
     tup.each do |key, value|
@@ -158,7 +158,7 @@ describe "NamedTuple" do
     i.should eq(2)
   end
 
-  it "does each_key" do
+  it("does each_key") do
     tup = {a: 1, b: "hello"}
     i = 0
     tup.each_key do |key|
@@ -173,7 +173,7 @@ describe "NamedTuple" do
     i.should eq(2)
   end
 
-  it "does each_value" do
+  it("does each_value") do
     tup = {a: 1, b: "hello"}
     i = 0
     tup.each_value do |value|
@@ -188,7 +188,7 @@ describe "NamedTuple" do
     i.should eq(2)
   end
 
-  it "does each_with_index" do
+  it("does each_with_index") do
     tup = {a: 1, b: "hello"}
     i = 0
     tup.each_with_index do |key, value, index|
@@ -207,41 +207,41 @@ describe "NamedTuple" do
     i.should eq(2)
   end
 
-  it "does has_key? with symbol" do
+  it("does has_key? with symbol") do
     tup = {a: 1, b: 'a'}
     tup.has_key?(:a).should be_true
     tup.has_key?(:b).should be_true
     tup.has_key?(:c).should be_false
   end
 
-  it "does has_key? with string" do
+  it("does has_key? with string") do
     tup = {a: 1, b: 'a'}
     tup.has_key?("a").should be_true
     tup.has_key?("b").should be_true
     tup.has_key?("c").should be_false
   end
 
-  it "does empty" do
+  it("does empty") do
     {a: 1}.empty?.should be_false
   end
 
-  it "does to_a" do
+  it("does to_a") do
     tup = {a: 1, b: 'a'}
     tup.to_a.should eq([{:a, 1}, {:b, 'a'}])
   end
 
-  it "does key_index" do
+  it("does key_index") do
     tup = {a: 1, b: 'a'}
     tup.to_a.should eq([{:a, 1}, {:b, 'a'}])
   end
 
-  it "does map" do
+  it("does map") do
     tup = {a: 1, b: 'a'}
     strings = tup.map { |k, v| "#{k.inspect}-#{v.inspect}" }
     strings.should eq([":a-1", ":b-'a'"])
   end
 
-  it "compares with same named tuple type" do
+  it("compares with same named tuple type") do
     tup1 = {a: 1, b: 'a'}
     tup2 = {b: 'a', a: 1}
     tup3 = {a: 1, b: 'b'}
@@ -249,7 +249,7 @@ describe "NamedTuple" do
     tup1.should_not eq(tup3)
   end
 
-  it "compares with other named tuple type" do
+  it("compares with other named tuple type") do
     tup1 = {a: 1, b: 'a'}
     tup2 = {b: 'a', a: 1.0}
     tup3 = {b: 'a', a: 1.1}
@@ -257,18 +257,18 @@ describe "NamedTuple" do
     tup1.should_not eq(tup3)
   end
 
-  it "does to_h" do
+  it("does to_h") do
     tup1 = {a: 1, b: "hello"}
     hash = tup1.to_h
     hash.should eq({:a => 1, :b => "hello"})
   end
 
-  it "does to_s" do
+  it("does to_s") do
     tup = {a: 1, b: "hello"}
     tup.to_s.should eq(%({a: 1, b: "hello"}))
   end
 
-  it "dups" do
+  it("dups") do
     tup1 = {a: 1, b: [1, 2, 3]}
     tup2 = tup1.dup
 
@@ -276,7 +276,7 @@ describe "NamedTuple" do
     tup2[:b].should be(tup1[:b])
   end
 
-  it "clones" do
+  it("clones") do
     tup1 = {a: 1, b: [1, 2, 3]}
     tup2 = tup1.clone
 
@@ -287,17 +287,17 @@ describe "NamedTuple" do
     tup2.clone.should eq(tup2)
   end
 
-  it "does keys" do
+  it("does keys") do
     tup = {a: 1, b: 2}
     tup.keys.should eq({:a, :b})
   end
 
-  it "does values" do
+  it("does values") do
     tup = {a: 1, b: 'a'}
     tup.values.should eq({1, 'a'})
   end
 
-  it "does types" do
+  it("does types") do
     tuple = {a: 1, b: 'a', c: "hello"}
     tuple.class.types.to_s.should eq("{a: Int32, b: Char, c: String}")
   end

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 
-describe "Number" do
-  describe "significant" do
-    it "10 base " do
+describe("Number") do
+  describe("significant") do
+    it("10 base ") do
       1234.567.significant(1).should eq(1000)
       1234.567.significant(2).should eq(1200)
       1234.567.significant(3).should eq(1230)
@@ -12,49 +12,49 @@ describe "Number" do
       1234.567.significant(7).should eq(1234.567)
     end
 
-    it "2 base " do
+    it("2 base ") do
       -1763.116.significant(2, base: 2).should eq(-1536.0)
       753.155.significant(3, base: 2).should eq(768.0)
       15.159.significant(1, base: 2).should eq(16.0)
     end
 
-    it "8 base " do
+    it("8 base ") do
       -1763.116.significant(2, base: 8).should eq(-1792.0)
       753.155.significant(3, base: 8).should eq(752.0)
       15.159.significant(1, base: 8).should eq(16.0)
     end
 
-    it "preserves type" do
+    it("preserves type") do
       123.significant(2).should eq(120)
       123.significant(2).should be_a(Int32)
     end
   end
 
-  describe "round" do
-    it "10 base " do
+  describe("round") do
+    it("10 base ") do
       -1763.116.round(2).should eq(-1763.12)
       753.155.round(2).should eq(753.16)
       15.151.round(2).should eq(15.15)
     end
 
-    it "2 base " do
+    it("2 base ") do
       -1763.116.round(2, base: 2).should eq(-1763.0)
       753.155.round(2, base: 2).should eq(753.25)
       15.159.round(2, base: 2).should eq(15.25)
     end
 
-    it "8 base " do
+    it("8 base ") do
       -1763.116.round(2, base: 8).should eq(-1763.109375)
       753.155.round(1, base: 8).should eq(753.125)
       15.159.round(0, base: 8).should eq(15.0)
     end
 
-    it "preserves type" do
+    it("preserves type") do
       123.round(2).should eq(123)
       123.round(2).should be_a(Int32)
     end
 
-    it "accepts negative precision" do
+    it("accepts negative precision") do
       123.round(-2).should eq(100)
       123.round(-3).should eq(0)
       523.round(-3).should eq(1000)
@@ -65,8 +65,8 @@ describe "Number" do
     end
   end
 
-  describe "clamp" do
-    it "clamps integers" do
+  describe("clamp") do
+    it("clamps integers") do
       -5.clamp(-10, 100).should eq(-5)
       -5.clamp(10, 100).should eq(10)
       5.clamp(10, 100).should eq(10)
@@ -76,7 +76,7 @@ describe "Number" do
       50.clamp(10..100).should eq(50)
     end
 
-    it "clamps floats" do
+    it("clamps floats") do
       -5.5.clamp(-10.1, 100.1).should eq(-5.5)
       -5.5.clamp(10.1, 100.1).should eq(10.1)
       5.5.clamp(10.1, 100.1).should eq(10.1)
@@ -86,7 +86,7 @@ describe "Number" do
       50.5.clamp(10.1..100.1).should eq(50.5)
     end
 
-    it "fails with an exclusive range" do
+    it("fails with an exclusive range") do
       expect_raises(ArgumentError) do
         range = Range.new(1, 2, exclusive: true)
         5.clamp(range)
@@ -94,25 +94,25 @@ describe "Number" do
     end
   end
 
-  it "gives the absolute value" do
+  it("gives the absolute value") do
     123.abs.should eq(123)
     -123.abs.should eq(123)
   end
 
-  it "gives the square of a value" do
+  it("gives the square of a value") do
     2.abs2.should eq(4)
     -2.abs2.should eq(4)
     2.5.abs2.should eq(6.25)
     -2.5.abs2.should eq(6.25)
   end
 
-  it "gives the sign" do
+  it("gives the sign") do
     123.sign.should eq(1)
     -123.sign.should eq(-1)
     0.sign.should eq(0)
   end
 
-  it "divides and calculs the modulo" do
+  it("divides and calculs the modulo") do
     11.divmod(3).should eq({3, 2})
     11.divmod(-3).should eq({-4, -1})
 
@@ -129,26 +129,26 @@ describe "Number" do
     -11.divmod(-2).should eq({5, -1})
   end
 
-  it "compare the numbers" do
+  it("compare the numbers") do
     10.<=>(10).should eq(0)
     10.<=>(11).should eq(-1)
     11.<=>(10).should eq(1)
   end
 
-  it "creates an array with [] and some elements" do
+  it("creates an array with [] and some elements") do
     ary = Int64[1, 2, 3]
     ary.should eq([1, 2, 3])
     ary[0].should be_a(Int64)
   end
 
-  it "creates an array with [] and no elements" do
+  it("creates an array with [] and no elements") do
     ary = Int64[]
     ary.should eq([] of Int64)
     ary << 1_i64
     ary.should eq([1])
   end
 
-  it "creates a slice" do
+  it("creates a slice") do
     slice = Int8.slice(1, 2, 300)
     slice.should be_a(Slice(Int8))
     slice.size.should eq(3)
@@ -157,7 +157,7 @@ describe "Number" do
     slice[2].should eq(300.to_u8)
   end
 
-  it "creates a static array" do
+  it("creates a static array") do
     ary = Int8.static_array(1, 2, 300)
     ary.should be_a(StaticArray(Int8, 3))
     ary.size.should eq(3)
@@ -166,7 +166,7 @@ describe "Number" do
     ary[2].should eq(300.to_u8)
   end
 
-  it "test zero?" do
+  it("test zero?") do
     0.zero?.should eq true
     0.0.zero?.should eq true
     0f32.zero?.should eq true
@@ -175,8 +175,8 @@ describe "Number" do
     1f32.zero?.should eq false
   end
 
-  describe "step" do
-    it "from int to float" do
+  describe("step") do
+    it("from int to float") do
       count = 0
       0.step(by: 0.1, to: 0.3) do |x|
         typeof(x).should eq(typeof(0.1))
@@ -189,7 +189,7 @@ describe "Number" do
       end
     end
 
-    it "iterator" do
+    it("iterator") do
       iter = 0.step(by: 0.1, to: 0.3)
       iter.next.should eq(0.0)
       iter.next.should eq(0.1)
@@ -200,7 +200,7 @@ describe "Number" do
       iter.next.should eq(0.0)
     end
 
-    it "iterator without limit" do
+    it("iterator without limit") do
       iter = 0.step
 
       1000.times do

--- a/spec/std/oauth/access_token_spec.cr
+++ b/spec/std/oauth/access_token_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "oauth"
 
-describe OAuth::AccessToken do
-  it "creates from response body" do
+describe(OAuth::AccessToken) do
+  it("creates from response body") do
     access_token = OAuth::AccessToken.from_response("oauth_token=1234-nyi1G37179bVdYNZGZqKQEdO&oauth_token_secret=f7T6ibH25q4qkVTAUN&user_id=1234&screen_name=someuser")
     access_token.token.should eq("1234-nyi1G37179bVdYNZGZqKQEdO")
     access_token.secret.should eq("f7T6ibH25q4qkVTAUN")

--- a/spec/std/oauth/authorization_header_spec.cr
+++ b/spec/std/oauth/authorization_header_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "oauth"
 
-describe OAuth::AuthorizationHeader do
-  it "builds" do
+describe(OAuth::AuthorizationHeader) do
+  it("builds") do
     params = OAuth::AuthorizationHeader.new
     params.add "foo", "value1"
     params.add "bar", "a+b"

--- a/spec/std/oauth/consumer_spec.cr
+++ b/spec/std/oauth/consumer_spec.cr
@@ -1,30 +1,30 @@
 require "spec"
 require "oauth"
 
-describe OAuth::Consumer do
-  describe "gets authorize uri" do
-    it "without callback url" do
+describe(OAuth::Consumer) do
+  describe("gets authorize uri") do
+    it("without callback url") do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token
       uri.should eq("https://example.com/oauth/authorize?oauth_token=request_token")
     end
 
-    it "with callback url" do
+    it("with callback url") do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token, oauth_callback: "some_callback"
       uri.should eq("https://example.com/oauth/authorize?oauth_token=request_token&oauth_callback=some_callback")
     end
 
-    it "without custom authorize uri" do
+    it("without custom authorize uri") do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret", authorize_uri: "/foo"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token
       uri.should eq("https://example.com/foo?oauth_token=request_token")
     end
 
-    it "without block" do
+    it("without block") do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri(request_token) do |form|
@@ -33,7 +33,7 @@ describe OAuth::Consumer do
       uri.should eq("https://example.com/oauth/authorize?oauth_token=request_token&baz=qux")
     end
 
-    it "with absolute uri" do
+    it("with absolute uri") do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret",
         authorize_uri: "https://example2.com:1234/foo?bar=baz"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"

--- a/spec/std/oauth/params_spec.cr
+++ b/spec/std/oauth/params_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "oauth"
 
-describe OAuth::Params do
-  it "builds" do
+describe(OAuth::Params) do
+  it("builds") do
     params = OAuth::Params.new
     params.add "foo", "value1"
     params.add "bar", "a+b"

--- a/spec/std/oauth/request_token_spec.cr
+++ b/spec/std/oauth/request_token_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "oauth"
 
-describe OAuth::RequestToken do
-  it "creates from response" do
+describe(OAuth::RequestToken) do
+  it("creates from response") do
     token = OAuth::RequestToken.from_response("oauth_token_secret=p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8&oauth_callback_confirmed=true&oauth_token=qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")
     token.secret.should eq("p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8")
     token.token.should eq("qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")

--- a/spec/std/oauth/signature_spec.cr
+++ b/spec/std/oauth/signature_spec.cr
@@ -1,21 +1,21 @@
 require "spec"
 require "oauth"
 
-describe OAuth::Signature do
-  describe "key" do
-    it "gets when token secret is empty" do
+describe(OAuth::Signature) do
+  describe("key") do
+    it("gets when token secret is empty") do
       signature = OAuth::Signature.new "consumer_key", "consumer secret"
       signature.key.should eq("consumer%20secret&")
     end
 
-    it "gets when token secret is not empty" do
+    it("gets when token secret is not empty") do
       signature = OAuth::Signature.new "consumer_key", "consumer secret", token_shared_secret: "token secret"
       signature.key.should eq("consumer%20secret&token%20secret")
     end
   end
 
-  describe "base string" do
-    it "computes without port in host" do
+  describe("base string") do
+    it("computes without port in host") do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
       tls = false
@@ -28,7 +28,7 @@ describe OAuth::Signature do
       base_string.should eq("POST&http%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
-    it "computes with port in host" do
+    it("computes with port in host") do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host:5678"
       tls = false
@@ -41,7 +41,7 @@ describe OAuth::Signature do
       base_string.should eq("POST&http%3A%2F%2Fsome.host%3A5678%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
-    it "computes when TLS" do
+    it("computes when TLS") do
       request = HTTP::Request.new "POST", "/some/path"
       request.headers["Host"] = "some.host"
       tls = true
@@ -56,7 +56,7 @@ describe OAuth::Signature do
   end
 
   # https://dev.twitter.com/oauth/overview/creating-signatures
-  it "does twitter sample" do
+  it("does twitter sample") do
     request = HTTP::Request.new "POST", "/1/statuses/update.json?include_entities=true", body: "status=Hello%20Ladies%20%2b%20Gentlemen%2c%20a%20signed%20OAuth%20request%21"
     request.headers["Host"] = "api.twitter.com"
     request.headers["Content-type"] = "application/x-www-form-urlencoded"

--- a/spec/std/oauth2/access_token_spec.cr
+++ b/spec/std/oauth2/access_token_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "oauth2"
 
 class OAuth2::AccessToken
-  describe Bearer do
-    it "builds from json" do
+  describe(Bearer) do
+    it("builds from json") do
       token_value = "some token value"
       token_type = "Bearer"
       expires_in = 3600
@@ -34,20 +34,20 @@ class OAuth2::AccessToken
       access_token.scope.should eq(scope)
     end
 
-    it "dumps to json" do
+    it("dumps to json") do
       token = Bearer.new("access token", 3600, "refresh token")
       token2 = AccessToken.from_json(token.to_json)
       token2.should eq(token)
     end
 
-    it "authenticates request" do
+    it("authenticates request") do
       token = Bearer.new("access token", 3600, "refresh token")
       request = HTTP::Request.new "GET", "/"
       token.authenticate request, false
       request.headers["Authorization"].should eq("Bearer access token")
     end
 
-    it "builds from json without expires_in (#4041)" do
+    it("builds from json without expires_in (#4041)") do
       access_token = AccessToken.from_json(%({
         "access_token" : "foo",
         "token_type" : "Bearer",
@@ -57,7 +57,7 @@ class OAuth2::AccessToken
       access_token.expires_in.should be_nil
     end
 
-    it "builds from json with unknown key (#4437)" do
+    it("builds from json with unknown key (#4437)") do
       token = AccessToken.from_json(%({
         "access_token" : "foo",
         "token_type" : "Bearer",
@@ -68,7 +68,7 @@ class OAuth2::AccessToken
       token.extra.not_nil!["unknown"].should eq("[1,2,3]")
     end
 
-    it "builds from json without token_type, assumes Bearer (#4503)" do
+    it("builds from json without token_type, assumes Bearer (#4503)") do
       token = AccessToken.from_json(%({
         "access_token" : "foo",
         "refresh_token" : "bar",
@@ -79,8 +79,8 @@ class OAuth2::AccessToken
     end
   end
 
-  describe Mac do
-    it "builds from json" do
+  describe(Mac) do
+    it("builds from json") do
       mac_algorithm = "hmac-sha-256"
       expires_in = 3600
       mac_key = "secret key"
@@ -118,7 +118,7 @@ class OAuth2::AccessToken
       access_token.mac_key.should eq(mac_key)
     end
 
-    it "builds with null refresh token" do
+    it("builds with null refresh token") do
       json = %({
         "token_type": "Mac",
         "access_token":"WRN01OBN1gme8HxeRL5yJ8w05PjCvt-2vXOIle43w9s",
@@ -132,13 +132,13 @@ class OAuth2::AccessToken
       access_token.refresh_token.should be_nil
     end
 
-    it "dumps to json" do
+    it("dumps to json") do
       token = Mac.new("access token", 3600, "mac algorithm", "mac key", "refresh token", "scope")
       token2 = AccessToken.from_json(token.to_json)
       token2.should eq(token)
     end
 
-    it "authenticates request" do
+    it("authenticates request") do
       headers = HTTP::Headers.new
       headers["Host"] = "localhost:4000"
 
@@ -149,7 +149,7 @@ class OAuth2::AccessToken
       (auth =~ /MAC id=".+?", nonce=".+?", ts=".+?", mac=".+?"/).should be_truthy
     end
 
-    it "computes signature" do
+    it("computes signature") do
       mac = Mac.signature 1, "0:1234", "GET", "/resource.json", "localhost", "4000", "", "hmac-sha-256", "i-pt1Lir-yAfUdXbt-AXM1gMupK7vDiOK1SZGWkASDc"
       mac.should eq("21vVRFACz5NrO+zlVfFuxTjTx5Wb0qBMfKelMTtujpE=")
     end

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -1,27 +1,27 @@
 require "spec"
 require "oauth2"
 
-describe OAuth2::Client do
-  describe "authorization uri" do
-    it "gets with default endpoint" do
+describe(OAuth2::Client) do
+  describe("authorization uri") do
+    it("gets with default endpoint") do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri"
       uri = client.get_authorize_uri(scope: "foo bar")
       uri.should eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo+bar")
     end
 
-    it "gets with custom endpoint" do
+    it("gets with custom endpoint") do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri", authorize_uri: "/baz"
       uri = client.get_authorize_uri(scope: "foo bar")
       uri.should eq("https://localhost/baz?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo+bar")
     end
 
-    it "gets with state" do
+    it("gets with state") do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri"
       uri = client.get_authorize_uri(scope: "foo bar", state: "xyz")
       uri.should eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo+bar&state=xyz")
     end
 
-    it "gets with block" do
+    it("gets with block") do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri"
       uri = client.get_authorize_uri(scope: "foo bar") do |form|
         form.add "baz", "qux"
@@ -29,7 +29,7 @@ describe OAuth2::Client do
       uri.should eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo+bar&baz=qux")
     end
 
-    it "gets with absolute uri" do
+    it("gets with absolute uri") do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret",
         redirect_uri: "uri",
         authorize_uri: "https://example2.com:1234/foo?bar=baz"

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -29,7 +29,7 @@ private class TestObject
   getter(getter11) { 11 }
 
   @@getter12_value = 12
-  getter getter12 : Int32 { @@getter12_value }
+  getter(getter12 : Int32) { @@getter12_value }
 
   def self.getter12_value=(@@getter12_value)
   end
@@ -55,7 +55,7 @@ private class TestObject
   property? property10 = true
 
   property(property11) { 11 }
-  property property12 : Int32 { 10 + 2 }
+  property(property12 : Int32) { 10 + 2 }
 
   def initialize
     @getter1 = 1
@@ -97,9 +97,9 @@ private class TestObject
   end
 end
 
-describe Object do
-  describe "delegate" do
-    it "delegates" do
+describe(Object) do
+  describe("delegate") do
+    it("delegates") do
       wrapper = StringWrapper.new("HellO")
       wrapper.downcase.should eq("hello")
       wrapper.upcase.should eq("HELLO")
@@ -118,36 +118,36 @@ describe Object do
     end
   end
 
-  describe "getter" do
-    it "uses simple getter" do
+  describe("getter") do
+    it("uses simple getter") do
       obj = TestObject.new
       obj.getter1.should eq(1)
       typeof(obj.@getter1).should eq(Int32)
       typeof(obj.getter1).should eq(Int32)
     end
 
-    it "uses getter with type declaration" do
+    it("uses getter with type declaration") do
       obj = TestObject.new
       obj.getter2.should eq(2)
       typeof(obj.@getter2).should eq(Int32)
       typeof(obj.getter2).should eq(Int32)
     end
 
-    it "uses getter with type declaration and default value" do
+    it("uses getter with type declaration and default value") do
       obj = TestObject.new
       obj.getter3.should eq(3)
       typeof(obj.@getter3).should eq(Int32)
       typeof(obj.getter3).should eq(Int32)
     end
 
-    it "uses getter with assignment" do
+    it("uses getter with assignment") do
       obj = TestObject.new
       obj.getter4.should eq(4)
       typeof(obj.@getter4).should eq(Int32)
       typeof(obj.getter4).should eq(Int32)
     end
 
-    it "defines lazy getter with block" do
+    it("defines lazy getter with block") do
       obj = TestObject.new
       obj.getter11.should eq(11)
       obj.getter12.should eq(12)
@@ -159,8 +159,8 @@ describe Object do
     end
   end
 
-  describe "getter!" do
-    it "uses getter!" do
+  describe("getter!") do
+    it("uses getter!") do
       obj = TestObject.new
       expect_raises do
         obj.getter5
@@ -171,7 +171,7 @@ describe Object do
       typeof(obj.getter5).should eq(Int32)
     end
 
-    it "uses getter! with type declaration" do
+    it("uses getter! with type declaration") do
       obj = TestObject.new
       expect_raises do
         obj.getter6
@@ -183,29 +183,29 @@ describe Object do
     end
   end
 
-  describe "getter?" do
-    it "uses getter?" do
+  describe("getter?") do
+    it("uses getter?") do
       obj = TestObject.new
       obj.getter7?.should be_true
       typeof(obj.@getter7).should eq(Bool)
       typeof(obj.getter7?).should eq(Bool)
     end
 
-    it "uses getter? with type declaration" do
+    it("uses getter? with type declaration") do
       obj = TestObject.new
       obj.getter8?.should be_true
       typeof(obj.@getter8).should eq(Bool)
       typeof(obj.getter8?).should eq(Bool)
     end
 
-    it "uses getter? with type declaration and default value" do
+    it("uses getter? with type declaration and default value") do
       obj = TestObject.new
       obj.getter9?.should be_true
       typeof(obj.@getter9).should eq(Bool)
       typeof(obj.getter9?).should eq(Bool)
     end
 
-    it "uses getter? with default value" do
+    it("uses getter? with default value") do
       obj = TestObject.new
       obj.getter10?.should be_true
       typeof(obj.@getter10).should eq(Bool)
@@ -213,29 +213,29 @@ describe Object do
     end
   end
 
-  describe "setter" do
-    it "uses setter" do
+  describe("setter") do
+    it("uses setter") do
       obj = TestObject.new
       obj.setter1.should eq(1)
       obj.setter1 = 2
       obj.setter1.should eq(2)
     end
 
-    it "uses setter with type declaration" do
+    it("uses setter with type declaration") do
       obj = TestObject.new
       obj.setter2.should eq(2)
       obj.setter2 = 3
       obj.setter2.should eq(3)
     end
 
-    it "uses setter with type declaration and default value" do
+    it("uses setter with type declaration and default value") do
       obj = TestObject.new
       obj.setter3.should eq(3)
       obj.setter3 = 4
       obj.setter3.should eq(4)
     end
 
-    it "uses setter with default value" do
+    it("uses setter with default value") do
       obj = TestObject.new
       obj.setter4.should eq(4)
       obj.setter4 = 5
@@ -243,36 +243,36 @@ describe Object do
     end
   end
 
-  describe "property" do
-    it "uses property" do
+  describe("property") do
+    it("uses property") do
       obj = TestObject.new
       obj.property1.should eq(1)
       obj.property1 = 2
       obj.property1.should eq(2)
     end
 
-    it "uses property with type declaration" do
+    it("uses property with type declaration") do
       obj = TestObject.new
       obj.property2.should eq(2)
       obj.property2 = 3
       obj.property2.should eq(3)
     end
 
-    it "uses property with type declaration and default value" do
+    it("uses property with type declaration and default value") do
       obj = TestObject.new
       obj.property3.should eq(3)
       obj.property3 = 4
       obj.property3.should eq(4)
     end
 
-    it "uses property with default value" do
+    it("uses property with default value") do
       obj = TestObject.new
       obj.property4.should eq(4)
       obj.property4 = 5
       obj.property4.should eq(5)
     end
 
-    it "defines lazy property with block" do
+    it("defines lazy property with block") do
       obj = TestObject.new
       obj.property11.should eq(11)
       obj.property11 = 12
@@ -284,8 +284,8 @@ describe Object do
     end
   end
 
-  describe "property!" do
-    it "uses property!" do
+  describe("property!") do
+    it("uses property!") do
       obj = TestObject.new
       expect_raises do
         obj.property5
@@ -294,7 +294,7 @@ describe Object do
       obj.property5.should eq(5)
     end
 
-    it "uses property! with type declaration" do
+    it("uses property! with type declaration") do
       obj = TestObject.new
       expect_raises do
         obj.property6
@@ -304,29 +304,29 @@ describe Object do
     end
   end
 
-  describe "property?" do
-    it "uses property?" do
+  describe("property?") do
+    it("uses property?") do
       obj = TestObject.new
       obj.property7?.should be_true
       obj.property7 = false
       obj.property7?.should be_false
     end
 
-    it "uses property? with type declaration" do
+    it("uses property? with type declaration") do
       obj = TestObject.new
       obj.property8?.should be_true
       obj.property8 = false
       obj.property8?.should be_false
     end
 
-    it "uses property? with type declaration and default value" do
+    it("uses property? with type declaration and default value") do
       obj = TestObject.new
       obj.property9?.should be_true
       obj.property9 = false
       obj.property9?.should be_false
     end
 
-    it "uses property? with default value" do
+    it("uses property? with default value") do
       obj = TestObject.new
       obj.property10?.should be_true
       obj.property10 = false
@@ -334,7 +334,7 @@ describe Object do
     end
   end
 
-  it "#unsafe_as" do
+  it("#unsafe_as") do
     0x12345678.unsafe_as(Tuple(UInt8, UInt8, UInt8, UInt8)).should eq({0x78, 0x56, 0x34, 0x12})
   end
 end

--- a/spec/std/openssl/cipher_spec.cr
+++ b/spec/std/openssl/cipher_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "openssl/cipher"
 
-describe OpenSSL::Cipher do
-  it "encrypts/decrypts" do
+describe(OpenSSL::Cipher) do
+  it("encrypts/decrypts") do
     cipher = "aes-128-cbc"
     c1 = OpenSSL::Cipher.new(cipher)
     c2 = OpenSSL::Cipher.new(cipher)

--- a/spec/std/openssl/digest_io_spec.cr
+++ b/spec/std/openssl/digest_io_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "../../../src/openssl"
 
-describe OpenSSL::DigestIO do
-  it "calculates digest from reading" do
+describe(OpenSSL::DigestIO) do
+  it("calculates digest from reading") do
     base_io = IO::Memory.new("foo")
     base_digest = OpenSSL::Digest.new("SHA256")
     io = OpenSSL::DigestIO.new(base_io, base_digest)
@@ -13,7 +13,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".hexbytes)
   end
 
-  it "calculates digest from multiple reads" do
+  it("calculates digest from multiple reads") do
     base_io = IO::Memory.new("foo")
     base_digest = OpenSSL::Digest.new("SHA256")
     io = OpenSSL::DigestIO.new(base_io, base_digest)
@@ -27,7 +27,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".hexbytes)
   end
 
-  it "does not calculate digest on read" do
+  it("does not calculate digest on read") do
     base_io = IO::Memory.new("foo")
     base_digest = OpenSSL::Digest.new("SHA256")
     empty_digest = OpenSSL::Digest.new("SHA256").digest
@@ -38,7 +38,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq(empty_digest)
   end
 
-  it "calculates digest from writing" do
+  it("calculates digest from writing") do
     base_io = IO::Memory.new
     base_digest = OpenSSL::Digest.new("SHA256")
     io = OpenSSL::DigestIO.new(base_io, base_digest, OpenSSL::DigestIO::DigestMode::Write)
@@ -48,7 +48,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".hexbytes)
   end
 
-  it "calculates digest from writing a string" do
+  it("calculates digest from writing a string") do
     base_io = IO::Memory.new
     base_digest = OpenSSL::Digest.new("SHA256")
     io = OpenSSL::DigestIO.new(base_io, base_digest, OpenSSL::DigestIO::DigestMode::Write)
@@ -58,7 +58,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".hexbytes)
   end
 
-  it "calculates digest from multiple writes" do
+  it("calculates digest from multiple writes") do
     base_io = IO::Memory.new
     base_digest = OpenSSL::Digest.new("SHA256")
     io = OpenSSL::DigestIO.new(base_io, base_digest, OpenSSL::DigestIO::DigestMode::Write)
@@ -69,7 +69,7 @@ describe OpenSSL::DigestIO do
     io.digest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae".hexbytes)
   end
 
-  it "does not calculate digest on write" do
+  it("does not calculate digest on write") do
     base_io = IO::Memory.new
     base_digest = OpenSSL::Digest.new("SHA256")
     empty_digest = OpenSSL::Digest.new("SHA256").digest

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -1,36 +1,36 @@
 require "spec"
 require "../../../src/openssl"
 
-describe OpenSSL::Digest do
+describe(OpenSSL::Digest) do
   [
     {"SHA1", "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"},
     {"SHA256", "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"},
     {"SHA512", "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"},
   ].each do |(algorithm, expected)|
-    it "should be able to calculate #{algorithm}" do
+    it("should be able to calculate #{algorithm}") do
       digest = OpenSSL::Digest.new(algorithm)
       digest << "foo"
       digest.hexdigest.should eq(expected)
     end
   end
 
-  it "raises a UnsupportedError if digest is unsupported" do
-    expect_raises OpenSSL::Digest::UnsupportedError do
+  it("raises a UnsupportedError if digest is unsupported") do
+    expect_raises(OpenSSL::Digest::UnsupportedError) do
       OpenSSL::Digest.new("unsupported")
     end
   end
 
-  it "returns the digest size" do
+  it("returns the digest size") do
     OpenSSL::Digest.new("SHA1").digest_size.should eq 20
     OpenSSL::Digest.new("SHA256").digest_size.should eq 32
   end
 
-  it "returns the block size" do
+  it("returns the block size") do
     OpenSSL::Digest.new("SHA1").block_size.should eq 64
     OpenSSL::Digest.new("SHA256").block_size.should eq 64
   end
 
-  it "correctly reads from IO" do
+  it("correctly reads from IO") do
     r, w = IO.pipe
     digest = OpenSSL::Digest.new("SHA256")
 

--- a/spec/std/openssl/hmac_spec.cr
+++ b/spec/std/openssl/hmac_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "openssl/hmac"
 
-describe OpenSSL::HMAC do
+describe(OpenSSL::HMAC) do
   [
     {:md4, "f3593b56f00b25c8af31d02ddef6d2d0"},
     {:md5, "0c7a250281315ab863549f66cd8a3a53"},
@@ -12,7 +12,7 @@ describe OpenSSL::HMAC do
     {:sha512, "114682914c5d017dfe59fdc804118b56a3a652a0b8870759cf9e792ed7426b08197076bf7d01640b1b0684df79e4b67e37485669e8ce98dbab60445f0db94fce"},
     {:ripemd160, "20d23140503df606c91bda9293f1ad4a23afe509"},
   ].each do |(algorithm, expected)|
-    it "computes #{algorithm}" do
+    it("computes #{algorithm}") do
       OpenSSL::HMAC.hexdigest(algorithm, "foo", "bar").should eq(expected)
     end
   end

--- a/spec/std/openssl/pkcs5_spec.cr
+++ b/spec/std/openssl/pkcs5_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "openssl/pkcs5"
 
-describe OpenSSL::PKCS5 do
-  it "computes pbkdf2_hmac_sha1" do
+describe(OpenSSL::PKCS5) do
+  it("computes pbkdf2_hmac_sha1") do
     [
       {1, 16, "0c60c80f961f0e71f3a9b524af601206"},
       {1, 32, "0c60c80f961f0e71f3a9b524af6012062fe037a6e0f0eb94fe8fc46bdc637164"},

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "openssl"
 
-describe OpenSSL::SSL::Context do
-  it "new for client" do
+describe(OpenSSL::SSL::Context) do
+  it("new for client") do
     context = OpenSSL::SSL::Context::Client.new
 
     (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
@@ -18,7 +18,7 @@ describe OpenSSL::SSL::Context do
     OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
   end
 
-  it "new for server" do
+  it("new for server") do
     context = OpenSSL::SSL::Context::Server.new
 
     (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
@@ -35,7 +35,7 @@ describe OpenSSL::SSL::Context do
     OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)
   end
 
-  it "insecure for client" do
+  it("insecure for client") do
     context = OpenSSL::SSL::Context::Client.insecure
     context.should be_a(OpenSSL::SSL::Context::Client)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
@@ -45,7 +45,7 @@ describe OpenSSL::SSL::Context do
     OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
   end
 
-  it "insecure for server" do
+  it("insecure for server") do
     context = OpenSSL::SSL::Context::Server.insecure
     context.should be_a(OpenSSL::SSL::Context::Server)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
@@ -55,40 +55,40 @@ describe OpenSSL::SSL::Context do
     OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end
 
-  it "sets certificate chain" do
+  it("sets certificate chain") do
     context = OpenSSL::SSL::Context::Client.new
     context.certificate_chain = File.join(__DIR__, "openssl.crt")
   end
 
-  it "fails to set certificate chain" do
+  it("fails to set certificate chain") do
     context = OpenSSL::SSL::Context::Client.new
     expect_raises(OpenSSL::Error) { context.certificate_chain = File.join(__DIR__, "unknown.crt") }
     expect_raises(OpenSSL::Error) { context.certificate_chain = __FILE__ }
   end
 
-  it "sets private key" do
+  it("sets private key") do
     context = OpenSSL::SSL::Context::Client.new
     context.private_key = File.join(__DIR__, "openssl.key")
   end
 
-  it "fails to set private key" do
+  it("fails to set private key") do
     context = OpenSSL::SSL::Context::Client.new
     expect_raises(OpenSSL::Error) { context.private_key = File.join(__DIR__, "unknown.key") }
     expect_raises(OpenSSL::Error) { context.private_key = __FILE__ }
   end
 
-  it "sets ciphers" do
+  it("sets ciphers") do
     ciphers = "EDH+aRSA DES-CBC3-SHA !RC4"
     context = OpenSSL::SSL::Context::Client.new
     (context.ciphers = ciphers).should eq(ciphers)
   end
 
-  it "adds temporary ecdh curve (P-256)" do
+  it("adds temporary ecdh curve (P-256)") do
     context = OpenSSL::SSL::Context::Client.new
     context.set_tmp_ecdh_key
   end
 
-  it "adds options" do
+  it("adds options") do
     context = OpenSSL::SSL::Context::Client.new
     context.remove_options(context.options) # reset
     default_options = context.options       # options we can't unset
@@ -100,40 +100,40 @@ describe OpenSSL::SSL::Context do
            .should eq(OpenSSL::SSL::Options.flags(ALL, NO_SSL_V2, NO_SSL_V3))
   end
 
-  it "removes options" do
+  it("removes options") do
     context = OpenSSL::SSL::Context::Client.insecure
     default_options = context.options
     context.add_options(OpenSSL::SSL::Options.flags(NO_TLS_V1, NO_SSL_V2))
     context.remove_options(OpenSSL::SSL::Options::NO_TLS_V1).should eq(default_options | OpenSSL::SSL::Options::NO_SSL_V2)
   end
 
-  it "returns options" do
+  it("returns options") do
     context = OpenSSL::SSL::Context::Client.insecure
     default_options = context.options
     context.add_options(OpenSSL::SSL::Options.flags(ALL, NO_SSL_V2))
     context.options.should eq(default_options | OpenSSL::SSL::Options.flags(ALL, NO_SSL_V2))
   end
 
-  it "adds modes" do
+  it("adds modes") do
     context = OpenSSL::SSL::Context::Client.insecure
     context.add_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     context.add_modes(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
            .should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
-  it "removes modes" do
+  it("removes modes") do
     context = OpenSSL::SSL::Context::Client.insecure
     context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     context.remove_modes(OpenSSL::SSL::Modes::AUTO_RETRY).should eq(OpenSSL::SSL::Modes::RELEASE_BUFFERS)
   end
 
-  it "returns modes" do
+  it("returns modes") do
     context = OpenSSL::SSL::Context::Client.insecure
     context.add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 
-  it "sets the verify mode" do
+  it("sets the verify mode") do
     context = OpenSSL::SSL::Context::Client.new
     context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)

--- a/spec/std/openssl/ssl/hostname_validation_spec.cr
+++ b/spec/std/openssl/ssl/hostname_validation_spec.cr
@@ -8,9 +8,9 @@ private def openssl_create_cert(subject = nil, san = nil)
   cert.to_unsafe
 end
 
-describe OpenSSL::SSL::HostnameValidation do
-  describe "validate_hostname" do
-    it "matches IP from certificate SAN entries" do
+describe(OpenSSL::SSL::HostnameValidation) do
+  describe("validate_hostname") do
+    it("matches IP from certificate SAN entries") do
       OpenSSL::SSL::HostnameValidation.validate_hostname("192.168.1.1", openssl_create_cert(san: "IP:192.168.1.1")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("192.168.1.2", openssl_create_cert(san: "IP:192.168.1.1")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchNotFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("::1", openssl_create_cert(san: "IP:::1")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
@@ -22,38 +22,38 @@ describe OpenSSL::SSL::HostnameValidation do
       OpenSSL::SSL::HostnameValidation.validate_hostname("fe80::0:1", openssl_create_cert(san: "IP:fe80:0::1")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
     end
 
-    it "matches domains from certificate SAN entries" do
+    it("matches domains from certificate SAN entries") do
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.com", openssl_create_cert(san: "DNS:example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.org", openssl_create_cert(san: "DNS:example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchNotFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("foo.example.com", openssl_create_cert(san: "DNS:*.example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
     end
 
-    it "verifies all SAN entries" do
+    it("verifies all SAN entries") do
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.com", openssl_create_cert(san: "DNS:example.com,DNS:example.org")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("10.0.3.1", openssl_create_cert(san: "IP:192.168.1.1,IP:10.0.3.1")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.com", openssl_create_cert(san: "IP:192.168.1.1,DNS:example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
     end
 
-    it "fallbacks to CN entry (unless SAN entry is defined)" do
+    it("fallbacks to CN entry (unless SAN entry is defined)") do
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.com", openssl_create_cert(subject: "CN=example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.com", openssl_create_cert(san: "DNS:example.org", subject: "CN=example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchNotFound)
       OpenSSL::SSL::HostnameValidation.validate_hostname("example.org", openssl_create_cert(san: "DNS:example.org", subject: "CN=example.com")).should eq(OpenSSL::SSL::HostnameValidation::Result::MatchFound)
     end
   end
 
-  describe "matches_hostname?" do
-    it "skips trailing dot" do
+  describe("matches_hostname?") do
+    it("skips trailing dot") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("example.com.", "example.com").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?("example.com", "example.com.").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?(".example.com", "example.com").should be_false
       OpenSSL::SSL::HostnameValidation.matches_hostname?("example.com", ".example.com").should be_false
     end
 
-    it "normalizes case" do
+    it("normalizes case") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("exAMPLE.cOM", "EXample.Com").should be_true
     end
 
-    it "literal matches" do
+    it("literal matches") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("example.com", "example.com").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?("example.com", "www.example.com").should be_false
       OpenSSL::SSL::HostnameValidation.matches_hostname?("www.example.com", "www.example.com").should be_true
@@ -61,7 +61,7 @@ describe OpenSSL::SSL::HostnameValidation do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("foo.bar.example.com", "foo.bar.example.com").should be_true
     end
 
-    it "wildcard matches according to RFC 6125, section 6.4.3" do
+    it("wildcard matches according to RFC 6125, section 6.4.3") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("*.com", "example.com").should be_false
       OpenSSL::SSL::HostnameValidation.matches_hostname?("bar.*.example.com", "bar.foo.example.com").should be_false
 
@@ -82,14 +82,14 @@ describe OpenSSL::SSL::HostnameValidation do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("*.168.0.1", "192.168.0.1").should be_false
     end
 
-    it "matches IDNA label" do
+    it("matches IDNA label") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?("*.example.org", "xn--kcry6tjko.example.org").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?("*.xn--kcry6tjko.example.org", "foo.xn--kcry6tjko.example.org").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?("xn--*.example.org", "xn--kcry6tjko.example.org").should be_false
       OpenSSL::SSL::HostnameValidation.matches_hostname?("xn--kcry6tjko*.example.org", "xn--kcry6tjkofoo.example.org").should be_false
     end
 
-    it "matches leading dot" do
+    it("matches leading dot") do
       OpenSSL::SSL::HostnameValidation.matches_hostname?(".example.org", "example.org").should be_false
       OpenSSL::SSL::HostnameValidation.matches_hostname?(".example.org", "xn--kcry6tjko.example.org").should be_true
       OpenSSL::SSL::HostnameValidation.matches_hostname?(".example.org", "foo.example.org").should be_true

--- a/spec/std/openssl/x509/certificate_spec.cr
+++ b/spec/std/openssl/x509/certificate_spec.cr
@@ -1,14 +1,14 @@
 require "spec"
 require "openssl"
 
-describe OpenSSL::X509::Certificate do
-  it "subject" do
+describe(OpenSSL::X509::Certificate) do
+  it("subject") do
     cert = OpenSSL::X509::Certificate.new
     cert.subject = "CN=Nobody/DC=example"
     cert.subject.to_a.should eq([{"CN", "Nobody"}, {"DC", "example"}])
   end
 
-  it "extension" do
+  it("extension") do
     cert = OpenSSL::X509::Certificate.new
 
     cert.add_extension OpenSSL::X509::Extension.new("subjectAltName", "IP:127.0.0.1")

--- a/spec/std/openssl/x509/name_spec.cr
+++ b/spec/std/openssl/x509/name_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "openssl"
 
-describe "OpenSSL::X509::Name" do
-  it "parse" do
+describe("OpenSSL::X509::Name") do
+  it("parse") do
     name = OpenSSL::X509::Name.parse("CN=nobody/DC=example")
     name.to_a.should eq([{"CN", "nobody"}, {"DC", "example"}])
 
@@ -11,7 +11,7 @@ describe "OpenSSL::X509::Name" do
     end
   end
 
-  it "add_entry" do
+  it("add_entry") do
     name = OpenSSL::X509::Name.new
     name.to_a.size.should eq(0)
 

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -23,7 +23,7 @@ private def expect_doesnt_capture_option(args, option)
 end
 
 private def expect_missing_option(option)
-  expect_raises OptionParser::MissingOption do
+  expect_raises(OptionParser::MissingOption) do
     OptionParser.parse([] of String) do |opts|
       opts.on(option, "some flag") do |flag_value|
       end
@@ -32,7 +32,7 @@ private def expect_missing_option(option)
 end
 
 private def expect_missing_option(args, option, flag)
-  expect_raises OptionParser::MissingOption, "Missing option: #{flag}" do
+  expect_raises(OptionParser::MissingOption, "Missing option: #{flag}") do
     OptionParser.parse(args) do |opts|
       opts.on(option, "some flag") do |flag_value|
       end
@@ -40,104 +40,104 @@ private def expect_missing_option(args, option, flag)
   end
 end
 
-describe "OptionParser" do
-  it "has flag" do
+describe("OptionParser") do
+  it("has flag") do
     expect_capture_option ["-f"], "-f", ""
   end
 
-  it "has flag with many letters" do
+  it("has flag with many letters") do
     expect_capture_option ["-ll"], "-ll", "l"
   end
 
-  it "doesn't have flag" do
+  it("doesn't have flag") do
     expect_doesnt_capture_option [] of String, "-f"
   end
 
-  it "has flag with double dash" do
+  it("has flag with double dash") do
     expect_capture_option ["--flag"], "--flag", ""
   end
 
-  it "doesn't have flag with double dash" do
+  it("doesn't have flag with double dash") do
     expect_doesnt_capture_option [] of String, "--flag"
   end
 
-  it "has required option next to flag" do
+  it("has required option next to flag") do
     expect_capture_option ["-f123"], "-fFLAG", "123"
   end
 
-  it "has required option next to flag but given separated" do
+  it("has required option next to flag but given separated") do
     expect_capture_option ["-f", "123"], "-fFLAG", "123"
   end
 
-  it "raises if missing option next to flag" do
+  it("raises if missing option next to flag") do
     expect_missing_option ["-f"], "-fFLAG", "-f"
   end
 
-  it "has required option separated from flag" do
+  it("has required option separated from flag") do
     expect_capture_option ["-f", "123"], "-f FLAG", "123"
   end
 
-  it "has required option separated from flag but given together" do
+  it("has required option separated from flag but given together") do
     expect_capture_option ["-f123"], "-f FLAG", "123"
   end
 
-  it "gets short option with value that looks like flag" do
+  it("gets short option with value that looks like flag") do
     expect_capture_option ["-f", "-g -h"], "-f FLAG", "-g -h"
   end
 
-  it "raises if missing required option with space" do
+  it("raises if missing required option with space") do
     expect_missing_option ["-f"], "-f FLAG", "-f"
   end
 
-  it "has required option separated from long flag" do
+  it("has required option separated from long flag") do
     expect_capture_option ["--flag", "123"], "--flag FLAG", "123"
   end
 
-  it "has required option with =" do
+  it("has required option with =") do
     expect_capture_option ["--flag=123"], "--flag FLAG", "123"
   end
 
-  it "has required option with = (2)" do
+  it("has required option with = (2)") do
     expect_capture_option ["--flag=123"], "--flag=FLAG", "123"
   end
 
-  it "has required option with = (3) raises" do
+  it("has required option with = (3) raises") do
     expect_missing_option ["--flag="], "--flag=FLAG", "--flag"
   end
 
-  it "raises if missing required argument separated from long flag" do
+  it("raises if missing required argument separated from long flag") do
     expect_missing_option ["--flag"], "--flag FLAG", "--flag"
   end
 
-  it "has required option with space" do
+  it("has required option with space") do
     expect_capture_option ["-f", "123"], "-f ", "123"
   end
 
-  it "has required option with long flag space" do
+  it("has required option with long flag space") do
     expect_capture_option ["--flag", "123"], "--flag ", "123"
   end
 
-  it "doesn't raise if required option is not specified" do
+  it("doesn't raise if required option is not specified") do
     expect_doesnt_capture_option [] of String, "-f "
   end
 
-  it "doesn't raise if optional option is not specified with short flag" do
+  it("doesn't raise if optional option is not specified with short flag") do
     expect_doesnt_capture_option [] of String, "-f[FLAG]"
   end
 
-  it "doesn't raise if optional option is not specified with long flag" do
+  it("doesn't raise if optional option is not specified with long flag") do
     expect_doesnt_capture_option [] of String, "--flag [FLAG]"
   end
 
-  it "doesn't raise if optional option is not specified with separated short flag" do
+  it("doesn't raise if optional option is not specified with separated short flag") do
     expect_doesnt_capture_option [] of String, "-f [FLAG]"
   end
 
-  it "doesn't raise if required option is not specified with separated short flag" do
+  it("doesn't raise if required option is not specified with separated short flag") do
     expect_doesnt_capture_option [] of String, "-f FLAG"
   end
 
-  it "parses argument when only referenced in long flag" do
+  it("parses argument when only referenced in long flag") do
     captured = ""
     parser = OptionParser.parse([] of String) do |opts|
       opts.on("-f", "--flag X", "some flag") { |x| captured = x }
@@ -147,7 +147,7 @@ describe "OptionParser" do
     parser.to_s.should contain "   -f, --flag X"
   end
 
-  it "parses argument when referenced in long and short flag" do
+  it("parses argument when referenced in long and short flag") do
     captured = ""
     parser = OptionParser.parse([] of String) do |opts|
       opts.on("-f X", "--flag X", "some flag") { |x| captured = x }
@@ -157,7 +157,7 @@ describe "OptionParser" do
     parser.to_s.should contain "   -f X, --flag X"
   end
 
-  it "does to_s with banner" do
+  it("does to_s with banner") do
     parser = OptionParser.parse([] of String) do |opts|
       opts.banner = "Usage: foo"
       opts.on("-f", "--flag", "some flag") do
@@ -172,7 +172,7 @@ describe "OptionParser" do
       USAGE
   end
 
-  it "does to_s with separators" do
+  it("does to_s with separators") do
     parser = OptionParser.parse([] of String) do |opts|
       opts.banner = "Usage: foo"
       opts.separator
@@ -195,7 +195,7 @@ describe "OptionParser" do
       USAGE
   end
 
-  it "does to_s with very long flag (#3305)" do
+  it("does to_s with very long flag (#3305)") do
     parser = OptionParser.parse([] of String) do |opts|
       opts.banner = "Usage: foo"
       opts.on("--very_long_option_kills=formatter", "long") do
@@ -214,15 +214,15 @@ describe "OptionParser" do
       USAGE
   end
 
-  it "raises on invalid option" do
-    expect_raises OptionParser::InvalidOption, "Invalid option: -j" do
+  it("raises on invalid option") do
+    expect_raises(OptionParser::InvalidOption, "Invalid option: -j") do
       OptionParser.parse(["-f", "-j"]) do |opts|
         opts.on("-f", "some flag") { }
       end
     end
   end
 
-  it "calls the handler for invalid options" do
+  it("calls the handler for invalid options") do
     called = false
     OptionParser.parse(["-f", "-j"]) do |opts|
       opts.on("-f", "some flag") { }
@@ -235,7 +235,7 @@ describe "OptionParser" do
     called.should be_true
   end
 
-  it "calls the handler for missing options" do
+  it("calls the handler for missing options") do
     called = false
     OptionParser.parse(["-f"]) do |opts|
       opts.on("-f FOO", "some flag") { }
@@ -248,8 +248,8 @@ describe "OptionParser" do
     called.should be_true
   end
 
-  describe "multiple times" do
-    it "gets an existence flag multiple times" do
+  describe("multiple times") do
+    it("gets an existence flag multiple times") do
       args = %w(-f -f -f)
       count = 0
       OptionParser.parse(args) do |opts|
@@ -260,7 +260,7 @@ describe "OptionParser" do
       count.should eq(3)
     end
 
-    it "gets a single flag option multiple times" do
+    it("gets a single flag option multiple times") do
       args = %w(-f 1 -f 2)
       values = [] of String
       OptionParser.parse(args) do |opts|
@@ -271,7 +271,7 @@ describe "OptionParser" do
       values.should eq(%w(1 2))
     end
 
-    it "gets a double flag option multiple times" do
+    it("gets a double flag option multiple times") do
       args = %w(--f 1 --f 2)
       values = [] of String
       OptionParser.parse(args) do |opts|
@@ -283,8 +283,8 @@ describe "OptionParser" do
     end
   end
 
-  describe "--" do
-    it "ignores everything after -- with bool flag" do
+  describe("--") do
+    it("ignores everything after -- with bool flag") do
       args = ["-f", "bar", "--", "baz", "qux", "-g"]
       f = false
       g = false
@@ -301,7 +301,7 @@ describe "OptionParser" do
       args.should eq(["bar", "baz", "qux", "-g"])
     end
 
-    it "ignores everything after -- with single flag)" do
+    it("ignores everything after -- with single flag)") do
       args = ["-f", "bar", "x", "--", "baz", "qux", "-g", "lala"]
       f = nil
       g = nil
@@ -318,7 +318,7 @@ describe "OptionParser" do
       args.should eq(["x", "baz", "qux", "-g", "lala"])
     end
 
-    it "ignores everything after -- with double flag" do
+    it("ignores everything after -- with double flag") do
       args = ["--f", "bar", "x", "--", "baz", "qux", "--g", "lala"]
       f = nil
       g = nil
@@ -335,7 +335,7 @@ describe "OptionParser" do
       args.should eq(["x", "baz", "qux", "--g", "lala"])
     end
 
-    it "returns a pair with things coming before and after --" do
+    it("returns a pair with things coming before and after --") do
       args = %w(--f bar baz -- qux)
       f = nil
       unknown_args = nil
@@ -352,7 +352,7 @@ describe "OptionParser" do
       unknown_args.should eq({["baz"], ["qux"]})
     end
 
-    it "returns a pair with things coming before and after --, without --" do
+    it("returns a pair with things coming before and after --, without --") do
       args = %w(--f bar baz)
       f = nil
       unknown_args = nil
@@ -369,7 +369,7 @@ describe "OptionParser" do
       unknown_args.should eq({["baz"], [] of String})
     end
 
-    it "initializes without block and does parse!" do
+    it("initializes without block and does parse!") do
       old_argv = ARGV.dup
       begin
         ARGV.clear
@@ -387,7 +387,7 @@ describe "OptionParser" do
       end
     end
 
-    it "gets `-` as argument" do
+    it("gets `-` as argument") do
       args = %w(-)
       OptionParser.parse(args) do |opts|
       end
@@ -395,8 +395,8 @@ describe "OptionParser" do
     end
   end
 
-  describe "forward-match" do
-    it "distinguishes between '--lamb VALUE' and '--lambda VALUE'" do
+  describe("forward-match") do
+    it("distinguishes between '--lamb VALUE' and '--lambda VALUE'") do
       args = %w(--lamb value1 --lambda value2)
       value1 = nil
       value2 = nil
@@ -408,7 +408,7 @@ describe "OptionParser" do
       value2.should eq("value2")
     end
 
-    it "distinguishes between '--lamb=VALUE' and '--lambda=VALUE'" do
+    it("distinguishes between '--lamb=VALUE' and '--lambda=VALUE'") do
       args = %w(--lamb=value1 --lambda=value2)
       value1 = nil
       value2 = nil
@@ -421,17 +421,17 @@ describe "OptionParser" do
     end
   end
 
-  it "raises if flag doesn't start with dash (#4001)" do
+  it("raises if flag doesn't start with dash (#4001)") do
     OptionParser.parse([] of String) do |opts|
-      expect_raises ArgumentError, %(Argument 'flag' ("foo") must start with a dash) do
+      expect_raises(ArgumentError, %(Argument 'flag' ("foo") must start with a dash)) do
         opts.on("foo", "") { }
       end
 
-      expect_raises ArgumentError, %(Argument 'short_flag' ("foo") must start with a dash) do
+      expect_raises(ArgumentError, %(Argument 'short_flag' ("foo") must start with a dash)) do
         opts.on("foo", "bar", "baz") { }
       end
 
-      expect_raises ArgumentError, %(Argument 'long_flag' ("bar") must start with a dash) do
+      expect_raises(ArgumentError, %(Argument 'long_flag' ("bar") must start with a dash)) do
         opts.on("-foo", "bar", "baz") { }
       end
 

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -5,29 +5,29 @@ private def reset(p1, p2)
   p2.value = 20
 end
 
-describe "Pointer" do
-  it "does malloc with value" do
+describe("Pointer") do
+  it("does malloc with value") do
     p1 = Pointer.malloc(4, 1)
     4.times do |i|
       p1[i].should eq(1)
     end
   end
 
-  it "does malloc with value from block" do
+  it("does malloc with value from block") do
     p1 = Pointer.malloc(4) { |i| i }
     4.times do |i|
       p1[i].should eq(i)
     end
   end
 
-  it "does index with count" do
+  it("does index with count") do
     p1 = Pointer.malloc(4) { |i| i ** 2 }
     p1.to_slice(4).index(4).should eq(2)
     p1.to_slice(4).index(5).should be_nil
   end
 
-  describe "copy_from" do
-    it "performs" do
+  describe("copy_from") do
+    it("performs") do
       p1 = Pointer.malloc(4) { |i| i }
       p2 = Pointer.malloc(4) { 0 }
       p2.copy_from(p1, 4)
@@ -36,14 +36,14 @@ describe "Pointer" do
       end
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       p1 = Pointer.malloc(4, 0)
       expect_raises(ArgumentError, "Negative count") do
         p1.copy_from(p1, -1)
       end
     end
 
-    it "copies from union of pointers" do
+    it("copies from union of pointers") do
       p1 = Pointer.malloc(4, 1)
       p2 = Pointer.malloc(4, 1.5)
       p3 = Pointer.malloc(4, 0 || 0.0)
@@ -52,8 +52,8 @@ describe "Pointer" do
     end
   end
 
-  describe "realloc" do
-    it "raises on negative count" do
+  describe("realloc") do
+    it("raises on negative count") do
       p1 = Pointer(Int32).new(123)
       expect_raises(ArgumentError) do
         p1.realloc(-1)
@@ -61,8 +61,8 @@ describe "Pointer" do
     end
   end
 
-  describe "copy_to" do
-    it "performs" do
+  describe("copy_to") do
+    it("performs") do
       p1 = Pointer.malloc(4) { |i| i }
       p2 = Pointer.malloc(4) { 0 }
       p1.copy_to(p2, 4)
@@ -71,14 +71,14 @@ describe "Pointer" do
       end
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       p1 = Pointer.malloc(4, 0)
       expect_raises(ArgumentError, "Negative count") do
         p1.copy_to(p1, -1)
       end
     end
 
-    it "copies to union of pointers" do
+    it("copies to union of pointers") do
       p1 = Pointer.malloc(4, 1)
       p2 = Pointer.malloc(4, 0 || 1.5)
       p3 = Pointer.malloc(4, 0 || 'a')
@@ -87,8 +87,8 @@ describe "Pointer" do
     end
   end
 
-  describe "move_from" do
-    it "performs with overlap right to left" do
+  describe("move_from") do
+    it("performs with overlap right to left") do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 1).move_from(p1 + 2, 2)
       p1[0].should eq(0)
@@ -97,7 +97,7 @@ describe "Pointer" do
       p1[3].should eq(3)
     end
 
-    it "performs with overlap left to right" do
+    it("performs with overlap left to right") do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 2).move_from(p1 + 1, 2)
       p1[0].should eq(0)
@@ -106,14 +106,14 @@ describe "Pointer" do
       p1[3].should eq(2)
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       p1 = Pointer.malloc(4, 0)
       expect_raises(ArgumentError, "Negative count") do
         p1.move_from(p1, -1)
       end
     end
 
-    it "moves from union of pointers" do
+    it("moves from union of pointers") do
       p1 = Pointer.malloc(4, 1)
       p2 = Pointer.malloc(4, 1.5)
       p3 = Pointer.malloc(4, 0 || 0.0)
@@ -122,8 +122,8 @@ describe "Pointer" do
     end
   end
 
-  describe "move_to" do
-    it "performs with overlap right to left" do
+  describe("move_to") do
+    it("performs with overlap right to left") do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 2).move_to(p1 + 1, 2)
       p1[0].should eq(0)
@@ -132,7 +132,7 @@ describe "Pointer" do
       p1[3].should eq(3)
     end
 
-    it "performs with overlap left to right" do
+    it("performs with overlap left to right") do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 1).move_to(p1 + 2, 2)
       p1[0].should eq(0)
@@ -141,14 +141,14 @@ describe "Pointer" do
       p1[3].should eq(2)
     end
 
-    it "raises on negative count" do
+    it("raises on negative count") do
       p1 = Pointer.malloc(4, 0)
       expect_raises(ArgumentError, "Negative count") do
         p1.move_to(p1, -1)
       end
     end
 
-    it "moves to union of pointers" do
+    it("moves to union of pointers") do
       p1 = Pointer.malloc(4, 1)
       p2 = Pointer.malloc(4, 0 || 1.5)
       p3 = Pointer.malloc(4, 0 || 'a')
@@ -157,7 +157,7 @@ describe "Pointer" do
     end
   end
 
-  describe "memcmp" do
+  describe("memcmp") do
     it do
       p1 = Pointer.malloc(4) { |i| i }
       p2 = Pointer.malloc(4) { |i| i }
@@ -169,7 +169,7 @@ describe "Pointer" do
     end
   end
 
-  it "compares two pointers by address" do
+  it("compares two pointers by address") do
     p1 = Pointer(Int32).malloc(1)
     p2 = Pointer(Int32).malloc(1)
     p1.should eq(p1)
@@ -177,16 +177,16 @@ describe "Pointer" do
     p1.should_not eq(1)
   end
 
-  it "does to_s" do
+  it("does to_s") do
     Pointer(Int32).null.to_s.should eq("Pointer(Int32).null")
     Pointer(Int32).new(1234_u64).to_s.should eq("Pointer(Int32)@0x4d2")
   end
 
-  it "creates from int" do
+  it("creates from int") do
     Pointer(Int32).new(1234).address.should eq(1234)
   end
 
-  it "shuffles!" do
+  it("shuffles!") do
     a = Pointer(Int32).malloc(3) { |i| i + 1 }
     a.shuffle!(3)
 
@@ -197,7 +197,7 @@ describe "Pointer" do
     end
   end
 
-  it "maps!" do
+  it("maps!") do
     a = Pointer(Int32).malloc(3) { |i| i + 1 }
     a.map!(3) { |i| i + 1 }
     a[0].should eq(2)
@@ -205,7 +205,7 @@ describe "Pointer" do
     a[2].should eq(4)
   end
 
-  it "maps_with_index!" do
+  it("maps_with_index!") do
     a = Pointer(Int32).malloc(3) { |i| i + 1 }
     a.map_with_index!(3) { |e, i| e + i }
     a[0].should eq(1)
@@ -213,11 +213,11 @@ describe "Pointer" do
     a[2].should eq(5)
   end
 
-  it "raises if mallocs negative size" do
+  it("raises if mallocs negative size") do
     expect_raises(ArgumentError) { Pointer.malloc(-1, 0) }
   end
 
-  it "copies/move with different types" do
+  it("copies/move with different types") do
     p1 = Pointer(Int32).malloc(1)
     p2 = Pointer(Int32 | String).malloc(1)
 
@@ -280,8 +280,8 @@ describe "Pointer" do
     p2.value.should eq(20)
   end
 
-  describe "clear" do
-    it "clears one" do
+  describe("clear") do
+    it("clears one") do
       ptr = Pointer(Int32).malloc(2)
       ptr[0] = 10
       ptr[1] = 20
@@ -290,7 +290,7 @@ describe "Pointer" do
       ptr[1].should eq(20)
     end
 
-    it "clears many" do
+    it("clears many") do
       ptr = Pointer(Int32).malloc(4)
       ptr[0] = 10
       ptr[1] = 20
@@ -303,7 +303,7 @@ describe "Pointer" do
       ptr[3].should eq(40)
     end
 
-    it "clears with union" do
+    it("clears with union") do
       ptr = Pointer(Int32 | Nil).malloc(4)
       ptr[0] = 10
       ptr[1] = 20
@@ -318,12 +318,12 @@ describe "Pointer" do
     end
   end
 
-  it "does !" do
+  it("does !") do
     (!Pointer(Int32).null).should be_true
     (!Pointer(Int32).new(123)).should be_false
   end
 
-  it "clones" do
+  it("clones") do
     ptr = Pointer(Int32).new(123)
     ptr.clone.should eq(ptr)
   end

--- a/spec/std/pretty_print_spec.cr
+++ b/spec/std/pretty_print_spec.cr
@@ -1,6 +1,6 @@
 require "spec"
 
-describe PrettyPrint do
+describe(PrettyPrint) do
   assert_hello 0..6, <<-END
     hello
     a
@@ -225,7 +225,7 @@ describe PrettyPrint do
     abc def ghi jkl mno pqr stu
     END
 
-  it "tail group" do
+  it("tail group") do
     text = String.build do |io|
       PrettyPrint.format(io, 10) do |q|
         q.group do
@@ -417,7 +417,7 @@ private def fill(width)
 end
 
 private def assert_hello(range, expected)
-  it "pretty prints hello #{range}" do
+  it("pretty prints hello #{range}") do
     range.each do |width|
       hello(width).should eq(expected)
     end
@@ -425,7 +425,7 @@ private def assert_hello(range, expected)
 end
 
 private def assert_tree(range, expected)
-  it "pretty prints tree #{range}" do
+  it("pretty prints tree #{range}") do
     range.each do |width|
       tree(width).should eq(expected)
     end
@@ -433,7 +433,7 @@ private def assert_tree(range, expected)
 end
 
 private def assert_tree_alt(range, expected)
-  it "pretty prints tree alt #{range}" do
+  it("pretty prints tree alt #{range}") do
     range.each do |width|
       tree_alt(width).should eq(expected)
     end
@@ -441,7 +441,7 @@ private def assert_tree_alt(range, expected)
 end
 
 private def assert_strict_pretty(range, expected)
-  it "pretty prints strict pretty #{range}" do
+  it("pretty prints strict pretty #{range}") do
     range.each do |width|
       stritc_pretty(width).should eq(expected)
     end
@@ -449,7 +449,7 @@ private def assert_strict_pretty(range, expected)
 end
 
 private def assert_fill(range, expected)
-  it "pretty prints fill #{range}" do
+  it("pretty prints fill #{range}") do
     range.each do |width|
       fill(width).should eq(expected)
     end

--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -1,14 +1,14 @@
 require "spec"
 
-describe "Proc" do
-  it "does to_s(io)" do
+describe("Proc") do
+  it("does to_s(io)") do
     str = IO::Memory.new
     f = ->(x : Int32) { x.to_f }
     f.to_s(str)
     str.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
-  it "does to_s(io) when closured" do
+  it("does to_s(io) when closured") do
     str = IO::Memory.new
     a = 1.5
     f = ->(x : Int32) { x + a }
@@ -16,62 +16,62 @@ describe "Proc" do
     str.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")
   end
 
-  it "does to_s" do
+  it("does to_s") do
     str = IO::Memory.new
     f = ->(x : Int32) { x.to_f }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
-  it "does to_s when closured" do
+  it("does to_s when closured") do
     str = IO::Memory.new
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")
   end
 
-  it "gets pointer" do
+  it("gets pointer") do
     f = ->{ 1 }
     f.pointer.address.should be > 0
   end
 
-  it "gets closure data for non-closure" do
+  it("gets closure data for non-closure") do
     f = ->{ 1 }
     f.closure_data.address.should eq(0)
     f.closure?.should be_false
   end
 
-  it "gets closure data for closure" do
+  it("gets closure data for closure") do
     a = 1
     f = ->{ a }
     f.closure_data.address.should be > 0
     f.closure?.should be_true
   end
 
-  it "does new" do
+  it("does new") do
     a = 1
     f = ->(x : Int32) { x + a }
     f2 = Proc(Int32, Int32).new(f.pointer, f.closure_data)
     f2.call(3).should eq(4)
   end
 
-  it "does ==" do
+  it("does ==") do
     func = ->{ 1 }
     func.should eq(func)
     func2 = ->{ 1 }
     func2.should_not eq(func)
   end
 
-  it "clones" do
+  it("clones") do
     func = ->{ 1 }
     func.clone.should eq(func)
   end
 
-  it "#arity" do
+  it("#arity") do
     f = ->(x : Int32, y : Int32) {}
     f.arity.should eq(2)
   end
 
-  it "#partial" do
+  it("#partial") do
     f = ->(x : Int32, y : Int32, z : Int32) { x + y + z }
     f.call(1, 2, 3).should eq(6)
 

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -2,52 +2,52 @@ require "spec"
 require "process"
 require "tempfile"
 
-describe Process do
-  it "runs true" do
+describe(Process) do
+  it("runs true") do
     process = Process.new("true")
     process.wait.exit_code.should eq(0)
   end
 
-  it "runs false" do
+  it("runs false") do
     process = Process.new("false")
     process.wait.exit_code.should eq(1)
   end
 
-  it "returns status 127 if command could not be executed" do
+  it("returns status 127 if command could not be executed") do
     process = Process.new("foobarbaz")
     process.wait.exit_code.should eq(127)
   end
 
-  it "run waits for the process" do
+  it("run waits for the process") do
     Process.run("true").exit_code.should eq(0)
   end
 
-  it "runs true in block" do
+  it("runs true in block") do
     Process.run("true") { }
     $?.exit_code.should eq(0)
   end
 
-  it "receives arguments in array" do
+  it("receives arguments in array") do
     Process.run("/bin/sh", ["-c", "exit 123"]).exit_code.should eq(123)
   end
 
-  it "receives arguments in tuple" do
+  it("receives arguments in tuple") do
     Process.run("/bin/sh", {"-c", "exit 123"}).exit_code.should eq(123)
   end
 
-  it "redirects output to /dev/null" do
+  it("redirects output to /dev/null") do
     # This doesn't test anything but no output should be seen while running tests
     Process.run("/bin/ls", output: Process::Redirect::Close).exit_code.should eq(0)
   end
 
-  it "gets output" do
+  it("gets output") do
     value = Process.run("/bin/sh", {"-c", "echo hello"}) do |proc|
       proc.output.gets_to_end
     end
     value.should eq("hello\n")
   end
 
-  it "sends input in IO" do
+  it("sends input in IO") do
     value = Process.run("/bin/cat", input: IO::Memory.new("hello")) do |proc|
       proc.input?.should be_nil
       proc.output.gets_to_end
@@ -55,19 +55,19 @@ describe Process do
     value.should eq("hello")
   end
 
-  it "sends output to IO" do
+  it("sends output to IO") do
     output = IO::Memory.new
     Process.run("/bin/sh", {"-c", "echo hello"}, output: output)
     output.to_s.should eq("hello\n")
   end
 
-  it "sends error to IO" do
+  it("sends error to IO") do
     error = IO::Memory.new
     Process.run("/bin/sh", {"-c", "echo hello 1>&2"}, error: error)
     error.to_s.should eq("hello\n")
   end
 
-  it "controls process in block" do
+  it("controls process in block") do
     value = Process.run("/bin/cat") do |proc|
       proc.input.print "hello"
       proc.input.close
@@ -76,12 +76,12 @@ describe Process do
     value.should eq("hello")
   end
 
-  it "closes ios after block" do
+  it("closes ios after block") do
     Process.run("/bin/cat") { }
     $?.exit_code.should eq(0)
   end
 
-  it "sets working directory" do
+  it("sets working directory") do
     parent = File.dirname(Dir.current)
     value = Process.run("pwd", shell: true, chdir: parent, output: Process::Redirect::Pipe) do |proc|
       proc.output.gets_to_end
@@ -89,40 +89,40 @@ describe Process do
     value.should eq "#{parent}\n"
   end
 
-  it "disallows passing arguments to nowhere" do
-    expect_raises ArgumentError, /args.+@/ do
+  it("disallows passing arguments to nowhere") do
+    expect_raises(ArgumentError, /args.+@/) do
       Process.run("foo bar", {"baz"}, shell: true)
     end
   end
 
-  it "looks up programs in the $PATH with a shell" do
+  it("looks up programs in the $PATH with a shell") do
     proc = Process.run("uname", {"-a"}, shell: true, output: Process::Redirect::Close)
     proc.exit_code.should eq(0)
   end
 
-  it "allows passing huge argument lists to a shell" do
+  it("allows passing huge argument lists to a shell") do
     proc = Process.new(%(echo "${@}"), {"a", "b"}, shell: true, output: Process::Redirect::Pipe)
     output = proc.output.gets_to_end
     proc.wait
     output.should eq "a b\n"
   end
 
-  it "does not run shell code in the argument list" do
+  it("does not run shell code in the argument list") do
     proc = Process.new("echo", {"`echo hi`"}, shell: true, output: Process::Redirect::Pipe)
     output = proc.output.gets_to_end
     proc.wait
     output.should eq "`echo hi`\n"
   end
 
-  describe "environ" do
-    it "clears the environment" do
+  describe("environ") do
+    it("clears the environment") do
       value = Process.run("env", clear_env: true) do |proc|
         proc.output.gets_to_end
       end
       value.should eq("")
     end
 
-    it "sets an environment variable" do
+    it("sets an environment variable") do
       env = {"FOO" => "bar"}
       value = Process.run("env", clear_env: true, env: env) do |proc|
         proc.output.gets_to_end
@@ -130,7 +130,7 @@ describe Process do
       value.should eq("FOO=bar\n")
     end
 
-    it "deletes an environment variable" do
+    it("deletes an environment variable") do
       env = {"HOME" => nil}
       value = Process.run("env | egrep '^HOME='", env: env, shell: true) do |proc|
         proc.output.gets_to_end
@@ -139,13 +139,13 @@ describe Process do
     end
   end
 
-  describe "kill" do
-    it "kills a process" do
+  describe("kill") do
+    it("kills a process") do
       process = fork { loop { } }
       process.kill(Signal::KILL).should be_nil
     end
 
-    it "kills many process" do
+    it("kills many process") do
       process1 = fork { loop { } }
       process2 = fork { loop { } }
       process1.kill(Signal::KILL).should be_nil
@@ -153,14 +153,14 @@ describe Process do
     end
   end
 
-  it "gets the pgid of a process id" do
+  it("gets the pgid of a process id") do
     process = fork { loop { } }
     Process.pgid(process.pid).should be_a(Int32)
     process.kill(Signal::KILL)
     Process.pgid.should eq(Process.pgid(Process.pid))
   end
 
-  it "can link processes together" do
+  it("can link processes together") do
     buffer = IO::Memory.new
     Process.run("/bin/cat") do |cat|
       Process.run("/bin/cat", input: cat.output, output: buffer) do
@@ -171,7 +171,7 @@ describe Process do
     buffer.to_s.lines.size.should eq(1000)
   end
 
-  it "executes the new process with exec" do
+  it("executes the new process with exec") do
     tmpfile = Tempfile.new("crystal-spec-exec")
     tmpfile.close
     tmpfile.unlink
@@ -186,7 +186,7 @@ describe Process do
     tmpfile.unlink
   end
 
-  it "checks for existence" do
+  it("checks for existence") do
     # We can't reliably check whether it ever returns false, since we can't predict
     # how PIDs are used by the system, a new process might be spawned in between
     # reaping the one we would spawn and checking for it, using the now available
@@ -208,26 +208,26 @@ describe Process do
     process.terminated?.should be_true
   end
 
-  describe "executable_path" do
-    it "searches executable" do
+  describe("executable_path") do
+    it("searches executable") do
       Process.executable_path.should be_a(String | Nil)
     end
   end
 
-  describe "find_executable" do
+  describe("find_executable") do
     pwd = Process::INITIAL_PWD
     crystal_path = File.join(pwd, "bin", "crystal")
 
-    it "resolves absolute executable" do
+    it("resolves absolute executable") do
       Process.find_executable(File.join(pwd, "bin", "crystal")).should eq(crystal_path)
     end
 
-    it "resolves relative executable" do
+    it("resolves relative executable") do
       Process.find_executable(File.join("bin", "crystal")).should eq(crystal_path)
       Process.find_executable(File.join("..", File.basename(pwd), "bin", "crystal")).should eq(crystal_path)
     end
 
-    it "searches within PATH" do
+    it("searches within PATH") do
       (path = Process.find_executable("ls")).should_not be_nil
       path.not_nil!.should match(/#{File::SEPARATOR}ls$/)
 

--- a/spec/std/raise_spec.cr
+++ b/spec/std/raise_spec.cr
@@ -1,17 +1,17 @@
 require "spec"
 
-describe "raise" do
+describe("raise") do
   callstack_on_rescue = nil
 
-  it "should set exception's callstack" do
-    exception = expect_raises Exception, "without callstack" do
+  it("should set exception's callstack") do
+    exception = expect_raises(Exception, "without callstack") do
       raise "without callstack"
     end
     exception.callstack.should_not be_nil
   end
 
-  it "shouldn't overwrite the callstack on re-raise" do
-    exception_after_reraise = expect_raises Exception, "exception to be rescued" do
+  it("shouldn't overwrite the callstack on re-raise") do
+    exception_after_reraise = expect_raises(Exception, "exception to be rescued") do
       begin
         raise "exception to be rescued"
       rescue exception_on_rescue

--- a/spec/std/random/isaac_spec.cr
+++ b/spec/std/random/isaac_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "random/isaac"
 
-describe "Random::ISAAC" do
-  it "generates random numbers as generated official implementation" do
+describe("Random::ISAAC") do
+  it("generates random numbers as generated official implementation") do
     numbers = [
       0xc9d3bc51, 0x5bc24339, 0x23e22e3a, 0x5659b89a, 0x21c6dcfd, 0x168e10a4, 0x1df755f6, 0x99d3a910,
       0xf48f0656, 0xe9431f57, 0x839c384b, 0x238bac78, 0xd3693e2a, 0x96e06a6f, 0x1358bb9e, 0x6872ff7f,
@@ -346,7 +346,7 @@ describe "Random::ISAAC" do
     end
   end
 
-  it "can be initialized without explicit seed" do
+  it("can be initialized without explicit seed") do
     Random::ISAAC.new.should be_a Random::ISAAC
   end
 end

--- a/spec/std/random/pcg32_spec.cr
+++ b/spec/std/random/pcg32_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "random/pcg32"
 
-describe "Random::PCG32" do
-  it "generates random numbers as generated official implementation" do
+describe("Random::PCG32") do
+  it("generates random numbers as generated official implementation") do
     numbers = [
       3152259133, 2489095755, 485973489, 739446704, 3084920751,
       2161564962, 2655557215, 4238523805, 4127884210, 1729992006,
@@ -213,7 +213,7 @@ describe "Random::PCG32" do
     end
   end
 
-  it "can jump ahead" do
+  it("can jump ahead") do
     seed = {123_u64, 456_u64}
 
     m1 = Random::PCG32.new(*seed)
@@ -222,7 +222,7 @@ describe "Random::PCG32" do
     m2.jump(10)
     m1.next_u.should eq m2.next_u
   end
-  it "can jump back" do
+  it("can jump back") do
     seed = {123_u64, 456_u64}
 
     m1 = Random::PCG32.new(*seed)
@@ -232,7 +232,7 @@ describe "Random::PCG32" do
     m1.next_u.should eq m2.next_u
   end
 
-  it "can be initialized without explicit seed" do
+  it("can be initialized without explicit seed") do
     Random::PCG32.new.should be_a Random::PCG32
   end
 end

--- a/spec/std/random/system_spec.cr
+++ b/spec/std/random/system_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "random/system"
 
-describe "Random::System" do
-  it "returns random number from the secure system source" do
+describe("Random::System") do
+  it("returns random number from the secure system source") do
     Random::System.next_u.should be_a(Int::Unsigned)
 
     x = Random::System.rand(123456...654321)

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -24,8 +24,8 @@ private RNG_DATA_64 = [148763248732657823u64, 18446744073709551615u64, 0u64,
                        32456325635673576u64, 2456245614625u64, 32452456246u64, 3956529762u64,
                        9823674982364u64, 234253464546456u64, 14345435645646u64]
 
-describe "Random" do
-  it "limited number" do
+describe("Random") do
+  it("limited number") do
     rand(1).should eq(0)
 
     x = rand(2)
@@ -40,35 +40,35 @@ describe "Random" do
     rand(0).should eq 0
   end
 
-  it "float number" do
+  it("float number") do
     x = rand
     x.should be >= 0
     x.should be <= 1
   end
 
-  it "limited float number" do
+  it("limited float number") do
     x = rand(3.5)
     x.should be >= 0
     x.should be < 3.5
   end
 
-  it "float number 0.0" do
+  it("float number 0.0") do
     rand(0.0).should eq 0.0
   end
 
-  it "raises on invalid number" do
-    expect_raises ArgumentError, "Invalid bound for rand: -1" do
+  it("raises on invalid number") do
+    expect_raises(ArgumentError, "Invalid bound for rand: -1") do
       rand(-1)
     end
   end
 
-  it "raises on invalid float number" do
-    expect_raises ArgumentError, "Invalid bound for rand: -1.0" do
+  it("raises on invalid float number") do
+    expect_raises(ArgumentError, "Invalid bound for rand: -1.0") do
       rand(-1.0)
     end
   end
 
-  it "does with inclusive range" do
+  it("does with inclusive range") do
     [1..1, 1..3, 0u8..255u8, -1..1, Int64::MIN..7i64,
      -7i64..Int64::MAX, 0u64..0u64].each do |range|
       x = rand(range)
@@ -77,7 +77,7 @@ describe "Random" do
     end
   end
 
-  it "does with exclusive range" do
+  it("does with exclusive range") do
     [1...2, 1...4, 0u8...255u8, -1...1, Int64::MIN...7i64,
      -7i64...Int64::MAX, -1i8...0i8].each do |range|
       x = rand(range)
@@ -86,41 +86,41 @@ describe "Random" do
     end
   end
 
-  it "does with inclusive range of floats" do
+  it("does with inclusive range of floats") do
     rand(1.0..1.0).should eq(1.0)
     x = rand(1.8..3.2)
     x.should be >= 1.8
     x.should be <= 3.2
   end
 
-  it "does with exclusive range of floats" do
+  it("does with exclusive range of floats") do
     x = rand(1.8...3.3)
     x.should be >= 1.8
     x.should be < 3.3
   end
 
-  it "raises on invalid range" do
-    expect_raises ArgumentError, "Invalid range for rand: 1...1" do
+  it("raises on invalid range") do
+    expect_raises(ArgumentError, "Invalid range for rand: 1...1") do
       rand(1...1)
     end
-    expect_raises ArgumentError, "Invalid range for rand: 1..0" do
+    expect_raises(ArgumentError, "Invalid range for rand: 1..0") do
       rand(1..0)
     end
-    expect_raises ArgumentError, "Invalid range for rand: 1.0...1.0" do
+    expect_raises(ArgumentError, "Invalid range for rand: 1.0...1.0") do
       rand(1.0...1.0)
     end
-    expect_raises ArgumentError, "Invalid range for rand: 1.0..0.0" do
+    expect_raises(ArgumentError, "Invalid range for rand: 1.0..0.0") do
       rand(1.0..0.0)
     end
   end
 
-  it "allows creating a new default random" do
+  it("allows creating a new default random") do
     rand = Random.new
     value = rand.rand
     (0 <= value < 1).should be_true
   end
 
-  it "allows creating a new default random with a seed" do
+  it("allows creating a new default random with a seed") do
     values = Array.new(2) do
       rand = Random.new(1234)
       {rand.rand, rand.rand(0xffffffffffffffff), rand.rand(2), rand.rand(-5i8..5i8)}
@@ -129,11 +129,11 @@ describe "Random" do
     values[0].should eq values[1]
   end
 
-  it "gets a random bool" do
+  it("gets a random bool") do
     Random::DEFAULT.next_bool.should be_a(Bool)
   end
 
-  it "generates by accumulation" do
+  it("generates by accumulation") do
     rng = TestRNG.new([234u8, 153u8, 0u8, 0u8, 127u8, 128u8, 255u8, 255u8])
     rng.rand(65536).should eq 60057    # 234*0x100 + 153
     rng.rand(60000).should eq 0        # 0*0x100 + 0
@@ -145,7 +145,7 @@ describe "Random" do
     rng.rand(32768u16).should eq 27289 # (234*0x100 + 153) % 32768
   end
 
-  it "generates by truncation" do
+  it("generates by truncation") do
     rng = TestRNG.new([31541451u32, 0u32, 1u32, 234u32, 342475672u32])
     rng.rand(1).should eq 0
     rng.rand(10).should eq 0
@@ -157,14 +157,14 @@ describe "Random" do
     rng.rand(0x7fffffff).should eq 0
   end
 
-  it "generates full-range" do
+  it("generates full-range") do
     rng = TestRNG.new(RNG_DATA_64)
     RNG_DATA_64.each do |a|
       rng.rand(UInt64::MIN..UInt64::MAX).should eq a
     end
   end
 
-  it "generates full-range by accumulation" do
+  it("generates full-range by accumulation") do
     rng = TestRNG.new(RNG_DATA_8)
     RNG_DATA_8.each_slice(2) do |(a, b)|
       expected = a.to_u16 * 0x100u16 + b.to_u16
@@ -172,7 +172,7 @@ describe "Random" do
     end
   end
 
-  it "generates full-range by truncation" do
+  it("generates full-range by truncation") do
     rng = TestRNG.new(RNG_DATA_32)
     RNG_DATA_32.each do |a|
       expected = a % 0x10000
@@ -180,7 +180,7 @@ describe "Random" do
     end
   end
 
-  it "generates full-range by negation" do
+  it("generates full-range by negation") do
     rng = TestRNG.new(RNG_DATA_8)
     RNG_DATA_8.each do |a|
       expected = a.to_i

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -26,14 +26,14 @@ struct RangeSpecIntWrapper
   end
 end
 
-describe "Range" do
-  it "initialized with new method" do
+describe("Range") do
+  it("initialized with new method") do
     Range.new(1, 10).should eq(1..10)
     Range.new(1, 10, false).should eq(1..10)
     Range.new(1, 10, true).should eq(1...10)
   end
 
-  it "gets basic properties" do
+  it("gets basic properties") do
     r = 1..5
     r.begin.should eq(1)
     r.end.should eq(5)
@@ -45,7 +45,7 @@ describe "Range" do
     r.excludes_end?.should be_true
   end
 
-  it "includes?" do
+  it("includes?") do
     (1..5).includes?(1).should be_true
     (1..5).includes?(5).should be_true
 
@@ -53,33 +53,33 @@ describe "Range" do
     (1...5).includes?(5).should be_false
   end
 
-  it "does to_s" do
+  it("does to_s") do
     (1...5).to_s.should eq("1...5")
     (1..5).to_s.should eq("1..5")
   end
 
-  it "does inspect" do
+  it("does inspect") do
     (1...5).inspect.should eq("1...5")
   end
 
-  it "is empty with .. and begin > end" do
+  it("is empty with .. and begin > end") do
     (1..0).to_a.empty?.should be_true
   end
 
-  it "is empty with ... and begin > end" do
+  it("is empty with ... and begin > end") do
     (1...0).to_a.empty?.should be_true
   end
 
-  it "is not empty with .. and begin == end" do
+  it("is not empty with .. and begin == end") do
     (1..1).to_a.should eq([1])
   end
 
-  it "is not empty with ... and begin.succ == end" do
+  it("is not empty with ... and begin.succ == end") do
     (1...2).to_a.should eq([1])
   end
 
-  describe "sum" do
-    it "called with no block is specialized for performance" do
+  describe("sum") do
+    it("called with no block is specialized for performance") do
       (1..3).sum.should eq 6
       (1...3).sum.should eq 3
       (BigInt.new("1")..BigInt.new("1 000 000 000")).sum.should eq BigInt.new("500 000 000 500 000 000")
@@ -90,7 +90,7 @@ describe "Range" do
       (BigInt.new("1")..BigInt.new("1 000 000 000")).step(2).sum.should eq BigInt.new("250 000 000 000 000 000")
     end
 
-    it "is equivalent to Enumerable#sum" do
+    it("is equivalent to Enumerable#sum") do
       (1..3).sum { |x| x * 2 }.should eq 12
       (1..3).step(2).sum { |x| x * 2 }.should eq 8
       (RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(3)).sum.should eq RangeSpecIntWrapper.new(6)
@@ -98,8 +98,8 @@ describe "Range" do
     end
   end
 
-  describe "bsearch" do
-    it "Int" do
+  describe("bsearch") do
+    it("Int") do
       ary = [3, 4, 7, 9, 12]
       (0...ary.size).bsearch { |i| ary[i] >= 2 }.should eq 0
       (0...ary.size).bsearch { |i| ary[i] >= 4 }.should eq 1
@@ -125,7 +125,7 @@ describe "Range" do
       (BigInt.new("-10")...BigInt.new("10")).bsearch { |x| x >= -5 }.should eq BigInt.new("-5")
     end
 
-    it "Float" do
+    it("Float") do
       inf = Float64::INFINITY
       (0.0...100.0).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
       (0.0...inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
@@ -167,22 +167,22 @@ describe "Range" do
     end
   end
 
-  describe "each" do
-    it "gives correct values with inclusive range" do
+  describe("each") do
+    it("gives correct values with inclusive range") do
       range = -1..3
       arr = [] of Int32
       range.each { |x| arr << x }
       arr.should eq([-1, 0, 1, 2, 3])
     end
 
-    it "gives correct values with exclusive range" do
+    it("gives correct values with exclusive range") do
       range = 'a'...'c'
       arr = [] of Char
       range.each { |x| arr << x }
       arr.should eq(['a', 'b'])
     end
 
-    it "is empty with empty inclusive range" do
+    it("is empty with empty inclusive range") do
       range = 0..-1
       any = false
       range.each { any = true }
@@ -190,22 +190,22 @@ describe "Range" do
     end
   end
 
-  describe "reverse_each" do
-    it "gives correct values with inclusive range" do
+  describe("reverse_each") do
+    it("gives correct values with inclusive range") do
       range = 'a'..'c'
       arr = [] of Char
       range.reverse_each { |x| arr << x }
       arr.should eq(['c', 'b', 'a'])
     end
 
-    it "gives correct values with exclusive range" do
+    it("gives correct values with exclusive range") do
       range = -1...3
       arr = [] of Int32
       range.reverse_each { |x| arr << x }
       arr.should eq([2, 1, 0, -1])
     end
 
-    it "is empty with empty inclusive range" do
+    it("is empty with empty inclusive range") do
       range = 0..-1
       any = false
       range.reverse_each { any = true }
@@ -213,8 +213,8 @@ describe "Range" do
     end
   end
 
-  describe "each iterator" do
-    it "does next with inclusive range" do
+  describe("each iterator") do
+    it("does next with inclusive range") do
       a = 1..3
       iter = a.each
       iter.next.should eq(1)
@@ -226,7 +226,7 @@ describe "Range" do
       iter.next.should eq(1)
     end
 
-    it "does next with exclusive range" do
+    it("does next with exclusive range") do
       r = 1...3
       iter = r.each
       iter.next.should eq(1)
@@ -237,29 +237,29 @@ describe "Range" do
       iter.next.should eq(1)
     end
 
-    it "cycles" do
+    it("cycles") do
       (1..3).cycle.first(8).join.should eq("12312312")
     end
 
-    it "is empty with .. and begin > end" do
+    it("is empty with .. and begin > end") do
       (1..0).each.to_a.empty?.should be_true
     end
 
-    it "is empty with ... and begin > end" do
+    it("is empty with ... and begin > end") do
       (1...0).each.to_a.empty?.should be_true
     end
 
-    it "is not empty with .. and begin == end" do
+    it("is not empty with .. and begin == end") do
       (1..1).each.to_a.should eq([1])
     end
 
-    it "is not empty with ... and begin.succ == end" do
+    it("is not empty with ... and begin.succ == end") do
       (1...2).each.to_a.should eq([1])
     end
   end
 
-  describe "reverse_each iterator" do
-    it "does next with inclusive range" do
+  describe("reverse_each iterator") do
+    it("does next with inclusive range") do
       a = 1..3
       iter = a.reverse_each
       iter.next.should eq(3)
@@ -271,7 +271,7 @@ describe "Range" do
       iter.next.should eq(3)
     end
 
-    it "does next with exclusive range" do
+    it("does next with exclusive range") do
       r = 1...3
       iter = r.reverse_each
       iter.next.should eq(2)
@@ -282,29 +282,29 @@ describe "Range" do
       iter.next.should eq(2)
     end
 
-    it "reverse cycles" do
+    it("reverse cycles") do
       (1..3).reverse_each.cycle.first(8).join.should eq("32132132")
     end
 
-    it "is empty with .. and begin > end" do
+    it("is empty with .. and begin > end") do
       (1..0).reverse_each.to_a.empty?.should be_true
     end
 
-    it "is empty with ... and begin > end" do
+    it("is empty with ... and begin > end") do
       (1...0).reverse_each.to_a.empty?.should be_true
     end
 
-    it "is not empty with .. and begin == end" do
+    it("is not empty with .. and begin == end") do
       (1..1).reverse_each.to_a.should eq([1])
     end
 
-    it "is not empty with ... and begin.succ == end" do
+    it("is not empty with ... and begin.succ == end") do
       (1...2).reverse_each.to_a.should eq([1])
     end
   end
 
-  describe "step iterator" do
-    it "does next with inclusive range" do
+  describe("step iterator") do
+    it("does next with inclusive range") do
       a = 1..5
       iter = a.step(2)
       iter.next.should eq(1)
@@ -316,7 +316,7 @@ describe "Range" do
       iter.next.should eq(1)
     end
 
-    it "does next with exclusive range" do
+    it("does next with exclusive range") do
       a = 1...5
       iter = a.step(2)
       iter.next.should eq(1)
@@ -327,7 +327,7 @@ describe "Range" do
       iter.next.should eq(1)
     end
 
-    it "does next with exclusive range (2)" do
+    it("does next with exclusive range (2)") do
       a = 1...6
       iter = a.step(2)
       iter.next.should eq(1)
@@ -339,48 +339,48 @@ describe "Range" do
       iter.next.should eq(1)
     end
 
-    it "is empty with .. and begin > end" do
+    it("is empty with .. and begin > end") do
       (1..0).step(1).to_a.empty?.should be_true
     end
 
-    it "is empty with ... and begin > end" do
+    it("is empty with ... and begin > end") do
       (1...0).step(1).to_a.empty?.should be_true
     end
 
-    it "is not empty with .. and begin == end" do
+    it("is not empty with .. and begin == end") do
       (1..1).step(1).to_a.should eq([1])
     end
 
-    it "is not empty with ... and begin.succ == end" do
+    it("is not empty with ... and begin.succ == end") do
       (1...2).step(1).to_a.should eq([1])
     end
   end
 
-  describe "map" do
-    it "optimizes for int range" do
+  describe("map") do
+    it("optimizes for int range") do
       (5..12).map(&.itself).should eq([5, 6, 7, 8, 9, 10, 11, 12])
       (5...12).map(&.itself).should eq([5, 6, 7, 8, 9, 10, 11])
       (5..4).map(&.itself).size.should eq(0)
     end
 
-    it "works for other types" do
+    it("works for other types") do
       ('a'..'c').map(&.itself).should eq(['a', 'b', 'c'])
     end
   end
 
-  describe "size" do
-    it "optimizes for int range" do
+  describe("size") do
+    it("optimizes for int range") do
       (5..12).size.should eq(8)
       (5...12).size.should eq(7)
       (5..4).size.should eq(0)
     end
 
-    it "works for other types" do
+    it("works for other types") do
       ('a'..'c').size.should eq(3)
     end
   end
 
-  it "clones" do
+  it("clones") do
     range = [1]..[2]
     clone = range.clone
     clone.should eq(range)

--- a/spec/std/readline_spec.cr
+++ b/spec/std/readline_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "readline"
 
-describe Readline do
+describe(Readline) do
   typeof(Readline.readline)
   typeof(Readline.readline("Hello", true))
   typeof(Readline.readline(prompt: "Hello"))
@@ -10,7 +10,7 @@ describe Readline do
   typeof(Readline.point)
   typeof(Readline.autocomplete { |s| %w(foo bar) })
 
-  it "gets prefix in bytesize between two strings" do
+  it("gets prefix in bytesize between two strings") do
     Readline.common_prefix_bytesize("", "foo").should eq(0)
     Readline.common_prefix_bytesize("foo", "").should eq(0)
     Readline.common_prefix_bytesize("a", "a").should eq(1)

--- a/spec/std/record_spec.cr
+++ b/spec/std/record_spec.cr
@@ -14,8 +14,8 @@ private module RecordSpec
     y = [2, 3]
 end
 
-describe "record" do
-  it "defines record with type declarations" do
+describe("record") do
+  it("defines record with type declarations") do
     ary = [2, 3]
     rec = RecordSpec::Record1.new(1, ary)
     rec.x.should eq(1)
@@ -27,7 +27,7 @@ describe "record" do
     cloned.y.should_not be(ary)
   end
 
-  it "defines record with type declaration and initialization" do
+  it("defines record with type declaration and initialization") do
     rec = RecordSpec::Record2.new
     rec.x.should eq(0)
     rec.y.should eq([2, 3])
@@ -38,7 +38,7 @@ describe "record" do
     cloned.y.should_not be(rec.y)
   end
 
-  it "defines record with assignments" do
+  it("defines record with assignments") do
     rec = RecordSpec::Record3.new
     rec.x.should eq(0)
     rec.y.should eq([2, 3])

--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -37,8 +37,8 @@ private module ReferenceSpec
   end
 end
 
-describe "Reference" do
-  it "compares reference to other reference" do
+describe("Reference") do
+  it("compares reference to other reference") do
     o1 = Reference.new
     o2 = Reference.new
     (o1 == o1).should be_true
@@ -46,42 +46,42 @@ describe "Reference" do
     (o1 == 1).should be_false
   end
 
-  it "should not be nil" do
+  it("should not be nil") do
     Reference.new.nil?.should be_false
   end
 
-  it "should be false when negated" do
+  it("should be false when negated") do
     (!Reference.new).should be_false
   end
 
-  it "does inspect" do
+  it("does inspect") do
     r = ReferenceSpec::TestClass.new(1, "hello")
     r.inspect.should eq(%(#<ReferenceSpec::TestClass:0x#{r.object_id.to_s(16)} @x=1, @y="hello">))
   end
 
-  it "does to_s" do
+  it("does to_s") do
     r = ReferenceSpec::TestClass.new(1, "hello")
     r.to_s.should eq(%(#<ReferenceSpec::TestClass:0x#{r.object_id.to_s(16)}>))
   end
 
-  it "does inspect for class" do
+  it("does inspect for class") do
     String.inspect.should eq("String")
   end
 
-  it "does to_s for class" do
+  it("does to_s for class") do
     String.to_s.should eq("String")
   end
 
-  it "does to_s for class if virtual" do
+  it("does to_s for class if virtual") do
     [ReferenceSpec::TestClassBase, ReferenceSpec::TestClassSubclass].to_s.should eq("[ReferenceSpec::TestClassBase, ReferenceSpec::TestClassSubclass]")
   end
 
-  it "returns itself" do
+  it("returns itself") do
     x = "hello"
     x.itself.should be(x)
   end
 
-  it "dups" do
+  it("dups") do
     original = ReferenceSpec::DupCloneClass.new
     duplicate = original.dup
     duplicate.should_not be(original)
@@ -89,7 +89,7 @@ describe "Reference" do
     duplicate.y.should be(original.y)
   end
 
-  it "can dup class that inherits abstract class" do
+  it("can dup class that inherits abstract class") do
     original = ReferenceSpec::Concrete.new(2).as(ReferenceSpec::Abstract)
     duplicate = original.dup
     duplicate.should be_a(ReferenceSpec::Concrete)
@@ -97,7 +97,7 @@ describe "Reference" do
     duplicate.x.should eq(original.x)
   end
 
-  it "clones with def_clone" do
+  it("clones with def_clone") do
     original = ReferenceSpec::DupCloneClass.new
     clone = original.clone
     clone.should_not be(original)
@@ -106,7 +106,7 @@ describe "Reference" do
     clone.y.should eq(original.y)
   end
 
-  it "pretty_print" do
+  it("pretty_print") do
     ReferenceSpec::TestClassBase.new.pretty_inspect.should match(/\A#<ReferenceSpec::TestClassBase:0x[0-9a-f]+>\Z/)
     ReferenceSpec::TestClass.new(42, "foo").pretty_inspect.should match(/\A#<ReferenceSpec::TestClass:0x[0-9a-f]+ @x=42, @y="foo">\Z/)
   end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -1,23 +1,23 @@
 require "spec"
 
-describe "Regex" do
-  it "compare to other instances" do
+describe("Regex") do
+  it("compare to other instances") do
     Regex.new("foo").should eq(Regex.new("foo"))
     Regex.new("foo").should_not eq(Regex.new("bar"))
   end
 
-  it "does =~" do
+  it("does =~") do
     (/foo/ =~ "bar foo baz").should eq(4)
     $~.group_size.should eq(0)
   end
 
-  it "does inspect" do
+  it("does inspect") do
     /foo/.inspect.should eq("/foo/")
     /foo/.inspect.should eq("/foo/")
     /foo/imx.inspect.should eq("/foo/imx")
   end
 
-  it "does to_s" do
+  it("does to_s") do
     /foo/.to_s.should eq("(?-imsx:foo)")
     /foo/im.to_s.should eq("(?ims-x:foo)")
     /foo/imx.to_s.should eq("(?imsx-:foo)")
@@ -31,50 +31,50 @@ describe "Regex" do
     md["foo"].should eq("r")
   end
 
-  it "does inspect with slash" do
+  it("does inspect with slash") do
     %r(/).inspect.should eq("/\\//")
   end
 
-  it "does to_s with slash" do
+  it("does to_s with slash") do
     %r(/).to_s.should eq("(?-imsx:\\/)")
   end
 
-  it "doesn't crash when PCRE tries to free some memory (#771)" do
+  it("doesn't crash when PCRE tries to free some memory (#771)") do
     expect_raises(ArgumentError) { Regex.new("foo)") }
   end
 
-  it "escapes" do
+  it("escapes") do
     Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
   end
 
-  it "matches ignore case" do
+  it("matches ignore case") do
     ("HeLlO" =~ /hello/).should be_nil
     ("HeLlO" =~ /hello/i).should eq(0)
   end
 
-  it "matches lines beginnings on ^ in multiline mode" do
+  it("matches lines beginnings on ^ in multiline mode") do
     ("foo\nbar" =~ /^bar/).should be_nil
     ("foo\nbar" =~ /^bar/m).should eq(4)
   end
 
-  it "matches multiline" do
+  it("matches multiline") do
     ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
     ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
   end
 
-  it "matches with =~ and captures" do
+  it("matches with =~ and captures") do
     ("fooba" =~ /f(o+)(bar?)/).should eq(0)
     $~.group_size.should eq(2)
     $1.should eq("oo")
     $2.should eq("ba")
   end
 
-  it "matches with =~ and gets utf-8 codepoint index" do
+  it("matches with =~ and gets utf-8 codepoint index") do
     index = "こんに" =~ /ん/
     index.should eq(1)
   end
 
-  it "matches with === and captures" do
+  it("matches with === and captures") do
     "foo" =~ /foo/
     (/f(o+)(bar?)/ === "fooba").should be_true
     $~.group_size.should eq(2)
@@ -82,8 +82,8 @@ describe "Regex" do
     $2.should eq("ba")
   end
 
-  describe "name_table" do
-    it "is a map of capture group number to name" do
+  describe("name_table") do
+    it("is a map of capture group number to name") do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table
       table[1].should eq("date")
       table[2].should eq("year")
@@ -93,59 +93,59 @@ describe "Regex" do
     end
   end
 
-  it "raises exception with invalid regex" do
+  it("raises exception with invalid regex") do
     expect_raises(ArgumentError) { Regex.new("+") }
   end
 
-  it "raises if outside match range with []" do
+  it("raises if outside match range with []") do
     "foo" =~ /foo/
     expect_raises(IndexError) { $1 }
   end
 
-  describe ".union" do
-    it "constructs a Regex that matches things any of its arguments match" do
+  describe(".union") do
+    it("constructs a Regex that matches things any of its arguments match") do
       re = Regex.union(/skiing/i, "sledding")
       re.match("Skiing").not_nil![0].should eq "Skiing"
       re.match("sledding").not_nil![0].should eq "sledding"
     end
 
-    it "returns a regular expression that will match passed arguments" do
+    it("returns a regular expression that will match passed arguments") do
       Regex.union("penzance").should eq /penzance/
       Regex.union("skiing", "sledding").should eq /skiing|sledding/
       Regex.union(/dogs/, /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
-    it "quotes any string arguments" do
+    it("quotes any string arguments") do
       Regex.union("n", ".").should eq /n|\./
     end
 
-    it "returns a Regex with an Array(String) with special characters" do
+    it("returns a Regex with an Array(String) with special characters") do
       Regex.union(["+", "-"]).should eq /\+|\-/
     end
 
-    it "accepts a single Array(String | Regex) argument" do
+    it("accepts a single Array(String | Regex) argument") do
       Regex.union(["skiing", "sledding"]).should eq /skiing|sledding/
       Regex.union([/dogs/, /cats/i]).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
-    it "accepts a single Tuple(String | Regex) argument" do
+    it("accepts a single Tuple(String | Regex) argument") do
       Regex.union({"skiing", "sledding"}).should eq /skiing|sledding/
       Regex.union({/dogs/, /cats/i}).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
-    it "combines Regex objects in the same way as Regex#+" do
+    it("combines Regex objects in the same way as Regex#+") do
       Regex.union(/skiing/i, /sledding/).should eq(/skiing/i + /sledding/)
     end
   end
 
-  it "dups" do
+  it("dups") do
     regex = /foo/
     regex.dup.should be(regex)
   end
 
-  it "clones" do
+  it("clones") do
     regex = /foo/
     regex.clone.should be(regex)
   end

--- a/spec/std/secure_random_spec.cr
+++ b/spec/std/secure_random_spec.cr
@@ -1,42 +1,42 @@
 require "spec"
 require "secure_random"
 
-describe SecureRandom do
-  describe "base64" do
-    it "gets base64 with default number of digits" do
+describe(SecureRandom) do
+  describe("base64") do
+    it("gets base64 with default number of digits") do
       base64 = SecureRandom.base64
       base64.size.should eq(24)
       base64.should_not match(/\n/)
     end
 
-    it "gets base64 with requested number of digits" do
+    it("gets base64 with requested number of digits") do
       base64 = SecureRandom.base64(50)
       base64.size.should eq(68)
       base64.should_not match(/\n/)
     end
   end
 
-  describe "urlsafe_base64" do
-    it "gets urlsafe base64 with default number of digits" do
+  describe("urlsafe_base64") do
+    it("gets urlsafe base64 with default number of digits") do
       base64 = SecureRandom.urlsafe_base64
       (base64.size <= 24).should be_true
       base64.should_not match(/[\n+\/=]/)
     end
 
-    it "gets urlsafe base64 with requested number of digits" do
+    it("gets urlsafe base64 with requested number of digits") do
       base64 = SecureRandom.urlsafe_base64(50)
       (base64.size >= 24 && base64.size <= 68).should be_true
       base64.should_not match(/[\n+\/=]/)
     end
 
-    it "keeps padding" do
+    it("keeps padding") do
       base64 = SecureRandom.urlsafe_base64(padding: true)
       base64[-2..-1].should eq("==")
     end
   end
 
-  describe "hex" do
-    it "gets hex with default number of digits" do
+  describe("hex") do
+    it("gets hex with default number of digits") do
       hex = SecureRandom.hex
       hex.size.should eq(32)
       hex.each_char do |char|
@@ -44,7 +44,7 @@ describe SecureRandom do
       end
     end
 
-    it "gets hex with requested number of digits" do
+    it("gets hex with requested number of digits") do
       hex = SecureRandom.hex(50)
       hex.size.should eq(100)
       hex.each_char do |char|
@@ -53,23 +53,23 @@ describe SecureRandom do
     end
   end
 
-  describe "random_bytes" do
-    it "gets random bytes with default number of digits" do
+  describe("random_bytes") do
+    it("gets random bytes with default number of digits") do
       bytes = SecureRandom.random_bytes
       bytes.size.should eq(16)
     end
 
-    it "gets random bytes with requested number of digits" do
+    it("gets random bytes with requested number of digits") do
       bytes = SecureRandom.random_bytes(50)
       bytes.size.should eq(50)
     end
 
-    it "fully fills a large buffer" do
+    it("fully fills a large buffer") do
       bytes = SecureRandom.random_bytes(10000)
       bytes[9990, 10].should_not eq(Bytes.new(10))
     end
 
-    it "fills given buffer with random bytes" do
+    it("fills given buffer with random bytes") do
       bytes = Bytes.new(2000)
       SecureRandom.random_bytes(bytes)
       bytes.size.should eq 2000
@@ -77,8 +77,8 @@ describe SecureRandom do
     end
   end
 
-  describe "uuid" do
-    it "gets uuid" do
+  describe("uuid") do
+    it("gets uuid") do
       uuid = SecureRandom.uuid
       uuid.should match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{4}[0-9a-f]{8}\Z/)
     end

--- a/spec/std/semantic_version_spec.cr
+++ b/spec/std/semantic_version_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "semantic_version"
 
-describe SemanticVersion do
-  it "compares <" do
+describe(SemanticVersion) do
+  it("compares <") do
     sversions = %w(
       1.2.3-2
       1.2.3-10
@@ -26,7 +26,7 @@ describe SemanticVersion do
     end
   end
 
-  it "compares build equivalence" do
+  it("compares build equivalence") do
     sversions = [
       "1.2.3+1",
       "1.2.3+999",

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -1,19 +1,19 @@
 require "spec"
 require "set"
 
-describe "Set" do
-  describe "an empty set" do
-    it "is empty" do
+describe("Set") do
+  describe("an empty set") do
+    it("is empty") do
       Set(Nil).new.empty?.should be_true
     end
 
-    it "has size 0" do
+    it("has size 0") do
       Set(Nil).new.size.should eq(0)
     end
   end
 
-  describe "new" do
-    it "creates new set with enumerable without block" do
+  describe("new") do
+    it("creates new set with enumerable without block") do
       set_from_array = Set.new([2, 4, 6, 4])
       set_from_array.size.should eq(3)
       set_from_array.to_a.sort.should eq([2, 4, 6])
@@ -26,22 +26,22 @@ describe "Set" do
     end
   end
 
-  describe "add" do
-    it "adds and includes" do
+  describe("add") do
+    it("adds and includes") do
       set = Set(Int32).new
       set.add 1
       set.includes?(1).should be_true
       set.size.should eq(1)
     end
 
-    it "returns self" do
+    it("returns self") do
       set = Set(Int32).new
       set.add(1).should eq(set)
     end
   end
 
-  describe "delete" do
-    it "deletes an object" do
+  describe("delete") do
+    it("deletes an object") do
       set = Set{1, 2, 3}
       set.delete 2
       set.size.should eq(2)
@@ -49,14 +49,14 @@ describe "Set" do
       set.includes?(3).should be_true
     end
 
-    it "returns self" do
+    it("returns self") do
       set = Set{1, 2, 3}
       set.delete(2).should eq(set)
     end
   end
 
-  describe "dup" do
-    it "creates a dup" do
+  describe("dup") do
+    it("creates a dup") do
       set1 = Set{[1, 2]}
       set2 = set1.dup
 
@@ -72,8 +72,8 @@ describe "Set" do
     end
   end
 
-  describe "clone" do
-    it "creates a clone" do
+  describe("clone") do
+    it("creates a clone") do
       set1 = Set{[1, 2]}
       set2 = set1.clone
 
@@ -89,8 +89,8 @@ describe "Set" do
     end
   end
 
-  describe "==" do
-    it "compares two sets" do
+  describe("==") do
+    it("compares two sets") do
       set1 = Set{1, 2, 3}
       set2 = Set{1, 2, 3}
       set3 = Set{1, 2, 3, 4}
@@ -101,169 +101,169 @@ describe "Set" do
     end
   end
 
-  describe "concat" do
-    it "adds all the other elements" do
+  describe("concat") do
+    it("adds all the other elements") do
       set = Set{1, 4, 8}
       set.concat [1, 9, 10]
       set.should eq(Set{1, 4, 8, 9, 10})
     end
 
-    it "returns self" do
+    it("returns self") do
       set = Set{1, 4, 8}
       set.concat([1, 9, 10]).should eq(Set{1, 4, 8, 9, 10})
     end
   end
 
-  it "does &" do
+  it("does &") do
     set1 = Set{1, 2, 3}
     set2 = Set{4, 2, 5, 3}
     set3 = set1 & set2
     set3.should eq(Set{2, 3})
   end
 
-  it "does |" do
+  it("does |") do
     set1 = Set{1, 2, 3}
     set2 = Set{4, 2, 5, "3"}
     set3 = set1 | set2
     set3.should eq(Set{1, 2, 3, 4, 5, "3"})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 6}
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 'a'}
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = Set{2, 4, 5}
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 'b'})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 'a']
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 5})
   end
 
-  it "does -" do
+  it("does -") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = [2, 4, 5]
     set3 = set1 - set2
     set3.should eq(Set{1, 3, 'b'})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 6}
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 6})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 'a'}
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 'a'})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = Set{2, 4, 5}
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 'b'})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 6})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 'a']
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 'a'})
   end
 
-  it "does ^" do
+  it("does ^") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = [2, 4, 5]
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 'b'})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 6}
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 'a'}
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = Set{2, 4, 5}
     set1.subtract set2
     set1.should eq(Set{1, 3, 'b'})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 'a']
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end
 
-  it "does subtract" do
+  it("does subtract") do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = [2, 4, 5]
     set1.subtract set2
     set1.should eq(Set{1, 3, 'b'})
   end
 
-  it "does to_a" do
+  it("does to_a") do
     Set{1, 2, 3}.to_a.should eq([1, 2, 3])
   end
 
-  it "does to_s" do
+  it("does to_s") do
     Set{1, 2, 3}.to_s.should eq("Set{1, 2, 3}")
     Set{"foo"}.to_s.should eq(%(Set{"foo"}))
   end
 
-  it "does clear" do
+  it("does clear") do
     x = Set{1, 2, 3}
     x.to_a.should eq([1, 2, 3])
     x.clear.should be(x)
@@ -271,7 +271,7 @@ describe "Set" do
     x.to_a.should eq([1])
   end
 
-  it "checks intersects" do
+  it("checks intersects") do
     set = Set{3, 4, 5}
     empty_set = Set(Int32).new
 
@@ -289,13 +289,13 @@ describe "Set" do
     set.should eq(Set{3, 4, 5})
   end
 
-  it "compares hashes of sets" do
+  it("compares hashes of sets") do
     h1 = {Set{1, 2, 3} => 1}
     h2 = {Set{1, 2, 3} => 1}
     h1.should eq(h2)
   end
 
-  it "does each" do
+  it("does each") do
     set = Set{1, 2, 3}
     i = 1
     set.each do |v|
@@ -305,7 +305,7 @@ describe "Set" do
     i.should eq(4)
   end
 
-  it "gets each iterator" do
+  it("gets each iterator") do
     iter = Set{1, 2, 3}.each
     iter.next.should eq(1)
     iter.next.should eq(2)
@@ -316,7 +316,7 @@ describe "Set" do
     iter.next.should eq(1)
   end
 
-  it "check subset" do
+  it("check subset") do
     set = Set{1, 2, 3}
     empty_set = Set(Int32).new
 
@@ -330,7 +330,7 @@ describe "Set" do
     empty_set.subset?(empty_set).should be_true
   end
 
-  it "check proper_subset" do
+  it("check proper_subset") do
     set = Set{1, 2, 3}
     empty_set = Set(Int32).new
 
@@ -344,7 +344,7 @@ describe "Set" do
     empty_set.proper_subset?(empty_set).should be_false
   end
 
-  it "check superset" do
+  it("check superset") do
     set = Set{1, 2, "3"}
     empty_set = Set(Int32).new
 
@@ -358,7 +358,7 @@ describe "Set" do
     empty_set.superset?(empty_set).should be_true
   end
 
-  it "check proper_superset" do
+  it("check proper_superset") do
     set = Set{1, 2, "3"}
     empty_set = Set(Int32).new
 
@@ -372,7 +372,7 @@ describe "Set" do
     empty_set.proper_superset?(empty_set).should be_false
   end
 
-  it "has object_id" do
+  it("has object_id") do
     Set(Int32).new.object_id.should be > 0
   end
 

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -1,12 +1,12 @@
 require "spec"
 require "signal"
 
-describe "Signal" do
+describe("Signal") do
   typeof(Signal::PIPE.reset)
   typeof(Signal::PIPE.ignore)
   typeof(Signal::PIPE.trap { 1 })
 
-  it "runs a signal handler" do
+  it("runs a signal handler") do
     ran = false
     Signal::USR1.trap do
       ran = true
@@ -19,7 +19,7 @@ describe "Signal" do
     ran.should be_true
   end
 
-  it "ignores a signal" do
+  it("ignores a signal") do
     Signal::USR2.ignore
     Process.kill Signal::USR2, Process.pid
   end

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -1,14 +1,14 @@
 require "spec"
 
-describe "Slice" do
-  it "gets pointer and size" do
+describe("Slice") do
+  it("gets pointer and size") do
     pointer = Pointer.malloc(1, 0)
     slice = Slice.new(pointer, 1)
     slice.pointer(0).should eq(pointer)
     slice.size.should eq(1)
   end
 
-  it "does []" do
+  it("does []") do
     slice = Slice.new(3) { |i| i + 1 }
     3.times do |i|
       slice[i].should eq(i + 1)
@@ -21,7 +21,7 @@ describe "Slice" do
     expect_raises(IndexError) { slice[3] }
   end
 
-  it "does []=" do
+  it("does []=") do
     slice = Slice.new(3, 0)
     slice[0] = 1
     slice[0].should eq(1)
@@ -30,7 +30,7 @@ describe "Slice" do
     expect_raises(IndexError) { slice[3] = 1 }
   end
 
-  it "does +" do
+  it("does +") do
     slice = Slice.new(3) { |i| i + 1 }
 
     slice1 = slice + 1
@@ -45,7 +45,7 @@ describe "Slice" do
     expect_raises(IndexError) { slice + (-1) }
   end
 
-  it "does [] with start and count" do
+  it("does [] with start and count") do
     slice = Slice.new(4) { |i| i + 1 }
     slice1 = slice[1, 2]
     slice1.size.should eq(2)
@@ -58,32 +58,32 @@ describe "Slice" do
     expect_raises(IndexError) { slice[3, -1] }
   end
 
-  it "does empty?" do
+  it("does empty?") do
     Slice.new(0, 0).empty?.should be_true
     Slice.new(1, 0).empty?.should be_false
   end
 
-  it "raises if size is negative on new" do
+  it("raises if size is negative on new") do
     expect_raises(ArgumentError) { Slice.new(-1, 0) }
   end
 
-  it "does to_s" do
+  it("does to_s") do
     slice = Slice.new(4) { |i| i + 1 }
     slice.to_s.should eq("Slice[1, 2, 3, 4]")
   end
 
-  it "does to_s for bytes" do
+  it("does to_s for bytes") do
     slice = Bytes[1, 2, 3]
     slice.to_s.should eq("Bytes[1, 2, 3]")
   end
 
-  it "gets pointer" do
+  it("gets pointer") do
     slice = Slice.new(4, 0)
     expect_raises(IndexError) { slice.pointer(5) }
     expect_raises(IndexError) { slice.pointer(-1) }
   end
 
-  it "does copy_from pointer" do
+  it("does copy_from pointer") do
     pointer = Pointer.malloc(4) { |i| i + 1 }
     slice = Slice.new(4, 0)
     slice.copy_from(pointer, 4)
@@ -92,7 +92,7 @@ describe "Slice" do
     expect_raises(IndexError) { slice.copy_from(pointer, 5) }
   end
 
-  it "does copy_to pointer" do
+  it("does copy_to pointer") do
     pointer = Pointer.malloc(4, 0)
     slice = Slice.new(4) { |i| i + 1 }
     slice.copy_to(pointer, 4)
@@ -101,8 +101,8 @@ describe "Slice" do
     expect_raises(IndexError) { slice.copy_to(pointer, 5) }
   end
 
-  describe ".copy_to(Slice)" do
-    it "copies bytes" do
+  describe(".copy_to(Slice)") do
+    it("copies bytes") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(4) { 'b' }
 
@@ -110,14 +110,14 @@ describe "Slice" do
       dst.should eq(src)
     end
 
-    it "raises if dst is smaller" do
+    it("raises if dst is smaller") do
       src = Slice.new(8) { 'a' }
       dst = Slice.new(4) { 'b' }
 
       expect_raises(IndexError) { src.copy_to(dst) }
     end
 
-    it "copies at most src.size" do
+    it("copies at most src.size") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(8) { 'b' }
 
@@ -126,8 +126,8 @@ describe "Slice" do
     end
   end
 
-  describe ".copy_from(Slice)" do
-    it "copies bytes" do
+  describe(".copy_from(Slice)") do
+    it("copies bytes") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(4) { 'b' }
 
@@ -135,14 +135,14 @@ describe "Slice" do
       dst.should eq(src)
     end
 
-    it "raises if dst is smaller" do
+    it("raises if dst is smaller") do
       src = Slice.new(8) { 'a' }
       dst = Slice.new(4) { 'b' }
 
       expect_raises(IndexError) { dst.copy_from(src) }
     end
 
-    it "copies at most src.size" do
+    it("copies at most src.size") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(8) { 'b' }
 
@@ -151,8 +151,8 @@ describe "Slice" do
     end
   end
 
-  describe ".move_to(Slice)" do
-    it "moves bytes" do
+  describe(".move_to(Slice)") do
+    it("moves bytes") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(4) { 'b' }
 
@@ -160,14 +160,14 @@ describe "Slice" do
       dst.should eq(src)
     end
 
-    it "raises if dst is smaller" do
+    it("raises if dst is smaller") do
       src = Slice.new(8) { 'a' }
       dst = Slice.new(4) { 'b' }
 
       expect_raises(IndexError) { src.move_to(dst) }
     end
 
-    it "moves most src.size" do
+    it("moves most src.size") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(8) { 'b' }
 
@@ -175,7 +175,7 @@ describe "Slice" do
       dst.should eq(Slice['a', 'a', 'a', 'a', 'b', 'b', 'b', 'b'])
     end
 
-    it "handles intersecting ranges" do
+    it("handles intersecting ranges") do
       # Test with ranges offset by 0 to 8 bytes
       (0..8).each do |offset|
         buf = Slice.new(16) { |i| 'a' + i }
@@ -190,8 +190,8 @@ describe "Slice" do
     end
   end
 
-  describe ".move_from(Slice)" do
-    it "moves bytes" do
+  describe(".move_from(Slice)") do
+    it("moves bytes") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(4) { 'b' }
 
@@ -199,14 +199,14 @@ describe "Slice" do
       dst.should eq(src)
     end
 
-    it "raises if dst is smaller" do
+    it("raises if dst is smaller") do
       src = Slice.new(8) { 'a' }
       dst = Slice.new(4) { 'b' }
 
       expect_raises(IndexError) { dst.move_from(src) }
     end
 
-    it "moves at most src.size" do
+    it("moves at most src.size") do
       src = Slice.new(4) { 'a' }
       dst = Slice.new(8) { 'b' }
 
@@ -214,7 +214,7 @@ describe "Slice" do
       dst.should eq(Slice['a', 'a', 'a', 'a', 'b', 'b', 'b', 'b'])
     end
 
-    it "handles intersecting ranges" do
+    it("handles intersecting ranges") do
       # Test with ranges offset by 0 to 8 bytes
       (0..8).each do |offset|
         buf = Slice.new(16) { |i| 'a' + i }
@@ -229,16 +229,16 @@ describe "Slice" do
     end
   end
 
-  it "does hexstring" do
+  it("does hexstring") do
     slice = Bytes.new(4) { |i| i.to_u8 + 1 }
     slice.hexstring.should eq("01020304")
   end
 
-  it "does hexdump for empty slice" do
+  it("does hexdump for empty slice") do
     Bytes.empty.hexdump.should eq("")
   end
 
-  it "does hexdump" do
+  it("does hexdump") do
     ascii_table = <<-EOF
       00000000  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
       00000010  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?
@@ -265,7 +265,7 @@ describe "Slice" do
     plus.hexdump.should eq(ascii_table_plus)
   end
 
-  it "does iterator" do
+  it("does iterator") do
     slice = Slice(Int32).new(3) { |i| i + 1 }
     iter = slice.each
     iter.next.should eq(1)
@@ -280,7 +280,7 @@ describe "Slice" do
     iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
   end
 
-  it "does reverse iterator" do
+  it("does reverse iterator") do
     slice = Slice(Int32).new(3) { |i| i + 1 }
     iter = slice.reverse_each
     iter.next.should eq(3)
@@ -292,7 +292,7 @@ describe "Slice" do
     iter.next.should eq(3)
   end
 
-  it "does index iterator" do
+  it("does index iterator") do
     slice = Slice(Int32).new(2) { |i| i + 1 }
     iter = slice.each_index
     iter.next.should eq(0)
@@ -303,24 +303,24 @@ describe "Slice" do
     iter.next.should eq(0)
   end
 
-  it "does to_a" do
+  it("does to_a") do
     slice = Slice.new(3) { |i| i }
     ary = slice.to_a
     ary.should eq([0, 1, 2])
   end
 
-  it "does rindex" do
+  it("does rindex") do
     slice = "foobar".to_slice
     slice.rindex('o'.ord.to_u8).should eq(2)
     slice.rindex('z'.ord.to_u8).should be_nil
   end
 
-  it "does bytesize" do
+  it("does bytesize") do
     slice = Slice(Int32).new(2)
     slice.bytesize.should eq(8)
   end
 
-  it "does ==" do
+  it("does ==") do
     a = Slice.new(3) { |i| i }
     b = Slice.new(3) { |i| i }
     c = Slice.new(3) { |i| i + 1 }
@@ -328,7 +328,7 @@ describe "Slice" do
     a.should_not eq(c)
   end
 
-  it "does macro []" do
+  it("does macro []") do
     slice = Slice[1, 'a', "foo"]
     slice.should be_a(Slice(Int32 | Char | String))
     slice.size.should eq(3)
@@ -337,37 +337,37 @@ describe "Slice" do
     slice[2].should eq("foo")
   end
 
-  it "does macro [] with numbers (#3055)" do
+  it("does macro [] with numbers (#3055)") do
     slice = Bytes[1, 2, 3]
     slice.should be_a(Bytes)
     slice.to_a.should eq([1, 2, 3])
   end
 
-  it "uses percent vars in [] macro (#2954)" do
+  it("uses percent vars in [] macro (#2954)") do
     slices = itself(Slice[1, 2], Slice[3])
     slices[0].to_a.should eq([1, 2])
     slices[1].to_a.should eq([3])
   end
 
-  it "reverses" do
+  it("reverses") do
     slice = Bytes[1, 2, 3]
     slice.reverse!
     slice.to_a.should eq([3, 2, 1])
   end
 
-  it "shuffles" do
+  it("shuffles") do
     a = Bytes[1, 2, 3]
     a.shuffle!
     b = [1, 2, 3]
     3.times { a.includes?(b.shift).should be_true }
   end
 
-  it "creates empty slice" do
+  it("creates empty slice") do
     slice = Slice(Int32).empty
     slice.empty?.should be_true
   end
 
-  it "creates read-only slice" do
+  it("creates read-only slice") do
     slice = Slice.new(3, 0, read_only: true)
     expect_raises { slice[0] = 1 }
     expect_raises { slice.copy_from(slice) }

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -1,10 +1,10 @@
 require "spec"
 require "socket"
 
-describe Socket do
+describe(Socket) do
   # Tests from libc-test:
   # http://repo.or.cz/libc-test.git/blob/master:/src/functional/inet_pton.c
-  it ".ip?" do
+  it(".ip?") do
     # dotted-decimal notation
     Socket.ip?("0.0.0.0").should be_true
     Socket.ip?("127.0.0.1").should be_true
@@ -63,8 +63,8 @@ describe Socket do
     Socket.ip?("c0a8").should be_false
   end
 
-  describe ".unix" do
-    it "creates a unix socket" do
+  describe(".unix") do
+    it("creates a unix socket") do
       sock = Socket.unix
       sock.should be_a(Socket)
       sock.family.should eq(Socket::Family::UNIX)
@@ -76,21 +76,21 @@ describe Socket do
   end
 end
 
-describe Socket::Addrinfo do
-  describe ".resolve" do
-    it "returns an array" do
+describe(Socket::Addrinfo) do
+  describe(".resolve") do
+    it("returns an array") do
       addrinfos = Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::STREAM)
       typeof(addrinfos).should eq(Array(Socket::Addrinfo))
       addrinfos.size.should_not eq(0)
     end
 
-    it "yields each result" do
+    it("yields each result") do
       Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
         typeof(addrinfo).should eq(Socket::Addrinfo)
       end
     end
 
-    it "eventually raises returned error" do
+    it("eventually raises returned error") do
       expect_raises(Socket::Error) do |addrinfo|
         Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
           Socket::Error.new("please fail")
@@ -99,35 +99,35 @@ describe Socket::Addrinfo do
     end
   end
 
-  describe ".tcp" do
-    it "returns an array" do
+  describe(".tcp") do
+    it("returns an array") do
       addrinfos = Socket::Addrinfo.tcp("localhost", 80)
       typeof(addrinfos).should eq(Array(Socket::Addrinfo))
       addrinfos.size.should_not eq(0)
     end
 
-    it "yields each result" do
+    it("yields each result") do
       Socket::Addrinfo.tcp("localhost", 80) do |addrinfo|
         typeof(addrinfo).should eq(Socket::Addrinfo)
       end
     end
   end
 
-  describe ".udp" do
-    it "returns an array" do
+  describe(".udp") do
+    it("returns an array") do
       addrinfos = Socket::Addrinfo.udp("localhost", 80)
       typeof(addrinfos).should eq(Array(Socket::Addrinfo))
       addrinfos.size.should_not eq(0)
     end
 
-    it "yields each result" do
+    it("yields each result") do
       Socket::Addrinfo.udp("localhost", 80) do |addrinfo|
         typeof(addrinfo).should eq(Socket::Addrinfo)
       end
     end
   end
 
-  describe "#ip_address" do
+  describe("#ip_address") do
     it do
       addrinfos = Socket::Addrinfo.udp("localhost", 80)
       typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
@@ -135,8 +135,8 @@ describe Socket::Addrinfo do
   end
 end
 
-describe Socket::IPAddress do
-  it "transforms an IPv4 address into a C struct and back" do
+describe(Socket::IPAddress) do
+  it("transforms an IPv4 address into a C struct and back") do
     addr1 = Socket::IPAddress.new("127.0.0.1", 8080)
     addr2 = Socket::IPAddress.from(addr1.to_unsafe, addr1.size)
 
@@ -146,7 +146,7 @@ describe Socket::IPAddress do
     addr2.address.should eq(addr1.address)
   end
 
-  it "transforms an IPv6 address into a C struct and back" do
+  it("transforms an IPv6 address into a C struct and back") do
     addr1 = Socket::IPAddress.new("2001:db8:8714:3a90::12", 8080)
     addr2 = Socket::IPAddress.from(addr1.to_unsafe, addr1.size)
 
@@ -156,20 +156,20 @@ describe Socket::IPAddress do
     addr2.address.should eq(addr1.address)
   end
 
-  it "won't resolve domains" do
+  it("won't resolve domains") do
     expect_raises(Socket::Error, /Invalid IP address/) do
       Socket::IPAddress.new("localhost", 1234)
     end
   end
 
-  it "to_s" do
+  it("to_s") do
     Socket::IPAddress.new("127.0.0.1", 80).to_s.should eq("127.0.0.1:80")
     Socket::IPAddress.new("2001:db8:8714:3a90::12", 443).to_s.should eq("[2001:db8:8714:3a90::12]:443")
   end
 end
 
-describe Socket::UNIXAddress do
-  it "transforms into a C struct and back" do
+describe(Socket::UNIXAddress) do
+  it("transforms into a C struct and back") do
     addr1 = Socket::UNIXAddress.new("/tmp/service.sock")
     addr2 = Socket::UNIXAddress.from(addr1.to_unsafe, addr1.size)
 
@@ -178,24 +178,24 @@ describe Socket::UNIXAddress do
     addr2.to_s.should eq("/tmp/service.sock")
   end
 
-  it "raises when path is too long" do
+  it("raises when path is too long") do
     path = "/tmp/crystal-test-too-long-unix-socket-#{("a" * 2048)}.sock"
     expect_raises(ArgumentError, "Path size exceeds the maximum size") { Socket::UNIXAddress.new(path) }
   end
 
-  it "to_s" do
+  it("to_s") do
     Socket::UNIXAddress.new("some_path").to_s.should eq("some_path")
   end
 end
 
-describe UNIXServer do
-  it "raises when path is too long" do
+describe(UNIXServer) do
+  it("raises when path is too long") do
     path = "/tmp/crystal-test-too-long-unix-socket-#{("a" * 2048)}.sock"
     expect_raises(ArgumentError, "Path size exceeds the maximum size") { UNIXServer.new(path) }
     File.exists?(path).should be_false
   end
 
-  it "creates the socket file" do
+  it("creates the socket file") do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do
@@ -205,7 +205,7 @@ describe UNIXServer do
     File.exists?(path).should be_false
   end
 
-  it "deletes socket file on close" do
+  it("deletes socket file on close") do
     path = "/tmp/crystal-test-unix-sock"
 
     begin
@@ -217,7 +217,7 @@ describe UNIXServer do
     end
   end
 
-  it "raises when socket file already exists" do
+  it("raises when socket file already exists") do
     path = "/tmp/crystal-test-unix-sock"
     server = UNIXServer.new(path)
 
@@ -228,14 +228,14 @@ describe UNIXServer do
     end
   end
 
-  it "won't delete existing file on bind failure" do
+  it("won't delete existing file on bind failure") do
     path = "/tmp/crystal-test-unix.sock"
 
     File.write(path, "")
     File.exists?(path).should be_true
 
     begin
-      expect_raises Errno, /(already|Address) in use/ do
+      expect_raises(Errno, /(already|Address) in use/) do
         UNIXServer.new(path)
       end
 
@@ -245,8 +245,8 @@ describe UNIXServer do
     end
   end
 
-  describe "accept" do
-    it "returns the client UNIXSocket" do
+  describe("accept") do
+    it("returns the client UNIXSocket") do
       UNIXServer.open("/tmp/crystal-test-unix-sock") do |server|
         UNIXSocket.open("/tmp/crystal-test-unix-sock") do |_|
           client = server.accept
@@ -256,7 +256,7 @@ describe UNIXServer do
       end
     end
 
-    it "raises when server is closed" do
+    it("raises when server is closed") do
       server = UNIXServer.new("/tmp/crystal-test-unix-sock")
       exception = nil
 
@@ -278,8 +278,8 @@ describe UNIXServer do
     end
   end
 
-  describe "accept?" do
-    it "returns the client UNIXSocket" do
+  describe("accept?") do
+    it("returns the client UNIXSocket") do
       UNIXServer.open("/tmp/crystal-test-unix-sock") do |server|
         UNIXSocket.open("/tmp/crystal-test-unix-sock") do |_|
           client = server.accept?.not_nil!
@@ -289,7 +289,7 @@ describe UNIXServer do
       end
     end
 
-    it "returns nil when server is closed" do
+    it("returns nil when server is closed") do
       server = UNIXServer.new("/tmp/crystal-test-unix-sock")
       ret = :initial
 
@@ -305,14 +305,14 @@ describe UNIXServer do
   end
 end
 
-describe UNIXSocket do
-  it "raises when path is too long" do
+describe(UNIXSocket) do
+  it("raises when path is too long") do
     path = "/tmp/crystal-test-too-long-unix-socket-#{("a" * 2048)}.sock"
     expect_raises(ArgumentError, "Path size exceeds the maximum size") { UNIXSocket.new(path) }
     File.exists?(path).should be_false
   end
 
-  it "sends and receives messages" do
+  it("sends and receives messages") do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do |server|
@@ -339,7 +339,7 @@ describe UNIXSocket do
     end
   end
 
-  it "sync flag after accept" do
+  it("sync flag after accept") do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do |server|
@@ -359,7 +359,7 @@ describe UNIXSocket do
     end
   end
 
-  it "creates a pair of sockets" do
+  it("creates a pair of sockets") do
     UNIXSocket.pair do |left, right|
       left.local_address.family.should eq(Socket::Family::UNIX)
       left.local_address.path.should eq("")
@@ -372,7 +372,7 @@ describe UNIXSocket do
     end
   end
 
-  it "tests read and write timeouts" do
+  it("tests read and write timeouts") do
     UNIXSocket.pair do |left, right|
       # BUG: shrink the socket buffers first
       left.write_timeout = 0.0001
@@ -389,7 +389,7 @@ describe UNIXSocket do
     end
   end
 
-  it "tests socket options" do
+  it("tests socket options") do
     UNIXSocket.pair do |left, right|
       size = 12000
       # linux returns size * 2
@@ -404,8 +404,8 @@ describe UNIXSocket do
   end
 end
 
-describe TCPServer do
-  it "creates a raw socket" do
+describe(TCPServer) do
+  it("creates a raw socket") do
     sock = TCPServer.new
     sock.family.should eq(Socket::Family::INET)
 
@@ -413,10 +413,10 @@ describe TCPServer do
     sock.family.should eq(Socket::Family::INET6)
   end
 
-  it "fails when port is in use" do
+  it("fails when port is in use") do
     port = free_udp_socket_port
 
-    expect_raises Errno, /(already|Address) in use/ do
+    expect_raises(Errno, /(already|Address) in use/) do
       sock = Socket.tcp(Socket::Family::INET6)
       sock.bind(Socket::IPAddress.new("::1", port))
 
@@ -424,7 +424,7 @@ describe TCPServer do
     end
   end
 
-  it "doesn't reuse the TCP port by default (SO_REUSEPORT)" do
+  it("doesn't reuse the TCP port by default (SO_REUSEPORT)") do
     TCPServer.open("::", 0) do |server|
       expect_raises(Errno) do
         TCPServer.open("::", server.local_address.port) { }
@@ -432,15 +432,15 @@ describe TCPServer do
     end
   end
 
-  it "reuses the TCP port (SO_REUSEPORT)" do
+  it("reuses the TCP port (SO_REUSEPORT)") do
     TCPServer.open("::", 0, reuse_port: true) do |server|
       TCPServer.open("::", server.local_address.port, reuse_port: true) { }
     end
   end
 end
 
-describe TCPSocket do
-  it "creates a raw socket" do
+describe(TCPSocket) do
+  it("creates a raw socket") do
     sock = TCPSocket.new
     sock.family.should eq(Socket::Family::INET)
 
@@ -448,7 +448,7 @@ describe TCPSocket do
     sock.family.should eq(Socket::Family::INET6)
   end
 
-  it "sends and receives messages" do
+  it("sends and receives messages") do
     port = TCPServer.open("::", 0) do |server|
       server.local_address.port
     end
@@ -527,7 +527,7 @@ describe TCPSocket do
     end
   end
 
-  it "fails when connection is refused" do
+  it("fails when connection is refused") do
     port = TCPServer.open("localhost", 0) do |server|
       server.local_address.port
     end
@@ -537,21 +537,21 @@ describe TCPSocket do
     end
   end
 
-  it "fails when host doesn't exist" do
+  it("fails when host doesn't exist") do
     expect_raises(Socket::Error, /No address/i) do
       TCPSocket.new("doesnotexist.example.org.", 12345)
     end
   end
 
-  it "fails (rather than segfault on darwin) when host doesn't exist and port is 0" do
+  it("fails (rather than segfault on darwin) when host doesn't exist and port is 0") do
     expect_raises(Socket::Error, /No address/i) do
       TCPSocket.new("doesnotexist.example.org.", 0)
     end
   end
 end
 
-describe UDPSocket do
-  it "creates a raw socket" do
+describe(UDPSocket) do
+  it("creates a raw socket") do
     sock = UDPSocket.new
     sock.family.should eq(Socket::Family::INET)
 
@@ -559,7 +559,7 @@ describe UDPSocket do
     sock.family.should eq(Socket::Family::INET6)
   end
 
-  it "reads and writes data to server" do
+  it("reads and writes data to server") do
     port = free_udp_socket_port
 
     server = UDPSocket.new(Socket::Family::INET6)
@@ -579,7 +579,7 @@ describe UDPSocket do
     server.close
   end
 
-  it "sends and receives messages over IPv4" do
+  it("sends and receives messages over IPv4") do
     buffer = uninitialized UInt8[256]
 
     server = UDPSocket.new(Socket::Family::INET)
@@ -610,7 +610,7 @@ describe UDPSocket do
     client.close
   end
 
-  it "sends and receives messages over IPv6" do
+  it("sends and receives messages over IPv6") do
     buffer = uninitialized UInt8[1500]
 
     server = UDPSocket.new(Socket::Family::INET6)
@@ -634,7 +634,7 @@ describe UDPSocket do
     client.close
   end
 
-  it "broadcasts messages" do
+  it("broadcasts messages") do
     port = free_udp_socket_port
 
     client = UDPSocket.new(Socket::Family::INET)

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "JUnit Formatter" do
-  it "reports successful results" do
+describe("JUnit Formatter") do
+  it("reports successful results") do
     output = build_report do |f|
       f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil, nil)
       f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil, nil)
@@ -18,7 +18,7 @@ describe "JUnit Formatter" do
     output.chomp.should eq(expected)
   end
 
-  it "reports failures" do
+  it("reports failures") do
     output = build_report do |f|
       f.report Spec::Result.new(:fail, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
@@ -35,7 +35,7 @@ describe "JUnit Formatter" do
     output.chomp.should eq(expected)
   end
 
-  it "reports errors" do
+  it("reports errors") do
     output = build_report do |f|
       f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
@@ -52,7 +52,7 @@ describe "JUnit Formatter" do
     output.chomp.should eq(expected)
   end
 
-  it "reports mixed results" do
+  it("reports mixed results") do
     output = build_report do |f|
       f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, 2.seconds, nil)
       f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, 0.5.seconds, nil)
@@ -79,7 +79,7 @@ describe "JUnit Formatter" do
     output.chomp.should eq(expected)
   end
 
-  it "escapes spec names" do
+  it("escapes spec names") do
     output = build_report do |f|
       f.report Spec::Result.new(:success, "complicated \" <n>'&ame", __FILE__, __LINE__, nil, nil)
     end
@@ -88,7 +88,7 @@ describe "JUnit Formatter" do
     name.should eq("complicated \" <n>'&ame")
   end
 
-  it "report failure stacktrace if present" do
+  it("report failure stacktrace if present") do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|
@@ -103,7 +103,7 @@ describe "JUnit Formatter" do
     backtrace.should eq(cause.backtrace.join("\n"))
   end
 
-  it "report error stacktrace if present" do
+  it("report error stacktrace if present") do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -8,101 +8,101 @@ private class SpecException < Exception
   end
 end
 
-describe "Spec matchers" do
-  describe "should be_truthy" do
-    it "passes for true" do
+describe("Spec matchers") do
+  describe("should be_truthy") do
+    it("passes for true") do
       true.should be_truthy
     end
 
-    it "passes for some non-nil, non-false value" do
+    it("passes for some non-nil, non-false value") do
       42.should be_truthy
     end
   end
 
-  describe "should_not be_truthy" do
-    it "passes for false" do
+  describe("should_not be_truthy") do
+    it("passes for false") do
       false.should_not be_truthy
     end
 
-    it "passes for nil" do
+    it("passes for nil") do
       nil.should_not be_truthy
     end
   end
 
-  describe "should be_falsey" do
-    it "passes for false" do
+  describe("should be_falsey") do
+    it("passes for false") do
       false.should be_falsey
     end
 
-    it "passes for nil" do
+    it("passes for nil") do
       nil.should be_falsey
     end
   end
 
-  describe "should_not be_falsey" do
-    it "passses for true" do
+  describe("should_not be_falsey") do
+    it("passses for true") do
       true.should_not be_falsey
     end
 
-    it "passes for some non-nil, non-false value" do
+    it("passes for some non-nil, non-false value") do
       42.should_not be_falsey
     end
   end
 
-  describe "should contain" do
-    it "passes when string includes? specified substring" do
+  describe("should contain") do
+    it("passes when string includes? specified substring") do
       "hello world!".should contain("hello")
     end
 
-    it "works with array" do
+    it("works with array") do
       [1, 2, 3, 5, 8].should contain(5)
     end
 
-    it "works with set" do
+    it("works with set") do
       [1, 2, 3, 5, 8].to_set.should contain(8)
     end
 
-    it "works with range" do
+    it("works with range") do
       (50..55).should contain(53)
     end
 
-    it "does not pass when string does not includes? specified substring" do
-      expect_raises Spec::AssertionFailed, %{Expected:   "hello world!"\nto include: "crystal"} do
+    it("does not pass when string does not includes? specified substring") do
+      expect_raises(Spec::AssertionFailed, %{Expected:   "hello world!"\nto include: "crystal"}) do
         "hello world!".should contain("crystal")
       end
     end
   end
 
-  describe "should_not contain" do
-    it "passes when string does not includes? specified substring" do
+  describe("should_not contain") do
+    it("passes when string does not includes? specified substring") do
       "hello world!".should_not contain("crystal")
     end
 
-    it "does not pass when string does not includes? specified substring" do
-      expect_raises Spec::AssertionFailed, %{Expected: value "hello world!"\nto not include: "world"} do
+    it("does not pass when string does not includes? specified substring") do
+      expect_raises(Spec::AssertionFailed, %{Expected: value "hello world!"\nto not include: "world"}) do
         "hello world!".should_not contain("world")
       end
     end
   end
 
-  describe "expect_raises" do
-    it "return exception" do
+  describe("expect_raises") do
+    it("return exception") do
       ex = expect_raises(SpecException) { raise SpecException.new(11, "O_o") }
       ex.value.should eq 11
       ex.message.should eq "O_o"
     end
   end
 
-  context "should work like describe" do
-    it "is true" do
+  context("should work like describe") do
+    it("is true") do
       true.should be_truthy
     end
   end
 end
 
-describe "Spec" do
-  describe "use_colors?" do
-    it "returns if output is colored or not" do
+describe("Spec") do
+  describe("use_colors?") do
+    it("returns if output is colored or not") do
       saved = Spec.use_colors?
       begin
         Spec.use_colors = false

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -1,12 +1,12 @@
 require "spec"
 
-describe "StaticArray" do
-  it "creates with new" do
+describe("StaticArray") do
+  it("creates with new") do
     a = StaticArray(Int32, 3).new 0
     a.size.should eq(3)
   end
 
-  it "creates with new and value" do
+  it("creates with new and value") do
     a = StaticArray(Int32, 3).new 1
     a.size.should eq(3)
     a[0].should eq(1)
@@ -14,7 +14,7 @@ describe "StaticArray" do
     a[2].should eq(1)
   end
 
-  it "creates with new and block" do
+  it("creates with new and block") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.size.should eq(3)
     a[0].should eq(1)
@@ -22,64 +22,64 @@ describe "StaticArray" do
     a[2].should eq(3)
   end
 
-  it "raises index out of bounds on read" do
+  it("raises index out of bounds on read") do
     a = StaticArray(Int32, 3).new 0
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       a[4]
     end
   end
 
-  it "raises index out of bounds on write" do
+  it("raises index out of bounds on write") do
     a = StaticArray(Int32, 3).new 0
-    expect_raises IndexError do
+    expect_raises(IndexError) do
       a[4] = 1
     end
   end
 
-  it "allows using negative indices" do
+  it("allows using negative indices") do
     a = StaticArray(Int32, 3).new 0
     a[-1] = 2
     a[-1].should eq(2)
     a[2].should eq(2)
   end
 
-  describe "==" do
-    it "compares empty" do
+  describe("==") do
+    it("compares empty") do
       (StaticArray(Int32, 0).new(0)).should eq(StaticArray(Int32, 0).new(0))
       (StaticArray(Int32, 1).new(0)).should_not eq(StaticArray(Int32, 0).new(0))
       (StaticArray(Int32, 0).new(0)).should_not eq(StaticArray(Int32, 1).new(0))
     end
 
-    it "compares elements" do
+    it("compares elements") do
       a = StaticArray(Int32, 3).new { |i| i * 2 }
       a.should eq(StaticArray(Int32, 3).new { |i| i * 2 })
       a.should_not eq(StaticArray(Int32, 3).new { |i| i * 3 })
     end
 
-    it "compares other" do
+    it("compares other") do
       (StaticArray(Int32, 0).new(0)).should_not eq(nil)
       (StaticArray(Int32, 3).new(0)).should eq(StaticArray(Int8, 3).new(0_i8))
     end
   end
 
-  describe "values_at" do
-    it "returns the given indexes" do
+  describe("values_at") do
+    it("returns the given indexes") do
       StaticArray(Int32, 4).new { |i| i + 1 }.values_at(1, 0, 2).should eq({2, 1, 3})
     end
 
-    it "raises when passed an invalid index" do
-      expect_raises IndexError do
+    it("raises when passed an invalid index") do
+      expect_raises(IndexError) do
         StaticArray(Int32, 1).new { |i| i + 1 }.values_at(10)
       end
     end
   end
 
-  it "does to_s" do
+  it("does to_s") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.to_s.should eq("StaticArray[1, 2, 3]")
   end
 
-  it "shuffles" do
+  it("shuffles") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.shuffle!
 
@@ -90,7 +90,7 @@ describe "StaticArray" do
     end
   end
 
-  it "shuffles with a seed" do
+  it("shuffles with a seed") do
     a = StaticArray(Int32, 10).new { |i| i + 1 }
     b = StaticArray(Int32, 10).new { |i| i + 1 }
     a.shuffle!(Random.new(42))
@@ -101,7 +101,7 @@ describe "StaticArray" do
     end
   end
 
-  it "reverse" do
+  it("reverse") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.reverse!
     a[0].should eq(3)
@@ -109,7 +109,7 @@ describe "StaticArray" do
     a[2].should eq(1)
   end
 
-  it "maps!" do
+  it("maps!") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.map! { |i| i + 1 }
     a[0].should eq(2)
@@ -117,7 +117,7 @@ describe "StaticArray" do
     a[2].should eq(4)
   end
 
-  it "map_with_index!" do
+  it("map_with_index!") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.map_with_index! { |e, i| i * 2 }
     a[0].should eq(0)
@@ -126,7 +126,7 @@ describe "StaticArray" do
     a.should be_a(StaticArray(Int32, 3))
   end
 
-  it "updates value" do
+  it("updates value") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.update(1) { |x| x * 2 }
     a[0].should eq(1)
@@ -134,14 +134,14 @@ describe "StaticArray" do
     a[2].should eq(3)
   end
 
-  it "clones" do
+  it("clones") do
     a = StaticArray(Array(Int32), 1).new { |i| [1] }
     b = a.clone
     b[0].should eq(a[0])
     b[0].should_not be(a[0])
   end
 
-  it "iterates with each" do
+  it("iterates with each") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     iter = a.each
     iter.next.should eq(1)
@@ -156,7 +156,7 @@ describe "StaticArray" do
     iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
   end
 
-  it "iterates with reverse each" do
+  it("iterates with reverse each") do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     iter = a.reverse_each
     iter.next.should eq(3)

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe String::Builder do
-  it "builds" do
+describe(String::Builder) do
+  it("builds") do
     str = String::Builder.build do |builder|
       builder << 123
       builder << 456
@@ -11,7 +11,7 @@ describe String::Builder do
     str.bytesize.should eq(6)
   end
 
-  it "raises if invokes to_s twice" do
+  it("raises if invokes to_s twice") do
     builder = String::Builder.new
     builder << 123
     builder.to_s.should eq("123")
@@ -19,7 +19,7 @@ describe String::Builder do
     expect_raises { builder.to_s }
   end
 
-  it "goes back" do
+  it("goes back") do
     s = String::Builder.build do |str|
       str << 12
       str.back(1)
@@ -27,7 +27,7 @@ describe String::Builder do
     s.should eq("1")
   end
 
-  it "goes back all" do
+  it("goes back all") do
     s = String::Builder.build do |str|
       str << 12
       str.back(2)

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -1,14 +1,14 @@
 require "spec"
 require "string_pool"
 
-describe StringPool do
-  it "is empty" do
+describe(StringPool) do
+  it("is empty") do
     pool = StringPool.new
     pool.empty?.should be_true
     pool.size.should eq(0)
   end
 
-  it "gets string" do
+  it("gets string") do
     pool = StringPool.new
     s1 = pool.get "foo"
     s2 = pool.get "foo"
@@ -19,7 +19,7 @@ describe StringPool do
     pool.size.should eq(1)
   end
 
-  it "gets string IO" do
+  it("gets string IO") do
     pool = StringPool.new
     io = IO::Memory.new "foo"
 
@@ -32,7 +32,7 @@ describe StringPool do
     pool.size.should eq(1)
   end
 
-  it "gets slice" do
+  it("gets slice") do
     pool = StringPool.new
     slice = Bytes.new(3, 'a'.ord.to_u8)
 
@@ -45,7 +45,7 @@ describe StringPool do
     pool.size.should eq(1)
   end
 
-  it "gets pointer with size" do
+  it("gets pointer with size") do
     pool = StringPool.new
     slice = Bytes.new(3, 'a'.ord.to_u8)
 
@@ -58,7 +58,7 @@ describe StringPool do
     pool.size.should eq(1)
   end
 
-  it "puts many" do
+  it("puts many") do
     pool = StringPool.new
     10_000.times do |i|
       pool.get(i.to_s)

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "string_scanner"
 
-describe StringScanner, "#scan" do
-  it "returns the string matched and advances the offset" do
+describe(StringScanner, "#scan") do
+  it("returns the string matched and advances the offset") do
     s = StringScanner.new("this is a string")
     s.scan(/\w+\s/).should eq("this ")
     s.scan(/\w+\s/).should eq("is ")
@@ -10,7 +10,7 @@ describe StringScanner, "#scan" do
     s.scan(/\w+/).should eq("string")
   end
 
-  it "returns nil if it can't match from the offset" do
+  it("returns nil if it can't match from the offset") do
     s = StringScanner.new("test string")
     s.scan(/\w+/).should_not be_nil # => "test"
     s.scan(/\w+/).should be_nil
@@ -19,23 +19,23 @@ describe StringScanner, "#scan" do
   end
 end
 
-describe StringScanner, "#scan_until" do
-  it "returns the string matched and advances the offset" do
+describe(StringScanner, "#scan_until") do
+  it("returns the string matched and advances the offset") do
     s = StringScanner.new("test string")
     s.scan_until(/tr/).should eq("test str")
     s.offset.should eq(8)
     s.scan_until(/g/).should eq("ing")
   end
 
-  it "returns nil if it can't match from the offset" do
+  it("returns nil if it can't match from the offset") do
     s = StringScanner.new("test string")
     s.offset = 8
     s.scan_until(/tr/).should be_nil
   end
 end
 
-describe StringScanner, "#skip" do
-  it "advances the offset but does not returns the string matched" do
+describe(StringScanner, "#skip") do
+  it("advances the offset but does not returns the string matched") do
     s = StringScanner.new("this is a string")
 
     s.skip(/\w+\s/).should eq(5)
@@ -56,8 +56,8 @@ describe StringScanner, "#skip" do
   end
 end
 
-describe StringScanner, "#skip_until" do
-  it "advances the offset but does not returns the string matched" do
+describe(StringScanner, "#skip_until") do
+  it("advances the offset but does not returns the string matched") do
     s = StringScanner.new("this is a string")
 
     s.skip_until(/not/).should eq(nil)
@@ -73,8 +73,8 @@ describe StringScanner, "#skip_until" do
   end
 end
 
-describe StringScanner, "#eos" do
-  it "it is true when the offset is at the end" do
+describe(StringScanner, "#eos") do
+  it("it is true when the offset is at the end") do
     s = StringScanner.new("this is a string")
     s.eos?.should eq(false)
     s.skip(/(\w+\s?){4}/)
@@ -82,8 +82,8 @@ describe StringScanner, "#eos" do
   end
 end
 
-describe StringScanner, "#check" do
-  it "returns the string matched but does not advances the offset" do
+describe(StringScanner, "#check") do
+  it("returns the string matched but does not advances the offset") do
     s = StringScanner.new("this is a string")
     s.offset = 5
 
@@ -93,14 +93,14 @@ describe StringScanner, "#check" do
     s.offset.should eq(5)
   end
 
-  it "returns nil if it can't match from the offset" do
+  it("returns nil if it can't match from the offset") do
     s = StringScanner.new("test string")
     s.check(/\d+/).should be_nil
   end
 end
 
-describe StringScanner, "#check_until" do
-  it "returns the string matched and advances the offset" do
+describe(StringScanner, "#check_until") do
+  it("returns the string matched and advances the offset") do
     s = StringScanner.new("test string")
     s.check_until(/tr/).should eq("test str")
     s.offset.should eq(0)
@@ -108,15 +108,15 @@ describe StringScanner, "#check_until" do
     s.offset.should eq(0)
   end
 
-  it "returns nil if it can't match from the offset" do
+  it("returns nil if it can't match from the offset") do
     s = StringScanner.new("test string")
     s.offset = 8
     s.check_until(/tr/).should be_nil
   end
 end
 
-describe StringScanner, "#rest" do
-  it "returns the remainder of the string from the offset" do
+describe(StringScanner, "#rest") do
+  it("returns the remainder of the string from the offset") do
     s = StringScanner.new("this is a string")
     s.rest.should eq("this is a string")
 
@@ -128,8 +128,8 @@ describe StringScanner, "#rest" do
   end
 end
 
-describe StringScanner, "#[]" do
-  it "allows access to subgroups of the last match" do
+describe(StringScanner, "#[]") do
+  it("allows access to subgroups of the last match") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
     s.scan(regex).should eq("Fri Dec 12")
@@ -142,14 +142,14 @@ describe StringScanner, "#[]" do
     s["day"].should eq("12")
   end
 
-  it "raises when there is no last match" do
+  it("raises when there is no last match") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     s.scan(/this is not there/)
 
     expect_raises { s[0] }
   end
 
-  it "raises when there is no subgroup" do
+  it("raises when there is no subgroup") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
     s.scan(regex)
@@ -160,8 +160,8 @@ describe StringScanner, "#[]" do
   end
 end
 
-describe StringScanner, "#[]?" do
-  it "allows access to subgroups of the last match" do
+describe(StringScanner, "#[]?") do
+  it("allows access to subgroups of the last match") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     result = s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
 
@@ -175,14 +175,14 @@ describe StringScanner, "#[]?" do
     s["day"]?.should eq("12")
   end
 
-  it "returns nil when there is no last match" do
+  it("returns nil when there is no last match") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     s.scan(/this is not there/)
 
     s[0]?.should be_nil
   end
 
-  it "raises when there is no subgroup" do
+  it("raises when there is no subgroup") do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
 
@@ -192,12 +192,12 @@ describe StringScanner, "#[]?" do
   end
 end
 
-describe StringScanner, "#string" do
+describe(StringScanner, "#string") do
   it { StringScanner.new("foo").string.should eq("foo") }
 end
 
-describe StringScanner, "#offset" do
-  it "returns the current position" do
+describe(StringScanner, "#offset") do
+  it("returns the current position") do
     s = StringScanner.new("this is a string")
     s.offset.should eq(0)
     s.scan(/\w+/)
@@ -205,21 +205,21 @@ describe StringScanner, "#offset" do
   end
 end
 
-describe StringScanner, "#offset=" do
-  it "sets the current position" do
+describe(StringScanner, "#offset=") do
+  it("sets the current position") do
     s = StringScanner.new("this is a string")
     s.offset = 5
     s.scan(/\w+/).should eq("is")
   end
 
-  it "raises on negative positions" do
+  it("raises on negative positions") do
     s = StringScanner.new("this is a string")
     expect_raises(IndexError) { s.offset = -2 }
   end
 end
 
-describe StringScanner, "#inspect" do
-  it "has information on the scanner" do
+describe(StringScanner, "#inspect") do
+  it("has information on the scanner") do
     s = StringScanner.new("this is a string")
     s.inspect.should eq(%(#<StringScanner 0/16 "this " >))
     s.scan(/\w+\s/)
@@ -230,7 +230,7 @@ describe StringScanner, "#inspect" do
     s.inspect.should eq(%(#<StringScanner 16/16 "tring" >))
   end
 
-  it "works with small strings" do
+  it("works with small strings") do
     s = StringScanner.new("hi")
     s.inspect.should eq(%(#<StringScanner 0/2 "hi" >))
     s.scan(/\w\w/)
@@ -238,8 +238,8 @@ describe StringScanner, "#inspect" do
   end
 end
 
-describe StringScanner, "#peek" do
-  it "shows the next len characters without advancing the offset" do
+describe(StringScanner, "#peek") do
+  it("shows the next len characters without advancing the offset") do
     s = StringScanner.new("this is a string")
     s.offset.should eq(0)
     s.peek(4).should eq("this")
@@ -249,8 +249,8 @@ describe StringScanner, "#peek" do
   end
 end
 
-describe StringScanner, "#reset" do
-  it "resets the scan offset to the beginning and clears the last match" do
+describe(StringScanner, "#reset") do
+  it("resets the scan offset to the beginning and clears the last match") do
     s = StringScanner.new("this is a string")
     s.scan_until(/str/)
     s[0]?.should_not be_nil
@@ -262,8 +262,8 @@ describe StringScanner, "#reset" do
   end
 end
 
-describe StringScanner, "#terminate" do
-  it "moves the scan offset to the end of the string and clears the last match" do
+describe(StringScanner, "#terminate") do
+  it("moves the scan offset to the end of the string and clears the last match") do
     s = StringScanner.new("this is a string")
     s.scan_until(/str/)
     s[0]?.should_not be_nil

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1,46 +1,46 @@
 require "spec"
 
-describe "String" do
-  describe "[]" do
-    it "gets with positive index" do
+describe("String") do
+  describe("[]") do
+    it("gets with positive index") do
       c = "hello!"[1]
       c.should be_a(Char)
       c.should eq('e')
     end
 
-    it "gets with negative index" do
+    it("gets with negative index") do
       "hello!"[-1].should eq('!')
     end
 
-    it "gets with inclusive range" do
+    it("gets with inclusive range") do
       "hello!"[1..4].should eq("ello")
     end
 
-    it "gets with inclusive range with negative indices" do
+    it("gets with inclusive range with negative indices") do
       "hello!"[-5..-2].should eq("ello")
     end
 
-    it "gets with exclusive range" do
+    it("gets with exclusive range") do
       "hello!"[1...4].should eq("ell")
     end
 
-    it "gets with start and count" do
+    it("gets with start and count") do
       "hello"[1, 3].should eq("ell")
     end
 
-    it "gets with exclusive range with unicode" do
+    it("gets with exclusive range with unicode") do
       "há日本語"[1..3].should eq("á日本")
     end
 
-    it "gets when index is last and count is zero" do
+    it("gets when index is last and count is zero") do
       "foo"[3, 0].should eq("")
     end
 
-    it "gets when index is last and count is positive" do
+    it("gets when index is last and count is positive") do
       "foo"[3, 10].should eq("")
     end
 
-    it "gets when index is last and count is negative at last" do
+    it("gets when index is last and count is negative at last") do
       expect_raises(ArgumentError) do
         "foo"[3, -1]
       end
@@ -48,79 +48,79 @@ describe "String" do
 
     it { "foo"[3..-10].should eq("") }
 
-    it "gets when index is last and count is negative at last with utf-8" do
+    it("gets when index is last and count is negative at last with utf-8") do
       expect_raises(ArgumentError) do
         "há日本語"[5, -1]
       end
     end
 
-    it "gets when index is last and count is zero in utf-8" do
+    it("gets when index is last and count is zero in utf-8") do
       "há日本語"[5, 0].should eq("")
     end
 
-    it "gets when index is last and count is positive in utf-8" do
+    it("gets when index is last and count is positive in utf-8") do
       "há日本語"[5, 10].should eq("")
     end
 
-    it "raises index out of bound on index out of range with range" do
+    it("raises index out of bound on index out of range with range") do
       expect_raises(IndexError) do
         "foo"[4..1]
       end
     end
 
-    it "raises index out of bound on index out of range with range and utf-8" do
+    it("raises index out of bound on index out of range with range and utf-8") do
       expect_raises(IndexError) do
         "há日本語"[6..1]
       end
     end
 
-    it "gets with exclusive with start and count" do
+    it("gets with exclusive with start and count") do
       "há日本語"[1, 3].should eq("á日本")
     end
 
-    it "gets with exclusive with start and count to end" do
+    it("gets with exclusive with start and count to end") do
       "há日本語"[1, 4].should eq("á日本語")
     end
 
-    it "gets with start and count with negative start" do
+    it("gets with start and count with negative start") do
       "こんいちは"[-3, 2].should eq("いち")
     end
 
-    it "raises if index out of bounds" do
+    it("raises if index out of bounds") do
       expect_raises(IndexError) do
         "foo"[4, 1]
       end
     end
 
-    it "raises if index out of bounds with utf-8" do
+    it("raises if index out of bounds with utf-8") do
       expect_raises(IndexError) do
         "こんいちは"[6, 1]
       end
     end
 
-    it "raises if count is negative" do
+    it("raises if count is negative") do
       expect_raises(ArgumentError) do
         "foo"[1, -1]
       end
     end
 
-    it "raises if count is negative with utf-8" do
+    it("raises if count is negative with utf-8") do
       expect_raises(ArgumentError) do
         "こんいちは"[3, -1]
       end
     end
 
-    it "gets with single char" do
+    it("gets with single char") do
       ";"[0..-2].should eq("")
     end
 
-    it "raises on too negative left bound" do
-      expect_raises IndexError do
+    it("raises on too negative left bound") do
+      expect_raises(IndexError) do
         "foo"[-4..0]
       end
     end
 
-    describe "with a regex" do
+    describe("with a regex") do
       it { "FooBar"[/o+/].should eq "oo" }
       it { "FooBar"[/([A-Z])/, 1].should eq "F" }
       it { "FooBar"[/x/]?.should be_nil }
@@ -131,21 +131,21 @@ describe "String" do
       it { "FooBar"[/(?<this>x)/, "that"]?.should be_nil }
     end
 
-    it "gets with a string" do
+    it("gets with a string") do
       "FooBar"["Bar"].should eq "Bar"
       expect_raises { "FooBar"["Baz"] }
       "FooBar"["Bar"]?.should eq "Bar"
       "FooBar"["Baz"]?.should be_nil
     end
 
-    it "gets with a char" do
+    it("gets with a char") do
       "foo/bar"['/'].should eq '/'
       expect_raises { "foo/bar"['-'] }
       "foo/bar"['/']?.should eq '/'
       "foo/bar"['-']?.should be_nil
     end
 
-    it "gets with index and []?" do
+    it("gets with index and []?") do
       "hello"[1]?.should eq('e')
       "hello"[5]?.should be_nil
       "hello"[-1]?.should eq('o')
@@ -153,39 +153,39 @@ describe "String" do
     end
   end
 
-  describe "byte_slice" do
-    it "gets byte_slice" do
+  describe("byte_slice") do
+    it("gets byte_slice") do
       "hello".byte_slice(1, 3).should eq("ell")
     end
 
-    it "gets byte_slice with negative count" do
+    it("gets byte_slice with negative count") do
       expect_raises(ArgumentError) do
         "hello".byte_slice(1, -10)
       end
     end
 
-    it "gets byte_slice with negative count at last" do
+    it("gets byte_slice with negative count at last") do
       expect_raises(ArgumentError) do
         "hello".byte_slice(5, -1)
       end
     end
 
-    it "gets byte_slice with start out of bounds" do
+    it("gets byte_slice with start out of bounds") do
       expect_raises(IndexError) do
         "hello".byte_slice(10, 3)
       end
     end
 
-    it "gets byte_slice with large count" do
+    it("gets byte_slice with large count") do
       "hello".byte_slice(1, 10).should eq("ello")
     end
 
-    it "gets byte_slice with negative index" do
+    it("gets byte_slice with negative index") do
       "hello".byte_slice(-2, 3).should eq("lo")
     end
   end
 
-  describe "i" do
+  describe("i") do
     it { "1234".to_i.should eq(1234) }
     it { "   +1234   ".to_i.should eq(1234) }
     it { "   -1234   ".to_i.should eq(-1234) }
@@ -222,7 +222,7 @@ describe "String" do
     it { "1z".to_i(62).should eq(97) }
     it { "ZZ".to_i(62).should eq(3843) }
 
-    describe "to_i8" do
+    describe("to_i8") do
       it { "127".to_i8.should eq(127) }
       it { "-128".to_i8.should eq(-128) }
       it { expect_raises(ArgumentError) { "128".to_i8 } }
@@ -235,7 +235,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_i8 } }
     end
 
-    describe "to_u8" do
+    describe("to_u8") do
       it { "255".to_u8.should eq(255) }
       it { "0".to_u8.should eq(0) }
       it { expect_raises(ArgumentError) { "256".to_u8 } }
@@ -248,7 +248,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_u8 } }
     end
 
-    describe "to_i16" do
+    describe("to_i16") do
       it { "32767".to_i16.should eq(32767) }
       it { "-32768".to_i16.should eq(-32768) }
       it { expect_raises(ArgumentError) { "32768".to_i16 } }
@@ -261,7 +261,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_i16 } }
     end
 
-    describe "to_u16" do
+    describe("to_u16") do
       it { "65535".to_u16.should eq(65535) }
       it { "0".to_u16.should eq(0) }
       it { expect_raises(ArgumentError) { "65536".to_u16 } }
@@ -274,7 +274,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_u16 } }
     end
 
-    describe "to_i32" do
+    describe("to_i32") do
       it { "2147483647".to_i32.should eq(2147483647) }
       it { "-2147483648".to_i32.should eq(-2147483648) }
       it { expect_raises(ArgumentError) { "2147483648".to_i32 } }
@@ -287,7 +287,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_i32 } }
     end
 
-    describe "to_u32" do
+    describe("to_u32") do
       it { "4294967295".to_u32.should eq(4294967295) }
       it { "0".to_u32.should eq(0) }
       it { expect_raises(ArgumentError) { "4294967296".to_u32 } }
@@ -300,7 +300,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_u32 } }
     end
 
-    describe "to_i64" do
+    describe("to_i64") do
       it { "9223372036854775807".to_i64.should eq(9223372036854775807) }
       it { "-9223372036854775808".to_i64.should eq(-9223372036854775808) }
       it { expect_raises(ArgumentError) { "9223372036854775808".to_i64 } }
@@ -313,7 +313,7 @@ describe "String" do
       it { expect_raises(ArgumentError) { "18446744073709551616".to_i64 } }
     end
 
-    describe "to_u64" do
+    describe("to_u64") do
       it { "18446744073709551615".to_u64.should eq(18446744073709551615) }
       it { "0".to_u64.should eq(0) }
       it { expect_raises(ArgumentError) { "18446744073709551616".to_u64 } }
@@ -335,7 +335,7 @@ describe "String" do
     it { "1Y2P0IJ32E8E7".to_i64(36).should eq(9223372036854775807) }
   end
 
-  it "does to_f" do
+  it("does to_f") do
     expect_raises(ArgumentError) { "".to_f }
     "".to_f?.should be_nil
     expect_raises(ArgumentError) { " ".to_f }
@@ -363,7 +363,7 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
   end
 
-  it "does to_f32" do
+  it("does to_f32") do
     expect_raises(ArgumentError) { "".to_f32 }
     "".to_f32?.should be_nil
     expect_raises(ArgumentError) { " ".to_f32 }
@@ -391,7 +391,7 @@ describe "String" do
     "x1.2".to_f32?(strict: false).should be_nil
   end
 
-  it "does to_f64" do
+  it("does to_f64") do
     expect_raises(ArgumentError) { "".to_f64 }
     "".to_f64?.should be_nil
     expect_raises(ArgumentError) { " ".to_f64 }
@@ -419,24 +419,24 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
   end
 
-  it "compares strings: different size" do
+  it("compares strings: different size") do
     "foo".should_not eq("fo")
   end
 
-  it "compares strings: same object" do
+  it("compares strings: same object") do
     f = "foo"
     f.should eq(f)
   end
 
-  it "compares strings: same size, same string" do
+  it("compares strings: same size, same string") do
     "foo".should eq("fo" + "o")
   end
 
-  it "compares strings: same size, different string" do
+  it("compares strings: same size, different string") do
     "foo".should_not eq("bar")
   end
 
-  it "interpolates string" do
+  it("interpolates string") do
     foo = "<foo>"
     bar = 123
     "foo #{bar}".should eq("foo 123")
@@ -444,25 +444,25 @@ describe "String" do
     "#{foo} bar".should eq("<foo> bar")
   end
 
-  it "multiplies" do
+  it("multiplies") do
     str = "foo"
     (str * 0).should eq("")
     (str * 3).should eq("foofoofoo")
   end
 
-  it "multiplies with size one" do
+  it("multiplies with size one") do
     str = "f"
     (str * 0).should eq("")
     (str * 10).should eq("ffffffffff")
   end
 
-  it "multiplies with negative size" do
+  it("multiplies with negative size") do
     expect_raises(ArgumentError, "Negative argument") do
       "f" * -1
     end
   end
 
-  describe "downcase" do
+  describe("downcase") do
     it { "HELLO!".downcase.should eq("hello!") }
     it { "HELLO MAN!".downcase.should eq("hello man!") }
     it { "ÁÉÍÓÚĀ".downcase.should eq("áéíóúā") }
@@ -475,7 +475,7 @@ describe "String" do
     it { "ΣίσυφοςﬁÆ".downcase(Unicode::CaseOptions::Fold).should eq("σίσυφοσfiæ") }
   end
 
-  describe "upcase" do
+  describe("upcase") do
     it { "hello!".upcase.should eq("HELLO!") }
     it { "hello man!".upcase.should eq("HELLO MAN!") }
     it { "áéíóúā".upcase.should eq("ÁÉÍÓÚĀ") }
@@ -486,7 +486,7 @@ describe "String" do
     it { "ﬀ".upcase.should eq("FF") }
   end
 
-  describe "capitalize" do
+  describe("capitalize") do
     it { "HELLO!".capitalize.should eq("Hello!") }
     it { "HELLO MAN!".capitalize.should eq("Hello man!") }
     it { "".capitalize.should eq("") }
@@ -494,7 +494,7 @@ describe "String" do
     it { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
   end
 
-  describe "chomp" do
+  describe("chomp") do
     it { "hello\n".chomp.should eq("hello") }
     it { "hello\r".chomp.should eq("hello") }
     it { "hello\r\n".chomp.should eq("hello") }
@@ -520,7 +520,7 @@ describe "String" do
     it { "hello\r\n".chomp("\n").should eq("hello") }
   end
 
-  describe "rchop" do
+  describe("rchop") do
     it { "".rchop.should eq("") }
     it { "foo".rchop.should eq("fo") }
     it { "foo\n".rchop.should eq("foo") }
@@ -538,7 +538,7 @@ describe "String" do
     it { "foobar".rchop("baz").should eq("foobar") }
   end
 
-  describe "lchomp" do
+  describe("lchomp") do
     it { "".lchop.should eq("") }
     it { "h".lchop.should eq("") }
     it { "hello".lchop.should eq("ello") }
@@ -555,7 +555,7 @@ describe "String" do
     it { "\n\n\n\nhello".lchop("").should eq("\n\n\n\nhello") }
   end
 
-  describe "strip" do
+  describe("strip") do
     it { "  hello  \n\t\f\v\r".strip.should eq("hello") }
     it { "hello".strip.should eq("hello") }
     it { "かたな \n\f\v".strip.should eq("かたな") }
@@ -588,7 +588,7 @@ describe "String" do
     it { "ababcdaba".strip { |c| c == 'a' || c == 'b' }.should eq("cd") }
   end
 
-  describe "rstrip" do
+  describe("rstrip") do
     it { "".rstrip.should eq("") }
     it { "  hello  ".rstrip.should eq("  hello") }
     it { "hello".rstrip.should eq("hello") }
@@ -609,7 +609,7 @@ describe "String" do
     it { "foobar".rstrip { |c| c == 'a' || c == 'r' }.should eq("foob") }
   end
 
-  describe "lstrip" do
+  describe("lstrip") do
     it { "  hello  ".lstrip.should eq("hello  ") }
     it { "hello".lstrip.should eq("hello") }
     it { "  \n\v かたな  ".lstrip.should eq("かたな  ") }
@@ -629,19 +629,19 @@ describe "String" do
     it { "barfoo".lstrip { |c| c == 'a' || c == 'b' }.should eq("rfoo") }
   end
 
-  describe "empty?" do
+  describe("empty?") do
     it { "a".empty?.should be_false }
     it { "".empty?.should be_true }
   end
 
-  describe "blank?" do
+  describe("blank?") do
     it { " \t\n".blank?.should be_true }
     it { "\u{1680}\u{2029}".blank?.should be_true }
     it { "hello".blank?.should be_false }
   end
 
-  describe "index" do
-    describe "by char" do
+  describe("index") do
+    describe("by char") do
       it { "foo".index('o').should eq(1) }
       it { "foo".index('g').should be_nil }
       it { "bar".index('r').should eq(2) }
@@ -649,7 +649,7 @@ describe "String" do
       it { "bar".index('あ').should be_nil }
       it { "あいう_えお".index('_').should eq(3) }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "foobarbaz".index('a', 5).should eq(7) }
         it { "foobarbaz".index('a', -4).should eq(7) }
         it { "foo".index('g', 1).should be_nil }
@@ -658,14 +658,14 @@ describe "String" do
       end
     end
 
-    describe "by string" do
+    describe("by string") do
       it { "foo bar".index("o b").should eq(2) }
       it { "foo".index("fg").should be_nil }
       it { "foo".index("").should eq(0) }
       it { "foo".index("foo").should eq(0) }
       it { "日本語日本語".index("本語").should eq(1) }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "foobarbaz".index("ba", 4).should eq(6) }
         it { "foobarbaz".index("ba", -5).should eq(6) }
         it { "foo".index("ba", 1).should be_nil }
@@ -676,14 +676,14 @@ describe "String" do
       end
     end
 
-    describe "by regex" do
+    describe("by regex") do
       it { "string 12345".index(/\d+/).should eq(7) }
       it { "12345".index(/\d/).should eq(0) }
       it { "Hello, world!".index(/\d/).should be_nil }
       it { "abcdef".index(/[def]/).should eq(3) }
       it { "日本語日本語".index(/本語/).should eq(1) }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "abcDef".index(/[A-Z]/).should eq(3) }
         it { "foobarbaz".index(/ba/, -5).should eq(6) }
         it { "Foo".index(/[A-Z]/, 1).should be_nil }
@@ -695,26 +695,26 @@ describe "String" do
     end
   end
 
-  describe "rindex" do
-    describe "by char" do
+  describe("rindex") do
+    describe("by char") do
       it { "foobar".rindex('a').should eq(4) }
       it { "foobar".rindex('g').should be_nil }
       it { "日本語日本語".rindex('本').should eq(4) }
       it { "あいう_えお".rindex('_').should eq(3) }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "faobar".rindex('a', 3).should eq(1) }
         it { "faobarbaz".rindex('a', -3).should eq(4) }
         it { "日本語日本語".rindex('本', 3).should eq(1) }
       end
     end
 
-    describe "by string" do
+    describe("by string") do
       it { "foo baro baz".rindex("o b").should eq(7) }
       it { "foo baro baz".rindex("fg").should be_nil }
       it { "日本語日本語".rindex("日本").should eq(3) }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "foo baro baz".rindex("o b", 6).should eq(2) }
         it { "foo".rindex("", 3).should eq(3) }
         it { "foo".rindex("", 4).should eq(3) }
@@ -722,12 +722,12 @@ describe "String" do
       end
     end
 
-    describe "by regex" do
+    describe("by regex") do
       it { "bbbb".rindex(/b/).should eq(3) }
       it { "a43b53".rindex(/\d+/).should eq(4) }
       it { "bbbb".rindex(/\d/).should be_nil }
 
-      describe "with offset" do
+      describe("with offset") do
         it { "bbbb".rindex(/b/, -3).should eq(2) }
         it { "bbbb".rindex(/b/, -1235).should be_nil }
         it { "日本語日本語".rindex(/日本/, 2).should eq(0) }
@@ -735,15 +735,15 @@ describe "String" do
     end
   end
 
-  describe "partition" do
-    describe "by char" do
+  describe("partition") do
+    describe("by char") do
       "hello".partition('h').should eq ({"", "h", "ello"})
       "hello".partition('o').should eq ({"hell", "o", ""})
       "hello".partition('l').should eq ({"he", "l", "lo"})
       "hello".partition('x').should eq ({"hello", "", ""})
     end
 
-    describe "by string" do
+    describe("by string") do
       "hello".partition("h").should eq ({"", "h", "ello"})
       "hello".partition("o").should eq ({"hell", "o", ""})
       "hello".partition("l").should eq ({"he", "l", "lo"})
@@ -751,7 +751,7 @@ describe "String" do
       "hello".partition("x").should eq ({"hello", "", ""})
     end
 
-    describe "by regex" do
+    describe("by regex") do
       "hello".partition(/h/).should eq ({"", "h", "ello"})
       "hello".partition(/o/).should eq ({"hell", "o", ""})
       "hello".partition(/l/).should eq ({"he", "l", "lo"})
@@ -765,14 +765,14 @@ describe "String" do
     end
   end
 
-  describe "rpartition" do
-    describe "by char" do
+  describe("rpartition") do
+    describe("by char") do
       "hello".rpartition('l').should eq ({"hel", "l", "o"})
       "hello".rpartition('o').should eq ({"hell", "o", ""})
       "hello".rpartition('h').should eq ({"", "h", "ello"})
     end
 
-    describe "by string" do
+    describe("by string") do
       "hello".rpartition("l").should eq ({"hel", "l", "o"})
       "hello".rpartition("x").should eq ({"", "", "hello"})
       "hello".rpartition("o").should eq ({"hell", "o", ""})
@@ -782,7 +782,7 @@ describe "String" do
       "hello".rpartition("he").should eq ({"", "he", "llo"})
     end
 
-    describe "by regex" do
+    describe("by regex") do
       "hello".rpartition(/.l/).should eq ({"he", "ll", "o"})
       "hello".rpartition(/ll/).should eq ({"he", "ll", "o"})
       "hello".rpartition(/.o/).should eq ({"hel", "lo", ""})
@@ -791,12 +791,12 @@ describe "String" do
     end
   end
 
-  describe "byte_index" do
+  describe("byte_index") do
     it { "foo".byte_index('o'.ord).should eq(1) }
     it { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
     it { "foo".byte_index('a'.ord).should be_nil }
 
-    it "gets byte index of string" do
+    it("gets byte index of string") do
       "hello world".byte_index("he").should eq(0)
       "hello world".byte_index("lo").should eq(3)
       "hello world".byte_index("world", 7).should be_nil
@@ -806,21 +806,21 @@ describe "String" do
     end
   end
 
-  describe "includes?" do
-    describe "by char" do
+  describe("includes?") do
+    describe("by char") do
       it { "foo".includes?('o').should be_true }
       it { "foo".includes?('g').should be_false }
     end
 
-    describe "by string" do
+    describe("by string") do
       it { "foo bar".includes?("o b").should be_true }
       it { "foo".includes?("fg").should be_false }
       it { "foo".includes?("").should be_true }
     end
   end
 
-  describe "split" do
-    describe "by char" do
+  describe("split") do
+    describe("by char") do
       it { "".split(',').should eq([""]) }
       it { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz", ""]) }
       it { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
@@ -849,7 +849,7 @@ describe "String" do
       it { "=".split('=', 2).should eq(["", ""]) }
     end
 
-    describe "by string" do
+    describe("by string") do
       it { "".split(",").should eq([""]) }
       it { "".split(":-").should eq([""]) }
       it { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz", ""]) }
@@ -867,7 +867,7 @@ describe "String" do
       it { "=".split("=", 2).should eq(["", ""]) }
     end
 
-    describe "by regex" do
+    describe("by regex") do
       it { "".split(/\n\t/).should eq([""] of String) }
       it { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
       it { "foo\n\tbar\n\t\n\tbaz".split(/(?:\n\t)+/).should eq(["foo", "bar", "baz"]) }
@@ -890,14 +890,14 @@ describe "String" do
       it { "=".split(/\=/, 2).should eq(["", ""]) }
       it { ",".split(/(?:(x)|(,))/).should eq(["", ",", ""]) }
 
-      it "keeps groups" do
+      it("keeps groups") do
         s = "split on the word on okay?"
         s.split(/(on)/).should eq(["split ", "on", " the word ", "on", " okay?"])
       end
     end
   end
 
-  describe "starts_with?" do
+  describe("starts_with?") do
     it { "foobar".starts_with?("foo").should be_true }
     it { "foobar".starts_with?("").should be_true }
     it { "foobar".starts_with?("foobarbaz").should be_false }
@@ -908,7 +908,7 @@ describe "String" do
     it { "よし!".starts_with?("よし").should be_true }
   end
 
-  describe "ends_with?" do
+  describe("ends_with?") do
     it { "foobar".ends_with?("bar").should be_true }
     it { "foobar".ends_with?("").should be_true }
     it { "foobar".ends_with?("foobarbaz").should be_false }
@@ -920,23 +920,23 @@ describe "String" do
     it { "あいう_".ends_with?('_').should be_true }
   end
 
-  describe "=~" do
-    it "matches with group" do
+  describe("=~") do
+    it("matches with group") do
       "foobar" =~ /(o+)ba(r?)/
       $1.should eq("oo")
       $2.should eq("r")
     end
 
-    it "returns nil with string" do
+    it("returns nil with string") do
       ("foo" =~ "foo").should be_nil
     end
 
-    it "returns nil with regex and regex" do
+    it("returns nil with regex and regex") do
       (/foo/ =~ /foo/).should be_nil
     end
   end
 
-  describe "delete" do
+  describe("delete") do
     it { "foobar".delete { |char| char == 'o' }.should eq("fbar") }
     it { "hello world".delete("lo").should eq("he wrd") }
     it { "hello world".delete("lo", "o").should eq("hell wrld") }
@@ -948,7 +948,7 @@ describe "String" do
     it { "hello world\\r\\n".delete("\\A").should eq("hello world\\r\\n") }
     it { "hello world\\r\\n".delete("X-\\w").should eq("hello orldrn") }
 
-    it "deletes one char" do
+    it("deletes one char") do
       deleted = "foobar".delete('o')
       deleted.bytesize.should eq(4)
       deleted.should eq("fbar")
@@ -959,40 +959,40 @@ describe "String" do
     end
   end
 
-  it "reverses string" do
+  it("reverses string") do
     reversed = "foobar".reverse
     reversed.bytesize.should eq(6)
     reversed.should eq("raboof")
   end
 
-  it "reverses utf-8 string" do
+  it("reverses utf-8 string") do
     reversed = "こんいちは".reverse
     reversed.bytesize.should eq(15)
     reversed.size.should eq(5)
     reversed.should eq("はちいんこ")
   end
 
-  it "reverses taking grapheme clusters into account" do
+  it("reverses taking grapheme clusters into account") do
     reversed = "noël".reverse
     reversed.bytesize.should eq("noël".bytesize)
     reversed.size.should eq("noël".size)
     reversed.should eq("lëon")
   end
 
-  describe "sub" do
-    it "subs char with char" do
+  describe("sub") do
+    it("subs char with char") do
       replaced = "foobar".sub('o', 'e')
       replaced.bytesize.should eq(6)
       replaced.should eq("feobar")
     end
 
-    it "subs char with string" do
+    it("subs char with string") do
       replaced = "foobar".sub('o', "ex")
       replaced.bytesize.should eq(7)
       replaced.should eq("fexobar")
     end
 
-    it "subs char with string" do
+    it("subs char with string") do
       replaced = "foobar".sub do |char|
         char.should eq 'f'
         "some"
@@ -1004,64 +1004,64 @@ describe "String" do
       empty.sub { 'f' }.should be(empty)
     end
 
-    it "subs with regex and block" do
+    it("subs with regex and block") do
       actual = "foo booor booooz".sub(/o+/) do |str|
         "#{str}#{str.size}"
       end
       actual.should eq("foo2 booor booooz")
     end
 
-    it "subs with regex and block with group" do
+    it("subs with regex and block with group") do
       actual = "foo booor booooz".sub(/(o+).*?(o+)/) do |str, match|
         "#{match[1].size}#{match[2].size}"
       end
       actual.should eq("f23r booooz")
     end
 
-    it "subs with regex and string" do
+    it("subs with regex and string") do
       "foo boor booooz".sub(/o+/, "a").should eq("fa boor booooz")
     end
 
-    it "subs with regex and string, returns self if no match" do
+    it("subs with regex and string, returns self if no match") do
       str = "hello"
       str.sub(/a/, "b").should be(str)
     end
 
-    it "subs with regex and string (utf-8)" do
+    it("subs with regex and string (utf-8)") do
       "fここ bここr bここここz".sub(/こ+/, "そこ").should eq("fそこ bここr bここここz")
     end
 
-    it "subs with empty string" do
+    it("subs with empty string") do
       "foo".sub("", "x").should eq("xfoo")
     end
 
-    it "subs with empty regex" do
+    it("subs with empty regex") do
       "foo".sub(//, "x").should eq("xfoo")
     end
 
-    it "subs null character" do
+    it("subs null character") do
       null = "\u{0}"
       "f\u{0}\u{0}".sub(/#{null}/, "o").should eq("fo\u{0}")
     end
 
-    it "subs with string and string" do
+    it("subs with string and string") do
       "foo boor booooz".sub("oo", "a").should eq("fa boor booooz")
     end
 
-    it "subs with string and string return self if no match" do
+    it("subs with string and string return self if no match") do
       str = "hello"
       str.sub("a", "b").should be(str)
     end
 
-    it "subs with string and string (utf-8)" do
+    it("subs with string and string (utf-8)") do
       "fここ bここr bここここz".sub("ここ", "そこ").should eq("fそこ bここr bここここz")
     end
 
-    it "subs with string and string (#3258)" do
+    it("subs with string and string (#3258)") do
       "私は日本人です".sub("日本", "スペイン").should eq("私はスペイン人です")
     end
 
-    it "subs with string and block" do
+    it("subs with string and block") do
       result = "foo boo".sub("oo") do |value|
         value.should eq("oo")
         "a"
@@ -1069,7 +1069,7 @@ describe "String" do
       result.should eq("fa boo")
     end
 
-    it "subs with char hash" do
+    it("subs with char hash") do
       str = "hello"
       str.sub({'e' => 'a', 'l' => 'd'}).should eq("hallo")
 
@@ -1077,115 +1077,115 @@ describe "String" do
       empty.sub({'a' => 'b'}).should be(empty)
     end
 
-    it "subs with regex and hash" do
+    it("subs with regex and hash") do
       str = "hello"
       str.sub(/(he|l|o)/, {"he" => "ha", "l" => "la"}).should eq("hallo")
       str.sub(/(he|l|o)/, {"l" => "la"}).should be(str)
     end
 
-    it "subs with regex and named tuple" do
+    it("subs with regex and named tuple") do
       str = "hello"
       str.sub(/(he|l|o)/, {he: "ha", l: "la"}).should eq("hallo")
       str.sub(/(he|l|o)/, {l: "la"}).should be(str)
     end
 
-    it "subs using $~" do
+    it("subs using $~") do
       "foo".sub(/(o)/) { "x#{$1}x" }.should eq("fxoxo")
     end
 
-    it "subs using with \\" do
+    it("subs using with \\") do
       "foo".sub(/(o)/, "\\").should eq("f\\o")
     end
 
-    it "subs using with z\\w" do
+    it("subs using with z\\w") do
       "foo".sub(/(o)/, "z\\w").should eq("fz\\wo")
     end
 
-    it "replaces with numeric back-reference" do
+    it("replaces with numeric back-reference") do
       "foo".sub(/o/, "x\\0x").should eq("fxoxo")
       "foo".sub(/(o)/, "x\\1x").should eq("fxoxo")
       "foo".sub(/(o)/, "\\\\1").should eq("f\\1o")
       "hello".sub(/[aeiou]/, "(\\0)").should eq("h(e)llo")
     end
 
-    it "replaces with incomplete named back-reference (1)" do
+    it("replaces with incomplete named back-reference (1)") do
       "foo".sub(/(oo)/, "|\\k|").should eq("f|\\k|")
     end
 
-    it "replaces with incomplete named back-reference (2)" do
+    it("replaces with incomplete named back-reference (2)") do
       "foo".sub(/(oo)/, "|\\k\\1|").should eq("f|\\koo|")
     end
 
-    it "replaces with named back-reference" do
+    it("replaces with named back-reference") do
       "foo".sub(/(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
     end
 
-    it "replaces with multiple named back-reference" do
+    it("replaces with multiple named back-reference") do
       "fooxx".sub(/(?<bar>oo)(?<baz>x+)/, "|\\k<bar>|\\k<baz>|").should eq("f|oo|xx|")
     end
 
-    it "replaces with \\a" do
+    it("replaces with \\a") do
       "foo".sub(/(oo)/, "|\\a|").should eq("f|\\a|")
     end
 
-    it "replaces with \\\\\\1" do
+    it("replaces with \\\\\\1") do
       "foo".sub(/(oo)/, "|\\\\\\1|").should eq("f|\\oo|")
     end
 
-    it "ignores if backreferences: false" do
+    it("ignores if backreferences: false") do
       "foo".sub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xo")
     end
 
-    it "subs at index with char" do
+    it("subs at index with char") do
       string = "hello".sub(1, 'a')
       string.should eq("hallo")
       string.bytesize.should eq(5)
       string.size.should eq(5)
     end
 
-    it "subs at index with char, non-ascii" do
+    it("subs at index with char, non-ascii") do
       string = "あいうえお".sub(2, 'の')
       string.should eq("あいのえお")
       string.size.should eq(5)
       string.bytesize.should eq("あいのえお".bytesize)
     end
 
-    it "subs at index with string" do
+    it("subs at index with string") do
       string = "hello".sub(1, "eee")
       string.should eq("heeello")
       string.bytesize.should eq(7)
       string.size.should eq(7)
     end
 
-    it "subs at index with string, non-ascii" do
+    it("subs at index with string, non-ascii") do
       string = "あいうえお".sub(2, "けくこ")
       string.should eq("あいけくこえお")
       string.bytesize.should eq("あいけくこえお".bytesize)
       string.size.should eq(7)
     end
 
-    it "subs range with char" do
+    it("subs range with char") do
       string = "hello".sub(1..2, 'a')
       string.should eq("halo")
       string.bytesize.should eq(4)
       string.size.should eq(4)
     end
 
-    it "subs range with char, non-ascii" do
+    it("subs range with char, non-ascii") do
       string = "あいうえお".sub(1..2, 'け')
       string.should eq("あけえお")
       string.size.should eq(4)
       string.bytesize.should eq("あけえお".bytesize)
     end
 
-    it "subs range with string" do
+    it("subs range with string") do
       string = "hello".sub(1..2, "eee")
       string.should eq("heeelo")
       string.size.should eq(6)
       string.bytesize.should eq(6)
     end
 
-    it "subs range with string, non-ascii" do
+    it("subs range with string, non-ascii") do
       string = "あいうえお".sub(1..2, "けくこ")
       string.should eq("あけくこえお")
       string.size.should eq(6)
@@ -1193,25 +1193,25 @@ describe "String" do
     end
   end
 
-  describe "gsub" do
-    it "gsubs char with char" do
+  describe("gsub") do
+    it("gsubs char with char") do
       replaced = "foobar".gsub('o', 'e')
       replaced.bytesize.should eq(6)
       replaced.should eq("feebar")
     end
 
-    it "gsubs char with string" do
+    it("gsubs char with string") do
       replaced = "foobar".gsub('o', "ex")
       replaced.bytesize.should eq(8)
       replaced.should eq("fexexbar")
     end
 
-    it "gsubs char with string (nop)" do
+    it("gsubs char with string (nop)") do
       s = "foobar"
       s.gsub('x', "yz").should be(s)
     end
 
-    it "gsubs char with string depending on the char" do
+    it("gsubs char with string depending on the char") do
       replaced = "foobar".gsub do |char|
         case char
         when 'f'
@@ -1228,60 +1228,60 @@ describe "String" do
       replaced.should eq("somethingthingbexr")
     end
 
-    it "gsubs with regex and block" do
+    it("gsubs with regex and block") do
       actual = "foo booor booooz".gsub(/o+/) do |str|
         "#{str}#{str.size}"
       end
       actual.should eq("foo2 booo3r boooo4z")
     end
 
-    it "gsubs with regex and block with group" do
+    it("gsubs with regex and block with group") do
       actual = "foo booor booooz".gsub(/(o+).*?(o+)/) do |str, match|
         "#{match[1].size}#{match[2].size}"
       end
       actual.should eq("f23r b31z")
     end
 
-    it "gsubs with regex and string" do
+    it("gsubs with regex and string") do
       "foo boor booooz".gsub(/o+/, "a").should eq("fa bar baz")
     end
 
-    it "gsubs with regex and string, returns self if no match" do
+    it("gsubs with regex and string, returns self if no match") do
       str = "hello"
       str.gsub(/a/, "b").should be(str)
     end
 
-    it "gsubs with regex and string (utf-8)" do
+    it("gsubs with regex and string (utf-8)") do
       "fここ bここr bここここz".gsub(/こ+/, "そこ").should eq("fそこ bそこr bそこz")
     end
 
-    it "gsubs with empty string" do
+    it("gsubs with empty string") do
       "foo".gsub("", "x").should eq("xfxoxox")
     end
 
-    it "gsubs with empty regex" do
+    it("gsubs with empty regex") do
       "foo".gsub(//, "x").should eq("xfxoxox")
     end
 
-    it "gsubs null character" do
+    it("gsubs null character") do
       null = "\u{0}"
       "f\u{0}\u{0}".gsub(/#{null}/, "o").should eq("foo")
     end
 
-    it "gsubs with string and string" do
+    it("gsubs with string and string") do
       "foo boor booooz".gsub("oo", "a").should eq("fa bar baaz")
     end
 
-    it "gsubs with string and string return self if no match" do
+    it("gsubs with string and string return self if no match") do
       str = "hello"
       str.gsub("a", "b").should be(str)
     end
 
-    it "gsubs with string and string (utf-8)" do
+    it("gsubs with string and string (utf-8)") do
       "fここ bここr bここここz".gsub("ここ", "そこ").should eq("fそこ bそこr bそこそこz")
     end
 
-    it "gsubs with string and block" do
+    it("gsubs with string and block") do
       i = 0
       result = "foo boo".gsub("oo") do |value|
         value.should eq("oo")
@@ -1291,66 +1291,66 @@ describe "String" do
       result.should eq("fa be")
     end
 
-    it "gsubs with char hash" do
+    it("gsubs with char hash") do
       str = "hello"
       str.gsub({'e' => 'a', 'l' => 'd'}).should eq("haddo")
     end
 
-    it "gsubs with char named tuple" do
+    it("gsubs with char named tuple") do
       str = "hello"
       str.gsub({e: 'a', l: 'd'}).should eq("haddo")
     end
 
-    it "gsubs with regex and hash" do
+    it("gsubs with regex and hash") do
       str = "hello"
       str.gsub(/(he|l|o)/, {"he" => "ha", "l" => "la"}).should eq("halala")
     end
 
-    it "gsubs with regex and named tuple" do
+    it("gsubs with regex and named tuple") do
       str = "hello"
       str.gsub(/(he|l|o)/, {he: "ha", l: "la"}).should eq("halala")
     end
 
-    it "gsubs using $~" do
+    it("gsubs using $~") do
       "foo".gsub(/(o)/) { "x#{$1}x" }.should eq("fxoxxox")
     end
 
-    it "replaces with numeric back-reference" do
+    it("replaces with numeric back-reference") do
       "foo".gsub(/o/, "x\\0x").should eq("fxoxxox")
       "foo".gsub(/(o)/, "x\\1x").should eq("fxoxxox")
       "foo".gsub(/(ここ)|(oo)/, "x\\1\\2x").should eq("fxoox")
     end
 
-    it "replaces with named back-reference" do
+    it("replaces with named back-reference") do
       "foo".gsub(/(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
       "foo".gsub(/(?<x>ここ)|(?<bar>oo)/, "|\\k<bar>|").should eq("f|oo|")
     end
 
-    it "replaces with incomplete back-reference (1)" do
+    it("replaces with incomplete back-reference (1)") do
       "foo".gsub(/o/, "\\").should eq("f\\\\")
     end
 
-    it "replaces with incomplete back-reference (2)" do
+    it("replaces with incomplete back-reference (2)") do
       "foo".gsub(/o/, "\\\\").should eq("f\\\\")
     end
 
-    it "replaces with incomplete back-reference (3)" do
+    it("replaces with incomplete back-reference (3)") do
       "foo".gsub(/o/, "\\k").should eq("f\\k\\k")
     end
 
-    it "raises with incomplete back-reference (1)" do
+    it("raises with incomplete back-reference (1)") do
       expect_raises(ArgumentError) do
         "foo".gsub(/(?<bar>oo)/, "|\\k<bar|")
       end
     end
 
-    it "raises with incomplete back-reference (2)" do
+    it("raises with incomplete back-reference (2)") do
       expect_raises(ArgumentError, "Missing ending '>' for '\\\\k<...") do
         "foo".gsub(/o/, "\\k<")
       end
     end
 
-    it "replaces with back-reference to missing capture group" do
+    it("replaces with back-reference to missing capture group") do
       "foo".gsub(/o/, "\\1").should eq("f")
 
       expect_raises(IndexError, "Undefined group name reference: \"bar\"") do
@@ -1362,24 +1362,24 @@ describe "String" do
       end
     end
 
-    it "replaces with escaped back-reference" do
+    it("replaces with escaped back-reference") do
       "foo".gsub(/o/, "\\\\0").should eq("f\\0\\0")
       "foo".gsub(/oo/, "\\\\k<bar>").should eq("f\\k<bar>")
     end
 
-    it "ignores if backreferences: false" do
+    it("ignores if backreferences: false") do
       "foo".gsub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xx\\0x")
     end
   end
 
-  it "scans using $~" do
+  it("scans using $~") do
     str = String.build do |str|
       "fooxooo".scan(/(o+)/) { str << $1 }
     end
     str.should eq("ooooo")
   end
 
-  it "dumps" do
+  it("dumps") do
     "a".dump.should eq("\"a\"")
     "\\".dump.should eq("\"\\\\\"")
     "\"".dump.should eq("\"\\\"\"")
@@ -1395,14 +1395,14 @@ describe "String" do
     "\u{81}".dump.should eq("\"\\u0081\"")
   end
 
-  it "dumps unquoted" do
+  it("dumps unquoted") do
     "a".dump_unquoted.should eq("a")
     "\\".dump_unquoted.should eq("\\\\")
     "á".dump_unquoted.should eq("\\u00e1")
     "\u{81}".dump_unquoted.should eq("\\u0081")
   end
 
-  it "inspects" do
+  it("inspects") do
     "a".inspect.should eq("\"a\"")
     "\\".inspect.should eq("\"\\\\\"")
     "\"".inspect.should eq("\"\\\"\"")
@@ -1418,34 +1418,34 @@ describe "String" do
     "\u{81}".inspect.should eq("\"\\u0081\"")
   end
 
-  it "inspects unquoted" do
+  it("inspects unquoted") do
     "a".inspect_unquoted.should eq("a")
     "\\".inspect_unquoted.should eq("\\\\")
     "á".inspect_unquoted.should eq("á")
     "\u{81}".inspect_unquoted.should eq("\\u0081")
   end
 
-  it "does *" do
+  it("does *") do
     str = "foo" * 10
     str.bytesize.should eq(30)
     str.should eq("foofoofoofoofoofoofoofoofoofoo")
   end
 
-  describe "+" do
-    it "does for both ascii" do
+  describe("+") do
+    it("does for both ascii") do
       str = "foo" + "bar"
       str.bytesize.should eq(6)
       str.@length.should eq(6)
       str.should eq("foobar")
     end
 
-    it "does for both unicode" do
+    it("does for both unicode") do
       str = "青い" + "旅路"
       str.@length.should eq(4)
       str.should eq("青い旅路")
     end
 
-    it "does with ascii char" do
+    it("does with ascii char") do
       str = "foo"
       str2 = str + '/'
       str2.should eq("foo/")
@@ -1453,7 +1453,7 @@ describe "String" do
       str2.size.should eq(4)
     end
 
-    it "does with unicode char" do
+    it("does with unicode char") do
       str = "fooba"
       str2 = str + 'る'
       str2.should eq("foobaる")
@@ -1461,20 +1461,20 @@ describe "String" do
       str2.size.should eq(6)
     end
 
-    it "does when right is empty" do
+    it("does when right is empty") do
       str1 = "foo"
       str2 = ""
       (str1 + str2).should be(str1)
     end
 
-    it "does when left is empty" do
+    it("does when left is empty") do
       str1 = ""
       str2 = "foo"
       (str1 + str2).should be(str2)
     end
   end
 
-  it "does %" do
+  it("does %") do
     ("foo" % 1).should eq("foo")
     ("foo %d" % 1).should eq("foo 1")
     ("%d" % 123).should eq("123")
@@ -1572,7 +1572,7 @@ describe "String" do
     end
   end
 
-  it "escapes chars" do
+  it("escapes chars") do
     "\b"[0].should eq('\b')
     "\t"[0].should eq('\t')
     "\n"[0].should eq('\n')
@@ -1584,7 +1584,7 @@ describe "String" do
     "\\"[0].should eq('\\')
   end
 
-  it "escapes with octal" do
+  it("escapes with octal") do
     "\3"[0].ord.should eq(3)
     "\23"[0].ord.should eq((2 * 8) + 3)
     "\123"[0].ord.should eq((1 * 8 * 8) + (2 * 8) + 3)
@@ -1592,32 +1592,32 @@ describe "String" do
     "\033a"[1].should eq('a')
   end
 
-  it "escapes with unicode" do
+  it("escapes with unicode") do
     "\u{12}".codepoint_at(0).should eq(1 * 16 + 2)
     "\u{A}".codepoint_at(0).should eq(10)
     "\u{AB}".codepoint_at(0).should eq(10 * 16 + 11)
     "\u{AB}1".codepoint_at(1).should eq('1'.ord)
   end
 
-  it "does char_at" do
+  it("does char_at") do
     "いただきます".char_at(2).should eq('だ')
   end
 
-  it "does byte_at" do
+  it("does byte_at") do
     "hello".byte_at(1).should eq('e'.ord)
     expect_raises(IndexError) { "hello".byte_at(5) }
   end
 
-  it "does byte_at?" do
+  it("does byte_at?") do
     "hello".byte_at?(1).should eq('e'.ord)
     "hello".byte_at?(5).should be_nil
   end
 
-  it "does chars" do
+  it("does chars") do
     "ぜんぶ".chars.should eq(['ぜ', 'ん', 'ぶ'])
   end
 
-  it "allows creating a string with zeros" do
+  it("allows creating a string with zeros") do
     p = Pointer(UInt8).malloc(3)
     p[0] = 'a'.ord.to_u8
     p[1] = '\0'.ord.to_u8
@@ -1629,8 +1629,8 @@ describe "String" do
     s.bytesize.should eq(3)
   end
 
-  describe "tr" do
-    it "translates" do
+  describe("tr") do
+    it("translates") do
       "bla".tr("a", "h").should eq("blh")
       "bla".tr("a", "⊙").should eq("bl⊙")
       "bl⊙a".tr("⊙", "a").should eq("blaa")
@@ -1644,31 +1644,31 @@ describe "String" do
       "über".tr("ü", "u").should eq("uber")
     end
 
-    context "given no replacement characters" do
-      it "acts as #delete" do
+    context("given no replacement characters") do
+      it("acts as #delete") do
         "foo".tr("o", "").should eq("foo".delete("o"))
       end
     end
   end
 
-  describe "compare" do
-    it "compares with == when same string" do
+  describe("compare") do
+    it("compares with == when same string") do
       "foo".should eq("foo")
     end
 
-    it "compares with == when different strings same contents" do
+    it("compares with == when different strings same contents") do
       s1 = "foo#{1}"
       s2 = "foo#{1}"
       s1.should eq(s2)
     end
 
-    it "compares with == when different contents" do
+    it("compares with == when different contents") do
       s1 = "foo#{1}"
       s2 = "foo#{2}"
       s1.should_not eq(s2)
     end
 
-    it "sorts strings" do
+    it("sorts strings") do
       s1 = "foo1"
       s2 = "foo"
       s3 = "bar"
@@ -1676,7 +1676,7 @@ describe "String" do
     end
   end
 
-  it "does underscore" do
+  it("does underscore") do
     "Foo".underscore.should eq("foo")
     "FooBar".underscore.should eq("foo_bar")
     "ABCde".underscore.should eq("ab_cde")
@@ -1692,12 +1692,12 @@ describe "String" do
     "I2C".underscore.should eq("i2_c")
   end
 
-  it "does camelcase" do
+  it("does camelcase") do
     "foo".camelcase.should eq("Foo")
     "foo_bar".camelcase.should eq("FooBar")
   end
 
-  it "answers ascii_only?" do
+  it("answers ascii_only?") do
     "a".ascii_only?.should be_true
     "あ".ascii_only?.should be_false
 
@@ -1718,8 +1718,8 @@ describe "String" do
     str.ascii_only?.should be_false
   end
 
-  describe "scan" do
-    it "does without block" do
+  describe("scan") do
+    it("does without block") do
       a = "cruel world"
       a.scan(/\w+/).map(&.[0]).should eq(["cruel", "world"])
       a.scan(/.../).map(&.[0]).should eq(["cru", "el ", "wor"])
@@ -1727,7 +1727,7 @@ describe "String" do
       a.scan(/(..)(..)/).map { |m| {m[1], m[2]} }.should eq([{"cr", "ue"}, {"l ", "wo"}])
     end
 
-    it "does with block" do
+    it("does with block") do
       a = "foo goo"
       i = 0
       a.scan(/\w(o+)/) do |match|
@@ -1745,24 +1745,24 @@ describe "String" do
       end
     end
 
-    it "does with utf-8" do
+    it("does with utf-8") do
       a = "こん こん"
       a.scan(/こ/).map(&.[0]).should eq(["こ", "こ"])
     end
 
-    it "works when match is empty" do
+    it("works when match is empty") do
       r = %r([\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*))
       "hello".scan(r).map(&.[0]).should eq(["hello", ""])
       "hello world".scan(/\w+|(?= )/).map(&.[0]).should eq(["hello", "", "world"])
     end
 
-    it "works with strings with block" do
+    it("works with strings with block") do
       res = [] of String
       "bla bla ablf".scan("bl") { |s| res << s }
       res.should eq(["bl", "bl", "bl"])
     end
 
-    it "works with strings" do
+    it("works with strings") do
       "bla bla ablf".scan("bl").should eq(["bl", "bl", "bl"])
       "hello".scan("world").should eq([] of String)
       "bbb".scan("bb").should eq(["bb"])
@@ -1774,30 +1774,30 @@ describe "String" do
       "".scan("a").should eq([] of String)
     end
 
-    it "does with number and string" do
+    it("does with number and string") do
       "1ab4".scan(/\d+/).map(&.[0]).should eq(["1", "4"])
     end
   end
 
-  it "has match" do
+  it("has match") do
     "FooBar".match(/oo/).not_nil![0].should eq("oo")
   end
 
-  it "matches with position" do
+  it("matches with position") do
     "こんにちは".match(/./, 1).not_nil![0].should eq("ん")
   end
 
-  it "matches empty string" do
+  it("matches empty string") do
     match = "".match(/.*/).not_nil!
     match.group_size.should eq(0)
     match[0].should eq("")
   end
 
-  it "has size (same as size)" do
+  it("has size (same as size)") do
     "テスト".size.should eq(3)
   end
 
-  describe "count" do
+  describe("count") do
     it { "hello world".count("lo").should eq(5) }
     it { "hello world".count("lo", "o").should eq(2) }
     it { "hello world".count("hello", "^l").should eq(4) }
@@ -1811,7 +1811,7 @@ describe "String" do
     it { "aabbcc".count { |c| ['a', 'b'].includes?(c) }.should eq(4) }
   end
 
-  describe "squeeze" do
+  describe("squeeze") do
     it { "aaabbbccc".squeeze { |c| ['a', 'b'].includes?(c) }.should eq("abccc") }
     it { "aaabbbccc".squeeze { |c| ['a', 'c'].includes?(c) }.should eq("abbbc") }
     it { "a       bbb".squeeze.should eq("a b") }
@@ -1819,26 +1819,26 @@ describe "String" do
     it { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
   end
 
-  describe "ljust" do
+  describe("ljust") do
     it { "123".ljust(2).should eq("123") }
     it { "123".ljust(5).should eq("123  ") }
     it { "12".ljust(7, '-').should eq("12-----") }
     it { "12".ljust(7, 'あ').should eq("12あああああ") }
   end
 
-  describe "rjust" do
+  describe("rjust") do
     it { "123".rjust(2).should eq("123") }
     it { "123".rjust(5).should eq("  123") }
     it { "12".rjust(7, '-').should eq("-----12") }
     it { "12".rjust(7, 'あ').should eq("あああああ12") }
   end
 
-  describe "succ" do
-    it "returns an empty string for empty strings" do
+  describe("succ") do
+    it("returns an empty string for empty strings") do
       "".succ.should eq("")
     end
 
-    it "returns the successor by increasing the rightmost alphanumeric (digit => digit, letter => letter with same case)" do
+    it("returns the successor by increasing the rightmost alphanumeric (digit => digit, letter => letter with same case)") do
       "abcd".succ.should eq("abce")
       "THX1138".succ.should eq("THX1139")
 
@@ -1846,12 +1846,12 @@ describe "String" do
       "==A??".succ.should eq("==B??")
     end
 
-    it "increases non-alphanumerics (via ascii rules) if there are no alphanumerics" do
+    it("increases non-alphanumerics (via ascii rules) if there are no alphanumerics") do
       "***".succ.should eq("**+")
       "**`".succ.should eq("**a")
     end
 
-    it "increases the next best alphanumeric (jumping over non-alphanumerics) if there is a carry" do
+    it("increases the next best alphanumeric (jumping over non-alphanumerics) if there is a carry") do
       "dz".succ.should eq("ea")
       "HZ".succ.should eq("IA")
       "49".succ.should eq("50")
@@ -1866,7 +1866,7 @@ describe "String" do
       "NZ/[]ZZZ9999".succ.should eq("OA/[]AAA0000")
     end
 
-    it "adds an additional character (just left to the last increased one) if there is a carry and no character left to increase" do
+    it("adds an additional character (just left to the last increased one) if there is a carry and no character left to increase") do
       "z".succ.should eq("aa")
       "Z".succ.should eq("AA")
       "9".succ.should eq("10")
@@ -1883,16 +1883,16 @@ describe "String" do
     end
   end
 
-  it "uses sprintf from top-level" do
+  it("uses sprintf from top-level") do
     sprintf("Hello %d world", 123).should eq("Hello 123 world")
     sprintf("Hello %d world", [123]).should eq("Hello 123 world")
   end
 
-  it "formats floats (#1562)" do
+  it("formats floats (#1562)") do
     sprintf("%12.2f %12.2f %6.2f %.2f" % {2.0, 3.0, 4.0, 5.0}).should eq("        2.00         3.00   4.00 5.00")
   end
 
-  it "does each_char" do
+  it("does each_char") do
     s = "abc"
     i = 0
     s.each_char do |c|
@@ -1909,7 +1909,7 @@ describe "String" do
     i.should eq(3)
   end
 
-  it "gets each_char iterator" do
+  it("gets each_char iterator") do
     iter = "abc".each_char
     iter.next.should eq('a')
     iter.next.should eq('b')
@@ -1920,7 +1920,7 @@ describe "String" do
     iter.next.should eq('a')
   end
 
-  it "gets each_char with empty string" do
+  it("gets each_char with empty string") do
     iter = "".each_char
     iter.next.should be_a(Iterator::Stop)
 
@@ -1928,11 +1928,11 @@ describe "String" do
     iter.next.should be_a(Iterator::Stop)
   end
 
-  it "cycles chars" do
+  it("cycles chars") do
     "abc".each_char.cycle.first(8).join.should eq("abcabcab")
   end
 
-  it "does each_byte" do
+  it("does each_byte") do
     s = "abc"
     i = 0
     s.each_byte do |b|
@@ -1949,7 +1949,7 @@ describe "String" do
     i.should eq(3)
   end
 
-  it "gets each_byte iterator" do
+  it("gets each_byte iterator") do
     iter = "abc".each_byte
     iter.next.should eq('a'.ord)
     iter.next.should eq('b'.ord)
@@ -1960,11 +1960,11 @@ describe "String" do
     iter.next.should eq('a'.ord)
   end
 
-  it "cycles bytes" do
+  it("cycles bytes") do
     "abc".each_byte.cycle.first(8).join.should eq("9798999798999798")
   end
 
-  it "gets lines" do
+  it("gets lines") do
     "".lines.should eq([] of String)
     "\n".lines.should eq([""] of String)
     "\r".lines.should eq(["\r"] of String)
@@ -1976,13 +1976,13 @@ describe "String" do
     "foo\nbar\r\nbaz\r\n".lines.should eq(["foo", "bar", "baz"])
   end
 
-  it "gets lines with chomp = false" do
+  it("gets lines with chomp = false") do
     "foo".lines(chomp: false).should eq(["foo"])
     "foo\nbar\r\nbaz\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\n"])
     "foo\nbar\r\nbaz\r\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\r\n"])
   end
 
-  it "gets each_line" do
+  it("gets each_line") do
     lines = [] of String
     "foo\n\nbar\r\nbaz\n".each_line do |line|
       lines << line
@@ -1990,7 +1990,7 @@ describe "String" do
     lines.should eq(["foo", "", "bar", "baz"])
   end
 
-  it "gets each_line with chomp = false" do
+  it("gets each_line with chomp = false") do
     lines = [] of String
     "foo\n\nbar\r\nbaz\r\n".each_line(chomp: false) do |line|
       lines << line
@@ -1998,7 +1998,7 @@ describe "String" do
     lines.should eq(["foo\n", "\n", "bar\r\n", "baz\r\n"])
   end
 
-  it "gets each_line iterator" do
+  it("gets each_line iterator") do
     iter = "foo\nbar\r\nbaz\r\n".each_line
     iter.next.should eq("foo")
     iter.next.should eq("bar")
@@ -2009,7 +2009,7 @@ describe "String" do
     iter.next.should eq("foo")
   end
 
-  it "gets each_line iterator with chomp = false" do
+  it("gets each_line iterator with chomp = false") do
     iter = "foo\nbar\nbaz\n".each_line(chomp: false)
     iter.next.should eq("foo\n")
     iter.next.should eq("bar\n")
@@ -2020,7 +2020,7 @@ describe "String" do
     iter.next.should eq("foo\n")
   end
 
-  it "has yields to each_codepoint" do
+  it("has yields to each_codepoint") do
     codepoints = [] of Int32
     "ab☃".each_codepoint do |codepoint|
       codepoints << codepoint
@@ -2028,23 +2028,23 @@ describe "String" do
     codepoints.should eq [97, 98, 9731]
   end
 
-  it "has the each_codepoint iterator" do
+  it("has the each_codepoint iterator") do
     iter = "ab☃".each_codepoint
     iter.next.should eq 97
     iter.next.should eq 98
     iter.next.should eq 9731
   end
 
-  it "has codepoints" do
+  it("has codepoints") do
     "ab☃".codepoints.should eq [97, 98, 9731]
   end
 
-  it "gets size of \0 string" do
+  it("gets size of \0 string") do
     "\0\0".size.should eq(2)
   end
 
-  describe "char_index_to_byte_index" do
-    it "with ascii" do
+  describe("char_index_to_byte_index") do
+    it("with ascii") do
       "foo".char_index_to_byte_index(0).should eq(0)
       "foo".char_index_to_byte_index(1).should eq(1)
       "foo".char_index_to_byte_index(2).should eq(2)
@@ -2052,7 +2052,7 @@ describe "String" do
       "foo".char_index_to_byte_index(4).should be_nil
     end
 
-    it "with utf-8" do
+    it("with utf-8") do
       "これ".char_index_to_byte_index(0).should eq(0)
       "これ".char_index_to_byte_index(1).should eq(3)
       "これ".char_index_to_byte_index(2).should eq(6)
@@ -2060,8 +2060,8 @@ describe "String" do
     end
   end
 
-  describe "byte_index_to_char_index" do
-    it "with ascii" do
+  describe("byte_index_to_char_index") do
+    it("with ascii") do
       "foo".byte_index_to_char_index(0).should eq(0)
       "foo".byte_index_to_char_index(1).should eq(1)
       "foo".byte_index_to_char_index(2).should eq(2)
@@ -2069,7 +2069,7 @@ describe "String" do
       "foo".byte_index_to_char_index(4).should be_nil
     end
 
-    it "with utf-8" do
+    it("with utf-8") do
       "これ".byte_index_to_char_index(0).should eq(0)
       "これ".byte_index_to_char_index(3).should eq(1)
       "これ".byte_index_to_char_index(6).should eq(2)
@@ -2078,8 +2078,8 @@ describe "String" do
     end
   end
 
-  context "%" do
-    it "substitutes one placeholder" do
+  context("%") do
+    it("substitutes one placeholder") do
       res = "change %{this}" % {"this" => "nothing"}
       res.should eq "change nothing"
 
@@ -2087,7 +2087,7 @@ describe "String" do
       res.should eq "change nothing"
     end
 
-    it "substitutes multiple placeholder" do
+    it("substitutes multiple placeholder") do
       res = "change %{this} and %{more}" % {"this" => "nothing", "more" => "something"}
       res.should eq "change nothing and something"
 
@@ -2095,29 +2095,29 @@ describe "String" do
       res.should eq "change nothing and something"
     end
 
-    it "throws an error when the key is not found" do
-      expect_raises KeyError do
+    it("throws an error when the key is not found") do
+      expect_raises(KeyError) do
         "change %{this}" % {"that" => "wrong key"}
       end
 
-      expect_raises KeyError do
+      expect_raises(KeyError) do
         "change %{this}" % {that: "wrong key"}
       end
     end
 
-    it "raises if expecting hash or named tuple but not given" do
+    it("raises if expecting hash or named tuple but not given") do
       expect_raises(ArgumentError, "One hash or named tuple required") do
         "change %{this}" % "this"
       end
     end
 
-    it "raises on unbalanced curly" do
+    it("raises on unbalanced curly") do
       expect_raises(ArgumentError, "Malformed name - unmatched parenthesis") do
         "change %{this" % {"this" => 1}
       end
     end
 
-    it "applies formatting to %<...> placeholder" do
+    it("applies formatting to %<...> placeholder") do
       res = "change %<this>.2f" % {"this" => 23.456}
       res.should eq "change 23.46"
 
@@ -2126,31 +2126,31 @@ describe "String" do
     end
   end
 
-  it "raises if string capacity is negative" do
+  it("raises if string capacity is negative") do
     expect_raises(ArgumentError, "Negative capacity") do
       String.new(-1) { |buf| {0, 0} }
     end
   end
 
-  it "raises if capacity too big on new with UInt32::MAX" do
+  it("raises if capacity too big on new with UInt32::MAX") do
     expect_raises(ArgumentError, "Capacity too big") do
       String.new(UInt32::MAX) { {0, 0} }
     end
   end
 
-  it "raises if capacity too big on new with UInt32::MAX - String::HEADER_SIZE - 1" do
+  it("raises if capacity too big on new with UInt32::MAX - String::HEADER_SIZE - 1") do
     expect_raises(ArgumentError, "Capacity too big") do
       String.new(UInt32::MAX - String::HEADER_SIZE) { {0, 0} }
     end
   end
 
-  it "raises if capacity too big on new with UInt64::MAX" do
+  it("raises if capacity too big on new with UInt64::MAX") do
     expect_raises(ArgumentError, "Capacity too big") do
       String.new(UInt64::MAX) { {0, 0} }
     end
   end
 
-  it "compares non-case insensitive" do
+  it("compares non-case insensitive") do
     "fo".compare("foo").should eq(-1)
     "foo".compare("fo").should eq(1)
     "foo".compare("foo").should eq(0)
@@ -2159,7 +2159,7 @@ describe "String" do
     "foo".compare("Foo").should eq(1)
   end
 
-  it "compares case insensitive" do
+  it("compares case insensitive") do
     "fo".compare("FOO", case_insensitive: true).should eq(-1)
     "foo".compare("FO", case_insensitive: true).should eq(1)
     "foo".compare("FOO", case_insensitive: true).should eq(0)
@@ -2168,7 +2168,7 @@ describe "String" do
     "fo\u{0000}".compare("FO", case_insensitive: true).should eq(1)
   end
 
-  it "builds with write_byte" do
+  it("builds with write_byte") do
     string = String.build do |io|
       255_u8.times do |byte|
         io.write_byte(byte)
@@ -2179,68 +2179,68 @@ describe "String" do
     end
   end
 
-  it "raises if String.build negative capacity" do
+  it("raises if String.build negative capacity") do
     expect_raises(ArgumentError, "Negative capacity") do
       String.build(-1) { }
     end
   end
 
-  it "raises if String.build capacity too big" do
+  it("raises if String.build capacity too big") do
     expect_raises(ArgumentError, "Capacity too big") do
       String.build(UInt32::MAX) { }
     end
   end
 
-  describe "encode" do
-    it "encodes" do
+  describe("encode") do
+    it("encodes") do
       bytes = "Hello".encode("UCS-2LE")
       bytes.to_a.should eq([72, 0, 101, 0, 108, 0, 108, 0, 111, 0])
     end
 
-    it "raises if wrong encoding" do
-      expect_raises ArgumentError, "Invalid encoding: FOO" do
+    it("raises if wrong encoding") do
+      expect_raises(ArgumentError, "Invalid encoding: FOO") do
         "Hello".encode("FOO")
       end
     end
 
-    it "raises if wrong encoding with skip" do
-      expect_raises ArgumentError, "Invalid encoding: FOO" do
+    it("raises if wrong encoding with skip") do
+      expect_raises(ArgumentError, "Invalid encoding: FOO") do
         "Hello".encode("FOO", invalid: :skip)
       end
     end
 
-    it "raises if illegal byte sequence" do
-      expect_raises ArgumentError, "Invalid multibyte sequence" do
+    it("raises if illegal byte sequence") do
+      expect_raises(ArgumentError, "Invalid multibyte sequence") do
         "ñ".encode("GB2312")
       end
     end
 
-    it "doesn't raise on invalid byte sequence" do
+    it("doesn't raise on invalid byte sequence") do
       "好ñ是".encode("GB2312", invalid: :skip).to_a.should eq([186, 195, 202, 199])
     end
 
-    it "raises if incomplete byte sequence" do
-      expect_raises ArgumentError, "Incomplete multibyte sequence" do
+    it("raises if incomplete byte sequence") do
+      expect_raises(ArgumentError, "Incomplete multibyte sequence") do
         "好".byte_slice(0, 1).encode("GB2312")
       end
     end
 
-    it "doesn't raise if incomplete byte sequence" do
+    it("doesn't raise if incomplete byte sequence") do
       ("好".byte_slice(0, 1) + "是").encode("GB2312", invalid: :skip).to_a.should eq([202, 199])
     end
 
-    it "decodes" do
+    it("decodes") do
       bytes = "Hello".encode("UTF-16LE")
       String.new(bytes, "UTF-16LE").should eq("Hello")
     end
 
-    it "decodes with skip" do
+    it("decodes with skip") do
       bytes = Bytes[186, 195, 140, 202, 199]
       String.new(bytes, "GB2312", invalid: :skip).should eq("好是")
     end
   end
 
-  it "inserts" do
+  it("inserts") do
     "bar".insert(0, "foo").should eq("foobar")
     "bar".insert(1, "foo").should eq("bfooar")
     "bar".insert(2, "foo").should eq("bafoor")
@@ -2276,31 +2276,31 @@ describe "String" do
     "".insert(0, 'あ').ascii_only?.should be_false
   end
 
-  it "hexbytes" do
+  it("hexbytes") do
     expect_raises(ArgumentError) { "abc".hexbytes }
     expect_raises(ArgumentError) { "abc ".hexbytes }
     "abcd".hexbytes.should eq(Bytes[171, 205])
   end
 
-  it "hexbytes?" do
+  it("hexbytes?") do
     "abc".hexbytes?.should be_nil
     "abc ".hexbytes?.should be_nil
     "abcd".hexbytes?.should eq(Bytes[171, 205])
   end
 
-  it "dups" do
+  it("dups") do
     string = "foo"
     dup = string.dup
     string.should be(dup)
   end
 
-  it "clones" do
+  it("clones") do
     string = "foo"
     clone = string.clone
     string.should be(clone)
   end
 
-  it "#at" do
+  it("#at") do
     "foo".at(0).should eq('f')
     "foo".at(4) { 'x' }.should eq('x')
 
@@ -2309,48 +2309,48 @@ describe "String" do
     end
   end
 
-  it "allocates buffer of correct size when UInt8 is given to new (#3332)" do
+  it("allocates buffer of correct size when UInt8 is given to new (#3332)") do
     String.new(255_u8) do |buffer|
       LibGC.size(buffer).should be >= 255
       {255, 0}
     end
   end
 
-  it "raises on String.new if returned bytesize is greater than capacity" do
-    expect_raises ArgumentError, "Bytesize out of capacity bounds" do
+  it("raises on String.new if returned bytesize is greater than capacity") do
+    expect_raises(ArgumentError, "Bytesize out of capacity bounds") do
       String.new(123) do |buffer|
         {124, 0}
       end
     end
   end
 
-  describe "invalide utf-8 byte sequence" do
-    it "gets size" do
+  describe("invalide utf-8 byte sequence") do
+    it("gets size") do
       string = String.new(Bytes[255, 0, 0, 0, 65])
       string.size.should eq(5)
     end
 
-    it "gets size (2)" do
+    it("gets size (2)") do
       string = String.new(Bytes[104, 101, 108, 108, 111, 32, 255, 32, 255, 32, 119, 111, 114, 108, 100, 33])
       string.size.should eq(16)
     end
 
-    it "gets chars" do
+    it("gets chars") do
       string = String.new(Bytes[255, 0, 0, 0, 65])
       string.chars.should eq([Char::REPLACEMENT, 0.chr, 0.chr, 0.chr, 65.chr])
     end
 
-    it "gets chars (2)" do
+    it("gets chars (2)") do
       string = String.new(Bytes[255, 0])
       string.chars.should eq([Char::REPLACEMENT, 0.chr])
     end
 
-    it "valid_encoding?" do
+    it("valid_encoding?") do
       "hello".valid_encoding?.should be_true
       String.new(Bytes[255, 0]).valid_encoding?.should be_false
     end
 
-    it "scrubs" do
+    it("scrubs") do
       string = String.new(Bytes[255, 129, 97, 255, 97])
       string.scrub.bytes.should eq([239, 191, 189, 97, 239, 191, 189, 97])
 

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -29,28 +29,28 @@ private module StructSpec
   end
 end
 
-describe "Struct" do
-  it "does to_s" do
+describe("Struct") do
+  it("does to_s") do
     s = StructSpec::TestClass.new(1, "hello")
     s.to_s.should eq(%(StructSpec::TestClass(@x=1, @y="hello")))
   end
 
-  it "does ==" do
+  it("does ==") do
     s = StructSpec::TestClass.new(1, "hello")
     s.should eq(s)
   end
 
-  it "does hash" do
+  it("does hash") do
     s = StructSpec::TestClass.new(1, "hello")
     s.hash.should eq(s.dup.hash)
   end
 
-  it "does hash for struct wrapper (#1940)" do
+  it("does hash for struct wrapper (#1940)") do
     s = StructSpec::BigIntWrapper.new(BigInt.new(0))
     s.hash.should eq(s.dup.hash)
   end
 
-  it "does dup" do
+  it("does dup") do
     original = StructSpec::DupCloneStruct.new
     duplicate = original.dup
     duplicate.x.should eq(original.x)
@@ -60,7 +60,7 @@ describe "Struct" do
     duplicate.x.should_not eq(10)
   end
 
-  it "clones with def_clone" do
+  it("clones with def_clone") do
     original = StructSpec::DupCloneStruct.new
     clone = original.clone
     clone.x.should eq(original.x)

--- a/spec/std/symbol_spec.cr
+++ b/spec/std/symbol_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe Symbol do
-  it "inspects" do
+describe(Symbol) do
+  it("inspects") do
     :foo.inspect.should eq(%(:foo))
     :"{".inspect.should eq(%(:"{"))
     :"hi there".inspect.should eq(%(:"hi there"))
@@ -9,7 +9,7 @@ describe Symbol do
     # :かたな.inspect.should eq(%(:かたな))
   end
 
-  it "can be compared with another symbol" do
+  it("can be compared with another symbol") do
     (:foo > :bar).should be_true
     (:foo < :bar).should be_false
 
@@ -18,13 +18,13 @@ describe Symbol do
     a.sort.should eq(b)
   end
 
-  it "displays symbols that don't need quotes without quotes" do
+  it("displays symbols that don't need quotes without quotes") do
     a = %i(+ - * / == < <= > >= ! != =~ !~ & | ^ ~ ** >> << % [] <=> === []? []=)
     b = "[:+, :-, :*, :/, :==, :<, :<=, :>, :>=, :!, :!=, :=~, :!~, :&, :|, :^, :~, :**, :>>, :<<, :%, :[], :<=>, :===, :[]?, :[]=]"
     a.inspect.should eq(b)
   end
 
-  describe "clone" do
+  describe("clone") do
     it { :foo.clone.should eq(:foo) }
   end
 end

--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -1,9 +1,9 @@
 require "spec"
 require "system"
 
-describe System do
-  describe "hostname" do
-    it "returns current hostname" do
+describe(System) do
+  describe("hostname") do
+    it("returns current hostname") do
       shell_hostname = `hostname`.strip
       $?.success?.should be_true # The hostname command has to be available
       hostname = System.hostname
@@ -11,8 +11,8 @@ describe System do
     end
   end
 
-  describe "cpu_count" do
-    it "returns current CPU count" do
+  describe("cpu_count") do
+    it("returns current CPU count") do
       shell_cpus = `getconf _NPROCESSORS_ONLN || nproc --all || grep -c '^processor' /proc/cpuinfo || sysctl -n hw.ncpu`.to_i
       cpu_count = System.cpu_count
       cpu_count.should eq(shell_cpus)

--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "tempfile"
 
-describe Tempfile do
-  it "creates and writes" do
+describe(Tempfile) do
+  it("creates and writes") do
     tempfile = Tempfile.new "foo"
     tempfile.print "Hello!"
     tempfile.close
@@ -11,7 +11,7 @@ describe Tempfile do
     File.read(tempfile.path).should eq("Hello!")
   end
 
-  it "creates and deletes" do
+  it("creates and deletes") do
     tempfile = Tempfile.new "foo"
     tempfile.close
     tempfile.delete
@@ -19,14 +19,14 @@ describe Tempfile do
     File.exists?(tempfile.path).should be_false
   end
 
-  it "doesn't delete on open with block" do
+  it("doesn't delete on open with block") do
     tempfile = Tempfile.open("foo") do |f|
       f.print "Hello!"
     end
     File.exists?(tempfile.path).should be_true
   end
 
-  it "creates and writes with TMPDIR environment variable" do
+  it("creates and writes with TMPDIR environment variable") do
     old_tmpdir = ENV["TMPDIR"]?
     ENV["TMPDIR"] = "/tmp"
 
@@ -42,7 +42,7 @@ describe Tempfile do
     end
   end
 
-  it "is seekable" do
+  it("is seekable") do
     tempfile = Tempfile.new "foo"
     tempfile.puts "Hello!"
     tempfile.seek(0, IO::Seek::Set)
@@ -54,14 +54,14 @@ describe Tempfile do
     tempfile.close
   end
 
-  it "returns default directory for tempfiles" do
+  it("returns default directory for tempfiles") do
     old_tmpdir = ENV["TMPDIR"]?
     ENV.delete("TMPDIR")
     Tempfile.dirname.should eq("/tmp")
     ENV["TMPDIR"] = old_tmpdir if old_tmpdir
   end
 
-  it "returns configure directory for tempfiles" do
+  it("returns configure directory for tempfiles") do
     old_tmpdir = ENV["TMPDIR"]?
     ENV["TMPDIR"] = "/my/tmp"
     Tempfile.dirname.should eq("/my/tmp")

--- a/spec/std/thread/condition_variable_spec.cr
+++ b/spec/std/thread/condition_variable_spec.cr
@@ -5,8 +5,8 @@ require "spec"
 # need condition variables.
 #
 # Also: review these specs!
-describe Thread::ConditionVariable do
-  pending "signals" do
+describe(Thread::ConditionVariable) do
+  pending("signals") do
     mutex = Thread::Mutex.new
     cond = Thread::ConditionVariable.new
     pcond = Thread::ConditionVariable.new
@@ -36,7 +36,7 @@ describe Thread::ConditionVariable do
     threads.map &.join
   end
 
-  pending "broadcasts" do
+  pending("broadcasts") do
     mutex = Thread::Mutex.new
     cond = Thread::ConditionVariable.new
     pcond = Thread::ConditionVariable.new
@@ -67,7 +67,7 @@ describe Thread::ConditionVariable do
     threads.map &.join
   end
 
-  pending "waits and send signal" do
+  pending("waits and send signal") do
     a = 0
     cv1 = Thread::ConditionVariable.new
     cv2 = Thread::ConditionVariable.new

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -1,16 +1,16 @@
 require "spec"
 
-describe Thread do
-  it "allows passing an argumentless fun to execute" do
+describe(Thread) do
+  it("allows passing an argumentless fun to execute") do
     a = 0
     thread = Thread.new { a = 1; 10 }
     thread.join
     a.should eq(1)
   end
 
-  it "raises inside thread and gets it on join" do
+  it("raises inside thread and gets it on join") do
     thread = Thread.new { raise "OH NO" }
-    expect_raises Exception, "OH NO" do
+    expect_raises(Exception, "OH NO") do
       thread.join
     end
   end

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -1,13 +1,13 @@
 require "spec"
 
 private def expect_overflow
-  expect_raises ArgumentError, "Time::Span too big or too small" do
+  expect_raises(ArgumentError, "Time::Span too big or too small") do
     yield
   end
 end
 
-describe Time::Span do
-  it "initializes" do
+describe(Time::Span) do
+  it("initializes") do
     t1 = Time::Span.new 1234567890
     t1.to_s.should eq("00:02:03.4567890")
 
@@ -27,26 +27,26 @@ describe Time::Span do
     t1.to_s.should eq("1.01:00:00")
   end
 
-  it "days overflows" do
+  it("days overflows") do
     expect_overflow do
       days = (Int64::MAX / Time::Span::TicksPerDay).to_i32 + 1
       Time::Span.new days, 0, 0, 0, 0
     end
   end
 
-  it "max days" do
+  it("max days") do
     expect_overflow do
       Int32::MAX.days
     end
   end
 
-  it "min days" do
+  it("min days") do
     expect_overflow do
       Int32::MIN.days
     end
   end
 
-  it "max seconds" do
+  it("max seconds") do
     ts = Int32::MAX.seconds
     ts.days.should eq(24855)
     ts.hours.should eq(3)
@@ -56,7 +56,7 @@ describe Time::Span do
     ts.ticks.should eq(21474836470000000)
   end
 
-  it "min seconds" do
+  it("min seconds") do
     ts = Int32::MIN.seconds
     ts.days.should eq(-24855)
     ts.hours.should eq(-3)
@@ -66,7 +66,7 @@ describe Time::Span do
     ts.ticks.should eq(-21474836480000000)
   end
 
-  it "max milliseconds" do
+  it("max milliseconds") do
     ts = Int32::MAX.milliseconds
     ts.days.should eq(24)
     ts.hours.should eq(20)
@@ -76,7 +76,7 @@ describe Time::Span do
     ts.ticks.should eq(21474836470000)
   end
 
-  it "min milliseconds" do
+  it("min milliseconds") do
     ts = Int32::MIN.milliseconds
     ts.days.should eq(-24)
     ts.hours.should eq(-20)
@@ -86,7 +86,7 @@ describe Time::Span do
     ts.ticks.should eq(-21474836480000)
   end
 
-  it "negative timespan" do
+  it("negative timespan") do
     ts = Time::Span.new -23, -59, -59
     ts.days.should eq(0)
     ts.hours.should eq(-23)
@@ -96,7 +96,7 @@ describe Time::Span do
     ts.ticks.should eq(-863990000000)
   end
 
-  it "test properties" do
+  it("test properties") do
     t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1
 
@@ -113,7 +113,7 @@ describe Time::Span do
     t2.milliseconds.should eq(-5)
   end
 
-  it "test add" do
+  it("test add") do
     t1 = Time::Span.new 2, 3, 4, 5, 6
     t2 = Time::Span.new 1, 2, 3, 4, 5
     t3 = t1 + t2
@@ -128,7 +128,7 @@ describe Time::Span do
     # TODO check overflow
   end
 
-  it "test compare" do
+  it("test compare") do
     t1 = Time::Span.new -1
     t2 = Time::Span.new 1
 
@@ -145,7 +145,7 @@ describe Time::Span do
     (t1 <= t2).should be_true
   end
 
-  it "test equals" do
+  it("test equals") do
     t1 = Time::Span.new 1
     t2 = Time::Span.new 2
 
@@ -154,7 +154,7 @@ describe Time::Span do
     (t1 == "hello").should be_false
   end
 
-  it "test float extension methods" do
+  it("test float extension methods") do
     12.345.days.to_s.should eq("12.08:16:48")
     12.345.hours.to_s.should eq("12:20:42")
     12.345.minutes.to_s.should eq("00:12:20.7000000")
@@ -167,7 +167,7 @@ describe Time::Span do
     0.0005.seconds.to_s.should eq("00:00:00.0010000")
   end
 
-  it "test negate and duration" do
+  it("test negate and duration") do
     (-Time::Span.new(12345)).to_s.should eq("-00:00:00.0012345")
     Time::Span.new(-12345).duration.to_s.should eq("00:00:00.0012345")
     Time::Span.new(-12345).abs.to_s.should eq("00:00:00.0012345")
@@ -175,13 +175,13 @@ describe Time::Span do
     (+Time::Span.new(77)).to_s.should eq("00:00:00.0000077")
   end
 
-  it "test hash code" do
+  it("test hash code") do
     t1 = Time::Span.new(77)
     t2 = Time::Span.new(77)
     t1.hash.should eq(t2.hash)
   end
 
-  it "test subtract" do
+  it("test subtract") do
     t1 = Time::Span.new 2, 3, 4, 5, 6
     t2 = Time::Span.new 1, 2, 3, 4, 5
     t3 = t1 - t2
@@ -191,7 +191,7 @@ describe Time::Span do
     # TODO check overflow
   end
 
-  it "test multiply" do
+  it("test multiply") do
     t1 = Time::Span.new 5, 4, 3, 2, 1
     t2 = t1 * 61
 
@@ -200,7 +200,7 @@ describe Time::Span do
     # TODO check overflow
   end
 
-  it "test divide" do
+  it("test divide") do
     t1 = Time::Span.new 3, 3, 3, 3, 3
     t2 = t1 / 2
 
@@ -209,7 +209,7 @@ describe Time::Span do
     # TODO check overflow
   end
 
-  it "divides by another Time::Span" do
+  it("divides by another Time::Span") do
     ratio = 20.minutes / 15.seconds
     ratio.should eq(80.0)
 
@@ -217,7 +217,7 @@ describe Time::Span do
     ratio2.should eq(0.75)
   end
 
-  it "test to_s" do
+  it("test to_s") do
     t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1
 
@@ -228,7 +228,7 @@ describe Time::Span do
     Time::Span::Zero.to_s.should eq("00:00:00")
   end
 
-  it "test totals" do
+  it("test totals") do
     t1 = Time::Span.new 1, 2, 3, 4, 5
     t1.total_days.should be_close(1.08546, 1e-05)
     t1.total_hours.should be_close(26.0511, 1e-04)
@@ -239,11 +239,11 @@ describe Time::Span do
     t1.to_i.should eq(93784)
   end
 
-  it "should sum" do
+  it("should sum") do
     [1.second, 5.seconds].sum.should eq(6.seconds)
   end
 
-  it "test zero?" do
+  it("test zero?") do
     Time::Span.new(0).zero?.should eq true
     Time::Span.new(123456789).zero?.should eq false
   end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -7,13 +7,13 @@ private TimeSpecTicks = [
 ]
 
 def Time.expect_invalid
-  expect_raises ArgumentError, "Invalid time" do
+  expect_raises(ArgumentError, "Invalid time") do
     yield
   end
 end
 
-describe Time do
-  it "initialize" do
+describe(Time) do
+  it("initialize") do
     t1 = Time.new 2002, 2, 25
     t1.ticks.should eq(TimeSpecTicks[0])
 
@@ -33,47 +33,47 @@ describe Time do
     t3.ticks.should eq(TimeSpecTicks[2])
   end
 
-  it "initialize max" do
+  it("initialize max") do
     Time.new(9999, 12, 31, 23, 59, 59, 999).ticks.should eq(3155378975999990000)
   end
 
-  it "initialize millisecond negative" do
+  it("initialize millisecond negative") do
     Time.expect_invalid do
       Time.new(9999, 12, 31, 23, 59, 59, -1)
     end
   end
 
-  it "initialize millisecond 1000" do
+  it("initialize millisecond 1000") do
     Time.expect_invalid do
       Time.new(9999, 12, 31, 23, 59, 59, 1000)
     end
   end
 
-  it "initialize with .epoch" do
+  it("initialize with .epoch") do
     seconds = 1439404155
     time = Time.epoch(seconds)
     time.should eq(Time.new(2015, 8, 12, 18, 29, 15, kind: Time::Kind::Utc))
     time.epoch.should eq(seconds)
   end
 
-  it "initialize with .epoch_ms" do
+  it("initialize with .epoch_ms") do
     milliseconds = 1439404155000
     time = Time.epoch_ms(milliseconds)
     time.should eq(Time.new(2015, 8, 12, 18, 29, 15, kind: Time::Kind::Utc))
     time.epoch_ms.should eq(milliseconds)
   end
 
-  it "clones" do
+  it("clones") do
     time = Time.now
     (time == time.clone).should be_true
   end
 
-  it "fields" do
+  it("fields") do
     Time::MaxValue.ticks.should eq(3155378975999999999)
     Time::MinValue.ticks.should eq(0)
   end
 
-  it "add" do
+  it("add") do
     t1 = Time.new TimeSpecTicks[1]
     span = Time::Span.new 3, 54, 1
     t2 = t1 + span
@@ -89,23 +89,23 @@ describe Time do
     t1.second.should eq(13)
   end
 
-  it "add out of range 1" do
+  it("add out of range 1") do
     t1 = Time.new TimeSpecTicks[1]
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       t1 + Time::Span::MaxValue
     end
   end
 
-  it "add out of range 2" do
+  it("add out of range 2") do
     t1 = Time.new TimeSpecTicks[1]
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       t1 + Time::Span::MinValue
     end
   end
 
-  it "add days" do
+  it("add days") do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 3.days
 
@@ -127,21 +127,21 @@ describe Time do
     t1.second.should eq(13)
   end
 
-  it "add days out of range 1" do
+  it("add days out of range 1") do
     t1 = Time.new TimeSpecTicks[1]
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       t1 + 10000000.days
     end
   end
 
-  it "add days out of range 2" do
+  it("add days out of range 2") do
     t1 = Time.new TimeSpecTicks[1]
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       t1 - 10000000.days
     end
   end
 
-  it "add months" do
+  it("add months") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t2 = t + 1.month
     t2.to_s.should eq("2014-11-30 21:18:13")
@@ -162,7 +162,7 @@ describe Time do
     t2.to_s.should eq("2015-04-30 21:18:13")
   end
 
-  it "add years" do
+  it("add years") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t2 = t + 1.year
     t2.to_s.should eq("2015-10-30 21:18:13")
@@ -172,7 +172,7 @@ describe Time do
     t2.to_s.should eq("2012-10-30 21:18:13")
   end
 
-  it "add hours" do
+  it("add hours") do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 10.hours
 
@@ -194,7 +194,7 @@ describe Time do
     t1.second.should eq(8)
   end
 
-  it "add milliseconds" do
+  it("add milliseconds") do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 1e10.milliseconds
 
@@ -216,22 +216,22 @@ describe Time do
     t1.second.should eq(13)
   end
 
-  it "gets time of day" do
+  it("gets time of day") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t.time_of_day.should eq(Time::Span.new(21, 18, 13))
   end
 
-  it "gets day of week" do
+  it("gets day of week") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t.day_of_week.should eq(Time::DayOfWeek::Thursday)
   end
 
-  it "gets day of year" do
+  it("gets day of year") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t.day_of_year.should eq(303)
   end
 
-  it "compares" do
+  it("compares") do
     t1 = Time.new 2014, 10, 30, 21, 18, 13
     t2 = Time.new 2014, 10, 30, 21, 18, 14
 
@@ -240,19 +240,19 @@ describe Time do
     (t1 < t2).should be_true
   end
 
-  it "gets unix epoch seconds" do
+  it("gets unix epoch seconds") do
     t1 = Time.new 2014, 10, 30, 21, 18, 13, 0, Time::Kind::Utc
     t1.epoch.should eq(1414703893)
     t1.epoch_f.should be_close(1414703893, 1e-01)
   end
 
-  it "gets unix epoch seconds at GMT" do
+  it("gets unix epoch seconds at GMT") do
     t1 = Time.now
     t1.epoch.should eq(t1.to_utc.epoch)
     t1.epoch_f.should be_close(t1.to_utc.epoch_f, 1e-01)
   end
 
-  it "to_s" do
+  it("to_s") do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t.to_s.should eq("2014-10-30 21:18:13")
 
@@ -272,7 +272,7 @@ describe Time do
     t.to_s.should eq("2014-10-30 21:18:01")
   end
 
-  it "formats" do
+  it("formats") do
     t = Time.new 2014, 1, 2, 3, 4, 5, 6
     t2 = Time.new 2014, 1, 2, 15, 4, 5, 6
     t3 = Time.new 2014, 1, 2, 12, 4, 5, 6
@@ -367,7 +367,7 @@ describe Time do
     t.to_s("%s").should eq("1388631845")
   end
 
-  it "parses empty" do
+  it("parses empty") do
     t = Time.parse("", "")
     t.year.should eq(1)
     t.month.should eq(1)
@@ -471,53 +471,53 @@ describe Time do
     time.to_utc.to_s.should eq("2014-10-31 16:11:12 UTC")
   end
 
-  it "parses microseconds" do
+  it("parses microseconds") do
     time = Time.parse("2016-09-09T17:03:28.456789+01:00", "%FT%T.%L%z").to_utc
     time.to_s.should eq("2016-09-09 16:03:28 UTC")
     time.millisecond.should eq(456)
   end
 
-  it "parses the correct amount of digits (#853)" do
+  it("parses the correct amount of digits (#853)") do
     time = Time.parse("20150624", "%Y%m%d")
     time.year.should eq(2015)
     time.month.should eq(6)
     time.day.should eq(24)
   end
 
-  it "parses month blank padded" do
+  it("parses month blank padded") do
     time = Time.parse("2015 624", "%Y%_m%d")
     time.year.should eq(2015)
     time.month.should eq(6)
     time.day.should eq(24)
   end
 
-  it "parses day of month blank padded" do
+  it("parses day of month blank padded") do
     time = Time.parse("201506 4", "%Y%m%e")
     time.year.should eq(2015)
     time.month.should eq(6)
     time.day.should eq(4)
   end
 
-  it "parses hour 24 blank padded" do
+  it("parses hour 24 blank padded") do
     time = Time.parse(" 31112", "%k%M%S")
     time.hour.should eq(3)
     time.minute.should eq(11)
     time.second.should eq(12)
   end
 
-  it "parses hour 12 blank padded" do
+  it("parses hour 12 blank padded") do
     time = Time.parse(" 31112", "%l%M%S")
     time.hour.should eq(3)
     time.minute.should eq(11)
     time.second.should eq(12)
   end
 
-  it "can parse in UTC" do
+  it("can parse in UTC") do
     time = Time.parse("2014-10-31 11:12:13", "%F %T", Time::Kind::Utc)
     time.kind.should eq(Time::Kind::Utc)
   end
 
-  it "at" do
+  it("at") do
     t1 = Time.new 2014, 11, 25, 10, 11, 12, 13
     t2 = Time.new 2014, 6, 25, 10, 11, 12, 13
 
@@ -577,7 +577,7 @@ describe Time do
     t2.at_end_of_semester.to_s.should eq("2014-06-30 23:59:59")
   end
 
-  it "does time span units" do
+  it("does time span units") do
     1.millisecond.ticks.should eq(Time::Span::TicksPerMillisecond)
     1.milliseconds.ticks.should eq(Time::Span::TicksPerMillisecond)
     1.second.ticks.should eq(Time::Span::TicksPerSecond)
@@ -590,14 +590,14 @@ describe Time do
     2.weeks.should eq(14.days)
   end
 
-  it "preserves kind when adding" do
+  it("preserves kind when adding") do
     time = Time.utc_now
     time.kind.should eq(Time::Kind::Utc)
 
     (time + 5.minutes).kind.should eq(Time::Kind::Utc)
   end
 
-  it "asks for day name" do
+  it("asks for day name") do
     7.times do |i|
       time = Time.new(2015, 2, 15 + i)
       time.sunday?.should eq(i == 0)
@@ -610,12 +610,12 @@ describe Time do
     end
   end
 
-  it "compares different kinds" do
+  it("compares different kinds") do
     time = Time.now
     (time.to_utc <=> time).should eq(0)
   end
 
-  it %(changes timezone with ENV["TZ"]) do
+  it(%(changes timezone with ENV["TZ"])) do
     old_tz = ENV["TZ"]?
 
     begin
@@ -631,7 +631,7 @@ describe Time do
     end
   end
 
-  it "does diff of utc vs local time" do
+  it("does diff of utc vs local time") do
     local = Time.now
     utc = local.to_utc
     (utc - local).should eq(0.seconds)

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -11,17 +11,17 @@ private class TupleSpecObj
   end
 end
 
-describe "Tuple" do
-  it "does size" do
+describe("Tuple") do
+  it("does size") do
     {1, 2, 1, 2}.size.should eq(4)
   end
 
-  it "checks empty?" do
+  it("checks empty?") do
     Tuple.new.empty?.should be_true
     {1}.empty?.should be_false
   end
 
-  it "does []" do
+  it("does []") do
     a = {1, 2.5}
     i = 0
     a[i].should eq(1)
@@ -33,7 +33,7 @@ describe "Tuple" do
     a[i].should eq(1)
   end
 
-  it "does [] raises index out of bounds" do
+  it("does [] raises index out of bounds") do
     a = {1, 2.5}
     i = 2
     expect_raises(IndexError) { a[i] }
@@ -41,7 +41,7 @@ describe "Tuple" do
     expect_raises(IndexError) { a[i] }
   end
 
-  it "does []?" do
+  it("does []?") do
     a = {1, 2}
     i = 1
     a[i]?.should eq(2)
@@ -53,7 +53,7 @@ describe "Tuple" do
     a[i]?.should be_nil
   end
 
-  it "does at" do
+  it("does at") do
     a = {1, 2}
     a.at(1).should eq(2)
     a.at(-1).should eq(2)
@@ -65,23 +65,23 @@ describe "Tuple" do
     a.at(-3) { 3 }.should eq(3)
   end
 
-  describe "values_at" do
-    it "returns the given indexes" do
+  describe("values_at") do
+    it("returns the given indexes") do
       {"a", "b", "c", "d"}.values_at(1, 0, 2).should eq({"b", "a", "c"})
     end
 
-    it "raises when passed an invalid index" do
-      expect_raises IndexError do
+    it("raises when passed an invalid index") do
+      expect_raises(IndexError) do
         {"a"}.values_at(10)
       end
     end
 
-    it "works with mixed types" do
+    it("works with mixed types") do
       {1, "a", 1.0, :a}.values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
     end
   end
 
-  it "does ==" do
+  it("does ==") do
     a = {1, 2}
     b = {3, 4}
     c = {1, 2, 3}
@@ -94,15 +94,15 @@ describe "Tuple" do
     a.should_not eq(d)
   end
 
-  it "does == with different types but same size" do
+  it("does == with different types but same size") do
     {1, 2}.should eq({1.0, 2.0})
   end
 
-  it "does == with another type" do
+  it("does == with another type") do
     {1, 2}.should_not eq(1)
   end
 
-  it "does compare" do
+  it("does compare") do
     a = {1, 2}
     b = {3, 4}
     c = {1, 6}
@@ -112,7 +112,7 @@ describe "Tuple" do
     [a, b, c, d, e].min.should eq(e)
   end
 
-  it "does compare with different sizes" do
+  it("does compare with different sizes") do
     a = {2}
     b = {1, 2, 3}
     c = {1, 2}
@@ -122,11 +122,11 @@ describe "Tuple" do
     [a, b, c, d, e].min.should eq(d)
   end
 
-  it "does to_s" do
+  it("does to_s") do
     {1, 2, 3}.to_s.should eq("{1, 2, 3}")
   end
 
-  it "does each" do
+  it("does each") do
     a = 0
     {1, 2, 3}.each do |i|
       a += i
@@ -134,7 +134,7 @@ describe "Tuple" do
     a.should eq(6)
   end
 
-  it "does dup" do
+  it("does dup") do
     r1, r2 = TupleSpecObj.new(10), TupleSpecObj.new(20)
     t = {r1, r2}
     u = t.dup
@@ -143,7 +143,7 @@ describe "Tuple" do
     u[1].should be(r2)
   end
 
-  it "does clone" do
+  it("does clone") do
     r1, r2 = TupleSpecObj.new(10), TupleSpecObj.new(20)
     t = {r1, r2}
     u = t.clone
@@ -154,17 +154,17 @@ describe "Tuple" do
     u[1].should_not be(r2)
   end
 
-  it "does Tuple.new" do
+  it("does Tuple.new") do
     Tuple.new(1, 2, 3).should eq({1, 2, 3})
     Tuple.new([1, 2, 3]).should eq({[1, 2, 3]})
   end
 
-  it "does Tuple.from" do
+  it("does Tuple.from") do
     t = Tuple(Int32, Float64).from([1_i32, 2.0_f64])
     t.should eq({1_i32, 2.0_f64})
     t.class.should eq(Tuple(Int32, Float64))
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       Tuple(Int32).from([1, 2])
     end
 
@@ -173,12 +173,12 @@ describe "Tuple" do
     end
   end
 
-  it "does Tuple#from" do
+  it("does Tuple#from") do
     t = {Int32, Float64}.from([1_i32, 2.0_f64])
     t.should eq({1_i32, 2.0_f64})
     t.class.should eq(Tuple(Int32, Float64))
 
-    expect_raises ArgumentError do
+    expect_raises(ArgumentError) do
       {Int32}.from([1, 2])
     end
 
@@ -187,11 +187,11 @@ describe "Tuple" do
     end
   end
 
-  it "clones empty tuple" do
+  it("clones empty tuple") do
     Tuple.new.clone.should eq(Tuple.new)
   end
 
-  it "does iterator" do
+  it("does iterator") do
     iter = {1, 2, 3}.each
 
     iter.next.should eq(1)
@@ -203,18 +203,18 @@ describe "Tuple" do
     iter.next.should eq(1)
   end
 
-  it "does map" do
+  it("does map") do
     tuple = {1, 2.5, "a"}
     tuple2 = tuple.map &.to_s
     tuple2.is_a?(Tuple).should be_true
     tuple2.should eq({"1", "2.5", "a"})
   end
 
-  it "does reverse" do
+  it("does reverse") do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end
 
-  it "does reverse_each" do
+  it("does reverse_each") do
     str = ""
     {"a", "b", "c"}.reverse_each do |i|
       str += i
@@ -222,8 +222,8 @@ describe "Tuple" do
     str.should eq("cba")
   end
 
-  describe "reverse_each iterator" do
-    it "does next" do
+  describe("reverse_each iterator") do
+    it("does next") do
       a = {1, 2, 3}
       iter = a.reverse_each
       iter.next.should eq(3)
@@ -236,57 +236,57 @@ describe "Tuple" do
     end
   end
 
-  it "gets first element" do
+  it("gets first element") do
     tuple = {1, 2.5}
     tuple.first.should eq(1)
     typeof(tuple.first).should eq(Int32)
   end
 
-  it "gets first? element" do
+  it("gets first? element") do
     tuple = {1, 2.5}
     tuple.first?.should eq(1)
 
     Tuple.new.first?.should be_nil
   end
 
-  it "gets last element" do
+  it("gets last element") do
     tuple = {1, 2.5, "a"}
     tuple.last.should eq("a")
     typeof(tuple.last).should eq(String)
   end
 
-  it "gets last? element" do
+  it("gets last? element") do
     tuple = {1, 2.5, "a"}
     tuple.last?.should eq("a")
 
     Tuple.new.last?.should be_nil
   end
 
-  it "does comparison" do
+  it("does comparison") do
     tuple1 = {"a", "a", "c"}
     tuple2 = {"a", "b", "c"}
     (tuple1 <=> tuple2).should eq(-1)
     (tuple2 <=> tuple1).should eq(1)
   end
 
-  it "does <=> for equality" do
+  it("does <=> for equality") do
     tuple1 = {0, 1}
     tuple2 = {0.0, 1}
     (tuple1 <=> tuple2).should eq(0)
   end
 
-  it "does <=> with the same beginning and different size" do
+  it("does <=> with the same beginning and different size") do
     tuple1 = {1, 2, 3}
     tuple2 = {1, 2}
     (tuple1 <=> tuple2).should eq(1)
   end
 
-  it "does types" do
+  it("does types") do
     tuple = {1, 'a', "hello"}
     tuple.class.types.to_s.should eq("{Int32, Char, String}")
   end
 
-  it "does ===" do
+  it("does ===") do
     ({1, 2} === {1, 2}).should be_true
     ({1, 2} === {1, 3}).should be_false
     ({1, 2, 3} === {1, 2}).should be_false

--- a/spec/std/uint_spec.cr
+++ b/spec/std/uint_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 
-describe "UInt" do
-  it "compares with <=>" do
+describe("UInt") do
+  it("compares with <=>") do
     (1_u32 <=> 0_u32).should eq(1)
     (0_u32 <=> 0_u32).should eq(0)
     (0_u32 <=> 1_u32).should eq(-1)

--- a/spec/std/uri/uri_parser_spec.cr
+++ b/spec/std/uri/uri_parser_spec.cr
@@ -208,8 +208,8 @@ require "uri"
 #     fragment, "frag"
 # end
 
-describe URI::Parser, "#run" do
-  it "runs for normal urls" do
+describe(URI::Parser, "#run") do
+  it("runs for normal urls") do
     uri = URI::Parser.new("http://user:pass@bitfission.com:8080/path?a=b#frag").run.uri
     uri.scheme.should eq("http")
     uri.user.should eq("user")
@@ -221,7 +221,7 @@ describe URI::Parser, "#run" do
     uri.fragment.should eq("frag")
   end
 
-  it "runs for schemelss urls" do
+  it("runs for schemelss urls") do
     uri = URI::Parser.new("//user:pass@bitfission.com:8080/path?a=b#frag").run.uri
     uri.scheme.should eq(nil)
     uri.user.should eq("user")
@@ -233,7 +233,7 @@ describe URI::Parser, "#run" do
     uri.fragment.should eq("frag")
   end
 
-  it "runs for path relative urls" do
+  it("runs for path relative urls") do
     uri = URI::Parser.new("/path?a=b#frag").run.uri
     uri.scheme.should eq(nil)
     uri.host.should eq(nil)
@@ -242,13 +242,13 @@ describe URI::Parser, "#run" do
     uri.fragment.should eq("frag")
   end
 
-  it "runs for path mailto" do
+  it("runs for path mailto") do
     uri = URI::Parser.new("mailto:user@example.com").run.uri
     uri.scheme.should eq("mailto")
     uri.opaque.should eq("user@example.com")
   end
 
-  it "runs for file wth and without host" do
+  it("runs for file wth and without host") do
     uri = URI::Parser.new("file://localhost/etc/fstab").run.uri
     uri.scheme.should eq("file")
     uri.host.should eq("localhost")
@@ -260,13 +260,13 @@ describe URI::Parser, "#run" do
     uri.path.should eq("/etc/fstab")
   end
 
-  it "runs for scheme and path only urls" do
+  it("runs for scheme and path only urls") do
     uri = URI::Parser.new("test:/test").run.uri
     uri.scheme.should eq("test")
     uri.path.should eq("/test")
   end
 
-  context "bad urls" do
+  context("bad urls") do
     it { expect_raises(URI::Error) { URI::Parser.new("http://some.com:8f80/path").run } }
   end
 end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "uri"
 
 private def assert_uri(string, scheme = nil, host = nil, port = nil, path = "", query = nil, user = nil, password = nil, fragment = nil, opaque = nil)
-  it "parse #{string}" do
+  it("parse #{string}") do
     uri = URI.parse(string)
     uri.scheme.should eq(scheme)
     uri.host.should eq(host)
@@ -16,7 +16,7 @@ private def assert_uri(string, scheme = nil, host = nil, port = nil, path = "", 
   end
 end
 
-describe "URI" do
+describe("URI") do
   assert_uri("http://www.example.com", scheme: "http", host: "www.example.com")
   assert_uri("http://www.example.com:81", scheme: "http", host: "www.example.com", port: 81)
   assert_uri("http://www.example.com/foo", scheme: "http", host: "www.example.com", path: "/foo")
@@ -39,8 +39,8 @@ describe "URI" do
   it { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
   it { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
 
-  describe "normalize" do
-    it "removes dot notation from path" do
+  describe("normalize") do
+    it("removes dot notation from path") do
       cases = {
         "../bar"      => "bar",
         "./bar"       => "bar",
@@ -67,21 +67,21 @@ describe "URI" do
     end
   end
 
-  it "implements ==" do
+  it("implements ==") do
     URI.parse("http://example.com").should eq(URI.parse("http://example.com"))
   end
 
-  it "implements hash" do
+  it("implements hash") do
     URI.parse("http://example.com").hash.should eq(URI.parse("http://example.com").hash)
   end
 
-  describe "userinfo" do
+  describe("userinfo") do
     it { URI.parse("http://www.example.com").userinfo.should be_nil }
     it { URI.parse("http://foo@www.example.com").userinfo.should eq("foo") }
     it { URI.parse("http://foo:bar@www.example.com").userinfo.should eq("foo:bar") }
   end
 
-  describe "to_s" do
+  describe("to_s") do
     it { URI.new("http", "www.example.com").to_s.should eq("http://www.example.com") }
     it { URI.new("http", "www.example.com", 80).to_s.should eq("http://www.example.com") }
     it do
@@ -106,7 +106,7 @@ describe "URI" do
     it { URI.new("mailto", opaque: "foo@example.com").to_s.should eq("mailto:foo@example.com") }
   end
 
-  describe ".unescape" do
+  describe(".unescape") do
     {
       {"hello", "hello"},
       {"hello%20world", "hello world"},
@@ -120,31 +120,31 @@ describe "URI" do
       {"%e3%81%aa%e3%81%aa", "なな"},
       {"%27Stop%21%27+said+Fred", "'Stop!'+said+Fred"},
     }.each do |(from, to)|
-      it "unescapes #{from}" do
+      it("unescapes #{from}") do
         URI.unescape(from).should eq(to)
       end
 
-      it "unescapes #{from} to IO" do
+      it("unescapes #{from} to IO") do
         String.build do |str|
           URI.unescape(from, str)
         end.should eq(to)
       end
     end
 
-    it "unescapes plus to space" do
+    it("unescapes plus to space") do
       URI.unescape("hello+world", plus_to_space: true).should eq("hello world")
       String.build do |str|
         URI.unescape("hello+world", str, plus_to_space: true)
       end.should eq("hello world")
     end
 
-    it "does not unescape string when block returns true" do
+    it("does not unescape string when block returns true") do
       URI.unescape("hello%26world") { |byte| URI.reserved? byte }
          .should eq("hello%26world")
     end
   end
 
-  describe ".escape" do
+  describe(".escape") do
     [
       {"hello", "hello"},
       {"hello%20world", "hello world"},
@@ -157,59 +157,59 @@ describe "URI" do
       {"%27Stop%21%27%20said%20Fred", "'Stop!' said Fred"},
       {"%0A", "\n"},
     ].each do |(from, to)|
-      it "escapes #{to}" do
+      it("escapes #{to}") do
         URI.escape(to).should eq(from)
       end
 
-      it "escapes #{to} to IO" do
+      it("escapes #{to} to IO") do
         String.build do |str|
           URI.escape(to, str)
         end.should eq(from)
       end
     end
 
-    describe "invalid utf8 strings" do
+    describe("invalid utf8 strings") do
       input = String.new(1) { |buf| buf.value = 255_u8; {1, 0} }
 
-      it "escapes without failing" do
+      it("escapes without failing") do
         URI.escape(input).should eq("%FF")
       end
 
-      it "escapes to IO without failing" do
+      it("escapes to IO without failing") do
         String.build do |str|
           URI.escape(input, str)
         end.should eq("%FF")
       end
     end
 
-    it "escape space to plus when space_to_plus flag is true" do
+    it("escape space to plus when space_to_plus flag is true") do
       URI.escape("hello world", space_to_plus: true).should eq("hello+world")
       URI.escape("'Stop!' said Fred", space_to_plus: true).should eq("%27Stop%21%27+said+Fred")
     end
 
-    it "does not escape character when block returns true" do
+    it("does not escape character when block returns true") do
       URI.unescape("hello&world") { |byte| URI.reserved? byte }
          .should eq("hello&world")
     end
   end
 
-  describe "reserved?" do
+  describe("reserved?") do
     reserved_chars = Set.new([':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='])
 
     ('\u{00}'..'\u{7F}').each do |char|
       ok = reserved_chars.includes? char
-      it "should return #{ok} on given #{char}" do
+      it("should return #{ok} on given #{char}") do
         URI.reserved?(char.ord.to_u8).should eq(ok)
       end
     end
   end
 
-  describe "unreserved?" do
+  describe("unreserved?") do
     unreserved_chars = Set.new(('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '.', '-', '~'])
 
     ('\u{00}'..'\u{7F}').each do |char|
       ok = unreserved_chars.includes? char
-      it "should return #{ok} on given #{char}" do
+      it("should return #{ok} on given #{char}") do
         URI.unreserved?(char.ord.to_u8).should eq(ok)
       end
     end

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -26,27 +26,27 @@ private class Foo
   end
 end
 
-describe WeakRef do
-  it "should get dereferenced object" do
+describe(WeakRef) do
+  it("should get dereferenced object") do
     foo = Foo.new :foo
     ref = WeakRef.new(foo)
     ref.should_not be_nil
     ref.value.should be(foo)
   end
 
-  it "should get dereferenced object in data section" do
+  it("should get dereferenced object in data section") do
     foo = "foo"
     ref = WeakRef.new(foo)
     ref.value.should be(foo)
   end
 
-  it "should not crash with object in data section during GC" do
+  it("should not crash with object in data section during GC") do
     foo = "foo"
     ref = WeakRef.new(foo)
     GC.collect
   end
 
-  it "State counts released objects" do
+  it("State counts released objects") do
     State.reset
     State.count(:foo).should eq 0
     10.times do
@@ -56,7 +56,7 @@ describe WeakRef do
     State.count(:foo).should be > 0
   end
 
-  it "Referenced object should not be released" do
+  it("Referenced object should not be released") do
     State.reset
     instances = [] of Foo
     State.count(:strong_foo_ref).should eq 0
@@ -67,7 +67,7 @@ describe WeakRef do
     State.count(:strong_foo_ref).should eq 0
   end
 
-  it "Weak referenced object should be released if no other reference" do
+  it("Weak referenced object should be released if no other reference") do
     State.reset
     instances = [] of WeakRef(Foo)
     last = nil

--- a/spec/std/xml/builder_spec.cr
+++ b/spec/std/xml/builder_spec.cr
@@ -8,19 +8,19 @@ private def assert_built(expected, quote_char = nil)
   string.should eq(expected)
 end
 
-describe XML::Builder do
-  it "writes document" do
+describe(XML::Builder) do
+  it("writes document") do
     assert_built(%[<?xml version=\"1.0\"?>\n\n]) do
     end
   end
 
-  it "writes element" do
+  it("writes element") do
     assert_built(%[<?xml version="1.0"?>\n<foo/>\n]) do
       element("foo") { }
     end
   end
 
-  it "writes nested element" do
+  it("writes nested element") do
     assert_built(%[<?xml version="1.0"?>\n<foo><bar/></foo>\n]) do
       element("foo") do
         element("bar") { }
@@ -28,19 +28,19 @@ describe XML::Builder do
     end
   end
 
-  it "writes element with namspace" do
+  it("writes element with namspace") do
     assert_built(%[<?xml version="1.0"?>\n<x:foo id="1" xmlns:x="http://foo.com"/>\n]) do
       element("x", "foo", "http://foo.com", id: 1) { }
     end
   end
 
-  it "writes element with namspace, without block" do
+  it("writes element with namspace, without block") do
     assert_built(%[<?xml version="1.0"?>\n<x:foo id="1" xmlns:x="http://foo.com"/>\n]) do
       element("x", "foo", "http://foo.com", id: 1)
     end
   end
 
-  it "writes attribute" do
+  it("writes attribute") do
     assert_built(%[<?xml version="1.0"?>\n<foo id="1"/>\n]) do
       element("foo") do
         attribute("id", 1)
@@ -48,7 +48,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes attribute with namespace" do
+  it("writes attribute with namespace") do
     assert_built(%[<?xml version="1.0"?>\n<foo x:id="1" xmlns:x="http://ww.foo.com"/>\n]) do
       element("foo") do
         attribute("x", "id", "http://ww.foo.com", 1)
@@ -56,7 +56,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes text" do
+  it("writes text") do
     assert_built(%[<?xml version="1.0"?>\n<foo>1 &lt; 2</foo>\n]) do
       element("foo") do
         text "1 < 2"
@@ -64,7 +64,7 @@ describe XML::Builder do
     end
   end
 
-  it "sets indent with string" do
+  it("sets indent with string") do
     assert_built("<?xml version=\"1.0\"?>\n<foo>\n\t<bar/>\n</foo>\n") do |xml|
       xml.indent = "\t"
       element("foo") do
@@ -73,7 +73,7 @@ describe XML::Builder do
     end
   end
 
-  it "sets indent with count" do
+  it("sets indent with count") do
     assert_built("<?xml version=\"1.0\"?>\n<foo>\n  <bar/>\n</foo>\n") do |xml|
       xml.indent = 2
       element("foo") do
@@ -82,7 +82,7 @@ describe XML::Builder do
     end
   end
 
-  it "sets quote char" do
+  it("sets quote char") do
     assert_built("<?xml version='1.0'?>\n<foo id='1'/>\n", quote_char: '\'') do |xml|
       element("foo") do
         attribute("id", 1)
@@ -90,13 +90,13 @@ describe XML::Builder do
     end
   end
 
-  it "writes element with attributes as named tuple" do
+  it("writes element with attributes as named tuple") do
     assert_built(%[<?xml version="1.0"?>\n<foo id="1" name="foo"/>\n]) do |xml|
       element("foo", id: 1, name: "foo")
     end
   end
 
-  it "writes element with attributes as named tuple, nesting" do
+  it("writes element with attributes as named tuple, nesting") do
     assert_built(%[<?xml version="1.0"?>\n<foo id="1" name="foo" baz="2"/>\n]) do |xml|
       element("foo", id: 1, name: "foo") do
         attribute "baz", 2
@@ -104,13 +104,13 @@ describe XML::Builder do
     end
   end
 
-  it "writes element with attributes as hash" do
+  it("writes element with attributes as hash") do
     assert_built(%[<?xml version="1.0"?>\n<foo id="1" name="foo"/>\n]) do |xml|
       element("foo", {"id" => 1, "name" => "foo"})
     end
   end
 
-  it "writes element with attributes as hash, nesting" do
+  it("writes element with attributes as hash, nesting") do
     assert_built(%[<?xml version="1.0"?>\n<foo id="1" name="foo" baz="2"/>\n]) do |xml|
       element("foo", {"id" => 1, "name" => "foo"}) do
         attribute "baz", 2
@@ -118,7 +118,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes cdata" do
+  it("writes cdata") do
     assert_built(%{<?xml version="1.0"?>\n<foo><![CDATA[hello]]></foo>\n}) do |xml|
       element("foo") do
         cdata("hello")
@@ -126,7 +126,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes cdata with block" do
+  it("writes cdata with block") do
     assert_built(%{<?xml version="1.0"?>\n<foo><![CDATA[hello]]></foo>\n}) do |xml|
       element("foo") do
         cdata do
@@ -136,7 +136,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes comment" do
+  it("writes comment") do
     assert_built(%{<?xml version="1.0"?>\n<foo><!--hello--></foo>\n}) do |xml|
       element("foo") do
         comment("hello")
@@ -144,7 +144,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes comment with block" do
+  it("writes comment with block") do
     assert_built(%{<?xml version="1.0"?>\n<foo><!--hello--></foo>\n}) do |xml|
       element("foo") do
         comment do
@@ -154,21 +154,21 @@ describe XML::Builder do
     end
   end
 
-  it "writes DTD" do
+  it("writes DTD") do
     assert_built(%{<?xml version="1.0"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" [subset]>\n}) do |xml|
       dtd "html", "-//W3C//DTD XHTML 1.0 Transitional//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd", "subset"
     end
   end
 
-  it "writes DTD with block" do
+  it("writes DTD with block") do
     assert_built(%{<?xml version="1.0"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" [subset]>\n}) do |xml|
-      dtd "html", "-//W3C//DTD XHTML 1.0 Transitional//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" do
+      dtd("html", "-//W3C//DTD XHTML 1.0 Transitional//EN", "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd") do
         text "subset"
       end
     end
   end
 
-  it "writes namespace" do
+  it("writes namespace") do
     assert_built(%{<?xml version="1.0"?>\n<foo x:xmlns="http://foo.com"/>\n}) do |xml|
       element("foo") do
         namespace "x", "http://foo.com"
@@ -176,7 +176,7 @@ describe XML::Builder do
     end
   end
 
-  it "writes to string" do
+  it("writes to string") do
     str = XML.build do |xml|
       xml.element("foo", id: 1) do
         xml.text "hello"
@@ -185,7 +185,7 @@ describe XML::Builder do
     str.should eq("<?xml version=\"1.0\"?>\n<foo id=\"1\">hello</foo>\n")
   end
 
-  it "writes to IO" do
+  it("writes to IO") do
     io = IO::Memory.new
     XML.build(io) do |xml|
       xml.element("foo", id: 1) do

--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "xml"
 
-describe XML do
-  it "parses HTML" do
+describe(XML) do
+  it("parses HTML") do
     doc = XML.parse_html(%(\
       <!doctype html>
       <html>
@@ -39,7 +39,7 @@ describe XML do
     attr.inner_text.should eq("large")
   end
 
-  it "parses HTML from IO" do
+  it("parses HTML from IO") do
     io = IO::Memory.new(%(\
       <!doctype html>
       <html>
@@ -57,20 +57,20 @@ describe XML do
     html.name.should eq("html")
   end
 
-  it "parses html5 (#1404)" do
+  it("parses html5 (#1404)") do
     html5 = "<html><body><nav>Test</nav></body></html>"
     xml = XML.parse_html(html5)
     xml.errors.should_not be_nil
     xml.xpath_node("//html/body/nav").should_not be_nil
   end
 
-  it "raises error when parsing empty string (#2752)" do
-    expect_raises XML::Error, "Document is empty" do
+  it("raises error when parsing empty string (#2752)") do
+    expect_raises(XML::Error, "Document is empty") do
       XML.parse_html("")
     end
   end
 
-  it "gets name of HTML document node (#4040)" do
+  it("gets name of HTML document node (#4040)") do
     doc = XML.parse_html(%(\
       <!doctype html>
       <html>

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "xml"
 
-describe XML do
-  it "parses" do
+describe(XML) do
+  it("parses") do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <people>
@@ -76,7 +76,7 @@ describe XML do
     name.parent.should eq(person)
   end
 
-  it "parses from io" do
+  it("parses from io") do
     io = IO::Memory.new(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <people>
@@ -96,13 +96,13 @@ describe XML do
     person["id"].should eq("1")
   end
 
-  it "raises exception on empty string" do
-    expect_raises XML::Error, "Document is empty" do
+  it("raises exception on empty string") do
+    expect_raises(XML::Error, "Document is empty") do
       XML.parse("")
     end
   end
 
-  it "does to_s" do
+  it("does to_s") do
     string = <<-XML
       <?xml version='1.0' encoding='UTF-8'?>\
       <people>
@@ -124,7 +124,7 @@ describe XML do
     )
   end
 
-  it "navigates in tree" do
+  it("navigates in tree") do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <people>
@@ -157,7 +157,7 @@ describe XML do
     person2.previous_element.should eq(person)
   end
 
-  it "handles errors" do
+  it("handles errors") do
     xml = XML.parse(%(<people>))
     xml.root.not_nil!.name.should eq("people")
     errors = xml.errors.not_nil!
@@ -167,7 +167,7 @@ describe XML do
     errors[0].to_s.should eq("Premature end of data in tag people line 1")
   end
 
-  it "gets root namespaces scopes" do
+  it("gets root namespaces scopes") do
     doc = XML.parse(<<-XML
       <?xml version="1.0" encoding="UTF-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
@@ -183,7 +183,7 @@ describe XML do
     namespaces[1].prefix.should eq("openSearch")
   end
 
-  it "returns empty array if no namespaces scopes exists" do
+  it("returns empty array if no namespaces scopes exists") do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <name>John</name>
@@ -194,7 +194,7 @@ describe XML do
     namespaces.size.should eq(0)
   end
 
-  it "gets root namespaces as hash" do
+  it("gets root namespaces as hash") do
     doc = XML.parse(<<-XML
       <?xml version="1.0" encoding="UTF-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
@@ -208,14 +208,14 @@ describe XML do
     })
   end
 
-  it "reads big xml file (#1455)" do
+  it("reads big xml file (#1455)") do
     content = "." * 20_000
     string = %(<?xml version="1.0"?><root>#{content}</root>)
     parsed = XML.parse(IO::Memory.new(string))
     parsed.root.not_nil!.children[0].text.should eq(content)
   end
 
-  it "sets node text/content" do
+  it("sets node text/content") do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <name>John</name>
@@ -229,12 +229,12 @@ describe XML do
     root.content.should eq("Foo")
   end
 
-  it "gets empty content" do
+  it("gets empty content") do
     doc = XML.parse("<foo/>")
     doc.children.first.content.should eq("")
   end
 
-  it "sets node name" do
+  it("sets node name") do
     doc = XML.parse(<<-XML
       <?xml version='1.0' encoding='UTF-8'?>
       <name>John</name>
@@ -245,7 +245,7 @@ describe XML do
     root.name.should eq("last-name")
   end
 
-  it "gets encoding" do
+  it("gets encoding") do
     doc = XML.parse(<<-XML
         <?xml version='1.0' encoding='UTF-8'?>
         <people>
@@ -255,7 +255,7 @@ describe XML do
     doc.encoding.should eq("UTF-8")
   end
 
-  it "gets encoding when nil" do
+  it("gets encoding when nil") do
     doc = XML.parse(<<-XML
         <?xml version='1.0'>
         <people>
@@ -265,7 +265,7 @@ describe XML do
     doc.encoding.should be_nil
   end
 
-  it "gets version" do
+  it("gets version") do
     doc = XML.parse(<<-XML
         <?xml version='1.0' encoding='UTF-8'?>
         <people>
@@ -275,7 +275,7 @@ describe XML do
     doc.version.should eq("1.0")
   end
 
-  it "unlinks nodes" do
+  it("unlinks nodes") do
     xml = <<-XML
         <person id="1">
           <firstname>Jane</firstname>
@@ -290,7 +290,7 @@ describe XML do
     document.xpath_node("//lastname").should eq(nil)
   end
 
-  it "does to_s with correct encoding (#2319)" do
+  it("does to_s with correct encoding (#2319)") do
     xml_str = <<-XML
     <?xml version='1.0' encoding='UTF-8'?>
     <person>
@@ -302,21 +302,21 @@ describe XML do
     doc.root.to_s.should eq("<person>\n  <name>たろう</name>\n</person>")
   end
 
-  describe "escape" do
-    it "does not change a safe string" do
+  describe("escape") do
+    it("does not change a safe string") do
       str = XML.escape("safe_string")
 
       str.should eq("safe_string")
     end
 
-    it "escapes dangerous characters from a string" do
+    it("escapes dangerous characters from a string") do
       str = XML.escape("< & >")
 
       str.should eq("&lt; &amp; &gt;")
     end
   end
 
-  it "sets an attribute" do
+  it("sets an attribute") do
     doc = XML.parse(%{<foo />})
     root = doc.root.not_nil!
 
@@ -325,7 +325,7 @@ describe XML do
     root.to_s.should eq(%{<foo bar="baz"/>})
   end
 
-  it "changes an attribute" do
+  it("changes an attribute") do
     doc = XML.parse(%{<foo bar="baz"></foo>})
     root = doc.root.not_nil!
 

--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -16,8 +16,8 @@ private def doc
 end
 
 module XML
-  describe XPathContext do
-    it "finds nodes" do
+  describe(XPathContext) do
+    it("finds nodes") do
       doc = doc()
 
       nodes = doc.xpath("//people/person").as(NodeSet)
@@ -33,7 +33,7 @@ module XML
       nodes.size.should eq(2)
     end
 
-    it "finds string" do
+    it("finds string") do
       doc = doc()
 
       id = doc.xpath("string(//people/person[1]/@id)").as(String)
@@ -43,7 +43,7 @@ module XML
       id.should eq("1")
     end
 
-    it "finds number" do
+    it("finds number") do
       doc = doc()
 
       count = doc.xpath("count(//people/person)").as(Float64)
@@ -53,7 +53,7 @@ module XML
       count.should eq(2)
     end
 
-    it "finds boolean" do
+    it("finds boolean") do
       doc = doc()
 
       id = doc.xpath("boolean(//people/person[1]/@id)").as(Bool)
@@ -63,19 +63,19 @@ module XML
       id.should be_true
     end
 
-    it "raises on invalid xpath" do
-      expect_raises XML::Error do
+    it("raises on invalid xpath") do
+      expect_raises(XML::Error) do
         doc = doc()
         doc.xpath("coco()")
       end
     end
 
-    it "returns nil with invalid xpath" do
+    it("returns nil with invalid xpath") do
       doc = doc()
       doc.xpath_node("//invalid").should be_nil
     end
 
-    it "finds with namespace" do
+    it("finds with namespace") do
       doc = XML.parse(%(\
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
@@ -89,7 +89,7 @@ module XML
       ns.prefix.should be_nil
     end
 
-    it "finds with root namespaces" do
+    it("finds with root namespaces") do
       doc = XML.parse(%(\
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
@@ -103,7 +103,7 @@ module XML
       ns.prefix.should be_nil
     end
 
-    it "finds with variable binding" do
+    it("finds with variable binding") do
       doc = XML.parse(%(\
         <?xml version="1.0" encoding="UTF-8"?>
         <feed>

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -1,65 +1,65 @@
 require "spec"
 require "yaml"
 
-describe YAML::Any do
-  describe "casts" do
-    it "gets nil" do
+describe(YAML::Any) do
+  describe("casts") do
+    it("gets nil") do
       YAML.parse("").as_nil.should be_nil
     end
 
-    it "gets string" do
+    it("gets string") do
       YAML.parse("hello").as_s.should eq("hello")
       YAML.parse("hello").as_s?.should eq("hello")
       YAML.parse("hello:\n- cruel\n- world\n").as_s?.should be_nil
     end
 
-    it "gets array" do
+    it("gets array") do
       YAML.parse("- foo\n- bar\n").as_a.should eq(["foo", "bar"])
       YAML.parse("- foo\n- bar\n").as_a?.should eq(["foo", "bar"])
       YAML.parse("hello").as_a?.should be_nil
     end
 
-    it "gets hash" do
+    it("gets hash") do
       YAML.parse("foo: bar").as_h.should eq({"foo" => "bar"})
       YAML.parse("foo: bar").as_h?.should eq({"foo" => "bar"})
       YAML.parse("foo: bar")["foo"].as_h?.should be_nil
     end
   end
 
-  describe "#size" do
-    it "of array" do
+  describe("#size") do
+    it("of array") do
       YAML.parse("- foo\n- bar\n").size.should eq(2)
     end
 
-    it "of hash" do
+    it("of hash") do
       YAML.parse("foo: bar").size.should eq(1)
     end
   end
 
-  describe "#[]" do
-    it "of array" do
+  describe("#[]") do
+    it("of array") do
       YAML.parse("- foo\n- bar\n")[1].raw.should eq("bar")
     end
 
-    it "of hash" do
+    it("of hash") do
       YAML.parse("foo: bar")["foo"].raw.should eq("bar")
     end
   end
 
-  describe "#[]?" do
-    it "of array" do
+  describe("#[]?") do
+    it("of array") do
       YAML.parse("- foo\n- bar\n")[1]?.not_nil!.raw.should eq("bar")
       YAML.parse("- foo\n- bar\n")[3]?.should be_nil
     end
 
-    it "of hash" do
+    it("of hash") do
       YAML.parse("foo: bar")["foo"]?.not_nil!.raw.should eq("bar")
       YAML.parse("foo: bar")["fox"]?.should be_nil
     end
   end
 
-  describe "each" do
-    it "of array" do
+  describe("each") do
+    it("of array") do
       elems = [] of String
       YAML.parse("- foo\n- bar\n").each do |any|
         elems << any.as_s
@@ -67,7 +67,7 @@ describe YAML::Any do
       elems.should eq(%w(foo bar))
     end
 
-    it "of hash" do
+    it("of hash") do
       elems = [] of String
       YAML.parse("foo: bar").each do |key, value|
         elems << key.to_s << value.to_s
@@ -76,33 +76,33 @@ describe YAML::Any do
     end
   end
 
-  it "traverses big structure" do
+  it("traverses big structure") do
     obj = YAML.parse("--- \nfoo: \n  bar: \n    baz: \n      - qux\n      - fox")
     obj["foo"]["bar"]["baz"][1].as_s.should eq("fox")
   end
 
-  it "compares to other objects" do
+  it("compares to other objects") do
     obj = YAML.parse("- foo\n- bar \n")
     obj.should eq(%w(foo bar))
     obj[0].should eq("foo")
   end
 
-  it "returns array of any when doing parse all" do
+  it("returns array of any when doing parse all") do
     docs = YAML.parse_all("---\nfoo\n---\nbar\n")
     docs[0].as_s.should eq("foo")
     docs[1].as_s.should eq("bar")
   end
 
-  it "can compare with ===" do
+  it("can compare with ===") do
     ("1" === YAML.parse("1")).should be_truthy
   end
 
-  it "exposes $~ when doing Regex#===" do
+  it("exposes $~ when doing Regex#===") do
     (/o+/ === YAML.parse(%("foo"))).should be_truthy
     $~[0].should eq("oo")
   end
 
-  it "is enumerable" do
+  it("is enumerable") do
     nums = YAML.parse("[1, 2, 3]")
     nums.each_with_index do |x, i|
       x.should be_a(YAML::Any)

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -8,14 +8,14 @@ private def assert_built(expected)
   string.should eq(expected)
 end
 
-describe YAML::Builder do
-  it "writes scalar" do
+describe(YAML::Builder) do
+  it("writes scalar") do
     assert_built("--- 1\n...\n") do
       scalar(1)
     end
   end
 
-  it "writes sequence" do
+  it("writes sequence") do
     assert_built("---\n- 1\n- 2\n- 3\n") do
       sequence do
         scalar(1)
@@ -25,7 +25,7 @@ describe YAML::Builder do
     end
   end
 
-  it "writes mapping" do
+  it("writes mapping") do
     assert_built("---\nfoo: 1\nbar: 2\n") do
       mapping do
         scalar("foo")

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -96,15 +96,15 @@ private class YAMLWithPresence
   })
 end
 
-describe "YAML mapping" do
-  it "parses person" do
+describe("YAML mapping") do
+  it("parses person") do
     person = YAMLPerson.from_yaml("---\nname: John\nage: 30\n")
     person.should be_a(YAMLPerson)
     person.name.should eq("John")
     person.age.should eq(30)
   end
 
-  it "parses person without age" do
+  it("parses person without age") do
     person = YAMLPerson.from_yaml("---\nname: John\n")
     person.should be_a(YAMLPerson)
     person.name.should eq("John")
@@ -112,7 +112,7 @@ describe "YAML mapping" do
     person.age.should be_nil
   end
 
-  it "parses person with blank age" do
+  it("parses person with blank age") do
     person = YAMLPerson.from_yaml("---\nname: John\nage:\n")
     person.should be_a(YAMLPerson)
     person.name.should eq("John")
@@ -120,22 +120,22 @@ describe "YAML mapping" do
     person.age.should be_nil
   end
 
-  it "parses array of people" do
+  it("parses array of people") do
     people = Array(YAMLPerson).from_yaml("---\n- name: John\n- name: Doe\n")
     people.size.should eq(2)
     people[0].name.should eq("John")
     people[1].name.should eq("Doe")
   end
 
-  it "parses person with unknown attributes" do
+  it("parses person with unknown attributes") do
     person = YAMLPerson.from_yaml("---\nname: John\nunknown: [1, 2, 3]\nage: 30\n")
     person.should be_a(YAMLPerson)
     person.name.should eq("John")
     person.age.should eq(30)
   end
 
-  it "parses strict person with unknown attributes" do
-    ex = expect_raises YAML::ParseException, "Unknown yaml attribute: foo" do
+  it("parses strict person with unknown attributes") do
+    ex = expect_raises(YAML::ParseException, "Unknown yaml attribute: foo") do
       StrictYAMLPerson.from_yaml <<-YAML
         ---
         name: John
@@ -146,19 +146,19 @@ describe "YAML mapping" do
     ex.location.should eq({3, 1})
   end
 
-  it "does to_yaml" do
+  it("does to_yaml") do
     person = YAMLPerson.from_yaml("---\nname: John\nage: 30\n")
     person2 = YAMLPerson.from_yaml(person.to_yaml)
     person2.should eq(person)
   end
 
-  it "doesn't emit null when doing to_yaml" do
+  it("doesn't emit null when doing to_yaml") do
     person = YAMLPerson.from_yaml("---\nname: John\n")
     (person.to_yaml =~ /age/).should be_falsey
   end
 
-  it "raises if non-nilable attribute is nil" do
-    ex = expect_raises YAML::ParseException, "Missing yaml attribute: name" do
+  it("raises if non-nilable attribute is nil") do
+    ex = expect_raises(YAML::ParseException, "Missing yaml attribute: name") do
       YAMLPerson.from_yaml <<-YAML
         ---
         age: 30
@@ -167,12 +167,12 @@ describe "YAML mapping" do
     ex.location.should eq({2, 1})
   end
 
-  it "doesn't raises on false value when not-nil" do
+  it("doesn't raises on false value when not-nil") do
     yaml = YAMLWithBool.from_yaml("---\nvalue: false\n")
     yaml.value.should be_false
   end
 
-  it "parses yaml with Time::Format converter" do
+  it("parses yaml with Time::Format converter") do
     yaml = YAMLWithTime.from_yaml("---\nvalue: 2014-10-31 23:37:16\n")
     yaml.value.should be_a(Time)
     yaml.value.to_s.should eq("2014-10-31 23:37:16")
@@ -180,14 +180,14 @@ describe "YAML mapping" do
     yaml.to_yaml.should eq("---\nvalue: 2014-10-31 23:37:16\n")
   end
 
-  it "parses YAML with mapping key named 'key'" do
+  it("parses YAML with mapping key named 'key'") do
     yaml = YAMLWithKey.from_yaml("---\nkey: foo\nvalue: 1\npull: 2")
     yaml.key.should eq("foo")
     yaml.value.should eq(1)
     yaml.pull.should eq(2)
   end
 
-  it "allows small types of integer" do
+  it("allows small types of integer") do
     yaml = YAMLWithSmallIntegers.from_yaml(%({"foo": 21, "bar": 7}))
 
     yaml.foo.should eq(21)
@@ -197,8 +197,8 @@ describe "YAML mapping" do
     typeof(yaml.bar).should eq(Int8)
   end
 
-  describe "parses YAML with defaults" do
-    it "mixed" do
+  describe("parses YAML with defaults") do
+    it("mixed") do
       json = YAMLWithDefaults.from_yaml(%({"a":1,"b":"bla"}))
       json.a.should eq 1
       json.b.should eq "bla"
@@ -221,7 +221,7 @@ describe "YAML mapping" do
       # json.b.should eq "Haha"
     end
 
-    it "bool" do
+    it("bool") do
       json = YAMLWithDefaults.from_yaml(%({}))
       json.c.should eq true
       typeof(json.c).should eq Bool
@@ -239,7 +239,7 @@ describe "YAML mapping" do
       json.d.should eq true
     end
 
-    it "with nilable" do
+    it("with nilable") do
       json = YAMLWithDefaults.from_yaml(%({}))
 
       json.e.should eq false
@@ -263,7 +263,7 @@ describe "YAML mapping" do
       json.i.should eq("bla")
     end
 
-    it "create new array every time" do
+    it("create new array every time") do
       json = YAMLWithDefaults.from_yaml(%({}))
       json.h.should eq [1, 2, 3]
       json.h << 4
@@ -274,7 +274,7 @@ describe "YAML mapping" do
     end
   end
 
-  it "parses YAML with any" do
+  it("parses YAML with any") do
     yaml = YAMLWithAny.from_yaml("obj: hello")
     yaml.obj.as_s.should eq("hello")
 
@@ -285,12 +285,12 @@ describe "YAML mapping" do
     yaml.obj["foo"].as_s.should eq("bar")
   end
 
-  it "outputs with converter when nilable" do
+  it("outputs with converter when nilable") do
     yaml = YAMLWithNilableTime.new
     yaml.to_yaml.should eq("--- {}\n")
   end
 
-  it "uses Time::EpochConverter" do
+  it("uses Time::EpochConverter") do
     string = %({"value":1459859781})
     yaml = YAMLWithTimeEpoch.from_yaml(string)
     yaml.value.should be_a(Time)
@@ -298,7 +298,7 @@ describe "YAML mapping" do
     yaml.to_yaml.should eq("---\nvalue: 1459859781\n")
   end
 
-  it "uses Time::EpochMillisConverter" do
+  it("uses Time::EpochMillisConverter") do
     string = %({"value":1459860483856})
     yaml = YAMLWithTimeEpochMillis.from_yaml(string)
     yaml.value.should be_a(Time)
@@ -306,8 +306,8 @@ describe "YAML mapping" do
     yaml.to_yaml.should eq("---\nvalue: 1459860483856\n")
   end
 
-  describe "parses YAML with presence markers" do
-    it "parses person with absent attributes" do
+  describe("parses YAML with presence markers") do
+    it("parses person with absent attributes") do
       yaml = YAMLWithPresence.from_yaml("---\nfirst_name:\n")
       yaml.first_name.should be_nil
       yaml.first_name_present?.should be_true

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -9,49 +9,49 @@ enum YAMLSpecEnum
   Two
 end
 
-describe "YAML serialization" do
-  describe "from_yaml" do
-    it "does Nil#from_yaml" do
+describe("YAML serialization") do
+  describe("from_yaml") do
+    it("does Nil#from_yaml") do
       Nil.from_yaml("--- \n...\n").should be_nil
     end
 
-    it "does Bool#from_yaml" do
+    it("does Bool#from_yaml") do
       Bool.from_yaml("true").should be_true
       Bool.from_yaml("false").should be_false
     end
 
-    it "does Int32#from_yaml" do
+    it("does Int32#from_yaml") do
       Int32.from_yaml("123").should eq(123)
     end
 
-    it "does Int64#from_yaml" do
+    it("does Int64#from_yaml") do
       Int64.from_yaml("123456789123456789").should eq(123456789123456789)
     end
 
-    it "does String#from_yaml" do
+    it("does String#from_yaml") do
       String.from_yaml("hello").should eq("hello")
     end
 
-    it "does Float32#from_yaml" do
+    it("does Float32#from_yaml") do
       Float32.from_yaml("1.5").should eq(1.5)
     end
 
-    it "does Float64#from_yaml" do
+    it("does Float64#from_yaml") do
       value = Float64.from_yaml("1.5")
       value.should eq(1.5)
       value.should be_a(Float64)
     end
 
-    it "does Array#from_yaml" do
+    it("does Array#from_yaml") do
       Array(Int32).from_yaml("---\n- 1\n- 2\n- 3\n").should eq([1, 2, 3])
     end
 
-    it "does Array#from_yaml from IO" do
+    it("does Array#from_yaml from IO") do
       io = IO::Memory.new "---\n- 1\n- 2\n- 3\n"
       Array(Int32).from_yaml(io).should eq([1, 2, 3])
     end
 
-    it "does Array#from_yaml with block" do
+    it("does Array#from_yaml with block") do
       elements = [] of Int32
       Array(Int32).from_yaml("---\n- 1\n- 2\n- 3\n") do |element|
         elements << element
@@ -59,33 +59,33 @@ describe "YAML serialization" do
       elements.should eq([1, 2, 3])
     end
 
-    it "does Hash#from_yaml" do
+    it("does Hash#from_yaml") do
       Hash(Int32, Bool).from_yaml("---\n1: true\n2: false\n").should eq({1 => true, 2 => false})
     end
 
-    it "does Tuple#from_yaml" do
+    it("does Tuple#from_yaml") do
       Tuple(Int32, String, Bool).from_yaml("---\n- 1\n- foo\n- true\n").should eq({1, "foo", true})
     end
 
-    it "does for named tuple" do
+    it("does for named tuple") do
       tuple = NamedTuple(x: Int32, y: String).from_yaml(%({"y": "hello", "x": 1}))
       tuple.should eq({x: 1, y: "hello"})
       tuple.should be_a(NamedTuple(x: Int32, y: String))
     end
 
-    it "does for BigInt" do
+    it("does for BigInt") do
       big = BigInt.from_yaml("123456789123456789123456789123456789123456789")
       big.should be_a(BigInt)
       big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
     end
 
-    it "does for BigFloat" do
+    it("does for BigFloat") do
       big = BigFloat.from_yaml("1234.567891011121314")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
-    it "does for Enum with number" do
+    it("does for Enum with number") do
       YAMLSpecEnum.from_yaml(%("1")).should eq(YAMLSpecEnum::One)
 
       expect_raises do
@@ -93,7 +93,7 @@ describe "YAML serialization" do
       end
     end
 
-    it "does for Enum with string" do
+    it("does for Enum with string") do
       YAMLSpecEnum.from_yaml(%("One")).should eq(YAMLSpecEnum::One)
 
       expect_raises do
@@ -101,7 +101,7 @@ describe "YAML serialization" do
       end
     end
 
-    it "does Time::Format#from_yaml" do
+    it("does Time::Format#from_yaml") do
       pull = YAML::PullParser.new("--- 2014-01-02\n...\n")
       pull.read_stream do
         pull.read_document do
@@ -110,16 +110,16 @@ describe "YAML serialization" do
       end
     end
 
-    it "deserializes union" do
+    it("deserializes union") do
       Array(Int32 | String).from_yaml(%([1, "hello"])).should eq([1, "hello"])
     end
 
-    it "deserializes time" do
+    it("deserializes time") do
       Time.from_yaml(%(2016-11-16T09:55:48-0300)).to_utc.should eq(Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc))
     end
 
-    describe "parse exceptions" do
-      it "has correct location when raises in Nil#from_yaml" do
+    describe("parse exceptions") do
+      it("has correct location when raises in Nil#from_yaml") do
         ex = expect_raises(YAML::ParseException) do
           Array(Nil).from_yaml <<-YAML
             [
@@ -131,7 +131,7 @@ describe "YAML serialization" do
         ex.location.should eq({2, 3})
       end
 
-      it "has correct location when raises in Int32#from_yaml" do
+      it("has correct location when raises in Int32#from_yaml") do
         ex = expect_raises(YAML::ParseException) do
           Array(Int32).from_yaml <<-YAML
             [
@@ -142,7 +142,7 @@ describe "YAML serialization" do
         ex.location.should eq({2, 3})
       end
 
-      it "has correct location when raises in NamedTuple#from_yaml" do
+      it("has correct location when raises in NamedTuple#from_yaml") do
         ex = expect_raises(YAML::ParseException) do
           Array({foo: Int32, bar: String}).from_yaml <<-YAML
             [
@@ -153,7 +153,7 @@ describe "YAML serialization" do
         ex.location.should eq({2, 3})
       end
 
-      it "has correct location when raises in Union#from_yaml" do
+      it("has correct location when raises in Union#from_yaml") do
         ex = expect_raises(YAML::ParseException) do
           Array(Int32 | Bool).from_yaml <<-YAML
             [
@@ -166,83 +166,83 @@ describe "YAML serialization" do
     end
   end
 
-  describe "to_yaml" do
-    it "does for Nil" do
+  describe("to_yaml") do
+    it("does for Nil") do
       Nil.from_yaml(nil.to_yaml).should eq(nil)
     end
 
-    it "does for Bool" do
+    it("does for Bool") do
       Bool.from_yaml(true.to_yaml).should eq(true)
       Bool.from_yaml(false.to_yaml).should eq(false)
     end
 
-    it "does for Int32" do
+    it("does for Int32") do
       Int32.from_yaml(1.to_yaml).should eq(1)
     end
 
-    it "does for Float64" do
+    it("does for Float64") do
       Float64.from_yaml(1.5.to_yaml).should eq(1.5)
     end
 
-    it "does for String" do
+    it("does for String") do
       String.from_yaml("hello".to_yaml).should eq("hello")
     end
 
-    it "does for String with stars (#3353)" do
+    it("does for String with stars (#3353)") do
       String.from_yaml("***".to_yaml).should eq("***")
     end
 
-    it "does for String with quote" do
+    it("does for String with quote") do
       String.from_yaml("hel\"lo".to_yaml).should eq("hel\"lo")
     end
 
-    it "does for String with slash" do
+    it("does for String with slash") do
       String.from_yaml("hel\\lo".to_yaml).should eq("hel\\lo")
     end
 
-    it "does for Array" do
+    it("does for Array") do
       Array(Int32).from_yaml([1, 2, 3].to_yaml).should eq([1, 2, 3])
     end
 
-    it "does for Set" do
+    it("does for Set") do
       Array(Int32).from_yaml(Set(Int32).new([1, 1, 2]).to_yaml).should eq([1, 2])
     end
 
-    it "does for Hash" do
+    it("does for Hash") do
       Hash(String, Int32).from_yaml({"foo" => 1, "bar" => 2}.to_yaml).should eq({"foo" => 1, "bar" => 2})
     end
 
-    it "does for Hash with symbol keys" do
+    it("does for Hash with symbol keys") do
       Hash(String, Int32).from_yaml({:foo => 1, :bar => 2}.to_yaml).should eq({"foo" => 1, "bar" => 2})
     end
 
-    it "does for Tuple" do
+    it("does for Tuple") do
       Tuple(Int32, String).from_yaml({1, "hello"}.to_yaml).should eq({1, "hello"})
     end
 
-    it "does for NamedTuple" do
+    it("does for NamedTuple") do
       {x: 1, y: "hello"}.to_yaml.should eq({:x => 1, :y => "hello"}.to_yaml)
     end
 
-    it "does for BigInt" do
+    it("does for BigInt") do
       big = BigInt.new("123456789123456789123456789123456789123456789")
       BigInt.from_yaml(big.to_yaml).should eq(big)
     end
 
-    it "does for BigFloat" do
+    it("does for BigFloat") do
       big = BigFloat.new("1234.567891011121314")
       BigFloat.from_yaml(big.to_yaml).should eq(big)
     end
 
-    it "does for Enum" do
+    it("does for Enum") do
       YAMLSpecEnum.from_yaml(YAMLSpecEnum::One.to_yaml).should eq(YAMLSpecEnum::One)
     end
 
-    it "does for time" do
+    it("does for time") do
       Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc).to_yaml.should eq("--- 2016-11-16T12:55:48+0000\n...\n")
     end
 
-    it "does a full document" do
+    it("does a full document") do
       data = {
         :hello   => "World",
         :integer => 2,
@@ -260,7 +260,7 @@ describe "YAML serialization" do
       data.to_yaml.should eq(expected)
     end
 
-    it "writes to a stream" do
+    it("writes to a stream") do
       string = String.build do |str|
         %w(a b c).to_yaml(str)
       end

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "yaml"
 
 private def assert_raw(string, expected = string, file = __FILE__, line = __LINE__)
-  it "parses raw #{string.inspect}", file, line do
+  it("parses raw #{string.inspect}", file, line) do
     pull = YAML::PullParser.new(string)
     pull.read_stream do
       pull.read_document do
@@ -13,15 +13,15 @@ private def assert_raw(string, expected = string, file = __FILE__, line = __LINE
 end
 
 module YAML
-  describe PullParser do
-    it "reads empty stream" do
+  describe(PullParser) do
+    it("reads empty stream") do
       parser = PullParser.new("")
       parser.kind.should eq(EventKind::STREAM_START)
       parser.read_next.should eq(EventKind::STREAM_END)
       parser.kind.should eq(EventKind::STREAM_END)
     end
 
-    it "reads an empty document" do
+    it("reads an empty document") do
       parser = PullParser.new("---\n...\n")
       parser.read_stream do
         parser.read_document do
@@ -30,7 +30,7 @@ module YAML
       end
     end
 
-    it "reads a scalar" do
+    it("reads a scalar") do
       parser = PullParser.new("--- foo\n...\n")
       parser.read_stream do
         parser.read_document do
@@ -39,7 +39,7 @@ module YAML
       end
     end
 
-    it "reads a scalar having a null character" do
+    it("reads a scalar having a null character") do
       parser = PullParser.new(%(--- "foo\\0bar"\n...\n))
       parser.read_stream do
         parser.read_document do
@@ -48,7 +48,7 @@ module YAML
       end
     end
 
-    it "reads a sequence" do
+    it("reads a sequence") do
       parser = PullParser.new("---\n- 1\n- 2\n- 3\n")
       parser.read_stream do
         parser.read_document do
@@ -61,7 +61,7 @@ module YAML
       end
     end
 
-    it "reads a scalar with an anchor" do
+    it("reads a scalar with an anchor") do
       parser = PullParser.new("--- &foo bar\n...\n")
       parser.read_stream do
         parser.read_document do
@@ -71,7 +71,7 @@ module YAML
       end
     end
 
-    it "reads a sequence with an anchor" do
+    it("reads a sequence with an anchor") do
       parser = PullParser.new("--- &foo []\n")
       parser.read_stream do
         parser.read_document do
@@ -82,7 +82,7 @@ module YAML
       end
     end
 
-    it "reads a mapping" do
+    it("reads a mapping") do
       parser = PullParser.new(%(---\nfoo: 1\nbar: 2\n))
       parser.read_stream do
         parser.read_document do
@@ -96,7 +96,7 @@ module YAML
       end
     end
 
-    it "reads a mapping with an anchor" do
+    it("reads a mapping with an anchor") do
       parser = PullParser.new(%(---\n&lala {}\n))
       parser.read_stream do
         parser.read_document do
@@ -107,7 +107,7 @@ module YAML
       end
     end
 
-    it "parses alias" do
+    it("parses alias") do
       parser = PullParser.new("--- *foo\n")
       parser.read_stream do
         parser.read_document do
@@ -122,7 +122,7 @@ module YAML
     assert_raw %(["hello","world"])
     assert_raw %({"hello":"world"})
 
-    it "raises exception at correct location" do
+    it("raises exception at correct location") do
       parser = PullParser.new("[1]")
       parser.read_stream do
         parser.read_document do

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "yaml"
 
-describe "YAML" do
-  describe "parser" do
+describe("YAML") do
+  describe("parser") do
     it { YAML.parse("foo").should eq("foo") }
     it { YAML.parse("- foo\n- bar").should eq(["foo", "bar"]) }
     it { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
@@ -10,12 +10,12 @@ describe "YAML" do
     it { YAML.parse("--- []\n").should eq([] of YAML::Type) }
     it { YAML.parse("---\n...").should eq("") }
 
-    it "parses recursive sequence" do
+    it("parses recursive sequence") do
       doc = YAML.parse("--- &foo\n- *foo\n")
       doc[0].raw.should be(doc.raw)
     end
 
-    it "parses recursive mapping" do
+    it("parses recursive mapping") do
       doc = YAML.parse(%(--- &1
         friends:
         - *1
@@ -23,14 +23,14 @@ describe "YAML" do
       doc["friends"][0].raw.should be(doc.raw)
     end
 
-    it "parses alias to scalar" do
+    it("parses alias to scalar") do
       doc = YAML.parse("---\n- &x foo\n- *x\n")
       doc.should eq(["foo", "foo"])
       doc[0].raw.should be(doc[1].raw)
     end
 
-    describe "merging with << key" do
-      it "merges other mapping" do
+    describe("merging with << key") do
+      it("merges other mapping") do
         doc = YAML.parse(%(---
           foo: bar
           <<:
@@ -39,7 +39,7 @@ describe "YAML" do
         doc["baz"]?.should eq("foobar")
       end
 
-      it "raises if merging with missing alias" do
+      it("raises if merging with missing alias") do
         expect_raises do
           YAML.parse(%(---
             foo:
@@ -48,7 +48,7 @@ describe "YAML" do
         end
       end
 
-      it "doesn't merge explicit string key <<" do
+      it("doesn't merge explicit string key <<") do
         doc = YAML.parse(%(---
           foo: &foo
             hello: world
@@ -58,7 +58,7 @@ describe "YAML" do
         doc.should eq({"foo" => {"hello" => "world"}, "bar" => {"<<" => {"hello" => "world"}}})
       end
 
-      it "doesn't merge empty mapping" do
+      it("doesn't merge empty mapping") do
         doc = YAML.parse(%(---
           foo: &foo
           bar:
@@ -67,7 +67,7 @@ describe "YAML" do
         doc["bar"].should eq({"<<" => ""})
       end
 
-      it "doesn't merge arrays" do
+      it("doesn't merge arrays") do
         doc = YAML.parse(%(---
           foo: &foo
             - 1
@@ -77,7 +77,7 @@ describe "YAML" do
         doc["bar"].should eq({"<<" => ["1"]})
       end
 
-      it "has correct line/number info (#2585)" do
+      it("has correct line/number info (#2585)") do
         begin
           YAML.parse <<-YAML
             ---
@@ -93,7 +93,7 @@ describe "YAML" do
         end
       end
 
-      it "has correct line/number info (2)" do
+      it("has correct line/number info (2)") do
         begin
           parser = YAML::PullParser.new <<-MSG
 
@@ -112,8 +112,8 @@ describe "YAML" do
         end
       end
 
-      it "has correct message (#4006)" do
-        expect_raises YAML::ParseException, "could not find expected ':' at line 4, column 1, while scanning a simple key at line 3, column 5" do
+      it("has correct message (#4006)") do
+        expect_raises(YAML::ParseException, "could not find expected ':' at line 4, column 1, while scanning a simple key at line 3, column 5") do
           YAML.parse <<-END
             a:
               - "b": >
@@ -122,18 +122,18 @@ describe "YAML" do
         end
       end
 
-      it "parses from IO" do
+      it("parses from IO") do
         YAML.parse(IO::Memory.new("- foo\n- bar")).should eq(["foo", "bar"])
       end
     end
   end
 
-  describe "dump" do
-    it "returns YAML as a string" do
+  describe("dump") do
+    it("returns YAML as a string") do
       YAML.dump(%w(1 2 3)).should eq("---\n- 1\n- 2\n- 3\n")
     end
 
-    it "writes YAML to a stream" do
+    it("writes YAML to a stream") do
       string = String.build do |str|
         YAML.dump(%w(1 2 3), str)
       end

--- a/spec/std/zip/zip_file_spec.cr
+++ b/spec/std/zip/zip_file_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "zip"
 
-describe Zip do
-  it "reads file from memory" do
+describe(Zip) do
+  it("reads file from memory") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -35,7 +35,7 @@ describe Zip do
     end
   end
 
-  it "reads file from file system" do
+  it("reads file from file system") do
     filename = "#{__DIR__}/../data/file.zip"
 
     begin
@@ -74,7 +74,7 @@ describe Zip do
     end
   end
 
-  it "writes comment" do
+  it("writes comment") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -89,7 +89,7 @@ describe Zip do
     end
   end
 
-  it "reads big file" do
+  it("reads big file") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -105,7 +105,7 @@ describe Zip do
     end
   end
 
-  it "reads zip file with different extra in local file header and central directory header" do
+  it("reads zip file with different extra in local file header and central directory header") do
     Zip::File.open("#{__DIR__}/../data/test.zip") do |zip|
       zip.entries.size.should eq(2)
       zip["one.txt"].open(&.gets_to_end).should eq("One")
@@ -113,7 +113,7 @@ describe Zip do
     end
   end
 
-  it "reads zip comment" do
+  it("reads zip comment") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|

--- a/spec/std/zip/zip_spec.cr
+++ b/spec/std/zip/zip_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "zip"
 
-describe Zip do
-  it "writes and reads to memory" do
+describe(Zip) do
+  it("writes and reads to memory") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -32,7 +32,7 @@ describe Zip do
     end
   end
 
-  it "writes entry" do
+  it("writes entry") do
     io = IO::Memory.new
 
     time = Time.new(2017, 1, 14, 2, 3, 4)
@@ -55,7 +55,7 @@ describe Zip do
     end
   end
 
-  it "writes entry uncompressed" do
+  it("writes entry uncompressed") do
     io = IO::Memory.new
 
     text = "contents of foo"
@@ -94,7 +94,7 @@ describe Zip do
     end
   end
 
-  it "adds a directory" do
+  it("adds a directory") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -118,7 +118,7 @@ describe Zip do
     end
   end
 
-  it "writes string" do
+  it("writes string") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -134,7 +134,7 @@ describe Zip do
     end
   end
 
-  it "writes bytes" do
+  it("writes bytes") do
     io = IO::Memory.new
 
     Zip::Writer.open(io) do |zip|
@@ -150,7 +150,7 @@ describe Zip do
     end
   end
 
-  it "writes io" do
+  it("writes io") do
     io = IO::Memory.new
     data = IO::Memory.new("contents of foo")
 
@@ -167,7 +167,7 @@ describe Zip do
     end
   end
 
-  it "writes file" do
+  it("writes file") do
     io = IO::Memory.new
     filename = "#{__DIR__}/../data/test_file.txt"
 

--- a/spec/std/zlib/reader_spec.cr
+++ b/spec/std/zlib/reader_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "zlib"
 
 module Zlib
-  describe Reader do
-    it "should be able to read" do
+  describe(Reader) do
+    it("should be able to read") do
       io = IO::Memory.new
       "789c2bc9c82c5600a2448592d4e21285e292a2ccbc74054520e00200854f087b".scan(/../).each do |match|
         io.write_byte match[0].to_u8(16)
@@ -20,19 +20,19 @@ module Zlib
       reader.read(Bytes.new(10)).should eq(0)
     end
 
-    it "can be closed without sync" do
+    it("can be closed without sync") do
       io = IO::Memory.new(Bytes[120, 156, 3, 0, 0, 0, 0, 1])
       reader = Reader.new(io)
       reader.close
       reader.closed?.should be_true
       io.closed?.should be_false
 
-      expect_raises IO::Error, "Closed stream" do
+      expect_raises(IO::Error, "Closed stream") do
         reader.gets
       end
     end
 
-    it "can be closed with sync (1)" do
+    it("can be closed with sync (1)") do
       io = IO::Memory.new(Bytes[120, 156, 3, 0, 0, 0, 0, 1])
       reader = Reader.new(io, sync_close: true)
       reader.close
@@ -40,7 +40,7 @@ module Zlib
       io.closed?.should be_true
     end
 
-    it "can be closed with sync (2)" do
+    it("can be closed with sync (2)") do
       io = IO::Memory.new(Bytes[120, 156, 3, 0, 0, 0, 0, 1])
       reader = Reader.new(io)
       reader.sync_close = true
@@ -49,13 +49,13 @@ module Zlib
       io.closed?.should be_true
     end
 
-    it "should not read from empty stream" do
+    it("should not read from empty stream") do
       io = IO::Memory.new(Bytes[120, 156, 3, 0, 0, 0, 0, 1])
       reader = Reader.new(io)
       reader.read_byte.should be_nil
     end
 
-    it "should not freeze when reading empty slice" do
+    it("should not freeze when reading empty slice") do
       io = IO::Memory.new
       "789c2bc9c82c5600a2448592d4e21285e292a2ccbc74054520e00200854f087b".scan(/../).each do |match|
         io.write_byte match[0].to_u8(16)

--- a/spec/std/zlib/stress_spec.cr
+++ b/spec/std/zlib/stress_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "zlib"
 
 module Zlib
-  describe Zlib do
-    it "write read should be inverse with random string" do
+  describe(Zlib) do
+    it("write read should be inverse with random string") do
       expected = String.build do |io|
         1_000_000.times { rand(2000).to_i.to_s(32, io) }
       end
@@ -19,7 +19,7 @@ module Zlib
       reader.gets_to_end.should eq(expected)
     end
 
-    it "write read should be inverse (utf-8)" do
+    it("write read should be inverse (utf-8)") do
       expected = "日本さん語日本さん語"
 
       io = IO::Memory.new

--- a/spec/std/zlib/writer_spec.cr
+++ b/spec/std/zlib/writer_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "zlib"
 
 module Zlib
-  describe Writer do
-    it "should be able to write" do
+  describe(Writer) do
+    it("should be able to write") do
       message = "this is a test string !!!!\n"
       io = IO::Memory.new
 
@@ -21,19 +21,19 @@ module Zlib
       reader.gets_to_end.should eq(message)
     end
 
-    it "can be closed without sync" do
+    it("can be closed without sync") do
       io = IO::Memory.new
       writer = Writer.new(io)
       writer.close
       writer.closed?.should be_true
       io.closed?.should be_false
 
-      expect_raises IO::Error, "Closed stream" do
+      expect_raises(IO::Error, "Closed stream") do
         writer.print "a"
       end
     end
 
-    it "can be closed with sync (1)" do
+    it("can be closed with sync (1)") do
       io = IO::Memory.new
       writer = Writer.new(io, sync_close: true)
       writer.close
@@ -41,7 +41,7 @@ module Zlib
       io.closed?.should be_true
     end
 
-    it "can be closed with sync (2)" do
+    it("can be closed with sync (2)") do
       io = IO::Memory.new
       writer = Writer.new(io)
       writer.sync_close = true
@@ -50,7 +50,7 @@ module Zlib
       io.closed?.should be_true
     end
 
-    it "can be flushed" do
+    it("can be flushed") do
       io = IO::Memory.new
       writer = Writer.new(io)
 

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -118,7 +118,7 @@ class Crystal::ASTNode
 end
 
 def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__)
-  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline do
+  it("says syntax error on #{str.inspect}", metafile, metaline, metaendline) do
     begin
       parse str
       fail "Expected SyntaxException to be raised", metafile, metaline

--- a/src/array.cr
+++ b/src/array.cr
@@ -1803,7 +1803,7 @@ class Array(T)
   end
 
   protected def self.heap_sort!(a, n)
-    (n / 2).downto 0 do |p|
+    (n / 2).downto(0) do |p|
       heapify!(a, p, n)
     end
     while n > 1
@@ -1901,7 +1901,7 @@ class Array(T)
   end
 
   protected def self.heap_sort!(a, n, comp)
-    (n / 2).downto 0 do |p|
+    (n / 2).downto(0) do |p|
       heapify!(a, p, n, comp)
     end
     while n > 1

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -35,7 +35,7 @@ module Crystal
       main_return_type = llvm_context.void if node.type.nil_type?
 
       wrapper = llvm_mod.functions.add("__evaluate_wrapper", [] of LLVM::Type, main_return_type) do |func|
-        func.basic_blocks.append "entry" do |builder|
+        func.basic_blocks.append("entry") do |builder|
           argc = llvm_context.int32.const_int(0)
           argv = llvm_context.void_pointer.pointer.null
           ret = builder.call(main, [argc, argv])

--- a/src/compiler/crystal/codegen/phi.cr
+++ b/src/compiler/crystal/codegen/phi.cr
@@ -21,7 +21,7 @@ class Crystal::CodeGenVisitor
       @count = 0
     end
 
-    getter exit_block : LLVM::BasicBlock do
+    getter(exit_block : LLVM::BasicBlock) do
       @codegen.new_block "exit"
     end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -259,7 +259,7 @@ class Crystal::Command
     end
   end
 
-  record CompilerConfig,
+  record(CompilerConfig,
     compiler : Compiler,
     sources : Array(Compiler::Source),
     output_filename : String,
@@ -268,7 +268,7 @@ class Crystal::Command
     specified_output : Bool,
     hierarchy_exp : String?,
     cursor_location : String?,
-    output_format : String? do
+    output_format : String?) do
     def compile(output_filename = self.output_filename)
       compiler.emit_base_filename = original_output_filename
       compiler.compile sources, output_filename

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -4,7 +4,7 @@
 # logic is in `crystal/tools/formatter.cr`.
 
 class Crystal::Command
-  record FormatResult, filename : String, code : Code do
+  record(FormatResult, filename : String, code : Code) do
     enum Code
       FORMAT
       SYNTAX

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -99,7 +99,7 @@ class Crystal::Program
     MacroRunResult.new(out_io.to_s, err_io.to_s, $?)
   end
 
-  record RequireWithTimestamp, filename : String, epoch : Int64 do
+  record(RequireWithTimestamp, filename : String, epoch : Int64) do
     JSON.mapping(filename: String, epoch: Int64)
   end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -410,7 +410,7 @@ module Crystal
       end
     end
 
-    record RecordedRequire, filename : String, relative_to : String? do
+    record(RecordedRequire, filename : String, relative_to : String?) do
       JSON.mapping(filename: String, relative_to: String?)
     end
     property recorded_requires = [] of RecordedRequire

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -360,7 +360,7 @@ class Crystal::Call
           check_return_type(typed_def, typed_def_return_type, match, match_owner)
         end
 
-        check_recursive_splat_call match.def, typed_def_args do
+        check_recursive_splat_call(match.def, typed_def_args) do
           bubbling_exception do
             visitor = MainVisitor.new(program, typed_def_args, typed_def)
             visitor.yield_vars = yield_vars

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2013,7 +2013,7 @@ module Crystal
 
       @while_stack.push node
 
-      with_block_kind :while do
+      with_block_kind(:while) do
         node.body.accept self
       end
 
@@ -2643,7 +2643,7 @@ module Crystal
           merge_rescue_vars exception_handler_vars, all_rescue_vars
 
           # And then accept the ensure part
-          with_block_kind :ensure do
+          with_block_kind(:ensure) do
             node.ensure.try &.accept self
           end
         end
@@ -2665,7 +2665,7 @@ module Crystal
 
           before_ensure_vars = @vars.dup
 
-          with_block_kind :ensure do
+          with_block_kind(:ensure) do
             node_ensure.accept self
           end
 

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -1,7 +1,7 @@
 require "../types"
 
 module Crystal
-  record NamedArgumentType, name : String, type : Type do
+  record(NamedArgumentType, name : String, type : Type) do
     def self.from_args(named_args : Array(NamedArgument)?)
       named_args.try &.map { |named_arg| new(named_arg.name, named_arg.value.type) }
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -41,7 +41,7 @@ module Crystal
       # as belonging to the current parsed call. For example when writing
       #
       # ```
-      # foo bar do
+      # foo(bar) do
       # end
       # ```
       #

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -15,14 +15,14 @@ module Crystal
     property raw : String
     property start : Int32
 
-    record MacroState,
+    record(MacroState,
       whitespace : Bool,
       nest : Int32,
       control_nest : Int32,
       delimiter_state : DelimiterState?,
       beginning_of_line : Bool,
       yields : Bool,
-      comment : Bool do
+      comment : Bool) do
       def self.default
         MacroState.new(true, 0, 0, nil, true, false, false)
       end
@@ -31,13 +31,13 @@ module Crystal
       setter control_nest
     end
 
-    record DelimiterState,
+    record(DelimiterState,
       kind : Symbol,
       nest : Char | String,
       end : Char | String,
       open_count : Int32,
       heredoc_indent : Int32,
-      allow_escapes : Bool do
+      allow_escapes : Bool) do
     end
 
     struct DelimiterState

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -59,7 +59,7 @@ module Crystal
             row do
               cell expr
               ctxs.each do |ctx|
-                cell align: :center do |io|
+                cell(align: :center) do |io|
                   PrettyTypeNameJsonConverter.pretty_type_name(ctx[expr], io)
                 end
               end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -254,7 +254,7 @@ class Crystal::Doc::Generator
   end
 
   def fetch_doc_lines(doc)
-    doc.gsub /\n+/ do |match|
+    doc.gsub(/\n+/) do |match|
       if match.size == 1
         " "
       else

--- a/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
@@ -45,13 +45,13 @@ class Crystal::Doc::MarkdownDocRenderer < Markdown::HTMLRenderer
     end
 
     # Check Type#method(...) or Type or #method(...)
-    text = text.gsub /\b
+    text = text.gsub(/\b
       ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)?(?:\#|\.)(?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?(?:\(.+?\))?)
         |
       ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)?)
         |
       ((?:\#|\.)(?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?(?:\(.+?\))?)
-      /x do |match_text, match|
+      /x) do |match_text, match|
       sharp_index = match_text.index('#')
       dot_index = match_text.index('.')
       kind = sharp_index ? :instance : :class

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -1,31 +1,31 @@
 require "ecr/macros"
 
 module Crystal::Doc
-  record TypeTemplate, type : Type, types : Array(Type) do
+  record(TypeTemplate, type : Type, types : Array(Type)) do
     ECR.def_to_s "#{__DIR__}/html/type.html"
   end
 
-  record ListItemsTemplate, types : Array(Type), current_type : Type? do
+  record(ListItemsTemplate, types : Array(Type), current_type : Type?) do
     ECR.def_to_s "#{__DIR__}/html/list_items.html"
   end
 
-  record MethodSummaryTemplate, title : String, methods : Array(Method) | Array(Macro) do
+  record(MethodSummaryTemplate, title : String, methods : Array(Method) | Array(Macro)) do
     ECR.def_to_s "#{__DIR__}/html/method_summary.html"
   end
 
-  record MethodDetailTemplate, title : String, methods : Array(Method) | Array(Macro) do
+  record(MethodDetailTemplate, title : String, methods : Array(Method) | Array(Macro)) do
     ECR.def_to_s "#{__DIR__}/html/method_detail.html"
   end
 
-  record MethodsInheritedTemplate, type : Type, ancestor : Type, methods : Array(Method), label : String do
+  record(MethodsInheritedTemplate, type : Type, ancestor : Type, methods : Array(Method), label : String) do
     ECR.def_to_s "#{__DIR__}/html/methods_inherited.html"
   end
 
-  record OtherTypesTemplate, title : String, type : Type, other_types : Array(Type) do
+  record(OtherTypesTemplate, title : String, type : Type, other_types : Array(Type)) do
     ECR.def_to_s "#{__DIR__}/html/other_types.html"
   end
 
-  record MainTemplate, body : String, types : Array(Type), repository_name : String do
+  record(MainTemplate, body : String, types : Array(Type), repository_name : String) do
     ECR.def_to_s "#{__DIR__}/html/main.html"
   end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2108,7 +2108,7 @@ module Crystal
               last_arg = args.pop
             end
 
-            has_newlines, found_comment, _ = format_args args, true, node.named_args
+            has_newlines, found_comment, _ = format_args args, node.named_args
             if @token.type == :"," || @token.type == :NEWLINE
               if has_newlines
                 write ","
@@ -2212,7 +2212,7 @@ module Crystal
       if (node.name == "[]" || node.name == "[]?") && @token.type == :"["
         write "["
         next_token_skip_space_or_newline
-        format_call_args(node, false)
+        format_call_args(node)
         write_token :"]"
         write_token :"?" if node.name == "[]?"
         return false
@@ -2240,7 +2240,7 @@ module Crystal
           has_parentheses = true
           slash_is_regex!
           next_token
-          format_call_args(node, true)
+          format_call_args(node)
           skip_space_or_newline
           write_token :")"
         else
@@ -2275,7 +2275,7 @@ module Crystal
 
         write "("
         has_parentheses = true
-        has_newlines, found_comment = format_call_args(node, true)
+        has_newlines, found_comment = format_call_args(node)
         found_comment ||= skip_space
         if @token.type == :NEWLINE
           ends_with_newline = true
@@ -2284,7 +2284,7 @@ module Crystal
       elsif has_args || node.block_arg
         write " " unless passed_backslash_newline
         skip_space
-        has_newlines, found_comment = format_call_args(node, false)
+        has_newlines, found_comment = format_call_args(node)
       end
 
       if block = node.block
@@ -2311,11 +2311,11 @@ module Crystal
       false
     end
 
-    def format_call_args(node : ASTNode, has_parentheses)
-      format_args node.args, has_parentheses, node.named_args, node.block_arg
+    def format_call_args(node : ASTNode)
+      format_args node.args, node.named_args, node.block_arg
     end
 
-    def format_args(args : Array, has_parentheses, named_args = nil, block_arg = nil, needed_indent = @indent + 2, do_consume_newlines = false)
+    def format_args(args : Array, named_args = nil, block_arg = nil, needed_indent = @indent + 2, do_consume_newlines = false)
       has_newlines = false
       found_comment = false
       @inside_call_or_assign += 1
@@ -2414,7 +2414,7 @@ module Crystal
         end
       end
 
-      format_args named_args, false, needed_indent: named_args_column, do_consume_newlines: true
+      format_args named_args, needed_indent: named_args_column, do_consume_newlines: true
     end
 
     def format_block_arg(block_arg, needed_indent)
@@ -2469,7 +2469,7 @@ module Crystal
     def format_parenthesized_args(args, named_args = nil)
       write "("
       next_token_skip_space
-      has_newlines, found_comment, _ = format_args args, true, named_args: named_args
+      has_newlines, found_comment, _ = format_args args, named_args: named_args
       skip_space
       ends_with_newline = @token.type == :NEWLINE
       finish_args(true, has_newlines, ends_with_newline, found_comment, @indent)
@@ -2539,7 +2539,7 @@ module Crystal
             when :"["
               write_token :"["
               skip_space_or_newline
-              format_call_args(call, false)
+              format_call_args(call)
               skip_space_or_newline
               write_token :"]"
               write_token :"?" if call.name == "[]?"
@@ -2549,7 +2549,7 @@ module Crystal
               if @token.type == :"("
                 write "("
                 next_token_skip_space_or_newline
-                format_call_args(call, true)
+                format_call_args(call)
                 skip_space_or_newline
                 write_token :")"
               end
@@ -2562,7 +2562,7 @@ module Crystal
               last_arg = call.args.pop
               write_token :"["
               skip_space_or_newline
-              format_call_args(call, false)
+              format_call_args(call)
               skip_space_or_newline
               write_token :"]"
               skip_space
@@ -2575,7 +2575,7 @@ module Crystal
               if @token.type == :"("
                 write "("
                 next_token_skip_space_or_newline
-                format_call_args(call, true)
+                format_call_args(call)
                 skip_space_or_newline
                 write_token :")"
               end
@@ -3155,7 +3155,7 @@ module Crystal
         skip_space
 
         if exp.is_a?(TupleLiteral) && @token.type != :"{"
-          format_args(exp.elements, has_parentheses)
+          format_args(exp.elements)
           skip_space if has_parentheses
         else
           indent(@indent, exp)
@@ -3183,7 +3183,7 @@ module Crystal
       else
         write " " unless node.exps.empty?
         skip_space
-        format_args node.exps, false
+        format_args node.exps
       end
 
       false
@@ -3435,7 +3435,7 @@ module Crystal
     end
 
     def visit(node : TypeOf)
-      format_unary(:typeof) { format_args node.expressions, true }
+      format_unary(:typeof) { format_args node.expressions }
     end
 
     def visit(node : SizeOf)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -17,13 +17,13 @@ module Crystal
       formatter.finish
     end
 
-    record AlignInfo,
+    record(AlignInfo,
       id : UInt64,
       line : Int32,
       start_column : Int32,
       middle_column : Int32,
       end_column : Int32,
-      number : Bool do
+      number : Bool) do
       def size
         end_column - start_column
       end
@@ -3867,13 +3867,13 @@ module Crystal
       end
 
       if inputs = node.inputs
-        visit_asm_parts inputs, colon_column, write_colon: false do |input|
+        visit_asm_parts(inputs, colon_column, write_colon: false) do |input|
           accept input
         end
       end
 
       if clobbers = node.clobbers
-        visit_asm_parts clobbers, colon_column, write_colon: true do |clobber|
+        visit_asm_parts(clobbers, colon_column, write_colon: true) do |clobber|
           accept StringLiteral.new(clobber)
         end
       end
@@ -3882,7 +3882,7 @@ module Crystal
         write_token @token.type
         skip_space_or_newline
         parts = [node.volatile?, node.alignstack?, node.intel?].select(&.itself)
-        visit_asm_parts parts, colon_column, write_colon: false do
+        visit_asm_parts(parts, colon_column, write_colon: false) do
           accept StringLiteral.new("")
         end
       end

--- a/src/compiler/crystal/tools/playground/agent.cr
+++ b/src/compiler/crystal/tools/playground/agent.cr
@@ -14,7 +14,7 @@ class Crystal::Playground::Agent
     rescue ex
       if @send_runtime
         @send_runtime = false # send only the inner runtime exception
-        send "runtime-exception" do |json|
+        send("runtime-exception") do |json|
           json.field "line", line
           json.field "exception", ex.to_s
         end
@@ -22,13 +22,13 @@ class Crystal::Playground::Agent
       raise ex
     end
 
-    send "value" do |json|
+    send("value") do |json|
       json.field "line", line
       json.field "value", safe_to_value(value)
       json.field "value_type", typeof(value).to_s
 
       if names && value.is_a?(Tuple)
-        json.field "data" do
+        json.field("data") do
           json.object do
             value.to_a.zip(names) do |v, name|
               json.field name, safe_to_value(v)

--- a/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
+++ b/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
@@ -23,7 +23,7 @@ module Crystal
 
       def visit(node : Call)
         if node_block = node.block
-          @instrumentor.ignoring_line_of_node node do
+          @instrumentor.ignoring_line_of_node(node) do
             node.block = node_block.transform(@instrumentor)
           end
         end
@@ -185,7 +185,7 @@ module Crystal
     end
 
     def transform(node : Def)
-      ignoring_line_of_node node do
+      ignoring_line_of_node(node) do
         node.body = node.body.transform(self)
         node
       end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -75,7 +75,7 @@ module Crystal::Playground
         send_with_json_builder do |json|
           json.field "type", "bug"
           json.field "tag", tag
-          json.field "exception" do
+          json.field("exception") do
             append_exception json, ex
           end
         end
@@ -116,7 +116,7 @@ module Crystal::Playground
       send_with_json_builder do |json|
         json.field "type", "exception"
         json.field "tag", tag
-        json.field "exception" do
+        json.field("exception") do
           append_exception json, ex
         end
       end
@@ -126,7 +126,7 @@ module Crystal::Playground
       json.object do
         json.field "message", ex.to_s
         if ex.is_a?(Crystal::Exception)
-          json.field "payload" do
+          json.field("payload") do
             ex.to_json(json)
           end
         end
@@ -449,7 +449,7 @@ module Crystal::Playground
       views_dir = File.join(playground_dir, "views")
       public_dir = File.join(playground_dir, "public")
 
-      agent_ws = PathWebSocketHandler.new "/agent" do |ws, context|
+      agent_ws = PathWebSocketHandler.new("/agent") do |ws, context|
         match_data = context.request.path.not_nil!.match(/\/(\d+)\/(\d+)$/).not_nil!
         session_key = match_data[1]?.try(&.to_i)
         tag = match_data[2]?.try(&.to_i)
@@ -466,7 +466,7 @@ module Crystal::Playground
         end
       end
 
-      client_ws = PathWebSocketHandler.new "/client" do |ws, context|
+      client_ws = PathWebSocketHandler.new("/client") do |ws, context|
         origin = context.request.headers["Origin"]
         if !accept_request?(origin)
           @logger.warn "Invalid Request Origin: #{origin}"

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -283,7 +283,7 @@ module Crystal
     def print_subtypes(types, json)
       types = types.sort_by &.to_s
 
-      json.field "sub_types" do
+      json.field("sub_types") do
         json.array do
           types.each_with_index do |type, index|
             if must_print? type
@@ -322,7 +322,7 @@ module Crystal
       instance_vars = type.instance_vars
       return if instance_vars.empty?
 
-      json.field "instance_vars" do
+      json.field("instance_vars") do
         json.array do
           instance_vars.each do |name, var|
             json.object do
@@ -339,7 +339,7 @@ module Crystal
       return if instance_vars.empty?
 
       instance_vars = instance_vars.values
-      json.field "instance_vars" do
+      json.field("instance_vars") do
         json.array do
           instance_vars.each do |instance_var|
             if ivar_type = instance_var.type?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -93,7 +93,7 @@ module Crystal
     end
 
     # Returns this type's metaclass, which holds class methods for this type.
-    getter metaclass : Type do
+    getter(metaclass : Type) do
       metaclass = MetaclassType.new(program, self)
       initialize_metaclass(metaclass)
       metaclass
@@ -672,11 +672,11 @@ module Crystal
   # - max_size: the maxinum number of arguments that can be passed to the method
   # - min_size: the minimum number of arguments that can be passed to the method
   # - yields: whether the method has a block
-  record DefWithMetadata,
+  record(DefWithMetadata,
     min_size : Int32,
     max_size : Int32,
     yields : Bool,
-    def : Def do
+    def : Def) do
     def self.new(a_def : Def)
       min_size, max_size = a_def.min_max_args_sizes
       new min_size, max_size, !!a_def.yields, a_def

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -6,7 +6,7 @@ struct HTTP::Headers
   include Enumerable({String, Array(String)})
 
   # :nodoc:
-  record Key, name : String do
+  record(Key, name : String) do
     forward_missing_to @name
 
     def hash(hasher)

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -97,7 +97,7 @@ class HTTP::StaticFileHandler
     end
   end
 
-  record DirectoryListing, request_path : String, path : String do
+  record(DirectoryListing, request_path : String, path : String) do
     @escaped_request_path : String?
 
     def escaped_request_path

--- a/src/json.cr
+++ b/src/json.cr
@@ -39,7 +39,7 @@
 # string = JSON.build do |json|
 #   json.object do
 #     json.field "name", "foo"
-#     json.field "values" do
+#     json.field("values") do
 #       json.array do
 #         json.number 1
 #         json.number 2

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -341,7 +341,7 @@ module JSON
   # string = JSON.build do |json|
   #   json.object do
   #     json.field "name", "foo"
-  #     json.field "values" do
+  #     json.field("values") do
   #       json.array do
   #         json.number 1
   #         json.number 2

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -80,7 +80,7 @@ class Hash
   def to_json(json : JSON::Builder)
     json.object do
       each do |key, value|
-        json.field key do
+        json.field(key) do
           value.to_json(json)
         end
       end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -18,7 +18,7 @@
 # An example with the block version:
 #
 # ```
-# record Person, first_name : String, last_name : String do
+# record(Person, first_name : String, last_name : String) do
 #   def full_name
 #     "#{first_name} #{last_name}"
 #   end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -7,19 +7,19 @@ require "./spec/dsl"
 # ```
 # require "spec"
 #
-# describe "Array" do
-#   describe "#size" do
-#     it "correctly reports the number of elements in the Array" do
+# describe("Array") do
+#   describe("#size") do
+#     it("correctly reports the number of elements in the Array") do
 #       [1, 2, 3].size.should eq 3
 #     end
 #   end
 #
-#   describe "#empty?" do
-#     it "is empty when no elements are in the array" do
+#   describe("#empty?") do
+#     it("is empty when no elements are in the array") do
 #       ([] of Int32).empty?.should be_true
 #     end
 #
-#     it "is not empty if there are elements in the array" do
+#     it("is not empty if there are elements in the array") do
 #       [1].empty?.should be_false
 #     end
 #   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3879,7 +3879,7 @@ class String
   end
 
   private def inspect_char(char, error, io)
-    dump_or_inspect_char char, error, io do
+    dump_or_inspect_char(char, error, io) do
       char.ascii_control?
     end
   end


### PR DESCRIPTION
This eliminates the subtle difference in associativity of `do/end` and `{/}` by enforcing calls which pass a block to have parentheses around their arguments to disambiguate. This is first done by changing the formatter to enforce this rule, formatting, then changing the compiler.

We should land the compiler change commit in `next_release + 1` to give people a formatter tool which they can use to get their projects up to date, but it's included in this PR for criticism.

The largest hit is the spec DSL, every `it "foo" do` gets turned into `it("foo") do`, which is definitely uglier, but not impossible to live with I think. We could possibly also introduce a rule that this rule doesn't have to be followed if there's no block inside the block arguments, or we could unify both syntaxes to act like `do/end`, or we could leave this as-is (but I think the current state is confusing). So please start the discussion below.