### PR TITLE
remove debian 32 bit from Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,8 +26,8 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  [[:jessie, '3.5'], [:stretch, '3.9']].product([32, 64]).each do |(dist, ver), bits|
-    box_name = "#{dist}#{bits}"
+  [[:jessie, '3.5'], [:stretch, '3.9']].each do |(dist, ver)|
+    box_name = "#{dist}64"
 
     config.vm.define(box_name) do |c|
       c.vm.box = "debian/#{box_name}"


### PR DESCRIPTION
Debian seems to only support 64 bit operating systems on vagrant now as listed here https://app.vagrantup.com/debian.
This was breaking vagrant up so I removed the 32 bit instances.