### PR TITLE
Improve #inspect format for Time types

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -193,8 +193,19 @@ class Time::Location
     end
 
     describe ".fixed" do
-      it "accepts a name" do
-        location = Location.fixed("Fixed", 1800)
+      it "without name" do
+        location = Location.fixed -9012
+        location.name.should eq "-02:30:12"
+        location.zones.should eq [Zone.new(nil, -9012, false)]
+        location.transitions.size.should eq 0
+
+        location.utc?.should be_false
+        location.fixed?.should be_true
+        location.local?.should be_false
+      end
+
+      it "with name" do
+        location = Location.fixed "Fixed", 1800
         location.name.should eq "Fixed"
         location.zones.should eq [Zone.new("Fixed", 1800, false)]
         location.transitions.size.should eq 0
@@ -206,13 +217,13 @@ class Time::Location
 
       it "positive" do
         location = Location.fixed 8000
-        location.name.should eq "+02:13"
+        location.name.should eq "+02:13:20"
         location.zones.first.offset.should eq 8000
       end
 
-      it "ngeative" do
+      it "negative" do
         location = Location.fixed -7539
-        location.name.should eq "-02:05"
+        location.name.should eq "-02:05:39"
         location.zones.first.offset.should eq -7539
       end
 
@@ -322,6 +333,20 @@ class Time::Location
           location.lookup(Time.utc(2017, 11, 23, 22, 6, 12)).should eq cached_zone
         end
       end
+    end
+  end
+
+  describe Time::Location::Zone do
+    it "#inspect" do
+      Time::Location::Zone.new("CET", 3600, false).inspect.should eq "#<Time::Location::Zone CET +01:00 (3600s) STD>"
+      Time::Location::Zone.new("CEST", 7200, true).inspect.should eq "#<Time::Location::Zone CEST +02:00 (7200s) DST>"
+      Time::Location::Zone.new(nil, 9000, true).inspect.should eq "#<Time::Location::Zone +02:30 (9000s) DST>"
+      Time::Location::Zone.new(nil, 9012, true).inspect.should eq "#<Time::Location::Zone +02:30:12 (9012s) DST>"
+    end
+
+    it "#name" do
+      Time::Location::Zone.new("CEST", 7200, true).name.should eq "CEST"
+      Time::Location::Zone.new(nil, 9000, true).name.should eq "+02:30"
     end
   end
 end

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -338,10 +338,10 @@ class Time::Location
 
   describe Time::Location::Zone do
     it "#inspect" do
-      Time::Location::Zone.new("CET", 3600, false).inspect.should eq "#<Time::Location::Zone CET +01:00 (3600s) STD>"
-      Time::Location::Zone.new("CEST", 7200, true).inspect.should eq "#<Time::Location::Zone CEST +02:00 (7200s) DST>"
-      Time::Location::Zone.new(nil, 9000, true).inspect.should eq "#<Time::Location::Zone +02:30 (9000s) DST>"
-      Time::Location::Zone.new(nil, 9012, true).inspect.should eq "#<Time::Location::Zone +02:30:12 (9012s) DST>"
+      Time::Location::Zone.new("CET", 3600, false).inspect.should eq "Time::Location::Zone(CET +01:00 (3600s) STD)"
+      Time::Location::Zone.new("CEST", 7200, true).inspect.should eq "Time::Location::Zone(CEST +02:00 (7200s) DST)"
+      Time::Location::Zone.new(nil, 9000, true).inspect.should eq "Time::Location::Zone(+02:30 (9000s) DST)"
+      Time::Location::Zone.new(nil, 9012, true).inspect.should eq "Time::Location::Zone(+02:30:12 (9012s) DST)"
     end
 
     it "#name" do

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -336,56 +336,65 @@ describe Time do
     (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
   end
 
-  describe "to_s" do
-    it "prints local time" do
-      with_env("TZ", nil) do
-        t = Time.new 2014, 10, 30, 21, 18, 13
-        t.to_s.should eq("2014-10-30 21:18:13 #{t.to_s("%:z")}")
-
-        t = Time.new 2014, 1, 30, 21, 18, 13
-        t.to_s.should eq("2014-01-30 21:18:13 #{t.to_s("%:z")}")
-
-        t = Time.new 2014, 10, 1, 21, 18, 13
-        t.to_s.should eq("2014-10-01 21:18:13 #{t.to_s("%:z")}")
-
-        t = Time.new 2014, 10, 30, 1, 18, 13
-        t.to_s.should eq("2014-10-30 01:18:13 #{t.to_s("%:z")}")
-
-        t = Time.new 2014, 10, 30, 21, 1, 13
-        t.to_s.should eq("2014-10-30 21:01:13 #{t.to_s("%:z")}")
-
-        t = Time.new 2014, 10, 30, 21, 18, 1
-        t.to_s.should eq("2014-10-30 21:18:01 #{t.to_s("%:z")}")
-      end
+  describe "#to_s" do
+    it "prints date-time fields" do
+      Time.utc(2014, 1, 30, 21, 18, 13).to_s.should eq("2014-01-30 21:18:13 UTC")
+      Time.utc(2014, 10, 1, 21, 18, 13).to_s.should eq("2014-10-01 21:18:13 UTC")
+      Time.utc(2014, 10, 30, 1, 18, 13).to_s.should eq("2014-10-30 01:18:13 UTC")
+      Time.utc(2014, 10, 30, 21, 1, 13).to_s.should eq("2014-10-30 21:01:13 UTC")
+      Time.utc(2014, 10, 30, 21, 18, 1).to_s.should eq("2014-10-30 21:18:01 UTC")
     end
 
-    it "prints without nanoseconds" do
-      with_env("TZ", nil) do
-        t = Time.new 2014, 10, 30, 21, 18, 13, nanosecond: 12345
-        t.to_s.should eq("2014-10-30 21:18:13 #{t.to_s("%:z")}")
-      end
+    it "omits nanoseconds" do
+      Time.utc(2014, 10, 30, 21, 18, 13).to_s.should eq("2014-10-30 21:18:13 UTC")
+      Time.utc(2014, 10, 30, 21, 18, 13, nanosecond: 12345).to_s.should eq("2014-10-30 21:18:13 UTC")
     end
 
-    it "prints UTC" do
-      t = Time.utc 2014, 10, 30, 21, 18, 13
-      t.to_s.should eq("2014-10-30 21:18:13 UTC")
-    end
-
-    it "prints zone" do
+    it "prints offset for location" do
       with_zoneinfo do
         location = Time::Location.load("Europe/Berlin")
-        t = Time.new 2014, 10, 30, 21, 18, 13, location: location
-        t.to_s.should eq("2014-10-30 21:18:13 +01:00 Europe/Berlin")
+        Time.new(2014, 10, 30, 21, 18, 13, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
+        Time.new(2014, 10, 30, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-30 21:18:13 +01:00")
 
-        t = Time.new 2014, 10, 10, 21, 18, 13, location: location
-        t.to_s.should eq("2014-10-10 21:18:13 +02:00 Europe/Berlin")
+        Time.new(2014, 10, 10, 21, 18, 13, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
+        Time.new(2014, 10, 10, 21, 18, 13, nanosecond: 123_456, location: location).to_s.should eq("2014-10-10 21:18:13 +02:00")
       end
     end
 
-    it "prints offset" do
+    it "prints offset for fixed location" do
+      location = Time::Location.fixed(3601)
+      Time.new(2014, 1, 2, 3, 4, 5, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
+      Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).to_s.should eq "2014-01-02 03:04:05 +01:00:01"
+
       t = Time.new 2014, 10, 30, 21, 18, 13, location: Time::Location.fixed(-9000)
       t.to_s.should eq("2014-10-30 21:18:13 -02:30")
     end
+
+    it "prints local time" do
+      # Simulates loading non-fixed offset local time from /etc/localtime
+      old_local = Time::Location.local
+      begin
+        location = Time::Location.new "Local", [Time::Location::Zone.new("STZ", 3600, false), Time::Location::Zone.new("DTZ", -3600, false)], [] of Time::Location::ZoneTransition
+        Time::Location.local = location
+
+        Time.new(2014, 10, 30, 21, 18, 13).to_s.should eq("2014-10-30 21:18:13 +01:00")
+      ensure
+        Time::Location.local = old_local
+      end
+    end
+  end
+
+  it "#inspect" do
+    Time.utc(2014, 1, 2, 3, 4, 5).inspect.should eq "2014-01-02 03:04:05.0 UTC"
+    Time.utc(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789).inspect.should eq "2014-01-02 03:04:05.123456789 UTC"
+
+    location = Time::Location.load("Europe/Berlin")
+    Time.new(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00 Europe/Berlin"
+    Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00 Europe/Berlin"
+
+    location = Time::Location.fixed(3601)
+    Time.new(2014, 1, 2, 3, 4, 5, location: location).inspect.should eq "2014-01-02 03:04:05.0 +01:00:01"
+    Time.new(2014, 1, 2, 3, 4, 5, nanosecond: 123_456_789, location: location).inspect.should eq "2014-01-02 03:04:05.123456789 +01:00:01"
   end
 
   it "formats" do
@@ -935,7 +944,7 @@ describe Time do
 
       location = Time::Location.load("Europe/Berlin")
       time = Time.new(2017, 11, 25, 22, 6, 17, location: location)
-      time.to_s.should eq "2017-11-25 22:06:17 +01:00 Europe/Berlin"
+      time.to_s.should eq "2017-11-25 22:06:17 +01:00"
     end
   end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -471,19 +471,49 @@ struct Time
     (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
   end
 
-  def inspect(io : IO)
-    case
-    when utc?
-      to_s "%F %T UTC", io
-    else
-      if offset % 60 == 0
-        to_s "%F %T %:z", io
+  # Prints this `Time` to *io*.
+  #
+  # The local date-time is formatted as date string `YYYY-MM-DD HH:mm:ss.nnnnnnnnn +ZZ:ZZ:ZZ`.
+  # Nanoseconds are omitted if *with_nanoseconds* is `false`.
+  # When the location is `UTC`, the offset is omitted. Offset seconds are omitted if `0`.
+  #
+  # The name of the location is appended unless it is a fixed zone offset.
+  def inspect(io : IO, with_nanoseconds = true)
+    to_s "%F %T", io
+
+    if with_nanoseconds
+      if @nanoseconds == 0
+        io << ".0"
       else
-        to_s "%F %T %::z", io
+        to_s ".%N", io
       end
-      io << ' ' << location.name unless location.fixed? || location.name == "Local"
     end
+
+    if utc?
+      io << " UTC"
+    else
+      io << ' '
+      zone.format(io)
+      io << ' ' << location.name unless location.fixed?
+    end
+
     io
+  end
+
+  # Prints this `Time` to *io*.
+  #
+  # The local date-time is formatted as date string `YYYY-MM-DD HH:mm:ss +ZZ:ZZ:ZZ`.
+  # Nanoseconds are always omitted.
+  # When the location is `UTC`, the offset is replaced with the string `UTC`.
+  # Offset seconds are omitted if `0`.
+  def to_s(io : IO)
+    to_s("%F %T ", io)
+
+    if utc?
+      io << "UTC"
+    else
+      zone.format(io)
+    end
   end
 
   # Formats this time using the given format (see `Time::Format`).

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -148,50 +148,15 @@ struct Time::Format
     end
 
     def time_zone(with_seconds = false)
-      negative, hours, minutes, seconds = local_time_zone_info
-      io << (negative ? '-' : '+')
-      io << '0' if hours < 10
-      io << hours
-      io << '0' if minutes < 10
-      io << minutes
-      if with_seconds
-        io << '0' if seconds < 10
-        io << seconds
-      end
+      time.zone.format(io, with_colon: false, with_seconds: with_seconds)
     end
 
     def time_zone_colon(with_seconds = false)
-      negative, hours, minutes, seconds = local_time_zone_info
-      io << (negative ? '-' : '+')
-      io << '0' if hours < 10
-      io << hours
-      io << ':'
-      io << '0' if minutes < 10
-      io << minutes
-      if with_seconds
-        io << ':'
-        io << '0' if seconds < 10
-        io << seconds
-      end
+      time.zone.format(io, with_colon: true, with_seconds: with_seconds)
     end
 
     def time_zone_colon_with_seconds
       time_zone_colon(with_seconds: true)
-    end
-
-    def local_time_zone_info
-      offset = time.offset
-      if offset < 0
-        offset = -offset
-        negative = true
-      else
-        negative = false
-      end
-      seconds = offset % 60
-      minutes = offset / 60
-      hours = minutes / 60
-      minutes = minutes % 60
-      {negative, hours, minutes, seconds}
     end
 
     def char(char)

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -61,10 +61,14 @@ class Time::Location
     end
 
     def inspect(io : IO)
-      io << "Time::Zone<"
+      io << "#<Time::Location::Zone "
       io << offset
-      io << ", " << name
-      io << " (DST)" if dst?
+      io << name << ' '
+      if dst?
+        io << " DST"
+      else
+        io << "STD"
+      end
       io << '>'
     end
   end
@@ -74,11 +78,15 @@ class Time::Location
     getter? standard, utc
 
     def inspect(io : IO)
-      io << "Time::ZoneTransition<"
-      io << '#' << index << ", "
+      io << "#<Time::Location::ZoneTransition "
+      io << '#' << index << ' '
       Time.epoch(self.when).to_s("%F %T", io)
-      io << ", STD" if standard?
-      io << ", UTC" if utc?
+      if standard?
+        io << " STD"
+      else
+        io << " DST"
+      end
+      io << " UTC" if utc?
       io << '>'
     end
   end
@@ -204,7 +212,7 @@ class Time::Location
   end
 
   def inspect(io : IO)
-    io << "Time::Location<"
+    io << "#<Time::Location "
     to_s(io)
     io << '>'
   end

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -49,27 +49,80 @@ class Time::Location
   struct Zone
     UTC = new "UTC", 0, false
 
-    getter name : String
     getter offset : Int32
     getter? dst : Bool
 
-    def initialize(@name : String, @offset : Int32, @dst : Bool)
+    def initialize(@name : String?, @offset : Int32, @dst : Bool)
       # Maximium offets of IANA timezone database are -12:00 and +14:00.
       # +/-24 hours allows a generous padding for unexpected offsets.
       # TODO: Maybe reduce to Int16 (+/- 18 hours).
       raise InvalidTimezoneOffsetError.new(offset) if offset >= SECONDS_PER_DAY || offset <= -SECONDS_PER_DAY
     end
 
+    def name : String
+      @name || format
+    end
+
     def inspect(io : IO)
       io << "#<Time::Location::Zone "
-      io << offset
-      io << name << ' '
+      io << @name << ' ' unless @name.nil?
+      format(io)
+      io << " (" << offset << "s)"
       if dst?
         io << " DST"
       else
-        io << "STD"
+        io << " STD"
       end
       io << '>'
+    end
+
+    # Prints `#offset` to *io* in the format `+HH:mm:ss`.
+    # When *with_colon* is `false`, the format is `+HHmmss`.
+    #
+    # When *with_seconds* is `false`, seconds are omitted; when `:auto`, seconds
+    # are ommitted if `0`.
+    def format(io : IO, with_colon = true, with_seconds = :auto)
+      sign, hours, minutes, seconds = sign_hours_minutes_seconds
+
+      io << sign
+      io << '0' if hours < 10
+      io << hours
+      io << ':' if with_colon
+      io << '0' if minutes < 10
+      io << minutes
+
+      if with_seconds == true || (seconds != 0 && with_seconds == :auto)
+        io << ':' if with_colon
+        io << '0' if seconds < 10
+        io << seconds
+      end
+    end
+
+    # Returns the `#offset` formatted as `+HH:mm:ss`.
+    # When *with_colon* is `false`, the format is `+HHmmss`.
+    #
+    # When *with_seconds* is `false`, seconds are omitted; when `:auto`, seconds
+    # are ommitted if `0`.
+    def format(with_colon = true, with_seconds = :auto)
+      String.build do |io|
+        format(io, with_colon: with_colon, with_seconds: with_seconds)
+      end
+    end
+
+    # :nodoc:
+    def sign_hours_minutes_seconds
+      offset = @offset
+      if offset < 0
+        offset = -offset
+        sign = '-'
+      else
+        sign = '+'
+      end
+      seconds = offset % 60
+      minutes = offset / 60
+      hours = minutes / 60
+      minutes = minutes % 60
+      {sign, hours, minutes, seconds}
     end
   end
 
@@ -114,9 +167,8 @@ class Time::Location
 
   # Creates a `Location` instance with fixed *offset*.
   def self.fixed(offset : Int32)
-    span = offset.abs.seconds
-    name = sprintf("%s%02d:%02d", offset.sign < 0 ? '-' : '+', span.hours, span.minutes)
-    fixed name, offset
+    zone = Zone.new(nil, offset, false)
+    new zone.name, [zone]
   end
 
   # Returns the `Location` with the given name.

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -63,8 +63,12 @@ class Time::Location
       @name || format
     end
 
+    # Prints this `Zone` to *io*.
+    #
+    # It contains the `name`, hour-minute-second format (see `#format`),
+    # `offset` in seconds and `"DST"` if `#dst?`, otherwise `"STD"`.
     def inspect(io : IO)
-      io << "#<Time::Location::Zone "
+      io << "Time::Location::Zone("
       io << @name << ' ' unless @name.nil?
       format(io)
       io << " (" << offset << "s)"
@@ -73,7 +77,7 @@ class Time::Location
       else
         io << " STD"
       end
-      io << '>'
+      io << ')'
     end
 
     # Prints `#offset` to *io* in the format `+HH:mm:ss`.
@@ -131,7 +135,7 @@ class Time::Location
     getter? standard, utc
 
     def inspect(io : IO)
-      io << "#<Time::Location::ZoneTransition "
+      io << "Time::Location::ZoneTransition("
       io << '#' << index << ' '
       Time.epoch(self.when).to_s("%F %T", io)
       if standard?
@@ -140,7 +144,7 @@ class Time::Location
         io << " DST"
       end
       io << " UTC" if utc?
-      io << '>'
+      io << ')'
     end
   end
 


### PR DESCRIPTION
I'm doing some housekeeping to normalize and improve the inspect (and to_s) output of time and location related types.

`Time#inspect` now includes nanoseconds <del>unless it is `0`</del>. `#to_s` still omits them to avoid cluttering the output. When calling `#inspect` you typically expect a detailed output that allows to distinguish the difference between two instances. While nanoseconds are usually not relevant, it should still show up in case it is significant.

```crystal
Time.now.inspect # => 2018-03-09 12:52:36.506736000 +01:00 Europe/Berlin
Time.now.to_s    # => 2018-03-09 12:52:36 +01:00 Europe/Berlin
```

`Time::Zone` now includes a `#format` method which is used to print the offset as `+HH:mm:ss`. This format is added to the `#inspect` output and also used by `Time::Formatter#time_zone`.