### PR TITLE
Allow private method invocation with self receiver

### DIFF
--- a/spec/compiler/semantic/visibility_modifiers_spec.cr
+++ b/spec/compiler/semantic/visibility_modifiers_spec.cr
@@ -74,6 +74,22 @@ describe "Visibility modifiers" do
       "private method 'bar' called for Foo"
   end
 
+  it "allows invoking private method from the same class" do
+    assert_type(%(
+      class Foo
+        private def foo
+          1
+        end
+
+        def bar
+          self.foo
+        end
+      end
+
+      Foo.new.bar
+      )) { int32 }
+  end
+
   it "allows invoking protected method from the same class" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -568,8 +568,8 @@ class Crystal::Call
     case match.def.visibility
     when .private?
       if obj = @obj
-        if obj.is_a?(Var) && obj.name == "self" && match.def.name.ends_with?('=')
-          # Special case: private setter can be called with self
+        if obj.is_a?(Var) && obj.name == "self"
+          # Special case: private method can be called with self
           return
         end
 


### PR DESCRIPTION
Closes #5995

I was surprised there is no spec for checking this. All specs are passed even if calling private method with `self` receiver is allowed.

IMHO it is not so problem to allow this. This change makes `private` visibility rule complex, but `protected` is more complex than that still. And there is no reason not to allow this in statically typed programming language like Crystal.

Additionally I don't know and can't find the case breaking compatibility for this change. Perhaps it is so little we think.

Thank you.