### PR TITLE
Format: keep trailing spaces in macros

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1258,25 +1258,25 @@ describe Crystal::Formatter do
   assert_format <<-CODE
     macro foo
       <<-FOO
-        hello  
+        hello#{"  "}
       FOO
     end
 
     {% verbatim do %}
       <<-FOO
-        hello  
+        hello#{"  "}
       FOO
     {% end %}
 
     {% if true %}
       <<-FOO
-        hello  
+        hello#{"  "}
       FOO
     {% end %}
 
     {% for a in %w() %}
       <<-FOO
-        hello  
+        hello#{"  "}
       FOO
     {% end %}
     CODE

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1280,4 +1280,23 @@ describe Crystal::Formatter do
       FOO
     {% end %}
     CODE
+
+  # But remove trailing space in macro expression.
+  assert_format <<-CODE, <<-EXPECTED
+    macro foo
+      1#{"  "}
+      {{#{"  "}
+        42#{"  "}
+      }}#{"  "}
+      2#{"  "}
+    end
+    CODE
+    macro foo
+      1#{"  "}
+      {{
+        42
+      }}#{"  "}
+      2#{"  "}
+    end
+    EXPECTED
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1260,20 +1260,23 @@ describe Crystal::Formatter do
     "  <<-FOO\n" +
     "    hello  \n" +
     "  FOO\n" +
-    "end\n" +
-    "\n" +
+    "end"
+  )
+  assert_format(
     "{% verbatim do %}\n" +
     "  <<-FOO\n" +
     "    hello  \n" +
     "  FOO\n" +
-    "{% end %}\n" +
-    "\n" +
+    "{% end %}"
+  )
+  assert_format(
     "{% if true %}\n" +
     "  <<-FOO\n" +
     "    hello  \n" +
     "  FOO\n" +
-    "{% end %}\n" +
-    "\n" +
+    "{% end %}"
+  )
+  assert_format(
     "{% for a in %w() %}\n" +
     "  <<-FOO\n" +
     "    hello  \n" +

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -599,12 +599,12 @@ describe Crystal::Formatter do
   assert_format "macro foo( x  =   1, y  =  2,  &block)\nend", "macro foo(x = 1, y = 2, &block)\nend"
   assert_format "macro foo\n  1 + 2\nend"
   assert_format "macro foo\n  if 1\n 1 + 2\n end\nend"
-  assert_format "macro foo\n  {{1 + 2}} \nend", "macro foo\n  {{1 + 2}}\nend"
-  assert_format "macro foo\n  {{ 1 + 2 }} \nend", "macro foo\n  {{ 1 + 2 }}\nend"
-  assert_format "macro foo\n  {% 1 + 2 %} \nend", "macro foo\n  {% 1 + 2 %}\nend"
-  assert_format "macro foo\n  {{ 1 + 2 }}\\ \nend", "macro foo\n  {{ 1 + 2 }}\\\nend"
-  assert_format "macro foo\n  {{ 1 + 2 }}\\ \n 1\n end", "macro foo\n  {{ 1 + 2 }}\\\n 1\n end"
-  assert_format "macro foo\n  {%1 + 2%}\\ \nend", "macro foo\n  {% 1 + 2 %}\\\nend"
+  assert_format "macro foo\n  {{1 + 2}}\nend", "macro foo\n  {{1 + 2}}\nend"
+  assert_format "macro foo\n  {{ 1 + 2 }}\nend", "macro foo\n  {{ 1 + 2 }}\nend"
+  assert_format "macro foo\n  {% 1 + 2 %}\nend", "macro foo\n  {% 1 + 2 %}\nend"
+  assert_format "macro foo\n  {{ 1 + 2 }}\\\nend", "macro foo\n  {{ 1 + 2 }}\\\nend"
+  assert_format "macro foo\n  {{ 1 + 2 }}\\\n 1\n end", "macro foo\n  {{ 1 + 2 }}\\\n 1\n end"
+  assert_format "macro foo\n  {%1 + 2%}\\\nend", "macro foo\n  {% 1 + 2 %}\\\nend"
   assert_format "macro foo\n  {% if 1 %} 2 {% end %}\nend"
   assert_format "macro foo\n  {% unless 1 %} 2 {% end %}\nend"
   assert_format "macro foo\n  {% if 1 %} 2 {% else %} 3 {% end %}\nend"
@@ -612,7 +612,7 @@ describe Crystal::Formatter do
   assert_format "macro foo\n  {% for x in y %} 2 {% end %}\nend"
   assert_format "macro foo\n  {% for x in y %}\\ 2 {% end %}\\\nend"
   assert_format "macro foo\n  %foo\nend"
-  assert_format "macro foo\n  %foo{x.id+2} \nend", "macro foo\n  %foo{x.id + 2}\nend"
+  assert_format "macro foo\n  %foo{x.id+2}\nend", "macro foo\n  %foo{x.id + 2}\nend"
   assert_format "macro foo\n  %foo{x,y}\nend", "macro foo\n  %foo{x, y}\nend"
   assert_format "def foo : Int32\n  1\nend"
   assert_format "class Foo\n  macro foo\n    1\n  end\nend"
@@ -625,7 +625,7 @@ describe Crystal::Formatter do
   assert_format "if 1\n  {{1 + 2}}\nend"
   assert_format "def foo : self | Nil\n  nil\nend"
   assert_format "macro foo(x)\n  {% if 1 %} 2 {% end %}\nend"
-  assert_format "macro foo()\n  {% if 1 %} 2 {% end %} \nend", "macro foo\n  {% if 1 %} 2 {% end %}\nend"
+  assert_format "macro foo()\n  {% if 1 %} 2 {% end %}\nend", "macro foo\n  {% if 1 %} 2 {% end %}\nend"
   assert_format "macro flags\n  {% if 1 %}\\\n  {% end %}\\\nend"
   assert_format "macro flags\n  {% if 1 %}\\\n 1 {% else %}\\\n {% end %}\\\nend"
   assert_format "macro flags\n  {% if 1 %}{{1}}a{{2}}{% end %}\\\nend"
@@ -1252,5 +1252,32 @@ describe Crystal::Formatter do
     X(typeof(begin
       e.is_a?(Y)
     end))
+    CODE
+
+  # Keep trailing spaces in macros.
+  assert_format <<-CODE
+    macro foo
+      <<-FOO
+        hello  
+      FOO
+    end
+
+    {% verbatim do %}
+      <<-FOO
+        hello  
+      FOO
+    {% end %}
+
+    {% if true %}
+      <<-FOO
+        hello  
+      FOO
+    {% end %}
+
+    {% for a in %w() %}
+      <<-FOO
+        hello  
+      FOO
+    {% end %}
     CODE
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1255,48 +1255,47 @@ describe Crystal::Formatter do
     CODE
 
   # Keep trailing spaces in macros.
-  assert_format <<-CODE
-    macro foo
-      <<-FOO
-        hello#{"  "}
-      FOO
-    end
-
-    {% verbatim do %}
-      <<-FOO
-        hello#{"  "}
-      FOO
-    {% end %}
-
-    {% if true %}
-      <<-FOO
-        hello#{"  "}
-      FOO
-    {% end %}
-
-    {% for a in %w() %}
-      <<-FOO
-        hello#{"  "}
-      FOO
-    {% end %}
-    CODE
+  assert_format(
+    "macro foo\n" +
+    "  <<-FOO\n" +
+    "    hello  \n" +
+    "  FOO\n" +
+    "end\n" +
+    "\n" +
+    "{% verbatim do %}\n" +
+    "  <<-FOO\n" +
+    "    hello  \n" +
+    "  FOO\n" +
+    "{% end %}\n" +
+    "\n" +
+    "{% if true %}\n" +
+    "  <<-FOO\n" +
+    "    hello  \n" +
+    "  FOO\n" +
+    "{% end %}\n" +
+    "\n" +
+    "{% for a in %w() %}\n" +
+    "  <<-FOO\n" +
+    "    hello  \n" +
+    "  FOO\n" +
+    "{% end %}"
+  )
 
   # But remove trailing space in macro expression.
-  assert_format <<-CODE, <<-EXPECTED
-    macro foo
-      1#{"  "}
-      {{#{"  "}
-        42#{"  "}
-      }}#{"  "}
-      2#{"  "}
-    end
-    CODE
-    macro foo
-      1#{"  "}
-      {{
-        42
-      }}#{"  "}
-      2#{"  "}
-    end
-    EXPECTED
+  assert_format(
+    "macro foo\n" +
+    "  1  \n" +
+    "  {{  \n" +
+    "    42  \n" +
+    "  }}  \n" +
+    "  2  \n" +
+    "end",
+    "macro foo\n" +
+    "  1  \n" +
+    "  {{\n" +
+    "    42\n" +
+    "  }}  \n" +
+    "  2  \n" +
+    "end"
+  )
 end


### PR DESCRIPTION
Currently the formatter removes trailing spaces in macros, however macro may contain meaningful trailing spaces (e.g. space inside string literals), so it is possible to change program meaning.
The formatter should keep such spaces because formatter doesn't change input program meaning at any time.