### PR TITLE
spec/methods.cr: Fix typo in comment

### DIFF
--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -16,7 +16,7 @@ module Spec::Methods
     Spec::RootContext.describe(description.to_s, file, line, &block)
   end
 
-  # Defines an example group that establishes a specifc context,
+  # Defines an example group that establishes a specific context,
   # like *empty array* versus *array with elements*.
   # Inside *&block* examples are defined by `#it` or `#pending`.
   #


### PR DESCRIPTION
specifc -> specific