### PR TITLE
Standardize naming of Exceptions and Errors.

### DIFF
--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -4,23 +4,23 @@ require "ini"
 describe "INI" do
   describe "parse from string" do
     it "fails on malformed section" do
-      expect_raises(INI::ParseException, "unterminated section") do
+      expect_raises(INI::ParseError, "unterminated section") do
         INI.parse("[section")
       end
     end
 
     it "fails on data after section" do
-      expect_raises(INI::ParseException, "data after section") do
+      expect_raises(INI::ParseError, "data after section") do
         INI.parse("[section] foo  ")
       end
     end
 
     it "fails on malformed declaration" do
-      expect_raises(INI::ParseException, "expected declaration") do
+      expect_raises(INI::ParseError, "expected declaration") do
         INI.parse("foobar")
       end
 
-      expect_raises(INI::ParseException, "expected declaration") do
+      expect_raises(INI::ParseError, "expected declaration") do
         INI.parse("foo: bar")
       end
     end

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -215,7 +215,7 @@ describe "JSON mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    ex = expect_raises JSON::ParseException, "Unknown json attribute: foo" do
+    ex = expect_raises JSON::ParseError, "Unknown json attribute: foo" do
       StrictJSONPerson.from_json <<-JSON
         {
           "name": "John",
@@ -228,7 +228,7 @@ describe "JSON mapping" do
   end
 
   it "raises if non-nilable attribute is nil" do
-    ex = expect_raises JSON::ParseException, "Missing json attribute: name" do
+    ex = expect_raises JSON::ParseError, "Missing json attribute: name" do
       JSONPerson.from_json(%({"age": 30}))
     end
     ex.location.should eq({1, 1})
@@ -511,7 +511,7 @@ describe "JSON mapping" do
     end
 
     it "raises if non-nilable attribute is nil" do
-      ex = expect_raises JSON::ParseException, "Missing json attribute: foo" do
+      ex = expect_raises JSON::ParseError, "Missing json attribute: foo" do
         JSONWithQueryAttributes.from_json(%({"is_bar": true}))
       end
       ex.location.should eq({1, 1})

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -9,7 +9,7 @@ end
 
 private def it_raises_on_parse(string, file = __FILE__, line = __LINE__)
   it "raises on parse #{string}", file, line do
-    expect_raises JSON::ParseException do
+    expect_raises JSON::ParseError do
       JSON.parse(string)
     end
   end
@@ -63,13 +63,13 @@ describe JSON::Parser do
   it_raises_on_parse "1\u{0}"
 
   it "prevents stack overflow for arrays" do
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises JSON::ParseError, "Nesting of 513 is too deep" do
       JSON.parse(("[" * 513) + ("]" * 513))
     end
   end
 
   it "prevents stack overflow for hashes" do
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises JSON::ParseError, "Nesting of 513 is too deep" do
       JSON.parse((%({"x": ) * 513) + ("}" * 513))
     end
   end

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -86,7 +86,7 @@ class JSON::PullParser
   end
 
   def assert_error
-    expect_raises JSON::ParseException do
+    expect_raises JSON::ParseError do
       read_next
     end
   end
@@ -102,7 +102,7 @@ end
 
 private def assert_pull_parse_error(string)
   it "errors on #{string}" do
-    expect_raises JSON::ParseException do
+    expect_raises JSON::ParseError do
       parser = JSON::PullParser.new string
       while parser.kind != :EOF
         parser.read_next
@@ -164,7 +164,7 @@ describe JSON::PullParser do
 
   it "prevents stack overflow for arrays" do
     parser = JSON::PullParser.new(("[" * 513) + ("]" * 513))
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises JSON::ParseError, "Nesting of 513 is too deep" do
       while true
         break if parser.kind == :EOF
         parser.read_next
@@ -174,7 +174,7 @@ describe JSON::PullParser do
 
   it "prevents stack overflow for hashes" do
     parser = JSON::PullParser.new((%({"x": ) * 513) + ("}" * 513))
-    expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
+    expect_raises JSON::ParseError, "Nesting of 513 is too deep" do
       while true
         break if parser.kind == :EOF
         parser.read_next

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -154,7 +154,7 @@ describe "JSON serialization" do
 
     describe "parse exceptions" do
       it "has correct location when raises in NamedTuple#from_json" do
-        ex = expect_raises(JSON::ParseException) do
+        ex = expect_raises(JSON::ParseError) do
           Array({foo: Int32, bar: String}).from_json <<-JSON
             [
               {"foo": 1}
@@ -165,7 +165,7 @@ describe "JSON serialization" do
       end
 
       it "has correct location when raises in Union#from_json" do
-        ex = expect_raises(JSON::ParseException) do
+        ex = expect_raises(JSON::ParseError) do
           Array(Int32 | Bool).from_json <<-JSON
             [
               {"foo": "bar"}

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -229,7 +229,7 @@ describe "YAML mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    ex = expect_raises YAML::ParseException, "Unknown yaml attribute: foo" do
+    ex = expect_raises YAML::ParseError, "Unknown yaml attribute: foo" do
       StrictYAMLPerson.from_yaml <<-YAML
         ---
         name: John
@@ -252,7 +252,7 @@ describe "YAML mapping" do
   end
 
   it "raises if non-nilable attribute is nil" do
-    ex = expect_raises YAML::ParseException, "Missing yaml attribute: name" do
+    ex = expect_raises YAML::ParseError, "Missing yaml attribute: name" do
       YAMLPerson.from_yaml <<-YAML
         ---
         age: 30
@@ -387,11 +387,11 @@ describe "YAML mapping" do
     end
 
     it "raises when not a mapping or empty scalar" do
-      expect_raises(YAML::ParseException) do
+      expect_raises(YAML::ParseError) do
         YAMLWithDefaults.from_yaml("1")
       end
 
-      expect_raises(YAML::ParseException) do
+      expect_raises(YAML::ParseError) do
         YAMLWithDefaults.from_yaml("[1]")
       end
     end
@@ -514,7 +514,7 @@ describe "YAML mapping" do
     end
 
     it "raises if non-nilable attribute is nil" do
-      ex = expect_raises YAML::ParseException, "Missing yaml attribute: foo" do
+      ex = expect_raises YAML::ParseError, "Missing yaml attribute: foo" do
         YAMLWithQueryAttributes.from_yaml(%({"is_bar": true}))
       end
       ex.location.should eq({1, 1})

--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -9,7 +9,7 @@ end
 
 private def it_raises_on_parse(string, message, file = __FILE__, line = __LINE__)
   it "raises on parse #{string.inspect}", file, line do
-    expect_raises(YAML::ParseException, message) do
+    expect_raises(YAML::ParseError, message) do
       YAML::Schema::Core.parse(string)
     end
   end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -45,7 +45,7 @@ describe "YAML serialization" do
     end
 
     it "raises on reserved string" do
-      expect_raises(YAML::ParseException) do
+      expect_raises(YAML::ParseError) do
         String.from_yaml(%(1.2))
       end
     end
@@ -170,7 +170,7 @@ describe "YAML serialization" do
 
     describe "parse exceptions" do
       it "has correct location when raises in Nil#from_yaml" do
-        ex = expect_raises(YAML::ParseException) do
+        ex = expect_raises(YAML::ParseError) do
           Array(Nil).from_yaml <<-YAML
             [
               1
@@ -182,7 +182,7 @@ describe "YAML serialization" do
       end
 
       it "has correct location when raises in Int32#from_yaml" do
-        ex = expect_raises(YAML::ParseException) do
+        ex = expect_raises(YAML::ParseError) do
           Array(Int32).from_yaml <<-YAML
             [
               "hello"
@@ -193,7 +193,7 @@ describe "YAML serialization" do
       end
 
       it "has correct location when raises in NamedTuple#from_yaml" do
-        ex = expect_raises(YAML::ParseException) do
+        ex = expect_raises(YAML::ParseError) do
           Array({foo: Int32, bar: String}).from_yaml <<-YAML
             [
               {"foo": 1}
@@ -204,7 +204,7 @@ describe "YAML serialization" do
       end
 
       it "has correct location when raises in Union#from_yaml" do
-        ex = expect_raises(YAML::ParseException) do
+        ex = expect_raises(YAML::ParseError) do
           Array(Int32 | Bool).from_yaml <<-YAML
             [
               {"foo": "bar"}

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -110,7 +110,7 @@ module YAML
       parser.read_stream do
         parser.read_document do
           parser.read_sequence do
-            ex = expect_raises(YAML::ParseException) do
+            ex = expect_raises(YAML::ParseError) do
               parser.read_mapping do
               end
             end

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -40,7 +40,7 @@ describe "YAML" do
       end
 
       it "raises if merging with missing alias" do
-        expect_raises(YAML::ParseException, "Unknown anchor 'bar'") do
+        expect_raises(YAML::ParseError, "Unknown anchor 'bar'") do
           YAML.parse(%(---
             foo:
               <<: *bar
@@ -110,7 +110,7 @@ describe "YAML" do
                  one: "broken"
             YAML
           fail "expected YAML.parse to raise"
-        rescue ex : YAML::ParseException
+        rescue ex : YAML::ParseError
           ex.line_number.should eq(4)
           ex.column_number.should eq(4)
         end
@@ -129,14 +129,14 @@ describe "YAML" do
               parser.read_scalar
             end
           end
-        rescue ex : YAML::ParseException
+        rescue ex : YAML::ParseError
           ex.line_number.should eq(2)
           ex.column_number.should eq(3)
         end
       end
 
       it "has correct message (#4006)" do
-        expect_raises YAML::ParseException, "could not find expected ':' at line 4, column 1, while scanning a simple key at line 3, column 5" do
+        expect_raises YAML::ParseError, "could not find expected ':' at line 4, column 1, while scanning a simple key at line 3, column 5" do
           YAML.parse <<-END
             a:
               - "b": >

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -1,6 +1,6 @@
 class INI
   # Exception thrown on an INI parse error.
-  class ParseException < Exception
+  class ParseError < Exception
     getter line_number : Int32
     getter column_number : Int32
 
@@ -14,7 +14,7 @@ class INI
   end
 
   # Parses INI-style configuration from the given string.
-  # Raises a `ParseException` on any errors.
+  # Raises a `ParseError` on any errors.
   #
   # ```
   # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => "1"}}
@@ -39,14 +39,14 @@ class INI
         next
       when '['
         end_idx = line.index(']', offset)
-        raise ParseException.new("unterminated section", lineno, line.size) unless end_idx
-        raise ParseException.new("data after section", lineno, end_idx + 1) unless end_idx == line.size - 1
+        raise ParseError.new("unterminated section", lineno, line.size) unless end_idx
+        raise ParseError.new("data after section", lineno, end_idx + 1) unless end_idx == line.size - 1
 
         current_section_name = line[offset + 1...end_idx]
         current_section = ini[current_section_name] ||= Hash(String, String).new
       else
         key, eq, value = line.partition('=')
-        raise ParseException.new("expected declaration", lineno, key.size) if eq != "="
+        raise ParseError.new("expected declaration", lineno, key.size) if eq != "="
 
         current_section[key.strip] = value.strip
       end

--- a/src/json.cr
+++ b/src/json.cr
@@ -61,8 +61,8 @@ module JSON
   class Error < Exception
   end
 
-  # Exception thrown on a JSON parse error.
-  class ParseException < Error
+  # Error thrown on a JSON parse error.
+  class ParseError < Error
     getter line_number : Int32
     getter column_number : Int32
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -166,7 +166,7 @@ def NamedTuple.new(pull : JSON::PullParser)
 
     {% for key in T.keys %}
       if %var{key.id}.nil?
-        raise JSON::ParseException.new("Missing json attribute: {{key}}", *location)
+        raise JSON::ParseError.new("Missing json attribute: {{key}}", *location)
       end
     {% end %}
 
@@ -223,11 +223,11 @@ def Union.new(pull : JSON::PullParser)
   {% for type in T %}
     begin
       return {{type}}.from_json(string)
-    rescue JSON::ParseException
+    rescue JSON::ParseError
       # Ignore
     end
   {% end %}
-  raise JSON::ParseException.new("Couldn't parse #{self} from #{string}", *location)
+  raise JSON::ParseError.new("Couldn't parse #{self} from #{string}", *location)
 end
 
 def Time.new(pull : JSON::PullParser)

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -362,7 +362,7 @@ abstract class JSON::Lexer
   end
 
   private def raise(msg)
-    ::raise ParseException.new(msg, @line_number, @column_number)
+    ::raise ParseError.new(msg, @line_number, @column_number)
   end
 end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -134,7 +134,7 @@ module JSON
         {% end %}
         else
           {% if strict %}
-            raise ::JSON::ParseException.new("Unknown json attribute: #{key}", *%key_location)
+            raise ::JSON::ParseError.new("Unknown json attribute: #{key}", *%key_location)
           {% else %}
             %pull.skip
           {% end %}
@@ -145,7 +145,7 @@ module JSON
       {% for key, value in _properties_ %}
         {% unless value[:nilable] || value[:default] != nil %}
           if %var{key.id}.nil? && !%found{key.id} && !::Union({{value[:type]}}).nilable?
-            raise ::JSON::ParseException.new("Missing json attribute: {{(value[:key] || value[:key_id]).id}}", *%location)
+            raise ::JSON::ParseError.new("Missing json attribute: {{(value[:key] || value[:key_id]).id}}", *%location)
           end
         {% end %}
 

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -122,7 +122,7 @@ class JSON::Parser
   end
 
   private def parse_exception(msg)
-    raise ParseException.new(msg, token.line_number, token.column_number)
+    raise ParseError.new(msg, token.line_number, token.column_number)
   end
 
   private def nest

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -515,7 +515,7 @@ class JSON::PullParser
   end
 
   private def parse_exception(msg)
-    raise ParseException.new(msg, token.line_number, token.column_number)
+    raise ParseError.new(msg, token.line_number, token.column_number)
   end
 
   private def push_in_object_stack(symbol)

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -63,7 +63,7 @@ module YAML
   end
 
   # Exception thrown on a YAML parse error.
-  class ParseException < Error
+  class ParseError < Error
     getter line_number : Int32
     getter column_number : Int32
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -195,7 +195,7 @@ def Union.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   {% for type in T %}
     begin
       return {{type}}.new(ctx, node)
-    rescue YAML::ParseException
+    rescue YAML::ParseError
       # Ignore
     end
   {% end %}

--- a/src/yaml/mapping.cr
+++ b/src/yaml/mapping.cr
@@ -25,13 +25,13 @@ module YAML
   # ```
   #
   # Attributes not mapped with `YAML.mapping` are not defined as properties.
-  # Also, missing attributes raise a `ParseException`.
+  # Also, missing attributes raise a `ParseError`.
   #
   # ```
   # employee = Employee.from_yaml("title: Manager\nname: John\nage: 30")
   # employee.age # undefined method 'age'. (compile error)
   #
-  # Employee.from_yaml("title: Manager") # raises YAML::ParseException
+  # Employee.from_yaml("title: Manager") # raises YAML::ParseError
   # ```
   #
   # You can also define attributes for each property.

--- a/src/yaml/nodes/nodes.cr
+++ b/src/yaml/nodes/nodes.cr
@@ -24,10 +24,10 @@ module YAML::Nodes
       {start_line, start_column}
     end
 
-    # Raises a `YAML::ParseException` with the given message
+    # Raises a `YAML::ParseError` with the given message
     # located at this node's `location`.
     def raise(message)
-      ::raise YAML::ParseException.new(message, *location)
+      ::raise YAML::ParseError.new(message, *location)
     end
   end
 

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -320,6 +320,6 @@ class YAML::PullParser
   end
 
   def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil)
-    ::raise ParseException.new(msg, line_number, column_number, context_info)
+    ::raise ParseError.new(msg, line_number, column_number, context_info)
   end
 end

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -219,7 +219,7 @@ module YAML::Schema::Core
   protected def self.parse_binary(string, location) : Bytes
     Base64.decode(string)
   rescue ex : Base64::Error
-    raise YAML::ParseException.new("Error decoding Base64: #{ex.message}", *location)
+    raise YAML::ParseError.new("Error decoding Base64: #{ex.message}", *location)
   end
 
   protected def self.parse_bool(string, location) : Bool
@@ -228,18 +228,18 @@ module YAML::Schema::Core
       return value
     end
 
-    raise YAML::ParseException.new("Invalid bool", *location)
+    raise YAML::ParseError.new("Invalid bool", *location)
   end
 
   protected def self.parse_int(string, location) : Int64
     string.to_i64?(underscore: true, prefix: true) ||
-      raise(YAML::ParseException.new("Invalid int", *location))
+      raise(YAML::ParseError.new("Invalid int", *location))
   end
 
   protected def self.parse_float(string, location) : Float64
     parse_float_infinity_and_nan?(string) ||
       parse_float?(string) ||
-      raise(YAML::ParseException.new("Invalid float", *location))
+      raise(YAML::ParseError.new("Invalid float", *location))
   end
 
   protected def self.parse_null(string, location) : Nil
@@ -247,12 +247,12 @@ module YAML::Schema::Core
       return nil
     end
 
-    raise YAML::ParseException.new("Invalid null", *location)
+    raise YAML::ParseError.new("Invalid null", *location)
   end
 
   protected def self.parse_time(string, location) : Time
     parse_time?(string) ||
-      raise(YAML::ParseException.new("Invalid timestamp", *location))
+      raise(YAML::ParseError.new("Invalid timestamp", *location))
   end
 
   protected def self.process_scalar_tag(scalar)


### PR DESCRIPTION
Follow up from #5559.

Standardizes naming of `Exception`s and `Error`s in Crystal. The convention is to name everything `FooError` and make the base class for all the errors `Exception`. The classes [`JSON::ParseException`](https://crystal-lang.org/api/0.24.1/JSON/ParseException.html), [`YAML::ParseException`](https://crystal-lang.org/api/0.24.1/YAML/ParseException.html), `INI::ParseException` and  [`InvalidBigDecimalException`](https://crystal-lang.org/api/0.24.1/InvalidBigDecimalException.html) did not follow this convention. I have renamed all of them (ensuring that nothing broke).

I'm not sure what [`OptionsParser::Exception`](https://crystal-lang.org/api/0.24.1/OptionParser/Exception.html) does so I didn't rename it.

References:
- [Stack Overflow](https://stackoverflow.com/questions/48142967/exceptions-errors-in-crystal)
- Comment by @RX14 on the issue
> The general consensus (I recall) is to name everything FooError (assuming it's actually an error) but keep the top-level class called Exception. Not all exceptions have to be errors.
>
> The remaining stuff like ParseException should be renamed ParseError.