### PR TITLE
Converting between JSON and YAML

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "json"
+require "yaml"
 
 describe JSON::Any do
   describe "casts" do
@@ -156,5 +157,25 @@ describe JSON::Any do
     any = JSON.parse("[[1], 2, 3]")
     any2 = any.clone
     any2.as_a[0].as_a.should_not be(any.as_a[0].as_a)
+  end
+
+  it "#to_yaml" do
+    any = JSON.parse <<-JSON
+      {
+        "foo": "bar",
+        "baz": [1, 2.3, true, "qux", {"qax": "qox"}]
+      }
+      JSON
+    any.to_yaml.should eq <<-YAML
+      ---
+      foo: bar
+      baz:
+      - 1
+      - 2.3
+      - true
+      - qux
+      - qax: qox
+
+      YAML
   end
 end

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "yaml"
+require "json"
 
 describe YAML::Any do
   describe "casts" do
@@ -212,5 +213,13 @@ describe YAML::Any do
     any = YAML.parse("[[1], 2, 3]")
     any2 = any.clone
     any2.as_a[0].as_a.should_not be(any.as_a[0].as_a)
+  end
+
+  it "#to_json" do
+    any = YAML.parse <<-YAML
+      foo: bar
+      baz: [1, 2.3, true, "qux", {"qax": "qox"}]
+      YAML
+    any.to_json.should eq %({"foo":"bar","baz":[1,2.3,true,"qux",{"qax":"qox"}]})
   end
 end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -276,6 +276,10 @@ struct JSON::Any
     raw.to_json(json)
   end
 
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    raw.to_yaml(yaml)
+  end
+
   # Returns a new JSON::Any instance with the `raw` value `dup`ed.
   def dup
     Any.new(raw.dup)

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -287,6 +287,14 @@ struct YAML::Any
     raw.to_yaml(io)
   end
 
+  def to_json(builder : JSON::Builder)
+    if (raw = self.raw).is_a?(Slice)
+      raise "Can't serialize #{raw.class} to JSON"
+    else
+      raw.to_json(builder)
+    end
+  end
+
   # Returns a new YAML::Any instance with the `raw` value `dup`ed.
   def dup
     Any.new(raw.dup)


### PR DESCRIPTION
This adds `YAML::Any#to_json(builder)` and `JSON::Any#to_yaml(builder)` to convert arbitrary data between both formats.

There are many uses cases for such a conversion, one example is storing arbitrary YAML input data in a database using a JSON type.

The conversion can almost entirely be implemented by delegating to `raw.to_yaml(builder)` and this is works quite nicely out of the box. 

Since YAML is a superset of JSON, `JSON::Any#to_yaml` is always valid and fully reversible.

All YAML raw types except `Bytes` implement both `#to_yaml` and `#to_json`, so it's not a huge issue.
I've implemted Serializing  `YAML::Any#to_json` so that it raises when raw is a `Slice`.
We could also consider serializing `Bytes` as Base64 encoded string like in YAML.
JSON serializes some data types which are distinct in YAML, such as `Time` as strings, thus converting from YAML to JSON is not fully reversible.