### PR TITLE
Use T#to_s instead of T#inspect for Array#to_s

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -10,6 +10,16 @@ private class BadSortingClass
   end
 end
 
+private class DummyType
+  def to_s(io)
+    io << "to_s"
+  end
+
+  def inspect(io)
+    io << "inspect"
+  end
+end
+
 describe "Array" do
   describe "new" do
     it "creates with default value" do
@@ -35,6 +45,18 @@ describe "Array" do
       expect_raises(ArgumentError, "Negative array size") do
         Array(Int32).new(-1)
       end
+    end
+  end
+
+  describe "to_s" do
+    it "calls to_s on all elements" do
+      [DummyType.new].to_s.should eq "[to_s]"
+    end
+  end
+
+  describe "inspect" do
+    it "calls inspect on all elements" do
+      [DummyType.new].inspect.should eq "[inspect]"
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -847,7 +847,12 @@ class Array(T)
 
   # :nodoc:
   def inspect(io : IO)
-    to_s io
+    executed = exec_recursive(:inspect) do
+      io << "["
+      join ", ", io, &.inspect(io)
+      io << "]"
+    end
+    io << "[...]" unless executed
   end
 
   # Returns the last *n* elements of the array.
@@ -1605,7 +1610,7 @@ class Array(T)
   def to_s(io : IO)
     executed = exec_recursive(:to_s) do
       io << "["
-      join ", ", io, &.inspect(io)
+      join ", ", io, &.to_s(io)
       io << "]"
     end
     io << "[...]" unless executed


### PR DESCRIPTION
- `[1_i64].to_s` gave: `[1_i64]`
- `[1_i64].inspect` gave: `[1_i64]`

It was because `Array#inspect` used `Array#to_s`, with uses `T#inspect` instead of `T#to_s`.

Now `Array#to_s` uses `T#to_s` & `Array#inspect` uses `T#inspect`:
- `[1_i64].to_s` should give: `[1]`
- `[1_i64].inspect` should give: `[1_i64]`