### PR TITLE
Fix macro interpreter Number type of arithmetic expressions

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -173,6 +173,10 @@ module Crystal
         assert_macro "", "{{1 + 2}}", [] of ASTNode, "3"
       end
 
+      it "executes + and preserves type" do
+        assert_macro "", "{{1_u64 + 2_u64}}", [] of ASTNode, "3_u64"
+      end
+
       it "executes -" do
         assert_macro "", "{{1 - 2}}", [] of ASTNode, "-1"
       end

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -193,9 +193,9 @@ describe "Semantic: enum" do
       end
       ))
     enum_type = result.program.types["Foo"].as(EnumType)
-    enum_type.types["OtherNone"].as(Const).value.should eq(NumberLiteral.new(0, :i32))
-    enum_type.types["Bar"].as(Const).value.should eq(NumberLiteral.new(1, :i32))
-    enum_type.types["Baz"].as(Const).value.should eq(NumberLiteral.new(2, :i32))
+    enum_type.types["OtherNone"].as(Const).value.should eq(NumberLiteral.new("0", :i32))
+    enum_type.types["Bar"].as(Const).value.should eq(NumberLiteral.new("1", :i32))
+    enum_type.types["Baz"].as(Const).value.should eq(NumberLiteral.new("2", :i32))
   end
 
   it "disallows None value when defined with @[Flags]" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -699,7 +699,7 @@ module Crystal
         end
 
         if value
-          NumberLiteral.new(value)
+          NumberLiteral.new(value.to_s, :i32)
         else
           raise "StringLiteral#to_i: #{@value} is not an integer"
         end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -474,7 +474,7 @@ module Crystal
                 if visitor
                   numeric_value = visitor.interpret_enum_value(value)
                   numeric_type = node_type.program.int?(numeric_value) || raise "BUG: expected integer type, not #{numeric_value.class}"
-                  type_var = NumberLiteral.new(numeric_value, numeric_type.kind)
+                  type_var = NumberLiteral.new(numeric_value.to_s, numeric_type.kind)
                   type_var.set_type_from(numeric_type, from)
                 else
                   node.raise "can't use constant #{node} (value = #{value}) as generic type argument, it must be a numeric constant"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2521,7 +2521,7 @@ module Crystal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
       if type && !node.exp.is_a?(TypeOf)
-        expanded = NumberLiteral.new(@program.size_of(type.sizeof_type))
+        expanded = NumberLiteral.new(@program.size_of(type.sizeof_type).to_s, :i32)
         expanded.type = @program.int32
         node.expanded = expanded
       end
@@ -2546,7 +2546,7 @@ module Crystal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
       if type && type.instance_type.devirtualize.class? && !node.exp.is_a?(TypeOf)
-        expanded = NumberLiteral.new(@program.instance_size_of(type.sizeof_type))
+        expanded = NumberLiteral.new(@program.instance_size_of(type.sizeof_type).to_s, :i32)
         expanded.type = @program.int32
         node.expanded = expanded
       end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -576,7 +576,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     unless existed
       if enum_type.flags?
         unless enum_type.types["None"]?
-          none = NumberLiteral.new(0, enum_base_type.kind)
+          none = NumberLiteral.new("0", enum_base_type.kind)
           none.type = enum_type
           enum_type.add_constant Arg.new("None", default_value: none)
 
@@ -584,7 +584,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         end
 
         unless enum_type.types["All"]?
-          all = NumberLiteral.new(all_value, enum_base_type.kind)
+          all = NumberLiteral.new(all_value.to_s, enum_base_type.kind)
           all.type = enum_type
           enum_type.add_constant Arg.new("All", default_value: all)
         end
@@ -643,7 +643,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
 
       all_value |= counter
-      const_value = NumberLiteral.new(counter, base_type.kind)
+      const_value = NumberLiteral.new(counter.to_s, base_type.kind)
       member.default_value = const_value
       if enum_type.types.has_key?(member.name)
         member.raise "enum '#{enum_type}' already contains a member named '#{member.name}'"

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -214,8 +214,8 @@ module Crystal
     def initialize(@value : String, @kind = :i32)
     end
 
-    def initialize(value : Number, @kind = :i32)
-      @value = value.to_s
+    def self.new(value : Number)
+      new(value.to_s, kind_from_number(value))
     end
 
     def has_sign?
@@ -243,6 +243,24 @@ module Crystal
 
     def_equals value.to_f64, kind
     def_hash value, kind
+
+    def self.kind_from_number(number : Number)
+      case number
+      when Int8    then :i8
+      when Int16   then :i16
+      when Int32   then :i32
+      when Int64   then :i64
+      when Int128  then :i128
+      when UInt8   then :u8
+      when UInt16  then :u16
+      when UInt32  then :u32
+      when UInt64  then :u64
+      when UInt128 then :u128
+      when Float32 then :f32
+      when Float64 then :f64
+      else              raise "Unsupported Number type for NumberLiteral: #{number.class}"
+      end
+    end
   end
 
   # A char literal.


### PR DESCRIPTION
`NumberLiteral` constructor receiving the value as a `Number` now uses the number type to determine it's `kind`. The few cases where a specific other type is required are changed to use the constructor receiving `String` plus explicit `kind`.

Fixes #5971