### PR TITLE
Semantic: before setting a number as free variable, check if exists with a different value

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -415,4 +415,16 @@ describe "Restrictions" do
       ),
       "undefined constant T"
   end
+
+  it "sets number as free variable (#2699)" do
+    assert_error %(
+      def foo(x : T[N], y : T[N]) forall T, N
+      end
+
+      x = uninitialized UInt8[10]
+      y = uninitialized UInt8[11]
+      foo(x, y)
+      ),
+      "no overload matches"
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -641,7 +641,16 @@ module Crystal
           end
         when Path
           if other_type_var.names.size == 1
-            context.set_free_var(other_type_var.names.first, type_var)
+            name = other_type_var.names.first
+
+            # If the free variable is already set to another
+            # number, there's no match
+            existing = context.get_free_var(name)
+            if existing && existing != type_var
+              return nil
+            end
+
+            context.set_free_var(name, type_var)
             return type_var
           end
         end


### PR DESCRIPTION
Fixes #2699