### PR TITLE
Add tls scheme to HTTP::Server#bind and rename HTTP::Server#bind_ssl

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -351,9 +351,13 @@ module HTTP
           begin
             port = unused_port
             expect_raises(ArgumentError, "missing CA certificate") do
-              server.bind "ssl://127.0.0.1:#{port}?key=#{private_key}&cert=#{certificate}&verify_mode=force-peer"
+              server.bind "tls://127.0.0.1:#{port}?key=#{private_key}&cert=#{certificate}&verify_mode=force-peer"
             end
 
+            address = server.bind "tls://127.0.0.1:#{port}?key=#{private_key}&cert=#{certificate}&ca=#{certificate}"
+            address.should eq Socket::IPAddress.new("127.0.0.1", port)
+
+            port = unused_port
             address = server.bind "ssl://127.0.0.1:#{port}?key=#{private_key}&cert=#{certificate}&ca=#{certificate}"
             address.should eq Socket::IPAddress.new("127.0.0.1", port)
           ensure
@@ -368,9 +372,9 @@ module HTTP
           certificate = datapath("openssl", "openssl.crt")
 
           begin
-            expect_raises(ArgumentError, "missing private key") { server.bind "ssl://127.0.0.1:8081" }
-            expect_raises(OpenSSL::Error, "No such file or directory") { server.bind "ssl://127.0.0.1:8081?key=foo.key" }
-            expect_raises(ArgumentError, "missing certificate") { server.bind "ssl://127.0.0.1:8081?key=#{private_key}" }
+            expect_raises(ArgumentError, "missing private key") { server.bind "tls://127.0.0.1:8081" }
+            expect_raises(OpenSSL::Error, "No such file or directory") { server.bind "tls://127.0.0.1:8081?key=foo.key" }
+            expect_raises(ArgumentError, "missing certificate") { server.bind "tls://127.0.0.1:8081?key=#{private_key}" }
           ensure
             server.close
           end

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -394,7 +394,7 @@ module HTTP
       end
     end
 
-    describe "#bind_ssl" do
+    describe "#bind_tls" do
       it "binds SSL server context" do
         server = Server.new do |context|
           context.response.puts "Test Server (#{context.request.headers["Host"]?})"
@@ -405,7 +405,7 @@ module HTTP
 
         socket = OpenSSL::SSL::Server.new(TCPServer.new("127.0.0.1", 0), server_context)
         server.bind socket
-        ip_address1 = server.bind_ssl "127.0.0.1", 0, server_context
+        ip_address1 = server.bind_tls "127.0.0.1", 0, server_context
         ip_address2 = socket.local_address
 
         spawn server.listen

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -355,7 +355,7 @@ describe HTTP::WebSocket do
 
       http_server = http_ref = HTTP::Server.new([ws_handler])
 
-      address = http_server.bind_ssl("127.0.0.1", context: server_context)
+      address = http_server.bind_tls("127.0.0.1", context: server_context)
       address_chan.send(address)
       http_server.listen
     end

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -218,9 +218,9 @@ class HTTP::Server
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
     # context.private_key = "openssl.key"
-    # server.bind_ssl "127.0.0.1", 8080, context
+    # server.bind_tls "127.0.0.1", 8080, context
     # ```
-    def bind_ssl(host : String, port : Int32, context : OpenSSL::SSL::Context::Server, reuse_port : Bool = false) : Socket::IPAddress
+    def bind_tls(host : String, port : Int32, context : OpenSSL::SSL::Context::Server, reuse_port : Bool = false) : Socket::IPAddress
       tcp_server = TCPServer.new(host, port, reuse_port)
       server = OpenSSL::SSL::Server.new(tcp_server, context)
 
@@ -238,10 +238,10 @@ class HTTP::Server
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
     # context.private_key = "openssl.key"
-    # address = server.bind_ssl "127.0.0.1", context
+    # address = server.bind_tls "127.0.0.1", context
     # ```
-    def bind_ssl(host : String, context : OpenSSL::SSL::Context::Server) : Socket::IPAddress
-      bind_ssl(host, 0, context)
+    def bind_tls(host : String, context : OpenSSL::SSL::Context::Server) : Socket::IPAddress
+      bind_tls(host, 0, context)
     end
 
     # Creates an `OpenSSL::SSL::Server` and adds it as a socket.
@@ -253,10 +253,10 @@ class HTTP::Server
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
     # context.private_key = "openssl.key"
-    # address = server.bind_ssl Socket::IPAddress.new("127.0.0.1", 8000), context
+    # address = server.bind_tls Socket::IPAddress.new("127.0.0.1", 8000), context
     # ```
-    def bind_ssl(address : Socket::IPAddress, context : OpenSSL::SSL::Context::Server) : Socket::IPAddress
-      bind_ssl(address.address, address.port, context)
+    def bind_tls(address : Socket::IPAddress, context : OpenSSL::SSL::Context::Server) : Socket::IPAddress
+      bind_tls(address.address, address.port, context)
     end
   {% end %}
 


### PR DESCRIPTION
This adds `tls://` scheme for `HTTP::Server#bind` and makes it default in documentation. It also renames `HTTP::Server#bind_ssl`to `HTTP::Server#bind_tls`.

Follow-up on #6500 (discussion starting at https://github.com/crystal-lang/crystal/pull/6500#issuecomment-412087373)