### PR TITLE
Accessibility Fix in Doc Generation HTML

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_sidebar.html
+++ b/src/compiler/crystal/tools/doc/html/_sidebar.html
@@ -1,7 +1,7 @@
 <div class="sidebar">
   <div class="sidebar-header">
     <div class="search-box">
-      <input type="search" class="search-input" placeholder="Search..." spellcheck="false">
+      <input type="search" class="search-input" placeholder="Search..." spellcheck="false" aria-label="Search">
     </div>
 
     <div class="repository-links">


### PR DESCRIPTION
Add a aria-label atttribute to the search input in the template for auto
generated docs.

Resolves #6921