### PR TITLE
Fix Socket#reuse_port? if SO_REUSEPORT is not supported

### DIFF
--- a/src/socket.cr
+++ b/src/socket.cr
@@ -391,7 +391,7 @@ class Socket < IO
   end
 
   def reuse_port?
-    0 != getsockopt(LibC::SO_REUSEPORT, 0) do |errno|
+    ret = getsockopt(LibC::SO_REUSEPORT, 0) do |errno|
       # If SO_REUSEPORT is not supported, the return value should be `false`
       if errno.errno == Errno::ENOPROTOOPT
         return false
@@ -399,6 +399,7 @@ class Socket < IO
         raise errno
       end
     end
+    ret != 0
   end
 
   def reuse_port=(val : Bool)


### PR DESCRIPTION
Currently, if `SO_REUSEPORT` is not supported, `LibC.getsockopt` returns `-1`. When calling `Socket#reuse_port?` this causes an exception.

This PR fixes that to return `false` if errno is `ENOPROTOOPT` (meaning that `SO_REUSEPORT` is not supported).