### PR TITLE
[WIP] OpenSSL RSA Bindings

### DIFF
--- a/spec/std/openssl/rsa_spec.cr
+++ b/spec/std/openssl/rsa_spec.cr
@@ -1,0 +1,128 @@
+require "spec"
+require "openssl/rsa"
+
+describe OpenSSL::RSA do
+  describe "instantiating and generate a key" do
+    it "can instantiate and generate for a given key size" do
+      pkey = OpenSSL::RSA.new(256)
+      pkey.private?.should be_true
+      pkey.public?.should be_false
+
+      pkey.public_key.public?.should be_true
+    end
+    it "can export to PEM format" do
+      pkey = OpenSSL::RSA.new(256)
+      pkey.private?.should be_true
+
+      pem = pkey.to_pem
+      isEmpty = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n" == pem
+
+      pem.should contain("BEGIN PRIVATE KEY")
+      isEmpty.should be_false
+    end
+    it "can export to DER format" do
+      pkey = OpenSSL::RSA.new(256)
+      pkey.private?.should be_true
+      pem = pkey.to_pem
+      der = pkey.to_der
+
+      pkey = OpenSSL::RSA.new(der)
+      pkey.to_pem.should eq pem
+      pkey.to_der.should eq der
+    end
+    it "can instantiate with a PEM encoded key" do
+      pem = OpenSSL::RSA.new(1024).to_pem
+      pkey = OpenSSL::RSA.new(pem)
+
+      pkey.to_pem.should eq pem
+    end
+    it "can instantiate with a DER encoded key" do
+      der = OpenSSL::RSA.new(1024).to_der
+      pkey = OpenSSL::RSA.new(der)
+
+      pkey.to_der.should eq der
+    end
+    it "can instantiate with a PEM encoded key and a passphrase" do
+      # At present, cannot export with passphrase - for some unknown openssl error means it writes an empty pem
+      # The following encrypted_pem has the passphrase 'test'
+      encrypted_pem = "-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,ABD606CE6CAEC3F9
+
+KffBt0WVDVMnzcCG2lzeHmTao0N4pO+hnbGRFzpdvRtJeBRTJVY7fpVQS8dKinO4
+tQlnx/e8iMuxiiVAND8YOjKMCRFVmNyry64hWPpBq69KgvBNAgnPTppc2AwCY5ZQ
+juZjzQMllq1hxOuvh1zt0qQHFRVCoWtbTxziedqhgPHFCoUKoMOB+GD4Rj+t5jYh
+fg/qStG1/rZ4mrPKTwS3LCYbVxc9X/7XJQWQ7IHmkf2VRr8mk9XRAZ0GLJXyNeai
+O5PBYt+fw2hi+00kRCbvEU83yYYoELteSLcoYcd7scYl73myOkYruDAZWu1YJnnt
+areXUPidcE+qCRSiF7395Ri5aLxcmGSgRm/P6z/nm31+3t2ISlvJwm5G73uAJWii
+XrnZQq2uWsIagRQlm+SHW21dDfDw5v1QKzLGC6vhpKI1dPYJPqcU6CB3mym9l+xB
+FLMigVC+QdmtSoFvcBu711TXEhEiDmszZEDWQoiF1nVXk2h/t8V6CE4b8TcODlHi
+gZC/oMCdYsmt3lePIcnudNHjCcYJPxV7KciChuI4i6IfPzZGLr94Q7doNwYD8TLj
+8MIcSNzsuUowMORKOfcV+kPGivm9hZ5hkvLqVHYKxkWJiTl0sHmx8QG/Mm4JW+cf
+kAK6rBib7m+r78eCRNPCh3nkW4mCE3R9z6QPBW//3FnTEqmTljK4Fa+uA59jpMOb
+1iEcbf2vwv7jrRx/CEu1VmOgsptVm1dcTABl/cL17Qp4tR7JUaW8FJYbf6WDyHl2
+7V/JgTownoEvqM38HpjZwF8kO1NckwSNdWCbDEpBbDR20cwMSWy79Q==
+-----END RSA PRIVATE KEY-----"
+
+      decoded = OpenSSL::RSA.new(encrypted_pem, "test")
+
+      not_encrypted = "-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQC5+5+xnWggxNnnmCSNbIwTQFjcyawcvmPupeXs10sfhUAHUxtm
+T5zH3AI46JrRZN7KV5Ac5bQWzF9ZMPeHqmq5FBdYooIF8W7lVtYx23OQX5vjFRN0
+LRY8hyOKL07Us+aUeMwDXX7M6o58XO4bqOh8pGOqFLscCAkdAP9lDgeDGwIDAQAB
+AoGAcRt/jnSNbEhrwXZ83GmkctzSbkxUWRLNEclhIP36WQwf2ZSIeFt4nO/Hhjao
+WSqAeAxyv7BPKwJWBpdKIv7Ycfbu2c1JxWgacuotewMk5IYPXUs89QY3AL5I4BJd
+Zqd3o9K4OWwakukkfjxHKFC/grifNa4yVQ6IZn+XuW/AspkCQQDlmzkUapzg0n0t
+3gmK6KQD9f5YdXKYGYzYO3Scrtrz53fewqfDXdLC7TGL9qw9vGEFvSE727vwR3X+
++DZ6RWYvAkEAz1yqUNnrPwzGx3JuINIXgfzGTq4gSf+xRjb5qDJUPnMt4I3PrPyV
+pm34aUCgo26go2+itBGjzFDaJCOT4izi1QJAJq6E6kSf01yCzFRo5ScWYrhxtjNr
+L+a2DMPPfIoUxxyK3FOM8eP/mulc/Ih9MhVnfxEC5VO6kNtpLKBihSzl7wJBAJrR
+4eu5uJV7kZJqEmV41spbkyg9g6gcOxxkgWQeJ5302wT0fGD4uTbolnbnJMjBGTjN
+adot7XDn0Ob4lTpiLv0CQQDkECppYQ4N0ecegg1xPVqf19fHo/WGHGuScjfUPTI/
+k0LaJjYM2ycehinmuLHgY3qdDJgtEbt4WG5XNQzhyfaN
+-----END RSA PRIVATE KEY-----"
+
+      not_encrypted_pkey = OpenSSL::RSA.new(not_encrypted)
+      decoded.to_pem.should eq not_encrypted_pkey.to_pem
+    end
+  end
+  describe "RSA-blinding" do
+    it "can turn blinding on" do
+      rsa = OpenSSL::RSA.new(128)
+      rsa.blinding_on!
+
+      rsa.blinding_on?.should be_true
+    end
+    it "can turn blinding off" do
+      rsa = OpenSSL::RSA.new(128)
+      rsa.blinding_on!
+      rsa.blinding_off!
+
+      rsa.blinding_on?.should be_false
+    end
+  end
+  describe "encrypting / decrypting" do
+    it "can encrypt a string using its private key and decrypt with public key" do
+      rsa = OpenSSL::RSA.new(256)
+      encrypted = rsa.private_encrypt "hello world"
+      decrypted = rsa.public_decrypt encrypted
+
+      String.new(decrypted).should eq "hello world"
+    end
+    it "can encrypt a string using its public key and decrypt with private key" do
+      rsa = OpenSSL::RSA.new(256)
+      encrypted = rsa.public_encrypt "hello world"
+      decrypted = rsa.private_decrypt encrypted
+
+      String.new(decrypted).should eq "hello world"
+    end
+  end
+  describe "can set parameters for more efficient decryption" do
+    it "can set dmp1, dmq1, iqmp" do
+    end
+    it "can set p and q" do
+    end
+    it "can set n, e and d for key" do
+    end
+  end
+end

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -34,6 +34,24 @@ struct OpenSSL::BIO
       LibCrypto::Long.new(val)
     end
 
+    crystal_bio.bgets = LibCrypto::BioMethodGets.new do |bio, buffer, len|
+      io = Box(IO).unbox(bio.value.ptr)
+      io.flush
+
+      position = io.pos
+
+      line = io.gets(len, false)
+
+      if line.nil?
+        return 0
+      end
+
+      io.seek(position)
+      bytes = io.read(Slice.new(buffer, line.bytesize)).to_i
+
+      bytes - 1
+    end
+
     crystal_bio.create = LibCrypto::BioMethodCreate.new do |bio|
       bio.value.shutdown = 1
       bio.value.init = 1

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -104,6 +104,10 @@ class OpenSSL::Cipher
     @ctx = nil
   end
 
+  def to_unsafe
+    cipher
+  end
+
   private def cipherinit(cipher = nil, engine = nil, key = nil, iv = nil, enc = -1)
     if LibCrypto.evp_cipherinit_ex(@ctx, cipher, engine, key, iv, enc) != 1
       raise Error.new "EVP_CipherInit_ex"

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -289,4 +289,228 @@ lib LibCrypto
     fun x509_verify_param_set1_ip_asc = X509_VERIFY_PARAM_set1_ip_asc(param : X509VerifyParam, ip : UInt8*) : Int
     fun x509_verify_param_set_flags = X509_VERIFY_PARAM_set_flags(param : X509VerifyParam, flags : X509VerifyFlags) : Int
   {% end %}
+
+  struct EvpPKey
+    type : LibC::Int
+    save_type : LibC::Int
+    references : LibC::Int
+    ameth : EVP_PKEY_ASN1_method
+    engine : Engine
+    pkey : EVP_PKEY_KEY
+    save_parameters : LibC::Int
+    attributes : StackStX509Attribute*
+  end
+
+  struct StackStX509Attribute
+    stack : Stack
+  end
+
+  struct Stack
+    num : LibC::Int
+    data : LibC::Char**
+    sorted : LibC::Int
+    num_alloc : LibC::Int
+    comp : (Void*, Void* -> LibC::Int)
+  end
+
+  struct Dsa
+    pad : LibC::Int
+    version : LibC::Long
+    write_params : LibC::Int
+    p : Bignum*
+    q : Bignum*
+    g : Bignum*
+    pub_key : Bignum*
+    priv_key : Bignum*
+    kinv : Bignum*
+    r : Bignum*
+    flags : LibC::Int
+    method_mont_p : BnMontCtx*
+    references : LibC::Int
+    ex_data : CryptoExData
+    meth : DsaMethod*
+    engine : Engine
+  end
+
+  struct Bignum
+    d : LibC::ULong*
+    top : LibC::Int
+    dmax : LibC::Int
+    neg : LibC::Int
+    flags : LibC::Int
+  end
+
+  struct BnMontCtx
+    ri : LibC::Int
+    rr : Bignum
+    n : Bignum
+    ni : Bignum
+    n0 : LibC::ULong[2]
+    flags : LibC::Int
+  end
+
+  struct CryptoExData
+    sk : StackVoid*
+    dummy : LibC::Int
+  end
+
+  struct DsaMethod
+    name : LibC::Char*
+    dsa_do_sign : (UInt8*, LibC::Int, Dsa* -> DsaSig*)
+    dsa_sign_setup : (Dsa*, BnCtx, Bignum**, Bignum** -> LibC::Int)
+    dsa_do_verify : (UInt8*, LibC::Int, DsaSig*, Dsa* -> LibC::Int)
+    dsa_mod_exp : (Dsa*, Bignum*, Bignum*, Bignum*, Bignum*, Bignum*, Bignum*, BnCtx, BnMontCtx* -> LibC::Int)
+    bn_mod_exp : (Dsa*, Bignum*, Bignum*, Bignum*, Bignum*, BnCtx, BnMontCtx* -> LibC::Int)
+    init : (Dsa* -> LibC::Int)
+    finish : (Dsa* -> LibC::Int)
+    flags : LibC::Int
+    app_data : LibC::Char*
+    dsa_paramgen : (Dsa*, LibC::Int, UInt8*, LibC::Int, LibC::Int*, LibC::ULong*, BnGencb* -> LibC::Int)
+    dsa_keygen : (Dsa* -> LibC::Int)
+  end
+
+  struct StackVoid
+    stack : Stack
+  end
+
+  struct DsaSig
+    r : Bignum*
+    s : Bignum*
+  end
+
+  struct BnGencb
+    ver : LibC::UInt
+    arg : Void*
+    cb : BnGencbCb
+  end
+
+  struct Dh
+    pad : LibC::Int
+    version : LibC::Int
+    p : Bignum*
+    g : Bignum*
+    length : LibC::Long
+    pub_key : Bignum*
+    priv_key : Bignum*
+    flags : LibC::Int
+    method_mont_p : BnMontCtx*
+    q : Bignum*
+    j : Bignum*
+    seed : UInt8*
+    seedlen : LibC::Int
+    counter : Bignum*
+    references : LibC::Int
+    ex_data : CryptoExData
+    meth : DhMethod*
+    engine : Engine
+  end
+
+  struct DhMethod
+    name : LibC::Char*
+    generate_key : (Dh* -> LibC::Int)
+    compute_key : (UInt8*, Bignum*, Dh* -> LibC::Int)
+    bn_mod_exp : (Dh*, Bignum*, Bignum*, Bignum*, Bignum*, BnCtx, BnMontCtx* -> LibC::Int)
+    init : (Dh* -> LibC::Int)
+    finish : (Dh* -> LibC::Int)
+    flags : LibC::Int
+    app_data : LibC::Char*
+    generate_params : (Dh*, LibC::Int, LibC::Int, BnGencb* -> LibC::Int)
+  end
+
+  struct Rsa
+    pad : LibC::Int
+    version : LibC::Long
+    meth : RsaMethod*
+    engine : Engine
+    n : Bignum*
+    e : Bignum*
+    d : Bignum*
+    p : Bignum*
+    q : Bignum*
+    dmp1 : Bignum*
+    dmq1 : Bignum*
+    iqmp : Bignum*
+    ex_data : CryptoExData
+    references : LibC::Int
+    flags : LibC::Int
+    _method_mod_n : BnMontCtx*
+    _method_mod_p : BnMontCtx*
+    _method_mod_q : BnMontCtx*
+    bignum_data : LibC::Char*
+    blinding : BnBlinding
+    mt_blinding : BnBlinding
+  end
+
+  struct RsaMethod
+    name : LibC::Char*
+    rsa_pub_enc : (LibC::Int, UInt8*, UInt8*, Rsa*, LibC::Int -> LibC::Int)
+    rsa_pub_dec : (LibC::Int, UInt8*, UInt8*, Rsa*, LibC::Int -> LibC::Int)
+    rsa_priv_enc : (LibC::Int, UInt8*, UInt8*, Rsa*, LibC::Int -> LibC::Int)
+    rsa_priv_dec : (LibC::Int, UInt8*, UInt8*, Rsa*, LibC::Int -> LibC::Int)
+    rsa_mod_exp : (Bignum*, Bignum*, Rsa*, BnCtx -> LibC::Int)
+    bn_mod_exp : (Bignum*, Bignum*, Bignum*, Bignum*, BnCtx, BnMontCtx* -> LibC::Int)
+    init : (Rsa* -> LibC::Int)
+    finish : (Rsa* -> LibC::Int)
+    flags : LibC::Int
+    app_data : LibC::Char*
+    rsa_sign : (LibC::Int, UInt8*, LibC::UInt, UInt8*, LibC::UInt*, Rsa* -> LibC::Int)
+    rsa_verify : (LibC::Int, UInt8*, LibC::UInt, UInt8*, LibC::UInt, Rsa* -> LibC::Int)
+    rsa_keygen : (Rsa*, LibC::Int, Bignum*, BnGencb* -> LibC::Int)
+  end
+
+  union EVP_PKEY_KEY
+    ptr : LibC::Char*
+    rsa : Rsa*
+    dsa : Dsa*
+    dh : Dh*
+    ec : Void*
+  end
+
+  union BnGencbCb
+    cb_1 : (LibC::Int, LibC::Int, Void* -> Void)
+    cb_2 : (LibC::Int, LibC::Int, BnGencb* -> LibC::Int)
+  end
+
+  enum Padding
+    PKCS1_PADDING      = 1
+    SSLV23_PADDING     = 2
+    NO_PADDING         = 3
+    PKCS1_OAEP_PADDING = 4
+    X931_PADDING       = 5
+    PKCS1_PSS_PADDING  = 6
+  end
+
+  type EVP_PKEY_ASN1_method = Void*
+  type Engine = Void*
+  type BnCtx = Void*
+  type BnBlinding = Void*
+
+  fun bignum_new = BN_new : Bignum*
+  fun set_bignum_from_decimal = BN_dec2bn(a : Bignum**, str : LibC::Char*) : LibC::Int
+
+  fun evp_pkey_new = EVP_PKEY_new : EvpPKey*
+  fun evp_pkey_free = EVP_PKEY_free(pkey : EvpPKey*)
+  fun evp_pkey_size = EVP_PKEY_size(pkey : EvpPKey*) : LibC::Int
+  fun evp_pkey_get1_rsa = EVP_PKEY_get1_RSA(pkey : EvpPKey*) : Rsa*
+  fun evp_pkey_set1_rsa = EVP_PKEY_set1_RSA(pkey : EvpPKey*, key : Rsa*) : LibC::Int
+
+  fun rsa_new = RSA_new : Rsa*
+  fun rsa_public_key_dup = RSAPublicKey_dup(rsa : Rsa*) : Rsa*
+  fun rsa_blinding_on = RSA_blinding_on(rsa : Rsa*, ctx : BnCtx) : LibC::Int
+  fun rsa_blinding_off = RSA_blinding_off(rsa : Rsa*)
+  fun rsa_generate_key_ex = RSA_generate_key_ex(rsa : Rsa*, bits : LibC::Int, e : Bignum*, cb : BnGencb*) : LibC::Int
+  fun rsa_private_encrypt = RSA_private_encrypt(flen : LibC::Int, from : UInt8*, to : UInt8*, rsa : Rsa*, padding : LibC::Int) : LibC::Int
+  fun rsa_public_encrypt = RSA_public_encrypt(flen : LibC::Int, from : UInt8*, to : UInt8*, rsa : Rsa*, padding : LibC::Int) : LibC::Int
+  fun rsa_private_decrypt = RSA_private_decrypt(flen : LibC::Int, from : UInt8*, to : UInt8*, rsa : Rsa*, padding : LibC::Int) : LibC::Int
+  fun rsa_public_decrypt = RSA_public_decrypt(flen : LibC::Int, from : UInt8*, to : UInt8*, rsa : Rsa*, padding : LibC::Int) : LibC::Int
+
+  fun pem_read_bio_private_key = PEM_read_bio_PrivateKey(bp : Bio*, x : EvpPKey**, cb : (LibC::Char*, LibC::Int, LibC::Int, Void* -> LibC::Int), u : Void*) : EvpPKey*
+  fun pem_write_bio_rsa_private_key = PEM_write_bio_RSAPrivateKey(bp : Bio*, x : Rsa*, enc : EVP_MD*, kstr : UInt8*, klen : LibC::Int, cb : (LibC::Char*, LibC::Int, LibC::Int, Void* -> LibC::Int), u : Void*) : LibC::Int
+  fun pem_write_bio_rsa_public_key = PEM_write_bio_RSAPublicKey(bp : Bio*, x : Rsa*) : LibC::Int
+  fun pem_write_bio_pkcs8_private_key = PEM_write_bio_PKCS8PrivateKey(bp : Bio*, x : EvpPKey*, enc : EVP_CIPHER*, kstr : LibC::Char*, klen : LibC::Int, cb : (LibC::Char*, LibC::Int, LibC::Int, Void* -> LibC::Int), u : Void*) : LibC::Int
+  fun pem_write_bio_public_key = PEM_write_bio_PUBKEY(bp : Bio*, x : EvpPKey*) : LibC::Int
+
+  fun d2i_private_key_bio = d2i_PrivateKey_bio(bp : Bio*, a : EvpPKey**) : EvpPKey*
+  fun i2d_private_key = i2d_PrivateKey(a : EvpPKey*, pp : UInt8**) : LibC::Int
+  fun i2d_public_key = i2d_PublicKey(a : EvpPKey*, pp : UInt8**) : LibC::Int
 end

--- a/src/openssl/pkey.cr
+++ b/src/openssl/pkey.cr
@@ -1,0 +1,134 @@
+require "./cipher"
+
+module OpenSSL
+  abstract class PKey
+    class PKeyError < OpenSSL::Error; end
+
+    def initialize(@pkey : LibCrypto::EvpPKey*, @is_private : Bool)
+      raise PKeyError.new "Invalid EVP_PKEY" unless @pkey
+    end
+
+    def initialize(is_private)
+      initialize(LibCrypto.evp_pkey_new, is_private)
+    end
+
+    def self.new(encoded : String, passphrase = nil, is_private = true)
+      self.new(IO::Memory.new(encoded), passphrase, is_private)
+    end
+
+    def self.new(io : IO, passphrase = nil, is_private = true)
+      begin
+        bio = OpenSSL::BIO.new(io)
+        new(LibCrypto.pem_read_bio_private_key(bio, nil, nil, passphrase), is_private)
+      rescue
+        bio = OpenSSL::BIO.new(IO::Memory.new(Base64.decode(io.to_s)))
+        new(LibCrypto.d2i_private_key_bio(bio, nil), is_private)
+      end
+    end
+
+    def self.new(size : Int32)
+      exponent = 65537.to_u32
+      self.generate(size, exponent)
+    end
+
+    def to_unsafe
+      @pkey
+    end
+
+    def finalize
+      LibCrypto.evp_pkey_free(self)
+    end
+
+    def private?
+      @is_private
+    end
+
+    def public?
+      !private?
+    end
+
+    def to_pem(io : IO, cipher : (OpenSSL::Cipher | Nil) = nil, passphrase = nil)
+      bio = BIO.new(io)
+
+      if private?
+        cipher_pointer = nil
+
+        if !cipher.nil?
+          unsafe = cipher.to_unsafe
+          cipher_pointer = pointerof(unsafe)
+        end
+
+        raise PKeyError.new "Could not write to PEM" unless LibCrypto.pem_write_bio_pkcs8_private_key(bio, self, cipher_pointer, nil, 0, passphrase_callback, Box.box(passphrase)) == 1
+      else
+        raise PKeyError.new "Could not write to PEM" unless LibCrypto.pem_write_bio_public_key(bio, self) == 1
+      end
+    end
+
+    def to_pem(cipher : OpenSSL::Cipher, passphrase)
+      io = IO::Memory.new
+      to_pem(io, cipher, passphrase)
+      io.to_s
+    end
+
+    def to_pem
+      io = IO::Memory.new
+      to_pem(io)
+      io.to_s
+    end
+
+    def to_der
+      io = IO::Memory.new
+      to_der(io)
+      Base64.encode(io.to_s)
+    end
+
+    def to_der(io)
+      fn = ->(buf : UInt8** | Nil) {
+        if private?
+          LibCrypto.i2d_private_key(self, buf)
+        else
+          LibCrypto.i2d_public_key(self, buf)
+        end
+      }
+
+      len = fn.call(nil)
+      if len <= 0
+        raise PKeyError.new "Could not output in DER format"
+      end
+      slice = Slice(UInt8).new(len)
+      p = slice.to_unsafe
+      len = fn.call(pointerof(p))
+
+      output = slice[0, len]
+      io.write(output)
+    end
+
+    private def passphrase_callback
+      ->(buffer : UInt8*, key_size : Int32, is_read_write : Int32, u : Void*) {
+        pwd = Box(String).unbox(u)
+
+        if pwd.nil?
+          return 0
+        end
+
+        len = pwd.bytesize
+
+        if len <= 0
+          return 0
+        end
+
+        if len > key_size
+          len = key_size
+        end
+
+        buffer.copy_from(pwd.to_slice.pointer(len), len)
+
+        return len
+      }
+    end
+
+    private def max_encrypt_size
+      LibCrypto.evp_pkey_size(self)
+    end
+  end
+end

--- a/src/openssl/rsa.cr
+++ b/src/openssl/rsa.cr
@@ -1,0 +1,97 @@
+require "big"
+require "./pkey"
+
+module OpenSSL
+  class RSA < PKey
+    class RsaError < PKeyError; end
+
+    @blinding_on : Bool = false
+
+    def self.generate(size : Int32, exponent : UInt32)
+      rsa_pointer = LibCrypto.rsa_new
+
+      exponent_bn = LibCrypto.bignum_new
+      LibCrypto.set_bignum_from_decimal(pointerof(exponent_bn), exponent.to_s)
+      LibCrypto.rsa_generate_key_ex(rsa_pointer, size, exponent_bn, nil)
+
+      new(true).tap do |pkey|
+        LibCrypto.evp_pkey_set1_rsa(pkey, rsa_pointer)
+      end
+    end
+
+    private def rsa
+      LibCrypto.evp_pkey_get1_rsa(self)
+    end
+
+    def public_key
+      pub_rsa = LibCrypto.rsa_public_key_dup(rsa)
+      raise RsaError.new "Could not get public key from RSA" unless pub_rsa
+
+      RSA.new(false).tap do |pkey|
+        LibCrypto.evp_pkey_set1_rsa(pkey, pub_rsa)
+      end
+    end
+
+    def public_encrypt(data, padding = LibCrypto::Padding::PKCS1_PADDING)
+      from = data.to_slice
+      if max_encrypt_size < from.size
+        raise RsaError.new "value is too big to be encrypted"
+      end
+      to = Slice(UInt8).new max_encrypt_size
+      len = LibCrypto.rsa_public_encrypt(from.size, from, to, rsa, padding)
+      if len < 0
+        raise RsaError.new "unable to encrypt"
+      end
+      to[0, len]
+    end
+
+    def public_decrypt(data, padding = LibCrypto::Padding::PKCS1_PADDING)
+      from = data.to_slice
+      to = Slice(UInt8).new max_encrypt_size
+      len = LibCrypto.rsa_public_decrypt(from.size, from, to, rsa, padding)
+      if len < 0
+        raise RsaError.new "unable to decrypt"
+      end
+      to[0, len]
+    end
+
+    def private_encrypt(data, padding = LibCrypto::Padding::PKCS1_PADDING)
+      unless private?
+        raise RsaError.new "private key needed"
+      end
+      from = data.to_slice
+      to = Slice(UInt8).new max_encrypt_size
+      len = LibCrypto.rsa_private_encrypt(from.size, from, to, rsa, padding)
+      if len < 0
+        raise RsaError.new "unable to encrypt"
+      end
+      to[0, len]
+    end
+
+    def private_decrypt(data, padding = LibCrypto::Padding::PKCS1_PADDING)
+      unless private?
+        raise RsaError.new "private key needed"
+      end
+      from = data.to_slice
+      to = Slice(UInt8).new max_encrypt_size
+      len = LibCrypto.rsa_private_decrypt(from.size, from, to, rsa, padding)
+      if len < 0
+        raise RsaError.new "unable to decrypt"
+      end
+      to[0, len]
+    end
+
+    def blinding_on?
+      @blinding_on
+    end
+
+    def blinding_on!
+      @blinding_on = (LibCrypto.rsa_blinding_on(rsa, nil) == 1)
+    end
+
+    def blinding_off!
+      LibCrypto.rsa_blinding_off(rsa)
+      @blinding_on = false
+    end
+  end
+end


### PR DESCRIPTION
Adds RSA bindings to OpenSSL as mentioned in #3941 

One slight nuance - it can't export to PEM format using a passphrase as OpenSSL fails without any error when performing this. Otherwise works similarly to the [Ruby API](https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html) but without aliases.