### PR TITLE
Detect recursive generic structs

### DIFF
--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -230,6 +230,20 @@ describe "Semantic: struct" do
       "recursive struct Foo detected: `@moo : Moo` -> `Moo` -> `Foo`"
   end
 
+  it "detects recursive generic struct through module (#4720)" do
+    assert_error %(
+      module Bar
+      end
+
+      struct Foo(T)
+        include Bar
+        def initialize(@base : Bar?)
+        end
+      end
+      ),
+      "recursive struct Foo(T) detected: `@base : (Bar | Nil)` -> `Bar` -> `Foo(T)`"
+  end
+
   it "detects recursive struct through inheritance (#3071)" do
     assert_error %(
       abstract struct Foo

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -244,6 +244,20 @@ describe "Semantic: struct" do
       "recursive struct Foo(T) detected: `@base : (Bar | Nil)` -> `Bar` -> `Foo(T)`"
   end
 
+  it "detects recursive generic struct through generic module (#4720)" do
+    assert_error %(
+      module Bar(T)
+      end
+
+      struct Foo(T)
+        include Bar(T)
+        def initialize(@base : Bar(T)?)
+        end
+      end
+      ),
+      "recursive struct Foo(T) detected: `@base : (Bar(T) | Nil)` -> `Bar(T)` -> `Foo(T)`"
+  end
+
   it "detects recursive struct through inheritance (#3071)" do
     assert_error %(
       abstract struct Foo

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -140,6 +140,6 @@ class Crystal::RecursiveStructChecker
   end
 
   def struct?(type)
-    type.struct? && type.is_a?(InstanceVarContainer) && !type.is_a?(PrimitiveType) && !type.is_a?(ProcInstanceType) && !type.is_a?(GenericClassType) && !type.abstract?
+    type.struct? && type.is_a?(InstanceVarContainer) && !type.is_a?(PrimitiveType) && !type.is_a?(ProcInstanceType) && !type.abstract?
   end
 end

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -91,7 +91,7 @@ class Crystal::RecursiveStructChecker
       end
     end
 
-    if type.is_a?(NonGenericModuleType)
+    if type.is_a?(NonGenericModuleType) || type.is_a?(GenericModuleInstanceType)
       path.push type
       # Check if the module is composed, recursively, of the target struct
       type.raw_including_types.try &.each do |module_type|


### PR DESCRIPTION
Hi, this PR is referencing the issue #4720 

You can see that compiler currently doesn't detect recursive structs when generics are involved. 
1) https://carc.in/#/r/2vu8
```crystal
module Bar
end

struct Foo(T)
  include Bar
  def initialize(@base : Bar?)
  end
end

x = Foo(Int32).new(nil)
z = Foo(Int32).new(x)
```

2) https://carc.in/#/r/2vu9
```crystal
module Bar(T)
end

struct Foo
  include Bar(Int32)
  def initialize(@base : Bar(Int32)?)
  end
end

x = Foo.new(nil)
z = Foo.new(x)
```

*Note: my first PR*