### PR TITLE
Fix build in travis due to git checkout depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     - env: ARCH=x86_64 ARCH_CMD=linux64
       os: linux
 
+git:
+  depth: false
+
 before_install:
   - echo '{"ipv6":true, "fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
   - sudo service docker restart


### PR DESCRIPTION
Before this change travis did a `$ git clone --depth=50`

With a full history `$ git describe --tags --long --always` will return `0.26.1-64-g6f9582e91` but with the `--depth=50` will return only the commit information.

This leads to the built compiler using `+?` suffix from https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/config.cr#L45 which is actually a non valid semantic version value.

Credits to @RX14  to point the --depth=50 in the travis logs.