### PR TITLE
Add time formatters for days with ordinal suffix. Includes specs and docs.

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -184,6 +184,46 @@ describe "Int" do
     end
   end
 
+  describe "#ordinal" do
+    it "returns the correct suffix" do
+      1.ordinal.should eq("st")
+      2.ordinal.should eq("nd")
+      3.ordinal.should eq("rd")
+      4.ordinal.should eq("th")
+      5.ordinal.should eq("th")
+      10.ordinal.should eq("th")
+      11.ordinal.should eq("th")
+      12.ordinal.should eq("th")
+      13.ordinal.should eq("th")
+      21.ordinal.should eq("st")
+      22.ordinal.should eq("nd")
+      23.ordinal.should eq("rd")
+      122.ordinal.should eq("nd")
+      123.ordinal.should eq("rd")
+      1322.ordinal.should eq("nd")
+      1323.ordinal.should eq("rd")
+    end
+
+    it "appends the correct suffix" do
+      1.to_ordinal.should eq("1st")
+      2.to_ordinal.should eq("2nd")
+      3.to_ordinal.should eq("3rd")
+      4.to_ordinal.should eq("4th")
+      5.to_ordinal.should eq("5th")
+      10.to_ordinal.should eq("10th")
+      11.to_ordinal.should eq("11th")
+      12.to_ordinal.should eq("12th")
+      13.to_ordinal.should eq("13th")
+      21.to_ordinal.should eq("21st")
+      22.to_ordinal.should eq("22nd")
+      23.to_ordinal.should eq("23rd")
+      122.to_ordinal.should eq("122nd")
+      123.to_ordinal.should eq("123rd")
+      1322.to_ordinal.should eq("1322nd")
+      1323.to_ordinal.should eq("1323rd")
+    end
+  end
+
   describe "#inspect" do
     it "appends the type" do
       23.inspect.should eq("23")

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -295,8 +295,11 @@ describe Time do
     t.to_s("%h").should eq("Jan")
     t.to_s("%^h").should eq("JAN")
     t.to_s("%d").should eq("02")
+    t.to_s("%d+").should eq("02nd")
     t.to_s("%-d").should eq("2")
+    t.to_s("%-d+").should eq("2nd")
     t.to_s("%e").should eq(" 2")
+    t.to_s("%e+").should eq(" 2nd")
     t.to_s("%j").should eq("002")
     t.to_s("%H").should eq("03")
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -456,6 +456,35 @@ struct Int
     yield ptr, count
   end
 
+  # Returns the ordinal for this number.
+  #
+  # ```
+  # 3.ordinal  # => "rd"
+  # 14.ordinal # => "th"
+  # ```
+  def ordinal : String
+    case self % 100
+    when 11, 12, 13 then "th"
+    else
+      case self % 10
+      when 1 then "st"
+      when 2 then "nd"
+      when 3 then "rd"
+      else        "th"
+      end
+    end
+  end
+
+  # Returns the number as a string with its ordinal appended.
+  #
+  # ```
+  # 3.to_ordinal  # => "3rd"
+  # 14.to_ordinal # => "14th"
+  # ```
+  def to_ordinal : String
+    "#{to_s}#{ordinal}"
+  end
+
   def inspect(io)
     type = case self
            when Int8   then "_i8"

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -17,9 +17,12 @@
 # * **%c**: date and time (Tue Apr  5 10:26:19 2016)
 # * **%C**: year divided by 100
 # * **%d**: day of month, zero padded (01, 02, ...)
+# * **%d+**: day of month, zero padded, with ordinal suffix (01, 02, ...)
 # * **%-d**: day of month (1, 2, ..., 31)
+# * **%-d+**: day of month, with ordinal suffix (1, 2, ..., 31)
 # * **%D**: date (04/05/16)
 # * **%e**: day of month, blank padded (" 1", " 2", ..., "10", "11", ...)
+# * **%e+**: day of month, blank padded, with ordinal suffix (" 1st", " 2nd", ..., "10th", "11th", ...)
 # * **%F**: ISO 8601 date (2016-04-05)
 # * **%h**: (same as %b) short month name (Jan, Feb, Mar, ...)
 # * **%H**: hour of the day, 24-hour clock, zero padded (00, 01, ..., 24)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -62,6 +62,18 @@ struct Time::Format
     def day_of_month_blank_padded
       pad2 time.day, ' '
     end
+    
+    def day_of_month_ordinal
+      io << time.day.to_ordinal
+    end
+
+    def day_of_month_zero_padded_ordinal
+      pad4 time.day.to_ordinal, '0'
+    end
+
+    def day_of_month_blank_padded_ordinal
+      pad4 time.day.to_ordinal, ' '
+    end
 
     def day_name
       io << get_day_name

--- a/src/time/format/pattern.cr
+++ b/src/time/format/pattern.cr
@@ -30,11 +30,21 @@ struct Time::Format
         when 'C'
           year_divided_by_100
         when 'd'
-          day_of_month_zero_padded
+          case char = reader.next_char
+          when '+'
+            day_of_month_zero_padded_ordinal
+          else
+            day_of_month_zero_padded
+          end
         when 'D', 'x'
           date
         when 'e'
-          day_of_month_blank_padded
+          case char = reader.next_char
+          when '+'
+            day_of_month_blank_padded_ordinal
+          else
+            day_of_month_blank_padded
+          end
         when 'F'
           iso_8601_date
         when 'H'
@@ -89,7 +99,12 @@ struct Time::Format
         when '-'
           case char = reader.next_char
           when 'd'
-            day_of_month
+            case char = reader.next_char
+            when '+'
+              day_of_month_ordinal
+            else
+              day_of_month
+            end
           when 'm'
             month
           else


### PR DESCRIPTION
This PR depends on the methods added in #5054, and so cannot be merged
unless #5054 is merged first.