### PR TITLE
Use Exception#inspect_with_backtrace where sensible

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -115,11 +115,7 @@ class Crystal::Command
   rescue ex : OptionParser::Exception
     error ex.message
   rescue ex
-    STDERR.puts ex
-    ex.backtrace.each do |frame|
-      STDERR.puts frame
-    end
-    STDERR.puts
+    ex.inspect_with_backtrace STDERR
     error "you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues"
   end
 

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -82,15 +82,10 @@ module Spec
             end
             puts
 
-            ex.to_s.split('\n').each do |line|
+            message = ex.is_a?(AssertionFailed) ? ex.to_s : ex.inspect_with_backtrace
+            message.split('\n').each do |line|
               print "       "
               puts Spec.color(line, :error)
-            end
-            unless ex.is_a?(AssertionFailed)
-              ex.backtrace.each do |trace|
-                print "       "
-                puts Spec.color(trace, :error)
-              end
             end
 
             if ex.is_a?(AssertionFailed)


### PR DESCRIPTION
"you've found a bug" error messages are currently formatted a bit weird, this fixes it. Also gives us showing the type of the exception for free.

Same with `Spec`.