### PR TITLE
Compiler: always mention the scope (and with ... yield scope, if any) on undefined method error

### DIFF
--- a/spec/compiler/semantic/did_you_mean_spec.cr
+++ b/spec/compiler/semantic/did_you_mean_spec.cr
@@ -237,8 +237,6 @@ describe "Semantic: did you mean" do
   end
 
   it "suggests a better alternative to logical operators (#2715)" do
-    message = "undefined method 'and'"
-    message = " (did you mean '&&'?)".colorize.yellow.bold.to_s
     assert_error %(
       def rand(x : Int32)
       end
@@ -252,7 +250,8 @@ describe "Semantic: did you mean" do
       if "a".bytes and 1
         1
       end
-      ), message
+      ),
+      "undefined method 'and' for top-level (did you mean '&&'?)"
   end
 
   it "says did you mean in instance var declaration" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "undefined local variable or method 'allocate' for Moo:Module #{" (modules cannot be instantiated)".colorize.yellow.bold}"
+      "undefined local variable or method 'allocate' for Moo:Module (modules cannot be instantiated)"
   end
 
   it "gives error when trying to instantiate with allocate" do
@@ -924,7 +924,7 @@ describe "Semantic: module" do
         end
       end
       Moo.allocate),
-      "undefined method 'allocate' for Moo:Module#{" (modules cannot be instantiated)".colorize.yellow.bold}"
+      "undefined method 'allocate' for Moo:Module (modules cannot be instantiated)"
   end
 
   it "uses type declaration inside module" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -914,7 +914,7 @@ describe "Semantic: module" do
         end
       end
       Moo.new),
-      "undefined local variable or method 'allocate'#{" (modules cannot be instantiated)".colorize.yellow.bold}"
+      "undefined local variable or method 'allocate' for Moo:Module #{" (modules cannot be instantiated)".colorize.yellow.bold}"
   end
 
   it "gives error when trying to instantiate with allocate" do

--- a/spec/compiler/semantic/yield_with_scope_spec.cr
+++ b/spec/compiler/semantic/yield_with_scope_spec.cr
@@ -186,4 +186,23 @@ describe "Semantic: yield with scope" do
       Bar.new.bar
       )) { int32 }
   end
+
+  it "mentions with yield scope and current scope in error" do
+    assert_error %(
+      def foo
+        with 1 yield
+      end
+
+      class Foo
+        def bar
+          foo do
+            baz
+          end
+        end
+      end
+
+      Foo.new.bar
+      ),
+      "undefined local variable or method 'baz' for Int32 (with ... yield) and Foo (current scope)"
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -47,7 +47,7 @@ def semantic(code : String, wants_doc = false, inject_primitives = true)
 end
 
 def semantic(node : ASTNode, wants_doc = false)
-  program = Program.new
+  program = new_program
   program.wants_doc = wants_doc
   node = program.normalize node
   node = program.semantic node
@@ -56,7 +56,7 @@ end
 
 def semantic_result(str, flags = nil, inject_primitives = true)
   str = inject_primitives(str) if inject_primitives
-  program = Program.new
+  program = new_program
   program.flags.concat(flags.split) if flags
   input = parse str
   input = program.normalize input
@@ -66,7 +66,7 @@ def semantic_result(str, flags = nil, inject_primitives = true)
 end
 
 def assert_normalize(from, to, flags = nil)
-  program = Program.new
+  program = new_program
   program.flags.concat(flags.split) if flags
   normalizer = Normalizer.new(program)
   from_nodes = Parser.parse(from)
@@ -79,7 +79,7 @@ def assert_expand(from : String, to)
 end
 
 def assert_expand(from_nodes : ASTNode, to)
-  to_nodes = LiteralExpander.new(Program.new).expand(from_nodes)
+  to_nodes = LiteralExpander.new(new_program).expand(from_nodes)
   to_nodes.to_s.strip.should eq(to.strip)
 end
 
@@ -113,7 +113,7 @@ def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas =
 end
 
 def assert_macro(macro_args, macro_body, expected, expected_pragmas = nil, flags = nil)
-  program = Program.new
+  program = new_program
   program.flags.concat(flags.split) if flags
   sub_node = yield program
   assert_macro_internal program, sub_node, macro_args, macro_body, expected, expected_pragmas
@@ -135,6 +135,12 @@ def codegen(code, inject_primitives = true, debug = Crystal::Debug::None)
   node = parse code
   result = semantic node
   result.program.codegen(result.node, single_module: false, debug: debug)[""].mod
+end
+
+private def new_program
+  program = Program.new
+  program.color = false
+  program
 end
 
 class Crystal::SpecRunOutput
@@ -183,7 +189,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
 
     SpecRunOutput.new(output)
   else
-    Program.new.run(code, filename: filename, debug: debug)
+    new_program.run(code, filename: filename, debug: debug)
   end
 end
 


### PR DESCRIPTION
Fixes #7357

For the code in the issue:

```crystal
def make_object
  "test"
  puts "This was my error"
end

def doit
	with make_object() yield
end

doit {
  size
}
```

You now get this error:

```
Error in baz.cr:11: instantiating 'doit()'

doit {
^~~~

in baz.cr:11: instantiating 'doit()'

doit {
^~~~

in baz.cr:12: undefined local variable or method 'size' for Nil (for `with ... yield`) and top-level (current scope)

  size
  ^~~~
```

The error now mentions both scopes (in order) where the method was searched.

Additionally, the scope is now always mentioned to make it easy to understand what went wrong. For example, for this code:

```crystal
hello
```

Before: `undefined local variable or method 'hello'`
After: `undefined local variable or method 'hello' for top-level`

Similarly, for this code:

```crystal
class Foo
  def foo
    hello
  end
end

Foo.new.foo
```

Before: `undefined local variable or method 'hello'`
After: `undefined local variable or method 'hello' for Foo`

Or...

```crystal
class Foo
  def self.foo
    hello
  end
end

Foo.foo
```

Before: `undefined local variable or method 'hello'`
After: `undefined local variable or method 'hello' for Foo.class` ("Ooooh... I totally forgot I was in a class method!")