### PR TITLE
Expand children of currently selected item in documentation

### DIFF
--- a/src/compiler/crystal/tools/doc/html/list_items.html
+++ b/src/compiler/crystal/tools/doc/html/list_items.html
@@ -1,6 +1,6 @@
 <ul>
   <% types.each do |type| %>
-  <li class="<%= (type.program? || type.types.empty?) ? "" : ("parent" + (type.parents_of?(current_type) ? " open" : "")) %> <%= type.current?(current_type) ? "current" : "" %>" data-id="<%= type.html_id %>" data-name="<%= type.full_name.downcase %>">
+  <li class="<%= (type.program? || type.types.empty?) ? "" : ("parent" + (type.current?(current_type) || type.parents_of?(current_type) ? " open" : "")) %> <%= type.current?(current_type) ? "current" : "" %>" data-id="<%= type.html_id %>" data-name="<%= type.full_name.downcase %>">
       <a href="<%= type.path_from(current_type) %>"><%= type.name %></a>
       <% unless type.program? || type.types.empty? %>
         <%= ListItemsTemplate.new(type.types, current_type) %>


### PR DESCRIPTION
I think it's more convenient like this. When you click on an item in documentation and it has sub-nodes, why not expand it? Another nice property of doing the change this way is that if you haven't manually expanded it, it will not stay expanded.

[Try this in action](http://oprypin.github.io/crsfml/api/SF/Ftp.html)