### PR TITLE
Allow to visit cond node in case

### DIFF
--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1142,6 +1142,7 @@ module Crystal
     end
 
     def accept_children(visitor)
+      @cond.try &.accept visitor
       @whens.each &.accept visitor
       @else.try &.accept visitor
     end


### PR DESCRIPTION
For some reason, the compiler does not allow to traverse the nodes in `Crystal::Case#cond`. I guess it is a bug. Please suggest the place for the specs.

Example:

```crystal
class Visitor < Crystal::Visitor
  def visit(node : Crystal::ASTNode)
    puts node.class
    true
  end
end

parser = Crystal::Parser.new %(
  case (a == 2 && b == 3) # cond expression is not expanded/visited
  when true then nil
  end
)

Visitor.new.accept parser.parse # Crystal::Case
                                # Crystal::When
                                # Crystal::BoolLiteral
                                # Crystal::NilLiteral
```