### PR TITLE
Blur is only activated when modal is opened

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -553,6 +553,10 @@ span.flag.purple {
 .js-modal-visible .modal-background {
   display: flex;
 }
+.js-modal-visible .types-list,
+.js-modal-visible .main-content {
+  filter: blur(2px);
+}
 .modal-background {
   position: absolute;
   display: none;


### PR DESCRIPTION
Blur is only activated when modal is opened

Coincides with straight-shoota's request https://github.com/crystal-lang/crystal/pull/6764#issuecomment-423694501