### PR TITLE
Fix to lookup NamedTuple from self

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -427,4 +427,16 @@ describe "Restrictions" do
       ),
       "no overload matches"
   end
+
+  it "can instantiate NamedTuple by self" do
+    assert_type(%(
+      struct NamedTuple
+        def self.foo : self
+          {x: 42}
+        end
+      end
+
+      NamedTuple.foo
+      )) { named_tuple_of({"x": int32}) }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2140,6 +2140,10 @@ module Crystal
     @instantiations = {} of Array(NamedArgumentType) => Type
 
     def instantiate(type_vars)
+      if type_vars.size == 1 && (param = type_vars.first?).is_a?(TypeParameter) && param.name == "T"
+        return self
+      end
+
       raise "can't instantiate NamedTuple type yet"
     end
 


### PR DESCRIPTION
Fixed #5464

This bug prevents to work `self` restriction against NamedTuple.
So this code raises a compile error as same as #5464's, but now it works:

```crystal
struct NamedTuple
  def self.foo : self
    {x: 42}
  end
end

pp NamedTuple.foo
```