### PR TITLE
Ensure FormData::Builder field value is a String

### DIFF
--- a/spec/std/http/formdata/builder_spec.cr
+++ b/spec/std/http/formdata/builder_spec.cr
@@ -38,6 +38,26 @@ describe HTTP::FormData::Builder do
     generated.should eq(expected.gsub("\n", "\r\n"))
   end
 
+  describe "#field" do
+    it "converts value to a string" do
+      io = IO::Memory.new
+      HTTP::FormData.build(io, "fixed-boundary") do |g|
+        g.field("foo", 12)
+      end
+
+      generated = io.to_s
+      expected = <<-'MULTIPART'
+        --fixed-boundary
+        Content-Disposition: form-data; name="foo"
+
+        12
+        --fixed-boundary--
+        MULTIPART
+
+      generated.should eq(expected.gsub("\n", "\r\n"))
+    end
+  end
+
   describe "#content_type" do
     it "calculates the content type" do
       builder = HTTP::FormData::Builder.new(IO::Memory.new, "a delimiter string with a quote in \"")

--- a/src/http/formdata/builder.cr
+++ b/src/http/formdata/builder.cr
@@ -37,15 +37,15 @@ module HTTP::FormData
 
     # Adds a form part with the given *name* and *value*. *Headers* can
     # optionally be provided for the form part.
-    def field(name, value, headers : HTTP::Headers = HTTP::Headers.new)
-      file(name, IO::Memory.new(value), headers: headers)
+    def field(name : String, value, headers : HTTP::Headers = HTTP::Headers.new)
+      file(name, IO::Memory.new(value.to_s), headers: headers)
     end
 
     # Adds a form part called *name*, with data from *io* as the value.
     # *Metadata* can be provided to add extra metadata about the file to the
     # Content-Disposition header for the form part. Other headers can be added
     # using *headers*.
-    def file(name, io, metadata : FileMetadata = FileMetadata.new, headers : HTTP::Headers = HTTP::Headers.new)
+    def file(name : String, io, metadata : FileMetadata = FileMetadata.new, headers : HTTP::Headers = HTTP::Headers.new)
       fail "Cannot add form part: already finished" if @state == :FINISHED
 
       headers["Content-Disposition"] = generate_content_disposition(name, metadata)


### PR DESCRIPTION
See https://github.com/RX14/multipart.cr/issues/7.

`field` could be passed an integer, which meant the incorrect `IO::Memory.new` overload was chosen. I chose to fix this by calling `to_s` on the result, but we could also make this more explicit by restricting to an IO.