### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout eea9da1645d9690a674d984276541e12e7630fa4
+          git checkout f83d13b3232d4e8594a2638f78ebbabc6b760467
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
Update to bdw-gc v7.6.8 and libatomic_ops v7.6.6
Add pkg-config as dependency
Add libz as suggested dependency
Patch bdw-gc for GCF

maintenance release CI [is happy already](https://circleci.com/workflow-run/fac5a944-38cb-4eda-bb16-ad088923ed6a)