### PR TITLE
Fix YAML core schema parses integer 0

### DIFF
--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -94,17 +94,21 @@ describe YAML::Schema::Core do
   end
 
   # integer (base 10)
+  it_parses_scalar "0", 0
   it_parses_scalar "123", 123
   it_parses_scalar "+123", 123
   it_parses_scalar "-123", -123
 
   # integer (binary)
+  it_parses_scalar "0b0", 0
   it_parses_scalar "0b10110", 0b10110
 
   # integer (octal)
+  it_parses_scalar "00", 0
   it_parses_scalar "0123", 0o123
 
   # integer (hex)
+  it_parses_scalar "0x0", 0
   it_parses_scalar "0x123abc", 0x123abc
   it_parses_scalar "-0x123abc", -0x123abc
 

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -84,6 +84,7 @@ module YAML::Schema::Core
       value = parse_float?(string)
       return value || string
     when .starts_with?('0')
+      return 0_i64 if string.size == 1
       value = string.to_i64?(base: 8, prefix: true)
       return value || string
     when .starts_with?('-'),


### PR DESCRIPTION
Parsing scalar `0` previously returned a string (`"0"`) instead of integer.
This fixes it by adding a special case for `0`. Also adds a few specs for zero values (though binary, octal, hex were not broken).

Fixes #5771