### PR TITLE
Improve String#pretty_print output by splitting newline

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1494,6 +1494,13 @@ describe "String" do
     "\u{1f48e}".inspect_unquoted.should eq %(\u{1F48E})
   end
 
+  it "does pretty_inspect" do
+    "a".pretty_inspect.should eq(%("a"))
+    "hello\nworld".pretty_inspect.should eq(%("hello\\n" + "world"))
+    "hello\nworld".pretty_inspect(width: 9).should eq(%("hello\\n" +\n"world"))
+    "hello\nworld\n".pretty_inspect(width: 9).should eq(%("hello\\n" +\n"world\\n"))
+  end
+
   it "does *" do
     str = "foo" * 10
     str.bytesize.should eq(30)

--- a/src/string.cr
+++ b/src/string.cr
@@ -3831,7 +3831,23 @@ class String
 
   # Pretty prints `self` into the given printer.
   def pretty_print(pp : PrettyPrint) : Nil
-    pp.text(inspect)
+    printed_bytesize = 0
+    pp.group do
+      split('\n') do |part|
+        printed_bytesize += part.bytesize
+        if printed_bytesize != bytesize
+          printed_bytesize += 1 # == "\n".bytesize
+          pp.text("\"")
+          pp.text(part.inspect_unquoted)
+          pp.text("\\n\"")
+          break if printed_bytesize == bytesize
+          pp.text(" +")
+          pp.breakable
+        else
+          pp.text(part.inspect)
+        end
+      end
+    end
   end
 
   # Returns a representation of `self` using character escapes for special characters and wrapped in quotes.


### PR DESCRIPTION
Like Ruby's `pp`, `String#pretty_print` should split its content by newline and show each lines with joining `+` operator.

I believe this improves readability against large multiline string on `p`.

```crystal
p "Hello World\n" * 10
```

Before:

```crystal
"Hello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\n"
```


After:

```crystal
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n" +
"Hello World\n"
```