### PR TITLE
 Suggest `next` when trying to break from captured block 

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1075,7 +1075,7 @@ describe "Block inference" do
 
       bar
       ),
-      "can't break from captured block"
+      "can't break from captured block, use next"
   end
 
   it "errors if doing next in proc literal" do

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1075,7 +1075,7 @@ describe "Block inference" do
 
       bar
       ),
-      "can't break from captured block, use `next`, however `next` will have behave differently when used in a block or a loop inside of the captured block."
+      "can't break from captured block, try using `next` to exit the block."
   end
 
   it "errors if doing next in proc literal" do

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1085,7 +1085,7 @@ describe "Block inference" do
       }
       foo.call
       ),
-      "Invalid next"
+      "invalid next"
   end
 
   it "does next from captured block" do

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1075,7 +1075,7 @@ describe "Block inference" do
 
       bar
       ),
-      "can't break from captured block, try using `next` to exit the block."
+      "can't break from captured block, try using `next`."
   end
 
   it "errors if doing next in proc literal" do

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1075,7 +1075,7 @@ describe "Block inference" do
 
       bar
       ),
-      "can't break from captured block, use next"
+      "can't break from captured block, use `next`, however `next` will have behave differently when used in a block or a loop inside of the captured block."
   end
 
   it "errors if doing next in proc literal" do

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -15,7 +15,7 @@ describe "Semantic: while" do
 
   it "reports break cannot be used outside a while" do
     assert_error "break",
-      "Invalid break"
+      "invalid break"
   end
 
   it "types while true as NoReturn" do
@@ -32,7 +32,7 @@ describe "Semantic: while" do
 
   it "reports next cannot be used outside a while" do
     assert_error "next",
-      "Invalid next"
+      "invalid next"
   end
 
   it "uses var type inside while if endless loop" do

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2299,7 +2299,7 @@ module Crystal
         break_vars.push @vars.dup
       else
         if @typed_def.try &.captured_block?
-          node.raise "can't break from captured block, use `next`, however `next` will have behave differently when used in a block or a loop inside of the captured block."
+          node.raise "can't break from captured block, try using `next` to exit the block."
         end
 
         node.raise "invalid break"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2299,7 +2299,7 @@ module Crystal
         break_vars.push @vars.dup
       else
         if @typed_def.try &.captured_block?
-          node.raise "can't break from captured block, try using `next` to exit the block."
+          node.raise "can't break from captured block, try using `next`."
         end
 
         node.raise "invalid break"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2302,7 +2302,7 @@ module Crystal
           node.raise "can't break from captured block, use next"
         end
 
-        node.raise "Invalid break"
+        node.raise "invalid break"
       end
 
       node.type = @program.no_return
@@ -2332,7 +2332,7 @@ module Crystal
           node.target = typed_def
           typed_def.bind_to(node_exp_or_nil_literal(node))
         else
-          node.raise "Invalid next"
+          node.raise "invalid next"
         end
       end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2299,7 +2299,7 @@ module Crystal
         break_vars.push @vars.dup
       else
         if @typed_def.try &.captured_block?
-          node.raise "can't break from captured block"
+          node.raise "can't break from captured block, use next"
         end
 
         node.raise "Invalid break"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2299,7 +2299,7 @@ module Crystal
         break_vars.push @vars.dup
       else
         if @typed_def.try &.captured_block?
-          node.raise "can't break from captured block, use next"
+          node.raise "can't break from captured block, use `next`, however `next` will have behave differently when used in a block or a loop inside of the captured block."
         end
 
         node.raise "invalid break"


### PR DESCRIPTION
When doing this:
```cr
def method(&block)
  block.call
end

method do
  break
end
```
then you get `Error in line 6: can't break from captured block`.
Now this makes the error message suggest `next` because when using `break` in a captured block you most likely tried to escape from the captured block and `next` makes that possible.
Also when you instead try to `return` from a captured block, it gives you a helpful error message: `Error in line 6: can't return from captured block, use next` so why not suggest `next` in case of `break` too?

This also downcases `next`'s and `break`'s error message just like all the other error messages.