### PR TITLE
Add MIME::MediaType

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -255,8 +255,8 @@ class HTTP::Client
     end
 
     it "returns content type and no charset" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain"})
-      response.content_type.should eq("text/plain")
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "application/octet-stream"})
+      response.content_type.should eq("application/octet-stream")
       response.charset.should be_nil
     end
 
@@ -273,8 +273,8 @@ class HTTP::Client
     end
 
     it "returns content type and no charset, other parameter (#2520)" do
-      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "text/plain ; colenc=U"})
-      response.content_type.should eq("text/plain")
+      response = Response.new(200, "", headers: HTTP::Headers{"Content-Type" => "application/octet-stream ; colenc=U"})
+      response.content_type.should eq("application/octet-stream")
       response.charset.should be_nil
     end
 

--- a/spec/std/http/multipart/builder_spec.cr
+++ b/spec/std/http/multipart/builder_spec.cr
@@ -65,7 +65,7 @@ describe HTTP::Multipart::Builder do
   describe "#content_type" do
     it "calculates the content type" do
       builder = HTTP::Multipart::Builder.new(IO::Memory.new, "a delimiter string with a quote in \"")
-      builder.content_type("alternative").should eq(%q(multipart/alternative; boundary="a\ delimiter\ string\ with\ a\ quote\ in\ \""))
+      builder.content_type("alternative").should eq(%q(multipart/alternative; boundary="a delimiter string with a quote in \""))
     end
   end
 

--- a/spec/std/mime/media_type_spec.cr
+++ b/spec/std/mime/media_type_spec.cr
@@ -1,0 +1,291 @@
+require "spec"
+require "mime/media_type"
+
+private def parse(string)
+  type = MIME::MediaType.parse(string)
+
+  {type.media_type, type.@params}
+end
+
+private def assert_format(string, format = string, file = __FILE__, line = __LINE__)
+  MIME::MediaType.parse(string).to_s.should eq(format), file, line
+end
+
+describe MIME::MediaType do
+  describe ".new" do
+    it "create new instance" do
+      media_type = MIME::MediaType.new("foo/bar", {"param" => "value"})
+      media_type.media_type.should eq "foo/bar"
+      media_type["param"].should eq "value"
+    end
+
+    it "raises for invalid parameter name" do
+      expect_raises(MIME::Error, %q(Invalid parameter name "ß")) do
+        MIME::MediaType.new("foo/bar", {"param" => "value", "ß" => "invalid"})
+      end
+    end
+  end
+
+  describe ".parse" do
+    it "parses media type" do
+      MIME::MediaType.parse("text/html; charset=utf-8").media_type.should eq "text/html"
+    end
+
+    it "parses params" do
+      parse("text/html; charset=utf-8").should eq({"text/html", {"charset" => "utf-8"}})
+
+      parse("text/html; charset=us-ascii").should eq({"text/html", {"charset" => "us-ascii"}})
+
+      parse("text/html; foo = bar; bar= foo ;").should eq({"text/html", {"foo" => "bar", "bar" => "foo", "charset" => "utf-8"}})
+
+      parse(%(form-data; name="foo")).should eq({"form-data", {"name" => "foo"}})
+      parse(%(form-data; name ="foo")).should eq({"form-data", {"name" => "foo"}})
+      parse(%(form-data; name= "foo")).should eq({"form-data", {"name" => "foo"}})
+
+      parse(%( form-data ; name=foo)).should eq({"form-data", {"name" => "foo"}})
+
+      parse(%(FORM-DATA;name="foo")).should eq({"form-data", {"name" => "foo"}})
+
+      parse(%( FORM-DATA ; name="foo")).should eq({"form-data", {"name" => "foo"}})
+
+      expect_raises(MIME::Error, "Missing media type") { parse("") }
+      expect_raises(MIME::Error, "Missing media type") { parse(" ") }
+      expect_raises(MIME::Error, "Missing media type") { parse(";") }
+      expect_raises(MIME::Error, "Missing media type") { parse(" ;") }
+
+      expect_raises(MIME::Error, "Missing attribute name at 10") { parse("form-data;=foo") }
+      expect_raises(MIME::Error, "Missing attribute name at ") { parse("form-data; =foo") }
+      expect_raises(MIME::Error, "Missing attribute value") { parse("form-data;foo") }
+
+      parse(%(form-data; key=value;  blah="value";name="foo" )).should eq({"form-data", {"key" => "value", "blah" => "value", "name" => "foo"}})
+
+      expect_raises(MIME::Error, "Duplicate key 'key' at 15") { parse(%(foo; key=val1; key=the-key-appears-again-which-is-bogus)) }
+
+      parse(%(FORM-DATA;NAMe="foo")).should eq({"form-data", {"name" => "foo"}})
+
+      # From RFC 2231:
+
+      parse(%(application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A)).should eq({"application/x-stuff", {"title" => "This is ***fun***"}})
+
+      parse(%(message/external-body; access-type=URL; URL*0="ftp://";URL*1="cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar")).should eq({
+        "message/external-body",
+        {"access-type" => "URL", "url" => "ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar"},
+      })
+
+      # Tests from http://greenbytes.de/tech/tc2231/
+
+      # attonly
+      parse(%(attachment)).should eq({"attachment", {} of String => String})
+      # attonlyucase
+      parse(%(ATTACHMENT)).should eq({"attachment", {} of String => String})
+      # attwithasciifilename
+      parse(%(attachment; filename="foo.html")).should eq({"attachment", {"filename" => "foo.html"}})
+      # attwithasciifilename25
+      parse(%(attachment; filename="0000000000111111111122222")).should eq({"attachment", {"filename" => "0000000000111111111122222"}})
+      # attwithasciifilename35
+      parse(%(attachment; filename="00000000001111111111222222222233333")).should eq({"attachment", {"filename" => "00000000001111111111222222222233333"}})
+      # attwithasciifnescapedchar
+      parse(%(attachment; filename="f\\oo.html")).should eq({"attachment", {"filename" => "f\\oo.html"}})
+      # attwithasciifnescapedquote
+      parse(%(attachment; filename="\\"quoting\\" tested.html")).should eq({"attachment", {"filename" => %("quoting" tested.html)}})
+      # attwithquotedsemicolon
+      parse(%(attachment; filename="Here's a semicolon;.html")).should eq({"attachment", {"filename" => "Here's a semicolon;.html"}})
+      # attwithfilenameandextparam
+      parse(%(attachment; foo="bar"; filename="foo.html")).should eq({"attachment", {"foo" => "bar", "filename" => "foo.html"}})
+      # attwithfilenameandextparamescaped
+      parse(%(attachment; foo="\\"\\\\";filename="foo.html")).should eq({"attachment", {"foo" => %("\\), "filename" => "foo.html"}})
+      # attwithasciifilenameucase
+      parse(%(attachment; FILENAME="foo.html")).should eq({"attachment", {"filename" => "foo.html"}})
+      # attwithasciifilenamenq
+      parse(%(attachment; filename=foo.html)).should eq({"attachment", {"filename" => "foo.html"}})
+      # attwithasciifilenamenqs
+      parse(%(attachment; filename=foo.html ;)).should eq({"attachment", {"filename" => "foo.html"}})
+      # attwithfntokensq
+      parse(%(attachment; filename='foo.html')).should eq({"attachment", {"filename" => "'foo.html'"}})
+      # attwithisofnplain
+      parse(%(attachment; filename="foo-ä.html")).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attwithutf8fnplain
+      parse(%(attachment; filename="foo-Ã¤.html")).should eq({"attachment", {"filename" => "foo-Ã¤.html"}})
+      # attwithfnrawpctenca
+      parse(%(attachment; filename="foo-%41.html")).should eq({"attachment", {"filename" => "foo-%41.html"}})
+      # attwithfnusingpct
+      parse(%(attachment; filename="50%.html")).should eq({"attachment", {"filename" => "50%.html"}})
+      # attwithfnrawpctencaq
+      parse(%(attachment; filename="foo-%\\41.html")).should eq({"attachment", {"filename" => "foo-%\\41.html"}})
+      # attwithnamepct
+      parse(%(attachment; name="foo-%41.html")).should eq({"attachment", {"name" => "foo-%41.html"}})
+      # attwithfilenamepctandiso
+      parse(%(attachment; name="ä-%41.html")).should eq({"attachment", {"name" => "ä-%41.html"}})
+      # attwithfnrawpctenclong
+      parse(%(attachment; filename="foo-%c3%a4-%e2%82%ac.html")).should eq({"attachment", {"filename" => "foo-%c3%a4-%e2%82%ac.html"}})
+      # attwithasciifilenamews1
+      parse(%(attachment; filename ="foo.html")).should eq({"attachment", {"filename" => "foo.html"}})
+      # attmissingdisposition
+      expect_raises(MIME::Error, "Invalid character '=' at 8") { parse(%(filename=foo.html)) }
+      # attmissingdisposition2
+      expect_raises(MIME::Error, "Invalid character '=' at 1") { parse(%(x=y; filename=foo.html)) }
+      # attmissingdisposition3
+      expect_raises(MIME::Error, "Invalid character '\"' at 0") { parse(%("foo; filename=bar;baz"; filename=qux)) }
+      # attmissingdisposition4
+      expect_raises(MIME::Error, "Invalid character '=' at 8") { parse(%(filename=foo.html, filename=bar.html)) }
+      # emptydisposition
+      expect_raises(MIME::Error, "Missing media type") { parse(%(; filename=foo.html)) }
+      # doublecolon
+      expect_raises(MIME::Error, "Invalid character ':' at 0") { parse(%(: inline; attachment; filename=foo.html)) }
+      # attandinline
+      expect_raises(MIME::Error, "Invalid ';' at 18, expecting '='") { parse(%(inline; attachment; filename=foo.html)) }
+      # attandinline2
+      expect_raises(MIME::Error, "Invalid ';' at 18, expecting '='") { parse(%(attachment; inline; filename=foo.html)) }
+      # attbrokenquotedfn
+      expect_raises(MIME::Error, "Invalid character '.' at 31, expecting ';'") { parse(%(attachment; filename="foo.html".txt)) }
+      # attbrokenquotedfn2
+      expect_raises(MIME::Error, "Unclosed quote at 25") { parse(%(attachment; filename="bar)) }
+      # attbrokenquotedfn3
+      expect_raises(MIME::Error, "Unexpected '\"' at 24") { parse(%(attachment; filename=foo"bar;baz"qux)) }
+      # attmultinstances
+      expect_raises(MIME::Error, "Duplicate key 'filename' at 43") { parse(%(attachment; filename=foo.html, attachment; filename=bar.html)) }
+      # attmissingdelim
+      expect_raises(MIME::Error, "Unexpected '=' at 28") { parse(%(attachment; foo=foo filename=bar)) }
+      # attmissingdelim2
+      expect_raises(MIME::Error, "Unexpected '=' at 28") { parse(%(attachment; filename=bar foo=foo)) }
+      # attmissingdelim3
+      expect_raises(MIME::Error, "Invalid character '=' at 19") { parse(%(attachment filename=bar)) }
+      # attreversed
+      expect_raises(MIME::Error, "Invalid character '=' at 8") { parse(%(filename=foo.html; attachment)) }
+      # attconfusedparam
+      parse(%(attachment; xfilename=foo.html)).should eq({"attachment", {"xfilename" => "foo.html"}})
+      # attcdate
+      parse(%(attachment; creation-date="Wed, 12 Feb 1997 16:29:51 -0500")).should eq({"attachment", {"creation-date" => "Wed, 12 Feb 1997 16:29:51 -0500"}})
+      # attmdate
+      parse(%(attachment; modification-date="Wed, 12 Feb 1997 16:29:51 -0500")).should eq({"attachment", {"modification-date" => "Wed, 12 Feb 1997 16:29:51 -0500"}})
+      # dispext
+      parse("foobar").should eq({"foobar", {} of String => String})
+      # dispextbadfn
+      parse(%(attachment; example="filename=example.txt")).should eq({"attachment", {"example" => "filename=example.txt"}})
+      # # attwithfn2231utf8
+      parse(%(attachment; filename*=UTF-8''foo-%c3%a4-%e2%82%ac.html)).should eq({"attachment", {"filename" => "foo-ä-€.html"}})
+      # attwithfn2231noc
+      parse(%(attachment; filename*=''foo-%c3%a4-%e2%82%ac.html)).should eq({"attachment", {} of String => String})
+      # attwithfn2231utf8comp
+      parse(%(attachment; filename*=UTF-8''foo-a%cc%88.html)).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attwithfn2231ws2
+      parse(%(attachment; filename*= UTF-8''foo-%c3%a4.html)).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attwithfn2231ws3
+      parse(%(attachment; filename* =UTF-8''foo-%c3%a4.html)).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attwithfn2231quot
+      parse(%(attachment; filename*="UTF-8''foo-%c3%a4.html")).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attwithfn2231quot2
+      parse(%(attachment; filename*="foo%20bar.html")).should eq({"attachment", {} of String => String})
+      # attwithfn2231singleqmissing
+      parse(%(attachment; filename*=UTF-8'foo-%c3%a4.html)).should eq({"attachment", {} of String => String})
+      # attwithfn2231nbadpct1
+      parse(%(attachment; filename*=UTF-8''foo%)).should eq({"attachment", {} of String => String})
+      # attwithfn2231nbadpct2
+      parse(%(attachment; filename*=UTF-8''f%oo.html)).should eq({"attachment", {} of String => String})
+      # attwithfn2231dpct
+      parse(%(attachment; filename*=UTF-8''A-%2541.html)).should eq({"attachment", {"filename" => "A-%41.html"}})
+      # attfncont
+      parse(%(attachment; filename*0="foo."; filename*1="html")).should eq({"attachment", {"filename" => "foo.html"}})
+
+      expect_raises(MIME::Error, "Duplicate key 'foo *0' at 25") { parse(%(attachment; foo*0="foo"; foo *0="bar")) }
+      expect_raises(MIME::Error, "Duplicate key 'foo* 0' at 25") { parse(%(attachment; foo*0="foo"; foo* 0="bar")) }
+      expect_raises(MIME::Error, "Invalid key 'foo*foo' at 12") { parse(%(attachment; foo*foo=foo)) }
+
+      # attfncontenc
+      parse(%(attachment; filename*0*=UTF-8''foo-%c3%a4; filename*1=".html")).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attfncontlz
+      parse(%(attachment; filename*0="foo"; filename*01="bar")).should eq({"attachment", {"filename" => "foo"}})
+      # attfncontnc
+      parse(%(attachment; filename*0="foo"; filename*2="bar")).should eq({"attachment", {"filename" => "foo"}})
+      # attfnconts1
+      parse(%(attachment; filename*1="foo."; filename*2="html")).should eq({"attachment", {} of String => String})
+      # attfncontord
+      parse(%(attachment; filename*1="bar"; filename*0="foo")).should eq({"attachment", {"filename" => "foobar"}})
+      # attfnboth
+      parse(%(attachment; filename="foo-ae.html"; filename*=UTF-8''foo-%c3%a4.html)).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attfnboth2
+      parse(%(attachment; filename*=UTF-8''foo-%c3%a4.html; filename="foo-ae.html")).should eq({"attachment", {"filename" => "foo-ä.html"}})
+      # attfnboth3
+      parse(%(attachment; filename*0*=ISO-8859-15''euro-sign%3d%a4; filename*=ISO-8859-1''currency-sign%3d%a4)).should eq({"attachment", {"filename" => "currency-sign=¤"}})
+      # attnewandfn
+      parse(%(attachment; foobar=x; filename="foo.html")).should eq({"attachment", {"foobar" => "x", "filename" => "foo.html"}})
+
+      # Browsers also just send UTF-8 directly without RFC 2231,
+      # at least when the source page is served with UTF-8.
+      parse(%(form-data; firstname="Брэд"; lastname="Фицпатрик")).should eq({"form-data", {"firstname" => "Брэд", "lastname" => "Фицпатрик"}})
+
+      # Empty string used to be mishandled.
+      parse(%(foo; bar="")).should eq({"foo", {"bar" => ""}})
+
+      # Microsoft browsers in intranet mode do not think they need to escape \ in file name.
+      parse(%(form-data; name="file"; filename="C:\\dev\\go\\robots.txt")).should eq({"form-data", {"name" => "file", "filename" => "C:\\dev\\go\\robots.txt"}})
+
+      # Skip whitespace after =
+      parse(%(form-data; foo= foo)).should eq({"form-data", {"foo" => "foo"}})
+      parse(%(form-data; foo= " foo ")).should eq({"form-data", {"foo" => " foo "}})
+    end
+
+    it "sets default charset to utf-8 for text media types" do
+      type = MIME::MediaType.parse("text/html")
+      type["charset"]?.should eq "utf-8"
+
+      type = MIME::MediaType.parse("application/html")
+      type["charset"]?.should be_nil
+    end
+  end
+
+  it "#sub_type" do
+    MIME::MediaType.new("text/plain").sub_type.should eq "plain"
+    MIME::MediaType.new("foo").sub_type.should be_nil
+  end
+
+  it "#type" do
+    MIME::MediaType.new("text/plain").type.should eq "text"
+    MIME::MediaType.new("foo").type.should eq "foo"
+  end
+
+  it "#to_s" do
+    assert_format "foo/bar"
+    assert_format "text/plain; charset=utf-8"
+    assert_format "foo/bar; foo=bar; bar=foo;", "foo/bar; foo=bar; bar=foo"
+    assert_format "form-data; name=foo"
+    assert_format "attachment"
+    assert_format %(attachment; faa="\\"\\\\"; filename="foo.html?")
+    assert_format %(attachment; filename="foo-Ã¤.html")
+    assert_format %(attachment; filename=foo-%41.html)
+    assert_format %(attachment; filename="\\"quoting\\" tested.html")
+  end
+
+  it "#fetch" do
+    MIME::MediaType.parse("x-application/example").fetch("foo", "baz").should eq "baz"
+    MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo", "baz").should eq "bar"
+    MIME::MediaType.parse("x-application/example").fetch("foo") { |key| key }.should eq "foo"
+    MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo") { |key| key }.should eq "bar"
+  end
+
+  it "#[]=" do
+    mime_type = MIME::MediaType.parse("x-application/example")
+    mime_type["foo"] = "bar"
+    mime_type["foo"].should eq "bar"
+
+    expect_raises(MIME::Error, "Invalid parameter name") do
+      mime_type["ä"] = "foo"
+    end
+  end
+
+  it "#each_parameter" do
+    mime_type = MIME::MediaType.parse("x-application/example; foo=bar; bar=baz")
+
+    arr = [] of String
+    mime_type.each_parameter do |key, value|
+      arr << "#{key}=#{value}"
+    end
+    arr.should eq ["foo=bar", "bar=baz"]
+
+    arr = [] of String
+    mime_type.each_parameter.each do |key, value|
+      arr << "#{key}=#{value}"
+    end
+    arr.should eq ["foo=bar", "bar=baz"]
+  end
+end

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -1,5 +1,6 @@
 require "../client"
 require "../common"
+require "mime/media_type"
 
 class HTTP::Client::Response
   getter version : String
@@ -44,19 +45,17 @@ class HTTP::Client::Response
     HTTP.keep_alive?(self)
   end
 
-  def content_type
-    process_content_type_header.content_type
+  def content_type : String?
+    mime_type.try &.media_type
   end
 
-  def charset
-    process_content_type_header.charset
+  def charset : String?
+    mime_type.try &.["charset"]?
   end
 
-  @computed_content_type_header : ComputedContentTypeHeader?
-
-  private def process_content_type_header
-    @computed_content_type_header ||= begin
-      HTTP.content_type_and_charset(headers)
+  def mime_type : MIME::MediaType?
+    if content_type = headers["Content-Type"]?
+      MIME::MediaType.parse(content_type)
     end
   end
 

--- a/src/http/multipart.cr
+++ b/src/http/multipart.cr
@@ -1,5 +1,6 @@
 require "random/secure"
 require "./multipart/*"
+require "mime/media_type"
 
 # The `HTTP::Multipart` module contains utilities for parsing MIME multipart
 # messages, which contain multiple body parts, each containing a header section
@@ -35,10 +36,15 @@ module HTTP::Multipart
   # HTTP::Multipart.parse_boundary("multipart/mixed; boundary=\"abcde\"") # => "abcde"
   # ```
   def self.parse_boundary(content_type)
-    # TODO: remove regex
-    match = content_type.match(/\Amultipart\/.*boundary="?([^";,]+)"?/i)
-    return nil unless match
-    HTTP.dequote_string(match[1])
+    type = MIME::MediaType.parse?(content_type)
+
+    if type && type.type == "multipart"
+      boundary = type["boundary"]?
+
+      if boundary && !boundary.empty?
+        boundary
+      end
+    end
   end
 
   # Parses a MIME multipart message, yielding `HTTP::Headers` and an `IO` for

--- a/src/http/multipart/builder.cr
+++ b/src/http/multipart/builder.cr
@@ -1,3 +1,5 @@
+require "mime/media_type"
+
 module HTTP::Multipart
   # Builds a multipart MIME message.
   #
@@ -30,13 +32,7 @@ module HTTP::Multipart
     # builder.content_type("mixed") # => "multipart/mixed; boundary=\"a4VF\""
     # ```
     def content_type(subtype = "mixed")
-      String.build do |str|
-        str << "multipart/"
-        str << subtype
-        str << "; boundary=\""
-        HTTP.quote_string(@boundary, str)
-        str << '"'
-      end
+      MIME::MediaType.new("multipart/#{subtype}", {"boundary" => @boundary}).to_s
     end
 
     # Appends *string* to the preamble segment of the multipart message. Throws

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -1,0 +1,494 @@
+require "uri"
+require "http"
+require "mime"
+
+module MIME
+  # A `MediaType` describes a MIME content type with optional parameters.
+  struct MediaType
+    getter media_type : String
+
+    # Creates a new `MediaType` instance.
+    def initialize(@media_type, @params = {} of String => String)
+      @params.each_key do |name|
+        raise Error.new("Invalid parameter name #{name.inspect}") unless MIME::MediaType.token? name
+      end
+    end
+
+    def to_s(io : IO)
+      io << media_type
+
+      @params.each do |key, value|
+        io << "; "
+        io << key.downcase << '='
+
+        if MIME::MediaType.token? value
+          io << value
+        else
+          io << '"'
+          MIME::MediaType.quote_string(value, io)
+          io << '"'
+        end
+      end
+    end
+
+    # Returns the value for the parameter given by *key*. If not found, raises `KeyError`.
+    #
+    # ```
+    # MIME::MediaType.parse("text/plain; charset=UTF-8")["charset"] # => "UTF-8"
+    # MIME::MediaType.parse("text/plain; charset=UTF-8")["foo"]     # raises KeyError
+    # ```
+    def [](key : String) : String
+      @params[key]
+    end
+
+    # Returns the value for the parameter given by *key*. If not found, returns `nil`.
+    #
+    # ```
+    # MIME::MediaType.parse("text/plain; charset=UTF-8")["charset"]? # => "UTF-8"
+    # MIME::MediaType.parse("text/plain; charset=UTF-8")["foo"]?     # => nil
+    # ```
+    def []?(key : String) : String?
+      @params[key]?
+    end
+
+    # Sets the value of parameter *key* to the given value.
+    #
+    # ```
+    # mime_type = MIME::MediaType.parse("x-application/example")
+    # mime_type["foo"] = "bar"
+    # mime_type["foo"] # => "bar"
+    # ```
+    def []=(key : String, value : String)
+      raise Error.new("Invalid parameter name") unless MIME::MediaType.token? key
+      @params[key] = value
+    end
+
+    # Returns the value for the parameter given by *key*, or when not found the value given by *default*.
+    #
+    # ```
+    # MIME::MediaType.parse("x-application/example").fetch("foo", "baz")          # => "baz"
+    # MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo", "baz") # => "bar"
+    # ```
+    def fetch(key : String, default)
+      @params.fetch(key, default)
+    end
+
+    # Returns the value for the parameter given by *key*, or when not found calls the given block with the *key*.
+    #
+    # ```
+    # MIME::MediaType.parse("x-application/example").fetch("foo") { |key| key }          # => "foo"
+    # MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo") { |key| key } # => "bar"
+    # ```
+    def fetch(key : String, &block : String -> _)
+      @params.fetch(key) { |key| yield key }
+    end
+
+    # Calls the given block for each parameter and passes in the key and the value.
+    def each_parameter(&block : String, String -> _) : Nil
+      @params.each do |key, value|
+        yield key, value
+      end
+    end
+
+    # Returns an iterator over the parameter which behaves like an `Iterator` returning a `Tuple` of key and value.
+    def each_parameter : Iterator(Tuple(String, String))
+      @params.each
+    end
+
+    # First component of `media_type`.
+    #
+    # ```
+    # MIME::MediaType.new("text/plain").type # => "text"
+    # MIME::MediaType.new("foo").type        # => "foo"
+    # ```
+    #
+    def type : String
+      index = media_type.byte_index('/'.ord) || media_type.bytesize
+      media_type.byte_slice(0, index)
+    end
+
+    # Second component of `media_type` or `nil`.
+    #
+    # ```
+    # MIME::MediaType.new("text/plain").sub_type # => "plain"
+    # MIME::MediaType.new("foo").sub_type        # => nil
+    # ```
+    def sub_type : String?
+      index = media_type.byte_index('/'.ord) || return
+      media_type.byte_slice(index + 1, media_type.bytesize - index - 1)
+    end
+
+    # Parses a MIME type string representation including any optional parameters,
+    # per RFC 1521.
+    # Media types are the values in `Content-Type` and `Content-Disposition` HTTP
+    # headers (RFC 2183).
+    #
+    # Media type is lowercased and trimmed of white space. Param keys are lowercased.
+    #
+    # Raises `MIME::Error` on error.
+    def self.parse(string : String) : MediaType
+      parse_impl(string) { |err| raise MIME::Error.new("Parsing error: #{err} (#{string.dump})") }
+    end
+
+    # Parses a MIME type string representation including any optional parameters,
+    # per RFC 1521.
+    # Media types are the values in `Content-Type` and `Content-Disposition` HTTP
+    # headers (RFC 2183).
+    #
+    # Media type is lowercased and trimmed of white space. Param keys are lowercased.
+    #
+    # Returns `nil` on error.
+    def self.parse?(string : String) : MediaType?
+      parse_impl(string) { return nil }
+    end
+
+    # This methods parses a MIME media type according to RFC 2231
+    private def self.parse_impl(string : String, &block : String -> NoReturn)
+      reader = Char::Reader.new(string)
+
+      # 1. Reading the type and subtype, separated by a '/'
+      #    media_type := type "/" sub_type
+
+      sub_type_start = -1 # invalid value to detect if sub type start was read
+      while reader.has_next?
+        char = reader.current_char
+
+        if char == ';'
+          # when ';' is reached, the media type is finished
+          # optional parameters may follow
+          break
+        elsif char == '/'
+          # Abort if there had already been a '/'
+          yield "Invalid '/' at #{reader.pos}" if sub_type_start > -1
+
+          # The separator between type and subtype has been reached
+          sub_type_start = reader.pos
+          reader.next_char
+        elsif token?(char)
+          reader.next_char
+        else
+          yield "Invalid character '#{char}' at #{reader.pos}"
+        end
+      end
+
+      # string is empty or first character was a ';'
+      yield "Missing media type" if reader.pos == 0
+
+      mediatype = string.byte_slice(0, reader.pos).strip.downcase
+
+      # string contained only whitespace as media type
+      yield "Missing media type" if mediatype.empty?
+
+      # 2. Consume parameters, consisting of attribute-value pairs
+      #     parameters := *( ";" parameter)
+      #     parameter  := attribute "=" value
+
+      # Stores regular attribute-value pairs
+      params = {} of String => String
+
+      # Stores extended parameters with continuating values
+      continuation = Hash(String, Hash(String, String)).new do |hash, key|
+        hash[key] = {} of String => String
+      end
+
+      while reader.has_next?
+        # Consume optional whitespace
+        reader = consume_whitespace(reader)
+
+        break unless reader.has_next?
+
+        # ';' has not been consumed previously
+        reader.next_char
+
+        # Consume optional whitespace
+        reader = consume_whitespace(reader)
+
+        break unless reader.has_next?
+
+        key_start = reader.pos
+
+        # Consume attribute name and break at '='
+        while reader.has_next?
+          case char = reader.current_char
+          when ';'
+            yield "Invalid ';' at #{reader.pos}, expecting '='"
+          when '='
+            break
+          else
+            unless token?(char)
+              yield "Invalid character '#{char}' at #{reader.pos}"
+            end
+
+            reader.next_char
+          end
+        end
+
+        # Read the attribute name into a variable. It is case-insensitive and
+        # might be surrounded by whitespace, hence `.rstrip.downcase`.
+        key = string.byte_slice(key_start, reader.pos - key_start).rstrip.downcase
+
+        yield "Missing attribute name at #{key_start}" if key.empty?
+
+        # Consume '='
+        if reader.has_next?
+          reader.next_char
+        else
+          yield "Missing attribute value at #{reader.pos}"
+        end
+
+        # '*' designates an extended parameter name
+        # It is not yet processed but extended parameters are added to a
+        # special `continuation` map instead of `params` for later processing.
+        base_key, star, section = key.partition('*')
+        if star.empty?
+          if params.has_key?(key)
+            yield "Duplicate key '#{key}' at #{key_start}"
+          end
+
+          # Consume parameter value
+          reader, value = parse_parameter_value(reader) { |err| yield err }
+
+          # Add the attribute-value pair to `params`.
+          params[key] = value
+        else
+          # Remove whitespace surrounding '*'
+          base_key = base_key.rstrip
+          section = section.lstrip
+
+          section.each_char_with_index do |char, index|
+            unless char.ascii_number? || (char == '*' && index == section.bytesize - 1)
+              yield "Invalid key '#{key}' at #{key_start}"
+            end
+          end
+
+          # TODO: Using a different datastructure than `Hash` for storing
+          # continuation sections could improve performance.
+          normalized_key = "#{base_key}*#{section}"
+          continuation_map = continuation[base_key]
+          if continuation_map.has_key?(normalized_key)
+            yield "Duplicate key '#{key}' at #{key_start}"
+          end
+
+          # Consume parameter value
+          reader, value = parse_parameter_value(reader) { |err| yield err }
+
+          # Add the attribute-value pair to `continuation` map.
+          continuation_map[normalized_key] = value
+        end
+      end
+
+      # 3. Resolve continuation parameters
+      #
+      #     extended-parameter := (extended-initial-name "=" extended-value) /
+      #                           (extended-other-names "=" extended-other-values)
+      #
+      #     initial-section := "*0"
+      #
+      #     other-sections := "*" ("1" / "2" / "3" / "4" / "5" /
+      #                            "6" / "7" / "8" / "9") *DIGIT)
+      #
+      #     extended-initial-name := attribute [initial-section] "*"
+      #
+      #     extended-other-names := attribute other-sections "*"
+      #
+      #     extended-initial-value := [charset] "'" [language] "'" extended-other-values
+      #
+      #     extended-other-values := *(ext-octet / attribute-char)
+      continuation.each do |base_key, pieces|
+        # `#{base_key}*` is an extended-initial-name without inital-section.
+        # This is not the start of a continuation, just a single encoded value.
+        if value = pieces["#{base_key}*"]?
+          if decoded = decode_rfc2231(value)
+            params[base_key] = decoded
+          end
+          next
+        end
+
+        # All other pieces are extended-parameter and need to be sequentially
+        # ordered by section number
+        valid = false
+        composite_value = String.build do |io|
+          counter = 0
+          loop do
+            part_key = "#{base_key}*#{counter}"
+            if part = pieces[part_key]?
+              valid = true
+              io << part
+            elsif part = pieces["#{part_key}*"]?
+              valid = true
+
+              io << decode_rfc2231(part) || next
+            else
+              break
+            end
+            counter += 1
+          end
+        end
+        if valid
+          params[base_key] = composite_value
+        else
+          # TODO: Not sure if invalid parameter should error or just be ignored.
+          # yield "Invalid extended parameter: '#{base_key}'"
+        end
+      end
+
+      # text types should automatically use UTF-8 charset unless specified differently.
+      if mediatype.starts_with?("text/")
+        params["charset"] ||= "utf-8"
+      end
+
+      MediaType.new mediatype, params
+    end
+
+    private def self.parse_parameter_value(reader)
+      reader = consume_whitespace(reader)
+
+      # Quoted value.
+      if reader.current_char == '"'
+        reader.next_char
+
+        quoted = true
+        waiting_for_closing_quote = true
+      else
+        quoted = false
+        waiting_for_closing_quote = false
+      end
+
+      value = String.build do |io|
+        # Set positions for copying data from reader string to `io` in bulk.
+        value_start = reader.pos
+        value_end = reader.pos
+
+        while reader.has_next?
+          case char = reader.current_char
+          when ';'
+            break unless quoted
+
+            reader.next_char
+          when '"'
+            yield "Unexpected '\"' at #{reader.pos}" unless waiting_for_closing_quote
+
+            waiting_for_closing_quote = false
+            break
+          when '\\'
+            reader.next_char
+
+            char = reader.current_char
+            # Escape `\\` and `\"`
+            if char == '\\' || (quoted && char == '"')
+              # Write everything before the escaping backslash to io, then set
+              # `value_start` to the position of the escaped character, thus it
+              # will be included in the next write.
+              # This essentially skips writing the escaping backslash.
+              io.write reader.string.to_slice[value_start, reader.pos - value_start - 1]
+              value_start = reader.pos
+
+              reader.next_char
+            end
+          when '='
+            if quoted
+              reader.next_char
+            else
+              yield "Unexpected '=' at #{reader.pos}"
+            end
+          else
+            reader.next_char
+          end
+        end
+
+        if quoted
+          if waiting_for_closing_quote
+            yield "Unclosed quote at #{reader.pos}"
+          end
+
+          # Set position for final bulk copy.
+          value_end = reader.pos
+
+          reader.next_char
+
+          reader = consume_whitespace(reader)
+
+          if reader.has_next? && reader.current_char != ';'
+            yield "Invalid character '#{reader.current_char}' at #{reader.pos}, expecting ';'"
+          end
+        else
+          # remove right-hand-side whitespace when unquoted
+
+          # 1. Step one character back to check for whitespace.
+          reader.previous_char if reader.has_previous?
+          # 2. Remove whitespace.
+          while reader.has_previous? && reader.current_char.ascii_whitespace?
+            reader.previous_char
+          end
+          # 3. Step one character ahead again.
+          reader.next_char
+
+          value_end = reader.pos
+        end
+
+        io.write reader.string.to_slice[value_start, value_end - value_start]
+      end
+
+      return reader, value
+    end
+
+    private def self.decode_rfc2231(encoded : String)
+      encoding, split1, rest = encoded.partition('\'')
+      lang, split2, value = rest.partition('\'')
+
+      return if encoding.empty? || value.empty?
+
+      encoding = encoding.downcase
+
+      IO::Memory.new.tap do |io|
+        io.set_encoding encoding
+
+        reader = Char::Reader.new(value)
+        while reader.has_next?
+          case char = reader.current_char
+          when '%'
+            first = reader.next_char.to_i?(16) || return
+            second = reader.next_char.to_i?(16) || return
+
+            num = first << 4 | second
+            io.write_byte num.to_u8
+            reader.next_char
+          else
+            io << char
+            reader.next_char
+          end
+        end
+      end.rewind.gets_to_end
+    end
+
+    private def self.consume_whitespace(reader)
+      while reader.current_char.ascii_whitespace?
+        reader.next_char
+      end
+      reader
+    end
+
+    # :nodoc:
+    def self.token?(char : Char)
+      !TSPECIAL_CHARACTERS.includes?(char) && 0x20 <= char.ord < 0x7F
+    end
+
+    # :nodoc:
+    def self.token?(string)
+      string.each_char.all? { |char| token? char }
+    end
+
+    # :nodoc:
+    def self.quote_string(string, io)
+      string.each_byte do |byte|
+        case byte
+        when '"'.ord, '\\'.ord
+          io << '\\'
+        when 0x00..0x1F, 0x7F
+          raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+        end
+        io.write_byte byte
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `MIME::MediaType` type with methods for parsing mime media types as per [RFC 2045](https://tools.ietf.org/html/rfc2045) and [RFC 2046](https://tools.ietf.org/html/rfc2046) including support for optional parameters.

This type is put to use for reading and writing HTTP `Content-Type` headers and `HTTP::Multipart` boundaries replacing existing incomplete implementations.

This is not directly integrated with the `MIME` registry (added in #5765) but can be optionally used together.

Closes #5686