### PR TITLE
Mark .editorconfig as root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*.cr]
 charset = utf-8
 end_of_line = lf

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -80,6 +80,7 @@ module Crystal
       {"example", "example_app", "example-lib", "camel_example-camel_lib"}.each do |name|
         describe_file "#{name}/.editorconfig" do |editorconfig|
           parsed = INI.parse(editorconfig)
+          parsed["root"].should eq("true")
           cr_ext = parsed["*.cr"]
           cr_ext["charset"].should eq("utf-8")
           cr_ext["end_of_line"].should eq("lf")

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -80,8 +80,7 @@ module Crystal
       {"example", "example_app", "example-lib", "camel_example-camel_lib"}.each do |name|
         describe_file "#{name}/.editorconfig" do |editorconfig|
           parsed = INI.parse(editorconfig)
-          # TODO: remove comment out after next release
-          # parsed["root"].should eq("true")
+          parsed[""]["root"].should eq("true")
           cr_ext = parsed["*.cr"]
           cr_ext["charset"].should eq("utf-8")
           cr_ext["end_of_line"].should eq("lf")

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -80,7 +80,8 @@ module Crystal
       {"example", "example_app", "example-lib", "camel_example-camel_lib"}.each do |name|
         describe_file "#{name}/.editorconfig" do |editorconfig|
           parsed = INI.parse(editorconfig)
-          parsed["root"].should eq("true")
+          # TODO: remove comment out after next release
+          # parsed["root"].should eq("true")
           cr_ext = parsed["*.cr"]
           cr_ext["charset"].should eq("utf-8")
           cr_ext["end_of_line"].should eq("lf")

--- a/src/compiler/crystal/tools/init/template/editorconfig.ecr
+++ b/src/compiler/crystal/tools/init/template/editorconfig.ecr
@@ -1,3 +1,5 @@
+root = true
+
 [*.cr]
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
I think `.editorconfig` in project root should set `root = true` and [almost all projects](https://github.com/search?q=.editorconfig+in%3Apath&type=Code) do such. Why not `crystal-lang/crystal` do?