### PR TITLE
Fix bug at the --threads command

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -462,7 +462,7 @@ class Crystal::Command
       error "You have input an invalid format, only text and JSON are supported"
     end
 
-    error "maximum number of threads cannot be lower than 1" if compiler.n_threads<1
+    error "maximum number of threads cannot be lower than 1" if compiler.n_threads < 1
 
     if !no_codegen && !run && Dir.exists?(output_filename)
       error "can't use `#{output_filename}` as output filename because it's a directory"

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -462,6 +462,8 @@ class Crystal::Command
       error "You have input an invalid format, only text and JSON are supported"
     end
 
+    error "maximum number of threads cannot be lower than 1" if compiler.n_threads<1
+
     if !no_codegen && !run && Dir.exists?(output_filename)
       error "can't use `#{output_filename}` as output filename because it's a directory"
     end


### PR DESCRIPTION
Right now when you compile with `crystal myfile.cr --threads 0` then this happens:
```Crystal
Division by zero
???
???
???
???
???
???
???

Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://githu
b.com/crystal-lang/crystal/issues
```
Or when you specify something lower than 0:
`crystal myfile.cr --threads -1228`
```Crystal
Negative deque capacity: -1228
???
???
???
???
???
???
???

Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://githu
b.com/crystal-lang/crystal/issues
```
My `crystal -v` output:
```Crystal
Crystal 0.24.2 [4f9ed8d03] (2018-03-08)

LLVM: 4.0.0
Default target: x86_64-unknown-linux-gnu
```