### PR TITLE
 Fix boundary check in Time#add_span and move it to constructor

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -197,6 +197,10 @@ struct Time
   {% end %}
 
   def initialize(*, @seconds : Int64, @nanoseconds : Int32, @location : Location)
+    unless 0 <= offset_seconds <= MAX_SECONDS
+      raise ArgumentError.new "Invalid time: seconds out of range"
+    end
+
     unless 0 <= @nanoseconds < NANOSECONDS_PER_SECOND
       raise ArgumentError.new "Invalid time: nanoseconds out of range"
     end
@@ -295,10 +299,6 @@ struct Time
     if nanoseconds < 0
       seconds -= 1
       nanoseconds += NANOSECONDS_PER_SECOND
-    end
-
-    unless 0 <= seconds <= MAX_SECONDS
-      raise ArgumentError.new "Invalid time"
     end
 
     Time.new(seconds: seconds, nanoseconds: nanoseconds.to_i, location: location)


### PR DESCRIPTION
Previously, `Time#add_span` did not handle times at the min or max range with positive or
negative offsets correctly because `@seconds` can legitimately be `< 0` or `> MAX_SECONDS`
when the offset is taken into account.

The boundary check was moved to the constructor to prevent manually
creating an invalid date.