### PR TITLE
 Add `options` argument to String#camelcase and String#underscore

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -913,7 +913,7 @@ class String
   def downcase(options = Unicode::CaseOptions::None)
     return self if empty?
 
-    if ascii_only?
+    if ascii_only? && (options.none? || options.ascii?)
       String.new(bytesize) do |buffer|
         bytesize.times do |i|
           buffer[i] = to_unsafe[i].unsafe_chr.downcase.ord.to_u8

--- a/src/string.cr
+++ b/src/string.cr
@@ -3382,7 +3382,7 @@ class String
   # "HTTP_CLIENT".underscore            # => "http_client"
   # "3.14IsPi".underscore               # => "3.14_is_pi"
   # ```
-  def underscore
+  def underscore(options = Unicode::CaseOptions::None)
     first = true
     last_is_downcase = false
     last_is_upcase = false
@@ -3391,12 +3391,12 @@ class String
 
     String.build(bytesize + 10) do |str|
       each_char do |char|
-        digit = '0' <= char <= '9'
-        downcase = 'a' <= char <= 'z' || digit
-        upcase = 'A' <= char <= 'Z'
+        digit = char.ascii_number?
+        downcase = char.ascii_lowercase? || digit
+        upcase = char.ascii_uppercase?
 
         if first
-          str << char.downcase
+          str << char.downcase(options)
         elsif last_is_downcase && upcase
           if mem
             # This is the case of A1Bcd, we need to put 'mem' (not to need to convert as downcase
@@ -3408,7 +3408,7 @@ class String
           # This is the case of AbcDe, we need to put an underscore before the 'D'
           #                        ^
           str << '_'
-          str << char.downcase
+          str << char.downcase(options)
         elsif (last_is_upcase || last_is_digit) && (upcase || digit)
           # This is the case of 1) A1Bcd, 2) A1BCd or 3) A1B_cd:if the next char is upcase (case 1) we need
           #                          ^         ^           ^
@@ -3418,7 +3418,7 @@ class String
           # 3) we need to append this char as downcase and then a single underscore
           if mem
             # case 2
-            str << mem.downcase
+            str << mem.downcase(options)
           end
           mem = char
         else
@@ -3429,11 +3429,11 @@ class String
               # case 1
               str << '_'
             end
-            str << mem.downcase
+            str << mem.downcase(options)
             mem = nil
           end
 
-          str << char.downcase
+          str << char.downcase(options)
         end
 
         last_is_downcase = downcase
@@ -3442,7 +3442,7 @@ class String
         first = false
       end
 
-      str << mem.downcase if mem
+      str << mem.downcase(options) if mem
     end
   end
 
@@ -3451,7 +3451,7 @@ class String
   # ```
   # "eiffel_tower".camelcase # => "EiffelTower"
   # ```
-  def camelcase
+  def camelcase(options = Unicode::CaseOptions::None)
     return self if empty?
 
     first = true
@@ -3460,11 +3460,11 @@ class String
     String.build(bytesize) do |str|
       each_char do |char|
         if first
-          str << char.upcase
+          str << char.upcase(options)
         elsif char == '_'
           last_is_underscore = true
         elsif last_is_underscore
-          str << char.upcase
+          str << char.upcase(options)
           last_is_underscore = false
         else
           str << char

--- a/src/string.cr
+++ b/src/string.cr
@@ -913,7 +913,7 @@ class String
   def downcase(options = Unicode::CaseOptions::None)
     return self if empty?
 
-    if ascii_only? && (options.none? || options.ascii?)
+    if ascii_only?
       String.new(bytesize) do |buffer|
         bytesize.times do |i|
           buffer[i] = to_unsafe[i].unsafe_chr.downcase.ord.to_u8

--- a/src/string.cr
+++ b/src/string.cr
@@ -3383,7 +3383,7 @@ class String
   # "3.14IsPi".underscore                                       # => "3.14_is_pi"
   # "InterestingImage".underscore(Unicode::CaseOptions::Turkic) # => "ınteresting_ımage"
   # ```
-  def underscore(options = Unicode::CaseOptions::None)
+  def underscore(options : Unicode::CaseOptions = Unicode::CaseOptions::None)
     first = true
     last_is_downcase = false
     last_is_upcase = false
@@ -3459,7 +3459,7 @@ class String
   # "eiffel_tower".camelcase                                   # => "EiffelTower"
   # "isolated_integer".camelcase(Unicode::CaseOptions::Turkic) # => "İsolatedİnteger"
   # ```
-  def camelcase(options = Unicode::CaseOptions::None)
+  def camelcase(options : Unicode::CaseOptions = Unicode::CaseOptions::None)
     return self if empty?
 
     first = true

--- a/src/string.cr
+++ b/src/string.cr
@@ -3377,10 +3377,11 @@ class String
   # Converts camelcase boundaries to underscores.
   #
   # ```
-  # "DoesWhatItSaysOnTheTin".underscore # => "does_what_it_says_on_the_tin"
-  # "PartyInTheUSA".underscore          # => "party_in_the_usa"
-  # "HTTP_CLIENT".underscore            # => "http_client"
-  # "3.14IsPi".underscore               # => "3.14_is_pi"
+  # "DoesWhatItSaysOnTheTin".underscore                         # => "does_what_it_says_on_the_tin"
+  # "PartyInTheUSA".underscore                                  # => "party_in_the_usa"
+  # "HTTP_CLIENT".underscore                                    # => "http_client"
+  # "3.14IsPi".underscore                                       # => "3.14_is_pi"
+  # "InterestingImage".underscore(Unicode::CaseOptions::Turkic) # => "ınteresting_ımage"
   # ```
   def underscore(options = Unicode::CaseOptions::None)
     first = true
@@ -3392,8 +3393,14 @@ class String
     String.build(bytesize + 10) do |str|
       each_char do |char|
         digit = char.ascii_number?
-        downcase = char.ascii_lowercase? || digit
-        upcase = char.ascii_uppercase?
+
+        if options.none?
+          downcase = digit || char.ascii_lowercase?
+          upcase = char.ascii_uppercase?
+        else
+          downcase = digit || char.lowercase?
+          upcase = char.uppercase?
+        end
 
         if first
           str << char.downcase(options)
@@ -3449,7 +3456,8 @@ class String
   # Converts underscores to camelcase boundaries.
   #
   # ```
-  # "eiffel_tower".camelcase # => "EiffelTower"
+  # "eiffel_tower".camelcase                                   # => "EiffelTower"
+  # "isolated_integer".camelcase(Unicode::CaseOptions::Turkic) # => "İsolatedİnteger"
   # ```
   def camelcase(options = Unicode::CaseOptions::None)
     return self if empty?


### PR DESCRIPTION
That are the only methods that upcase or downcase a string internally and don't have an `options` argument. Because what if you speak Turkish and want to camelcase `"interesting_integer"` to `"İnterestingİnteger"` instead of `"InterestingInteger"`? And `String#capitalize` has it too so I don't see why these shouldn't have it.