### PR TITLE
Avoid misleading error message in HTTP::Params.encode

### DIFF
--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -76,9 +76,12 @@ module HTTP
       end
     end
 
-    # Returns the given key value pairs as a
-    # url-encoded HTTP form/query.
-    def self.encode(hash : Hash(String, _))
+    # Returns the given key value pairs as a url-encoded HTTP form/query.
+    #
+    # ```
+    # HTTP::Params.encode({"foo" => "bar", "baz" => "qux"}) # => foo=bar&baz=qux
+    # ```
+    def self.encode(hash : Hash(String, String))
       build do |builder|
         hash.each do |key, value|
           builder.add key, value
@@ -86,7 +89,11 @@ module HTTP
       end
     end
 
-    # ditto
+    # Returns the given key value pairs as a url-encoded HTTP form/query.
+    #
+    # ```
+    # HTTP::Params.encode({foo: "bar", baz: "qux"}) # => foo=bar&baz=qux
+    # ```
     def self.encode(named_tuple : NamedTuple)
       build do |builder|
         named_tuple.each do |key, value|


### PR DESCRIPTION
Restrict types supported by `HTTP::Params.encode` to avoid long and confusing error messages.

With this change, attempt to use a `Hash` other than `Hash(String, String)` will result in a better error message:

```crystal
require "http/params"

puts HTTP::Params.encode({"foo" => 10})
```

Output:

```
no overload matches 'HTTP::Params.encode' with type Hash(String, Int32)
Overloads are:
 - HTTP::Params.encode(hash : Hash(String, String))
 - HTTP::Params.encode(named_tuple : NamedTuple)
```

Also includes examples on usage.

Fixes #5172

Thank you.
❤️ ❤️ ❤️ 