### PR TITLE
Use enum (flags) instead of hardcoded string values for emit kinds

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -307,7 +307,7 @@ class Crystal::Command
       end
 
       unless no_codegen
-        valid_emit_values = {{ Compiler::EmitKinds.constants.map(&.stringify).reject { |m| %w(none all).includes?(m.downcase) } }}
+        valid_emit_values = Compiler::EmitTarget.names
         valid_emit_values.map! { |v| v.tr("_", "-").downcase }
 
         opts.on("--emit [#{valid_emit_values.join('|')}]", "Comma separated list of types of output for the compiler to emit") do |emit_values|
@@ -515,15 +515,15 @@ class Crystal::Command
   end
 
   private def validate_emit_values(values)
-    emit_kinds = Compiler::EmitKinds::None
+    emit_targets = Compiler::EmitTarget::None
     values.each do |value|
-      if kind = Compiler::EmitKinds.parse?(value.tr("-", "_"))
-        emit_kinds |= kind
+      if target = Compiler::EmitTarget.parse?(value.tr("-", "_"))
+        emit_targets |= target
       else
         error "invalid emit value '#{value}'"
       end
     end
-    emit_kinds
+    emit_targets
   end
 
   private def error(msg, exit_code = 1)

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -308,7 +308,7 @@ class Crystal::Command
 
       unless no_codegen
         valid_emit_values = Compiler::EmitTarget.names
-        valid_emit_values.map! { |v| v.tr("_", "-").downcase }
+        valid_emit_values.map! { |v| v.gsub('_', '-').downcase }
 
         opts.on("--emit [#{valid_emit_values.join('|')}]", "Comma separated list of types of output for the compiler to emit") do |emit_values|
           compiler.emit = validate_emit_values(emit_values.split(',').map(&.strip))
@@ -517,7 +517,7 @@ class Crystal::Command
   private def validate_emit_values(values)
     emit_targets = Compiler::EmitTarget::None
     values.each do |value|
-      if target = Compiler::EmitTarget.parse?(value.tr("-", "_"))
+      if target = Compiler::EmitTarget.parse?(value.gsub('-', '_'))
         emit_targets |= target
       else
         error "invalid emit value '#{value}'"

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -99,9 +99,9 @@ module Crystal
     property? wants_doc = false
 
     @[Flags]
-    enum EmitKinds
-      Asm
-      Obj
+    enum EmitTarget
+      ASM
+      OBJ
       LLVM_BC
       LLVM_IR
     end
@@ -112,7 +112,7 @@ module Crystal
     # * llvm-bc: LLVM bitcode
     # * llvm-ir: LLVM IR
     # * obj: object file
-    property emit : EmitKinds?
+    property emit : EmitTarget?
 
     # Base filename to use for `emit` output.
     property emit_base_filename : String?
@@ -675,18 +675,18 @@ module Crystal
         llvm_mod.print_to_file ll_name if compiler.dump_ll?
       end
 
-      def emit(emit_kinds : EmitKinds, output_filename)
-        emit_kinds.each do |kind|
-          case kind
-          when .asm?
-            compiler.target_machine.emit_asm_to_file llvm_mod, "#{output_filename}.s"
-          when .llvm_bc?
-            FileUtils.cp(bc_name, "#{output_filename}.bc")
-          when .llvm_ir?
-            llvm_mod.print_to_file "#{output_filename}.ll"
-          when .obj?
-            FileUtils.cp(object_name, "#{output_filename}.o")
-          end
+      def emit(emit_target : EmitTarget, output_filename)
+        if emit_target.asm?
+          compiler.target_machine.emit_asm_to_file llvm_mod, "#{output_filename}.s"
+        end
+        if emit_target.llvm_bc?
+          FileUtils.cp(bc_name, "#{output_filename}.bc")
+        end
+        if emit_target.llvm_ir?
+          llvm_mod.print_to_file "#{output_filename}.ll"
+        end
+        if emit_target.obj?
+          FileUtils.cp(object_name, "#{output_filename}.o")
         end
       end
 


### PR DESCRIPTION
I think that using enum flags is cleaner in this case.
It's better to remove handcoded emit values from obscure places in the compiler code :smiley:

I tried to keep the emit values the same (e.g: `llvm-ir`), but it would be simpler (?) to use `llvm_ir` as it's how the enum flag can be easily parsed. This could be changed though, but a breaking change.

This is the beginning to work on #5820, and maybe #5821.