### PR TITLE
Fix: Rename datapath helper to compiler_datapath for compiler specs

### DIFF
--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -4,7 +4,7 @@ require "./spec_helper"
 describe "Compiler" do
   it "compiles a file" do
     with_tempfile "compiler_spec_output" do |path|
-      Crystal::Command.run ["build", datapath("compiler_sample"), "-o", path]
+      Crystal::Command.run ["build", compiler_datapath("compiler_sample"), "-o", path]
 
       File.exists?(path).should be_true
 
@@ -13,7 +13,7 @@ describe "Compiler" do
   end
 
   it "runs subcommand in preference to a filename " do
-    Dir.cd datapath do
+    Dir.cd compiler_datapath do
       with_tempfile "compiler_spec_output" do |path|
         Crystal::Command.run ["build", "compiler_sample", "-o", path]
 

--- a/spec/compiler/spec_helper.cr
+++ b/spec/compiler/spec_helper.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 require "../support/tempfile"
 
-def datapath(*components)
+def compiler_datapath(*components)
   File.join("spec", "compiler", "data", *components)
 end


### PR DESCRIPTION
Followup to #5951

See https://github.com/crystal-lang/crystal/pull/5951#issuecomment-400986673