### PR TITLE
fix extname with one char filename

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -316,6 +316,7 @@ describe "File" do
     File.extname("/foo.bar/baz").should eq("")
     File.extname("test.cr").should eq(".cr")
     File.extname("test.cr.cz").should eq(".cz")
+    File.extname("a.cr").should eq(".cr")
     File.extname(".test").should eq("")
     File.extname(".test.cr").should eq(".cr")
     File.extname(".test.cr.cz").should eq(".cz")

--- a/src/file.cr
+++ b/src/file.cr
@@ -284,7 +284,7 @@ class File < IO::FileDescriptor
 
     dot_index = filename.rindex('.')
 
-    if dot_index && dot_index != filename.size - 1 && dot_index - 1 > (filename.rindex(SEPARATOR) || 0)
+    if dot_index && dot_index != filename.size - 1 && dot_index > ((filename.rindex(SEPARATOR) || -1) + 1)
       filename[dot_index, filename.size - dot_index]
     else
       ""


### PR DESCRIPTION
Should fix #6215.
let me know If I should move `filename.rindex(SEPARATOR) || -1` to separate variable to be more readable.