### PR TITLE
Implemented #sorted_insert for Array using binary search.

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -697,6 +697,44 @@ describe "Array" do
     end
   end
 
+  describe "sorted_insert" do
+    it "inserts value sorted relative to values inside" do
+      a = [1, 3, 4]
+      expected = [1, 2, 3, 4]
+      a.sorted_insert(2).should eq(expected)
+      a.should eq(expected)
+    end
+
+    it "inserts smallest value at head" do
+      a = [1, 3, 4]
+      expected = [0, 1, 3, 4]
+      a.sorted_insert(0).should eq(expected)
+      a.should eq(expected)
+    end
+
+    it "inserts largest value at tail" do
+      a = [1, 3, 4]
+      expected = [1, 3, 4, 5]
+      a.sorted_insert(5).should eq(expected)
+      a.should eq(expected)
+    end
+
+    it "inserts object according to provided block" do
+      a = ["a", "aaa", "aaaa"]
+      expected = ["a", "aa", "aaa", "aaaa"]
+      val = "aa"
+      a.sorted_insert(val) { |x| x.size >= val.size }.should eq(expected)
+      a.should eq(expected)
+    end
+
+    it "inserts values sorted into an empty array" do
+      a = [] of Int32
+      expected = [0, 1, 2, 3, 6, 9]
+      expected.shuffle.each { |x| a.sorted_insert x }
+      a.should eq(expected)
+    end
+  end
+
   describe "inspect" do
     it { [1, 2, 3].inspect.should eq("[1, 2, 3]") }
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -845,6 +845,44 @@ class Array(T)
     self
   end
 
+  # Insert *object* before the first element where the passed block returns true.
+  # Returns `self`.
+  #
+  # Array must be sorted or empty prior to invoking this method.
+  #
+  # ```
+  # var = "aa"
+  # a = ["a", "aaa", "aaaa"]
+  # a.sorted_insert(var) { |x| x.size >= var.size } # => ["a", "aa", "aaa", "aaaa"]
+  # ```
+  #
+  # See also: `Indexable#bsearch_index`.
+  def sorted_insert(object : T)
+    index = bsearch_index { |x, i| yield x, i }
+    if index
+      insert index, object
+    else
+      push object
+    end
+  end
+
+  # Insert *object* to preserve ordering.
+  # Returns `self`.
+  #
+  # Array must be sorted or empty prior to invoking this method.
+  #
+  # ```
+  # a = [1, 3, 4]
+  # a.sorted_insert(2) # => [1, 2, 3, 4]
+  # a.sorted_insert(0) # => [0, 1, 2, 3, 4]
+  # a.sorted_insert(5) # => [0, 1, 2, 3, 4, 5]
+  # ```
+  #
+  # See also: `Indexable#bsearch_index`.
+  def sorted_insert(object : T)
+    sorted_insert(object) { |x| x >= object }
+  end
+
   # :nodoc:
   def inspect(io : IO)
     to_s io


### PR DESCRIPTION
I noticed there's no nice sorted_insert method for Array so I decided to make one. It's fairly simple and it uses the bsearch_index method to find where to put the provided object. 

This is my first pull request so let me know if I missed anything or if you want me to add something more to the feature.