### PR TITLE
Fix typo mutli to multi

### DIFF
--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3522,12 +3522,12 @@ module Crystal
       else
         write " "
       end
-      format_mutli_assign_values node.values
+      format_multi_assign_values node.values
 
       false
     end
 
-    def format_mutli_assign_values(values)
+    def format_multi_assign_values(values)
       if values.size == 1
         accept_assign_value values.first
       else

--- a/src/file.cr
+++ b/src/file.cr
@@ -520,7 +520,7 @@ class File < IO::FileDescriptor
   end
 
   # Yields an `IO` to read a section inside this file.
-  # Mutliple sections can be read concurrently.
+  # Multiple sections can be read concurrently.
   def read_at(offset, bytesize, &block)
     self_bytesize = self.size
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1115,7 +1115,7 @@ abstract class IO
   # The `IO` class raises on this method, but some subclasses, notable
   # `File` and `IO::Memory` implement it.
   #
-  # Mutliple sections can be read concurrently.
+  # Multiple sections can be read concurrently.
   def read_at(offset, bytesize, &block)
     raise Error.new "Unable to read_at"
   end


### PR DESCRIPTION
- `mutli` -> `multi`
- `Mutliple` -> `Multiple`
