### PR TITLE
Revert "allow rand from zero value"

### DIFF
--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -36,8 +36,6 @@ describe "Random" do
     5.times do
       rand(Int64::MAX).should be >= 0
     end
-
-    rand(0).should eq 0
   end
 
   it "float number" do
@@ -52,17 +50,19 @@ describe "Random" do
     x.should be < 3.5
   end
 
-  it "float number 0.0" do
-    rand(0.0).should eq 0.0
-  end
-
   it "raises on invalid number" do
+    expect_raises ArgumentError, "Invalid bound for rand: 0" do
+      rand(0)
+    end
     expect_raises ArgumentError, "Invalid bound for rand: -1" do
       rand(-1)
     end
   end
 
   it "raises on invalid float number" do
+    expect_raises ArgumentError, "Invalid bound for rand: 0.0" do
+      rand(0.0)
+    end
     expect_raises ArgumentError, "Invalid bound for rand: -1.0" do
       rand(-1.0)
     end

--- a/src/random.cr
+++ b/src/random.cr
@@ -116,10 +116,6 @@ module Random
     {% utype = "UInt#{size}".id %}
     {% for type in ["Int#{size}".id, utype] %}
       private def rand_int(max : {{type}}) : {{type}}
-        if max == 0
-          return {{type}}.new(0)
-        end
-
         unless max > 0
           raise ArgumentError.new "Invalid bound for rand: #{max}"
         end
@@ -254,7 +250,7 @@ module Random
   # Random.new.rand(10.725) # => 7.70147
   # ```
   def rand(max : Float) : Float64
-    unless max >= 0
+    unless max > 0
       raise ArgumentError.new "Invalid bound for rand: #{max}"
     end
     max_prec = 1u64 << 53 # Float64, excluding mantissa, has 2^53 values


### PR DESCRIPTION
This reverts #3493.

That commit introduced a bad change: it silenced a valid error for an arbitrary case.
Saying "this is useful" while showing wrong code is not an argument; that code should have just used an inclusive range.

`rand(n)` is always equivalent to `rand(0...n)`.

`rand(0...0)` even now says "Invalid range for rand: 0...0".

`rand(0)` asks for a number ≥ 0 and < 0. This makes no sense and should obviously be an error for the same reason.