### PR TITLE
Remove unneeded parenthesis from calls in macro expression

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1049,7 +1049,7 @@ describe "Semantic: macro" do
         class A
         end
 
-        {% skip_file() %}
+        {% skip_file %}
 
         class B
         end
@@ -1066,7 +1066,7 @@ describe "Semantic: macro" do
 
         {% if true %}
           class C; end
-          {% skip_file() %}
+          {% skip_file %}
           class D; end
         {% end %}
 

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -1,4 +1,4 @@
-{% skip_file() if flag?(:win32) %}
+{% skip_file if flag?(:win32) %}
 
 require "c/dlfcn"
 require "c/stdio"

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -77,7 +77,7 @@ module Crystal
                    @scope : Type, @path_lookup : Type, @location : Location?,
                    @vars = {} of String => ASTNode, @block : Block? = nil, @def : Def? = nil,
                    @in_macro = false)
-      @str = IO::Memory.new(512) # Can't be String::Builder because of `{{debug()}}
+      @str = IO::Memory.new(512) # Can't be String::Builder because of `{{debug}}`
       @last = Nop.new
     end
 

--- a/src/crystal/system/unix/arc4random.cr
+++ b/src/crystal/system/unix/arc4random.cr
@@ -1,4 +1,4 @@
-{% skip_file() unless flag?(:openbsd) %}
+{% skip_file unless flag?(:openbsd) %}
 
 require "c/stdlib"
 

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -1,4 +1,4 @@
-{% skip_file() unless flag?(:linux) %}
+{% skip_file unless flag?(:linux) %}
 
 require "c/unistd"
 require "c/sys/syscall"

--- a/src/crystal/system/unix/sysconf_cpucount.cr
+++ b/src/crystal/system/unix/sysconf_cpucount.cr
@@ -1,4 +1,4 @@
-{% skip_file() if flag?(:openbsd) || flag?(:freebsd) %}
+{% skip_file if flag?(:openbsd) || flag?(:freebsd) %}
 
 require "c/unistd"
 

--- a/src/crystal/system/unix/sysctl_cpucount.cr
+++ b/src/crystal/system/unix/sysctl_cpucount.cr
@@ -1,4 +1,4 @@
-{% skip_file() unless flag?(:openbsd) || flag?(:freebsd) %}
+{% skip_file unless flag?(:openbsd) || flag?(:freebsd) %}
 
 require "c/sysctl"
 

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -1,5 +1,5 @@
 # TODO: replace with `flag?(:unix) && !flag?(:openbsd) && !flag?(:linux)` after crystal > 0.22.0 is released
-{% skip_file() if flag?(:openbsd) && flag?(:linux) %}
+{% skip_file if flag?(:openbsd) && flag?(:linux) %}
 
 module Crystal::System::Random
   @@initialized = false

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -1,5 +1,4 @@
-# TODO: replace with `flag?(:unix) && !flag?(:openbsd) && !flag?(:linux)` after crystal > 0.22.0 is released
-{% skip_file if flag?(:openbsd) && flag?(:linux) %}
+{% skip_file unless flag?(:unix) && !flag?(:openbsd) && !flag?(:linux) %}
 
 module Crystal::System::Random
   @@initialized = false

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -1,4 +1,4 @@
-{% skip_file() if flag?(:win32) %}
+{% skip_file if flag?(:win32) %}
 
 require "termios"
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -15,7 +15,7 @@ class IO
     end
   end
 
-  {% skip_file() if flag?(:win32) %}
+  {% skip_file if flag?(:win32) %}
 
   private class Encoder
     def initialize(@encoding_options : EncodingOptions)

--- a/src/io/syscall.cr
+++ b/src/io/syscall.cr
@@ -1,4 +1,4 @@
-{% skip_file() if flag?(:win32) %}
+{% skip_file if flag?(:win32) %}
 
 module IO::Syscall
   @read_timed_out = false


### PR DESCRIPTION
As of 0.24.0 empty parenthesis are not needed anymore to denote calling a macro method.

see #4927

While at it, I also resolved a TODO in `crystal/system/unix/urandom.cr` though I'm not sure if this is correct because the conditions seem somewhat contradictory. But what target would match `flag?(:openbsd) && flag?(:linux)` in the first place?