### PR TITLE
Format: insert space between `{` and `%` to prevent writing `{%`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1006,6 +1006,8 @@ describe Crystal::Formatter do
   assert_format "{ {{FOO}}, nil}", "{ {{FOO}}, nil }"
   assert_format "{ {% begin %}1{% end %}, nil }"
   assert_format "{ {% for x in 1..2 %}3{% end %}, nil }"
+  assert_format "{ %() }"
+  assert_format "{ %w() }"
 
   assert_format "String?"
   assert_format "String???"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -767,23 +767,18 @@ module Crystal
           current_element = current_element.key
         end
 
-        if prefix == :"{" && i == 0 && !wrote_newline
-          # This is to prevent writing `{{`
-          if current_element.is_a?(TupleLiteral) ||
+        # This is to prevent writing `{{` and `{%`
+        if prefix == :"{" && i == 0 && !wrote_newline && (
+             current_element.is_a?(TupleLiteral) ||
              current_element.is_a?(NamedTupleLiteral) ||
              current_element.is_a?(HashLiteral) ||
              current_element.is_a?(MacroExpression) ||
              current_element.is_a?(MacroIf) ||
-             current_element.is_a?(MacroFor)
-            write " "
-            write_space_at_end = true
-          end
-
-          # This is to prevent writing `{%`
-          if @token.raw.starts_with?("%")
-            write " "
-            write_space_at_end = true
-          end
+             current_element.is_a?(MacroFor) ||
+             @token.raw.starts_with?('%')
+           )
+          write " "
+          write_space_at_end = true
         end
 
         if next_needs_indent

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -762,22 +762,28 @@ module Crystal
       end
 
       elements.each_with_index do |element, i|
-        # This is to prevent writing `{{`
         current_element = element
         if current_element.is_a?(HashLiteral::Entry)
           current_element = current_element.key
         end
 
-        if prefix == :"{" && i == 0 && !wrote_newline && (
-             current_element.is_a?(TupleLiteral) ||
+        if prefix == :"{" && i == 0 && !wrote_newline
+          # This is to prevent writing `{{`
+          if current_element.is_a?(TupleLiteral) ||
              current_element.is_a?(NamedTupleLiteral) ||
              current_element.is_a?(HashLiteral) ||
              current_element.is_a?(MacroExpression) ||
              current_element.is_a?(MacroIf) ||
              current_element.is_a?(MacroFor)
-           )
-          write " "
-          write_space_at_end = true
+            write " "
+            write_space_at_end = true
+          end
+
+          # This is to prevent writing `{%`
+          if @token.raw.starts_with?("%")
+            write " "
+            write_space_at_end = true
+          end
         end
 
         if next_needs_indent


### PR DESCRIPTION
Fixed #5277

I think it is the best solution because it treats same thing against `{{` already.