### PR TITLE
Don't automatically virtualize two types in the same hierarchy, unless one is deeper than the other

### DIFF
--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -321,7 +321,7 @@ point_count = ARGV.size > 0 ? ARGV[0].to_i : 4
 yellow = YellowColorPattern.new
 magenta = MagentaColorPattern.new
 cyan = CyanColorPattern.new
-rainbow = RainbowColorPattern.new [yellow, magenta, cyan]
+rainbow = RainbowColorPattern.new [yellow, magenta, cyan] of ColorPattern
 
 main_points = [] of MainPoint
 main_points << MainPoint.new(50, 50, -Math::PI / 8, 1.4, yellow)

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -504,7 +504,15 @@ describe "Code gen: class" do
 
   it "does to_s for virtual metaclass type (3)" do
     run(%(
-      require "prelude"
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+
+        def to_s
+          name
+        end
+      end
 
       class Foo; end
       class Bar < Foo; end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -178,7 +178,7 @@ describe "Semantic: class" do
       end
 
       a = Bar.new || Baz.new
-      ") { types["Foo"].virtual_type }
+      ") { union_of types["Bar"], types["Baz"] }
   end
 
   it "types class and subclass as one type" do

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -316,7 +316,7 @@ describe "Semantic: def" do
 
   it "says compile-time type on error" do
     assert_error %(
-      abstract class Foo
+      class Foo
       end
 
       class Bar < Foo
@@ -328,7 +328,7 @@ describe "Semantic: def" do
       class Baz < Foo
       end
 
-      f = Bar.new || Baz.new
+      f = Bar.new || Foo.new
       f.bar
       ),
       "compile-time type is Foo+"

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -39,7 +39,7 @@ describe "Semantic: struct" do
       struct Baz < Foo
       end
 
-      Bar.new || Baz.new
+      (Bar.new || Baz.new).as(Foo)
       ") { types["Foo"].virtual_type! }
   end
 

--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -35,7 +35,7 @@ describe "Semantic: virtual metaclass" do
 
   it "allows allocating virtual type when base class is abstract" do
     assert_type("
-      abstract class Foo
+      class Foo
       end
 
       class Bar < Foo
@@ -44,7 +44,7 @@ describe "Semantic: virtual metaclass" do
       class Baz < Foo
       end
 
-      bar = Bar.new || Baz.new
+      bar = Bar.new || Foo.new
       baz = bar.class.allocate
       ") { types["Foo"].virtual_type }
   end

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -37,7 +37,7 @@ describe "Semantic: virtual" do
       end
 
       a = Bar.new || Baz.new
-      ") { types["Foo"].virtual_type }
+      ") { union_of types["Bar"], types["Baz"] }
   end
 
   it "types class and two subclasses" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -505,6 +505,11 @@ class Crystal::CodeGenVisitor
   end
 
   def upcast_distinct(value, to_type : MetaclassType | GenericClassInstanceMetaclassType | GenericModuleInstanceMetaclassType | VirtualMetaclassType, from_type)
+    # Special case: union of metaclasses is still represented as a union
+    if from_type.is_a?(MixedUnionType)
+      return load(union_type_id(value))
+    end
+
     value
   end
 

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -87,7 +87,7 @@ module Crystal
       exps = Array(ASTNode).new(node.entries.size + 2)
       exps << Assign.new(temp_var.clone, constructor).at(node)
       node.entries.each do |entry|
-        exps << Call.new(temp_var.clone, "[]=", [entry.key.clone, entry.value.clone]).at(node)
+        exps << Call.new(temp_var.clone, "[]=", [entry.key.clone, entry.value.clone] of ASTNode).at(node)
       end
       exps << temp_var.clone
 

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -260,7 +260,7 @@ module Crystal
 
       # (1); (4)
       if assign
-        Expressions.new([assign, call]).at(node)
+        Expressions.new([assign, call] of ASTNode).at(node)
       else
         call
       end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -120,6 +120,19 @@ module Crystal
     end
 
     def type_combine(types)
+      # Modules and types at a higher level in the hierarchy are the ones
+      # that will "delete" deeper types and combine them into virtual
+      # types (or just modules), so we put them in the front for the algorithm.
+      types.sort! do |t1, t2|
+        if t1.module?
+          -1
+        elsif t2.module?
+          1
+        else
+          t1.depth <=> t2.depth
+        end
+      end
+
       all_types = [types.shift] of Type
 
       types.each do |t2|
@@ -331,14 +344,10 @@ private def class_common_ancestor(t1, t2)
     return t1
   end
 
-  if t1.depth == t2.depth
-    t1_superclass = t1.superclass
-    t2_superclass = t2.superclass
-
-    if t1_superclass && t2_superclass
-      return t1_superclass.common_ancestor(t2_superclass)
-    end
-  elsif t1.depth > t2.depth
+  # If one type is deeper than the other, check if going up we find
+  # the one in the top, and if so we combine them.
+  # But if they are at the same depth we don't go up.
+  if t1.depth > t2.depth
     t1_superclass = t1.superclass
     if t1_superclass
       return t1_superclass.common_ancestor(t2)

--- a/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
+++ b/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
@@ -96,11 +96,11 @@ module Crystal
 
     def transform(node : MultiAssign)
       node.values = if node.values.size == 1
-                      [instrument(node.values[0])]
+                      [instrument(node.values[0])] of ASTNode
                     else
                       rhs = TupleLiteral.new(node.values)
                       rhs.location = node.location
-                      [instrument(rhs)]
+                      [instrument(rhs)] of ASTNode
                     end
       node
     end


### PR DESCRIPTION
Fixes #2661
Fixes #4303

What this means is that with this PR, the language will now behave like this:

```crystal
class Foo
end

class Bar < Foo
end

class Baz < Foo
end

var = rand < 0.5 ? Bar.new : Baz.new
typeof(var) #=> Bar | Baz
```

Previously the type would go up to `Foo`.

However:

```crystal
var = rand < 0.5 ? Bar.new : Foo.new
typeof(var) #=> Foo
```

because `Bar < Foo`, so that gets "upcasted" to `Foo` (or `Foo+`, if you know what I mean).

This makes it possible to have more accurate information about the type of a variable. For example in the compiler's source code we have a `TypeDeclaration` node whose `var` is of type `ASTNode`, where in reality it can only be `Var | InstanceVar | ClassVar | Global`. So the compiler has some "otherwise, raise bug" that could be removed.

Somehow, compilation times for the compiler don't get much more slower. Memory consumption goes a bit higher (most probably because now there are some union types that previously would go up to `ASTNode` but not now, so a bit more duplicated code is generated), but I don't think we should care anymore about compile times or memory consumption of the compiler (Slack alone, or Chrome, already consume 1GB from your computer and nobody seems to complain... or maybe yes, but well, "if they do it..."). Or, as usual, we can worry about such things later, or maybe a superhero will come with a compiler rewrite or some patches to improve performance 😛 

**PLEASE**, if you can, checkout this branch, compiler the compiler, and try it in your projects. Many things can happen:
1. Your code won't compile for some reason. This usually happens when you have `[foo, bar]`, you'll probably now have to write `[foo, bar] of T` for some `T` because (taking the above example), `Array(Foo)` is not compatible with `Array(Bar | Baz)`.
2. Your code will explode (after fixing possible errors in 1). This is what I'd like to know, as it probably means this PR is buggy.

---

Once and if we can go ahead with this change, I'd like to revisit #4837, as it can be another great addition for more type safey and accuracy in the language, avoiding useless `else raise "Impossible"` and generally making the code more robust to changes.