### PR TITLE
Expose HTTP response headers in HTTP::WebSocket::Protocol

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -1,5 +1,6 @@
 class HTTP::WebSocket
   getter? closed = false
+  delegate :response_headers, to: @ws
 
   # :nodoc:
   def initialize(io : IO)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -33,7 +33,9 @@ class HTTP::WebSocket::Protocol
     size : Int32,
     final : Bool
 
-  def initialize(@io : IO, masked = false)
+  getter :response_headers
+
+  def initialize(@io : IO, masked = false, @response_headers : HTTP::Headers = HTTP::Headers.new)
     @header = uninitialized UInt8[2]
     @mask = uninitialized UInt8[4]
     @mask_offset = 0
@@ -285,7 +287,7 @@ class HTTP::WebSocket::Protocol
       raise exc
     end
 
-    new(socket, masked: true)
+    new(socket, masked: true, response_headers: handshake_response.headers)
   end
 
   def self.new(uri : URI | String, headers = HTTP::Headers.new)


### PR DESCRIPTION
Sometimes you might be curious about the HTTP response headers after a successful websocket upgrade. I haven't found any tests for the Protocol class, so I did not create any tests. However, if you really need tests for this, please let me know if I have to create a file or add something into the spec file for `HTTP::Websocket`.