### PR TITLE
Expand Regex to allow querying for metacharacters

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -45,6 +45,17 @@ describe "Regex" do
     expect_raises(ArgumentError) { Regex.new("foo)") }
   end
 
+  it "checks if Char need to be escaped" do
+    Regex.needs_escape?('*').should be_true
+    Regex.needs_escape?('|').should be_true
+    Regex.needs_escape?('@').should be_false
+  end
+
+  it "checks if String need to be escaped" do
+    Regex.needs_escape?("10$").should be_true
+    Regex.needs_escape?("foo").should be_false
+  end
+
   it "escapes" do
     Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
   end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -192,6 +192,15 @@ require "./regex/*"
 # `Hash` of `String` => `Int32`, and therefore requires named capture groups to have
 # unique names within a single `Regex`.
 class Regex
+  # List of metacharacters that need to be escaped.
+  #
+  # See `Regex.needs_escape?` and `Regex.escape`.
+  SPECIAL_CHARACTERS = {
+    ' ', '.', '\\', '+', '*', '?', '[',
+    '^', ']', '$', '(', ')', '{', '}',
+    '=', '!', '<', '>', '|', ':', '-',
+  }
+
   @[Flags]
   enum Options
     IGNORE_CASE = 1
@@ -265,6 +274,27 @@ class Regex
     end
   end
 
+  # Returns `true` if *char* need to be escaped, `false` otherwise.
+  #
+  # ```
+  # Regex.needs_escape?('*') # => true
+  # Regex.needs_escape?('@') # => false
+  # ```
+  def self.needs_escape?(char : Char) : Bool
+    SPECIAL_CHARACTERS.includes?(char)
+  end
+
+  # Returns `true` if *str* need to be escaped, `false` otherwise.
+  #
+  # ```
+  # Regex.needs_escape?("10$") # => true
+  # Regex.needs_escape?("foo") # => false
+  # ```
+  def self.needs_escape?(str : String) : Bool
+    str.each_char { |char| return true if SPECIAL_CHARACTERS.includes?(char) }
+    false
+  end
+
   # Returns a `String` constructed by escaping any metacharacters in *str*.
   #
   # ```
@@ -274,15 +304,8 @@ class Regex
   def self.escape(str) : String
     String.build do |result|
       str.each_byte do |byte|
-        case byte.unsafe_chr
-        when ' ', '.', '\\', '+', '*', '?', '[',
-             '^', ']', '$', '(', ')', '{', '}',
-             '=', '!', '<', '>', '|', ':', '-'
-          result << '\\'
-          result.write_byte byte
-        else
-          result.write_byte byte
-        end
+        result << '\\' if needs_escape?(byte.unsafe_chr)
+        result.write_byte byte
       end
     end
   end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -304,7 +304,13 @@ class Regex
   def self.escape(str) : String
     String.build do |result|
       str.each_byte do |byte|
-        result << '\\' if needs_escape?(byte.unsafe_chr)
+        case byte.unsafe_chr
+        # See `Regex::SPECIAL_CHARACTERS`
+        when ' ', '.', '\\', '+', '*', '?', '[',
+             '^', ']', '$', '(', ')', '{', '}',
+             '=', '!', '<', '>', '|', ':', '-'
+          result << '\\'
+        end
         result.write_byte byte
       end
     end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -304,13 +304,12 @@ class Regex
   def self.escape(str) : String
     String.build do |result|
       str.each_byte do |byte|
-        case byte.unsafe_chr
-        # See `Regex::SPECIAL_CHARACTERS`
-        when ' ', '.', '\\', '+', '*', '?', '[',
-             '^', ']', '$', '(', ')', '{', '}',
-             '=', '!', '<', '>', '|', ':', '-'
-          result << '\\'
-        end
+        {% begin %}
+          case byte.unsafe_chr
+          when {{*SPECIAL_CHARACTERS}}
+            result << '\\'
+          end
+        {% end %}
         result.write_byte byte
       end
     end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -308,9 +308,11 @@ class Regex
           case byte.unsafe_chr
           when {{*SPECIAL_CHARACTERS}}
             result << '\\'
+            result.write_byte byte
+          else
+            result.write_byte byte
           end
         {% end %}
-        result.write_byte byte
       end
     end
   end


### PR DESCRIPTION
Would accommodate the need for such query from outside of `Regex.escape`.