### PR TITLE
AST: fix incorrect `to_s` for ImplicitObj

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -108,4 +108,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(1 <= 2 <= 3)
   expect_to_s %((1 <= 2) <= 3)
   expect_to_s %(1 <= (2 <= 3))
+  expect_to_s %(case 1; when .foo?; 2; end), %(case 1\nwhen .foo?\n  2\nend)
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -432,7 +432,8 @@ module Crystal
           end
         end
       when Var, NilLiteral, BoolLiteral, CharLiteral, NumberLiteral, StringLiteral,
-           StringInterpolation, Path, Generic, InstanceVar, ClassVar, Global
+           StringInterpolation, Path, Generic, InstanceVar, ClassVar, Global,
+           ImplicitObj
         false
       when ArrayLiteral
         !!obj.of


### PR DESCRIPTION
Fixes #4289