### PR TITLE
 Add yielding line number to {String,IO}#each_line

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -95,6 +95,32 @@ describe "File" do
     idx.should eq(20)
   end
 
+  describe ".each_line_with_number" do
+    it "yields line number" do
+      idx = 0
+      File.each_line_with_number(datapath("test_file.txt")) do |line, line_number|
+        if idx == 0
+          line.should eq("Hello World")
+        end
+        idx += 1
+        line_number.should eq idx
+      end
+      idx.should eq(20)
+    end
+
+    it "yields line number with offset" do
+      idx = 0
+      File.each_line_with_number(datapath("test_file.txt"), offset: 10) do |line, line_number|
+        if idx == 0
+          line.should eq("Hello World")
+        end
+        idx += 1
+        line_number.should eq idx + 10
+      end
+      idx.should eq(20)
+    end
+  end
+
   describe "empty?" do
     it "gives true when file is empty" do
       File.empty?(datapath("blank_test_file.txt")).should be_true

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -400,6 +400,26 @@ describe IO do
     end
   end
 
+  describe "#each_line_with_number" do
+    it "yields line number" do
+      lines = [] of String
+      io = SimpleIOMemory.new("a\nbb\ncc")
+      io.each_line_with_number do |line, lino|
+        lines << "#{lino}:#{line}"
+      end
+      lines.should eq ["1:a", "2:bb", "3:cc"]
+    end
+
+    it "yields line number with offset" do
+      lines = [] of String
+      io = SimpleIOMemory.new("a\nbb\ncc")
+      io.each_line_with_number(offset: 10) do |line, lino|
+        lines << "#{lino}:#{line}"
+      end
+      lines.should eq ["11:a", "12:bb", "13:cc"]
+    end
+  end
+
   describe "write operations" do
     it "does puts" do
       io = SimpleIOMemory.new

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -334,54 +334,30 @@ describe IO do
     end
 
     it "does each_line" do
+      lines = [] of String
       io = SimpleIOMemory.new("a\nbb\ncc")
-      counter = 0
       io.each_line do |line|
-        case counter
-        when 0
-          line.should eq("a")
-        when 1
-          line.should eq("bb")
-        when 2
-          line.should eq("cc")
-        end
-        counter += 1
-      end.should be_nil
-      counter.should eq(3)
+        lines << line
+      end
+      lines.should eq ["a", "bb", "cc"]
     end
 
     it "does each_char" do
+      chars = [] of Char
       io = SimpleIOMemory.new("あいう")
-      counter = 0
       io.each_char do |c|
-        case counter
-        when 0
-          c.should eq('あ')
-        when 1
-          c.should eq('い')
-        when 2
-          c.should eq('う')
-        end
-        counter += 1
-      end.should be_nil
-      counter.should eq(3)
+        chars << c
+      end
+      chars.should eq ['あ', 'い', 'う']
     end
 
     it "does each_byte" do
+      bytes = [] of UInt8
       io = SimpleIOMemory.new("abc")
-      counter = 0
       io.each_byte do |b|
-        case counter
-        when 0
-          b.should eq('a'.ord)
-        when 1
-          b.should eq('b'.ord)
-        when 2
-          b.should eq('c'.ord)
-        end
-        counter += 1
-      end.should be_nil
-      counter.should eq(3)
+        bytes << b
+      end
+      bytes.should eq ['a'.ord.to_u8, 'b'.ord.to_u8, 'c'.ord.to_u8]
     end
 
     it "raises on EOF with read_line" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2089,6 +2089,24 @@ describe "String" do
     lines.should eq(["foo\n", "\n", "bar\r\n", "baz\r\n"])
   end
 
+  describe "#each_line_with_number" do
+    it "yields line number" do
+      lines = [] of String
+      "foo\n\nbar\r\nbaz\r\n".each_line_with_number do |line, lino|
+        lines << "#{lino}:#{line}"
+      end.should be_nil
+      lines.should eq(["1:foo", "2:", "3:bar", "4:baz"])
+    end
+
+    it "yields line nubmer with offset" do
+      lines = [] of String
+      "foo\n\nbar\r\nbaz\r\n".each_line_with_number(offset: 10) do |line, lino|
+        lines << "#{lino}:#{line}"
+      end.should be_nil
+      lines.should eq(["11:foo", "12:", "13:bar", "14:baz"])
+    end
+  end
+
   it "gets each_line iterator" do
     iter = "foo\nbar\r\nbaz\r\n".each_line
     iter.next.should eq("foo")

--- a/src/file.cr
+++ b/src/file.cr
@@ -731,6 +731,30 @@ class File < IO::FileDescriptor
     end
   end
 
+  # Yields each line in *filename* and the line number to the given block.
+  #
+  # See `File.each_line` for basic behaviour.
+  #
+  # The second argument yielded to the block is the line number starting at `1`.
+  # The optional *offset* argument is added to the first line number.
+  #
+  # ```
+  # File.write("foobar", "foo\nbar")
+  #
+  # array = [] of String
+  # File.each_line("foobar") do |line, lino|
+  #   array << "#{lino}: #{line}"
+  # end
+  # array # => ["1: foo", "2: bar"]
+  # ```
+  def self.each_line_with_number(filename, encoding = nil, invalid = nil, chomp = true, offset : Int32 = 0)
+    open(filename, "r", encoding: encoding, invalid: invalid) do |file|
+      file.each_line_with_number(chomp: chomp, offset: offset) do |line, line_number|
+        yield line, line_number
+      end
+    end
+  end
+
   # Returns all lines in *filename* as an array of strings.
   #
   # ```

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -22,10 +22,8 @@ class INI
   def self.parse(str) : Hash(String, Hash(String, String))
     ini = Hash(String, Hash(String, String)).new
     current_section = ini[""] = Hash(String, String).new
-    lineno = 0
 
-    str.each_line do |line|
-      lineno += 1
+    str.each_line_with_number do |line, lineno|
       next if line.empty?
 
       offset = 0

--- a/src/io.cr
+++ b/src/io.cr
@@ -908,17 +908,26 @@ abstract class IO
   # ```
   # io = IO::Memory.new("hello\nworld")
   # io.each_line do |line|
-  #   puts line.chomp.reverse
+  #   puts line
   # end
+  # # output:
+  # # hello
+  # # world
   # ```
   #
-  # Output:
+  # The second argument yielded to the block is the line number starting at `1`.
+  # The optional *offset* argument is added to the first line number.
   #
-  # ```text
-  # olleh
-  # dlrow
   # ```
-  def each_line(*args, **options) : Nil
+  # io = IO::Memory.new("hello\nworld")
+  # io.each_line do |line, lino|
+  #   puts "#{lino}: #{line}"
+  # end
+  # # output:
+  # # 1: hello
+  # # 2: world
+  # ```
+  def each_line(*args, **options, &block : String -> _) : Nil
     while line = gets(*args, **options)
       yield line
     end

--- a/src/io.cr
+++ b/src/io.cr
@@ -933,6 +933,30 @@ abstract class IO
     end
   end
 
+  # Reads this `IO` line by line and yields each line and the line number to a block.
+  #
+  # See `#each_line` for basic behaviour.
+  #
+  # The second argument yielded to the block is the line number starting at `1`.
+  # The optional *offset* argument is added to the first line number.
+  #
+  # ```
+  # io = IO::Memory.new("hello\nworld")
+  # io.each_line do |line, lino|
+  #   puts "#{lino}: #{line}"
+  # end
+  # # output:
+  # # 1: hello
+  # # 2: world
+  # ```
+  def each_line_with_number(*args, offset = 0, **options, &block : String, Int32 -> _) : Nil
+    line_number = offset
+    each_line do |line|
+      line_number += 1
+      yield line, line_number
+    end
+  end
+
   # Returns an `Iterator` for the *lines* in this `IO`, where a line
   # is defined by the arguments passed to this method, which can be the same
   # ones as in the `gets` methods.

--- a/src/string.cr
+++ b/src/string.cr
@@ -3365,23 +3365,49 @@ class String
   def each_line(chomp = true, &block : String -> _) : Nil
     return if empty?
 
-    offset = 0
-
-    while byte_index = byte_index('\n'.ord.to_u8, offset)
-      count = byte_index - offset + 1
+    byte_offset = 0
+    while byte_index = byte_index('\n'.ord.to_u8, byte_offset)
+      count = byte_index - byte_offset + 1
       if chomp
         count -= 1
-        if offset + count > 0 && to_unsafe[offset + count - 1] === '\r'
+        if byte_offset + count > 0 && to_unsafe[byte_offset + count - 1] === '\r'
           count -= 1
         end
       end
 
-      yield unsafe_byte_slice_string(offset, count)
-      offset = byte_index + 1
+      yield unsafe_byte_slice_string(byte_offset, count)
+      byte_offset = byte_index + 1
     end
 
-    unless offset == bytesize
-      yield unsafe_byte_slice_string(offset)
+    unless byte_offset == bytesize
+      yield unsafe_byte_slice_string(byte_offset)
+    end
+  end
+
+  # Splits the string after each newline and yields each line and the line number to a block.
+  #
+  # See `#each_line` for basic behaviour.
+  #
+  # The second argument yielded to the block is the line number starting at `1`.
+  # The optional *offset* argument is added to the first line number.
+  #
+  # ```
+  # haiku = "the first cold shower
+  # even the monkey seems to want
+  # a little coat of straw"
+  # haiku.each_line do |stanza, lino|
+  #   puts "#{lino}: #{stanza}"
+  # end
+  # # output:
+  # # 1: the first cold shower
+  # # 2: even the monkey seems to want
+  # # 3: a little coat of straw
+  # ```
+  def each_line_with_number(chomp = true, offset : Int32 = 0, &block : String, Int32 -> _) : Nil
+    line_number = offset
+    each_line(chomp: chomp) do |line|
+      line_number += 1
+      yield line, line_number
     end
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -3355,13 +3355,14 @@ class String
   # even the monkey seems to want
   # a little coat of straw"
   # haiku.each_line do |stanza|
-  #   puts stanza.upcase
+  #   puts stanza
   # end
-  # # => THE FIRST COLD SHOWER
-  # # => EVEN THE MONKEY SEEMS TO WANT
-  # # => A LITTLE COAT OF STRAW
+  # # output:
+  # # the first cold shower
+  # # even the monkey seems to want
+  # # a little coat of straw
   # ```
-  def each_line(chomp = true) : Nil
+  def each_line(chomp = true, &block : String -> _) : Nil
     return if empty?
 
     offset = 0


### PR DESCRIPTION
When iterating through lines you often need a line number. This PR adds them as a second (optional) argument to the block provided to `String#each_line`, `IO#each_line` and `File.each_line`.
In the updated API docs I removed unrelated features `upcase` and `reverse` from the examples.

Alternatively, it could be a separate method called `#each_line_with_number` but I think the proposed option is better.

A second commit in this PR refactors related specs in `io_spec.cr` which I noticed could be simplified while adding the specs for yielding a line number.