### PR TITLE
Issue #6646 extend GMP implementation

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -254,19 +254,11 @@ describe "BigInt" do
   end
 
   it "tdivs mutably" do
-<<<<<<< HEAD
     i = 0.to_big_i
     i.tdiv(5.to_big_i, 3).should eq(1)
     i.tdiv(-5.to_big_i, 3).should eq(-1)
     i.tdiv(5.to_big_i, -3).should eq(-1)
     i.tdiv(-5.to_big_i, -3).should eq(1)
-=======
-  i = 0.to_big_i
-  i.tdiv(5.to_big_i, 3).should eq(1)
-  i.tdiv(-5.to_big_i, 3).should eq(-1)
-  i.tdiv(5.to_big_i, -3).should eq(-1)
-  i.tdiv(-5.to_big_i, -3).should eq(1)
->>>>>>> fff2addaa999c6e1cac6d97d95460c0fde37cb74
   end
 
   it "does modulo" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -121,20 +121,22 @@ describe "BigInt" do
   end
 
   it "subs mutably" do
-    a = 5.to_big_i
-    a.sub(2.to_big_i).should eq 3.to_big_i
-    b = 0.to_big_i
-    b.sub(5.to_big_i, 3.to_big_i).should eq 2.to_big_i
-    c = 0.to_big_i
-    c.sub(5.to_big_i, 3).should eq 2.to_big_i
-    d = 0.to_big_i
-    d.sub(5, 3.to_big_i).should eq 2.to_big_i
-    e = Int64::MAX.to_big_i
-    e.sub(5).should eq(Int64::MAX - 5)
-    f = 5.to_big_i
-    f.sub(Int64::MAX).should eq(-(Int64::MAX - 5))
-    g = 0.to_big_i
-    g.sub(Int64::MAX, Int64::MAX).should eq(0)
+    i = 5.to_big_i
+    i.sub(2.to_big_i).should eq 3.to_big_i
+    i = 0.to_big_i
+    i.sub(5.to_big_i, 3.to_big_i).should eq 2.to_big_i
+    i = 0.to_big_i
+    i.sub(5.to_big_i, 3).should eq 2.to_big_i
+    i = 0.to_big_i
+    i.sub(5, 3.to_big_i).should eq 2.to_big_i
+    i = 0.to_big_i
+    i.sub(5, -3.to_big_i).should eq 8.to_big_i
+    i = Int64::MAX.to_big_i
+    i.sub(5).should eq(Int64::MAX - 5)
+    i = 5.to_big_i
+    i.sub(Int64::MAX).should eq(-(Int64::MAX - 5))
+    i = 0.to_big_i
+    i.sub(Int64::MAX, Int64::MAX).should eq(0)
   end
 
   it "negates" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -131,6 +131,10 @@ describe "BigInt" do
     i.sub(5, 3.to_big_i).should eq 2.to_big_i
     i = 0.to_big_i
     i.sub(5, -3.to_big_i).should eq 8.to_big_i
+    i = 0.to_big_i
+    i.sub(-5, 3.to_big_i).should eq -8.to_big_i
+    i = 0.to_big_i
+    i.sub(Int64::MAX, Int64::MAX.to_big_i + 5).should eq -5.to_big_i
     i = Int64::MAX.to_big_i
     i.sub(5).should eq(Int64::MAX - 5)
     i = 5.to_big_i

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -169,7 +169,15 @@ describe "BigInt" do
     i = 0.to_big_i
     i.mul(2.to_big_i, 3.to_big_i).should eq(6.to_big_i)
     i = 0.to_big_i
+    i.mul(2, 3).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2, -3).should eq(-6.to_big_i)
+    i = 0.to_big_i
     i.mul(2.to_big_i, 3).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2.to_big_i, 3u8).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2_u8, 3.to_big_i).should eq(6.to_big_i)
     i = 0.to_big_i
     i.mul(2, 3.to_big_i).should eq(6.to_big_i)
     i = 0.to_big_i

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -89,6 +89,25 @@ describe "BigInt" do
     (2 + 1.to_big_i).should eq(3.to_big_i)
   end
 
+  it "adds mutably" do
+    a = 1.to_big_i
+    a.add(2.to_big_i).should eq 3.to_big_i
+    b = 1.to_big_i
+    b.add(2.to_big_i, 3.to_big_i).should eq 5.to_big_i
+    c = 1.to_big_i
+    c.add(2.to_big_i, 3).should eq 5.to_big_i
+    d = 1.to_big_i
+    d.add(2, 3.to_big_i).should eq 5.to_big_i
+    e = 5.to_big_i
+    e.add(Int64::MAX).should be > Int64::MAX.to_big_i
+    f = 5.to_big_i
+    f.add(Int64::MAX).should eq(Int64::MAX.to_big_i + 5)
+    g = 0.to_big_i
+    g.add(Int64::MAX, Int64::MAX).should be > Int64::MAX.to_big_i
+    h = 0.to_big_i
+    h.add(Int64::MAX, Int64::MAX).should eq(Int64::MAX.to_big_i + Int64::MAX.to_big_i)
+  end
+
   it "subs" do
     (5.to_big_i - 2.to_big_i).should eq(3.to_big_i)
     (5.to_big_i - 2).should eq(3.to_big_i)
@@ -99,6 +118,23 @@ describe "BigInt" do
 
     (5 - 1.to_big_i).should eq(4.to_big_i)
     (-5 - 1.to_big_i).should eq(-6.to_big_i)
+  end
+
+  it "subs mutably" do
+    a = 5.to_big_i
+    a.sub(2.to_big_i).should eq 3.to_big_i
+    b = 0.to_big_i
+    b.sub(5.to_big_i, 3.to_big_i).should eq 2.to_big_i
+    c = 0.to_big_i
+    c.sub(5.to_big_i, 3).should eq 2.to_big_i
+    d = 0.to_big_i
+    d.sub(5, 3.to_big_i).should eq 2.to_big_i
+    e = Int64::MAX.to_big_i
+    e.sub(5).should eq(Int64::MAX - 5)
+    f = 5.to_big_i
+    f.sub(Int64::MAX).should eq(-(Int64::MAX - 5))
+    g = 0.to_big_i
+    g.sub(Int64::MAX, Int64::MAX).should eq(0)
   end
 
   it "negates" do
@@ -112,6 +148,76 @@ describe "BigInt" do
     (3 * 2.to_big_i).should eq(6.to_big_i)
     (3_u8 * 2.to_big_i).should eq(6.to_big_i)
     (2.to_big_i * Int64::MAX).should eq(2.to_big_i * Int64::MAX.to_big_i)
+  end
+
+  it "multiplies mutably" do
+    i = 2.to_big_i
+    i.mul(3).should eq(6.to_big_i)
+    i = 2.to_big_i
+    i.mul(-3).should eq(-6.to_big_i)
+    i = 2.to_big_i
+    i.mul(3_u8).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(3).should eq(0.to_big_i)
+
+    i = 0.to_big_i
+    i.mul(2.to_big_i, 3.to_big_i).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2.to_big_i, 3).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2, 3.to_big_i).should eq(6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2.to_big_i, -3).should eq(-6.to_big_i)
+    i = 0.to_big_i
+    i.mul(2.to_big_i, Int64::MAX).should eq(2.to_big_i * Int64::MAX.to_big_i)
+    i = 0.to_big_i
+    i.mul(Int64::MAX, Int64::MAX).should eq(Int64::MAX.to_big_i * Int64::MAX.to_big_i)
+    i = 0.to_big_i
+    i.mul(3.to_big_i, 0).should eq(0.to_big_i)
+    i = 0.to_big_i
+    i.mul(0.to_big_i, 3).should eq(0.to_big_i)
+  end
+
+  it "submuls mutably" do
+    i = 100.to_big_i
+    i.submul(10.to_big_i, 10.to_big_i).should eq(0.to_big_i)
+    i = 100.to_big_i
+    i.submul(100.to_big_i, 2.to_big_i).should eq(-100.to_big_i)
+    i = 100.to_big_i
+    i.submul(100.to_big_i, -2.to_big_i).should eq(300.to_big_i)
+    i = 100.to_big_i
+    i.submul(-100.to_big_i, 2.to_big_i).should eq(300.to_big_i)
+    i = 100.to_big_i
+    i.submul(-100.to_big_i, -2.to_big_i).should eq(-100.to_big_i)
+    i = 100.to_big_i
+    i.submul(25.to_big_i, 2).should eq(50.to_big_i)
+    i = 0.to_big_i
+    i.submul(2.to_big_i, Int64::MAX).should eq(-Int64::MAX.to_big_i * 2)
+    i = 100.to_big_i
+    i.submul(25.to_big_i, 2_u8).should eq(50.to_big_i)
+    i = 100.to_big_i
+    i.submul(25.to_big_i, -2).should eq(150.to_big_i)
+  end
+
+  it "addmuls mutably" do
+    i = 100.to_big_i
+    i.addmul(10.to_big_i, 10.to_big_i).should eq(200.to_big_i)
+    i = 100.to_big_i
+    i.addmul(100.to_big_i, 2.to_big_i).should eq(300.to_big_i)
+    i = 100.to_big_i
+    i.addmul(100.to_big_i, -2.to_big_i).should eq(-100.to_big_i)
+    i = 100.to_big_i
+    i.addmul(-100.to_big_i, 2.to_big_i).should eq(-100.to_big_i)
+    i = 100.to_big_i
+    i.addmul(-100.to_big_i, -2.to_big_i).should eq(300.to_big_i)
+    i = 100.to_big_i
+    i.addmul(25.to_big_i, 2).should eq(150.to_big_i)
+    i = 0.to_big_i
+    i.addmul(2.to_big_i, Int64::MAX).should eq(Int64::MAX.to_big_i * 2)
+    i = 100.to_big_i
+    i.addmul(25.to_big_i, 2_u8).should eq(150.to_big_i)
+    i = 100.to_big_i
+    i.addmul(25.to_big_i, -2).should eq(50.to_big_i)
   end
 
   it "gets absolute value" do
@@ -145,6 +251,14 @@ describe "BigInt" do
     -5.to_big_i.tdiv(3).should eq(-1)
     5.to_big_i.tdiv(-3).should eq(-1)
     -5.to_big_i.tdiv(-3).should eq(1)
+  end
+
+  it "tdivs mutably" do
+    i = 0.to_big_i
+    i.tdiv(5.to_big_i, 3).should eq(1)
+    i.tdiv(-5.to_big_i, 3).should eq(-1)
+    i.tdiv(5.to_big_i, -3).should eq(-1)
+    i.tdiv(-5.to_big_i, -3).should eq(1)
   end
 
   it "does modulo" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -172,7 +172,7 @@ struct BigInt < Int
     elsif op1 <= LibGMP::ULong::MAX
       LibGMP.add_ui(self, op2, op1)
     else
-      add(op1, op2.to_big_i)
+      add(op1.to_big_i, op2)
     end
     self
   end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -314,7 +314,7 @@ struct BigInt < Int
     self
   end
 
-  #ditto
+  # ditto
   def mul(other : LibGMP::IntPrimitiveUnsigned) : self
     LibGMP.mul_ui(self, self, other)
     self

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -116,6 +116,7 @@ struct BigInt < Int
   end
 
   # a.add(b), a += b, avoiding allocations by mutating a
+  #
   # ```
   # a = 100.to_big_i
   # a.add(10) => # a = 110
@@ -140,6 +141,7 @@ struct BigInt < Int
   # a.add(b,c), a = b+c avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  #
   # ```
   # a = 0.to_big_i
   # a.add(10_to_big_i, 5.to_big_i) => # a = 15
@@ -206,6 +208,7 @@ struct BigInt < Int
   end
 
   # a.sub(b) a -= b avoiding allocations by mutating a
+  #
   # ```
   # a = 100.to_big_i
   # a.sub(10) => # a = 90
@@ -230,6 +233,7 @@ struct BigInt < Int
   # a.sub(b,c), a = b-c avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  #
   # ```
   # a = 0.to_big_i
   # a.sub(10_to_big_i, 5.to_big_i) => # a = 5
@@ -300,6 +304,7 @@ struct BigInt < Int
   end
 
   # a.mul(b) a*b avoiding allocations by mutating a
+  #
   # ```
   # a = 100.to_big_i
   # a.mul(10_to_big_i) => # a = 1000
@@ -324,6 +329,7 @@ struct BigInt < Int
   # a.mul(b,c), a = b*c, avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  #
   # ```
   # a = 0.to_big_i
   # a.mul(10_to_big_i, 5) => # a = 50
@@ -367,6 +373,7 @@ struct BigInt < Int
   end
 
   # a -= b*c avoiding allocations by mutating a
+  #
   # ```
   # a = 100.to_big_i
   # a.submul(10_to_big_i, 5) => # a = 50
@@ -398,6 +405,7 @@ struct BigInt < Int
   end
 
   # a += b*c avoiding allocations by mutating a
+  #
   # ```
   # a = 10.to_big_i
   # a.addmul(10_to_big_i, 5) => #a = 60

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -116,15 +116,16 @@ struct BigInt < Int
   end
 
   # a.add(b), a += b, avoiding allocations by mutating a
-  #
-  #    a = 100.to_big_i
-  #    a.add(10) => # a = 110
+  # ```
+  # a = 100.to_big_i
+  # a.add(10) => # a = 110
+  # ```
   def add(other : BigInt) : self
     LibGMP.add(self, self, other)
     self
   end
 
-  # a.add(b), a += b, avoiding allocations by mutating a
+  # ditto
   def add(other : Int) : self
     if other < 0
       sub(other.abs)
@@ -139,20 +140,19 @@ struct BigInt < Int
   # a.add(b,c), a = b+c avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  # ```
+  # a = 0.to_big_i
+  # a.add(10_to_big_i, 5.to_big_i) => # a = 15
   #
-  #    a = 0.to_big_i
-  #    a.add(10_to_big_i, 5.to_big_i) => # a = 15
-  #
-  #    a = 100.to_big_i
-  #    a.add(10.to_big_i, 5.to_big_i) => # a = 15
+  # a = 100.to_big_i
+  # a.add(10.to_big_i, 5.to_big_i) => # a = 15
+  # ```
   def add(op1 : BigInt, op2 : BigInt) : self
     LibGMP.add(self, op1, op2)
     self
   end
 
-  # a.add(b,c), a = b+c avoiding allocations by mutating a. This is a nice way
-  # to "reuse" `BigInt` variables and avoid new allocations. Beware that
-  # the value of "a" will be overwritten with the result of b*c
+  # ditto
   def add(op1 : BigInt, op2 : Int) : self
     if op2 < 0
       sub(op1, op2.abs)
@@ -172,7 +172,7 @@ struct BigInt < Int
     elsif op1 <= LibGMP::ULong::MAX
       LibGMP.add_ui(self, op2, op1)
     else
-      add(op1.to_big_i, op2)
+      add(op1, op2)
     end
     self
   end
@@ -206,9 +206,10 @@ struct BigInt < Int
   end
 
   # a.sub(b) a -= b avoiding allocations by mutating a
-  #
-  #    a = 100.to_big_i
-  #    a.sub(10) => # a = 90
+  # ```
+  # a = 100.to_big_i
+  # a.sub(10) => # a = 90
+  # ```
   def sub(other : Int) : self
     if other < 0
       add(other.abs)
@@ -220,7 +221,7 @@ struct BigInt < Int
     self
   end
 
-  # a.sub(b) a -= b avoiding allocations by mutating a
+  # ditto
   def sub(other : BigInt) : self
     LibGMP.sub(self, self, other)
     self
@@ -229,20 +230,19 @@ struct BigInt < Int
   # a.sub(b,c), a = b-c avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  # ```
+  # a = 0.to_big_i
+  # a.sub(10_to_big_i, 5.to_big_i) => # a = 5
   #
-  #    a = 0.to_big_i
-  #    a.sub(10_to_big_i, 5.to_big_i) => # a = 5
-  #
-  #    a = 100.to_big_i
-  #    a.sub(10.to_big_i, 5.to_big_i) => # a = 5
+  # a = 100.to_big_i
+  # a.sub(10.to_big_i, 5.to_big_i) => # a = 5
+  # ```
   def sub(op1 : BigInt, op2 : BigInt) : self
     LibGMP.sub(self, op1, op2)
     self
   end
 
-  # a.sub(b,c), a = b-c avoiding allocations by mutating a. This is a nice way
-  # to "reuse" `BigInt` variables and avoid new allocations. Beware that
-  # the value of "a" will be overwritten with the result of b*c
+  # ditto
   def sub(op1 : BigInt, op2 : Int) : self
     if op2 < 0
       add(op1, op2.abs)
@@ -300,15 +300,16 @@ struct BigInt < Int
   end
 
   # a.mul(b) a*b avoiding allocations by mutating a
-  #
-  #    a = 100.to_big_i
-  #    a.mul(10_to_big_i) => # a = 1000
+  # ```
+  # a = 100.to_big_i
+  # a.mul(10_to_big_i) => # a = 1000
+  # ```
   def mul(other : BigInt) : self
     LibGMP.mul(self, self, other)
     self
   end
 
-  # a.mul(b) a*b avoiding allocations by mutating a
+  # ditto
   def mul(other : LibGMP::IntPrimitiveSigned) : self
     LibGMP.mul_si(self, self, other)
     self
@@ -323,20 +324,19 @@ struct BigInt < Int
   # a.mul(b,c), a = b*c, avoiding allocations by mutating a. This is a nice way
   # to "reuse" `BigInt` variables and avoid new allocations. Beware that
   # the value of "a" will be overwritten with the result of b*c
+  # ```
+  # a = 0.to_big_i
+  # a.mul(10_to_big_i, 5) => # a = 50
   #
-  #    a = 0.to_big_i
-  #    a.mul(10_to_big_i, 5) => # a = 50
-  #
-  #    a = 100.to_big_i
-  #    a.mul(10.to_big_i, 5.to_big_i) => # a = 50
+  # a = 100.to_big_i
+  # a.mul(10.to_big_i, 5.to_big_i) => # a = 50
+  # ```
   def mul(op1 : BigInt, op2 : BigInt) : self
     LibGMP.mul(self, op1, op2)
     self
   end
 
-  # a.mul(b,c) avoiding allocations by mutating a. This is a nice way
-  # to "reuse" `BigInt` variables and avoid new allocations. Beware that
-  # the value of "a" will be overwritten with the result of b*c
+  # ditto
   def mul(op1 : BigInt, op2 : LibGMP::IntPrimitiveSigned) : self
     LibGMP.mul_si(self, op1, op2)
     self
@@ -367,9 +367,10 @@ struct BigInt < Int
   end
 
   # a -= b*c avoiding allocations by mutating a
-  #
-  #    a = 100.to_big_i
-  #    a.submul(10_to_big_i, 5) => # a = 50
+  # ```
+  # a = 100.to_big_i
+  # a.submul(10_to_big_i, 5) => # a = 50
+  # ```
   def submul(op1 : BigInt, op2 : Int) : self
     if op2 < 0
       LibGMP.addmul(self, op1, op2.abs.to_big_i)
@@ -379,7 +380,7 @@ struct BigInt < Int
     self
   end
 
-  # a -= b*c avoiding allocations by mutating a
+  # ditto
   def submul(op1 : BigInt, op2 : BigInt) : self
     if op2 < 0
       LibGMP.abs(op2, op2)
@@ -397,9 +398,10 @@ struct BigInt < Int
   end
 
   # a += b*c avoiding allocations by mutating a
-  #
-  #    a = 10.to_big_i
-  #    a.addmul(10_to_big_i, 5) => #a = 60
+  # ```
+  # a = 10.to_big_i
+  # a.addmul(10_to_big_i, 5) => #a = 60
+  # ```
   def addmul(op1 : BigInt, op2 : Int) : self
     if op2 < 0
       LibGMP.submul(self, op1, op2.abs.to_big_i)
@@ -409,7 +411,7 @@ struct BigInt < Int
     self
   end
 
-  # a += b*c avoiding allocations by mutating a
+  # ditto
   def addmul(op1 : BigInt, op2 : BigInt) : self
     if op2 < 0
       LibGMP.abs(op2, op2)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -262,7 +262,7 @@ struct BigInt < Int
     elsif op2 <= LibGMP::ULong::MAX
       LibGMP.sub_ui(self, op1.to_big_i, op2)
     else
-      sub(op1, op2.to_big_i)
+      sub(op1.to_big_i, op2)
     end
     self
   end

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -56,6 +56,11 @@ lib LibGMP
   fun mul_si = __gmpz_mul_si(rop : MPZ*, op1 : MPZ*, op2 : Long)
   fun mul_ui = __gmpz_mul_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
 
+  fun submul_ui = __gmpz_submul_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
+  fun addmul_ui = __gmpz_addmul_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
+  fun submul = __gmpz_submul(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
+  fun addmul = __gmpz_addmul(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
+
   fun fdiv_q = __gmpz_fdiv_q(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun fdiv_q_ui = __gmpz_fdiv_q_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
 

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -61,10 +61,6 @@ lib LibGMP
   fun submul = __gmpz_submul(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun addmul = __gmpz_addmul(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
 
-<<<<<<< HEAD
-=======
-
->>>>>>> fff2addaa999c6e1cac6d97d95460c0fde37cb74
   fun fdiv_q = __gmpz_fdiv_q(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun fdiv_q_ui = __gmpz_fdiv_q_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -13,6 +13,19 @@
 # response.body.lines.first # => "<!doctype html>"
 # ```
 #
+# ### Parameters
+#
+# Parameters can be added to any request with the `HTTP::Params#encode` method, which
+# converts a `Hash` or `NamedTuple` to a URL encoded HTTP query.
+#
+# ```
+# require "http/client"
+#
+# params = HTTP::Params.encode({"author" => "John Doe", "offset" => "20"}) # => author=John+Doe&offset=20
+# response = HTTP::Client.get "http://www.example.com?" + params
+# response.status_code # => 200
+# ```
+#
 # ### Streaming
 #
 # With a block, an `HTTP::Client::Response` body is returned and the response's body


### PR DESCRIPTION
I made this pull request after the discussion in thread #6646. This solved most of current BigInt implementations performance issues, and using the Benchmarks game pidigits benchmark as a measurement of performance sets this on par with the Rust implentation (within ~5%).

You can now mutate a BigInt variable and reuse a variable for the most common operations add, sub, mul, div, submul, addmul.

The api will look like this:
```
# mutating a variable comparable to a += b, avoiding new allocations:
a = # some big int
b = # some big int
a.add(b) # a += b

# Reusing a variable, avoiding new allocations:
a = # some big int
b = # some big int
c = # some big int
a.add(b, c) # a = b + c
```
See the suggested documentation for more information.