### PR TITLE
Add copy method to record macro.

### DIFF
--- a/spec/std/record_spec.cr
+++ b/spec/std/record_spec.cr
@@ -21,7 +21,7 @@ describe "record" do
     rec.x.should eq(1)
     rec.y.should be(ary)
 
-    copy = rec.copy(x: 5)
+    copy = rec.copy_with(x: 5)
     copy.x.should eq(5)
     copy.y.should be(rec.y)
 
@@ -36,7 +36,7 @@ describe "record" do
     rec.x.should eq(0)
     rec.y.should eq([2, 3])
 
-    copy = rec.copy(y: [7, 8])
+    copy = rec.copy_with(y: [7, 8])
     copy.x.should eq(rec.x)
     copy.y.should eq([7, 8])
 
@@ -51,7 +51,7 @@ describe "record" do
     rec.x.should eq(0)
     rec.y.should eq([2, 3])
 
-    copy = rec.copy(y: [7, 8])
+    copy = rec.copy_with(y: [7, 8])
     copy.x.should eq(rec.x)
     copy.y.should eq([7, 8])
 

--- a/spec/std/record_spec.cr
+++ b/spec/std/record_spec.cr
@@ -21,6 +21,10 @@ describe "record" do
     rec.x.should eq(1)
     rec.y.should be(ary)
 
+    copy = rec.copy(x: 5)
+    copy.x.should eq(5)
+    copy.y.should be(rec.y)
+
     cloned = rec.clone
     cloned.x.should eq(1)
     cloned.y.should eq(ary)
@@ -32,6 +36,10 @@ describe "record" do
     rec.x.should eq(0)
     rec.y.should eq([2, 3])
 
+    copy = rec.copy(y: [7, 8])
+    copy.x.should eq(rec.x)
+    copy.y.should eq([7, 8])
+
     cloned = rec.clone
     cloned.x.should eq(0)
     cloned.y.should eq(rec.y)
@@ -42,6 +50,10 @@ describe "record" do
     rec = RecordSpec::Record3.new
     rec.x.should eq(0)
     rec.y.should eq([2, 3])
+
+    copy = rec.copy(y: [7, 8])
+    copy.x.should eq(rec.x)
+    copy.y.should eq([7, 8])
 
     cloned = rec.clone
     cloned.x.should eq(0)

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -47,13 +47,15 @@
 # Point.new y: 2 # => #<Point(@x=0, @y=2)>
 # ```
 #
-# An example of creating a copy of a record with some properties changed:
+# This macro also provides a `copy_with` method which returns
+# a copy of the record with the provided properties altered.
 #
 # ```
 # record Point, x = 0, y = 0
 #
 # p = Point.new y: 2 # => #<Point(@x=0, @y=2)>
 # p.copy_with x: 3   # => #<Point(@x=3, @y=2)>
+# p                  # => #<Point(@x=0, @y=2)>
 # ```
 macro record(name, *properties)
   struct {{name.id}}

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -53,7 +53,7 @@
 # record Point, x = 0, y = 0
 #
 # p = Point.new y: 2 # => #<Point(@x=0, @y=2)>
-# p.copy x: 3        # => #<Point(@x=3, @y=2)>
+# p.copy_with x: 3   # => #<Point(@x=3, @y=2)>
 # ```
 macro record(name, *properties)
   struct {{name.id}}
@@ -76,17 +76,17 @@ macro record(name, *properties)
 
     {{yield}}
 
-    def copy({{
-               *properties.map do |property|
-                 if property.is_a?(Assign)
-                   "#{property.target.id} _#{property.target.id} = @#{property.target.id}".id
-                 elsif property.is_a?(TypeDeclaration)
-                   "#{property.var.id} _#{property.var.id} = @#{property.var.id}".id
-                 else
-                   "#{property.id} _#{property.id} = @#{property.id}".id
-                 end
-               end
-             }})
+    def copy_with({{
+                    *properties.map do |property|
+                      if property.is_a?(Assign)
+                        "#{property.target.id} _#{property.target.id} = @#{property.target.id}".id
+                      elsif property.is_a?(TypeDeclaration)
+                        "#{property.var.id} _#{property.var.id} = @#{property.var.id}".id
+                      else
+                        "#{property.id} _#{property.id} = @#{property.id}".id
+                      end
+                    end
+                  }})
       {{name.id}}.new({{
                         *properties.map do |property|
                           if property.is_a?(Assign)

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -53,7 +53,7 @@
 # record Point, x = 0, y = 0
 #
 # p = Point.new y: 2 # => #<Point(@x=0, @y=2)>
-# p.copy x: 3 # => #<Point(@x=3, @y=2)>
+# p.copy x: 3        # => #<Point(@x=3, @y=2)>
 # ```
 macro record(name, *properties)
   struct {{name.id}}


### PR DESCRIPTION
This allows a copy of a record to be made, specifying properties that should be changed.
It's useful to be able to do this when there are more than a couple of properties and you want a new record identical to the old one but with one or two properties changed. It maintains immutability while improving usability.

Example:
```
record Point, x : Int32, y : Int32, z : Int32
p1 = Point.new(3, 4, 5)
p1.copy y: 9 # => #<Point(@x=3, @y=9, @z=5)>
```

The inspiration for this comes from Scala case class copy: https://docs.scala-lang.org/tour/case-classes.html