### PR TITLE
Fix strdup for LibXML: undefined behavior

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -304,7 +304,7 @@ LibXML.xmlGcMemSetup(
   ->GC.malloc(LibC::SizeT),
   ->GC.realloc(Void*, LibC::SizeT),
   ->(str) {
-    len = LibC.strlen(str)
+    len = LibC.strlen(str) + 1
     copy = Pointer(UInt8).malloc(len)
     copy.copy_from(str, len)
     copy


### PR DESCRIPTION
The last argument of xmlGcMemSetup is a GC-aware implementation of strdup. It should return a valid C-string with the null-character.

This most likely is causing a buffer overflow condition inside libxml, because it might treat the return of this function as a null-terminated string, and it was not. This change is hard to spec.

For reference, here is `strdup` from glibc: https://gist.github.com/reagent/3758387