### PR TITLE
Rewrite macro spec without executing a shell command

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -568,7 +568,7 @@ describe "Semantic: macro" do
 
   it "allows declaring class with macro expression" do
     assert_type(%(
-      {{ `echo "class Foo; end"` }}
+      {{ "class Foo; end".id }}
 
       Foo.new
       )) { types["Foo"] }


### PR DESCRIPTION
Maybe fixes #6961

Let's see if CI fails like this. I'll try to re-run it a few times.

This is probably a workaround and we should investigate why it fails for this specific spec.