### PR TITLE
[WIP] Force enable IPv6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,13 @@ matrix:
 before_install:
   - bin/ci prepare_system
 
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
+
 install:
   - bin/ci prepare_build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   # Add an IPv6 config - see the corresponding Travis issue
   # https://github.com/travis-ci/travis-ci/issues/8361
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      bash -c 'echo $TRAVIS_OS_NAME'
       sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
     fi
 


### PR DESCRIPTION
Travis has been red for a while, ex: https://travis-ci.org/crystal-lang/crystal/jobs/318702154

It's because Travis does not support IPv6. It may have worked in the past, but it was never officially supported.

See: https://github.com/travis-ci/travis-ci/issues/3302#issuecomment-159748795