### PR TITLE
Fix HTTP::ChunkedContent#peek return empty bytes at EOF

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -17,6 +17,8 @@ describe HTTP::ChunkedContent do
     content = HTTP::ChunkedContent.new(mem)
 
     content.peek.should eq("123\n".to_slice)
+    content.skip(4)
+    content.peek.should eq Bytes.empty
   end
 
   it "peeks into next chunk" do
@@ -94,7 +96,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    content.peek.should be_nil
+    content.peek.should eq Bytes.empty
     mem.pos.should eq mem.bytesize
   end
 
@@ -239,9 +241,9 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("0\r\n\r\n1\r\nA\r\n0\r\n\r\n")
 
     chunked = HTTP::ChunkedContent.new(mem)
-    chunked.peek.should be_nil
+    chunked.peek.should eq Bytes.empty
     mem.pos.should eq 5
-    chunked.peek.should be_nil
+    chunked.peek.should eq Bytes.empty
     mem.pos.should eq 5
   end
 end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -71,7 +71,7 @@ module HTTP
 
       next_chunk
 
-      return 0 if @chunk_remaining == 0
+      return 0 if @received_final_chunk
 
       to_read = Math.min(count, @chunk_remaining)
 
@@ -88,7 +88,7 @@ module HTTP
 
     def read_byte
       next_chunk
-      return super if @chunk_remaining == 0
+      return super if @received_final_chunk
 
       byte = @io.read_byte
       if byte
@@ -101,7 +101,7 @@ module HTTP
 
     def peek
       next_chunk
-      return if @chunk_remaining == 0
+      return Bytes.empty if @received_final_chunk
 
       peek = @io.peek || return
 


### PR DESCRIPTION
After #5928 was merged I noticed the implementation of `#peek` was incorrect: it is supposed to return an empty slice at EOF but returned `nil` instead (which would mean the IO is not peekable).

That was already broken before, so it was not recognized in the PR.