### PR TITLE
Fix String#gsub and #tr ASCII-only optimisations

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1665,6 +1665,7 @@ describe "String" do
       "hello".tr("helo", "1212").should eq("12112")
       "this".tr("this", "ⓧ").should eq("ⓧⓧⓧⓧ")
       "über".tr("ü", "u").should eq("uber")
+      "foo bär".tr(" ", "-").should eq("foo-bär")
     end
 
     context "given no replacement characters" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -2014,7 +2014,7 @@ class String
     end
 
     if includes?(char)
-      if replacement.is_a?(Char) && char.ascii? && replacement.ascii?
+      if replacement.is_a?(Char) && char.ascii? && replacement.ascii? && ascii_only?
         return gsub_ascii_char(char, replacement)
       end
 


### PR DESCRIPTION
b14d8c7 introduced some `String#gsub` and `#tr` optimisations for ASCII-only replacements. Unfortunately, to the best of my understading, for those optimisations to work the `String` itself has to be ASCII-only – with the current implementation `String#gsub_ascii_char` turns `"foo bär".tr(" ", "-")` into `"foo-bä\u0000"`