### PR TITLE
Allow creating None enum flag with Enum.from_value

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -117,7 +117,7 @@ describe Enum do
     end
 
     it "for flags enum" do
-      SpecEnumFlags.from_value?(0).should be_nil
+      SpecEnumFlags.from_value?(0).should eq(SpecEnumFlags::None)
       SpecEnumFlags.from_value?(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value?(2).should eq(SpecEnumFlags::Two)
       SpecEnumFlags.from_value?(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)
@@ -134,10 +134,11 @@ describe Enum do
     end
 
     it "for flags enum" do
-      expect_raises(Exception, "Unknown enum SpecEnumFlags value: 0") { SpecEnumFlags.from_value(0) }
+      SpecEnumFlags.from_value(0).should eq(SpecEnumFlags::None)
       SpecEnumFlags.from_value(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value(2).should eq(SpecEnumFlags::Two)
       SpecEnumFlags.from_value(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)
+      expect_raises(Exception, "Unknown enum SpecEnumFlags value: 8") { SpecEnumFlags.from_value(8) }
     end
   end
 

--- a/src/debug/elf.cr
+++ b/src/debug/elf.cr
@@ -168,7 +168,7 @@ module Debug
       ei_version = @io.read_byte.not_nil!
       raise Error.new("Unsupported version number") unless ei_version == 1
 
-      ei_osabi = OSABI.from_value(@io.read_byte)
+      ei_osabi = OSABI.from_value(@io.read_byte.not_nil!)
       ei_abiversion = @io.read_byte.not_nil!
 
       # padding (unused)

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -347,12 +347,10 @@ struct Enum
   # Color.from_value?(2) # => Color::Blue
   # Color.from_value?(3) # => nil
   # ```
-  def self.from_value?(value) : self?
+  def self.from_value?(value : Int) : self?
     {% if @type.has_attribute?("Flags") %}
-      mask = {% for member, i in @type.constants %}\
-        {% if i != 0 %} | {% end %}\
-        {{@type}}::{{member}}.value{% end %}
-      return if (mask & value != value) || (value == 0 && values.none? { |val| val.to_i == 0 })
+      all_mask = {{@type}}::All.value
+      return if all_mask & value != value
       return new(value)
     {% else %}
       {% for member in @type.constants %}
@@ -371,7 +369,7 @@ struct Enum
   # Color.from_value(2) # => Color::Blue
   # Color.from_value(3) # raises Exception
   # ```
-  def self.from_value(value) : self
+  def self.from_value(value : Int) : self
     from_value?(value) || raise "Unknown enum #{self} value: #{value}"
   end
 


### PR DESCRIPTION
Fixes #5768

It also adds type restrictions to `Int`, and fix one usage in `src/debug/elf.cr`