### PR TITLE
Fix ENV#each

### DIFF
--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -142,4 +142,11 @@ describe "ENV" do
     ENV.delete("TEST_UNICODE_1")
     ENV.delete("TEST_UNICODE_2")
   end
+
+  it "#to_h" do
+    ENV["FOO"] = "foo"
+    ENV.to_h["FOO"].should eq "foo"
+  ensure
+    ENV.delete("FOO")
+  end
 end

--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -16,6 +16,8 @@ describe "ENV" do
     (ENV["FOO"] = "1").should eq("1")
     ENV["FOO"].should eq("1")
     ENV["FOO"]?.should eq("1")
+  ensure
+    ENV.delete("FOO")
   end
 
   it "sets to nil (same as delete)" do
@@ -28,12 +30,16 @@ describe "ENV" do
   it "sets to empty string" do
     (ENV["FOO_EMPTY"] = "").should eq ""
     ENV["FOO_EMPTY"]?.should eq ""
+  ensure
+    ENV.delete("FOO_EMPTY")
   end
 
   it "does has_key?" do
     ENV["FOO"] = "1"
-    ENV.has_key?("BAR").should be_false
+    ENV.has_key?("NON_EXISTENT").should be_false
     ENV.has_key?("FOO").should be_true
+  ensure
+    ENV.delete("FOO")
   end
 
   it "deletes a key" do
@@ -47,6 +53,9 @@ describe "ENV" do
     %w(FOO BAR).each { |k| ENV.keys.should_not contain(k) }
     ENV["FOO"] = ENV["BAR"] = "1"
     %w(FOO BAR).each { |k| ENV.keys.should contain(k) }
+  ensure
+    ENV.delete("FOO")
+    ENV.delete("BAR")
   end
 
   it "does .values" do
@@ -54,6 +63,9 @@ describe "ENV" do
     ENV["FOO"] = "SOMEVALUE_1"
     ENV["BAR"] = "SOMEVALUE_2"
     [1, 2].each { |i| ENV.values.should contain("SOMEVALUE_#{i}") }
+  ensure
+    ENV.delete("FOO")
+    ENV.delete("BAR")
   end
 
   describe "[]=" do
@@ -80,18 +92,24 @@ describe "ENV" do
     it "fetches with one argument" do
       ENV["1"] = "2"
       ENV.fetch("1").should eq("2")
+    ensure
+      ENV.delete("1")
     end
 
     it "fetches with default value" do
       ENV["1"] = "2"
       ENV.fetch("1", "3").should eq("2")
       ENV.fetch("2", "3").should eq("3")
+    ensure
+      ENV.delete("1")
     end
 
     it "fetches with block" do
       ENV["1"] = "2"
       ENV.fetch("1") { |k| k + "block" }.should eq("2")
       ENV.fetch("2") { |k| k + "block" }.should eq("2block")
+    ensure
+      ENV.delete("1")
     end
 
     it "fetches and raises" do
@@ -99,6 +117,8 @@ describe "ENV" do
       expect_raises KeyError, "Missing ENV key: \"2\"" do
         ENV.fetch("2")
       end
+    ensure
+      ENV.delete("1")
     end
   end
 
@@ -118,5 +138,8 @@ describe "ENV" do
       "TEST_UNICODE_1" => "bar\u{d7ff}\u{10000}",
       "TEST_UNICODE_2" => "\u{1234}",
     })
+  ensure
+    ENV.delete("TEST_UNICODE_1")
+    ENV.delete("TEST_UNICODE_2")
   end
 end

--- a/src/env.cr
+++ b/src/env.cr
@@ -105,7 +105,7 @@ module ENV
   # ```
   def self.each
     Crystal::System::Env.each do |key, value|
-      yield key, value
+      yield({key, value})
     end
   end
 


### PR DESCRIPTION
In #6333 `ENV.each` yields `String, String` instead of `{String, String}`. That messes up all the `Enumerable` methods, including `Enumerable#first` which is used by `Enumerable#to_h`.

I also added a few `ensure`s to delete ENV variables added by each spec.

Fixes #6253 (the second issue in that thread)