### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@
 # * alpine is unable to to use the github .tar.gz compiler
 #
 
-INSTALL_GITHUB_TARGZ = true
+INSTALL_GITHUB_TARGZ = false
 GITHUB_URL = "https://github.com/crystal-lang/crystal/releases/download/0.27.0/crystal-0.27.0-1"
 CRYSTAL_LINUX64_TARGZ = "#{GITHUB_URL}-linux-x86_64.tar.gz"
 CRYSTAL_LINUX32_TARGZ = "#{GITHUB_URL}-linux-i686.tar.gz"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,6 @@
 # * freebsd needs post install manual scripts in order to install crystal.
 # * alpine provisionning is failing due to openssl libressl issues.
 # * alpine is unable to to use the github .tar.gz compiler
-# * there is no crystal pre built package for alpine32
 #
 
 INSTALL_GITHUB_TARGZ = true
@@ -58,7 +57,6 @@ Vagrant.configure("2") do |config|
   define_freebsd config, name: 'freebsd11', box: '11.2-STABLE', github_targz: false
 
   define_alpine config, name: 'alpine64', bits: 64, github_targz: false
-  define_alpine config, name: 'alpine32', bits: 32, github_targz: false
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 6*1024

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,33 @@ GITHUB_URL = "https://github.com/crystal-lang/crystal/releases/download/0.27.0/c
 CRYSTAL_LINUX64_TARGZ = "#{GITHUB_URL}-linux-x86_64.tar.gz"
 CRYSTAL_LINUX32_TARGZ = "#{GITHUB_URL}-linux-i686.tar.gz"
 
+Vagrant.configure("2") do |config|
+  define_ubuntu config, name: 'bionic64', dist: 'bionic', bits: 64
+  define_ubuntu config, name: 'xenial64', dist: 'xenial', bits: 64
+  define_ubuntu config, name: 'xenial32', dist: 'xenial', bits: 32
+  # llvm packages > 3.8 are not available for precise/trusty. Using pre built packages
+  define_ubuntu config, name: 'trusty64', dist: 'trusty', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'trusty32', dist: 'trusty', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'precise64', dist: 'precise', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'precise32', dist: 'precise', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
+
+  define_debian config, name: 'stretch64', dist: 'stretch', bits: 64
+  define_debian config, name: 'jessie64', dist: 'jessie', bits: 64
+
+  define_freebsd config, name: 'freebsd11', box: '11.2-STABLE', github_targz: false
+
+  define_alpine config, name: 'alpine64', bits: 64, github_targz: false
+  define_alpine config, name: 'alpine32', bits: 32, github_targz: false
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 6*1024
+    vb.cpus = 2
+
+    # Keep time synced with host
+    # vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
+  end
+end
+
 def clone_crystal_from_vagrant(config)
   # use ~/crystal directory instead of /vagrant
   # to have a clean copy of working directory
@@ -273,29 +300,3 @@ def define_alpine(config, name:, bits:, github_targz: INSTALL_GITHUB_TARGZ)
   end
 end
 
-Vagrant.configure("2") do |config|
-  define_ubuntu config, name: 'bionic64', dist: 'bionic', bits: 64
-  define_ubuntu config, name: 'xenial64', dist: 'xenial', bits: 64
-  define_ubuntu config, name: 'xenial32', dist: 'xenial', bits: 32
-  # llvm packages > 3.8 are not available for precise/trusty. Using pre built packages
-  define_ubuntu config, name: 'trusty64', dist: 'trusty', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
-  define_ubuntu config, name: 'trusty32', dist: 'trusty', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
-  define_ubuntu config, name: 'precise64', dist: 'precise', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
-  define_ubuntu config, name: 'precise32', dist: 'precise', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
-
-  define_debian config, name: 'stretch64', dist: 'stretch', bits: 64
-  define_debian config, name: 'jessie64', dist: 'jessie', bits: 64
-
-  define_freebsd config, name: 'freebsd11', box: '11.2-STABLE', github_targz: false
-
-  define_alpine config, name: 'alpine64', bits: 64, github_targz: false
-  define_alpine config, name: 'alpine32', bits: 32, github_targz: false
-
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = 6*1024
-    vb.cpus = 2
-
-    # Keep time synced with host
-    # vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
-  end
-end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ def install_crystal(c, family, dist:, bits:, github_targz:)
     c.vm.provision :shell, inline: %(
       mkdir -p /opt/crystal
       echo '#{targz_url}'
-      curl -sSL --output - '#{targz_url}' | tar xz -C /opt/crystal --strip-component=1 -f -
+      curl -sSL '#{targz_url}' | tar xz -C /opt/crystal --strip-component=1 -f -
 
       echo 'export LIBRARY_PATH=/opt/crystal/lib/crystal/lib/:${LIBRARY_PATH}' >> /etc/profile.d/crystal.sh
       echo 'export PATH=/opt/crystal/bin:$PATH' >> /etc/profile.d/crystal.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,30 +1,121 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-clone_crystal_from_vagrant = lambda do |config|
+# Usage
+#
+# ```
+# $ vagrant up xenial64
+# $ vagrant ssh xenial64
+# vagrant@ubuntu-xenial:~$ cd ~/crystal/
+# vagrant@ubuntu-xenial:~$ make std_spec
+# ```
+#
+# The working directory is also available at /vagrant
+# but using the clone in ~/crystal helps isolating the binaries
+# from each platform and it can be faster on some circumstances
+# where files are shared with host since the clone is in the
+# native fs.
+#
+# To use Makefile targets on some machines the `FLAGS=--no-debug`
+# might be needed to reduce the memory footprint.
+#
+# Notes:
+# * Running specs from /vagrant directly might cause some failures in
+#   specs related to permissions.
+# * bionic64 std_spec fails #6577
+# * xenial32 FLAGS=--no-debug is unable to run compiler_spec.
+# * trusty64 FLAGS=--no-debug is unable to build the compiler.
+# * precise32 is unable to build std_spec due to outdated libxml2. ~> 2.9.0 is required
+# * precise32 will fail running std_spec related to reuse_port & ipv6
+
+def clone_crystal_from_vagrant(config)
+  # use ~/crystal directory instead of /vagrant
+  # to have a clean copy of working directory
+  # in the native fs of the vm
   config.vm.provision :shell, privileged: false, inline: %(
     git clone /vagrant crystal
   )
 end
 
-Vagrant.configure("2") do |config|
-  %w(precise trusty xenial).product([32, 64]).each do |dist, bits|
-    box_name = "#{dist}#{bits}"
-
-    config.vm.define(box_name) do |c|
-      c.vm.box = "ubuntu/#{box_name}"
-
-      c.vm.provision :shell, inline: %(
-        curl -s https://dist.crystal-lang.org/apt/setup.sh | sh
-        apt-get install -y crystal git libgmp3-dev zlib1g-dev libedit-dev libxml2-dev libssl-dev libyaml-dev libreadline-dev g++
-        curl -s https://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-linux-`uname -m`.tar.gz | tar xz -C /opt
-        echo 'export LIBRARY_PATH="/opt/crystal/embedded/lib"' > /etc/profile.d/crystal.sh
-        echo 'export PATH="$PATH:/opt/llvm-3.5.0-1/bin"' >> /etc/profile.d/crystal.sh
+# define a ubuntu box with the given *name*
+# *llvm* values: 6.0, 7, (empty), Hash with {url:, path:}
+def define_ubuntu(config, name:, dist:, bits:, llvm: "6.0")
+  install_llvm =
+    if llvm.is_a?(Hash)
+      %(
+        curl -s #{llvm[:url]} | tar xz -C /opt
+        echo 'export PATH="$PATH:/opt/#{llvm[:path]}/bin"' >> /etc/profile.d/crystal.sh
       )
+    else
+      llvm_suffix = llvm != "" ? "-#{llvm}" : ""
 
-      clone_crystal_from_vagrant.call(c)
+      %(
+        add-apt-repository "deb http://apt.llvm.org/#{dist}/ llvm-toolchain-#{dist}#{llvm_suffix} main"
+        curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        apt-get update
+        apt-get install -y llvm#{llvm_suffix}-dev
+      )
     end
+
+  install_cxx =
+    if dist == "precise"
+      # llvm 3.9 requires g++ 4.7 or greater and is not the one shipped in precise
+      %(
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update
+        apt-get install -y g++-4.7
+        echo 'export CXX=g++-4.7' >> /etc/profile.d/crystal.sh
+      )
+    end
+
+  register_crystal_key =
+    if dist == "precise" || dist == "trusty"
+      %(
+        apt-key adv --keyserver keys.gnupg.net --recv-keys 09617FD37CC06B54
+      )
+    end
+
+  config.vm.define(name) do |c|
+    c.vm.box = "ubuntu/#{dist}#{bits}"
+
+    if bits == 32
+      config.vm.provider "virtualbox" do |vb|
+        vb.memory = 4*1024
+      end
+    end
+
+    c.vm.provision :shell, inline: %(
+      echo '' > /etc/profile.d/crystal.sh
+
+      apt-get install -y apt-transport-https curl build-essential git
+      apt-get install -y libxml2-dev libyaml-dev libreadline-dev libgmp3-dev libssl-dev
+      apt-get install -y
+
+      #{install_llvm}
+
+      #{install_cxx}
+
+      #{register_crystal_key}
+
+      curl -s https://dist.crystal-lang.org/apt/setup.sh | sh
+      apt-get install -y crystal
+
+      echo 'export LIBRARY_PATH="/usr/lib/crystal/lib/"' >> /etc/profile.d/crystal.sh
+    )
+
+    clone_crystal_from_vagrant(c)
   end
+end
+
+Vagrant.configure("2") do |config|
+  define_ubuntu config, name: 'bionic64', dist: 'bionic', bits: 64
+  define_ubuntu config, name: 'xenial64', dist: 'xenial', bits: 64
+  define_ubuntu config, name: 'xenial32', dist: 'xenial', bits: 32
+  # llvm packages > 3.8 are not available for precise/trusty. Using pre built packages
+  define_ubuntu config, name: 'trusty64', dist: 'trusty', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'trusty32', dist: 'trusty', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'precise64', dist: 'precise', bits: 64, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-x86_64.tar.gz", path: "llvm-3.9.1-1" }
+  define_ubuntu config, name: 'precise32', dist: 'precise', bits: 32, llvm: { url: "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.9.1-1-linux-i686.tar.gz", path: "llvm-3.9.1-1" }
 
   [[:jessie, '3.5'], [:stretch, '3.9']].product([32, 64]).each do |(dist, ver), bits|
     box_name = "#{dist}#{bits}"
@@ -61,11 +152,14 @@ Vagrant.configure("2") do |config|
       pkg install -y git gmake pkgconf pcre libunwind clang36 libyaml gmp libevent2
     )
 
-    clone_crystal_from_vagrant.call(c)
+    clone_crystal_from_vagrant(c)
   end
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = 4096
+    vb.memory = 6*1024
     vb.cpus = 2
+
+    # Keep time synced with host
+    # vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000 ]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,9 +54,9 @@ Vagrant.configure("2") do |config|
   define_debian config, name: 'stretch64', dist: 'stretch', bits: 64
   define_debian config, name: 'jessie64', dist: 'jessie', bits: 64
 
-  define_freebsd config, name: 'freebsd11', box: '11.2-STABLE', github_targz: false
+  define_freebsd config, name: 'freebsd11', box: '11.2-STABLE'
 
-  define_alpine config, name: 'alpine64', bits: 64, github_targz: false
+  define_alpine config, name: 'alpine64', bits: 64
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 6*1024
@@ -108,6 +108,8 @@ end
 # instructions to install crystal binary on all platforms
 def install_crystal(c, family, dist:, bits:, github_targz:)
   if github_targz
+    fail "github .tar.gz installation method for #{family} is not supported" unless family == "ubuntu" || family == "debian"
+
     targz_url = bits == 64 ? CRYSTAL_LINUX64_TARGZ : CRYSTAL_LINUX32_TARGZ
 
     c.vm.provision :shell, inline: %(
@@ -247,7 +249,7 @@ def define_debian(config, name:, dist:, bits:, llvm: nil, github_targz: INSTALL_
   end
 end
 
-def define_freebsd(config, name:, box:, github_targz: INSTALL_GITHUB_TARGZ)
+def define_freebsd(config, name:, box:)
   config.vm.define name do |c|
     c.ssh.shell = "sh"
     c.vm.box = "freebsd/FreeBSD-#{box}"
@@ -268,13 +270,13 @@ def define_freebsd(config, name:, box:, github_targz: INSTALL_GITHUB_TARGZ)
       pkg install -y llvm60
     )
 
-    install_crystal(c, "freebsd", dist: nil, bits: 64, github_targz: github_targz)
+    install_crystal(c, "freebsd", dist: nil, bits: 64, github_targz: false)
 
     clone_crystal_from_vagrant(c)
   end
 end
 
-def define_alpine(config, name:, bits:, github_targz: INSTALL_GITHUB_TARGZ)
+def define_alpine(config, name:, bits:)
   config.vm.define name do |c|
     c.vm.box = "alpine/alpine#{bits}"
 
@@ -292,7 +294,7 @@ def define_alpine(config, name:, bits:, github_targz: INSTALL_GITHUB_TARGZ)
         llvm4-dev llvm4-static || echo "WARNING: apk failed (ignored)"
     )
 
-    install_crystal(c, "alpine", dist: nil, bits: bits, github_targz: github_targz)
+    install_crystal(c, "alpine", dist: nil, bits: bits, github_targz: false)
 
     clone_crystal_from_vagrant(c)
   end


### PR DESCRIPTION
I'm was trying to bring up to date the Vagrantfile.

Despite which distros/versions are included I wanted to be able to:

**a.** Install a crystal compiler using each distro package management (even if they are not maintained by crystal-lang) and reproduce better the end use experience.

**b.** Install a crystal compiler from a .tar.gz hosted in github. This will allow up to date test without waiting for each platform and compile master easily without non crystal-lang resource.

I am not sure how to achieve (b) for freebsd and alpine. Or if we need to port the compiler in other platform before using it in the target ones. Help is apreciated here :-)

Aiming for (b) helps to have a porting instructions written that depends only in crystal-lang resources. It's a great reference for the future IMO.

Supporting (b) means that dependencies needs to be installed explictly. Whether for (a) that is not needed. This is the reason why lots of dependencies appears.

I'm also refactored the configurate to have an explicit list of machines defined, easier to follow and probably to tweak.

I also added some docs and notes, but before going further I would apprecite input to this a resource we can all feel comfortable using it.

Closes #4802, Closes #4803, Closes #6722.

cc: @j8r, @jirutka, @myfreeweb