### PR TITLE
HTTP::Client: move `@socket` instance variable at the end of the method to avoid wrong intermediate states

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -676,16 +676,14 @@ class HTTP::Client
     socket = TCPSocket.new hostname, @port, @dns_timeout, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
     socket.sync = false
-    @socket = socket
 
     {% if !flag?(:without_openssl) %}
       if tls = @tls
-        tls_socket = OpenSSL::SSL::Socket::Client.new(socket, context: tls, sync_close: true, hostname: @host)
-        @socket = socket = tls_socket
+        socket = OpenSSL::SSL::Socket::Client.new(socket, context: tls, sync_close: true, hostname: @host)
       end
     {% end %}
 
-    socket
+    @socket = socket
   end
 
   private def host_header


### PR DESCRIPTION
Fixes #7120

It seems that when you create an OpenSSL socket a few bytes are sent and then read, probably to establish the SSL connection. If an exception is raised then (in this case because of the timeout) then  `@socket` is left with a non-SSL socket, and then the next request will fail. The solution is to set `@socket` to `nil` so that the next call tries to establish the connection again.

Unfortunately I can't think of a spec other than the code that reproduces it, but that expects a read-timeout to happen under a certain condition and also a known server that supports TLS.