### PR TITLE
CI: Allow travis build with no output for 20min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - travis_retry bin/ci prepare_build
 
 script:
-  - travis_retry bin/ci build
+  - travis_wait 40 travis_retry bin/ci build
 
 branches:
   only:


### PR DESCRIPTION
This PR extends the timeout in travis to match the one used already in CircleCI

Ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received