### PR TITLE
Disallow non-invariant types in `Pointer#value=`

### DIFF
--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -163,4 +163,15 @@ describe "Semantic: pointer" do
       pointerof(LibFoo.extern)
       )) { pointer_of(int32) }
   end
+
+  it "doesn't allow non-invariant type in value= (#6997)" do
+    assert_error %(
+      class Gen(T)
+      end
+
+      ptr = Pointer(Gen(Char | Int32)).malloc(1_u64)
+      ptr.value = Gen(Char).new
+      ),
+      "can't insert Gen(Char) into Pointer(Gen(Char | Int32))"
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2426,7 +2426,11 @@ module Crystal
 
       value = @vars["value"]
 
-      scope.var.bind_to value
+      # Check for a strict match (filter_by does that)
+      unless scope.var.type.filter_by(value.type)
+        node.raise "can't insert #{value.type} into Pointer(#{scope.var.type})"
+      end
+
       node.bind_to value
     end
 

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -48,7 +48,7 @@ module Debug
           if abbrev = abbreviations[code - 1]? # abbreviations.find { |a| a.code == abbrev }
             abbrev.attributes.each do |attr|
               value = read_attribute_value(attr.form)
-              attributes << {attr.at, attr.form, value}
+              attributes << {attr.at, attr.form, value.as(Value)}
             end
             yield code, abbrev, attributes
           else


### PR DESCRIPTION
Fixes #6997

The code in #6997 shouldn't compile at all, as I explained in the issue.

This PR changes `Pointer#value=` to disallow non-invariant types. If you have a `Pointer(Array(String | Int32))` then you must insert an `Array(String | Int32)` into it. You can't insert `Array(String)` or `Array(Int32)`.

As a second step to this I would like to change all restrictions to always check invariance for generic types. Right now we can do `x : Range(Int, Int)` as a type restriction to say "any type that inherits `Int`" but that gives the problem of #6997. We can change the semantic to mean "must be an `Int`" (in this case it doesn't make sense) and eventually introduce some syntax to mean "must be an `Int` or inherit it".