### PR TITLE
Use Menlo instead of Monaco in generated documentation

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -235,7 +235,7 @@ body {
 }
 
 .entry-const {
-  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
 }
 
 .entry-const code {
@@ -257,7 +257,7 @@ body {
   border: 1px solid #f0f0f0;
   text-decoration: none;
   border-radius: 3px;
-  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
   transition: background .15s, border-color .15s;
 }
 
@@ -293,7 +293,7 @@ body {
   background-color: #f8f8f8;
   color: #47266E;
   border: 1px solid #f0f0f0;
-  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
   transition: .2s ease-in-out;
 }
 
@@ -366,7 +366,7 @@ pre {
 }
 
 code {
-  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
 }
 
 :not(pre) > code {


### PR DESCRIPTION
## Details/Motivation

Monaco is specified second to last in the font stack, but is never used because macOS has the Courier New and Courier fonts, which always gets used instead and looks pretty bad.

This patch adds Menlo to the front of the font stack and moves Monaco to be after it.

This shouldn't affect font displays on platforms other than macOS.

## Comparison

Before:

![image](https://user-images.githubusercontent.com/4206232/44614765-38f62080-a7df-11e8-90ee-d21376b01395.png)

After:

![image](https://user-images.githubusercontent.com/4206232/44614764-3267a900-a7df-11e8-9037-3906c6533c8a.png)
