### PR TITLE
Parser: add missing escape sequence for Char

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -238,6 +238,8 @@ describe "Lexer" do
   it_lexes_char "'\\r'", '\r'
   it_lexes_char "'\\0'", '\0'
   it_lexes_char "'\\0'", '\0'
+  it_lexes_char "'\\x40'", '@'
+  it_lexes_char "'\\100'", '@'
   it_lexes_char "'\\''", '\''
   it_lexes_char "'\\\\'", '\\'
   assert_syntax_error "'", "unterminated char literal"
@@ -475,7 +477,7 @@ describe "Lexer" do
   assert_syntax_error "'\\u{110000}'", "invalid unicode codepoint (too large)"
   assert_syntax_error ":+1", "unexpected token"
 
-  assert_syntax_error "'\\1'", "invalid char escape sequence"
+  assert_syntax_error "'\\9'", "invalid char escape sequence"
 
   it_lexes_string %("\\1"), String.new(Bytes[1])
   it_lexes_string %("\\4"), String.new(Bytes[4])

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -606,11 +606,15 @@ module Crystal
             @token.value = '\t'
           when 'v'
             @token.value = '\v'
+          when 'x'
+            value = consume_string_hex_escape
+            @token.value = value.chr
           when 'u'
             value = consume_char_unicode_escape
             @token.value = value.chr
-          when '0'
-            @token.value = '\0'
+          when '0', '1', '2', '3', '4', '5', '6', '7'
+            value = consume_octal_escape(char2)
+            @token.value = value.chr
           when '\0'
             raise "unterminated char literal", line, column
           else


### PR DESCRIPTION
The compiler accepts this code:

```crystal
p "\x64" # => "d"
```

But the compiler does not accept this:

```
p '\x64' #  invalid char escape sequence
```

And `\100` style escape sequence has same issue.

This PR adds `\xFF` (hex) and `\100` (octal) style escape sequence for `Char`.