### PR TITLE
IO#write: return early if slice is empty

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -13,14 +13,13 @@ module Crystal::System::FileDescriptor
   end
 
   private def unbuffered_write(slice : Bytes)
-    loop do
+    until slice.empty?
       bytes_written = LibC._write(@fd, slice, slice.size)
       if bytes_written == -1
         raise Errno.new("Error writing file")
       end
 
       slice += bytes_written
-      return if slice.size == 0
     end
   end
 

--- a/src/flate/writer.cr
+++ b/src/flate/writer.cr
@@ -48,6 +48,8 @@ class Flate::Writer < IO
   def write(slice : Bytes)
     check_open
 
+    return if slice.empty?
+
     @stream.avail_in = slice.size
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH

--- a/src/gzip/writer.cr
+++ b/src/gzip/writer.cr
@@ -68,6 +68,8 @@ class Gzip::Writer < IO
   def write(slice : Bytes) : Nil
     check_open
 
+    return if slice.empty?
+
     flate_io = write_header
     flate_io.write(slice)
 

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -63,6 +63,8 @@ class HTTP::Server
 
     # See `IO#write(slice)`.
     def write(slice : Bytes)
+      return if slice.empty?
+
       @output.write(slice)
     end
 
@@ -159,6 +161,8 @@ class HTTP::Server
       end
 
       private def unbuffered_write(slice : Bytes)
+        return if slice.empty?
+
         unless response.wrote_headers?
           if response.version != "HTTP/1.0" && !response.headers.has_key?("Content-Length")
             response.headers["Transfer-Encoding"] = "chunked"

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -50,6 +50,8 @@ class HTTP::WebSocket::Protocol
     end
 
     def write(slice : Bytes)
+      return if slice.empty?
+
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.pointer(count), count)
       @pos += count

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -113,6 +113,8 @@ module IO::Buffered
   def write(slice : Bytes)
     check_open
 
+    return if slice.empty?
+
     count = slice.size
 
     if sync?

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -33,6 +33,8 @@ class IO::Hexdump < IO
   end
 
   def write(buf : Bytes)
+    return if buf.empty?
+
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write
     end

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -32,6 +32,8 @@ class IO::MultiWriter < IO
   def write(slice : Bytes)
     check_open
 
+    return if slice.empty?
+
     @writers.each { |writer| writer.write(slice) }
   end
 

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -68,6 +68,8 @@ class IO::Stapled < IO
   def write(slice : Bytes) : Nil
     check_open
 
+    return if slice.empty?
+
     @writer.write(slice)
   end
 

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -43,6 +43,8 @@ module OpenSSL
     end
 
     def write(slice : Bytes)
+      return if slice.empty?
+
       if @mode.write?
         digest_algorithm.update(slice)
       end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -107,6 +107,8 @@ abstract class OpenSSL::SSL::Socket < IO
   def unbuffered_write(slice : Bytes)
     check_open
 
+    return if slice.empty?
+
     count = slice.size
     bytes = LibSSL.ssl_write(@ssl, slice.pointer(count), count)
     unless bytes > 0

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -39,6 +39,8 @@ class String::Builder < IO
   end
 
   def write(slice : Bytes)
+    return if slice.empty?
+
     count = slice.size
     new_bytesize = real_bytesize + count
     if new_bytesize > @capacity

--- a/src/zip/checksum_writer.cr
+++ b/src/zip/checksum_writer.cr
@@ -14,6 +14,8 @@ module Zip
     end
 
     def write(slice : Bytes)
+      return if slice.empty?
+
       @count += slice.size
       @crc32 = CRC32.update(slice, @crc32) if @compute_crc32
       io.write(slice)

--- a/src/zlib/writer.cr
+++ b/src/zlib/writer.cr
@@ -47,6 +47,8 @@ class Zlib::Writer < IO
   def write(slice : Bytes) : Nil
     check_open
 
+    return if slice.empty?
+
     write_header unless @wrote_header
 
     @flate_io.write(slice)


### PR DESCRIPTION
Fixes #6268

Writing an empty slice should do nothing, so this PR adds this check to return early in that case. Fixes that case for OpenSSL socket, but also for others (no tests included because it's a bit hard to test, but the change isn't that complex).