### PR TITLE
Improve division by zero exception

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -132,13 +132,13 @@ describe BigDecimal do
     BigDecimal.new("1.2621466432").should eq(BigDecimal.new("1.12345") * BigDecimal.new("1.123456"))
     BigDecimal.new("1.2621466432").should eq(BigDecimal.new("1.123456") * BigDecimal.new("1.12345"))
 
-    expect_raises(DivisionByZero) do
+    expect_raises(DivisionByZeroError) do
       BigDecimal.new(0) / BigDecimal.new(0)
     end
-    expect_raises(DivisionByZero) do
+    expect_raises(DivisionByZeroError) do
       BigDecimal.new(1) / BigDecimal.new(0)
     end
-    expect_raises(DivisionByZero) do
+    expect_raises(DivisionByZeroError) do
       BigDecimal.new(-1) / BigDecimal.new(0)
     end
     BigDecimal.new(1).should eq(BigDecimal.new(1) / BigDecimal.new(1))

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -95,7 +95,7 @@ describe "BigFloat" do
     it { ("0.04".to_big_f / "89.0001".to_big_f).to_s.should eq("0.000449437697261014313467") }
     it { ("-5.5".to_big_f / "5.5".to_big_f).to_s.should eq("-1") }
     it { ("5.5".to_big_f / "-5.5".to_big_f).to_s.should eq("-1") }
-    expect_raises(DivisionByZero) { 0.1.to_big_f / 0 }
+    expect_raises(DivisionByZeroError) { 0.1.to_big_f / 0 }
     it { ("5.5".to_big_f / 16_u64).to_s.should eq("0.34375") }
     it { ("5.5".to_big_f / 16_u8).to_s.should eq("0.34375") }
   end

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -208,29 +208,29 @@ describe "BigInt" do
   end
 
   it "raises if divides by zero" do
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10.to_big_i / 0.to_big_i
     end
 
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10.to_big_i / 0
     end
 
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10 / 0.to_big_i
     end
   end
 
   it "raises if mods by zero" do
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10.to_big_i % 0.to_big_i
     end
 
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10.to_big_i % 0
     end
 
-    expect_raises DivisionByZero do
+    expect_raises DivisionByZeroError do
       10 % 0.to_big_i
     end
   end

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -27,11 +27,11 @@ describe BigRational do
     BigRational.new(BigInt.new(10), BigInt.new(3))
                .should eq(BigRational.new(10, 3))
 
-    expect_raises(DivisionByZero) do
+    expect_raises(DivisionByZeroError) do
       BigRational.new(BigInt.new(2), BigInt.new(0))
     end
 
-    expect_raises(DivisionByZero) do
+    expect_raises(DivisionByZeroError) do
       BigRational.new(2, 0)
     end
   end
@@ -134,7 +134,7 @@ describe BigRational do
 
   it "#/" do
     (br(10, 7) / br(3, 7)).should eq(br(10, 3))
-    expect_raises(DivisionByZero) { br(10, 7) / br(0, 10) }
+    expect_raises(DivisionByZeroError) { br(10, 7) / br(0, 10) }
     (br(10, 7) / 3).should eq(br(10, 21))
     (1 / br(10, 7)).should eq(br(7, 10))
   end
@@ -145,7 +145,7 @@ describe BigRational do
 
   it "#inv" do
     (br(10, 3).inv).should eq(br(3, 10))
-    expect_raises(DivisionByZero) { br(0, 3).inv }
+    expect_raises(DivisionByZeroError) { br(0, 3).inv }
   end
 
   it "#abs" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -20,7 +20,7 @@ describe "Float" do
 
   describe "modulo" do
     it "raises when mods by zero" do
-      expect_raises(DivisionByZero) { 1.2.modulo 0.0 }
+      expect_raises(DivisionByZeroError) { 1.2.modulo 0.0 }
     end
 
     it { (13.0.modulo 4.0).should eq(1.0) }
@@ -35,7 +35,7 @@ describe "Float" do
 
   describe "remainder" do
     it "raises when mods by zero" do
-      expect_raises(DivisionByZero) { 1.2.remainder 0.0 }
+      expect_raises(DivisionByZeroError) { 1.2.remainder 0.0 }
     end
 
     it { (13.0.remainder 4.0).should eq(1.0) }

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -379,7 +379,7 @@ describe "Int" do
   end
 
   it "raises when divides by zero" do
-    expect_raises(DivisionByZero) { 1 / 0 }
+    expect_raises(DivisionByZeroError) { 1 / 0 }
     (4 / 2).should eq(2)
   end
 
@@ -393,7 +393,7 @@ describe "Int" do
   end
 
   it "raises when mods by zero" do
-    expect_raises(DivisionByZero) { 1 % 0 }
+    expect_raises(DivisionByZeroError) { 1 % 0 }
     (4 % 2).should eq(0)
   end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -276,7 +276,7 @@ struct BigDecimal < Number
   end
 
   private def check_division_by_zero(bd : BigDecimal)
-    raise DivisionByZero.new if bd.value == 0
+    raise DivisionByZeroError.new if bd.value == 0
   end
 
   private def power_ten_to(x : Int) : Int

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -125,7 +125,7 @@ struct BigFloat < Float
   end
 
   def /(other : Number)
-    raise DivisionByZero.new if other == 0
+    raise DivisionByZeroError.new if other == 0
     if other.is_a?(UInt8 | UInt16 | UInt32) || (LibGMP::ULong == UInt64 && other.is_a?(UInt64))
       BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, other) }
     else

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -457,7 +457,7 @@ struct BigInt < Int
 
   private def check_division_by_zero(value)
     if value == 0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     end
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -224,7 +224,7 @@ struct BigRational < Number
   end
 
   private def check_division_by_zero(value)
-    raise DivisionByZero.new if value == 0
+    raise DivisionByZeroError.new if value == 0
   end
 end
 

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -111,10 +111,10 @@ end
 # Raised when attempting to divide an integer by 0.
 #
 # ```
-# 1 / 0 # raises DivisionByZero (Division by zero)
+# 1 / 0 # raises DivisionByZero (Division by 0)
 # ```
-class DivisionByZero < Exception
-  def initialize(message = "Division by zero")
+class DivisionByZeroError < Exception
+  def initialize(message = "Division by 0")
     super(message)
   end
 end

--- a/src/float.cr
+++ b/src/float.cr
@@ -67,7 +67,7 @@ struct Float
 
   def modulo(other)
     if other == 0.0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     else
       self - other * self.fdiv(other).floor
     end
@@ -75,7 +75,7 @@ struct Float
 
   def remainder(other)
     if other == 0.0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     else
       mod = self % other
       return self.class.zero if mod == 0.0

--- a/src/int.cr
+++ b/src/int.cr
@@ -135,7 +135,7 @@ struct Int
 
   private def check_div_argument(other)
     if other == 0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     end
 
     {% begin %}
@@ -156,7 +156,7 @@ struct Int
   # See `Int#/` for more details.
   def %(other : Int)
     if other == 0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     elsif (self ^ other) >= 0
       self.unsafe_mod(other)
     else
@@ -172,7 +172,7 @@ struct Int
   # See `Int#div` for more details.
   def remainder(other : Int)
     if other == 0
-      raise DivisionByZero.new
+      raise DivisionByZeroError.new
     else
       unsafe_mod other
     end


### PR DESCRIPTION
Working on my Crystal book, I thought the error message related to `DivisionByZero` exception class could be better.

- Renamed the class to be `DivisionByZeroError` like the other exceptions directly inheriting from `Exception` as `InvalidByteSequenceError`, `KeyError` and others.
- Changed the message to be `Division by 0`

This PR:

```crystal
Division by 0 (DivisionByZeroError)
```

Before:

```crystal
Division by zero (DivisionByZero)
```


Thank you :heart: 
