### PR TITLE
Formatter: correctly indent implicit exception handler of do/end block

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -198,6 +198,7 @@ describe Crystal::Formatter do
   assert_format "def foo\n  1\n  #\n\n\nrescue\nend", "def foo\n  1\n  #\n\nrescue\nend"
 
   assert_format "loop do\n  1\nrescue\n  2\nend"
+  assert_format "loop do\n  1\n  loop do\n    2\n  rescue\n    3\n  end\n  4\nend"
 
   assert_format "foo"
   assert_format "foo()"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -62,7 +62,7 @@ module Crystal
     @inside_lib : Int32
     @inside_struct_or_union : Int32
     @dot_column : Int32?
-    @def_indent : Int32
+    @implicit_exception_handler_indent : Int32
     @last_write : String
     @exp_needs_indent : Bool
     @inside_def : Int32
@@ -100,7 +100,7 @@ module Crystal
       @inside_lib = 0
       @inside_struct_or_union = 0
       @dot_column = nil
-      @def_indent = 0
+      @implicit_exception_handler_indent = 0
       @last_write = ""
       @exp_needs_indent = true
       @inside_def = 0
@@ -1317,7 +1317,7 @@ module Crystal
     end
 
     def visit(node : Def)
-      @def_indent = @indent
+      @implicit_exception_handler_indent = @indent
       @inside_def += 1
 
       write_keyword :abstract, " " if node.abstract?
@@ -2500,7 +2500,9 @@ module Crystal
         write " do"
         next_token_skip_space
         body = format_block_args node.args, node
+        old_implicit_exception_handler_indent, @implicit_exception_handler_indent = @implicit_exception_handler_indent, @indent
         format_nested_with_end body
+        @implicit_exception_handler_indent = old_implicit_exception_handler_indent
       elsif @token.type == :"{"
         write "," if needs_comma
         write " {"
@@ -3525,7 +3527,7 @@ module Crystal
         accept node.body
         write_line unless skip_space_or_newline last: true
         implicit_handler = true
-        column = @def_indent
+        column = @implicit_exception_handler_indent
       else
         if node.suffix
           accept node.body


### PR DESCRIPTION
Fixed #5175

Now, `crystal tool format` keeps this code.

```crystal
loop do
  loop do
    1
  rescue
    2
  end
end
```

Thanks for reporting, @straight-shoota!