### PR TITLE
Fix formatter to format multiline literal elements

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -70,6 +70,8 @@ describe Crystal::Formatter do
   assert_format "[1,\n2,\n3]", "[1,\n 2,\n 3]"
   assert_format "[1,\n2,\n3\n]", "[1,\n 2,\n 3,\n]"
   assert_format "[\n1,\n2,\n3]", "[\n  1,\n  2,\n  3,\n]"
+  assert_format "[\n  [\n    1,\n  ], [\n    2,\n  ], [\n    3,\n  ],\n]"
+  assert_format "[\n  {\n    1 => 2,\n  }, {\n    3 => 4,\n  }, {\n    5 => 6,\n  },\n]"
   assert_format "if 1\n[   1  ,    2  ,    3  ]\nend", "if 1\n  [1, 2, 3]\nend"
   assert_format "    [   1,   \n   2   ,   \n   3   ]   ", "[1,\n 2,\n 3]"
   assert_format "Set { 1 , 2 }", "Set{1, 2}"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -820,7 +820,7 @@ module Crystal
         if next_needs_indent
           write_indent(offset, element)
         else
-          accept element
+          indent(offset, element)
         end
 
         has_heredoc_in_line = !@lexer.heredocs.empty?


### PR DESCRIPTION
Fixed #7046 

Now `crystal tool format` keeps following format:

```crystal
[
  {
    "some" => "hash",
    "with" => "values",
  }, {
    "another"  => "hash",
    "will get" => "deindented",
  }, {
    "now" => "totally",
  }, {
    "flat" => "against the left",
  },
]
```

@dscottboggs Thank you for great reporting!