### PR TITLE
Fixed OpenSSL bindings to work with LibreSSL

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -53,7 +53,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Client)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if LibSSL::OPENSSL_111 %}
+    {% if LibSSL::OPENSSL_VERSION >= 0x10101000 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -67,7 +67,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Server)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if LibSSL::OPENSSL_111 %}
+    {% if LibSSL::OPENSSL_VERSION >= 0x10101000 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -162,7 +162,7 @@ describe OpenSSL::SSL::Context do
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
   end
 
-  {% if LibSSL::OPENSSL_102 %}
+  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
   it "alpn_protocol=" do
     context = OpenSSL::SSL::Context::Client.insecure
     context.alpn_protocol = "h2"

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -53,7 +53,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Client)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if LibSSL::OPENSSL_VERSION >= 0x10101000 %}
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -67,7 +67,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Server)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if LibSSL::OPENSSL_VERSION >= 0x10101000 %}
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -162,7 +162,7 @@ describe OpenSSL::SSL::Context do
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
   end
 
-  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
   it "alpn_protocol=" do
     context = OpenSSL::SSL::Context::Client.insecure
     context.alpn_protocol = "h2"

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -90,7 +90,7 @@ module OpenSSL
     alias Options = LibSSL::Options
     alias VerifyMode = LibSSL::VerifyMode
     alias ErrorType = LibSSL::SSLError
-    {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
     alias X509VerifyFlags = LibCrypto::X509VerifyFlags
     {% end %}
 

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -90,7 +90,7 @@ module OpenSSL
     alias Options = LibSSL::Options
     alias VerifyMode = LibSSL::VerifyMode
     alias ErrorType = LibSSL::SSLError
-    {% if LibSSL::OPENSSL_102 %}
+    {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
     alias X509VerifyFlags = LibCrypto::X509VerifyFlags
     {% end %}
 

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -3,7 +3,7 @@ require "./lib_crypto"
 # :nodoc:
 struct OpenSSL::BIO
   def self.get_data(bio) : Void*
-    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibCrypto.BIO_get_data(bio)
     {% else %}
       bio.value.ptr
@@ -11,7 +11,7 @@ struct OpenSSL::BIO
   end
 
   def self.set_data(bio, data : Void*)
-    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibCrypto.BIO_set_data(bio, data)
     {% else %}
       bio.value.ptr = data
@@ -65,7 +65,7 @@ struct OpenSSL::BIO
     end
 
     create = LibCrypto::BioMethodCreate.new do |bio|
-      {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
         LibCrypto.BIO_set_shutdown(bio, 1)
         LibCrypto.BIO_set_init(bio, 1)
         # bio.value.num = -1
@@ -82,10 +82,10 @@ struct OpenSSL::BIO
       1
     end
 
-    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
       biom = LibCrypto.BIO_meth_new(Int32::MAX, "Crystal BIO")
 
-      {% if LibCrypto::OPENSSL_VERSION >= 0x10101000 %}
+      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.1") >= 0 %}
         LibCrypto.BIO_meth_set_write_ex(biom, bwrite_ex)
         LibCrypto.BIO_meth_set_read_ex(biom, bread_ex)
       {% else %}

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -3,7 +3,7 @@ require "./lib_crypto"
 # :nodoc:
 struct OpenSSL::BIO
   def self.get_data(bio) : Void*
-    {% if LibCrypto::OPENSSL_110 %}
+    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
       LibCrypto.BIO_get_data(bio)
     {% else %}
       bio.value.ptr
@@ -11,7 +11,7 @@ struct OpenSSL::BIO
   end
 
   def self.set_data(bio, data : Void*)
-    {% if LibCrypto::OPENSSL_110 %}
+    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
       LibCrypto.BIO_set_data(bio, data)
     {% else %}
       bio.value.ptr = data
@@ -65,7 +65,7 @@ struct OpenSSL::BIO
     end
 
     create = LibCrypto::BioMethodCreate.new do |bio|
-      {% if LibCrypto::OPENSSL_110 %}
+      {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
         LibCrypto.BIO_set_shutdown(bio, 1)
         LibCrypto.BIO_set_init(bio, 1)
         # bio.value.num = -1
@@ -82,10 +82,10 @@ struct OpenSSL::BIO
       1
     end
 
-    {% if LibCrypto::OPENSSL_110 %}
+    {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
       biom = LibCrypto.BIO_meth_new(Int32::MAX, "Crystal BIO")
 
-      {% if LibCrypto::OPENSSL_111 %}
+      {% if LibCrypto::OPENSSL_VERSION >= 0x10101000 %}
         LibCrypto.BIO_meth_set_write_ex(biom, bwrite_ex)
         LibCrypto.BIO_meth_set_read_ex(biom, bread_ex)
       {% else %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,15 +1,16 @@
 {% begin %}
   lib LibCrypto
-    {% from_libressl = (`command -v pkg-config > /dev/null || printf %s false` != "false") &&
+    {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                        (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
-                       (`printf %s "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libcrypto || true`.chomp}  -E -`.chomp.split('\n').last == "LIBRESSL_VERSION_NUMBER") %}
+                       (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+    {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
 
     {% if from_libressl %}
-      LIBRESSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last }}
+      LIBRESSL_VERSION = {{ ssl_version }}
       OPENSSL_VERSION = "0.0.0"
     {% else %}
       LIBRESSL_VERSION = "0.0.0"
-      OPENSSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last }}
+      OPENSSL_VERSION = {{ ssl_version }}
     {% end %}
   end
 {% end %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,29 +1,15 @@
 {% begin %}
   lib LibCrypto
-    {% if `command -v pkg-config > /dev/null || printf %s false` != "false" %}
-      {% if `test -f $(pkg-config --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false" %}
-        {% libressl_version_number = `printf %s "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libcrypto || true`.chomp}  -E -`.chomp.split.last %}
-        LIBRESSL_VERSION = {{ (libressl_version_number == "LIBRESSL_VERSION_NUMBER") ? 0 : libressl_version_number.split('L').first.split("0x").last.to_i(16) }}
-        {% if libressl_version_number == "LIBRESSL_VERSION_NUMBER" %}
-          OPENSSL_VERSION = {{ `printf %s "#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libcrypto || true`.chomp}  -E -`.chomp.split.last.split("L").first.id }}
-        {% else %}
-          OPENSSL_VERSION = 0
-        {% end %}
-      {% else %}
-        LIBRESSL_VERSION = 0
-        {% if `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.1 libcrypto || printf %s false`.stringify != "false" %}
-          OPENSSL_VERSION = 0x10101000
-        {% elsif `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libcrypto || printf %s false`.stringify != "false" %}
-          OPENSSL_VERSION = 0x10100000
-        {% elsif `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libcrypto || printf %s false`.stringify != "false" %}
-          OPENSSL_VERSION = 0x10002000
-        {% else %}
-          OPENSSL_VERSION = 0
-        {% end %}
-      {% end %}
+    {% from_libressl = (`command -v pkg-config > /dev/null || printf %s false` != "false") &&
+                       (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
+                       (`printf %s "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libcrypto || true`.chomp}  -E -`.chomp.split('\n').last == "LIBRESSL_VERSION_NUMBER") %}
+
+    {% if from_libressl %}
+      LIBRESSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last }}
+      OPENSSL_VERSION = "0.0.0"
     {% else %}
-      OPENSSL_VERSION = 0
-      LIBRESSL_VERSION = 0
+      LIBRESSL_VERSION = "0.0.0"
+      OPENSSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last }}
     {% end %}
   end
 {% end %}
@@ -79,7 +65,7 @@ lib LibCrypto
   alias BioMethodDestroy = Bio* -> Int
   alias BioMethodCallbackCtrl = (Bio*, Int, Void*) -> Long
 
-  {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
     type BioMethod = Void
   {% else %}
     struct BioMethod
@@ -103,7 +89,7 @@ lib LibCrypto
   fun BIO_set_init(Bio*, Int)
   fun BIO_set_shutdown(Bio*, Int)
 
-  {% if LibCrypto::OPENSSL_VERSION >= 0x10100000 %}
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun BIO_meth_new(Int, Char*) : BioMethod*
     fun BIO_meth_set_read(BioMethod*, BioMethodReadOld)
     fun BIO_meth_set_write(BioMethod*, BioMethodWriteOld)
@@ -114,7 +100,7 @@ lib LibCrypto
     fun BIO_meth_set_destroy(BioMethod*, BioMethodDestroy)
     fun BIO_meth_set_callback_ctrl(BioMethod*, BioMethodCallbackCtrl)
   {% end %}
-  {% if LibCrypto::OPENSSL_VERSION >= 0x10101000 %}
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.1") >= 0 %}
     fun BIO_meth_set_read_ex(BioMethod*, BioMethodRead)
     fun BIO_meth_set_write_ex(BioMethod*, BioMethodWrite)
   {% end %}
@@ -187,7 +173,7 @@ lib LibCrypto
   fun evp_md_block_size = EVP_MD_block_size(md : EVP_MD) : LibC::Int
   fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx : EVP_MD_CTX, md : UInt8*, size : UInt32*) : Int32
 
-  {% if OPENSSL_VERSION >= 0x10100000 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun evp_md_ctx_new = EVP_MD_CTX_new : EVP_MD_CTX
     fun evp_md_ctx_free = EVP_MD_CTX_free(ctx : EVP_MD_CTX)
   {% else %}
@@ -255,7 +241,7 @@ lib LibCrypto
   NID_commonName       = 13
   NID_subject_alt_name = 85
 
-  {% if OPENSSL_VERSION >= 0x10100000 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun sk_free = OPENSSL_sk_free(st : Void*)
     fun sk_num = OPENSSL_sk_num(x0 : Void*) : Int
     fun sk_pop_free = OPENSSL_sk_pop_free(st : Void*, callback : (Void*) ->)
@@ -300,12 +286,12 @@ lib LibCrypto
   fun x509v3_ext_nconf_nid = X509V3_EXT_nconf_nid(conf : Void*, ctx : Void*, ext_nid : Int, value : Char*) : X509_EXTENSION
   fun x509v3_ext_print = X509V3_EXT_print(out : Bio*, ext : X509_EXTENSION, flag : Int, indent : Int) : Int
 
-  {% unless OPENSSL_VERSION >= 0x10100000 %}
+  {% unless compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun err_load_crypto_strings = ERR_load_crypto_strings
     fun openssl_add_all_algorithms = OPENSSL_add_all_algorithms_noconf
   {% end %}
 
-  {% if OPENSSL_VERSION >= 0x10002000 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}
     type X509VerifyParam = Void*
 
     @[Flags]

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -2,9 +2,31 @@ require "./lib_crypto"
 
 {% begin %}
   lib LibSSL
-    OPENSSL_111 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.1 libssl || printf %s false`.stringify != "false" }}
-    OPENSSL_110 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libssl || printf %s false`.stringify != "false" }}
-    OPENSSL_102 = {{ `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libssl || printf %s false`.stringify != "false" }}
+    {% if `command -v pkg-config > /dev/null || printf %s false` != "false" %}
+      {% if `test -f $(pkg-config --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false" %}
+        {% libressl_version_number = `printf %s "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libssl || true`.chomp}  -E -`.chomp.split.last %}
+        LIBRESSL_VERSION = {{ (libressl_version_number == "LIBRESSL_VERSION_NUMBER") ? 0 : libressl_version_number.split('L').first.split("0x").last.to_i(16) }}
+        {% if libressl_version_number == "LIBRESSL_VERSION_NUMBER" %}
+          OPENSSL_VERSION = {{ `printf %s "#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libssl || true`.chomp}  -E -`.chomp.split.last.split("L").first.id }}
+        {% else %}
+          OPENSSL_VERSION = 0
+        {% end %}
+      {% else %}
+        LIBRESSL_VERSION = 0
+        {% if `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.1 libssl|| printf %s false`.stringify != "false" %}
+          OPENSSL_VERSION = 0x10101000
+        {% elsif `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.1.0 libssl || printf %s false`.stringify != "false" %}
+          OPENSSL_VERSION = 0x10100000
+        {% elsif `command -v pkg-config > /dev/null && pkg-config --atleast-version=1.0.2 libssl || printf %s false`.stringify != "false" %}
+          OPENSSL_VERSION = 0x10002000
+        {% else %}
+          OPENSSL_VERSION = 0
+        {% end %}
+      {% end %}
+    {% else %}
+      OPENSSL_VERSION = 0
+      LIBRESSL_VERSION = 0
+    {% end %}
   end
 {% end %}
 
@@ -93,7 +115,7 @@ lib LibSSL
     NETSCAPE_DEMO_CIPHER_CHANGE_BUG = 0x40000000
     CRYPTOPRO_TLSEXT_BUG            = 0x80000000
 
-    {% if OPENSSL_110 %}
+    {% if OPENSSL_VERSION >= 0x10100000 %}
       MICROSOFT_SESS_ID_BUG            = 0x00000000
       NETSCAPE_CHALLENGE_BUG           = 0x00000000
       NETSCAPE_REUSE_CIPHER_CHANGE_BUG = 0x00000000
@@ -179,7 +201,7 @@ lib LibSSL
   fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSLContext) : Int
   fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : ULong, parg : Void*) : ULong
 
-  {% if OPENSSL_110 %}
+  {% if OPENSSL_VERSION >= 0x10100000 %}
     fun ssl_ctx_get_options = SSL_CTX_get_options(ctx : SSLContext) : ULong
     fun ssl_ctx_set_options = SSL_CTX_set_options(ctx : SSLContext, larg : ULong) : ULong
     fun ssl_ctx_clear_options = SSL_CTX_clear_options(ctx : SSLContext, larg : ULong) : ULong
@@ -191,7 +213,7 @@ lib LibSSL
   # Hostname validation for OpenSSL <= 1.0.1
   fun ssl_ctx_set_cert_verify_callback = SSL_CTX_set_cert_verify_callback(ctx : SSLContext, callback : CertVerifyCallback, arg : Void*)
 
-  {% if OPENSSL_110 %}
+  {% if OPENSSL_VERSION >= 0x10100000 %}
     fun tls_method = TLS_method : SSLMethod
   {% else %}
     fun ssl_library_init = SSL_library_init
@@ -199,19 +221,23 @@ lib LibSSL
     fun sslv23_method = SSLv23_method : SSLMethod
   {% end %}
 
-  {% if OPENSSL_102 %}
+  {% if OPENSSL_VERSION >= 0x10002000 || LIBRESSL_VERSION >= 0x20500000 %}
     alias ALPNCallback = (SSL, Char**, Char*, Char*, Int, Void*) -> Int
+
+    fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
+    fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
+  {% end %}
+
+  {% if OPENSSL_VERSION >= 0x10002000 %}
     alias X509VerifyParam = LibCrypto::X509VerifyParam
 
     fun ssl_get0_param = SSL_get0_param(handle : SSL) : X509VerifyParam
-    fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
-    fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
     fun ssl_ctx_get0_param = SSL_CTX_get0_param(ctx : SSLContext) : X509VerifyParam
     fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int
   {% end %}
 end
 
-{% unless LibSSL::OPENSSL_110 %}
+{% unless LibSSL::OPENSSL_VERSION >= 0x10100000 %}
   LibSSL.ssl_library_init
   LibSSL.ssl_load_error_strings
   LibCrypto.openssl_add_all_algorithms

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -2,16 +2,17 @@ require "./lib_crypto"
 
 {% begin %}
   lib LibSSL
-    {% from_libressl = (`command -v pkg-config > /dev/null || printf %s false` != "false") &&
+    {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                        (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&
-                       (`printf %s "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | #{(env("CC") || "cc").id} #{`pkg-config --cflags --silence-errors libssl || true`.chomp}  -E -`.chomp.split('\n').last == "LIBRESSL_VERSION_NUMBER") %}
+                       (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+    {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
 
     {% if from_libressl %}
-      LIBRESSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") }}
+      LIBRESSL_VERSION = {{ ssl_version }}
       OPENSSL_VERSION = "0.0.0"
     {% else %}
       LIBRESSL_VERSION = "0.0.0"
-      OPENSSL_VERSION = {{ `command -v pkg-config > /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") }}
+      OPENSSL_VERSION = {{ ssl_version }}
     {% end %}
   end
 {% end %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -3,7 +3,7 @@ require "uri/punycode"
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method
-    {% if LibSSL::OPENSSL_110 %}
+    {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
       LibSSL.tls_method
     {% else %}
       LibSSL.sslv23_method
@@ -81,7 +81,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-      {% if LibSSL::OPENSSL_102 %}
+      {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
       self.default_verify_param = "ssl_server"
       {% end %}
     end
@@ -157,7 +157,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
-      {% if LibSSL::OPENSSL_102 %}
+      {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
       self.default_verify_param = "ssl_client"
       {% end %}
 
@@ -301,7 +301,7 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the current options set on the TLS context.
   def options
-    opts = {% if LibSSL::OPENSSL_110 %}
+    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
       LibSSL.ssl_ctx_get_options(@handle)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
@@ -320,7 +320,7 @@ abstract class OpenSSL::SSL::Context
   # )
   # ```
   def add_options(options : OpenSSL::SSL::Options)
-    opts = {% if LibSSL::OPENSSL_110 %}
+    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
       LibSSL.ssl_ctx_set_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
@@ -335,7 +335,7 @@ abstract class OpenSSL::SSL::Context
   # context.remove_options(OpenSSL::SSL::Options::NO_SSL_V3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
-    opts = {% if LibSSL::OPENSSL_110 %}
+    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
       LibSSL.ssl_ctx_clear_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
@@ -353,7 +353,7 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  {% if LibSSL::OPENSSL_102 %}
+  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
 
   @alpn_protocol : Pointer(Void)?
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -3,7 +3,7 @@ require "uri/punycode"
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method
-    {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.tls_method
     {% else %}
       LibSSL.sslv23_method
@@ -81,7 +81,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-      {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
       self.default_verify_param = "ssl_server"
       {% end %}
     end
@@ -157,7 +157,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
-      {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
       self.default_verify_param = "ssl_client"
       {% end %}
 
@@ -301,7 +301,7 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the current options set on the TLS context.
   def options
-    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
+    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.ssl_ctx_get_options(@handle)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
@@ -320,7 +320,7 @@ abstract class OpenSSL::SSL::Context
   # )
   # ```
   def add_options(options : OpenSSL::SSL::Options)
-    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
+    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.ssl_ctx_set_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
@@ -335,7 +335,7 @@ abstract class OpenSSL::SSL::Context
   # context.remove_options(OpenSSL::SSL::Options::NO_SSL_V3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
-    opts = {% if LibSSL::OPENSSL_VERSION >= 0x10100000 %}
+    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.ssl_ctx_clear_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
@@ -353,7 +353,7 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
 
   @alpn_protocol : Pointer(Void)?
 

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -12,7 +12,7 @@ abstract class OpenSSL::SSL::Socket < IO
           hostname.to_unsafe.as(Pointer(Void))
         )
 
-        {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+        {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
           param = LibSSL.ssl_get0_param(@ssl)
 
           if ::Socket.ip?(hostname)
@@ -129,7 +129,7 @@ abstract class OpenSSL::SSL::Socket < IO
     @bio.io.flush
   end
 
-  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
+  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
   # Returns the negotiated ALPN protocol (eg: `"h2"`) of `nil` if no protocol was
   # negotiated.
   def alpn_protocol

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -12,7 +12,7 @@ abstract class OpenSSL::SSL::Socket < IO
           hostname.to_unsafe.as(Pointer(Void))
         )
 
-        {% if LibSSL::OPENSSL_102 %}
+        {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
           param = LibSSL.ssl_get0_param(@ssl)
 
           if ::Socket.ip?(hostname)
@@ -129,7 +129,7 @@ abstract class OpenSSL::SSL::Socket < IO
     @bio.io.flush
   end
 
-  {% if LibSSL::OPENSSL_102 %}
+  {% if LibSSL::OPENSSL_VERSION >= 0x10002000 %}
   # Returns the negotiated ALPN protocol (eg: `"h2"`) of `nil` if no protocol was
   # negotiated.
   def alpn_protocol


### PR DESCRIPTION
- Reworked #5676 with sane fallbacks, like falling back to using just `pkg-config` if the header files are inaccessible.
- Replaced flags like `OPENSSL_110` with actual version number values e.g. `OPENSSL_VERSION` is `0x10102000` when its version is `1.1.2`.
- When we can't check the headers but can use `pkg-config`, we assume OpenSSL is installed and set the version values accordingly. Although this behavior is a bit iffy for systems that have LibreSSL installed without the headers but the current behavior also works exactly like this AFAIU.