### PR TITLE
Fix windows monotonic time bug

### DIFF
--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -49,7 +49,7 @@ module Crystal::System::Time
       raise WinError.new("QueryPerformanceCounter")
     end
 
-    {ticks / @@performance_frequency, (ticks.remainder(NANOSECONDS_PER_SECOND) * NANOSECONDS_PER_SECOND / @@performance_frequency).to_i32}
+    {ticks / @@performance_frequency, (ticks.remainder(@@performance_frequency) * NANOSECONDS_PER_SECOND / @@performance_frequency).to_i32}
   end
 
   def self.load_localtime : ::Time::Location?


### PR DESCRIPTION
Performance frequency isn't necessarily 1 billion, so we now take the correct remainder.

For example, on my system it is only 10 million, so I only get 100 ns precision.

If this is considered "not minor", let me know and I can open an issue for this pull request.