### PR TITLE
Standardize methods between JSON::Any/YAML::Any

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -15,22 +15,28 @@ describe JSON::Any do
       JSON.parse("2").as_bool?.should be_nil
     end
 
-    it "gets int" do
+    it "gets int32" do
       JSON.parse("123").as_i.should eq(123)
-      JSON.parse("123456789123456").as_i64.should eq(123456789123456)
       JSON.parse("123").as_i?.should eq(123)
-      JSON.parse("123456789123456").as_i64?.should eq(123456789123456)
       JSON.parse("true").as_i?.should be_nil
+    end
+
+    it "gets int64" do
+      JSON.parse("123456789123456").as_i64.should eq(123456789123456)
+      JSON.parse("123456789123456").as_i64?.should eq(123456789123456)
       JSON.parse("true").as_i64?.should be_nil
     end
 
-    it "gets float" do
-      JSON.parse("123.45").as_f.should eq(123.45)
+    it "gets float32" do
       JSON.parse("123.45").as_f32.should eq(123.45_f32)
-      JSON.parse("123.45").as_f?.should eq(123.45)
       JSON.parse("123.45").as_f32?.should eq(123.45_f32)
-      JSON.parse("true").as_f?.should be_nil
       JSON.parse("true").as_f32?.should be_nil
+    end
+
+    it "gets float64" do
+      JSON.parse("123.45").as_f.should eq(123.45)
+      JSON.parse("123.45").as_f?.should eq(123.45)
+      JSON.parse("true").as_f?.should be_nil
     end
 
     it "gets string" do

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -7,6 +7,14 @@ describe YAML::Any do
       YAML.parse("").as_nil.should be_nil
     end
 
+    it "gets bool" do
+      YAML.parse("true").as_bool.should be_true
+      YAML.parse("false").as_bool.should be_false
+      YAML.parse("true").as_bool?.should be_true
+      YAML.parse("false").as_bool?.should be_false
+      YAML.parse("2").as_bool?.should be_nil
+    end
+
     it "gets string" do
       YAML.parse("hello").as_s.should eq("hello")
       YAML.parse("hello").as_s?.should eq("hello")
@@ -25,6 +33,19 @@ describe YAML::Any do
       YAML.parse("foo: bar")["foo"].as_h?.should be_nil
     end
 
+    it "gets int32" do
+      value = YAML.parse("1").as_i
+      value.should eq(1)
+      value.should be_a(Int32)
+
+      value = YAML.parse("1").as_i?
+      value.should eq(1)
+      value.should be_a(Int32)
+
+      value = YAML.parse("true").as_i?
+      value.should be_nil
+    end
+
     it "gets int64" do
       value = YAML.parse("1").as_i64
       value.should eq(1)
@@ -38,16 +59,16 @@ describe YAML::Any do
       value.should be_nil
     end
 
-    it "gets int32" do
-      value = YAML.parse("1").as_i
-      value.should eq(1)
-      value.should be_a(Int32)
+    it "gets float32" do
+      value = YAML.parse("1.2").as_f32
+      value.should eq(1.2_f32)
+      value.should be_a(Float32)
 
-      value = YAML.parse("1").as_i?
-      value.should eq(1)
-      value.should be_a(Int32)
+      value = YAML.parse("1.2").as_f32?
+      value.should eq(1.2_f32)
+      value.should be_a(Float32)
 
-      value = YAML.parse("true").as_i?
+      value = YAML.parse("true").as_f32?
       value.should be_nil
     end
 

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -186,13 +186,13 @@ struct JSON::Any
   # Checks that the underlying value is `Float`, and returns its value as an `Float64`.
   # Raises otherwise.
   def as_f : Float64
-    @raw.as(Float).to_f
+    @raw.as(Float64)
   end
 
   # Checks that the underlying value is `Float`, and returns its value as an `Float64`.
   # Returns `nil` otherwise.
   def as_f? : Float64?
-    as_f if @raw.is_a?(Float64)
+    @raw.as?(Float64)
   end
 
   # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
@@ -204,7 +204,7 @@ struct JSON::Any
   # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
   # Returns `nil` otherwise.
   def as_f32? : Float32?
-    as_f32 if (@raw.is_a?(Float32) || @raw.is_a?(Float64))
+    as_f32 if @raw.is_a?(Float)
   end
 
   # Checks that the underlying value is `String`, and returns its value.

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -158,6 +158,18 @@ struct YAML::Any
     @raw.as(Nil)
   end
 
+  # Checks that the underlying value is `Bool`, and returns its value.
+  # Raises otherwise.
+  def as_bool : Bool
+    @raw.as(Bool)
+  end
+
+  # Checks that the underlying value is `Bool`, and returns its value.
+  # Returns `nil` otherwise.
+  def as_bool? : Bool?
+    as_bool if @raw.is_a?(Bool)
+  end
+
   # Checks that the underlying value is `String`, and returns its value.
   # Raises otherwise.
   def as_s : String
@@ -191,7 +203,7 @@ struct YAML::Any
   # Checks that the underlying value is `Int64`, and returns its value as `Int32`.
   # Returns `nil` otherwise.
   def as_i? : Int32?
-    @raw.as?(Int64).try &.to_i
+    as_i if @raw.is_a?(Int)
   end
 
   # Checks that the underlying value is `Float64`, and returns its value.
@@ -204,6 +216,18 @@ struct YAML::Any
   # Returns `nil` otherwise.
   def as_f? : Float64?
     @raw.as?(Float64)
+  end
+
+  # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
+  # Raises otherwise.
+  def as_f32 : Float32
+    @raw.as(Float).to_f32
+  end
+
+  # Checks that the underlying value is `Float`, and returns its value as an `Float32`.
+  # Returns `nil` otherwise.
+  def as_f32? : Float32?
+    as_f32 if @raw.is_a?(Float)
   end
 
   # Checks that the underlying value is `Time`, and returns its value.


### PR DESCRIPTION
Details:
- Adds `#as_bool?` and `#as_bool` to `YAML::Any`
- Separate `Int32`/`Int64` and `Float32`/`Float64` tests in the `JSON::Any` specs
- Standardize and shorten conditions for nillable variants of cast methods