### PR TITLE
Adds OpenBSD's pledge()

### DIFF
--- a/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/unistd.cr
@@ -37,4 +37,6 @@ lib LibC
   fun sysconf(x0 : Int) : Long
   fun unlink(x0 : Char*) : Int
   fun write(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
+
+  fun pledge(promises : Char*, execpromises : Char*) : Int
 end


### PR DESCRIPTION
Adds OpenBSD's [pledge](http://man.openbsd.org/pledge) function.

"The current process is forced into a restricted-service operating mode. A few subsets are available, roughly described as computation, memory management, read-write operations on file descriptors, opening of files, networking. In general, these modes were selected by studying the operation of many programs using libc and other such interfaces, and setting promises or execpromises."