### PR TITLE
Don't print query params if they are empty

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -32,12 +32,20 @@ describe "URI" do
   assert_uri("/foo?q=1", path: "/foo", query: "q=1")
   assert_uri("mailto:foo@example.org", scheme: "mailto", path: nil, opaque: "foo@example.org")
 
-  it { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
-  it { URI.parse("http://www.example.com").full_path.should eq("/") }
-  it { URI.parse("http://www.example.com/foo?q=1").full_path.should eq("/foo?q=1") }
-  it { URI.parse("http://www.example.com/?q=1").full_path.should eq("/?q=1") }
-  it { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
-  it { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
+  describe "full_path" do
+    it { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
+    it { URI.parse("http://www.example.com").full_path.should eq("/") }
+    it { URI.parse("http://www.example.com/foo?q=1").full_path.should eq("/foo?q=1") }
+    it { URI.parse("http://www.example.com/?q=1").full_path.should eq("/?q=1") }
+    it { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
+    it { URI.parse("http://test.dev/a%3Ab").full_path.should eq("/a%3Ab") }
+
+    it "does not add '?' to the end if the query params are empty" do
+      uri = URI.parse("http://www.example.com/foo")
+      uri.query = ""
+      uri.full_path.should eq("/foo")
+    end
+  end
 
   describe "normalize" do
     it "removes dot notation from path" do

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -128,7 +128,9 @@ class URI
   def full_path
     String.build do |str|
       str << (@path.try { |p| !p.empty? } ? @path : "/")
-      str << "?" << @query if @query
+      if (query = @query) && !query.empty?
+        str << "?" << query
+      end
     end
   end
 


### PR DESCRIPTION
I found this while investigating this issue on Lucky:
https://github.com/luckyframework/lucky/issues/214

It turns out that because I parsed the query params in the handler mentioned in the above link, it
set the `URI#query` to `""`. This caused `HTTP::Request#resource` to add
an extra `?` to the end of the path, even though the query params were
empty.

This PR fixes the issue by also checking for an empty string before
printing `?`