### PR TITLE
Fix File.join with empty path component

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -307,7 +307,7 @@ describe "File" do
     File.join(["foo", "//bar//", "baz///"]).should eq("foo//bar//baz///")
     File.join(["/foo/", "/bar/", "/baz/"]).should eq("/foo/bar/baz/")
     File.join(["", "foo"]).should eq("foo")
-    File.join(["foo", ""]).should eq("foo")
+    File.join(["foo", ""]).should eq("foo/")
     File.join(["", "", "foo"]).should eq("foo")
     File.join(["foo", "", "bar"]).should eq("foo/bar")
     File.join(["foo", "", "", "bar"]).should eq("foo/bar")

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -306,6 +306,11 @@ describe "File" do
     File.join(["foo", "bar", "baz"]).should eq("foo/bar/baz")
     File.join(["foo", "//bar//", "baz///"]).should eq("foo//bar//baz///")
     File.join(["/foo/", "/bar/", "/baz/"]).should eq("/foo/bar/baz/")
+    File.join(["", "foo"]).should eq("foo")
+    File.join(["foo", ""]).should eq("foo")
+    File.join(["", "", "foo"]).should eq("foo")
+    File.join(["foo", "", "bar"]).should eq("foo/bar")
+    File.join(["foo", "", "", "bar"]).should eq("foo/bar")
   end
 
   it "chown" do

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -231,7 +231,11 @@ class Dir
     return 0 if Dir.exists?(path)
 
     components = path.split(File::SEPARATOR)
-    if components.first == "." || components.first == ""
+    case components.first
+    when ""
+      components.shift
+      subpath = "/"
+    when "."
       subpath = components.shift
     else
       subpath = "."

--- a/src/file.cr
+++ b/src/file.cr
@@ -707,10 +707,13 @@ class File < IO::FileDescriptor
   # ```
   def self.join(parts : Array | Tuple) : String
     String.build do |str|
+      first = true
       parts.each_with_index do |part, index|
         part.check_no_null_byte
+        next if part.empty?
 
-        str << SEPARATOR if index > 0
+        str << SEPARATOR unless first
+        first = false
 
         byte_start = 0
         byte_count = part.bytesize

--- a/src/file.cr
+++ b/src/file.cr
@@ -710,15 +710,14 @@ class File < IO::FileDescriptor
       first = true
       parts.each_with_index do |part, index|
         part.check_no_null_byte
-        next if part.empty?
+        next if part.empty? && index != parts.size - 1
 
         str << SEPARATOR unless first
-        first = false
 
         byte_start = 0
         byte_count = part.bytesize
 
-        if index > 0 && part.starts_with?(SEPARATOR)
+        if !first && part.starts_with?(SEPARATOR)
           byte_start += 1
           byte_count -= 1
         end
@@ -728,6 +727,8 @@ class File < IO::FileDescriptor
         end
 
         str.write part.unsafe_byte_slice(byte_start, byte_count)
+
+        first = false
       end
     end
   end


### PR DESCRIPTION
Fixes #5905 

It could be debated if an empty last component (`File.join("foo", "")`) should result in a path ending with a separator (`"foo/"`). That would be more complicated than this simple fix and is probably not that useful as `File.join("foo", "/")` yields the same result.