### PR TITLE
Add #clear method to ArrayLiteral/HashLiteral

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -542,6 +542,10 @@ module Crystal::Macros
     def splat(trailing_string : StringLiteral = nil) : MacroId
     end
 
+    # Similar to `Array#clear`
+    def clear : ArrayLiteral
+    end
+
     # Similar to `Array#empty?`
     def empty? : BoolLiteral
     end
@@ -621,6 +625,10 @@ module Crystal::Macros
 
   # A hash literal.
   class HashLiteral < ASTNode
+    # Similar to `Hash#clear`
+    def clear : HashLiteral
+    end
+
     # Similar to `Hash#empty?`
     def empty? : BoolLiteral
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -753,6 +753,11 @@ module Crystal
         interpret_argless_method(method, args) { @of || Nop.new }
       when "type"
         interpret_argless_method(method, args) { @name || Nop.new }
+      when "clear"
+        interpret_argless_method(method, args) do
+          elements.clear
+          self
+        end
       else
         value = intepret_array_or_tuple_method(self, ArrayLiteral, method, args, block, interpreter)
         value || super
@@ -837,6 +842,11 @@ module Crystal
         interpret_argless_method(method, args) { @of.try(&.value) || Nop.new }
       when "type"
         interpret_argless_method(method, args) { @name || Nop.new }
+      when "clear"
+        interpret_argless_method(method, args) do
+          entries.clear
+          self
+        end
       else
         super
       end


### PR DESCRIPTION
Without this addition it's impossible to clear out `Array`/`Hash` from macros. IMO it should be possible since there are mutator methods (like `<<`), which allow for adding new entries but there's no way of removing them once added.