### PR TITLE
Capitalise Crystal in CLI output

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -21,7 +21,7 @@ class Crystal::Command
         docs                     generate documentation
         env                      print Crystal environment information
         eval                     eval code from args or standard input
-        play                     starts crystal playground server
+        play                     starts Crystal playground server
         run (default)            build and run program
         spec                     build and run specs (in spec directory)
         tool                     run a tool


### PR DESCRIPTION
The default output to the Crystal command has the name capitalised in one place (for `env`) but not for `play`. This capitalises the latter to make them consistent. I think it's nicer to capitalise the language name rather than lowercasing it everywhere.