### PR TITLE
 Add OpenSSL::SSL::Server and HTTP::Server#bind_ssl

### DIFF
--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -1,0 +1,78 @@
+require "spec"
+require "socket"
+require "../../spec_helper"
+require "../../../support/ssl"
+
+describe OpenSSL::SSL::Server do
+  it "sync_close" do
+    TCPServer.open(0) do |tcp_server|
+      context = OpenSSL::SSL::Context::Server.new
+      ssl_server = OpenSSL::SSL::Server.new(tcp_server, context)
+
+      ssl_server.close
+
+      tcp_server.closed?.should be_true
+    end
+  end
+
+  it "don't sync_close" do
+    TCPServer.open(0) do |tcp_server|
+      context = OpenSSL::SSL::Context::Server.new
+      ssl_server = OpenSSL::SSL::Server.new(tcp_server, context, sync_close: false)
+      ssl_server.context.should eq context
+
+      ssl_server.close
+
+      tcp_server.closed?.should be_false
+    end
+  end
+
+  it ".new" do
+    context = OpenSSL::SSL::Context::Server.new
+    TCPServer.open(0) do |tcp_server|
+      ssl_server = OpenSSL::SSL::Server.new tcp_server, context, sync_close: false
+
+      ssl_server.context.should eq context
+      ssl_server.wrapped.should eq tcp_server
+      ssl_server.sync_close?.should be_false
+    end
+  end
+
+  it ".open" do
+    context = OpenSSL::SSL::Context::Server.new
+    TCPServer.open(0) do |tcp_server|
+      ssl_server = nil
+      OpenSSL::SSL::Server.open tcp_server, context do |server|
+        server.wrapped.should eq tcp_server
+        ssl_server = server
+      end
+
+      ssl_server.try(&.closed?).should be_true
+      tcp_server.closed?.should be_true
+    end
+  end
+
+  describe "#accept?" do
+    it "accepts" do
+      tcp_server = TCPServer.new(0)
+
+      server_context, client_context = ssl_context_pair
+
+      OpenSSL::SSL::Server.open tcp_server, server_context do |server|
+        spawn do
+          client = server.accept?
+          client.should be_a(OpenSSL::SSL::Socket::Server)
+          client = client.not_nil!
+          client.gets.should eq "Hello, SSL!"
+          client.close
+        end
+
+        Fiber.yield
+
+        OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context) do |socket|
+          socket.puts "Hello, SSL!"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/ssl.cr
+++ b/spec/support/ssl.cr
@@ -1,0 +1,12 @@
+require "openssl"
+
+def ssl_context_pair
+  server_context = OpenSSL::SSL::Context::Server.new
+  server_context.certificate_chain = datapath("openssl", "openssl.crt")
+  server_context.private_key = datapath("openssl", "openssl.key")
+
+  client_context = OpenSSL::SSL::Context::Client.new
+  client_context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+
+  {server_context, client_context}
+end

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -270,7 +270,9 @@ class HTTP::Server
   end
 
   private def handle_client(io : IO)
-    io.sync = false
+    if io.is_a?(IO::Buffered)
+      io.sync = false
+    end
 
     {% if !flag?(:without_openssl) %}
       if tls = @tls

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -1,0 +1,89 @@
+require "socket"
+
+# This class wraps another `::Socket::Server` in an SSL layer.
+#
+# ```
+# require "socket"
+# require "openssl"
+#
+# tcp_server = TCPServer.new(0)
+#
+# ssl_context = OpenSSL::SSL::Context::Server.new
+# ssl_context.certificate_chain = "openssl.crt"
+# ssl_context.private_key = "openssl.key"
+# ssl_server = OpenSSL::SSL::Server.new(tcp_server, ssl_context)
+#
+# puts "SSL Server listening on #{tcp_server.local_address}"
+# while connection = ssl_server.accept?
+#   connection.puts "secure message"
+#   connection.close
+# end
+# ```
+class OpenSSL::SSL::Server
+  include ::Socket::Server
+
+  # Returns the wrapped server socket.
+  getter wrapped : ::Socket::Server
+
+  # Returns the SSL context.
+  getter context : OpenSSL::SSL::Context::Server
+
+  # If `#sync_close?` is `true`, closing this server will
+  # close the wrapped server.
+  property? sync_close : Bool
+
+  # Returns `true` if this SSL server has been closed.
+  getter? closed : Bool = false
+
+  # Creates a new SSL server wrapping *wrapped*.
+  #
+  # *context* configures the SSL options, see `OpenSSL::SSL::Context::Server` for details
+  def initialize(@wrapped : ::Socket::Server, @context : OpenSSL::SSL::Context::Server = OpenSSL::SSL::Context::Server.new, @sync_close : Bool = true)
+  end
+
+  # Creates a new SSL server wrapping *wrapped*  and yields it to the block.
+  #
+  # *context* configures the SSL options, see `OpenSSL::SSL::Context::Server` for details
+  #
+  # The server is closed after the block returns.
+  def self.open(wrapped : ::Socket::Server, context : OpenSSL::SSL::Context::Server = OpenSSL::SSL::Context::Server.new, sync_close : Bool = true)
+    server = new(wrapped, context, sync_close)
+
+    begin
+      yield server
+    ensure
+      server.close
+    end
+  end
+
+  # Implements `::Socket::Server#accept`.
+  #
+  # This method calls `@wrapped.accept` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
+  def accept : OpenSSL::SSL::Socket::Server
+    OpenSSL::SSL::Socket::Server.new(@wrapped.accept, @context, sync_close: @sync_close)
+  end
+
+  # Implements `::Socket::Server#accept?`.
+  #
+  # This method calls `@wrapped.accept?` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
+  def accept? : OpenSSL::SSL::Socket::Server?
+    if socket = @wrapped.accept?
+      OpenSSL::SSL::Socket::Server.new(socket, @context, sync_close: @sync_close)
+    end
+  end
+
+  # Closes this SSL server.
+  #
+  # Propagates to `wrapped` if `sync_close` is `true`.
+  def close
+    return if @closed
+    @closed = true
+
+    @wrapped.close if @sync_close
+  end
+
+  # Returns local address of `wrapped`.
+  def local_address : ::Socket::Address
+    @wrapped.local_address
+  end
+end

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -1,5 +1,15 @@
 class Socket
   module Server
+    # Accepts an incoming connection and returns the client socket.
+    #
+    # If the server is closed after invoking this method, an `IO::Error` (closed stream) exception must be raised.
+    abstract def accept : Socket
+
+    # Accepts an incoming connection and returns the client socket.
+    #
+    # Returns `nil` if the server is closed after invoking this method.
+    abstract def accept? : Socket?
+
     # Accepts an incoming connection and yields the client socket to the block.
     # Eventually closes the connection when the block returns.
     #


### PR DESCRIPTION
This adds a reusable `SSLServer` class which wraps another `Socket::Server` in an SSL layer.

With `HTTP::Server#bind_ssl` SSL context can be configured for every server socket individually instead of using the instance variable `tls` for all sockets.

Followup on #5776