### PR TITLE
Simplify rotate count calculation

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1388,8 +1388,7 @@ class Array(T)
 
   def rotate!(n = 1)
     return self if size == 0
-    n %= size if n.abs >= size
-    n += size if n < 0
+    n %= size
     return self if n == 0
     if n <= size / 2
       tmp = self[0..n]
@@ -1405,8 +1404,7 @@ class Array(T)
 
   def rotate(n = 1)
     return self if size == 0
-    n %= size if n.abs >= size
-    n += size if n < 0
+    n %= size
     return self if n == 0
     res = Array(T).new(size)
     res.to_unsafe.copy_from(@buffer + n, size - n)


### PR DESCRIPTION
[Behaves the same](https://carc.in/#/r/2so1):
```crystal
(1..15).each do |size|
  (-16..16).each do |n|
    m = n
    
    n %= size if n.abs >= size
    n += size if n < 0
    
    m %= size
    
    raise ":(" if n != m
  end
end
```

Performs the same:
```crystal
require "benchmark"
Benchmark.ips do |x|
  x.report("old") do
    (1..15).each do |size|
      (-15..15).each do |n|
        n %= size if n.abs >= size
        n += size if n < 0
      end
    end
  end
  x.report("new") do
    (1..15).each do |size|
      (-15..15).each do |n|
        n %= size
      end
    end
  end
end
```
```
old 469.55M (  2.13ns) (± 3.77%)  1.00× slower
new 470.83M (  2.12ns) (± 3.44%)       fastest
```