### PR TITLE
Markdown: fix handling of code fences appearing on the same line

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -70,6 +70,8 @@ describe Markdown do
   assert_render "```crystal\nHello\nWorld\n```", %(<pre><code class="language-crystal">Hello\nWorld</code></pre>)
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
+  # TODO: this should render as one code block:
+  assert_render "```invisible man```", "<p><code></code><code>invisible man</code><code></code></p>"
 
   assert_render "> Hello World\n", "<blockquote>Hello World</blockquote>"
   assert_render "> __Hello World__", "<blockquote><strong>Hello World</strong></blockquote>"

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -70,6 +70,7 @@ describe Markdown do
   assert_render "```crystal\nHello\nWorld\n```", %(<pre><code class="language-crystal">Hello\nWorld</code></pre>)
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
+  assert_render "````\n---\n````", "<pre><code>---</code></pre>"
   # TODO: this should render as one code block:
   assert_render "```invisible man```", "<p><code></code><code>invisible man</code><code></code></p>"
 

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -73,7 +73,7 @@ class Markdown::Parser
       return UnorderedList.new('-')
     end
 
-    if starts_with_backticks? line
+    if starts_with_code_fence? line
       return :fenced_code
     end
 
@@ -178,7 +178,7 @@ class Markdown::Parser
           break
         end
 
-        if starts_with_backticks? @lines[@line]
+        if starts_with_code_fence? @lines[@line]
           @line += 1
           break
         end
@@ -472,11 +472,6 @@ class Markdown::Parser
     true
   end
 
-  def next_line_starts_with_backticks?
-    return false unless @line + 1 < @lines.size
-    starts_with_backticks? @lines[@line + 1]
-  end
-
   def count_pounds(line)
     bytesize = line.bytesize
     str = line.to_unsafe
@@ -531,8 +526,8 @@ class Markdown::Parser
     !next_line.starts_with?("  ")
   end
 
-  def starts_with_backticks?(line)
-    line.starts_with? "```"
+  def starts_with_code_fence?(line)
+    line.starts_with?("```") && !line.index('`', 3)
   end
 
   def starts_with_digits_dot?(line)

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -1,6 +1,7 @@
 class Markdown::Parser
   record PrefixHeader, count : Int32
   record UnorderedList, char : Char
+  record CodeFence, language : String
 
   @lines : Array(String)
 
@@ -33,8 +34,8 @@ class Markdown::Parser
       render_horizontal_rule
     when UnorderedList
       render_unordered_list(item.char)
-    when :fenced_code
-      render_fenced_code
+    when CodeFence
+      render_fenced_code(item.language)
     when :ordered_list
       render_ordered_list
     when :quote
@@ -73,8 +74,8 @@ class Markdown::Parser
       return UnorderedList.new('-')
     end
 
-    if starts_with_code_fence? line
-      return :fenced_code
+    if (code_fence = code_fence?(line))
+      return code_fence
     end
 
     if starts_with_digits_dot? line
@@ -155,9 +156,8 @@ class Markdown::Parser
     append_double_newline_if_has_more
   end
 
-  def render_fenced_code
+  def render_fenced_code(language : String)
     line = @lines[@line]
-    language = line[3..-1].strip
 
     if language.empty?
       @renderer.begin_code nil
@@ -178,7 +178,7 @@ class Markdown::Parser
           break
         end
 
-        if starts_with_code_fence? @lines[@line]
+        if code_fence? @lines[@line]
           @line += 1
           break
         end
@@ -526,8 +526,11 @@ class Markdown::Parser
     !next_line.starts_with?("  ")
   end
 
-  def starts_with_code_fence?(line)
-    line.starts_with?("```") && !line.index('`', 3)
+  def code_fence?(line)
+    return nil unless line.starts_with?("```")
+    language = line.lstrip('`').strip
+    return nil if language.includes? '`'
+    CodeFence.new(language)
   end
 
   def starts_with_digits_dot?(line)


### PR DESCRIPTION
In conformance with http://spec.commonmark.org/0.12/#fenced-code-blocks

To avoid detecting this whole line as the language of the code:

    ```invisible man```

<!-- -->

    Expected: "<p><code></code><code>invisible man</code><code></code></p>"
         got: "<pre><code class='language-invisible man```'></code></pre>"

Also delete an unused method