### PR TITLE
Add `String#enclosed_with?`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -967,6 +967,22 @@ describe "String" do
     it { "あいう_".ends_with?('_').should be_true }
   end
 
+  describe "enclosed_with?" do
+    it { "foobar".enclosed_with?("foo", "bar").should be_true }
+    it { "foobar".enclosed_with?("bar", "foo").should be_false }
+    it { "foobar".enclosed_with?("foo").should be_false }
+    it { "foobar".enclosed_with?("foobarbaz").should be_false }
+    it { "foobar".enclosed_with?("oba").should be_false }
+    it { "foobar".enclosed_with?("").should be_true }
+    it { "_foobar_".enclosed_with?('_').should be_true }
+    it { "foobar".enclosed_with?('f', 'r').should be_true }
+    it { "foobar".enclosed_with?(/fo|ar/).should be_true }
+    it { "foobar".enclosed_with?(/bar/, /foo/).should be_false }
+    it { "foobarし".enclosed_with?(/foo/, 'し').should be_true }
+    it { "しよし".enclosed_with?('し').should be_true }
+    it { "よし".enclosed_with?('な', 'し').should be_false }
+  end
+
   describe "=~" do
     it "matches with group" do
       "foobar" =~ /(o+)ba(r?)/

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -972,11 +972,14 @@ describe "String" do
     it { "foobar".enclosed_with?("bar", "foo").should be_false }
     it { "foobar".enclosed_with?("foo").should be_false }
     it { "foobar".enclosed_with?("foobarbaz").should be_false }
-    it { "foobar".enclosed_with?("oba").should be_false }
+    it { "foobarfoo".enclosed_with?("foo").should be_true }
     it { "foobar".enclosed_with?("").should be_true }
     it { "_foobar_".enclosed_with?('_').should be_true }
     it { "foobar".enclosed_with?('f', 'r').should be_true }
     it { "foobar".enclosed_with?(/fo|ar/).should be_true }
+    it { "foobar".enclosed_with?(/oo|ba/).should be_false }
+    it { "foobar".enclosed_with?(/foo/).should be_false }
+    it { "foobar".enclosed_with?(/bar/).should be_false }
     it { "foobar".enclosed_with?(/bar/, /foo/).should be_false }
     it { "foobarし".enclosed_with?(/foo/, 'し').should be_true }
     it { "しよし".enclosed_with?('し').should be_true }

--- a/src/string.cr
+++ b/src/string.cr
@@ -4050,8 +4050,17 @@ class String
     !!($~ = /#{re}\z/.match(self))
   end
 
-  def enclosed_with?(delimiter)
+  def enclosed_with?(str : String)
+    return false if str.bytesize > bytesize
+    (to_unsafe + bytesize - str.bytesize).memcmp(str.to_unsafe, str.bytesize) == to_unsafe.memcmp(str.to_unsafe, str.bytesize) == 0
+  end
+
+  def enclosed_with?(delimiter : Char)
     starts_with?(delimiter) && ends_with?(delimiter)
+  end
+
+  def enclosed_with?(re : Regex)
+    !!($~ = /^#{re}.*#{re}\z/.match(self))
   end
 
   def enclosed_with?(start_delimiter, end_delimiter)

--- a/src/string.cr
+++ b/src/string.cr
@@ -4050,6 +4050,14 @@ class String
     !!($~ = /#{re}\z/.match(self))
   end
 
+  def enclosed_with?(delimiter)
+    starts_with?(delimiter) && ends_with?(delimiter)
+  end
+
+  def enclosed_with?(start_delimiter, end_delimiter)
+    starts_with?(start_delimiter) && ends_with?(end_delimiter)
+  end
+
   # Interpolates *other* into the string using `Kernel#sprintf`.
   #
   # ```


### PR DESCRIPTION
A method that combine `starts_with?` and `ends_with?`.
This is of course not an essential feature, but I find it quite elegant - specially when used with `when` inside `case` expressions.
Be free to not merge.