### PR TITLE
Fix `Crystal::Doc::Method#has_args?` to show double splat arg

### DIFF
--- a/spec/compiler/crystal/tools/doc/method_spec.cr
+++ b/spec/compiler/crystal/tools/doc/method_spec.cr
@@ -1,0 +1,75 @@
+require "../../../spec_helper"
+
+describe Doc::Method do
+  describe "args_to_s" do
+    it "shows simple args" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", ["foo".arg, "bar".arg]
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(foo, bar)")
+    end
+
+    it "shows splat args" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", ["foo".arg], splat_index: 0
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(*foo)")
+    end
+
+    it "shows double splat args" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", double_splat: "foo".arg
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(**foo)")
+    end
+
+    it "shows block args" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", block_arg: "foo".arg
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(&foo)")
+    end
+
+    it "shows block args if a def has `yield`" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", yields: 1
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(&block)")
+    end
+
+    it "shows return type restriction" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", return_type: "Foo".path
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq(" : Foo")
+    end
+
+    it "shows args and return type restriction" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo", ["foo".arg], return_type: "Foo".path
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.args_to_s.should eq("(foo) : Foo")
+    end
+  end
+end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -200,7 +200,7 @@ class Crystal::Doc::Method
   end
 
   def has_args?
-    !@def.args.empty? || @def.block_arg || @def.yields
+    !@def.args.empty? || @def.double_splat || @def.block_arg || @def.yields
   end
 
   def to_json(builder : JSON::Builder)


### PR DESCRIPTION
Fixed https://github.com/crystal-lang/crystal/issues/5351#issuecomment-435654252