### PR TITLE
GitHub issue template: redirect users to Google Groups, Stack Overflow, etc.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,10 @@
+# Precheck
+
+* Do not use the issues tracker for help or support (try Crystal Google Groups, Stack Overflow, Gitter, IRC, etc.)
+* For proposing a new feature, please start a discussion on the Crystal Google Groups mailing list
+* For bugs, do a quick search and make sure the bug has not yet been reported
+* Finally, be nice and have fun!
+
 # Submitting bugs
 
 Make sure to review these points before submitting issues - thank you!


### PR DESCRIPTION
Yesterday I wanted to discuss a new feature in Elixir so I went to their issue tracker and hit the [New Issue](https://github.com/elixir-lang/elixir/issues/new) button. I found this in the issue template:

```
### Precheck

* Do not use the issues tracker for help or support (try Elixir Forum, Stack Overflow, IRC, etc.)
* For proposing a new feature, please start a discussion on the Elixir Core mailing list
* For bugs, do a quick search and make sure the bug has not yet been reported
* Finally, be nice and have fun!
```

I **really** like this. With this, the issue tracker doesn't become cluttered with issues that are not planned to be tackled by the core team, or anyone else ( for example #5074 ), and which probably deserve more discussion before being turned into a good "formal" proposal.

I like this even better than a repository for RFCs because it's more informal and it's just "let's discuss this idea I have". We could later have an RFCs repository with more formal proposals, though.