### PR TITLE
Fix identical link generation prevention for the "Defined in" section (docs)

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -393,6 +393,9 @@ class Crystal::Doc::Generator
       filename = filename[1..-1] if filename.starts_with? File::SEPARATOR
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
+      # Prevent identical link generation in the "Defined in:" section in the docs because of macros
+      next if locations.any? { |loc| loc.filename == filename && loc.line_number == location.line_number}
+
       show_line_number = locations.any? do |location|
         if location.filename == filename
           location.show_line_number = true

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -394,7 +394,7 @@ class Crystal::Doc::Generator
       filename = filename[4..-1] if filename.starts_with? SRC_SEP
 
       # Prevent identical link generation in the "Defined in:" section in the docs because of macros
-      next if locations.any? { |loc| loc.filename == filename && loc.line_number == location.line_number}
+      next if locations.any? { |loc| loc.filename == filename && loc.line_number == location.line_number }
 
       show_line_number = locations.any? do |location|
         if location.filename == filename

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -705,8 +705,7 @@ module Crystal
     # Adds a location to this type.
     def add_location(location : Location)
       locations = @locations ||= [] of Location
-      # The `unless` prevents that identical links are being generated in the "Defined in:" section in the docs because of macros
-      locations << location unless locations.any? { |loc| loc.filename == location.filename && loc.line_number == location.line_number }
+      locations << location
     end
 
     getter(types) { {} of String => NamedType }


### PR DESCRIPTION
Follow-up of #6280.

Preventing duplicates in types.cr doesn't seems to work. See: [Float32](https://crystal-lang.org/api/master/Float32.html).
But it works now by preventing them in generator.cr.