### PR TITLE
Fix to_h inspect in NamedTuple

### DIFF
--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -286,15 +286,6 @@ describe "Semantic: named tuples" do
       )) { named_tuple_of({"x": types["Foo"].virtual_type!, "y": types["Foo"].virtual_type!}) }
   end
 
-  it "does not compile to_h of empty tuples" do
-    # TODO change the location of this spec upon #2391
-    assert_error %(
-      require "prelude"
-      NamedTuple.new.to_h
-      ),
-      "Can't convert an empty NamedTuple to a Hash"
-  end
-
   it "types T as a tuple of metaclasses" do
     assert_type("
       struct NamedTuple

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -272,10 +272,6 @@ describe "NamedTuple" do
     tup1 = {a: 1, b: "hello"}
     hash = tup1.to_h
     hash.should eq({:a => 1, :b => "hello"})
-
-    expect_raises Exception, "Can't convert an empty NamedTuple to a Hash" do
-      NamedTuple.new.to_h
-    end
   end
 
   it "does to_s" do
@@ -315,7 +311,7 @@ describe "NamedTuple" do
   it "merges with other named tuple" do
     a = {one: 1, two: 2, three: 3, four: 4, five: 5, "im \"string": "works"}
     b = {two: "Two", three: true, "new one": "ok"}
-    c = a.merge(b).merge(four: "Four").should eq({one: 1, two: "Two", three: true, four: "Four", five: 5, "new one": "ok", "im \"string": "works"})
+    a.merge(b).merge(four: "Four").merge(NamedTuple.new).should eq({one: 1, two: "Two", three: true, four: "Four", five: 5, "new one": "ok", "im \"string": "works"})
   end
 
   it "does types" do

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -223,6 +223,7 @@ describe "NamedTuple" do
 
   it "does empty" do
     {a: 1}.empty?.should be_false
+    NamedTuple.new.empty?.should be_true
   end
 
   it "does to_a" do
@@ -271,6 +272,10 @@ describe "NamedTuple" do
     tup1 = {a: 1, b: "hello"}
     hash = tup1.to_h
     hash.should eq({:a => 1, :b => "hello"})
+
+    expect_raises Exception, "Can't convert an empty NamedTuple to a Hash" do
+      NamedTuple.new.to_h
+    end
   end
 
   it "does to_s" do

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -441,14 +441,14 @@ struct NamedTuple
   # tuple.to_h # => {:name => "Crystal", :year => 2011}
   # ```
   def to_h
-    raise "Can't convert an empty NamedTuple to a Hash" if empty?
-
-    {% if T.size > 0 %}
-    {
-      {% for key in T %}
-        {{key.symbolize}} => self[{{key.symbolize}}],
-      {% end %}
-    }
+    {% if T.size == 0 %}
+      {} of NoReturn => NoReturn
+    {% else %}
+      {
+        {% for key in T %}
+          {{key.symbolize}} => self[{{key.symbolize}}],
+        {% end %}
+      }
     {% end %}
   end
 

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -441,14 +441,14 @@ struct NamedTuple
   # tuple.to_h # => {:name => "Crystal", :year => 2011}
   # ```
   def to_h
-    {% if T.size == 0 %}
-      {% raise "Can't convert an empty NamedTuple to a Hash" %}
-    {% else %}
-      {
-        {% for key in T %}
-          {{key.symbolize}} => self[{{key.symbolize}}],
-        {% end %}
-      }
+    raise "Can't convert an empty NamedTuple to a Hash" if empty?
+
+    {% if T.size > 0 %}
+    {
+      {% for key in T %}
+        {{key.symbolize}} => self[{{key.symbolize}}],
+      {% end %}
+    }
     {% end %}
   end
 


### PR DESCRIPTION
Test Code:

```crystal
def foo(**options)
  unless options.empty?
    options.to_h
  end
end

puts foo
```

Current wrong result: 

```
in line 3: Can't convert an empty NamedTuple to a Hash
```

Now correct result:

```
nil
```