### PR TITLE
rename alias HTTP::Handler::Proc to HTTP::Handler::HandlerProc

### DIFF
--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -9,7 +9,7 @@ describe HTTP::CompressHandler do
     context = HTTP::Server::Context.new(request, response)
 
     handler = HTTP::CompressHandler.new
-    handler.next = HTTP::Handler::Proc.new do |ctx|
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
       ctx.response.print "Hello"
     end
     handler.call(context)
@@ -28,7 +28,7 @@ describe HTTP::CompressHandler do
     context = HTTP::Server::Context.new(request, response)
 
     handler = HTTP::CompressHandler.new
-    handler.next = HTTP::Handler::Proc.new do |ctx|
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
       ctx.response.print "Hello"
     end
     handler.call(context)
@@ -56,7 +56,7 @@ describe HTTP::CompressHandler do
     context = HTTP::Server::Context.new(request, response)
 
     handler = HTTP::CompressHandler.new
-    handler.next = HTTP::Handler::Proc.new do |ctx|
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
       ctx.response.print "Hello"
     end
     handler.call(context)

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -10,7 +10,7 @@ describe HTTP::WebSocketHandler do
 
     invoked = false
     handler = HTTP::WebSocketHandler.new { invoked = true }
-    handler.next = HTTP::Handler::Proc.new &.response.print("Hello")
+    handler.next = HTTP::Handler::HandlerProc.new &.response.print("Hello")
     handler.call context
 
     response.close
@@ -33,7 +33,7 @@ describe HTTP::WebSocketHandler do
 
     invoked = false
     handler = HTTP::WebSocketHandler.new { invoked = true }
-    handler.next = HTTP::Handler::Proc.new &.response.print("Hello")
+    handler.next = HTTP::Handler::HandlerProc.new &.response.print("Hello")
     handler.call context
 
     response.close
@@ -55,7 +55,7 @@ describe HTTP::WebSocketHandler do
       context = HTTP::Server::Context.new(request, response)
 
       handler = HTTP::WebSocketHandler.new { }
-      handler.next = HTTP::Handler::Proc.new &.response.print("Hello")
+      handler.next = HTTP::Handler::HandlerProc.new &.response.print("Hello")
 
       begin
         handler.call context
@@ -82,7 +82,7 @@ describe HTTP::WebSocketHandler do
     context = HTTP::Server::Context.new(request, response)
 
     handler = HTTP::WebSocketHandler.new { }
-    handler.next = HTTP::Handler::Proc.new &.response.print("Hello")
+    handler.next = HTTP::Handler::HandlerProc.new &.response.print("Hello")
 
     begin
       handler.call context

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -108,13 +108,13 @@ class HTTP::Server
   getter? listening : Bool = false
 
   # Creates a new HTTP server with the given block as handler.
-  def self.new(&handler : HTTP::Handler::Proc) : self
+  def self.new(&handler : HTTP::Handler::HandlerProc) : self
     new(handler)
   end
 
   # Creates a new HTTP server with a handler chain constructed from the *handlers*
   # array and the given block.
-  def self.new(handlers : Array(HTTP::Handler), &handler : HTTP::Handler::Proc) : self
+  def self.new(handlers : Array(HTTP::Handler), &handler : HTTP::Handler::HandlerProc) : self
     new(HTTP::Server.build_middleware(handlers, handler))
   end
 
@@ -124,7 +124,7 @@ class HTTP::Server
   end
 
   # Creates a new HTTP server with the given *handler*.
-  def initialize(handler : HTTP::Handler | HTTP::Handler::Proc)
+  def initialize(handler : HTTP::Handler | HTTP::Handler::HandlerProc)
     @processor = RequestProcessor.new(handler)
   end
 

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -15,7 +15,7 @@
 # end
 # ```
 module HTTP::Handler
-  property next : Handler | Proc | Nil
+  property next : Handler | HandlerProc | Nil
 
   abstract def call(context : HTTP::Server::Context)
 
@@ -29,7 +29,7 @@ module HTTP::Handler
     end
   end
 
-  alias Proc = HTTP::Server::Context ->
+  alias HandlerProc = HTTP::Server::Context ->
 end
 
 require "./handlers/*"

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -1,11 +1,11 @@
 require "../server"
 
 class HTTP::Server::RequestProcessor
-  def initialize(&@handler : HTTP::Handler::Proc)
+  def initialize(&@handler : HTTP::Handler::HandlerProc)
     @wants_close = false
   end
 
-  def initialize(@handler : HTTP::Handler | HTTP::Handler::Proc)
+  def initialize(@handler : HTTP::Handler | HTTP::Handler::HandlerProc)
     @wants_close = false
   end
 


### PR DESCRIPTION
closes: #6386 

I know that the name is a bit verbose, but naming is hard. 😂  If anyone has a suggestion for a better name, I'll make the change.

The reason for the rename as mentioned in that issue is that when you are creating a custom HTTP::Handler, and you include it in your class, you're not able to use the standard type `Proc` anymore since it's been overridden by the alias. I hope no one was using this in particular, but it should probably be noted as a breaking change just in case.