### PR TITLE
Add `Set#===` as alias to `Set#includes?`

### DIFF
--- a/src/set.cr
+++ b/src/set.cr
@@ -276,6 +276,13 @@ struct Set(T)
     same?(other) || @hash == other.@hash
   end
 
+  # Alias to `#includes?`.
+  #
+  # It is for convenience with using on `case` statement.
+  def ===(object : T)
+    includes? object
+  end
+
   # Returns a new `Set` with all of the same elements.
   def dup
     Set.new(self)

--- a/src/set.cr
+++ b/src/set.cr
@@ -276,9 +276,25 @@ struct Set(T)
     same?(other) || @hash == other.@hash
   end
 
-  # Alias to `#includes?`.
+  # Same as `#includes?`.
   #
   # It is for convenience with using on `case` statement.
+  #
+  # ```
+  # red_like = Set{"red", "pink", "violet"}
+  # blue_like = Set{"blue", "azure", "violet"}
+  #
+  # case "violet"
+  # when red_like & blue_like
+  #   puts "red & blue like color!"
+  # when red_like
+  #   puts "red like color!"
+  # when blue_like
+  #   puts "blue like color!"
+  # end
+  # ```
+  #
+  # See also: `Object#===`.
   def ===(object : T)
     includes? object
   end


### PR DESCRIPTION
This method is for convenience with using on `case` statement.

[Ruby 2.5 decides such a change](https://bugs.ruby-lang.org/issues/13801), this PR follows it. However IMO, this is more natural than current and useful.