### PR TITLE
Added support for secure web sockets when protocol is HTTPS

### DIFF
--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -297,7 +297,8 @@ Playground.Session = function(options) {
   this.editor._playgroundSession = this;
 
   this.connect = function() {
-    this.ws = new WebSocket("ws://" + location.host + "/client");
+    var socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+    this.ws = new WebSocket(socketProtocol + "//" + location.host + "/client");
 
     this.ws.onopen = function() {
       this._triggerReady();


### PR DESCRIPTION
Though the compiler does not ship with any openssl support at this time, the playground may be served behind a proxy like Nginx which handles the TLS handshake.  If the playground is served over HTTPS in this way, modern browsers will raise a SecurityError when the playground front-end attempts to open an insecure web socket (i.e.: ws://<domain>/client).  This disables a key feature of the playground which is dynamically compiling and executing code provided by the front-end.

With this change, we can select the secure/insecure web socket protocol based on the secure/insecure HTTP protocol being used.  This is determined using [`location.protocol`][0].  This change allows the playground to effectively be served over HTTPS (at least up to the proxy).

A use case for this includes developing Crystal workbooks to be accessible to multiple users securely over a given network.  Given an interactive class or presentation about Crystal, the presenter may host the playground server supplied with their own unique workbook examples while users interact securely with the examples provided by the presenter.

This is in reference to issue #5519.

[0]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/protocol