### PR TITLE
Let Complex inherit from Number

### DIFF
--- a/src/complex.cr
+++ b/src/complex.cr
@@ -9,7 +9,7 @@
 # Complex.new(1, 0)   # => 1.0 + 0.0i
 # Complex.new(5, -12) # => 5.0 - 12.0i
 # ```
-struct Complex
+struct Complex < Number
   # Returns the real part of self.
   getter real : Float64
 


### PR DESCRIPTION
While digging through stdlib I've noticed that `Complex` for some reason does not subclass `Number`.
It seems like an omission, since it **is** a number. This PR changes that.

Also, in Ruby `Complex < Numeric # => true`.