### PR TITLE
Fix version check for LLVM < 6.0

### DIFF
--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -60,7 +60,7 @@ LLVMDIBuilderRef LLVMNewDIBuilder(LLVMModuleRef mref) {
   return wrap(new DIBuilder(*m));
 }
 
-#if LLVM_VERSION_LE(5, 9)
+#if LLVM_VERSION_LE(5, 0)
 void LLVMDIBuilderFinalize(LLVMDIBuilderRef dref) { unwrap(dref)->finalize(); }
 #endif
 


### PR DESCRIPTION
This is a minor fixup for the LLVM 6.0 support quick fix  (#6380) that changes the versions check for "below 6.0" (<= 5.9) to <= 5.0 since there wont be any new 5.x versions after 5.0.