### PR TITLE
Fix/ssl shutdown

### DIFF
--- a/spec/manual/https_client_spec.cr
+++ b/spec/manual/https_client_spec.cr
@@ -1,0 +1,15 @@
+require "spec"
+require "openssl"
+require "http"
+
+describe "https requests" do
+  it "can fetch from google.com" do
+    HTTP::Client.get("https://google.com")
+  end
+
+  it "can close request before consuming body" do
+    HTTP::Client.get("https://crystal-lang.org") do
+      break
+    end
+  end
+end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -165,6 +165,10 @@ abstract class OpenSSL::SSL::Socket < IO
           case e.error
           when .want_read?, .want_write?
             # Ignore, shutdown did not complete yet
+          when .syscall?
+            # OpenSSL claimed an underlying syscall failed, but that didn't set any error state,
+            # assume we're done
+            break
           else
             raise e
           end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -148,19 +148,6 @@ abstract class OpenSSL::SSL::Socket < IO
           ret = LibSSL.ssl_shutdown(@ssl)
           break if ret == 1
           raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_shutdown") if ret < 0
-        rescue e : Errno
-          case e.errno
-          when 0
-            # OpenSSL claimed an underlying syscall failed, but that didn't set any error state,
-            # assume we're done
-            break
-          when Errno::EAGAIN
-            # Ignore/retry, shutdown did not complete yet
-          when Errno::EINPROGRESS
-            # Ignore/retry, another operation not complete yet
-          else
-            raise e
-          end
         rescue e : OpenSSL::SSL::Error
           case e.error
           when .want_read?, .want_write?


### PR DESCRIPTION
Fix #7364

After #7068 the logic to ignore the `OpenSSL::SSL::Error::SYSCALL` while closing the connection was lost.

This PR also removes unused code for when `Errno` was raised.

It adds some manual specs that exhibited issues: request to google and closing the connection before consuming the body. These are domain sensible.