### PR TITLE
Fix typo in Crystal playground

### DIFF
--- a/src/compiler/crystal/tools/playground/public/application.js
+++ b/src/compiler/crystal/tools/playground/public/application.js
@@ -62,7 +62,7 @@ $(function(){
 
   $("#saveAsGist").click(function(e) {
     if (Playground.settings.getGithubToken() == '') {
-      window.open('/settings.html');
+      window.open('/settings');
       return;
     }
 


### PR DESCRIPTION
If a user doesn't have a Github token set, clicking `share as Gist` will return `Not Found`. The fix is fairly self-explanatory.