### PR TITLE
Fix: HTTP::FormData parsing of multipart subparts

### DIFF
--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -133,7 +133,7 @@ module HTTP::FormData
 
     parts = content_disposition.split(';')
     type = parts[0]
-  raise Error.new("Invalid Content-Disposition: not form-data or file") unless ["form-data", "file"].includes?(type)
+    raise Error.new("Invalid Content-Disposition: not form-data or file") unless {"form-data", "file"}.includes?(type)
     (1...parts.size).each do |i|
       part = parts[i]
 

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -133,7 +133,7 @@ module HTTP::FormData
 
     parts = content_disposition.split(';')
     type = parts[0]
-    raise Error.new("Invalid Content-Disposition: not form-data") unless type == "form-data"
+  raise Error.new("Invalid Content-Disposition: not form-data or file") unless ["form-data", "file"].includes?(type)
     (1...parts.size).each do |i|
       part = parts[i]
 


### PR DESCRIPTION
For example post data see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
In a multi-file upload the files are uploaded as a subpart with `Content-Disposition: file; filename="file1.txt"` this patch allows parsing of subparts using the standard library.

References: https://tools.ietf.org/html/rfc2388

```
   either of the "content-disposition: form-data"
   header or, in the case of multiple files, in a "content-disposition:
   file" header of the subpart.
```