### PR TITLE
Fix offset handling of String#rindex with Regex

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -707,12 +707,17 @@ describe "String" do
 
   describe "rindex" do
     describe "by char" do
+      it { "bbbb".rindex('b').should eq(3) }
       it { "foobar".rindex('a').should eq(4) }
       it { "foobar".rindex('g').should be_nil }
       it { "日本語日本語".rindex('本').should eq(4) }
       it { "あいう_えお".rindex('_').should eq(3) }
 
       describe "with offset" do
+        it { "bbbb".rindex('b', 2).should eq(2) }
+        it { "abbbb".rindex('b', 0).should be_nil }
+        it { "abbbb".rindex('b', 1).should eq(1) }
+        it { "abbbb".rindex('a', 0).should eq(0) }
         it { "faobar".rindex('a', 3).should eq(1) }
         it { "faobarbaz".rindex('a', -3).should eq(4) }
         it { "日本語日本語".rindex('本', 3).should eq(1) }
@@ -720,11 +725,16 @@ describe "String" do
     end
 
     describe "by string" do
+      it { "bbbb".rindex("b").should eq(3) }
       it { "foo baro baz".rindex("o b").should eq(7) }
       it { "foo baro baz".rindex("fg").should be_nil }
       it { "日本語日本語".rindex("日本").should eq(3) }
 
       describe "with offset" do
+        it { "bbbb".rindex("b", 2).should eq(2) }
+        it { "abbbb".rindex("b", 0).should be_nil }
+        it { "abbbb".rindex("b", 1).should eq(1) }
+        it { "abbbb".rindex("a", 0).should eq(0) }
         it { "foo baro baz".rindex("o b", 6).should eq(2) }
         it { "foo".rindex("", 3).should eq(3) }
         it { "foo".rindex("", 4).should eq(3) }
@@ -738,8 +748,9 @@ describe "String" do
       it { "bbbb".rindex(/\d/).should be_nil }
 
       describe "with offset" do
-        it { "bbbb".rindex(/b/, -3).should eq(2) }
-        it { "bbbb".rindex(/b/, -1235).should be_nil }
+        it { "bbbb".rindex(/b/, 2).should eq(2) }
+        it { "abbbb".rindex(/b/, 0).should be_nil }
+        it { "abbbb".rindex(/a/, 0).should eq(0) }
         it { "日本語日本語".rindex(/日本/, 2).should eq(0) }
       end
     end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -718,6 +718,9 @@ describe "String" do
         it { "abbbb".rindex('b', 0).should be_nil }
         it { "abbbb".rindex('b', 1).should eq(1) }
         it { "abbbb".rindex('a', 0).should eq(0) }
+        it { "bbbb".rindex('b', -2).should eq(2) }
+        it { "bbbb".rindex('b', -5).should be_nil }
+        it { "bbbb".rindex('b', -4).should eq(0) }
         it { "faobar".rindex('a', 3).should eq(1) }
         it { "faobarbaz".rindex('a', -3).should eq(4) }
         it { "日本語日本語".rindex('本', 3).should eq(1) }
@@ -735,6 +738,9 @@ describe "String" do
         it { "abbbb".rindex("b", 0).should be_nil }
         it { "abbbb".rindex("b", 1).should eq(1) }
         it { "abbbb".rindex("a", 0).should eq(0) }
+        it { "bbbb".rindex("b", -2).should eq(2) }
+        it { "bbbb".rindex("b", -5).should be_nil }
+        it { "bbbb".rindex("b", -4).should eq(0) }
         it { "foo baro baz".rindex("o b", 6).should eq(2) }
         it { "foo".rindex("", 3).should eq(3) }
         it { "foo".rindex("", 4).should eq(3) }
@@ -751,6 +757,9 @@ describe "String" do
         it { "bbbb".rindex(/b/, 2).should eq(2) }
         it { "abbbb".rindex(/b/, 0).should be_nil }
         it { "abbbb".rindex(/a/, 0).should eq(0) }
+        it { "bbbb".rindex(/b/, -2).should eq(2) }
+        it { "bbbb".rindex(/b/, -5).should be_nil }
+        it { "bbbb".rindex(/b/, -4).should eq(0) }
         it { "日本語日本語".rindex(/日本/, 2).should eq(0) }
       end
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2739,14 +2739,16 @@ class String
 
   # ditto
   def rindex(search : Regex, offset = size - 1)
+    offset += size if offset < 0
     return nil unless 0 <= offset <= size
 
     match_result = nil
-    self[0..offset].scan(search) do |match_data|
+    scan(search) do |match_data|
+      break if (index = match_data.begin) && index > offset
       match_result = match_data
     end
 
-    match_result.try &.begin(0)
+    match_result.try &.begin
   end
 
   # Searches separator or pattern (`Regex`) in the string, and returns

--- a/src/string.cr
+++ b/src/string.cr
@@ -2738,12 +2738,11 @@ class String
   end
 
   # ditto
-  def rindex(search : Regex, offset = 0)
-    offset += size if offset < 0
+  def rindex(search : Regex, offset = size - 1)
     return nil unless 0 <= offset <= size
 
     match_result = nil
-    self[0, self.size - offset].scan(search) do |match_data|
+    self[0..offset].scan(search) do |match_data|
       match_result = match_data
     end
 


### PR DESCRIPTION
This also addas a few specs to ensure all variants of #rindex treat offset similarly.

Closes #5590