### PR TITLE
Missing ref to mkstemps in ARM

### DIFF
--- a/src/lib_c/arm-linux-gnueabihf/c/stdlib.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/stdlib.cr
@@ -14,6 +14,7 @@ lib LibC
   fun getenv(name : Char*) : Char*
   fun malloc(size : SizeT) : Void*
   fun mkstemp(template : Char*) : Int
+  fun mkstemps(template : Char*, suffixlen : Int) : Int
   fun putenv(string : Char*) : Int
   fun realloc(ptr : Void*, size : SizeT) : Void*
   fun realpath(name : Char*, resolved : Char*) : Char*


### PR DESCRIPTION
Should fix #5264 for ARM architecture.

I recently have to compile something in ARM architecture and the compilation was broken.

Fixing this line permits to finish the compilation.

What I don't know is why this line was not added before? Is there a problem with it on ARM architecture?

How could I check that all is OK about this?