### PR TITLE
Improve too big tuple and named tuple error message

### DIFF
--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -287,7 +287,7 @@ describe "Semantic: tuples" do
         pos += {0, 0}
       end
       ),
-      "tuple too big"
+      "tuple size cannot be greater than 300"
   end
 
   it "doesn't unify tuple metaclasses (#5384)" do

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -293,12 +293,12 @@ describe "Semantic: tuples" do
   it "errors on named tuple too big" do
     assert_error %(
       { #{String.build do |io|
-            301.times do |i|
+            333.times do |i|
               io << "arg" << i << ": 0, "
             end
           end} }
       ),
-      "named tuple size cannot be greater than 300 (size is 301)"
+      "named tuple size cannot be greater than 300 (size is 333)"
   end
 
   it "doesn't unify tuple metaclasses (#5384)" do

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -290,6 +290,17 @@ describe "Semantic: tuples" do
       "tuple size cannot be greater than 300"
   end
 
+  it "errors on named tuple too big" do
+    assert_error %(
+      { #{String.build do |io|
+            301.times do |i|
+              io << "arg" << i << ": 0, "
+            end
+          end} }
+      ),
+      "named tuple size cannot be greater than 300"
+  end
+
   it "doesn't unify tuple metaclasses (#5384)" do
     assert_type(%(
       Tuple(Int32) || Tuple(String)

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -283,11 +283,11 @@ describe "Semantic: tuples" do
       require "prelude"
 
       pos = {0, 0}
-      while true
+      301.times do
         pos += {0, 0}
       end
       ),
-      "tuple size cannot be greater than 300"
+      "tuple size cannot be greater than 300 (size is 301)"
   end
 
   it "errors on named tuple too big" do
@@ -298,7 +298,7 @@ describe "Semantic: tuples" do
             end
           end} }
       ),
-      "named tuple size cannot be greater than 300"
+      "named tuple size cannot be greater than 300 (size is 301)"
   end
 
   it "doesn't unify tuple metaclasses (#5384)" do

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -283,7 +283,7 @@ describe "Semantic: tuples" do
       require "prelude"
 
       pos = {0, 0}
-      301.times do
+      while true
         pos += {0, 0}
       end
       ),

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -287,7 +287,7 @@ describe "Semantic: tuples" do
         pos += {0, 0}
       end
       ),
-      "tuple size cannot be greater than 300 (size is 301)"
+      "tuple size cannot be greater than 300 (size is 302)"
   end
 
   it "errors on named tuple too big" do

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -291,12 +291,12 @@ describe "Semantic: tuples" do
   end
 
   it "errors on named tuple too big" do
+    named_tuple_keys = String.build do |io|
+      333.times { |i| io << "key" << i << ": 0, " }
+    end
+
     assert_error %(
-      { #{String.build do |io|
-            333.times do |i|
-              io << "arg" << i << ": 0, "
-            end
-          end} }
+      { #{named_tuple_keys} }
       ),
       "named tuple size cannot be greater than 300 (size is 333)"
   end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -519,7 +519,7 @@ module Crystal
       end
 
       if types.size > 300
-        raise "tuple too big: Tuple(#{types[0...10].join(',')}, ...)"
+        raise "tuple size cannot be greater than 300 (size is #{types.size})"
       end
 
       self.type = tuple_type
@@ -543,7 +543,7 @@ module Crystal
       end
 
       if entries.size > 300
-        raise "named tuple too big: #{named_tuple_type}"
+        raise "named tuple size cannot be greater than 300 (size is #{entries.size})"
       end
 
       self.type = named_tuple_type


### PR DESCRIPTION
When you do this:
```cr
def method(*arguments)
end

method(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
```
Then you get this:

```
Error in line 4: instantiating 'method(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)'

in line 1: tuple too big: Tuple(Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32, ...)
```
It's not quite useful here after "tuple too big" to show the type of the Tuple again when it's already shown above it after "instantiating" once. There are also spaces missing after the commas.
This improves this error message by informing the user that the tuple size cannot be greater than 300 and also shows the size of the tuple that caused the error.
This also improves the error message of when a named tuple size is greater than 300 and adds a spec for it.