### PR TITLE
Can't use `self` in toplevel method

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -476,4 +476,14 @@ describe "Semantic: def" do
       foo(1)
       )) { int32.metaclass }
   end
+
+  it "can't use self in toplevel method" do
+    assert_error %(
+      def foo
+        self
+      end
+
+      foo
+    ), "there's no self in this scope"
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -341,6 +341,10 @@ module Crystal
     def visit(node : Var)
       var = @vars[node.name]?
       if var
+        if var.type?.is_a?(Program) && node.name == "self"
+          node.raise "there's no self in this scope"
+        end
+
         meta_var = @meta_vars[node.name]
         check_closured meta_var
 


### PR DESCRIPTION
Related issue #5225 

Now the compiler shows right error message:

```crystal
def foo
  self # raise: there's no self in this scope
end

foo
```