### PR TITLE
Fix: String#gsub replacing ascii chars to work in non-ascii string

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1248,6 +1248,10 @@ describe "String" do
       s.gsub('x', "yz").should be(s)
     end
 
+    it "gsubs char with char in non-ascii string" do
+      "/ä".gsub('/', '-').should eq("-ä")
+    end
+
     it "gsubs char with string depending on the char" do
       replaced = "foobar".gsub do |char|
         case char

--- a/src/string.cr
+++ b/src/string.cr
@@ -2014,7 +2014,7 @@ class String
     end
 
     if includes?(char)
-      if replacement.is_a?(Char) && char.ascii? && replacement.ascii? && ascii_only?
+      if replacement.is_a?(Char) && char.ascii? && replacement.ascii?
         return gsub_ascii_char(char, replacement)
       end
 
@@ -2026,11 +2026,11 @@ class String
 
   private def gsub_ascii_char(char, replacement)
     String.new(bytesize) do |buffer|
-      each_char_with_index do |my_char, i|
-        buffer[i] = if my_char == char
+      to_slice.each_with_index do |byte, i|
+        buffer[i] = if char === byte
                       replacement.ord.to_u8
                     else
-                      unsafe_byte_at(i)
+                      byte
                     end
       end
       {bytesize, bytesize}

--- a/src/string.cr
+++ b/src/string.cr
@@ -2027,11 +2027,11 @@ class String
   private def gsub_ascii_char(char, replacement)
     String.new(bytesize) do |buffer|
       to_slice.each_with_index do |byte, i|
-        buffer[i] = if char === byte
-                      replacement.ord.to_u8
-                    else
-                      byte
-                    end
+        if char.ord == byte
+          buffer[i] = replacement.ord.to_u8
+        else
+          buffer[i] = byte
+        end
       end
       {bytesize, bytesize}
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2014,7 +2014,7 @@ class String
     end
 
     if includes?(char)
-      if replacement.is_a?(Char) && char.ascii? && replacement.ascii?
+      if replacement.is_a?(Char) && char.ascii? && replacement.ascii? && ascii_only?
         return gsub_ascii_char(char, replacement)
       end
 


### PR DESCRIPTION
Fixes #5348