### PR TITLE
Update bin/ci to use LIBRARY_PATH from 0.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: ARCH=i386 ARCH_CMD=linux32
+    - env: ARCH=i386 ARCH_CMD=linux32 ARCH_LIBRARY_PATH=/opt/crystal/embedded/lib/
       os: linux
     - env: ARCH=x86_64 ARCH_CMD=linux64 DEPLOY=true
       os: linux

--- a/bin/ci
+++ b/bin/ci
@@ -164,7 +164,7 @@ with_build_env() {
     -u $(id -u) \
     -v $(pwd):/mnt \
     -w /mnt \
-    -e LIBRARY_PATH="/opt/crystal/embedded/lib/" \
+    -e LIBRARY_PATH="${ARCH_LIBRARY_PATH:-/usr/lib/crystal/lib/}" \
     -e CRYSTAL_CACHE_DIR="/tmp/crystal" \
     "jhass/crystal-build-$ARCH" \
     "$ARCH_CMD" /bin/bash -c "'$command'"


### PR DESCRIPTION
Fix #5457 .

Once merged in release/0.24 should be cherrypicked on master