### PR TITLE
Add compile-time flag to docs generator

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -11,6 +11,8 @@ class Crystal::Command
     output_directory = File.join(".", "docs")
     canonical_base_url = nil
 
+    compiler = Compiler.new
+
     OptionParser.parse(options) do |opts|
       opts.banner = <<-'BANNER'
         Usage: crystal docs [options]
@@ -34,6 +36,10 @@ class Crystal::Command
 
       opts.on("--canonical-base-url=URL", "-b URL", "Set the canonical base url") do |value|
         canonical_base_url = value
+      end
+
+      opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+        compiler.flags << flag
       end
 
       opts.on("-h", "--help", "Show this message") do

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -42,6 +42,31 @@ class Crystal::Command
         compiler.flags << flag
       end
 
+      opts.on("--error-trace", "Show full error trace") do
+        compiler.show_error_trace = true
+      end
+
+      opts.on("--no-color", "Disable colored output") do
+        @color = false
+        compiler.color = false
+      end
+
+      opts.on("--prelude ", "Use given file as prelude") do |prelude|
+        compiler.prelude = prelude
+      end
+
+      opts.on("-s", "--stats", "Enable statistics output") do
+        @progress_tracker.stats = true
+      end
+
+      opts.on("-p", "--progress", "Enable progress output") do
+        @progress_tracker.progress = true
+      end
+
+      opts.on("-t", "--time", "Enable execution time output") do
+        @time = true
+      end
+
       opts.on("-h", "--help", "Show this message") do
         puts opts
         exit

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -54,6 +54,7 @@ class Crystal::Command
     included_dirs << File.expand_path("./src")
 
     compiler = Compiler.new
+    compiler.flags << "docs"
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 


### PR DESCRIPTION
This PR adds a `docs` flag when running the docs generator.

A macro like `{% if flag?(:docs) %}{% end %}` can be used to include some conditional code for the docs generator.

While it is generally not advised to customize code for generating the API docs, there are situations where this is required.

For example, the stdlib includes some features that are only available for specific targets and skipped on all other targets. For example `FileDescriptor#fcntl` is only available on POSIX, but `WinError` only on Windows. It is certainly not said that these will stay as they are and there should definitely be a strong motivation to try to minimize differences between platforms, especially in the stdlib. But some features simply won't work on all platforms. The docs generator is also not only used for stdlib API docs but for any Crystal library and they might have reasons for not having the API as much platform-independent as possible.

This PR just adds the compiler feature, that doesn't necessarily mean it should be used in the stdlib.

The second commit adds `-D` flag to `crystal docs` to allow specifying custom flags with the docs generator in the same way as when building. This is mostly for completeness sake, but can be useful to use the same flags for building and generating docs (for example `-Dwithout_openssl` should produce API docs without SSL; I know this is not a particularly convincing example, but that's the kind of thing this is about).