### PR TITLE
Add `Slice#[](Range)`

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -412,6 +412,19 @@ describe "Slice" do
   it "optimizes hash for Bytes" do
     Bytes[1, 2, 3].hash.should_not eq(Slice[1, 2, 3].hash)
   end
+
+  it "#[]" do
+    slice = Slice.new(6) { |i| i + 1 }
+    subslice = slice[2..4]
+    subslice.read_only?.should be_false
+    subslice.size.should eq(3)
+    subslice.should eq(Slice.new(3) { |i| i + 3 })
+  end
+
+  it "#[] keeps read-only value" do
+    slice = Slice.new(6, read_only: true) { |i| i + 1 }
+    slice[2..4].read_only?.should be_true
+  end
 end
 
 private def itself(*args)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -203,6 +203,25 @@ struct Slice(T)
     Slice.new(@pointer + start, count, read_only: @read_only)
   end
 
+  # Returns a new slice with the elements in the given range.
+  #
+  #
+  # Negative indices count backward from the end of the slice (-1 is the last
+  # element). Additionally, an empty slice is returned when the starting index
+  # for an element range is at the end of the slice.
+  #
+  # ```
+  # slice = Slice.new(5) { |i| i + 10 }
+  # slice # => Slice[10, 11, 12, 13, 14]
+  #
+  # slice2 = slice[1..3]
+  # slice2 # => Slice[11, 12, 13]
+  # ```
+  def [](range : Range)
+    start, count = Indexable.range_to_index_and_count(range, size)
+    self[start, count]
+  end
+
   @[AlwaysInline]
   def unsafe_fetch(index : Int)
     @pointer[index]


### PR DESCRIPTION
For some reason this was missing and I needed it a couple of times now (with `#[start, count]` you can do it too but a range is usually more convenient/expressive).