### PR TITLE
Fix passing reuse_port in TCPServer's listen backlog parameter

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -221,7 +221,7 @@ class HTTP::Server
     # server.bind_tls "127.0.0.1", 8080, context
     # ```
     def bind_tls(host : String, port : Int32, context : OpenSSL::SSL::Context::Server, reuse_port : Bool = false) : Socket::IPAddress
-      tcp_server = TCPServer.new(host, port, reuse_port)
+      tcp_server = TCPServer.new(host, port, reuse_port: reuse_port)
       server = OpenSSL::SSL::Server.new(tcp_server, context)
 
       bind(server)

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -183,13 +183,13 @@ class Socket < IO
   end
 
   # Tells the previously bound socket to listen for incoming connections.
-  def listen(backlog = SOMAXCONN)
+  def listen(backlog : Int = SOMAXCONN)
     listen(backlog) { |errno| raise errno }
   end
 
   # Tries to listen for connections on the previously bound socket.
   # Yields an `Errno` on failure.
-  def listen(backlog = SOMAXCONN)
+  def listen(backlog : Int = SOMAXCONN)
     unless LibC.listen(fd, backlog) == 0
       yield Errno.new("listen")
     end

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -29,7 +29,7 @@ class TCPServer < TCPSocket
   end
 
   # Binds a socket to the *host* and *port* combination.
-  def initialize(host : String, port : Int, backlog = SOMAXCONN, dns_timeout = nil, reuse_port = false)
+  def initialize(host : String, port : Int, backlog : Int = SOMAXCONN, dns_timeout = nil, reuse_port : Bool = false)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol)
 

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -31,7 +31,7 @@ class UNIXServer < UNIXSocket
   # ```
   # UNIXServer.new("/tmp/dgram.sock", Socket::Type::DGRAM)
   # ```
-  def initialize(@path : String, type : Type = Type::STREAM, backlog = 128)
+  def initialize(@path : String, type : Type = Type::STREAM, backlog : Int = 128)
     super(Family::UNIX, type)
 
     bind(UNIXAddress.new(path)) do |error|


### PR DESCRIPTION
Also added type restrictions to prevent similar mistakes.

This was hanging the spec suite for me. `listen(sock, 0)` is undefined - apparently it behaves differently on my PC and CI.

cc @straight-shoota 