### PR TITLE
Avoid using Comparable(self) in reference types

### DIFF
--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -2,7 +2,7 @@ require "../../../partial_comparable"
 
 # A location of an `ASTnode`, including its filename, line number and column number.
 class Crystal::Location
-  include PartialComparable(self)
+  include PartialComparable(Crystal::Location)
 
   getter line_number
   getter column_number

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -52,7 +52,7 @@ struct Pointer(T)
     end
   end
 
-  include Comparable(self)
+  include Comparable(Pointer(T))
 
   # Returns `true` if this pointer's address is zero.
   #

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -1,7 +1,7 @@
 # Conforms to Semantic Versioning 2.0.0
 # See http://semver.org/ for more information.
 class SemanticVersion
-  include Comparable(self)
+  include Comparable(SemanticVersion)
 
   getter major : Int32
   getter minor : Int32

--- a/src/string.cr
+++ b/src/string.cr
@@ -136,7 +136,7 @@ class String
   # :nodoc:
   HEADER_SIZE = sizeof({Int32, Int32, Int32})
 
-  include Comparable(self)
+  include Comparable(String)
 
   macro inherited
     {{ raise "Cannot inherit from String" }}

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -40,7 +40,7 @@ struct Time::Span
   # *Heavily* inspired by Mono's Time::Span class:
   # https://github.com/mono/mono/blob/master/mcs/class/corlib/System/Time::Span.cs
 
-  include Comparable(self)
+  include Comparable(Time::Span)
 
   MAX  = new seconds: Int64::MAX, nanoseconds: 999_999_999
   MIN  = new seconds: Int64::MIN, nanoseconds: -999_999_999


### PR DESCRIPTION
Fixes #6547.

This is a workaround fix.

There seems to be an issue with type guessed ivars and generics and self that I'm trying to narrow it down. But maybe it also involves macros that lucky quite much since I wasn't able to frame it yet.

Meanwhile this PR removes `include Comparable(self)` from reference types (leaving it only in Enum and some specs).
