### PR TITLE
Add tests to expectations methods

### DIFF
--- a/spec/std/spec/expectations_spec.cr
+++ b/spec/std/spec/expectations_spec.cr
@@ -1,7 +1,93 @@
 require "spec"
 
 describe "expectations" do
-  context "start_with" do
+  describe "be" do
+    it { 1.should be < 3 }
+    it { 2.should be <= 3 }
+    it { 3.should be <= 3 }
+    it { 3.should be >= 3 }
+    it { 4.should be >= 3 }
+    it { 5.should be > 3 }
+  end
+
+  describe "be" do
+    it { "hello".should be "hello" }
+    it do
+      array = [1]
+      array.should_not be [1]
+    end
+  end
+
+  describe "be_a" do
+    it { "Hello".should be_a(String) }
+    it { 100_000.should_not be_a(String) }
+    it { 100_000.should be_a(Int32) }
+    it { "Hello".should_not be_a(Int32) }
+  end
+
+  describe "be_close" do
+    it { 8.5.should be_close(9, 0.5) }
+    it { 7.5.should_not be_close(9, 0.5) }
+  end
+
+  describe "be_nil" do
+    it { nil.should be_nil }
+    it { "".should_not be_nil }
+    it { 10.should_not be_nil }
+  end
+
+  describe "be_falsey" do
+    it { nil.should be_falsey }
+    it { false.should be_falsey }
+    it { true.should_not be_falsey }
+    it { "crystal".should_not be_falsey }
+  end
+
+  describe "be_truthy" do
+    it { true.should be_truthy }
+    it { "crystal".should be_truthy }
+    it { nil.should_not be_truthy }
+    it { false.should_not be_truthy }
+  end
+
+  describe "be_false" do
+    it { false.should be_false }
+    it { nil.should_not be_false }
+    it { true.should_not be_false }
+    it { "crystal".should_not be_false }
+  end
+
+  describe "be_true" do
+    it { true.should be_true }
+    it { nil.should_not be_true }
+    it { false.should_not be_true }
+    it { "crystal".should_not be_true }
+  end
+
+  describe "contain" do
+    it { [1, 2, 3].should contain(1) }
+    it { [1, 2, 3].should contain(2) }
+    it { [1, 2, 3].should contain(3) }
+    it { [1, 2, 3].should_not contain(4) }
+    it { "crystal".should contain("c") }
+    it { "crystal".should contain("crys") }
+    it { "crystal".should contain("crystal") }
+    it { "crystal".should_not contain("o") }
+    it { "crystal".should_not contain("world") }
+  end
+
+  describe "eq" do
+    it { 10.should eq(10) }
+    it { 10.should_not eq(1) }
+  end
+
+  describe "match" do
+    it { "Crystal".should match(/Crystal/) }
+    it { "Crystal".should match(/ysta/) }
+    it { "Crystal".should_not match(/hello/) }
+  end
+
+  describe "start_with" do
     it { "1-2-3".should start_with("") }
     it { "1-2-3".should start_with("1") }
     it { "1-2-3".should start_with("1-") }
@@ -10,7 +96,7 @@ describe "expectations" do
     it { "1-2-3".should_not start_with("1-2-3-4") }
   end
 
-  context "end_with" do
+  describe "end_with" do
     it { "1-2-3".should end_with("") }
     it { "1-2-3".should end_with("3") }
     it { "1-2-3".should end_with("-3") }
@@ -27,5 +113,11 @@ describe "expectations" do
     it { ["foo", "bar"].should_not be_empty }
     it { {"foo" => "bar"}.should_not be_empty }
     it { {"foo", "bar"}.should_not be_empty }
+  end
+
+  describe "expect_raises" do
+    it "pass if raises MyError" do
+      expect_raises(Exception, "Ops") { raise Exception.new("Ops") }
+    end
   end
 end


### PR DESCRIPTION
# What is this PR for?

This PR is for adding tests for the expectation methods on the spec module.

## TODO

List of the methods to be covered with tests in this PR:

- [x] `be`
- [x] `be(value)`
- [x] `be_a(type)`
- [x] `be_close(expected, delta)`
- [x] `be_nil`
- [x] `be_truthy`
- [x] `be_falsey`
- [x] `be_true`
- [x] `be_false`
- [x] `contain(expected)`
- [x] `eq(value)`
- [x] `match(value)`
- [x] `expect_raises(klass)`