### PR TITLE
Fix socket initialization

### DIFF
--- a/src/socket.cr
+++ b/src/socket.cr
@@ -42,7 +42,7 @@ class Socket
   @read_event : Event::Event?
   @write_event : Event::Event?
 
-  @closed = false
+  @closed : Bool
 
   getter family : Family
   getter type : Type
@@ -67,6 +67,7 @@ class Socket
   end
 
   def initialize(@family, @type, @protocol = Protocol::IP, blocking = false)
+    @closed = false
     fd = LibC.socket(family, type, protocol)
     raise Errno.new("failed to create socket:") if fd == -1
     init_close_on_exec(fd)
@@ -79,6 +80,7 @@ class Socket
   end
 
   protected def initialize(@fd : Int32, @family, @type, @protocol = Protocol::IP, blocking = false)
+    @closed = false
     init_close_on_exec(@fd)
 
     self.sync = true


### PR DESCRIPTION
When #4707 was merged, in particular c26fbc9714c700d65190e89bf48f2743bb0122d0 the socket initialization got screwed a little bit.

I notice it because the playground was not working in master in a manual test.

Socket initialization (TCPSocket at least) [uses Addrinfo.tcp](https://github.com/crystal-lang/crystal/blob/master/src/socket/tcp_socket.cr#L28-L29) which may retry and call Socket#initialize, leaving inconsistent state since the socket is tracked as closed.

It is a code smell to use super in a closure probably 💭 