### PR TITLE
Restrict `exp.@var` to types in the same hierarchy

### DIFF
--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -288,8 +288,14 @@ describe "Code gen: struct" do
         end
       end
 
+      struct LibFoo::Foo
+        def _x
+          @x
+        end
+      end
+
       f = LibFoo::Foo.new x: 123
-      f.@x
+      f._x
       )).to_i.should eq(123)
   end
 

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -293,10 +293,14 @@ describe "Code gen: class" do
       class Foo
         def initialize(@x : Int32)
         end
+
+        def self.read(foo)
+          foo.@x
+        end
       end
 
       foo = Foo.new(1)
-      foo.@x
+      Foo.read(foo)
       )).to_i.should eq(1)
   end
 
@@ -305,13 +309,17 @@ describe "Code gen: class" do
       class Foo
         def initialize(@x : Int32)
         end
+
+        def self.read(foo)
+          foo.@x
+        end
       end
 
       class Bar < Foo
       end
 
       foo = Foo.new(1) || Bar.new(2)
-      foo.@x
+      Foo.read(foo)
       )).to_i.should eq(1)
   end
 

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1459,9 +1459,13 @@ describe "Code gen: macro" do
         {% begin %}
           @x = 1
         {% end %}
+
+        def _x
+          @x
+        end
       end
 
-      Foo.new.@x
+      Foo.new._x
       ), inject_primitives: false).to_i.should eq(1)
   end
 

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -356,10 +356,14 @@ describe "Code gen: pointer" do
         def x
           @x
         end
+
+        def self.ptr(foo)
+          pointerof(foo.@x)
+        end
       end
 
       foo = Foo.new
-      pointerof(foo.@x).value = 123
+      Foo.ptr(foo).value = 123
       foo.x
       )).to_i.should eq(123)
   end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -727,9 +727,13 @@ describe "Code gen: proc" do
         def foo
           42
         end
+
+        def _f
+          @f
+        end
       end
 
-      Foo.new.@f.call
+      Foo.new._f.call
       )).to_i.should eq(42)
   end
 

--- a/spec/compiler/codegen/struct_spec.cr
+++ b/spec/compiler/codegen/struct_spec.cr
@@ -414,6 +414,10 @@ describe "Code gen: struct" do
         def initialize
           @x = 21
         end
+
+        def self.access(foo)
+          foo.@x
+        end
       end
 
       struct Bar < Foo
@@ -425,7 +429,7 @@ describe "Code gen: struct" do
       struct Baz < Foo
       end
 
-      Bar.new.as(Foo).@x
+      Foo.access(Bar.new.as(Foo))
       )).to_i.should eq(42)
   end
 

--- a/spec/compiler/semantic/c_struct_spec.cr
+++ b/spec/compiler/semantic/c_struct_spec.cr
@@ -303,8 +303,14 @@ describe "Semantic: struct" do
         end
       end
 
+      struct LibFoo::Foo
+        def self.read(foo)
+          foo.@x
+        end
+      end
+
       f = LibFoo::Foo.new x: 123
-      f.@x
+      LibFoo::Foo.read(f)
       )) { int32 }
   end
 

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -481,47 +481,15 @@ describe "Semantic: class" do
     assert_error "Number.allocate", "can't instantiate abstract struct Number"
   end
 
-  it "reads an object instance var" do
-    assert_type(%(
-      class Foo
-        def initialize(@x : Int32)
-        end
-      end
-
-      foo = Foo.new(1)
-      foo.@x
-      )) { int32 }
-  end
-
-  it "reads a virtual type instance var" do
-    assert_type(%(
-      class Foo
-        def initialize(@x : Int32)
-        end
-      end
-
-      class Bar < Foo
-      end
-
-      foo = Foo.new(1) || Bar.new(2)
-      foo.@x
-      )) { int32 }
-  end
-
-  it "errors if reading non-existent ivar" do
-    assert_error %(
-      class Foo
-      end
-
-      foo = Foo.new
-      foo.@y
-      ),
-      "Can't infer the type of instance variable '@y' of Foo"
-  end
-
   it "errors if reading ivar from non-ivar container" do
     assert_error %(
-      1.@y
+      struct Int32
+        def foo
+          1.@y
+        end
+      end
+
+      1.foo
       ),
       "can't use instance variables inside primitive types (at Int32)"
   end
@@ -956,10 +924,14 @@ describe "Semantic: class" do
         def foo
           @foo
         end
+
+        def self.read(foo)
+          foo.@foo
+        end
       end
 
       f = Foo.new
-      f.@foo
+      Foo.read(f)
       ),
       "Can't infer the type of instance variable '@foo' of Foo"
   end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -888,9 +888,13 @@ describe "Semantic: instance var" do
         def x
           @x ||= 1
         end
+
+        def _x
+          @x
+        end
       end
 
-      Foo.new.@x
+      Foo.new._x
       )) { nilable int32 }
   end
 
@@ -900,9 +904,13 @@ describe "Semantic: instance var" do
         def x
           x = @x ||= 1
         end
+
+        def _x
+          @x
+        end
       end
 
-      Foo.new.@x
+      Foo.new._x
       )) { nilable int32 }
   end
 
@@ -4697,9 +4705,13 @@ describe "Semantic: instance var" do
             @never_nil = 2
           end
         end
+
+        def _never_nil
+          @never_nil
+        end
       end
 
-      Foo.new.@never_nil
+      Foo.new._never_nil
       )) { int32 }
   end
 
@@ -4714,6 +4726,10 @@ describe "Semantic: instance var" do
             @never_nil = 2
           end
         end
+
+        def _never_nil
+          @never_nil
+        end
       end
 
       class Bar
@@ -4724,9 +4740,13 @@ describe "Semantic: instance var" do
             @never_nil = 2
           end
         end
+
+        def _never_nil
+          @never_nil
+        end
       end
 
-      {Foo.new.@never_nil, Bar.new.@never_nil}
+      {Foo.new._never_nil, Bar.new._never_nil}
     )) { tuple_of([int32, int32]) }
   end
 
@@ -4840,9 +4860,13 @@ describe "Semantic: instance var" do
 
       class Foo
         @foo = Gen(Int32 | A).new
+
+        def _foo
+          @foo
+        end
       end
 
-      Foo.new.@foo
+      Foo.new._foo
     )) { generic_class "Gen", union_of(int32, types["A"]) }
   end
 

--- a/spec/compiler/semantic/read_instance_var_spec.cr
+++ b/spec/compiler/semantic/read_instance_var_spec.cr
@@ -1,0 +1,148 @@
+require "../../spec_helper"
+
+describe "Semantic: read instance var" do
+  it "can read from same class" do
+    assert_type(%(
+      class Foo
+        @x = 1
+
+        def foo(other)
+          other.@x
+        end
+      end
+
+      Foo.new.foo(Foo.new)
+      )) { int32 }
+  end
+
+  it "can read from subclass" do
+    assert_type(%(
+      class Foo
+        @x = 1
+
+        def foo(other)
+          other.@x
+        end
+      end
+
+      class Bar < Foo
+      end
+
+      Foo.new.foo(Bar.new)
+      )) { int32 }
+  end
+
+  it "can read from superclass" do
+    assert_type(%(
+      class Foo
+        @x = 1
+      end
+
+      class Bar < Foo
+        def foo(other)
+          other.@x
+        end
+      end
+
+      Bar.new.foo(Foo.new)
+      )) { int32 }
+  end
+
+  it "can read from different instantiations of a generic type" do
+    assert_type(%(
+      class Foo(T)
+        @x = 1
+
+        def read(other)
+          other.@x
+        end
+      end
+
+      Foo(Int32).new.read(Foo(Bool).new)
+      )) { int32 }
+  end
+
+  it "can't read from unrelated type in same namespace" do
+    assert_error %(
+      module Moo
+        class Foo
+          @x = 1
+
+          def foo(other)
+            other.@x
+          end
+        end
+
+        class Bar
+          @x = 2
+        end
+      end
+
+      Moo::Foo.new.foo(Moo::Bar.new)
+      ),
+      "can't access Moo::Bar.@x from unrelated type Moo::Foo"
+  end
+
+  it "can't read from unrelated type" do
+    assert_error %(
+      class Foo
+        @x = 1
+
+        def foo(other)
+          other.@x
+        end
+      end
+
+      class Bar
+        @x = 2
+      end
+
+      Foo.new.foo(Bar.new)
+      ),
+      "can't access Bar.@x from unrelated type Foo"
+  end
+
+  it "can't read from top-level" do
+    assert_error %(
+      class Foo
+        @x = 1
+      end
+
+      Foo.new.@x
+      ),
+      "can't access Foo.@x from the top-level"
+  end
+
+  it "reads a virtual type instance var" do
+    run(%(
+      class Foo
+        def initialize(@x : Int32)
+        end
+
+        def self.read_x(foo)
+          foo.@x
+        end
+      end
+
+      class Bar < Foo
+      end
+
+      foo = Foo.new(1) || Bar.new(2)
+      Foo.read_x(foo)
+      )).to_i.should eq(1)
+  end
+
+  it "errors if reading non-existent ivar" do
+    assert_error %(
+      class Foo
+        def self.read(foo)
+          foo.@y
+        end
+      end
+
+      foo = Foo.new
+      Foo.read(foo)
+      ),
+      "Can't infer the type of instance variable '@y' of Foo"
+  end
+end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -10,6 +10,12 @@ private class BadSortingClass
   end
 end
 
+class Array
+  def _capacity
+    @capacity
+  end
+end
+
 describe "Array" do
   describe "new" do
     it "creates with default value" do
@@ -383,11 +389,11 @@ describe "Array" do
     it "concats enumerable to empty array (#2047)" do
       a = [] of Int32
       a.concat(1..1)
-      a.@capacity.should eq(3)
+      a._capacity.should eq(3)
 
       a = [] of Int32
       a.concat(1..4)
-      a.@capacity.should eq(6)
+      a._capacity.should eq(6)
     end
 
     it "concats a union of arrays" do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -1,6 +1,12 @@
 require "spec"
 require "unicode"
 
+class String
+  def _length
+    @length
+  end
+end
+
 describe "Char" do
   describe "upcase" do
     it { 'a'.upcase.should eq('A') }
@@ -262,13 +268,13 @@ describe "Char" do
     it "does for both ascii" do
       str = 'f' + "oo"
       str.bytesize.should eq(3)
-      str.@length.should eq(3)
+      str._length.should eq(3)
       str.should eq("foo")
     end
 
     it "does for both unicode" do
       str = '青' + "旅路"
-      str.@length.should eq(3)
+      str._length.should eq(3)
       str.should eq("青旅路")
     end
   end

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -14,6 +14,16 @@ enum TestHasherEnum
   B
 end
 
+struct Crystal::Hasher
+  def _a
+    @a
+  end
+
+  def _b
+    @b
+  end
+end
+
 alias TestHasher = Crystal::Hasher
 
 describe "Crystal::Hasher" do
@@ -223,11 +233,11 @@ describe "Crystal::Hasher" do
     it "should not expose internal data" do
       hasher = TestHasher.new(1_u64, 2_u64)
       hasher.to_s.should_not contain('1')
-      hasher.to_s.should_not contain(hasher.@a.to_s)
-      hasher.to_s.should_not contain(hasher.@a.to_s(16))
+      hasher.to_s.should_not contain(hasher._a.to_s)
+      hasher.to_s.should_not contain(hasher._a.to_s(16))
       hasher.to_s.should_not contain('2')
-      hasher.to_s.should_not contain(hasher.@b.to_s)
-      hasher.to_s.should_not contain(hasher.@b.to_s(16))
+      hasher.to_s.should_not contain(hasher._b.to_s)
+      hasher.to_s.should_not contain(hasher._b.to_s(16))
     end
   end
 
@@ -235,11 +245,11 @@ describe "Crystal::Hasher" do
     it "should not expose internal data" do
       hasher = TestHasher.new(1_u64, 2_u64)
       hasher.inspect.should_not contain('1')
-      hasher.inspect.should_not contain(hasher.@a.to_s)
-      hasher.inspect.should_not contain(hasher.@a.to_s(16))
+      hasher.inspect.should_not contain(hasher._a.to_s)
+      hasher.inspect.should_not contain(hasher._a.to_s(16))
       hasher.inspect.should_not contain('2')
-      hasher.inspect.should_not contain(hasher.@b.to_s)
-      hasher.inspect.should_not contain(hasher.@b.to_s(16))
+      hasher.inspect.should_not contain(hasher._b.to_s)
+      hasher.inspect.should_not contain(hasher._b.to_s(16))
     end
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -14,6 +14,12 @@ end
 
 private alias RecursiveType = String | Int32 | Array(RecursiveType) | Hash(Symbol, RecursiveType)
 
+class Hash
+  def _buckets_size
+    @buckets_size
+  end
+end
+
 describe "Hash" do
   describe "empty" do
     it "size should be zero" do
@@ -816,18 +822,18 @@ describe "Hash" do
 
   it "creates with initial capacity" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234)
-    hash.@buckets_size.should eq(1234)
+    hash._buckets_size.should eq(1234)
   end
 
   it "creates with initial capacity and default value" do
     hash = Hash(Int32, Int32).new(default_value: 3, initial_capacity: 1234)
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash._buckets_size.should eq(1234)
   end
 
   it "creates with initial capacity and block" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234) { |h, k| h[k] = 3 }
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash._buckets_size.should eq(1234)
   end
 end

--- a/spec/std/http/multipart/parser_spec.cr
+++ b/spec/std/http/multipart/parser_spec.cr
@@ -12,6 +12,12 @@ private def parse(delim, data, *, gsub = true)
   parsed
 end
 
+class HTTP::Multipart::Parser
+  def _state
+    @state
+  end
+end
+
 describe HTTP::Multipart::Parser do
   it "parses basic multipart messages" do
     data = parse "AaB03x", <<-MULTIPART
@@ -144,7 +150,7 @@ describe HTTP::Multipart::Parser do
       end
     end
 
-    parser.@state.should eq(:FINISHED)
+    parser._state.should eq(:FINISHED)
     ios.each { |io| io.closed?.should eq(true) }
   end
 end

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -184,6 +184,14 @@ private class JSONWithOverwritingQueryAttributes
     foo?: Bool,
     bar?: {type: Bool, default: false, presence: true, key: "is_bar"},
   })
+
+  def _foo
+    @foo
+  end
+
+  def _bar
+    @bar
+  end
 end
 
 describe "JSON mapping" do
@@ -581,8 +589,8 @@ describe "JSON mapping" do
 
     it "overwrites non-query attributes" do
       json = JSONWithOverwritingQueryAttributes.from_json(%({"foo": true}))
-      typeof(json.@foo).should eq(Bool)
-      typeof(json.@bar).should eq(Bool)
+      typeof(json._foo).should eq(Bool)
+      typeof(json._bar).should eq(Bool)
     end
   end
 

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -58,6 +58,12 @@ private class TestObject
   property(property11) { 11 }
   property property12 : Int32 { 10 + 2 }
 
+  {% for i in 1..10 %}
+    def _getter{{i}}
+      @getter{{i}}
+    end
+  {% end %}
+
   def initialize
     @getter1 = 1
     @getter2 = 2
@@ -161,28 +167,28 @@ describe Object do
     it "uses simple getter" do
       obj = TestObject.new
       obj.getter1.should eq(1)
-      typeof(obj.@getter1).should eq(Int32)
+      typeof(obj._getter1).should eq(Int32)
       typeof(obj.getter1).should eq(Int32)
     end
 
     it "uses getter with type declaration" do
       obj = TestObject.new
       obj.getter2.should eq(2)
-      typeof(obj.@getter2).should eq(Int32)
+      typeof(obj._getter2).should eq(Int32)
       typeof(obj.getter2).should eq(Int32)
     end
 
     it "uses getter with type declaration and default value" do
       obj = TestObject.new
       obj.getter3.should eq(3)
-      typeof(obj.@getter3).should eq(Int32)
+      typeof(obj._getter3).should eq(Int32)
       typeof(obj.getter3).should eq(Int32)
     end
 
     it "uses getter with assignment" do
       obj = TestObject.new
       obj.getter4.should eq(4)
-      typeof(obj.@getter4).should eq(Int32)
+      typeof(obj._getter4).should eq(Int32)
       typeof(obj.getter4).should eq(Int32)
     end
 
@@ -206,7 +212,7 @@ describe Object do
       end
       obj.getter5 = 5
       obj.getter5.should eq(5)
-      typeof(obj.@getter5).should eq(Int32 | Nil)
+      typeof(obj._getter5).should eq(Int32 | Nil)
       typeof(obj.getter5).should eq(Int32)
     end
 
@@ -217,7 +223,7 @@ describe Object do
       end
       obj.getter6 = 6
       obj.getter6.should eq(6)
-      typeof(obj.@getter6).should eq(Int32 | Nil)
+      typeof(obj._getter6).should eq(Int32 | Nil)
       typeof(obj.getter6).should eq(Int32)
     end
   end
@@ -226,28 +232,28 @@ describe Object do
     it "uses getter?" do
       obj = TestObject.new
       obj.getter7?.should be_true
-      typeof(obj.@getter7).should eq(Bool)
+      typeof(obj._getter7).should eq(Bool)
       typeof(obj.getter7?).should eq(Bool)
     end
 
     it "uses getter? with type declaration" do
       obj = TestObject.new
       obj.getter8?.should be_true
-      typeof(obj.@getter8).should eq(Bool)
+      typeof(obj._getter8).should eq(Bool)
       typeof(obj.getter8?).should eq(Bool)
     end
 
     it "uses getter? with type declaration and default value" do
       obj = TestObject.new
       obj.getter9?.should be_true
-      typeof(obj.@getter9).should eq(Bool)
+      typeof(obj._getter9).should eq(Bool)
       typeof(obj.getter9?).should eq(Bool)
     end
 
     it "uses getter? with default value" do
       obj = TestObject.new
       obj.getter10?.should be_true
-      typeof(obj.@getter10).should eq(Bool)
+      typeof(obj._getter10).should eq(Bool)
       typeof(obj.getter10?).should eq(Bool)
     end
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1,5 +1,11 @@
 require "spec"
 
+class String
+  def _length
+    @length
+  end
+end
+
 describe "String" do
   describe "[]" do
     it "gets with positive index" do
@@ -1517,13 +1523,13 @@ describe "String" do
     it "does for both ascii" do
       str = "foo" + "bar"
       str.bytesize.should eq(6)
-      str.@length.should eq(6)
+      str._length.should eq(6)
       str.should eq("foobar")
     end
 
     it "does for both unicode" do
       str = "青い" + "旅路"
-      str.@length.should eq(4)
+      str._length.should eq(4)
       str.should eq("青い旅路")
     end
 

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -145,6 +145,14 @@ private class YAMLWithOverwritingQueryAttributes
     foo?: Bool,
     bar?: {type: Bool, default: false, presence: true, key: "is_bar"},
   })
+
+  def _foo
+    @foo
+  end
+
+  def _bar
+    @bar
+  end
 end
 
 private class YAMLWithFinalize
@@ -522,8 +530,8 @@ describe "YAML mapping" do
 
     it "overwrites non-query attributes" do
       yaml = YAMLWithOverwritingQueryAttributes.from_yaml(%({"foo": true}))
-      typeof(yaml.@foo).should eq(Bool)
-      typeof(yaml.@bar).should eq(Bool)
+      typeof(yaml._foo).should eq(Bool)
+      typeof(yaml._bar).should eq(Bool)
     end
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -770,7 +770,7 @@ struct Char
       byte = ord.to_u8
 
       # Optimization: writing a slice is much slower than writing a byte
-      if io.@encoding
+      if io.has_non_utf8_encoding?
         io.write_utf8 Slice.new(pointerof(byte), 1)
       else
         io.write_byte byte

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -557,8 +557,17 @@ module Crystal
       obj_type = obj.type?
       return unless obj_type
 
-      var = visitor.lookup_instance_var(self, obj_type)
-      self.type = var.type
+      owner_type = obj_type.instance_type.devirtualize
+      scope_type = (visitor.scope? || visitor.current_type).instance_type.devirtualize
+
+      if scope_type.has_protected_acces_to?(owner_type, allow_same_namespace: false)
+        var = visitor.lookup_instance_var(self, obj_type)
+        self.type = var.type
+      elsif scope_type.is_a?(Program)
+        raise "can't access #{owner_type}.#{name} from the top-level"
+      else
+        raise "can't access #{owner_type}.#{name} from unrelated type #{scope_type}"
+      end
     end
   end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -591,41 +591,9 @@ class Crystal::Call
       scope_type = scope.instance_type
       owner_type = match.def.owner.instance_type
 
-      # OK if in the same hierarchy,
-      # either because scope_type < owner_type
-      return if scope_type.implements?(owner_type)
-
-      # or because owner_type < scope_type
-      return if owner_type.implements?(scope_type)
-
-      # OK if both types are in the same namespace
-      return if in_same_namespace?(scope_type, owner_type)
-
-      raise "protected method '#{match.def.name}' called for #{match.def.owner}"
-    end
-  end
-
-  def in_same_namespace?(scope, target)
-    top_namespace(scope) == top_namespace(target) ||
-      scope.parents.try &.any? { |parent| in_same_namespace?(parent, target) }
-  end
-
-  def top_namespace(type)
-    namespace = case type
-                when NamedType
-                  type.namespace
-                when GenericClassInstanceType
-                  type.namespace
-                else
-                  nil
-                end
-    case namespace
-    when Program
-      type
-    when NamedType, GenericClassInstanceType
-      top_namespace(namespace)
-    else
-      type
+      unless scope_type.has_protected_acces_to?(owner_type)
+        raise "protected method '#{match.def.name}' called for #{match.def.owner}"
+      end
     end
   end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -300,6 +300,52 @@ module Crystal
       instance_vars[name] = var
     end
 
+    # Determines if `self` can access *type* assuming it's a `protected` access.
+    # If `allow_same_namespace` is true (the default), `protected` also means
+    # the types are in the same namespace. Otherwise, it means they are just
+    # in the same type hierarchy.
+    def has_protected_acces_to?(type, allow_same_namespace = true)
+      owner = self
+
+      # Allow two different generic instantiations
+      # of the same type to have protected access
+      type = type.generic_type.as(Type) if type.is_a?(GenericInstanceType)
+      owner = owner.generic_type.as(Type) if owner.is_a?(GenericInstanceType)
+
+      self.implements?(type) ||
+        type.implements?(self) ||
+        (allow_same_namespace && same_namespace?(type))
+    end
+
+    # Returns true if `self` and *other* are in the same namespace.
+    def same_namespace?(other)
+      top_namespace(self) == top_namespace(other) ||
+        parents.try &.any? { |parent| parent.same_namespace?(other) }
+    end
+
+    private def top_namespace(type)
+      type = type.generic_type if type.is_a?(GenericInstanceType)
+
+      namespace = case type
+                  when NamedType
+                    type.namespace
+                  when GenericClassInstanceType
+                    type.namespace
+                  else
+                    nil
+                  end
+      case namespace
+      when Program
+        type
+      when GenericInstanceType
+        top_namespace(namespace.generic_type)
+      when NamedType
+        top_namespace(namespace)
+      else
+        type
+      end
+    end
+
     def types
       raise "BUG: #{self} has no types"
     end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -923,6 +923,11 @@ class Hash(K, V)
     raise "Hash table too big"
   end
 
+  # Needed for BaseIterator#rewind
+  protected def __first
+    @first
+  end
+
   private class Entry(K, V)
     getter key : K
     property value : V
@@ -955,7 +960,7 @@ class Hash(K, V)
     end
 
     def rewind
-      @current = @hash.@first
+      @current = @hash.__first
     end
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1043,6 +1043,11 @@ abstract class IO
     @encoding.try(&.name) || "UTF-8"
   end
 
+  # :nodoc:
+  def has_non_utf8_encoding?
+    !!@encoding
+  end
+
   # Seeks to a given *offset* (in bytes) according to the *whence* argument.
   #
   # The `IO` class raises on this method, but some subclasses, notable


### PR DESCRIPTION
Fixes #6066

With this PR, doing `exp.@var` only works if:

1. the current type is the same as the type of `exp`, or
2. the current type inherits the type of `exp`, or
3. the type of `exp` inherits the current type, or
4. ~the current type and the type of `exp` live in the same namespace~

So, freely accessing instance vars is disallowed. Of course, one can always reopen a class and add an accessor (which is why I didn't see the current behaviour as a big problem, and why probably Ruby has `instance_variable_get`, because one can always access an instance var if you want to). But, at least we are not encouraging its use.

I was hesitant about point 4. All 4 points mean (Crystal, not Ruby) `protected`. Without 4, it's almost `protected`. At first I implemented just 1, 2 and 3, but then noticed it's used in `Hash::BaseIterator`:

https://github.com/crystal-lang/crystal/blob/4771dcb2125dfdda88da5afad7b2ed64391bb820/src/hash.cr#L958

So I added rule 4. However, later I noticed it's the **only** place where that "in the same namespace" rule is used for instance vars, at least in the standard library.

But, I think accessing instance vars like that should be mainly used for struct comparison, or accessing instance vars from types in the same hierarchy. If you really need to access an instance var from an unrelated type, even in the same namespace, you can always define a `protected` method, which gives you that access (like I did in this PR).

I was also hesitant to remove point 4, because now you can't say "`exp.@var` has protected access", but I expect a doc page explaining those three points without mentioning `protected` access, and we are done. Plus, it's a super rare thing to need, so understanding this rule and how it's different from `protected` won't be needed for most of users.

Separate notes:
- I had to add `IO#has_non_utf8_encoding?` as `:nodoc:` because `Char#to_s` uses it. The other alternative is to do `io.encoding == "UTF-8"` but that's probably much slower.
- For specs, I added accessors like `_var` to test the value of some instance vars. These are necessary because the tests check implementation details.