### PR TITLE
Callstack: Fix confused block variable naming.

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -293,8 +293,8 @@ struct CallStack
                 info.read_abbreviations(io)
               end
 
-              parse_function_names_from_dwarf(info, strings) do |name, low_pc, high_pc|
-                names << {name, low_pc, high_pc}
+              parse_function_names_from_dwarf(info, strings) do |low_pc, high_pc, name|
+                names << {low_pc, high_pc, name}
               end
             end
 


### PR DESCRIPTION
names is defined as names = [] of {LibC::SizeT, LibC::SizeT, String}.
That also matches the order of the variables that
parse_function_names_from_dwarf, which yields the variables:
yield low_pc, high_pc, name

Found when reading code  related to #7413.