### PR TITLE
Semantic: don't combine union of Number and Number subclass into Number

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4779,4 +4779,26 @@ describe "Semantic: instance var" do
       A.new.a
       )) { int32 }
   end
+
+  it "doesn't combine union of Number and Number subclass (#5073)" do
+    assert_type(%(
+      class Gen(T)
+      end
+
+      struct A < Number
+        def hash(hasher)
+          hasher
+        end
+
+        def to_s(io : IO)
+        end
+      end
+
+      class Foo
+        @foo = Gen(Int32 | A).new
+      end
+
+      Foo.new.@foo
+    )) { generic_class "Gen", union_of(int32, types["A"]) }
+  end
 end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -325,7 +325,7 @@ private def class_common_ancestor(t1, t2)
   end
 
   case t1
-  when t1.program.struct, t1.program.int, t1.program.float
+  when t1.program.struct, t1.program.number, t1.program.int, t1.program.float
     return nil
   when t2
     return t1


### PR DESCRIPTION
Fixes #5073

`Number` was missing in the logic that must prevent it from being combined in unions.