### PR TITLE
Optimize fore, back and mode of Colorize::Object(T)

### DIFF
--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -234,10 +234,13 @@ struct Colorize::Object(T)
   {% end %}
 
   def fore(color : Symbol)
-    {% for name in COLORS %}
-      if color == :{{name.id}}
+    {% begin %}
+      case color
+      {% for name in COLORS %}
+      when :{{name.id}}
         @fore = ColorANSI::{{name.camelcase.id}}
         return self
+      {% end %}
       end
     {% end %}
 
@@ -249,10 +252,13 @@ struct Colorize::Object(T)
   end
 
   def back(color : Symbol)
-    {% for name in COLORS %}
-      if color == :{{name.id}}
+    {% begin %}
+      case color
+      {% for name in COLORS %}
+      when :{{name.id}}
         @back = ColorANSI::{{name.camelcase.id}}
         return self
+      {% end %}
       end
     {% end %}
 
@@ -264,10 +270,13 @@ struct Colorize::Object(T)
   end
 
   def mode(mode : Symbol)
-    {% for name in MODES %}
-      if mode == :{{name.id}}
+    {% begin %}
+      case mode
+      {% for name in MODES %}
+      when :{{name.id}}
         @mode |= MODE_{{name.upcase.id}}_FLAG
         return self
+      {% end %}
       end
     {% end %}
 


### PR DESCRIPTION
This optimizes [`Colorize::Object(T)`](https://crystal-lang.org/api/0.26.1/Colorize/Object.html)'s [`fore`](https://crystal-lang.org/api/0.26.1/Colorize/Object.html#fore%28color%3ASymbol%29-instance-method), [`back`](https://crystal-lang.org/api/0.26.1/Colorize/Object.html#back%28color%3ASymbol%29-instance-method) and [`mode`](https://crystal-lang.org/api/0.26.1/Colorize/Object.html#mode%28mode%3ASymbol%29-instance-method) by generating one `case` instead of multiple `if`'s.
The generated `if`'s currently: [gist](https://gist.github.com/r00ster91/8aa54c5fdeb9cd4a27e009358c29d9d9).
The generated `case` after this: [gist](https://gist.github.com/r00ster91/1ca54e4a3e065c0ed658fe670e96dd00).

I'm not sure to be honest why exactly this is faster but maybe it's because one `case` just makes it easier for the compiler to optimize.

Benchmark for [`fore`](https://crystal-lang.org/api/0.26.1/Colorize/Object.html#fore%28color%3ASymbol%29-instance-method):
```cr
require "colorize"
require "benchmark"

struct Colorize::Object(T)
  def new_fore(color : Symbol)
    {% begin %}
      case color
      {% for name in COLORS %}
      when :{{name.id}}
        @fore = ColorANSI::{{name.camelcase.id}}
        return self
      {% end %}
      end
    {% end %}

    raise ArgumentError.new "Unknown color: #{color}"
  end
end

Benchmark.ips do |bm|
  bm.report "new fore" do
    "hello".colorize.new_fore(:green)
  end
  bm.report "old fore" do
    "hello".colorize.fore(:green)
  end
end
```
```
$ crystal benchmark.cr --release
new fore 251.67M (  3.97ns) (±15.44%)  0 B/op        fastest
old fore 184.56M (  5.42ns) (±18.41%)  0 B/op   1.36× slower
```