### PR TITLE
Fixed OpenSSL bindings to recognize LibreSSL

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -84,7 +84,7 @@ prepare_build() {
 
   on_linux docker pull "jhass/crystal-build-$ARCH"
 
-  on_osx brew install crystal-lang
+  on_osx brew install crystal-lang pkg-config
 
   # Make sure binaries from llvm are available in PATH
   on_osx brew install jq
@@ -123,6 +123,7 @@ with_build_env() {
   on_osx sudo systemsetup -settimezone $TZ
   on_osx PATH="/usr/local/opt/llvm/bin:\$PATH" \
     CRYSTAL_CACHE_DIR="/tmp/crystal" \
+    PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" \
     /bin/sh -c "'$command'"
 
 }

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,7 +1,16 @@
 {% begin %}
   lib LibCrypto
-    OPENSSL_110 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libcrypto || printf %s false`.stringify != "false" }}
-    OPENSSL_102 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libcrypto || printf %s false`.stringify != "false" }}
+    # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
+    # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
+    LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + " -E -").chomp.split('\n').last.split('L').first.id + "0" }}
+    OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + " -E -").chomp.split('\n').last.split('L').first.id }}
+  end
+{% end %}
+
+{% begin %}
+  lib LibCrypto
+    OPENSSL_110 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10101000) }}
+    OPENSSL_102 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10002000) }}
   end
 {% end %}
 

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -15,6 +15,7 @@
   lib LibCrypto
     OPENSSL_110 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10101000) }}
     OPENSSL_102 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10002000) }}
+    LIBRESSL_250 = {{ LibCrypto::LIBRESSL_VERSION >= 0x205000000 }}
   end
 {% end %}
 

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -2,12 +2,13 @@
   lib LibCrypto
     # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
     # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
-    {{ p "On newer OS X systems, the OpenSSL/LibreSSL library supplied by the system may be newer than homebrew ones. If you wish to use them, set the compilation flag OPENSSL_NOBREW." if flag?(:darwin) && !flag?(:OPENSSL_NOBREW) }}
+    # On newer OS X systems, the OpenSSL/LibreSSL library supplied by the system may be newer than homebrew ones. If you wish to use them, set the compilation flag OPENSSL_NOBREW.
+    # Also on OS X, set the compilation flag LIBRESSL_BREW to use the libressl provided by homebrew.
     LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " + (env("CC") || "cc") +
-                                 ((flag?(:darwin) && !flag?(:OPENSSL_NOBREW)) ? (" -I" + `command -v brew > /dev/null && brew --prefix openssl`.chomp.stringify + "/include") : "") +
+                                 ((flag?(:darwin) && !flag?(:OPENSSL_NOBREW)) ? (" -I" + system("command -v brew > /dev/null && brew --prefix " + (flag?(:LIBRESSL_BREW) ? "libressl" : "openssl")).chomp.stringify + "/include") : "") +
                                  " -E -").chomp.split('\n').last.split('L').first.id + "0" }}
     OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " + (env("CC") || "cc") +
-                                ((flag?(:darwin) && !flag?(:OPENSSL_NOBREW)) ? (" -I" + `command -v brew > /dev/null && brew --prefix openssl`.chomp.stringify + "/include") : "") +
+                                ((flag?(:darwin) && !flag?(:OPENSSL_NOBREW)) ? (" -I" + system("command -v brew > /dev/null && brew --prefix " + (flag?(:LIBRESSL_BREW) ? "libressl" : "openssl")).chomp.stringify + "/include") : "") +
                                 " -E -").chomp.split('\n').last.split('L').first.id }}
   end
 {% end %}
@@ -22,7 +23,11 @@
 
 # Check for brew's openssl libs on OS X
 {% if flag?(:darwin) && !flag?(:OPENSSL_NOBREW) %}
-  @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
+  {% if flag?(:LIBRESSL_BREW) %}
+    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix libressl; echo '/lib') | tr -d '\n'`")]
+  {% else %}
+    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
+  {% end %}
 {% end %}
 @[Link("crypto")]
 lib LibCrypto

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -2,8 +2,8 @@
   lib LibCrypto
     # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
     # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
-    LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + " -E -").chomp.split('\n').last.split('L').first.id + "0" }}
-    OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + " -E -").chomp.split('\n').last.split('L').first.id }}
+    LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + (flag?(:darwin) ? " -I/usr/local/opt/openssl/include" : "") + " -E -").chomp.split('\n').last.split('L').first.id + "0" }}
+    OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " + (env("CC") || "cc") + (flag?(:darwin) ? " -I/usr/local/opt/openssl/include" : "") + " -E -").chomp.split('\n').last.split('L').first.id }}
   end
 {% end %}
 

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -10,7 +10,11 @@ require "./lib_crypto"
 
 # Check for brew's openssl libs on OS X
 {% if flag?(:darwin) && !flag?(:OPENSSL_NOBREW) %}
-  @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
+  {% if flag?(:LIBRESSL_BREW) %}
+    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix libressl; echo '/lib') | tr -d '\n'`")]
+  {% else %}
+    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
+  {% end %}
 {% end %}
 @[Link("crypto")]
 @[Link("ssl")]

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -7,6 +7,10 @@ require "./lib_crypto"
   end
 {% end %}
 
+# Check for brew's openssl libs on OS X
+{% if flag?(:darwin) %}
+  @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix || echo '/usr/local'; echo '/opt/openssl/lib') | tr -d '\n'`")]
+{% end %}
 @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
 lib LibSSL
   alias Int = LibC::Int

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -8,16 +8,7 @@ require "./lib_crypto"
   end
 {% end %}
 
-# Check for brew's openssl libs on OS X
-{% if flag?(:darwin) && !flag?(:OPENSSL_NOBREW) %}
-  {% if flag?(:LIBRESSL_BREW) %}
-    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix libressl; echo '/lib') | tr -d '\n'`")]
-  {% else %}
-    @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
-  {% end %}
-{% end %}
-@[Link("crypto")]
-@[Link("ssl")]
+@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
 lib LibSSL
   alias Int = LibC::Int
   alias Char = LibC::Char

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -9,10 +9,11 @@ require "./lib_crypto"
 {% end %}
 
 # Check for brew's openssl libs on OS X
-{% if flag?(:darwin) %}
-  @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix || echo '/usr/local'; echo '/opt/openssl/lib') | tr -d '\n'`")]
+{% if flag?(:darwin) && !flag?(:OPENSSL_NOBREW) %}
+  @[Link(ldflags: "`(echo '-L'; command -v brew > /dev/null && brew --prefix openssl; echo '/lib') | tr -d '\n'`")]
 {% end %}
-@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
+@[Link("crypto")]
+@[Link("ssl")]
 lib LibSSL
   alias Int = LibC::Int
   alias Char = LibC::Char

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -2,8 +2,8 @@ require "./lib_crypto"
 
 {% begin %}
   lib LibSSL
-    OPENSSL_110 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libssl || printf %s false`.stringify != "false" }}
-    OPENSSL_102 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libssl || printf %s false`.stringify != "false" }}
+    OPENSSL_110 = {{ LibCrypto::OPENSSL_110 }}
+    OPENSSL_102 = {{ LibCrypto::OPENSSL_102 }}
   end
 {% end %}
 

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -4,6 +4,7 @@ require "./lib_crypto"
   lib LibSSL
     OPENSSL_110 = {{ LibCrypto::OPENSSL_110 }}
     OPENSSL_102 = {{ LibCrypto::OPENSSL_102 }}
+    LIBRESSL_250 = {{ LibCrypto::LIBRESSL_250 }}
   end
 {% end %}
 
@@ -202,13 +203,17 @@ lib LibSSL
     fun sslv23_method = SSLv23_method : SSLMethod
   {% end %}
 
-  {% if OPENSSL_102 %}
+  {% if OPENSSL_102 || LIBRESSL_250 %}
     alias ALPNCallback = (SSL, Char**, Char*, Char*, Int, Void*) -> Int
+
+    fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
+    fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
+  {% end %}
+
+  {% if OPENSSL_102 %}
     alias X509VerifyParam = LibCrypto::X509VerifyParam
 
     fun ssl_get0_param = SSL_get0_param(handle : SSL) : X509VerifyParam
-    fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
-    fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
     fun ssl_ctx_get0_param = SSL_CTX_get0_param(ctx : SSLContext) : X509VerifyParam
     fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int
   {% end %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -305,7 +305,7 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  {% if LibSSL::OPENSSL_102 %}
+  {% if LibSSL::OPENSSL_102 || LibSSL::LIBRESSL_250 %}
 
   @alpn_protocol : Pointer(Void)?
 
@@ -337,6 +337,10 @@ abstract class OpenSSL::SSL::Context
     @alpn_protocol = alpn_protocol = Box.box(protocol)
     LibSSL.ssl_ctx_set_alpn_select_cb(@handle, alpn_cb, alpn_protocol)
   end
+
+  {% end %}
+
+  {% if LibSSL::OPENSSL_102 %}
 
   # Set this context verify param to the default one of the given name.
   #

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -119,7 +119,7 @@ abstract class OpenSSL::SSL::Socket < IO
     @bio.io.flush
   end
 
-  {% if LibSSL::OPENSSL_102 %}
+  {% if LibSSL::OPENSSL_102 || LibSSL::LIBRESSL_250 %}
   # Returns the negotiated ALPN protocol (eg: `"h2"`) of `nil` if no protocol was
   # negotiated.
   def alpn_protocol


### PR DESCRIPTION
Used the C preprocessor from `cc` to get `LIBRESSL_VERSION_NUMBER` and `LIBRESSL_VERSION_NUMBER` which are used to determine `OPENSSL_110` and `OPENSSL_102`, as @RX14 suggested. This fixes #4676. Tested on my Void Linux machine with LibreSSL.