### PR TITLE
Alternative hash function

### DIFF
--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -47,9 +47,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#int should be equal for different types" do
@@ -65,9 +63,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#char should change state and differ" do
@@ -78,9 +74,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#enum should change state and differ" do
@@ -91,9 +85,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#symbol should change state and differ" do
@@ -104,9 +96,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#reference should change state and differ" do
@@ -118,9 +108,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#string should change state and differ" do
@@ -131,9 +119,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#class should change state and differ" do
@@ -144,9 +130,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
 
     it "#bytes should change state and differ" do
@@ -159,9 +143,7 @@ describe "Crystal::Hasher" do
       [hasher, hasher1, hasher2, hasher12]
         .map(&.result)
         .combinations(2)
-        .each do |(a, b)|
-        a.should_not eq(b)
-      end
+        .each { |(a, b)| a.should_not eq(b) }
     end
   end
 

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -205,4 +205,28 @@ describe "Crystal::Hasher" do
       hasher2.result.should eq(0x2908fdd2bb81fbed_u64)
     end
   end
+
+  describe "to_s" do
+    it "should not expose internal data" do
+      hasher = THasher.new(1_u64, 2_u64)
+      hasher.to_s.should_not contain('1')
+      hasher.to_s.should_not contain(hasher.@a.to_s)
+      hasher.to_s.should_not contain(hasher.@a.to_s(16))
+      hasher.to_s.should_not contain('2')
+      hasher.to_s.should_not contain(hasher.@b.to_s)
+      hasher.to_s.should_not contain(hasher.@b.to_s(16))
+    end
+  end
+
+  describe "inspect" do
+    it "should not expose internal data" do
+      hasher = THasher.new(1_u64, 2_u64)
+      hasher.inspect.should_not contain('1')
+      hasher.inspect.should_not contain(hasher.@a.to_s)
+      hasher.inspect.should_not contain(hasher.@a.to_s(16))
+      hasher.inspect.should_not contain('2')
+      hasher.inspect.should_not contain(hasher.@b.to_s)
+      hasher.inspect.should_not contain(hasher.@b.to_s(16))
+    end
+  end
 end

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -3,10 +3,6 @@ require "bit_array"
 require "random/secure"
 
 struct Crystal::Hasher
-  def initialize(a, b : UInt64)
-    @hasher = FunnyHash64.new(a, b)
-  end
-
   def self.for_test
     new(1_u64, 1_u64)
   end
@@ -204,9 +200,6 @@ describe "Crystal::Hasher" do
       hasher0 = "".hash(hasher)
       hasher1 = "1".hash(hasher)
       hasher2 = "2.0".hash(hasher)
-      puts "#{hasher0.result.to_s(16)}"
-      puts "#{hasher1.result.to_s(16)}"
-      puts "#{hasher2.result.to_s(16)}"
       hasher0.result.should eq(0x15cf71e56618745b_u64)
       hasher1.result.should eq(0x70ef623beff8c213_u64)
       hasher2.result.should eq(0x2908fdd2bb81fbed_u64)

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -3,145 +3,231 @@ require "bit_array"
 require "random/secure"
 
 struct Crystal::Hasher
-  struct SpecResult
-    def initialize(@v = 0_u64)
-    end
-
-    def differs(other)
-      @v.should_not eq(other.@v)
-      (@v ^ other.@v).popcount.should be_close(32, 24)
-    end
+  def initialize(a, b : UInt64)
+    @hasher = FunnyHash64.new(a, b)
   end
 
-  def self.bytes(b)
-    SpecResult.new(new.bytes(b).result)
+  def self.for_test
+    new(1_u64, 1_u64)
   end
 end
 
-# Note: this tests are probabilistic.
-# Hasher is randomly seeded, therefore this tests could randomly
-# fail. Probability of fail is very very low, but not zero.
-# If test fails two times in a row, then error is certainly real.
-describe "Hasher" do
-  describe "bytes" do
-    it "should differ for every single bit and length" do
-      empty_hash = Crystal::Hasher.bytes(Bytes.new(0))
-      1.upto(64) do |byte_len|
-        bytes = Bytes.new(byte_len, 0_u8)
-        zero_hash = Crystal::Hasher.bytes(bytes)
-        prev_hash = zero_hash
-        prev_prev_hash = Crystal::Hasher::SpecResult.new
-        bit_len = byte_len * 8
-        0.upto(bit_len - 1) do |bit|
-          bytes[bit/8] ^= 1 << (bit & 7)
-          cur_hash = Crystal::Hasher.bytes(bytes)
-          cur_hash.differs empty_hash
-          cur_hash.differs zero_hash
-          cur_hash.differs prev_hash
-          cur_hash.differs prev_prev_hash
-          prev_hash, prev_prev_hash = cur_hash, prev_hash
-          # check for other random bit
-          while true
-            other_bit = rand(bit_len)
-            break if other_bit != bit
-          end
-          bytes[other_bit/8] ^= 1 << (other_bit & 7)
-          oth_hash = Crystal::Hasher.bytes(bytes)
-          cur_hash.differs oth_hash
-          bytes[other_bit/8] ^= 1 << (other_bit & 7)
-          # check for length extention
-          (byte_len - 1).downto((bit + 7)/8) do |len|
-            short_hash = Crystal::Hasher.bytes(bytes[0, len])
-            cur_hash.differs short_hash
-          end
-          bytes[bit/8] ^= 1 << (bit & 7)
-        end
+enum TestHasherEnum
+  A
+  B
+end
+
+alias THasher = Crystal::Hasher
+
+describe "Crystal::Hasher" do
+  context "behavior" do
+    it "#nil should change hasher state" do
+      hasher = THasher.for_test
+      hasher1 = nil.hash(hasher)
+      hasher2 = nil.hash(hasher1)
+      hasher1.result.should_not eq(hasher.result)
+      hasher2.result.should_not eq(hasher.result)
+      hasher2.result.should_not eq(hasher1.result)
+    end
+
+    it "#bool should change state and differ" do
+      hasher = THasher.for_test
+      hasher_true = true.hash(hasher)
+      hasher_false = false.hash(hasher)
+      hasher.result.should_not eq(hasher_true.result)
+      hasher.result.should_not eq(hasher_false.result)
+      hasher_true.result.should_not eq(hasher_false.result)
+    end
+
+    it "#int should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = 1.hash(hasher)
+      hasher2 = 2.hash(hasher)
+      hasher12 = 2.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
       end
     end
 
-    it "should change for every single bit flip" do
-      empty_hash = Crystal::Hasher.bytes(Bytes.new(0))
-      1.upto(64) do |byte_len|
-        bytes = Bytes.new(byte_len, 0_u8)
-        Random::Secure.random_bytes(bytes)
-        zero_hash = Crystal::Hasher.bytes(bytes)
-        prev_hash = zero_hash
-        prev_prev_hash = Crystal::Hasher::SpecResult.new
-        bit_len = byte_len * 8
-        0.upto(bit_len - 1) do |bit|
-          bytes[bit/8] ^= 1 << (bit & 7)
-          cur_hash = Crystal::Hasher.bytes(bytes)
-          cur_hash.differs empty_hash
-          cur_hash.differs zero_hash
-          cur_hash.differs prev_hash
-          cur_hash.differs prev_prev_hash
-          prev_hash, prev_prev_hash = cur_hash, prev_hash
-          # check for other random bit
-          while true
-            other_bit = rand(bit_len)
-            break if other_bit != bit
-          end
-          bytes[other_bit/8] ^= 1 << (other_bit & 7)
-          oth_hash = Crystal::Hasher.bytes(bytes)
-          cur_hash.differs oth_hash
-          bytes[other_bit/8] ^= 1 << (other_bit & 7)
-          bytes[bit/8] ^= 1 << (bit & 7)
-        end
+    it "#int should be equal for different types" do
+      1.hash.should eq(1_u64.hash)
+      2.hash.should eq(2_u64.hash)
+    end
+
+    it "#float should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = 1.0.hash(hasher)
+      hasher2 = 2.0.hash(hasher)
+      hasher12 = 2.0.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#char should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = 'a'.hash(hasher)
+      hasher2 = 'b'.hash(hasher)
+      hasher12 = 'b'.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#enum should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = TestHasherEnum::A.hash(hasher)
+      hasher2 = TestHasherEnum::B.hash(hasher)
+      hasher12 = TestHasherEnum::B.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#symbol should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = :A.hash(hasher)
+      hasher2 = :B.hash(hasher)
+      hasher12 = :B.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#reference should change state and differ" do
+      hasher = THasher.for_test
+      a, b = Reference.new, Reference.new
+      hasher1 = a.hash(hasher)
+      hasher2 = b.hash(hasher)
+      hasher12 = b.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#string should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = "a".hash(hasher)
+      hasher2 = "b".hash(hasher)
+      hasher12 = "b".hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#class should change state and differ" do
+      hasher = THasher.for_test
+      hasher1 = THasher.hash(hasher)
+      hasher2 = TestHasherEnum.hash(hasher)
+      hasher12 = TestHasherEnum.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
+      end
+    end
+
+    it "#bytes should change state and differ" do
+      hasher = THasher.for_test
+      a = Bytes[1, 2, 3]
+      b = Bytes[2, 3, 4]
+      hasher1 = a.hash(hasher)
+      hasher2 = b.hash(hasher)
+      hasher12 = b.hash(hasher1)
+      [hasher, hasher1, hasher2, hasher12]
+        .map(&.result)
+        .combinations(2)
+        .each do |(a, b)|
+        a.should_not eq(b)
       end
     end
   end
 
-  describe "int" do
-    it "should satisfy birthday paradox (32)" do
-      d = 2**22
-      d1d = (d.to_f - 1.0)/d.to_f
-      bits = Array.new(4) { BitArray.new(d) }
-      counts = [0, 0, 0]
-      65537.times do |i|
-        hsh = (i * 0xcafebeef).hash
-        vals = [hsh, hsh >> 22, hsh >> 42]
-        3.times do |j|
-          pos = vals[j] & (d - 1)
-          if bits[j][pos]
-            counts[j] += 1
-          else
-            bits[j][pos] = true
-          end
-        end
-        if i > 30000 && i % 1024 == 0
-          expected = (i - d).to_f + d * d1d**i
-          3.times do |j|
-            counts[j].should be_close(expected, expected/2)
-          end
-        end
-      end
+  context "funny_hash" do
+    it "result should work" do
+      hasher = THasher.new(1_u64, 1_u64)
+      typeof(hasher.result).should eq(UInt64)
+      hasher.result.should eq(0x162c591a100060e5_u64)
+
+      hasher = THasher.new(1_u64, 2_u64)
+      hasher.result.should eq(0x7f8304f0947082d1_u64)
+
+      hasher = THasher.new(2_u64, 1_u64)
+      hasher.result.should eq(0xc302065c9b909fdf_u64)
+
+      hasher = THasher.new(0x123456789abcdef0_u64, 0x016fcd2b89e745a3_u64)
+      hasher.result.should eq(0x54258afe17b6a4bb_u64)
+
+      # "bad seed"
+      hasher = THasher.new(0_u64, 0_u64)
+      hasher.result.should eq(0_u64)
     end
 
-    it "should satisfy birthday paradox (64)" do
-      d = 2**22
-      d1d = (d.to_f - 1.0)/d.to_f
-      bits = Array.new(4) { BitArray.new(d) }
-      counts = [0, 0, 0]
-      v = 0_u64
-      165537.times do |i|
-        v = v*5 + 1
-        hsh = v.hash
-        vals = [hsh, hsh >> 22, hsh >> 42]
-        3.times do |j|
-          pos = vals[j] & (d - 1)
-          if bits[j][pos]
-            counts[j] += 1
-          else
-            bits[j][pos] = true
-          end
-        end
-        if i > 30000 && i % 1024 == 0
-          expected = (i - d).to_f + d * d1d**i
-          3.times do |j|
-            counts[j].should be_close(expected, expected/2)
-          end
-        end
-      end
+    it "#nil should match test vectors" do
+      hasher = THasher.for_test
+      hasher1 = nil.hash(hasher)
+      hasher2 = nil.hash(hasher1)
+      hasher1.result.should eq(0x2c58b2332000c1cb_u64)
+      hasher2.result.should eq(0xef5ab89129b8991b_u64)
+    end
+
+    it "#bool should match test vectors" do
+      hasher = THasher.for_test
+      hasher_true = true.hash(hasher)
+      hasher_false = false.hash(hasher)
+      hasher_true.result.should eq(0x94e4534c12903881_u64)
+      hasher_false.result.should eq(0x15cf71e56618745b_u64)
+    end
+
+    it "#int should match test vectors" do
+      hasher = THasher.for_test
+      hasher1 = 1.hash(hasher)
+      hasher2 = 2.hash(hasher)
+      hasher1.result.should eq(0x94e4534c12903881_u64)
+      hasher2.result.should eq(0xaf42909720d981e7_u64)
+    end
+
+    it "#float should match test vectors" do
+      hasher = THasher.for_test
+      hasher1 = 1.0.hash(hasher)
+      hasher2 = 2.0.hash(hasher)
+      hasher1.result.should eq(0xecfbe7798e8f67f2_u64)
+      hasher2.result.should eq(0x72847386c9572c30_u64)
+    end
+
+    it "#string should match test vectors" do
+      hasher = THasher.for_test
+      hasher0 = "".hash(hasher)
+      hasher1 = "1".hash(hasher)
+      hasher2 = "2.0".hash(hasher)
+      puts "#{hasher0.result.to_s(16)}"
+      puts "#{hasher1.result.to_s(16)}"
+      puts "#{hasher2.result.to_s(16)}"
+      hasher0.result.should eq(0x15cf71e56618745b_u64)
+      hasher1.result.should eq(0x70ef623beff8c213_u64)
+      hasher2.result.should eq(0x2908fdd2bb81fbed_u64)
     end
   end
 end

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -13,12 +13,12 @@ enum TestHasherEnum
   B
 end
 
-alias THasher = Crystal::Hasher
+alias TestHasher = Crystal::Hasher
 
 describe "Crystal::Hasher" do
   context "behavior" do
     it "#nil should change hasher state" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = nil.hash(hasher)
       hasher2 = nil.hash(hasher1)
       hasher1.result.should_not eq(hasher.result)
@@ -27,7 +27,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#bool should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher_true = true.hash(hasher)
       hasher_false = false.hash(hasher)
       hasher.result.should_not eq(hasher_true.result)
@@ -36,7 +36,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#int should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = 1.hash(hasher)
       hasher2 = 2.hash(hasher)
       hasher12 = 2.hash(hasher1)
@@ -52,7 +52,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#float should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = 1.0.hash(hasher)
       hasher2 = 2.0.hash(hasher)
       hasher12 = 2.0.hash(hasher1)
@@ -63,7 +63,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#char should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = 'a'.hash(hasher)
       hasher2 = 'b'.hash(hasher)
       hasher12 = 'b'.hash(hasher1)
@@ -74,7 +74,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#enum should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = TestHasherEnum::A.hash(hasher)
       hasher2 = TestHasherEnum::B.hash(hasher)
       hasher12 = TestHasherEnum::B.hash(hasher1)
@@ -85,7 +85,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#symbol should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = :A.hash(hasher)
       hasher2 = :B.hash(hasher)
       hasher12 = :B.hash(hasher1)
@@ -96,7 +96,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#reference should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       a, b = Reference.new, Reference.new
       hasher1 = a.hash(hasher)
       hasher2 = b.hash(hasher)
@@ -108,7 +108,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#string should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = "a".hash(hasher)
       hasher2 = "b".hash(hasher)
       hasher12 = "b".hash(hasher1)
@@ -119,8 +119,8 @@ describe "Crystal::Hasher" do
     end
 
     it "#class should change state and differ" do
-      hasher = THasher.for_test
-      hasher1 = THasher.hash(hasher)
+      hasher = TestHasher.for_test
+      hasher1 = TestHasher.hash(hasher)
       hasher2 = TestHasherEnum.hash(hasher)
       hasher12 = TestHasherEnum.hash(hasher1)
       [hasher, hasher1, hasher2, hasher12]
@@ -130,7 +130,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#bytes should change state and differ" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       a = Bytes[1, 2, 3]
       b = Bytes[2, 3, 4]
       hasher1 = a.hash(hasher)
@@ -145,26 +145,26 @@ describe "Crystal::Hasher" do
 
   context "funny_hash" do
     it "result should work" do
-      hasher = THasher.new(1_u64, 1_u64)
+      hasher = TestHasher.new(1_u64, 1_u64)
       typeof(hasher.result).should eq(UInt64)
       hasher.result.should eq(0x162c591a100060e5_u64)
 
-      hasher = THasher.new(1_u64, 2_u64)
+      hasher = TestHasher.new(1_u64, 2_u64)
       hasher.result.should eq(0x7f8304f0947082d1_u64)
 
-      hasher = THasher.new(2_u64, 1_u64)
+      hasher = TestHasher.new(2_u64, 1_u64)
       hasher.result.should eq(0xc302065c9b909fdf_u64)
 
-      hasher = THasher.new(0x123456789abcdef0_u64, 0x016fcd2b89e745a3_u64)
+      hasher = TestHasher.new(0x123456789abcdef0_u64, 0x016fcd2b89e745a3_u64)
       hasher.result.should eq(0x54258afe17b6a4bb_u64)
 
       # "bad seed"
-      hasher = THasher.new(0_u64, 0_u64)
+      hasher = TestHasher.new(0_u64, 0_u64)
       hasher.result.should eq(0_u64)
     end
 
     it "#nil should match test vectors" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = nil.hash(hasher)
       hasher2 = nil.hash(hasher1)
       hasher1.result.should eq(0x2c58b2332000c1cb_u64)
@@ -172,7 +172,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#bool should match test vectors" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher_true = true.hash(hasher)
       hasher_false = false.hash(hasher)
       hasher_true.result.should eq(0x94e4534c12903881_u64)
@@ -180,7 +180,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#int should match test vectors" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = 1.hash(hasher)
       hasher2 = 2.hash(hasher)
       hasher1.result.should eq(0x94e4534c12903881_u64)
@@ -188,7 +188,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#float should match test vectors" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher1 = 1.0.hash(hasher)
       hasher2 = 2.0.hash(hasher)
       hasher1.result.should eq(0xecfbe7798e8f67f2_u64)
@@ -196,7 +196,7 @@ describe "Crystal::Hasher" do
     end
 
     it "#string should match test vectors" do
-      hasher = THasher.for_test
+      hasher = TestHasher.for_test
       hasher0 = "".hash(hasher)
       hasher1 = "1".hash(hasher)
       hasher2 = "2.0".hash(hasher)
@@ -208,7 +208,7 @@ describe "Crystal::Hasher" do
 
   describe "to_s" do
     it "should not expose internal data" do
-      hasher = THasher.new(1_u64, 2_u64)
+      hasher = TestHasher.new(1_u64, 2_u64)
       hasher.to_s.should_not contain('1')
       hasher.to_s.should_not contain(hasher.@a.to_s)
       hasher.to_s.should_not contain(hasher.@a.to_s(16))
@@ -220,7 +220,7 @@ describe "Crystal::Hasher" do
 
   describe "inspect" do
     it "should not expose internal data" do
-      hasher = THasher.new(1_u64, 2_u64)
+      hasher = TestHasher.new(1_u64, 2_u64)
       hasher.inspect.should_not contain('1')
       hasher.inspect.should_not contain(hasher.@a.to_s)
       hasher.inspect.should_not contain(hasher.@a.to_s(16))

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -1,0 +1,147 @@
+require "spec"
+require "bit_array"
+require "random/secure"
+
+struct Crystal::Hasher
+  struct SpecResult
+    def initialize(@v = 0_u64)
+    end
+
+    def differs(other)
+      @v.should_not eq(other.@v)
+      (@v ^ other.@v).popcount.should be_close(32, 24)
+    end
+  end
+
+  def self.bytes(b)
+    SpecResult.new(new.bytes(b).result)
+  end
+end
+
+# Note: this tests are probabilistic.
+# Hasher is randomly seeded, therefore this tests could randomly
+# fail. Probability of fail is very very low, but not zero.
+# If test fails two times in a row, then error is certainly real.
+describe "Hasher" do
+  describe "bytes" do
+    it "should differ for every single bit and length" do
+      empty_hash = Crystal::Hasher.bytes(Bytes.new(0))
+      1.upto(64) do |byte_len|
+        bytes = Bytes.new(byte_len, 0_u8)
+        zero_hash = Crystal::Hasher.bytes(bytes)
+        prev_hash = zero_hash
+        prev_prev_hash = Crystal::Hasher::SpecResult.new
+        bit_len = byte_len * 8
+        0.upto(bit_len - 1) do |bit|
+          bytes[bit/8] ^= 1 << (bit & 7)
+          cur_hash = Crystal::Hasher.bytes(bytes)
+          cur_hash.differs empty_hash
+          cur_hash.differs zero_hash
+          cur_hash.differs prev_hash
+          cur_hash.differs prev_prev_hash
+          prev_hash, prev_prev_hash = cur_hash, prev_hash
+          # check for other random bit
+          while true
+            other_bit = rand(bit_len)
+            break if other_bit != bit
+          end
+          bytes[other_bit/8] ^= 1 << (other_bit & 7)
+          oth_hash = Crystal::Hasher.bytes(bytes)
+          cur_hash.differs oth_hash
+          bytes[other_bit/8] ^= 1 << (other_bit & 7)
+          # check for length extention
+          (byte_len - 1).downto((bit + 7)/8) do |len|
+            short_hash = Crystal::Hasher.bytes(bytes[0, len])
+            cur_hash.differs short_hash
+          end
+          bytes[bit/8] ^= 1 << (bit & 7)
+        end
+      end
+    end
+
+    it "should change for every single bit flip" do
+      empty_hash = Crystal::Hasher.bytes(Bytes.new(0))
+      1.upto(64) do |byte_len|
+        bytes = Bytes.new(byte_len, 0_u8)
+        Random::Secure.random_bytes(bytes)
+        zero_hash = Crystal::Hasher.bytes(bytes)
+        prev_hash = zero_hash
+        prev_prev_hash = Crystal::Hasher::SpecResult.new
+        bit_len = byte_len * 8
+        0.upto(bit_len - 1) do |bit|
+          bytes[bit/8] ^= 1 << (bit & 7)
+          cur_hash = Crystal::Hasher.bytes(bytes)
+          cur_hash.differs empty_hash
+          cur_hash.differs zero_hash
+          cur_hash.differs prev_hash
+          cur_hash.differs prev_prev_hash
+          prev_hash, prev_prev_hash = cur_hash, prev_hash
+          # check for other random bit
+          while true
+            other_bit = rand(bit_len)
+            break if other_bit != bit
+          end
+          bytes[other_bit/8] ^= 1 << (other_bit & 7)
+          oth_hash = Crystal::Hasher.bytes(bytes)
+          cur_hash.differs oth_hash
+          bytes[other_bit/8] ^= 1 << (other_bit & 7)
+          bytes[bit/8] ^= 1 << (bit & 7)
+        end
+      end
+    end
+  end
+
+  describe "int" do
+    it "should satisfy birthday paradox (32)" do
+      d = 2**22
+      d1d = (d.to_f - 1.0)/d.to_f
+      bits = Array.new(4) { BitArray.new(d) }
+      counts = [0, 0, 0]
+      65537.times do |i|
+        hsh = (i * 0xcafebeef).hash
+        vals = [hsh, hsh >> 22, hsh >> 42]
+        3.times do |j|
+          pos = vals[j] & (d - 1)
+          if bits[j][pos]
+            counts[j] += 1
+          else
+            bits[j][pos] = true
+          end
+        end
+        if i > 30000 && i % 1024 == 0
+          expected = (i - d).to_f + d * d1d**i
+          3.times do |j|
+            counts[j].should be_close(expected, expected/2)
+          end
+        end
+      end
+    end
+
+    it "should satisfy birthday paradox (64)" do
+      d = 2**22
+      d1d = (d.to_f - 1.0)/d.to_f
+      bits = Array.new(4) { BitArray.new(d) }
+      counts = [0, 0, 0]
+      v = 0_u64
+      165537.times do |i|
+        v = v*5 + 1
+        hsh = v.hash
+        vals = [hsh, hsh >> 22, hsh >> 42]
+        3.times do |j|
+          pos = vals[j] & (d - 1)
+          if bits[j][pos]
+            counts[j] += 1
+          else
+            bits[j][pos] = true
+          end
+        end
+        if i > 30000 && i % 1024 == 0
+          expected = (i - d).to_f + d * d1d**i
+          3.times do |j|
+            counts[j].should be_close(expected, expected/2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -404,6 +404,14 @@ describe "Slice" do
     slice = Bytes[1, 2, 3, read_only: true]
     expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 0_u8 }
   end
+
+  it "hashes each item in collection" do
+    Slice[1, 2, 3].hash.should eq(Slice[1_u64, 2_u64, 3_u64].hash)
+  end
+
+  it "optimizes hash for Bytes" do
+    Bytes[1, 2, 3].hash.should_not eq(Slice[1, 2, 3].hash)
+  end
 end
 
 private def itself(*args)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -75,7 +75,6 @@ struct Crystal::Hasher
     bytes(value.to_slice)
   end
 
-  @[NoInline]
   def bytes(value)
     bsz = value.size
     v = bsz.to_u64 << 56

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -122,7 +122,7 @@ struct Crystal::Hasher
   def bytes(value)
     bsz = value.size
     u = value.to_unsafe
-    if bsz == 0
+    if bsz <= 0
       v = 0_u64
     elsif bsz <= 3
       v = read_u24(u, bsz)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -128,14 +128,14 @@ struct Crystal::Hasher
       v = readu24(u, bsz)
     elsif bsz <= 7
       v = readu32(u)
-      v |= readu32(u + (bsz&3)) << 32
+      v |= readu32(u + (bsz & 3)) << 32
     else
       while bsz >= 8
         permute(readu64(u))
         u += 8
         bsz -= 8
       end
-      v = readu64(u-(8-bsz))
+      v = readu64(u - (8 - bsz))
     end
     @a ^= bsz
     @b ^= bsz

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -91,7 +91,7 @@ struct Crystal::Hasher
       # force correct unaligned read
       t4 = uninitialized UInt32
       pointerof(t4).as(UInt8*).copy_from(u, 4)
-      v |= t4 << 24
+      v |= t4.to_u64 << 24
       u += 4
     end
     if (r = bsz & 3) != 0

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -72,11 +72,11 @@ struct Crystal::Hasher
   end
 
   def string(value)
-    string(value.to_slice)
+    bytes(value.to_slice)
   end
 
   @[NoInline]
-  def string(value : Bytes)
+  def bytes(value)
     bsz = value.size
     v = bsz.to_u64 << 56
     u = value.to_unsafe

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -119,9 +119,6 @@ struct Crystal::Hasher
     t8
   end
 
-  # Fast hash for `Bytes`.
-  # It treats `Bytes` as binary data, and not as "an array of small numbers".
-  # `Bytes#hash(hasher)` (ie `Slice(UInt8)#hash(hasher)`) calls this method.
   def bytes(value : Bytes)
     size = value.size
     ptr = value.to_unsafe

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -101,18 +101,18 @@ struct Crystal::Hasher
     bytes(value.to_slice)
   end
 
-  private def readu24(u, r)
+  private def read_u24(u, r)
     u[0].to_u64 | (u[r/2].to_u64 << 8) | (u[r - 1].to_u64 << 16)
   end
 
-  private def readu32(u)
+  private def read_u32(u)
     # force correct unaligned read
     t4 = uninitialized UInt32
     pointerof(t4).as(UInt8*).copy_from(u, 4)
     t4.to_u64
   end
 
-  private def readu64(u)
+  private def read_u64(u)
     # force correct unaligned read
     t8 = uninitialized UInt64
     pointerof(t8).as(UInt8*).copy_from(u, 8)
@@ -125,17 +125,17 @@ struct Crystal::Hasher
     if bsz == 0
       v = 0_u64
     elsif bsz <= 3
-      v = readu24(u, bsz)
+      v = read_u24(u, bsz)
     elsif bsz <= 7
-      v = readu32(u)
-      v |= readu32(u + (bsz & 3)) << 32
+      v = read_u32(u)
+      v |= read_u32(u + (bsz & 3)) << 32
     else
       while bsz >= 8
-        permute(readu64(u))
+        permute(read_u64(u))
         u += 8
         bsz -= 8
       end
-      v = readu64(u - (8 - bsz))
+      v = read_u64(u - (8 - bsz))
     end
     @a ^= bsz
     @b ^= bsz

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -119,7 +119,10 @@ struct Crystal::Hasher
     t8
   end
 
-  def bytes(value)
+  # Fast hash for `Bytes`.
+  # It treats `Bytes` as binary data, and not as "an array of small numbers".
+  # `Bytes#hash(hasher)` (ie `Slice(UInt8)#hash(hasher)`) calls this method.
+  def bytes(value : Bytes)
     size = value.size
     ptr = value.to_unsafe
     if size <= 0

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -148,4 +148,9 @@ struct Crystal::Hasher
   def class(value)
     value.crystal_type_id.hash(self)
   end
+
+  def inspect(io)
+    io << "#{self.class}(hidden_state)"
+    nil
+  end
 end

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -50,7 +50,14 @@ struct Crystal::Hasher
   end
 
   def string(value)
-    value.to_slice.hash(self)
+    string(value.to_slice)
+  end
+
+  def string(value : Bytes)
+    value.each do |b|
+      @result = @result * 31  + b.to_u64
+    end
+    self
   end
 
   def class(value)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -28,10 +28,10 @@ struct Crystal::Hasher
   # and then combines them with addition. It greatly reduce
   # possibility of state deduction.
   #
-  # Note, it provides good protection from HashDos iif:
+  # Note, it provides good protection from HashDos if and only if:
   # - seed is securely random and not exposed to attacker,
   # - hash result is also not exposed to attacker in a way other
-  #   than effect of using it Hash implementation.
+  #   than effect of using it in Hash implementation.
   # Do not output calculated hash value to user's console/form/
   # html/api response, etc. Use some from digest package instead.
 

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -38,47 +38,30 @@ struct Crystal::Hasher
   @@seed = uninitialized UInt64[2]
   Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
 
-  @a : UInt64 = @@seed[0]
-  @b : UInt64 = @@seed[1]
-
-  private C1 = 0xacd5ad43274593b9_u64
-  private C2 = 0x6956abd6ed268a3d_u64
-
-  private def rotl32(v : UInt64)
-    (v << 32) | (v >> 32)
-  end
-
-  private def permute(v : UInt64)
-    @a = rotl32(@a ^ v) * C1
-    @b = (rotl32(@b) ^ v) * C2
-    self
+  def initialize
+    @hasher = FunnyHash64.new(@@seed[0], @@seed[1])
   end
 
   def result
-    a, b = @a, @b
-    a ^= (a >> 23) ^ (a >> 40)
-    b ^= (b >> 23) ^ (b >> 40)
-    a *= C1
-    b *= C2
-    a ^= a >> 32
-    b ^= b >> 32
-    a + b
+    @hasher.result
   end
 
   def nil
+    @hasher.permute_nil
     self
   end
 
   def bool(value)
-    (value ? 1 : 0).hash(self)
+    (value ? 1_u64 : 0_u64).hash(self)
   end
 
   def int(value)
-    permute(value.to_u64)
+    @hasher.permute(value.to_u64)
+    self
   end
 
   def float(value)
-    permute(value.to_f64.unsafe_as(UInt64))
+    value.to_f64.unsafe_as(UInt64).hash(self)
   end
 
   def char(value)
@@ -94,56 +77,95 @@ struct Crystal::Hasher
   end
 
   def reference(value)
-    permute(value.object_id.to_u64)
+    value.object_id.to_u64.hash(self)
   end
 
   def string(value)
-    bytes(value.to_slice)
-  end
-
-  private def read_u24(ptr, rest)
-    ptr[0].to_u64 | (ptr[rest/2].to_u64 << 8) | (ptr[rest - 1].to_u64 << 16)
-  end
-
-  private def read_u32(ptr)
-    # force correct unaligned read
-    t4 = uninitialized UInt32
-    pointerof(t4).as(UInt8*).copy_from(ptr, 4)
-    t4.to_u64
-  end
-
-  private def read_u64(ptr)
-    # force correct unaligned read
-    t8 = uninitialized UInt64
-    pointerof(t8).as(UInt8*).copy_from(ptr, 8)
-    t8
-  end
-
-  def bytes(value : Bytes)
-    size = value.size
-    ptr = value.to_unsafe
-    if size <= 0
-      last = 0_u64
-    elsif size <= 3
-      last = read_u24(ptr, size)
-    elsif size <= 7
-      last = read_u32(ptr)
-      last |= read_u32(ptr + (size & 3)) << 32
-    else
-      while size >= 8
-        permute(read_u64(ptr))
-        ptr += 8
-        size -= 8
-      end
-      last = read_u64(ptr - (8 - size))
-    end
-    @a ^= size
-    @b ^= size
-    permute(last)
+    @hasher.permute(value.to_slice)
     self
   end
 
   def class(value)
     value.crystal_type_id.hash(self)
+  end
+
+  def bytes(value : Bytes)
+    @hasher.permute(value)
+    self
+  end
+
+  # :nodoc:
+  struct FunnyHash64
+    def initialize(@a : UInt64, @b : UInt64)
+    end
+
+    private C1 = 0xacd5ad43274593b9_u64
+    private C2 = 0x6956abd6ed268a3d_u64
+
+    def permute_nil
+      @a += @b
+      @b += 1
+    end
+
+    def permute(value : UInt64)
+      @a = rotl32(@a ^ value) * C1
+      @b = (rotl32(@b) ^ value) * C2
+    end
+
+    def permute(value : Bytes)
+      size = value.size
+      ptr = value.to_unsafe
+      if size <= 0
+        last = 0_u64
+      elsif size <= 3
+        last = read_u24(ptr, size)
+      elsif size <= 7
+        last = read_u32(ptr)
+        last |= read_u32(ptr + (size & 3)) << 32
+      else
+        while size >= 8
+          permute(read_u64(ptr))
+          ptr += 8
+          size -= 8
+        end
+        last = read_u64(ptr - (8 - size))
+      end
+      @a ^= size
+      @b ^= size
+      permute(last)
+    end
+
+    def result
+      a, b = @a, @b
+      a ^= (a >> 23) ^ (a >> 40)
+      b ^= (b >> 23) ^ (b >> 40)
+      a *= C1
+      b *= C2
+      a ^= a >> 32
+      b ^= b >> 32
+      a + b
+    end
+
+    private def rotl32(v : UInt64)
+      (v << 32) | (v >> 32)
+    end
+
+    private def read_u24(ptr, rest)
+      ptr[0].to_u64 | (ptr[rest/2].to_u64 << 8) | (ptr[rest - 1].to_u64 << 16)
+    end
+
+    private def read_u32(ptr)
+      # force correct unaligned read
+      t4 = uninitialized UInt32
+      pointerof(t4).as(UInt8*).copy_from(ptr, 4)
+      t4.to_u64
+    end
+
+    private def read_u64(ptr)
+      # force correct unaligned read
+      t8 = uninitialized UInt64
+      pointerof(t8).as(UInt8*).copy_from(ptr, 8)
+      t8
+    end
   end
 end

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -9,10 +9,35 @@ struct Crystal::Hasher
   # TODO: the implementation is naive and should probably use
   # another algorithm like SipHash or FNV.
 
-  @@seed = uninitialized UInt64
-  Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), 8))
+  @@seed = uninitialized UInt64[2]
+  Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
 
-  property result : UInt64 = @@seed
+  @a : UInt64 = @@seed[0]
+  @b : UInt64 = @@seed[1]
+
+  private C1 = 0xacd5ad43274593b9_u64
+  private C2 = 0x6956abd6ed268a3d_u64
+
+  private def rotl32(v : UInt64)
+    v.unsafe_shl(32) | v.unsafe_shr(32)
+  end
+
+  private def permute(v : UInt64)
+    @a = rotl32(@a ^ v) * C1
+    @b = (rotl32(@b) ^ v) * C2
+    self
+  end
+
+  def result
+    a, b = @a, @b
+    a ^= a >> 33
+    b ^= b >> 32
+    a *= C1
+    b *= C2
+    a ^= a >> 32
+    b ^= b >> 33
+    a + b
+  end
 
   def nil
     self
@@ -23,13 +48,11 @@ struct Crystal::Hasher
   end
 
   def int(value)
-    @result = @result * 31 + value.to_u64
-    self
+    permute(value.to_u64)
   end
 
   def float(value)
-    @result = @result * 31 + value.to_f64.unsafe_as(UInt64)
-    self
+    permute(value.to_f64.unsafe_as(UInt64))
   end
 
   def char(value)
@@ -45,18 +68,36 @@ struct Crystal::Hasher
   end
 
   def reference(value)
-    @result = @result * 31 + value.object_id.to_u64
-    self
+    permute(value.object_id.to_u64)
   end
 
   def string(value)
     string(value.to_slice)
   end
 
+  @[NoInline]
   def string(value : Bytes)
-    value.each do |b|
-      @result = @result * 31  + b.to_u64
+    bsz = value.size
+    v = bsz.to_u64 << 56
+    u = value.to_unsafe
+    bsz.unsafe_div(8).downto(1) do
+      # force correct unaligned read
+      t8 = uninitialized UInt64
+      pointerof(t8).as(UInt8*).copy_from(u, 8)
+      permute(t8)
+      u += 8
     end
+    if (bsz & 4) != 0
+      # force correct unaligned read
+      t4 = uninitialized UInt32
+      pointerof(t4).as(UInt8*).copy_from(u, 4)
+      v |= t4 << 24
+      u += 4
+    end
+    if (r = bsz & 3) != 0
+      v |= u[0].to_u64 | (u[r/2].to_u64 << 8) | (u[r - 1].to_u64 << 16)
+    end
+    permute(v)
     self
   end
 

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -533,6 +533,15 @@ struct Slice(T)
     nil
   end
 
+  # See `Object#hash(hasher)`
+  def hash(hasher)
+    {% if T == UInt8 %}
+      hasher.bytes(self)
+    {% else %}
+      super hasher
+    {% end %}
+  end
+
   protected def check_writable
     raise "Can't write to read-only Slice" if @read_only
   end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -534,8 +534,6 @@ struct Slice(T)
   end
 
   # See `Object#hash(hasher)`
-  # Be awary: `Slice(UInt8)` is hashed as binary data, and not as "an array of small
-  # numbers".
   def hash(hasher)
     {% if T == UInt8 %}
       hasher.bytes(self)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -534,6 +534,8 @@ struct Slice(T)
   end
 
   # See `Object#hash(hasher)`
+  # Be awary: `Slice(UInt8)` is hashed as binary data, and not as "an array of small
+  # numbers".
   def hash(hasher)
     {% if T == UInt8 %}
       hasher.bytes(self)

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -176,7 +176,7 @@ class StringPool
 
   private def hash(str, len)
     hasher = Crystal::Hasher.new
-    hasher = str.to_slice(len).hash(hasher)
+    hasher = hasher.string(str.to_slice(len))
     # hash should be non-zero, so `or` it with high bit
     hasher.result | 0x8000000000000000_u64
   end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -176,7 +176,7 @@ class StringPool
 
   private def hash(str, len)
     hasher = Crystal::Hasher.new
-    hasher = hasher.bytes(str.to_slice(len))
+    hasher = str.to_slice(len).hash(hasher)
     # hash should be non-zero, so `or` it with high bit
     hasher.result | 0x8000000000000000_u64
   end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -176,7 +176,7 @@ class StringPool
 
   private def hash(str, len)
     hasher = Crystal::Hasher.new
-    hasher = hasher.string(str.to_slice(len))
+    hasher = hasher.bytes(str.to_slice(len))
     # hash should be non-zero, so `or` it with high bit
     hasher.result | 0x8000000000000000_u64
   end


### PR DESCRIPTION
This is multiplicative function resilent to HashDos attack.
(Claim is bounded with restrictions that neither seed nor hash-value is exposed to attacker).

It provides good performance, and at least certainly not slower than current unsafe hasher's hash function.

This PR is alternative to #5104 
(though I don't claim this function is alternative to SipHash in all possible SipHash's applications).