### PR TITLE
build: depend on standard variable to let the user define the builddate

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -34,7 +34,8 @@ module Crystal
     end
 
     def self.date
-      {{ env("CRYSTAL_CONFIG_BUILD_DATE") || `date "+%Y-%m-%d"`.stringify.chomp }}
+      time = {{ (env("SOURCE_DATE_EPOCH") || `date +%s`).to_i }}
+      Time.unix(time).to_s("%Y-%m-%d")
     end
 
     def self.default_target_triple


### PR DESCRIPTION
SOURCE_DATE_EPOCH is the standard for reproducible builds; using it means most groups that care will automatically benefit from this without setting project-specific variables.

https://reproducible-builds.org/docs/source-date-epoch/

...

I am going with the flow here since this currently uses a subprocess, but surely there must be some part of the language spec that allows you to do this without such hacks? Anyway, that's not strictly related to this fix...