### PR TITLE
Fix custom array/hash-like literals in nested modules

### DIFF
--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -130,4 +130,50 @@ describe "Code gen: array literal spec" do
       custom.value
       )).to_i.should eq(6)
   end
+
+  it "creates custom non-generic array in module" do
+    run(%(
+      module Moo
+        class Custom
+          def initialize
+            @value = 0
+          end
+
+          def <<(element)
+            @value += element
+          end
+
+          def value
+            @value
+          end
+        end
+      end
+
+      custom = Moo::Custom {1, 2, 3}
+      custom.value
+      )).to_i.should eq(6)
+  end
+
+  it "creates custom generic array in module (#5684)" do
+    run(%(
+      module Moo
+        class Custom(T)
+          def initialize
+            @value = 0
+          end
+
+          def <<(element : T)
+            @value += element
+          end
+
+          def value
+            @value
+          end
+        end
+      end
+
+      custom = Moo::Custom {1, 2, 3}
+      custom.value
+      )).to_i.should eq(6)
+  end
 end

--- a/spec/compiler/codegen/hash_literal_spec.cr
+++ b/spec/compiler/codegen/hash_literal_spec.cr
@@ -152,4 +152,62 @@ describe "Code gen: hash literal spec" do
       b["a"].call
       )).to_i.should eq(1)
   end
+
+  it "creates custom non-generic hash in module" do
+    run(%(
+      module Moo
+        class Custom
+          def initialize
+            @keys = 0
+            @values = 0
+          end
+
+          def []=(key, value)
+            @keys += key
+            @values += value
+          end
+
+          def keys
+            @keys
+          end
+
+          def values
+            @values
+          end
+        end
+      end
+
+      custom = Moo::Custom {1 => 10, 2 => 20}
+      custom.keys * custom.values
+      )).to_i.should eq(90)
+  end
+
+  it "creates custom generic hash in module (#5684)" do
+    run(%(
+      module Moo
+        class Custom(K, V)
+          def initialize
+            @keys = 0
+            @values = 0
+          end
+
+          def []=(key, value)
+            @keys += key
+            @values += value
+          end
+
+          def keys
+            @keys
+          end
+
+          def values
+            @values
+          end
+        end
+      end
+
+      custom = Moo::Custom {1 => 10, 2 => 20}
+      custom.keys * custom.values
+      )).to_i.should eq(90)
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2795,19 +2795,16 @@ module Crystal
 
         case type
         when GenericClassType
-          type_name = type.name.split "::"
-
-          path = Path.global(type_name).at(node.location)
+          generic_type = TypeNode.new(type).at(node.location)
           type_of = TypeOf.new(node.elements).at(node.location)
-          generic = Generic.new(path, type_of).at(node.location)
+
+          generic = Generic.new(generic_type, type_of).at(node.location)
 
           node.name = generic
         when GenericClassInstanceType
           # Nothing
         else
-          type_name = type.to_s.split "::"
-          path = Path.global(type_name).at(node.location)
-          node.name = path
+          node.name = TypeNode.new(name.type).at(node.location)
         end
 
         expand_named(node)
@@ -2823,22 +2820,16 @@ module Crystal
 
         case type
         when GenericClassType
-          type_name = type.name.split "::"
-
-          path = Path.global(type_name).at(node.location)
+          generic_type = TypeNode.new(type).at(node.location)
           type_of_keys = TypeOf.new(node.entries.map { |x| x.key.as(ASTNode) }).at(node.location)
           type_of_values = TypeOf.new(node.entries.map { |x| x.value.as(ASTNode) }).at(node.location)
-          generic = Generic.new(path, [type_of_keys, type_of_values] of ASTNode).at(node.location)
+          generic = Generic.new(generic_type, [type_of_keys, type_of_values] of ASTNode).at(node.location)
 
           node.name = generic
         when GenericClassInstanceType
           # Nothing
         else
-          type_name = type.to_s.split "::"
-
-          path = Path.global(type_name).at(node.location)
-
-          node.name = path
+          node.name = TypeNode.new(name.type).at(node.location)
         end
 
         expand_named(node)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -395,7 +395,7 @@ module Crystal
 
     def restrict(other : Generic, context)
       # Special case: consider `Union(X, Y, ...)` the same as `X | Y | ...`
-      generic_type = context.defining_type.lookup_path other.name
+      generic_type = get_generic_type(other, context)
       if generic_type.is_a?(GenericUnionType)
         return restrict(Union.new(other.type_vars), context)
       end
@@ -545,7 +545,7 @@ module Crystal
     end
 
     def restrict(other : Generic, context)
-      generic_type = context.defining_type.lookup_path other.name
+      generic_type = get_generic_type(other, context)
       generic_type = generic_type.remove_alias if generic_type.is_a? AliasType
       return super unless generic_type == self.generic_type
 
@@ -683,7 +683,7 @@ module Crystal
     end
 
     def restrict(other : Generic, context)
-      generic_type = context.defining_type.lookup_path other.name
+      generic_type = get_generic_type(other, context)
       return super unless generic_type == self.generic_type
 
       generic_type = generic_type.as(TupleType)
@@ -743,7 +743,7 @@ module Crystal
     end
 
     def restrict(other : Generic, context)
-      generic_type = context.defining_type.lookup_path other.name
+      generic_type = get_generic_type(other, context)
       return super unless generic_type == self.generic_type
 
       other_named_args = other.named_args
@@ -1023,7 +1023,7 @@ module Crystal
     end
 
     def restrict(other : Generic, context)
-      generic_type = context.defining_type.lookup_path other.name
+      generic_type = get_generic_type(other, context)
       return super unless generic_type.is_a?(ProcType)
 
       # Consider the case of a splat in the type vars
@@ -1089,5 +1089,14 @@ module Crystal
 
       true
     end
+  end
+end
+
+private def get_generic_type(node, context)
+  name = node.name
+  if name.is_a?(Crystal::Path)
+    context.defining_type.lookup_path name
+  else
+    name.type
   end
 end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -597,7 +597,8 @@ module Crystal
       end
 
       # If it's Pointer(T).malloc or Pointer(T).null, guess it to Pointer(T)
-      if obj.is_a?(Generic) && obj.name.single?("Pointer") &&
+      if obj.is_a?(Generic) &&
+         (name = obj.name).is_a?(Path) && name.single?("Pointer") &&
          (node.name == "malloc" || node.name == "null")
         type = lookup_type?(obj)
         return type if type.is_a?(PointerInstanceType)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1351,7 +1351,9 @@ module Crystal
   end
 
   class Generic < ASTNode
-    property name : Path
+    # Usually a Path, but can also be a TypeNode in the case of a
+    # custom array/hash-like literal.
+    property name : ASTNode
     property type_vars : Array(ASTNode)
     property named_args : Array(NamedArgument)?
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -834,8 +834,10 @@ module Crystal
     end
 
     def visit(node : Generic)
-      if @inside_lib && node.name.names.size == 1
-        case node.name.names.first
+      name = node.name
+
+      if @inside_lib && (name.is_a?(Path) && name.names.size == 1)
+        case name.names.first
         when "Pointer"
           node.type_vars.first.accept self
           @str << "*"

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -257,7 +257,7 @@ module Crystal
     end
 
     def transform(node : Generic)
-      node.name = node.name.transform(self).as(Path)
+      node.name = node.name.transform(self)
       transform_many node.type_vars
       node
     end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -502,7 +502,7 @@ class Crystal::Doc::Type
   end
 
   def node_to_html(node : Generic, io, links = true)
-    match = lookup_path(node.name)
+    match = lookup_path(node.name.as(Path))
     if match
       if match.must_be_included?
         if links

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1052,7 +1052,7 @@ module Crystal
     end
 
     def visit(node : Generic)
-      name = node.name
+      name = node.name.as(Path)
       first_name = name.global? && name.names.size == 1 && name.names.first
 
       if name.global? && @token.type == :"::"


### PR DESCRIPTION
Fixes #5684

The problem was that when we find:

```crystal
Foo::Bar { 1, 2, 3 }
```

we first solve `Foo::Bar`. If it's a generic type then we must deduce the type from the literal elements using `typeof`. So we basically rewrite it to something like:

```crystal
temp = Foo::Bar(typeof(1, 2, 3)).new
temp << 1
temp << 2
temp << 3
```

We do this using a `Generic` node and `TypeOf` node as the generic type. The problem is that `Generic` needs a `Path` (the `Foo::Bar` in `Foo::Bar(...)`). So we constructed a `Path` from the type by getting its name and splitting it with `::`, which is horrible and also doesn't work with private types.

The solution is to pass the type to the generic so it doesn't need to be solved again, but for this I had to change the `name` property of `Generic` to `ASTNode` because now it can be `Path` or `TypeNode` (and that union goes up to `ASTNode`). This is why I had to change the handling of `name` in a few places, but luckily they weren't many.  