### PR TITLE
Improve HTTP::ChunkedContent implementation

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -9,7 +9,7 @@ describe HTTP::ChunkedContent do
     bytes_read = content.read(bytes.to_slice)
     bytes_read.should eq(4)
     String.new(bytes.to_slice).should eq("123\n")
-    mem.pos.should eq(9) # only this chunk was read
+    mem.pos.should eq(7) # only this chunk was read
   end
 
   it "peeks" do

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -55,4 +55,68 @@ describe HTTP::ChunkedContent do
     content.skip(4)
     content.gets_to_end.should eq("456")
   end
+
+  it "#read handles interrupted io" do
+    mem = IO::Memory.new("3\r\n123\n\r")
+    content = HTTP::ChunkedContent.new(mem)
+
+    content.skip(3)
+    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+      content.read Bytes.new(5)
+    end
+  end
+
+  it "#read_byte handles interrupted io" do
+    mem = IO::Memory.new("3\r\n123\n\r")
+    content = HTTP::ChunkedContent.new(mem)
+
+    content.skip(3)
+    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+      content.read_byte
+    end
+  end
+
+  it "#peek handles interrupted io" do
+    mem = IO::Memory.new("3\r\n123\n\r")
+    content = HTTP::ChunkedContent.new(mem)
+
+    content.skip(3)
+    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+      content.peek
+    end
+  end
+
+  it "#read handles empty data" do
+    mem = IO::Memory.new("3\r\n")
+    content = HTTP::ChunkedContent.new(mem)
+
+    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+      content.read Bytes.new(1)
+    end
+  end
+
+  it "#read_byte handles empty data" do
+    mem = IO::Memory.new("3\r\n")
+    content = HTTP::ChunkedContent.new(mem)
+
+    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+      content.read_byte
+    end
+  end
+
+  it "#peek handles empty data" do
+    mem = IO::Memory.new("3\r\n")
+    content = HTTP::ChunkedContent.new(mem)
+
+    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+      content.peek
+    end
+  end
+
+  it "handles empty io" do
+    mem = IO::Memory.new("")
+    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+      HTTP::ChunkedContent.new(mem)
+    end
+  end
 end

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -64,6 +64,16 @@ describe HTTP::ChunkedContent do
     mem.pos.should eq mem.bytesize
   end
 
+  it "#gets reads multiple chunks with \n" do
+    # The RFC format requires CRLF, but several standard implementations also
+    # accept LF, so we should too.
+    mem = IO::Memory.new("1\nA\n1\nB\n0\n\n")
+    content = HTTP::ChunkedContent.new(mem)
+
+    content.gets.should eq "AB"
+    mem.pos.should eq mem.bytesize
+  end
+
   it "#read reads empty content" do
     mem = IO::Memory.new("0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -61,7 +61,7 @@ describe HTTP::ChunkedContent do
     content = HTTP::ChunkedContent.new(mem)
 
     content.skip(3)
-    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected size but got EOF" do
       content.read Bytes.new(5)
     end
   end
@@ -71,7 +71,7 @@ describe HTTP::ChunkedContent do
     content = HTTP::ChunkedContent.new(mem)
 
     content.skip(3)
-    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected size but got EOF" do
       content.read_byte
     end
   end
@@ -81,7 +81,7 @@ describe HTTP::ChunkedContent do
     content = HTTP::ChunkedContent.new(mem)
 
     content.skip(3)
-    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected size but got EOF" do
       content.peek
     end
   end
@@ -90,7 +90,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("3\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected data but got EOF (missing 3 more bytes)" do
       content.read Bytes.new(1)
     end
   end
@@ -99,7 +99,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("3\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected data but got EOF (missing 3 more bytes)" do
       content.read_byte
     end
   end
@@ -108,14 +108,14 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("3\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    expect_raises IO::Error, "ChunkedContent missing data (expected 3 more bytes)" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected data but got EOF (missing 3 more bytes)" do
       content.peek
     end
   end
 
   it "handles empty io" do
     mem = IO::Memory.new("")
-    expect_raises IO::Error, "ChunkedContent misses chunk remaining" do
+    expect_raises IO::Error, "Invalid HTTP chunked content: expected size but got EOF" do
       HTTP::ChunkedContent.new(mem)
     end
   end

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -173,7 +173,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("0\r\nAdditional-Header: Foo")
 
     chunked = HTTP::ChunkedContent.new(mem)
-    expect_raises IO::Error, "Invalid HTTP chunked content: expected CRLF" do
+    expect_raises IO::EOFError do
       chunked.gets
     end
   end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -7,6 +7,9 @@ module HTTP
   private DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
 
   # :nodoc:
+  MAX_HEADER_SIZE = 16_384
+
+  # :nodoc:
   enum BodyType
     OnDemand
     Prohibited
@@ -18,9 +21,9 @@ module HTTP
     headers = Headers.new
 
     headers_size = 0
-    while line = io.gets(16_384, chomp: true)
+    while line = io.gets(MAX_HEADER_SIZE, chomp: true)
       headers_size += line.bytesize
-      break if headers_size > 16_384
+      break if headers_size > MAX_HEADER_SIZE
 
       if line.empty?
         body = nil

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -58,7 +58,7 @@ module HTTP
     # All headers in the trailing headers section will be returned. Applications
     # need to make sure to ignore them or fail if headers are not allowed
     # in the chunked trailer part (see [RFC 7230 section 4.1.2](https://tools.ietf.org/html/rfc7230#section-4.1.2)).
-    getter headers : HTTP::Headers = HTTP::Headers.new
+    getter headers : HTTP::Headers { HTTP::Headers.new }
 
     def initialize(@io : IO)
       @chunk_remaining = 0
@@ -176,7 +176,7 @@ module HTTP
         break if line.empty?
 
         key, value = HTTP.parse_header(line)
-        break unless @headers.add?(key, value)
+        break unless headers.add?(key, value)
       end
     end
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -78,7 +78,7 @@ module HTTP
       bytes_read = @io.read slice[0, to_read]
 
       if bytes_read == 0
-        raise IO::EOFError.new("Invalid HTTP chunked content: unexpected end of file")
+        raise IO::EOFError.new("Invalid HTTP chunked content")
       end
 
       chunk_bytes_read bytes_read
@@ -95,7 +95,7 @@ module HTTP
         chunk_bytes_read 1
         byte
       else
-        raise IO::EOFError.new("Invalid HTTP chunked content: unexpected end of file")
+        raise IO::EOFError.new("Invalid HTTP chunked content")
       end
     end
 
@@ -108,7 +108,7 @@ module HTTP
       if @chunk_remaining < peek.size
         peek = peek[0, @chunk_remaining]
       elsif peek.size == 0
-        raise IO::EOFError.new("Invalid HTTP chunked content: unexpected end of file")
+        raise IO::EOFError.new("Invalid HTTP chunked content")
       end
 
       peek
@@ -167,7 +167,7 @@ module HTTP
         chunk_size = line
       end
 
-      @chunk_remaining = chunk_size.to_i?(16) || raise IO::Error.new("Invalid HTTP chunked content: invalid chunk size (#{chunk_size.dump})")
+      @chunk_remaining = chunk_size.to_i?(16) || raise IO::Error.new("Invalid HTTP chunked content: invalid chunk size")
     end
 
     private def read_trailer

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -52,7 +52,7 @@ module HTTP
 
     # Returns trailing headers read by this chunked content.
     #
-    # Thiel value will only be populated once the entire content has been read,
+    # The value will only be populated once the entire content has been read,
     # i.e. this IO is at EOF.
     #
     # All headers in the trailing headers section will be returned. Applications

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -159,7 +159,7 @@ module HTTP
     end
 
     private def read_chunk_size
-      line = @io.read_line(16_384, chomp: true)
+      line = @io.read_line(HTTP::MAX_HEADER_SIZE, chomp: true)
 
       if index = line.byte_index(';'.ord)
         chunk_size = line.byte_slice(0, index)
@@ -172,7 +172,7 @@ module HTTP
 
     private def read_trailer
       while true
-        line = @io.read_line(16_384, chomp: true)
+        line = @io.read_line(HTTP::MAX_HEADER_SIZE, chomp: true)
         break if line.empty?
 
         key, value = HTTP.parse_header(line)

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -67,15 +67,15 @@ module HTTP
 
       return 0 if @chunk_remaining == 0
 
-      to_read = Math.min(slice.size, @chunk_remaining)
+      to_read = Math.min(count, @chunk_remaining)
 
       bytes_read = @io.read slice[0, to_read]
-      @chunk_remaining -= bytes_read
 
-      if bytes_read < to_read
-        missing_bytes = @chunk_remaining - bytes_read
-        raise IO::Error.new("ChunkedContent missing data (expected #{missing_bytes} more bytes)")
+      if bytes_read == 0
+        raise IO::Error.new("ChunkedContent missing data (expected #{@chunk_remaining} more bytes)")
       end
+
+      @chunk_remaining -= bytes_read
       check_chunk_remaining_is_zero
 
       bytes_read
@@ -105,7 +105,7 @@ module HTTP
 
           if @chunk_remaining < peek.size
             peek = peek[0, @chunk_remaining]
-          elsif peek.size == 0 && @chunk_remaining > 0
+          elsif peek.size == 0
             raise IO::Error.new("ChunkedContent missing data (expected #{@chunk_remaining} more bytes)")
           end
 


### PR DESCRIPTION
Reading from `HTTP::ChunkedContent` now raises `IO::Error` if the IO ends before the entire size of a chunk is read.

Fixes #5852