### PR TITLE
Fix: always close signal handler pipe in fork/exec

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -433,6 +433,13 @@ class Process
       ->Random::DEFAULT.new_seed,
     ] of -> Nil
   end
+
+  # Hooks that must always run between fork/exec.
+  def self.after_fork_before_exec_callbacks
+    @@after_fork_before_exec_callbacks ||= [
+      ->Crystal::Signal.after_fork_before_exec,
+    ] of -> Nil
+  end
 end
 
 {% unless flag?(:win32) %}

--- a/src/process.cr
+++ b/src/process.cr
@@ -121,7 +121,11 @@ class Process
     case pid
     when 0
       pid = nil
-      Process.after_fork_child_callbacks.each(&.call) if run_hooks
+      if run_hooks
+        Process.after_fork_child_callbacks.each(&.call)
+      else
+        Process.after_fork_before_exec_callbacks.each(&.call)
+      end
     when -1
       raise Errno.new("fork")
     end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -191,6 +191,10 @@ module Crystal::Signal
     @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
   end
 
+  def self.after_fork_before_exec
+    @@pipe.each(&.close)
+  end
+
   private def self.reader
     @@pipe[0]
   end


### PR DESCRIPTION
We must always close the signal handler pipe between a fork/exec combination, otherwise a simple `system("")` call prevents further signals from being handled.

fixes #5830