### PR TITLE
Always print backtrace on error inside fork

### DIFF
--- a/src/process.cr
+++ b/src/process.cr
@@ -104,7 +104,7 @@ class Process
         yield
         LibC._exit 0
       rescue ex
-        ex.inspect STDERR
+        ex.inspect_with_backtrace STDERR
         STDERR.flush
         LibC._exit 1
       ensure


### PR DESCRIPTION
`ex.inspect` is far far uglier and less useful than `ex.inspect_with_backtrace`, and everyone uses the latter. So bring `Process.fork` up to date.