### PR TITLE
Support LLVM 5.0 postfixed versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=$PWD/src)
 SHELL = sh
 LLVM_CONFIG_FINDER := \
   [ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+  command -v llvm-config-5.0 || command -v llvm-config50 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 5.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-4.0 || command -v llvm-config40 || \
     (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 4.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-3.9 || command -v llvm-config39 || \

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -2,6 +2,8 @@
 lib LibLLVM
   LLVM_CONFIG = {{
                   `[ -n "$LLVM_CONFIG" ] && command -v "$LLVM_CONFIG" || \
+                   command -v llvm-config-5.0 || command -v llvm-config50 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 5.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-4.0 || command -v llvm-config40 || \
                    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 4.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-3.9 || command -v llvm-config39 || \


### PR DESCRIPTION
Basically a clone of #5013 for LLVM 5.0. See there for reasons.
#5058 already tried that and LLVM 5.0 was not considered sufficiently stable at the time, but it's three months later and it has been promoted to the default version in many distributions, so I think it is fair to make it the default here as well.
  