### PR TITLE
Demonstrate Parameters for HTTP::Client

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -23,7 +23,7 @@
 #
 # params = HTTP::Params.encode({"author" => "John Doe", "offset" => "20"}) # => author=John+Doe&offset=20
 # response = HTTP::Client.get "http://www.example.com?" + params
-# response.status_code      # => 200
+# response.status_code # => 200
 # ```
 #
 # ### Streaming

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -13,6 +13,20 @@
 # response.body.lines.first # => "<!doctype html>"
 # ```
 #
+# ### Parameters
+#
+# Parameters can be added to any request with the `HTTP::Params#encode` method, which
+# converts a `Hash` or `NamedTuple` to a URL encoded HTTP query.
+#
+# ```
+# require "http/client"
+#
+# params = HTTP::Params.encode({ "q" => "test"}) # => q=test
+# response = HTTP::Client.get "http://www.example.com?" + params
+# response.status_code      # => 200
+# response.body.lines.first # => "<!doctype html>"
+# ```
+#
 # ### Streaming
 #
 # With a block, an `HTTP::Client::Response` body is returned and the response's body

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -21,10 +21,9 @@
 # ```
 # require "http/client"
 #
-# params = HTTP::Params.encode({ "q" => "test"}) # => q=test
+# params = HTTP::Params.encode({"author" => "John Doe", "offset" => "20"}) # => author=John+Doe&offset=20
 # response = HTTP::Client.get "http://www.example.com?" + params
 # response.status_code      # => 200
-# response.body.lines.first # => "<!doctype html>"
 # ```
 #
 # ### Streaming


### PR DESCRIPTION
Adding parameters to an HTTP request seems like a common use case, so some example code would be very useful in the documentation.