### PR TITLE
Format: fix indentation after backslash newline

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1100,6 +1100,8 @@ describe Crystal::Formatter do
   assert_format "1 \\\nensure 2", "1 \\\n  ensure 2"
   assert_format "foo bar, \\\nbaz", "foo bar,\n  baz"
   assert_format "x 1, \\\n  2", "x 1,\n  2"
+  assert_format "begin\n  1 + \\\n    2\n  3\nend"
+  assert_format "begin\n  1 \\\n    + 2\n  3\nend"
 
   assert_format "alias X = ((Y, Z) ->)"
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4327,6 +4327,7 @@ module Crystal
       old_indent = @indent
       @indent = indent
       value = yield
+      @passed_backslash_newline = false
       @indent = old_indent
       value
     end


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/issues/5892#issuecomment-377822847

This code:

```crystal
begin
  1 + \
    2
  3
end
```

is formatted as:

```crystal
begin
  1 + \
    2
3
end
```

The indent of `3` is removed, it looks wrong. It is fixed by this PR.