### PR TITLE
pointerof lib external

### DIFF
--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -474,4 +474,29 @@ describe "Code gen: pointer" do
       ptr == ptr
       )).to_b.should be_true
   end
+
+  it "takes pointerof lib external var" do
+    test_c(
+      %(
+        int external_var = 0;
+      ),
+      %(
+        lib LibFoo
+          $external_var : Int32
+        end
+
+        LibFoo.external_var = 1
+
+        ptr = pointerof(LibFoo.external_var)
+        x = ptr.value
+
+        ptr.value = 10
+        y = ptr.value
+
+        ptr.value = 100
+        z = LibFoo.external_var
+
+        x + y + z
+      ), &.to_i.should eq(111))
+  end
 end

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -169,4 +169,14 @@ describe "Semantic: pointer" do
       ),
       "can't create instance of a pointer type"
   end
+
+  it "takes pointerof lib external var" do
+    assert_type(%(
+      lib LibFoo
+        $extern : Int32
+      end
+
+      pointerof(LibFoo.extern)
+      )) { pointer_of(int32) }
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -492,6 +492,11 @@ module Crystal
               when ReadInstanceVar
                 node_exp.obj.accept self
                 instance_var_ptr (node_exp.obj.type), node_exp.name, @last
+              when Call
+                # lib external var
+                extern = node_exp.dependencies.first.as(External)
+                var = get_external_var(extern)
+                check_c_fun extern.type, var
               else
                 raise "BUG: #{node}"
               end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -557,8 +557,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_primitive_external_var_get(node, target_def, call_args)
     external = target_def.as(External)
-    name = target_def.as(External).real_name
-    var = declare_lib_var name, node.type, external.thread_local?
+    var = get_external_var(external)
 
     if external.type.passed_by_value?
       @last = var
@@ -571,7 +570,12 @@ class Crystal::CodeGenVisitor
     @last
   end
 
-  def codegen_primitive_object_id(node, target_def, call_args)
+  def get_external_var(external)
+    name = external.as(External).real_name
+    declare_lib_var name, external.type, external.thread_local?
+  end
+
+  def codegen_primitive_object_id(node, external, call_args)
     ptr2int call_args[0], llvm_context.int64
   end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2286,6 +2286,16 @@ module Crystal
       add_def getter
     end
 
+    def lookup_var(name)
+      a_def = lookup_first_def(name, false)
+      return nil unless a_def
+
+      body = a_def.body
+      return nil unless body.is_a?(Primitive) && body.name == "external_var_get"
+
+      a_def
+    end
+
     def type_desc
       "lib"
     end


### PR DESCRIPTION
fixes #4845

first pr so maybe not good. tried with libc environ, worked.

implement mostly by copy other code. LibType has `add_var` for externals with primitive "external_var_get". so for pointerof call `lookup_var` if `pointerof(LibType.var)`. only if looks like that, not if has args or block or named args.

codegen not sure. in semantic bind to var, which stored in `dependencies`. only one dependency, so that dependency is the external. `codegen_primitive_external_var_get` has code for get pointer of external. so use that, refactor a bit. call `check_c_fun` not sure, i think thats if external var has fun type, but didn't try. but if works with regular vars already improvement over existing code.