### PR TITLE
Pass an unhandled exception to at_exit block as second argument

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -225,4 +225,20 @@ describe "at_exit" do
                            Unhandled exception: Kaboom!
                            OUTPUT
   end
+
+  it "can get unhandled exception in at_exit handler" do
+    status, _, error = build_and_run <<-CODE
+      at_exit do |_, ex|
+        STDERR.puts ex.try &.message
+      end
+
+      raise "Kaboom!"
+    CODE
+
+    status.success?.should be_false
+    error.should contain <<-OUTPUT
+                           Kaboom!
+                           Unhandled exception: Kaboom!
+                           OUTPUT
+  end
 end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -181,10 +181,11 @@ end
 # goodbye cruel world
 # ```
 #
-# The first block argument is the status code that will be returned by this
-# program and the second is unhandled exception of this program.
-# When the second argument is `nil`, it means this program is succeeded or
-# calls `exit(status)` explicitly.
+# The exit status code that will be returned by this program is passed to
+# the block as its first argument. In case of any unhandled exception, it is
+# passed as the second argument to the block, if the program terminates
+# normally or `exit(status)` is called explicitly, then the second argument
+# will be nil.
 def at_exit(&handler : Int32, Exception? ->) : Nil
   AtExitHandlers.add(handler)
 end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -180,6 +180,11 @@ end
 # ```text
 # goodbye cruel world
 # ```
+#
+# The first block argument is the status code that will be returned by this
+# program and the second is unhandled exception of this program.
+# When the second argument is `nil`, it means this program is succeeded or
+# calls `exit(status)` explicitly.
 def at_exit(&handler : Int32, Exception? ->) : Nil
   AtExitHandlers.add(handler)
 end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -127,7 +127,7 @@ module AtExitHandlers
 
   class_property exception : Exception?
 
-  private class_getter(handlers) { [] of Int32 -> }
+  private class_getter(handlers) { [] of Int32, Exception? -> }
 
   def self.add(handler)
     raise "Cannot use at_exit from an at_exit handler" if @@running
@@ -142,7 +142,7 @@ module AtExitHandlers
       # Run the registered handlers in reverse order
       while handler = handlers.pop?
         begin
-          handler.call status
+          handler.call status, exception
         rescue handler_ex
           STDERR.puts "Error running at_exit handler: #{handler_ex}"
           status = 1 if status.zero?
@@ -180,7 +180,7 @@ end
 # ```text
 # goodbye cruel world
 # ```
-def at_exit(&handler : Int32 ->) : Nil
+def at_exit(&handler : Int32, Exception? ->) : Nil
   AtExitHandlers.add(handler)
 end
 


### PR DESCRIPTION
Follow up #1921

It is better in some ways:

  - it does not need a new exception like `SystemExit`.
  - it does not break compatibility in most cases because block fill up lacking arguments. In fact this PR does not fix existing tests for `at_exit`.