### PR TITLE
Improve Ctrl-C handling of spec

### DIFF
--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -42,15 +42,15 @@ module Spec
       @results[result.kind] << result
     end
 
-    def self.print_results(elapsed_time)
-      @@instance.print_results(elapsed_time)
+    def self.print_results(elapsed_time, aborted = false)
+      @@instance.print_results(elapsed_time, aborted)
     end
 
     def self.succeeded
       @@instance.succeeded
     end
 
-    def print_results(elapsed_time)
+    def print_results(elapsed_time, aborted = false)
       Spec.formatters.each(&.finish)
 
       pendings = @results[:pending]
@@ -124,11 +124,13 @@ module Spec
       total = pendings.size + failures.size + errors.size + success.size
 
       final_status = case
+                     when aborted                           then :error
                      when (failures.size + errors.size) > 0 then :fail
                      when pendings.size > 0                 then :pending
                      else                                        :success
                      end
 
+      puts "Aborted!".colorize.red if aborted
       puts "Finished in #{Spec.to_human(elapsed_time)}"
       puts Spec.color("#{total} examples, #{failures.size} failures, #{errors.size} errors, #{pendings.size} pending", final_status)
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -52,6 +52,7 @@ module Spec
 
   # :nodoc:
   def self.abort!
+    @@aborted = true
     exit
   end
 
@@ -169,8 +170,8 @@ module Spec
     start_time = Time.monotonic
     at_exit do
       elapsed_time = Time.monotonic - start_time
-      Spec::RootContext.print_results(elapsed_time)
-      exit 1 unless Spec::RootContext.succeeded
+      Spec::RootContext.print_results(elapsed_time, @@aborted)
+      exit 1 unless Spec::RootContext.succeeded && !@@aborted
     end
   end
 end


### PR DESCRIPTION
Against this code:

```crystal
require "spec"

puts "start"
it "never ends" do
  loop { sleep 1 }
end
```

Before this PR:

![before](https://user-images.githubusercontent.com/6679325/36167361-f5abb11a-1138-11e8-900a-73e626aa00b4.png)

After:

![after](https://user-images.githubusercontent.com/6679325/36167376-05cf4b42-1139-11e8-874f-5fbd9ba084c3.png)

I think the spec process should be exited with non-zero status on Ctrl-C.