### PR TITLE
Allow p! pp! macros to be used with tuples

### DIFF
--- a/spec/std/pp_spec.cr
+++ b/spec/std/pp_spec.cr
@@ -1,0 +1,15 @@
+require "spec"
+
+describe "p" do
+  it "can be used with tuples" do
+    typeof(p!({1, 2}))
+    typeof(p!({1, 2}, {3, 4}))
+  end
+end
+
+describe "pp" do
+  it "can be used with tuples" do
+    typeof(pp!({1, 2}))
+    typeof(pp!({1, 2}, {3, 4}))
+  end
+end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -136,7 +136,7 @@ macro pp!(*exps)
     {% exp = exps.first %}
     %prefix = "#{{{ exp.stringify }}} # => "
     ::print %prefix
-    ::pp {{exp}}
+    ::pp({{exp}})
   {% else %}
     %names = { {{*exps.map(&.stringify)}} }
     %max_size = %names.max_of &.size
@@ -145,7 +145,7 @@ macro pp!(*exps)
         begin
           %prefix = "#{%names[{{i}}].ljust(%max_size)} # => "
           ::print %prefix
-          ::pp {{exp}}
+          ::pp({{exp}})
         end,
       {% end %}
     }
@@ -170,7 +170,7 @@ macro p!(*exps)
     {% exp = exps.first %}
     %prefix = "#{{{ exp.stringify }}} # => "
     ::print %prefix
-    ::p {{exp}}
+    ::p({{exp}})
   {% else %}
     %names = { {{*exps.map(&.stringify)}} }
     %max_size = %names.max_of &.size
@@ -179,7 +179,7 @@ macro p!(*exps)
         begin
           %prefix = "#{%names[{{i}}].ljust(%max_size)} # => "
           ::print %prefix
-          ::p {{exp}}
+          ::p({{exp}})
         end,
       {% end %}
     }


### PR DESCRIPTION
Fix a regression introduced in #6044
Expression with tuples are not able to be used in `p!` and `pp!` macros in 0.25.0 but they were in 0.24

Some users will probably use `p!(foo, bar)` instead of `p!({foo, bar})` though. (But I am not one of those somehow...)