### PR TITLE
Remove `Tempfile#unlink` dead alias

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -192,7 +192,7 @@ describe Process do
   it "executes the new process with exec" do
     tmpfile = Tempfile.new("crystal-spec-exec")
     tmpfile.close
-    tmpfile.unlink
+    tmpfile.delete
     File.exists?(tmpfile.path).should be_false
 
     fork = Process.fork do
@@ -201,7 +201,7 @@ describe Process do
     fork.wait
 
     File.exists?(tmpfile.path).should be_true
-    tmpfile.unlink
+    tmpfile.delete
   ensure
     File.delete(tmpfile.path) if tmpfile && File.exists?(tmpfile.path)
   end

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -29,7 +29,7 @@ require "c/stdlib"
 #
 # ```
 # tempfile = Tempfile.new("foo")
-# tempfile.unlink
+# tempfile.delete
 # ```
 #
 # The optional `extension` argument can be used to force the resulting filename
@@ -104,10 +104,5 @@ class Tempfile < File
   # Deletes this tempfile.
   def delete
     File.delete(@path)
-  end
-
-  # ditto
-  def unlink
-    delete
   end
 end


### PR DESCRIPTION
This PR removes dead `Tempfile#unlink` alias as specified in this comment:
https://github.com/crystal-lang/crystal/pull/6035#issuecomment-385446006