### PR TITLE
Update CI distribution scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 839e8ce63e5c48393faa0c126dd2f42aa5c798aa
+          git checkout bc320f21edb40622ec0e294995c8dc42e0e81f17
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
See https://github.com/crystal-lang/distribution-scripts/commit/bc320f21edb40622ec0e294995c8dc42e0e81f17.

Updates libgc to use the large configuration, recommended for applications using >512MiB of ram (lol).

Fixes #5610