### PR TITLE
Clean up tuple elements after unreachable

### DIFF
--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -559,7 +559,7 @@ describe "Code gen: def" do
       ))
   end
 
-  it "codegens yield with destructing tuple having unrachable element" do
+  it "codegens yield with destructing tuple having unreachable element" do
     codegen(%(
       def foo
         yield({1, while true; end})

--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -558,4 +558,14 @@ describe "Code gen: def" do
       foo(1 || true)
       ))
   end
+
+  it "codegens yield with destructing tuple having unrachable element" do
+    codegen(%(
+      def foo
+        yield({1, while true; end})
+      end
+
+      foo { |a, b| }
+      ))
+  end
 end

--- a/spec/compiler/semantic/cleanup_spec.cr
+++ b/spec/compiler/semantic/cleanup_spec.cr
@@ -16,6 +16,14 @@ describe "cleanup" do
       ), "expression has no effect"
   end
 
+  it "strip tuple elements after unreachable element" do
+    assert_after_cleanup "{1, while true; end, 2}", "1\nwhile true\nend"
+  end
+
+  it "strip named-tuple elements after unreachable element" do
+    assert_after_cleanup "{foo: 1, bar: while true; end, baz: 2}", "1\nwhile true\nend"
+  end
+
   # it "errors comparison of unsigned integer with zero or negative literal" do
   #   error = "comparison of unsigned integer with zero or negative literal will always be false"
   #   assert_error "1_u32 < 0", error

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -730,6 +730,28 @@ module Crystal
     def transform(node : TupleLiteral)
       super
       node.update
+
+      no_return_index = node.elements.index &.no_returns?
+      if no_return_index
+        exps = Expressions.new(node.elements[0, no_return_index + 1])
+        exps.bind_to(exps.expressions.last)
+        return exps
+      end
+
+      node
+    end
+
+    def transform(node : NamedTupleLiteral)
+      super
+      node.update
+
+      no_return_index = node.entries.index &.value.no_returns?
+      if no_return_index
+        exps = Expressions.new(node.entries[0, no_return_index + 1].map &.value)
+        exps.bind_to(exps.expressions.last)
+        return exps
+      end
+
       node
     end
 


### PR DESCRIPTION
Resolve https://github.com/crystal-lang/crystal/pull/6628#issuecomment-417981480 problem.

Small reproducible example:

```crystal
def foo
  yield({1, while true; end})
end

foo { |a, b| }
```

Result:

```console
$ crystal run foo.cr
Missing hash key: "b" (KeyError)
  from Hash(String, Crystal::CodeGenVisitor::LLVMVar)+@Hash(K, V)#[]<String>:Crystal::CodeGenVisitor::LLVMVar
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::CodeGenVisitor>:Nil
  from Crystal::CodeGenVisitor#visit<Crystal::Call>:Bool
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::CodeGenVisitor>:Nil
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::CodeGenVisitor>:Nil
  from Crystal::Compiler#codegen<Crystal::Program, Crystal::ASTNode+, Array(Crystal::Compiler::Source), String>:(Tuple(Array(Crystal::Compiler::CompilationUnit), Array(String)) | Nil)
  from Crystal::Compiler#compile<Array(Crystal::Compiler::Source), String>:Crystal::Compiler::Result
  from Crystal::Command#run_command<Bool>:Nil
  from Crystal::Command#run:(Bool | Crystal::Compiler::Result | Nil)
  from main
```

This reason is `yield` tuple destructing against the tuple having unreachable elements. An unreachable element should be treated by `CleanupTransformer`. This PR adds cleanup process for `TupleLiteral` and `NamedTupleLiteral` to `CleanupTransformer`.

Thank you.