### PR TITLE
Add step in Installation section in README template

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -99,6 +99,7 @@ dependencies:
     github: jsmith/example
 ```})
 
+        readme.should contain(%{and run `shards install`.})
         readme.should contain(%{TODO: Write a description here})
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
@@ -115,6 +116,7 @@ dependencies:
     github: jsmith/example
 ```})
 
+        readme.should_not contain(%{and run `shards install`.})
         readme.should contain(%{TODO: Write a description here})
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -99,7 +99,7 @@ dependencies:
     github: jsmith/example
 ```})
 
-        readme.should contain(%{and run `shards install`.})
+        readme.should contain(%{Then run `shards install`.})
         readme.should contain(%{TODO: Write a description here})
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
@@ -116,7 +116,7 @@ dependencies:
     github: jsmith/example
 ```})
 
-        readme.should_not contain(%{and run `shards install`.})
+        readme.should_not contain(%{Then run `shards install`.})
         readme.should contain(%{TODO: Write a description here})
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -13,7 +13,7 @@ dependencies:
     github: <%= config.github_name %>/<%= config.name %>
 ```
 
-and run `shards install`.
+Then run `shards install`.
 <%- else -%>
 TODO: Write installation instructions here
 <%- end -%>

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -12,6 +12,8 @@ dependencies:
   <%= config.name %>:
     github: <%= config.github_name %>/<%= config.name %>
 ```
+
+and run `shards install`.
 <%- else -%>
 TODO: Write installation instructions here
 <%- end -%>


### PR DESCRIPTION
This documents the `shards install` step in the Installation section of the README template.
Because actually the Installation section is without this step incomplete. That's not everything you need to do to install the shard so you can use it.
So now the Installation section for a shard would look like this:

---

## Installation

Add this to your application's `shard.yml`:
 
```yaml
dependencies:
  shard:
    github: user/shard
```

Then run `shards install`.