### PR TITLE
NamedTuple: Make comparison of union of named tuples work

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -257,6 +257,16 @@ describe "NamedTuple" do
     tup1.should_not eq(tup3)
   end
 
+  it "compares with named tuple union (#5131)" do
+    tup1 = {a: 1, b: 'a'}
+    tup2 = {a: 1, c: 'b'}
+    u = tup1 || tup2
+    u.should eq(u)
+
+    v = tup2 || tup1
+    u.should_not eq(v)
+  end
+
   it "does to_h" do
     tup1 = {a: 1, b: "hello"}
     hash = tup1.to_h

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -224,6 +224,16 @@ struct NamedTuple
     {% end %}
   end
 
+  protected def sorted_keys
+    {% begin %}
+      Tuple.new(
+        {% for key in T.keys.sort %}
+          {{key.symbolize}},
+        {% end %}
+      )
+    {% end %}
+  end
+
   # Returns a `Tuple` with the values in this named tuple.
   #
   # ```
@@ -484,19 +494,13 @@ struct NamedTuple
 
   # ditto
   def ==(other : NamedTuple)
-    compare_with_other_named_tuple(other)
-  end
+    return false unless sorted_keys == other.sorted_keys
 
-  private def compare_with_other_named_tuple(other : U) forall U
-    {% if T.keys.sort == U.keys.sort %}
-      {% for key in T %}
-        return false unless self[{{key.symbolize}}] == other[{{key.symbolize}}]
-      {% end %}
-
-      true
-    {% else %}
-      false
+    {% for key in T %}
+      return false unless self[{{key.symbolize}}] == other[{{key.symbolize}}]?
     {% end %}
+
+    return true
   end
 
   # Returns a named tuple with the same keys but with cloned values, using the `clone` method.


### PR DESCRIPTION
Fixes #5131

For this I needed to add a `sorted_keys` method, which I made `protected` because I don't know if it makes sense except for this method, so I wouldn't want to add a method to the API that might later change or be removed.