### PR TITLE
Proof of Concept: detect stack overflows (x86_64-linux-gnu target only)

### DIFF
--- a/src/lib_c/x86_64-linux-gnu/c/sys/resource.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/resource.cr
@@ -1,0 +1,12 @@
+lib LibC
+  alias RlimT = ULong
+
+  struct Rlimit
+    rlim_cur : RlimT
+    rlim_max : RlimT
+  end
+
+  fun getrlimit(Int, Rlimit*) : Int
+
+  RLIMIT_STACK = 3
+end


### PR DESCRIPTION
I noticed that memory accesses that segfaults are near the bottom of stack, that is within the stack guard allocated by the kernel —I initially expected the guard to be *after* the stack, but it's actually within it. Checking if `addr` in the segfault handler (the faulting memory address) is within the stack of the current fiber stack is enough to detect a stack overflow.

Since the main fiber doesn't have a `@stack`, I use `getrlimit(2)` to get the default stack size and determine the main stack limit. I only added bindings for x86_64-linux-gnu, but they should be the same for all Linux libc.

I don't know how other POSIX systems (Darwin, OpenBSD, FreeBSD) handle their stack guard.

NOTE: there could a `Crystal::System.within_current_stack?(addr)` or `stack_overflow?` method.

refs #271