### PR TITLE
Add `Iterator#slice_before`

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -826,4 +826,88 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
   end
+
+  describe "#slice_before" do
+    it "slices before" do
+      ary = [1, 3, 5, 8, 10, 11, 13, 15, 16, 17]
+      iter = ary.slice_before(&.even?)
+      iter.next.should eq([1, 3, 5])
+      iter.next.should eq([8])
+      iter.next.should eq([10, 11, 13, 15])
+      iter.next.should eq([16, 17])
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "slices before: first element matches" do
+      ary = [2, 3, 4]
+      iter = ary.slice_before(&.even?)
+      iter.next.should eq([2, 3])
+      iter.next.should eq([4])
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "slices before nil" do
+      ary = [1, 2, nil, 3, nil]
+      iter = ary.slice_before(&.nil?)
+      iter.next.should eq([1, 2])
+      iter.next.should eq([nil, 3])
+      iter.next.should eq([nil])
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "slices before: #to_a" do
+      ary = [1, 3, 5, 8, 10, 11, 13, 15, 16, 17]
+      ary.slice_before(&.even?).to_a.should eq([
+        [1, 3, 5],
+        [8],
+        [10, 11, 13, 15],
+        [16, 17],
+      ])
+    end
+
+    it "slices after: #rewind" do
+      ary = [1, 3, 5, 8, 10, 11, 13, 15, 16, 17]
+      iter = ary.slice_before(&.even?)
+      iter.next.should eq([1, 3, 5])
+      iter.next.should eq([8])
+
+      iter.rewind
+      iter.next.should eq([1, 3, 5])
+    end
+
+    it "slices before with reuse = true" do
+      ary = [1, 3, 5, 8, 10, 11, 13, 15, 16, 17]
+      iter = ary.slice_before(reuse: true, &.even?)
+      a = iter.next
+      a.should eq([1, 3, 5])
+
+      b = iter.next
+      b.should eq([8])
+
+      a.should be(b)
+    end
+
+    it "slices before with reuse = array" do
+      reuse = [] of Int32
+      ary = [1, 3, 5, 8, 10, 11, 13, 15, 16, 17]
+      iter = ary.slice_before(reuse: reuse, &.even?)
+      a = iter.next
+      a.should eq([1, 3, 5])
+
+      b = iter.next
+      b.should eq([8])
+
+      a.should be(b)
+      a.should be(reuse)
+    end
+
+    it "slices before: non-bool block" do
+      ary = [1, nil, nil, 2, 3, nil]
+      iter = ary.slice_before(&.itself)
+      iter.next.should eq([1, nil, nil])
+      iter.next.should eq([2])
+      iter.next.should eq([3, nil])
+      iter.next.should be_a(Iterator::Stop)
+    end
+  end
 end

--- a/src/iterable.cr
+++ b/src/iterable.cr
@@ -50,4 +50,9 @@ module Iterable(T)
   def slice_after(reuse : Bool | Array(T) = false, &block : T -> B) forall B
     each.slice_after(reuse, &block)
   end
+
+  # Same as `each.slice_before(reuse, &block)`.
+  def slice_before(reuse : Bool | Array(T) = false, &block : T -> B) forall B
+    each.slice_before(reuse, &block)
+  end
 end


### PR DESCRIPTION
Part of #7142

This also improves the documentation of `slice_after`, now the two docs are similar and make it more clear why they are called that way.

I thought about reusing the implementation of `slice_before` but it might not be worth it. The algorithms need different variables. Plus at least in Ruby I think they don't seem to reuse the algorithm either. (in Ruby it's also much, much longer, in Crystal the core algorithm is just 30 lines)