### PR TITLE
Autodetect llvm-config-6.0 / llvm-config60

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src")
 SHELL = sh
 LLVM_CONFIG_FINDER := \
   [ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+  command -v llvm-config-6.0 || command -v llvm-config60 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 6.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-5.0 || command -v llvm-config50 || \
     (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 5.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-4.0 || command -v llvm-config40 || \

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -2,6 +2,8 @@
 lib LibLLVM
   LLVM_CONFIG = {{
                   `[ -n "$LLVM_CONFIG" ] && command -v "$LLVM_CONFIG" || \
+                   command -v llvm-config-6.0 || command -v llvm-config60 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 6.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-5.0 || command -v llvm-config50 || \
                    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 5.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-4.0 || command -v llvm-config40 || \


### PR DESCRIPTION
Extend the llvm-config finder code to autodetect suffixed versions for LLVM 6.0.

These suffixed versions are for example used by the https://apt.llvm.org packages.