### PR TITLE
Implement JSON::Any and YAML::Any without recursive aliases

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -86,24 +86,6 @@ describe JSON::Any do
     end
   end
 
-  describe "each" do
-    it "of array" do
-      elems = [] of Int32
-      JSON.parse("[1, 2, 3]").each do |any|
-        elems << any.as_i
-      end
-      elems.should eq([1, 2, 3])
-    end
-
-    it "of hash" do
-      elems = [] of String
-      JSON.parse(%({"foo": "bar"})).each do |key, value|
-        elems << key.to_s << value.to_s
-      end
-      elems.should eq(%w(foo bar))
-    end
-  end
-
   it "traverses big structure" do
     obj = JSON.parse(%({"foo": [1, {"bar": [2, 3]}]}))
     obj["foo"][1]["bar"][1].as_i.should eq(3)
@@ -122,13 +104,5 @@ describe JSON::Any do
   it "exposes $~ when doing Regex#===" do
     (/o+/ === JSON.parse(%("foo"))).should be_truthy
     $~[0].should eq("oo")
-  end
-
-  it "is enumerable" do
-    nums = JSON.parse("[1, 2, 3]")
-    nums.each_with_index do |x, i|
-      x.should be_a(JSON::Any)
-      x.raw.should eq(i + 1)
-    end
   end
 end

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -34,7 +34,7 @@ describe JSON::Parser do
   it_parses "[0]", [0]
   it_parses " [ 0 ] ", [0]
 
-  it_parses "{}", {} of String => JSON::Type
+  it_parses "{}", {} of String => JSON::Any
   it_parses %({"foo": 1}), {"foo" => 1}
   it_parses %({"foo": 1, "bar": 1.5}), {"foo" => 1, "bar" => 1.5}
   it_parses %({"fo\\no": 1}), {"fo\no" => 1}
@@ -75,7 +75,7 @@ describe JSON::Parser do
   end
 
   it "returns raw" do
-    value = JSON.parse_raw("1")
+    value = JSON.parse("1").raw
     value.should eq(1)
     value.should be_a(Int64)
   end

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -46,7 +46,7 @@ class JSON::PullParser
   def assert(array : Array)
     assert_array do
       array.each do |x|
-        assert x
+        assert x.raw
       end
     end
   end
@@ -54,8 +54,8 @@ class JSON::PullParser
   def assert(hash : Hash)
     assert_object do
       hash.each do |key, value|
-        assert(key.as(String)) do
-          assert value
+        assert(key) do
+          assert value.raw
         end
       end
     end

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -128,24 +128,6 @@ describe YAML::Any do
     end
   end
 
-  describe "each" do
-    it "of array" do
-      elems = [] of String
-      YAML.parse("- foo\n- bar\n").each do |any|
-        elems << any.as_s
-      end
-      elems.should eq(%w(foo bar))
-    end
-
-    it "of hash" do
-      elems = [] of String
-      YAML.parse("foo: bar").each do |key, value|
-        elems << key.to_s << value.to_s
-      end
-      elems.should eq(%w(foo bar))
-    end
-  end
-
   it "traverses big structure" do
     obj = YAML.parse("--- \nfoo: \n  bar: \n    baz: \n      - qux\n      - fox")
     obj["foo"]["bar"]["baz"][1].as_s.should eq("fox")
@@ -174,7 +156,7 @@ describe YAML::Any do
 
   it "is enumerable" do
     nums = YAML.parse("[1, 2, 3]")
-    nums.each_with_index do |x, i|
+    nums.as_a.each_with_index do |x, i|
       x.should be_a(YAML::Any)
       x.raw.should eq(i + 1)
     end

--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -31,7 +31,7 @@ private def it_parses_scalar_from_pull(string, expected, file = __FILE__, line =
   end
 end
 
-private def it_parses_scalar_from_pull(string, file = __FILE__, line = __LINE__, &block : YAML::Type ->)
+private def it_parses_scalar_from_pull(string, file = __FILE__, line = __LINE__, &block : YAML::Any::Type ->)
   it "parses #{string.inspect}", file, line do
     pull = YAML::PullParser.new(%(value: #{string}))
     pull.read_stream_start
@@ -39,7 +39,7 @@ private def it_parses_scalar_from_pull(string, file = __FILE__, line = __LINE__,
     pull.read_mapping_start
     pull.read_scalar # key
 
-    block.call(YAML::Schema::Core.parse_scalar(pull).as(YAML::Type))
+    block.call(YAML::Schema::Core.parse_scalar(pull).as(YAML::Any::Type))
   end
 end
 

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -7,12 +7,12 @@ describe "YAML" do
     it { YAML.parse("- foo\n- bar").should eq(["foo", "bar"]) }
     it { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
     it { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
-    it { YAML.parse("--- []\n").should eq([] of YAML::Type) }
+    it { YAML.parse("--- []\n").should eq([] of YAML::Any) }
     it { YAML.parse("---\n...").should eq nil }
 
     it "parses recursive sequence" do
       doc = YAML.parse("--- &foo\n- *foo\n")
-      doc[0].raw.as(Array).should be(doc.raw.as(Array))
+      doc[0].as_a.should be(doc.raw.as(Array))
     end
 
     it "parses recursive mapping" do
@@ -20,13 +20,13 @@ describe "YAML" do
         friends:
         - *1
         ))
-      doc["friends"][0].raw.as(Hash).should be(doc.raw.as(Hash))
+      doc["friends"][0].as_h.should be(doc.as_h)
     end
 
     it "parses alias to scalar" do
       doc = YAML.parse("---\n- &x foo\n- *x\n")
       doc.should eq(["foo", "foo"])
-      doc[0].raw.as(String).should be(doc[1].raw.as(String))
+      doc[0].as_s.should be(doc[1].as_s)
     end
 
     describe "merging with << key" do

--- a/src/json.cr
+++ b/src/json.cr
@@ -75,16 +75,8 @@ module JSON
     end
   end
 
-  # All valid JSON types.
-  alias Type = Nil | Bool | Int64 | Float64 | String | Array(Type) | Hash(String, Type)
-
   # Parses a JSON document as a `JSON::Any`.
   def self.parse(input : String | IO) : Any
-    Any.new parse_raw(input)
-  end
-
-  # Parses a JSON document as a `JSON::Type`.
-  def self.parse_raw(input : String | IO) : Type
     Parser.new(input).parse
   end
 end

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -9,7 +9,7 @@ class JSON::Parser
     next_token
   end
 
-  def parse : Type
+  def parse : Any
     json = parse_value
     check :EOF
     json
@@ -41,7 +41,7 @@ class JSON::Parser
   private def parse_array
     next_token
 
-    ary = [] of Type
+    ary = [] of Any
 
     nest do
       if token.type != :"]"
@@ -63,13 +63,13 @@ class JSON::Parser
 
     next_token
 
-    ary
+    Any.new(ary)
   end
 
   private def parse_object
     next_token_expect_object_key
 
-    object = {} of String => Type
+    object = {} of String => Any
 
     nest do
       if token.type != :"}"
@@ -101,7 +101,7 @@ class JSON::Parser
 
     next_token
 
-    object
+    Any.new(object)
   end
 
   private delegate token, to: @lexer
@@ -110,7 +110,7 @@ class JSON::Parser
 
   private def value_and_next_token(value)
     next_token
-    value
+    Any.new(value)
   end
 
   private def check(token_type)

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -83,9 +83,6 @@ module YAML
     end
   end
 
-  # All valid YAML core schema types.
-  alias Type = Nil | Bool | Int64 | Float64 | String | Time | Bytes | Array(Type) | Hash(Type, Type) | Set(Type)
-
   # Deserializes a YAML document according to the core schema.
   #
   # ```yaml

--- a/src/yaml/nodes/parser.cr
+++ b/src/yaml/nodes/parser.cr
@@ -67,4 +67,20 @@ class YAML::Nodes::Parser < YAML::Parser
 
   def process_tag(tag, &block)
   end
+
+  def add_to_documents(documents, document)
+    documents << document
+  end
+
+  def add_to_document(document, node)
+    document << node
+  end
+
+  def add_to_sequence(sequence, node)
+    sequence << node
+  end
+
+  def add_to_mapping(mapping, key, value)
+    mapping[key] = value
+  end
 end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -16,15 +16,15 @@ abstract class YAML::Parser
   abstract def new_scalar
   abstract def put_anchor(anchor, value)
   abstract def get_anchor(anchor)
+  abstract def add_to_documents(documents, document)
+  abstract def add_to_document(document, node)
+  abstract def add_to_sequence(sequence, node)
+  abstract def add_to_mapping(mapping, key, value)
 
   def end_value(value)
   end
 
   def process_tag(tag, &block)
-  end
-
-  protected def cast_value(value)
-    value
   end
 
   protected def cast_document(document)
@@ -41,7 +41,7 @@ abstract class YAML::Parser
       when .stream_end?
         return documents
       when .document_start?
-        documents << cast_value(parse_document)
+        add_to_documents(documents, parse_document)
       else
         unexpected_event
       end
@@ -62,7 +62,7 @@ abstract class YAML::Parser
       unexpected_event
     end
 
-    cast_value(cast_document(document))
+    cast_document(document)
   end
 
   private def parse_document
@@ -73,7 +73,7 @@ abstract class YAML::Parser
 
   private def parse_document(document)
     @pull_parser.read_next
-    document << parse_node
+    add_to_document(document, parse_node)
     end_value(document)
     @pull_parser.read_document_end
   end
@@ -116,7 +116,7 @@ abstract class YAML::Parser
     sequence = anchor new_sequence
 
     parse_sequence(sequence) do
-      sequence << parse_node
+      add_to_sequence(sequence, parse_node)
     end
 
     sequence
@@ -138,7 +138,7 @@ abstract class YAML::Parser
     mapping = anchor new_mapping
 
     parse_mapping(mapping) do
-      mapping[parse_node] = parse_node
+      add_to_mapping(mapping, parse_node, parse_node)
     end
 
     mapping

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -19,7 +19,7 @@ module YAML::Schema::Core
   # parses it according to the core schema, taking the
   # scalar's style and tag into account, then advances
   # the pull parser.
-  def self.parse_scalar(pull_parser : YAML::PullParser) : Type
+  def self.parse_scalar(pull_parser : YAML::PullParser) : Nil | Bool | Int64 | Float64 | String | Time | Bytes
     string = pull_parser.value
 
     # Check for core schema tags
@@ -36,7 +36,7 @@ module YAML::Schema::Core
   end
 
   # Parses a scalar value from the given *node*.
-  def self.parse_scalar(node : YAML::Nodes::Scalar) : Type
+  def self.parse_scalar(node : YAML::Nodes::Scalar) : Nil | Bool | Int64 | Float64 | String | Time | Bytes
     string = node.value
 
     # Check for core schema tags
@@ -60,7 +60,7 @@ module YAML::Schema::Core
   # YAML::Schema::Core.parse_scalar("1.2")   # => 1.2
   # YAML::Schema::Core.parse_scalar("false") # => false
   # ```
-  def self.parse_scalar(string : String) : Type
+  def self.parse_scalar(string : String) : Nil | Bool | Int64 | Float64 | String | Time | Bytes
     if parse_null?(string)
       return nil
     end

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -2,22 +2,19 @@
 # fail-safe schema, as specified in http://www.yaml.org/spec/1.2/spec.html#id2802346,
 # where all scalar values are considered strings.
 module YAML::Schema::FailSafe
-  # All possible types according to the failsafe schema
-  alias Type = String | Hash(Type, Type) | Array(Type) | Nil
-
   # Deserializes a YAML document.
-  def self.parse(data : String | IO) : Type
+  def self.parse(data : String | IO) : Any
     Parser.new data, &.parse
   end
 
   # Deserializes multiple YAML documents.
-  def self.parse_all(data : String | IO) : Type
+  def self.parse_all(data : String | IO) : Any
     Parser.new data, &.parse_all
   end
 
   # :nodoc:
   class Parser < YAML::Parser
-    @anchors = {} of String => Type
+    @anchors = {} of String => Any
 
     def put_anchor(anchor, value)
       @anchors[anchor] = value
@@ -30,27 +27,43 @@ module YAML::Schema::FailSafe
     end
 
     def new_documents
-      [] of Type
+      [] of Any
     end
 
     def new_document
-      [] of Type
+      Any.new([] of Any)
     end
 
     def cast_document(doc)
-      doc.first?
+      doc.first? || Any.new(nil)
     end
 
     def new_sequence
-      [] of Type
+      Any.new([] of Any)
     end
 
     def new_mapping
-      {} of Type => Type
+      Any.new({} of Any => Any)
     end
 
     def new_scalar
-      @pull_parser.value
+      Any.new(@pull_parser.value)
+    end
+
+    def add_to_documents(documents, document)
+      documents << document
+    end
+
+    def add_to_document(document, node)
+      document.as_a << node
+    end
+
+    def add_to_sequence(sequence, node)
+      sequence.as_a << node
+    end
+
+    def add_to_mapping(mapping, key, value)
+      mapping.as_h[key] = value
     end
   end
 end


### PR DESCRIPTION
Related to #5155

(this PR isn't finished, but it's working well)

So, I managed to implement `JSON.parse` and `YAML.parse` without recursive aliases.

`JSON.parse` still returns `JSON::Any`, but this is a struct whose raw value contains all possible types such as `Nil`, `String` or `Array(JSON::Any)`, so an array of these same structs - that's how we achieve recursion without recursive aliases (instead of it being `Array(JSON::Type)`, which doesn't exist anymore).

Some things I noticed when doing this:

1) In YAML a `Hash` (mapping) can have keys of any YAML type, not just strings. With recursive aliases, the key is simply a `YAML::Type`, and because it's a union it can be an `Int64` or a `String`, for example. Without recursive aliases the key is a `YAML::Any`, which isn't a union. So, when you index a `Hash(YAML::Any, YAML::Any)` with a `String`, that won't work out of the box, unless we make comparisons between `String` and `YAML::Any` work both ways, and their `hash` values are the same. This is just a matter of reopening these types and overloading `==`, but it still a bit surprising. In any case, it was a bit surprising before because `YAML::Any==(String)` would work well but `String==(YAML::Any)` wouldn't, so that was necessary even with recursive aliases.

2) The overall API ends up being nicer and more consistent in my opinion.

For example, https://github.com/crystal-lang/crystal/issues/3158 won't exist. For example this works just fine now:

```crystal
require "json"

json = JSON.parse("[{\"key\": \"value\"}]")
array = json.as_a
first = array[0]
hash = first.as_h
value = hash["key"].as_s
p value # => "value"
```

Trying to do the same with the existing code we get:

```crystal
require "json"

json = JSON.parse("[{\"key\": \"value\"}]")
array = json.as_a
first = array[0]
hash = first.as_h # undefined method 'as_h' for Array(JSON::Type)
```

Super inconsistent. At that point we have to do `JSON::Any.new(first).as_h` or `first.as(Hash)`. Why in one place we can use `as_a` and in another place we can use `.as(Hash)`.

So maybe we just get rid of `JSON::Any` and use the recursive definition? We'd have to cast with `as` every time we want to use a value, but at least it would be consistent.

Unfortunately, that will work, but if we want, for example, to include a property in `JSON.mapping` that can be of any JSON type (so basically, just parse it to the recursive type) we can't do it with a recursive alias because **recursive aliases can't have methods**. We need to provide a `new(JSON::PullParser)` method and that's impossible to do. Or introduce a type that has this method (basically `JSON::Any`) but it's just simpler to have one type and not two.

I still think that doing it this way is the best way:
- It's consistent
- Less typing with `as_a`, `as_h`, etc. instead of `.as(Array)`, `.as(Hash)`
- Less redundant features in the language (less work for the core team, less things to learn, less possible bugs, etc.)

I also think that removing recursive aliases will make it much easier to implement generic aliases because we don't have to deal with recursive generic aliases.

In any case, I don't think this will get merged before 0.24.0, and even after I'll have to discuss it with the team at Manas.