### PR TITLE
Add missing type declaration in property? docs

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -972,10 +972,10 @@ class Object
     # class Person
     #   {{var_prefix}}happy : Bool
     #
-    #   def {{method_prefix}}happy=({{var_prefix}}happy)
+    #   def {{method_prefix}}happy=({{var_prefix}}happy : Bool)
     #   end
     #
-    #   def {{method_prefix}}happy?
+    #   def {{method_prefix}}happy? : Bool
     #     {{var_prefix}}happy
     #   end
     # end


### PR DESCRIPTION
When declaring a new `property?` type  are added to both setter and getter