### PR TITLE
Reenable Crystal::Hasher seed randomisation on win32

### DIFF
--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -82,9 +82,7 @@ struct Crystal::Hasher
   private HASH_INF_MINUS = (-314159_i64).unsafe_as(UInt64)
 
   @@seed = uninitialized UInt64[2]
-  {% unless flag?(:win32) %}
-    Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
-  {% end %}
+  Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
 
   def initialize(@a : UInt64 = @@seed[0], @b : UInt64 = @@seed[1])
   end


### PR DESCRIPTION
This was missed from #5539.