### PR TITLE
 Add nanoseconds to Time.unix constructor

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -175,20 +175,23 @@ describe Time do
     end
   end
 
-  it ".unix" do
-    seconds = 1439404155
-    time = Time.unix(seconds)
-    time.should eq(Time.utc(2015, 8, 12, 18, 29, 15))
-    time.to_unix.should eq(seconds)
-    time.utc?.should be_true
+  describe ".unix" do
+    it "with seconds" do
+      Time.unix(1439404155).should eq Time.utc(2015, 8, 12, 18, 29, 15)
+    end
+
+    it "with nanoseconds" do
+      Time.unix(1439404155, 123_345_789).should eq Time.utc(2015, 8, 12, 18, 29, 15, nanosecond: 123_345_789)
+    end
+
+    it "with result from #to_unix" do
+      now = Time.utc_now
+      Time.unix(now.to_unix, now.nanosecond).should eq now
+    end
   end
 
   it ".unix_ms" do
-    milliseconds = 1439404155000
-    time = Time.unix_ms(milliseconds)
-    time.should eq(Time.utc(2015, 8, 12, 18, 29, 15))
-    time.to_unix_ms.should eq(milliseconds)
-    time.utc?.should be_true
+    Time.unix_ms(1439404155123).should eq(Time.utc(2015, 8, 12, 18, 29, 15, nanosecond: 123_000_000))
   end
 
   describe ".local without arguments" do

--- a/src/time.cr
+++ b/src/time.cr
@@ -471,13 +471,14 @@ struct Time
     local(year, month, day, hour, minute, second, nanosecond: nanosecond, location: Location::UTC)
   end
 
+  # :nodoc:
   # Creates a new `Time` instance that corresponds to the number of *seconds*
   # and *nanoseconds* elapsed from epoch (`0001-01-01 00:00:00.0 UTC`)
   # observed in *location*.
   #
   # Valid range for *seconds* is `0..315_537_897_599`.
   # For *nanoseconds* it is `0..999_999_999`.
-  def initialize(*, @seconds : Int64, @nanoseconds : Int32, @location : Location)
+  protected def initialize(*, @seconds : Int64, @nanoseconds : Int32, @location : Location)
     unless 0 <= offset_seconds <= MAX_SECONDS
       raise ArgumentError.new "Invalid time: seconds out of range"
     end
@@ -487,13 +488,14 @@ struct Time
     end
   end
 
+  # :nodoc:
   # Creates a new `Time` instance that corresponds to the number of *seconds*
   # and *nanoseconds* elapsed from epoch (`0001-01-01 00:00:00.0 UTC`)
   # in UTC.
   #
   # Valid range for *seconds* is `0..315_537_897_599`.
   # For *nanoseconds* it is `0..999_999_999`.
-  def self.utc(*, seconds : Int64, nanoseconds : Int32) : Time
+  protected def self.utc(*, seconds : Int64, nanoseconds : Int32) : Time
     new(seconds: seconds, nanoseconds: nanoseconds, location: Location::UTC)
   end
 
@@ -1445,10 +1447,12 @@ struct Time
     year * 365 + year // 4 - year // 100 + year // 400 + days_in_year
   end
 
+  # :nodoc:
   protected def total_seconds
     @seconds
   end
 
+  # :nodoc:
   protected def offset_seconds
     @seconds + offset
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -514,8 +514,8 @@ struct Time
   # ```
   # Time.unix(981173106) # => 2001-02-03 04:05:06 UTC
   # ```
-  def self.unix(seconds : Int) : Time
-    utc(seconds: UNIX_EPOCH.total_seconds + seconds, nanoseconds: 0)
+  def self.unix(seconds : Int, nanoseconds : Int32 = 0) : Time
+    utc(seconds: UNIX_EPOCH.total_seconds + seconds, nanoseconds: nanoseconds)
   end
 
   # Creates a new `Time` instance that corresponds to the number of
@@ -529,9 +529,10 @@ struct Time
   # ```
   def self.unix_ms(milliseconds : Int) : Time
     milliseconds = milliseconds.to_i64
-    seconds = UNIX_EPOCH.total_seconds + (milliseconds // 1_000)
+    seconds = milliseconds // 1_000
     nanoseconds = (milliseconds % 1000) * NANOSECONDS_PER_MILLISECOND
-    utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
+
+    unix(seconds: seconds, nanoseconds: nanoseconds.to_i)
   end
 
   # Creates a new `Time` instance representing the current time from the


### PR DESCRIPTION
This is an alternative to #6661 to provide a simple interface to convert a `Time` instance from and to primitive data types (`Int64`/`Int32`). Instead of publicly exposing `#total_seconds` which could be used together with `Time.new(seconds, nanoseconds)`, it adds a `nanoseconds` argument to `Time.unix` which can be used together with `#to_unix`.

In return, `Time.new(seconds, nanoseconds)` and `Time.utc(seconds, nanoseconds)` constructors are removed from the public API and only used as internal helper methods.

`#total_seconds` could be replaced by `@seconds`, but I fear it would be confusing in respect to `#seconds` which returns a different value. IMHO it makes sense to keep `#total_seconds` and `#offset_seconds` as internal helper methods (they can't be `private`, though).

See also #5374 (probably fixes that).