### PR TITLE
Fix: missing virtual types in literal type guessing

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4928,4 +4928,118 @@ describe "Semantic: instance var" do
       ),
       "can't use Gen(T) as the type of instance variable @x of Foo, use a more specific type"
   end
+
+  it "guesses virtual array type (1) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(T) < Array(T)
+      end
+
+      class Second
+        @ary = [[1]]
+
+        def ary
+          @ary
+        end
+      end
+
+      Second.new.ary
+      )) { array_of(array_of(int32).virtual_type).virtual_type }
+  end
+
+  it "guesses virtual array type (2) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(T) < Array(T)
+      end
+
+      class Second
+        @ary = Array { Array { 1 } }
+
+        def ary
+          @ary
+        end
+      end
+
+      Second.new.ary
+      )) { array_of(array_of(int32).virtual_type).virtual_type }
+  end
+
+  it "guesses virtual array type (3) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(T) < Array(T)
+      end
+
+      class Second
+        @ary = [] of Array(Int32)
+
+        def ary
+          @ary
+        end
+      end
+
+      Second.new.ary
+      )) { array_of(array_of(int32).virtual_type).virtual_type }
+  end
+
+  it "guesses virtual hash type (1) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(K, V) < Hash(K, V)
+      end
+
+      class Second
+        @hash = { {1 => 2} => 3}
+
+        def hash
+          @hash
+        end
+      end
+
+      Second.new.hash
+      )) { hash_of(hash_of(int32, int32).virtual_type, int32).virtual_type }
+  end
+
+  it "guesses virtual hash type (2) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(K, V) < Hash(K, V)
+      end
+
+      class Second
+        @hash = Hash { Hash { 1 => 2 } => 3 }
+
+        def hash
+          @hash
+        end
+      end
+
+      Second.new.hash
+      )) { hash_of(hash_of(int32, int32).virtual_type, int32).virtual_type }
+  end
+
+  it "guesses virtual array type (3) (#5342)" do
+    assert_type(%(
+      require "prelude"
+
+      class First(K, V) < Hash(K, V)
+      end
+
+      class Second
+        @hash = {} of Hash(Int32, Int32) => Int32
+
+        def hash
+          @hash
+        end
+      end
+
+      Second.new.hash
+      )) { hash_of(hash_of(int32, int32).virtual_type, int32).virtual_type }
+  end
 end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -451,7 +451,7 @@ module Crystal
         if type.is_a?(GenericClassType)
           element_types = guess_array_literal_element_types(node)
           if element_types
-            return type.instantiate([Type.merge!(element_types)] of TypeVar)
+            return type.instantiate([Type.merge!(element_types)] of TypeVar).virtual_type
           end
         else
           return check_allowed_in_generics(node, type)
@@ -459,12 +459,12 @@ module Crystal
       elsif node_of = node.of
         type = lookup_type?(node_of)
         if type
-          return program.array_of(type.virtual_type)
+          return program.array_of(type.virtual_type).virtual_type
         end
       else
         element_types = guess_array_literal_element_types(node)
         if element_types
-          return program.array_of(Type.merge!(element_types))
+          return program.array_of(Type.merge!(element_types)).virtual_type
         end
       end
 
@@ -489,7 +489,7 @@ module Crystal
         if type.is_a?(GenericClassType)
           key_types, value_types = guess_hash_literal_key_value_types(node)
           if key_types && value_types
-            return type.instantiate([Type.merge!(key_types), Type.merge!(value_types)] of TypeVar)
+            return type.instantiate([Type.merge!(key_types), Type.merge!(value_types)] of TypeVar).virtual_type
           end
         else
           return check_allowed_in_generics(node, type)
@@ -501,11 +501,11 @@ module Crystal
         value_type = lookup_type?(node_of.value)
         return nil unless value_type
 
-        return program.hash_of(key_type.virtual_type, value_type.virtual_type)
+        return program.hash_of(key_type.virtual_type, value_type.virtual_type).virtual_type
       else
         key_types, value_types = guess_hash_literal_key_value_types(node)
         if key_types && value_types
-          return program.hash_of(Type.merge!(key_types), Type.merge!(value_types))
+          return program.hash_of(Type.merge!(key_types), Type.merge!(value_types)).virtual_type
         end
       end
 


### PR DESCRIPTION
Fixes #5342

A few `virtual_type` calls were missing.