### PR TITLE
Handle malformed http requests

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -184,4 +184,10 @@ describe HTTP::Headers do
     value = (32..126).map(&.chr).join
     headers.add("foo", value)
   end
+
+  it "can validate content" do
+    headers = HTTP::Headers.new
+    headers.valid_value?("foo").should be_true
+    headers.valid_value?("\r\nLocation: http://example.com").should be_false
+  end
 end

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -185,9 +185,15 @@ describe HTTP::Headers do
     headers.add("foo", value)
   end
 
-  it "can validate content" do
+  it "validates content" do
     headers = HTTP::Headers.new
-    headers.valid_value?("foo").should be_true
-    headers.valid_value?("\r\nLocation: http://example.com").should be_false
+    valid_value = "foo"
+    invalid_value = "\r\nLocation: http://example.com"
+    headers.valid_value?(valid_value).should be_true
+    headers.valid_value?(invalid_value).should be_false
+    headers.add?("foo", valid_value).should be_true
+    headers.add?("foo", [valid_value]).should be_true
+    headers.add?("foobar", invalid_value).should be_false
+    headers.add?("foobar", [invalid_value]).should be_false
   end
 end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -174,6 +174,8 @@ module HTTP
     it "handles malformed request" do
       request = Request.from_io(IO::Memory.new("nonsense"))
       request.should be_a(Request::BadRequest)
+      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nX-Test-Header: \u{0}\r\n"))
+      request.should be_a(Request::BadRequest)
     end
 
     it "handles long request lines" do

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -59,8 +59,7 @@ module HTTP
       end
 
       name, value = parse_header(line)
-      break unless headers.valid_value?(value)
-      headers.add(name, value)
+      break unless headers.add?(name, value)
     end
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -59,7 +59,11 @@ module HTTP
       end
 
       name, value = parse_header(line)
-      headers.add(name, value)
+      begin
+        headers.add(name, value)
+      rescue ex : ArgumentError
+        break
+      end
     end
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -59,11 +59,8 @@ module HTTP
       end
 
       name, value = parse_header(line)
-      begin
-        headers.add(name, value)
-      rescue ex : ArgumentError
-        break
-      end
+      break unless headers.valid_value?(value)
+      headers.add(name, value)
     end
   end
 

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -255,12 +255,7 @@ struct HTTP::Headers
   end
 
   def valid_value?(value)
-    value.each_byte do |byte|
-      unless valid_char?(char = byte.unsafe_chr)
-        return false
-      end
-    end
-    true
+    return invalid_value_char(value).nil?
   end
 
   forward_missing_to @hash
@@ -289,10 +284,8 @@ struct HTTP::Headers
   end
 
   private def check_invalid_header_content(value)
-    value.each_byte do |byte|
-      unless valid_char?(char = byte.unsafe_chr)
-        raise ArgumentError.new("Header content contains invalid character #{char.inspect}")
-      end
+    if char = invalid_value_char(value)
+      raise ArgumentError.new("Header content contains invalid character #{char.inspect}")
     end
   end
 
@@ -305,5 +298,13 @@ struct HTTP::Headers
       return false
     end
     true
+  end
+
+  private def invalid_value_char(value)
+    value.each_byte do |byte|
+      unless valid_char?(char = byte.unsafe_chr)
+        return char
+      end
+    end
   end
 end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -102,7 +102,9 @@ struct HTTP::Headers
   end
 
   def add(key, value : String)
-    add(key, [value])
+    check_invalid_header_content value
+    unsafe_add(key, value)
+    self
   end
 
   def add(key, value : Array(String))
@@ -112,7 +114,9 @@ struct HTTP::Headers
   end
 
   def add?(key, value : String)
-    add?(key, [value])
+    return false unless valid_value?(value)
+    unsafe_add(key, value)
+    true
   end
 
   def add?(key, value : Array(String))
@@ -253,6 +257,16 @@ struct HTTP::Headers
   end
 
   forward_missing_to @hash
+
+  private def unsafe_add(key, value : String)
+    key = wrap(key)
+    existing = @hash[key]?
+    if existing
+      existing << value
+    else
+      @hash[key] = [value]
+    end
+  end
 
   private def unsafe_add(key, value : Array(String))
     key = wrap(key)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -95,11 +95,8 @@ class HTTP::Request
     return BadRequest.new unless parts.size == 3
 
     method, resource, http_version = parts
-    begin
-      HTTP.parse_headers_and_body(io) do |headers, body|
-        return new method, resource, headers, body, http_version
-      end
-    rescue ex : ArgumentError
+    HTTP.parse_headers_and_body(io) do |headers, body|
+      return new method, resource, headers, body, http_version
     end
 
     # Malformed or unexpectedly ended http request

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -95,11 +95,14 @@ class HTTP::Request
     return BadRequest.new unless parts.size == 3
 
     method, resource, http_version = parts
-    HTTP.parse_headers_and_body(io) do |headers, body|
-      return new method, resource, headers, body, http_version
+    begin
+      HTTP.parse_headers_and_body(io) do |headers, body|
+        return new method, resource, headers, body, http_version
+      end
+    rescue ex : ArgumentError
     end
 
-    # Unexpected end of http request
+    # Malformed or unexpectedly ended http request
     BadRequest.new
   end
 


### PR DESCRIPTION
Fixes #4878. ArgumentError is thrown while parsing, so it is better to catch it and return BadRequest.