### PR TITLE
Add bindings for LibC::Statfs

### DIFF
--- a/src/lib_c/aarch64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/stat.cr
@@ -45,6 +45,21 @@ lib LibC
     __glibc_reserved : StaticArray(Int, 2)
   end
 
+  struct Statfs
+    type : Int64
+    bsize : Int64
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int64
+    frsize : Int64
+    flags : Int64
+    spare : StaticArray(Long, 4)
+  end
+
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
@@ -52,5 +67,6 @@ lib LibC
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
   fun stat(file : Char*, buf : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/aarch64-linux-gnu/c/sys/types.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/aarch64-linux-musl/c/sys/stat.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/stat.cr
@@ -45,6 +45,21 @@ lib LibC
     __unused : StaticArray(UInt, 2)
   end
 
+  struct Statfs
+    type : Int64
+    bsize : Int64
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int64
+    frsize : Int64
+    flags : Int64
+    spare : StaticArray(Long, 4)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -52,5 +67,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/aarch64-linux-musl/c/sys/types.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
@@ -63,10 +63,10 @@ lib LibC
     f_namemax : UInt32
     f_owner : UInt32
     f_ctime : UInt64
-    f_fstypename : StaticArray(ShortShort, 16)
-    f_mntonname : StaticArray(ShortShort, 90)
-    f_mntfromname : StaticArray(ShortShort, 90)
-    f_mntfromspec : StaticArray(ShortShort, 90)
+    f_fstypename : StaticArray(Int16, 16)
+    f_mntonname : StaticArray(Int16, 90)
+    f_mntfromname : StaticArray(Int16, 90)
+    f_mntfromspec : StaticArray(Int16, 90)
   end
 
   fun chmod(x0 : Char*, x1 : ModeT) : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
@@ -59,7 +59,7 @@ lib LibC
     f_syncreads : UInt64
     f_asyncwrites : UInt64
     f_asyncreads : UInt64
-    f_fsid : Fsid
+    f_fsid : FsidT
     f_namemax : UInt32
     f_owner : UInt32
     f_ctime : UInt64

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/stat.cr
@@ -45,6 +45,30 @@ lib LibC
     __st_birthtim : Timespec
   end
 
+  struct Statfs
+    f_flags : UInt32
+    f_bsize : UInt32
+    f_iosize : UInt32
+    f_blocks : UInt64
+    f_bfree : UInt64
+    f_bavail : Int64
+    f_files : UInt64
+    f_ffree : UInt64
+    f_favail : Int64
+    f_syncwrites : UInt64
+    f_syncreads : UInt64
+    f_asyncwrites : UInt64
+    f_asyncreads : UInt64
+    f_fsid : Fsid
+    f_namemax : UInt32
+    f_owner : UInt32
+    f_ctime : UInt64
+    f_fstypename : StaticArray(ShortShort, 16)
+    f_mntonname : StaticArray(ShortShort, 90)
+    f_mntfromname : StaticArray(ShortShort, 90)
+    f_mntfromspec : StaticArray(ShortShort, 90)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -52,5 +76,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/types.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = LongLong
   alias ClockidT = Int
   alias DevT = Int
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULongLong

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/stat.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/stat.cr
@@ -46,6 +46,21 @@ lib LibC
     __glibc_reserved5 : ULong
   end
 
+  struct Statfs
+    type : Int
+    bsize : Int
+    blocks : UInt64
+    bfree : UInt64
+    bavail : ULong
+    files : ULong
+    ffree : ULong
+    fsid : FsidT
+    namelen : Int
+    frsize : Int
+    flags : Int
+    spare : StaticArray(Int, 4)
+  end
+
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
@@ -53,5 +68,6 @@ lib LibC
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
   fun stat(file : Char*, buf : Stat*) : Int
+  fun statfs(file : Char*, buf : Stat*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/types.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULongLong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/i686-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/i686-linux-gnu/c/sys/stat.cr
@@ -46,6 +46,21 @@ lib LibC
     __unused5 : ULong
   end
 
+  struct Statfs
+    type : Int32
+    bsize : Int32
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int32
+    frsize : Int32
+    flags : Int32
+    spare : StaticArray(Short, 4)
+  end
+
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
@@ -53,5 +68,6 @@ lib LibC
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
   fun stat(file : Char*, buf : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/i686-linux-gnu/c/sys/types.cr
+++ b/src/lib_c/i686-linux-gnu/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULongLong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/i686-linux-musl/c/sys/stat.cr
+++ b/src/lib_c/i686-linux-musl/c/sys/stat.cr
@@ -45,6 +45,21 @@ lib LibC
     st_ino : InoT
   end
 
+  struct Statfs
+    type : Int32
+    bsize : Int32
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int32
+    frsize : Int32
+    flags : Int32
+    spare : StaticArray(Short, 4)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -52,5 +67,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/i686-linux-musl/c/sys/types.cr
+++ b/src/lib_c/i686-linux-musl/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULongLong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULongLong

--- a/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
@@ -44,6 +44,21 @@ lib LibC
     __glibc_reserved : StaticArray(Long, 3)
   end
 
+  struct Statfs
+    type : Int64
+    bsize : Int64
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int64
+    frsize : Int64
+    flags : Int64
+    spare : StaticArray(Long, 4)
+  end
+
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
@@ -51,5 +66,6 @@ lib LibC
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
   fun stat(file : Char*, buf : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/types.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/x86_64-linux-musl/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/stat.cr
@@ -44,6 +44,21 @@ lib LibC
     __unused : StaticArray(Long, 3)
   end
 
+  struct Statfs
+    type : Int64
+    bsize : Int64
+    blocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : FsidT
+    namelen : Int64
+    frsize : Int64
+    flags : Int64
+    spare : StaticArray(Long, 4)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -51,5 +66,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Statfs*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/x86_64-linux-musl/c/sys/types.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULong
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = ULong

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
@@ -54,7 +54,7 @@ lib LibC
     bavail : UInt64
     files : UInt64
     ffree : UInt64
-    fsid : Fsid
+    fsid : FsidT
     owner : UInt32
     type : UInt32
     flags : UInt32

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
@@ -59,9 +59,9 @@ lib LibC
     type : UInt32
     flags : UInt32
     fssubtype : UInt32
-    fstypename : StaticArray(ShortShort, 16)
-    mntonname : StaticArray(ShortShort, 1024)
-    mntfromname : StaticArray(ShortShort, 1024)
+    fstypename : StaticArray(Int16, 16)
+    mntonname : StaticArray(Int16, 1024)
+    mntfromname : StaticArray(Int16, 1024)
     reserved : StaticArray(Long, 8)
   end
 

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/stat.cr
@@ -46,6 +46,25 @@ lib LibC
     st_qspare : StaticArray(LongLong, 2)
   end
 
+  struct Statfs
+    bsize : UInt32
+    iosize : Int32
+    nlocks : UInt64
+    bfree : UInt64
+    bavail : UInt64
+    files : UInt64
+    ffree : UInt64
+    fsid : Fsid
+    owner : UInt32
+    type : UInt32
+    flags : UInt32
+    fssubtype : UInt32
+    fstypename : StaticArray(ShortShort, 16)
+    mntonname : StaticArray(ShortShort, 1024)
+    mntfromname : StaticArray(ShortShort, 1024)
+    reserved : StaticArray(Long, 8)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -53,5 +72,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Stat*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/x86_64-macosx-darwin/c/sys/types.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sys/types.cr
@@ -6,6 +6,7 @@ lib LibC
   alias BlksizeT = Int
   alias ClockT = ULong
   alias DevT = Int
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = UInt
   alias InoT = UInt

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
@@ -55,7 +55,7 @@ lib LibC
     st_blocks : BlkcntT
     st_blksize : BlksizeT
     st_flags : FflagsT
-    {% if flag?("freebsd12.0") %}
+    {% if flag?(:"freebsd12.0") %}
       st_gen : ULong
       st_spare : StaticArray(ULong, 10)
     {% else %}
@@ -67,6 +67,31 @@ lib LibC
     {% end %}
   end
 
+  struct Statfs
+    version : UInt32
+    type : UInt32
+    flags : UInt64
+    bsize : UInt64
+    iosize : UInt64
+    blocks : UInt64
+    bfree : UInt64
+    bavail : Int64
+    files : UInt64
+    ffree : Int64
+    syncwrites : UInt64
+    asyncwrites : UInt64
+    syncreads : UInt64
+    asyncreads : UInt64
+    spare : StaticArray(LongLong, 10)
+    namemax : UInt32
+    owner : UInt32
+    fsid : Fsid
+    charspare : StaticArray(ShortShort, 80)
+    fstypename : StaticArray(ShortShort, 16)
+    mntfromname : StaticArray(ShortShort, 88)
+    mntonname : StaticArray(ShortShort, 88)
+  end
+
   fun chmod(x0 : Char*, x1 : ModeT) : Int
   fun fstat(x0 : Int, x1 : Stat*) : Int
   fun lstat(x0 : Char*, x1 : Stat*) : Int
@@ -74,5 +99,6 @@ lib LibC
   fun mkfifo(x0 : Char*, x1 : ModeT) : Int
   fun mknod(x0 : Char*, x1 : ModeT, x2 : DevT) : Int
   fun stat(x0 : Char*, x1 : Stat*) : Int
+  fun statfs(file : Char*, buf : Stat*) : Int
   fun umask(x0 : ModeT) : ModeT
 end

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
@@ -86,10 +86,10 @@ lib LibC
     namemax : UInt32
     owner : UInt32
     fsid : FsidT
-    charspare : StaticArray(ShortShort, 80)
-    fstypename : StaticArray(ShortShort, 16)
-    mntfromname : StaticArray(ShortShort, 88)
-    mntonname : StaticArray(ShortShort, 88)
+    charspare : StaticArray(Int16, 80)
+    fstypename : StaticArray(Int16, 16)
+    mntfromname : StaticArray(Int16, 88)
+    mntonname : StaticArray(Int16, 88)
   end
 
   fun chmod(x0 : Char*, x1 : ModeT) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/stat.cr
@@ -85,7 +85,7 @@ lib LibC
     spare : StaticArray(LongLong, 10)
     namemax : UInt32
     owner : UInt32
-    fsid : Fsid
+    fsid : FsidT
     charspare : StaticArray(ShortShort, 80)
     fstypename : StaticArray(ShortShort, 16)
     mntfromname : StaticArray(ShortShort, 88)

--- a/src/lib_c/x86_64-portbld-freebsd/c/sys/types.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sys/types.cr
@@ -7,6 +7,7 @@ lib LibC
   alias ClockT = Int
   alias ClockidT = Int
   alias DevT = UInt
+  alias FsidT = StaticArray(Int32, 2)
   alias GidT = UInt
   alias IdT = Long
   {% if flag?(:"freebsd12.0") %}


### PR DESCRIPTION
This work is based on `ztypes` of https://golang.org/src/syscall.
This is the first time I do this, not sure what do choose between `Long`, `Int` and `Int32`.
I haven't indeed tested on all platforms, but works at least on `x86_64-linux-musl`.
Fix #6053 