### PR TITLE
Add lazy versions of Object#getter?/property? macros

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -38,6 +38,9 @@ private class TestObject
   @getter13_counter = 0
   getter(getter13) { @getter13_counter += 1; false }
 
+  getter?(getter14 : Bool) { true }
+  getter?(getter15) { true }
+
   setter setter1
   setter setter2 : Int32
   setter setter3 : Int32 = 3
@@ -63,6 +66,9 @@ private class TestObject
 
   @property13_counter = 0
   property(property13) { @property13_counter += 1; false }
+
+  property?(property14 : Bool) { true }
+  property?(property15) { true }
 
   def initialize
     @getter1 = 1
@@ -272,6 +278,24 @@ describe Object do
       typeof(obj.@getter10).should eq(Bool)
       typeof(obj.getter10?).should eq(Bool)
     end
+
+    it "uses getter? with type declaration and block" do
+      obj = TestObject.new
+      typeof(obj.@getter14).should eq(Bool?)
+      typeof(obj.getter14?).should eq(Bool)
+      obj.@getter14.should be_nil
+      obj.getter14?.should be_true
+      obj.@getter14.should be_true
+    end
+
+    it "uses getter? with block" do
+      obj = TestObject.new
+      typeof(obj.@getter15).should eq(Bool?)
+      typeof(obj.getter15?).should eq(Bool)
+      obj.@getter15.should be_nil
+      obj.getter15?.should be_true
+      obj.@getter15.should be_true
+    end
   end
 
   describe "setter" do
@@ -399,6 +423,24 @@ describe Object do
       obj.property10?.should be_true
       obj.property10 = false
       obj.property10?.should be_false
+    end
+
+    it "uses property? with type declaration and block" do
+      obj = TestObject.new
+      typeof(obj.@property14).should eq(Bool?)
+      typeof(obj.property14?).should eq(Bool)
+      obj.@property14.should be_nil
+      obj.property14?.should be_true
+      obj.@property14.should be_true
+    end
+
+    it "uses property? with block" do
+      obj = TestObject.new
+      typeof(obj.@property15).should eq(Bool?)
+      typeof(obj.property15?).should eq(Bool)
+      obj.@property15.should be_nil
+      obj.property15?.should be_true
+      obj.@property15.should be_true
     end
   end
 

--- a/src/object.cr
+++ b/src/object.cr
@@ -559,24 +559,56 @@ class Object
     #   end
     # end
     # ```
-    macro {{macro_prefix}}getter?(*names)
-      \{% for name in names %}
+    #
+    # If a block is given to the macro, a getter is generated
+    # with a variable that is lazily initialized with
+    # the block's contents, for examples see `#{{macro_prefix}}getter`.
+    macro {{macro_prefix}}getter?(*names, &block)
+      \{% if block %}
+        \{% if names.size != 1 %}
+          \{{ raise "Only one argument can be passed to `getter?` with a block" }}
+        \{% end %}
+
+        \{% name = names[0] %}
+
         \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name}}
+          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            {{var_prefix}}\{{name.var.id}}
-          end
-        \{% elsif name.is_a?(Assign) %}
-          {{var_prefix}}\{{name}}
-
-          def {{method_prefix}}\{{name.target.id}}?
-            {{var_prefix}}\{{name.target.id}}
+          def {{method_prefix}}\{{name.var.id}}?
+            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+              {{var_prefix}}\{{name.var.id}} = \{{yield}}
+            else
+              value
+            end
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}?
-            {{var_prefix}}\{{name.id}}
+            if (value = {{var_prefix}}\{{name.id}}).nil?
+              {{var_prefix}}\{{name.id}} = \{{yield}}
+            else
+              value
+            end
           end
+        \{% end %}
+      \{% else %}
+        \{% for name in names %}
+          \{% if name.is_a?(TypeDeclaration) %}
+            {{var_prefix}}\{{name}}
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              {{var_prefix}}\{{name.var.id}}
+            end
+          \{% elsif name.is_a?(Assign) %}
+            {{var_prefix}}\{{name}}
+
+            def {{method_prefix}}\{{name.target.id}}?
+              {{var_prefix}}\{{name.target.id}}
+            end
+          \{% else %}
+            def {{method_prefix}}\{{name.id}}?
+              {{var_prefix}}\{{name.id}}
+            end
+          \{% end %}
         \{% end %}
       \{% end %}
     end
@@ -1051,33 +1083,71 @@ class Object
     #   end
     # end
     # ```
-    macro {{macro_prefix}}property?(*names)
-      \{% for name in names %}
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name}}
+    #
+    # If a block is given to the macro, a property is generated
+    # with a variable that is lazily initialized with
+    # the block's contents, for examples see `#{{macro_prefix}}property`.
+    macro {{macro_prefix}}property?(*names, &block)
+      \{% if block %}
+        \{% if names.size != 1 %}
+          \{{ raise "Only one argument can be passed to `property?` with a block" }}
+        \{% end %}
 
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            {{var_prefix}}\{{name.var.id}}
+        \{% name = names[0] %}
+
+        \{% if name.is_a?(TypeDeclaration) %}
+          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+
+          def {{method_prefix}}\{{name.var.id}}?
+            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+              {{var_prefix}}\{{name.var.id}} = \{{yield}}
+            else
+              value
+            end
           end
 
           def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
           end
-        \{% elsif name.is_a?(Assign) %}
-          {{var_prefix}}\{{name}}
-
-          def {{method_prefix}}\{{name.target.id}}?
-            {{var_prefix}}\{{name.target.id}}
-          end
-
-          def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
-          end
         \{% else %}
           def {{method_prefix}}\{{name.id}}?
-            {{var_prefix}}\{{name.id}}
+            if (value = {{var_prefix}}\{{name.id}}).nil?
+              {{var_prefix}}\{{name.id}} = \{{yield}}
+            else
+              value
+            end
           end
 
           def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
           end
+        \{% end %}
+      \{% else %}
+        \{% for name in names %}
+          \{% if name.is_a?(TypeDeclaration) %}
+            {{var_prefix}}\{{name}}
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              {{var_prefix}}\{{name.var.id}}
+            end
+
+            def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
+            end
+          \{% elsif name.is_a?(Assign) %}
+            {{var_prefix}}\{{name}}
+
+            def {{method_prefix}}\{{name.target.id}}?
+              {{var_prefix}}\{{name.target.id}}
+            end
+
+            def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
+            end
+          \{% else %}
+            def {{method_prefix}}\{{name.id}}?
+              {{var_prefix}}\{{name.id}}
+            end
+
+            def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
+            end
+          \{% end %}
         \{% end %}
       \{% end %}
     end


### PR DESCRIPTION
This PR adds lazy initialized versions of `Object#getter?/property?`. They do exist for `getter/property` macros, so that would bring feature parity to both variants.

Possibly closes #7321