### PR TITLE
Fix reference links to .from_io methods

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -877,7 +877,7 @@ abstract class IO
   # `from_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)`
   # method can be read in this way.
   #
-  # See `Int.from_io` and `Float.from_io`.
+  # See `Int#from_io` and `Float#from_io`.
   #
   # ```
   # io = IO::Memory.new


### PR DESCRIPTION
Ref: [`read_bytes`](https://crystal-lang.org/api/master/IO.html#read_bytes%28type%2Cformat%3AIO%3A%3AByteFormat%3DIO%3A%3AByteFormat%3A%3ASystemEndian%29-instance-method)

Notice the "See ..." section

![image](https://user-images.githubusercontent.com/3067335/42725515-3f77543e-874a-11e8-8047-62bd37f95573.png)

Comparison to [`write_bytes`](https://crystal-lang.org/api/master/IO.html#write_bytes(object,format:IO::ByteFormat=IO::ByteFormat::SystemEndian)-instance-method)

![image](https://user-images.githubusercontent.com/3067335/42725523-7a82eba6-874a-11e8-8596-b7316bcd4d71.png)
