### PR TITLE
Add raise Errno if Process.new fails to exec

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -14,9 +14,10 @@ describe Process do
     process.wait.exit_code.should eq(1)
   end
 
-  it "returns status 127 if command could not be executed" do
-    process = Process.new("foobarbaz")
-    process.wait.exit_code.should eq(127)
+  it "raises if command could not be executed" do
+    expect_raises Errno do
+      Process.new("foobarbaz")
+    end
   end
 
   it "run waits for the process" do

--- a/src/process.cr
+++ b/src/process.cr
@@ -240,8 +240,12 @@ class Process
       end
     end
 
+    parent_sock, child_sock = IO.pipe
+
     @pid = Process.fork_internal(run_hooks: false) do
       begin
+        parent_sock.close
+        child_sock.close_on_exec = true
         Process.exec_internal(
           command,
           argv,
@@ -252,11 +256,22 @@ class Process
           fork_error || error,
           chdir
         )
+      rescue ex : Errno
+        value = ex.errno
+        child_sock.write(Bytes.new(pointerof(value).as(UInt8*), 4))
       rescue ex
         ex.inspect_with_backtrace STDERR
       ensure
         LibC._exit 127
       end
+    end
+
+    child_sock.close
+    slice = Bytes.new(4)
+    if parent_sock.read(slice) == 4
+      parent_sock.close
+      Errno.value = slice.pointer(4).as(Int32*).value
+      raise Errno.new("execvp")
     end
 
     @waitpid = Crystal::SignalChildHandler.wait(pid)


### PR DESCRIPTION
This PR picks up the stalled PR #3520 by @lbguilherme 

I refactored `exec_internal` to return if it was successful instead of raising. This avoids unnecessarily raising and immediately rescuing `Errno`.

Also used `write_bytes` and `ByteFormat.decode` for piping the Int32. There is no non-raising `read_bytes`.

Fixes #3517