### PR TITLE
FileUtils: Add a recursive `chmod_r` and `chown_r`

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -202,6 +202,14 @@ describe "FileUtils" do
     end
   end
 
+  describe "chown_r" do
+    it "change the owner of the directory recursively" do
+      # changing owners requires special privileges, so we test that method calls do compile
+      typeof(FileUtils.chown_r("/tmp/test"))
+      typeof(FileUtils.chown_r("/tmp/test", uid: 1001, gid: 100, follow_symlinks: true))
+    end
+  end
+
   describe "rm_r" do
     it "deletes a directory recursively" do
       data_path = File.join(__DIR__, "data")

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -183,6 +183,25 @@ describe "FileUtils" do
     end
   end
 
+  describe "chmod_r" do
+    it "changes the permissions of the directory recursively" do
+      data_path = File.join(__DIR__, "data")
+      path = File.join(data_path, "chmod_r_test")
+
+      begin
+        Dir.mkdir(path)
+        Dir.mkdir(File.join(path, "a"))
+        File.write(File.join(path, "a/b"), "")
+
+        FileUtils.chmod_r(path, 0o775)
+        File.stat(File.join(path, "a")).perm.should eq(0o775)
+        File.stat(File.join(path, "a/b")).perm.should eq(0o775)
+      ensure
+        FileUtils.rm_r(path)
+      end
+    end
+  end
+
   describe "rm_r" do
     it "deletes a directory recursively" do
       data_path = File.join(__DIR__, "data")

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -146,6 +146,29 @@ module FileUtils
     end
   end
 
+  # Changes the permissions of the directories and files recursively at the given *path*
+  #
+  # Symlinks are dereferenced, so that only the permissions of the symlink
+  # destination are changed, never the permissions of the symlink itself.
+  #
+  # ```
+  # File.chmod_r("foo", 0o755)
+  # File.stat("foo").perm # => 0o755
+  #
+  # File.chmod_r("foo", 0o700)
+  # File.stat("foo").perm # => 0o700
+  # ```
+  def chmod_r(path, mode : Int)
+    File.chmod(path, mode)
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        src = File.join(path, entry)
+        File.chmod(src, mode)
+        chmod_r(src, mode)
+      end
+    end
+  end
+
   # Creates a new directory at the given *path*. The linux-style permission *mode*
   # can be specified, with a default of 777 (0o777).
   #

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -169,6 +169,33 @@ module FileUtils
     end
   end
 
+  # Changes the owner of the directories and files recursively at the given *path*
+  #
+  # ```
+  # File.chown_r("/foo/bar", 1001, 100)
+  # ```
+  #
+  # Unless *follow_symlinks* is set to `true`, then the owner symlink itself will
+  # be changed, otherwise the owner of the symlink destination file will be
+  # changed. For example, assuming symlinks as `foo -> bar -> baz`:
+  #
+  # ```
+  # File.chown_r("foo", gid: 100)                        # changes foo's gid
+  # File.chown_r("foo", gid: 100, follow_symlinks: true) # changes baz's gid
+  # ```
+  #
+  # This applies recursively for all subfiles and sudirectories at the given *path*.
+  def chown_r(path, uid : Int? = -1, gid : Int = -1, follow_symlinks = false)
+    File.chown(path, uid, gid, follow_symlinks)
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        src = File.join(path, entry)
+        File.chown(src, uid, gid, follow_symlinks)
+        chown_r(src, uid, gid, follow_symlinks)
+      end
+    end
+  end
+
   # Creates a new directory at the given *path*. The linux-style permission *mode*
   # can be specified, with a default of 777 (0o777).
   #


### PR DESCRIPTION
Implements a recursive `chown` and `chmod` that applies to all subfiles and subdirectories at a given path.