### PR TITLE
Ensure that HTTP::WebSocket uses SNI, just like HTTP::Client.

### DIFF
--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -253,7 +253,7 @@ class HTTP::WebSocket::Protocol
         else
           context = tls
         end
-        socket = OpenSSL::SSL::Socket::Client.new(socket, context: context, sync_close: true)
+        socket = OpenSSL::SSL::Socket::Client.new(socket, context: context, sync_close: true, hostname: host)
       end
     {% end %}
 


### PR DESCRIPTION
Please see the manual spec for a use-case for this. Websockets over Cloudflare fail without SNI. I can modify the manual spec to whatever you guys would like.