### PR TITLE
Improved search feature for API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -78,6 +78,7 @@ class Crystal::Doc::Generator
 
     main_index = Main.new(raw_body, Type.new(self, @program), repository_name)
     File.write File.join(@output_dir, "index.json"), main_index
+    File.write File.join(@output_dir, "index.jsonp"), main_index.to_jsonp
   end
 
   def copy_files

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -78,7 +78,7 @@ class Crystal::Doc::Generator
 
     main_index = Main.new(raw_body, Type.new(self, @program), repository_name)
     File.write File.join(@output_dir, "index.json"), main_index
-    File.write File.join(@output_dir, "index.jsonp"), main_index.to_jsonp
+    File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
   end
 
   def copy_files

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -524,3 +524,87 @@ span.flag.purple {
   line-height: 1.2em;
   max-height: 2.4em;
 }
+
+.js-modal-visible .modal-background {
+  display: flex;
+}
+#types-list,
+#main-content {
+  filter: blur(0);
+  transition: filter 200ms;
+}
+.js-modal-visible #types-list,
+.js-modal-visible #main-content {
+  filter: blur(2px);
+}
+.modal-background {
+  position: absolute;
+  display: none;
+  height: 100%;
+  width: 100%;
+  background: rgba(120,120,120,.4);
+  z-index: 100;
+  align-items: center;
+  justify-content: center;
+}
+.usage-modal {
+  max-width: 90%;
+  background: #fff;
+  border: 2px solid #ccc;
+  border-radius: 9px;
+  padding: 5px 15px 20px;
+  min-width: 50%;
+  color: #555;
+  position: relative;
+  transform: scale(.5);
+  transition: transform 200ms;
+}
+.js-modal-visible .usage-modal {
+  transform: scale(1);
+}
+.usage-modal > .close-button {
+  position: absolute;
+  right: 15px;
+  top: 8px;
+  color: #aaa;
+  font-size: 27px;
+  cursor: pointer;
+}
+.usage-modal > .close-button:hover {
+  text-shadow: 2px 2px 2px #ccc;
+  color: #999;
+}
+.modal-title {
+  margin: 0;
+  text-align: center;
+  font-weight: normal;
+  color: #666;
+  border-bottom: 2px solid #ddd;
+  padding: 10px;
+}
+.usage-list {
+  padding: 0;
+  margin: 13px;
+}
+.usage-list > li {
+  padding: 5px 2px;
+  overflow: auto;
+  padding-left: 100px;
+  min-width: 12em;
+}
+.usage-modal kbd {
+  background: #eee;
+  border: 1px solid #ccc;
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  padding: 3px 8px;
+  font-family: monospace;
+  margin-right: 2px;
+  display: inline-block;
+}
+.usage-key {
+  float: left;
+  clear: left;
+  margin-left: -100px;
+  margin-right: 12px;
+}

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -117,12 +117,15 @@ h2 {
   display: none;
 }
 
-#types-list a {
+#types-list a,
+.search_result .search-result__title > a {
   display: block;
-  padding: 5px 15px 5px 30px;
   text-decoration: none;
   color: #F8F4FD;
   transition: color .14s;
+}
+.types-list a {
+  padding: 5px 15px 5px 30px;
 }
 
 #types-list a:focus {
@@ -330,7 +333,7 @@ h2 {
 }
 
 .methods-inherited .tooltip * {
-    color: #47266E;
+  color: #47266E;
 }
 
 pre {
@@ -429,4 +432,95 @@ span.flag.purple {
 
 .m {
   color: #795da3;
+}
+
+.hidden {
+  display: none;
+}
+.search-results {
+  font-size: 90%;
+  line-height: 1.3;
+}
+
+.search-results mark {
+  color: inherit;
+  background: transparent;
+  font-weight: bold;
+}
+.search-result {
+  padding: 5px 8px 5px 5px;
+  cursor: pointer;
+  border-left: 5px solid transparent;
+  transform: translateX(-3px);
+  transition: all .2s, background-color 0s, border .02s;
+  min-height: 3.2em;
+}
+.search-result.current {
+  border-left-color: #ddd;
+  background-color: rgba(200,200,200,0.4);
+  transform: translateX(0);
+  transition: all .2s, background-color .5s, border 0s;
+}
+.search-result.current:hover,
+.search-result.current:focus {
+  border-left-color: #866BA6;
+}
+.search-result:not(.current):nth-child(2n) {
+  background-color: rgba(255,255,255,.06);
+}
+.search-result__title {
+  font-size: 105%;
+  word-break: break-all;
+  line-height: 1.1;
+  padding: 3px 0;
+}
+.search-result__title strong {
+  font-weight: normal;
+}
+.search-results .search-result__title > a {
+  padding: 0;
+}
+.search-result__title > a > .args {
+  color: #dddddd;
+  font-weight: 300;
+  transition: inherit;
+  font-size: 88%;
+  line-height: 1.2;
+  letter-spacing: -.02em;
+}
+.search-result__title > a > .args * {
+  color: inherit;
+}
+
+.search-result a,
+.search-result a:hover {
+  color: inherit;
+}
+.search-result:not(.current):hover .search-result__title > a,
+.search-result:not(.current):focus .search-result__title > a,
+.search-result__title > a:focus {
+  color: #866BA6;
+}
+.search-result:not(.current):hover .args,
+.search-result:not(.current):focus .args {
+  color: #6a5a7d;
+}
+
+.search-result__type {
+  color: #e8e8e8;
+  font-weight: 300;
+}
+.search-result__doc {
+  color: #bbbbbb;
+  font-size: 90%;
+}
+.search-result__doc p {
+  margin: 0;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  line-height: 1.2em;
+  max-height: 2.4em;
 }

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -43,9 +43,7 @@ Navigator = function(sidebar, searchInput, list){
     if(!elem){
       return;
     }
-    if(this.current){
-      this.current.classList.remove("current");
-    }
+    this.removeHighlight();
 
     this.current = elem;
     this.current.classList.add("current");
@@ -54,6 +52,19 @@ Navigator = function(sidebar, searchInput, list){
   this.highlightFirst = function(){
     this.highlight(this.list.querySelector('li:first-child'));
   };
+
+  this.removeHighlight = function() {
+    if(this.current){
+      this.current.classList.remove("current");
+    }
+    this.current = null;
+  }
+
+  this.openSelectedResult = function() {
+    if(this.current) {
+      this.current.click();
+    }
+  }
 
   function handleKeyUp(event) {
     switch(event.key) {
@@ -76,14 +87,14 @@ Navigator = function(sidebar, searchInput, list){
     switch(event.key) {
       case "Enter":
         event.stopPropagation();
-        self.current.click();
+        self.openSelectedResult();
         break;
       case "Escape":
         event.stopPropagation();
         CrystalDoc.toggleResultsList(false);
         sessionStorage.setItem(repositoryName + '::search-input:value', "");
         break;
-      case "i":
+      case "j":
       case "c":
       case "ArrowUp":
         if(event.ctrlKey || event.key == "ArrowUp") {
@@ -92,7 +103,7 @@ Navigator = function(sidebar, searchInput, list){
           startMoveTimeout(true);
         }
         break;
-      case "j":
+      case "k":
       case "h":
       case "ArrowDown":
         if(event.ctrlKey || event.key == "ArrowDown") {
@@ -132,7 +143,7 @@ Navigator = function(sidebar, searchInput, list){
     switch(event.key) {
       case "Enter":
         event.stopPropagation();
-        self.current.click();
+        self.openSelectedResult();
         break;
       case "Escape":
         event.stopPropagation();

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -1,0 +1,173 @@
+Navigator = function(sidebar, searchInput, list){
+  this.list = list;
+  var self = this;
+
+  function clearMoveTimeout() {
+    clearTimeout(self.moveTimeout);
+    self.moveTimeout = null;
+  }
+
+  function startMoveTimeout(upwards){
+    /*if(self.moveTimeout) {
+      clearMoveTimeout();
+    }
+
+    var go = function() {
+      if (!self.moveTimeout) return;
+      self.move(upwards);
+      self.moveTimout = setTimeout(go, 600);
+    };
+    self.moveTimeout = setTimeout(go, 800);*/
+  }
+
+  var move = this.move = function(upwards){
+    if(!this.current){
+      this.highlightFirst();
+      return true;
+    }
+    var next = upwards ? this.current.previousElementSibling : this.current.nextElementSibling;
+    if(next && next.classList) {
+      this.highlight(next);
+      next.scrollIntoViewIfNeeded();
+      return true;
+    }
+    return false;
+  };
+
+  this.moveRight = function(){
+  };
+  this.moveLeft = function(){
+  };
+
+  this.highlight = function(elem) {
+    if(!elem){
+      return;
+    }
+    if(this.current){
+      this.current.classList.remove("current");
+    }
+
+    this.current = elem;
+    this.current.classList.add("current");
+  };
+
+  this.highlightFirst = function(){
+    this.highlight(this.list.querySelector('li:first-child'));
+  };
+
+  function handleKeyUp(event) {
+    switch(event.key) {
+      case "ArrowUp":
+      case "ArrowDown":
+      case "i":
+      case "j":
+      case "k":
+      case "l":
+      case "c":
+      case "h":
+      case "t":
+      case "n":
+      event.stopPropagation();
+      clearMoveTimeout();
+    }
+  }
+
+  function handleKeyDown(event) {
+    switch(event.key) {
+      case "Enter":
+        event.stopPropagation();
+        self.current.click();
+        break;
+      case "Escape":
+        event.stopPropagation();
+        CrystalDoc.toggleResultsList(false);
+        sessionStorage.setItem(repositoryName + '::search-input:value', "");
+        break;
+      case "i":
+      case "c":
+      case "ArrowUp":
+        if(event.ctrlKey || event.key == "ArrowUp") {
+          event.stopPropagation();
+          self.move(true);
+          startMoveTimeout(true);
+        }
+        break;
+      case "j":
+      case "h":
+      case "ArrowDown":
+        if(event.ctrlKey || event.key == "ArrowDown") {
+          event.stopPropagation();
+          self.move(false);
+          startMoveTimeout(false);
+        }
+        break;
+      case "k":
+      case "t":
+      case "ArrowLeft":
+        if(event.ctrlKey || event.key == "ArrowLeft") {
+          event.stopPropagation();
+          self.moveLeft();
+        }
+        break;
+      case "l":
+      case "n":
+      case "ArrowRight":
+        if(event.ctrlKey || event.key == "ArrowRight") {
+          event.stopPropagation();
+          self.moveRight();
+        }
+        break;
+    }
+  }
+
+  function handleInputKeyUp(event) {
+    switch(event.key) {
+      case "ArrowUp":
+      case "ArrowDown":
+      clearMoveTimeout();
+    }
+  }
+
+  function handleInputKeyDown(event) {
+    switch(event.key) {
+      case "Enter":
+        event.stopPropagation();
+        self.current.click();
+        break;
+      case "Escape":
+        event.stopPropagation();
+        event.preventDefault();
+        // remove focus from search input
+        sidebar.focus();
+        break;
+      case "ArrowUp":
+        event.stopPropagation();
+        event.preventDefault();
+        self.move(true);
+        startMoveTimeout(true);
+        break;
+
+      case "ArrowDown":
+        event.stopPropagation();
+        event.preventDefault();
+        self.move(false);
+        startMoveTimeout(false);
+        break;
+    }
+  }
+
+  sidebar.tabIndex = 100; // set tabIndex to enable keylistener
+  sidebar.addEventListener('keyup', function(event) {
+    handleKeyUp(event);
+  });
+  sidebar.addEventListener('keydown', function(event) {
+    handleKeyDown(event);
+  });
+  searchInput.addEventListener('keydown', function(event) {
+    handleInputKeyDown(event);
+  });
+  searchInput.addEventListener('keyup', function(event) {
+    handleInputKeyUp(event);
+  });
+  this.move();
+};

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -1,4 +1,4 @@
-Navigator = function(sidebar, searchInput, list){
+Navigator = function(sidebar, searchInput, list, leaveSearchScope){
   this.list = list;
   var self = this;
 
@@ -66,6 +66,12 @@ Navigator = function(sidebar, searchInput, list){
     }
   }
 
+  this.focus = function() {
+    searchInput.focus();
+    searchInput.select();
+    this.highlightFirst();
+  }
+
   function handleKeyUp(event) {
     switch(event.key) {
       case "ArrowUp":
@@ -87,12 +93,14 @@ Navigator = function(sidebar, searchInput, list){
     switch(event.key) {
       case "Enter":
         event.stopPropagation();
+        event.preventDefault();
+        leaveSearchScope();
         self.openSelectedResult();
         break;
       case "Escape":
         event.stopPropagation();
-        CrystalDoc.toggleResultsList(false);
-        sessionStorage.setItem(repositoryName + '::search-input:value', "");
+        event.preventDefault();
+        leaveSearchScope();
         break;
       case "j":
       case "c":
@@ -135,6 +143,8 @@ Navigator = function(sidebar, searchInput, list){
     switch(event.key) {
       case "ArrowUp":
       case "ArrowDown":
+      event.stopPropagation();
+      event.preventDefault();
       clearMoveTimeout();
     }
   }
@@ -143,12 +153,15 @@ Navigator = function(sidebar, searchInput, list){
     switch(event.key) {
       case "Enter":
         event.stopPropagation();
+        event.preventDefault();
         self.openSelectedResult();
+        leaveSearchScope();
         break;
       case "Escape":
         event.stopPropagation();
         event.preventDefault();
         // remove focus from search input
+        leaveSearchScope();
         sidebar.focus();
         break;
       case "ArrowUp":

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -56,7 +56,7 @@ Navigator = function(sidebar, searchInput, list, leaveSearchScope){
     var next = upwards ? this.current.previousElementSibling : this.current.nextElementSibling;
     if(next && next.classList) {
       this.highlight(next);
-      next.scrollIntoViewIfNeeded();
+      next.scrollIntoView({behaviour: 'smooth', block: 'center'});
       return true;
     }
     return false;

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -48,6 +48,12 @@ Navigator = function(sidebar, searchInput, list, leaveSearchScope){
     self.moveTimeout = setTimeout(go, 800);*/
   }
 
+  function scrollCenter(element) {
+    var rect = element.getBoundingClientRect();
+    var middle = sidebar.clientHeight / 2;
+    sidebar.scrollTop += rect.top + rect.height / 2 - middle;
+  }
+
   var move = this.move = function(upwards){
     if(!this.current){
       this.highlightFirst();
@@ -56,7 +62,7 @@ Navigator = function(sidebar, searchInput, list, leaveSearchScope){
     var next = upwards ? this.current.previousElementSibling : this.current.nextElementSibling;
     if(next && next.classList) {
       this.highlight(next);
-      next.scrollIntoView({behaviour: 'smooth', block: 'center'});
+      scrollCenter(next);
       return true;
     }
     return false;

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -474,7 +474,12 @@ CrystalDoc.Query.stripModifiers = function(term) {
 
 CrystalDoc.search = function(string) {
   if(!CrystalDoc.searchIndex) {
-    console.error("CrystalDoc search index not initialized.");
+    console.log("CrystalDoc search index not initialized, delaying search");
+
+    document.addEventListener("CrystalDoc:loaded", function listener(){
+      document.removeEventListener("CrystalDoc:loaded", listener);
+      CrystalDoc.search(string);
+    });
     return;
   }
 

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -511,7 +511,7 @@ CrystalDoc.loadIndex = function() {
     if (script.src && script.src.indexOf("js/doc.js") >= 0) {
       if (script.src.indexOf("file://") == 0) {
         // We need to support JSONP files for the search to work on local file system.
-        var jsonPath = script.src.replace("js/doc.js", "index.jsonp");
+        var jsonPath = script.src.replace("js/doc.js", "search-index.js");
         loadScript(jsonPath);
         return;
       } else {

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -477,10 +477,15 @@ CrystalDoc.search = function(string) {
     console.error("CrystalDoc search index not initialized.");
     return;
   }
+
+  document.dispatchEvent(new Event("CrystalDoc:searchStarted"));
+
   var query = new CrystalDoc.Query(string);
   var results = CrystalDoc.runQuery(query);
   results = CrystalDoc.rankResults(results, query);
   CrystalDoc.displaySearchResults(results, query);
+
+  document.dispatchEvent(new Event("CrystalDoc:searchPerformed"));
 };
 
 CrystalDoc.initializeIndex = function(data) {

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -1,0 +1,512 @@
+CrystalDoc.searchIndex = (CrystalDoc.searchIndex || false);
+CrystalDoc.MAX_RESULTS_DISPLAY = 140;
+
+CrystalDoc.runQuery = function(query) {
+  function searchType(type, query, results) {
+    var matches = [];
+    var matchedFields = [];
+    var name = type.full_name;
+    var i = name.lastIndexOf("::");
+    if (i > 0) {
+      name = name.substring(i + 2);
+    }
+    var nameMatches = query.matches(name);
+    if (nameMatches){
+      matches = matches.concat(nameMatches);
+      matchedFields.push("name");
+    }
+
+    var namespaceMatches = query.matchesNamespace(type.full_name);
+    if(namespaceMatches){
+      matches = matches.concat(namespaceMatches);
+      matchedFields.push("name");
+    }
+
+    var docMatches = query.matches(type.doc);
+    if(docMatches){
+      matches = matches.concat(docMatches);
+      matchedFields.push("doc");
+    }
+    if (matches.length > 0) {
+      results.push({
+        id: type.id,
+        result_type: "type",
+        kind: type.kind,
+        name: name,
+        full_name: type.full_name,
+        href: type.path,
+        summary: type.summary,
+        matched_fields: matchedFields,
+        matched_terms: matches
+      });
+    }
+
+    type.instance_methods.forEach(function(method) {
+      searchMethod(method, type, "instance_method", query, results);
+    })
+    type.class_methods.forEach(function(method) {
+      searchMethod(method, type, "class_method", query, results);
+    })
+    type.constructors.forEach(function(constructor) {
+      searchMethod(constructor, type, "constructor", query, results);
+    })
+    type.macros.forEach(function(macro) {
+      searchMethod(macro, type, "macro", query, results);
+    })
+    type.constants.forEach(function(constant){
+      searchConstant(constant, type, query, results);
+    });
+
+    type.types.forEach(function(subtype){
+      searchType(subtype, query, results);
+    });
+  };
+
+  function searchMethod(method, type, kind, query, results) {
+    var matches = [];
+    var matchedFields = [];
+    var nameMatches = query.matchesMethod(method.name, kind, type);
+    if (nameMatches){
+      matches = matches.concat(nameMatches);
+      matchedFields.push("name");
+    }
+
+    method.args.forEach(function(arg){
+      var argMatches = query.matches(arg.external_name);
+      if (argMatches) {
+        matches = matches.concat(argMatches);
+        matchedFields.push("args");
+      }
+    });
+
+    var docMatches = query.matches(type.doc);
+    if(docMatches){
+      matches = matches.concat(docMatches);
+      matchedFields.push("doc");
+    }
+
+    if (matches.length > 0) {
+      var typeMatches = query.matches(type.full_name);
+      if (typeMatches) {
+        matchedFields.push("type");
+        matches = matches.concat(typeMatches);
+      }
+      results.push({
+        id: method.id,
+        type: type.full_name,
+        result_type: kind,
+        name: method.name,
+        full_name: type.full_name + "#" + method.name,
+        args_string: method.args_string,
+        summary: method.summary,
+        href: type.path + "#" + method.id,
+        matched_fields: matchedFields,
+        matched_terms: matches
+      });
+    }
+  }
+
+  function searchConstant(constant, type, query, results) {
+    var matches = [];
+    var matchedFields = [];
+    var nameMatches = query.matches(constant.name);
+    if (nameMatches){
+      matches = matches.concat(nameMatches);
+      matchedFields.push("name");
+    }
+    var docMatches = query.matches(constant.doc);
+    if(docMatches){
+      matches = matches.concat(docMatches);
+      matchedFields.push("doc");
+    }
+    if (matches.length > 0) {
+      var typeMatches = query.matches(type.full_name);
+      if (typeMatches) {
+        matchedFields.push("type");
+        matches = matches.concat(typeMatches);
+      }
+      results.push({
+        id: constant.id,
+        type: type.full_name,
+        result_type: "constant",
+        name: constant.name,
+        full_name: type.full_name + "#" + constant.name,
+        value: constant.value,
+        summary: constant.summary,
+        href: type.path + "#" + constant.id,
+        matched_fields: matchedFields,
+        matched_terms: matches
+      });
+    }
+  }
+
+  var results = [];
+  searchType(CrystalDoc.searchIndex.program, query, results);
+  return results;
+};
+
+CrystalDoc.rankResults = function(results, query) {
+  function uniqueArray(ar) {
+    var j = {};
+
+    ar.forEach(function(v) {
+      j[v + "::" + typeof v] = v;
+    });
+
+    return Object.keys(j).map(function(v) {
+      return j[v];
+    });
+  }
+
+  results = results.sort(function(a, b) {
+    var matchedTermsDiff = uniqueArray(b.matched_terms).length - uniqueArray(a.matched_terms).length;
+    var aHasDocs = b.matched_fields.includes("doc");
+    var bHasDocs = b.matched_fields.includes("doc");
+
+    if (matchedTermsDiff != 0 || (aHasDocs != bHasDocs)) {
+      if(CrystalDoc.DEBUG) { console.log("matchedTermsDiff: " + matchedTermsDiff, aHasDocs, bHasDocs); }
+      return matchedTermsDiff;
+    }
+
+    var aOnlyDocs = aHasDocs && a.matched_fields.length == 1;
+    var bOnlyDocs = bHasDocs && b.matched_fields.length == 1;
+
+    if (a.result_type == "type" && b.result_type != "type" && !aOnlyDocs) {
+      if(CrystalDoc.DEBUG) { console.log("a is type b not"); }
+      return -1;
+    } else if (b.result_type == "type" && a.result_type != "type" && !bOnlyDocs) {
+      if(CrystalDoc.DEBUG) { console.log("b is type, a not"); }
+      return 1;
+    }
+    if (a.matched_fields.includes("name")) {
+      if (b.matched_fields.includes("name")) {
+        var a_name = CrystalDoc.prefixForType(a.result_type) + a.result_type == "type" ? a.full_name : a.name;
+        var b_name = CrystalDoc.prefixForType(b.result_type) + b.result_type == "type" ? b.full_name : b.name;
+        for(var i = 0; i < query.terms.length; i++) {
+          var term = query.terms[i];
+          term = term.replace(/^::?|::?$/, "");
+          var a_orig_index = a_name.indexOf(term);
+          var b_orig_index = b_name.indexOf(term);
+          if(CrystalDoc.DEBUG) { console.log(a_orig_index, b_orig_index, a_orig_index - b_orig_index); }
+          if (a_orig_index >= 0) {
+            if (b_orig_index >= 0) {
+              if(CrystalDoc.DEBUG) { console.log("both have exact match", a_orig_index > b_orig_index ? -1 : 1); }
+              if(a_orig_index != b_orig_index) {
+                if(CrystalDoc.DEBUG) { console.log("both have exact match at different positions", a_orig_index > b_orig_index ? 1 : -1); }
+                return a_orig_index > b_orig_index ? 1 : -1;
+              }
+            } else {
+              if(CrystalDoc.DEBUG) { console.log("a has exact match, b not"); }
+              return -1;
+            }
+          } else if (b_orig_index >= 0) {
+            if(CrystalDoc.DEBUG) { console.log("b has exact match, a not"); }
+            return 1;
+          }
+        }
+      } else {
+        if(CrystalDoc.DEBUG) { console.log("a has match in name, b not"); }
+        return -1;
+      }
+    } else if (
+      !a.matched_fields.includes("name") &&
+      b.matched_fields.includes("name")
+    ) {
+      return 1;
+    }
+
+    var matchedFieldsDiff = b.matched_fields.length - a.matched_fields.length;
+    if (matchedFieldsDiff != 0) {
+      if(CrystalDoc.DEBUG) { console.log("matched to different number of fields: " + matchedFieldsDiff); }
+      return matchedFieldsDiff > 0 ? 1 : -1;
+    }
+
+    var nameCompare = a.name.localeCompare(b.name);
+    if(nameCompare != 0){
+      if(CrystalDoc.DEBUG) { console.log("nameCompare resulted in: " + nameCompare); }
+      return nameCompare > 0 ? 1 : -1;
+    }
+
+    if(a.matched_fields.includes("args") && b.matched_fields.includes("args")) {
+      for(var i = 0; i < query.terms.length; i++) {
+        var term = query.terms[i];
+        var aIndex = a.args_string.indexOf(term);
+        var bIndex = b.args_string.indexOf(term);
+        if(CrystalDoc.DEBUG) { console.log("index of " + term + " in args_string: " + aIndex + " - " + bIndex); }
+        if(aIndex >= 0){
+          if(bIndex >= 0){
+            if(aIndex != bIndex){
+              return aIndex > bIndex ? 1 : -1;
+            }
+          }else{
+            return -1;
+          }
+        }else if(bIndex >= 0) {
+          return 1;
+        }
+      }
+    }
+
+    return 0;
+  });
+
+  if (results.length > 1) {
+    // if we have more than two search terms, only include results whith the most matches
+    var bestMatchedTerms = uniqueArray(results[0].matched_terms).length;
+
+    results = results.filter(function(result) {
+      return uniqueArray(result.matched_terms).length + 1 >= bestMatchedTerms;
+    });
+  }
+  return results;
+};
+
+CrystalDoc.prefixForType = function(type) {
+  switch (type) {
+    case "instance_method":
+      return "#";
+
+    case "class_method":
+    case "macro":
+    case "constructor":
+      return ".";
+
+    default:
+      return false;
+  }
+};
+
+CrystalDoc.displaySearchResults = function(results, query) {
+  function sanitize(html){
+    return html.replace(/<(?!\/?code)[^>]+>/g, "");
+  }
+
+  // limit results
+  if (results.length > CrystalDoc.MAX_RESULTS_DISPLAY) {
+    results = results.slice(0, CrystalDoc.MAX_RESULTS_DISPLAY);
+  }
+
+  var $frag = document.createDocumentFragment();
+  var $resultsElem = document.querySelector(".search-list");
+  $resultsElem.innerHTML = "<!--" + JSON.stringify(query) + "-->";
+
+  results.forEach(function(result, i) {
+    var url = CrystalDoc.base_path + result.href;
+    var type = false;
+
+    var title = query.highlight(result.result_type == "type" ? result.full_name : result.name);
+
+    var prefix = CrystalDoc.prefixForType(result.result_type);
+    if (prefix) {
+      title = "<b>" + prefix + "</b>" + title;
+    }
+
+    title = "<strong>" + title + "</strong>";
+
+    if (result.args_string) {
+      title +=
+        "<span class=\"args\">" + query.highlight(result.args_string) + "</span>";
+    }
+
+    $elem = document.createElement("li");
+    $elem.className = "search-result search-result--" + result.result_type;
+    $elem.dataset.href = url;
+    $elem.setAttribute("title", result.full_name + " docs page");
+
+    var $title = document.createElement("div");
+    $title.setAttribute("class", "search-result__title");
+    var $titleLink = document.createElement("a");
+    $titleLink.setAttribute("href", url);
+
+    $titleLink.innerHTML = title;
+    $title.appendChild($titleLink);
+    $elem.appendChild($title);
+    $elem.addEventListener("click", function() {
+      $titleLink.click();
+    });
+
+    if (result.result_type !== "type") {
+      var $type = document.createElement("div");
+      $type.setAttribute("class", "search-result__type");
+      $type.innerHTML = query.highlight(result.type);
+      $elem.appendChild($type);
+    }
+
+    if(result.summary){
+      var $doc = document.createElement("div");
+      $doc.setAttribute("class", "search-result__doc");
+      $doc.innerHTML = query.highlight(sanitize(result.summary));
+      $elem.appendChild($doc);
+    }
+
+    $elem.appendChild(document.createComment(JSON.stringify(result)));
+    $frag.appendChild($elem);
+  });
+
+  $resultsElem.appendChild($frag);
+
+  CrystalDoc.toggleResultsList(true);
+};
+
+CrystalDoc.toggleResultsList = function(visible) {
+  if (visible) {
+    document.querySelector(".types-list").classList.add("hidden");
+    document.querySelector(".search-results").classList.remove("hidden");
+  } else {
+    document.querySelector(".types-list").classList.remove("hidden");
+    document.querySelector(".search-results").classList.add("hidden");
+  }
+};
+
+CrystalDoc.Query = function(string) {
+  this.original = string;
+  this.terms = string.split(/\s+/).filter(function(word) {
+    switch (word[0]) {
+      case "#":
+      case ".":
+        return word.length > 1;
+
+      default:
+        return word.length > 0;
+    }
+  });
+
+  var normalized = this.terms.map(CrystalDoc.Query.normalizeTerm);
+  this.normalized = normalized;
+
+  function runMatcher(field, matcher) {
+    if (!field) {
+      return false;
+    }
+    var normalizedValue = CrystalDoc.Query.normalizeTerm(field);
+
+    var matches = [];
+    normalized.forEach(function(term) {
+      if (matcher(normalizedValue, term)) {
+        matches.push(term);
+      }
+    });
+    return matches.length > 0 ? matches : false;
+  }
+
+  this.matches = function(field) {
+    return runMatcher(field, function(normalized, term) {
+      if (term[0] == "#" || term[0] == ".") {
+        return false;
+      }
+      return normalized.indexOf(term) >= 0;
+    });
+  };
+
+  function namespaceMatcher(normalized, term){
+    var i = term.indexOf(":");
+    if(i >= 0){
+      term = term.replace(/^::?|::?$/, "");
+      var index = normalized.indexOf(term);
+      if((index == 0) || (index > 0 && normalized[index-1] == ":")){
+        return true;
+      }
+    }
+    return false;
+  }
+  this.matchesMethod = function(name, kind, type) {
+    return runMatcher(name, function(normalized, term) {
+      var i = term.indexOf("#");
+      if(i >= 0){
+        if (kind != "instance_method") {
+          return false;
+        }
+      }else{
+        i = term.indexOf(".");
+        if(i >= 0){
+          if (kind != "class_method" && kind != "macro" && kind != "constructor") {
+            return false;
+          }
+        }else{
+          //neither # nor .
+          if(term.indexOf(":") && namespaceMatcher(normalized, term)){
+            return true;
+          }
+        }
+      }
+
+      var methodName = term;
+      if(i >= 0){
+        var termType = term.substring(0, i);
+        methodName = term.substring(i+1);
+
+        if(termType != "") {
+          if(CrystalDoc.Query.normalizeTerm(type.full_name).indexOf(termType) < 0){
+            return false;
+          }
+        }
+      }
+      return normalized.indexOf(methodName) >= 0;
+    });
+  };
+
+  this.matchesNamespace = function(namespace){
+    return runMatcher(namespace, namespaceMatcher);
+  };
+
+  this.highlight = function(string) {
+    if (typeof string == "undefined") {
+      return "";
+    }
+    function escapeRegExp(s) {
+      return s.replace(/[.*+?\^${}()|\[\]\\]/g, "\\$&").replace(/^[#\.:]+/, "");
+    }
+    return string.replace(
+      new RegExp("(" + this.normalized.map(escapeRegExp).join("|") + ")", "gi"),
+      "<mark>$1</mark>"
+    );
+  };
+};
+CrystalDoc.Query.normalizeTerm = function(term) {
+  return term.toLowerCase();
+};
+
+CrystalDoc.search = function(string) {
+  if(!CrystalDoc.searchIndex) {
+    console.error("CrystalDoc search index not initialized.");
+    return;
+  }
+  var query = new CrystalDoc.Query(string);
+  var results = CrystalDoc.runQuery(query);
+  results = CrystalDoc.rankResults(results, query);
+  CrystalDoc.displaySearchResults(results, query);
+};
+
+CrystalDoc.initializeIndex = function(data) {
+  CrystalDoc.searchIndex = data;
+
+  document.dispatchEvent(new Event("CrystalDoc:loaded"));
+};
+
+CrystalDoc.loadIndex = function() {
+  function loadJSON(file, callback) {
+    var xobj = new XMLHttpRequest();
+    xobj.overrideMimeType("application/json");
+    xobj.open("GET", file, true);
+    xobj.onreadystatechange = function() {
+      if (xobj.readyState == 4 && xobj.status == "200") {
+        callback(xobj.responseText);
+      }
+    };
+    xobj.send(null);
+  }
+
+  function parseJSON(json) {
+    CrystalDoc.initializeIndex(JSON.parse(json));
+  }
+
+  for(var i = 0; i < document.scripts.length; i++){
+    var script = document.scripts[i];
+    if (script.src && script.src.indexOf("js/doc.js") >= 0) {
+      var jsonPath = script.src.replace("js/doc.js", "index.json");
+      loadJSON(jsonPath, parseJSON);
+      return;
+    }
+  }
+  console.error("Could not find location of js/doc.js");
+};

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -496,6 +496,12 @@ CrystalDoc.loadIndex = function() {
     xobj.send(null);
   }
 
+  function loadScript(file) {
+    script = document.createElement("script");
+    script.src = file;
+    document.body.appendChild(script);
+  }
+
   function parseJSON(json) {
     CrystalDoc.initializeIndex(JSON.parse(json));
   }
@@ -503,10 +509,22 @@ CrystalDoc.loadIndex = function() {
   for(var i = 0; i < document.scripts.length; i++){
     var script = document.scripts[i];
     if (script.src && script.src.indexOf("js/doc.js") >= 0) {
-      var jsonPath = script.src.replace("js/doc.js", "index.json");
-      loadJSON(jsonPath, parseJSON);
-      return;
+      if (script.src.indexOf("file://") == 0) {
+        // We need to support JSONP files for the search to work on local file system.
+        var jsonPath = script.src.replace("js/doc.js", "index.jsonp");
+        loadScript(jsonPath);
+        return;
+      } else {
+        var jsonPath = script.src.replace("js/doc.js", "index.json");
+        loadJSON(jsonPath, parseJSON);
+        return;
+      }
     }
   }
   console.error("Could not find location of js/doc.js");
 };
+
+// Callback for jsonp
+function crystal_doc_search_index_callback(data) {
+  CrystalDoc.initializeIndex(data);
+}

--- a/src/compiler/crystal/tools/doc/html/js/_usage-modal.js
+++ b/src/compiler/crystal/tools/doc/html/js/_usage-modal.js
@@ -1,0 +1,42 @@
+var UsageModal = function(title, content) {
+  var $body = document.body;
+  var self = this;
+  var $modalBackground = document.createElement("div");
+  $modalBackground.classList.add("modal-background");
+  var $usageModal = document.createElement("div");
+  $usageModal.classList.add("usage-modal");
+  $modalBackground.appendChild($usageModal);
+  var $title = document.createElement("h3");
+  $title.classList.add("modal-title");
+  $title.innerHTML = title
+  $usageModal.appendChild($title);
+  var $closeButton = document.createElement("span");
+  $closeButton.classList.add("close-button");
+  $closeButton.setAttribute("title", "Close modal");
+  $closeButton.innerText = '×';
+  $usageModal.appendChild($closeButton);
+  $usageModal.insertAdjacentHTML("beforeend", content);
+
+  $modalBackground.addEventListener('click', function(event) {
+    var element = event.target || event.srcElement;
+
+    if(element == $modalBackground) {
+      self.hide();
+    }
+  });
+  $closeButton.addEventListener('click', function(event) {
+    self.hide();
+  });
+
+  $body.insertAdjacentElement('beforeend', $modalBackground);
+
+  this.show = function(){
+    $body.classList.add("js-modal-visible");
+  };
+  this.hide = function(){
+    $body.classList.remove("js-modal-visible");
+  };
+  this.isVisible = function(){
+    return $body.classList.contains("js-modal-visible");
+  }
+}

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -98,6 +98,12 @@ document.addEventListener('DOMContentLoaded', function() {
   searchInput.addEventListener('input', performSearch);
 
   function handleShortkeys(event) {
+    var element = event.target || event.srcElement;
+
+    if(element.tagName == "INPUT" || element.tagName == "TEXTAREA" || element.parentElement.tagName == "TEXTAREA"){
+      return;
+    }
+
     switch(event.key) {
       case "?":
         // TODO: Show usage popup

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -4,6 +4,7 @@ CrystalDoc.base_path = (CrystalDoc.base_path || "");
 
 <%= JsSearchTemplate.new %>
 <%= JsNavigatorTemplate.new %>
+<%= JsUsageModal.new %>
 
 document.addEventListener('DOMContentLoaded', function() {
   var sessionStorage;
@@ -97,6 +98,47 @@ document.addEventListener('DOMContentLoaded', function() {
   searchInput.addEventListener('keyup', performSearch);
   searchInput.addEventListener('input', performSearch);
 
+  var usageModal = new UsageModal('Keyboard Shortcuts', '' +
+      '<ul class="usage-list">' +
+      '  <li>' +
+      '    <span class="usage-key">' +
+      '      <kbd>s</kbd>,' +
+      '      <kbd>/</kbd>' +
+      '    </span>' +
+      '    Search' +
+      '  </li>' +
+      '  <li>' +
+      '    <kbd class="usage-key">Esc</kbd>' +
+      '    Abort search / Close modal' +
+      '  </li>' +
+      '  <li>' +
+      '    <span class="usage-key">' +
+      '      <kbd>⇨</kbd>,' +
+      '      <kbd>Enter</kbd>' +
+      '    </span>' +
+      '    Open highlighted result' +
+      '  </li>' +
+      '  <li>' +
+      '    <span class="usage-key">' +
+      '      <kbd>⇧</kbd>,' +
+      '      <kbd>Ctrl+j</kbd>' +
+      '    </span>' +
+      '    Select previous result' +
+      '  </li>' +
+      '  <li>' +
+      '    <span class="usage-key">' +
+      '      <kbd>⇩</kbd>,' +
+      '      <kbd>Ctrl+k</kbd>' +
+      '    </span>' +
+      '    Select next result' +
+      '  </li>' +
+      '  <li>' +
+      '    <kbd class="usage-key">?</kbd>' +
+      '    Show usage info' +
+      '  </li>' +
+      '</ul>'
+    );
+
   function handleShortkeys(event) {
     var element = event.target || event.srcElement;
 
@@ -106,11 +148,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
     switch(event.key) {
       case "?":
-        // TODO: Show usage popup
+        usageModal.show();
+        break;
+
+      case "Escape":
+        usageModal.hide();
         break;
 
       case "s":
       case "/":
+        if(usageModal.isVisible()) {
+          return;
+        }
         event.stopPropagation();
         navigator.focus();
         performSearch();

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', function() {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(function() {
       var text = searchInput.value;
+      navigator.removeHighlight();
 
       if(text == "") {
         CrystalDoc.toggleResultsList(false);

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -172,16 +172,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
   document.addEventListener('keyup', handleShortkeys);
 
-  typesList.onscroll = function() {
-    var y = typesList.scrollTop;
-    sessionStorage.setItem(repositoryName + '::types-list:scrollTop', y);
-  };
-
-  var initialY = parseInt(sessionStorage.getItem(repositoryName + '::types-list:scrollTop') + "", 10);
-  if(initialY > 0) {
-    typesList.scrollTop = initialY;
-  }
-
   var scrollToEntryFromLocationHash = function() {
     var hash = window.location.hash;
     if (hash) {

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -94,7 +94,6 @@ document.addEventListener('DOMContentLoaded', function() {
       searchInput.value = searchText;
     }
   }
-  searchInput.focus();
   searchInput.addEventListener('keyup', performSearch);
   searchInput.addEventListener('input', performSearch);
 

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -62,13 +62,17 @@ document.addEventListener('DOMContentLoaded', function() {
   var searchTimeout;
   var lastSearchText = false;
   var performSearch = function() {
+    document.dispatchEvent(new Event("CrystalDoc:searchDebounceStarted"));
+
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(function() {
       var text = searchInput.value;
 
       if(text == "") {
         CrystalDoc.toggleResultsList(false);
-      }else if(text != lastSearchText){
+      }else if(text == lastSearchText){
+        document.dispatchEvent(new Event("CrystalDoc:searchDebounceStopped"));
+      }else{
         CrystalDoc.search(text);
         navigator.highlightFirst();
         searchInput.focus();

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -23,6 +23,10 @@ document.addEventListener('DOMContentLoaded', function() {
   var searchInput = document.getElementById('search-input');
   var parents = document.querySelectorAll('#types-list li.parent');
 
+  var setPersistentSearchQuery = function(value){
+    sessionStorage.setItem(repositoryName + '::search-input:value', value);
+  }
+
   for(var i = 0; i < parents.length; i++) {
     var _parent = parents[i];
     _parent.addEventListener('click', function(e) {
@@ -46,7 +50,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  var navigator = new Navigator(document.querySelector('#types-list'), searchInput, document.querySelector(".search-results"));
+  var leaveSearchScope = function(){
+    CrystalDoc.toggleResultsList(false);
+    window.focus();
+  }
+
+  var navigator = new Navigator(document.querySelector('#types-list'), searchInput, document.querySelector(".search-results"), leaveSearchScope);
 
   CrystalDoc.loadIndex();
   var searchTimeout;
@@ -55,7 +64,6 @@ document.addEventListener('DOMContentLoaded', function() {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(function() {
       var text = searchInput.value;
-      navigator.removeHighlight();
 
       if(text == "") {
         CrystalDoc.toggleResultsList(false);
@@ -65,7 +73,7 @@ document.addEventListener('DOMContentLoaded', function() {
         searchInput.focus();
       }
       lastSearchText = text;
-      sessionStorage.setItem(repositoryName + '::search-input:value', text);
+      setPersistentSearchQuery(text);
     }, 200);
   };
 
@@ -76,15 +84,13 @@ document.addEventListener('DOMContentLoaded', function() {
     var searchQuery = location.hash.substring(3);
     history.pushState({searchQuery: searchQuery}, "Search for " + searchQuery, location.href.replace(/#q=.*/, ""));
     searchInput.value = searchQuery;
+    document.addEventListener('CrystalDoc:loaded', performSearch);
   }
 
-  if (searchInput.value.length > 0) {
-    document.addEventListener('CrystalDoc:loaded', performSearch);
-  }else {
+  if (searchInput.value.length == 0) {
     var searchText = sessionStorage.getItem(repositoryName + '::search-input:value');
     if(searchText){
       searchInput.value = searchText;
-      document.addEventListener('CrystalDoc:loaded', performSearch);
     }
   }
   searchInput.focus();
@@ -100,7 +106,8 @@ document.addEventListener('DOMContentLoaded', function() {
       case "s":
       case "/":
         event.stopPropagation();
-        searchInput.focus();
+        navigator.focus();
+        performSearch();
         break;
     }
   }

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -6,19 +6,26 @@
   <link href="css/style.css" rel="stylesheet" type="text/css" />
   <script type="text/javascript" src="js/doc.js"></script>
   <title>README - <%= repository_name %></title>
+  <script type="text/javascript">
+  CrystalDoc.base_path = "";
+  </script>
 </head>
 <body>
 
 <div id="types-list">
   <div id="search-box">
-    <input type="search" id="search-input" placeholder="Search...">
+    <input type="search" id="search-input" placeholder="Search..." spellcheck="false">
   </div>
 
-  <ul>
-    <li class="current"><a href="index.html">README</a></li>
-  </ul>
+  <a href="index.html">README</a>
 
-  <%= ListItemsTemplate.new(types, nil) %>
+  <div class="search-results" class="hidden">
+    <ul class="search-list"></ul>
+  </div>
+
+  <div class="types-list">
+    <%= ListItemsTemplate.new(types, nil) %>
+  </div>
 </div>
 
 <div id="main-content">

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -6,19 +6,26 @@
   <link href="<%= type.path_to "css/style.css" %>" rel="stylesheet" type="text/css" />
   <script type="text/javascript" src="<%= type.path_to "js/doc.js" %>"></script>
   <title><%= type.full_name %> - <%= type.repository_name %></title>
+  <script type="text/javascript">
+    CrystalDoc.base_path = "<%= type.path_to "" %>";
+  </script>
 </head>
 <body>
 
 <div id="types-list">
   <div id="search-box">
-    <input type="search" id="search-input" placeholder="Search...">
+    <input type="search" id="search-input" placeholder="Search..." spellcheck="false">
   </div>
 
-  <ul>
-    <li><a href="<%= type.path_to("index.html") %>">README</a></li>
-  </ul>
+  <a href="<%= type.path_to("index.html") %>">README</a>
 
-  <%= ListItemsTemplate.new(types, type) %>
+  <div class="search-results" class="hidden">
+    <ul class="search-list"></ul>
+  </div>
+
+  <div class="types-list">
+    <%= ListItemsTemplate.new(types, type) %>
+  </div>
 </div>
 
 <div id="main-content">

--- a/src/compiler/crystal/tools/doc/main.cr
+++ b/src/compiler/crystal/tools/doc/main.cr
@@ -4,6 +4,18 @@ module Crystal::Doc
       to_json(io)
     end
 
+    def to_jsonp
+      String.build do |io|
+        to_jsonp(io)
+      end
+    end
+
+    def to_jsonp(io : IO)
+      io << "crystal_doc_search_index_callback("
+      to_json(io)
+      io << ")"
+    end
+
     def to_json(builder : JSON::Builder)
       builder.object do
         builder.field "repository_name", repository_name

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -33,6 +33,14 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/js/doc.js"
   end
 
+  struct JsSearchTemplate
+    ECR.def_to_s "#{__DIR__}/html/js/_search.js"
+  end
+
+  struct JsNavigatorTemplate
+    ECR.def_to_s "#{__DIR__}/html/js/_navigator.js"
+  end
+
   struct StyleTemplate
     ECR.def_to_s "#{__DIR__}/html/css/style.css"
   end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -41,6 +41,10 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/js/_navigator.js"
   end
 
+  struct JsUsageModal
+    ECR.def_to_s "#{__DIR__}/html/js/_usage-modal.js"
+  end
+
   struct StyleTemplate
     ECR.def_to_s "#{__DIR__}/html/css/style.css"
   end


### PR DESCRIPTION
This PR greatly improves client-side search on generated HTML pages of the API docs.
It uses the program description available as JSON data from #4746 and implements a custom search algorithm in JavaScript.
The search results include types, constants, methods, macros matching the query string in one or more of the fields name, namespace, description, arguments or type.
A custom ranking algorithm sorts results based on matching quality and relevance.

The search-algorithm is actually quite simple, it uses no search index or advanced information retrieval functions. It simply traverses through all the types and tries to find matching features. This is really just fast enough.
I considered using something like lunr.js but this would have been complicated to setup to create a domain-specific search experience. With the custom algorithm it is very easy to fine tune matching and ranking behaviour to allow developers to find what they need as fast as possible.

This approach has some drawbacks with regards to fulltext search capabilities (especially concerning docstrings), but this can certainly be improved upon.

## Search features:
* prefix filter: `#` matches instance methods, `.` matches class methods and macros, `:`/`::` matches namespace
* search is generally case-insensitive but results with case-equality areranked higher.
* search results list can be navigated by key (when in focus):
  * `i`, `c`, `ArrowUp`: move upwards
  * `j`, `h`, `ArrowDown`: move downwards
  * `Enter`: load result
  * `Escape`: cancel search
  * arrows, `Enter` and `Escape` also work when the search-input is in focus
* support for URL fragment-based search query: `/#q=mysearch` will initialize a search at page load
* page-wide shortkeys to start search: `s` or `/`

## Preview
[Online Preview](https://straight-shoota.github.io/crystal/docs-search-only/)

This is intended to be alongside #4755 which makes it look even better ([Online Preview](https://straight-shoota.github.io/crystal/doc-search/)) though it can be merged separately.

Closes #1792