### PR TITLE
Refactor: String#to_i to avoid future overflow

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -197,6 +197,7 @@ describe "String" do
 
   describe "to_i" do
     it { "1234".to_i.should eq(1234) }
+    it { "-128".to_i8.should eq(-128) }
     it { "   +1234   ".to_i.should eq(1234) }
     it { "   -1234   ".to_i.should eq(-1234) }
     it { "   +1234   ".to_i.should eq(1234) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -497,7 +497,7 @@ class String
     if info.negative
       {% if max_negative %}
         return yield if info.value > {{max_negative}}
-        -info.value.to_{{method}}
+        (~info.value &+ 1).unsafe_as(Int64).to_{{method}}
       {% else %}
         return yield
       {% end %}


### PR DESCRIPTION
This is a small refactor on `String#to_i` methods.

Before this PR when parsing the minimum negative value (eg: `-128` for `Int8`) the code will first convert the `UInt64` absolute value to a `Int8` and then return it with opposite sign.

The positive `128` is not a valid `Int8` so we should change the conversion to use 2's complement.

First compute the binary `Int64` representation of negative number to return, cast it as `Int64` and then narrow its type to the expected one.