### PR TITLE
Support FreeBSD 12 (64-bit inodes)

### DIFF
--- a/src/lib_c/x86_64-portbld-freebsd/c/dirent.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/dirent.cr
@@ -4,10 +4,21 @@ lib LibC
   type DIR = Void
 
   struct Dirent
-    d_fileno : UInt
+    {% if flag?(:"freebsd12.0") %}
+      d_fileno : ULong
+      d_off : ULong
+    {% else %}
+      d_fileno : UInt
+    {% end %}
     d_reclen : UShort
     d_type : UChar
-    d_namlen : UChar
+    {% if flag?(:"freebsd12.0") %}
+      d_pad0 : UChar
+      d_namlen : UShort
+      d_pad1 : UShort
+    {% else %}
+      d_namlen : UChar
+    {% end %}
     d_name : StaticArray(Char, 256)
   end
 

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
@@ -31,23 +31,40 @@ lib LibC
   struct Stat
     st_dev : DevT
     st_ino : InoT
-    st_mode : ModeT
-    st_nlink : NlinkT
+    {% if flag?(:"freebsd12.0") %}
+      st_nlink : NlinkT
+      st_mode : ModeT
+      st_pad0 : UShort
+    {% else %}
+      st_mode : ModeT
+      st_nlink : NlinkT
+    {% end %}
     st_uid : UidT
     st_gid : GidT
+    {% if flag?(:"freebsd12.0") %}
+      st_pad1 : UInt
+    {% end %}
     st_rdev : DevT
     st_atim : Timespec
     st_mtim : Timespec
     st_ctim : Timespec
+    {% if flag?(:"freebsd12.0") %}
+      st_birthtim : Timespec
+    {% end %}
     st_size : OffT
     st_blocks : BlkcntT
     st_blksize : BlksizeT
     st_flags : FflagsT
-    st_gen : UInt
-    st_lspare : Int
-    st_birthtim : Timespec
-    __reserved_17 : UInt
-    __reserved_18 : UInt
+    {% if flag?("freebsd12.0") %}
+      st_gen : ULong
+      st_spare : StaticArray(ULong, 10)
+    {% else %}
+      st_gen : UInt
+      st_lspare : Int
+      st_birthtim : Timespec
+      __reserved_17 : UInt
+      __reserved_18 : UInt
+    {% end %}
   end
 
   fun chmod(x0 : Char*, x1 : ModeT) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/types.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/types.cr
@@ -9,9 +9,17 @@ lib LibC
   alias DevT = UInt
   alias GidT = UInt
   alias IdT = Long
-  alias InoT = UInt
+  {% if flag?(:"freebsd12.0") %}
+    alias InoT = ULong
+  {% else %}
+    alias InoT = UInt
+  {% end %}
   alias ModeT = UShort
-  alias NlinkT = UShort
+  {% if flag?(:"freebsd12.0") %}
+    alias NlinkT = ULong
+  {% else %}
+    alias NlinkT = UShort
+  {% end %}
   alias OffT = Long
   alias PidT = Int
   type PthreadAttrT = Void*

--- a/src/lib_c/x86_64-unknown-freebsd
+++ b/src/lib_c/x86_64-unknown-freebsd
@@ -1,0 +1,1 @@
+x86_64-portbld-freebsd


### PR DESCRIPTION
(also we're `unknown` now instead of `portbld`, so I added a symlink there)

THANK YOU for simply splitting the llvm target on `-` and shoving everything into flags. Rust currently drops the version number from targets and it's painful.

// Ideally, this would use a version comparison `>= 12.0`, but this is fine for now.