### PR TITLE
JSON: Handle non-standard UTF-8 string escapes

### DIFF
--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -90,6 +90,7 @@ describe JSON::Lexer do
   it_lexes_string "\"hello\\tworld\"", "hello\tworld"
   it_lexes_string "\"\\u201chello world\\u201d\"", "“hello world”"
   it_lexes_string "\"\\uD834\\uDD1E\"", "𝄞"
+  it_lexes_string "\"\\u00c3\\u0096\"", "Ö"
   it_lexes_int "0", 0
   it_lexes_int "1", 1
   it_lexes_int "1234", 1234

--- a/src/json/lexer/string_based.cr
+++ b/src/json/lexer/string_based.cr
@@ -42,7 +42,7 @@ class JSON::Lexer::StringBased < JSON::Lexer
   private def consume_string_slow_path(start_pos)
     consume_string_with_buffer do
       @buffer.write slice_range(start_pos + 1, current_pos)
-      @buffer << consume_string_escape_sequence
+      consume_string_escape_sequence
     end
   end
 


### PR DESCRIPTION
I came across `\u` escapes like this in Facebook's JSON-exported user
data. Here's another example of these in the wild:

  http://seclists.org/wireshark/2018/Jul/36

This issue is present in the standard Ruby/Python/Go/PHP parsers too.
The only parser I found that handles it is Perl's JSON module:

  https://github.com/makamaka/JSON/blob/master/lib/JSON/backportPP.pm#L811