### PR TITLE
Protect internal String methods

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -469,7 +469,7 @@ class File < IO::FileDescriptor
           byte_count -= 1
         end
 
-        str.write part.unsafe_byte_slice(byte_start, byte_count)
+        str.write part.to_slice[byte_start, byte_count]
       end
     end
   end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -38,7 +38,7 @@ module HTTP
       first_equal = true
       bytesize = query.bytesize
       while i < bytesize
-        byte = query.unsafe_byte_at(i)
+        byte = query.to_unsafe[i]
         char = byte.unsafe_chr
 
         case char

--- a/src/io.cr
+++ b/src/io.cr
@@ -789,7 +789,7 @@ abstract class IO
 
     # One byte: use gets(Char)
     if delimiter.bytesize == 1
-      return gets(delimiter.unsafe_byte_at(0).unsafe_chr, chomp: chomp)
+      return gets(delimiter.to_unsafe[0].unsafe_chr, chomp: chomp)
     end
 
     # One char: use gets(Char)

--- a/src/string.cr
+++ b/src/string.cr
@@ -900,10 +900,6 @@ class String
     end
   end
 
-  protected def unsafe_byte_at(index)
-    to_unsafe[index]
-  end
-
   # Returns a new `String` with each uppercase letter replaced with its lowercase
   # counterpart.
   #
@@ -1591,7 +1587,7 @@ class String
     return delete(from) if to.empty?
 
     if from.bytesize == 1
-      return gsub(from.unsafe_byte_at(0).unsafe_chr, to)
+      return gsub(from.to_unsafe[0].unsafe_chr, to)
     end
 
     multi = nil
@@ -2010,7 +2006,7 @@ class String
   # ```
   def gsub(char : Char, replacement)
     if replacement.is_a?(String) && replacement.bytesize == 1
-      return gsub(char, replacement.unsafe_byte_at(0).unsafe_chr)
+      return gsub(char, replacement.to_unsafe[0].unsafe_chr)
     end
 
     if includes?(char)
@@ -2120,7 +2116,7 @@ class String
   # ```
   def gsub(string : String, replacement)
     if string.bytesize == 1
-      gsub(string.unsafe_byte_at(0).unsafe_chr, replacement)
+      gsub(string.to_unsafe[0].unsafe_chr, replacement)
     else
       gsub(string) { replacement }
     end
@@ -4066,7 +4062,7 @@ class String
   end
 
   protected def char_bytesize_at(byte_index)
-    first = unsafe_byte_at(byte_index)
+    first = to_unsafe[byte_index]
 
     if first < 0x80
       return 1
@@ -4076,7 +4072,7 @@ class String
       return 1
     end
 
-    second = unsafe_byte_at(byte_index + 1)
+    second = to_unsafe[byte_index + 1]
     if (second & 0xc0) != 0x80
       return 1
     end
@@ -4085,7 +4081,7 @@ class String
       return 2
     end
 
-    third = unsafe_byte_at(byte_index + 2)
+    third = to_unsafe[byte_index + 2]
     if (third & 0xc0) != 0x80
       return 2
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -4150,11 +4150,11 @@ class String
     pointerof(@c)
   end
 
-  def unsafe_byte_slice(byte_offset, count)
+  protected def unsafe_byte_slice(byte_offset, count)
     Slice.new(to_unsafe + byte_offset, count, read_only: true)
   end
 
-  def unsafe_byte_slice(byte_offset)
+  protected def unsafe_byte_slice(byte_offset)
     Slice.new(to_unsafe + byte_offset, bytesize - byte_offset, read_only: true)
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -900,7 +900,7 @@ class String
     end
   end
 
-  def unsafe_byte_at(index)
+  protected def unsafe_byte_at(index)
     to_unsafe[index]
   end
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -227,7 +227,7 @@ class URI
     i = 0
     bytesize = string.bytesize
     while i < bytesize
-      byte = string.unsafe_byte_at(i)
+      byte = string.to_unsafe[i]
       char = byte.unsafe_chr
       i = unescape_one(string, bytesize, i, byte, char, io, plus_to_space) { |byte| yield byte }
     end
@@ -338,7 +338,7 @@ class URI
 
     if char == '%' && i < bytesize - 2
       i += 1
-      first = string.unsafe_byte_at(i)
+      first = string.to_unsafe[i]
       first_num = first.unsafe_chr.to_i? 16
       unless first_num
         io.write_byte byte
@@ -346,7 +346,7 @@ class URI
       end
 
       i += 1
-      second = string.unsafe_byte_at(i)
+      second = string.to_unsafe[i]
       second_num = second.unsafe_chr.to_i? 16
       unless second_num
         io.write_byte byte


### PR DESCRIPTION
This makes `String#unsafe_byte_at` and `String#unsafe_byte_slice` protected, as per [this comment](https://github.com/crystal-lang/crystal/pull/5500#issuecomment-354668575).