### PR TITLE
init: Turn fork URL into a Markdown link

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -104,7 +104,7 @@ dependencies:
         readme.should contain(%{TODO: Write a description here})
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
-        readme.should contain(%{1. Fork it ( https://github.com/jsmith/example/fork )})
+        readme.should contain(%{1. Fork it (<https://github.com/jsmith/example/fork>)})
         readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
       end
 
@@ -120,7 +120,7 @@ dependencies:
         readme.should contain(%{TODO: Write a description here})
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})
-        readme.should contain(%{1. Fork it ( https://github.com/jsmith/example_app/fork )})
+        readme.should contain(%{1. Fork it (<https://github.com/jsmith/example_app/fork>)})
         readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
       end
 

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -32,7 +32,7 @@ TODO: Write development instructions here
 
 ## Contributing
 
-1. Fork it ( https://github.com/<%= config.github_name %>/<%= config.name %>/fork )
+1. Fork it (<https://github.com/<%= config.github_name %>/<%= config.name %>/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
This is a pretty small change: it just turns the fork URL generated by `crystal init` into a real Markdown link. GitHub does this automatically for things that look like URLs, but adding the angle brackets should please a broader range of Markdown parsers.

Old:

```
1. Fork it ( https://github.com/woodruffw/whatever/fork )
```

New:

```
1. Fork it (<https://github.com/woodruffw/whatever/fork>)
```