### PR TITLE
Make Nil#not_nil! raise NilAssertionError

### DIFF
--- a/src/exception.cr
+++ b/src/exception.cr
@@ -138,3 +138,14 @@ class NotImplementedError < Exception
     super("Not Implemented: #{item}")
   end
 end
+
+# Raised when a `not_nil!` assertion fails.
+#
+# ```
+# "hello".index('x').not_nil! # raises NilAssertionError ("hello" does not contain 'x')
+# ```
+class NilAssertionError < Exception
+  def initialize(message = "Nil assertion failed")
+    super(message)
+  end
+end

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -99,12 +99,11 @@ struct Nil
     self
   end
 
-  # Raises an exception.
-  # Reports the file and line at which the `not_nil!` assertion is called.
+  # Raises `NilAssertionError`.
   #
   # See also: `Object#not_nil!`.
-  def not_nil!(caller_file = __FILE__, caller_line = __LINE__)
-    raise "Nil assertion failed at #{caller_file}:#{caller_line}"
+  def not_nil!
+    raise NilAssertionError.new
   end
 
   def clone

--- a/src/object.cr
+++ b/src/object.cr
@@ -172,7 +172,8 @@ class Object
     yield self
   end
 
-  # Returns `self`. `Nil` overrides this method and raises an exception.
+  # Returns `self`.
+  # `Nil` overrides this method and raises `NilAssertionError`, see `Nil#not_nil!`.
   def not_nil!
     self
   end


### PR DESCRIPTION
Fixes #7278 

This makes [`Nil#not_nil!`](https://crystal-lang.org/api/0.27.0/Nil.html#not_nil%21%28caller_file%3D__FILE__%2Ccaller_line%3D__LINE__%29-instance-method) raise `NilAssertionError` instead of just `Exception`.
This also makes the `caller_file` and `caller_line` arguments redundant.