### PR TITLE
Codegen: compile untyped typeof(exp) correctly

### DIFF
--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -81,4 +81,12 @@ describe "Code gen: no return" do
       end
       ))
   end
+
+  it "codegens untyped typeof (#5105)" do
+    codegen(%(
+      require "prelude"
+
+      typeof(raise("").foo)
+      ))
+  end
 end

--- a/spec/compiler/semantic/no_return_spec.cr
+++ b/spec/compiler/semantic/no_return_spec.cr
@@ -319,4 +319,12 @@ describe "Semantic: NoReturn" do
       baz
       )) { int32 }
   end
+
+  it "types as NoReturn if typeof(exp)'s exp is NoReturn" do
+    assert_type(%(
+      require "prelude"
+
+      typeof(raise("").foo)
+      )) { no_return.metaclass }
+  end
 end

--- a/spec/compiler/semantic/no_return_spec.cr
+++ b/spec/compiler/semantic/no_return_spec.cr
@@ -325,6 +325,6 @@ describe "Semantic: NoReturn" do
       require "prelude"
 
       typeof(raise("").foo)
-      )) { no_return }
+      )) { no_return.metaclass }
   end
 end

--- a/spec/compiler/semantic/no_return_spec.cr
+++ b/spec/compiler/semantic/no_return_spec.cr
@@ -325,6 +325,6 @@ describe "Semantic: NoReturn" do
       require "prelude"
 
       typeof(raise("").foo)
-      )) { no_return.metaclass }
+      )) { no_return }
   end
 end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -743,7 +743,12 @@ module Crystal
 
     def transform(node : TypeOf)
       node = super
-      node.bind_to node.expressions
+
+      unless node.type?
+        node.unbind_from node.dependencies
+        node.bind_to node.expressions
+      end
+
       node
     end
 

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -742,16 +742,9 @@ module Crystal
     end
 
     def transform(node : TypeOf)
-      # When the expression inside `typeof` node is untyped, that is
-      # `typeof(raise("").foo)` for example, then `node` is untyped also.
-      # This may crash the compiler, but the below prevents it.
-      unless node.type?
-        call = untyped_expression node
-        node.bind_to call
-        call
-      else
-        node
-      end
+      node = super
+      node.bind_to node.expressions
+      node
     end
 
     @false_literal : BoolLiteral?

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -741,6 +741,19 @@ module Crystal
       node
     end
 
+    def transform(node : TypeOf)
+      # When the expression inside `typeof` node is untyped, that is
+      # `typeof(raise("").foo)` for example, then `node` is untyped also.
+      # This may crash the compiler, but the below prevents it.
+      unless node.type?
+        call = untyped_expression node
+        node.bind_to call
+        call
+      else
+        node
+      end
+    end
+
     @false_literal : BoolLiteral?
 
     def false_literal

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -741,6 +741,12 @@ module Crystal
       node
     end
 
+    def transform(node : TypeOf)
+      node = super
+      node.bind_to node.expressions
+      node
+    end
+
     @false_literal : BoolLiteral?
 
     def false_literal

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -741,12 +741,6 @@ module Crystal
       node
     end
 
-    def transform(node : TypeOf)
-      node = super
-      node.bind_to node.expressions
-      node
-    end
-
     @false_literal : BoolLiteral?
 
     def false_literal

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -81,7 +81,7 @@ class Crystal::FixMissingTypes < Crystal::Visitor
 
   def visit(node : TypeOf)
     node.expressions.each &.accept self
-    node.type = @program.no_return.metaclass unless node.type?
+    node.type = @program.no_return unless node.type?
     false
   end
 

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -79,12 +79,6 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     end
   end
 
-  def visit(node : TypeOf)
-    node.expressions.each &.accept self
-    node.type = @program.no_return.metaclass unless node.type?
-    false
-  end
-
   def visit(node : ASTNode)
     true
   end

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -81,7 +81,7 @@ class Crystal::FixMissingTypes < Crystal::Visitor
 
   def visit(node : TypeOf)
     node.expressions.each &.accept self
-    node.type = @program.no_return unless node.type?
+    node.type = @program.no_return.metaclass unless node.type?
     false
   end
 

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -79,6 +79,12 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     end
   end
 
+  def visit(node : TypeOf)
+    node.expressions.each &.accept self
+    node.type = @program.no_return.metaclass unless node.type?
+    false
+  end
+
   def visit(node : ASTNode)
     true
   end


### PR DESCRIPTION
Fixed #5105