### PR TITLE
init: Surround `git` commands with backticks

### DIFF
--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -33,9 +33,9 @@ TODO: Write development instructions here
 ## Contributing
 
 1. Fork it ( https://github.com/<%= config.github_name %>/<%= config.name %>/fork )
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
 ## Contributors


### PR DESCRIPTION
Just for consistency with the rest of the generated README.