### PR TITLE
Raise ArgumentError if BigFloat initialized with invalid string

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -15,6 +15,12 @@ describe "BigFloat" do
       BigFloat.new("-#{string_of_integer_value}").to_s.should eq("-#{string_of_integer_value}")
     end
 
+    it "raises an ArgumentError unless string denotes valid float" do
+      expect_raises(ArgumentError) { BigFloat.new("abc") }
+      expect_raises(ArgumentError) { BigFloat.new("+") }
+      expect_raises(ArgumentError) { BigFloat.new("") }
+    end
+
     it "new(BigInt)" do
       bigfloat_on_bigint_value = BigFloat.new(BigInt.new(string_of_integer_value))
       bigfloat_on_bigint_value.should eq(bigfloat_of_integer_value)

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -15,8 +15,9 @@ struct BigFloat < Float
   def initialize(str : String)
     # Strip leading '+' char to smooth out cases with strings like "+123"
     str = str.lchop('+')
-    err = LibGMP.mpf_init_set_str(out @mpf, str, 10)
-    raise ArgumentError.new("Invalid BigFloat: #{str}") if err == -1
+    if LibGMP.mpf_init_set_str(out @mpf, str, 10) == -1
+      raise ArgumentError.new("Invalid BigFloat: #{str.inspect}")
+    end
   end
 
   def initialize(num : BigInt)

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -15,7 +15,8 @@ struct BigFloat < Float
   def initialize(str : String)
     # Strip leading '+' char to smooth out cases with strings like "+123"
     str = str.lchop('+')
-    LibGMP.mpf_init_set_str(out @mpf, str, 10)
+    err = LibGMP.mpf_init_set_str(out @mpf, str, 10)
+    raise ArgumentError.new("Invalid BigFloat: #{str}") if err == -1
   end
 
   def initialize(num : BigInt)


### PR DESCRIPTION
Raise `ArgumentError` if `BigFloat.new()` initialized with string
that doesn't represent a valid float.

Currently: 
`BigFloat.new("abc") # => 0`

Note: `BigInt.new("abc")` raises `ArgumentError`
