### PR TITLE
Allow `it` and `pending` to be used without blocks

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -117,6 +117,9 @@ describe "Spec matchers" do
 end
 
 describe "Spec" do
+  it "should treat it calls without blocks as pending"
+  pending "should allow pending calls without blocks"
+
   describe "use_colors?" do
     it "returns if output is colored or not" do
       saved = Spec.use_colors?

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -117,9 +117,6 @@ describe "Spec matchers" do
 end
 
 describe "Spec" do
-  it "should treat it calls without blocks as pending"
-  pending "should allow pending calls without blocks"
-
   describe "use_colors?" do
     it "returns if output is colored or not" do
       saved = Spec.use_colors?

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -56,14 +56,6 @@ module Spec::Methods
     end
   end
 
-  # Defines a yet-to-be-implemented pending test case
-  #
-  # For complete clarity, you should stick with `#pending`
-  # to make your intentions completely clear.
-  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__)
-    pending description, file, line, end_line
-  end
-
   # Defines a pending test case.
   #
   # *&block* is never evaluated.

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -56,6 +56,14 @@ module Spec::Methods
     end
   end
 
+  # Defines a yet-to-be-implemented pending test case
+  #
+  # For complete clarity, you should stick with `#pending`
+  # to make your intentions completely clear.
+  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__)
+    pending description, file, line, end_line
+  end
+
   # Defines a pending test case.
   #
   # *&block* is never evaluated.
@@ -73,6 +81,11 @@ module Spec::Methods
     Spec.formatters.each(&.before_example(description))
 
     Spec::RootContext.report(:pending, description, file, line)
+  end
+
+  # Define a yet-to-be-implemented pending test case
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__)
+    pending(description, file, line, end_line) { }
   end
 
   # DEPRECATED: Use `#it`


### PR DESCRIPTION
Both `it` and `pending` can be used in RSpec without a block. Calling `it` without a block is a way of specifying that it is pending. I was caught off guard when writing a spec and it failed in both instances because I lacked a block.