### PR TITLE
Refactor Socket to reuse Crystal::System::FileDescriptor

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1197,6 +1197,32 @@ describe "File" do
     end
   end
 
+  it "#close_on_exec?" do
+    File.open(datapath("test_file.txt")) do |file|
+      file.close_on_exec?.should be_true
+      file.close_on_exec = false
+      file.close_on_exec?.should be_false
+      file.close_on_exec = true
+      file.close_on_exec?.should be_true
+    end
+  end
+
+  it "#blocking?" do
+    File.open(datapath("test_file.txt")) do |file|
+      file.blocking.should be_true
+      file.blocking = false
+      file.blocking.should be_false
+      file.blocking = true
+      file.blocking.should be_true
+    end
+  end
+
+  it "#tty?" do
+    File.open(datapath("test_file.txt")) do |file|
+      file.tty?.should be_false
+    end
+  end
+
   describe ".match?" do
     it "matches basics" do
       File.match?("abc", "abc").should be_true

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -26,4 +26,30 @@ describe Socket do
     client.type.should eq(Socket::Type::STREAM)
     client.protocol.should eq(Socket::Protocol::TCP)
   end
+
+  it "#close_on_exec?" do
+    socket = Socket.tcp(Socket::Family::INET)
+    socket.close_on_exec?.should be_false
+    socket.close_on_exec = true
+    socket.close_on_exec?.should be_true
+    socket.close_on_exec = false
+    socket.close_on_exec?.should be_false
+  ensure
+    socket.try &.close
+  end
+
+  it "#blocking?" do
+    socket = Socket.tcp(Socket::Family::INET)
+    socket.blocking.should be_false
+    socket.blocking = true
+    socket.blocking.should be_true
+    socket.blocking = false
+    socket.blocking.should be_false
+  ensure
+    socket.try &.close
+  end
+
+  it "#tty?" do
+    Socket.tcp(Socket::Family::INET).tty?.should be_false
+  end
 end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -130,13 +130,13 @@ module Crystal::System::FileDescriptor
     event.add timeout
   end
 
-  private def system_close
+  private def system_close(error = "Error closing file")
     if LibC.close(@fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore
       else
-        raise Errno.new("Error closing file")
+        raise Errno.new(error)
       end
     end
   ensure


### PR DESCRIPTION
`Socket` wraps a file descriptor, similar to `IO::FileDescriptor` and many of methods for dealing with the basic libc file descriptor API have duplicate implementations in `Socket` and `Crystal::System::FileDescriptor`.  Thus I figure it makes sense to include the latter into `Socket` in order to reuse the same methods and instance variables.

