### PR TITLE
Change `Socket::Server#accept` to return `IO` and add default implementation

### DIFF
--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -3,12 +3,14 @@ class Socket
     # Accepts an incoming connection and returns the client socket.
     #
     # If the server is closed after invoking this method, an `IO::Error` (closed stream) exception must be raised.
-    abstract def accept : Socket
+    def accept : IO
+      accept? || raise IO::Error.new("Closed stream")
+    end
 
     # Accepts an incoming connection and returns the client socket.
     #
     # Returns `nil` if the server is closed after invoking this method.
-    abstract def accept? : Socket?
+    abstract def accept? : IO?
 
     # Accepts an incoming connection and yields the client socket to the block.
     # Eventually closes the connection when the block returns.


### PR DESCRIPTION
This PR changes the return type of  `Socket::Server#accept` and `#accept?` to `IO` and `IO?`.
It decouples the interface from a specific `Socket` design. Right now, every `Socket` inherits from `IO`, but for a UDP socket implementation, this doesn't make sense because it is not a stream (see #5778).
The purpose of the `Socket::Server#accept` methods is to accept an incoming connection to use it as a stream IO. That's what the `IO` class is meant for.

It also adds a default implementation for `#accept` which returns the value of `#accept?` or raises if it is `nil`.
It is the same implementation as already used in `Socket#accept`.
This makes it easier for classes inheriting the module to implement the interface, they might just need to override `#accept?`.