### PR TITLE
Support BigDecimal comparison with and initialization from BigRational

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -65,6 +65,9 @@ describe BigDecimal do
 
     BigDecimal.new(BigDecimal.new(2))
       .should eq(BigDecimal.new(2.to_big_i))
+
+    BigDecimal.new(BigRational.new(1, 2))
+      .should eq(BigDecimal.new(BigInt.new(5), 1))
   end
 
   it "raises InvalidBigDecimalException when initializing from invalid input" do
@@ -181,6 +184,7 @@ describe BigDecimal do
     BigInt.new(15).to_big_d.should eq (BigDecimal.new(15, 0))
     1.5.to_big_d.should eq (BigDecimal.new(15, 1))
     1.5.to_big_f.to_big_d.should eq (BigDecimal.new(15, 1))
+    1.5.to_big_r.to_big_d.should eq(BigDecimal.new(15, 1))
   end
 
   it "can be converted from scientific notation" do
@@ -243,6 +247,12 @@ describe BigDecimal do
 
     (BigDecimal.new("6.5") > 7).should be_false
     (BigDecimal.new("7.5") > 6).should be_true
+
+    BigDecimal.new("0.5").should eq(BigRational.new(1, 2))
+    BigDecimal.new("0.25").should eq(BigDecimal.new("0.25"))
+
+    BigRational.new(1, 2).should eq(BigDecimal.new("0.5"))
+    BigRational.new(1, 4).should eq(BigDecimal.new("0.25"))
   end
 
   it "keeps precision" do

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -19,11 +19,25 @@ struct BigDecimal < Number
   DEFAULT_MAX_DIV_ITERATIONS = 100_u64
 
   include Comparable(Int)
-  include Comparable(BigDecimal)
   include Comparable(Float)
+  include Comparable(BigRational)
+  include Comparable(BigDecimal)
 
   getter value : BigInt
   getter scale : UInt64
+
+  # Creates a new `BigDecimal` from `Float`.
+  #
+  # NOTE: Floats are fundamentally less precise than BigDecimals,
+  # which makes initialization from them risky.
+  def self.new(num : Float)
+    new(num.to_s)
+  end
+
+  # Creates a new `BigDecimal` from `BigRational`.
+  def self.new(num : BigRational)
+    num.numerator.to_big_d / num.denominator.to_big_d
+  end
 
   # Returns *num*. Useful for generic code that does `T.new(...)` with `T`
   # being a `Number`.
@@ -125,14 +139,6 @@ struct BigDecimal < Number
     end
   end
 
-  # Creates a new `BigDecimal` from `Float`.
-  #
-  # NOTE: Floats are fundamentally less precise than BigDecimals,
-  # which makes initialization from them risky.
-  def initialize(num : Float)
-    initialize(num.to_s)
-  end
-
   def - : BigDecimal
     BigDecimal.new(-@value, @scale)
   end
@@ -225,15 +231,16 @@ struct BigDecimal < Number
     end
   end
 
-  def <=>(other : Int | Float)
+  def <=>(other : Int | Float | BigRational)
     self <=> BigDecimal.new(other)
   end
 
   def ==(other : BigDecimal) : Bool
-    if @scale > other.scale
+    case @scale
+    when .>(other.scale)
       scaled = other.value * power_ten_to(@scale - other.scale)
       @value == scaled
-    elsif @scale < other.scale
+    when .<(other.scale)
       scaled = @value * power_ten_to(other.scale - @scale)
       scaled == other.value
     else
@@ -453,6 +460,19 @@ struct Float
   #
   # NOTE: Floats are fundamentally less precise than BigDecimals,
   # which makes conversion to them risky.
+  def to_big_d
+    BigDecimal.new(self)
+  end
+end
+
+struct BigRational
+  include Comparable(BigDecimal)
+
+  def <=>(other : BigDecimal)
+    to_big_d <=> other
+  end
+
+  # Converts `self` to `BigDecimal`.
   def to_big_d
     BigDecimal.new(self)
   end


### PR DESCRIPTION
This PR allows below code to work:

```cr
def add_numbers(*numbers : Number)
  numbers.reduce(0.to_big_d) { |sum, n| sum + n.to_big_d }
end

add_numbers(1, 1.23, 3.to_big_d, 3.3.to_big_r) # => 8.53
```