### PR TITLE
INI::parse, .each_line is faster than .lines.each

### DIFF
--- a/src/ini.cr
+++ b/src/ini.cr
@@ -8,7 +8,7 @@ class INI
     ini = {} of String => Hash(String, String)
 
     section = ""
-    str.lines.each do |line|
+    str.each_line do |line|
       if line =~ /\s*(.*[^\s])\s*=\s*(.*[^\s])/
         ini[section] ||= {} of String => String if section == ""
         ini[section][$1] = $2


### PR DESCRIPTION
I am still quite new to Crystal, so forgive/educate me if I am overlooking something, but String#each_line seems to be faster than String#lines and then Array#each. Most likely because it does not have to generate an Array.

Sorry it is not the most exciting place to gain speed, but I guess every little helps.