### PR TITLE
Remove implicit null skip from Hash to JSON serialization

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -45,10 +45,6 @@ describe "JSON serialization" do
       Hash(String, Int32).from_json(%({"foo": 1, "bar": 2})).should eq({"foo" => 1, "bar" => 2})
     end
 
-    it "does Hash(String, Int32)#from_json and skips null" do
-      Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null})).should eq({"foo" => 1, "bar" => 2})
-    end
-
     it "does for Array(Int32) from IO" do
       io = IO::Memory.new "[1, 2, 3]"
       Array(Int32).from_json(io).should eq([1, 2, 3])

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -45,6 +45,12 @@ describe "JSON serialization" do
       Hash(String, Int32).from_json(%({"foo": 1, "bar": 2})).should eq({"foo" => 1, "bar" => 2})
     end
 
+    it "raises an error Hash(String, Int32)#from_json with null value" do
+      expect_raises(JSON::ParseException, "Expected int but was null") do
+        Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null}))
+      end
+    end
+
     it "does for Array(Int32) from IO" do
       io = IO::Memory.new "[1, 2, 3]"
       Array(Int32).from_json(io).should eq([1, 2, 3])

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -123,11 +123,7 @@ end
 def Hash.new(pull : JSON::PullParser)
   hash = new
   pull.read_object do |key|
-    if pull.kind == :null
-      pull.read_next
-    else
-      hash[key] = V.new(pull)
-    end
+    hash[key] = V.new(pull)
   end
   hash
 end


### PR DESCRIPTION
Fixed #7052 

I think `Hash(String, String).from_str(%{{"foo": null}})` should be failed because `String` does not contain `nil` and JSON `null` is just `nil`. In fact Rust (serde) and Swift does not allow this.

Rust:

```rust
#[macro_use]
extern crate serde_derive;

extern crate serde;
extern crate serde_json;

use std::collections::HashMap;

fn main() {
    let _: HashMap<String, String> = serde_json::from_str(r#"{"foo": null}"#).unwrap();
}
// Error("invalid type: null, expected a string", line: 1, column: 12)
```

Swift:

```swift
import Foundation

let decoder: JSONDecoder = JSONDecoder()
let _: [String: String] = try! decoder.decode(Dictionary<String, String>.self, from: """
  {"foo": null}
""".data(using: .utf8)!)
// Swift.DecodingError.valueNotFound(Swift.String, Swift.DecodingError.Context(codingPath: [_DictionaryCodingKey(stringValue: "foo", intValue: nil)], debugDescription: "Expected String but found null value instead.", underlyingError: nil))
```