### PR TITLE
Workaround buggy offset debug info values

### DIFF
--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -100,6 +100,10 @@ module Crystal
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
           offset = @program.target_machine.data_layout.offset_of_element(struct_type, idx &+ (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
+
+          # FIXME structs like LibC::PthreadMutexT generate huge offset values
+          next if offset > UInt64::MAX / 8u64
+
           member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)
           element_types << member
         end


### PR DESCRIPTION
I've narrow a bit where the overflow was generated, but is more related to buggy debug information that is being generated or obtained.

This occur in `def create_debug_type(type : InstanceVarContainer)` only for `LibC::PthreadMutexT#@__align` so far.

Now instead of failing the debug info on that field is skipped. The other members of the struct were also created without debug info.

Some build where I extract additional traces of the issue:

* https://circleci.com/gh/bcardiff/crystal/38
* https://circleci.com/gh/bcardiff/crystal/45
* https://travis-ci.org/bcardiff/crystal/jobs/483895732

```
WARN: check_overflow src/compiler/crystal/codegen/debug.cr:126:11 in 'create_debug_type' LibC::PthreadMutexT @__align offset: 6593625271604084736
      @__data idx: 0  -- no type --
      @__size idx: 1  -- no type --
      @__align  idx: 2  offset: 6593625271604084736 size: 32

WARN: check_overflow src/compiler/crystal/codegen/debug.cr:126:11 in 'create_debug_type' LibC::PthreadMutexT @__align offset: 6593962857292369312
      @__data idx: 0  -- no type --
      @__size idx: 1  -- no type --
      @__align  idx: 2  offset: 6593962857292369312 size: 32

WARN: check_overflow src/compiler/crystal/codegen/debug.cr:126:11 in 'create_debug_type' LibC::PthreadMutexT @__align offset: 8030606727934340709
      @__data idx: 0  -- no type --
      @__size idx: 1  -- no type --
      @__align  idx: 2  offset: 8030606727934340709 size: 64

WARN: check_overflow src/compiler/crystal/codegen/debug.cr:126:11 in 'create_debug_type' LibC::PthreadMutexT @__align offset: 4611686018427387909
      @__data idx: 0  -- no type --
      @__size idx: 1  -- no type --
      @__align  idx: 2  offset: 4611686018427387909 size: 64
```