### PR TITLE
Add new keywords support to Doc::Highlighter

### DIFF
--- a/spec/compiler/crystal/tools/doc/highlighter_spec.cr
+++ b/spec/compiler/crystal/tools/doc/highlighter_spec.cr
@@ -42,6 +42,7 @@ describe "Crystal::Doc::Highlighter#highlight" do
     as as? typeof for in with self super private asm
     nil? abstract pointerof
     protected uninitialized instance_sizeof
+    annotation verbatim
   ).each do |kw|
     it_highlights kw, %(<span class="k">#{kw}</span>)
   end

--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -53,7 +53,8 @@ module Crystal::Doc::Highlighter
                :lib, :fun, :type, :struct, :union, :enum, :macro, :out, :require,
                :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?,
                :alias, :pointerof, :sizeof, :instance_sizeof, :as, :as?, :typeof, :for, :in,
-               :undef, :with, :self, :super, :private, :asm, :nil?, :protected, :uninitialized, "new"
+               :undef, :with, :self, :super, :private, :asm, :nil?, :protected, :uninitialized, "new",
+               :annotation, :verbatim
             highlight token, "k", io
           when :true, :false, :nil
             highlight token, "n", io


### PR DESCRIPTION
`annotation` and `verbatim` are missing.

Before:

![2018-11-09 23 54 20](https://user-images.githubusercontent.com/6679325/48269427-e7bf0a00-e47a-11e8-84bc-c90375f11ece.png)

After:

![2018-11-09 23 54 45](https://user-images.githubusercontent.com/6679325/48269440-ed1c5480-e47a-11e8-92eb-2ccf505c7a8c.png)

Thank you.