### PR TITLE
Fix HTTP::StaticFileHandler to properly parse HTTP date

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -68,14 +68,13 @@ class HTTP::StaticFileHandler
       context.response.headers["Last-Modified"] = HTTP.rfc1123_date(last_modified)
 
       if if_modified_since = context.request.headers["If-Modified-Since"]?
-        # TODO: Use a more generalized time format parser for better compatibility to RFC 7232
-        header_time = Time.parse(if_modified_since, "%a, %d %b %Y %H:%M:%S GMT")
+        header_time = HTTP.parse_time(if_modified_since)
 
         # File mtime probably has a higher resolution than the header value.
         # An exact comparison might be slightly off, so we add 1s padding.
         # Static files should generally not be modified in subsecond intervals, so this is perfectly safe.
-        # This might replaced by a more sophisticated time comparison when it becomes available.
-        if last_modified <= header_time + 1.second
+        # This might be replaced by a more sophisticated time comparison when it becomes available.
+        if header_time && last_modified <= header_time + 1.second
           context.response.status_code = 304
           return
         end


### PR DESCRIPTION
Resolves inconsistent usage of `Time.parse` after #2470 and #5324 were merged recently.

This PR completely replaces it with `HTTP.parse_time` which is more appropriate in this context (that was a TODO anyway).