### PR TITLE
Compiler: make sure to remove literal types before instantiating matches

### DIFF
--- a/spec/compiler/codegen/double_splat_spec.cr
+++ b/spec/compiler/codegen/double_splat_spec.cr
@@ -124,4 +124,18 @@ describe "Codegen: double splat" do
       Global.x
       )).to_i.should eq(1)
   end
+
+  it "removes literal types in all matches (#6239)" do
+    run(%(
+      def foo(y : Float64)
+        y.to_i
+      end
+
+      def bar(x : Float64, **args)
+        foo(**args)
+      end
+
+      bar(x: 1, y: 2.0)
+      )).to_i.should eq(2)
+  end
 end

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -117,6 +117,11 @@ module Crystal
 
     def initialize(@def, @arg_types, @context, @named_arg_types = nil)
     end
+
+    def remove_literals
+      @arg_types.map!(&.remove_literal)
+      @named_arg_types.try &.map! { |arg| NamedArgumentType.new(arg.name, arg.type.remove_literal) }
+    end
   end
 
   struct Matches


### PR DESCRIPTION
Fixes #6239

When initial lookup matches fail, we do a second lookup with "literal types", for the automatic cast. If there are matches, those literal types must be converted back to the real types (because those literal types are just used for the lookup, they are fictitious). This was done in a few places, but apparently not in all of them.

This PR changes the code to make sure that, before instantiating those matches, if the lookup was done with those literal types, they are removed.