### PR TITLE
Parser: fix parsing of macro argument followed by a newline

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -804,6 +804,8 @@ describe "Parser" do
   it_parses "macro foo;bar{% for x in y %}\\  \n   body{% end %}\\   baz;end", Macro.new("foo", [] of Arg, Expressions.from(["bar".macro_literal, MacroFor.new(["x".var], "y".var, "body".macro_literal), "baz;".macro_literal] of ASTNode))
   it_parses "macro foo; 1 + 2 {{foo}}\\ 3 + 4; end", Macro.new("foo", [] of Arg, Expressions.from([" 1 + 2 ".macro_literal, MacroExpression.new("foo".var), "3 + 4; ".macro_literal] of ASTNode))
 
+  it_parses "macro foo(\na = 0\n)\nend", Macro.new("foo", [Arg.new("a", default_value: 0.int32)], Expressions.new)
+
   assert_syntax_error "macro foo; {% foo = 1 }; end"
   assert_syntax_error "macro def foo : String; 1; end"
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2808,7 +2808,7 @@ module Crystal
           elsif @token.type == :","
             next_token_skip_space_or_newline
           else
-            skip_space
+            skip_space_or_newline
             if @token.type != :")"
               unexpected_token @token.to_s, "expected ',' or ')'"
             end


### PR DESCRIPTION
Fixes #5966