### PR TITLE
Add Errno#errno_message getter

### DIFF
--- a/src/errno.cr
+++ b/src/errno.cr
@@ -204,6 +204,9 @@ class Errno < Exception
   # Returns the numeric value of errno.
   getter errno : Int32
 
+  # Returns the message of errno.
+  getter errno_message : String
+
   # Creates a new `Errno` with the given message. The message will
   # have concatenated the errno message denoted by *errno*.
   #
@@ -217,12 +220,8 @@ class Errno < Exception
   # ```
   def initialize(message, errno = Errno.value)
     @errno = errno
-    super "#{message}: #{Errno.message(errno)}"
-  end
-
-  # Returns the errno message denoted by *errno*.
-  def self.message(errno)
-    String.new(LibC.strerror(errno))
+    @errno_message = String.new(LibC.strerror(@errno))
+    super "#{message}: #{@errno_message}"
   end
 
   # Returns the value of libc's errno.

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -205,7 +205,7 @@ class Errno < Exception
   getter errno : Int32
 
   # Creates a new `Errno` with the given message. The message will
-  # have concatenated the message denoted by *errno*.
+  # have concatenated the description denoted by *errno*.
   #
   # Typical usage:
   #
@@ -217,11 +217,11 @@ class Errno < Exception
   # ```
   def initialize(message, errno = Errno.value)
     @errno = errno
-    super "#{message}: #{message(errno)}"
+    super "#{message}: #{description(errno)}"
   end
 
-  # Returns the message denoted by *errno*.
-  def message(errno = Errno.value)
+  # Returns the description denoted by *errno*.
+  def description(errno = Errno.value)
     String.new(LibC.strerror(errno))
   end
 

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -205,7 +205,7 @@ class Errno < Exception
   getter errno : Int32
 
   # Creates a new `Errno` with the given message. The message will
-  # have concatenated the error message denoted by *errno*.
+  # have concatenated the errno message denoted by *errno*.
   #
   # Typical usage:
   #
@@ -217,11 +217,11 @@ class Errno < Exception
   # ```
   def initialize(message, errno = Errno.value)
     @errno = errno
-    super "#{message}: #{Errno.error(errno)}"
+    super "#{message}: #{Errno.message(errno)}"
   end
 
-  # Returns the error message denoted by *errno*.
-  def self.error(errno = Errno.value)
+  # Returns the errno message denoted by *errno*.
+  def self.message(errno)
     String.new(LibC.strerror(errno))
   end
 

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -204,8 +204,8 @@ class Errno < Exception
   # Returns the numeric value of errno.
   getter errno : Int32
 
-  # Creates a new Errno with the given message. The message will
-  # have concatenated the message denoted by `Errno#value`.
+  # Creates a new `Errno` with the given message. The message will
+  # have concatenated the message denoted by *errno*.
   #
   # Typical usage:
   #
@@ -217,7 +217,12 @@ class Errno < Exception
   # ```
   def initialize(message, errno = Errno.value)
     @errno = errno
-    super "#{message}: #{String.new(LibC.strerror(errno))}"
+    super "#{message}: #{message(errno)}"
+  end
+
+  # Returns the message denoted by *errno*.
+  def self.message(errno = Errno.value)
+    String.new(LibC.strerror(errno))
   end
 
   # Returns the value of libc's errno.

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -221,7 +221,7 @@ class Errno < Exception
   end
 
   # Returns the message denoted by *errno*.
-  def self.message(errno = Errno.value)
+  def message(errno = Errno.value)
     String.new(LibC.strerror(errno))
   end
 

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -205,7 +205,7 @@ class Errno < Exception
   getter errno : Int32
 
   # Creates a new `Errno` with the given message. The message will
-  # have concatenated the description denoted by *errno*.
+  # have concatenated the error message denoted by *errno*.
   #
   # Typical usage:
   #
@@ -217,11 +217,11 @@ class Errno < Exception
   # ```
   def initialize(message, errno = Errno.value)
     @errno = errno
-    super "#{message}: #{description(errno)}"
+    super "#{message}: #{Errno.error(errno)}"
   end
 
-  # Returns the description denoted by *errno*.
-  def description(errno = Errno.value)
+  # Returns the error message denoted by *errno*.
+  def self.error(errno = Errno.value)
     String.new(LibC.strerror(errno))
   end
 
@@ -237,7 +237,7 @@ class Errno < Exception
       LibC.__error.value
     {% elsif flag?(:win32) %}
       ret = LibC._get_errno(out errno)
-      raise Errno.new("get_errno", ret) unless ret == 0
+      raise Errno.new("_get_errno", ret) unless ret == 0
       errno
     {% end %}
   end
@@ -254,7 +254,7 @@ class Errno < Exception
       LibC.__error.value = value
     {% elsif flag?(:win32) %}
       ret = LibC._set_errno(value)
-      raise Errno.new("set_errno", ret) unless ret == 0
+      raise Errno.new("_set_errno", ret) unless ret == 0
       value
     {% end %}
   end


### PR DESCRIPTION
This adds `Errno#errno_message` getter which returns the last raised errno message.

Usecase:
I want to print the error message from errno in my application just like this: `No such file or directory` instead of this: `Unhandled exception: some_call: No such file or directory (Errno)`.