### PR TITLE
Add Fiber#cancel

### DIFF
--- a/spec/std/fiber_spec.cr
+++ b/spec/std/fiber_spec.cr
@@ -1,0 +1,54 @@
+require "spec"
+
+private def assert_cancel(&block : ->)
+  exception = nil
+  fiber = spawn name: "fiber" do
+    block.call
+  rescue exc : Fiber::CancelledException
+    exception = exc
+  end
+
+  Fiber.yield
+  fiber.cancel
+  Fiber.yield
+
+  exception.should_not be_nil
+  exception.not_nil!.fiber.should eq fiber
+  exception.not_nil!.message.should eq "Fiber cancelled: #{fiber}"
+  cause = exception.not_nil!.cause.not_nil!
+  cause.message.should eq "Fiber cancel request"
+  cause.fiber.should eq Fiber.current
+end
+
+describe Fiber do
+  describe "#cancel" do
+    context "from other fiber" do
+      it "Fiber.yield" do
+        assert_cancel { Fiber.yield }
+      end
+      it "sleep" do
+        assert_cancel { sleep }
+      end
+      it "sleep(1)" do
+        assert_cancel { sleep(1) }
+      end
+    end
+
+    it "from same fiber" do
+      exception = nil
+      fiber = nil
+      fiber = spawn name: "fiber" do
+        fiber.not_nil!.cancel
+      rescue exc : Fiber::CancelledException
+        exception = exc
+      end
+
+      Fiber.yield
+
+      exception.should_not be_nil
+      exception.not_nil!.fiber.should eq fiber
+      exception.not_nil!.message.should eq "Fiber cancelled: #{fiber}"
+      exception.not_nil!.cause.should be_nil
+    end
+  end
+end

--- a/src/crystal/event.cr
+++ b/src/crystal/event.cr
@@ -28,6 +28,10 @@ struct Crystal::Event
     )
   end
 
+  def delete
+    LibEvent2.event_del(@event)
+  end
+
   def free
     LibEvent2.event_free(@event) unless @freed
     @freed = true

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -60,6 +60,14 @@ class Crystal::Scheduler
     current, @current = @current, fiber
     GC.stack_bottom = fiber.@stack_bottom
     Fiber.swapcontext(pointerof(current.@stack_top), fiber.@stack_top)
+
+    # The stack has changed but `fiber` still references the old fiber, that's
+    # why we acquire the actual current fiber.
+    current_fiber = self.class.current_fiber
+
+    if cancel_request = current_fiber.@cancel_request
+      raise Fiber::CancelledException.new current_fiber, cancel_request
+    end
   end
 
   protected def reschedule : Nil


### PR DESCRIPTION
This PR adds a method `Fiber#cancel` which allows to stop a fiber as described in #3561

The implementation is pretty simple: Calling `#cancel` sets a flag (`@cancel_request`) and enqueues the fiber to resume at the next rescheduling. `Fiber#resume` checks (after the stack switch) if the now resuming fiber has been requested to be cancelled. If so, it raises `Fiber::CancelledException` which unwinds the stack like any other exception until it reaches the `rescue` handler in `#run`.

Resuming the fiber-to-be-cancelled could already happen in `#cancel` itself. It is better to delay the unwinding until the next rescheduling, in order to allow cancelling multiple fibers at once without any unforeseeable context switches while unwinding the stack.

Apart from the included specs, I have also tested this with #6385 to resolve the issue described in https://github.com/crystal-lang/crystal/issues/6357#issuecomment-405095355 and a proof of concept for a structured concurrency feature (RFC will follow).

An issue worth mentioning is that `CancelledException` is just an ordinary exception and thus it can be rescued from. It would unintentionally be caught by any `rescue` without an explicit type restriction. This is bad because rescuing it somewhere on the unwinding stack can prevents the purpose of cancelling the fiber.

In order to solve this, `CancelledException` should not be matched by a `rescue` without a type restriction. I would recommend a change to the exception hierarchy, inserting a new exception type (for example `BaseException`)  as parent of both `Exception` and `CancelledException`. Untyped `rescue` would still catch all `Exception` types, but not `CancelledException`. But you can still rescue from `CancelledException` (or `BaseException`)  if explicitly declared.
This is similar to the exception hierarchies of Ruby and Python, both have a type for user exceptions (`StandardError` / `Exception`) and above that a base type (`Exception` / `BaseException`) which is also the parent type of system exceptions (for example `SystemExit` in both).

Fixes #3561