### PR TITLE
Fix v1, 2, 3, 4, 5 methods of UUID

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -125,4 +125,22 @@ describe "UUID" do
     expect_raises(ArgumentError) { UUID.new "2b1bfW06368947e59ac07c3ffdaf514c" }
     expect_raises(ArgumentError) { UUID.new "xyz:uuid:1ed1ee2f-ef9a-4f9c-9615-ab14d8ef2892" }
   end
+
+  describe "v4?" do
+    it "returns true if UUID is v4, false otherwise" do
+      uuid = UUID.random
+      uuid.v4?.should eq(true)
+      uuid = UUID.new("00000000-0000-0000-0000-000000000000", version: UUID::Version::V5)
+      uuid.v4?.should eq(false)
+    end
+  end
+
+  describe "v4!" do
+    it "returns true if UUID is v4, raises otherwise" do
+      uuid = UUID.random
+      uuid.v4!.should eq(true)
+      uuid = UUID.new("00000000-0000-0000-0000-000000000000", version: UUID::Version::V5)
+      expect_raises(UUID::Error) { uuid.v4! }
+    end
+  end
 end

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -211,13 +211,16 @@ struct UUID
     end
   end
 
+  class Error < Exception
+  end
+
   {% for v in %w(1 2 3 4 5) %}
-    # Returns `true` if UUID looks is a V{{ v.id }}, `false` otherwise.
+    # Returns `true` if UUID is a V{{ v.id }}, `false` otherwise.
     def v{{ v.id }}?
-      variant == Variant::RFC4122 && version == RFC4122::Version::V{{ v.id }}
+      variant == Variant::RFC4122 && version == Version::V{{ v.id }}
     end
 
-    # Returns `true` if UUID looks is a V{{ v.id }}, raises `Error` otherwise.
+    # Returns `true` if UUID is a V{{ v.id }}, raises `Error` otherwise.
     def v{{ v.id }}!
       unless v{{ v.id }}?
         raise Error.new("Invalid UUID variant #{variant} version #{version}, expected RFC 4122 V{{ v.id }}")


### PR DESCRIPTION
Fixes #6951 

This fixes [`UUID`](https://crystal-lang.org/api/0.26.1/UUID.html)s `v1?`, `v2?`, `v3?`, `v4?`, `v5?` and `v1!`, `v2!`, `v3!`, `v4!`, `v5!`. This also adds specs.