### PR TITLE
[WIP] Added colour to post-compile errors

### DIFF
--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -23,13 +23,13 @@ describe "Backtrace" do
     output = `#{tempfile.path}`
 
     # resolved file line:column
-    output.should match(/#{sample}:3:10 in 'callee1'/)
+    output.should match(/#{sample}:7:10 in 'callee1'/)
 
     # The first line is the old (incorrect) behaviour,
     # the second line is the new (correct) behaviour.
     # TODO: keep only the second one after Crystal 0.23.1
-    unless output =~ /#{sample}:15:3 in 'callee3'/ ||
-           output =~ /#{sample}:13:5 in 'callee3'/
+    unless output =~ /#{sample}:19:3 in 'callee3'/ ||
+           output =~ /#{sample}:17:5 in 'callee3'/
       fail "didn't find callee3 in the backtrace"
     end
 

--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "tempfile"
 
 describe "Backtrace" do
-  it "prints file line:colunm" do
+  it "prints file line:column" do
     tempfile = Tempfile.new("compiler_spec_output")
     tempfile.close
     sample = "#{__DIR__}/data/backtrace_sample"

--- a/spec/std/data/backtrace_sample
+++ b/spec/std/data/backtrace_sample
@@ -1,3 +1,7 @@
+require "exception"
+
+Exception.colorize = false
+
 class Kls
   def callee1
     puts caller.join('\n')

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -162,6 +162,14 @@ struct CallStack
     end
   end
 
+  private def colorize_address(address)
+    {% if flag?(:raw_err) %}
+      address
+    {% else %}
+      "#{GREEN}#{address}#{CLEAR}"
+    {% end %}
+  end
+
   private def decode_backtrace
     show_full_info = ENV["CRYSTAL_CALLSTACK_FULL_INFO"]? == "1"
 
@@ -176,7 +184,11 @@ struct CallStack
         # Turn to relative to the current dir, if possible
         file = file.lchop(CURRENT_DIR)
 
-        file_line_column = "#{CYAN}#{BOLD}#{file}#{CLEAR}#{CYAN}:#{line}:#{column}#{CLEAR}"
+        file_line_column = {% if flag?(:raw_err) %}
+                             "#{file}:#{line}:#{column}"
+                           {% else %}
+                             "#{CYAN}#{BOLD}#{file}#{CLEAR}#{CYAN}:#{line}:#{column}#{CLEAR}"
+                           {% end %}
       end
 
       if name = CallStack.decode_function_name(pc)
@@ -207,16 +219,16 @@ struct CallStack
       if file_line_column
         if show_full_info && (frame = CallStack.decode_frame(ip))
           _, sname = frame
-          line = "#{file_line_column} in '#{GREEN}#{String.new(sname)}#{CLEAR}'"
+          line = "#{file_line_column} in '#{colorize_address(String.new(sname))}'"
         else
-          line = "#{file_line_column} in '#{GREEN}#{function}#{CLEAR}'"
+          line = "#{file_line_column} in '#{colorize_address(function)}'"
         end
       else
         line = function
       end
 
       if show_full_info
-        line = "#{line} at #{GREEN}0x#{ip.address.to_s(16)}#{CLEAR}"
+        line = "#{line} at 0x#{colorize_address(ip.address.to_s(16))}"
       end
 
       line

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -31,6 +31,19 @@ struct CallStack
     dir
   end
 
+  # ANSI color and formatting escape codes
+  RED = "\e[31m"
+  GREEN = "\e[32m"
+  YELLOW = "\e[33m"
+  CYAN = "\e[36m"
+
+  BOLD = "\e[1m"
+
+  RESET_COLOR = "\e[39;49m"
+
+  # ANSI command to clear the current state of colors and formatting
+  CLEAR = "\e[0m"
+
   @@skip = [] of String
 
   def self.skip(filename)
@@ -166,7 +179,7 @@ struct CallStack
         # Turn to relative to the current dir, if possible
         file = file.lchop(CURRENT_DIR)
 
-        file_line_column = "#{file}:#{line}:#{column}"
+        file_line_column = "#{GREEN}#{file}#{CLEAR}:#{YELLOW}#{line}:#{column}#{CLEAR}"
       end
 
       if name = CallStack.decode_function_name(pc)
@@ -197,16 +210,16 @@ struct CallStack
       if file_line_column
         if show_full_info && (frame = CallStack.decode_frame(ip))
           _, sname = frame
-          line = "#{file_line_column} in '#{String.new(sname)}'"
+          line = "#{file_line_column} in '#{CYAN}#{String.new(sname)}#{CLEAR}'"
         else
-          line = "#{file_line_column} in '#{function}'"
+          line = "#{file_line_column} in '#{CYAN}#{function}#{CLEAR}'"
         end
       else
         line = function
       end
 
       if show_full_info
-        line = "#{line} at 0x#{ip.address.to_s(16)}"
+        line = "#{line} at #{CYAN}0x#{ip.address.to_s(16)}#{CLEAR}"
       end
 
       line

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -34,12 +34,9 @@ struct CallStack
   # ANSI color and formatting escape codes
   RED = "\e[31m"
   GREEN = "\e[32m"
-  YELLOW = "\e[33m"
   CYAN = "\e[36m"
 
   BOLD = "\e[1m"
-
-  RESET_COLOR = "\e[39;49m"
 
   # ANSI command to clear the current state of colors and formatting
   CLEAR = "\e[0m"

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -41,6 +41,8 @@ struct CallStack
   # ANSI command to clear the current state of colors and formatting
   CLEAR = "\e[0m"
 
+  class_property colorize = true
+
   @@skip = [] of String
 
   def self.skip(filename)
@@ -163,11 +165,11 @@ struct CallStack
   end
 
   private def colorize_address(address)
-    {% if flag?(:raw_err) %}
-      address
-    {% else %}
+    if @@colorize
       "#{GREEN}#{address}#{CLEAR}"
-    {% end %}
+    else
+      address
+    end
   end
 
   private def decode_backtrace
@@ -184,11 +186,11 @@ struct CallStack
         # Turn to relative to the current dir, if possible
         file = file.lchop(CURRENT_DIR)
 
-        file_line_column = {% if flag?(:raw_err) %}
-                             "#{file}:#{line}:#{column}"
-                           {% else %}
+        file_line_column = if @@colorize
                              "#{CYAN}#{BOLD}#{file}#{CLEAR}#{CYAN}:#{line}:#{column}#{CLEAR}"
-                           {% end %}
+                           else
+                             "#{file}:#{line}:#{column}"
+                           end
       end
 
       if name = CallStack.decode_function_name(pc)

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -179,7 +179,7 @@ struct CallStack
         # Turn to relative to the current dir, if possible
         file = file.lchop(CURRENT_DIR)
 
-        file_line_column = "#{GREEN}#{file}#{CLEAR}:#{YELLOW}#{line}:#{column}#{CLEAR}"
+        file_line_column = "#{CYAN}#{BOLD}#{file}#{CLEAR}#{CYAN}:#{line}:#{column}#{CLEAR}"
       end
 
       if name = CallStack.decode_function_name(pc)
@@ -210,16 +210,16 @@ struct CallStack
       if file_line_column
         if show_full_info && (frame = CallStack.decode_frame(ip))
           _, sname = frame
-          line = "#{file_line_column} in '#{CYAN}#{String.new(sname)}#{CLEAR}'"
+          line = "#{file_line_column} in '#{GREEN}#{String.new(sname)}#{CLEAR}'"
         else
-          line = "#{file_line_column} in '#{CYAN}#{function}#{CLEAR}'"
+          line = "#{file_line_column} in '#{GREEN}#{function}#{CLEAR}'"
         end
       else
         line = function
       end
 
       if show_full_info
-        line = "#{line} at #{CYAN}0x#{ip.address.to_s(16)}#{CLEAR}"
+        line = "#{line} at #{GREEN}0x#{ip.address.to_s(16)}#{CLEAR}"
       end
 
       line

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -41,7 +41,7 @@ struct CallStack
   # ANSI command to clear the current state of colors and formatting
   CLEAR = "\e[0m"
 
-  class_property colorize = true
+  class_property colorize : Bool = {% if flag?(:release) %} false {% else %} STDERR.tty? {% end %}
 
   @@skip = [] of String
 

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -53,7 +53,7 @@ class Exception
     if message.nil?
       "\e[1m\e[31m" + self.class.name + "\e[0m"
     else
-      "\e[1m\e[31m" + self.class.name + ": \e[0m\e[31m" + message.not_nil! + "\e[0m"
+      "\e[1m\e[31m" + self.class.name + ": \e[0m\e[1m" + message.not_nil! + "\e[0m"
     end
   end
 

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -50,7 +50,7 @@ class Exception
   end
 
   def inspect_with_backtrace(io : IO)
-    io << message << " (\e[31m" << self.class << "\e[0m)\n"
+    io << "\e[1m\e[31m" << self.class << ": \e[0m\e[31m" << message << "\e[0m\n"
     backtrace?.try &.each do |frame|
       io.print "  from "
       io.puts frame

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -11,7 +11,7 @@ CallStack.skip(__FILE__)
 # optional traceback information.
 # Exception subclasses may add additional information.
 class Exception
-  class_getter colorize : Bool = {% if flag?(:release) %} STDERR.tty? {% else %} false {% end %}
+  class_getter colorize : Bool = {% if flag?(:release) %} false {% else %} STDERR.tty? {% end %}
   
   getter message : String?
   # Returns the previous exception at the time this exception was raised.
@@ -21,7 +21,6 @@ class Exception
   property callstack : CallStack?
 
   def initialize(@message : String? = nil, @cause : Exception? = nil)
-    CallStack.colorize = @@colorize
   end
 
   def self.colorize=(@@colorize)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -55,7 +55,7 @@ class Exception
     end
   end
 
-  def Exception.colorize(io, class_name, message)
+  def Exception.colorize_backtrace(io, class_name, message)
     if @@colorize
       if message.nil?
         io << "\e[1m\e[31m" << class_name << "\e[0m\n"
@@ -68,7 +68,7 @@ class Exception
   end
 
   def inspect_with_backtrace(io : IO)
-    Exception.colorize(io, self.class.name, message)
+    Exception.colorize_backtrace(io, self.class.name, message)
 
     backtrace?.try &.each do |frame|
       io.print "  from "

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -49,8 +49,22 @@ class Exception
     end
   end
 
+  private def colorized_backtrace
+    if message.nil?
+      "\e[1m\e[31m" + self.class.name + "\e[0m"
+    else
+      "\e[1m\e[31m" + self.class.name + ": \e[0m\e[31m" + message.not_nil! + "\e[0m"
+    end
+  end
+
   def inspect_with_backtrace(io : IO)
-    io << "\e[1m\e[31m" << self.class << ": \e[0m\e[31m" << message << "\e[0m\n"
+    trace = {% if flag?(:raw_err) %}
+      self.class.name + (message.nil? ? "" : ": #{message}")
+    {% else %}
+      colorized_backtrace
+    {% end %}
+
+    io << trace << "\n"
     backtrace?.try &.each do |frame|
       io.print "  from "
       io.puts frame

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -11,7 +11,7 @@ CallStack.skip(__FILE__)
 # optional traceback information.
 # Exception subclasses may add additional information.
 class Exception
-  class_getter colorize
+  class_getter colorize : Bool = {% if flag?(:release) %} STDERR.tty? {% else %} false {% end %}
   
   getter message : String?
   # Returns the previous exception at the time this exception was raised.
@@ -21,11 +21,7 @@ class Exception
   property callstack : CallStack?
 
   def initialize(@message : String? = nil, @cause : Exception? = nil)
-    {% if flag?(:release) %}
-      @@colorize = STDERR.tty?
-    {% else %}
-      @@colorize = false
-    {% end %}
+    CallStack.colorize = @@colorize
   end
 
   def self.colorize=(@@colorize)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -11,7 +11,7 @@ CallStack.skip(__FILE__)
 # optional traceback information.
 # Exception subclasses may add additional information.
 class Exception
-  class_getter colorize = true
+  class_getter colorize
   
   getter message : String?
   # Returns the previous exception at the time this exception was raised.
@@ -21,6 +21,11 @@ class Exception
   property callstack : CallStack?
 
   def initialize(@message : String? = nil, @cause : Exception? = nil)
+    {% if flag?(:release) %}
+      @@colorize = STDERR.tty?
+    {% else %}
+      @@colorize = false
+    {% end %}
   end
 
   def self.colorize=(@@colorize)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -50,7 +50,7 @@ class Exception
   end
 
   def inspect_with_backtrace(io : IO)
-    io << message << " (" << self.class << ")\n"
+    io << message << " (\e[31m" << self.class << "\e[0m)\n"
     backtrace?.try &.each do |frame|
       io.print "  from "
       io.puts frame


### PR DESCRIPTION
Extra fixes to #4968.

A few problems with the PR so far:
- `callstack_spec.cr` doesn't pass right now, for obvious reasons. I'll edit the spec files once this is finalised.
- The colours in `callstack.cr` might not be to everyone's liking - I personally am fine with this, and the colours are more like placeholders to highlight the important parts of the error.
- I'm personally not sure if the colour constants in the namespace are good practice.
- I changed around the error formatting in `exception.cr` to have it like `IndexError: Index out of bounds`. I'm not sure if this is good or not.