### PR TITLE
Drop 'when _' support

### DIFF
--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -100,8 +100,4 @@ describe "Normalize: case" do
   it "normalizes case with multiple expressions and non-tuple" do
     assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === ({x, y})\n  4\nend"
   end
-
-  it "normalizes case with single expressions with underscore" do
-    assert_expand_second "x = 1; case x; when _; 2; end", "if true\n  2\nend"
-  end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1657,6 +1657,9 @@ describe "Parser" do
     assert_syntax_error %(case x; when 1..2; 2; when 1..2; end), "duplicate when 1..2 in case"
     assert_syntax_error %(case x; when /x/; 2; when /x/; end), "duplicate when /x/ in case"
     assert_syntax_error %(case x; when X; 2; when X; end), "duplicate when X in case"
+    assert_syntax_error "case x; when _; end", "'when _' is not supported, use 'else' block instead"
+    assert_syntax_error "case x; when 1; when _; end", "'when _' is not supported, use 'else' block instead"
+    assert_syntax_error "case x; when 1, _; end", "'when _' is not supported, use 'else' block instead"
 
     it_parses "%w{one  two}", (["one".string, "two".string] of ASTNode).array_of(Path.global("String"))
     it_parses "%w{one\ntwo}", (["one".string, "two".string] of ASTNode).array_of(Path.global("String"))

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2485,7 +2485,7 @@ module Crystal
                   tuple_elements = [] of ASTNode
 
                   while true
-                    tuple_elements << parse_when_expression(cond)
+                    tuple_elements << parse_when_expression(cond, single: false)
                     skip_space
                     if @token.type == :","
                       next_token_skip_space_or_newline
@@ -2505,7 +2505,7 @@ module Crystal
                   check :"}"
                   next_token_skip_space
                 else
-                  exp = parse_when_expression(cond)
+                  exp = parse_when_expression(cond, single: true)
                   when_conds << exp
                   add_when_exp(when_exps, exp)
                   skip_space
@@ -2515,7 +2515,7 @@ module Crystal
               end
             else
               while true
-                exp = parse_when_expression(cond)
+                exp = parse_when_expression(cond, single: true)
                 when_conds << exp
                 add_when_exp(when_exps, exp)
                 skip_space
@@ -2609,7 +2609,7 @@ module Crystal
       false
     end
 
-    def parse_when_expression(cond)
+    def parse_when_expression(cond, single)
       if cond && @token.type == :"."
         next_token
         call = parse_var_or_call(force_call: true)
@@ -2623,6 +2623,8 @@ module Crystal
           raise "BUG: expected Call, RespondsTo, IsA, Cast or NilableCast"
         end
         call
+      elsif single && @token.type == :UNDERSCORE
+        raise "'when _' is not supported, use 'else' block instead"
       else
         parse_op_assign_no_control
       end


### PR DESCRIPTION
Ref #4837

I think this syntax has no use-case. It can be replaced with `else` block always.