### PR TITLE
Fix bug when Hash only has one nil value

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -440,7 +440,7 @@ describe "Hash" do
     h1 = {:a => 1, :b => 2, :c => nil}
 
     h2 = h1.compact
-    h2.should be_a(Hash(Symbol, Int32))
+    h2.should be_a(Hash(Symbol, Int32 | Nil))
     h2.should eq({:a => 1, :b => 2})
   end
 
@@ -449,6 +449,22 @@ describe "Hash" do
 
     h2 = h1.compact!
     h2.should eq({:a => 1, :b => 2})
+    h2.should be(h1)
+  end
+
+  it "compacts when nil" do
+    h1 = {:c => nil}
+
+    h2 = h1.compact
+    h2.should be_a(Hash(Symbol, Nil))
+    h2.should eq({} of Symbol => Int32)
+  end
+
+  it "compacts! when nil" do
+    h1 = {:c => nil}
+
+    h2 = h1.compact!
+    h2.should eq({} of Symbol => Nil)
     h2.should be(h1)
   end
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -574,7 +574,7 @@ class Hash(K, V)
   # hash.compact # => {"hello" => "world"}
   # ```
   def compact
-    each_with_object({} of K => typeof(self.first_value.not_nil!)) do |(key, value), memo|
+    each_with_object({} of K => typeof(self.first_value)) do |(key, value), memo|
       memo[key] = value unless value.nil?
     end
   end


### PR DESCRIPTION
When a Hash only has one value and this is nil, compact throws a compile error