### PR TITLE
Fix spec for Time::Location.load_local with TZ=nil

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -174,7 +174,10 @@ class Time::Location
     describe ".load_local" do
       it "with unset TZ" do
         with_env("TZ", nil) do
-          Location.load_local.name.should eq "Local"
+          # This should generally be `Local`, but if `/etc/localtime` doesn't exist,
+          # `Crystal::System::Time.load_localtime` can't resolve a local time zone,
+          # making the return value default to `UTC`.
+          {"Local", "UTC"}.should contain Location.load_local.name
         end
       end
 


### PR DESCRIPTION
On POSIX systems, if environment variable `TZ` is not set, `Time::Location.load_local` looks up the time zone setting in `/etc/localtime`. However, if this file is not available (or invalid), the default value `UTC` is used.
That breaks the spec, which assumes the return value to be always `Local`.

This is an issue when `/etc/localtime` is not populated by default which makes it depend on OS configuration.
The FreeBSD port contains [a patch](https://git.alpinelinux.org/cgit/aports/tree/community/crystal/fix-spec-time-location.patch) to disable this spec because it would fail on a clean install without time zone configured.

I changed the spec to pass when the returned location name is either `Local` or `UTC`.