### PR TITLE
Class: add comparison operators

### DIFF
--- a/spec/std/class_spec.cr
+++ b/spec/std/class_spec.cr
@@ -1,5 +1,18 @@
 require "spec"
 
+# TODO: uncomment at v > 0.24
+# private class A
+# end
+
+# private class B1 < A
+# end
+
+# private class C1 < B1
+# end
+
+# private class B2 < A
+# end
+
 describe Class do
   it "does ===" do
     (Int32 === 1).should be_true
@@ -37,4 +50,97 @@ describe Class do
     (Int32 | String).nilable?.should be_false
     Int32?.nilable?.should be_true
   end
+
+  # TODO: uncomment at v > 0.24
+  # describe "comparison operators" do
+  #   t = [A, B1, B2, C1]
+
+  #   it "<" do
+  #     (t[0] < t[0]).should eq(false)
+  #     (t[0] < t[1]).should eq(false)
+  #     (t[0] < t[2]).should eq(false)
+  #     (t[0] < t[3]).should eq(false)
+
+  #     (t[1] < t[0]).should eq(true)
+  #     (t[1] < t[1]).should eq(false)
+  #     (t[1] < t[2]).should eq(false)
+  #     (t[1] < t[3]).should eq(false)
+
+  #     (t[2] < t[0]).should eq(true)
+  #     (t[2] < t[1]).should eq(false)
+  #     (t[2] < t[2]).should eq(false)
+  #     (t[2] < t[3]).should eq(false)
+
+  #     (t[3] < t[0]).should eq(true)
+  #     (t[3] < t[1]).should eq(true)
+  #     (t[3] < t[2]).should eq(false)
+  #     (t[3] < t[3]).should eq(false)
+  #   end
+
+  #   it "<=" do
+  #     (t[0] <= t[0]).should eq(true)
+  #     (t[0] <= t[1]).should eq(false)
+  #     (t[0] <= t[2]).should eq(false)
+  #     (t[0] <= t[3]).should eq(false)
+
+  #     (t[1] <= t[0]).should eq(true)
+  #     (t[1] <= t[1]).should eq(true)
+  #     (t[1] <= t[2]).should eq(false)
+  #     (t[1] <= t[3]).should eq(false)
+
+  #     (t[2] <= t[0]).should eq(true)
+  #     (t[2] <= t[1]).should eq(false)
+  #     (t[2] <= t[2]).should eq(true)
+  #     (t[2] <= t[3]).should eq(false)
+
+  #     (t[3] <= t[0]).should eq(true)
+  #     (t[3] <= t[1]).should eq(true)
+  #     (t[3] <= t[2]).should eq(false)
+  #     (t[3] <= t[3]).should eq(true)
+  #   end
+
+  #   it ">" do
+  #     (t[0] > t[0]).should eq(false)
+  #     (t[0] > t[1]).should eq(true)
+  #     (t[0] > t[2]).should eq(true)
+  #     (t[0] > t[3]).should eq(true)
+
+  #     (t[1] > t[0]).should eq(false)
+  #     (t[1] > t[1]).should eq(false)
+  #     (t[1] > t[2]).should eq(false)
+  #     (t[1] > t[3]).should eq(true)
+
+  #     (t[2] > t[0]).should eq(false)
+  #     (t[2] > t[1]).should eq(false)
+  #     (t[2] > t[2]).should eq(false)
+  #     (t[2] > t[3]).should eq(false)
+
+  #     (t[3] > t[0]).should eq(false)
+  #     (t[3] > t[1]).should eq(false)
+  #     (t[3] > t[2]).should eq(false)
+  #     (t[3] > t[3]).should eq(false)
+  #   end
+
+  #   it ">=" do
+  #     (t[0] >= t[0]).should eq(true)
+  #     (t[0] >= t[1]).should eq(true)
+  #     (t[0] >= t[2]).should eq(true)
+  #     (t[0] >= t[3]).should eq(true)
+
+  #     (t[1] >= t[0]).should eq(false)
+  #     (t[1] >= t[1]).should eq(true)
+  #     (t[1] >= t[2]).should eq(false)
+  #     (t[1] >= t[3]).should eq(true)
+
+  #     (t[2] >= t[0]).should eq(false)
+  #     (t[2] >= t[1]).should eq(false)
+  #     (t[2] >= t[2]).should eq(true)
+  #     (t[2] >= t[3]).should eq(false)
+
+  #     (t[3] >= t[0]).should eq(false)
+  #     (t[3] >= t[1]).should eq(false)
+  #     (t[3] >= t[2]).should eq(false)
+  #     (t[3] >= t[3]).should eq(true)
+  #   end
+  # end
 end

--- a/src/class.cr
+++ b/src/class.cr
@@ -8,8 +8,90 @@ class Class
     hasher.class(self)
   end
 
-  def ==(other : Class)
+  # Returns whether this class is the same as *other*.
+  #
+  # ```
+  # Int32 == Int32  # => true
+  # Int32 == String # => false
+  # ```
+  def ==(other : Class) : Bool
     crystal_type_id == other.crystal_type_id
+  end
+
+  # Returns whether this class inherits or includes *other*.
+  #
+  # ```
+  # Int32 < Number  # => true
+  # Int32 < Value   # => true
+  # Int32 < Int32   # => false
+  # Int32 <= String # => false
+  # ```
+  def <(other : T.class) : Bool forall T
+    # This is so that the method is expanded differently for each type
+    {% @type %}
+    other._gt(self)
+  end
+
+  # Returns whether this class inherits or includes *other*, or
+  # is equal to *other*.
+  #
+  # ```
+  # Int32 < Number  # => true
+  # Int32 < Value   # => true
+  # Int32 <= Int32  # => true
+  # Int32 <= String # => false
+  # ```
+  def <=(other : T.class) : Bool forall T
+    # This is so that the method is expanded differently for each type
+    {% @type %}
+    other._gte(self)
+  end
+
+  # Returns whether *other* inherits or includes `self`.
+  #
+  # ```
+  # Number > Int32  # => true
+  # Number > Number # => false
+  # Number > Object # => false
+  # ```
+  def >(other : T.class) forall T
+    # This is so that the method is expanded differently for each type
+    {% @type %}
+    other._lt(self)
+  end
+
+  # Returns whether *other* inherits or includes `self`, or is equal
+  # to `self`.
+  #
+  # ```
+  # Number >= Int32  # => true
+  # Number >= Number # => true
+  # Number >= Object # => false
+  # ```
+  def >=(other : T.class) forall T
+    # This is so that the method is expanded differently for each type
+    {% @type %}
+    other._lte(self)
+  end
+
+  # :nodoc:
+  def _lt(other : T.class) forall T
+    {{ @type < T }}
+  end
+
+  # :nodoc:
+  def _lte(other : T.class) forall T
+    {{ @type <= T }}
+  end
+
+  # :nodoc:
+  def _gt(other : T.class) forall T
+    {{ @type > T }}
+  end
+
+  # :nodoc:
+  def _gte(other : T.class) forall T
+    {{ @type >= T }}
   end
 
   def ===(other)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1512,8 +1512,9 @@ module Crystal
             raise "TypeNode##{method} expects TypeNode, not #{arg.class_desc}"
           end
 
-          self_type = self.type
-          other_type = arg.type
+          self_type = self.type.devirtualize
+          other_type = arg.type.devirtualize
+
           case method
           when "<"
             value = self_type != other_type && self_type.implements?(other_type)


### PR DESCRIPTION
Fixes #2060

The problem with combining types in a same hierarchy is that the compiler combines them to their parent type as a virtual type. Then when you pass it to a method and match with `other : T.class`, that `T` is the virtual type.

I solve this with using `@type` inside macro code, which signals that the method must be expanded separately for each different type. Well, that solves the problem for `self`, but the problem still remains for `other`. That's why I invoke the opposite method in `other` using a helper method and there too, I use `@type` inside macro code, and actually use macro code to achieve that.

It works. It could always be improved later if we find that's needed. The specs are commented because I also had to change something in the macro comparison code, so those will fail for CI... but we can uncomment those in a next version.