### PR TITLE
Fix to keep double quote of symbol in syntax higlight for `crystal docs`

### DIFF
--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -32,12 +32,7 @@ module Crystal::Doc::Highlighter
       when :CHAR
         highlight token.raw, "s", io
       when :SYMBOL
-        sym = token.value.to_s
-        if Symbol.needs_quotes?(sym)
-          highlight HTML.escape(%(:#{sym.inspect})), "n", io
-        else
-          highlight ":#{sym}", "n", io
-        end
+        highlight HTML.escape(token.raw), "n", io
       when :CONST, :"::"
         highlight token, "t", io
       when :DELIMITER_START


### PR DESCRIPTION
`crystal docs` removes unneeded double of symbol. For example, there is `src/hello.cr`:

```crystal
# ```
# :"hello"
# ```
module Hello
end
```

And `crystal docs` generates this against `hello.cr`:

![2017-11-03 22 34 20](https://user-images.githubusercontent.com/6679325/32376116-269377d8-c0e7-11e7-8e26-17400d525091.png)

But my expectation is this (and it is this PR's output):

![2017-11-03 22 33 33](https://user-images.githubusercontent.com/6679325/32376064-0bab373a-c0e7-11e7-8f9e-4d829642b8db.png)

I think it should keep user input even if this double quote is not needed.