### PR TITLE
Add Process.exit stub on windows

### DIFF
--- a/src/windows_stubs.cr
+++ b/src/windows_stubs.cr
@@ -53,3 +53,9 @@ abstract class IO
     end
   end
 end
+
+class Process
+  def self.exit(status = 0)
+    LibC.exit(status)
+  end
+end


### PR DESCRIPTION
This stub allows the ::exit function to compile on win32.