### PR TITLE
Compiler: add locations to all expanded macro arguments

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -156,4 +156,18 @@ describe "MacroExpander" do
   it "can't use `yield` outside a macro" do
     assert_error %({{yield}}), "can't use `{{yield}}` outside a macro"
   end
+
+  it "outputs invisible location pragmas" do
+    node = 42.int32
+    node.location = Location.new "foo.cr", 10, 20
+    assert_macro "node", %({{node}}), [node] of ASTNode, "42", {
+      0 => [
+        Lexer::LocStackPragma::Push,
+        Lexer::LocSetPragma.new("foo.cr", 10, 20),
+      ] of Lexer::LocPragma,
+      2 => [
+        Lexer::LocStackPragma::Pop,
+      ] of Lexer::LocPragma,
+    }
+  end
 end

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -162,11 +162,11 @@ describe "MacroExpander" do
     node.location = Location.new "foo.cr", 10, 20
     assert_macro "node", %({{node}}), [node] of ASTNode, "42", {
       0 => [
-        Lexer::LocStackPragma::Push,
+        Lexer::LocPushPragma.new,
         Lexer::LocSetPragma.new("foo.cr", 10, 20),
       ] of Lexer::LocPragma,
       2 => [
-        Lexer::LocStackPragma::Pop,
+        Lexer::LocPopPragma.new,
       ] of Lexer::LocPragma,
     }
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -108,25 +108,26 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
-def assert_macro(macro_args, macro_body, call_args, expected, flags = nil)
-  assert_macro(macro_args, macro_body, expected, flags) { call_args }
+def assert_macro(macro_args, macro_body, call_args, expected, expected_loc_pragmas = nil, flags = nil)
+  assert_macro(macro_args, macro_body, expected, expected_loc_pragmas, flags) { call_args }
 end
 
-def assert_macro(macro_args, macro_body, expected, flags = nil)
+def assert_macro(macro_args, macro_body, expected, expected_loc_pragmas = nil, flags = nil)
   program = Program.new
   program.flags = flags if flags
   sub_node = yield program
-  assert_macro_internal program, sub_node, macro_args, macro_body, expected
+  assert_macro_internal program, sub_node, macro_args, macro_body, expected, expected_loc_pragmas
 end
 
-def assert_macro_internal(program, sub_node, macro_args, macro_body, expected)
+def assert_macro_internal(program, sub_node, macro_args, macro_body, expected, expected_loc_pragmas)
   macro_def = "macro foo(#{macro_args});#{macro_body};end"
   a_macro = Parser.parse(macro_def).as(Macro)
 
   call = Call.new(nil, "", sub_node)
-  result = program.expand_macro a_macro, call, program, program
+  result, result_loc_pragmas = program.expand_macro a_macro, call, program, program
   result = result.chomp(';')
   result.should eq(expected)
+  result_loc_pragmas.should eq(expected_loc_pragmas) if expected_loc_pragmas
 end
 
 def codegen(code, inject_primitives = true, debug = Crystal::Debug::None)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -108,26 +108,26 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
-def assert_macro(macro_args, macro_body, call_args, expected, expected_loc_pragmas = nil, flags = nil)
-  assert_macro(macro_args, macro_body, expected, expected_loc_pragmas, flags) { call_args }
+def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil)
+  assert_macro(macro_args, macro_body, expected, expected_pragmas, flags) { call_args }
 end
 
-def assert_macro(macro_args, macro_body, expected, expected_loc_pragmas = nil, flags = nil)
+def assert_macro(macro_args, macro_body, expected, expected_pragmas = nil, flags = nil)
   program = Program.new
   program.flags = flags if flags
   sub_node = yield program
-  assert_macro_internal program, sub_node, macro_args, macro_body, expected, expected_loc_pragmas
+  assert_macro_internal program, sub_node, macro_args, macro_body, expected, expected_pragmas
 end
 
-def assert_macro_internal(program, sub_node, macro_args, macro_body, expected, expected_loc_pragmas)
+def assert_macro_internal(program, sub_node, macro_args, macro_body, expected, expected_pragmas)
   macro_def = "macro foo(#{macro_args});#{macro_body};end"
   a_macro = Parser.parse(macro_def).as(Macro)
 
   call = Call.new(nil, "", sub_node)
-  result, result_loc_pragmas = program.expand_macro a_macro, call, program, program
+  result, result_pragmas = program.expand_macro a_macro, call, program, program
   result = result.chomp(';')
   result.should eq(expected)
-  result_loc_pragmas.should eq(expected_loc_pragmas) if expected_loc_pragmas
+  result_pragmas.should eq(expected_pragmas) if expected_pragmas
 end
 
 def codegen(code, inject_primitives = true, debug = Crystal::Debug::None)

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -39,18 +39,18 @@ class Crystal::Program
   def expand_macro(a_macro : Macro, call : Call, scope : Type, path_lookup : Type? = nil, a_def : Def? = nil)
     interpreter = MacroInterpreter.new self, scope, path_lookup || scope, a_macro, call, a_def, in_macro: true
     a_macro.body.accept interpreter
-    {interpreter.to_s, interpreter.invisible_loc_pragmas}
+    {interpreter.to_s, interpreter.macro_expansion_pragmas}
   end
 
   def expand_macro(node : ASTNode, scope : Type, path_lookup : Type? = nil, free_vars = nil, a_def : Def? = nil)
     interpreter = MacroInterpreter.new self, scope, path_lookup || scope, node.location, def: a_def, in_macro: false
     interpreter.free_vars = free_vars
     node.accept interpreter
-    {interpreter.to_s, interpreter.invisible_loc_pragmas}
+    {interpreter.to_s, interpreter.macro_expansion_pragmas}
   end
 
-  def parse_macro_source(generated_source, invisible_loc_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, mode : MacroExpansionMode = MacroExpansionMode::Normal)
-    parse_macro_source(generated_source, invisible_loc_pragmas, the_macro, node, vars, current_def, inside_type, inside_exp) do |parser|
+  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, mode : MacroExpansionMode = MacroExpansionMode::Normal)
+    parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def, inside_type, inside_exp) do |parser|
       case mode
       when .lib?
         parser.parse_lib_body
@@ -64,11 +64,11 @@ class Crystal::Program
     end
   end
 
-  def parse_macro_source(generated_source, invisible_loc_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false)
+  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false)
     begin
       parser = Parser.new(generated_source, @program.string_pool, [vars.dup])
       parser.filename = VirtualFile.new(the_macro, generated_source, node.location)
-      parser.invisible_loc_pragmas = invisible_loc_pragmas
+      parser.macro_expansion_pragmas = macro_expansion_pragmas
       parser.visibility = node.visibility
       parser.def_nest = 1 if current_def
       parser.type_nest = 1 if inside_type

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -139,7 +139,7 @@ module Crystal
     end
 
     def interpret_skip_file(node)
-      raise SkipMacroException.new(@str.to_s, invisible_loc_pragmas)
+      raise SkipMacroException.new(@str.to_s, macro_expansion_pragmas)
     end
 
     def interpret_system(node)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -139,7 +139,7 @@ module Crystal
     end
 
     def interpret_skip_file(node)
-      raise SkipMacroException.new(@str.to_s)
+      raise SkipMacroException.new(@str.to_s, invisible_loc_pragmas)
     end
 
     def interpret_system(node)

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -296,8 +296,9 @@ module Crystal
 
   class SkipMacroException < ::Exception
     getter expanded_before_skip : String
+    getter invisible_loc_pragmas : Hash(Int32, Array(Lexer::LocPragma))
 
-    def initialize(@expanded_before_skip)
+    def initialize(@expanded_before_skip, @invisible_loc_pragmas)
       super()
     end
   end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -19,7 +19,7 @@ module Crystal
       if location
         column_number = node.name_column_number
         name_size = node.name_size
-        if column_number == 0
+        if column_number == 0 || (end_location = node.end_location) && end_location.filename != location.filename
           name_size = 0
           column_number = location.column_number
         end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -296,9 +296,9 @@ module Crystal
 
   class SkipMacroException < ::Exception
     getter expanded_before_skip : String
-    getter invisible_loc_pragmas : Hash(Int32, Array(Lexer::LocPragma))
+    getter macro_expansion_pragmas : Hash(Int32, Array(Lexer::LocPragma))?
 
-    def initialize(@expanded_before_skip, @invisible_loc_pragmas)
+    def initialize(@expanded_before_skip, @macro_expansion_pragmas)
       super()
     end
   end

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -65,14 +65,14 @@ module Crystal
         block: block_node.is_a?(Block) ? block_node : nil)
       fake_call = Call.new(nil, "method_missing", [call] of ASTNode)
 
-      expanded_macro, invisible_loc_pragmas = program.expand_macro method_missing, fake_call, self, self
+      expanded_macro, macro_expansion_pragmas = program.expand_macro method_missing, fake_call, self, self
 
       # Check if the expanded macro is a def. We do this
       # by just lexing the result and seeing if the first
       # token is `def`
       expands_to_def = starts_with_def?(expanded_macro)
       generated_nodes =
-        program.parse_macro_source(expanded_macro, invisible_loc_pragmas, method_missing, method_missing, args_nodes_names) do |parser|
+        program.parse_macro_source(expanded_macro, macro_expansion_pragmas, method_missing, method_missing, args_nodes_names) do |parser|
           if expands_to_def
             parser.parse
           else

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -65,14 +65,14 @@ module Crystal
         block: block_node.is_a?(Block) ? block_node : nil)
       fake_call = Call.new(nil, "method_missing", [call] of ASTNode)
 
-      expanded_macro = program.expand_macro method_missing, fake_call, self, self
+      expanded_macro, invisible_loc_pragmas = program.expand_macro method_missing, fake_call, self, self
 
       # Check if the expanded macro is a def. We do this
       # by just lexing the result and seeing if the first
       # token is `def`
       expands_to_def = starts_with_def?(expanded_macro)
       generated_nodes =
-        program.parse_macro_source(expanded_macro, method_missing, method_missing, args_nodes_names) do |parser|
+        program.parse_macro_source(expanded_macro, invisible_loc_pragmas, method_missing, method_missing, args_nodes_names) do |parser|
           if expands_to_def
             parser.parse
           else

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -296,9 +296,9 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     generated_nodes = expand_macro(the_macro, node) do
       old_args = node.args
       node.args = args
-      expanded_macro, invisible_loc_pragmas = @program.expand_macro the_macro, node, expansion_scope, expansion_scope, @untyped_def
+      expanded_macro, macro_expansion_pragmas = @program.expand_macro the_macro, node, expansion_scope, expansion_scope, @untyped_def
       node.args = old_args
-      {expanded_macro, invisible_loc_pragmas}
+      {expanded_macro, macro_expansion_pragmas}
     end
     @exp_nest += 1
 
@@ -310,7 +310,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   end
 
   def expand_macro(the_macro, node, mode = nil)
-    expanded_macro, invisible_loc_pragmas =
+    expanded_macro, macro_expansion_pragmas =
       eval_macro(node) do
         yield
       end
@@ -323,7 +323,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
                Program::MacroExpansionMode::Normal
              end
 
-    generated_nodes = @program.parse_macro_source(expanded_macro, invisible_loc_pragmas, the_macro, node, Set.new(@vars.keys),
+    generated_nodes = @program.parse_macro_source(expanded_macro, macro_expansion_pragmas, the_macro, node, Set.new(@vars.keys),
       current_def: @typed_def,
       inside_type: !current_type.is_a?(Program),
       inside_exp: @exp_nest > 0,
@@ -400,7 +400,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
         @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
       rescue ex : SkipMacroException
         skip_macro_exception = ex
-        {ex.expanded_before_skip, ex.invisible_loc_pragmas}
+        {ex.expanded_before_skip, ex.macro_expansion_pragmas}
       end
     end
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -296,9 +296,9 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     generated_nodes = expand_macro(the_macro, node) do
       old_args = node.args
       node.args = args
-      expanded = @program.expand_macro the_macro, node, expansion_scope, expansion_scope, @untyped_def
+      expanded_macro, invisible_loc_pragmas = @program.expand_macro the_macro, node, expansion_scope, expansion_scope, @untyped_def
       node.args = old_args
-      expanded
+      {expanded_macro, invisible_loc_pragmas}
     end
     @exp_nest += 1
 
@@ -310,7 +310,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   end
 
   def expand_macro(the_macro, node, mode = nil)
-    expanded_macro =
+    expanded_macro, invisible_loc_pragmas =
       eval_macro(node) do
         yield
       end
@@ -323,7 +323,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
                Program::MacroExpansionMode::Normal
              end
 
-    generated_nodes = @program.parse_macro_source(expanded_macro, the_macro, node, Set.new(@vars.keys),
+    generated_nodes = @program.parse_macro_source(expanded_macro, invisible_loc_pragmas, the_macro, node, Set.new(@vars.keys),
       current_def: @typed_def,
       inside_type: !current_type.is_a?(Program),
       inside_exp: @exp_nest > 0,
@@ -400,7 +400,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
         @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
       rescue ex : SkipMacroException
         skip_macro_exception = ex
-        ex.expanded_before_skip
+        {ex.expanded_before_skip, ex.invisible_loc_pragmas}
       end
     end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -7,17 +7,17 @@ module Crystal
       to_s(io)
     end
 
-    def to_s(io, emit_loc_pragma = nil, emit_doc = false)
-      visitor = ToSVisitor.new(io, emit_loc_pragma: emit_loc_pragma, emit_doc: emit_doc)
+    def to_s(io, macro_expansion_pragmas = nil, emit_doc = false)
+      visitor = ToSVisitor.new(io, macro_expansion_pragmas: macro_expansion_pragmas, emit_doc: emit_doc)
       self.accept visitor
     end
   end
 
   class ToSVisitor < Visitor
     @str : IO
-    @emit_loc_pragma : Hash(Int32, Array(Lexer::LocPragma))?
+    @macro_expansion_pragmas : Hash(Int32, Array(Lexer::LocPragma))?
 
-    def initialize(@str = IO::Memory.new, @emit_loc_pragma = nil, @emit_doc = false)
+    def initialize(@str = IO::Memory.new, @macro_expansion_pragmas = nil, @emit_doc = false)
       @indent = 0
       @inside_macro = 0
       @inside_lib = false
@@ -33,8 +33,8 @@ module Crystal
         @str.puts
       end
 
-      if (emit_loc_pragma = @emit_loc_pragma) && (loc = node.location) && (filename = loc.filename).is_a?(String)
-        pragmas = emit_loc_pragma[@str.pos.to_i32] ||= [] of Lexer::LocPragma
+      if (macro_expansion_pragmas = @macro_expansion_pragmas) && (loc = node.location) && (filename = loc.filename).is_a?(String)
+        pragmas = macro_expansion_pragmas[@str.pos.to_i32] ||= [] of Lexer::LocPragma
         pragmas << Lexer::LocSetPragma.new(filename, loc.line_number, loc.column_number)
       end
 


### PR DESCRIPTION
This PR changes compiler to add locations to all expanded macro arguments if possible. It makes helpful error message on macro expansion.

For example the following code makes an error with message `undefined constant BadType`.

```crystal
class Foo
  getter foo : BadType
end
```

However, currently the compiler shows expanded macro code and reports expanded macro line as error location. It is confusing for Crystal beginners I think.

```console
$ crystal run foo.cr
Error in foo.cr:2: expanding macro

  getter foo : BadType
  ^~~~~~

in foo.cr:2: expanding macro

  getter foo : BadType
  ^

in macro 'getter' expanded macro: macro_4384842512:113, line 4:

   1.
   2.
   3.
>  4.             @foo : BadType
   5.
   6.             def foo : BadType
   7.               @foo
   8.             end
   9.
  10.
  11.
  12.

undefined constant BadType
```

After this PR, the compiler shows such a simple error:

```console
$ bin/crystal foo.cr
Error in foo.cr:2: expanding macro

  getter foo : BadType
  ^~~~~~

in foo.cr:2: undefined constant BadType

  getter foo : BadType
               ^~~~~~~

```

Great!

- - -

## Technical Note

I believe this PR is awesome and useful, however, some developers (especially compiler specialist @asterite) think it is unacceptable because emitting location pragmas more makes breaking change and they know it is unuseful in some cases. (ref. #3858)

Don't worry! This PR does not add emitting location pragmas actually. Instead of emitting location pragmas to expanded code, it saves a pair of expanded code position and location pragmas of its position on macro expansion (it is called as `invisible_loc_pragmas` in source code.), and the lexer processes this data on parsing expanded code. It is cleaner and better than embedding location pragmas.
(However we cannot remove location pragmas from language because it has use-case still, e.g. ECR)

- - -

@bew This PR solves #6125 indirectly. What do you think?

- - -

Thank you :smile: