### PR TITLE
Show line numbers at link when there are filename duplicates in "Defined in:" section (docs)

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -360,7 +360,13 @@ class Crystal::Doc::Generator
     filename[@base_dir.size..-1]
   end
 
-  record RelativeLocation, filename : String, line_number : Int32, url : String?, show_line_number : Bool do
+  class RelativeLocation
+    property show_line_number
+    getter filename, line_number, url
+
+    def initialize(@filename : String, @line_number : Int32, @url : String?, @show_line_number : Bool)
+    end
+
     def to_json(builder : JSON::Builder)
       builder.object do
         builder.field "filename", filename
@@ -387,12 +393,12 @@ class Crystal::Doc::Generator
       filename = filename[1..-1] if filename.starts_with? File::SEPARATOR
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
-      show_line_number = false
-      locations.each_with_index do |location, i|
+      show_line_number = locations.any? do |location|
         if location.filename == filename
-          locations[i] = location.copy_with(show_line_number: true)
-          show_line_number = true
-          break
+          location.show_line_number = true
+          true
+        else
+          false
         end
       end
 

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -360,12 +360,13 @@ class Crystal::Doc::Generator
     filename[@base_dir.size..-1]
   end
 
-  record RelativeLocation, filename : String, line_number : Int32, url : String? do
+  record RelativeLocation, filename : String, line_number : Int32, url : String?, duplicate : Bool do
     def to_json(builder : JSON::Builder)
       builder.object do
         builder.field "filename", filename
         builder.field "line_number", line_number
         builder.field "url", url
+        builder.field "duplicate", duplicate
       end
     end
   end
@@ -386,8 +387,10 @@ class Crystal::Doc::Generator
       filename = filename[1..-1] if filename.starts_with? File::SEPARATOR
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
-      locations << RelativeLocation.new(filename, location.line_number, url)
+      duplicate = locations.any? { |location| location.filename == filename }
+
+      locations << RelativeLocation.new(filename, location.line_number, url, duplicate)
     end
-    locations.uniq { |location| location.filename }
+    locations
   end
 end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -368,7 +368,6 @@ class Crystal::Doc::Generator
         builder.field "filename", filename
         builder.field "line_number", line_number
         builder.field "url", url
-        builder.field "show_line_number", show_line_number
       end
     end
   end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -360,8 +360,12 @@ class Crystal::Doc::Generator
     filename[@base_dir.size..-1]
   end
 
-  record RelativeLocation, filename : String, line_number : Int32, url : String?, show_line_number : Bool do
+  class RelativeLocation
     setter show_line_number
+    getter filename, line_number, url, show_line_number
+
+    def initialize(@filename : String, @line_number : Int32, @url : String?, @show_line_number : Bool)
+    end
 
     def to_json(builder : JSON::Builder)
       builder.object do
@@ -371,6 +375,7 @@ class Crystal::Doc::Generator
       end
     end
   end
+
   SRC_SEP = "src#{File::SEPARATOR}"
 
   def relative_locations(type)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -388,6 +388,6 @@ class Crystal::Doc::Generator
 
       locations << RelativeLocation.new(filename, location.line_number, url)
     end
-    locations
+    locations.uniq { |location| location.filename }
   end
 end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -361,8 +361,8 @@ class Crystal::Doc::Generator
   end
 
   class RelativeLocation
-    setter show_line_number
-    getter filename, line_number, url, show_line_number
+    property show_line_number
+    getter filename, line_number, url
 
     def initialize(@filename : String, @line_number : Int32, @url : String?, @show_line_number : Bool)
     end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -360,13 +360,15 @@ class Crystal::Doc::Generator
     filename[@base_dir.size..-1]
   end
 
-  record RelativeLocation, filename : String, line_number : Int32, url : String?, duplicate : Bool do
+  record RelativeLocation, filename : String, line_number : Int32, url : String?, show_line_number : Bool do
+    setter show_line_number
+
     def to_json(builder : JSON::Builder)
       builder.object do
         builder.field "filename", filename
         builder.field "line_number", line_number
         builder.field "url", url
-        builder.field "duplicate", duplicate
+        builder.field "show_line_number", show_line_number
       end
     end
   end
@@ -387,9 +389,16 @@ class Crystal::Doc::Generator
       filename = filename[1..-1] if filename.starts_with? File::SEPARATOR
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
-      duplicate = locations.any? { |location| location.filename == filename }
+      show_line_number = locations.any? do |location|
+        if location.filename == filename
+          location.show_line_number = true
+          true
+        else
+          false
+        end
+      end
 
-      locations << RelativeLocation.new(filename, location.line_number, url, duplicate)
+      locations << RelativeLocation.new(filename, location.line_number, url, show_line_number)
     end
     locations
   end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -360,13 +360,7 @@ class Crystal::Doc::Generator
     filename[@base_dir.size..-1]
   end
 
-  class RelativeLocation
-    property show_line_number
-    getter filename, line_number, url
-
-    def initialize(@filename : String, @line_number : Int32, @url : String?, @show_line_number : Bool)
-    end
-
+  record RelativeLocation, filename : String, line_number : Int32, url : String?, show_line_number : Bool do
     def to_json(builder : JSON::Builder)
       builder.object do
         builder.field "filename", filename
@@ -393,12 +387,12 @@ class Crystal::Doc::Generator
       filename = filename[1..-1] if filename.starts_with? File::SEPARATOR
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
-      show_line_number = locations.any? do |location|
+      show_line_number = false
+      locations.each_with_index do |location, i|
         if location.filename == filename
-          location.show_line_number = true
-          true
-        else
-          false
+          locations[i] = location.copy_with(show_line_number: true)
+          show_line_number = true
+          break
         end
       end
 

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -47,6 +47,9 @@
     <% else %>
       <%= location.filename %>
     <% end %>
+    <% if location.duplicate %>
+      (line <%= location.line_number %>)
+    <% end %>
     <br/>
   <% end %>
 <% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -47,8 +47,8 @@
     <% else %>
       <%= location.filename %>
     <% end %>
-    <% if location.duplicate %>
-      (line <%= location.line_number %>)
+    <% if location.show_line_number %>
+      :<%= location.line_number %>
     <% end %>
     <br/>
   <% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -43,12 +43,17 @@
   <h2>Defined in:</h2>
   <% locations.each do |location| %>
     <% if url = location.url %>
-      <a href="<%= url %>#L<%= location.line_number %>" target="_blank"><%= location.filename %></a>
+      <a href="<%= url %>#L<%= location.line_number %>" target="_blank">
+        <%= location.filename %>
+        <% if location.show_line_number %>
+          :<%= location.line_number %>
+        <% end %>
+      </a>
     <% else %>
       <%= location.filename %>
-    <% end %>
-    <% if location.show_line_number %>
-      :<%= location.line_number %>
+      <% if location.show_line_number %>
+        :<%= location.line_number %>
+      <% end %>
     <% end %>
     <br/>
   <% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -44,16 +44,10 @@
   <% locations.each do |location| %>
     <% if url = location.url %>
       <a href="<%= url %>#L<%= location.line_number %>" target="_blank">
-        <%= location.filename %>
-        <% if location.show_line_number %>
-          :<%= location.line_number %>
-        <% end %>
+        <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
       </a>
     <% else %>
-      <%= location.filename %>
-      <% if location.show_line_number %>
-        :<%= location.line_number %>
-      <% end %>
+      <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
     <% end %>
     <br/>
   <% end %>

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -790,7 +790,7 @@ class Crystal::Doc::Type
           ancestors.each &.to_json_simple(builder)
         end
       end
-      builder.field "locations", locations.uniq! { |location| location.filename }
+      builder.field "locations", locations
       builder.field "repository_name", repository_name
       builder.field "program", program?
       builder.field "enum", enum?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -790,7 +790,7 @@ class Crystal::Doc::Type
           ancestors.each &.to_json_simple(builder)
         end
       end
-      builder.field "locations", locations
+      builder.field "locations", locations.uniq! { |location| location.filename }
       builder.field "repository_name", repository_name
       builder.field "program", program?
       builder.field "enum", enum?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -655,7 +655,7 @@ module Crystal
     # Adds a location to this type.
     def add_location(location : Location)
       locations = @locations ||= [] of Location
-      # The `unless` prevents that identical links are being generated in the "Defined in:" section in the docs
+      # The `unless` prevents that identical links are being generated in the "Defined in:" section in the docs because of macros
       locations << location unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -655,7 +655,8 @@ module Crystal
     # Adds a location to this type.
     def add_location(location : Location)
       locations = @locations ||= [] of Location
-      locations << location # unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
+      # The `unless` prevents that identical links are being generated in the "Defined in:" section in the docs
+      locations << location unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
     end
 
     getter(types) { {} of String => NamedType }

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -655,7 +655,7 @@ module Crystal
     # Adds a location to this type.
     def add_location(location : Location)
       locations = @locations ||= [] of Location
-      locations << location
+      locations << location unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
     end
 
     getter(types) { {} of String => NamedType }

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -655,7 +655,7 @@ module Crystal
     # Adds a location to this type.
     def add_location(location : Location)
       locations = @locations ||= [] of Location
-      locations << location unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
+      locations << location # unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
     end
 
     getter(types) { {} of String => NamedType }


### PR DESCRIPTION
For example this **Defined in:** section example:

---

## Defined in:
[colorize.cr](https://github.com/crystal-lang/crystal/blob/7fb783f7afec0a199d6f22ef78aae0f45517068a/src/colorize.cr#L79)
[colorize.cr](https://github.com/crystal-lang/crystal/blob/7fb783f7afec0a199d6f22ef78aae0f45517068a/src/colorize.cr#L126)
[foo.cr](foo)
[bar.cr](bar)

---

Would change to this:

---

## Defined in:
[colorize.cr:79](https://github.com/crystal-lang/crystal/blob/7fb783f7afec0a199d6f22ef78aae0f45517068a/src/colorize.cr#L79)
[colorize.cr:126](https://github.com/crystal-lang/crystal/blob/7fb783f7afec0a199d6f22ef78aae0f45517068a/src/colorize.cr#L126)
[foo.cr](foo)
[bar.cr](bar)

---

for more readability.

And this PR also fixes identical link generations like in the **Defined in:** section of [Float32](https://crystal-lang.org/api/0.25.0/Float32.html) where the two [primitives.cr](https://github.com/crystal-lang/crystal/blob/7fb783f7afec0a199d6f22ef78aae0f45517068a/src/primitives.cr#L269) links lead to the same line and file because of macros.