### PR TITLE
Format: fix formatter bug on nesting begin/end

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -150,6 +150,8 @@ describe Crystal::Formatter do
   assert_format "begin; 1; end", "begin\n  1\nend"
   assert_format "begin\n1\n2\n3\nend", "begin\n  1\n  2\n  3\nend"
   assert_format "begin\n1 ? 2 : 3\nend", "begin\n  1 ? 2 : 3\nend"
+  assert_format "begin\n  begin\n\n  end\nend"
+  assert_format "begin\n  ()\nend"
 
   assert_format "def   foo  \n  end", "def foo\nend"
   assert_format "def foo\n1\nend", "def foo\n  1\nend"

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -124,4 +124,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"
+  expect_to_s %(begin\n  ()\nend)
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1222,7 +1222,7 @@ module Crystal
       exps = parse_expressions
       node, end_location = parse_exception_handler exps
       node.end_location = end_location
-      if !node.is_a?(ExceptionHandler) && !node.is_a?(Expressions)
+      if !node.is_a?(ExceptionHandler) && (!node.is_a?(Expressions) || node.keyword)
         node = Expressions.new([node]).at(node).at_end(node)
       end
       node.keyword = :begin if node.is_a?(Expressions)


### PR DESCRIPTION
This file reproduces a formatter bug:

```crystal
begin
  begin
  end
end
```

```
Error: couldn't format STDIN, please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues

expecting keyword end, not `(, `, at :2:3 (Exception)
  from Crystal::Formatter#check_keyword<Symbol>:Nil
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::Formatter>:(Bool | Nil)
  from Crystal::Formatter::format<String, Nil>:String
  from Crystal::Command#tool:(Bool | IO::FileDescriptor | Nil)
  from Crystal::Command#run:(Bool | Crystal::Compiler::Result | IO::FileDescriptor | Nil)
  from main
```

It is fixed by this PR.