### PR TITLE
Add custom time formats

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -312,7 +312,7 @@ describe "JSON serialization" do
     end
 
     it "does for time" do
-      Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc).to_json.should eq(%("2016-11-16T12:55:48+0000"))
+      Time.new(2016, 11, 16, 12, 55, 48, kind: Time::Kind::Utc).to_json.should eq(%("2016-11-16T12:55:48Z"))
     end
   end
 end

--- a/spec/std/time/custom_formats_spec.cr
+++ b/spec/std/time/custom_formats_spec.cr
@@ -1,0 +1,81 @@
+require "spec"
+
+describe Time::Format do
+  describe "RFC_3339" do
+    it "parses regular format" do
+      time = Time.new(2016, 2, 15, kind: Time::Kind::Utc)
+      Time::Format::RFC_3339.format(time).should eq "2016-02-15T00:00:00Z"
+      Time::Format::RFC_3339.parse("2016-02-15T00:00:00+00:00").should eq time
+      Time::Format::RFC_3339.parse("2016-02-15t00:00:00+00:00").should eq time
+      Time::Format::RFC_3339.parse("2016-02-15 00:00:00+00:00").should eq time
+      Time::Format::RFC_3339.parse("2016-02-15T00:00:00Z").should eq time
+      Time::Format::RFC_3339.parse("2016-02-15T00:00:00.0000000+00:00").should eq time
+    end
+  end
+
+  describe Time::Format::RFC_2822 do
+    it "parses regular format" do
+      time = Time.new(2016, 2, 15, kind: Time::Kind::Utc)
+      Time::Format::RFC_2822.format(time).should eq "Mon, 15 Feb 2016 00:00:00 +0000"
+      Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 00:00:00 +0000").should eq time
+      Time::Format::RFC_2822.parse("Mon, 15 Feb 16 00:00 UT").should eq time
+      Time::Format::RFC_2822.parse(" Mon , 14 Feb 2016 20 : 00 : 00 EDT (comment)").to_utc.should eq time
+    end
+  end
+
+  describe "ISO_8601_DATE" do
+    it "formats default format" do
+      time = Time.new(1985, 4, 12, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE.format(time).should eq "1985-04-12"
+    end
+
+    it "parses calendar date" do
+      time = Time.new(1985, 4, 12, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE.parse("1985-04-12").should eq(time)
+      Time::Format::ISO_8601_DATE.parse("19850412").should eq(time)
+    end
+
+    it "parses ordinal date" do
+      time = Time.new(1985, 4, 12, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE.parse("1985-102").should eq(time)
+      Time::Format::ISO_8601_DATE.parse("1985102").should eq(time)
+    end
+
+    pending "parses week date" do
+      Time::Format::ISO_8601_DATE.parse("1985-W15-5").should eq(time)
+      Time::Format::ISO_8601_DATE.parse("1985W155").should eq(time)
+    end
+  end
+
+  describe "ISO_8601_DATE_TIME" do
+    it "formats default format" do
+      time = Time.new(1985, 4, 12, 23, 20, 50, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE_TIME.format(time).should eq "1985-04-12T23:20:50Z"
+    end
+    it "parses calendar date" do
+      time = Time.new(1985, 4, 12, 23, 20, 50, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985-04-12T23:20:50Z").should eq(time)
+      Time::Format::ISO_8601_DATE_TIME.parse("19850412T232050Z").should eq(time)
+    end
+    it "parses ordinal date" do
+      time = Time.new(1985, 4, 12, 23, 20, 50, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985-102T23:20:50Z").should eq(time)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985102T232050Z").should eq(time)
+    end
+    it "parses hour:minutes" do
+      time = Time.new(1985, 4, 12, 23, 20, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985-102T23:20Z").should eq(time)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985102T2320Z").should eq(time)
+    end
+    it "parses hour" do
+      time = Time.new(1985, 4, 12, 23, kind: Time::Kind::Utc)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985-102T23Z").should eq(time)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985102T23Z").should eq(time)
+    end
+
+    pending "week date" do
+      Time::Format::ISO_8601_DATE_TIME.parse("1985-W15-5TZ").should eq(time)
+      Time::Format::ISO_8601_DATE_TIME.parse("1985W155T23:20:50Z").should eq(time)
+    end
+  end
+end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -4,8 +4,6 @@
 {% end %}
 
 module HTTP
-  private DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
-
   # :nodoc:
   enum BodyType
     OnDemand
@@ -217,15 +215,16 @@ module HTTP
     ComputedContentTypeHeader.new(content_type.strip, nil)
   end
 
+  # Parse a time string using the formats specified by [RFC 2616](https://tools.ietf.org/html/rfc2616#section-3.3.1)
+  #
+  # ```
+  # HTTP.parse_time("Sun, 14 Feb 2016 21:00:00 GMT")  # => "2016-02-14 21:00:00 UTC"
+  # HTTP.parse_time("Sunday, 14-Feb-16 21:00:00 GMT") # => "2016-02-14 21:00:00 UTC"
+  # HTTP.parse_time("Sun Feb 14 21:00:00 2016")       # => "2016-02-14 21:00:00 UTC"
+  # ```
   def self.parse_time(time_str : String) : Time?
-    DATE_PATTERNS.each do |pattern|
-      begin
-        return Time.parse(time_str, pattern, kind: Time::Kind::Utc)
-      rescue Time::Format::Error
-      end
-    end
-
-    nil
+    HTTP_DATE.parse(time_str)
+  rescue Time::Format::Error
   end
 
   # Format a Time object as a String using the format specified by [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
@@ -234,8 +233,7 @@ module HTTP
   # HTTP.rfc1123_date(Time.new(2016, 2, 15)) # => "Sun, 14 Feb 2016 21:00:00 GMT"
   # ```
   def self.rfc1123_date(time : Time) : String
-    # TODO: GMT should come from the Time classes instead
-    time.to_utc.to_s("%a, %d %b %Y %H:%M:%S GMT")
+    HTTP_DATE.format(time)
   end
 
   # Dequotes an [RFC 2616](https://tools.ietf.org/html/rfc2616#page-17)

--- a/src/http/http_date.cr
+++ b/src/http/http_date.cr
@@ -1,0 +1,94 @@
+# Parse a time string using the formats specified by [RFC 2616](https://tools.ietf.org/html/rfc2616#section-3.3.1).
+#
+# Supported formats:
+# * [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55)
+# * [RFC 850](https://tools.ietf.org/html/rfc850#section-2.1.4)
+# * [asctime](http://en.cppreference.com/w/c/chrono/asctime)
+#
+# ```
+# HTTP::HTTP_DATE.parse("Sun, 14 Feb 2016 21:00:00 GMT")  # => 2016-02-14 21:00:00 UTC
+# HTTP::HTTP_DATE.parse("Sunday, 14-Feb-16 21:00:00 GMT") # => 2016-02-14 21:00:00 UTC
+# HTTP::HTTP_DATE.parse("Sun Feb 14 21:00:00 2016")       # => 2016-02-14 21:00:00 UTC
+#
+# HTTP::HTTP_DATE.format(Time.new(2016, 2, 15)) # => "Sun, 14 Feb 2016 21:00:00 GMT"
+# ```
+module HTTP::HTTP_DATE
+  extend Time::Format
+
+  # :nodoc:
+  module Visitor
+    @ansi_c_format = false
+
+    def visit
+      short_day_name_with_comma?
+
+      if @ansi_c_format
+        return visit_ansi_c
+      end
+
+      day_of_month_zero_padded
+
+      if rfc1123?
+        whitespace
+        short_month_name
+        whitespace
+        year
+      else
+        char '-'
+        short_month_name
+        char '-'
+        year_modulo_100
+      end
+
+      whitespace
+      twenty_four_hour_time_with_seconds
+      whitespace
+      time_zone_gmt_or_rfc2822
+    end
+
+    def visit_ansi_c
+      short_month_name
+      whitespace
+      day_of_month_blank_padded
+
+      whitespace
+
+      twenty_four_hour_time_with_seconds
+
+      whitespace
+
+      year
+
+      @kind = Time::Kind::Utc
+    end
+  end
+
+  # :nodoc:
+  struct Parser
+    def rfc1123?
+      !@ansi_c_format && current_char.ascii_whitespace?
+    end
+
+    def short_day_name_with_comma?
+      return unless current_char.ascii_letter?
+
+      short_day_name
+
+      @ansi_c_format = current_char != ','
+      next_char unless @ansi_c_format
+
+      whitespace
+    end
+  end
+
+  # :nodoc:
+  struct Formatter
+    def initialize(time : Time, io : IO)
+      super(time.to_utc, io)
+    end
+
+    def rfc1123?
+      true
+    end
+  end
+end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -234,7 +234,7 @@ def Time.new(pull : JSON::PullParser)
   Time::Format::ISO_8601_DATE_TIME.parse(pull.read_string)
 end
 
-struct Time::Format
+module Time::Format
   def from_json(pull : JSON::PullParser)
     string = pull.read_string
     parse(string)

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -110,7 +110,7 @@ struct NamedTuple
   end
 end
 
-struct Time::Format
+module Time::Format
   def to_json(value : Time, json : JSON::Builder)
     format(value).to_json(json)
   end

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -28,11 +28,11 @@
 # * **%k**: hour of the day, 24-hour clock, blank padded (" 0", " 1", ..., "24")
 # * **%l**: hour of the day, 12-hour clock, blank padded (" 0", " 1", ..., "12")
 # * **%L**: milliseconds, zero padded (000, 001, ..., 999)
-# * **%N**: nanoseconds, zero padded (000000000, 000000001, ..., 999999999)
 # * **%m**: month number, zero padded (01, 02, ..., 12)
 # * **%_m**: month number, blank padded (" 1", " 2", ..., "12")
 # * **%-m**: month number (1, 2, ..., 12)
 # * **%M**: minute, zero padded (00, 01, 02, ..., 59)
+# * **%N**: nanoseconds, zero padded (000000000, 000000001, ..., 999999999)
 # * **%p**: am-pm (lowercase)
 # * **%P**: AM-PM (uppercase)
 # * **%r**: 12-hour time (03:04:05 AM)
@@ -49,31 +49,23 @@
 # * **%z**: time zone as hour and minute offset from UTC (+0900)
 # * **%:z**: time zone as hour and minute offset from UTC with a colon (+09:00)
 # * **%::z**: time zone as hour, minute and second offset from UTC with a colon (+09:00:00)
-struct Time::Format
+module Time::Format
   # The ISO 8601 date format. This is just `"%F"`.
   ISO_8601_DATE = new "%F"
 
   # The ISO 8601 datetime format. This is just `"%FT%X%z"`.
   ISO_8601_DATE_TIME = new "%FT%X%z"
 
-  # Error raised when an invalid pattern is used.
-  class Error < ::Exception
-  end
-
-  # Returns the string pattern of this format.
-  getter pattern : String
-
-  # Creates a new `Time::Format` with the given *pattern*. The given time
-  # *kind* will be used when parsing a `Time` and no time zone is found in it.
-  def initialize(@pattern : String, @kind = Time::Kind::Unspecified)
-  end
+  # :nodoc:
+  MONTH_NAMES = %w(January February March April May June July August September October November December)
+  # :nodoc:
+  DAY_NAMES   = %w(Sunday Monday Tuesday Wednesday Thursday Friday Saturday)
 
   # Parses a string into a `Time`.
-  def parse(string, kind = @kind) : Time
-    parser = Parser.new(string)
-    parser.visit(pattern)
-    parser.time(kind)
-  end
+  abstract def parse(string, kind = @kind) : Time
+
+  # Formats a `Time` into the given *io*.
+  abstract def format(time : Time, io : IO)
 
   # Turns a `Time` into a `String`.
   def format(time : Time) : String
@@ -82,10 +74,13 @@ struct Time::Format
     end
   end
 
-  # Formats a `Time` into the given *io*.
-  def format(time : Time, io : IO)
-    formatter = Formatter.new(time, io)
-    formatter.visit(pattern)
-    io
+  # Error raised when an invalid pattern is used.
+  class Error < ::Exception
+  end
+
+  # Creates a new `Time::Format::Pattern` with the given *pattern*. The given time
+  # *kind* will be used when parsing a `Time` and no time zone is found in it.
+  def self.new(pattern : String, kind = Time::Kind::Unspecified)
+    Format::Pattern.new(pattern, kind)
   end
 end

--- a/src/time/format/composite_terms.cr
+++ b/src/time/format/composite_terms.cr
@@ -1,0 +1,54 @@
+# :nodoc:
+module Time::Format::CompositeTerms
+  def date_and_time
+    short_day_name
+    char ' '
+    short_month_name
+    char ' '
+    day_of_month_blank_padded
+    char ' '
+    twenty_four_hour_time_with_seconds
+    char ' '
+    year
+  end
+
+  def date
+    month_zero_padded
+    char '/'
+    day_of_month_zero_padded
+    char '/'
+    year_modulo_100
+  end
+
+  def year_month_day
+    year
+    char '-'
+    month_zero_padded
+    char '-'
+    day_of_month_zero_padded
+  end
+
+  def twelve_hour_time
+    hour_12_zero_padded
+    char ':'
+    minute
+    char ':'
+    second
+    char ' '
+    am_pm_upcase
+  end
+
+  def twenty_four_hour_time
+    hour_24_zero_padded
+    char ':'
+    minute
+  end
+
+  def twenty_four_hour_time_with_seconds
+    hour_24_zero_padded
+    char ':'
+    minute
+    char ':'
+    second
+  end
+end

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -1,0 +1,143 @@
+module Time::Format
+  # :nodoc:
+  module ISO_8601
+    # :nodoc:
+    module Parser
+      def year_month_day_iso_8601
+        year
+        extended_format = char? '-'
+        if current_char == 'W'
+          # week date
+          # TODO: Add support for week day (needs mapping between year and week day)
+          week = consume_number(2)
+          char '-', raise: extended_format
+          day_of_the_week = consume_number(1)
+
+          raise "week date not yet supported"
+          return
+        end
+        month_zero_padded
+
+        if @reader.peek_next_char.ascii_number? || !current_char.ascii_number?
+          # calendar date
+          char '-', raise: extended_format
+          day_of_month_zero_padded
+        else
+          # ordinal date
+          day_of_the_year = @month * 10 + current_char.to_i
+          @month = 0
+          next_char
+          days_per_month = Time.leap_year?(@year) ? Time::DAYS_MONTH_LEAP : Time::DAYS_MONTH
+
+          days_per_month.each_with_index do |days, month|
+            if day_of_the_year > days
+              day_of_the_year -= days
+            else
+              @day = day_of_the_year
+              @month = month
+              break
+            end
+          end
+        end
+      end
+
+      def hour_minute_second_iso8601
+        hour_24_zero_padded
+        decimal_seconds = Time::SECONDS_PER_HOUR
+
+        extended_format = char? ':'
+
+        if current_char.ascii_number?
+          minute
+          decimal_seconds = Time::SECONDS_PER_MINUTE
+
+          char ':', raise: extended_format && current_char.ascii_number?
+          if current_char.ascii_number?
+            second
+            decimal_seconds = 1
+          end
+        end
+
+        if current_char == '.' || current_char == ','
+          decimal = consume_number_i64(12) * decimal_seconds
+          # TODO: implement parser for decimal fractions
+        end
+      end
+    end
+
+    # :nodoc:
+    module Formatter
+      def year_month_day_iso_8601
+        year_month_day
+      end
+
+      def hour_minute_second_iso8601
+        twenty_four_hour_time_with_seconds
+      end
+    end
+  end
+
+  # The ISO 8601 date format.
+  module ISO_8601_DATE
+    extend Format
+
+    # :nodoc:
+    module Visitor
+      def visit
+        year_month_day_iso_8601
+      end
+    end
+
+    struct Parser
+      include ISO_8601::Parser
+    end
+
+    struct Formatter
+      include ISO_8601::Formatter
+    end
+  end
+
+  # The ISO 8601 date time format.
+  module ISO_8601_DATE_TIME
+    extend Format
+
+    # :nodoc:
+    module Visitor
+      def visit
+        year_month_day_iso_8601
+        char? 'T'
+        hour_minute_second_iso8601
+        time_zone_z_or_offset
+      end
+    end
+
+    struct Parser
+      include ISO_8601::Parser
+    end
+
+    struct Formatter
+      include ISO_8601::Formatter
+    end
+  end
+
+  # The ISO 8601 time format.
+  module ISO_8601_TIME
+    extend Format
+
+    # :nodoc:
+    module Visitor
+      def visit
+        hour_minute_second_iso8601
+        time_zone_z_or_offset
+      end
+    end
+
+    struct Parser
+      include ISO_8601::Parser
+    end
+
+    struct Formatter
+      include ISO_8601::Formatter
+    end
+  end
+end

--- a/src/time/format/custom/rfc_2822.cr
+++ b/src/time/format/custom/rfc_2822.cr
@@ -1,0 +1,104 @@
+# The [RFC 2822](https://tools.ietf.org/html/rfc2822) datetime format.
+#
+# This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
+module Time::Format::RFC_2822
+  extend Format
+
+  # :nodoc:
+  module Visitor
+    def visit
+      cfws?
+      short_day_name_with_comma?
+      day_of_month
+      cfws
+      short_month_name
+      cfws
+      full_or_short_year
+
+      folding_white_space
+
+      cfws?
+      hour_24_zero_padded
+      cfws?
+      char ':'
+      cfws?
+      minute
+      cfws?
+      seconds_with_colon?
+
+      folding_white_space
+
+      time_zone_rfc2822
+
+      cfws?
+    end
+  end
+
+  # :nodoc:
+  struct Parser
+    def short_day_name_with_comma?
+      return unless current_char.ascii_letter?
+
+      short_day_name
+      cfws?
+      char ','
+      cfws
+    end
+
+    def seconds_with_colon?
+      if current_char == ':'
+        next_char
+        cfws?
+        second
+      end
+    end
+
+    # comment or folding white space
+    def cfws?
+      in_comment = false
+      seen_whitespace = false
+      loop do
+        case char = current_char
+        when .ascii_whitespace?
+          seen_whitespace = true
+        when '('
+          in_comment = true
+        when ')'
+          in_comment = false
+        else
+          break unless in_comment
+        end
+        break unless @reader.has_next?
+        next_char
+      end
+      seen_whitespace
+    end
+
+    def cfws
+      cfws? || raise "Invalid format"
+    end
+
+    def folding_white_space
+      skip_space
+    end
+  end
+
+  # :nodoc:
+  struct Formatter
+    def seconds_with_colon?
+      char ':'
+      second
+    end
+
+    def cfws?
+    end
+
+    def cfws
+      folding_white_space
+    end
+
+    def folding_white_space
+      io << ' '
+    end
+  end
+end

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -1,0 +1,15 @@
+# The [RFC 3339](https://tools.ietf.org/html/rfc3339) datetime format ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
+module Time::Format::RFC_3339
+  extend Format
+
+  # :nodoc:
+  module Visitor
+    def visit
+      year_month_day
+      char 'T', 't', ' '
+      twenty_four_hour_time_with_seconds
+      second_fraction?
+      time_zone_z_or_offset(force_colon: true)
+    end
+  end
+end

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -1,9 +1,9 @@
-require "./pattern"
+require "./composite_terms"
 
-struct Time::Format
+module Time::Format
   # :nodoc:
-  struct Formatter
-    include Pattern
+  module Formatter
+    include CompositeTerms
 
     getter io : IO
     getter time : Time

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -1,8 +1,9 @@
-struct Time::Format
-  # :nodoc:
-  struct Parser
-    include Pattern
+require "./composite_terms"
 
+module Time::Format
+  # :nodoc:
+  module Parser
+    include CompositeTerms
     @epoch : Int64?
 
     def initialize(string)
@@ -44,10 +45,10 @@ struct Time::Format
     end
 
     def year_modulo_100
-      year = consume_number(2)
-      if 69 <= year <= 99
+      case year = consume_number(2)
+      when 69..99
         @year = year + 1900
-      elsif 0 <= year
+      when .>(0)
         @year = year + 2000
       else
         raise "Invalid year"

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -4,6 +4,21 @@ module Time::Format
   # :nodoc:
   module Parser
     include CompositeTerms
+
+    # :nodoc:
+    RFC_2822_ZONES = {
+      "UT"  => 0,
+      "GMT" => 0,
+      "EST" => -5,
+      "EDT" => -4,
+      "CST" => -6,
+      "CDT" => -5,
+      "MST" => -7,
+      "MDT" => -6,
+      "PST" => -8,
+      "PDT" => -7,
+    }
+
     @epoch : Int64?
 
     def initialize(string)
@@ -59,6 +74,17 @@ module Time::Format
       @year = consume_number(2) * 100
     end
 
+    def full_or_short_year
+      @year = case year = consume_number(4)
+              when 0..49
+                year + 2000
+              when 50..999
+                year + 1900
+              else
+                year
+              end
+    end
+
     def month
       @month = consume_number(2)
     end
@@ -91,7 +117,18 @@ module Time::Format
     end
 
     def short_month_name
-      month_name
+      string = consume_string
+      if string.size != 3
+        raise "Invalid month"
+      end
+
+      string = string.capitalize
+      index = MONTH_NAMES.index &.starts_with?(string)
+      if index
+        @month = 1 + index
+      else
+        raise "Invalid month"
+      end
     end
 
     def short_month_name_upcase
@@ -133,6 +170,14 @@ module Time::Format
 
     def short_day_name_upcase
       day_name
+    end
+
+    def short_day_name_with_comma?
+      return unless current_char.ascii_letter?
+
+      short_day_name
+      char ','
+      whitespace
     end
 
     def day_of_year_zero_padded
@@ -190,6 +235,13 @@ module Time::Format
       @nanosecond = nanosecond
     end
 
+    def second_fraction?
+      if current_char == '.'
+        next_char
+        milliseconds
+      end
+    end
+
     def am_pm
       string = consume_string
       case string.downcase
@@ -230,9 +282,7 @@ module Time::Format
     def time_zone
       case char = current_char
       when 'Z'
-        @offset_in_minutes = 0
-        @kind = Time::Kind::Utc
-        next_char
+        time_zone_z
       when 'U'
         if next_char == 'T' && next_char == 'C'
           @offset_in_minutes = 0
@@ -242,38 +292,68 @@ module Time::Format
           raise "Invalid timezone"
         end
       when '-', '+'
-        sign = char == '-' ? -1 : 1
+        time_zone_offset
+      else
+        raise "Invalid timezone"
+      end
+    end
 
+    def time_zone_z_or_offset(**options)
+      case char = current_char
+      when 'Z', 'z'
+        time_zone_z
+      when '-', '+'
+        time_zone_offset(**options)
+      else
+        raise "Invalid timezone: #{current_char.inspect} (#{@reader.pos}) #{self.inspect}"
+      end
+    end
+
+    def time_zone_z
+      raise "Invalid timezone" unless {'Z', 'z'}.includes? current_char
+
+      @offset_in_minutes = 0
+      @kind = Time::Kind::Utc
+      next_char
+    end
+
+    def time_zone_offset(force_colon = false, allow_colon = true, allow_seconds = true)
+      sign = current_char == '-' ? -1 : 1
+
+      char = next_char
+      raise "Invalid timezone" unless char.ascii_number?
+      hours = char.to_i
+
+      char = next_char
+      raise "Invalid timezone" unless char.ascii_number?
+      hours = 10*hours + char.to_i
+
+      char = next_char
+      if char == ':'
+        raise "Invalid timezone" unless allow_colon
         char = next_char
-        raise "Invalid timezone" unless char.ascii_number?
-        hours = char.to_i
+      elsif force_colon
+        raise "Invalid timezone"
+      end
+      raise "Invalid timezone" unless char.ascii_number?
+      minutes = char.to_i
 
-        char = next_char
-        raise "Invalid timezone" unless char.ascii_number?
-        hours = 10*hours + char.to_i
+      char = next_char
+      raise "Invalid timezone" unless char.ascii_number?
+      minutes = 10*minutes + char.to_i
 
-        char = next_char
-        char = next_char if char == ':'
-        raise "Invalid timezone" unless char.ascii_number?
-        minutes = char.to_i
+      @offset_in_minutes = sign * (60*hours + minutes)
+      @kind = Time::Kind::Utc
+      char = next_char
 
-        char = next_char
-        raise "Invalid timezone" unless char.ascii_number?
-        minutes = 10*minutes + char.to_i
-
-        @offset_in_minutes = sign * (60*hours + minutes)
-        @kind = Time::Kind::Utc
-        char = next_char
-
-        if @reader.has_next?
-          pos = @reader.pos
-          if char == ':' && next_char.ascii_number? && @reader.has_next? && next_char.ascii_number?
-            next_char
-          elsif char.ascii_number? && next_char.ascii_number?
-            next_char
-          else
-            @reader.pos = pos
-          end
+      if @reader.has_next? && allow_seconds
+        pos = @reader.pos
+        if char == ':' && next_char.ascii_number? && @reader.has_next? && next_char.ascii_number?
+          next_char
+        elsif char.ascii_number? && next_char.ascii_number?
+          next_char
+        else
+          @reader.pos = pos
         end
       end
     end
@@ -286,12 +366,41 @@ module Time::Format
       time_zone
     end
 
-    def char(char)
-      if current_char == char
-        next_char
+    def time_zone_gmt
+      consume_string == "GMT" || raise "Invalid timezone"
+      @kind = Time::Kind::Utc
+      @offset_in_minutes = 0
+    end
+
+    def time_zone_rfc2822
+      case char = current_char
+      when '-', '+'
+        time_zone_offset(allow_colon: false)
       else
-        raise "Unexpected char: #{char.inspect} (#{@reader.pos})"
+        zone = consume_string
+        @offset_in_minutes = (RFC_2822_ZONES[zone]? || 0) * 60
+        @kind = Time::Kind::Utc
       end
+    end
+
+    def time_zone_gmt_or_rfc2822(**options)
+      time_zone_rfc2822
+    end
+
+    def char(char, *alternatives, raise do_raise = true)
+      if current_char == char || alternatives.includes?(current_char)
+        next_char
+        true
+      else
+        if do_raise
+          raise "Unexpected char: #{current_char.inspect} (#{@reader.pos})"
+        end
+        false
+      end
+    end
+
+    def char?(char, *alternatives)
+      char(char, *alternatives, raise: false)
     end
 
     def consume_number(max_digits)
@@ -339,6 +448,13 @@ module Time::Format
 
     def skip_space
       next_char if current_char.ascii_whitespace?
+    end
+
+    def whitespace
+      unless current_char.ascii_whitespace?
+        raise "Unexpected char: #{current_char.inspect} (#{@reader.pos})"
+      end
+      next_char
     end
 
     def current_char

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -207,7 +207,7 @@ def Time.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   parse_scalar(ctx, node, Time)
 end
 
-struct Time::Format
+module Time::Format
   def from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
       node.raise "Expected scalar, not #{node.class}"

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -124,7 +124,7 @@ struct Time
   end
 end
 
-struct Time::Format
+module Time::Format
   def to_yaml(value : Time, yaml : YAML::Nodes::Builder)
     yaml.scalar format(value)
   end


### PR DESCRIPTION
The format patterns from `Time::Format` allow to define simple date formats but they are quite limited in flexibility. Many standardized formats include slight variations which must be taken into account for parsing such formats in a standards-compliant way.

This PR reorganizes `Time::Formatter` and introduces custom format definitions for some well-used time formats.

This accompanies #4729 which improves the external API using fixed formats.