### PR TITLE
Add microsecond precision to System::File.utime (Unix)

### DIFF
--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -125,7 +125,7 @@ module Crystal::System::File
   private def self.to_timeval(time : ::Time)
     t = uninitialized LibC::Timeval
     t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
-    t.tv_usec = typeof(t.tv_usec).new(0)
+    t.tv_usec = typeof(t.tv_usec).new(time.nanosecond / ::Time::NANOSECONDS_PER_MICROSECOND)
     t
   end
 


### PR DESCRIPTION
Seems like this has been forgotten.

It might have been left out intentionally, but I can't see any reason.