### PR TITLE
Add Char#+(Char) and fix <=>'s behaviour

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -30,10 +30,19 @@ describe "Char" do
 
   describe "+" do
     it { ('a' + 2).should eq('c') }
+    it { ('a' + 'b').should eq("ab") }
+    it { ('f' + "oo").should eq("foo") }
   end
 
   describe "-" do
     it { ('c' - 2).should eq('a') }
+    it { ('c' - 'a').should eq(2) }
+  end
+
+  describe "<=>" do
+    it { ('a' <=> 'z').should eq(-1) }
+    it { ('a' <=> 'a').should eq(0) }
+    it { ('z' <=> 'a').should eq(1) }
   end
 
   describe "ascii_uppercase?" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -63,6 +63,28 @@ struct Char
     ord - other.ord
   end
 
+  # Concatenates this char and *other*.
+  #
+  # ```
+  # 'a' + 'b' # => "ab"
+  # ```
+  def +(other : Char)
+    bytesize = other.bytesize + self.bytesize
+    String.new(bytesize) do |buffer|
+      index = 0
+      other.each_byte do |byte|
+        buffer[index] = byte
+        index += 1
+      end
+      self.each_byte do |byte|
+        buffer[index] = byte
+        index += 1
+      end
+
+      {bytesize, 2}
+    end
+  end
+
   # Concatenates this char and *string*.
   #
   # ```
@@ -103,13 +125,21 @@ struct Char
     (ord - other).chr
   end
 
-  # Implements the comparison operator.
+  # The comparison operator.
   #
   # ```
-  # 'a' <=> 'c' # => -2
+  # 'a' <=> 'z' # => -1
+  # 'a' <=> 'a' # => 0
+  # 'z' <=> 'a' # => 1
   # ```
   def <=>(other : Char)
-    self - other
+    if self == other
+      0
+    elsif self.ord > other.ord
+      1
+    else
+      -1
+    end
   end
 
   # Returns `true` if this char is an ASCII character


### PR DESCRIPTION
This adds the concatenation of two chars and fixes the behaviour of the `<=>` operator of `Char`.

I feel like `Char#+(Char)` was missing and right now in my code I have `'"' + char + '"'` which I would like to use instead of `%("#{char}")` or even worse `"\"#{char}\""`. I personally find the first one the easiest to read.
Also, the first one is much faster:
```cr
              +  11.55M ( 86.58ns) (±25.21%)   48 B/op        fastest
percent literal   6.18M ( 161.7ns) (±38.42%)  208 B/op   1.87× slower
       escaping   7.45M (134.16ns) (±33.66%)  208 B/op   1.55× slower
```
---
The behaviour of the [spaceship operator](https://crystal-lang.org/api/0.27.0/Char.html#%28other%3AChar%29-instance-method) is currently wrong. It's just an alias of [`Char#-`](https://crystal-lang.org/api/0.27.0/Char.html#-%28other%3AChar%29-instance-method).
Right now `'a' <=> 'c'` returns `-2` instead of `-1`.

This also adds some missing specs.