### PR TITLE
Fix formatting `{% verbatim do %} ... {% end %}` outside macro

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1164,6 +1164,8 @@ describe Crystal::Formatter do
   assert_format "class X\n annotation  FooAnnotation  \n  end \n end", "class X\n  annotation FooAnnotation\n  end\nend"
 
   assert_format "macro foo\n{% verbatim do %}1 + 2{% end %}\nend"
+  assert_format "{% verbatim do %}{{1}} + {{2}}{% end %}"
+  assert_format "foo({% verbatim do %}{{1}} + {{2}}{% end %})"
 
   assert_format "{% foo <<-X\nbar\nX\n%}"
   assert_format "foo do\n  {% foo <<-X\n  bar\n  X\n  %}\nend"


### PR DESCRIPTION
This script crashes `crystal tool format`:

```crystal
p!(
  {% verbatim do %}
    1
    {{2}}
    3
  {% end %}
)
```

```console
$ crystal tool format foo.cr
Error: couldn't format 'foo.cr', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues

expecting MACRO_CONTROL_START, not `{%, `, at :2:3 (Exception)
  from Crystal::Formatter#check<Symbol>:Nil
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::Formatter>:(Bool | Nil)
  from Crystal::Formatter#format_args_simple<Array(Crystal::ASTNode+), Int32, Bool>:Tuple(Bool, Bool, Int32)
  from Crystal::Formatter#format_args<Array(Crystal::ASTNode+), Bool, (Array(Crystal::NamedArgument) | Nil), (Crystal::ASTNode+ | Nil), Int32, Bool>:Tuple(Bool | Nil, Bool, Int32)
  from Crystal::Formatter#visit<Crystal::Call>:Bool
  from Crystal::ASTNode+@Crystal::ASTNode#accept<Crystal::Formatter>:(Bool | Nil)
  from Crystal::format<String, String>:String
  from Crystal::Command#tool:(Bool | Nil)
  from Crystal::Command#run:(Bool | Crystal::Compiler::Result | Nil)
  from main
```

This PR fixes it.