### PR TITLE
Fix libyaml 0.2.1 incompatibility

### DIFF
--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -157,4 +157,10 @@ module YAML
   def self.dump(object, io : IO)
     object.to_yaml(io)
   end
+
+  # Returns the used version of `libyaml`.
+  def self.libyaml_version : {Int32, Int32, Int32}
+    LibYAML.yaml_get_version(out major, out minor, out patch)
+    {major, minor, patch}
+  end
 end

--- a/src/yaml/lib_yaml.cr
+++ b/src/yaml/lib_yaml.cr
@@ -143,4 +143,6 @@ lib LibYAML
   fun yaml_emitter_emit(emitter : Emitter*, event : Event*) : Int
   fun yaml_emitter_delete(emitter : Emitter*)
   fun yaml_emitter_flush(emitter : Emitter*) : Int
+
+  fun yaml_get_version(major : LibC::Int*, minor : LibC::Int*, patch : LibC::Int*)
 end


### PR DESCRIPTION
Fixes #6283

libyaml 0.2.1 removed the errorneously written document end marker (`...`) after some scalars in root context (see yaml/libyaml#18).
Earlier libyaml releases still write the document end marker and both older and newer releases need to be supported. 

This implements modifying the expected value depending on the version of libyaml as suggested in https://github.com/crystal-lang/crystal/pull/6285#issuecomment-401071230.

I don't think it is feasible to implement the fix for libyaml < 0.2.1 in Crystal as suggested in https://github.com/crystal-lang/crystal/pull/6285#issuecomment-401088531. This would make `YAML` always behave the same, whatever version of libyaml it is used with. But it would require rewriting the output written to the builder `IO` by libyaml. Since the impact is pretty small - YAML documents consisting of only a scalar are pretty rare outside of test suites.