### PR TITLE
Adds `IO::Memory.truncate()`

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -226,6 +226,16 @@ describe IO::Memory do
     io.gets(1).should eq("d")
   end
 
+  it "can seek and truncate" do
+    io = IO::Memory.new "hello world"
+    io.seek(-6, Seek::Current)
+    io.pos = 0
+    io.gets().should eq("hello")
+    io << " friend"
+    io.pos = 0
+    io.gets().should eq("hello friend")
+  end
+
   it "clears" do
     io = IO::Memory.new
     io << "abc"

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -336,6 +336,26 @@ class IO::Memory < IO
     @pos = value.to_i
   end
 
+
+  # Sets the current bytesize to be equal to the current position
+  # effectively truncating the contents at the current position.
+  #
+  # Note this does nothing if the curront position is at the end.
+  #
+  # ```
+  # io = IO::Memory.new "hello world"
+  # io.seek(-6, Seek::Current)
+  # io.truncate()
+  # io.pos = 0
+  # io.gets # => "hello"
+  # ```
+  def truncate() : Nil
+    check_open
+    check_resizeable
+    @bytesize = @pos if @bytesize != @pos
+  end
+
+
   # Yields an `IO::Memory` to read a section of this `IO`'s buffer.
   #
   # During the block duration `self` becomes read-only,


### PR DESCRIPTION
Truncates the contents of IO::Memory at the current cursor position.