### PR TITLE
Compiler: give proper error when trying to access instance variable of union type

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1075,4 +1075,20 @@ describe "Semantic: class" do
       { {{ Foo::Bar.superclass }}, {{ Foo::Baz.superclass }} }
     )) { tuple_of [types["Foo"].metaclass, types["Foo"].metaclass] }
   end
+
+  it "errors if reading instance var of union type (#7187)" do
+    assert_error %(
+      class Foo
+        @x = 1
+      end
+
+      class Bar
+        @x = 1
+      end
+
+      z = Foo.new || Bar.new
+      z.@x
+      ),
+      "can't read instance variables of union types (@x of (Bar | Foo))"
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -557,6 +557,10 @@ module Crystal
       obj_type = obj.type?
       return unless obj_type
 
+      if obj_type.is_a?(UnionType)
+        raise "can't read instance variables of union types (#{name} of #{obj_type})"
+      end
+
       var = visitor.lookup_instance_var(self, obj_type)
       self.type = var.type
     end


### PR DESCRIPTION
Fixes #7187

Eventually we can consider supporting this if all union types define that instance variable, though it would be a new kind of dispatch. Right now I don't want to spend more time on this so at least giving a proper error is better than printing "BUG".