### PR TITLE
Fix Object.delegate to setter

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -98,6 +98,13 @@ private class TestObject
   end
 end
 
+private class DelegatedTestObject
+  delegate "property1=", to: @test_object
+
+  def initialize(@test_object : TestObject)
+  end
+end
+
 private class TestObjectWithFinalize
   property key : Symbol?
 
@@ -128,6 +135,13 @@ describe Object do
         matches << match[0]
       end
       matches.should eq(["l", "l"])
+    end
+
+    it "delegates setter" do
+      test_object = TestObject.new
+      delegated = DelegatedTestObject.new(test_object)
+      delegated.property1 = 42
+      test_object.property1.should eq 42
     end
   end
 

--- a/src/object.cr
+++ b/src/object.cr
@@ -1083,15 +1083,21 @@ class Object
   # ```
   macro delegate(*methods, to object)
     {% for method in methods %}
-      def {{method.id}}(*args, **options)
-        {{object.id}}.{{method.id}}(*args, **options)
-      end
-
-      def {{method.id}}(*args, **options)
-        {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
-          yield *yield_args
+      {% if method.id.ends_with?('=') %}
+        def {{method.id}}(arg)
+          {{object.id}}.{{method.id}} arg
         end
-      end
+      {% else %}
+        def {{method.id}}(*args, **options)
+          {{object.id}}.{{method.id}}(*args, **options)
+        end
+
+        def {{method.id}}(*args, **options)
+          {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
+            yield *yield_args
+          end
+        end
+      {% end %}
     {% end %}
   end
 


### PR DESCRIPTION
Setters can only receive one argument but the method produced by `delegate` would forward splash and double-splash arguments, resulting in a syntax error:

```cr
delegate "foo=", to: bar
# before:
def foo(*args, **options)
  bar.foo=(*args, **options) # Syntax error in expanded macro: expecting token ')', not ','
end
# now:
def foo(arg)
  bar.foo= arg
end
```