### PR TITLE
Compiler: don't show "expanded macro" right after raise is being used in macro error messages

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1355,4 +1355,22 @@ describe "Semantic: macro" do
       Foo(Int32).foo
       )) { array_of(int32).metaclass }
   end
+
+  it "executes raise inside method defined by macro" do
+    ex = assert_error %(
+      macro foo
+        def bar
+          \\{{ raise "OH NO" }}
+        end
+      end
+
+      class Foo
+        foo
+      end
+
+      Foo.new.bar
+      ), "OH NO"
+
+    ex.to_s.should_not contain("expanding macro")
+  end
 end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -53,7 +53,11 @@ module Crystal
 
     protected def self.wrap_macro_expression(ex, location)
       filename = location.filename
-      if filename.is_a?(VirtualFile) && (expanded_location = filename.expanded_location)
+      # Don't wrap in "expanding macro" if the error came from a macro {% raise ... %}
+      # and immediately after that there's a macro expansion (one doesn't
+      # want to show expanded macro code that's related to a macro `raise`,
+      # but instead make the error look as if it was produced by the method call).
+      if !ex.is_a?(MacroRaiseException) && filename.is_a?(VirtualFile) && (expanded_location = filename.expanded_location)
         ex = TypeException.new "expanding macro", expanded_location.line_number, expanded_location.column_number, expanded_location.filename, 0, ex
       end
       ex


### PR DESCRIPTION
This lets one better raise errors that look like any compile-time error the compiler would show.

There's the example in the spec, but also for example this:

```crystal
class Object
  # Defines an `initialize` method accepting one named argument per instance variable
  # in this object. Instance variables that are not nilable and which don't have a default
  # value must be passed.
  macro def_initialize
    def initialize(**args : **T) forall T
      {% verbatim do %}
        {% begin %}
          {% ivar_names = @type.instance_vars.map(&.id) %}
          {% args_names = T.keys %}

          # Check for unknown named arguments
          {% for arg_name in args_names %}
            {% if !ivar_names.includes?(arg_name) %}
              {% raise "unknown named argument: #{arg_name}" %}
            {% end %}
          {% end %}

          # Assign to instance vars, checking missing ones because
          # they are not nilable nor they have a default value
          {% for ivar in @type.instance_vars %}
            {% if args_names.includes?(ivar.id) %}
              @{{ivar}} = args[{{ivar.symbolize}}]
            {% elsif !ivar.type.nilable? && !ivar.has_default_value? %}
              {% raise "missing named argument: #{ivar}" %}
            {% end %}
          {% end %}
        {% end %}
      {% end %}
    end
  end
end

class Options
  property x : Int32
  property y : Int32
  property z : Int32?
  property w = 10

  def_initialize
end

Options.new(x: 1, y: 2) # Works
Options.new(x: 1, y: 2, z: 3) # Works
Options.new(x: 1, y: 2, w: 3) # Works
Options.new(x: 1) # missing named argument: y
```

In the above code, `def_initialze` is a macro that expands to a method that has macro inside it. When the call fails, right now you get an error like this:

```
Error in foo.cr:40: instantiating 'Options.class#new()'

p Options.new(x: 1)
          ^~~

in foo.cr:37: expanding macro

  def_initialize
  ^

in macro 'def_initialize' /Users/asterite/Projects/crystal/foo.cr:2, line 3:

   1.     def initialize(**args : **T) forall T
   2.       
>  3.         {% if true %}
   4.           {% ivar_names = @type.instance_vars.map(&.id) %}
   5.           {% args_names = T.keys %}
   6. 
   7.           # Check for unknown named arguments
   8.           {% for arg_name in args_names %}
   9.             {% if !(ivar_names.includes?(arg_name)) %}
  10.               {% raise("unknown named argument: #{arg_name}") %}
  11.             {% end %}
  12.           {% end %}
  13. 
  14.           # Assign to instance vars, checking missing ones because
  15.           # they are not nilable nor they have a default value
  16.           {% for ivar in @type.instance_vars %}
  17.             {% if args_names.includes?(ivar.id) %}
  18.               @{{ ivar }} = args[{{ ivar.symbolize }}]
  19.             {% else %}{% if (!ivar.type.nilable?) && (!ivar.has_default_value?) %}
  20.               {% raise("missing named argument: #{ivar}") %}
  21.             {% end %}{% end %}
  22.           {% end %}
  23.         {% end %}
  24.       
  25.     end
  26.   

expanding macro
in foo.cr:37: missing named argument: y

  def_initialize
  ^
```

That's pretty confusing and ugly. Usually, when we use the `raise` macro method, we do it to make it look similar to a regular compile-time error. That the method was actually defined by a macro (which succeeded), isn't useful.

This PR makes the above error be:

```
Error in foo.cr:40: missing named argument: y

p Options.new(x: 1)
          ^~~
```

The above is just one example which motivated this fix, but the fix/change is generally good, I think.