### PR TITLE
Add `Enumerable#one?`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -733,6 +733,9 @@ describe "Enumerable" do
     it { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
     it { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
     it { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
+    it { [1, 2, false].one?.should be_false }
+    it { [1, false, false].one?.should be_true }
+    it { [false].one?.should be_false }
   end
 
   describe "partition" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1010,6 +1010,19 @@ module Enumerable(T)
     c == 1
   end
 
+  # Returns `true` if only one element in this enumerable
+  # is _truthy_.
+  #
+  # ```
+  # [1, false, false].one? # => true
+  # [1, false, 3].one?     # => false
+  # [1].one?               # => true
+  # [false].one?           # => false
+  # ```
+  def one?
+    one? &.itself
+  end
+
   # Returns a `Tuple` with two arrays. The first one contains the elements
   # in the collection for which the passed block returned `true`,
   # and the second one those for which it returned `false`.


### PR DESCRIPTION
This method was missing. Similar non-block versions exist for `all?` and `none?`.