### PR TITLE
add .new and .empty? to HTTP::Params

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -3,6 +3,10 @@ require "http/params"
 
 module HTTP
   describe Params do
+    describe ".new" do
+      Params.new.should eq(Params.parse(""))
+    end
+
     describe ".parse" do
       {
         {"", {} of String => Array(String)},
@@ -248,6 +252,14 @@ module HTTP
         expect_raises KeyError do
           params.fetch("foo")
         end
+      end
+    end
+
+    describe "#empty?" do
+      it "test empty?" do
+        Params.parse("foo=bar&foo=baz&baz=qux").empty?.should be_false
+        Params.parse("").empty?.should be_true
+        Params.new.empty?.should be_true
       end
     end
   end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -124,6 +124,11 @@ module HTTP
 
     protected getter raw_params
 
+    # Returns an empty `HTTP::Params`.
+    def initialize
+      @raw_params = {} of String => Array(String)
+    end
+
     def initialize(@raw_params : Hash(String, Array(String)))
     end
 
@@ -163,6 +168,14 @@ module HTTP
     # params.has_key?("garbage") # => false
     # ```
     delegate has_key?, to: raw_params
+
+    # Return `true` if params is empty.
+    #
+    # ```
+    # Params.new.empty?                              # => true
+    # Params.parse("foo=bar&foo=baz&qux=zoo").empty? # => false
+    # ```
+    delegate empty?, to: raw_params
 
     # Sets first *value* for specified param *name*.
     #


### PR DESCRIPTION
Add two new methods to `HTTP::Params`:

## self.new

```crystal
params = HTTP::Params.new # return same HTTP::Params.parse("") but faster
```

## empty?

Here is no simple way to check if not empty.

```crystal
params = HTTP::Params.new
params.empty?
```