### PR TITLE
Explosive birth of automatic casts!

### DIFF
--- a/spec/compiler/codegen/automatic_cast.cr
+++ b/spec/compiler/codegen/automatic_cast.cr
@@ -1,0 +1,218 @@
+require "../../spec_helper"
+
+describe "Code gen: automatic cast" do
+  it "casts literal integer (Int32 -> Int64)" do
+    run(%(
+      def foo(x : Int64)
+        x
+      end
+
+      foo(12345)
+      )).to_i.should eq(12345)
+  end
+
+  it "casts literal integer (Int64 -> Int32, ok)" do
+    run(%(
+      def foo(x : Int32)
+        x
+      end
+
+      foo(2147483647_i64)
+      )).to_i.should eq(2147483647)
+  end
+
+  it "casts literal integer (Int32 -> Float32)" do
+    run(%(
+      def foo(x : Float32)
+        x
+      end
+
+      foo(12345).to_i
+      )).to_i.should eq(12345)
+  end
+
+  it "casts literal integer (Int32 -> Float64)" do
+    run(%(
+      def foo(x : Float64)
+        x
+      end
+
+      foo(12345).to_i
+      )).to_i.should eq(12345)
+  end
+
+  it "casts literal float (Float32 -> Float64)" do
+    run(%(
+      def foo(x : Float64)
+        x
+      end
+
+      foo(12345.0_f32).to_i
+      )).to_i.should eq(12345)
+  end
+
+  it "casts literal float (Float64 -> Float32)" do
+    run(%(
+      def foo(x : Float32)
+        x
+      end
+
+      foo(12345.0).to_i
+      )).to_i.should eq(12345)
+  end
+
+  it "casts symbol literal to enum" do
+    run(%(
+      :four
+
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo)
+        x
+      end
+
+      foo(:three)
+      )).to_i.should eq(2)
+  end
+
+  it "casts Int32 to Int64 in ivar assignment" do
+    run(%(
+      class Foo
+        @x : Int64
+
+        def initialize
+          @x = 10
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(10)
+  end
+
+  it "casts Symbol to Enum in ivar assignment" do
+    run(%(
+      enum E
+        One
+        Two
+        Three
+      end
+
+      class Foo
+        @x : E
+
+        def initialize
+          @x = :three
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(2)
+  end
+
+  it "casts Int32 to Int64 in cvar assignment" do
+    run(%(
+      class Foo
+        @@x : Int64 = 0_i64
+
+        def self.x
+          @@x = 10
+          @@x
+        end
+      end
+
+      Foo.x
+      )).to_i.should eq(10)
+  end
+
+  it "casts Int32 to Int64 in lvar assignment" do
+    run(%(
+      x : Int64
+      x = 123
+      x
+      )).to_i.should eq(123)
+  end
+
+  it "casts Int32 to Int64 in ivar type declaration" do
+    run(%(
+      class Foo
+        @x : Int64 = 10
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(10)
+  end
+
+  it "casts Symbol to Enum in ivar type declaration" do
+    run(%(
+      enum Color
+        Red
+        Green
+        Blue
+      end
+
+      class Foo
+        @x : Color = :blue
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(2)
+  end
+
+  it "casts Int32 to Int64 in cvar type declaration" do
+    run(%(
+      class Foo
+        @@x : Int64 = 10
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x
+      )).to_i.should eq(10)
+  end
+
+  it "casts Int32 -> Int64 in arg restriction" do
+    run(%(
+      def foo(x : Int64 = 123)
+        x
+      end
+
+      foo
+      )).to_i.should eq(123)
+  end
+
+  it "casts Int32 to Int64 in ivar type declaration in generic" do
+    run(%(
+      class Foo(T)
+        @x : T = 10
+
+        def x
+          @x
+        end
+      end
+
+      Foo(Int64).new.x
+      )).to_i.should eq(10)
+  end
+end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -33,8 +33,11 @@ describe "Normalize: def" do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 1)
     expected = parse("def foo(x); y = 1; z = 2i64; x + y + z; end").as(Def)
-    expected.body.as(Expressions).expressions.insert 1, TypeRestriction.new Var.new("y"), Path.new(["Int32"])
-    expected.body.as(Expressions).expressions.insert 3, TypeRestriction.new Var.new("z"), Path.new(["Int64"])
+
+    exps = expected.body.as(Expressions).expressions
+    exps[0] = AssignWithRestriction.new(exps[0].as(Assign), Path.new("Int32"))
+    exps[1] = AssignWithRestriction.new(exps[1].as(Assign), Path.new("Int64"))
+
     actual.should eq(expected)
   end
 
@@ -42,7 +45,10 @@ describe "Normalize: def" do
     a_def = parse("def foo(x, y : Int32 = 1, z : Int64 = 2i64); x + y + z; end").as(Def)
     actual = a_def.expand_default_arguments(Program.new, 2)
     expected = parse("def foo(x, y : Int32); z = 2i64; x + y + z; end").as(Def)
-    expected.body.as(Expressions).expressions.insert 1, TypeRestriction.new Var.new("z"), Path.new(["Int64"])
+
+    exps = expected.body.as(Expressions).expressions
+    exps[0] = AssignWithRestriction.new(exps[0].as(Assign), Path.new("Int64"))
+
     actual.should eq(expected)
   end
 

--- a/spec/compiler/semantic/automatic_cast.cr
+++ b/spec/compiler/semantic/automatic_cast.cr
@@ -1,0 +1,370 @@
+require "../../spec_helper"
+
+describe "Semantic: automatic cast" do
+  it "casts literal integer (Int32 -> no restriction)" do
+    assert_type(%(
+      def foo(x)
+        x + 1
+      end
+
+      foo(12345)
+      ), inject_primitives: true) { int32 }
+  end
+
+  it "casts literal integer (Int32 -> Int64)" do
+    assert_type(%(
+      def foo(x : Int64)
+        x
+      end
+
+      foo(12345)
+      )) { int64 }
+  end
+
+  it "casts literal integer (Int64 -> Int32, ok)" do
+    assert_type(%(
+      def foo(x : Int32)
+        x
+      end
+
+      foo(2147483647_i64)
+      )) { int32 }
+  end
+
+  it "casts literal integer (Int64 -> Int32, too big)" do
+    assert_error %(
+      def foo(x : Int32)
+        x
+      end
+
+      foo(2147483648_i64)
+      ),
+      "no overload matches"
+  end
+
+  it "casts literal integer (Int32 -> Float32)" do
+    assert_type(%(
+      def foo(x : Float32)
+        x
+      end
+
+      foo(12345)
+      )) { float32 }
+  end
+
+  it "casts literal integer (Int32 -> Float64)" do
+    assert_type(%(
+      def foo(x : Float64)
+        x
+      end
+
+      foo(12345)
+      )) { float64 }
+  end
+
+  it "casts literal float (Float32 -> Float64)" do
+    assert_type(%(
+      def foo(x : Float64)
+        x
+      end
+
+      foo(1.23_f32)
+      )) { float64 }
+  end
+
+  it "casts literal float (Float64 -> Float32)" do
+    assert_type(%(
+      def foo(x : Float32)
+        x
+      end
+
+      foo(1.23)
+      )) { float32 }
+  end
+
+  it "matches correct overload" do
+    assert_type(%(
+      def foo(x : Int32)
+        x
+      end
+
+      def foo(x : Int64)
+        x
+      end
+
+      foo(1_i64)
+      )) { int64 }
+  end
+
+  it "casts literal integer through alias with union" do
+    assert_type(%(
+      alias A = Int64 | String
+
+      def foo(x : A)
+        x
+      end
+
+      foo(12345)
+      )) { int64 }
+  end
+
+  it "says ambiguous call for integer" do
+    assert_error %(
+      def foo(x : Int8)
+        x
+      end
+
+      def foo(x : UInt8)
+        x
+      end
+
+      foo(1)
+      ),
+      "ambiguous"
+  end
+
+  it "says ambiguous call for integer (2)" do
+    assert_error %(
+      def foo(x : Int8 | UInt8)
+        x
+      end
+
+      foo(1)
+      ),
+      "ambiguous"
+  end
+
+  it "casts symbol literal to enum" do
+    assert_type(%(
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo)
+        x
+      end
+
+      foo(:one)
+      )) { types["Foo"] }
+  end
+
+  it "casts literal integer through alias with union" do
+    assert_type(%(
+      enum Foo
+        One
+        Two
+      end
+
+      alias A = Foo | String
+
+      def foo(x : A)
+        x
+      end
+
+      foo(:two)
+      )) { types["Foo"] }
+  end
+
+  it "errors if symbol name doesn't match enum member" do
+    assert_error %(
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo)
+        x
+      end
+
+      foo(:four)
+      ),
+      "no overload matches"
+  end
+
+  it "says ambiguous call for symbol" do
+    assert_error %(
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      enum Foo2
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo)
+        x
+      end
+
+      def foo(x : Foo2)
+        x
+      end
+
+      foo(:one)
+      ),
+      "ambiguous"
+  end
+
+  it "casts Int32 to Int64 in ivar assignment" do
+    assert_type(%(
+      class Foo
+        @x : Int64
+
+        def initialize
+          @x = 10
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { int64 }
+  end
+
+  it "casts Symbol to Enum in ivar assignment" do
+    assert_type(%(
+      enum E
+        One
+        Two
+        Three
+      end
+
+      class Foo
+        @x : E
+
+        def initialize
+          @x = :two
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { types["E"] }
+  end
+
+  it "casts Int32 to Int64 in cvar assignment" do
+    assert_type(%(
+      class Foo
+        @@x : Int64 = 0_i64
+
+        def self.x
+          @@x = 10
+          @@x
+        end
+      end
+
+      Foo.x
+      )) { int64 }
+  end
+
+  it "casts Int32 to Int64 in lvar assignment" do
+    assert_type(%(
+      x : Int64
+      x = 123
+      x
+      )) { int64 }
+  end
+
+  it "casts Int32 to Int64 in ivar type declaration" do
+    assert_type(%(
+      class Foo
+        @x : Int64 = 10
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { int64 }
+  end
+
+  it "casts Symbol to Enum in ivar type declaration" do
+    assert_type(%(
+      enum Color
+        Red
+        Green
+        Blue
+      end
+
+      class Foo
+        @x : Color = :red
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { types["Color"] }
+  end
+
+  it "casts Int32 to Int64 in cvar type declaration" do
+    assert_type(%(
+      class Foo
+        @@x : Int64 = 10
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x
+      )) { int64 }
+  end
+
+  it "casts Symbol to Enum in cvar type declaration" do
+    assert_type(%(
+      enum Color
+        Red
+        Green
+        Blue
+      end
+
+      class Foo
+        @@x : Color = :red
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x
+      )) { types["Color"] }
+  end
+
+  it "casts Int32 -> Int64 in arg restriction" do
+    assert_type(%(
+      def foo(x : Int64 = 0)
+        x
+      end
+
+      foo
+      )) { int64 }
+  end
+
+  it "casts Int32 to Int64 in ivar type declaration in generic" do
+    assert_type(%(
+      class Foo(T)
+        @x : T = 10
+
+        def x
+          @x
+        end
+      end
+
+      Foo(Int64).new.x
+      )) { int64 }
+  end
+end

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -173,12 +173,12 @@ describe "Semantic: def" do
 
   it "errors when default value is incompatible with type restriction" do
     assert_error "
-      def foo(x : Int64 = 1)
+      def foo(x : Int64 = 'a')
       end
 
       foo
       ",
-      "can't restrict Int32 to Int64"
+      "can't restrict Char to Int64"
   end
 
   it "types call with global scope" do

--- a/spec/compiler/semantic/uninitialized_spec.cr
+++ b/spec/compiler/semantic/uninitialized_spec.cr
@@ -58,9 +58,9 @@ describe "Semantic: uninitialized" do
   it "errors if declares var and then assigns other type" do
     assert_error %(
       x = uninitialized Int32
-      x = 1_i64
+      x = 'a'
       ),
-      "type must be Int32, not (Int32 | Int64)"
+      "type must be Int32, not (Char | Int32)"
   end
 
   it "errors if declaring variable multiple times with different types (#917)" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -488,6 +488,39 @@ class Crystal::CodeGenVisitor
     target_pointer
   end
 
+  # This is the case of the automatic cast between integer types
+  def downcast_distinct(value, to_type : IntegerType, from_type : IntegerType)
+    codegen_cast(from_type, to_type, value)
+  end
+
+  # This is the case of the automatic cast between integer type and float type
+  def downcast_distinct(value, to_type : FloatType, from_type : IntegerType)
+    codegen_cast(from_type, to_type, value)
+  end
+
+  # This is the case of the automatic cast between float types
+  def downcast_distinct(value, to_type : FloatType, from_type : FloatType)
+    codegen_cast(from_type, to_type, value)
+  end
+
+  # This is the case of the automatic cast between symbol and enum
+  def downcast_distinct(value, to_type : EnumType, from_type : SymbolType)
+    # value has the value of the symbol inside the symbol table,
+    # so we first get which symbol name that is, and then match
+    # it to one of the enum members
+    index = value.const_int_get_sext_value
+    symbol = @symbols_by_index[index].underscore
+
+    to_type.types.each do |name, value|
+      if name.underscore == symbol
+        accept(value.as(Const).value)
+        return @last
+      end
+    end
+
+    raise "Bug: expected to find enum member of #{to_type} matching symbol #{symbol}"
+  end
+
   def downcast_distinct(value, to_type : Type, from_type : Type)
     raise "BUG: trying to downcast #{to_type} <- #{from_type}"
   end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -179,9 +179,11 @@ module Crystal
       @in_lib = false
       @strings = {} of StringKey => LLVM::Value
       @symbols = {} of String => Int32
+      @symbols_by_index = [] of String
       @symbol_table_values = [] of LLVM::Value
       program.symbols.each_with_index do |sym, index|
         @symbols[sym] = index
+        @symbols_by_index << sym
         @symbol_table_values << build_string_constant(sym, sym)
       end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -77,21 +77,20 @@ module Crystal
     def_equals_and_hash type
   end
 
-  # Fictitious node to represent a type restriction
-  #
-  # It is used for type restrection of method arguments.
-  class TypeRestriction < ASTNode
-    getter obj
-    getter to
+  # Fictitious node to represent an assignment with a type restriction,
+  # created to match the assignment of a method argument's default value.
+  class AssignWithRestriction < ASTNode
+    property assign
+    property restriction
 
-    def initialize(@obj : ASTNode, @to : ASTNode)
+    def initialize(@assign : Assign, @restriction : ASTNode)
     end
 
     def clone_without_location
-      TypeRestriction.new @obj.clone, @to.clone
+      AssignWithRestriction.new @assign.clone, @restriction.clone
     end
 
-    def_equals_and_hash obj, to
+    def_equals_and_hash assign, restriction
   end
 
   class Arg
@@ -732,6 +731,22 @@ module Crystal
 
     def clone_without_location
       self
+    end
+  end
+
+  class NumberLiteral
+    def can_be_autocast_to?(other_type)
+      case {self.type, other_type}
+      when {IntegerType, IntegerType}
+        min, max = other_type.range
+        min <= integer_value <= max
+      when {IntegerType, FloatType}
+        true
+      when {FloatType, FloatType}
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -17,6 +17,21 @@ module Crystal
       @type
     end
 
+    def type(*, with_literals = false)
+      type = self.type
+
+      if with_literals
+        case self
+        when NumberLiteral
+          return NumberLiteralType.new(type.program, self)
+        when SymbolLiteral
+          return SymbolLiteralType.new(type.program, self)
+        end
+      end
+
+      type
+    end
+
     def set_type(type : Type)
       type = type.remove_alias_if_simple
       if !type.no_return? && (freeze_type = @freeze_type) && !type.implements?(freeze_type)

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -68,7 +68,17 @@ module Crystal
         end
 
         main_visitor.pushing_type(owner.as(ModuleType)) do
-          node.accept main_visitor
+          # Check if we can autocast
+          if (node.is_a?(NumberLiteral) || node.is_a?(SymbolLiteral)) &&
+             (class_var_type = class_var.type?)
+            cloned_node = node.clone
+            cloned_node.accept MainVisitor.new(self)
+            if casted_value = MainVisitor.check_automatic_cast(cloned_node, class_var_type)
+              node = initializer.node = casted_value
+            end
+          end
+
+          node.accept main_visitor unless node.type?
         end
 
         unless had_class_var

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -753,6 +753,10 @@ module Crystal
       node
     end
 
+    def transform(node : AssignWithRestriction)
+      transform(node.assign)
+    end
+
     @false_literal : BoolLiteral?
 
     def false_literal

--- a/src/compiler/crystal/semantic/cover.cr
+++ b/src/compiler/crystal/semantic/cover.cr
@@ -276,4 +276,12 @@ module Crystal
   class AliasType
     delegate cover, cover_size, to: aliased_type
   end
+
+  class NumberLiteralType
+    delegate cover, cover_size, to: (@matched_type || literal.type)
+  end
+
+  class SymbolLiteralType
+    delegate cover, cover_size, to: (@matched_type || literal.type)
+  end
 end

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -121,11 +121,13 @@ class Crystal::Def
           if default_value.is_a?(MagicConstant)
             expansion.args.push arg.clone
           else
-            new_body << Assign.new(Var.new(arg.name).at(arg), default_value).at(arg)
+            assign = Assign.new(Var.new(arg.name).at(arg), default_value).at(arg)
 
             if restriction = arg.restriction
-              new_body << TypeRestriction.new(Var.new(arg.name).at(arg), restriction).at(arg)
+              assign = AssignWithRestriction.new(assign, restriction)
             end
+
+            new_body << assign
           end
         end
       end

--- a/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
@@ -70,6 +70,8 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
   end
 
   def finish
+    scope_initializers = [] of InstanceVarInitializerContainer::InstanceVarInitializer?
+
     # First declare them, so when we type all of them we will have
     # the info of which instance vars have initializers (so they are not nil)
     initializers.each do |i|
@@ -78,18 +80,31 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
         program.undefined_instance_variable(i.target, scope, nil)
       end
 
-      scope.add_instance_var_initializer(i.target.name, i.value, scope.is_a?(GenericType) ? nil : i.meta_vars)
+      scope_initializers <<
+        scope.add_instance_var_initializer(i.target.name, i.value, scope.is_a?(GenericType) ? nil : i.meta_vars)
     end
 
     # Now type them
-    initializers.each do |i|
+    initializers.each_with_index do |i, index|
       scope = i.scope
+      value = i.value
 
-      unless scope.is_a?(GenericType)
-        ivar_visitor = MainVisitor.new(program, meta_vars: i.meta_vars)
-        ivar_visitor.scope = scope
-        i.value.accept ivar_visitor
+      next if scope.is_a?(GenericType)
+
+      # Check if we can autocast
+      if (value.is_a?(NumberLiteral) || value.is_a?(SymbolLiteral)) &&
+         (scope_initializer = scope_initializers[index])
+        cloned_value = value.clone
+        cloned_value.accept MainVisitor.new(program)
+        if casted_value = MainVisitor.check_automatic_cast(cloned_value, scope.lookup_instance_var(i.target.name).type)
+          scope_initializer.value = casted_value
+          next
+        end
       end
+
+      ivar_visitor = MainVisitor.new(program, meta_vars: i.meta_vars)
+      ivar_visitor.scope = scope
+      value.accept ivar_visitor
     end
   end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -741,18 +741,39 @@ module Crystal
       false
     end
 
-    def type_assign(target : Var, value, node)
+    def type_assign(target : Var, value, node, restriction = nil)
       value.accept self
+
+      var_name = target.name
+      meta_var = (@meta_vars[var_name] ||= new_meta_var(var_name))
+
+      if freeze_type = meta_var.freeze_type
+        if casted_value = check_automatic_cast(value, freeze_type, node)
+          value = casted_value
+        end
+      end
+
+      # If this assign comes from a AssignWithRestriction node, check the restriction
+
+      if restriction && (value_type = value.type?)
+        if value_type.restrict(restriction, match_context.not_nil!)
+          # OK
+        else
+          # Check autocast too
+          restriction_type = scope.lookup_type(restriction, free_vars: free_vars)
+          if casted_value = check_automatic_cast(value, restriction_type, node)
+            value = casted_value
+          else
+            node.raise "can't restrict #{value.type} to #{restriction}"
+          end
+        end
+      end
 
       target.bind_to value
       node.bind_to value
 
-      var_name = target.name
-
       value_type_filters = @type_filters
       @type_filters = nil
-
-      meta_var = (@meta_vars[var_name] ||= new_meta_var(var_name))
 
       # Save variable assignment location for debugging output
       meta_var.location ||= target.location
@@ -817,6 +838,9 @@ module Crystal
       value.accept self
 
       var = lookup_instance_var target
+      if casted_value = check_automatic_cast(value, var.type, node)
+        value = casted_value
+      end
 
       target.bind_to var
       node.bind_to value
@@ -911,6 +935,10 @@ module Crystal
       var = lookup_class_var(target)
       check_class_var_is_thread_local(target, var, attributes)
 
+      if casted_value = check_automatic_cast(value, var.type, node)
+        value = casted_value
+      end
+
       target.bind_to var
 
       node.bind_to value
@@ -929,6 +957,34 @@ module Crystal
 
     def type_assign(target, value, node)
       raise "BUG: unknown assign target in MainVisitor: #{target}"
+    end
+
+    # See if we can automatically cast the value if the types don't exactly match
+    def check_automatic_cast(value, var_type, assign = nil)
+      MainVisitor.check_automatic_cast(value, var_type, assign)
+    end
+
+    def self.check_automatic_cast(value, var_type, assign = nil)
+      if value.is_a?(NumberLiteral) && value.type != var_type && (var_type.is_a?(IntegerType) || var_type.is_a?(FloatType))
+        if value.can_be_autocast_to?(var_type)
+          value.type = var_type
+          value.kind = var_type.kind
+          assign.value = value if assign
+          return value
+        end
+      elsif value.is_a?(SymbolLiteral) && var_type.is_a?(EnumType)
+        member = var_type.find_member(value.value)
+        if member
+          path = Path.new(member.name)
+          path.target_const = member
+          path.type = var_type
+          value = path
+          assign.value = value if assign
+          return value
+        end
+      end
+
+      nil
     end
 
     def visit(node : Yield)
@@ -2938,22 +2994,13 @@ module Crystal
       false
     end
 
-    def visit(node : TypeRestriction)
-      obj = node.obj
-      to = node.to
-
-      obj.accept self
-
-      unless context = match_context
-        node.raise "BUG: there is no match context"
-      end
-
-      if type = obj.type.restrict(to, context)
-        node.type = type
-      else
-        node.raise "can't restrict #{obj.type} to #{to}"
-      end
-
+    def visit(node : AssignWithRestriction)
+      type_assign(
+        node.assign.target.as(Var),
+        node.assign.value,
+        node.assign,
+        restriction: node.restriction)
+      node.bind_to(node.assign)
       false
     end
 

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -60,6 +60,7 @@ module Crystal
 
     def set_free_var(name, type)
       free_vars = @free_vars ||= {} of String => TypeVar
+      type = type.remove_literal if type.is_a?(Type)
       free_vars[name] = type
     end
 

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -2,8 +2,10 @@ require "../types"
 
 module Crystal
   record NamedArgumentType, name : String, type : Type do
-    def self.from_args(named_args : Array(NamedArgument)?)
-      named_args.try &.map { |named_arg| new(named_arg.name, named_arg.value.type) }
+    def self.from_args(named_args : Array(NamedArgument)?, with_literals = false)
+      named_args.try &.map do |named_arg|
+        new(named_arg.name, named_arg.value.type(with_literals: with_literals))
+      end
     end
   end
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1117,6 +1117,54 @@ module Crystal
       true
     end
   end
+
+  class NumberLiteralType
+    def restrict(other, context)
+      if other.is_a?(IntegerType) || other.is_a?(FloatType)
+        if literal.can_be_autocast_to?(other)
+          if @matched_type && @matched_type != other
+            literal.raise "ambiguous call matches both #{@matched_type} and #{other}"
+          end
+
+          @matched_type = other
+          other
+        else
+          literal.type.restrict(other, context)
+        end
+      else
+        type = super(other, context) ||
+               literal.type.restrict(other, context)
+        if type == self
+          type = @matched_type || literal.type
+        end
+        type
+      end
+    end
+  end
+
+  class SymbolLiteralType
+    def restrict(other, context)
+      if other.is_a?(EnumType)
+        if other.find_member(literal.value)
+          if @matched_type && @matched_type != other
+            literal.raise "ambiguous call matches both #{@matched_type} and #{other}"
+          end
+
+          @matched_type = other
+          other
+        else
+          literal.type.restrict(other, context)
+        end
+      else
+        type = super(other, context) ||
+               literal.type.restrict(other, context)
+        if type == self
+          type = @matched_type || literal.type
+        end
+        type
+      end
+    end
+  end
 end
 
 private def get_generic_type(node, context)

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -48,11 +48,13 @@ module Crystal
       false
     end
 
-    def visit(node : TypeRestriction)
+    def visit(node : AssignWithRestriction)
       @str << "# type restriction: "
-      node.obj.accept self
+      node.assign.target.accept self
       @str << " : "
-      node.to.accept self
+      node.restriction.accept self
+      @str << " = "
+      node.assign.value.accept self
       false
     end
 

--- a/src/compiler/crystal/semantic/transformer.cr
+++ b/src/compiler/crystal/semantic/transformer.cr
@@ -2,7 +2,7 @@ require "../syntax/transformer"
 
 module Crystal
   class Transformer
-    def transform(node : MetaVar | MetaMacroVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | TypeRestriction | YieldBlockBinder | MacroId)
+    def transform(node : MetaVar | MetaMacroVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | AssignWithRestriction | YieldBlockBinder | MacroId)
       node
     end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -222,6 +222,21 @@ module Crystal
       @value[0] == '+' || @value[0] == '-'
     end
 
+    def integer_value
+      case kind
+      when :i8  then value.to_i8
+      when :i16 then value.to_i16
+      when :i32 then value.to_i32
+      when :i64 then value.to_i64
+      when :u8  then value.to_u8
+      when :u16 then value.to_u16
+      when :u32 then value.to_u32
+      when :u64 then value.to_u64
+      else
+        raise "Bug: called 'integer_value' for non-integer literal"
+      end
+    end
+
     def clone_without_location
       NumberLiteral.new(@value, @kind)
     end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -352,4 +352,7 @@ lib LibLLVM
   fun create_builder_in_context = LLVMCreateBuilderInContext(c : ContextRef) : BuilderRef
 
   fun get_type_context = LLVMGetTypeContext(TypeRef) : ContextRef
+
+  fun const_int_get_sext_value = LLVMConstIntGetSExtValue(ValueRef) : Int64
+  fun const_int_get_zext_value = LLVMConstIntGetZExtValue(ValueRef) : UInt64
 end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -87,6 +87,14 @@ module LLVM::ValueMethods
     LibLLVM.set_alignment(self, bytes)
   end
 
+  def const_int_get_sext_value
+    LibLLVM.const_int_get_sext_value(self)
+  end
+
+  def const_int_get_zext_value
+    LibLLVM.const_int_get_zext_value(self)
+  end
+
   def to_value
     LLVM::Value.new unwrap
   end


### PR DESCRIPTION
## What

This PR lets the compiler match number literals against type restrictions that don't exactly match the expected type, but since the literal's value fits the type, it is automatically cast.

Additionally, a similar behaviour is provided to specify enum values by using a symbol.

All of this works as long as the call doesn't become ambiguous. The implementation was a bit tricky, but finally, and amazingly, it worked.

For a quick understanding of the first part (numbers), you can read what's being requested in #2995. With this PR, **all** of those snippets now compile.

But I'll write a few snippets here.

### Method type restrictions

#### Numbers

```crystal
def foo(x : Int8)
end

foo(1)    # OK, same as passing 1_u8, because 1 fits Int8
foo(1234) # Error
```

```crystal
def foo(x : Float64)
end

foo(1) # OK, same as passing 1.0
```
#### Symbols -> Enums

```crystal
enum Color
  Red
  Green
  Blue
end

def paint(color : Color)
end

paint(:red) # OK, same as passing Color::Red
paint(:yellow) # Error
```
### Instance variables

```crystal
class Foo
  @x : Int8

  def initialize
    @x = 0 # OK, because @x's type is specified, and 0 can pass as 0_u8
  end 
end
```

### Class variables

```crystal
class Foo
  @@x : Int8 = 0 # OK
end
```

### Local variables

```crystal
x : Int8
x = 0 # OK
```

### Method default values, with restriction

```crystal
enum Color
  Red
  Green
  Blue
end

def paint(color : Color = :red) # OK
end

paint # OK
```

### Combined

```crystal
record Vector, x : Float64, y : Float64, z : Float64

# Works because record will use those restrictions in initialize
Vector.new(1, 2, 3)
```

### Some examples with the current standard library

#### File

```crystal
file = File.open(__FILE__)
file.seek(-10, :end) # Same as passing IO::Seek::End
```

#### Process

```crystal
Process.run("ls", output: :inherit) # Same as passing Process::Redirect::Inherit
```

#### String

```crystal
# Well, this one doesn't work, it's missing the type restriction in the method, but it's super easy to fix
"Súper".upcase(:ascii) # => "SúPER"
```

### What if it's ambiguous?

```crystal
def foo(x : Int8)
end

def foo(x : Int16)
end

foo(1) # Error: ambiguous call matches both Int8 and Int16
```

### When it doesn't work

```crystal
def foo(x : Int8)
end

foo(rand < 0.5 ? 1 : 2) # Error
```

All of the above works **only** when passed directly to a method, or assigned directly to an instance/class variable. When putting intermediary expressions, or intermediary assignments, it stops working. But I think that's OK. We simply must document these rules. I also believe for example in Go you can pass number literals like that, but of course it stops working when you introduce intermediate expressions too.

## Why

I can easily say this might be one of the most wanted features in Crystal. Having to type those number suffixes for no real reason, when the compiler could figure this out, or having to type long enum values, is super tedious, and kind of goes against Crystal's philosophy.

Converting symbols to enums might be controversial.

The important thing to understand here is that this is all sound and type safe. If I pass a symbol to a method expecting an enum, and the name can be matched (currently `underscore` is being invoked on both ends), then there's simply no confusion: the symbol must mean that enum member. If there's a typo in the symbol you get an error, exactly like what happens with the full enum member. The big advantage is that you get to type less, and also read less redundant information.

With the rule for numbers you can more easily write numeric and scientific code, and also code for games.

With the rule for symbols -> enum, one is actually more encouraged to use enums, because using them in APIs, when having to choose one option between many, one can still pass a symbol (but you'll have to type the full enum value if choosing the value dynamically, but that's as bad as now).

## How

Implementing this was tricky.

First I started with number literals. My first idea was to give them a different type that would be compatible with other number types if the literal's value fits. That worked, but then this happened:

```crystal
def foo(x : Int8)
end

def foo(x : Int16)
end

def foo(x : Int32)
end

foo(1) # Now matches all of them and ends up calling the first one
```

So I thought I could detect the ambiguous case, and that didn't work at all, because `foo(1)` still matches all overloads.

The solution then came: first try to match methods the old, usual way. If that matches, then all is good and should work like before. If no match is found, only then try again with this special types for literals. If just one matches (or, well, multiple overloads can match, but all of them must match against the same integer type... think about union types in other positions and how that can create a multiple dispatch), then we are good to go. If more than one matches (against different integer types), then it's an ambiguous call.

This is not the most efficient way to do it because when the rule applies, we end up doing two method lookups instead of one. But I think the number of places in a program where this will be used will be much less than the total number of calls where this rule won't be used. And, in any case, this just adds a small performance cost but compilation speed isn't important at this point.

After that, adding the symbol -> enum rule was simple.

Then I had to make sure the rule worked in all of the cases I documented above, which was a bit tedious, but it finally worked.

Fixes #2995
Fixes #6067