### PR TITLE
fix failing SIGSEGV spec

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -224,7 +224,7 @@ end
 describe "seg fault" do
   it "reports SIGSEGV" do
     status, _, error = build_and_run <<-'CODE'
-      puts Pointer(Int64).new(0x00FEDCBA).value
+      puts Pointer(Int64).null.value
     CODE
 
     status.success?.should be_false


### PR DESCRIPTION
On linux the spec "seg fault reports SIGSEGV" is intermittently failing because the process is exiting with success.  I.e, it looks like the desired seg fault is not being generated.  I have not reproduced this, but presumably the hard-coded pointer address in the spec is intermittently in user space.

Fixed by dereferencing a null pointer instead, which should always generate a seg fault.