### PR TITLE
Docs: Prevent virtual types reaching docs generator

### DIFF
--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -5,7 +5,8 @@ class Crystal::Doc::Type
 
   getter type : Crystal::Type
 
-  def initialize(@generator : Generator, @type : Crystal::Type)
+  def initialize(@generator : Generator, type : Crystal::Type)
+    @type = type.devirtualize
   end
 
   def kind


### PR DESCRIPTION
Fixes #6201 

I was unable to reduce the code for a short repro. But somehow the `Lucky::Routeable` managed to produce some virtual types that were not handled in the docs generator.

Virtual types does not make sense in the doc generator since from the user perspective they are always substitutable by a subclass. That is what virtual types represent inside the compiler, while a type is an exact reference. This serves mainly during the codegen.

@paulcsmith, would you mind checking the the output is the expected one? The method that complained was `Lucky::Route#action` that was returning a virtual type of `Lucky::Action.class`