### PR TITLE
Parser: fix the condition to decide var or call

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -302,7 +302,9 @@ describe "Parser" do
   it_parses "foo +1.0", Call.new(nil, "foo", 1.float64)
   it_parses "foo +1_i64", Call.new(nil, "foo", 1.int64)
   it_parses "foo = 1; foo +1", [Assign.new("foo".var, 1.int32), Call.new("foo".var, "+", 1.int32)]
+  it_parses "foo = 1; foo(+1)", [Assign.new("foo".var, 1.int32), Call.new(nil, "foo", 1.int32)]
   it_parses "foo = 1; foo -1", [Assign.new("foo".var, 1.int32), Call.new("foo".var, "-", 1.int32)]
+  it_parses "foo = 1; foo(-1)", [Assign.new("foo".var, 1.int32), Call.new(nil, "foo", -1.int32)]
 
   it_parses "foo(&block)", Call.new(nil, "foo", block_arg: "block".call)
   it_parses "foo &block", Call.new(nil, "foo", block_arg: "block".call)
@@ -941,6 +943,7 @@ describe "Parser" do
   it_parses "case a\nwhen b\n/ /\n\nelse\n/ /\nend", Case.new("a".call, [When.new(["b".call] of ASTNode, RegexLiteral.new(StringLiteral.new(" ")))], RegexLiteral.new(StringLiteral.new(" ")))
   assert_syntax_error "case {1, 2}; when {3}; 4; end", "wrong number of tuple elements (given 1, expected 2)", 1, 19
   assert_syntax_error "case 1; end", "unexpected token: end (expecting when or else)", 1, 9
+  it_parses "a = 1\ncase 1\nwhen a then 1\nend", [Assign.new("a".var, 1.int32), Case.new(1.int32, [When.new(["a".var] of ASTNode, 1.int32)])] of ASTNode
 
   it_parses "select\nwhen foo\n2\nend", Select.new([Select::When.new("foo".call, 2.int32)])
   it_parses "select\nwhen foo\n2\nwhen bar\n4\nend", Select.new([Select::When.new("foo".call, 2.int32), Select::When.new("bar".call, 4.int32)])

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3743,7 +3743,10 @@ module Crystal
           Call.new(nil, name, (args || [] of ASTNode), block, block_arg, named_args, global, name_column_number, has_parentheses)
         else
           if args
-            if (!force_call && is_var) && args.size == 1 && (num = args[0]) && (num.is_a?(NumberLiteral) && num.has_sign?)
+            maybe_var = !force_call && is_var && !has_parentheses
+            if maybe_var && args.size == 0
+              Var.new(name)
+            elsif maybe_var && args.size == 1 && (num = args[0]) && (num.is_a?(NumberLiteral) && num.has_sign?)
               sign = num.value[0].to_s
               num.value = num.value.byte_slice(1)
               Call.new(Var.new(name), sign, args)


### PR DESCRIPTION
There is source code `foo`, this `foo` is decided var or call on parsing, and the condition for this has some bugs.

First bug, `foo(+1)` is parsed as `foo + 1` if `foo` is variable. For example:

```crystal
foo = 1
p foo(+1) # => 2 (wtf??)
```

Second bug, `case 1 when foo then 2 end` is parsed as `case 1 when foo() then 2 end` even if `foo` is variable. For example:

```crystal
foo = 1
case 1
when foo then 2
end

# Error: undefined method 'foo'
```

These bugs are fixed in this PR. Thank you.