### PR TITLE
Format: prevent conflicting between nested tuple types and macro expressions

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -485,6 +485,7 @@ describe Crystal::Formatter do
   assert_format "x  :   (A -> B)", "x : (A -> B)"
   assert_format "x  :   (A -> B)?", "x : (A -> B)?"
   assert_format "x  :   {A, B}", "x : {A, B}"
+  assert_format "x : { {A, B}, {C, D} }"
   assert_format "class Foo\n@x  : Int32\nend", "class Foo\n  @x : Int32\nend"
   assert_format "class Foo\n@x  :  Int32\nend", "class Foo\n  @x : Int32\nend"
   assert_format "class Foo\nx = 1\nend", "class Foo\n  x = 1\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1107,12 +1107,12 @@ module Crystal
       if first_name == "Tuple" && @token.value != "Tuple"
         write_token :"{"
         found_comment = skip_space_or_newline
-        wrote_space_at_end = false
+        write_space_at_end = false
         node.type_vars.each_with_index do |type_var, i|
           # This is to prevent writing `{{` and `{%`
           if i == 0 && !found_comment && (@token.type == :"{" || @token.type == :"{{" || @token.type == :"{%" || @token.type == :"%" || @token.raw.starts_with?("%"))
             write " "
-            wrote_space_at_end = true
+            write_space_at_end = true
           end
           accept type_var
           skip_space_or_newline
@@ -1121,7 +1121,7 @@ module Crystal
             next_token_skip_space_or_newline
           end
           # Write space at end when write space for preventing writing `{{` and `{%` at first.
-          write " " if last?(i, node.type_vars) && wrote_space_at_end
+          write " " if last?(i, node.type_vars) && write_space_at_end
         end
         write_token :"}"
         return false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1106,14 +1106,22 @@ module Crystal
       # Check if it's {A, B} instead of Tuple(A, B)
       if first_name == "Tuple" && @token.value != "Tuple"
         write_token :"{"
-        skip_space_or_newline
+        found_comment = skip_space_or_newline
+        wrote_space_at_end = false
         node.type_vars.each_with_index do |type_var, i|
+          # This is to prevent writing `{{` and `{%`
+          if i == 0 && !found_comment && (@token.type == :"{" || @token.type == :"{{" || @token.type == :"{%" || @token.type == :"%" || @token.raw.starts_with?("%"))
+            write " "
+            wrote_space_at_end = true
+          end
           accept type_var
           skip_space_or_newline
           if @token.type == :","
             write ", " unless last?(i, node.type_vars)
             next_token_skip_space_or_newline
           end
+          # Write space at end when write space for preventing writing `{{` and `{%` at first.
+          write " " if last?(i, node.type_vars) && wrote_space_at_end
         end
         write_token :"}"
         return false


### PR DESCRIPTION
Fixed #7095

Now `crystal tool format` keeps the following file format:

```crystal
foo : { {Int32, String} }
```