### PR TITLE
Returns the effective, real group and user ID of the current process

### DIFF
--- a/src/lib_c/aarch64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT 
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT 
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
@@ -26,7 +26,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
@@ -23,6 +23,10 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/i686-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i686-linux-gnu/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/i686-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i686-linux-gnu/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/i686-linux-musl/c/unistd.cr
+++ b/src/lib_c/i686-linux-musl/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/i686-linux-musl/c/unistd.cr
+++ b/src/lib_c/i686-linux-musl/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/unistd.cr
@@ -27,7 +27,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/unistd.cr
@@ -24,6 +24,10 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/unistd.cr
@@ -23,6 +23,10 @@ lib LibC
   fun getpgid(pid : PidT) : Int
   fun getpid : PidT
   fun getppid : PidT
+  fun getegid : GidT
+  fun getgid : GidT
+  fun geteuid : UidT
+  fun getuid : UidT  
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/unistd.cr
@@ -26,7 +26,7 @@ lib LibC
   fun getegid : GidT
   fun getgid : GidT
   fun geteuid : UidT
-  fun getuid : UidT  
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int
   fun link(x0 : Char*, x1 : Char*) : Int

--- a/src/process.cr
+++ b/src/process.cr
@@ -33,7 +33,7 @@ class Process
   def self.uid : LibC::UidT
     LibC.getuid
   end
-  
+
   # Returns the process identifier of the current process.
   def self.pid : LibC::PidT
     LibC.getpid

--- a/src/process.cr
+++ b/src/process.cr
@@ -25,12 +25,12 @@ class Process
   end
 
   # Returns the effective user ID of the current process.
-  def self.euid : LibC::GidT
+  def self.euid : LibC::UidT
     LibC.geteuid
   end
 
   # Returns the real user ID of the current process.
-  def self.uid : LibC::GidT
+  def self.uid : LibC::UidT
     LibC.getuid
   end
   

--- a/src/process.cr
+++ b/src/process.cr
@@ -14,6 +14,26 @@ class Process
     LibC.exit(status)
   end
 
+  # Returns the effective group ID of the current process.
+  def self.egid : LibC::GidT
+    LibC.getegid
+  end
+
+  # Returns the real group ID of the current process.
+  def self.gid : LibC::GidT
+    LibC.getgid
+  end
+
+  # Returns the effective user ID of the current process.
+  def self.euid : LibC::GidT
+    LibC.geteuid
+  end
+
+  # Returns the real user ID of the current process.
+  def self.uid : LibC::GidT
+    LibC.getuid
+  end
+  
   # Returns the process identifier of the current process.
   def self.pid : LibC::PidT
     LibC.getpid


### PR DESCRIPTION
The code got posted a few days ago on Gitter when somebody asked how to get the effective and real group/user ID on Linux but nobody has committed the change to the Crystal source.