### PR TITLE
Fix be_nil expectation to use .nil?

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -8,6 +8,12 @@ private class SpecException < Exception
   end
 end
 
+private class NilMimicker
+  def ==(nil : Nil)
+    true
+  end
+end
+
 describe "Spec matchers" do
   describe "should be_truthy" do
     it "passes for true" do
@@ -46,6 +52,16 @@ describe "Spec matchers" do
 
     it "passes for some non-nil, non-false value" do
       42.should_not be_falsey
+    end
+  end
+
+  describe "be_nil" do
+    it "passes for nil" do
+      nil.should be_nil
+    end
+
+    it "does not pass for overwritten `==`" do
+      NilMimicker.new.should_not be_nil
     end
   end
 

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -8,7 +8,7 @@ describe "YAML" do
     it { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
     it { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
     it { YAML.parse("--- []\n").should eq([] of YAML::Type) }
-    it { YAML.parse("---\n...").should be_nil }
+    it { YAML.parse("---\n...").should eq nil }
 
     it "parses recursive sequence" do
       doc = YAML.parse("--- &foo\n- *foo\n")

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -72,6 +72,21 @@ module Spec
   end
 
   # :nodoc:
+  struct BeNilExpectation
+    def match(actual_value)
+      actual_value.nil?
+    end
+
+    def failure_message(actual_value)
+      "Expected: #{actual_value.inspect} to be nil"
+    end
+
+    def negative_failure_message(actual_value)
+      "Expected: #{actual_value.inspect} not to be nil"
+    end
+  end
+
+  # :nodoc:
   struct CloseExpectation(T, D)
     def initialize(@expected_value : T, @delta : D)
     end
@@ -211,7 +226,7 @@ module Spec
     end
 
     def be_nil
-      eq nil
+      Spec::BeNilExpectation.new
     end
 
     def be_close(expected, delta)


### PR DESCRIPTION
The `be_nil` expectation compares the actual value with `nil` using the `==` operator. This operator can be redefined by any class. This makes it unreliable for testing if a value is actually `nil`.

I would expect the `be_nil` expectation to test with `.nil?` (which as a compiler feature cannot be redefined). `be` is used of identity while `eq` tests equality.

If it should matter for any purpose, the current behaviour of the `==` operator can easily be accomplished by using `eq nil` instead of `be_nil`.