### PR TITLE
Add Etag support in HTTP::StaticFileHandler

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -24,7 +24,7 @@ class HTTP::StaticFileHandler
   end
 
   def call(context)
-    unless context.request.method == "GET" || context.request.method == "HEAD"
+    unless {"GET", "HEAD"}.includes?(context.request.method)
       if @fallthrough
         call_next(context)
       else
@@ -64,20 +64,12 @@ class HTTP::StaticFileHandler
       context.response.content_type = "text/html"
       directory_listing(context.response, request_path, file_path)
     elsif is_file
-      last_modified = File.info(file_path).modification_time
-      context.response.headers["Last-Modified"] = HTTP.format_time(last_modified)
+      last_modified = modification_time(file_path)
+      add_cache_headers(context.response.headers, last_modified)
 
-      if if_modified_since = context.request.headers["If-Modified-Since"]?
-        header_time = HTTP.parse_time(if_modified_since)
-
-        # File mtime probably has a higher resolution than the header value.
-        # An exact comparison might be slightly off, so we add 1s padding.
-        # Static files should generally not be modified in subsecond intervals, so this is perfectly safe.
-        # This might be replaced by a more sophisticated time comparison when it becomes available.
-        if header_time && last_modified <= header_time + 1.second
-          context.response.status_code = 304
-          return
-        end
+      if cache_request?(context, last_modified)
+        context.response.status_code = 304
+        return
       end
 
       context.response.content_type = mime_type(file_path)
@@ -101,6 +93,36 @@ class HTTP::StaticFileHandler
 
     url = URI.escape(url) { |byte| URI.unreserved?(byte) || byte.chr == '/' }
     context.response.headers.add "Location", url
+  end
+
+  private def add_cache_headers(response_headers : HTTP::Headers, last_modified : Time) : Nil
+    response_headers["Etag"] = etag(last_modified)
+    response_headers["Last-Modified"] = HTTP.format_time(last_modified)
+  end
+
+  private def cache_request?(context : HTTP::Server::Context, last_modified : Time) : Bool
+    # According to RFC 7232:
+    # A recipient must ignore If-Modified-Since if the request contains an If-None-Match header field
+    if if_none_match = context.request.headers["If-None-Match"]?
+      if_none_match == context.response.headers["Etag"]
+    elsif if_modified_since = context.request.headers["If-Modified-Since"]?
+      header_time = HTTP.parse_time(if_modified_since)
+      # File mtime probably has a higher resolution than the header value.
+      # An exact comparison might be slightly off, so we add 1s padding.
+      # Static files should generally not be modified in subsecond intervals, so this is perfectly safe.
+      # This might be replaced by a more sophisticated time comparison when it becomes available.
+      !!(header_time && last_modified <= header_time + 1.second)
+    else
+      false
+    end
+  end
+
+  private def etag(modification_time)
+    %{W/"#{modification_time.epoch}"}
+  end
+
+  private def modification_time(file_path)
+    File.info(file_path).modification_time
   end
 
   private def mime_type(path)


### PR DESCRIPTION
Hi all

I was trying to extract some logic in Kemal - https://github.com/kemalcr/kemal/pull/440 - it seems at this point static file handler is kinda hard to re-use as it's quite coupled - a lot of stuff is going on there at the moment.

Maybe injecting _conditional_ into handle arguments might be a good idea? So you can basically plug-in anything you want there (you could also remove caching by injecting some class that will simply return false for `matches?` class method).

It's just a totally random proposal / proof of concept (wip) - please let me know what you think about it so we can proceed with it / change the approach or simply reject it 💣 

Keep up great work, I'm really enjoying having 'ruby experience' in a compiled language - it's truly awesome ❤️ 