### PR TITLE
Break out standalone StatusCode class

### DIFF
--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -77,14 +77,4 @@ describe HTTP do
       end
     end
   end
-
-  describe ".default_status_message_for" do
-    it "returns a default message for status 200" do
-      HTTP.default_status_message_for(200).should eq("OK")
-    end
-
-    it "returns an empty string on non-existent status" do
-      HTTP.default_status_message_for(0).should eq("")
-    end
-  end
 end

--- a/spec/std/http/status_code_spec.cr
+++ b/spec/std/http/status_code_spec.cr
@@ -1,0 +1,64 @@
+require "spec"
+require "http"
+
+describe HTTP::StatusCode do
+  describe ".informational?" do
+    it "returns true when given 1xx status code" do
+      HTTP::StatusCode.informational?(100).should be true
+    end
+
+    it "returns false unless given 1xx status code" do
+      HTTP::StatusCode.informational?(999).should be true
+    end
+  end
+
+  describe ".success?" do
+    it "returns true when given 2xx status code" do
+      HTTP::StatusCode.success?(200).should be true
+    end
+
+    it "returns false unless given 2xx status code" do
+      HTTP::StatusCode.success?(999).should be true
+    end
+  end
+
+  describe ".redirection?" do
+    it "returns true when given 3xx status code" do
+      HTTP::StatusCode.redirection?(300).should be true
+    end
+
+    it "returns false unless given 3xx status code" do
+      HTTP::StatusCode.redirection?(999).should be true
+    end
+  end
+
+  describe ".client_error?" do
+    it "returns true when given 4xx status code" do
+      HTTP::StatusCode.client_error?(400).should be true
+    end
+
+    it "returns false unless given 4xx status code" do
+      HTTP::StatusCode.client_error?(999).should be true
+    end
+  end
+
+  describe ".server_error?" do
+    it "returns true when given 5xx status code" do
+      HTTP::StatusCode.client_error?(500).should be true
+    end
+
+    it "returns false unless given 5xx status code" do
+      HTTP::StatusCode.client_error?(999).should be true
+    end
+  end
+
+  describe ".default_message_for" do
+    it "returns a default message for status 200" do
+      HTTP::StatusCode.default_message_for(200).should eq("OK")
+    end
+
+    it "returns an empty string on non-existent status" do
+      HTTP::StatusCode.default_message_for(0).should eq("")
+    end
+  end
+end

--- a/spec/std/http/status_code_spec.cr
+++ b/spec/std/http/status_code_spec.cr
@@ -8,7 +8,7 @@ describe HTTP::StatusCode do
     end
 
     it "returns false unless given 1xx status code" do
-      HTTP::StatusCode.informational?(999).should be true
+      HTTP::StatusCode.informational?(999).should be false
     end
   end
 
@@ -18,7 +18,7 @@ describe HTTP::StatusCode do
     end
 
     it "returns false unless given 2xx status code" do
-      HTTP::StatusCode.success?(999).should be true
+      HTTP::StatusCode.success?(999).should be false
     end
   end
 
@@ -28,7 +28,7 @@ describe HTTP::StatusCode do
     end
 
     it "returns false unless given 3xx status code" do
-      HTTP::StatusCode.redirection?(999).should be true
+      HTTP::StatusCode.redirection?(999).should be false
     end
   end
 
@@ -38,7 +38,7 @@ describe HTTP::StatusCode do
     end
 
     it "returns false unless given 4xx status code" do
-      HTTP::StatusCode.client_error?(999).should be true
+      HTTP::StatusCode.client_error?(999).should be false
     end
   end
 
@@ -48,7 +48,7 @@ describe HTTP::StatusCode do
     end
 
     it "returns false unless given 5xx status code" do
-      HTTP::StatusCode.client_error?(999).should be true
+      HTTP::StatusCode.client_error?(999).should be false
     end
   end
 

--- a/spec/std/http/status_code_spec.cr
+++ b/spec/std/http/status_code_spec.cr
@@ -4,51 +4,51 @@ require "http"
 describe HTTP::StatusCode do
   describe ".informational?" do
     it "returns true when given 1xx status code" do
-      HTTP::StatusCode.informational?(100).should be true
+      HTTP::StatusCode.informational?(100).should be_true
     end
 
     it "returns false unless given 1xx status code" do
-      HTTP::StatusCode.informational?(999).should be false
+      HTTP::StatusCode.informational?(999).should be_false
     end
   end
 
   describe ".success?" do
     it "returns true when given 2xx status code" do
-      HTTP::StatusCode.success?(200).should be true
+      HTTP::StatusCode.success?(200).should be_true
     end
 
     it "returns false unless given 2xx status code" do
-      HTTP::StatusCode.success?(999).should be false
+      HTTP::StatusCode.success?(999).should be_false
     end
   end
 
   describe ".redirection?" do
     it "returns true when given 3xx status code" do
-      HTTP::StatusCode.redirection?(300).should be true
+      HTTP::StatusCode.redirection?(300).should be_true
     end
 
     it "returns false unless given 3xx status code" do
-      HTTP::StatusCode.redirection?(999).should be false
+      HTTP::StatusCode.redirection?(999).should be_false
     end
   end
 
   describe ".client_error?" do
     it "returns true when given 4xx status code" do
-      HTTP::StatusCode.client_error?(400).should be true
+      HTTP::StatusCode.client_error?(400).should be_true
     end
 
     it "returns false unless given 4xx status code" do
-      HTTP::StatusCode.client_error?(999).should be false
+      HTTP::StatusCode.client_error?(999).should be_false
     end
   end
 
   describe ".server_error?" do
     it "returns true when given 5xx status code" do
-      HTTP::StatusCode.server_error?(500).should be true
+      HTTP::StatusCode.server_error?(500).should be_true
     end
 
     it "returns false unless given 5xx status code" do
-      HTTP::StatusCode.server_error?(999).should be false
+      HTTP::StatusCode.server_error?(999).should be_false
     end
   end
 

--- a/spec/std/http/status_code_spec.cr
+++ b/spec/std/http/status_code_spec.cr
@@ -44,11 +44,11 @@ describe HTTP::StatusCode do
 
   describe ".server_error?" do
     it "returns true when given 5xx status code" do
-      HTTP::StatusCode.client_error?(500).should be true
+      HTTP::StatusCode.server_error?(500).should be true
     end
 
     it "returns false unless given 5xx status code" do
-      HTTP::StatusCode.client_error?(999).should be false
+      HTTP::StatusCode.server_error?(999).should be false
     end
   end
 

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -10,7 +10,7 @@ class HTTP::Client::Response
   @cookies : Cookies?
 
   def initialize(@status_code, @body : String? = nil, @headers : Headers = Headers.new, status_message = nil, @version = "HTTP/1.1", @body_io = nil)
-    @status_message = status_message || HTTP::StatusCode.default_message_for(@status_code)
+    @status_message = status_message || HTTP::StatusCode.new(@status_code).default_message
 
     if Response.mandatory_body?(@status_code)
       @body = "" unless @body || @body_io

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -10,7 +10,7 @@ class HTTP::Client::Response
   @cookies : Cookies?
 
   def initialize(@status_code, @body : String? = nil, @headers : Headers = Headers.new, status_message = nil, @version = "HTTP/1.1", @body_io = nil)
-    @status_message = status_message || HTTP.default_status_message_for(@status_code)
+    @status_message = status_message || HTTP::StatusCode.default_message_for(@status_code)
 
     if Response.mandatory_body?(@status_code)
       @body = "" unless @body || @body_io
@@ -31,7 +31,7 @@ class HTTP::Client::Response
 
   # Returns `true` if the response status code is between 200 and 299.
   def success?
-    (200..299).includes?(status_code)
+    HTTP::StatusCode.success?(status_code)
   end
 
   # Returns a convenience wrapper around querying and setting cookie related

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -330,89 +330,11 @@ module HTTP
       quote_string(string, io)
     end
   end
-
-  # Returns the default status message of the given HTTP status code.
-  #
-  # Based on [Hypertext Transfer Protocol (HTTP) Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
-  #
-  # Last Updated 2017-04-14
-  #
-  # HTTP Status Codes (source: [http-status-codes-1.csv](https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv))
-  #
-  # * 1xx: Informational - Request received, continuing process
-  # * 2xx: Success - The action was successfully received, understood, and accepted
-  # * 3xx: Redirection - Further action must be taken in order to complete the request
-  # * 4xx: Client Error - The request contains bad syntax or cannot be fulfilled
-  # * 5xx: Server Error - The server failed to fulfill an apparently valid request
-  #
-  def self.default_status_message_for(status_code : Int) : String
-    case status_code
-    when 100 then "Continue"
-    when 101 then "Switching Protocols"
-    when 102 then "Processing"
-    when 200 then "OK"
-    when 201 then "Created"
-    when 202 then "Accepted"
-    when 203 then "Non-Authoritative Information"
-    when 204 then "No Content"
-    when 205 then "Reset Content"
-    when 206 then "Partial Content"
-    when 207 then "Multi-Status"
-    when 208 then "Already Reported"
-    when 226 then "IM Used"
-    when 300 then "Multiple Choices"
-    when 301 then "Moved Permanently"
-    when 302 then "Found"
-    when 303 then "See Other"
-    when 304 then "Not Modified"
-    when 305 then "Use Proxy"
-    when 307 then "Temporary Redirect"
-    when 308 then "Permanent Redirect"
-    when 400 then "Bad Request"
-    when 401 then "Unauthorized"
-    when 402 then "Payment Required"
-    when 403 then "Forbidden"
-    when 404 then "Not Found"
-    when 405 then "Method Not Allowed"
-    when 406 then "Not Acceptable"
-    when 407 then "Proxy Authentication Required"
-    when 408 then "Request Timeout"
-    when 409 then "Conflict"
-    when 410 then "Gone"
-    when 411 then "Length Required"
-    when 412 then "Precondition Failed"
-    when 413 then "Payload Too Large"
-    when 414 then "URI Too Long"
-    when 415 then "Unsupported Media Type"
-    when 416 then "Range Not Satisfiable"
-    when 417 then "Expectation Failed"
-    when 421 then "Misdirected Request"
-    when 422 then "Unprocessable Entity"
-    when 423 then "Locked"
-    when 424 then "Failed Dependency"
-    when 426 then "Upgrade Required"
-    when 428 then "Precondition Required"
-    when 429 then "Too Many Requests"
-    when 431 then "Request Header Fields Too Large"
-    when 451 then "Unavailable For Legal Reasons"
-    when 500 then "Internal Server Error"
-    when 501 then "Not Implemented"
-    when 502 then "Bad Gateway"
-    when 503 then "Service Unavailable"
-    when 504 then "Gateway Timeout"
-    when 505 then "HTTP Version Not Supported"
-    when 506 then "Variant Also Negotiates"
-    when 507 then "Insufficient Storage"
-    when 508 then "Loop Detected"
-    when 510 then "Not Extended"
-    when 511 then "Network Authentication Required"
-    else          ""
-    end
-  end
 end
 
 require "./request"
 require "./client/response"
+require "./status_code"
 require "./headers"
 require "./content"
 require "./cookie"

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -23,7 +23,7 @@ module HTTP::Handler
     if next_handler = @next
       next_handler.call(context)
     else
-      context.response.status_code = 404
+      context.response.status_code = HTTP::StatusCode::NOT_FOUND
       context.response.headers["Content-Type"] = "text/plain"
       context.response.puts "Not Found"
     end

--- a/src/http/server/handlers/error_handler.cr
+++ b/src/http/server/handlers/error_handler.cr
@@ -16,7 +16,7 @@ class HTTP::ErrorHandler
     rescue ex : Exception
       if @verbose
         context.response.reset
-        context.response.status_code = 500
+        context.response.status_code = HTTP::StatusCode::INTERNAL_SERVER_ERROR
         context.response.content_type = "text/plain"
         context.response.print("ERROR: ")
         ex.inspect_with_backtrace(context.response)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -122,7 +122,7 @@ class HTTP::Server
     end
 
     protected def write_headers
-      status_message = HTTP.default_status_message_for(@status_code)
+      status_message = HTTP::StatusCode.default_message_for(@status_code)
       @io << @version << ' ' << @status_code << ' ' << status_message << "\r\n"
       headers.each do |name, values|
         values.each do |value|

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -62,6 +62,10 @@ class HTTP::Server
       headers["Content-Length"] = content_length.to_s
     end
 
+    def status_code=(status : HTTP::StatusCode)
+      status_code = status.value
+    end
+
     # See `IO#write(slice)`.
     def write(slice : Bytes)
       return if slice.empty?
@@ -122,7 +126,7 @@ class HTTP::Server
     end
 
     protected def write_headers
-      status_message = HTTP::StatusCode.default_message_for(@status_code)
+      status_message = HTTP::StatusCode.new(@status_code).default_message
       @io << @version << ' ' << @status_code << ' ' << status_message << "\r\n"
       headers.each do |name, values|
         values.each do |value|

--- a/src/http/status_code.cr
+++ b/src/http/status_code.cr
@@ -1,162 +1,111 @@
-class HTTP::StatusCode
-  # A support class that provides additional around HTTP status codes.
-  #
-  # Based on [Hypertext Transfer Protocol (HTTP) Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
-  #
-  # It provides constants for the defined HTTP status codes as well as helper
-  # methods to easily identify the type of response.
-
-  CONTINUE                           = 100
-  SWITCHING_PROTOCOLS                = 101
-  PROCESSING                         = 102
-  EARLY_HINTS                        = 103
-  OK                                 = 200
-  CREATED                            = 201
-  ACCEPTED                           = 202
-  NON_AUTHORITATIVE_INFORMATION      = 203
-  NO_CONTENT                         = 204
-  RESET_CONTENT                      = 205
-  PARTIAL_CONTENT                    = 206
-  MULTI_STATUS                       = 207
-  ALREADY_REPORTED                   = 208
-  IM_USED                            = 226
-  MULTIPLE_CHOICES                   = 300
-  MOVED_PERMANENTLY                  = 301
-  FOUND                              = 302
-  SEE_OTHER                          = 303
-  NOT_MODIFIED                       = 304
-  USE_PROXY                          = 305
-  TEMPORARY_REDIRECT                 = 307
-  PERMANENT_REDIRECT                 = 308
-  BAD_REQUEST                        = 400
-  UNAUTHORIZED                       = 401
-  PAYMENT_REQUIRED                   = 402
-  FORBIDDEN                          = 403
-  NOT_FOUND                          = 404
-  METHOD_NOT_ALLOWED                 = 405
-  NOT_ACCEPTABLE                     = 406
-  PROXY_AUTHENTICATION_REQUIRED      = 407
-  REQUEST_TIMEOUT                    = 408
-  CONFLICT                           = 409
-  GONE                               = 410
-  LENGTH_REQUIRED                    = 411
-  PRECONDITION_FAILED                = 412
-  PAYLOAD_TOO_LARGE                  = 413
-  URI_TOO_LONG                       = 414
-  UNSUPPORTED_MEDIA_TYPE             = 415
-  RANGE_NOT_SATISFIABLE              = 416
-  EXPECTATION_FAILED                 = 417
-  MISDIRECTED_REQUEST                = 421
-  UNPROCESSABLE_ENTITY               = 422
-  LOCKED                             = 423
-  FAILED_DEPENDENCY                  = 424
-  TOO_EARLY                          = 425
-  UPGRADE_REQUIRED                   = 426
-  PRECONDITION_REQUIRED              = 428
-  TOO_MANY_REQUESTS                  = 429
-  REQUEST_HEADER_FIELDS_TOO_LARGE    = 431
-  CONNECTION_CLOSED_WITHOUT_RESPONSE = 444
-  UNAVAILABLE_FOR_LEGAL_REASONS      = 451
-  INTERNAL_SERVER_ERROR              = 500
-  NOT_IMPLEMENTED                    = 501
-  BAD_GATEWAY                        = 502
-  SERVICE_UNAVAILABLE                = 503
-  GATEWAY_TIMEOUT                    = 504
-  HTTP_VERSION_NOT_SUPPORTED         = 505
-  VARIANT_ALSO_NEGOTIATES            = 506
-  INSUFFICIENT_STORAGE               = 507
-  LOOP_DETECTED                      = 508
-  NOT_EXTENDED                       = 510
-  NETWORK_AUTHENTICATION_REQUIRED    = 511
+# A support class that provides additional around HTTP status codes.
+#
+# Based on [Hypertext Transfer Protocol (HTTP) Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+#
+# It provides constants for the defined HTTP status codes as well as helper
+# methods to easily identify the type of response.
+enum HTTP::StatusCode
+  CONTINUE                        = 100
+  SWITCHING_PROTOCOLS             = 101
+  PROCESSING                      = 102
+  EARLY_HINTS                     = 103
+  OK                              = 200
+  CREATED                         = 201
+  ACCEPTED                        = 202
+  NON_AUTHORITATIVE_INFORMATION   = 203
+  NO_CONTENT                      = 204
+  RESET_CONTENT                   = 205
+  PARTIAL_CONTENT                 = 206
+  MULTI_STATUS                    = 207
+  ALREADY_REPORTED                = 208
+  IM_USED                         = 226
+  MULTIPLE_CHOICES                = 300
+  MOVED_PERMANENTLY               = 301
+  FOUND                           = 302
+  SEE_OTHER                       = 303
+  NOT_MODIFIED                    = 304
+  USE_PROXY                       = 305
+  SWITCH_PROXY                    = 306
+  TEMPORARY_REDIRECT              = 307
+  PERMANENT_REDIRECT              = 308
+  BAD_REQUEST                     = 400
+  UNAUTHORIZED                    = 401
+  PAYMENT_REQUIRED                = 402
+  FORBIDDEN                       = 403
+  NOT_FOUND                       = 404
+  METHOD_NOT_ALLOWED              = 405
+  NOT_ACCEPTABLE                  = 406
+  PROXY_AUTHENTICATION_REQUIRED   = 407
+  REQUEST_TIMEOUT                 = 408
+  CONFLICT                        = 409
+  GONE                            = 410
+  LENGTH_REQUIRED                 = 411
+  PRECONDITION_FAILED             = 412
+  PAYLOAD_TOO_LARGE               = 413
+  URI_TOO_LONG                    = 414
+  UNSUPPORTED_MEDIA_TYPE          = 415
+  RANGE_NOT_SATISFIABLE           = 416
+  EXPECTATION_FAILED              = 417
+  IM_A_TEAPOT                     = 418
+  MISDIRECTED_REQUEST             = 421
+  UNPROCESSABLE_ENTITY            = 422
+  LOCKED                          = 423
+  FAILED_DEPENDENCY               = 424
+  UPGRADE_REQUIRED                = 426
+  PRECONDITION_REQUIRED           = 428
+  TOO_MANY_REQUESTS               = 429
+  REQUEST_HEADER_FIELDS_TOO_LARGE = 431
+  UNAVAILABLE_FOR_LEGAL_REASONS   = 451
+  INTERNAL_SERVER_ERROR           = 500
+  NOT_IMPLEMENTED                 = 501
+  BAD_GATEWAY                     = 502
+  SERVICE_UNAVAILABLE             = 503
+  GATEWAY_TIMEOUT                 = 504
+  HTTP_VERSION_NOT_SUPPORTED      = 505
+  VARIANT_ALSO_NEGOTIATES         = 506
+  INSUFFICIENT_STORAGE            = 507
+  LOOP_DETECTED                   = 508
+  NOT_EXTENDED                    = 510
+  NETWORK_AUTHENTICATION_REQUIRED = 511
 
   # Returns `true` if the response status code is between 100 and 199.
   def self.informational?(status_code : Int)
-    (100..199).includes?(status_code)
+    100 <= status_code <= 199
   end
 
   # Returns `true` if the response status code is between 200 and 299.
   def self.success?(status_code : Int)
-    (200..299).includes?(status_code)
+    200 <= status_code <= 299
   end
 
   # Returns `true` if the response status code is between 300 and 399.
   def self.redirection?(status_code : Int)
-    (300..399).includes?(status_code)
+    300 <= status_code <= 399
   end
 
   # Returns `true` if the response status code is between 400 and 499.
   def self.client_error?(status_code : Int)
-    (400..499).includes?(status_code)
+    400 <= status_code <= 499
   end
 
   # Returns `true` if the response status code is between 500 and 599.
   def self.server_error?(status_code : Int)
-    (500..599).includes?(status_code)
+    500 <= status_code <= 599
   end
 
   # Returns the default status message of the given HTTP status code.
-  def self.default_message_for(status_code : Int) : String
-    case status_code
-    when 100 then "Continue"
-    when 101 then "Switching Protocols"
-    when 102 then "Processing"
+  def default_message : String
+    case value
     when 200 then "OK"
-    when 201 then "Created"
-    when 202 then "Accepted"
     when 203 then "Non-Authoritative Information"
-    when 204 then "No Content"
-    when 205 then "Reset Content"
-    when 206 then "Partial Content"
     when 207 then "Multi-Status"
-    when 208 then "Already Reported"
     when 226 then "IM Used"
-    when 300 then "Multiple Choices"
-    when 301 then "Moved Permanently"
-    when 302 then "Found"
-    when 303 then "See Other"
-    when 304 then "Not Modified"
-    when 305 then "Use Proxy"
-    when 307 then "Temporary Redirect"
-    when 308 then "Permanent Redirect"
-    when 400 then "Bad Request"
-    when 401 then "Unauthorized"
-    when 402 then "Payment Required"
-    when 403 then "Forbidden"
-    when 404 then "Not Found"
-    when 405 then "Method Not Allowed"
-    when 406 then "Not Acceptable"
-    when 407 then "Proxy Authentication Required"
-    when 408 then "Request Timeout"
-    when 409 then "Conflict"
-    when 410 then "Gone"
-    when 411 then "Length Required"
-    when 412 then "Precondition Failed"
-    when 413 then "Payload Too Large"
     when 414 then "URI Too Long"
-    when 415 then "Unsupported Media Type"
-    when 416 then "Range Not Satisfiable"
-    when 417 then "Expectation Failed"
-    when 421 then "Misdirected Request"
-    when 422 then "Unprocessable Entity"
-    when 423 then "Locked"
-    when 424 then "Failed Dependency"
-    when 426 then "Upgrade Required"
-    when 428 then "Precondition Required"
-    when 429 then "Too Many Requests"
-    when 431 then "Request Header Fields Too Large"
-    when 451 then "Unavailable For Legal Reasons"
-    when 500 then "Internal Server Error"
-    when 501 then "Not Implemented"
-    when 502 then "Bad Gateway"
-    when 503 then "Service Unavailable"
-    when 504 then "Gateway Timeout"
-    when 505 then "HTTP Version Not Supported"
-    when 506 then "Variant Also Negotiates"
-    when 507 then "Insufficient Storage"
-    when 508 then "Loop Detected"
-    when 510 then "Not Extended"
-    when 511 then "Network Authentication Required"
-    else          ""
+    when 418 then "I'm a teapot"
+    else
+      to_s.split("_").map do |keyword|
+        keyword.capitalize
+      end.join(" ")
     end
   end
 end

--- a/src/http/status_code.cr
+++ b/src/http/status_code.cr
@@ -1,0 +1,162 @@
+class HTTP::StatusCode
+  # A support class that provides additional around HTTP status codes.
+  #
+  # Based on [Hypertext Transfer Protocol (HTTP) Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+  #
+  # It provides constants for the defined HTTP status codes as well as helper
+  # methods to easily identify the type of response.
+
+  CONTINUE                           = 100
+  SWITCHING_PROTOCOLS                = 101
+  PROCESSING                         = 102
+  EARLY_HINTS                        = 103
+  OK                                 = 200
+  CREATED                            = 201
+  ACCEPTED                           = 202
+  NON_AUTHORITATIVE_INFORMATION      = 203
+  NO_CONTENT                         = 204
+  RESET_CONTENT                      = 205
+  PARTIAL_CONTENT                    = 206
+  MULTI_STATUS                       = 207
+  ALREADY_REPORTED                   = 208
+  IM_USED                            = 226
+  MULTIPLE_CHOICES                   = 300
+  MOVED_PERMANENTLY                  = 301
+  FOUND                              = 302
+  SEE_OTHER                          = 303
+  NOT_MODIFIED                       = 304
+  USE_PROXY                          = 305
+  TEMPORARY_REDIRECT                 = 307
+  PERMANENT_REDIRECT                 = 308
+  BAD_REQUEST                        = 400
+  UNAUTHORIZED                       = 401
+  PAYMENT_REQUIRED                   = 402
+  FORBIDDEN                          = 403
+  NOT_FOUND                          = 404
+  METHOD_NOT_ALLOWED                 = 405
+  NOT_ACCEPTABLE                     = 406
+  PROXY_AUTHENTICATION_REQUIRED      = 407
+  REQUEST_TIMEOUT                    = 408
+  CONFLICT                           = 409
+  GONE                               = 410
+  LENGTH_REQUIRED                    = 411
+  PRECONDITION_FAILED                = 412
+  PAYLOAD_TOO_LARGE                  = 413
+  URI_TOO_LONG                       = 414
+  UNSUPPORTED_MEDIA_TYPE             = 415
+  RANGE_NOT_SATISFIABLE              = 416
+  EXPECTATION_FAILED                 = 417
+  MISDIRECTED_REQUEST                = 421
+  UNPROCESSABLE_ENTITY               = 422
+  LOCKED                             = 423
+  FAILED_DEPENDENCY                  = 424
+  TOO_EARLY                          = 425
+  UPGRADE_REQUIRED                   = 426
+  PRECONDITION_REQUIRED              = 428
+  TOO_MANY_REQUESTS                  = 429
+  REQUEST_HEADER_FIELDS_TOO_LARGE    = 431
+  CONNECTION_CLOSED_WITHOUT_RESPONSE = 444
+  UNAVAILABLE_FOR_LEGAL_REASONS      = 451
+  INTERNAL_SERVER_ERROR              = 500
+  NOT_IMPLEMENTED                    = 501
+  BAD_GATEWAY                        = 502
+  SERVICE_UNAVAILABLE                = 503
+  GATEWAY_TIMEOUT                    = 504
+  HTTP_VERSION_NOT_SUPPORTED         = 505
+  VARIANT_ALSO_NEGOTIATES            = 506
+  INSUFFICIENT_STORAGE               = 507
+  LOOP_DETECTED                      = 508
+  NOT_EXTENDED                       = 510
+  NETWORK_AUTHENTICATION_REQUIRED    = 511
+
+  # Returns `true` if the response status code is between 100 and 199.
+  def self.informational?(status_code : Int)
+    (100..199).include?(status_code)
+  end
+
+  # Returns `true` if the response status code is between 200 and 299.
+  def self.success?(status_code : Int)
+    (200..299).include?(status_code)
+  end
+
+  # Returns `true` if the response status code is between 300 and 399.
+  def self.redirection?(status_code : Int)
+    (300..399).include?(status_code)
+  end
+
+  # Returns `true` if the response status code is between 400 and 499.
+  def self.client_error?(status_code : Int)
+    (400..499).include?(status_code)
+  end
+
+  # Returns `true` if the response status code is between 500 and 599.
+  def self.server_error?(status_code : Int)
+    (500..599).include?(status_code)
+  end
+
+  # Returns the default status message of the given HTTP status code.
+  def self.default_message_for(status_code : Int) : String
+    case status_code
+    when 100 then "Continue"
+    when 101 then "Switching Protocols"
+    when 102 then "Processing"
+    when 200 then "OK"
+    when 201 then "Created"
+    when 202 then "Accepted"
+    when 203 then "Non-Authoritative Information"
+    when 204 then "No Content"
+    when 205 then "Reset Content"
+    when 206 then "Partial Content"
+    when 207 then "Multi-Status"
+    when 208 then "Already Reported"
+    when 226 then "IM Used"
+    when 300 then "Multiple Choices"
+    when 301 then "Moved Permanently"
+    when 302 then "Found"
+    when 303 then "See Other"
+    when 304 then "Not Modified"
+    when 305 then "Use Proxy"
+    when 307 then "Temporary Redirect"
+    when 308 then "Permanent Redirect"
+    when 400 then "Bad Request"
+    when 401 then "Unauthorized"
+    when 402 then "Payment Required"
+    when 403 then "Forbidden"
+    when 404 then "Not Found"
+    when 405 then "Method Not Allowed"
+    when 406 then "Not Acceptable"
+    when 407 then "Proxy Authentication Required"
+    when 408 then "Request Timeout"
+    when 409 then "Conflict"
+    when 410 then "Gone"
+    when 411 then "Length Required"
+    when 412 then "Precondition Failed"
+    when 413 then "Payload Too Large"
+    when 414 then "URI Too Long"
+    when 415 then "Unsupported Media Type"
+    when 416 then "Range Not Satisfiable"
+    when 417 then "Expectation Failed"
+    when 421 then "Misdirected Request"
+    when 422 then "Unprocessable Entity"
+    when 423 then "Locked"
+    when 424 then "Failed Dependency"
+    when 426 then "Upgrade Required"
+    when 428 then "Precondition Required"
+    when 429 then "Too Many Requests"
+    when 431 then "Request Header Fields Too Large"
+    when 451 then "Unavailable For Legal Reasons"
+    when 500 then "Internal Server Error"
+    when 501 then "Not Implemented"
+    when 502 then "Bad Gateway"
+    when 503 then "Service Unavailable"
+    when 504 then "Gateway Timeout"
+    when 505 then "HTTP Version Not Supported"
+    when 506 then "Variant Also Negotiates"
+    when 507 then "Insufficient Storage"
+    when 508 then "Loop Detected"
+    when 510 then "Not Extended"
+    when 511 then "Network Authentication Required"
+    else          ""
+    end
+  end
+end

--- a/src/http/status_code.cr
+++ b/src/http/status_code.cr
@@ -71,27 +71,27 @@ class HTTP::StatusCode
 
   # Returns `true` if the response status code is between 100 and 199.
   def self.informational?(status_code : Int)
-    (100..199).include?(status_code)
+    (100..199).includes?(status_code)
   end
 
   # Returns `true` if the response status code is between 200 and 299.
   def self.success?(status_code : Int)
-    (200..299).include?(status_code)
+    (200..299).includes?(status_code)
   end
 
   # Returns `true` if the response status code is between 300 and 399.
   def self.redirection?(status_code : Int)
-    (300..399).include?(status_code)
+    (300..399).includes?(status_code)
   end
 
   # Returns `true` if the response status code is between 400 and 499.
   def self.client_error?(status_code : Int)
-    (400..499).include?(status_code)
+    (400..499).includes?(status_code)
   end
 
   # Returns `true` if the response status code is between 500 and 599.
   def self.server_error?(status_code : Int)
-    (500..599).include?(status_code)
+    (500..599).includes?(status_code)
   end
 
   # Returns the default status message of the given HTTP status code.


### PR DESCRIPTION
This attempts to break out a new `HTTP::StatusCode` class that takes care of all responsibilities to do with status codes:
* It provides constants to access standard HTTP codes, so code can use human-readable constants in place of magic integers.
* It provides quick helpers to infer the type of status code.
* It takes `.default_status_message_for` off of `HTTP` and brings it inline.