### PR TITLE
Fix leaks in HTTP::Server specs

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "../spec_helper"
 require "openssl"
 require "http/client"
 require "http/server"
@@ -132,11 +132,10 @@ module HTTP
         context.response.print context.request.headers["Host"]
       end
       address = server.bind_unused_port "::1"
-      spawn { server.listen }
 
-      HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("[::1]:#{address.port}")
-
-      server.close
+      run_server(server) do
+        HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("[::1]:#{address.port}")
+      end
     end
 
     it "sends a 'connection: close' header on one-shot request" do
@@ -144,11 +143,10 @@ module HTTP
         context.response.print context.request.headers["connection"]
       end
       address = server.bind_unused_port "::1"
-      spawn { server.listen }
 
-      HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("close")
-
-      server.close
+      run_server(server) do
+        HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("close")
+      end
     end
 
     it "sends a 'connection: close' header on one-shot request with block" do
@@ -156,13 +154,12 @@ module HTTP
         context.response.print context.request.headers["connection"]
       end
       address = server.bind_unused_port "::1"
-      spawn { server.listen }
 
-      HTTP::Client.get("http://[::1]:#{address.port}/") do |response|
-        response.body_io.gets_to_end
-      end.should eq("close")
-
-      server.close
+      run_server(server) do
+        HTTP::Client.get("http://[::1]:#{address.port}/") do |response|
+          response.body_io.gets_to_end
+        end.should eq("close")
+      end
     end
 
     it "doesn't read the body if request was HEAD" do

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -1,3 +1,4 @@
+require "./spec_helper"
 require "../spec_helper"
 require "http/web_socket"
 require "random/secure"
@@ -380,13 +381,12 @@ describe HTTP::WebSocket do
     end
 
     address = http_server.bind_unused_port
-    spawn http_server.not_nil!.listen # TODO: Remove .not_nil! when #6037 is fixed
 
-    expect_raises(Socket::Error, "Handshake got denied. Status code was 200.") do
-      HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+    run_server(http_server) do
+      expect_raises(Socket::Error, "Handshake got denied. Status code was 200.") do
+        HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+      end
     end
-  ensure
-    # http_server.try &.close # TODO: Uncomment when #5958 is fixed
   end
 
   describe "handshake fails if server does not verify Sec-WebSocket-Key" do
@@ -399,13 +399,12 @@ describe HTTP::WebSocket do
       end
 
       address = http_server.bind_unused_port
-      spawn http_server.not_nil!.listen # TODO: Remove .not_nil! when #6037 is fixed
 
-      expect_raises(Socket::Error, "Handshake got denied. Server did not verify WebSocket challenge.") do
-        HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+      run_server(http_server) do
+        expect_raises(Socket::Error, "Handshake got denied. Server did not verify WebSocket challenge.") do
+          HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+        end
       end
-    ensure
-      # http_server.try &.close # TODO: Uncomment when #5958 is fixed
     end
 
     it "Sec-WebSocket-Accept incorrect" do
@@ -418,13 +417,12 @@ describe HTTP::WebSocket do
       end
 
       address = http_server.bind_unused_port
-      spawn http_server.not_nil!.listen # TODO: Remove .not_nil! when #6037 is fixed
 
-      expect_raises(Socket::Error, "Handshake got denied. Server did not verify WebSocket challenge.") do
-        HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+      run_server(http_server) do
+        expect_raises(Socket::Error, "Handshake got denied. Server did not verify WebSocket challenge.") do
+          HTTP::WebSocket::Protocol.new(address.address, port: address.port, path: "/")
+        end
       end
-    ensure
-      # http_server.try &.close # TODO: Uncomment when #5958 is fixed
     end
   end
 

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -28,8 +28,12 @@ describe TCPServer do
       it "binds to port 0" do
         server = TCPServer.new(address, 0)
 
-        server.local_address.address.should eq(address)
-        server.local_address.port.should be > 0
+        begin
+          server.local_address.address.should eq(address)
+          server.local_address.port.should be > 0
+        ensure
+          server.close
+        end
       end
 
       it "raises when port is negative" do
@@ -74,7 +78,8 @@ describe TCPServer do
 
     describe "address resolution" do
       it "binds to localhost" do
-        TCPServer.new("localhost", unused_local_port)
+        server = TCPServer.new("localhost", unused_local_port)
+        server.close
       end
 
       it "raises when host doesn't exist" do

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -171,7 +171,12 @@ class HTTP::Server
   def bind_tcp(host : String, port : Int32, reuse_port : Bool = false) : Socket::IPAddress
     tcp_server = TCPServer.new(host, port, reuse_port: reuse_port)
 
-    bind(tcp_server)
+    begin
+      bind(tcp_server)
+    rescue exc
+      tcp_server.close
+      raise exc
+    end
 
     tcp_server.local_address
   end
@@ -234,7 +239,12 @@ class HTTP::Server
   def bind_unix(path : String) : Socket::UNIXAddress
     server = UNIXServer.new(path)
 
-    bind(server)
+    begin
+      bind(server)
+    rescue exc
+      server.close
+      raise exc
+    end
 
     server.local_address
   end
@@ -269,7 +279,12 @@ class HTTP::Server
       tcp_server = TCPServer.new(host, port, reuse_port: reuse_port)
       server = OpenSSL::SSL::Server.new(tcp_server, context)
 
-      bind(server)
+      begin
+        bind(server)
+      rescue exc
+        server.close
+        raise exc
+      end
 
       tcp_server.local_address
     end


### PR DESCRIPTION
This fixes several issues with `HTTP::Server` specs.

Previously, there were some weird influences between individual specs. For example, when disabling `handles exception during SSL handshake` (e.g. marking it `pending`), the following spec `closes gracefully` would fail with the following error:

```
End of file reached (IO::EOFError)
         from src/io.cr:814:31 in 'read_line:chomp'
         from src/http/content.cr:196:7 in 'read_chunk_size'
         from src/http/content.cr:178:7 in 'next_chunk'
         from src/http/content.cr:145:7 in 'peek'
         from src/io.cr:632:37 in 'gets'
         from src/io.cr:605:5 in 'gets'
         from src/io.cr:575:5 in 'gets'
         from src/io.cr:574:3 in 'gets'
         from spec/std/http/server/server_spec.cr:609:11 in '->'
         from src/spec/methods.cr:255:3 in 'it'
         from spec/std/http/server/server_spec.cr:587:7 in '->'
         from src/spec/context.cr:255:3 in 'describe'
         from src/spec/methods.cr:16:5 in 'describe'
         from spec/std/http/server/server_spec.cr:586:5 in '->'
         from src/spec/context.cr:255:3 in 'describe'
         from src/spec/methods.cr:16:5 in 'describe'
         from spec/std/http/server/server_spec.cr:234:3 in '__crystal_main'
         from src/crystal/main.cr:97:5 in 'main_user_code'
         from src/crystal/main.cr:86:7 in 'main'
         from src/crystal/main.cr:106:3 in 'main'
         from __libc_start_main
```

@RX14 had already identified reusing fildescriptors by leftover fibers as probable reason.

And in fact, a large number of specs was not fully contained and leaking either open ports or unstopped fibers.

One issue was an actual bug in `HTTP::Server#bind_tcp` (and similar methods) which would bind a new socket and try to add it to the server. If that failed (because the server was already closed), it would raise an error but the newly created socket would not be terminated.

The other issues were all introduced by the specs themselves, a few missing `server.close`.

I also added a helper `run_server` which starts the server in a new fiber, then yields to a block for interacting with it and finally ensures that it is properly shut down. This should avoid any breaking specs from leaking server fibers.

I'm not sure if `ensure_no_ports_leaking` should stay around. It's rather rudimentary. If a open port is leaked at some point, all following specs will fail because of this.

This might not fix all the issues and I still don't completely understand the reasons why exactly one spec failed when the other was deactivated. But it already improves quite a lot.
I'll try to run the specs randomized to see if there might be any other issues with couplings between specs.