### PR TITLE
Compiler: don't fail when typeof argument doesn't have a type

### DIFF
--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -65,8 +65,16 @@ describe "Semantic: primitives" do
     assert_type("sizeof(Float64)") { int32 }
   end
 
+  it "types sizeof NoReturn (missing type) (#5717)" do
+    assert_type("x = nil; x ? sizeof(typeof(x)) : 1") { int32 }
+  end
+
   it "types instance_sizeof" do
     assert_type("instance_sizeof(Reference)") { int32 }
+  end
+
+  it "types instance_sizeof NoReturn (missing type) (#5717)" do
+    assert_type("x = nil; x ? instance_sizeof(typeof(x)) : 1") { int32 }
   end
 
   it "errors when comparing void (#225)" do

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2461,19 +2461,18 @@ module Crystal
       @in_type_args -= 1
 
       type = node.exp.type?
-      unless type
-        raise "BUG: #{node} at #{node.location} should receive a type"
-      end
 
       # Try to resolve the sizeof right now to a number literal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
-      if !node.exp.is_a?(TypeOf)
+      if type && !node.exp.is_a?(TypeOf)
         expanded = NumberLiteral.new(@program.size_of(type.sizeof_type))
         expanded.type = @program.int32
         node.expanded = expanded
       end
+
       node.type = @program.int32
+
       false
     end
 
@@ -2483,9 +2482,6 @@ module Crystal
       @in_type_args -= 1
 
       type = node.exp.type?
-      unless type
-        raise "BUG: #{node} at #{node.location} should receive a type"
-      end
 
       if type.is_a? GenericType
         node.raise "can't calculate instance_sizeof of generic class #{type} without specifying its type vars"
@@ -2494,12 +2490,14 @@ module Crystal
       # Try to resolve the instance_sizeof right now to a number literal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
-      if type.instance_type.devirtualize.class? && !node.exp.is_a?(TypeOf)
+      if type && type.instance_type.devirtualize.class? && !node.exp.is_a?(TypeOf)
         expanded = NumberLiteral.new(@program.instance_size_of(type.sizeof_type))
         expanded.type = @program.int32
         node.expanded = expanded
       end
+
       node.type = @program.int32
+
       false
     end
 


### PR DESCRIPTION
Fixes #5717

This reverts a bug that was introduced that did `raise bug` when the expression given to a `typeof` didn't have a type.

Not having a type is something that the compiler should be very resilient to, because it can mean an unreachable path (as in the examples shown in the specs) that will later simply be not emitted in the codegen phase.