### PR TITLE
Change Installation section of README template to numbered list

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -93,13 +93,15 @@ module Crystal
       describe_file "example/README.md" do |readme|
         readme.should contain("# example")
 
+        readme.should contain(%{1. Run `shards init`.})
+        readme.should contain(%{2. Add this to your application's `shard.yml`:})
+
         readme.should contain(%{```yaml
 dependencies:
   example:
     github: jsmith/example
 ```})
-
-        readme.should contain(%{Then run `shards install`.})
+        readme.should contain(%{3. Run `shards install`.})
         readme.should contain(%{TODO: Write a description here})
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
@@ -110,14 +112,17 @@ dependencies:
       describe_file "example_app/README.md" do |readme|
         readme.should contain("# example")
 
+        readme.should contain(%{TODO: Write a description here})
+
+        readme.should_not contain(%{1. Run `shards init`.})
+        readme.should_not contain(%{2. Add this to your application's `shard.yml`:})
+
         readme.should_not contain(%{```yaml
 dependencies:
   example:
     github: jsmith/example
 ```})
-
-        readme.should_not contain(%{Then run `shards install`.})
-        readme.should contain(%{TODO: Write a description here})
+        readme.should_not contain(%{3. Run `shards install`.})
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example_app/fork>)})

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -93,7 +93,7 @@ module Crystal
       describe_file "example/README.md" do |readme|
         readme.should contain("# example")
 
-        readme.should contain(%{1. Run `shards init`.})
+        readme.should contain(%{1. Run `shards init`})
         readme.should contain(%{2. Add this to your application's `shard.yml`:})
 
         readme.should contain(%{```yaml
@@ -101,7 +101,7 @@ dependencies:
   example:
     github: jsmith/example
 ```})
-        readme.should contain(%{3. Run `shards install`.})
+        readme.should contain(%{3. Run `shards install`})
         readme.should contain(%{TODO: Write a description here})
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
@@ -114,7 +114,7 @@ dependencies:
 
         readme.should contain(%{TODO: Write a description here})
 
-        readme.should_not contain(%{1. Run `shards init`.})
+        readme.should_not contain(%{1. Run `shards init`})
         readme.should_not contain(%{2. Add this to your application's `shard.yml`:})
 
         readme.should_not contain(%{```yaml
@@ -122,7 +122,7 @@ dependencies:
   example:
     github: jsmith/example
 ```})
-        readme.should_not contain(%{3. Run `shards install`.})
+        readme.should_not contain(%{3. Run `shards install`})
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example_app/fork>)})

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -5,15 +5,15 @@ TODO: Write a description here
 ## Installation
 
 <%- if config.skeleton_type == "lib" -%>
-Add this to your application's `shard.yml`:
+1. Run `shards init`
+2. Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
   <%= config.name %>:
     github: <%= config.github_name %>/<%= config.name %>
 ```
-
-Then run `shards install`.
+3. Run `shards install`
 <%- else -%>
 TODO: Write installation instructions here
 <%- end -%>


### PR DESCRIPTION
Follow-up of #6914 

Actually there's a step missing: `shards init` which creates `shard.yml`. But now after a third step, it would make sense to use a numbered list I think.
I didn't put a dot behind step **1** and **3** for consistency because there aren't dots either behind the steps in the **Contributing** section.

So now the **Installation** section would look like this:

---

## Installation

1. Run `shards init`
2. Add this to your application's `shard.yml`:
```yaml
dependencies:
  library:
    github: user/library
```
3. Run `shards install`