### PR TITLE
Allow comments after :nodoc: marker

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -163,7 +163,8 @@ class Crystal::Doc::Generator
   end
 
   def nodoc?(str : String?)
-    str == ":nodoc:" || str == "nodoc"
+    return false unless str
+    str.starts_with?(":nodoc:") || str.starts_with?("nodoc")
   end
 
   def nodoc?(obj)


### PR DESCRIPTION
Right now comment contents must be exactly `# :nodoc:`, otherwise they'll still be included in the docs. This PR allows for following comments, checking only for `:nodoc:` marker at the beginning.

This is preferrable since at times there's a wish to include documentation in the code (usually related to the technical side of things), which won't be included in generated API docs.