### PR TITLE
Refactor Time methods 

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -495,6 +495,19 @@ describe Time do
     end
   end
 
+  it "#year" do
+    Time.utc(2008, 12, 31).year.should eq 2008
+    Time.utc(2000, 12, 31).year.should eq 2000
+    Time.utc(1900, 12, 31).year.should eq 1900
+    Time.utc(1800, 12, 31).year.should eq 1800
+    Time.utc(1700, 12, 31).year.should eq 1700
+    Time.utc(1600, 12, 31).year.should eq 1600
+    Time.utc(400, 12, 31).year.should eq 400
+    Time.utc(100, 12, 31).year.should eq 100
+    Time.utc(4, 12, 31).year.should eq 4
+    Time.utc(1, 1, 1).year.should eq 1
+  end
+
   describe "#to_s" do
     it "prints string" do
       with_zoneinfo do

--- a/src/time.cr
+++ b/src/time.cr
@@ -1000,10 +1000,6 @@ struct Time
       raise ArgumentError.new "Invalid month"
     end
 
-    unless 1 <= year <= 9999
-      raise ArgumentError.new "Invalid year"
-    end
-
     days = leap_year?(year) ? DAYS_MONTH_LEAP : DAYS_MONTH
     days[month]
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -1413,17 +1413,25 @@ struct Time
     end
   {% end %}
 
-  protected def self.absolute_days(year, month, day)
-    days = leap_year?(year) ? DAYS_MONTH_LEAP : DAYS_MONTH
+  # Returns the number of days from `0001-01-01` to the date indicated
+  # by *year*, *month*, *day* in the proleptic Gregorian calendar.
+  #
+  # The valid range for *year* is `1..9999` and for *month* `1..12`. The value
+  # of *day*  is not validated and can exceed the number of days in the specified
+  # month or even a year.
+  protected def self.absolute_days(year, month, day) : Int32
+    days_per_month = leap_year?(year) ? DAYS_MONTH_LEAP : DAYS_MONTH
 
-    temp = 0
-    m = 1
-    while m < month
-      temp += days[m]
-      m += 1
+    days_in_year = day - 1
+    month_index = 1
+    while month_index < month
+      days_in_year += days_per_month[month_index]
+      month_index += 1
     end
 
-    (day - 1) + temp + (365*(year - 1)) + ((year - 1)/4) - ((year - 1)/100) + ((year - 1)/400)
+    year -= 1
+
+    year * 365 + year / 4 - year / 100 + year / 400 + days_in_year
   end
 
   protected def total_seconds


### PR DESCRIPTION
This PR refactors `Time.year_month_day_year` and `Time.absolute_days` to simplify the code and make it easier to understand.

The changes are mostly just formal, but there are a few semantic changes such as storing the value of an expression in a local variable for re-use.