### PR TITLE
Disallow typeof in type restrictions

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -86,16 +86,49 @@ describe "Restrictions" do
       )) { types["Foo"] }
   end
 
-  it "allows typeof as restriction" do
-    assert_type(%(
-      struct Int32
-        def self.foo(x : typeof(self))
-          x
-        end
+  it "errors if using typeof" do
+    assert_error %(
+      def foo(x : typeof(1))
       end
 
-      Int32.foo 1
-      )) { int32 }
+      foo(1)
+      ),
+      "can't use typeof in type restrictions"
+  end
+
+  it "errors if using typeof inside generic type" do
+    assert_error %(
+      class Gen(T)
+      end
+
+      def foo(x : Gen(typeof(1)))
+      end
+
+      foo(Gen(Int32).new)
+      ),
+      "can't use typeof in type restrictions"
+  end
+
+  it "errors if using typeof in block restriction" do
+    assert_error %(
+      def foo(&x : typeof(1) -> )
+        yield 1
+      end
+
+      foo {}
+      ),
+      "can't use 'typeof' here"
+  end
+
+  it "errors if using typeof in block restriction" do
+    assert_error %(
+      def foo(&x : -> typeof(1))
+        yield
+      end
+
+      foo {}
+      ),
+      "can't use typeof in type restriction"
   end
 
   it "passes #278" do

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -941,12 +941,12 @@ class Crystal::Call
 
   private def lookup_node_type(context, node)
     bubbling_exception do
-      context.defining_type.lookup_type(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars)
+      context.defining_type.lookup_type(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars, allow_typeof: false)
     end
   end
 
   private def lookup_node_type?(context, node)
-    context.defining_type.lookup_type?(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars)
+    context.defining_type.lookup_type?(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars, allow_typeof: false)
   end
 
   def bubbling_exception

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -323,8 +323,7 @@ module Crystal
     end
 
     def restrict(other : TypeOf, context)
-      lookup_type = self.lookup_type(other, self_type: context.instantiated_type.instance_type)
-      restrict lookup_type, context
+      other.raise "can't use typeof in type restrictions"
     end
 
     def restrict(other : UnionType, context)


### PR DESCRIPTION
Fixes #2052
Fixes #5189

Type restrictions in methods are currently lazily evaluated. That means that this doesn't give an error right now:

```crystal
def foo(x : DoesntExist)
end
```

It only gives an error when you try to invoke it.

Eventually we'd like type restrictions to be solved as soon as found, to avoid confusions like this: https://github.com/crystal-lang/crystal/issues/4897 . In that example, because BigRational didn't exist when defining the method, it got in an incorrect order in the overload list.

Because methods are defined and solved before "main code" is analyzed (method calls, etc.), `typeof` can't be used in type restrictions, just like it can be used in type declarations for instance variables.

Note that because we aren't yet solving restrictions as soon as found, the error you will get when using `typeof` here will only happen when you try to invoke the method, just like in the example above. Eventually this will be fixed too.