### PR TITLE
Fix typo in StaticArray docs

### DIFF
--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -16,7 +16,7 @@
 # case is in combination with `uninitialized`:
 #
 # ```
-# ints = unininitialized Int32[3]
+# ints = uninitialized Int32[3]
 # ints[0] = 0
 # ints[1] = 8
 # ints[3] = 15


### PR DESCRIPTION
@hinrik noticed a typo. See: https://github.com/crystal-lang/crystal/commit/6ab9c603c9cc290dc0b84ba2de307afba29f7208#r29775544.