### PR TITLE
http: support serving wasm by StaticFileHandler

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -133,6 +133,7 @@ class HTTP::StaticFileHandler
     when ".css"          then "text/css"
     when ".js"           then "application/javascript"
     when ".svg"          then "image/svg+xml"
+    when ".wasm"         then "application/wasm"
     else                      "application/octet-stream"
     end
   end


### PR DESCRIPTION
This is import to serve wasm file. Browsers don't run wasm without correct 'Content-Type'.

@straight-shoota Can you add `wasm` mime type to #5765 when this is merged?