### PR TITLE
Fix Atomic#swap with reference types

### DIFF
--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -169,4 +169,20 @@ describe Atomic do
     atomic.swap(2).should eq(1)
     atomic.get.should eq(2)
   end
+
+  it "#swap with Reference type" do
+    atomic = Atomic.new("hello")
+    atomic.swap("world").should eq("hello")
+    atomic.get.should eq("world")
+  end
+
+  it "#swap with nil" do
+    atomic = Atomic(String?).new(nil)
+
+    atomic.swap("not nil").should eq(nil)
+    atomic.get.should eq("not nil")
+
+    atomic.swap(nil).should eq("not nil")
+    atomic.get.should eq(nil)
+  end
 end

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -157,7 +157,12 @@ struct Atomic(T)
   # atomic.get      # => 10
   # ```
   def swap(value : T)
-    Ops.atomicrmw(:xchg, pointerof(@value), value, :sequentially_consistent, false)
+    {% if T.union? && T.union_types.all? { |t| t == Nil || t < Reference } || T < Reference %}
+      address = Ops.atomicrmw(:xchg, pointerof(@value).as(LibC::SizeT*), LibC::SizeT.new(value.as(T).object_id), :sequentially_consistent, false)
+      Pointer(T).new(address).as(T)
+    {% else %}
+      Ops.atomicrmw(:xchg, pointerof(@value), value, :sequentially_consistent, false)
+    {% end %}
   end
 
   # Atomically sets this atomic's value to *value*. Returns the **new** value.


### PR DESCRIPTION
Previously the compiler crashed with "Module validation failed: atomicrmw operand must have integer type!".
(followed the example of ```#compare_and_set```)