### PR TITLE
Compiler: define self variable inside types

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1039,4 +1039,24 @@ describe "Code gen: class" do
       foo.x
       ), inject_primitives: false).to_i.should eq(1)
   end
+
+  it "can use self.is_a? inside type (#5911)" do
+    run(%(
+      class Foo
+        @x = 0
+        def x; @x; end
+        def x=(@x); end
+      end
+
+      FOO = Foo.new
+
+      module Moo
+        if self.is_a?(Moo.class)
+          FOO.x = 3
+        end
+      end
+
+      FOO.x
+    )).to_i.should eq(3)
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -367,7 +367,21 @@ module Crystal
         if current_type.is_a?(Program)
           node.raise "there's no self in this scope"
         else
-          node.type = current_type.metaclass
+          self_type = current_type.metaclass
+
+          # Define the "self" var as it might be used later,
+          # for example if someone filters it with an is_a?
+          var = MetaVar.new(node.name)
+          var.type = self_type
+          var.bind_to(var)
+          @vars[node.name] = var
+
+          meta_var = new_meta_var(node.name)
+          meta_var.type = self_type
+          meta_var.bind_to(meta_var)
+          @meta_vars[node.name] = meta_var
+
+          node.type = self_type
         end
       elsif node.special_var?
         special_var = define_special_var(node.name, program.nil_var)


### PR DESCRIPTION
Fixes #5911

When `self` was used inside a type, there wasn't really a variable representing it, we just assigned the type of that `self` node to what it needed to be. But that `self` var could later be needed to restrict its type in an `is_a?` or other constructs, so we now declare it.