### PR TITLE
Fix formatting of `1\n.as(Int32)`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1059,6 +1059,7 @@ describe Crystal::Formatter do
   assert_format "page= <<-HTML\n  foo\nHTML", "page = <<-HTML\n  foo\nHTML"
   assert_format "page= <<-HTML\n  \#{1}foo\nHTML", "page = <<-HTML\n  \#{1}foo\nHTML"
 
+  assert_format "self.as(Int32)"
   assert_format "foo.as ( Int32* )", "foo.as(Int32*)"
   assert_format "foo.as   Int32*", "foo.as Int32*"
   assert_format "foo.as(T).bar"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1035,8 +1035,8 @@ describe Crystal::Formatter do
 
   assert_format "foo &.nil?"
   assert_format "foo &.bar.nil?"
-  assert_format "foo &.nil?()"
-  assert_format "foo &.bar.nil?()"
+  assert_format "foo &.nil?()", "foo &.nil?"
+  assert_format "foo &.bar.nil?()", "foo &.bar.nil?"
 
   assert_format "foo(<<-X,\na\nX\n  1)"
   assert_format "def bar\n  foo(<<-X,\n  a\n  X\n    1)\nend"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1040,6 +1040,8 @@ describe Crystal::Formatter do
   assert_format "foo &.nil?()", "foo &.nil?"
   assert_format "foo &.bar.nil?()", "foo &.bar.nil?"
 
+  assert_format "1 if nil?\na.b + c"
+
   assert_format "foo(<<-X,\na\nX\n  1)"
   assert_format "def bar\n  foo(<<-X,\n  a\n  X\n    1)\nend"
   assert_format %(run("a", 1))

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -559,9 +559,11 @@ describe Crystal::Formatter do
 
   assert_format "1.as   Int32", "1.as Int32"
   assert_format "foo.bar. as   Int32", "foo.bar.as Int32"
+  assert_format "1\n.as(Int32)", "1\n  .as(Int32)"
 
   assert_format "1.as?   Int32", "1.as? Int32"
   assert_format "foo.bar. as?   Int32", "foo.bar.as? Int32"
+  assert_format "1\n.as?(Int32)", "1\n  .as?(Int32)"
 
   assert_format "1 .. 2", "1..2"
   assert_format "1 ... 2", "1...2"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2189,7 +2189,7 @@ module Crystal
       end
 
       # Consider the case of `as T`, that is, casting `self` without an explicit `self`
-      if special_call && obj.is_a?(Var) && obj.name == "self" && @token.type != :self
+      if special_call && obj.is_a?(Var) && obj.name == "self" && !@token.keyword?(:self)
         obj = nil
       end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2433,7 +2433,7 @@ module Crystal
 
       # For special calls we want to format `.as (Int32)` into `.as(Int32)`
       # so we remove the space between "as" and "(".
-      skip_space_or_newline if special_call
+      skip_space if special_call
 
       if @token.type == :"("
         slash_is_regex!


### PR DESCRIPTION
Fixes #6006

This PR consists of two commits:
1. Let the formatter create fake `Call`s for special calls like `is_a?`, `as` and `responds_to?` and format these calls. This removes a lot of code that was special-cased for this. In this way the logic of formatting calls (which isn't that trivial because it tries to align columns, for example) is kept unified for all these calls. 
2. That commit alone already fixes #6006 but I added a couple of specs to prove it