### PR TITLE
Enumerable#each_cons support for accepting deque as a reuse buffer

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -286,6 +286,15 @@ describe "Enumerable" do
       a.should be(reuse)
     end
 
+    it "returns each_cons iterator with reuse = deque" do
+      reuse = Deque(Int32).new
+      iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
+
+      a = iter.next
+      a.should eq(Deque{1, 2, 3})
+      a.should be(reuse)
+    end
+
     it "yields running pairs with reuse = true" do
       array = [] of Array(Int32)
       object_ids = Set(UInt64).new

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -306,6 +306,16 @@ describe "Enumerable" do
       end
       array.should eq([[1, 2], [2, 3], [3, 4]])
     end
+
+    it "yields running pairs with reuse = deque" do
+      array = [] of Deque(Int32)
+      reuse = Deque(Int32).new
+      [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
+        pair.should be(reuse)
+        array << pair.dup
+      end
+      array.should eq([Deque{1, 2}, Deque{2, 3}, Deque{3, 4}])
+    end
   end
 
   describe "each_slice" do

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -286,7 +286,7 @@ describe "Enumerable" do
       a.should be(reuse)
     end
 
-    it "returns running pairs with reuse = true" do
+    it "yields running pairs with reuse = true" do
       array = [] of Array(Int32)
       object_ids = Set(UInt64).new
       [1, 2, 3, 4].each_cons(2, reuse: true) do |pair|
@@ -297,7 +297,7 @@ describe "Enumerable" do
       object_ids.size.should eq(1)
     end
 
-    it "returns running pairs with reuse = array" do
+    it "yields running pairs with reuse = array" do
       array = [] of Array(Int32)
       reuse = [] of Int32
       [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -127,6 +127,78 @@ describe Iterator do
       iter.rewind
       iter.next.should eq([1, 2, 3])
     end
+
+    describe "reuse" do
+      it "reuse as nil" do
+        iter = (1..5).each.cons(3, reuse: nil)
+        first = iter.next
+        first.should eq([1, 2, 3])
+        second = iter.next
+        second.should eq([2, 3, 4])
+        first.should_not be(second)
+        iter.next.should eq([3, 4, 5])
+        iter.next.should be_a(Iterator::Stop)
+
+        iter.rewind
+        iter.next.should eq([1, 2, 3])
+        iter.next.should_not be(first)
+      end
+
+      it "reuse as Bool" do
+        iter = (1..5).each.cons(3, reuse: true)
+        first = iter.next
+        first.should eq([1, 2, 3])
+        second = iter.next
+        second.should eq([2, 3, 4])
+        first.should be(second)
+        iter.next.should eq([3, 4, 5])
+        iter.next.should be_a(Iterator::Stop)
+
+        iter.rewind
+        iter.next.should eq([1, 2, 3])
+        iter.next.should be(first)
+      end
+
+      it "reuse as Array" do
+        reuse = [] of Int32
+        iter = (1..5).each.cons(3, reuse: reuse)
+        value = iter.next
+        value.should be(reuse)
+        value.should eq([1, 2, 3])
+        value = iter.next
+        value.should be(reuse)
+        value.should eq([2, 3, 4])
+        value = iter.next
+        value.should be(reuse)
+        value.should eq([3, 4, 5])
+        iter.next.should be_a(Iterator::Stop)
+
+        iter.rewind
+        value = iter.next
+        value.should be(reuse)
+        value.should eq([1, 2, 3])
+      end
+
+      it "reuse as deque" do
+        reuse = Deque(Int32).new
+        iter = (1..5).each.cons(3, reuse: reuse)
+        value = iter.next
+        value.should be(reuse)
+        value.should eq(Deque{1, 2, 3})
+        value = iter.next
+        value.should be(reuse)
+        value.should eq(Deque{2, 3, 4})
+        value = iter.next
+        value.should be(reuse)
+        value.should eq(Deque{3, 4, 5})
+        iter.next.should be_a(Iterator::Stop)
+
+        iter.rewind
+        value = iter.next
+        value.should be(reuse)
+        value.should eq(Deque{1, 2, 3})
+      end
+    end
   end
 
   describe "cycle" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -283,22 +283,21 @@ module Enumerable(T)
   #
   # By default, a new array is created and yielded for each consecutive slice of elements.
   # * If *reuse* is given, the array can be reused
-  # * If *reuse* is an `Array`, this array will be reused
-  # * If *reuse* is truthy, the method will create a new array and reuse it.
+  # * If *reuse* is `true`, the method will create a new array and reuse it.
+  # * If *reuse*  is an instance of `Array`, `Deque` or a similar collection type (implementing `#<<`, `#shift` and `#size`) it will be used.
+  # * If *reuse* is falsey, the array will not be reused.
   #
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
   def each_cons(count : Int, reuse = false)
-    if reuse
-      unless reuse.is_a?(Array)
-        reuse = Array(T).new(count)
-      end
-      cons = reuse
+    if reuse.nil? || reuse.is_a?(Bool)
+      each_cons_internal(count, reuse, Array(T).new(count)) { |slice| yield slice }
     else
-      cons = Array(T).new(count)
-      reuse = nil
+      each_cons_internal(count, true, reuse) { |slice| yield slice }
     end
+  end
 
+  private def each_cons_internal(count : Int, reuse, cons)
     each do |elem|
       cons << elem
       cons.shift if cons.size > count

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -290,6 +290,7 @@ module Enumerable(T)
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
   def each_cons(count : Int, reuse = false)
+    raise ArgumentError.new "Invalid cons size: #{count}" if count <= 0
     if reuse.nil? || reuse.is_a?(Bool)
       each_cons_internal(count, reuse, Array(T).new(count)) { |slice| yield slice }
     else


### PR DESCRIPTION
This removes the restriction on `Enumerable#each_cons` and `Iterator#cons` to only accept arrays as a container to reuse. With this, it will be possible to use a Deque instead, for better performance.

Also adds some missing tests in iterator_spec.cr

Solves #7189 