### PR TITLE
Add missing parameter to ArrayLiteral#unshift

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -643,7 +643,7 @@ module Crystal::Macros
     end
 
     # Similar to `Array#unshift`.
-    def unshift : ArrayLiteral
+    def unshift(value : ASTNode) : ArrayLiteral
     end
 
     # Similar to `Array#push`.


### PR DESCRIPTION
Extracts the addition of the missing parameter on `ArrayLiteral#unshift` from #7109.