### PR TITLE
Fix: Removes overriding local var

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -84,7 +84,6 @@ class Crystal::Command
 
     included_dirs << File.expand_path("./src")
 
-    compiler = Compiler.new
     compiler.flags << "docs"
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources


### PR DESCRIPTION
Fixup for #6668 (see https://github.com/crystal-lang/crystal/pull/6668#discussion_r244969345).