### PR TITLE
CI: Test linux 64 bits package using docker image recent build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,27 @@ jobs:
           path: /tmp/workspace/build
           destination: dist_packages
 
+  test_dist_linux_on_docker:
+    machine: true
+    environment:
+      <<: *env
+      TRAVIS_OS_NAME: linux
+      ARCH: x86_64
+      ARCH_CMD: linux64
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: |
+          cd /tmp/workspace/distribution-scripts
+          source ./build.env
+          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}.tar.gz | docker image load
+          export DOCKER_TEST_PREFIX="crystallang/crystal:$DOCKER_TAG" >> $BASH_ENV
+      - checkout
+      - run: bin/ci prepare_system
+      - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
+      - run: bin/ci prepare_build
+      - run: bin/ci build
+
 workflows:
   version: 2
   test_all_platforms:
@@ -309,6 +330,7 @@ workflows:
                 - master
           requires:
             - test_linux
+
   tagged_release:
     jobs:
       - test_linux:
@@ -350,6 +372,10 @@ workflows:
           filters: *per_tag
           requires:
             - dist_linux
+      - test_dist_linux_on_docker:
+          filters: *per_tag
+          requires:
+            - dist_docker
       # Tagged release do not publish docker images since they are unsigned
       # publish_docker:
       - dist_docs:
@@ -399,6 +425,9 @@ workflows:
       - dist_docker:
           requires:
             - dist_linux
+      - test_dist_linux_on_docker:
+          requires:
+            - dist_docker
       - publish_docker:
           requires:
             - dist_docker
@@ -454,6 +483,10 @@ workflows:
           filters: *maintenance
           requires:
             - dist_linux
+      - test_dist_linux_on_docker:
+          filters: *maintenance
+          requires:
+            - dist_docker
       - publish_docker:
           filters: *maintenance
           requires:

--- a/bin/ci
+++ b/bin/ci
@@ -114,7 +114,7 @@ with_build_env() {
 
   on_linux verify_linux_environment
 
-  export DOCKER_TEST_PREFIX="crystallang/crystal:0.27.1"
+  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:=crystallang/crystal:0.27.1}"
 
   case $ARCH in
     x86_64)


### PR DESCRIPTION
This PR will run the specs using the distributable linux 64 package inside the docker image built.

For nightlies and maintenance releases it uses de same docker image that is pushed to docker hub.
For tagged release it uses a docker image that was already built but that is not pushed since the binaries are not signed.

This would have caught some of the regressions in 0.27.1