### PR TITLE
Optimize Tuple#to_a by preallocate Array

### DIFF
--- a/src/deque.cr
+++ b/src/deque.cr
@@ -483,15 +483,6 @@ class Deque(T)
     self
   end
 
-  # Returns an `Array` (shallow copy) that contains all the items of this deque.
-  def to_a
-    arr = Array(T).new(@size)
-    each do |x|
-      arr << x
-    end
-    arr
-  end
-
   def to_s(io : IO)
     inspect(io)
   end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -281,6 +281,17 @@ module Indexable(T)
     self
   end
 
+  # Returns an `Array` with all the elements in the collection.
+  #
+  # ```
+  # {1, 2, 3}.to_a # => [1, 2, 3]
+  # ```
+  def to_a
+    ary = Array(T).new(size)
+    each { |e| ary << e }
+    ary
+  end
+
   # Returns `true` if `self` is empty, `false` otherwise.
   #
   # ```


### PR DESCRIPTION
Benchmark: 
```
require "benchmark"

struct Tuple
  def to_aa
    Array(Union(*T)).new(size) do |i|
      self[i]
    end
  end
end

t = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 }
Benchmark.ips do |x|
  x.report("original") { t.to_a }
  x.report("optimized") { t.to_aa }
end
```

Output:
```
original    2.86M (349.71ns) (± 2.36%)  1.72× slower
optimized   4.93M (202.81ns) (± 3.79%)       fastest
```