### PR TITLE
Fix Time::Format API doc

### DIFF
--- a/src/time/format/custom/http_date.cr
+++ b/src/time/format/custom/http_date.cr
@@ -1,20 +1,20 @@
 require "./rfc_2822"
 
-# Parse a time string using the formats specified by [RFC 2616](https://tools.ietf.org/html/rfc2616#section-3.3.1).
-#
-# Supported formats:
-# * [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55)
-# * [RFC 850](https://tools.ietf.org/html/rfc850#section-2.1.4)
-# * [asctime](http://en.cppreference.com/w/c/chrono/asctime)
-#
-# ```
-# Time::Format::HTTP_DATE.parse("Sun, 14 Feb 2016 21:00:00 GMT")  # => 2016-02-14 21:00:00 UTC
-# Time::Format::HTTP_DATE.parse("Sunday, 14-Feb-16 21:00:00 GMT") # => 2016-02-14 21:00:00 UTC
-# Time::Format::HTTP_DATE.parse("Sun Feb 14 21:00:00 2016")       # => 2016-02-14 21:00:00 UTC
-#
-# Time::Format::HTTP_DATE.format(Time.utc(2016, 2, 15)) # => "Mon, 15 Feb 2016 00:00:00 GMT"
-# ```
 struct Time::Format
+  # Parse a time string using the formats specified by [RFC 2616](https://tools.ietf.org/html/rfc2616#section-3.3.1).
+  #
+  # Supported formats:
+  # * [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55)
+  # * [RFC 850](https://tools.ietf.org/html/rfc850#section-2.1.4)
+  # * [asctime](http://en.cppreference.com/w/c/chrono/asctime)
+  #
+  # ```
+  # Time::Format::HTTP_DATE.parse("Sun, 14 Feb 2016 21:00:00 GMT")  # => 2016-02-14 21:00:00 UTC
+  # Time::Format::HTTP_DATE.parse("Sunday, 14-Feb-16 21:00:00 GMT") # => 2016-02-14 21:00:00 UTC
+  # Time::Format::HTTP_DATE.parse("Sun Feb 14 21:00:00 2016")       # => 2016-02-14 21:00:00 UTC
+  #
+  # Time::Format::HTTP_DATE.format(Time.utc(2016, 2, 15)) # => "Mon, 15 Feb 2016 00:00:00 GMT"
+  # ```
   module HTTP_DATE
     # Parses a string into a `Time`.
     def self.parse(string, location = Time::Location::UTC) : Time

--- a/src/time/format/custom/rfc_2822.cr
+++ b/src/time/format/custom/rfc_2822.cr
@@ -1,7 +1,7 @@
-# The [RFC 2822](https://tools.ietf.org/html/rfc2822) datetime format.
-#
-# This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
 struct Time::Format
+  # The [RFC 2822](https://tools.ietf.org/html/rfc2822) datetime format.
+  #
+  # This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
   module RFC_2822
     # Parses a string into a `Time`.
     def self.parse(string, kind = Time::Location::UTC) : Time

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -1,5 +1,5 @@
-# The [RFC 3339](https://tools.ietf.org/html/rfc3339) datetime format ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
 struct Time::Format
+  # The [RFC 3339](https://tools.ietf.org/html/rfc3339) datetime format ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   module RFC_3339
     # Parses a string into a `Time`.
     def self.parse(string, location = Time::Location::UTC) : Time


### PR DESCRIPTION
The API doc comment for `Time::Format` was overridden in multiple places (introduced by #5123), so #6214 was not a complete fix.