### PR TITLE
Syntax: allow empty `case` without `when`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -494,6 +494,12 @@ describe Crystal::Formatter do
   assert_format "case 1\nwhen 1, # 1\n     2, # 2\n     3  # 3\n  1\nend"
   assert_format "a = case 1\n    when 1, # 1\n         2, # 2\n         3  # 3\n      1\n    end"
   assert_format "a = 1\ncase\nwhen 2\nelse\n  a /= 3\nend"
+  assert_format "case 1\nend"
+  assert_format "case 1\nelse\n  2\nend"
+  assert_format "case\nend"
+  assert_format "case 1\nend"
+  assert_format "case\nend"
+  assert_format "case\nelse\n  1\nend"
 
   assert_format "select   \n when  foo \n 2 \n end", "select\nwhen foo\n  2\nend"
   assert_format "select   \n when  foo \n 2 \n when bar \n 3 \n end", "select\nwhen foo\n  2\nwhen bar\n  3\nend"

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -100,4 +100,20 @@ describe "Normalize: case" do
   it "normalizes case with multiple expressions and non-tuple" do
     assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
   end
+
+  it "normalizes case without when and else" do
+    assert_expand "case x; end", "x"
+  end
+
+  it "normalizes case without when but else" do
+    assert_expand "case x; else; y; end", "x\ny"
+  end
+
+  it "normalizes case without cond, when and else" do
+    assert_expand "case; end", ""
+  end
+
+  it "normalizes case without cond, when but else" do
+    assert_expand "case; else; y; end", "y"
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -373,6 +373,18 @@ module Crystal
     #     end
     def expand(node : Case)
       node_cond = node.cond
+
+      if node.whens.empty?
+        expressions = [] of ASTNode
+        if node_cond
+          expressions << node_cond
+        end
+        if node_else = node.else
+          expressions << node_else
+        end
+        return Expressions.new(expressions).at(node)
+      end
+
       if node_cond
         if node_cond.is_a?(TupleLiteral)
           conds = node_cond.elements

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2454,7 +2454,11 @@ module Crystal
     def parse_case
       slash_is_regex!
       next_token_skip_space_or_newline
-      unless @token.keyword?(:when)
+      while @token.type == :";"
+        next_token_skip_space
+      end
+
+      unless @token.keyword? && {:when, :else, :end}.includes?(@token.value)
         cond = parse_op_assign_no_control
         skip_statement_end
       end
@@ -2527,9 +2531,6 @@ module Crystal
             skip_space_or_newline
             whens << When.new(when_conds, when_body).at(location)
           when :else
-            if whens.size == 0
-              unexpected_token @token.to_s, "expecting when"
-            end
             next_token_skip_statement_end
             a_else = parse_expressions
             skip_statement_end
@@ -2537,9 +2538,6 @@ module Crystal
             next_token
             break
           when :end
-            if whens.empty?
-              unexpected_token @token.to_s, "expecting when or else"
-            end
             next_token
             break
           else


### PR DESCRIPTION
Fixes #6318

The following is no longer a syntax error:
```cr
case foo # expands to `foo`
end

case foo # expands to `foo; bar`
else
  bar
end
```

While an empty case doesn't make much sense in regular code, it is useful for automatically generated `when` branches (for example in a macro) and avoids extra effort to prevent empty case nodes.

This also fixes a parsing error for `case` without condition (`case;
when true; end`) and adds specs for this.