### PR TITLE
Thread.allocate_stack: Pass MAP_STACK to mmap() on OpenBSD 6.3+

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -90,9 +90,13 @@ class Fiber
   end
 
   protected def self.allocate_stack
+    flags = LibC::MAP_PRIVATE | LibC::MAP_ANON
+    {% if flag?(:openbsd) && !flag?(:"openbsd6.2") %}
+      flags |= LibC::MAP_STACK
+    {% end %}
     @@stack_pool.pop? || LibC.mmap(nil, Fiber::STACK_SIZE,
       LibC::PROT_READ | LibC::PROT_WRITE,
-      LibC::MAP_PRIVATE | LibC::MAP_ANON,
+      flags,
       -1, 0
     ).tap do |pointer|
       raise Errno.new("Cannot allocate new fiber stack") if pointer == LibC::MAP_FAILED

--- a/src/lib_c/amd64-unknown-openbsd/c/sys/mman.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sys/mman.cr
@@ -11,11 +11,12 @@ lib LibC
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
   MAP_FAILED            = Pointer(Void).new(-1)
-  POSIX_MADV_DONTNEED   = 4
-  POSIX_MADV_NORMAL     = 0
-  POSIX_MADV_RANDOM     = 1
-  POSIX_MADV_SEQUENTIAL = 2
-  POSIX_MADV_WILLNEED   = 3
+  MAP_STACK             = 0x4000
+  POSIX_MADV_DONTNEED   =      4
+  POSIX_MADV_NORMAL     =      0
+  POSIX_MADV_RANDOM     =      1
+  POSIX_MADV_SEQUENTIAL =      2
+  POSIX_MADV_WILLNEED   =      3
   MADV_DONTNEED         = LibC::POSIX_MADV_DONTNEED
   MADV_NORMAL           = LibC::POSIX_MADV_NORMAL
   MADV_RANDOM           = LibC::POSIX_MADV_RANDOM


### PR DESCRIPTION
This is required as of OpenBSD 6.3.