### PR TITLE
Add Time#at_{beginning,end}_of_second

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -10,6 +10,10 @@ private def parse_time(format, string)
   Time.parse(format, string, Time::Location::UTC)
 end
 
+private def parse_time(string)
+  Time.parse(string, "%F %T.%N", Time::Location::UTC)
+end
+
 describe Time do
   it "initialize" do
     t1 = Time.new 2002, 2, 25
@@ -809,63 +813,63 @@ describe Time do
   end
 
   it "at" do
-    t1 = Time.new 2014, 11, 25, 10, 11, 12, nanosecond: 13
-    t2 = Time.new 2014, 6, 25, 10, 11, 12, nanosecond: 13
+    t1 = Time.utc 2014, 11, 25, 10, 11, 12, nanosecond: 13
+    t2 = Time.utc 2014, 6, 25, 10, 11, 12, nanosecond: 13
 
-    t1.at_beginning_of_year.to_s("%F %T").should eq("2014-01-01 00:00:00")
+    t1.at_beginning_of_year.should eq parse_time("2014-01-01 00:00:00.0")
 
     1.upto(3) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s("%F %T").should eq("2014-01-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s("%F %T").should eq("2014-03-31 23:59:59")
+      Time.utc(2014, i, 10).at_beginning_of_quarter.should eq parse_time("2014-01-01 00:00:00.0")
+      Time.utc(2014, i, 10).at_end_of_quarter.should eq parse_time("2014-03-31 23:59:59.999999999")
     end
     4.upto(6) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s("%F %T").should eq("2014-04-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s("%F %T").should eq("2014-06-30 23:59:59")
+      Time.utc(2014, i, 10).at_beginning_of_quarter.should eq parse_time("2014-04-01 00:00:00.0")
+      Time.utc(2014, i, 10).at_end_of_quarter.should eq parse_time("2014-06-30 23:59:59.999999999")
     end
     7.upto(9) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s("%F %T").should eq("2014-07-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s("%F %T").should eq("2014-09-30 23:59:59")
+      Time.utc(2014, i, 10).at_beginning_of_quarter.should eq parse_time("2014-07-01 00:00:00.0")
+      Time.utc(2014, i, 10).at_end_of_quarter.should eq parse_time("2014-09-30 23:59:59.999999999")
     end
     10.upto(12) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s("%F %T").should eq("2014-10-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s("%F %T").should eq("2014-12-31 23:59:59")
+      Time.utc(2014, i, 10).at_beginning_of_quarter.should eq parse_time("2014-10-01 00:00:00.0")
+      Time.utc(2014, i, 10).at_end_of_quarter.should eq parse_time("2014-12-31 23:59:59.999999999")
     end
 
-    t1.at_beginning_of_quarter.to_s("%F %T").should eq("2014-10-01 00:00:00")
-    t1.at_beginning_of_month.to_s("%F %T").should eq("2014-11-01 00:00:00")
+    t1.at_beginning_of_quarter.should eq parse_time("2014-10-01 00:00:00.0")
+    t1.at_beginning_of_month.should eq parse_time("2014-11-01 00:00:00.0")
 
     3.upto(9) do |i|
-      Time.new(2014, 11, i).at_beginning_of_week.to_s("%F %T").should eq("2014-11-03 00:00:00")
+      Time.utc(2014, 11, i).at_beginning_of_week.should eq parse_time("2014-11-03 00:00:00.0")
     end
 
-    t1.at_beginning_of_day.to_s("%F %T").should eq("2014-11-25 00:00:00")
-    t1.at_beginning_of_hour.to_s("%F %T").should eq("2014-11-25 10:00:00")
-    t1.at_beginning_of_minute.to_s("%F %T").should eq("2014-11-25 10:11:00")
+    t1.at_beginning_of_day.should eq parse_time("2014-11-25 00:00:00.0")
+    t1.at_beginning_of_hour.should eq parse_time("2014-11-25 10:00:00.0")
+    t1.at_beginning_of_minute.should eq parse_time("2014-11-25 10:11:00.0")
 
-    t1.at_end_of_year.to_s("%F %T").should eq("2014-12-31 23:59:59")
+    t1.at_end_of_year.should eq parse_time("2014-12-31 23:59:59.999999999")
 
-    t1.at_end_of_quarter.to_s("%F %T").should eq("2014-12-31 23:59:59")
-    t2.at_end_of_quarter.to_s("%F %T").should eq("2014-06-30 23:59:59")
+    t1.at_end_of_quarter.should eq parse_time("2014-12-31 23:59:59.999999999")
+    t2.at_end_of_quarter.should eq parse_time("2014-06-30 23:59:59.999999999")
 
-    t1.at_end_of_month.to_s("%F %T").should eq("2014-11-30 23:59:59")
-    t1.at_end_of_week.to_s("%F %T").should eq("2014-11-30 23:59:59")
+    t1.at_end_of_month.should eq parse_time("2014-11-30 23:59:59.999999999")
+    t1.at_end_of_week.should eq parse_time("2014-11-30 23:59:59.999999999")
 
-    Time.new(2014, 11, 2).at_end_of_week.to_s("%F %T").should eq("2014-11-02 23:59:59")
+    Time.utc(2014, 11, 2).at_end_of_week.should eq parse_time("2014-11-02 23:59:59.999999999")
     3.upto(9) do |i|
-      Time.new(2014, 11, i).at_end_of_week.to_s("%F %T").should eq("2014-11-09 23:59:59")
+      Time.utc(2014, 11, i).at_end_of_week.should eq parse_time("2014-11-09 23:59:59.999999999")
     end
 
-    t1.at_end_of_day.to_s("%F %T").should eq("2014-11-25 23:59:59")
-    t1.at_end_of_hour.to_s("%F %T").should eq("2014-11-25 10:59:59")
-    t1.at_end_of_minute.to_s("%F %T").should eq("2014-11-25 10:11:59")
+    t1.at_end_of_day.should eq parse_time("2014-11-25 23:59:59.999999999")
+    t1.at_end_of_hour.should eq parse_time("2014-11-25 10:59:59.999999999")
+    t1.at_end_of_minute.should eq parse_time("2014-11-25 10:11:59.999999999")
 
-    t1.at_midday.to_s("%F %T").should eq("2014-11-25 12:00:00")
+    t1.at_midday.should eq parse_time("2014-11-25 12:00:00.0")
 
-    t1.at_beginning_of_semester.to_s("%F %T").should eq("2014-07-01 00:00:00")
-    t2.at_beginning_of_semester.to_s("%F %T").should eq("2014-01-01 00:00:00")
+    t1.at_beginning_of_semester.should eq parse_time("2014-07-01 00:00:00.0")
+    t2.at_beginning_of_semester.should eq parse_time("2014-01-01 00:00:00.0")
 
-    t1.at_end_of_semester.to_s("%F %T").should eq("2014-12-31 23:59:59")
-    t2.at_end_of_semester.to_s("%F %T").should eq("2014-06-30 23:59:59")
+    t1.at_end_of_semester.should eq parse_time("2014-12-31 23:59:59.999999999")
+    t2.at_end_of_semester.should eq parse_time("2014-06-30 23:59:59.999999999")
   end
 
   it "does time span units" do

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -845,6 +845,7 @@ describe Time do
     t1.at_beginning_of_day.should eq parse_time("2014-11-25 00:00:00.0")
     t1.at_beginning_of_hour.should eq parse_time("2014-11-25 10:00:00.0")
     t1.at_beginning_of_minute.should eq parse_time("2014-11-25 10:11:00.0")
+    t1.at_beginning_of_second.should eq parse_time("2014-11-25 10:11:12.0")
 
     t1.at_end_of_year.should eq parse_time("2014-12-31 23:59:59.999999999")
 
@@ -862,6 +863,7 @@ describe Time do
     t1.at_end_of_day.should eq parse_time("2014-11-25 23:59:59.999999999")
     t1.at_end_of_hour.should eq parse_time("2014-11-25 10:59:59.999999999")
     t1.at_end_of_minute.should eq parse_time("2014-11-25 10:11:59.999999999")
+    t1.at_end_of_second.should eq parse_time("2014-11-25 10:11:12.999999999")
 
     t1.at_midday.should eq parse_time("2014-11-25 12:00:00.0")
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -986,7 +986,11 @@ struct Time
   def_at_beginning(month) { Time.new(year, month, 1, location: location) }
   def_at_beginning(day) { Time.new(year, month, day, location: location) }
   def_at_beginning(hour) { Time.new(year, month, day, hour, location: location) }
-  def_at_beginning(minute) { Time.new(year, month, day, hour, minute, location: location) }
+
+  # Returns a copy of this `Time` representing the beginning of the minute.
+  def at_beginning_of_minute : Time
+    Time.new(seconds: total_seconds - second, nanoseconds: 0, location: location)
+  end
 
   # Returns a copy of this `Time` representing the beginning of the seconds.
   #
@@ -1051,7 +1055,11 @@ struct Time
 
   def_at_end(day) { Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location) }
   def_at_end(hour) { Time.new(year, month, day, hour, 59, 59, nanosecond: 999_999_999, location: location) }
-  def_at_end(minute) { Time.new(year, month, day, hour, minute, 59, nanosecond: 999_999_999, location: location) }
+
+  # Returns a copy of this `Time` representing the end of the minute.
+  def at_end_of_minute
+    Time.new(seconds: total_seconds - second + 59, nanoseconds: 999_999_999, location: location)
+  end
 
   # Returns a copy of this `Time` representing the end of the second.
   def at_end_of_second

--- a/src/time.cr
+++ b/src/time.cr
@@ -988,6 +988,13 @@ struct Time
   def_at_beginning(hour) { Time.new(year, month, day, hour, location: location) }
   def_at_beginning(minute) { Time.new(year, month, day, hour, minute, location: location) }
 
+  # Returns a copy of this `Time` representing the beginning of the seconds.
+  #
+  # This essentially scaps off `nanoseconds`.
+  def at_beginning_of_second : Time
+    Time.new(seconds: total_seconds, nanoseconds: 0, location: location)
+  end
+
   # Returns a copy of this `Time` representing the beginning of the week.
   #
   # TODO: Ensure correctness in local time-line.
@@ -1045,6 +1052,11 @@ struct Time
   def_at_end(day) { Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location) }
   def_at_end(hour) { Time.new(year, month, day, hour, 59, 59, nanosecond: 999_999_999, location: location) }
   def_at_end(minute) { Time.new(year, month, day, hour, minute, 59, nanosecond: 999_999_999, location: location) }
+
+  # Returns a copy of this `Time` representing the end of the second.
+  def at_end_of_second
+    Time.new(seconds: total_seconds, nanoseconds: 999_999_999, location: location)
+  end
 
   # Returns a copy of this `Time` representing midday (`12:00`) of the same day.
   def at_midday : Time


### PR DESCRIPTION
* Adds `Time#at_beginning_of_second`, `Time#at_end_of_second`
* Adds spec helper for Time-at specs
* Improves Time-at expectations to take nanoseconds into account
* Optimizes implementation of `Time#at_beginning_of_minute`, `Time#at_end_of_minute` - they don't need to do calendaric calculations.