### PR TITLE
Fix incorrect formatting of ending expression after heredoc

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1125,4 +1125,17 @@ describe Crystal::Formatter do
   assert_format "class X\n annotation  FooAnnotation  \n  end \n end", "class X\n  annotation FooAnnotation\n  end\nend"
 
   assert_format "macro foo\n{% verbatim do %}1 + 2{% end %}\nend"
+
+  assert_format "{% foo <<-X\nbar\nX\n%}"
+  assert_format "foo do\n  {% foo <<-X\n  bar\n  X\n  %}\nend"
+  assert_format "{{ foo <<-X\nbar\nX\n}}"
+  assert_format "foo do\n  {{ foo <<-X\n  bar\n  X\n  }}\nend"
+  assert_format "[foo <<-X\nbar\nX\n]"
+  assert_format "foo do\n  [foo <<-X\n  bar\n  X\n  ]\nend"
+  assert_format "{1 => foo <<-X\nbar\nX\n}"
+  assert_format "foo do\n  {1 => foo <<-X\n  bar\n  X\n  }\nend"
+  assert_format "bar do\n  foo <<-X\n  bar\n  X\nend"
+  assert_format "foo do\n  bar do\n    foo <<-X\n    bar\n    X\n  end\nend"
+  assert_format "call(foo <<-X\nbar\nX\n)"
+  assert_format "bar do\n  call(foo <<-X\n  bar\n  X\n  )\nend"
 end


### PR DESCRIPTION
Fixes #6121 

It was a bit tricky to fix because the formatter works like this:
- To format an expression, like `1` or `1 + 2`, the formatter traverses that and outputs/fixes that (corrects whitespace, etc.), but it doesn't insert a newline
- Newline is inserted after an expression is formatter only if more expressions come, or if it's before an "end", etc.
- But a heredoc already ends with a newline (it's probably the only expression with this characteristic), so a second newline must not be placed in the above cases

That's why a newline is now inserted after writing a heredoc, and in some places I check that if a newline was already printed, don't print it again.

The issue also happened with other closing stuff, like `}}`, `]`, `}`, not only `%}`.