### PR TITLE
Make OverflowError's message a bit more detailed

### DIFF
--- a/src/exception.cr
+++ b/src/exception.cr
@@ -133,12 +133,12 @@ end
 # that can be represented within the given operands types.
 #
 # ```
-# Int32::MAX + 1      # raises OverflowError (Overflow)
-# Int32::MIN - 1      # raises OverflowError (Overflow)
-# Float64::MAX.to_f32 # raises OverflowError (Overflow)
+# Int32::MAX + 1      # raises OverflowError (Arithmetic overflow)
+# Int32::MIN - 1      # raises OverflowError (Arithmetic overflow)
+# Float64::MAX.to_f32 # raises OverflowError (Arithmetic overflow)
 # ```
 class OverflowError < Exception
-  def initialize(message = "Overflow")
+  def initialize(message = "Arithmetic overflow")
     super(message)
   end
 end


### PR DESCRIPTION
This changes the error message to `"Arithmetic overflow"`. Whenever I look at it, it feels so empty. Like there's something missing. Also currently it's the only error message which has only one word as the message and is thus IMO the most undescriptive one. It could also be confused with a stack overflow.

CC @bcardiff 