### PR TITLE
Fix: private aliases at top-level not considered private

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -610,6 +610,7 @@ describe Crystal::Formatter do
   assert_format "class Foo\nend\nclass Bar\nend", "class Foo\nend\n\nclass Bar\nend"
 
   assert_format "alias  Foo  =   Bar", "alias Foo = Bar"
+  assert_format "alias  Foo::Bar  =   Baz", "alias Foo::Bar = Baz"
   assert_format "alias A = (B)"
   assert_format "alias A = (B) -> C"
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -750,7 +750,7 @@ module Crystal
     it_parses "lib LibC\n$errno : Int32\n$errno2 : Int32\nend", LibDef.new("LibC", [ExternalVar.new("errno", "Int32".path), ExternalVar.new("errno2", "Int32".path)] of ASTNode)
     it_parses "lib LibC\n$errno : B, C -> D\nend", LibDef.new("LibC", [ExternalVar.new("errno", ProcNotation.new(["B".path, "C".path] of ASTNode, "D".path))] of ASTNode)
     it_parses "lib LibC\n$errno = Foo : Int32\nend", LibDef.new("LibC", [ExternalVar.new("errno", "Int32".path, "Foo")] of ASTNode)
-    it_parses "lib LibC\nalias Foo = Bar\nend", LibDef.new("LibC", [Alias.new("Foo", "Bar".path)] of ASTNode)
+    it_parses "lib LibC\nalias Foo = Bar\nend", LibDef.new("LibC", [Alias.new("Foo".path, "Bar".path)] of ASTNode)
     it_parses "lib LibC; struct Foo; include Bar; end; end", LibDef.new("LibC", [CStructOrUnionDef.new("Foo", Include.new("Bar".path))] of ASTNode)
 
     it_parses "lib LibC\nfun SomeFun\nend", LibDef.new("LibC", [FunDef.new("SomeFun")] of ASTNode)
@@ -1099,7 +1099,8 @@ module Crystal
 
     it_parses "foo.bar = {} of Int32 => Int32", Call.new("foo".call, "bar=", HashLiteral.new(of: HashLiteral::Entry.new("Int32".path, "Int32".path)))
 
-    it_parses "alias Foo = Bar", Alias.new("Foo", "Bar".path)
+    it_parses "alias Foo = Bar", Alias.new("Foo".path, "Bar".path)
+    it_parses "alias Foo::Bar = Baz", Alias.new(Path.new(["Foo", "Bar"]), "Baz".path)
 
     it_parses "def foo\n1\nend\nif 1\nend", [Def.new("foo", body: 1.int32), If.new(1.int32)] of ASTNode
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -116,6 +116,7 @@ describe "ASTNode#to_s" do
   expect_to_s %(lib Foo\n  FOO = 0\nend)
   expect_to_s %(enum Foo\n  A = 0\n  B\nend)
   expect_to_s %(alias Foo = Void)
+  expect_to_s %(alias Foo::Bar = Void)
   expect_to_s %(type(Foo = Void))
   expect_to_s %(return true ? 1 : 2)
   expect_to_s %(1 <= 2 <= 3)

--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -8,6 +8,13 @@ describe "Semantic: alias" do
       ") { types["Int32"].metaclass }
   end
 
+  it "declares alias inside type" do
+    assert_type("
+      alias Foo::Bar = Int32
+      Foo::Bar
+      ") { types["Int32"].metaclass }
+  end
+
   it "works with alias type as restriction" do
     assert_type("
       alias Alias = Int32

--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -201,6 +201,23 @@ describe "Semantic: private" do
     end
   end
 
+  it "doesn't find private alias in another file" do
+    expect_raises Crystal::TypeException, "undefined constant Foo" do
+      compiler = Compiler.new
+      sources = [
+        Compiler::Source.new("foo.cr", %(
+                                          private alias Foo = Int32
+                                        )),
+        Compiler::Source.new("bar.cr", %(
+                                          Foo
+                                        )),
+      ]
+      compiler.no_codegen = true
+      compiler.prelude = "empty"
+      compiler.compile sources, "output"
+    end
+  end
+
   it "finds private type in same file" do
     compiler = Compiler.new
     sources = [

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -270,10 +270,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : Alias)
     check_outside_exp node, "declare alias"
 
-    scope = current_type
-    if scope.is_a?(Program)
-      scope = program.check_private(node) || scope
-    end
+    scope, name, existing_type = lookup_type_def(node)
 
     if existing_type
       if existing_type.is_a?(AliasType)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1849,12 +1849,12 @@ module Crystal
   end
 
   class Alias < ASTNode
-    property name : String
+    property name : Path
     property value : ASTNode
     property doc : String?
     property visibility = Visibility::Public
 
-    def initialize(@name : String, @value : ASTNode)
+    def initialize(@name : Path, @value : ASTNode)
     end
 
     def accept_children(visitor)
@@ -1862,7 +1862,7 @@ module Crystal
     end
 
     def clone_without_location
-      Alias.new(@name, @value.clone)
+      Alias.new(@name.clone, @value.clone)
     end
 
     def_equals_and_hash @name, @value

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5298,8 +5298,9 @@ module Crystal
       doc = @token.doc
 
       next_token_skip_space_or_newline
-      name = check_const
-      next_token_skip_space_or_newline
+
+      name = parse_ident(allow_type_vars: false).as(Path)
+      skip_space
       check :"="
       next_token_skip_space_or_newline
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1389,7 +1389,7 @@ module Crystal
     def visit(node : Alias)
       @str << keyword("alias")
       @str << ' '
-      @str << node.name
+      node.name.accept self
       @str << " = "
       node.value.accept self
       false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3813,7 +3813,13 @@ module Crystal
     def format_alias_or_typedef(node, keyword, value)
       write_keyword keyword, " "
 
-      write node.name
+      name = node.name
+      if name.is_a?(Path)
+        accept name
+      else
+        write name
+      end
+
       next_token_skip_space_or_newline
 
       write_token " ", :"=", " "


### PR DESCRIPTION
Fixes #5752

As a bonus, this works now (similar to other declarations, like classes and constants):

```crystal
alias Foo::Bar = Int32
```