### PR TITLE
Fix missing Dir#each to be an Enumerable

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -234,7 +234,7 @@ describe "Dir" do
     filenames = [] of String
 
     dir = Dir.new(__DIR__)
-    dir.each_entry do |filename|
+    dir.each do |filename|
       filenames << filename
     end.should be_nil
     dir.close
@@ -246,7 +246,7 @@ describe "Dir" do
     filenames = [] of String
 
     Dir.open(__DIR__) do |dir|
-      dir.each_entry do |filename|
+      dir.each do |filename|
         filenames << filename
       end.should be_nil
     end
@@ -272,7 +272,7 @@ describe "Dir" do
   it "gets dir iterator" do
     filenames = [] of String
 
-    iter = Dir.new(__DIR__).each_entry
+    iter = Dir.new(__DIR__).each
     iter.each do |filename|
       filenames << filename
     end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -48,7 +48,7 @@ class Dir
   # File.write("testdir/config.h", "")
   #
   # d = Dir.new("testdir")
-  # d.each_entry { |x| puts "Got #{x}" }
+  # d.each { |x| puts "Got #{x}" }
   # ```
   #
   # produces:
@@ -58,20 +58,20 @@ class Dir
   # Got ..
   # Got config.h
   # ```
-  def each_entry : Nil
+  def each : Nil
     while entry = read
       yield entry
     end
   end
 
-  def each_entry
+  def each
     EntryIterator.new(self)
   end
 
   # Returns an array containing all of the filenames in the given directory.
   def entries : Array(String)
     entries = [] of String
-    each_entry do |filename|
+    each do |filename|
       entries << filename
     end
     entries
@@ -85,7 +85,7 @@ class Dir
   # File.write("testdir/config.h", "")
   #
   # d = Dir.new("testdir")
-  # d.each_entry { |x| puts "Got #{x}" }
+  # d.each_child { |x| puts "Got #{x}" }
   # ```
   #
   # produces:
@@ -181,10 +181,10 @@ class Dir
     end
   end
 
-  # See `#each_entry`.
-  def self.each_entry(dirname)
+  # See `#each`.
+  def self.each(dirname)
     Dir.open(dirname) do |dir|
-      dir.each_entry do |filename|
+      dir.each do |filename|
         yield filename
       end
     end


### PR DESCRIPTION
Dir is missing `#each` method to comply the `Enumerable(String)`.

Part of #4811 renamed `each` to `each_entry`. This PR rollback that.

Probably most of the time `Dir#each_child` will be used. That method filters `.` and `..` from the list of items.

Maybe the `each` should filter `.` and `..` by default. But the proposed change keeps the behavior of 0.23.