### PR TITLE
Fix libressl/openssl version detection - again

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -3,9 +3,9 @@
     # An extra zero is appended to the output of LIBRESSL_VERSION to make it 0 when LibreSSL does not exist on the system.
     # Any comparisons to it should be affixed with an extra zero as well e.g. `(LIBRESSL_VERSION_NUMBER >= 0x2050500F0)`.
     LIBRESSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER\" | " +
-                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>&1 > /dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
+                                 (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>/dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
     OPENSSL_VERSION = {{ system("echo \"#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER\" | " +
-                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>&1 > /dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
+                                (env("CC") || "cc") + " " + `pkg-config --cflags --silence-errors libssl || true`.chomp.stringify + " -E - 2>/dev/null || echo ''").chomp.split('\n').last.split('L').first.id + "0" }}
   end
 {% end %}
 


### PR DESCRIPTION
If this code gets another bug we'll just rip it out and only support libressl via `-Dlibressl` or similar.

Or maybe it'll give me a reason to finally rip out `OpenSSL`, refactor to generic SSL, and provide `libssl` and `libtls` backends - which would support both libressl and openssl.