### PR TITLE
compiler: Introduce non-nilable read_file macro

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1766,10 +1766,12 @@ module Crystal
           >, filename = __FILE__).to_string.should eq(File.read("#{__DIR__}/../data/build"))
       end
 
-      it "reads file (doesn't exists)" do
-        run(%q<
-          {{read_file("#{__DIR__}/../data/build_foo")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(20)
+      it "reads file (doesn't exist)" do
+        expect_raises(Errno, "No such file or directory") do
+          run(%q<
+            {{read_file("#{__DIR__}/../data/build_foo")}}
+            >, filename = __FILE__)
+        end
       end
     end
 
@@ -1780,9 +1782,29 @@ module Crystal
           >, filename = __FILE__).to_string.should eq(File.read("spec/compiler/data/build"))
       end
 
-      it "reads file (doesn't exists)" do
+      it "reads file (doesn't exist)" do
+        expect_raises(Errno, "No such file or directory") do
+          run(%q<
+          {{read_file("spec/compiler/data/build_foo")}}
+          >, filename = __FILE__)
+        end
+      end
+    end
+  end
+
+  describe "read_file?" do
+    context "with absolute path" do
+      it "reads file (doesn't exist)" do
         run(%q<
-          {{read_file("spec/compiler/data/build_foo")}} ? 10 : 20
+          {{read_file?("#{__DIR__}/../data/build_foo")}} ? 10 : 20
+          >, filename = __FILE__).to_i.should eq(20)
+      end
+    end
+
+    context "with relative path" do
+      it "reads file (doesn't exist)" do
+        run(%q<
+          {{read_file?("spec/compiler/data/build_foo")}} ? 10 : 20
           >, filename = __FILE__).to_i.should eq(20)
       end
     end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1767,7 +1767,7 @@ module Crystal
       end
 
       it "reads file (doesn't exist)" do
-        expect_raises(Errno, "No such file or directory") do
+        expect_raises(Crystal::TypeException, "No such file or directory") do
           run(%q<
             {{read_file("#{__DIR__}/../data/build_foo")}}
             >, filename = __FILE__)
@@ -1783,7 +1783,7 @@ module Crystal
       end
 
       it "reads file (doesn't exist)" do
-        expect_raises(Errno, "No such file or directory") do
+        expect_raises(Crystal::TypeException, "No such file or directory") do
           run(%q<
           {{read_file("spec/compiler/data/build_foo")}}
           >, filename = __FILE__)

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -67,8 +67,10 @@ module Crystal::Macros
   def raise(message) : NoReturn
   end
 
-  # Reads a file: if it exists, returns a `StringLiteral` with its contents;
-  # otherwise `nil` is returned.
+  # Reads a file and returns a `StringLiteral` with its contents.
+  #
+  # Gives a compile-time error if the file doesn't exist or if
+  # reading the file fails.
   #
   # To read a file relative to where the macro is defined, use:
   #
@@ -77,7 +79,12 @@ module Crystal::Macros
   # ```
   #
   # NOTE: Relative paths are resolved to the current working directory.
-  def read_file(filename) : StringLiteral | NilLiteral
+  def read_file(filename) : StringLiteral
+  end
+
+  # Same as `read_file`, except that `nil` is returned on any I/O failure
+  # instead of issuing a compile-time failure.
+  def read_file?(filename) : StringLiteral | NilLiteral
   end
 
   # Compiles and execute a Crystal program and returns its output

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -65,6 +65,8 @@ module Crystal
         interpret_raise(node)
       when "read_file"
         interpret_read_file(node)
+      when "read_file?"
+        interpret_read_file(node, nilable: true)
       when "run"
         interpret_run(node)
       else
@@ -198,16 +200,18 @@ module Crystal
       macro_raise(node, node.args, self)
     end
 
-    def interpret_read_file(node)
+    def interpret_read_file(node, nilable = false)
       unless node.args.size == 1
-        node.wrong_number_of_arguments "macro call 'read_file'", node.args.size, 1
+        node.wrong_number_of_arguments "macro call '#{node.name}'", node.args.size, 1
       end
 
       node.args[0].accept self
       filename = @last.to_macro_id
-      if File.file?(filename)
+
+      begin
         @last = StringLiteral.new(File.read(filename))
-      else
+      rescue e
+        node.raise e.to_s unless nilable
         @last = NilLiteral.new
       end
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -210,8 +210,8 @@ module Crystal
 
       begin
         @last = StringLiteral.new(File.read(filename))
-      rescue e
-        node.raise e.to_s unless nilable
+      rescue ex
+        node.raise ex.to_s unless nilable
         @last = NilLiteral.new
       end
     end


### PR DESCRIPTION
Follow-up on #6967.

The original (nilable) macro has been renamed to `read_file?`.
