### PR TITLE
Fix to parse regex starting with ';' after call

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -882,6 +882,7 @@ describe "Parser" do
   it_parses "foo(/ /)", Call.new(nil, "foo", regex(" "))
   it_parses "foo(/ /, / /)", Call.new(nil, "foo", [regex(" "), regex(" ")] of ASTNode)
   it_parses "foo a, / /", Call.new(nil, "foo", ["a".call, regex(" ")] of ASTNode)
+  it_parses "foo /;/", Call.new(nil, "foo", regex(";"))
 
   it_parses "$?", Global.new("$?")
   it_parses "$?.foo", Call.new(Global.new("$?"), "foo")

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -277,7 +277,7 @@ module Crystal
           @token.type = :DELIMITER_START
           @token.delimiter_state = Token::DelimiterState.new(:regex, '/', '/')
           @token.raw = "/"
-        elsif char.ascii_whitespace? || char == '\0' || char == ';'
+        elsif char.ascii_whitespace? || char == '\0'
           @token.type = :"/"
         elsif @wants_regex
           @token.type = :DELIMITER_START


### PR DESCRIPTION
Currently this code cannot be compiled for syntax error:

```crystal
p /;/

# Syntax error in foo.cr:1: unexpected token: ;
```

This PR fixes it.