### PR TITLE
Pedantic & controversial: rewrite/remove explicit nils

### DIFF
--- a/samples/degree_days.cr
+++ b/samples/degree_days.cr
@@ -45,12 +45,12 @@ class DegreeDays
 
   private def heating_day(temps)
     heat = avg temps.map { |temp| heating_degree(temp) }
-    (heat > heating_threshold) ? heat : nil
+    heat if heat > heating_threshold
   end
 
   private def cooling_day(temps)
     cool = avg temps.map { |temp| cooling_degree(temp) }
-    (cool > cooling_threshold) ? cool : nil
+    cool if cool > cooling_threshold
   end
 
   private def heating_degree(temp)

--- a/samples/sdl/raytracer.cr
+++ b/samples/sdl/raytracer.cr
@@ -76,11 +76,11 @@ class Sphere
   def intersect(ray, distance)
     vl = @center - ray.start
     a = vl.dot(ray.dir)
-    return nil if a < 0
+    return if a < 0
 
     b2 = vl.dot(vl) - a * a
     r2 = @radius * @radius
-    return nil if b2 > r2
+    return if b2 > r2
 
     c = Math.sqrt(r2 - b2)
     near = a - c

--- a/samples/text_raytracer.cr
+++ b/samples/text_raytracer.cr
@@ -66,20 +66,20 @@ def intersect_sphere(ray, center, radius)
   l = center - ray.orig
   tca = l.dot(ray.dir)
   if tca < 0.0
-    return nil
+    return
   end
 
   d2 = l.dot(l) - tca*tca
   r2 = radius*radius
   if d2 > r2
-    return nil
+    return
   end
 
   thc = Math.sqrt(r2 - d2)
   t0 = tca - thc
   # t1 = tca + thc
   if t0 > 10_000
-    return nil
+    return
   end
 
   t0

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -337,8 +337,6 @@ struct CallStack
             end
           end
         end
-
-        nil
       end
 
       # The address offset at which the program was loaded at.
@@ -430,7 +428,6 @@ struct CallStack
     end
 
     def self.decode_function_name(pc)
-      nil
     end
   {% end %}
 

--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -94,7 +94,6 @@ module Crystal
     end
 
     def call_convention
-      nil
     end
 
     @c_calling_convention : Bool? = nil

--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -107,7 +107,7 @@ module Crystal
         @c_calling_convention = compute_c_calling_convention
       end
 
-      @c_calling_convention ? self : nil
+      self if @c_calling_convention
     end
 
     private def compute_c_calling_convention

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1887,8 +1887,6 @@ module Crystal
       @malloc_fun ||= @main_mod.functions[MALLOC_NAME]?
       if malloc_fun = @malloc_fun
         check_main_fun MALLOC_NAME, malloc_fun
-      else
-        nil
       end
     end
 
@@ -1896,8 +1894,6 @@ module Crystal
       @malloc_atomic_fun ||= @main_mod.functions[MALLOC_ATOMIC_NAME]?
       if malloc_fun = @malloc_atomic_fun
         check_main_fun MALLOC_ATOMIC_NAME, malloc_fun
-      else
-        nil
       end
     end
 
@@ -1905,8 +1901,6 @@ module Crystal
       @realloc_fun ||= @main_mod.functions[REALLOC_NAME]?
       if realloc_fun = @realloc_fun
         check_main_fun REALLOC_NAME, realloc_fun
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -32,8 +32,6 @@ module Crystal
         interpret_raise(node)
       when "run"
         interpret_run(node)
-      else
-        nil
       end
     end
 
@@ -2154,8 +2152,6 @@ private def intepret_array_or_tuple_method(object, klass, method, args, block, i
       end
       klass.new(object.elements + other_elements)
     end
-  else
-    nil
   end
 end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -475,8 +475,6 @@ module Crystal
       when UInt16 then uint16
       when UInt32 then uint32
       when UInt64 then uint64
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -552,13 +552,13 @@ module Crystal
     end
 
     def check_private(node)
-      return nil unless node.visibility.private?
+      return unless node.visibility.private?
 
       location = node.location
-      return nil unless location
+      return unless location
 
       filename = location.filename
-      return nil unless filename.is_a?(String)
+      return unless filename.is_a?(String)
 
       file_module(filename)
     end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -333,7 +333,7 @@ module Crystal
     # to arguments before a def's splat index, matching the given objects.
     # If there are more objects than arguments in the method, they are not yielded.
     # If splat index is `nil`, all args and objects (with their indices) are yielded.
-    def self.before(a_def, objects, &block)
+    def self.before(a_def, objects, &block) : Nil
       splat = a_def.splat_index || a_def.args.size
       splat.times do |i|
         obj = objects[i]?
@@ -342,14 +342,13 @@ module Crystal
         yield a_def.args[i], i, obj, i
         i += 1
       end
-      nil
     end
 
     # Yields `arg, arg_index, object, object_index` corresponding
     # to arguments at a def's splat index, matching the given objects.
     # If there are more objects than arguments in the method, they are not yielded.
     # If splat index is `nil`, all args and objects (with their indices) are yielded.
-    def self.at(a_def, objects, &block)
+    def self.at(a_def, objects, &block) : Nil
       splat_index = a_def.splat_index
       return unless splat_index
 
@@ -361,8 +360,6 @@ module Crystal
 
         yield a_def.args[splat_index], splat_index, obj, obj_index
       end
-
-      nil
     end
 
     # Returns the splat size of this def matching the given objects.

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -380,7 +380,7 @@ module Crystal
     property! call : Call
 
     def map_type(type)
-      return nil unless call.type?
+      return unless call.type?
 
       arg_types = call.args.map &.type
       arg_types.push call.type

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -656,7 +656,7 @@ class Crystal::Call
       when Macro
         return result
       when Type::DefInMacroLookup
-        return nil
+        return
       end
     end
   end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -468,7 +468,6 @@ class Crystal::Call
         raise "index out of bounds for #{owner} (#{arg} not in #{-instance_type.size}..#{instance_type.size - 1})"
       end
     end
-    nil
   end
 
   def named_tuple_indexer_helper(args, arg_types, owner, instance_type, nilable)
@@ -489,7 +488,6 @@ class Crystal::Call
         raise "missing key '#{name}' for named tuple #{owner}"
       end
     end
-    nil
   end
 
   def replace_splats

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -285,7 +285,6 @@ class Crystal::Call
     when "and"; "&&"
     when "or" ; "||"
     when "not"; "!"
-    else        nil
     end
   end
 
@@ -609,8 +608,6 @@ class Crystal::Call
                   type.namespace
                 when GenericClassInstanceType
                   type.namespace
-                else
-                  nil
                 end
     case namespace
     when Program

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -343,7 +343,7 @@ class Crystal::Call
       return "missing arguments: #{missing_args.join ", "}"
     end
 
-    return nil
+    return
   end
 
   def append_error_when_no_matching_defs(owner, def_name, all_arguments_sizes, real_args_size, min_splat, defs, io)

--- a/src/compiler/crystal/semantic/conversions.cr
+++ b/src/compiler/crystal/semantic/conversions.cr
@@ -7,7 +7,7 @@ module Crystal::Conversions
       convert_call.accept visitor
     rescue ex : Crystal::Exception
       if ex.message.try(&.includes?("undefined method '#{convert_call_name}'"))
-        return nil
+        return
       end
 
       node.raise "converting from #{actual_type} to #{expected_type} by invoking '#{convert_call_name}'", ex
@@ -25,7 +25,7 @@ module Crystal::Conversions
       unless to_unsafe_lookup_failed?(ex)
         node.raise ex.message, ex
       end
-      return nil
+      return
     end
     if unsafe_call.type? != expected_type
       node.raise "invoked 'to_unsafe' to convert from #{actual_type} to #{expected_type}, but got #{unsafe_call.type?}"

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -281,7 +281,6 @@ module Crystal
     end
 
     def deepest_error_message
-      nil
     end
   end
 

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -184,8 +184,6 @@ module Crystal
       when 0
         if @filter.is_a?(TruthyFilter)
           other
-        else
-          nil
         end
       when 1
         resulting_types.first
@@ -298,8 +296,6 @@ module Crystal
           end
         end
         new_filters
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -124,11 +124,11 @@ module Crystal
     end
 
     def apply(other)
-      return nil unless other
+      return unless other
 
       case other
       when NilType
-        return nil
+        return
       when UnionType
         return Type.merge(other.union_types.reject &.nil_type?)
       else

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1737,15 +1737,16 @@ module Crystal
     def get_expression_var(exp)
       case exp
       when Var
-        return exp
+        exp
       when Assign
-        target = exp.target
-        return target if target.is_a?(Var)
+        if (target = exp.target).is_a?(Var)
+          target
+        end
       when Expressions
-        return unless exp = exp.single_expression?
-        return get_expression_var(exp)
+        if exp = exp.single_expression?
+          get_expression_var(exp)
+        end
       end
-      nil
     end
 
     def visit(node : Cast | NilableCast)
@@ -2145,24 +2146,22 @@ module Crystal
     def get_while_cond_assign_target(node)
       case node
       when Assign
-        target = node.target
-        if target.is_a?(Var)
-          return target
+        if (target = node.target).is_a?(Var)
+          target
         end
       when And
-        return get_while_cond_assign_target(node.left)
+        get_while_cond_assign_target(node.left)
       when If
         if node.and?
-          return get_while_cond_assign_target(node.cond)
+          get_while_cond_assign_target(node.cond)
         end
       when Call
-        return get_while_cond_assign_target(node.obj)
+        get_while_cond_assign_target(node.obj)
       when Expressions
-        return unless node = node.single_expression?
-        return get_while_cond_assign_target(node)
+        if node = node.single_expression?
+          get_while_cond_assign_target(node)
+        end
       end
-
-      nil
     end
 
     # If we have:
@@ -2915,8 +2914,6 @@ module Crystal
           return type_filters.not
         end
       end
-
-      nil
     end
 
     def visit(node : VisibilityModifier)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -620,7 +620,7 @@ module Crystal
     def lookup_similar_instance_variable_name(node, owner)
       case owner
       when NonGenericModuleType, GenericClassType, GenericModuleType
-        return nil
+        return
       end
 
       Levenshtein.find(node.name) do |finder|

--- a/src/compiler/crystal/semantic/math_interpreter.cr
+++ b/src/compiler/crystal/semantic/math_interpreter.cr
@@ -95,10 +95,8 @@ struct Crystal::MathInterpreter
     end
 
     if visitor.expand_macro(node, raise_on_missing_const: false, first_pass: true)
-      return interpret(node.expanded.not_nil!, target_type)
+      interpret(node.expanded.not_nil!, target_type)
     end
-
-    nil
   end
 
   def interpret(node : Path, target_type = nil)

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -135,13 +135,13 @@ module Crystal
 
       # If yieldness isn't the same there's no match
       if def_metadata.yields != !!signature.block
-        return nil
+        return
       end
 
       # If there are more positional arguments than those required, there's no match
       # (if there's less they might be matched with named arguments)
       if signature.arg_types.size > def_metadata.max_size
-        return nil
+        return
       end
 
       a_def = def_metadata.def
@@ -156,7 +156,7 @@ module Crystal
       # unless all args past it have default values
       if splat_index && a_def.args.size > splat_index + 1 && !named_args
         unless (splat_index + 1...a_def.args.size).all? { |i| a_def.args[i].default_value }
-          return nil
+          return
         end
       end
 
@@ -166,7 +166,7 @@ module Crystal
         mandatory_args = BitArray.new(a_def.args.size)
       elsif signature.arg_types.size < def_metadata.min_size
         # Otherwise, they must be matched by positional arguments
-        return nil
+        return
       end
 
       matched_arg_types = nil
@@ -177,7 +177,7 @@ module Crystal
       if splat_index && splat_restriction &&
          !splat_restriction.is_a?(Splat) &&
          Splat.size(a_def, arg_types) == 0
-        return nil
+        return
       end
 
       if splat_restriction.is_a?(Splat)
@@ -197,7 +197,7 @@ module Crystal
           matched_arg_types.push match_arg_type
           mandatory_args[arg_index] = true if mandatory_args
         else
-          return nil
+          return
         end
       end
 
@@ -206,7 +206,7 @@ module Crystal
         tuple_type = context.instantiated_type.program.tuple_of(splat_arg_types)
         match_arg_type = tuple_type.restrict(splat_restriction.exp, context)
         unless match_arg_type
-          return nil
+          return
         end
       end
 
@@ -224,24 +224,24 @@ module Crystal
           if found_index
             # A named arg can't target the splat index
             if found_index == splat_index
-              return nil
+              return
             end
 
             # Check whether the named arg refers to an argument that was already specified
             if mandatory_args
               if mandatory_args[found_index]
-                return nil
+                return
               end
               mandatory_args[found_index] = true
             else
               if found_index < min_index
-                return nil
+                return
               end
             end
 
             match_arg_type = named_arg.type.restrict(a_def.args[found_index], context)
             unless match_arg_type
-              return nil
+              return
             end
 
             matched_named_arg_types ||= [] of NamedArgumentType
@@ -258,7 +258,7 @@ module Crystal
                 else
                   match_arg_type = named_arg.type.restrict(double_splat_restriction, context)
                   unless match_arg_type
-                    return nil
+                    return
                   end
                 end
               end
@@ -270,7 +270,7 @@ module Crystal
               next
             end
 
-            return nil
+            return
           end
         end
       end
@@ -280,7 +280,7 @@ module Crystal
         named_tuple_type = context.instantiated_type.program.named_tuple_of(double_splat_entries)
         value = named_tuple_type.restrict(double_splat_restriction.exp, context)
         unless value
-          return nil
+          return
         end
       end
 
@@ -289,7 +289,7 @@ module Crystal
       if mandatory_args
         a_def.args.each_with_index do |arg, index|
           if index != splat_index && !arg.default_value && !mandatory_args[index]
-            return nil
+            return
           end
         end
       end
@@ -297,7 +297,7 @@ module Crystal
       # If there's a restriction on a double splat, zero matching named arguments don't matc
       if double_splat && double_splat_restriction &&
          !double_splat_restriction.is_a?(DoubleSplat) && !found_unmatched_named_arg
-        return nil
+        return
       end
 
       # We reuse a match context without free vars, but we create

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -24,7 +24,7 @@ module Crystal
 
     def lookup_method_missing
       a_macro = lookup_macro("method_missing", ONE_ARG, nil)
-      a_macro.is_a?(Macro) ? a_macro : nil
+      a_macro if a_macro.is_a?(Macro)
     end
 
     def define_method_from_method_missing(method_missing, signature, original_call)

--- a/src/compiler/crystal/semantic/path_lookup.cr
+++ b/src/compiler/crystal/semantic/path_lookup.cr
@@ -70,7 +70,7 @@ module Crystal
       type = types?.try &.[name]?
       if type
         if type.private? && !include_private
-          return nil
+          return
         end
 
         return type
@@ -109,7 +109,7 @@ module Crystal
       # If we are Foo(T) and somebody looks up the type T, we return `nil` because we don't
       # know what type T is, and we don't want to continue search in the namespace
       if type_vars.includes?(name)
-        return nil
+        return
       end
       super
     end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -304,8 +304,6 @@ module Crystal
       if parents.try &.any? &.restriction_of?(other, context.instantiated_type)
         return self
       end
-
-      nil
     end
 
     def restrict(other : AliasType, context)
@@ -409,11 +407,9 @@ module Crystal
     end
 
     def restrict(other : Metaclass, context)
-      nil
     end
 
     def restrict(other : ProcNotation, context)
-      nil
     end
 
     def restrict(other : Underscore, context)
@@ -425,11 +421,9 @@ module Crystal
     end
 
     def restrict(other : NumberLiteral, context)
-      nil
     end
 
     def restrict(other : Splat, context)
-      nil
     end
 
     def restrict(other : ASTNode, context)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -531,9 +531,9 @@ module Crystal
         other_type_var = other.type_vars[name]
         if type_var.is_a?(Var) && other_type_var.is_a?(Var)
           restricted = type_var.type.implements?(other_type_var.type)
-          return nil unless restricted
+          return unless restricted
         else
-          return nil unless type_var == other_type_var
+          return unless type_var == other_type_var
         end
       end
 
@@ -556,7 +556,7 @@ module Crystal
           other.raise "can only instantiate NamedTuple with named arguments"
         end
         # We match named tuples in NamedTupleInstanceType
-        return nil
+        return
       end
 
       # Consider the case of a splat in the type vars
@@ -565,7 +565,7 @@ module Crystal
         types = Array(Type).new(type_vars.size)
         i = 0
         type_vars.each_value do |var|
-          return nil unless var.is_a?(Var)
+          return unless var.is_a?(Var)
 
           var_type = var.type
           if i == self.splat_index
@@ -584,13 +584,13 @@ module Crystal
             found_splat = true
 
             count = types.size - (other.type_vars.size - 1)
-            return nil unless count >= 0
+            return unless count >= 0
 
             arg_types = types[i, count]
             arg_types_tuple = context.instantiated_type.program.tuple_of(arg_types)
 
             restricted = arg_types_tuple.restrict(type_var.exp, context)
-            return nil unless restricted == arg_types_tuple
+            return unless restricted == arg_types_tuple
 
             i += count
           else
@@ -613,7 +613,7 @@ module Crystal
       type_vars.each do |name, type_var|
         other_type_var = other.type_vars[i]
         restricted = restrict_type_var(type_var, other_type_var, context)
-        return nil unless restricted
+        return unless restricted
         i += 1
       end
 
@@ -647,7 +647,7 @@ module Crystal
             # number, there's no match
             existing = context.get_free_var(name)
             if existing && existing != type_var
-              return nil
+              return
             end
 
             context.set_free_var(name, type_var)
@@ -699,13 +699,13 @@ module Crystal
             found_splat = true
 
             count = tuple_types.size - (other.type_vars.size - 1)
-            return nil unless count >= 0
+            return unless count >= 0
 
             arg_types = tuple_types[i, count]
             arg_types_tuple = context.instantiated_type.program.tuple_of(arg_types)
 
             restricted = arg_types_tuple.restrict(type_var.exp, context)
-            return nil unless restricted == arg_types_tuple
+            return unless restricted == arg_types_tuple
 
             i += count
           else
@@ -719,11 +719,11 @@ module Crystal
 
         return self
       else
-        return nil unless other.type_vars.size == tuple_types.size
+        return unless other.type_vars.size == tuple_types.size
 
         tuple_types.zip(other.type_vars) do |tuple_type, type_var|
           restricted = tuple_type.restrict(type_var, context)
-          return nil unless restricted == tuple_type
+          return unless restricted == tuple_type
         end
       end
 
@@ -755,7 +755,7 @@ module Crystal
       other_names = other_named_args.map(&.name).sort!
       self_names = self.entries.map(&.name).sort!
 
-      return nil unless self_names == other_names
+      return unless self_names == other_names
 
       # Now match name by name
       other_named_args.each do |named_arg|
@@ -763,7 +763,7 @@ module Crystal
         other_type = named_arg.value
 
         restricted = self_type.restrict(other_type, context)
-        return nil unless restricted
+        return unless restricted
       end
 
       self
@@ -887,7 +887,7 @@ module Crystal
       return self if self == other
 
       if !self.simple? && !other.simple?
-        return nil
+        return
       end
 
       remove_alias.restrict(other, context)
@@ -975,13 +975,13 @@ module Crystal
         inputs.each do |input|
           if input.is_a?(Splat)
             count = arg_types.size - (inputs.size - 1)
-            return nil unless count >= 0
+            return unless count >= 0
 
             input_arg_types = arg_types[i, count]
             input_arg_types_tuple = context.instantiated_type.program.tuple_of(input_arg_types)
 
             restricted = input_arg_types_tuple.restrict(input.exp, context)
-            return nil unless restricted == input_arg_types_tuple
+            return unless restricted == input_arg_types_tuple
 
             i += count
           else
@@ -993,12 +993,12 @@ module Crystal
           end
         end
       else
-        return nil if arg_types.size != inputs_size
+        return if arg_types.size != inputs_size
 
         if inputs
           inputs.zip(arg_types) do |input, my_input|
             restricted = my_input.restrict(input, context)
-            return nil unless restricted == my_input
+            return unless restricted == my_input
           end
         end
       end
@@ -1009,7 +1009,7 @@ module Crystal
           # Ok, NoReturn can be "cast" to anything
         else
           restricted = my_output.restrict(output, context)
-          return nil unless restricted == my_output
+          return unless restricted == my_output
         end
 
         self
@@ -1035,13 +1035,13 @@ module Crystal
         other.type_vars.each do |type_var|
           if type_var.is_a?(Splat)
             count = proc_types.size - (other.type_vars.size - 1)
-            return nil unless count >= 0
+            return unless count >= 0
 
             arg_types = proc_types[i, count]
             arg_types_tuple = context.instantiated_type.program.tuple_of(arg_types)
 
             restricted = arg_types_tuple.restrict(type_var.exp, context)
-            return nil unless restricted == arg_types_tuple
+            return unless restricted == arg_types_tuple
 
             i += count
           else
@@ -1057,13 +1057,13 @@ module Crystal
       end
 
       unless other.type_vars.size == arg_types.size + 1
-        return nil
+        return
       end
 
       other.type_vars.each_with_index do |other_type_var, i|
         proc_type = arg_types[i]? || return_type
         restricted = proc_type.restrict other_type_var, context
-        return nil unless restricted == proc_type
+        return unless restricted == proc_type
       end
 
       self
@@ -1081,7 +1081,7 @@ module Crystal
       end
 
       # Disallow casting a function to another one accepting different argument count
-      return nil if arg_types.size != other.arg_types.size
+      return if arg_types.size != other.arg_types.size
 
       arg_types.zip(other.arg_types) do |arg_type, other_arg_type|
         return false unless arg_type == other_arg_type

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -185,8 +185,6 @@ module Crystal
     def required_named_arguments
       if (splat_index = self.def.splat_index) && splat_index != self.def.args.size - 1
         self.def.args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by &.external_name
-      else
-        nil
       end
     end
   end
@@ -815,8 +813,6 @@ module Crystal
             return instance
           end
         end
-        nil
-      else
         nil
       end
     end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -327,18 +327,18 @@ module Crystal
 
     def restrict(other : UnionType, context)
       restricted = other.union_types.any? { |union_type| restrict(union_type, context) }
-      restricted ? self : nil
+      self if restricted
     end
 
     def restrict(other : VirtualType, context)
-      implements?(other.base_type) ? self : nil
+      self if implements?(other.base_type)
     end
 
     def restrict(other : Union, context)
       types = other.types.compact_map do |ident|
         restrict(ident, context).as(Type?)
       end
-      types.size > 0 ? program.type_merge_union_of(types) : nil
+      program.type_merge_union_of(types) if types.size > 0
     end
 
     def restrict(other : Path, context)
@@ -729,7 +729,7 @@ module Crystal
     end
 
     def restrict(other : TupleInstanceType, context)
-      self.implements?(other) ? self : nil
+      self if implements?(other)
     end
   end
 
@@ -768,7 +768,7 @@ module Crystal
     end
 
     def restrict(other : NamedTupleInstanceType, context)
-      self.implements?(other) ? self : nil
+      self if implements?(other)
     end
   end
 
@@ -790,8 +790,9 @@ module Crystal
         end
         program.type_merge types
       elsif other.is_a?(VirtualType)
-        result = base_type.restrict(other.base_type, context) || other.base_type.restrict(base_type, context)
-        result ? result.virtual_type : nil
+        if result = base_type.restrict(other.base_type, context) || other.base_type.restrict(base_type, context)
+          result.virtual_type
+        end
       elsif other.implements?(base_type)
         other.virtual_type
       elsif base_type.implements?(other)
@@ -918,12 +919,12 @@ module Crystal
   class MetaclassType
     def restrict(other : Metaclass, context)
       restricted = instance_type.restrict(other.name, context)
-      instance_type == restricted ? self : nil
+      self if instance_type == restricted
     end
 
     def restrict(other : VirtualMetaclassType, context)
       restricted = instance_type.restrict(other.instance_type.base_type, context)
-      restricted ? self : nil
+      self if restricted
     end
 
     def restriction_of?(other : VirtualMetaclassType, owner)
@@ -934,28 +935,28 @@ module Crystal
   class GenericClassInstanceMetaclassType
     def restrict(other : Metaclass, context)
       restricted = instance_type.restrict(other.name, context)
-      instance_type == restricted ? self : nil
+      self if instance_type == restricted
     end
 
     def restrict(other : MetaclassType, context)
       return self if instance_type.generic_type.metaclass == other
 
       restricted = instance_type.restrict(other.instance_type, context)
-      restricted ? self : nil
+      self if restricted
     end
   end
 
   class GenericModuleInstanceMetaclassType
     def restrict(other : Metaclass, context)
       restricted = instance_type.restrict(other.name, context)
-      instance_type == restricted ? self : nil
+      self if instance_type == restricted
     end
 
     def restrict(other : MetaclassType, context)
       return self if instance_type.generic_type.metaclass == other
 
       restricted = instance_type.restrict(other.instance_type, context)
-      restricted ? self : nil
+      self if restricted
     end
   end
 
@@ -1015,7 +1016,7 @@ module Crystal
     end
 
     def restrict(other : ProcInstanceType, context)
-      compatible_with?(other) ? other : nil
+      other if compatible_with?(other)
     end
 
     def restrict(other : Generic, context)

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -206,7 +206,6 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
   # Returns free variables
   def free_vars : Hash(String, TypeVar)?
-    nil
   end
 
   def nesting_exp?(node)

--- a/src/compiler/crystal/semantic/suggestions.cr
+++ b/src/compiler/crystal/semantic/suggestions.cr
@@ -34,7 +34,9 @@ module Crystal
         return match if match
       end
 
-      lookup_in_namespace && self != program ? namespace.lookup_similar_path(names) : nil
+      if lookup_in_namespace && self != program
+        namespace.lookup_similar_path(names)
+      end
     end
 
     def lookup_similar_def(name, args_size, block)

--- a/src/compiler/crystal/semantic/suggestions.cr
+++ b/src/compiler/crystal/semantic/suggestions.cr
@@ -38,7 +38,7 @@ module Crystal
     end
 
     def lookup_similar_def(name, args_size, block)
-      return nil unless name =~ SuggestableDefName
+      return unless name =~ SuggestableDefName
 
       if (defs = self.defs)
         best_def = nil

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -520,8 +520,6 @@ module Crystal
 
       if from_type && to_type
         program.range_of(from_type, to_type)
-      else
-        nil
       end
     end
 
@@ -541,8 +539,6 @@ module Crystal
 
       if element_types
         program.tuple_of(element_types)
-      else
-        nil
       end
     end
 
@@ -558,8 +554,6 @@ module Crystal
 
       if entries
         program.named_tuple_of(entries)
-      else
-        nil
       end
     end
 
@@ -822,8 +816,6 @@ module Crystal
       info = @guessed_instance_vars[current_type]?.try &.[node.name]?
       if info
         info.type
-      else
-        nil
       end
     end
 
@@ -910,8 +902,6 @@ module Crystal
 
       if types
         Type.merge!(types)
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -432,26 +432,21 @@ module Crystal
       if name = node.name
         type = lookup_type_no_check?(name)
         if type.is_a?(GenericClassType)
-          element_types = guess_array_literal_element_types(node)
-          if element_types
+          if element_types = guess_array_literal_element_types(node)
             return type.instantiate([Type.merge!(element_types)] of TypeVar)
           end
         else
           return check_allowed_in_generics(node, type)
         end
       elsif node_of = node.of
-        type = lookup_type?(node_of)
-        if type
+        if type = lookup_type?(node_of)
           return program.array_of(type.virtual_type)
         end
       else
-        element_types = guess_array_literal_element_types(node)
-        if element_types
+        if element_types = guess_array_literal_element_types(node)
           return program.array_of(Type.merge!(element_types))
         end
       end
-
-      nil
     end
 
     def guess_array_literal_element_types(node)
@@ -491,8 +486,6 @@ module Crystal
           return program.hash_of(Type.merge!(key_types), Type.merge!(value_types))
         end
       end
-
-      nil
     end
 
     def guess_hash_literal_key_value_types(node : HashLiteral)
@@ -606,8 +599,6 @@ module Crystal
 
       type = guess_type_call_with_type_annotation(node)
       return type if type
-
-      nil
     end
 
     # If it's Pointer.malloc(size, value), infer element type from value
@@ -619,13 +610,11 @@ module Crystal
          obj.single?("Pointer") && node.name == "malloc"
         type = lookup_type_no_check?(obj)
         if type.is_a?(PointerType)
-          element_type = guess_type(node.args[1])
-          if element_type
+          if element_type = guess_type(node.args[1])
             return @program.pointer_of(element_type)
           end
         end
       end
-      nil
     end
 
     def guess_type_call_lib_fun(node)
@@ -649,7 +638,6 @@ module Crystal
           return external_type
         end
       end
-      nil
     end
 
     # Guess type from T.method, where T is a Path and
@@ -777,8 +765,7 @@ module Crystal
 
       if args = @args
         # Find an argument with the same name as this variable
-        arg = args.find { |arg| arg.name == node.name }
-        if arg
+        if arg = args.find { |arg| arg.name == node.name }
           # If the argument has a restriction, guess the type from it
           if restriction = arg.restriction
             type = lookup_type?(restriction)
@@ -794,8 +781,7 @@ module Crystal
 
       # Try to guess type from a block argument with the same name
       if (block_arg = @block_arg) && block_arg.name == node.name
-        restriction = block_arg.restriction
-        if restriction
+        if restriction = block_arg.restriction
           type = lookup_type?(restriction)
           return type if type
         else
@@ -803,8 +789,6 @@ module Crystal
           return @program.proc_of([@program.void] of Type)
         end
       end
-
-      nil
     end
 
     def guess_type(node : InstanceVar)
@@ -953,7 +937,6 @@ module Crystal
     end
 
     def guess_type(node : ASTNode)
-      nil
     end
 
     def check_has_self(node)

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -479,10 +479,10 @@ module Crystal
         end
       elsif node_of = node.of
         key_type = lookup_type?(node_of.key)
-        return nil unless key_type
+        return unless key_type
 
         value_type = lookup_type?(node_of.value)
-        return nil unless value_type
+        return unless value_type
 
         return program.hash_of(key_type.virtual_type, value_type.virtual_type)
       else
@@ -533,7 +533,7 @@ module Crystal
       element_types = nil
       node.elements.each do |element|
         element_type = guess_type(element)
-        return nil unless element_type
+        return unless element_type
 
         element_types ||= [] of Type
         element_types << element_type
@@ -550,7 +550,7 @@ module Crystal
       entries = nil
       node.entries.each do |entry|
         element_type = guess_type(entry.value)
-        return nil unless element_type
+        return unless element_type
 
         entries ||= [] of NamedArgumentType
         entries << NamedArgumentType.new(entry.key, element_type)
@@ -663,11 +663,11 @@ module Crystal
     # (use the type annotation)
     def guess_type_call_with_type_annotation(node)
       obj = node.obj
-      return nil unless obj
-      return nil unless obj.is_a?(Path) || obj.is_a?(Generic)
+      return unless obj
+      return unless obj.is_a?(Path) || obj.is_a?(Generic)
 
       obj_type = lookup_type_no_check?(obj)
-      return nil unless obj_type
+      return unless obj_type
 
       guess_type_from_method(obj_type, node)
     end
@@ -717,14 +717,14 @@ module Crystal
 
       # If we only have one def, check the body, we might be
       # able to infer something from it if it's sufficiently simple
-      return nil unless defs.size == 1
+      return unless defs.size == 1
 
       a_def = defs.first
       body = a_def.body
 
       # Prevent infinite recursion
       if @methods_being_checked.any? &.same?(a_def)
-        return nil
+        return
       end
 
       @methods_being_checked.push a_def
@@ -776,7 +776,7 @@ module Crystal
         if current_type.is_a?(NonGenericClassType)
           return current_type.virtual_type
         else
-          return nil
+          return
         end
       end
 
@@ -869,11 +869,11 @@ module Crystal
 
     def guess_type(node : Path)
       type = lookup_type_var?(node)
-      return nil unless type
+      return unless type
 
       if type.is_a?(Const)
         # Don't solve a constant we've already seen
-        return nil if @consts.includes?(type)
+        return if @consts.includes?(type)
 
         # Check if the const's value is actually an enum member
         if type.value.type?.try &.is_a?(EnumType)
@@ -902,7 +902,7 @@ module Crystal
       types = nil
       nodes.each do |node|
         type = guess_type(node)
-        return nil unless type
+        return unless type
 
         types ||= [] of Type
         types << type
@@ -1026,7 +1026,7 @@ module Crystal
 
     def lookup_type_var?(node, root = current_type)
       type_var = root.lookup_type_var?(node)
-      return nil unless type_var.is_a?(Type)
+      return unless type_var.is_a?(Type)
 
       check_allowed_in_generics(node, type_var)
       type_var
@@ -1041,7 +1041,7 @@ module Crystal
       # and as variables types, so we disallow them.
       if type && !type.allowed_in_generics?
         @error = Error.new(node, type)
-        return nil
+        return
       end
 
       case type

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -757,8 +757,9 @@ module Crystal
     end
 
     def guess_type(node : NilableCast)
-      type = lookup_type?(node.to)
-      type ? @program.nilable(type) : nil
+      if type = lookup_type?(node.to)
+        @program.nilable(type)
+      end
     end
 
     def guess_type(node : UninitializedVar)
@@ -856,7 +857,7 @@ module Crystal
         end
       end
 
-      types ? Type.merge!(types) : nil
+      Type.merge!(types) if types
     end
 
     def guess_type(node : Path)
@@ -882,8 +883,9 @@ module Crystal
     end
 
     def guess_type(node : Expressions)
-      last = node.expressions.last?
-      last ? guess_type(last) : nil
+      if last = node.expressions.last?
+        guess_type(last)
+      end
     end
 
     def guess_type_in_method_body(node : Expressions)
@@ -911,7 +913,7 @@ module Crystal
       end
 
       type_var = process_assign(node)
-      type_var.is_a?(Type) ? type_var : nil
+      type_var if type_var.is_a?(Type)
     end
 
     def guess_type(node : Not)

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -97,8 +97,6 @@ class Crystal::Type
 
       if @raise
         raise_undefined_constant(node)
-      else
-        nil
       end
     end
 
@@ -108,8 +106,6 @@ class Crystal::Type
 
       if @raise
         raise_undefined_constant(node)
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -87,7 +87,7 @@ class Crystal::Type
         if @raise
           node.raise "#{type_var} is not a type, it's a constant"
         else
-          return nil
+          return
         end
       when Type
         return type_var

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -5,7 +5,7 @@ module Crystal
     def type_merge(types : Array(Type?))
       case types.size
       when 0
-        return nil
+        return
       when 1
         return types.first
       when 2
@@ -21,7 +21,7 @@ module Crystal
     def type_merge(nodes : Array(ASTNode))
       case nodes.size
       when 0
-        return nil
+        return
       when 1
         return nodes.first.type?
       when 2
@@ -283,7 +283,7 @@ module Crystal
 
   class TupleInstanceType
     def common_ancestor(other : TupleInstanceType)
-      return nil unless self.size == other.size
+      return unless self.size == other.size
 
       result_types = tuple_types.map_with_index do |self_tuple_type, index|
         Type.merge!(self_tuple_type, other.tuple_types[index]).as(Type)
@@ -294,14 +294,14 @@ module Crystal
 
   class NamedTupleInstanceType
     def common_ancestor(other : NamedTupleInstanceType)
-      return nil if self.size != other.size
+      return if self.size != other.size
 
       self_entries = self.entries.sort_by &.name
       other_entries = other.entries.sort_by &.name
 
       # First check if the names are the same
       self_entries.zip(other_entries) do |self_entry, other_entry|
-        return nil unless self_entry.name == other_entry.name
+        return unless self_entry.name == other_entry.name
       end
 
       # If the names are the same we now merge the types for each key
@@ -321,12 +321,12 @@ end
 private def class_common_ancestor(t1, t2)
   # This discards Object, Reference and Value
   if t1.depth <= 1
-    return nil
+    return
   end
 
   case t1
   when t1.program.struct, t1.program.number, t1.program.int, t1.program.float
-    return nil
+    return
   when t2
     return t1
   end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -172,8 +172,6 @@ module Crystal
     def common_ancestor(other : Type)
       if other.implements?(self)
         self
-      else
-        nil
       end
     end
   end
@@ -182,8 +180,6 @@ module Crystal
     def common_ancestor(other : Type)
       if other.implements?(self)
         self
-      else
-        nil
       end
     end
   end
@@ -192,8 +188,6 @@ module Crystal
     def common_ancestor(other : Type)
       if other.implements?(self)
         self
-      else
-        nil
       end
     end
   end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -164,7 +164,6 @@ module Crystal
     end
 
     def common_ancestor(other)
-      nil
     end
   end
 
@@ -244,7 +243,6 @@ module Crystal
 
   class PrimitiveType
     def common_ancestor(other)
-      nil
     end
   end
 
@@ -270,8 +268,6 @@ module Crystal
       if other.return_type.no_return? && arg_types == other.arg_types
         return self
       end
-
-      nil
     end
   end
 
@@ -330,19 +326,15 @@ private def class_common_ancestor(t1, t2)
     t2_superclass = t2.superclass
 
     if t1_superclass && t2_superclass
-      return t1_superclass.common_ancestor(t2_superclass)
+      t1_superclass.common_ancestor(t2_superclass)
     end
   elsif t1.depth > t2.depth
-    t1_superclass = t1.superclass
-    if t1_superclass
-      return t1_superclass.common_ancestor(t2)
+    if t1_superclass = t1.superclass
+      t1_superclass.common_ancestor(t2)
     end
   elsif t1.depth < t2.depth
-    t2_superclass = t2.superclass
-    if t2_superclass
-      return t1.common_ancestor(t2_superclass)
+    if t2_superclass = t2.superclass
+      t1.common_ancestor(t2_superclass)
     end
   end
-
-  nil
 end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -26,8 +26,6 @@ class Crystal::Location
       self
     when VirtualFile
       filename.expanded_location.try &.original_location
-    else
-      nil
     end
   end
 
@@ -57,8 +55,6 @@ class Crystal::Location
     other_file = other.filename
     if self_file.is_a?(String) && other_file.is_a?(String) && self_file == other_file
       {@line_number, @column_number} <=> {other.line_number, other.column_number}
-    else
-      nil
     end
   end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3051,7 +3051,7 @@ module Crystal
 
           return MacroIf.new(BoolLiteral.new(true), body).at_end(token_end_location)
         when :else, :elsif, :end
-          return nil
+          return
         end
       end
 
@@ -4086,37 +4086,37 @@ module Crystal
       @call_args_nest += 1
 
       if @token.keyword?(:end) && !next_comes_colon_space?
-        return nil
+        return
       end
 
       case @token.type
       when :"&"
-        return nil if current_char.ascii_whitespace?
+        return if current_char.ascii_whitespace?
       when :"+", :"-"
         if check_plus_and_minus
-          return nil if current_char.ascii_whitespace?
+          return if current_char.ascii_whitespace?
         end
       when :"{"
-        return nil unless allow_curly
+        return unless allow_curly
       when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"~", :"->", :"{{", :__LINE__, :__END_LINE__, :__FILE__, :__DIR__, :UNDERSCORE
         # Nothing
       when :"*", :"**"
         if current_char.ascii_whitespace?
-          return nil
+          return
         end
       when :"::"
         if current_char.ascii_whitespace?
-          return nil
+          return
         end
       else
-        return nil
+        return
       end
 
       case @token.value
       when :if, :unless, :while, :until, :rescue, :ensure
-        return nil unless next_comes_colon_space?
+        return unless next_comes_colon_space?
       when :yield
-        return nil if @stop_on_yield > 0 && !next_comes_colon_space?
+        return if @stop_on_yield > 0 && !next_comes_colon_space?
       end
 
       args = [] of ASTNode

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4073,8 +4073,6 @@ module Crystal
         end
 
         parse_call_args_space_consumed check_plus_and_minus: true, allow_curly: allow_curly, control: control
-      else
-        nil
       end
     ensure
       @call_args_nest -= 1

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -230,14 +230,14 @@ class Crystal::Doc::Generator
 
   def summary(obj : Type | Method | Macro | Constant)
     doc = obj.doc
-    return nil unless doc
+    return unless doc
 
     summary obj, doc
   end
 
   def summary(context, string)
     line = fetch_doc_lines(string).lines.first?
-    return nil unless line
+    return unless line
 
     dot_index = line =~ /\.($|\s)/
     if dot_index
@@ -249,7 +249,7 @@ class Crystal::Doc::Generator
 
   def doc(obj : Type | Method | Macro | Constant)
     doc = obj.doc
-    return nil unless doc
+    return unless doc
 
     doc obj, doc
   end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -56,8 +56,6 @@ class Crystal::Doc::Type
     case type = @type
     when GenericType
       type.type_vars
-    else
-      nil
     end
   end
 
@@ -91,8 +89,6 @@ class Crystal::Doc::Type
 
     if superclass
       @generator.type(superclass)
-    else
-      nil
     end
   end
 

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -63,8 +63,6 @@ module Crystal
 
       if f.is_a?(VirtualFile)
         f.expanded_location
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -214,7 +214,7 @@ module Crystal
       def overwrite_checks
         overwriting_files = views.compact_map do |view|
           path = view.full_path
-          File.exists?(path) ? path : nil
+          path if File.exists?(path)
         end
 
         if overwriting_files.any?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -11,12 +11,10 @@ module Crystal
 
     # Returns any doc comments associated to this type.
     def doc : String?
-      nil
     end
 
     # Returns all locations where this type is declared
     def locations : Array(Location)?
-      nil
     end
 
     # Returns `true` if this type has the give attribute.
@@ -83,13 +81,11 @@ module Crystal
     # Returns the methods defined in this type, indexed by their name.
     # This does not include methods defined in ancestors.
     def defs : Hash(String, Array(DefWithMetadata))?
-      nil
     end
 
     # Returns all macros defines in this type, indexed by their name.
     # This does not inlcude methods defined in ancestors.
     def macros : Hash(String, Array(Macro))?
-      nil
     end
 
     # Returns this type's metaclass, which holds class methods for this type.
@@ -275,7 +271,6 @@ module Crystal
     end
 
     def filter_by_responds_to(name)
-      nil
     end
 
     def add_instance_var_initializer(name, value, meta_vars)
@@ -296,11 +291,9 @@ module Crystal
     end
 
     def types?
-      nil
     end
 
     def parents
-      nil
     end
 
     def ancestors
@@ -318,7 +311,6 @@ module Crystal
 
     # Returns this type's superclass, or `nil` if it doesn't have one
     def superclass : Type?
-      nil
     end
 
     def lookup_defs(name : String, lookup_ancestors_for_new : Bool = false)
@@ -415,8 +407,6 @@ module Crystal
         parent_macro = parent.lookup_macro(name, args, named_args)
         return parent_macro if parent_macro
       end
-
-      nil
     end
 
     # Looks up macros with the given name. Returns:
@@ -443,8 +433,6 @@ module Crystal
         parent_macros = parent.lookup_macros(name)
         return parent_macros if parent_macros
       end
-
-      nil
     end
 
     def add_including_type(mod)
@@ -507,7 +495,6 @@ module Crystal
     end
 
     def lookup_class_var?(name)
-      nil
     end
 
     def lookup_class_var(name)
@@ -561,7 +548,6 @@ module Crystal
     end
 
     def splat_index
-      nil
     end
 
     def type_vars
@@ -2939,10 +2925,8 @@ module Crystal
         var.initializer = class_var.initializer
         var.bind_to(class_var)
         self.class_vars[name] = var
-        return var
+        var
       end
-
-      nil
     end
 
     def replace_type_parameters(instance)
@@ -3005,10 +2989,8 @@ module Crystal
         var.initializer = class_var.initializer
         var.bind_to(class_var)
         self.class_vars[name] = var
-        return var
+        var
       end
-
-      nil
     end
 
     def implements?(other : VirtualMetaclassType)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -490,8 +490,6 @@ module Crystal
           index = instance_vars.key_index(name)
           if index
             superclass.all_instance_vars_count + index
-          else
-            nil
           end
         end
       else
@@ -962,8 +960,6 @@ module Crystal
         all_types = Array(Type).new(including_types.size)
         add_to_including_types(all_types)
         program.type_merge_union_of(all_types)
-      else
-        nil
       end
     end
 
@@ -1830,8 +1826,6 @@ module Crystal
         all_types = Array(Type).new(including_types.size)
         add_to_including_types(all_types)
         program.type_merge_union_of(all_types)
-      else
-        nil
       end
     end
 
@@ -2330,8 +2324,6 @@ module Crystal
       process_value
       if aliased_type = @aliased_type
         aliased_type.types?
-      else
-        nil
       end
     end
 
@@ -2557,8 +2549,6 @@ module Crystal
     def filter_by_responds_to(name)
       if instance_type.generic_type.metaclass.filter_by_responds_to(name)
         self
-      else
-        nil
       end
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -804,7 +804,7 @@ module Crystal
     end
 
     def filter_by_responds_to(name)
-      has_def?(name) ? self : nil
+      self if has_def?(name)
     end
 
     def include(mod)
@@ -1772,7 +1772,7 @@ module Crystal
       splat_index, double_variadic?, to: @generic_type
 
     def filter_by_responds_to(name)
-      @generic_type.filter_by_responds_to(name) ? self : nil
+      self if @generic_type.filter_by_responds_to(name)
     end
 
     def class?
@@ -1854,7 +1854,7 @@ module Crystal
     end
 
     def filter_by_responds_to(name)
-      @generic_type.filter_by_responds_to(name) ? self : nil
+      self if @generic_type.filter_by_responds_to(name)
     end
 
     def module?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -753,7 +753,7 @@ module Crystal
             return ex_item.def
           else
             list.insert(i, item)
-            return nil
+            return
           end
         end
       end
@@ -2187,14 +2187,14 @@ module Crystal
 
     def implements?(other)
       if other.is_a?(NamedTupleInstanceType)
-        return nil unless self.size == other.size
+        return unless self.size == other.size
 
         self_entries = self.entries.sort_by &.name
         other_entries = other.entries.sort_by &.name
 
         self_entries.zip(other_entries) do |self_entry, other_entry|
-          return nil unless self_entry.name == other_entry.name
-          return nil unless self_entry.type.implements?(other_entry.type)
+          return unless self_entry.name == other_entry.name
+          return unless self_entry.type.implements?(other_entry.type)
         end
 
         self
@@ -2277,10 +2277,10 @@ module Crystal
 
     def lookup_var(name)
       a_def = lookup_first_def(name, false)
-      return nil unless a_def
+      return unless a_def
 
       body = a_def.body
-      return nil unless body.is_a?(Primitive) && body.name == "external_var_get"
+      return unless body.is_a?(Primitive) && body.name == "external_var_get"
 
       a_def
     end

--- a/src/concurrent/channel.cr
+++ b/src/concurrent/channel.cr
@@ -28,11 +28,10 @@ abstract class Channel(T)
     Buffered(T).new(capacity)
   end
 
-  def close
+  def close : Nil
     @closed = true
     Scheduler.enqueue @receivers
     @receivers.clear
-    nil
   end
 
   def closed?
@@ -83,13 +82,12 @@ abstract class Channel(T)
     self.select(channels.map(&.receive_select_action))[1]
   end
 
-  def self.send_first(value, *channels)
+  def self.send_first(value, *channels) : Nil
     send_first value, channels
   end
 
-  def self.send_first(value, channels : Tuple | Array)
+  def self.send_first(value, channels : Tuple | Array) : Nil
     self.select(channels.map(&.send_select_action(value)))
-    nil
   end
 
   def self.select(*ops : SelectAction)

--- a/src/concurrent/channel.cr
+++ b/src/concurrent/channel.cr
@@ -44,7 +44,7 @@ abstract class Channel(T)
   end
 
   def receive?
-    receive_impl { return nil }
+    receive_impl { return }
   end
 
   def inspect(io)

--- a/src/concurrent/future.cr
+++ b/src/concurrent/future.cr
@@ -56,12 +56,11 @@ class Concurrent::Future(R)
     @state == State::Idle
   end
 
-  def cancel(msg = "Future canceled, you reached the [End of Time]")
+  def cancel(msg = "Future canceled, you reached the [End of Time]") : Nil
     return if @state >= State::Completed
     @state = State::Canceled
     @cancel_msg = msg
     @channel.close
-    nil
   end
 
   private def compute

--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -5,13 +5,12 @@ class Scheduler
   @@runnables = Deque(Fiber).new
   @@eb = Event::Base.new
 
-  def self.reschedule
+  def self.reschedule : Nil
     if runnable = @@runnables.shift?
       runnable.resume
     else
       loop_fiber.resume
     end
-    nil
   end
 
   def self.loop_fiber

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -291,8 +291,7 @@ struct Crystal::Hasher
     value.crystal_type_id.hash(self)
   end
 
-  def inspect(io)
+  def inspect(io) : Nil
     io << "#{self.class}(hidden_state)"
-    nil
   end
 end

--- a/src/crystal/system/unix/dir.cr
+++ b/src/crystal/system/unix/dir.cr
@@ -15,8 +15,6 @@ module Crystal::System::Dir
       String.new(entry.value.d_name.to_unsafe)
     elsif Errno.value != 0
       raise Errno.new("readdir")
-    else
-      nil
     end
   end
 

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -196,13 +196,11 @@ module Crystal::System::File
     flock LibC::FlockOp::UN
   end
 
-  private def flock(op : LibC::FlockOp, blocking : Bool = true)
+  private def flock(op : LibC::FlockOp, blocking : Bool = true) : Nil
     op |= LibC::FlockOp::NB unless blocking
 
     if LibC.flock(@fd, op) != 0
       raise Errno.new("flock")
     end
-
-    nil
   end
 end

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -73,7 +73,7 @@ module Crystal::System::File
   def self.stat?(path : String) : ::File::Stat?
     if LibC.stat(path.check_no_null_byte, out stat) != 0
       if {Errno::ENOENT, Errno::ENOTDIR}.includes? Errno.value
-        return nil
+        return
       else
         raise Errno.new("Unable to get stat for '#{path}'")
       end
@@ -84,7 +84,7 @@ module Crystal::System::File
   def self.lstat?(path : String) : ::File::Stat?
     if LibC.lstat(path.check_no_null_byte, out stat) != 0
       if {Errno::ENOENT, Errno::ENOTDIR}.includes? Errno.value
-        return nil
+        return
       else
         raise Errno.new("Unable to get lstat for '#{path}'")
       end

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -155,6 +155,5 @@ module Crystal::System::Time
   # and returns the English name.
   private def self.translate_zone_name(stdname, dstname)
     # TODO: Needs implementation once there is access to the registry.
-    nil
   end
 end

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -371,7 +371,6 @@ class CSV
           return maybe_strip(@row[i]? || "")
         end
       end
-      nil
     end
 
     # Returns the number of columns in this row, regardless of the number

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -328,8 +328,6 @@ class CSV
       index = csv.indices[header]?
       if index
         maybe_strip(@row[index]? || "")
-      else
-        nil
       end
     end
 

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -350,7 +350,7 @@ class CSV
 
       value = @row[column]?
       value ||= "" if 0 <= column < size
-      value ? maybe_strip(value) : nil
+      maybe_strip(value) if value
     end
 
     # Returns this row's value corresponding to the given *header_pattern*.

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -35,7 +35,7 @@ class CSV::Parser
   def next_row : Array(String) | Nil
     token = @lexer.next_token
     if token.kind == Token::Kind::Eof
-      return nil
+      return
     end
 
     row = Array(String).new(@max_row_size)
@@ -47,7 +47,7 @@ class CSV::Parser
   def next_row(array : Array(String)) : Array(String) | Nil
     token = @lexer.next_token
     if token.kind == Token::Kind::Eof
-      return nil
+      return
     end
 
     next_row_internal(token, array)

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -207,8 +207,6 @@ module Debug
             end
           end
         end
-
-        nil
       end
 
       # Decodes the compressed matrix of addresses to line numbers.

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -112,7 +112,6 @@ struct Enum
     {% else %}
       io << to_s
     {% end %}
-    nil
   end
 
   # Returns a `String` representation of this enum member.
@@ -349,7 +348,6 @@ struct Enum
         return {{@type}}::{{member}} if {{@type}}::{{member}}.value == value
       {% end %}
     {% end %}
-    nil
   end
 
   # Returns the enum member that has the given value, or raises
@@ -408,8 +406,6 @@ struct Enum
         when {{member.stringify.camelcase.downcase}}
           {{@type}}::{{member}}
       {% end %}
-      else
-        nil
       end
     {% end %}
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -311,11 +311,11 @@ module Enumerable(T)
   #
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
-  def each_slice(count : Int, reuse = false)
+  def each_slice(count : Int, reuse = false) : Nil
     each_slice_internal(count, Array(T), reuse) { |slice| yield slice }
   end
 
-  private def each_slice_internal(count : Int, type, reuse)
+  private def each_slice_internal(count : Int, type, reuse) : Nil
     if reuse
       unless reuse.is_a?(Array)
         reuse = type.new(count)
@@ -339,7 +339,6 @@ module Enumerable(T)
       end
     end
     yield slice unless slice.empty?
-    nil
   end
 
   # Iterates over the collection, yielding both the elements and their index.

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -731,7 +731,7 @@ module Enumerable(T)
   # Like `max_by` but returns `nil` if the collection is empty.
   def max_by?(&block : T -> U) forall U
     found, value = max_by_internal { |value| yield value }
-    found ? value : nil
+    value if found
   end
 
   private def max_by_internal(&block : T -> U) forall U
@@ -765,7 +765,7 @@ module Enumerable(T)
   # Like `max_of` but returns `nil` if the collection is empty.
   def max_of?(&block : T -> U) forall U
     found, value = max_of_internal { |value| yield value }
-    found ? value : nil
+    value if found
   end
 
   private def max_of_internal(&block : T -> U) forall U
@@ -820,7 +820,7 @@ module Enumerable(T)
   # Like `min_by` but returns `nil` if the collection is empty.
   def min_by?(&block : T -> U) forall U
     found, value = min_by_internal { |value| yield value }
-    found ? value : nil
+    value if found
   end
 
   private def min_by_internal(&block : T -> U) forall U
@@ -854,7 +854,7 @@ module Enumerable(T)
   # Like `min_of` but returns `nil` if the collection is empty.
   def min_of?(&block : T -> U) forall U
     found, value = min_of_internal { |value| yield value }
-    found ? value : nil
+    value if found
   end
 
   private def min_of_internal(&block : T -> U) forall U

--- a/src/env.cr
+++ b/src/env.cr
@@ -97,8 +97,6 @@ module ENV
     if value = self[key]?
       LibC.unsetenv(key)
       value
-    else
-      nil
     end
   end
 

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -116,11 +116,10 @@ module GC
     # Nothing
   end
 
-  private def self.add_finalizer_impl(object : T) forall T
+  private def self.add_finalizer_impl(object : T) : Nil forall T
     LibGC.register_finalizer_ignore_self(object.as(Void*),
       ->(obj, data) { obj.as(T).finalize },
       nil, nil, nil)
-    nil
   end
 
   def self.add_root(object : Reference)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -833,7 +833,7 @@ class Hash(K, V)
   end
 
   protected def find_entry(key)
-    return nil if empty?
+    return if empty?
 
     index = bucket_index key
     entry = @buckets[index]
@@ -846,7 +846,7 @@ class Hash(K, V)
       while entry
         if entry.key == key
           entry.value = value
-          return nil
+          return
         end
         if entry.next
           entry = entry.next

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -424,7 +424,6 @@ class Hash(K, V)
     each_with_index do |(my_key, my_value), index|
       return index if key == my_key
     end
-    nil
   end
 
   # Returns a new `Hash` with the keys and values of this hash and *other* combined.
@@ -866,7 +865,6 @@ class Hash(K, V)
       end
       entry = entry.next
     end
-    nil
   end
 
   private def bucket_index(key)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -121,8 +121,6 @@ class HTTP::Client
                OpenSSL::SSL::Context::Client.new
              when OpenSSL::SSL::Context::Client
                tls
-             when false
-               nil
              end
 
       @port = (port || (@tls ? 443 : 80)).to_i

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -97,7 +97,7 @@ class HTTP::Client::Response
         response.consume_body_io
         return response
       else
-        return nil
+        return
       end
     end
   end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -166,7 +166,7 @@ module HTTP
   # :nodoc:
   def self.content_length(headers)
     length_headers = headers.get? "Content-Length"
-    return nil unless length_headers
+    return unless length_headers
     first_header = length_headers[0]
     if length_headers.size > 1 && length_headers.any? { |header| header != first_header }
       raise ArgumentError.new("Multiple Content-Length headers received did not match: #{length_headers}")

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -94,7 +94,7 @@ module HTTP
       while true
         if @chunk_remaining > 0
           peek = @io.peek
-          return nil unless peek
+          return unless peek
 
           if @chunk_remaining < peek.size
             peek = peek[0, @chunk_remaining]

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -67,8 +67,9 @@ struct HTTP::Headers
   end
 
   def []?(key)
-    values = @hash[wrap(key)]?
-    values ? concat(values) : nil
+    if values = @hash[wrap(key)]?
+      concat(values)
+    end
   end
 
   # Returns if among the headers for *key* there is some that contains *word* as a value.
@@ -148,8 +149,9 @@ struct HTTP::Headers
   end
 
   def delete(key)
-    values = @hash.delete wrap(key)
-    values ? concat(values) : nil
+    if values = @hash.delete wrap(key)
+      concat(values)
+    end
   end
 
   def merge!(other)

--- a/src/http/multipart.cr
+++ b/src/http/multipart.cr
@@ -37,7 +37,7 @@ module HTTP::Multipart
   def self.parse_boundary(content_type)
     # TODO: remove regex
     match = content_type.match(/\Amultipart\/.*boundary="?([^";,]+)"?/i)
-    return nil unless match
+    return unless match
     HTTP.dequote_string(match[1])
   end
 
@@ -61,10 +61,10 @@ module HTTP::Multipart
   # See: `Multipart::Parser`
   def self.parse(request : HTTP::Request)
     boundary = parse_boundary(request.headers["Content-Type"])
-    return nil unless boundary
+    return unless boundary
 
     body = request.body
-    return nil unless body
+    return unless body
     parse(body, boundary) { |headers, io| yield headers, io }
   end
 

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -49,7 +49,7 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.pointer(count), count)
       @pos += count
@@ -61,8 +61,6 @@ class HTTP::WebSocket::Protocol
       if count < slice.size
         write(slice + count)
       end
-
-      nil
     end
 
     def read(slice : Bytes)

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -299,7 +299,7 @@ module Indexable(T)
   # ```
   def index(offset : Int = 0)
     offset += size if offset < 0
-    return nil if offset < 0
+    return if offset < 0
 
     offset.upto(size - 1) do |i|
       if yield unsafe_at(i)
@@ -378,7 +378,7 @@ module Indexable(T)
   # ```
   def rindex(offset = size - 1)
     offset += size if offset < 0
-    return nil if offset >= size
+    return if offset >= size
 
     offset.downto(0) do |i|
       if yield unsafe_at(i)

--- a/src/io.cr
+++ b/src/io.cr
@@ -209,7 +209,6 @@ abstract class IO
   # ```
   def print(obj) : Nil
     self << obj
-    nil
   end
 
   # Writes the given objects into this `IO` by invoking `to_s(io)`
@@ -224,7 +223,6 @@ abstract class IO
     objects.each do |obj|
       print obj
     end
-    nil
   end
 
   # Writes the given string to this `IO` followed by a newline character
@@ -239,7 +237,6 @@ abstract class IO
   def puts(string : String) : Nil
     self << string
     puts unless string.ends_with?('\n')
-    nil
   end
 
   # Writes the given object to this `IO` followed by a newline character.
@@ -264,7 +261,6 @@ abstract class IO
   # ```
   def puts : Nil
     print '\n'
-    nil
   end
 
   # Writes the given objects, each followed by a newline character.
@@ -278,7 +274,6 @@ abstract class IO
     objects.each do |obj|
       puts obj
     end
-    nil
   end
 
   def printf(format_string, *args) : Nil
@@ -288,7 +283,6 @@ abstract class IO
   # ditto
   def printf(format_string, args : Array | Tuple) : Nil
     String::Formatter(typeof(args)).new(format_string, args, self).format
-    nil
   end
 
   # Reads a single byte from this `IO`. Returns `nil` if there is no more
@@ -480,17 +474,15 @@ abstract class IO
   # that provide buffering or wrap other IOs should override
   # this method.
   def peek : Bytes?
-    nil
   end
 
   # Writes a slice of UTF-8 encoded bytes to this `IO`, using the current encoding.
-  def write_utf8(slice : Bytes)
+  def write_utf8(slice : Bytes) : Nil
     if encoder = encoder()
       encoder.write(self, slice)
     else
       write(slice)
     end
-    nil
   end
 
   private def encoder
@@ -1028,7 +1020,7 @@ abstract class IO
   #
   # String operations (`gets`, `gets_to_end`, `read_char`, `<<`, `print`, `puts`
   # `printf`) will use this encoding.
-  def set_encoding(encoding : String, invalid : Symbol? = nil)
+  def set_encoding(encoding : String, invalid : Symbol? = nil) : Nil
     if (encoding == "UTF-8") && (invalid != :skip)
       @encoding = nil
     else
@@ -1038,7 +1030,6 @@ abstract class IO
     @decoder.try &.close
     @encoder = nil
     @decoder = nil
-    nil
   end
 
   # Returns this `IO`'s encoding. The default is `UTF-8`.

--- a/src/io.cr
+++ b/src/io.cr
@@ -303,8 +303,6 @@ abstract class IO
     byte = uninitialized UInt8
     if read(Slice.new(pointerof(byte), 1)) == 1
       byte
-    else
-      nil
     end
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -326,7 +326,7 @@ abstract class IO
     # If so, this will be faster than reading byte per byte.
     if !decoder && (peek = self.peek)
       if peek.empty?
-        return nil
+        return
       else
         return read_char_with_bytesize_peek(peek)
       end
@@ -362,7 +362,7 @@ abstract class IO
 
   private def read_char_with_bytesize_slow
     first = read_utf8_byte
-    return nil unless first
+    return unless first
 
     first = first.to_u32
     return first.unsafe_chr, 1 if first < 0x80
@@ -539,7 +539,7 @@ abstract class IO
     count = slice.size
     while slice.size > 0
       read_bytes = read slice
-      return nil if read_bytes == 0
+      return if read_bytes == 0
       slice += read_bytes
     end
     count
@@ -705,7 +705,7 @@ abstract class IO
 
         if !peek || peek.empty?
           if buffer.bytesize == 0
-            return nil
+            return
           else
             break
           end

--- a/src/io.cr
+++ b/src/io.cr
@@ -315,8 +315,9 @@ abstract class IO
   # io.read_char # => nil
   # ```
   def read_char : Char?
-    info = read_char_with_bytesize
-    info ? info[0] : nil
+    if info = read_char_with_bytesize
+      info[0]
+    end
   end
 
   private def read_char_with_bytesize

--- a/src/io.cr
+++ b/src/io.cr
@@ -496,16 +496,12 @@ abstract class IO
   private def encoder
     if encoding = @encoding
       @encoder ||= Encoder.new(encoding)
-    else
-      nil
     end
   end
 
   private def decoder
     if encoding = @encoding
       @decoder ||= Decoder.new(encoding)
-    else
-      nil
     end
   end
 

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -49,8 +49,6 @@ class IO::ARGF < IO
     if !@read_from_stdin && !@argv.empty?
       read_next_argv
       self.peek
-    else
-      nil
     end
   end
 

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -103,7 +103,7 @@ module IO::Buffered
   end
 
   # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_open
 
     count = slice.size
@@ -134,11 +134,10 @@ module IO::Buffered
 
     slice.copy_to(out_buffer + @out_count, count)
     @out_count += count
-    nil
   end
 
   # :nodoc:
-  def write_byte(byte : UInt8)
+  def write_byte(byte : UInt8) : Nil
     check_open
 
     if sync?

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -160,7 +160,7 @@ class IO
 
     def gets(io, delimiter : UInt8, limit : Int, chomp)
       read(io)
-      return nil if @out_slice.empty?
+      return if @out_slice.empty?
 
       index = @out_slice.index(delimiter)
       if index

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,7 +82,7 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_writeable
     check_open
 
@@ -104,13 +104,11 @@ class IO::Memory < IO
 
     @pos += count
     @bytesize = @pos if @pos > @bytesize
-
-    nil
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write_byte(byte : UInt8)
+  def write_byte(byte : UInt8) : Nil
     check_writeable
     check_open
 
@@ -128,8 +126,6 @@ class IO::Memory < IO
 
     @pos += 1
     @bytesize = @pos if @pos > @bytesize
-
-    nil
   end
 
   # :nodoc:

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -149,7 +149,7 @@ class IO::Memory < IO
       end
     else
       index = @bytesize - @pos
-      return nil if index == 0
+      return if index == 0
 
       if index >= limit
         index = limit

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -41,8 +41,6 @@ class IO::Sized < IO
       byte = @io.read_byte
       @read_remaining -= 1 if byte
       byte
-    else
-      nil
     end
   end
 

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -52,7 +52,7 @@ class IO::Sized < IO
     return Bytes.empty if @read_remaining == 0 # EOF
 
     peek = @io.peek
-    return nil unless peek
+    return unless peek
 
     if @read_remaining < peek.size
       peek = peek[0, @read_remaining]

--- a/src/io/syscall.cr
+++ b/src/io/syscall.cr
@@ -99,11 +99,11 @@ module IO::Syscall
     end
   end
 
-  private def wait_readable(timeout = @read_timeout)
+  private def wait_readable(timeout = @read_timeout) : Nil
     wait_readable(timeout: timeout) { |err| raise err }
   end
 
-  private def wait_readable(timeout = @read_timeout)
+  private def wait_readable(timeout = @read_timeout) : Nil
     readers = (@readers ||= Deque(Fiber).new)
     readers << Fiber.current
     add_read_event(timeout)
@@ -113,17 +113,15 @@ module IO::Syscall
       @read_timed_out = false
       yield Timeout.new("Read timed out")
     end
-
-    nil
   end
 
   private abstract def add_read_event(timeout = @read_timeout)
 
-  private def wait_writable(timeout = @write_timeout)
+  private def wait_writable(timeout = @write_timeout) : Nil
     wait_writable(timeout: timeout) { |err| raise err }
   end
 
-  private def wait_writable(timeout = @write_timeout)
+  private def wait_writable(timeout = @write_timeout) : Nil
     writers = (@writers ||= Deque(Fiber).new)
     writers << Fiber.current
     add_write_event(timeout)
@@ -133,8 +131,6 @@ module IO::Syscall
       @write_timed_out = false
       yield Timeout.new("Write timed out")
     end
-
-    nil
   end
 
   private abstract def add_write_event(timeout = @write_timeout)

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -55,7 +55,6 @@ def Array.from_json(string_or_io) : Nil
   new(parser) do |element|
     yield element
   end
-  nil
 end
 
 def Nil.new(pull : JSON::PullParser)

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -92,10 +92,9 @@ class JSON::PullParser
     read_end_object
   end
 
-  def read_null
+  def read_null : Nil
     expect_kind :null
     read_next
-    nil
   end
 
   def read_bool

--- a/src/llvm/function_collection.cr
+++ b/src/llvm/function_collection.cr
@@ -22,8 +22,9 @@ struct LLVM::FunctionCollection
   end
 
   def []?(name)
-    func = LibLLVM.get_named_function(@mod, name)
-    func ? Function.new(func) : nil
+    if func = LibLLVM.get_named_function(@mod, name)
+      Function.new(func)
+    end
   end
 
   def each : Nil

--- a/src/llvm/global_collection.cr
+++ b/src/llvm/global_collection.cr
@@ -9,8 +9,9 @@ struct LLVM::GlobalCollection
   end
 
   def []?(name)
-    global = LibLLVM.get_named_global(@mod, name)
-    global ? Value.new(global) : nil
+    if global = LibLLVM.get_named_global(@mod, name)
+      Value.new(global)
+    end
   end
 
   def [](name)

--- a/src/llvm/instruction_collection.cr
+++ b/src/llvm/instruction_collection.cr
@@ -7,8 +7,9 @@ struct LLVM::InstructionCollection
   end
 
   def first?
-    value = llvm_first
-    value ? Value.new(value) : nil
+    if value = llvm_first
+      Value.new(value)
+    end
   end
 
   def first

--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -12,8 +12,9 @@ struct LLVM::Target
   end
 
   def self.first? : self?
-    target = LibLLVM.get_first_target
-    target ? Target.new(target) : nil
+    if target = LibLLVM.get_first_target
+      target
+    end
   end
 
   def self.from_triple(triple) : self

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -69,8 +69,9 @@ struct LLVM::Type
   def struct_name : String?
     raise "not a Struct" unless kind == Kind::Struct
 
-    name = LibLLVM.get_struct_name(self)
-    name ? String.new(name) : nil
+    if name = LibLLVM.get_struct_name(self)
+      String.new(name)
+    end
   end
 
   def struct_element_types

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -71,8 +71,9 @@ module LLVM::ValueMethods
   end
 
   def initializer
-    init = LibLLVM.get_initializer(self)
-    init ? LLVM::Value.new(init) : nil
+    if init = LibLLVM.get_initializer(self)
+      LLVM::Value.new(init)
+    end
   end
 
   def volatile=(volatile)

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -92,8 +92,6 @@ class Markdown::Parser
     if next_line_is_all?('-')
       return :header2
     end
-
-    nil
   end
 
   def render_prefix_header(level, line)

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -445,13 +445,13 @@ class Markdown::Parser
       pos += 1
     end
 
-    return nil unless bracket_count == 0
+    return unless bracket_count == 0
     bracket_idx = pos
 
-    return nil unless str[bracket_idx + 1] === '('
+    return unless str[bracket_idx + 1] === '('
 
     paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord
-    return nil unless paren_idx
+    return unless paren_idx
 
     String.new(Slice.new(str + bracket_idx + 2, paren_idx - 1))
   end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -8,7 +8,7 @@ class Mutex
     @lock_count = 0
   end
 
-  def lock
+  def lock : Nil
     mutex_fiber = @mutex_fiber
     current_fiber = Fiber.current
 
@@ -21,11 +21,9 @@ class Mutex
       queue << current_fiber
       Scheduler.reschedule
     end
-
-    nil
   end
 
-  def unlock
+  def unlock : Nil
     unless @mutex_fiber == Fiber.current
       raise "Attempt to unlock a mutex which is not locked"
     end
@@ -41,8 +39,6 @@ class Mutex
     else
       @mutex_fiber = nil
     end
-
-    nil
   end
 
   def synchronize

--- a/src/object.cr
+++ b/src/object.cr
@@ -55,7 +55,6 @@ class Object
   # Overridden by descendants (notably `Regex` and `String`) to provide meaningful
   # pattern-match semantics.
   def =~(other)
-    nil
   end
 
   # Appends this object's value to *hasher*, and returns the modified *hasher*.

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -108,8 +108,6 @@ class OpenSSL::Cipher
     if LibCrypto.evp_cipherinit_ex(@ctx, cipher, engine, key, iv, enc) != 1
       raise Error.new "EVP_CipherInit_ex"
     end
-
-    nil
   end
 
   private def cipher

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -104,7 +104,7 @@ abstract class OpenSSL::SSL::Socket < IO
     end
   end
 
-  def unbuffered_write(slice : Bytes)
+  def unbuffered_write(slice : Bytes) : Nil
     check_open
 
     count = slice.size
@@ -112,7 +112,6 @@ abstract class OpenSSL::SSL::Socket < IO
     unless bytes > 0
       raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_write")
     end
-    nil
   end
 
   def unbuffered_flush

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -302,7 +302,7 @@ class OptionParser
       index = @args.index { |arg| yield arg }
       if index
         if (double_dash_index = @double_dash_index) && index >= double_dash_index
-          return nil
+          return
         end
       end
       index

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -190,7 +190,7 @@ struct Proc
     self
   end
 
-  def to_s(io)
+  def to_s(io) : Nil
     io << "#<"
     io << {{@type.name.stringify}}
     io << ":0x"
@@ -199,6 +199,5 @@ struct Proc
       io << ":closure"
     end
     io << ">"
-    nil
   end
 end

--- a/src/process.cr
+++ b/src/process.cr
@@ -89,8 +89,6 @@ class Process
   def self.fork : self?
     if pid = fork_internal
       new pid
-    else
-      nil
     end
   end
 

--- a/src/process/executable_path.cr
+++ b/src/process/executable_path.cr
@@ -64,7 +64,7 @@ end
 
       if LibC._NSGetExecutablePath(buf, pointerof(size)) == -1
         buf = GC.malloc_atomic(size).as(UInt8*)
-        return nil if LibC._NSGetExecutablePath(buf, pointerof(size)) == -1
+        return if LibC._NSGetExecutablePath(buf, pointerof(size)) == -1
       end
 
       String.new(buf)

--- a/src/readline.cr
+++ b/src/readline.cr
@@ -45,8 +45,6 @@ module Readline
     if line
       LibReadline.add_history(line) if add_history
       String.new(line).tap { LibC.free(line.as(Void*)) }
-    else
-      nil
     end
   end
 

--- a/src/readline.cr
+++ b/src/readline.cr
@@ -55,7 +55,7 @@ module Readline
 
   def line_buffer
     line = LibReadline.rl_line_buffer
-    return nil unless line
+    return unless line
 
     String.new(line)
   end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -73,7 +73,6 @@ class Reference
       io << " ..."
     end
     io << ">"
-    nil
   end
 
   def pretty_print(pp) : Nil
@@ -109,7 +108,6 @@ class Reference
     io << "#<" << self.class.name << ":0x"
     object_id.to_s(16, io)
     io << ">"
-    nil
   end
 
   # :nodoc:

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -395,7 +395,6 @@ class Regex
   # /ax/ =~ "input data" # => nil
   # ```
   def =~(other)
-    nil
   end
 
   # Convert to `String` in literal format. Returns the source as a `String` in

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -202,7 +202,7 @@ class Regex
       match
     end
 
-    private def named_capture_number(group_name)
+    private def named_capture_number(group_name) : Nil
       name_entry_size = LibPCRE.get_stringtable_entries(@code, group_name, out first, out last)
       return if name_entry_size < 0
 
@@ -212,8 +212,6 @@ class Regex
 
         first += name_entry_size
       end
-
-      nil
     end
 
     # Returns the part of the original string before the match. If the match

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -376,7 +376,7 @@ struct Slice(T)
   end
 
   # :nodoc:
-  def hexstring(buffer)
+  def hexstring(buffer) : Nil
     self.as(Slice(UInt8))
 
     offset = 0
@@ -385,8 +385,6 @@ struct Slice(T)
       buffer[offset + 1] = to_hex(v & 0x0f)
       offset += 2
     end
-
-    nil
   end
 
   # Returns a hexdump of this slice, assuming it's a `Slice(UInt8)`.
@@ -528,13 +526,10 @@ struct Slice(T)
   def fast_index(object, offset)
     offset += size if offset < 0
     if 0 <= offset < size
-      result = LibC.memchr(to_unsafe + offset, object, size - offset)
-      if result
+      if result = LibC.memchr(to_unsafe + offset, object, size - offset)
         return (result - to_unsafe.as(Void*)).to_i32
       end
     end
-
-    nil
   end
 
   # See `Object#hash(hasher)`

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -538,16 +538,14 @@ class Socket < IO
     end
   end
 
-  private def add_read_event(timeout = @read_timeout)
+  private def add_read_event(timeout = @read_timeout) : Nil
     event = @read_event ||= Scheduler.create_fd_read_event(self)
     event.add timeout
-    nil
   end
 
-  private def add_write_event(timeout = @write_timeout)
+  private def add_write_event(timeout = @write_timeout) : Nil
     event = @write_event ||= Scheduler.create_fd_write_event(self)
     event.add timeout
-    nil
   end
 
   private def unbuffered_rewind

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -24,7 +24,6 @@ module Spec
     end
 
     def parent
-      nil
     end
 
     def succeeded

--- a/src/spec/source.cr
+++ b/src/spec/source.cr
@@ -6,7 +6,7 @@ module Spec
 
   # :nodoc:
   def self.read_line(file, line)
-    return nil unless File.file?(file)
+    return unless File.file?(file)
 
     lines = lines_cache[file] ||= File.read_lines(file)
     lines[line - 1]?

--- a/src/string.cr
+++ b/src/string.cr
@@ -795,7 +795,7 @@ class String
   end
 
   def []?(str : String | Char)
-    includes?(str) ? str : nil
+    str if includes?(str)
   end
 
   def []?(regex : Regex)

--- a/src/string.cr
+++ b/src/string.cr
@@ -2447,7 +2447,6 @@ class String
 
   # ditto
   def =~(other)
-    nil
   end
 
   # Concatenates *str* and *other*.
@@ -2562,8 +2561,6 @@ class String
         return i
       end
     end
-
-    nil
   end
 
   # ditto
@@ -2854,7 +2851,6 @@ class String
         return i
       end
     end
-    nil
   end
 
   def byte_index(search : String, offset = 0)
@@ -2898,8 +2894,6 @@ class String
       head_pointer += 1
       offset += 1
     end
-
-    nil
   end
 
   # Returns the byte index of a char index, or `nil` if out of bounds.
@@ -2921,8 +2915,7 @@ class String
     size = each_byte_index_and_char_index do |byte_index, char_index|
       return byte_index if index == char_index
     end
-    return @bytesize if index == size
-    nil
+    @bytesize if index == size
   end
 
   # Returns the char index of a byte index, or `nil` if out of bounds.
@@ -2937,8 +2930,7 @@ class String
     size = each_byte_index_and_char_index do |byte_index, char_index|
       return char_index if index == byte_index
     end
-    return size if index == @bytesize
-    nil
+    size if index == @bytesize
   end
 
   # Returns `true` if the string contains *search*.
@@ -3798,11 +3790,10 @@ class String
   # end
   # array # => [97, 98, 226, 152, 131]
   # ```
-  def each_byte
+  def each_byte : Nil
     to_slice.each do |byte|
       yield byte
     end
-    nil
   end
 
   # Returns an `Iterator` over each byte in the string.

--- a/src/string.cr
+++ b/src/string.cr
@@ -2555,7 +2555,7 @@ class String
     end
 
     offset += size if offset < 0
-    return nil if offset < 0
+    return if offset < 0
 
     each_char_with_index do |char, i|
       if i >= offset && char == search
@@ -2640,7 +2640,7 @@ class String
   # ditto
   def index(search : Regex, offset = 0)
     offset += size if offset < 0
-    return nil unless 0 <= offset <= size
+    return unless 0 <= offset <= size
 
     self.match(search, offset).try &.begin
   end
@@ -2662,7 +2662,7 @@ class String
     end
 
     offset += size if offset < 0
-    return nil if offset < 0
+    return if offset < 0
 
     if offset == size - 1
       reader = Char::Reader.new(at_end: self)
@@ -2679,7 +2679,7 @@ class String
         reader.previous_char
         offset -= 1
       else
-        return nil
+        return
       end
     end
   end
@@ -2740,7 +2740,7 @@ class String
   # ditto
   def rindex(search : Regex, offset = size - 1)
     offset += size if offset < 0
-    return nil unless 0 <= offset <= size
+    return unless 0 <= offset <= size
 
     match_result = nil
     scan(search) do |match_data|

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,7 +38,7 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     count = slice.size
     new_bytesize = real_bytesize + count
     if new_bytesize > @capacity
@@ -47,11 +47,9 @@ class String::Builder < IO
 
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
-
-    nil
   end
 
-  def write_byte(byte : UInt8)
+  def write_byte(byte : UInt8) : Nil
     new_bytesize = real_bytesize + 1
     if new_bytesize > @capacity
       resize_to_capacity(Math.pw2ceil(new_bytesize))
@@ -60,8 +58,6 @@ class String::Builder < IO
     @buffer[real_bytesize] = byte
 
     @bytesize += 1
-
-    nil
   end
 
   def buffer

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -114,8 +114,6 @@ class StringScanner
       @byte_offset = new_byte_offset if advance
 
       @str.byte_slice(start, new_byte_offset - start)
-    else
-      nil
     end
   end
 

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -106,7 +106,6 @@ struct Struct
       @{{ivar.id}}.inspect(io)
     {% end %}
     io << ")"
-    nil
   end
 
   def pretty_print(pp) : Nil

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -42,7 +42,7 @@ class Time::Location
   end
 
   private def self.open_file_cached(name : String, path : String)
-    return nil unless File.exists?(path)
+    return unless File.exists?(path)
 
     mtime = File.stat(path).mtime
     if (cache = @@location_cache[name]?) && cache[:time] == mtime

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -142,7 +142,7 @@ struct Time::Span
       if raise_exception
         raise ArgumentError.new "Time::Span too big or too small"
       end
-      return nil
+      return
     end
 
     s

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -456,11 +456,10 @@ struct Tuple
   # "hello"
   # 1
   # ```
-  def reverse_each
+  def reverse_each : Nil
     {% for i in 1..T.size %}
       yield self[{{T.size - i}}]
     {% end %}
-    nil
   end
 
   # Returns the first element of this tuple. Doesn't compile
@@ -485,9 +484,7 @@ struct Tuple
   # empty.first? # => nil
   # ```
   def first?
-    {% if T.size == 0 %}
-      nil
-    {% else %}
+    {% unless T.size == 0 %}
       self[0]
     {% end %}
   end
@@ -516,9 +513,7 @@ struct Tuple
   # empty.last? # => nil
   # ```
   def last?
-    {% if T.size == 0 %}
-      nil
-    {% else %}
+    {% unless T.size == 0 %}
       self[{{T.size - 1}}]
     {% end %}
   end

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -62,22 +62,20 @@ module Unicode
   private def self.check_upcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_lowercase?
-        return (char.ord - 32).unsafe_chr
+        (char.ord - 32).unsafe_chr
       else
-        return char
+        char
       end
     end
-    nil
   end
 
   private def self.check_upcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'ı'; return 'I'
-      when 'i'; return 'İ'
+      when 'ı' then 'I'
+      when 'i' then 'İ'
       end
     end
-    nil
   end
 
   private def self.check_upcase_ranges(char)
@@ -134,41 +132,39 @@ module Unicode
   private def self.check_downcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_uppercase?
-        return (char.ord + 32).unsafe_chr
+        (char.ord + 32).unsafe_chr
       else
-        return char
+        char
       end
     end
-
-    nil
   end
 
   private def self.check_downcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'I'; return 'ı'
-      when 'İ'; return 'i'
+      when 'I' then 'ı'
+      when 'İ' then 'i'
       end
     end
-    nil
   end
 
   private def self.check_downcase_fold(char, options)
     if options.fold?
-      result = search_ranges(casefold_ranges, char.ord)
-      return {char.ord + result} if result
-
+      if result = search_ranges(casefold_ranges, char.ord)
+        return {char.ord + result}
+      end
       return fold_cases[char.ord]?
     end
-    nil
   end
 
   private def self.check_downcase_ranges(char)
-    result = search_ranges(downcase_ranges, char.ord)
-    return char + result if result
+    if result = search_ranges(downcase_ranges, char.ord)
+      return char + result
+    end
 
-    result = search_alternate(alternate_ranges, char.ord)
-    return char + 1 if result && (char.ord - result).even?
+    if result = search_alternate(alternate_ranges, char.ord)
+      return char + 1 if (char.ord - result).even?
+    end
 
     char
   end

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -205,8 +205,6 @@ module Unicode
     value = haystack.bsearch { |low, high, delta| needle <= high }
     if value && value[0] <= needle <= value[1]
       value[2]
-    else
-      nil
     end
   end
 
@@ -214,8 +212,6 @@ module Unicode
     value = haystack.bsearch { |low, high| needle <= high }
     if value && value[0] <= needle <= value[1]
       value[0]
-    else
-      nil
     end
   end
 

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -8,7 +8,9 @@ struct XML::Namespace
   def_hash object_id
 
   def href
-    @ns.value.href ? String.new(@ns.value.href) : nil
+    if ptr = @ns.value.href
+      String.new(ptr)
+    end
   end
 
   def object_id
@@ -16,7 +18,9 @@ struct XML::Namespace
   end
 
   def prefix
-    @ns.value.prefix ? String.new(@ns.value.prefix) : nil
+    if ptr = @ns.value.prefix
+      String.new(ptr)
+    end
   end
 
   def to_s(io)

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -292,7 +292,7 @@ struct XML::Node
   def namespace
     case type
     when Type::DOCUMENT_NODE, Type::ATTRIBUTE_DECL, Type::DTD_NODE, Type::ELEMENT_DECL
-      return nil
+      return
     end
 
     ns = @node.value.ns

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -120,8 +120,9 @@ struct XML::Node
   # Returns the encoding of this node's document.
   def encoding
     if document?
-      encoding = @node.as(LibXML::Doc*).value.encoding
-      encoding ? String.new(encoding) : nil
+      if encoding = @node.as(LibXML::Doc*).value.encoding
+        String.new(encoding)
+      end
     else
       document.encoding
     end
@@ -130,8 +131,9 @@ struct XML::Node
   # Returns the version of this node's document.
   def version
     if document?
-      version = @node.as(LibXML::Doc*).value.version
-      version ? String.new(version) : nil
+      if version = @node.as(LibXML::Doc*).value.version
+        String.new(version)
+      end
     else
       document.version
     end
@@ -231,8 +233,9 @@ struct XML::Node
 
   # Returns the next sibling node or `nil` if not found.
   def next
-    next_node = @node.value.next
-    next_node ? Node.new(next_node) : nil
+    if next_node = @node.value.next
+      Node.new(next_node)
+    end
   end
 
   # ditto
@@ -295,8 +298,9 @@ struct XML::Node
       return
     end
 
-    ns = @node.value.ns
-    ns ? Namespace.new(document, ns) : nil
+    if ns = @node.value.ns
+      Namespace.new(document, ns)
+    end
   end
 
   # Returns namespaces in scope for self – those defined on self element
@@ -355,14 +359,16 @@ struct XML::Node
 
   # Returns the parent node or `nil` if not found.
   def parent
-    parent = @node.value.parent
-    parent ? Node.new(parent) : nil
+    if parent = @node.value.parent
+      Node.new(parent)
+    end
   end
 
   # Returns the previous sibling node or `nil` if not found.
   def previous
-    prev_node = @node.value.prev
-    prev_node ? Node.new(prev_node) : nil
+    if prev_node = @node.value.prev
+      Node.new(prev_node)
+    end
   end
 
   # Returns the previous sibling node that is an element or `nil` if not found.
@@ -390,8 +396,9 @@ struct XML::Node
 
   # Returns the root node for this document or `nil`.
   def root
-    root = LibXML.xmlDocGetRootElement(@node.value.doc)
-    root ? Node.new(root) : nil
+    if root = LibXML.xmlDocGetRootElement(@node.value.doc)
+      Node.new(root)
+    end
   end
 
   # Same as `#content`.
@@ -553,8 +560,9 @@ struct XML::Node
   # Returns the list of `XML::Error` found when parsing this document.
   # Returns `nil` if no errors were found.
   def errors
-    ptr = @node.value._private
-    ptr ? (ptr.as(Array(XML::Error))) : nil
+    if ptr = @node.value._private
+      ptr.as(Array(XML::Error))
+    end
   end
 
   private SUBSTITUTIONS = {

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -116,8 +116,6 @@ struct YAML::Any
     when Array
       if index_or_key.is_a?(Int)
         object[index_or_key]?
-      else
-        nil
       end
     when Hash
       object[index_or_key]?

--- a/src/yaml/parse_context.cr
+++ b/src/yaml/parse_context.cr
@@ -57,7 +57,5 @@ class YAML::ParseContext
 
       raise("Error deserailizing alias") if raise_on_alias
     end
-
-    nil
   end
 end

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -57,7 +57,7 @@ class YAML::PullParser
     when .scalar?
       ptr = @event.data.scalar.tag
     end
-    ptr ? String.new(ptr) : nil
+    String.new(ptr) if ptr
   end
 
   # Returns the scalar value, assuming the pull parser
@@ -314,7 +314,7 @@ class YAML::PullParser
   end
 
   private def read_anchor(anchor)
-    anchor ? String.new(anchor) : nil
+    String.new(anchor) if anchor
   end
 
   def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil)

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -81,8 +81,6 @@ class YAML::PullParser
       read_anchor @event.data.mapping_start.anchor
     when .alias?
       read_anchor @event.data.alias.anchor
-    else
-      nil
     end
   end
 

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -62,7 +62,7 @@ module YAML::Schema::Core
   # ```
   def self.parse_scalar(string : String) : Nil | Bool | Int64 | Float64 | String | Time | Bytes
     if parse_null?(string)
-      return nil
+      return
     end
 
     value = parse_bool?(string)
@@ -249,7 +249,7 @@ module YAML::Schema::Core
 
   protected def self.parse_null(string, location) : Nil
     if parse_null?(string)
-      return nil
+      return
     end
 
     raise YAML::ParseException.new("Invalid null", *location)
@@ -300,8 +300,6 @@ module YAML::Schema::Core
       true
     when "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF"
       false
-    else
-      nil
     end
   end
 
@@ -326,14 +324,12 @@ module YAML::Schema::Core
       -Float64::INFINITY
     when ".nan", ".NaN", ".NAN"
       Float64::NAN
-    else
-      nil
     end
   end
 
   private def self.parse_time?(string)
     # Minimum length is that of YYYY-M-D
-    return nil if string.size < 8
+    return if string.size < 8
 
     TimeParser.new(string).parse
   end

--- a/src/yaml/schema/core/parser.cr
+++ b/src/yaml/schema/core/parser.cr
@@ -109,8 +109,6 @@ class YAML::Schema::Core::Parser < YAML::Parser
       parse_set
     when "tag:yaml.org,2002:seq"
       parse_sequence
-    else
-      nil
     end
   end
 

--- a/src/yaml/schema/core/time_parser.cr
+++ b/src/yaml/schema/core/time_parser.cr
@@ -194,6 +194,5 @@ struct YAML::Schema::Core::TimeParser
   def new_time(*args, **named_args)
     Time.utc(*args, **named_args)
   rescue
-    nil
   end
 end

--- a/src/yaml/schema/core/time_parser.cr
+++ b/src/yaml/schema/core/time_parser.cr
@@ -24,17 +24,17 @@ struct YAML::Schema::Core::TimeParser
 
   def parse
     year = parse_number(4)
-    return nil unless year
+    return unless year
 
-    return nil unless dash?
+    return unless dash?
 
     month = parse_number_1_or_2
-    return nil unless month
+    return unless month
 
-    return nil unless dash?
+    return unless dash?
 
     day = parse_number_1_or_2
-    return nil unless day
+    return unless day
 
     case current_char
     when 'T', 't'
@@ -59,17 +59,17 @@ struct YAML::Schema::Core::TimeParser
 
   def parse_after_date(year, month, day)
     hour = parse_number_1_or_2
-    return nil unless hour
+    return unless hour
 
-    return nil unless colon?
+    return unless colon?
 
     minute = parse_number(2)
-    return nil unless minute
+    return unless minute
 
-    return nil unless colon?
+    return unless colon?
 
     second = parse_number(2)
-    return nil unless second
+    return unless second
 
     unless @reader.has_next?
       return new_time(year, month, day, hour, minute, second)
@@ -81,7 +81,7 @@ struct YAML::Schema::Core::TimeParser
       next_char
 
       nanosecond = parse_nanoseconds
-      return nil unless nanosecond
+      return unless nanosecond
     end
 
     skip_space
@@ -94,11 +94,11 @@ struct YAML::Schema::Core::TimeParser
       next_char
 
       tz_hour = parse_number_1_or_2
-      return nil unless tz_hour
+      return unless tz_hour
 
       if colon?
         tz_minute = parse_number(2)
-        return nil unless tz_minute
+        return unless tz_minute
       else
         tz_minute = parse_number(2)
         tz_minute = 0 unless tz_minute
@@ -107,7 +107,7 @@ struct YAML::Schema::Core::TimeParser
       tz_offset = tz_sign * (tz_hour * 60 + tz_minute)
     end
 
-    return nil if @reader.has_next?
+    return if @reader.has_next?
 
     time = new_time(year, month, day, hour, minute, second, nanosecond: nanosecond)
     if time && tz_offset
@@ -117,7 +117,7 @@ struct YAML::Schema::Core::TimeParser
   end
 
   def parse_nanoseconds
-    return nil unless current_char.ascii_number?
+    return unless current_char.ascii_number?
 
     multiplier = Time::NANOSECONDS_PER_SECOND / 10
     number = current_char.to_i
@@ -145,7 +145,7 @@ struct YAML::Schema::Core::TimeParser
     number = 0
 
     n.times do
-      return nil unless current_char.ascii_number?
+      return unless current_char.ascii_number?
 
       number *= 10
       number += current_char.to_i
@@ -157,7 +157,7 @@ struct YAML::Schema::Core::TimeParser
   end
 
   def parse_number_1_or_2
-    return nil unless current_char.ascii_number?
+    return unless current_char.ascii_number?
 
     number = current_char.to_i
     next_char

--- a/src/zip/reader.cr
+++ b/src/zip/reader.cr
@@ -60,7 +60,7 @@ class Zip::Reader
   # After reading a next entry, previous entries can no
   # longer be read (their `IO` will be closed.)
   def next_entry : Entry?
-    return nil if @reached_end
+    return if @reached_end
 
     if last_entry = @last_entry
       last_entry.close
@@ -86,7 +86,7 @@ class Zip::Reader
       else
         # Other signature: we are done with entries (next comes metadata)
         @reached_end = true
-        return nil
+        return
       end
     end
 


### PR DESCRIPTION
Crystal's language is based on Ruby's language, which itself reflects of the Japanese language. In Japanese the context is often not spoken out because it would be redundant (if not rude) to specify it. It's only ever specified to avoid a misunderstanding —but sometimes left confusing, for example in poetry.

Implicitness is part of Ruby's beauty. You can call `something` instead of `self.something()` for example, avoiding unrequited noise. Unless an expression evaluates to something it will evaluate to `nil` or a nilable. An empty method body? it returns `nil`. An `if` expression with no `else` branch? it evaluates to a nilable. A `return` expression with no value? it returns `nil`.

Let's fully embrace implicitness once and for all and clean the compiler/stdlib code base.