### PR TITLE
Discourage the use of Bool#to_unsafe other than for C bindings

### DIFF
--- a/src/bool.cr
+++ b/src/bool.cr
@@ -46,8 +46,10 @@ struct Bool
     hasher.bool(self)
   end
 
-  # Returns `1` for `true` and `0` for `false`.
-  def to_unsafe
+  # Returns an integer derived from the boolean value, for interoperability with C-style booleans.
+  #
+  # The value is `1` for `true` and `0` for `false`.
+  def to_unsafe : LibC::Int
     self ? 1 : 0
   end
 


### PR DESCRIPTION
Dependent codebases shouldn't be infested with the word "unsafe" even if this happens to do the job. Directly using ternary is clearer, too.