### PR TITLE
Add XML::Reader ParserOptions Support

### DIFF
--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -18,19 +18,46 @@ end
 module XML
   describe Reader do
     describe ".new" do
-      it "can be initialized from a string" do
-        reader = Reader.new(xml)
-        reader.should be_a(XML::Reader)
-        reader.read.should be_true
-        reader.name.should eq("people")
+      context "with default parser options" do
+        it "can be initialized from a string" do
+          reader = Reader.new(xml)
+          reader.should be_a(XML::Reader)
+          reader.read.should be_true
+          reader.name.should eq("people")
+          reader.read.should be_true
+          reader.name.should eq("#text")
+        end
+
+        it "can be initialized from an io" do
+          io = IO::Memory.new(xml)
+          reader = Reader.new(io)
+          reader.should be_a(XML::Reader)
+          reader.read.should be_true
+          reader.name.should eq("people")
+          reader.read.should be_true
+          reader.name.should eq("#text")
+        end
       end
 
-      it "can be initialize from an io" do
-        io = IO::Memory.new(xml)
-        reader = Reader.new(io)
-        reader.should be_a(XML::Reader)
-        reader.read.should be_true
-        reader.name.should eq("people")
+      context "with custom parser options" do
+        it "can be initialized from a string" do
+          reader = Reader.new(xml, XML::ParserOptions::NOBLANKS)
+          reader.should be_a(XML::Reader)
+          reader.read.should be_true
+          reader.name.should eq("people")
+          reader.read.should be_true
+          reader.name.should eq("person")
+        end
+
+        it "can be initialized from an io" do
+          io = IO::Memory.new(xml)
+          reader = Reader.new(io, XML::ParserOptions::NOBLANKS)
+          reader.should be_a(XML::Reader)
+          reader.read.should be_true
+          reader.name.should eq("people")
+          reader.read.should be_true
+          reader.name.should eq("person")
+        end
       end
     end
 
@@ -95,6 +122,51 @@ module XML
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::DTD_NODE)
         reader.name.should eq("#text")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("people")
+        reader.read.should be_false
+      end
+
+      it "reads all non-blank nodes with NOBLANKS option" do
+        reader = Reader.new(xml, XML::ParserOptions::NOBLANKS)
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("people")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader["id"].should eq("1")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::TEXT_NODE)
+        reader.name.should eq("#text")
+        reader.value.should eq("John")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("person")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("person")
+        reader["id"].should eq("2")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_NODE)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::TEXT_NODE)
+        reader.name.should eq("#text")
+        reader.value.should eq("Peter")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("name")
+        reader.read.should be_true
+        reader.node_type.should eq(XML::Type::ELEMENT_DECL)
+        reader.name.should eq("person")
         reader.read.should be_true
         reader.node_type.should eq(XML::Type::ELEMENT_DECL)
         reader.name.should eq("people")

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -94,6 +94,9 @@ lib LibXML
   fun xmlParserInputBufferCreateIO(ioread : (Void*, UInt8*, Int) -> Int, ioclose : Void* -> Int, ioctx : Void*, enc : Int) : InputBuffer
   fun xmlNewTextReader(input : InputBuffer, uri : UInt8*) : XMLTextReader
 
+  fun xmlReaderForMemory(buffer : UInt8*, size : Int, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : XMLTextReader
+  fun xmlReaderForIO(ioread : (Void*, UInt8*, Int) -> Int, ioclose : Void* -> Int, ioctx : Void*, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : XMLTextReader
+
   fun xmlTextReaderRead(reader : XMLTextReader) : Int
   fun xmlTextReaderNext(reader : XMLTextReader) : Int
   fun xmlTextReaderNextSibling(reader : XMLTextReader) : Int


### PR DESCRIPTION
This adds support for passing `XML::ParserOptions` flags to `XML::Reader`, similar to `XML.parse`.

Passing flags like `XML::ParserOptions::NOBLANKS` can give huge memory savings and speedups compared to the default parser options.