### PR TITLE
Improve socket specs

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -26,4 +26,20 @@ describe Socket do
     client.type.should eq(Socket::Type::STREAM)
     client.protocol.should eq(Socket::Protocol::TCP)
   end
+
+  describe "#bind" do
+    each_ip_family do |family, _, any_address|
+      it "binds to port" do
+        socket = TCPSocket.new family
+        socket.bind(any_address, 0)
+        socket.listen
+
+        address = socket.local_address.as(Socket::IPAddress)
+        address.address.should eq(any_address)
+        address.port.should be > 0
+      ensure
+        socket.try &.close
+      end
+    end
+  end
 end

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -6,3 +6,13 @@ def unused_local_port
     server.local_address.port
   end
 end
+
+def each_ip_family(&block : Socket::Family, String, String ->)
+  describe "using IPv4" do
+    block.call Socket::Family::INET, "127.0.0.1", "0.0.0.0"
+  end
+
+  describe "using IPv6" do
+    block.call Socket::Family::INET6, "::1", "::"
+  end
+end

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -16,3 +16,7 @@ def each_ip_family(&block : Socket::Family, String, String ->)
     block.call Socket::Family::INET6, "::1", "::"
   end
 end
+
+def linux?
+  {{ flag?(:linux) }}
+end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -12,9 +12,8 @@ describe TCPServer do
         server.reuse_port?.should be_false
         server.reuse_address?.should be_true
 
-        server.local_address.should eq Socket::IPAddress.new(address, port)
-        server.local_address.port.should eq(port)
-        server.local_address.address.should eq(address)
+        local_address = Socket::IPAddress.new(address, port)
+        server.local_address.should eq local_address
 
         server.closed?.should be_false
 
@@ -87,6 +86,13 @@ describe TCPServer do
         expect_raises(Socket::Error, "No address") do
           TCPServer.new("doesnotexist.example.org.", 0)
         end
+      end
+    end
+
+    it "binds to all interfaces" do
+      port = unused_local_port
+      TCPServer.open(port) do |server|
+        server.local_address.port.should eq port
       end
     end
   end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -2,36 +2,99 @@ require "./spec_helper"
 require "socket"
 
 describe TCPServer do
-  it "creates a raw socket" do
-    sock = TCPServer.new
-    sock.family.should eq(Socket::Family::INET)
+  describe ".new" do
+    each_ip_family do |family, address|
+      it "listens on local address" do
+        port = unused_local_port
 
-    sock = TCPServer.new(Socket::Family::INET6)
-    sock.family.should eq(Socket::Family::INET6)
-  end
+        server = TCPServer.new(address, port)
 
-  it "fails when port is in use" do
-    port = unused_local_port
+        server.reuse_port?.should be_false
+        server.reuse_address?.should be_true
 
-    expect_raises Errno, /(already|Address) in use/ do
-      sock = Socket.tcp(Socket::Family::INET6)
-      sock.bind(Socket::IPAddress.new("::1", port))
+        server.local_address.should eq Socket::IPAddress.new(address, port)
+        server.local_address.port.should eq(port)
+        server.local_address.address.should eq(address)
 
-      TCPServer.open("::1", port) { }
+        server.closed?.should be_false
+
+        server.close
+
+        server.closed?.should be_true
+        expect_raises(Errno, "getsockname: Bad file descriptor") do
+          server.local_address
+        end
+      end
+
+      it "binds to port 0" do
+        server = TCPServer.new(address, 0)
+
+        server.local_address.address.should eq(address)
+        server.local_address.port.should be > 0
+      end
+
+      it "raises when port is negative" do
+        expect_raises(Socket::Error, linux? ? "getaddrinfo: Servname not supported for ai_socktype" : "No address found for #{address}:-12 over TCP") do
+          TCPServer.new(address, -12)
+        end
+      end
+
+      describe "reuse_port" do
+        it "raises when port is in use" do
+          TCPServer.open(address, 0) do |server|
+            expect_raises Errno, /(already|Address) in use/ do
+              TCPServer.open(address, server.local_address.port) { }
+            end
+          end
+        end
+
+        it "raises when not binding with reuse_port" do
+          TCPServer.open(address, 0, reuse_port: true) do |server|
+            expect_raises Errno, /(already|Address) in use/ do
+              TCPServer.open(address, server.local_address.port) { }
+            end
+          end
+        end
+
+        it "raises when port is not ready to be reused" do
+          TCPServer.open(address, 0) do |server|
+            expect_raises Errno, /(already|Address) in use/ do
+              TCPServer.open(address, server.local_address.port, reuse_port: true) { }
+            end
+          end
+        end
+
+        it "binds to used port with reuse_port = true" do
+          TCPServer.open(address, 0, reuse_port: true) do |server|
+            TCPServer.open(address, server.local_address.port, reuse_port: true) { }
+          end
+        end
+      end
     end
-  end
 
-  it "doesn't reuse the TCP port by default (SO_REUSEPORT)" do
-    TCPServer.open("::", 0) do |server|
-      expect_raises(Errno) do
-        TCPServer.open("::", server.local_address.port) { }
+    describe "address resolution" do
+      it "binds to localhost" do
+        TCPServer.new("localhost", unused_local_port)
+      end
+
+      it "raises when host doesn't exist" do
+        expect_raises(Socket::Error, "No address") do
+          TCPServer.new("doesnotexist.example.org.", 12345)
+        end
+      end
+
+      it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
+        expect_raises(Socket::Error, "No address") do
+          TCPServer.new("doesnotexist.example.org.", 0)
+        end
       end
     end
   end
 
-  it "reuses the TCP port (SO_REUSEPORT)" do
-    TCPServer.open("::", 0, reuse_port: true) do |server|
-      TCPServer.open("::", server.local_address.port, reuse_port: true) { }
+  it "settings" do
+    TCPServer.open("::", unused_local_port) do |server|
+      (server.recv_buffer_size = 42).should eq 42
+      server.recv_buffer_size.should eq 42
     end
   end
 end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -91,10 +91,14 @@ describe TCPServer do
     end
   end
 
-  it "settings" do
-    TCPServer.open("::", unused_local_port) do |server|
-      (server.recv_buffer_size = 42).should eq 42
-      server.recv_buffer_size.should eq 42
+  {% if flag?(:linux) %}
+    pending "settings"
+  {% else %}
+    it "settings" do
+      TCPServer.open("::", unused_local_port) do |server|
+        (server.recv_buffer_size = 42).should eq 42
+        server.recv_buffer_size.should eq 42
+      end
     end
-  end
+  {% end %}
 end

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -3,6 +3,17 @@ require "socket"
 
 describe UDPSocket do
   each_ip_family do |family, address|
+    it "#bind" do
+      port = unused_local_port
+      socket = UDPSocket.new(family)
+      socket.bind(address, port)
+      socket.local_address.should eq(Socket::IPAddress.new(address, port))
+      socket.close
+      socket = UDPSocket.new(family)
+      socket.bind(address, 0)
+      socket.local_address.address.should eq address
+    end
+
     it "sends and receives messages" do
       port = unused_local_port
 

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -2,93 +2,52 @@ require "./spec_helper"
 require "socket"
 
 describe UDPSocket do
-  it "creates a raw socket" do
-    sock = UDPSocket.new
-    sock.family.should eq(Socket::Family::INET)
+  each_ip_family do |family, address|
+    it "sends and receives messages" do
+      port = unused_local_port
 
-    sock = UDPSocket.new(Socket::Family::INET6)
-    sock.family.should eq(Socket::Family::INET6)
+      server = UDPSocket.new(family)
+      server.bind(address, port)
+      server.local_address.should eq(Socket::IPAddress.new(address, port))
+
+      client = UDPSocket.new(family)
+      client.bind(address, 0)
+
+      client.send "message", to: server.local_address
+      server.receive.should eq({"message", client.local_address})
+
+      client.connect(address, port)
+      client.local_address.family.should eq(family)
+      client.local_address.address.should eq(address)
+      client.remote_address.should eq(Socket::IPAddress.new(address, port))
+
+      client.send "message"
+      server.receive.should eq({"message", client.local_address})
+
+      client.send("laus deo semper")
+
+      buffer = uninitialized UInt8[256]
+
+      bytes_read, client_addr = server.receive(buffer.to_slice)
+      message = String.new(buffer.to_slice[0, bytes_read])
+      message.should eq("laus deo semper")
+
+      client.send("laus deo semper")
+
+      bytes_read, client_addr = server.receive(buffer.to_slice[0, 4])
+      message = String.new(buffer.to_slice[0, bytes_read])
+      message.should eq("laus")
+
+      client.close
+      server.close
+    end
   end
 
-  it "reads and writes data to server" do
-    port = unused_local_port
-
-    server = UDPSocket.new(Socket::Family::INET6)
-    server.bind("::", port)
-    server.local_address.should eq(Socket::IPAddress.new("::", port))
-
-    client = UDPSocket.new(Socket::Family::INET6)
-    client.connect("::1", port)
-    client.local_address.family.should eq(Socket::Family::INET6)
-    client.local_address.address.should eq("::1")
-    client.remote_address.should eq(Socket::IPAddress.new("::1", port))
-
-    client << "message"
-    server.gets(7).should eq("message")
-
-    client.close
-    server.close
-  end
-
-  it "sends and receives messages over IPv4" do
-    buffer = uninitialized UInt8[256]
-
-    server = UDPSocket.new(Socket::Family::INET)
-    server.bind("127.0.0.1", 0)
-
-    client = UDPSocket.new(Socket::Family::INET)
-    client.send("message equal to buffer", server.local_address)
-
-    bytes_read, client_addr = server.receive(buffer.to_slice[0, 23])
-    message = String.new(buffer.to_slice[0, bytes_read])
-    message.should eq("message equal to buffer")
-    client_addr.should eq(Socket::IPAddress.new("127.0.0.1", client.local_address.port))
-
-    client.send("message less than buffer", server.local_address)
-
-    bytes_read, client_addr = server.receive(buffer.to_slice)
-    message = String.new(buffer.to_slice[0, bytes_read])
-    message.should eq("message less than buffer")
-
-    client.connect server.local_address
-    client.send "ip4 message"
-
-    message, client_addr = server.receive
-    message.should eq("ip4 message")
-    client_addr.should eq(Socket::IPAddress.new("127.0.0.1", client.local_address.port))
-
-    server.close
-    client.close
-  end
-
-  it "sends and receives messages over IPv6" do
-    buffer = uninitialized UInt8[1500]
-
-    server = UDPSocket.new(Socket::Family::INET6)
-    server.bind("::1", 0)
-
-    client = UDPSocket.new(Socket::Family::INET6)
-    client.send("some message", server.local_address)
-
-    bytes_read, client_addr = server.receive(buffer.to_slice)
-    String.new(buffer.to_slice[0, bytes_read]).should eq("some message")
-    client_addr.should eq(Socket::IPAddress.new("::1", client.local_address.port))
-
-    client.connect server.local_address
-    client.send "ip6 message"
-
-    message, client_addr = server.receive(20)
-    message.should eq("ip6 message")
-    client_addr.should eq(Socket::IPAddress.new("::1", client.local_address.port))
-
-    server.close
-    client.close
-  end
-
-  it "broadcasts messages" do
+  it "sends broadcast message" do
     port = unused_local_port
 
     client = UDPSocket.new(Socket::Family::INET)
+    client.bind("localhost", 0)
     client.broadcast = true
     client.broadcast?.should be_true
     client.connect("255.255.255.255", port)

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -43,15 +43,19 @@ describe UDPSocket do
     end
   end
 
-  it "sends broadcast message" do
-    port = unused_local_port
+  {% if flag?(:linux) %}
+    it "sends broadcast message" do
+      port = unused_local_port
 
-    client = UDPSocket.new(Socket::Family::INET)
-    client.bind("localhost", 0)
-    client.broadcast = true
-    client.broadcast?.should be_true
-    client.connect("255.255.255.255", port)
-    client.send("broadcast").should eq(9)
-    client.close
-  end
+      client = UDPSocket.new(Socket::Family::INET)
+      client.bind("localhost", 0)
+      client.broadcast = true
+      client.broadcast?.should be_true
+      client.connect("255.255.255.255", port)
+      client.send("broadcast").should eq(9)
+      client.close
+    end
+  {% else %}
+    pending "sends broadcast message"
+  {% end %}
 end


### PR DESCRIPTION
Adds new and improves existing specs for `Socket`, `TCPSocket`, `TCPServer`, `UNIXServer` and `UDPSocket`.

The diff is best viewed with `-w`/`&w=1` to ignore whitespace.

<del>This is still work in progress, I'm publishing it as PR to validate if the specs perform correctly on all platforms.</del>