### PR TITLE
Formatter: fix call args indent in case of backslash follows method name

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1111,6 +1111,9 @@ describe Crystal::Formatter do
   assert_format "x 1, \\\n  2", "x 1,\n  2"
   assert_format "begin\n  1 + \\\n    2\n  3\nend"
   assert_format "begin\n  1 \\\n    + 2\n  3\nend"
+  assert_format "foo \\\n  1,\n  2"
+  assert_format "foo \\\n  foo: 1,\n  bar: 2"
+  assert_format "foo \\\n  1,\n  2\n\nbar \\\n  foo: 1,\n  bar: 2"
 
   assert_format "alias X = ((Y, Z) ->)"
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -241,7 +241,7 @@ module Crystal
         if next_needs_indent
           write_indent(@indent, exp)
         else
-          accept exp
+          indent(@indent, exp)
         end
         @multiline_call_indent = nil
 
@@ -2399,7 +2399,7 @@ module Crystal
       format_args node.args, has_parentheses, node.named_args, node.block_arg
     end
 
-    def format_args(args : Array, has_parentheses, named_args = nil, block_arg = nil, needed_indent = @indent + 2, do_consume_newlines = false)
+    def format_args(args : Array, has_parentheses, named_args = nil, block_arg = nil, needed_indent = @indent + (@passed_backslash_newline ? 0 : 2), do_consume_newlines = false)
       has_newlines = false
       found_comment = false
       @inside_call_or_assign += 1


### PR DESCRIPTION
Fixed #6010