### PR TITLE
Update previous crystal release & docker images for ci to 0.24.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
       TRAVIS_OS_NAME: linux
       ARCH: i386
       ARCH_CMD: linux32
-      ARCH_LIBRARY_PATH: /opt/crystal/embedded/lib/
     steps: *ci_steps
 
   test_darwin:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           echo "export CRYSTAL_SHA1=$CIRCLE_SHA1" >> build.env
 
           # Which previous version use
-          export PREVIOUS_CRYSTAL_BASE_URL="https://github.com/crystal-lang/crystal/releases/download/v0.24.1/crystal-0.24.1-2"
+          export PREVIOUS_CRYSTAL_BASE_URL="https://github.com/crystal-lang/crystal/releases/download/0.24.2/crystal-0.24.2-1"
           echo "export PREVIOUS_CRYSTAL_RELEASE_LINUX_TARGZ=${PREVIOUS_CRYSTAL_BASE_URL}-linux-x86_64.tar.gz" >> build.env
           echo "export PREVIOUS_CRYSTAL_RELEASE_DARWIN_TARGZ=${PREVIOUS_CRYSTAL_BASE_URL}-darwin-x86_64.tar.gz" >> build.env
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: ARCH=i386 ARCH_CMD=linux32 ARCH_LIBRARY_PATH=/opt/crystal/embedded/lib/
+    - env: ARCH=i386 ARCH_CMD=linux32
       os: linux
     - env: ARCH=x86_64 ARCH_CMD=linux64
       os: linux

--- a/bin/ci
+++ b/bin/ci
@@ -94,14 +94,25 @@ with_build_env() {
   export TZ="America/New_York"
 
   on_linux verify_linux_environment
+
+  export DOCKER_TEST_PREFIX="crystallang/crystal:0.24.2"
+
+  case $ARCH in
+    x86_64)
+      export DOCKER_TEST_IMAGE="$DOCKER_TEST_PREFIX-build"
+      ;;
+    i386)
+      export DOCKER_TEST_IMAGE="$DOCKER_TEST_PREFIX-i386-build"
+      ;;
+  esac
+
   on_linux docker run \
     --rm -t \
     -u $(id -u) \
     -v $PWD:/mnt \
     -w /mnt \
-    -e LIBRARY_PATH="${ARCH_LIBRARY_PATH:-/usr/lib/crystal/lib/}" \
     -e CRYSTAL_CACHE_DIR="/tmp/crystal" \
-    "jhass/crystal-build-$ARCH" \
+    "$DOCKER_TEST_IMAGE" \
     "$ARCH_CMD" /bin/sh -c "'$command'"
 
   on_osx sudo systemsetup -settimezone $TZ


### PR DESCRIPTION
Update previous compiler version for releases.
Switch from jhass' docker images to crystallang/crystal:*-build images for ci.
The *-build images already have the required LIBRARY_PATH env var set.