### PR TITLE
replace / to . on fun_literal_name

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2069,7 +2069,15 @@ module Crystal
         end
       end
     else
-      name
+      String.build do |str|
+        name.each_char do |char|
+          if char == '/'
+            str << '.'
+          else
+            str << char
+          end
+        end
+      end
     end
   end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2069,15 +2069,7 @@ module Crystal
         end
       end
     else
-      String.build do |str|
-        name.each_char do |char|
-          if char == '/'
-            str << '.'
-          else
-            str << char
-          end
-        end
-      end
+      name.gsub('/', '.')
     end
   end
 


### PR DESCRIPTION
LLVM's opt tool generate .dot files on each function like following

opt hello.ll -dot-cfg > /dev/null

```
Writing 'cfg.~procProc(Nil)@src/dpdk/patches.cr:99.dot'...  error opening file for writing!
Writing 'cfg.~proc2Proc(Nil)@src/dpdk/patches.cr:99.dot'...  error opening file for writing!
```

but on linux you will get an error with slash in filename.

This PR should fixes that to following

```
Writing 'cfg.~procProc(Nil)@src.dpdk.patches.cr:99.dot'...
Writing 'cfg.~proc2Proc(Nil)@src.dpdk.patches.cr:99.dot'...
```

