### PR TITLE
Add Deque#to_unsafe

### DIFF
--- a/src/deque.cr
+++ b/src/deque.cr
@@ -100,6 +100,13 @@ class Deque(T)
     Deque(T).new(array.size) { |i| array[i] }
   end
 
+  # Returns a pointer to the internal buffer where the deque's elements are stored.
+  #
+  # This method is **unsafe** because using the pointer in the wrong way can easily result in a segmentation fault.
+  def to_unsafe
+    @buffer
+  end
+
   # Returns `true` if it is passed a `Deque` and `equals?` returns `true`
   # for both deques, the caller and the argument.
   #


### PR DESCRIPTION
I'm writing a binding and in one function I need to pass a pointer to some memory. For this I would like to allow passing any collection. So this:
```cr
lib SomeLib
  fun call_function(pointer : Int16*)
end

module Something
  def self.method(collection : Indexable(Int16))
    SomeLib.call_function(collection)
  end
end
```
But when doing `Something.method(Deque(Int16).new(1))`, I get `argument 'pointer' of 'SomeLib#call_function' must be Pointer(Int16), not Deque(Int16)`.
It works for all other members of `Indexable` since they have `to_unsafe` because when passing an object to a function which has a `to_unsafe` method, the value returned by this method is passed to the function (which is a pointer to the elements in this case).