### PR TITLE
pp: fix the width and indentation of second and later line contents

### DIFF
--- a/spec/std/pretty_print_spec.cr
+++ b/spec/std/pretty_print_spec.cr
@@ -225,6 +225,25 @@ describe PrettyPrint do
     abc def ghi jkl mno pqr stu
     END
 
+  assert_indent 0, 23, <<-END
+    x x x x x x x x x x x
+    END
+
+  assert_indent 5, 20, <<-END
+    x x x x x x x x
+         x x x
+    END
+
+  assert_indent 6, 20, <<-END
+    x x x x x x x
+          x x x x
+    END
+
+  assert_indent 7, 20, <<-END
+    x x x x x x x
+           x x x x
+    END
+
   it "tail group" do
     text = String.build do |io|
       PrettyPrint.format(io, 10) do |q|
@@ -416,6 +435,20 @@ private def fill(width)
   end
 end
 
+private def indent(indent, width)
+  String.build do |io|
+    PrettyPrint.format(io, width, indent: indent) do |q|
+      q.text "x"
+      10.times do |i|
+        q.group do
+          q.breakable
+          q.text "x"
+        end
+      end
+    end
+  end
+end
+
 private def assert_hello(range, expected)
   it "pretty prints hello #{range}" do
     range.each do |width|
@@ -453,5 +486,11 @@ private def assert_fill(range, expected)
     range.each do |width|
       fill(width).should eq(expected)
     end
+  end
+end
+
+private def assert_indent(width, indent, expected)
+  it "pretty prints width #{width} indent #{indent}" do
+    indent(width, indent).should eq(expected)
   end
 end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -100,7 +100,7 @@ macro pp(*exps)
     %prefix = "#{{{ exp.stringify }}} # => "
     ::print %prefix
     %object = {{exp}}
-    PrettyPrint.format(%object, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
+    PrettyPrint.format(%object, STDOUT, width: 80, indent: %prefix.size)
     ::puts
     %object
   {% else %}
@@ -112,7 +112,7 @@ macro pp(*exps)
           %prefix = "#{%names[{{i}}].ljust(%max_size)} # => "
           ::print %prefix
           %object = {{exp}}
-          PrettyPrint.format(%object, STDOUT, width: 80 - %prefix.size, indent: %prefix.size)
+          PrettyPrint.format(%object, STDOUT, width: 80, indent: %prefix.size)
           ::puts
           %object
         end,

--- a/src/pretty_print.cr
+++ b/src/pretty_print.cr
@@ -14,7 +14,7 @@ class PrettyPrint
   # Creates a new pretty printer that will write to the given *output*
   # and be capped at *maxwidth*.
   def initialize(@output : IO, @maxwidth = 79, @newline = "\n", @indent = 0)
-    @output_width = 0
+    @output_width = @indent
     @buffer_width = 0
 
     # Buffer of object that can't yet be printed to


### PR DESCRIPTION
For example,

```crystal
class X
  def pretty_print(pp : PrettyPrint)
    100.times do
      pp.group do
        pp.text "x"
        pp.breakable
      end
    end
  end
end

pp X.new
```

Above code prints this:

```
X.new # => x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
           x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
           x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
           x x x x x x x
```

This second and third lines are shorter than first line, it seems odd.

Expected result:

```
X.new # => x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
           x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
           x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
```

This PR fixes `pp` and `PrettyPrint` to output correctly.