### PR TITLE
Move ECDHE key init to OpenSSL server context

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -132,6 +132,8 @@ abstract class OpenSSL::SSL::Context
       {% if LibSSL::OPENSSL_102 %}
       self.default_verify_param = "ssl_server"
       {% end %}
+
+      set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
     end
 
     # Returns a new TLS server context with only the given method set.
@@ -161,8 +163,6 @@ abstract class OpenSSL::SSL::Context
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
 
     self.ciphers = CIPHERS
-
-    set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
   end
 
   # Overriding initialize or new in the child classes as public methods,


### PR DESCRIPTION
For client sockets it restricts what curves are available,
making some TLS handshakes fail needlessly

I mistakenly enabled this for client sockets in https://github.com/crystal-lang/crystal/commit/6e438376e67a53c308e74f5009a2ea7a3a3f1dda