### PR TITLE
Remove comment after :nodoc: in `URI.escape_one`

### DIFF
--- a/src/uri.cr
+++ b/src/uri.cr
@@ -348,7 +348,6 @@ class URI
   end
 
   # :nodoc:
-  # Unescapes one character. Private API
   def self.unescape_one(string, bytesize, i, byte, char, io, plus_to_space = false)
     if plus_to_space && char == '+'
       io.write_byte ' '.ord.to_u8


### PR DESCRIPTION
The `:nodoc:` is visible in the docs because of the comment under it: [`URI.unescape_one`](https://crystal-lang.org/api/0.26.1/URI.html#unescape_one%28string%2Cbytesize%2Ci%2Cbyte%2Cchar%2Cio%2Cplus_to_space%3Dfalse%2C%26block%29-class-method).