### PR TITLE
Optimize String#to_json

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -215,6 +215,19 @@ describe "JSON serialization" do
       "\u{19}".to_json.should eq("\"\\u0019\"")
     end
 
+    it "does for String with control codes in a few places" do
+      "\fab".to_json.should eq(%q("\fab"))
+      "ab\f".to_json.should eq(%q("ab\f"))
+      "ab\fcd".to_json.should eq(%q("ab\fcd"))
+      "ab\fcd\f".to_json.should eq(%q("ab\fcd\f"))
+      "ab\fcd\fe".to_json.should eq(%q("ab\fcd\fe"))
+      "\u{19}ab".to_json.should eq(%q("\u0019ab"))
+      "ab\u{19}".to_json.should eq(%q("ab\u0019"))
+      "ab\u{19}cd".to_json.should eq(%q("ab\u0019cd"))
+      "ab\u{19}cd\u{19}".to_json.should eq(%q("ab\u0019cd\u0019"))
+      "ab\u{19}cd\u{19}e".to_json.should eq(%q("ab\u0019cd\u0019e"))
+    end
+
     it "does for Array" do
       [1, 2, 3].to_json.should eq("[1,2,3]")
     end


### PR DESCRIPTION
saw this: https://stackoverflow.com/questions/47952457/crystal-slow-json-serialization-of-structs-containing-large-strings

this pr still slower then go (crystal memory allocator slower, probably gc slower), but faster then before

old code: go char by char and append it
new code: go char by char, if escape then append all before that point, then escaped char

best case: string has no escape, append all in one go
worse case: all chars escapes, similar to old code

bench:

```crystal
require "benchmark"
require "json"

record Page, uri : String, html : String do
  JSON.mapping(uri: String, html: String)
end

url = "not an uri has escape like \" \\ and also \n "
html = "a" * (128 * 1024)

page = Page.new(url, html)
io = IO::Memory.new

Benchmark.ips do |x|
  x.report("json") do
    page.to_json(io)
    io.clear
  end
end
```

old:

```
json 766.91  (   1.3ms) (± 3.00%) fastest
```

new:

```
json    1.7k (587.83µs) (± 8.62%) fastest
```

