### PR TITLE
Define `new(JSON::PullParser)` on BigDecimal so it can be deserialized

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "json"
+require "big/json"
 
 private class JSONPerson
   JSON.mapping({
@@ -29,6 +30,10 @@ end
 
 private class JSONWithBool
   JSON.mapping value: Bool
+end
+
+private class JSONWithBigDecimal
+  JSON.mapping value: BigDecimal
 end
 
 private class JSONWithTime
@@ -516,6 +521,28 @@ describe "JSON mapping" do
       json = JSONWithOverwritingQueryAttributes.from_json(%({"foo": true}))
       typeof(json.@foo).should eq(Bool)
       typeof(json.@bar).should eq(Bool)
+    end
+  end
+
+  describe "BigDecimal" do
+    it "parses json string with BigDecimal" do
+      json = JSONWithBigDecimal.from_json(%({"value": "10.05"}))
+      json.value.should eq(BigDecimal.new("10.05"))
+    end
+
+    it "parses large json ints with BigDecimal" do
+      json = JSONWithBigDecimal.from_json(%({"value": 9223372036854775808}))
+      json.value.should eq(BigDecimal.new("9223372036854775808"))
+    end
+
+    it "parses json float with BigDecimal" do
+      json = JSONWithBigDecimal.from_json(%({"value": 10.05}))
+      json.value.should eq(BigDecimal.new("10.05"))
+    end
+
+    it "parses large precision json floats with BigDecimal" do
+      json = JSONWithBigDecimal.from_json(%({"value": 0.00045808999999999997}))
+      json.value.should eq(BigDecimal.new("0.00045808999999999997"))
     end
   end
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -91,6 +91,18 @@ describe "JSON serialization" do
       big.should eq(BigFloat.new("1234"))
     end
 
+    it "does for BigDecimal from int" do
+      big = BigDecimal.from_json("1234")
+      big.should be_a(BigDecimal)
+      big.should eq(BigDecimal.new("1234"))
+    end
+
+    it "does for BigDecimal from int" do
+      big = BigDecimal.from_json("1234.05")
+      big.should be_a(BigDecimal)
+      big.should eq(BigDecimal.new("1234.05"))
+    end
+
     it "does for Enum with number" do
       JSONSpecEnum.from_json("1").should eq(JSONSpecEnum::One)
 

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -10,3 +10,17 @@ def BigFloat.new(pull : JSON::PullParser)
   pull.read_float
   BigFloat.new(pull.raw_value)
 end
+
+def BigDecimal.new(pull : JSON::PullParser)
+  case pull.kind
+  when :int
+    pull.read_int
+    value = pull.raw_value
+  when :float
+    pull.read_float
+    value = pull.raw_value
+  else
+    value = pull.read_string
+  end
+  BigDecimal.new(value)
+end


### PR DESCRIPTION
This is my first PR to this repo, and I'm a crystal noob so apologies for anything screwy here. I didn't bother with an issue first, as per contribution guidelines, as I think this qualifies as a minor fix.

Arguably analogous changes to those here should be made for the other "big" types. Happy to do that in this or a separate PR, if desired.

cheers