### PR TITLE
Add String#rchop? and String#lchop?

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -553,8 +553,28 @@ describe "String" do
     it { "foo".rchop('o').should eq("fo") }
     it { "foo".rchop('x').should eq("foo") }
 
+    it { "".rchop("").should eq("") }
     it { "foobar".rchop("bar").should eq("foo") }
     it { "foobar".rchop("baz").should eq("foobar") }
+  end
+
+  describe "rchop?" do
+    it { "".rchop?.should be_nil }
+    it { "foo".rchop?.should eq("fo") }
+    it { "foo\n".rchop?.should eq("foo") }
+    it { "foo\r".rchop?.should eq("foo") }
+    it { "foo\r\n".rchop?.should eq("foo\r") }
+    it { "\r\n".rchop?.should eq("\r") }
+    it { "かたな".rchop?.should eq("かた") }
+    it { "かたな\n".rchop?.should eq("かたな") }
+    it { "かたな\r\n".rchop?.should eq("かたな\r") }
+
+    it { "foo".rchop?('o').should eq("fo") }
+    it { "foo".rchop?('x').should be_nil }
+
+    it { "".rchop?("").should eq("") }
+    it { "foobar".rchop?("bar").should eq("foo") }
+    it { "foobar".rchop?("baz").should be_nil }
   end
 
   describe "lchomp" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -539,6 +539,42 @@ describe "String" do
     it { "hello\r\n".chomp("\n").should eq("hello") }
   end
 
+  describe "lchop" do
+    it { "".lchop.should eq("") }
+    it { "h".lchop.should eq("") }
+    it { "hello".lchop.should eq("ello") }
+    it { "かたな".lchop.should eq("たな") }
+
+    it { "hello".lchop('g').should eq("hello") }
+    it { "hello".lchop('h').should eq("ello") }
+    it { "かたな".lchop('か').should eq("たな") }
+
+    it { "".lchop("").should eq("") }
+    it { "hello".lchop("good").should eq("hello") }
+    it { "hello".lchop("hel").should eq("lo") }
+    it { "かたな".lchop("かた").should eq("な") }
+
+    it { "\n\n\n\nhello".lchop("").should eq("\n\n\n\nhello") }
+  end
+
+  describe "lchop?" do
+    it { "".lchop?.should be_nil }
+    it { "h".lchop?.should eq("") }
+    it { "hello".lchop?.should eq("ello") }
+    it { "かたな".lchop?.should eq("たな") }
+
+    it { "hello".lchop?('g').should be_nil }
+    it { "hello".lchop?('h').should eq("ello") }
+    it { "かたな".lchop?('か').should eq("たな") }
+
+    it { "".lchop?("").should eq("") }
+    it { "hello".lchop?("good").should be_nil }
+    it { "hello".lchop?("hel").should eq("lo") }
+    it { "かたな".lchop?("かた").should eq("な") }
+
+    it { "\n\n\n\nhello".lchop("").should eq("\n\n\n\nhello") }
+  end
+
   describe "rchop" do
     it { "".rchop.should eq("") }
     it { "foo".rchop.should eq("fo") }
@@ -575,23 +611,6 @@ describe "String" do
     it { "".rchop?("").should eq("") }
     it { "foobar".rchop?("bar").should eq("foo") }
     it { "foobar".rchop?("baz").should be_nil }
-  end
-
-  describe "lchomp" do
-    it { "".lchop.should eq("") }
-    it { "h".lchop.should eq("") }
-    it { "hello".lchop.should eq("ello") }
-    it { "かたな".lchop.should eq("たな") }
-
-    it { "hello".lchop('g').should eq("hello") }
-    it { "hello".lchop('h').should eq("ello") }
-    it { "かたな".lchop('か').should eq("たな") }
-
-    it { "hello".lchop("good").should eq("hello") }
-    it { "hello".lchop("hel").should eq("lo") }
-    it { "かたな".lchop("かた").should eq("な") }
-
-    it { "\n\n\n\nhello".lchop("").should eq("\n\n\n\nhello") }
   end
 
   describe "strip" do

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -929,9 +929,9 @@ module Crystal
         end
       when :GLOBAL_MATCH_DATA_INDEX
         value = @token.value.to_s
-        if value.ends_with? '?'
+        if value_prefix = value.rchop? '?'
           method = "[]?"
-          value = value.rchop
+          value = value_prefix
         else
           method = "[]"
         end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -1,16 +1,12 @@
 module Crystal
-  def self.relative_filename(filename : String)
-    dir = Dir.current
-    if filename.starts_with?(dir)
-      filename = filename[dir.size..-1]
-      if filename.starts_with? '/'
-        filename[1..-1]
-      else
-        filename
+  def self.relative_filename(filename : String) : String
+    if base_file = filename.lchop? Dir.current
+      if file_prefix = base_file.lchop? '/'
+        return file_prefix
       end
-    else
-      filename
+      return base_file
     end
+    filename
   end
 
   def self.relative_filename(filename)

--- a/src/spec/source.cr
+++ b/src/spec/source.cr
@@ -15,10 +15,10 @@ module Spec
   # :nodoc:
   def self.relative_file(file)
     cwd = Dir.current
-    if file.starts_with?(cwd)
-      file = file[cwd.size..-1]
-      file = file[1..-1] if file.starts_with?('/')
+    if basename = file.lchop? cwd
+      basename.lchop '/'
+    else
+      file
     end
-    file
   end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -1059,38 +1059,46 @@ class String
   # "hello".lchop # => "ello"
   # "".lchop      # => ""
   # ```
-  def lchop
-    return "" if empty?
+  def lchop : String
+    lchop? || ""
+  end
+
+  # Returns a new `String` with *prefix* removed from the beginning of the string.
+  #
+  # ```
+  # "hello".lchop('h')   # => "ello"
+  # "hello".lchop('g')   # => "hello"
+  # "hello".lchop("hel") # => "lo"
+  # "hello".lchop("eh")  # => "hello"
+  # ```
+  def lchop(prefix : Char | String) : String
+    lchop?(prefix) || self
+  end
+
+  # Returns a new `String` with the first char removed from it if possible, else returns `nil`.
+  #
+  # ```
+  # "hello".lchop? # => "ello"
+  # "".lchop?      # => nil
+  # ```
+  def lchop? : String?
+    return if empty?
 
     reader = Char::Reader.new(self)
     unsafe_byte_slice_string(reader.current_char_width, bytesize - reader.current_char_width)
   end
 
-  # Returns a new `String` with *prefix* removed from the beginning of the string.
+  # Returns a new `String` with *prefix* removed from the beginning of the string if possible, else returns `nil`.
   #
   # ```
-  # "hello".lchop('h') # => "ello"
-  # "hello".lchop('g') # => "hello"
+  # "hello".lchop?('h')   # => "ello"
+  # "hello".lchop?('g')   # => nil
+  # "hello".lchop?("hel") # => "lo"
+  # "hello".lchop?("eh")  # => nil
   # ```
-  def lchop(prefix : Char)
+  def lchop?(prefix : Char | String) : String?
     if starts_with?(prefix)
       unsafe_byte_slice_string(prefix.bytesize, bytesize - prefix.bytesize)
-    else
-      self
-    end
-  end
-
-  # Returns a new `String` with *prefix* removed from the beginning of the string.
-  #
-  # ```
-  # "hello".lchop("hel") # => "lo"
-  # "hello".lchop("eh")  # => "hello"
-  # ```
-  def lchop(prefix : String)
-    if starts_with?(prefix)
-      unsafe_byte_slice_string(prefix.bytesize, bytesize - prefix.bytesize)
-    else
-      self
     end
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -1104,8 +1104,33 @@ class String
   # "string".rchop     # => "strin"
   # "x".rchop.rchop    # => ""
   # ```
-  def rchop
-    return "" if bytesize <= 1
+  def rchop : String
+    rchop? || ""
+  end
+
+  # Returns a new `String` with *suffix* removed from the end of the string.
+  #
+  # ```
+  # "string".rchop('g')   # => "strin"
+  # "string".rchop('x')   # => "string"
+  # "string".rchop("ing") # => "str"
+  # "string".rchop("inx") # => "string"
+  # ```
+  def rchop(suffix : Char | String) : String
+    rchop?(suffix) || self
+  end
+
+  # Returns a new `String` with the last character removed if possible, else returns `nil`.
+  #
+  # ```
+  # "string\r\n".rchop? # => "string\r"
+  # "string\n\r".rchop? # => "string\n"
+  # "string\n".rchop?   # => "string"
+  # "string".rchop?     # => "strin"
+  # "".rchop?           # => nil
+  # ```
+  def rchop? : String?
+    return if bytesize <= 1
 
     if to_unsafe[bytesize - 1] < 128 || ascii_only?
       return unsafe_byte_slice_string(0, bytesize - 1)
@@ -1114,35 +1139,17 @@ class String
     self[0, size - 1]
   end
 
-  # Returns a new `String` with *suffix* removed from the end of the string.
+  # Returns a new `String` with *suffix* removed from the end of the string if possible, else returns `nil`.
   #
   # ```
-  # "string".rchop('g') # => "strin"
-  # "string".rchop('x') # => "string"
+  # "string".rchop?('g')   # => "strin"
+  # "string".rchop?('x')   # => nil
+  # "string".rchop?("ing") # => "str"
+  # "string".rchop?("inx") # => nil
   # ```
-  def rchop(suffix : Char)
-    return "" if empty?
-
+  def rchop?(suffix : Char | String) : String?
     if ends_with?(suffix)
       unsafe_byte_slice_string(0, bytesize - suffix.bytesize)
-    else
-      self
-    end
-  end
-
-  # Returns a new `String` with *suffix* removed from the end of the string.
-  #
-  # ```
-  # "string".rchop("ing") # => "str"
-  # "string".rchop("inx") # => "string"
-  # ```
-  def rchop(suffix : String)
-    return "" if empty?
-
-    if ends_with?(suffix)
-      unsafe_byte_slice_string(0, bytesize - suffix.bytesize)
-    else
-      self
     end
   end
 


### PR DESCRIPTION
`String#rchop?` and `String#lchop?` are the nillable variants of `String#rchop` and `String#lchop`.

A use case for them is to remove a prefix/suffix when a string starts/ends with a certain string, else continue.

```cr
# This is inefficient because lchop also do a starts_with? check internally 
if mystring.starts_with? "prefix"
  substring = mystring.lchop "prefix"
# This is also not optimal and verbose
elsif (substring = mystring.lchop "prefix") != mystring
  substring
# The new way to do - try to lchop
elsif substring = mystring.lchop? "prefix"
  substring
end
```