### PR TITLE
Add `Enum.valid?`

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -142,6 +142,22 @@ describe Enum do
     end
   end
 
+  describe "valid?" do
+    it "for simple enum" do
+      SpecEnum.valid?(SpecEnum::One).should be_true
+      SpecEnum.valid?(SpecEnum::Two).should be_true
+      SpecEnum.valid?(SpecEnum::Three).should be_true
+      SpecEnum.valid?(SpecEnum.new(3i8)).should be_false
+    end
+
+    it "for flags eunm" do
+      SpecEnumFlags.valid?(SpecEnumFlags::One).should be_true
+      SpecEnumFlags.valid?(SpecEnumFlags::Two).should be_true
+      SpecEnumFlags.valid?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true
+      SpecEnumFlags.valid?(SpecEnumFlags.new(8)).should be_false
+    end
+  end
+
   it "has hash" do
     SpecEnum::Two.hash.should_not eq(SpecEnum::Three.hash)
   end

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -18,6 +18,10 @@ enum SpecEnumFlags
   Three
 end
 
+enum SpecBigEnum : Int64
+  TooBig = 4294967296i64 # == 2**32
+end
+
 describe Enum do
   describe "to_s" do
     it "for simple enum" do
@@ -155,6 +159,11 @@ describe Enum do
       SpecEnumFlags.valid?(SpecEnumFlags::Two).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags.new(8)).should be_false
+    end
+
+    it "for Int64 enum" do
+      SpecBigEnum.valid?(SpecBigEnum::TooBig).should be_true
+      SpecBigEnum.valid?(SpecBigEnum.new(0i64)).should be_false
     end
   end
 

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -159,6 +159,8 @@ describe Enum do
       SpecEnumFlags.valid?(SpecEnumFlags::Two).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags.new(8)).should be_false
+      SpecEnumFlags.valid?(SpecEnumFlags::None).should be_true
+      SpecEnumFlags.valid?(SpecEnumFlags::All).should be_true
     end
 
     it "for Int64 enum" do

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -154,7 +154,7 @@ describe Enum do
       SpecEnum.valid?(SpecEnum.new(3i8)).should be_false
     end
 
-    it "for flags eunm" do
+    it "for flags enum" do
       SpecEnumFlags.valid?(SpecEnumFlags::One).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags::Two).should be_true
       SpecEnumFlags.valid?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -373,7 +373,7 @@ struct Enum
     from_value?(value) || raise "Unknown enum #{self} value: #{value}"
   end
 
-  # Returns `true` if the given *value* is the enum member, or returns
+  # Returns `true` if the given *value* is an enum member, otherwise `false`.
   # `false` if not member.
   #
   # ```

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -381,7 +381,7 @@ struct Enum
   # Color.valid?(Color.new(4)) # => false
   # ```
   #
-  # NOTE: this is a class method, not an instance method because
+  # NOTE: This is a class method, not an instance method because
   # an instance method `valid?` is defined by the language when a user
   # defines an enum member named `Valid`.
   def self.valid?(value : self) : Bool

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -385,7 +385,7 @@ struct Enum
   # an instance method `valid?` is defined by the language when a user
   # defines an enum member named `Valid`.
   def self.valid?(value : self) : Bool
-    !!from_value?(value.to_i)
+    !!from_value?(value.value)
   end
 
   # def self.to_h : Hash(String, self)

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -373,6 +373,21 @@ struct Enum
     from_value?(value) || raise "Unknown enum #{self} value: #{value}"
   end
 
+  # Returns `true` if the given *value* is the enum member, or returns
+  # `false` if not member.
+  #
+  # ```
+  # Color.valid?(Color::Red)   # => true
+  # Color.valid?(Color.new(4)) # => false
+  # ```
+  #
+  # NOTE: this is a class method, not an instance method because
+  # an instance method `valid?` is defined by the language when a user
+  # defines an enum member named `Valid`.
+  def self.valid?(value : self) : Bool
+    !!from_value?(value.to_i)
+  end
+
   # def self.to_h : Hash(String, self)
   #   {
   #     {% for member in @type.constants %}


### PR DESCRIPTION
As the first step to establish the exhaustiveness checking for enums, I want to define what enum value is valid or invalid. In this PR, a valid enum value means that `ThisEnum.from_value?(value)` returns the `ThisEnum` member, and an invalid enum value means that it returns `nil`. It makes sense to me, but maybe it is more natural if the relation between `from_value?` and `valid?` is reversed.

The reason that this is implemented as a class method is explained in NOTE section of the document comment.