### PR TITLE
Improve static compilation support

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -324,7 +324,7 @@ module Crystal
 
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
-        link_flags += " -static" if static?
+        link_flags += " -static" if static? && !program.has_flag? "darwin"
 
         %(#{cc} #{object_name} -o '#{output_filename}' #{link_flags} #{program.lib_flags})
       end

--- a/src/readline.cr
+++ b/src/readline.cr
@@ -1,6 +1,8 @@
 @[Link("readline")]
 {% if flag?(:openbsd) %}
 @[Link("termcap")]
+{% elsif flag?(:darwin) %}
+@[Link("ncurses")]
 {% end %}
 lib LibReadline
   alias Int = LibC::Int


### PR DESCRIPTION
The `-static` flag isn't supported on macOS, but a build can be created which only dynamically links the system library. Also, readline implicitly depends on ncurses and so linking it is required when creating a static build or else you get missing symbol errors.