### PR TITLE
ECR: fix error location when specified wrong `io_name`

### DIFF
--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -17,13 +17,13 @@ describe "ECR" do
 
     pieces = [
       %(__str__ << "hello "),
-      %((#<loc:"foo.cr",1,10> 1 ).to_s __str__),
+      %(#<loc:push>(#<loc:"foo.cr",1,10> 1 )#<loc:pop>.to_s __str__),
       %(__str__ << " wor\\nld "),
-      %(#<loc:"foo.cr",2,6> while true ),
+      %(#<loc:push>#<loc:"foo.cr",2,6> while true #<loc:pop>),
       %(__str__ << " 2 "),
-      %(#<loc:"foo.cr",2,25> end ),
+      %(#<loc:push>#<loc:"foo.cr",2,25> end #<loc:pop>),
       %(__str__ << "\\n"),
-      %(#<loc:\"foo.cr\",3,3> # skip ),
+      %(#<loc:push>#<loc:\"foo.cr\",3,3> # skip #<loc:pop>),
       %(__str__ << " "),
       %(__str__ << "<% \\"string\\" %>"),
     ]

--- a/src/ecr/processor.cr
+++ b/src/ecr/processor.cr
@@ -37,10 +37,10 @@ module ECR
 
           supress_trailing_whitespace(token, supress_trailing)
 
-          str << '('
+          str << "#<loc:push>("
           append_loc(str, filename, line_number, column_number)
           str << string
-          str << ").to_s "
+          str << ")#<loc:pop>.to_s "
           str << buffer_name
           str << '\n'
         when :CONTROL
@@ -52,9 +52,11 @@ module ECR
 
           supress_trailing_whitespace(token, supress_trailing)
 
+          str << "#<loc:push>"
           append_loc(str, filename, line_number, column_number)
           str << ' ' unless string.starts_with?(' ')
           str << string
+          str << "#<loc:pop>"
           str << '\n'
         when :EOF
           break


### PR DESCRIPTION
This PR makes `ECR` wrap loc pragma and expression by `#<loc:push>` and `#<loc:pop>`.

For example, there are the following two files.

`foo.cr`:

```crystal
require "ecr"

io = IO::Memory.new
ECR.embed "./foo.ecr", ioo
io.to_s STDOUT
```

`foo.ecr`:

```ecr
<% foo = 1 -%>
<%= foo %>
```

`crystal run foo.cr` will fail because `ioo` is wrong `io_name`, it should be `io`.

It shows such a error message before this PR:

```console
$ crystal run foo.cr
Error in foo.cr:4: expanding macro

ECR.embed "./foo.ecr", ioo
    ^~~~~

in foo.cr:4: expanding macro

ECR.embed "./foo.ecr", ioo
^

in macro 'embed' /crystal/0.27.0/src/ecr/macros.cr:69, line 1:

>  1.     {{ run("ecr/process", "./foo.ecr", "ioo") }}
   2.

expanding macro
in ./foo.ecr:2: undefined local variable or method 'ioo' (did you mean 'io'?)

<%= foo %>
^~~

```

This location looks wrong. `<%= foo %>` is irrelevant to `ioo`.

After this PR, `crystal run foo.cr` shows expanded macro source.

```console
$ crystal
Using compiled compiler at `.build/crystal'
Error in foo.cr:4: expanding macro

ECR.embed "./foo.ecr", ioo
    ^~~~~

in foo.cr:4: expanding macro

ECR.embed "./foo.ecr", ioo
^

in macro 'embed' /crystal-lang/crystal/src/ecr/macros.cr:69, line 1:

>  1.     {{ run("ecr/process", "./foo.ecr", "ioo") }}
   2.

expanding macro
in macro 'embed' /crystal-lang/crystal/src/ecr/macros.cr:69, line 1:

>  1.     {{ run("ecr/process", "./foo.ecr", "ioo") }}
   2.

expanding macro
in macro 'macro_4521946960' expanded macro: embed:1, line 2:

   1. #<loc:push>#<loc:"./foo.ecr",1,3> foo = 1 #<loc:pop>
>  2. ioo << ""
   3. #<loc:push>(#<loc:"./foo.ecr",2,4> foo )#<loc:pop>.to_s ioo
   4. ioo << "\n"

undefined local variable or method 'ioo' (did you mean 'io'?)
```

I think it is better than old.

Thank you.