### PR TITLE
Add missing Float#weeks method similar to Int#weeks

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -277,5 +277,6 @@ describe Time::Span do
     1.hours.should eq(60.minutes)
     1.week.should eq(7.days)
     2.weeks.should eq(14.days)
+    1.1.weeks.should eq(7.7.days)
   end
 end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -476,6 +476,11 @@ struct Int
 end
 
 struct Float
+  # Returns a `Time::Span` of `self` weeks.
+  def weeks : Time::Span
+    (self * 7).days
+  end
+
   # Returns a `Time::Span` of `self` days.
   def days : Time::Span
     (self * 24).hours


### PR DESCRIPTION
Both `Int` and `Float` have `days`, `hours`,`minutes`, `seconds`, `milliseconds`, `microseconds`, `nanoseconds`.

On top of that `Int` also has `weeks` method, but `Float` does not.