### PR TITLE
Change Time::DayOfWeek to ISO ordinal numbering based on Monday = 1

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -548,6 +548,39 @@ describe Time do
     end
   end
 
+  describe Time::DayOfWeek do
+    it "#value" do
+      Time::DayOfWeek::Monday.value.should eq 1
+      Time::DayOfWeek::Tuesday.value.should eq 2
+      Time::DayOfWeek::Wednesday.value.should eq 3
+      Time::DayOfWeek::Thursday.value.should eq 4
+      Time::DayOfWeek::Friday.value.should eq 5
+      Time::DayOfWeek::Saturday.value.should eq 6
+      Time::DayOfWeek::Sunday.value.should eq 7
+    end
+
+    it ".from_value" do
+      Time::DayOfWeek.from_value(1).should eq Time::DayOfWeek::Monday
+      Time::DayOfWeek.from_value(2).should eq Time::DayOfWeek::Tuesday
+      Time::DayOfWeek.from_value(3).should eq Time::DayOfWeek::Wednesday
+      Time::DayOfWeek.from_value(4).should eq Time::DayOfWeek::Thursday
+      Time::DayOfWeek.from_value(5).should eq Time::DayOfWeek::Friday
+      Time::DayOfWeek.from_value(6).should eq Time::DayOfWeek::Saturday
+      Time::DayOfWeek.from_value(7).should eq Time::DayOfWeek::Sunday
+
+      # Special case: Identify 0 as Sunday
+      Time::DayOfWeek.from_value(0).should eq Time::DayOfWeek::Sunday
+
+      expect_raises(Exception, "Unknown enum Time::DayOfWeek value: 8") do
+        Time::DayOfWeek.from_value(8)
+      end
+    end
+
+    it ".new does not identify 0 as Sunday" do
+      Time::DayOfWeek.new(0).should_not eq Time::DayOfWeek::Sunday
+    end
+  end
+
   typeof(Time.now.year)
   typeof(1.minute.from_now.year)
   typeof(1.minute.ago.year)

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -114,7 +114,7 @@ module Crystal::System::Time
     day = 1
 
     time = ::Time.utc(year, systemtime.wMonth.to_i32, day, systemtime.wHour.to_i32, systemtime.wMinute.to_i32, systemtime.wSecond.to_i32)
-    i = systemtime.wDayOfWeek.to_i32 - time.day_of_week.to_i32
+    i = systemtime.wDayOfWeek.to_i32 - (time.day_of_week.to_i32 % 7)
 
     if i < 0
       i += 7

--- a/src/time.cr
+++ b/src/time.cr
@@ -65,6 +65,15 @@ require "crystal/system/time"
 # time.time_of_day # => 10:20:30
 # ```
 #
+# For querying if a time is at a specific day of week, `Time` offers named
+# predicate methods, delegating to `#day_of_week`:
+#
+# ```
+# time.monday? # => true
+# # ...
+# time.sunday? # => false
+# ```
+#
 # ### Time Zones
 #
 # Each time is attached to a specific time zone, represented by a `Location`
@@ -254,27 +263,35 @@ struct Time
   # :nodoc:
   MAX_SECONDS = 315537897599_i64
 
-  # `DayOfWeek` represents a day-of-week in the Gregorian calendar.
+  # `DayOfWeek` represents a day of the week in the Gregorian calendar.
   #
   # ```
   # time = Time.new(2016, 2, 15)
   # time.day_of_week # => Time::DayOfWeek::Monday
   # ```
   #
-  # Alternatively, you can use question methods:
+  # Each member is identified by its ordinal number starting from `Monday = 1`
+  # according to [ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf).
   #
-  # ```
-  # time.friday? # => false
-  # time.monday? # => true
-  # ```
+  # `#value` returns this ordinal number. It can easily be converted to the also
+  # common numbering based on `Sunday = 0` using `value % 7`.
   enum DayOfWeek
-    Sunday
-    Monday
-    Tuesday
-    Wednesday
-    Thursday
-    Friday
-    Saturday
+    Monday    = 1
+    Tuesday   = 2
+    Wednesday = 3
+    Thursday  = 4
+    Friday    = 5
+    Saturday  = 6
+    Sunday    = 7
+
+    # Returns the day of week that has the given value, or raises if no such member exists.
+    #
+    # This method also accepts `0` to identify `Sunday` in order to be compliant
+    # with the `Sunday = 0` numbering. All other days are equal in both formats.
+    def self.from_value(value : Int32) : self
+      value = 7 if value == 0
+      super(value)
+    end
   end
 
   @seconds : Int64
@@ -690,10 +707,10 @@ struct Time
     Span.new(nanoseconds: NANOSECONDS_PER_SECOND * (offset_seconds % SECONDS_PER_DAY) + nanosecond)
   end
 
-  # Returns the day of the week (`Sunday..Saturday`).
+  # Returns the day of the week (`Monday..Sunday`).
   def day_of_week : Time::DayOfWeek
-    value = ((offset_seconds / SECONDS_PER_DAY) + 1) % 7
-    DayOfWeek.new value.to_i
+    days = offset_seconds / SECONDS_PER_DAY
+    DayOfWeek.new days.to_i % 7 + 1
   end
 
   # Returns the day of the year.
@@ -1117,12 +1134,7 @@ struct Time
   #
   # TODO: Ensure correctness in local time-line.
   def at_beginning_of_week : Time
-    dow = day_of_week.value
-    if dow == 0
-      (self - 6.days).at_beginning_of_day
-    else
-      (self - (dow - 1).days).at_beginning_of_day
-    end
+    (self - (day_of_week.value - 1).days).at_beginning_of_day
   end
 
   def_at_end(year) { Time.new(year, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: location) }
@@ -1159,12 +1171,7 @@ struct Time
   #
   # TODO: Ensure correctness in local time-line.
   def at_end_of_week : Time
-    dow = day_of_week.value
-    if dow == 0
-      at_end_of_day
-    else
-      (self + (7 - dow).days).at_end_of_day
-    end
+    (self + (7 - day_of_week.value).days).at_end_of_day
   end
 
   def_at_end(day) { Time.new(year, month, day, 23, 59, 59, nanosecond: 999_999_999, location: location) }

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -26,7 +26,7 @@ struct Time::Format
         day_of_week = consume_number(1)
 
         first_day_of_year = Time.utc(@year, 1, 1)
-        week_day = first_day_of_year.day_of_week.value
+        week_day = first_day_of_year.day_of_week.value % 7
 
         if week_day < 5
           first_day_in_weeks_of_year = first_day_of_year - (week_day % 7 - 1).days

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -151,13 +151,11 @@ struct Time::Format
     end
 
     def day_of_week_monday_1_7
-      v = time.day_of_week.value
-      v = 7 if v == 0
-      io << v
+      io << time.day_of_week.value
     end
 
     def day_of_week_sunday_0_6
-      io << time.day_of_week.value
+      io << time.day_of_week.value % 7
     end
 
     def epoch
@@ -225,7 +223,7 @@ struct Time::Format
     end
 
     def get_day_name
-      DAY_NAMES[time.day_of_week.value]
+      DAY_NAMES[time.day_of_week.value % 7]
     end
 
     def get_short_day_name


### PR DESCRIPTION
Fixes #6554

`DayOfWeek.from_value` also identifies `0` as `Sunday` making it work with both numbering schemes. I don't think this should pose a problem.
`DayOfWeek.new` still requires the proper value, meaning `0` is not recognized.

I did not add a method to retrieve the value based on sunday = 0 (initially proposed as `#value_sun0`) because I think it is much easier and maybe even better understandable to just use `value % 7`.