### PR TITLE
Fixed set-cookie regex to allow whitespace

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -22,6 +22,12 @@ module HTTP
         cookie.value.should eq("value")
         cookie.to_set_cookie_header.should eq("key=value; path=/")
       end
+      
+      it "parse_set_cookie with space"
+        cookie = parse_set_cookie("key=value; path=/test")
+        parse_set_cookie("key=value;path=/test").should eq cookie
+        parse_set_cookie("key=value;  \t\npath=/test").should eq cookie
+     end
 
       it "parses key=" do
         cookie = parse_first_cookie("key=")

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -22,12 +22,12 @@ module HTTP
         cookie.value.should eq("value")
         cookie.to_set_cookie_header.should eq("key=value; path=/")
       end
-      
+
       it "parse_set_cookie with space" do
         cookie = parse_set_cookie("key=value; path=/test")
         parse_set_cookie("key=value;path=/test").should eq cookie
         parse_set_cookie("key=value;  \t\npath=/test").should eq cookie
-     end
+      end
 
       it "parses key=" do
         cookie = parse_first_cookie("key=")

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -23,7 +23,7 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; path=/")
       end
       
-      it "parse_set_cookie with space"
+      it "parse_set_cookie with space" do
         cookie = parse_set_cookie("key=value; path=/test")
         parse_set_cookie("key=value;path=/test").should eq cookie
         parse_set_cookie("key=value;  \t\npath=/test").should eq cookie

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -81,7 +81,7 @@ module HTTP
       end
 
       CookieString    = /(?:^|; )#{Regex::CookiePair}/
-      SetCookieString = /^#{Regex::CookiePair}(?:; #{Regex::CookieAV})*$/
+      SetCookieString = /^#{Regex::CookiePair}(?:;\s?#{Regex::CookieAV})*$/
 
       def parse_cookies(header)
         header.scan(CookieString).each do |pair|

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -81,7 +81,7 @@ module HTTP
       end
 
       CookieString    = /(?:^|; )#{Regex::CookiePair}/
-      SetCookieString = /^#{Regex::CookiePair}(?:;\s?#{Regex::CookieAV})*$/
+      SetCookieString = /^#{Regex::CookiePair}(?:;\s*#{Regex::CookieAV})*$/
 
       def parse_cookies(header)
         header.scan(CookieString).each do |pair|


### PR DESCRIPTION
Add an optional whitespace to set-cookie regex
This is a fix for: #5407