### PR TITLE
Optimized Array#skip

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1866,4 +1866,17 @@ describe "Array" do
     a = [s, t, u, 12, 13]
     a.flatten.to_a.should eq([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
   end
+
+  it "#skip" do
+    ary = [1, 2, 3]
+    ary.skip(0).should eq([1, 2, 3])
+    ary.skip(1).should eq([2, 3])
+    ary.skip(2).should eq([3])
+    ary.skip(3).should eq([] of Int32)
+    ary.skip(4).should eq([] of Int32)
+
+    expect_raises(ArgumentError, "Attempt to skip negative size") do
+      ary.skip(-1)
+    end
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -946,6 +946,24 @@ class Array(T)
     self
   end
 
+  # Returns an `Array` with the first *count* elements removed
+  # from the original array.
+  #
+  # If *count* is bigger than the number of elements in the array, returns an empty array.
+  #
+  # ```
+  # [1, 2, 3, 4, 5, 6].skip(3) # => [4, 5, 6]
+  # ```
+  def skip(count : Int) : Array(T)
+    raise ArgumentError.new("Attempt to skip negative size") if count < 0
+
+    new_size = Math.max(size - count, 0)
+    Array(T).build(new_size) do |buffer|
+      buffer.copy_from(to_unsafe + count, new_size)
+      new_size
+    end
+  end
+
   # Returns an `Array` with all possible permutations of *size*.
   #
   # ```


### PR DESCRIPTION
`Enumerable#skip` doesn't know the size of the resulting array, plus it's much efficient to do a mem-copy here.

A benchmark I did:

```crystal
require "benchmark"

a = Array.new(10_000) { |i| i }

Benchmark.ips do |x|
  x.report("old skip") do
    a.skip(1)
  end
  x.report("new skip 2") do
    a.skip2(1)
  end
  x.report("new skip 3") do
    a.skip3(1)
  end
end
```

where `skip` is the current one, `skip2` just called `[count..-1]` and `skip3` is the version in this PR.

Results:

```
  old skip  15.75k ( 63.48µs) (± 3.89%)  99072 B/op   2.62× slower
  new skip 2 41.28k ( 24.23µs) (± 6.37%)  40032 B/op   1.00× slower
new skip 3  41.31k ( 24.21µs) (± 6.05%)  40032 B/op        fastest
```