### PR TITLE
Make ARGF's ARGV modifiable

### DIFF
--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -3,6 +3,8 @@ class IO::ARGF < IO
   @path : String?
   @current_io : IO?
 
+  property argv : Array(String)
+
   def initialize(@argv : Array(String), @stdin : IO)
     @path = nil
     @current_io = nil


### PR DESCRIPTION
This adds a `property` to `IO::ARGF` which allows to modify `ARGF`'s `argv`. That's useful if you e.g. want to remove values from the array that aren't filenames. Or if you just want to take the first argument.