### PR TITLE
Fix ASTNode#to_s to wrap with parenthesis as needed

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -3,12 +3,12 @@ require "../../../spec_helper"
 private def instrument(source)
   ast = Parser.new(source).parse
   instrumented = Playground::AgentInstrumentorTransformer.transform ast
-  instrumented.to_s
+  instrumented.to_s(toplevel_expressions: true)
 end
 
 private def assert_agent(source, expected)
   # parse/to_s expected so block syntax and spaces do not bother
-  expected = Parser.new(expected).parse.to_s
+  expected = Parser.new(expected).parse.to_s(toplevel_expressions: true)
 
   instrument(source).should contain(expected)
 
@@ -18,7 +18,7 @@ end
 
 private def assert_agent_eq(source, expected)
   # parse/to_s expected so block syntax and spaces do not bother
-  expected = Parser.new(expected).parse.to_s
+  expected = Parser.new(expected).parse.to_s(toplevel_expressions: true)
   instrument(source).should eq(expected)
 end
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -109,4 +109,11 @@ describe "ASTNode#to_s" do
   expect_to_s %((1 <= 2) <= 3)
   expect_to_s %(1 <= (2 <= 3))
   expect_to_s %(case 1; when .foo?; 2; end), %(case 1\nwhen .foo?\n  2\nend)
+  expect_to_s %({(1 + 2)})
+  expect_to_s %({foo: (1 + 2)})
+  expect_to_s %q("#{(1 + 2)}")
+  expect_to_s %({(1 + 2) => (3 + 4)})
+  expect_to_s %([(1 + 2)] of Int32)
+  expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
+  expect_to_s %(if (1 + 2\n3)\n  4\nend), %(if begin\n  1 + 2\n  3\nend\n  4\nend)
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -71,7 +71,7 @@ def assert_normalize(from, to, flags = nil)
   normalizer = Normalizer.new(program)
   from_nodes = Parser.parse(from)
   to_nodes = program.normalize(from_nodes)
-  to_nodes.to_s.strip.should eq(to.strip)
+  to_nodes.to_s(toplevel_expressions: true).strip.should eq(to.strip)
 end
 
 def assert_expand(from : String, to)
@@ -80,7 +80,7 @@ end
 
 def assert_expand(from_nodes : ASTNode, to)
   to_nodes = LiteralExpander.new(Program.new).expand(from_nodes)
-  to_nodes.to_s.strip.should eq(to.strip)
+  to_nodes.to_s(toplevel_expressions: true).strip.should eq(to.strip)
 end
 
 def assert_expand_second(from : String, to)
@@ -97,7 +97,7 @@ def assert_after_cleanup(before, after)
   # before = inject_primitives(before)
   node = Parser.parse(before)
   result = semantic node
-  result.node.to_s.strip.should eq(after.strip)
+  result.node.to_s(toplevel_expressions: true).strip.should eq(after.strip)
 end
 
 def assert_error(str, message, inject_primitives = true)
@@ -168,7 +168,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
     call = Call.new(nil, "print", Var.new("__tempvar"))
     exps = Expressions.new([assign, call] of ASTNode)
     ast.expressions[-1] = exps
-    code = ast.to_s
+    code = ast.to_s(toplevel_expressions: true)
 
     output_filename = Crystal.tempfile("crystal-spec-output")
 

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -60,7 +60,12 @@ module Crystal
       @str.puts
       @str << "# " << node.filename
       @str.puts
-      node.node.accept self
+      case body = node.node
+      when Expressions
+        body.expressions.each &.accept self
+      else
+        body.accept self
+      end
       false
     end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -7,8 +7,12 @@ module Crystal
       to_s(io)
     end
 
-    def to_s(io, emit_loc_pragma = false, emit_doc = false)
-      visitor = ToSVisitor.new(io, emit_loc_pragma: emit_loc_pragma, emit_doc: emit_doc)
+    def to_s(**args)
+      String.build { |io| to_s io, **args }
+    end
+
+    def to_s(io, emit_loc_pragma = false, emit_doc = false, toplevel_expressions = false)
+      visitor = ToSVisitor.new(io, emit_loc_pragma: emit_loc_pragma, emit_doc: emit_doc, toplevel_expressions: toplevel_expressions)
       self.accept visitor
     end
   end
@@ -16,13 +20,15 @@ module Crystal
   class ToSVisitor < Visitor
     @str : IO
 
-    def initialize(@str = IO::Memory.new, @emit_loc_pragma = false, @emit_doc = false)
+    def initialize(@str = IO::Memory.new, @emit_loc_pragma = false, @emit_doc = false, @toplevel_expressions = false)
       @indent = 0
       @inside_macro = 0
       @inside_lib = false
     end
 
     def visit_any(node)
+      @toplevel_expressions = false unless node.is_a?(Expressions)
+
       if @emit_doc && (doc = node.doc) && !doc.empty?
         doc.each_line(chomp: false) do |line|
           append_indent
@@ -1496,19 +1502,23 @@ module Crystal
       @indent -= 1
     end
 
-    def accept_with_indent(node : Expressions)
-      with_indent do
-        if @inside_macro > 0
-          node.expressions.each &.accept self
-        else
-          node.expressions.each do |exp|
-            unless exp.nop?
-              append_indent
-              exp.accept self
-              newline
-            end
+    def accept_expressions(node)
+      if @inside_macro > 0
+        node.expressions.each &.accept self
+      else
+        node.expressions.each do |exp|
+          unless exp.nop?
+            append_indent
+            exp.accept self
+            newline
           end
         end
+      end
+    end
+
+    def accept_with_indent(node : Expressions)
+      with_indent do
+        accept_expressions node
       end
     end
 
@@ -1526,16 +1536,20 @@ module Crystal
     def accept_with_maybe_begin_end(node)
       case node
       when Expressions
-        if node.expressions.size == 1
-          @str << "("
-          node.expressions.first.accept self
-          @str << ")"
+        if @toplevel_expressions
+          accept_expressions node
         else
-          @str << keyword("begin")
-          newline
-          accept_with_indent(node)
-          append_indent
-          @str << keyword("end")
+          if node.expressions.size == 1
+            @str << "("
+            node.expressions.first.accept self
+            @str << ")"
+          else
+            @str << keyword("begin")
+            newline
+            accept_with_indent(node)
+            append_indent
+            @str << keyword("end")
+          end
         end
       when If, Unless, While, Until
         @str << keyword("begin")

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -201,13 +201,7 @@ module Crystal
       if @inside_macro > 0
         node.expressions.each &.accept self
       else
-        node.expressions.each do |exp|
-          unless exp.nop?
-            append_indent
-            exp.accept self
-            newline
-          end
-        end
+        accept_with_maybe_begin_end node
       end
       false
     end
@@ -1504,7 +1498,17 @@ module Crystal
 
     def accept_with_indent(node : Expressions)
       with_indent do
-        node.accept self
+        if @inside_macro > 0
+          node.expressions.each &.accept self
+        else
+          node.expressions.each do |exp|
+            unless exp.nop?
+              append_indent
+              exp.accept self
+              newline
+            end
+          end
+        end
       end
     end
 

--- a/src/compiler/crystal/tools/expand.cr
+++ b/src/compiler/crystal/tools/expand.cr
@@ -80,7 +80,7 @@ module Crystal
       end
 
       private def self.ast_to_s(node)
-        source = String.build { |io| node.to_s(io, emit_doc: true) }
+        source = node.to_s(emit_doc: true, toplevel_expressions: true)
 
         # Re-indentation is needed for `MacroIf` and `MacroFor`, because they have
         # `MacroBody`, which is sub string of source code, in other words they may


### PR DESCRIPTION
Fixed #5219

Whether current `ASTNode#to_s` wrap `Expressions` with parenthesis (or begin/end) is depending on the parent of this. And default wrapping policy is no wrapping. It causes some problems, for example #5219 or see this:

```crystal
macro foo(x)
  {{ x }}
  {% debug() %}
end

foo(if (true
        false)
      p true
    else
      p false
    end)
```

Expected output is `false` of course but this program prints `true` currently, because `{% debug() %}` output is:

```crystal
if true
  false

  p(true)
else
  p(false)
end
```

So parenthesis is disappeared and program is broken.

I fixed `ASTNode#to_s` to wrap parenthesis in every time except this `Expressions` wants indent.