### PR TITLE
Doc: remove duplicate source_link field

### DIFF
--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -214,7 +214,6 @@ class Crystal::Doc::Method
       builder.field "args", args
       builder.field "args_string", args_to_s
       builder.field "source_link", source_link
-      builder.field "source_link", source_link
       builder.field "def", self.def
     end
   end


### PR DESCRIPTION
I've just notice that `source_link` was introduced twice in https://github.com/crystal-lang/crystal/pull/4746/files#diff-b04a18f501e2b67dce56e2f7202245d2R217
