### PR TITLE
Bool: Add `to_unsafe`

### DIFF
--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -31,6 +31,11 @@ describe "Bool" do
     it { true.hash.should_not eq(false.hash) }
   end
 
+  describe "to_unsafe" do
+    it { true.to_unsafe.should eq(1) }
+    it { false.to_unsafe.should eq(0) }
+  end
+
   describe "to_s" do
     it { true.to_s.should eq("true") }
     it { false.to_s.should eq("false") }

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -46,6 +46,11 @@ struct Bool
     hasher.bool(self)
   end
 
+  # Returns `1` for `true` and `0` for `false`.
+  def to_unsafe
+    self ? 1 : 0
+  end
+
   # Returns `"true"` for `true` and `"false"` for `false`.
   def to_s
     self ? "true" : "false"


### PR DESCRIPTION
Introduces `Bool.to_unsafe`, which returns `1` for `true` and `0` for false.

This comes in handy when calling C bindings that take a `bool`-ish integer, and is clearer than `Bool.hash` (which also changed in `0.24.1`):

```crystal
def whatever(foo, bar, *, baz = true)
  # frobulate(char* foo, type_t bar, int baz)
  LibWhatever.frobulate(foo, bar, baz.to_unsafe)
end
```