### PR TITLE
Fix DEVNULL docs

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -64,11 +64,11 @@ class File < IO::FileDescriptor
   #   file.puts "this is discarded"
   # end
   # ```
-  {% if flag?(:win32) %}
-    DEVNULL = "NUL"
-  {% else %}
-    DEVNULL = "/dev/null"
-  {% end %}
+  DEVNULL = {% if flag?(:win32) %}
+              "NUL"
+            {% else %}
+              "/dev/null"
+            {% end %}
 
   include Crystal::System::File
 


### PR DESCRIPTION
Currently there are no docs for the [`DEVNULL`](https://crystal-lang.org/api/0.26.1/File.html#DEVNULL) constant.
That's because there's a line generated at the macro between the comment and the constant:
```crystal

  # The name of the null device on the host platform. `/dev/null` on UNIX and `NUL`
  # on win32.
  #
  # When this device is opened using `File.open`, read operations will always
  # return EOF, and any data written will be immediately discarded.
  #
  # ```
  # File.open(File::DEVNULL) do |file|
  #   file.puts "this is discarded"
  # end
  # ```

    DEVNULL = "/dev/null"
```
This fixes it.