### PR TITLE
Spec: silence errors from system_spec on BSD platforms

### DIFF
--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -13,7 +13,7 @@ describe System do
 
   describe "cpu_count" do
     it "returns current CPU count" do
-      shell_cpus = `getconf _NPROCESSORS_ONLN || nproc --all || grep -c '^processor' /proc/cpuinfo || sysctl -n hw.ncpu`.to_i
+      shell_cpus = `getconf _NPROCESSORS_ONLN 2>/dev/null || nproc --all 2>/dev/null || grep -sc '^processor' /proc/cpuinfo || sysctl -n hw.ncpu 2>/dev/null`.to_i
       cpu_count = System.cpu_count
       cpu_count.should eq(shell_cpus)
     end


### PR DESCRIPTION
On platforms where `getconf _NPROCESSORS_ONLN` doesn't work, like OpenBSD, each command emits an error:

Before:
````
$ crystal spec spec/std/system_spec.cr 
/usr/local/lib/libevent_core.so.1.1: warning: random() may return deterministic values, is that what you want?
.getconf: _NPROCESSORS_ONLN: unknown variable
-: nproc: not found
grep: /proc/cpuinfo: No such file or directory
.

Finished in 16.14 milliseconds
2 examples, 0 failures, 0 errors, 0 pending
````

After:

````
$ crystal spec spec/std/system_spec.cr
/usr/local/lib/libevent_core.so.1.1: warning: random() may return deterministic values, is that what you want?
..

Finished in 16.03 milliseconds
2 examples, 0 failures, 0 errors, 0 pending
````