### PR TITLE
Implement snprintf on win32

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/stdarg.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdarg.cr
@@ -1,0 +1,3 @@
+lib LibC
+  type VaList = Void*
+end

--- a/src/lib_c/x86_64-windows-msvc/c/stdio.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdio.cr
@@ -3,5 +3,12 @@ require "./stddef"
 lib LibC
   fun printf(format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
-  fun snprintf(s : Char*, maxlen : SizeT, format : Char*, ...) : Int
+  fun vsnprintf(str : Char*, size : SizeT, format : Char*, ap : VaList) : Int
+  fun snprintf = __crystal_snprintf(str : Char*, size : SizeT, format : Char*, ...) : Int
+end
+
+fun __crystal_snprintf(str : LibC::Char*, size : LibC::SizeT, format : LibC::Char*, ...) : LibC::Int
+  VaList.open do |varargs|
+    LibC.vsnprintf(str, size, format, varargs)
+  end
 end


### PR DESCRIPTION
x86_64-pc-windows-msvc doesn't export the snprintf symbol, only the vsnprintf symbol. This means we need to define out own snprintf implementation which captures va_args correctly.