### PR TITLE
 Give proper error when trying to instantiate Module

### DIFF
--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -907,6 +907,26 @@ describe "Semantic: module" do
       "undefined method 'new' for Moo:Module"
   end
 
+  it "gives error when trying to instantiate with new" do
+    assert_error %(
+      module Moo
+        def initialize
+        end
+      end
+      Moo.new),
+      "Cannot instantiate Moo:Module"
+  end
+
+  it "gives error when trying to instantiate with allocate" do
+    assert_error %(
+      module Moo
+        def initialize
+        end
+      end
+      Moo.allocate),
+      "Cannot instantiate Moo:Module"
+  end
+
   it "uses type declaration inside module" do
     assert_type(%(
       module Moo

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "undefined local variable or method 'allocate'#{colorize(" (modules cannot be instantiated)").yellow.bold}"
+      "undefined local variable or method 'allocate'#{" (modules cannot be instantiated)".colorize.yellow.bold}"
   end
 
   it "gives error when trying to instantiate with allocate" do
@@ -924,7 +924,7 @@ describe "Semantic: module" do
         end
       end
       Moo.allocate),
-      "undefined method 'allocate' for Moo:Module#{colorize(" (modules cannot be instantiated)").yellow.bold}"
+      "undefined method 'allocate' for Moo:Module#{" (modules cannot be instantiated)".colorize.yellow.bold}"
   end
 
   it "uses type declaration inside module" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "cannot instantiate Moo:Module"
+      "undefined local variable or method 'allocate' (modules cannot be instantiated)"
   end
 
   it "gives error when trying to instantiate with allocate" do
@@ -924,7 +924,7 @@ describe "Semantic: module" do
         end
       end
       Moo.allocate),
-      "cannot instantiate Moo:Module"
+      "undefined method 'allocate' for Moo:Module (modules cannot be instantiated)"
   end
 
   it "uses type declaration inside module" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "Cannot instantiate Moo:Module"
+      "cannot instantiate Moo:Module"
   end
 
   it "gives error when trying to instantiate with allocate" do
@@ -924,7 +924,7 @@ describe "Semantic: module" do
         end
       end
       Moo.allocate),
-      "Cannot instantiate Moo:Module"
+      "cannot instantiate Moo:Module"
   end
 
   it "uses type declaration inside module" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "undefined local variable or method 'allocate' (modules cannot be instantiated)"
+      "undefined local variable or method 'allocate'#{colorize(" (modules cannot be instantiated)").yellow.bold}"
   end
 
   it "gives error when trying to instantiate with allocate" do
@@ -924,7 +924,7 @@ describe "Semantic: module" do
         end
       end
       Moo.allocate),
-      "undefined method 'allocate' for Moo:Module (modules cannot be instantiated)"
+      "undefined method 'allocate' for Moo:Module#{colorize(" (modules cannot be instantiated)").yellow.bold}"
   end
 
   it "uses type declaration inside module" do

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -39,7 +39,7 @@ end
 class Crystal::Call
   def raise_matches_not_found(owner, def_name, arg_types, named_args_types, matches = nil, with_literals = false)
     if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
-      raise "Cannot instantiate #{owner}"
+      raise "cannot instantiate #{owner}"
     end
 
     # Special case: Foo+.class#new

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -97,10 +97,11 @@ class Crystal::Call
             msg << "undefined method '#{def_name}'"
           else
             msg << "undefined local variable or method '#{def_name}'"
-            if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
-              msg << colorize(" (modules cannot be instantiated)").yellow.bold
-            end
           end
+        end
+
+        if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
+          msg << colorize(" (modules cannot be instantiated)").yellow.bold
         end
 
         if obj && obj.type != owner

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -38,6 +38,10 @@ end
 
 class Crystal::Call
   def raise_matches_not_found(owner, def_name, arg_types, named_args_types, matches = nil, with_literals = false)
+    if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
+      raise "Cannot instantiate #{owner}"
+    end
+
     # Special case: Foo+.class#new
     if owner.is_a?(VirtualMetaclassType) && def_name == "new"
       raise_matches_not_found_for_virtual_metaclass_new owner

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -100,7 +100,7 @@ class Crystal::Call
           end
         end
 
-        if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
+        if def_name == "allocate" && owner.is_a?(MetaclassType) && owner.instance_type.module?
           msg << colorize(" (modules cannot be instantiated)").yellow.bold
         end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -38,10 +38,6 @@ end
 
 class Crystal::Call
   def raise_matches_not_found(owner, def_name, arg_types, named_args_types, matches = nil, with_literals = false)
-    if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
-      raise "cannot instantiate #{owner}"
-    end
-
     # Special case: Foo+.class#new
     if owner.is_a?(VirtualMetaclassType) && def_name == "new"
       raise_matches_not_found_for_virtual_metaclass_new owner
@@ -101,6 +97,9 @@ class Crystal::Call
             msg << "undefined method '#{def_name}'"
           else
             msg << "undefined local variable or method '#{def_name}'"
+            if def_name == "allocate" && owner.is_a?(ModuleType) && owner.is_a?(MetaclassType)
+              msg << colorize(" (modules cannot be instantiated)").yellow.bold
+            end
           end
         end
 


### PR DESCRIPTION
Fixes #3885 

Now this:
```cr
module Foo
  def initialize
  end
end
Foo.new
```
gives:
```c
Error in test.cr:5: instantiating 'Foo:Module#new()'

Foo.new
    ^~~

in test.cr:2: cannot instantiate Foo:Module

  def initialize
  ^
```
instead of:
```c
Error in line 5: instantiating 'Foo:Module#new()'

in line 2: undefined local variable or method 'allocate'
```