### PR TITLE
HTTP: delete `Content-Encoding` and `Content-Length` headers after decompression

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -306,6 +306,26 @@ class HTTP::Client::Response
       response.body.should eq("")
     end
 
+    it "deletes Content-Encoding and Content-Length headers after gzip decompression" do
+      body = String.build do |io|
+        Compress::Gzip::Writer.open(io, &.print("hello"))
+      end
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
+      response.body.should eq("hello")
+      response.headers["content-encoding"]?.should eq(nil)
+      response.headers["content-length"]?.should eq(nil)
+    end
+
+    it "deletes Content-Encoding and Content-Length headers after deflate decompression" do
+      body = String.build do |io|
+        Compress::Deflate::Writer.open(io, &.print("hello"))
+      end
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
+      response.body.should eq("hello")
+      response.headers["content-encoding"]?.should eq(nil)
+      response.headers["content-length"]?.should eq(nil)
+    end
+
     describe "success?" do
       it "returns true for the 2xx" do
         response = Response.new(:ok)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -62,8 +62,12 @@ module HTTP
             case encoding
             when "gzip"
               body = Compress::Gzip::Reader.new(body, sync_close: true)
+              headers.delete("Content-Encoding")
+              headers.delete("Content-Length")
             when "deflate"
               body = Compress::Deflate::Reader.new(body, sync_close: true)
+              headers.delete("Content-Encoding")
+              headers.delete("Content-Length")
             else
               # not a format we support
             end


### PR DESCRIPTION
We got following conclusions from #4957.
1. keep consistency by deleting some headers after decompression
2. FYI: Go lang sets Uncompressed flag when the body is decompressed.

This PR provides the former and solves consistency problem I'm facing.
```crystal
# pseudo code
io  = some_compressed_http
res = HTTP::Client::Response.from_io(io)
io  = res.to_io
res = HTTP::Client::Response.from_io(io)
io  = res.to_io
res = HTTP::Client::Response.from_io(io)
... # This works well infinitely
```

Since some discussion is necessary and the amount of change is further increased,
I'd like to divide the latter issue into other PR.

Thank you,