### PR TITLE
Fix a tiny typo in comment

### DIFF
--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -703,7 +703,7 @@ module Crystal
         defs = [defs.first]
       end
 
-      # Only use teturn type if all matching defs have a return type
+      # Only use return type if all matching defs have a return type
       if defs.all? &.return_type
         # We can only infer the type if all overloads return
         # the same type (because we can't know the call


### PR DESCRIPTION
I can't find the word 'teturn' in my dictionary.