### PR TITLE
Serialize nil as `~` in YAML

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -326,7 +326,7 @@ describe "YAML serialization" do
         :null  => nil,
       }
 
-      expected = "---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: \n"
+      expected = "---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: ~\n"
 
       data.to_yaml.should eq(expected)
     end

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -76,7 +76,7 @@ end
 
 struct Nil
   def to_yaml(yaml : YAML::Nodes::Builder)
-    yaml.scalar ""
+    yaml.scalar "~"
   end
 end
 


### PR DESCRIPTION
Result with following code:

```cr
puts({"foo" => nil}.to_yaml)
```

**before**:
```yaml
---
foo: 
```

**after**:
```yaml
---
foo: ~
```

Refs #6137