### PR TITLE
Remove singular names like Int#day, Int#month, etc.

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1122,7 +1122,7 @@ describe "File" do
         File.touch(path)
 
         info = File.info(path)
-        info.modification_time.should be_close(Time.now, 1.second)
+        info.modification_time.should be_close(Time.now, 1.seconds)
       end
     end
 

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -160,7 +160,7 @@ module HTTP
     it "tests read_timeout" do
       TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
-        client.read_timeout = 1.second
+        client.read_timeout = 1.seconds
         client.get("/")
       end
 

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -47,7 +47,7 @@ describe HTTP::StaticFileHandler do
 
     it "returns 304 Not Modified if file mtime is older" do
       headers = HTTP::Headers.new
-      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time + 1.hour)
+      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time + 1.hours)
       response = handle HTTP::Request.new("GET", "/test.txt", headers), ignore_body: true
 
       response.status_code.should eq(304)
@@ -55,7 +55,7 @@ describe HTTP::StaticFileHandler do
 
     it "serves file if file mtime is younger" do
       headers = HTTP::Headers.new
-      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time - 1.hour)
+      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time - 1.hours)
       response = handle HTTP::Request.new("GET", "/test.txt", headers), ignore_body: false
 
       response.status_code.should eq(200)
@@ -88,7 +88,7 @@ describe HTTP::StaticFileHandler do
       initial_response = handle HTTP::Request.new("GET", "/test.txt")
 
       headers = HTTP::Headers.new
-      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time - 1.hour)
+      headers["If-Modified-Since"] = HTTP.format_time(File.info(datapath("static_file_handler", "test.txt")).modification_time - 1.hours)
       headers["If-None-Match"] = initial_response.headers["Etag"]
       response = handle HTTP::Request.new("GET", "/test.txt", headers), ignore_body: true
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1644,7 +1644,7 @@ describe "String" do
     ("%A" % 12345678.45).should eq("0X1.78C29CE666666P+23")
     ("%100.50g" % 123.45).should eq("                                                  123.4500000000000028421709430404007434844970703125")
 
-    span = 1.second
+    span = 1.seconds
     ("%s" % span).should eq(span.to_s)
 
     ("%.2f" % 2.536_f32).should eq("2.54")

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -235,7 +235,7 @@ class Time::Location
           location = Location.load("Europe/Berlin")
           time = Time.utc(2017, 10, 29, 1, 0, 0)
 
-          summer = location.lookup(time - 1.second)
+          summer = location.lookup(time - 1.seconds)
           summer.name.should eq "CEST"
           summer.offset.should eq 2 * SECONDS_PER_HOUR
           summer.dst?.should be_true
@@ -245,7 +245,7 @@ class Time::Location
           winter.offset.should eq 1 * SECONDS_PER_HOUR
           winter.dst?.should be_false
 
-          last_ns = location.lookup(time - 1.nanosecond)
+          last_ns = location.lookup(time - 1.nanoseconds)
           last_ns.name.should eq "CEST"
           last_ns.offset.should eq 2 * SECONDS_PER_HOUR
           last_ns.dst?.should be_true

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -221,7 +221,7 @@ describe Time::Span do
     ratio = 20.minutes / 15.seconds
     ratio.should eq(80.0)
 
-    ratio2 = 45.seconds / 1.minute
+    ratio2 = 45.seconds / 1.minutes
     ratio2.should eq(0.75)
   end
 
@@ -251,7 +251,7 @@ describe Time::Span do
   end
 
   it "should sum" do
-    [1.second, 5.seconds].sum.should eq(6.seconds)
+    [1.seconds, 5.seconds].sum.should eq(6.seconds)
   end
 
   it "test zero?" do

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -103,7 +103,7 @@ describe Time do
     # NOTE: On some systems, the sleep may not always wait for 1ms and the fiber
     #       be resumed early. We thus merely test that the method returns a
     #       positive time span.
-    elapsed = Time.measure { sleep 1.millisecond }
+    elapsed = Time.measure { sleep 1.milliseconds }
     elapsed.should be >= 0.seconds
   end
 
@@ -225,28 +225,25 @@ describe Time do
 
   it "add months" do
     t = Time.utc 2014, 10, 30, 21, 18, 13
-    t2 = t + 1.month
-    t2.to_s.should eq("2014-11-30 21:18:13 UTC")
-
     t2 = t + 1.months
     t2.to_s.should eq("2014-11-30 21:18:13 UTC")
 
     t = Time.utc 2014, 10, 31, 21, 18, 13
-    t2 = t + 1.month
+    t2 = t + 1.months
     t2.to_s.should eq("2014-11-30 21:18:13 UTC")
 
     t = Time.utc 2014, 10, 31, 21, 18, 13
-    t2 = t - 1.month
+    t2 = t - 1.months
     t2.to_s.should eq("2014-09-30 21:18:13 UTC")
 
     t = Time.utc 2014, 10, 31, 21, 18, 13
-    t2 = t + 6.month
+    t2 = t + 6.months
     t2.to_s.should eq("2015-04-30 21:18:13 UTC")
   end
 
   it "add years" do
     t = Time.utc 2014, 10, 30, 21, 18, 13
-    t2 = t + 1.year
+    t2 = t + 1.years
     t2.to_s.should eq("2015-10-30 21:18:13 UTC")
 
     t = Time.utc 2014, 10, 30, 21, 18, 13
@@ -335,8 +332,8 @@ describe Time do
   end
 
   it "current time is similar in differnt locations" do
-    (Time.now - Time.utc_now).should be_close(0.seconds, 1.second)
-    (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.second)
+    (Time.now - Time.utc_now).should be_close(0.seconds, 1.seconds)
+    (Time.now - Time.now(Time::Location.fixed(1234))).should be_close(0.seconds, 1.seconds)
   end
 
   describe "#to_s" do
@@ -898,15 +895,10 @@ describe Time do
 
   it "does time span units" do
     1.nanoseconds.should eq(Time::Span.new(nanoseconds: 1))
-    1.millisecond.should eq(1_000_000.nanoseconds)
     1.milliseconds.should eq(1_000_000.nanoseconds)
-    1.second.should eq(1000.milliseconds)
     1.seconds.should eq(1000.milliseconds)
-    1.minute.should eq(60.seconds)
     1.minutes.should eq(60.seconds)
-    1.hour.should eq(60.minutes)
     1.hours.should eq(60.minutes)
-    1.week.should eq(7.days)
     2.weeks.should eq(14.days)
   end
 
@@ -1028,10 +1020,10 @@ describe Time do
   end
 
   typeof(Time.now.year)
-  typeof(1.minute.from_now.year)
-  typeof(1.minute.ago.year)
-  typeof(1.month.from_now.year)
-  typeof(1.month.ago.year)
+  typeof(1.minutes.from_now.year)
+  typeof(1.minutes.ago.year)
+  typeof(1.months.from_now.year)
+  typeof(1.months.ago.year)
   typeof(Time.now.to_utc)
   typeof(Time.now.to_local)
 end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -111,7 +111,7 @@ class HTTP::StaticFileHandler
       # An exact comparison might be slightly off, so we add 1s padding.
       # Static files should generally not be modified in subsecond intervals, so this is perfectly safe.
       # This might be replaced by a more sophisticated time comparison when it becomes available.
-      !!(header_time && last_modified <= header_time + 1.second)
+      !!(header_time && last_modified <= header_time + 1.seconds)
     else
       false
     end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -389,19 +389,9 @@ struct Time::Span
 end
 
 struct Int
-  # :nodoc:
-  def week : Time::Span
-    weeks
-  end
-
   # Returns a `Time::Span` of `self` weeks.
   def weeks : Time::Span
     Time::Span.new 7 * self, 0, 0, 0
-  end
-
-  # :nodoc:
-  def day : Time::Span
-    days
   end
 
   # Returns a `Time::Span` of `self` days.
@@ -409,19 +399,9 @@ struct Int
     Time::Span.new self, 0, 0, 0
   end
 
-  # :nodoc:
-  def hour : Time::Span
-    hours
-  end
-
   # Returns a `Time::Span` of `self` hours.
   def hours : Time::Span
     Time::Span.new self, 0, 0
-  end
-
-  # :nodoc:
-  def minute : Time::Span
-    minutes
   end
 
   # Returns a `Time::Span` of `self` minutes.
@@ -429,29 +409,14 @@ struct Int
     Time::Span.new 0, self, 0
   end
 
-  # :nodoc:
-  def second : Time::Span
-    seconds
-  end
-
   # Returns a `Time::Span` of `self` seconds.
   def seconds : Time::Span
     Time::Span.new 0, 0, self
   end
 
-  # :nodoc:
-  def millisecond : Time::Span
-    milliseconds
-  end
-
   # Returns a `Time::Span` of `self` milliseconds.
   def milliseconds : Time::Span
     Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND)
-  end
-
-  # :nodoc:
-  def nanosecond : Time::Span
-    nanoseconds
   end
 
   # Returns a `Time::Span` of `self` nanoseconds.
@@ -537,19 +502,9 @@ struct Time::MonthSpan
 end
 
 struct Int
-  # :nodoc:
-  def month : Time::MonthSpan
-    months
-  end
-
   # Returns a `Time::MonthSpan` of `self` months.
   def months : Time::MonthSpan
     Time::MonthSpan.new(self)
-  end
-
-  # :nodoc:
-  def year : Time::MonthSpan
-    years
   end
 
   # Returns a `Time::MonthSpan` of `self` years.


### PR DESCRIPTION
It seems in https://github.com/crystal-lang/crystal/pull/5093#discussion_r144641009 it was decided to remove these aliases. At that time they were marked as `:nodoc:`, not sure why, but it's better to remove them as soon as possible.