### PR TITLE
Fixed File.extname edge case for '.' in path with no extension

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -290,6 +290,7 @@ describe "File" do
     File.extname("/foo/bar/.profile").should eq("")
     File.extname("/foo/bar/.profile.sh").should eq(".sh")
     File.extname("/foo/bar/foo.").should eq("")
+    File.extname("/foo.bar/baz").should eq("")
     File.extname("test").should eq("")
   end
 

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -291,6 +291,11 @@ describe "File" do
     File.extname("/foo/bar/.profile.sh").should eq(".sh")
     File.extname("/foo/bar/foo.").should eq("")
     File.extname("/foo.bar/baz").should eq("")
+    File.extname("test.cr").should eq(".cr")
+    File.extname("test.cr.cz").should eq(".cz")
+    File.extname(".test").should eq("")
+    File.extname(".test.cr").should eq(".cr")
+    File.extname(".test.cr.cz").should eq(".cz")
     File.extname("test").should eq("")
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -299,9 +299,10 @@ class File < IO::FileDescriptor
     dot_index = filename.rindex('.')
 
     if dot_index && dot_index != filename.size - 1 && dot_index - 1 > (filename.rindex(SEPARATOR) || 0)
-      return filename[dot_index, filename.size - dot_index]
+      filename[dot_index, filename.size - dot_index]
+    else
+      ""
     end
-    ""
   end
 
   # Converts *path* to an absolute path. Relative paths are

--- a/src/file.cr
+++ b/src/file.cr
@@ -297,7 +297,7 @@ class File < IO::FileDescriptor
     filename.check_no_null_byte
 
     dot_index = filename.rindex('.')
-    separator_index = filename.rindex(SEPARATOR)
+    separator_index = filename.rindex(SEPARATOR) || 0
 
     if dot_index && dot_index > separator_index && dot_index != filename.size - 1 && filename[dot_index - 1] != SEPARATOR
       filename[dot_index, filename.size - dot_index]

--- a/src/file.cr
+++ b/src/file.cr
@@ -297,8 +297,9 @@ class File < IO::FileDescriptor
     filename.check_no_null_byte
 
     dot_index = filename.rindex('.')
+    separator_index = filename.rindex(SEPARATOR)
 
-    if dot_index && dot_index != filename.size - 1 && filename[dot_index - 1] != SEPARATOR
+    if dot_index && dot_index > separator_index && dot_index != filename.size - 1 && filename[dot_index - 1] != SEPARATOR
       filename[dot_index, filename.size - dot_index]
     else
       ""

--- a/src/file.cr
+++ b/src/file.cr
@@ -297,13 +297,11 @@ class File < IO::FileDescriptor
     filename.check_no_null_byte
 
     dot_index = filename.rindex('.')
-    separator_index = filename.rindex(SEPARATOR) || 0
 
-    if dot_index && dot_index > separator_index && dot_index != filename.size - 1 && filename[dot_index - 1] != SEPARATOR
-      filename[dot_index, filename.size - dot_index]
-    else
-      ""
+    if dot_index && dot_index != filename.size - 1 && dot_index - 1 > (filename.rindex(SEPARATOR) || 0)
+      return filename[dot_index, filename.size - dot_index]
     end
+    ""
   end
 
   # Converts *path* to an absolute path. Relative paths are


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/5780