### PR TITLE
Improve readability of Float::Printer::* docs

### DIFF
--- a/src/float/printer.cr
+++ b/src/float/printer.cr
@@ -1,13 +1,15 @@
 require "./printer/*"
 
-# Float::Printer is based on Grisu3 algorithm described in the 2004 paper
+# :nodoc:
+#
+# `Float::Printer` is based on Grisu3 algorithm described in the 2004 paper
 # "Printing Floating-Point Numbers Quickly and Accurately with Integers" by
 # Florian Loitsch.
 module Float::Printer
   extend self
   BUFFER_SIZE = 128
 
-  # Converts Float *v* to a string representation and prints it onto *io*
+  # Converts `Float` *v* to a string representation and prints it onto *io*.
   #
   # It is used by `Float64#to_s` and it is probably not necessary to use
   # this directly.

--- a/src/float/printer/diy_fp.cr
+++ b/src/float/printer/diy_fp.cr
@@ -1,4 +1,5 @@
 # DiyFP is ported from the C++ "double-conversions" library.
+#
 # The following is their license:
 #   Copyright 2010 the V8 project authors. All rights reserved.
 #   Redistribution and use in source and binary forms, with or without
@@ -30,15 +31,18 @@
 require "./ieee"
 
 # This "Do It Yourself Floating Point" struct implements a floating-point number
-# with a `UIht64` significand and an `Int32` exponent. Normalized DiyFP numbers will
+# with a `UInt64` significand and an `Int32` exponent. Normalized `DiyFP` numbers will
 # have the most significant bit of the significand set.
 # Multiplication and Subtraction do not normalize their results.
-# DiyFP is not designed to contain special Floats (NaN and Infinity).
+#
+# NOTE: `DiyFP` is not designed to contain special Floats (*NaN* and *Infinity*).
 struct Float::Printer::DiyFP
   SIGNIFICAND_SIZE = 64
-  # Also known as the significand
+
+  # Also known as the significand.
   property frac : UInt64
-  # exponent
+
+  # Exponent.
   property exp : Int32
 
   def initialize(@frac, @exp)
@@ -52,26 +56,26 @@ struct Float::Printer::DiyFP
     new frac.to_u64, exp
   end
 
-  # Returns a new `DiyFP` caculated as self - *other*.
+  # Returns a new `DiyFP` caculated as `self - other`.
   #
-  # The exponents of both numbers must be the same and the frac of self must be
-  # greater than the other.
+  # The exponents of both numbers must be the same and the `frac` of `self`
+  # must be greater than the *other*.
   #
-  # This result is not normalized.
+  # NOTE: This result is not normalized.
   def -(other : DiyFP)
     self.class.new(frac - other.frac, exp)
   end
 
   MASK32 = 0xFFFFFFFF_u32
 
-  # Returns a new `DiyFP` caculated as self * *other*.
+  # Returns a new `DiyFP` caculated as `self * other`.
   #
   # Simply "emulates" a 128 bit multiplication.
   # However: the resulting number only contains 64 bits. The least
   # significant 64 bits are only used for rounding the most significant 64
   # bits.
   #
-  # This result is not normalized.
+  # NOTE: This result is not normalized.
   def *(other : DiyFP)
     a = frac >> 32
     b = frac & MASK32
@@ -119,7 +123,7 @@ struct Float::Printer::DiyFP
     new(frac, exp)
   end
 
-  # Normalize such that the most signficiant bit of frac is set
+  # Normalize such that the most signficiant bit of `frac` is set.
   def self.from_f_normalized(v : Float64 | Float32)
     pre_normalized = from_f(v)
     f = pre_normalized.frac

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -1,4 +1,5 @@
 # IEEE is ported from the C++ "double-conversions" library.
+#
 # The following is their license:
 #   Copyright 2012 the V8 project authors. All rights reserved.
 #   Redistribution and use in source and binary forms, with or without
@@ -30,20 +31,21 @@
 module Float::Printer::IEEE
   extend self
 
-  EXPONENT_MASK_64             = 0x7FF0000000000000_u64
-  SIGNIFICAND_MASK_64          = 0x000FFFFFFFFFFFFF_u64
-  HIDDEN_BIT_64                = 0x0010000000000000_u64
-  PHYSICAL_SIGNIFICAND_SIZE_64 =                     52 # Excludes the hidden bit
-  SIGNIFICAND_SIZE_64          =                     53
+  EXPONENT_MASK_64    = 0x7FF0000000000000_u64
+  SIGNIFICAND_MASK_64 = 0x000FFFFFFFFFFFFF_u64
+  HIDDEN_BIT_64       = 0x0010000000000000_u64
+  # Excludes the hidden bit
+  PHYSICAL_SIGNIFICAND_SIZE_64 = 52
+  SIGNIFICAND_SIZE_64          = 53
   EXPONENT_BIAS_64             = 0x3FF + PHYSICAL_SIGNIFICAND_SIZE_64
   DENORMAL_EXPONENT_64         = -EXPONENT_BIAS_64 + 1
   SIGN_MASK_64                 = 0x8000000000000000_u64
-
-  EXPONENT_MASK_32             = 0x7F800000_u32
-  SIGNIFICAND_MASK_32          = 0x007FFFFF_u32
-  HIDDEN_BIT_32                = 0x00800000_u32
-  PHYSICAL_SIGNIFICAND_SIZE_32 =             23 # Excludes the hidden bit
-  SIGNIFICAND_SIZE_32          =             24
+  EXPONENT_MASK_32             =         0x7F800000_u32
+  SIGNIFICAND_MASK_32          =         0x007FFFFF_u32
+  HIDDEN_BIT_32                =         0x00800000_u32
+  # Excludes the hidden bit
+  PHYSICAL_SIGNIFICAND_SIZE_32 = 23
+  SIGNIFICAND_SIZE_32          = 24
   EXPONENT_BIAS_32             = 0x7F + PHYSICAL_SIGNIFICAND_SIZE_32
   DENORMAL_EXPONENT_32         = -EXPONENT_BIAS_32 + 1
   SIGN_MASK_32                 = 0x80000000_u32
@@ -89,9 +91,11 @@ module Float::Printer::IEEE
   end
 
   # Computes the two boundaries of *v*.
-  # The bigger boundary (m_plus) is normalized. The lower boundary has the same
-  # exponent as m_plus.
-  # Precondition: the value encoded by this Flaot must be greater than 0.
+  #
+  # The bigger boundary (*m_plus*) is normalized. The lower boundary has the same
+  # exponent as *m_plus*.
+  #
+  # Precondition: the value encoded by this `Float` must be greater than 0.
   def normalized_boundaries(v : Float64)
     w = DiyFP.from_f(v)
     m_plus = DiyFP.new((w.frac << 1) + 1, w.exp - 1).normalize


### PR DESCRIPTION
ATM docs for `Float::Printer` modules are quite unreadable (see for instance [`Float::Printer::Grisu3#digit_gen`](https://crystal-lang.org/api/0.23.1/Float/Printer/Grisu3.html#digit_gen%28low%3ADiyFP%2Cw%3ADiyFP%2Chigh%3ADiyFP%2Cbuffer_p%29%3ATuple%28Bool%2CInt32%2CInt32%29-instance-method)), this PR improves that.