### PR TITLE
`run` macro shows stderr when succeeded but there is stderr output

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -218,6 +218,19 @@ module Crystal
 
       result = @program.macro_run(filename, run_args)
       if result.status.success?
+        unless result.stderr.empty?
+          command = "#{original_filename} #{run_args.map(&.inspect).join " "}"
+          @program.stdout.puts "Success executing run: #{command}".colorize.mode(:bold)
+          @program.stdout.puts "stderr:".colorize.mode(:bold)
+          @program.stdout.puts
+          result.stderr.each_line do |line|
+            @program.stdout << "    "
+            @program.stdout << line
+            @program.stdout.puts
+          end
+          @program.stdout.puts
+        end
+
         @last = MacroId.new(result.stdout)
       else
         command = "#{original_filename} #{run_args.map(&.inspect).join " "}"


### PR DESCRIPTION
Currently `run` macro loses stderr output when it is succeeded.

```crystal
# foo.cr
STDERR.puts "foo!"
```

```crystal
# bar.cr
{{ run "./foo.cr" }}
```

So `crystal run bar.cr` says nothing, but I think it is useful for debugging if stderr is showed.