### PR TITLE
Fix: Added missing name field to constant doc json

### DIFF
--- a/src/compiler/crystal/tools/doc/constant.cr
+++ b/src/compiler/crystal/tools/doc/constant.cr
@@ -27,6 +27,7 @@ class Crystal::Doc::Constant
 
   def to_json(builder : JSON::Builder)
     builder.object do
+      builder.field "name", name
       builder.field "value", value.try(&.to_s)
       builder.field "doc", doc
       builder.field "summary", formatted_summary


### PR DESCRIPTION
Fixup for #4746 

Seems like I missed the name field for constants during the PR refactoring... 😢 