### PR TITLE
Add connection metadata to HTTP::Server::Response

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -325,10 +325,10 @@ describe UNIXSocket do
 
         server.accept do |sock|
           sock.local_address.family.should eq(Socket::Family::UNIX)
-          sock.local_address.path.should eq("")
+          sock.local_address.path.should eq(path)
 
           sock.remote_address.family.should eq(Socket::Family::UNIX)
-          sock.remote_address.path.should eq("")
+          sock.remote_address.path.should eq(path)
 
           client << "ping"
           sock.gets(4).should eq("ping")

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -61,6 +61,25 @@ class HTTP::Server
       headers["Content-Length"] = content_length.to_s
     end
 
+    # Returns the local address of the network socket used by this connection.
+    #
+    # This can be useful if the server listens on multiple sockets.
+    def local_address : Socket::Address?
+      if (socket = @io).responds_to? :local_address
+        socket.local_address
+      end
+    end
+
+    # Returns the remote address of the network socket used by this connection.
+    #
+    # This is not necessarily the address of the original requestor but the last
+    # proxy (e.g. a load balancer).
+    def remote_address : Socket::Address?
+      if (socket = @io).responds_to? :remote_address
+        socket.remote_address
+      end
+    end
+
     # See `IO#write(slice)`.
     def write(slice : Bytes)
       @output.write(slice)

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -64,7 +64,7 @@ class UNIXServer < UNIXSocket
   # this method.
   def accept? : UNIXSocket?
     if client_fd = accept_impl
-      sock = UNIXSocket.new(client_fd, type)
+      sock = UNIXSocket.new(client_fd, type, @path)
       sock.sync = sync?
       sock
     end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -28,7 +28,7 @@ class UNIXSocket < Socket
     super family, type, Protocol::IP
   end
 
-  protected def initialize(fd : Int32, type : Type)
+  protected def initialize(fd : Int32, type : Type, @path : String? = nil)
     super fd, Family::UNIX, type, Protocol::IP
   end
 


### PR DESCRIPTION
This PR adds methods `#local_address` and `#remote_address` address to `HTTP::Server::Response`.

I'm not entirely sure whether the method's return type should be nilable. It's not very typical to have a Response not wrapping a socket. This is mostly used as mockup for specs. Maybe we can avoid forcing usually unnecessary nil-checks in actual code. This could be done either by raising (though there should probably also be a non-raising option) or returning some default address if the IO does not provide one.

Closes #5784
Based on #5869