### PR TITLE
Corrected missing return value in the FileInfo flags method

### DIFF
--- a/src/crystal/system/unix/file_info.cr
+++ b/src/crystal/system/unix/file_info.cr
@@ -36,6 +36,7 @@ struct Crystal::System::FileInfo < ::File::Info
     flags |= ::File::Flags::SetUser if @stat.st_mode.bits_set? LibC::S_ISUID
     flags |= ::File::Flags::SetGroup if @stat.st_mode.bits_set? LibC::S_ISGID
     flags |= ::File::Flags::Sticky if @stat.st_mode.bits_set? LibC::S_ISVTX
+    flags
   end
 
   def modification_time : ::Time


### PR DESCRIPTION
Hey guys,

Reproduction of this problem I just discovered:

```
icr(0.25.0) > File.info("Zebra2_28_7422_Mac.zip").flags
Error in .icr_CTWDYWE1dyvsCD6uVxiy-Q.cr:17: instantiating '__icr_exec__()'

puts "|||YIH22hSkVQN|||#{__icr_exec__.inspect}"
                         ^~~~~~~~~~~~

in .icr_CTWDYWE1dyvsCD6uVxiy-Q.cr:12: instantiating 'Crystal::System::FileInfo#flags()'

  File.info("Zebra2_28_7422_Mac.zip").flags
                                      ^~~~~

in /usr/local/Cellar/crystal-lang/0.25.0/src/crystal/system/unix/file_info.cr:34: type must be File::Flags, not (File::Flags | Nil)

  def flags : ::File::Flags
      ^~~~~

Rerun with --error-trace to show a complete error trace.
```

This method was simply missing a return value.

Cheers
Fotis