### PR TITLE
ENV#[]=: Disallow null bytes in key and value

### DIFF
--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -50,6 +50,26 @@ describe "ENV" do
     [1, 2].each { |i| ENV.values.should contain("SOMEVALUE_#{i}") }
   end
 
+  describe "[]=" do
+    it "disallows NUL-bytes in key" do
+      expect_raises(ArgumentError, "Key contains null byte") do
+        ENV["FOO\0BAR"] = "something"
+      end
+    end
+
+    it "disallows NUL-bytes in key if value is nil" do
+      expect_raises(ArgumentError, "Key contains null byte") do
+        ENV["FOO\0BAR"] = nil
+      end
+    end
+
+    it "disallows NUL-bytes in value" do
+      expect_raises(ArgumentError, "Value contains null byte") do
+        ENV["FOO"] = "BAR\0BAZ"
+      end
+    end
+  end
+
   describe "fetch" do
     it "fetches with one argument" do
       ENV["1"] = "2"

--- a/src/env.cr
+++ b/src/env.cr
@@ -32,10 +32,16 @@ module ENV
   # Overwrites existing environment variable if already present.
   # Returns *value* if successful, otherwise raises an exception.
   # If *value* is `nil`, the environment variable is deleted.
+  #
+  # If *key* or *value* contains a null-byte an `ArgumentError` is raised.
   def self.[]=(key : String, value : String?)
+    raise ArgumentError.new("Key contains null byte") if key.byte_index(0)
+
     if value
+      raise ArgumentError.new("Value contains null byte") if value.byte_index(0)
+
       if LibC.setenv(key, value, 1) != 0
-        raise Errno.new("Error setting environment variable \"#{key}\"")
+        raise Errno.new("Error setting environment variable #{key.inspect}")
       end
     else
       LibC.unsetenv(key)


### PR DESCRIPTION
Make `ENV#[]=` raise an `ArgumentError` if *key* or *value* contain a NUL byte.

Before this, a call to `ENV[k] = v` would not check for NUL-bytes.
`setenv(3)` would then take the key and value, and as it doesn't know
about the embedded NUL-byte(s) in the key and/or value, would truncate
at the NUL-byte.

This may not sound too terrible at first.  But it can turn into a
security issue:

```cr
from_user = "DO-SOMETHING-BAD\0GOOD" # Received from user input
if from_user.ends_with?("GOOD") # Will match
  ENV["FOO"] = from_user # Will set "FOO" to "DO-SOMETHING-BAD"
end
```

Truncating user input is a real issue, with exploitation in the wild: https://mathiasbynens.be/notes/mysql-utf8mb4

Regards,
Korb