### PR TITLE
Format: fix to format newline after &.foo in call

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -298,6 +298,8 @@ describe Crystal::Formatter do
   assert_format "foo   &.is_a?(T)", "foo &.is_a?(T)"
   assert_format "foo   &.responds_to?(:foo)", "foo &.responds_to?(:foo)"
 
+  assert_format "foo(\n  1,\n  &.foo\n)"
+
   %w(return break next yield).each do |keyword|
     assert_format keyword
     assert_format "#{keyword}( 1 )", "#{keyword}(1)"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2470,6 +2470,13 @@ module Crystal
           return false
         end
         indent(block_indent) { format_block block, needs_space }
+        if has_parentheses
+          skip_space
+          if @token.type == :NEWLINE
+            ends_with_newline = true
+          end
+          skip_space_or_newline
+        end
       end
 
       if has_args || node.block_arg


### PR DESCRIPTION
Fixed #7237

Now, the formatter keeps the following code:

```crystal
foo(
  1,
  &.foo
)
```