### PR TITLE
Fix Dir.glob to list broken symlinks

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -261,6 +261,7 @@ describe "Dir" do
           datapath("f1_link.txt"),
           datapath("non_link.txt"),
         ].sort
+        Dir["#{datapath}/non_link.txt"].should eq [datapath("non_link.txt")]
       ensure
         File.delete link
         File.delete non_link

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -182,7 +182,7 @@ class Dir
         when ConstantEntry
           return if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           full = join(path, cmd.path)
-          yield full if File.exists?(full)
+          yield full if File.exists?(full) || File.symlink?(full)
         when ConstantDirectory
           path_stack << {next_pos, join(path, cmd.path)}
           # Don't check if full exists. It just costs us time


### PR DESCRIPTION
`File.exists?` is `false` for broken symlinks. But they should be included by glob. Any other glob implementation does this.

Fixes #6463