### PR TITLE
Clone macro default argument before macro expansion

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1223,4 +1223,19 @@ describe "Semantic: macro" do
       Foo.new.foo
     )) { int32 }
   end
+
+  it "clones default value before expanding" do
+    assert_type(%(
+      FOO = {} of String => String?
+
+      macro foo(x = {} of String => String)
+        {% FOO["foo"] = x["foo"] %}
+        {% x["foo"] = "foo" %}
+      end
+
+      foo
+      foo
+      {{ FOO["foo"] }}
+    )) { nil_type }
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -51,7 +51,7 @@ module Crystal
         next if vars.has_key?(macro_arg.name)
 
         default_value = default_value.expand_node(call.location, call.end_location) if default_value.is_a?(MagicConstant)
-        vars[macro_arg.name] = default_value
+        vars[macro_arg.name] = default_value.clone
       end
 
       # The named arguments


### PR DESCRIPTION
Currently macro default argument is not cloned on expanding, so it causes unexpected behavior when mutating default argument. For example:

```crystal
macro foo(foo = [] of String)
  {% foo.push "foo" %}
  p {{foo}}
end

foo
foo
```

I expected the below because method's default value is evaluated on every call:

```crystal
["foo"]
["foo"]
```

However, `crystal run` outputs this:

```crystal
["foo"]
["foo", "foo"]
```

This PR fixes this behavior.