### PR TITLE
Use shards version in crystal init tool

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -147,18 +147,11 @@ dependencies:
       end
 
       describe_file "example/src/example.cr" do |example|
-        example.should eq(%{require "./example/*"
-
-# TODO: Write documentation for `Example`
+        example.should eq(%{# TODO: Write documentation for `Example`
 module Example
-  # TODO: Put your code here
-end
-})
-      end
+  VERSION = {{ `shards version \#{__DIR__}`.chomp.stringify }}
 
-      describe_file "example/src/example/version.cr" do |version|
-        version.should eq(%{module Example
-  VERSION = "0.1.0"
+  # TODO: Put your code here
 end
 })
       end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -207,7 +207,6 @@ module Crystal
     template ShardView, "shard.yml.ecr", "shard.yml"
 
     template SrcExampleView, "example.cr.ecr", "src/#{config.name}.cr"
-    template SrcVersionView, "version.cr.ecr", "src/#{config.name}/version.cr"
 
     template SpecHelperView, "spec_helper.cr.ecr", "spec/spec_helper.cr"
     template SpecExampleView, "example_spec.cr.ecr", "spec/#{config.name}_spec.cr"

--- a/src/compiler/crystal/tools/init/template/example.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example.cr.ecr
@@ -1,6 +1,6 @@
-require "./<%= config.name %>/*"
-
 # TODO: Write documentation for `<%= module_name %>`
 module <%= module_name %>
+  VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
+
   # TODO: Put your code here
 end

--- a/src/compiler/crystal/tools/init/template/version.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/version.cr.ecr
@@ -1,3 +1,0 @@
-module <%= module_name %>
-  VERSION = "0.1.0"
-end


### PR DESCRIPTION
Use the `shards version` command introduced by https://github.com/crystal-lang/shards/pull/148 to populate the `VERSION` constant inside generated projects with `crystal init`.

I moved the `VERSION` constant into the main "example.cr" file, instead of a `version.cr` file too. I guess that will be a divisive change, but I don't think a seperate `version.cr` gains us anything.