### PR TITLE
Change Foo:Class representation of Class types to Foo.class

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1120,7 +1120,7 @@ module Crystal
       end
 
       it "executes class" do
-        assert_macro("x", "{{x.class.name}}", "String:Class") do |program|
+        assert_macro("x", "{{x.class.name}}", "String.class") do |program|
           [TypeNode.new(program.string)] of ASTNode
         end
       end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1059,7 +1059,7 @@ describe "Semantic: class" do
 
       Foo.bar
       ),
-      "undefined method 'bar' for Foo:Class"
+      "undefined method 'bar' for Foo.class"
   end
 
   it "inherits self twice (#5495)" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1257,7 +1257,7 @@ describe "Semantic: module" do
         extend Foo
       end
       ),
-      "can't declare instance variables in Bar:Class"
+      "can't declare instance variables in Bar.class"
   end
 
   it "can't pass module class to virtual metaclass (#6113)" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -219,7 +219,7 @@ class Crystal::CodeGenVisitor
   end
 
   def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : UnionType, value)
-    # Can happen when assigning Foo+:Class <- Bar:Class | Baz:Class with Bar < Foo and Baz < Foo
+    # Can happen when assigning Foo+.class <- Bar.class | Baz.class with Bar < Foo and Baz < Foo
     casted_value = cast_to_pointer(union_value(value), target_type)
     store load(casted_value), target_pointer
   end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -38,7 +38,7 @@ end
 
 class Crystal::Call
   def raise_matches_not_found(owner, def_name, arg_types, named_args_types, matches = nil, with_literals = false)
-    # Special case: Foo+:Class#new
+    # Special case: Foo+.class#new
     if owner.is_a?(VirtualMetaclassType) && def_name == "new"
       raise_matches_not_found_for_virtual_metaclass_new owner
     end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -351,7 +351,7 @@ module Crystal
         # Check matches but without parents: only included modules
         subtype_matches = subtype_lookup.lookup_matches_with_modules(signature, subtype_virtual_lookup, subtype_virtual_lookup)
 
-        # For Foo+:Class#new we need to check that this subtype doesn't define
+        # For Foo+.class#new we need to check that this subtype doesn't define
         # an incompatible initialize: if so, we return empty matches, because
         # all subtypes must have an initialize with the same number of arguments.
         if is_new && subtype_matches.empty?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2581,9 +2581,9 @@ module Crystal
 
   # A metaclass type, that results from invoking `.class` on a type.
   #
-  # For example `String:Class` is the metaclass of `String`, and it's
+  # For example `String.class` is the metaclass of `String`, and it's
   # the type of `String` (the type of `"foo"` is `String`, the type of
-  # `String` is `String:Class`).
+  # `String` is `String.class`).
   #
   # This metaclass represents only the metaclass of non-generic types.
   class MetaclassType < ClassType
@@ -2603,7 +2603,7 @@ module Crystal
         if instance_type.module?
           name = "#{@instance_type}:Module"
         else
-          name = "#{@instance_type}:Class"
+          name = "#{@instance_type}.class"
         end
       end
       super(program, program, name, super_class)
@@ -2644,7 +2644,7 @@ module Crystal
     end
   end
 
-  # The metaclass of a generic class instance type, like `Array(String):Class`
+  # The metaclass of a generic class instance type, like `Array(String).class`
   class GenericClassInstanceMetaclassType < Type
     include DefInstanceContainer
 
@@ -2693,11 +2693,11 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       instance_type.to_s(io)
-      io << ":Class"
+      io << ".class"
     end
   end
 
-  # The metaclass of a generic module instance type, like `Enumerable(Int32):Class`
+  # The metaclass of a generic module instance type, like `Enumerable(Int32).class`
   class GenericModuleInstanceMetaclassType < Type
     include DefInstanceContainer
 
@@ -2724,7 +2724,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       instance_type.to_s(io)
-      io << ":Class"
+      io << ".class"
     end
   end
 
@@ -3121,7 +3121,7 @@ module Crystal
       instance_type.leaf?
     end
 
-    # Given `Foo+:Class` returns `Foo` (not `Foo:Class`)
+    # Given `Foo+.class` returns `Foo` (not `Foo.class`)
     delegate base_type, to: instance_type
 
     delegate lookup_first_def, to: instance_type.metaclass
@@ -3156,7 +3156,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       instance_type.to_s_with_options(io, codegen: codegen)
-      io << ":Class"
+      io << ".class"
     end
   end
 end


### PR DESCRIPTION
Using the Foo.class representation of class types in error messages matches the
type syntax used to write these types, instead of using a special and confusing
syntax unique to compiler error messages.

For example:

```
class variable '@@foo' of Bar must be Hash(Thing:Class, String), not Hash(Thing, String)
```

becomes

```
class variable '@@foo' of Bar must be Hash(Thing.class, String), not Hash(Thing, String)
```

which means the type is now represented exactly the same way in the error
messages as source code.