### PR TITLE
Add wrapping arithmetics operators

### DIFF
--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -1,0 +1,57 @@
+require "../../spec_helper"
+
+describe "Code gen: arithmetics primitives" do
+  describe "&+ addition" do
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around for {{type}}" do
+        run(%(
+          require "prelude"
+          {{type}}::MAX &+ {{type}}.new(1) == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "wrap around for {{type}} + Int64" do
+        run(%(
+          require "prelude"
+          {{type}}::MAX &+ 1_i64 == {{type}}::MIN
+        )).to_b.should be_true
+      end
+    {% end %}
+  end
+
+  describe "&- subtraction" do
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around for {{type}}" do
+        run(%(
+          require "prelude"
+          {{type}}::MIN &- {{type}}.new(1) == {{type}}::MAX
+        )).to_b.should be_true
+      end
+
+      it "wrap around for {{type}} - Int64" do
+        run(%(
+          require "prelude"
+          {{type}}::MIN &- 1_i64 == {{type}}::MAX
+        )).to_b.should be_true
+      end
+    {% end %}
+  end
+
+  describe "&* multiplication" do
+    {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      it "wrap around for {{type}}" do
+        run(%(
+          require "prelude"
+          ({{type}}::MAX / {{type}}.new(2) &+ {{type}}.new(1)) &* {{type}}.new(2) == {{type}}::MIN
+        )).to_b.should be_true
+      end
+
+      it "wrap around for {{type}} + Int64" do
+        run(%(
+          require "prelude"
+          ({{type}}::MAX / {{type}}.new(2) &+ {{type}}.new(1)) &* 2_i64 == {{type}}::MIN
+        )).to_b.should be_true
+      end
+    {% end %}
+  end
+end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -58,12 +58,24 @@ describe "Code gen: primitives" do
     run(%(1 + 2)).to_i.should eq(3)
   end
 
-  it "codegens 1 + 2" do
+  it "codegens 1 &+ 2" do
+    run(%(1 &+ 2)).to_i.should eq(3)
+  end
+
+  it "codegens 1 - 2" do
     run(%(1 - 2)).to_i.should eq(-1)
+  end
+
+  it "codegens 1 &- 2" do
+    run(%(1 &- 2)).to_i.should eq(-1)
   end
 
   it "codegens 2 * 3" do
     run(%(2 * 3)).to_i.should eq(6)
+  end
+
+  it "codegens 2 &* 3" do
+    run(%(2 &* 3)).to_i.should eq(6)
   end
 
   it "codegens 8.unsafe_div 3" do

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -125,9 +125,9 @@ class Crystal::CodeGenVisitor
     p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     case op
-    when "+"               then codegen_trunc_binary_op_result(t1, t2, builder.add(p1, p2))
-    when "-"               then codegen_trunc_binary_op_result(t1, t2, builder.sub(p1, p2))
-    when "*"               then codegen_trunc_binary_op_result(t1, t2, builder.mul(p1, p2))
+    when "+", "&+"         then codegen_trunc_binary_op_result(t1, t2, builder.add(p1, p2))
+    when "-", "&-"         then codegen_trunc_binary_op_result(t1, t2, builder.sub(p1, p2))
+    when "*", "&*"         then codegen_trunc_binary_op_result(t1, t2, builder.mul(p1, p2))
     when "/", "unsafe_div" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2))
     when "%", "unsafe_mod" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2))
     when "unsafe_shl"      then codegen_trunc_binary_op_result(t1, t2, builder.shl(p1, p2))

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -327,6 +327,12 @@ end
             @[Primitive(:binary)]
             def {{op.id}}(other : {{int2.id}}) : self
             end
+
+            # Returns the result of {{desc.id}} `self` and *other*.
+            # In case of overflow a wrapping is performed.
+            @[Primitive(:binary)]
+            def &{{op.id}}(other : {{int2.id}}) : self
+            end
           {% end %}
         {% end %}
 


### PR DESCRIPTION
This PR adds the semantics to the `&+` `&-` `&*` operators for integers operands.

After the next release it can be used in the std lib where wrapping semantics is explicitly needed.

Ref: #6223