### PR TITLE
Allow HTTP::Client to use ipv6 addresses

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -121,6 +121,16 @@ module HTTP
       end
     end
 
+    it "sends the host header ipv6 with brackets" do
+      server = HTTP::Server.new do |context|
+        context.response.print context.request.headers["Host"]
+      end
+      address = server.bind_unused_port "::1"
+      spawn { server.listen }
+
+      HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("[::1]:#{address.port}")
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -19,6 +19,7 @@ end
 describe "URI" do
   assert_uri("http://www.example.com", scheme: "http", host: "www.example.com")
   assert_uri("http://www.example.com:81", scheme: "http", host: "www.example.com", port: 81)
+  assert_uri("http://[::1]:81", scheme: "http", host: "[::1]", port: 81)
   assert_uri("http://www.example.com/foo", scheme: "http", host: "www.example.com", path: "/foo")
   assert_uri("http://www.example.com/foo?q=1", scheme: "http", host: "www.example.com", path: "/foo", query: "q=1")
   assert_uri("http://www.example.com?q=1", scheme: "http", host: "www.example.com", query: "q=1")

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -33,6 +33,12 @@ describe "URI" do
   assert_uri("/foo?q=1", path: "/foo", query: "q=1")
   assert_uri("mailto:foo@example.org", scheme: "mailto", path: nil, opaque: "foo@example.org")
 
+  describe "hostname" do
+    it { URI.parse("http://www.example.com/foo").hostname.should eq("www.example.com") }
+    it { URI.parse("http://[::1]/foo").hostname.should eq("::1") }
+    it { URI.parse("/foo").hostname.should be_nil }
+  end
+
   describe "full_path" do
     it { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
     it { URI.parse("http://www.example.com").full_path.should eq("/") }

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -651,7 +651,8 @@ class HTTP::Client
     socket = @socket
     return socket if socket
 
-    socket = TCPSocket.new URI.hostname(@host), @port, @dns_timeout, @connect_timeout
+    hostname = @host.starts_with?('[') && @host.ends_with?(']') ? @host[1..-2] : @host
+    socket = TCPSocket.new hostname, @port, @dns_timeout, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
     socket.sync = false
     @socket = socket

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -651,11 +651,7 @@ class HTTP::Client
     socket = @socket
     return socket if socket
 
-    # URI host may have ipv6 enclosed by brackets and is fine according to
-    # rfc3986. The host http header must contains the brackets, ie: the same
-    # value as returned by URI#host
-    ip_host = @host[0] == '[' && @host[-1] == ']' ? @host[1..-2] : @host
-    socket = TCPSocket.new ip_host, @port, @dns_timeout, @connect_timeout
+    socket = TCPSocket.new URI.hostname(@host), @port, @dns_timeout, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
     socket.sync = false
     @socket = socket

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -651,7 +651,11 @@ class HTTP::Client
     socket = @socket
     return socket if socket
 
-    socket = TCPSocket.new @host, @port, @dns_timeout, @connect_timeout
+    # URI host may have ipv6 enclosed by brackets and is fine according to
+    # rfc3986. The host http header must contains the brackets, ie: the same
+    # value as returned by URI#host
+    ip_host = @host[0] == '[' && @host[-1] == ']' ? @host[1..-2] : @host
+    socket = TCPSocket.new ip_host, @port, @dns_timeout, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
     socket.sync = false
     @socket = socket

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -129,13 +129,7 @@ class URI
     host.try { |h| URI.hostname(h) }
   end
 
-  # Returns the *host* without brackets for IPv6 addresses. See `URI#hostname`.
-  #
-  # ```
-  # URI.hostname("www.example.org") # => "www.example.org"
-  # URI.hostname("127.0.0.1")       # => "127.0.0.1"
-  # URI.hostname("[::1]")           # => "::1"
-  # ```
+  # :nodoc:
   def self.hostname(host : String)
     host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host
   end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -126,12 +126,7 @@ class URI
   # URI.parse("http://[::1]/bar").host     # => "[::1]"
   # ```
   def hostname
-    host.try { |h| URI.hostname(h) }
-  end
-
-  # :nodoc:
-  def self.hostname(host : String)
-    host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host
+    host.try { |host| host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host }
   end
 
   # Returns the full path of this URI.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -137,7 +137,7 @@ class URI
   # URI.hostname("[::1]")           # => "::1"
   # ```
   def self.hostname(host : String)
-    host[0] == '[' && host[-1] == ']' ? host[1..-2] : host
+    host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host
   end
 
   # Returns the full path of this URI.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -119,6 +119,27 @@ class URI
   def initialize(@scheme = nil, @host = nil, @port = nil, @path = nil, @query = nil, @user = nil, @password = nil, @fragment = nil, @opaque = nil)
   end
 
+  # Returns the host part of the URI and unwrap brackets for IPv6 addresses.
+  #
+  # ```
+  # URI.parse("http://[::1]/bar").hostname # => "::1"
+  # URI.parse("http://[::1]/bar").host     # => "[::1]"
+  # ```
+  def hostname
+    host.try { |h| URI.hostname(h) }
+  end
+
+  # Returns the *host* without brackets for IPv6 addresses. See `URI#hostname`.
+  #
+  # ```
+  # URI.hostname("www.example.org") # => "www.example.org"
+  # URI.hostname("127.0.0.1")       # => "127.0.0.1"
+  # URI.hostname("[::1]")           # => "::1"
+  # ```
+  def self.hostname(host : String)
+    host[0] == '[' && host[-1] == ']' ? host[1..-2] : host
+  end
+
   # Returns the full path of this URI.
   #
   # ```


### PR DESCRIPTION
Fixes #5514 

The `URI#host` is fine to have the brackets since they are part of rfc3986 host description.
The `HTTP::Client` needs to extract them before creating the `TCPSocket`.