### PR TITLE
Add comments and escapes to ECR docs

### DIFF
--- a/src/ecr.cr
+++ b/src/ecr.cr
@@ -60,7 +60,7 @@
 #   ECR.def_to_s "greeter.ecr"
 # end
 #
-# Greeter.new(nil).to_s # => "Greetings!\n"
+# Greeter.new(nil).to_s    # => "Greetings!\n"
 # Greeter.new("Jill").to_s # => "Greetings, Jill!\n"
 # ```
 #

--- a/src/ecr.cr
+++ b/src/ecr.cr
@@ -36,7 +36,7 @@
 #   ECR.def_to_s "greeter.ecr"
 # end
 #
-# Greeter.new("John").to_s # => Greetings, John!
+# Greeter.new("John").to_s # => "Greetings, John!\n"
 # ```
 #
 # Using logical statements:
@@ -54,13 +54,14 @@
 # require "ecr"
 #
 # class Greeter
-#   def initialize(@name : String)
+#   def initialize(@name : String | Nil)
 #   end
 #
 #   ECR.def_to_s "greeter.ecr"
 # end
 #
-# Greeter.new(nil).to_s # => Greetings!
+# Greeter.new(nil).to_s # => "Greetings!\n"
+# Greeter.new("Jill").to_s # => "Greetings, Jill!\n"
 # ```
 #
 # Using loops:
@@ -85,10 +86,7 @@
 #   ECR.def_to_s "greeter.ecr"
 # end
 #
-# Greeter.new("John", "Zoe", "Ben").to_s
-# # => Hi, John!
-# # => Hi, Zoe!
-# # => Hi, Ben!
+# Greeter.new("John", "Zoe", "Ben").to_s # => "Hi, John!\nHi, Zoe!\nHi, Ben!\n"
 # ```
 #
 # Comments and Escapes:
@@ -102,8 +100,7 @@
 # ```
 # require "ecr"
 # foo = 2
-# string = ECR.render("demo.ecr")
-# string.inspect # => "A valid ECR tag looks like this: <%= foo %>\n"
+# ECR.render("demo.ecr") # => "A valid ECR tag looks like this: <%= foo %>\n"
 # ```
 #
 # Likewise, other Crystal logic can be implemented in ECR text.

--- a/src/ecr.cr
+++ b/src/ecr.cr
@@ -12,61 +12,98 @@
 # * `<%-= ... %>`: removes previous indentation
 # * `<%= ... -%>`: removes next newline
 #
+# A comment can be created the same as normal code: `<% # hello %>` or by the special
+# tag: `<%# hello %>`. An ECR tag can be inserted directly (i.e. the tag itself may be
+# escaped) by using a second `%` like so: `<%% a = b %>` or `<%%= foo %>`.
+#
 # Quick Example:
+#
+# Create a simple ECR file named `greeter.ecr`:
+#
+# ```
+# Greetings, <%= @name %>!
+# ```
+#
+# and then use it like so with the `#def_to_s` macro:
 #
 # ```
 # require "ecr"
 #
-# class Greeting
+# class Greeter
 #   def initialize(@name : String)
 #   end
 #
-#   ECR.def_to_s "greeting.ecr"
+#   ECR.def_to_s "greeter.ecr"
 # end
 #
-# # greeting.ecr
-# Greeting, <%= @name %>!
-#
-# Greeting.new("John").to_s #=> Greeting, John!
+# Greeter.new("John").to_s # => Greetings, John!
 # ```
 #
 # Using logical statements:
 #
 # ```
-# # greeting.ecr
+# # greeter.ecr
 # <%- if @name -%>
-# Greeting, <%= @name %>!
+# Greetings, <%= @name %>!
 # <%- else -%>
-# Greeting!
+# Greetings!
 # <%- end -%>
+# ```
 #
-# Greeting.new(nil).to_s #=> Greeting!
+# ```
+# require "ecr"
+#
+# class Greeter
+#   def initialize(@name : String)
+#   end
+#
+#   ECR.def_to_s "greeter.ecr"
+# end
+#
+# Greeter.new(nil).to_s # => Greetings!
 # ```
 #
 # Using loops:
 #
 # ```
-# require "ecr"
-#
-# class Greeting
-#   @names : Array(String)
-#
-#   def initialize(*names)
-#    @names = names.to_a
-#   end
-#
-#   ECR.def_to_s "greeting.ecr"
-# end
-#
-# # greeting.ecr
+# # greeter.ecr
 # <%- @names.each do |name| -%>
 # Hi, <%= name %>!
 # <%- end -%>
+# ```
 #
-# Greeting.new("John", "Zoe", "Ben").to_s
-# #=> Hi, John!
-# #=> Hi, Zoe!
-# #=> Hi, Ben!
+# ```
+# require "ecr"
+#
+# class Greeter
+#   @names : Array(String)
+#
+#   def initialize(*names)
+#     @names = names.to_a
+#   end
+#
+#   ECR.def_to_s "greeter.ecr"
+# end
+#
+# Greeter.new("John", "Zoe", "Ben").to_s
+# # => Hi, John!
+# # => Hi, Zoe!
+# # => Hi, Ben!
+# ```
+#
+# Comments and Escapes:
+#
+# ```
+# # demo.ecr
+# <%# Demonstrate use of ECR tag -%>
+# A valid ECR tag looks like this: <%%= foo %>
+# ```
+#
+# ```
+# require "ecr"
+# foo = 2
+# string = ECR.render("demo.ecr")
+# string.inspect # => "A valid ECR tag looks like this: <%= foo %>\n"
 # ```
 #
 # Likewise, other Crystal logic can be implemented in ECR text.


### PR DESCRIPTION
PR #2004 added some new features to ECR, here are the docs to go with them.

Also, I felt like the language was a little awkward in the examples. Originally the class: `Greeting` would greet a user with the phrase `Greeting, KC` but I believe it is more natural to call the class a `Greeter` and I'm sure (as a native English speaker) that the idiom is "Greetings, KC".

Sorry if that kind of input isn't welcome, I don't mean to be pedantic. I'm happy to revert that aspect of this PR if requested :)