### PR TITLE
Fix bcrypt hard limit on passwords to 71 bytes

### DIFF
--- a/spec/std/crypto/bcrypt_spec.cr
+++ b/spec/std/crypto/bcrypt_spec.cr
@@ -17,6 +17,7 @@ describe "Crypto::Bcrypt" do
     {5, latin1_pound_sign, "CCCCCCCCCCCCCCCCCCCCC.", "BvtRGGx3p8o0C5C36uS442Qqnrwofrq"},
     {5, utf8_pound_sign, "CCCCCCCCCCCCCCCCCCCCC.", "CAzSxlf0FLW7g1A5q7W/ZCj1xsN6A.e"},
     {5, bit8_unicode_pound_sign, "CCCCCCCCCCCCCCCCCCCCC.", "CAzSxlf0FLW7g1A5q7W/ZCj1xsN6A.e"},
+    {5, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789012345678", "VU6N0LbtX7trKLCg4Uf8qe", "5WYPzqIUUIrkveFjCbMg/hXc592OQLK"},
   ]
 
   it "computes digest vectors" do

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -5,6 +5,10 @@ require "./subtle"
 # Mazières, as [presented at USENIX in
 # 1999](https://www.usenix.org/legacy/events/usenix99/provos/provos_html/index.html).
 #
+# The algorithm has a maximum password length limit of 71 characters (see
+# [this comment](https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length#answer-39851)
+# on stackoverflow).
+#
 # Refer to `Crypto::Bcrypt::Password` for a higher level interface.
 #
 # About the Cost
@@ -31,7 +35,7 @@ class Crypto::Bcrypt
 
   DEFAULT_COST   = 11
   COST_RANGE     = 4..31
-  PASSWORD_RANGE = 1..51
+  PASSWORD_RANGE = 1..72
   SALT_SIZE      = 16
 
   private BLOWFISH_ROUNDS = 16


### PR DESCRIPTION
Despite the original Bcrypt paper claiming passwords have a maximum of 56 bytes, some implementations are compatible to up to 72 bytes; Ruby's BCrypt gem doesn't even enforce any limit.

I don't have enough knowledge to verify the claim, yet, increasing the limit to 72 —including the leading null byte, thus allowing a 71 bytes password— doesn't break the current digests. Please test and report!

closes #5353 