### PR TITLE
Fix Object#def_hash when passing Symbols

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -122,6 +122,16 @@ private class TestObjectWithFinalize
   def_clone
 end
 
+private class HashedTestObject
+  property a : Int32
+  property b : Int32
+
+  def initialize(@a, @b)
+  end
+
+  def_hash :a, :b
+end
+
 describe Object do
   describe "delegate" do
     it "delegates" do
@@ -379,5 +389,15 @@ describe Object do
   it "calls #finalize on #clone'd objects" do
     obj = TestObjectWithFinalize.new
     assert_finalizes(:clone) { obj.clone }
+  end
+
+  describe "def_hash" do
+    it "should return same hash for equal property values" do
+      HashedTestObject.new(1, 2).hash.should eq HashedTestObject.new(1, 2).hash
+    end
+
+    it "shouldn't return same hash for different property values" do
+      HashedTestObject.new(1, 2).hash.should_not eq HashedTestObject.new(3, 4).hash
+    end
   end
 end

--- a/src/object.cr
+++ b/src/object.cr
@@ -1117,7 +1117,7 @@ class Object
   macro def_hash(*fields)
     def hash(hasher)
       {% for field in fields %}
-        hasher = {{field}}.hash(hasher)
+        hasher = {{field.id}}.hash(hasher)
       {% end %}
       hasher
     end


### PR DESCRIPTION
When passing `Symbol` to `Object#def_hash` macro it'll hash that instead of resolving it, this PR fixes this behaviour.

Relevant spec - https://carc.in/#/r/4q0k