### PR TITLE
Remove block argument from `loop`

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -14,22 +14,18 @@ PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
 ARGV         = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
 ARGF         = IO::ARGF.new(ARGV, STDIN)
 
-# Repeatedly executes the block, passing an incremental `Int32`
-# that starts with `0`.
+# Repeatedly executes the block.
 #
 # ```
-# loop do |i|
-#   print "#{i}) "
+# loop do
 #   line = gets
 #   break unless line
 #   # ...
 # end
 # ```
 def loop
-  i = 0
   while true
-    yield i
-    i += 1
+    yield
   end
 end
 


### PR DESCRIPTION
Introducing a block argument here was a mistake. Some people now want the loop index to be a different value. But the worse thing is that the loop index can silently overflow. And if we ever change the language to raise on overflow, this could eventually break some long running programs like servers (and that wouldn't be nice).

`loop` is intended to be a cute syntax sugar for `while true` while also allowing you to keep the variable inside the loop local to the block.

Closes #5975