### PR TITLE
Compiler: use freeze_type as node type if node doesn't have a type

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1404,4 +1404,32 @@ describe "Block inference" do
       i
       ), inject_primitives: false) { int32 }
   end
+
+  it "can infer block type given that the method has a return type (#7160)" do
+    assert_type(%(
+      struct Int32
+        def self.foo
+          0
+        end
+      end
+
+      class Node
+        @child : Node?
+
+        def sum : Int32
+          if child = @child
+            child.call(&.sum)
+          else
+            0
+          end
+        end
+
+        def call(&block : self -> T) forall T
+          T.foo
+        end
+      end
+
+      Node.new.sum
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -10,11 +10,11 @@ module Crystal
     @type : Type?
 
     def type
-      @type || ::raise "BUG: `#{self}` at #{self.location} has no type"
+      type? || ::raise "BUG: `#{self}` at #{self.location} has no type"
     end
 
     def type?
-      @type
+      @type || @freeze_type
     end
 
     def type(*, with_literals = false)


### PR DESCRIPTION
Fixes #7160

When the compiler sees a method return type it will try to resolve it and then set it as the def's `@freeze_type`. This instance variable holds a type that eventually must match the type that is normally inferred. The compiler doesn't use `@freeze_type` for anything else.

This PR changes that: if there's no inferred type for a node but it has a `@freeze_type`, the node's type will be "inferred" to be that type. So if you say a method's return type is `Int32`, even before the compiler can deduce its real type and see if it matches `Int32` it will have an `Int32` type. This allows using the method in a recursive method and still be able to fully "infer" it's type (it's a bit of cheating because we are saying the type, but previously this didn't work).

One example is the issue this PR solves:

```crystal
class Tree
  def initialize(@value : Int32, @children : Array(Tree))
  end

  def sum : Int32
    @value + @children.each.map(&.sum).sum
  end
end

Tree.new(1, [] of Tree).sum
```

Here the compiler will try to type `Tree.new(...).sum` and for that it will need to type `@children.each.map(&.sum)`, which needs the type of `sum`, which isn't computed yet. The compiler before this PR would fail. With this PR it will succeed because we now know the type of `sum`.

Don't worry: the compiler will later check that the type is effectively what we told it.

An interesting side effect of this change is that in these recursive scenarios the return type isn't a hint anymore, it's a type that's used for inference. For example, this works as well:

```crystal
class Tree
  def initialize(@value : Int32, @children : Array(Tree))
  end

  def sum : Float64
    @value + @children.each.map(&.sum).sum
  end
end

Tree.new(1, [] of Tree).sum
```

Because `@value` is `Int32` and `sum` is told to be `Float64`, the right-hand side expression `@children...` is deduced to be `Float64`, and `Int32 + Float64` gives `Float64`, so this compiles fine. It's a bit spooky, but it's fine :-)

@bcardiff Would it be possible to run the script that checks the compiler works fine for many of the major crystal projects? This is a simple change, all specs pass, but I wonder if it could break something that I'm not seeing.