### PR TITLE
Fix: detect OpenSSL/LibreSSL from official C headers

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -86,7 +86,7 @@ format() {
 prepare_build() {
   on_linux verify_linux_environment
 
-  on_osx brew install crystal
+  on_osx brew install crystal openssl
 
   # Make sure binaries from llvm are available in PATH
   on_osx brew install jq

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -53,7 +53,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Client)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_01_00_0 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -67,7 +67,7 @@ describe OpenSSL::SSL::Context do
     context.should be_a(OpenSSL::SSL::Context::Server)
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
     context.options.no_ssl_v3?.should_not be_true
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_01_00_0 %}
     context.modes.should eq(OpenSSL::SSL::Modes::AUTO_RETRY)
     {% else %}
     context.modes.should eq(OpenSSL::SSL::Modes::None)
@@ -162,7 +162,7 @@ describe OpenSSL::SSL::Context do
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
   end
 
-  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 || LibSSL::LIBRESSL_VERSION_NUMBER >= 0x2_05_00_00__0 %}
   it "alpn_protocol=" do
     context = OpenSSL::SSL::Context::Client.insecure
     context.alpn_protocol = "h2"
@@ -203,13 +203,13 @@ describe OpenSSL::SSL::Context do
       expect_raises(ArgumentError, "missing private key") do
         OpenSSL::SSL::Context::Client.from_hash({} of String => String)
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_use_PrivateKey_file: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error, /SSL_CTX_use_PrivateKey_file: .+No such file or directory/) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => nonexistent})
       end
       expect_raises(ArgumentError, "missing certificate") do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key})
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_use_certificate_chain_file: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error, /SSL_CTX_use_certificate_chain_file: .+No such file or directory/) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => nonexistent})
       end
       expect_raises(ArgumentError, "Invalid SSL context: missing CA certificate") do
@@ -221,7 +221,7 @@ describe OpenSSL::SSL::Context do
       expect_raises(ArgumentError, "Invalid SSL context: missing CA certificate") do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => certificate, "verify_mode" => "peer"})
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_load_verify_locations: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error, /SSL_CTX_load_verify_locations: .+No such file or directory/) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => certificate, "ca" => nonexistent})
       end
     end

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -90,7 +90,7 @@ module OpenSSL
     alias Options = LibSSL::Options
     alias VerifyMode = LibSSL::VerifyMode
     alias ErrorType = LibSSL::SSLError
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+    {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 %}
     alias X509VerifyFlags = LibCrypto::X509VerifyFlags
     {% end %}
 

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -3,7 +3,7 @@ require "./lib_crypto"
 # :nodoc:
 struct OpenSSL::BIO
   def self.get_data(bio) : Void*
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibCrypto.BIO_get_data(bio)
     {% else %}
       bio.value.ptr
@@ -11,7 +11,7 @@ struct OpenSSL::BIO
   end
 
   def self.set_data(bio, data : Void*)
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibCrypto.BIO_set_data(bio, data)
     {% else %}
       bio.value.ptr = data
@@ -65,7 +65,7 @@ struct OpenSSL::BIO
     end
 
     create = LibCrypto::BioMethodCreate.new do |bio|
-      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      {% if LibCrypto::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
         LibCrypto.BIO_set_shutdown(bio, 1)
         LibCrypto.BIO_set_init(bio, 1)
         # bio.value.num = -1
@@ -82,10 +82,10 @@ struct OpenSSL::BIO
       1
     end
 
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       biom = LibCrypto.BIO_meth_new(Int32::MAX, "Crystal BIO")
 
-      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.1") >= 0 %}
+      {% if LibCrypto::OPENSSL_VERSION_NUMBER >= 0x1_01_01_00_0 %}
         LibCrypto.BIO_meth_set_write_ex(biom, bwrite_ex)
         LibCrypto.BIO_meth_set_read_ex(biom, bread_ex)
       {% else %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -3,7 +3,7 @@ require "uri/punycode"
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibSSL.tls_method
     {% else %}
       LibSSL.sslv23_method
@@ -81,7 +81,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 %}
       self.default_verify_param = "ssl_server"
       {% end %}
     end
@@ -114,26 +114,26 @@ abstract class OpenSSL::SSL::Context
       super(params)
     end
 
-    # Wraps the original certificate verification to also validate the
-    # hostname against the certificate configured Subject Alternate
-    # Names or Common Name.
-    #
-    # Required for OpenSSL <= 1.0.1 only.
-    protected def set_cert_verify_callback(hostname : String)
-      # Sanitize the hostname with PunyCode
-      hostname = URI::Punycode.to_ascii hostname
+    {% if LibSSL::OPENSSL_VERSION_NUMBER <= 0x1_00_01_00_0 %}
+      # Wraps the original certificate verification to also validate the
+      # hostname against the certificate configured Subject Alternate
+      # Names or Common Name.
+      protected def set_cert_verify_callback(hostname : String)
+        # Sanitize the hostname with PunyCode
+        hostname = URI::Punycode.to_ascii hostname
 
-      # Keep a reference so the GC doesn't collect it after sending it to C land
-      @hostname = hostname
-      LibSSL.ssl_ctx_set_cert_verify_callback(@handle, ->(x509_ctx, arg) {
-        if LibCrypto.x509_verify_cert(x509_ctx) != 0
-          cert = LibCrypto.x509_store_ctx_get_current_cert(x509_ctx)
-          HostnameValidation.validate_hostname(arg.as(String), cert) == HostnameValidation::Result::MatchFound ? 1 : 0
-        else
-          0
-        end
-      }, hostname.as(Void*))
-    end
+        # Keep a reference so the GC doesn't collect it after sending it to C land
+        @hostname = hostname
+        LibSSL.ssl_ctx_set_cert_verify_callback(@handle, ->(x509_ctx, arg) {
+          if LibCrypto.x509_verify_cert(x509_ctx) != 0
+            cert = LibCrypto.x509_store_ctx_get_current_cert(x509_ctx)
+            HostnameValidation.validate_hostname(arg.as(String), cert) == HostnameValidation::Result::MatchFound ? 1 : 0
+          else
+            0
+          end
+        }, hostname.as(Void*))
+      end
+    {% end %}
   end
 
   class Server < Context
@@ -157,7 +157,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 %}
       self.default_verify_param = "ssl_client"
       {% end %}
 
@@ -301,7 +301,7 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the current options set on the TLS context.
   def options
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibSSL.ssl_ctx_get_options(@handle)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
@@ -320,7 +320,7 @@ abstract class OpenSSL::SSL::Context
   # )
   # ```
   def add_options(options : OpenSSL::SSL::Options)
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibSSL.ssl_ctx_set_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
@@ -335,7 +335,7 @@ abstract class OpenSSL::SSL::Context
   # context.remove_options(OpenSSL::SSL::Options::NO_SSL_V3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_01_00_00_0 %}
       LibSSL.ssl_ctx_clear_options(@handle, options)
     {% else %}
       LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
@@ -353,7 +353,7 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 || LibSSL::LIBRESSL_VERSION_NUMBER >= 0x2_05_00_00_0 %}
 
   @alpn_protocol : Pointer(Void)?
 
@@ -385,6 +385,10 @@ abstract class OpenSSL::SSL::Context
     @alpn_protocol = alpn_protocol = Box.box(protocol)
     LibSSL.ssl_ctx_set_alpn_select_cb(@handle, alpn_cb, alpn_protocol)
   end
+
+  {% end %}
+
+  {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 %}
 
   # Sets this context verify param to the default one of the given name.
   #

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -12,7 +12,7 @@ abstract class OpenSSL::SSL::Socket < IO
           hostname.to_unsafe.as(Pointer(Void))
         )
 
-        {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+        {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 %}
           param = LibSSL.ssl_get0_param(@ssl)
 
           if ::Socket.ip?(hostname)
@@ -129,7 +129,7 @@ abstract class OpenSSL::SSL::Socket < IO
     @bio.io.flush
   end
 
-  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if LibSSL::OPENSSL_VERSION_NUMBER >= 0x1_00_02_00_0 || LibSSL::LIBRESSL_VERSION_NUMBER >= 0x2_05_00_00_0 %}
   # Returns the negotiated ALPN protocol (eg: `"h2"`) of `nil` if no protocol was
   # negotiated.
   def alpn_protocol

--- a/src/openssl/version.sh
+++ b/src/openssl/version.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+LIBNAME=$1
+
+if [ -z $OPENSSL_DIR ]; then
+    # use pkg-config if available:
+    OPENSSL_CFLAGS=$(command -v pkg-config > /dev/null && pkg-config --cflags --silence-errors $LIBNAME)
+else
+    # use specified prefix:
+    OPENSSL_CFLAGS="-I$OPENSSL_DIR/include"
+fi
+
+# extract version numbers from OpenSSL/LibreSSL C headers:
+LIBRESSL_VERSION_NUMBER=$(printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $OPENSSL_CFLAGS -E - 2> /dev/null | tail -n 1)
+OPENSSL_VERSION_NUMBER=$(printf "#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER" | ${CC:-cc} $OPENSSL_CFLAGS -E - 2> /dev/null | tail -n 1)
+
+if [ $LIBRESSL_VERSION_NUMBER = LIBRESSL_VERSION_NUMBER ]; then
+    # not libressl:
+    echo LIBRESSL_VERSION_NUMBER = 0x0
+
+    if [ $OPENSSL_VERSION_NUMBER = OPENSSL_VERSION_NUMBER ]; then
+        echo '{% raise "Error: failed to find OpenSSL or LibreSSL development headers" %}'
+    else
+        # detected OpenSSL:
+        echo OPENSSL_VERSION_NUMBER = $(echo $OPENSSL_VERSION_NUMBER | sed 's/L//')
+    fi
+else
+    # detected LibreSSL:
+    echo LIBRESSL_VERSION_NUMBER = $(echo $LIBRESSL_VERSION_NUMBER | sed 's/L//')
+    echo OPENSSL_VERSION_NUMBER = 0x0
+fi
+
+if [ -z $OPENSSL_DIR ]; then
+    echo LDFLAGS = nil
+else
+    # pass specified lib folder:
+    echo LDFLAGS = \"-L$OPENSSL_DIR/lib\"
+fi

--- a/src/openssl/version.sh
+++ b/src/openssl/version.sh
@@ -10,6 +10,22 @@ else
     OPENSSL_CFLAGS="-I$OPENSSL_DIR/include"
 fi
 
+if [ -z $OPENSSL_CFLAGS ] && [ "`uname -s`" = "Darwin" ]; then
+    OPENSSL_DIR=/usr/local/opt/openssl
+
+    # check default homebrew install directory (fast):
+    if [ -d "$OPENSSL_DIR/include" ]; then
+        OPENSSL_CFLAGS="-I$OPENSSL_DIR/include"
+    else
+        # ask homebrew (slower):
+        OPENSSL_DIR=$(command -v brew > /dev/null && brew --prefix openssl)
+
+        if [ -n "$OPENSSL_DIR" ] && [ -d "$OPENSSL_DIR/include" ]; then
+            OPENSSL_CFLAGS="-I$OPENSSL_DIR/include"
+        fi
+    fi
+fi
+
 # extract version numbers from OpenSSL/LibreSSL C headers:
 LIBRESSL_VERSION_NUMBER=$(printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $OPENSSL_CFLAGS -E - 2> /dev/null | tail -n 1)
 OPENSSL_VERSION_NUMBER=$(printf "#include <openssl/opensslv.h>\nOPENSSL_VERSION_NUMBER" | ${CC:-cc} $OPENSSL_CFLAGS -E - 2> /dev/null | tail -n 1)


### PR DESCRIPTION
Detecting the OpenSSL version using pkg-config is prone to bugs when a libssl.pc or libcrypto.pc definition aren't available, or pkg-config itself isn't available. Using a C preprocessor to extract the official `OPENSSL_VERSION_NUMBER` and `LIBRESSL_VERSION_NUMBER` constants from the `openssl/opensslv.h` header should always be correct.

The version numbers are a little cryptic when compared to their text counterpart, but this is what's expected by OpenSSL, so we should follow.

Of course, if `pkg-config` if installed we use it to detect the correct version (linking will use it).

fixes #7244 