### PR TITLE
Spec String#unsafe_byte_at

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1636,6 +1636,12 @@ describe "String" do
     "hello".byte_at?(5).should be_nil
   end
 
+  describe "unsafe_byte_at" do
+    it "returns the byte at the given index" do
+      "hello".unsafe_byte_at(1).should eq('e'.ord)
+    end
+  end
+
   it "does chars" do
     "ぜんぶ".chars.should eq(['ぜ', 'ん', 'ぶ'])
   end


### PR DESCRIPTION
I noticed the `String#unsafe_byte_at#unsafe_chr` pattern used in a few places, so this adds `String#unsafe_chr_at`.

Question: should `String#unsafe_byte_at` indeed return `0_u8` on out-of-bounds index?