### PR TITLE
Fix Time::Span initializer from big seconds and sleep with big seconds 

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -27,6 +27,11 @@ describe Time::Span do
     t1.to_s.should eq("1.01:00:00")
   end
 
+  it "initializes with big seconds value" do
+    t = Time::Span.new 0, 0, 1231231231231
+    t.total_seconds.should eq(1231231231231)
+  end
+
   it "days overflows" do
     expect_overflow do
       days = 106751991167301

--- a/src/crystal/event.cr
+++ b/src/crystal/event.cr
@@ -23,7 +23,7 @@ struct Crystal::Event
 
   def add(timeout : Time::Span)
     add LibC::Timeval.new(
-      tv_sec: timeout.total_seconds.to_i,
+      tv_sec: LibC::TimeT.new(timeout.total_seconds),
       tv_usec: timeout.nanoseconds / 1_000
     )
   end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -98,9 +98,9 @@ struct Time::Span
   private def self.compute_seconds(days, hours, minutes, seconds, raise_exception)
     # there's no overflow checks for hours, minutes, ...
     # so big hours/minutes values can overflow at some point and change expected values
-    hrssec = hours * 3600 # break point at (Int32::MAX - 596523)
-    minsec = minutes * 60
-    s = (hrssec + minsec + seconds).to_i64
+    hrssec = 3600_i64 * hours # break point at (Int32::MAX - 596523)
+    minsec = 60_i64 * minutes
+    s = hrssec + minsec + seconds
 
     result = 0_i64
 


### PR DESCRIPTION
Fixes #7220

The two commits are self-descriptive. In the first case it was silently overflowing because the `to_i64` was applied too late. In the second case an incorrect `to_i` call was used when casting to `TimeT` should have been used.

I think in both cases this would have been caught by an overflow error in the overflow branch (but I didn't try it).

(I don't think there's a way to test `sleep`, so no tests for that)