### PR TITLE
Bug: initialize with {% @type %}

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4429,6 +4429,21 @@ describe "Semantic: instance var" do
       ), inject_primitives: false) { types["Foo"] }
   end
 
+  it "is more permissive with macro def initialize, bug with named args" do
+    assert_error %(
+      class Foo
+        @x : Int32
+
+        def initialize(**args)
+          {% @type %}
+        end
+      end
+
+      Foo.new(x: 1)
+      ),
+      "instance variable '@x' of Foo was not initialized"
+  end
+
   it "is more permissive with macro def initialize, other initialize" do
     assert_type(%(
       class Foo

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4464,6 +4464,35 @@ describe "Semantic: instance var" do
       ), inject_primitives: false) { types["Foo"] }
   end
 
+  it "is more permissive with macro def initialize, multiple" do
+    assert_type(%(
+      class Foo
+        @x : Int32
+
+        def initialize
+          {% begin %}
+            {% @type %}
+            @x = 1
+          {% end %}
+        end
+
+        def initialize(x)
+          {% begin %}
+            {% @type %}
+            @x = x
+          {% end %}
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new
+      Foo.new(1).x
+      )) { int32 }
+  end
+
   it "errors with macro def but another def doesn't initialize all" do
     assert_error %(
       class Foo

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -116,7 +116,10 @@ module Crystal
       @while_stack = [] of While
       @needs_type_filters = 0
       @typeof_nest = 0
-      @is_initialize = !!(typed_def && typed_def.name == "initialize")
+      @is_initialize = !!(typed_def && (
+        typed_def.name == "initialize" ||
+        typed_def.name.starts_with?("initialize:") # Because of expanded methods from named args
+      ))
       @found_self_in_initialize_call = nil
       @used_ivars_in_calls_in_initialize = nil
       @in_is_a = false

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -108,7 +108,7 @@ struct Crystal::TypeDeclarationProcessor
     # removed if an explicit type is found (in remove_error).
     @errors = {} of Type => Hash(String, Error)
 
-    # Types that have a single macro def initialize
+    # Types whose initialize methods are all macro defs
     @has_macro_def = Set(Type).new
 
     @type_decl_visitor = TypeDeclarationVisitor.new(@program, @explicit_instance_vars)
@@ -417,7 +417,7 @@ struct Crystal::TypeDeclarationProcessor
       infos = find_initialize_infos(owner)
 
       if infos
-        @has_macro_def << owner if infos.size == 1 && infos.first.def.macro_def?
+        @has_macro_def << owner if infos.all?(&.def.macro_def?)
         non_nilable = compute_non_nilable_instance_vars_multi(owner, infos)
       end
 


### PR DESCRIPTION
Fixes a bug found in https://github.com/crystal-lang/crystal/pull/6063#issuecomment-386824508

The compiler has a secret rule that's not documented (but probably should): if an `initialize` uses `@type` in macros, then checking what instance variables are initialized is delayed until the semantic phase, only for those methods. This allows the definition of `initialize` methods that are based on a type's instance vars, for example.

But there were a few bugs with that. This PR fixes those.