### PR TITLE
Add remove_empty option to many String#split overloads

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -829,8 +829,11 @@ describe "String" do
 
     describe "by char" do
       it { "".split(',').should eq([""]) }
+      it { "".split(',', remove_empty: true).should eq([] of String) }
       it { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz", ""]) }
+      it { "foo,bar,,baz,".split(',', remove_empty: true).should eq(["foo", "bar", "baz"]) }
       it { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
+      it { "foo,bar,,baz".split(',', remove_empty: true).should eq(["foo", "bar", "baz"]) }
       it { "foo".split(',').should eq(["foo"]) }
       it { "foo".split(' ').should eq(["foo"]) }
       it { "   foo".split(' ').should eq(["", "", "", "foo"]) }
@@ -850,12 +853,15 @@ describe "String" do
       it { "a=".split('=').should eq(["a", ""]) }
       it { "=b".split('=').should eq(["", "b"]) }
       it { "=".split('=', 2).should eq(["", ""]) }
+      it { "=".split('=', 2, remove_empty: true).should eq([] of String) }
     end
 
     describe "by string" do
       it { "".split(",").should eq([""]) }
       it { "".split(":-").should eq([""]) }
+      it { "".split(":-", remove_empty: true).should eq([] of String) }
       it { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz", ""]) }
+      it { "foo:-bar:-:-baz:-".split(":-", remove_empty: true).should eq(["foo", "bar", "baz"]) }
       it { "foo:-bar:-:-baz".split(":-").should eq(["foo", "bar", "", "baz"]) }
       it { "foo".split(":-").should eq(["foo"]) }
       it { "foo".split("").should eq(["f", "o", "o"]) }
@@ -868,11 +874,14 @@ describe "String" do
       it { "a=".split("=").should eq(["a", ""]) }
       it { "=b".split("=").should eq(["", "b"]) }
       it { "=".split("=", 2).should eq(["", ""]) }
+      it { "=".split("=", 2, remove_empty: true).should eq([] of String) }
     end
 
     describe "by regex" do
-      it { "".split(/\n\t/).should eq([""] of String) }
+      it { "".split(/\n\t/).should eq([""]) }
+      it { "".split(/\n\t/, remove_empty: true).should eq([] of String) }
       it { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
+      it { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/, remove_empty: true).should eq(["foo", "bar", "baz"]) }
       it { "foo\n\tbar\n\t\n\tbaz".split(/(?:\n\t)+/).should eq(["foo", "bar", "baz"]) }
       it { "foo,bar".split(/,/, 1).should eq(["foo,bar"]) }
       it { "foo,bar,".split(/,/).should eq(["foo", "bar", ""]) }
@@ -891,6 +900,7 @@ describe "String" do
       it { "a=".split(/\=/).should eq(["a", ""]) }
       it { "=b".split(/\=/).should eq(["", "b"]) }
       it { "=".split(/\=/, 2).should eq(["", ""]) }
+      it { "=".split(/\=/, 2, remove_empty: true).should eq([] of String) }
       it { ",".split(/(?:(x)|(,))/).should eq(["", ",", ""]) }
 
       it "keeps groups" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -820,6 +820,13 @@ describe "String" do
   end
 
   describe "split" do
+    describe "by whitespace" do
+      it { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
+      it { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
+      it { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
+      it { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
+    end
+
     describe "by char" do
       it { "".split(',').should eq([""]) }
       it { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz", ""]) }
@@ -830,9 +837,6 @@ describe "String" do
       it { "foo   ".split(' ').should eq(["foo", "", "", ""]) }
       it { "   foo  bar".split(' ').should eq(["", "", "", "foo", "", "bar"]) }
       it { "   foo   bar\n\t  baz   ".split(' ').should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
-      it { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
-      it { "   foo   bar\n\t  baz   ".split(1).should eq(["   foo   bar\n\t  baz   "]) }
-      it { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
       it { "   foo   bar\n\t  baz   ".split(" ").should eq(["", "", "", "foo", "", "", "bar\n\t", "", "baz", "", "", ""]) }
       it { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }
       it { "foo,bar,baz,qux".split(',', 3).should eq(["foo", "bar", "baz,qux"]) }
@@ -841,7 +845,6 @@ describe "String" do
       it { "foo bar baz qux".split(' ', 3).should eq(["foo", "bar", "baz qux"]) }
       it { "foo bar baz qux".split(' ', 30).should eq(["foo", "bar", "baz", "qux"]) }
       it { "a,b,".split(',', 3).should eq(["a", "b", ""]) }
-      it { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
       it { "日本ん語日本ん語".split('ん').should eq(["日本", "語日本", "語"]) }
       it { "=".split('=').should eq(["", ""]) }
       it { "a=".split('=').should eq(["a", ""]) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -2951,11 +2951,11 @@ class String
     !!index(search)
   end
 
-  # Makes an array by splitting the string on any ASCII whitespace characters
-  # (and removing that whitespace).
+  # Makes an array by splitting the string on any amount of ASCII whitespace
+  # characters (and removing that whitespace).
   #
-  # If *limit* is present, up to *limit* new strings will be created,
-  # with the entire remainder added to the last string.
+  # If *limit* is present, up to *limit* new strings will be created, with the
+  # entire remainder added to the last string.
   #
   # ```
   # old_pond = "
@@ -2974,10 +2974,11 @@ class String
     ary
   end
 
-  # Splits the string after any ASCII whitespace character and yields each part to a block.
+  # Splits the string after any amount of ASCII whitespace characters and yields
+  # each non-whitespace part to a block.
   #
-  # If *limit* is present, up to *limit* new strings will be created,
-  # with the entire remainder added to the last string.
+  # If *limit* is present, up to *limit* new strings will be created, with the
+  # entire remainder added to the last string.
   #
   # ```
   # ary = [] of String


### PR DESCRIPTION
Based on [this](https://github.com/crystal-lang/crystal/issues/4644#issuecomment-328351484) comment by @asterite.

Closes #4644.