### PR TITLE
Add Object#then

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -133,6 +133,17 @@ private class HashedTestObject
 end
 
 describe Object do
+  describe "then" do
+    it "returns output of given block" do
+      "Hello".then { "World" }.should eq("World")
+      "Hello".then(&.upcase).should eq("HELLO")
+    end
+
+    it "works on nils" do
+      nil.then { |x| x.should be_nil; true }.should be_true
+    end
+  end
+
   describe "delegate" do
     it "delegates" do
       wrapper = StringWrapper.new("HellO")

--- a/src/object.cr
+++ b/src/object.cr
@@ -143,6 +143,29 @@ class Object
     end
   end
 
+  # Yields `self` to the block, and returns its output.
+  #
+  # Overall, `then` improves readability of the code by promoting chaining
+  # over nested function calls.
+  #
+  # ```
+  # "Hello".then { |str| str + " World" } # => "Hello World"
+  # # vs
+  # "Hello".tap { |str| str + " World" } # => "Hello"
+  #
+  # (1..100).each do |i|
+  #   case i
+  #   when .then { |i| i >= 10 && i <= 30 }
+  #     # ...
+  #   when .then { |i| (i % 2) == 0 && i != 50 }
+  #     # ...
+  #   end
+  # end
+  # ```
+  def then
+    yield self
+  end
+
   # Yields `self` to the block, and then returns `self`.
   #
   # The primary purpose of this method is to "tap into" a method chain,


### PR DESCRIPTION
- Brought from Ruby 2.6, which aliased `Object#yield_self` to `Object#then`
- Followup to #5110