### PR TITLE
Detect recursive structs through tuples, named tuples and recursive aliases

### DIFF
--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -10,7 +10,7 @@ describe "Semantic: recursive struct check" do
 
       Test.new(Test.new(nil))
       ),
-      "recursive struct Test detected: `@test : (Test | Nil)`"
+      "recursive struct Test detected:\n\n  `@test : (Test | Nil)`"
   end
 
   it "errors on recursive struct inside module" do
@@ -22,7 +22,7 @@ describe "Semantic: recursive struct check" do
 
       Foo::Test.new(Foo::Test.new(nil))
       ),
-      "recursive struct Foo::Test detected: `@test : (Foo::Test | Nil)`"
+      "recursive struct Foo::Test detected:\n\n  `@test : (Foo::Test | Nil)`"
   end
 
   it "errors on recursive generic struct inside module" do
@@ -34,7 +34,7 @@ describe "Semantic: recursive struct check" do
 
       Foo::Test(Int32).new(Foo::Test(Int32).new(nil))
       ),
-      "recursive struct Foo::Test(T) detected: `@test : (Foo::Test(T) | Nil)`"
+      "recursive struct Foo::Test(T) detected:\n\n  `@test : (Foo::Test(T) | Nil)`"
   end
 
   it "errors on mutually recursive struct" do
@@ -52,7 +52,7 @@ describe "Semantic: recursive struct check" do
       Foo.new(Bar.new(nil))
       Bar.new(Foo.new(nil))
       ),
-      "recursive struct Foo detected: `@bar : (Bar | Nil)` -> `@foo : (Foo | Nil)`"
+      "recursive struct Foo detected:\n\n  `@bar : (Bar | Nil)` -> `(Bar | Nil)` -> `Bar` -> `@foo : (Foo | Nil)`"
   end
 
   it "detects recursive struct through module" do
@@ -67,7 +67,7 @@ describe "Semantic: recursive struct check" do
         end
       end
       ),
-      "recursive struct Foo detected: `@moo : Moo` -> `Moo` -> `Foo`"
+      "recursive struct Foo detected:\n\n  `@moo : Moo` -> `Moo` -> `Foo`"
   end
 
   it "detects recursive generic struct through module (#4720)" do
@@ -81,7 +81,7 @@ describe "Semantic: recursive struct check" do
         end
       end
       ),
-      "recursive struct Foo(T) detected: `@base : (Bar | Nil)` -> `Bar` -> `Foo(T)`"
+      "recursive struct Foo(T) detected:\n\n  `@base : (Bar | Nil)` -> `(Bar | Nil)` -> `Bar` -> `Foo(T)`"
   end
 
   it "detects recursive generic struct through generic module (#4720)" do
@@ -95,7 +95,7 @@ describe "Semantic: recursive struct check" do
         end
       end
       ),
-      "recursive struct Foo(T) detected: `@base : (Bar(T) | Nil)` -> `Bar(T)` -> `Foo(T)`"
+      "recursive struct Foo(T) detected:\n\n  `@base : (Bar(T) | Nil)` -> `(Bar(T) | Nil)` -> `Bar(T)` -> `Foo(T)`"
   end
 
   it "detects recursive struct through inheritance (#3071)" do
@@ -107,7 +107,7 @@ describe "Semantic: recursive struct check" do
         @value = uninitialized Foo
       end
       ),
-      "recursive struct Bar detected: `@value : Foo` -> `Foo` -> `Bar`"
+      "recursive struct Bar detected:\n\n  `@value : Foo` -> `Foo` -> `Bar`"
   end
 
   it "errors on recursive struct through tuple" do
@@ -119,7 +119,7 @@ describe "Semantic: recursive struct check" do
         end
       end
       ),
-      "recursive struct Foo detected: `@x : Tuple(Foo)`"
+      "recursive struct Foo detected:\n\n  `@x : Tuple(Foo)`"
   end
 
   it "errors on recursive struct through named tuple" do
@@ -131,6 +131,18 @@ describe "Semantic: recursive struct check" do
         end
       end
       ),
-      "recursive struct Foo detected: `@x : NamedTuple(x: Foo)`"
+      "recursive struct Foo detected:\n\n  `@x : NamedTuple(x: Foo)`"
+  end
+
+  it "errors on recursive struct through recursive alias (#4454) (#4455)" do
+    assert_error %(
+      struct Bar(T)
+        def initialize(@x : T)
+        end
+      end
+
+      alias Foo = Int32 | Bar(Foo)
+      ),
+      "recursive struct Foo detected (recursive aliases are structs):\n\n  `(Bar(Foo) | Int32)` -> `Bar(Foo)` -> `@x : Foo`"
   end
 end

--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -121,4 +121,16 @@ describe "Semantic: recursive struct check" do
       ),
       "recursive struct Foo detected: `@x : Tuple(Foo)`"
   end
+
+  it "errors on recursive struct through named tuple" do
+    assert_error %(
+      struct Foo
+        @x : {x: Foo}
+
+        def initialize(@x)
+        end
+      end
+      ),
+      "recursive struct Foo detected: `@x : NamedTuple(x: Foo)`"
+  end
 end

--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -1,0 +1,112 @@
+require "../../spec_helper"
+
+describe "Semantic: recursive struct check" do
+  it "errors on recursive struct" do
+    assert_error %(
+      struct Test
+        def initialize(@test : Test?)
+        end
+      end
+
+      Test.new(Test.new(nil))
+      ),
+      "recursive struct Test detected: `@test : (Test | Nil)`"
+  end
+
+  it "errors on recursive struct inside module" do
+    assert_error %(
+      struct Foo::Test
+        def initialize(@test : Foo::Test?)
+        end
+      end
+
+      Foo::Test.new(Foo::Test.new(nil))
+      ),
+      "recursive struct Foo::Test detected: `@test : (Foo::Test | Nil)`"
+  end
+
+  it "errors on recursive generic struct inside module" do
+    assert_error %(
+      struct Foo::Test(T)
+        def initialize(@test : Foo::Test(T)?)
+        end
+      end
+
+      Foo::Test(Int32).new(Foo::Test(Int32).new(nil))
+      ),
+      "recursive struct Foo::Test(T) detected: `@test : (Foo::Test(T) | Nil)`"
+  end
+
+  it "errors on mutually recursive struct" do
+    assert_error %(
+      struct Foo
+        def initialize(@bar : Bar?)
+        end
+      end
+
+      struct Bar
+        def initialize(@foo : Foo?)
+        end
+      end
+
+      Foo.new(Bar.new(nil))
+      Bar.new(Foo.new(nil))
+      ),
+      "recursive struct Foo detected: `@bar : (Bar | Nil)` -> `@foo : (Foo | Nil)`"
+  end
+
+  it "detects recursive struct through module" do
+    assert_error %(
+      module Moo
+      end
+
+      struct Foo
+        include Moo
+
+        def initialize(@moo : Moo)
+        end
+      end
+      ),
+      "recursive struct Foo detected: `@moo : Moo` -> `Moo` -> `Foo`"
+  end
+
+  it "detects recursive generic struct through module (#4720)" do
+    assert_error %(
+      module Bar
+      end
+
+      struct Foo(T)
+        include Bar
+        def initialize(@base : Bar?)
+        end
+      end
+      ),
+      "recursive struct Foo(T) detected: `@base : (Bar | Nil)` -> `Bar` -> `Foo(T)`"
+  end
+
+  it "detects recursive generic struct through generic module (#4720)" do
+    assert_error %(
+      module Bar(T)
+      end
+
+      struct Foo(T)
+        include Bar(T)
+        def initialize(@base : Bar(T)?)
+        end
+      end
+      ),
+      "recursive struct Foo(T) detected: `@base : (Bar(T) | Nil)` -> `Bar(T)` -> `Foo(T)`"
+  end
+
+  it "detects recursive struct through inheritance (#3071)" do
+    assert_error %(
+      abstract struct Foo
+      end
+
+      struct Bar < Foo
+        @value = uninitialized Foo
+      end
+      ),
+      "recursive struct Bar detected: `@value : Foo` -> `Foo` -> `Bar`"
+  end
+end

--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -109,4 +109,16 @@ describe "Semantic: recursive struct check" do
       ),
       "recursive struct Bar detected: `@value : Foo` -> `Foo` -> `Bar`"
   end
+
+  it "errors on recursive struct through tuple" do
+    assert_error %(
+      struct Foo
+        @x : {Foo}
+
+        def initialize(@x)
+        end
+      end
+      ),
+      "recursive struct Foo detected: `@x : Tuple(Foo)`"
+  end
 end

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -97,60 +97,6 @@ describe "Semantic: struct" do
       ", "Foo is not a class, it's a struct"
   end
 
-  it "errors on recursive struct" do
-    assert_error %(
-      struct Test
-        def initialize(@test : Test?)
-        end
-      end
-
-      Test.new(Test.new(nil))
-      ),
-      "recursive struct Test detected: `@test : (Test | Nil)`"
-  end
-
-  it "errors on recursive struct inside module" do
-    assert_error %(
-      struct Foo::Test
-        def initialize(@test : Foo::Test?)
-        end
-      end
-
-      Foo::Test.new(Foo::Test.new(nil))
-      ),
-      "recursive struct Foo::Test detected: `@test : (Foo::Test | Nil)`"
-  end
-
-  it "errors on recursive generic struct inside module" do
-    assert_error %(
-      struct Foo::Test(T)
-        def initialize(@test : Foo::Test(T)?)
-        end
-      end
-
-      Foo::Test(Int32).new(Foo::Test(Int32).new(nil))
-      ),
-      "recursive struct Foo::Test(T) detected: `@test : (Foo::Test(T) | Nil)`"
-  end
-
-  it "errors on mutually recursive struct" do
-    assert_error %(
-      struct Foo
-        def initialize(@bar : Bar?)
-        end
-      end
-
-      struct Bar
-        def initialize(@foo : Foo?)
-        end
-      end
-
-      Foo.new(Bar.new(nil))
-      Bar.new(Foo.new(nil))
-      ),
-      "recursive struct Foo detected: `@bar : (Bar | Nil)` -> `@foo : (Foo | Nil)`"
-  end
-
   it "can't extend struct from non-abstract struct" do
     assert_error %(
       struct Foo
@@ -213,61 +159,6 @@ describe "Semantic: struct" do
 
       Bar.new.as(Foo)
       )) { types["Foo"].virtual_type! }
-  end
-
-  it "detects recursive struct through module" do
-    assert_error %(
-      module Moo
-      end
-
-      struct Foo
-        include Moo
-
-        def initialize(@moo : Moo)
-        end
-      end
-      ),
-      "recursive struct Foo detected: `@moo : Moo` -> `Moo` -> `Foo`"
-  end
-
-  it "detects recursive generic struct through module (#4720)" do
-    assert_error %(
-      module Bar
-      end
-
-      struct Foo(T)
-        include Bar
-        def initialize(@base : Bar?)
-        end
-      end
-      ),
-      "recursive struct Foo(T) detected: `@base : (Bar | Nil)` -> `Bar` -> `Foo(T)`"
-  end
-
-  it "detects recursive generic struct through generic module (#4720)" do
-    assert_error %(
-      module Bar(T)
-      end
-
-      struct Foo(T)
-        include Bar(T)
-        def initialize(@base : Bar(T)?)
-        end
-      end
-      ),
-      "recursive struct Foo(T) detected: `@base : (Bar(T) | Nil)` -> `Bar(T)` -> `Foo(T)`"
-  end
-
-  it "detects recursive struct through inheritance (#3071)" do
-    assert_error %(
-      abstract struct Foo
-      end
-
-      struct Bar < Foo
-        @value = uninitialized Foo
-      end
-      ),
-      "recursive struct Bar detected: `@value : Foo` -> `Foo` -> `Bar`"
   end
 
   it "errors if defining finalize for struct (#3840)" do

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -113,6 +113,12 @@ class Crystal::RecursiveStructChecker
         check_recursive(target, union_type, checked, path)
       end
     end
+
+    if type.is_a?(TupleInstanceType)
+      type.tuple_types.each do |tuple_type|
+        check_recursive(target, tuple_type, checked, path)
+      end
+    end
   end
 
   def check_recursive_instance_var_container(target, type, checked, path)

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -41,6 +41,13 @@ class Crystal::RecursiveStructChecker
       check_recursive_instance_var_container(target, type, checked, path)
     end
 
+    if type.is_a?(AliasType) && !type.simple?
+      target = type
+      checked = Set(Type).new
+      path = [] of Var | Type
+      check_recursive(target, type.aliased_type, checked, path)
+    end
+
     check_types(type)
     check_generic_instances(type)
   end
@@ -55,8 +62,14 @@ class Crystal::RecursiveStructChecker
 
   def check_recursive(target, type, checked, path)
     if target == type
+      if target.is_a?(AliasType)
+        alias_message = " (recursive aliases are structs)"
+      end
+
       msg = <<-MSG
-        recursive struct #{target} detected: #{path_to_s(path)}
+        recursive struct #{target} detected#{alias_message}:
+
+          #{path_to_s(path)}
 
         The struct #{target} has, either directly or indirectly,
         an instance variable whose type is, eventually, this same
@@ -81,25 +94,25 @@ class Crystal::RecursiveStructChecker
 
     if type.is_a?(VirtualType)
       if type.struct?
-        path.push type
-        type.subtypes.each do |subtype|
-          path.push subtype
-          check_recursive(target, subtype, checked, path)
-          path.pop
+        push(path, type) do
+          type.subtypes.each do |subtype|
+            push(path, subtype) do
+              check_recursive(target, subtype, checked, path)
+            end
+          end
         end
-        path.pop
       end
     end
 
     if type.is_a?(NonGenericModuleType) || type.is_a?(GenericModuleInstanceType)
-      path.push type
-      # Check if the module is composed, recursively, of the target struct
-      type.raw_including_types.try &.each do |module_type|
-        path.push module_type
-        check_recursive(target, module_type, checked, path)
-        path.pop
+      push(path, type) do
+        # Check if the module is composed, recursively, of the target struct
+        type.raw_including_types.try &.each do |module_type|
+          push(path, module_type) do
+            check_recursive(target, module_type, checked, path)
+          end
+        end
       end
-      path.pop
     end
 
     if type.is_a?(InstanceVarContainer)
@@ -109,20 +122,32 @@ class Crystal::RecursiveStructChecker
     end
 
     if type.is_a?(UnionType)
-      type.union_types.each do |union_type|
-        check_recursive(target, union_type, checked, path)
+      push(path, type) do
+        type.union_types.each do |union_type|
+          push(path, union_type) do
+            check_recursive(target, union_type, checked, path)
+          end
+        end
       end
     end
 
     if type.is_a?(TupleInstanceType)
-      type.tuple_types.each do |tuple_type|
-        check_recursive(target, tuple_type, checked, path)
+      push(path, type) do
+        type.tuple_types.each do |tuple_type|
+          push(path, tuple_type) do
+            check_recursive(target, tuple_type, checked, path)
+          end
+        end
       end
     end
 
     if type.is_a?(NamedTupleInstanceType)
-      type.entries.each do |entry|
-        check_recursive(target, entry.type, checked, path)
+      push(path, type) do
+        type.entries.each do |entry|
+          push(path, entry.type) do
+            check_recursive(target, entry.type, checked, path)
+          end
+        end
       end
     end
   end
@@ -133,9 +158,9 @@ class Crystal::RecursiveStructChecker
       var_type = var.type?
       next unless var_type
 
-      path.push var
-      check_recursive(target, var_type, checked, path)
-      path.pop
+      push(path, var) do
+        check_recursive(target, var_type, checked, path)
+      end
     end
     checked.delete type
   end
@@ -153,5 +178,15 @@ class Crystal::RecursiveStructChecker
 
   def struct?(type)
     type.struct? && type.is_a?(InstanceVarContainer) && !type.is_a?(PrimitiveType) && !type.is_a?(ProcInstanceType) && !type.abstract?
+  end
+
+  def push(path, type)
+    if path.last? == type
+      yield
+    else
+      path.push type
+      yield
+      path.pop
+    end
   end
 end

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -119,6 +119,12 @@ class Crystal::RecursiveStructChecker
         check_recursive(target, tuple_type, checked, path)
       end
     end
+
+    if type.is_a?(NamedTupleInstanceType)
+      type.entries.each do |entry|
+        check_recursive(target, entry.type, checked, path)
+      end
+    end
   end
 
   def check_recursive_instance_var_container(target, type, checked, path)


### PR DESCRIPTION
Fixes #4454
Fixes #4455

This compiles right now but shouldn't:

```crystal
struct Foo
  @x : Tuple(Foo, Foo)

  def initialize(@x)
  end
end
```

Since a tuple is like a struct, the representation of `Foo` would expand infinitely. A check was missing regarding tuples and named tuples (first two commits).

Likewise, this compiles but shouldn't:

```crystal
struct Bar(T)
  def initialize(@x : T)
  end
end

alias Foo = Int32 | Bar(Foo)
```

The problem is that the representation of `Bar` in memory is that of Foo, which is recursive, and since recursive aliases are represented as structs this leads to undefined behavior (random crashes).

Now, while fixing this I realized [recursive aliases are not needed in the language](https://github.com/crystal-lang/crystal/issues/5155) but until (and if) we remove recursive aliases this fixes those bugs, and also fixes potential bugs regarding tuples.
