### PR TITLE
Remove `ditto` and `nodoc` without colons

### DIFF
--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -82,7 +82,7 @@ describe "Semantic: doc" do
         def bar
         end
 
-        # ditto
+        # :ditto:
         def bar2
         end
       end

--- a/src/array.cr
+++ b/src/array.cr
@@ -666,7 +666,7 @@ class Array(T)
     self
   end
 
-  # ditto
+  # :ditto:
   def concat(other : Enumerable)
     left_before_resize = @capacity - @size
     len = @size

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -53,7 +53,7 @@ struct BigInt < Int
     end
   end
 
-  # ditto
+  # :ditto:
   def initialize(num : Int::Unsigned)
     if num <= LibC::ULong::MAX
       LibGMP.init_set_ui(out @mpz, num)
@@ -62,22 +62,22 @@ struct BigInt < Int
     end
   end
 
-  # ditto
+  # :ditto:
   def initialize(num : Float::Primitive)
     LibGMP.init_set_d(out @mpz, num)
   end
 
-  # ditto
+  # :ditto:
   def self.new(num : BigFloat)
     num.to_big_i
   end
 
-  # ditto
+  # :ditto:
   def self.new(num : BigDecimal)
     num.to_big_i
   end
 
-  # ditto
+  # :ditto:
   def self.new(num : BigRational)
     num.to_big_i
   end
@@ -397,7 +397,7 @@ struct BigInt < Int
     String.new(to_cstr)
   end
 
-  # ditto
+  # :ditto:
   def to_s(io : IO) : Nil
     str = to_cstr
     io.write_utf8 Slice.new(str, LibC.strlen(str))

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -224,7 +224,7 @@ struct BitArray
     io << ']'
   end
 
-  # ditto
+  # :ditto:
   def inspect(io : IO) : Nil
     to_s(io)
   end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -61,7 +61,7 @@ module Crystal::Macros
   def `(command) : MacroId
   end
 
-  # ditto
+  # :ditto:
   def system(command) : MacroId
   end
 
@@ -276,19 +276,19 @@ module Crystal::Macros
     def <(other : NumberLiteral) : BoolLiteral
     end
 
-    # ditto
+    # :ditto:
     def <=(other : NumberLiteral) : BoolLiteral
     end
 
-    # ditto
+    # :ditto:
     def >(other : NumberLiteral) : BoolLiteral
     end
 
-    # ditto
+    # :ditto:
     def >=(other : NumberLiteral) : BoolLiteral
     end
 
-    # ditto
+    # :ditto:
     def <=>(other : NumberLiteral) : NumberLiteral
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -318,7 +318,7 @@ module Crystal
       named_tuple_of(entries)
     end
 
-    # ditto
+    # :ditto:
     def named_tuple_of(entries : Array(NamedArgumentType))
       named_tuple.instantiate_named_args(entries)
     end

--- a/src/compiler/crystal/semantic/path_lookup.cr
+++ b/src/compiler/crystal/semantic/path_lookup.cr
@@ -38,7 +38,7 @@ module Crystal
       (path.global? ? program : self).lookup_path(path.names, lookup_in_namespace, include_private, location)
     end
 
-    # ditto
+    # :ditto:
     def lookup_path(names : Array(String), lookup_in_namespace = true, include_private = false, location = nil) : Type | ASTNode | Nil
       type = self
       names.each_with_index do |name, i|

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1056,13 +1056,18 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
   end
 
-  def check_ditto(node)
+  def check_ditto(node : Def | Assign | FunDef | Const) : Nil
+    return if !@program.wants_doc?
     stripped_doc = node.doc.try &.strip
-    if stripped_doc == ":ditto:" || stripped_doc == "ditto"
+    if stripped_doc == ":ditto:"
       node.doc = @last_doc
+    elsif stripped_doc == "ditto"
+      # TODO: remove after 0.33.0
+      @program.warning_failures << "`ditto` is no longer supported. Use `:ditto:` instead"
+      node.doc = @last_doc
+    else
+      @last_doc = node.doc
     end
-
-    @last_doc = node.doc
   end
 
   def annotations_doc(annotations)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -211,9 +211,14 @@ class Crystal::Doc::Generator
     toplevel_items.any? { |item| must_include? item }
   end
 
-  def nodoc?(str : String?)
-    return false unless str
-    str.starts_with?(":nodoc:") || str.starts_with?("nodoc")
+  def nodoc?(str : String?) : Bool
+    return false if !str || !@program.wants_doc?
+    # TODO: remove after 0.33.0
+    if str.starts_with?("nodoc")
+      @program.warning_failures << "`nodoc` is no longer supported. Use `:nodoc:` instead"
+      return true
+    end
+    str.starts_with?(":nodoc:")
   end
 
   def nodoc?(obj)

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -33,12 +33,12 @@ struct Complex
     @real == other.real && @imag == other.imag
   end
 
-  # ditto
+  # :ditto:
   def ==(other : Number)
     self == other.to_c
   end
 
-  # ditto
+  # :ditto:
   def ==(other)
     false
   end
@@ -235,7 +235,7 @@ struct Complex
     Complex.new(@real + other.real, @imag + other.imag)
   end
 
-  # ditto
+  # :ditto:
   def +(other : Number)
     Complex.new(@real + other, @imag)
   end
@@ -250,7 +250,7 @@ struct Complex
     Complex.new(@real - other.real, @imag - other.imag)
   end
 
-  # ditto
+  # :ditto:
   def -(other : Number)
     Complex.new(@real - other, @imag)
   end
@@ -260,7 +260,7 @@ struct Complex
     Complex.new(@real * other.real - @imag * other.imag, @real * other.imag + @imag * other.real)
   end
 
-  # ditto
+  # :ditto:
   def *(other : Number)
     Complex.new(@real * other, @imag * other)
   end
@@ -278,7 +278,7 @@ struct Complex
     end
   end
 
-  # ditto
+  # :ditto:
   def /(other : Number)
     Complex.new(@real / other, @imag / other)
   end

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -68,7 +68,7 @@ class CSV::Builder
     end
   end
 
-  # ditto
+  # :ditto:
   def row(*values)
     row values
   end
@@ -119,7 +119,7 @@ class CSV::Builder
       end
     end
 
-    # ditto
+    # :ditto:
     def <<(value : Nil | Bool | Number)
       case @quoting
       when .all?
@@ -133,7 +133,7 @@ class CSV::Builder
       end
     end
 
-    # ditto
+    # :ditto:
     def <<(value)
       self << value.to_s
     end
@@ -145,7 +145,7 @@ class CSV::Builder
       end
     end
 
-    # ditto
+    # :ditto:
     def concat(*values)
       concat values
     end

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -8,7 +8,7 @@ class Dir
     glob(patterns)
   end
 
-  # ditto
+  # :ditto:
   def self.[](patterns : Enumerable(String)) : Array(String)
     glob(patterns)
   end
@@ -24,7 +24,7 @@ class Dir
     glob(patterns, match_hidden: match_hidden)
   end
 
-  # ditto
+  # :ditto:
   def self.glob(patterns : Enumerable(String), match_hidden = false) : Array(String)
     paths = [] of String
     glob(patterns, match_hidden: match_hidden) do |path|
@@ -46,7 +46,7 @@ class Dir
     end
   end
 
-  # ditto
+  # :ditto:
   def self.glob(patterns : Enumerable(String), match_hidden = false, &block : String -> _)
     Globber.glob(patterns, match_hidden: match_hidden) do |path|
       yield path

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -53,7 +53,7 @@ struct Number
     end
   end
 
-  # ditto
+  # :ditto:
   def format(separator = '.', delimiter = ',', decimal_places : Int? = nil, *, group : Int = 3, only_significant : Bool = false) : String
     String.build do |io|
       format(io, separator, delimiter, decimal_places, group: group, only_significant: only_significant)
@@ -120,7 +120,7 @@ struct Number
     end
   end
 
-  # ditto
+  # :ditto:
   def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes = SI_PREFIXES) : String
     String.build do |io|
       humanize(io, precision, separator, delimiter, base: base, significant: significant, prefixes: prefixes)
@@ -222,7 +222,7 @@ struct Number
     io << unit
   end
 
-  # ditto
+  # :ditto:
   def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true) : String
     String.build do |io|
       humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, number|
@@ -231,14 +231,14 @@ struct Number
     end
   end
 
-  # ditto
+  # :ditto:
   def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : Nil
     humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, number|
       prefixes.call(magnitude, number)
     end
   end
 
-  # ditto
+  # :ditto:
   def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : Nil
     String.build do |io|
       humanize(io, precision, separator, delimiter, base: base, significant: significant, prefixes: prefixes)
@@ -299,7 +299,7 @@ struct Int
     end
   end
 
-  # ditto
+  # :ditto:
   def humanize_bytes(precision : Int = 3, separator = '.', *, significant : Bool = true, format : BinaryPrefixFormat = :IEC) : String
     String.build do |io|
       humanize_bytes(io, precision, separator, significant: significant, format: format)

--- a/src/io.cr
+++ b/src/io.cr
@@ -274,7 +274,7 @@ abstract class IO
     printf format_string, args
   end
 
-  # ditto
+  # :ditto:
   def printf(format_string, args : Array | Tuple) : Nil
     String::Formatter(typeof(args)).new(format_string, args, self).format
     nil

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -99,7 +99,7 @@ module Iterator(T)
     Iterator.stop
   end
 
-  # ditto
+  # :ditto:
   def self.stop
     Stop::INSTANCE
   end

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -226,17 +226,17 @@ class JSON::Builder
     null
   end
 
-  # ditto
+  # :ditto:
   def scalar(value : Bool)
     bool(value)
   end
 
-  # ditto
+  # :ditto:
   def scalar(value : Int | Float)
     number(value)
   end
 
-  # ditto
+  # :ditto:
   def scalar(value : String)
     string(value)
   end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -125,7 +125,7 @@ def printf(format_string, *args) : Nil
   printf format_string, args
 end
 
-# ditto
+# :ditto:
 def printf(format_string, args : Array | Tuple) : Nil
   STDOUT.printf format_string, args
 end
@@ -353,7 +353,7 @@ def sprintf(format_string, *args) : String
   sprintf format_string, args
 end
 
-# ditto
+# :ditto:
 def sprintf(format_string, args : Array | Tuple) : String
   String.build(format_string.bytesize) do |str|
     String::Formatter(typeof(args)).new(format_string, args, str).format

--- a/src/math/math.cr
+++ b/src/math/math.cr
@@ -15,12 +15,12 @@ module Math
       LibM.{{name.id}}_f32(value)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value : Float64)
       LibM.{{name.id}}_f64(value)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value)
       {{name.id}}(value.to_f)
     end
@@ -36,12 +36,12 @@ module Math
       {% end %}
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value : Float64)
       LibM.{{name.id}}_f64(value)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value)
       {{name.id}}(value.to_f)
     end
@@ -55,12 +55,12 @@ module Math
     LibM.tgamma_f32(value)
   end
 
-  # ditto
+  # :ditto:
   def gamma(value : Float64)
     LibM.tgamma_f64(value)
   end
 
-  # ditto
+  # :ditto:
   def gamma(value)
     gamma(value.to_f)
   end
@@ -82,12 +82,12 @@ module Math
     {% end %}
   end
 
-  # ditto
+  # :ditto:
   def lgamma(value : Float64)
     LibM.gamma_f64(value)
   end
 
-  # ditto
+  # :ditto:
   def lgamma(value)
     lgamma(value.to_f)
   end
@@ -98,12 +98,12 @@ module Math
       LibM.{{name.id}}_f32(value1, value2)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1 : Float64, value2 : Float64)
       LibM.{{name.id}}_f64(value1, value2)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1, value2)
       {{name.id}}(value1.to_f, value2.to_f)
     end
@@ -150,12 +150,12 @@ module Math
       {% end %}
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1 : Int32, value2 : Float64)
       LibM.{{name.id}}_f64(value1, value2)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1, value2)
       {{name.id}}(value1.to_i32, value1.to_f)
     end
@@ -167,12 +167,12 @@ module Math
       LibM.{{name.id}}_f32(value1, value2)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1 : Float64, value2 : Int32)
       LibM.{{name.id}}_f64(value1, value2)
     end
 
-    # ditto
+    # :ditto:
     def {{name.id}}(value1, value2)
       {{name.id}}(value1.to_f, value2.to_i32)
     end
@@ -183,12 +183,12 @@ module Math
     LibM.scalbln_f32(value, exp)
   end
 
-  # ditto
+  # :ditto:
   def scalbln(value : Float64, exp : Int64)
     LibM.scalbln_f64(value, exp)
   end
 
-  # ditto
+  # :ditto:
   def scalbln(value, exp)
     scalbln(value.to_f, exp.to_i64)
   end
@@ -199,13 +199,13 @@ module Math
     {frac, exp}
   end
 
-  # ditto
+  # :ditto:
   def frexp(value : Float64)
     frac = LibM.frexp_f64(value, out exp)
     {frac, exp}
   end
 
-  # ditto
+  # :ditto:
   def frexp(value)
     frexp(value.to_f)
   end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -213,7 +213,7 @@ struct NamedTuple
     merge(**other)
   end
 
-  # ditto
+  # :ditto:
   def merge(**other : **U) forall U
     {% begin %}
     {
@@ -306,7 +306,7 @@ struct NamedTuple
     false
   end
 
-  # ditto
+  # :ditto:
   def has_key?(key : String) : Bool
     {% for key in T %}
       return true if {{key.stringify}} == key
@@ -534,7 +534,7 @@ struct NamedTuple
     true
   end
 
-  # ditto
+  # :ditto:
   def ==(other : NamedTuple)
     return false unless sorted_keys == other.sorted_keys
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -97,22 +97,22 @@ struct Path
     new(name.check_no_null_byte, Kind.native)
   end
 
-  # ditto
+  # :ditto:
   def self.new(name : String, *parts) : Path
     new(name).join(*parts)
   end
 
-  # ditto
+  # :ditto:
   def self.[](name : String, *parts) : Path
     new(name, *parts)
   end
 
-  # ditto
+  # :ditto:
   def self.new(parts : Enumerable) : Path
     new("").join(parts)
   end
 
-  # ditto
+  # :ditto:
   def self.[](parts : Enumerable) : Path
     new(parts)
   end
@@ -122,12 +122,12 @@ struct Path
     new(name.check_no_null_byte, Kind::POSIX)
   end
 
-  # ditto
+  # :ditto:
   def self.posix(name : String, *parts) : Path
     posix(name).join(parts)
   end
 
-  # ditto
+  # :ditto:
   def self.posix(parts : Enumerable) : Path
     posix("").join(parts)
   end
@@ -137,12 +137,12 @@ struct Path
     new(name.check_no_null_byte, Kind::WINDOWS)
   end
 
-  # ditto
+  # :ditto:
   def self.windows(name : String, *parts) : Path
     windows(name).join(parts)
   end
 
-  # ditto
+  # :ditto:
   def self.windows(parts : Enumerable) : Path
     windows("").join(parts)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2526,7 +2526,7 @@ class String
     match.try &.begin(0)
   end
 
-  # ditto
+  # :ditto:
   def =~(other)
     nil
   end
@@ -2554,7 +2554,7 @@ class String
     end
   end
 
-  # ditto
+  # :ditto:
   def +(char : Char)
     bytes, count = String.char_bytes_and_bytesize(char)
     size = bytesize + count
@@ -2647,7 +2647,7 @@ class String
     nil
   end
 
-  # ditto
+  # :ditto:
   def index(search : String, offset = 0)
     offset += size if offset < 0
     return if offset < 0
@@ -2718,7 +2718,7 @@ class String
     end
   end
 
-  # ditto
+  # :ditto:
   def index(search : Regex, offset = 0)
     offset += size if offset < 0
     return nil unless 0 <= offset <= size
@@ -2765,7 +2765,7 @@ class String
     end
   end
 
-  # ditto
+  # :ditto:
   def rindex(search : String, offset = size - search.size)
     offset += size if offset < 0
     return if offset < 0
@@ -2818,7 +2818,7 @@ class String
     end
   end
 
-  # ditto
+  # :ditto:
   def rindex(search : Regex, offset = size - 1)
     offset += size if offset < 0
     return nil unless 0 <= offset <= size
@@ -2857,7 +2857,7 @@ class String
     {pre, mid, post}
   end
 
-  # ditto
+  # :ditto:
   def partition(search : Regex) : Tuple(String, String, String)
     pre = mid = post = ""
     case m = self.match(search)
@@ -2900,7 +2900,7 @@ class String
     {pre, mid, post}
   end
 
-  # ditto
+  # :ditto:
   def rpartition(search : Regex) : Tuple(String, String, String)
     match_result = nil
     pos = self.size - 1

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -401,7 +401,7 @@ struct Int
     Time::Span.new 7 * self, 0, 0, 0
   end
 
-  # ditto
+  # :ditto:
   def week : Time::Span
     weeks
   end
@@ -411,7 +411,7 @@ struct Int
     Time::Span.new self, 0, 0, 0
   end
 
-  # ditto
+  # :ditto:
   def day : Time::Span
     days
   end
@@ -421,7 +421,7 @@ struct Int
     Time::Span.new self, 0, 0
   end
 
-  # ditto
+  # :ditto:
   def hour : Time::Span
     hours
   end
@@ -431,7 +431,7 @@ struct Int
     Time::Span.new 0, self, 0
   end
 
-  # ditto
+  # :ditto:
   def minute : Time::Span
     minutes
   end
@@ -441,7 +441,7 @@ struct Int
     Time::Span.new 0, 0, self
   end
 
-  # ditto
+  # :ditto:
   def second : Time::Span
     seconds
   end
@@ -451,7 +451,7 @@ struct Int
     Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND)
   end
 
-  # ditto
+  # :ditto:
   def millisecond : Time::Span
     milliseconds
   end
@@ -461,7 +461,7 @@ struct Int
     Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MICROSECOND)
   end
 
-  # ditto
+  # :ditto:
   def microsecond : Time::Span
     microseconds
   end
@@ -471,7 +471,7 @@ struct Int
     Time::Span.new(nanoseconds: self.to_i64)
   end
 
-  # ditto
+  # :ditto:
   def nanosecond : Time::Span
     nanoseconds
   end
@@ -569,7 +569,7 @@ struct Int
     Time::MonthSpan.new(self)
   end
 
-  # ditto
+  # :ditto:
   def month : Time::MonthSpan
     months
   end
@@ -579,7 +579,7 @@ struct Int
     Time::MonthSpan.new(self * 12)
   end
 
-  # ditto
+  # :ditto:
   def year : Time::MonthSpan
     years
   end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -224,7 +224,7 @@ struct Tuple
     true
   end
 
-  # ditto
+  # :ditto:
   def ==(other : Tuple)
     return false unless size == other.size
 
@@ -297,7 +297,7 @@ struct Tuple
     0
   end
 
-  # ditto
+  # :ditto:
   def <=>(other : Tuple)
     min_size = Math.min(size, other.size)
     min_size.times do |i|

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -73,7 +73,7 @@ struct XML::Builder
     end
   end
 
-  # ditto
+  # :ditto:
   def element(__name__ : String, attributes : Hash | NamedTuple)
     start_element __name__
     attributes(attributes)
@@ -85,7 +85,7 @@ struct XML::Builder
     element(__name__, attributes)
   end
 
-  # ditto
+  # :ditto:
   def element(name : String, attributes : Hash | NamedTuple)
     element(name, attributes) { }
   end
@@ -98,7 +98,7 @@ struct XML::Builder
     end
   end
 
-  # ditto
+  # :ditto:
   def element(__prefix__ : String?, __name__ : String, __namespace_uri__ : String?, attributes : Hash | NamedTuple)
     start_element __prefix__, __name__, __namespace_uri__
     attributes(attributes)
@@ -110,7 +110,7 @@ struct XML::Builder
     element(prefix, name, namespace_uri, attributes)
   end
 
-  # ditto
+  # :ditto:
   def element(prefix : String?, name : String, namespace_uri : String?, attributes : Hash | NamedTuple)
     start_element(prefix, name, namespace_uri)
     attributes(attributes)
@@ -154,7 +154,7 @@ struct XML::Builder
     attributes(attributes)
   end
 
-  # ditto
+  # :ditto:
   def attributes(attributes : Hash | NamedTuple)
     attributes.each do |key, value|
       attribute key.to_s, value

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -6,12 +6,12 @@ struct XML::Node
     initialize(node.as(LibXML::Node*))
   end
 
-  # ditto
+  # :ditto:
   def initialize(node : LibXML::Doc*)
     initialize(node.as(LibXML::Node*))
   end
 
-  # ditto
+  # :ditto:
   def initialize(@node : LibXML::Node*)
   end
 
@@ -229,7 +229,7 @@ struct XML::Node
     next_node ? Node.new(next_node) : nil
   end
 
-  # ditto
+  # :ditto:
   def next_sibling
     self.next
   end


### PR DESCRIPTION
We are used to choose `:nodoc:` with colons but `ditto` without.
However the other variant is also supported, `nodoc` and `:ditto:` could also be used.
Using colons shows that they are special semantics and not another comments.

Since `# :nodoc:` is always used vs. `# nodoc`, the diffs are mainly about changing `# ditto` to `# :ditto:`.