### PR TITLE
Simplify Crystal::System interface by adding File.stat? and lstat?

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -42,9 +42,16 @@ describe "Dir" do
     end
 
     it "tests empty? on nonexistent directory" do
-      expect_raises Errno do
+      expect_raises(Errno, /Error determining size of/) do
         Dir.empty?(File.join([__DIR__, "/foo/bar/"]))
       end
+    end
+
+    it "tests empty? on a directory path to a file" do
+      ex = expect_raises(Errno, /Error determining size of/) do
+        Dir.empty?("#{__FILE__}/")
+      end
+      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -116,9 +116,17 @@ describe "File" do
 
     it "raises an error when the file does not exist" do
       filename = "#{__DIR__}/data/non_existing_file.txt"
-      expect_raises Errno do
+      expect_raises(Errno, /Error determining size/) do
         File.empty?(filename)
       end
+    end
+
+    it "raises an error when a component of the path is a file" do
+      filename = "#{__DIR__}/data/non_existing_file.txt"
+      ex = expect_raises(Errno, /Error determining size/) do
+        File.empty?("#{__FILE__}/")
+      end
+      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 
@@ -130,11 +138,23 @@ describe "File" do
     it "gives false" do
       File.exists?("#{__DIR__}/data/non_existing_file.txt").should be_false
     end
+
+    it "gives false when a component of the path is a file" do
+      File.exists?("#{__FILE__}/").should be_false
+    end
   end
 
   describe "executable?" do
     it "gives false" do
       File.executable?("#{__DIR__}/data/test_file.txt").should be_false
+    end
+
+    it "gives false when the file doesn't exist" do
+      File.executable?("#{__DIR__}/data/non_existing_file.txt").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.executable?("#{__FILE__}/").should be_false
     end
   end
 
@@ -142,11 +162,27 @@ describe "File" do
     it "gives true" do
       File.readable?("#{__DIR__}/data/test_file.txt").should be_true
     end
+
+    it "gives false when the file doesn't exist" do
+      File.readable?("#{__DIR__}/data/non_existing_file.txt").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.readable?("#{__FILE__}/").should be_false
+    end
   end
 
   describe "writable?" do
     it "gives true" do
       File.writable?("#{__DIR__}/data/test_file.txt").should be_true
+    end
+
+    it "gives false when the file doesn't exist" do
+      File.writable?("#{__DIR__}/data/non_existing_file.txt").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.writable?("#{__FILE__}/").should be_false
     end
   end
 
@@ -158,6 +194,14 @@ describe "File" do
     it "gives false" do
       File.file?("#{__DIR__}/data").should be_false
     end
+
+    it "gives false when the file doesn't exist" do
+      File.file?("#{__DIR__}/data/non_existing_file.txt").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.file?("#{__FILE__}/").should be_false
+    end
   end
 
   describe "directory?" do
@@ -167,6 +211,14 @@ describe "File" do
 
     it "gives false" do
       File.directory?("#{__DIR__}/data/test_file.txt").should be_false
+    end
+
+    it "gives false when the directory doesn't exist" do
+      File.directory?("#{__DIR__}/data/non_existing").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.directory?("#{__FILE__}/").should be_false
     end
   end
 
@@ -203,6 +255,14 @@ describe "File" do
     it "gives false" do
       File.symlink?("#{__DIR__}/data/test_file.txt").should be_false
       File.symlink?("#{__DIR__}/data/unknown_file.txt").should be_false
+    end
+
+    it "gives false when the symlink doesn't exist" do
+      File.symlink?("#{__DIR__}/data/non_existing_file.txt").should be_false
+    end
+
+    it "gives false when a component of the path is a file" do
+      File.symlink?("#{__FILE__}/").should be_false
     end
   end
 
@@ -375,6 +435,21 @@ describe "File" do
       File.open("#{__DIR__}/data/test_file.txt", "r") do |file|
         file.size.should eq(240)
       end
+    end
+
+    it "raises an error when the file does not exist" do
+      filename = "#{__DIR__}/data/non_existing_file.txt"
+      expect_raises(Errno, /Error determining size/) do
+        File.size(filename)
+      end
+    end
+
+    it "raises an error when a component of the path is a file" do
+      filename = "#{__DIR__}/data/non_existing_file.txt"
+      ex = expect_raises(Errno, /Error determining size/) do
+        File.size("#{__FILE__}/")
+      end
+      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 

--- a/src/crystal/system/dir.cr
+++ b/src/crystal/system/dir.cr
@@ -19,9 +19,6 @@ module Crystal::System::Dir
   # Sets the current working directory of the application.
   # def self.current=(path : String)
 
-  # Returns `true` if *path* exists and is a directory.
-  # def self.exists?(path : String) : Bool
-
   # Creates a new directory at *path*. The UNIX-style directory mode *node*
   # must be applied.
   # def self.create(path : String, mode : Int32) : Nil

--- a/src/crystal/system/unix/dir.cr
+++ b/src/crystal/system/unix/dir.cr
@@ -48,18 +48,6 @@ module Crystal::System::Dir
     path
   end
 
-  def self.exists?(path : String) : Bool
-    if LibC.stat(path.check_no_null_byte, out stat) != 0
-      if Errno.value == Errno::ENOENT || Errno.value == Errno::ENOTDIR
-        return false
-      else
-        raise Errno.new("stat")
-      end
-    end
-
-    (stat.st_mode & LibC::S_IFMT) == LibC::S_IFDIR
-  end
-
   def self.create(path : String, mode : Int32) : Nil
     if LibC.mkdir(path.check_no_null_byte, mode) == -1
       raise Errno.new("Unable to create directory '#{path}'")

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -193,7 +193,11 @@ class Dir
 
   # Returns `true` if the given path exists and is a directory
   def self.exists?(path) : Bool
-    Crystal::System::Dir.exists? path
+    if stat = File.stat?(path)
+      stat.directory?
+    else
+      false
+    end
   end
 
   # Returns `true` if the directory at *path* is empty, otherwise returns `false`.

--- a/src/file.cr
+++ b/src/file.cr
@@ -34,6 +34,36 @@ class File < IO::FileDescriptor
 
   getter path : String
 
+  # Returns a `File::Stat` object for the file given by *path* or returns `nil`
+  # if the file does not exist. Raises `Errno` in case of an error. In case of
+  # a symbolic link it is followed and information about the target is returned.
+  #
+  # ```
+  # File.write("foo", "foo")
+  # File.stat?("foo").try(&.size) # => 3
+  # File.stat?("non_existent")    # => nil
+  # ```
+  def self.stat?(path : String) : Stat?
+    Crystal::System::File.stat?(path)
+  end
+
+  # Returns a `File::Stat` object for the file given by *path* or returns `nil`
+  # if the file does not exist. Raises `Errno` in case of an error. In case of
+  # a symbolic link information about the link itself is returned.
+  #
+  # ```
+  # File.write("foo", "foo")
+  # File.lstat?("foo").try(&.size) # => 3
+  #
+  # File.symlink("foo", "bar")
+  # File.lstat?("bar").try(&.symlink?) # => true
+  #
+  # File.lstat?("non_existent") # => nil
+  # ```
+  def self.lstat?(path : String) : Stat?
+    Crystal::System::File.lstat?(path)
+  end
+
   # Returns a `File::Stat` object for the file given by *path* or raises
   # `Errno` in case of an error. In case of a symbolic link
   # it is followed and information about the target is returned.
@@ -44,12 +74,12 @@ class File < IO::FileDescriptor
   # File.stat("foo").mtime # => 2015-09-23 06:24:19 UTC
   # ```
   def self.stat(path) : Stat
-    Crystal::System::File.stat(path)
+    stat?(path) || raise Errno.new("Unable to get stat for #{path.inspect}")
   end
 
   # Returns a `File::Stat` object for the file given by *path* or raises
   # `Errno` in case of an error. In case of a symbolic link
-  # information about it is returned.
+  # information about the link itself is returned.
   #
   # ```
   # File.write("foo", "foo")
@@ -57,7 +87,7 @@ class File < IO::FileDescriptor
   # File.lstat("foo").mtime # => 2015-09-23 06:24:19 UTC
   # ```
   def self.lstat(path) : Stat
-    Crystal::System::File.lstat(path)
+    lstat?(path) || raise Errno.new("Unable to get stat for #{path.inspect}")
   end
 
   # Returns `true` if *path* exists else returns `false`
@@ -72,6 +102,20 @@ class File < IO::FileDescriptor
     Crystal::System::File.exists?(path)
   end
 
+  # Returns the size of *filename* bytes. Raises `Errno` if the file at *path*
+  # does not exist.
+  #
+  # ```
+  # File.size("foo") # raises Errno
+  # File.write("foo", "foo")
+  # File.size("foo") # => 3
+  # ```
+  def self.size(filename) : UInt64
+    stat(filename).size
+  rescue ex : Errno
+    raise Errno.new("Error determining size of #{filename.inspect}", ex.errno)
+  end
+
   # Returns `true` if the file at *path* is empty, otherwise returns `false`.
   # Raises `Errno` if the file at *path* does not exist.
   #
@@ -82,7 +126,7 @@ class File < IO::FileDescriptor
   # File.empty?("foo") # => false
   # ```
   def self.empty?(path) : Bool
-    Crystal::System::File.empty?(path)
+    size(path) == 0
   end
 
   # Returns `true` if *path* is readable by the real user id of this process else returns `false`.
@@ -125,7 +169,11 @@ class File < IO::FileDescriptor
   # File.file?("foobar") # => false
   # ```
   def self.file?(path) : Bool
-    Crystal::System::File.file?(path)
+    if stat = stat?(path)
+      stat.file?
+    else
+      false
+    end
   end
 
   # Returns `true` if the given *path* exists and is a directory.
@@ -324,7 +372,11 @@ class File < IO::FileDescriptor
 
   # Returns `true` if the *path* is a symbolic link.
   def self.symlink?(path) : Bool
-    Crystal::System::File.symlink?(path)
+    if stat = lstat?(path)
+      stat.symlink?
+    else
+      false
+    end
   end
 
   # Opens the file named by *filename*. If a file is being created, its initial
@@ -472,11 +524,6 @@ class File < IO::FileDescriptor
         str.write part.unsafe_byte_slice(byte_start, byte_count)
       end
     end
-  end
-
-  # Returns the size of *filename* bytes.
-  def self.size(filename) : UInt64
-    stat(filename.check_no_null_byte).size
   end
 
   # Moves *old_filename* to *new_filename*.


### PR DESCRIPTION
By providing these methods we can make the implementation of File.empty? and File.file? platform-unspecific. This makes the interface to Crystal::System::File smaller and cleaner.