### PR TITLE
Fix YAML::Core parse float with leading 0 or .

### DIFF
--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -108,6 +108,18 @@ describe YAML::Schema::Core do
   it_parses_scalar "0x123abc", 0x123abc
   it_parses_scalar "-0x123abc", -0x123abc
 
+  # float
+  it_parses_scalar "1.2", 1.2
+  it_parses_scalar "0.815", 0.815
+  it_parses_scalar "0.", 0.0
+  it_parses_scalar "-0.0", 0.0
+  it_parses_scalar "1_234.2", 1_234.2
+  it_parses_scalar "-2E+05", -2e05
+  it_parses_scalar "+12.3", 12.3
+  it_parses_scalar ".5", 0.5
+  it_parses_scalar "+.5", 0.5
+  it_parses_scalar "-.5", -0.5
+
   # time
   it_parses_scalar "2002-12-14", Time.utc(2002, 12, 14)
   it_parses_scalar "2002-1-2", Time.utc(2002, 1, 2)
@@ -176,7 +188,17 @@ describe YAML::Schema::Core do
 
   # !!float
   it_parses "!!float '1.2'", 1.2
+  it_parses "!!float '0.5'", 0.5
   it_parses "!!float '1_234.2'", 1_234.2
+
+  it_parses "!!float -1", -1.0
+  it_parses "!!float 0", 0.0
+  it_parses "!!float 2.3e4", 2.3e4
+
+  it "parses !!float .nan" do
+    YAML::Schema::Core.parse("!!float .nan").as_f.nan?.should be_true
+  end
+
   it_parses "!!float .inf", Float64::INFINITY
   it_raises_on_parse "!!float 'hello'", "Invalid float"
 

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -79,6 +79,10 @@ module YAML::Schema::Core
          .starts_with?("-0x")
       value = string.to_i64?(base: 16, prefix: true)
       return value || string
+    when .starts_with?("0."),
+         .starts_with?('.')
+      value = parse_float?(string)
+      return value || string
     when .starts_with?('0')
       value = string.to_i64?(base: 8, prefix: true)
       return value || string


### PR DESCRIPTION
Also adds some specs for parsing float values

Fixes #5698