### PR TITLE
Add Char#code_point method

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -396,6 +396,12 @@ describe "Char" do
     '酒'.ascii?.should be_false
   end
 
+  it "returns proper code_point" do
+    'A'.code_point.should eq 65
+    'a'.code_point.should eq 97
+    '\n'.code_point.should eq 10
+  end
+
   describe "clone" do
     it { 'a'.clone.should eq('a') }
   end

--- a/src/char.cr
+++ b/src/char.cr
@@ -796,6 +796,16 @@ struct Char
     ord === byte
   end
 
+  # Returns the codepoint of this char.
+  # Same as `ord`.
+  #
+  # ```
+  # 'c'.code_point # => 99
+  # ```
+  def code_point : Int32
+    ord
+  end
+
   def clone
     self
   end


### PR DESCRIPTION
When we use `Char`, often use case is to get it's code point.

However in Crystal there isn't `code_point` method on Char, only `ord`. This PR adds `code_point` method (which is intuitive), that returns code point of given char (same as `ord`).

I've included specs and documentation for this method.