### PR TITLE
Make String#[] not read out-of-bounds if string ends in unicode char

### DIFF
--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -165,4 +165,16 @@ describe "Char::Reader" do
   it "errors if first_byte >= 0xF5" do
     assert_invalid_byte_sequence Bytes[0xf5, 0x8F, 0xA0, 0xA0], 4
   end
+
+  it "errors if second_byte is out of bounds" do
+    assert_invalid_byte_sequence Bytes[0xf4], 1
+  end
+
+  it "errors if third_byte is out of bounds" do
+    assert_invalid_byte_sequence Bytes[0xf4, 0x8f], 2
+  end
+
+  it "errors if fourth_byte is out of bounds" do
+    assert_invalid_byte_sequence Bytes[0xf4, 0x8f, 0xa0], 3
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -62,6 +62,12 @@ describe "String" do
       "há日本語"[5, 10].should eq("")
     end
 
+    it "raises IndexError if pointing after last char which is non-ASCII" do
+      expect_raises(IndexError) do
+        "ß"[1]
+      end
+    end
+
     it "raises index out of bound on index out of range with range" do
       expect_raises(IndexError) do
         "foo"[4..1]
@@ -150,6 +156,10 @@ describe "String" do
       "hello"[5]?.should be_nil
       "hello"[-1]?.should eq('o')
       "hello"[-6]?.should be_nil
+    end
+
+    it "returns nil with []? if pointing after last char which is non-ASCII" do
+      "ß"[1]?.should be_nil
     end
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -837,7 +837,7 @@ class String
     index += size if index < 0
 
     byte_index = char_index_to_byte_index(index)
-    if byte_index
+    if byte_index && byte_index < @bytesize
       reader = Char::Reader.new(self, pos: byte_index)
       return reader.current_char
     else


### PR DESCRIPTION
Hello,

While working on `fancyline`, I noticed that `String#[]` didn't do proper bound checking,
but relied on `Char::Reader` for this instead.  `Char::Reader` didn't do bound-checking
either (At all, actually), creating an out-of-bounds memory read.

### Sample code

```cr
"ß"[1] # => Char(0), expected an IndexError
"ß"[1]? # => Char(0), expected `nil`

# And this does an unchecked memory read:
Char::Reader.new("", pos: 100).current_char
# ^ now always gives `Char(0)`.  Changing it to just raise breaks a ton
# of assumptions made in String.
```

Both showcased behaviours are fixed by this PR for now.
