### PR TITLE
Rename Time constructors

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -430,9 +430,9 @@ describe "File" do
     with_tempfile("mtime") do |path|
       File.touch(path)
       File.open(path) do |file|
-        file.info.modification_time.should be_close(Time.now, 1.seconds)
+        file.info.modification_time.should be_close(Time.utc, 1.seconds)
       end
-      File.info(path).modification_time.should be_close(Time.now, 1.seconds)
+      File.info(path).modification_time.should be_close(Time.utc, 1.seconds)
     end
   end
 
@@ -1171,12 +1171,12 @@ describe "File" do
       end
     end
 
-    it "sets file times to Time.now if no time argument given" do
+    it "sets file times to current time if no time argument given" do
       with_tempfile("touch-time_now.txt") do |path|
         File.touch(path)
 
         info = File.info(path)
-        info.modification_time.should be_close(Time.now, 1.second)
+        info.modification_time.should be_close(Time.utc, 1.second)
       end
     end
 

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -159,14 +159,14 @@ module HTTP
         parse_set_cookie("a=1; domain=127.0.0.1; path=/; HttpOnly").domain.should eq "127.0.0.1"
       end
 
-      it "parse max-age as seconds from Time.now" do
+      it "parse max-age as seconds from current time" do
         cookie = parse_set_cookie("a=1; max-age=10")
-        delta = cookie.expires.not_nil! - Time.now
+        delta = cookie.expires.not_nil! - Time.utc
         delta.should be > 9.seconds
         delta.should be < 11.seconds
 
         cookie = parse_set_cookie("a=1; max-age=0")
-        delta = Time.now - cookie.expires.not_nil!
+        delta = Time.utc - cookie.expires.not_nil!
         delta.should be > 0.seconds
         delta.should be < 1.seconds
       end

--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -44,7 +44,7 @@ describe HTTP do
     end
 
     it "with local time zone" do
-      time = Time.new(1994, 11, 6, 8, 49, 37, nanosecond: 0, location: Time::Location.load("Europe/Berlin"))
+      time = Time.local(1994, 11, 6, 8, 49, 37, nanosecond: 0, location: Time::Location.load("Europe/Berlin"))
       HTTP.format_time(time).should eq(time.to_utc.to_s("%a, %d %b %Y %H:%M:%S GMT"))
     end
   end

--- a/spec/std/oauth2/session_spec.cr
+++ b/spec/std/oauth2/session_spec.cr
@@ -6,7 +6,7 @@ module OAuth2
     client = Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri", authorize_uri: "/baz"
     token = OAuth2::AccessToken::Bearer.new("token", 3600)
     session = Session.new(client, token) { |s| }
-    session = Session.new(client, token, Time.new) { |s| }
+    session = Session.new(client, token, Time.utc) { |s| }
     session.authenticate(HTTP::Client.new("localhost"))
   end)
 end

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -68,22 +68,22 @@ describe Time::Format do
       t.to_s("%:z").should eq("+00:00")
       t.to_s("%::z").should eq("+00:00:00")
 
-      zoned = Time.new(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
+      zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
       zoned.to_s("%z").should eq("+0100")
       zoned.to_s("%:z").should eq("+01:00")
       zoned.to_s("%::z").should eq("+01:00:00")
 
-      zoned = Time.new(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
+      zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
       zoned.to_s("%z").should eq("-0300")
       zoned.to_s("%:z").should eq("-03:00")
       zoned.to_s("%::z").should eq("-03:00:00")
 
-      offset = Time.new(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9000))
+      offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9000))
       offset.to_s("%z").should eq("+0230")
       offset.to_s("%:z").should eq("+02:30")
       offset.to_s("%::z").should eq("+02:30:00")
 
-      offset = Time.new(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9001))
+      offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9001))
       offset.to_s("%z").should eq("+0230")
       offset.to_s("%:z").should eq("+02:30")
       offset.to_s("%::z").should eq("+02:30:01")

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -11,12 +11,12 @@ end
 describe Time::Format do
   it "formats" do
     with_zoneinfo do
-      t = Time.new 2014, 1, 2, 3, 4, 5, nanosecond: 6_000_000
-      t2 = Time.new 2014, 1, 2, 15, 4, 5, nanosecond: 6_000_000
-      t3 = Time.new 2014, 1, 2, 12, 4, 5, nanosecond: 6_000_000
+      t = Time.utc 2014, 1, 2, 3, 4, 5, nanosecond: 6_000_000
+      t2 = Time.utc 2014, 1, 2, 15, 4, 5, nanosecond: 6_000_000
+      t3 = Time.utc 2014, 1, 2, 12, 4, 5, nanosecond: 6_000_000
 
       t.to_s("%Y").should eq("2014")
-      Time.new(1, 1, 2, 3, 4, 5, nanosecond: 6).to_s("%Y").should eq("0001")
+      Time.utc(1, 1, 2, 3, 4, 5, nanosecond: 6).to_s("%Y").should eq("0001")
 
       t.to_s("%C").should eq("20")
       t.to_s("%y").should eq("14")
@@ -64,9 +64,9 @@ describe Time::Format do
       t.to_s("%6N").to_s.should eq("006000")
       t.to_s("%9N").to_s.should eq("006000000")
 
-      Time.utc_now.to_s("%z").should eq("+0000")
-      Time.utc_now.to_s("%:z").should eq("+00:00")
-      Time.utc_now.to_s("%::z").should eq("+00:00:00")
+      t.to_s("%z").should eq("+0000")
+      t.to_s("%:z").should eq("+00:00")
+      t.to_s("%::z").should eq("+00:00:00")
 
       zoned = Time.new(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
       zoned.to_s("%z").should eq("+0100")
@@ -95,7 +95,7 @@ describe Time::Format do
       t.to_s("%u").to_s.should eq("4")
       t.to_s("%w").to_s.should eq("4")
 
-      t3 = Time.new 2014, 1, 5 # A Sunday
+      t3 = Time.utc 2014, 1, 5 # A Sunday
       t3.to_s("%u").to_s.should eq("7")
       t3.to_s("%w").to_s.should eq("0")
 

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -8,12 +8,12 @@ class Time::Location
           location = Location.load("Europe/Berlin")
 
           location.name.should eq "Europe/Berlin"
-          standard_time = location.lookup(Time.new(2017, 11, 22))
+          standard_time = location.lookup(Time.utc(2017, 11, 22))
           standard_time.name.should eq "CET"
           standard_time.offset.should eq 3600
           standard_time.dst?.should be_false
 
-          summer_time = location.lookup(Time.new(2017, 10, 22))
+          summer_time = location.lookup(Time.utc(2017, 10, 22))
           summer_time.name.should eq "CEST"
           summer_time.offset.should eq 7200
           summer_time.dst?.should be_true
@@ -156,7 +156,7 @@ class Time::Location
         location.local?.should be_false
       end
 
-      zone = location.lookup(Time.now)
+      zone = location.lookup(Time.utc)
       zone.name.should eq "UTC"
       zone.offset.should eq 0
       zone.dst?.should be_false

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -266,7 +266,7 @@ describe Time do
     end
 
     it "adds zero span" do
-      time = Time.now
+      time = Time.utc
       time.shift(0, 0).should eq time
     end
 
@@ -422,13 +422,13 @@ describe Time do
   end
 
   it "#time_of_day" do
-    t = Time.new 2014, 10, 30, 21, 18, 13
+    t = Time.utc 2014, 10, 30, 21, 18, 13
     t.time_of_day.should eq(Time::Span.new(21, 18, 13))
   end
 
   describe "#day_of_week" do
     it "gets day of week" do
-      t = Time.new 2014, 10, 30, 21, 18, 13
+      t = Time.utc 2014, 10, 30, 21, 18, 13
       t.day_of_week.should eq(Time::DayOfWeek::Thursday)
     end
 
@@ -441,7 +441,7 @@ describe Time do
 
   it "answers day name predicates" do
     7.times do |i|
-      time = Time.new(2015, 2, 15 + i)
+      time = Time.utc(2015, 2, 15 + i)
       time.sunday?.should eq(i == 0)
       time.monday?.should eq(i == 1)
       time.tuesday?.should eq(i == 2)
@@ -461,14 +461,14 @@ describe Time do
   end
 
   it "#day_of_year" do
-    t = Time.new 2014, 10, 30, 21, 18, 13
+    t = Time.utc 2014, 10, 30, 21, 18, 13
     t.day_of_year.should eq(303)
   end
 
   describe "#<=>" do
     it "compares" do
-      t1 = Time.new 2014, 10, 30, 21, 18, 13
-      t2 = Time.new 2014, 10, 30, 21, 18, 14
+      t1 = Time.utc 2014, 10, 30, 21, 18, 13
+      t2 = Time.utc 2014, 10, 30, 21, 18, 14
 
       (t1 <=> t2).should eq(-1)
       (t1 == t2).should be_false

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -188,7 +188,7 @@ describe Time do
 
   describe ".now" do
     it "current time is similar in different locations" do
-      (Time.now - Time.utc_now).should be_close(0.seconds, 1.second)
+      (Time.now - Time.utc).should be_close(0.seconds, 1.second)
       (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
     end
   end
@@ -411,7 +411,7 @@ describe Time do
     end
 
     it "preserves location when adding" do
-      time = Time.utc_now
+      time = Time.utc
       time.utc?.should be_true
 
       (time + 5.minutes).utc?.should be_true

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -188,8 +188,8 @@ describe Time do
 
   describe ".local without arguments" do
     it "current time is similar in different locations" do
-      (Time.now - Time.utc).should be_close(0.seconds, 1.second)
-      (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
+      (Time.local - Time.utc).should be_close(0.seconds, 1.second)
+      (Time.local - Time.local(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
     end
   end
 
@@ -211,7 +211,7 @@ describe Time do
   end
 
   it "#clone" do
-    time = Time.now
+    time = Time.local
     (time == time.clone).should be_true
   end
 
@@ -416,8 +416,9 @@ describe Time do
 
       (time + 5.minutes).utc?.should be_true
 
-      time = Time.now
-      (time + 5.minutes).location.should eq time.location
+      location = Time::Location.fixed(1234)
+      time = Time.local(location)
+      (time + 5.minutes).location.should eq location
     end
   end
 
@@ -476,7 +477,7 @@ describe Time do
     end
 
     it "compares different locations" do
-      time = Time.now
+      time = Time.local(Time::Location.fixed(1234))
       (time.to_utc <=> time).should eq(0)
     end
   end
@@ -489,7 +490,7 @@ describe Time do
     end
 
     it "gets unix seconds at GMT" do
-      t1 = Time.now
+      t1 = Time.local(Time::Location.fixed(1234))
       t1.to_unix.should eq(t1.to_utc.to_unix)
       t1.to_unix_f.should be_close(t1.to_utc.to_unix_f, 1e-01)
     end
@@ -638,7 +639,7 @@ describe Time do
   end
 
   it "does diff of utc vs local time" do
-    local = Time.now
+    local = Time.local(Time::Location.fixed(1234))
     utc = local.to_utc
     (utc - local).should eq(0.seconds)
     (local - utc).should eq(0.seconds)
@@ -648,7 +649,7 @@ describe Time do
     it "changes location" do
       location = Time::Location.fixed(3600)
       location2 = Time::Location.fixed(12345)
-      time1 = Time.now(location)
+      time1 = Time.local(location)
       time1.location.should eq(location)
 
       time2 = time1.in(location2)
@@ -661,7 +662,7 @@ describe Time do
     it "keeps wall clock" do
       location = Time::Location.fixed(3600)
       location2 = Time::Location.fixed(12345)
-      time1 = Time.now(location)
+      time1 = Time.local(location)
       time1.location.should eq(location)
 
       time2 = time1.to_local_in(location2)
@@ -678,7 +679,7 @@ describe Time do
     it "is the difference of offsets apart" do
       location = Time::Location.fixed(3600)
       location2 = Time::Location.fixed(12345)
-      time1 = Time.now(location)
+      time1 = Time.local(location)
       time2 = time1.to_local_in(location2)
 
       (time2 - time1).should eq (time1.offset - time2.offset).seconds
@@ -816,11 +817,11 @@ describe Time do
     end
   end
 
-  typeof(Time.now.year)
+  typeof(Time.local.year)
   typeof(1.minute.from_now.year)
   typeof(1.minute.ago.year)
   typeof(1.month.from_now.year)
   typeof(1.month.ago.year)
-  typeof(Time.now.to_utc)
-  typeof(Time.now.to_local)
+  typeof(Time.local.to_utc)
+  typeof(Time.local.to_local)
 end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -103,15 +103,15 @@ CALENDAR_WEEK_TEST_DATA = [
 ]
 
 describe Time do
-  describe ".new" do
+  describe ".local" do
     it "initializes" do
-      t1 = Time.new 2002, 2, 25
+      t1 = Time.local 2002, 2, 25
       t1.year.should eq(2002)
       t1.month.should eq(2)
       t1.day.should eq(25)
       t1.local?.should be_true
 
-      t2 = Time.new 2002, 2, 25, 15, 25, 13, nanosecond: 8
+      t2 = Time.local 2002, 2, 25, 15, 25, 13, nanosecond: 8
       t2.year.should eq(2002)
       t2.month.should eq(2)
       t2.day.should eq(25)
@@ -123,7 +123,7 @@ describe Time do
     end
 
     it "initializes max value" do
-      time = Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999)
+      time = Time.local(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999)
       time.year.should eq(9999)
       time.month.should eq(12)
       time.day.should eq(31)
@@ -135,13 +135,13 @@ describe Time do
 
     it "fails with negative nanosecond" do
       expect_raises ArgumentError, "Invalid time" do
-        Time.new(9999, 12, 31, 23, 59, 59, nanosecond: -1)
+        Time.local(9999, 12, 31, 23, 59, 59, nanosecond: -1)
       end
     end
 
     it "fails with too big nanoseconds" do
       expect_raises ArgumentError, "Invalid time" do
-        Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 1_000_000_000)
+        Time.local(9999, 12, 31, 23, 59, 59, nanosecond: 1_000_000_000)
       end
     end
 
@@ -186,7 +186,7 @@ describe Time do
     time.utc?.should be_true
   end
 
-  describe ".now" do
+  describe ".local without arguments" do
     it "current time is similar in different locations" do
       (Time.now - Time.utc).should be_close(0.seconds, 1.second)
       (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
@@ -243,8 +243,8 @@ describe Time do
       {5 * 3600, 1, 0, -1, -5 * 3600}.each do |offset|
         location = Time::Location.fixed(offset)
 
-        time = Time.new(1, 1, 1, location: location)
-        time.shift(0, 1).should eq Time.new(1, 1, 1, nanosecond: 1, location: location)
+        time = Time.local(1, 1, 1, location: location)
+        time.shift(0, 1).should eq Time.local(1, 1, 1, nanosecond: 1, location: location)
         time.shift(0, 0).should eq time
         expect_raises(ArgumentError) do
           time.shift(0, -1)
@@ -256,8 +256,8 @@ describe Time do
       {5 * 3600, 1, 0, -1, -5 * 3600}.each do |offset|
         location = Time::Location.fixed(offset)
 
-        time = Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: location)
-        time.shift(0, -1).should eq Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_998, location: location)
+        time = Time.local(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: location)
+        time.shift(0, -1).should eq Time.local(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_998, location: location)
         time.shift(0, 0).should eq time
         expect_raises(ArgumentError) do
           time.shift(0, 1)
@@ -276,7 +276,7 @@ describe Time do
         # because it skipped 2011-12-28 due to changing time zone from -11:00 to +13:00.
         with_zoneinfo do
           samoa = Time::Location.load("Pacific/Apia")
-          start = Time.new(2011, 12, 25, 0, 0, 0, location: samoa)
+          start = Time.local(2011, 12, 25, 0, 0, 0, location: samoa)
 
           plus_one_week = start.shift days: 7
           plus_one_week.should eq start + 6.days
@@ -290,7 +290,7 @@ describe Time do
         # Venezuela switched from -4:30 to -4:00 on 2016-05-01, the hour between 2:00 and 3:00 lasted only 30 minutes
         with_zoneinfo do
           venezuela = Time::Location.load("America/Caracas")
-          start = Time.new(2016, 5, 1, 2, 0, 0, location: venezuela)
+          start = Time.local(2016, 5, 1, 2, 0, 0, location: venezuela)
           plus_one_hour = start.shift hours: 1
           plus_one_hour.should eq start + 30.minutes
         end
@@ -314,7 +314,7 @@ describe Time do
       it "over dst" do
         with_zoneinfo do
           location = Time::Location.load("Europe/Berlin")
-          reference = Time.new(2017, 10, 28, 13, 37, location: location)
+          reference = Time.local(2017, 10, 28, 13, 37, location: location)
           next_day = reference.shift days: 1
 
           next_day.should eq reference + 25.hours
@@ -498,17 +498,17 @@ describe Time do
   describe "#to_s" do
     it "prints string" do
       with_zoneinfo do
-        time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location::UTC)
+        time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location::UTC)
         time.to_s.should eq "2017-11-25 22:06:17 UTC"
 
-        time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7200))
+        time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7200))
         time.to_s.should eq "2017-11-25 22:06:17 -02:00"
 
-        time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7259))
+        time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7259))
         time.to_s.should eq "2017-11-25 22:06:17 -02:00:59"
 
         location = Time::Location.load("Europe/Berlin")
-        time = Time.new(2017, 11, 25, 22, 6, 17, location: location)
+        time = Time.local(2017, 11, 25, 22, 6, 17, location: location)
         time.to_s.should eq "2017-11-25 22:06:17 +01:00"
       end
     end
@@ -529,20 +529,20 @@ describe Time do
     it "prints offset for location" do
       with_zoneinfo do
         location = Time::Location.load("Europe/Berlin")
-        Time.new(2014, 10, 30, 21, 18, 13, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
-        Time.new(2014, 10, 30, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
+        Time.local(2014, 10, 30, 21, 18, 13, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
+        Time.local(2014, 10, 30, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
 
-        Time.new(2014, 10, 10, 21, 18, 13, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
-        Time.new(2014, 10, 10, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
+        Time.local(2014, 10, 10, 21, 18, 13, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
+        Time.local(2014, 10, 10, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
       end
     end
 
     it "prints offset for fixed location" do
       location = Time::Location.fixed(3601)
-      Time.new(2014, 1, 2, 3, 4, 5, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
-      Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
+      Time.local(2014, 1, 2, 3, 4, 5, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
+      Time.local(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
 
-      t = Time.new 2014, 10, 30, 21, 18, 13, location: Time::Location.fixed(-9000)
+      t = Time.local 2014, 10, 30, 21, 18, 13, location: Time::Location.fixed(-9000)
       t.to_s.should eq("2014-10-30 21:18:13 -02:30")
     end
 
@@ -553,7 +553,7 @@ describe Time do
         location = Time::Location.new "Local", [Time::Location::Zone.new("STZ", 3600, false), Time::Location::Zone.new("DTZ", -3600, false)], [] of Time::Location::ZoneTransition
         Time::Location.local = location
 
-        Time.new(2014, 10, 30, 21, 18, 13).to_s.should eq("2014-10-30 21:18:13 +01:00")
+        Time.local(2014, 10, 30, 21, 18, 13).to_s.should eq("2014-10-30 21:18:13 +01:00")
       ensure
         Time::Location.local = old_local
       end
@@ -566,13 +566,13 @@ describe Time do
 
     with_zoneinfo do
       location = Time::Location.load("Europe/Berlin")
-      Time.new(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00 Europe/Berlin"
-      Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00 Europe/Berlin"
+      Time.local(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00 Europe/Berlin"
+      Time.local(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00 Europe/Berlin"
     end
 
     location = Time::Location.fixed(3601)
-    Time.new(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00:01"
-    Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00:01"
+    Time.local(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00:01"
+    Time.local(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00:01"
   end
 
   it "at methods" do
@@ -687,17 +687,17 @@ describe Time do
 
   it "#to_s" do
     with_zoneinfo do
-      time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location::UTC)
+      time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location::UTC)
       time.to_s.should eq "2017-11-25 22:06:17 UTC"
 
-      time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7200))
+      time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7200))
       time.to_s.should eq "2017-11-25 22:06:17 -02:00"
 
-      time = Time.new(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7259))
+      time = Time.local(2017, 11, 25, 22, 6, 17, location: Time::Location.fixed(-7259))
       time.to_s.should eq "2017-11-25 22:06:17 -02:00:59"
 
       location = Time::Location.load("Europe/Berlin")
-      time = Time.new(2017, 11, 25, 22, 6, 17, location: location)
+      time = Time.local(2017, 11, 25, 22, 6, 17, location: location)
       time.to_s.should eq "2017-11-25 22:06:17 +01:00"
     end
   end
@@ -796,8 +796,8 @@ describe Time do
           it "W#{week_date.join('-')} eq #{date.join('-')}" do
             Time.week_date(*week_date, location: Time::Location::UTC).should eq(Time.utc(*date))
             Time.week_date(week_date[0], week_date[1], Time::DayOfWeek.from_value(week_date[2]), location: Time::Location::UTC).should eq(Time.utc(*date))
-            Time.week_date(*week_date).should eq(Time.new(*date))
-            Time.week_date(*week_date, location: location).should eq(Time.new(*date, location: location))
+            Time.week_date(*week_date).should eq(Time.local(*date))
+            Time.week_date(*week_date, location: location).should eq(Time.local(*date, location: location))
           end
         end
       end
@@ -807,11 +807,11 @@ describe Time do
       with_zoneinfo do
         location = Time::Location.load("Europe/Berlin")
         Time.week_date(*CALENDAR_WEEK_TEST_DATA[0][1], 11, 57, 32, nanosecond: 123_567, location: location).should eq(
-          Time.new(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
+          Time.local(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
 
         location = Time::Location.load("America/Buenos_Aires")
         Time.week_date(*CALENDAR_WEEK_TEST_DATA[0][1], 11, 57, 32, nanosecond: 123_567, location: location).should eq(
-          Time.new(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
+          Time.local(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
       end
     end
   end

--- a/spec/std/zip/zip_spec.cr
+++ b/spec/std/zip/zip_spec.cr
@@ -35,7 +35,7 @@ describe Zip do
   it "writes entry" do
     io = IO::Memory.new
 
-    time = Time.new(2017, 1, 14, 2, 3, 4)
+    time = Time.utc(2017, 1, 14, 2, 3, 4)
     extra = Bytes[1, 2, 3, 4]
 
     Zip::Writer.open(io) do |zip|

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -124,7 +124,7 @@ class Crystal::Program
 
     # First, update times for the program dir, so it remains in the cache longer
     # (this is specially useful if a macro run program is used by multiple programs)
-    now = Time.utc_now
+    now = Time.utc
     File.utime(now, now, program_dir)
 
     if can_reuse_previous_compilation?(filename, executable_path, recorded_requires_path, requires_path)

--- a/src/compiler/crystal/tools/init/template/license.ecr
+++ b/src/compiler/crystal/tools/init/template/license.ecr
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <%= Time.now.year %> <%= config.author %>
+Copyright (c) <%= Time.local.year %> <%= config.author %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -88,7 +88,7 @@ module Crystal::System::Time
 
     transitions = [] of ::Time::Location::ZoneTransition
 
-    current_year = ::Time.utc_now.year
+    current_year = ::Time.utc.year
 
     (current_year - 100).upto(current_year + 100) do |year|
       tstamp = calculate_switchdate_in_year(year, first_date) - (zones[second_index].offset)

--- a/src/file.cr
+++ b/src/file.cr
@@ -846,7 +846,7 @@ class File < IO::FileDescriptor
   # in the *filename* parameter to the value given in *time*.
   #
   # If the file does not exist, it will be created.
-  def self.touch(filename : String, time : Time = Time.utc_now)
+  def self.touch(filename : String, time : Time = Time.utc)
     open(filename, "a") { } unless exists?(filename)
     utime time, time, filename
   end

--- a/src/file/tempfile.cr
+++ b/src/file/tempfile.cr
@@ -17,7 +17,7 @@ class File
         io << '-'
       end
 
-      io << Time.now.to_s("%Y%m%d")
+      io << Time.local.to_s("%Y%m%d")
       io << '-'
 
       {% unless flag?(:win32) %}

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -77,7 +77,7 @@ module FileUtils
   # ```
   #
   # NOTE: Alias of `File.touch`
-  def touch(path : String, time : Time = Time.utc_now)
+  def touch(path : String, time : Time = Time.utc)
     File.touch(path, time)
   end
 
@@ -89,7 +89,7 @@ module FileUtils
   # ```
   # FileUtils.touch(["foo", "bar"])
   # ```
-  def touch(paths : Enumerable(String), time : Time = Time.utc_now)
+  def touch(paths : Enumerable(String), time : Time = Time.utc)
     paths.each do |path|
       touch(path, time)
     end

--- a/src/gzip/header.cr
+++ b/src/gzip/header.cr
@@ -18,7 +18,7 @@ class Gzip::Header
 
   # :nodoc:
   def initialize
-    @modification_time = Time.new
+    @modification_time = Time.utc
     @os = 255_u8 # Unknown
   end
 

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -179,7 +179,7 @@ module HTTP
     #
     # ```
     # response = HTTP::Client::Response.new(200)
-    # response.cookies["foo"] = HTTP::Cookie.new("foo", "bar", "/admin", Time.now + 12.hours, secure: true)
+    # response.cookies["foo"] = HTTP::Cookie.new("foo", "bar", "/admin", Time.utc + 12.hours, secure: true)
     # ```
     def []=(key, value : Cookie)
       unless key == value.name

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -44,7 +44,7 @@ module HTTP
 
     def expired?
       if e = expires
-        e < Time.utc_now
+        e < Time.utc
       else
         false
       end
@@ -101,7 +101,7 @@ module HTTP
         return unless match
 
         expires = if max_age = match["max_age"]?
-                    Time.utc_now + max_age.to_i.seconds
+                    Time.utc + max_age.to_i.seconds
                   else
                     parse_time(match["expires"]?)
                   end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -152,7 +152,7 @@ class Logger
   # severity. *progname* overrides a default progname set in this logger.
   def log(severity, message, progname = nil)
     return if severity < level || !@io
-    write(severity, Time.now, progname || @progname, message)
+    write(severity, Time.local, progname || @progname, message)
   end
 
   # Logs the message as returned from the given block if *severity*
@@ -160,7 +160,7 @@ class Logger
   # if *severity* is lower. *progname* overrides a default progname set in this logger.
   def log(severity, progname = nil)
     return if severity < level || !@io
-    write(severity, Time.now, progname || @progname, yield)
+    write(severity, Time.local, progname || @progname, yield)
   end
 
   private def write(severity, datetime, progname, message)

--- a/src/oauth/oauth.cr
+++ b/src/oauth/oauth.cr
@@ -49,7 +49,7 @@ module OAuth
   end
 
   private def self.oauth_header(client, request, token, token_secret, consumer_key, consumer_secret, extra_params)
-    ts = Time.utc_now.to_unix.to_s
+    ts = Time.utc.to_unix.to_s
     nonce = Random::Secure.hex
 
     signature = Signature.new consumer_key, consumer_secret, token, token_secret, extra_params

--- a/src/oauth2/access_token/access_token.cr
+++ b/src/oauth2/access_token/access_token.cr
@@ -35,7 +35,7 @@ abstract class OAuth2::AccessToken
     when "bearer"
       Bearer.new(access_token, expires_in, refresh_token, scope, extra)
     when "mac"
-      Mac.new(access_token, expires_in, mac_algorithm.not_nil!, mac_key.not_nil!, refresh_token, scope, Time.utc_now.to_unix, extra)
+      Mac.new(access_token, expires_in, mac_algorithm.not_nil!, mac_key.not_nil!, refresh_token, scope, Time.utc.to_unix, extra)
     else
       raise "Unknown token_type in access token json: #{token_type}"
     end

--- a/src/oauth2/access_token/mac.cr
+++ b/src/oauth2/access_token/mac.cr
@@ -12,7 +12,7 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
   property mac_key : String
   property issued_at : Int64
 
-  def initialize(access_token, expires_in, @mac_algorithm, @mac_key, refresh_token = nil, scope = nil, @issued_at = Time.utc_now.to_unix, extra = nil)
+  def initialize(access_token, expires_in, @mac_algorithm, @mac_key, refresh_token = nil, scope = nil, @issued_at = Time.utc.to_unix, extra = nil)
     super(access_token, expires_in, refresh_token, scope, extra)
   end
 
@@ -21,7 +21,7 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
   end
 
   def authenticate(request : HTTP::Request, tls)
-    ts = Time.utc_now.to_unix
+    ts = Time.utc.to_unix
     nonce = "#{ts - @issued_at}:#{Random::Secure.hex}"
     method = request.method
     uri = request.resource

--- a/src/oauth2/session.cr
+++ b/src/oauth2/session.cr
@@ -12,7 +12,7 @@ class OAuth2::Session
   #   * *access_token*: the OAuth2::AccessToken to make requests.
   #   * *expires_at*: the Time when the access token expires.
   #   * *callback*: invoked when an access token is refreshed, giving you a chance to persist it.
-  def initialize(@oauth2_client : Client, @access_token : AccessToken, @expires_at = Time.utc_now, &@callback : OAuth2::Session ->)
+  def initialize(@oauth2_client : Client, @access_token : AccessToken, @expires_at = Time.utc, &@callback : OAuth2::Session ->)
   end
 
   # Authenticates an `HTTP::Client`, refreshing the access token if it is expired.
@@ -33,7 +33,7 @@ class OAuth2::Session
 
   private def access_token_expired?
     if expires_at = @expires_at
-      Time.utc_now >= expires_at
+      Time.utc >= expires_at
     else
       false
     end
@@ -45,7 +45,7 @@ class OAuth2::Session
 
     expires_in = @access_token.expires_in
     if expires_in
-      @expires_at = Time.utc_now + expires_in.seconds
+      @expires_at = Time.utc + expires_in.seconds
     else
       # If there's no expires_in in the access token, we assume it never expires
       @expires_at = nil

--- a/src/object.cr
+++ b/src/object.cr
@@ -331,7 +331,7 @@ class Object
     #
     # ```
     # class Person
-    #   {{macro_prefix}}getter(birth_date) { Time.now }
+    #   {{macro_prefix}}getter(birth_date) { Time.local }
     # end
     # ```
     #
@@ -341,7 +341,7 @@ class Object
     # class Person
     #   def {{method_prefix}}birth_date
     #     if (value = {{var_prefix}}birth_date).nil?
-    #       {{var_prefix}}birth_date = Time.now
+    #       {{var_prefix}}birth_date = Time.local
     #     else
     #       value
     #     end
@@ -794,7 +794,7 @@ class Object
     #
     # ```
     # class Person
-    #   {{macro_prefix}}property(birth_date) { Time.now }
+    #   {{macro_prefix}}property(birth_date) { Time.local }
     # end
     # ```
     #
@@ -804,7 +804,7 @@ class Object
     # class Person
     #   def {{method_prefix}}birth_date
     #     if (value = {{var_prefix}}birth_date).nil?
-    #       {{var_prefix}}birth_date = Time.now
+    #       {{var_prefix}}birth_date = Time.local
     #     else
     #       value
     #     end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -206,7 +206,7 @@ class Socket < IO
   #
   # server = TCPServer.new(2202)
   # socket = server.accept
-  # socket.puts Time.now
+  # socket.puts Time.utc
   # socket.close
   # ```
   def accept
@@ -223,7 +223,7 @@ class Socket < IO
   #
   # server = TCPServer.new(2202)
   # if socket = server.accept?
-  #   socket.puts Time.now
+  #   socket.puts Time.utc
   #   socket.close
   # end
   # ```

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -42,7 +42,7 @@ class Socket
     #
     # server = TCPServer.new(2202)
     # server.accept do |socket|
-    #   socket.puts Time.now
+    #   socket.puts Time.utc
     # end
     # ```
     def accept
@@ -65,7 +65,7 @@ class Socket
     #
     # server = UNIXServer.new("/tmp/service.sock")
     # server.accept? do |socket|
-    #   socket.puts Time.now
+    #   socket.puts Time.utc
     # end
     # ```
     def accept?

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -8,7 +8,7 @@ class Socket
     # server = TCPServer.new(2202)
     # while true
     #   socket = server.accept
-    #   socket.puts Time.utc_now
+    #   socket.puts Time.utc
     #   socket.close
     # end
     # ```
@@ -25,7 +25,7 @@ class Socket
     #
     # server = TCPServer.new(2202)
     # while socket = server.accept?
-    #   socket.puts Time.utc_now
+    #   socket.puts Time.utc
     #   socket.close
     # end
     # ```

--- a/src/time.cr
+++ b/src/time.cr
@@ -21,9 +21,9 @@ require "crystal/system/time"
 # current time:
 #
 # ```crystal
-# Time.utc                                      # returns the current time in UTC
-# Time.now Time::Location.load("Europe/Berlin") # returns the current time in time zone Europe/Berlin
-# Time.now                                      # returns the current time in current time zone
+# Time.utc                                        # returns the current time in UTC
+# Time.local Time::Location.load("Europe/Berlin") # returns the current time in time zone Europe/Berlin
+# Time.local                                      # returns the current time in current time zone
 # ```
 #
 # It is generally recommended to keep instances in UTC and only apply a
@@ -173,7 +173,7 @@ require "crystal/system/time"
 # suitable for accurately measuring elapsed time.
 #
 # Instances of `Time` are focused on telling time – using a "wall clock".
-# When `Time.now` is called multiple times, the difference between the
+# When `Time.local` is called multiple times, the difference between the
 # returned instances is not guaranteed to equal to the time elapsed between
 # making the calls; even the order of the returned `Time` instances might
 # not reflect invocation order.
@@ -358,21 +358,15 @@ struct Time
 
   # Creates a new `Time` instance representing the current time from the
   # system clock observed in *location* (defaults to local time zone).
-  def self.new(location : Location = Location.local) : Time
+  def self.local(location : Location = Location.local) : Time
     seconds, nanoseconds = Crystal::System::Time.compute_utc_seconds_and_nanoseconds
     new(seconds: seconds, nanoseconds: nanoseconds, location: location)
   end
 
   # Creates a new `Time` instance representing the current time from the
-  # system clock observed in *location* (defaults to local time zone).
-  def self.now(location : Location = Location.local) : Time
-    new(location)
-  end
-
-  # Creates a new `Time` instance representing the current time from the
   # system clock in UTC.
   def self.utc : Time
-    now(Location::UTC)
+    local(Location::UTC)
   end
 
   # Creates a new `Time` instance representing the given local date-time in

--- a/src/time.cr
+++ b/src/time.cr
@@ -38,7 +38,7 @@ require "crystal/system/time"
 # ```
 # time = Time.utc(2016, 2, 15, 10, 20, 30)
 # time.to_s # => 2016-02-15 10:20:30 UTC
-# time = Time.new(2016, 2, 15, 10, 20, 30, location: Time::Location.load("Europe/Berlin"))
+# time = Time.local(2016, 2, 15, 10, 20, 30, location: Time::Location.load("Europe/Berlin"))
 # time.to_s # => 2016-02-15 10:20:30 +01:00 Europe/Berlin
 # # The time-of-day can be omitted and defaults to midnight (start of day):
 # time = Time.utc(2016, 2, 15)
@@ -83,7 +83,7 @@ require "crystal/system/time"
 # `#offset` returns the offset of the current zone in seconds.
 #
 # ```
-# time = Time.new(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
+# time = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
 # time          # => 2018-03-08 22:05:13 +01:00 Europe/Berlin
 # time.location # => #<Time::Location Europe/Berlin>
 # time.zone     # => #<Time::Location::Zone CET +01:00 (3600s) STD>
@@ -104,7 +104,7 @@ require "crystal/system/time"
 # the same instant using `#in`:
 #
 # ```
-# time_de = Time.new(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
+# time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
 # time_ar = time_de.in Time::Location.load("America/Buenos_Aires")
 # time_de # => 2018-03-08 22:05:13 +01:00 Europe/Berlin
 # time_ar # => 2018-03-08 18:05:13 -03:00 America/Buenos_Aires
@@ -276,7 +276,7 @@ struct Time
   # `DayOfWeek` represents a day of the week in the Gregorian calendar.
   #
   # ```
-  # time = Time.new(2016, 2, 15)
+  # time = Time.local(2016, 2, 15)
   # time.day_of_week # => Time::DayOfWeek::Monday
   # ```
   #
@@ -379,7 +379,7 @@ struct Time
   # *location* (defaults to local time zone).
   #
   # ```
-  # time = Time.new(2016, 2, 15, 10, 20, 30, location: Time::Location.load("Europe/Berlin"))
+  # time = Time.local(2016, 2, 15, 10, 20, 30, location: Time::Location.load("Europe/Berlin"))
   # time.inspect # => "2016-02-15 10:20:30.0 +01:00 Europe/Berlin"
   # ```
   #
@@ -396,7 +396,7 @@ struct Time
   # The time-of-day can be omitted and defaults to midnight (start of day):
   #
   # ```
-  # time = Time.new(2016, 2, 15)
+  # time = Time.utc(2016, 2, 15)
   # time.to_s # => "2016-02-15 00:00:00 +00:00"
   # ```
   #
@@ -412,7 +412,7 @@ struct Time
   # In such cases, the choice of time zone, and therefore the time, is not
   # well-defined. This method returns a time that is correct in one of the two
   # zones involved in the transition, but it does not guarantee which.
-  def self.new(year : Int32, month : Int32, day : Int32, hour : Int32 = 0, minute : Int32 = 0, second : Int32 = 0, *, nanosecond : Int32 = 0, location : Location = Location.local) : Time
+  def self.local(year : Int32, month : Int32, day : Int32, hour : Int32 = 0, minute : Int32 = 0, second : Int32 = 0, *, nanosecond : Int32 = 0, location : Location = Location.local) : Time
     unless 1 <= year <= 9999 &&
            1 <= month <= 12 &&
            1 <= day <= Time.days_in_month(year, month) &&
@@ -464,7 +464,7 @@ struct Time
   # Since UTC does not have any time zone transitions, each date-time is
   # unambiguously resolved.
   def self.utc(year : Int32, month : Int32, day : Int32, hour : Int32 = 0, minute : Int32 = 0, second : Int32 = 0, *, nanosecond : Int32 = 0) : Time
-    new(year, month, day, hour, minute, second, nanosecond: nanosecond, location: Location::UTC)
+    local(year, month, day, hour, minute, second, nanosecond: nanosecond, location: Location::UTC)
   end
 
   # Creates a new `Time` instance that corresponds to the number of *seconds*
@@ -751,9 +751,9 @@ struct Time
   # nanoseconds) set to zero.
   #
   # This equals `at_beginning_of_day` or
-  # `Time.new(year, month, day, 0, 0, 0, nanoseconds: 0, location: location)`.
+  # `Time.local(year, month, day, 0, 0, 0, nanoseconds: 0, location: location)`.
   def date : Time
-    Time.new(year, month, day, location: location)
+    Time.local(year, month, day, location: location)
   end
 
   # Returns the year of the proleptic Georgian Calendar (`0..9999`).
@@ -971,8 +971,8 @@ struct Time
   # the instant time-line, even if they show a different local date-time.
   #
   # ```
-  # time_de = Time.new(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
-  # time_ar = Time.new(2018, 3, 8, 18, 5, 13, location: Time::Location.load("America/Buenos_Aires"))
+  # time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
+  # time_ar = Time.local(2018, 3, 8, 18, 5, 13, location: Time::Location.load("America/Buenos_Aires"))
   # time_de == time_ar # => true
   #
   # # both times represent the same instant:
@@ -1080,7 +1080,7 @@ struct Time
   # See `Time::Format` for details.
   #
   # ```
-  # time = Time.new(2016, 4, 5)
+  # time = Time.local(2016, 4, 5)
   # time.to_s("%F") # => "2016-04-05"
   # ```
   def to_s(format : String) : String
@@ -1260,7 +1260,7 @@ struct Time
   # the result because it retains the same instant.
   #
   # ```
-  # time_de = Time.new(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
+  # time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
   # time_ar = time_de.in Time::Location.load("America/Buenos_Aires")
   # time_de # => 2018-03-08 22:05:13 +01:00 Europe/Berlin
   # time_ar # => 2018-03-08 18:05:13 -03:00 America/Buenos_Aires
@@ -1322,12 +1322,12 @@ struct Time
     end
   end
 
-  def_at_beginning(year) { Time.new(year, 1, 1, location: location) }
-  def_at_beginning(semester) { Time.new(year, ((month - 1) / 6) * 6 + 1, 1, location: location) }
-  def_at_beginning(quarter) { Time.new(year, ((month - 1) / 3) * 3 + 1, 1, location: location) }
-  def_at_beginning(month) { Time.new(year, month, 1, location: location) }
-  def_at_beginning(day) { Time.new(year, month, day, location: location) }
-  def_at_beginning(hour) { Time.new(year, month, day, hour, location: location) }
+  def_at_beginning(year) { Time.local(year, 1, 1, location: location) }
+  def_at_beginning(semester) { Time.local(year, ((month - 1) / 6) * 6 + 1, 1, location: location) }
+  def_at_beginning(quarter) { Time.local(year, ((month - 1) / 3) * 3 + 1, 1, location: location) }
+  def_at_beginning(month) { Time.local(year, month, 1, location: location) }
+  def_at_beginning(day) { Time.local(year, month, day, location: location) }
+  def_at_beginning(hour) { Time.local(year, month, day, hour, location: location) }
 
   # Returns a copy of this `Time` representing the beginning of the minute.
   def at_beginning_of_minute : Time
@@ -1348,7 +1348,7 @@ struct Time
     (self - (day_of_week.value - 1).days).at_beginning_of_day
   end
 
-  def_at_end(year) { Time.new(year, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: location) }
+  def_at_end(year) { Time.local(year, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: location) }
 
   # Returns a copy of this `Time` representing the end of the semester.
   def at_end_of_semester : Time
@@ -1358,7 +1358,7 @@ struct Time
     else
       month, day = 12, 31
     end
-    Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location)
+    Time.local(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location)
   end
 
   # Returns a copy of this `Time` representing the end of the quarter.
@@ -1373,10 +1373,10 @@ struct Time
     else
       month, day = 12, 31
     end
-    Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location)
+    Time.local(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location)
   end
 
-  def_at_end(month) { Time.new(year, month, Time.days_in_month(year, month), 23, 59, 59, nanosecond: 999_999_999, location: location) }
+  def_at_end(month) { Time.local(year, month, Time.days_in_month(year, month), 23, 59, 59, nanosecond: 999_999_999, location: location) }
 
   # Returns a copy of this `Time` representing the end of the week.
   #
@@ -1385,8 +1385,8 @@ struct Time
     (self + (7 - day_of_week.value).days).at_end_of_day
   end
 
-  def_at_end(day) { Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location) }
-  def_at_end(hour) { Time.new(year, month, day, hour, 59, 59, nanosecond: 999_999_999, location: location) }
+  def_at_end(day) { Time.local(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location) }
+  def_at_end(hour) { Time.local(year, month, day, hour, 59, 59, nanosecond: 999_999_999, location: location) }
 
   # Returns a copy of this `Time` representing the end of the minute.
   def at_end_of_minute
@@ -1401,7 +1401,7 @@ struct Time
   # Returns a copy of this `Time` representing midday (`12:00`) of the same day.
   def at_midday : Time
     year, month, day = year_month_day_day_year
-    Time.new(year, month, day, 12, 0, 0, nanosecond: 0, location: location)
+    Time.local(year, month, day, 12, 0, 0, nanosecond: 0, location: location)
   end
 
   {% for name in DayOfWeek.constants %}

--- a/src/time.cr
+++ b/src/time.cr
@@ -21,7 +21,7 @@ require "crystal/system/time"
 # current time:
 #
 # ```crystal
-# Time.utc_now                                  # returns the current time in UTC
+# Time.utc                                      # returns the current time in UTC
 # Time.now Time::Location.load("Europe/Berlin") # returns the current time in time zone Europe/Berlin
 # Time.now                                      # returns the current time in current time zone
 # ```
@@ -179,9 +179,9 @@ require "crystal/system/time"
 # not reflect invocation order.
 #
 # ```
-# t1 = Time.utc_now
+# t1 = Time.utc
 # # operation that takes 1 minute
-# t2 = Time.utc_now
+# t2 = Time.utc
 # t2 - t1 # => ?
 # ```
 #
@@ -266,7 +266,7 @@ struct Time
   # Can be used to create a `Time::Span` that represents an Unix Epoch time duration.
   #
   # ```
-  # Time.utc_now - Time::UNIX_EPOCH
+  # Time.utc - Time::UNIX_EPOCH
   # ```
   UNIX_EPOCH = utc(1970, 1, 1)
 
@@ -371,7 +371,7 @@ struct Time
 
   # Creates a new `Time` instance representing the current time from the
   # system clock in UTC.
-  def self.utc_now : Time
+  def self.utc : Time
     now(Location::UTC)
   end
 

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -52,7 +52,7 @@ struct Time::Format
         # If all components of a week date are available, they are used to create a Time instance
         time = Time.week_date calendar_week_year, calendar_week_week, day_of_week, @hour, @minute, @second, nanosecond: @nanosecond, location: location
       else
-        time = Time.new @year, @month, @day, @hour, @minute, @second, nanosecond: @nanosecond, location: location
+        time = Time.local @year, @month, @day, @hour, @minute, @second, nanosecond: @nanosecond, location: location
       end
 
       time = time.shift 0, @nanosecond_offset

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -17,7 +17,7 @@ require "./location/loader"
 # ```
 # location = Time::Location.load("Europe/Berlin")
 # location # => #<Time::Location Europe/Berlin>
-# time = Time.new(2016, 2, 15, 21, 1, 10, location: location)
+# time = Time.local(2016, 2, 15, 21, 1, 10, location: location)
 # time # => 2016-02-15 21:01:10 +01:00 Europe/Berlin
 # ```
 #
@@ -313,9 +313,9 @@ class Time::Location
   # The value can be changed to overwrite the system default:
   #
   # ```
-  # Time.now.location # => #<Time::Location America/New_York>
+  # Time.local.location # => #<Time::Location America/New_York>
   # Time::Location.local = Time::Location.load("Europe/Berlin")
-  # Time.now.location # => #<Time::Location Europe/Berlin>
+  # Time.local.location # => #<Time::Location Europe/Berlin>
   # ```
   class_property(local : Location) { load_local }
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -13,7 +13,7 @@
 # Calculation between `Time` also returns a `Time::Span`.
 #
 # ```
-# span = Time.new(2015, 10, 10) - Time.new(2015, 9, 10)
+# span = Time.utc(2015, 10, 10) - Time.utc(2015, 9, 10)
 # span       # => 30.00:00:00
 # span.class # => Time::Span
 # ```

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -541,8 +541,8 @@ end
 # specified number of months.
 #
 # ```
-# Time.new(2016, 2, 1) + 13.months # => 2017-03-01 00:00:00
-# Time.new(2016, 2, 29) + 2.years  # => 2018-02-28 00:00:00
+# Time.local(2016, 2, 1) + 13.months # => 2017-03-01 00:00:00
+# Time.local(2016, 2, 29) + 2.years  # => 2018-02-28 00:00:00
 # ```
 struct Time::MonthSpan
   # The number of months.

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -261,12 +261,12 @@ struct Time::Span
 
   # Returns a `Time` that happens later by `self` than the current time.
   def from_now : Time
-    Time.now + self
+    Time.local + self
   end
 
   # Returns a `Time` that happens earlier by `self` than the current time.
   def ago : Time
-    Time.now - self
+    Time.local - self
   end
 
   def -(other : self) : Time::Span
@@ -554,12 +554,12 @@ struct Time::MonthSpan
 
   # Returns a `Time` that happens N months after now.
   def from_now : Time
-    Time.now + self
+    Time.local + self
   end
 
   # Returns a `Time` that happens N months before now.
   def ago : Time
-    Time.now - self
+    Time.local - self
   end
 end
 

--- a/src/zip/file_info.cr
+++ b/src/zip/file_info.cr
@@ -65,7 +65,7 @@ module Zip::FileInfo
     {file_name_length, extra_field_length, time}
   end
 
-  def initialize(@filename : String, @time = Time.now, @comment = "", @extra = Bytes.empty)
+  def initialize(@filename : String, @time = Time.utc, @comment = "", @extra = Bytes.empty)
   end
 
   # Returns `true` if this entry is a directory.
@@ -151,7 +151,7 @@ module Zip::FileInfo
     minute = (time >> 5) & 0b111111
     second = (time & 0b11111) * 2
 
-    Time.new(year.to_i, month.to_i, day.to_i, hour.to_i, minute.to_i, second.to_i)
+    Time.utc(year.to_i, month.to_i, day.to_i, hour.to_i, minute.to_i, second.to_i)
   end
 
   private def to_dos

--- a/src/zip/writer.cr
+++ b/src/zip/writer.cr
@@ -62,7 +62,7 @@ class Zip::Writer
   end
 
   # Adds an entry that will have the given *filename* and current
-  # time (`Time.now`) and yields an `IO` to write that entry's
+  # time (`Time.utc`) and yields an `IO` to write that entry's
   # contents.
   def add(filename : String)
     add(Entry.new(filename)) do |io|
@@ -81,7 +81,7 @@ class Zip::Writer
   # size and uncompressed size will be computed from the data
   # written to the yielded IO.
   #
-  # You can also set the Entry's time (which is `Time.now` by default)
+  # You can also set the Entry's time (which is `Time.utc` by default)
   #  and extra data before adding it to the zip stream.
   def add(entry : Entry)
     # bit 3: unknown compression size (not needed for STORED, by if left out it doesn't work...)


### PR DESCRIPTION
This is a follow-up to #5321 which added the `Time.utc` constructor.

I think this constructor should allso be callable without arguments resembling `Time.new` with location UTC. You can use `Time.new()` for the *current* and `Time.new(2017, 12, 4, 12, 51)` for a *specific* time instance in local time. `Time.utc(2017, 12, 4, 12, 51)` and `Time.utc()` should be usable in the same way to get time instances in UTC.

There is already `Time.utc_now` which could stick around as an alias like `Time.now` for `Time.new` or we could remove it.