### PR TITLE
Doc: use string array delimiter as-is input on highlight

### DIFF
--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -108,11 +108,7 @@ module Crystal::Doc::Highlighter
 
   private def highlight_string_array(lexer, token, io)
     start_highlight_class "s", io
-    if token.type == :STRING_ARRAY_START
-      io << "%w("
-    else
-      io << "%i("
-    end
+    HTML.escape(token.raw, io)
     first = true
     while true
       lexer.next_string_array_token
@@ -122,7 +118,7 @@ module Crystal::Doc::Highlighter
         HTML.escape(token.raw, io)
         first = false
       when :STRING_ARRAY_END
-        io << ")"
+        HTML.escape(token.raw, io)
         end_highlight_class io
         break
       when :EOF


### PR DESCRIPTION
Current highlighter implementation loses string array delimiter information, and replaces it with `%w(` or `%i(`. Highlighter should respect user input and it can produce invalid Crystal code if string array item has `)`.

For example, `src/string_array.cr`:

```crystal
# ```
# %w[:-) ;)]
# ```
def string_array_example
end
```

and generated is:

<img width="537" alt="2017-11-15 20 17 07" src="https://user-images.githubusercontent.com/6679325/32833393-1d08deba-ca42-11e7-883c-1c26778dfa5c.png">

Thank you.