### PR TITLE
Fix: CI is mising gmp dependency on macOS

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -149,7 +149,7 @@ prepare_build() {
 
   on_linux docker pull "jhass/crystal-build-$ARCH"
 
-  on_osx brew install llvm crystal-lang
+  on_osx brew install llvm crystal-lang gmp
 }
 
 with_build_env() {


### PR DESCRIPTION
The homebrew formula no longer installs GMP. We must install it manually.