### PR TITLE
Replace inappropriate uses of `Time.now`

### DIFF
--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -384,24 +384,26 @@ class RedBlackTreeRunner
 end
 
 def bench(name, n = 1)
-  t = Time.now
-  print "#{name}: "
   res = nil
-  n.times do
-    res = yield
+  elapsed = Time.measure do
+    print "#{name}: "
+    res = nil
+    n.times do
+      res = yield
+    end
   end
-  puts "#{Time.now - t}, res: #{res}"
+  puts "#{elapsed}, res: #{res}"
 end
 
-t = Time.now
+elapsed = Time.measure do
+  b = RedBlackTreeRunner.new 100_000
+  bench("delete", 10) { b.run_delete }
+  bench("add", 10) { b.run_add }
+  bench("search", 10) { b.run_search }
+  bench("walk", 100) { b.run_inorder_walk }
+  bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
+  bench("min", 100) { b.run_min }
+  bench("max", 100) { b.run_max }
+end
 
-b = RedBlackTreeRunner.new 100_000
-bench("delete", 10) { b.run_delete }
-bench("add", 10) { b.run_add }
-bench("search", 10) { b.run_search }
-bench("walk", 100) { b.run_inorder_walk }
-bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
-bench("min", 100) { b.run_min }
-bench("max", 100) { b.run_max }
-
-puts "summary time: #{Time.now - t}"
+puts "summary time: #{elapsed}"

--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -384,26 +384,24 @@ class RedBlackTreeRunner
 end
 
 def bench(name, n = 1)
+  start = Time.monotonic
+  print "#{name}: "
   res = nil
-  elapsed = Time.measure do
-    print "#{name}: "
-    res = nil
-    n.times do
-      res = yield
-    end
+  n.times do
+    res = yield
   end
-  puts "#{elapsed}, res: #{res}"
+
+  puts "#{Time.monotonic - start}, res: #{res}"
 end
 
-elapsed = Time.measure do
-  b = RedBlackTreeRunner.new 100_000
-  bench("delete", 10) { b.run_delete }
-  bench("add", 10) { b.run_add }
-  bench("search", 10) { b.run_search }
-  bench("walk", 100) { b.run_inorder_walk }
-  bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
-  bench("min", 100) { b.run_min }
-  bench("max", 100) { b.run_max }
-end
+start = Time.monotonic
+b = RedBlackTreeRunner.new 100_000
+bench("delete", 10) { b.run_delete }
+bench("add", 10) { b.run_add }
+bench("search", 10) { b.run_search }
+bench("walk", 100) { b.run_inorder_walk }
+bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
+bench("min", 100) { b.run_min }
+bench("max", 100) { b.run_max }
 
-puts "summary time: #{elapsed}"
+puts "summary time: #{Time.monotonic - start}"

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -124,7 +124,7 @@ class Crystal::Program
 
     # First, update times for the program dir, so it remains in the cache longer
     # (this is specially useful if a macro run program is used by multiple programs)
-    now = Time.now
+    now = Time.utc_now
     File.utime(now, now, program_dir)
 
     if can_reuse_previous_compilation?(filename, executable_path, recorded_requires_path, requires_path)

--- a/src/file.cr
+++ b/src/file.cr
@@ -821,7 +821,7 @@ class File < IO::FileDescriptor
   # in the *filename* parameter to the value given in *time*.
   #
   # If the file does not exist, it will be created.
-  def self.touch(filename : String, time : Time = Time.now)
+  def self.touch(filename : String, time : Time = Time.utc_now)
     open(filename, "a") { } unless exists?(filename)
     utime time, time, filename
   end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -77,7 +77,7 @@ module FileUtils
   # ```
   #
   # NOTE: Alias of `File.touch`
-  def touch(path : String, time : Time = Time.now)
+  def touch(path : String, time : Time = Time.utc_now)
     File.touch(path, time)
   end
 
@@ -89,7 +89,7 @@ module FileUtils
   # ```
   # FileUtils.touch(["foo", "bar"])
   # ```
-  def touch(paths : Enumerable(String), time : Time = Time.now)
+  def touch(paths : Enumerable(String), time : Time = Time.utc_now)
     paths.each do |path|
       touch(path, time)
     end

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -44,7 +44,7 @@ module HTTP
 
     def expired?
       if e = expires
-        e < Time.now
+        e < Time.utc_now
       else
         false
       end
@@ -100,7 +100,7 @@ module HTTP
         return unless match
 
         expires = if max_age = match["max_age"]?
-                    Time.now + max_age.to_i.seconds
+                    Time.utc_now + max_age.to_i.seconds
                   else
                     parse_time(match["expires"]?)
                   end


### PR DESCRIPTION
For measuring elapsed time, `Time.measure` should be used. In applications, where a time zone won't be used anyway, it's better to use `Time.utc_now` instead of `Time.now` to avoid loading a time zone which can be expensive (loading from disk) when it is completely unnecessary.