### PR TITLE
Add positive?/negative? to Number and Time::Span

### DIFF
--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -180,4 +180,11 @@ describe "Complex" do
     Complex.new(1.2, 0).zero?.should eq false
     Complex.new(1.2, 3.4).zero?.should eq false
   end
+
+  it "test positive?" do
+    Complex.new(0, 0).zero?.should eq true
+    Complex.new(0, 3.4).zero?.should eq false
+    Complex.new(1.2, 0).zero?.should eq false
+    Complex.new(1.2, 3.4).zero?.should eq false
+  end
 end

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -181,6 +181,24 @@ describe "Number" do
     1f32.zero?.should eq false
   end
 
+  it "test positive?" do
+    1.positive?.should eq true
+    1.0.positive?.should eq true
+    0.positive?.should eq false
+    0.0.positive?.should eq false
+    -1.positive?.should eq false
+    -1.1.positive?.should eq false
+  end
+
+  it "test negative?" do
+    1.negative?.should eq false
+    1.0.negative?.should eq false
+    0.negative?.should eq false
+    0.0.negative?.should eq false
+    -1.negative?.should eq true
+    -1.1.negative?.should eq true
+  end
+
   describe "step" do
     it "from int to float" do
       count = 0

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -264,4 +264,16 @@ describe Time::Span do
     Time::Span.new(nanoseconds: 0).zero?.should eq true
     Time::Span.new(nanoseconds: 123456789).zero?.should eq false
   end
+
+  it "test positive?" do
+    Time::Span.new(nanoseconds: 123456789).positive?.should eq true
+    Time::Span.new(nanoseconds: 0).positive?.should eq false
+    Time::Span.new(nanoseconds: -123456789).positive?.should eq false
+  end
+
+  it "test negative?" do
+    Time::Span.new(nanoseconds: 123456789).negative?.should eq false
+    Time::Span.new(nanoseconds: 0).negative?.should eq false
+    Time::Span.new(nanoseconds: -123456789).negative?.should eq true
+  end
 end

--- a/src/number.cr
+++ b/src/number.cr
@@ -255,6 +255,16 @@ struct Number
     self == 0
   end
 
+  # Returns `true` if value is greater than 0.
+  def positive? : Bool
+    self > 0
+  end
+
+  # Returns true if value is less than 0.
+  def negative? : Bool
+    self < 0
+  end
+
   private class StepIterator(T, L, B)
     include Iterator(T)
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -389,7 +389,15 @@ struct Time::Span
   end
 
   def zero? : Bool
-    to_i == 0 && nanoseconds == 0
+    self == ZERO
+  end
+
+  def positive? : Bool
+    self > ZERO
+  end
+
+  def negative? : Bool
+    self < ZERO
   end
 end
 


### PR DESCRIPTION
Hi! I know we don't want to copy every Ruby-ism in Crystal stdlib. And I will understand if you reject this PR.

But `Number` already has `even?`, `odd?`, and `zero?`. So I think `positive?` and `negative?` fits into that group of functions.

Vote for this pull request :+1: or :-1: 