### PR TITLE
make wait_readable and wait_writable public

### DIFF
--- a/src/io/syscall.cr
+++ b/src/io/syscall.cr
@@ -103,10 +103,12 @@ module IO::Syscall
     end
   end
 
+  # :nodoc:
   def wait_readable(timeout = @read_timeout)
     wait_readable(timeout: timeout) { |err| raise err }
   end
 
+  # :nodoc:
   def wait_readable(timeout = @read_timeout)
     readers = (@readers ||= Deque(Fiber).new)
     readers << Fiber.current
@@ -123,10 +125,12 @@ module IO::Syscall
 
   private abstract def add_read_event(timeout = @read_timeout)
 
+  # :nodoc:
   def wait_writable(timeout = @write_timeout)
     wait_writable(timeout: timeout) { |err| raise err }
   end
 
+  # :nodoc:
   def wait_writable(timeout = @write_timeout)
     writers = (@writers ||= Deque(Fiber).new)
     writers << Fiber.current

--- a/src/io/syscall.cr
+++ b/src/io/syscall.cr
@@ -103,11 +103,11 @@ module IO::Syscall
     end
   end
 
-  private def wait_readable(timeout = @read_timeout)
+  def wait_readable(timeout = @read_timeout)
     wait_readable(timeout: timeout) { |err| raise err }
   end
 
-  private def wait_readable(timeout = @read_timeout)
+  def wait_readable(timeout = @read_timeout)
     readers = (@readers ||= Deque(Fiber).new)
     readers << Fiber.current
     add_read_event(timeout)
@@ -123,11 +123,11 @@ module IO::Syscall
 
   private abstract def add_read_event(timeout = @read_timeout)
 
-  private def wait_writable(timeout = @write_timeout)
+  def wait_writable(timeout = @write_timeout)
     wait_writable(timeout: timeout) { |err| raise err }
   end
 
-  private def wait_writable(timeout = @write_timeout)
+  def wait_writable(timeout = @write_timeout)
     writers = (@writers ||= Deque(Fiber).new)
     writers << Fiber.current
     add_write_event(timeout)


### PR DESCRIPTION
These methods are useful for integrating 3rd party libraries that require you to wait for a readable or writable socket.
Example [libssh2](https://github.com/libssh2/libssh2/blob/master/example/ssh2_exec.c)
How this is implemented in crystal: https://github.com/spider-gazelle/ssh2.cr/blob/a93eb957420b9e9f31bb8cd46e50ff862c5bc54b/src/session.cr#L39-L49