### PR TITLE
Add macro verbatim blocks

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -146,7 +146,7 @@ describe "Lexer" do
                      :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?, :alias,
                      :pointerof, :sizeof, :instance_sizeof, :as, :as?, :typeof, :for, :in,
                      :with, :self, :super, :private, :protected, :asm, :uninitialized, :nil?,
-                     :annotation]
+                     :annotation, :verbatim]
   it_lexes_idents ["ident", "something", "with_underscores", "with_1", "foo?", "bar!", "fooBar",
                    "❨╯°□°❩╯︵┻━┻"]
   it_lexes_idents ["def?", "if?", "else?", "elsif?", "end?", "true?", "false?", "class?", "while?",

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -806,6 +806,8 @@ describe "Parser" do
 
   it_parses "macro foo(\na = 0\n)\nend", Macro.new("foo", [Arg.new("a", default_value: 0.int32)], Expressions.new)
 
+  it_parses "macro foo;{% verbatim do %}1{% foo %}2{% end %};end", Macro.new("foo", [] of Arg, Expressions.from(["1{% foo %}2".macro_literal, ";".macro_literal] of ASTNode))
+
   assert_syntax_error "macro foo; {% foo = 1 }; end"
   assert_syntax_error "macro def foo : String; 1; end"
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1024,6 +1024,11 @@ module Crystal
           end
         end
         scan_ident(start)
+      when 'v'
+        if next_char == 'e' && next_char == 'r' && next_char == 'b' && next_char == 'a' && next_char == 't' && next_char == 'i' && next_char == 'm'
+          return check_ident_or_keyword(:verbatim, start)
+        end
+        scan_ident(start)
       when 'w'
         case next_char
         when 'h'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3085,6 +3085,33 @@ module Crystal
           return MacroIf.new(BoolLiteral.new(true), body).at_end(token_end_location)
         when :else, :elsif, :end
           return nil
+        when :verbatim
+          next_token_skip_space
+          unless @token.keyword?(:do)
+            unexpected_token(msg: "expecting 'do'")
+          end
+          next_token_skip_space
+          check :"%}"
+
+          macro_state.control_nest += 1
+          body, end_location = parse_macro_body(start_line, start_column, macro_state)
+          macro_state.control_nest -= 1
+
+          check_ident :end
+          next_token_skip_space
+          check :"%}"
+
+          string_body = String.build do |io|
+            if body.is_a?(Expressions)
+              body.expressions.each do |exp|
+                exp.to_s(io)
+              end
+            else
+              body.to_s(io)
+            end
+          end
+
+          return MacroLiteral.new(string_body)
         end
       end
 


### PR DESCRIPTION
## What

This adds the ability to specify verbatim blocks in macros, so macro code isn't **immediately** execute.

## Why

Take a look at how the macro `def_clone` is implemented:

```crystal
  macro def_clone
    # Returns a copy of `self` with all instance variables cloned.
    def clone
      clone = \{{@type}}.allocate
      clone.initialize_copy(self)
      GC.add_finalizer(clone) if clone.responds_to?(:finalize)
      clone
    end

    protected def initialize_copy(other)
      \{% for ivar in @type.instance_vars %}
        @\{{ivar.id}} = other.@\{{ivar.id}}.clone
      \{% end %}
    end
  end
```

Note all the `\{%` and `\{{` in there. It's needed because we don't want to execute `@type` right away: we want to defer it until the method is executed, so it works like a macro method. The `\` is ugly, but it works.

With this PR, we can write it like this:

```crystal
  macro def_clone
    {% verbatim do %}
      # Returns a copy of `self` with all instance variables cloned.
      def clone
        clone = {{@type}}.allocate
        clone.initialize_copy(self)
        GC.add_finalizer(clone) if clone.responds_to?(:finalize)
        clone
      end

      protected def initialize_copy(other)
        {% for ivar in @type.instance_vars %}
          @{{ivar.id}} = other.@{{ivar.id}}.clone
        {% end %}
      end
    {% end %}
  end
```

`verbatim` basically won't treat the block inside it as macro code, but instead as just a string that's being pasted. Then when the `clone` and `initialize_copy` methods are invoked, the pasted code that's actually macro is executed.

So this is just a better way to write and do what we can already do.

I also need this for a complete implementation of https://github.com/crystal-lang/crystal/pull/6082 . The `JSON::Serialize` module must inject an `initialize` in the included type so that types referenced in attributes (like `converter`) work well. For example:

```crystal
class Foo
  class MyConverter
  end

  @[JSON::Field(converter: MyConverter)]
  property x : Int32
end
```

If `MyConverter` is pasted in the included `JSON::Serialize` module, it will give an error because `MyConverter` can't be reached from that location (that's the reason why I had to remove all the private types in the specs in that PR). If `initalize` is injected with an `included` macro, `MyConverter` can be accessed.

But since that injected `initialize` method already uses `@type` in macros, I'll have to escape with `\` all of that. But it's so much simpler to just surround everything with a `verbatim` block.

