### PR TITLE
Add helper methods to emit float32 float64 values

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -441,9 +441,9 @@ module Crystal
         # TODO: implement String#to_u128 and use it
         @last = int128(node.value.to_u64)
       when :f32
-        @last = llvm_context.float.const_float(node.value)
+        @last = float32(node.value)
       when :f64
-        @last = llvm_context.double.const_double(node.value)
+        @last = float64(node.value)
       else
         node.raise "Bug: unhandled number kind: #{node.kind}"
       end

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -32,6 +32,25 @@ module Crystal
       llvm_type(type).const_int(n)
     end
 
+    def float32(value)
+      llvm_context.float.const_float(value)
+    end
+
+    def float64(value)
+      llvm_context.double.const_double(value)
+    end
+
+    def float(value, type)
+      case type.kind
+      when :f32
+        float32(value.to_f32)
+      when :f64
+        float64(value.to_f64)
+      else
+        raise "Unsupported float type"
+      end
+    end
+
     def llvm_nil
       llvm_typer.nil_value
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1306,6 +1306,17 @@ module Crystal
     def kind
       @bytes == 4 ? :f32 : :f64
     end
+
+    def range
+      case kind
+      when :f32
+        {Float32::MIN, Float32::MAX}
+      when :f64
+        {Float64::MIN, Float64::MAX}
+      else
+        raise "Bug: called 'range' for non-float literal"
+      end
+    end
   end
 
   class SymbolType < PrimitiveType


### PR DESCRIPTION
This is mostly a refactor that adds helper methods to align integers and float treatment within the compiler.

* Adds `LLVMBuilderHelper#float32`, `#float64` and `#float` that mimics `#int{n}` and `#int`.
* Adds `FloatType#range` that mimics `IntegerType#range`.

It is needed as a part of implementing overflow.