### PR TITLE
Always read unbuffered when IO::Buffered#sync = true

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -317,7 +317,9 @@ describe "IO::Buffered" do
     end
 
     it "works with IO#read (already buffered)" do
-      str = IO::Memory.new "#{"a" * IO::Buffered::BUFFER_SIZE}bcde"
+      str = IO::Memory.new
+      str << "a" * IO::Buffered::BUFFER_SIZE
+      str.pos = 0
 
       io = BufferedWrapper.new(str)
       io.sync?.should be_false
@@ -330,6 +332,9 @@ describe "IO::Buffered" do
 
       io.sync = true
       io.sync?.should be_true
+
+      str << "bcde"
+      str.pos -= 4
 
       byte = Bytes.new(1)
       io.read_fully(byte)
@@ -352,8 +357,10 @@ describe "IO::Buffered" do
       str.gets_to_end.should eq("bc")
     end
 
-    it "works with IO#read (already buffered)" do
-      str = IO::Memory.new "#{"a" * IO::Buffered::BUFFER_SIZE}bcde"
+    it "works with IO#read_byte (already buffered)" do
+      str = IO::Memory.new
+      str << "a" * IO::Buffered::BUFFER_SIZE
+      str.pos = 0
 
       io = BufferedWrapper.new(str)
       io.sync?.should be_false
@@ -364,6 +371,9 @@ describe "IO::Buffered" do
 
       io.sync = true
       io.sync?.should be_true
+
+      str << "bcde"
+      str.pos -= 4
 
       io.read_byte.should eq('b'.ord.to_u8)
 

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -317,16 +317,16 @@ describe "IO::Buffered" do
     end
 
     it "works with IO#read (already buffered)" do
-      str = IO::Memory.new "abc"
+      str = IO::Memory.new "#{"a" * IO::Buffered::BUFFER_SIZE}bcde"
 
       io = BufferedWrapper.new(str)
       io.sync?.should be_false
 
-      byte = Bytes.new(1)
-      io.read_fully(byte)
-      byte[0].should eq('a'.ord.to_u8)
-
-      str.gets_to_end.should eq("")
+      IO::Buffered::BUFFER_SIZE.times do
+        byte = Bytes.new(1)
+        io.read_fully(byte)
+        byte[0].should eq('a'.ord.to_u8)
+      end
 
       io.sync = true
       io.sync?.should be_true
@@ -334,6 +334,8 @@ describe "IO::Buffered" do
       byte = Bytes.new(1)
       io.read_fully(byte)
       byte[0].should eq('b'.ord.to_u8)
+
+      str.gets_to_end.should eq("cde")
     end
 
     it "works with IO#read_byte" do
@@ -351,18 +353,21 @@ describe "IO::Buffered" do
     end
 
     it "works with IO#read (already buffered)" do
-      str = IO::Memory.new "abc"
+      str = IO::Memory.new "#{"a" * IO::Buffered::BUFFER_SIZE}bcde"
 
       io = BufferedWrapper.new(str)
       io.sync?.should be_false
 
-      io.read_byte.should eq('a'.ord.to_u8)
-      str.gets_to_end.should eq("")
+      IO::Buffered::BUFFER_SIZE.times do
+        io.read_byte.should eq('a'.ord.to_u8)
+      end
 
       io.sync = true
       io.sync?.should be_true
 
       io.read_byte.should eq('b'.ord.to_u8)
+
+      str.gets_to_end.should eq("cde")
     end
   end
 

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -33,9 +33,16 @@ module IO::Buffered
   def read_byte : UInt8?
     check_open
 
-    fill_buffer if @in_buffer_rem.empty?
+    fill_buffer if !sync? && @in_buffer_rem.empty?
     if @in_buffer_rem.empty?
-      nil
+      return nil unless sync?
+
+      byte = uninitialized UInt8
+      if read(Slice.new(pointerof(byte), 1)) == 1
+        byte
+      else
+        nil
+      end
     else
       b = @in_buffer_rem[0]
       @in_buffer_rem += 1
@@ -54,7 +61,7 @@ module IO::Buffered
       # If we are asked to read more than half the buffer's size,
       # read directly into the slice, as it's not worth the extra
       # memory copy.
-      if count >= BUFFER_SIZE / 2
+      if sync? || count >= BUFFER_SIZE / 2
         return unbuffered_read(slice[0, count]).to_i
       else
         fill_buffer


### PR DESCRIPTION
Previously the sync option only affected writes, which wasn't optimal.