### PR TITLE
fix HTTP::Params.parse("&&") bug

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -6,6 +6,7 @@ module HTTP
     describe ".parse" do
       {
         {"", {} of String => Array(String)},
+        {"&&", {} of String => Array(String)},
         {"   ", {"   " => [""]}},
         {"foo=bar", {"foo" => ["bar"]}},
         {"foo=bar&foo=baz", {"foo" => ["bar", "baz"]}},

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -58,7 +58,7 @@ module HTTP
           if key
             yield key.not_nil!, value
           else
-            yield value, ""
+            yield value, "" unless value.empty?
           end
 
           key = nil
@@ -72,7 +72,7 @@ module HTTP
       if key
         yield key.not_nil!, buffer.to_s
       else
-        yield buffer.to_s, ""
+        yield buffer.to_s, "" unless buffer.empty?
       end
     end
 


### PR DESCRIPTION
fix #5273