### PR TITLE
Parser: error on duplicate case when condition

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -373,7 +373,8 @@ describe Crystal::Formatter do
   assert_format "while / /\nend"
   assert_format "[/ /, / /]"
   assert_format "{/ / => / /, / / => / /}"
-  assert_format "case / /\nwhen / /, / /\n  / /\nend"
+  assert_format "case / /\nwhen / /, /x/\n  / /\nend"
+  assert_format "case / /\nwhen /x/, / /\n  / /\nend"
   assert_format "/\#{1}/imx"
 
   assert_format "`foo`"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1578,6 +1578,18 @@ describe "Parser" do
     assert_syntax_error %({"a" : 1}), "space not allowed between named argument name and ':'"
     assert_syntax_error %({"a": 1, "b" : 2}), "space not allowed between named argument name and ':'"
 
+    assert_syntax_error "case x; when nil; 2; when nil; end", "duplicate when nil in case"
+    assert_syntax_error "case x; when true; 2; when true; end", "duplicate when true in case"
+    assert_syntax_error "case x; when 1; 2; when 1; end", "duplicate when 1 in case"
+    assert_syntax_error "case x; when 'a'; 2; when 'a'; end", "duplicate when 'a' in case"
+    assert_syntax_error %(case x; when "a"; 2; when "a"; end), %(duplicate when "a" in case)
+    assert_syntax_error %(case x; when :a; 2; when :a; end), "duplicate when :a in case"
+    assert_syntax_error %(case x; when {1, 2}; 2; when {1, 2}; end), "duplicate when {1, 2} in case"
+    assert_syntax_error %(case x; when [1, 2]; 2; when [1, 2]; end), "duplicate when [1, 2] in case"
+    assert_syntax_error %(case x; when 1..2; 2; when 1..2; end), "duplicate when 1..2 in case"
+    assert_syntax_error %(case x; when /x/; 2; when /x/; end), "duplicate when /x/ in case"
+    assert_syntax_error %(case x; when X; 2; when X; end), "duplicate when X in case"
+
     it "gets corrects of ~" do
       node = Parser.parse("\n  ~1")
       loc = node.location.not_nil!

--- a/src/compiler/crystal/semantic/math_interpreter.cr
+++ b/src/compiler/crystal/semantic/math_interpreter.cr
@@ -8,7 +8,7 @@ struct Crystal::MathInterpreter
 
   def interpret(node : NumberLiteral, target_type = nil)
     case node.kind
-    when :i8, :i16, :i32, :i64, :u8, :u16, :u32, :u64, :i64
+    when :i8, :i16, :i32, :i64, :u8, :u16, :u32, :u64
       target_kind = target_type.try(&.kind) || node.kind
       case target_kind
       when :i8  then node.value.to_i8? || node.raise "invalid Int8: #{node.value}"

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -153,8 +153,6 @@ module HTTP::FormData
         modification_time = HTTP.parse_time value
       when "read-date"
         read_time = HTTP.parse_time value
-      when "creation-date"
-        creation_time = HTTP.parse_time value
       when "size"
         size = value.to_u64
       when "name"

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -297,7 +297,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
 
     def sse?
       case self
-      when SSEFs, SSEFv, SSEDs, SSEDs
+      when SSEFs, SSEFv, SSEDs
         true
       else
         false


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/pull/5011 was manually detected, but maybe it's better if the compiler can help us here :-)

Also removes some duplicate cases in the compiler's code and the standard library. You gotta love bootstrapping :-D