### PR TITLE
Colorize: abstract colors and support 8bit and true color

### DIFF
--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -33,6 +33,14 @@ describe "colorize" do
     colorize("hello").white.to_s.should eq("\e[97mhello\e[0m")
   end
 
+  it "colorizes foreground with 8-bit color" do
+    colorize("hello").fore(Colorize::Color256.new(123u8)).to_s.should eq("\e[38;5;123mhello\e[0m")
+  end
+
+  it "colorizes foreground with true color" do
+    colorize("hello").fore(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[38;2;12;34;56mhello\e[0m")
+  end
+
   it "colorizes background" do
     colorize("hello").on_black.to_s.should eq("\e[40mhello\e[0m")
     colorize("hello").on_red.to_s.should eq("\e[41mhello\e[0m")
@@ -50,6 +58,14 @@ describe "colorize" do
     colorize("hello").on_light_magenta.to_s.should eq("\e[105mhello\e[0m")
     colorize("hello").on_light_cyan.to_s.should eq("\e[106mhello\e[0m")
     colorize("hello").on_white.to_s.should eq("\e[107mhello\e[0m")
+  end
+
+  it "colorizes background with 8-bit color" do
+    colorize("hello").back(Colorize::Color256.new(123u8)).to_s.should eq("\e[48;5;123mhello\e[0m")
+  end
+
+  it "colorizes background with true color" do
+    colorize("hello").back(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[48;2;12;34;56mhello\e[0m")
   end
 
   it "colorizes mode" do

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -123,43 +123,63 @@ class Object
   include Colorize::ObjectExtensions
 end
 
+module Colorize
+  alias Color = ColorANSI | Color256 | ColorRGB
+
+  enum ColorANSI
+    Default      = 39
+    Black        = 30
+    Red          = 31
+    Green        = 32
+    Yellow       = 33
+    Blue         = 34
+    Magenta      = 35
+    Cyan         = 36
+    LightGray    = 37
+    DarkGray     = 90
+    LightRed     = 91
+    LightGreen   = 92
+    LightYellow  = 93
+    LightBlue    = 94
+    LightMagenta = 95
+    LightCyan    = 96
+    White        = 97
+
+    def fore
+      to_i.to_s
+    end
+
+    def back
+      (to_i + 10).to_s
+    end
+  end
+
+  record Color256,
+    value : UInt8 do
+    def fore
+      "38;5;#{value}"
+    end
+
+    def back
+      "48;5;#{value}"
+    end
+  end
+
+  record ColorRGB,
+    red : UInt8,
+    green : UInt8,
+    blue : UInt8 do
+    def fore
+      "38;2;#{red};#{green};#{blue}"
+    end
+
+    def back
+      "48;2;#{red};#{green};#{blue}"
+    end
+  end
+end
+
 struct Colorize::Object(T)
-  private FORE_DEFAULT       = "39"
-  private FORE_BLACK         = "30"
-  private FORE_RED           = "31"
-  private FORE_GREEN         = "32"
-  private FORE_YELLOW        = "33"
-  private FORE_BLUE          = "34"
-  private FORE_MAGENTA       = "35"
-  private FORE_CYAN          = "36"
-  private FORE_LIGHT_GRAY    = "37"
-  private FORE_DARK_GRAY     = "90"
-  private FORE_LIGHT_RED     = "91"
-  private FORE_LIGHT_GREEN   = "92"
-  private FORE_LIGHT_YELLOW  = "93"
-  private FORE_LIGHT_BLUE    = "94"
-  private FORE_LIGHT_MAGENTA = "95"
-  private FORE_LIGHT_CYAN    = "96"
-  private FORE_WHITE         = "97"
-
-  private BACK_DEFAULT       = "49"
-  private BACK_BLACK         = "40"
-  private BACK_RED           = "41"
-  private BACK_GREEN         = "42"
-  private BACK_YELLOW        = "43"
-  private BACK_BLUE          = "44"
-  private BACK_MAGENTA       = "45"
-  private BACK_CYAN          = "46"
-  private BACK_LIGHT_GRAY    = "47"
-  private BACK_DARK_GRAY     = "100"
-  private BACK_LIGHT_RED     = "101"
-  private BACK_LIGHT_GREEN   = "102"
-  private BACK_LIGHT_YELLOW  = "103"
-  private BACK_LIGHT_BLUE    = "104"
-  private BACK_LIGHT_MAGENTA = "105"
-  private BACK_LIGHT_CYAN    = "106"
-  private BACK_WHITE         = "107"
-
   private MODE_DEFAULT   = '0'
   private MODE_BOLD      = '1'
   private MODE_BRIGHT    = '1'
@@ -180,21 +200,24 @@ struct Colorize::Object(T)
   private COLORS = %w(black red green yellow blue magenta cyan light_gray dark_gray light_red light_green light_yellow light_blue light_magenta light_cyan white)
   private MODES  = %w(bold bright dim underline blink reverse hidden)
 
+  @fore : Color
+  @back : Color
+
   def initialize(@object : T)
-    @fore = FORE_DEFAULT
-    @back = BACK_DEFAULT
+    @fore = ColorANSI::Default
+    @back = ColorANSI::Default
     @mode = 0
     @enabled = Colorize.enabled?
   end
 
   {% for name in COLORS %}
     def {{name.id}}
-      @fore = FORE_{{name.upcase.id}}
+      @fore = ColorANSI::{{name.camelcase.id}}
       self
     end
 
     def on_{{name.id}}
-      @back = BACK_{{name.upcase.id}}
+      @back = ColorANSI::{{name.camelcase.id}}
       self
     end
   {% end %}
@@ -209,7 +232,7 @@ struct Colorize::Object(T)
   def fore(color : Symbol)
     {% for name in COLORS %}
       if color == :{{name.id}}
-        @fore = FORE_{{name.upcase.id}}
+        @fore = ColorANSI::{{name.camelcase.id}}
         return self
       end
     {% end %}
@@ -217,15 +240,23 @@ struct Colorize::Object(T)
     raise ArgumentError.new "Unknown color: #{color}"
   end
 
+  def fore(@fore : Color)
+    self
+  end
+
   def back(color : Symbol)
     {% for name in COLORS %}
       if color == :{{name.id}}
-        @back = BACK_{{name.upcase.id}}
+        @back = ColorANSI::{{name.camelcase.id}}
         return self
       end
     {% end %}
 
     raise ArgumentError.new "Unknown color: #{color}"
+  end
+
+  def back(@back : Color)
+    self
   end
 
   def mode(mode : Symbol)
@@ -287,8 +318,8 @@ struct Colorize::Object(T)
   protected def append_start(io, reset = false)
     return false unless @enabled
 
-    fore_is_default = @fore == FORE_DEFAULT
-    back_is_default = @back == BACK_DEFAULT
+    fore_is_default = @fore == ColorANSI::Default
+    back_is_default = @back == ColorANSI::Default
     mode_is_default = @mode == 0
 
     if fore_is_default && back_is_default && mode_is_default && !reset
@@ -305,13 +336,13 @@ struct Colorize::Object(T)
 
       unless fore_is_default
         io << ';' if printed
-        io << @fore
+        io << @fore.fore
         printed = true
       end
 
       unless back_is_default
         io << ';' if printed
-        io << @back
+        io << @back.back
         printed = true
       end
 

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -145,23 +145,25 @@ module Colorize
     LightCyan    = 96
     White        = 97
 
-    def fore
-      to_i.to_s
+    def fore(io : IO) : Nil
+      to_i.to_s io
     end
 
-    def back
-      (to_i + 10).to_s
+    def back(io : IO) : Nil
+      (to_i + 10).to_s io
     end
   end
 
   record Color256,
     value : UInt8 do
-    def fore
-      "38;5;#{value}"
+    def fore(io : IO) : Nil
+      io << "38;5;"
+      value.to_s io
     end
 
-    def back
-      "48;5;#{value}"
+    def back(io : IO) : Nil
+      io << "48;5;"
+      value.to_s io
     end
   end
 
@@ -169,12 +171,14 @@ module Colorize
     red : UInt8,
     green : UInt8,
     blue : UInt8 do
-    def fore
-      "38;2;#{red};#{green};#{blue}"
+    def fore(io : IO) : Nil
+      io << "38;2;"
+      {red, green, blue}.join(";", io, &.to_s io)
     end
 
-    def back
-      "48;2;#{red};#{green};#{blue}"
+    def back(io : IO) : Nil
+      io << "48;2;"
+      {red, green, blue}.join(";", io, &.to_s io)
     end
   end
 end
@@ -336,13 +340,13 @@ struct Colorize::Object(T)
 
       unless fore_is_default
         io << ';' if printed
-        io << @fore.fore
+        @fore.fore io
         printed = true
       end
 
       unless back_is_default
         io << ';' if printed
-        io << @back.back
+        @back.back io
         printed = true
       end
 

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -173,12 +173,12 @@ module Colorize
     blue : UInt8 do
     def fore(io : IO) : Nil
       io << "38;2;"
-      {red, green, blue}.join(";", io, &.to_s io)
+      {red, green, blue}.join(';', io, &.to_s io)
     end
 
     def back(io : IO) : Nil
       io << "48;2;"
-      {red, green, blue}.join(";", io, &.to_s io)
+      {red, green, blue}.join(';', io, &.to_s io)
     end
   end
 end


### PR DESCRIPTION
Closes #5900 

It is separated from #3925.

This abstraction is minimum.

You can use true color with such a code:

```crystal
require "colorize"

loop do
  STDOUT << "\r" \
    << "I am a rainbow".colorize.fore(Colorize::ColorRGB.new(rand(0u8..255u8), rand(0u8..255u8), rand(0u8..255u8)))
  STDOUT.flush
  sleep 0.1
end
```

This PR **does NOT provide** a color parser and any utility methods, so you need to create `Colorize::Color256` (8 bit color) or `Colorize::ColorRGB` (true color) instance manually.
Because a color parse is too complex (`rgb()` syntax, `hsla()` syntax, and how to convert color name to color value?). If such a thing is needed, it should be provided as external shard.