### PR TITLE
Correctly stub out Exception#backtrace?

### DIFF
--- a/src/exception.cr
+++ b/src/exception.cr
@@ -33,7 +33,7 @@ class Exception
   # “0xAddress: Function at File Line Column”.
   def backtrace?
     {% if flag?(:win32) %}
-      nil
+      Array(String).new
     {% else %}
       @callstack.try &.printable_backtrace
     {% end %}


### PR DESCRIPTION
Previously, this would mean `Exception#backtrace` raised, now it just returns an empty backtrace.