### PR TITLE
Remove old legacy checks in callstack specs

### DIFF
--- a/spec/std/callstack_spec.cr
+++ b/spec/std/callstack_spec.cr
@@ -25,11 +25,7 @@ describe "Backtrace" do
     # resolved file line:column
     output.should match(/#{sample}:3:10 in 'callee1'/)
 
-    # The first line is the old (incorrect) behaviour,
-    # the second line is the new (correct) behaviour.
-    # TODO: keep only the second one after Crystal 0.23.1
-    unless output =~ /#{sample}:15:3 in 'callee3'/ ||
-           output =~ /#{sample}:13:5 in 'callee3'/
+    unless output =~ /#{sample}:13:5 in 'callee3'/
       fail "didn't find callee3 in the backtrace"
     end
 


### PR DESCRIPTION
0.23.1 is out since some time now, it's time to remove this old check!
  