### PR TITLE
Fix RequestProcessor connection reuse with unconsumed requests

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -715,44 +715,6 @@ module HTTP
         ))
       end
 
-      it "skips body with known length" do
-        processor = HTTP::Server::RequestProcessor.new do |context|
-          context.response.content_type = "text/plain"
-          context.response.puts "Hello world\r"
-        end
-
-        input = IO::Memory.new(requestize(<<-REQUEST
-          POST / HTTP/1.1
-          Content-Length: 7
-
-          hello
-          POST / HTTP/1.1
-          Content-Length: 7
-
-          hello
-          REQUEST
-        ))
-        output = IO::Memory.new
-        processor.process(input, output)
-        output.rewind
-        output.gets_to_end.should eq(requestize(<<-RESPONSE
-          HTTP/1.1 200 OK
-          Connection: keep-alive
-          Content-Type: text/plain
-          Content-Length: 13
-
-          Hello world
-          HTTP/1.1 200 OK
-          Connection: keep-alive
-          Content-Type: text/plain
-          Content-Length: 13
-
-          Hello world
-
-          RESPONSE
-        ))
-      end
-
       it "fail if body is not consumed" do
         processor = HTTP::Server::RequestProcessor.new do |context|
           context.response.content_type = "text/plain"
@@ -827,9 +789,9 @@ module HTTP
 
         input = IO::Memory.new(requestize(<<-REQUEST
           POST / HTTP/1.1
-          Content-Length: 16387
+          Content-Length: 4
 
-          #{"0" * 16_384}1
+          1
           POST / HTTP/1.1
           Content-Length: 7
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -216,5 +216,9 @@ module HTTP
     def write(slice : Bytes)
       raise IO::Error.new "Can't write to ChunkedContent"
     end
+
+    def closed?
+      @received_final_chunk || super
+    end
   end
 end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -10,7 +10,6 @@ module HTTP
 
     def close
       @expects_continue = false
-      skip_to_end
       super
     end
 

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -113,6 +113,19 @@ require "./common"
 # Currently processing requests are not interrupted but also not waited for.
 # In order to give them some grace period for finishing, the calling context
 # can add a timeout like `sleep 10.seconds` after `#listen` returns.
+#
+# ### Reusing connections
+#
+# The request processor supports reusing a connection for subsequent
+# requests. This is used by default for HTTP/1.1 or when requested by
+# the `Connection: keep-alive` header. This is signalled by this header being
+# set on the `HTTP::Server::Response` when it's passed into the handler chain.
+#
+# If in the handler chain this header is overridden to `Connection: close`, then
+# the connection will not be reused after the request has been processed.
+#
+# Reusing the connection also requires that the request body (if present) is
+# entirely consumed in the handler chain. Otherwise the connection will be closed.
 class HTTP::Server
   @sockets = [] of Socket::Server
 

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -55,9 +55,26 @@ class HTTP::Server::RequestProcessor
 
         break unless request.keep_alive?
 
-        # Skip request body in case the handler
-        # didn't read it all, for the next request
-        request.body.try &.close
+        # Don't continue if the handler set `Connection` header to `close`
+        break unless HTTP.keep_alive?(response)
+
+        # The request body is either FixedLengthContent or ChunkedContent.
+        # In case it has not entirely been consumed by the handler, try to
+        # skip to the end. If the request is larger than maxmum skippable size,
+        # we close the connection even if keep alive was requested.
+        case body = request.body
+        when FixedLengthContent
+          if body.read_remaining > 16_384
+            # Close the connection if remaining length exceeds the maximum skipable size.
+            break
+          else
+            body.skip_to_end
+          end
+        when ChunkedContent
+          # Try to read maximum skipable number of bytes.
+          # Close the connection if the IO has still more to read.
+          break unless skip_to_end(body)
+        end
       end
     rescue ex : Errno
       # IO-related error, nothing to do
@@ -68,5 +85,17 @@ class HTTP::Server::RequestProcessor
         # IO-related error, nothing to do
       end
     end
+  end
+
+  # Reads and discards bytes from `io` until there are no more bytes.
+  # If there are more than 16_384 bytes to be read from the IO, it returns `false`.
+  private def skip_to_end(io : IO) : Bool
+    buffer = uninitialized UInt8[4096]
+
+    4.times do
+      return true if io.read(buffer.to_slice) < 4096
+    end
+
+    false
   end
 end


### PR DESCRIPTION
Fixes #6924

This removes the `skip_to_end` call from `HTTP::Content#close`, which would involuntary consume a large (or infinite) HTTP body.

Instead, the logic is moved to `RequestProcessor` and it closes the connection if the body is too large (in this case `>16kb`).

I'm not entirely sure if it should skip any body at all automatically. I'm more leaning towards making this the responsibility of the handler. And the rule would just be if the handler doesn't entirely consume the request body, the connection can't be reused. It's probably fine to leave some leeway, though. That's why I included this into the PR. But we can easily remove it and break if the body contains any data at all.
I'll leave that up for discussion.

The handler can also tell the request processor to close the connection by setting `Connection: close` header.