### PR TITLE
Fix 'NamedTupleLiteral#[]` to raise an error for invalid key type

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -811,6 +811,12 @@ module Crystal
         assert_macro "", %({{{a: 1}["b"]}}), [] of ASTNode, "nil"
       end
 
+      it "executes [] with invalid key type" do
+        expect_raises(Crystal::TypeException, "argument to [] must be a symbol or string, not BoolLiteral") do
+          assert_macro "", %({{{a: 1}[true]}}), [] of ASTNode, ""
+        end
+      end
+
       it "executes keys" do
         assert_macro "", %({{{a: 1, b: 2}.keys}}), [] of ASTNode, "[a, b]"
       end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -769,11 +769,11 @@ module Crystal::Macros
     end
 
     # Similar to `NamedTuple#[]` but returns `NilLiteral` if *key* is undefined.
-    def [](key : ASTNode) : ASTNode
+    def [](key : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
 
     # Adds or replaces a key.
-    def []=(key : ASTNode) : ASTNode
+    def []=(key : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -937,7 +937,7 @@ module Crystal
           when StringLiteral
             key = key.value
           else
-            return NilLiteral.new
+            raise "argument to [] must be a symbol or string, not #{key.class_desc}:\n\n#{key}"
           end
 
           entry = entries.find &.key.==(key)


### PR DESCRIPTION
Ref #7153

And also update doc.

 `NamedTupleLiteral#[]=` denies key typed neither `StringLiteral`, `SymbolLiteral` nor `MacroId` already. I think `NamedTuple#[]` should do same.