### PR TITLE
Remove unnecessary NoReturn annotation

### DIFF
--- a/src/env.cr
+++ b/src/env.cr
@@ -71,7 +71,7 @@ module ENV
 
   # Retrieves a value corresponding to a given *key*. Return the value of the block if
   # the *key* does not exist.
-  def self.fetch(key : String, &block : String -> String? | NoReturn)
+  def self.fetch(key : String, &block : String -> String?)
     value = LibC.getenv key
     return String.new(value) if value
     yield(key)


### PR DESCRIPTION
It makes no sense to add it, as almost every method/block can potentially raise.

Note: it was the only place in the stdlib where this annotation is added.