### PR TITLE
Add path to UNIXSocket created by UNIXServer

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -325,10 +325,10 @@ describe UNIXSocket do
 
         server.accept do |sock|
           sock.local_address.family.should eq(Socket::Family::UNIX)
-          sock.local_address.path.should eq("")
+          sock.local_address.path.should eq(path)
 
           sock.remote_address.family.should eq(Socket::Family::UNIX)
-          sock.remote_address.path.should eq("")
+          sock.remote_address.path.should eq(path)
 
           client << "ping"
           sock.gets(4).should eq("ping")

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -64,7 +64,7 @@ class UNIXServer < UNIXSocket
   # this method.
   def accept? : UNIXSocket?
     if client_fd = accept_impl
-      sock = UNIXSocket.new(client_fd, type)
+      sock = UNIXSocket.new(client_fd, type, @path)
       sock.sync = sync?
       sock
     end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -28,7 +28,7 @@ class UNIXSocket < Socket
     super family, type, Protocol::IP
   end
 
-  protected def initialize(fd : Int32, type : Type)
+  protected def initialize(fd : Int32, type : Type, @path : String? = nil)
     super fd, Family::UNIX, type, Protocol::IP
   end
 


### PR DESCRIPTION
A `UNIXServer` creates an instance of `UNIXSocket` for every incoming socket connection but unlike client sockets, the values for `local_address` and `remote_address` were missing. This PR adds them.

```crystal
UNIXServer.open(path) do |server|
  server.local_address.path     # => path

  UNIXSocket.open(path) do |client|
    client.local_address.path   # => path
    client.remote_address.path  # => path

    server.accept do |sock|
      sock.local_address.path   # => path (previously "")
      sock.remote_address.path  # => path (previously "")
    end
  end
end
```

There were specs to explicitly check that `local_address` and `remote_address` on a server `UNIXSocket` would be `""` but I don't think there is any reason for this and they should in fact return the path the server listens to.