### PR TITLE
Change 'doc' to 'docs', fixes #5405

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,4 +131,4 @@ clean: clean_crystal ## Clean up built directories and files
 .PHONY: clean_crystal
 clean_crystal: ## Clean up crystal built files
 	rm -rf $(O)
-	rm -rf ./doc
+	rm -rf ./docs

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -152,7 +152,7 @@ Alias for shards, the dependency manager for Crystal language.
 .It
 .Cm docs
 .Pp
-Generate documentation from comments using a subset of markdown. The output is saved in html format on the created doc/ folder. More information about documentation conventions can be found at https://crystal-lang.org/docs/conventions/documenting_code.html.
+Generate documentation from comments using a subset of markdown. The output is saved in html format on the created docs/ folder. More information about documentation conventions can be found at https://crystal-lang.org/docs/conventions/documenting_code.html.
 .Pp
 .It Cm eval
 .Pp

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -1,7 +1,7 @@
 # Implementation of the `crystal docs` command
 #
 # This is just the command-line part. Everything else
-# is in `crystal/tools/doc.cr`
+# is in `crystal/tools/doc/`
 
 class Crystal::Command
   private def docs

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,4 +1,4 @@
-/doc/
+/docs/
 /lib/
 /bin/
 /.shards/


### PR DESCRIPTION
This pull request fixes some parts of crystal that still use `doc` instead of `docs`.