### PR TITLE
Remove the possibility to require big_*. Leaving only with require "big"

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_float"
+require "big"
 
 describe "BigFloat" do
   describe "new" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_int"
+require "big"
 
 describe "BigInt" do
   it "creates with a value of zero" do

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_rational"
+require "big"
 
 private def br(n, d)
   BigRational.new(n, d)

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_int"
+require "big"
 
 private def to_s_with_io(num)
   String.build { |str| num.to_s(str) }

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_int"
+require "big"
 require "base64"
 
 # This is a non-optimized version of IO::Memory so we can test

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_int"
+require "big"
 
 struct RangeSpecIntWrapper
   include Comparable(self)

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "big_int"
+require "big"
 
 private module StructSpec
   struct TestClass

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -1,5 +1,4 @@
 require "c/string"
-require "big"
 
 # A `BigFloat` can represent arbitrarily large floats.
 #

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -1,5 +1,4 @@
 require "c/string"
-require "big"
 
 # A `BigInt` can represent arbitrarily large integers.
 #

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -1,5 +1,3 @@
-require "big"
-
 # Rational numbers are represented as the quotient of arbitrarily large
 # numerators and denominators. Rationals are canonicalized such that the
 # denominator and the numerator have no common factors, and that the

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -4,7 +4,7 @@
 # denominator is positive. Zero has the unique representation 0/1.
 #
 # ```
-# require "big_rational"
+# require "big"
 #
 # r = BigRational.new(7.to_big_i, 3.to_big_i)
 # r.to_s # => "7/3"

--- a/src/big_float.cr
+++ b/src/big_float.cr
@@ -1,1 +1,0 @@
-require "./big/big_float"

--- a/src/big_int.cr
+++ b/src/big_int.cr
@@ -1,1 +1,0 @@
-require "./big/big_int"

--- a/src/big_rational.cr
+++ b/src/big_rational.cr
@@ -1,1 +1,0 @@
-require "./big/big_rational"


### PR DESCRIPTION
This one is connected to #5113 

There is no point for allowing to require "big_*" because they `require "big"` in themselves. 
Its an attempt to leave us only with `require "big"`