### PR TITLE
Fix ASTNode#to_s to use escape sequence correctly

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -125,4 +125,10 @@ describe "ASTNode#to_s" do
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"
   expect_to_s %(begin\n  ()\nend)
+  expect_to_s %q("\e\0\""), %q("\e\u0000\"")
+  expect_to_s %q("#{1}\0"), %q("#{1}\u0000")
+  expect_to_s %q(%r{\/\0}), %q(/\/\0/)
+  expect_to_s %q(%r{#{1}\/\0}), %q(/#{1}\/\0/)
+  expect_to_s %q(`\n\0`), %q(`\n\u0000`)
+  expect_to_s %q(`#{1}\n\0`), %q(`#{1}\n\u0000`)
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -970,17 +970,13 @@ module Crystal
       when StringLiteral
         Regex.append_source exp.value, @str
       when StringInterpolation
-        visit_interpolation(exp) { |s| escape_regex s }
+        visit_interpolation(exp) { |s| Regex.append_source s, @str }
       end
       @str << '/'
       @str << 'i' if node.options.includes? Regex::Options::IGNORE_CASE
       @str << 'm' if node.options.includes? Regex::Options::MULTILINE
       @str << 'x' if node.options.includes? Regex::Options::EXTENDED
       false
-    end
-
-    def escape_regex(s)
-      String.build { |io| Regex.append_source s, io }
     end
 
     def visit(node : TupleLiteral)

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -102,7 +102,7 @@ module Crystal
 
     def visit(node : StringInterpolation)
       @str << '"'
-      visit_interpolation node, &.gsub('"', "\\\"")
+      visit_interpolation node, &.inspect_unquoted
       @str << '"'
       false
     end
@@ -499,9 +499,9 @@ module Crystal
       @str << '`'
       case exp
       when StringLiteral
-        @str << exp.value.inspect[1..-2]
+        @str << exp.value.inspect_unquoted.gsub('`', "\\`")
       when StringInterpolation
-        visit_interpolation exp, &.gsub('`', "\\`")
+        visit_interpolation exp, &.inspect_unquoted.gsub('`', "\\`")
       end
       @str << '`'
       false
@@ -968,15 +968,33 @@ module Crystal
       @str << '/'
       case exp = node.value
       when StringLiteral
-        @str << exp.value.gsub('/', "\\/")
+        @str << escape_regex exp.value
       when StringInterpolation
-        visit_interpolation exp, &.gsub('/', "\\/")
+        visit_interpolation(exp) { |s| escape_regex s }
       end
       @str << '/'
       @str << 'i' if node.options.includes? Regex::Options::IGNORE_CASE
       @str << 'm' if node.options.includes? Regex::Options::MULTILINE
       @str << 'x' if node.options.includes? Regex::Options::EXTENDED
       false
+    end
+
+    def escape_regex(s)
+      String.build do |io|
+        reader = Char::Reader.new(s)
+        while reader.has_next?
+          case char = reader.current_char
+          when '\\'
+            io << '\\'
+            io << reader.next_char
+          when '/'
+            io << "\\/"
+          else
+            io << char
+          end
+          reader.next_char
+        end
+      end
     end
 
     def visit(node : TupleLiteral)

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -968,7 +968,7 @@ module Crystal
       @str << '/'
       case exp = node.value
       when StringLiteral
-        @str << escape_regex exp.value
+        Regex.append_source exp.value, @str
       when StringInterpolation
         visit_interpolation(exp) { |s| escape_regex s }
       end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -980,21 +980,7 @@ module Crystal
     end
 
     def escape_regex(s)
-      String.build do |io|
-        reader = Char::Reader.new(s)
-        while reader.has_next?
-          case char = reader.current_char
-          when '\\'
-            io << '\\'
-            io << reader.next_char
-          when '/'
-            io << "\\/"
-          else
-            io << char
-          end
-          reader.next_char
-        end
-      end
+      String.build { |io| Regex.append_source s, io }
     end
 
     def visit(node : TupleLiteral)

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -519,7 +519,7 @@ class Regex
   end
 
   # :nodoc:
-  def self.append_source(source, io)
+  def self.append_source(source, io) : Nil
     reader = Char::Reader.new(source)
     while reader.has_next?
       case char = reader.current_char

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -407,7 +407,7 @@ class Regex
   # ```
   def inspect(io : IO)
     io << '/'
-    append_source(io)
+    Regex.append_source(source, io)
     io << '/'
     io << 'i' if options.ignore_case?
     io << 'm' if options.multiline?
@@ -514,11 +514,12 @@ class Regex
     io << 'x' unless options.extended?
 
     io << ':'
-    append_source(io)
+    Regex.append_source(source, io)
     io << ')'
   end
 
-  private def append_source(io)
+  # :nodoc:
+  def self.append_source(source, io)
     reader = Char::Reader.new(source)
     while reader.has_next?
       case char = reader.current_char


### PR DESCRIPTION
`ASTNode#to_s` against `StringInterpolation`, `RegexLiteral`, and `Call` of backtick operator is buggy, it is missing to use escape sequence.

For example `pp "#{1}\0"` cannot be compiled by current compiler:

```console
$ cat foo.cr
pp "#{1}\0"
$ crystal run foo.cr
Error in foo.cr:1: macro didn't expand to a valid program, it expanded to:

================================================================================
--------------------------------------------------------------------------------
   1.
   2.
   3.     __temp_20 = "#{"\"\#{1}\u0000\""} # => "
   4.     ::print __temp_20
   5.     __temp_21 = "#{1}"
   6.     PrettyPrint.format(__temp_21, STDOUT, width: 80 - __temp_20.size, indent: __temp_20.size)
   7.     ::puts
   8.     __temp_21
   9.
--------------------------------------------------------------------------------
Syntax error in expanded macro: pp:5: unterminated string literal

    __temp_21 = "#{1}"
                     ^

================================================================================

pp "#{1}\0"
^~

```

Because `ASTNode#to_s` against `"#{1}\0"` yields `"#{1}` and real null character.

Thank you.