### PR TITLE
Relocate and document Time::DayOfWeek

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -103,6 +103,29 @@ struct Time
   # :nodoc:
   MAX_SECONDS = 315537897599_i64
 
+  # `DayOfWeek` represents the day.
+  #
+  # ```
+  # time = Time.new(2016, 2, 15)
+  # time.day_of_week # => Monday
+  # ```
+  #
+  # Alternatively, you can use question methods:
+  #
+  # ```
+  # time.friday? # => false
+  # time.monday? # => true
+  # ```
+  enum DayOfWeek
+    Sunday
+    Monday
+    Tuesday
+    Wednesday
+    Thursday
+    Friday
+    Saturday
+  end
+
   # `Kind` represents a specified time zone.
   #
   # Initializing a `Time` instance with specified `Kind`:
@@ -621,10 +644,10 @@ struct Time
     Time.new(year, month, day, 12, 0, 0, nanosecond: 0, kind: kind)
   end
 
-  {% for name, index in %w(Sunday Monday Tuesday Wednesday Thursday Friday Saturday) %}
+  {% for name in DayOfWeek.constants %}
     # Does `self` happen on {{name.id}}?
     def {{name.id.downcase}}? : Bool
-      day_of_week.value == {{index}}
+      day_of_week.{{name.id.downcase}}?
     end
   {% end %}
 

--- a/src/time/day_of_week.cr
+++ b/src/time/day_of_week.cr
@@ -1,9 +1,0 @@
-enum Time::DayOfWeek
-  Sunday
-  Monday
-  Tuesday
-  Wednesday
-  Thursday
-  Friday
-  Saturday
-end


### PR DESCRIPTION
Consolidate `Time::DayOfWeek` definition inside `Time`, adding documentation and examples on its usage.

Refactor day question methods (ie `#monday?`) macro to use Enum's constants and question methods, avoiding duplication of definitions.

This change does not introduce performance penalties by itself, but a synthetic benchmark might present it otherwise:

```
day_of_week.value == index: 626.33M (   1.6ns) (±10.72%)       fastest
     day_of_week.question?: 621.56M (  1.61ns) (±10.35%)  1.01× slower

dow.value == index: 622.68M (  1.61ns) (± 9.82%)  1.00× slower
     dow.question?: 624.23M (   1.6ns) (±10.82%)       fastest
```

Benchmark code:

```crystal
require "benchmark"

time = Time.new(2016, 2, 15)
dow = time.day_of_week

# benchmark against `day_of_week` being computed each time
Benchmark.ips do |results|
  results.report("day_of_week.value == index:") { time.day_of_week.value == 1 }
  results.report("day_of_week.question?:") { time.day_of_week.monday? }
end

# benchmark against cached `day_of_week`
Benchmark.ips do |results|
  results.report("dow.value == index:") { dow.value == 1 }
  results.report("dow.question?:") { dow.monday? }
end
```

---

Apologies for submitting a refactor without starting a discussion about it first, but this has been a nitpick I had with `Time` when was exploring the codebase.

I know doesn't introduce lot of value, but had the changes locally so thought, why not? 😁 

Thank you in advance for your review.
❤️ ❤️ ❤️ 