### PR TITLE
Fix zlib missing handling of buffer error

### DIFF
--- a/spec/std/zlib/reader_spec.cr
+++ b/spec/std/zlib/reader_spec.cr
@@ -66,7 +66,7 @@ module Zlib
       reader.read(slice).should eq(0)
     end
 
-    it "should raise bufer error on error (#6575)" do
+    it "should raise buffer error on error (#6575)" do
       io = IO::Memory.new("x\x9C4\xC9\xD1\n@@\u0010\u0005\xD0\u007F\xB9ϻeEj~E\xD2`B\xAD\xA55H\x9B\u007F\xE7\xC5۩\x93\xA0\xA0pxo\xB0\xFFX7\x90\xCB\f\u0006P\xC2$\u001C\xB5\u0013\xD6v\u000E*\xF1d\u000F*\\^~\xDFj\xE4^@5FV\xB9\xF8\xB6[\u001C\xEC\xC2s\xB0\x99\xD3\n\xCD\xF3\xBC\u0000\u0000\u0000\xFF\xFF")
 
       reader = Reader.new(io)

--- a/spec/std/zlib/reader_spec.cr
+++ b/spec/std/zlib/reader_spec.cr
@@ -71,7 +71,7 @@ module Zlib
 
       reader = Reader.new(io)
 
-      expect_raises(Flate::Error) do
+      expect_raises(Flate::Error, "flate: buffer error") do
         reader.gets_to_end
       end
     end

--- a/spec/std/zlib/reader_spec.cr
+++ b/spec/std/zlib/reader_spec.cr
@@ -65,5 +65,15 @@ module Zlib
       slice = Bytes.empty
       reader.read(slice).should eq(0)
     end
+
+    it "should raise bufer error on error (#6575)" do
+      io = IO::Memory.new("x\x9C4\xC9\xD1\n@@\u0010\u0005\xD0\u007F\xB9ϻeEj~E\xD2`B\xAD\xA55H\x9B\u007F\xE7\xC5۩\x93\xA0\xA0pxo\xB0\xFFX7\x90\xCB\f\u0006P\xC2$\u001C\xB5\u0013\xD6v\u000E*\xF1d\u000F*\\^~\xDFj\xE4^@5FV\xB9\xF8\xB6[\u001C\xEC\xC2s\xB0\x99\xD3\n\xCD\xF3\xBC\u0000\u0000\u0000\xFF\xFF")
+
+      reader = Reader.new(io)
+
+      expect_raises(Flate::Error) do
+        reader.gets_to_end
+      end
+    end
   end
 end

--- a/src/flate/flate.cr
+++ b/src/flate/flate.cr
@@ -22,9 +22,12 @@ module Flate
 
   class Error < Exception
     def initialize(ret, stream)
-      if msg = stream.msg
+      msg = stream.msg
+      msg = LibZ.zError(ret) if msg.null?
+
+      if msg
         error_msg = String.new(msg)
-        super("flate: #{error_msg} #{ret}")
+        super("flate: #{error_msg}")
       else
         super("flate: #{ret}")
       end

--- a/src/flate/reader.cr
+++ b/src/flate/reader.cr
@@ -99,8 +99,11 @@ class Flate::Reader < IO
         end
 
         raise Flate::Error.new(ret, @stream)
-      when LibZ::Error::DATA_ERROR,
-           LibZ::Error::MEM_ERROR
+      when LibZ::Error::ERRNO,
+           LibZ::Error::DATA_ERROR,
+           LibZ::Error::MEM_ERROR,
+           LibZ::Error::BUF_ERROR,
+           LibZ::Error::VERSION_ERROR
         raise Flate::Error.new(ret, @stream)
       when LibZ::Error::STREAM_END
         @end = true

--- a/src/flate/reader.cr
+++ b/src/flate/reader.cr
@@ -20,9 +20,7 @@ class Flate::Reader < IO
     @stream.zalloc = LibZ::AllocFunc.new { |opaque, items, size| GC.malloc(items * size) }
     @stream.zfree = LibZ::FreeFunc.new { |opaque, address| GC.free(address) }
     ret = LibZ.inflateInit2(pointerof(@stream), -LibZ::MAX_BITS, LibZ.zlibVersion, sizeof(LibZ::ZStream))
-    if ret != LibZ::Error::OK
-      raise Flate::Error.new(ret, @stream)
-    end
+    raise Flate::Error.new(ret, @stream) unless ret.ok?
 
     @end = false
   end
@@ -92,20 +90,20 @@ class Flate::Reader < IO
       end
 
       case ret
-      when LibZ::Error::NEED_DICT
+      when .need_dict?
         if dict = @dict
           ret = LibZ.inflateSetDictionary(pointerof(@stream), dict, dict.size)
-          next if ret == LibZ::Error::OK
+          next if ret.ok?
         end
 
         raise Flate::Error.new(ret, @stream)
-      when LibZ::Error::ERRNO,
-           LibZ::Error::DATA_ERROR,
-           LibZ::Error::MEM_ERROR,
-           LibZ::Error::BUF_ERROR,
-           LibZ::Error::VERSION_ERROR
+      when .errno?,
+           .data_error?,
+           .mem_error?,
+           .buf_error?,
+           .version_error?
         raise Flate::Error.new(ret, @stream)
-      when LibZ::Error::STREAM_END
+      when .stream_end?
         @end = true
         return read_bytes
       else
@@ -126,7 +124,8 @@ class Flate::Reader < IO
     return if @closed
     @closed = true
 
-    LibZ.inflateEnd(pointerof(@stream))
+    ret = LibZ.inflateEnd(pointerof(@stream))
+    raise Flate::Error.new(ret, @stream) unless ret.ok?
 
     @io.close if @sync_close
   end

--- a/src/flate/writer.cr
+++ b/src/flate/writer.cr
@@ -25,9 +25,7 @@ class Flate::Writer < IO
     @closed = false
     ret = LibZ.deflateInit2(pointerof(@stream), level, LibZ::Z_DEFLATED, -LibZ::MAX_BITS, LibZ::DEF_MEM_LEVEL,
       strategy.value, LibZ.zlibVersion, sizeof(LibZ::ZStream))
-    if ret != LibZ::Error::OK
-      raise Flate::Error.new(ret, @stream)
-    end
+    raise Flate::Error.new(ret, @stream) unless ret.ok?
   end
 
   # Creates a new writer for the given *io*, yields it to the given block,
@@ -70,7 +68,9 @@ class Flate::Writer < IO
     @stream.avail_in = 0
     @stream.next_in = Pointer(UInt8).null
     consume_output LibZ::Flush::FINISH
-    LibZ.deflateEnd(pointerof(@stream))
+
+    ret = LibZ.deflateEnd(pointerof(@stream))
+    raise Flate::Error.new(ret, @stream) unless ret.ok?
 
     @output.close if @sync_close
   end

--- a/src/lib_z/lib_z.cr
+++ b/src/lib_z/lib_z.cr
@@ -74,4 +74,5 @@ lib LibZ
   fun inflate(stream : ZStream*, flush : Flush) : Error
   fun inflateEnd(stream : ZStream*) : Error
   fun inflateSetDictionary(stream : ZStream*, dictionary : UInt8*, len : UInt) : Error
+  fun zError(error : Error) : UInt8*
 end

--- a/src/lib_z/lib_z.cr
+++ b/src/lib_z/lib_z.cr
@@ -66,15 +66,15 @@ lib LibZ
                                    window_bits : Int32, mem_level : Int32, strategy : Int32,
                                    version : UInt8*, stream_size : Int32) : Error
   fun deflate(stream : ZStream*, flush : Flush) : Error
-  fun deflateEnd(stream : ZStream*) : Int32
+  fun deflateEnd(stream : ZStream*) : Error
   fun deflateReset(stream : ZStream*) : Error
   fun deflateSetDictionary(stream : ZStream*, dictionary : UInt8*, len : UInt) : Int
 
   fun inflateInit2 = inflateInit2_(stream : ZStream*, window_bits : Int32, version : UInt8*, stream_size : Int32) : Error
   fun inflate(stream : ZStream*, flush : Flush) : Error
-  fun inflateEnd(stream : ZStream*) : Int32
+  fun inflateEnd(stream : ZStream*) : Error
   fun inflateReset(stream : ZStream*) : Int32
-  fun inflateSetDictionary(stream : ZStream*, dictionary : UInt8*, len : UInt) : Int
+  fun inflateSetDictionary(stream : ZStream*, dictionary : UInt8*, len : UInt) : Error
 
   alias InFunc = Void*, UInt8** -> UInt
   alias OutFunc = Void*, UInt8*, UInt -> Int

--- a/src/lib_z/lib_z.cr
+++ b/src/lib_z/lib_z.cr
@@ -73,12 +73,5 @@ lib LibZ
   fun inflateInit2 = inflateInit2_(stream : ZStream*, window_bits : Int32, version : UInt8*, stream_size : Int32) : Error
   fun inflate(stream : ZStream*, flush : Flush) : Error
   fun inflateEnd(stream : ZStream*) : Error
-  fun inflateReset(stream : ZStream*) : Int32
   fun inflateSetDictionary(stream : ZStream*, dictionary : UInt8*, len : UInt) : Error
-
-  alias InFunc = Void*, UInt8** -> UInt
-  alias OutFunc = Void*, UInt8*, UInt -> Int
-
-  fun inflateBackInit = inflateBackInit_(stream : ZStream*, window_bits : Int, window : UInt8*, version : UInt8*, stream_size : Int) : Int
-  fun inflateBack(stream : ZStream*, in : InFunc, in_desc : Void*, out : OutFunc, out_desc : Void*) : Int
 end


### PR DESCRIPTION
Fixes #6575

The first commit fixes #6575: translating the [code that reproduces the bug](https://github.com/z64/zlib-freeze) to ruby raises "buffer error", and we were missing handling that error. I additionally added a check for other potential errors too.

The next commits refactor and improve zilb, fixing a few bugs too, where a function would return `Int` and it was expected to return an `Error` (an enum). This was easily detected by using the question methods of enums instead of comparing them with enum values.

Finally, peeking some Ruby code that deals with zlib, I found out about the `zError` function to get a nice error message in case zlib's stream doesn't provide one.

It might be nice to include this fix in 0.26.1 /cc @bcardiff 