### PR TITLE
Fix: use Crystal::System::Random in Crystal::Hasher

### DIFF
--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -1,5 +1,3 @@
-require "random/secure"
-
 # :nodoc:
 struct Crystal::Hasher
   # Implementation of a Hasher to compute a fast and safe hash
@@ -82,7 +80,7 @@ struct Crystal::Hasher
   private HASH_INF_MINUS = (-314159_i64).unsafe_as(UInt64)
 
   @@seed = uninitialized UInt64[2]
-  Random::Secure.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
+  Crystal::System::Random.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
 
   def initialize(@a : UInt64 = @@seed[0], @b : UInt64 = @@seed[1])
   end


### PR DESCRIPTION
Using `Random::Secure` in `prelude.cr` causes some load order issues when the [crystal-random](https://github.com/crystal-lang/crystal-random) shard is required, and this prevents a program compilation (e.g. the crystal-random specs). The exact issue is unknown. Maybe it's related to adding more implementations of the `Random` module, required by `Random::Secure`, and creating a kind of loop between `Hash` -> `Crystal::Hasher` -> `Random::Secure` <-> `Random` that the compiler can't satisfy.

Using `Crystal::System::Random` directly instead of `Random::Secure` (which merely delegates to `Crystal::System::Random`) fixes the compilation issue. I'm not fond of that solution (or hack), but it works.