### PR TITLE
Use join instead of each_with_index and `if i > 0`

### DIFF
--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -128,10 +128,7 @@ module Crystal
         @str << "["
       end
 
-      node.elements.each_with_index do |exp, i|
-        @str << ", " if i > 0
-        exp.accept self
-      end
+      node.elements.join(", ", @str, &.accept self)
 
       if name
         @str << "}"
@@ -183,8 +180,7 @@ module Crystal
 
     def visit(node : NamedTupleLiteral)
       @str << "{"
-      node.entries.each_with_index do |entry, i|
-        @str << ", " if i > 0
+      node.entries.join(", ", @str) do |entry|
         visit_named_arg_name(entry.key)
         @str << ": "
         entry.value.accept self
@@ -375,10 +371,7 @@ module Crystal
         if node.name.ends_with?('=') && node.name[0].ascii_letter?
           @str << decorate_call(node, node.name.rchop)
           @str << " = "
-          node.args.each_with_index do |arg, i|
-            @str << ", " if i > 0
-            arg.accept self
-          end
+          node.args.join(", ", @str, &.accept self)
         else
           @str << decorate_call(node, node.name)
 
@@ -569,15 +562,9 @@ module Crystal
     end
 
     def visit(node : MultiAssign)
-      node.targets.each_with_index do |target, i|
-        @str << ", " if i > 0
-        target.accept self
-      end
+      node.targets.join(", ", @str, &.accept self)
       @str << " = "
-      node.values.each_with_index do |value, i|
-        @str << ", " if i > 0
-        value.accept self
-      end
+      node.values.join(", ", @str, &.accept self)
       false
     end
 
@@ -614,10 +601,7 @@ module Crystal
       @str << "->"
       if node.def.args.size > 0
         @str << "("
-        node.def.args.each_with_index do |arg, i|
-          @str << ", " if i > 0
-          arg.accept self
-        end
+        node.def.args.join(", ", @str, &.accept self)
         @str << ")"
       end
       @str << " "
@@ -639,10 +623,7 @@ module Crystal
 
       if node.args.size > 0
         @str << "("
-        node.args.each_with_index do |arg, i|
-          @str << ", " if i > 0
-          arg.accept self
-        end
+        node.args.join(", ", @str, &.accept self)
         @str << ")"
       end
       false
@@ -765,10 +746,7 @@ module Crystal
 
     def visit(node : MacroFor)
       @str << "{% for "
-      node.vars.each_with_index do |var, i|
-        @str << ", " if i > 0
-        var.accept self
-      end
+      node.vars.join(", ", @str, &.accept self)
       @str << " in "
       node.exp.accept self
       @str << " %}"
@@ -784,10 +762,7 @@ module Crystal
       @str << node.name
       if exps = node.exps
         @str << '{'
-        exps.each_with_index do |exp, i|
-          @str << ", " if i > 0
-          exp.accept self
-        end
+        exps.join(", ", @str, &.accept self)
         @str << '}'
       end
       false
@@ -838,10 +813,7 @@ module Crystal
     def visit(node : ProcNotation)
       @str << "("
       if inputs = node.inputs
-        inputs.each_with_index do |input, i|
-          @str << ", " if i > 0
-          input.accept self
-        end
+        inputs.join(", ", @str, &.accept self)
         @str << " "
       end
       @str << "-> "
@@ -857,10 +829,8 @@ module Crystal
     end
 
     def visit(node : Path)
-      node.names.each_with_index do |name, i|
-        @str << "::" if i > 0 || node.global?
-        @str << name
-      end
+      @str << "::" if node.global?
+      node.names.join("::", @str)
     end
 
     def visit(node : Generic)
@@ -886,8 +856,7 @@ module Crystal
       printed_arg = false
 
       @str << "("
-      node.type_vars.each_with_index do |var, i|
-        @str << ", " if i > 0
+      node.type_vars.join(", ", @str) do |var|
         var.accept self
         printed_arg = true
       end
@@ -932,10 +901,7 @@ module Crystal
     end
 
     def visit(node : Union)
-      node.types.each_with_index do |ident, i|
-        @str << " | " if i > 0
-        ident.accept self
-      end
+      node.types.join(" | ", @str, &.accept self)
       false
     end
 
@@ -970,10 +936,7 @@ module Crystal
       @str << keyword("yield")
       if node.exps.size > 0
         @str << " "
-        node.exps.each_with_index do |exp, i|
-          @str << ", " if i > 0
-          exp.accept self
-        end
+        node.exps.join(", ", @str, &.accept self)
       end
       false
     end
@@ -1020,10 +983,7 @@ module Crystal
       first = node.elements.first?
       space = first.is_a?(TupleLiteral) || first.is_a?(NamedTupleLiteral) || first.is_a?(HashLiteral)
       @str << " " if space
-      node.elements.each_with_index do |exp, i|
-        @str << ", " if i > 0
-        exp.accept self
-      end
+      node.elements.join(", ", @str, &.accept self)
       @str << " " if space
       @str << "}"
       false
@@ -1147,8 +1107,7 @@ module Crystal
       end
       if node.args.size > 0
         @str << "("
-        node.args.each_with_index do |arg, i|
-          @str << ", " if i > 0
+        node.args.join(", ", @str) do |arg|
           if arg_name = arg.name
             @str << arg_name << " : "
           end
@@ -1328,10 +1287,7 @@ module Crystal
       append_indent
       @str << keyword("when")
       @str << " "
-      node.conds.each_with_index do |cond, i|
-        @str << ", " if i > 0
-        cond.accept self
-      end
+      node.conds.join(", ", @str, &.accept self)
       newline
       accept_with_indent node.body
       false
@@ -1401,10 +1357,7 @@ module Crystal
           @str << " :"
         end
         @str << " "
-        types.each_with_index do |type, i|
-          @str << " | " if i > 0
-          type.accept self
-        end
+        types.join(" | ", @str, &.accept self)
       end
       newline
       accept_with_indent node.body
@@ -1423,10 +1376,7 @@ module Crystal
     def visit(node : TypeOf)
       @str << keyword("typeof")
       @str << "("
-      node.expressions.each_with_index do |exp, i|
-        @str << ", " if i > 0
-        exp.accept self
-      end
+      node.expressions.join(", ", @str, &.accept self)
       @str << ")"
       false
     end
@@ -1437,8 +1387,7 @@ module Crystal
       if !node.args.empty? || node.named_args
         @str << "("
         printed_arg = false
-        node.args.each_with_index do |arg, i|
-          @str << ", " if i > 0
+        node.args.join(", ", @str) do |arg|
           arg.accept self
           printed_arg = true
         end
@@ -1472,17 +1421,11 @@ module Crystal
       @str << ":"
       if inputs = node.inputs
         @str << " "
-        inputs.each_with_index do |input, i|
-          @str << ", " if i > 0
-          input.accept self
-        end
+        inputs.join(", ", @str, &.accept self)
       end
       if clobbers = node.clobbers
         @str << " : "
-        clobbers.each_with_index do |clobber, i|
-          @str << ", " if i > 0
-          clobber.inspect(@str)
-        end
+        clobbers.join(", ", @str, &.inspect @str)
       end
       if node.volatile? || node.alignstack? || node.intel?
         @str << " : "

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1511,10 +1511,7 @@ module Crystal
       super
       if generic_args
         io << "("
-        type_vars.each_with_index do |type_var, i|
-          io << ", " if i > 0
-          type_var.to_s(io)
-        end
+        type_vars.join(", ", io, &.to_s(io))
         io << ")"
       end
     end
@@ -1574,10 +1571,7 @@ module Crystal
       super
       if generic_args
         io << "("
-        type_vars.each_with_index do |type_var, i|
-          io << ", " if i > 0
-          type_var.to_s(io)
-        end
+        type_vars.join(", ", io, &.to_s(io))
         io << ")"
       end
     end
@@ -1703,14 +1697,12 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       generic_type.append_full_name(io)
       io << "("
-      i = 0
-      type_vars.each_value do |type_var|
+      type_vars.each_value.with_index do |type_var, i|
         io << ", " if i > 0
         if type_var.is_a?(Var)
           if i == splat_index
             tuple = type_var.type.as(TupleInstanceType)
-            tuple.tuple_types.each_with_index do |tuple_type, j|
-              io << ", " if j > 0
+            tuple.tuple_types.join(", ", io) do |tuple_type|
               tuple_type = tuple_type.devirtualize unless codegen
               tuple_type.to_s_with_options(io, codegen: codegen)
             end
@@ -1722,7 +1714,6 @@ module Crystal
         else
           type_var.to_s(io)
         end
-        i += 1
       end
       io << ")"
     end
@@ -2007,7 +1998,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       io << "Proc("
-      arg_types.each_with_index do |type, i|
+      arg_types.each do |type|
         type = type.devirtualize unless codegen
         type.to_s_with_options(io, codegen: codegen)
         io << ", "
@@ -2120,8 +2111,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       io << "Tuple("
-      @tuple_types.each_with_index do |tuple_type, i|
-        io << ", " if i > 0
+      @tuple_types.join(", ", io) do |tuple_type|
         tuple_type = tuple_type.devirtualize unless codegen
         tuple_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
       end
@@ -2234,8 +2224,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       io << "NamedTuple("
-      @entries.each_with_index do |entry, i|
-        io << ", " if i > 0
+      @entries.join(", ", io) do |entry|
         if Symbol.needs_quotes?(entry.name)
           entry.name.inspect(io)
         else
@@ -2749,8 +2738,7 @@ module Crystal
         union_types = @union_types.dup
         union_types << union_types.delete_at(nil_type_index)
       end
-      union_types.each_with_index do |type, i|
-        io << " | " if i > 0
+      union_types.join(" | ", io) do |type|
         type = type.devirtualize unless codegen
         type.to_s_with_options(io, codegen: codegen)
       end

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -80,10 +80,7 @@ class SemanticVersion
     end
 
     def to_s(io : IO)
-      identifiers.each_with_index do |s, i|
-        io << "." if i > 0
-        io << s
-      end
+      identifiers.join(".", io)
     end
 
     def <=>(other : self) : Int32


### PR DESCRIPTION
Once upon a time `each_with_index` and `if i > 0` idiom is used sometimes:

```crystal
elems.each_with_index do |elem, i|
  io << ", " if i > 0
  elem.inspect io
end
```

This idiom can be rewrite with `join(String, IO)` method:

```crystal
elems.join(", ", io, &.inspect io)
```

Wow, it is simple amazingly!