### PR TITLE
Use double quotes in html_renderer.cr, begin_code

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -67,7 +67,7 @@ describe Markdown do
   assert_render "    Hello\n   World", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
   assert_render "    Hello\n\n\nWorld", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
 
-  assert_render "```crystal\nHello\nWorld\n```", "<pre><code class="language-crystal">Hello\nWorld</code></pre>"
+  assert_render %(```crystal\nHello\nWorld\n```", "<pre><code class="language-crystal">Hello\nWorld</code></pre>)
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
 

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -67,7 +67,7 @@ describe Markdown do
   assert_render "    Hello\n   World", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
   assert_render "    Hello\n\n\nWorld", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
 
-  assert_render %(```crystal\nHello\nWorld\n```", "<pre><code class="language-crystal">Hello\nWorld</code></pre>)
+  assert_render "```crystal\nHello\nWorld\n```", %(<pre><code class="language-crystal">Hello\nWorld</code></pre>)
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
 

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -67,7 +67,7 @@ describe Markdown do
   assert_render "    Hello\n   World", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
   assert_render "    Hello\n\n\nWorld", "<pre><code>Hello</code></pre>\n\n<p>World</p>"
 
-  assert_render "```crystal\nHello\nWorld\n```", "<pre><code class='language-crystal'>Hello\nWorld</code></pre>"
+  assert_render "```crystal\nHello\nWorld\n```", "<pre><code class="language-crystal">Hello\nWorld</code></pre>"
   assert_render "Hello\n```\nWorld\n```", "<p>Hello</p>\n\n<pre><code>World</code></pre>"
   assert_render "```\n---\n```", "<pre><code>---</code></pre>"
 

--- a/src/markdown/html_renderer.cr
+++ b/src/markdown/html_renderer.cr
@@ -54,7 +54,7 @@ class Markdown::HTMLRenderer
     if language.nil?
       @io << "<pre><code>"
     else
-      @io << "<pre><code class='language-#{language}'>"
+      @io << %(<pre><code class="language-#{language}">)
     end
   end
 


### PR DESCRIPTION
It should use double quotes there instead of apostrophes. Because thats generating bad html code.
For example this is what glitch.com (glitch is an online html editor) says to an markdown crystal code block right now:
https://imgur.com/a/6nUKz

And other sources say too that double quotes are better.