### PR TITLE
Add reduce macromethod to TupleLiteral and ArrayLiteral

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -555,6 +555,14 @@ describe "macro methods" do
       assert_macro "", %({{[1, 2, 3].map { |e| e == 2 }}}), [] of ASTNode, "[false, true, false]"
     end
 
+    it "executes reduce with no initial value" do
+      assert_macro "", %({{[1, 2, 3].reduce { |acc, val| acc * val }}}), [] of ASTNode, "6"
+    end
+
+    it "executes reduce with initial value" do
+      assert_macro "", %({{[1, 2, 3].reduce(4) { |acc, val| acc * val }}}), [] of ASTNode, "24"
+    end
+
     it "executes map with constants" do
       assert_macro "x", %({{x.map { |e| e.id }}}), [ArrayLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "[Foo, Bar]"
     end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -582,6 +582,10 @@ module Crystal::Macros
     def reject(&block) : ArrayLiteral
     end
 
+    # Similar to `Enumerable#reduce`
+    def reduce(&block) : ASTNode
+    end
+
     # Similar to `Array#shuffle`
     def shuffle : ArrayLiteral
     end


### PR DESCRIPTION
Just adds a reduce macro method to `TupleLiteral` and `ArrayLiteral`.

I'm not sure if there is a reason this was previously excluded, I couldn't find anything previous issues.