### PR TITLE
Fix heredoc start + comma formatter

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1140,4 +1140,11 @@ describe Crystal::Formatter do
   assert_format "foo do\n  bar do\n    foo <<-X\n    bar\n    X\n  end\nend"
   assert_format "call(foo <<-X\nbar\nX\n)"
   assert_format "bar do\n  call(foo <<-X\n  bar\n  X\n  )\nend"
+
+  assert_format "[\n  <<-EOF,\n  foo\n  EOF\n]"
+  assert_format "[\n  <<-EOF,\n  foo\n  EOF\n  <<-BAR,\n  bar\n  BAR\n]"
+  assert_format "Hash{\n  foo => <<-EOF,\n  foo\n  EOF\n}"
+  assert_format "Hash{\n  foo => <<-EOF,\n  foo\n  EOF\n  bar => <<-BAR,\n  bar\n  BAR\n}"
+  assert_format "Hash{\n  foo => <<-EOF\n  foo\n  EOF\n}"
+  assert_format "{\n  <<-KEY => 1,\n  key\n  KEY\n}"
 end


### PR DESCRIPTION
Fixes #6197

This is not a great fix, but it seems to work. If anyone has a better solution, go ahead.