### PR TITLE
[WIP] Add remote_address to HTTP::Server::Context

### DIFF
--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -173,6 +173,20 @@ abstract class OpenSSL::SSL::Socket < IO
     raise IO::Error.new("Can't rewind OpenSSL::SSL::Socket::Client")
   end
 
+  def remote_address
+    if (io = @bio.io).responds_to?(:remote_address)
+      io.remote_address
+    else
+      raise "#{io} doesn't have a remote address"
+    end
+  end
+
+  def remote_address?
+    if (io = @bio.io).responds_to?(:remote_address)
+      io.remote_address
+    end
+  end
+
   # Returns the hostname provided through Server Name Indication (SNI)
   def hostname : String?
     if host_name = LibSSL.ssl_get_servername(@ssl, LibSSL::TLSExt::NAMETYPE_host_name)


### PR DESCRIPTION
Would appear to close #453 and #5784.

This PR adds support for `remote_address` by pulling it from the underlying IO.

I'm currently unsure if adding this as a separate field to `Context` is appropriate. It may make more sense to provide a `Context::Info` or `Context::Metadata`, which could contain `remote_address` and `local_address`, or other useful information that would be relevant in some cases, with functionality similar to #1722.

Example use:
```crystal
# A very basic HTTP server
require "http/server"

server = HTTP::Server.new do |context|
  context.response.content_type = "text/plain"
  context.response.print "Hello to #{context.remote_address}!"
end

address = server.bind_tcp 8080
puts "Listening on http://#{address}"
server.listen
```

```
$ curl http://127.0.0.1:8080
Hello to 127.0.0.1:37024!
```

This PR also patches `OpenSSL::SSL::Socket` so the `IPAddress` can be determined for servers with SSL enabled.

It might be good to change [this line](https://github.com/crystal-lang/crystal/compare/master...omarroth:add-remote-ip?expand=1#diff-157d96b494d2033fd2ed0f4d8d12a856R46) to a warning or safer default.

Still needs tests.