### PR TITLE
Remove static linking for macos

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -410,7 +410,7 @@ class Crystal::Command
           # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
             raise "macOS doesn't support static linking.\
-            For more informations: https://developer.apple.com/library/content/qa/qa1118/_index.html"
+            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html"
           {% else %}
             compiler.static = true
           {% end %}

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -409,7 +409,7 @@ class Crystal::Command
         opts.on("--static", "Link statically") do
           # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
-            abort "macOS doesn't support static linking.\
+            abort "macOS doesn't support static linking.\n\
             For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html"
           {% else %}
             compiler.static = true

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -407,7 +407,13 @@ class Crystal::Command
           compiler.verbose = true
         end
         opts.on("--static", "Link statically") do
-          compiler.static = true
+          # https://developer.apple.com/library/content/qa/qa1118/_index.html
+          {% if flag?(:darwin) %}
+            raise "macOS doesn't support static linking.\
+            For more informations: https://developer.apple.com/library/content/qa/qa1118/_index.html"
+          {% else %}
+            compiler.static = true
+          {% end %}
         end
       end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -409,7 +409,7 @@ class Crystal::Command
         opts.on("--static", "Link statically") do
           # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
-            raise "macOS doesn't support static linking.\
+            abort "macOS doesn't support static linking.\
             For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html"
           {% else %}
             compiler.static = true

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -105,13 +105,6 @@ class Crystal::Command
   rescue ex : Crystal::LocationlessException
     error ex.message
   rescue ex : Crystal::Exception
-    # https://developer.apple.com/library/content/qa/qa1118/_index.html
-    {% if flag?(:darwin) %}
-      STDERR.puts <<-INFO
-      macOS doesn't officially support static linking.
-      For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
-      INFO
-   {% end %}
     ex.color = @color
     if @config.try(&.output_format) == "json"
       STDERR.puts ex.to_json
@@ -415,6 +408,13 @@ class Crystal::Command
         end
         opts.on("--static", "Link statically") do
           compiler.static = true
+          # https://developer.apple.com/library/content/qa/qa1118/_index.html                                           
+          {% if flag?(:darwin) %}                                                                                       
+            STDERR.puts <<-INFO                                                                                         
+            macOS doesn't officially support static linking.                                                            
+            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html                     
+            INFO                                                                                                        
+          {% end %
         end
       end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -108,8 +108,8 @@ class Crystal::Command
     # https://developer.apple.com/library/content/qa/qa1118/_index.html
     {% if flag?(:darwin) %}
       STDERR.puts <<-INFO
-      macOS doesn't support static linking.
-      For more information: https://developer.apple.com/library/content/qa/qa1118/_ind
+      macOS doesn't officially support static linking.
+      For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
       INFO
    {% end %}
     ex.color = @color

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -408,12 +408,12 @@ class Crystal::Command
         end
         opts.on("--static", "Link statically") do
           compiler.static = true
-          # https://developer.apple.com/library/content/qa/qa1118/_index.html                                           
-          {% if flag?(:darwin) %}                                                                                       
-            STDERR.puts <<-INFO                                                                                         
-            macOS doesn't officially support static linking.                                                            
-            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html                     
-            INFO                                                                                                        
+          # https://developer.apple.com/library/content/qa/qa1118/_index.html
+          {% if flag?(:darwin) %}
+            STDERR.puts <<-INFO
+            macOS doesn't officially support static linking.
+            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
+            INFO
           {% end %}
         end
       end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -408,7 +408,6 @@ class Crystal::Command
         end
         opts.on("--static", "Link statically") do
           compiler.static = true
-          # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
             puts <<-INFO
             macOS doesn't officially support static linking.

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -410,7 +410,7 @@ class Crystal::Command
           compiler.static = true
           # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
-            STDERR.puts <<-INFO
+            puts <<-INFO
             macOS doesn't officially support static linking.
             For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
             INFO

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -409,8 +409,10 @@ class Crystal::Command
         opts.on("--static", "Link statically") do
           # https://developer.apple.com/library/content/qa/qa1118/_index.html
           {% if flag?(:darwin) %}
-            abort "macOS doesn't support static linking.\n\
-            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html"
+            abort <<-E
+            macOS doesn't support static linking.
+            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
+            E
           {% else %}
             compiler.static = true
           {% end %}

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -105,6 +105,13 @@ class Crystal::Command
   rescue ex : Crystal::LocationlessException
     error ex.message
   rescue ex : Crystal::Exception
+    # https://developer.apple.com/library/content/qa/qa1118/_index.html
+    {% if flag?(:darwin) %}
+      STDERR.puts <<-INFO
+      macOS doesn't support static linking.
+      For more information: https://developer.apple.com/library/content/qa/qa1118/_ind
+      INFO
+   {% end %}
     ex.color = @color
     if @config.try(&.output_format) == "json"
       STDERR.puts ex.to_json
@@ -407,15 +414,7 @@ class Crystal::Command
           compiler.verbose = true
         end
         opts.on("--static", "Link statically") do
-          # https://developer.apple.com/library/content/qa/qa1118/_index.html
-          {% if flag?(:darwin) %}
-            abort <<-E
-            macOS doesn't support static linking.
-            For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html
-            E
-          {% else %}
-            compiler.static = true
-          {% end %}
+          compiler.static = true
         end
       end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -414,7 +414,7 @@ class Crystal::Command
             macOS doesn't officially support static linking.                                                            
             For more information: https://developer.apple.com/library/content/qa/qa1118/_index.html                     
             INFO                                                                                                        
-          {% end %
+          {% end %}
         end
       end
 


### PR DESCRIPTION
[Static linking isn't supported on macos](https://developer.apple.com/library/content/qa/qa1118/_index.html).
Fix #5991