### PR TITLE
Fix String#dump for UTF-8 charachters > \uFFFF

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1452,15 +1452,17 @@ describe "String" do
     "\t".dump.should eq("\"\\t\"")
     "\v".dump.should eq("\"\\v\"")
     "\#{".dump.should eq("\"\\\#{\"")
-    "á".dump.should eq("\"\\u00e1\"")
+    "á".dump.should eq("\"\\u00E1\"")
     "\u{81}".dump.should eq("\"\\u0081\"")
+    "\u{1F48E}".dump.should eq %("\\u{1F48E}")
   end
 
   it "dumps unquoted" do
     "a".dump_unquoted.should eq("a")
     "\\".dump_unquoted.should eq("\\\\")
-    "á".dump_unquoted.should eq("\\u00e1")
+    "á".dump_unquoted.should eq("\\u00E1")
     "\u{81}".dump_unquoted.should eq("\\u0081")
+    "\u{1F48E}".dump_unquoted.should eq "\\u{1F48E}"
   end
 
   it "inspects" do
@@ -1477,6 +1479,7 @@ describe "String" do
     "\#{".inspect.should eq("\"\\\#{\"")
     "á".inspect.should eq("\"á\"")
     "\u{81}".inspect.should eq("\"\\u0081\"")
+    "\u{1F48E}".inspect.should eq %("\u{1F48E}")
   end
 
   it "inspects unquoted" do
@@ -1484,6 +1487,7 @@ describe "String" do
     "\\".inspect_unquoted.should eq("\\\\")
     "á".inspect_unquoted.should eq("á")
     "\u{81}".inspect_unquoted.should eq("\\u0081")
+    "\u{1F48E}".inspect_unquoted.should eq "\u{1F48E}"
   end
 
   it "does *" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -3950,11 +3950,12 @@ class String
 
   private def dump_unicode(char, io)
     io << "\\u"
+    io << '{' if char.ord > 65535
     io << "0" if char.ord < 4096
     io << "0" if char.ord < 256
     io << "0" if char.ord < 16
-    char.ord.to_s(16, io)
-    io << ""
+    char.ord.to_s(16, io, upcase: true)
+    io << '}' if char.ord > 65535
   end
 
   def starts_with?(str : String)


### PR DESCRIPTION
`String#dump` formatted unicode characters with more than four hex digits (> `\uFFFF`) without braces:
`"\u{1F48E}".dump` returned `%("\\u1f48e")`.

This PR fixes that to put large codepoints in braces.

I also changed the hex digits to use upper case, I think that's preferable. This variant is used throughout the docs.