### PR TITLE
Improve HTTP::Server docs

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -83,8 +83,8 @@ require "./common"
 # ### Handler chain
 #
 # The handler given to a server can simply be a block that receives an `HTTP::Server::Context`,
-# or it can be an instance of `HTTP::Handler`. An `HTTP::Handler` has an optional
-# `#next` method to forward processing to the next handler in the chain.
+# or it can be an instance of `HTTP::Handler`. An `HTTP::Handler` has a `#next`
+# method to forward processing to the next handler in the chain.
 #
 # For example, an initial handler might handle exceptions raised from subsequent
 # handlers and return a `500 Server Error` status (see `HTTP::ErrorHandler`).

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -28,7 +28,7 @@ require "./common"
 #
 # ## Binding to sockets
 #
-# The server can be bound to one ore more server sockets (see )
+# The server can be bound to one ore more server sockets (see `#bind`)
 #
 # Supported types:
 #
@@ -36,7 +36,7 @@ require "./common"
 # * TCP socket with TLS/SSL: `#bind_tls`
 # * Unix socket `#bind_unix`
 #
-# `#bind(uri : URI)` and `bind(uri : String)` parse socket configuration for
+# `#bind(uri : URI)` and `#bind(uri : String)` parse socket configuration for
 # one of these types from an `URI`. This can be useful for injecting plain text
 # configuration values.
 #


### PR DESCRIPTION
This is a general overhaul of the `HTTP::Server` API docs, describing the updated behaviour after #5776.
It adds some more details and structures the text.

I've left out the section about reusing connections which will be added with the changed behaviour in #7055.