### PR TITLE
Semantic: Allow macro overload on named args

### DIFF
--- a/spec/compiler/semantic/macro_overload_spec.cr
+++ b/spec/compiler/semantic/macro_overload_spec.cr
@@ -1,0 +1,29 @@
+require "../../spec_helper"
+
+describe "Semantic: macro overload" do
+  it "something between 2 macros (I need a name!!!)" do
+    assert_type(%(
+      macro foo(*, arg1)
+        {{ arg1 }}
+      end
+
+      macro foo(*, arg2)
+        {{ arg2 }}
+      end
+
+      foo(arg1: 1)
+    )) { int32 }
+
+    assert_type(%(
+      macro foo(*, arg1)
+        {{ arg1 }}
+      end
+
+      macro foo(*, arg2)
+        {{ arg2 }}
+      end
+
+      foo(arg2: "test")
+    )) { string }
+  end
+end

--- a/spec/compiler/semantic/macro_overload_spec.cr
+++ b/spec/compiler/semantic/macro_overload_spec.cr
@@ -1,29 +1,29 @@
 require "../../spec_helper"
 
 describe "Semantic: macro overload" do
-  it "something between 2 macros (I need a name!!!)" do
+  it "doesn't overwrite last macro definition if named args differs" do
     assert_type(%(
       macro foo(*, arg1)
-        {{ arg1 }}
+        1
       end
 
       macro foo(*, arg2)
-        {{ arg2 }}
+        "foo"
       end
 
-      foo(arg1: 1)
+      foo(arg1: true)
     )) { int32 }
 
     assert_type(%(
       macro foo(*, arg1)
-        {{ arg1 }}
+        1
       end
 
       macro foo(*, arg2)
-        {{ arg2 }}
+        "foo"
       end
 
-      foo(arg2: "test")
+      foo(arg2: true)
     )) { string }
   end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -206,6 +206,9 @@ module Crystal
       self_named_args = self.required_named_arguments
       other_named_args = other.required_named_arguments
 
+      # If both don't have named arguments, override.
+      return true if !self_named_args && !other_named_args
+
       # If one has required named args and the other doesn't, no override.
       return false unless self_named_args && other_named_args
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -198,8 +198,8 @@ module Crystal
       # If they have different number of arguments, splat index or presence of
       # double splat, no override.
       if args.size != other.args.size ||
-         splat_index != other.splat_index ||
-         !!double_splat != other.double_splat
+          splat_index != other.splat_index ||
+          !!double_splat != !!other.double_splat
         return false
       end
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -66,6 +66,8 @@ module Crystal
 
   struct DefWithMetadata
     def restriction_of?(other : DefWithMetadata, owner)
+      # This is how multiple defs are sorted by 'restrictions' (?)
+
       # If one yields and the other doesn't, none is stricter than the other
       return false unless yields == other.yields
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -197,9 +197,9 @@ module Crystal
     def overrides?(other : Macro)
       # If they have different number of arguments, splat index or presence of
       # double splat, no override.
-      unless args.size == other.args.size &&
-             splat_index == other.splat_index &&
-             !!double_splat == !!other.double_splat
+      if args.size != other.args.size ||
+         splat_index != other.splat_index ||
+         !!double_splat != other.double_splat
         return false
       end
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -198,8 +198,8 @@ module Crystal
       # If they have different number of arguments, splat index or presence of
       # double splat, no override.
       if args.size != other.args.size ||
-          splat_index != other.splat_index ||
-          !!double_splat != !!other.double_splat
+         splat_index != other.splat_index ||
+         !!double_splat != !!other.double_splat
         return false
       end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -766,37 +766,37 @@ module Crystal
       nil
     end
 
-    def add_macro(a_def)
-      case a_def.name
+    def add_macro(a_macro)
+      case a_macro.name
       when "inherited"
-        return add_hook :inherited, a_def
+        return add_hook :inherited, a_macro
       when "included"
-        return add_hook :included, a_def
+        return add_hook :included, a_macro
       when "extended"
-        return add_hook :extended, a_def
+        return add_hook :extended, a_macro
       when "method_added"
-        return add_hook :method_added, a_def, args_size: 1
+        return add_hook :method_added, a_macro, args_size: 1
       when "method_missing"
-        if a_def.args.size != 1
+        if a_macro.args.size != 1
           raise TypeException.new "macro 'method_missing' expects 1 argument (call)"
         end
       end
 
       macros = (@macros ||= {} of String => Array(Macro))
-      array = (macros[a_def.name] ||= [] of Macro)
-      index = array.index { |existing_macro| a_def.overrides?(existing_macro) }
+      array = (macros[a_macro.name] ||= [] of Macro)
+      index = array.index { |existing_macro| a_macro.overrides?(existing_macro) }
       if index
         # a_macro has the same signature of an existing macro, we override it.
-        a_def.doc ||= array[index].doc
-        array[index] = a_def
+        a_macro.doc ||= array[index].doc
+        array[index] = a_macro
       else
         # a_macro has a new signature, add it with the others.
-        array.push a_def
+        array << a_macro
       end
     end
 
-    def add_hook(kind, a_def, args_size = 0)
-      if a_def.args.size != args_size
+    def add_hook(kind, a_macro, args_size = 0)
+      if a_macro.args.size != args_size
         case args_size
         when 0
           raise TypeException.new "macro '#{kind}' must not have arguments"
@@ -808,7 +808,7 @@ module Crystal
       end
 
       hooks = @hooks ||= [] of Hook
-      hooks << Hook.new(kind, a_def)
+      hooks << Hook.new(kind, a_macro)
     end
 
     def filter_by_responds_to(name)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -746,17 +746,21 @@ module Crystal
       list.each_with_index do |ex_item, i|
         if item.restriction_of?(ex_item, self)
           if ex_item.restriction_of?(item, self)
+            # The two defs have the same signature so item overrides ex_item.
             list[i] = item
             a_def.previous = ex_item
             a_def.doc ||= ex_item.def.doc
             ex_item.def.next = a_def
             return ex_item.def
           else
+            # item has a new signature, stricter than ex_item.
             list.insert(i, item)
             return nil
           end
         end
       end
+
+      # item has a new signature, less strict than the existing defs with same name.
       list << item
 
       nil
@@ -782,9 +786,11 @@ module Crystal
       array = (macros[a_def.name] ||= [] of Macro)
       index = array.index { |existing_macro| a_def.overrides?(existing_macro) }
       if index
+        # a_macro has the same signature of an existing macro, we override it.
         a_def.doc ||= array[index].doc
         array[index] = a_def
       else
+        # a_macro has a new signature, add it with the others.
         array.push a_def
       end
     end


### PR DESCRIPTION
I think this is my first PR in the compiler, deep into the semantic pass :tada: 

Fixes #5769 

I added a few comments here and there to help me understand what some parts does, I can remove them if needed. I also fixed a bad argument name (`a_def` => `a_macro`) in 2 macro-related methods.

I'll add more specs later if you think what I did is correct.
Thank you!