### PR TITLE
Fix examples in Formatting and Parsing Time

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -127,7 +127,7 @@ require "crystal/system/time"
 # The method `#to_s` formats the date-time according to a specified pattern.
 #
 # ```
-# time = Time.utc(2015, 10, 12, 10, 30, 00)
+# time = Time.utc(2015, 10, 12, 10, 30, 0)
 # time.to_s("%Y-%m-%d %H:%m:%s %Z") # => "2015-10-12 10:30:00 +00:00"
 # ```
 #
@@ -135,7 +135,7 @@ require "crystal/system/time"
 # information in a string, according to a specified pattern:
 #
 # ```
-# Time.parse("2015-10-12 10:30:00 +00:00", "%Y-%m-%d %H:%m:%s %Z")
+# Time.parse("2015-10-12 10:30:00 +00:00", "%Y-%m-%d %H:%M:%S %z")
 # ```
 #
 # See `Time::Format` for all directives.

--- a/src/time.cr
+++ b/src/time.cr
@@ -128,7 +128,7 @@ require "crystal/system/time"
 #
 # ```
 # time = Time.utc(2015, 10, 12, 10, 30, 0)
-# time.to_s("%Y-%m-%d %H:%m:%s %Z") # => "2015-10-12 10:30:00 +00:00"
+# time.to_s("%Y-%m-%d %H:%M:%S %:z") # => "2015-10-12 10:30:00 +00:00"
 # ```
 #
 # Similarly, `Time.parse` is used to construct a `Time` instance from date-time


### PR DESCRIPTION
Fixes #6207 

In the first example the `00` causes this error: `octal constants should be prefixed with 0o` so the `00` itself and the code behind it got cut off so it looks like this in the docs right now:
```Crystal
time = Time.utc(2015, 10, 12, 10, 30, 
```