### PR TITLE
Optimize slice reverse

### DIFF
--- a/src/slice.cr
+++ b/src/slice.cr
@@ -212,13 +212,17 @@ struct Slice(T)
   def reverse!
     check_writable
 
-    i = 0
-    j = size - 1
-    while i < j
-      @pointer.swap i, j
-      i += 1
-      j -= 1
+    return self if size <= 1
+
+    p = @pointer
+    q = @pointer + size - 1
+
+    while p < q
+      p.value, q.value = q.value, p.value
+      p += 1
+      q -= 1
     end
+
     self
   end
 


### PR DESCRIPTION
current slice reverse uses offsets. then each step need to compute new offset. faster if use just pointers and move pointers. less math. benchmark:

```crystal
require "benchmark"

struct Slice
  def new_reverse!
    check_writable

    p = @pointer
    q = @pointer + size - 1

    while p < q
      p.value, q.value = q.value, p.value
      p += 1
      q -= 1
    end

    self
  end
end

bytes = Bytes[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]

Benchmark.ips do |x|
  x.report("old") do
    bytes.reverse!
  end
  x.report("new") do
    bytes.new_reverse!
  end
end
```

output:

```
old   34.7M ( 28.82ns) (± 4.03%)  1.43× slower
new  49.52M ( 20.19ns) (± 4.44%)       fastest
```