### PR TITLE
Restore STDIN|OUT|ERR blocking state on exit

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -174,6 +174,7 @@ def exit(status = 0) : NoReturn
   AtExitHandlers.run status
   STDOUT.flush
   STDERR.flush
+  Crystal.restore_blocking_state
   Process.exit(status)
 end
 


### PR DESCRIPTION
Extracted from #5413 to have it merged faster, as it could fix issues in #2713.