### PR TITLE
Increase no_output_timeout to 20m for linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,11 +163,13 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          cd /tmp/workspace/distribution-scripts
-          source build.env
-          cd linux
-          make all64 release=true
+      - run:
+          no_output_timeout: 20m
+          command: |
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+            cd linux
+            make all64 release=true
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/linux/
           paths:
@@ -178,11 +180,13 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          cd /tmp/workspace/distribution-scripts
-          source build.env
-          cd linux
-          make all32 release=true
+      - run:
+          no_output_timeout: 20m
+          command: |
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+            cd linux
+            make all32 release=true
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/linux/
           paths:


### PR DESCRIPTION
A sample build with the increased timeout can be found https://circleci.com/workflow-run/8a40b86a-82f3-4398-a127-e5f58bdbdfb8

We are hitting the default timeout without output of 10m sometimes