### PR TITLE
Security Fix: don't buffer reads from /dev/urandom

### DIFF
--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -15,7 +15,7 @@ end
 {% elsif flag?(:openbsd) %}
   require "./unix/arc4random"
 {% elsif flag?(:unix) %}
-  require "./unix/urandom"
+  require "./unix/random"
 {% elsif flag?(:win32) %}
   require "./win32/random"
 {% else %}

--- a/src/crystal/system/unix/random.cr
+++ b/src/crystal/system/unix/random.cr
@@ -1,0 +1,15 @@
+{% skip_file unless flag?(:unix) && !flag?(:openbsd) && !flag?(:linux) %}
+
+require "./urandom"
+
+module Crystal::System::Random
+  def self.random_bytes(buf : Bytes) : Nil
+    Crystal::System::Urandom.random_bytes(buf)
+  end
+
+  def self.next_u : UInt8
+    buf = uninitialized UInt8[1]
+    random_bytes(buf.to_slice)
+    buf.unsafe_at(0)
+  end
+end

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -1,35 +1,60 @@
-{% skip_file unless flag?(:unix) && !flag?(:openbsd) && !flag?(:linux) %}
+{% skip_file unless flag?(:unix) && !flag?(:openbsd) %}
 
-module Crystal::System::Random
-  @@initialized = false
-  @@urandom : ::File?
+require "c/fcntl"
+require "c/unistd"
+require "c/sys/stat"
+require "mutex"
 
+# :nodoc:
+module Crystal::System::Urandom
+  @@mutex = Mutex.new
+  @@fd : LibC::Int?
+
+  # Opens `/dev/urandom`, verifies the opened file is indeed a character device.
+  #
+  # We rely on raw POSIX calls instead of leveraging Crystal IO and File
+  # facilities to ensure that we don't inadvertently use an insecure feature
+  # while reading from `/dev/urandom` such as buffering or even evented IO since
+  # `/dev/urandom` shall only block very early during the OS boot process.
   private def self.init
-    @@initialized = true
+    @@mutex.synchronize do
+      fd = LibC.open("/dev/urandom", LibC::O_RDONLY)
+      raise Errno.new("open") if fd == -1
 
-    urandom = ::File.open("/dev/urandom", "r")
-    return unless urandom.stat.chardev?
+      if LibC.fstat(fd, out stats) == -1
+        raise Errno.new("fstat")
+      end
+      if (stats.st_mode & LibC::S_IFMT) == LibC::S_IFCHR
+        flags = LibC.fcntl(fd, LibC::F_GETFD, 0)
+        raise Errno.new("fcntl") if flags == -1
 
-    urandom.close_on_exec = true
-    urandom.sync = true # don't buffer bytes
-    @@urandom = urandom
-  end
+        if LibC.fcntl(fd, LibC::F_SETFD, flags | LibC::FD_CLOEXEC) == -1
+          raise Errno.new("fcntl")
+        end
+      else
+        if LibC.close(fd) == -1
+          raise Errno.new("close")
+        end
+      end
 
-  def self.random_bytes(buf : Bytes) : Nil
-    init unless @@initialized
-
-    if urandom = @@urandom
-      urandom.read_fully(buf)
-    else
-      raise "Failed to access secure source to generate random bytes!"
+      @@fd = fd
     end
   end
 
-  def self.next_u : UInt8
-    init unless @@initialized
+  def self.random_bytes(buf : Bytes) : Nil
+    init unless @@fd
 
-    if urandom = @@urandom
-      urandom.read_bytes(UInt8)
+    if fd = @@fd
+      while buf.size > 0
+        read_bytes = LibC.read(fd, buf, buf.size)
+        if read_bytes < 0
+          unless Errno.value == Errno::EINTR
+            raise Errno.new("read")
+          end
+        else
+          buf += read_bytes
+        end
+      end
     else
       raise "Failed to access secure source to generate random bytes!"
     end


### PR DESCRIPTION
This avoids the weird behavior of IO::Buffered that always buffers reads (and only stops buffering writes). This is a security issue in the case of Random::Secure. Let's switch to direct C calls to completely avoid such issues (now and in the future).

Also unifies the urandom implementation for UNIX (generic) and Linux (getrandom fallback).