### PR TITLE
Avoid empty author and email

### DIFF
--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -5,8 +5,6 @@ require "option_parser"
 
 module Crystal
   module Init
-    WHICH_GIT_COMMAND = "which git >/dev/null"
-
     def self.run(args)
       config = Config.new
 
@@ -43,19 +41,27 @@ module Crystal
       InitProject.new(config).run
     end
 
+    def self.which_git_command
+      system("which git >/dev/null")
+    end
+
     def self.fetch_author
-      return "[your-name-here]" unless system(WHICH_GIT_COMMAND)
-      `git config --get user.name`.strip
+      default = "[your-name-here]"
+      return default unless self.which_git_command
+      user_name = `git config --get user.name`.strip
+      user_name.empty? ? default : user_name
     end
 
     def self.fetch_email
-      return "[your-email-here]" unless system(WHICH_GIT_COMMAND)
-      `git config --get user.email`.strip
+      default = "[your-email-here]"
+      return default unless which_git_command
+      user_email = `git config --get user.email`.strip
+      user_email.empty? ? default : user_email
     end
 
     def self.fetch_github_name
       default = "[your-github-name]"
-      return default unless system(WHICH_GIT_COMMAND)
+      return default unless which_git_command
       github_user = `git config --get github.user`.strip
       github_user.empty? ? default : github_user
     end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -5,6 +5,8 @@ require "option_parser"
 
 module Crystal
   module Init
+    WHICH_GIT_COMMAND = "which git >/dev/null"
+
     def self.run(args)
       config = Config.new
 
@@ -41,27 +43,23 @@ module Crystal
       InitProject.new(config).run
     end
 
-    def self.which_git_command
-      system("which git >/dev/null")
-    end
-
     def self.fetch_author
       default = "your-name-here"
-      return default unless self.which_git_command
+      return default unless system(WHICH_GIT_COMMAND)
       user_name = `git config --get user.name`.strip
       user_name.empty? ? default : user_name
     end
 
     def self.fetch_email
       default = "your-email-here"
-      return default unless self.which_git_command
+      return default unless system(WHICH_GIT_COMMAND)
       user_email = `git config --get user.email`.strip
       user_email.empty? ? default : user_email
     end
 
     def self.fetch_github_name
       default = "your-github-name"
-      return default unless self.which_git_command
+      return default unless system(WHICH_GIT_COMMAND)
       github_user = `git config --get github.user`.strip
       github_user.empty? ? default : github_user
     end
@@ -171,7 +169,7 @@ module Crystal
 
     class GitInitView < View
       def render
-        return unless self.which_git_command
+        return unless system(WHICH_GIT_COMMAND)
         return command if config.silent
         puts command
       end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -61,10 +61,10 @@ module Crystal
 
     def self.fetch_github_name
       if system(WHICH_GIT_COMMAND)
-        github_name = `git config --get github.name`.strip
-        github_name = nil if github_name.empty?
+        github_user = `git config --get github.user`.strip
+        github_user = nil if github_user.empty?
       end
-      github_name || "your-github-name"
+      github_user || "your-github-user"
     end
 
     def self.fetch_name(opts, args)

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -46,22 +46,22 @@ module Crystal
     end
 
     def self.fetch_author
-      default = "[your-name-here]"
+      default = "your-name-here"
       return default unless self.which_git_command
       user_name = `git config --get user.name`.strip
       user_name.empty? ? default : user_name
     end
 
     def self.fetch_email
-      default = "[your-email-here]"
-      return default unless which_git_command
+      default = "your-email-here"
+      return default unless self.which_git_command
       user_email = `git config --get user.email`.strip
       user_email.empty? ? default : user_email
     end
 
     def self.fetch_github_name
-      default = "[your-github-name]"
-      return default unless which_git_command
+      default = "your-github-name"
+      return default unless self.which_git_command
       github_user = `git config --get github.user`.strip
       github_user.empty? ? default : github_user
     end
@@ -171,7 +171,7 @@ module Crystal
 
     class GitInitView < View
       def render
-        return unless system(WHICH_GIT_COMMAND)
+        return unless self.which_git_command
         return command if config.silent
         puts command
       end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -44,24 +44,27 @@ module Crystal
     end
 
     def self.fetch_author
-      default = "your-name-here"
-      return default unless system(WHICH_GIT_COMMAND)
-      user_name = `git config --get user.name`.strip
-      user_name.empty? ? default : user_name
+      if system(WHICH_GIT_COMMAND)
+        user_name = `git config --get user.name`.strip
+        user_name = nil if user_name.empty?
+      end
+      user_name || "your-name-here"
     end
 
     def self.fetch_email
-      default = "your-email-here"
-      return default unless system(WHICH_GIT_COMMAND)
-      user_email = `git config --get user.email`.strip
-      user_email.empty? ? default : user_email
+      if system(WHICH_GIT_COMMAND)
+        user_email = `git config --get user.email`.strip
+        user_email = nil if user_email.empty?
+      end
+      user_email || "your-email-here"
     end
 
     def self.fetch_github_name
-      default = "your-github-name"
-      return default unless system(WHICH_GIT_COMMAND)
-      github_user = `git config --get github.user`.strip
-      github_user.empty? ? default : github_user
+      if system(WHICH_GIT_COMMAND)
+        github_name = `git config --get github.name`.strip
+        github_name = nil if github_name.empty?
+      end
+      github_name || "your-github-here"
     end
 
     def self.fetch_name(opts, args)

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -64,7 +64,7 @@ module Crystal
         github_name = `git config --get github.name`.strip
         github_name = nil if github_name.empty?
       end
-      github_name || "your-github-here"
+      github_name || "your-github-name"
     end
 
     def self.fetch_name(opts, args)


### PR DESCRIPTION
User may not also have `user.email` and `user.name` configured, so `fetch_email` and `fetch_author` will return an empty string (instead of `"[your-email-here]"` or `"[your-name-here]"`).

Suggested on https://github.com/amberframework/amber/pull/434#discussion_r154794069