### PR TITLE
New logging system (addresses #5874)

### DIFF
--- a/spec/std/logger/adapter_spec.cr
+++ b/spec/std/logger/adapter_spec.cr
@@ -6,8 +6,10 @@ describe Logger::IOAdapter do
     IO.pipe do |r, w|
       adapter = Logger::IOAdapter.new(w, "")
       adapter.write(Logger::WARN, "message", Time.now, "crystal")
+      adapter.write(Logger::WARN, "message", Time.now, "")
 
       r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN \/ crystal: message\n/)
+      r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN: message\n/)
     end
   end
 
@@ -15,17 +17,10 @@ describe Logger::IOAdapter do
     IO.pipe do |r, w|
       adapter = Logger::IOAdapter.new(w, "crystal")
       adapter.write(Logger::ERROR, "whoops", Time.now, "adapter")
-      adapter.write(Logger::UNKNOWN, "uh oh", Time.now, "spec")
+      adapter.write(Logger::UNKNOWN, "uh oh", Time.now, "")
 
       r.gets(chomp: false).should match(/E, \[.+? #\d+\] ERROR -- crystal \/ adapter: whoops\n/)
-      r.gets(chomp: false).should match(/A, \[.+? #\d+\]   ANY -- crystal \/ spec: uh oh\n/)
-    end
-  end
-
-  it "closes" do
-    IO.pipe do |r, w|
-      Logger::IOAdapter.new(w).close
-      w.closed?.should be_true
+      r.gets(chomp: false).should match(/A, \[.+? #\d+\]   ANY -- crystal: uh oh\n/)
     end
   end
 end

--- a/spec/std/logger/adapter_spec.cr
+++ b/spec/std/logger/adapter_spec.cr
@@ -4,22 +4,21 @@ require "logger"
 describe Logger::IOAdapter do
   it "formats message" do
     IO.pipe do |r, w|
-      adapter = Logger::IOAdapter.new(w)
-      adapter.write(Logger::WARN, Time.now, "crystal", "message")
+      adapter = Logger::IOAdapter.new(w, "")
+      adapter.write(Logger::WARN, "message", Time.now, "crystal")
 
-      r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
+      r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN \/ crystal: message\n/)
     end
   end
 
-  it "uses custom formatter" do
+  it "formats message with program_name" do
     IO.pipe do |r, w|
-      adapter = Logger::IOAdapter.new(w)
-      adapter.formatter = Logger::IOAdapter::Formatter.new do |severity, datetime, component, message, io|
-        io << severity.to_s[0] << " " << component << ": " << message
-      end
-      adapter.write(Logger::WARN, Time.now, "prog", "message")
+      adapter = Logger::IOAdapter.new(w, "crystal")
+      adapter.write(Logger::ERROR, "whoops", Time.now, "adapter")
+      adapter.write(Logger::UNKNOWN, "uh oh", Time.now, "spec")
 
-      r.gets(chomp: false).should eq("W prog: message\n")
+      r.gets(chomp: false).should match(/E, \[.+? #\d+\] ERROR -- crystal \/ adapter: whoops\n/)
+      r.gets(chomp: false).should match(/A, \[.+? #\d+\]   ANY -- crystal \/ spec: uh oh\n/)
     end
   end
 

--- a/spec/std/logger/adapter_spec.cr
+++ b/spec/std/logger/adapter_spec.cr
@@ -1,0 +1,32 @@
+require "spec"
+require "logger"
+
+describe Logger::IOAdapter do
+  it "formats message" do
+    IO.pipe do |r, w|
+      adapter = Logger::IOAdapter.new(w)
+      adapter.write(Logger::WARN, Time.now, "crystal", "message")
+
+      r.gets(chomp: false).should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
+    end
+  end
+
+  it "uses custom formatter" do
+    IO.pipe do |r, w|
+      adapter = Logger::IOAdapter.new(w)
+      adapter.formatter = Logger::IOAdapter::Formatter.new do |severity, datetime, component, message, io|
+        io << severity.to_s[0] << " " << component << ": " << message
+      end
+      adapter.write(Logger::WARN, Time.now, "prog", "message")
+
+      r.gets(chomp: false).should eq("W prog: message\n")
+    end
+  end
+
+  it "closes" do
+    IO.pipe do |r, w|
+      Logger::IOAdapter.new(w).close
+      w.closed?.should be_true
+    end
+  end
+end

--- a/spec/std/logger/handler_spec.cr
+++ b/spec/std/logger/handler_spec.cr
@@ -1,0 +1,132 @@
+require "spec"
+require "logger"
+
+class TestAdapter
+  include Logger::Adapter
+  getter messages = [] of String
+
+  def write(severity, message, time, component)
+    @messages << "#{severity} #{component} #{message}"
+  end
+end
+
+describe Logger::Handler do
+  it "logs messages" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    handler.log Logger::DEBUG, "debug:skip"
+    handler.log Logger::INFO, "info:show"
+
+    handler.set_level Logger::DEBUG
+    handler.log Logger::DEBUG, "debug:show"
+
+    handler.set_level Logger::WARN
+    handler.log Logger::DEBUG, "debug:skip:again"
+    handler.log Logger::INFO, "info:skip"
+    handler.log Logger::ERROR, "error:show"
+
+    adapter.messages.shift.should match(/info:show/)
+    adapter.messages.shift.should match(/debug:show/)
+    adapter.messages.shift.should match(/error:show/)
+    adapter.messages.size.should eq 0
+  end
+
+  it "logs components selectively" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    handler.set_level Logger::ERROR
+    handler.set_level "Foo::Bar", Logger::WARN
+    handler.log Logger::WARN, "root:warn"
+    handler.log Logger::WARN, "foo:warn", "Foo"
+    handler.log Logger::WARN, "foobar:warn", "Foo::Bar"
+    handler.log Logger::WARN, "fooquux:warn", "Foo::Quux"
+    handler.log Logger::WARN, "foobarbaz:warn", "Foo::Bar::Baz"
+
+    adapter.messages.shift.should match(/foobar:warn/)
+    adapter.messages.shift.should match(/foobarbaz:warn/)
+    adapter.messages.size.should eq 0
+
+    handler.set_level "Foo", Logger::DEBUG
+    handler.log Logger::DEBUG, "root:debug"
+    handler.log Logger::DEBUG, "foo:debug", "Foo"
+    handler.log Logger::DEBUG, "foobar:debug", "Foo::Bar"
+    handler.log Logger::DEBUG, "foobarbaz:debug", "Foo::Bar::Baz"
+    handler.log Logger::DEBUG, "fooquux:debug", "Foo::Quux"
+
+    adapter.messages.shift.should match(/foo:debug/)
+    adapter.messages.shift.should match(/fooquux:debug/)
+    adapter.messages.size.should eq 0
+
+    handler.unset_level "Foo::Bar"
+    handler.log Logger::DEBUG, "foobar:debug", "Foo::Bar"
+    handler.log Logger::DEBUG, "foobarbaz:debug", "Foo::Bar::Baz"
+
+    adapter.messages.shift.should match(/foobar:debug/)
+    adapter.messages.shift.should match(/foobarbaz:debug/)
+    adapter.messages.size.should eq 0
+  end
+
+  it "finds real and effective levels" do
+    handler = Logger::Handler.new([] of Logger::Adapter)
+
+    handler.set_level "one::two", Logger::WARN
+    handler.set_level "one::two::three", Logger::ERROR
+
+    handler.level?("one").should be_nil
+    handler.level!("one").should eq Logger::INFO
+    handler.level?("one::two").should eq Logger::WARN
+    handler.level!("one::two").should eq Logger::WARN
+    handler.level?("one::two::three").should eq Logger::ERROR
+    handler.level!("one::two::three").should eq Logger::ERROR
+    handler.level?("one::two::three::four").should be_nil
+    handler.level!("one::two::three::four").should eq Logger::ERROR
+    handler.level?("one::two::five").should be_nil
+    handler.level!("one::two::five").should eq Logger::WARN
+
+    handler.unset_level "one::two::three"
+    handler.level?("one::two::three").should be_nil
+    handler.level!("one::two::three").should eq Logger::WARN
+    handler.level?("one::two::three::four").should be_nil
+    handler.level!("one::two::three::four").should eq Logger::WARN
+  end
+
+  it "logs any object" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    handler.log Logger::INFO, 12345
+
+    adapter.messages.shift.should match(/12345/)
+    adapter.messages.size.should eq 0
+  end
+
+  it "uses adapters" do
+    adapter1 = TestAdapter.new
+    adapter2 = TestAdapter.new
+    handler = Logger::Handler.new([adapter1, adapter2] of Logger::Adapter)
+    handler.log Logger::INFO, "one"
+    handler.adapters.pop
+    handler.log Logger::INFO, "two"
+    handler.adapters.clear
+    handler.log Logger::INFO, "three"
+    handler.adapters << adapter2
+    handler.log Logger::INFO, "four"
+
+    adapter1.messages.shift.should match(/one/)
+    adapter2.messages.shift.should match(/one/)
+    adapter1.messages.shift.should match(/two/)
+    adapter2.messages.shift.should match(/four/)
+    adapter1.messages.size.should eq 0
+    adapter2.messages.size.should eq 0
+  end
+
+  it "yields message" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    handler.log(Logger::ERROR) { "message" }
+    handler.log(Logger::UNKNOWN, component: "comp") { "another message" }
+
+    adapter.messages.shift.should eq("ERROR  message")
+    adapter.messages.shift.should eq("UNKNOWN comp another message")
+    adapter.messages.size.should eq 0
+  end
+end

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -59,9 +59,9 @@ describe "Logger" do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.level = Logger::SILENT
-      logger.log(Logger::SILENT, "skip")
+      logger.log(Logger::SILENT, "skip", "")
       logger.level = Logger::UNKNOWN
-      logger.log(Logger::SILENT, "show")
+      logger.log(Logger::SILENT, "show", "")
 
       r.gets.should match(/ANY.*show/)
     end
@@ -102,21 +102,10 @@ describe "Logger" do
     IO.pipe do |r, w|
       logger = Logger.new(w)
       logger.error { "message" }
-      logger.unknown { "another message" }
+      logger.unknown(component: "comp") { "another message" }
 
-      r.gets(chomp: false).should match(/ERROR -- : message\n/)
-      r.gets(chomp: false).should match(/  ANY -- : another message\n/)
-    end
-  end
-
-  it "yields message with progname" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.error("crystal") { "message" }
-      logger.unknown("shard") { "another message" }
-
-      r.gets(chomp: false).should match(/ERROR -- crystal: message\n/)
-      r.gets(chomp: false).should match(/  ANY -- shard: another message\n/)
+      r.gets(chomp: false).should match(/ERROR: message\n/)
+      r.gets(chomp: false).should match(/  ANY \/ comp: another message\n/)
     end
   end
 

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -1,123 +1,71 @@
 require "spec"
 require "logger"
 
-describe "Logger" do
-  it "logs messages" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.debug "debug:skip"
-      logger.info "info:show"
+class TestAdapter
+  include Logger::Adapter
+  getter messages = [] of String
 
-      logger.level = Logger::DEBUG
-      logger.debug "debug:show"
+  def write(severity, message, time, component)
+    @messages << "#{severity} #{component} #{message}"
+  end
+end
 
-      logger.level = Logger::WARN
-      logger.debug "debug:skip:again"
-      logger.info "info:skip"
-      logger.error "error:show"
+describe Logger do
+  it "forwards log messages" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    logger1 = Logger.new("foo", handler)
+    logger2 = Logger.new("bar", handler)
 
-      r.gets.should match(/info:show/)
-      r.gets.should match(/debug:show/)
-      r.gets.should match(/error:show/)
-    end
+    logger1.warn "one"
+    logger2.debug "skip"
+    logger2.info "two"
+    logger1.warn "three"
+
+    adapter.messages.shift.should eq("WARN foo one")
+    adapter.messages.shift.should eq("INFO bar two")
+    adapter.messages.shift.should eq("WARN foo three")
+    adapter.messages.size.should eq 0
   end
 
-  it "logs components selectively" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.set_level Logger::ERROR
-      logger.set_level Logger::WARN, "Foo::Bar"
-      logger.warn "root:warn"
-      logger.warn "foo:warn", "Foo"
-      logger.warn "foobar:warn", "Foo::Bar"
-      logger.warn "fooquux:warn", "Foo::Quux"
-      logger.warn "foobarbaz:warn", "Foo::Bar::Baz"
+  it "delegates level methods" do
+    adapter = TestAdapter.new
+    handler = Logger::Handler.new(adapter)
+    logger1 = Logger.new("foo", handler)
+    logger2 = Logger.new("foo::bar", handler)
 
-      r.gets.should match(/foobar:warn/)
-      r.gets.should match(/foobarbaz:warn/)
+    logger2.level?.should be_nil
+    logger2.level!.should eq Logger::INFO
+    logger2.debug?.should be_false
+    logger2.debug "skip"
 
-      logger.set_level Logger::DEBUG, "Foo"
-      logger.debug "root:debug"
-      logger.debug "foo:debug", "Foo"
-      logger.debug "foobar:debug", "Foo::Bar"
-      logger.debug "foobarbaz:debug", "Foo::Bar::Baz"
-      logger.debug "fooquux:debug", "Foo::Quux"
+    logger1.level = Logger::DEBUG
 
-      r.gets.should match(/foo:debug/)
-      r.gets.should match(/fooquux:debug/)
+    logger1.level?.should eq Logger::DEBUG
+    logger1.level!.should eq Logger::DEBUG
+    logger2.level?.should be_nil
+    logger2.level!.should eq Logger::DEBUG
+    logger2.debug?.should be_true
+    logger2.debug "show"
 
-      logger.unset_level "Foo::Bar"
-      logger.debug "foobar:debug", "Foo::Bar"
-      logger.debug "foobarbaz:debug", "Foo::Bar::Baz"
+    logger1.level = nil
 
-      r.gets.should match(/foobar:debug/)
-      r.gets.should match(/foobarbaz:debug/)
-    end
-  end
+    logger1.level?.should be_nil
+    logger1.level!.should eq Logger::INFO
+    logger2.level?.should be_nil
+    logger2.level!.should eq Logger::INFO
+    logger2.debug?.should be_false
+    logger2.debug "show"
 
-  it "converts SILENT to UNKNOWN" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.level = Logger::SILENT
-      logger.log(Logger::SILENT, "skip", "")
-      logger.level = Logger::UNKNOWN
-      logger.log(Logger::SILENT, "show", "")
-
-      r.gets.should match(/ANY.*show/)
-    end
+    adapter.messages.size.should eq 1
   end
 
   it "logs any object" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.info 12345
+    adapter = TestAdapter.new
+    logger = Logger.new(Logger::Handler.new(adapter))
+    logger.info 12345
 
-      r.gets.should match(/12345/)
-    end
-  end
-
-  it "uses adapters" do
-    IO.pipe do |r1, w1|
-      IO.pipe do |r2, w2|
-        adapter1 = Logger::IOAdapter.new(w1)
-        adapter2 = Logger::IOAdapter.new(w2)
-        logger = Logger.new(adapter1)
-        logger.info "one"
-        logger.adapters << adapter2
-        logger.info "two"
-        logger.adapters.clear
-        logger.info "three"
-        logger.adapters << adapter1
-        logger.info "four"
-
-        r1.gets.should match(/one/)
-        r1.gets.should match(/two/)
-        r1.gets.should match(/four/)
-        r2.gets.should match(/two/)
-      end
-    end
-  end
-
-  it "yields message" do
-    IO.pipe do |r, w|
-      logger = Logger.new(w)
-      logger.error { "message" }
-      logger.unknown(component: "comp") { "another message" }
-
-      r.gets(chomp: false).should match(/ERROR: message\n/)
-      r.gets(chomp: false).should match(/  ANY \/ comp: another message\n/)
-    end
-  end
-
-  it "can create a logger with nil (#3065)" do
-    logger = Logger.new(nil)
-    logger.error("ouch")
-  end
-
-  it "doesn't yield to the block with nil" do
-    a = 0
-    logger = Logger.new(nil)
-    logger.info { a = 1 }
-    a.should eq(0)
+    adapter.messages.shift.should eq("INFO  12345")
+    adapter.messages.size.should eq 0
   end
 end

--- a/src/logger/adapter.cr
+++ b/src/logger/adapter.cr
@@ -1,26 +1,28 @@
 class Logger
-  # The `Adapter` module can be used to supply behaviors to `Logger` other
-  # than writing to an `IO`, such as appending logs to a database or
-  # shipping them via a particular protocal. All that needs to be done is to
-  # include `Adapter` in a class, define `#write`, and pass an instance to
-  # the constructor of `Logger`.
+  # The `Adapter` module can be used to supply log writing behaviors such as
+  # appending to an `IO` or shipping them via a particular protocal. All that
+  # needs to be done is to include `Adapter` in a class and define `#write`.
   module Adapter
     # Receives log data from a `Logger` and does something with it, typically
     # persisting the message somewhere or shipping it to a log aggregator.
     abstract def write(severity : Severity, message : String, time : Time, component : String)
   end
 
-  # `IOAdapter` is the built-in `Adapter`. It is automatically
-  # instantiated when passing an `IO` to `Logger.new`.
+  # `IOAdapter` is the built-in `Adapter`. It formats log messages nicely and
+  # then writes them to an `IO`. The default handler uses an `IOAdapter` that
+  # writes to `STDERR`.
   class IOAdapter
     include Adapter
 
     # The name of the program, as should be included in log messages.
     getter program_name : String
 
-    # Creates a new IOLogAdapter. If not supplied with a program name, the
+    # The `IO` object to be written to.
+    getter io
+
+    # Creates a new `IOAdapter`. If not supplied with a program name, the
     # filename of the running executable is used.
-    def initialize(@io : IO, program_name = self.class.find_program_name)
+    def initialize(@io : IO, program_name = File.basename(PROGRAM_NAME))
       @program_name = program_name.to_s
       @closed = false
       @mutex = Mutex.new
@@ -35,27 +37,9 @@ class Logger
       end
     end
 
-    # Calls the *close* method on the object passed to `initialize`.
-    def close
-      return if @closed
-      @closed = true
-
-      @mutex.synchronize do
-        @io.close
-      end
-    end
-
-    protected def self.find_program_name
-      if path = Process.executable_path
-        File.basename(path)
-      else
-        ""
-      end
-    end
-
-    # Formats a single `Logger::Entry` and prints it to the given `IO`.
+    # Formats a single log entry and prints it to the given `IO`.
     #
-    # To provide a custom formatter, simply subclass `IOAdapter` and override this method.
+    # To provide a custom formatter, subclass `IOAdapter` and override this method.
     # Example:
     #
     # ```
@@ -75,13 +59,13 @@ class Logger
     #   end
     # end
     #
-    # logger = Logger.new(MyAdapter.new(STDERR, program_name: "YodaBot"))
+    # Logger.default_handler.adapters = [MyAdapter.new(STDERR, program_name: "YodaBot")] of Logger::Adapter
+    # logger = Logger.new
     # logger.warn("Fear leads to anger. Anger leads to hate. Hate leads to suffering.")
     #
     # # Prints to the console:
     # # -- 2018-03-29 00:13:38 -07:00 WARN YodaBot: Fear leads to anger. Anger leads to hate. Hate leads to suffering.
     # ```
-
     def format(severity, message, time, component)
       label = severity.unknown? ? "ANY" : severity.to_s
       @io << label[0] << ", [" << time << " #" << Process.pid << "] " << label.rjust(5)

--- a/src/logger/adapter.cr
+++ b/src/logger/adapter.cr
@@ -1,0 +1,87 @@
+class Logger
+  # The `Adapter` module can be used to supply behaviors to `Logger` other
+  # than writing to an `IO`, such as appending logs to a database or
+  # shipping them via a particular protocal. All that needs to be done is to
+  # include `Adapter` in a class, define `#write`, and pass an instance to
+  # the constructor of `Logger`.
+  module Adapter
+    # Receives log data from a `Logger` and does something with it, typically
+    # persisting the message somewhere or shipping it to a log aggregator.
+    abstract def write(severity : Logger::Severity, datetime : Time, progname : String, message : String)
+  end
+
+  # `IOAdapter` is the built-in `Adapter`. It is automatically
+  # instantiated when passing an `IO` to `Logger.new`.
+  class IOAdapter
+    include Adapter
+
+    alias Formatter = Severity, Time, String, String, IO ->
+    # Customizable `Proc` (with a reasonable default)
+    # which the `IOAdapter` uses to format and print its entries.
+    #
+    # Use this setter to provide a custom formatter.
+    # The `IOAdapter` will invoke it with the following arguments:
+    #  - severity: a `Logger::Severity`
+    #  - datetime: `Time`, the entry's timestamp
+    #  - progname: `String`, the program name, if set when the logger was built
+    #  - message: `String`, the body of a message
+    #  - io: `IO`, the Logger's stream, to which you must write the final output
+    #
+    # Example:
+    #
+    # ```
+    # require "logger"
+    #
+    # formatter = Logger::IOAdapter::Formatter.new do |severity, datetime, progname, message, io|
+    #   case severity
+    #   when .>= Logger::ERROR
+    #     io << "!!"
+    #   when .>= Logger::INFO
+    #     io << "--"
+    #   else
+    #     io << ".."
+    #   end
+    #   io << ' ' << datetime << ' ' << severity.to_s.rjust(5) << ' ' << progname << ": " << message
+    # end
+    #
+    # logger = Logger.new(STDOUT, formatter: formatter, progname: "YodaBot")
+    # logger.warn("Fear leads to anger. Anger leads to hate. Hate leads to suffering.")
+    #
+    # # Prints to the console:
+    # # "-- 2017-05-06 18:00:41 -03:00  WARN YodaBot: Fear leads to anger.
+    # # Anger leads to hate. Hate leads to suffering."
+    # ```
+    property formatter : Formatter
+    DEFAULT_FORMATTER = Formatter.new do |severity, datetime, progname, message, io|
+      label = severity.unknown? ? "ANY" : severity.to_s
+      io << label[0] << ", [" << datetime << " #" << Process.pid << "] "
+      io << label.rjust(5) << " -- " << progname << ": " << message
+    end
+
+    # Creates a new IOLogAdapter. If not supplied with a `formatter`, a
+    # default is used.
+    def initialize(@io : IO, @formatter = DEFAULT_FORMATTER)
+      @closed = false
+      @mutex = Mutex.new
+    end
+
+    # Writes a message to `@io`.
+    def write(severity, datetime, progname, message)
+      @mutex.synchronize do
+        @formatter.call(severity, datetime, progname.to_s, message.to_s, @io)
+        @io.puts
+        @io.flush
+      end
+    end
+
+    # Calls the *close* method on the object passed to `initialize`.
+    def close
+      return if @closed
+      @closed = true
+
+      @mutex.synchronize do
+        @io.close
+      end
+    end
+  end
+end

--- a/src/logger/handler.cr
+++ b/src/logger/handler.cr
@@ -1,0 +1,130 @@
+require "./severity"
+
+class Logger
+  # `Handler` is responsible for accepting log messages, filtering them based
+  # on severity, and dispatching them to one or more `Adapter` objects.
+  #
+  # Each handler internally maintains a hash of components and their
+  # associated log levels. Components are simply strings, and are treated
+  # hierarchically using "::" as a delimiter. This means that if the level for
+  # component "Foo" is set to WARN, then messages from component "Foo::Bar"
+  # will also use WARN as their threshold.
+  #
+  # Most programs will only ever need the default handler provided by
+  # `Logger.default_handler`.
+  #
+  # Example:
+  # ```crystal
+  # require "logger"
+  #
+  # module Zoo
+  #   class Giraffe
+  #     @@logger = Logger.new(name)
+  #
+  #     # Equivalent to `Logger.default_handler.set_level "Zoo::Giraffe", Logger::DEBUG`
+  #     @@logger.level = Logger::DEBUG
+  #
+  #     def initialize
+  #       @@logger.info "A giraffe has arrived."
+  #     end
+  #   end
+  #
+  #   class Rhinocerous
+  #     @@logger = Logger.new(name)
+  #
+  #     def initialize
+  #       @@logger.info "A rhino has arrived."
+  #       @@logger.warn "The rhino is charging!"
+  #     end
+  #   end
+  # end
+  #
+  # # I only want to hear about problems from most animals:
+  # Logger.default_handler.set_level "Zoo", Logger::WARN
+  #
+  # Zoo::Giraffe.new     # prints "A giraffe has arrived"
+  # Zoo::Rhinocerous.new # prints only "The rhino is charging!"
+  # ```
+  class Handler
+    # Each log message that meets this handler's severity level will be output
+    # by all of the  adapters in this array.
+    property adapters : Array(Adapter)
+
+    # Creates a new handler that will use the given adapter to log messages.
+    def self.new(adapter : Adapter, level = DEFAULT_SEVERITY)
+      return new([adapter] of Adapter, level)
+    end
+
+    # Creates a new handler that will use multiple adapters to log messages.
+    def initialize(@adapters : Array(Adapter), level = DEFAULT_SEVERITY)
+      @levels = {"" => level} of String => Severity
+    end
+
+    # Searches up the component hierarchy to find the effective log level for
+    # the given component.
+    def level!(component : String = "") : Severity
+      if severity = @levels[component]?
+        return severity
+      end
+
+      parts = component.split "::"
+      until parts.empty?
+        parts.pop
+        if severity = @levels[parts.join "::"]?
+          return severity
+        end
+      end
+
+      # Never executes - @levels[""] should always exist
+      raise "No log level found for #{component}"
+    end
+
+    # Gets the log level of the given component, returning `nil` if none is
+    # set.
+    def level?(component : String = "") : Severity?
+      @levels[component]?
+    end
+
+    # Sets the log level for the given component
+    def set_level(component : String, level : Severity) : Nil
+      @levels[component] = level
+    end
+
+    # Sets the log level for the root component
+    def set_level(level : Severity) : Nil
+      @levels[""] = level
+    end
+
+    # Removes the log level for a given component, causing it to fall back on
+    # its parents in the hierarchy. Unsetting the root component (`""`) sets
+    # it to INFO.
+    def unset_level(component : String = "") : Nil
+      if component.empty?
+        @levels[""] = DEFAULT_SEVERITY
+      else
+        @levels.delete component
+      end
+    end
+
+    # Logs *message* if *severity* meets or exceeds level of *component*.
+    def log(severity, message, component = nil)
+      component = component.to_s
+      return if severity < level!(component)
+      @adapters.each &.write(severity, message.to_s, Time.now, component)
+    end
+
+    # Logs the message returned from the given block if *severity* meets or
+    # exceeds the level of *component*. The block is not run otherwise. This
+    # is preferable to passing the message in directly when building the
+    # message adds significant overhead.
+    def log(severity, component = nil)
+      component = component.to_s
+      return if severity < level!(component)
+      @adapters.each &.write(severity, yield.to_s, Time.now, component)
+    end
+  end
+
+  def self.default_handler
+    @@default_handler ||= Handler.new(IOAdapter.new(STDERR))
+  end
+end

--- a/src/logger/severity.cr
+++ b/src/logger/severity.cr
@@ -1,0 +1,30 @@
+class Logger
+  # A logger severity level.
+  enum Severity
+    # Low-level information for developers
+    DEBUG
+
+    # Generic (useful) information about system operation
+    INFO
+
+    # A warning
+    WARN
+
+    # A handleable error condition
+    ERROR
+
+    # An unhandleable error that results in a program crash
+    FATAL
+
+    UNKNOWN
+
+    # Mutes all output when used as a threshold. Attempting to logging at this
+    # level will produce UNKNOWN instead.
+    SILENT
+  end
+
+  DEFAULT_SEVERITY = Severity::INFO
+  {% for name in Severity.constants %}
+    {{name.id}} = Severity::{{name.id}}
+  {% end %}
+end


### PR DESCRIPTION
Here's my first stab at a better `Logger` class for the standard library as discussed in #5874. Control goes from `Logger` -> `Handler` -> `Adapter`, where `Logger` stores a class name and provides user-friendly methods, `Handler` filters by severity, and `Adapter` formats the message to an IO.

One detail I wasn't sure whether to address - how much do we care about backwards compatibility? As-is this breaks 100% of programs using `Logger`, but I can add a slightly ugly constructor that will preserve some of the simpler use cases.