### PR TITLE
Clean SemanticVersion for better performance

### DIFF
--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -1,7 +1,7 @@
 # Conforms to Semantic Versioning 2.0.0
 #
 # See [https://semver.org/](https://semver.org/) for more information.
-class SemanticVersion
+struct SemanticVersion
   include Comparable(self)
 
   # The major version of this semantic version
@@ -30,8 +30,7 @@ class SemanticVersion
   #
   # Raises `ArgumentError` if *str* is not a semantic version.
   def self.parse(str : String) : self
-    m = str.match /^(\d+)\.(\d+)\.(\d+)(-([\w\.]+))?(\+(\w+))??$/
-    if m
+    if m = str.match /^(\d+)\.(\d+)\.(\d+)(-([\w\.]+))?(\+(\w+))??$/
       major = m[1].to_i
       minor = m[2].to_i
       patch = m[3].to_i
@@ -118,8 +117,8 @@ class SemanticVersion
     def self.parse(str : String) : self
       identifiers = [] of String | Int32
       str.split('.').each do |val|
-        if val.match /^\d+$/
-          identifiers << val.to_i32
+        if number = val.to_i32?
+          identifiers << number
         else
           identifiers << val
         end
@@ -143,7 +142,7 @@ class SemanticVersion
     # semver.prerelease.to_s # => "rc.1"
     # ```
     def to_s(io : IO)
-      identifiers.join(".", io)
+      identifiers.join('.', io)
     end
 
     # The comparison operator
@@ -167,8 +166,6 @@ class SemanticVersion
         end
       elsif other.identifiers.empty?
         return -1
-      else
-        # continue
       end
 
       identifiers.each_with_index do |item, i|


### PR DESCRIPTION
I've noticed minor improvements that can be done in `SemanticVersion` here and there.
Changed to a `struct` because it's immutable.