### PR TITLE
Extend XML::Reader with more LibXML methods

### DIFF
--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -1,0 +1,434 @@
+require "spec"
+require "xml"
+
+private def xml
+  <<-XML
+  <?xml version="1.0" encoding="UTF-8"?>
+  <people>
+    <person id="1">
+      <name>John</name>
+    </person>
+    <person id="2">
+      <name>Peter</name>
+    </person>
+  </people>
+  XML
+end
+
+module XML
+  describe Reader do
+    describe ".new" do
+      it "can be initialized from a string" do
+        reader = Reader.new(xml)
+        reader.should be_a(XML::Reader)
+        reader.read.should be_true
+        reader.name.should eq("people")
+      end
+
+      it "can be initialize from an io" do
+        io = IO::Memory.new(xml)
+        reader = Reader.new(io)
+        reader.should be_a(XML::Reader)
+        reader.read.should be_true
+        reader.name.should eq("people")
+      end
+    end
+
+    describe "#read" do
+      it "reads all nodes" do
+        reader = Reader.new(xml)
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("people")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("1")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::TEXT_NODE)
+        reader.name.should eq("#text")
+        reader.value.should eq("John")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("person")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("2")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::TEXT_NODE)
+        reader.name.should eq("#text")
+        reader.value.should eq("Peter")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("person")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("people")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#next" do
+      it "reads next node in doc order, skipping subtrees" do
+        reader = Reader.new(xml)
+        while reader.read
+          break if reader.depth == 2
+        end
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("name")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("1")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("2")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.next.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("people")
+        reader.next.should be_false
+      end
+    end
+
+    describe "#next_sibling" do
+      it "reads next sibling node in doc order, skipping subtrees" do
+        reader = Reader.new(xml)
+        while reader.read
+          break if reader.depth == 1
+        end
+        reader.next_sibling.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("1")
+        reader.next_sibling.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.next_sibling.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader.attribute("id").should eq("2")
+        reader.next_sibling.should be_true
+        reader.node_type.should eq(XML::Type::DTD_NODE)
+        reader.name.should eq("#text")
+        reader.next_sibling.should be_false
+      end
+    end
+
+    describe "#node_type" do
+      it "returns the node type" do
+        reader = Reader.new("<root/>")
+        reader.node_type.should eq(XML::Type::NONE)
+        reader.read
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+      end
+    end
+
+    describe "#name" do
+      it "reads node name" do
+        reader = Reader.new("<root/>")
+        reader.name.should be_nil
+        reader.read
+        reader.name.should eq("root")
+      end
+    end
+
+    describe "#empty_element?" do
+      it "checks if the node is empty" do
+        reader = Reader.new("<root/>")
+        reader.empty_element?.should be_false
+        reader.read
+        reader.empty_element?.should be_true
+        reader = Reader.new("<root></root>")
+        reader.read
+        reader.empty_element?.should be_false
+      end
+    end
+
+    describe "#has_attributes?" do
+      it "checks if the node has attributes" do
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.has_attributes?.should be_false
+        reader.read # <root id="1">
+        reader.has_attributes?.should be_true
+        reader.read # <child/>
+        reader.has_attributes?.should be_false
+        reader.read # </root>
+        reader.has_attributes?.should be_true
+      end
+    end
+
+    describe "#attributes_count" do
+      it "returns the node's number of attributes" do
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.attributes_count.should eq(0)
+        reader.read # <root id="1">
+        reader.attributes_count.should eq(1)
+        reader.read # <child/>
+        reader.attributes_count.should eq(0)
+        reader.read # </root>
+        # This is weird, since has_attributes? will be true.
+        reader.attributes_count.should eq(0)
+      end
+    end
+
+    describe "#move_to_first_attribute" do
+      it "moves to the first attribute of the node" do
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.move_to_first_attribute.should be_false
+        reader.read # <root id="1">
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.move_to_first_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.value.should eq("1")
+        reader.read # <child/>
+        reader.move_to_first_attribute.should be_false
+        reader.read # </root>
+        reader.move_to_first_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.value.should eq("1")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#move_to_next_attribute" do
+      it "moves to the next attribute of the node" do
+        reader = Reader.new(%{<root id="1" id2="2"><child/></root>})
+        reader.move_to_next_attribute.should be_false
+        reader.read # <root id="1" id2="2">
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.move_to_next_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.value.should eq("1")
+        reader.move_to_next_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id2")
+        reader.value.should eq("2")
+        reader.move_to_next_attribute.should be_false
+        reader.read # <child/>
+        reader.move_to_next_attribute.should be_false
+        reader.read # </root>
+        reader.move_to_next_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.value.should eq("1")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#move_to_attribute" do
+      it "moves to attribute with the specified name" do
+        reader = Reader.new(%{<root id="1" id2="2"><child/></root>})
+        reader.move_to_attribute("id2").should be_false
+        reader.read # <root id="1" id2="2">
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.move_to_attribute("id2").should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id2")
+        reader.value.should eq("2")
+        reader.move_to_attribute("id").should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.value.should eq("1")
+        reader.move_to_attribute("bogus").should be_false
+        reader.read # <child/>
+        reader.move_to_attribute("id2").should be_false
+        reader.read # </root>
+        reader.move_to_attribute("id2").should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id2")
+        reader.value.should eq("2")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#attribute" do
+      it "reads node attributes" do
+        reader = Reader.new("<root/>")
+        reader.attribute("id").should be_nil
+        reader.read
+        reader.attribute("id").should be_nil
+        reader = Reader.new(%{<root id="1"/>})
+        reader.read
+        reader.attribute("id").should eq("1")
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.read # <root id="1">
+        reader.attribute("id").should eq("1")
+        reader.read # <child/>
+        reader.attribute("id").should be_nil
+        reader.read # </root>
+        reader.attribute("id").should eq("1")
+      end
+    end
+
+    describe "#move_to_element" do
+      it "moves to the element node that contains the current attribute node" do
+        reader = Reader.new(%{<root id="1"></root>})
+        reader.move_to_element.should be_false
+        reader.read # <root id="1">
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("root")
+        reader.move_to_element.should be_false
+        reader.move_to_first_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.move_to_element.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("root")
+        reader.read # </root>
+        reader.move_to_element.should be_false
+        reader.move_to_first_attribute.should be_true
+        reader.node_type.should eq(XML::Type::ATTRIBUTE_NODE)
+        reader.name.should eq("id")
+        reader.move_to_element.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("root")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#depth" do
+      it "returns the depth of the node" do
+        reader = Reader.new("<root><child/></root>")
+        reader.depth.should eq(0)
+        reader.read # <root>
+        reader.depth.should eq(0)
+        reader.read # <child/>
+        reader.depth.should eq(1)
+        reader.read # </root>
+        reader.depth.should eq(0)
+      end
+    end
+
+    describe "#read_inner_xml" do
+      it "reads the contents of the node including child nodes and markup" do
+        reader = Reader.new("<root>\n<child/>\n</root>\n")
+        reader.read_inner_xml.should be_nil
+        reader.read # <root>
+        reader.read_inner_xml.should eq("\n<child/>\n")
+        reader.read # \n
+        reader.read_inner_xml.should eq("")
+        reader.read # <child/>
+        reader.read_inner_xml.should eq("")
+        reader.read # \n
+        reader.read_inner_xml.should eq("")
+        reader.read # </root>
+        reader.read_inner_xml.should eq("")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#read_outer_xml" do
+      it "reads the xml of the node including child nodes and markup" do
+        reader = Reader.new("<root>\n<child/>\n</root>\n")
+        reader.read_outer_xml.should be_nil
+        reader.read # <root>
+        reader.read_outer_xml.should eq("<root>\n<child/>\n</root>")
+        reader.read # \n
+        reader.read_outer_xml.should eq("\n")
+        reader.read # <child/>
+        reader.read_outer_xml.should eq("<child/>")
+        reader.read # \n
+        reader.read_outer_xml.should eq("\n")
+        reader.read # </root>
+        # Note that the closing element is transformed into a self-closing one.
+        reader.read_outer_xml.should eq("<root/>")
+        reader.read.should be_false
+      end
+    end
+
+    describe "#expand" do
+      it "parses the content of the node and subtree" do
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.expand.should be_nil
+        reader.read # <root id="1">
+        node = reader.expand
+        node.should be_a(XML::Node)
+        node.not_nil!.attributes["id"].content.should eq("1")
+        node.not_nil!.xpath_node("child").should be_a(XML::Node)
+      end
+
+      it "is only available until the next read" do
+        reader = Reader.new(%{<root><child><subchild/></child></root>})
+        reader.read # <root>
+        reader.read # <child>
+        node = reader.expand
+        node.should be_a(XML::Node)
+        node.not_nil!.xpath_node("subchild").should be_a(XML::Node)
+        reader.read # <subchild/>
+        reader.read # </child>
+        node.not_nil!.xpath_node("subchild").should be_nil
+      end
+    end
+
+    describe "#value" do
+      it "reads node text value" do
+        reader = Reader.new(%{<root id="1">hello<!-- world --></root>})
+        reader.value.should be_nil
+        reader.read # <root>
+        reader.value.should be_nil
+        reader.read # hello
+        reader.value.should eq("hello")
+        reader.read # <!-- world -->
+        reader.value.should eq(" world ")
+        reader.read # </root>
+        reader.move_to_first_attribute.should be_true
+        reader.value.should eq("1")
+      end
+    end
+
+    describe "#to_unsafe" do
+      it "returns a pointer to the underlying LibXML::XMLTextReader" do
+        reader = Reader.new("<root/>")
+        reader.to_unsafe.should be_a(LibXML::XMLTextReader)
+      end
+    end
+  end
+end

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -46,7 +46,7 @@ module XML
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_NODE)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
@@ -72,7 +72,7 @@ module XML
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_NODE)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("2")
+        reader["id"].should eq("2")
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
@@ -117,14 +117,14 @@ module XML
         reader.next.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_DECL)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
         reader.next.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
         reader.next.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_NODE)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("2")
+        reader["id"].should eq("2")
         reader.next.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
@@ -144,14 +144,14 @@ module XML
         reader.next_sibling.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_NODE)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
         reader.next_sibling.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
         reader.next_sibling.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_NODE)
         reader.name.should eq("person")
-        reader.attribute("id").should eq("2")
+        reader["id"].should eq("2")
         reader.next_sibling.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
@@ -289,22 +289,41 @@ module XML
       end
     end
 
-    describe "#attribute" do
+    describe "#[]" do
       it "reads node attributes" do
         reader = Reader.new("<root/>")
-        reader.attribute("id").should be_nil
+        expect_raises(KeyError) { reader["id"] }
         reader.read
-        reader.attribute("id").should be_nil
+        expect_raises(KeyError) { reader["id"] }
         reader = Reader.new(%{<root id="1"/>})
         reader.read
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
         reader = Reader.new(%{<root id="1"><child/></root>})
         reader.read # <root id="1">
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
         reader.read # <child/>
-        reader.attribute("id").should be_nil
+        expect_raises(KeyError) { reader["id"] }
         reader.read # </root>
-        reader.attribute("id").should eq("1")
+        reader["id"].should eq("1")
+      end
+    end
+
+    describe "#[]?" do
+      it "reads node attributes" do
+        reader = Reader.new("<root/>")
+        reader["id"]?.should be_nil
+        reader.read
+        reader["id"]?.should be_nil
+        reader = Reader.new(%{<root id="1"/>})
+        reader.read
+        reader["id"]?.should eq("1")
+        reader = Reader.new(%{<root id="1"><child/></root>})
+        reader.read # <root id="1">
+        reader["id"]?.should eq("1")
+        reader.read # <child/>
+        reader["id"]?.should be_nil
+        reader.read # </root>
+        reader["id"]?.should eq("1")
       end
     end
 

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -171,7 +171,7 @@ module XML
     describe "#name" do
       it "reads node name" do
         reader = Reader.new("<root/>")
-        reader.name.should be_nil
+        reader.name.should eq("")
         reader.read
         reader.name.should eq("root")
       end
@@ -350,7 +350,7 @@ module XML
     describe "#read_inner_xml" do
       it "reads the contents of the node including child nodes and markup" do
         reader = Reader.new("<root>\n<child/>\n</root>\n")
-        reader.read_inner_xml.should be_nil
+        reader.read_inner_xml.should eq("")
         reader.read # <root>
         reader.read_inner_xml.should eq("\n<child/>\n")
         reader.read # \n
@@ -368,7 +368,7 @@ module XML
     describe "#read_outer_xml" do
       it "reads the xml of the node including child nodes and markup" do
         reader = Reader.new("<root>\n<child/>\n</root>\n")
-        reader.read_outer_xml.should be_nil
+        reader.read_outer_xml.should eq("")
         reader.read # <root>
         reader.read_outer_xml.should eq("<root>\n<child/>\n</root>")
         reader.read # \n
@@ -411,9 +411,9 @@ module XML
     describe "#value" do
       it "reads node text value" do
         reader = Reader.new(%{<root id="1">hello<!-- world --></root>})
-        reader.value.should be_nil
+        reader.value.should eq("")
         reader.read # <root>
-        reader.value.should be_nil
+        reader.value.should eq("")
         reader.read # hello
         reader.value.should eq("hello")
         reader.read # <!-- world -->

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -95,6 +95,8 @@ lib LibXML
   fun xmlNewTextReader(input : InputBuffer, uri : UInt8*) : XMLTextReader
 
   fun xmlTextReaderRead(reader : XMLTextReader) : Int
+  fun xmlTextReaderNext(reader : XMLTextReader) : Int
+  fun xmlTextReaderNextSibling(reader : XMLTextReader) : Int
   fun xmlTextReaderNodeType(reader : XMLTextReader) : XML::Type
   fun xmlTextReaderConstName(reader : XMLTextReader) : UInt8*
   fun xmlTextReaderIsEmptyElement(reader : XMLTextReader) : Int
@@ -103,6 +105,13 @@ lib LibXML
   fun xmlTextReaderAttributeCount(reader : XMLTextReader) : Int
   fun xmlTextReaderMoveToFirstAttribute(reader : XMLTextReader) : Int
   fun xmlTextReaderMoveToNextAttribute(reader : XMLTextReader) : Int
+  fun xmlTextReaderMoveToAttribute(reader : XMLTextReader, name : UInt8*) : Int
+  fun xmlTextReaderGetAttribute(reader : XMLTextReader, name : UInt8*) : UInt8*
+  fun xmlTextReaderMoveToElement(reader : XMLTextReader) : Int
+  fun xmlTextReaderDepth(reader : XMLTextReader) : Int
+  fun xmlTextReaderReadInnerXml(reader : XMLTextReader) : UInt8*
+  fun xmlTextReaderReadOuterXml(reader : XMLTextReader) : UInt8*
+  fun xmlTextReaderExpand(reader : XMLTextReader) : Node*
 
   fun xmlTextReaderSetErrorHandler(reader : XMLTextReader, f : TextReaderErrorFunc) : Void
 

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -112,6 +112,7 @@ lib LibXML
   fun xmlTextReaderReadInnerXml(reader : XMLTextReader) : UInt8*
   fun xmlTextReaderReadOuterXml(reader : XMLTextReader) : UInt8*
   fun xmlTextReaderExpand(reader : XMLTextReader) : Node*
+  fun xmlTextReaderCurrentNode(reader : XMLTextReader) : Node*
 
   fun xmlTextReaderSetErrorHandler(reader : XMLTextReader, f : TextReaderErrorFunc) : Void
 

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -1,6 +1,7 @@
 require "./libxml2"
 
 struct XML::Reader
+  # Creates a new reader from a string.
   def initialize(str : String)
     input = LibXML.xmlParserInputBufferCreateStatic(str, str.bytesize, 1)
     @reader = LibXML.xmlNewTextReader(input, "")
@@ -11,6 +12,7 @@ struct XML::Reader
     end
   end
 
+  # Creates a new reader from an IO.
   def initialize(io : IO)
     input = LibXML.xmlParserInputBufferCreateIO(
       ->(context, buffer, length) { Box(IO).unbox(context).read(Slice.new(buffer, length)).to_i },
@@ -21,14 +23,17 @@ struct XML::Reader
     @reader = LibXML.xmlNewTextReader(input, "")
   end
 
+  # Moves the reader to the next node.
   def read
     LibXML.xmlTextReaderRead(@reader) == 1
   end
 
+  # Moves the reader to the next node while skipping subtrees.
   def next
     LibXML.xmlTextReaderNext(@reader) == 1
   end
 
+  # Moves the reader to the next sibling node while skipping subtrees.
   def next_sibling
     result = LibXML.xmlTextReaderNextSibling(@reader)
     # Work around libxml2 with incomplete xmlTextReaderNextSibling()
@@ -47,72 +52,89 @@ struct XML::Reader
     end
   end
 
+  # Returns the `XML::Type` of the node.
   def node_type
     LibXML.xmlTextReaderNodeType(@reader)
   end
 
+  # Returns the name of the node.
   def name
     value = LibXML.xmlTextReaderConstName(@reader)
     String.new(value) if value
   end
 
+  # Checks if the node is an empty element.
   def empty_element?
     LibXML.xmlTextReaderIsEmptyElement(@reader) == 1
   end
 
+  # Checks if the node has any attributes.
   def has_attributes?
     LibXML.xmlTextReaderHasAttributes(@reader) == 1
   end
 
+  # Returns attribute count of the node.
   def attributes_count
     LibXML.xmlTextReaderAttributeCount(@reader)
   end
 
+  # Moves to the first `XML::Type::ATTRIBUTE_NODE` of the node.
   def move_to_first_attribute
     LibXML.xmlTextReaderMoveToFirstAttribute(@reader) == 1
   end
 
+  # Moves to the next `XML::Type::ATTRIBUTE_NODE` of the node.
   def move_to_next_attribute
     LibXML.xmlTextReaderMoveToNextAttribute(@reader) == 1
   end
 
+  # Moves to the `XML::Type::ATTRIBUTE_NODE` with the specified name.
   def move_to_attribute(name)
     LibXML.xmlTextReaderMoveToAttribute(@reader, name.to_s) == 1
   end
 
+  # Returns the text value of the attribute with the specified name.
   def attribute(name)
     value = LibXML.xmlTextReaderGetAttribute(@reader, name.to_s)
     String.new(value) if value
   end
 
+  # Moves from the `XML::Type::ATTRIBUTE_NODE` to its containing `XML::Type::ELEMENT_NODE`.
   def move_to_element
     LibXML.xmlTextReaderMoveToElement(@reader) == 1
   end
 
+  # Returns the current nesting depth of the reader.
   def depth
     LibXML.xmlTextReaderDepth(@reader)
   end
 
+  # Returns the node's XML content including subtrees.
   def read_inner_xml
     xml = LibXML.xmlTextReaderReadInnerXml(@reader)
     String.new(xml) if xml
   end
 
+  # Returns the XML for the node and its content including subtrees.
   def read_outer_xml
     xml = LibXML.xmlTextReaderReadOuterXml(@reader)
     String.new(xml) if xml
   end
 
+  # Expand the node to a `XML::Node` that can be searched with XPath etc.
+  # The returned `XML::Node` is only valid until the next call to `#read`.
   def expand
     xml = LibXML.xmlTextReaderExpand(@reader)
     XML::Node.new(xml) if xml
   end
 
+  # Returns the text content of the node.
   def value
     value = LibXML.xmlTextReaderConstValue(@reader)
     String.new(value) if value
   end
 
+  # Returns a reference to the underlying `LibXML::XMLTextReader`.
   def to_unsafe
     @reader
   end

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -52,7 +52,8 @@ struct XML::Reader
   end
 
   def name
-    String.new(LibXML.xmlTextReaderConstName(@reader))
+    value = LibXML.xmlTextReaderConstName(@reader)
+    String.new(value) if value
   end
 
   def empty_element?
@@ -108,7 +109,8 @@ struct XML::Reader
   end
 
   def value
-    String.new(LibXML.xmlTextReaderConstValue(@reader))
+    value = LibXML.xmlTextReaderConstValue(@reader)
+    String.new(value) if value
   end
 
   def to_unsafe

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -93,9 +93,16 @@ struct XML::Reader
     LibXML.xmlTextReaderMoveToAttribute(@reader, name) == 1
   end
 
-  # Returns the text value of the attribute with the specified name.
-  def attribute(name : String)
-    value = LibXML.xmlTextReaderGetAttribute(@reader, name)
+  # Gets the attribute content for the *attribute* given by name.
+  # Raises `KeyError` if attribute is not found.
+  def [](attribute : String) : String
+    self[attribute]? || raise(KeyError.new("Missing attribute: #{attribute}"))
+  end
+
+  # Gets the attribute content for the *attribute* given by name.
+  # Returns `nil` if attribute is not found.
+  def []?(attribute : String) : String?
+    value = LibXML.xmlTextReaderGetAttribute(@reader, attribute)
     String.new(value) if value
   end
 

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -25,6 +25,14 @@ struct XML::Reader
     LibXML.xmlTextReaderRead(@reader) == 1
   end
 
+  def next
+    LibXML.xmlTextReaderNext(@reader) == 1
+  end
+
+  def next_sibling
+    LibXML.xmlTextReaderNextSibling(@reader) == 1
+  end
+
   def node_type
     LibXML.xmlTextReaderNodeType(@reader)
   end
@@ -51,6 +59,38 @@ struct XML::Reader
 
   def move_to_next_attribute
     LibXML.xmlTextReaderMoveToNextAttribute(@reader) == 1
+  end
+
+  def move_to_attribute(name)
+    LibXML.xmlTextReaderMoveToAttribute(@reader, name.to_s) == 1
+  end
+
+  def attribute(name)
+    value = LibXML.xmlTextReaderGetAttribute(@reader, name.to_s)
+    String.new(value) if value
+  end
+
+  def move_to_element
+    LibXML.xmlTextReaderMoveToElement(@reader) == 1
+  end
+
+  def depth
+    LibXML.xmlTextReaderDepth(@reader)
+  end
+
+  def read_inner_xml
+    xml = LibXML.xmlTextReaderReadInnerXml(@reader)
+    String.new(xml) if xml
+  end
+
+  def read_outer_xml
+    xml = LibXML.xmlTextReaderReadOuterXml(@reader)
+    String.new(xml) if xml
+  end
+
+  def expand
+    xml = LibXML.xmlTextReaderExpand(@reader)
+    XML::Node.new(xml) if xml
   end
 
   def value

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -60,7 +60,7 @@ struct XML::Reader
   # Returns the name of the node.
   def name
     value = LibXML.xmlTextReaderConstName(@reader)
-    String.new(value) if value
+    value ? String.new(value) : ""
   end
 
   # Checks if the node is an empty element.
@@ -112,13 +112,13 @@ struct XML::Reader
   # Returns the node's XML content including subtrees.
   def read_inner_xml
     xml = LibXML.xmlTextReaderReadInnerXml(@reader)
-    String.new(xml) if xml
+    xml ? String.new(xml) : ""
   end
 
   # Returns the XML for the node and its content including subtrees.
   def read_outer_xml
     xml = LibXML.xmlTextReaderReadOuterXml(@reader)
-    String.new(xml) if xml
+    xml ? String.new(xml) : ""
   end
 
   # Expand the node to a `XML::Node` that can be searched with XPath etc.
@@ -131,7 +131,7 @@ struct XML::Reader
   # Returns the text content of the node.
   def value
     value = LibXML.xmlTextReaderConstValue(@reader)
-    String.new(value) if value
+    value ? String.new(value) : ""
   end
 
   # Returns a reference to the underlying `LibXML::XMLTextReader`.

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -89,13 +89,13 @@ struct XML::Reader
   end
 
   # Moves to the `XML::Type::ATTRIBUTE_NODE` with the specified name.
-  def move_to_attribute(name)
-    LibXML.xmlTextReaderMoveToAttribute(@reader, name.to_s) == 1
+  def move_to_attribute(name : String)
+    LibXML.xmlTextReaderMoveToAttribute(@reader, name) == 1
   end
 
   # Returns the text value of the attribute with the specified name.
-  def attribute(name)
-    value = LibXML.xmlTextReaderGetAttribute(@reader, name.to_s)
+  def attribute(name : String)
+    value = LibXML.xmlTextReaderGetAttribute(@reader, name)
     String.new(value) if value
   end
 

--- a/src/xml/type.cr
+++ b/src/xml/type.cr
@@ -1,4 +1,5 @@
 enum XML::Type
+  NONE               =  0
   ELEMENT_NODE       =  1
   ATTRIBUTE_NODE     =  2
   TEXT_NODE          =  3


### PR DESCRIPTION
This adds a couple of method bindings that come in handy when doing pull parsing or hybrid parsing (search with pull then expand node).