### PR TITLE
Compiler: only give named args errors when there's a single overload

### DIFF
--- a/spec/compiler/semantic/named_args_spec.cr
+++ b/spec/compiler/semantic/named_args_spec.cr
@@ -21,6 +21,19 @@ describe "Semantic: named args" do
       "argument 'x' already specified"
   end
 
+  it "errors if named arg already specified, but multiple overloads (#7281)" do
+    assert_error %(
+      def foo(x : String, y = 1, z = 2)
+      end
+
+      def foo(x : Int32, y : Int32)
+      end
+
+      foo 1, x: 1
+      ),
+      "no overload matches"
+  end
+
   it "errors if named arg not found in new" do
     assert_error %(
       class Foo

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -208,7 +208,9 @@ class Crystal::Call
           raise "'#{full_name(owner, def_name)}' is expected to be invoked with a block, but no block was given"
         end
 
-        if named_args_types
+        # Only check for named args mismatch if there's just one overload for
+        # the method name, otherwise the error might not be correct
+        if named_args_types && defs.one?
           defs_matching_args_size.each do |a_def|
             check_named_args_mismatch owner, arg_types, named_args_types, a_def
           end


### PR DESCRIPTION
Fixes #7281

The compiler would try to determine if you already specified a named arguments solely based on the number of arguments, their position and the name of named arguments. But this might lead to false positives when there are multiple overloads.

For safety, this PR just triggers that other error message when there's a single overload, when it's safe to say so. In any other case the usual "no overload matches" is shown, which also lets you see which arguments you passed and which overloads are available. This can always be improved in the future, but for now it's better to not give misleading directions.