### PR TITLE
Compiler specs: avoid executing subprocess for spec that doesn't need it

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -566,9 +566,9 @@ describe "Semantic: macro" do
       )) { types["Foo"] }
   end
 
-  it "allows declaring class with macro expression" do
+  it "allows declaring class with inline macro expression (#1333)" do
     assert_type(%(
-      {{ `echo "class Foo; end"` }}
+      {{ "class Foo; end".id }}
 
       Foo.new
       )) { types["Foo"] }


### PR DESCRIPTION
There's an existing macro spec that proves that #1333 is fixed. The original issue was about not being able to define a class through `macro run`. However, the real problem was that this didn't work at all for inline macro expressions.

I simplified that spec to avoid starting a subprocess. This has these advantages:
- the test is simpler
- it's multiplatform (`echo` is not)
- it doesn't create a subprocess, which, at least in CI linux 32 bits seem to sometimes bring the process down because of out of memory errors ([reference](https://circleci.com/gh/crystal-lang/crystal/18676?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification))

I'll repeat this: the subprocess execution has nothing to do with the bug. There's no point in keeping that there.

I also clarified a bit the test description and linked it to the issue. 