### PR TITLE
Use Char for single char strings

### DIFF
--- a/samples/sdl/tv.cr
+++ b/samples/sdl/tv.cr
@@ -87,7 +87,7 @@ end
 
 def parse_rectangles
   rects = [] of Rectangle
-  lines = File.read("#{__DIR__}/tv.txt").split("\n").map { |line| line.rstrip }
+  lines = File.read("#{__DIR__}/tv.txt").split('\n').map { |line| line.rstrip }
   lines.each_with_index do |line, y|
     x = 0
     line.each_char do |c|

--- a/samples/sudoku.cr
+++ b/samples/sudoku.cr
@@ -148,7 +148,7 @@ sudoku = "
 
 def solve_all(sudoku)
   mr, mc = sd_genmat()
-  sudoku.split("\n").map do |line|
+  sudoku.split('\n').map do |line|
     if line.size >= 81
       ret = sd_solve(mr, mc, line)
       ret.map { |s2| s2.join }

--- a/scripts/generate_windows_zone_names.cr
+++ b/scripts/generate_windows_zone_names.cr
@@ -51,7 +51,7 @@ hash_items = String.build do |io|
     entry[:key].inspect(io)
     io << " => "
     entry[:zones].inspect(io)
-    io << ", # " << entry[:tzdata_name] << "\n"
+    io << ", # " << entry[:tzdata_name] << '\n'
   end
 end
 

--- a/spec/compiler/crystal/tools/expand_spec.cr
+++ b/spec/compiler/crystal/tools/expand_spec.cr
@@ -620,6 +620,6 @@ describe "expand" do
     end
     CODE
 
-    assert_expand_simple code, original: "foo(hello)", expanded: expanded + "\n"
+    assert_expand_simple code, original: "foo(hello)", expanded: expanded + '\n'
   end
 end

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -27,7 +27,7 @@ describe "ECR" do
       %(__str__ << " "),
       %(__str__ << "<% \\"string\\" %>"),
     ]
-    program.should eq(pieces.join("\n") + "\n")
+    program.should eq(pieces.join('\n') + '\n')
   end
 
   it "does ECR.def_to_s" do

--- a/spec/std/http/formdata/builder_spec.cr
+++ b/spec/std/http/formdata/builder_spec.cr
@@ -35,7 +35,7 @@ describe HTTP::FormData::Builder do
       --fixed-boundary--
       MULTIPART
 
-    generated.should eq(expected.gsub("\n", "\r\n"))
+    generated.should eq(expected.gsub('\n', "\r\n"))
   end
 
   describe "#field" do
@@ -54,7 +54,7 @@ describe HTTP::FormData::Builder do
         --fixed-boundary--
         MULTIPART
 
-      generated.should eq(expected.gsub("\n", "\r\n"))
+      generated.should eq(expected.gsub('\n', "\r\n"))
     end
   end
 

--- a/spec/std/http/formdata/parser_spec.cr
+++ b/spec/std/http/formdata/parser_spec.cr
@@ -23,7 +23,7 @@ describe HTTP::FormData::Parser do
       -----------------------------735323031399963166993862150--
       FORMDATA
 
-    parser = HTTP::FormData::Parser.new IO::Memory.new(formdata.gsub("\n", "\r\n")), "---------------------------735323031399963166993862150"
+    parser = HTTP::FormData::Parser.new IO::Memory.new(formdata.gsub('\n', "\r\n")), "---------------------------735323031399963166993862150"
 
     runs = 0
     while parser.has_next?

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -28,7 +28,7 @@ describe HTTP::Headers do
     headers = HTTP::Headers{"FOO_BAR" => "bar", "Foobar-foo" => "baz"}
     serialized = String.build do |io|
       headers.each do |name, values|
-        io << name << ": " << values.first << ";"
+        io << name << ": " << values.first << ';'
       end
     end
 

--- a/spec/std/http/multipart/builder_spec.cr
+++ b/spec/std/http/multipart/builder_spec.cr
@@ -25,7 +25,7 @@ describe HTTP::Multipart::Builder do
       --fixed-boundary--
       MULTIPART
 
-    io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
+    io.to_s.should eq(expected_message.gsub('\n', "\r\n"))
   end
 
   it "generates valid multipart messages with preamble and epilogue" do
@@ -59,7 +59,7 @@ describe HTTP::Multipart::Builder do
       Irelevant textMuch more irelevant text
       MULTIPART
 
-    io.to_s.should eq(expected_message.gsub("\n", "\r\n"))
+    io.to_s.should eq(expected_message.gsub('\n', "\r\n"))
   end
 
   describe "#content_type" do
@@ -99,7 +99,7 @@ describe HTTP::Multipart::Builder do
         --boundary--
         MULTIPART
 
-      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+      generated_multipart.should eq(expected_multipart.gsub('\n', "\r\n"))
     end
 
     it "raises when called after starting the body" do
@@ -156,7 +156,7 @@ describe HTTP::Multipart::Builder do
         --boundary--
         MULTIPART
 
-      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+      generated_multipart.should eq(expected_multipart.gsub('\n', "\r\n"))
     end
 
     it "raises when called after finishing" do
@@ -211,7 +211,7 @@ describe HTTP::Multipart::Builder do
 
         MULTIPART
 
-      generated_multipart.should eq(expected_multipart.gsub("\n", "\r\n"))
+      generated_multipart.should eq(expected_multipart.gsub('\n', "\r\n"))
     end
 
     it "raises when called after finishing" do

--- a/spec/std/http/multipart/parser_spec.cr
+++ b/spec/std/http/multipart/parser_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "http"
 
 private def parse(delim, data, *, gsub = true)
-  data_io = IO::Memory.new(gsub ? data.gsub("\n", "\r\n") : data)
+  data_io = IO::Memory.new(gsub ? data.gsub('\n', "\r\n") : data)
   parser = HTTP::Multipart::Parser.new(data_io, delim)
 
   parsed = [] of {headers: HTTP::Headers, body: String}
@@ -89,7 +89,7 @@ describe HTTP::Multipart::Parser do
       Foo
       --AaB03x--
       MULTIPART
-    parser = HTTP::Multipart::Parser.new(IO::Memory.new(input.gsub("\n", "\r\n")), "AaB03x")
+    parser = HTTP::Multipart::Parser.new(IO::Memory.new(input.gsub('\n', "\r\n")), "AaB03x")
 
     parser.next { }
     parser.has_next?.should eq(false)
@@ -126,7 +126,7 @@ describe HTTP::Multipart::Parser do
       --b--
       MULTIPART
 
-    parser = HTTP::Multipart::Parser.new(IO::Memory.new(input.gsub("\n", "\r\n")), "b")
+    parser = HTTP::Multipart::Parser.new(IO::Memory.new(input.gsub('\n', "\r\n")), "b")
 
     ios = [] of IO
 

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -350,5 +350,5 @@ module HTTP
 end
 
 private def requestize(string)
-  string.gsub("\n", "\r\n")
+  string.gsub('\n', "\r\n")
 end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -243,9 +243,9 @@ describe IO do
 
     it "gets with single byte string as delimiter" do
       io = SimpleIOMemory.new("hello\nworld\nbye")
-      io.gets("\n").should eq("hello\n")
-      io.gets("\n").should eq("world\n")
-      io.gets("\n").should eq("bye")
+      io.gets('\n').should eq("hello\n")
+      io.gets('\n').should eq("world\n")
+      io.gets('\n').should eq("bye")
     end
 
     it "does gets with limit" do

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -45,7 +45,7 @@ describe "Logger" do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << severity.to_s[0] << " " << progname << ": " << message
+        io << severity.to_s[0] << ' ' << progname << ": " << message
       end
       logger.warn "message", "prog"
 

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -100,7 +100,7 @@ describe "JUnit Formatter" do
     name.should eq("Something happened")
 
     backtrace = xml.xpath_string("string(//testsuite/testcase[1]/failure/text())")
-    backtrace.should eq(cause.backtrace.join("\n"))
+    backtrace.should eq(cause.backtrace.join('\n'))
   end
 
   it "report error stacktrace if present" do
@@ -115,7 +115,7 @@ describe "JUnit Formatter" do
     name.should eq("Something happened")
 
     backtrace = xml.xpath_string("string(//testsuite/testcase[1]/error/text())")
-    backtrace.should eq(cause.backtrace.join("\n"))
+    backtrace.should eq(cause.backtrace.join('\n'))
   end
 end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -1657,9 +1657,9 @@ class Array(T)
 
   def to_s(io : IO)
     executed = exec_recursive(:to_s) do
-      io << "["
+      io << '['
       join ", ", io, &.inspect(io)
-      io << "]"
+      io << ']'
     end
     io << "[...]" unless executed
   end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -209,9 +209,9 @@ struct BitArray
   def to_s(io : IO)
     io << "BitArray["
     each do |value|
-      io << (value ? "1" : "0")
+      io << (value ? '1' : '0')
     end
-    io << "]"
+    io << ']'
   end
 
   # ditto

--- a/src/char.cr
+++ b/src/char.cr
@@ -479,7 +479,7 @@ struct Char
       if ascii_control?
         io << "\\u{"
         ord.to_s(16, io)
-        io << "}"
+        io << '}'
       else
         to_s(io)
       end
@@ -507,7 +507,7 @@ struct Char
       if ascii_control? || ord >= 0x80
         io << "\\u{"
         ord.to_s(16, io)
-        io << "}"
+        io << '}'
       else
         to_s(io)
       end

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -160,14 +160,14 @@ struct Colorize::Object(T)
   private BACK_LIGHT_CYAN    = "106"
   private BACK_WHITE         = "107"
 
-  private MODE_DEFAULT   = "0"
-  private MODE_BOLD      = "1"
-  private MODE_BRIGHT    = "1"
-  private MODE_DIM       = "2"
-  private MODE_UNDERLINE = "4"
-  private MODE_BLINK     = "5"
-  private MODE_REVERSE   = "7"
-  private MODE_HIDDEN    = "8"
+  private MODE_DEFAULT   = '0'
+  private MODE_BOLD      = '1'
+  private MODE_BRIGHT    = '1'
+  private MODE_DIM       = '2'
+  private MODE_UNDERLINE = '4'
+  private MODE_BLINK     = '5'
+  private MODE_REVERSE   = '7'
+  private MODE_HIDDEN    = '8'
 
   private MODE_BOLD_FLAG      =  1
   private MODE_BRIGHT_FLAG    =  1
@@ -304,13 +304,13 @@ struct Colorize::Object(T)
       end
 
       unless fore_is_default
-        io << ";" if printed
+        io << ';' if printed
         io << @fore
         printed = true
       end
 
       unless back_is_default
-        io << ";" if printed
+        io << ';' if printed
         io << @back
         printed = true
       end
@@ -319,14 +319,14 @@ struct Colorize::Object(T)
         # Can't reuse MODES constant because it has bold/bright duplicated
         {% for name in %w(bold dim underline blink reverse hidden) %}
           if @mode.bits_set? MODE_{{name.upcase.id}}_FLAG
-            io << ";" if printed
+            io << ';' if printed
             io << MODE_{{name.upcase.id}}
             printed = true
           end
         {% end %}
       end
 
-      io << "m"
+      io << 'm'
 
       true
     end

--- a/src/compiler/crystal/codegen/asm.cr
+++ b/src/compiler/crystal/codegen/asm.cr
@@ -16,22 +16,22 @@ class Crystal::CodeGenVisitor
     input_values = [] of LLVM::Value
 
     if inputs = node.inputs
-      constraints << "," unless constraints.empty?
+      constraints << ',' unless constraints.empty?
 
       inputs.each_with_index do |input, i|
         accept input.exp
         input_types << llvm_type(input.exp.type)
         input_values << @last
-        constraints << "," if i > 0
+        constraints << ',' if i > 0
         constraints << input.constraint
       end
     end
 
     if clobbers = node.clobbers
-      constraints << "," unless constraints.empty?
+      constraints << ',' unless constraints.empty?
 
       clobbers.each_with_index do |clobber, i|
-        constraints << "," if i > 0
+        constraints << ',' if i > 0
         constraints << "~{"
         constraints << clobber
         constraints << '}'

--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -37,23 +37,23 @@ module Crystal
 
     def mangled_name(program, self_type)
       name = String.build do |str|
-        str << "*"
+        str << '*'
 
         if owner = @owner
           if owner.metaclass?
             self_type.instance_type.llvm_name(str)
             if original_owner != self_type
-              str << "@"
+              str << '@'
               original_owner.instance_type.llvm_name(str)
             end
             str << "::"
           elsif !owner.is_a?(Crystal::Program)
             self_type.llvm_name(str)
             if original_owner != self_type
-              str << "@"
+              str << '@'
               original_owner.llvm_name(str)
             end
-            str << "#"
+            str << '#'
           end
         end
 
@@ -61,12 +61,12 @@ module Crystal
 
         next_def = self.next
         while next_def
-          str << "'"
+          str << '\''
           next_def = next_def.next
         end
 
         if args.size > 0 || uses_block_arg?
-          str << "<"
+          str << '<'
           if args.size > 0
             args.each_with_index do |arg, i|
               str << ", " if i > 0
@@ -75,13 +75,13 @@ module Crystal
           end
           if uses_block_arg?
             str << ", " if args.size > 0
-            str << "&"
+            str << '&'
             block_arg.not_nil!.type.llvm_name(str)
           end
-          str << ">"
+          str << '>'
         end
         if return_type = @type
-          str << ":"
+          str << ':'
           return_type.llvm_name(str)
         end
       end

--- a/src/compiler/crystal/codegen/cache_dir.cr
+++ b/src/compiler/crystal/codegen/cache_dir.cr
@@ -92,7 +92,7 @@ module Crystal
         io.puts "Crystal needs a cache directory. These directories were candidates for it:"
         io.puts
         candidates.each do |candidate|
-          io << " - " << candidate << "\n"
+          io << " - " << candidate << '\n'
         end
         io.puts
         io.puts "but none of them are writable."

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -89,11 +89,11 @@ module Crystal
       String.build do |flags|
         link_attributes.reverse_each do |attr|
           if ldflags = attr.ldflags
-            flags << " " << ldflags
+            flags << ' ' << ldflags
           end
 
           if libname = attr.lib
-            flags << " " << libname << ".lib"
+            flags << ' ' << libname << ".lib"
           end
         end
       end
@@ -106,7 +106,7 @@ module Crystal
       String.build do |flags|
         link_attributes.reverse_each do |attr|
           if ldflags = attr.ldflags
-            flags << " " << ldflags
+            flags << ' ' << ldflags
           end
 
           if libname = attr.lib
@@ -117,9 +117,9 @@ module Crystal
             static = has_flag?("static") || attr.static?
 
             if has_pkg_config && (libflags = pkg_config_flags(libname, static, library_path))
-              flags << " " << libflags
+              flags << ' ' << libflags
             elsif static && (static_lib = find_static_lib(libname, library_path))
-              flags << " " << static_lib
+              flags << ' ' << static_lib
             else
               flags << " -l" << libname
             end
@@ -157,7 +157,7 @@ module Crystal
               flags << cfg
             end
           end
-          flags.join " "
+          flags.join ' '
         else
           `pkg-config #{libname} --libs`.chomp
         end

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -120,7 +120,7 @@ module Crystal
     def llvm_name(io)
       if extern?
         io << (extern_union? ? "union" : "struct")
-        io << "."
+        io << '.'
       end
       to_s_with_options io, codegen: true
     end

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -159,7 +159,7 @@ class Crystal::Command
         check_files << FormatResult.new(filename, FormatResult::Code::FORMAT)
       else
         File.write(filename, result)
-        STDOUT << "Format".colorize(:green).toggle(@color) << " " << filename << "\n"
+        STDOUT << "Format".colorize(:green).toggle(@color) << ' ' << filename << '\n'
       end
     rescue ex : InvalidByteSequenceError
       if check_files
@@ -173,7 +173,7 @@ class Crystal::Command
       if check_files
         check_files << FormatResult.new(filename, FormatResult::Code::SYNTAX)
       else
-        STDERR << "Syntax Error:".colorize(:yellow).toggle(@color) << " " << ex.message << " at " << filename << ":" << ex.line_number << ":" << ex.column_number << "\n"
+        STDERR << "Syntax Error:".colorize(:yellow).toggle(@color) << ' ' << ex.message << " at " << filename << ':' << ex.line_number << ':' << ex.column_number << '\n'
       end
     rescue ex
       if check_files

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -66,7 +66,7 @@ class Crystal::Command
 
     source_filename = File.expand_path("spec")
 
-    source = target_filenames.map { |filename| %(require "./#{filename}") }.join("\n")
+    source = target_filenames.map { |filename| %(require "./#{filename}") }.join('\n')
     sources = [Compiler::Source.new(source_filename, source)]
 
     output_filename = Crystal.tempfile "spec"

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -185,7 +185,7 @@ class Crystal::Call
             all_arguments_sizes.join ", ", str
           end
 
-          str << "+" if min_splat != Int32::MAX
+          str << '+' if min_splat != Int32::MAX
           str << ")\n"
         end
         str << "Overloads are:"
@@ -223,8 +223,8 @@ class Crystal::Call
         msg << "no overload matches '#{full_name(owner, def_name)}'"
         unless args.empty?
           msg << " with type"
-          msg << "s" if arg_types.size > 1 || named_args_types
-          msg << " "
+          msg << 's' if arg_types.size > 1 || named_args_types
+          msg << ' '
           arg_types.join(", ", msg)
         end
 
@@ -237,7 +237,7 @@ class Crystal::Call
           end
         end
 
-        msg << "\n"
+        msg << '\n'
 
         defs.each do |a_def|
           arg_names.try &.push a_def.args.map(&.name)
@@ -270,7 +270,7 @@ class Crystal::Call
               end
               msg << "\n - #{full_name(owner, def_name)}(#{signature_args}"
               msg << ", &block" if block
-              msg << ")"
+              msg << ')'
             end
           end
         end
@@ -416,8 +416,8 @@ class Crystal::Call
       str << '*' if a_def.splat_index == i
 
       if arg.external_name != arg.name
-        str << (arg.external_name.empty? ? "_" : arg.external_name)
-        str << " "
+        str << (arg.external_name.empty? ? '_' : arg.external_name)
+        str << ' '
       end
 
       str << arg.name
@@ -457,12 +457,12 @@ class Crystal::Call
 
     if block_arg = a_def.block_arg
       str << ", " if printed
-      str << "&" << block_arg.name
+      str << '&' << block_arg.name
     elsif a_def.yields
       str << ", " if printed
       str << "&block"
     end
-    str << ")"
+    str << ')'
   end
 
   def raise_matches_not_found_for_virtual_metaclass_new(owner)
@@ -548,14 +548,14 @@ class Crystal::Call
         msg = String.build do |str|
           str << "no argument named '"
           str << named_arg.name
-          str << "'"
+          str << '\''
           if similar_name
             str << colorize(" (did you mean '#{similar_name}'?)").yellow.bold
           end
 
           defs = owner.lookup_defs(a_def.name)
 
-          str << "\n"
+          str << '\n'
           str << "Matches are:"
           append_matches defs, arg_types, str, matched_def: a_def, argument_name: named_arg.name
         end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -461,11 +461,7 @@ module Crystal
 
     def untyped_expression(node, msg = nil)
       ex_msg = String.build do |str|
-        str << "can't execute `"
-        str << node
-        str << "`"
-        str << " at "
-        str << node.location
+        str << "can't execute `" << node << "` at " << node.location
         if msg
           str << ": "
           str << msg

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -95,7 +95,7 @@ module Crystal
       when String
         if File.file?(filename)
           lines = File.read_lines(filename)
-          io << "in " << relative_filename(filename) << ":" << @line << ": "
+          io << "in " << relative_filename(filename) << ':' << @line << ": "
           append_error_message io, msg
         else
           lines = source ? source.lines.to_a : nil
@@ -115,24 +115,24 @@ module Crystal
       if lines && (line_number = @line) && (line = lines[line_number - 1]?)
         io << "\n\n"
         io << replace_leading_tabs_with_spaces(line.chomp)
-        io << "\n"
+        io << '\n'
         io << (" " * (@column - 1))
         with_color.green.bold.surround(io) do
-          io << "^"
+          io << '^'
           if @size > 0
             io << ("~" * (@size - 1))
           end
         end
       end
-      io << "\n"
+      io << '\n'
 
       if is_macro
-        io << "\n"
+        io << '\n'
         append_error_message io, @message
       end
 
       if inner && inner.has_location?
-        io << "\n"
+        io << '\n'
         inner.append_to_s source, io
       end
     end
@@ -254,7 +254,7 @@ module Crystal
 
       io << "\n\n"
       io << "  "
-      io << relative_filename(filename) << ":" << line_number
+      io << relative_filename(filename) << ':' << line_number
       io << "\n\n"
 
       return unless lines
@@ -273,7 +273,7 @@ module Crystal
       io << "    "
       io << (" " * (name_column - 1))
       with_color.green.bold.surround(io) do
-        io << "^"
+        io << '^'
         if name_size > 0
           io << ("~" * (name_size - 1)) if name_size
         end

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -68,7 +68,7 @@ module Crystal
     def to_s(io)
       io << "F("
       @type.to_s(io)
-      io << ")"
+      io << ')'
     end
   end
 
@@ -88,7 +88,7 @@ module Crystal
     end
 
     def to_s(io)
-      io << "(" << @filter1 << " && " << @filter2 << ")"
+      io << '(' << @filter1 << " && " << @filter2 << ')'
     end
   end
 
@@ -112,7 +112,7 @@ module Crystal
     end
 
     def to_s(io)
-      io << "(" << @filter1 << " || " << @filter2 << ")"
+      io << '(' << @filter1 << " || " << @filter2 << ')'
     end
   end
 
@@ -203,7 +203,7 @@ module Crystal
     end
 
     def to_s(io)
-      io << "!"
+      io << '!'
       @filter.to_s(io)
     end
   end
@@ -217,7 +217,7 @@ module Crystal
     end
 
     def to_s(io)
-      io << "responds_to?(" << @name << ")"
+      io << "responds_to?(" << @name << ')'
     end
   end
 

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -264,7 +264,7 @@ module Crystal
         name = String.build do |str|
           str << "new"
           named_args.each do |named_arg|
-            str << ":"
+            str << ':'
             str << named_arg
             def_args << Arg.new(named_arg)
             i += 1

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -5,12 +5,12 @@ module Crystal
     def visit(node : Arg)
       if node.external_name != node.name
         visit_named_arg_name(node.external_name)
-        @str << " "
+        @str << ' '
       end
       if node.name
         @str << decorate_arg(node, node.name)
       else
-        @str << "?"
+        @str << '?'
       end
       if type = node.type?
         @str << " : "

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -41,17 +41,17 @@ module Crystal
           if line
             io << "\n\n"
             io << replace_leading_tabs_with_spaces(line.chomp)
-            io << "\n"
+            io << '\n'
             (@column_number - 1).times do
-              io << " "
+              io << ' '
             end
             with_color.green.bold.surround(io) do
-              io << "^"
+              io << '^'
               if size = @size
                 io << ("~" * (size - 1))
               end
             end
-            io << "\n"
+            io << '\n'
           end
         end
       end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -45,7 +45,7 @@ class Crystal::Location
   end
 
   def to_s(io)
-    io << filename << ":" << line_number << ":" << column_number
+    io << filename << ':' << line_number << ':' << column_number
   end
 
   def pretty_print(pp)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2007,8 +2007,8 @@ module Crystal
               current_line.clear
               remove_indent = true
             end
-          elsif (slash_n = value.starts_with?("\n")) || value.starts_with?("\r\n")
-            current_line << (slash_n ? "\n" : "\r\n")
+          elsif (slash_n = value.starts_with?('\n')) || value.starts_with?("\r\n")
+            current_line << (slash_n ? '\n' : "\r\n")
             line = current_line.to_s
             line = remove_heredoc_from_line(line, indent, line_number - 1) if remove_indent
             add_heredoc_piece new_pieces, line

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -35,11 +35,11 @@ module Crystal
       if @emit_loc_pragma && (loc = node.location) && loc.filename.is_a?(String)
         @str << "#<loc:"
         loc.filename.inspect(@str)
-        @str << ","
+        @str << ','
         @str << loc.line_number
-        @str << ","
+        @str << ','
         @str << loc.column_number
-        @str << ">"
+        @str << '>'
       end
 
       true
@@ -56,7 +56,7 @@ module Crystal
       @str << node.value
 
       if needs_suffix?(node)
-        @str << "_"
+        @str << '_'
         @str << node.kind.to_s
       end
     end
@@ -101,9 +101,9 @@ module Crystal
     end
 
     def visit(node : StringInterpolation)
-      @str << %(")
+      @str << '"'
       visit_interpolation node, &.gsub('"', "\\\"")
-      @str << %(")
+      @str << '"'
       false
     end
 
@@ -114,7 +114,7 @@ module Crystal
         else
           @str << "\#{"
           exp.accept(self)
-          @str << "}"
+          @str << '}'
         end
       end
     end
@@ -125,21 +125,21 @@ module Crystal
         name.accept self
         @str << " {"
       else
-        @str << "["
+        @str << '['
       end
 
       node.elements.join(", ", @str, &.accept self)
 
       if name
-        @str << "}"
+        @str << '}'
       else
-        @str << "]"
+        @str << ']'
       end
 
       if of = node.of
-        @str << " "
+        @str << ' '
         @str << keyword("of")
-        @str << " "
+        @str << ' '
         of.accept self
       end
       false
@@ -148,29 +148,29 @@ module Crystal
     def visit(node : HashLiteral)
       if name = node.name
         name.accept self
-        @str << " "
+        @str << ' '
       end
 
       space = false
-      @str << "{"
+      @str << '{'
 
       node.entries.each_with_index do |entry, i|
         @str << ", " if i > 0
 
         space = i == 0 && entry.key.is_a?(TupleLiteral) || entry.key.is_a?(NamedTupleLiteral) || entry.key.is_a?(HashLiteral)
-        @str << " " if space
+        @str << ' ' if space
 
         entry.key.accept self
         @str << " => "
         entry.value.accept self
       end
 
-      @str << " " if space
-      @str << "}"
+      @str << ' ' if space
+      @str << '}'
       if of = node.of
-        @str << " "
+        @str << ' '
         @str << keyword("of")
-        @str << " "
+        @str << ' '
         of.key.accept self
         @str << " => "
         of.value.accept self
@@ -179,13 +179,13 @@ module Crystal
     end
 
     def visit(node : NamedTupleLiteral)
-      @str << "{"
+      @str << '{'
       node.entries.join(", ", @str) do |entry|
         visit_named_arg_name(entry.key)
         @str << ": "
         entry.value.accept self
       end
-      @str << "}"
+      @str << '}'
       false
     end
 
@@ -199,7 +199,7 @@ module Crystal
 
       case
       when parens
-        @str << "("
+        @str << '('
       when begin_end
         @str << "begin"
         @indent += 1
@@ -220,7 +220,7 @@ module Crystal
 
       case
       when parens
-        @str << ")"
+        @str << ')'
       when begin_end
         @indent -= 1
         append_indent
@@ -249,7 +249,7 @@ module Crystal
 
     def visit_if_or_unless(prefix, node)
       @str << keyword(prefix)
-      @str << " "
+      @str << ' '
       node.cond.accept self
       newline
       accept_with_indent(node.then)
@@ -267,19 +267,19 @@ module Crystal
     def visit(node : ClassDef)
       if node.abstract?
         @str << keyword("abstract")
-        @str << " "
+        @str << ' '
       end
       @str << keyword(node.struct? ? "struct" : "class")
-      @str << " "
+      @str << ' '
       node.name.accept self
       if type_vars = node.type_vars
-        @str << "("
+        @str << '('
         type_vars.each_with_index do |type_var, i|
           @str << ", " if i > 0
-          @str << "*" if node.splat_index == i
+          @str << '*' if node.splat_index == i
           @str << type_var.to_s
         end
-        @str << ")"
+        @str << ')'
       end
       if superclass = node.superclass
         @str << " < "
@@ -295,16 +295,16 @@ module Crystal
 
     def visit(node : ModuleDef)
       @str << keyword("module")
-      @str << " "
+      @str << ' '
       node.name.accept self
       if type_vars = node.type_vars
-        @str << "("
+        @str << '('
         type_vars.each_with_index do |type_var, i|
           @str << ", " if i > 0
-          @str << "*" if node.splat_index == i
+          @str << '*' if node.splat_index == i
           @str << type_var
         end
-        @str << ")"
+        @str << ')'
       end
       newline
       accept_with_indent(node.body)
@@ -347,9 +347,9 @@ module Crystal
         @str << decorate_call(node, "[")
         visit_args(node, excluse_last: true)
         @str << decorate_call(node, "]")
-        @str << " "
+        @str << ' '
         @str << decorate_call(node, "=")
-        @str << " "
+        @str << ' '
         node.args.last.accept self
       elsif node_obj && !letter_or_underscore?(node.name) && node.args.size == 0
         @str << decorate_call(node, node.name)
@@ -357,16 +357,16 @@ module Crystal
       elsif node_obj && !letter_or_underscore?(node.name) && node.args.size == 1
         in_parenthesis(need_parens, node_obj)
 
-        @str << " "
+        @str << ' '
         @str << decorate_call(node, node.name)
-        @str << " "
+        @str << ' '
 
         arg = node.args[0]
         in_parenthesis(need_parens(arg), arg)
       else
         if node_obj
           in_parenthesis(need_parens, node_obj)
-          @str << "."
+          @str << '.'
         end
         if node.name.ends_with?('=') && node.name[0].ascii_letter?
           @str << decorate_call(node, node.name.rchop)
@@ -377,7 +377,7 @@ module Crystal
 
           call_args_need_parens = node.has_parentheses? || !node.args.empty? || node.block_arg || node.named_args
 
-          @str << "(" if call_args_need_parens
+          @str << '(' if call_args_need_parens
           visit_args(node)
         end
       end
@@ -394,7 +394,7 @@ module Crystal
             if block_obj.is_a?(Var) && block_obj.name == first_block_arg.name
               if node.args.empty?
                 unless call_args_need_parens
-                  @str << "("
+                  @str << '('
                   call_args_need_parens = true
                 end
               else
@@ -408,10 +408,10 @@ module Crystal
         end
       end
 
-      @str << ")" if call_args_need_parens
+      @str << ')' if call_args_need_parens
 
       if block
-        @str << " "
+        @str << ' '
         block.accept self
       end
 
@@ -436,7 +436,7 @@ module Crystal
       end
       if block_arg = node.block_arg
         @str << ", " if printed_arg
-        @str << "&"
+        @str << '&'
         block_arg.accept self
       end
     end
@@ -470,9 +470,9 @@ module Crystal
 
     def in_parenthesis(need_parens)
       if need_parens
-        @str << "("
+        @str << '('
         yield
-        @str << ")"
+        @str << ')'
       else
         yield
       end
@@ -556,7 +556,7 @@ module Crystal
 
     def visit(node : OpAssign)
       node.target.accept self
-      @str << " " << node.op << "=" << " "
+      @str << ' ' << node.op << '=' << ' '
       node.value.accept self
       false
     end
@@ -578,7 +578,7 @@ module Crystal
 
     def visit_while_or_until(node, name)
       @str << keyword(name)
-      @str << " "
+      @str << ' '
       node.cond.accept self
       newline
       accept_with_indent(node.body)
@@ -600,11 +600,11 @@ module Crystal
     def visit(node : ProcLiteral)
       @str << "->"
       if node.def.args.size > 0
-        @str << "("
+        @str << '('
         node.def.args.join(", ", @str, &.accept self)
-        @str << ")"
+        @str << ')'
       end
-      @str << " "
+      @str << ' '
       @str << keyword("do")
       newline
       accept_with_indent(node.def.body)
@@ -617,14 +617,14 @@ module Crystal
       @str << "->"
       if obj = node.obj
         obj.accept self
-        @str << "."
+        @str << '.'
       end
       @str << node.name
 
       if node.args.size > 0
-        @str << "("
+        @str << '('
         node.args.join(", ", @str, &.accept self)
-        @str << ")"
+        @str << ')'
       end
       false
     end
@@ -632,18 +632,18 @@ module Crystal
     def visit(node : Def)
       @str << "abstract " if node.abstract?
       @str << keyword("def")
-      @str << " "
+      @str << ' '
       if node_receiver = node.receiver
         node_receiver.accept self
-        @str << "."
+        @str << '.'
       end
       @str << def_name(node.name)
       if node.args.size > 0 || node.block_arg || node.double_splat
-        @str << "("
+        @str << '('
         printed_arg = false
         node.args.each_with_index do |arg, i|
           @str << ", " if printed_arg
-          @str << "*" if node.splat_index == i
+          @str << '*' if node.splat_index == i
           arg.accept self
           printed_arg = true
         end
@@ -654,11 +654,11 @@ module Crystal
         end
         if block_arg = node.block_arg
           @str << ", " if printed_arg
-          @str << "&"
+          @str << '&'
           block_arg.accept self
           printed_arg = true
         end
-        @str << ")"
+        @str << ')'
       end
       if return_type = node.return_type
         @str << " : "
@@ -682,14 +682,14 @@ module Crystal
 
     def visit(node : Macro)
       @str << keyword("macro")
-      @str << " "
+      @str << ' '
       @str << node.name.to_s
       if node.args.size > 0 || node.block_arg || node.double_splat
-        @str << "("
+        @str << '('
         printed_arg = false
         node.args.each_with_index do |arg, i|
           @str << ", " if printed_arg
-          @str << "*" if i == node.splat_index
+          @str << '*' if i == node.splat_index
           arg.accept self
           printed_arg = true
         end
@@ -701,10 +701,10 @@ module Crystal
         end
         if block_arg = node.block_arg
           @str << ", " if printed_arg
-          @str << "&"
+          @str << '&'
           block_arg.accept self
         end
-        @str << ")"
+        @str << ')'
       end
       newline
 
@@ -720,9 +720,9 @@ module Crystal
 
     def visit(node : MacroExpression)
       @str << (node.output? ? "{{" : "{% ")
-      @str << " " if node.output?
+      @str << ' ' if node.output?
       node.exp.accept self
-      @str << " " if node.output?
+      @str << ' ' if node.output?
       @str << (node.output? ? "}}" : " %}")
       false
     end
@@ -778,7 +778,7 @@ module Crystal
     end
 
     def visit(node : ExternalVar)
-      @str << "$"
+      @str << '$'
       @str << node.name
       if real_name = node.real_name
         @str << " = "
@@ -792,12 +792,12 @@ module Crystal
     def visit(node : Arg)
       if node.external_name != node.name
         visit_named_arg_name(node.external_name)
-        @str << " "
+        @str << ' '
       end
       if node.name
         @str << decorate_arg(node, node.name)
       else
-        @str << "?"
+        @str << '?'
       end
       if restriction = node.restriction
         @str << " : "
@@ -811,16 +811,16 @@ module Crystal
     end
 
     def visit(node : ProcNotation)
-      @str << "("
+      @str << '('
       if inputs = node.inputs
         inputs.join(", ", @str, &.accept self)
-        @str << " "
+        @str << ' '
       end
       @str << "-> "
       if output = node.output
         output.accept self
       end
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -840,14 +840,14 @@ module Crystal
         case name.names.first
         when "Pointer"
           node.type_vars.first.accept self
-          @str << "*"
+          @str << '*'
           return false
         when "StaticArray"
           if node.type_vars.size == 2
             node.type_vars[0].accept self
-            @str << "["
+            @str << '['
             node.type_vars[1].accept self
-            @str << "]"
+            @str << ']'
             return false
           end
         end
@@ -857,7 +857,7 @@ module Crystal
 
       printed_arg = false
 
-      @str << "("
+      @str << '('
       node.type_vars.join(", ", @str) do |var|
         var.accept self
         printed_arg = true
@@ -873,7 +873,7 @@ module Crystal
         end
       end
 
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -886,12 +886,12 @@ module Crystal
     end
 
     def visit(node : Underscore)
-      @str << "_"
+      @str << '_'
       false
     end
 
     def visit(node : Splat)
-      @str << "*"
+      @str << '*'
       node.exp.accept self
       false
     end
@@ -909,7 +909,7 @@ module Crystal
 
     def visit(node : Metaclass)
       node.name.accept self
-      @str << "."
+      @str << '.'
       @str << keyword("class")
       false
     end
@@ -920,7 +920,7 @@ module Crystal
 
     def visit(node : ReadInstanceVar)
       node.obj.accept self
-      @str << "."
+      @str << '.'
       @str << node.name
       false
     end
@@ -933,11 +933,11 @@ module Crystal
       if scope = node.scope
         @str << "with "
         scope.accept self
-        @str << " "
+        @str << ' '
       end
       @str << keyword("yield")
       if node.exps.size > 0
-        @str << " "
+        @str << ' '
         node.exps.join(", ", @str, &.accept self)
       end
       false
@@ -958,36 +958,36 @@ module Crystal
     def visit_control(node, keyword)
       @str << keyword(keyword)
       if exp = node.exp
-        @str << " "
+        @str << ' '
         exp.accept self
       end
       false
     end
 
     def visit(node : RegexLiteral)
-      @str << "/"
+      @str << '/'
       case exp = node.value
       when StringLiteral
         @str << exp.value.gsub('/', "\\/")
       when StringInterpolation
         visit_interpolation exp, &.gsub('/', "\\/")
       end
-      @str << "/"
-      @str << "i" if node.options.includes? Regex::Options::IGNORE_CASE
-      @str << "m" if node.options.includes? Regex::Options::MULTILINE
-      @str << "x" if node.options.includes? Regex::Options::EXTENDED
+      @str << '/'
+      @str << 'i' if node.options.includes? Regex::Options::IGNORE_CASE
+      @str << 'm' if node.options.includes? Regex::Options::MULTILINE
+      @str << 'x' if node.options.includes? Regex::Options::EXTENDED
       false
     end
 
     def visit(node : TupleLiteral)
-      @str << "{"
+      @str << '{'
 
       first = node.elements.first?
       space = first.is_a?(TupleLiteral) || first.is_a?(NamedTupleLiteral) || first.is_a?(HashLiteral)
-      @str << " " if space
+      @str << ' ' if space
       node.elements.join(", ", @str, &.accept self)
-      @str << " " if space
-      @str << "}"
+      @str << ' ' if space
+      @str << '}'
       false
     end
 
@@ -1016,10 +1016,10 @@ module Crystal
         @str << " |"
         node.args.each_with_index do |arg, i|
           @str << ", " if i > 0
-          @str << "*" if i == node.splat_index
+          @str << '*' if i == node.splat_index
           arg.accept self
         end
-        @str << "|"
+        @str << '|'
       end
 
       newline
@@ -1033,14 +1033,14 @@ module Crystal
 
     def visit(node : Include)
       @str << keyword("include")
-      @str << " "
+      @str << ' '
       node.name.accept self
       false
     end
 
     def visit(node : Extend)
       @str << keyword("extend")
-      @str << " "
+      @str << ' '
       node.name.accept self
       false
     end
@@ -1054,7 +1054,7 @@ module Crystal
     end
 
     def visit(node : Not)
-      @str << "!"
+      @str << '!'
       need_parens = need_parens(node.exp)
       in_parenthesis(need_parens, node.exp)
       false
@@ -1071,9 +1071,9 @@ module Crystal
       left_needs_parens = need_parens(node.left)
       in_parenthesis(left_needs_parens, node.left)
 
-      @str << " "
+      @str << ' '
       @str << op
-      @str << " "
+      @str << ' '
 
       right_needs_parens = need_parens(node.right)
       in_parenthesis(right_needs_parens, node.right)
@@ -1086,7 +1086,7 @@ module Crystal
 
     def visit(node : LibDef)
       @str << keyword("lib")
-      @str << " "
+      @str << ' '
       @str << node.name
       newline
       @inside_lib = true
@@ -1099,7 +1099,7 @@ module Crystal
 
     def visit(node : FunDef)
       @str << keyword("fun")
-      @str << " "
+      @str << ' '
       if node.name == node.real_name
         @str << node.name
       else
@@ -1108,7 +1108,7 @@ module Crystal
         @str << node.real_name
       end
       if node.args.size > 0
-        @str << "("
+        @str << '('
         node.args.join(", ", @str) do |arg|
           if arg_name = arg.name
             @str << arg_name << " : "
@@ -1118,7 +1118,7 @@ module Crystal
         if node.varargs?
           @str << ", ..."
         end
-        @str << ")"
+        @str << ')'
       elsif node.varargs?
         @str << "(...)"
       end
@@ -1138,7 +1138,7 @@ module Crystal
 
     def visit(node : TypeDef)
       @str << keyword("type")
-      @str << " "
+      @str << ' '
       @str << node.name.to_s
       @str << " = "
       node.type_spec.accept self
@@ -1147,7 +1147,7 @@ module Crystal
 
     def visit(node : CStructOrUnionDef)
       @str << keyword(node.union? ? "union" : "struct")
-      @str << " "
+      @str << ' '
       @str << node.name.to_s
       newline
       accept_with_indent node.body
@@ -1158,7 +1158,7 @@ module Crystal
 
     def visit(node : EnumDef)
       @str << keyword("enum")
-      @str << " "
+      @str << ' '
       @str << node.name.to_s
       if base_type = node.base_type
         @str << " : "
@@ -1195,25 +1195,25 @@ module Crystal
 
     def visit(node : PointerOf)
       @str << keyword("pointerof")
-      @str << "("
+      @str << '('
       node.exp.accept(self)
-      @str << ")"
+      @str << ')'
       false
     end
 
     def visit(node : SizeOf)
       @str << keyword("sizeof")
-      @str << "("
+      @str << '('
       node.exp.accept(self)
-      @str << ")"
+      @str << ')'
       false
     end
 
     def visit(node : InstanceSizeOf)
       @str << keyword("instance_sizeof")
-      @str << "("
+      @str << '('
       node.exp.accept(self)
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -1224,7 +1224,7 @@ module Crystal
       else
         @str << ".is_a?("
         node.const.accept self
-        @str << ")"
+        @str << ')'
       end
       false
     end
@@ -1240,11 +1240,11 @@ module Crystal
     def visit_cast(node, keyword)
       need_parens = need_parens(node.obj)
       in_parenthesis(need_parens, node.obj)
-      @str << "."
+      @str << '.'
       @str << keyword(keyword)
-      @str << "("
+      @str << '('
       node.to.accept self
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -1252,7 +1252,7 @@ module Crystal
       node.obj.accept self
       @str << ".responds_to?("
       visit_symbol_literal_value node.name
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -1260,14 +1260,14 @@ module Crystal
       @str << keyword("require")
       @str << " \""
       @str << node.string
-      @str << "\""
+      @str << '"'
       false
     end
 
     def visit(node : Case)
       @str << keyword("case")
       if cond = node.cond
-        @str << " "
+        @str << ' '
         cond.accept self
       end
       newline
@@ -1288,7 +1288,7 @@ module Crystal
     def visit(node : When)
       append_indent
       @str << keyword("when")
-      @str << " "
+      @str << ' '
       node.conds.join(", ", @str, &.accept self)
       newline
       accept_with_indent node.body
@@ -1351,14 +1351,14 @@ module Crystal
     def visit(node : Rescue)
       @str << keyword("rescue")
       if name = node.name
-        @str << " "
+        @str << ' '
         @str << name
       end
       if (types = node.types) && types.size > 0
         if node.name
           @str << " :"
         end
-        @str << " "
+        @str << ' '
         types.join(" | ", @str, &.accept self)
       end
       newline
@@ -1368,7 +1368,7 @@ module Crystal
 
     def visit(node : Alias)
       @str << keyword("alias")
-      @str << " "
+      @str << ' '
       @str << node.name
       @str << " = "
       node.value.accept self
@@ -1377,9 +1377,9 @@ module Crystal
 
     def visit(node : TypeOf)
       @str << keyword("typeof")
-      @str << "("
+      @str << '('
       node.expressions.join(", ", @str, &.accept self)
-      @str << ")"
+      @str << ')'
       false
     end
 
@@ -1387,7 +1387,7 @@ module Crystal
       @str << "@["
       @str << node.name
       if !node.args.empty? || node.named_args
-        @str << "("
+        @str << '('
         printed_arg = false
         node.args.join(", ", @str) do |arg|
           arg.accept self
@@ -1402,9 +1402,9 @@ module Crystal
             printed_arg = true
           end
         end
-        @str << ")"
+        @str << ')'
       end
-      @str << "]"
+      @str << ']'
       false
     end
 
@@ -1416,13 +1416,13 @@ module Crystal
       node.text.inspect(@str)
       @str << " :"
       if output = node.output
-        @str << " "
+        @str << ' '
         output.accept self
-        @str << " "
+        @str << ' '
       end
-      @str << ":"
+      @str << ':'
       if inputs = node.inputs
-        @str << " "
+        @str << ' '
         inputs.join(", ", @str, &.accept self)
       end
       if clobbers = node.clobbers
@@ -1459,7 +1459,7 @@ module Crystal
     end
 
     def newline
-      @str << "\n"
+      @str << '\n'
     end
 
     def indent_string

--- a/src/compiler/crystal/tools/doc/main.cr
+++ b/src/compiler/crystal/tools/doc/main.cr
@@ -13,7 +13,7 @@ module Crystal::Doc
     def to_jsonp(io : IO)
       io << "crystal_doc_search_index_callback("
       to_json(io)
-      io << ")"
+      io << ')'
     end
 
     def to_json(builder : JSON::Builder)

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -172,8 +172,8 @@ class Crystal::Doc::Method
 
   def arg_to_html(arg : Arg, io, links = true)
     if arg.external_name != arg.name
-      io << (arg.external_name.empty? ? "_" : arg.external_name)
-      io << " "
+      io << (arg.external_name.empty? ? '_' : arg.external_name)
+      io << ' '
     end
 
     io << arg.name

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -520,11 +520,11 @@ class Crystal::Doc::Type
     else
       io << node.name
     end
-    io << "("
+    io << '('
     node.type_vars.join(", ", io) do |type_var|
       node_to_html type_var, io, links: links
     end
-    io << ")"
+    io << ')'
   end
 
   def node_to_html(node : ProcNotation, io, links = true)
@@ -557,12 +557,12 @@ class Crystal::Doc::Type
 
   private def nilable_type_to_html(node : ASTNode, io, links)
     node_to_html node, io, links: links
-    io << "?"
+    io << '?'
   end
 
   private def nilable_type_to_html(type : Crystal::Type, io, text, links)
     type_to_html(type, io, text, links: links)
-    io << "?"
+    io << '?'
   end
 
   def nil_type?(node : ASTNode)
@@ -603,7 +603,7 @@ class Crystal::Doc::Type
       type_to_html union_type, io, text, links: links
     end
 
-    io << ")" if has_type_splat
+    io << ')' if has_type_splat
   end
 
   def type_to_html(type : Crystal::ProcInstanceType, io, text = nil, links = true)
@@ -616,15 +616,15 @@ class Crystal::Doc::Type
   end
 
   def type_to_html(type : Crystal::TupleInstanceType, io, text = nil, links = true)
-    io << "{"
+    io << '{'
     type.tuple_types.join(", ", io) do |tuple_type|
       type_to_html tuple_type, io, links: links
     end
-    io << "}"
+    io << '}'
   end
 
   def type_to_html(type : Crystal::NamedTupleInstanceType, io, text = nil, links = true)
-    io << "{"
+    io << '{'
     type.entries.join(", ", io) do |entry|
       if Symbol.needs_quotes?(entry.name)
         entry.name.inspect(io)
@@ -634,7 +634,7 @@ class Crystal::Doc::Type
       io << ": "
       type_to_html entry.type, io, links: links
     end
-    io << "}"
+    io << '}'
   end
 
   def type_to_html(type : Crystal::GenericInstanceType, io, text = nil, links = true)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -540,9 +540,9 @@ module Crystal
 
       node.expressions.each do |exp|
         if @token.type == :DELIMITER_END
-          # If the delimiter ends with "\n" it's something like "\n  HEREDOC",
+          # If the delimiter ends with '\n' it's something like "\n  HEREDOC",
           # so we are done
-          break if @token.raw.starts_with?("\n")
+          break if @token.raw.starts_with?('\n')
 
           # This is for " ... " \
           #     " ... "
@@ -4415,7 +4415,7 @@ module Crystal
       write_line
       skip_space_or_newline last: true
       result = to_s.strip
-      lines = result.split("\n")
+      lines = result.split('\n')
       fix_heredocs(lines, @heredoc_fixes)
       align_infos(lines, @when_infos)
       align_infos(lines, @hash_infos)
@@ -4431,7 +4431,7 @@ module Crystal
           line.rstrip
         end
       end
-      result = lines.join("\n") + '\n'
+      result = lines.join('\n') + '\n'
       result = "" if result == "\n"
       if @shebang
         result = result[0] + result[2..-1]
@@ -4504,7 +4504,7 @@ module Crystal
       after = line[middle..-1]
       result = String.build do |str|
         str << before
-        gap.times { str << " " }
+        gap.times { str << ' ' }
         str << after
       end
 
@@ -4558,7 +4558,7 @@ module Crystal
 
       result = String.build do |str|
         str << source_line
-        gap.times { str << " " }
+        gap.times { str << ' ' }
         str << comment_line
       end
       result
@@ -4585,7 +4585,7 @@ module Crystal
           formatted_lines = formatted_comment.lines
           formatted_lines.map! do |line|
             String.build do |str|
-              sharp_index.times { str << " " }
+              sharp_index.times { str << ' ' }
               str << "# "
               str << line
             end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1465,7 +1465,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
-      io << "*" << @splatted_type
+      io << '*' << @splatted_type
     end
   end
 
@@ -1510,9 +1510,9 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       super
       if generic_args
-        io << "("
+        io << '('
         type_vars.join(", ", io, &.to_s(io))
-        io << ")"
+        io << ')'
       end
     end
   end
@@ -1570,9 +1570,9 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       super
       if generic_args
-        io << "("
+        io << '('
         type_vars.join(", ", io, &.to_s(io))
-        io << ")"
+        io << ')'
       end
     end
   end
@@ -1696,7 +1696,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       generic_type.append_full_name(io)
-      io << "("
+      io << '('
       type_vars.each_value.with_index do |type_var, i|
         io << ", " if i > 0
         if type_var.is_a?(Var)
@@ -1715,7 +1715,7 @@ module Crystal
           type_var.to_s(io)
         end
       end
-      io << ")"
+      io << ')'
     end
   end
 
@@ -2006,7 +2006,7 @@ module Crystal
       return_type = self.return_type
       return_type = return_type.devirtualize unless codegen
       return_type.to_s_with_options(io, codegen: codegen)
-      io << ")"
+      io << ')'
     end
   end
 
@@ -2115,7 +2115,7 @@ module Crystal
         tuple_type = tuple_type.devirtualize unless codegen
         tuple_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
       end
-      io << ")"
+      io << ')'
     end
 
     def type_desc
@@ -2235,7 +2235,7 @@ module Crystal
         entry_type = entry_type.devirtualize unless codegen
         entry_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
       end
-      io << ")"
+      io << ')'
     end
 
     def type_desc
@@ -2731,7 +2731,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
-      io << "(" unless skip_union_parens
+      io << '(' unless skip_union_parens
       union_types = @union_types
       # Make sure to put Nil at the end
       if nil_type_index = @union_types.index(&.nil_type?)
@@ -2742,7 +2742,7 @@ module Crystal
         type = type.devirtualize unless codegen
         type.to_s_with_options(io, codegen: codegen)
       end
-      io << ")" unless skip_union_parens
+      io << ')' unless skip_union_parens
     end
 
     def type_desc
@@ -2961,7 +2961,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       base_type.to_s(io)
-      io << "+"
+      io << '+'
     end
 
     def name

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -39,6 +39,6 @@ module Crystal
         end
       end
       str
-    end.join "\n"
+    end.join '\n'
   end
 end

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -45,7 +45,7 @@ struct Complex
     io << @real
     io << (@imag >= 0 ? " + " : " - ")
     io << @imag.abs
-    io << "i"
+    io << 'i'
   end
 
   # Write this complex object to an *io*, surrounded by parentheses.

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -44,7 +44,7 @@ class CSV::Builder
   # to `IO` after the block exits.
   def row
     yield Row.new(self)
-    @io << "\n"
+    @io << '\n'
     @first_cell_in_row = true
   end
 
@@ -86,7 +86,7 @@ class CSV::Builder
   end
 
   private def append_cell
-    @io << "," unless @first_cell_in_row
+    @io << ',' unless @first_cell_in_row
     yield
     @first_cell_in_row = false
   end

--- a/src/debug/elf.cr
+++ b/src/debug/elf.cr
@@ -104,12 +104,12 @@ module Debug
 
         def short
           String.build do |str|
-            str << "W" if write?
-            str << "A" if alloc?
-            str << "X" if execinstr?
-            str << "M" if merge?
-            str << "S" if strings?
-            str << "T" if tls?
+            str << 'W' if write?
+            str << 'A' if alloc?
+            str << 'X' if execinstr?
+            str << 'M' if merge?
+            str << 'S' if strings?
+            str << 'T' if tls?
           end
         end
       end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -334,7 +334,7 @@ class Deque(T)
     executed = exec_recursive(:inspect) do
       io << "Deque{"
       join ", ", io, &.inspect(io)
-      io << "}"
+      io << '}'
     end
     io << "Deque{...}" unless executed
   end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -252,7 +252,7 @@ class Dir
   end
 
   def to_s(io)
-    io << "#<Dir:" << @path << ">"
+    io << "#<Dir:" << @path << '>'
   end
 
   def inspect(io)

--- a/src/ecr/macros.cr
+++ b/src/ecr/macros.cr
@@ -28,7 +28,7 @@ module ECR
   #   def to_s(io)
   #     io << "Hello "
   #     io << @name
-  #     io << "!"
+  #     io << '!'
   #   end
   # end
   # ```
@@ -64,7 +64,7 @@ module ECR
   # ```
   # io << "Hello "
   # io << name
-  # io << "!"
+  # io << '!'
   # ```
   macro embed(filename, io_name)
     \{{ run("ecr/process", {{filename}}, {{io_name.id.stringify}}) }}

--- a/src/ecr/processor.cr
+++ b/src/ecr/processor.cr
@@ -27,7 +27,7 @@ module ECR
           str << buffer_name
           str << " << "
           string.inspect(str)
-          str << "\n"
+          str << '\n'
         when :OUTPUT
           string = token.value
           line_number = token.line_number
@@ -37,12 +37,12 @@ module ECR
 
           supress_trailing_whitespace(token, supress_trailing)
 
-          str << "("
+          str << '('
           append_loc(str, filename, line_number, column_number)
           str << string
           str << ").to_s "
           str << buffer_name
-          str << "\n"
+          str << '\n'
         when :CONTROL
           string = token.value
           line_number = token.line_number
@@ -53,9 +53,9 @@ module ECR
           supress_trailing_whitespace(token, supress_trailing)
 
           append_loc(str, filename, line_number, column_number)
-          str << " " unless string.starts_with?(' ')
+          str << ' ' unless string.starts_with?(' ')
           str << string
-          str << "\n"
+          str << '\n'
         when :EOF
           break
         end
@@ -95,8 +95,8 @@ module ECR
     str << filename
     str << %(",)
     str << line_number
-    str << %(,)
+    str << ','
     str << column_number
-    str << %(>)
+    str << '>'
   end
 end

--- a/src/env.cr
+++ b/src/env.cr
@@ -132,7 +132,7 @@ module ENV
 
   # Writes the contents of the environment to *io*.
   def self.inspect(io)
-    io << "{"
+    io << '{'
     found_one = false
     each do |key, value|
       io << ", " if found_one
@@ -141,7 +141,7 @@ module ENV
       value.inspect(io)
       found_one = true
     end
-    io << "}"
+    io << '}'
   end
 
   def self.pretty_print(pp)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -44,7 +44,7 @@ class Exception
   end
 
   def inspect(io : IO)
-    io << "#<" << self.class.name << ":" << message << ">"
+    io << "#<" << self.class.name << ':' << message << '>'
   end
 
   def inspect_with_backtrace

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -293,7 +293,7 @@ class Fiber
     if name = @name
       io << ": " << name
     end
-    io << ">"
+    io << '>'
   end
 
   def inspect(io)

--- a/src/file.cr
+++ b/src/file.cr
@@ -793,7 +793,7 @@ class File < IO::FileDescriptor
   def inspect(io)
     io << "#<File:" << @path
     io << " (closed)" if closed?
-    io << ">"
+    io << '>'
     io
   end
 

--- a/src/file/stat.cr
+++ b/src/file/stat.cr
@@ -120,7 +120,7 @@ class File
       io << ", atime=" << atime
       io << ", mtime=" << mtime
       io << ", ctime=" << ctime
-      io << ">"
+      io << '>'
     end
 
     def pretty_print(pp)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -769,7 +769,7 @@ class Hash(K, V)
   # ```
   def to_s(io : IO)
     executed = exec_recursive(:to_s) do
-      io << "{"
+      io << '{'
       found_one = false
       each do |key, value|
         io << ", " if found_one
@@ -778,7 +778,7 @@ class Hash(K, V)
         value.inspect(io)
         found_one = true
       end
-      io << "}"
+      io << '}'
     end
     io << "{...}" unless executed
   end

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -61,7 +61,7 @@ class HTTP::Client::Response
   end
 
   def to_io(io)
-    io << @version << " " << @status_code << " " << @status_message << "\r\n"
+    io << @version << ' ' << @status_code << ' ' << @status_message << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_response_headers(@headers) : @headers
     HTTP.serialize_headers_and_body(io, headers, @body, @body_io, @version)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -227,7 +227,7 @@ struct HTTP::Headers
         values.inspect(io)
       end
     end
-    io << "}"
+    io << '}'
   end
 
   def inspect(io : IO)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -76,7 +76,7 @@ class HTTP::Request
   end
 
   def to_io(io)
-    io << @method << " " << resource << " " << @version << "\r\n"
+    io << @method << ' ' << resource << ' ' << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
     HTTP.serialize_headers_and_body(io, headers, nil, @body, @version)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -115,7 +115,7 @@ class HTTP::Server
 
     protected def write_headers
       status_message = HTTP.default_status_message_for(@status_code)
-      @io << @version << " " << @status_code << " " << status_message << "\r\n"
+      @io << @version << ' ' << @status_code << ' ' << status_message << "\r\n"
       headers.each do |name, values|
         values.each do |value|
           @io << name << ": " << value << "\r\n"

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -143,7 +143,7 @@ class IO::FileDescriptor < IO
     else
       io << " fd=" << @fd
     end
-    io << ">"
+    io << '>'
     io
   end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -160,7 +160,7 @@ class JSON::Builder
     start_scalar
     @current_indent += 1
     @state.push ArrayState.new(empty: true)
-    @io << "["
+    @io << '['
   end
 
   # Writes the end of an array.
@@ -172,7 +172,7 @@ class JSON::Builder
       raise JSON::Error.new("Can't do end_array: not inside an array")
     end
     write_indent state
-    @io << "]"
+    @io << ']'
     @current_indent -= 1
     end_scalar
   end
@@ -189,7 +189,7 @@ class JSON::Builder
     start_scalar
     @current_indent += 1
     @state.push ObjectState.new(empty: true, name: true)
-    @io << "{"
+    @io << '{'
   end
 
   # Writes the end of an object.
@@ -204,7 +204,7 @@ class JSON::Builder
       raise JSON::Error.new("Can't do end_object: not inside an object")
     end
     write_indent state
-    @io << "}"
+    @io << '}'
     @current_indent -= 1
     end_scalar
   end
@@ -312,16 +312,16 @@ class JSON::Builder
   end
 
   private def comma
-    @io << ","
+    @io << ','
   end
 
   private def colon
-    @io << ":"
-    @io << " " if @indent
+    @io << ':'
+    @io << ' ' if @indent
   end
 
   private def newline
-    @io << "\n"
+    @io << '\n'
   end
 
   private def write_indent

--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -46,7 +46,7 @@ struct LLVM::Target
     name.inspect(io)
     io << ", description="
     description.inspect(io)
-    io << ")"
+    io << ')'
   end
 
   def inspect(io)

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -637,7 +637,7 @@ class Markdown::Parser
     line -= 1 if line == @lines.size
 
     if line > start
-      @lines[line] = (start..line).join("\n") { |i| @lines[i] }
+      @lines[line] = (start..line).join('\n') { |i| @lines[i] }
       @line = line
     end
   end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -279,7 +279,7 @@ struct NamedTuple
   # tuple.to_s # => %({name: "Crystal", year: 2011})
   # ```
   def to_s(io)
-    io << "{"
+    io << '{'
     {% for key, value, i in T %}
       {% if i > 0 %}
         io << ", "
@@ -293,7 +293,7 @@ struct NamedTuple
       io << ": "
       self[{{key.symbolize}}].inspect(io)
     {% end %}
-    io << "}"
+    io << '}'
   end
 
   def pretty_print(pp)

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -161,9 +161,9 @@ class OptionParser
   def to_s(io : IO)
     if banner = @banner
       io << banner
-      io << "\n"
+      io << '\n'
     end
-    @flags.join "\n", io
+    @flags.join '\n', io
   end
 
   private def append_flag(flag, description)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -320,7 +320,7 @@ struct Pointer(T)
   def to_s(io : IO)
     io << "Pointer("
     io << T.to_s
-    io << ")"
+    io << ')'
     if address == 0
       io << ".null"
     else

--- a/src/pretty_print.cr
+++ b/src/pretty_print.cr
@@ -90,7 +90,7 @@ class PrettyPrint
     if group.break?
       flush
       @output << @newline
-      @indent.times { @output << " " }
+      @indent.times { @output << ' ' }
       @output_width = @indent
       @buffer_width = 0
     else
@@ -227,7 +227,7 @@ class PrettyPrint
       @group.breakables.shift
       if @group.break?
         out << @pp.newline
-        @indent.times { out << " " }
+        @indent.times { out << ' ' }
         @indent
       else
         @pp.group_queue.delete @group if @group.breakables.empty?

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -198,7 +198,7 @@ struct Proc
     if closure?
       io << ":closure"
     end
-    io << ">"
+    io << '>'
     nil
   end
 end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -63,7 +63,7 @@ class Reference
     executed = exec_recursive(:inspect) do
       {% for ivar, i in @type.instance_vars %}
         {% if i > 0 %}
-          io << ","
+          io << ','
         {% end %}
         io << " @{{ivar.id}}="
         @{{ivar.id}}.inspect io
@@ -72,7 +72,7 @@ class Reference
     unless executed
       io << " ..."
     end
-    io << ">"
+    io << '>'
     nil
   end
 
@@ -108,7 +108,7 @@ class Reference
   def to_s(io : IO) : Nil
     io << "#<" << self.class.name << ":0x"
     object_id.to_s(16, io)
-    io << ">"
+    io << '>'
     nil
   end
 

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -406,12 +406,12 @@ class Regex
   # /ab+c/ix.inspect # => "/ab+c/ix"
   # ```
   def inspect(io : IO)
-    io << "/"
+    io << '/'
     append_source(io)
-    io << "/"
-    io << "i" if options.ignore_case?
-    io << "m" if options.multiline?
-    io << "x" if options.extended?
+    io << '/'
+    io << 'i' if options.ignore_case?
+    io << 'm' if options.multiline?
+    io << 'x' if options.extended?
   end
 
   # Match at character index. Matches a regular expression against `String`
@@ -504,18 +504,18 @@ class Regex
   # ```
   def to_s(io : IO)
     io << "(?"
-    io << "i" if options.ignore_case?
+    io << 'i' if options.ignore_case?
     io << "ms" if options.multiline?
-    io << "x" if options.extended?
+    io << 'x' if options.extended?
 
-    io << "-"
-    io << "i" unless options.ignore_case?
+    io << '-'
+    io << 'i' unless options.ignore_case?
     io << "ms" unless options.multiline?
-    io << "x" unless options.extended?
+    io << 'x' unless options.extended?
 
-    io << ":"
+    io << ':'
     append_source(io)
-    io << ")"
+    io << ')'
   end
 
   private def append_source(io)

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -334,11 +334,11 @@ class Regex
 
       io << "#<Regex::MatchData"
       size.times do |i|
-        io << " "
-        io << name_table.fetch(i, i) << ":" if i > 0
+        io << ' '
+        io << name_table.fetch(i, i) << ':' if i > 0
         self[i]?.inspect(io)
       end
-      io << ">"
+      io << '>'
     end
 
     def pretty_print(pp) : Nil

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -37,13 +37,13 @@ class SemanticVersion
   end
 
   def to_s(io : IO)
-    io << major << "." << minor << "." << patch
+    io << major << '.' << minor << '.' << patch
     unless prerelease.identifiers.empty?
-      io << "-"
+      io << '-'
       prerelease.to_s io
     end
     if build
-      io << "+" << build
+      io << '+' << build
     end
   end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -353,7 +353,7 @@ struct Set(T)
   def to_s(io)
     io << "Set{"
     join ", ", io, &.inspect(io)
-    io << "}"
+    io << '}'
   end
 
   # Returns `true` if the set is a subset of the *other* set.

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -478,16 +478,14 @@ struct Slice(T)
 
   def to_s(io)
     if T == UInt8
-      io << "Bytes"
-      io << "["
+      io << "Bytes["
       # Inspect using to_s because we know this is a UInt8.
       join ", ", io, &.to_s(io)
-      io << "]"
+      io << ']'
     else
-      io << "Slice"
-      io << "["
+      io << "Slice["
       join ", ", io, &.inspect(io)
-      io << "]"
+      io << ']'
     end
   end
 

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -82,7 +82,7 @@ module Spec
             end
             puts
 
-            ex.to_s.split("\n").each do |line|
+            ex.to_s.split('\n').each do |line|
               print "       "
               puts Spec.color(line, :error)
             end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -289,13 +289,13 @@ module Spec
       case message
       when Regex
         unless (ex_to_s =~ message)
-          backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+          backtrace = ex.backtrace.join('\n') { |f| "  # #{f}" }
           fail "Expected #{klass} with message matching #{message.inspect}, " \
                "got #<#{ex.class}: #{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
       when String
         unless ex_to_s.includes?(message)
-          backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+          backtrace = ex.backtrace.join('\n') { |f| "  # #{f}" }
           fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: " \
                "#{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
@@ -303,7 +303,7 @@ module Spec
 
       ex
     rescue ex
-      backtrace = ex.backtrace.join("\n") { |f| "  # #{f}" }
+      backtrace = ex.backtrace.join('\n') { |f| "  # #{f}" }
       fail "Expected #{klass}, got #<#{ex.class}: #{ex.to_s}> with backtrace:\n" \
            "#{backtrace}", file, line
     else

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -229,7 +229,7 @@ struct StaticArray(T, N)
   def to_s(io : IO)
     io << "StaticArray["
     join ", ", io, &.inspect(io)
-    io << "]"
+    io << ']'
   end
 
   def pretty_print(pp)

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -271,7 +271,7 @@ class StringScanner
   def inspect(io : IO)
     io << "#<StringScanner "
     offset = offset()
-    io << offset << "/" << @str.size
+    io << offset << '/' << @str.size
     start = Math.min(Math.max(offset - 2, 0), Math.max(0, @str.size - 5))
     io << " \"" << @str[start, 5] << "\" >"
   end

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -97,7 +97,7 @@ struct Struct
   # p1.inspect # "Point(@x=1, @y=2)"
   # ```
   def inspect(io : IO) : Nil
-    io << {{@type.name.id.stringify}} << "("
+    io << {{@type.name.id.stringify}} << '('
     {% for ivar, i in @type.instance_vars %}
       {% if i > 0 %}
         io << ", "
@@ -105,7 +105,7 @@ struct Struct
       io << "@{{ivar.id}}="
       @{{ivar.id}}.inspect(io)
     {% end %}
-    io << ")"
+    io << ')'
     nil
   end
 

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -35,7 +35,7 @@ struct Symbol
   # :crystal.inspect # => ":crystal"
   # ```
   def inspect(io : IO)
-    io << ":"
+    io << ':'
 
     value = to_s
     if Symbol.needs_quotes?(value)

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -383,9 +383,9 @@ struct Tuple
   # tuple.to_s # => "{1, \"hello\"}"
   # ```
   def to_s(io)
-    io << "{"
+    io << '{'
     join ", ", io, &.inspect(io)
-    io << "}"
+    io << '}'
   end
 
   def pretty_print(pp) : Nil

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -127,9 +127,9 @@ class URI
   # ```
   def full_path
     String.build do |str|
-      str << (@path.try { |p| !p.empty? } ? @path : "/")
+      str << (@path.try { |p| !p.empty? } ? @path : '/')
       if (query = @query) && !query.empty?
-        str << "?" << query
+        str << '?' << query
       end
     end
   end

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -53,9 +53,9 @@ struct XML::Attributes
   end
 
   def to_s(io)
-    io << "["
+    io << '['
     join ", ", io, &.inspect(io)
-    io << "]"
+    io << ']'
   end
 
   def inspect(io)

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -33,7 +33,7 @@ struct XML::Namespace
       href.inspect(io)
     end
 
-    io << ">"
+    io << '>'
     io
   end
 

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -199,7 +199,7 @@ struct XML::Node
     object_id.to_s(16, io)
 
     if text?
-      io << " "
+      io << ' '
       content.inspect(io)
     else
       unless document?
@@ -225,7 +225,7 @@ struct XML::Node
       end
     end
 
-    io << ">"
+    io << '>'
     io
   end
 

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -32,9 +32,9 @@ struct XML::NodeSet
   def_hash object_id
 
   def inspect(io)
-    io << "["
+    io << '['
     join ", ", io, &.inspect(io)
-    io << "]"
+    io << ']'
   end
 
   def size
@@ -46,7 +46,7 @@ struct XML::NodeSet
   end
 
   def to_s(io)
-    join "\n", io
+    join '\n', io
   end
 
   def to_unsafe


### PR DESCRIPTION
Lil' change for noticeable gain:

```cr
require "benchmark"

Benchmark.ips do |x|
  io1 = IO::Memory.new
  io2 = IO::Memory.new

  x.report("<< Char") do
    io1 << 'a' << 'b' << 'c'
  end
  x.report("<< String") do
    io2 << "a" << "b" << "c"
  end
end
```

```
~ ❯ crystal run x.cr --release                                                                                                                                                                            
  << Char  47.06M ( 21.25ns) (±23.32%)       fastest
<< String  29.56M ( 33.83ns) (±17.99%)  1.59× slower

~ ❯ crystal run x.cr --release
  << Char  54.37M ( 18.39ns) (±31.44%)       fastest
<< String  28.09M ( 35.61ns) (±15.39%)  1.94× slower

~ ❯ crystal run x.cr --release
  << Char   48.6M ( 20.58ns) (±23.82%)       fastest
<< String  28.97M ( 34.51ns) (±17.46%)  1.68× slower
```