### PR TITLE
Compiler: evaluate instance var initializers at the metaclass level

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -646,7 +646,7 @@ describe "Code gen: class" do
   it "doesn't crash on instance variable assigned a proc, and never instantiated (#923)" do
     codegen(%(
       class Klass
-        def f(arg)
+        def self.f(arg)
         end
 
         @a : Proc(String, Nil) = ->f(String)
@@ -1030,5 +1030,41 @@ describe "Code gen: class" do
       foo.foo = {Foo.new(2), Foo.new(3)}
       foo.x
       ), inject_primitives: false).to_i.should eq(1)
+  end
+
+  it "runs instance variable initializer at the class level" do
+    run(%(
+      class Foo
+        @x : Int32 = bar
+
+        def self.bar
+          42
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )).to_i.should eq(42)
+  end
+
+  it "runs instance variable initializer at the class level, for generic type" do
+    run(%(
+      class Foo(T)
+        @x : T = bar
+
+        def self.bar
+          42
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo(Int32).new.x
+      )).to_i.should eq(42)
   end
 end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -724,7 +724,7 @@ describe "Code gen: proc" do
       class Foo
         @f : -> Int32 = ->foo
 
-        def foo
+        def self.foo
           42
         end
       end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -854,7 +854,7 @@ describe "Semantic: class" do
   it "doesn't crash on instance variable assigned a proc, and never instantiated (#923)" do
     assert_type(%(
       class Klass
-        def f(arg)
+        def self.f(arg)
         end
 
         @a  : Proc(String, Nil) = ->f(String)

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5042,4 +5042,71 @@ describe "Semantic: instance var" do
       Second.new.hash
       )) { hash_of(hash_of(int32, int32).virtual_type, int32).virtual_type }
   end
+
+  it "doesn't solve instance var initializer in instance context (1) (#5876)" do
+    assert_error %(
+      class Foo
+        @x : Int32 = bar
+
+        def bar
+          1
+        end
+      end
+
+      Foo.new
+      ),
+      "undefined local variable or method 'bar'"
+  end
+
+  it "doesn't solve instance var initializer in instance context (2) (#5876)" do
+    assert_error %(
+      class Foo(T)
+        @x : T = bar
+
+        def bar
+          1
+        end
+      end
+
+      Foo(Int32).new
+      ),
+      "undefined local variable or method 'bar'"
+  end
+
+  it "doesn't solve instance var initializer in instance context (3) (#5876)" do
+    assert_error %(
+      module Moo(T)
+        @x : T = bar
+
+        def bar
+          1
+        end
+      end
+
+      class Foo
+        include Moo(Int32)
+      end
+
+      Foo.new
+      ),
+      "undefined local variable or method 'bar'"
+  end
+
+  it "solves instance var initializer in metaclass context (#5876)" do
+    assert_type(%(
+      class Foo
+        @x : Int32 = bar
+
+        def self.bar
+          1
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1831,9 +1831,8 @@ module Crystal
         with_cloned_context do
           # Instance var initializers must run with "self"
           # properly set up to the type being allocated
-          context.type = real_type
+          context.type = real_type.metaclass
           context.vars = LLVMVars.new
-          context.vars["self"] = LLVMVar.new(type_ptr, real_type)
           alloca_vars init.meta_vars
 
           accept init.value

--- a/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
@@ -103,7 +103,7 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
       end
 
       ivar_visitor = MainVisitor.new(program, meta_vars: i.meta_vars)
-      ivar_visitor.scope = scope
+      ivar_visitor.scope = scope.metaclass
       value.accept ivar_visitor
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -945,7 +945,7 @@ module Crystal
       if !meta_vars && !self.is_a?(GenericType)
         meta_vars = MetaVars.new
         visitor = MainVisitor.new(program, vars: meta_vars, meta_vars: meta_vars)
-        visitor.scope = self
+        visitor.scope = self.metaclass
         value = value.clone
         value.accept visitor
       end
@@ -1460,7 +1460,7 @@ module Crystal
     def run_instance_var_initializer(initializer, instance : GenericClassInstanceType | NonGenericClassType)
       meta_vars = MetaVars.new
       visitor = MainVisitor.new(program, vars: meta_vars, meta_vars: meta_vars)
-      visitor.scope = instance
+      visitor.scope = instance.metaclass
       value = initializer.value.clone
       value.accept visitor
       instance_var = instance.lookup_instance_var(initializer.name)


### PR DESCRIPTION
Fixes #5876

This currently compiles:

```crystal
class Foo
  @x : Int32 = bar

  def bar
    1
  end
end
```

However, it makes very little sense to run an instance var initializer at the instance level, because that's what we are initializing.

Java allows that behavior, but C# rejects it, demanding that `bar` has to be a static method. That makes much more sense to me.

In any case, you can initialize it at the instance level if you want to, in an `initialize` method:

```crystal
class Foo
  @x : Int32

  def initialize
    @x = bar
  end

  def bar
    1
  end
end
```

That makes it much more clear that this is run at the instance level, and additionally the compiler will check that the instance var isn't used before it's assigned a value, etc.

It also makes sense from a scope level. If we do:

```crystal
class Foo
  def bar
    1
  end

  bar # Error
  CONST = bar # error
  # but this works?: @x : Int32 = bar
end
```

So now it's uniform:

```crystal
class Foo
  @x : Int32 = bar # ok
  bar # ok
  CONST = bar # ok

  def self.bar
    1
  end
end
```

This is a breaking change, but I doubt there's a lot of code out there that uses this kind of initializers.