### PR TITLE
Add example of using mapping to parse array

### DIFF
--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -24,6 +24,10 @@ module JSON
   # house.address  # => "Crystal Road 1234"
   # house.location # => #<Location:0x10cd93d80 @lat=12.3, @lng=34.5>
   # house.to_json  # => %({"address":"Crystal Road 1234","location":{"lat":12.3,"lng":34.5}})
+  #
+  # houses = Array(House).from_json(%([{"address": "Crystal Road 1234", "location": {"lat": 12.3, "lng": 34.5}}]))
+  # houses.size    # => 1
+  # houses.to_json # => [{"address":"Crystal Road 1234","location":{"lat":12.3,"lng":34.5}}]
   # ```
   #
   # ### Usage


### PR DESCRIPTION
Currently json documentation is missing a very common example of parsing array of objects using mapping. 

This PR add this example into documentation (in section about using `from_json`).