### PR TITLE
Fix docs navigator not scrolling into selected element on page load

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -24,6 +24,16 @@ document.addEventListener('DOMContentLoaded', function() {
   var searchInput = document.querySelector('.search-input');
   var parents = document.querySelectorAll('.types-list li.parent');
 
+  var scrollSidebarToOpenType = function(){
+    var openTypes = typesList.querySelectorAll('.current');
+    if (openTypes.length > 0) {
+      var lastOpenType = openTypes[openTypes.length - 1];
+      lastOpenType.scrollIntoView();
+    }
+  }
+
+  scrollSidebarToOpenType();
+
   var setPersistentSearchQuery = function(value){
     sessionStorage.setItem(repositoryName + '::search-input:value', value);
   }


### PR DESCRIPTION
According to @straight-shoota, this function worked before #5229.

I've created my own implementation of that function. It identifies open item by `.current` class, and selects last of it (to handle case of nested items).

Used function `.scrollIntoView()` browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

Function was tested locally and it works, but one may test by himself.