### PR TITLE
(WIP) Optimize String#gsub with block

### DIFF
--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -61,9 +61,15 @@ describe JSON::Builder do
     end
   end
 
-  it "writes string with controls and slashes " do
-    assert_built("\" \\\" \\\\ \\b \\f \\n \\r \\t \\u0019 \"") do
-      string(" \" \\ \b \f \n \r \t \u{19} ")
+  it "writes string with controls and slashes" do
+    assert_built(%(" \\\" \\\\ \\b \\f \\n \\r \\t \\u0019")) do |json|
+      string(" \" \\ \b \f \n \r \t \u{19}")
+    end
+  end
+
+  it "writes string with utf-8" do
+    assert_built(%("\u{1F609}")) do |json|
+      string("\u{1F609}")
     end
   end
 

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -73,12 +73,10 @@ class CSV::Builder
   def quote_cell(value)
     append_cell do
       @io << @quote_char
-      value.each_byte do |byte|
-        case byte
+      value.gsub(@io, ascii_only: true) do |char|
+        case char
         when @quote_char
-          @io << @quote_char << @quote_char
-        else
-          @io.write_byte byte
+          next @quote_char, @quote_char
         end
       end
       @io << @quote_char

--- a/src/html.cr
+++ b/src/html.cr
@@ -33,8 +33,8 @@ module HTML
   # io.to_s                          # => "Crystal &amp; You"
   # ```
   def self.escape(string : String, io : IO) : Nil
-    string.each_char do |char|
-      io << SUBSTITUTIONS.fetch(char, char)
+    string.gsub(io) do |char|
+      next SUBSTITUTIONS[char]?
     end
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -298,14 +298,13 @@ module HTTP
   def self.quote_string(string, io)
     # Escaping rules: https://evolvis.org/pipermail/evolvis-platfrm-discuss/2014-November/000675.html
 
-    string.each_byte do |byte|
-      case byte
-      when '\t'.ord, ' '.ord, '"'.ord, '\\'.ord
-        io << '\\'
-      when 0x00..0x1F, 0x7F
-        raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+    string.gsub(io, ascii_only: true) do |char|
+      case char
+      when '\t', ' ', '"', '\\'
+        next '\\', char
+      when '\u{00}'..'\u{1F}', '\u{7F}'
+        raise ArgumentError.new("String contained invalid character #{char.inspect}")
       end
-      io.write_byte byte
     end
   end
 

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -354,6 +354,26 @@ struct Slice(T)
     source.move_to(self)
   end
 
+  def gsub(buffer, &block : T -> _)
+    current_chunk_start = 0
+    each_index do |pos|
+      item = unsafe_at(pos)
+      if result = yield item
+        buffer.write Slice.new(to_unsafe + current_chunk_start, pos - current_chunk_start)
+        current_chunk_start = pos + 1
+
+        if result.is_a?(Tuple)
+          result.each { |part| buffer << part }
+        else
+          buffer << result
+        end
+      end
+    end
+    unless current_chunk_start == size
+      buffer.write Slice.new(to_unsafe + current_chunk_start, size - current_chunk_start)
+    end
+  end
+
   def inspect(io)
     to_s(io)
   end


### PR DESCRIPTION
When replacing characters in a string, typically only a minority of characters are changed like most most escaping or encoding use-cases. Currently, `String#gsub` loops through the string, yields each character and writes the return to an IO. However, these single-character writes are not as efficient as writing a larger slice.

The best example for this is a string with no replacement. In the previous implementation, it would be copied byte-by-byte (or rather char-by-char) to a new string. If some characters need to be replaced, the size of the slices that can be copied as whole is smaller, but it's still considerably faster than writing byte-by-byte.

An algorithm that only writes replaced chars and copies a series of unchanged characters in bulk can improve performance considerably.
This approach was previously used by a custom implementation in [`JSON::Builder#string`](https://github.com/crystal-lang/crystal/blob/466e0a2201c2e5b225cf4452993a95353c2b63d7/src/json/builder.cr#L95-L146).

In this PR, the proposed implementation of `String#gsub` yields each char and only writes the returned value if it is not `nil`. When using this method, returning `nil` signals that the current character can be copied as is and multiple `nil` returns are combined to a larger slice copy.

I also added a method variant receiving an `io` for better integration. And there is a similar `Slice#gsub` method, which is utilized for ascii-only strings (ore replacements). This method is part of the public API of `Slice` because it could be useful for any slice to replace some elements. It requires some sort of builder with an `IO` API, so currently it's only  effectively usable for `Slice(UInt8)`.

```
replace 6/49 chars: "Alle meine Entchen schwimmen auf dem Sä".gsub(' ', '-')

                   old   1.15M (865.84ns) (±12.39%)  192 B/op   1.36× slower
                   new 883.68k (  1.13µs) (±14.82%)  160 B/op   1.77× slower
new (ascii_only: true)   1.57M (637.87ns) (±10.70%)  160 B/op        fastest
```

```
replace all: "äääääääääääääääää".gsub('ä', '-')

                   old   1.03M (971.22ns) (±11.46%)  144 B/op   1.02× slower
                   new 739.62k (  1.35µs) (± 9.79%)  144 B/op   1.42× slower
new (ascii_only: true)   1.05M (948.91ns) (± 9.81%)  144 B/op        fastest
```

```
replace none: "Alle-meine-Entchen-schwimmen-auf-dem-Sä".gsub(' ', '-')

                   old   1.57M (638.41ns) (±15.57%)  176 B/op   1.60× slower
                   new   1.17M (852.01ns) (±10.92%)  160 B/op   2.13× slower
new (ascii_only: true)   2.51M (399.19ns) (±15.46%)  160 B/op        fastest
```

I also tested `JSON::Builder#string` and the new gsub is even slightly faster than the previous implementation because it doesn't need to decode multibyte chars (they won't be replaced anyway).

```
simple string
old   4.75M (210.51ns) (±20.85%)  12 B/op   1.15× slower
new   5.45M (183.33ns) (±29.58%)  13 B/op        fastest
many replacements
old 648.03k (  1.54µs) (±18.61%)  149 B/op   1.05× slower
new 683.31k (  1.46µs) (±20.73%)  203 B/op        fastest
normal replacements
old 812.58k (  1.23µs) (±25.99%)  253 B/op   1.25× slower
new   1.01M (985.81ns) (±25.16%)  282 B/op        fastest
```

Obviously, there are cases where the previous, simple implementation is equal or even more performant then the proposed batch copy. This is typically the case when there is a high amount and equal distribution of replaced chars, especially in ascii-only strings. For some use cases, a customized replace loop can achieve more performance than this generalized `String#gsub`.

In total, I expect this to be an improvement (backed by the benchmarks) because replacements are usually less frequent in most applications.