### PR TITLE
Add support for specifying the build date

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -54,7 +54,7 @@ module Crystal
     end
 
     def self.date
-      {{ `date "+%Y-%m-%d"`.stringify.chomp }}
+      {{ env("CRYSTAL_CONFIG_BUILD_DATE") || `date "+%Y-%m-%d"`.stringify.chomp }}
     end
 
     def self.default_target_triple


### PR DESCRIPTION
Currently the compiler gets the compilation date embedded into it - instead allow a date to be specified (would typically be the release date) so that subsequent compilations would not be different.

Further to https://github.com/crystal-lang/crystal/issues/3973

Do you still require specs for something this small?

Tangibly, this will be used by https://github.com/NixOS/nixpkgs/pull/47166 instead of the ugly replacement I'm doing over there.