### PR TITLE
Add pp! and p! macro methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1686,5 +1686,52 @@ module Crystal
     it "compares versions" do
       assert_macro "", %({{compare_versions("1.10.3", "1.2.3")}}), [] of ASTNode, %(1)
     end
+
+    describe "printing" do
+      it "puts" do
+        String.build do |io|
+          assert_macro "foo", %({% puts foo %}), "" do |program|
+            program.stdout = io
+            ["bar".string] of ASTNode
+          end
+        end.should eq %("bar"\n)
+      end
+
+      it "p" do
+        String.build do |io|
+          assert_macro "foo", %({% p foo %}), "" do |program|
+            program.stdout = io
+            ["bar".string] of ASTNode
+          end
+        end.should eq %("bar"\n)
+      end
+
+      it "p!" do
+        String.build do |io|
+          assert_macro "foo", "{% p! foo %}", "" do |program|
+            program.stdout = io
+            ["bar".string] of ASTNode
+          end
+        end.should eq %(foo # => "bar"\n)
+      end
+
+      it "pp" do
+        String.build do |io|
+          assert_macro "foo", "{% pp foo %}", "" do |program|
+            program.stdout = io
+            ["bar".string] of ASTNode
+          end
+        end.should eq %("bar"\n)
+      end
+
+      it "pp!" do
+        String.build do |io|
+          assert_macro "foo", "{% pp! foo %}", "" do |program|
+            program.stdout = io
+            ["bar".string] of ASTNode
+          end
+        end.should eq %(foo # => "bar"\n)
+      end
+    end
   end
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -20,10 +20,10 @@ module Crystal
         interpret_env(node)
       when "flag?"
         interpret_flag?(node)
-      when "puts", "p"
+      when "puts", "p", "pp"
         interpret_puts(node)
-      when "pp"
-        interpret_pp(node)
+      when "p!", "pp!"
+        interpret_pp!(node)
       when "skip_file"
         interpret_skip_file(node)
       when "system", "`"
@@ -122,7 +122,7 @@ module Crystal
       @last = Nop.new
     end
 
-    def interpret_pp(node)
+    def interpret_pp!(node)
       strings = [] of {String, String}
 
       node.args.each do |arg|


### PR DESCRIPTION
This mirrors the recent additions of `pp!` and `p!` methods in Crystal stdlib to the macro interpreter.

The macro interpreter doesn't use pretty printing, so `p` and `pp` as well as `p!` and `pp!` behave the same, but all are available for convenience.