### PR TITLE
Fix to parse `"\#{{ ... }}"` inside macro

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -744,6 +744,8 @@ describe "Parser" do
   it_parses "{% if 1; 2; end %}", MacroExpression.new(If.new(1.int32, 2.int32), output: false)
   it_parses "{% unless 1; 2; end %}", MacroExpression.new(If.new(1.int32, Nop.new, 2.int32), output: false)
   it_parses "{%\n1\n2\n3\n%}", MacroExpression.new(Expressions.new([1.int32, 2.int32, 3.int32] of ASTNode), output: false)
+  it_parses %q({% begin %}"\#{{foo}}"{% end %}), MacroIf.new(true.bool, Expressions.new(["\"\\#".macro_literal, MacroExpression.new("foo".var), "\"".macro_literal]))
+  it_parses %q({% begin %}"\\#{{foo}}"{% end %}), MacroIf.new(true.bool, Expressions.new([%q("\\#{).macro_literal, %q({foo}}").macro_literal] of ASTNode))
 
   it_parses "[] of Int", ([] of ASTNode).array_of("Int".path)
   it_parses "[1, 2] of Int", ([1.int32, 2.int32] of ASTNode).array_of("Int".path)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2101,7 +2101,7 @@ module Crystal
         when '\\'
           char = next_char
           if delimiter_state
-            if char == '"'
+            if char == '"' || char == '#' || char == '\\'
               char = next_char
             end
             whitespace = false


### PR DESCRIPTION
Fixed #5287

Now `"\#{{ ... }}"` is parsed as macro expreession `{{ ... }}` wrapped with macro literal `"\#` and `"`.
And this PR also fixed `"\\#{{ ... }}"` to parse it as only macro literal `"\\#{{ ... }}"`.