### PR TITLE
Change symbol mangling on Windows to avoid conflicts

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2049,14 +2049,15 @@ module Crystal
 
   def self.safe_mangling(program, name)
     if program.has_flag?("windows")
-      name.gsub do |char|
-        case char
-        when '<', '>', '(', ')', '*', ':', ',', '#', '@', ' '
-          "."
-        when '+'
-          ".."
-        else
-          char
+      String.build do |str|
+        name.each_char do |char|
+          if char.ascii_alphanumeric? || char == '_'
+            str << char
+          else
+            str << '.'
+            char.ord.to_s(16, str, upcase: true)
+            str << '.'
+          end
         end
       end
     else


### PR DESCRIPTION
Previously, certain symbols produced conflicts on windows, since `**` was mangled into `..` which was the same as what `+` was mangled into, producing undefined behaviour (In this case, it seems that `+` was being executed instead of `**`). This change mangles non-alphanumerical characters into codes with their (upper-case) hex values (e.g. `<` is mangled into `.3C.`), which will avoid conflicts and, in case of issues, still show which symbol used to be there, at the cost of being rather verbose.
  