### PR TITLE
enum parse macro to no longer parse virtual `None` or `All` members

### DIFF
--- a/src/enum.cr
+++ b/src/enum.cr
@@ -405,6 +405,7 @@ struct Enum
   # the enum members names, so a member named "FourtyTwo" or "FOURTY_TWO"
   # is found with any of these strings: "fourty_two", "FourtyTwo", "FOURTY_TWO",
   # "FOURTYTWO", "fourtytwo".
+  # It won't parse the `None` and `All` members of flags enums.
   #
   # ```
   # Color.parse?("Red")    # => Color::Red
@@ -415,8 +416,10 @@ struct Enum
     {% begin %}
       case string.camelcase.downcase
       {% for member in @type.constants %}
-        when {{member.stringify.camelcase.downcase}}
-          {{@type}}::{{member}}
+        {% unless @type.has_attribute?("Flags") && %w(none all).includes?(member.stringify.downcase) %}
+          when {{member.stringify.camelcase.downcase}}
+            {{@type}}::{{member}}
+        {% end %}
       {% end %}
       else
         nil


### PR DESCRIPTION
Using crystal 0.27.2 on OSX
When I execute the following code:

```crystal
OpenSSL::SSL::VerifyMode.parse("peer")
```

I get `duplicate when "none" in case`:
![image](https://user-images.githubusercontent.com/368013/52320094-6ea36480-2a21-11e9-9b08-5090c24207ad.png)

However looking the [definition](https://github.com/crystal-lang/crystal/blob/master/src/openssl/lib_ssl.cr#L52) of that enum:
```crystal
  @[Flags]
  enum VerifyMode : Int
    NONE                 = 0
    PEER                 = 1
    FAIL_IF_NO_PEER_CERT = 2
    CLIENT_ONCE          = 4
  end
```

The macro that builds `.parse?` needs to ignore the built in `None` and `All` members for this code to compile.