### PR TITLE
Ensure time parser raises if timezone is missing

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -624,6 +624,15 @@ describe Time do
     time.location.fixed?.should be_true
   end
 
+  it "raises when time zone missing" do
+    expect_raises(Time::Format::Error, "Invalid timezone") do
+      Time.parse("", "%z")
+    end
+    expect_raises(Time::Format::Error, "Invalid timezone") do
+      Time.parse("123456+01:00", "%3N%z")
+    end
+  end
+
   # TODO %Z
   # TODO %G
   # TODO %g

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -4,7 +4,8 @@
 {% end %}
 
 module HTTP
-  private DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
+  private DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y",
+                           "%a, %d %b %Y %H:%M:%S GMT", "%d %b %Y %H:%M:%S GMT", "%A, %d-%b-%y %H:%M:%S GMT", "%a %b %e %H:%M:%S %Y"}
 
   # :nodoc:
   MAX_HEADER_SIZE = 16_384

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -284,6 +284,8 @@ struct Time::Format
             @reader.pos = pos
           end
         end
+      else
+        raise "Invalid timezone"
       end
     end
 


### PR DESCRIPTION
Reviewing the changes from #5317 I noticed that the time parser does not raise if it expects a time zone but there is none. Until now it only raised if the format was detected as invalid, but not if it was entirely missing.

There might be similar issues in the time parser, but most other fields are at least somewhat tested while `%z` is not (#5324 will add some tests for `%z`).

/cc @bcardiff 