### PR TITLE
Formatter: fix bug related to typeof inside generic type

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1235,4 +1235,16 @@ describe Crystal::Formatter do
     # 3 + 4
     # ```
     CODE
+
+  assert_format <<-CODE
+    X(typeof(begin
+      e.is_a?(Y) ? 1 : 2
+    end))
+    CODE
+
+  assert_format <<-CODE
+    X(typeof(begin
+      e.is_a?(Y)
+    end))
+    CODE
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1147,14 +1147,18 @@ module Crystal
       accept name
       skip_space_or_newline
 
-      check_open_paren
+      write_token :"("
+      skip_space
 
-      paren_count = @paren_count
+      # Given that generic type arguments are always inside parentheses
+      # we can start counting them from 0 inside them.
+      old_paren_count = @paren_count
+      @paren_count = 0
 
       if named_args = node.named_args
         has_newlines, _, _ = format_named_args([] of ASTNode, named_args, @indent + 2)
         # `format_named_args` doesn't skip trailing comma
-        if @paren_count == paren_count && @token.type == :","
+        if @paren_count == 0 && @token.type == :","
           next_token_skip_space_or_newline
           if has_newlines
             write ","
@@ -1166,7 +1170,7 @@ module Crystal
         skip_space_or_newline
         node.type_vars.each_with_index do |type_var, i|
           accept type_var
-          if @paren_count == paren_count
+          if @paren_count == 0
             skip_space_or_newline
             if @token.type == :","
               write ", " unless last?(i, node.type_vars)
@@ -1176,8 +1180,11 @@ module Crystal
         end
       end
 
-      skip_space_or_newline if @paren_count == paren_count
-      check_close_paren
+      skip_space_or_newline if @paren_count == 0
+      write_token :")"
+
+      # Restore the old parentheses count
+      @paren_count = old_paren_count
 
       false
     end


### PR DESCRIPTION
Fixes a formatter bug found in #7174

I can't remember much, but it seems the formatter keeps a `@paren_count` variable to count parentheses found surrounding types. For example, this is valid:

```crystal
x = [] of (Int32)
```

The parentheses are used to group types for a Proc type:

```crystal
a = [] of (Int32, Int32) -> String
```

but just one type inside the parentheses count as well.

The AST nodes for types don't store this information so the formatter has to track whether it found an open paren when formatting a type, and closing it appropriately after passing over  a type.

This wasn't working well inside `typeof` inside generic type arguments:

```crystal
X(typeof(begin
#^ incremented here: parent_count += 1
  e.is_a?(Y)
#          ^ just passed a type and paren_count > 0 -> consume that paren
end)
```

The problem is that inside generic type arguments there's no need to increment `paren_count`: it can start all over from 0 because type arguments are guaranteed to start and end with parentheses. This is what this PR does.

I still feel the whole `paren_count` could be improved, right now this is the smallest/easiest change I could find to fix it. Another solution could be to stick a `paren_count` to each type node that the formatter would use, but I'd rather do that in a separate PR.