### PR TITLE
Prevent Time::Span overflow

### DIFF
--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -89,7 +89,7 @@ struct Time::Span
       nanoseconds -= NANOSECONDS_PER_SECOND
     end
 
-    @seconds = seconds
+    @seconds = seconds.to_i64
     @nanoseconds = nanoseconds.to_i32
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -64,7 +64,10 @@ struct Time::Span
     )
   end
 
-  def initialize(*, seconds : Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32, nanoseconds : Int = 0)
+  def initialize(*, seconds : Int, nanoseconds : Int = 0)
+    unless Int64::MIN <= seconds <= Int64::MAX
+      raise ArgumentError.new "Time::Span too big or too small"
+    end
     seconds = seconds.to_i64
     # Normalize nanoseconds in the range 0...1_000_000_000
     # check for possible overflow seconds could become too big
@@ -90,17 +93,7 @@ struct Time::Span
     @nanoseconds = nanoseconds.to_i32
   end
 
-  def self.new(*, seconds : Int, nanoseconds : Int = 0)
-    unless Int64::MIN <= seconds <= Int64::MAX
-      raise ArgumentError.new "Time::Span too big or too small"
-    end
-    new(
-      seconds: seconds.to_i64,
-      nanoseconds: nanoseconds,
-    )
-  end
-
-  def self.new(*, nanoseconds : Int = 0)
+  def self.new(*, nanoseconds : Int)
     new(
       seconds: 0_i64,
       nanoseconds: nanoseconds,

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -64,7 +64,7 @@ struct Time::Span
     )
   end
 
-  def initialize(*, seconds : Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32, nanoseconds : Int)
+  def initialize(*, seconds : Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32, nanoseconds : Int = 0)
     seconds = seconds.to_i64
     # Normalize nanoseconds in the range 0...1_000_000_000
     # check for possible overflow seconds could become too big
@@ -90,7 +90,7 @@ struct Time::Span
     @nanoseconds = nanoseconds.to_i32
   end
 
-  def self.new(*, seconds : Int, nanoseconds : Int)
+  def self.new(*, seconds : Int, nanoseconds : Int = 0)
     unless Int64::MIN <= seconds <= Int64::MAX
       raise ArgumentError.new "Time::Span too big or too small"
     end
@@ -100,7 +100,7 @@ struct Time::Span
     )
   end
 
-  def self.new(*, nanoseconds : Int)
+  def self.new(*, nanoseconds : Int = 0)
     new(
       seconds: 0_i64,
       nanoseconds: nanoseconds,

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -296,6 +296,7 @@ struct Time::Span
     (total_nanoseconds * number).nanoseconds
   end
 
+  # Return a `Time::Span` that is divided by *number*.
   def /(number : Number) : Time::Span
     # TODO check overflow
     (total_nanoseconds / number).nanoseconds

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -74,7 +74,7 @@ struct Time::Span
     end
     seconds += sec
     nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND)
-    
+
     # Make sure that if seconds is positive, nanoseconds is
     # positive too. Likewise, if seconds is negative, make
     # sure that nanoseconds is negative too.
@@ -296,10 +296,7 @@ struct Time::Span
 
   # Returns the result of adding `self` and *other*.
   def +(other : self) : Time::Span
-    # check seconds for possible integer overflow
-    if ((other.to_i > 0) && (to_i > Int64::MAX - other.to_i)) || ((other.to_i < 0) && (to_i < Int64::MIN - other.to_i))
-      raise ArgumentError.new "Overflow: Time::Span too big or too small"
-    end
+    # TODO check overflow
     Span.new(
       seconds: to_i + other.to_i,
       nanoseconds: nanoseconds + other.nanoseconds,

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -290,7 +290,10 @@ struct Time::Span
   end
 
   def +(other : self) : Time::Span
-    # TODO check overflow
+    # check seconds for possible integer overflow
+    if ((other.to_i > 0) && (to_i > Int64::MAX - other.to_i)) || ((other.to_i < 0) && (to_i < Int64::MIN - other.to_i))
+      raise ArgumentError.new "Overflow: Time::Span too big or too small"
+    end
     Span.new(
       seconds: to_i + other.to_i,
       nanoseconds: nanoseconds + other.nanoseconds,

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -60,13 +60,25 @@ struct Time::Span
   def self.new(days : Int, hours : Int, minutes : Int, seconds : Int, nanoseconds : Int = 0)
     new(
       seconds: compute_seconds!(days, hours, minutes, seconds),
-      nanoseconds: nanoseconds.to_i64,
+      nanoseconds: nanoseconds,
     )
   end
 
   def initialize(*, seconds : Int, nanoseconds : Int)
+    # check for possible overflow
+    # seconds could be too big
+    if Int64::MIN > seconds || seconds > Int64::MAX
+      raise ArgumentError.new "Time::Span too big or too small"
+    else
+      seconds = seconds.to_i64
+    end
     # Normalize nanoseconds in the range 0...1_000_000_000
-    seconds += nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
+    sec = nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
+    if ((seconds > Int64::MAX - sec) && (sec > 0)) || ((sec < 0) && (seconds < Int64::MIN - sec))
+      raise ArgumentError.new "Time::Span too big or too small"
+    else
+      seconds += sec
+    end
     nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND)
 
     # Make sure that if seconds is positive, nanoseconds is
@@ -86,8 +98,8 @@ struct Time::Span
 
   def self.new(*, nanoseconds : Int)
     new(
-      seconds: nanoseconds.to_i64.tdiv(NANOSECONDS_PER_SECOND),
-      nanoseconds: nanoseconds.to_i64.remainder(NANOSECONDS_PER_SECOND),
+      seconds: 0,
+      nanoseconds: nanoseconds,
     )
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -310,14 +310,36 @@ struct Time::Span
   end
 
   # Returns a `Time::Span` that is *number* times longer.
-  def *(number : Number) : Time::Span
+  def *(number : Int) : Time::Span
     # TODO check overflow
+    Span.new(
+      seconds: to_i * number,
+      nanoseconds: nanoseconds.to_i64 * number,
+    )
+  end
+
+  # Returns a `Time::Span` that is *number* times longer.
+  def *(number : Float) : Time::Span
     (total_nanoseconds * number).nanoseconds
   end
 
   # Return a `Time::Span` that is divided by *number*.
-  def /(number : Number) : Time::Span
+  def /(number : Int) : Time::Span
+    seconds = to_i.tdiv(number)
+    nanoseconds = self.nanoseconds.tdiv(number)
+
+    remainder = to_i.remainder(number)
+    nanoseconds += (remainder * NANOSECONDS_PER_SECOND) / number
+
     # TODO check overflow
+    Span.new(
+      seconds: seconds,
+      nanoseconds: nanoseconds,
+    )
+  end
+
+  # Returns a `Time::Span` that is divided by *number*.
+  def /(number : Float) : Time::Span
     (total_nanoseconds / number).nanoseconds
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -278,7 +278,6 @@ struct Time::Span
     Time.now - self
   end
 
-  # Returns the result of subtracting `self` and *other*.
   def -(other : self) : Time::Span
     # TODO check overflow
     Span.new(
@@ -294,7 +293,6 @@ struct Time::Span
     )
   end
 
-  # Returns the result of adding `self` and *other*.
   def +(other : self) : Time::Span
     # TODO check overflow
     Span.new(
@@ -303,7 +301,6 @@ struct Time::Span
     )
   end
 
-  # Returns self.
   def + : self
     self
   end
@@ -464,7 +461,6 @@ struct Int
 
   # Returns a `Time::Span` of `self` milliseconds.
   def milliseconds : Time::Span
-    # this might overflow
     Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND)
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -293,24 +293,12 @@ struct Time::Span
   # Returns a `Time::Span` that is *number* times longer.
   def *(number : Number) : Time::Span
     # TODO check overflow
-    Span.new(
-      seconds: to_i.to_i64 * number,
-      nanoseconds: nanoseconds.to_i64 * number,
-    )
+    (total_nanoseconds * number).nanoseconds
   end
 
   def /(number : Number) : Time::Span
-    seconds = to_i.tdiv(number)
-    nanoseconds = self.nanoseconds.tdiv(number)
-
-    remainder = to_i.remainder(number)
-    nanoseconds += (remainder * NANOSECONDS_PER_SECOND) / number
-
     # TODO check overflow
-    Span.new(
-      seconds: seconds,
-      nanoseconds: nanoseconds,
-    )
+    (total_nanoseconds / number).nanoseconds
   end
 
   def /(other : self) : Float64

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -67,11 +67,10 @@ struct Time::Span
   def initialize(*, seconds : Int, nanoseconds : Int)
     # check for possible overflow
     # seconds could be too big
-    if Int64::MIN > seconds || seconds > Int64::MAX
+    unless Int64::MIN <= seconds <= Int64::MAX
       raise ArgumentError.new "Time::Span too big or too small"
-    else
-      seconds = seconds.to_i64
     end
+    seconds = seconds.to_i64
     # Normalize nanoseconds in the range 0...1_000_000_000
     sec = nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
     if ((seconds > Int64::MAX - sec) && (sec > 0)) || ((sec < 0) && (seconds < Int64::MIN - sec))


### PR DESCRIPTION
While fixing multiply and divide by numbers, I noticed that there are a lot of possible overflows.
The biggest problem is that a lot of `.to_i64` etc. are used and the general type restriction `Int` or `Number` for methods. 
eg. This makes it possible to pass in a `BigInt`, which could overflow if `.to_i64` is invoked on it.

Related to #5272 and possibly others.
This is a work-in-progress PR. 