### PR TITLE
Fix to parse regex in default argument

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -867,6 +867,7 @@ describe "Parser" do
   it_parses "a()/3", Call.new("a".call, "/", 3.int32)
   it_parses "a() /3", Call.new("a".call, "/", 3.int32)
   it_parses "a.b() /3", Call.new(Call.new("a".call, "b"), "/", 3.int32)
+  it_parses "def foo(x = / /); end", Def.new("foo", [Arg.new("x", regex(" "))])
 
   it_parses "1 =~ 2", Call.new(1.int32, "=~", 2.int32)
   it_parses "1.=~(2)", Call.new(1.int32, "=~", 2.int32)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3446,6 +3446,7 @@ module Crystal
         raise "splat argument can't have default value", @token if splat
         raise "double splat argument can't have default value", @token if double_splat
 
+        slash_is_regex!
         next_token_skip_space_or_newline
 
         case @token.type


### PR DESCRIPTION
An error happens on this code:

```crystal
def foo(x = / /); end
```

```console
$ crystal run foo.cr
Syntax error in foo.cr:1: unexpected token: /

def foo(x = / /); end
            ^

```

This PR fixes it.