### PR TITLE
Add nillable range fetching

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -224,11 +224,6 @@ describe "Array" do
       a[0..0].should eq(a)
     end
 
-    it "gets nilable" do
-      [1, 2, 3][2]?.should eq(3)
-      [1, 2, 3][3]?.should be_nil
-    end
-
     it "doesn't exceed limits" do
       [1][0..3].should eq([1])
     end
@@ -242,6 +237,23 @@ describe "Array" do
       expect_raises IndexError do
         [1, 2, 3][-4..0]
       end
+    end
+  end
+
+  describe "[]?" do
+    it "gets with index" do
+      [1, 2, 3][2]?.should eq(3)
+      [1, 2, 3][3]?.should be_nil
+    end
+
+    it "gets with range" do
+      [1, 2, 3][1..2]?.should eq([2, 3])
+      [1, 2, 3][4..-1]?.should be_nil
+    end
+
+    it "gets with start and count" do
+      [1, 2, 3][1, 3]?.should eq([2, 3])
+      [1, 2, 3][4, 0]?.should be_nil
     end
   end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -148,6 +148,15 @@ describe "String" do
     it "gets with a string" do
       "FooBar"["Bar"].should eq "Bar"
       expect_raises(Exception, "Nil assertion failed") { "FooBar"["Baz"] }
+    end
+
+    it "gets with a char" do
+      expect_raises(Exception, "Nil assertion failed") { "foo/bar"['-'] }
+    end
+  end
+
+  describe "[]?" do
+    it "gets with a string" do
       "FooBar"["Bar"]?.should eq "Bar"
       "FooBar"["Baz"]?.should be_nil
     end
@@ -159,15 +168,25 @@ describe "String" do
       "foo/bar"['-']?.should be_nil
     end
 
-    it "gets with index and []?" do
+    it "gets with index" do
       "hello"[1]?.should eq('e')
       "hello"[5]?.should be_nil
       "hello"[-1]?.should eq('o')
       "hello"[-6]?.should be_nil
     end
 
-    it "returns nil with []? if pointing after last char which is non-ASCII" do
+    it "returns nil if pointing after last char which is non-ASCII" do
       "ß"[1]?.should be_nil
+    end
+
+    it "gets with range" do
+      "hello"[1..2]?.should eq "el"
+      "hello"[6..-1]?.should be_nil
+    end
+
+    it "gets with start and count" do
+      "hello"[1, 3]?.should eq("ell")
+      "hello"[6, 3]?.should be_nil
     end
   end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -429,8 +429,8 @@ class Crystal::Command
     filenames += opt_filenames.not_nil!
     arguments = opt_arguments.not_nil!
 
-    if single_file && filenames.size > 1
-      arguments = filenames[1..-1] + arguments
+    if single_file && (files = filenames[1..-1]?)
+      arguments = files + arguments
       filenames = [filenames[0]]
     end
 


### PR DESCRIPTION
This adds `String#[Range]?`, `String#[Int, Int]?`, `Array[Range]?` and `Array#[Int, Int]?`.
Like the existing `String#[Int]?` and `Array#[Int]?`, the bound check is done internally.

Before:
```cr
ary = [1, 2, 3]
if var.size > 1
  sub = var[1..-1]
  ...
end
```
The  typical `.size > start_index` can now be removed.
```cr
ary = [1, 2, 3]
if sub = ary[1..-1]?
  ...
end
```