### PR TITLE
Move Socket.ip? to Socket::IPAddress.ip?

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -162,65 +162,65 @@ describe Socket::UNIXAddress do
   end
 end
 
-describe Socket do
+describe Socket::Address do
   # Tests from libc-test:
   # http://repo.or.cz/libc-test.git/blob/master:/src/functional/inet_pton.c
   it ".ip?" do
     # dotted-decimal notation
-    Socket.ip?("0.0.0.0").should be_true
-    Socket.ip?("127.0.0.1").should be_true
-    Socket.ip?("10.0.128.31").should be_true
-    Socket.ip?("255.255.255.255").should be_true
+    Socket::IPAddress.ip?("0.0.0.0").should be_true
+    Socket::IPAddress.ip?("127.0.0.1").should be_true
+    Socket::IPAddress.ip?("10.0.128.31").should be_true
+    Socket::IPAddress.ip?("255.255.255.255").should be_true
 
     # numbers-and-dots notation, but not dotted-decimal
-    # Socket.ip?("1.2.03.4").should be_false # fails on darwin
-    Socket.ip?("1.2.0x33.4").should be_false
-    Socket.ip?("1.2.0XAB.4").should be_false
-    Socket.ip?("1.2.0xabcd").should be_false
-    Socket.ip?("1.0xabcdef").should be_false
-    Socket.ip?("00377.0x0ff.65534").should be_false
+    # Socket::IPAddress.ip?("1.2.03.4").should be_false # fails on darwin
+    Socket::IPAddress.ip?("1.2.0x33.4").should be_false
+    Socket::IPAddress.ip?("1.2.0XAB.4").should be_false
+    Socket::IPAddress.ip?("1.2.0xabcd").should be_false
+    Socket::IPAddress.ip?("1.0xabcdef").should be_false
+    Socket::IPAddress.ip?("00377.0x0ff.65534").should be_false
 
     # invalid
-    Socket.ip?(".1.2.3").should be_false
-    Socket.ip?("1..2.3").should be_false
-    Socket.ip?("1.2.3.").should be_false
-    Socket.ip?("1.2.3.4.5").should be_false
-    Socket.ip?("1.2.3.a").should be_false
-    Socket.ip?("1.256.2.3").should be_false
-    Socket.ip?("1.2.4294967296.3").should be_false
-    Socket.ip?("1.2.-4294967295.3").should be_false
-    Socket.ip?("1.2. 3.4").should be_false
+    Socket::IPAddress.ip?(".1.2.3").should be_false
+    Socket::IPAddress.ip?("1..2.3").should be_false
+    Socket::IPAddress.ip?("1.2.3.").should be_false
+    Socket::IPAddress.ip?("1.2.3.4.5").should be_false
+    Socket::IPAddress.ip?("1.2.3.a").should be_false
+    Socket::IPAddress.ip?("1.256.2.3").should be_false
+    Socket::IPAddress.ip?("1.2.4294967296.3").should be_false
+    Socket::IPAddress.ip?("1.2.-4294967295.3").should be_false
+    Socket::IPAddress.ip?("1.2. 3.4").should be_false
 
     # ipv6
-    Socket.ip?(":").should be_false
-    Socket.ip?("::").should be_true
-    Socket.ip?("::1").should be_true
-    Socket.ip?(":::").should be_false
-    Socket.ip?(":192.168.1.1").should be_false
-    Socket.ip?("::192.168.1.1").should be_true
-    Socket.ip?("0:0:0:0:0:0:192.168.1.1").should be_true
-    Socket.ip?("0:0::0:0:0:192.168.1.1").should be_true
-    # Socket.ip?("::012.34.56.78").should be_false # fails on darwin
-    Socket.ip?(":ffff:192.168.1.1").should be_false
-    Socket.ip?("::ffff:192.168.1.1").should be_true
-    Socket.ip?(".192.168.1.1").should be_false
-    Socket.ip?(":.192.168.1.1").should be_false
-    Socket.ip?("a:0b:00c:000d:E:F::").should be_true
-    # Socket.ip?("a:0b:00c:000d:0000e:f::").should be_false # fails on GNU libc
-    Socket.ip?("1:2:3:4:5:6::").should be_true
-    Socket.ip?("1:2:3:4:5:6:7::").should be_true
-    Socket.ip?("1:2:3:4:5:6:7:8::").should be_false
-    Socket.ip?("1:2:3:4:5:6:7::9").should be_false
-    Socket.ip?("::1:2:3:4:5:6").should be_true
-    Socket.ip?("::1:2:3:4:5:6:7").should be_true
-    Socket.ip?("::1:2:3:4:5:6:7:8").should be_false
-    Socket.ip?("a:b::c:d:e:f").should be_true
-    Socket.ip?("ffff:c0a8:5e4").should be_false
-    Socket.ip?(":ffff:c0a8:5e4").should be_false
-    Socket.ip?("0:0:0:0:0:ffff:c0a8:5e4").should be_true
-    Socket.ip?("0:0:0:0:ffff:c0a8:5e4").should be_false
-    Socket.ip?("0::ffff:c0a8:5e4").should be_true
-    Socket.ip?("::0::ffff:c0a8:5e4").should be_false
-    Socket.ip?("c0a8").should be_false
+    Socket::IPAddress.ip?(":").should be_false
+    Socket::IPAddress.ip?("::").should be_true
+    Socket::IPAddress.ip?("::1").should be_true
+    Socket::IPAddress.ip?(":::").should be_false
+    Socket::IPAddress.ip?(":192.168.1.1").should be_false
+    Socket::IPAddress.ip?("::192.168.1.1").should be_true
+    Socket::IPAddress.ip?("0:0:0:0:0:0:192.168.1.1").should be_true
+    Socket::IPAddress.ip?("0:0::0:0:0:192.168.1.1").should be_true
+    # Socket::IPAddress.ip?("::012.34.56.78").should be_false # fails on darwin
+    Socket::IPAddress.ip?(":ffff:192.168.1.1").should be_false
+    Socket::IPAddress.ip?("::ffff:192.168.1.1").should be_true
+    Socket::IPAddress.ip?(".192.168.1.1").should be_false
+    Socket::IPAddress.ip?(":.192.168.1.1").should be_false
+    Socket::IPAddress.ip?("a:0b:00c:000d:E:F::").should be_true
+    # Socket::IPAddress.ip?("a:0b:00c:000d:0000e:f::").should be_false # fails on GNU libc
+    Socket::IPAddress.ip?("1:2:3:4:5:6::").should be_true
+    Socket::IPAddress.ip?("1:2:3:4:5:6:7::").should be_true
+    Socket::IPAddress.ip?("1:2:3:4:5:6:7:8::").should be_false
+    Socket::IPAddress.ip?("1:2:3:4:5:6:7::9").should be_false
+    Socket::IPAddress.ip?("::1:2:3:4:5:6").should be_true
+    Socket::IPAddress.ip?("::1:2:3:4:5:6:7").should be_true
+    Socket::IPAddress.ip?("::1:2:3:4:5:6:7:8").should be_false
+    Socket::IPAddress.ip?("a:b::c:d:e:f").should be_true
+    Socket::IPAddress.ip?("ffff:c0a8:5e4").should be_false
+    Socket::IPAddress.ip?(":ffff:c0a8:5e4").should be_false
+    Socket::IPAddress.ip?("0:0:0:0:0:ffff:c0a8:5e4").should be_true
+    Socket::IPAddress.ip?("0:0:0:0:ffff:c0a8:5e4").should be_false
+    Socket::IPAddress.ip?("0::ffff:c0a8:5e4").should be_true
+    Socket::IPAddress.ip?("::0::ffff:c0a8:5e4").should be_false
+    Socket::IPAddress.ip?("c0a8").should be_false
   end
 end

--- a/src/openssl/ssl/hostname_validation.cr
+++ b/src/openssl/ssl/hostname_validation.cr
@@ -129,7 +129,7 @@ module OpenSSL::SSL::HostnameValidation
     end
 
     # fail match when hostname is an IP address
-    if ::Socket.ip?(hostname)
+    if ::Socket::IPAddress.ip?(hostname)
       return false
     end
 

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -15,7 +15,7 @@ abstract class OpenSSL::SSL::Socket < IO
         {% if LibSSL::OPENSSL_102 %}
           param = LibSSL.ssl_get0_param(@ssl)
 
-          if ::Socket.ip?(hostname)
+          if ::Socket::IPAddress.ip?(hostname)
             unless LibCrypto.x509_verify_param_set1_ip_asc(param, hostname) == 1
               raise OpenSSL::Error.new("X509_VERIFY_PARAM_set1_ip_asc")
             end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -482,13 +482,6 @@ class Socket < IO
     optval
   end
 
-  # Returns `true` if the string represents a valid IPv4 or IPv6 address.
-  def self.ip?(string : String)
-    addr = LibC::In6Addr.new
-    ptr = pointerof(addr).as(Void*)
-    LibC.inet_pton(LibC::AF_INET, string, ptr) > 0 || LibC.inet_pton(LibC::AF_INET6, string, ptr) > 0
-  end
-
   def blocking
     fcntl(LibC::F_GETFL) & LibC::O_NONBLOCK == 0
   end

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -6,7 +6,7 @@ class Socket
     getter family : Family
     getter size : Int32
 
-    # Returns either an `IPAddress` or `UNIXAddres` from the internal OS
+    # Returns either an `IPAddress` or `UNIXAddress` from the internal OS
     # representation. Only INET, INET6 and UNIX families are supported.
     def self.from(sockaddr : LibC::Sockaddr*, addrlen) : Address
       case family = Family.new(sockaddr.value.sa_family)
@@ -239,6 +239,13 @@ class Socket
       sockaddr.value.sin_port = LibC.htons(port)
       sockaddr.value.sin_addr = @addr4.not_nil!
       sockaddr.as(LibC::Sockaddr*)
+    end
+
+    # Returns `true` if *address* represents a valid IPv4 or IPv6 address.
+    def self.ip?(address : String)
+      addr = LibC::In6Addr.new
+      ptr = pointerof(addr).as(Void*)
+      LibC.inet_pton(LibC::AF_INET, address, ptr) > 0 || LibC.inet_pton(LibC::AF_INET6, address, ptr) > 0
     end
   end
 


### PR DESCRIPTION
The method is specific to `IPAddress`, so it shouldn't be defined in the parent namespace.

It could also be `Socket::Address.ip?`, but it fits more closely in `IPAddress`.