### PR TITLE
Rename skip() macro method to skip_file() in docs

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -100,13 +100,13 @@ module Crystal::Macros
 
   # Skips the rest of the file from which it is executed.
   # Typical usage is to skip files that have platform specific code,
-  # without having to surround the most relevant code in `{% if flag %} ... {% end %}` macro blocks.
+  # without having to surround the most relevant code in `{% if flag?(...) %} ... {% end %}` macro blocks.
   #
   # Example:
   #
   # ```
   # # sth_for_osx.cr
-  # {% skip_file unless flag?(:darwin) %}
+  # {% skip_file() unless flag?(:darwin) %}
   #
   # # Class FooForMac will only be defined if we're compiling on OS X
   # class FooForMac

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -106,7 +106,7 @@ module Crystal::Macros
   #
   # ```
   # # sth_for_osx.cr
-  # {% skip_file() unless flag?(:darwin) %}
+  # {% skip_file unless flag?(:darwin) %}
   #
   # # Class FooForMac will only be defined if we're compiling on OS X
   # class FooForMac

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -100,19 +100,19 @@ module Crystal::Macros
 
   # Skips the rest of the file from which it is executed.
   # Typical usage is to skip files that have platform specific code,
-  # without having to surround the most relevant code in `{%...%}` macro blocks.
+  # without having to surround the most relevant code in `{% if flag %} ... {% end %}` macro blocks.
   #
   # Example:
   #
   # ```
   # # sth_for_osx.cr
-  # {% skip unless flag?(:darwin) %}
+  # {% skip_file unless flag?(:darwin) %}
   #
   # # Class FooForMac will only be defined if we're compiling on OS X
   # class FooForMac
   # end
   # ```
-  def skip : Nop
+  def skip_file : Nop
   end
 
   # This is the base class of all AST nodes. This methods are


### PR DESCRIPTION
This macro method was renamed in #4709 yet the documentation was not updated.