### PR TITLE
Removes unnecessary addition

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -567,7 +567,7 @@ class Array(T)
     end
 
     (@buffer + @size).copy_from(other.to_unsafe, other_size)
-    @size += other_size
+    @size = new_size
 
     self
   end


### PR DESCRIPTION
The current implementation of `Array#concat` when the argument is an array is

```crystal
def concat(other : Array)
  other_size = other.size
  new_size = size + other_size
  if new_size > @capacity
    resize_to_capacity(Math.pw2ceil(new_size))
  end

  (@buffer + @size).copy_from(other.to_unsafe, other_size)
  @size += other_size

  self
end
```

There, the increment

```crystal
@size += other_size
```

is unnecessary because that value was already stored in the variable `new_size`.