### PR TITLE
Fix dead links in docs of Enumerable#chunks and Iterator#chunk

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -92,11 +92,6 @@ module Enumerable(T)
   # ary # => [{false, [3, 1]}, {true, [4]}, {false, [1, 5, 9]}, {true, [2, 6]}, {false, [5, 3, 5]}]
   # ```
   #
-  # The following key values have special meaning:
-  #
-  # * `Enumerable::Chunk::Drop` specifies that the elements should be dropped
-  # * `Enumerable::Chunk::Alone` specifies that the element should be chunked by itself
-  #
   # See also: `Iterator#chunk`.
   def chunks(&block : T -> U) forall U
     res = [] of Tuple(U, Array(T))

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1223,11 +1223,6 @@ module Iterator(T)
   # #    [false, [5, 3, 5]]
   # ```
   #
-  # The following key values have special meaning:
-  #
-  # * `Enumerable::Chunk::Drop` specifies that the elements should be dropped
-  # * `Enumerable::Chunk::Alone` specifies that the element should be chunked by itself
-  #
   # By default, a new array is created and yielded for each chunk when invoking `next`.
   # * If *reuse* is given, the array can be reused
   # * If *reuse* is an `Array`, this array will be reused


### PR DESCRIPTION
Clicking on `Enumerable::Chunk::Drop` or `::Alone` leads to https://crystal-lang.org/api/0.26.1/Enumerable/Chunk/Drop.html which leads to https://crystal-lang.org/404 because `Enumerable::Chunk` is `:nodoc:`.