### PR TITLE
Validate LibC error codes in specs involving Errno errors

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../support/errno"
 
 private def it_raises_on_null_byte(operation, &block)
   it "errors on #{operation}" do
@@ -38,17 +39,16 @@ describe "Dir" do
     end
 
     it "tests empty? on nonexistent directory" do
-      expect_raises(Errno, /Error determining size of/) do
+      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{datapath("foo", "bar")}'") do
         Dir.empty?(datapath("foo", "bar"))
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "tests empty? on a directory path to a file" do
-      ex = expect_raises(Errno, /Error determining size of/) do
+      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("dir", "f1.txt", "/")}'") do
         Dir.empty?(datapath("dir", "f1.txt", "/"))
       end
-      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 
@@ -62,7 +62,7 @@ describe "Dir" do
   end
 
   it "tests mkdir with an existing path" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
       Dir.mkdir(datapath, 0o700)
     end
   end
@@ -79,21 +79,22 @@ describe "Dir" do
 
   it "tests mkdir_p with an existing path" do
     Dir.mkdir_p(datapath)
-    expect_raises Errno do
+    # FIXME: Refactor Dir#mkdir_p to remove leading `./` in error message
+    expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("dir", "f1.txt")}'") do
       Dir.mkdir_p(datapath("dir", "f1.txt"))
     end
   end
 
   it "tests rmdir with an nonexistent path" do
     with_tempfile("nonexistant") do |path|
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}'") do
         Dir.rmdir(path)
       end
     end
   end
 
   it "tests rmdir with a path that cannot be removed" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       Dir.rmdir(datapath)
     end
   end
@@ -326,7 +327,7 @@ describe "Dir" do
     end
 
     it "raises" do
-      expect_raises(Errno, "No such file or directory") do
+      expect_raises_errno(LibC::ENOENT, "Error while changing directory to '/nope'") do
         Dir.cd("/nope")
       end
     end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -39,14 +39,14 @@ describe "Dir" do
     end
 
     it "tests empty? on nonexistent directory" do
-      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{datapath("foo", "bar")}'") do
+      expect_raises_errno(Errno::ENOENT, "Error determining size of '#{datapath("foo", "bar")}'") do
         Dir.empty?(datapath("foo", "bar"))
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "tests empty? on a directory path to a file" do
-      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("dir", "f1.txt", "/")}'") do
+      expect_raises_errno(Errno::ENOTDIR, "Error determining size of '#{datapath("dir", "f1.txt", "/")}'") do
         Dir.empty?(datapath("dir", "f1.txt", "/"))
       end
     end
@@ -62,7 +62,7 @@ describe "Dir" do
   end
 
   it "tests mkdir with an existing path" do
-    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
+    expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath}'") do
       Dir.mkdir(datapath, 0o700)
     end
   end
@@ -80,21 +80,21 @@ describe "Dir" do
   it "tests mkdir_p with an existing path" do
     Dir.mkdir_p(datapath)
     # FIXME: Refactor Dir#mkdir_p to remove leading `./` in error message
-    expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("dir", "f1.txt")}'") do
+    expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("dir", "f1.txt")}'") do
       Dir.mkdir_p(datapath("dir", "f1.txt"))
     end
   end
 
   it "tests rmdir with an nonexistent path" do
     with_tempfile("nonexistant") do |path|
-      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}'") do
+      expect_raises_errno(Errno::ENOENT, "Unable to remove directory '#{path}'") do
         Dir.rmdir(path)
       end
     end
   end
 
   it "tests rmdir with a path that cannot be removed" do
-    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
+    expect_raises_errno(Errno::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       Dir.rmdir(datapath)
     end
   end
@@ -327,7 +327,7 @@ describe "Dir" do
     end
 
     it "raises" do
-      expect_raises_errno(LibC::ENOENT, "Error while changing directory to '/nope'") do
+      expect_raises_errno(Errno::ENOENT, "Error while changing directory to '/nope'") do
         Dir.cd("/nope")
       end
     end

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -84,7 +84,7 @@ describe File do
     end
 
     it "fails in unwritable folder" do
-      expect_raises_errno(LibC::ENOENT, "mkstemp: '#{datapath("non-existing-folder")}/") do
+      expect_raises_errno(Errno::ENOENT, "mkstemp: '#{datapath("non-existing-folder")}/") do
         File.tempfile dir: datapath("non-existing-folder")
       end
     end

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../support/errno"
 
 describe File do
   describe ".tempname" do
@@ -83,7 +84,7 @@ describe File do
     end
 
     it "fails in unwritable folder" do
-      expect_raises(Errno, /mkstemp: ".*\/non-existing-folder\/.*": No such file or directory/) do
+      expect_raises_errno(LibC::ENOENT, "mkstemp: '#{datapath("non-existing-folder")}/") do
         File.tempfile dir: datapath("non-existing-folder")
       end
     end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../support/errno"
 
 private def base
   Dir.current
@@ -105,17 +106,16 @@ describe "File" do
 
     it "raises an error when the file does not exist" do
       filename = datapath("non_existing_file.txt")
-      expect_raises(Errno, /Error determining size/) do
+      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{filename}'") do
         File.empty?(filename)
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "raises an error when a component of the path is a file" do
-      ex = expect_raises(Errno, /Error determining size/) do
+      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
         File.empty?(datapath("test_file.txt", ""))
       end
-      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 
@@ -379,7 +379,7 @@ describe "File" do
     end
 
     it "raises when destination doesn't exist" do
-      expect_raises(Errno) do
+      expect_raises_errno(LibC::ENOENT, "Error changing permissions of '#{datapath("unknown_chmod_path.txt")}'") do
         File.chmod(datapath("unknown_chmod_path.txt"), 0o664)
       end
     end
@@ -421,7 +421,7 @@ describe "File" do
   end
 
   it "gets info for non-existent file and raises" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::ENOENT, "Unable to get info for 'non-existent'") do
       File.info("non-existent")
     end
   end
@@ -464,17 +464,16 @@ describe "File" do
 
     it "raises an error when the file does not exist" do
       filename = datapath("non_existing_file.txt")
-      expect_raises(Errno, /Error determining size/) do
+      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{filename}'") do
         File.size(filename)
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "raises an error when a component of the path is a file" do
-      ex = expect_raises(Errno, /Error determining size/) do
+      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
         File.size(datapath("test_file.txt", ""))
       end
-      ex.errno.should eq(Errno::ENOTDIR)
     end
   end
 
@@ -490,7 +489,7 @@ describe "File" do
 
     it "raises errno when file doesn't exist" do
       with_tempfile("nonexistant_file.txt") do |path|
-        expect_raises Errno do
+        expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path}'") do
           File.delete(path)
         end
       end
@@ -511,7 +510,7 @@ describe "File" do
 
     it "raises if old file doesn't exist" do
       with_tempfile("rename-fail-source.txt", "rename-fail-target.txt") do |source_path, target_path|
-        expect_raises Errno do
+        expect_raises_errno(LibC::ENOENT, "Error renaming file '#{source_path}' to '#{target_path}'") do
           File.rename(source_path, target_path)
         end
       end
@@ -629,7 +628,7 @@ describe "File" do
     end
 
     it "raises Errno if file doesn't exist" do
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Error resolving real path of '/usr/share/foo/bar'") do
         File.real_path("/usr/share/foo/bar")
       end
     end
@@ -865,7 +864,7 @@ describe "File" do
       with_tempfile("truncate-opened.txt") do |path|
         File.write(path, "0123456789")
         File.open(path, "r") do |f|
-          expect_raises(Errno) do
+          expect_raises_errno(LibC::EINVAL, "Error truncating file '#{path}'") do
             f.truncate(4)
           end
         end
@@ -892,7 +891,7 @@ describe "File" do
         File.open(datapath("test_file.txt")) do |file2|
           file1.flock_exclusive do
             # BUG: check for EWOULDBLOCK when exception filters are implemented
-            expect_raises(Errno) do
+            expect_raises_errno(LibC::EAGAIN, "flock") do
               file2.flock_exclusive(blocking: false) { }
             end
           end
@@ -1147,7 +1146,7 @@ describe "File" do
       atime = Time.utc(2000, 1, 2)
       mtime = Time.utc(2000, 3, 4)
 
-      expect_raises Errno, "Error setting time on file" do
+      expect_raises_errno(LibC::ENOENT, "Error setting time on file '#{datapath("nonexistent_file.txt")}'") do
         File.utime(atime, mtime, datapath("nonexistent_file.txt"))
       end
     end
@@ -1183,7 +1182,7 @@ describe "File" do
 
     it "raises if path contains non-existent directory" do
       with_tempfile(File.join("nonexistant-dir", "touch.txt")) do |path|
-        expect_raises Errno, "Error opening file" do
+        expect_raises_errno(LibC::ENOENT, "Error opening file '#{path}'") do
           File.touch(path)
         end
       end
@@ -1191,7 +1190,7 @@ describe "File" do
 
     # TODO: there is no file which is reliably unwritable on windows
     pending_win32 "raises if file cannot be accessed" do
-      expect_raises Errno, "Operation not permitted" do
+      expect_raises_errno(LibC::EPERM, "Error setting time on file '/bin/ls'") do
         File.touch("/bin/ls")
       end
     end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -106,14 +106,14 @@ describe "File" do
 
     it "raises an error when the file does not exist" do
       filename = datapath("non_existing_file.txt")
-      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{filename}'") do
+      expect_raises_errno(Errno::ENOENT, "Error determining size of '#{filename}'") do
         File.empty?(filename)
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "raises an error when a component of the path is a file" do
-      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
+      expect_raises_errno(Errno::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
         File.empty?(datapath("test_file.txt", ""))
       end
     end
@@ -379,7 +379,7 @@ describe "File" do
     end
 
     it "raises when destination doesn't exist" do
-      expect_raises_errno(LibC::ENOENT, "Error changing permissions of '#{datapath("unknown_chmod_path.txt")}'") do
+      expect_raises_errno(Errno::ENOENT, "Error changing permissions of '#{datapath("unknown_chmod_path.txt")}'") do
         File.chmod(datapath("unknown_chmod_path.txt"), 0o664)
       end
     end
@@ -421,7 +421,7 @@ describe "File" do
   end
 
   it "gets info for non-existent file and raises" do
-    expect_raises_errno(LibC::ENOENT, "Unable to get info for 'non-existent'") do
+    expect_raises_errno(Errno::ENOENT, "Unable to get info for 'non-existent'") do
       File.info("non-existent")
     end
   end
@@ -464,14 +464,14 @@ describe "File" do
 
     it "raises an error when the file does not exist" do
       filename = datapath("non_existing_file.txt")
-      expect_raises_errno(LibC::ENOENT, "Error determining size of '#{filename}'") do
+      expect_raises_errno(Errno::ENOENT, "Error determining size of '#{filename}'") do
         File.size(filename)
       end
     end
 
     # TODO: do we even want this?
     pending_win32 "raises an error when a component of the path is a file" do
-      expect_raises_errno(LibC::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
+      expect_raises_errno(Errno::ENOTDIR, "Error determining size of '#{datapath("test_file.txt", "")}'") do
         File.size(datapath("test_file.txt", ""))
       end
     end
@@ -489,7 +489,7 @@ describe "File" do
 
     it "raises errno when file doesn't exist" do
       with_tempfile("nonexistant_file.txt") do |path|
-        expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path}'") do
+        expect_raises_errno(Errno::ENOENT, "Error deleting file '#{path}'") do
           File.delete(path)
         end
       end
@@ -510,7 +510,7 @@ describe "File" do
 
     it "raises if old file doesn't exist" do
       with_tempfile("rename-fail-source.txt", "rename-fail-target.txt") do |source_path, target_path|
-        expect_raises_errno(LibC::ENOENT, "Error renaming file '#{source_path}' to '#{target_path}'") do
+        expect_raises_errno(Errno::ENOENT, "Error renaming file '#{source_path}' to '#{target_path}'") do
           File.rename(source_path, target_path)
         end
       end
@@ -628,7 +628,7 @@ describe "File" do
     end
 
     it "raises Errno if file doesn't exist" do
-      expect_raises_errno(LibC::ENOENT, "Error resolving real path of '/usr/share/foo/bar'") do
+      expect_raises_errno(Errno::ENOENT, "Error resolving real path of '/usr/share/foo/bar'") do
         File.real_path("/usr/share/foo/bar")
       end
     end
@@ -864,7 +864,7 @@ describe "File" do
       with_tempfile("truncate-opened.txt") do |path|
         File.write(path, "0123456789")
         File.open(path, "r") do |f|
-          expect_raises_errno(LibC::EINVAL, "Error truncating file '#{path}'") do
+          expect_raises_errno(Errno::EINVAL, "Error truncating file '#{path}'") do
             f.truncate(4)
           end
         end
@@ -891,7 +891,7 @@ describe "File" do
         File.open(datapath("test_file.txt")) do |file2|
           file1.flock_exclusive do
             # BUG: check for EWOULDBLOCK when exception filters are implemented
-            expect_raises_errno(LibC::EAGAIN, "flock") do
+            expect_raises_errno(Errno::EAGAIN, "flock") do
               file2.flock_exclusive(blocking: false) { }
             end
           end
@@ -1146,7 +1146,7 @@ describe "File" do
       atime = Time.utc(2000, 1, 2)
       mtime = Time.utc(2000, 3, 4)
 
-      expect_raises_errno(LibC::ENOENT, "Error setting time on file '#{datapath("nonexistent_file.txt")}'") do
+      expect_raises_errno(Errno::ENOENT, "Error setting time on file '#{datapath("nonexistent_file.txt")}'") do
         File.utime(atime, mtime, datapath("nonexistent_file.txt"))
       end
     end
@@ -1182,7 +1182,7 @@ describe "File" do
 
     it "raises if path contains non-existent directory" do
       with_tempfile(File.join("nonexistant-dir", "touch.txt")) do |path|
-        expect_raises_errno(LibC::ENOENT, "Error opening file '#{path}'") do
+        expect_raises_errno(Errno::ENOENT, "Error opening file '#{path}'") do
           File.touch(path)
         end
       end
@@ -1190,7 +1190,7 @@ describe "File" do
 
     # TODO: there is no file which is reliably unwritable on windows
     pending_win32 "raises if file cannot be accessed" do
-      expect_raises_errno(LibC::EPERM, "Error setting time on file '/bin/ls'") do
+      expect_raises_errno(Errno::EPERM, "Error setting time on file '/bin/ls'") do
         File.touch("/bin/ls")
       end
     end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "file_utils"
+require "../support/errno"
 
 private class OneByOneIO < IO
   @bytes : Bytes
@@ -33,7 +34,7 @@ describe "FileUtils" do
     end
 
     it "raises" do
-      expect_raises(Errno, "No such file or directory") do
+      expect_raises_errno(LibC::ENOENT, "Error while changing directory to '/nope'") do
         FileUtils.cd("/nope")
       end
     end
@@ -252,7 +253,7 @@ describe "FileUtils" do
 
     it "raises an error if non correct arguments" do
       with_tempfile("mv-nonexitent") do |path|
-        expect_raises Errno do
+        expect_raises_errno(LibC::ENOENT, "Error renaming file '#{File.join(path, "a")}' to '#{File.join(path, "b")}'") do
           FileUtils.mv(File.join(path, "a"), File.join(path, "b"))
         end
       end
@@ -322,18 +323,18 @@ describe "FileUtils" do
   end
 
   it "tests mkdir with an existing path" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
       Dir.mkdir(datapath, 0o700)
     end
   end
 
   it "tests mkdir with multiples existing paths" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
       FileUtils.mkdir([datapath, datapath], 0o700)
     end
 
     with_tempfile("mkdir-nonexisting") do |path|
-      expect_raises Errno do
+      expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
         FileUtils.mkdir([path, datapath], 0o700)
       end
     end
@@ -364,7 +365,8 @@ describe "FileUtils" do
 
   it "tests mkdir_p with an existing path" do
     FileUtils.mkdir_p(datapath).should be_nil
-    expect_raises Errno do
+    # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
+    expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
       FileUtils.mkdir_p(datapath("test_file.txt"))
     end
   end
@@ -372,7 +374,8 @@ describe "FileUtils" do
   it "tests mkdir_p with multiple existing path" do
     FileUtils.mkdir_p([datapath, datapath]).should be_nil
     with_tempfile("mkdir_p-existing") do |path|
-      expect_raises Errno do
+      # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
+      expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
         FileUtils.mkdir_p([datapath("test_file.txt"), path])
       end
     end
@@ -380,7 +383,7 @@ describe "FileUtils" do
 
   it "tests rmdir with an non existing path" do
     with_tempfile("rmdir-nonexisting") do |path|
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}'") do
         FileUtils.rmdir(path)
       end
     end
@@ -388,20 +391,20 @@ describe "FileUtils" do
 
   it "tests rmdir with multiple non existing path" do
     with_tempfile("rmdir-nonexisting") do |path|
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}1'") do
         FileUtils.rmdir(["#{path}1", "#{path}2"])
       end
     end
   end
 
   it "tests rmdir with a path that cannot be removed" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       FileUtils.rmdir(datapath)
     end
   end
 
   it "tests rmdir with multiple path that cannot be removed" do
-    expect_raises Errno do
+    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       FileUtils.rmdir([datapath, datapath])
     end
   end
@@ -416,7 +419,7 @@ describe "FileUtils" do
 
   it "tests rm with non existing path" do
     with_tempfile("rm-nonexistinent") do |path|
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path}'") do
         FileUtils.rm(path)
       end
     end
@@ -437,7 +440,7 @@ describe "FileUtils" do
       File.write(path1, "")
       File.write(path2, "")
 
-      expect_raises Errno do
+      expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path2}'") do
         FileUtils.rm([path1, path2, path2])
       end
     end
@@ -498,11 +501,9 @@ describe "FileUtils" do
       path1 = "/tmp/crystal_ln_test_#{Process.pid}"
       path2 = "/tmp/crystal_ln_test_#{Process.pid + 1}"
 
-      ex = expect_raises Errno do
+      ex = expect_raises_errno(LibC::ENOENT, "Error creating link from '#{path1}' to '#{path2}'") do
         FileUtils.ln(path1, path2)
       end
-
-      ex.errno.should eq(Errno::ENOENT)
     end
 
     it "fails with an extant destination" do
@@ -512,11 +513,9 @@ describe "FileUtils" do
       begin
         FileUtils.touch([path1, path2])
 
-        ex = expect_raises Errno do
+        expect_raises_errno(LibC::EEXIST, "Error creating link from '#{path1}' to '#{path2}'") do
           FileUtils.ln(path1, path2)
         end
-
-        ex.errno.should eq(Errno::EEXIST)
       ensure
         FileUtils.rm_rf([path1, path2])
       end
@@ -583,11 +582,9 @@ describe "FileUtils" do
         File.exists?(path2).should be_false
         File.symlink?(path2).should be_true
 
-        ex = expect_raises Errno do
+        expect_raises_errno(LibC::ENOENT, "Error resolving real path of '#{path2}'") do
           File.real_path(path2)
         end
-
-        ex.errno.should eq(Errno::ENOENT)
       ensure
         FileUtils.rm_rf(path2)
       end
@@ -600,11 +597,9 @@ describe "FileUtils" do
       begin
         FileUtils.touch([path1, path2])
 
-        ex = expect_raises Errno do
+        expect_raises_errno(LibC::EEXIST, "Error creating symlink from '#{path1}' to '#{path2}'") do
           FileUtils.ln_s(path1, path2)
         end
-
-        ex.errno.should eq(Errno::EEXIST)
       ensure
         FileUtils.rm_rf([path1, path2])
       end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -34,7 +34,7 @@ describe "FileUtils" do
     end
 
     it "raises" do
-      expect_raises_errno(LibC::ENOENT, "Error while changing directory to '/nope'") do
+      expect_raises_errno(Errno::ENOENT, "Error while changing directory to '/nope'") do
         FileUtils.cd("/nope")
       end
     end
@@ -253,7 +253,7 @@ describe "FileUtils" do
 
     it "raises an error if non correct arguments" do
       with_tempfile("mv-nonexitent") do |path|
-        expect_raises_errno(LibC::ENOENT, "Error renaming file '#{File.join(path, "a")}' to '#{File.join(path, "b")}'") do
+        expect_raises_errno(Errno::ENOENT, "Error renaming file '#{File.join(path, "a")}' to '#{File.join(path, "b")}'") do
           FileUtils.mv(File.join(path, "a"), File.join(path, "b"))
         end
       end
@@ -323,18 +323,18 @@ describe "FileUtils" do
   end
 
   it "tests mkdir with an existing path" do
-    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
+    expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath}'") do
       Dir.mkdir(datapath, 0o700)
     end
   end
 
   it "tests mkdir with multiples existing paths" do
-    expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
+    expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath}'") do
       FileUtils.mkdir([datapath, datapath], 0o700)
     end
 
     with_tempfile("mkdir-nonexisting") do |path|
-      expect_raises_errno(LibC::EEXIST, "Unable to create directory '#{datapath}'") do
+      expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath}'") do
         FileUtils.mkdir([path, datapath], 0o700)
       end
     end
@@ -366,7 +366,7 @@ describe "FileUtils" do
   it "tests mkdir_p with an existing path" do
     FileUtils.mkdir_p(datapath).should be_nil
     # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
-    expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
+    expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
       FileUtils.mkdir_p(datapath("test_file.txt"))
     end
   end
@@ -375,7 +375,7 @@ describe "FileUtils" do
     FileUtils.mkdir_p([datapath, datapath]).should be_nil
     with_tempfile("mkdir_p-existing") do |path|
       # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
-      expect_raises_errno(LibC::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
+      expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
         FileUtils.mkdir_p([datapath("test_file.txt"), path])
       end
     end
@@ -383,7 +383,7 @@ describe "FileUtils" do
 
   it "tests rmdir with an non existing path" do
     with_tempfile("rmdir-nonexisting") do |path|
-      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}'") do
+      expect_raises_errno(Errno::ENOENT, "Unable to remove directory '#{path}'") do
         FileUtils.rmdir(path)
       end
     end
@@ -391,20 +391,20 @@ describe "FileUtils" do
 
   it "tests rmdir with multiple non existing path" do
     with_tempfile("rmdir-nonexisting") do |path|
-      expect_raises_errno(LibC::ENOENT, "Unable to remove directory '#{path}1'") do
+      expect_raises_errno(Errno::ENOENT, "Unable to remove directory '#{path}1'") do
         FileUtils.rmdir(["#{path}1", "#{path}2"])
       end
     end
   end
 
   it "tests rmdir with a path that cannot be removed" do
-    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
+    expect_raises_errno(Errno::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       FileUtils.rmdir(datapath)
     end
   end
 
   it "tests rmdir with multiple path that cannot be removed" do
-    expect_raises_errno(LibC::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
+    expect_raises_errno(Errno::ENOTEMPTY, "Unable to remove directory '#{datapath}'") do
       FileUtils.rmdir([datapath, datapath])
     end
   end
@@ -419,7 +419,7 @@ describe "FileUtils" do
 
   it "tests rm with non existing path" do
     with_tempfile("rm-nonexistinent") do |path|
-      expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path}'") do
+      expect_raises_errno(Errno::ENOENT, "Error deleting file '#{path}'") do
         FileUtils.rm(path)
       end
     end
@@ -440,7 +440,7 @@ describe "FileUtils" do
       File.write(path1, "")
       File.write(path2, "")
 
-      expect_raises_errno(LibC::ENOENT, "Error deleting file '#{path2}'") do
+      expect_raises_errno(Errno::ENOENT, "Error deleting file '#{path2}'") do
         FileUtils.rm([path1, path2, path2])
       end
     end
@@ -501,7 +501,7 @@ describe "FileUtils" do
       path1 = "/tmp/crystal_ln_test_#{Process.pid}"
       path2 = "/tmp/crystal_ln_test_#{Process.pid + 1}"
 
-      ex = expect_raises_errno(LibC::ENOENT, "Error creating link from '#{path1}' to '#{path2}'") do
+      ex = expect_raises_errno(Errno::ENOENT, "Error creating link from '#{path1}' to '#{path2}'") do
         FileUtils.ln(path1, path2)
       end
     end
@@ -513,7 +513,7 @@ describe "FileUtils" do
       begin
         FileUtils.touch([path1, path2])
 
-        expect_raises_errno(LibC::EEXIST, "Error creating link from '#{path1}' to '#{path2}'") do
+        expect_raises_errno(Errno::EEXIST, "Error creating link from '#{path1}' to '#{path2}'") do
           FileUtils.ln(path1, path2)
         end
       ensure
@@ -582,7 +582,7 @@ describe "FileUtils" do
         File.exists?(path2).should be_false
         File.symlink?(path2).should be_true
 
-        expect_raises_errno(LibC::ENOENT, "Error resolving real path of '#{path2}'") do
+        expect_raises_errno(Errno::ENOENT, "Error resolving real path of '#{path2}'") do
           File.real_path(path2)
         end
       ensure
@@ -597,7 +597,7 @@ describe "FileUtils" do
       begin
         FileUtils.touch([path1, path2])
 
-        expect_raises_errno(LibC::EEXIST, "Error creating symlink from '#{path1}' to '#{path2}'") do
+        expect_raises_errno(Errno::EEXIST, "Error creating symlink from '#{path1}' to '#{path2}'") do
           FileUtils.ln_s(path1, path2)
         end
       ensure

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -2,6 +2,7 @@ require "spec"
 require "process"
 require "./spec_helper"
 require "../spec_helper"
+require "../support/errno"
 
 describe Process do
   it "runs true" do
@@ -15,7 +16,8 @@ describe Process do
   end
 
   it "raises if command could not be executed" do
-    expect_raises Errno do
+    # FIXME: Oddly doubled error message
+    expect_raises_errno(LibC::ENOENT, "execvp: No such file or directory: No such file or directory") do
       Process.new("foobarbaz")
     end
   end

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -17,7 +17,7 @@ describe Process do
 
   it "raises if command could not be executed" do
     # FIXME: Oddly doubled error message
-    expect_raises_errno(LibC::ENOENT, "execvp: No such file or directory: No such file or directory") do
+    expect_raises_errno(Errno::ENOENT, "execvp: No such file or directory: No such file or directory") do
       Process.new("foobarbaz")
     end
   end

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -16,7 +16,3 @@ def each_ip_family(&block : Socket::Family, String, String ->)
     block.call Socket::Family::INET6, "::1", "::"
   end
 end
-
-def linux?
-  {{ flag?(:linux) }}
-end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -20,7 +20,7 @@ describe TCPServer do
         server.close
 
         server.closed?.should be_true
-        expect_raises_errno(LibC::EBADF, "getsockname: ") do
+        expect_raises_errno(Errno::EBADF, "getsockname: ") do
           server.local_address
         end
       end
@@ -42,7 +42,7 @@ describe TCPServer do
       describe "reuse_port" do
         it "raises when port is in use" do
           TCPServer.open(address, 0) do |server|
-            expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
+            expect_raises_errno(Errno::EADDRINUSE, "bind: ") do
               TCPServer.open(address, server.local_address.port) { }
             end
           end
@@ -50,7 +50,7 @@ describe TCPServer do
 
         it "raises when not binding with reuse_port" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
-            expect_raises_errno(LibC::EADDRINUSE, {% if flag?(:linux) %}"listen: "{% else %}"bind: "{% end %}) do
+            expect_raises_errno(Errno::EADDRINUSE, {% if flag?(:linux) %}"listen: "{% else %}"bind: "{% end %}) do
               TCPServer.open(address, server.local_address.port) { }
             end
           end
@@ -58,7 +58,7 @@ describe TCPServer do
 
         it "raises when port is not ready to be reused" do
           TCPServer.open(address, 0) do |server|
-            expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
+            expect_raises_errno(Errno::EADDRINUSE, "bind: ") do
               TCPServer.open(address, server.local_address.port, reuse_port: true) { }
             end
           end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -33,9 +33,10 @@ describe TCPServer do
       end
 
       it "raises when port is negative" do
-        expect_raises(Socket::Error, linux? ? "getaddrinfo: Servname not supported for ai_socktype" : "No address found for #{address}:-12 over TCP") do
+        error = expect_raises(Socket::Addrinfo::Error) do
           TCPServer.new(address, -12)
         end
+        error.error_code.should eq({% if flag?(:linux) %}LibC::EAI_SERVICE{% else %}LibC::EAI_NONAME{% end %})
       end
 
       describe "reuse_port" do

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -1,5 +1,5 @@
 require "./spec_helper"
-require "socket"
+require "../../support/errno"
 
 describe TCPServer do
   describe ".new" do
@@ -20,7 +20,7 @@ describe TCPServer do
         server.close
 
         server.closed?.should be_true
-        expect_raises(Errno, "getsockname: Bad file descriptor") do
+        expect_raises_errno(LibC::EBADF, "getsockname: ") do
           server.local_address
         end
       end
@@ -41,7 +41,7 @@ describe TCPServer do
       describe "reuse_port" do
         it "raises when port is in use" do
           TCPServer.open(address, 0) do |server|
-            expect_raises Errno, /(already|Address) in use/ do
+            expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
               TCPServer.open(address, server.local_address.port) { }
             end
           end
@@ -49,7 +49,7 @@ describe TCPServer do
 
         it "raises when not binding with reuse_port" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
-            expect_raises Errno, /(already|Address) in use/ do
+            expect_raises_errno(LibC::EADDRINUSE, {% if flag?(:linux) %}"listen: "{% else %}"bind: "{% end %}) do
               TCPServer.open(address, server.local_address.port) { }
             end
           end
@@ -57,7 +57,7 @@ describe TCPServer do
 
         it "raises when port is not ready to be reused" do
           TCPServer.open(address, 0) do |server|
-            expect_raises Errno, /(already|Address) in use/ do
+            expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
               TCPServer.open(address, server.local_address.port, reuse_port: true) { }
             end
           end
@@ -77,13 +77,13 @@ describe TCPServer do
       end
 
       it "raises when host doesn't exist" do
-        expect_raises(Socket::Error, "No address") do
+        expect_raises(Socket::Error, "No address found for doesnotexist.example.org.:12345 over TCP") do
           TCPServer.new("doesnotexist.example.org.", 12345)
         end
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
-        expect_raises(Socket::Error, "No address") do
+        expect_raises(Socket::Error, /No address found for doesnotexist.example.org.:00? over TCP/) do
           TCPServer.new("doesnotexist.example.org.", 0)
         end
       end

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../../support/errno"
 
 describe TCPSocket do
   describe "#connect" do
@@ -27,7 +28,7 @@ describe TCPSocket do
       it "raises when connection is refused" do
         port = unused_local_port
 
-        expect_raises(Errno, "Error connecting to '#{address}:#{port}': Connection refused") do
+        expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to '#{address}:#{port}'") do
           TCPSocket.new(address, port)
         end
       end
@@ -39,7 +40,7 @@ describe TCPSocket do
       end
 
       it "raises when port is zero" do
-        expect_raises(Errno, linux? ? "Error connecting to '#{address}:0': Connection refused" : "connect: Can't assign requested address") do
+        expect_raises_errno({% if flag?(:linux) %}LibC::ECONNREFUSED{% else %}LibC::EADDRNOTAVAIL{% end %}) do
           TCPSocket.new(address, 0)
         end
       end
@@ -57,13 +58,13 @@ describe TCPSocket do
       end
 
       it "raises when host doesn't exist" do
-        expect_raises(Socket::Error, "No address") do
+        expect_raises(Socket::Error, "No address found for doesnotexist.example.org.:12345 over TCP") do
           TCPSocket.new("doesnotexist.example.org.", 12345)
         end
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
-        expect_raises(Socket::Error, "No address") do
+        expect_raises(Socket::Error, /No address found for doesnotexist.example.org.:00? over TCP/) do
           TCPSocket.new("doesnotexist.example.org.", 0)
         end
       end
@@ -73,7 +74,7 @@ describe TCPSocket do
       port = unused_local_port
 
       TCPServer.open("0.0.0.0", port) do |server|
-        expect_raises(Errno, "Error connecting to '::1:#{port}': Connection refused") do
+        expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to '::1:#{port}'") do
           TCPSocket.new("::1", port)
         end
       end
@@ -127,7 +128,7 @@ describe TCPSocket do
       server.local_address.port
     end
 
-    expect_raises(Errno, "Error connecting to 'localhost:#{port}': Connection refused") do
+    expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to 'localhost:#{port}'") do
       TCPSocket.new("localhost", port)
     end
   end

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -28,7 +28,7 @@ describe TCPSocket do
       it "raises when connection is refused" do
         port = unused_local_port
 
-        expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to '#{address}:#{port}'") do
+        expect_raises_errno(Errno::ECONNREFUSED, "Error connecting to '#{address}:#{port}'") do
           TCPSocket.new(address, port)
         end
       end
@@ -41,7 +41,7 @@ describe TCPSocket do
       end
 
       it "raises when port is zero" do
-        expect_raises_errno({% if flag?(:linux) %}LibC::ECONNREFUSED{% else %}LibC::EADDRNOTAVAIL{% end %}) do
+        expect_raises_errno({% if flag?(:linux) %}Errno::ECONNREFUSED{% else %}Errno::EADDRNOTAVAIL{% end %}) do
           TCPSocket.new(address, 0)
         end
       end
@@ -75,7 +75,7 @@ describe TCPSocket do
       port = unused_local_port
 
       TCPServer.open("0.0.0.0", port) do |server|
-        expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to '::1:#{port}'") do
+        expect_raises_errno(Errno::ECONNREFUSED, "Error connecting to '::1:#{port}'") do
           TCPSocket.new("::1", port)
         end
       end
@@ -129,7 +129,7 @@ describe TCPSocket do
       server.local_address.port
     end
 
-    expect_raises_errno(LibC::ECONNREFUSED, "Error connecting to 'localhost:#{port}'") do
+    expect_raises_errno(Errno::ECONNREFUSED, "Error connecting to 'localhost:#{port}'") do
       TCPSocket.new("localhost", port)
     end
   end

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -34,9 +34,10 @@ describe TCPSocket do
       end
 
       it "raises when port is negative" do
-        expect_raises(Socket::Error, linux? ? "getaddrinfo: Servname not supported for ai_socktype" : "No address found for #{address}:-12 over TCP") do
+        error = expect_raises(Socket::Addrinfo::Error) do
           TCPSocket.new(address, -12)
         end
+        error.error_code.should eq({% if flag?(:linux) %}LibC::EAI_SERVICE{% else %}LibC::EAI_NONAME{% end %})
       end
 
       it "raises when port is zero" do

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "socket"
+require "../../support/errno"
 require "../../support/tempfile"
 
 describe UNIXServer do
@@ -38,7 +39,9 @@ describe UNIXServer do
         server = UNIXServer.new(path)
 
         begin
-          expect_raises(Errno) { UNIXServer.new(path) }
+          expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
+            UNIXServer.new(path)
+          end
         ensure
           server.close
         end
@@ -50,7 +53,7 @@ describe UNIXServer do
         File.write(path, "")
         File.exists?(path).should be_true
 
-        expect_raises Errno, /(already|Address) in use/ do
+        expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
           UNIXServer.new(path)
         end
 

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -39,7 +39,7 @@ describe UNIXServer do
         server = UNIXServer.new(path)
 
         begin
-          expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
+          expect_raises_errno(Errno::EADDRINUSE, "bind: ") do
             UNIXServer.new(path)
           end
         ensure
@@ -53,7 +53,7 @@ describe UNIXServer do
         File.write(path, "")
         File.exists?(path).should be_true
 
-        expect_raises_errno(LibC::EADDRINUSE, "bind: ") do
+        expect_raises_errno(Errno::EADDRINUSE, "bind: ") do
           UNIXServer.new(path)
         end
 

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -20,7 +20,7 @@ describe Thread::Mutex do
     mutex = Thread::Mutex.new
     mutex.try_lock.should be_true
     mutex.try_lock.should be_false
-    expect_raises_errno(LibC::EDEADLK, "pthread_mutex_lock: ") { mutex.lock }
+    expect_raises_errno(Errno::EDEADLK, "pthread_mutex_lock: ") { mutex.lock }
     mutex.unlock
   end
 
@@ -28,7 +28,7 @@ describe Thread::Mutex do
     mutex = Thread::Mutex.new
     mutex.lock
 
-    expect_raises_errno(LibC::EPERM, "pthread_mutex_unlock: ") do
+    expect_raises_errno(Errno::EPERM, "pthread_mutex_unlock: ") do
       Thread.new { mutex.unlock }.join
     end
 

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../../support/errno"
 
 describe Thread::Mutex do
   it "synchronizes" do
@@ -19,7 +20,7 @@ describe Thread::Mutex do
     mutex = Thread::Mutex.new
     mutex.try_lock.should be_true
     mutex.try_lock.should be_false
-    expect_raises(Errno) { mutex.lock }
+    expect_raises_errno(LibC::EDEADLK, "pthread_mutex_lock: ") { mutex.lock }
     mutex.unlock
   end
 
@@ -27,7 +28,7 @@ describe Thread::Mutex do
     mutex = Thread::Mutex.new
     mutex.lock
 
-    expect_raises(Errno) do
+    expect_raises_errno(LibC::EPERM, "pthread_mutex_unlock: ") do
       Thread.new { mutex.unlock }.join
     end
 

--- a/spec/support/errno.cr
+++ b/spec/support/errno.cr
@@ -1,0 +1,15 @@
+# This spec helper allows to easily test the error code of `Errno` errors.
+#
+# The error messages returned by `strerror` vary between different libc
+# implementations. Error codes are a more reliable way to assert the expected
+# kind of error.
+#
+# *message* should usually only validate parts of the error message added by
+# Crystal.
+def expect_raises_errno(errno, message = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__)
+  error = expect_raises(Errno, message, file: file, line: line) do
+    yield
+  end
+  error.errno.should eq(errno), file: file, line: line
+  error
+end

--- a/src/crystal/system/unix/dir.cr
+++ b/src/crystal/system/unix/dir.cr
@@ -3,7 +3,7 @@ require "c/dirent"
 module Crystal::System::Dir
   def self.open(path : String) : LibC::DIR*
     dir = LibC.opendir(path.check_no_null_byte)
-    raise Errno.new("Error opening directory #{path.inspect}") unless dir
+    raise Errno.new("Error opening directory '#{path.inspect_unquoted}'") unless dir
     dir
   end
 
@@ -42,7 +42,7 @@ module Crystal::System::Dir
 
   def self.current=(path : String)
     if LibC.chdir(path.check_no_null_byte) != 0
-      raise Errno.new("Error while changing directory to #{path.inspect}")
+      raise Errno.new("Error while changing directory to '#{path.inspect_unquoted}'")
     end
 
     path
@@ -55,13 +55,13 @@ module Crystal::System::Dir
 
   def self.create(path : String, mode : Int32) : Nil
     if LibC.mkdir(path.check_no_null_byte, mode) == -1
-      raise Errno.new("Unable to create directory '#{path}'")
+      raise Errno.new("Unable to create directory '#{path.inspect_unquoted}'")
     end
   end
 
   def self.delete(path : String) : Nil
     if LibC.rmdir(path.check_no_null_byte) == -1
-      raise Errno.new("Unable to remove directory '#{path}'")
+      raise Errno.new("Unable to remove directory '#{path.inspect_unquoted}'")
     end
   end
 end

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -7,7 +7,7 @@ module Crystal::System::File
 
     fd = LibC.open(filename.check_no_null_byte, oflag, perm)
     if fd < 0
-      raise Errno.new("Error opening file '#{filename}' with mode '#{mode}'")
+      raise Errno.new("Error opening file '#{filename.inspect_unquoted}' with mode '#{mode}'")
     end
     fd
   end
@@ -22,7 +22,7 @@ module Crystal::System::File
       fd = LibC.mkstemp(path)
     end
 
-    raise Errno.new("mkstemp: #{path.inspect}") if fd == -1
+    raise Errno.new("mkstemp: '#{path.inspect_unquoted}'") if fd == -1
     {fd, path}
   end
 
@@ -40,7 +40,7 @@ module Crystal::System::File
       if {Errno::ENOENT, Errno::ENOTDIR}.includes? Errno.value
         return nil
       else
-        raise Errno.new("Unable to get info for '#{path}'")
+        raise Errno.new("Unable to get info for '#{path.inspect_unquoted}'")
       end
     end
   end
@@ -71,44 +71,44 @@ module Crystal::System::File
           else
             LibC.chown(path, uid, gid)
           end
-    raise Errno.new("Error changing owner of '#{path}'") if ret == -1
+    raise Errno.new("Error changing owner of '#{path.inspect_unquoted}'") if ret == -1
   end
 
   def self.chmod(path, mode)
     if LibC.chmod(path, mode) == -1
-      raise Errno.new("Error changing permissions of '#{path}'")
+      raise Errno.new("Error changing permissions of '#{path.inspect_unquoted}'")
     end
   end
 
   def self.delete(path)
     err = LibC.unlink(path.check_no_null_byte)
     if err == -1
-      raise Errno.new("Error deleting file '#{path}'")
+      raise Errno.new("Error deleting file '#{path.inspect_unquoted}'")
     end
   end
 
   def self.real_path(path)
     real_path_ptr = LibC.realpath(path, nil)
-    raise Errno.new("Error resolving real path of #{path}") unless real_path_ptr
+    raise Errno.new("Error resolving real path of '#{path.inspect_unquoted}'") unless real_path_ptr
     String.new(real_path_ptr).tap { LibC.free(real_path_ptr.as(Void*)) }
   end
 
   def self.link(old_path, new_path)
     ret = LibC.link(old_path.check_no_null_byte, new_path.check_no_null_byte)
-    raise Errno.new("Error creating link from #{old_path} to #{new_path}") if ret != 0
+    raise Errno.new("Error creating link from '#{old_path.inspect_unquoted}' to '#{new_path.inspect_unquoted}'") if ret != 0
     ret
   end
 
   def self.symlink(old_path, new_path)
     ret = LibC.symlink(old_path.check_no_null_byte, new_path.check_no_null_byte)
-    raise Errno.new("Error creating symlink from #{old_path} to #{new_path}") if ret != 0
+    raise Errno.new("Error creating symlink from '#{old_path.inspect_unquoted}' to '#{new_path.inspect_unquoted}'") if ret != 0
     ret
   end
 
   def self.rename(old_filename, new_filename)
     code = LibC.rename(old_filename.check_no_null_byte, new_filename.check_no_null_byte)
     if code != 0
-      raise Errno.new("Error renaming file '#{old_filename}' to '#{new_filename}'")
+      raise Errno.new("Error renaming file '#{old_filename.inspect_unquoted}' to '#{new_filename.inspect_unquoted}'")
     end
   end
 
@@ -118,7 +118,7 @@ module Crystal::System::File
     timevals[1] = to_timeval(mtime)
     ret = LibC.utimes(filename, timevals)
     if ret != 0
-      raise Errno.new("Error setting time on file '#{filename}'")
+      raise Errno.new("Error setting time on file '#{filename.inspect_unquoted}'")
     end
   end
 
@@ -133,7 +133,7 @@ module Crystal::System::File
     flush
     code = LibC.ftruncate(fd, size)
     if code != 0
-      raise Errno.new("Error truncating file '#{path}'")
+      raise Errno.new("Error truncating file '#{path.inspect_unquoted}'")
     end
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -119,7 +119,7 @@ class File < IO::FileDescriptor
   # File.info("bar", follow_symlinks: false).type.symlink? # => true
   # ```
   def self.info(path, follow_symlinks = true) : Info
-    info?(path, follow_symlinks) || raise Errno.new("Unable to get info for #{path.inspect}")
+    info?(path, follow_symlinks) || raise Errno.new("Unable to get info for '#{path.inspect_unquoted}'")
   end
 
   # Returns `true` if *path* exists else returns `false`
@@ -151,7 +151,7 @@ class File < IO::FileDescriptor
   def self.size(filename) : UInt64
     info(filename).size
   rescue ex : Errno
-    raise Errno.new("Error determining size of #{filename.inspect}", ex.errno)
+    raise Errno.new("Error determining size of '#{filename.inspect_unquoted}'", ex.errno)
   end
 
   # Returns `true` if the file at *path* is empty, otherwise returns `false`.

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -77,6 +77,18 @@ class Socket
       end
     end
 
+    class Error < Socket::Error
+      getter error_code : Int32
+
+      def self.new(error_code)
+        new error_code, "getaddrinfo: #{String.new(LibC.gai_strerror(error_code))}"
+      end
+
+      def initialize(@error_code, message)
+        super(message)
+      end
+    end
+
     private def self.getaddrinfo(domain, service, family, type, protocol, timeout)
       # RFC 3986 says:
       # > When a non-ASCII registered name represents an internationalized domain name
@@ -107,9 +119,9 @@ class Socket
       when 0
         # success
       when LibC::EAI_NONAME
-        raise Socket::Error.new("No address found for #{domain}:#{service} over #{protocol}")
+        raise Error.new(LibC::EAI_NONAME, "No address found for #{domain}:#{service} over #{protocol}")
       else
-        raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}")
+        raise Error.new(ret)
       end
 
       begin


### PR DESCRIPTION
This PR adds a spec helper `expect_raises_errno` which allows to easily test the error code of `Errno` errors.
The error messages returned by `strerror` vary between different libc implementations. Error codes are a more reliable way to assert the expected kind of error.

It also streamlines path representations in error messages to be wrapped in single quotes and escaped with `String#inspect_unquoted`.

Errors in `getattrinfo` are wrapped in a `Socket::Addrinfo::Error` and specs assert the error code.

Fixes #7057 (the first part)
Closes #7067