### PR TITLE
random: Implement Random#uuid

### DIFF
--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -260,4 +260,10 @@ describe "Random" do
       hex.should eq("9fd857f462831002ffffffffffffffff0000000000000000e88d3a30db4e730021b8a5e33b020000362f518e0700000062da")
     end
   end
+
+  describe "uuid" do
+    it "generates a v4 UUID" do
+      Random.new.uuid.should match(/[[:xdigit:]]{8}-[[:xdigit:]]{4}-4[[:xdigit:]]{3}-[ab89][[:xdigit:]]{3}-[[:xdigit:]]{12}/)
+    end
+  end
 end

--- a/src/random.cr
+++ b/src/random.cr
@@ -372,6 +372,24 @@ module Random
     random_bytes(n).hexstring
   end
 
+  # Generates a version 4 (random) UUID.
+  #
+  # ```
+  # Random::Secure.uuid # => "e8450590-0d53-4452-a882-217fd8a31e4c"
+  # ```
+  def uuid
+    io = IO::Memory.new(random_bytes(16))
+
+    fields = [UInt32, UInt16, UInt16, UInt16, UInt16, UInt32].map do |field|
+      field.from_io(io, IO::ByteFormat::LittleEndian)
+    end
+
+    fields[2] = (fields[2] & 0x0fff) | 0x4000
+    fields[3] = (fields[3] & 0x3fff) | 0x8000
+
+    "%08x-%04x-%04x-%04x-%04x%08x" % fields
+  end
+
   # See `#rand`.
   def self.rand : Float64
     DEFAULT.rand


### PR DESCRIPTION
This method behaves identically to Ruby's `SecureRandom#uuid`,
generating a random v4 UUID (with only the version and variant being
constant/determined).

Please let me know if there's a way to do this that involves fewer allocations :slightly_smiling_face: 