### PR TITLE
Let Zlib::Reader, Gzip::Reader and Flate::Reader include IO::Buffered for optimized performance

### DIFF
--- a/spec/std/flate/flate_spec.cr
+++ b/spec/std/flate/flate_spec.cr
@@ -1,14 +1,18 @@
 require "spec"
 require "flate"
 
+private def new_sample_io
+  io = IO::Memory.new
+  "cbc9cc4b350402ae1c20c30808b800".scan(/../).each do |match|
+    io.write_byte match[0].to_u8(16)
+  end
+  io.rewind
+end
+
 module Flate
   describe Reader do
     it "should read byte by byte (#4192)" do
-      io = IO::Memory.new
-      "cbc9cc4b350402ae1c20c30808b800".scan(/../).each do |match|
-        io.write_byte match[0].to_u8(16)
-      end
-      io.rewind
+      io = new_sample_io
 
       reader = Reader.new(io)
 
@@ -19,6 +23,15 @@ module Flate
       end
 
       str.should eq("line1111\nline2222\n")
+    end
+
+    it "should rewind" do
+      io = new_sample_io
+
+      reader = Reader.new(io)
+      reader.gets.should eq("line1111")
+      reader.rewind
+      reader.gets_to_end.should eq("line1111\nline2222\n")
     end
 
     describe ".open" do

--- a/spec/std/gzip/gzip_spec.cr
+++ b/spec/std/gzip/gzip_spec.cr
@@ -1,46 +1,60 @@
 require "spec"
 require "gzip"
 
+private SAMPLE_TIME     = Time.utc(2016, 1, 2)
+private SAMPLE_OS       = 4_u8
+private SAMPLE_EXTRA    = Bytes[1, 2, 3]
+private SAMPLE_NAME     = "foo.txt"
+private SAMPLE_COMMENT  = "some comment"
+private SAMPLE_CONTENTS = "hello world\nfoo bar"
+
+private def new_sample_io
+  io = IO::Memory.new
+
+  Gzip::Writer.open(io) do |gzip|
+    header = gzip.header
+    header.modification_time = SAMPLE_TIME
+    header.os = SAMPLE_OS
+    header.extra = SAMPLE_EXTRA
+    header.name = SAMPLE_NAME
+    header.comment = SAMPLE_COMMENT
+
+    io.bytesize.should eq(0)
+    gzip.flush
+    io.bytesize.should_not eq(0)
+
+    gzip.print SAMPLE_CONTENTS
+  end
+
+  io.rewind
+end
+
 describe Gzip do
   it "writes and reads to memory" do
-    io = IO::Memory.new
-
-    time = Time.utc(2016, 1, 2)
-    os = 4_u8
-    extra = Bytes[1, 2, 3]
-    name = "foo.txt"
-    comment = "some comment"
-    contents = "hello world"
-
-    Gzip::Writer.open(io) do |gzip|
-      header = gzip.header
-      header.modification_time = time
-      header.os = os
-      header.extra = extra
-      header.name = name
-      header.comment = comment
-
-      io.bytesize.should eq(0)
-      gzip.flush
-      io.bytesize.should_not eq(0)
-
-      gzip.print contents
-    end
-
-    io.rewind
+    io = new_sample_io
 
     Gzip::Reader.open(io) do |gzip|
       header = gzip.header.not_nil!
-      header.modification_time.should eq(time)
-      header.os.should eq(os)
-      header.extra.should eq(extra)
-      header.name.should eq(name)
-      header.comment.should eq(comment)
+      header.modification_time.should eq(SAMPLE_TIME)
+      header.os.should eq(SAMPLE_OS)
+      header.extra.should eq(SAMPLE_EXTRA)
+      header.name.should eq(SAMPLE_NAME)
+      header.comment.should eq(SAMPLE_COMMENT)
 
       # Reading zero bytes is OK
       gzip.read(Bytes.empty).should eq(0)
 
-      gzip.gets_to_end.should eq(contents)
+      gzip.gets_to_end.should eq(SAMPLE_CONTENTS)
     end
+  end
+
+  it "rewinds" do
+    io = new_sample_io
+
+    gzip = Gzip::Reader.new(io)
+    gzip.gets.should eq(SAMPLE_CONTENTS.lines.first)
+
+    gzip.rewind
+    gzip.gets_to_end.should eq(SAMPLE_CONTENTS)
   end
 end

--- a/src/gzip/reader.cr
+++ b/src/gzip/reader.cr
@@ -27,6 +27,8 @@
 # string # => "abc"
 # ```
 class Gzip::Reader < IO
+  include IO::Buffered
+
   # Whether to close the enclosed `IO` when closing this reader.
   property? sync_close = false
 
@@ -73,7 +75,7 @@ class Gzip::Reader < IO
   end
 
   # See `IO#read`.
-  def read(slice : Bytes)
+  def unbuffered_read(slice : Bytes)
     check_open
 
     return 0 if slice.empty?
@@ -121,16 +123,31 @@ class Gzip::Reader < IO
   end
 
   # Always raises `IO::Error` because this is a read-only `IO`.
-  def write(slice : Bytes) : Nil
+  def unbuffered_write(slice : Bytes) : Nil
     raise IO::Error.new("Can't write to Gzip::Reader")
   end
 
+  def unbuffered_flush
+    raise IO::Error.new "Can't flush Gzip::Reader"
+  end
+
   # Closes this reader.
-  def close
+  def unbuffered_close
     return if @closed
     @closed = true
 
     @flate_io.try &.close
     @io.close if @sync_close
+  end
+
+  def unbuffered_rewind
+    raise IO::Error.new "Closed stream" if closed?
+
+    @io.rewind
+
+    @header = nil
+    @flate_io = nil
+
+    initialize(@io, @sync_close)
   end
 end

--- a/src/zlib/reader.cr
+++ b/src/zlib/reader.cr
@@ -4,6 +4,8 @@
 # instance, it reads data from the underlying IO, decompresses it, and returns
 # it to the caller.
 class Zlib::Reader < IO
+  include IO::Buffered
+
   # Whether to close the enclosed `IO` when closing this reader.
   property? sync_close = false
 
@@ -56,7 +58,7 @@ class Zlib::Reader < IO
   end
 
   # See `IO#read`.
-  def read(slice : Bytes)
+  def unbuffered_read(slice : Bytes)
     check_open
 
     return 0 if slice.empty?
@@ -79,16 +81,28 @@ class Zlib::Reader < IO
   end
 
   # Always raises `IO::Error` because this is a read-only `IO`.
-  def write(slice : Bytes)
+  def unbuffered_write(slice : Bytes)
     raise IO::Error.new "Can't write to Zlib::Reader"
   end
 
-  def close
+  def unbuffered_flush
+    raise IO::Error.new "Can't flush Zlib::Reader"
+  end
+
+  def unbuffered_close
     return if @closed
     @closed = true
 
     @flate_io.close
     @io.close if @sync_close
+  end
+
+  def unbuffered_rewind
+    raise IO::Error.new "Closed stream" if closed?
+
+    @io.rewind
+
+    initialize(@io, @sync_close, @flate_io.dict)
   end
 
   protected def self.invalid_header


### PR DESCRIPTION
All of these readers wrap another IO from which they read. The problem is that when using methods like `gets` which read until some character is found, usually a newline, it's much faster to use input buffering to read a lot of bytes at once instead of going byte per byte (or worse, utf-8 char per char). The `gets` method actually relies on a `peek` method to peek next bytes if available to perform the scan faster, and the easiest way to accomplish this is by including `IO::Buffered`, which implements this.

(There _might_ be a way to implement this without include `IO::Buffered`, maybe for example in `Zlib::Reader` having an output buffer similar to the one in `IO::Buffered`, and reading there and copying from that to the requested slice by `read`, but that's basically duplicating the work that's done in `IO::Buffered`, so it's probably not worth it).

Note that this will require an additional 8KB of memory for each of these IOs, but that's fine because one usually doesn't deal with a lot of IOs at a time.

This optimization happened because the slowness was [discovered in IRC](https://gitter.im/crystal-lang/crystal?at=5bb999143844923661f7abb1).

Also checking what Python does, their gzip reader is buffered too (and I guess that's the case for Ruby too).

(An additional research, if someone wants to tackle this, is checking whether other IOs in the std, notably HTTP responses, might need this optimization too.)

Benchmark follows:

```crystal
require "gzip"
require "zlib"
require "flate"

FILENAME = "test.gzip"

def benchmark(type : T.class) forall T
  File.open(FILENAME, "w") do |file|
    T::Writer.open(file) do |writer|
      1_000_000.times do |i|
        writer.puts "This is line number #{i}"
      end
    end
  end

  i = 0
  puts "#{T}:"
  puts Time.measure {
    File.open(FILENAME) do |file|
      T::Reader.open(file) do |reader|
        reader.each_line do
          i += 1
        end
      end
    end
  }

  puts i
end

benchmark(Gzip)
benchmark(Zlib)
benchmark(Flate)
```

Old output:

```
Gzip:
00:00:03.052840054
1000000
Zlib:
00:00:02.439849829
1000000
Flate:
00:00:01.947586854
1000000
```

New output:

```
Gzip:
00:00:00.103666309
1000000
Zlib:
00:00:00.095306070
1000000
Flate:
00:00:00.090960507
1000000
```

Gzip: 29 times faster
Zlib: 25 times faster
Flate: 21 times faster