### PR TITLE
Fix: named arguments expanded from double splat clash with local variable names

### DIFF
--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -161,19 +161,19 @@ module Crystal
     it "expands a def with double splat and two named args" do
       a_def = parse("def foo(**options); options; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0, ["x", "y"])
-      other_def.to_s.should eq("def foo:x:y(x, y)\n  options = {x: x, y: y}\n  options\nend")
+      other_def.to_s.should eq("def foo:x:y(x __temp_1, y __temp_2)\n  options = {x: __temp_1, y: __temp_2}\n  options\nend")
     end
 
     it "expands a def with double splat and two named args and regular args" do
       a_def = parse("def foo(y, **options); y + options; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0, ["x", "y", "z"])
-      other_def.to_s.should eq("def foo:x:y:z(x, y, z)\n  options = {x: x, z: z}\n  y + options\nend")
+      other_def.to_s.should eq("def foo:x:y:z(x __temp_1, y, z __temp_3)\n  options = {x: __temp_1, z: __temp_3}\n  y + options\nend")
     end
 
     it "expands a def with splat and double splat" do
       a_def = parse("def foo(*args, **options); args + options; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 2, ["x", "y"])
-      other_def.to_s.should eq("def foo:x:y(__temp_1, __temp_2, x, y)\n  args = {__temp_1, __temp_2}\n  options = {x: x, y: y}\n  args + options\nend")
+      other_def.to_s.should eq("def foo:x:y(__temp_1, __temp_2, x __temp_3, y __temp_4)\n  args = {__temp_1, __temp_2}\n  options = {x: __temp_3, y: __temp_4}\n  args + options\nend")
     end
 
     it "expands arg with default value after splat" do
@@ -218,6 +218,12 @@ module Crystal
       actual = a_def.expand_default_arguments(Program.new, 1)
       expected = parse("def foo(x x1); y1 = 1; z1 = 2; yield x1 + y1 + z1; end")
       actual.should eq(expected)
+    end
+
+    it "expands a new def with double splat and two named args and regular args" do
+      a_def = parse("def new(y, **options); y + options; end").as(Def)
+      other_def = a_def.expand_new_default_arguments(Program.new, 0, ["x", "y", "z"])
+      other_def.to_s.should eq("def new:x:y:z(x __temp_1, y __temp_2, z __temp_3)\n  _ = allocate\n  _.initialize(x: __temp_1, y: __temp_2, z: __temp_3)\n  if _.responds_to?(:finalize)\n    ::GC.add_finalizer(_)\n  end\n  _\nend")
     end
   end
 end

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -68,18 +68,25 @@ class Crystal::Def
     end
 
     if named_args
+      # When **opts is expanded for named arguments, we must use internal
+      # names that won't clash with local variables defined in the method.
+      named_args_temp_names = Array(String).new(named_args.size)
+
       new_name = String.build do |str|
         str << name
         named_args.each do |named_arg|
           str << ':'
           str << named_arg
 
+          temp_name = program.new_temp_var_name
+          named_args_temp_names << temp_name
+
           # If a named argument matches an argument's external name, use the internal name
           matching_arg = args.find { |arg| arg.external_name == named_arg }
           if matching_arg
             new_args << Arg.new(matching_arg.name, external_name: named_arg)
           else
-            new_args << Arg.new(named_arg)
+            new_args << Arg.new(temp_name, external_name: named_arg)
           end
         end
       end
@@ -146,11 +153,12 @@ class Crystal::Def
       # Double splat argument
       if double_splat
         named_tuple_entries = [] of NamedTupleLiteral::Entry
-        named_args.try &.each do |named_arg|
+        named_args.try &.each_with_index do |named_arg, i|
           # Don't put here regular arguments
           next if args.any? &.name.==(named_arg)
 
-          named_tuple_entries << NamedTupleLiteral::Entry.new(named_arg, Var.new(named_arg))
+          temp_name = named_args_temp_names.not_nil![i]
+          named_tuple_entries << NamedTupleLiteral::Entry.new(named_arg, Var.new(temp_name))
         end
         named_tuple = NamedTupleLiteral.new(named_tuple_entries).at(double_splat)
         new_body << Assign.new(Var.new(double_splat.name).at(double_splat), named_tuple).at(double_splat)

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -177,7 +177,7 @@ module Crystal
         # Check if the argument has to be passed as a named argument
         if splat_index && i > splat_index
           named_args ||= [] of NamedArgument
-          named_args << NamedArgument.new(arg.name, Var.new(arg.name).at(self)).at(self)
+          named_args << NamedArgument.new(arg.external_name, Var.new(arg.name).at(self)).at(self)
         else
           new_var = Var.new(arg.name).at(self)
           new_var = Splat.new(new_var).at(self) if i == splat_index
@@ -266,7 +266,11 @@ module Crystal
           named_args.each do |named_arg|
             str << ':'
             str << named_arg
-            def_args << Arg.new(named_arg)
+
+            # When **opts is expanded for named arguments, we must use internal
+            # names that won't clash with local variables defined in the method.
+            temp_name = instance_type.program.new_temp_var_name
+            def_args << Arg.new(temp_name, external_name: named_arg)
             i += 1
           end
         end


### PR DESCRIPTION
Fixes #5693

When there's code like this:

```crystal
def foo(**opts)
  opts
end

foo(x: 1, y: 2)
```

the compiler transforms it to something like this (call, per call):

```crystal
def foo:x:y(x, y)
  opts = {x: x, y: y}
  # next comes the original def's body, in this case just "opts"
  opts
end

foo(x: 1, y: 2)
```

The problem with that approach is that this will not work correctly if the method already defined `x` or `y` as local variables. This:

```crystal
def foo(**opts)
  x = 1
  opts
end

foo(x: 1, y: 2)
```

gets expanded to:

```crystal
def foo:x:y(x, y)
  opts = {x: x, y: y}
  x = 1
  opts
end

foo(x: 1, y: 2)
```

This isn't usually a problem unless `x` is declared as a local variable with `x : Type`, or if x is captured in a closure.

The solution in this PR changes the expansion to be:

```crystal
def foo:x:y(x __temp_1, y __temp_2)
  opts = {x: __temp_1, y: __temp_2}
  x = 1
  opts
end

foo(x: 1, y: 2)
```

That way there's no clash.

(well, there could be a clash with those temp names, but variables that start with underscore are reserved for the compiler, more so ones with double underscore (this is used all over the compiler, not just here))