### PR TITLE
Fix to keep paren information for `to_s` on clone

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -5,7 +5,14 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
     str = IO::Memory.new expected.bytesize
     parser = Parser.new original
     parser.wants_doc = emit_doc
-    parser.parse.to_s(str, emit_doc: emit_doc)
+    node = parser.parse
+    node.to_s(str, emit_doc: emit_doc)
+    str.to_s.should eq(expected), file, line
+
+    # Check keeping information for `to_s` on clone
+    cloned = node.clone
+    str.clear
+    cloned.to_s(str, emit_doc: emit_doc)
     str.to_s.should eq(expected), file, line
   end
 end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -151,7 +151,7 @@ module Crystal
     end
 
     def clone_without_location
-      Expressions.new(@expressions.clone)
+      Expressions.new(@expressions.clone).tap &.keyword = keyword
     end
 
     def_equals_and_hash expressions


### PR DESCRIPTION
Fixed #5415

And I added keeping information for `to_s` on clone check in `compiler/parser/to_s_spec.cr`.
I think this property should be kept by all `ASTNode#clone` implementation.