### PR TITLE
Atomic::Flag

### DIFF
--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -186,3 +186,18 @@ describe Atomic do
     atomic.get.should eq(nil)
   end
 end
+
+describe Atomic::Flag do
+  it "#test_and_set" do
+    flag = Atomic::Flag.new
+    flag.test_and_set.should be_true
+    flag.test_and_set.should be_false
+  end
+
+  it "#clear" do
+    flag = Atomic::Flag.new
+    flag.test_and_set.should be_true
+    flag.clear
+    flag.test_and_set.should be_true
+  end
+end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -122,15 +122,12 @@ enum Signal : Int32
     LibC.sigismember(pointerof(@@sigset), self) == 1
   end
 
-  @@setup_default_handlers = Atomic(Int32).new(0)
+  @@setup_default_handlers = Atomic::Flag.new
 
   # :nodoc:
   def self.setup_default_handlers
-    _, success = @@setup_default_handlers.compare_and_set(0, 1)
-    return unless success
-
+    return unless @@setup_default_handlers.test_and_set
     LibC.sigemptyset(pointerof(@@sigset))
-
     Crystal::Signal.start_loop
     Signal::PIPE.ignore
     Signal::CHLD.reset


### PR DESCRIPTION
An atomic flag, that can be set or not.

Obviously a requirement for MT; not really useful on a single thread, except for the slightly nicer API (I think); definitely an improvement over doing this manually with an `Atomic(Int32)` (see second commit).

```crystal
flag = Atomic::Flag.new

if flag.test_and_set
  do_something
end
```

```crystal
flag = false

unless flag
  flag = true
  do_something
end
```