### PR TITLE
Fix `==` and `!=` when comparing signed vs unsigned integers

### DIFF
--- a/spec/std/float_printer/diy_fp_spec.cr
+++ b/spec/std/float_printer/diy_fp_spec.cr
@@ -173,6 +173,6 @@ describe DiyFP do
     fp = DiyFP.from_f_normalized(f)
 
     fp.exp.should eq 0x7FE - 0x3FF - 52 - 11
-    fp.frac.should eq 0x001fffffffffffff << 11
+    fp.frac.should eq 0x001fffffffffffff_u64 << 11
   end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -537,6 +537,18 @@ describe "Int" do
     end
   end
 
+  {% if compare_versions(Crystal::VERSION, "0.26.1") > 0 %}
+    it "compares equality and inequality of signed vs. unsigned integers" do
+      x = -1
+      y = x.unsafe_as(UInt32)
+
+      (x == y).should be_false
+      (y == x).should be_false
+      (x != y).should be_true
+      (y != x).should be_true
+    end
+  {% end %}
+
   it "clones" do
     [1_u8, 2_u16, 3_u32, 4_u64, 5_i8, 6_i16, 7_i32, 8_i64].each do |value|
       value.clone.should eq(value)

--- a/src/iconv.cr
+++ b/src/iconv.cr
@@ -4,6 +4,8 @@ require "c/iconv"
 struct Iconv
   @skip_invalid : Bool
 
+  ERROR = LibC::SizeT::MAX # (size_t)(-1)
+
   def initialize(from : String, to : String, invalid : Symbol? = nil)
     original_from, original_to = from, to
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -31,7 +31,7 @@ class IO
         outbuf_ptr = outbuf.to_unsafe
         outbytesleft = LibC::SizeT.new(outbuf.size)
         err = @iconv.convert(pointerof(inbuf_ptr), pointerof(inbytesleft), pointerof(outbuf_ptr), pointerof(outbytesleft))
-        if err == -1
+        if err == Iconv::ERROR
           @iconv.handle_invalid(pointerof(inbuf_ptr), pointerof(inbytesleft))
         end
         io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
@@ -95,7 +95,7 @@ class IO
         @out_slice = @out_buffer[0, OUT_BUFFER_SIZE - out_buffer_left]
 
         # Check for errors
-        if result == -1
+        if result == Iconv::ERROR
           case Errno.value
           when Errno::EILSEQ
             # For an illegal sequence we just skip one byte and we'll continue next

--- a/src/llvm/generic_value.cr
+++ b/src/llvm/generic_value.cr
@@ -2,31 +2,35 @@ class LLVM::GenericValue
   def initialize(@unwrap : LibLLVM::GenericValueRef, @context : LLVM::Context)
   end
 
-  def to_i
-    LibLLVM.generic_value_to_int(self, 1)
+  def to_i : Int32
+    to_i64.to_i32
   end
 
-  def to_u64
-    to_i
+  def to_i64 : Int64
+    LibLLVM.generic_value_to_int(self, signed: 1).unsafe_as(Int64)
   end
 
-  def to_b
+  def to_u64 : UInt64
+    LibLLVM.generic_value_to_int(self, signed: 0)
+  end
+
+  def to_b : Bool
     to_i != 0
   end
 
-  def to_f32
-    LibLLVM.generic_value_to_float(@context.float, self)
+  def to_f32 : Float32
+    LibLLVM.generic_value_to_float(@context.float, self).to_f32
   end
 
-  def to_f64
+  def to_f64 : Float64
     LibLLVM.generic_value_to_float(@context.double, self)
   end
 
-  def to_string
+  def to_string : String
     to_pointer.as(String)
   end
 
-  def to_pointer
+  def to_pointer : Void*
     LibLLVM.generic_value_to_pointer(self)
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -1175,7 +1175,7 @@ class String
         outbuf_ptr = outbuf.to_unsafe
         outbytesleft = LibC::SizeT.new(outbuf.size)
         err = iconv.convert(pointerof(inbuf_ptr), pointerof(inbytesleft), pointerof(outbuf_ptr), pointerof(outbytesleft))
-        if err == -1
+        if err == Iconv::ERROR
           iconv.handle_invalid(pointerof(inbuf_ptr), pointerof(inbytesleft))
         end
         io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])


### PR DESCRIPTION
Fixes #571

