### PR TITLE
Avoid fork and spawn when `--threads=1` and use that for CI

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -73,13 +73,13 @@ prepare_system() {
 }
 
 build() {
-  with_build_env 'make std_spec clean'
-  with_build_env 'make crystal std_spec compiler_spec docs'
+  with_build_env 'make std_spec clean threads=1'
+  with_build_env 'make crystal std_spec compiler_spec docs threads=1'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
 }
 
 format() {
-  with_build_env 'make clean crystal'
+  with_build_env 'make clean crystal threads=1'
   with_build_env './bin/crystal tool format --check samples spec src'
 }
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -397,8 +397,8 @@ module Crystal
       wants_stats_or_progress = @progress_tracker.stats? || @progress_tracker.progress?
 
       # If threads is 1 and no stats/progress is needed we can avoid
-      # fork/spwan/channels altogether. This is particularly useful for
-      # CI becuase there forking eventually leads to "out of memory" errors.
+      # fork/spawn/channels altogether. This is particularly useful for
+      # CI because there forking eventually leads to "out of memory" errors.
       if @n_threads == 1
         units.each do |unit|
           unit.compile


### PR DESCRIPTION
This PR consists of two commits:
- the first one improves the compiler by not forking/spawning at all when `--threads=1` is passed. This is a general useful change because currently we are always spawning and forking for no reason in this case.
- the second one changes the CI scripts to pass `--threads=1` when compiling the compiler and specs. This avoids allocating a bit more memory because `fork` seems to require that (when changes happen memory is copied) and, as shown in #7395, this makes some existing PRs that are failing now pass.

Changing CI to `--threads=1` doesn't change completion time a lot, or at all, because most of the time is spent running the thousands of specs we have.

This is obviously a change almost exclusive to let the CI handle bigger programs and spec suites. I'd like to eventually improve the compiler's performance and memory consumption but for now this is a bit hard. The best we can do right now is to make this change so the CI doesn't fail... it's mostly a problem that happens in CI because anyone with a more or less recent computer should be able to compile the compiler and all the specs just fine (I currently have a MacBook Pro Late 2013).