### PR TITLE
Macro: add missing document for ArrayLiteral#push and #unshift

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -610,6 +610,18 @@ module Crystal::Macros
     def []=(index : NumberLiteral, value : ASTNode)
     end
 
+    # Similar to `Array#unshift`.
+    def unshift : ArrayLiteral
+    end
+
+    # Similar to `Array#push`.
+    def push(value : ASTNode) : ArrayLiteral
+    end
+
+    # Similar to `Array#<<`.
+    def <<(value : ASTNode) : ArrayLiteral
+    end
+
     # Similar to `Array#+`.
     def +(other : ArrayLiteral) : ArrayLiteral
     end


### PR DESCRIPTION
Why are these methods hiding?