### PR TITLE
Add context to errors in JSON.mapping

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -221,7 +221,11 @@ describe "JSON mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    ex = expect_raises JSON::MappingError, "Unknown JSON attribute: foo\n  parsing StrictJSONPerson" do
+    error_message = <<-'MSG'
+      Unknown JSON attribute: foo
+        parsing StrictJSONPerson
+      MSG
+    ex = expect_raises JSON::MappingError, error_message do
       StrictJSONPerson.from_json <<-JSON
         {
           "name": "John",
@@ -234,14 +238,22 @@ describe "JSON mapping" do
   end
 
   it "raises if non-nilable attribute is nil" do
-    ex = expect_raises JSON::MappingError, "Missing JSON attribute: name\n  parsing JSONPerson at 1:1" do
+    error_message = <<-'MSG'
+      Missing JSON attribute: name
+        parsing JSONPerson at 1:1
+      MSG
+    ex = expect_raises JSON::MappingError, error_message do
       JSONPerson.from_json(%({"age": 30}))
     end
     ex.location.should eq({1, 1})
   end
 
   it "raises if not an object" do
-    ex = expect_raises JSON::MappingError, "Expected begin_object but was string at 1:1\n  parsing StrictJSONPerson at 0:0" do
+    error_message = <<-'MSG'
+      Expected begin_object but was string at 1:1
+        parsing StrictJSONPerson at 0:0
+      MSG
+    ex = expect_raises JSON::MappingError, error_message do
       StrictJSONPerson.from_json <<-JSON
         "foo"
         JSON
@@ -250,7 +262,11 @@ describe "JSON mapping" do
   end
 
   it "raises if data type does not match" do
-    ex = expect_raises JSON::MappingError, "Expected int but was string at 3:15\n  parsing StrictJSONPerson#age at 3:3" do
+    error_message = <<-'MSG'
+      Expected int but was string at 3:15
+        parsing StrictJSONPerson#age at 3:3
+      MSG
+    ex = expect_raises JSON::MappingError, error_message do
       StrictJSONPerson.from_json <<-JSON
         {
           "name": "John",
@@ -545,7 +561,11 @@ describe "JSON mapping" do
     end
 
     it "raises if non-nilable attribute is nil" do
-      ex = expect_raises JSON::MappingError, "Missing JSON attribute: foo\n  parsing JSONWithQueryAttributes at 1:1" do
+      error_message = <<-'MSG'
+        Missing JSON attribute: foo
+          parsing JSONWithQueryAttributes at 1:1
+        MSG
+      ex = expect_raises JSON::MappingError, error_message do
         JSONWithQueryAttributes.from_json(%({"is_bar": true}))
       end
       ex.location.should eq({1, 1})

--- a/src/json.cr
+++ b/src/json.cr
@@ -66,8 +66,8 @@ module JSON
     getter line_number : Int32
     getter column_number : Int32
 
-    def initialize(message, @line_number, @column_number)
-      super "#{message} at #{@line_number}:#{@column_number}"
+    def initialize(message, @line_number, @column_number, cause = nil)
+      super "#{message} at #{@line_number}:#{@column_number}", cause
     end
 
     def location


### PR DESCRIPTION
Errors from JSON parse methods generated by `JSON.mapping` are difficult to debug. The message only tells about the immediate error encountered by `JSON::PullParser`, for example `Expected int but was string`. At least the source location is attached, but that makes it still quite hard to figure out, what exactly the parser was doing and parsing which object failed, especially in large JSON structures (such as the `index.json` produced by the docs generator).

This PR adds some context to errors raised by `.parse_json` by adding the name of the class and property (if available) that is being parsed.
These errors are wrapped, so each level of JSON data is unwrapped and can be followed. It's roughly comparable to a stack trace.

```text
Expected begin_object but was string at 12:10
  parsing Foo at 12:10
  parsing Bar#foo at 12:5
  parsing Baz#bar at 3:15
```

This exception hierarchy can probably get pretty large with highly nested JSON structures. I'm not sure if the outer contexts are really that useful.

This deep wrapping could be removed and only the significant innermost scope would get wrapped, adding the most important context information.

Obviously, this entire context feature adds some additional overhead to the JSON mapping parser. Exceptions are usually pretty rare, so it shouldn't matter much. In the case it happens, the additional debug info should be worth it.