### PR TITLE
Fix ChecksumReader.write error

### DIFF
--- a/src/zip/checksum_reader.cr
+++ b/src/zip/checksum_reader.cr
@@ -25,7 +25,7 @@ module Zip
     end
 
     def write(slice : Bytes)
-      raise IO::Error.new "Can't read from Zip::Reader or Zip::File entry"
+      raise IO::Error.new "Can't write to Zip::Reader or Zip::File entry"
     end
   end
 end

--- a/src/zip/zip.cr
+++ b/src/zip/zip.cr
@@ -10,7 +10,7 @@ require "./*"
 # Two types are provided to read from zip files:
 # * `Zip::File`: can read zip entries from a `File` or from an `IO::Memory`
 # and provides random read access to its entries.
-# * `Zip::Reader`: can only read zip entries sequentially from any `IO.
+# * `Zip::Reader`: can only read zip entries sequentially from any `IO`.
 #
 # `Zip::File` is the preferred method to read zip files if you
 # can provide a `File`, because it's a bit more flexible and provides


### PR DESCRIPTION
This fixes an error which says "read from" even if the user tried to write to it.
And this adds a missing \`.