### PR TITLE
Fix: missing codegen cast from metaclass union to virtual metaclass

### DIFF
--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -689,4 +689,38 @@ describe "Code gen: virtual type" do
       p.value.new.foo
       )).to_i.should eq(456)
   end
+
+  it "casts metaclass union type to virtual metaclass type (#6298)" do
+    run(%(
+      class Foo
+        def self.x
+          1
+        end
+      end
+
+      class Bar < Foo
+        def self.x
+          2
+        end
+      end
+
+      class Baz < Foo
+        def self.x
+          3
+        end
+      end
+
+      class Moo
+        def initialize(@foo : Foo.class)
+        end
+
+        def foo
+          @foo
+        end
+      end
+
+      klass = Bar || Baz
+      Moo.new(klass).foo.x
+      )).to_i.should eq(2)
+  end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -218,6 +218,12 @@ class Crystal::CodeGenVisitor
     store value, target_pointer
   end
 
+  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : UnionType, value)
+    # Can happen when assigning Foo+:Class <- Bar:Class | Baz:Class with Bar < Foo and Baz < Foo
+    casted_value = cast_to_pointer(union_value(value), target_type)
+    store load(casted_value), target_pointer
+  end
+
   def assign_distinct(target_pointer, target_type : NilableProcType, value_type : NilType, value)
     nilable_fun = make_nilable_fun target_type
     store nilable_fun, target_pointer


### PR DESCRIPTION
Fixes #6298

This case was missing when we removed the cast from a union type to the base type in the hierarchy, which also applies to metaclasses.