### PR TITLE
Compiler: let a metaclass' metaclass be a new type instead of Class

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -662,7 +662,7 @@ describe "Code gen: class" do
       end
 
       Foo.class.to_s
-      )).to_string.should eq("Class")
+      )).to_string.should eq("Foo.class")
   end
 
   it "invokes class method inside instance method (#1119)" do

--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -568,4 +568,23 @@ describe "Code gen: def" do
       foo { |a, b| }
       ))
   end
+
+  it "codegens T.class restriction matching metaclass type" do
+    run(%(
+      class Gen(T)
+        def initialize(@x : T.class)
+        end
+
+        def match(value)
+          value.is_a?(T)
+        end
+      end
+
+      def be(x)
+        Gen.new(x)
+      end
+
+      be(String.class).match(String)
+      )).to_b.should be_true
+  end
 end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -715,16 +715,4 @@ describe "Codegen: is_a?" do
       1.to_s.is_a?(B)
       )).to_b.should be_true
   end
-
-  it "says true for Class.is_a?(Class.class) (#4374)" do
-    run("
-      Class.is_a?(Class.class)
-    ").to_b.should be_true
-  end
-
-  it "says true for Class.is_a?(Class.class.class) (#4374)" do
-    run("
-      Class.is_a?(Class.class.class)
-    ").to_b.should be_true
-  end
 end

--- a/spec/compiler/semantic/reflection_spec.cr
+++ b/spec/compiler/semantic/reflection_spec.cr
@@ -6,17 +6,17 @@ describe "Semantic: reflection" do
   end
 
   it "types Class class" do
-    assert_type("Class") { types["Class"] }
+    assert_type("Class") { types["Class"].metaclass }
   end
 
   it "types Object and Class metaclases" do
-    assert_type("Object.class") { types["Class"] }
-    assert_type("Class.class") { types["Class"] }
+    assert_type("Object.class") { types["Object"].metaclass.metaclass }
+    assert_type("Class.class") { types["Class"].metaclass.metaclass }
   end
 
   it "types Reference metaclass" do
     assert_type("Reference") { types["Reference"].metaclass }
-    assert_type("Reference.class") { types["Class"] }
+    assert_type("Reference.class") { types["Reference"].metaclass.metaclass }
   end
 
   it "types metaclass parent" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -460,4 +460,14 @@ describe "Restrictions" do
       ),
       "no overload matches"
   end
+
+  it "matches metaclass with T.class restriction" do
+    assert_type(%(
+      def foo(x : T.class) forall T
+        T
+      end
+
+      foo(String.class)
+      )) { string.metaclass.metaclass }
+  end
 end

--- a/src/class.cr
+++ b/src/class.cr
@@ -129,7 +129,7 @@ class Class
   # ```
   # Int32 | Char # => (Int32 | Char)
   # ```
-  def self.|(other : U.class) forall U
+  def |(other : U.class) forall U
     t = uninitialized self
     u = uninitialized U
     typeof(t, u)

--- a/src/compiler/crystal/tools/typed_def_processor.cr
+++ b/src/compiler/crystal/tools/typed_def_processor.cr
@@ -3,6 +3,8 @@
 #
 # It is used for `crystal tool context/expand/implementation`.
 module Crystal::TypedDefProcessor
+  @processed_types = Set(Type).new
+
   private def process_typed_def(typed_def : Def)
     typed_def.accept self
   end
@@ -17,6 +19,9 @@ module Crystal::TypedDefProcessor
   end
 
   private def process_type(type : Type) : Nil
+    return if @processed_types.includes?(type)
+    @processed_types << type
+
     if type.is_a?(NamedType) || type.is_a?(Program) || type.is_a?(FileModule)
       type.types?.try &.each_value do |inner_type|
         process_type inner_type
@@ -29,7 +34,7 @@ module Crystal::TypedDefProcessor
       end
     end
 
-    process_type type.metaclass if type.metaclass != type
+    process_type type.metaclass unless type.metaclass?
 
     if type.is_a?(DefInstanceContainer)
       type.def_instances.each_value do |typed_def|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2713,10 +2713,6 @@ module Crystal
       super(program, program, name, super_class)
     end
 
-    def metaclass
-      program.class_type
-    end
-
     delegate abstract?, generic_nest, lookup_new_in_ancestors?,
       type_var?, to: instance_type
 
@@ -3211,10 +3207,6 @@ module Crystal
 
     def initialize(program, @instance_type)
       super(program)
-    end
-
-    def metaclass
-      program.class_type
     end
 
     def parents

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -367,8 +367,8 @@ module Spec
     end
 
     # Creates an `Expectation` that passes if actual is of type *type* (`is_a?`).
-    macro be_a(type)
-      Spec::BeAExpectation({{type}}).new
+    def be_a(type : T.class) forall T
+      Spec::BeAExpectation(T).new
     end
 
     # Runs the block and passes if it raises an exception of type *klass* and the error message matches.


### PR DESCRIPTION
This PR changes the language a bit regarding metaclasses. An explanation follows.

Every expression has a value and a type. For example:

- `1` has a value of `1` and a type of `Int32`. Methods for `1` are looked up in the `Int32` type. These are denoted as `Int32#method`.
- `Int32` has a value of `Int32` and a type of `Int32.class`. In the compiler this is called a _metaclass_. Methods for `Int32` are looked up in the `Int32.class` type. These are denoted as `Int32.method`.

When we have a restriction like:

```crystal
def capture(x : T) forall T
  T
end

capture(1)
```

what happens is that `1` is typed (as usual) and we get the `Int32` type. Then when passed to the method this is matched against `T` and `T` becomes `Int32`.

When we have this (note it's `T.class`):

```crystal
def capture(x : T.class) forall T
  T
end

capture(Int32)
```

what happens is that `Int32` is typed and it gets the `Int32.class` type. Then matching against `T.class` we get `Int32`. Internally to implement this we go from the metaclass to the instance type (every metaclass has an instance type, in the case of `Int32.class` it's `Int32` and so on). 

So far, so good.

The problem comes when we want to pass `Int32.class` and capture that type. The current use case is using it in the `be_a` matcher in spec, but I stumbled upon this use case a few other types (but I can't remember now what they were):

```crystal
def capture(x : T.class) forall T
  T
end

capture(Int32.class)
```

Here `Int32.class` is typed, and currently this gets a type of `Class`, because the type of a metaclass is always `Class`. And from there the compiler would go to the instance type, but the instance type of `Class` is `Object`, because a class is an object. (Note: in this point I'm a bit confused, but the important thing to know is that we go from `Int32.class` to `Class` and we lost the information of from which class we came from, to go back to it when matching against `T.class`).

This PR changes the above so that the type of `Int32.class` is a new metaclass called `Int32.class.class`, whose instance type is `Int32.class` (and this is repeated indefinitely, so you have `Int32.class.class.class`, they are created on the fly). The good thing about this is that it can go back to `Int32.class` via its instance type.

And so, the above matching works as expected, and we can write `be_a` as a method (an in general many macros that are based on types can be now always written as methods, which is always good).

I'm not sure which metamodel representation is better, but it might not matter much: one usually doesn't dabble at that level, and as long as it works as expected it's probably fine.

I also thought of an alternative: having the type of `Int32.class` be `Class`, but one whose instance type point to `Int32.class`. In that way we would have many `Class` types on the implementation side, but from the outside they would look like a single one. I think this is a bit harder to implement and at this point it might not be worth it, so I went with this simpler approach.