### PR TITLE
Add macro verbatim blocks

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1123,4 +1123,6 @@ describe Crystal::Formatter do
 
   assert_format "class X; annotation  FooAnnotation  ;  end ; end", "class X\n  annotation FooAnnotation; end\nend"
   assert_format "class X\n annotation  FooAnnotation  \n  end \n end", "class X\n  annotation FooAnnotation\n  end\nend"
+
+  assert_format "macro foo\n{% verbatim do %}1 + 2{% end %}\nend"
 end

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -146,7 +146,7 @@ describe "Lexer" do
                      :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?, :alias,
                      :pointerof, :sizeof, :instance_sizeof, :as, :as?, :typeof, :for, :in,
                      :with, :self, :super, :private, :protected, :asm, :uninitialized, :nil?,
-                     :annotation]
+                     :annotation, :verbatim]
   it_lexes_idents ["ident", "something", "with_underscores", "with_1", "foo?", "bar!", "fooBar",
                    "❨╯°□°❩╯︵┻━┻"]
   it_lexes_idents ["def?", "if?", "else?", "elsif?", "end?", "true?", "false?", "class?", "while?",

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -806,6 +806,8 @@ describe "Parser" do
 
   it_parses "macro foo(\na = 0\n)\nend", Macro.new("foo", [Arg.new("a", default_value: 0.int32)], Expressions.new)
 
+  it_parses "macro foo;{% verbatim do %}1{% foo %}2{% end %};end", Macro.new("foo", [] of Arg, Expressions.from([MacroVerbatim.new(Expressions.from(["1".macro_literal, MacroExpression.new("foo".var, false), "2".macro_literal] of ASTNode)), ";".macro_literal] of ASTNode))
+
   assert_syntax_error "macro foo; {% foo = 1 }; end"
   assert_syntax_error "macro def foo : String; 1; end"
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -131,4 +131,5 @@ describe "ASTNode#to_s" do
   expect_to_s %q(%r{#{1}\/\0}), %q(/#{1}\/\0/)
   expect_to_s %q(`\n\0`), %q(`\n\u0000`)
   expect_to_s %q(`#{1}\n\0`), %q(`#{1}\n\u0000`)
+  expect_to_s "macro foo\n{% verbatim do %}1{% end %}\nend"
 end

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1252,4 +1252,31 @@ describe "Semantic: macro" do
       {{ FOO["foo"] }}
     )) { nil_type }
   end
+
+  it "does macro verbatim inside macro" do
+    assert_type(%(
+      class Foo
+        macro inherited
+          {% verbatim do %}
+            def foo
+              {{ @type }}
+            end
+          {% end %}
+        end
+      end
+
+      class Bar < Foo
+      end
+
+      Bar.new.foo
+      )) { types["Bar"].metaclass }
+  end
+
+  it "does macro verbatim outside macro" do
+    assert_type(%(
+      {% verbatim do %}
+        1
+      {% end %}
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -115,6 +115,18 @@ module Crystal
       @str << node.value
     end
 
+    def visit(node : MacroVerbatim)
+      exp = node.exp
+      if exp.is_a?(Expressions)
+        exp.expressions.each do |subexp|
+          subexp.to_s(@str)
+        end
+      else
+        exp.to_s(@str)
+      end
+      false
+    end
+
     def visit(node : Var)
       var = @vars[node.name]?
       if var

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -597,7 +597,7 @@ module Crystal
   {% for name in %w(And Or
                    ArrayLiteral HashLiteral RegexLiteral RangeLiteral
                    Case StringInterpolation
-                   MacroExpression MacroIf MacroFor MultiAssign
+                   MacroExpression MacroIf MacroFor MacroVerbatim MultiAssign
                    SizeOf InstanceSizeOf Global Require Select) %}
     class {{name.id}}
       include ExpandableNode

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -172,6 +172,16 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     false
   end
 
+  def visit(node : MacroVerbatim)
+    expansion = MacroIf.new(BoolLiteral.new(true), node)
+    expand_inline_macro expansion
+
+    node.expanded = expansion
+    node.bind_to expansion
+
+    false
+  end
+
   def visit(node : ExternalVar | Path | Generic | ProcNotation | Union | Metaclass | Self | TypeOf)
     false
   end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1990,6 +1990,12 @@ module Crystal
     def_equals_and_hash value
   end
 
+  class MacroVerbatim < UnaryExpression
+    def clone_without_location
+      MacroVerbatim.new(@exp.clone)
+    end
+  end
+
   # if inside a macro
   #
   #     {% 'if' cond %}

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1024,6 +1024,11 @@ module Crystal
           end
         end
         scan_ident(start)
+      when 'v'
+        if next_char == 'e' && next_char == 'r' && next_char == 'b' && next_char == 'a' && next_char == 't' && next_char == 'i' && next_char == 'm'
+          return check_ident_or_keyword(:verbatim, start)
+        end
+        scan_ident(start)
       when 'w'
         case next_char
         when 'h'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3085,6 +3085,23 @@ module Crystal
           return MacroIf.new(BoolLiteral.new(true), body).at_end(token_end_location)
         when :else, :elsif, :end
           return nil
+        when :verbatim
+          next_token_skip_space
+          unless @token.keyword?(:do)
+            unexpected_token(msg: "expecting 'do'")
+          end
+          next_token_skip_space
+          check :"%}"
+
+          macro_state.control_nest += 1
+          body, end_location = parse_macro_body(start_line, start_column, macro_state)
+          macro_state.control_nest -= 1
+
+          check_ident :end
+          next_token_skip_space
+          check :"%}"
+
+          return MacroVerbatim.new(body).at_end(token_end_location)
         end
       end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -787,6 +787,13 @@ module Crystal
       false
     end
 
+    def visit(node : MacroVerbatim)
+      @str << "{% verbatim do %}"
+      node.exp.accept self
+      @str << "{% end %}"
+      false
+    end
+
     def visit(node : ExternalVar)
       @str << '$'
       @str << node.name

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -560,6 +560,10 @@ module Crystal
       node
     end
 
+    def transform(node : MacroVerbatim)
+      node
+    end
+
     def transform(node : MacroIf)
       node
     end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1660,6 +1660,32 @@ module Crystal
       false
     end
 
+    def visit(node : MacroVerbatim)
+      check :MACRO_CONTROL_START
+      write "{%"
+      next_token_skip_space_or_newline
+      check_keyword :verbatim
+      write " verbatim"
+      next_token_skip_space
+      check_keyword :do
+      write " do"
+      next_token_skip_space
+      check :"%}"
+      write " %}"
+      next_macro_token
+      node.exp.accept self
+      check :MACRO_CONTROL_START
+      write "{%"
+      next_token_skip_space_or_newline
+      check_keyword :end
+      write " end"
+      next_token_skip_space
+      check :"%}"
+      write " %}"
+      next_macro_token
+      false
+    end
+
     def visit(node : MacroExpression)
       reset_macro_state
 


### PR DESCRIPTION
(correct implementation of #6105... I should have not closed the other PR so fast :-P)

## What

This adds the ability to specify verbatim blocks in macros, so macro code isn't **immediately** execute.

## Why

Take a look at how the macro `def_clone` is implemented:

```crystal
  macro def_clone
    # Returns a copy of `self` with all instance variables cloned.
    def clone
      clone = \{{@type}}.allocate
      clone.initialize_copy(self)
      GC.add_finalizer(clone) if clone.responds_to?(:finalize)
      clone
    end

    protected def initialize_copy(other)
      \{% for ivar in @type.instance_vars %}
        @\{{ivar.id}} = other.@\{{ivar.id}}.clone
      \{% end %}
    end
  end
```

Note all the `\{%` and `\{{` in there. It's needed because we don't want to execute `@type` right away: we want to defer it until the method is executed, so it works like a macro method. The `\` is ugly, but it works.

With this PR, we can write it like this:

```crystal
  macro def_clone
    {% verbatim do %}
      # Returns a copy of `self` with all instance variables cloned.
      def clone
        clone = {{@type}}.allocate
        clone.initialize_copy(self)
        GC.add_finalizer(clone) if clone.responds_to?(:finalize)
        clone
      end

      protected def initialize_copy(other)
        {% for ivar in @type.instance_vars %}
          @{{ivar.id}} = other.@{{ivar.id}}.clone
        {% end %}
      end
    {% end %}
  end
```

`verbatim` basically won't treat the block inside it as macro code, but instead as just a string that's being pasted. Then when the `clone` and `initialize_copy` methods are invoked, the pasted code that's actually macro is executed.

So this is just a better way to write and do what we can already do.

I also need this for a complete implementation of https://github.com/crystal-lang/crystal/pull/6082 . The `JSON::Serialize` module must inject an `initialize` in the included type so that types referenced in attributes (like `converter`) work well. For example:

```crystal
class Foo
  class MyConverter
  end

  @[JSON::Field(converter: MyConverter)]
  property x : Int32
end
```

If `MyConverter` is pasted in the included `JSON::Serialize` module, it will give an error because `MyConverter` can't be reached from that location (that's the reason why I had to remove all the private types in the specs in that PR). If `initalize` is injected with an `included` macro, `MyConverter` can be accessed.

But since that injected `initialize` method already uses `@type` in macros, I'll have to escape with `\` all of that. But it's so much simpler to just surround everything with a `verbatim` block.

