### PR TITLE
Scheduler: resume only alive and non-current fibers

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -63,7 +63,11 @@ class Crystal::Scheduler
   end
 
   protected def reschedule : Nil
-    if runnable = @runnables.shift?
+    while runnable = @runnables.shift?
+      next if runnable == @current
+      break if runnable.alive
+    end
+    if runnable
       runnable.resume
     else
       Crystal::EventLoop.resume

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -62,6 +62,7 @@ class Fiber
 
   # :nodoc:
   property previous : Fiber?
+  property alive : Bool = true
 
   # :nodoc:
   def self.inactive(fiber : Fiber)
@@ -155,6 +156,7 @@ class Fiber
     ex.inspect_with_backtrace(STDERR)
     STDERR.flush
   ensure
+    @alive = false
     @@stack_pool << @stack
 
     # Remove the current fiber from the linked list


### PR DESCRIPTION
Fixes #3900

`select` when used with buffered channels can cause a single fiber to be enqueued multiple times.
This can cause `Crystal::Scheduler.reschedule` to segfault when:
- resuming an already dead fiber
- resuming the currently running fiber from itself

This PR fixes that by having an `@alive` flag associated with every fiber and resuming only alive and non-current fibers.