### PR TITLE
CI: Format before running specs

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -73,10 +73,10 @@ prepare_system() {
 }
 
 build() {
-  with_build_env './bin/crystal tool format --check samples spec src'
-  with_build_env 'make std_spec clean'
   with_build_env 'make crystal std_spec compiler_spec docs'
+  with_build_env './bin/crystal tool format --check samples spec src'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
+  with_build_env 'make std_spec clean'
 }
 
 prepare_build() {

--- a/bin/ci
+++ b/bin/ci
@@ -73,10 +73,10 @@ prepare_system() {
 }
 
 build() {
+  with_build_env './bin/crystal tool format --check samples spec src'
   with_build_env 'make std_spec clean'
   with_build_env 'make crystal std_spec compiler_spec docs'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
-  with_build_env './bin/crystal tool format --check samples spec src'
 }
 
 prepare_build() {
@@ -86,7 +86,7 @@ prepare_build() {
 
   # Make sure binaries from llvm are available in PATH
   on_osx brew install jq
-  on_osx OSX_LLVM_PACKAGE=`brew info --json=v1 crystal | jq '.[].dependencies | .[] | select(startswith("llvm"))'`
+  on_osx OSX_LLVM_PACKAGE=$(brew info --json=v1 crystal | jq '.[].dependencies | .[] | select(startswith("llvm"))')
   on_osx brew link --force $OSX_LLVM_PACKAGE
 
   on_tag verify_version
@@ -94,7 +94,7 @@ prepare_build() {
 
 verify_version() {
   # If building a tag, check it matches with file
-  FILE_VERSION=`cat VERSION`
+  FILE_VERSION=$(cat VERSION)
 
   if [ "$FILE_VERSION" != "$CURRENT_TAG" ]
   then

--- a/bin/ci
+++ b/bin/ci
@@ -73,10 +73,11 @@ prepare_system() {
 }
 
 build() {
-  with_build_env 'make crystal std_spec compiler_spec docs'
-  with_build_env './bin/crystal tool format --check samples spec src'
-  with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
   with_build_env 'make std_spec clean'
+  with_build_env 'make crystal'
+  with_build_env './bin/crystal tool format --check samples spec src'
+  with_build_env 'make std_spec compiler_spec docs'
+  with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
 }
 
 prepare_build() {


### PR DESCRIPTION
`crystal tool format` is a lot faster than running the whole specs.
This change provides a [Fail-fast](https://en.wikipedia.org/wiki/Fail-fast) system when the syntax isn't properly formatted.

I have also seen minor deprecated syntax (shell ticks), so I replaced them too (can be dropped from the PR)