### PR TITLE
Semantic: correctly guess ivar type from splat argument

### DIFF
--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -25,6 +25,9 @@ module Crystal
 
     @args : Array(Arg)?
     @block_arg : Arg?
+    @splat_index : Int32?
+    @double_splat : Arg?
+    @splat : Arg?
 
     @args_hash_initialized = true
     @args_hash = {} of String => Arg
@@ -800,6 +803,20 @@ module Crystal
       if arg = args_hash[node.name]?
         # If the argument has a restriction, guess the type from it
         if restriction = arg.restriction
+          # It is for something like `def foo(*@foo : *T)`.
+          if @splat == arg
+            # If restriction is not splat (like `*foo : T`),
+            # we cannot guess the type.
+            # (We can also guess `Indexable(T)`, but it is not perfact.)
+            # And this early return is no problem because splat argument
+            # cannot have a default value.
+            return unless restriction.is_a?(Splat)
+            restriction = restriction.exp
+            # It is for something like `def foo(**@foo : **T)`.
+          elsif @double_splat == arg
+            return unless restriction.is_a?(DoubleSplat)
+            restriction = restriction.exp
+          end
           type = lookup_type?(restriction)
           return type if type
         end
@@ -1096,6 +1113,8 @@ module Crystal
       @found_self = false
       @args = node.args
       @block_arg = node.block_arg
+      @double_splat = node.double_splat
+      @splat_index = node.splat_index
       @args_hash_initialized = false
 
       if !node.receiver && node.name == "initialize" && !current_type.is_a?(Program)
@@ -1115,6 +1134,9 @@ module Crystal
       @initialize_info = nil
       @block_arg = nil
       @args = nil
+      @double_splat = nil
+      @splat_index = nil
+      @splat = nil
       @args_hash.clear
       @args_hash_initialized = true
       @outside_def = true
@@ -1170,7 +1192,12 @@ module Crystal
 
     def args_hash
       unless @args_hash_initialized
-        @args.try &.each do |arg|
+        @args.try &.each_with_index do |arg, i|
+          @splat = arg if @splat_index == i
+          @args_hash[arg.name] = arg
+        end
+
+        @double_splat.try do |arg|
           @args_hash[arg.name] = arg
         end
 

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -804,7 +804,7 @@ module Crystal
         # If the argument has a restriction, guess the type from it
         if restriction = arg.restriction
           # It is for something like `def foo(*@foo : *T)`.
-          if @splat == arg
+          if @splat.same?(arg)
             # If restriction is not splat (like `*foo : T`),
             # we cannot guess the type.
             # (We can also guess `Indexable(T)`, but it is not perfact.)
@@ -813,7 +813,7 @@ module Crystal
             return unless restriction.is_a?(Splat)
             restriction = restriction.exp
             # It is for something like `def foo(**@foo : **T)`.
-          elsif @double_splat == arg
+          elsif @double_splat.same?(arg)
             return unless restriction.is_a?(DoubleSplat)
             restriction = restriction.exp
           end


### PR DESCRIPTION
Caught from https://twitter.com/n_siena/status/1026021219714269184 (Japanese).

Before this PR the type of ivar `@foo` of `def initialize(*@foo : Int32)` is guessed to `Int32`. It causes very strange error. For example:

```crystal
class Foo
  def initialize(*@foo : Int32)
  end
end

Foo.new(1)
# Error: instance variable '@foo' of Foo must be Int32, not Tuple(Int32)
```

I think it should not be guessed to any types because this restriction means variable-length tuple and we have no type for it. `Indexable(Int32)` is one of generic types of variable-length tuple, but it is not perfect. So, it should be specified explicitly if needed.

Nevertheless, `@foo` type of `def initialize(*@foo : *{Int32})` can be guessed to `{Int32}` easily. It should be guessed.

A double-splat and ivar has the same problems. This PR fixes them. Now we get this error and result.

```crystal
class Foo
  def initialize(*@foo : Int32)
  end
end

Foo.new(1)
# Error: Can't infer the type of instance variable '@foo' of Foo
```

```crystal
alias T1 = {Int32}

class Foo
  getter foo
  def initialize(*@foo : *T1)
  end
end

pp Foo.new(1).foo.class # => {Int32}
```
