### PR TITLE
add reinit for Crystal::System::Random on after_fork, fixed #5843

### DIFF
--- a/src/crystal/system/unix/arc4random.cr
+++ b/src/crystal/system/unix/arc4random.cr
@@ -3,6 +3,9 @@
 require "c/stdlib"
 
 module Crystal::System::Random
+  def self.after_fork
+  end
+
   # Fills *buffer* with random bytes using arc4random.
   #
   # NOTE: only secure on OpenBSD and CloudABI

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -23,6 +23,10 @@ module Crystal::System::Random
     end
   end
 
+  def self.after_fork
+    @@initialized = false
+  end
+
   # Reads n random bytes using the Linux `getrandom(2)` syscall.
   def self.random_bytes(buf : Bytes) : Nil
     init unless @@initialized

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -15,6 +15,10 @@ module Crystal::System::Random
     @@urandom = urandom
   end
 
+  def self.after_fork
+    @@initialized = false
+  end
+
   def self.random_bytes(buf : Bytes) : Nil
     init unless @@initialized
 

--- a/src/crystal/system/win32/random.cr
+++ b/src/crystal/system/win32/random.cr
@@ -1,6 +1,9 @@
 require "c/ntsecapi"
 
 module Crystal::System::Random
+  def self.after_fork
+  end
+
   def self.random_bytes(buf : Bytes) : Nil
     if LibC.RtlGenRandom(buf, buf.size) == 0
       raise WinError.new("RtlGenRandom")

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -192,6 +192,7 @@ class Process
       ->Scheduler.after_fork,
       ->Crystal::Signal.after_fork,
       ->Crystal::SignalChildHandler.after_fork,
+      ->Crystal::System::Random.after_fork,
       ->Random::DEFAULT.new_seed,
     ] of -> Nil
   end


### PR DESCRIPTION
now example in #5843 returns:
```
{0.11081753529688289, "ae96e22d-b69a-4951-9f56-3df4edbc7652"}
{0.7271770859230039, "0948319d-2078-466c-b1d4-6c91b7aad11a"}
{0.07958717249673676, "57da4980-08fd-4cf5-b52b-354c249e7926"}
{0.21592823632081862, "de0648c0-79f3-47cf-a416-ca8b069be32e"}
{0.6035845341814196, "1346b2f6-cf9f-4bfa-a97a-ea1fbcc3d659"}
{0.43879859033351215, "608396bd-710b-4342-81f9-9bff3fcaa975"}
{0.41325373119462844, "4b350ce6-8396-49cb-828b-b96c6b640b03"}
{0.20799528629624045, "7860057b-14f3-44f2-93c5-65ad2c83b81e"}
{0.19575174346064342, "a05276d1-06bd-4be5-833c-78c3c1b30569"}
{0.2045484056180609, "2019cf79-1512-4d89-952a-63887f925cf2"}
```