### PR TITLE
Fix: check presence of named argument via external name

### DIFF
--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -225,5 +225,11 @@ module Crystal
       other_def = a_def.expand_new_default_arguments(Program.new, 0, ["x", "y", "z"])
       other_def.to_s.should eq("def new:x:y:z(x __temp_1, y __temp_2, z __temp_3)\n  _ = allocate\n  _.initialize(x: __temp_1, y: __temp_2, z: __temp_3)\n  if _.responds_to?(:finalize)\n    ::GC.add_finalizer(_)\n  end\n  _\nend")
     end
+
+    it "expands def with reserved external name (#6559)" do
+      a_def = parse("def foo(abstract __arg0, **options); @abstract = __arg0; end").as(Def)
+      other_def = a_def.expand_default_arguments(Program.new, 0, ["abstract"])
+      other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = {}\n  @abstract = __arg0\nend")
+    end
   end
 end

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -155,7 +155,7 @@ class Crystal::Def
         named_tuple_entries = [] of NamedTupleLiteral::Entry
         named_args.try &.each_with_index do |named_arg, i|
           # Don't put here regular arguments
-          next if args.any? &.name.==(named_arg)
+          next if args.any? &.external_name.==(named_arg)
 
           temp_name = named_args_temp_names.not_nil![i]
           named_tuple_entries << NamedTupleLiteral::Entry.new(named_arg, Var.new(temp_name))


### PR DESCRIPTION
Fixes #6559

It seems the bug was always there but it became apparent when we changed the way `def foo(@abstract)` and similar constructs with keywords changed their implementation.