### PR TITLE
Fix: some specs rely on Fiber.yield behavior

### DIFF
--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -26,9 +26,9 @@ describe Mutex do
     mutex = Mutex.new
 
     a = 1
-    two = true
-    three = true
-    four = true
+    two = false
+    three = false
+    four = false
     ch = Channel(Nil).new
 
     spawn do

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -67,8 +67,6 @@ describe OpenSSL::SSL::Server do
           client.close
         end
 
-        Fiber.yield
-
         OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context) do |socket|
           socket.puts "Hello, SSL!"
         end

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -64,11 +64,14 @@ describe OpenSSL::SSL::Server do
           client.should be_a(OpenSSL::SSL::Socket::Server)
           client = client.not_nil!
           client.gets.should eq "Hello, SSL!"
+          client.puts "Hello back, SSL!"
           client.close
         end
 
         OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context) do |socket|
           socket.puts "Hello, SSL!"
+          socket.flush
+          socket.gets.should eq "Hello back, SSL!"
         end
       end
     end


### PR DESCRIPTION
Some specs are relying on the `Fiber.yield` behavior, that's actually the event loop behavior (libevent2). They start failing whenever the `Fiber.yield` algorithm changes —for example to push the current fiber to the runnables queue, instead of adding a resume event.

This patch proposes changes to make the fiber synchronization expectations explicit. Either by looping until somethig is ready, or using Channel::Unbuffered's sync ability, or with an explicit enqueue/resume for specs testing Channel itself.