### PR TITLE
Fixes issue with linking lib_unwind on OpenBSD

### DIFF
--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -1,3 +1,6 @@
+{% if flag?(:openbsd) %}
+  @[Link("stdc++")]
+{% end %}
 lib LibUnwind
   @[Flags]
   enum Action

--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -1,5 +1,5 @@
 {% if flag?(:openbsd) %}
-  @[Link("stdc++")]
+  @[Link("c++abi")]
 {% end %}
 lib LibUnwind
   @[Flags]


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/5280

I'm not sure but I think the problem may be related to OpenBSD's change of default compiler to Clang, and the update of LLVM to v5 in ports.