### PR TITLE
Compiler: remove extra `shell` argument when executing macro run

### DIFF
--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -95,7 +95,7 @@ class Crystal::Program
 
     out_io = IO::Memory.new
     err_io = IO::Memory.new
-    Process.run(compiled_file, args: args, shell: true, output: out_io, error: err_io)
+    Process.run(compiled_file, args: args, output: out_io, error: err_io)
     MacroRunResult.new(out_io.to_s, err_io.to_s, $?)
   end
 


### PR DESCRIPTION
`compiled_file` here is a binary that results from compiling the file passed to the `run` macro method, so there's no need to run in the context of a shell.

With `shell: true`, this will fail if that executable ends up in a path with spaces.

This should fix https://github.com/luckyframework/lucky_cli/issues/147 , but if not it's anyway a good change.