### PR TITLE
add default `script` to template `travis.yml`

### DIFF
--- a/src/compiler/crystal/tools/init/template/travis.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/travis.yml.ecr
@@ -1,1 +1,5 @@
 language: crystal
+
+script:
+  - crystal spec
+  - crystal tool format --check

--- a/src/compiler/crystal/tools/init/template/travis.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/travis.yml.ecr
@@ -1,5 +1,6 @@
 language: crystal
 
-script:
-  - crystal spec
-  - crystal tool format --check
+# Uncomment the following if you'd like Travis to run specs and check code formatting
+# script:
+#   - crystal spec
+#   - crystal tool format --check


### PR DESCRIPTION
Based on some discussion here: https://github.com/crystal-lang/crystal-book/pull/299#discussion_r238002788

Our docs recommend that folks add these lines to their `travis.yml` but it seems reasonable that the template could be shipped with them by default.