### PR TITLE
Allow leading '+' in number strings

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -177,6 +177,7 @@ describe BigDecimal do
   it "can be converted from other types" do
     1.to_big_d.should eq (BigDecimal.new(1))
     "1.5".to_big_d.should eq (BigDecimal.new(15, 1))
+    "+1.5".to_big_d.should eq (BigDecimal.new(15, 1))
     BigInt.new(15).to_big_d.should eq (BigDecimal.new(15, 0))
     1.5.to_big_d.should eq (BigDecimal.new(15, 1))
     1.5.to_big_f.to_big_d.should eq (BigDecimal.new(15, 1))

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -11,6 +11,8 @@ describe "BigFloat" do
     it "new(String)" do
       bigfloat_of_integer_value.to_s.should eq(string_of_integer_value)
       bigfloat_of_float_value.to_s.should eq(string_of_float_value)
+      BigFloat.new("+#{string_of_integer_value}").to_s.should eq(string_of_integer_value)
+      BigFloat.new("-#{string_of_integer_value}").to_s.should eq("-#{string_of_integer_value}")
     end
 
     it "new(BigInt)" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -22,6 +22,8 @@ describe "BigInt" do
 
   it "creates from string" do
     BigInt.new("12345678").to_s.should eq("12345678")
+    BigInt.new("+12345678").to_s.should eq("12345678")
+    BigInt.new("-12345678").to_s.should eq("-12345678")
   end
 
   it "raises if creates from string but invalid" do

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -45,6 +45,9 @@ struct BigDecimal < Number
   #
   # Allows only valid number strings with an optional negative sign.
   def initialize(str : String)
+    # Strip leading '+' char to smooth out cases with strings like "+123"
+    str = str.lchop('+')
+
     raise InvalidBigDecimalException.new(str, "Zero size") if str.bytesize == 0
 
     # Check str's validity and find index of .

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -13,6 +13,8 @@ struct BigFloat < Float
   end
 
   def initialize(str : String)
+    # Strip leading '+' char to smooth out cases with strings like "+123"
+    str = str.lchop('+')
     LibGMP.mpf_init_set_str(out @mpf, str, 10)
   end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -28,6 +28,8 @@ struct BigInt < Int
   # BigInt.new("1234567890ABCDEF", base: 16)           # => 1311768467294899695
   # ```
   def initialize(str : String, base = 10)
+    # Strip leading '+' char to smooth out cases with strings like "+123"
+    str = str.lchop('+')
     err = LibGMP.init_set_str(out @mpz, str, base)
     if err == -1
       raise ArgumentError.new("Invalid BigInt: #{str}")


### PR DESCRIPTION
This PR allows `+` leading character in numeric strings passed to `Big*` class constructors, bringing coherence to the rest of the `Number` constructors and parity with Ruby:

Crystal:

```cr
require "big"

# WORKS
"+10".to_i  # => 10
"+10".to_u8 # => 10_u8
"+10".to_f  # => 10.0

# DOESN'T WORK
"+10".to_big_i # => Invalid BigInt: +10 (ArgumentError)
"+10".to_big_d # => Invalid BigDecimal: +10 (Unexpected '+' character) (InvalidBigDecimalException)
"+10".to_big_f # => 0_big_f
```

Ruby:

```rb
require "bigdecimal"
require "bigdecimal/util"

# WORKS
"+10".to_i # => 10
"+10".to_f # => 10.0

"+10".to_d # => 0.1e2
"+10".to_r # => (10/1)
"+10".to_c # => (10+0i)
```