### PR TITLE
Fix `ASTNode#to_s` for multiline macro expression

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -150,4 +150,5 @@ describe "ASTNode#to_s" do
   expect_to_s "1.&*"
   expect_to_s "1.&**"
   expect_to_s "1.~(2)"
+  expect_to_s %({% for foo in bar %}\n  {{ if true\n  foo\n  bar\nend }}\n{% end %})
 end

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1355,4 +1355,18 @@ describe "Semantic: macro" do
       Foo(Int32).foo
       )) { array_of(int32).metaclass }
   end
+
+  it "expands multiline macro expression in verbatim (#6643)" do
+    assert_type(%(
+      {% verbatim do %}
+        {{
+          if true
+            1
+            "2"
+            3
+          end
+        }}
+      {% end %}
+    )) { int32 }
+  end
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -748,7 +748,9 @@ module Crystal
     def visit(node : MacroExpression)
       @str << (node.output? ? "{{" : "{% ")
       @str << ' ' if node.output?
-      node.exp.accept self
+      outside_macro do
+        node.exp.accept self
+      end
       @str << ' ' if node.output?
       @str << (node.output? ? "}}" : " %}")
       false
@@ -1539,6 +1541,13 @@ module Crystal
       @inside_macro += 1
       yield
       @inside_macro -= 1
+    end
+
+    def outside_macro
+      old_inside_macro = @inside_macro
+      @inside_macro = 0
+      yield
+      @inside_macro = old_inside_macro
     end
 
     def to_s


### PR DESCRIPTION
Fixed #6643