### PR TITLE
Compiler: don't type generic type instance var initialization on non-instantiated generics

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4801,4 +4801,21 @@ describe "Semantic: instance var" do
       Foo.new.@foo
     )) { generic_class "Gen", union_of(int32, types["A"]) }
   end
+
+  it "uses T.new (#4291)" do
+    assert_type(%(
+      class Foo
+      end
+
+      class Gen(T)
+        @x = T.new
+
+        def x
+          @x
+        end
+      end
+
+      Gen(Foo).new.x
+      )) { types["Foo"] }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -908,13 +908,15 @@ module Crystal
 
       # No meta vars means this initializer came from a generic type,
       # so we must type it now that we are defining it in a concrete type
-      unless meta_vars
+      if !meta_vars && !self.is_a?(GenericType)
         meta_vars = MetaVars.new
         visitor = MainVisitor.new(program, vars: meta_vars, meta_vars: meta_vars)
         visitor.scope = self
         value = value.clone
         value.accept visitor
       end
+
+      meta_vars ||= MetaVars.new
 
       unless self.is_a?(GenericType)
         instance_var = lookup_instance_var(name)


### PR DESCRIPTION
Fixes #4291