### PR TITLE
Outdated version alert in docs

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -87,6 +87,8 @@ class Crystal::Doc::Generator
 
     File.write File.join(@output_dir, "css", "style.css"), StyleTemplate.new
     File.write File.join(@output_dir, "js", "doc.js"), JsTypeTemplate.new
+
+    File.write File.join(@output_dir, "js", "version-checker.js"), JsVersionCheckerTemplate.new
   end
 
   def generate_types_docs(types, dir, all_types)

--- a/src/compiler/crystal/tools/doc/html/_head.html
+++ b/src/compiler/crystal/tools/doc/html/_head.html
@@ -13,6 +13,7 @@
 <link href="<%= base_path %>css/style.css" rel="stylesheet" type="text/css">
 
 <script type="text/javascript" src="<%= base_path %>js/doc.js"></script>
+<script type="text/javascript" src="<%= base_path %>js/version-checker.js"></script>
 <script type="text/javascript">
   CrystalDoc.base_path = "<%= base_path %>";
 </script>

--- a/src/compiler/crystal/tools/doc/html/_sidebar.html
+++ b/src/compiler/crystal/tools/doc/html/_sidebar.html
@@ -1,10 +1,12 @@
 <div class="sidebar">
   <div class="sidebar-header">
 
-    <a href="/api/latest/">
-      <div class="alert">
-        This documentation may be out of date. Click here to visit the latest version.
-      </div>
+    <a id="outdated-alert" href="/api/latest/">
+      <noscript>
+        <div class="alert">
+          This documentation may be out of date. Click here to visit the latest version.
+        </div>
+      </noscript>
     </a>
 
     <div class="search-box">

--- a/src/compiler/crystal/tools/doc/html/_sidebar.html
+++ b/src/compiler/crystal/tools/doc/html/_sidebar.html
@@ -1,5 +1,12 @@
 <div class="sidebar">
   <div class="sidebar-header">
+
+    <a href="/api/latest/">
+      <div class="alert">
+        This documentation may be out of date. Click here to visit the latest version.
+      </div>
+    </a>
+
     <div class="search-box">
       <input type="search" class="search-input" placeholder="Search..." spellcheck="false" aria-label="Search">
     </div>

--- a/src/compiler/crystal/tools/doc/html/_sidebar.html
+++ b/src/compiler/crystal/tools/doc/html/_sidebar.html
@@ -1,7 +1,7 @@
 <div class="sidebar">
   <div class="sidebar-header">
 
-    <a id="outdated-alert" href="/api/latest/">
+    <a id="outdated-alert" href="/api/latest/<%= current_type.try(&.path)%>">
       <noscript>
         <div class="alert">
           This documentation may be out of date. Click here to visit the latest version.

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -624,3 +624,17 @@ span.flag.purple {
   margin-left: -100px;
   margin-right: 12px;
 }
+.alert {
+  padding: 0.5rem;
+  margin: 0.5rem;
+  background-color: hsl(270, 25%, 80%);
+  border: 1px solid hsl(270, 25%, 60%);
+  border-radius: 5px;
+  color: hsl(270, 25%, 20%);
+}
+.alert:hover {
+  background-color: hsl(270, 25%, 85%);
+}
+.alert:active {
+  background-color: hsl(270, 25%, 75%);
+}

--- a/src/compiler/crystal/tools/doc/html/js/version-checker.js
+++ b/src/compiler/crystal/tools/doc/html/js/version-checker.js
@@ -1,0 +1,19 @@
+function apiFromURL(url) {
+  var u = new URL(url)
+  return u.pathname.split("/")[2]
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  var xhr = new XMLHttpRequest()
+  xhr.open('GET', 'https://crystal-lang.org/api/latest/');
+  xhr.onload = function(x) {
+    var myVersion = apiFromURL(x.target.responseURL)
+    var latestVersion = apiFromURL(window.location.href)
+    iAmOutdated = myVersion < latestVersion
+    if (iAmOutdated) {
+      var alertBox = document.getElementById("outdated-alert")
+      alertBox.innerHTML += '<div class="alert">This documentation is out of date. Click here to visit the latest version.</div>'
+    }
+  }
+  xhr.send()
+})

--- a/src/compiler/crystal/tools/doc/html/js/version-checker.js
+++ b/src/compiler/crystal/tools/doc/html/js/version-checker.js
@@ -5,10 +5,10 @@ function apiFromURL(url) {
 
 document.addEventListener('DOMContentLoaded', function() {
   var xhr = new XMLHttpRequest()
-  xhr.open('GET', 'https://crystal-lang.org/api/latest/');
+  xhr.open('GET', '/api/latest/');
   xhr.onload = function(x) {
-    var myVersion = apiFromURL(x.target.responseURL)
-    var latestVersion = apiFromURL(window.location.href)
+    var myVersion = apiFromURL(window.location.href)
+    var latestVersion = apiFromURL(x.target.responseURL)
     iAmOutdated = myVersion < latestVersion
     if (iAmOutdated) {
       var alertBox = document.getElementById("outdated-alert")

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -53,6 +53,10 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/js/_usage-modal.js"
   end
 
+  struct JsVersionCheckerTemplate
+    ECR.def_to_s "#{__DIR__}/html/js/version-checker.js"
+  end
+
   struct StyleTemplate
     ECR.def_to_s "#{__DIR__}/html/css/style.css"
   end


### PR DESCRIPTION
When I'm looking up Crystal docs, my search – either on a search engine or my browser history – often results in an old version of the docs (eg. `/api/0.24/Array.html`). I thought it would be a nice convenience to have a link on every docs page that points to the latest version (eg.`/api/latest/Array.html`). 

This PR adds such a link to the sidebar. When Javascript is disabled, the link indicates that the user "might" be looking at old docs. When Javascript is enabled, either the link indicates that the user "is" looking at old docs or the link is hidden. The way I've done this isn't the cleanest way, but I think it's the only way it will work without manual work or a change in the docs deployment process. 

On page load, the current version of the docs and the latest version of the docs are compared to determine if the link should be displayed. The current version is obtained by looking at the URL of the current page. The latest version is obtained by requesting `/api/latest` and checking the resulting URL.

Here's a screenshot of where I added the link:
![image](https://user-images.githubusercontent.com/7304492/47823701-d1f56a80-dd3f-11e8-9e33-ba3ed30d9308.png)

To test that the links worked well locally I rigged up a preview web application that handles things like redirecting `/api/latest` to `/api/0.26.1`. If anyone wants to use that to test this PR out locally, you can use my (docs-preview app)[https://github.com/willamin/docs-preview]

I think it would also be interesting to evolve this feature into one where the version can be selected with a dropdown, but this seemed like a good first step at least.