### PR TITLE
Fix Random example

### DIFF
--- a/src/random.cr
+++ b/src/random.cr
@@ -4,7 +4,6 @@ require "random/pcg32"
 # `Random` provides an interface for random values generation, using a pseudo random number generator (PRNG).
 #
 # ```
-# Random.new_seed # => 112705036
 # Random.rand     # => 0.167595
 # Random.rand(5)  # => 2
 # ```

--- a/src/random.cr
+++ b/src/random.cr
@@ -4,8 +4,8 @@ require "random/pcg32"
 # `Random` provides an interface for random values generation, using a pseudo random number generator (PRNG).
 #
 # ```
-# Random.rand     # => 0.167595
-# Random.rand(5)  # => 2
+# Random.rand    # => 0.167595
+# Random.rand(5) # => 2
 # ```
 #
 # The above methods delegate to a `Random` instance.


### PR DESCRIPTION
Random.new_seed isn't existing.

If you are doing this:
```Crystal
Random.new_seed
```
then it gives you this:
```
Error in crystal.cr:1: undefined method 'new_seed' for Random:Module

Random.new_seed
       ^~~~~~~~
```