### PR TITLE
Support OpenSSL 1.1.1

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -53,7 +53,11 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Client)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
+    {% if LibSSL::OPENSSL_111 %}
+    context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
+    {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
+    {% end %}
 
     OpenSSL::SSL::Context::Client.insecure(LibSSL.tlsv1_method)
   end
@@ -63,7 +67,11 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Server)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
+    {% if LibSSL::OPENSSL_111 %}
+    context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
+    {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
+    {% end %}
 
     OpenSSL::SSL::Context::Server.insecure(LibSSL.tlsv1_method)
   end

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -3,22 +3,19 @@ require "./lib_crypto"
 # :nodoc:
 struct OpenSSL::BIO
   CRYSTAL_BIO = begin
-    crystal_bio = LibCrypto::BioMethod.new
-    crystal_bio.name = "Crystal BIO".to_unsafe
-
-    crystal_bio.bwrite = LibCrypto::BioMethodWrite.new do |bio, data, len|
+    bwrite = LibCrypto::BioMethodWriteOld.new do |bio, data, len|
       io = Box(IO).unbox(bio.value.ptr)
       io.write Slice.new(data, len)
       len
     end
 
-    crystal_bio.bread = LibCrypto::BioMethodRead.new do |bio, buffer, len|
+    bread = LibCrypto::BioMethodReadOld.new do |bio, buffer, len|
       io = Box(IO).unbox(bio.value.ptr)
       io.flush
       io.read(Slice.new(buffer, len)).to_i
     end
 
-    crystal_bio.ctrl = LibCrypto::BioMethodCtrl.new do |bio, cmd, num, ptr|
+    ctrl = LibCrypto::BioMethodCtrl.new do |bio, cmd, num, ptr|
       io = Box(IO).unbox(bio.value.ptr)
 
       val = case cmd
@@ -34,24 +31,43 @@ struct OpenSSL::BIO
       LibCrypto::Long.new(val)
     end
 
-    crystal_bio.create = LibCrypto::BioMethodCreate.new do |bio|
+    create = LibCrypto::BioMethodCreate.new do |bio|
       bio.value.shutdown = 1
       bio.value.init = 1
       bio.value.num = -1
     end
 
-    crystal_bio.destroy = LibCrypto::BioMethodDestroy.new do |bio|
+    destroy = LibCrypto::BioMethodDestroy.new do |bio|
       bio.value.ptr = Pointer(Void).null
       1
     end
 
-    crystal_bio
+    {% if LibCrypto::OPENSSL_110 %}
+      biom = LibCrypto.BIO_meth_new(Int32::MAX, "Crystal BIO")
+      LibCrypto.BIO_meth_set_write(biom, bwrite)
+      LibCrypto.BIO_meth_set_read(biom, bread)
+      LibCrypto.BIO_meth_set_ctrl(biom, ctrl)
+      LibCrypto.BIO_meth_set_create(biom, create)
+      LibCrypto.BIO_meth_set_destroy(biom, destroy)
+      biom
+    {% else %}
+      biom = Pointer(LibCrypto::BioMethod).malloc(1)
+      biom.value.type_id = Int32::MAX
+      biom.value.name = "Crystal BIO"
+      biom.value.bwrite = bwrite
+      biom.value.bread = bread
+      biom.value.ctrl = ctrl
+      biom.value.create = create
+      biom.value.destroy = destroy
+      biom
+    {% end %}
   end
 
   @boxed_io : Void*
+  @bio : LibCrypto::Bio*
 
   def initialize(@io : IO)
-    @bio = LibCrypto.bio_new(pointerof(CRYSTAL_BIO))
+    @bio = LibCrypto.bio_new(CRYSTAL_BIO)
 
     # We need to store a reference to the box because it's
     # stored in `@bio.value.ptr`, but that lives in C-land,

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,5 +1,6 @@
 {% begin %}
   lib LibCrypto
+    OPENSSL_111 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.1 libcrypto || printf %s false`.stringify != "false" }}
     OPENSSL_110 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libcrypto || printf %s false`.stringify != "false" }}
     OPENSSL_102 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libcrypto || printf %s false`.stringify != "false" }}
   end
@@ -45,8 +46,10 @@ lib LibCrypto
   CTRL_POP   =  7
   CTRL_FLUSH = 11
 
-  alias BioMethodWrite = (Bio*, Char*, Int) -> Int
-  alias BioMethodRead = (Bio*, Char*, Int) -> Int
+  alias BioMethodWrite = (Bio*, Char*, SizeT, SizeT*) -> Int
+  alias BioMethodWriteOld = (Bio*, Char*, Int) -> Int
+  alias BioMethodRead = (Bio*, Char*, SizeT, SizeT*) -> Int
+  alias BioMethodReadOld = (Bio*, Char*, Int) -> Int
   alias BioMethodPuts = (Bio*, Char*) -> Int
   alias BioMethodGets = (Bio*, Char*, Int) -> Int
   alias BioMethodCtrl = (Bio*, Int, Long, Void*) -> Long
@@ -54,21 +57,41 @@ lib LibCrypto
   alias BioMethodDestroy = Bio* -> Int
   alias BioMethodCallbackCtrl = (Bio*, Int, Void*) -> Long
 
-  struct BioMethod
-    type_id : Int
-    name : Char*
-    bwrite : BioMethodWrite
-    bread : BioMethodRead
-    bputs : BioMethodPuts
-    bgets : BioMethodGets
-    ctrl : BioMethodCtrl
-    create : BioMethodCreate
-    destroy : BioMethodDestroy
-    callback_ctrl : BioMethodCallbackCtrl
-  end
+  {% if LibCrypto::OPENSSL_110 %}
+    type BioMethod = Void
+  {% else %}
+    struct BioMethod
+      type_id : Int
+      name : Char*
+      bwrite : BioMethodWriteOld
+      bread : BioMethodReadOld
+      bputs : BioMethodPuts
+      bgets : BioMethodGets
+      ctrl : BioMethodCtrl
+      create : BioMethodCreate
+      destroy : BioMethodDestroy
+      callback_ctrl : BioMethodCallbackCtrl
+    end
+  {% end %}
 
   fun bio_new = BIO_new(method : BioMethod*) : Bio*
   fun bio_free = BIO_free(bio : Bio*) : Int
+
+  {% if LibCrypto::OPENSSL_110 %}
+    fun BIO_meth_new(Int, Char*) : BioMethod*
+    fun BIO_meth_set_read(BioMethod*, BioMethodReadOld)
+    fun BIO_meth_set_write(BioMethod*, BioMethodWriteOld)
+    fun BIO_meth_set_puts(BioMethod*, BioMethodPuts)
+    fun BIO_meth_set_gets(BioMethod*, BioMethodGets)
+    fun BIO_meth_set_ctrl(BioMethod*, BioMethodCtrl)
+    fun BIO_meth_set_create(BioMethod*, BioMethodCreate)
+    fun BIO_meth_set_destroy(BioMethod*, BioMethodDestroy)
+    fun BIO_meth_set_callback_ctrl(BioMethod*, BioMethodCallbackCtrl)
+  {% end %}
+  {% if LibCrypto::OPENSSL_111 %}
+    fun BIO_meth_set_read_ex(BioMethod*, BioMethodRead)
+    fun BIO_meth_set_write_ex(BioMethod*, BioMethodWrite)
+  {% end %}
 
   fun sha1 = SHA1(data : Char*, length : SizeT, md : Char*) : Char*
 

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -74,8 +74,12 @@ lib LibCrypto
     end
   {% end %}
 
-  fun bio_new = BIO_new(method : BioMethod*) : Bio*
-  fun bio_free = BIO_free(bio : Bio*) : Int
+  fun BIO_new(BioMethod*) : Bio*
+  fun BIO_free(Bio*) : Int
+  fun BIO_set_data(Bio*, Void*)
+  fun BIO_get_data(Bio*) : Void*
+  fun BIO_set_init(Bio*, Int)
+  fun BIO_set_shutdown(Bio*, Int)
 
   {% if LibCrypto::OPENSSL_110 %}
     fun BIO_meth_new(Int, Char*) : BioMethod*

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -2,6 +2,7 @@ require "./lib_crypto"
 
 {% begin %}
   lib LibSSL
+    OPENSSL_111 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.1 libssl || printf %s false`.stringify != "false" }}
     OPENSSL_110 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libssl || printf %s false`.stringify != "false" }}
     OPENSSL_102 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libssl || printf %s false`.stringify != "false" }}
   end


### PR DESCRIPTION
OpenSSL 1.1.0 introduced a public API to create and populate the BIO and BIO_METHOD structs. We now use it when available. We still keep the manual creation for OpenSSL 1.0.2 (and below) which is still supported.

This fixes an internal ABI breaking change introduced in OpenSSL 1.1.1 that causes a compiled program to segfault. See #6737.

This also implements the new BIO read/write methods that take `size_t` lengths instead of `int`. This skips the compatibility methods provided by OpenSSL.

NOTE: the patch also starts to use uppercased external symbols, such as `BIO_set_init`, to avoid `bio_set_init = BIO_set_init` aliases. This is limited to the `BIO_` and `BIO_meth_*` used in this patch.