### PR TITLE
Switch order of "xmlns" and prefix in XML::Builder#namespace

### DIFF
--- a/spec/std/xml/builder_spec.cr
+++ b/spec/std/xml/builder_spec.cr
@@ -169,7 +169,7 @@ describe XML::Builder do
   end
 
   it "writes namespace" do
-    assert_built(%{<?xml version="1.0"?>\n<foo x:xmlns="http://foo.com"/>\n}) do |xml|
+    assert_built(%{<?xml version="1.0"?>\n<foo xmlns:x="http://foo.com"/>\n}) do |xml|
       element("foo") do
         namespace "x", "http://foo.com"
       end

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -228,7 +228,7 @@ struct XML::Builder
 
   # Emits a namespace.
   def namespace(prefix, uri)
-    attribute prefix, "xmlns", nil, uri
+    attribute "xmlns", prefix, nil, uri
   end
 
   # Forces content written to this writer to be flushed to


### PR DESCRIPTION
Changed order of `"xmlns"` and `prefix` in `XML::Builder#namespace` so that the function produces a valid namespace declaration of the form`xmlns:prefix="URI"` (https://www.w3schools.com/xml/xml_namespaces.asp), rather than `prefix:xmlns="URI"`.