### PR TITLE
Prevent invoking `method_added` macro hook recursively

### DIFF
--- a/spec/compiler/semantic/hooks_spec.cr
+++ b/spec/compiler/semantic/hooks_spec.cr
@@ -70,6 +70,24 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
+  it "does not invoke 'method_added' hook recusively" do
+    assert_type("
+      class Foo
+        macro method_added(d)
+          def {{d.name.id}}
+            1
+          end
+        end
+
+        def foo
+          nil
+        end
+      end
+
+      Foo.new.foo
+      ") { int32 }
+  end
+
   it "errors if wrong inherited args size" do
     assert_error %(
       class Foo

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -42,6 +42,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   record FinishedHook, scope : ModuleType, macro : Macro
   @finished_hooks = [] of FinishedHook
 
+  @method_added_running = false
+
   @last_doc : String?
 
   def visit(node : ClassDef)
@@ -343,7 +345,11 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         new_expansions << {original: node, expanded: new_method}
       end
 
-      run_hooks target_type.metaclass, target_type, :method_added, node, Call.new(nil, "method_added", [node] of ASTNode).at(node.location)
+      unless @method_added_running
+        @method_added_running = true
+        run_hooks target_type.metaclass, target_type, :method_added, node, Call.new(nil, "method_added", [node] of ASTNode).at(node.location)
+        @method_added_running = false
+      end
     end
 
     false


### PR DESCRIPTION
Fixed #5066 

Now this program can work correctly:

```crystal
module Tracer
  macro included
    macro method_added(def_node)
      def \{{def_node.name}}(\{{def_node.args.splat}})
        puts "Entering method \{{def_node.name}}"

        previous_def

        puts "Leaving method \{{def_node.name}}"
      end
    end
  end
end

class MyClass
  include Tracer

  def foo
    puts "Hello from foo"
  end
end


MyClass.new.foo
# =>Entering method foo
# => Hello from foo
# => Leaving method foo
```