### PR TITLE
Handle File.extname edge case

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -312,6 +312,7 @@ describe "File" do
     File.extname(".test.cr.cz").should eq(".cz")
     File.extname("test").should eq("")
     File.extname("test.").should eq("")
+    File.extname("").should eq("")
   end
 
   it "constructs a path from parts" do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -297,18 +297,21 @@ describe "File" do
   end
 
   it "gets extname" do
+    File.extname("/foo/bar/a.cr").should eq(".cr")
     File.extname("/foo/bar/baz.cr").should eq(".cr")
     File.extname("/foo/bar/baz.cr.cz").should eq(".cz")
     File.extname("/foo/bar/.profile").should eq("")
     File.extname("/foo/bar/.profile.sh").should eq(".sh")
     File.extname("/foo/bar/foo.").should eq("")
     File.extname("/foo.bar/baz").should eq("")
+    File.extname("a.cr").should eq(".cr")
     File.extname("test.cr").should eq(".cr")
     File.extname("test.cr.cz").should eq(".cz")
     File.extname(".test").should eq("")
     File.extname(".test.cr").should eq(".cr")
     File.extname(".test.cr.cz").should eq(".cz")
     File.extname("test").should eq("")
+    File.extname("test.").should eq("")
   end
 
   it "constructs a path from parts" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -311,7 +311,7 @@ class File < IO::FileDescriptor
     # we are not at the beginning,
     # the previous char is not a '/',
     # and we have an extension
-    return filename.byte_slice(reader.pos + 1)
+    filename.byte_slice(reader.pos + 1)
   end
 
   # Converts *path* to an absolute path. Relative paths are

--- a/src/file.cr
+++ b/src/file.cr
@@ -299,11 +299,11 @@ class File < IO::FileDescriptor
     return "" unless reader.has_previous?
 
     # otherwise we are not at the beginning, and there is a previous char.
-    # if current is '/', then the patern is prefix/foo and has no extension
+    # if current is '/', then the pattern is prefix/foo and has no extension
     return "" if current_char == SEPARATOR
 
     # otherwise the current_char is '.'
-    # if previous is '/', then the patern is prefix/.foo  and has no extension
+    # if previous is '/', then the pattern is prefix/.foo  and has no extension
     return "" if reader.previous_char == SEPARATOR
 
     # So the current char is '.',

--- a/src/file.cr
+++ b/src/file.cr
@@ -283,6 +283,9 @@ class File < IO::FileDescriptor
     filename.check_no_null_byte
 
     bytes = filename.to_slice
+
+    return "" if bytes.empty?
+
     current = bytes.size - 1
 
     # if the pattern is foo. it has no extension

--- a/src/file.cr
+++ b/src/file.cr
@@ -288,8 +288,9 @@ class File < IO::FileDescriptor
     return "" if reader.current_char == '.'
 
     # position the reader at the last . or SEPARATOR
-    while (current_char = reader.current_char) &&
-          (current_char != SEPARATOR && current_char != '.') &&
+    # that is not the first char
+    while reader.current_char != SEPARATOR &&
+          reader.current_char != '.' &&
           reader.has_previous?
       reader.previous_char
     end
@@ -300,7 +301,7 @@ class File < IO::FileDescriptor
 
     # otherwise we are not at the beginning, and there is a previous char.
     # if current is '/', then the pattern is prefix/foo and has no extension
-    return "" if current_char == SEPARATOR
+    return "" if reader.current_char == SEPARATOR
 
     # otherwise the current_char is '.'
     # if previous is '/', then the pattern is prefix/.foo  and has no extension

--- a/src/file.cr
+++ b/src/file.cr
@@ -310,7 +310,7 @@ class File < IO::FileDescriptor
     # we are not at the beginning,
     # the previous char is not a '/',
     # and we have an extension
-    return filename[reader.pos + 1, filename.size - 1]
+    return filename.byte_slice(reader.pos + 1)
   end
 
   # Converts *path* to an absolute path. Relative paths are


### PR DESCRIPTION
Fix #6215. Isn't it nice how many ways it can be written?

#6216 and #6217 were closed before merging.

This PR took the approach of reverse iterating the string until . or separator is found and making all the decisions from there. Similar to what @straight-shoota did in #5635 as [Path#extension](https://github.com/crystal-lang/crystal/pull/5635/files#diff-1f0d7bff1de8f6f03579762d8e7f1d99R446) but with a more linear flow IMO.