### PR TITLE
Add `MetaVar#defualt_value` and `MetaVar#has_default_value?`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1007,15 +1007,19 @@ describe "macro methods" do
 
   describe "metavar methods" do
     it "executes nothing" do
-      assert_macro "x", %({{x}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
+      assert_macro "x", %({{x}}), [MetaMacroVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
     end
 
     it "executes name" do
-      assert_macro "x", %({{x.name}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
+      assert_macro "x", %({{x.name}}), [MetaMacroVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
     end
 
     it "executes id" do
-      assert_macro "x", %({{x.id}}), [MetaVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
+      assert_macro "x", %({{x.id}}), [MetaMacroVar.new("foo", Program.new.int32)] of ASTNode, %(foo)
+    end
+
+    it "executes is_a?" do
+      assert_macro "x", %({{x.is_a?(MetaVar)}}), [MetaMacroVar.new("foo", Program.new.int32)] of ASTNode, %(true)
     end
   end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -786,6 +786,19 @@ module Crystal::Macros
     # Returns the type of this variable, if known, or `nil`.
     def type : TypeNode | NilLiteral
     end
+
+    # Returns the default value of this variable.
+    # Note that if the variable doesn't have a default value,
+    # or the default value is `nil`, a `NilLiteral` will be
+    # returned. To distinguish between these cases, use
+    # `has_default_value?`.
+    def default_value : ASTNode
+    end
+
+    # Returns whether this variable has a default value (which.
+    # can in turn be `nil`).
+    def has_default_value? : BoolLiteral
+    end
   end
 
   # A local variable or block argument.

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -717,4 +717,21 @@ module Crystal
 
     def_equals_and_hash value
   end
+
+  # Ficticious node representing a variable in macros
+  class MetaMacroVar < ASTNode
+    property name : String
+    property default_value : ASTNode?
+
+    def initialize(@name, @type)
+    end
+
+    def class_desc
+      "MetaVar"
+    end
+
+    def clone_without_location
+      self
+    end
+  end
 end

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -35,6 +35,10 @@ module Crystal
       @str << node.name
     end
 
+    def visit(node : MetaMacroVar)
+      @str << node.name
+    end
+
     def visit(node : TypeFilteredNode)
       false
     end

--- a/src/compiler/crystal/semantic/transformer.cr
+++ b/src/compiler/crystal/semantic/transformer.cr
@@ -2,7 +2,7 @@ require "../syntax/transformer"
 
 module Crystal
   class Transformer
-    def transform(node : MetaVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestriction | YieldBlockBinder | MacroId)
+    def transform(node : MetaVar | MetaMacroVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestriction | YieldBlockBinder | MacroId)
       node
     end
 


### PR DESCRIPTION
Fixes #4387

After this, my idea is to implement some form of [meta attribute](https://github.com/crystal-lang/crystal/issues/3620) to be able to implement JSON/YAML/others serialization in a much better, extensible way. So this is just the first step towards that, because one needs to know whether an instance variable has a default value, so if it's not present in the document, when mapping, one should not error.