### PR TITLE
Flatten project structure created by crystal init

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -144,18 +144,11 @@ dependencies:
       end
 
       describe_file "example/src/example.cr" do |example|
-        example.should eq(%{require "./example/*"
-
-# TODO: Write documentation for `Example`
+        example.should eq(%{# TODO: Write documentation for `Example`
 module Example
-  # TODO: Put your code here
-end
-})
-      end
-
-      describe_file "example/src/example/version.cr" do |version|
-        version.should eq(%{module Example
   VERSION = "0.1.0"
+
+  # TODO: Put your code here
 end
 })
       end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -274,7 +274,6 @@ module Crystal
     template ShardView, "shard.yml.ecr", "shard.yml"
 
     template SrcExampleView, "example.cr.ecr", "src/#{config.name}.cr"
-    template SrcVersionView, "version.cr.ecr", "src/#{config.name}/version.cr"
 
     template SpecHelperView, "spec_helper.cr.ecr", "spec/spec_helper.cr"
     template SpecExampleView, "example_spec.cr.ecr", "spec/#{config.name}_spec.cr"

--- a/src/compiler/crystal/tools/init/template/example.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example.cr.ecr
@@ -1,6 +1,6 @@
-require "./<%= config.name %>/*"
-
 # TODO: Write documentation for `<%= module_name %>`
 module <%= module_name %>
+  VERSION = "0.1.0"
+
   # TODO: Put your code here
 end

--- a/src/compiler/crystal/tools/init/template/version.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/version.cr.ecr
@@ -1,3 +1,0 @@
-module <%= module_name %>
-  VERSION = "0.1.0"
-end


### PR DESCRIPTION
`crystal init` previously created `src/example/version.cr` file which only contained a `VERSION` constant. This is moved into the main library file. It also removes `require "./example/*"` from main file.

The old `version.cr` convention persisted from Ruby due to the need for gemspec files to require only the version constant from the library.

Extracted from #5428 to make this easier to merge with (hopfully) less discussion and we can focus there (or in a new issue) on the value of `VERSION`. @RX14 I hope you don't mind 😉 

https://github.com/crystal-lang/crystal/pull/5428#issuecomment-353474769
> In my view version.cr is much more cluttered than just adding a line in your main file. Ruby convention has it separate only because the gemspec depends on the version.cr - in Crystal we have it the other way around so we can merge it back in.