### PR TITLE
Format: fix to use right alignment only if all whens are number literal

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -502,7 +502,6 @@ describe Crystal::Formatter do
   assert_format "case 1\nend"
   assert_format "case\nend"
   assert_format "case\nelse\n  1\nend"
-  assert_format "case 1\nwhen 1\n  1\nwhen 123\n  2\nwhen 1..123\n  3\nelse\n  4\nend"
 
   assert_format "select   \n when  foo \n 2 \n end", "select\nwhen foo\n  2\nend"
   assert_format "select   \n when  foo \n 2 \n when bar \n 3 \n end", "select\nwhen foo\n  2\nwhen bar\n  3\nend"
@@ -848,6 +847,7 @@ describe Crystal::Formatter do
   assert_format "case 1\nwhen \"foo\"      then 3\nwhen \"lalalala\" then 4\nelse                 5\nend"
   assert_format "case 1        # foo\nwhen 2 then 3 # bar\nwhen 4 then 5 # baz\nelse        6 # zzz\nend"
   assert_format "case 1\nwhen 8     then 1\nwhen 16    then 2\nwhen 256   then 3\nwhen 'a'   then 5\nwhen \"foo\" then 6\nelse            4\nend"
+  assert_format "case 1\nwhen 1      then 1\nwhen 123    then 2\nwhen 1..123 then 3\nelse             4\nend"
   assert_format "macro bar\n  1\nend\n\ncase 1\nwhen  2 then 3\nwhen 45 then 6\nend"
   assert_format "{\n         1 => 2,\n        10 => 30,\n        30 => 40,\n  \"foobar\" => 50,\n  \"coco\"   => 60,\n}"
   assert_format "{1 => 2, 3 => 4}\n{5234234 => 234098234, 7 => 8}"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -502,6 +502,7 @@ describe Crystal::Formatter do
   assert_format "case 1\nend"
   assert_format "case\nend"
   assert_format "case\nelse\n  1\nend"
+  assert_format "case 1\nwhen 1\n  1\nwhen 123\n  2\nwhen 1..123\n  3\nelse\n  4\nend"
 
   assert_format "select   \n when  foo \n 2 \n end", "select\nwhen foo\n  2\nend"
   assert_format "select   \n when  foo \n 2 \n when bar \n 3 \n end", "select\nwhen foo\n  2\nwhen bar\n  3\nend"
@@ -846,7 +847,7 @@ describe Crystal::Formatter do
   assert_format "case 1\nwhen \"foo\"     ; 3\nwhen \"lalalala\"; 4\nelse             5\nend"
   assert_format "case 1\nwhen \"foo\"      then 3\nwhen \"lalalala\" then 4\nelse                 5\nend"
   assert_format "case 1        # foo\nwhen 2 then 3 # bar\nwhen 4 then 5 # baz\nelse        6 # zzz\nend"
-  assert_format "case 1\nwhen     8 then 1\nwhen    16 then 2\nwhen   256 then 3\nwhen 'a'   then 5\nwhen \"foo\" then 6\nelse            4\nend"
+  assert_format "case 1\nwhen 8     then 1\nwhen 16    then 2\nwhen 256   then 3\nwhen 'a'   then 5\nwhen \"foo\" then 6\nelse            4\nend"
   assert_format "macro bar\n  1\nend\n\ncase 1\nwhen  2 then 3\nwhen 45 then 6\nend"
   assert_format "{\n         1 => 2,\n        10 => 30,\n        30 => 40,\n  \"foobar\" => 50,\n  \"coco\"   => 60,\n}"
   assert_format "{1 => 2, 3 => 4}\n{5234234 => 234098234, 7 => 8}"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3355,8 +3355,10 @@ module Crystal
 
       skip_space_write_line
 
+      align_number = node.whens.all? { |a_when| a_when.conds.size === 1 && a_when.conds.first.is_a?(NumberLiteral) }
+
       node.whens.each_with_index do |a_when, i|
-        format_when(node, a_when, last?(i, node.whens))
+        format_when(node, a_when, last?(i, node.whens), align_number)
         skip_space_or_newline(@indent + 2)
       end
 
@@ -3391,7 +3393,7 @@ module Crystal
       false
     end
 
-    def format_when(case_node, node, is_last)
+    def format_when(case_node, node, is_last, align_number)
       skip_space_or_newline
 
       slash_is_regex!
@@ -3441,8 +3443,7 @@ module Crystal
           when_column_end = @column
           accept node.body
           if @line == when_start_line
-            number = node.conds.size == 1 && node.conds.first.is_a?(NumberLiteral)
-            @when_infos << AlignInfo.new(case_node.object_id, @line, when_start_column, when_column_middle, when_column_end, number)
+            @when_infos << AlignInfo.new(case_node.object_id, @line, when_start_column, when_column_middle, when_column_end, align_number)
           end
           found_comment = skip_space
           write_line unless found_comment


### PR DESCRIPTION
Fix #6366

#6366 example is now formatted to:

```crystal
def to_pretty(t)
  a = (Time.now - t).to_i

  case a
  when 0               then "just now"
  when 1               then "a second ago"
  when 2..59           then a.to_s + " seconds ago"
  when 60..119         then "a minute ago" # 120 = 2 minutes
  when 120..3540       then (a/60).to_i.to_s + " minutes ago"
  when 3541..7100      then "an hour ago" # 3600 = 1 hour
  when 7101..82800     then ((a + 99)/3600).to_i.to_s + " hours ago"
  when 82801..172000   then "a day ago" # 86400 = 1 day
  when 172001..518400  then ((a + 800)/(60*60*24)).to_i.to_s + " days ago"
  when 518400..1036800 then "a week ago"
  else                      ((a + 180000)/(60*60*24*7)).to_i.to_s + " weeks ago"
  end
end
```