### PR TITLE
Add Crystal::Environment module

### DIFF
--- a/spec/std/crystal/environment_spec.cr
+++ b/spec/std/crystal/environment_spec.cr
@@ -1,0 +1,61 @@
+require "spec"
+require "crystal/environment"
+
+def with_env(env)
+  old_env = ENV[Crystal::Environment::ENV_KEY]?
+  begin
+    ENV[Crystal::Environment::ENV_KEY] = env
+    yield
+  ensure
+    ENV[Crystal::Environment::ENV_KEY] = old_env
+  end
+end
+
+describe "Crystal.env" do
+  it "makes an alias to Crystal::Environment" do
+    Crystal.env.should be_a(Crystal::Environment)
+  end
+end
+
+describe "Crystal::Environment" do
+  it "returns \"#{Crystal::Environment::ENV_DEFAULT}\" as default #name when #{Crystal::Environment::ENV_KEY} variable is not set" do
+    with_env(nil) do
+      Crystal::Environment.name.should eq Crystal::Environment::ENV_DEFAULT
+    end
+  end
+
+  it "returns value of #{Crystal::Environment::ENV_KEY} variable as #name" do
+    with_env("foo") do
+      Crystal::Environment.name.should eq("foo")
+    end
+  end
+
+  it "sets given #name as value of #{Crystal::Environment::ENV_KEY} variable" do
+    old_env = ENV[Crystal::Environment::ENV_KEY]?
+    begin
+      Crystal::Environment.name = "foo"
+      ENV[Crystal::Environment::ENV_KEY]?.should eq("foo")
+    ensure
+      Crystal::Environment.name = old_env
+      ENV[Crystal::Environment::ENV_KEY]?.should eq(old_env)
+    end
+  end
+
+  {% for env in Crystal::Environment::ENV_VALUES %}
+    it "defines {{ env.id }} query method" do
+      Crystal::Environment.{{ env.id }}?.should_not be_nil
+    end
+
+    it "returns true if given \"{{ env.id }}\" environment matches #{Crystal::Environment::ENV_KEY}" do
+      with_env({{ env.id.stringify }}) do
+        Crystal::Environment.{{ env.id }}?.should be_true
+      end
+    end
+
+    it "returns false if given \"{{ env.id }}\" environment does not match #{Crystal::Environment::ENV_KEY}" do
+      with_env("foo") do
+        Crystal::Environment.{{ env.id }}?.should be_false
+      end
+    end
+  {% end %}
+end

--- a/spec/std/crystal/environment_spec.cr
+++ b/spec/std/crystal/environment_spec.cr
@@ -18,6 +18,11 @@ describe "Crystal.env" do
 end
 
 describe "Crystal::Environment" do
+  it "returns name of the module in #inspect and #to_s" do
+    Crystal::Environment.inspect.should eq("Crystal::Environment")
+    Crystal::Environment.to_s.should eq("Crystal::Environment")
+  end
+
   it "returns \"#{Crystal::Environment::ENV_DEFAULT}\" as default #name when #{Crystal::Environment::ENV_KEY} variable is not set" do
     with_env(nil) do
       Crystal::Environment.name.should eq Crystal::Environment::ENV_DEFAULT

--- a/src/crystal/environment.cr
+++ b/src/crystal/environment.cr
@@ -1,0 +1,35 @@
+module Crystal
+  # ```
+  # require "crystal/environment"
+  #
+  # Crystal.env.name         # => "development"
+  # Crystal.env.development? # => true
+  # Crystal.env.production?  # => false
+  # ```
+  module Environment
+    ENV_KEY     = "CRYSTAL_ENV"
+    ENV_VALUES  = %i(development test staging production)
+    ENV_DEFAULT = "development"
+
+    extend self
+
+    {% for env in ENV_VALUES %}
+      def {{ env.id }}?
+        name == {{ env.id.stringify }}
+      end
+    {% end %}
+
+    def name
+      ENV[ENV_KEY]? || ENV_DEFAULT
+    end
+
+    def name=(env : String?)
+      ENV[ENV_KEY] = env
+    end
+  end
+
+  # See `Crystal::Environment`.
+  def self.env
+    Environment
+  end
+end

--- a/src/crystal/environment.cr
+++ b/src/crystal/environment.cr
@@ -13,6 +13,10 @@ module Crystal
 
     extend self
 
+    def to_s(io)
+      io << {{ @type.name.stringify }}
+    end
+
     {% for env in ENV_VALUES %}
       def {{ env.id }}?
         name == {{ env.id.stringify }}


### PR DESCRIPTION
This PR supplements stdlib with basic functionality around `ENV["CRYSTAL_ENV"]` variable.

```cr
# handy alias for Crystal::Environment
Crystal.env # => "development"

# getter with "development" as default value
Crystal.env.name # => "development"

# setter
Crystal.env.name = "test"

# query methods
Crystal.env.development? # => false
Crystal.env.test?        # => true
Crystal.env.staging?     # => false
Crystal.env.production?  # => false
```

Closes #5220.

---

Code from this PR ATM lives in a shard, available at https://github.com/Sija/crystal-environment.