### PR TITLE
Rename 'failed' to 'failures' in junit output.

### DIFF
--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -9,7 +9,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" errors="0" failed="0">
+                 <testsuite tests="2" errors="0" failures="0">
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something"/>
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else"/>
                  </testsuite>
@@ -25,7 +25,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="0" failed="1">
+                 <testsuite tests="1" errors="0" failures="1">
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
                      <failure/>
                    </testcase>
@@ -42,7 +42,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="1" failed="0">
+                 <testsuite tests="1" errors="1" failures="0">
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
                      <error/>
                    </testcase>
@@ -62,7 +62,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" errors="2" failed="1">
+                 <testsuite tests="4" errors="2" failures="1">
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1"/>
                    <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
                      <failure/>

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -30,8 +30,8 @@ module Spec
 
       XML.build(io, indent: 2) do |xml|
         attributes = {
-          tests:  @results.size,
-          errors: @summary[:error]? || 0,
+          tests:    @results.size,
+          errors:   @summary[:error]? || 0,
           failures: @summary[:fail]? || 0,
         }
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -32,7 +32,7 @@ module Spec
         attributes = {
           tests:  @results.size,
           errors: @summary[:error]? || 0,
-          failed: @summary[:fail]? || 0,
+          failures: @summary[:fail]? || 0,
         }
 
         xml.element("testsuite", attributes) do


### PR DESCRIPTION
The junit formatter output contains the 'failed' attribute
on the testsuite node, which must be called 'failures'. Closes #5462 