### PR TITLE
Re-raise exceptions in the parallel macro, add documentation

### DIFF
--- a/spec/std/concurrent_spec.cr
+++ b/spec/std/concurrent_spec.cr
@@ -8,38 +8,65 @@ private def method_named(expected_named)
   Fiber.current.name.should eq(expected_named)
 end
 
+class SomeParallelJobException < Exception
+end
+
+private def raising_job : String
+  raise SomeParallelJobException.new("boom")
+  "result"
+end
+
 describe "concurrent" do
-  it "does four things concurrently" do
-    a, b, c, d = parallel(1 + 2, "hello".size, [1, 2, 3, 4].size, nil)
-    a.should eq(3)
-    b.should eq(5)
-    c.should eq(4)
-    d.should be_nil
-  end
-
-  it "uses spawn macro" do
-    chan = Channel(Int32).new
-
-    spawn method_with_named_args(chan)
-    chan.receive.should eq(3)
-
-    spawn method_with_named_args(chan, y: 20)
-    chan.receive.should eq(21)
-
-    spawn method_with_named_args(chan, x: 10, y: 20)
-    chan.receive.should eq(30)
-  end
-
-  it "spawns named" do
-    spawn(name: "sub") do
-      Fiber.current.name.should eq("sub")
+  describe "parallel" do
+    it "does four things concurrently" do
+      a, b, c, d = parallel(1 + 2, "hello".size, [1, 2, 3, 4].size, nil)
+      a.should eq(3)
+      b.should eq(5)
+      c.should eq(4)
+      d.should be_nil
     end
-    Fiber.yield
+
+    it "re-raises errors from Fibers as ConcurrentExecutionException" do
+      exception = expect_raises(ConcurrentExecutionException) do
+        a, b = parallel(raising_job, raising_job)
+      end
+
+      exception.cause.should be_a(SomeParallelJobException)
+    end
+
+    it "is strict about the return value type" do
+      a, b = parallel(1 + 2, "hello")
+
+      typeof(a).should eq(Int32)
+      typeof(b).should eq(String)
+    end
   end
 
-  it "spawns named with macro" do
-    spawn method_named("foo"), name: "foo"
-    Fiber.yield
+  describe "spawn" do
+    it "uses spawn macro" do
+      chan = Channel(Int32).new
+
+      spawn method_with_named_args(chan)
+      chan.receive.should eq(3)
+
+      spawn method_with_named_args(chan, y: 20)
+      chan.receive.should eq(21)
+
+      spawn method_with_named_args(chan, x: 10, y: 20)
+      chan.receive.should eq(30)
+    end
+
+    it "spawns named" do
+      spawn(name: "sub") do
+        Fiber.current.name.should eq("sub")
+      end
+      Fiber.yield
+    end
+
+    it "spawns named with macro" do
+      spawn method_named("foo"), name: "foo"
+      Fiber.yield
+    end
   end
 
   it "accepts method call with receiver" do

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -128,21 +128,77 @@ macro spawn(call, *, name = nil)
   {% end %}
 end
 
+# Wraps around exceptions re-raised from concurrent calls.
+# The original exception can be accessed via `#cause`.
+class ConcurrentExecutionException < Exception
+end
+
+# Runs the commands passed as arguments concurrently (in Fibers) and waits
+# for them to finish.
+#
+# ```
+# def say(word)
+#   puts word
+# end
+#
+# # Will print out the three words concurrently
+# parallel(
+#   say("concurrency"),
+#   say("is"),
+#   say("easy")
+# )
+# ```
+#
+# Can also be used to conveniently collect the return values of the
+# concurrent operations.
+#
+# ```
+# def concurrent_job(word)
+#   word
+# end
+#
+# a, b, c =
+#   parallel(
+#     concurrent_job("concurrency"),
+#     concurrent_job("is"),
+#     concurrent_job("easy")
+#   )
+#
+# puts a # => "concurrency"
+# puts b # => "is"
+# puts c # => "easy"
+# ```
+#
+# Due to the concurrent nature of this macro, it is highly recommended
+# to handle any exceptions within the concurrent calls. Unhandled
+# exceptions raised within the concurrent operations will be re-raised
+# inside the parent fiber as `ConcurrentExecutionException`, with the
+# `cause` attribute set to the original exception.
 macro parallel(*jobs)
-  %channel = Channel(Nil).new
+  %channel = Channel(Exception | Nil).new
 
   {% for job, i in jobs %}
     %ret{i} = uninitialized typeof({{job}})
     spawn do
       begin
         %ret{i} = {{job}}
-      ensure
+      rescue e : Exception
+        %channel.send e
+      else
         %channel.send nil
       end
     end
   {% end %}
 
-  {{ jobs.size }}.times { %channel.receive }
+  {{ jobs.size }}.times do
+    %value = %channel.receive
+    if %value.is_a?(Exception)
+      raise ConcurrentExecutionException.new(
+        "An unhandled error occured inside a `parallel` call",
+        cause: %value
+      )
+    end
+  end
 
   {
     {% for job, i in jobs %}


### PR DESCRIPTION
The `parallel` macro is very convenient and I was surprised that it didn't make it into the Crystal book and that it's not even documented. Then I realised the implementation comes with some risks - more specifically when the concurrent operations raise unhandled exceptions:

```crystal
def job_with_exception
  raise Exception.new("boom")
  "hello"
end

a, b = parallel(job_with_exception, job_with_exception)

# This will crash the program with invalid memory access
puts a, b
```

The problem is the usage of `uninitialized` but I personally wouldn't want to trade the current syntax for union types and introducing nil checks.

So my suggestion is introducing a `parallel!` macro, for all the cases where the concurrent operations might raise unhandled exceptions. The behaviour of this macro is very similar to the original one, the only difference being that unhandled exceptions are propagated to the parent thread. This solves the problem of the invalid memory access and doesn't compromise on the syntax or usage.

I think the `parallel` macro is quite valuable and as long as the documentation states the risks it should be fine. Alternatively, we could also have the current implementation of `parallel` work more like my `parallel!` suggestion and stick with only one version (or remove the old macro entirely).

I wrote a bit more about this [here](https://lipanski.github.io/posts/crystal-parallel).

Let me know what you think of this :)

**EDIT:** In hindsight I'd actually recommend removing the old implementation entirely in favour of the `parallel!` macro - provided that you're fine with the breaking change. This will make the macro safe to use in all situations. The memory access error can be quite unexpected/dangerous (in my case it was crashing the web server).