### PR TITLE
string: Fix typo in documentation of `*`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -2494,7 +2494,7 @@ class String
   #
   # ```
   # "Developers! " * 4
-  # # => "Developers! Developers! Developers! Developers!"
+  # # => "Developers! Developers! Developers! Developers! "
   # ```
   def *(times : Int)
     raise ArgumentError.new "Negative argument" if times < 0


### PR DESCRIPTION
```cr
"a " * 2 # => "a a " (with a space at the end!)
```