### PR TITLE
Fix linking to openssl

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -11,7 +11,7 @@
 
 {% begin %}
   lib LibCrypto
-    OPENSSL_110 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10101000) }}
+    OPENSSL_110 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10100000) }}
     OPENSSL_102 = {{ (LibCrypto::LIBRESSL_VERSION == 0) && (LibCrypto::OPENSSL_VERSION >= 0x10002000) }}
     LIBRESSL_250 = {{ LibCrypto::LIBRESSL_VERSION >= 0x205000000 }}
   end


### PR DESCRIPTION
Fixes linking to openssl 1.1.0. The new openssl 1.1.0 checks added in #5676 was incorrect, using the version constant for `1.1.1`, which is currently a prerelease.