### PR TITLE
Fix CSV.build about the corner case of quoting Chars and Symbols

### DIFF
--- a/spec/std/csv/csv_build_spec.cr
+++ b/spec/std/csv/csv_build_spec.cr
@@ -142,5 +142,22 @@ describe CSV do
       end
       string.should eq(%("1","doesn't"," , ","he said ""no"""\n))
     end
+
+    it "builds with inside quoted chars and symbols" do
+      string = CSV.build(quoting: CSV::Builder::Quoting::NONE) do |csv|
+        csv.row 'c', '\'', '"', :sym, :"s'm", :"s\"m"
+      end
+      string.should eq(%(c,',",sym,s'm,s"m\n))
+
+      string = CSV.build(quoting: CSV::Builder::Quoting::RFC) do |csv|
+        csv.row 'c', '\'', '"', :sym, :"s'm", :"s\"m"
+      end
+      string.should eq(%(c,',"""",sym,s'm,"s""m"\n))
+
+      string = CSV.build(quoting: CSV::Builder::Quoting::ALL) do |csv|
+        csv.row 'c', '\'', '"', :sym, :"s'm", :"s\"m"
+      end
+      string.should eq(%("c","'","""","sym","s'm","s""m"\n))
+    end
   end
 end


### PR DESCRIPTION
`CSV.build` now handles the corner case of quoting Chars and Symbols those contain quotes inside.
- related #6723 

```crystal
CSV.build do |csv|
  csv.row ','
  csv.row '"'
  csv.row :ab
  csv.row :"a,b"
  csv.row :"a\"b"
end
```

```
","
""""
ab
"a,b"
"a""b"
```

Best regards,