### PR TITLE
Update ISSUE_TEMPLATE to include forum

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+# Submitting questions
+
+If your have a question like "how do I do X?", this is not the right place for asking it. Please ask on the [Crystal Forum](https://forum.crystal-lang.org), on our combined [Gitter](https://gitter.im/crystal-lang/crystal)/[IRC](http://webchat.freenode.net/?channels=#crystal-lang) or on [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang).
+
 # Submitting bugs
 
 Make sure to review these points before submitting issues - thank you!
@@ -8,8 +12,3 @@ Make sure to review these points before submitting issues - thank you!
 - Reduce code, if possible, to the minimum size that reproduces the bug.
 - If all of the above is impossible due to a large project, create a branch that reproduces the bug and point us to it.
 - Include Crystal compiler version (`crystal -v`) and OS. If possible, try to see if the bug still reproduces on master.
-
-# Submitting questions
-
-- If the question is something like "how do I do X?", consider using [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang)
-- If the question is about a shard, consider asking the question in that shard

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Submitting questions
 
-If your have a question like "how do I do X?", this is not the right place for asking it. Please ask on the [Crystal Forum](https://forum.crystal-lang.org), on our combined [Gitter](https://gitter.im/crystal-lang/crystal)/[IRC](http://webchat.freenode.net/?channels=#crystal-lang) or on [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang).
+If you have a question like "how do I do X?", this is not the right place for asking it. Please ask on the [Crystal Forum](https://forum.crystal-lang.org), on our combined [Gitter](https://gitter.im/crystal-lang/crystal)/[IRC](http://webchat.freenode.net/?channels=#crystal-lang) or on [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang).
 
 # Submitting bugs
 


### PR DESCRIPTION
This updates the Github ISSUE_TEMPLATE to send people with general questions to the forum (or chat or SO).

Also reorders the content, putting the sections about questions first. I think that's a better order to make this clear at the beginning without needing to skip several paragraphs/list items.

Individual shards are usually prominent enough that we don't need to remind people about using their specific communication channels.

Related: #7235