### PR TITLE
Compiler: fix wrong exception type thrown on missing require

### DIFF
--- a/spec/compiler/semantic/require_spec.cr
+++ b/spec/compiler/semantic/require_spec.cr
@@ -1,0 +1,10 @@
+require "../../spec_helper"
+
+describe "Semantic: require" do
+  it "raises crystal exception if can't find require (#7385)" do
+    node = parse(%(require "file_that_doesnt_exist"))
+    expect_raises ::Crystal::Exception do
+      semantic(node)
+    end
+  end
+end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -1,8 +1,9 @@
 require "./config"
+require "./exception"
 
 module Crystal
   struct CrystalPath
-    class Error < Exception
+    class Error < LocationlessException
     end
 
     def self.default_path


### PR DESCRIPTION
Fixes #7385

The problem was that `Error < Exception` should have been something like `Error < Crystal::Exception` but that class wasn't defined yet.