### PR TITLE
Remove useless suffix condition

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -472,7 +472,7 @@ struct Time
     when utc?
       io << " UTC"
     when local?
-      Format.new(" %:z").format(self, io) if local?
+      Format.new(" %:z").format(self, io)
     end
     io
   end


### PR DESCRIPTION
As the expression is in a `when local?` branch, there's no need for a suffix `if local?` here.