### PR TITLE
HTTP::Client: set `connection: close` header on one-shot requests

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -129,6 +129,8 @@ module HTTP
       spawn { server.listen }
 
       HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("[::1]:#{address.port}")
+
+      server.close
     end
 
     it "doesn't read the body if request was HEAD" do

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -133,6 +133,32 @@ module HTTP
       server.close
     end
 
+    it "sends a 'connection: close' header on one-shot request" do
+      server = HTTP::Server.new do |context|
+        context.response.print context.request.headers["connection"]
+      end
+      address = server.bind_unused_port "::1"
+      spawn { server.listen }
+
+      HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("close")
+
+      server.close
+    end
+
+    it "sends a 'connection: close' header on one-shot request with block" do
+      server = HTTP::Server.new do |context|
+        context.response.print context.request.headers["connection"]
+      end
+      address = server.bind_unused_port "::1"
+      spawn { server.listen }
+
+      HTTP::Client.get("http://[::1]:#{address.port}/") do |response|
+        response.body_io.gets_to_end
+      end.should eq("close")
+
+      server.close
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = TestServer.open("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)


### PR DESCRIPTION
Fixes #6401

Also adds a missing `server.close` in specs