### PR TITLE
Fix error message on crystal tool format

### DIFF
--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -193,7 +193,7 @@ class Crystal::Command
 
       ex.inspect_with_backtrace STDERR
     else
-      STDERR << "there's a bug formatting #{file}, to show more information, please run:\n\n  $ crystal tool format #{file}"
+      STDERR << "there's a bug formatting #{file}, to show more information, please run:\n\n  $ crystal tool format - < #{file}"
     end
 
     STDERR.puts


### PR DESCRIPTION
Formatting error message is wrong. For example it shows:

> `$ crystal tool format foo.cr`

But the above command makes the same result because single argument
special case is removed by #7144.

STDIN case `-` is still alived, so I think the right message is:

> `$ crystal tool format - < foo.cr`

/cc @straight-shoota 