### PR TITLE
 Improve sprintf docs, minor String::Formatter refactors

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -73,7 +73,7 @@ end
 # The syntax for a format specifier is:
 #
 # ```text
-# %[flags][width][.precision][type]
+# %[flags][width][.precision]type
 # ```
 #
 # A format specifier consists of a percent sign, followed by optional flags,

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -73,7 +73,7 @@ end
 # The syntax for a format specifier is:
 #
 # ```text
-# %[flags][width][.precision]type
+# %[flags][width][.precision][type]
 # ```
 #
 # A format specifier consists of a percent sign, followed by optional flags,
@@ -87,70 +87,67 @@ end
 # The field type characters are:
 #
 # ```text
-#     Field |  Integer Format
-#     ------+--------------------------------------------------------------
-#       b   | Formats argument as a binary number.
-#       d   | Formats argument as a decimal number.
-#       i   | Same as d.
-#       o   | Formats argument as an octal number.
-#       x   | Formats argument as a hexadecimal number using lowercase letters.
-#       X   | Same as x, but uses uppercase letters.
+# Field | Integer Format
+# ------+------------------------------------------------------------------
+#   b   | Formats argument as a binary number.
+#   d   | Formats argument as a decimal number.
+#   i   | Same as d.
+#   o   | Formats argument as an octal number.
+#   x   | Formats argument as a hexadecimal number using lowercase letters.
+#   X   | Same as x, but uses uppercase letters.
 #
-#     Field |  Float Format
-#     ------+--------------------------------------------------------------
-#       e   | Formats floating point argument into exponential notation
-#           | with one digit before the decimal point as [-]d.dddddde[+-]dd.
-#           | The precision specifies the number of digits after the decimal
-#           | point (defaulting to six).
-#       E   | Equivalent to e, but uses an uppercase E to indicate
-#           | the exponent.
-#       f   | Formats floating point argument as [-]ddd.dddddd,
-#           | where the precision specifies the number of digits after
-#           | the decimal point.
-#       g   | Formats a floating point number using exponential form
-#           | if the exponent is less than -4 or greater than or
-#           | equal to the precision, or in dd.dddd form otherwise.
-#           | The precision specifies the number of significant digits.
-#       G   | Equivalent to g, but use an uppercase E in exponent form.
-#       a   | Formats floating point argument as [-]0xh.hhhhp[+-]dd,
-#           | which is consisted from optional sign, "0x", fraction part
-#           | as hexadecimal, "p", and exponential part as decimal.
-#       A   | Equivalent to a, but use uppercase X and P.
+# Field | Float Format
+# ------+---------------------------------------------------------------
+#   e   | Formats floating point argument into exponential notation
+#       | with one digit before the decimal point as [-]d.dddddde[+-]dd.
+#       | The precision specifies the number of digits after the decimal
+#       | point (defaulting to six).
+#   E   | Equivalent to e, but uses an uppercase E to indicate
+#       | the exponent.
+#   f   | Formats floating point argument as [-]ddd.dddddd,
+#       | where the precision specifies the number of digits after
+#       | the decimal point.
+#   g   | Formats a floating point number using exponential form
+#       | if the exponent is less than -4 or greater than or
+#       | equal to the precision, or in dd.dddd form otherwise.
+#       | The precision specifies the number of significant digits.
+#   G   | Equivalent to g, but use an uppercase E in exponent form.
+#   a   | Formats floating point argument as [-]0xh.hhhhp[+-]dd,
+#       | which is consisted from optional sign, "0x", fraction part
+#       | as hexadecimal, "p", and exponential part as decimal.
+#   A   | Equivalent to a, but use uppercase X and P.
 #
-#     Field |  Other Format
-#     ------+--------------------------------------------------------------
-#       c   | Argument is the numeric code for a single character or
-#           | a single character string itself.
-#       s   | Argument is a string to be substituted.  If the format
-#           | sequence contains a precision, at most that many characters
-#           | will be copied.
-#       %   | A percent sign itself will be displayed.  No argument taken.
-#
+# Field | Other Format
+# ------+------------------------------------------------------------
+#   c   | Argument is a single character itself.
+#   s   | Argument is a string to be substituted. If the format
+#       | sequence contains a precision, at most that many characters
+#       | will be copied.
+#   %   | A percent sign itself will be displayed. No argument taken.
 # ```
 # The flags modifies the behavior of the formats.
 # The flag characters are:
 # ```text
-#
-#   Flag     | Applies to    | Meaning
-#   ---------+---------------+-----------------------------------------
-#   space    | bdiouxX       | Add a leading space character to
-#            | aAeEfgG       | non-negative numbers.
-#            | (numeric fmt) | For o, x, X, b, use
-#            |               | a minus sign with absolute value for
-#            |               | negative values.
-#   ---------+---------------+-----------------------------------------
-#   +        | bdiouxX       | Add a leading plus sign to non-negative
-#            | aAeEfgG       | numbers.
-#            | (numeric fmt) | For o, x, X, b, use
-#            |               | a minus sign with absolute value for
-#            |               | negative values.
-#   ---------+---------------+-----------------------------------------
-#   -        | all           | Left-justify the result of this conversion.
-#   ---------+---------------+-----------------------------------------
-#   0 (zero) | bdiouxX       | Pad with zeros, not spaces.
-#            | aAeEfgG       | For o, x, X, b, radix-1
-#            | (numeric fmt) | is used for negative numbers formatted as
-#            |               | complements.
+# Flag     | Applies to    | Meaning
+# ---------+---------------+--------------------------------------------
+# space    | bdiouxX       | Add a leading space character to
+#          | aAeEfgG       | non-negative numbers.
+#          | (numeric fmt) | For o, x, X, b, use
+#          |               | a minus sign with absolute value for
+#          |               | negative values.
+# ---------+---------------+--------------------------------------------
+# +        | bdiouxX       | Add a leading plus sign to non-negative
+#          | aAeEfgG       | numbers.
+#          | (numeric fmt) | For o, x, X, b, use
+#          |               | a minus sign with absolute value for
+#          |               | negative values.
+# ---------+---------------+--------------------------------------------
+# -        | all           | Left-justify the result of this conversion.
+# ---------+---------------+--------------------------------------------
+# 0 (zero) | bdiouxX       | Pad with zeros, not spaces.
+#          | aAeEfgG       | For o, x, X, b, radix-1
+#          | (numeric fmt) | is used for negative numbers formatted as
+#          |               | complements.
 # ```
 #
 # Examples of flags:

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -92,6 +92,8 @@ struct String::Formatter(A)
       case current_char
       when ' '
         flags.space = true
+      when '#'
+        flags.sharp = true
       when '+'
         flags.plus = true
       when '-'
@@ -283,6 +285,7 @@ struct String::Formatter(A)
 
     io = IO::Memory.new(Bytes.new(format_buf, capacity))
     io << '%'
+    io << '#' if flags.sharp
     io << '+' if flags.plus
     io << '-' if flags.minus
     io << '0' if flags.zero
@@ -360,12 +363,12 @@ struct String::Formatter(A)
   end
 
   struct Flags
-    property space : Bool, plus : Bool, minus : Bool, zero : Bool, base : Int32
+    property space : Bool, sharp : Bool, plus : Bool, minus : Bool, zero : Bool, base : Int32
     property width : Int32, width_size : Int32
     property type : Char, precision : Int32?, precision_size : Int32
 
     def initialize
-      @space = @plus = @minus = @zero = false
+      @space = @sharp = @plus = @minus = @zero = false
       @width = 0
       @width_size = 0
       @base = 10

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -110,7 +110,7 @@ struct String::Formatter(A)
 
   private def consume_width(flags)
     case current_char
-    when '0'..'9'
+    when '1'..'9'
       num, size = consume_number
       flags.width = num
       flags.width_size = size
@@ -125,7 +125,7 @@ struct String::Formatter(A)
   private def consume_precision(flags)
     if current_char == '.'
       case next_char
-      when '0'..'9'
+      when '1'..'9'
         num, size = consume_number
         flags.precision = num
         flags.precision_size = size


### PR DESCRIPTION
This removes redundant spaces in the [`sprintf`](https://crystal-lang.org/api/0.26.1/toplevel.html#sprintf%28format_string%2C%2Aargs%29%3AString-class-method) documentation. The spaces have just been copied from Ruby's [`sprintf.c`](https://github.com/ruby/ruby/blob/96db72ce38b27799dd8e80ca00696e41234db6ba/sprintf.c#L219). They are there because Ruby uses the 4-space-code-markdown but in Crystal that's not required because Crystal uses the ```-markdown.

And this also adds the missing `c` format flag. [It's documented](https://github.com/crystal-lang/crystal/blob/391785249f66aaf5929b787b29810aeb4af0e1e8/src/kernel.cr#L122) but not actually implemented.