### PR TITLE
Use query string from WebSocket URI-based instantiation

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -300,7 +300,9 @@ describe HTTP::WebSocket do
     spawn do
       http_ref = nil
       ws_handler = HTTP::WebSocketHandler.new do |ws, ctx|
-        ctx.request.path.should eq("/")
+        ctx.request.path.should eq("/foo/bar")
+        ctx.request.query_params["query"].should eq("arg")
+        ctx.request.query_params["yes"].should eq("please")
 
         ws.on_message do |str|
           ws.send("pong #{str}")
@@ -319,7 +321,7 @@ describe HTTP::WebSocket do
 
     listen_port = port_chan.receive
 
-    ws2 = HTTP::WebSocket.new("ws://127.0.0.1:#{listen_port}")
+    ws2 = HTTP::WebSocket.new("ws://127.0.0.1:#{listen_port}/foo/bar?query=arg&yes=please")
 
     random = Random::Secure.hex
     ws2.on_message do |str|

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -280,7 +280,7 @@ class HTTP::WebSocket::Protocol
   def self.new(uri : URI | String, headers = HTTP::Headers.new)
     uri = URI.parse(uri) if uri.is_a?(String)
 
-    if (host = uri.host) && (path = uri.path)
+    if (host = uri.host) && (path = uri.full_path)
       tls = uri.scheme == "https" || uri.scheme == "wss"
       return new(host, path, uri.port, tls, headers)
     end


### PR DESCRIPTION
When instantiating a WebSocket using separate parameters for host and path, it is possible to pass in a query string to the connection by appending it to the end of the path parameter. This is effectively stripped out when is passed through as a URI since the `path` call on the URL does not return the query string.

Fixed by calling `full_path` instead of `path` on the given URI.

See: https://github.com/crystal-lang/crystal/issues/3234 for further and working example