### PR TITLE
Don't use heredoc inside interpolation

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1203,6 +1203,7 @@ describe "Parser" do
   assert_syntax_error "<<-HERE\n   One\n  \#{1}\n wrong\n  HERE", "heredoc line must have an indent greater or equal than 2", 4, 1
   assert_syntax_error "<<-HERE\n   One\n  \#{1}\n wrong\#{1}\n  HERE", "heredoc line must have an indent greater or equal than 2", 4, 1
   assert_syntax_error "<<-HERE\n One\n  \#{1}\n  HERE", "heredoc line must have an indent greater or equal than 2", 2, 1
+  assert_syntax_error %("\#{<<-HERE}"\nHERE), "heredoc cannot be used inside interpolation"
   assert_syntax_error %("foo" "bar")
 
   it_parses "<<-'HERE'\n  hello \\n world\n  \#{1}\n  HERE", "hello \\n world\n\#{1}".string_interpolation


### PR DESCRIPTION
A heredoc inside interpolation is buggy. For example, this code cannot be compiled even though it was valid Ruby code:

```crystal
p <<-HERE1
  here1-1
  #{<<-HERE2}
    here2
  HERE2
  here1-2
HERE1
```

And this code is compiled even though it was invalid Ruby code:

```crystal
p "#{<<-HERE}
"
hello
HERE
# => "hello\n"
```

I tried to fix these, however I did't complete it and I found it is a bit hard to fix.
A heredoc inside interpolation is very tricky, so I suggest forbidding this.

Thank you.