### PR TITLE
JSON/YAML: error if a maximum nesting is reached (prevents stack overflow)

### DIFF
--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -278,4 +278,33 @@ describe JSON::Builder do
       end
     end
   end
+
+  it "errors on max nesting (array)" do
+    io = IO::Memory.new
+    builder = JSON::Builder.new(io)
+    builder.max_nesting = 3
+    builder.start_document
+    3.times do
+      builder.start_array
+    end
+
+    expect_raises(JSON::Error, "Nesting of 4 is too deep") do
+      builder.start_array
+    end
+  end
+
+  it "errors on max nesting (object)" do
+    io = IO::Memory.new
+    builder = JSON::Builder.new(io)
+    builder.max_nesting = 3
+    builder.start_document
+    3.times do
+      builder.start_object
+      builder.string "key"
+    end
+
+    expect_raises(JSON::Error, "Nesting of 4 is too deep") do
+      builder.start_object
+    end
+  end
 end

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -126,4 +126,34 @@ describe YAML::Builder do
       end
     end
   end
+
+  it "errors on max nesting (sequence)" do
+    io = IO::Memory.new
+    builder = YAML::Builder.new(io)
+    builder.max_nesting = 3
+    builder.start_stream
+    builder.start_document
+    3.times do
+      builder.start_sequence
+    end
+
+    expect_raises(YAML::Error, "Nesting of 4 is too deep") do
+      builder.start_sequence
+    end
+  end
+
+  it "errors on max nesting (mapping)" do
+    io = IO::Memory.new
+    builder = YAML::Builder.new(io)
+    builder.max_nesting = 3
+    builder.start_stream
+    builder.start_document
+    3.times do
+      builder.start_mapping
+    end
+
+    expect_raises(YAML::Error, "Nesting of 4 is too deep") do
+      builder.start_mapping
+    end
+  end
 end

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -26,12 +26,18 @@
 class YAML::Builder
   @box : Void*
 
+  # By default the maximum nesting of sequences/amppings is 99. Nesting more
+  # than this will result in a YAML::Error. Changing the value of this property
+  # allows more/less nesting.
+  property max_nesting = 99
+
   # Creates a `YAML::Builder` that will write to the given `IO`.
   def initialize(@io : IO)
     @box = Box.box(io)
     @emitter = Pointer(Void).malloc(LibYAML::EMITTER_SIZE).as(LibYAML::Emitter*)
     @event = LibYAML::Event.new
     @closed = false
+    @nesting = 0
     LibYAML.yaml_emitter_initialize(@emitter)
     LibYAML.yaml_emitter_set_output(@emitter, ->(data, buffer, size) {
       data_io = Box(IO).unbox(data)
@@ -90,11 +96,13 @@ class YAML::Builder
   def start_sequence(anchor : String? = nil, tag : String? = nil, style : YAML::SequenceStyle = YAML::SequenceStyle::ANY)
     implicit = tag ? 0 : 1
     emit sequence_start, get_anchor(anchor), string_to_unsafe(tag), implicit, style
+    increase_nesting
   end
 
   # Ends a sequence.
   def end_sequence
     emit sequence_end
+    decrease_nesting
   end
 
   # Starts a sequence, invokes the block, and the ends it.
@@ -107,11 +115,13 @@ class YAML::Builder
   def start_mapping(anchor : String? = nil, tag : String? = nil, style : YAML::MappingStyle = YAML::MappingStyle::ANY)
     implicit = tag ? 0 : 1
     emit mapping_start, get_anchor(anchor), string_to_unsafe(tag), implicit, style
+    increase_nesting
   end
 
   # Ends a mapping.
   def end_mapping
     emit mapping_end
+    decrease_nesting
   end
 
   # Starts a mapping, invokes the block, and then ends it.
@@ -159,6 +169,17 @@ class YAML::Builder
     if ret != 1
       raise YAML::Error.new("Error emitting #{event_name}")
     end
+  end
+
+  private def increase_nesting
+    @nesting += 1
+    if @nesting > @max_nesting
+      raise YAML::Error.new("Nesting of #{@nesting} is too deep")
+    end
+  end
+
+  private def decrease_nesting
+    @nesting -= 1
   end
 end
 


### PR DESCRIPTION
Fixes #6321

This PR adds a `max_nesting` property to both `JSON::Builder` and `YAML::Builder` with a default value of 99. When trying to generate a JSON/YAML document with a nesting (arrays/objects inside arrays/objects) greater than the maximum, an error is raised.

Other languages usually do the same, because it's super rare (I'd say unmanagable) to have a JSON/YAML document that deep. There was also a website listing how JSON is handled in each language, and checking for a maximum nesting was done and most languages did this: those that not were marked as red, because it means the language is not safe. And it's not safe because it will cause a stack overflow, which usually results in the end of a program.

The error message is copied from Ruby.

Of course there's no easy way to control this maximum nesting calling just `to_json`, `to_yaml`. However, in the rare case you need to change this maximum nesting you can always creating a builder, configure it, and pass it to `to_json`/`to_yaml`.