### PR TITLE
Document Top Level Namespace constants

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -59,7 +59,7 @@ ARGV = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
 # ```
 # # Argument passed to the program: "file"
 # ARGF.gets_to_end # => "123"
-# ARGV # => []
+# ARGV             # => []
 # ```
 #
 # You can manipulate `ARGV` yourself to control what `ARGF` operates on.
@@ -68,7 +68,7 @@ ARGV = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
 # ```
 # ARGV.replace ["file1"]
 # ARGF.gets_to_end # => The content of file1
-# ARGV # => []
+# ARGV             # => []
 # ARGV << "file2"
 # ARGF.gets_to_end # => The content of file2
 # ```

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -16,7 +16,7 @@
   STDERR = IO::FileDescriptor.from_stdio(2).tap { |f| f.flush_on_newline = true }
 {% end %}
 
-# Path to the current temporary program.
+# Path to the current program.
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
 
 # The arguments passed to the program.

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -2,14 +2,18 @@
   # The standard input file descriptor. Contains data piped to the program.
   STDIN  = IO::FileDescriptor.new(0)
 
-  # The standard output file descriptor. Gets flushed when a newline is written.
+  # The standard output file descriptor.
   #
   # Typically used to output data and information.
+  #
+  # NOTE: Gets flushed when a newline is written.
   STDOUT = IO::FileDescriptor.new(1).tap { |f| f.flush_on_newline = true }
 
-  # The standard error file descriptor. Gets flushed when a newline is written.
+  # The standard error file descriptor.
   #
   # Typically used to output error messages and diagnostics.
+  #
+  # NOTE: Gets flushed when a newline is written.
   STDERR = IO::FileDescriptor.new(2).tap { |f| f.flush_on_newline = true }
 {% else %}
   require "c/unistd"
@@ -17,14 +21,18 @@
   # The standard input file descriptor. Contains data piped to the program.
   STDIN  = IO::FileDescriptor.from_stdio(0)
 
-  # The standard output file descriptor. Gets flushed when a newline is written.
+  # The standard output file descriptor.
   #
   # Typically used to output data and information.
+  #
+  # NOTE: Gets flushed when a newline is written.
   STDOUT = IO::FileDescriptor.from_stdio(1).tap { |f| f.flush_on_newline = true }
 
-  # The standard error file descriptor. Gets flushed when a newline is written.
+  # The standard error file descriptor.
   #
   # Typically used to output error messages and diagnostics.
+  #
+  # NOTE: Gets flushed when a newline is written.
   STDERR = IO::FileDescriptor.from_stdio(2).tap { |f| f.flush_on_newline = true }
 {% end %}
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -44,43 +44,43 @@ ARGV = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
 
 # An `IO` for reading files from `ARGV`.
 #
-# `ARGF` assumes that `ARGV` contains only filenames.
+# Usage example:
 #
-# After a file from `ARGV` has been read, it's removed from `ARGV`.
+# `program.cr`:
+# ```
+# puts ARGF.gets_to_end
+# ```
 #
-# Example:
-#
-# A file to read from: (called `file`)
-#
+# A file to read from: (`file`)
 # ```text
 # 123
 # ```
 #
+# ```text
+# $ crystal build program.cr
+# $ ./program file
+# 123
+# $ ./program file file
+# 123123
+# $ # If ARGV is empty, ARGF reads from STDIN instead:
+# $ echo "hello" | ./program
+# hello
+# $ ./program unknown
+# Unhandled exception: Error opening file 'unknown' with mode 'r': No such file or directory (Errno)
+# ...
 # ```
-# # Argument passed to the program: "file"
-# ARGF.gets_to_end # => "123"
-# ARGV             # => []
-# ```
+#
+# After a file from `ARGV` has been read, it's removed from `ARGV`.
 #
 # You can manipulate `ARGV` yourself to control what `ARGF` operates on.
 # If you remove a file from `ARGV`, it is ignored by `ARGF`; if you add files to `ARGV`, `ARGF` will read from it.
 #
 # ```
 # ARGV.replace ["file1"]
-# ARGF.gets_to_end # => The content of file1
+# ARGF.gets_to_end # => Content of file1
 # ARGV             # => []
 # ARGV << "file2"
-# ARGF.gets_to_end # => The content of file2
-# ```
-#
-# If `ARGV` is empty, `ARGF` reads from `STDIN` instead:
-#
-# ```
-# echo "hello" | crystal eval "print ARGF.gets_to_end"
-# ```
-# prints:
-# ```text
-# hello
+# ARGF.gets_to_end # => Content of file2
 # ```
 ARGF = IO::ARGF.new(ARGV, STDIN)
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -16,7 +16,7 @@
   STDERR = IO::FileDescriptor.from_stdio(2).tap { |f| f.flush_on_newline = true }
 {% end %}
 
-# Path to the current program.
+# The name of the current program.
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
 
 # The arguments passed to the program.

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -18,11 +18,11 @@
 
 # Path to the current temporary program.
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
-# The count of arguments passed to the program.
-ARGC = ARGC_UNSAFE - 1
+
 # The arguments passed to the program.
-ARGV = Array.new(ARGC) { |i| String.new(ARGV_UNSAFE[1 + i]) }
-# An `IO` which reads from `ARGV` if `ARGV` is specified.
+ARGV = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
+
+# An `IO` which reads from `ARGV` if arguments are specified.
 #
 # A file to read from: (`file`)
 # ```text

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -1,18 +1,39 @@
 {% if flag?(:win32) %}
+  # The standard input file descriptor.
   STDIN  = IO::FileDescriptor.new(0)
+  # The standard output file descriptor. Gets flushed when a newline is written.
   STDOUT = IO::FileDescriptor.new(1).tap { |f| f.flush_on_newline = true }
+  # The standard error file descriptor. Gets flushed when a newline is written.
   STDERR = IO::FileDescriptor.new(2).tap { |f| f.flush_on_newline = true }
 {% else %}
   require "c/unistd"
 
+  # The standard input file descriptor.
   STDIN  = IO::FileDescriptor.from_stdio(0)
+  # The standard output file descriptor. Gets flushed when a newline is written.
   STDOUT = IO::FileDescriptor.from_stdio(1).tap { |f| f.flush_on_newline = true }
+  # The standard error file descriptor. Gets flushed when a newline is written.
   STDERR = IO::FileDescriptor.from_stdio(2).tap { |f| f.flush_on_newline = true }
 {% end %}
 
+# Path to the current temporary program.
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
-ARGV         = Array.new(ARGC_UNSAFE - 1) { |i| String.new(ARGV_UNSAFE[1 + i]) }
-ARGF         = IO::ARGF.new(ARGV, STDIN)
+# The count of arguments passed to the program.
+ARGC = ARGC_UNSAFE - 1
+# The arguments passed to the program.
+ARGV = Array.new(ARGC) { |i| String.new(ARGV_UNSAFE[1 + i]) }
+# An `IO` which reads from `ARGV` if `ARGV` is specified.
+#
+# A file to read from: (`file`)
+# ```text
+# 123
+# ```
+#
+# ```
+# # Argument passed to the program: "file"
+# ARGF.gets_to_end # => "123"
+# ```
+ARGF = IO::ARGF.new(ARGV, STDIN)
 
 # Repeatedly executes the block.
 #


### PR DESCRIPTION
This documents the Top Level Namespace constants [`STDIN`](https://crystal-lang.org/api/0.26.1/toplevel.html#STDIN), [`STDOUT`](https://crystal-lang.org/api/0.26.1/toplevel.html#STDOUT), [`STDERR`](https://crystal-lang.org/api/0.26.1/toplevel.html#STDERR), [`ARGV`](https://crystal-lang.org/api/0.26.1/toplevel.html#ARGV) and [`ARGF`](https://crystal-lang.org/api/0.26.1/toplevel.html#ARGF).