### PR TITLE
Fix `Signal::CHLD.reset` not clearing previously set handler, and fix related race condition in spec

### DIFF
--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -50,5 +50,25 @@ describe "Signal" do
     called.should be_true
   end
 
+  it "CHLD.reset removes previously set trap" do
+    call_count = 0
+
+    Signal::CHLD.trap do
+      call_count += 1
+    end
+
+    Process.new("true", shell: true).wait
+    Fiber.yield
+
+    call_count.should eq(1)
+
+    Signal::CHLD.reset
+
+    Process.new("true", shell: true).wait
+    Fiber.yield
+
+    call_count.should eq(1)
+  end
+
   # TODO: test Signal::X.reset
 end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -178,7 +178,9 @@ module Crystal::Signal
 
   private def self.set(signal, handler)
     if signal == ::Signal::CHLD
-      # don't reset/ignore SIGCHLD, Process#wait requires it
+      # Clear any existing signal child handler
+      @@child_handler = nil
+      # But keep a default SIGCHLD, Process#wait requires it
       trap(signal, ->(signal : ::Signal) {
         Crystal::SignalChildHandler.call
         @@child_handler.try(&.call(signal))


### PR DESCRIPTION
Fixes #7243

I thought about many ways to fix the race condition in this spec... I think the only safe alternative is to use a channel and send that over to the signal handler. If the handler runs before we send the channel, it will wait. If it runs later, the process will be already finished.

The only problem with this spec is that if the CHLD handler doesn't run for some reason (bug) then the spec will wait forever in `chan.send` because nobody will consume it. However, given that everything is working well now I don't this as a big problem, plus signal handling code doesn't change that frequently.