### PR TITLE
Honor no-color option from `spec` command

### DIFF
--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -60,6 +60,10 @@ class Crystal::Command
       end
     end
 
+    unless @color
+      options << "--no-color"
+    end
+
     source_filename = File.expand_path("spec")
 
     source = target_filenames.map { |filename| %(require "./#{filename}") }.join("\n")


### PR DESCRIPTION
Prior this change, `crystal spec` only recognized `--no-color` when provided as child command additional arguments.

This worked:

```shell
$ crystal spec -- --no-color
```

However, this didn't:

```shell
$ crystal spec --no-color
```

This change ensures that option specified to `spec` command is passed to child process.

Thank you.
❤️ ❤️ ❤️ 

Fixes #1587
Ref #4292