### PR TITLE
Don't try to mess with closed FDs when creating a subprocess

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -52,6 +52,10 @@ module Crystal::System::FileDescriptor
     arg
   end
 
+  private def system_closed?
+    LibC.fcntl(@fd, LibC::F_GETFL) == -1
+  end
+
   def self.fcntl(fd, cmd, arg = 0)
     r = LibC.fcntl(fd, cmd, arg)
     raise Errno.new("fcntl() failed") if r == -1
@@ -101,6 +105,9 @@ module Crystal::System::FileDescriptor
         self.close_on_exec = true
       end
     {% end %}
+
+    # Mark the handle open, since we had to have dup'd a live handle.
+    @closed = false
 
     # We are now pointing to a new file descriptor, we need to re-register
     # events with libevent and enqueue readers and writers again.

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -42,6 +42,10 @@ module Crystal::System::FileDescriptor
     raise NotImplementedError.new("Crystal::System::FileDescriptor#system_close_on_exec=") if close_on_exec
   end
 
+  private def system_closed?
+    false
+  end
+
   private def windows_handle
     ret = LibC._get_osfhandle(@fd)
     raise Errno.new("_get_osfhandle") if ret == -1
@@ -104,6 +108,9 @@ module Crystal::System::FileDescriptor
         self.close_on_exec = true
       end
     {% end %}
+
+    # Mark the handle open, since we had to have dup'd a live handle.
+    @closed = false
   end
 
   private def system_close

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -154,7 +154,8 @@ class IO::FileDescriptor < IO
 
   def reopen(other : IO::FileDescriptor)
     system_reopen(other)
-
+    # You shouldn't be able to reopen a closed FD
+    @closed = false
     other
   end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -13,7 +13,7 @@ class IO::FileDescriptor < IO
   def initialize(@fd, blocking = false)
     @closed =
       {% unless flag?(:win32) %}
-        fcntl(LibC::F_GETFD) < 0
+        !fcntl(LibC::F_GETFD) rescue true
       {% else %}
         false
       {% end %}

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -11,12 +11,7 @@ class IO::FileDescriptor < IO
   getter fd
 
   def initialize(@fd, blocking = false)
-    @closed =
-      {% unless flag?(:win32) %}
-        !fcntl(LibC::F_GETFD) rescue true
-      {% else %}
-        false
-      {% end %}
+    @closed = system_closed?
 
     unless blocking || {{flag?(:win32)}}
       self.blocking = false
@@ -154,8 +149,7 @@ class IO::FileDescriptor < IO
 
   def reopen(other : IO::FileDescriptor)
     system_reopen(other)
-    # You shouldn't be able to reopen a closed FD
-    @closed = false
+
     other
   end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -11,7 +11,12 @@ class IO::FileDescriptor < IO
   getter fd
 
   def initialize(@fd, blocking = false)
-    @closed = false
+    @closed =
+      {% unless flag?(:win32) %}
+        fcntl(LibC::F_GETFD) < 0
+      {% else %}
+        false
+      {% end %}
 
     unless blocking || {{flag?(:win32)}}
       self.blocking = false

--- a/src/process.cr
+++ b/src/process.cr
@@ -415,17 +415,20 @@ class Process
     when IO::FileDescriptor
       src_io.blocking = true
       dst_io.reopen(src_io)
+      dst_io.close_on_exec = false
     when Redirect::Inherit
-      dst_io.blocking = true
+      if LibC.fcntl(dst_io.fd, LibC::F_GETFD) >= 0
+        dst_io.blocking = true
+        dst_io.close_on_exec = false
+      end
     when Redirect::Close
       File.open("/dev/null", mode) do |file|
         dst_io.reopen(file)
+        dst_io.close_on_exec = false
       end
     else
       raise "BUG: unknown object type #{src_io}"
     end
-
-    dst_io.close_on_exec = false
   end
 
   private def close_io(io)


### PR DESCRIPTION
So when on a mac, spawning a child process crashes if stdin is closed (and probably the other handles). This makes `entr -r` break my apps when trying to run them.
This is because when forking off a child, crystal tries to fiddle with the standard handles, which you cannot do if they're closed. This patch checks to see if the handle is closed before messing with it.

While I'm at it, the existing `Redirect::Close` behavior seems really strange to me, too. Opening `/dev/null`, duping it, closing it, *then* setting flags on it seems to bug out on the mac.. I've moved the `close_on_exec` call to inside the `File.open` block for now, which seems to work, but it feels like there is a bigger problem here with how BSD treats filehandles.