### PR TITLE
Remove dependency on libxml from spec runner

### DIFF
--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -9,15 +9,14 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <testsuite tests="2" errors="0" failed="0">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else">
-                 </testcase>
+                 <?xml version="1.0"?>
+                 <testsuite tests="2" errors="0" failures="0">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports failures" do
@@ -26,14 +25,15 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <testsuite tests="1" errors="0" failed="1">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 <failure />
-                 </testcase>
+                 <?xml version="1.0"?>
+                 <testsuite tests="1" errors="0" failures="1">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                     <failure/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports errors" do
@@ -42,14 +42,15 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <testsuite tests="1" errors="1" failed="0">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                 <error />
-                 </testcase>
+                 <?xml version="1.0"?>
+                 <testsuite tests="1" errors="1" failures="0">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                     <error/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "reports mixed results" do
@@ -61,31 +62,31 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <testsuite tests="4" errors="2" failed="1">
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1">
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
-                 <failure />
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
-                 <error />
-                 </testcase>
-                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
-                 <error />
-                 </testcase>
+                 <?xml version="1.0"?>
+                 <testsuite tests="4" errors="2" failures="1">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2">
+                     <failure/>
+                   </testcase>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something3">
+                     <error/>
+                   </testcase>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something4">
+                     <error/>
+                   </testcase>
                  </testsuite>
                  XML
 
-    output.should eq(expected)
+    output.chomp.should eq(expected)
   end
 
   it "escapes spec names" do
     output = build_report do |f|
-      f.report Spec::Result.new(:success, "complicated \" <n>'&ame", __FILE__, __LINE__, nil, nil)
+      f.report Spec::Result.new(:success, %(complicated " <n>'&ame), __FILE__, __LINE__, nil, nil)
     end
 
     name = XML.parse(output).xpath_string("string(//testsuite/testcase[1]/@name)")
-    name.should eq("complicated \" <n>'&ame")
+    name.should eq(%(complicated \" <n>'&ame))
   end
 
   it "report failure stacktrace if present" do

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "xml"
 
 describe "JUnit Formatter" do
   it "reports successful results" do
@@ -8,14 +9,15 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <?xml version="1.0"?>
-                 <testsuite tests="2" errors="0" failures="0">
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something"/>
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else"/>
+                 <testsuite tests="2" errors="0" failed="0">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something else">
+                 </testcase>
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports failures" do
@@ -24,15 +26,14 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <?xml version="1.0"?>
-                 <testsuite tests="1" errors="0" failures="1">
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                     <failure/>
-                   </testcase>
+                 <testsuite tests="1" errors="0" failed="1">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 <failure />
+                 </testcase>
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports errors" do
@@ -41,15 +42,14 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <?xml version="1.0"?>
-                 <testsuite tests="1" errors="1" failures="0">
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
-                     <error/>
-                   </testcase>
+                 <testsuite tests="1" errors="1" failed="0">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something">
+                 <error />
+                 </testcase>
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports mixed results" do
@@ -61,22 +61,22 @@ describe "JUnit Formatter" do
     end
 
     expected = <<-XML
-                 <?xml version="1.0"?>
-                 <testsuite tests="4" errors="2" failures="1">
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1"/>
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
-                     <failure/>
-                   </testcase>
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
-                     <error/>
-                   </testcase>
-                   <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
-                     <error/>
-                   </testcase>
+                 <testsuite tests="4" errors="2" failed="1">
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something1">
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something2">
+                 <failure />
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something3">
+                 <error />
+                 </testcase>
+                 <testcase file=\"spec/some_spec.cr\" classname=\"spec.some_spec\" name="should do something4">
+                 <error />
+                 </testcase>
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "escapes spec names" do

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -71,8 +71,9 @@ module Spec
       if message = exception.message
         io << %( message=")
         HTML.escape(message, io)
+        io << '"'
       end
-      io << %(">)
+      io << '>'
 
       if backtrace = exception.backtrace?
         HTML.escape(backtrace.join('\n'), io)

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -40,8 +40,11 @@ module Spec
 
     # -------- private utility methods
     private def write_report(result, io)
-      io << %(  <testcase file=") << result.file
-      io << %(" classname=") << classname(result) << %(" name=")
+      io << %(  <testcase file=")
+      HTML.escape(result.file, io)
+      io << %(" classname=")
+      HTML.escape(classname(result), io)
+      io << %(" name=")
       HTML.escape(result.description, io)
 
       if tag = inner_content_tag(result.kind)


### PR DESCRIPTION
This PR reverts the implementation of #4090 but modifies the plain string formatter to produce the same, indented output as `XML::Builder`. This avoids having all specs depend on `libxml` while still enabling JUnit formatter.

Closes #5662