### PR TITLE
Raise syntax error when method argument name is keyword

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -163,6 +163,20 @@ describe "Parser" do
   assert_syntax_error "def foo!=; end", "unexpected token: !="
   assert_syntax_error "def foo?=(x); end", "unexpected token: ?"
 
+  # #5895
+  %w(
+    begin nil true false yield with abstract
+    def macro require case select if unless include
+    extend class struct module enum while until return
+    next break lib fun alias pointerof sizeof
+    instance_sizeof typeof private protected asm
+    end
+  ).each do |kw|
+    assert_syntax_error "def foo(#{kw}); end", "cannot use '#{kw}' as argument name", 1, 9
+    assert_syntax_error "def foo(foo #{kw}); end", "cannot use '#{kw}' as argument name", 1, 13
+    it_parses "def foo(#{kw} foo); end", Def.new("foo", [Arg.new("foo", external_name: kw.to_s)])
+  end
+
   it_parses "def self.foo\n1\nend", Def.new("foo", body: 1.int32, receiver: "self".var)
   it_parses "def self.foo()\n1\nend", Def.new("foo", body: 1.int32, receiver: "self".var)
   it_parses "def self.foo=\n1\nend", Def.new("foo=", body: 1.int32, receiver: "self".var)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -172,8 +172,8 @@ describe "Parser" do
     instance_sizeof typeof private protected asm
     end
   ).each do |kw|
-    assert_syntax_error "def foo(#{kw}); end", "cannot use '#{kw}' as argument name", 1, 9
-    assert_syntax_error "def foo(foo #{kw}); end", "cannot use '#{kw}' as argument name", 1, 13
+    assert_syntax_error "def foo(#{kw}); end", "cannot use '#{kw}' as an argument name", 1, 9
+    assert_syntax_error "def foo(foo #{kw}); end", "cannot use '#{kw}' as an argument name", 1, 13
     it_parses "def foo(#{kw} foo); end", Def.new("foo", [Arg.new("foo", external_name: kw.to_s)])
   end
 

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -9,7 +9,7 @@ private class SpecException < Exception
 end
 
 private class NilMimicker
-  def ==(nil : Nil)
+  def ==(a_nil : Nil)
     true
   end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -920,6 +920,8 @@ module Crystal
       when :__DIR__
         node_and_next_token MagicConstant.expand_dir_node(@token.location)
       when :IDENT
+        # NOTE: Update `Parser#invalid_internal_name?` keyword list
+        # when adding or removing keyword to handle here.
         case @token.value
         when :begin
           check_type_declaration { parse_begin }
@@ -3593,7 +3595,7 @@ module Crystal
       case @token.type
       when :IDENT
         if @token.keyword? && invalid_internal_name?(@token.value)
-          raise "cannot use '#{@token}' as argument name", @token
+          raise "cannot use '#{@token}' as an argument name", @token
         end
 
         arg_name = @token.value.to_s
@@ -3641,7 +3643,7 @@ module Crystal
             raise "unexpected token: #{@token}, expected argument internal name"
           end
           if invalid_internal_name
-            raise "cannot use '#{invalid_internal_name}' as argument name", invalid_internal_name
+            raise "cannot use '#{invalid_internal_name}' as an argument name", invalid_internal_name
           end
           arg_name = external_name
         else
@@ -3661,7 +3663,7 @@ module Crystal
 
     def invalid_internal_name?(keyword)
       case keyword
-      # These names are handled as keyword by `parser_atomic_without_location`.
+      # These names are handled as keyword by `Parser#parse_atomic_without_location`.
       # We cannot assign value into them and never reference them,
       # so they are invalid internal name.
       when :begin, :nil, :true, :false, :yield, :with, :abstract,

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -95,6 +95,10 @@ module Crystal
       @type == :TOKEN && @value == token
     end
 
+    def keyword?
+      @type == :IDENT && @value.is_a?(Symbol)
+    end
+
     def keyword?(keyword)
       @type == :IDENT && @value == keyword
     end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -158,7 +158,7 @@ class Crystal::Doc::Generator
     end
   end
 
-  def must_include?(nil : Nil)
+  def must_include?(a_nil : Nil)
     false
   end
 


### PR DESCRIPTION
Closes #5895

However some keywords are valid argument name still.
Invalid argument names are listed here:

    begin nil true false yield with abstract
    def macro require case select if unless include
    extend class struct module enum while until return
    next break lib fun alias pointerof sizeof
    instance_sizeof typeof private protected asm
    end

Above names except `end` are handled as keyword by `Crystal::Parser.parse_atomic_without_location`.
It means, we cannot assign value into them and never reference them.
In other words we have no way using them, so it does not make sense to allow these names as argument name.

Additionally `end` is confusable. It maybe terminate `def` block.

Thank you.