### PR TITLE
Fix: detect error when trying to use unbound generic type in instance var

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4912,4 +4912,20 @@ describe "Semantic: instance var" do
       ),
       "Can't infer the type of instance variable '@x' of Foo"
   end
+
+  it "can't infer type of generic method that returns self (#5383)" do
+    assert_error %(
+      class Gen(T)
+        def self.new(&block : -> T) : self
+        end
+      end
+
+      class Foo
+        def initialize(x, y)
+          @x = Gen.new { 1 }
+        end
+      end
+      ),
+      "can't use Gen(T) as the type of instance variable @x of Foo, use a more specific type"
+  end
 end


### PR DESCRIPTION
Fixes #5383

Sorry, this one is a bit hard to explain, why the fix works. But basically, an uninstantiated generic type should only be instantiated with available free vars, not all the time (in the new test case, `T` shouldn't be found because we are trying to find instance vars of `Foo`, and so `Gen(T)` shouldn't be a valid type for an instance var of `Foo` (it could be valid for an instance var of `Gen(T)`, but that's not the case).