### PR TITLE
POSIX threads corrections & enhancements

### DIFF
--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -1,0 +1,36 @@
+require "spec"
+
+describe Thread::Mutex do
+  it "synchronizes" do
+    a = 0
+    mutex = Thread::Mutex.new
+
+    threads = 10.times.map do
+      Thread.new do
+        mutex.synchronize { a += 1 }
+      end
+    end.to_a
+
+    threads.each(&.join)
+    a.should eq(10)
+  end
+
+  it "won't lock recursively" do
+    mutex = Thread::Mutex.new
+    mutex.try_lock.should be_true
+    mutex.try_lock.should be_false
+    expect_raises(Errno) { mutex.lock }
+    mutex.unlock
+  end
+
+  it "won't unlock from another thread" do
+    mutex = Thread::Mutex.new
+    mutex.lock
+
+    expect_raises(Errno) do
+      Thread.new { mutex.unlock }.join
+    end
+
+    mutex.unlock
+  end
+end

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -14,4 +14,12 @@ describe Thread do
       thread.join
     end
   end
+
+  it "returns current thread object" do
+    current = nil
+    thread = Thread.new { current = Thread.current }
+    thread.join
+    current.should be(thread)
+    current.should_not be(Thread.current)
+  end
 end

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -22,4 +22,19 @@ describe Thread do
     current.should be(thread)
     current.should_not be(Thread.current)
   end
+
+  it "yields the processor" do
+    done = false
+
+    thread = Thread.new do
+      3.times { Thread.yield }
+      done = true
+    end
+
+    until done
+      Thread.yield
+    end
+
+    thread.join
+  end
 end

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -162,7 +162,7 @@ module GC
     # :nodoc:
     def self.pthread_join(thread : LibC::PthreadT) : Void*
       ret = LibGC.pthread_join(thread, out value)
-      raise Errno.new("pthread_join") unless ret == 0
+      raise Errno.new("pthread_join", ret) unless ret == 0
       value
     end
 

--- a/src/lib_c/aarch64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
@@ -10,6 +12,9 @@ lib LibC
   fun pthread_detach(th : PthreadT) : Int
   fun pthread_equal(thread1 : PthreadT, thread2 : PthreadT) : Int
   fun pthread_join(th : PthreadT, thread_return : Void**) : Int
+  fun pthread_mutexattr_destroy(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(attr : PthreadMutexattrT*, type : Int) : Int
   fun pthread_mutex_destroy(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_init(mutex : PthreadMutexT*, mutexattr : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(mutex : PthreadMutexT*) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(attr : PthreadCondattrT*, type : ClockidT) : Int
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
   fun pthread_cond_signal(cond : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(cond : PthreadCondT*, mutex : PthreadMutexT*, abstime : Timespec*) : Int
   fun pthread_cond_wait(cond : PthreadCondT*, mutex : PthreadMutexT*) : Int
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/sched.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/aarch64-linux-musl/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-musl/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/aarch64-linux-musl/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-musl/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(x0 : PthreadCondattrT*, x1 : ClockidT) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/aarch64-linux-musl/c/sched.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/amd64-unknown-openbsd/c/pthread.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/pthread.cr
@@ -4,10 +4,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 1
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(x0 : PthreadCondattrT*, x1 : ClockidT) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/pthread.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/pthread.cr
@@ -2,6 +2,8 @@ require "./sys/types"
 
 @[Link("pthread")]
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 1
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -14,6 +16,9 @@ lib LibC
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
   alias PthreadKeyDestructor = (Void*) ->
   fun pthread_key_create(PthreadKeyT*, PthreadKeyDestructor) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/amd64-unknown-openbsd/c/sched.cr
+++ b/src/lib_c/amd64-unknown-openbsd/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
@@ -10,6 +12,9 @@ lib LibC
   fun pthread_detach(th : PthreadT) : Int
   fun pthread_equal(thread1 : PthreadT, thread2 : PthreadT) : Int
   fun pthread_join(th : PthreadT, thread_return : Void**) : Int
+  fun pthread_mutexattr_destroy(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(attr : PthreadMutexattrT*, type : Int) : Int
   fun pthread_mutex_destroy(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_init(mutex : PthreadMutexT*, mutexattr : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(mutex : PthreadMutexT*) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(attr : PthreadCondattrT*, type : ClockidT) : Int
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
   fun pthread_cond_signal(cond : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(cond : PthreadCondT*, mutex : PthreadMutexT*, abstime : Timespec*) : Int
   fun pthread_cond_wait(cond : PthreadCondT*, mutex : PthreadMutexT*) : Int
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/sched.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/i686-linux-gnu/c/pthread.cr
+++ b/src/lib_c/i686-linux-gnu/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(attr : PthreadCondattrT*, type : ClockidT) : Int
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
   fun pthread_cond_signal(cond : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(cond : PthreadCondT*, mutex : PthreadMutexT*, abstime : Timespec*) : Int
   fun pthread_cond_wait(cond : PthreadCondT*, mutex : PthreadMutexT*) : Int
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int

--- a/src/lib_c/i686-linux-gnu/c/pthread.cr
+++ b/src/lib_c/i686-linux-gnu/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int
   fun pthread_join(th : PthreadT, thread_return : Void**) : Int
+  fun pthread_mutexattr_destroy(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(attr : PthreadMutexattrT*, type : Int) : Int
   fun pthread_mutex_destroy(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_init(mutex : PthreadMutexT*, mutexattr : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(mutex : PthreadMutexT*) : Int

--- a/src/lib_c/i686-linux-gnu/c/sched.cr
+++ b/src/lib_c/i686-linux-gnu/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/i686-linux-musl/c/pthread.cr
+++ b/src/lib_c/i686-linux-musl/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/i686-linux-musl/c/pthread.cr
+++ b/src/lib_c/i686-linux-musl/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(x0 : PthreadCondattrT*, x1 : ClockidT) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/i686-linux-musl/c/sched.cr
+++ b/src/lib_c/i686-linux-musl/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/x86_64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(attr : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(attr : PthreadCondattrT*, type : ClockidT) : Int
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
   fun pthread_cond_signal(cond : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(cond : PthreadCondT*, mutex : PthreadMutexT*, abstime : Timespec*) : Int
   fun pthread_cond_wait(cond : PthreadCondT*, mutex : PthreadMutexT*) : Int
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(cond : PthreadCondT*) : Int
   fun pthread_cond_destroy(cond : PthreadCondT*) : Int
   fun pthread_cond_init(cond : PthreadCondT*, cond_attr : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(newthread : PthreadT*, attr : PthreadAttrT*, start_routine : Void* -> Void*, arg : Void*) : Int
   fun pthread_detach(th : PthreadT) : Int
   fun pthread_join(th : PthreadT, thread_return : Void**) : Int
+  fun pthread_mutexattr_destroy(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(attr : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(attr : PthreadMutexattrT*, type : Int) : Int
   fun pthread_mutex_destroy(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_init(mutex : PthreadMutexT*, mutexattr : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(mutex : PthreadMutexT*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sched.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/x86_64-linux-musl/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-musl/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 2
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-musl/c/pthread.cr
@@ -3,10 +3,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(x0 : PthreadCondattrT*, x1 : ClockidT) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/x86_64-linux-musl/c/sched.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/x86_64-macosx-darwin/c/pthread.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/pthread.cr
@@ -1,6 +1,8 @@
 require "./sys/types"
 
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 1
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -9,6 +11,9 @@ lib LibC
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/pthread.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/pthread.cr
@@ -3,10 +3,13 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 1
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait_relative_np(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/x86_64-macosx-darwin/c/sched.cr
+++ b/src/lib_c/x86_64-macosx-darwin/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/lib_c/x86_64-portbld-freebsd/c/pthread.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/pthread.cr
@@ -2,6 +2,8 @@ require "./sys/types"
 
 @[Link("pthread")]
 lib LibC
+  PTHREAD_MUTEX_ERRORCHECK = 1
+
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
@@ -10,6 +12,9 @@ lib LibC
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int
   fun pthread_join(x0 : PthreadT, x1 : Void**) : Int
+  fun pthread_mutexattr_destroy(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_init(x0 : PthreadMutexattrT*) : Int
+  fun pthread_mutexattr_settype(x0 : PthreadMutexattrT*, x1 : Int) : Int
   fun pthread_mutex_destroy(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_init(x0 : PthreadMutexT*, x1 : PthreadMutexattrT*) : Int
   fun pthread_mutex_lock(x0 : PthreadMutexT*) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/pthread.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/pthread.cr
@@ -4,10 +4,14 @@ require "./sys/types"
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 1
 
+  fun pthread_condattr_destroy(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_init(x0 : PthreadCondattrT*) : Int
+  fun pthread_condattr_setclock(x0 : PthreadCondattrT*, x1 : ClockidT) : Int
   fun pthread_cond_broadcast(x0 : PthreadCondT*) : Int
   fun pthread_cond_destroy(x0 : PthreadCondT*) : Int
   fun pthread_cond_init(x0 : PthreadCondT*, x1 : PthreadCondattrT*) : Int
   fun pthread_cond_signal(x0 : PthreadCondT*) : Int
+  fun pthread_cond_timedwait(x0 : PthreadCondT*, x1 : PthreadMutexT*, x2 : Timespec*) : Int
   fun pthread_cond_wait(x0 : PthreadCondT*, x1 : PthreadMutexT*) : Int
   fun pthread_create(x0 : PthreadT*, x1 : PthreadAttrT*, x2 : Void* -> Void*, x3 : Void*) : Int
   fun pthread_detach(x0 : PthreadT) : Int

--- a/src/lib_c/x86_64-portbld-freebsd/c/sched.cr
+++ b/src/lib_c/x86_64-portbld-freebsd/c/sched.cr
@@ -1,0 +1,3 @@
+lib LibC
+  fun sched_yield : Int
+end

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -1,4 +1,5 @@
 require "c/pthread"
+require "c/sched"
 require "./thread/*"
 
 # :nodoc:
@@ -105,6 +106,11 @@ class Thread
   #
   # TODO: consider moving to `kernel.cr` or `crystal/main.cr`
   self.current = new
+
+  def self.yield
+    ret = LibC.sched_yield
+    raise Errno.new("sched_yield") unless ret == 0
+  end
 
   # Returns the Fiber representing the thread's main stack.
   def main_fiber

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -32,7 +32,7 @@ class Thread
     if ret == 0
       @@threads.push(self)
     else
-      raise Errno.new("pthread_create")
+      raise Errno.new("pthread_create", ret)
     end
   end
 
@@ -67,7 +67,7 @@ class Thread
 
     @@current_key = begin
       ret = LibC.pthread_key_create(out current_key, nil)
-      raise Errno.new("pthread_key_create") unless ret == 0
+      raise Errno.new("pthread_key_create", ret) unless ret == 0
       current_key
     end
 
@@ -83,7 +83,7 @@ class Thread
     # Associates the Thread object to the running system thread.
     protected def self.current=(thread : Thread) : Thread
       ret = LibC.pthread_setspecific(@@current_key, thread.as(Void*))
-      raise Errno.new("pthread_setspecific") unless ret == 0
+      raise Errno.new("pthread_setspecific", ret) unless ret == 0
       thread
     end
   {% else %}

--- a/src/thread/condition_variable.cr
+++ b/src/thread/condition_variable.cr
@@ -5,33 +5,28 @@ class Thread
   # :nodoc:
   class ConditionVariable
     def initialize
-      if LibC.pthread_cond_init(out @cond, nil) != 0
-        raise Errno.new("pthread_cond_init")
-      end
+      ret = LibC.pthread_cond_init(out @cond, nil)
+      raise Errno.new("pthread_cond_init", ret) unless ret == 0
     end
 
     def signal
-      if LibC.pthread_cond_signal(self) != 0
-        raise Errno.new("pthread_cond_signal")
-      end
+      ret = LibC.pthread_cond_signal(self)
+      raise Errno.new("pthread_cond_signal", ret) unless ret == 0
     end
 
     def broadcast
-      if LibC.pthread_cond_broadcast(self) != 0
-        raise Errno.new("pthread_cond_broadcast")
-      end
+      ret = LibC.pthread_cond_broadcast(self)
+      raise Errno.new("pthread_cond_broadcast", ret) unless ret == 0
     end
 
     def wait(mutex : Thread::Mutex)
-      if LibC.pthread_cond_wait(self, mutex) != 0
-        raise Errno.new("pthread_cond_wait")
-      end
+      ret = LibC.pthread_cond_wait(self, mutex)
+      raise Errno.new("pthread_cond_wait", ret) unless ret == 0
     end
 
     def finalize
-      if LibC.pthread_cond_destroy(self) != 0
-        raise Errno.new("pthread_cond_broadcast")
-      end
+      ret = LibC.pthread_cond_destroy(self)
+      raise Errno.new("pthread_cond_broadcast", ret) unless ret == 0
     end
 
     def to_unsafe

--- a/src/thread/condition_variable.cr
+++ b/src/thread/condition_variable.cr
@@ -5,8 +5,17 @@ class Thread
   # :nodoc:
   class ConditionVariable
     def initialize
-      ret = LibC.pthread_cond_init(out @cond, nil)
+      attributes = uninitialized LibC::PthreadCondattrT
+      LibC.pthread_condattr_init(pointerof(attributes))
+
+      {% unless flag?(:darwin) %}
+        LibC.pthread_condattr_setclock(pointerof(attributes), LibC::CLOCK_MONOTONIC)
+      {% end %}
+
+      ret = LibC.pthread_cond_init(out @cond, pointerof(attributes))
       raise Errno.new("pthread_cond_init", ret) unless ret == 0
+
+      LibC.pthread_condattr_destroy(pointerof(attributes))
     end
 
     def signal
@@ -22,6 +31,37 @@ class Thread
     def wait(mutex : Thread::Mutex)
       ret = LibC.pthread_cond_wait(self, mutex)
       raise Errno.new("pthread_cond_wait", ret) unless ret == 0
+    end
+
+    def wait(mutex : Thread::Mutex, time : Time::Span)
+      ret =
+        {% if flag?(:darwin) %}
+          ts = uninitialized LibC::Timespec
+          ts.tv_sec = time.to_i
+          ts.tv_nsec = time.nanoseconds
+
+          LibC.pthread_cond_timedwait_relative_np(self, mutex, pointerof(ts))
+        {% else %}
+          LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
+          ts.tv_sec += time.to_i
+          ts.tv_nsec += time.nanoseconds
+
+          if ts.tv_nsec >= 1_000_000_000
+            ts.tv_sec += 1
+            ts.tv_nsec -= 1_000_000_000
+          end
+
+          LibC.pthread_cond_timedwait(self, mutex, pointerof(ts))
+        {% end %}
+
+      case ret
+      when 0
+        # normal resume from #signal or #broadcast
+      when Errno::ETIMEDOUT
+        yield
+      else
+        raise Errno.new("pthread_cond_timedwait", ret)
+      end
     end
 
     def finalize

--- a/src/thread/mutex.cr
+++ b/src/thread/mutex.cr
@@ -5,27 +5,29 @@ class Thread
   # :nodoc:
   class Mutex
     def initialize
-      if LibC.pthread_mutex_init(out @mutex, nil) != 0
-        raise Errno.new("pthread_mutex_init")
-      end
+      ret = LibC.pthread_mutex_init(out @mutex, nil)
+      raise Errno.new("pthread_mutex_init", ret) unless ret == 0
     end
 
     def lock
-      if LibC.pthread_mutex_lock(self) != 0
-        raise Errno.new("pthread_mutex_lock")
-      end
+      ret = LibC.pthread_mutex_lock(self)
+      raise Errno.new("pthread_mutex_lock", ret) unless ret == 0
     end
 
     def try_lock
-      if LibC.pthread_mutex_trylock(self) != 0
-        raise Errno.new("pthread_mutex_trylock")
+      case ret = LibC.pthread_mutex_trylock(self)
+      when 0
+        true
+      when Errno::EBUSY
+        false
+      else
+        raise Errno.new("pthread_mutex_trylock", ret)
       end
     end
 
     def unlock
-      if LibC.pthread_mutex_unlock(self) != 0
-        raise Errno.new("pthread_mutex_unlock")
-      end
+      ret = LibC.pthread_mutex_unlock(self)
+      raise Errno.new("pthread_mutex_unlock", ret) unless ret == 0
     end
 
     def synchronize
@@ -36,9 +38,8 @@ class Thread
     end
 
     def finalize
-      if LibC.pthread_mutex_destroy(self) != 0
-        raise Errno.new("pthread_mutex_destroy")
-      end
+      ret = LibC.pthread_mutex_destroy(self)
+      raise Errno.new("pthread_mutex_destroy", ret) unless ret == 0
     end
 
     def to_unsafe

--- a/src/thread/mutex.cr
+++ b/src/thread/mutex.cr
@@ -5,8 +5,14 @@ class Thread
   # :nodoc:
   class Mutex
     def initialize
-      ret = LibC.pthread_mutex_init(out @mutex, nil)
+      attributes = uninitialized LibC::PthreadMutexattrT
+      LibC.pthread_mutexattr_init(pointerof(attributes))
+      LibC.pthread_mutexattr_settype(pointerof(attributes), LibC::PTHREAD_MUTEX_ERRORCHECK)
+
+      ret = LibC.pthread_mutex_init(out @mutex, pointerof(attributes))
       raise Errno.new("pthread_mutex_init", ret) unless ret == 0
+
+      LibC.pthread_mutexattr_destroy(pointerof(attributes))
     end
 
     def lock


### PR DESCRIPTION
A collection of corrections and small enhancements to POSIX threads integration:

Fixes:
- wrong error reporting: pthreads return an errnum but don't set `errno`;
- prevent deadlocks & undefined behaviors by setting PTHREAD_MUTEX_ERRORCHECK;
- make `Thread::Mutex#try_lock` report whether the lock was acquired or not;

Features:
- add an overload with timeout to `Thread::ConditionVariable#wait`;
- add `Thread.yield` to pass CPU time to another thread.