### PR TITLE
allow pointer/UInt subtraction

### DIFF
--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -186,6 +186,24 @@ describe "Pointer" do
     Pointer(Int32).new(1234).address.should eq(1234)
   end
 
+  it "performs arithmetic with u64" do
+    p = Pointer(Int8).new(1234)
+    d = 4_u64
+    (p + d).address.should eq(1238)
+    (p - d).address.should eq(1230)
+
+    p = Pointer(Int8).new(UInt64::MAX)
+    d = UInt64::MAX - 1
+    (p - d).address.should eq(1)
+  end
+
+  it "performs arithmetic with u32" do
+    p = Pointer(Int8).new(1234)
+    d = 4_u32
+    (p + d).address.should eq(1238)
+    (p - d).address.should eq(1230)
+  end
+
   it "shuffles!" do
     a = Pointer(Int32).malloc(3) { |i| i + 1 }
     a.shuffle!(3)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -92,7 +92,10 @@ struct Pointer(T)
   # ptr2.address # => 1230
   # ```
   def -(other : Int)
-    self + (-other)
+    # TODO: If throwing on overflow for integer conversion is implemented,
+    # then (here and in `Pointer#-`) for a `UInt64` argument the call to
+    # `to_i64` should become `as_unsafe`.
+    self + (-other.to_i64)
   end
 
   # Returns -1, 0 or 1 if this pointer's address is less, equal or greater than *other*'s address,


### PR DESCRIPTION
Allow subtraction of a `Pointer` and an unsigned integer. 

 Previously
```crystal
a = Pointer(Int8).new(1234)
b = a - 1_u64
```
yielded

```
in src/pointer.cr:95: wrong number of arguments for 'UInt64#-' (given 0, expected 1)
Overloads are:
 - UInt64#-(other : Int8)
 - UInt64#-(other : Int16)
 - UInt64#-(other : Int32)
 - UInt64#-(other : Int64)
 - UInt64#-(other : Int128)
 - UInt64#-(other : UInt8)
 - UInt64#-(other : UInt16)
 - UInt64#-(other : UInt32)
 - UInt64#-(other : UInt64)
 - UInt64#-(other : UInt128)
 - UInt64#-(other : Float32)
 - UInt64#-(other : Float64)

    self + (-other)
```