### PR TITLE
Normalize and add error messages for unterminated literals

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1601,8 +1601,14 @@ describe "Parser" do
     assert_syntax_error %(case x; when /x/; 2; when /x/; end), "duplicate when /x/ in case"
     assert_syntax_error %(case x; when X; 2; when X; end), "duplicate when X in case"
 
-    assert_syntax_error "%w(", "Unterminated String array literal"
-    assert_syntax_error "%i(", "Unterminated Symbol array literal"
+    assert_syntax_error "%w(", "Unterminated string array literal"
+    assert_syntax_error "%i(", "Unterminated symbol array literal"
+    assert_syntax_error "%x(", "Unterminated command literal"
+    assert_syntax_error "%r(", "Unterminated regular expression"
+    assert_syntax_error "%q(", "Unterminated string literal"
+    assert_syntax_error "%Q(", "Unterminated string literal"
+    assert_syntax_error "<<-HEREDOC", "Unexpected EOF on heredoc identifier"
+    assert_syntax_error "<<-HEREDOC\n", "Unterminated heredoc"
 
     it "gets corrects of ~" do
       node = Parser.parse("\n  ~1")

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -116,4 +116,5 @@ describe "ASTNode#to_s" do
   expect_to_s %([(1 + 2)] of Int32)
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
+  expect_to_s "%x(whoami)", "`whoami`"
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -183,7 +183,7 @@ module Crystal
               when ident_part?(char)
                 here << char
               when char == '\0'
-                raise "unexpected EOF on heredoc identifier"
+                raise "Unexpected EOF on heredoc identifier"
               else
                 if char == '\'' && has_single_quote
                   found_closing_single_quote = true
@@ -1729,7 +1729,7 @@ module Crystal
 
       case current_char
       when '\0'
-        raise_unterminated_quoted string_end
+        raise_unterminated_quoted delimiter_state
       when string_end
         next_char
         if string_open_count == 0
@@ -1801,7 +1801,7 @@ module Crystal
                 char = next_char
                 case char
                 when '\0'
-                  raise_unterminated_quoted string_end
+                  raise_unterminated_quoted delimiter_state
                 when '\n'
                   incr_line_number
                   @token.line_number = @line_number
@@ -1919,12 +1919,14 @@ module Crystal
       @token
     end
 
-    def raise_unterminated_quoted(string_end)
-      msg = case string_end
-            when '`'    then "unterminated command"
-            when '/'    then "unterminated regular expression"
-            when String then "unterminated heredoc"
-            else             "unterminated string literal"
+    def raise_unterminated_quoted(delimiter_state)
+      msg = case delimiter_state.kind
+            when :command then "Unterminated command literal"
+            when :regex   then "Unterminated regular expression"
+            when :heredoc then "Unterminated heredoc"
+            when :string  then "Unterminated string literal"
+            else
+              ::raise "unreachable"
             end
       raise msg, @line_number, @column_number
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2050,7 +2050,7 @@ module Crystal
           next_token
           break
         else
-          raise "Unterminated #{elements_type} array literal"
+          raise "Unterminated #{elements_type.downcase} array literal"
         end
       end
 


### PR DESCRIPTION
This PR normalizes error messages for unterminated literals to start with an uppercase letter and use a lower case letter for the literal type. It also fixes reported literal type which was previously `string` for any percent literal.  It adds some specs for several literals.