### PR TITLE
Compiler: add missing NamedTupleInstanceType#has_in_type_vars?

### DIFF
--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -321,4 +321,15 @@ describe "Semantic: named tuples" do
       end
     )) { nil_type }
   end
+
+  it "doesn't crash on named tuple type recursion (#7162)" do
+    assert_type(%(
+      def call(*args)
+        call({a: 1})
+        1
+      end
+
+      call("")
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2437,6 +2437,10 @@ module Crystal
       entries.any? &.type.unbound?
     end
 
+    def has_in_type_vars?(type)
+      entries.any? { |entry| entry.type.includes_type?(type) || entry.type.has_in_type_vars?(type) }
+    end
+
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
       io << "NamedTuple("
       @entries.join(", ", io) do |entry|


### PR DESCRIPTION
Fixes #7162

There's a check the compiler does, calling ` has_in_type_vars?`, which all types implement, but it was missing for `NamedTupleInstanceType`. The implementation of `GenericInstanceType` was used, and because a named tuple type has a named tuple type as its type vars, so this led to an infinite recursion.