### PR TITLE
Add Time.monotonic to return monotonic clock

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -60,6 +60,19 @@ describe Time do
     time.epoch_ms.should eq(milliseconds)
   end
 
+  it "returns always increasing monotonic clock" do
+    clock = Time.monotonic
+    Time.monotonic.should be >= clock
+  end
+
+  it "measures elapsed time" do
+    # NOTE: On some systems, the sleep may not always wait for 1ms and the fiber
+    #       be resumed early. We thus merely test that the method returns a
+    #       positive time span.
+    elapsed = Time.measure { sleep 1.millisecond }
+    elapsed.should be >= 0.seconds
+  end
+
   it "clones" do
     time = Time.now
     (time == time.clone).should be_true

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -117,9 +117,9 @@ module Benchmark
 
   # Returns the time used to execute the given block.
   def measure(label = "") : BM::Tms
-    t0, r0 = Process.times, Time.now
+    t0, r0 = Process.times, Time.monotonic
     yield
-    t1, r1 = Process.times, Time.now
+    t1, r1 = Process.times, Time.monotonic
     BM::Tms.new(t1.utime - t0.utime,
       t1.stime - t0.stime,
       t1.cutime - t0.cutime,
@@ -134,8 +134,6 @@ module Benchmark
   # Benchmark.realtime { "a" * 100_000 } # => 00:00:00.0005840
   # ```
   def realtime : Time::Span
-    r0 = Time.now
-    yield
-    Time.now - r0
+    Time.measure { yield }
   end
 end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -218,13 +218,14 @@ class Crystal::Command
     time? = @time && !@progress_tracker.stats?
     status, elapsed_time = @progress_tracker.stage("Execute") do
       begin
-        start_time = Time.now
-        Process.run(output_filename, args: run_args, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) do |process|
-          # Ignore the signal so we don't exit the running process
-          # (the running process can still handle this signal)
-          Signal::INT.ignore # do
+        elapsed = Time.measure do
+          Process.run(output_filename, args: run_args, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) do |process|
+            # Ignore the signal so we don't exit the running process
+            # (the running process can still handle this signal)
+            Signal::INT.ignore # do
+          end
         end
-        {$?, Time.now - start_time}
+        {$?, elapsed}
       ensure
         File.delete(output_filename) rescue nil
 

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -104,7 +104,7 @@ class Crystal::Program
   end
 
   def macro_compile(filename)
-    time = Time.now
+    time = Time.monotonic
 
     source = File.read(filename)
 
@@ -127,7 +127,7 @@ class Crystal::Program
     File.utime(now, now, program_dir)
 
     if can_reuse_previous_compilation?(filename, executable_path, recorded_requires_path, requires_path)
-      elapsed_time = Time.now - time
+      elapsed_time = Time.monotonic - time
       return CompiledMacroRun.new(executable_path, elapsed_time, true)
     end
 
@@ -166,7 +166,7 @@ class Crystal::Program
       requires_with_timestamps.to_json(file)
     end
 
-    elapsed_time = Time.now - time
+    elapsed_time = Time.monotonic - time
     CompiledMacroRun.new(executable_path, elapsed_time, false)
   end
 

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -18,9 +18,9 @@ module Crystal
       print_stats
       print_progress
 
-      start_time = Time.now
+      time_start = Time.monotonic
       retval = yield
-      time_taken = Time.now - start_time
+      time_taken = Time.monotonic - time_start
 
       print_stats(time_taken)
       print_progress

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -32,9 +32,10 @@ module Crystal
   # ```
   # fun main(argc : Int32, argv : UInt8**) : Int32
   #   Crystal.main do
-  #     time = Time.now
-  #     Crystal.main_user_code(argc, argv)
-  #     puts "Time to execute program: #{Time.now - time}"
+  #     elapsed = Time.measure do
+  #       Crystal.main_user_code(argc, argv)
+  #     end
+  #     puts "Time to execute program: #{elapsed}"
   #   end
   # end
   # ```

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -1,6 +1,15 @@
 require "c/sys/time"
 require "c/time"
 
+{% if flag?(:darwin) %}
+  # Darwin supports clock_gettime starting from macOS Sierra, but we can't
+  # use it because it would prevent running binaries built on macOS Sierra
+  # to run on older macOS releases.
+  #
+  # Furthermore, mach_absolute_time is reported to have a higher precision.
+  require "c/mach/mach_time"
+{% end %}
+
 module Crystal::System::Time
   UnixEpochInSeconds = 62135596800_i64
 
@@ -37,4 +46,30 @@ module Crystal::System::Time
       {timeval.tv_sec.to_i64 + UnixEpochInSeconds, timeval.tv_usec.to_i * 1_000}
     {% end %}
   end
+
+  def self.monotonic
+    {% if flag?(:darwin) %}
+      info = mach_timebase_info
+      total_nanoseconds = LibC.mach_absolute_time * info.numer / info.denom
+      seconds = total_nanoseconds / 1_000_000_000
+      nanoseconds = total_nanoseconds.remainder(1_000_000_000)
+      {seconds.to_i64, nanoseconds.to_i32}
+    {% else %}
+      if LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp) == 1
+        raise Errno.new("clock_gettime(CLOCK_MONOTONIC)")
+      end
+      {tp.tv_sec.to_i64, tp.tv_nsec.to_i32}
+    {% end %}
+  end
+
+  {% if flag?(:darwin) %}
+    @@mach_timebase_info : LibC::MachTimebaseInfo?
+
+    private def self.mach_timebase_info
+      @@mach_timebase_info ||= begin
+        LibC.mach_timebase_info(out info)
+        info
+      end
+    end
+  {% end %}
 end

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -8,9 +8,7 @@ class HTTP::LogHandler
   end
 
   def call(context)
-    time = Time.now
-    call_next(context)
-    elapsed = Time.now - time
+    elapsed = Time.measure { call_next(context) }
     elapsed_text = elapsed_text(elapsed)
 
     @io.puts "#{context.request.method} #{context.request.resource} - #{context.response.status_code} (#{elapsed_text})"

--- a/src/lib_c/x86_64-macosx-darwin/c/mach/mach_time.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/mach/mach_time.cr
@@ -1,0 +1,9 @@
+lib LibC
+  struct MachTimebaseInfo
+    numer : UInt32
+    denom : UInt32
+  end
+
+  fun mach_timebase_info(info : MachTimebaseInfo*) : LibC::Int
+  fun mach_absolute_time : UInt64
+end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -166,9 +166,9 @@ module Spec
 
   # :nodoc:
   def self.run
-    start_time = Time.now
+    start_time = Time.monotonic
     at_exit do
-      elapsed_time = Time.now - start_time
+      elapsed_time = Time.monotonic - start_time
       Spec::RootContext.print_results(elapsed_time)
       exit 1 unless Spec::RootContext.succeeded
     end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -12,16 +12,16 @@ module Spec::Methods
 
     Spec.formatters.each(&.before_example(description))
 
-    start = Time.now
+    start = Time.monotonic
     begin
       Spec.run_before_each_hooks
       block.call
-      Spec::RootContext.report(:success, description, file, line, Time.now - start)
+      Spec::RootContext.report(:success, description, file, line, Time.monotonic - start)
     rescue ex : Spec::AssertionFailed
-      Spec::RootContext.report(:fail, description, file, line, Time.now - start, ex)
+      Spec::RootContext.report(:fail, description, file, line, Time.monotonic - start, ex)
       Spec.abort! if Spec.fail_fast?
     rescue ex
-      Spec::RootContext.report(:error, description, file, line, Time.now - start, ex)
+      Spec::RootContext.report(:error, description, file, line, Time.monotonic - start, ex)
       Spec.abort! if Spec.fail_fast?
     ensure
       Spec.run_after_each_hooks

--- a/src/time.cr
+++ b/src/time.cr
@@ -135,6 +135,26 @@ struct Time
   @nanoseconds : Int32
   @kind : Kind
 
+  # Returns a clock from an unspecified starting point, but strictly linearly
+  # increasing. This clock should be independent from discontinuous jumps in the
+  # system time, such as leap seconds, time zone adjustments or manual changes
+  # to the computer's time.
+  #
+  # For example, the monotonic clock must always be used to measure an elapsed
+  # time.
+  def self.monotonic : Time::Span
+    seconds, nanoseconds = Crystal::System::Time.monotonic
+    Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
+  end
+
+  # Measures how long the block took to run. Relies on `monotonic` to not be
+  # affected by time fluctuations.
+  def self.measure : Time::Span
+    start = monotonic
+    yield
+    monotonic - start
+  end
+
   def self.new
     seconds, nanoseconds, offset = Time.compute_seconds_nanoseconds_and_offset
     new(seconds: seconds + offset, nanoseconds: nanoseconds, kind: Kind::Local)


### PR DESCRIPTION
Exposes `Time.monotonic` as a `Time::Span` with unspecified starting point, but guaranteed to be always increasing, and ready for time span computations, comparisons, ...

Also introduces a `Time.measure(&block)` sugar to measure how long a block takes to run —using the monotonic clock, obviously.

Relies on `clock_gettime(CLOCK_REALTIME)` on POSIX platforms, but rely on `mach_absolute_time` on macOS, which is more widely available and is supposed to have a higher precision.

Supersedes #5107 and #3827.