### PR TITLE
[WIP] Arithmetic with Overflow

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -74,7 +74,8 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean'
-  with_build_env 'make crystal std_spec compiler_spec docs'
+  with_build_env 'make crystal'
+  with_build_env 'make std_spec compiler_spec docs FLAGS=--overflow-checked'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env './bin/crystal tool format --check samples spec src'
 }

--- a/spec/compiler/codegen/overflow_check_scope_spec.cr
+++ b/spec/compiler/codegen/overflow_check_scope_spec.cr
@@ -117,4 +117,85 @@ describe "Code gen: overflow check scope" do
       end
     )).to_i.should eq(1)
   end
+
+  describe "work at lexical scope." do
+    it "is not forwarded to function calls" do
+      checked_run(%(
+        require "prelude"
+
+        def inc_checked(v)
+          v + 1_i8
+        end
+
+        def twice(v)
+          unchecked { inc_checked(inc_checked(v)) }
+        end
+
+        begin
+          twice(126_i8)
+          1
+        rescue OverflowError
+          2
+        end
+      )).to_i.should eq(2)
+
+      unchecked_run(%(
+        require "prelude"
+
+        def inc_unchecked(v)
+          v + 1_i8
+        end
+
+        def twice(v)
+          checked { inc_unchecked(inc_unchecked(v)) }
+        end
+
+        begin
+          twice(126_i8)
+          1
+        rescue OverflowError
+          2
+        end
+      )).to_i.should eq(1)
+    end
+
+    it "is not forwarded to blocks yields" do
+      unchecked_run(%(
+        require "prelude"
+
+        def inc_unchecked
+          yield + 1_i8
+        end
+
+        def foo
+          checked {
+            inc_unchecked { 127_i8 }
+          }
+        end
+
+        foo
+      )).to_i.should eq(-128_i8)
+    end
+
+    it "is forwarded to blocks" do
+      unchecked_run(%(
+        require "prelude"
+
+        def inc_unchecked(v)
+          yield v
+        end
+
+        def foo
+          checked {
+            inc_unchecked(127_i8) { |v| v + 1_i8 }
+          }
+          1
+        rescue OverflowError
+          0
+        end
+
+        foo
+      )).to_i.should eq(0)
+    end
+  end
 end

--- a/spec/compiler/codegen/overflow_check_scope_spec.cr
+++ b/spec/compiler/codegen/overflow_check_scope_spec.cr
@@ -72,6 +72,69 @@ describe "Code gen: overflow check scope" do
     {% end %}
   end
 
+  describe "for sub" do
+    it "can be unchecked" do
+      checked_run(%(
+        unchecked { -2147483648_i32 - 1_i32 }
+      )).to_i.should eq(2147483647_i32)
+    end
+
+    it "can be checked " do
+      unchecked_run(%(
+        require "prelude"
+
+        x = 0
+        begin
+          checked { -2147483648_i32 - 1_i32 }
+          x = 1
+        rescue OverflowError
+          x = 2
+        end
+        x
+      )).to_i.should eq(2)
+    end
+
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around if unchecked for {{type}}" do
+        unchecked_run(%(
+          require "prelude"
+          {{type}}::MIN - {{type}}.new(1) == {{type}}::MAX
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}}" do
+        checked_run(%(
+          require "prelude"
+          begin
+            {{type}}::MIN - {{type}}.new(1)
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
+
+      it "wrap around if unchecked for {{type}} - Int64" do
+        unchecked_run(%(
+          require "prelude"
+          {{type}}::MIN - 1_i64 == {{type}}::MAX
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}} - Int64" do
+        checked_run(%(
+          require "prelude"
+          begin
+            {{type}}::MIN - 1_i64
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
+    {% end %}
+  end
+
   it "obey default checked" do
     checked_run(%(
       require "prelude"

--- a/spec/compiler/codegen/overflow_check_scope_spec.cr
+++ b/spec/compiler/codegen/overflow_check_scope_spec.cr
@@ -1,0 +1,101 @@
+require "../../spec_helper"
+
+def checked_run(code)
+  run(code, overflow_check: Crystal::OverflowCheckScope::Policy::Checked)
+end
+
+def unchecked_run(code)
+  run(code, overflow_check: Crystal::OverflowCheckScope::Policy::Unchecked)
+end
+
+describe "Code gen: overflow check scope" do
+  describe "for add" do
+    it "can be unchecked" do
+      checked_run(%(
+        unchecked { 2147483647_i32 + 1_i32 }
+      )).to_i.should eq(-2147483648_i32)
+    end
+
+    it "can be checked " do
+      unchecked_run(%(
+        require "prelude"
+
+        x = 0
+        begin
+          checked { 2147483647_i32 + 1_i32 }
+          x = 1
+        rescue OverflowError
+          x = 2
+        end
+        x
+      )).to_i.should eq(2)
+    end
+
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around if unchecked for {{type}}" do
+        unchecked_run(%(
+          require "prelude"
+          {{type}}::MAX + {{type}}.new(1) == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}}" do
+        checked_run(%(
+          require "prelude"
+          begin
+            {{type}}::MAX + {{type}}.new(1)
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
+    {% end %}
+  end
+
+  it "obey default checked" do
+    checked_run(%(
+      require "prelude"
+
+      x = 0
+      begin
+        a = 2147483647_i32 + 1_i32
+        x = 1
+      rescue OverflowError
+        x = 2
+      end
+      x
+    )).to_i.should eq(2)
+  end
+
+  it "obey default unchecked" do
+    unchecked_run(%(
+      2147483647_i32 + 1_i32
+    )).to_i.should eq(-2147483648_i32)
+  end
+
+  it "is obeyed in return" do
+    checked_run(%(
+      def inc(v)
+        unchecked {
+          return v + 1_i8
+        }
+      end
+
+      inc(127_i8)
+    )).to_i.should eq(-128)
+  end
+
+  it "can be nested" do
+    unchecked_run(%(
+      require "prelude"
+
+      begin
+        checked { unchecked { 2147483647_i32 + 1_i32 } + 2147483647_i32 + 2147483647_i32 + 2_i32 }
+        0
+      rescue OverflowError
+        1
+      end
+    )).to_i.should eq(1)
+  end
+end

--- a/spec/compiler/codegen/overflow_check_scope_spec.cr
+++ b/spec/compiler/codegen/overflow_check_scope_spec.cr
@@ -50,6 +50,25 @@ describe "Code gen: overflow check scope" do
           end
         )).to_i.should eq(1)
       end
+
+      it "wrap around if unchecked for {{type}} + Int64" do
+        unchecked_run(%(
+          require "prelude"
+          {{type}}::MAX + 1_i64 == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}} + Int64" do
+        checked_run(%(
+          require "prelude"
+          begin
+            {{type}}::MAX + 1_i64
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
     {% end %}
   end
 

--- a/spec/compiler/codegen/overflow_check_scope_spec.cr
+++ b/spec/compiler/codegen/overflow_check_scope_spec.cr
@@ -135,6 +135,69 @@ describe "Code gen: overflow check scope" do
     {% end %}
   end
 
+  describe "for mul" do
+    it "can be unchecked" do
+      checked_run(%(
+        unchecked { 2147483647_i32 * 2_i32 }
+      )).to_i.should eq(-2_i32)
+    end
+
+    it "can be checked " do
+      unchecked_run(%(
+        require "prelude"
+
+        x = 0
+        begin
+          checked { 2147483647_i32 * 2_i32 }
+          x = 1
+        rescue OverflowError
+          x = 2
+        end
+        x
+      )).to_i.should eq(2)
+    end
+
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around if unchecked for {{type}}" do
+        unchecked_run(%(
+          require "prelude"
+          ({{type}}::MAX / {{type}}.new(2) + {{type}}.new(1)) * {{type}}.new(2) == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}}" do
+        checked_run(%(
+          require "prelude"
+          begin
+            ({{type}}::MAX / {{type}}.new(2) + {{type}}.new(1)) * {{type}}.new(2)
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
+
+      it "wrap around if unchecked for {{type}} + Int64" do
+        unchecked_run(%(
+          require "prelude"
+          ({{type}}::MAX / {{type}}.new(2) + {{type}}.new(1)) * 2_i64 == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "raises if checked for {{type}} + Int64" do
+        checked_run(%(
+          require "prelude"
+          begin
+            ({{type}}::MAX / {{type}}.new(2) + {{type}}.new(1)) * 2_i64
+            0
+          rescue OverflowError
+            1
+          end
+        )).to_i.should eq(1)
+      end
+    {% end %}
+  end
+
   it "obey default checked" do
     checked_run(%(
       require "prelude"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -126,6 +126,9 @@ module Crystal
     it_parses "foo[1] /2", Call.new(Call.new("foo".call, "[]", 1.int32), "/", 2.int32)
     it_parses "[1] /2", Call.new(([1.int32] of ASTNode).array, "/", 2.int32)
 
+    it_parses "checked { 1 + 2 }", OverflowCheckScope.new(OverflowCheckScope::Policy::Checked, Expressions.from([Call.new(1.int32, "+", 2.int32)] of ASTNode))
+    it_parses "unchecked { 1 + 2 }", OverflowCheckScope.new(OverflowCheckScope::Policy::Unchecked, Expressions.from([Call.new(1.int32, "+", 2.int32)] of ASTNode))
+
     it_parses "!1", Not.new(1.int32)
     it_parses "- 1", Call.new(1.int32, "-")
     it_parses "+ 1", Call.new(1.int32, "+")
@@ -181,6 +184,7 @@ module Crystal
       extend class struct module enum while until return
       next break lib fun alias pointerof sizeof
       instance_sizeof typeof private protected asm out
+      checked unchecked
       end
     ).each do |kw|
       assert_syntax_error "def foo(#{kw}); end", "cannot use '#{kw}' as an argument name", 1, 9
@@ -1643,6 +1647,8 @@ module Crystal
       assert_end_location "extend Foo"
       assert_end_location "1.as(Int32)"
       assert_end_location "puts obj.foo"
+      assert_end_location "checked { 1 + 1 }"
+      assert_end_location "unchecked { 1 + 1 }"
 
       assert_syntax_error %({"a" : 1}), "space not allowed between named argument name and ':'"
       assert_syntax_error %({"a": 1, "b" : 2}), "space not allowed between named argument name and ':'"

--- a/spec/compiler/semantic/overflow_check_scope_spec.cr
+++ b/spec/compiler/semantic/overflow_check_scope_spec.cr
@@ -1,0 +1,10 @@
+require "../../spec_helper"
+
+describe "Semantic: overflow check scope" do
+  it "type block by expression" do
+    assert_type("checked { 1 }") { int32 }
+    assert_type("unchecked { 1 }") { int32 }
+    assert_type("checked { 1 + 2; '1' }") { char }
+    assert_type("def foo; unchecked { return 1 }; end; foo") { int32 }
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -153,7 +153,7 @@ class Crystal::SpecRunOutput
   end
 end
 
-def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None)
+def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None, overflow_check = Crystal::OverflowCheck::Default)
   code = inject_primitives(code) if inject_primitives
 
   # Code that requires the prelude doesn't run in LLVM's MCJIT
@@ -174,6 +174,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
 
     compiler = Compiler.new
     compiler.debug = debug
+    compiler.overflow_check = overflow_check
     compiler.compile Compiler::Source.new("spec", code), output_filename
 
     output = `#{output_filename}`
@@ -181,7 +182,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
 
     SpecRunOutput.new(output)
   else
-    Program.new.run(code, filename: filename, debug: debug)
+    Program.new.run(code, filename: filename, debug: debug, overflow_check: overflow_check)
   end
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -153,7 +153,7 @@ class Crystal::SpecRunOutput
   end
 end
 
-def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None, overflow_check = Crystal::OverflowCheck::Default)
+def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None, overflow_check = Crystal::DefaultOverflowCheckPolicy)
   code = inject_primitives(code) if inject_primitives
 
   # Code that requires the prelude doesn't run in LLVM's MCJIT

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -39,10 +39,52 @@ describe "Int" do
       x.should be_a(Int64)
     end
 
+    it "should overflow with larger integers" do
+      expect_raises(OverflowError) do
+        51_i64 ** 12
+      end
+    end
+
     describe "with float" do
       it { (2 ** 2.0).should be_close(4, 0.0001) }
       it { (2 ** 2.5_f32).should be_close(5.656854249492381, 0.0001) }
       it { (2 ** 2.5).should be_close(5.656854249492381, 0.0001) }
+    end
+  end
+
+  describe "unchecked_pow" do
+    it "with positive Int32" do
+      x = 2.unchecked_pow(2)
+      x.should eq(4)
+      x.should be_a(Int32)
+
+      x = 2.unchecked_pow(0)
+      x.should eq(1)
+      x.should be_a(Int32)
+    end
+
+    it "with positive UInt8" do
+      x = 2_u8.unchecked_pow(2)
+      x.should eq(4)
+      x.should be_a(UInt8)
+    end
+
+    it "raises with negative exponent" do
+      expect_raises(ArgumentError, "Cannot raise an integer to a negative integer power, use floats for that") do
+        2.unchecked_pow(-1)
+      end
+    end
+
+    it "should work with large integers" do
+      x = 51_i64.unchecked_pow(11)
+      x.should eq(6071163615208263051_i64)
+      x.should be_a(Int64)
+    end
+
+    it "should wrap with larger integers" do
+      x = 51_i64.unchecked_pow(12)
+      x.should eq(-3965304877440961871_i64)
+      x.should be_a(Int64)
     end
   end
 

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -200,7 +200,7 @@ struct Char
       end
 
       if first < 0xe0
-        return yield (first << 6) + (second - 0x3080), 2, nil
+        return yield __next_unchecked { (first << 6) + (second - 0x3080) }, 2, nil
       end
 
       third = byte_at?(pos + 2)
@@ -217,7 +217,7 @@ struct Char
           invalid_byte_sequence 3
         end
 
-        return yield (first << 12) + (second << 6) + (third - 0xE2080), 3, nil
+        return yield __next_unchecked { (first << 12) + (second << 6) + (third - 0xE2080) }, 3, nil
       end
 
       if first == 0xf0 && second < 0x90
@@ -236,7 +236,7 @@ struct Char
       end
 
       if first < 0xf5
-        return yield (first << 18) + (second << 12) + (third << 6) + (fourth - 0x3C82080), 4, nil
+        return yield __next_unchecked { (first << 18) + (second << 12) + (third << 6) + (fourth - 0x3C82080) }, 4, nil
       end
 
       invalid_byte_sequence 4

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -283,7 +283,12 @@ class Crystal::CodeGenVisitor
           context.return_phi = phi
 
           request_value do
+            @caller_overflow_check = @overflow_check
+            @overflow_check = @main_overflow_check
+
             accept target_def.body
+
+            @overflow_check = @caller_overflow_check.not_nil!
           end
 
           phi.add @last, target_def.body.type?, last: true

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -144,6 +144,7 @@ module Crystal
 
     def initialize(@program : Program, @node : ASTNode, single_module = false, @debug = Debug::Default, @overflow_check = DefaultOverflowCheckPolicy)
       @single_module = !!single_module
+      @main_overflow_check = @overflow_check
       @abi = @program.target_machine.abi
       @llvm_context = LLVM::Context.new
       # LLVM::Context.register(@llvm_context, "main")
@@ -1454,7 +1455,12 @@ module Crystal
           @needs_value = true
           set_ensure_exception_handler(block)
 
+          old_overflow_check = @overflow_check
+          @overflow_check = @caller_overflow_check.not_nil!
+
           accept block.body
+
+          @overflow_check = old_overflow_check
         end
 
         phi.add @last, block.body.type?, last: true

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -15,7 +15,7 @@ module Crystal
   GET_EXCEPTION_NAME = "__crystal_get_exception"
 
   class Program
-    def run(code, filename = nil, debug = Debug::Default, overflow_check = OverflowCheck::Default)
+    def run(code, filename = nil, debug = Debug::Default, overflow_check = DefaultOverflowCheckPolicy)
       parser = Parser.new(code)
       parser.filename = filename
       node = parser.parse
@@ -24,7 +24,7 @@ module Crystal
       evaluate node, debug: debug, overflow_check: overflow_check
     end
 
-    def evaluate(node, debug = Debug::Default, overflow_check = OverflowCheck::Default)
+    def evaluate(node, debug = Debug::Default, overflow_check = DefaultOverflowCheckPolicy)
       llvm_mod = codegen(node, single_module: true, debug: debug, overflow_check: overflow_check)[""].mod
       main = llvm_mod.functions[MAIN_NAME]
 
@@ -60,7 +60,7 @@ module Crystal
       end
     end
 
-    def codegen(node, single_module = false, debug = Debug::Default, overflow_check = OverflowCheck::Default)
+    def codegen(node, single_module = false, debug = Debug::Default, overflow_check = DefaultOverflowCheckPolicy)
       visitor = CodeGenVisitor.new self, node, single_module: single_module, debug: debug, overflow_check: overflow_check
       visitor.accept node
       visitor.process_finished_hooks
@@ -140,9 +140,9 @@ module Crystal
     @main_llvm_typer : LLVMTyper
     @main_module_info : ModuleInfo
     @main_builder : CrystalLLVMBuilder
-    @overflow_check : Crystal::OverflowCheck
+    @overflow_check : OverflowCheckScope::Policy
 
-    def initialize(@program : Program, @node : ASTNode, single_module = false, @debug = Debug::Default, @overflow_check = OverflowCheck::Default)
+    def initialize(@program : Program, @node : ASTNode, single_module = false, @debug = Debug::Default, @overflow_check = DefaultOverflowCheckPolicy)
       @single_module = !!single_module
       @abi = @program.target_machine.abi
       @llvm_context = LLVM::Context.new

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -63,6 +63,8 @@ class Crystal::CodeGenVisitor
 
     old_needs_value = @needs_value
 
+    old_overflow_check = @overflow_check
+
     with_cloned_context do |old_context|
       context.type = self_type
       context.vars = LLVMVars.new
@@ -76,6 +78,8 @@ class Crystal::CodeGenVisitor
       @ensure_exception_handlers = nil
       @rescue_block = nil
       @needs_value = true
+
+      @overflow_check = @main_overflow_check
 
       args = codegen_fun_signature(mangled_name, target_def, self_type, is_fun_literal, is_closure)
 
@@ -155,6 +159,8 @@ class Crystal::CodeGenVisitor
       @entry_block = old_entry_block
       @alloca_block = old_alloca_block
       @needs_value = old_needs_value
+
+      @overflow_check = old_overflow_check
 
       if @debug.line_numbers?
         # set_current_debug_location associates a scope from the current fun,

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -112,35 +112,35 @@ class Crystal::CodeGenVisitor
     # Comparisons are a bit trickier because we want to get comparisons
     # between signed and unsigned integers right.
     case op
-    when "<"  then return @last = codegen_binary_op_lt(t1, t2, p1, p2)
-    when "<=" then return @last = codegen_binary_op_lte(t1, t2, p1, p2)
-    when ">"  then return @last = codegen_binary_op_gt(t1, t2, p1, p2)
-    when ">=" then return @last = codegen_binary_op_gte(t1, t2, p1, p2)
+    when "<"  then return codegen_binary_op_lt(t1, t2, p1, p2)
+    when "<=" then return codegen_binary_op_lte(t1, t2, p1, p2)
+    when ">"  then return codegen_binary_op_gt(t1, t2, p1, p2)
+    when ">=" then return codegen_binary_op_gte(t1, t2, p1, p2)
     end
 
     p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
-    @last = case op
-            when "+"               then builder.add p1, p2
-            when "-"               then builder.sub p1, p2
-            when "*"               then builder.mul p1, p2
-            when "/", "unsafe_div" then t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2)
-            when "%", "unsafe_mod" then t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2)
-            when "unsafe_shl"      then builder.shl(p1, p2)
-            when "unsafe_shr"      then t1.signed? ? builder.ashr(p1, p2) : builder.lshr(p1, p2)
-            when "|"               then or(p1, p2)
-            when "&"               then and(p1, p2)
-            when "^"               then builder.xor(p1, p2)
-            when "=="              then return builder.icmp LLVM::IntPredicate::EQ, p1, p2
-            when "!="              then return builder.icmp LLVM::IntPredicate::NE, p1, p2
-            else                        raise "BUG: trying to codegen #{t1} #{op} #{t2}"
-            end
+    result = case op
+             when "+"               then builder.add p1, p2
+             when "-"               then builder.sub p1, p2
+             when "*"               then builder.mul p1, p2
+             when "/", "unsafe_div" then t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2)
+             when "%", "unsafe_mod" then t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2)
+             when "unsafe_shl"      then builder.shl(p1, p2)
+             when "unsafe_shr"      then t1.signed? ? builder.ashr(p1, p2) : builder.lshr(p1, p2)
+             when "|"               then or(p1, p2)
+             when "&"               then and(p1, p2)
+             when "^"               then builder.xor(p1, p2)
+             when "=="              then return builder.icmp LLVM::IntPredicate::EQ, p1, p2
+             when "!="              then return builder.icmp LLVM::IntPredicate::NE, p1, p2
+             else                        raise "BUG: trying to codegen #{t1} #{op} #{t2}"
+             end
 
     if t1.normal_rank != t2.normal_rank && t1.rank < t2.rank
-      @last = trunc @last, llvm_type(t1)
+      result = trunc result, llvm_type(t1)
     end
 
-    @last
+    result
   end
 
   def codegen_binary_extend_int(t1, t2, p1, p2)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -118,7 +118,7 @@ class Crystal::CodeGenVisitor
     when ">=" then return codegen_binary_op_gte(t1, t2, p1, p2)
     end
 
-    p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+    tmax, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     case op
     when "+"               then codegen_binary_op_add(t1, t2, p1, p2)
@@ -140,12 +140,15 @@ class Crystal::CodeGenVisitor
   def codegen_binary_extend_int(t1, t2, p1, p2)
     if t1.normal_rank == t2.normal_rank
       # Nothing to do
+      tmax = t1
     elsif t1.rank < t2.rank
       p1 = extend_int t1, t2, p1
+      tmax = t2
     else
       p2 = extend_int t2, t1, p2
+      tmax = t1
     end
-    {p1, p2}
+    {tmax, p1, p2}
   end
 
   # Ensures the result is returned in the type of the left hand side operand t1.
@@ -176,7 +179,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_lt(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SLT : LLVM::IntPredicate::ULT), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -214,7 +217,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_lte(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SLE : LLVM::IntPredicate::ULE), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -252,7 +255,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_gt(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SGT : LLVM::IntPredicate::UGT), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -290,7 +293,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_gte(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SGE : LLVM::IntPredicate::UGE), p1, p2
     else
       if t1.signed? && t2.unsigned?

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -121,9 +121,9 @@ class Crystal::CodeGenVisitor
     p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     result = case op
-             when "+"               then builder.add p1, p2
-             when "-"               then builder.sub p1, p2
-             when "*"               then builder.mul p1, p2
+             when "+"               then codegen_binary_op_add(p1, p2)
+             when "-"               then codegen_binary_op_sub(p1, p2)
+             when "*"               then codegen_binary_op_mul(p1, p2)
              when "/", "unsafe_div" then t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2)
              when "%", "unsafe_mod" then t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2)
              when "unsafe_shl"      then builder.shl(p1, p2)
@@ -152,6 +152,18 @@ class Crystal::CodeGenVisitor
       p2 = extend_int t2, t1, p2
     end
     {p1, p2}
+  end
+
+  def codegen_binary_op_add(p1, p2)
+    builder.add p1, p2
+  end
+
+  def codegen_binary_op_sub(p1, p2)
+    builder.sub p1, p2
+  end
+
+  def codegen_binary_op_mul(p1, p2)
+    builder.mul p1, p2
   end
 
   def codegen_binary_op_lt(t1, t2, p1, p2)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -130,7 +130,7 @@ class Crystal::CodeGenVisitor
 
     case op
     when "+"               then codegen_binary_op_add(location, tmax, t1, t2, p1, p2)
-    when "-"               then codegen_binary_op_sub(t1, t2, p1, p2)
+    when "-"               then codegen_binary_op_sub(location, tmax, t1, t2, p1, p2)
     when "*"               then codegen_binary_op_mul(t1, t2, p1, p2)
     when "/", "unsafe_div" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2))
     when "%", "unsafe_mod" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2))
@@ -200,9 +200,34 @@ class Crystal::CodeGenVisitor
     end
   end
 
-  def codegen_binary_op_sub(t1, t2, p1, p2)
-    result = builder.sub(p1, p2)
-    codegen_trunc_binary_op_result(t1, t2, result)
+  def codegen_binary_op_sub(location, t : IntegerType, t1, t2, p1, p2)
+    if overflow_checked_scope?
+      llvm_fun = case t.kind
+                 when :i8
+                   binary_overflow_fun "llvm.ssub.with.overflow.i8", llvm_context.int8
+                 when :i16
+                   binary_overflow_fun "llvm.ssub.with.overflow.i16", llvm_context.int16
+                 when :i32
+                   binary_overflow_fun "llvm.ssub.with.overflow.i32", llvm_context.int32
+                 when :i64
+                   binary_overflow_fun "llvm.ssub.with.overflow.i64", llvm_context.int64
+                 when :u8
+                   binary_overflow_fun "llvm.usub.with.overflow.i8", llvm_context.int8
+                 when :u16
+                   binary_overflow_fun "llvm.usub.with.overflow.i16", llvm_context.int16
+                 when :u32
+                   binary_overflow_fun "llvm.usub.with.overflow.i32", llvm_context.int32
+                 when :u64
+                   binary_overflow_fun "llvm.usub.with.overflow.i64", llvm_context.int64
+                 else
+                   raise "unreachable"
+                 end
+
+      codegen_binary_overflow_check(location, llvm_fun, t, t1, t2, p1, p2)
+    else
+      result = builder.sub(p1, p2)
+      codegen_trunc_binary_op_result(t1, t2, result)
+    end
   end
 
   def codegen_binary_op_mul(t1, t2, p1, p2)

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -302,10 +302,10 @@ class Crystal::Command
         end
         # TODO change deafult
         opts.on("--overflow-checked", "Perform integer overflow check") do
-          compiler.overflow_check = Crystal::OverflowCheck::Checked
+          compiler.overflow_check = Crystal::OverflowCheckScope::Policy::Checked
         end
         opts.on("--overflow-unchecked", "Skip integer overflow check (default)") do
-          compiler.overflow_check = Crystal::OverflowCheck::Unchecked
+          compiler.overflow_check = Crystal::OverflowCheckScope::Policy::Unchecked
         end
         {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
         opts.on("--lto=FLAG", "Use ThinLTO --lto=thin") do |flag|
@@ -497,10 +497,10 @@ class Crystal::Command
     end
     # TODO change deafult
     opts.on("--overflow-checked", "Perform integer overflow check") do
-      compiler.overflow_check = Crystal::OverflowCheck::Checked
+      compiler.overflow_check = Crystal::OverflowCheckScope::Policy::Checked
     end
     opts.on("--overflow-unchecked", "Skip integer overflow check (default)") do
-      compiler.overflow_check = Crystal::OverflowCheck::Unchecked
+      compiler.overflow_check = Crystal::OverflowCheckScope::Policy::Unchecked
     end
     opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
       compiler.flags << flag

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -300,6 +300,13 @@ class Crystal::Command
         opts.on("--no-debug", "Skip any symbolic debug info") do
           compiler.debug = Crystal::Debug::None
         end
+        # TODO change deafult
+        opts.on("--overflow-checked", "Perform integer overflow check") do
+          compiler.overflow_check = Crystal::OverflowCheck::Checked
+        end
+        opts.on("--overflow-unchecked", "Skip integer overflow check (default)") do
+          compiler.overflow_check = Crystal::OverflowCheck::Unchecked
+        end
         {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
         opts.on("--lto=FLAG", "Use ThinLTO --lto=thin") do |flag|
           error "--lto=thin is the only lto supported option" unless flag == "thin"
@@ -487,6 +494,13 @@ class Crystal::Command
     end
     opts.on("--no-debug", "Skip any symbolic debug info") do
       compiler.debug = Crystal::Debug::None
+    end
+    # TODO change deafult
+    opts.on("--overflow-checked", "Perform integer overflow check") do
+      compiler.overflow_check = Crystal::OverflowCheck::Checked
+    end
+    opts.on("--overflow-unchecked", "Skip integer overflow check (default)") do
+      compiler.overflow_check = Crystal::OverflowCheck::Unchecked
     end
     opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
       compiler.flags << flag

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -12,11 +12,8 @@ module Crystal
     Default     = LineNumbers
   end
 
-  enum OverflowCheck
-    Unchecked
-    Checked
-    Default   = Unchecked # TODO change
-  end
+  # TODO change to checked in future release
+  DefaultOverflowCheckPolicy = OverflowCheckScope::Policy::Unchecked
 
   # Main interface to the compiler.
   #
@@ -52,7 +49,7 @@ module Crystal
     property debug = Debug::Default
 
     # Defines the default overflow check policy
-    property overflow_check = OverflowCheck::Default
+    property overflow_check = DefaultOverflowCheckPolicy
 
     # If `true`, `.ll` files will be generated in the default cache
     # directory for each generated LLVM module.

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -230,7 +230,7 @@ module Crystal
 
     private def bc_flags_changed?(output_dir)
       bc_flags_changed = true
-      current_bc_flags = "#{@target_triple}|#{@mcpu}|#{@mattr}|#{@release}|#{@link_flags}"
+      current_bc_flags = "#{@target_triple}|#{@mcpu}|#{@mattr}|#{@release}|#{@link_flags}|#{@overflow_check}"
       bc_flags_filename = "#{output_dir}/bc_flags"
       if File.file?(bc_flags_filename)
         previous_bc_flags = File.read(bc_flags_filename).strip

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -114,7 +114,7 @@ module Crystal
     property progress_tracker = ProgressTracker.new
 
     # Defines the default overflow check policy
-    property overflow_check = OverflowCheck::Default
+    property overflow_check = DefaultOverflowCheckPolicy
 
     def initialize
       super(self, self, "main")

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -113,6 +113,9 @@ module Crystal
     # Set to a `ProgressTracker` object which tracks compilation progress.
     property progress_tracker = ProgressTracker.new
 
+    # Defines the default overflow check policy
+    property overflow_check = OverflowCheck::Default
+
     def initialize
       super(self, self, "main")
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3003,6 +3003,10 @@ module Crystal
       false
     end
 
+    def end_visit(node : OverflowCheckScope)
+      node.bind_to node.body
+    end
+
     # # Helpers
 
     def free_vars

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -675,7 +675,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
           if counter == 0 # In case the member is set to 0
             1
           else
-            counter * 2
+            __next_unchecked { counter * 2 }
           end
         else
           counter + 1

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1526,6 +1526,30 @@ module Crystal
     def_equals_and_hash @body, @types, @name
   end
 
+  class OverflowCheckScope < ASTNode
+    enum Policy
+      Unchecked
+      Checked
+    end
+
+    property body : ASTNode
+    property policy : Policy
+
+    def initialize(@policy : Policy, body = nil)
+      @body = Expressions.from body
+    end
+
+    def accept_children(visitor)
+      @body.accept visitor
+    end
+
+    def clone_without_location
+      OverflowCheckScope.new(@policy, @body.clone)
+    end
+
+    def_equals_and_hash @policy, @body
+  end
+
   class ExceptionHandler < ASTNode
     property body : ASTNode
     property rescues : Array(Rescue)?

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -762,6 +762,10 @@ module Crystal
           if next_char == 's' && next_char == 'e'
             return check_ident_or_keyword(:case, start)
           end
+        when 'h'
+          if next_char == 'e' && next_char == 'c' && next_char == 'k' && next_char == 'e' && next_char == 'd'
+            return check_ident_or_keyword(:checked, start)
+          end
         when 'l'
           if next_char == 'a' && next_char == 's' && next_char == 's'
             return check_ident_or_keyword(:class, start)
@@ -1002,6 +1006,10 @@ module Crystal
       when 'u'
         if next_char == 'n'
           case next_char
+          when 'c'
+            if next_char == 'h' && next_char == 'e' && next_char == 'c' && next_char == 'k' && next_char == 'e' && next_char == 'd'
+              return check_ident_or_keyword(:unchecked, start)
+            end
           when 'i'
             case next_char
             when 'o'

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1087,6 +1087,20 @@ module Crystal
       false
     end
 
+    def visit(node : OverflowCheckScope)
+      case node.policy
+      when OverflowCheckScope::Policy::Unchecked
+        @str << "unchecked"
+      when OverflowCheckScope::Policy::Checked
+        @str << "checked"
+      end
+
+      @str << " {"
+      node.body.accept self
+      @str << '}'
+      false
+    end
+
     def to_s_binary(node, op)
       left_needs_parens = need_parens(node.left)
       in_parenthesis(left_needs_parens, node.left)

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -260,6 +260,11 @@ module Crystal
       node
     end
 
+    def transform(node : OverflowCheckScope)
+      node.body = node.body.transform(self)
+      node
+    end
+
     def transform(node : Generic)
       node.name = node.name.transform(self)
       transform_many node.type_vars

--- a/src/crypto/blowfish.cr
+++ b/src/crypto/blowfish.cr
@@ -73,7 +73,9 @@ class Crypto::Blowfish
     c = (x >> 8) & 0xff_u32
     b = (x >> 16) & 0xff_u32
     a = (x >> 24) & 0xff_u32
-    ((@s.to_unsafe[a] + @s1[b]) ^ @s2[c]) + @s3[d]
+    __next_unchecked {
+      ((@s.to_unsafe[a] + @s1[b]) ^ @s2[c]) + @s3[d]
+    }
   end
 
   private def next_word(data, pos)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -93,26 +93,32 @@ struct Crystal::Hasher
   end
 
   private def permute(v : UInt64)
-    @a = rotl32(@a ^ v) * C1
-    @b = (rotl32(@b) ^ v) * C2
-    self
+    __next_unchecked {
+      @a = rotl32(@a ^ v) * C1
+      @b = (rotl32(@b) ^ v) * C2
+      self
+    }
   end
 
   def result
-    a, b = @a, @b
-    a ^= (a >> 23) ^ (a >> 40)
-    b ^= (b >> 23) ^ (b >> 40)
-    a *= C1
-    b *= C2
-    a ^= a >> 32
-    b ^= b >> 32
-    a + b
+    __next_unchecked {
+      a, b = @a, @b
+      a ^= (a >> 23) ^ (a >> 40)
+      b ^= (b >> 23) ^ (b >> 40)
+      a *= C1
+      b *= C2
+      a ^= a >> 32
+      b ^= b >> 32
+      a + b
+    }
   end
 
   def nil
-    @a += @b
-    @b += 1
-    self
+    __next_unchecked {
+      @a += @b
+      @b += 1
+      self
+    }
   end
 
   def bool(value)

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -38,23 +38,25 @@ module Debug
       end
 
       def each
-        end_offset = @offset + @unit_length
-        attributes = [] of {AT, FORM, Value}
+        __next_unchecked {
+          end_offset = @offset + @unit_length
+          attributes = [] of {AT, FORM, Value}
 
-        while @io.tell < end_offset
-          code = DWARF.read_unsigned_leb128(@io)
-          attributes.clear
+          while @io.tell < end_offset
+            code = DWARF.read_unsigned_leb128(@io)
+            attributes.clear
 
-          if abbrev = abbreviations[code - 1]? # abbreviations.find { |a| a.code == abbrev }
-            abbrev.attributes.each do |attr|
-              value = read_attribute_value(attr.form)
-              attributes << {attr.at, attr.form, value}
+            if abbrev = abbreviations[code - 1]? # abbreviations.find { |a| a.code == abbrev }
+              abbrev.attributes.each do |attr|
+                value = read_attribute_value(attr.form)
+                attributes << {attr.at, attr.form, value}
+              end
+              yield code, abbrev, attributes
+            else
+              yield code, nil, attributes
             end
-            yield code, abbrev, attributes
-          else
-            yield code, nil, attributes
           end
-        end
+        }
       end
 
       private def read_attribute_value(form)

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -103,27 +103,35 @@ class Digest::MD5 < Digest::Base
   end
 
   def ff(a, b, c, d, x, s, ac)
-    a += f(b, c, d) + x + ac.to_u32
-    a = rotate_left a, s
-    a += b
+    __next_unchecked {
+      a += f(b, c, d) + x + ac.to_u32
+      a = rotate_left a, s
+      a += b
+    }
   end
 
   def gg(a, b, c, d, x, s, ac)
-    a += g(b, c, d) + x + ac.to_u32
-    a = rotate_left a, s
-    a += b
+    __next_unchecked {
+      a += g(b, c, d) + x + ac.to_u32
+      a = rotate_left a, s
+      a += b
+    }
   end
 
   def hh(a, b, c, d, x, s, ac)
-    a += h(b, c, d) + x + ac.to_u32
-    a = rotate_left a, s
-    a += b
+    __next_unchecked {
+      a += h(b, c, d) + x + ac.to_u32
+      a = rotate_left a, s
+      a += b
+    }
   end
 
   def ii(a, b, c, d, x, s, ac)
-    a += i(b, c, d) + x + ac.to_u32
-    a = rotate_left a, s
-    a += b
+    __next_unchecked {
+      a += i(b, c, d) + x + ac.to_u32
+      a = rotate_left a, s
+      a += b
+    }
   end
 
   def transform(in)
@@ -201,10 +209,12 @@ class Digest::MD5 < Digest::Base
     c = ii(c, d, a, b, in[2], S43, 718787259)   # 63
     b = ii(b, c, d, a, in[9], S44, 3951481745)  # 64
 
-    @buf[0] += a
-    @buf[1] += b
-    @buf[2] += c
-    @buf[3] += d
+    __next_unchecked {
+      @buf[0] += a
+      @buf[1] += b
+      @buf[2] += c
+      @buf[3] += d
+    }
   end
 
   def final

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -45,72 +45,74 @@ class Digest::SHA1 < Digest::Base
   end
 
   def process_message_block
-    k = {0x5A827999_u32, 0x6ED9EBA1_u32, 0x8F1BBCDC_u32, 0xCA62C1D6_u32}
+    __next_unchecked {
+      k = {0x5A827999_u32, 0x6ED9EBA1_u32, 0x8F1BBCDC_u32, 0xCA62C1D6_u32}
 
-    w = uninitialized UInt32[80]
+      w = uninitialized UInt32[80]
 
-    {% for t in (0...16) %}
-      w[{{t}}] = @message_block[{{t}} * 4].to_u32 << 24
-      w[{{t}}] |= @message_block[{{t}} * 4 + 1].to_u32 << 16
-      w[{{t}}] |= @message_block[{{t}} * 4 + 2].to_u32 << 8
-      w[{{t}}] |= @message_block[{{t}} * 4 + 3].to_u32
-    {% end %}
+      {% for t in (0...16) %}
+        w[{{t}}] = @message_block[{{t}} * 4].to_u32 << 24
+        w[{{t}}] |= @message_block[{{t}} * 4 + 1].to_u32 << 16
+        w[{{t}}] |= @message_block[{{t}} * 4 + 2].to_u32 << 8
+        w[{{t}}] |= @message_block[{{t}} * 4 + 3].to_u32
+      {% end %}
 
-    {% for t in (16...80) %}
-      w[{{t}}] = circular_shift(1, w[{{t - 3}}] ^ w[{{t - 8}}] ^ w[{{t - 14}}] ^ w[{{t - 16}}])
-    {% end %}
+      {% for t in (16...80) %}
+        w[{{t}}] = circular_shift(1, w[{{t - 3}}] ^ w[{{t - 8}}] ^ w[{{t - 14}}] ^ w[{{t - 16}}])
+      {% end %}
 
-    a = @intermediate_hash[0]
-    b = @intermediate_hash[1]
-    c = @intermediate_hash[2]
-    d = @intermediate_hash[3]
-    e = @intermediate_hash[4]
+      a = @intermediate_hash[0]
+      b = @intermediate_hash[1]
+      c = @intermediate_hash[2]
+      d = @intermediate_hash[3]
+      e = @intermediate_hash[4]
 
-    {% for t in (0...20) %}
-      temp = circular_shift(5, a) +
-        ((b & c) | ((~b) & d)) + e + w[{{t}}] + k[0]
-      e = d
-      d = c
-      c = circular_shift(30, b)
-      b = a
-      a = temp
-    {% end %}
+      {% for t in (0...20) %}
+        temp = circular_shift(5, a) +
+          ((b & c) | ((~b) & d)) + e + w[{{t}}] + k[0]
+        e = d
+        d = c
+        c = circular_shift(30, b)
+        b = a
+        a = temp
+      {% end %}
 
-    {% for t in (20...40) %}
-      temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[1]
-      e = d
-      d = c
-      c = circular_shift(30, b)
-      b = a
-      a = temp
-    {% end %}
+      {% for t in (20...40) %}
+        temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[1]
+        e = d
+        d = c
+        c = circular_shift(30, b)
+        b = a
+        a = temp
+      {% end %}
 
-    {% for t in (40...60) %}
-      temp = circular_shift(5, a) +
-        ((b & c) | (b & d) | (c & d)) + e + w[{{t}}] + k[2]
-      e = d
-      d = c
-      c = circular_shift(30, b)
-      b = a
-      a = temp
-    {% end %}
+      {% for t in (40...60) %}
+        temp = circular_shift(5, a) +
+          ((b & c) | (b & d) | (c & d)) + e + w[{{t}}] + k[2]
+        e = d
+        d = c
+        c = circular_shift(30, b)
+        b = a
+        a = temp
+      {% end %}
 
-    {% for t in (60...80) %}
-      temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[3]
-      e = d
-      d = c
-      c = circular_shift(30, b)
-      b = a
-      a = temp
-    {% end %}
+      {% for t in (60...80) %}
+        temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[3]
+        e = d
+        d = c
+        c = circular_shift(30, b)
+        b = a
+        a = temp
+      {% end %}
 
-    @intermediate_hash[0] += a
-    @intermediate_hash[1] += b
-    @intermediate_hash[2] += c
-    @intermediate_hash[3] += d
-    @intermediate_hash[4] += e
+      @intermediate_hash[0] += a
+      @intermediate_hash[1] += b
+      @intermediate_hash[2] += c
+      @intermediate_hash[3] += d
+      @intermediate_hash[4] += e
 
-    @message_block_index = 0
+      @message_block_index = 0
+    }
   end
 
   def circular_shift(bits, word)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -129,6 +129,12 @@ class DivisionByZeroError < Exception
   end
 end
 
+class OverflowError < Exception
+  def initialize(message = "Overflow")
+    super(message)
+  end
+end
+
 # Raised when a method is not implemented.
 #
 # This can be used either to stub out method bodies, or when the method is not

--- a/src/float/printer/grisu3.cr
+++ b/src/float/printer/grisu3.cr
@@ -151,7 +151,9 @@ module Float::Printer::Grisu3
     #   Since too_low = too_high - unsafe_interval this is equivalent to
     #      [too_high - unsafe_interval + 4 ulp; too_high - 2 ulp]
     #   Conceptually we have: rest ~= too_high - buffer
-    return (2 * unit <= rest) && (rest <= unsafe_interval - 4 * unit)
+    __next_unchecked {
+      return (2 * unit <= rest) && (rest <= unsafe_interval - 4 * unit)
+    }
   end
 
   # Generates the digits of input number w.

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -148,7 +148,9 @@ module Float::Printer::IEEE
       exp = 1 - EXPONENT_BIAS_64
     else
       frac = (d64 & SIGNIFICAND_MASK_64) + HIDDEN_BIT_64
-      exp = (((d64 & EXPONENT_MASK_64) >> PHYSICAL_SIGNIFICAND_SIZE_64) - EXPONENT_BIAS_64).to_i
+      __next_unchecked {
+        exp = (((d64 & EXPONENT_MASK_64) >> PHYSICAL_SIGNIFICAND_SIZE_64) - EXPONENT_BIAS_64).to_i
+      }
     end
 
     {frac, exp}
@@ -162,7 +164,9 @@ module Float::Printer::IEEE
       exp = 1 - EXPONENT_BIAS_32
     else
       frac = (d32 & SIGNIFICAND_MASK_32) + HIDDEN_BIT_32
-      exp = (((d32 & EXPONENT_MASK_32) >> PHYSICAL_SIGNIFICAND_SIZE_32) - EXPONENT_BIAS_32).to_i
+      __next_unchecked {
+        exp = (((d32 & EXPONENT_MASK_32) >> PHYSICAL_SIGNIFICAND_SIZE_32) - EXPONENT_BIAS_32).to_i
+      }
     end
 
     {frac.to_u64, exp}

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -759,7 +759,9 @@ class Hash(K, V)
       copy = hasher
       copy = key.hash(copy)
       copy = value.hash(copy)
-      result += copy.result
+      __next_unchecked {
+        result += copy.result
+      }
     end
 
     result.hash(hasher)

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -247,11 +247,13 @@ abstract class JSON::Lexer
       integer = (current_char - '0').to_i64
       char = next_char
       while '0' <= char <= '9'
-        append_number_char
-        integer *= 10
-        integer += char - '0'
-        digits += 1
-        char = next_char
+        __next_unchecked {
+          append_number_char
+          integer *= 10
+          integer += char - '0'
+          digits += 1
+          char = next_char
+        }
       end
 
       case char
@@ -279,12 +281,14 @@ abstract class JSON::Lexer
     end
 
     while '0' <= char <= '9'
-      append_number_char
-      integer *= 10
-      integer += char - '0'
-      divisor *= 10
-      digits += 1
-      char = next_char
+      __next_unchecked {
+        append_number_char
+        integer *= 10
+        integer += char - '0'
+        divisor *= 10
+        digits += 1
+        char = next_char
+      }
     end
     float = integer.to_f64 / divisor
 

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -193,3 +193,12 @@ macro assert_responds_to(var, method)
     raise "Expected {{var}} to respond to :{{method}}, not #{ {{var}} }"
   end
 end
+
+# TODO remove in next release
+macro __next_unchecked
+  {% if Crystal::VERSION.includes?("0.25.0+") || compare_versions(Crystal::VERSION, "0.25.0") > 0 %}
+    unchecked { {{ yield }} }
+  {% else %}
+    {{ yield }}
+  {% end %}
+end

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -325,6 +325,7 @@ end
           {% if op != "/" %}
             # Returns the result of {{desc.id}} `self` and *other*.
             @[Primitive(:binary)]
+            @[Raises]
             def {{op.id}}(other : {{int2.id}}) : self
             end
           {% end %}

--- a/src/random.cr
+++ b/src/random.cr
@@ -116,107 +116,109 @@ module Random
     {% utype = "UInt#{size}".id %}
     {% for type in ["Int#{size}".id, utype] %}
       private def rand_int(max : {{type}}) : {{type}}
-        if max == 0
-          return {{type}}.new(0)
-        end
-
-        unless max > 0
-          raise ArgumentError.new "Invalid bound for rand: #{max}"
-        end
-
-        # The basic ideas of the algorithm are best illustrated with examples.
-        #
-        # Let's say we have a random number generator that gives uniformly distributed random
-        # numbers between 0 and 15. We need to get a uniformly distributed random number between
-        # 0 and 5 (*max* = 6). The typical mistake made in this case is to just use `rand() % 6`,
-        # but it is clear that some results will appear more often than others. So, the surefire
-        # approach is to make the RNG spit out numbers until it gives one inside our desired range.
-        # That is really wasteful though. So the approach taken here is to discard only a small
-        # range of the possible generated numbers, and use the modulo operation on the "valid" ones,
-        # like this (where X means "discard and try again"):
-        #
-        # Generated number:  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
-        #           Result:  0  1  2  3  4  5  0  1  2  3  4  5  X  X  X  X
-        #
-        # 12 is the *limit* here - the highest number divisible by *max* while still being within
-        # bounds of what the RNG can produce.
-        #
-        # On the other side of the spectrum is the problem of generating a random number in a higher
-        # range than what the RNG can produce. Let's say we have the same mentioned RNG, but we need
-        # a uniformly distributed random number between 0 and 255. All that needs to be done is to
-        # generate two random numbers between 0 and 15, and combine their bits
-        # (i.e. `rand()*16 + rand()`).
-        #
-        # Using a combination of these tricks, any RNG can be turned into any RNG, however, there
-        # are several difficult parts about this. The code below uses as few calls to the underlying
-        # RNG as possible, meaning that (with the above example) with *max* being 257, it would call
-        # the RNG 3 times. (Of course, it doesn't actually deal with RNGs that produce numbers
-        # 0 to 15, only with the `UInt8`, `UInt16`, `UInt32` and `UInt64` ranges.
-        #
-        # Another problem is how to actually compute the *limit*. The obvious way to do it, which is
-        # `(RAND_MAX + 1) / max * max`, fails because `RAND_MAX` is usually already the highest
-        # number that an integer type can hold. And even the *limit* itself will often be
-        # `RAND_MAX + 1`, meaning that we don't have to discard anything. The ways to deal with this
-        # are described below.
-
-        # if max - 1 <= typeof(next_u)::MAX
-        if typeof(next_u).new(max - 1) == max - 1
-          # One number from the RNG will be enough.
-          # All the computations will (almost) fit into `typeof(next_u)`.
-
-          # Relies on integer overflow + wraparound to find the highest number divisible by *max*.
-          limit = typeof(next_u).new(0) - (typeof(next_u).new(0) - max) % max
-          # *limit* might be 0, which means it would've been `typeof(next_u)::MAX + 1, but didn't
-          # fit into the integer type.
-
-          loop do
-            result = next_u
-
-            # For a uniform distribution we may need to throw away some numbers
-            if result < limit || limit == 0
-              return {{type}}.new(result % max)
-            end
-          end
-        else
-          # We need to find out how many random numbers need to be combined to be able to generate a
-          # random number of this magnitude.
-          # All the computations will be based on `{{utype}}` as the larger type.
-
-          # `rand_max - 1` is the maximal number we can get from combining `needed_parts` random
-          # numbers.
-          # Compute *rand_max* as `(typeof(next_u)::MAX + 1) ** needed_parts)`.
-          # If *rand_max* overflows, that means it has reached `high({{utype}}) + 1`.
-          rand_max = {{utype}}.new(1) << (sizeof(typeof(next_u))*8)
-          needed_parts = 1
-          while rand_max < max && rand_max > 0
-            rand_max <<= sizeof(typeof(next_u))*8
-            needed_parts += 1
+        __next_unchecked {
+          if max == 0
+            return {{type}}.new(0)
           end
 
-          limit =
-            if rand_max > 0
-              # `rand_max` didn't overflow, so we can calculate the *limit* the straightforward way.
-              rand_max / max * max
-            else
-              # *rand_max* is `{{utype}}::MAX + 1`, need the same wraparound trick. *limit* might
-              # overflow, which means it would've been `{{utype}}::MAX + 1`, but didn't fit into
-              # the integer type.
-              {{utype}}.new(0) - ({{utype}}.new(0) - max) % max
+          unless max > 0
+            raise ArgumentError.new "Invalid bound for rand: #{max}"
+          end
+
+          # The basic ideas of the algorithm are best illustrated with examples.
+          #
+          # Let's say we have a random number generator that gives uniformly distributed random
+          # numbers between 0 and 15. We need to get a uniformly distributed random number between
+          # 0 and 5 (*max* = 6). The typical mistake made in this case is to just use `rand() % 6`,
+          # but it is clear that some results will appear more often than others. So, the surefire
+          # approach is to make the RNG spit out numbers until it gives one inside our desired range.
+          # That is really wasteful though. So the approach taken here is to discard only a small
+          # range of the possible generated numbers, and use the modulo operation on the "valid" ones,
+          # like this (where X means "discard and try again"):
+          #
+          # Generated number:  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+          #           Result:  0  1  2  3  4  5  0  1  2  3  4  5  X  X  X  X
+          #
+          # 12 is the *limit* here - the highest number divisible by *max* while still being within
+          # bounds of what the RNG can produce.
+          #
+          # On the other side of the spectrum is the problem of generating a random number in a higher
+          # range than what the RNG can produce. Let's say we have the same mentioned RNG, but we need
+          # a uniformly distributed random number between 0 and 255. All that needs to be done is to
+          # generate two random numbers between 0 and 15, and combine their bits
+          # (i.e. `rand()*16 + rand()`).
+          #
+          # Using a combination of these tricks, any RNG can be turned into any RNG, however, there
+          # are several difficult parts about this. The code below uses as few calls to the underlying
+          # RNG as possible, meaning that (with the above example) with *max* being 257, it would call
+          # the RNG 3 times. (Of course, it doesn't actually deal with RNGs that produce numbers
+          # 0 to 15, only with the `UInt8`, `UInt16`, `UInt32` and `UInt64` ranges.
+          #
+          # Another problem is how to actually compute the *limit*. The obvious way to do it, which is
+          # `(RAND_MAX + 1) / max * max`, fails because `RAND_MAX` is usually already the highest
+          # number that an integer type can hold. And even the *limit* itself will often be
+          # `RAND_MAX + 1`, meaning that we don't have to discard anything. The ways to deal with this
+          # are described below.
+
+          # if max - 1 <= typeof(next_u)::MAX
+          if typeof(next_u).new(max - 1) == max - 1
+            # One number from the RNG will be enough.
+            # All the computations will (almost) fit into `typeof(next_u)`.
+
+            # Relies on integer overflow + wraparound to find the highest number divisible by *max*.
+            limit = typeof(next_u).new(0) - (typeof(next_u).new(0) - max) % max
+            # *limit* might be 0, which means it would've been `typeof(next_u)::MAX + 1, but didn't
+            # fit into the integer type.
+
+            loop do
+              result = next_u
+
+              # For a uniform distribution we may need to throw away some numbers
+              if result < limit || limit == 0
+                return {{type}}.new(result % max)
+              end
+            end
+          else
+            # We need to find out how many random numbers need to be combined to be able to generate a
+            # random number of this magnitude.
+            # All the computations will be based on `{{utype}}` as the larger type.
+
+            # `rand_max - 1` is the maximal number we can get from combining `needed_parts` random
+            # numbers.
+            # Compute *rand_max* as `(typeof(next_u)::MAX + 1) ** needed_parts)`.
+            # If *rand_max* overflows, that means it has reached `high({{utype}}) + 1`.
+            rand_max = {{utype}}.new(1) << (sizeof(typeof(next_u))*8)
+            needed_parts = 1
+            while rand_max < max && rand_max > 0
+              rand_max <<= sizeof(typeof(next_u))*8
+              needed_parts += 1
             end
 
-          loop do
-            result = rand_type({{utype}}, needed_parts)
+            limit =
+              if rand_max > 0
+                # `rand_max` didn't overflow, so we can calculate the *limit* the straightforward way.
+                rand_max / max * max
+              else
+                # *rand_max* is `{{utype}}::MAX + 1`, need the same wraparound trick. *limit* might
+                # overflow, which means it would've been `{{utype}}::MAX + 1`, but didn't fit into
+                # the integer type.
+                {{utype}}.new(0) - ({{utype}}.new(0) - max) % max
+              end
 
-            # For a uniform distribution we may need to throw away some numbers.
-            if result < limit || limit == 0
-              return {{type}}.new(result % max)
+            loop do
+              result = rand_type({{utype}}, needed_parts)
+
+              # For a uniform distribution we may need to throw away some numbers.
+              if result < limit || limit == 0
+                return {{type}}.new(result % max)
+              end
             end
           end
-        end
+        }
       end
 
       private def rand_range(range : Range({{type}}, {{type}})) : {{type}}
-        span = {{utype}}.new(range.end - range.begin)
+        span = {{utype}}.new(__next_unchecked { range.end - range.begin })
         if range.excludes_end?
           unless range.begin < range.end
             raise ArgumentError.new "Invalid range for rand: #{range}"

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -43,21 +43,23 @@ class Random::ISAAC
   end
 
   private def isaac
-    @cc += 1
-    @bb += cc
+    __next_unchecked {
+      @cc += 1
+      @bb += cc
 
-    256.times do |i|
-      @aa ^= case i % 4
-             when 0 then aa << 13
-             when 1 then aa >> 6
-             when 2 then aa << 2
-             else        aa >> 16
-             end
-      x = @mm[i]
-      @aa = @mm[(i + 128) % 256] + aa
-      @mm[i] = y = @mm[(x >> 2) % 256] + aa + bb
-      @rsl[i] = @bb = @mm[(y >> 10) % 256] + x
-    end
+      256.times do |i|
+        @aa ^= case i % 4
+               when 0 then aa << 13
+               when 1 then aa >> 6
+               when 2 then aa << 2
+               else        aa >> 16
+               end
+        x = @mm[i]
+        @aa = @mm[(i + 128) % 256] + aa
+        @mm[i] = y = @mm[(x >> 2) % 256] + aa + bb
+        @rsl[i] = @bb = @mm[(y >> 10) % 256] + x
+      end
+    }
   end
 
   private def init_by_array(seeds)
@@ -67,25 +69,29 @@ class Random::ISAAC
     a = b = c = d = e = f = g = h = 0x9e3779b9_u32
 
     mix = ->{
-      a ^= b << 11; d += a; b += c
-      b ^= c >> 2; e += b; c += d
-      c ^= d << 8; f += c; d += e
-      d ^= e >> 16; g += d; e += f
-      e ^= f << 10; h += e; f += g
-      f ^= g >> 4; a += f; g += h
-      g ^= h << 8; b += g; h += a
-      h ^= a >> 9; c += h; a += b
+      __next_unchecked {
+        a ^= b << 11; d += a; b += c
+        b ^= c >> 2; e += b; c += d
+        c ^= d << 8; f += c; d += e
+        d ^= e >> 16; g += d; e += f
+        e ^= f << 10; h += e; f += g
+        f ^= g >> 4; a += f; g += h
+        g ^= h << 8; b += g; h += a
+        h ^= a >> 9; c += h; a += b
+      }
     }
     4.times(&mix)
 
     scramble = ->(seed : StaticArray(UInt32, 256)) {
-      0.step(to: 255, by: 8) do |i|
-        a += seed[i]; b += seed[i + 1]; c += seed[i + 2]; d += seed[i + 3]
-        e += seed[i + 4]; f += seed[i + 5]; g += seed[i + 6]; h += seed[i + 7]
-        mix.call
-        @mm[i] = a; @mm[i + 1] = b; @mm[i + 2] = c; @mm[i + 3] = d
-        @mm[i + 4] = e; @mm[i + 5] = f; @mm[i + 6] = g; @mm[i + 7] = h
-      end
+      __next_unchecked {
+        0.step(to: 255, by: 8) do |i|
+          a += seed[i]; b += seed[i + 1]; c += seed[i + 2]; d += seed[i + 3]
+          e += seed[i + 4]; f += seed[i + 5]; g += seed[i + 6]; h += seed[i + 7]
+          mix.call
+          @mm[i] = a; @mm[i + 1] = b; @mm[i + 2] = c; @mm[i + 3] = d
+          @mm[i + 4] = e; @mm[i + 5] = f; @mm[i + 6] = g; @mm[i + 7] = h
+        end
+      }
     }
 
     scramble.call(@rsl)

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -58,33 +58,40 @@ class Random::PCG32
     @state = 0_u64
     @inc = (initseq << 1) | 1
     next_u
-    @state += initstate
+    __next_unchecked {
+      @state += initstate
+    }
     next_u
   end
 
   def next_u
-    oldstate = @state
-    @state = oldstate * PCG_DEFAULT_MULTIPLIER_64 + @inc
-    xorshifted = UInt32.new(((oldstate >> 18) ^ oldstate) >> 27)
-    rot = UInt32.new(oldstate >> 59)
-    return UInt32.new((xorshifted >> rot) | (xorshifted << ((~rot + 1) & 31)))
+    __next_unchecked {
+      oldstate = @state
+      @state = oldstate * PCG_DEFAULT_MULTIPLIER_64 + @inc
+      xorshifted = UInt32.new(((oldstate >> 18) ^ oldstate) >> 27)
+      rot = UInt32.new(oldstate >> 59)
+      res = UInt32.new((xorshifted >> rot) | (xorshifted << ((~rot + 1) & 31)))
+      return res
+    }
   end
 
   def jump(delta)
-    deltau64 = UInt64.new(delta)
-    acc_mult = 1u64
-    acc_plus = 0u64
-    cur_plus = @inc
-    cur_mult = PCG_DEFAULT_MULTIPLIER_64
-    while (deltau64 > 0)
-      if deltau64 & 1 > 0
-        acc_mult *= cur_mult
-        acc_plus = acc_plus * cur_mult + cur_plus
+    __next_unchecked {
+      deltau64 = UInt64.new(delta)
+      acc_mult = 1u64
+      acc_plus = 0u64
+      cur_plus = @inc
+      cur_mult = PCG_DEFAULT_MULTIPLIER_64
+      while (deltau64 > 0)
+        if deltau64 & 1 > 0
+          acc_mult *= cur_mult
+          acc_plus = acc_plus * cur_mult + cur_plus
+        end
+        cur_plus = (cur_mult + 1) * cur_plus
+        cur_mult *= cur_mult
+        deltau64 /= 2
       end
-      cur_plus = (cur_mult + 1) * cur_plus
-      cur_mult *= cur_mult
-      deltau64 /= 2
-    end
-    @state = acc_mult * @state + acc_plus
+      @state = acc_mult * @state + acc_plus
+    }
   end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -497,7 +497,7 @@ class String
     if info.negative
       {% if max_negative %}
         return yield if info.value > {{max_negative}}
-        -info.value.to_{{method}}
+        __next_unchecked { 0.to_{{method}} - info.value.to_{{method}} }
       {% else %}
         return yield
       {% end %}
@@ -582,7 +582,9 @@ class String
       value *= base
 
       old = value
-      value += digit
+      __next_unchecked {
+        value += digit
+      }
       if value < old
         invalid = true
         break
@@ -2531,7 +2533,7 @@ class String
       {% if i != 1 %}
         byte = head_pointer.value
       {% end %}
-      hash = hash * PRIME_RK + pointer.value - pow * byte
+      hash = __next_unchecked { hash * PRIME_RK + pointer.value - pow * byte }
       pointer += 1
       head_pointer += 1
     {% end %}
@@ -2579,9 +2581,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.each_byte do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = __next_unchecked { search_hash * PRIME_RK + b }
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK.unchecked_pow search.bytesize
 
     # Find start index with offset
     char_index = 0
@@ -2608,7 +2610,7 @@ class String
     hash_end_pointer = pointer + search.bytesize
     return if hash_end_pointer > end_pointer
     while pointer < hash_end_pointer
-      hash = hash * PRIME_RK + pointer.value
+      hash = __next_unchecked { hash * PRIME_RK + pointer.value }
       pointer += 1
     end
 
@@ -2695,9 +2697,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.to_slice.reverse_each do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = __next_unchecked { search_hash * PRIME_RK + b }
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK.unchecked_pow search.bytesize
 
     hash = 0u32
     char_index = size
@@ -2715,7 +2717,7 @@ class String
       byte = pointer.value
       char_index -= 1 if (byte & 0xC0) != 0x80
 
-      hash = hash * PRIME_RK + byte
+      hash = __next_unchecked { hash * PRIME_RK + byte }
     end
 
     while true
@@ -2733,7 +2735,7 @@ class String
       char_index -= 1 if (byte & 0xC0) != 0x80
 
       # update a rolling hash of this text (haystack)
-      hash = hash * PRIME_RK + byte - pow * tail_pointer.value
+      hash = __next_unchecked { hash * PRIME_RK + byte - pow * tail_pointer.value }
     end
   end
 
@@ -2869,9 +2871,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.each_byte do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = __next_unchecked { search_hash * PRIME_RK + b }
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK.unchecked_pow search.bytesize
 
     # calculate a rolling hash of this text (haystack)
     pointer = head_pointer = to_unsafe + offset
@@ -2880,7 +2882,7 @@ class String
     hash = 0u32
     return if hash_end_pointer > end_pointer
     while pointer < hash_end_pointer
-      hash = hash * PRIME_RK + pointer.value
+      hash = __next_unchecked { hash * PRIME_RK + pointer.value }
       pointer += 1
     end
 
@@ -2893,7 +2895,7 @@ class String
       return if pointer >= end_pointer
 
       # update a rolling hash of this text (haystack)
-      hash = hash * PRIME_RK + pointer.value - pow * head_pointer.value
+      hash = __next_unchecked { hash * PRIME_RK + pointer.value - pow * head_pointer.value }
       pointer += 1
       head_pointer += 1
       offset += 1

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -109,7 +109,7 @@ struct Time::Span
     # "legal" (i.e. temporary) (e.g. if other parameters are negative) or
     # illegal (e.g. sign change).
     if days > 0
-      sd = SECONDS_PER_DAY.to_i64 * days
+      sd = __next_unchecked { SECONDS_PER_DAY.to_i64 * days }
       if sd < days
         overflow = true
       elsif s < 0
@@ -123,7 +123,7 @@ struct Time::Span
         overflow = s < 0
       end
     elsif days < 0
-      sd = SECONDS_PER_DAY.to_i64 * days
+      sd = __next_unchecked { SECONDS_PER_DAY.to_i64 * days }
       if sd > days
         overflow = true
       elsif s <= 0


### PR DESCRIPTION
This PR adds overflow to integer arithmetics, adds new language constructs to allow user 
to choose where overflowing (`checked`) or wrapping (`unchecked`) semantic is desired in a given _lexical_ scope. 

It also updates the STD where `unchecked` semantic is required. Or at least, where specs began to fail if run with `--overflow-checked`.

## Updates in the compiler options

There are two compiler options `--overflow-checked` and `--overflow-unchecked` to change the 
default overflow policy to be used. Currently the default is `--overflow-unchecked` to keep the current 
semantic and allow code to be updated more easily. In future versions I think the default should be `--overflow-checked` in favor of safety.

After building a crystal compiler you build with `--overflow-checked` option and run specs as follows.

```
$ ./bin/crystal foo.cr --overflow-checked
$ ./bin/crystal build foo.cr --overflow-checked
$ ./bin/crystal spec --overflow-checked
```

## Updates in the language

The operations affected by the overflow policy are only `+`,`-`,`*` between integers.

The new language constructs are:

```crystal
checked { <expr> }
unchecked { <expr> }
```

The type and value of the whole `[un]checked { <expr> }` matches the type and value of `<expr>` or it raise an `OverflowError`.

When an `OverflowError` is raised the location advertised by the exception is/should be the location of the operator that generate the overflow.

## Lexical Scope

The intention of using a lexical scope is that it would make as easy as possible to know how the operation is performed.

When compiled with `--overflow-checked`,

```crystal
def foo(v)
  unchecked { 
    # the * will not raise on overflow
    bar(v) * 2 
  }
end

def bar(v)
  # the + will raise on overflow
  v + 2
end
```

Regarding blocks the idea is the same, when compiled with `--overflow-unchecked`,

```crystal
def bar(v)
  # all operations here would be unchecked due to default policy
  yield v
end

def foo
  checked {
    bar(127_i8) do |v| 
      # Although the block is yielded from bar, the + is
      # performed as checked since it is written lexically
      # inside a checked section
      v + 1_i8
    end
  }
  1
rescue OverflowError
  0
end

foo # => 0
```

## Implementation details

Given that `+`,`-`,`*` for `Int` are primitives they are always inlined and the codegen stage knows what to do along the way.
It is easy to change the semantic of the operation give some context, in this case the lexical scope information.

The current behaviour and under the `unchecked` policy the `+` is translated to `add` IR.

```
def inc(v)
  v + 1
end
```

```
define i32 @"*inc<Int32>:Int32"(i32 %v) #0 {
entry:
  %0 = add i32 %v, 1
  ret i32 %0
}
```

Under the `checked` policy the `+` is translated to `llvm.sadd.with.overflow.*` a [LLVM with Overflow Intrinsics](https://llvm.org/docs/LangRef.html#arithmetic-with-overflow-intrinsics).

```
define i32 @"*inc<Int32>:Int32"(i32 %v) #0 {
entry:
  %0 = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %v, i32 1)
  %1 = extractvalue { i32, i1 } %0, 0
  %2 = extractvalue { i32, i1 } %0, 1
  br i1 %2, label %overflow, label %normal

overflow:                                         ; preds = %entry
  %3 = call %OverflowError* @"*OverflowError::new:OverflowError"()
  call void @"*raise<OverflowError>:NoReturn"(%OverflowError* %3)
  unreachable

normal:                                           ; preds = %entry
  ret i32 %1
}
```

Note: In both situations when the operands do not belong to the same type some expansion, truncation and additional checks for overflow are done. This is because the operation is carried on the "bigger" type, and the result is always translated to the type of the left operand. This is the current semantic.

## Limitations of the scopes

While developing the feature I came across two operations that would be nice to overflow along with `+`,`-`,`*`.

1. `Int#**(exponent : Int)`
2. `Int#-()`

This operation are not primitives as the others, but they are operators. I think it would be nicer if their overflow semantic is changed together with the current overflow scope policy.

Maybe for now, `Int#**(exponent : Int)` got its counterpart `Int#unchecked_pow(exponent : Int)` since the former will match the compiler policy that will eventually be checked.

The second one was used [in one single place](https://github.com/crystal-lang/crystal/blob/0.25.0/src/string.cr#L500) 
as `-info.value.to_{{method}}` and changed to `unchecked { 0.to_{{method}} - info.value.to_{{method}} }`.

These two cases are methods and they are not inlined, so the mechanism described in "Implementation details" does not longer apply.

If we want them to be affected by the overflow policy the possible paths to go are:

1. Make them `@[AlwaysInline]` and make the inline methods be affected by the policy.
2. Add another annotation to specify the method is affected by the overflow policy. If not inlined then the code gen should make the call to the `checked` or the `unchecked` version directly.

Inlining the `**` might not be that nice since it's ~10 lines and used it in many places. Adding the annotation seems a bit to much for a first round.

Another usage of forwarding the policy to other methods I can imagine is for example in matrix operations: If `*` is to be applied between matrices or matrix-scalar the user might have fine-grained control beyond the global policy (`--overflow-[un]checked`). But I found that either the packages always wrap silently or use floats.

So, all in all, up to here the only real candidate was `**`, hence the `unchecked_pow` method.

## Standard Library changes

As a migration technique a temporal macro `__next_unchecked` is added and should be replaced with `unchecked` on the release after merge.

These changes are marked as `Random: Mark required unchecked code blocks` or different std-lib sections. All of these change can be changed later specially Time and JSON. They are focused of keeping the current behavior mostly. In the case of Time, there was some manual overflow check.

All of these changes were pushed due to existing specs that failed otherwise.

## Pending

- [ ] Add `[un]checked do; end` notation also. I like that `{ }` fits better to be used inside expressions.
- [ ] Overflow on type casts (eg: `256.to_u8` should raise in checked context)
- [ ] Fix/Test some cases of variables shadowing if they are first declared in a `[un]checked` scope
- [ ] Fix/Test lexical scope and anonymous functions declaration
- [ ] Formatter (Same rules as method, but with the `OverflowCheckScope` ast node)
- [ ] Track highlighters to add the new keywords

Feedback is welcome