### PR TITLE
Fix: uninitialized sa_mask value in sigfault handler

### DIFF
--- a/src/ext/sigfault.c
+++ b/src/ext/sigfault.c
@@ -18,6 +18,7 @@ void setup_sigfault_handler() {
   altstack.ss_flags = 0;
   sigaltstack(&altstack, NULL);
 
+  sigemptyset(&action.sa_mask);
   action.sa_flags = SA_ONSTACK | SA_SIGINFO;
   action.sa_sigaction = &sigfault_handler;
 


### PR DESCRIPTION
Valgrind complains that the `sigaction.sa_mask` value in the sigfault handler was uninitialized, and indeed it wasn't zeroed.