### PR TITLE
Fix default value for SSL::Context default_verify_param

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -77,7 +77,7 @@ abstract class OpenSSL::SSL::Context
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
       {% if LibSSL::OPENSSL_102 %}
-      self.default_verify_param = "ssl_client"
+      self.default_verify_param = "ssl_server"
       {% end %}
     end
 
@@ -130,7 +130,7 @@ abstract class OpenSSL::SSL::Context
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
       {% if LibSSL::OPENSSL_102 %}
-      self.default_verify_param = "ssl_server"
+      self.default_verify_param = "ssl_client"
       {% end %}
     end
 


### PR DESCRIPTION
This is a fix for #5266 but it might require a review from someone with better understanding of x509.

We've just been debugging this issue with @ggiraldez and found that it seems like the verify parameters are inverted for `Client` and `Server`.

GitHub certificates has both key usages (client and server) and that's why they pass the verification, but Google new certificate has only "server" usage.

We'd like to actually know if this verification must be enabled by default on every context. Otherwise, just the validity of the certificate is checked.

@jhass what do you think?