### PR TITLE
CI: Disable linux 32 bits travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: ARCH=i386 ARCH_CMD=linux32
-      os: linux
     - env: ARCH=x86_64 ARCH_CMD=linux64
       os: linux
 


### PR DESCRIPTION
linux 32 bits build in travis are failing a lot due to OOM (Out of memory) but on CircleCI they are running fine/better.

This disabled that portion in travis, keeping linux64 builds and notifications to IRC/Slack