### PR TITLE
Refactor `HTTP::Server` to bind to multiple addresses

### DIFF
--- a/samples/http_server.cr
+++ b/samples/http_server.cr
@@ -1,9 +1,10 @@
 require "http/server"
 
-server = HTTP::Server.new "0.0.0.0", 8080 do |context|
+server = HTTP::Server.new do |context|
   context.response.headers["Content-Type"] = "text/plain"
   context.response.print("Hello world!")
 end
 
+server.bind "0.0.0.0", 8080
 puts "Listening on http://0.0.0.0:8080"
 server.listen

--- a/samples/http_server.cr
+++ b/samples/http_server.cr
@@ -5,6 +5,5 @@ server = HTTP::Server.new do |context|
   context.response.print("Hello world!")
 end
 
-server.bind "0.0.0.0", 8080
 puts "Listening on http://0.0.0.0:8080"
-server.listen
+server.listen "0.0.0.0", 8080

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -248,6 +248,16 @@ module HTTP
       HTTP::Client.get("http://#{address1}/").body.should eq "Test Server (#{address1})"
       HTTP::Client.get("http://#{address1}/").body.should eq "Test Server (#{address1})"
     end
+
+    it "lists addresses" do
+      server = Server.new { }
+
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      addresses = [server.bind_unused_port, server.bind_unused_port, tcp_server.local_address]
+      server.bind tcp_server
+
+      server.addresses.should eq addresses
+    end
   end
 
   describe HTTP::Server::RequestProcessor do

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -200,7 +200,7 @@ module HTTP
       address.port.should_not eq(0)
 
       server = Server.new { |ctx| }
-      port = server.bind(0).port
+      port = server.bind_tcp(0).port
       port.should_not eq(0)
     end
 
@@ -221,7 +221,7 @@ module HTTP
       address = s1.bind_unused_port(reuse_port: true)
 
       s2 = Server.new { |ctx| }
-      s2.bind(address.port, reuse_port: true)
+      s2.bind_tcp(address.port, reuse_port: true)
 
       s1.close
       s2.close
@@ -331,7 +331,7 @@ module HTTP
   typeof(begin
     # Initialize with custom host
     server = Server.new { |ctx| }
-    server.bind "0.0.0.0", 0
+    server.bind_tcp "0.0.0.0", 0
     server.listen
     server.close
 
@@ -342,18 +342,18 @@ module HTTP
       StaticFileHandler.new("."),
     ]
     )
-    server.bind "0.0.0.0", 0
+    server.bind_tcp "0.0.0.0", 0
     server.listen
     server.close
 
     server = Server.new([StaticFileHandler.new(".")]) { |ctx| }
-    server.bind "0.0.0.0", 0
+    server.bind_tcp "0.0.0.0", 0
     server.listen
     server.close
 
     # Initialize with default host
     server = Server.new { |ctx| }
-    server.bind 0
+    server.bind_tcp 0
     server.listen
     server.close
 
@@ -364,12 +364,12 @@ module HTTP
       StaticFileHandler.new("."),
     ]
     )
-    server.bind 0
+    server.bind_tcp 0
     server.listen
     server.close
 
     server = Server.new([StaticFileHandler.new(".")]) { |ctx| }
-    server.bind 0
+    server.bind_tcp 0
     server.listen
     server.close
   end)

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -295,7 +295,7 @@ describe HTTP::WebSocket do
   end
 
   it "negotiates over HTTP correctly" do
-    port_chan = Channel(Int32).new
+    address_chan = Channel(Socket::IPAddress).new
 
     spawn do
       http_ref = nil
@@ -314,14 +314,14 @@ describe HTTP::WebSocket do
       end
 
       http_server = http_ref = HTTP::Server.new([ws_handler])
-      http_server.bind 0
-      port_chan.send(http_server.port.not_nil!)
+      address = http_server.bind_unused_port
+      address_chan.send(address)
       http_server.listen
     end
 
-    listen_port = port_chan.receive
+    listen_address = address_chan.receive
 
-    ws2 = HTTP::WebSocket.new("ws://127.0.0.1:#{listen_port}/foo/bar?query=arg&yes=please")
+    ws2 = HTTP::WebSocket.new("ws://#{listen_address}/foo/bar?query=arg&yes=please")
 
     random = Random::Secure.hex
     ws2.on_message do |str|
@@ -334,7 +334,7 @@ describe HTTP::WebSocket do
   end
 
   it "negotiates over HTTPS correctly" do
-    port_chan = Channel(Int32).new
+    address_chan = Channel(Socket::IPAddress).new
 
     spawn do
       http_ref = nil
@@ -354,15 +354,15 @@ describe HTTP::WebSocket do
       tls = http_server.tls = OpenSSL::SSL::Context::Server.new
       tls.certificate_chain = File.join(__DIR__, "../openssl/ssl/openssl.crt")
       tls.private_key = File.join(__DIR__, "../openssl/ssl/openssl.key")
-      http_server.bind 0
-      port_chan.send(http_server.port.not_nil!)
+      address = http_server.bind_unused_port
+      address_chan.send(address)
       http_server.listen
     end
 
-    listen_port = port_chan.receive
+    listen_address = address_chan.receive
 
     client_context = OpenSSL::SSL::Context::Client.insecure
-    ws2 = HTTP::WebSocket.new("127.0.0.1", port: listen_port, path: "/", tls: client_context)
+    ws2 = HTTP::WebSocket.new(listen_address.address, port: listen_address.port, path: "/", tls: client_context)
 
     random = Random::Secure.hex
     ws2.on_message do |str|

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -313,9 +313,9 @@ describe HTTP::WebSocket do
         end
       end
 
-      http_server = http_ref = HTTP::Server.new(0, [ws_handler])
-      http_server.bind
-      port_chan.send(http_server.port)
+      http_server = http_ref = HTTP::Server.new([ws_handler])
+      http_server.bind 0
+      port_chan.send(http_server.port.not_nil!)
       http_server.listen
     end
 
@@ -350,12 +350,12 @@ describe HTTP::WebSocket do
         end
       end
 
-      http_server = http_ref = HTTP::Server.new(0, [ws_handler])
+      http_server = http_ref = HTTP::Server.new([ws_handler])
       tls = http_server.tls = OpenSSL::SSL::Context::Server.new
       tls.certificate_chain = File.join(__DIR__, "../openssl/ssl/openssl.crt")
       tls.private_key = File.join(__DIR__, "../openssl/ssl/openssl.key")
-      http_server.bind
-      port_chan.send(http_server.port)
+      http_server.bind 0
+      port_chan.send(http_server.port.not_nil!)
       http_server.listen
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -507,13 +507,13 @@ module Crystal::Playground
 
       host = @host
       if host
-        server.bind host, @port
+        address = server.bind_tcp host, @port
       else
-        server.bind @port
-        host = "localhost"
+        address = server.bind_tcp @port
       end
+      @port = address.port
 
-      puts "Listening on http://#{host}:#{@port}"
+      puts "Listening on http://#{address}"
       if host == "0.0.0.0"
         puts "WARNING running playground with 0.0.0.0 is unsecure."
       end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -503,11 +503,13 @@ module Crystal::Playground
         HTTP::StaticFileHandler.new(public_dir),
       ]
 
+      server = HTTP::Server.new handlers
+
       host = @host
       if host
-        server = HTTP::Server.new host, @port, handlers
+        server.bind host, @port
       else
-        server = HTTP::Server.new @port, handlers
+        server.bind @port
         host = "localhost"
       end
 

--- a/src/compiler/crystal/tools/playground/views/_about.html
+++ b/src/compiler/crystal/tools/playground/views/_about.html
@@ -60,11 +60,12 @@ And you can use the whole standard library. Seriously. Run the next sample and <
 <pre class="playground">
 require "http/server"
 
-server = HTTP::Server.new "0.0.0.0", 5678 do |context|
+server = HTTP::Server.new do |context|
   context.request.path
   context.response.headers["Content-Type"] = "text/plain"
   context.response.print("Hello world!")
 end
+server.bind "0.0.0.0", 5678
 
 puts "Listening on http://0.0.0.0:5678"
 server.listen</pre>

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -12,7 +12,7 @@ require "./formdata/**"
 # require "http"
 # require "tempfile"
 #
-# server = HTTP::Server.new(8085) do |context|
+# server = HTTP::Server.new do |context|
 #   name = nil
 #   file = nil
 #   HTTP::FormData.parse(context.request) do |part|
@@ -34,6 +34,7 @@ require "./formdata/**"
 #   context.response << file.path
 # end
 #
+# server.bind 8085
 # server.listen
 # ```
 #

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -123,22 +123,6 @@ class HTTP::Server
     @processor = RequestProcessor.new(handler)
   end
 
-  # Returns the TCP port of the first socket the server is bound to.
-  #
-  # For example you may let the system choose a port, then report it:
-  # ```
-  # server = HTTP::Server.new { }
-  # server.bind 0
-  # server.port # => 12345
-  # ```
-  def port : Int32?
-    @sockets.each do |socket|
-      if socket.is_a?(TCPServer)
-        return socket.local_address.port.to_i
-      end
-    end
-  end
-
   # Creates a `TCPServer` and adds it as a socket, returning the local address
   # and port the server listens on.
   #
@@ -161,6 +145,18 @@ class HTTP::Server
   # which allows multiple processes to bind to the same port.
   def bind(port : Int32, reuse_port : Bool = false) : Socket::IPAddress
     bind "127.0.0.1", port, reuse_port
+  end
+
+  # Creates a `TCPServer` listening on an unused port and adds it as a socket.
+  #
+  # Returns the `Socket::IPAddress` with the determined port number.
+  #
+  # ```
+  # server = HTTP::Server.new { }
+  # server.bind_unused_port # => Socket::IPAddress.new("127.0.0.1", 12345)
+  # ```
+  def bind_unused_port(host : String = "127.0.0.1", reuse_port : Bool = false) : Socket::IPAddress
+    bind host, 0, reuse_port
   end
 
   # Adds a `Socket::Server` *socket* to this server.

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -164,6 +164,21 @@ class HTTP::Server
     socket
   end
 
+  # Enumerates all addresses this server is bound to.
+  def each_address(&block : Socket::Address ->)
+    @sockets.each do |socket|
+      yield socket.local_address
+    end
+  end
+
+  def addresses : Array(Socket::Address)
+    array = [] of Socket::Address
+    each_address do |address|
+      array << address
+    end
+    array
+  end
+
   # Creates a `TCPServer` listenting on `127.0.0.1:port`, adds it as a socket
   # and starts the server. Blocks until the server is closed.
   #

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -123,28 +123,26 @@ class HTTP::Server
     @processor = RequestProcessor.new(handler)
   end
 
-  # Creates a `TCPServer` and adds it as a socket, returning the local address
+  # Creates a `TCPServer` listenting on `host:port` and adds it as a socket, returning the local address
   # and port the server listens on.
   #
-  # If *port* is `0`, a random, free port will be chosen.
-  #
-  # You may set *reuse_port* to `true` to enable the `SO_REUSEPORT` socket option,
+  # If *reuse_port* is `true`, it enables the `SO_REUSEPORT` socket option,
   # which allows multiple processes to bind to the same port.
-  def bind(host : String, port : Int32, reuse_port : Bool = false) : Socket::IPAddress
+  def bind_tcp(host : String, port : Int32, reuse_port : Bool = false) : Socket::IPAddress
     tcp_server = TCPServer.new(host, port, reuse_port: reuse_port)
+
     bind(tcp_server)
+
     tcp_server.local_address
   end
 
-  # Creates a `TCPServer` listenting on `127.0.0.1` and adds it as a socket,
+  # Creates a `TCPServer` listenting on `127.0.0.1:port` and adds it as a socket,
   # returning the local address and port the server listens on.
   #
-  # If *port* is `0`, a random, free port will be chosen.
-  #
-  # You may set *reuse_port* to true to enable the `SO_REUSEPORT` socket option,
+  # If *reuse_port* is `true`, it enables the `SO_REUSEPORT` socket option,
   # which allows multiple processes to bind to the same port.
-  def bind(port : Int32, reuse_port : Bool = false) : Socket::IPAddress
-    bind "127.0.0.1", port, reuse_port
+  def bind_tcp(port : Int32, reuse_port : Bool = false) : Socket::IPAddress
+    bind_tcp "127.0.0.1", port, reuse_port
   end
 
   # Creates a `TCPServer` listening on an unused port and adds it as a socket.
@@ -156,7 +154,7 @@ class HTTP::Server
   # server.bind_unused_port # => Socket::IPAddress.new("127.0.0.1", 12345)
   # ```
   def bind_unused_port(host : String = "127.0.0.1", reuse_port : Bool = false) : Socket::IPAddress
-    bind host, 0, reuse_port
+    bind_tcp host, 0, reuse_port
   end
 
   # Adds a `Socket::Server` *socket* to this server.
@@ -164,6 +162,26 @@ class HTTP::Server
     @sockets << socket
 
     socket
+  end
+
+  # Creates a `TCPServer` listenting on `127.0.0.1:port`, adds it as a socket
+  # and starts the server. Blocks until the server is closed.
+  #
+  # See `#bind(port : Int32)` for details.
+  def listen(port : Int32, reuse_port : Bool = false)
+    bind_tcp(port, reuse_port)
+
+    listen
+  end
+
+  # Creates a `TCPServer` listenting on `host:port`, adds it as a socket
+  # and starts the server. Blocks until the server is closed.
+  #
+  # See `#bind(host : String, port : Int32)` for details.
+  def listen(host : String, port : Int32, reuse_port : Bool = false)
+    bind_tcp(host, port, reuse_port)
+
+    listen
   end
 
   # Starts the server. Blocks until the server is closed.

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -210,7 +210,7 @@ class HTTP::Server
         until @wants_close
           spawn handle_client(socket.accept? || break)
         end
-
+      ensure
         done.send nil
       end
     end

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -158,10 +158,8 @@ class HTTP::Server
   end
 
   # Adds a `Socket::Server` *socket* to this server.
-  def bind(socket : Socket::Server) : Socket::Server
+  def bind(socket : Socket::Server) : Nil
     @sockets << socket
-
-    socket
   end
 
   # Enumerates all addresses this server is bound to.


### PR DESCRIPTION
Until now, a `HTTP::Server` instance binds to exactly one IP address (host + port). This address was set in the constructor alongside several options for passing one or more handlers.

This resulted in quite a few constructors already, and adding support for more options (such as using a Unix socket) would multiply the numbers. Additionally, it should be possible to have the server listen on multiple addresses, as many other HTTP server implementations.

This PR changes the API of `HTTP::Server`:

* The constructor only accepts handlers (in multiple variations, as before).
* `#bind` is used to add one ore multiple addresses the server should listen on. It accepts the same arguments previously used in the constructor (`port`, `host, port` - each with optional `reuse_port`).
* Additional overloads exist for `Socket::IPAddress` and `Socker::Server`.
* <del>You can bind to a Unix socket using `#bind(Socket::UNIXAddress)` or by supplying a `UNIXServer`</del> (<ins>will be a subsequent PR</ins>)
* <del>There is also a single-argument overload that accepts a string with either a host + port or a Unix socket (prefixed by `unix:`) and creates the appropriate server accordingly. See [#2735 (issue-comment)](https://github.com/crystal-lang/crystal/issues/2735#issuecomment-301349490) for the reasoning behind this.</del> (<ins>will be a subsequent PR</ins>)
* `#bind_unused_port` is a shortcut for `bind(0)` and returns the port. This is particularly useful for the use case of binding to an unused port and printing the port (could maybe change the return type to `Socket::IPAddress` to include the address as well). `#port` was removed because there is no single port anymore that this method could return.
* `#listen` starts accepting incoming requests, as before. However, there is also an catch-all overload which forwards all arguments to `#bind` and starts listening. This is a shortcut for the following:
```crystal
server.bind 80
server.listen
# same as
server.listen 80
```

With a server listening on multiple interfaces, I figured it would be useful to be able to determine from which connection a client request originates, so I added a nilable (for stubbing) instance variable `socket` to `HTTP::Server::Context`.

<del>This also includes a minor fix to copy the path of a UNIXServer to each socket. Otherwise you couldn't really tell them apart if (only by the file descriptor).</del> (<ins>will be a subsequent PR</ins>)

<del>Fixes one half of #2735</del> (<ins>will be a subsequent PR</ins>)