### PR TITLE
Fix enum flags assigned values when a member has value 0

### DIFF
--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -183,6 +183,21 @@ describe "Semantic: enum" do
       )) { int32 }
   end
 
+  it "doesn't break assigned values in enum flags when a member has value 0 (#5767)" do
+    result = semantic(%(
+      @[Flags]
+      enum Foo
+        OtherNone = 0
+        Bar
+        Baz
+      end
+      ))
+    enum_type = result.program.types["Foo"].as(EnumType)
+    enum_type.types["OtherNone"].as(Const).value.should eq(NumberLiteral.new(0, :i32))
+    enum_type.types["Bar"].as(Const).value.should eq(NumberLiteral.new(1, :i32))
+    enum_type.types["Baz"].as(Const).value.should eq(NumberLiteral.new(2, :i32))
+  end
+
   it "disallows None value when defined with @[Flags]" do
     assert_error %(
       @[Flags]

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -603,8 +603,17 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
 
       const_value.type = enum_type
-      counter = is_flags ? counter * 2 : counter + 1
-      {counter, all_value}
+      new_counter =
+        if is_flags
+          if counter == 0 # In case the member is set to 0
+            1
+          else
+            counter * 2
+          end
+        else
+          counter + 1
+        end
+      {new_counter, all_value}
     else
       member.accept self
       {counter, all_value}


### PR DESCRIPTION
Fixes #5767 

Given this enum flags:
```cr
@[Flags]
enum EventMask
  NoEvent = 0

  KeyPress
  ButtonPress
  EnterWindow
  # ...
end
```
Before:
```cr
EventMask::NoEvent # => None
EventMask::EnterWindow # => None
EventMask::EnterWindow.value # => 0
```
After:
```cr
EventMask::NoEvent # => None
EventMask::EnterWindow # => EnterWindow
EventMask::EnterWindow.value # => 4
```