### PR TITLE
Move Time::Location spec additions to spec_helper

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -1,23 +1,6 @@
-require "spec"
 require "./spec_helper"
 
 class Time::Location
-  def __cached_range
-    @cached_range
-  end
-
-  def __cached_zone
-    @cached_zone
-  end
-
-  def __cached_zone=(zone)
-    @cached_zone = zone
-  end
-
-  def self.__clear_location_cache
-    @@location_cache.clear
-  end
-
   describe Time::Location do
     describe ".load" do
       it "loads Europe/Berlin" do

--- a/spec/std/time/spec_helper.cr
+++ b/spec/std/time/spec_helper.cr
@@ -1,3 +1,23 @@
+require "spec"
+
+class Time::Location
+  def __cached_range
+    @cached_range
+  end
+
+  def __cached_zone
+    @cached_zone
+  end
+
+  def __cached_zone=(zone)
+    @cached_zone = zone
+  end
+
+  def self.__clear_location_cache
+    @@location_cache.clear
+  end
+end
+
 def with_env(name, value)
   previous = ENV[name]?
   begin

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -1,4 +1,3 @@
-require "spec"
 require "./spec_helper"
 
 def Time.expect_invalid


### PR DESCRIPTION
The added test methods are used by a method in `spec_helper` and would not be available if only `time_spec.cr` is run.