### PR TITLE
Add Crystal::System::Dir

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -37,7 +37,7 @@ describe "Dir" do
 
     it "tests empty? on an empty directory" do
       path = "/tmp/crystal_empty_test_#{Process.pid}/"
-      Dir.mkdir(path, 0o700).should eq(0)
+      Dir.mkdir(path, 0o700)
       Dir.empty?(path).should be_true
     end
 
@@ -50,9 +50,9 @@ describe "Dir" do
 
   it "tests mkdir and rmdir with a new path" do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
-    Dir.mkdir(path, 0o700).should eq(0)
+    Dir.mkdir(path, 0o700)
     Dir.exists?(path).should be_true
-    Dir.rmdir(path).should eq(0)
+    Dir.rmdir(path)
     Dir.exists?(path).should be_false
   end
 
@@ -64,15 +64,15 @@ describe "Dir" do
 
   it "tests mkdir_p with a new path" do
     path = "/tmp/crystal_mkdir_ptest_#{Process.pid}/"
-    Dir.mkdir_p(path).should eq(0)
+    Dir.mkdir_p(path)
     Dir.exists?(path).should be_true
     path = File.join({path, "a", "b", "c"})
-    Dir.mkdir_p(path).should eq(0)
+    Dir.mkdir_p(path)
     Dir.exists?(path).should be_true
   end
 
   it "tests mkdir_p with an existing path" do
-    Dir.mkdir_p(__DIR__).should eq(0)
+    Dir.mkdir_p(__DIR__)
     expect_raises Errno do
       Dir.mkdir_p(__FILE__)
     end

--- a/src/crystal/system/dir.cr
+++ b/src/crystal/system/dir.cr
@@ -1,0 +1,37 @@
+# :nodoc:
+module Crystal::System::Dir
+  # Returns a new handle to an iterator of entries inside *path*.
+  # def self.open(path : String) : Handle
+
+  # Return the next directory entry in the iterator represented by *handle*, or
+  # `nil` if iteration is complete.
+  # def self.next(handle : Handle) : String?
+
+  # Rewinds the iterator to the beginning of the directory.
+  # def self.rewind(handle : Handle) : Nil
+
+  # Closes *handle*, freeing it's resources.
+  # def self.close(handle : Handle) : Nil
+
+  # Returns the current working directory of the application.
+  # def self.current : String
+
+  # Sets the current working directory of the application.
+  # def self.current=(path : String)
+
+  # Returns `true` if *path* exists and is a directory.
+  # def self.exists?(path : String) : Bool
+
+  # Creates a new directory at *path*. The UNIX-style directory mode *node*
+  # must be applied.
+  # def self.create(path : String, mode : Int32) : Nil
+
+  # Deletes the directory at *path*.
+  # def self.delete(path : String) : Nil
+end
+
+{% if flag?(:unix) %}
+  require "./unix/dir"
+{% else %}
+  {% raise "No implementation of Crystal::System::Dir available" %}
+{% end %}

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -1,6 +1,4 @@
-require "c/dirent"
-require "c/unistd"
-require "c/sys/stat"
+require "crystal/system/dir"
 
 # Objects of class `Dir` are directory streams representing directories in the underlying file system.
 # They provide a variety of ways to list directories and their contents.
@@ -17,10 +15,7 @@ class Dir
 
   # Returns a new directory object for the named directory.
   def initialize(@path)
-    @dir = LibC.opendir(@path.check_no_null_byte)
-    unless @dir
-      raise Errno.new("Error opening directory '#{@path}'")
-    end
+    @dir = Crystal::System::Dir.open(@path)
     @closed = false
   end
 
@@ -125,47 +120,30 @@ class Dir
   # array.sort # => [".", "..", "config.h"]
   # ```
   def read
-    # readdir() returns NULL for failure and sets errno or returns NULL for EOF but leaves errno as is.  wtf.
-    Errno.value = 0
-    ent = LibC.readdir(@dir)
-    if ent
-      String.new(ent.value.d_name.to_unsafe)
-    elsif Errno.value != 0
-      raise Errno.new("readdir")
-    else
-      nil
-    end
+    Crystal::System::Dir.next(@dir)
   end
 
   # Repositions this directory to the first entry.
   def rewind
-    LibC.rewinddir(@dir)
+    Crystal::System::Dir.rewind(@dir)
     self
   end
 
   # Closes the directory stream.
   def close
     return if @closed
-    if LibC.closedir(@dir) != 0
-      raise Errno.new("closedir")
-    end
+    Crystal::System::Dir.close(@dir)
     @closed = true
   end
 
   # Returns the current working directory.
   def self.current : String
-    if dir = LibC.getcwd(nil, 0)
-      String.new(dir).tap { LibC.free(dir.as(Void*)) }
-    else
-      raise Errno.new("getcwd")
-    end
+    Crystal::System::Dir.current
   end
 
   # Changes the current working directory of the process to the given string.
   def self.cd(path)
-    if LibC.chdir(path.check_no_null_byte) != 0
-      raise Errno.new("Error while changing directory to #{path.inspect}")
-    end
+    Crystal::System::Dir.current = path
   end
 
   # Changes the current working directory of the process to the given string
@@ -215,14 +193,7 @@ class Dir
 
   # Returns `true` if the given path exists and is a directory
   def self.exists?(path) : Bool
-    if LibC.stat(path.check_no_null_byte, out stat) != 0
-      if Errno.value == Errno::ENOENT || Errno.value == Errno::ENOTDIR
-        return false
-      else
-        raise Errno.new("stat")
-      end
-    end
-    File::Stat.new(stat).directory?
+    Crystal::System::Dir.exists? path
   end
 
   # Returns `true` if the directory at *path* is empty, otherwise returns `false`.
@@ -246,10 +217,7 @@ class Dir
   # Creates a new directory at the given path. The linux-style permission mode
   # can be specified, with a default of 777 (0o777).
   def self.mkdir(path, mode = 0o777)
-    if LibC.mkdir(path.check_no_null_byte, mode) == -1
-      raise Errno.new("Unable to create directory '#{path}'")
-    end
-    0
+    Crystal::System::Dir.create(path, mode)
   end
 
   # Creates a new directory at the given path, including any non-existing
@@ -276,10 +244,7 @@ class Dir
 
   # Removes the directory at the given path.
   def self.rmdir(path)
-    if LibC.rmdir(path.check_no_null_byte) == -1
-      raise Errno.new("Unable to remove directory '#{path}'")
-    end
-    0
+    Crystal::System::Dir.delete(path)
   end
 
   def to_s(io)


### PR DESCRIPTION
I decided to expose `Crystal::System::Dir` as an `Iterator(String)` since I think it's the nicest yet most generic interface for what `readdir` actually is: an iterator.