### PR TITLE
Unify way of printing exceptions from within fibers

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -120,11 +120,11 @@ class Fiber
     @proc.call
   rescue ex
     if name = @name
-      STDERR.puts "Unhandled exception in spawn(name: #{name}):"
+      STDERR.print "Unhandled exception in spawn(name: #{name}): "
     else
-      STDERR.puts "Unhandled exception in spawn:"
+      STDERR.print "Unhandled exception in spawn: "
     end
-    ex.inspect_with_backtrace STDERR
+    ex.inspect_with_backtrace(STDERR)
     STDERR.flush
   ensure
     @@stack_pool << @stack

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -403,6 +403,7 @@ module AtExitHandlers
 
       STDERR.print "Unhandled exception: "
       ex.inspect_with_backtrace(STDERR)
+      STDERR.flush
     end
 
     status


### PR DESCRIPTION
There was slight inconsistency how these exceptions were printed to `STDERR` (`puts` vs `print`), now they should be even. I've also added `STDERR.flush` missing from `AtExitHandlers.run`.

For the reference:

https://github.com/crystal-lang/crystal/blob/5e059ab5c24ed60426d58dda019b5904bcd33fca/src/kernel.cr#L404-L405

vs

https://github.com/crystal-lang/crystal/blob/5e059ab5c24ed60426d58dda019b5904bcd33fca/src/fiber.cr#L122-L128