### PR TITLE
Add Enum.size

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -14,7 +14,7 @@ end
 enum SpecNonUniqueEnum
   One      = 1
   Two      = 2
-  OneAgain = 1
+  OneAgain = One
 end
 
 @[Flags]
@@ -111,8 +111,8 @@ describe Enum do
       SpecEnumFlags.size.should eq 3
     end
 
-    it "gives number of unique enum values" do
-      SpecNonUniqueEnum.size.should eq 2
+    it "gives number of enum members" do
+      SpecNonUniqueEnum.size.should eq 3
     end
 
     it "gives number of unique enum flags" do

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -11,11 +11,25 @@ enum SpecEnum2
   FOURTY_FOUR
 end
 
+enum SpecNonUniqueEnum
+  One      = 1
+  Two      = 2
+  OneAgain = 1
+end
+
 @[Flags]
 enum SpecEnumFlags
   One
   Two
   Three
+end
+
+@[Flags]
+enum SpecNonUniqueEnumFlags
+  One    = 0b001
+  Two    = 0b010
+  Four   = 0b100
+  OneTwo = 0b011
 end
 
 describe Enum do
@@ -95,6 +109,14 @@ describe Enum do
 
     it "for flags enum" do
       SpecEnumFlags.size.should eq 3
+    end
+
+    it "gives number of unique enum values" do
+      SpecNonUniqueEnum.size.should eq 2
+    end
+
+    it "gives number of unique enum flags" do
+      SpecNonUniqueEnumFlags.size.should eq 3
     end
   end
 

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -88,6 +88,16 @@ describe Enum do
     end
   end
 
+  describe "size" do
+    it "for simple enum" do
+      SpecEnum.size.should eq 3
+    end
+
+    it "for flags enum" do
+      SpecEnumFlags.size.should eq 3
+    end
+  end
+
   describe "names" do
     it "for simple enum" do
       SpecEnum.names.should eq(%w(One Two Three))

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -307,7 +307,7 @@ struct Enum
     {% end %}
   end
 
-  # Returns the number of unique enum members.
+  # Returns the number of enum members for normal enum, or the number of flags for flags enum.
   #
   # ```
   # Color.size  # => 3

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -307,7 +307,7 @@ struct Enum
     {% end %}
   end
 
-  # Returns the number of enum members.
+  # Returns the number of unique enum members.
   #
   # ```
   # Color.size  # => 3
@@ -315,7 +315,7 @@ struct Enum
   # ```
   def self.size : Int32
     {% if @type.has_attribute?("Flags") %}
-      {{ @type.constants.size - 2 }}
+      {{ @type }}::All.value.popcount
     {% else %}
       {{ @type.constants.size }}
     {% end %}

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -307,6 +307,20 @@ struct Enum
     {% end %}
   end
 
+  # Returns the number of enum members.
+  #
+  # ```
+  # Color.size  # => 3
+  # IOMode.size # => 3
+  # ```
+  def self.size : Int32
+    {% if @type.has_attribute?("Flags") %}
+      {{ @type.constants.size - 2 }}
+    {% else %}
+      {{ @type.constants.size }}
+    {% end %}
+  end
+
   # Returns all enum members as an `Array(String)`.
   #
   # ```


### PR DESCRIPTION
I just stepped on the need to know the number of enum members in an enum, and was surprised there wasn't a class method `Enum.size` or `Enum.count`, so here it is.