### PR TITLE
Overflow prepare stdlib

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -895,7 +895,7 @@ describe "Hash" do
   end
 
   it "doesn't generate a negative index for the bucket index (#2321)" do
-    items = (0..100000).map { rand(100000).to_i16 }
+    items = (0..100000).map { rand(100000).to_i16! }
     items.uniq.size
   end
 

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -202,7 +202,7 @@ describe "Number" do
     slice.size.should eq(3)
     slice[0].should eq(1)
     slice[1].should eq(2)
-    slice[2].should eq(300.to_u8)
+    slice[2].should eq(300.to_u8!)
   end
 
   it "creates a static array" do
@@ -211,7 +211,7 @@ describe "Number" do
     ary.size.should eq(3)
     ary[0].should eq(1)
     ary[1].should eq(2)
-    ary[2].should eq(300.to_u8)
+    ary[2].should eq(300.to_u8!)
   end
 
   it "test zero?" do

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -250,9 +250,9 @@ module Base64
       break if cstr > endcstr
       a, b, c, d = next_decoded_value, next_decoded_value, next_decoded_value, next_decoded_value
 
-      yield (a << 2 | b >> 4).to_u8
-      yield (b << 4 | c >> 2).to_u8
-      yield (c << 6 | d).to_u8
+      yield (a << 2 | b >> 4).to_u8!
+      yield (b << 4 | c >> 2).to_u8!
+      yield (c << 6 | d).to_u8!
     end
 
     while (cstr < endcstr + 4) && (cstr.value == NL || cstr.value == NR)
@@ -262,11 +262,11 @@ module Base64
     mod = (endcstr - cstr) % 4
     if mod == 2
       a, b = next_decoded_value, next_decoded_value
-      yield (a << 2 | b >> 4).to_u8
+      yield (a << 2 | b >> 4).to_u8!
     elsif mod == 3
       a, b, c = next_decoded_value, next_decoded_value, next_decoded_value
-      yield (a << 2 | b >> 4).to_u8
-      yield (b << 4 | c >> 2).to_u8
+      yield (a << 2 | b >> 4).to_u8!
+      yield (b << 4 | c >> 2).to_u8!
     elsif mod != 0
       raise Error.new("Wrong size")
     end

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -200,7 +200,7 @@ struct Char
       end
 
       if first < 0xe0
-        return yield (first << 6) + (second - 0x3080), 2, nil
+        return yield (first << 6) &+ (second &- 0x3080), 2, nil
       end
 
       third = byte_at?(pos + 2)
@@ -217,7 +217,7 @@ struct Char
           invalid_byte_sequence 3
         end
 
-        return yield (first << 12) + (second << 6) + (third - 0xE2080), 3, nil
+        return yield (first << 12) &+ (second << 6) &+ (third &- 0xE2080), 3, nil
       end
 
       if first == 0xf0 && second < 0x90
@@ -236,7 +236,7 @@ struct Char
       end
 
       if first < 0xf5
-        return yield (first << 18) + (second << 12) + (third << 6) + (fourth - 0x3C82080), 4, nil
+        return yield (first << 18) &+ (second << 12) &+ (third << 6) &+ (fourth &- 0x3C82080), 4, nil
       end
 
       invalid_byte_sequence 4

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -115,10 +115,10 @@ class Crypto::Bcrypt
     j = -1
 
     cipher.size.times do |i|
-      ret[j += 1] = (cdata[i] >> 24).to_u8
-      ret[j += 1] = (cdata[i] >> 16).to_u8
-      ret[j += 1] = (cdata[i] >> 8).to_u8
-      ret[j += 1] = cdata[i].to_u8
+      ret[j += 1] = (cdata[i] >> 24).to_u8!
+      ret[j += 1] = (cdata[i] >> 16).to_u8!
+      ret[j += 1] = (cdata[i] >> 8).to_u8!
+      ret[j += 1] = cdata[i].to_u8!
     end
 
     ret

--- a/src/crypto/bcrypt/base64.cr
+++ b/src/crypto/bcrypt/base64.cr
@@ -68,18 +68,18 @@ module Crypto::Bcrypt::Base64
       break if c1 == -1 || c2 == -1
       off += 2
 
-      str[i += 1] = ((c1 << 2) | (c2 & 0x30) >> 4).to_u8
+      str[i += 1] = ((c1 << 2) | (c2 & 0x30) >> 4).to_u8!
       break if (olen += 1) >= maxolen || off >= slen
 
       c3 = char64(string[off])
       break if c3 == -1
       off += 1
 
-      str[i += 1] = (((c2 & 0x0f) << 4) | ((c3 & 0x3c) >> 2)).to_u8
+      str[i += 1] = (((c2 & 0x0f) << 4) | ((c3 & 0x3c) >> 2)).to_u8!
       break if (olen += 1) >= maxolen || off >= slen
 
       c4 = char64(string[off])
-      str[i += 1] = (((c3 & 0x03) << 6) | c4).to_u8
+      str[i += 1] = (((c3 & 0x03) << 6) | c4).to_u8!
       off += 1
       olen += 1
     end

--- a/src/crypto/blowfish.cr
+++ b/src/crypto/blowfish.cr
@@ -73,7 +73,7 @@ class Crypto::Blowfish
     c = (x >> 8) & 0xff_u32
     b = (x >> 16) & 0xff_u32
     a = (x >> 24) & 0xff_u32
-    ((@s.to_unsafe[a] + @s1[b]) ^ @s2[c]) + @s3[d]
+    ((@s.to_unsafe[a] &+ @s1[b]) ^ @s2[c]) &+ @s3[d]
   end
 
   private def next_word(data, pos)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -93,8 +93,8 @@ struct Crystal::Hasher
   end
 
   private def permute(v : UInt64)
-    @a = rotl32(@a ^ v) * C1
-    @b = (rotl32(@b) ^ v) * C2
+    @a = rotl32(@a ^ v) &* C1
+    @b = (rotl32(@b) ^ v) &* C2
     self
   end
 
@@ -102,16 +102,16 @@ struct Crystal::Hasher
     a, b = @a, @b
     a ^= (a >> 23) ^ (a >> 40)
     b ^= (b >> 23) ^ (b >> 40)
-    a *= C1
-    b *= C2
+    a &*= C1
+    b &*= C2
     a ^= a >> 32
     b ^= b >> 32
-    a + b
+    a &+ b
   end
 
   def nil
-    @a += @b
-    @b += 1
+    @a &+= @b
+    @b &+= 1
     self
   end
 

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -45,7 +45,7 @@ module Debug
           code = DWARF.read_unsigned_leb128(@io)
           attributes.clear
 
-          if abbrev = abbreviations[code - 1]? # abbreviations.find { |a| a.code == abbrev }
+          if abbrev = abbreviations[code &- 1]? # abbreviations.find { |a| a.code == abbrev }
             abbrev.attributes.each do |attr|
               value = read_attribute_value(attr.form)
               attributes << {attr.at, attr.form, value}

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -288,8 +288,7 @@ module Debug
             adjusted_opcode = opcode - sequence.opcode_base
             operation_advance = adjusted_opcode / sequence.line_range
             increment_address_and_op_index(operation_advance)
-
-            registers.line += sequence.line_base + (adjusted_opcode % sequence.line_range)
+            registers.line &+= sequence.line_base + (adjusted_opcode % sequence.line_range)
             register_to_matrix(sequence, registers)
             registers.reset
           elsif opcode == 0
@@ -331,7 +330,7 @@ module Debug
               operation_advance = DWARF.read_unsigned_leb128(@io)
               increment_address_and_op_index(operation_advance)
             when LNS::AdvanceLine
-              registers.line += DWARF.read_signed_leb128(@io)
+              registers.line &+= DWARF.read_signed_leb128(@io)
             when LNS::SetFile
               registers.file = DWARF.read_unsigned_leb128(@io)
             when LNS::SetColumn

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -103,27 +103,27 @@ class Digest::MD5 < Digest::Base
   end
 
   def ff(a, b, c, d, x, s, ac)
-    a += f(b, c, d) + x + ac.to_u32
+    a &+= f(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
-    a += b
+    a &+= b
   end
 
   def gg(a, b, c, d, x, s, ac)
-    a += g(b, c, d) + x + ac.to_u32
+    a &+= g(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
-    a += b
+    a &+= b
   end
 
   def hh(a, b, c, d, x, s, ac)
-    a += h(b, c, d) + x + ac.to_u32
+    a &+= h(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
-    a += b
+    a &+= b
   end
 
   def ii(a, b, c, d, x, s, ac)
-    a += i(b, c, d) + x + ac.to_u32
+    a &+= i(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
-    a += b
+    a &+= b
   end
 
   def transform(in)
@@ -201,10 +201,10 @@ class Digest::MD5 < Digest::Base
     c = ii(c, d, a, b, in[2], S43, 718787259)   # 63
     b = ii(b, c, d, a, in[9], S44, 3951481745)  # 64
 
-    @buf[0] += a
-    @buf[1] += b
-    @buf[2] += c
-    @buf[3] += d
+    @buf[0] &+= a
+    @buf[1] &+= b
+    @buf[2] &+= c
+    @buf[3] &+= d
   end
 
   def final

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -67,8 +67,8 @@ class Digest::SHA1 < Digest::Base
     e = @intermediate_hash[4]
 
     {% for t in (0...20) %}
-      temp = circular_shift(5, a) +
-        ((b & c) | ((~b) & d)) + e + w[{{t}}] + k[0]
+      temp = circular_shift(5, a) &+
+        ((b & c) | ((~b) & d)) &+ e &+ w[{{t}}] &+ k[0]
       e = d
       d = c
       c = circular_shift(30, b)
@@ -77,7 +77,7 @@ class Digest::SHA1 < Digest::Base
     {% end %}
 
     {% for t in (20...40) %}
-      temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[1]
+      temp = circular_shift(5, a) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[1]
       e = d
       d = c
       c = circular_shift(30, b)
@@ -86,8 +86,8 @@ class Digest::SHA1 < Digest::Base
     {% end %}
 
     {% for t in (40...60) %}
-      temp = circular_shift(5, a) +
-        ((b & c) | (b & d) | (c & d)) + e + w[{{t}}] + k[2]
+      temp = circular_shift(5, a) &+
+        ((b & c) | (b & d) | (c & d)) &+ e &+ w[{{t}}] &+ k[2]
       e = d
       d = c
       c = circular_shift(30, b)
@@ -96,7 +96,7 @@ class Digest::SHA1 < Digest::Base
     {% end %}
 
     {% for t in (60...80) %}
-      temp = circular_shift(5, a) + (b ^ c ^ d) + e + w[{{t}}] + k[3]
+      temp = circular_shift(5, a) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[3]
       e = d
       d = c
       c = circular_shift(30, b)
@@ -104,11 +104,11 @@ class Digest::SHA1 < Digest::Base
       a = temp
     {% end %}
 
-    @intermediate_hash[0] += a
-    @intermediate_hash[1] += b
-    @intermediate_hash[2] += c
-    @intermediate_hash[3] += d
-    @intermediate_hash[4] += e
+    @intermediate_hash[0] &+= a
+    @intermediate_hash[1] &+= b
+    @intermediate_hash[2] &+= c
+    @intermediate_hash[3] &+= d
+    @intermediate_hash[4] &+= e
 
     @message_block_index = 0
   end
@@ -127,7 +127,7 @@ class Digest::SHA1 < Digest::Base
     @length_low = 0_u32
     @length_high = 0_u32
     {% for i in 0...20 %}
-      message_digest[{{i}}] = (@intermediate_hash[{{i >> 2}}] >> 8 * (3 - ({{i & 0x03}}))).to_u8
+      message_digest[{{i}}] = (@intermediate_hash[{{i >> 2}}] >> 8 * (3 - ({{i & 0x03}}))).to_u8!
     {% end %}
 
     message_digest
@@ -157,14 +157,14 @@ class Digest::SHA1 < Digest::Base
       end
     end
 
-    @message_block[56] = (@length_high >> 24).to_u8
-    @message_block[57] = (@length_high >> 16).to_u8
-    @message_block[58] = (@length_high >> 8).to_u8
-    @message_block[59] = (@length_high).to_u8
-    @message_block[60] = (@length_low >> 24).to_u8
-    @message_block[61] = (@length_low >> 16).to_u8
-    @message_block[62] = (@length_low >> 8).to_u8
-    @message_block[63] = (@length_low).to_u8
+    @message_block[56] = (@length_high >> 24).to_u8!
+    @message_block[57] = (@length_high >> 16).to_u8!
+    @message_block[58] = (@length_high >> 8).to_u8!
+    @message_block[59] = (@length_high).to_u8!
+    @message_block[60] = (@length_low >> 24).to_u8!
+    @message_block[61] = (@length_low >> 16).to_u8!
+    @message_block[62] = (@length_low >> 8).to_u8!
+    @message_block[63] = (@length_low).to_u8!
 
     process_message_block
   end

--- a/src/float/printer/grisu3.cr
+++ b/src/float/printer/grisu3.cr
@@ -155,7 +155,7 @@ module Float::Printer::Grisu3
     #   Since too_low = too_high - unsafe_interval this is equivalent to
     #      [too_high - unsafe_interval + 4 ulp; too_high - 2 ulp]
     #   Conceptually we have: rest ~= too_high - buffer
-    return (2 * unit <= rest) && (rest <= unsafe_interval - 4 * unit)
+    return (2 &* unit <= rest) && (rest <= unsafe_interval &- 4 &* unit)
   end
 
   # Generates the digits of input number *w*.

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -152,7 +152,7 @@ module Float::Printer::IEEE
       exp = 1 - EXPONENT_BIAS_64
     else
       frac = (d64 & SIGNIFICAND_MASK_64) + HIDDEN_BIT_64
-      exp = (((d64 & EXPONENT_MASK_64) >> PHYSICAL_SIGNIFICAND_SIZE_64) - EXPONENT_BIAS_64).to_i
+      exp = (((d64 & EXPONENT_MASK_64) >> PHYSICAL_SIGNIFICAND_SIZE_64) &- EXPONENT_BIAS_64).to_i!
     end
 
     {frac, exp}
@@ -166,7 +166,7 @@ module Float::Printer::IEEE
       exp = 1 - EXPONENT_BIAS_32
     else
       frac = (d32 & SIGNIFICAND_MASK_32) + HIDDEN_BIT_32
-      exp = (((d32 & EXPONENT_MASK_32) >> PHYSICAL_SIGNIFICAND_SIZE_32) - EXPONENT_BIAS_32).to_i
+      exp = (((d32 & EXPONENT_MASK_32) >> PHYSICAL_SIGNIFICAND_SIZE_32) &- EXPONENT_BIAS_32).to_i!
     end
 
     {frac.to_u64, exp}

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -892,7 +892,7 @@ class Hash(K, V)
       copy = hasher
       copy = key.hash(copy)
       copy = value.hash(copy)
-      result += copy.result
+      result &+= copy.result
     end
 
     result.hash(hasher)

--- a/src/iconv.cr
+++ b/src/iconv.cr
@@ -19,7 +19,7 @@ struct Iconv
 
     @iconv = LibC.iconv_open(to, from)
 
-    if @iconv.address == LibC::SizeT.new(-1)
+    if @iconv.address == ERROR
       if Errno.value == Errno::EINVAL
         if original_from == "UTF-8"
           raise ArgumentError.new("Invalid encoding: #{original_to}")

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -68,7 +68,7 @@ end
 
 {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
   def {{type.id}}.new(pull : JSON::PullParser)
-    {{type.id}}.new(pull.read_int)
+    {{type.id}}.new!(pull.read_int)
   end
 {% end %}
 

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -213,6 +213,8 @@ abstract class JSON::Lexer
   end
 
   private def consume_number
+    # TODO once overflow is the deafult the overflow custom logic can be refactored
+
     number_start
 
     integer = 0_i64
@@ -248,8 +250,8 @@ abstract class JSON::Lexer
       char = next_char
       while '0' <= char <= '9'
         append_number_char
-        integer *= 10
-        integer += char - '0'
+        integer &*= 10
+        integer &+= char - '0'
         digits += 1
         char = next_char
       end
@@ -270,6 +272,8 @@ abstract class JSON::Lexer
   end
 
   private def consume_float(negative, integer, digits)
+    # TODO once overflow is the deafult the overflow custom logic can be refactored
+
     append_number_char
     divisor = 1_u64
     char = next_char
@@ -280,9 +284,9 @@ abstract class JSON::Lexer
 
     while '0' <= char <= '9'
       append_number_char
-      integer *= 10
-      integer += char - '0'
-      divisor *= 10
+      integer &*= 10
+      integer &+= char - '0'
+      divisor &*= 10
       digits += 1
       char = next_char
     end
@@ -303,6 +307,8 @@ abstract class JSON::Lexer
   end
 
   private def consume_exponent(negative, float, digits)
+    # TODO once overflow is the deafult the overflow custom logic can be refactored
+
     append_number_char
     exponent = 0
     negative_exponent = false

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -250,35 +250,35 @@ class JSON::PullParser
   end
 
   def read?(klass : Int8.class)
-    read_int.to_i8 if kind == :int
+    read_int.to_i8! if kind == :int
   end
 
   def read?(klass : Int16.class)
-    read_int.to_i16 if kind == :int
+    read_int.to_i16! if kind == :int
   end
 
   def read?(klass : Int32.class)
-    read_int.to_i32 if kind == :int
+    read_int.to_i32! if kind == :int
   end
 
   def read?(klass : Int64.class)
-    read_int.to_i64 if kind == :int
+    read_int.to_i64! if kind == :int
   end
 
   def read?(klass : UInt8.class)
-    read_int.to_u8 if kind == :int
+    read_int.to_u8! if kind == :int
   end
 
   def read?(klass : UInt16.class)
-    read_int.to_u16 if kind == :int
+    read_int.to_u16! if kind == :int
   end
 
   def read?(klass : UInt32.class)
-    read_int.to_u32 if kind == :int
+    read_int.to_u32! if kind == :int
   end
 
   def read?(klass : UInt64.class)
-    read_int.to_u64 if kind == :int
+    read_int.to_u64! if kind == :int
   end
 
   def read?(klass : Float32.class)

--- a/src/number.cr
+++ b/src/number.cr
@@ -47,7 +47,7 @@ struct Number
   macro slice(*nums, read_only = false)
     %slice = Slice({{@type}}).new({{nums.size}}, read_only: {{read_only}})
     {% for num, i in nums %}
-      %slice.to_unsafe[{{i}}] = {{@type}}.new({{num}})
+      %slice.to_unsafe[{{i}}] = {{@type}}.new!({{num}})
     {% end %}
     %slice
   end
@@ -65,7 +65,7 @@ struct Number
   macro static_array(*nums)
     %array = uninitialized StaticArray({{@type}}, {{nums.size}})
     {% for num, i in nums %}
-      %array.to_unsafe[{{i}}] = {{@type}}.new({{num}})
+      %array.to_unsafe[{{i}}] = {{@type}}.new!({{num}})
     {% end %}
     %array
   end

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -95,7 +95,7 @@ struct Pointer(T)
     # TODO: If throwing on overflow for integer conversion is implemented,
     # then (here and in `Pointer#-`) for a `UInt64` argument the call to
     # `to_i64` should become `as_unsafe`.
-    self + (-other.to_i64)
+    self + (-other.to_i64!)
   end
 
   # Returns -1, 0 or 1 if this pointer's address is less, equal or greater than *other*'s address,

--- a/src/random.cr
+++ b/src/random.cr
@@ -156,12 +156,12 @@ module Random
         # are described below.
 
         # if max - 1 <= typeof(next_u)::MAX
-        if typeof(next_u).new(max - 1) == max - 1
+        if typeof(next_u).new!(max &- 1) == max &- 1
           # One number from the RNG will be enough.
           # All the computations will (almost) fit into `typeof(next_u)`.
 
           # Relies on integer overflow + wraparound to find the highest number divisible by *max*.
-          limit = typeof(next_u).new(0) - (typeof(next_u).new(0) - max) % max
+          limit = typeof(next_u).new(0) &- (typeof(next_u).new(0) &- max) % max
           # *limit* might be 0, which means it would've been `typeof(next_u)::MAX + 1, but didn't
           # fit into the integer type.
 
@@ -170,7 +170,7 @@ module Random
 
             # For a uniform distribution we may need to throw away some numbers
             if result < limit || limit == 0
-              return {{type}}.new(result % max)
+              return {{type}}.new!(result % max)
             end
           end
         else
@@ -192,12 +192,12 @@ module Random
           limit =
             if rand_max > 0
               # `rand_max` didn't overflow, so we can calculate the *limit* the straightforward way.
-              rand_max / max * max
+              rand_max / max &* max
             else
               # *rand_max* is `{{utype}}::MAX + 1`, need the same wraparound trick. *limit* might
               # overflow, which means it would've been `{{utype}}::MAX + 1`, but didn't fit into
               # the integer type.
-              {{utype}}.new(0) - ({{utype}}.new(0) - max) % max
+              {{utype}}.new(0) &- ({{utype}}.new(0) &- max) % max
             end
 
           loop do
@@ -212,7 +212,7 @@ module Random
       end
 
       private def rand_range(range : Range({{type}}, {{type}})) : {{type}}
-        span = {{utype}}.new(range.end - range.begin)
+        span = {{utype}}.new!(range.end &- range.begin)
         if range.excludes_end?
           unless range.begin < range.end
             raise ArgumentError.new "Invalid range for rand: #{range}"
@@ -226,18 +226,18 @@ module Random
           end
           span += 1
         end
-        range.begin + {{type}}.new(rand_int(span))
+        range.begin + {{type}}.new!(rand_int(span))
       end
 
       # Generates a random integer in range `{{type}}::MIN..{{type}}::MAX`.
       private def rand_type(type : {{type}}.class, needed_parts = sizeof({{type}}) / sizeof(typeof(next_u))) : {{type}}
         # Build up the number combining multiple outputs from the RNG.
-        result = {{utype}}.new(next_u)
+        result = {{utype}}.new!(next_u)
         (needed_parts - 1).times do
           result <<= sizeof(typeof(next_u))*8
-          result |= {{utype}}.new(next_u)
+          result |= {{utype}}.new!(next_u)
         end
-        {{type}}.new(result)
+        {{type}}.new!(result)
       end
     {% end %}
   {% end %}

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -43,8 +43,8 @@ class Random::ISAAC
   end
 
   private def isaac
-    @cc += 1
-    @bb += cc
+    @cc &+= 1
+    @bb &+= cc
 
     256.times do |i|
       @aa ^= case i % 4
@@ -54,9 +54,9 @@ class Random::ISAAC
              else        aa >> 16
              end
       x = @mm[i]
-      @aa = @mm[(i + 128) % 256] + aa
-      @mm[i] = y = @mm[(x >> 2) % 256] + aa + bb
-      @rsl[i] = @bb = @mm[(y >> 10) % 256] + x
+      @aa = @mm[(i + 128) % 256] &+ aa
+      @mm[i] = y = @mm[(x >> 2) % 256] &+ aa &+ bb
+      @rsl[i] = @bb = @mm[(y >> 10) % 256] &+ x
     end
   end
 
@@ -67,21 +67,21 @@ class Random::ISAAC
     a = b = c = d = e = f = g = h = 0x9e3779b9_u32
 
     mix = ->{
-      a ^= b << 11; d += a; b += c
-      b ^= c >> 2; e += b; c += d
-      c ^= d << 8; f += c; d += e
-      d ^= e >> 16; g += d; e += f
-      e ^= f << 10; h += e; f += g
-      f ^= g >> 4; a += f; g += h
-      g ^= h << 8; b += g; h += a
-      h ^= a >> 9; c += h; a += b
+      a ^= b << 11; d &+= a; b &+= c
+      b ^= c >> 2; e &+= b; c &+= d
+      c ^= d << 8; f &+= c; d &+= e
+      d ^= e >> 16; g &+= d; e &+= f
+      e ^= f << 10; h &+= e; f &+= g
+      f ^= g >> 4; a &+= f; g &+= h
+      g ^= h << 8; b &+= g; h &+= a
+      h ^= a >> 9; c &+= h; a &+= b
     }
     4.times(&mix)
 
     scramble = ->(seed : StaticArray(UInt32, 256)) {
       0.step(to: 255, by: 8) do |i|
-        a += seed[i]; b += seed[i + 1]; c += seed[i + 2]; d += seed[i + 3]
-        e += seed[i + 4]; f += seed[i + 5]; g += seed[i + 6]; h += seed[i + 7]
+        a &+= seed[i]; b &+= seed[i + 1]; c &+= seed[i + 2]; d &+= seed[i + 3]
+        e &+= seed[i + 4]; f &+= seed[i + 5]; g &+= seed[i + 6]; h &+= seed[i + 7]
         mix.call
         @mm[i] = a; @mm[i + 1] = b; @mm[i + 2] = c; @mm[i + 3] = d
         @mm[i + 4] = e; @mm[i + 5] = f; @mm[i + 6] = g; @mm[i + 7] = h

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -58,16 +58,16 @@ class Random::PCG32
     @state = 0_u64
     @inc = (initseq << 1) | 1
     next_u
-    @state += initstate
+    @state &+= initstate
     next_u
   end
 
   def next_u
     oldstate = @state
-    @state = oldstate * PCG_DEFAULT_MULTIPLIER_64 + @inc
-    xorshifted = UInt32.new(((oldstate >> 18) ^ oldstate) >> 27)
-    rot = UInt32.new(oldstate >> 59)
-    return UInt32.new((xorshifted >> rot) | (xorshifted << ((~rot + 1) & 31)))
+    @state = oldstate &* PCG_DEFAULT_MULTIPLIER_64 &+ @inc
+    xorshifted = UInt32.new!(((oldstate >> 18) ^ oldstate) >> 27)
+    rot = UInt32.new!(oldstate >> 59)
+    return UInt32.new!((xorshifted >> rot) | (xorshifted << ((~rot &+ 1) & 31)))
   end
 
   def jump(delta)
@@ -78,13 +78,13 @@ class Random::PCG32
     cur_mult = PCG_DEFAULT_MULTIPLIER_64
     while (deltau64 > 0)
       if deltau64 & 1 > 0
-        acc_mult *= cur_mult
-        acc_plus = acc_plus * cur_mult + cur_plus
+        acc_mult &*= cur_mult
+        acc_plus = acc_plus &* cur_mult &+ cur_plus
       end
-      cur_plus = (cur_mult + 1) * cur_plus
-      cur_mult *= cur_mult
+      cur_plus = (cur_mult &+ 1) &* cur_plus
+      cur_mult &*= cur_mult
       deltau64 /= 2
     end
-    @state = acc_mult * @state + acc_plus
+    @state = acc_mult &* @state &+ acc_plus
   end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -582,7 +582,7 @@ class String
       value *= base
 
       old = value
-      value += digit
+      value &+= digit
       if value < old
         invalid = true
         break
@@ -2531,7 +2531,7 @@ class String
       {% if i != 1 %}
         byte = head_pointer.value
       {% end %}
-      hash = hash * PRIME_RK + pointer.value - pow * byte
+      hash = hash &* PRIME_RK &+ pointer.value &- pow &* byte
       pointer += 1
       head_pointer += 1
     {% end %}
@@ -2579,9 +2579,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.each_byte do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = search_hash &* PRIME_RK &+ b
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK &** search.bytesize
 
     # Find start index with offset
     char_index = 0
@@ -2608,7 +2608,7 @@ class String
     hash_end_pointer = pointer + search.bytesize
     return if hash_end_pointer > end_pointer
     while pointer < hash_end_pointer
-      hash = hash * PRIME_RK + pointer.value
+      hash = hash &* PRIME_RK &+ pointer.value
       pointer += 1
     end
 
@@ -2695,9 +2695,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.to_slice.reverse_each do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = search_hash &* PRIME_RK &+ b
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK &** search.bytesize
 
     hash = 0u32
     char_index = size
@@ -2715,7 +2715,7 @@ class String
       byte = pointer.value
       char_index -= 1 if (byte & 0xC0) != 0x80
 
-      hash = hash * PRIME_RK + byte
+      hash = hash &* PRIME_RK &+ byte
     end
 
     while true
@@ -2733,7 +2733,7 @@ class String
       char_index -= 1 if (byte & 0xC0) != 0x80
 
       # update a rolling hash of this text (haystack)
-      hash = hash * PRIME_RK + byte - pow * tail_pointer.value
+      hash = hash &* PRIME_RK &+ byte &- pow &* tail_pointer.value
     end
   end
 
@@ -2869,9 +2869,9 @@ class String
     # calculate a rolling hash of search text (needle)
     search_hash = 0u32
     search.each_byte do |b|
-      search_hash = search_hash * PRIME_RK + b
+      search_hash = search_hash &* PRIME_RK &+ b
     end
-    pow = PRIME_RK ** search.bytesize
+    pow = PRIME_RK &** search.bytesize
 
     # calculate a rolling hash of this text (haystack)
     pointer = head_pointer = to_unsafe + offset
@@ -2880,7 +2880,7 @@ class String
     hash = 0u32
     return if hash_end_pointer > end_pointer
     while pointer < hash_end_pointer
-      hash = hash * PRIME_RK + pointer.value
+      hash = hash &* PRIME_RK &+ pointer.value
       pointer += 1
     end
 
@@ -2893,7 +2893,7 @@ class String
       return if pointer >= end_pointer
 
       # update a rolling hash of this text (haystack)
-      hash = hash * PRIME_RK + pointer.value - pow * head_pointer.value
+      hash = hash &* PRIME_RK &+ pointer.value &- pow &* head_pointer.value
       pointer += 1
       head_pointer += 1
       offset += 1

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -96,11 +96,13 @@ struct Time::Span
   end
 
   private def self.compute_seconds(days, hours, minutes, seconds, raise_exception)
+    # TODO once overflow is the deafult this can be refactored
+
     # there's no overflow checks for hours, minutes, ...
     # so big hours/minutes values can overflow at some point and change expected values
-    hrssec = 3600_i64 * hours # break point at (Int32::MAX - 596523)
-    minsec = 60_i64 * minutes
-    s = hrssec + minsec + seconds
+    hrssec = 3600_i64 &* hours # break point at (Int32::MAX - 596523)
+    minsec = 60_i64 &* minutes
+    s = hrssec &+ minsec &+ seconds
 
     result = 0_i64
 
@@ -109,7 +111,7 @@ struct Time::Span
     # "legal" (i.e. temporary) (e.g. if other parameters are negative) or
     # illegal (e.g. sign change).
     if days > 0
-      sd = SECONDS_PER_DAY.to_i64 * days
+      sd = SECONDS_PER_DAY.to_i64 &* days
       if sd < days
         overflow = true
       elsif s < 0
@@ -123,7 +125,7 @@ struct Time::Span
         overflow = s < 0
       end
     elsif days < 0
-      sd = SECONDS_PER_DAY.to_i64 * days
+      sd = SECONDS_PER_DAY.to_i64 &* days
       if sd > days
         overflow = true
       elsif s <= 0

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -48,7 +48,7 @@ end
 
 {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
   def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-    {{type.id}}.new parse_scalar(ctx, node, Int64)
+    {{type.id}}.new! parse_scalar(ctx, node, Int64)
   end
 {% end %}
 
@@ -57,7 +57,7 @@ def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
 end
 
 def Float32.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-  parse_scalar(ctx, node, Float64).to_f32
+  parse_scalar(ctx, node, Float64).to_f32!
 end
 
 def Float64.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)


### PR DESCRIPTION
The PR updates the stdlib to use unchecked operations & conversions where needed.

The changes should be read as: keep the current semantic once the operations will default to overflowing.

Some changes direct make sense because they manipulate data as bits mainly (eg: hasher).
Some might look a bit odd (eg: dwarf,  floatprinter). The changes were required to make specs pass once the overflow is turned on.
Other changes can be revised in future version (eg: time) since there is manual detection of overflow that could be simpler in the future.