### PR TITLE
Implemented #2770

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -75,13 +75,10 @@ abstract class OpenSSL::SSL::Context
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
 
-    # declare type of @hostname
-    @hostname : String
+    @hostname : String = ""
 
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
-
-      @hostname = ""
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
       {% if LibSSL::OPENSSL_102 %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -75,7 +75,7 @@ abstract class OpenSSL::SSL::Context
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
 
-    @hostname : String = ""
+    @hostname : String?
 
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -1,3 +1,5 @@
+require "uri/punycode"
+
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method
@@ -95,6 +97,9 @@ abstract class OpenSSL::SSL::Context
     #
     # Required for OpenSSL <= 1.0.1 only.
     protected def set_cert_verify_callback(hostname : String)
+      # Sanitize the hostname with PunyCode
+      hostname = URI::Punycode.to_ascii hostname
+
       # Keep a reference so the GC doesn't collect it after sending it to C land
       @hostname = hostname
       LibSSL.ssl_ctx_set_cert_verify_callback(@handle, ->(x509_ctx, arg) {

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -74,8 +74,14 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Client.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
+
+    # declare type of @hostname
+    @hostname : String
+
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
+
+      @hostname = ""
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
       {% if LibSSL::OPENSSL_102 %}


### PR DESCRIPTION
Implemented #2770.

Processed the hostname of the server in the OpenSSL Client with punycode to support non-ASCII characters in hostnames. I used punycode from #2543 and also used the same method he used for implementing this (`addrinfo.cr`).

First PR, feel free to rip it apart :).