### PR TITLE
INI: Implement type coercion for `parse`

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -55,10 +55,10 @@ module Crystal
         cr_ext = parsed["*.cr"]
         cr_ext["charset"].should eq("utf-8")
         cr_ext["end_of_line"].should eq("lf")
-        cr_ext["insert_final_newline"].should eq("true")
+        cr_ext["insert_final_newline"].should be_true
         cr_ext["indent_style"].should eq("space")
-        cr_ext["indent_size"].should eq("2")
-        cr_ext["trim_trailing_whitespace"].should eq("true")
+        cr_ext["indent_size"].should eq(2)
+        cr_ext["trim_trailing_whitespace"].should be_true
       end
     end
 

--- a/spec/std/data/test_file.ini
+++ b/spec/std/data/test_file.ini
@@ -8,3 +8,9 @@ bar = 2
 [section2]
 x.y.z = coco lala
 
+[section3]
+float = 3.14
+
+[section4]
+bool1 = true
+bool2 = false

--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -12,7 +12,7 @@ describe "INI" do
     end
 
     it "parses sections" do
-      INI.parse("[section]\na = 1").should eq({"section" => {"a" => "1"}})
+      INI.parse("[section]\na = 1").should eq({"section" => {"a" => 1}})
     end
 
     it "empty section" do
@@ -25,11 +25,18 @@ describe "INI" do
           "log_level" => "DEBUG",
         },
         "section1" => {
-          "foo" => "1",
-          "bar" => "2",
+          "foo" => 1,
+          "bar" => 2,
         },
         "section2" => {
           "x.y.z" => "coco lala",
+        },
+        "section3" => {
+          "float" => 3.14,
+        },
+        "section4" => {
+          "bool1" => true,
+          "bool2" => false,
         },
       })
     end

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -1,22 +1,38 @@
 class INI
+  alias INIValue = String | Int64 | Float64 | Bool
+
   # Parses INI-style configuration from the given string.
   #
+  # Booleans ("true", "false"), integers ("1", "432148765"),
+  # and floats ("3.14", "1.6667") are all coerced into their
+  # respective types (`Bool`, `Int64`, and `Float64`).
+  #
   # ```
-  # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => "1"}}
+  # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => 1}}
   # ```
-  def self.parse(str) : Hash(String, Hash(String, String))
-    ini = {} of String => Hash(String, String)
+  def self.parse(str) : Hash(String, Hash(String, INIValue))
+    ini = {} of String => Hash(String, INIValue)
 
     section = ""
     str.each_line do |line|
       if line =~ /\s*(.*[^\s])\s*=\s*(.*[^\s])/
-        ini[section] ||= {} of String => String if section == ""
-        ini[section][$1] = $2
+        ini[section] ||= {} of String => INIValue if section == ""
+        ini[section][$1] = coerce $2
       elsif line =~ /\[(.*)\]/
         section = $1
-        ini[section] = {} of String => String
+        ini[section] = {} of String => INIValue
       end
     end
     ini
+  end
+
+  private def self.coerce(value)
+    case value
+    when "true"           then true
+    when "false"          then false
+    when /\A-?\d+\z/      then value.to_i64
+    when /\A-?\d+\.\d+\z/ then value.to_f64
+    else                       value
+    end
   end
 end


### PR DESCRIPTION
This commit implements type coercion for `INI.parse`, allowing integers, floats, and booleans to be coerced into their respective Crystal types.
