### PR TITLE
Compiler: ensure parentheses inside assign value

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1712,4 +1712,23 @@ describe "Code gen: macro" do
       {{ Foo.union_types.size }}
       )).to_i.should eq(2)
   end
+
+  it "expands macro with op assign inside assign (#5568)" do
+    run(%(
+      require "prelude"
+
+      macro expand
+        {{ yield }}
+      end
+
+      def foo
+        {:foo => 1}
+      end
+
+      expand do
+        x = foo[:foo] += 1
+        puts x
+      end
+      )).to_string.chomp.should eq("2")
+  end
 end

--- a/spec/compiler/normalize/and_spec.cr
+++ b/spec/compiler/normalize/and_spec.cr
@@ -18,7 +18,7 @@ describe "Normalize: and" do
   end
 
   it "normalizes and with ! on var.is_a?(...)" do
-    assert_expand_second "a = 1; !a.is_a?(Int32) && b", "if !(a.is_a?(Int32))\n  b\nelse\n  !(a.is_a?(Int32))\nend"
+    assert_expand_second "a = 1; !a.is_a?(Int32) && b", "if !a.is_a?(Int32)\n  b\nelse\n  !a.is_a?(Int32)\nend"
   end
 
   it "normalizes and with is_a? on exp" do

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -74,7 +74,7 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with multiple expressions and types" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if (x.is_a?(Int32)) && (y.is_a?(Float64))\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and implicit obj" do
@@ -98,7 +98,7 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with multiple expressions and non-tuple" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === ({x, y})\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
   end
 
   it "normalizes case with single expressions with underscore" do

--- a/spec/compiler/normalize/or_spec.cr
+++ b/spec/compiler/normalize/or_spec.cr
@@ -22,6 +22,6 @@ describe "Normalize: or" do
   end
 
   it "normalizes or with ! on var.is_a?(...)" do
-    assert_expand_second "a = 1; !a.is_a?(Int32) || b", "if !(a.is_a?(Int32))\n  !(a.is_a?(Int32))\nelse\n  b\nend"
+    assert_expand_second "a = 1; !a.is_a?(Int32) || b", "if !a.is_a?(Int32)\n  !a.is_a?(Int32)\nelse\n  b\nend"
   end
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -3,10 +3,16 @@ require "../../support/syntax"
 private def expect_to_s(original, expected = original, emit_doc = false, file = __FILE__, line = __LINE__)
   it "does to_s of #{original.inspect}", file, line do
     str = IO::Memory.new expected.bytesize
-    parser = Parser.new original
-    parser.wants_doc = emit_doc
-    parser.parse.to_s(str, emit_doc: emit_doc)
-    str.to_s.should eq(expected), file, line
+
+    source = original
+    if source.is_a?(String)
+      parser = Parser.new source
+      parser.wants_doc = emit_doc
+      parser.parse.to_s(str, emit_doc: emit_doc)
+      str.to_s.should eq(expected), file, line
+    else
+      source.to_s.should eq(expected), file, line
+    end
   end
 end
 
@@ -117,4 +123,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"
+  expect_to_s Assign.new("x".var, Expressions.new([1.int32, 2.int32] of ASTNode)), "x = (1\n2\n)"
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -464,7 +464,7 @@ module Crystal
         end
       when Var, NilLiteral, BoolLiteral, CharLiteral, NumberLiteral, StringLiteral,
            StringInterpolation, Path, Generic, InstanceVar, ClassVar, Global,
-           ImplicitObj
+           ImplicitObj, TupleLiteral, NamedTupleLiteral, IsA
         false
       when ArrayLiteral
         !!obj.of
@@ -557,7 +557,10 @@ module Crystal
     def visit(node : Assign)
       node.target.accept self
       @str << " = "
-      node.value.accept self
+
+      need_parens = node.value.is_a?(Expressions)
+      in_parenthesis(need_parens, node.value)
+
       false
     end
 


### PR DESCRIPTION
Fixes #5568

As the issue mentions, this code:

```crystal
macro expand
  {{ yield }}
  {{ debug }}
end

def foo
  {:foo => 1}
end

expand do
  x = foo[:foo] += 1
  puts x
end
```

will print this from the `debug` part of the macro:

```crystal
begin
  x = __temp_2 = foo
  __temp_2[:foo] = __temp_2[:foo] + 1

  puts(x)
end
```

The issue is that `x = ...` is incorrectly printed with the `to_s` method of an ASTNode because it's either missing parentheses or `begin/end` so that its value is the last expression (not the first one here). So this PR fixes that.

Eventually, I think it might be better to make this expansion happen after macro code, so showing that macro code would show the original `foo[:foo] += 1`. In any case, this fix is more general because fixing the `to_s` should be done regardless of this other possible enhancement.