### PR TITLE
Add macro methods to ProcNotation and ProcLiteral

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1223,9 +1223,27 @@ describe "macro methods" do
     it "executes args" do
       assert_macro "x", %({{x.args}}), [ProcLiteral.new(Def.new("->", args: [Arg.new("z")]))] of ASTNode, "[z]"
     end
+  end
 
-    it "executes receiver" do
-      assert_macro "x", %({{x.receiver}}), [ProcLiteral.new(Def.new("->", receiver: Var.new("self")))] of ASTNode, "self"
+  describe "proc pointer methods" do
+    it "executes obj when present" do
+      assert_macro "x", %({{x.obj}}), [ProcPointer.new(Var.new("some_object"), "method", [] of ASTNode)] of ASTNode, "some_object"
+    end
+
+    it "executes obj when absent" do
+      assert_macro "x", %({{x.obj}}), [ProcPointer.new(NilLiteral.new, "method", [] of ASTNode)] of ASTNode, "nil"
+    end
+
+    it "executes name" do
+      assert_macro "x", %({{x.name}}), [ProcPointer.new(Var.new("some_object"), "method", [] of ASTNode)] of ASTNode, "method"
+    end
+
+    it "executes args when empty" do
+      assert_macro "x", %({{x.args}}), [ProcPointer.new(Var.new("some_object"), "method", [] of ASTNode)] of ASTNode, "[]"
+    end
+
+    it "executes args when not empty" do
+      assert_macro "x", %({{x.args}}), [ProcPointer.new(Var.new("some_object"), "method", [Path.new("SomeType"), Path.new("OtherType")] of ASTNode)] of ASTNode, "[SomeType, OtherType]"
     end
   end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1216,8 +1216,16 @@ describe "macro methods" do
   end
 
   describe "proc literal methods" do
-    it "gets def of proc" do
-      assert_macro "x", %({{x.method.body}}), [ProcLiteral.new(Def.new("->", body: 1.int32))] of ASTNode, "1"
+    it "executes body" do
+      assert_macro "x", %({{x.body}}), [ProcLiteral.new(Def.new("->", body: 1.int32))] of ASTNode, "1"
+    end
+
+    it "executes args" do
+      assert_macro "x", %({{x.args}}), [ProcLiteral.new(Def.new("->", args: [Arg.new("z")]))] of ASTNode, "[z]"
+    end
+
+    it "executes receiver" do
+      assert_macro "x", %({{x.receiver}}), [ProcLiteral.new(Def.new("->", receiver: Var.new("self")))] of ASTNode, "self"
     end
   end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1197,6 +1197,30 @@ describe "macro methods" do
     end
   end
 
+  describe "proc notation methods" do
+    it "gets single input" do
+      assert_macro "x", %({{x.inputs}}), [ProcNotation.new([Path.new("SomeType")] of ASTNode, Path.new("SomeResult"))] of ASTNode, "[SomeType]"
+    end
+
+    it "gets single output" do
+      assert_macro "x", %({{x.output}}), [ProcNotation.new([Path.new("SomeType")] of ASTNode, Path.new("SomeResult"))] of ASTNode, "SomeResult"
+    end
+
+    it "gets multiple inputs" do
+      assert_macro "x", %({{x.inputs}}), [ProcNotation.new([Path.new("SomeType"), Path.new("OtherType")] of ASTNode)] of ASTNode, "[SomeType, OtherType]"
+    end
+
+    it "gets empty output" do
+      assert_macro "x", %({{x.output}}), [ProcNotation.new([Path.new("SomeType")] of ASTNode)] of ASTNode, "nil"
+    end
+  end
+
+  describe "proc literal methods" do
+    it "gets def of proc" do
+      assert_macro "x", %({{x.method.body}}), [ProcLiteral.new(Def.new("->", body: 1.int32))] of ASTNode, "1"
+    end
+  end
+
   describe "def methods" do
     it "executes name" do
       assert_macro "x", %({{x.name}}), [Def.new("some_def")] of ASTNode, "some_def"

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -961,6 +961,7 @@ module Crystal::Macros
     end
   end
 
+  # The type of a proc or block argument, like `String -> Int32`.
   class ProcNotation < ASTNode
     # Returns the argument types, or an empty list if no arguments.
     def inputs : ArrayLiteral(ASTNode)
@@ -1239,6 +1240,12 @@ module Crystal::Macros
   # class ExceptionHandler < ASTNode
   # end
 
+  # A proc method, written like:
+  # ```
+  # ->(arg : String) {
+  #   puts arg
+  # }
+  # ```
   class ProcLiteral < ASTNode
     # Returns the arguments of this proc.
     def args : ArrayLiteral(Arg)
@@ -1247,15 +1254,22 @@ module Crystal::Macros
     # Returns the body of this proc.
     def body : ASTNode
     end
-
-    # Returns the receiver (for example `self`) of this proc,
-    # or `Nop` if not specified.
-    def receiver : ASTNode | Nop
-    end
   end
 
-  # class ProcPointer < ASTNode
-  # end
+  # A proc pointer, like `->my_var.some_method(String)`
+  class ProcPointer < ASTNode
+    # Returns the types of the arguments of the proc.
+    def args : ArrayLiteral(ASTNode)
+    end
+
+    # Returns the receiver of the proc, or nil if the proc is not attached to an object.
+    def obj : ASTNode | NilLiteral
+    end
+
+    # Returns the name of the method this proc points to.
+    def name : MacroId
+    end
+  end
 
   # A type union, like `(Int32 | String)`.
   class Union < ASTNode

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1240,9 +1240,17 @@ module Crystal::Macros
   # end
 
   class ProcLiteral < ASTNode
-    # Return the function declaration for this proc.
-    # The name of the function will be "->"
-    def method : Def
+    # Returns the arguments of this proc.
+    def args : ArrayLiteral(Arg)
+    end
+
+    # Returns the body of this proc.
+    def body : ASTNode
+    end
+
+    # Returns the receiver (for example `self`) of this proc,
+    # or `Nop` if not specified.
+    def receiver : ASTNode | Nop
     end
   end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -961,8 +961,15 @@ module Crystal::Macros
     end
   end
 
-  # class ProcNotation < ASTNode
-  # end
+  class ProcNotation < ASTNode
+    # Returns the argument types, or an empty list if no arguments.
+    def inputs : ArrayLiteral(ASTNode)
+    end
+
+    # Returns the output type, or nil if there is no return type.
+    def output : ASTNode | NilLiteral
+    end
+  end
 
   # A method definition.
   class Def < ASTNode
@@ -1232,8 +1239,12 @@ module Crystal::Macros
   # class ExceptionHandler < ASTNode
   # end
 
-  # class ProcLiteral < ASTNode
-  # end
+  class ProcLiteral < ASTNode
+    # Return the function declaration for this proc.
+    # The name of the function will be "->"
+    def method : Def
+    end
+  end
 
   # class ProcPointer < ASTNode
   # end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1100,8 +1100,8 @@ module Crystal
   class ProcLiteral
     def interpret(method, args, block, interpreter)
       case method
-      when "method"
-        interpret_argless_method(method, args) { @def }
+      when "args", "body"
+        @def.interpret(method, args, block, interpreter)
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1108,6 +1108,21 @@ module Crystal
     end
   end
 
+  class ProcPointer
+    def interpret(method, args, block, interpreter)
+      case method
+      when "obj"
+        interpret_argless_method(method, args) { @obj || NilLiteral.new }
+      when "name"
+        interpret_argless_method(method, args) { MacroId.new(@name) }
+      when "args"
+        interpret_argless_method(method, args) { ArrayLiteral.new(@args) }
+      else
+        super
+      end
+    end
+  end
+
   class Expressions
     def interpret(method, args, block, interpreter)
       case method

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1084,6 +1084,30 @@ module Crystal
     end
   end
 
+  class ProcNotation
+    def interpret(method, args, block, interpreter)
+      case method
+      when "inputs"
+        interpret_argless_method(method, args) { ArrayLiteral.new(@inputs || [] of ASTNode) }
+      when "output"
+        interpret_argless_method(method, args) { @output || NilLiteral.new }
+      else
+        super
+      end
+    end
+  end
+
+  class ProcLiteral
+    def interpret(method, args, block, interpreter)
+      case method
+      when "method"
+        interpret_argless_method(method, args) { @def }
+      else
+        super
+      end
+    end
+  end
+
   class Expressions
     def interpret(method, args, block, interpreter)
       case method


### PR DESCRIPTION
Fixes #4485.

I can't see where tests for macros live, so I've only briefly tested this manually. I will happily write some real tests before merging.

Also unsure about whether `NilLiteral` is the best thing to return in the case of no return type - is there already a convention for this?