### PR TITLE
Restore #bind_ssl as deprecated api

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -418,6 +418,30 @@ module HTTP
       end
     end
 
+    describe "#bind_ssl" do
+      it "binds SSL server context" do
+        server = Server.new do |context|
+          context.response.puts "Test Server (#{context.request.headers["Host"]?})"
+          context.response.close
+        end
+
+        server_context, client_context = ssl_context_pair
+
+        socket = OpenSSL::SSL::Server.new(TCPServer.new("127.0.0.1", 0), server_context)
+        server.bind socket
+        ip_address1 = server.bind_ssl "127.0.0.1", 0, server_context
+        ip_address2 = socket.local_address
+
+        spawn server.listen
+        Fiber.yield
+
+        HTTP::Client.get("https://#{ip_address1}", tls: client_context).body.should eq "Test Server (#{ip_address1})\n"
+        HTTP::Client.get("https://#{ip_address2}", tls: client_context).body.should eq "Test Server (#{ip_address2})\n"
+
+        server.close
+      end
+    end
+
     describe "#listen" do
       it "fails after listen" do
         server = Server.new { }

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -258,6 +258,11 @@ class HTTP::Server
     def bind_tls(address : Socket::IPAddress, context : OpenSSL::SSL::Context::Server) : Socket::IPAddress
       bind_tls(address.address, address.port, context)
     end
+
+    # DEPRECATED: Use `#bind_tls`.
+    def bind_ssl(*args)
+      bind_tls(*args)
+    end
   {% end %}
 
   # Parses a socket configuration from *uri* and adds it to this server.
@@ -287,7 +292,7 @@ class HTTP::Server
 
         bind_tls(address, context)
       {% else %}
-        raise ArgumentError.new "Unsupported socket type: ssl (program was compiled without openssl support)"
+        raise ArgumentError.new "Unsupported socket type: #{uri.scheme} (program was compiled without openssl support)"
       {% end %}
     else
       raise ArgumentError.new "Unsupported socket type: #{uri.scheme}"

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -260,6 +260,7 @@ class HTTP::Server
     end
 
     # DEPRECATED: Use `#bind_tls`.
+    # TODO: remove in 0.27.0
     def bind_ssl(*args)
       bind_tls(*args)
     end


### PR DESCRIPTION
Restores `HTTP::Server#bind_ssl` removed by #6533 so the current master can be used to ship 0.26.1 without breaking changes.

`HTTP::Server#bind_ssl` can be removed in 0.27