### PR TITLE
Add exception overload to `raise`

### DIFF
--- a/spec/std/raise_spec.cr
+++ b/spec/std/raise_spec.cr
@@ -13,7 +13,7 @@ describe "raise" do
   it "should reuse the previous callstack" do
     exception = expect_raises Exception, "with callstack" do
       begin
-        raise
+        raise ""
       rescue ex
         raise "with callstack", ex
       end

--- a/spec/std/raise_spec.cr
+++ b/spec/std/raise_spec.cr
@@ -10,6 +10,17 @@ describe "raise" do
     exception.callstack.should_not be_nil
   end
 
+  it "should reuse the previous callstack" do
+    exception = expect_raises Exception, "with callstack" do
+      begin
+        raise
+      rescue ex
+        raise "with callstack", ex
+      end
+    end
+    exception.callstack.should_not be_nil
+  end
+
   it "shouldn't overwrite the callstack on re-raise" do
     exception_after_reraise = expect_raises Exception, "exception to be rescued" do
       begin

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -229,8 +229,8 @@ end
 {% end %}
 
 # Raises an Exception with the *message*.
-def raise(message : String) : NoReturn
-  raise Exception.new(message)
+def raise(message : String? = nil, cause : Exception? = nil) : NoReturn
+  raise Exception.new(message, cause)
 end
 
 # :nodoc:

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -229,7 +229,7 @@ end
 {% end %}
 
 # Raises an Exception with the *message*.
-def raise(message : String? = nil, cause : Exception? = nil) : NoReturn
+def raise(message : String, cause : Exception? = nil) : NoReturn
   raise Exception.new(message, cause)
 end
 


### PR DESCRIPTION
The goal of this PR is to add the possibility to add an optional cause to `raise`,  as allowed by `Exception.new message, cause` – object used in the implementation.