### PR TITLE
Remove `expect_raises` matcher without type argument

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -326,7 +326,7 @@ describe "Char" do
     it { 'a'.in_set?("ab", "ac", "ad").should be_true }
 
     it "rejects invalid ranges" do
-      expect_raises do
+      expect_raises(ArgumentError, "Invalid range c-a") do
         'a'.in_set?("c-a")
       end
     end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -214,7 +214,7 @@ describe "Dir" do
     end
 
     it "raises" do
-      expect_raises do
+      expect_raises(Errno, "No such file or directory") do
         Dir.cd("/nope")
       end
     end

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -130,11 +130,11 @@ describe Enum do
       SpecEnum.from_value(0).should eq(SpecEnum::One)
       SpecEnum.from_value(1).should eq(SpecEnum::Two)
       SpecEnum.from_value(2).should eq(SpecEnum::Three)
-      expect_raises { SpecEnum.from_value(3) }
+      expect_raises(Exception, "Unknown enum SpecEnum value: 3") { SpecEnum.from_value(3) }
     end
 
     it "for flags enum" do
-      expect_raises { SpecEnumFlags.from_value(0) }
+      expect_raises(Exception, "Unknown enum SpecEnumFlags value: 0") { SpecEnumFlags.from_value(0) }
       SpecEnumFlags.from_value(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value(2).should eq(SpecEnumFlags::Two)
       SpecEnumFlags.from_value(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -35,7 +35,7 @@ describe "FileUtils" do
     end
 
     it "raises" do
-      expect_raises do
+      expect_raises(Errno, "No such file or directory") do
         FileUtils.cd("/nope")
       end
     end

--- a/spec/std/gc_spec.cr
+++ b/spec/std/gc_spec.cr
@@ -6,7 +6,7 @@ describe "GC" do
   end
 
   it "raises if calling enable when not disabled" do
-    expect_raises do
+    expect_raises(Exception, "GC is not disabled") do
       GC.enable
     end
   end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -88,7 +88,7 @@ module HTTP
         end
       {% else %}
         it "raises when trying to activate TLS" do
-          expect_raises do
+          expect_raises(Exception, "TLS is disabled") do
             Client.new "example.org", 443, tls: true
           end
         end

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -27,7 +27,7 @@ describe HTTP::LogHandler do
     log_io = IO::Memory.new
     handler = HTTP::LogHandler.new(log_io)
     handler.next = ->(ctx : HTTP::Server::Context) { raise "foo" }
-    expect_raises do
+    expect_raises(Exception, "foo") do
       handler.call(context)
     end
     (log_io.to_s =~ %r(GET / - Unhandled exception:)).should be_truthy

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -135,15 +135,15 @@ describe "Int" do
     it { 3843.to_s(62).should eq("ZZ") }
 
     it "raises on base 1" do
-      expect_raises { 123.to_s(1) }
+      expect_raises(ArgumentError, "Invalid base 1") { 123.to_s(1) }
     end
 
     it "raises on base 37" do
-      expect_raises { 123.to_s(37) }
+      expect_raises(ArgumentError, "Invalid base 37") { 123.to_s(37) }
     end
 
     it "raises on base 62 with upcase" do
-      expect_raises { 123.to_s(62, upcase: true) }
+      expect_raises(ArgumentError, "upcase must be false for base 62") { 123.to_s(62, upcase: true) }
     end
 
     it { to_s_with_io(12, 2).should eq("1100") }
@@ -172,15 +172,15 @@ describe "Int" do
     it { to_s_with_io(3843, 62).should eq("ZZ") }
 
     it "raises on base 1 with io" do
-      expect_raises { to_s_with_io(123, 1) }
+      expect_raises(ArgumentError, "Invalid base 1") { to_s_with_io(123, 1) }
     end
 
     it "raises on base 37 with io" do
-      expect_raises { to_s_with_io(123, 37) }
+      expect_raises(ArgumentError, "Invalid base 37") { to_s_with_io(123, 37) }
     end
 
     it "raises on base 62 with upcase with io" do
-      expect_raises { to_s_with_io(12, 62, upcase: true) }
+      expect_raises(ArgumentError, "upcase must be false for base 62") { to_s_with_io(12, 62, upcase: true) }
     end
   end
 

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -94,7 +94,7 @@ describe "JSON serialization" do
     it "does for Enum with number" do
       JSONSpecEnum.from_json("1").should eq(JSONSpecEnum::One)
 
-      expect_raises do
+      expect_raises(Exception, "Unknown enum JSONSpecEnum value: 3") do
         JSONSpecEnum.from_json("3")
       end
     end
@@ -102,7 +102,7 @@ describe "JSON serialization" do
     it "does for Enum with string" do
       JSONSpecEnum.from_json(%("One")).should eq(JSONSpecEnum::One)
 
-      expect_raises do
+      expect_raises(ArgumentError, "Unknown enum JSONSpecEnum value: Three") do
         JSONSpecEnum.from_json(%("Three"))
       end
     end

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -162,7 +162,7 @@ describe Object do
   describe "getter!" do
     it "uses getter!" do
       obj = TestObject.new
-      expect_raises do
+      expect_raises(Exception, "Nil assertion failed") do
         obj.getter5
       end
       obj.getter5 = 5
@@ -173,7 +173,7 @@ describe Object do
 
     it "uses getter! with type declaration" do
       obj = TestObject.new
-      expect_raises do
+      expect_raises(Exception, "Nil assertion failed") do
         obj.getter6
       end
       obj.getter6 = 6
@@ -287,7 +287,7 @@ describe Object do
   describe "property!" do
     it "uses property!" do
       obj = TestObject.new
-      expect_raises do
+      expect_raises(Exception, "Nil assertion failed") do
         obj.property5
       end
       obj.property5 = 5
@@ -296,7 +296,7 @@ describe Object do
 
     it "uses property! with type declaration" do
       obj = TestObject.new
-      expect_raises do
+      expect_raises(Exception, "Nil assertion failed") do
         obj.property6
       end
       obj.property6 = 6

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -369,14 +369,14 @@ describe "Slice" do
 
   it "creates read-only slice" do
     slice = Slice.new(3, 0, read_only: true)
-    expect_raises { slice[0] = 1 }
-    expect_raises { slice.copy_from(slice) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 1 }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.copy_from(slice) }
 
     subslice = slice[0, 1]
-    expect_raises { subslice[0] = 1 }
+    expect_raises(Exception, "Can't write to read-only Slice") { subslice[0] = 1 }
 
     slice = Bytes[1, 2, 3, read_only: true]
-    expect_raises { slice[0] = 0_u8 }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 0_u8 }
   end
 end
 

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -16,7 +16,7 @@ describe String::Builder do
     builder << 123
     builder.to_s.should eq("123")
 
-    expect_raises { builder.to_s }
+    expect_raises(Exception, "Can only invoke 'to_s' once on String::Builder") { builder.to_s }
   end
 
   it "goes back" do

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -146,7 +146,7 @@ describe StringScanner, "#[]" do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     s.scan(/this is not there/)
 
-    expect_raises { s[0] }
+    expect_raises(Exception, "Nil assertion failed") { s[0] }
   end
 
   it "raises when there is no subgroup" do
@@ -155,8 +155,8 @@ describe StringScanner, "#[]" do
     s.scan(regex)
 
     s[0].should_not be_nil
-    expect_raises { s[5] }
-    expect_raises { s["something"] }
+    expect_raises(IndexError) { s[5] }
+    expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
   end
 end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -133,14 +133,14 @@ describe "String" do
 
     it "gets with a string" do
       "FooBar"["Bar"].should eq "Bar"
-      expect_raises { "FooBar"["Baz"] }
+      expect_raises(Exception, "Nil assertion failed") { "FooBar"["Baz"] }
       "FooBar"["Bar"]?.should eq "Bar"
       "FooBar"["Baz"]?.should be_nil
     end
 
     it "gets with a char" do
       "foo/bar"['/'].should eq '/'
-      expect_raises { "foo/bar"['-'] }
+      expect_raises(Exception, "Nil assertion failed") { "foo/bar"['-'] }
       "foo/bar"['/']?.should eq '/'
       "foo/bar"['-']?.should be_nil
     end
@@ -331,7 +331,7 @@ describe "String" do
     it { expect_raises(ArgumentError, "Invalid base 1") { "12ab".to_i(1) } }
     it { expect_raises(ArgumentError, "Invalid base 37") { "12ab".to_i(37) } }
 
-    it { expect_raises { "1Y2P0IJ32E8E7".to_i(36) } }
+    it { expect_raises(ArgumentError, "Invalid Int32") { "1Y2P0IJ32E8E7".to_i(36) } }
     it { "1Y2P0IJ32E8E7".to_i64(36).should eq(9223372036854775807) }
   end
 

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -136,7 +136,7 @@ describe "YAML serialization" do
     it "does for Enum with number" do
       YAMLSpecEnum.from_yaml(%("1")).should eq(YAMLSpecEnum::One)
 
-      expect_raises do
+      expect_raises(Exception, "Unknown enum YAMLSpecEnum value: 3") do
         YAMLSpecEnum.from_yaml(%("3"))
       end
     end
@@ -144,7 +144,7 @@ describe "YAML serialization" do
     it "does for Enum with string" do
       YAMLSpecEnum.from_yaml(%("One")).should eq(YAMLSpecEnum::One)
 
-      expect_raises do
+      expect_raises(ArgumentError, "Unknown enum YAMLSpecEnum value: Three") do
         YAMLSpecEnum.from_yaml(%("Three"))
       end
     end

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -40,7 +40,7 @@ describe "YAML" do
       end
 
       it "raises if merging with missing alias" do
-        expect_raises do
+        expect_raises(YAML::ParseException, "Unknown anchor 'bar'") do
           YAML.parse(%(---
             foo:
               <<: *bar

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -235,12 +235,6 @@ module Spec
       Spec::BeAExpectation({{type}}).new
     end
 
-    macro expect_raises
-      expect_raises(Exception, nil) do
-        {{yield}}
-      end
-    end
-
     macro expect_raises(klass)
       expect_raises({{klass}}, nil) do
         {{yield}}


### PR DESCRIPTION
As @yxhuvud mentioned in [#5092 (line-comment)](https://github.com/crystal-lang/crystal/pull/5092#discussion_r143664554), the arg-less `expect_raises` matcher doesn't verify the type of an exception: it rescues *any* exception raised by the example block and thus can lead to hidden errors because even unexpected exceptions are accepted.

That's why this matcher has been deprecated in `rspec`.

An example should only be expected to raise one specific type of exception. 

I'd suggest to remove this matcher entirely. There is no reason to have it besides implicitly advising people to use this instead of a proper type-checking matcher. There were quite a few in the standard lib alone.
If, for some reason, there is a very unlikely need to rescue *any* spec, it can simply be replaced by `expect_raises(Exception)`.

It's also an option to deprecate it at first and remove it later, but it's only breaking (badly-designed) specs.

As a replacement, it might be considered to add `expect_raises(message)` which only matches an exception of the exact type `Exception` (no subtypes -- but that's debatable) with a matching message, being the equivalent matcher for exceptions created by `raise(message : String)`.

I also noticed a few exceptions which could be improved:

* `Nil#not_nil!` could raise a custom exception (`NilAssertionError`). It is commonly used such that a specific exception type would be great.
* writing to a read-only `Slice` could also be a candidate for a custom exception.
* `Enum.from_yaml` parsing an integer id raises `Exception: Unknown enum YAMLSpecEnum value: 3`, but parsing a enum name raises `ArgumentError: Unknown enum YAMLSpecEnum value: Three` (messages taken from `yaml/serialization_spec.cr`). I think both should raise the same error type, since there is no real semantic difference.