### PR TITLE
Fix: incorrect debug info for closured self

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -150,4 +150,22 @@ describe "Code gen: debug" do
       end
       ), debug: Crystal::Debug::All)
   end
+
+  it "doesn't emit incorrect debug info for closured self" do
+    codegen(%(
+      def foo(&block : Int32 ->)
+        block.call(1)
+      end
+
+      class Foo
+        def bar
+          foo do
+            self
+          end
+        end
+      end
+
+      Foo.new.bar
+      ), debug: Crystal::Debug::All)
+  end
 end

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -121,7 +121,9 @@ class Crystal::CodeGenVisitor
             args_offset = !is_fun_literal && self_type.passed_as_self? ? 2 : 1
             location = target_def.location
             context.vars.each do |name, var|
-              if name == "self"
+              # Self always comes as the first parameter, unless it's a closure:
+              # then it will be fetched from the closure data.
+              if name == "self" && !is_closure
                 declare_parameter(name, var.type, 1, var.pointer, location)
               elsif arg_no = args.index { |arg| arg.name == name }
                 declare_parameter(name, var.type, arg_no + args_offset, var.pointer, location)


### PR DESCRIPTION
Fixes #6195

Or so I guess. At least the [last snippet](https://github.com/crystal-lang/crystal/issues/6195#issuecomment-400263410) now compiles without error, but I don't know if some other code triggers this bug.