### PR TITLE
Fix: decode DWARF line sequences with single program entry

### DIFF
--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -154,6 +154,11 @@ module Debug
           @file_names = [{"", 0, 0, 0}]
           @standard_opcode_lengths = [0_u8]
         end
+
+        # Returns the unit length, adding the size of the `unit_length`.
+        def total_length
+          unit_length + sizeof(typeof(unit_length))
+        end
       end
 
       # Matrix of decompressed `Row` to search line number informations from the
@@ -230,14 +235,14 @@ module Debug
           read_directory_table(sequence)
           read_filename_table(sequence)
 
-          if @io.tell - @offset < sequence.offset + sequence.unit_length
+          if @io.tell - @offset < sequence.offset + sequence.total_length
             read_statement_program(sequence)
           end
         end
       end
 
       private def read_opcodes(sequence)
-        1.upto(sequence.opcode_base - 1) do |i|
+        1.upto(sequence.opcode_base - 1) do
           sequence.standard_opcode_lengths << @io.read_byte.not_nil!
         end
       end
@@ -296,7 +301,7 @@ module Debug
             when LNE::EndSequence
               registers.end_sequence = true
               register_to_matrix(sequence, registers)
-              if (@io.tell - @offset - sequence.offset) < sequence.unit_length
+              if (@io.tell - @offset - sequence.offset) < sequence.total_length
                 registers = Register.new(sequence.default_is_stmt)
               else
                 break


### PR DESCRIPTION
Debug::DWARF::LineNumbers skipped the program statement when it contained a single entry, because of a wrong assumption of the sequence unit_length entry, which doesn't account for the unit length space in the standard, and was overlooked in checking whether the sequence had any program statement, or not.

fixes #5224 