### PR TITLE
Fix redirect to stderr in Makefile to be more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CXXFLAGS += $(if $(debug),-g -O0)
 ifeq (${LLVM_CONFIG},)
   $(error Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
 else
-  $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >/dev/stderr)
+  $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
 endif
 
 .PHONY: all


### PR DESCRIPTION
`>/dev/stderr` does not work in some environments. Moreover, all POSIX compliant shells supports standard `>&2` for redirect stdout to stderr.