### PR TITLE
Use blocking IO on a TTY if it can't be reopened

### DIFF
--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -20,19 +20,18 @@ class IO::FileDescriptor < IO
 
   # :nodoc:
   def self.from_stdio(fd)
-    # If we have a TTY for stdin/out/err, it is a shared terminal.
+    # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
     # We need to reopen it to use O_NONBLOCK without causing other programs to break
 
     # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
     path = uninitialized UInt8[256]
-    if LibC.ttyname_r(fd, path, 256) == 0
-      # Open a fresh handle to the TTY
-      if (clone_fd = LibC.open(path, LibC::O_RDWR)) >= 0
-        return new(clone_fd).tap(&.close_on_exec = true)
-      end
-    end
-    # Fallback to blocking IO.
-    new(fd, blocking: true)
+    ret = LibC.ttyname_r(fd, path, 256)
+    return new(fd, blocking: true) unless ret == 0
+
+    clone_fd = LibC.open(path, LibC::O_RDWR)
+    return new(fd, blocking: true) if clone_fd == -1
+
+    new(clone_fd).tap(&.close_on_exec = true)
   end
 
   def blocking


### PR DESCRIPTION
Should fix issue #6624

Kinda hard to test though. Doesn't seem to have any regressions at least.