### PR TITLE
disallow return types on abstract methods

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -844,8 +844,8 @@ module Crystal
     it_parses "def foo : Int32\n1\nend", Def.new("foo", body: 1.int32, return_type: "Int32".path)
     it_parses "def foo(x) : Int32\n1\nend", Def.new("foo", args: ["x".arg], body: 1.int32, return_type: "Int32".path)
 
-    it_parses "abstract def foo : Int32", Def.new("foo", return_type: "Int32".path, abstract: true)
-    it_parses "abstract def foo(x) : Int32", Def.new("foo", args: ["x".arg], return_type: "Int32".path, abstract: true)
+    assert_syntax_error "abstract def foo : Int32"
+    assert_syntax_error "abstract def foo(x) : Int32"
 
     it_parses "{% for x in y %}body{% end %}", MacroFor.new(["x".var], "y".var, "body".macro_literal)
     it_parses "{% if x %}body{% end %}", MacroIf.new("x".var, "body".macro_literal)
@@ -1665,7 +1665,6 @@ module Crystal
       assert_end_location "def foo; 1; end"
       assert_end_location "def foo; rescue ex; end"
       assert_end_location "abstract def foo"
-      assert_end_location "abstract def foo : Int32"
       assert_end_location "begin; 1; end"
       assert_end_location "class Foo; end"
       assert_end_location "struct Foo; end"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3366,6 +3366,9 @@ module Crystal
       end
 
       if @token.type == :":"
+        if is_abstract
+          raise "abstract methods cannot specify a return type"
+        end
         next_token_skip_space
         return_type = parse_single_type
         end_location = return_type.end_location

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -78,32 +78,32 @@ class File
   # A `File::Info` contains metadata regarding a file. It is returned by
   # `File.info`, and `File#info`.
   abstract struct Info
-    # Size of the file, in bytes.
-    abstract def size : UInt64
+    # Size (`UInt64`) of the file, in bytes.
+    abstract def size
 
-    # The permissions of the file.
-    abstract def permissions : Permissions
+    # The `Permissions` of the file.
+    abstract def permissions
 
-    # The type of the file.
-    abstract def type : Type
+    # The `Type` of the file.
+    abstract def type
 
-    # The special flags this file has set.
-    abstract def flags : Flags
+    # The special `Flags` this file has set.
+    abstract def flags
 
-    # The last time this file was modified.
-    abstract def modification_time : Time
+    # The last `Time` this file was modified.
+    abstract def modification_time
 
-    # The user ID of the file's owner.
-    abstract def owner : UInt32
+    # The user ID (`UInt32`) of the file's owner.
+    abstract def owner
 
-    # The group ID that the file belongs to.
-    abstract def group : UInt32
+    # The group ID (`UInt32`) that the file belongs to.
+    abstract def group
 
     # Returns true if this `Info` and *other* are of the same file.
     #
     # On unix, this compares device and inode fields, and will compare equal for
     # hard linked files.
-    abstract def same_file?(other : File::Info) : Bool
+    abstract def same_file?(other : File::Info)
 
     # Returns true if this `Info` represents a standard file. Shortcut for
     # `type.file?`.

--- a/src/io.cr
+++ b/src/io.cr
@@ -109,7 +109,7 @@ abstract class IO
   # io.write(slice)
   # io.to_s # => "abcd"
   # ```
-  abstract def write(slice : Bytes) : Nil
+  abstract def write(slice : Bytes)
 
   # Closes this `IO`.
   #

--- a/src/random.cr
+++ b/src/random.cr
@@ -62,11 +62,11 @@ module Random
     PCG32.new
   end
 
-  # Generates a random unsigned integer.
+  # Generates a random unsigned integer (`UInt`).
   #
   # The integers must be uniformly distributed between `0` and
   # the maximal value for the chosen type.
-  abstract def next_u : UInt
+  abstract def next_u
 
   # Generates a random `Bool`.
   #

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -49,7 +49,8 @@ class Socket
     def initialize(@family : Family, @size : Int32)
     end
 
-    abstract def to_unsafe : LibC::Sockaddr*
+    # The underlying OS representation, a `Pointer(LibC::Sockaddr)`.
+    abstract def to_unsafe
 
     def ==(other)
       false

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -1,6 +1,6 @@
 class Socket
   module Server
-    # Accepts an incoming connection and returns the client socket.
+    # Accepts an incoming connection and returns the client `Socket`.
     #
     # ```
     # require "socket"
@@ -14,9 +14,9 @@ class Socket
     # ```
     #
     # If the server is closed after invoking this method, an `IO::Error` (closed stream) exception must be raised.
-    abstract def accept : Socket
+    abstract def accept
 
-    # Accepts an incoming connection and returns the client socket.
+    # Accepts an incoming connection and returns the client `Socket`.
     #
     # Returns `nil` if the server is closed after invoking this method.
     #
@@ -29,7 +29,7 @@ class Socket
     #   socket.close
     # end
     # ```
-    abstract def accept? : Socket?
+    abstract def accept?
 
     # Accepts an incoming connection and yields the client socket to the block.
     # Eventually closes the connection when the block returns.


### PR DESCRIPTION
Addresses #3546

This is a breaking language change -- return types on abstract methods will need to be removed before code will compile.  These had no effect anyways, so after removal there should be no impacts. Nevertheless, breaking changes are an irritation.

The standard library had a handful of examples where abstract methods had return types.  For the most part the hoped-for return types were noted in the documentation instead.