### PR TITLE
Add unsafe number ops

### DIFF
--- a/spec/compiler/codegen/convert_spec.cr
+++ b/spec/compiler/codegen/convert_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+
+describe "Code gen: convert primitives" do
+  describe "to_*!" do
+    it "works from negative values to unsigned types" do
+      run(%(
+        -1.to_u! == 4294967295_u32
+      )).to_b.should be_true
+    end
+
+    it "works from greater values to smaller types" do
+      run(%(
+        47866.to_i8! == -6_i8
+      )).to_b.should be_true
+    end
+
+    it "preserves negative sign" do
+      run(%(
+        -1_i8.to_i! == -1_i32
+      )).to_b.should be_true
+    end
+  end
+end

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -323,6 +323,21 @@ describe BigDecimal do
     bd2.to_f.should eq -0.00123
     bd3.to_f.should eq 123.0
     bd4.to_f.should eq -123.0
+
+    bd1.to_i!.should eq 0
+    bd2.to_i!.should eq 0
+    bd3.to_i!.should eq 123
+    bd4.to_i!.should eq -123
+
+    bd1.to_u!.should eq 0
+    bd2.to_u!.should eq 0
+    bd3.to_u!.should eq 123
+    bd4.to_u!.should eq 123
+
+    bd1.to_f!.should eq 0.00123
+    bd2.to_f!.should eq -0.00123
+    bd3.to_f!.should eq 123.0
+    bd4.to_f!.should eq -123.0
   end
 
   it "hashes" do

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -147,16 +147,34 @@ describe "BigFloat" do
     it { 1.234567.to_big_f.to_f32.should eq(1.234567_f32) }
   end
 
+  describe "to_f!" do
+    it { 1.34.to_big_f.to_f!.should eq(1.34) }
+    it { 0.0001304.to_big_f.to_f!.should eq(0.0001304) }
+    it { 1.234567.to_big_f.to_f32!.should eq(1.234567_f32) }
+  end
+
   describe "to_i" do
     it { 1.34.to_big_f.to_i.should eq(1) }
     it { 123.to_big_f.to_i.should eq(123) }
     it { -4321.to_big_f.to_i.should eq(-4321) }
   end
 
+  describe "to_i!" do
+    it { 1.34.to_big_f.to_i!.should eq(1) }
+    it { 123.to_big_f.to_i!.should eq(123) }
+    it { -4321.to_big_f.to_i!.should eq(-4321) }
+  end
+
   describe "to_u" do
     it { 1.34.to_big_f.to_u.should eq(1) }
     it { 123.to_big_f.to_u.should eq(123) }
     it { 4321.to_big_f.to_u.should eq(4321) }
+  end
+
+  describe "to_u!" do
+    it { 1.34.to_big_f.to_u!.should eq(1) }
+    it { 123.to_big_f.to_u!.should eq(123) }
+    it { 4321.to_big_f.to_u!.should eq(4321) }
   end
 
   describe "to_s" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -296,13 +296,13 @@ describe "BigInt" do
   it "can be casted into other Number types" do
     big = BigInt.new(1234567890)
     big.to_i.should eq(1234567890)
-    big.to_i8.should eq(-46)
-    big.to_i16.should eq(722)
+    big.to_i8!.should eq(-46)
+    big.to_i16!.should eq(722)
     big.to_i32.should eq(1234567890)
     big.to_i64.should eq(1234567890)
     big.to_u.should eq(1234567890)
-    big.to_u8.should eq(210)
-    big.to_u16.should eq(722)
+    big.to_u8!.should eq(210)
+    big.to_u16!.should eq(722)
     big.to_u32.should eq(1234567890)
 
     u64 = big.to_u64

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -60,16 +60,34 @@ describe BigRational do
     r.to_f64.should be_close(f, 0.001)
   end
 
+  it "#to_f64!" do
+    r = br(10, 3)
+    f = 10.to_f64 / 3.to_f64
+    r.to_f64!.should be_close(f, 0.001)
+  end
+
   it "#to_f" do
     r = br(10, 3)
     f = 10.to_f64 / 3.to_f64
     r.to_f.should be_close(f, 0.001)
   end
 
+  it "#to_f!" do
+    r = br(10, 3)
+    f = 10.to_f64 / 3.to_f64
+    r.to_f!.should be_close(f, 0.001)
+  end
+
   it "#to_f32" do
     r = br(10, 3)
     f = 10.to_f32 / 3.to_f32
     r.to_f32.should be_close(f, 0.001)
+  end
+
+  it "#to_f32!" do
+    r = br(10, 3)
+    f = 10.to_f32 / 3.to_f32
+    r.to_f32!.should be_close(f, 0.001)
   end
 
   it "#to_big_f" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -46,6 +46,42 @@ describe "Int" do
     end
   end
 
+  describe "&**" do
+    it "with positive Int32" do
+      x = 2 &** 2
+      x.should eq(4)
+      x.should be_a(Int32)
+
+      x = 2 &** 0
+      x.should eq(1)
+      x.should be_a(Int32)
+    end
+
+    it "with UInt8" do
+      x = 2_u8 &** 2
+      x.should eq(4)
+      x.should be_a(UInt8)
+    end
+
+    it "raises with negative exponent" do
+      expect_raises(ArgumentError, "Cannot raise an integer to a negative integer power, use floats for that") do
+        2 &** -1
+      end
+    end
+
+    it "works with large integers" do
+      x = 51_i64 &** 11
+      x.should eq(6071163615208263051_i64)
+      x.should be_a(Int64)
+    end
+
+    it "wraps with larger integers" do
+      x = 51_i64 &** 12
+      x.should eq(-3965304877440961871_i64)
+      x.should be_a(Int64)
+    end
+  end
+
   describe "#===(:Char)" do
     it { (99 === 'c').should be_true }
     it { (99_u8 === 'c').should be_true }

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -1,6 +1,48 @@
 require "spec"
 
+private macro it_initializes_from_value_to(number_type)
+  it "initialize from value to {{number_type}}" do
+    {{number_type}}.new(1).should be_a({{number_type}})
+    {{number_type}}.new(1).should eq(1)
+
+    {{number_type}}.new(1u32).should be_a({{number_type}})
+    {{number_type}}.new(1u32).should eq(1)
+
+    {{number_type}}.new(1.0).should be_a({{number_type}})
+    {{number_type}}.new(1.0).should eq(1)
+  end
+
+  it "unchecked initialize from value to {{number_type}}" do
+    {{number_type}}.new!(1).should be_a({{number_type}})
+    {{number_type}}.new!(1).should eq(1)
+
+    {{number_type}}.new!(1u32).should be_a({{number_type}})
+    {{number_type}}.new!(1u32).should eq(1)
+
+    {{number_type}}.new!(1.0).should be_a({{number_type}})
+    {{number_type}}.new!(1.0).should eq(1)
+  end
+end
+
 describe "Number" do
+  it_initializes_from_value_to Int8
+  it_initializes_from_value_to Int16
+  it_initializes_from_value_to Int32
+  it_initializes_from_value_to Int64
+
+  it_initializes_from_value_to UInt8
+  it_initializes_from_value_to UInt16
+  it_initializes_from_value_to UInt32
+  it_initializes_from_value_to UInt64
+
+  {% if flag?(:bits64) %}
+    it_initializes_from_value_to Int128
+    it_initializes_from_value_to UInt128
+  {% end %}
+
+  it_initializes_from_value_to Float32
+  it_initializes_from_value_to Float64
+
   describe "significant" do
     it "10 base" do
       1234.567.significant(1).should eq(1000)

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -307,28 +307,33 @@ struct BigDecimal < Number
     self
   end
 
+  # Converts to `BigInt`. Truncates anything on the right side of the decimal point.
+  def to_big_i
+    if @value >= 0
+      (@value / TEN ** @scale)
+    else
+      -(@value.abs / TEN ** @scale)
+    end
+  end
+
   # Converts to `Int64`. Truncates anything on the right side of the decimal point.
   def to_i64
-    if @value >= 0
-      (@value / TEN ** @scale).to_i64
-    else
-      -(@value.abs / TEN ** @scale).to_i64
-    end
+    to_big_i.to_i64
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
   def to_i32
-    to_i64.to_i32
+    to_big_i.to_i32
   end
 
   # Converts to `Int16`. Truncates anything on the right side of the decimal point.
   def to_i16
-    to_i64.to_i16
+    to_big_i.to_i16
   end
 
   # Converts to `Int8`. Truncates anything on the right side of the decimal point.
   def to_i8
-    to_i64.to_i8
+    to_big_i.to_i8
   end
 
   # Converts to `Int32`. Truncates anything on the right side of the decimal point.
@@ -336,34 +341,93 @@ struct BigDecimal < Number
     to_i32
   end
 
+  # Converts to `Int8`. Truncates anything on the right side of the decimal point.
+  def to_i8!
+    to_big_i.to_i8!
+  end
+
+  # Converts to `Int16`. Truncates anything on the right side of the decimal point.
+  def to_i16!
+    to_big_i.to_i16!
+  end
+
+  # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  def to_i32!
+    to_big_i.to_i32!
+  end
+
+  # Converts to `Int64`. Truncates anything on the right side of the decimal point.
+  def to_i64!
+    to_big_i.to_i64!
+  end
+
+  # Converts to `Int32`. Truncates anything on the right side of the decimal point.
+  def to_i!
+    to_i32!
+  end
+
+  private def to_big_u
+    (@value.abs / TEN ** @scale)
+  end
+
   # Converts to `UInt64`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
   def to_u64
-    (@value.abs / TEN ** @scale).to_u64
+    to_big_u.to_u64
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
   def to_u32
-    to_u64.to_u32
+    to_big_u.to_u32
   end
 
   # Converts to `UInt16`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
   def to_u16
-    to_u64.to_u16
+    to_big_u.to_u16
   end
 
   # Converts to `UInt8`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
   def to_u8
-    to_u64.to_u8
+    to_big_u.to_u8
   end
 
   # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
   # converting negative to positive.
   def to_u
     to_u32
+  end
+
+  # Converts to `UInt8`. Truncates anything on the right side of the decimal point,
+  # converting negative to positive.
+  def to_u8!
+    to_big_u.to_u8!
+  end
+
+  # Converts to `UInt16`. Truncates anything on the right side of the decimal point,
+  # converting negative to positive.
+  def to_u16!
+    to_big_u.to_u16!
+  end
+
+  # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
+  # converting negative to positive.
+  def to_u32!
+    to_big_u.to_u32!
+  end
+
+  # Converts to `UInt64`. Truncates anything on the right side of the decimal point,
+  # converting negative to positive.
+  def to_u64!
+    to_big_u.to_u64!
+  end
+
+  # Converts to `UInt32`. Truncates anything on the right side of the decimal point,
+  # converting negative to positive.
+  def to_u!
+    to_u32!
   end
 
   # Converts to `Float64`.
@@ -379,6 +443,21 @@ struct BigDecimal < Number
   # Converts to `Float64`.
   def to_f
     to_f64
+  end
+
+  # Converts to `Float32`.
+  def to_f32!
+    to_f64.to_f32!
+  end
+
+  # Converts to `Float64`.
+  def to_f64!
+    to_f64
+  end
+
+  # Converts to `Float64`.
+  def to_f!
+    to_f64!
   end
 
   # Converts to `BigFloat`.

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -172,6 +172,18 @@ struct BigFloat < Float
     to_f64
   end
 
+  def to_f32!
+    to_f64.to_f32!
+  end
+
+  def to_f64!
+    to_f64
+  end
+
+  def to_f!
+    to_f64!
+  end
+
   def to_big_f
     self
   end
@@ -196,6 +208,26 @@ struct BigFloat < Float
     to_i32
   end
 
+  def to_i!
+    to_i32!
+  end
+
+  def to_i8!
+    LibGMP.mpf_get_si(self).to_i8!
+  end
+
+  def to_i16!
+    LibGMP.mpf_get_si(self).to_i16!
+  end
+
+  def to_i32!
+    LibGMP.mpf_get_si(self).to_i32!
+  end
+
+  def to_i64!
+    LibGMP.mpf_get_si(self)
+  end
+
   def to_u64
     LibGMP.mpf_get_ui(self)
   end
@@ -214,6 +246,26 @@ struct BigFloat < Float
 
   def to_u
     to_u32
+  end
+
+  def to_u!
+    to_u32!
+  end
+
+  def to_u8!
+    LibGMP.mpf_get_ui(self).to_u8!
+  end
+
+  def to_u16!
+    LibGMP.mpf_get_ui(self).to_u16!
+  end
+
+  def to_u32!
+    LibGMP.mpf_get_ui(self).to_u32!
+  end
+
+  def to_u64!
+    LibGMP.mpf_get_ui(self)
   end
 
   def to_unsafe

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -414,6 +414,30 @@ struct BigInt < Int
     end
   end
 
+  def to_i!
+    to_i32!
+  end
+
+  def to_i8!
+    LibGMP.get_si(self).to_i8!
+  end
+
+  def to_i16!
+    LibGMP.get_si(self).to_i16!
+  end
+
+  def to_i32!
+    LibGMP.get_si(self).to_i32!
+  end
+
+  def to_i64!
+    if LibGMP::Long == Int64 || (self <= Int32::MAX && self >= Int32::MIN)
+      LibGMP.get_si(self).to_i64!
+    else
+      to_s.to_i64
+    end
+  end
+
   def to_u
     to_u32
   end
@@ -438,6 +462,30 @@ struct BigInt < Int
     end
   end
 
+  def to_u!
+    to_u32!
+  end
+
+  def to_u8!
+    LibGMP.get_ui(self).to_u8!
+  end
+
+  def to_u16!
+    LibGMP.get_ui(self).to_u16!
+  end
+
+  def to_u32!
+    LibGMP.get_ui(self).to_u32!
+  end
+
+  def to_u64!
+    if LibGMP::Long == Int64 || (self <= Int32::MAX && self >= Int32::MIN)
+      LibGMP.get_ui(self).to_u64!
+    else
+      to_s.to_u64
+    end
+  end
+
   def to_f
     to_f64
   end
@@ -447,6 +495,18 @@ struct BigInt < Int
   end
 
   def to_f64
+    LibGMP.get_d(self)
+  end
+
+  def to_f!
+    to_f64!
+  end
+
+  def to_f32!
+    LibGMP.get_d(self).to_f32!
+  end
+
+  def to_f64!
     LibGMP.get_d(self)
   end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -407,7 +407,7 @@ struct BigInt < Int
   end
 
   def to_i64
-    if LibGMP::Long == Int64 || (self <= Int32::MAX && self >= Int32::MIN)
+    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
       LibGMP.get_si(self).to_i64
     else
       to_s.to_i64
@@ -431,7 +431,7 @@ struct BigInt < Int
   end
 
   def to_i64!
-    if LibGMP::Long == Int64 || (self <= Int32::MAX && self >= Int32::MIN)
+    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
       LibGMP.get_si(self).to_i64!
     else
       to_s.to_i64
@@ -455,7 +455,7 @@ struct BigInt < Int
   end
 
   def to_u64
-    if LibGMP::ULong == UInt64 || (self <= UInt32::MAX && self >= UInt32::MIN)
+    if LibGMP::ULong == UInt64 || (UInt32::MIN <= self <= UInt32::MAX)
       LibGMP.get_ui(self).to_u64
     else
       to_s.to_u64
@@ -479,7 +479,7 @@ struct BigInt < Int
   end
 
   def to_u64!
-    if LibGMP::Long == Int64 || (self <= Int32::MAX && self >= Int32::MIN)
+    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
       LibGMP.get_ui(self).to_u64!
     else
       to_s.to_u64

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -177,6 +177,18 @@ struct BigRational < Number
     LibGMP.mpq_get_d(mpq)
   end
 
+  def to_f32!
+    to_f64.to_f32!
+  end
+
+  def to_f64!
+    to_f64
+  end
+
+  def to_f!
+    to_f64!
+  end
+
   def to_big_f
     BigFloat.new { |mpf| LibGMP.mpf_set_q(mpf, mpq) }
   end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -18,6 +18,9 @@ class Crystal::CodeGenVisitor
             when "binary"
               codegen_primitive_binary node, target_def, call_args
             when "cast"
+              # TODO 0.28.0 delete :cast
+              codegen_primitive_cast node, target_def, call_args
+            when "convert"
               codegen_primitive_cast node, target_def, call_args
             when "allocate"
               codegen_primitive_allocate node, target_def, call_args

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -22,6 +22,8 @@ class Crystal::CodeGenVisitor
               codegen_primitive_cast node, target_def, call_args
             when "convert"
               codegen_primitive_cast node, target_def, call_args
+            when "unchecked_convert"
+              codegen_primitive_cast node, target_def, call_args
             when "allocate"
               codegen_primitive_allocate node, target_def, call_args
             when "pointer_malloc"

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -164,6 +164,11 @@ struct Enum
     def to_{{name.id}} : {{type}}
       value.to_{{name.id}}
     end
+
+    # Returns the value of this enum member as a `{{type}}`
+    def to_{{name.id}}! : {{type}}
+      value.to_{{name.id}}!
+    end
   {% end %}
 
   # Returns the enum member that results from adding *other*

--- a/src/float.cr
+++ b/src/float.cr
@@ -139,6 +139,11 @@ struct Float32
     value.to_f32
   end
 
+  # Returns a `Float32` by invoking `to_f32!` on *value*.
+  def self.new!(value)
+    value.to_f32!
+  end
+
   def ceil
     LibM.ceil_f32(self)
   end
@@ -221,6 +226,11 @@ struct Float64
   # Returns a `Float64` by invoking `to_f64` on *value*.
   def Float64.new(value)
     value.to_f64
+  end
+
+  # Returns a `Float64` by invoking `to_f64!` on *value*.
+  def Float64.new!(value)
+    value.to_f64!
   end
 
   def ceil

--- a/src/int.cr
+++ b/src/int.cr
@@ -274,8 +274,33 @@ struct Int
     k = self
     while exponent > 0
       result *= k if exponent & 0b1 != 0
-      k *= k
       exponent = exponent.unsafe_shr(1)
+      k *= k if exponent > 0
+    end
+    result
+  end
+
+  # Returns the value of raising `self` to the power of *exponent*.
+  #
+  # Raises `ArgumentError` if *exponent* is negative: if this is needed,
+  # either use a float base or a float exponent.
+  #
+  # ```
+  # 2 &** 3  # => 8
+  # 2 &** 0  # => 1
+  # 2 &** -1 # ArgumentError
+  # ```
+  def &**(exponent : Int) : self
+    if exponent < 0
+      raise ArgumentError.new "Cannot raise an integer to a negative integer power, use floats for that"
+    end
+
+    result = self.class.new(1)
+    k = self
+    while exponent > 0
+      result &*= k if exponent & 0b1 != 0
+      exponent = exponent.unsafe_shr(1)
+      k &*= k if exponent > 0
     end
     result
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -615,6 +615,11 @@ struct Int8
     value.to_i8
   end
 
+  # Returns an `Int8` by invoking `to_i8!` on *value*.
+  def self.new!(value)
+    value.to_i8!
+  end
+
   def -
     0_i8 - self
   end
@@ -635,6 +640,11 @@ struct Int16
   # Returns an `Int16` by invoking `to_i16` on *value*.
   def self.new(value)
     value.to_i16
+  end
+
+  # Returns an `Int16` by invoking `to_i16!` on *value*.
+  def self.new!(value)
+    value.to_i16!
   end
 
   def -
@@ -659,6 +669,11 @@ struct Int32
     value.to_i32
   end
 
+  # Returns an `Int32` by invoking `to_i32!` on *value*.
+  def self.new!(value)
+    value.to_i32!
+  end
+
   def -
     0 - self
   end
@@ -679,6 +694,11 @@ struct Int64
   # Returns an `Int64` by invoking `to_i64` on *value*.
   def self.new(value)
     value.to_i64
+  end
+
+  # Returns an `Int64` by invoking `to_i64!` on *value*.
+  def self.new!(value)
+    value.to_i64!
   end
 
   def -
@@ -704,6 +724,11 @@ struct Int128
     value.to_i128
   end
 
+  # Returns an `Int128` by invoking `to_i128!` on *value*.
+  def self.new!(value)
+    value.to_i128!
+  end
+
   def -
     # TODO: use 0_i128 - self
     Int128.new(0) - self
@@ -725,6 +750,11 @@ struct UInt8
   # Returns an `UInt8` by invoking `to_u8` on *value*.
   def self.new(value)
     value.to_u8
+  end
+
+  # Returns an `UInt8` by invoking `to_u8!` on *value*.
+  def self.new!(value)
+    value.to_u8!
   end
 
   def abs
@@ -749,6 +779,11 @@ struct UInt16
     value.to_u16
   end
 
+  # Returns an `UInt16` by invoking `to_u16!` on *value*.
+  def self.new!(value)
+    value.to_u16!
+  end
+
   def abs
     self
   end
@@ -769,6 +804,11 @@ struct UInt32
   # Returns an `UInt32` by invoking `to_u32` on *value*.
   def self.new(value)
     value.to_u32
+  end
+
+  # Returns an `UInt32` by invoking `to_u32!` on *value*.
+  def self.new!(value)
+    value.to_u32!
   end
 
   def abs
@@ -793,6 +833,11 @@ struct UInt64
     value.to_u64
   end
 
+  # Returns an `UInt64` by invoking `to_u64!` on *value*.
+  def self.new!(value)
+    value.to_u64!
+  end
+
   def abs
     self
   end
@@ -814,6 +859,11 @@ struct UInt128
   # Returns an `UInt128` by invoking `to_u128` on *value*.
   def self.new(value)
     value.to_u128
+  end
+
+  # Returns an `UInt128` by invoking `to_u128!` on *value*.
+  def self.new!(value)
+    value.to_u128!
   end
 
   def abs

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -286,6 +286,13 @@ end
         @[Primitive(:cast)]
         def {{name.id}} : {{type}}
         end
+
+        # TODO 0.28.0 replace with @[Primitive(:unchecked_convert)]
+
+        # Returns `self` converted to `{{type}}`.
+        @[Primitive(:cast)]
+        def {{name.id}}! : {{type}}
+        end
       {% end %}
 
       {% for num2 in nums %}

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -280,6 +280,8 @@ end
                              to_u8: UInt8, to_u16: UInt16, to_u32: UInt32, to_u64: UInt64, to_u128: UInt128,
                              to_f32: Float32, to_f64: Float64,
                            } %}
+        # TODO 0.28.0 replace with @[Primitive(:convert)]
+
         # Returns `self` converted to `{{type}}`.
         @[Primitive(:cast)]
         def {{name.id}} : {{type}}


### PR DESCRIPTION
This PR adds some new methods to be able to keep current wrapping/unsafe behaviour once the overflow is activated. 

New methods/constructs:
*  `value.to_iX!`/`value.to_uX!`/`value.to_fX!` ~~`value.unsafe_to_iX`/`value.unsafe_to_uX`/`value.unsafe_to_fX`~~  
* `Int32.new!(value)` ~~`Int32.unsafe_new(value)`~~. 
* `Int#&**` is also added, and `Int#**` was refactored to avoid possible overflow in last iteration.

It prepares some new primitives to be able to have cleaner compiler code in the future. That is, drop the `:cast` internal in favor of `:convert` and `:unchecked_convert` ~~`:unsafe_convert`~~ to reflect better the nature of to_X methods.

This new methods should be used to be ready for upcoming breaking changes.