### PR TITLE
Correctly parse \A (and others) inside %r{...} inside macros

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1380,6 +1380,11 @@ module Crystal
 
     it_parses "foo.Bar", Call.new("foo".call, "Bar")
 
+    it_parses "{% begin %}%r(\\A){% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r(\\A)"))
+    it_parses "{% begin %}%r[\\A]{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r[\\A]"))
+    it_parses "{% begin %}%r<\\A>{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r<\\A>"))
+    it_parses "{% begin %}%r{\\A}{% end %}", MacroIf.new(true.bool, Expressions.new([MacroLiteral.new("%r"), MacroLiteral.new("{\\A}")] of ASTNode))
+
     assert_syntax_error "return do\nend", "unexpected token: do"
 
     %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1380,10 +1380,11 @@ module Crystal
 
     it_parses "foo.Bar", Call.new("foo".call, "Bar")
 
-    it_parses "{% begin %}%r(\\A){% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r(\\A)"))
-    it_parses "{% begin %}%r[\\A]{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r[\\A]"))
-    it_parses "{% begin %}%r<\\A>{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r<\\A>"))
-    it_parses "{% begin %}%r{\\A}{% end %}", MacroIf.new(true.bool, Expressions.new([MacroLiteral.new("%r"), MacroLiteral.new("{\\A}")] of ASTNode))
+    [{'(', ')'}, {'[', ']'}, {'<', '>'}, {'{', '}'}, {'|', '|'}].each do |open, close|
+      it_parses "{% begin %}%r#{open}\\A#{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r#{open}\\A#{close}"))
+      it_parses "{% begin %}%#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%#{open} %s #{close}"))
+      it_parses "{% begin %}%q#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%q#{open} %s #{close}"))
+    end
 
     assert_syntax_error "return do\nend", "unexpected token: do"
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2130,6 +2130,9 @@ module Crystal
         if char == 'q' && (peek = peek_next_char) && {'(', '<', '[', '{'}.includes?(peek)
           next_char
           delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
+        elsif char == 'r' && (peek = peek_next_char) && {'(', '<', '[', '{'}.includes?(peek)
+          next_char
+          delimiter_state = Token::DelimiterState.new(:regex, char, closing_char, 1)
         else
           start = current_pos
           while ident_part?(char)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2127,12 +2127,14 @@ module Crystal
 
       if !delimiter_state && current_char == '%' && ident_start?(peek_next_char)
         char = next_char
-        if char == 'q' && (peek = peek_next_char) && {'(', '<', '[', '{'}.includes?(peek)
+        if char == 'q' && (peek = peek_next_char) && {'(', '<', '[', '{', '|'}.includes?(peek)
           next_char
           delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
-        elsif char == 'r' && (peek = peek_next_char) && {'(', '<', '[', '{'}.includes?(peek)
+          next_char
+        elsif char == 'r' && (peek = peek_next_char) && {'(', '<', '[', '{', '|'}.includes?(peek)
           next_char
           delimiter_state = Token::DelimiterState.new(:regex, char, closing_char, 1)
+          next_char
         else
           start = current_pos
           while ident_part?(char)
@@ -2199,7 +2201,7 @@ module Crystal
           whitespace = false
         when '%'
           case char = peek_next_char
-          when '(', '[', '<', '{'
+          when '(', '[', '<', '{', '|'
             next_char
             delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
           else


### PR DESCRIPTION
Hopefully fixes #6180 (let's see what CI says)

The first commit fixes the direct issue: `%r(...)` is being confused inside macros with a macro var `%r`... choosing `%` as the start of a macro var was an unfortunate decision...

The second commit fixes a few other things:
- `|` was missing as a delimiter in a few places (it might be worth to extract the list of delimiters into a constant, but it's a bit hard to use inside `case` when other chars are involved in subsequent conditions, so if someone wants to improve the code later, please go ahead, but in a separate PR please)
- a few missing `next_char` after, for example, `%r`: only one `next_char` skipped the `%` but another `r` was missing. This wasn't a big deal, but one spec in this PR would fail otherwise (so it was incorrect behaviour after all, just very hidden).