### PR TITLE
Run formatter in travis. Update /bin/ci usage instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: ARCH=x86_64 ARCH_CMD=linux64
+    - env: ARCH=x86_64 ARCH_CMD=linux64 CI_CMD=build
+      os: linux
+    - env: ARCH=x86_64 ARCH_CMD=linux64 CI_CMD=format
       os: linux
 
 git:
@@ -25,7 +27,7 @@ install:
   - travis_retry bin/ci prepare_build
 
 script:
-  - travis_retry bin/ci build
+  - travis_retry bin/ci $CI_CMD
 
 branches:
   only:

--- a/bin/ci
+++ b/bin/ci
@@ -150,7 +150,8 @@ Helper script to prepare and run the testsuite on Travis CI.
 Commands:
   prepare_system          setup any necessaries repositories etc.
   prepare_build           download and extract any dependencies needed for the build
-  build                   run specs, build crystal, run format check, build samples, build the docs
+  build                   run specs, build crystal, build samples, build the docs
+  format                  build crystal, run format check
   with_build_env command  run command in the build environment
   help                    display this
 


### PR DESCRIPTION
I've found some leftovers from after #7228

Since forks might not have CircleCI it would be good to keep checking the format there. The same rules as in CircleCI applies using different jobs for format checking and specs.