### PR TITLE
Encoding: compare with case insensitive UTF-8 to avoid using iconv when not necessary

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -689,6 +689,18 @@ describe IO do
         end
       end
 
+      it "sets encoding to utf-8 and stays as UTF-8" do
+        io = SimpleIOMemory.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
+        io.set_encoding("utf-8")
+        io.encoding.should eq("UTF-8")
+      end
+
+      it "sets encoding to utf8 and stays as UTF-8" do
+        io = SimpleIOMemory.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
+        io.set_encoding("utf8")
+        io.encoding.should eq("UTF-8")
+      end
+
       it "does skips when converting to UTF-8" do
         io = SimpleIOMemory.new(Base64.decode_string("ey8qx+Tl8fwg7+Dw4Ozl8vD7IOLo5+jy4CovfQ=="))
         io.set_encoding("UTF-8", invalid: :skip)

--- a/src/io.cr
+++ b/src/io.cr
@@ -1023,7 +1023,10 @@ abstract class IO
   # String operations (`gets`, `gets_to_end`, `read_char`, `<<`, `print`, `puts`
   # `printf`) will use this encoding.
   def set_encoding(encoding : String, invalid : Symbol? = nil)
-    if (encoding == "UTF-8") && (invalid != :skip)
+    if invalid != :skip && (
+         encoding.compare("UTF-8", case_insensitive: true) == 0 ||
+         encoding.compare("UTF8", case_insensitive: true) == 0
+       )
       @encoding = nil
     else
       @encoding = EncodingOptions.new(encoding, invalid)


### PR DESCRIPTION
We have `IO#set_encoding` which accepts an encoding. If it's UTF-8 there's nothing to do, because IO is assumed to be UTF-8 by default (regarding text). The current comparison is case sensitive, but in some cases the encoding can come with other cases (like in #6353). So to avoid using iconv, which should be slower then just doing it in Crystal (and also a bit redundant), I added a case insensitive comparison.

Update: includes tests.