### PR TITLE
Prevent static linking segfaults

### DIFF
--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -1,4 +1,8 @@
-{% if flag?(:openbsd) %}
+# libunwind prevents END_OF_STACK errors, but the backtrace is empty
+# https://github.com/crystal-lang/crystal/issues/4276#issuecomment-313678321
+{% if flag?(:musl) && flag?(:static) %}
+  @[Link("unwind")]
+{% elsif flag?(:openbsd) %}
   @[Link("c++abi")]
 {% end %}
 lib LibUnwind

--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -1,7 +1,8 @@
 # libunwind prevents END_OF_STACK errors, but the backtrace is empty
 # https://github.com/crystal-lang/crystal/issues/4276#issuecomment-313678321
 {% if flag?(:musl) && flag?(:static) %}
-  @[Link("unwind")]
+require "llvm/lib_llvm"
+require "llvm/enums"
 {% elsif flag?(:openbsd) %}
   @[Link("c++abi")]
 {% end %}


### PR DESCRIPTION
`libunwind` prevents `END_OF_STACK` errors, but the backtrace is empty.

Relates to https://github.com/crystal-lang/crystal/issues/4276#issuecomment-313678321

Fixes https://github.com/crystal-lang/crystal/issues/6934
