### PR TITLE
Refactor missing unsafe_as

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -42,7 +42,7 @@ module Crystal::System::Random
     if @@getrandom_available
       buf = uninitialized UInt8[1]
       getrandom(buf.to_slice)
-      buf.to_unsafe.as(UInt8*).value
+      buf.unsafe_as(UInt8)
     elsif urandom = @@urandom
       urandom.read_byte.not_nil!
     else

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -149,14 +149,14 @@ module IO::ByteFormat
           buffer = uninitialized UInt8[{{bytesize}}]
           io.read_fully(buffer.to_slice)
           buffer.reverse! unless SystemEndian == self
-          buffer.to_unsafe.as(Pointer({{type.id}})).value
+          buffer.unsafe_as({{type.id}})
         end
 
         def self.decode(type : {{type.id}}.class, bytes : Bytes)
           buffer = uninitialized UInt8[{{bytesize}}]
           bytes.to_slice[0, {{bytesize}}].copy_to(buffer.to_slice)
           buffer.reverse! unless SystemEndian == self
-          buffer.to_unsafe.as(Pointer({{type.id}})).value
+          buffer.unsafe_as({{type.id}})
         end
       {% end %}
     end

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -45,7 +45,7 @@ module Random::Secure
         end
       else
         random_bytes(buf.to_slice)
-        buf.to_unsafe.as({{type}}*).value
+        buf.unsafe_as({{type}})
       end
     end
   {% end %}


### PR DESCRIPTION
Those were probably missed because they involve macros for most of them, and that's hard to grep.