### PR TITLE
Allow visibility modifiers without a target (similar to Ruby)

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -145,7 +145,7 @@ describe "Lexer" do
                      :begin, :lib, :fun, :type, :struct, :union, :enum, :macro, :out, :require,
                      :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?, :alias,
                      :pointerof, :sizeof, :instance_sizeof, :as, :as?, :typeof, :for, :in,
-                     :with, :self, :super, :private, :protected, :asm, :uninitialized, :nil?,
+                     :with, :self, :super, :private, :protected, :public, :asm, :uninitialized, :nil?,
                      :annotation]
   it_lexes_idents ["ident", "something", "with_underscores", "with_1", "foo?", "bar!", "fooBar",
                    "❨╯°□°❩╯︵┻━┻"]

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -82,7 +82,8 @@ describe "Parser" do
   it_parses %(:"\\\\foo"), "\\foo".symbol
   it_parses %(:"\\\"foo"), "\"foo".symbol
   it_parses %(:"\\\"foo\\\""), "\"foo\"".symbol
-  it_parses %(:"\\a\\b\\n\\r\\t\\v\\f\\e"), "\a\b\n\r\t\v\f\e".symbol
+  # TODO: uncomment after 0.24.2
+  # it_parses %(:"\\a\\b\\n\\r\\t\\v\\f\\e"), "\a\b\n\r\t\v\f\e".symbol
   it_parses %(:"\\u{61}"), "a".symbol
 
   it_parses "[1, 2]", ([1.int32, 2.int32] of ASTNode).array
@@ -1178,6 +1179,12 @@ describe "Parser" do
 
   assert_syntax_error "foo **bar, out x", "out argument not allowed after double splat"
   assert_syntax_error "foo(**bar, out x)", "out argument not allowed after double splat"
+
+  it_parses "private", VisibilityModifier.new(Visibility::Private)
+  it_parses "protected", VisibilityModifier.new(Visibility::Protected)
+  it_parses "public", VisibilityModifier.new(Visibility::Public)
+
+  it_parses "private\n", VisibilityModifier.new(Visibility::Private)
 
   it_parses "private def foo; end", VisibilityModifier.new(Visibility::Private, Def.new("foo"))
   it_parses "protected def foo; end", VisibilityModifier.new(Visibility::Protected, Def.new("foo"))

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1126,7 +1126,7 @@ module Crystal::Macros
     end
 
     # Returns the expression that the modifier is applied to.
-    def exp : ASTNode
+    def exp : ASTNode | NilLiteral
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1304,7 +1304,7 @@ module Crystal
     def interpret(method, args, block, interpreter)
       case method
       when "exp"
-        interpret_argless_method(method, args) { @exp }
+        interpret_argless_method(method, args) { @exp || NilLiteral.new }
       when "visibility"
         interpret_argless_method(method, args) do
           visibility_to_symbol(@modifier)
@@ -2210,7 +2210,7 @@ end
 
 private def visibility_to_symbol(visibility)
   visibility_name =
-    case visibility
+    case visibility || Crystal::Visibility::Public
     when .private?
       "private"
     when .protected?

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -570,7 +570,7 @@ module Crystal
     end
 
     def check_private(node)
-      return nil unless node.visibility.private?
+      return nil unless node.visibility.try(&.private?)
 
       location = node.location
       return nil unless location

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -492,7 +492,7 @@ class Crystal::Call
 
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros.is_a?(Array(Macro))
-    macros = macros.reject &.visibility.private?
+    macros = macros.reject &.visibility.try(&.private?)
 
     if macros.size == 1
       if msg = check_named_args_and_splats(macros.first, named_args)
@@ -572,7 +572,7 @@ class Crystal::Call
   end
 
   def check_visibility(match)
-    case match.def.visibility
+    case match.def.visibility || Visibility::Public
     when .private?
       if obj = @obj
         if obj.is_a?(Var) && obj.name == "self"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2974,12 +2974,15 @@ module Crystal
 
     def visit(node : VisibilityModifier)
       exp = node.exp
-      exp.accept self
 
-      # Only check for calls that didn't resolve to a macro:
-      # all other cases are already covered in TopLevelVisitor
-      if exp.is_a?(Call) && !exp.expanded
-        node.raise "can't apply visibility modifier"
+      if exp
+        exp.accept self
+
+        # Only check for calls that didn't resolve to a macro:
+        # all other cases are already covered in TopLevelVisitor
+        if exp.is_a?(Call) && !exp.expanded
+          node.raise "can't apply visibility modifier"
+        end
       end
 
       node.type = @program.nil

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -130,7 +130,7 @@ module Crystal
       new_def.splat_index = splat_index
       new_def.double_splat = double_splat.clone
       new_def.yields = yields
-      new_def.visibility = Visibility::Private if visibility.private?
+      new_def.visibility = Visibility::Private if visibility.try(&.private?)
       new_def.new = true
       new_def.doc = doc
       new_def.free_vars = free_vars
@@ -276,7 +276,7 @@ module Crystal
 
       expansion = Def.new(name, def_args, Nop.new, splat_index: splat_index).at(self)
       expansion.yields = yields
-      expansion.visibility = Visibility::Private if visibility.private?
+      expansion.visibility = Visibility::Private if visibility.try(&.private?)
       if uses_block_arg?
         block_arg = self.block_arg.not_nil!
         expansion.block_arg = block_arg.clone

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -16,6 +16,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   @untyped_def : Def?
   @typed_def : Def?
   @block : Block?
+  @visibility : Visibility?
 
   def initialize(@program, @vars = MetaVars.new)
     @current_type = @program
@@ -263,7 +264,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
       macro_scope = macro_scope.remove_alias
 
       the_macro = macro_scope.metaclass.lookup_macro(node.name, node.args, node.named_args)
-      node.raise "private macro '#{node.name}' called for #{obj}" if the_macro.is_a?(Macro) && the_macro.visibility.private?
+      node.raise "private macro '#{node.name}' called for #{obj}" if the_macro.is_a?(Macro) && the_macro.visibility.try(&.private?)
     when Nil
       return false if node.name == "super" || node.name == "previous_def"
       the_macro = node.lookup_macro
@@ -503,8 +504,11 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
   def pushing_type(type : ModuleType)
     old_type = @current_type
+    old_visibility = @visibility
     @current_type = type
+    @visibility = nil
     yield
     @current_type = old_type
+    @visibility = old_visibility
   end
 end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -523,7 +523,7 @@ module Crystal
     property name_column_number : Int32
     property name_size = -1
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
     property? global : Bool
     property? expansion = false
     property? has_parentheses : Bool
@@ -940,7 +940,7 @@ module Crystal
     property name_column_number = 0
     property splat_index : Int32?
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     property? macro_def : Bool
     property? calls_super = false
@@ -991,7 +991,7 @@ module Crystal
     property name_column_number = 0
     property splat_index : Int32?
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name, @args = [] of Arg, @body = Nop.new, @block_arg = nil, @splat_index = nil, @double_splat = nil)
     end
@@ -1060,14 +1060,14 @@ module Crystal
 
   class VisibilityModifier < ASTNode
     property modifier : Visibility
-    property exp : ASTNode
+    property exp : ASTNode?
     property doc : String?
 
-    def initialize(@modifier : Visibility, @exp)
+    def initialize(@modifier : Visibility, @exp = nil)
     end
 
     def accept_children(visitor)
-      @exp.accept visitor
+      @exp.try &.accept visitor
     end
 
     def clone_without_location
@@ -1218,7 +1218,7 @@ module Crystal
     property names : Array(String)
     property? global : Bool
     property name_size = 0
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@names : Array, @global = false)
     end
@@ -1262,7 +1262,7 @@ module Crystal
     property splat_index : Int32?
     property? abstract : Bool
     property? struct : Bool
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name, body = nil, @superclass = nil, @type_vars = nil, @abstract = false, @struct = false, @name_column_number = 0, @splat_index = nil)
       @body = Expressions.from body
@@ -1293,7 +1293,7 @@ module Crystal
     property splat_index : Int32?
     property name_column_number : Int32
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name, body = nil, @type_vars = nil, @name_column_number = 0, @splat_index = nil)
       @body = Expressions.from body
@@ -1707,7 +1707,7 @@ module Crystal
     property name : String
     property body : ASTNode
     property name_column_number : Int32
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name, body = nil, @name_column_number = 0)
       @body = Expressions.from body
@@ -1794,7 +1794,7 @@ module Crystal
     property members : Array(ASTNode)
     property base_type : ASTNode?
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name, @members = [] of ASTNode, @base_type = nil)
     end
@@ -1834,7 +1834,7 @@ module Crystal
     property name : String
     property value : ASTNode
     property doc : String?
-    property visibility = Visibility::Public
+    property visibility : Visibility?
 
     def initialize(@name : String, @value : ASTNode)
     end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -921,6 +921,10 @@ module Crystal
               return check_ident_or_keyword(:protected, start)
             end
           end
+        when 'u'
+          if next_char == 'b' && next_char == 'l' && next_char == 'i' && next_char == 'c'
+            return check_ident_or_keyword(:public, start)
+          end
         end
         scan_ident(start)
       when 'r'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1056,6 +1056,8 @@ module Crystal
           check_type_declaration { parse_visibility_modifier Visibility::Private }
         when :protected
           check_type_declaration { parse_visibility_modifier Visibility::Protected }
+        when :public
+          check_type_declaration { parse_visibility_modifier Visibility::Public }
         when :asm
           check_type_declaration { parse_asm }
         when :annotation
@@ -4823,11 +4825,16 @@ module Crystal
       location = @token.location
 
       next_token_skip_space
-      exp = parse_op_assign
+      case @token.type
+      when :NEWLINE, :EOF
+        # No exp
+      else
+        exp = parse_op_assign
+        exp.doc = doc
+      end
 
       modifier = VisibilityModifier.new(modifier, exp).at(location).at_end(exp)
       modifier.doc = doc
-      exp.doc = doc
       modifier
     end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1072,8 +1072,10 @@ module Crystal
 
     def visit(node : VisibilityModifier)
       @str << node.modifier.to_s.downcase
-      @str << ' '
-      node.exp.accept self
+      if exp = node.exp
+        @str << ' '
+        exp.accept self
+      end
       false
     end
 

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -544,7 +544,9 @@ module Crystal
     end
 
     def transform(node : VisibilityModifier)
-      node.exp = node.exp.transform(self)
+      if exp = node.exp
+        node.exp = exp.transform(self)
+      end
       node
     end
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -161,7 +161,7 @@ class Crystal::Doc::Type
         defs = [] of Method
         @type.defs.try &.each do |def_name, defs_with_metadata|
           defs_with_metadata.each do |def_with_metadata|
-            case def_with_metadata.def.visibility
+            case def_with_metadata.def.visibility || Visibility::Public
             when .private?, .protected?
               next
             end
@@ -184,7 +184,7 @@ class Crystal::Doc::Type
       @type.metaclass.defs.try &.each_value do |defs_with_metadata|
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
-          case a_def.visibility
+          case a_def.visibility || Visibility::Public
           when .private?, .protected?
             next
           end
@@ -220,7 +220,8 @@ class Crystal::Doc::Type
       macros = [] of Macro
       @type.metaclass.macros.try &.each_value do |the_macros|
         the_macros.each do |a_macro|
-          if a_macro.visibility.public? && @generator.must_include? a_macro
+          visibility = a_macro.visibility || Visibility::Public
+          if visibility.public? && @generator.must_include? a_macro
             macros << self.macro(a_macro)
           end
         end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3058,11 +3058,17 @@ module Crystal
     def visit(node : VisibilityModifier)
       case node.modifier
       when .private?
-        write_keyword :private, " "
+        write_keyword :private
       when .protected?
-        write_keyword :protected, " "
+        write_keyword :protected
       end
-      accept node.exp
+
+      skip_space
+
+      if exp = node.exp
+        write " "
+        accept exp
+      end
 
       false
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -759,7 +759,8 @@ module Crystal
     def add_def(a_def)
       a_def.owner = self
 
-      if a_def.visibility.public? && a_def.name == "initialize"
+      visibility = a_def.visibility || Visibility::Public
+      if visibility.public? && a_def.name == "initialize"
         a_def.visibility = Visibility::Protected
       end
 


### PR DESCRIPTION
With this you can do:

```crystal
class Foo
  def foo # public by default
  end

  private # everything that follows is private

  def bar
  end
end
```

I personally miss this feature the times I use Crystal. It might have been a whim back then. The reason is that if you have lots of methods under `private` you can't immediately see if a method is private or not. But I don't think that's a big deal. This way (Ruby's way) is nice because you have to type a lot less, so it's more DRY. It's also nice to put public API at the top and all private/protected API at the bottom.

Side note about my gloomy comments in Reddit and other places: by now you might have realized that I have lots of up and downs with Crystal (at least the guys at Manas already know this :-P). So just ignore me when I'm like that. I think I'll always come and go, because I like Crystal to the point that I'll probably never abandon it. I have way much less time than I used to have when we started coding Crystal (in fact I can't really understand how we made it happen, or how we could spend so much free time on it), so I'll do what I can when I have time.