### PR TITLE
add spec to reproduce sizeof(typeof(v)) bug

### DIFF
--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -286,4 +286,15 @@ describe "Code gen: if" do
       1
       ))
   end
+
+  it "doesn't detect type in else condition (#5717)" do
+    run(%(
+      v = nil : String
+      if v.nil?
+        0
+      else
+        sizeof(typeof(v))
+      end
+      )).to_i.should eq(0)
+  end
 end


### PR DESCRIPTION
After some `git bisect` work, it was discovered that the following bug
fix causes a regression on a patch which should be detectable.

> 074d61c4845f22939b29a8024129f892e609d0f0 is the first bad commit
>   commit 074d61c4845f22939b29a8024129f892e609d0f0
>   Author: Guilherme Bernal <dev@lbguilherme.com>
>   Date:   Fri Nov 3 11:44:21 2017 -0300
>
>       give error if using instance_sizeof on a generic type without type vars (#5209)
>
>   :040000 040000 2fa5bdc54dead5c6c70f011e4e131f74bc170156 546f4b9d362c210b3b26f688e9314fb31ea64acb M	spec
>   :040000 040000 a3694241ab2bdfc038018e3280758fa3937b29de 80ec4ae5f0c337447208280893acb2fca45dbf5b M	src