### PR TITLE
Fix `Annotation#[]` to behave like `NamedTupleLiteral#[]`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1683,6 +1683,43 @@ module Crystal
       end
     end
 
+    describe "annotation methods" do
+      it "executes [] with NumberLiteral" do
+        assert_macro "x, y", %({{x[y]}}), [
+          Annotation.new(Path.new("Foo"), [42.int32] of ASTNode),
+          0.int32,
+        ] of ASTNode, %(42)
+      end
+
+      it "executes [] with SymbolLiteral" do
+        assert_macro "x, y", %({{x[y]}}), [
+          Annotation.new(Path.new("Foo"), [] of ASTNode, [NamedArgument.new("foo", 42.int32)]),
+          "foo".symbol,
+        ] of ASTNode, %(42)
+      end
+
+      it "executes [] with StringLiteral" do
+        assert_macro "x, y", %({{x[y]}}), [
+          Annotation.new(Path.new("Foo"), [] of ASTNode, [NamedArgument.new("foo", 42.int32)]),
+          "foo".string,
+        ] of ASTNode, %(42)
+      end
+
+      it "executes [] with MacroId" do
+        assert_macro "x, y", %({{x[y]}}), [
+          Annotation.new(Path.new("Foo"), [] of ASTNode, [NamedArgument.new("foo", 42.int32)]),
+          MacroId.new("foo"),
+        ] of ASTNode, %(42)
+      end
+
+      it "executes [] with other ASTNode, but returns NilLiteral" do
+        assert_macro "x, y", %({{x[y]}}), [
+          Annotation.new(Path.new("Foo"), [] of ASTNode),
+          3.14.float64,
+        ] of ASTNode, %(nil)
+      end
+    end
+
     describe "env" do
       it "has key" do
         ENV["FOO"] = "foo"

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1712,11 +1712,13 @@ module Crystal
         ] of ASTNode, %(42)
       end
 
-      it "executes [] with other ASTNode, but returns NilLiteral" do
-        assert_macro "x, y", %({{x[y]}}), [
-          Annotation.new(Path.new("Foo"), [] of ASTNode),
-          3.14.float64,
-        ] of ASTNode, %(nil)
+      it "executes [] with other ASTNode, but raises an error" do
+        expect_raises(Crystal::TypeException, "argument to [] must be a number, symbol or string, not BoolLiteral") do
+          assert_macro "x, y", %({{x[y]}}), [
+            Annotation.new(Path.new("Foo"), [] of ASTNode),
+            true.bool,
+          ] of ASTNode, %(nil)
+        end
       end
     end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -860,7 +860,7 @@ module Crystal::Macros
     # Returns the value of a named argument,
     # or NilLiteral if the named argument isn't
     # used in this attribute.
-    def [](name : SymbolLiteral) : ASTNode
+    def [](name : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2013,15 +2013,18 @@ module Crystal
           case arg
           when NumberLiteral
             index = arg.to_number.to_i
-            self.args[index]? || NilLiteral.new
-          when SymbolLiteral
-            named_arg = self.named_args.try &.find do |named_arg|
-              named_arg.name == arg.value
-            end
-            named_arg.try(&.value) || NilLiteral.new
+            return self.args[index]? || NilLiteral.new
+          when SymbolLiteral then name = arg.value
+          when StringLiteral then name = arg.value
+          when MacroId       then name = arg.value
           else
-            raise "argument to 'Annotation#[]' must be integer or symbol, not #{arg.class_desc}"
+            return NilLiteral.new
           end
+
+          named_arg = self.named_args.try &.find do |named_arg|
+            named_arg.name == name
+          end
+          named_arg.try(&.value) || NilLiteral.new
         end
       else
         super

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2018,7 +2018,7 @@ module Crystal
           when StringLiteral then name = arg.value
           when MacroId       then name = arg.value
           else
-            return NilLiteral.new
+            arg.raise "argument to [] must be a number, symbol or string, not #{arg.class_desc}:\n\n#{arg}"
           end
 
           named_arg = self.named_args.try &.find do |named_arg|

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2018,7 +2018,7 @@ module Crystal
           when StringLiteral then name = arg.value
           when MacroId       then name = arg.value
           else
-            arg.raise "argument to [] must be a number, symbol or string, not #{arg.class_desc}:\n\n#{arg}"
+            raise "argument to [] must be a number, symbol or string, not #{arg.class_desc}:\n\n#{arg}"
           end
 
           named_arg = self.named_args.try &.find do |named_arg|


### PR DESCRIPTION
Fixed #7149 

But it doesn't accept any `ASTNode`, it raises an error simply. I think `NamedTupleLiteral#[]` should do the same. I'll open a new pull request.