### PR TITLE
Remove Object#=~ and Object#!~

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -969,14 +969,6 @@ describe "String" do
       $1.should eq("oo")
       $2.should eq("r")
     end
-
-    it "returns nil with string" do
-      ("foo" =~ "foo").should be_nil
-    end
-
-    it "returns nil with regex and regex" do
-      (/foo/ =~ /foo/).should be_nil
-    end
   end
 
   describe "delete" do

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -109,4 +109,12 @@ struct Nil
   def clone
     self
   end
+
+  def =~(other) : Bool
+    false
+  end
+
+  def !~(other) : Bool
+    true
+  end
 end

--- a/src/object.cr
+++ b/src/object.cr
@@ -14,11 +14,6 @@ class Object
     !(self == other)
   end
 
-  # Shortcut to `!(self =~ other)`.
-  def !~(other)
-    !(self =~ other)
-  end
-
   # Case equality.
   #
   # The `===` method is used in a `case ... when ... end` expression.
@@ -48,14 +43,6 @@ class Object
   # (notably `Regex`) can override it to provide meaningful case-equality semantics.
   def ===(other)
     self == other
-  end
-
-  # Pattern match.
-  #
-  # Overridden by descendants (notably `Regex` and `String`) to provide meaningful
-  # pattern-match semantics.
-  def =~(other)
-    nil
   end
 
   # Appends this object's value to *hasher*, and returns the modified *hasher*.

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -388,14 +388,14 @@ class Regex
     match.try &.begin(0)
   end
 
-  # Match. When the argument is not a `String`, always returns `nil`.
-  #
-  # ```
-  # /at/ =~ "input data" # => 7
-  # /ax/ =~ "input data" # => nil
-  # ```
-  def =~(other)
+  # ditto
+  def =~(other : Nil)
     nil
+  end
+
+  # Shortcut to `!(self =~ other)`.
+  def !~(other : String?) : Bool
+    !(self =~ other)
   end
 
   # Convert to `String` in literal format. Returns the source as a `String` in

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -170,7 +170,7 @@ module Spec
     end
 
     def match(actual_value)
-      actual_value =~ @expected_value
+      actual_value.responds_to?(:=~) && actual_value =~ @expected_value
     end
 
     def failure_message(actual_value)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -170,7 +170,7 @@ module Spec
     end
 
     def match(actual_value)
-      actual_value.responds_to?(:=~) && actual_value =~ @expected_value
+      actual_value =~ @expected_value
     end
 
     def failure_message(actual_value)

--- a/src/string.cr
+++ b/src/string.cr
@@ -2446,8 +2446,13 @@ class String
   end
 
   # ditto
-  def =~(other)
+  def =~(other : Nil)
     nil
+  end
+
+  # Shortcut to `!(self =~ other)`.
+  def !~(other : Regex?) : Bool
+    !(self =~ other)
   end
 
   # Concatenates *str* and *other*.


### PR DESCRIPTION
Fixes #5829 

Overloads for `Regex#=~` are restricted to receive `String | Nil` and for `String#=~` to receive `Regex | Nil`. `#!~` is re-added as instance method in both classes accepting the same overload.

It could be up for debate to leave `Object#!~` to avoid having individual definitions in classes implementing `=~`. But this would end up in a similar issues as #3450

I'm also not entirely sure about the type safety of `Regex#=~` and `String#=~`. Should their argument really be nilable, or allow only `String`, `Regex` type, respectively? On the other hand, they could even receive any type and just return `nil` like it is the case right now.