### PR TITLE
Spec: implement `be_a` and `expect_raises` without macros

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -91,7 +91,7 @@ describe Socket::Addrinfo do
     end
 
     it "eventually raises returned error" do
-      expect_raises(Socket::Error) do |addrinfo|
+      expect_raises(Socket::Error) do
         Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::DGRAM) do |addrinfo|
           Socket::Error.new("please fail")
         end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -267,17 +267,8 @@ module Spec
     end
 
     # Creates an `Expectation` that passes if actual is of type *type* (`is_a?`).
-    macro be_a(type)
-      Spec::BeAExpectation({{type}}).new
-    end
-
-    # Runs the block and passes if it raises an exception of type *klass*.
-    #
-    # It returns the rescued exception.
-    macro expect_raises(klass)
-      expect_raises({{klass}}, nil) do
-        {{yield}}
-      end
+    def be_a(type : T.class) forall T
+      Spec::BeAExpectation(T).new
     end
 
     # Runs the block and passes if it raises an exception of type *klass* and the error message matches.
@@ -286,41 +277,40 @@ module Spec
     # If *message* is a regular expression, it is used to match the error message.
     #
     # It returns the rescued exception.
-    macro expect_raises(klass, message, file = __FILE__, line = __LINE__)
-      %failed = false
+    def expect_raises(klass : T.class, message = nil, file = __FILE__, line = __LINE__) forall T
+      failed = false
       begin
-        {{yield}}
-        %failed = true
-        fail "Expected {{klass.id}} but nothing was raised", {{file}}, {{line}}
-      rescue %ex : {{klass.id}}
+        yield
+        failed = true
+        fail "Expected #{klass} but nothing was raised", file, line
+      rescue ex : T
         # We usually bubble Spec::AssertaionFailed, unless this is the expected exception
-        if %ex.class == Spec::AssertionFailed && {{klass}} != Spec::AssertionFailed
-          raise %ex
+        if ex.is_a?(Spec::AssertionFailed) && klass != Spec::AssertionFailed
+          raise ex
         end
 
-        %msg = {{message}}
-        %ex_to_s = %ex.to_s
-        case %msg
+        ex_to_s = ex.to_s
+        case message
         when Regex
-          unless (%ex_to_s =~ %msg)
-            backtrace = %ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-            fail "Expected {{klass.id}} with message matching #{ %msg.inspect }, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
+          unless (ex_to_s =~ message)
+            backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+            fail "Expected #{klass} with message matching #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
           end
         when String
-          unless %ex_to_s.includes?(%msg)
-            backtrace = %ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-            fail "Expected {{klass.id}} with #{ %msg.inspect }, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
+          unless ex_to_s.includes?(message)
+            backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+            fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
           end
         end
 
-        %ex
-      rescue %ex
-        if %failed
-          raise %ex
+        ex
+      rescue ex
+        if failed
+          raise ex
         else
-          %ex_to_s = %ex.to_s
-          backtrace = %ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-          fail "Expected {{klass.id}}, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
+          ex_to_s = ex.to_s
+          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+          fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
       end
     end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -289,21 +289,23 @@ module Spec
       case message
       when Regex
         unless (ex_to_s =~ message)
-          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-          fail "Expected #{klass} with message matching #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+          backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+          fail "Expected #{klass} with message matching #{message.inspect}, " \
+               "got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
       when String
         unless ex_to_s.includes?(message)
-          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-          fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+          backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+          fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: " \
+               "#{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
       end
 
       ex
     rescue ex
-      ex_to_s = ex.to_s
-      backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-      fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+      backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+      fail "Expected #{klass}, got #<#{ex.class}: #{ex.to_s}> with backtrace:\n" \
+           "#{backtrace}", file, line
     else
       fail "Expected #{klass} but nothing was raised", file, line
     end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -278,36 +278,34 @@ module Spec
     #
     # It returns the rescued exception.
     def expect_raises(klass : T.class, message = nil, file = __FILE__, line = __LINE__) forall T
-      begin
-        yield
-      rescue ex : T
-        # We usually bubble Spec::AssertaionFailed, unless this is the expected exception
-        if ex.is_a?(Spec::AssertionFailed) && klass != Spec::AssertionFailed
-          raise ex
-        end
-
-        ex_to_s = ex.to_s
-        case message
-        when Regex
-          unless (ex_to_s =~ message)
-            backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-            fail "Expected #{klass} with message matching #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
-          end
-        when String
-          unless ex_to_s.includes?(message)
-            backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-            fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
-          end
-        end
-
-        ex
-      rescue ex
-        ex_to_s = ex.to_s
-        backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-        fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
-      else
-        fail "Expected #{klass} but nothing was raised", file, line
+      yield
+    rescue ex : T
+      # We usually bubble Spec::AssertaionFailed, unless this is the expected exception
+      if ex.is_a?(Spec::AssertionFailed) && klass != Spec::AssertionFailed
+        raise ex
       end
+
+      ex_to_s = ex.to_s
+      case message
+      when Regex
+        unless (ex_to_s =~ message)
+          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+          fail "Expected #{klass} with message matching #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+        end
+      when String
+        unless ex_to_s.includes?(message)
+          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+          fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+        end
+      end
+
+      ex
+    rescue ex
+      ex_to_s = ex.to_s
+      backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+      fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+    else
+      fail "Expected #{klass} but nothing was raised", file, line
     end
   end
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -278,11 +278,8 @@ module Spec
     #
     # It returns the rescued exception.
     def expect_raises(klass : T.class, message = nil, file = __FILE__, line = __LINE__) forall T
-      failed = false
       begin
         yield
-        failed = true
-        fail "Expected #{klass} but nothing was raised", file, line
       rescue ex : T
         # We usually bubble Spec::AssertaionFailed, unless this is the expected exception
         if ex.is_a?(Spec::AssertionFailed) && klass != Spec::AssertionFailed
@@ -305,13 +302,11 @@ module Spec
 
         ex
       rescue ex
-        if failed
-          raise ex
-        else
-          ex_to_s = ex.to_s
-          backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
-          fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
-        end
+        ex_to_s = ex.to_s
+        backtrace = ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+        fail "Expected #{klass}, got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
+      else
+        fail "Expected #{klass} but nothing was raised", file, line
       end
     end
   end


### PR DESCRIPTION
Code without macros is easier to read.