### PR TITLE
Fix Time.new and Time.utc

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -162,7 +162,7 @@ struct Time
     new(seconds: seconds, nanoseconds: nanoseconds, location: location)
   end
 
-  def self.new(year, month, day, hour = 0, minute = 0, second = 0, *, nanosecond = 0, location = Location.local)
+  def self.new(year : Int32, month : Int32, day : Int32, hour = 0, minute = 0, second = 0, *, nanosecond = 0, location = Location.local)
     unless 1 <= year <= 9999 &&
            1 <= month <= 12 &&
            1 <= day <= Time.days_in_month(year, month) &&
@@ -231,7 +231,7 @@ struct Time
   end
 
   # Returns a new `Time` instance at the specified time in UTC time zone.
-  def self.utc(year, month, day, hour = 0, minute = 0, second = 0, *, nanosecond = 0) : Time
+  def self.utc(year : Int32, month : Int32, day : Int32, hour = 0, minute = 0, second = 0, *, nanosecond = 0) : Time
     new(year, month, day, hour, minute, second, nanosecond: nanosecond, location: Location::UTC)
   end
 


### PR DESCRIPTION
@Grabli66 found a bug in `Time.new`.

When you do for example this:
```Crystal
puts Time.new(1977, 8.to_i16, 9.to_i16)
```
then you get this:
```Ruby
0003-11-10 00:00:00
```
instead of:
```Ruby
1977-08-09 00:00:00
```
It's probably because of an overflow internally.
I fixed this by restricting `year`, `month` and `day` of `Time.new` and `Time.utc` to `Int32`.