### PR TITLE
Fix docs path in .gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ coverage/
 /Makefile.local
 all_spec
 /tmp
-/doc/
+/docs/
 /src/llvm/ext/llvm_ext.o
 /src/llvm/ext/llvm_ext.dwo
 /src/ext/*.o

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ The [standard library documentation](https://crystal-lang.org/api/) is on the co
 There is a version updated with every push to the master branch [here](https://crystal-lang.org/api/master/).
 It uses a subset of [Markdown](http://daringfireball.net/projects/markdown/). You can [use Ruby as a source
 of inspiration](https://twitter.com/yukihiro_matz/status/549317901002342400) whenever applicable. To generate
-the docs execute `make doc`. Please follow the guidelines described in our
+the docs execute `make docs`. Please follow the guidelines described in our
 [language documentation](https://crystal-lang.org/docs/conventions/documenting_code.html), like the use of the third person.
 
 ### The standard library

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ std_spec: $(O)/std_spec ## Run standard library specs
 compiler_spec: $(O)/compiler_spec ## Run compiler specs
 	$(O)/compiler_spec $(SPEC_FLAGS)
 
-.PHONY: doc
-doc: ## Generate standard library documentation
-	$(BUILD_PATH) ./bin/crystal doc src/docs_main.cr
+.PHONY: docs
+docs: ## Generate standard library documentation
+	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr
 
 .PHONY: crystal
 crystal: $(O)/crystal ## Build the compiler

--- a/bin/ci
+++ b/bin/ci
@@ -84,7 +84,7 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean'
-  with_build_env 'make crystal std_spec compiler_spec doc'
+  with_build_env 'make crystal std_spec compiler_spec docs'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check samples spec src'
 }
@@ -92,11 +92,11 @@ build() {
 deploy() {
   export CURRENT_TAG=`git describe --tags --exact-match 2> /dev/null`
   export GIT_VERSION=`git describe --tags --long --always 2>/dev/null`
-  on_deploy 'echo $GIT_VERSION > doc/revision.txt'
+  on_deploy 'echo $GIT_VERSION > docs/revision.txt'
 
-  on_deploy aws s3 sync doc/ s3://crystal-api/api/$TRAVIS_BRANCH
+  on_deploy aws s3 sync docs/ s3://crystal-api/api/$TRAVIS_BRANCH
 
-  on_deploy on_tag aws s3 sync doc/ s3://crystal-api/api/$CURRENT_TAG
+  on_deploy on_tag aws s3 sync docs/ s3://crystal-api/api/$CURRENT_TAG
   cat - > .aws-config <<EOF
     {
       "IndexDocument": {


### PR DESCRIPTION
#4937 changed the default location for `crystal docs` to `./docs`, this RP applies this rename to .gitignore and Makefile.