### PR TITLE
Optimize dwarf line numbers decoding

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -279,7 +279,7 @@ struct CallStack
           end
 
           strings = mach_o.read_section?("__debug_str") do |sh, io|
-            Debug::DWARF::Strings.new(io, sh.offset)
+            Debug::DWARF::Strings.new(io, sh.offset, sh.size)
           end
 
           mach_o.read_section?("__debug_info") do |sh, io|
@@ -381,7 +381,7 @@ struct CallStack
           end
 
           strings = elf.read_section?(".debug_str") do |sh, io|
-            Debug::DWARF::Strings.new(io, sh.offset)
+            Debug::DWARF::Strings.new(io, sh.offset, sh.size)
           end
 
           elf.read_section?(".debug_info") do |sh, io|

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -223,10 +223,7 @@ struct CallStack
       read_dwarf_sections unless @@dwarf_line_numbers
       if ln = @@dwarf_line_numbers
         if row = ln.find(pc)
-          path = ln.files[row.file]?
-          if dirname = ln.directories[row.directory]?
-            path = "#{dirname}/#{path}"
-          end
+          path = "#{row.directory}/#{row.file}"
           return {path, row.line, row.column}
         end
       end

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -282,11 +282,7 @@ struct CallStack
           mach_o.read_section?("__debug_info") do |sh, io|
             names = [] of {LibC::SizeT, LibC::SizeT, String}
 
-            while true
-              pos = io.pos
-              offset = pos - sh.offset
-              break unless offset < sh.size
-
+            while (offset = io.pos - sh.offset) < sh.size
               info = Debug::DWARF::Info.new(io, offset)
 
               mach_o.read_section?("__debug_abbrev") do |sh, io|
@@ -387,11 +383,7 @@ struct CallStack
           elf.read_section?(".debug_info") do |sh, io|
             names = [] of {LibC::SizeT, LibC::SizeT, String}
 
-            while true
-              pos = io.pos
-              offset = pos - sh.offset
-              break unless offset < sh.size
-
+            while (offset = io.pos - sh.offset) < sh.size
               info = Debug::DWARF::Info.new(io, offset)
 
               elf.read_section?(".debug_abbrev") do |sh, io|

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -285,8 +285,11 @@ struct CallStack
           mach_o.read_section?("__debug_info") do |sh, io|
             names = [] of {LibC::SizeT, LibC::SizeT, String}
 
-            while io.tell - sh.offset < sh.size
-              offset = io.tell - sh.offset
+            while true
+              pos = io.pos
+              offset = pos - sh.offset
+              break unless offset < sh.size
+
               info = Debug::DWARF::Info.new(io, offset)
 
               mach_o.read_section?("__debug_abbrev") do |sh, io|
@@ -387,8 +390,11 @@ struct CallStack
           elf.read_section?(".debug_info") do |sh, io|
             names = [] of {LibC::SizeT, LibC::SizeT, String}
 
-            while io.tell - sh.offset < sh.size
-              offset = io.tell - sh.offset
+            while true
+              pos = io.pos
+              offset = pos - sh.offset
+              break unless offset < sh.size
+
               info = Debug::DWARF::Info.new(io, offset)
 
               elf.read_section?(".debug_abbrev") do |sh, io|

--- a/src/debug/dwarf/info.cr
+++ b/src/debug/dwarf/info.cr
@@ -118,7 +118,7 @@ module Debug
         when FORM::RefSig8
           @io.read_bytes(UInt64)
         when FORM::String
-          @io.gets('\0').to_s.chomp('\0')
+          @io.gets('\0', chomp: true).to_s
         when FORM::Strp
           read_ulong
         when FORM::Indirect

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -389,20 +389,54 @@ module Debug
         end
       end
 
+      # When decoding statement programs when asking for the current
+      # filename it's usually the case that it's the same as the old
+      # one (because all info from a single file comes first, then
+      # another file comes next, etc.). So we remember the last
+      # mapped index to avoid unnecessary lookups.
+      @last_filename : String?
+      @last_filename_index = 0
+
       private def register_filename(name)
-        if index = @files.index(name)
-          return index
+        if name.same?(@last_filename)
+          return @last_filename_index
         end
-        @files << name
-        @files.size - 1
+
+        @last_filename = name
+
+        index = @files.index(name)
+
+        unless index
+          index = @files.size
+          @files << name
+        end
+
+        @last_filename_index = index
+
+        index
       end
 
+      # Same logic as `@last_filename` but for directories
+      @last_directory : String?
+      @last_directory_index = 0
+
       private def register_directory(name)
-        if index = @directories.index(name)
-          return index
+        if name.same?(@last_directory)
+          return @last_directory_index
         end
-        @directories << name
-        @directories.size - 1
+
+        @last_directory = name
+
+        index = @directories.index(name)
+
+        unless index
+          index = @directories.size
+          @directories << name
+        end
+
+        @last_directory_index = index
+
+        index
       end
     end
   end

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -255,7 +255,7 @@ module Debug
 
       private def read_directory_table(sequence)
         loop do
-          name = @io.gets('\0').to_s.chomp('\0')
+          name = @io.gets('\0', chomp: true).to_s
           break if name.empty?
           sequence.include_directories << name
         end
@@ -263,7 +263,7 @@ module Debug
 
       private def read_filename_table(sequence)
         loop do
-          name = @io.gets('\0').to_s.chomp('\0')
+          name = @io.gets('\0', chomp: true).to_s
           break if name.empty?
           dir = DWARF.read_unsigned_leb128(@io)
           time = DWARF.read_unsigned_leb128(@io)

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -219,10 +219,13 @@ module Debug
           filename:  {} of String => Int32,
         }
 
-        while (@io.tell - @offset) < size
-          sequence = Sequence.new
+        while true
+          pos = @io.tell
+          offset = pos - @offset
+          break unless offset < size
 
-          sequence.offset = @io.tell - @offset
+          sequence = Sequence.new
+          sequence.offset = offset
           sequence.unit_length = @io.read_bytes(UInt32)
           sequence.version = @io.read_bytes(UInt16)
           sequence.header_length = @io.read_bytes(UInt32)

--- a/src/debug/dwarf/strings.cr
+++ b/src/debug/dwarf/strings.cr
@@ -6,7 +6,7 @@ module Debug
 
       def decode(strp)
         @io.seek(@offset + strp) do
-          @io.gets('\0').to_s.chomp('\0')
+          @io.gets('\0', chomp: true).to_s
         end
       end
     end

--- a/src/debug/dwarf/strings.cr
+++ b/src/debug/dwarf/strings.cr
@@ -1,10 +1,23 @@
 module Debug
   module DWARF
     struct Strings
-      def initialize(@io : IO::FileDescriptor, @offset : UInt32 | UInt64)
+      def initialize(@io : IO::FileDescriptor, @offset : UInt32 | UInt64, size)
+        # Read a good chunk of bytes to decode strings faster
+        # (avoid seeking/reading the IO too many times)
+        @buffer = Bytes.new(Math.max(16384, size))
+        pos = @io.pos
+        @io.read_fully(@buffer)
+        @io.pos = pos
       end
 
       def decode(strp)
+        # See if we can read it from the buffer
+        if strp < @buffer.size
+          index = @buffer.index('\0'.ord, offset: strp)
+          return String.new(@buffer[strp, index - strp]) if index
+        end
+
+        # If not, try directly from the IO
         @io.seek(@offset + strp) do
           @io.gets('\0', chomp: true).to_s
         end

--- a/src/debug/elf.cr
+++ b/src/debug/elf.cr
@@ -201,7 +201,7 @@ module Debug
     def sh_name(index)
       sh = section_headers[shstrndx]
       @io.seek(sh.offset + index) do
-        @io.gets('\0').to_s.chomp('\0')
+        @io.gets('\0', chomp: true).to_s
       end
     end
 

--- a/src/debug/mach_o.cr
+++ b/src/debug/mach_o.cr
@@ -458,7 +458,7 @@ module Debug
 
           if nlist.strx > 0
             @io.seek(symtab.stroff + nlist.strx) do
-              nlist.name = @io.gets('\0').to_s.chomp('\0')
+              nlist.name = @io.gets('\0', chomp: true).to_s
             end
           end
 


### PR DESCRIPTION
The first time an Exception's full backtrace (filenames, line numbers, etc.) must be built, the runtime will first decode all DWARF information from the dwarf file (or somewhere else? not sure).

I noticed this process takes about 6 seconds for the compiler's std specs (because it's a huge program, the bigger the program the bigger the dwarf file and the longer it will take to decode it), specifically you can see this doing:

```
$ bin/crystal build spec/std_spec.cr
$ ./std_spec -e "inspects with cause"
.

Finished in 5.88 seconds
```

I thought 6 seconds to decode the backtrace was too much so I started to dig in the code to see if I can improve it. I managed to improve **part** of the decoding process by about 6 times.

The improvement is explained in the PR code comments. There's a `decode_sequences` method in `DWARF::LineNumbers`. Previously it took 4.84 seconds to do it for the std_spec. Now it takes 0.82 seconds.

Now running that spec above looks like this:

```
$ bin/crystal build spec/std_spec.cr
14:05 $ ./std_spec -e "inspects with cause"
.

Finished in 1.34 seconds
```

Note that this improvement is only see the first time `ex.inspect_with_backtrace` is called for any exception. Later on the dwarf info should have been decoded. Still, it's good to win a lot of time in this first decoding.

I believe there might be more things to improve, but so far this is the easiest change that gives the most boost.