### PR TITLE
Zip: avoid runtime modifications of deflate signature

### DIFF
--- a/src/zip/file_info.cr
+++ b/src/zip/file_info.cr
@@ -3,7 +3,7 @@ module Zip::FileInfo
   SIGNATURE                 = 0x04034b50
   DATA_DESCRIPTOR_SIGNATURE = 0x08074b50
 
-  DEFLATE_END_SIGNATURE = Bytes[80, 75, 7, 8]
+  DEFLATE_END_SIGNATURE = Bytes[80, 75, 7, 8, read_only: true]
 
   property version : UInt16 = Zip::VERSION
   property general_purpose_bit_flag = 0_u16


### PR DESCRIPTION
Freeze `DEFLATE_END_SIGNATURE` slice contents to avoid possible runtime alterations.

The constant is referenced at runtime when writing content to IO, so this change ensures the value written is consistent.

Thank you.
❤️ ❤️ ❤️ 