### PR TITLE
Treat untyped element in tuple and named tuple

### DIFF
--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -302,4 +302,23 @@ describe "Semantic: named tuples" do
       meta
     end
   end
+
+  it "doesn't crash on named tuple in not executed block (#6718)" do
+    assert_type(%(
+      require "prelude"
+
+      def pending(&block)
+      end
+
+      def untyped(x = nil)
+      end
+
+      # To reproduce this bug, it is needed to the expression that is
+      # not typed on main phase but is typed on cleanup phase.
+      # `untyped(untyped)` is just one.
+      pending do
+        {s: untyped(untyped)}
+      end
+    )) { nil_type }
+  end
 end

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -300,4 +300,23 @@ describe "Semantic: tuples" do
       )
     }
   end
+
+  it "doesn't crash on tuple in not executed block (#6718)" do
+    assert_type(%(
+      require "prelude"
+
+      def pending(&block)
+      end
+
+      def untyped(x = nil)
+      end
+
+      # To reproduce this bug, it is needed to the expression that is
+      # not typed on main phase but is typed on cleanup phase.
+      # `untyped(untyped)` is just one.
+      pending do
+        {untyped(untyped)}
+      end
+    )) { nil_type }
+  end
 end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -741,6 +741,12 @@ module Crystal
         return exps
       end
 
+      # `node.program` is assigned by `MainVisitor` usually, however
+      # it may not be assigned in some edge-case (e.g. this `node` is placed
+      # at not invoked block.). This assignment is for it.
+      node.program = @program
+      node.update
+
       node
     end
 
@@ -757,6 +763,9 @@ module Crystal
         exps.bind_to(exps.expressions.last)
         return exps
       end
+
+      node.program = @program
+      node.update
 
       node
     end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -729,7 +729,10 @@ module Crystal
 
     def transform(node : TupleLiteral)
       super
-      node.update
+
+      unless node.elements.all? &.type?
+        return untyped_expression node
+      end
 
       no_return_index = node.elements.index &.no_returns?
       if no_return_index
@@ -743,7 +746,10 @@ module Crystal
 
     def transform(node : NamedTupleLiteral)
       super
-      node.update
+
+      unless node.entries.all? &.value.type?
+        return untyped_expression node
+      end
 
       no_return_index = node.entries.index &.value.no_returns?
       if no_return_index


### PR DESCRIPTION
Fixed #6718

The reason of #6718 is calling `node.update` with untyped `TupleLiteral` or `NamedTupleLiteral`. An untyped node has no `node.program`, so it fails nil assertion.

I think this `node.update` is not needed because `CleanupTransformer` does not change the type of `node` except for untyped and unreachable node.  However such nodes should be transformed to other node. In other words `node.update` does nothing in general.

Thus, this replaces `node.update` with treating untyped element.