### PR TITLE
Add begin-less and end-less ranges

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -568,6 +568,7 @@ describe Crystal::Formatter do
   assert_format "1 .. 2", "1..2"
   assert_format "1 ... 2", "1...2"
   assert_format "(1 .. )", "(1..)"
+  assert_format " .. 2", "..2"
 
   assert_format "typeof( 1, 2, 3 )", "typeof(1, 2, 3)"
   assert_format "sizeof( Int32 )", "sizeof(Int32)"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -567,6 +567,7 @@ describe Crystal::Formatter do
 
   assert_format "1 .. 2", "1..2"
   assert_format "1 ... 2", "1...2"
+  assert_format "(1 .. )", "(1..)"
 
   assert_format "typeof( 1, 2, 3 )", "typeof(1, 2, 3)"
   assert_format "sizeof( Int32 )", "sizeof(Int32)"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -799,6 +799,14 @@ module Crystal
     it_parses "foo(1.., 2)", Call.new(nil, "foo", [RangeLiteral.new(1.int32, Nop.new, false), 2.int32] of ASTNode)
     it_parses "1..;", RangeLiteral.new(1.int32, Nop.new, false)
     it_parses "{1.. => 2};", HashLiteral.new([HashLiteral::Entry.new(RangeLiteral.new(1.int32, Nop.new, false), 2.int32)])
+    it_parses "..2", RangeLiteral.new(Nop.new, 2.int32, false)
+    it_parses "...2", RangeLiteral.new(Nop.new, 2.int32, true)
+    it_parses "foo..2", RangeLiteral.new("foo".call, 2.int32, false)
+    it_parses "foo(..2)", Call.new(nil, "foo", RangeLiteral.new(Nop.new, 2.int32, false))
+    it_parses "x[..2]", Call.new("x".call, "[]", RangeLiteral.new(Nop.new, 2.int32, false))
+    it_parses "x[1, ..2]", Call.new("x".call, "[]", [1.int32, RangeLiteral.new(Nop.new, 2.int32, false)] of ASTNode)
+    it_parses "{..2}", TupleLiteral.new([RangeLiteral.new(Nop.new, 2.int32, false)] of ASTNode)
+    it_parses "[..2]", ArrayLiteral.new([RangeLiteral.new(Nop.new, 2.int32, false)] of ASTNode)
 
     it_parses "A = 1", Assign.new("A".path, 1.int32)
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -794,6 +794,11 @@ module Crystal
 
     it_parses "1 .. 2", RangeLiteral.new(1.int32, 2.int32, false)
     it_parses "1 ... 2", RangeLiteral.new(1.int32, 2.int32, true)
+    it_parses "(1 .. )", Expressions.new([RangeLiteral.new(1.int32, Nop.new, false)] of ASTNode)
+    it_parses "(1 ... )", Expressions.new([RangeLiteral.new(1.int32, Nop.new, true)] of ASTNode)
+    it_parses "foo(1.., 2)", Call.new(nil, "foo", [RangeLiteral.new(1.int32, Nop.new, false), 2.int32] of ASTNode)
+    it_parses "1..;", RangeLiteral.new(1.int32, Nop.new, false)
+    it_parses "{1.. => 2};", HashLiteral.new([HashLiteral::Entry.new(RangeLiteral.new(1.int32, Nop.new, false), 2.int32)])
 
     it_parses "A = 1", Assign.new("A".path, 1.int32)
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -802,6 +802,7 @@ module Crystal
     it_parses "..2", RangeLiteral.new(Nop.new, 2.int32, false)
     it_parses "...2", RangeLiteral.new(Nop.new, 2.int32, true)
     it_parses "foo..2", RangeLiteral.new("foo".call, 2.int32, false)
+    it_parses "foo ..2", RangeLiteral.new("foo".call, 2.int32, false)
     it_parses "foo(..2)", Call.new(nil, "foo", RangeLiteral.new(Nop.new, 2.int32, false))
     it_parses "x[..2]", Call.new("x".call, "[]", RangeLiteral.new(Nop.new, 2.int32, false))
     it_parses "x[1, ..2]", Call.new("x".call, "[]", [1.int32, RangeLiteral.new(Nop.new, 2.int32, false)] of ASTNode)

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -159,4 +159,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(asm("nop" :: "a"(1) :: "volatile"))
   expect_to_s %(asm("nop" ::: "e" : "volatile"))
   expect_to_s %[(1..)]
+  expect_to_s %[..3]
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -158,4 +158,5 @@ describe "ASTNode#to_s" do
   expect_to_s %(asm("nop" :::: "volatile"))
   expect_to_s %(asm("nop" :: "a"(1) :: "volatile"))
   expect_to_s %(asm("nop" ::: "e" : "volatile"))
+  expect_to_s %[(1..)]
 end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -143,6 +143,10 @@ describe "Array" do
       [1, 2, 3][1..nil].should eq([2, 3])
     end
 
+    it "gets on range without begin" do
+      [1, 2, 3][nil..1].should eq([1, 2])
+    end
+
     it "raises on index out of bounds with range" do
       expect_raises IndexError do
         [1, 2, 3][4..6]
@@ -285,6 +289,10 @@ describe "Array" do
       a = [1, 2, 3, 4, 5]
       a[2..nil] = 6
       a.should eq([1, 2, 6])
+
+      a = [1, 2, 3, 4, 5]
+      a[nil..2] = 6
+      a.should eq([6, 4, 5])
     end
 
     it "replaces a subrange with an array" do
@@ -315,6 +323,10 @@ describe "Array" do
       a = [1, 2, 3, 4, 5]
       a[2..nil] = [6, 7]
       a.should eq([1, 2, 6, 7])
+
+      a = [1, 2, 3, 4, 5]
+      a[nil..2] = [6, 7]
+      a.should eq([6, 7, 4, 5])
     end
   end
 
@@ -600,6 +612,12 @@ describe "Array" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', 1..nil).should eq(expected)
+    end
+
+    it "replaces only values in range begin" do
+      a = ['a', 'b', 'c']
+      expected = ['x', 'x', 'c']
+      a.fill('x', nil..1).should eq(expected)
     end
 
     it "works with a block" do

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -139,9 +139,19 @@ describe "Array" do
       [1, 2, 3][2..-2].should eq([] of Int32)
     end
 
+    it "gets on range without end" do
+      [1, 2, 3][1..nil].should eq([2, 3])
+    end
+
     it "raises on index out of bounds with range" do
       expect_raises IndexError do
         [1, 2, 3][4..6]
+      end
+    end
+
+    it "raises on index out of bounds with range without end" do
+      expect_raises IndexError do
+        [1, 2, 3][4..nil]
       end
     end
 
@@ -271,6 +281,10 @@ describe "Array" do
       a = [1, 2, 3, 4, 5]
       a[1...1] = 6
       a.should eq([1, 6, 2, 3, 4, 5])
+
+      a = [1, 2, 3, 4, 5]
+      a[2..nil] = 6
+      a.should eq([1, 2, 6])
     end
 
     it "replaces a subrange with an array" do
@@ -297,6 +311,10 @@ describe "Array" do
       a = [1, 2, 3, 4, 5]
       a[1..3] = [6, 7, 8]
       a.should eq([1, 6, 7, 8, 5])
+
+      a = [1, 2, 3, 4, 5]
+      a[2..nil] = [6, 7]
+      a.should eq([1, 2, 6, 7])
     end
   end
 
@@ -443,6 +461,10 @@ describe "Array" do
       a = [1, 2, 3, 4, 5, 6, 7]
       a.delete_at(1..2)
       a.should eq([1, 4, 5, 6, 7])
+
+      a = [1, 2, 3, 4, 5, 6, 7]
+      a.delete_at(3..nil)
+      a.should eq([1, 2, 3])
     end
 
     it "deletes with index and count" do
@@ -572,6 +594,12 @@ describe "Array" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', -3..1).should eq(expected)
+    end
+
+    it "replaces only values in range without end" do
+      a = ['a', 'b', 'c']
+      expected = ['a', 'x', 'x']
+      a.fill('x', 1..nil).should eq(expected)
     end
 
     it "works with a block" do

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -110,6 +110,10 @@ describe "BitArray" do
       from_int(6, 0b011110)[2..nil].should eq(from_int(4, 0b1110))
     end
 
+    it "gets on beginless range" do
+      from_int(6, 0b011110)[nil..2].should eq(from_int(3, 0b011))
+    end
+
     it "raises on index out of bounds with range" do
       expect_raises IndexError do
         from_int(3, 0b111)[4..6]

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -106,6 +106,10 @@ describe "BitArray" do
       from_int(3, 0b011)[2..-2].should eq(BitArray.new(0))
     end
 
+    it "gets on endless range" do
+      from_int(6, 0b011110)[2..nil].should eq(from_int(4, 0b1110))
+    end
+
     it "raises on index out of bounds with range" do
       expect_raises IndexError do
         from_int(3, 0b111)[4..6]

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -161,6 +161,18 @@ describe Indexable do
     last_element.should eq(3)
   end
 
+  it "iterates within a range of indices, no end" do
+    indexable = SafeIndexable.new(5)
+    last_element = nil
+
+    return_value = indexable.each(within: 2..nil) do |elem|
+      last_element = elem
+    end
+
+    return_value.should eq(indexable)
+    last_element.should eq(4)
+  end
+
   it "joins strings (empty case)" do
     indexable = SafeStringIndexable.new(0)
     indexable.join.should eq("")

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -173,6 +173,17 @@ describe Indexable do
     last_element.should eq(4)
   end
 
+  it "iterates within a range of indices, no beginning" do
+    indexable = SafeIndexable.new(5)
+
+    elements = [] of Int32
+    return_value = indexable.each(within: nil..2) do |elem|
+      elements << elem
+    end
+
+    elements.should eq([0, 1, 2])
+  end
+
   it "joins strings (empty case)" do
     indexable = SafeStringIndexable.new(0)
     indexable.join.should eq("")

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -101,87 +101,88 @@ describe Indexable do
 
   it "iterates through a subset of its elements (#3386)" do
     indexable = SafeIndexable.new(5)
-    last_element = nil
+    elems = [] of Int32
 
     return_value = indexable.each(start: 2, count: 3) do |elem|
-      last_element = elem
+      elems << elem
     end
 
+    elems.should eq([2, 3, 4])
     return_value.should eq(indexable)
-    last_element.should eq(4)
   end
 
   it "iterates until its size (#3386)" do
     indexable = SafeIndexable.new(5)
-    last_element = nil
+    elems = [] of Int32
 
     indexable.each(start: 3, count: 999) do |elem|
-      last_element = elem
+      elems << elem
     end
 
-    last_element.should eq(4)
+    elems.should eq([3, 4])
   end
 
   it "iterates until its size, having mutated (#3386)" do
     indexable = SafeIndexable.new(10)
-    last_element = nil
+    elems = [] of Int32
 
     indexable.each(start: 3, count: 999) do |elem|
-      indexable.size += 1 if elem <= 5
       # size is incremented 3 times
-      last_element = elem
+      indexable.size += 1 if elem <= 5
+      elems << elem
     end
 
     # last was 9, but now is 12.
-    last_element.should eq(12)
+    elems.should eq([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
   end
 
   it "iterates until its size, having mutated (#3386)" do
     indexable = SafeIndexable.new(10)
-    last_element = nil
+    elems = [] of Int32
 
     indexable.each(start: 3, count: 5) do |elem|
       indexable.size += 1
-      last_element = elem
+      elems << elem
     end
 
     # last element iterated is still 7.
-    last_element.should eq(7)
+    elems.should eq([3, 4, 5, 6, 7])
   end
 
   it "iterates within a range of indices (#3386)" do
     indexable = SafeIndexable.new(5)
-    last_element = nil
+    elems = [] of Int32
 
     return_value = indexable.each(within: 2..3) do |elem|
-      last_element = elem
+      elems << elem
     end
 
+    elems.should eq([2, 3])
     return_value.should eq(indexable)
-    last_element.should eq(3)
   end
 
   it "iterates within a range of indices, no end" do
     indexable = SafeIndexable.new(5)
-    last_element = nil
+    elems = [] of Int32
 
     return_value = indexable.each(within: 2..nil) do |elem|
-      last_element = elem
+      elems << elem
     end
 
+    elems.should eq([2, 3, 4])
     return_value.should eq(indexable)
-    last_element.should eq(4)
   end
 
   it "iterates within a range of indices, no beginning" do
     indexable = SafeIndexable.new(5)
 
-    elements = [] of Int32
+    elems = [] of Int32
     return_value = indexable.each(within: nil..2) do |elem|
-      elements << elem
+      elems << elem
     end
 
-    elements.should eq([0, 1, 2])
+    elems.should eq([0, 1, 2])
+    return_value.should eq(indexable)
   end
 
   it "joins strings (empty case)" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -127,6 +127,9 @@ describe "Number" do
       50.clamp(10...nil).should eq(50)
       5.clamp(10..nil).should eq(10)
       5.clamp(10...nil).should eq(10)
+
+      5.clamp(nil..10).should eq(5)
+      50.clamp(nil..10).should eq(10)
     end
 
     it "clamps floats" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -122,6 +122,11 @@ describe "Number" do
       500.clamp(10, 100).should eq(100)
 
       50.clamp(10..100).should eq(50)
+
+      50.clamp(10..nil).should eq(50)
+      50.clamp(10...nil).should eq(50)
+      5.clamp(10..nil).should eq(10)
+      5.clamp(10...nil).should eq(10)
     end
 
     it "clamps floats" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -57,6 +57,8 @@ describe "Range" do
     (1...5).to_s.should eq("1...5")
     (1..5).to_s.should eq("1..5")
     (1..nil).to_s.should eq("1..")
+    (nil..3).to_s.should eq("..3")
+    (nil..nil).to_s.should eq("..")
   end
 
   it "does inspect" do
@@ -199,6 +201,13 @@ describe "Range" do
       end
       ary.should eq([3, 4, 5, 6, 7])
     end
+
+    it "raises on beginless" do
+      range = nil..4
+      expect_raises(ArgumentError, "Can't each beginless range") do
+        range.each { }
+      end
+    end
   end
 
   describe "reverse_each" do
@@ -228,6 +237,16 @@ describe "Range" do
       expect_raises(ArgumentError, "Can't reverse_each endless range") do
         range.reverse_each { }
       end
+    end
+
+    it "iterators on beginless range" do
+      range = nil..2
+      arr = [] of Int32
+      range.reverse_each do |x|
+        arr << x
+        break if arr.size == 5
+      end
+      arr.should eq([2, 1, 0, -1, -2])
     end
   end
 
@@ -264,6 +283,13 @@ describe "Range" do
       iter.rewind
       iter.next.should eq(3)
       iter.next.should eq(4)
+    end
+
+    it "raises on beginless range" do
+      r = nil..3
+      expect_raises(ArgumentError, "Can't each beginless range") do
+        r.each
+      end
     end
 
     it "cycles" do
@@ -366,6 +392,13 @@ describe "Range" do
       end
       elems.should eq([1, 3, 5, 7, 9])
     end
+
+    it "raises on beginless range" do
+      a = nil..3
+      expect_raises(ArgumentError, "Can't step beginless range") do
+        a.step(2) { }
+      end
+    end
   end
 
   describe "step iterator" do
@@ -430,6 +463,13 @@ describe "Range" do
       iter.next.should eq(1)
       iter.next.should eq(3)
     end
+
+    it "raises with beginless range" do
+      a = nil..3
+      expect_raises(ArgumentError, "Can't step beginless range") do
+        a.step(2)
+      end
+    end
   end
 
   describe "map" do
@@ -483,6 +523,18 @@ describe "Range" do
       ((1...nil) === 1).should be_true
       ((1...nil) === 2).should be_true
       ((1..nil) === 2).should be_true
+    end
+
+    it "beginless" do
+      ((nil..3) === -1).should be_true
+      ((nil..3) === 3).should be_true
+      ((nil..3) === 4).should be_false
+      ((nil...3) === 2).should be_true
+      ((nil...3) === 3).should be_false
+    end
+
+    it "no limits" do
+      ((nil..nil) === 1).should be_true
     end
   end
 end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -203,7 +203,7 @@ describe "Range" do
     end
 
     it "raises on beginless" do
-      range = nil..4
+      range = (true ? nil : 1)..4
       expect_raises(ArgumentError, "Can't each beginless range") do
         range.each { }
       end
@@ -286,7 +286,7 @@ describe "Range" do
     end
 
     it "raises on beginless range" do
-      r = nil..3
+      r = (true ? nil : 1)..3
       expect_raises(ArgumentError, "Can't each beginless range") do
         r.each
       end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -337,6 +337,18 @@ describe "Range" do
       iter.next.should eq(2)
     end
 
+    it "does next with beginless range" do
+      r = nil...3
+      iter = r.reverse_each
+      iter.next.should eq(2)
+      iter.next.should eq(1)
+      iter.next.should eq(0)
+      iter.next.should eq(-1)
+
+      iter.rewind
+      iter.next.should eq(2)
+    end
+
     it "reverse cycles" do
       (1..3).reverse_each.cycle.first(8).join.should eq("32132132")
     end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -36,6 +36,10 @@ describe "String" do
       "há日本語"[1..nil].should eq("á日本語")
     end
 
+    it "gets with range without beginning" do
+      "há日本語"[nil..2].should eq("há日")
+    end
+
     it "gets when index is last and count is zero" do
       "foo"[3, 0].should eq("")
     end
@@ -1218,6 +1222,14 @@ describe "String" do
 
     it "subs endless range with string" do
       "hello".sub(2..nil, "ya").should eq("heya")
+    end
+
+    it "subs beginless range with char" do
+      "hello".sub(nil..2, 'a').should eq("alo")
+    end
+
+    it "subs beginless range with string" do
+      "hello".sub(nil..2, "ye").should eq("yelo")
     end
   end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -32,6 +32,10 @@ describe "String" do
       "há日本語"[1..3].should eq("á日本")
     end
 
+    it "gets with range without end" do
+      "há日本語"[1..nil].should eq("á日本語")
+    end
+
     it "gets when index is last and count is zero" do
       "foo"[3, 0].should eq("")
     end
@@ -1206,6 +1210,14 @@ describe "String" do
 
     it "subs range with string, non-ascii" do
       "あいうえお".sub(1..2, "けくこ").should eq("あけくこえお")
+    end
+
+    it "subs endless range with char" do
+      "hello".sub(2..nil, 'a').should eq("hea")
+    end
+
+    it "subs endless range with string" do
+      "hello".sub(2..nil, "ya").should eq("heya")
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -370,8 +370,12 @@ class Array(T)
   # a = [1, 2, 3, 4, 5]
   # a[1...1] = 6
   # a # => [1, 6, 2, 3, 4, 5]
+  #
+  # a = [1, 2, 3, 4, 5]
+  # a[2...] = 6
+  # a # => [1, 2, 6]
   # ```
-  def []=(range : Range(Int, Int), value : T)
+  def []=(range : Range, value : T)
     self[*Indexable.range_to_index_and_count(range, size)] = value
   end
 
@@ -432,8 +436,12 @@ class Array(T)
   # a = [1, 2, 3, 4, 5]
   # a[1..3] = [6, 7, 8, 9, 10]
   # a # => [1, 6, 7, 8, 9, 10, 5]
+  #
+  # a = [1, 2, 3, 4, 5]
+  # a[2..] = [6, 7, 8, 9, 10]
+  # a # => [1, 2, 6, 7, 8, 9, 10]
   # ```
-  def []=(range : Range(Int, Int), values : Array(T))
+  def []=(range : Range, values : Array(T))
     self[*Indexable.range_to_index_and_count(range, size)] = values
   end
 
@@ -452,8 +460,9 @@ class Array(T)
   # a[6..10]   # raise IndexError
   # a[5..10]   # => []
   # a[-2...-1] # => ["d"]
+  # a[2..]     # => ["c", "d", "e"]
   # ```
-  def [](range : Range(Int, Int))
+  def [](range : Range)
     self[*Indexable.range_to_index_and_count(range, size)]
   end
 
@@ -640,7 +649,7 @@ class Array(T)
   # a                    # => ["ant", "dog"]
   # a.delete_at(99..100) # raises IndexError
   # ```
-  def delete_at(range : Range(Int, Int))
+  def delete_at(range : Range)
     index, count = Indexable.range_to_index_and_count(range, self.size)
     delete_at(index, count)
   end
@@ -754,7 +763,7 @@ class Array(T)
   # a = [1, 2, 3, 4, 5, 6]
   # a.fill(2..3) { |i| i * i } # => [1, 2, 4, 9, 5, 6]
   # ```
-  def fill(range : Range(Int, Int))
+  def fill(range : Range)
     fill(*Indexable.range_to_index_and_count(range, size)) do |i|
       yield i
     end
@@ -803,7 +812,7 @@ class Array(T)
   # a = [1, 2, 3, 4, 5]
   # a.fill(9, 2..3) # => [1, 2, 9, 9, 5]
   # ```
-  def fill(value : T, range : Range(Int, Int))
+  def fill(value : T, range : Range)
     fill(range) { value }
   end
 

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -85,7 +85,7 @@ struct BitArray
   # ba[5..10]   # => BitArray[]
   # ba[-2...-1] # => BitArray[0]
   # ```
-  def [](range : Range(Int, Int))
+  def [](range : Range)
     self[*Indexable.range_to_index_and_count(range, size)]
   end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -457,7 +457,16 @@ module Crystal
       check_void_value exp, location
       next_token_skip_space_or_newline
       check_void_expression_keyword
-      right = parse_or
+      right = if end_token? ||
+                 @token.type == :")" ||
+                 @token.type == :"," ||
+                 @token.type == :";"
+                 @token.type == :";" ||
+                 @token.type == :"=>"
+                Nop.new
+              else
+                parse_or
+              end
       RangeLiteral.new(exp, right, exclusive).at(location).at_end(right)
     end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -440,7 +440,13 @@ module Crystal
 
     def parse_range
       location = @token.location
-      exp = parse_or
+
+      if @token.type == :".." || @token.type == :"..."
+        exp = Nop.new
+      else
+        exp = parse_or
+      end
+
       while true
         case @token.type
         when :".."
@@ -460,7 +466,6 @@ module Crystal
       right = if end_token? ||
                  @token.type == :")" ||
                  @token.type == :"," ||
-                 @token.type == :";"
                  @token.type == :";" ||
                  @token.type == :"=>"
                 Nop.new
@@ -723,7 +728,14 @@ module Crystal
 
           column_number = @token.column_number
           next_token_skip_space_or_newline
-          call_args = preserve_stop_on_do { parse_call_args_space_consumed check_plus_and_minus: false, allow_curly: true, end_token: :"]" }
+          call_args = preserve_stop_on_do do
+            parse_call_args_space_consumed(
+              check_plus_and_minus: false,
+              allow_curly: true,
+              end_token: :"]",
+              allow_beginless_range: true,
+            )
+          end
           skip_space_or_newline
           check :"]"
           @wants_regex = false
@@ -4219,7 +4231,8 @@ module Crystal
       @call_args_nest -= 1
     end
 
-    def parse_call_args_space_consumed(check_plus_and_minus = true, allow_curly = false, control = false, end_token = :")")
+    def parse_call_args_space_consumed(check_plus_and_minus = true, allow_curly = false, control = false, end_token = :")",
+                                       allow_beginless_range = false)
       # This method is called by `parse_call_args`, so it increments once too much in this case.
       # But it is no problem, because it decrements once too much.
       @call_args_nest += 1
@@ -4247,6 +4260,8 @@ module Crystal
         if current_char.ascii_whitespace?
           return nil
         end
+      when :"..", :"..."
+        return nil unless allow_beginless_range
       else
         return nil
       end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1218,8 +1218,10 @@ module Crystal
     end
 
     def visit(node : RangeLiteral)
-      need_parens = need_parens(node.from)
-      in_parenthesis(need_parens, node.from)
+      unless node.from.nop?
+        need_parens = need_parens(node.from)
+        in_parenthesis(need_parens, node.from)
+      end
 
       if node.exclusive?
         @str << "..."

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1227,8 +1227,10 @@ module Crystal
         @str << ".."
       end
 
-      need_parens = need_parens(node.to)
-      in_parenthesis(need_parens, node.to)
+      unless node.to.nop?
+        need_parens = need_parens(node.to)
+        in_parenthesis(need_parens, node.to)
+      end
 
       false
     end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -705,8 +705,12 @@ module Indexable(T)
   # :nodoc:
   def self.range_to_index_and_count(range, collection_size)
     start_index = range.begin
-    start_index += collection_size if start_index < 0
-    raise IndexError.new if start_index < 0
+    if start_index.nil?
+      start_index = 0
+    else
+      start_index += collection_size if start_index < 0
+      raise IndexError.new if start_index < 0
+    end
 
     end_index = range.end
     if end_index.nil?

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -244,7 +244,7 @@ module Indexable(T)
   # ```text
   # b -- c -- d --
   # ```
-  def each(*, within range : Range(Int, Int))
+  def each(*, within range : Range)
     start, count = Indexable.range_to_index_and_count(range, size)
     each(start: start, count: count) { |element| yield element }
   end
@@ -709,9 +709,13 @@ module Indexable(T)
     raise IndexError.new if start_index < 0
 
     end_index = range.end
-    end_index += collection_size if end_index < 0
-    end_index -= 1 if range.excludes_end?
-    count = end_index - start_index + 1
+    if end_index.nil?
+      count = collection_size - start_index
+    else
+      end_index += collection_size if end_index < 0
+      end_index -= 1 if range.excludes_end?
+      count = end_index - start_index + 1
+    end
     count = 0 if count < 0
 
     {start_index, count}

--- a/src/number.cr
+++ b/src/number.cr
@@ -229,6 +229,9 @@ struct Number
   #
   # 5.clamp(10..)  # => 10
   # 50.clamp(10..) # => 50
+  #
+  # 5.clamp(..10)  # => 5
+  # 50.clamp(..10) # => 10
   # ```
   def clamp(range : Range)
     raise ArgumentError.new("Can't clamp an exclusive range") if !range.end.nil? && range.exclusive?
@@ -244,10 +247,13 @@ struct Number
   #
   # 5.clamp(10, nil)  # => 10
   # 50.clamp(10, nil) # => 50
+  #
+  # 5.clamp(nil, 10)  # => 5
+  # 50.clamp(nil, 10) # => 10
   # ```
   def clamp(min, max)
     return max if !max.nil? && self > max
-    return min if self < min
+    return min if !min.nil? && self < min
     self
   end
 

--- a/src/number.cr
+++ b/src/number.cr
@@ -226,9 +226,12 @@ struct Number
   # 5.clamp(10..100)   # => 10
   # 50.clamp(10..100)  # => 50
   # 500.clamp(10..100) # => 100
+  #
+  # 5.clamp(10..)  # => 10
+  # 50.clamp(10..) # => 50
   # ```
   def clamp(range : Range)
-    raise ArgumentError.new("Can't clamp an exclusive range") if range.exclusive?
+    raise ArgumentError.new("Can't clamp an exclusive range") if !range.end.nil? && range.exclusive?
     clamp range.begin, range.end
   end
 
@@ -238,9 +241,12 @@ struct Number
   # 5.clamp(10, 100)   # => 10
   # 50.clamp(10, 100)  # => 50
   # 500.clamp(10, 100) # => 100
+  #
+  # 5.clamp(10, nil)  # => 10
+  # 50.clamp(10, nil) # => 50
   # ```
   def clamp(min, max)
-    return max if self > max
+    return max if !max.nil? && self > max
     return min if self < min
     self
   end

--- a/src/range.cr
+++ b/src/range.cr
@@ -409,7 +409,9 @@ struct Range(B, E)
     end
 
     def next
-      return stop if @current <= @range.begin
+      begin_value = @range.begin
+
+      return stop if !begin_value.nil? && @current <= begin_value
       return @current = @current.pred
     end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -113,7 +113,7 @@ struct Range(B, E)
       yield current
       current = current.succ
     end
-    yield current if !@exclusive && !end_value.nil? && current == end_value
+    yield current if !@exclusive && current == end_value
   end
 
   # Returns an `Iterator` over the elements of this range.

--- a/src/range.cr
+++ b/src/range.cr
@@ -259,7 +259,7 @@ struct Range(B, E)
     begin_value = @begin
     end_value = @end
 
-    # TOOD: change to `nil?` after removing the `nil?` error related to `Pointer`
+    # TODO: change to `nil?` after removing the `nil?` error related to `Pointer`
 
     # begin passes
     (begin_value.is_a?(Nil) || value >= begin_value) &&

--- a/src/range.cr
+++ b/src/range.cr
@@ -103,6 +103,10 @@ struct Range(B, E)
   # # prints: 10 11 12 13 14 15
   # ```
   def each : Nil
+    {% if B == Nil %}
+      {% raise "Can't each beginless range" %}
+    {% end %}
+
     current = @begin
     if current.nil?
       raise ArgumentError.new("Can't each beginless range")
@@ -122,6 +126,10 @@ struct Range(B, E)
   # (1..3).each.skip(1).to_a # => [2, 3]
   # ```
   def each
+    {% if B == Nil %}
+      {% raise "Can't each beginless range" %}
+    {% end %}
+
     if @begin.nil?
       raise ArgumentError.new("Can't each beginless range")
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -729,7 +729,7 @@ class String
   # "hello"[1..-1]  # "ello"
   # "hello"[1...-1] # "ell"
   # ```
-  def [](range : Range(Int, Int))
+  def [](range : Range)
     self[*Indexable.range_to_index_and_count(range, size)]
   end
 
@@ -1882,7 +1882,7 @@ class String
   # ```
   # "hello".sub(1..2, 'a') # => "halo"
   # ```
-  def sub(range : Range(Int, Int), replacement : Char)
+  def sub(range : Range, replacement : Char)
     sub_range(range, replacement) do |buffer, from_index, to_index|
       replacement.each_byte do |byte|
         buffer.value = byte
@@ -1898,7 +1898,7 @@ class String
   # ```
   # "hello".sub(1..2, "eee") # => "heeelo"
   # ```
-  def sub(range : Range(Int, Int), replacement : String)
+  def sub(range : Range, replacement : String)
     sub_range(range, replacement) do |buffer|
       buffer.copy_from(replacement.to_unsafe, replacement.bytesize)
       buffer += replacement.bytesize


### PR DESCRIPTION
Fixes #7170

This PR introduces begin-less and end-less ranges. If most of us think this is a nice and useful feature we could merge it.

An end-less range is just a range with `nil` as its end. It can be written as `(3..)` or `(3..nil)`, but of course without an explicit `nil` is nicer.

A begin-less range is just a range with `nil` as its beginning. It can be written as `..3` or `nil..3`.

These ranges have two semantics:

## As a range

A range has methods like `each`, `step`, etc. An endless range doesn't stop iteration (well, it will, eventually, when it overflows):

```crystal
(3..).each do |x|
  puts x
  break if some_condition
end
```

You can't invoke `each` on a begin-less range (it errors at compile-time, unless the begin is a nilable int, and in that case it raises at runtime). But you can invoke `reverse_each`:

```crystal
(..3).reverse_each do |x|
  # ... eventually yields 0, -1, -2
end
```

Note that a begin-less range isn't equivalent to a range that starts with `0` in these case.

A range also has a `===` method which can be use in `case` ([and soon in some `Enumerable` methods ](#7174)). In this case an endless range means "greater than the beginning of the range":

```crystal
number = rand(1..10)
case number
when ..3 then "foo"
when (3..5) then "bar"
when (6..) then "bar" # or just else
end
```

(well, maybe the above isn't a good example because there's still an else `nil` branch there)

Another example:

```crystal
numbers = [1, 10, 3, 4, 5, 8]
numbers.select(6..) # => [10, 8]
numbers.select(..6) # => [1, 3, 4, 5]
```

The above is the same as:

```crystal
numbers.select(&.>=(6))
numbers.select(&.<=(6))
```

I think the former is a bit more readable.

There's also `Number#clamp`, so now there's another way of doing this:

```crystal
num = some_number
num = 10 if num <= 10
```

We can do:

```crystal
num = num.clamp(10..)
```

Same goes with capping to a max.

In Ruby 2.6 there was also an example like this:

```ruby
[1, 2, 3].zip(6..) # => [[1, 6], [2, 7], [3, 8]]
```

which is nice (no need to explicitly specify an upper bound) but currently doesn't work in Crystal (but I might make it work soon).

## As an indexer

As an indexer, an endless range means "until the end of the collection". It's equivalent to passing `-1`, except that you don't have to write that and you don't have to care about `..` vs. `...`:

```crystal
ary = [1, 2, 3, 4, 5]
ary[2..] # => [3, 4, 5]
ary[2...] # => [3, 4, 5]
```

This works for any indexable (`Array`, `Deque`) and `String`.

For a begin-less range it's equivalent to passing `0`, but maybe it's a bit more concise:

```crystal
ary = [1, 2, 3, 4, 5]
ary[..2] # => [1, 2, 3]
```

## The catch-all range

Because the begin and end are now optional, we can also write `(..)`. It doesn't have much use, really. We could forbid it. But right now you can use it:

```crystal
# replace all elements of an array with a single element
ary = [1, 2, 3, 4, 5]
ary[..] = 3
ary # => [3]

# replace all elements of an array
ary = [1, 2, 3, 4, 5]
ary[..] = [6, 7, 8]
ary # => [6, 7, 8]

# fill an array with a value
ary = [1, 2, 3]
ary.fill(8, ..)
ary # => [8, 8, 8]

# another way to dup an array
ary = [1, 2, 3]
b = ary[..]
```

And also:

```crystal
case number
when .. then "duh"
end
```

Yeah... not a lot of uses, but the semantics are consistent.

## Implementation details

Ideally I would change the `Range(Int, Int)` restrictions to `Range(Int?, Int?)`. However, that gives a compile-error in some cases saying that you can't have `Int` inside a union type. Instead of trying to fix that I decided to just drop those inner restrictions for two reasons:
- I don't have much time to think about fixing that error
- It doesn't matter much because you will still get an (probably uglier) error if you pass a non-number range, but:
- I don't think there will be many there passing ranges of non-integers to these methods
- It's still not clear what we want to do with these restrictions: is a `Range(Int, Int)` actually a thing, or should it be more like `Range(< Int, < Int)` saying "anything that inherits `Int`"?

Changing the parser was relatively simple.
Making the changes to `Range` methods was also simple, but it took a bit of time.
Changing the logic of indexers (`ary[3..]`) was very easy because all of that logic is in `Indexable.range_to_index_and_count` (we might want to move that method to `Range` because it's also used in `String` which is not an `Indexable`)

Thoughts?