### PR TITLE
Raise syntax error when using out as an arg

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -172,13 +172,13 @@ describe "Parser" do
   assert_syntax_error "def foo!=; end", "unexpected token: !="
   assert_syntax_error "def foo?=(x); end", "unexpected token: ?"
 
-  # #5895
+  # #5895 & #6042
   %w(
     begin nil true false yield with abstract
     def macro require case select if unless include
     extend class struct module enum while until return
     next break lib fun alias pointerof sizeof
-    instance_sizeof typeof private protected asm
+    instance_sizeof typeof private protected asm out
     end
   ).each do |kw|
     assert_syntax_error "def foo(#{kw}); end", "cannot use '#{kw}' as an argument name", 1, 9

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3672,7 +3672,7 @@ module Crystal
            :def, :macro, :require, :case, :select, :if, :unless, :include,
            :extend, :class, :struct, :module, :enum, :while, :until, :return,
            :next, :break, :lib, :fun, :alias, :pointerof, :sizeof,
-           :instance_sizeof, :typeof, :private, :protected, :asm,
+           :instance_sizeof, :typeof, :private, :protected, :asm, :out,
       # `end` is also invalid because it maybe terminate `def` block.
            :end
         true


### PR DESCRIPTION
That commit fixes issue #6042.