### PR TITLE
Add git pre-commit hook for `crystal tool format`

### DIFF
--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /bin/sh
 #
 # This script ensures Crystal code is correctly formatted before committing it.
 # It won't apply any format changes automatically.
@@ -17,4 +17,9 @@ changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$
 
 [ -z "$changed_cr_files" ] && exit 0
 
-exec crystal tool format --check $changed_cr_files >&2
+if [ -x bin/crystal ]; then
+  # use bin/crystal wrapper when available to run local compiler build
+  exec bin/crystal tool format --check $changed_cr_files >&2
+else
+  exec crystal tool format --check $changed_cr_files >&2
+fi

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# This script ensures Crystal code is correctly formatted before committing it.
+# It won't apply any format changes automatically.
+#
+# Only staged files (the ones to be committed) are being processed, but each file is checked
+# entirely as it is stored on disc, even parts that are not staged.
+#
+# To use this script, it needs to be installed in the local git repository. For example by running
+# `ln -s scripts/git/pre-commit .git/hooks` in the root folder.
+#
+# Called by "git commit" with no arguments. The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+changed_cr_files=$(git diff --cached --name-only --diff-filter=A | grep '\.cr$')
+
+[ -z "$changed_cr_files" ] && exit 0
+
+exec crystal tool format --check "$changed_cr_files" >&2

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -13,8 +13,8 @@
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 
-changed_cr_files=$(git diff --cached --name-only --diff-filter=A | grep '\.cr$')
+changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$')
 
 [ -z "$changed_cr_files" ] && exit 0
 
-exec crystal tool format --check "$changed_cr_files" >&2
+exec crystal tool format --check $changed_cr_files >&2


### PR DESCRIPTION
This adds a pre-commit git hook for applying `git tool format --check` on the current index as mentioned in https://github.com/crystal-lang/crystal/pull/7140#issuecomment-443912421. Git hooks need to be installed manually in the local repo, but this script makes it as simple as `ln -s scripts/git/pre-commit .git/hooks`.

Currently it doesn't work properly when only one Crystal file is in the index. The command will fail silently (no commit created) but don't print any error messages. #7144 fixes that. If that doesn't get merged soon, a workaround could be added.

A similar tool exists in Golangs repository: https://github.com/golang/go/blob/master/misc/git/pre-commit