### PR TITLE
Improve Contributors section of README template

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -104,7 +104,7 @@ dependencies:
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example/fork>)})
-        readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
+        readme.should contain(%{[John Smith](https://github.com/jsmith) John Smith - creator and maintainer})
       end
 
       describe_file "example_app/README.md" do |readme|
@@ -122,7 +122,7 @@ dependencies:
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example_app/fork>)})
-        readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
+        readme.should contain(%{[John Smith](https://github.com/jsmith) John Smith - creator and maintainer})
       end
 
       describe_file "example/shard.yml" do |shard_yml|

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -104,7 +104,7 @@ dependencies:
         readme.should_not contain(%{TODO: Write installation instructions here})
         readme.should contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example/fork>)})
-        readme.should contain(%{[John Smith](https://github.com/jsmith) John Smith - creator and maintainer})
+        readme.should contain(%{[John Smith](https://github.com/jsmith) - creator and maintainer})
       end
 
       describe_file "example_app/README.md" do |readme|
@@ -122,7 +122,7 @@ dependencies:
         readme.should contain(%{TODO: Write installation instructions here})
         readme.should_not contain(%{require "example"})
         readme.should contain(%{1. Fork it (<https://github.com/jsmith/example_app/fork>)})
-        readme.should contain(%{[John Smith](https://github.com/jsmith) John Smith - creator and maintainer})
+        readme.should contain(%{[John Smith](https://github.com/jsmith) - creator and maintainer})
       end
 
       describe_file "example/shard.yml" do |shard_yml|

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -40,4 +40,4 @@ TODO: Write development instructions here
 
 ## Contributors
 
-- [<%= config.github_name %>](https://github.com/<%= config.github_name %>) <%= config.author %> - creator, maintainer
+- [<%= config.author %>](https://github.com/<%= config.github_name %>) - creator and maintainer


### PR DESCRIPTION
What if for example your name is `username` and your GitHub username is `username` too? Then this is what you would get from generating a template: (when you also replace the `your-github-user` accordingly)

 - [username](https://github.com/username) username - creator, maintainer

This looks strange and quite confusing in my opinion.

But now with this PR, for the link name, the name is used which the user gave himself here in the settings:

![grafik](https://user-images.githubusercontent.com/35064754/47648319-fbfd3000-db79-11e8-978c-90762bb3b4e9.png)

When the user explicty entered his nickname or real name there, he likely wants this name to show up. Instead of both the GitHub username and the name. It's shorter and simple.

And for the link itself, the GitHub username is of course still used.

And for the "creator, maintainer" I don't see a reason to not make it 3 characters longer and use "and". Sounds better IMO.

So now the **Contributors** section would simply look like this:

---

## Contributors
- [username](https://github.com/username) - creator and maintainer