### PR TITLE
Revert: Don't automatically virtualize two types in the same hierarchy, unless one is deeper than the other

### DIFF
--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -321,7 +321,7 @@ point_count = ARGV.size > 0 ? ARGV[0].to_i : 4
 yellow = YellowColorPattern.new
 magenta = MagentaColorPattern.new
 cyan = CyanColorPattern.new
-rainbow = RainbowColorPattern.new [yellow, magenta, cyan] of ColorPattern
+rainbow = RainbowColorPattern.new [yellow, magenta, cyan]
 
 main_points = [] of MainPoint
 main_points << MainPoint.new(50, 50, -Math::PI / 8, 1.4, yellow)

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -504,15 +504,7 @@ describe "Code gen: class" do
 
   it "does to_s for virtual metaclass type (3)" do
     run(%(
-      class Class
-        def name : String
-          {{ @type.name.stringify }}
-        end
-
-        def to_s
-          name
-        end
-      end
+      require "prelude"
 
       class Foo; end
       class Bar < Foo; end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -178,7 +178,7 @@ describe "Semantic: class" do
       end
 
       a = Bar.new || Baz.new
-      ") { union_of types["Bar"], types["Baz"] }
+      ") { types["Foo"].virtual_type }
   end
 
   it "types class and subclass as one type" do

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -316,7 +316,7 @@ describe "Semantic: def" do
 
   it "says compile-time type on error" do
     assert_error %(
-      class Foo
+      abstract class Foo
       end
 
       class Bar < Foo
@@ -328,7 +328,7 @@ describe "Semantic: def" do
       class Baz < Foo
       end
 
-      f = Bar.new || Foo.new
+      f = Bar.new || Baz.new
       f.bar
       ),
       "compile-time type is Foo+"

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -39,7 +39,7 @@ describe "Semantic: struct" do
       struct Baz < Foo
       end
 
-      (Bar.new || Baz.new).as(Foo)
+      Bar.new || Baz.new
       ") { types["Foo"].virtual_type! }
   end
 

--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -35,7 +35,7 @@ describe "Semantic: virtual metaclass" do
 
   it "allows allocating virtual type when base class is abstract" do
     assert_type("
-      class Foo
+      abstract class Foo
       end
 
       class Bar < Foo
@@ -44,7 +44,7 @@ describe "Semantic: virtual metaclass" do
       class Baz < Foo
       end
 
-      bar = Bar.new || Foo.new
+      bar = Bar.new || Baz.new
       baz = bar.class.allocate
       ") { types["Foo"].virtual_type }
   end

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -37,7 +37,7 @@ describe "Semantic: virtual" do
       end
 
       a = Bar.new || Baz.new
-      ") { union_of types["Bar"], types["Baz"] }
+      ") { types["Foo"].virtual_type }
   end
 
   it "types class and two subclasses" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -544,11 +544,6 @@ class Crystal::CodeGenVisitor
   end
 
   def upcast_distinct(value, to_type : MetaclassType | GenericClassInstanceMetaclassType | GenericModuleInstanceMetaclassType | VirtualMetaclassType, from_type)
-    # Special case: union of metaclasses is still represented as a union
-    if from_type.is_a?(MixedUnionType)
-      return load(union_type_id(value))
-    end
-
     value
   end
 

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -120,19 +120,6 @@ module Crystal
     end
 
     def type_combine(types)
-      # Modules and types at a higher level in the hierarchy are the ones
-      # that will "delete" deeper types and combine them into virtual
-      # types (or just modules), so we put them in the front for the algorithm.
-      types.sort! do |t1, t2|
-        if t1.module?
-          -1
-        elsif t2.module?
-          1
-        else
-          t1.depth <=> t2.depth
-        end
-      end
-
       all_types = [types.shift] of Type
 
       types.each do |t2|
@@ -346,10 +333,14 @@ private def class_common_ancestor(t1, t2)
     return t1
   end
 
-  # If one type is deeper than the other, check if going up we find
-  # the one in the top, and if so we combine them.
-  # But if they are at the same depth we don't go up.
-  if t1.depth > t2.depth
+  if t1.depth == t2.depth
+    t1_superclass = t1.superclass
+    t2_superclass = t2.superclass
+
+    if t1_superclass && t2_superclass
+      return t1_superclass.common_ancestor(t2_superclass)
+    end
+  elsif t1.depth > t2.depth
     t1_superclass = t1.superclass
     if t1_superclass
       return t1_superclass.common_ancestor(t2)


### PR DESCRIPTION
Fixes #6349

Reverts https://github.com/crystal-lang/crystal/pull/6024/commits/26635f1052b99ab5b52a8b051020a25435dba751

To make it clear:
- PR #6024 was just an experiment. I expected compile time for the compiler to go to the roof with that change but that didn't happen.
- However, it did happen for other projects, namely the one mentioned in #6349 
- The main problem is that with a big type hierarchy, say N types, all different union types inside that hierarchy is basically a combinatorial explosion (take any M from N where M <= N). The compiler potentially has to create all these different union types, and consider them for method overloads, dispatch, etc. In the given program this happened (a lot it seems), to the point where the compiler crashed
- Reverting this change makes the above project compile again: "Semantic (main)" takes about 3.3 seconds with a non-release compiler. Total compilation time takes about 31 seconds, again with a non-release compiler (that is, I didn't pass `--release `when I compiled the compiler). EDIT: "Semantic (main)" takes about 1 second with a release compiler. And it's about 15K lines of code :-O

Not unifying types in the same hierarchy was something that I, and probably others, wanted, but it's simply not possible. That's the whole reason why we unified types in the first place: to avoid this combinatorial explosion of union types.

And remember, this is not that terrible: we've been doing just fine before 0.25.0 without this "feature", and without me trying to play with this it would never have happened, so... :-)