### PR TITLE
Added .DS_Store into template/gitignore.ecr

### DIFF
--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,3 +1,4 @@
+.DS_Store
 /doc/
 /lib/
 /bin/


### PR DESCRIPTION
Could you add .DS_Store into .gitignore for Mac users including me?

Like as crystal itself
https://github.com/crystal-lang/crystal/blob/3d48a9628d57cea739f30583fa6092aa9dd90be3/.gitignore#L1

Thanks!