### PR TITLE
Add server and socket constructors receiving a Socket::Address

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -303,6 +303,9 @@ describe UNIXServer do
       ret.should be_nil
     end
   end
+
+  typeof(UNIXServer.new(Socket::UNIXAddress.new("/tmp/crystal-unix-socket")))
+  typeof(UNIXServer.open(Socket::UNIXAddress.new("/tmp/crystal-unix-socket")) { })
 end
 
 describe UNIXSocket do
@@ -402,6 +405,9 @@ describe UNIXSocket do
       sizes.should contain(left.recv_buffer_size)
     end
   end
+
+  typeof(UNIXSocket.new(Socket::UNIXAddress.new("/tmp/crystal-unix-socket")))
+  typeof(UNIXSocket.open(Socket::UNIXAddress.new("/tmp/crystal-unix-socket")) { })
 end
 
 describe TCPServer do
@@ -437,6 +443,9 @@ describe TCPServer do
       TCPServer.open("::", server.local_address.port, reuse_port: true) { }
     end
   end
+
+  typeof(TCPServer.new(Socket::IPAddress.new("localhost", 123456)))
+  typeof(TCPServer.open(Socket::IPAddress.new("localhost", 123456)) { })
 end
 
 describe TCPSocket do
@@ -548,6 +557,9 @@ describe TCPSocket do
       TCPSocket.new("doesnotexist.example.org.", 0)
     end
   end
+
+  typeof(TCPSocket.new(Socket::IPAddress.new("localhost", 123456)))
+  typeof(TCPSocket.open(Socket::IPAddress.new("localhost", 123456)) { })
 end
 
 describe UDPSocket do
@@ -644,6 +656,9 @@ describe UDPSocket do
     client.send("broadcast").should eq(9)
     client.close
   end
+
+  typeof(UDPSocket.new.connect Socket::IPAddress.new("localhost", 123456))
+  typeof(UDPSocket.new.bind Socket::IPAddress.new("localhost", 123456))
 end
 
 private def free_udp_socket_port

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -24,7 +24,18 @@ class TCPSocket < IPSocket
   # must be in seconds (integers or floats).
   #
   # Note that `dns_timeout` is currently ignored.
-  def initialize(host, port, dns_timeout = nil, connect_timeout = nil)
+  def self.new(address : IPAddress, dns_timeout = nil, connect_timeout = nil)
+    new(address.address, address.port, dns_timeout, connect_timeout)
+  end
+
+  # Creates a new TCP connection to a remote TCP server.
+  #
+  # You may limit the DNS resolution time with `dns_timeout` and limit the
+  # connection time to the remote server with `connect_timeout`. Both values
+  # must be in seconds (integers or floats).
+  #
+  # Note that `dns_timeout` is currently ignored.
+  def initialize(host : String, port : Int32, dns_timeout = nil, connect_timeout = nil)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol)
       connect(addrinfo, timeout: connect_timeout) do |error|
@@ -46,7 +57,20 @@ class TCPSocket < IPSocket
   # eventually closes the socket when the block returns.
   #
   # Returns the value of the block.
-  def self.open(host, port)
+  def self.open(address : IPAddress)
+    sock = new(address)
+    begin
+      yield sock
+    ensure
+      sock.close
+    end
+  end
+
+  # Opens a TCP socket to a remote TCP server, yields it to the block, then
+  # eventually closes the socket when the block returns.
+  #
+  # Returns the value of the block.
+  def self.open(host : String, port : Int)
     sock = new(host, port)
     begin
       yield sock

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -15,10 +15,16 @@ class UNIXSocket < Socket
   getter path : String?
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
-  def initialize(@path : String, type : Type = Type::STREAM)
+  def self.new(path : String, type : Type = Type::STREAM)
+    new(UNIXAddress.new(path), type)
+  end
+
+  # Connects a named UNIX socket, bound to a filesystem pathname.
+  def initialize(address : UNIXAddress, type : Type = Type::STREAM)
     super(Family::UNIX, type, Protocol::IP)
 
-    connect(UNIXAddress.new(path)) do |error|
+    @path = address.path
+    connect(address) do |error|
       close
       raise error
     end
@@ -36,7 +42,7 @@ class UNIXSocket < Socket
   # eventually closes the socket when the block returns.
   #
   # Returns the value of the block.
-  def self.open(path, type : Type = Type::STREAM)
+  def self.open(path : String | UNIXAddress, type : Type = Type::STREAM)
     sock = new(path, type)
     begin
       yield sock


### PR DESCRIPTION
Currently, to create a `TCPSocket` connecting to a `Socket::IPAddress`, you have to access host and port properties and pass them in as separate arguments:
```crystal
address = Socket::IPAddress.new("localhost", 12345)
TCPSocket.new(address.address, address.port)
```

with this PR, the socket address can be used as a constructor argument directly:
```crystal
address = Socket::IPAddress.new("localhost", 12345)
TCPSocket.new(address)
```

Overloads have been added for:
* `TCPServer.new`
* `TCPServer.open`
* `TCPSocket.new`
* `TCPSocket.open`

And with `Socket::UNIXAddress`:
* `UNIXServer.new`
* `UNIXServer.open`
* `UNIXSocket.new`
* `UNIXSocket.open`

`UDPSocket#bind` and `UDPSocket#connect` already have overloads accepting a `Socket::IPAddress`.