### PR TITLE
Formatter: correctly handle annotation path

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -499,6 +499,8 @@ describe Crystal::Formatter do
   assert_format "@[Foo( 1, 2, foo: 3 )]", "@[Foo(1, 2, foo: 3)]"
   assert_format "@[Foo]\ndef foo\nend"
   assert_format "@[Foo(\n  1,\n)]"
+  assert_format "@[Foo::Bar]"
+  assert_format "@[::Foo::Bar]"
 
   assert_format "1.as   Int32", "1.as Int32"
   assert_format "foo.bar. as   Int32", "foo.bar.as Int32"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3490,8 +3490,8 @@ module Crystal
       write_token :"@["
       skip_space_or_newline
 
-      write @token
-      next_token_skip_space
+      node.path.accept self
+      skip_space_or_newline
 
       if @token.type == :"("
         has_args = !node.args.empty? || node.named_args


### PR DESCRIPTION
When annotations were introduced, I forgot to correctly format their name/path, now that it can have `::` and all that stuff. Thanks @kostya for spotting this.