### PR TITLE
Make Tuple#map_with_index return a Tuple.

### DIFF
--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -210,6 +210,12 @@ describe "Tuple" do
     tuple2.should eq({"1", "2.5", "a"})
   end
 
+  it "does map_with_index" do
+    tuple = {1, 1, 2, 2}
+    tuple2 = tuple.map_with_index { |e, i| e + i }
+    tuple2.should eq({1, 2, 4, 5})
+  end
+
   it "does reverse" do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -408,6 +408,22 @@ struct Tuple
    {% end %}
   end
 
+  # Like `map`, but the block gets passed both the element and its index.
+  #
+  # ```
+  # tuple = {1, 2.5, "a"}
+  # tuple.map_with_index { |e, i| "tuple[#{i}]: #{e}" } # => {"tuple[0]: 1", "tuple[1]: 2.5", "tuple[2]: a"}
+  # ```
+  def map_with_index
+    {% begin %}
+      Tuple.new(
+        {% for i in 0...T.size %}
+          (yield self[{{i}}], {{i}}),
+        {% end %}
+      )
+    {% end %}
+  end
+
   # Returns a new tuple where the elements are in reverse order.
   #
   # ```


### PR DESCRIPTION
According to issue #683, I think `map_with_index` should also return `Tuple`