### PR TITLE
Fix UUID.new URN string exception typos

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -118,5 +118,6 @@ describe "UUID" do
     expect_raises(ArgumentError) { UUID.new "0f02a229-4898-4029-926f=94be5628a7fd" }
     expect_raises(ArgumentError) { UUID.new "cda08c86-6413-474f-8822-a6646e0fb19G" }
     expect_raises(ArgumentError) { UUID.new "2b1bfW06368947e59ac07c3ffdaf514c" }
+    expect_raises(ArgumentError) { UUID.new "xyz:uuid:1ed1ee2f-ef9a-4f9c-9615-ab14d8ef2892" }
   end
 end

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -89,7 +89,7 @@ struct UUID
         bytes[i] = value[offset, 2].to_u8(16)
       end
     else
-      raise ArgumentError.new "Invalid string length #{value.size} for UUID, expected 32 (hexstring), 36 (hyphenated) or 46 (urn)"
+      raise ArgumentError.new "Invalid string length #{value.size} for UUID, expected 32 (hexstring), 36 (hyphenated) or 45 (urn)"
     end
 
     new(bytes, variant, version)

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -83,7 +83,7 @@ struct UUID
         bytes[i] = value[i * 2, 2].to_u8(16)
       end
     when 45 # URN
-      raise ArgumentError.new "Invalid URN UUID format, expected string starting with \":urn:uuid:\"" unless value.starts_with? "urn:uuid:"
+      raise ArgumentError.new "Invalid URN UUID format, expected string starting with \"urn:uuid:\"" unless value.starts_with? "urn:uuid:"
       [9, 11, 13, 15, 18, 20, 23, 25, 28, 30, 33, 35, 37, 39, 41, 43].each_with_index do |offset, i|
         string_has_hex_pair_at! value, offset
         bytes[i] = value[offset, 2].to_u8(16)


### PR DESCRIPTION
Fixes a couple of exception message typos when parsing a URN string in UUID.new:

1. Expected size was incorrectly quoted as 46 rather than 45 characters
2. Expected prefix was incorrectly quoted as starting with a `:` character