### PR TITLE
Add guard clause to Deque#rotate!

### DIFF
--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -472,6 +472,18 @@ describe "Deque" do
       a.rotate!(8)
       a.should eq(Deque{4, 1, 2, 3})
     end
+
+    it "rotates with size=0" do
+      a = Deque(Int32).new
+      a.rotate!
+      a.should eq(Deque(Int32).new)
+    end
+
+    it "rotates with size=1" do
+      a = Deque{1}
+      a.rotate!
+      a.should eq(Deque{1})
+    end
   end
 
   describe "shift" do

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -416,6 +416,7 @@ class Deque(T)
   # * For positive *n*, equivalent to `n.times { push(shift) }`.
   # * For negative *n*, equivalent to `(-n).times { unshift(pop) }`.
   def rotate!(n : Int = 1)
+    return if @size <= 1
     if @size == @capacity
       @start = (@start + n) % @capacity
     else


### PR DESCRIPTION
This is my first time contributing to Crystal, so please let me know if there's something I should change.  I went back and forth on writing the guard clause as `@size == 0` or `empty?`.  `shift` and `pop` used `@size == 0`.  `halfs` used `empty?`.

On one hand, the error this is fixing is due to `@size` being zero.  But on the other hand, it makes the most intuitive sense to me that we're short circuiting the rotation when the Deque is empty, because an empty Deque (or Array or whatever) rotated is still an empty Deque.

Come to think of it, we can actually return early if `@size <= 1` because a Deque of size 1 rotated any amount is still the same value.

Would you like me to change this guard clause to `@size <= 1`, leave it as is, or change it to `@size == 0`?

Fixes #5393