### PR TITLE
HTTP::Client: use required named argument `form` instead of post_form and put_form

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -37,10 +37,10 @@ module HTTP
       typeof(Client.new("host").{{method.id}}("uri", body: "body"))
     {% end %}
 
-    typeof(Client.post_form "url", {"a" => "b"})
-    typeof(Client.post_form("url", {"a" => "b"}) { })
-    typeof(Client.put_form "url", {"a" => "b"})
-    typeof(Client.put_form("url", {"a" => "b"}) { })
+    typeof(Client.post "url", form: {"a" => "b"})
+    typeof(Client.post("url", form: {"a" => "b"}) { })
+    typeof(Client.put "url", form: {"a" => "b"})
+    typeof(Client.put("url", form: {"a" => "b"}) { })
     typeof(Client.new("host").basic_auth("username", "password"))
     typeof(Client.new("host").before_request { |req| })
     typeof(Client.new("host").close)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -378,93 +378,91 @@ class HTTP::Client
         yield response
       end
     end
-  {% end %}
 
-  {% for http_method in %w(post put patch) %}
-    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
+    # Executes a {{method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
     # client = HTTP::Client.new "www.example.com"
-    # response = client.{{http_method.id}}_form "/", "foo=bar"
+    # response = client.{{method.id}} "/", form: "foo=bar"
     # ```
-    def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil) : HTTP::Client::Response
-      request = new_request({{http_method.upcase}}, path, headers, form)
+    def {{method.id}}(path, headers : HTTP::Headers? = nil, *, form : String | IO) : HTTP::Client::Response
+      request = new_request({{method.upcase}}, path, headers, form)
       request.headers["Content-Type"] = "application/x-www-form-urlencoded"
       exec request
     end
 
-    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
+    # Executes a {{method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
     # client = HTTP::Client.new "www.example.com"
-    # client.{{http_method.id}}_form("/", "foo=bar") do |response|
+    # client.{{method.id}}("/", form: "foo=bar") do |response|
     #   response.body_io.gets
     # end
     # ```
-    def {{http_method.id}}_form(path, form : String | IO, headers : HTTP::Headers? = nil)
-      request = new_request({{http_method.upcase}}, path, headers, form)
+    def {{method.id}}(path, headers : HTTP::Headers? = nil, *, form : String | IO)
+      request = new_request({{method.upcase}}, path, headers, form)
       request.headers["Content-Type"] = "application/x-www-form-urlencoded"
       exec(request) do |response|
         yield response
       end
     end
 
-    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
+    # Executes a {{method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
     # client = HTTP::Client.new "www.example.com"
-    # response = client.{{http_method.id}}_form "/", {"foo" => "bar"}
+    # response = client.{{method.id}} "/", form: {"foo" => "bar"}
     # ```
-    def {{http_method.id}}_form(path, form : Hash(String, String) | NamedTuple, headers : HTTP::Headers? = nil) : HTTP::Client::Response
+    def {{method.id}}(path, headers : HTTP::Headers? = nil, *, form : Hash(String, String) | NamedTuple) : HTTP::Client::Response
       body = HTTP::Params.encode(form)
-      {{http_method.id}}_form path, body, headers
+      {{method.id}} path, form: body, headers: headers
     end
 
-    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
+    # Executes a {{method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     # The "Content-type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
     # client = HTTP::Client.new "www.example.com"
-    # client.{{http_method.id}}_form("/", {"foo" => "bar"}) do |response|
+    # client.{{method.id}}("/", form: {"foo" => "bar"}) do |response|
     #   response.body_io.gets
     # end
     # ```
-    def {{http_method.id}}_form(path, form : Hash(String, String) | NamedTuple, headers : HTTP::Headers? = nil)
+    def {{method.id}}(path, headers : HTTP::Headers? = nil, *, form : Hash(String, String) | NamedTuple)
       body = HTTP::Params.encode(form)
-      {{http_method.id}}_form(path, body, headers) do |response|
+      {{method.id}}(path, form: body, headers: headers) do |response|
         yield response
       end
     end
 
-    # Executes a {{http_method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
+    # Executes a {{method.id.upcase}} request with form data and returns a `Response`. The "Content-Type" header is set
     # to "application/x-www-form-urlencoded".
     #
     # ```
-    # response = HTTP::Client.{{http_method.id}}_form "http://www.example.com", "foo=bar"
+    # response = HTTP::Client.{{method.id}} "http://www.example.com", form: "foo=bar"
     # ```
-    def self.{{http_method.id}}_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil) : HTTP::Client::Response
+    def self.{{method.id}}(url, headers : HTTP::Headers? = nil, tls = nil, *, form : String | IO | Hash) : HTTP::Client::Response
       exec(url, tls) do |client, path|
-        client.{{http_method.id}}_form(path, form, headers)
+        client.{{method.id}}(path, form: form, headers: headers)
       end
     end
 
-    # Executes a {{http_method.id.upcase}} request with form data and yields the response to the block.
+    # Executes a {{method.id.upcase}} request with form data and yields the response to the block.
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
-    # HTTP::Client.{{http_method.id}}_form("http://www.example.com", "foo=bar") do |response|
+    # HTTP::Client.{{method.id}}("http://www.example.com", form: "foo=bar") do |response|
     #   response.body_io.gets
     # end
     # ```
-    def self.{{http_method.id}}_form(url, form : String | IO | Hash, headers : HTTP::Headers? = nil, tls = nil)
+    def self.{{method.id}}(url, headers : HTTP::Headers? = nil, tls = nil, *, form : String | IO | Hash)
       exec(url, tls) do |client, path|
-        client.{{http_method.id}}_form(path, form, headers) do |response|
+        client.{{method.id}}(path, form: form, headers: headers) do |response|
           yield response
         end
       end

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -144,7 +144,7 @@ class OAuth2::Client
       "Accept" => "application/json",
     }
 
-    response = HTTP::Client.post_form(token_uri, body, headers)
+    response = HTTP::Client.post(token_uri, form: body, headers: headers)
     case response.status_code
     when 200, 201
       OAuth2::AccessToken.from_json(response.body)


### PR DESCRIPTION
Fixes #5136