### PR TITLE
Correct implementation of heredoc

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -881,6 +881,9 @@ describe Crystal::Formatter do
   assert_format "<<-HTML\n  hello \n  world   \n  HTML"
   assert_format "  <<-HTML\n    hello \n    world   \n    HTML", "<<-HTML\n  hello \n  world   \n  HTML"
 
+  assert_format "x, y = <<-FOO, <<-BAR\n  hello\n  FOO\n  world\n  BAR"
+  assert_format "x, y, z = <<-FOO, <<-BAR, <<-BAZ\n  hello\n  FOO\n  world\n  BAR\n  qux\nBAZ"
+
   assert_format "#!shebang\n1 + 2"
 
   assert_format "   {{\n1 + 2 }}", "{{\n  1 + 2\n}}"
@@ -1028,9 +1031,6 @@ describe Crystal::Formatter do
   assert_format "Union(Foo::Bar?, Baz?, Qux(T, U?))"
 
   assert_format "lib Foo\n  {% if 1 %}\n    2\n  {% end %}\nend\n\nmacro bar\n  1\nend"
-
-  assert_format %(puts(<<-FOO\n1\nFOO, 2))
-  assert_format %(puts <<-FOO\n1\nFOO, 2)
 
   assert_format "x : Int32 |\nString", "x : Int32 |\n    String"
 

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -161,6 +161,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("Hello, mom! I am HERE.")
     tester.next_string_token_should_be("\nHER dress is beautiful.")
     tester.next_string_token_should_be("\nHE is OK.")
@@ -173,6 +174,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("foo")
     tester.next_string_token_should_be("\n")
     tester.string_should_end_correctly
@@ -183,6 +185,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("foo")
     tester.next_string_token_should_be("\r\n")
     tester.string_should_end_correctly
@@ -193,6 +196,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("foo")
     tester.string_should_end_correctly
   end
@@ -203,6 +207,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("Hello, mom! I am HERE.")
     tester.token_should_be_at(line: 2)
     tester.next_string_token_should_be("\nHER dress is beautiful.")
@@ -221,6 +226,7 @@ describe "Lexer string" do
     tester = LexerObjects::Strings.new(lexer)
 
     tester.string_should_start_correctly
+    tester.next_token_should_be(:NEWLINE)
     tester.next_string_token_should_be("abc")
     tester.string_should_have_an_interpolation_of("foo")
     tester.string_should_end_correctly
@@ -239,42 +245,10 @@ describe "Lexer string" do
     end
   end
 
-  it "raises on invalid heredoc identifier (<<-HERE A)" do
-    lexer = Lexer.new("<<-HERE A\ntest\nHERE\n")
-
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
-      lexer.next_token
-    end
-  end
-
-  it "raises on invalid heredoc identifier (<<-HERE\\n)" do
-    lexer = Lexer.new("<<-HERE\\ntest\nHERE\n")
-
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
-      lexer.next_token
-    end
-  end
-
-  it "raises when identifier doesn't start with a leter" do
-    lexer = Lexer.new("<<-123\\ntest\n123\n")
+  it "raises when identifier doesn't start with a leter or number" do
+    lexer = Lexer.new("<<-!!!\\ntest\n!!!\n")
 
     expect_raises Crystal::SyntaxException, /heredoc identifier starts with invalid character/ do
-      lexer.next_token
-    end
-  end
-
-  it "raises when identifier contains a character not for identifier" do
-    lexer = Lexer.new("<<-aaa.bbb?\\ntest\naaa.bbb?\n")
-
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
-      lexer.next_token
-    end
-  end
-
-  it "raises when identifier contains spaces" do
-    lexer = Lexer.new("<<-aaa  bbb\\ntest\naaabbb\n")
-
-    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
       lexer.next_token
     end
   end

--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -10,4 +10,8 @@ describe "Normalize: string interpolation" do
     assert_expand "\"foo\#{bar}#{s}\"",
       "((((::String::Builder.new(218)) << \"foo\") << bar) << \"#{s}\").to_s"
   end
+
+  it "normalizes heredoc" do
+    assert_normalize "<<-FOO\nhello\nFOO", %("hello")
+  end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1180,16 +1180,17 @@ describe "Parser" do
   it_parses %("hello " \\\n "world"), StringLiteral.new("hello world")
   it_parses %("hello "\\\n"world"), StringLiteral.new("hello world")
   it_parses %("hello \#{1}" \\\n "\#{2} world"), StringInterpolation.new(["hello ".string, 1.int32, 2.int32, " world".string] of ASTNode)
-  it_parses "<<-HERE\nHello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY\nHERE", "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY".string
-  it_parses "<<-HERE\n   One\n  Zero\n  HERE", " One\nZero".string
-  it_parses "<<-HERE\n   One \\n Two\n  Zero\n  HERE", " One \n Two\nZero".string
-  it_parses "<<-HERE\n   One\n\n  Zero\n  HERE", " One\n\nZero".string
-  it_parses "<<-HERE\n   One\n \n  Zero\n  HERE", " One\n\nZero".string
+  it_parses "<<-HERE\nHello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY\nHERE",
+    "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY".string_interpolation
+  it_parses "<<-HERE\n   One\n  Zero\n  HERE", " One\nZero".string_interpolation
+  it_parses "<<-HERE\n   One \\n Two\n  Zero\n  HERE", " One \n Two\nZero".string_interpolation
+  it_parses "<<-HERE\n   One\n\n  Zero\n  HERE", " One\n\nZero".string_interpolation
+  it_parses "<<-HERE\n   One\n \n  Zero\n  HERE", " One\n\nZero".string_interpolation
   it_parses "<<-HERE\n   \#{1}One\n  \#{2}Zero\n  HERE", StringInterpolation.new([" ".string, 1.int32, "One\n".string, 2.int32, "Zero".string] of ASTNode)
   it_parses "<<-HERE\n  foo\#{1}bar\n   baz\n  HERE", StringInterpolation.new(["foo".string, 1.int32, "bar\n baz".string] of ASTNode)
-  it_parses "<<-HERE\r\n   One\r\n  Zero\r\n  HERE", " One\r\nZero".string
-  it_parses "<<-HERE\r\n   One\r\n  Zero\r\n  HERE\r\n", " One\r\nZero".string
-  it_parses "<<-SOME\n  Sa\n  Se\n  SOME", "Sa\nSe".string
+  it_parses "<<-HERE\r\n   One\r\n  Zero\r\n  HERE", " One\r\nZero".string_interpolation
+  it_parses "<<-HERE\r\n   One\r\n  Zero\r\n  HERE\r\n", " One\r\nZero".string_interpolation
+  it_parses "<<-SOME\n  Sa\n  Se\n  SOME", "Sa\nSe".string_interpolation
   it_parses "<<-HERE\n  \#{1} \#{2}\n  HERE", StringInterpolation.new([1.int32, " ".string, 2.int32] of ASTNode)
   it_parses "<<-HERE\n  \#{1} \\n \#{2}\n  HERE", StringInterpolation.new([1.int32, " \n ".string, 2.int32] of ASTNode)
   assert_syntax_error "<<-HERE\n   One\nwrong\n  Zero\n  HERE", "heredoc line must have an indent greater or equal than 2", 3, 1
@@ -1200,16 +1201,24 @@ describe "Parser" do
   assert_syntax_error "<<-HERE\n One\n  \#{1}\n  HERE", "heredoc line must have an indent greater or equal than 2", 2, 1
   assert_syntax_error %("foo" "bar")
 
-  it_parses "<<-'HERE'\n  hello \\n world\n  \#{1}\n  HERE", StringLiteral.new("hello \\n world\n\#{1}")
+  it_parses "<<-'HERE'\n  hello \\n world\n  \#{1}\n  HERE", "hello \\n world\n\#{1}".string_interpolation
   assert_syntax_error "<<-'HERE\n", "expecting closing single quote"
 
-  it_parses "<<-FOO\n1\nFOO.bar", Call.new("1".string, "bar")
-  it_parses "<<-FOO\n1\nFOO + 2", Call.new("1".string, "+", 2.int32)
+  it_parses "<<-'HERE COMES HEREDOC'\n  hello \\n world\n  \#{1}\n  HERE COMES HEREDOC", "hello \\n world\n\#{1}".string_interpolation
 
-  it_parses "<<-FOO\n\t1\n\tFOO", StringLiteral.new("1")
-  it_parses "<<-FOO\n \t1\n \tFOO", StringLiteral.new("1")
-  it_parses "<<-FOO\n \t 1\n \t FOO", StringLiteral.new("1")
-  it_parses "<<-FOO\n\t 1\n\t FOO", StringLiteral.new("1")
+  assert_syntax_error "<<-FOO\n1\nFOO.bar", "Unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
+  assert_syntax_error "<<-FOO\n1\nFOO + 2", "Unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
+
+  it_parses "<<-FOO\n\t1\n\tFOO", "1".string_interpolation
+  it_parses "<<-FOO\n \t1\n \tFOO", "1".string_interpolation
+  it_parses "<<-FOO\n \t 1\n \t FOO", "1".string_interpolation
+  it_parses "<<-FOO\n\t 1\n\t FOO", "1".string_interpolation
+
+  it_parses "x, y = <<-FOO, <<-BAR\nhello\nFOO\nworld\nBAR",
+    MultiAssign.new(["x".var, "y".var] of ASTNode, ["hello".string_interpolation, "world".string_interpolation] of ASTNode)
+
+  it_parses "x, y, z = <<-FOO, <<-BAR, <<-BAZ\nhello\nFOO\nworld\nBAR\n!\nBAZ",
+    MultiAssign.new(["x".var, "y".var, "z".var] of ASTNode, ["hello".string_interpolation, "world".string_interpolation, "!".string_interpolation] of ASTNode)
 
   it_parses "enum Foo; A\nB, C\nD = 1; end", EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)
   it_parses "enum Foo; A = 1, B; end", EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Arg.new("B")] of ASTNode)

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -90,6 +90,10 @@ class String
     StringLiteral.new self
   end
 
+  def string_interpolation
+    StringInterpolation.new([self.string] of ASTNode)
+  end
+
   def float32
     NumberLiteral.new self, :f32
   end

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -375,5 +375,16 @@ module Crystal
         Assign.new(target.clone, call).at(node)
       end
     end
+
+    def transform(node : StringInterpolation)
+      # If the interpolation has just one string literal inside it,
+      # return that instead of an interpolation
+      if node.expressions.size == 1
+        first = node.expressions.first
+        return first if first.is_a?(StringLiteral)
+      end
+
+      super
+    end
   end
 end


### PR DESCRIPTION
Now you can specify multiple heredocs in a single line, just like in Ruby.

For example:

```ruby
puts <<-ONE.upcase, <<-TWO.capitalize
  hello world
  ONE
  second message
  TWO
```

Right now this is not possible: one has to extract the string literal into a variable, but sometimes multiple heredocs are very handy. One use case I have in mind is specifying formatter specs:

```ruby
assert_format <<-INPUT, <<-OUTPUT
  def foo; 1; end
  INPUT
  def foo
    1
  end
  OUTPUT
```

[In the past](https://github.com/crystal-lang/crystal/issues/2089) I said this is not needed, maybe ugly and unnecessary. However, after some time of missing this functionality, and also after implementing [rufo](https://github.com/ruby-formatter/rufo) and understanding well how it works and how it could be implemented in Crystal, I decided to tackle this. Also because it's fun to implement this :-P

This is a small breaking change because previously we allowed stuff like this:

```crystal
puts <<-FOO
  message
  FOO.downcase
```

The rule was that a space or a symbol were allowed after the heredoc end, but this was an ugly exception and I think it doesn't work well with multiple heredocs. Plus it makes it harder to read (instead of having all logic in one line and all content in subsequent lines the logic is mixed). By I couldn't find usage of this in this project's source code, so it might be a really small breaking change.