### PR TITLE
Improve cross compilation

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -278,11 +278,15 @@ module Crystal
     end
 
     private def cross_compile(program, units, output_filename)
-      llvm_mod = units.first.llvm_mod
+      unit = units.first
+      llvm_mod = unit.llvm_mod
       object_name = "#{output_filename}.o"
 
       optimize llvm_mod if @release
-      llvm_mod.print_to_file object_name.gsub(/\.o/, ".ll") if dump_ll?
+
+      if emit = @emit
+        unit.emit(emit, emit_base_filename || output_filename)
+      end
 
       target_machine.emit_obj_to_file llvm_mod, object_name
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -238,11 +238,7 @@ module Crystal
         program.codegen node, debug: debug, single_module: @single_module || (!@thin_lto && @release) || @cross_compile || @emit
       end
 
-      if @cross_compile
-        output_dir = "."
-      else
-        output_dir = CacheDir.instance.directory_for(sources)
-      end
+      output_dir = CacheDir.instance.directory_for(sources)
 
       bc_flags_changed = bc_flags_changed? output_dir
       target_triple = target_machine.triple


### PR DESCRIPTION
Two things here:
- Honor `--emit` flag when cross compiling
- Don't change temp output dir when cross compiling (there were some files like `bc_flags` being generated in the current directory)