### PR TITLE
Compiler: fix automatic casting didn't work for private top-level methods

### DIFF
--- a/spec/compiler/semantic/automatic_cast.cr
+++ b/spec/compiler/semantic/automatic_cast.cr
@@ -82,6 +82,16 @@ describe "Semantic: automatic cast" do
       )) { float32 }
   end
 
+  it "casts literal integer in private top-level method (#7016)" do
+    assert_type(%(
+      private def foo(x : Int64)
+        x
+      end
+
+      foo(12345)
+      )) { int64 }
+  end
+
   it "matches correct overload" do
     assert_type(%(
       def foo(x : Int32)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -49,6 +49,15 @@ class Crystal::Call
       defs = owner.lookup_defs(def_name)
     end
 
+    # Also consider private top-level defs
+    if owner.is_a?(Program)
+      location = self.location
+      if location && (filename = location.original_filename)
+        private_defs = owner.file_module?(filename).try &.lookup_defs(def_name)
+        defs.concat(private_defs) if private_defs
+      end
+    end
+
     # Another special case: initialize is only looked up one level,
     # so we must find the first one defined.
     new_owner = owner


### PR DESCRIPTION
Fixes #7016