### PR TITLE
Regex: fix invalid #inspect result against %r{\/}

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -33,10 +33,12 @@ describe "Regex" do
 
   it "does inspect with slash" do
     %r(/).inspect.should eq("/\\//")
+    %r(\/).inspect.should eq("/\\//")
   end
 
   it "does to_s with slash" do
     %r(/).to_s.should eq("(?-imsx:\\/)")
+    %r(\/).to_s.should eq("(?-imsx:\\/)")
   end
 
   it "doesn't crash when PCRE tries to free some memory (#771)" do

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -519,12 +519,18 @@ class Regex
   end
 
   private def append_source(io)
-    source.each_char do |char|
-      if char == '/'
+    reader = Char::Reader.new(source)
+    while reader.has_next?
+      case char = reader.current_char
+      when '\\'
+        io << '\\'
+        io << reader.next_char
+      when '/'
         io << "\\/"
       else
         io << char
       end
+      reader.next_char
     end
   end
 


### PR DESCRIPTION
Currently this shows invalid regex.

```crystal
p %r{\/} # => /\\//
```

It is fixed by this PR.