### PR TITLE
Switches Darwin to arc4random

### DIFF
--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -12,7 +12,7 @@ end
 
 {% if flag?(:linux) %}
   require "./unix/getrandom"
-{% elsif flag?(:openbsd) %}
+{% elsif flag?(:openbsd) || flag?(:darwin) %}
   require "./unix/arc4random"
 {% elsif flag?(:unix) %}
   require "./unix/urandom"

--- a/src/crystal/system/unix/arc4random.cr
+++ b/src/crystal/system/unix/arc4random.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:openbsd) %}
+{% skip_file unless flag?(:openbsd) || flag?(:darwin) %}
 
 require "c/stdlib"
 

--- a/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/stdlib.cr
@@ -7,6 +7,8 @@ lib LibC
     rem : Int
   end
 
+  fun arc4random : UInt32
+  fun arc4random_buf(x0 : Void*, x1 : SizeT) : Void
   fun atof(x0 : Char*) : Double
   fun div(x0 : Int, x1 : Int) : DivT
   fun exit(x0 : Int) : NoReturn


### PR DESCRIPTION
Based on discussions on #6340.

- Performance improvements
- Works in chroot
- No File Descriptors needed

Note: The same could also be done for FreeBSD. 