### PR TITLE
Fix example in Hash#from

### DIFF
--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -66,7 +66,12 @@ struct NamedTuple
   #   "I see #{n} #{thing}s"
   # end
   #
-  # data = JSON.parse(%({"thing": "world", "n": 2})).as_h
+  # hash = JSON.parse(%({"thing": "world", "n": 2})).as_h
+  #
+  # # Cast types appropriately:
+  # data = {} of String => JSON::Any::Type
+  # hash.each { |key, value| data[key] = value.raw }
+  #
   # speak_about(**{thing: String, n: Int64}.from(data)) # => "I see 2 worlds"
   # ```
   def from(hash : Hash)


### PR DESCRIPTION
This is the current code:
```cr
require "json"

def speak_about(thing : String, n : Int64)
  "I see #{n} #{thing}s"
end

data = JSON.parse(%({"thing": "world", "n": 2})).as_h
speak_about(**{thing: String, n: Int64}.from(data)) # => "I see 2 worlds"
```
which results in:
```
Error in line 8: instantiating 'NamedTuple(thing: String.class, n: Int64.class)#from(Hash(String, JSON::Any))'

in /usr/lib/crystal/named_tuple.cr:77: expanding macro

    {% begin %}
    ^

in macro 'macro_94851401795888' /usr/lib/crystal/named_tuple.cr:77, line 4:

   1. 
   2.       NamedTuple.new(
   3.       
>  4.         "thing": self[:thing].cast(hash.fetch(:thing) { hash["thing"] }),
   5.       
   6.         "n": self[:n].cast(hash.fetch(:n) { hash["n"] }),
   7.       
   8.       )
   9.     

instantiating 'String.class#cast(JSON::Any)'
in /usr/lib/crystal/class.cr:124: can't cast JSON::Any to String

    other.as(self)
    ^
```
Because every value of `data` is `JSON::Any`.

Now it's:
```cr
require "json"

def speak_about(thing : String, n : Int64)
  "I see #{n} #{thing}s"
end

hash = JSON.parse(%({"thing": "world", "n": 2})).as_h

# Cast types appropriately:
data = {} of String => JSON::Any::Type
hash.each { |key, value| data[key] = value.raw }

speak_about(**{thing: String, n: Int64}.from(data)) # => "I see 2 worlds"
```
which appropriately casts every value to the real, raw type.