### PR TITLE
Doc: show macro double splat and block arg correctly

### DIFF
--- a/spec/compiler/crystal/tools/doc/macro_spec.cr
+++ b/spec/compiler/crystal/tools/doc/macro_spec.cr
@@ -1,0 +1,85 @@
+require "../../../spec_helper"
+
+describe Doc::Macro do
+  describe "args_to_s" do
+    it "shows simple args" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", [Arg.new("foo"), Arg.new("bar")]
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(foo, bar)")
+    end
+
+    it "shows splat arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", [Arg.new("foo")], splat_index: 0
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(*foo)")
+    end
+
+    it "shows simple arg and splat arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", [Arg.new("foo"), Arg.new("bar")], splat_index: 1
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(foo, *bar)")
+    end
+
+    it "shows double splat arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", double_splat: Arg.new("foo")
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(**foo)")
+    end
+
+    it "shows double splat arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", double_splat: Arg.new("foo")
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(**foo)")
+    end
+
+    it "show simple arg and double splat arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", [Arg.new("foo")], double_splat: Arg.new("bar")
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(foo, **bar)")
+    end
+
+    it "show block arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", block_arg: Arg.new("foo")
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(&foo)")
+    end
+
+    it "show simple arg and block arg" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo", [Arg.new("foo")], block_arg: Arg.new("bar")
+      doc_macro = Doc::Macro.new generator, doc_type, a_macro
+      doc_macro.args_to_s.should eq("(foo, &bar)")
+    end
+  end
+end

--- a/spec/compiler/crystal/tools/doc/macro_spec.cr
+++ b/spec/compiler/crystal/tools/doc/macro_spec.cr
@@ -7,7 +7,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", [Arg.new("foo"), Arg.new("bar")]
+      a_macro = Macro.new "foo", ["foo".arg, "bar".arg]
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(foo, bar)")
     end
@@ -17,7 +17,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", [Arg.new("foo")], splat_index: 0
+      a_macro = Macro.new "foo", ["foo".arg], splat_index: 0
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(*foo)")
     end
@@ -27,7 +27,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", [Arg.new("foo"), Arg.new("bar")], splat_index: 1
+      a_macro = Macro.new "foo", ["foo".arg, "bar".arg], splat_index: 1
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(foo, *bar)")
     end
@@ -37,7 +37,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", double_splat: Arg.new("foo")
+      a_macro = Macro.new "foo", double_splat: "foo".arg
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(**foo)")
     end
@@ -47,7 +47,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", double_splat: Arg.new("foo")
+      a_macro = Macro.new "foo", double_splat: "foo".arg
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(**foo)")
     end
@@ -57,7 +57,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", [Arg.new("foo")], double_splat: Arg.new("bar")
+      a_macro = Macro.new "foo", ["foo".arg], double_splat: "bar".arg
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(foo, **bar)")
     end
@@ -67,7 +67,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", block_arg: Arg.new("foo")
+      a_macro = Macro.new "foo", block_arg: "foo".arg
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(&foo)")
     end
@@ -77,7 +77,7 @@ describe Doc::Macro do
       generator = Doc::Generator.new program, ["."], ".", nil
       doc_type = Doc::Type.new generator, program
 
-      a_macro = Macro.new "foo", [Arg.new("foo")], block_arg: Arg.new("bar")
+      a_macro = Macro.new "foo", ["foo".arg], block_arg: "bar".arg
       doc_macro = Doc::Macro.new generator, doc_type, a_macro
       doc_macro.args_to_s.should eq("(foo, &bar)")
     end

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -64,7 +64,7 @@ class Crystal::Doc::Macro
   end
 
   def args_to_s(io)
-    return if @macro.args.empty?
+    return unless has_args?
 
     printed = false
     io << '('
@@ -80,9 +80,20 @@ class Crystal::Doc::Macro
       io << ", " if printed
       io << "**"
       io << double_splat
+      printed = true
+    end
+
+    if block_arg = @macro.block_arg
+      io << ", " if printed
+      io << '&'
+      io << block_arg
     end
 
     io << ')'
+  end
+
+  def has_args?
+    !@macro.args.empty? || @macro.double_splat || @macro.block_arg
   end
 
   def args_to_html


### PR DESCRIPTION
Fixed #5351

Block arg of macro is also missing. It is fixed too.

And it adds specs for `Crystal::Doc::Macro#arg_to_s`.

Thank you!