### PR TITLE
Refactor filename resolution logic out of `interpret_run`

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -220,8 +220,7 @@ module Crystal
       node.args.first.accept self
       original_filename = @last.to_macro_id
 
-      filename = original_filename
-      filename = find_source_file(filename) do |error_message|
+      filename = find_source_file(original_filename) do |error_message|
         node.raise "error executing macro 'run': #{error_message}"
       end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -4,6 +4,39 @@ require "semantic_version"
 
 module Crystal
   class MacroInterpreter
+    private def find_source_file(filename)
+      # Support absolute paths
+      if filename.starts_with?('/')
+        filename = "#{filename}.cr" unless filename.ends_with?(".cr")
+
+        if File.exists?(filename)
+          unless File.file?(filename)
+            return yield "#{filename.inspect} is not a file"
+          end
+        else
+          return yield "can't find file #{filename.inspect}"
+        end
+      else
+        begin
+          relative_to = @location.try &.original_filename
+          found_filenames = @program.find_in_path(filename, relative_to)
+        rescue ex
+          return yield ex.message
+        end
+
+        unless found_filenames
+          return yield "can't find file #{filename.inspect}"
+        end
+
+        if found_filenames.size > 1
+          return yield "#{filename.inspect} is a directory"
+        end
+
+        filename = found_filenames.first
+      end
+      filename
+    end
+
     def interpret_top_level_call(node)
       interpret_top_level_call?(node) ||
         node.raise("undefined macro method: '#{node.name}'")
@@ -185,37 +218,11 @@ module Crystal
       end
 
       node.args.first.accept self
-      filename = @last.to_macro_id
-      original_filename = filename
+      original_filename = @last.to_macro_id
 
-      # Support absolute paths
-      if filename.starts_with?("/")
-        filename = "#{filename}.cr" unless filename.ends_with?(".cr")
-
-        if File.exists?(filename)
-          unless File.file?(filename)
-            node.raise "error executing macro run: '#{filename}' is not a file"
-          end
-        else
-          node.raise "error executing macro run: can't find file '#{filename}'"
-        end
-      else
-        begin
-          relative_to = @location.try &.original_filename
-          found_filenames = @program.find_in_path(filename, relative_to)
-        rescue ex
-          node.raise "error executing macro run: #{ex.message}"
-        end
-
-        unless found_filenames
-          node.raise "error executing macro run: can't find file '#{filename}'"
-        end
-
-        if found_filenames.size > 1
-          node.raise "error executing macro run: '#{filename}' is a directory"
-        end
-
-        filename = found_filenames.first
+      filename = original_filename
+      filename = find_source_file(filename) do |error_message|
+        node.raise "error executing macro 'run': #{error_message}"
       end
 
       run_args = [] of String


### PR DESCRIPTION
Spinoff from #6967 as per https://github.com/crystal-lang/crystal/pull/6967#discussion_r231622556