### PR TITLE
Fix `String#tr` 1 byte `from` optimization bug

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1718,6 +1718,8 @@ describe "String" do
       "hello".tr("helo", "1212").should eq("12112")
       "this".tr("this", "ⓧ").should eq("ⓧⓧⓧⓧ")
       "über".tr("ü", "u").should eq("uber")
+      "aabbcc".tr("a", "xyz").should eq("xxbbcc")
+      "aabbcc".tr("a", "いろは").should eq("いいbbcc")
     end
 
     context "given no replacement characters" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -1591,7 +1591,7 @@ class String
     return delete(from) if to.empty?
 
     if from.bytesize == 1
-      return gsub(from.unsafe_byte_at(0).unsafe_chr, to)
+      return gsub(from.unsafe_byte_at(0).unsafe_chr, to[0])
     end
 
     multi = nil


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/pull/5912#discussion_r179045812

`"aabbcc".tr("a", "xyz")` yields `"xyzxyzbbcc"` currently.
Of course it is unintentional behavior, also bug. In Ruby it yields `"xxbbcc"` and on shell `echo aabbcc | tr a xyz` shows `xxbbcc` in fact.