### PR TITLE
Don't leak variable name when assigning to ivar/cvar in method signature

### DIFF
--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -268,7 +268,7 @@ class Screen
   @rects : Array(Rectangle)
 
   def initialize(@surface : SDL::Surface)
-    @background = Array(UInt32).new(surface.width * surface.height, 0_u32)
+    @background = Array(UInt32).new(@surface.width * @surface.height, 0_u32)
     @rects = parse_rectangles("#{__DIR__}/fire.txt")
   end
 

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -321,7 +321,7 @@ describe "context" do
     end
 
     Bar.new("s")
-    ), "self", "@ivar", "ivar"
+    ), "self", "@ivar", "__arg0"
   end
 
   it "can get context in generic class" do

--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -248,9 +248,9 @@ describe Playground::AgentInstrumentorTransformer do
     end
     ), <<-CR
     class Foo
-      def initialize(x, y)
-        @x = x
-        @y = y
+      def initialize(x __arg0, y __arg1)
+        @x = __arg0
+        @y = __arg1
         @z = _p.i(4) { @x + @y }.as(typeof(@x + @y))
       end
     end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -228,13 +228,13 @@ describe "Parser" do
   it_parses "def foo; with a yield; end", Def.new("foo", body: Yield.new(scope: "a".call), yields: 1)
   it_parses "def foo; with a yield 1; end", Def.new("foo", body: Yield.new([1.int32] of ASTNode, "a".call), yields: 1)
   it_parses "def foo; a = 1; with a yield a; end", Def.new("foo", body: [Assign.new("a".var, 1.int32), Yield.new(["a".var] of ASTNode, "a".var)] of ASTNode, yields: 1)
-  it_parses "def foo(@var); end", Def.new("foo", [Arg.new("var")], [Assign.new("@var".instance_var, "var".var)] of ASTNode)
-  it_parses "def foo(@var); 1; end", Def.new("foo", [Arg.new("var")], [Assign.new("@var".instance_var, "var".var), 1.int32] of ASTNode)
-  it_parses "def foo(@var = 1); 1; end", Def.new("foo", [Arg.new("var", 1.int32)], [Assign.new("@var".instance_var, "var".var), 1.int32] of ASTNode)
-  it_parses "def foo(@@var); end", Def.new("foo", [Arg.new("var")], [Assign.new("@@var".class_var, "var".var)] of ASTNode)
-  it_parses "def foo(@@var); 1; end", Def.new("foo", [Arg.new("var")], [Assign.new("@@var".class_var, "var".var), 1.int32] of ASTNode)
-  it_parses "def foo(@@var = 1); 1; end", Def.new("foo", [Arg.new("var", 1.int32)], [Assign.new("@@var".class_var, "var".var), 1.int32] of ASTNode)
-  it_parses "def foo(&@block); end", Def.new("foo", body: Assign.new("@block".instance_var, "block".var), block_arg: Arg.new("block"), yields: 0)
+  it_parses "def foo(@var); end", Def.new("foo", [Arg.new("__arg0", external_name: "var")], [Assign.new("@var".instance_var, "__arg0".var)] of ASTNode)
+  it_parses "def foo(@var); 1; end", Def.new("foo", [Arg.new("__arg0", external_name: "var")], [Assign.new("@var".instance_var, "__arg0".var), 1.int32] of ASTNode)
+  it_parses "def foo(@var = 1); 1; end", Def.new("foo", [Arg.new("__arg0", external_name: "var", default_value: 1.int32)], [Assign.new("@var".instance_var, "__arg0".var), 1.int32] of ASTNode)
+  it_parses "def foo(@@var); end", Def.new("foo", [Arg.new("__arg0", external_name: "var")], [Assign.new("@@var".class_var, "__arg0".var)] of ASTNode)
+  it_parses "def foo(@@var); 1; end", Def.new("foo", [Arg.new("__arg0", external_name: "var")], [Assign.new("@@var".class_var, "__arg0".var), 1.int32] of ASTNode)
+  it_parses "def foo(@@var = 1); 1; end", Def.new("foo", [Arg.new("__arg0", external_name: "var", default_value: 1.int32)], [Assign.new("@@var".class_var, "__arg0".var), 1.int32] of ASTNode)
+  it_parses "def foo(&@block); end", Def.new("foo", body: Assign.new("@block".instance_var, "__arg0".var), block_arg: Arg.new("__arg0"), yields: 0)
 
   it_parses "def foo(\n&block\n); end", Def.new("foo", block_arg: Arg.new("block"), yields: 0)
   it_parses "def foo(&block \n: Int ->); end", Def.new("foo", block_arg: Arg.new("block", restriction: ProcNotation.new(["Int".path] of ASTNode)), yields: 1)
@@ -264,8 +264,8 @@ describe "Parser" do
   assert_syntax_error "def foo(**args, *x); end", "only block argument is allowed after double splat"
 
   it_parses "def foo(x y); y; end", Def.new("foo", args: [Arg.new("y", external_name: "x")], body: "y".var)
-  it_parses "def foo(x @var); end", Def.new("foo", [Arg.new("var", external_name: "x")], [Assign.new("@var".instance_var, "var".var)] of ASTNode)
-  it_parses "def foo(x @@var); end", Def.new("foo", [Arg.new("var", external_name: "x")], [Assign.new("@@var".class_var, "var".var)] of ASTNode)
+  it_parses "def foo(x @var); end", Def.new("foo", [Arg.new("__arg0", external_name: "x")], [Assign.new("@var".instance_var, "__arg0".var)] of ASTNode)
+  it_parses "def foo(x @@var); end", Def.new("foo", [Arg.new("__arg0", external_name: "x")], [Assign.new("@@var".class_var, "__arg0".var)] of ASTNode)
   assert_syntax_error "def foo(_ y); y; end"
 
   it_parses %(def foo("bar qux" y); y; end), Def.new("foo", args: [Arg.new("y", external_name: "bar qux")], body: "y".var)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -152,7 +152,7 @@ module Crystal
       @llvm_typer = LLVMTyper.new(@program, @llvm_context)
       @main_llvm_typer = @llvm_typer
       @llvm_id = LLVMId.new(@program)
-      @main_ret_type = node.type? || @program.nil_type
+      @main_ret_type = @node.type? || @program.nil_type
       ret_type = @llvm_typer.llvm_return_type(@main_ret_type)
       @main = @llvm_mod.functions.add(MAIN_NAME, [llvm_context.int32, llvm_context.void_pointer.pointer], ret_type)
 
@@ -180,12 +180,12 @@ module Crystal
       @strings = {} of StringKey => LLVM::Value
       @symbols = {} of String => Int32
       @symbol_table_values = [] of LLVM::Value
-      program.symbols.each_with_index do |sym, index|
+      @program.symbols.each_with_index do |sym, index|
         @symbols[sym] = index
         @symbol_table_values << build_string_constant(sym, sym)
       end
 
-      unless program.symbols.empty?
+      unless @program.symbols.empty?
         symbol_table = define_symbol_table @llvm_mod, @llvm_typer
         symbol_table.initializer = llvm_type(@program.string).const_array(@symbol_table_values)
       end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -49,7 +49,7 @@ module Crystal
 
       @structs = {} of String => LLVM::Type
 
-      machine = program.target_machine
+      machine = @program.target_machine
       @layout = machine.data_layout
       @landing_pad_type = @llvm_context.struct([@llvm_context.void_pointer, @llvm_context.int32], "landing_pad")
     end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -35,7 +35,7 @@ module Crystal
       # message with that message. In this way the error message will
       # look like a regular message produced by the compiler, and not
       # because of an incorrect macro expansion.
-      if inner.is_a?(MacroRaiseException)
+      if (inner = @inner).is_a?(MacroRaiseException)
         message = inner.message
         @inner = nil
       end

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -2,7 +2,7 @@ module Crystal
   class TypeFilteredNode < ASTNode
     def initialize(@filter : TypeFilter, @node : ASTNode)
       @dependencies = [@node] of ASTNode
-      node.add_observer self
+      @node.add_observer self
       update(@node)
     end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -111,8 +111,9 @@ module Crystal
     # Type filters for `exp` in `!exp`, used after a `while`
     @before_not_type_filters : TypeFilters?
 
-    def initialize(program, vars = MetaVars.new, @typed_def = nil, meta_vars = nil)
+    def initialize(program, vars = MetaVars.new, typed_def = nil, meta_vars = nil)
       super(program, vars)
+      @typed_def = typed_def
       @while_stack = [] of While
       @needs_type_filters = 0
       @typeof_nest = 0

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -68,8 +68,8 @@ class Crystal::Type
       # If we are looking types inside a non-instantiated generic type,
       # for example Hash(K, V), we want to find K and V as type parameters
       # of that type.
-      if @find_root_generic_type_parameters && root.is_a?(GenericType)
-        free_vars ||= {} of String => TypeVar
+      if @find_root_generic_type_parameters && (root = @root).is_a?(GenericType)
+        free_vars = @free_vars ||= {} of String => TypeVar
         root.type_vars.each do |type_var|
           free_vars[type_var] ||= root.type_parameter(type_var)
         end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1694,7 +1694,8 @@ module Crystal
     property doc : String?
     property? varargs : Bool
 
-    def initialize(@name, @args = [] of Arg, @return_type = nil, @varargs = false, @body = nil, @real_name = name)
+    def initialize(@name, @args = [] of Arg, @return_type = nil, @varargs = false, @body = nil, real_name = nil)
+      @real_name = real_name || @name
     end
 
     def accept_children(visitor)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -29,7 +29,7 @@ module Crystal
       @def_nest = 0
       @type_nest = 0
       @call_args_nest = 0
-      @block_arg_count = 0
+      @temp_arg_count = 0
       @in_macro_expression = false
       @stop_on_yield = 0
       @inside_c_struct = false
@@ -1380,8 +1380,7 @@ module Crystal
       next_token_skip_space
 
       if @token.type == :"."
-        block_arg_name = "__arg#{@block_arg_count}"
-        @block_arg_count += 1
+        block_arg_name = new_temp_arg_name
 
         obj = Var.new(block_arg_name)
 
@@ -3613,6 +3612,9 @@ module Crystal
           raise "when specified, external name must be different than internal name", @token
         end
 
+        external_name ||= arg_name
+        arg_name = new_temp_arg_name
+
         ivar = InstanceVar.new(@token.value.to_s).at(location)
         var = Var.new(arg_name).at(location)
         assign = Assign.new(ivar, var).at(location)
@@ -3628,6 +3630,9 @@ module Crystal
         if arg_name == external_name
           raise "when specified, external name must be different than internal name", @token
         end
+
+        external_name ||= arg_name
+        arg_name = new_temp_arg_name
 
         cvar = ClassVar.new(@token.value.to_s).at(location)
         var = Var.new(arg_name).at(location)
@@ -3946,8 +3951,7 @@ module Crystal
           when :UNDERSCORE
             arg_name = "_"
           when :"("
-            block_arg_name = "__arg#{@block_arg_count}"
-            @block_arg_count += 1
+            block_arg_name = new_temp_arg_name
 
             next_token_skip_space_or_newline
 
@@ -5639,6 +5643,12 @@ module Crystal
       end
 
       token
+    end
+
+    def new_temp_arg_name
+      name = "__arg#{@temp_arg_count}"
+      @temp_arg_count += 1
+      name
     end
   end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1933,7 +1933,7 @@ module Crystal
         end
       end
 
-      if node.external_name != node.name
+      if !at_skip? && node.external_name != node.name
         if node.external_name.empty?
           write "_"
         elsif @token.type == :DELIMITER_START

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1045,16 +1045,16 @@ module Crystal
     property? extern_union = false
     property? packed = false
 
-    def initialize(program, namespace, name, @superclass, add_subclass = true)
+    def initialize(program, namespace, name, superclass, add_subclass = true)
       super(program, namespace, name)
-      superclass = @superclass
+      @superclass = superclass
       @depth = superclass ? (superclass.depth + 1) : 0
       parents.push superclass if superclass
       force_add_subclass if add_subclass
     end
 
-    def superclass=(@superclass)
-      superclass = @superclass
+    def superclass=(superclass)
+      @superclass = superclass
       @depth = superclass ? (superclass.depth + 1) : 0
       parents.push superclass if superclass
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1047,12 +1047,14 @@ module Crystal
 
     def initialize(program, namespace, name, @superclass, add_subclass = true)
       super(program, namespace, name)
+      superclass = @superclass
       @depth = superclass ? (superclass.depth + 1) : 0
       parents.push superclass if superclass
       force_add_subclass if add_subclass
     end
 
     def superclass=(@superclass)
+      superclass = @superclass
       @depth = superclass ? (superclass.depth + 1) : 0
       parents.push superclass if superclass
     end

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -15,7 +15,7 @@ module Debug
       @ref_offset : LibC::OffT
 
       def initialize(@io : IO::FileDescriptor, @offset)
-        @ref_offset = offset
+        @ref_offset = @offset
 
         @unit_length = @io.read_bytes(UInt32)
         if @unit_length == 0xffffffff

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -569,7 +569,10 @@ module Indexable(T)
   private class ReverseItemIterator(A, T)
     include Iterator(T)
 
-    def initialize(@array : A, @index : Int32 = array.size - 1)
+    @index : Int32
+
+    def initialize(@array : A)
+      @index = @array.size - 1
     end
 
     def next

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -5,7 +5,7 @@ class IO
     getter invalid : Symbol?
 
     def initialize(@name : String, @invalid : Symbol?)
-      EncodingOptions.check_invalid(invalid)
+      EncodingOptions.check_invalid(@invalid)
     end
 
     def self.check_invalid(invalid)
@@ -19,7 +19,7 @@ class IO
 
   private class Encoder
     def initialize(@encoding_options : EncodingOptions)
-      @iconv = Iconv.new("UTF-8", encoding_options.name, encoding_options.invalid)
+      @iconv = Iconv.new("UTF-8", @encoding_options.name, @encoding_options.invalid)
       @closed = false
     end
 
@@ -58,7 +58,7 @@ class IO
     @in_buffer : Pointer(UInt8)
 
     def initialize(@encoding_options : EncodingOptions)
-      @iconv = Iconv.new(encoding_options.name, "UTF-8", encoding_options.invalid)
+      @iconv = Iconv.new(@encoding_options.name, "UTF-8", @encoding_options.invalid)
       @buffer = Bytes.new((GC.malloc_atomic(BUFFER_SIZE).as(UInt8*)), BUFFER_SIZE)
       @in_buffer = @buffer.to_unsafe
       @in_buffer_left = LibC::SizeT.new(0)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1071,7 +1071,10 @@ module Iterator(T)
     include Iterator({T, Int32})
     include IteratorWrapper
 
-    def initialize(@iterator : I, @offset : O, @index : O = offset)
+    @index : O
+
+    def initialize(@iterator : I, @offset : O)
+      @index = @offset
     end
 
     def next

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -64,7 +64,7 @@ module Levenshtein
     @tolerance : Int32
 
     def initialize(@target : String, tolerance : Int? = nil)
-      @tolerance = tolerance || (target.size / 5.0).ceil.to_i
+      @tolerance = tolerance || (@target.size / 5.0).ceil.to_i
     end
 
     def test(name : String, value : String = name)

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -2,7 +2,7 @@ require "./lib_llvm"
 
 struct LLVM::DIBuilder
   def initialize(@llvm_module : Module)
-    @unwrap = LibLLVMExt.create_di_builder(llvm_module)
+    @unwrap = LibLLVMExt.create_di_builder(@llvm_module)
   end
 
   def create_compile_unit(lang, file, dir, producer, optimized, flags, runtime_version)

--- a/src/range.cr
+++ b/src/range.cr
@@ -312,9 +312,10 @@ struct Range(B, E)
 
     @range : Range(B, E)
     @current : B
-    @reached_end : Bool
+    @reached_end = false
 
-    def initialize(@range : Range(B, E), @current = range.begin, @reached_end = false)
+    def initialize(@range : Range(B, E))
+      @current = @range.begin
     end
 
     def next
@@ -348,7 +349,8 @@ struct Range(B, E)
     @range : Range(B, E)
     @current : E
 
-    def initialize(@range : Range(B, E), @current = range.end)
+    def initialize(@range : Range(B, E))
+      @current = @range.end
       rewind
     end
 
@@ -374,9 +376,10 @@ struct Range(B, E)
     @range : R
     @step : N
     @current : B
-    @reached_end : Bool
+    @reached_end = false
 
-    def initialize(@range, @step, @current = range.begin, @reached_end = false)
+    def initialize(@range, @step)
+      @current = @range.begin
     end
 
     def next

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -50,7 +50,8 @@ class Socket
     @addr6 : LibC::In6Addr?
     @addr4 : LibC::InAddr?
 
-    def initialize(@address : String, @port : Int32)
+    def initialize(address : String, @port : Int32)
+      @address = address
       if @addr6 = ip6?(address)
         @family = Family::INET6
         @size = sizeof(LibC::SockaddrIn6)

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -31,7 +31,9 @@ class UNIXServer < UNIXSocket
   # ```
   # UNIXServer.new("/tmp/dgram.sock", Socket::Type::DGRAM)
   # ```
-  def initialize(@path : String, type : Type = Type::STREAM, backlog = 128)
+  def initialize(path : String, type : Type = Type::STREAM, backlog = 128)
+    @path = path
+
     super(Family::UNIX, type)
 
     bind(UNIXAddress.new(path)) do |error|

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -15,7 +15,9 @@ class UNIXSocket < Socket
   getter path : String?
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
-  def initialize(@path : String, type : Type = Type::STREAM)
+  def initialize(path : String, type : Type = Type::STREAM)
+    @path = path
+
     super(Family::UNIX, type, Protocol::IP)
 
     connect(UNIXAddress.new(path)) do |error|

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -23,7 +23,7 @@ class YAML::Builder
 
   # Creates a `YAML::Builder` that will write to the given `IO`.
   def initialize(@io : IO)
-    @box = Box.box(io)
+    @box = Box.box(@io)
     @emitter = Pointer(Void).malloc(LibYAML::EMITTER_SIZE).as(LibYAML::Emitter*)
     @event = LibYAML::Event.new
     @closed = false

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -10,7 +10,8 @@
 class YAML::PullParser
   protected getter content
 
-  def initialize(@content : String | IO)
+  def initialize(content : String | IO)
+    @content = content
     @parser = Pointer(Void).malloc(LibYAML::PARSER_SIZE).as(LibYAML::Parser*)
     @event = LibYAML::Event.new
     @closed = false

--- a/src/zip/file.cr
+++ b/src/zip/file.cr
@@ -159,7 +159,7 @@ class Zip::File
 
     # :nodoc:
     def initialize(@io : IO)
-      super(at_central_directory_header: io)
+      super(at_central_directory_header: @io)
     end
 
     # Yields an `IO` to read this entry's contents.

--- a/src/zlib/reader.cr
+++ b/src/zlib/reader.cr
@@ -12,7 +12,7 @@ class Zlib::Reader < IO
 
   # Creates a new reader from the given *io*.
   def initialize(@io : IO, @sync_close = false, dict : Bytes? = nil)
-    Zlib::Reader.read_header(io, dict)
+    Zlib::Reader.read_header(@io, dict)
     @flate_io = Flate::Reader.new(@io, dict: dict)
     @adler32 = Adler32.initial
     @end = false

--- a/src/zlib/writer.cr
+++ b/src/zlib/writer.cr
@@ -16,7 +16,7 @@ class Zlib::Writer < IO
   def initialize(@io : IO, @level = Zlib::DEFAULT_COMPRESSION, @sync_close = false, @dict : Bytes? = nil)
     @wrote_header = false
     @adler32 = Adler32.initial
-    @flate_io = Flate::Writer.new(@io, level: level, dict: @dict)
+    @flate_io = Flate::Writer.new(@io, level: @level, dict: @dict)
   end
 
   # Creates a new writer to the given *filename*.


### PR DESCRIPTION
Fixes #5997
Fixes #4332

The idea is that this:

```crystal
def foo(@var)
end
```

expands to this:

```crystal
def foo(var __arg0)
  @var = __arg0 # the name __arg0 could be another one, you don't know it
end
```

instead of:

```crystal
def foo(var)
  @var = var
end
```

so you don't have access to that "implicit" local variable anymore.

I think this is good. It's a breaking change, but it's more intuitive. If you want it assigned to a local variable, explicitly assign it to a local variable.