### PR TITLE
Generate toplevel docs correctly

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -1,0 +1,85 @@
+require "../../../spec_helper"
+
+describe Doc::Generator do
+  describe "must_include_toplevel?" do
+    it "returns false if program has nothing" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      generator.must_include_toplevel?(doc_type).should be_false
+    end
+
+    it "returns true if program has constant" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      constant = Const.new program, program, "Foo", 1.int32
+      constant.add_location Location.new "foo", 1, 1
+      program.types[constant.name] = constant
+
+      generator.must_include_toplevel?(doc_type).should be_true
+    end
+
+    it "returns false if program has constant which is defined in other place" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      constant = Const.new program, program, "Foo", 1.int32
+      constant.add_location Location.new "bar", 1, 1
+      program.types[constant.name] = constant
+
+      generator.must_include_toplevel?(doc_type).should be_false
+    end
+
+    it "returns true if program has macro" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo"
+      a_macro.location = Location.new "foo", 1, 1
+      program.add_macro a_macro
+
+      generator.must_include_toplevel?(doc_type).should be_true
+    end
+
+    it "returns false if program has macro which is defined in other place" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_macro = Macro.new "foo"
+      a_macro.location = Location.new "bar", 1, 1
+      program.add_macro a_macro
+
+      generator.must_include_toplevel?(doc_type).should be_false
+    end
+
+    it "returns true if program has method" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.location = Location.new "foo", 1, 1
+      program.add_def a_def
+
+      generator.must_include_toplevel?(doc_type).should be_true
+    end
+
+    it "returns false if program has method which is defined in other place" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.location = Location.new "bar", 1, 1
+      program.add_def a_def
+
+      generator.must_include_toplevel?(doc_type).should be_false
+    end
+  end
+end


### PR DESCRIPTION
Fixed #6637

Until now `crystal docs` needs to define public toplevel method for generating `toplevel.html`. It seems a bug.

By this fix, `toplevel.html` is generated only if public toplevel constant, method or macro is defined under your project. I think it is proper behavior.

Thank you.