### PR TITLE
Remove _invariant macro from Float::Printer::* modules

### DIFF
--- a/src/float/printer/cached_powers.cr
+++ b/src/float/printer/cached_powers.cr
@@ -159,16 +159,6 @@ module Float::Printer::CachedPowers
     k = ((min_exp + DiyFP::SIGNIFICAND_SIZE - 1) * D_1_LOG2_10).ceil
     index = ((CACHED_POWER_OFFSET + k.to_i - 1) / CACHED_EXP_STEP) + 1
     pow = PowCache[index]
-    _invariant min_exp <= pow.binary_exp
-    _invariant pow.binary_exp <= max_exp
     return DiyFP.new(pow.significand, pow.binary_exp), pow.decimal_exp.to_i
-  end
-
-  private macro _invariant(exp, file = __FILE__, line = __LINE__)
-    {% if !flag?(:release) %}
-      unless {{exp}}
-        raise "Assertion Failed #{{{file}}}:#{{{line}}}"
-      end
-    {% end %}
   end
 end

--- a/src/float/printer/diy_fp.cr
+++ b/src/float/printer/diy_fp.cr
@@ -59,7 +59,6 @@ struct Float::Printer::DiyFP
   #
   # This result is not normalized.
   def -(other : DiyFP)
-    _invariant self.exp == other.exp && frac >= other.frac
     self.class.new(frac - other.frac, exp)
   end
 
@@ -93,7 +92,6 @@ struct Float::Printer::DiyFP
   end
 
   def normalize
-    _invariant frac != 0
     f = frac
     e = exp
 
@@ -117,7 +115,6 @@ struct Float::Printer::DiyFP
   end
 
   def self.from_f(d : Float64 | Float32)
-    _invariant d > 0
     frac, exp = IEEE.frac_and_exp(d)
     new(frac, exp)
   end
@@ -138,13 +135,5 @@ struct Float::Printer::DiyFP
     f <<= DiyFP::SIGNIFICAND_SIZE - IEEE::SIGNIFICAND_SIZE_64
     e -= DiyFP::SIGNIFICAND_SIZE - IEEE::SIGNIFICAND_SIZE_64
     DiyFP.new(f, e)
-  end
-
-  private macro _invariant(exp, file = __FILE__, line = __LINE__)
-    {% if !flag?(:release) %}
-      unless {{exp}}
-        raise "Assertion Failed #{{{file}}}:#{{{line}}}"
-      end
-    {% end %}
   end
 end

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -93,7 +93,6 @@ module Float::Printer::IEEE
   # exponent as m_plus.
   # Precondition: the value encoded by this Flaot must be greater than 0.
   def normalized_boundaries(v : Float64)
-    _invariant v > 0
     w = DiyFP.from_f(v)
     m_plus = DiyFP.new((w.frac << 1) + 1, w.exp - 1).normalize
 
@@ -122,7 +121,6 @@ module Float::Printer::IEEE
   end
 
   def normalized_boundaries(v : Float32)
-    _invariant v > 0
     w = DiyFP.from_f(v)
     m_plus = DiyFP.new((w.frac << 1) + 1, w.exp - 1).normalize
 
@@ -144,7 +142,6 @@ module Float::Printer::IEEE
 
   def frac_and_exp(v : Float64)
     d64 = to_uint(v)
-    _invariant (d64 & EXPONENT_MASK_64) != EXPONENT_MASK_64
 
     if (d64 & EXPONENT_MASK_64) == 0 # denormal float
       frac = d64 & SIGNIFICAND_MASK_64
@@ -159,7 +156,6 @@ module Float::Printer::IEEE
 
   def frac_and_exp(v : Float32)
     d32 = to_uint(v)
-    _invariant (d32 & EXPONENT_MASK_32) != EXPONENT_MASK_32
 
     if (d32 & EXPONENT_MASK_32) == 0 # denormal float
       frac = d32 & SIGNIFICAND_MASK_32
@@ -190,13 +186,5 @@ module Float::Printer::IEEE
     return DENORMAL_EXPONENT_32 if denormal?(d32)
     baised_e = ((d32 & EXPONENT_MASK_32) >> PHYSICAL_SIGNIFICAND_SIZE_32).to_i
     baised_e - EXPONENT_BIAS_32
-  end
-
-  private macro _invariant(exp, file = __FILE__, line = __LINE__)
-    {% if !flag?(:release) %}
-      unless {{exp}}
-        raise "Assertion Failed #{{{file}}}:#{{{line}}}"
-      end
-    {% end %}
   end
 end


### PR DESCRIPTION
As per https://github.com/crystal-lang/crystal/pull/5065#issuecomment-353392651.