### PR TITLE
Enable HTTP::Server#close in websocket specs

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -386,7 +386,7 @@ describe HTTP::WebSocket do
       HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
     end
   ensure
-    # http_server.try &.close # TODO: Uncomment when #5958 is fixed
+    http_server.try &.close
   end
 
   describe "handshake fails if server does not verify Sec-WebSocket-Key" do
@@ -405,7 +405,7 @@ describe HTTP::WebSocket do
         HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
       end
     ensure
-      # http_server.try &.close # TODO: Uncomment when #5958 is fixed
+      http_server.try &.close
     end
 
     it "Sec-WebSocket-Accept incorrect" do
@@ -424,7 +424,7 @@ describe HTTP::WebSocket do
         HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
       end
     ensure
-      # http_server.try &.close # TODO: Uncomment when #5958 is fixed
+      http_server.try &.close
     end
   end
 


### PR DESCRIPTION
Since the error in #5958 seems to be resolved, the calls to HTTP::Server#close in websocket spec can be uncommented.
See https://github.com/crystal-lang/crystal/pull/6027#issuecomment-385476764 for details.