### PR TITLE
adds some inline docs to hash constructors

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -16,22 +16,18 @@ class Hash(K, V)
   # Creates a new empty `Hash` with a *block* for handling missing keys.
   #
   # ```
-  # def foo(&block : (Hash(String, Int32), String -> Int32))
-  #   hash = Hash(String, Int32).new(block)
-  #   hash.size   # => 0
-  #   hash["foo"] # => 3
-  #   hash.size   # => 1
-  #   hash["bar"] = 10
-  #   hash["bar"] # => 10
-  # end
+  # proc = ->(hash : Hash(String, Int32), key : String) { hash[key] = key.size }
+  # hash = Hash(String, Int32).new(proc)
   #
-  # foo do |hash, key|
-  #   hash[key] = key.size
-  # end
+  # hash.size   # => 0
+  # hash["foo"] # => 3
+  # hash.size   # => 1
+  # hash["bar"] = 10
+  # hash["bar"] # => 10
   # ```
   #
   # The *initial_capacity* is useful to avoid unnecessary reallocations
-  # of the internal buffer in case of growth. If the maximum number of elements
+  # of the internal buffer in case of growth. If the number of elements
   # a hash will hold is known, the hash should be initialized with that
   # capacity for improved performance. Otherwise, the default is 11 and inputs
   # less than 11 are ignored.
@@ -60,7 +56,7 @@ class Hash(K, V)
   # ```
   #
   # The *initial_capacity* is useful to avoid unnecessary reallocations
-  # of the internal buffer in case of growth. If the maximum number of elements
+  # of the internal buffer in case of growth. If the number of elements
   # a hash will hold is known, the hash should be initialized with that
   # capacity for improved performance. Otherwise, the default is 11 and inputs
   # less than 11 are ignored.
@@ -83,6 +79,12 @@ class Hash(K, V)
   # hash["3"][1] = 4
   # arr # => [1, 4, 3]
   # ```
+  #
+  # The *initial_capacity* is useful to avoid unnecessary reallocations
+  # of the internal buffer in case of growth. If the number of elements
+  # a hash will hold is known, the hash should be initialized with that
+  # capacity for improved performance. Otherwise, the default is 11 and inputs
+  # less than 11 are ignored.
   def self.new(default_value : V, initial_capacity = nil)
     new(initial_capacity: initial_capacity) { default_value }
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -13,6 +13,7 @@ class Hash(K, V)
   @last : Entry(K, V)?
   @block : (self, K -> V)?
 
+  # :nodoc:
   def initialize(block : (Hash(K, V), K -> V)? = nil, initial_capacity = nil)
     initial_capacity ||= 11
     initial_capacity = 11 if initial_capacity < 11
@@ -23,10 +24,36 @@ class Hash(K, V)
     @block = block
   end
 
+  # Creates a new empty `Hash` of *initial_capacity* with a *block* that handles missing keys.
+  #
+  # The *initial_capacity* is useful to avoid unnecessary reallocations
+  # of the internal buffer in case of growth. If you have an estimate
+  # of the maximum number of elements a hash will hold, the hash should
+  # be initialized with that capacity for improved performance.
+  #
+  # NOTE: *initial_capacity* defaults to 11 and an input of < 11 is ignored.
+  # NOTE: `#size` does not reflect capacity as in `Array`.
+  #
+  # ```
+  # new_hash = Hash(Int32, String).new(5) do |hash, key|
+  #  hash[key-1] ? hash[key-1] : 0
+  # end
+  # new_hash.size # => 0
+  # new_hash[0] = "zero"
+  # new_hash[2] = "two"
+  # new_hash[1] # => "zero"
+  # new_hash[3] # => "two"
+  # ```
   def self.new(initial_capacity = nil, &block : (Hash(K, V), K -> V))
     new block, initial_capacity: initial_capacity
   end
 
+  # Creates a new empty `Hash` where the *default_value* is returned if key is missing.
+  #
+  # ```
+  # new_hash = Hash(Int32, String).new("not found")
+  # new_hash[0] # => "not found"
+  # ```
   def self.new(default_value : V, initial_capacity = nil)
     new(initial_capacity: initial_capacity) { default_value }
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -35,14 +35,13 @@ class Hash(K, V)
   # NOTE: `#size` does not reflect capacity as in `Array`.
   #
   # ```
-  # new_hash = Hash(Int32, String).new(5) do |hash, key|
-  #  hash[key-1] ? hash[key-1] : 0
+  # new_hash = Hash(String, Int32).new(50) do |hash, key|
+  #   key.size
   # end
   # new_hash.size # => 0
-  # new_hash[0] = "zero"
-  # new_hash[2] = "two"
-  # new_hash[1] # => "zero"
-  # new_hash[3] # => "two"
+  # new_hash["zero"] = 0
+  # new_hash["two"] = 2
+  # new_hash["four"] # => 4
   # ```
   def self.new(initial_capacity = nil, &block : (Hash(K, V), K -> V))
     new block, initial_capacity: initial_capacity
@@ -51,8 +50,9 @@ class Hash(K, V)
   # Creates a new empty `Hash` where the *default_value* is returned if key is missing.
   #
   # ```
-  # new_hash = Hash(Int32, String).new("not found")
-  # new_hash[0] # => "not found"
+  # inventory = Hash(String, Int32).new(0)
+  # inventory["socks"] = 3
+  # inventory["pickles"] # => 0
   # ```
   def self.new(default_value : V, initial_capacity = nil)
     new(initial_capacity: initial_capacity) { default_value }

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -13,35 +13,24 @@ class Hash(K, V)
   @last : Entry(K, V)?
   @block : (self, K -> V)?
 
-  # :nodoc:
-  def initialize(block : (Hash(K, V), K -> V)? = nil, initial_capacity = nil)
-    initial_capacity ||= 11
-    initial_capacity = 11 if initial_capacity < 11
-    initial_capacity = initial_capacity.to_i
-    @buckets = Pointer(Entry(K, V)?).malloc(initial_capacity)
-    @buckets_size = initial_capacity
-    @size = 0
-    @block = block
-  end
-
-  # Creates a new empty `Hash` of *initial_capacity* with a *block* that handles missing keys.
+  # Creates a new empty `Hash` with a *block* that handles missing keys.
   #
   # The *initial_capacity* is useful to avoid unnecessary reallocations
-  # of the internal buffer in case of growth. If you have an estimate
-  # of the maximum number of elements a hash will hold, the hash should
-  # be initialized with that capacity for improved performance.
-  #
-  # NOTE: *initial_capacity* defaults to 11 and an input of < 11 is ignored.
-  # NOTE: `#size` does not reflect capacity as in `Array`.
+  # of the internal buffer in case of growth. If the maximum number of elements
+  # a hash will hold is known, the hash should be initialized with that
+  # capacity for improved performance. Otherwise, the default is 11 and inputs
+  # less than 11 are ignored.
   #
   # ```
-  # new_hash = Hash(String, Int32).new(50) do |hash, key|
-  #   key.size
+  # hash = Hash(String, Int32).new do |hash, key|
+  #   hash[key] = key.size
   # end
-  # new_hash.size # => 0
-  # new_hash["zero"] = 0
-  # new_hash["two"] = 2
-  # new_hash["four"] # => 4
+  #
+  # hash.size   # => 0
+  # hash["foo"] # => 3
+  # hash.size   # => 1
+  # hash["bar"] = 10
+  # hash["bar"] # => 10
   # ```
   def self.new(initial_capacity = nil, &block : (Hash(K, V), K -> V))
     new block, initial_capacity: initial_capacity
@@ -54,8 +43,31 @@ class Hash(K, V)
   # inventory["socks"] = 3
   # inventory["pickles"] # => 0
   # ```
+  #
+  # NOTE: The default value is passed by reference:
+  # ```
+  # arr = [1, 2, 3]
+  # hash = Hash(String, Array(Int32)).new(arr)
+  # hash["3"][1] = 4
+  # arr # => [1, 4, 3]
+  # ```
   def self.new(default_value : V, initial_capacity = nil)
     new(initial_capacity: initial_capacity) { default_value }
+  end
+
+  # Creates a new empty `Hash` with the block passed as an argument.
+  #
+  # ```
+  # hash = Hash.new(block, initial_capacity: initial_capacity)
+  # ```
+  def initialize(block : (Hash(K, V), K -> V)? = nil, initial_capacity = nil)
+    initial_capacity ||= 11
+    initial_capacity = 11 if initial_capacity < 11
+    initial_capacity = initial_capacity.to_i
+    @buckets = Pointer(Entry(K, V)?).malloc(initial_capacity)
+    @buckets_size = initial_capacity
+    @size = 0
+    @block = block
   end
 
   # Sets the value of *key* to the given *value*.


### PR DESCRIPTION
As described in #6918, here's a little documentation for hash construction. 

I decided to nix the `initialize` docs since the other two `self.new` methods are wrappers to it. Let me know if that's misguided.

I'm open to adding in docs for other initialization methods (JSON, YAML), I would just need to actually learn about them (haven't used them myself) so it would slow this down a little.