### PR TITLE
Don't define `to_json` and `self.from_json` on Object

### DIFF
--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -1,33 +1,3 @@
-# Deserializes the given JSON in *string_or_io* into
-# an instance of `self`. This simply creates a `parser = JSON::PullParser`
-# and invokes `new(parser)`: classes that want to provide JSON
-# deserialization must provide an `def initialize(parser : JSON::PullParser)`
-# method.
-#
-# ```
-# Int32.from_json("1")                # => 1
-# Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
-# ```
-def Object.from_json(string_or_io) : self
-  parser = JSON::PullParser.new(string_or_io)
-  new parser
-end
-
-# Deserializes the given JSON in *string_or_io* into
-# an instance of `self`, assuming the JSON consists
-# of an JSON object with key *root*, and whose value is
-# the value to deserialize.
-#
-# ```
-# Int32.from_json(%({"main": 1}), root: "main") # => 1
-# ```
-def Object.from_json(string_or_io, root : String) : self
-  parser = JSON::PullParser.new(string_or_io)
-  parser.on_key!(root) do
-    new parser
-  end
-end
-
 # Parses a `String` or `IO` denoting a JSON array, yielding
 # each of its elements to the given block. This is useful
 # for decoding an array and processing its elements without

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -1,66 +1,56 @@
-class Object
-  def to_json
-    String.build do |str|
-      to_json str
-    end
-  end
-
-  def to_json(io : IO)
-    JSON.build(io) do |json|
-      to_json(json)
-    end
-  end
-
-  def to_pretty_json(indent : String = "  ")
-    String.build do |str|
-      to_pretty_json str, indent: indent
-    end
-  end
-
-  def to_pretty_json(io : IO, indent : String = "  ")
-    JSON.build(io, indent: indent) do |json|
-      to_json(json)
-    end
-  end
-end
+require "./serialization"
 
 struct Nil
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.null
   end
 end
 
 struct Bool
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.bool(self)
   end
 end
 
 struct Int
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.number(self)
   end
 end
 
 struct Float
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.number(self)
   end
 end
 
 class String
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.string(self)
   end
 end
 
 struct Symbol
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.string(to_s)
   end
 end
 
 class Array
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.array do
       each &.to_json(json)
@@ -69,6 +59,8 @@ class Array
 end
 
 struct Set
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.array do
       each &.to_json(json)
@@ -77,6 +69,8 @@ struct Set
 end
 
 class Hash
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.object do
       each do |key, value|
@@ -89,6 +83,8 @@ class Hash
 end
 
 struct Tuple
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.array do
       {% for i in 0...T.size %}
@@ -99,6 +95,8 @@ struct Tuple
 end
 
 struct NamedTuple
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.object do
       {% for key in T.keys %}
@@ -111,18 +109,24 @@ struct NamedTuple
 end
 
 struct Time::Format
+  include JSON::Serializable
+
   def to_json(value : Time, json : JSON::Builder)
     format(value).to_json(json)
   end
 end
 
 struct Enum
+  include JSON::Serializable
+
   def to_json(json : JSON::Builder)
     json.number(value)
   end
 end
 
 struct Time
+  include JSON::Serializable
+
   # Emits a string formated according to [RFC 3339](https://tools.ietf.org/html/rfc3339)
   # ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   #


### PR DESCRIPTION
Fixes #5695

As the title says, this removes `to_json` and `self.from_json` from `Object` and moves it to `JSON::Serializable`. For the class method (`self.from_json`) I had to define a module that gets extened on inclusion.

Then, `JSON::Serializable` is included on primitive types, `Hash`, `Array`, `Set`, etc. They of course override the `to_json` and `self.from_json` methods.

In that way, you can't invoke `to_json` on a method and get a strange compile error saying "undefined method `to_json(io)`", now you'll get a better error saying `undefined method `to_json`".

You could also check if a type `is_a?(JSON::Serializable)` or `responds_to?(:to_json)`, and so on.

If this direction is accepted, I can later add another commit with the same change for YAML.