### PR TITLE
Fix: type var that resolves to number in restriction didn't work

### DIFF
--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1063,4 +1063,17 @@ describe "Semantic: generic class" do
       ),
       "undefined constant T"
   end
+
+  it "can use type var that resolves to number in restriction (#6502)" do
+    assert_type(%(
+      class Foo(N)
+        def foo : Foo(N)
+          self
+        end
+      end
+
+      f = Foo(1).new
+      f.foo
+      )) { generic_class "Foo", 1.int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -261,9 +261,9 @@ class Crystal::Type
               type_var.raise "expanding constant value for a number value", inner: ex
             end
             next
-            # when ASTNode
-            #   type_vars << type
-            #   next
+          when ASTNode
+            type_vars << type
+            next
           end
         end
 


### PR DESCRIPTION
Fixes #6502

This got broken by https://github.com/crystal-lang/crystal/pull/3972

I don't know why but some code I wrote got commented in that commit, probably an accident.