### PR TITLE
Add Time constructor receiving LibC::FILETIME (win32)

### DIFF
--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -71,7 +71,7 @@ struct Crystal::System::FileInfo < ::File::Info
   end
 
   def modification_time : ::Time
-    Time.from_filetime(@file_attributes.ftLastWriteTime)
+    ::Time.new(@file_attributes.ftLastWriteTime)
   end
 
   def owner : UInt32

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -30,11 +30,6 @@ module Crystal::System::Time
     {seconds, nanoseconds}
   end
 
-  def self.from_filetime(filetime) : ::Time
-    seconds, nanoseconds = filetime_to_seconds_and_nanoseconds(filetime)
-    ::Time.utc(seconds: seconds, nanoseconds: nanoseconds)
-  end
-
   @@performance_frequency : Int64 = begin
     ret = LibC.QueryPerformanceFrequency(out frequency)
     if ret == 0

--- a/src/time.cr
+++ b/src/time.cr
@@ -492,8 +492,15 @@ struct Time
     new(seconds: seconds, nanoseconds: nanoseconds, location: Location::UTC)
   end
 
-  {% unless flag?(:win32) %}
-    # :nodoc:
+  {% if flag?(:win32) %}
+    # Creates a new `Time` instance from a `LibC::FILETIME`.
+    def self.new(filetime : LibC::FILETIME, location : Location = Location.local) : Time
+      seconds, nanoseconds = Crystal::System::Time.filetime_to_seconds_and_nanoseconds(filetime)
+
+      new(seconds: seconds, nanoseconds: nanoseconds, location: location)
+    end
+  {% else %}
+    # Creates a new `Time` instance from a `LibC::Timespec`.
     def self.new(time : LibC::Timespec, location : Location = Location.local)
       seconds = UNIX_EPOCH.total_seconds + time.tv_sec
       nanoseconds = time.tv_nsec.to_i


### PR DESCRIPTION
Time constructors receiving a LibC time struct should be publicly available because they're essential when converting time values from C bindings to Crystal `Time`.