### PR TITLE
Spec: detect nesting `it`/`pending` and raise compilation error

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1096,7 +1096,7 @@ describe "Array" do
 
   describe "to_s" do
     it "does to_s" do
-      it { [1, 2, 3].to_s.should eq("[1, 2, 3]") }
+      [1, 2, 3].to_s.should eq("[1, 2, 3]")
     end
 
     it "does with recursive" do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -373,10 +373,10 @@ describe "Char" do
   end
 
   it "does number?" do
-    it { '1'.number?.should be_true }
-    it { '٠'.number?.should be_true }
-    it { '٢'.number?.should be_true }
-    it { 'a'.number?.should be_false }
+    '1'.number?.should be_true
+    '٠'.number?.should be_true
+    '٢'.number?.should be_true
+    'a'.number?.should be_false
   end
 
   it "does ascii_control?" do

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "colorize"
 
-private def colorize(obj, *args)
+private def colorize_wrap(obj, *args)
   obj.colorize(*args).toggle(true)
 end
 
@@ -17,116 +17,116 @@ private class ColorizeToS
   end
 end
 
-describe "colorize" do
+describe "colorize_wrap" do
   it "colorizes without change" do
-    colorize("hello").to_s.should eq("hello")
+    colorize_wrap("hello").to_s.should eq("hello")
   end
 
   it "colorizes foreground" do
-    colorize("hello").black.to_s.should eq("\e[30mhello\e[0m")
-    colorize("hello").red.to_s.should eq("\e[31mhello\e[0m")
-    colorize("hello").green.to_s.should eq("\e[32mhello\e[0m")
-    colorize("hello").yellow.to_s.should eq("\e[33mhello\e[0m")
-    colorize("hello").blue.to_s.should eq("\e[34mhello\e[0m")
-    colorize("hello").magenta.to_s.should eq("\e[35mhello\e[0m")
-    colorize("hello").cyan.to_s.should eq("\e[36mhello\e[0m")
-    colorize("hello").light_gray.to_s.should eq("\e[37mhello\e[0m")
-    colorize("hello").dark_gray.to_s.should eq("\e[90mhello\e[0m")
-    colorize("hello").light_red.to_s.should eq("\e[91mhello\e[0m")
-    colorize("hello").light_green.to_s.should eq("\e[92mhello\e[0m")
-    colorize("hello").light_yellow.to_s.should eq("\e[93mhello\e[0m")
-    colorize("hello").light_blue.to_s.should eq("\e[94mhello\e[0m")
-    colorize("hello").light_magenta.to_s.should eq("\e[95mhello\e[0m")
-    colorize("hello").light_cyan.to_s.should eq("\e[96mhello\e[0m")
-    colorize("hello").white.to_s.should eq("\e[97mhello\e[0m")
+    colorize_wrap("hello").black.to_s.should eq("\e[30mhello\e[0m")
+    colorize_wrap("hello").red.to_s.should eq("\e[31mhello\e[0m")
+    colorize_wrap("hello").green.to_s.should eq("\e[32mhello\e[0m")
+    colorize_wrap("hello").yellow.to_s.should eq("\e[33mhello\e[0m")
+    colorize_wrap("hello").blue.to_s.should eq("\e[34mhello\e[0m")
+    colorize_wrap("hello").magenta.to_s.should eq("\e[35mhello\e[0m")
+    colorize_wrap("hello").cyan.to_s.should eq("\e[36mhello\e[0m")
+    colorize_wrap("hello").light_gray.to_s.should eq("\e[37mhello\e[0m")
+    colorize_wrap("hello").dark_gray.to_s.should eq("\e[90mhello\e[0m")
+    colorize_wrap("hello").light_red.to_s.should eq("\e[91mhello\e[0m")
+    colorize_wrap("hello").light_green.to_s.should eq("\e[92mhello\e[0m")
+    colorize_wrap("hello").light_yellow.to_s.should eq("\e[93mhello\e[0m")
+    colorize_wrap("hello").light_blue.to_s.should eq("\e[94mhello\e[0m")
+    colorize_wrap("hello").light_magenta.to_s.should eq("\e[95mhello\e[0m")
+    colorize_wrap("hello").light_cyan.to_s.should eq("\e[96mhello\e[0m")
+    colorize_wrap("hello").white.to_s.should eq("\e[97mhello\e[0m")
   end
 
   it "colorizes foreground with 8-bit color" do
-    colorize("hello").fore(Colorize::Color256.new(123u8)).to_s.should eq("\e[38;5;123mhello\e[0m")
+    colorize_wrap("hello").fore(Colorize::Color256.new(123u8)).to_s.should eq("\e[38;5;123mhello\e[0m")
   end
 
   it "colorizes foreground with true color" do
-    colorize("hello").fore(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[38;2;12;34;56mhello\e[0m")
+    colorize_wrap("hello").fore(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[38;2;12;34;56mhello\e[0m")
   end
 
   it "colorizes background" do
-    colorize("hello").on_black.to_s.should eq("\e[40mhello\e[0m")
-    colorize("hello").on_red.to_s.should eq("\e[41mhello\e[0m")
-    colorize("hello").on_green.to_s.should eq("\e[42mhello\e[0m")
-    colorize("hello").on_yellow.to_s.should eq("\e[43mhello\e[0m")
-    colorize("hello").on_blue.to_s.should eq("\e[44mhello\e[0m")
-    colorize("hello").on_magenta.to_s.should eq("\e[45mhello\e[0m")
-    colorize("hello").on_cyan.to_s.should eq("\e[46mhello\e[0m")
-    colorize("hello").on_light_gray.to_s.should eq("\e[47mhello\e[0m")
-    colorize("hello").on_dark_gray.to_s.should eq("\e[100mhello\e[0m")
-    colorize("hello").on_light_red.to_s.should eq("\e[101mhello\e[0m")
-    colorize("hello").on_light_green.to_s.should eq("\e[102mhello\e[0m")
-    colorize("hello").on_light_yellow.to_s.should eq("\e[103mhello\e[0m")
-    colorize("hello").on_light_blue.to_s.should eq("\e[104mhello\e[0m")
-    colorize("hello").on_light_magenta.to_s.should eq("\e[105mhello\e[0m")
-    colorize("hello").on_light_cyan.to_s.should eq("\e[106mhello\e[0m")
-    colorize("hello").on_white.to_s.should eq("\e[107mhello\e[0m")
+    colorize_wrap("hello").on_black.to_s.should eq("\e[40mhello\e[0m")
+    colorize_wrap("hello").on_red.to_s.should eq("\e[41mhello\e[0m")
+    colorize_wrap("hello").on_green.to_s.should eq("\e[42mhello\e[0m")
+    colorize_wrap("hello").on_yellow.to_s.should eq("\e[43mhello\e[0m")
+    colorize_wrap("hello").on_blue.to_s.should eq("\e[44mhello\e[0m")
+    colorize_wrap("hello").on_magenta.to_s.should eq("\e[45mhello\e[0m")
+    colorize_wrap("hello").on_cyan.to_s.should eq("\e[46mhello\e[0m")
+    colorize_wrap("hello").on_light_gray.to_s.should eq("\e[47mhello\e[0m")
+    colorize_wrap("hello").on_dark_gray.to_s.should eq("\e[100mhello\e[0m")
+    colorize_wrap("hello").on_light_red.to_s.should eq("\e[101mhello\e[0m")
+    colorize_wrap("hello").on_light_green.to_s.should eq("\e[102mhello\e[0m")
+    colorize_wrap("hello").on_light_yellow.to_s.should eq("\e[103mhello\e[0m")
+    colorize_wrap("hello").on_light_blue.to_s.should eq("\e[104mhello\e[0m")
+    colorize_wrap("hello").on_light_magenta.to_s.should eq("\e[105mhello\e[0m")
+    colorize_wrap("hello").on_light_cyan.to_s.should eq("\e[106mhello\e[0m")
+    colorize_wrap("hello").on_white.to_s.should eq("\e[107mhello\e[0m")
   end
 
   it "colorizes background with 8-bit color" do
-    colorize("hello").back(Colorize::Color256.new(123u8)).to_s.should eq("\e[48;5;123mhello\e[0m")
+    colorize_wrap("hello").back(Colorize::Color256.new(123u8)).to_s.should eq("\e[48;5;123mhello\e[0m")
   end
 
   it "colorizes background with true color" do
-    colorize("hello").back(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[48;2;12;34;56mhello\e[0m")
+    colorize_wrap("hello").back(Colorize::ColorRGB.new(12u8, 34u8, 56u8)).to_s.should eq("\e[48;2;12;34;56mhello\e[0m")
   end
 
   it "colorizes mode" do
-    colorize("hello").bold.to_s.should eq("\e[1mhello\e[0m")
-    colorize("hello").bright.to_s.should eq("\e[1mhello\e[0m")
-    colorize("hello").dim.to_s.should eq("\e[2mhello\e[0m")
-    colorize("hello").underline.to_s.should eq("\e[4mhello\e[0m")
-    colorize("hello").blink.to_s.should eq("\e[5mhello\e[0m")
-    colorize("hello").reverse.to_s.should eq("\e[7mhello\e[0m")
-    colorize("hello").hidden.to_s.should eq("\e[8mhello\e[0m")
+    colorize_wrap("hello").bold.to_s.should eq("\e[1mhello\e[0m")
+    colorize_wrap("hello").bright.to_s.should eq("\e[1mhello\e[0m")
+    colorize_wrap("hello").dim.to_s.should eq("\e[2mhello\e[0m")
+    colorize_wrap("hello").underline.to_s.should eq("\e[4mhello\e[0m")
+    colorize_wrap("hello").blink.to_s.should eq("\e[5mhello\e[0m")
+    colorize_wrap("hello").reverse.to_s.should eq("\e[7mhello\e[0m")
+    colorize_wrap("hello").hidden.to_s.should eq("\e[8mhello\e[0m")
   end
 
   it "colorizes mode combination" do
-    colorize("hello").bold.dim.underline.blink.reverse.hidden.to_s.should eq("\e[1;2;4;5;7;8mhello\e[0m")
+    colorize_wrap("hello").bold.dim.underline.blink.reverse.hidden.to_s.should eq("\e[1;2;4;5;7;8mhello\e[0m")
   end
 
   it "colorizes foreground with background" do
-    colorize("hello").blue.on_green.to_s.should eq("\e[34;42mhello\e[0m")
+    colorize_wrap("hello").blue.on_green.to_s.should eq("\e[34;42mhello\e[0m")
   end
 
   it "colorizes foreground with background with mode" do
-    colorize("hello").blue.on_green.bold.to_s.should eq("\e[34;42;1mhello\e[0m")
+    colorize_wrap("hello").blue.on_green.bold.to_s.should eq("\e[34;42;1mhello\e[0m")
   end
 
   it "colorizes foreground with symbol" do
-    colorize("hello", :red).to_s.should eq("\e[31mhello\e[0m")
-    colorize("hello").fore(:red).to_s.should eq("\e[31mhello\e[0m")
+    colorize_wrap("hello", :red).to_s.should eq("\e[31mhello\e[0m")
+    colorize_wrap("hello").fore(:red).to_s.should eq("\e[31mhello\e[0m")
   end
 
   it "colorizes mode with symbol" do
-    colorize("hello").mode(:bold).to_s.should eq("\e[1mhello\e[0m")
+    colorize_wrap("hello").mode(:bold).to_s.should eq("\e[1mhello\e[0m")
   end
 
   it "raises on unknown foreground color" do
     expect_raises ArgumentError, "Unknown color: brown" do
-      colorize("hello", :brown)
+      colorize_wrap("hello", :brown)
     end
   end
 
   it "raises on unknown background color" do
     expect_raises ArgumentError, "Unknown color: brown" do
-      colorize("hello").back(:brown)
+      colorize_wrap("hello").back(:brown)
     end
   end
 
   it "raises on unknown mode" do
     expect_raises ArgumentError, "Unknown mode: bad" do
-      colorize("hello").mode(:bad)
+      colorize_wrap("hello").mode(:bad)
     end
   end
 
   it "inspects" do
-    colorize("hello", :red).inspect.should eq("\e[31m\"hello\"\e[0m")
+    colorize_wrap("hello", :red).inspect.should eq("\e[31m\"hello\"\e[0m")
   end
 
   it "colorizes with surround" do
@@ -182,11 +182,11 @@ describe "colorize" do
   end
 
   it "toggles off" do
-    colorize("hello").black.toggle(false).to_s.should eq("hello")
-    colorize("hello").toggle(false).black.to_s.should eq("hello")
+    colorize_wrap("hello").black.toggle(false).to_s.should eq("hello")
+    colorize_wrap("hello").toggle(false).black.to_s.should eq("hello")
   end
 
   it "toggles off and on" do
-    colorize("hello").toggle(false).black.toggle(true).to_s.should eq("\e[30mhello\e[0m")
+    colorize_wrap("hello").toggle(false).black.toggle(true).to_s.should eq("\e[30mhello\e[0m")
   end
 end

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -17,7 +17,7 @@ private class ColorizeToS
   end
 end
 
-describe "colorize_wrap" do
+describe "colorize" do
   it "colorizes without change" do
     colorize_wrap("hello").to_s.should eq("hello")
   end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -545,7 +545,7 @@ describe "Deque" do
 
   describe "to_s" do
     it "does to_s" do
-      it { Deque{1, 2, 3}.to_s.should eq("Deque{1, 2, 3}") }
+      Deque{1, 2, 3}.to_s.should eq("Deque{1, 2, 3}")
     end
 
     it "does with recursive" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -14,7 +14,7 @@ describe "Float" do
 
   describe "%" do
     it "uses modulo behavior, not remainder behavior" do
-      it { ((-11.5) % 4.0).should eq(0.5) }
+      ((-11.5) % 4.0).should eq(0.5)
     end
   end
 

--- a/spec/std/raise_spec.cr
+++ b/spec/std/raise_spec.cr
@@ -1,8 +1,6 @@
 require "spec"
 
 describe "raise" do
-  callstack_on_rescue = nil
-
   it "should set exception's callstack" do
     exception = expect_raises Exception, "without callstack" do
       raise "without callstack"
@@ -11,6 +9,7 @@ describe "raise" do
   end
 
   it "shouldn't overwrite the callstack on re-raise" do
+    callstack_on_rescue : CallStack? = nil
     exception_after_reraise = expect_raises Exception, "exception to be rescued" do
       begin
         raise "exception to be rescued"


### PR DESCRIPTION
Fixed #7192

Fixed specs following changes also.

```crystal
require "spec"

it "foo" do
  pending
end
```

```console
$ crystal run foo.cr
Error in foo.cr:3: instantiating 'it(String)'

it "foo" do
^~

in foo.cr:3: cannot nest 'pending' of spec

it "foo" do
^~

```

NOTE: Reported location looks wrong due to #7147.