### PR TITLE
Add missing JSON field to docs generator output for constants

### DIFF
--- a/src/compiler/crystal/tools/doc/constant.cr
+++ b/src/compiler/crystal/tools/doc/constant.cr
@@ -17,6 +17,10 @@ class Crystal::Doc::Constant
     @const.name
   end
 
+  def id
+    name
+  end
+
   def value
     @const.value
   end
@@ -27,6 +31,7 @@ class Crystal::Doc::Constant
 
   def to_json(builder : JSON::Builder)
     builder.object do
+      builder.field "id", id
       builder.field "name", name
       builder.field "value", value.try(&.to_s)
       builder.field "doc", doc

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -59,7 +59,7 @@
   <% end %>
   <dl>
     <% type.constants.each do |const| %>
-      <dt class="entry-const" id="<%= const.name %>">
+      <dt class="entry-const" id="<%= const.id %>">
         <strong><%= const.name %></strong> = <code><%= const.formatted_value %></code>
       </dt>
       <% if doc = const.formatted_doc %>


### PR DESCRIPTION
Fixes #6202

The `id` field was missing in the JSON serialization of constants, resulting in an `undefined` value when using it to generate link targets for search results.
I added `Constant#id` and used this in the template as well, instead of reusing `Constant#name` to be more explicit (although both methods return the same value) and to have a consistent interface like the other classes where `id` and `name` are usually different.