### PR TITLE
Allow a path to declare a constant

### DIFF
--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -3,8 +3,7 @@ require "../../spec_helper"
 describe "Semantic: const" do
   it "types a constant" do
     input = parse("CONST = 1").as(Assign)
-    result = semantic input
-    mod = result.program
+    semantic input
     input.target.type?.should be_nil # Don't type value until needed
   end
 
@@ -14,6 +13,24 @@ describe "Semantic: const" do
 
   it "types a nested constant" do
     assert_type("class Foo; A = 1; end; Foo::A") { int32 }
+  end
+
+  it "types a constant using Path" do
+    assert_type(%(
+      Foo::Bar = 1
+
+      Foo::Bar
+      )) { int32 }
+  end
+
+  it "types a nested constant using Path" do
+    assert_type(%(
+      class Foo
+        Bar::Baz = 1
+      end
+
+      Foo::Bar::Baz
+      )) { int32 }
   end
 
   it "types a constant inside a def" do

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -33,6 +33,55 @@ describe "Semantic: const" do
       )) { int32 }
   end
 
+  it "creates container module if not exist when using Path" do
+    assert_type(%(
+      Foo::Bar = 1
+      Foo
+    )) do
+      foo = types["Foo"]
+      foo.module?.should be_true
+      foo.metaclass
+    end
+  end
+
+  it "keeps type of container when using Path" do
+    assert_type(%(
+      class Foo
+      end
+
+      Foo::Const = 1
+      Foo
+    )) do
+      foo = types["Foo"]
+      foo.class?.should be_true
+      foo.metaclass
+    end
+
+    assert_type(%(
+      struct Foo
+      end
+
+      Foo::Const = 1
+      Foo
+    )) do
+      foo = types["Foo"]
+      foo.struct?.should be_true
+      foo.metaclass
+    end
+
+    assert_type(%(
+      module Foo
+      end
+
+      Foo::Const = 1
+      Foo
+    )) do
+      foo = types["Foo"]
+      foo.module?.should be_true
+      foo.metaclass
+    end
+  end
+
   it "types a constant inside a def" do
     assert_type("
       class Foo

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -647,18 +647,18 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     check_outside_exp node, "declare constant"
     @exp_nest += 1
 
-    scope = current_type_scope(target)
+    scope, name = lookup_type_def_name(target)
 
-    type = scope.types[target.names.first]?
+    type = scope.types[name]?
     if type
       target.raise "already initialized constant #{type}"
     end
 
-    const = Const.new(@program, scope, target.names.first, value)
+    const = Const.new(@program, scope, name, value)
     const.private = true if target.visibility.private?
     attach_doc const, node
 
-    scope.types[target.names.first] = const
+    scope.types[name] = const
 
     target.target_const = const
   end


### PR DESCRIPTION
Allow `Foo::Bar = 1` to declare a constant `Bar` inside a module `Foo`.

Previously it was broken: it declared a constant `Foo`, discarding `Bar` completely.

Fixes #5742 