### PR TITLE
Refactor `crystal tool format` command completely

### DIFF
--- a/spec/compiler/crystal/tools/format.cr
+++ b/spec/compiler/crystal/tools/format.cr
@@ -1,0 +1,291 @@
+require "spec"
+require "compiler/crystal/formatter"
+require "compiler/crystal/command/format"
+require "../../../support/tempfile"
+
+private class BuggyFormatCommand < Crystal::Command::FormatCommand
+  def format(filename, source)
+    raise "format command test"
+  end
+end
+
+describe Crystal::Command::FormatCommand do
+  it "formats stdin" do
+    stdin = IO::Memory.new "if true\n1\nend"
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(0)
+    stdout.to_s.should eq("if true\n  1\nend\n")
+    stderr.to_s.empty?.should be_true
+  end
+
+  it "formats stdin (ok)" do
+    stdin = IO::Memory.new "if true\n  1\nend\n"
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(0)
+    stdout.to_s.should eq("if true\n  1\nend\n")
+    stderr.to_s.empty?.should be_true
+  end
+
+  it "formats stdin (syntax error)" do
+    stdin = IO::Memory.new "if"
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(1)
+    stdout.to_s.empty?.should be_true
+    stderr.to_s.should contain("Syntax error in STDIN:1: unexpected token: EOF")
+  end
+
+  it "formats stdin (invalid byte sequence error)" do
+    stdin = IO::Memory.new "\xfe\xff"
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(1)
+    stdout.to_s.empty?.should be_true
+    stderr.to_s.should contain("file 'STDIN' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+  end
+
+  it "formats stdin (bug)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = BuggyFormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(1)
+    stdout.to_s.empty?.should be_true
+    stderr.to_s.should contain("there's a bug formatting 'STDIN', to show more information, please run:\n\n  $ crystal tool format --show-backtrace -")
+  end
+
+  it "formats stdin (bug + show-backtrace)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    format_command = BuggyFormatCommand.new(["-"], show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command.run
+    format_command.status_code.should eq(1)
+    stdout.to_s.empty?.should be_true
+    stderr.to_s.should contain("format command test")
+    stderr.to_s.should contain("couldn't format 'STDIN', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues")
+  end
+
+  it "formats files" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("format_files") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(0)
+        stdout.to_s.should contain("Format ./format.cr")
+        stdout.to_s.should_not contain("Format ./not_format.cr")
+        stderr.to_s.empty?.should be_true
+
+        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
+      end
+    end
+  end
+
+  it "formats files (dir)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("format_files") do |path|
+      FileUtils.mkdir_p File.join(path, "dir")
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+        File.write File.join(path, "dir", "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "dir", "not_format.cr"), "if true\n  1\nend\n"
+
+        format_command = Crystal::Command::FormatCommand.new(["dir"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(0)
+        stdout.to_s.should contain("Format ./dir/format.cr")
+        stdout.to_s.should_not contain("Format ./dir/not_format.cr")
+        stderr.to_s.empty?.should be_true
+
+        {stdout, stderr}.each &.clear
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(0)
+        stdout.to_s.should contain("Format ./format.cr")
+        stdout.to_s.should_not contain("Format ./not_format.cr")
+        stdout.to_s.should_not contain("Format ./dir/format.cr")
+        stdout.to_s.should_not contain("Format ./dir/not_format.cr")
+        stderr.to_s.empty?.should be_true
+
+        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
+        File.read(File.join(path, "dir", "format.cr")).should eq("if true\n  1\nend\n")
+      end
+    end
+  end
+
+  it "formats files (error)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("format_files_error") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "syntax_error.cr"), "if"
+        File.write File.join(path, "invalid_byte_sequence_error.cr"), "\xfe\xff"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(1)
+        stdout.to_s.should contain("Format ./format.cr")
+        stderr.to_s.should contain("Syntax error in ./syntax_error.cr:1: unexpected token: EOF")
+        stderr.to_s.should contain("file './invalid_byte_sequence_error.cr' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+
+        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
+      end
+    end
+  end
+
+  it "formats files (bug)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("format_files_bug") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "empty.cr"), ""
+
+        format_command = BuggyFormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(1)
+        stderr.to_s.should contain("there's a bug formatting './empty.cr', to show more information, please run:\n\n  $ crystal tool format --show-backtrace './empty.cr'")
+      end
+    end
+  end
+
+  it "formats files (bug + show-stacktrace)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("format_files_bug_show_stacktrace") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "empty.cr"), ""
+
+        format_command = BuggyFormatCommand.new([] of String, show_backtrace: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(1)
+        stderr.to_s.should contain("format command test")
+        stderr.to_s.should contain("couldn't format './empty.cr', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues")
+      end
+    end
+  end
+
+  it "checks files format" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("check_files_format") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+        File.write File.join(path, "syntax_error.cr"), "if"
+        File.write File.join(path, "invalid_byte_sequence_error.cr"), "\xfe\xff"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(1)
+        stdout.to_s.empty?.should be_true
+        stderr.to_s.should_not contain("not_format.cr")
+        stderr.to_s.should contain("formatting './format.cr' produced changes")
+        stderr.to_s.should contain("Syntax error in ./syntax_error.cr:1: unexpected token: EOF")
+        stderr.to_s.should contain("file './invalid_byte_sequence_error.cr' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+      end
+    end
+  end
+
+  it "checks files format (ok)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("check_files_format_ok") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format1.cr"), "if true\n  1\nend\n"
+        File.write File.join(path, "format2.cr"), "if true\n  2\nend\n"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(0)
+        stdout.to_s.empty?.should be_true
+        stderr.to_s.empty?.should be_true
+      end
+    end
+  end
+
+  it "checks files format (excludes)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("check_files_format_excludes") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(0)
+        stdout.to_s.empty?.should be_true
+        stderr.to_s.empty?.should be_true
+      end
+    end
+  end
+
+  it "checks files format (excludes + includes)" do
+    stdin = IO::Memory.new ""
+    stdout = IO::Memory.new
+    stderr = IO::Memory.new
+
+    with_tempfile("check_files_format_excludes_includes") do |path|
+      FileUtils.mkdir_p path
+      Dir.cd(path) do
+        File.write File.join(path, "format.cr"), "if true\n1\nend"
+        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+
+        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], includes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+        format_command.run
+        format_command.status_code.should eq(1)
+        stdout.to_s.empty?.should be_true
+        stderr.to_s.should contain("formatting './format.cr' produced changes")
+      end
+    end
+  end
+end

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -4,31 +4,18 @@
 # logic is in `crystal/tools/formatter.cr`.
 
 class Crystal::Command
-  record FormatResult, filename : String, code : Code do
-    enum Code
-      FORMAT
-      SYNTAX
-      INVALID_BYTE_SEQUENCE
-      BUG
-    end
-  end
-
   private def format
-    @format = "text"
     excludes = ["lib"] of String
     includes = [] of String
-    check = nil
+    check = false
+    show_backtrace = false
 
     option_parser =
       OptionParser.parse(options) do |opts|
         opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
 
         opts.on("--check", "Checks that formatting code produces no changes") do |f|
-          check = [] of FormatResult
-        end
-
-        opts.on("-f text|json", "--format text|json", "Output format text (default) or json") do |f|
-          @format = f
+          check = true
         end
 
         opts.on("-i <path>", "--include <path>", "Include path") do |f|
@@ -47,156 +34,157 @@ class Crystal::Command
         opts.on("--no-color", "Disable colored output") do
           @color = false
         end
+
+        opts.on("--show-backtrace", "Show backtrace on a bug (it is only for report!)") do
+          show_backtrace = true
+        end
       end
 
     files = options
-    check_files = check
 
-    if files.size == 1
-      file = files.first
-      if file == "-"
-        return format_stdin(check_files)
+    format_command = FormatCommand.new(
+      files,
+      includes,
+      excludes,
+      check,
+      show_backtrace,
+      @color,
+    )
+    format_command.run
+    exit format_command.status_code
+  end
+
+  class FormatCommand
+    @format_stdin : Bool
+    @files : Array(String)
+    @excludes : Array(String)
+
+    getter status_code = 0
+
+    def initialize(
+      files : Array(String),
+      includes = [] of String, excludes = [] of String,
+      @check : Bool = false,
+      @show_backtrace : Bool = false,
+      @color : Bool = true,
+      # stdio is injectable for testing
+      @stdin : IO = STDIN, @stdout : IO = STDOUT, @stderr : IO = STDERR
+    )
+      @format_stdin = files.size == 1 && files[0] == "-"
+
+      includes = normalize_paths includes
+      excludes = normalize_paths excludes
+      excludes = excludes - includes
+      if files.empty?
+        files = Dir["./**/*.cr"]
+      else
+        files = normalize_paths files
+      end
+
+      @files = files
+      @excludes = excludes
+    end
+
+    private def normalize_paths(paths)
+      path_start = ".#{File::SEPARATOR}"
+      paths.map do |path|
+        path = path_start + path unless path.starts_with?(path_start)
+        path.rstrip(File::SEPARATOR)
       end
     end
 
-    includes = normalize_paths includes
-    excludes = normalize_paths excludes
-    excludes = excludes - includes
-
-    if files.empty?
-      files = Dir["./**/*.cr"]
-    else
-      files = normalize_paths files
+    def run
+      if @format_stdin
+        format_stdin
+      else
+        format_many @files
+      end
     end
 
-    format_many files, check_files, excludes
+    private def format_stdin
+      source = @stdin.gets_to_end
+      format_source "STDIN", source
+    end
 
-    if check_files
-      if check_files.empty?
-        exit 0
-      else
-        check_files.each do |result|
-          case result.code
-          when .format?
-            error "formatting '#{result.filename}' produced changes", exit_code: nil
-          when .syntax?
-            error "'#{result.filename}' has syntax errors", exit_code: nil
-          when .invalid_byte_sequence?
-            error "'#{result.filename}' is not a valid Crystal source file", exit_code: nil
-          when .bug?
-            error "there's a bug formatting '#{result.filename}', to show more information, please run:\n\n  $ crystal tool format '#{result.filename}'", exit_code: nil
-          end
+    private def format_many(files)
+      files.each do |filename|
+        format_file_or_directory filename
+      end
+    end
+
+    private def format_file_or_directory(filename)
+      if File.file?(filename)
+        unless @excludes.any? { |exclude| filename.starts_with?(exclude) }
+          format_file filename
         end
-        exit 1
-      end
-    end
-  end
-
-  private def normalize_paths(paths)
-    path_start = ".#{File::SEPARATOR}"
-    paths.map do |path|
-      path = path_start + path unless path.starts_with?(path_start)
-      path.rstrip(File::SEPARATOR)
-    end
-  end
-
-  private def format_stdin(check_files)
-    source = STDIN.gets_to_end
-
-    begin
-      result = Crystal.format(source)
-      exit(result == source ? 0 : 1) if check_files
-
-      print result
-    rescue ex : InvalidByteSequenceError
-      STDERR.print "Error: ".colorize.toggle(@color).red.bold
-      STDERR.print "source is not a valid Crystal source file: ".colorize.toggle(@color).bold
-      STDERR.puts ex.message
-      exit 1
-    rescue ex : Crystal::SyntaxException
-      if @format == "json"
-        STDERR.puts ex.to_json
+      elsif Dir.exists?(filename)
+        filename = filename.chomp('/')
+        filenames = Dir["#{filename}/**/*.cr"]
+        format_many filenames
       else
-        STDERR.puts ex
+        error "file or directory does not exist: #{filename}"
       end
-      exit 1
-    rescue ex
-      couldnt_format "STDIN", ex
-      STDERR.puts
-      exit 1
     end
-  end
 
-  private def format_many(files, check_files, excludes)
-    files.each do |filename|
-      format_file_or_directory filename, check_files, excludes
+    private def format_file(filename)
+      source = File.read(filename)
+      format_source filename, source
     end
-  end
 
-  private def format_file_or_directory(filename, check_files, excludes)
-    if File.file?(filename)
-      unless excludes.any? { |exclude| filename.starts_with?(exclude) }
-        format_file filename, check_files
-      end
-    elsif Dir.exists?(filename)
-      filename = filename.chomp('/')
-      filenames = Dir["#{filename}/**/*.cr"]
-      format_many filenames, check_files, excludes
-    else
-      error "file or directory does not exist: #{filename}"
-    end
-  end
-
-  private def format_file(filename, check_files)
-    source = File.read(filename)
-
-    begin
-      result = Crystal.format(source, filename: filename)
+    private def format_source(filename, source)
+      result = format(filename, source)
+      @stdout.print result if @format_stdin
       return if result == source
 
-      if check_files
-        check_files << FormatResult.new(filename, FormatResult::Code::FORMAT)
-      else
-        File.write(filename, result)
-        STDOUT << "Format".colorize(:green).toggle(@color) << ' ' << filename << '\n'
-      end
+      on_format filename, result
     rescue ex : InvalidByteSequenceError
-      if check_files
-        check_files << FormatResult.new(filename, FormatResult::Code::INVALID_BYTE_SEQUENCE)
-      else
-        STDERR.print "Error: ".colorize.toggle(@color).red.bold
-        STDERR.print "file '#{Crystal.relative_filename(filename)}' is not a valid Crystal source file: ".colorize.toggle(@color).bold
-        STDERR.puts ex.message
-      end
+      on_invalid_byte_sequence_error filename, ex
     rescue ex : Crystal::SyntaxException
-      if check_files
-        check_files << FormatResult.new(filename, FormatResult::Code::SYNTAX)
-      else
-        STDERR << "Syntax Error:".colorize(:yellow).toggle(@color) << ' ' << ex.message << " at " << filename << ':' << ex.line_number << ':' << ex.column_number << '\n'
-      end
+      on_syntax_error filename, ex
     rescue ex
-      if check_files
-        check_files << FormatResult.new(filename, FormatResult::Code::BUG)
+      on_bug filename, ex
+    end
+
+    # This method is for mocking `Crystal.format` in test.
+    private def format(filename, source)
+      result = Crystal.format(source, filename: filename)
+    end
+
+    private def on_format(filename, result)
+      if @check
+        error "formatting '#{filename}' produced changes"
+        @status_code = 1
       else
-        couldnt_format "'#{filename}'"
-        STDERR.puts
+        unless @format_stdin
+          File.write filename, result
+          @stdout << "Format".colorize(:green).toggle(@color) << ' ' << filename << '\n'
+        end
       end
     end
-  end
 
-  private def couldnt_format(file, ex = nil)
-    STDERR << "Error: ".colorize(:red).toggle(@color)
-
-    if ex
-      STDERR.puts "couldn't format #{file}, please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues"
-      STDERR.puts
-
-      ex.inspect_with_backtrace STDERR
-    else
-      STDERR << "there's a bug formatting #{file}, to show more information, please run:\n\n  $ crystal tool format #{file}"
+    private def on_invalid_byte_sequence_error(filename, ex)
+      error "file '#{filename}' is not a valid Crystal source file: #{ex.message}"
+      @status_code = 1
     end
 
-    STDERR.puts
-    STDERR.flush
+    private def on_syntax_error(filename, ex)
+      error ex
+      @status_code = 1
+    end
+
+    private def on_bug(filename, ex)
+      if @show_backtrace
+        ex.inspect_with_backtrace @stderr
+        @stderr.puts
+        error "couldn't format '#{filename}', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues"
+      else
+        error "there's a bug formatting '#{filename}', to show more information, please run:\n\n  $ crystal tool format --show-backtrace #{@format_stdin ? "-" : "'#{filename}'"}\n"
+      end
+      @status_code = 1
+    end
+
+    private def error(msg)
+      Crystal.error msg, @color, exit_code: nil, stderr: @stderr
+    end
   end
 end


### PR DESCRIPTION
Close #7241

Sorry, this contains some fixes and improvements:

  - Refactor by adding a new class `Crystal::Command::FormatCommand`.
  - Add `--show-backtrace` option.
  - Fix the error message on bug found.
  - Fix status-code. It returns `1` on occured some errors, otherwise it returns `0`.
  - Remove `--format` option because it does not work entirely.
    (I believe someone will implement it.)
  - Add specs powered by `FormatCommand` class.

In fact this reduces `src/compiler/crystal/command/format.cr` file-size by 10%.