### PR TITLE
Change Time#date to return a Tuple of year, month, day instead of Time

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -106,12 +106,17 @@ describe Time do
   describe ".local" do
     it "initializes" do
       t1 = Time.local 2002, 2, 25
+      t1.date.should eq({2002, 2, 25})
       t1.year.should eq(2002)
       t1.month.should eq(2)
       t1.day.should eq(25)
+      t1.hour.should eq(0)
+      t1.minute.should eq(0)
+      t1.second.should eq(0)
       t1.local?.should be_true
 
       t2 = Time.local 2002, 2, 25, 15, 25, 13, nanosecond: 8
+      t2.date.should eq({2002, 2, 25})
       t2.year.should eq(2002)
       t2.month.should eq(2)
       t2.day.should eq(25)

--- a/src/time.cr
+++ b/src/time.cr
@@ -741,13 +741,10 @@ struct Time
     )
   end
 
-  # Returns a copy of `self` with time-of-day components (hour, minute, second,
-  # nanoseconds) set to zero.
-  #
-  # This equals `at_beginning_of_day` or
-  # `Time.local(year, month, day, 0, 0, 0, nanoseconds: 0, location: location)`.
-  def date : Time
-    Time.local(year, month, day, location: location)
+  # Returns a `Tuple` with `year`, `month` and `day`.
+  def date : Tuple(Int32, Int32, Int32)
+    year, month, day, _ = year_month_day_day_year
+    {year, month, day}
   end
 
   # Returns the year of the proleptic Georgian Calendar (`0..9999`).


### PR DESCRIPTION
This is a proposal to remove the method `Time#date`. It does not actually return a date (there is no `Date` class), but a date-time at midnight (time-of-day fields set to zero). It's essentially an alias for `Time#at_beginning_of_day`.

I think this method would be generally useful, but should not return a `Time` instance because it always includes a time-of-day and therefor is not a date which would range from midnight to midnight. There is no way to tell a `Time` instance to have no time-of-day.

Maybe this method could also be replaced or re-added later (for example returning a tuple `year, month, day`, but the current implementation makes no sense and is an unnecessary alias.