### PR TITLE
Fix: Add type restriction to Crypto::Bcrypt::Password#==

### DIFF
--- a/spec/std/crypto/bcrypt/password_spec.cr
+++ b/spec/std/crypto/bcrypt/password_spec.cr
@@ -48,5 +48,16 @@ describe "Crypto::Bcrypt::Password" do
     it "verifies password is correct" do
       (password == "secret").should be_true
     end
+
+    it "works with Password" do
+      (password == password).should be_true
+
+      other_password = Crypto::Bcrypt::Password.create("wrong", 4)
+      (password == other_password).should be_false
+    end
+
+    it "works with other types" do
+      (password == 0.815).should be_false
+    end
   end
 end

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -58,7 +58,7 @@ class Crypto::Bcrypt::Password
   # password == "wrong secret" # => false
   # password == "super secret" # => true
   # ```
-  def ==(password)
+  def ==(password : String) : Bool
     hashed_password = Bcrypt.new(password, salt, cost)
     Crypto::Subtle.constant_time_compare(@raw_hash, hashed_password)
   end


### PR DESCRIPTION
Fixes #6339