### PR TITLE
Added missing XML::Attributes#delete

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -359,4 +359,17 @@ describe XML do
     root["bar"] = 1
     root["bar"].should eq("1")
   end
+
+  it "deletes an attribute" do
+    doc = XML.parse(%{<foo bar="baz"></foo>})
+    root = doc.root.not_nil!
+
+    res = root.delete("bar")
+    root["bar"]?.should be_nil
+    root.to_s.should eq(%{<foo/>})
+    res.should eq "baz"
+
+    res = root.delete("biz")
+    res.should be_nil
+  end
 end

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -42,6 +42,12 @@ struct XML::Attributes
     value
   end
 
+  def delete(name : String)
+    value = self[name]?.try &.content
+    res = LibXML.xmlUnsetProp(@node, name)
+    value if res == 0
+  end
+
   def each : Nil
     return unless @node.element?
 

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -308,6 +308,8 @@ lib LibXML
 
   fun xmlSetProp(node : Node*, name : UInt8*, value : UInt8*) : Attr*
 
+  fun xmlUnsetProp(node : Node*, name : UInt8*) : Int
+
   fun xmlValidateNameValue(value : UInt8*) : Int
 end
 


### PR DESCRIPTION
Hello!

This adds the missing `XML::Attributes#delete` referenced in #3902. I wasn't sure about what kind of return value that would be appropriate so I went with what felt natural. 