### PR TITLE
Make Spec compile on win32

### DIFF
--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -123,7 +123,7 @@ module Crystal::System::File
     timevals[1] = to_timeval(mtime)
     ret = LibC.utimes(filename, timevals)
     if ret != 0
-      raise Errno.new("Error setting time to file '#{filename}'")
+      raise Errno.new("Error setting time on file '#{filename}'")
     end
   end
 

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -176,16 +176,22 @@ module Crystal::System::File
     # TODO: read links using https://msdn.microsoft.com/en-us/library/windows/desktop/aa364571(v=vs.85).aspx
     win_path = to_windows_path(path)
 
-    System.retry_wstr_buffer do |buffer, small_buf|
+    real_path = System.retry_wstr_buffer do |buffer, small_buf|
       len = LibC.GetFullPathNameW(win_path, buffer.size, buffer, nil)
       if 0 < len < buffer.size
-        return String.from_utf16(buffer[0, len])
+        break String.from_utf16(buffer[0, len])
       elsif small_buf && len > 0
         next len
       else
         raise WinError.new("Error resolving real path of #{path.inspect}")
       end
     end
+
+    unless exists? real_path
+      raise Errno.new("Error resolving real path of #{path.inspect}", Errno::ENOTDIR)
+    end
+
+    real_path
   end
 
   def self.link(old_path : String, new_path : String) : Nil

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -15,7 +15,11 @@ module Crystal::System::FileDescriptor
     until slice.empty?
       bytes_written = LibC._write(@fd, slice, slice.size)
       if bytes_written == -1
-        raise Errno.new("Error writing file")
+        if Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for writing"
+        else
+          raise Errno.new("Error writing file")
+        end
       end
 
       slice += bytes_written

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -118,6 +118,9 @@ if ENV["SPEC_VERBOSE"]? == "1"
   Spec.override_default_formatter(Spec::VerboseFormatter.new)
 end
 
-Signal::INT.trap { Spec.abort! }
+{% unless flag?(:win32) %}
+  # TODO(windows): re-enable this once Signal is ported
+  Signal::INT.trap { Spec.abort! }
+{% end %}
 
 Spec.run

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -1,6 +1,5 @@
 require "colorize"
 require "option_parser"
-require "signal"
 
 module Spec
   private COLORS = {


### PR DESCRIPTION
This makes the spec runner work on win32, and also fixes a few issues in the windows File port caught by the addition of exception support.