### PR TITLE
Fix `spawn` macro for call with receiver

### DIFF
--- a/spec/std/concurrent_spec.cr
+++ b/spec/std/concurrent_spec.cr
@@ -41,4 +41,8 @@ describe "concurrent" do
     spawn method_named("foo"), name: "foo"
     Fiber.yield
   end
+
+  it "accepts method call with receiver" do
+    typeof(spawn String.new)
+  end
 end

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -105,7 +105,7 @@ macro spawn(call, *, name = nil)
       {% end %}
       ) {
       spawn(name: {{name}}) do
-        {{call.name}}(
+        {% if call.receiver %}{{ call.receiver }}.{% end %}{{call.name}}(
           {% for arg, i in call.args %}
             __arg{{i}},
           {% end %}


### PR DESCRIPTION
`spawn String.new` expands to (simplified) `spawn { new }` because the `spawn` macro only writes `{{ call.name }}` and not the receiver.
This PR fixes this by prepending `{% if call.receiver %}{{ call.receiver }}.{% end %}`.