### PR TITLE
Add missing stdarg.cr for i686-linux-musl

### DIFF
--- a/src/lib_c/i686-linux-musl/c/stdarg.cr
+++ b/src/lib_c/i686-linux-musl/c/stdarg.cr
@@ -1,0 +1,3 @@
+lib LibC
+  type VaList = Void*
+end


### PR DESCRIPTION
The stdarg.cr binding was missing for i686-linux-musl target in #5103 

It is needed to attempt an automated release for 32 bits in the same way 64 bits are currently done (going through musl)