### PR TITLE
http client: Fallback to default mime type 'application/octet-stream'

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -3,13 +3,13 @@ require "openssl"
 require "http/client"
 require "http/server"
 
-private def test_server(host, port, read_time = 0)
+private def test_server(host, port, read_time = 0, content_type = "text/plain")
   server = TCPServer.new(host, port)
   begin
     spawn do
       io = server.accept
       sleep read_time
-      response = HTTP::Client::Response.new(200, headers: HTTP::Headers{"Content-Type" => "text/plain"}, body: "OK")
+      response = HTTP::Client::Response.new(200, headers: HTTP::Headers{"Content-Type" => content_type}, body: "OK")
       response.to_io(io)
       io.flush
     end
@@ -209,6 +209,13 @@ module HTTP
       test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.connect_timeout = 0.5
+        client.get("/")
+      end
+    end
+
+    it "tests empty Content-Type" do
+      test_server("localhost", 0, content_type: "") do |server|
+        client = Client.new("localhost", server.local_address.port)
         client.get("/")
       end
     end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -74,12 +74,16 @@ module HTTP
   private def self.check_content_type_charset(body, headers)
     return unless body
 
-    if content_type = headers["Content-Type"]?
-      mime_type = MIME::MediaType.parse(content_type)
-      if charset = mime_type["charset"]?
-        body.set_encoding(charset, invalid: :skip)
-      end
-    end
+    content_type = headers["Content-Type"]?
+    return unless content_type
+
+    mime_type = MIME::MediaType.parse?(content_type)
+    return unless mime_type
+
+    charset = mime_type["charset"]?
+    return unless charset
+
+    body.set_encoding(charset, invalid: :skip)
   end
 
   # :nodoc:


### PR DESCRIPTION
Fixes #7370 

Uses a default mime type as a fallback when the `Content-Type` header cannot be parsed.

I'm not sure about the `DEFAULT_MIME_TYPE` as a constant, should the user be able to customize the default mime type?