### PR TITLE
Allow nested constants in type lookup for generic arguments that resolve to integers

### DIFF
--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -60,6 +60,27 @@ describe "Semantic: static array" do
       )) { static_array_of(char, 3) }
   end
 
+  it "types static array new with size being a nested constant inside type declaration (#5426)" do
+    assert_type(%(
+      module Moo
+        SIZE = 3
+      end
+
+      class Foo
+        @x : StaticArray(Char, Moo::SIZE)
+
+        def initialize(@x)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new(StaticArray(Char, Moo::SIZE).new).x
+      )) { static_array_of(char, 3) }
+  end
+
   it "types static array new with size being a computed constant" do
     assert_type(%(
       OTHER = 10

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -249,7 +249,7 @@ class Crystal::Type
         end
 
         # Check the case of T resolving to a number
-        if type_var.is_a?(Path) && type_var.names.size == 1
+        if type_var.is_a?(Path)
           type = @root.lookup_path(type_var)
           case type
           when Const


### PR DESCRIPTION
Fixes #5426