### PR TITLE
Fix to complete filename for `crystal tool` subcommands

### DIFF
--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -185,6 +185,7 @@ _crystal-tool() {
       case $line[1] in
         (context)
           _arguments \
+            $programfile \
             $help_args \
             $no_color_args \
             $exec_args \
@@ -195,6 +196,7 @@ _crystal-tool() {
 
         (expand)
           _arguments \
+            $programfile \
             $help_args \
             $no_color_args \
             $exec_args \
@@ -205,14 +207,16 @@ _crystal-tool() {
 
         (format)
           _arguments \
-              $help_args \
-              $no_color_args \
-              $format_args \
-              '(--check)--check[checks that formatting code produces no changes]'
+            $programfile \
+            $help_args \
+            $no_color_args \
+            $format_args \
+            '(--check)--check[checks that formatting code produces no changes]' \
         ;;
 
         (hierarchy)
           _arguments \
+            $programfile \
             $help_args \
             $no_color_args \
             $exec_args \
@@ -223,6 +227,7 @@ _crystal-tool() {
 
         (implementations)
           _arguments \
+            $programfile \
             $help_args \
             $no_color_args \
             $exec_args \
@@ -233,6 +238,7 @@ _crystal-tool() {
 
         (types)
           _arguments \
+            $programfile \
             $help_args \
             $no_color_args \
             $exec_args \

--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -147,6 +147,7 @@ _crystal-run() {
 
 _crystal-spec() {
   _arguments \
+    $programfile \
     $help_args \
     $no_color_args \
     $exec_args \


### PR DESCRIPTION
In `completion.zsh`, $programfile was missing for `crystal tool` subcommands, so we cannot complete filename for `crystal tool` subcommands. This PR fixes it.