### PR TITLE
Fix OpenSSL binding C preprocesor hack failing on absence of headers

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -3,9 +3,9 @@
     # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
     # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
     LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " +
-                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E -").chomp.split('\n').last.split('L').first.id + "0" }}
+                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
     OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " +
-                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E -").chomp.split('\n').last.split('L').first.id }}
+                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
   end
 {% end %}
 

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -3,9 +3,9 @@
     # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
     # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
     LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " +
-                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
+                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>&1 > /dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
     OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " +
-                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
+                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>&1 > /dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
   end
 {% end %}
 


### PR DESCRIPTION
The C preprocessor hack to determine OpenSSL & LibreSSL version numbers set them to 0 on failure now. Also I redirected stderr to stdoutput and redirected that to `/dev/null` to silence errors on the second commit but I'm not sure if a Unix compatible shell is guaranteed, we can omit that if you like.