### PR TITLE
Fix HTTP::Server crash with self-signed certificate

### DIFF
--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -83,6 +83,14 @@ abstract class OpenSSL::SSL::Socket < IO
     unless @ssl
       raise OpenSSL::Error.new("SSL_new")
     end
+
+    # Since OpenSSL::SSL::Socket is buffered it makes no
+    # sense to wrap a IO::Buffered with buffering activated.
+    if io.is_a?(IO::Buffered)
+      io.sync = false
+      io.read_buffering = false
+    end
+
     @bio = BIO.new(io)
     LibSSL.ssl_set_bio(@ssl, @bio, @bio)
   end


### PR DESCRIPTION
Fixes #6577

* Refactor how `socket.accept?` is called. `handle_client` is spawned after the `io` is returned.
  * It is assumed that `socket.accept?` wont raise and a STDOUT message is logged if that does not hold.
* `OpenSSL::SSL::Server#accept?` is changed to not raise
* This was optional but `OpenSSL::SSL::Socket::Server` will now call `LibSSL.ssl_shutdown` if the accept failed.

While reviewing the current state of `HTTP::Server` and recent PRs I have some doubts:

1. #6304 split the behaviour of `#sync`. I am not sure if that change should have changed https://github.com/crystal-lang/crystal/blob/0.26.0/src/http/server.cr#L379 to also set `read_buffering = false`. I am not sure if forcing `sync = false` was for reading or writing. That `sync = false` was first introduced to fix https://github.com/crystal-lang/crystal/issues/834 I am not sure if the performance improvement came from reads or writes changes. From #6304 description it seems that just unbuffered writes are wanted, so there is nothing to change.

2. The `sync = false` is, since 0.26.0 applied _after_ the handshake in the SSL, but in 0.25 it was applied _before_. I am not sure it that could be an issue or not. If so the following snippet might be required (assuming also that `read_buffering = false` is wanted)

```patch
--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -50,6 +50,11 @@ abstract class OpenSSL::SSL::Socket < IO
     def initialize(io, context : Context::Server = Context::Server.new, sync_close : Bool = false)
       super(io, context, sync_close)
 
+      if io.is_a?(IO::Buffered)
+        io.sync = false
+        io.read_buffering = false
+      end
+
       ret = LibSSL.ssl_accept(@ssl)
       unless ret == 1
         self.close
```

3. If (2) is not needed, there is still an issue. The `OpenSSL::SSL::Socket` implementation, it is a `IO::Buffered` that wraps and `IO`, and does not forward the `sync`/`read_buffering` values to the wrapped `io`. Since the default tcp socket is buffered, the ssl socket might be unbuffered due to `HTTP::Server#handle_client`, but the wrapped tcp socket is still buffered. It also make little sense to have a `IO::Buffered` wrapped by another `IO::Buffered`, so I think (2) make sense since it turns off the buffering of the inner `io`.

So, I think the only think pending should be to apply (2) as is in this PR. But I wanted to double check my assumptions of (1) mainly and, of course, the rest of the PR.