### PR TITLE
Refactor spec runner CLI for extensibility

### DIFF
--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "spec/cli"
 
-class SpecRunnerCLI < Spec::CLI
-  property exit_code : Int32?
+private class SpecRunnerCLI < Spec::CLI
+  getter exit_code : Int32?
 
   private def display(message)
     stdout.puts message

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -2,16 +2,16 @@ require "spec"
 require "spec/cli"
 
 class SpecRunnerCLI < Spec::CLI
-  property? exited : Int32?
+  property exit_code : Int32?
 
   private def display(message)
     stdout.puts message
-    @exited = 0
+    @exit_code = 0
   end
 
   private def terminate(message, status = 1)
     stderr.puts message
-    @exited = status
+    @exit_code = status
   end
 end
 
@@ -26,38 +26,38 @@ describe Spec::CLI do
   context "parses options" do
     it "captures provided example pattern" do
       _, options = prepare_cli %w(-e Foo)
-      options.pattern?.should be_truthy
-      options.pattern?.should eq("Foo")
+      options.pattern.should be_truthy
+      options.pattern.should eq("Foo")
 
       _, options = prepare_cli %w(--example Bar)
-      options.pattern?.should be_truthy
-      options.pattern?.should eq("Bar")
+      options.pattern.should be_truthy
+      options.pattern.should eq("Bar")
     end
 
     it "captures provided line number" do
       _, options = prepare_cli %w()
-      options.line?.should be_falsey
+      options.line.should be_falsey
 
       _, options = prepare_cli %w(-l 10)
-      options.line?.should be_truthy
-      options.line?.should eq(10)
+      options.line.should be_truthy
+      options.line.should eq(10)
 
       _, options = prepare_cli %w(--line 10)
-      options.line?.should be_truthy
-      options.line?.should eq(10)
+      options.line.should be_truthy
+      options.line.should eq(10)
     end
 
     it "enables slowest mode" do
       _, options = prepare_cli %w()
-      options.slowest?.should be_falsey
+      options.slowest.should be_falsey
 
       _, options = prepare_cli %w(-p)
-      options.slowest?.should be_truthy
-      options.slowest?.should eq(10)
+      options.slowest.should be_truthy
+      options.slowest.should eq(10)
 
       _, options = prepare_cli %w(--profile)
-      options.slowest?.should be_truthy
-      options.slowest?.should eq(10)
+      options.slowest.should be_truthy
+      options.slowest.should eq(10)
     end
 
     it "enables fail-fast mode" do
@@ -89,8 +89,8 @@ describe Spec::CLI do
         cli, options = prepare_cli %w(--location missing.cr), stderr: io
         options.locations.size.should eq(0)
 
-        cli.exited?.should be_truthy
-        cli.exited?.should eq(1)
+        cli.exit_code.should be_truthy
+        cli.exit_code.should eq(1)
 
         io.to_s.should contain("location missing.cr must be file:line")
       end
@@ -108,8 +108,8 @@ describe Spec::CLI do
 
       cli, _ = prepare_cli %w(--help), stdout: io
 
-      cli.exited?.should be_truthy
-      cli.exited?.should eq(0)
+      cli.exit_code.should be_truthy
+      cli.exit_code.should eq(0)
 
       output = io.to_s
       output.should contain("crystal spec runner")
@@ -118,15 +118,15 @@ describe Spec::CLI do
 
     it "changes default formatter to verbose" do
       _, options = prepare_cli %w()
-      options.default_formatter?.should be_falsey
+      options.default_formatter.should be_falsey
 
       _, options = prepare_cli %w(-v)
-      options.default_formatter?.should be_truthy
-      options.default_formatter?.should be_a(Spec::VerboseFormatter)
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
 
       _, options = prepare_cli %w(--verbose)
-      options.default_formatter?.should be_truthy
-      options.default_formatter?.should be_a(Spec::VerboseFormatter)
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
     end
 
     it "changes default formatter using SPEC_VERBOSE" do
@@ -134,8 +134,8 @@ describe Spec::CLI do
       ENV["SPEC_VERBOSE"] = "1"
 
       _, options = prepare_cli %w()
-      options.default_formatter?.should be_truthy
-      options.default_formatter?.should be_a(Spec::VerboseFormatter)
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
     ensure
       ENV["SPEC_VERBOSE"] = old_env
     end
@@ -149,8 +149,8 @@ describe Spec::CLI do
       io = IO::Memory.new
       cli, _ = prepare_cli %w(unknown), stderr: io
 
-      cli.exited?.should be_truthy
-      cli.exited?.should eq(1)
+      cli.exit_code.should be_truthy
+      cli.exit_code.should eq(1)
 
       io.to_s.should contain("Error: unknown argument 'unknown'")
     end

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -27,34 +27,43 @@ describe Spec::CLI do
     it "captures provided example pattern" do
       _, options = prepare_cli %w(-e Foo)
       options.pattern?.should be_truthy
-      options.pattern.should eq("Foo")
+      options.pattern?.should eq("Foo")
 
       _, options = prepare_cli %w(--example Bar)
       options.pattern?.should be_truthy
-      options.pattern.should eq("Bar")
+      options.pattern?.should eq("Bar")
     end
 
     it "captures provided line number" do
+      _, options = prepare_cli %w()
+      options.line?.should be_falsey
+
       _, options = prepare_cli %w(-l 10)
       options.line?.should be_truthy
-      options.line.should eq(10)
+      options.line?.should eq(10)
 
       _, options = prepare_cli %w(--line 10)
       options.line?.should be_truthy
-      options.line.should eq(10)
+      options.line?.should eq(10)
     end
 
     it "enables slowest mode" do
+      _, options = prepare_cli %w()
+      options.slowest?.should be_falsey
+
       _, options = prepare_cli %w(-p)
       options.slowest?.should be_truthy
-      options.slowest.should eq(10)
+      options.slowest?.should eq(10)
 
       _, options = prepare_cli %w(--profile)
       options.slowest?.should be_truthy
-      options.slowest.should eq(10)
+      options.slowest?.should eq(10)
     end
 
     it "enables fail-fast mode" do
+      _, options = prepare_cli %w()
+      options.fail_fast?.should be_false
+
       _, options = prepare_cli %w(--fail-fast)
       options.fail_fast?.should be_true
     end
@@ -112,12 +121,12 @@ describe Spec::CLI do
       options.default_formatter?.should be_falsey
 
       _, options = prepare_cli %w(-v)
-      options.default_formatter.should be_truthy
-      options.default_formatter.should be_a(Spec::VerboseFormatter)
+      options.default_formatter?.should be_truthy
+      options.default_formatter?.should be_a(Spec::VerboseFormatter)
 
       _, options = prepare_cli %w(--verbose)
-      options.default_formatter.should be_truthy
-      options.default_formatter.should be_a(Spec::VerboseFormatter)
+      options.default_formatter?.should be_truthy
+      options.default_formatter?.should be_a(Spec::VerboseFormatter)
     end
 
     it "changes default formatter using SPEC_VERBOSE" do
@@ -125,8 +134,8 @@ describe Spec::CLI do
       ENV["SPEC_VERBOSE"] = "1"
 
       _, options = prepare_cli %w()
-      options.default_formatter.should be_truthy
-      options.default_formatter.should be_a(Spec::VerboseFormatter)
+      options.default_formatter?.should be_truthy
+      options.default_formatter?.should be_a(Spec::VerboseFormatter)
     ensure
       ENV["SPEC_VERBOSE"] = old_env
     end

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -1,0 +1,183 @@
+require "spec"
+require "spec/cli"
+
+private def prepare_cli(argv, **kargs)
+  cli = Spec::CLI.new(argv, **kargs)
+  cli.prepare
+
+  {cli, cli.options}
+end
+
+# override and capture exit calls
+module Spec
+  class CLI
+    property! exited : Int32
+    property? testing = false
+
+    def testing
+      @testing = true
+      yield
+    ensure
+      @testing = false
+    end
+
+    private def display(message)
+      stdout.puts message
+
+      if testing?
+        @exited = 0
+      else
+        exit
+      end
+    end
+
+    private def terminate(message, status = 1)
+      stderr.puts message
+
+      if testing?
+        @exited = status
+      else
+        exit status
+      end
+    end
+  end
+end
+
+describe Spec::CLI do
+  context "parses options" do
+    it "captures provided example pattern" do
+      _, options = prepare_cli %w(-e Foo)
+      options.pattern?.should be_truthy
+      options.pattern.should eq("Foo")
+
+      _, options = prepare_cli %w(--example Bar)
+      options.pattern?.should be_truthy
+      options.pattern.should eq("Bar")
+    end
+
+    it "captures provided line number" do
+      _, options = prepare_cli %w(-l 10)
+      options.line?.should be_truthy
+      options.line.should eq(10)
+
+      _, options = prepare_cli %w(--line 10)
+      options.line?.should be_truthy
+      options.line.should eq(10)
+    end
+
+    it "enables slowest mode" do
+      _, options = prepare_cli %w(-p)
+      options.slowest?.should be_truthy
+      options.slowest.should eq(10)
+
+      _, options = prepare_cli %w(--profile)
+      options.slowest?.should be_truthy
+      options.slowest.should eq(10)
+    end
+
+    it "enables fail-fast mode" do
+      _, options = prepare_cli %w(--fail-fast)
+      options.fail_fast?.should be_true
+    end
+
+    context "locations" do
+      it "captures single file:line location" do
+        _, options = prepare_cli %w(--location foo.cr:1)
+
+        options.locations.size.should eq(1)
+        options.locations.should eq([{"foo.cr", 1}])
+      end
+
+      it "captures multiple file:line locations" do
+        _, options = prepare_cli %w(--location foo.cr:10 --location bar.cr:50)
+
+        options.locations.size.should eq(2)
+        options.locations.should eq([{"foo.cr", 10}, {"bar.cr", 50}])
+      end
+
+      it "aborts on incorrect location format" do
+        io = IO::Memory.new
+
+        cli = Spec::CLI.new %w(--location missing.cr), stderr: io
+        cli.testing do
+          cli.prepare
+        end
+
+        cli.options.locations.size.should eq(0)
+        cli.exited?.should be_truthy
+        cli.exited.should eq(1)
+
+        io.rewind
+        io.gets_to_end.should contain("location missing.cr must be file:line")
+      end
+    end
+
+    it "adds JUnit format to output" do
+      _, options = prepare_cli %w(--junit_output tmp)
+
+      options.formatters.size.should eq(1)
+      options.formatters.first.should be_a(Spec::JUnitFormatter)
+    end
+
+    it "displays help options" do
+      io = IO::Memory.new
+
+      cli = Spec::CLI.new %w(--help), stdout: io
+      cli.testing do
+        cli.prepare
+      end
+
+      cli.exited?.should be_truthy
+      cli.exited.should eq(0)
+
+      io.rewind
+      output = io.gets_to_end
+      output.should contain("crystal spec runner")
+      output.should contain("show this help")
+    end
+
+    it "changes default formatter to verbose" do
+      _, options = prepare_cli %w()
+      options.default_formatter?.should be_falsey
+
+      _, options = prepare_cli %w(-v)
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
+
+      _, options = prepare_cli %w(--verbose)
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
+    end
+
+    it "changes default formatter using SPEC_VERBOSE" do
+      old_env = ENV["SPEC_VERBOSE"]?
+      ENV["SPEC_VERBOSE"] = "1"
+
+      _, options = prepare_cli %w()
+      options.default_formatter.should be_truthy
+      options.default_formatter.should be_a(Spec::VerboseFormatter)
+    ensure
+      ENV["SPEC_VERBOSE"] = old_env
+    end
+
+    it "disables color output" do
+      _, options = prepare_cli %w(--no-color)
+      options.no_color?.should be_true
+    end
+
+    it "aborts execution with unknown arguments" do
+      io = IO::Memory.new
+      cli = Spec::CLI.new %w(unknown), stderr: io
+
+      cli.testing do
+        cli.prepare
+      end
+
+      cli.exited?.should be_truthy
+      cli.exited.should eq(1)
+
+      io.rewind
+      io.gets_to_end.should contain("Error: unknown argument 'unknown'")
+    end
+  end
+end

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "spec/cli"
 
 class SpecRunnerCLI < Spec::CLI
-  property! exited : Int32
+  property? exited : Int32? = nil
 
   private def display(message)
     stdout.puts message
@@ -90,7 +90,7 @@ describe Spec::CLI do
         options.locations.size.should eq(0)
 
         cli.exited?.should be_truthy
-        cli.exited.should eq(1)
+        cli.exited?.should eq(1)
 
         io.to_s.should contain("location missing.cr must be file:line")
       end
@@ -109,7 +109,7 @@ describe Spec::CLI do
       cli, _ = prepare_cli %w(--help), stdout: io
 
       cli.exited?.should be_truthy
-      cli.exited.should eq(0)
+      cli.exited?.should eq(0)
 
       output = io.to_s
       output.should contain("crystal spec runner")
@@ -150,7 +150,7 @@ describe Spec::CLI do
       cli, _ = prepare_cli %w(unknown), stderr: io
 
       cli.exited?.should be_truthy
-      cli.exited.should eq(1)
+      cli.exited?.should eq(1)
 
       io.to_s.should contain("Error: unknown argument 'unknown'")
     end

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "spec/cli"
 
 class SpecRunnerCLI < Spec::CLI
-  property? exited : Int32? = nil
+  property? exited : Int32?
 
   private def display(message)
     stdout.puts message

--- a/spec/std/spec/cli_spec.cr
+++ b/spec/std/spec/cli_spec.cr
@@ -107,8 +107,7 @@ describe Spec::CLI do
         cli.exited?.should be_truthy
         cli.exited.should eq(1)
 
-        io.rewind
-        io.gets_to_end.should contain("location missing.cr must be file:line")
+        io.to_s.should contain("location missing.cr must be file:line")
       end
     end
 
@@ -130,8 +129,7 @@ describe Spec::CLI do
       cli.exited?.should be_truthy
       cli.exited.should eq(0)
 
-      io.rewind
-      output = io.gets_to_end
+      output = io.to_s
       output.should contain("crystal spec runner")
       output.should contain("show this help")
     end
@@ -176,8 +174,7 @@ describe Spec::CLI do
       cli.exited?.should be_truthy
       cli.exited.should eq(1)
 
-      io.rewind
-      io.gets_to_end.should contain("Error: unknown argument 'unknown'")
+      io.to_s.should contain("Error: unknown argument 'unknown'")
     end
   end
 end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -1,4 +1,5 @@
 require "./spec/dsl"
+require "./spec/cli"
 
 # Crystal's built-in testing library. It provides a structure for writing executable examples
 # of how your code should behave. A domain specific language allows you to write them in a way similar to natural language.
@@ -66,55 +67,4 @@ require "./spec/dsl"
 module Spec
 end
 
-OptionParser.parse! do |opts|
-  opts.banner = "crystal spec runner"
-  opts.on("-e ", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
-    Spec.pattern = pattern
-  end
-  opts.on("-l ", "--line LINE", "run examples whose line matches LINE") do |line|
-    Spec.line = line.to_i
-  end
-  opts.on("-p", "--profile", "Print the 10 slowest specs") do
-    Spec.slowest = 10
-  end
-  opts.on("--fail-fast", "abort the run on first failure") do
-    Spec.fail_fast = true
-  end
-  opts.on("--location file:line", "run example at line 'line' in file 'file', multiple allowed") do |location|
-    if location =~ /\A(.+?)\:(\d+)\Z/
-      Spec.add_location $1, $2.to_i
-    else
-      STDERR.puts "location #{location} must be file:line"
-      exit 1
-    end
-  end
-  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
-    junit_formatter = Spec::JUnitFormatter.file(output_dir)
-    Spec.add_formatter(junit_formatter)
-  end
-  opts.on("--help", "show this help") do |pattern|
-    puts opts
-    exit
-  end
-  opts.on("-v", "--verbose", "verbose output") do
-    Spec.override_default_formatter(Spec::VerboseFormatter.new)
-  end
-  opts.on("--no-color", "Disable colored output") do
-    Spec.use_colors = false
-  end
-  opts.unknown_args do |args|
-  end
-end
-
-unless ARGV.empty?
-  STDERR.puts "Error: unknown argument '#{ARGV.first}'"
-  exit 1
-end
-
-if ENV["SPEC_VERBOSE"]? == "1"
-  Spec.override_default_formatter(Spec::VerboseFormatter.new)
-end
-
-Signal::INT.trap { Spec.abort! }
-
-Spec.run
+Spec::CLI.new(ARGV).run

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -8,13 +8,12 @@ module Spec
     class Options
       property formatters = Array(Spec::Formatter).new
       property locations = Array({String, Int32}).new
-
-      property? default_formatter : Spec::Formatter?
+      property default_formatter : Spec::Formatter?
       property? fail_fast : Bool = false
-      property? line : Int32?
+      property line : Int32?
       property? no_color : Bool = false
-      property? pattern : String?
-      property? slowest : Int32?
+      property pattern : String?
+      property slowest : Int32?
     end
 
     getter options : Options
@@ -56,15 +55,15 @@ module Spec
     end
 
     private def apply_options
-      if pattern = options.pattern?
+      if pattern = options.pattern
         Spec.pattern = pattern
       end
 
-      if line = options.line?
+      if line = options.line
         Spec.line = line
       end
 
-      if slowest = options.slowest?
+      if slowest = options.slowest
         Spec.slowest = slowest
       end
 
@@ -82,7 +81,7 @@ module Spec
         Spec.add_formatter formatter
       end
 
-      if formatter = options.default_formatter?
+      if formatter = options.default_formatter
         Spec.override_default_formatter formatter
       end
     end

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -30,7 +30,7 @@ module Spec
       setup
     end
 
-    def prepare
+    def prepare : Nil
       return if prepared?
 
       parser.parse(argv)
@@ -42,7 +42,7 @@ module Spec
       if ENV["SPEC_VERBOSE"]? == "1"
         options.default_formatter = Spec::VerboseFormatter.new
       end
-    ensure
+
       @prepared = true
     end
 

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -9,12 +9,12 @@ module Spec
       property formatters = Array(Spec::Formatter).new
       property locations = Array({String, Int32}).new
 
-      property! default_formatter : Spec::Formatter
-      property! fail_fast : Bool
-      property! line : Int32
-      property! no_color : Bool
-      property! pattern : String
-      property! slowest : Int32
+      property? default_formatter : Spec::Formatter? = nil
+      property? fail_fast : Bool = false
+      property? line : Int32? = nil
+      property? no_color : Bool = false
+      property? pattern : String? = nil
+      property? slowest : Int32? = nil
     end
 
     getter options : Options
@@ -56,11 +56,23 @@ module Spec
     end
 
     private def apply_options
-      Spec.pattern = options.pattern if options.pattern?
-      Spec.line = options.line if options.line?
-      Spec.slowest = options.slowest if options.slowest?
-      Spec.fail_fast = options.fail_fast if options.fail_fast?
-      Spec.use_colors = false if options.no_color?
+      if pattern = options.pattern?
+        Spec.pattern = pattern
+      end
+
+      if line = options.line?
+        Spec.line = line
+      end
+
+      if slowest = options.slowest?
+        Spec.slowest = slowest
+      end
+
+      Spec.fail_fast = options.fail_fast?
+
+      if options.no_color?
+        Spec.use_colors = false
+      end
 
       options.locations.each do |file, line|
         Spec.add_location file, line

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -1,0 +1,136 @@
+require "./formatter"
+require "option_parser"
+
+module Spec
+  # :nodoc:
+  class CLI
+    # :nodoc:
+    class Options
+      property formatters = Array(Spec::Formatter).new
+      property locations = Array({String, Int32}).new
+
+      property! default_formatter : Spec::Formatter
+      property! fail_fast : Bool
+      property! line : Int32
+      property! no_color : Bool
+      property! pattern : String
+      property! slowest : Int32
+    end
+
+    getter options : Options
+
+    private getter argv : Array(String)
+    private getter parser = OptionParser.new
+    private getter stderr : IO
+    private getter stdout : IO
+
+    private getter? prepared : Bool = false
+
+    def initialize(@argv, *, @options = Options.new, @stderr = STDERR, @stdout = STDOUT)
+      setup
+    end
+
+    def prepare
+      return if prepared?
+
+      parser.parse(argv)
+
+      unless argv.empty?
+        terminate "Error: unknown argument '#{argv.first}'"
+      end
+
+      if ENV["SPEC_VERBOSE"]? == "1"
+        options.default_formatter = Spec::VerboseFormatter.new
+      end
+    ensure
+      @prepared = true
+    end
+
+    def run
+      prepare unless prepared?
+      apply_options
+
+      Signal::INT.trap { Spec.abort! }
+
+      Spec.run
+    end
+
+    private def apply_options
+      Spec.pattern = options.pattern if options.pattern?
+      Spec.line = options.line if options.line?
+      Spec.slowest = options.slowest if options.slowest?
+      Spec.fail_fast = options.fail_fast if options.fail_fast?
+      Spec.use_colors = false if options.no_color?
+
+      options.locations.each do |file, line|
+        Spec.add_location file, line
+      end
+
+      options.formatters.each do |formatter|
+        Spec.add_formatter formatter
+      end
+
+      if formatter = options.default_formatter?
+        Spec.override_default_formatter formatter
+      end
+    end
+
+    private def setup
+      parser.banner = "crystal spec runner"
+
+      parser.on("-e ", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
+        options.pattern = pattern
+      end
+
+      parser.on("-l ", "--line LINE", "run examples whose line matches LINE") do |line|
+        options.line = line.to_i
+      end
+
+      parser.on("-p", "--profile", "Print the 10 slowest specs") do
+        options.slowest = 10
+      end
+
+      parser.on("--fail-fast", "abort the run on first failure") do
+        options.fail_fast = true
+      end
+
+      parser.on("--location file:line", "run example at line 'line' in file 'file', multiple allowed") do |location|
+        if location =~ /\A(.+?)\:(\d+)\Z/
+          options.locations << {$1, $2.to_i}
+        else
+          terminate "location #{location} must be file:line"
+        end
+      end
+
+      parser.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
+        junit_formatter = Spec::JUnitFormatter.file(output_dir)
+        options.formatters << junit_formatter
+      end
+
+      parser.on("--help", "show this help") do |pattern|
+        display parser
+      end
+
+      parser.on("-v", "--verbose", "verbose output") do
+        options.default_formatter = Spec::VerboseFormatter.new
+      end
+
+      parser.on("--no-color", "Disable colored output") do
+        options.no_color = true
+      end
+
+      parser.unknown_args do |args|
+      end
+    end
+
+    private def display(message)
+      stdout.puts message
+      exit
+    end
+
+    private def terminate(message, status = 1)
+      stderr.puts message
+      exit status
+    end
+  end
+end

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -9,12 +9,12 @@ module Spec
       property formatters = Array(Spec::Formatter).new
       property locations = Array({String, Int32}).new
 
-      property? default_formatter : Spec::Formatter? = nil
+      property? default_formatter : Spec::Formatter?
       property? fail_fast : Bool = false
-      property? line : Int32? = nil
+      property? line : Int32?
       property? no_color : Bool = false
-      property? pattern : String? = nil
-      property? slowest : Int32? = nil
+      property? pattern : String?
+      property? slowest : Int32?
     end
 
     getter options : Options

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -47,7 +47,7 @@ module Spec
     end
 
     def run
-      prepare unless prepared?
+      prepare
       apply_options
 
       Signal::INT.trap { Spec.abort! }


### PR DESCRIPTION
Introduce `Spec::CLI` class as new entry point of Spec runner. This new interface makes more easy to extend runner's behavior and options by extensions or formatters, overriding `#setup` and using previous definition:

```crystal
# TAP formatter extension (spec/tap.cr)
require "spec/cli"

class Spec::CLI
  def setup
    # important: include previous definition!
    previous_def

    # extend with new option
    parser.on("--tap", "use my own TAP formatter") do
      options.default_formatter = Spec::TAPFormatter.new
    end
  end
end

# my spec_helper.cr
require "spec"
require "spec/tap"
```

With these changes will be possible to extend Spec runner with other formatters or extensions.

It provides 1:1 behavior found in `spec.cr`, but it can be improved more easily moving forward (ie. register formatters, etc.)

Ref. #5662