### PR TITLE
Include type restriction on getters in JSON/mapping

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -510,8 +510,8 @@ describe "JSON mapping" do
     it "defines query getter with class restriction" do
       {% begin %}
         {% methods = JSONWithQueryAttributes.methods %}
-        {{methods.find(&.name.==("foo?")).return_type}}.should eq(Bool)
-        {{methods.find(&.name.==("bar?")).return_type}}.should eq(Bool)
+        {{ methods.find(&.name.==("foo?")).return_type }}.should eq(Bool)
+        {{ methods.find(&.name.==("bar?")).return_type }}.should eq(Bool)
       {% end %}
     end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -510,8 +510,8 @@ describe "JSON mapping" do
     it "defines query getter with class restriction" do
       {% begin %}
         {% methods = JSONWithQueryAttributes.methods %}
-        {{methods.find { |m| m.name == "foo?" }.return_type}}.should eq(Bool)
-        {{methods.find { |m| m.name == "bar?" }.return_type}}.should eq(Bool)
+        {{methods.find(&.name.==("foo?")).return_type}}.should eq(Bool)
+        {{methods.find(&.name.==("bar?")).return_type}}.should eq(Bool)
       {% end %}
     end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -509,9 +509,9 @@ describe "JSON mapping" do
 
     it "defines query getter with class restriction" do
       {% begin %}
-      {% methods = JSONWithQueryAttributes.methods %}
-      {{methods.find{ |m| m.name == "foo?"}.return_type }}.should eq(Bool)
-      {{methods.find{ |m| m.name == "bar?"}.return_type }}.should eq(Bool)
+        {% methods = JSONWithQueryAttributes.methods %}
+        {{methods.find { |m| m.name == "foo?" }.return_type}}.should eq(Bool)
+        {{methods.find { |m| m.name == "bar?" }.return_type}}.should eq(Bool)
       {% end %}
     end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -507,6 +507,14 @@ describe "JSON mapping" do
       json.bar?.should be_false
     end
 
+    it "defines query getter with class restriction" do
+      {% begin %}
+      {% methods = JSONWithQueryAttributes.methods %}
+      {{methods.find{ |m| m.name == "foo?"}.return_type }}.should eq(Bool)
+      {{methods.find{ |m| m.name == "bar?"}.return_type }}.should eq(Bool)
+      {% end %}
+    end
+
     it "defines non-query setter and presence methods" do
       json = JSONWithQueryAttributes.from_json(%({"foo": false}))
       json.bar_present?.should be_false

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -80,7 +80,7 @@ module JSON
       {% end %}
 
       {% if value[:getter] == nil ? true : value[:getter] %}
-        def {{key.id}}
+        def {{key.id}} : {{value[:type]}} {{ (value[:nilable] ? "?" : "").id }}
           @{{value[:key_id]}}
         end
       {% end %}

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -71,16 +71,16 @@ module JSON
     {% end %}
 
     {% for key, value in _properties_ %}
-      @{{value[:key_id]}} : {{value[:type]}} {{ (value[:nilable] ? "?" : "").id }}
+      @{{value[:key_id]}} : {{value[:type]}}{{ (value[:nilable] ? "?" : "").id }}
 
       {% if value[:setter] == nil ? true : value[:setter] %}
-        def {{value[:key_id]}}=(_{{value[:key_id]}} : {{value[:type]}} {{ (value[:nilable] ? "?" : "").id }})
+        def {{value[:key_id]}}=(_{{value[:key_id]}} : {{value[:type]}}{{ (value[:nilable] ? "?" : "").id }})
           @{{value[:key_id]}} = _{{value[:key_id]}}
         end
       {% end %}
 
       {% if value[:getter] == nil ? true : value[:getter] %}
-        def {{key.id}} : {{value[:type]}} {{ (value[:nilable] ? "?" : "").id }}
+        def {{key.id}} : {{value[:type]}}{{ (value[:nilable] ? "?" : "").id }}
           @{{value[:key_id]}}
         end
       {% end %}


### PR DESCRIPTION
Addresses #5920

Was unsure of a better way to spec this but I'm very aware of how dirty it is and how it relies on macro code more than anything else.