### PR TITLE
Fix codegen/asm and codegen/sizeof specs

### DIFF
--- a/spec/compiler/codegen/asm_spec.cr
+++ b/spec/compiler/codegen/asm_spec.cr
@@ -1,34 +1,37 @@
 require "../../spec_helper"
 
 describe "Code gen: asm" do
-  it "codegens without inputs" do
-    run(%(
-      dst = uninitialized Int32
-      asm("mov $$1234, $0" : "=r"(dst))
-      dst
-      )).to_i.should eq(1234)
-  end
+  # TODO: arm asm tests
+  {% if flag?(:i686) || flag?(:x86_64) %}
+    it "codegens without inputs" do
+      run(%(
+        dst = uninitialized Int32
+        asm("mov $$1234, $0" : "=r"(dst))
+        dst
+        )).to_i.should eq(1234)
+    end
 
-  it "codegens with one input" do
-    run(%(
-      src = 1234
-      dst = uninitialized Int32
-      asm("mov $1, $0" : "=r"(dst) : "r"(src))
-      dst
-      )).to_i.should eq(1234)
-  end
+    it "codegens with one input" do
+      run(%(
+        src = 1234
+        dst = uninitialized Int32
+        asm("mov $1, $0" : "=r"(dst) : "r"(src))
+        dst
+        )).to_i.should eq(1234)
+    end
 
-  it "codegens with two inputs" do
-    run(%(
-      c = uninitialized Int32
-      a = 20
-      b = 22
-      asm(
-        "add $2, $0"
-           : "=r"(c)
-           : "0"(a), "r"(b)
-        )
-      c
-      )).to_i.should eq(42)
-  end
+    it "codegens with two inputs" do
+      run(%(
+        c = uninitialized Int32
+        a = 20
+        b = 22
+        asm(
+          "add $2, $0"
+             : "=r"(c)
+             : "0"(a), "r"(b)
+          )
+        c
+        )).to_i.should eq(42)
+    end
+  {% end %}
 end

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -48,7 +48,7 @@ describe "Code gen: sizeof" do
     # be struct { 8 bytes, 8 bytes }.
     #
     # In 32 bits structs are aligned to 4 bytes, so it remains the same.
-    {% if flag?(:x86_64) %}
+    {% if flag?(:bits64) %}
       size.should eq(16)
     {% else %}
       size.should eq(12)
@@ -137,7 +137,7 @@ describe "Code gen: sizeof" do
       sizeof(typeof(foo))
       )).to_i
 
-    {% if flag?(:x86_64) %}
+    {% if flag?(:bits64) %}
       size.should eq(8)
     {% else %}
       size.should eq(4)


### PR DESCRIPTION
Requested in https://github.com/crystal-lang/crystal/pull/5861#issuecomment-376006679