### PR TITLE
Handle [CMD/CTRL]+S on Playground

### DIFF
--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -2,7 +2,9 @@ CodeMirror.keyMap.macDefault["Cmd-/"] = "toggleComment";
 CodeMirror.keyMap.pcDefault["Ctrl-/"] = "toggleComment";
 
 CodeMirror.keyMap.macDefault["Cmd-Enter"] = "runCode";
+CodeMirror.keyMap.macDefault["Cmd-S"] = "runCode";
 CodeMirror.keyMap.pcDefault["Ctrl-Enter"] = "runCode";
+CodeMirror.keyMap.pcDefault["Ctrl-S"] = "runCode";
 
 CodeMirror.commands.runCode = function(editor) {
   if (editor._playgroundSession) {


### PR DESCRIPTION
See: https://github.com/crystal-lang/crystal/issues/5672

Added both shortcuts for handling `cmd+s` and `ctrl+s` for running the code in playground