### PR TITLE
Semantic: missing restriction logic for generic instance module type

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -727,4 +727,22 @@ describe "Codegen: is_a?" do
       Class.is_a?(Class.class.class)
     ").to_b.should be_true
   end
+
+  it "codegens is_a? with generic module including module (#" do
+    run(%(
+      module A
+      end
+
+      module B(T)
+        include A
+      end
+
+      class C
+        include B(Int32)
+      end
+
+      c = C.new.as(A)
+      c.is_a?(C)
+      ), inject_primitives: false).to_b.should be_true
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -835,6 +835,12 @@ module Crystal
     end
   end
 
+  class GenericModuleInstanceType
+    def restrict(other, context)
+      super || including_types.try(&.restrict(other, context))
+    end
+  end
+
   class AliasType
     def restriction_of?(other, owner)
       return true if self == other


### PR DESCRIPTION
Fixes #4287

There was missing logic regarding generic module instances.

The whole logic in `restrictions.cr` is full of duplicated code and it's quite complex, so right now this is the easiest way to fix these things. Eventually the whole type system implementation should change and be simpler, but when that happens we'll have the specs to make sure nothing breaks.