### PR TITLE
return correct content type for SVG images

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -93,6 +93,7 @@ class HTTP::StaticFileHandler
     when ".htm", ".html" then "text/html"
     when ".css"          then "text/css"
     when ".js"           then "application/javascript"
+    when ".svg"          then "image/svg+xml"
     else                      "application/octet-stream"
     end
   end


### PR DESCRIPTION
add the SVG content type - "image/svg+xml" to the mime_type method in static file handler