### PR TITLE
Remove duplicated indefinite articles 'a a' in char.cr doc

### DIFF
--- a/src/char.cr
+++ b/src/char.cr
@@ -288,7 +288,7 @@ struct Char
   #
   # The backslash character \ can be used to escape ^ or - and
   # is otherwise ignored unless it appears at the end of a range
-  # or the end of a a set.
+  # or the end of a set.
   #
   # ```
   # 'l'.in_set? "lo"          # => true

--- a/src/char.cr
+++ b/src/char.cr
@@ -288,7 +288,7 @@ struct Char
   #
   # The backslash character \ can be used to escape ^ or - and
   # is otherwise ignored unless it appears at the end of a range
-  # or the end of a set.
+  # or set.
   #
   # ```
   # 'l'.in_set? "lo"          # => true


### PR DESCRIPTION
It is bad English as far as I know.