### PR TITLE
Automatically inherit docs from previous def and/or ancestors when missing

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -9,7 +9,14 @@
         <a class="method-permalink" href="<%= method.anchor %>">#</a>
       </div>
       <% if doc = method.formatted_doc %>
-        <div class="doc"><%= doc %></div>
+        <div class="doc">
+          <% if doc_copied_from = method.doc_copied_from %>
+            <div class="doc-inherited">
+              Description copied from <%= doc_copied_from.kind %> <%= doc_copied_from.link_from(method.type) %>
+            </div>
+          <% end %>
+          <%= doc %>
+        </div>
       <% end %>
       <br/>
       <div>

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -627,3 +627,6 @@ span.flag.purple {
   margin-left: -100px;
   margin-right: 12px;
 }
+.doc-inherited {
+  font-weight: bold;
+}

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -23,6 +23,10 @@ class Crystal::Doc::Macro
     @macro.doc
   end
 
+  def doc_copied_from
+    nil
+  end
+
   def source_link
     @generator.source_link(@macro)
   end


### PR DESCRIPTION
**NOTE: Final behavior is in https://github.com/crystal-lang/crystal/pull/6989#issuecomment-522152861**

This is something that should have been in the doc generator from the beginning.

This PR makes it so that if you don't document a method and that method either redefines a previous method (overwrites it) or is an override (it overrides the method of a superclass), the docs of that other method will be used.

For example:

```crystal
class MyClass
  # Some docs
  def foo
  end
end

class MyClass
  def foo
  end
end
```

In the above case we redefine a method, and the doc generator will use the original doc comments because we are not specifying any.

The other case is:

```crystal
class MyClass
  # Some docs
  def foo
  end
end

class MySubclass < MyClass
  def foo
  end
end
```

Here we are overriding a method in a subclass, and because we are not specifying any docs the doc generator will use the ones from the superclass.

I think it always makes sense to "inherit" the docs when we don't specify them because the current behavior is not showing anything at all, and that isn't very useful. We either want to inherit the docs (after all, a subclass method should behave more or less the same way as a superclass method) or we want to specify other docs.

Then one could think of having `:inehrit:` or something like that to inherit docs and add more docs. Let's please discuss that in a separate issue/PR.

My other PR about the `@[Redefine]` and `@[Override]` annotations are slightly related but not quite: the annotations won't be used by the doc generator, they are just for the compiler to check that your intentions match the behaviour of the compiler. The compiler already knows when you redefine or override a method. So these PRs are orthogonal.