### PR TITLE
Spec: do Fiber.yield after each test

### DIFF
--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -57,7 +57,7 @@ module Spec::Methods
 
         # We do this to give a chance for signals (like CTRL+C) to be handled,
         # which currently are only handled when there's a fiber switch
-        # (IO stuff, sleep, etc.). Without it the use might way more than needed
+        # (IO stuff, sleep, etc.). Without it the user might wait more than needed
         # after pressing CTRL+C to quit the tests.
         Fiber.yield
       end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -54,6 +54,12 @@ module Spec::Methods
         Spec.abort! if Spec.fail_fast?
       ensure
         Spec.run_after_each_hooks
+
+        # We do this to give a chance for signals (like CTRL+C) to be handled,
+        # which currently are only handled when there's a fiber switch
+        # (IO stuff, sleep, etc.). Without it the use might way more than needed
+        # after pressing CTRL+C to quit the tests.
+        Fiber.yield
       end
     end
   end


### PR DESCRIPTION
When you are running a lot of specs and you press CTRL+C you have to wait until there's some IO that would result in fiber switching for the signal event to be trapped. Not all specs do IO so if there are a bunch of them that only do CPU stuff you won't be able to halt the specs from running.

This PR adds a `Fiber.yield` before each spec to give a chance for the signal event to be handled.

I didn't notice any slowdown when doing this.

I think this won't be needed once we have multiple threads... but for now we don't.