### PR TITLE
Rename win_nt.cr to winnt.cr

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/win_nt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/win_nt.cr
@@ -1,5 +1,0 @@
-lib LibC
-  alias LPSTR = Char*
-  alias LONG = Int32
-  alias WCHAR = UInt16
-end

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -1,4 +1,4 @@
-require "c/win_nt"
+require "c/winnt"
 require "c/win_def"
 require "c/int_safe"
 

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -1,3 +1,9 @@
 lib LibC
   alias BOOLEAN = BYTE
+  alias LONG = Int32
+
+  alias CHAR = UChar
+  alias WCHAR = UInt16
+  alias LPSTR = CHAR*
+  alias LPWSTR = WCHAR*
 end


### PR DESCRIPTION
The header file is called winnt.h, the win_nt.cr was an error and should be merged with winnt.cr.