### PR TITLE
Int128: fix how LLVM::Type.const_int emit 128 literals

### DIFF
--- a/spec/std/llvm/type_spec.cr
+++ b/spec/std/llvm/type_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+require "llvm"
+
+describe LLVM::Type do
+  describe ".const_int" do
+    it "support Int64" do
+      ctx = LLVM::Context.new
+      ctx.int(64).const_int(Int64::MAX).to_s.should eq("i64 9223372036854775807")
+    end
+
+    it "support Int128" do
+      ctx = LLVM::Context.new
+      ctx.int(128).const_int(Int128::MAX).to_s.should eq("i128 170141183460469231731687303715884105727")
+    end
+  end
+end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -137,6 +137,7 @@ lib LibLLVM
   fun build_zext = LLVMBuildZExt(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
   fun const_array = LLVMConstArray(element_type : TypeRef, constant_vals : ValueRef*, length : UInt32) : ValueRef
   fun const_int = LLVMConstInt(int_type : TypeRef, value : UInt64, sign_extend : Int32) : ValueRef
+  fun const_int_of_arbitrary_precision = LLVMConstIntOfArbitraryPrecision(int_type : TypeRef, num_words : UInt32, words : UInt64*) : ValueRef
   fun const_null = LLVMConstNull(ty : TypeRef) : ValueRef
   fun const_pointer_null = LLVMConstPointerNull(ty : TypeRef) : ValueRef
   fun const_real = LLVMConstReal(real_ty : TypeRef, n : Float64) : ValueRef

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -126,7 +126,12 @@ struct LLVM::Type
   end
 
   def const_int(value) : Value
-    Value.new LibLLVM.const_int(self, value, 0)
+    if !value.is_a?(Int128) && !value.is_a?(UInt128) && int_width != 128
+      Value.new LibLLVM.const_int(self, value, 0)
+    else
+      encoded_value = UInt64[value & UInt64::MAX, (value >> 64) & UInt64::MAX]
+      Value.new LibLLVM.const_int_of_arbitrary_precision(self, encoded_value.size, encoded_value)
+    end
   end
 
   def const_float(value : Float32) : Value


### PR DESCRIPTION
The llvm wrapper is not able to emit 128bits ints.

Instead of going the way #7093 did of using String. This will allow to use `LLVMConstIntOfArbitraryPrecision` method that accept the number as an array of `UInt64`.