### PR TITLE
Fix empty case statement normalizes to condition expression

### DIFF
--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -13,6 +13,14 @@ describe "Code gen: case" do
     run("require \"prelude\"; case 1; when 0; 2; else; 3; end").to_i.should eq(3)
   end
 
+  it "codegens case without whens" do
+    run("require \"prelude\"; case 1; end").to_string.should eq ""
+  end
+
+  it "codegens case without whens but else" do
+    run("require \"prelude\"; case 1; else; 2; end").to_i.should eq(2)
+  end
+
   it "codegens case that always returns" do
     run("
       require \"prelude\"

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -102,7 +102,7 @@ describe "Normalize: case" do
   end
 
   it "normalizes case without when and else" do
-    assert_expand "case x; end", "x"
+    assert_expand "case x; end", "x\nnil"
   end
 
   it "normalizes case without when but else" do

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -376,12 +376,16 @@ module Crystal
 
       if node.whens.empty?
         expressions = [] of ASTNode
+
+        node_else = node.else
         if node_cond
           expressions << node_cond
+          expressions << NilLiteral.new unless node_else
         end
-        if node_else = node.else
+        if node_else
           expressions << node_else
         end
+
         return Expressions.new(expressions).at(node)
       end
 


### PR DESCRIPTION
After #6367, an empty case statement (without `when` or `else`) would be normalized to just the condition. This means that `case "foo"; else` is normalized to `"foo"`. But that's semantically incorrect. The return type of an empty `case` should just be `nil` because there is no branch that could return anything else.

This fix adds a `nil` after the condition when there are no `when` or `else` branches, so the example normalizes to `"foo"; nil`.

This PR also adds two codegen specs which are not necessary to document this fix, but they should have been added in #6367.