### PR TITLE
Add highlight to code tag in generated API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -10,6 +10,7 @@ html, body {
 body {
   font-family: "Avenir", "Tahoma", "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
   color: #333;
+  line-height: 1.5;
 }
 
 a {
@@ -350,6 +351,13 @@ pre {
 
 code {
   font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+}
+
+:not(pre) > code {
+  background-color: rgba(40,35,30,0.05);
+  padding: 0.2em 0.4em;
+  font-size: 85%;
+  border-radius: 3px;
 }
 
 span.flag {


### PR DESCRIPTION
This adds a slightly darker background color to `code` tags in the API docs to make them easier stand out from regular text.

This feature is extracted from #4755 and further improved. It seems like it will be easier to merge this as a single feature. And this keeps bugging me, I want to be able to recognize code highlights at one glance.

**before:**
![image](https://user-images.githubusercontent.com/466378/37221302-c13fbd38-23c9-11e8-966c-602378638b54.png)

**after:**
![image](https://user-images.githubusercontent.com/466378/37221373-f78b9e16-23c9-11e8-8045-ec75fdf8ca38.png)


