### PR TITLE
Number: remove type suffixes in `inspect` output

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -299,6 +299,10 @@ describe BigDecimal do
     BigDecimal.new(100, 4).to_s.should eq "0.01"
   end
 
+  it "#inspect" do
+    BigDecimal.new(1, 2).inspect.should eq "0.01"
+  end
+
   it "converts to other number types" do
     bd1 = BigDecimal.new(123, 5)
     bd2 = BigDecimal.new(-123, 5)

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -169,7 +169,7 @@ describe "BigFloat" do
   end
 
   describe "#inspect" do
-    it { "2.3".to_big_f.inspect.should eq("2.3_big_f") }
+    it { "2.3".to_big_f.inspect.should eq("2.3") }
   end
 
   it "#hash" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -259,7 +259,7 @@ describe "BigInt" do
   end
 
   describe "#inspect" do
-    it { "2".to_big_i.inspect.should eq("2_big_i") }
+    it { "2".to_big_i.inspect.should eq("2") }
   end
 
   it "does gcd and lcm" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -190,7 +190,7 @@ describe "Float" do
     end
 
     it "does inspect for f32" do
-      3.2_f32.inspect.should eq("3.2_f32")
+      3.2_f32.inspect.should eq("3.2")
     end
 
     it "does inspect for f64 with IO" do
@@ -200,7 +200,7 @@ describe "Float" do
 
     it "does inspect for f32" do
       str = String.build { |io| 3.2_f32.inspect(io) }
-      str.should eq("3.2_f32")
+      str.should eq("3.2")
     end
   end
 

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -185,23 +185,23 @@ describe "Int" do
   end
 
   describe "#inspect" do
-    it "appends the type" do
+    it "doesn't append the type" do
       23.inspect.should eq("23")
-      23_i8.inspect.should eq("23_i8")
-      23_i16.inspect.should eq("23_i16")
-      -23_i64.inspect.should eq("-23_i64")
-      23_u8.inspect.should eq("23_u8")
-      23_u16.inspect.should eq("23_u16")
-      23_u32.inspect.should eq("23_u32")
-      23_u64.inspect.should eq("23_u64")
+      23_i8.inspect.should eq("23")
+      23_i16.inspect.should eq("23")
+      -23_i64.inspect.should eq("-23")
+      23_u8.inspect.should eq("23")
+      23_u16.inspect.should eq("23")
+      23_u32.inspect.should eq("23")
+      23_u64.inspect.should eq("23")
     end
 
-    it "appends the type using IO" do
+    it "doesn't append the type using IO" do
       str = String.build { |io| 23.inspect(io) }
       str.should eq("23")
 
       str = String.build { |io| -23_i64.inspect(io) }
-      str.should eq("-23_i64")
+      str.should eq("-23")
     end
   end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -297,7 +297,6 @@ struct BigDecimal < Number
 
   def inspect(io)
     to_s(io)
-    io << "_big_d"
   end
 
   def to_big_d

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -220,7 +220,6 @@ struct BigFloat < Float
 
   def inspect(io)
     to_s(io)
-    io << "_big_f"
   end
 
   def to_s(io : IO)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -342,7 +342,6 @@ struct BigInt < Int
 
   def inspect(io)
     to_s io
-    io << "_big_i"
   end
 
   # TODO: improve this

--- a/src/float.cr
+++ b/src/float.cr
@@ -177,11 +177,6 @@ struct Float32
     Printer.print(self, io)
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_f32"
-  end
-
   def clone
     self
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -467,25 +467,6 @@ struct Int
     yield ptr, count
   end
 
-  def inspect(io)
-    type = case self
-           when Int8    then "_i8"
-           when Int16   then "_i16"
-           when Int32   then ""
-           when Int64   then "_i64"
-           when Int128  then "_i128"
-           when UInt8   then "_u8"
-           when UInt16  then "_u16"
-           when UInt32  then "_u32"
-           when UInt64  then "_u64"
-           when UInt128 then "_u128"
-           else              raise "BUG: impossible"
-           end
-
-    to_s(io)
-    io << type
-  end
-
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -479,14 +479,11 @@ struct Slice(T)
   def to_s(io)
     if T == UInt8
       io << "Bytes["
-      # Inspect using to_s because we know this is a UInt8.
-      join ", ", io, &.to_s(io)
-      io << ']'
     else
       io << "Slice["
-      join ", ", io, &.inspect(io)
-      io << ']'
     end
+    join ", ", io, &.inspect(io)
+    io << ']'
   end
 
   def pretty_print(pp) : Nil


### PR DESCRIPTION
Fixes #6615
Reverts #4747

This change is about:

```crystal
# Current behavior
1_u64.inspect # => "1_u64"

# Proposed behavior
p 1_u64 # => "1"

# And same goes for any other numeric type: don't show the type suffix
```

I know I previously approved #4747, but I regret it.

As I previously mentioned, and #6615 is a clear example of that, the type information makes it harder to grasp and understand the output. If we want Crystal to be used for math/science stuff, I think we should show numbers as numbers, not as language constructs with type information.

I understand that type information can be valuable for debugging. But in that case it's simply a matter of using `typeof` or `.class` when debugging. We shouldn't always hammer the user with type information.

## Arguments against this change

And if the argument is "inspect should print something that is valid Crystal code and can construct back that value", well, that already doesn't apply for classes and structs, so it's generally not true.

## Other languages

No other language shows type information for numbers when printing them, either by themselves or inside other structures (arrays, hashes, even class fields).

Ruby doesn't show type information when printing numbers. I know, Ruby is dynamic and it looks like there's a single number type, but this is not true. There's Fixnum and Bignum, but you don't get this information when using `inspect` on them, even though it might be important from a debugging perspective (or is it important?).

[Julia has many number types](https://julia-ylwu.readthedocs.io/en/latest/manual/integers-and-floating-point-numbers.html) yet you don't see their types when outputting them.

## Let `Array#to_s` invoke `to_s`?

Now, one could say that the problem is that `Array#to_s` invokes `inspect` on each of its elements. Some suggested that `Array#to_s` should invoke `to_s` on its elements, while `Array#inspect` should invoke `inspect` on its elements. If we try it out, we get:

```crystal
ary = ["foo", "bar", "baz, qux"]
puts ary # =>[foo, bar, baz, qux]

# Or if we want to output the values to a file
File.open("file.txt", "w") do |file|
  file << ary
end
```

That is, `String#to_s` returns the string without quotes, so that doesn't seem to work very well. So using `inspect` makes sense, because we want to see each element clearly delimited. Or maybe we could let `Array#to_s` invoke `inspect` but only for String elements? I fear that if we go that direction it's more complex, and that we'll need these special rules for more types.

Alternatively, to print arrays we could say to always use `p` instead of `puts`, and to do `ary.inspect(file)`, but then `to_s` is also used in interpolation, for example `"foo #{ary}"`, so one would also have to do `"foo #{ary.inspect}"` (which is also a bit slower).

## Final words

More importantly, I think #4747 was merged without any associated bug or request, which makes me think someone maybe asked for this feature on IRC and a PR was rushed. There wasn't much discussion about this change either.