### PR TITLE
Expose Time#total_seconds in public API

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -21,7 +21,7 @@ describe Time do
     end
 
     it "initializes max value" do
-      time = Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999)
+      time = Time.new(9999, 12, 31, 23, 59, 59, nanosecond: 999_999_999, location: Time::Location::UTC)
       time.year.should eq(9999)
       time.month.should eq(12)
       time.day.should eq(31)
@@ -29,6 +29,7 @@ describe Time do
       time.minute.should eq(59)
       time.second.should eq(59)
       time.nanosecond.should eq(999_999_999)
+      time.total_seconds.should eq Time::MAX_SECONDS
     end
 
     it "fails with negative nanosecond" do
@@ -331,6 +332,17 @@ describe Time do
       t1 = Time.now
       t1.epoch.should eq(t1.to_utc.epoch)
       t1.epoch_f.should be_close(t1.to_utc.epoch_f, 1e-01)
+    end
+  end
+
+  it "#total_seconds" do
+    Time.utc(1, 1, 1).total_seconds.should eq 0
+
+    now = Time.utc_now
+    Time.utc(seconds: now.total_seconds, nanoseconds: now.nanosecond).should eq now
+
+    expect_raises(ArgumentError, "Invalid time") do
+      Time.utc(seconds: Int64::MAX, nanoseconds: 999_999_999)
     end
   end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -1208,11 +1208,14 @@ struct Time
     (day - 1) + temp + (365*(year - 1)) + ((year - 1)/4) - ((year - 1)/100) + ((year - 1)/400)
   end
 
-  protected def total_seconds
+  # Returns the total number of seconds elapsed since epoch (`0001-01-01 00:00:00`).
+  def total_seconds
     @seconds
   end
 
-  protected def offset_seconds
+  # Returns the total number of seconds elapsed since epoch (`0001-01-01 00:00:00`)
+  # plus the offset observed in `#location` at that instant.
+  private def offset_seconds
     @seconds + offset
   end
 


### PR DESCRIPTION
`Time#total_seconds` was a protected method, but it can be useful outside of `Time` namespace, for example to implement custom extensions to the Time API.
This method directly exposes an implementation detail, but it doesn't depend on the implementation and would be useful even if the implementation was changed. It supplements the already existing constructor `Time.new(seconds, nanoseconds)` which accepts `total_seconds` since epoch as argument.

I don't think `Time#offset_seconds` needs to be exposed since it can easily be duplicated as sum of `#total_seconds` and `#offset`. Instead I changed visibility to `private` because it doesn't need to be exposed in the namespace (and isn't even used).

See also #5374 (probably fixes that).