### PR TITLE
channel: call ops.unwait as soon as fiber is resumed/enqueued; fixes select segfault

### DIFF
--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -100,4 +100,49 @@ describe "select" do
     sleep
     x.should eq 1
   end
+
+  it "select with buffered channels shouldn't segfault on resuming already completed fiber, fixed #3900" do
+    ch1 = Channel::Buffered(Int32).new(1)
+    ch2 = Channel::Buffered(Int32).new(1)
+    res = [] of Int32
+
+    spawn do
+      3.times do
+        select
+        when x = ch1.receive
+          res << x
+        when y = ch2.receive
+          res << y
+        end
+      end
+    end
+
+    spawn do
+      3.times do |i|
+        select
+        when ch1.send(1)
+        when ch2.send(2)
+        end
+      end
+    end
+
+    sleep 0
+    res.should eq([1, 2, 1])
+  end
+
+  it "select with buffered channels, multiple ops on the same channel doesn't segfault" do
+    ch = Channel::Buffered(Int32).new(1)
+
+    spawn do
+      ch.send(1)
+
+      select
+      when ch.send(1)
+      when ch.send(2)
+      end
+    end
+
+    ch.receive.should eq(1)
+    ch.receive.should eq(1)
+  end
 end


### PR DESCRIPTION
Fixes #3900

A `select` call registers multiple wait events (one for each of its branches) and yields. When any of the branches is ready, `select` fiber resumes and unwaits the remaining events by calling 
`
ops.each &.unwait
`. This works correctly with unbuffered channels as upon readiness, they immediately switch to the waiting/selecting fiber.

However, since buffered channels don't block unless buffer is full(send blocks) or empty(receive blocks), the `select`ing fiber is not resumed upon readiness. Hence, `unwait` is not called on time. By the time `unwait` is called, the `select`ing fiber may be enqueued multiple times.

Resuming this fiber after it has finished executing causes a segfault.

So, the fix here to call `ops.each &.unwait` as soon as the first resume/enqueue happens.


