### PR TITLE
Compiler: resolve generics in macros, and add `Genreic#resolve` and `Generic#resolve?` macro methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1618,6 +1618,24 @@ module Crystal
       it "executes named_args" do
         assert_macro "x", %({{x.named_args}}), [Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("x", "U".path), NamedArgument.new("y", "V".path)])] of ASTNode, "{x: U, y: V}"
       end
+
+      it "executes resolve" do
+        assert_macro "x", %({{x.resolve}}), [Generic.new("Array".path, ["String".path] of ASTNode)] of ASTNode, %(Array(String))
+
+        expect_raises(Crystal::TypeException, "undefined constant Foo") do
+          assert_macro "x", %({{x.resolve}}), [Generic.new("Foo".path, ["String".path] of ASTNode)] of ASTNode, %(Foo(String))
+        end
+
+        expect_raises(Crystal::TypeException, "undefined constant Foo") do
+          assert_macro "x", %({{x.resolve}}), [Generic.new("Array".path, ["Foo".path] of ASTNode)] of ASTNode, %(Array(foo))
+        end
+      end
+
+      it "executes resolve?" do
+        assert_macro "x", %({{x.resolve?}}), [Generic.new("Array".path, ["String".path] of ASTNode)] of ASTNode, %(Array(String))
+        assert_macro "x", %({{x.resolve?}}), [Generic.new("Foo".path, ["String".path] of ASTNode)] of ASTNode, %(nil)
+        assert_macro "x", %({{x.resolve?}}), [Generic.new("Array".path, ["Foo".path] of ASTNode)] of ASTNode, %(nil)
+      end
     end
 
     describe "union methods" do

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1333,4 +1333,26 @@ describe "Semantic: macro" do
       end
       )) { string }
   end
+
+  it "finds generic in macro code" do
+    assert_type(%(
+      {% begin %}
+        {{ Array(String) }}
+      {% end %}
+      )) { array_of(string).metaclass }
+  end
+
+  it "finds generic in macro code using free var" do
+    assert_type(%(
+      class Foo(T)
+        def self.foo
+          {% begin %}
+            {{ Array(T) }}
+          {% end %}
+        end
+      end
+
+      Foo(Int32).foo
+      )) { array_of(int32).metaclass }
+  end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1283,6 +1283,16 @@ module Crystal::Macros
     # Returns the named arguments of this instantiation, if any.
     def named_args : NamedTupleLiteral | NilLiteral
     end
+
+    # Resolves this generic to a `TypeNode` if it denotes a type,
+    # or otherwise gives a compile-time error.
+    def resolve : ASTNode
+    end
+
+    # Resolves this path to a `TypeNode` if it denotes a type,
+    # or otherwise returns a `NilLiteral`.
+    def resolve? : ASTNode | NilLiteral
+    end
   end
 
   # A type declaration like `x : Int32`

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -404,6 +404,11 @@ module Crystal
       false
     end
 
+    def visit(node : Generic)
+      @last = resolve(node)
+      false
+    end
+
     def resolve(node : Path)
       resolve?(node) || node.raise_undefined_constant(@path_lookup)
     end
@@ -461,6 +466,17 @@ module Crystal
       else
         node.raise "can't interpret #{node}"
       end
+    end
+
+    def resolve(node : Generic)
+      type = @path_lookup.lookup_type(node, self_type: @scope, free_vars: @free_vars)
+      TypeNode.new(type)
+    end
+
+    def resolve?(node : Generic)
+      resolve(node)
+    rescue Crystal::Exception
+      nil
     end
 
     def visit(node : Splat)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1968,6 +1968,10 @@ module Crystal
             NilLiteral.new
           end
         end
+      when "resolve"
+        interpret_argless_method(method, args) { interpreter.resolve(self) }
+      when "resolve?"
+        interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
       else
         super
       end


### PR DESCRIPTION
Fixes #6576

This code right now works:

```crystal
{{ String }}
```

`String` (a `Path` AST node) is resolved in macros to a `TypeNode` denoting its type, or a compile-error ir raised. However, the same thing with generics (a `Generic` AST node) doesn't work:

```crystal
{{ Array(String) }} # can't execute Generic in a macro
```

This should work in the same way, resolving to a `TypeNode`. This is what this PR fixes.

It also adds `resolve` and `resolve?` macro methods to the `Generic`. For example:

```crystal
# Macros always receive AST nodes, and we need `resolve` to solve them to a TypeNode
macro abstract?(node)
  {{ node.resolve.abstract? }}
end

p abstract? IO            # => true
p abstract? String        # => false
p abstract? Array(String) # => false
```
