### PR TITLE
Improve readline.cr

### DIFF
--- a/src/readline.cr
+++ b/src/readline.cr
@@ -65,22 +65,22 @@ module Readline
   end
 
   def bind_key(c : Char, &f : KeyBindingProc)
-    raise ArgumentError.new "Not a valid ASCII character: '#{c.inspect}'" unless 0 <= c.ord <= 255
+    raise ArgumentError.new "Not a valid ASCII character: #{c.inspect}" unless c.ascii?
 
     handlers = (@@key_bind_handlers ||= {} of LibReadline::Int => KeyBindingProc)
     handlers[c.ord] = f
 
     res = LibReadline.rl_bind_key(c.ord, KeyBindingHandler).to_i32
-    raise ArgumentError.new "Invalid key: '#{c.inspect}'" unless res == 0
+    raise ArgumentError.new "Invalid key: #{c.inspect}" unless res == 0
   end
 
   def unbind_key(c : Char)
     if (handlers = @@key_bind_handlers) && handlers[c.ord]?
       handlers.delete(c.ord)
       res = LibReadline.rl_unbind_key(c.ord).to_i32
-      raise Exception.new "Error unbinding key: '#{c.inspect}'" unless res == 0
+      raise Exception.new "Error unbinding key: #{c.inspect}" unless res == 0
     else
-      raise KeyError.new "Key not bound: '#{c.inspect}'"
+      raise KeyError.new "Key not bound: #{c.inspect}"
     end
   end
 


### PR DESCRIPTION
In line **68** I changed `unless 0 <= c.ord <= 255` to `unless c.ascii?` because thats probably the better way to check if `c` is ASCII.

And at the `raise` lines I changed `'#{c.inspect}'` to `#{c.inspect}`.
Because right now these errors look like this:
```Crystal
Not a valid ASCII character: ''ä'' (ArgumentError)
  from myfile.cr:0:1 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:11:3 in '_crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:112:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:101:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:135:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```
thats because [Char#inspect](https://crystal-lang.org/api/0.24.1/Char.html#inspect-instance-method) already surrounds the Char with `'`.