### PR TITLE
Add overflow detection with preview opt-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ static ?=       ## Enable static linking
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
-override FLAGS += $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )
+override FLAGS += -D preview_overflow -D compiler_rt $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src") CRYSTAL_CONFIG_BUILD_COMMIT="$(CRYSTAL_CONFIG_BUILD_COMMIT)"

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -231,6 +231,42 @@ describe "Code gen: arithmetics primitives" do
           ), flags: PreviewOverflowFlags).to_i.should eq(1)
         end
       {% end %}
+
+      {% for float_type in [Float32, Float64] %}
+        {% if type != UInt128 || float_type != Float32 %}
+          # skip for type == UInt128 && float_type == Float32
+          # since Float32::MAX < UInt128::MAX
+          it "raises overflow if greater than {{type}}::MAX (from {{float_type}})" do
+            run(%(
+              require "prelude"
+
+              v = {{float_type}}.new({{type}}::MAX) * {{float_type}}.new(1.5)
+
+              begin
+                v.{{method}}
+                0
+              rescue OverflowError
+                1
+              end
+            ), flags: PreviewOverflowFlags).to_i.should eq(1)
+          end
+        {% end %}
+
+        it "raises overflow if lower than {{type}}::MIN (from {{float_type}})" do
+          run(%(
+            require "prelude"
+
+            v = {{float_type}}.new({{type}}::MIN) * {{float_type}}.new(1.5) - {{float_type}}.new(1.0)
+
+            begin
+              v.{{method}}
+              0
+            rescue OverflowError
+              1
+            end
+          ), flags: PreviewOverflowFlags).to_i.should eq(1)
+        end
+      {% end %}
     {% end %}
   end
 end

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -1,11 +1,13 @@
 require "../../spec_helper"
 
-{% if flag?(:bits64) %}
+{% if flag?(:darwin) %}
 SupportedInts = [UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int32, Int64, Int128]
 
 PreviewOverflowFlags = ["preview_overflow"]
 {% else %}
-# skip Int128 and UInt128 on 32 bits platforms
+# Skip Int128 and UInt128 on linux platforms due to compiler-rt dependency.
+# PreviewOverflowFlags includes compiler_rt flag to support Int64 overflow
+# detection in 32 bits platforms.
 SupportedInts = [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64]
 
 PreviewOverflowFlags = ["preview_overflow", "compiler_rt"]

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -2,9 +2,13 @@ require "../../spec_helper"
 
 {% if flag?(:bits64) %}
 SupportedInts = [UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int32, Int64, Int128]
+
+PreviewOverflowFlags = ["preview_overflow"]
 {% else %}
 # skip Int128 and UInt128 on 32 bits platforms
 SupportedInts = [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64]
+
+PreviewOverflowFlags = ["preview_overflow", "compiler_rt"]
 {% end %}
 
 describe "Code gen: arithmetics primitives" do
@@ -73,7 +77,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
 
       it "raises overflow for {{type}} + Int64" do
@@ -85,7 +89,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
     {% end %}
   end
@@ -101,7 +105,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
 
       it "raises overflow for {{type}} - Int64" do
@@ -113,7 +117,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
     {% end %}
   end
@@ -129,7 +133,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
 
       it "raises overflow for {{type}} * Int64" do
@@ -141,7 +145,7 @@ describe "Code gen: arithmetics primitives" do
           rescue OverflowError
             1
           end
-        ), flags: ["preview_overflow"]).to_i.should eq(1)
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
       end
     {% end %}
   end

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -61,4 +61,32 @@ describe "Code gen: arithmetics primitives" do
       end
     {% end %}
   end
+
+  describe "+ addition" do
+    {% for type in SupportedInts %}
+      it "raises overflow for {{type}}" do
+        run(%(
+          require "prelude"
+          begin
+            {{type}}::MAX + {{type}}.new(1)
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+
+      it "raises overflow for {{type}} + Int64" do
+        run(%(
+          require "prelude"
+          begin
+            {{type}}::MAX + 1_i64
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+    {% end %}
+  end
 end

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -269,4 +269,36 @@ describe "Code gen: arithmetics primitives" do
       {% end %}
     {% end %}
   end
+
+  describe ".to_f conversions" do
+    it "raises overflow if greater than Float32::MAX" do
+      run(%(
+        require "prelude"
+
+        v = Float64.new(Float32::MAX) * 1.5_f64
+
+        begin
+          v.to_f32
+          0
+        rescue OverflowError
+          1
+        end
+      ), flags: PreviewOverflowFlags).to_i.should eq(1)
+    end
+
+    it "raises overflow if lower than Float32::MIN" do
+      run(%(
+        require "prelude"
+
+        v = Float64.new(Float32::MIN) * 1.5_f64
+
+        begin
+          v.to_f32
+          0
+        rescue OverflowError
+          1
+        end
+      ), flags: PreviewOverflowFlags).to_i.should eq(1)
+    end
+  end
 end

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -117,4 +117,32 @@ describe "Code gen: arithmetics primitives" do
       end
     {% end %}
   end
+
+  describe "* multiplication" do
+    {% for type in SupportedInts %}
+      it "raises overflow for {{type}}" do
+        run(%(
+          require "prelude"
+          begin
+            ({{type}}::MAX / {{type}}.new(2) &+ {{type}}.new(1)) * {{type}}.new(2)
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+
+      it "raises overflow for {{type}} * Int64" do
+        run(%(
+          require "prelude"
+          begin
+            ({{type}}::MAX / {{type}}.new(2) &+ {{type}}.new(1)) * 2_i64
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+    {% end %}
+  end
 end

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -271,6 +271,21 @@ describe "Code gen: arithmetics primitives" do
   end
 
   describe ".to_f conversions" do
+    {% if SupportedInts.includes?(Int128) %}
+      it "raises overflow if greater than Float32::MAX (from UInt128)" do
+        run(%(
+          require "prelude"
+
+          begin
+            UInt128::MAX.to_f32
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: PreviewOverflowFlags).to_i.should eq(1)
+      end
+    {% end %}
+
     it "raises overflow if greater than Float32::MAX" do
       run(%(
         require "prelude"

--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -89,4 +89,32 @@ describe "Code gen: arithmetics primitives" do
       end
     {% end %}
   end
+
+  describe "- subtraction" do
+    {% for type in SupportedInts %}
+      it "raises overflow for {{type}}" do
+        run(%(
+          require "prelude"
+          begin
+            {{type}}::MIN - {{type}}.new(1)
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+
+      it "raises overflow for {{type}} - Int64" do
+        run(%(
+          require "prelude"
+          begin
+            {{type}}::MIN - 1_i64
+            0
+          rescue OverflowError
+            1
+          end
+        ), flags: ["preview_overflow"]).to_i.should eq(1)
+      end
+    {% end %}
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -154,7 +154,7 @@ class Crystal::SpecRunOutput
   end
 end
 
-def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None)
+def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::None, flags = nil)
   code = inject_primitives(code) if inject_primitives
 
   # Code that requires the prelude doesn't run in LLVM's MCJIT
@@ -162,7 +162,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
   # in the current executable!), so instead we compile
   # the program and run it, printing the last
   # expression and using that to compare the result.
-  if code.includes?(%(require "prelude"))
+  if code.includes?(%(require "prelude")) || flags
     ast = Parser.parse(code).as(Expressions)
     last = ast.expressions.last
     assign = Assign.new(Var.new("__tempvar"), last)
@@ -175,6 +175,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
 
     compiler = Compiler.new
     compiler.debug = debug
+    compiler.flags.concat flags if flags
     compiler.compile Compiler::Source.new("spec", code), output_filename
 
     output = `#{output_filename}`

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -317,51 +317,61 @@ struct BigDecimal < Number
   end
 
   # Converts to `Int64`. Truncates anything on the right side of the decimal point.
+  # Raises `OverflowError` in case of overflow.
   def to_i64
     to_big_i.to_i64
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  # Raises `OverflowError` in case of overflow.
   def to_i32
     to_big_i.to_i32
   end
 
   # Converts to `Int16`. Truncates anything on the right side of the decimal point.
+  # Raises `OverflowError` in case of overflow.
   def to_i16
     to_big_i.to_i16
   end
 
   # Converts to `Int8`. Truncates anything on the right side of the decimal point.
+  # Raises `OverflowError` in case of overflow.
   def to_i8
     to_big_i.to_i8
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  # Raises `OverflowError` in case of overflow.
   def to_i
     to_i32
   end
 
   # Converts to `Int8`. Truncates anything on the right side of the decimal point.
+  # In case of overflow a wrapping is performed.
   def to_i8!
     to_big_i.to_i8!
   end
 
   # Converts to `Int16`. Truncates anything on the right side of the decimal point.
+  # In case of overflow a wrapping is performed.
   def to_i16!
     to_big_i.to_i16!
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  # In case of overflow a wrapping is performed.
   def to_i32!
     to_big_i.to_i32!
   end
 
   # Converts to `Int64`. Truncates anything on the right side of the decimal point.
+  # In case of overflow a wrapping is performed.
   def to_i64!
     to_big_i.to_i64!
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  # In case of overflow a wrapping is performed.
   def to_i!
     to_i32!
   end
@@ -372,90 +382,106 @@ struct BigDecimal < Number
 
   # Converts to `UInt64`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # Raises `OverflowError` in case of overflow.
   def to_u64
     to_big_u.to_u64
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # Raises `OverflowError` in case of overflow.
   def to_u32
     to_big_u.to_u32
   end
 
   # Converts to `UInt16`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # Raises `OverflowError` in case of overflow.
   def to_u16
     to_big_u.to_u16
   end
 
   # Converts to `UInt8`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # Raises `OverflowError` in case of overflow.
   def to_u8
     to_big_u.to_u8
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # Raises `OverflowError` in case of overflow.
   def to_u
     to_u32
   end
 
   # Converts to `UInt8`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # In case of overflow a wrapping is performed.
   def to_u8!
     to_big_u.to_u8!
   end
 
   # Converts to `UInt16`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # In case of overflow a wrapping is performed.
   def to_u16!
     to_big_u.to_u16!
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # In case of overflow a wrapping is performed.
   def to_u32!
     to_big_u.to_u32!
   end
 
   # Converts to `UInt64`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # In case of overflow a wrapping is performed.
   def to_u64!
     to_big_u.to_u64!
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
+  # In case of overflow a wrapping is performed.
   def to_u!
     to_u32!
   end
 
   # Converts to `Float64`.
+  # Raises `OverflowError` in case of overflow.
   def to_f64
     to_s.to_f64
   end
 
   # Converts to `Float32`.
+  # Raises `OverflowError` in case of overflow.
   def to_f32
     to_f64.to_f32
   end
 
   # Converts to `Float64`.
+  # Raises `OverflowError` in case of overflow.
   def to_f
     to_f64
   end
 
   # Converts to `Float32`.
+  # In case of overflow a wrapping is performed.
   def to_f32!
     to_f64.to_f32!
   end
 
   # Converts to `Float64`.
+  # In case of overflow a wrapping is performed.
   def to_f64!
     to_f64
   end
 
   # Converts to `Float64`.
+  # In case of overflow a wrapping is performed.
   def to_f!
     to_f64!
   end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -6,12 +6,13 @@ require "../program"
 require "./llvm_builder_helper"
 
 module Crystal
-  MAIN_NAME          = "__crystal_main"
-  RAISE_NAME         = "__crystal_raise"
-  MALLOC_NAME        = "__crystal_malloc64"
-  MALLOC_ATOMIC_NAME = "__crystal_malloc_atomic64"
-  REALLOC_NAME       = "__crystal_realloc64"
-  GET_EXCEPTION_NAME = "__crystal_get_exception"
+  MAIN_NAME           = "__crystal_main"
+  RAISE_NAME          = "__crystal_raise"
+  RAISE_OVERFLOW_NAME = "__crystal_raise_overflow"
+  MALLOC_NAME         = "__crystal_malloc64"
+  MALLOC_ATOMIC_NAME  = "__crystal_malloc_atomic64"
+  REALLOC_NAME        = "__crystal_realloc64"
+  GET_EXCEPTION_NAME  = "__crystal_get_exception"
 
   class Program
     def run(code, filename = nil, debug = Debug::Default)
@@ -137,6 +138,7 @@ module Crystal
     @cant_pass_closure_to_c_exception_call : Call?
     @realloc_fun : LLVM::Function?
     @c_realloc_fun : LLVM::Function?
+    @raise_overflow_fun : LLVM::Function?
     @main_llvm_context : LLVM::Context
     @main_llvm_typer : LLVMTyper
     @main_module_info : ModuleInfo
@@ -293,7 +295,7 @@ module Crystal
 
       def visit(node : FunDef)
         case node.name
-        when MALLOC_NAME, MALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME, @codegen.personality_name, GET_EXCEPTION_NAME
+        when MALLOC_NAME, MALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME, @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME
           @codegen.accept node
         end
         false
@@ -1924,6 +1926,15 @@ module Crystal
         check_main_fun REALLOC_NAME, realloc_fun
       else
         nil
+      end
+    end
+
+    def crystal_raise_overflow_fun
+      @raise_overflow_fun ||= @main_mod.functions[RAISE_OVERFLOW_NAME]?
+      if raise_overflow_fun = @raise_overflow_fun
+        check_main_fun RAISE_OVERFLOW_NAME, raise_overflow_fun
+      else
+        raise "BUG: __crystal_raise_overflow is not defined"
       end
     end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -141,6 +141,7 @@ module Crystal
     @main_llvm_typer : LLVMTyper
     @main_module_info : ModuleInfo
     @main_builder : CrystalLLVMBuilder
+    @call_location : Location?
 
     def initialize(@program : Program, @node : ASTNode, single_module = false, @debug = Debug::Default)
       @single_module = !!single_module

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -64,7 +64,7 @@ module Crystal
     end
 
     def create_debug_type(type : FloatType)
-      di_builder.create_basic_type(type.to_s, type.bytes * 8, type.bytes * 8, LLVM::DwarfTypeEncoding::Float)
+      di_builder.create_basic_type(type.to_s, 8u64 * type.bytes, 8u64 * type.bytes, LLVM::DwarfTypeEncoding::Float)
     end
 
     def create_debug_type(type : BoolType)
@@ -98,9 +98,9 @@ module Crystal
 
       ivars.each_with_index do |(name, ivar), idx|
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
-          offset = @program.target_machine.data_layout.offset_of_element(struct_type, idx + (type.struct? ? 0 : 1))
+          offset = @program.target_machine.data_layout.offset_of_element(struct_type, idx &+ (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
-          member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, offset * 8, LLVM::DIFlags::Zero, ivar_debug_type)
+          member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)
           element_types << member
         end
       end
@@ -108,7 +108,7 @@ module Crystal
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
       debug_type = di_builder.create_struct_type(nil, type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, di_builder.get_or_create_type_array(element_types))
       unless type.struct?
-        debug_type = di_builder.create_pointer_type(debug_type, llvm_typer.pointer_size * 8, llvm_typer.pointer_size * 8, type.to_s)
+        debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, type.to_s)
       end
       di_builder.replace_temporary(tmp_debug_type, debug_type)
       debug_type
@@ -117,7 +117,7 @@ module Crystal
     def create_debug_type(type : PointerInstanceType)
       element_type = get_debug_type(type.element_type)
       return unless element_type
-      di_builder.create_pointer_type(element_type, llvm_typer.pointer_size * 8, llvm_typer.pointer_size * 8, type.to_s)
+      di_builder.create_pointer_type(element_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, type.to_s)
     end
 
     def create_debug_type(type : StaticArrayInstanceType)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -14,6 +14,8 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_primitive(call, node, target_def, call_args)
+    @call_location = call.name_location if call.location
+
     @last = case node.name
             when "binary"
               codegen_primitive_binary node, target_def, call_args
@@ -79,6 +81,8 @@ class Crystal::CodeGenVisitor
             else
               raise "BUG: unhandled primitive in codegen: #{node.name}"
             end
+
+    @call_location = nil
   end
 
   def codegen_primitive_binary(node, target_def, call_args)
@@ -385,7 +389,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op(op, t1 : FloatType, t2 : IntegerType, p1, p2)
     p2 = codegen_cast(t2, t1, p2)
-    codegen_binary_op op, t1, t1, p1, p2
+    codegen_binary_op(op, t1, t1, p1, p2)
   end
 
   def codegen_binary_op(op, t1 : FloatType, t2 : FloatType, p1, p2)
@@ -413,7 +417,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_binary_op(op, t1 : TypeDefType, t2, p1, p2)
-    codegen_binary_op op, t1.remove_typedef, t2, p1, p2
+    codegen_binary_op(op, t1.remove_typedef, t2, p1, p2)
   end
 
   def codegen_binary_op(op, t1, t2, p1, p2)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -135,8 +135,9 @@ class Crystal::CodeGenVisitor
 
     case op
     when "+"               then codegen_binary_op_add(tmax, t1, t2, p1, p2)
+    when "-"               then codegen_binary_op_sub(tmax, t1, t2, p1, p2)
     when "&+"              then codegen_trunc_binary_op_result(t1, t2, builder.add(p1, p2))
-    when "-", "&-"         then codegen_trunc_binary_op_result(t1, t2, builder.sub(p1, p2))
+    when "&-"              then codegen_trunc_binary_op_result(t1, t2, builder.sub(p1, p2))
     when "*", "&*"         then codegen_trunc_binary_op_result(t1, t2, builder.mul(p1, p2))
     when "/", "unsafe_div" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.sdiv(p1, p2) : builder.udiv(p1, p2))
     when "%", "unsafe_mod" then codegen_trunc_binary_op_result(t1, t2, t1.signed? ? builder.srem(p1, p2) : builder.urem(p1, p2))
@@ -199,6 +200,38 @@ class Crystal::CodeGenVisitor
                  binary_overflow_fun "llvm.uadd.with.overflow.i64", llvm_context.int64
                when :u128
                  binary_overflow_fun "llvm.uadd.with.overflow.i128", llvm_context.int128
+               else
+                 raise "unreachable"
+               end
+
+    codegen_binary_overflow_check(llvm_fun, t, t1, t2, p1, p2)
+  end
+
+  def codegen_binary_op_sub(t : IntegerType, t1, t2, p1, p2)
+    # TODO remove on 0.28
+    return codegen_trunc_binary_op_result(t1, t2, builder.sub(p1, p2)) unless @program.has_flag?("preview_overflow")
+
+    llvm_fun = case t.kind
+               when :i8
+                 binary_overflow_fun "llvm.ssub.with.overflow.i8", llvm_context.int8
+               when :i16
+                 binary_overflow_fun "llvm.ssub.with.overflow.i16", llvm_context.int16
+               when :i32
+                 binary_overflow_fun "llvm.ssub.with.overflow.i32", llvm_context.int32
+               when :i64
+                 binary_overflow_fun "llvm.ssub.with.overflow.i64", llvm_context.int64
+               when :i128
+                 binary_overflow_fun "llvm.ssub.with.overflow.i128", llvm_context.int128
+               when :u8
+                 binary_overflow_fun "llvm.usub.with.overflow.i8", llvm_context.int8
+               when :u16
+                 binary_overflow_fun "llvm.usub.with.overflow.i16", llvm_context.int16
+               when :u32
+                 binary_overflow_fun "llvm.usub.with.overflow.i32", llvm_context.int32
+               when :u64
+                 binary_overflow_fun "llvm.usub.with.overflow.i64", llvm_context.int64
+               when :u128
+                 binary_overflow_fun "llvm.usub.with.overflow.i128", llvm_context.int128
                else
                  raise "unreachable"
                end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -274,6 +274,7 @@ class Crystal::CodeGenVisitor
     op_overflow = new_block "overflow"
     op_normal = new_block "normal"
 
+    overflow_condition = builder.call(llvm_expect_i1_fun, [overflow_condition, llvm_false])
     cond overflow_condition, op_overflow, op_normal
 
     position_at_end op_overflow
@@ -286,6 +287,12 @@ class Crystal::CodeGenVisitor
     llvm_mod.functions[fun_name]? ||
       llvm_mod.functions.add(fun_name, [llvm_operand_type, llvm_operand_type],
         llvm_context.struct([llvm_operand_type, llvm_context.int1]))
+  end
+
+  private def llvm_expect_i1_fun
+    llvm_mod.functions["llvm.expect.i1"]? ||
+      llvm_mod.functions.add("llvm.expect.i1", [llvm_context.int1, llvm_context.int1],
+        llvm_context.int1)
   end
 
   # The below methods (lt, lte, gt, gte, eq, ne) perform

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -131,7 +131,7 @@ class Crystal::CodeGenVisitor
     when "!=" then return codegen_binary_op_ne(t1, t2, p1, p2)
     end
 
-    p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+    tmax, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     case op
     when "+", "&+"         then codegen_trunc_binary_op_result(t1, t2, builder.add(p1, p2))
@@ -151,12 +151,15 @@ class Crystal::CodeGenVisitor
   def codegen_binary_extend_int(t1, t2, p1, p2)
     if t1.normal_rank == t2.normal_rank
       # Nothing to do
+      tmax = t1
     elsif t1.rank < t2.rank
       p1 = extend_int t1, t2, p1
+      tmax = t2
     else
       p2 = extend_int t2, t1, p2
+      tmax = t1
     end
-    {p1, p2}
+    {tmax, p1, p2}
   end
 
   # Ensures the result is returned in the type of the left hand side operand t1.
@@ -192,7 +195,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_lt(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SLT : LLVM::IntPredicate::ULT), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -230,7 +233,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_lte(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SLE : LLVM::IntPredicate::ULE), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -268,7 +271,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_gt(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SGT : LLVM::IntPredicate::UGT), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -306,7 +309,7 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op_gte(t1, t2, p1, p2)
     if t1.signed? == t2.signed?
-      p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+      _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
       builder.icmp (t1.signed? ? LLVM::IntPredicate::SGE : LLVM::IntPredicate::UGE), p1, p2
     else
       if t1.signed? && t2.unsigned?
@@ -343,7 +346,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_binary_op_eq(t1, t2, p1, p2)
-    p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+    _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     if t1.signed? == t2.signed?
       builder.icmp(LLVM::IntPredicate::EQ, p1, p2)
@@ -363,7 +366,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_binary_op_ne(t1, t2, p1, p2)
-    p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+    _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     if t1.signed? == t2.signed?
       builder.icmp(LLVM::IntPredicate::NE, p1, p2)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -623,10 +623,29 @@ class Crystal::CodeGenVisitor
 
   def codegen_convert(from_type : IntegerType, to_type : IntegerType, arg, *, checked : Bool)
     if from_type.normal_rank == to_type.normal_rank
+      # if the normal_rank is the same (eg: UInt64 / Int64)
+      # there is still chance for overflow
+
+      # TODO remove conditional after 0.28
+      if @program.has_flag?("preview_overflow")
+        if checked
+          overflow = codegen_out_of_range(to_type, from_type, arg)
+          codegen_raise_overflow_cond(overflow)
+        end
+      end
+
       arg
     elsif from_type.rank < to_type.rank
       extend_int from_type, to_type, arg
     else
+      # TODO remove conditional after 0.28
+      if @program.has_flag?("preview_overflow")
+        if checked
+          overflow = codegen_out_of_range(to_type, from_type, arg)
+          codegen_raise_overflow_cond(overflow)
+        end
+      end
+
       trunc arg, llvm_type(to_type)
     end
   end

--- a/src/crystal/compiler_rt.cr
+++ b/src/crystal/compiler_rt.cr
@@ -1,0 +1,38 @@
+{% skip_file unless flag?(:compiler_rt) %}
+
+fun __mulodi4(a : Int64, b : Int64, overflow : Int32*) : Int64
+  n = 64
+  min = Int64::MIN
+  max = Int64::MAX
+  overflow.value = 0
+  result = a &* b
+  if a == min
+    if b != 0 && b != 1
+      overflow.value = 1
+    end
+    return result
+  end
+  if b == min
+    if a != 0 && a != 1
+      overflow.value = 1
+    end
+    return result
+  end
+  sa = a >> (n &- 1)
+  abs_a = (a ^ sa) &- sa
+  sb = b >> (n &- 1)
+  abs_b = (b ^ sb) &- sb
+  if abs_a < 2 || abs_b < 2
+    return result
+  end
+  if sa == sb
+    if abs_a > max / abs_b
+      overflow.value = 1
+    end
+  else
+    if abs_a > min / (0i64 &- abs_b)
+      overflow.value = 1
+    end
+  end
+  return result
+end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -129,6 +129,20 @@ class DivisionByZeroError < Exception
   end
 end
 
+# Raised when the result of an arithmetic operation is outside of the range
+# that can be represented within the given operands types.
+#
+# ```
+# Int32::MAX + 1      # raises OverflowError (Overflow)
+# Int32::MIN - 1      # raises OverflowError (Overflow)
+# Float64::MAX.to_f32 # raises OverflowError (Overflow)
+# ```
+class OverflowError < Exception
+  def initialize(message = "Overflow")
+    super(message)
+  end
+end
+
 # Raised when a method is not implemented.
 #
 # This can be used either to stub out method bodies, or when the method is not

--- a/src/int.cr
+++ b/src/int.cr
@@ -262,6 +262,8 @@ struct Int
   # Raises `ArgumentError` if *exponent* is negative: if this is needed,
   # either use a float base or a float exponent.
   #
+  # Raises `OverflowError` in case of overflow.
+  #
   # ```
   # 2 ** 3  # => 8
   # 2 ** 0  # => 1
@@ -286,6 +288,8 @@ struct Int
   #
   # Raises `ArgumentError` if *exponent* is negative: if this is needed,
   # either use a float base or a float exponent.
+  #
+  # Intermediate multiplication will wrap around silently in case of overflow.
   #
   # ```
   # 2 &** 3  # => 8

--- a/src/int.cr
+++ b/src/int.cr
@@ -1,3 +1,5 @@
+require "crystal/compiler_rt"
+
 # Int is the base type of all integer types.
 #
 # There are four signed integer types: `Int8`, `Int16`, `Int32` and `Int64`,

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -196,7 +196,7 @@ lib LibLLVM
   fun is_constant = LLVMIsConstant(val : ValueRef) : Int32
   fun is_function_var_arg = LLVMIsFunctionVarArg(ty : TypeRef) : Int32
   fun module_create_with_name_in_context = LLVMModuleCreateWithNameInContext(module_id : UInt8*, context : ContextRef) : ModuleRef
-  fun offset_of_element = LLVMOffsetOfElement(td : TargetDataRef, struct_type : TypeRef, element : LibC::UInt) : Int64
+  fun offset_of_element = LLVMOffsetOfElement(td : TargetDataRef, struct_type : TypeRef, element : LibC::UInt) : UInt64
   fun pass_manager_builder_create = LLVMPassManagerBuilderCreate : PassManagerBuilderRef
   fun pass_manager_builder_set_opt_level = LLVMPassManagerBuilderSetOptLevel(builder : PassManagerBuilderRef, opt_level : UInt32)
   fun pass_manager_builder_set_size_level = LLVMPassManagerBuilderSetSizeLevel(builder : PassManagerBuilderRef, size_level : UInt32)

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -333,7 +333,9 @@ end
         {% for op, desc in binaries %}
           {% if op != "/" %}
             # Returns the result of {{desc.id}} `self` and *other*.
+            # Raises `OverflowError` in case of overflow.
             @[Primitive(:binary)]
+            @[Raises]
             def {{op.id}}(other : {{int2.id}}) : self
             end
 

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -283,13 +283,16 @@ end
         # TODO 0.28.0 replace with @[Primitive(:convert)]
 
         # Returns `self` converted to `{{type}}`.
+        # Raises `OverflowError` in case of overflow.
         @[Primitive(:cast)]
+        @[Raises]
         def {{name.id}} : {{type}}
         end
 
         # TODO 0.28.0 replace with @[Primitive(:unchecked_convert)]
 
         # Returns `self` converted to `{{type}}`.
+        # In case of overflow a wrapping is performed.
         @[Primitive(:cast)]
         def {{name.id}}! : {{type}}
         end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -237,3 +237,8 @@ end
 fun __crystal_raise_string(message : UInt8*)
   raise String.new(message)
 end
+
+# :nodoc:
+fun __crystal_raise_overflow : NoReturn
+  raise OverflowError.new
+end


### PR DESCRIPTION
This PR adds overflow checks for `+` `-` `*`, to number conversions `to_iX`, `to_uX`, `to_fX` and so to constructs like `Int32.new(value)`.

The raised exception will contain, when possible, the location of the method/operator that originate it.

~~It adds some new methods to be able to keep previous wrapping behaviour. `to_iX!`/ `Int32.new!(value)`. This methods should be used to be ready for upcoming breaking changes.~~ (Split at: #7226)

~~It prepares some new primitives to be able to have cleaner compiler code in the future. That is drop the `:cast` internal in favor of `:convert` and `:unchecked_convert` to reflect better the nature of `to_X`/`to_X!` methods.~~ (Split at: #7226)

~~There are many refactors to the stdlib~~ (Split at #7256) and ~~compiler code~~ (Split at #7262) ~~where the wrapping/unsafe behaviour was needed. Although some changes might look odd they should be reviewed as keeping the current code since operators and methods will be changing in a future version. Some changes show a need for _future_ refactor (JSON/YAML parsing for dealing with UInt64, Enum flags with UInt64 base types, conversions for big types). In future version the overflow check on Time and other can be simplified.~~

In order to avoid breaking changes and to allow a preview of this feature, the overflow behavior is only enabled if compiled with `-D preview_overflow`.

I checked locally that even a 2nd compiler generation pass the specs. I did catch some left overs with that.

```
$ make clean_crystal crystal && sleep 1 && touch src/compiler/crystal.cr && make crystal
$ make std_spec compiler_spec
```

Closes #6223
Closes #3103

#### Sample


```
# file: foo.cr
Int32::MAX + 1
puts "ok"
```

```
$ ./bin/crystal foo.cr 
ok
```

```
$ ./bin/crystal foo.cr -D preview_overflow
Unhandled exception: Overflow (OverflowError)
...
```