### PR TITLE
Remove `bin/crystal` usage for init tool specs

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -6,17 +6,14 @@ require "spec"
 require "yaml"
 
 PROJECT_ROOT_DIR = "#{__DIR__}/../../../.."
-BIN_CRYSTAL      = File.expand_path("#{PROJECT_ROOT_DIR}/bin/crystal")
 
 private def exec_init(project_name, project_dir = nil, type = "lib")
   args = ["init", type, project_name]
   args << project_dir if project_dir
 
-  process = Process.new(BIN_CRYSTAL, args, shell: true, error: Process::Redirect::Pipe)
-  stderr = process.error.gets_to_end
-  status = process.wait
-  $? = status
-  stderr
+  err_io = IO::Memory.new
+  Crystal::Init.run(args, stderr: err_io)
+  err_io.to_s
 end
 
 # Creates a temporary directory, cd to it and run the block inside it.

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -191,13 +191,13 @@ end
         existing_dir = "existing-dir"
         Dir.mkdir(existing_dir)
 
-        expect_raises(Crystal::Init::Error, "file or directory #{existing_dir} already exists") do
+        expect_raises(Crystal::Init::Error, "File or directory #{existing_dir} already exists") do
           exec_init(existing_dir)
         end
 
         existing_file = "existing-file"
         File.touch(existing_file)
-        expect_raises(Crystal::Init::Error, "file or directory #{existing_file} already exists") do
+        expect_raises(Crystal::Init::Error, "File or directory #{existing_file} already exists") do
           exec_init(existing_file)
         end
       end
@@ -212,7 +212,7 @@ end
 
         exec_init(project_name, project_dir)
 
-        expect_raises(Crystal::Init::Error, "file or directory #{project_dir} already exists") do
+        expect_raises(Crystal::Init::Error, "File or directory #{project_dir} already exists") do
           exec_init(project_name, project_dir)
         end
       end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -157,7 +157,12 @@ class Crystal::Command
   end
 
   private def init
-    Init.run(options)
+    begin
+      Init.run(options)
+    rescue ex : Init::Error
+      STDERR.puts ex
+      exit 1
+    end
   end
 
   private def build

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -88,7 +88,7 @@ module Crystal
     def self.fetch_directory(args, project_name)
       directory = args.empty? ? project_name : args.shift
       if Dir.exists?(directory) || File.exists?(directory)
-        raise Error.new "file or directory #{directory} already exists"
+        raise Error.new "File or directory #{directory} already exists"
       end
       directory
     end
@@ -96,14 +96,14 @@ module Crystal
     def self.fetch_skeleton_type(opts, args)
       skeleton_type = fetch_required_parameter(opts, args, "TYPE")
       unless {"lib", "app"}.includes?(skeleton_type)
-        raise ArgError.new "invalid TYPE value: #{skeleton_type}", opts
+        raise ArgError.new "Invalid TYPE value: #{skeleton_type}", opts
       end
       skeleton_type
     end
 
     def self.fetch_required_parameter(opts, args, name)
       if args.empty?
-        raise ArgError.new "#{name} is missing", opts
+        raise ArgError.new "Argument #{name} is missing", opts
       end
       args.shift
     end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -8,9 +8,6 @@ module Crystal
     WHICH_GIT_COMMAND = "which git >/dev/null"
 
     class Error < ::Exception
-    end
-
-    class ArgError < Error
       def self.new(message, opts : OptionParser)
         new("#{message}\n#{opts}\n")
       end
@@ -96,14 +93,14 @@ module Crystal
     def self.fetch_skeleton_type(opts, args)
       skeleton_type = fetch_required_parameter(opts, args, "TYPE")
       unless {"lib", "app"}.includes?(skeleton_type)
-        raise ArgError.new "Invalid TYPE value: #{skeleton_type}", opts
+        raise Error.new "Invalid TYPE value: #{skeleton_type}", opts
       end
       skeleton_type
     end
 
     def self.fetch_required_parameter(opts, args, name)
       if args.empty?
-        raise ArgError.new "Argument #{name} is missing", opts
+        raise Error.new "Argument #{name} is missing", opts
       end
       args.shift
     end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -7,7 +7,7 @@ module Crystal
   module Init
     WHICH_GIT_COMMAND = "which git >/dev/null"
 
-    def self.run(args)
+    def self.run(args, *, stderr = STDERR)
       config = Config.new
 
       OptionParser.parse(args) do |opts|
@@ -31,9 +31,9 @@ module Crystal
         end
 
         opts.unknown_args do |args, after_dash|
-          config.skeleton_type = fetch_skeleton_type(opts, args)
-          config.name = fetch_name(opts, args)
-          config.dir = fetch_directory(args, config.name)
+          config.skeleton_type = fetch_skeleton_type(opts, args, stderr)
+          config.name = fetch_name(opts, args, stderr)
+          config.dir = fetch_directory(args, config.name, stderr)
         end
       end
 
@@ -67,33 +67,33 @@ module Crystal
       github_user || "your-github-user"
     end
 
-    def self.fetch_name(opts, args)
-      fetch_required_parameter(opts, args, "NAME")
+    def self.fetch_name(opts, args, stderr)
+      fetch_required_parameter(opts, args, "NAME", stderr)
     end
 
-    def self.fetch_directory(args, project_name)
+    def self.fetch_directory(args, project_name, stderr)
       directory = args.empty? ? project_name : args.shift
       if Dir.exists?(directory) || File.exists?(directory)
-        STDERR.puts "file or directory #{directory} already exists"
+        stderr.puts "file or directory #{directory} already exists"
         exit 1
       end
       directory
     end
 
-    def self.fetch_skeleton_type(opts, args)
-      skeleton_type = fetch_required_parameter(opts, args, "TYPE")
+    def self.fetch_skeleton_type(opts, args, stderr)
+      skeleton_type = fetch_required_parameter(opts, args, "TYPE", stderr)
       unless {"lib", "app"}.includes?(skeleton_type)
-        STDERR.puts "invalid TYPE value: #{skeleton_type}"
-        STDERR.puts opts
+        stderr.puts "invalid TYPE value: #{skeleton_type}"
+        stderr.puts opts
         exit 1
       end
       skeleton_type
     end
 
-    def self.fetch_required_parameter(opts, args, name)
+    def self.fetch_required_parameter(opts, args, name, stderr)
       if args.empty?
-        STDERR.puts "#{name} is missing"
-        STDERR.puts opts
+        stderr.puts "#{name} is missing"
+        stderr.puts opts
         exit 1
       end
       args.shift


### PR DESCRIPTION
It feels ugly to pass `stderr` all over the place, but hey.. it works!

I think that the routines getting the correct fields from the given args being in the class is not correct, we should probably build a intermediate object (kind of factory which takes arguments and 'parse' them) that will create & return the `InitProject` object then execute it or sth like that.. Absolutely not sure about this..

Maybe we should just merge this to remove `bin/crystal` direct usage, and make another PR to refactor the init tool? (I think I would prefer that)

WDYT?