### PR TITLE
Format: fix formatting call having trailing comma with block

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -259,6 +259,8 @@ describe Crystal::Formatter do
   assert_format "foo(1,\n2,\n)", "foo(1,\n  2,\n)"
   assert_format "foo(out x)", "foo(out x)"
   assert_format "foo(\n  1,\n  a: 1,\n  b: 2,\n)"
+  assert_format "foo(1, ) { }", "foo(1) { }"
+  assert_format "foo(1, ) do\nend", "foo(1) do\nend"
 
   assert_format "foo.bar\n.baz", "foo.bar\n  .baz"
   assert_format "foo.bar.baz\n.qux", "foo.bar.baz\n  .qux"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2366,6 +2366,10 @@ module Crystal
         needs_space = !has_parentheses || has_args
         block_indent = @multiline_call_indent || @indent
         skip_space
+        if has_parentheses && @token.type == :","
+          next_token_skip_space
+          write "," if @token.type != :")" # foo(1, &.foo) case
+        end
         if has_parentheses && @token.type == :")"
           if ends_with_newline
             write_line unless found_comment


### PR DESCRIPTION
Fix #5853