### PR TITLE
Extract Socket constants in separate file.

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "socket"
+require "socket/address"
 
 describe Socket::Address do
   describe ".parse" do

--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "socket"
+require "socket/addrinfo"
 
 describe Socket::Addrinfo do
   describe ".resolve" do

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -1,41 +1,9 @@
-require "c/arpa/inet"
-require "c/netdb"
-require "c/netinet/in"
-require "c/netinet/tcp"
 require "c/sys/socket"
-require "c/sys/un"
+require "./socket/addrinfo"
 
 class Socket < IO
   include IO::Buffered
   include IO::Syscall
-
-  class Error < Exception
-  end
-
-  enum Type
-    STREAM    = LibC::SOCK_STREAM
-    DGRAM     = LibC::SOCK_DGRAM
-    RAW       = LibC::SOCK_RAW
-    SEQPACKET = LibC::SOCK_SEQPACKET
-  end
-
-  enum Protocol
-    IP   = LibC::IPPROTO_IP
-    TCP  = LibC::IPPROTO_TCP
-    UDP  = LibC::IPPROTO_UDP
-    RAW  = LibC::IPPROTO_RAW
-    ICMP = LibC::IPPROTO_ICMP
-  end
-
-  enum Family : LibC::SaFamilyT
-    UNSPEC = LibC::AF_UNSPEC
-    UNIX   = LibC::AF_UNIX
-    INET   = LibC::AF_INET
-    INET6  = LibC::AF_INET6
-  end
-
-  # :nodoc:
-  SOMAXCONN = 128
 
   getter fd : Int32
 
@@ -596,4 +564,10 @@ class Socket < IO
   end
 end
 
-require "./socket/*"
+require "./socket/ip_socket"
+require "./socket/server"
+require "./socket/tcp_socket"
+require "./socket/tcp_server"
+require "./socket/unix_socket"
+require "./socket/unix_server"
+require "./socket/udp_socket"

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -1,5 +1,10 @@
-require "socket"
 require "uri"
+require "c/arpa/inet"
+require "c/netdb"
+require "c/netinet/in"
+require "c/netinet/tcp"
+require "c/sys/un"
+require "./common"
 
 class Socket
   abstract struct Address

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -1,4 +1,5 @@
 require "uri/punycode"
+require "./address"
 
 class Socket
   # Domain name resolver.

--- a/src/socket/common.cr
+++ b/src/socket/common.cr
@@ -1,0 +1,28 @@
+class Socket < IO
+  class Error < Exception
+  end
+
+  enum Type
+    STREAM    = LibC::SOCK_STREAM
+    DGRAM     = LibC::SOCK_DGRAM
+    RAW       = LibC::SOCK_RAW
+    SEQPACKET = LibC::SOCK_SEQPACKET
+  end
+
+  enum Protocol
+    IP   = LibC::IPPROTO_IP
+    TCP  = LibC::IPPROTO_TCP
+    UDP  = LibC::IPPROTO_UDP
+    RAW  = LibC::IPPROTO_RAW
+    ICMP = LibC::IPPROTO_ICMP
+  end
+
+  enum Family : LibC::SaFamilyT
+    UNSPEC = LibC::AF_UNSPEC
+    UNIX   = LibC::AF_UNIX
+    INET   = LibC::AF_INET
+    INET6  = LibC::AF_INET6
+  end
+
+  SOMAXCONN = 128
+end


### PR DESCRIPTION
`Socket::Address` and `Socket::Addrinfo` conceptually don't dependent on
`Socket`. The shared constants and lib includes are extracted to `common.cr` to separate concerns more clearly.