### PR TITLE
Fix File.extname for filenames like "a.yml", and make the method easier to understand

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -320,6 +320,7 @@ describe "File" do
     File.extname(".test.cr").should eq(".cr")
     File.extname(".test.cr.cz").should eq(".cz")
     File.extname("test").should eq("")
+    File.extname("a.yml").should eq(".yml")
   end
 
   it "constructs a path from parts" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -284,11 +284,29 @@ class File < IO::FileDescriptor
 
     dot_index = filename.rindex('.')
 
-    if dot_index && dot_index != filename.size - 1 && dot_index - 1 > (filename.rindex(SEPARATOR) || 0)
-      filename[dot_index, filename.size - dot_index]
-    else
-      ""
-    end
+    # If there's no dot, there's no extension
+    return "" unless dot_index
+
+    # If the last dot happens on the first char, there's no extension
+    # (that's the whole filename, like ".gitignore")
+    return "" if dot_index == 0
+
+    # If the dot is the last char, there's no extension (for example: "foo.")
+    return "" if dot_index == filename.size - 1
+
+    # Check if there's a file separator
+    separator_index = filename.rindex(SEPARATOR)
+
+    # If the last file separator happens after the last dot, there's no extension
+    # (for example: "foo.bar/baz")
+    return "" if separator_index && separator_index > dot_index
+
+    # If the last dot comes right after the last file separator. there's no extension
+    # (for example: "foo/.bar")
+    return "" if separator_index && dot_index == separator_index + 1
+
+    # Otherwise, there's an extension
+    filename[dot_index, filename.size - dot_index]
   end
 
   # Converts *path* to an absolute path. Relative paths are


### PR DESCRIPTION
Fixes #6215

Alternative to #6216, which probably works, but please try to explain me in words what this means:

```crystal
if dot_index && dot_index != filename.size - 1 && dot_index > ((filename.rindex(SEPARATOR) || -1) + 1)
```

The regression was probably introduced because the code became hard to understand, practically unreadable. It's better to have small concise checks with comments, so that anyone can quickly understand what the code does.