### PR TITLE
add with_object with block to iterator

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -513,8 +513,8 @@ describe Iterator do
     end
   end
 
-  describe "with object" do
-    it "does with object" do
+  describe "with_object" do
+    it "does with_object" do
       iter = (1..3).each.with_object("a")
       iter.next.should eq({1, "a"})
       iter.next.should eq({2, "a"})
@@ -523,6 +523,13 @@ describe Iterator do
 
       iter.rewind
       iter.next.should eq({1, "a"})
+    end
+
+    it "does with_object with block" do
+      output = (1..5).each.with_object([] of Int32) do |value, object|
+        object << value if value % 2 == 0
+      end
+      output.should eq([2, 4])
     end
   end
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1100,6 +1100,15 @@ module Iterator(T)
     WithObject(typeof(self), T, typeof(obj)).new(self, obj)
   end
 
+  # Yields each element in this iterator together with given object
+  # and returns that object.
+  def with_object(obj)
+    each do |value|
+      yield value, obj
+    end
+    obj
+  end
+
   private struct WithObject(I, T, O)
     include Iterator({T, O})
     include IteratorWrapper


### PR DESCRIPTION
This PR adds missing with_object with block option to iterator (same as f.e. `with_index` with block).