### PR TITLE
Add Tempfile.tempname accepting block

### DIFF
--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -1,8 +1,9 @@
 require "spec"
 require "tempfile"
+require "file_utils"
 
 describe Tempfile do
-  describe "tempname" do
+  describe ".tempname" do
     it "creates a path without creating the file" do
       path = Tempfile.tempname
 
@@ -13,6 +14,45 @@ describe Tempfile do
       path = Tempfile.tempname ".sock"
 
       File.extname(path).should eq(".sock")
+    end
+  end
+
+  describe ".tempname (yield)" do
+    it "uses extension argument" do
+      Tempfile.tempname(".xml") do |path|
+        File.extname(path).should eq ".xml"
+      end
+    end
+
+    it "works if path is not used" do
+      temp_path = nil
+      Tempfile.tempname do |path|
+        File.exists?(path).should be_false
+        temp_path = path
+      end
+      File.exists?(temp_path.not_nil!).should be_false
+    end
+
+    it "ensures file is removed" do
+      temp_path = nil
+      Tempfile.tempname do |path|
+        File.exists?(path).should be_false
+        File.touch(path)
+        temp_path = path
+        File.exists?(path).should be_true
+      end
+      File.exists?(temp_path.not_nil!).should be_false
+    end
+
+    it "ensures dir is removed" do
+      temp_path = nil
+      Tempfile.tempname do |path|
+        File.exists?(path).should be_false
+        FileUtils.mkdir(path)
+        temp_path = path
+        File.exists?(path).should be_true
+      end
+      File.exists?(temp_path.not_nil!).should be_false
     end
   end
 

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -1,4 +1,5 @@
 require "c/stdlib"
+require "file_utils"
 
 # The `Tempfile` class is for managing temporary files.
 # Every tempfile is operated as a `File`, including
@@ -71,6 +72,36 @@ class Tempfile < File
     time = Time.now.to_s("%Y%m%d")
     rand = Random.rand(0x100000000).to_s(36)
     File.join(dirname, "#{time}-#{Process.pid}-#{rand}#{extension}")
+  end
+
+  # Yields a fully-qualified path to a temporary file to the given block and
+  # ensures the path is removed at exit if it exists.
+  #
+  # This method is useful to ensure a temporary path is cleaned up after it has
+  # been used. The path will be removed whether it is a file or directory.
+  #
+  # The optional `extension` argument can be used to make the resulting
+  # filename to end with the given extension.
+  #
+  # The file will not actually be created by this method.
+  #
+  # ```
+  # Tempfile.tempname("txt") do |temp|
+  #   File.write(temp, "foo")
+  #   File.read(temp) # => "foo"
+  # end
+  #
+  # Tempfile.tempname do |temp|
+  #   `git clone https://github.com/crystal-lang/crystal.git #{temp}`
+  # end
+  # ```
+  def self.tempname(extension = nil)
+    path = tempname(extension)
+    yield path
+  ensure
+    if path && File.exists?(path)
+      FileUtils.rm_r(path)
+    end
   end
 
   # Creates a file with *filename* and *extension*, and yields it to the given


### PR DESCRIPTION
This PR adds an overload to `Tempfile.tempname` which yields the path and ensures it is cleaned up after exiting the block.

A possible use case is detailed in #5811

Followup on #5360