### PR TITLE
Add bool#to_i

### DIFF
--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -41,6 +41,11 @@ describe "Bool" do
     it { false.to_s.should eq("false") }
   end
 
+  describe "to_i" do
+    it { true.to_i.should eq 1 }
+    it { false.to_i.should eq 0 }
+  end
+
   describe "clone" do
     it { true.clone.should be_true }
     it { false.clone.should be_false }

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -51,6 +51,11 @@ struct Bool
     self ? 1 : 0
   end
 
+  # Returns the integer representation of `self`.  `1` for `true` and `0` for `false`.
+  def to_i : Int32
+    self ? 1 : 0
+  end
+
   # Returns `"true"` for `true` and `"false"` for `false`.
   def to_s
     self ? "true" : "false"


### PR DESCRIPTION
Based on #7320, this PR adds a similar method to `to_s` but instead returns the integer representation of a bool, 1 for true and 0 for false.

This method, currently, is the same as `to_unsafe` but will be isolated from C binding changes.