### PR TITLE
Fix File.join with separator path component

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -305,6 +305,9 @@ describe "File" do
     File.join(["", "", "foo"]).should eq("foo")
     File.join(["foo", "", "bar"]).should eq("foo/bar")
     File.join(["foo", "", "", "bar"]).should eq("foo/bar")
+    File.join(["foo", "/", "bar"]).should eq("foo/bar")
+    File.join(["foo", "/", "/", "bar"]).should eq("foo/bar")
+    File.join(["/", "/foo", "/", "bar/", "/"]).should eq("/foo/bar/")
   end
 
   it "chown" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -721,9 +721,11 @@ class File < IO::FileDescriptor
   def self.join(parts : Array | Tuple) : String
     String.build do |str|
       first = true
+      parts_last_index = parts.size - 1
       parts.each_with_index do |part, index|
         part.check_no_null_byte
-        next if part.empty? && index != parts.size - 1
+        next if part.empty? && index != parts_last_index
+        next if !first && index != parts_last_index && part == SEPARATOR_STRING
 
         str << SEPARATOR unless first
 
@@ -735,7 +737,7 @@ class File < IO::FileDescriptor
           byte_count -= 1
         end
 
-        if index != parts.size - 1 && part.ends_with?(SEPARATOR)
+        if index != parts_last_index && part.ends_with?(SEPARATOR)
           byte_count -= 1
         end
 


### PR DESCRIPTION
Simliar #5915.

It throws an exception if only separator in the middle component, (for example `File.join("foo", "/", "bar")`)

```
Unhandled exception: Index out of bounds (IndexError)
  from Slice(UInt8)@Slice(T)#pointer<Int32>:Pointer(UInt8)
  from Slice(UInt8)@Slice(T)#copy_to<Pointer(UInt8), Int32>:Pointer(UInt8)
  from String::Builder#write<Slice(UInt8)>:Nil
  from File::join<Tuple(String, String, String)>:String
  from File::join<String, String, String>:String
  from __icr_exec__:String
  from __crystal_main
  from Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil
  from Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32
  from main
```