### PR TITLE
Replace HTTP::Server::Response#respond_with_error with #respond_with_status

### DIFF
--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -23,6 +23,6 @@ describe HTTP::Handler do
     io.rewind
     response = HTTP::Client::Response.from_io(io)
     response.status_code.should eq(404)
-    response.body.should eq("Not Found\n")
+    response.body.should eq("404 Not Found\n")
   end
 end

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -112,7 +112,7 @@ describe HTTP::WebSocketHandler do
 
     response.close
 
-    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
   end
 
   it "returns upgrade required if Sec-WebSocket-Version is missing" do

--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -145,13 +145,9 @@ describe HTTP::Server::RequestProcessor do
         Hello world
         HTTP/1.1 400 Bad Request
         Content-Type: text/plain
-        Transfer-Encoding: chunked
+        Content-Length: 16
 
-        10
         400 Bad Request\\n
-        0
-
-
         RESPONSE
       ).gsub("\\n", "\n"))
     end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -184,27 +184,35 @@ describe HTTP::Server::Response do
     response.close
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\nHello")
   end
-  describe "#responds_with_error" do
+
+  describe "#respond_with_status" do
     it "uses default values" do
       io = IO::Memory.new
       response = Response.new(io)
       response.content_type = "text/html"
-      response.respond_with_error
+      response.respond_with_status(500)
       io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 26\r\n\r\n500 Internal Server Error\n")
     end
 
-    it "sends custom message and code" do
+    it "sends custom code and message" do
       io = IO::Memory.new
       response = Response.new(io)
-      response.respond_with_error("Bad Request", 400)
-      io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+      response.respond_with_status(400, "Request Error")
+      io.to_s.should eq("HTTP/1.1 400 Request Error\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\n400 Request Error\n")
     end
 
     it "sends HTTP::Status" do
       io = IO::Memory.new
       response = Response.new(io)
-      response.respond_with_error(HTTP::Status::URI_TOO_LONG)
+      response.respond_with_status(HTTP::Status::URI_TOO_LONG)
       io.to_s.should eq("HTTP/1.1 414 URI Too Long\r\nContent-Type: text/plain\r\nContent-Length: 17\r\n\r\n414 URI Too Long\n")
+    end
+
+    it "sends HTTP::Status and custom message" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.respond_with_status(HTTP::Status::URI_TOO_LONG, "Request Error")
+      io.to_s.should eq("HTTP/1.1 414 Request Error\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\n414 Request Error\n")
     end
   end
 end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -190,11 +190,11 @@ describe HTTP::Server::Response do
     response = Response.new(io)
     response.content_type = "text/html"
     response.respond_with_error
-    io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n1a\r\n500 Internal Server Error\n\r\n")
+    io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 26\r\n\r\n500 Internal Server Error\n")
 
     io = IO::Memory.new
     response = Response.new(io)
     response.respond_with_error("Bad Request", 400)
-    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n10\r\n400 Bad Request\n\r\n")
+    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
   end
 end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -184,17 +184,27 @@ describe HTTP::Server::Response do
     response.close
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\nHello")
   end
+  describe "#responds_with_error" do
+    it "uses default values" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.content_type = "text/html"
+      response.respond_with_error
+      io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 26\r\n\r\n500 Internal Server Error\n")
+    end
 
-  it "responds with an error" do
-    io = IO::Memory.new
-    response = Response.new(io)
-    response.content_type = "text/html"
-    response.respond_with_error
-    io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 26\r\n\r\n500 Internal Server Error\n")
+    it "sends custom message and code" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.respond_with_error("Bad Request", 400)
+      io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+    end
 
-    io = IO::Memory.new
-    response = Response.new(io)
-    response.respond_with_error("Bad Request", 400)
-    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+    it "sends HTTP::Status" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.respond_with_error(HTTP::Status::URI_TOO_LONG)
+      io.to_s.should eq("HTTP/1.1 414 URI Too Long\r\nContent-Type: text/plain\r\nContent-Length: 17\r\n\r\n414 URI Too Long\n")
+    end
   end
 end

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -27,7 +27,7 @@ require "mime/multipart"
 #   end
 #
 #   unless name && file
-#     context.response.status = :bad_request
+#     context.response.respond_with_status(:bad_request)
 #     next
 #   end
 #

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -25,9 +25,7 @@ module HTTP::Handler
     if next_handler = @next
       next_handler.call(context)
     else
-      context.response.status = :not_found
-      context.response.headers["Content-Type"] = "text/plain"
-      context.response.puts "Not Found"
+      context.response.respond_with_status(:not_found)
     end
   end
 

--- a/src/http/server/handlers/error_handler.cr
+++ b/src/http/server/handlers/error_handler.cr
@@ -21,7 +21,7 @@ class HTTP::ErrorHandler
         context.response.print("ERROR: ")
         ex.inspect_with_backtrace(context.response)
       else
-        context.response.respond_with_error
+        context.response.respond_with_status(:internal_server_error)
       end
     end
   end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -42,7 +42,7 @@ class HTTP::StaticFileHandler
     # File path cannot contains '\0' (NUL) because all filesystem I know
     # don't accept '\0' character as file name.
     if request_path.includes? '\0'
-      context.response.status = :bad_request
+      context.response.respond_with_status(:bad_request)
       return
     end
 

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -27,7 +27,7 @@ class HTTP::WebSocketHandler
       key = context.request.headers["Sec-WebSocket-Key"]?
 
       unless key
-        response.status = :bad_request
+        response.respond_with_status(:bad_request)
         return
       end
 

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -35,7 +35,7 @@ class HTTP::Server::RequestProcessor
         break unless request
 
         if request.is_a?(HTTP::Status)
-          response.respond_with_error(request.description, request.value)
+          response.respond_with_status(request)
           return
         end
 
@@ -47,7 +47,7 @@ class HTTP::Server::RequestProcessor
         begin
           @handler.call(context)
         rescue ex
-          response.respond_with_error
+          response.respond_with_status(:internal_server_error)
           error.puts "Unhandled exception on HTTP::Handler"
           ex.inspect_with_backtrace(error)
           return

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -36,7 +36,6 @@ class HTTP::Server::RequestProcessor
 
         if request.is_a?(HTTP::Status)
           response.respond_with_error(request.description, request.value)
-          response.close
           return
         end
 
@@ -49,7 +48,6 @@ class HTTP::Server::RequestProcessor
           @handler.call(context)
         rescue ex
           response.respond_with_error
-          response.close
           error.puts "Unhandled exception on HTTP::Handler"
           ex.inspect_with_backtrace(error)
           return

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -125,6 +125,13 @@ class HTTP::Server
 
     # Sends an error response.
     #
+    # Calls `#reset`, writes the given status, and closes the response.
+    def respond_with_error(status : HTTP::Status)
+      respond_with_error(status.description, status.code)
+    end
+
+    # Sends an error response.
+    #
     # Calls `#reset`, writes the given message, and closes the response.
     def respond_with_error(message = "Internal Server Error", code = 500)
       reset

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -123,16 +123,16 @@ class HTTP::Server
       @output.closed?
     end
 
-    # Generates an error response using *message* and *code*.
+    # Sends an error response.
     #
-    # Calls `reset` and then writes the given message.
+    # Calls `#reset`, writes the given message, and closes the response.
     def respond_with_error(message = "Internal Server Error", code = 500)
       reset
       @status = HTTP::Status.new(code)
       message ||= @status.description
       self.content_type = "text/plain"
       self << @status.code << ' ' << message << '\n'
-      flush
+      close
     end
 
     protected def write_headers


### PR DESCRIPTION
`Response#respond_with_error` would previously just write the error header and flush the IO.
That flush seems unnecessary. Instead the response should be closed immediately. A call to this method was typically followed by a call tall to `close` anyway (which is no longer needed with this PR)

The only benefit of not closing directly is that you could append to the body (for example to provide more error data). That's a pretty irrelevant use case however. `#respond_with_error` already writes a body and you can't replace it, only append. Hence custom error pages will need to a custom implementation anyway.

This also changes the error response to a fixed content length.

/cc @jhass 