### PR TITLE
Allow underscores when initlalising BigInt

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -24,6 +24,7 @@ describe "BigInt" do
     BigInt.new("12345678").to_s.should eq("12345678")
     BigInt.new("+12345678").to_s.should eq("12345678")
     BigInt.new("-12345678").to_s.should eq("-12345678")
+    BigInt.new("-1234_5678_0000").to_s.should eq("-123456780000")
   end
 
   it "raises if creates from string but invalid" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -28,10 +28,12 @@ struct BigInt < Int
   # ```
   # BigInt.new("123456789123456789123456789123456789") # => 123456789123456789123456789123456789
   # BigInt.new("1234567890ABCDEF", base: 16)           # => 1311768467294899695
+  # BigInt.new("1234_5678_90AB_CDEF", base: 16)        # => 1311768467294899695
   # ```
   def initialize(str : String, base = 10)
     # Strip leading '+' char to smooth out cases with strings like "+123"
     str = str.lchop('+')
+    str = str.delete('_')
     err = LibGMP.init_set_str(out @mpz, str, base)
     if err == -1
       raise ArgumentError.new("Invalid BigInt: #{str}")


### PR DESCRIPTION
Implements https://github.com/crystal-lang/crystal/issues/7106