### PR TITLE
Optimize generating UUIDs from strings

### DIFF
--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -87,19 +87,16 @@ struct UUID
         end
       end
       {0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}.each_with_index do |offset, i|
-        string_has_hex_pair_at! value, offset
-        bytes[i] = (value[offset].to_u8(16) * 16) + value[offset + 1].to_u8(16)
+        bytes[i] = hex_pair_at value, offset
       end
     when 32 # Hexstring
       16.times do |i|
-        string_has_hex_pair_at! value, i * 2
-        bytes[i] = (value[i * 2].to_u8(16) * 16) + value[i * 2 + 1].to_u8(16)
+        bytes[i] = hex_pair_at value, i * 2
       end
     when 45 # URN
       raise ArgumentError.new "Invalid URN UUID format, expected string starting with \"urn:uuid:\"" unless value.starts_with? "urn:uuid:"
       {9, 11, 13, 15, 18, 20, 23, 25, 28, 30, 33, 35, 37, 39, 41, 43}.each_with_index do |offset, i|
-        string_has_hex_pair_at! value, offset
-        bytes[i] = (value[offset].to_u8(16) * 16) + value[offset + 1].to_u8(16)
+        bytes[i] = hex_pair_at value, offset
       end
     else
       raise ArgumentError.new "Invalid string length #{value.size} for UUID, expected 32 (hexstring), 36 (hyphenated) or 45 (urn)"
@@ -110,8 +107,10 @@ struct UUID
 
   # Raises `ArgumentError` if string `value` at index `i` doesn't contain hex
   # digit followed by another hex digit.
-  private def self.string_has_hex_pair_at!(value : String, i)
-    unless value[i].to_u8?(16) && value[i + 1].to_u8?(16)
+  private def self.hex_pair_at(value : String, i) : UInt8
+    if (ch1 = value[i].to_u8?(16)) && (ch2 = value[i + 1].to_u8?(16))
+      ch1 * 16 + ch2
+    else
       raise ArgumentError.new [
         "Invalid hex character at position #{i * 2} or #{i * 2 + 1}",
         "expected '0' to '9', 'a' to 'f' or 'A' to 'F'",

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -81,25 +81,25 @@ struct UUID
 
     case value.size
     when 36 # Hyphenated
-      [8, 13, 18, 23].each do |offset|
+      {8, 13, 18, 23}.each do |offset|
         if value[offset] != '-'
           raise ArgumentError.new "Invalid UUID string format, expected hyphen at char #{offset}"
         end
       end
-      [0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34].each_with_index do |offset, i|
+      {0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}.each_with_index do |offset, i|
         string_has_hex_pair_at! value, offset
-        bytes[i] = value[offset, 2].to_u8(16)
+        bytes[i] = (value[offset].to_u8(16) * 16) + value[offset + 1].to_u8(16)
       end
     when 32 # Hexstring
       16.times do |i|
         string_has_hex_pair_at! value, i * 2
-        bytes[i] = value[i * 2, 2].to_u8(16)
+        bytes[i] = (value[i * 2].to_u8(16) * 16) + value[i * 2 + 1].to_u8(16)
       end
     when 45 # URN
       raise ArgumentError.new "Invalid URN UUID format, expected string starting with \"urn:uuid:\"" unless value.starts_with? "urn:uuid:"
-      [9, 11, 13, 15, 18, 20, 23, 25, 28, 30, 33, 35, 37, 39, 41, 43].each_with_index do |offset, i|
+      {9, 11, 13, 15, 18, 20, 23, 25, 28, 30, 33, 35, 37, 39, 41, 43}.each_with_index do |offset, i|
         string_has_hex_pair_at! value, offset
-        bytes[i] = value[offset, 2].to_u8(16)
+        bytes[i] = (value[offset].to_u8(16) * 16) + value[offset + 1].to_u8(16)
       end
     else
       raise ArgumentError.new "Invalid string length #{value.size} for UUID, expected 32 (hexstring), 36 (hyphenated) or 45 (urn)"
@@ -111,7 +111,7 @@ struct UUID
   # Raises `ArgumentError` if string `value` at index `i` doesn't contain hex
   # digit followed by another hex digit.
   private def self.string_has_hex_pair_at!(value : String, i)
-    unless value[i, 2].to_u8(16, whitespace: false, underscore: false, prefix: false)
+    unless value[i].to_u8?(16) && value[i + 1].to_u8?(16)
       raise ArgumentError.new [
         "Invalid hex character at position #{i * 2} or #{i * 2 + 1}",
         "expected '0' to '9', 'a' to 'f' or 'A' to 'F'",


### PR DESCRIPTION
I'm building a [driver for Neo4j](https://github.com/jgaskins/neo4j.cr) and wanted to check on the overhead of generating UUIDs from strings since it's common to store UUIDs as strings in Neo4j. While it was still really good (1M UUIDs/sec), I noticed that `UUID` incurred a bunch of heap allocations for [hardcoded arrays](https://github.com/crystal-lang/crystal/blob/7c1337a3e5859fcc0018cdc7cedab414ec21cc66/src/uuid.cr#L89) and [intermediate strings](https://github.com/crystal-lang/crystal/blob/7c1337a3e5859fcc0018cdc7cedab414ec21cc66/src/uuid.cr#L91), so I wanted to see if it could be improved.

In total, generating a UUID from a 36-char string involved creating 2 intermediate arrays and 32 intermediate strings (each hex pair in the hardcoded array has one within the loop and [another in `string_has_hex_pair_at!`](https://github.com/crystal-lang/crystal/blob/7c1337a3e5859fcc0018cdc7cedab414ec21cc66/src/uuid.cr#L114)). Moving these to use stack-based values instead of heap, I was able to get a 4x performance boost.

```
➜  Code crystal build --release benchmark_optimized_uuid.cr
➜  Code ./benchmark_optimized_uuid
59c87908-4c45-4a94-b45f-2d338c2b2e17
59c87908-4c45-4a94-b45f-2d338c2b2e17
   string   1.03M (970.15ns) (± 0.44%)  688 B/op   4.11× slower
optimized   4.23M (236.14ns) (± 0.59%)    0 B/op        fastest
```

[Benchmark code](https://gist.github.com/jgaskins/4a408897edb990b4134212790f5b9dc5)