### PR TITLE
Remove File.each_line method that returns an iterator

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -82,28 +82,6 @@ describe "File" do
     idx.should eq(20)
   end
 
-  it "reads lines from file with each as iterator" do
-    idx = 0
-    File.each_line(datapath("test_file.txt")).each do |line|
-      if idx == 0
-        line.should eq("Hello World")
-      end
-      idx += 1
-    end
-    idx.should eq(20)
-  end
-
-  it "reads lines from file with each as iterator, chomp = false" do
-    idx = 0
-    File.each_line(datapath("test_file.txt"), chomp: false).each do |line|
-      if idx == 0
-        line.should eq("Hello World\n")
-      end
-      idx += 1
-    end
-    idx.should eq(20)
-  end
-
   describe "empty?" do
     it "gives true when file is empty" do
       File.empty?(datapath("blank_test_file.txt")).should be_true

--- a/src/file.cr
+++ b/src/file.cr
@@ -656,11 +656,6 @@ class File < IO::FileDescriptor
     end
   end
 
-  # Returns an `Iterator` for each line in *filename*.
-  def self.each_line(filename, encoding = nil, invalid = nil, chomp = true)
-    open(filename, "r", encoding: encoding, invalid: invalid).each_line(chomp: chomp)
-  end
-
   # Returns all lines in *filename* as an array of strings.
   #
   # ```


### PR DESCRIPTION
Fixes #6087

There's already `IO#each_line` which returns an iterator, so one can simply do:

```crystal
File.open(filename) do |file|
  file.each_line.more_iterator_methods
end
```

and be sure the file is closed.

And I was wrong, there's no class method `File.each_line` in Ruby.