### PR TITLE
Get SNI for OpenSSL

### DIFF
--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -76,4 +76,21 @@ describe OpenSSL::SSL::Server do
       end
     end
   end
+
+  it "detects SNI hostname" do
+    tcp_server = TCPServer.new(0)
+    server_context, client_context = ssl_context_pair
+
+    OpenSSL::SSL::Server.open tcp_server, server_context do |server|
+      spawn do
+        client = server.accept
+        client.hostname.should eq("example.com")
+        client.close
+      end
+
+      OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context) do |socket|
+        socket.hostname = "example.com"
+      end
+    end
+  end
 end

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -83,13 +83,14 @@ describe OpenSSL::SSL::Server do
 
     OpenSSL::SSL::Server.open tcp_server, server_context do |server|
       spawn do
-        client = server.accept
-        client.hostname.should eq("example.com")
-        client.close
+        sleep 1
+        OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com") do |socket|
+        end
       end
 
-      OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com") do |socket|
-      end
+      client = server.accept
+      client.hostname.should eq("example.com")
+      client.close
     end
   end
 end

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -88,8 +88,7 @@ describe OpenSSL::SSL::Server do
         client.close
       end
 
-      OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context) do |socket|
-        socket.hostname = "example.com"
+      OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com") do |socket|
       end
     end
   end

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -155,6 +155,7 @@ lib LibSSL
   fun tlsv1_2_method = TLSv1_2_method : SSLMethod
 
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
+  fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
   fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -156,6 +156,7 @@ lib LibSSL
 
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
+  fun ssl_set_tlsext_host_name = SSL_set_tlsext_host_name(ssl : SSL, hostname : UInt8*) : Int
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
   fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -156,7 +156,6 @@ lib LibSSL
 
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
-  fun ssl_set_tlsext_host_name = SSL_set_tlsext_host_name(ssl : SSL, hostname : UInt8*) : Int
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
   fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -73,7 +73,7 @@ class OpenSSL::SSL::Server
   end
 
   # This method allows to fetch the SSL SNI string if present
-  def get_sni : String
+  def sni : String
     String.new(LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name))
   end
 

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -73,9 +73,9 @@ class OpenSSL::SSL::Server
   end
 
   # This method allows to fetch the SSL SNI string if present
-  def sni : String?
-    if hostname = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
-      String.new(hostname)
+  def hostname : String?
+    if host_name = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
+      String.new(host_name)
     end
   end
 

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -73,8 +73,9 @@ class OpenSSL::SSL::Server
   end
 
   # This method allows to fetch the SSL SNI string if present
-  def sni : String
-    String.new(LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name))
+  def sni : String?
+    host_name = String.new(LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name))
+    host_name.empty? ? nil : host_name
   end
 
   # Closes this SSL server.

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -72,13 +72,6 @@ class OpenSSL::SSL::Server
     end
   end
 
-  # This method allows to fetch the SSL SNI string if present
-  def hostname : String?
-    if host_name = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
-      String.new(host_name)
-    end
-  end
-
   # Closes this SSL server.
   #
   # Propagates to `wrapped` if `sync_close` is `true`.

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -74,8 +74,9 @@ class OpenSSL::SSL::Server
 
   # This method allows to fetch the SSL SNI string if present
   def sni : String?
-    host_name = String.new(LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name))
-    host_name.empty? ? nil : host_name
+    if hostname = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
+      String.new(hostname)
+    end
   end
 
   # Closes this SSL server.

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -72,6 +72,11 @@ class OpenSSL::SSL::Server
     end
   end
 
+  # This method allows to fetch the SSL SNI string if present
+  def get_sni : String
+    String.new(LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name))
+  end
+
   # Closes this SSL server.
   #
   # Propagates to `wrapped` if `sync_close` is `true`.

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -44,6 +44,14 @@ abstract class OpenSSL::SSL::Socket < IO
         socket.close
       end
     end
+
+    # This method allows to fetch the SSL SNI string if present
+    def hostname=(host_name : String)
+      ret = LibSSL.ssl_set_tlsext_host_name(@ssl, host_name)
+      unless ret == LibSSL::SSL_TLSEXT_ERR_OK
+        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_set_tlsext_host_name")
+      end
+    end
   end
 
   class Server < Socket

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -182,7 +182,7 @@ abstract class OpenSSL::SSL::Socket < IO
     raise IO::Error.new("Can't rewind OpenSSL::SSL::Socket::Client")
   end
 
-  # This method allows to fetch the SSL SNI string if present
+  # Returns the hostname provided through Server Name Indication (SNI)
   def hostname : String?
     if host_name = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
       String.new(host_name)

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -44,14 +44,6 @@ abstract class OpenSSL::SSL::Socket < IO
         socket.close
       end
     end
-
-    # This method allows to set the SSL SNI string for client
-    def hostname=(host_name : String)
-      ret = LibSSL.ssl_set_tlsext_host_name(@ssl, host_name)
-      unless ret == LibSSL::SSL_TLSEXT_ERR_OK
-        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_set_tlsext_host_name")
-      end
-    end
   end
 
   class Server < Socket

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -181,4 +181,11 @@ abstract class OpenSSL::SSL::Socket < IO
   def unbuffered_rewind
     raise IO::Error.new("Can't rewind OpenSSL::SSL::Socket::Client")
   end
+
+  # This method allows to fetch the SSL SNI string if present
+  def hostname : String?
+    if host_name = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)
+      String.new(host_name)
+    end
+  end
 end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -45,7 +45,7 @@ abstract class OpenSSL::SSL::Socket < IO
       end
     end
 
-    # This method allows to fetch the SSL SNI string if present
+    # This method allows to set the SSL SNI string for client
     def hostname=(host_name : String)
       ret = LibSSL.ssl_set_tlsext_host_name(@ssl, host_name)
       unless ret == LibSSL::SSL_TLSEXT_ERR_OK


### PR DESCRIPTION
This PR adds the ability to query the [SNI](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_servername.html) string, having this ability is important when needing to decide which certificate to show the connecting client, or, when creating a proxy that should show the relevant certificate for each host.
There are other reasons for having this ability.

Overall this change is minor and have been tested locally.