### PR TITLE
Tempfile: Add `Tempfile.tempname`

### DIFF
--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -2,6 +2,20 @@ require "spec"
 require "tempfile"
 
 describe Tempfile do
+  describe "tempname" do
+    it "creates a path without creating the file" do
+      path = Tempfile.tempname
+
+      File.exists?(path).should be_false
+    end
+
+    it "has the given extension" do
+      path = Tempfile.tempname ".sock"
+
+      File.extname(path).should eq(".sock")
+    end
+  end
+
   it "creates and writes" do
     tempfile = Tempfile.new "foo"
     tempfile.print "Hello!"

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -62,6 +62,25 @@ class Tempfile < IO::FileDescriptor
   # ```
   getter path : String
 
+  # Returns a fully-qualified path to a temporary file without actually
+  # creating the file.
+  #
+  # ```
+  # Tempfile.tempname # => "/tmp/20171206-1234-449386"
+  # ```
+  #
+  # The optional `extension` argument can be used to make the resulting
+  # filename to end with the given extension.
+  #
+  # ```
+  # Tempfile.tempname(".sock") # => "/tmp/20171206-1234-449386.sock"
+  # ```
+  def self.tempname(extension = nil)
+    time = Time.now.to_s("%Y%m%d")
+    rand = Random.rand(0x100000000).to_s(36)
+    File.join(dirname, "#{time}-#{Process.pid}-#{rand}#{extension}")
+  end
+
   # Creates a file with *filename* and *extension*, and yields it to the given
   # block. It is closed and returned at the end of this method call.
   #


### PR DESCRIPTION
This new method behaves similarly to the `Dir::Tempname.make_tmpname`
method in Ruby in that it creates a filename that is not likely
to currently exist on disk.

Some key differences:

* `tempname` is fully qualified with the value of `Tempfile.dirname`,
while `make_tmpname` was not fully qualified by default.

* `tempname` does not allow the user to specify a custom prefix.

* `tempname` does not allow the user to specify a custom trailing
identifier.

Like `make_tmpname` in Ruby, this implementation is susceptible to [TOCTOU](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use), and does not actually test for the file's existence beforehand -- it counts on the space of `Random.rand(0x100000000).to_s(36)` being large enough for most purposes.

I'm just learning Crystal, so please let me know if there's anything I can do to improve this PR!