### PR TITLE
Doc: escape string array litral as HTML to prevent XSS

### DIFF
--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -119,7 +119,7 @@ module Crystal::Doc::Highlighter
       case token.type
       when :STRING
         io << " " unless first
-        io << token.value
+        HTML.escape(token.raw, io)
         first = false
       when :STRING_ARRAY_END
         io << ")"


### PR DESCRIPTION
`crystal doc` generates insecure result against this:

```crystal
# ```
# %w[<script>alert("XSS")</script>]
# ```
def xss
end
```

<img width="665" alt="2017-11-08 11 08 25" src="https://user-images.githubusercontent.com/6679325/32528211-2da74c0c-c475-11e7-97f5-03faf9addfeb.png">

This PR prevents it.