### PR TITLE
Fix YAML::Schema::FailSafe.parse and parse_all and add specs

### DIFF
--- a/spec/std/yaml/schema/fail_safe_spec.cr
+++ b/spec/std/yaml/schema/fail_safe_spec.cr
@@ -1,0 +1,71 @@
+require "spec"
+require "yaml"
+
+private def it_parses(string, expected, file = __FILE__, line = __LINE__)
+  it "parses #{string.inspect}", file, line do
+    YAML::Schema::FailSafe.parse(string).should eq(expected)
+  end
+end
+
+private def it_raises_on_parse(string, message, file = __FILE__, line = __LINE__)
+  it "raises on parse #{string.inspect}", file, line do
+    expect_raises(YAML::ParseException, message) do
+      YAML::Schema::FailSafe.parse(string)
+    end
+  end
+end
+
+private def it_parses_all(string, expected, file = __FILE__, line = __LINE__)
+  it "parses all #{string.inspect}", file, line do
+    YAML::Schema::FailSafe.parse_all(string).should eq(expected)
+  end
+end
+
+private def it_raises_on_parse_all(string, message, file = __FILE__, line = __LINE__)
+  it "raises on parse all #{string.inspect}", file, line do
+    expect_raises(YAML::ParseException, message) do
+      YAML::Schema::FailSafe.parse_all(string)
+    end
+  end
+end
+
+describe YAML::Schema::FailSafe do
+  # parse
+  it_parses "123", "123"
+  it_parses %(
+    context:
+        replace_me: "Yes please!"
+  ), {"context" => {"replace_me" => "Yes please!"}}
+  it_parses %(
+    first:
+      document:
+
+    second:
+      document:
+  ), {"first" => {"document" => ""}, "second" => {"document" => ""}}
+  it_raises_on_parse %(
+    this: "gives"
+      an: "error"
+  ), "did not find expected key at line 3, column 7, while parsing a block mapping at line 2, column 5"
+  it_raises_on_parse ":", "did not find expected key at line 1, column 1, while parsing a block mapping at line 1, column 1"
+
+  # parse_all
+  it_parses "321", "321"
+  it_parses_all %(
+    context:
+        replace_me: "Yes please!"
+  ), [{"context" => {"replace_me" => "Yes please!"}}]
+  it_parses_all %(
+    foo:
+      bar: 123
+
+    bar:
+      foo: 321
+  ), [{"foo" => {"bar" => "123"}, "bar" => {"foo" => "321"}}]
+  it_raises_on_parse_all %(
+    this: "raises"
+      an: "yaml"
+        parse: "exception"
+  ), "did not find expected key at line 3, column 7, while parsing a block mapping at line 2, column 5"
+  it_raises_on_parse_all ":", "did not find expected key at line 1, column 1, while parsing a block mapping at line 1, column 1"
+end

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -8,7 +8,7 @@ module YAML::Schema::FailSafe
   end
 
   # Deserializes multiple YAML documents.
-  def self.parse_all(data : String | IO) : Any
+  def self.parse_all(data : String | IO) : Array(Any)
     Parser.new data, &.parse_all
   end
 

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -35,7 +35,7 @@ module YAML::Schema::FailSafe
     end
 
     def cast_document(doc)
-      doc.first? || Any.new(nil)
+      doc[0]? || Any.new(nil)
     end
 
     def new_sequence


### PR DESCRIPTION
Fixes #6786 

Currently both [`YAML::Schema::FailSafe.parse`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse%28data%3AString%7CIO%29%3AAny-class-method) and [`YAML::Schema::FailSafe.parse_all`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse_all%28data%3AString%7CIO%29%3AAny-class-method) raise errors even if correct arguments are given.

In [`parse`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse%28data%3AString%7CIO%29%3AAny-class-method) using `first?` probably used to work but doesn't work anymore. So `[0]?` is now used instead.
At [`parse_all`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse_all%28data%3AString%7CIO%29%3AAny-class-method) the wrong return type is specified. It must be `Array(Any)`.

This also adds a new file called `fail_safe_spec.cr` with specs for [`parse`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse%28data%3AString%7CIO%29%3AAny-class-method) and [`parse_all`](https://crystal-lang.org/api/0.26.1/YAML/Schema/FailSafe.html#parse_all%28data%3AString%7CIO%29%3AAny-class-method).