### PR TITLE
Fix udp example for udp method on Socket::Addrinfo

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -141,7 +141,7 @@ class Socket
     #
     # Example:
     # ```
-    # addrinfos = Socket::Addrinfo.tcp("example.org", 53)
+    # addrinfos = Socket::Addrinfo.udp("example.org", 53)
     # ```
     def self.udp(domain, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
       resolve(domain, service, family, Type::DGRAM, Protocol::UDP)


### PR DESCRIPTION
See `Example:`

![image](https://user-images.githubusercontent.com/3067335/42729316-b7a6ea4c-8799-11e8-895a-ee31824625c0.png)

Ref: [`def self.udp(...)`](https://crystal-lang.org/api/master/Socket/Addrinfo.html#udp%28domain%2Cservice%2Cfamily%3DFamily%3A%3AUNSPEC%2Ctimeout%3Dnil%29%3AArray%28Addrinfo%29-class-method)
