### PR TITLE
Iterator: remove `rewind`. Implement `cycle` by storing elements in an array

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1395,9 +1395,6 @@ describe "Array" do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "cycles" do
@@ -1413,9 +1410,6 @@ describe "Array" do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(0)
     end
   end
 
@@ -1427,9 +1421,6 @@ describe "Array" do
       iter.next.should eq(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
   end
 
@@ -1574,9 +1565,6 @@ describe "Array" do
         iter.next.should eq(perm)
       end
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(perms[0])
     end
 
     it "returns iterator with given size" do
@@ -1587,9 +1575,6 @@ describe "Array" do
         iter.next.should eq(perm)
       end
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(perms[0])
     end
 
     it "returns iterator with reuse = true" do
@@ -1667,9 +1652,6 @@ describe "Array" do
         iter.next.should eq(comb)
       end
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(combs[0])
     end
 
     it "returns iterator with reuse = true" do
@@ -1760,9 +1742,6 @@ describe "Array" do
         iter.next.should eq(comb)
       end
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(combs[0])
     end
 
     it "returns iterator with reuse = true" do

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -316,12 +316,6 @@ describe "BitArray" do
     iter.next.should be_true
     iter.next.should be_false
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should be_true
-
-    iter.rewind
-    iter.cycle.first(3).to_a.should eq([true, false, true])
   end
 
   it "provides an index iterator" do
@@ -331,9 +325,6 @@ describe "BitArray" do
     iter.next.should eq(0)
     iter.next.should eq(1)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(0)
   end
 
   it "provides a reverse iterator" do
@@ -345,8 +336,5 @@ describe "BitArray" do
     iter.next.should be_false
     iter.next.should be_true
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should be_false
   end
 end

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -108,8 +108,5 @@ describe CSV do
     iter.next.should eq(["1", "2"])
     iter.next.should eq(["3", "4"])
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(["1", "2"])
   end
 end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -570,9 +570,6 @@ describe "Deque" do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "cycles" do
@@ -599,9 +596,6 @@ describe "Deque" do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(0)
     end
 
     it "works while modifying deque" do
@@ -624,9 +618,6 @@ describe "Deque" do
       iter.next.should eq(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -135,9 +135,6 @@ describe "Enumerable" do
       i = (0..10).chunk(&./(3))
       i.next.should eq({0, [0, 1, 2]})
       i.next.should eq({1, [3, 4, 5]})
-      i.rewind
-      i.next.should eq({0, [0, 1, 2]})
-      i.next.should eq({1, [3, 4, 5]})
     end
 
     it "returns elements of the Enumerable in an Array of Tuple, {v, ary}, where 'ary' contains the consecutive elements for which the block returned the value 'v'" do
@@ -187,11 +184,6 @@ describe "Enumerable" do
       c = iter.next.as(Tuple)
       c.should eq({3, [3, 3]})
       c[1].should be(a[1])
-
-      iter.rewind
-      a1 = iter.next.as(Tuple)
-      a1.should eq({1, [1, 1]})
-      a1[1].should be(a[1])
     end
   end
 
@@ -262,9 +254,6 @@ describe "Enumerable" do
       iter.next.should eq([2, 3, 4])
       iter.next.should eq([3, 4, 5])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2, 3])
     end
 
     it "returns each_cons iterator with reuse = true" do
@@ -369,9 +358,6 @@ describe "Enumerable" do
       iter.next.should eq([3, 4])
       iter.next.should eq([5])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2])
     end
   end
 
@@ -397,9 +383,6 @@ describe "Enumerable" do
       iter.next.should eq({1, 0})
       iter.next.should eq({2, 1})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, 0})
     end
   end
 
@@ -418,9 +401,6 @@ describe "Enumerable" do
       iter.next.should eq({1, "a"})
       iter.next.should eq({2, "a"})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, "a"})
     end
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -704,9 +704,6 @@ describe "Hash" do
     iter.next.should eq({:a, 1})
     iter.next.should eq({:b, 2})
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq({:a, 1})
   end
 
   it "gets each key iterator" do
@@ -714,9 +711,6 @@ describe "Hash" do
     iter.next.should eq(:a)
     iter.next.should eq(:b)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(:a)
   end
 
   it "gets each value iterator" do
@@ -724,9 +718,6 @@ describe "Hash" do
     iter.next.should eq(1)
     iter.next.should eq(2)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
   end
 
   describe "each_with_index" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -485,17 +485,13 @@ describe "Int" do
     iter.next.should eq(1)
     iter.next.should eq(2)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(0)
   end
 
   it "gets times iterator for UInt32 (#5019)" do
     iter = 4_u32.times
     iter.next.should be_a(UInt32)
 
-    iter.rewind
-    ary = iter.to_a
+    ary = 4_u32.times.to_a
     ary.should be_a(Array(UInt32))
     ary.should eq([0, 1, 2, 3])
   end
@@ -543,9 +539,6 @@ describe "Int" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
   end
 
   it "gets upto iterator max" do
@@ -555,9 +548,6 @@ describe "Int" do
     iter.next.should eq(Int32::MAX - 1)
     iter.next.should eq(Int32::MAX)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(Int32::MAX - 3)
   end
 
   it "upto iterator ups and downs" do
@@ -606,9 +596,6 @@ describe "Int" do
     iter.next.should eq(2)
     iter.next.should eq(1)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(3)
   end
 
   it "downto iterator ups and downs" do
@@ -627,9 +614,6 @@ describe "Int" do
     iter.next.should eq(1)
     iter.next.should eq(0)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(3)
   end
 
   it "gets to iterator" do
@@ -638,9 +622,6 @@ describe "Int" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
   end
 
   describe "#popcount" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -103,9 +103,6 @@ describe IO do
       lines.next.should eq("hello")
       lines.next.should eq("bye")
       lines.next.should be_a(Iterator::Stop)
-
-      lines.rewind
-      lines.next.should eq("hello")
     end
 
     it "iterates by line with chomp false" do
@@ -114,9 +111,6 @@ describe IO do
       lines.next.should eq("hello\n")
       lines.next.should eq("bye\n")
       lines.next.should be_a(Iterator::Stop)
-
-      lines.rewind
-      lines.next.should eq("hello\n")
     end
 
     it "iterates by char" do
@@ -127,9 +121,6 @@ describe IO do
       chars.next.should eq('あ')
       chars.next.should eq('ぼ')
       chars.next.should be_a(Iterator::Stop)
-
-      chars.rewind
-      chars.next.should eq('a')
     end
 
     it "iterates by byte" do
@@ -138,9 +129,6 @@ describe IO do
       bytes.next.should eq('a'.ord)
       bytes.next.should eq('b'.ord)
       bytes.next.should be_a(Iterator::Stop)
-
-      bytes.rewind
-      bytes.next.should eq('a'.ord)
     end
   end
 

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -34,9 +34,6 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "sums after compact_map to_a" do
@@ -52,12 +49,6 @@ describe Iterator do
       iter.next.should eq('a')
       iter.next.should eq('b')
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
-
-      iter.rewind
-      iter.to_a.should eq([1, 2, 'a', 'b'])
     end
 
     describe "chain indeterminate number of iterators" do
@@ -84,9 +75,6 @@ describe Iterator do
       it "rewinds" do
         iters = [[0], [1], ([] of Int32), [2, 3], ([] of Int32), [4, 5, 6]].each.map &.each
         iter = Iterator.chain iters
-        7.times { |i| iter.next.should eq i }
-        iter.next.should be_a Iterator::Stop
-        iter.rewind
         7.times { |i| iter.next.should eq i }
         iter.next.should be_a Iterator::Stop
       end
@@ -123,9 +111,6 @@ describe Iterator do
       iter.next.should eq([2, 3, 4])
       iter.next.should eq([3, 4, 5])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2, 3])
     end
 
     describe "reuse" do
@@ -138,10 +123,6 @@ describe Iterator do
         first.should_not be(second)
         iter.next.should eq([3, 4, 5])
         iter.next.should be_a(Iterator::Stop)
-
-        iter.rewind
-        iter.next.should eq([1, 2, 3])
-        iter.next.should_not be(first)
       end
 
       it "reuse as Bool" do
@@ -153,10 +134,6 @@ describe Iterator do
         first.should be(second)
         iter.next.should eq([3, 4, 5])
         iter.next.should be_a(Iterator::Stop)
-
-        iter.rewind
-        iter.next.should eq([1, 2, 3])
-        iter.next.should be(first)
       end
 
       it "reuse as Array" do
@@ -172,11 +149,6 @@ describe Iterator do
         value.should be(reuse)
         value.should eq([3, 4, 5])
         iter.next.should be_a(Iterator::Stop)
-
-        iter.rewind
-        value = iter.next
-        value.should be(reuse)
-        value.should eq([1, 2, 3])
       end
 
       it "reuse as deque" do
@@ -192,11 +164,6 @@ describe Iterator do
         value.should be(reuse)
         value.should eq(Deque{3, 4, 5})
         iter.next.should be_a(Iterator::Stop)
-
-        iter.rewind
-        value = iter.next
-        value.should be(reuse)
-        value.should eq(Deque{1, 2, 3})
       end
     end
   end
@@ -209,9 +176,6 @@ describe Iterator do
       iter.next.should eq(3)
       iter.next.should eq(1)
       iter.next.should eq(2)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "cycles an empty array" do
@@ -227,9 +191,6 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does not cycle provided 0" do
@@ -300,9 +261,6 @@ describe Iterator do
       iter.next.should eq([2])
       iter.next.should eq([3])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq [1]
     end
 
     it "creats a group of two" do
@@ -310,9 +268,6 @@ describe Iterator do
       iter.next.should eq([1, 2])
       iter.next.should eq([3, nil])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq [1, 2]
     end
 
     it "fills up with the fill up argument" do
@@ -320,9 +275,6 @@ describe Iterator do
       iter.next.should eq([1, 2])
       iter.next.should eq([3, 'z'])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq [1, 2]
     end
 
     it "raises argument error if size is less than 0" do
@@ -347,9 +299,6 @@ describe Iterator do
       b.should be(a)
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq [1, 2]
     end
   end
 
@@ -360,9 +309,6 @@ describe Iterator do
       iter.next.should eq(4)
       iter.next.should eq(6)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(2)
     end
   end
 
@@ -371,9 +317,6 @@ describe Iterator do
       iter = (1..3).each.reject &.>=(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does with pattern" do
@@ -396,9 +339,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(2)
     end
 
     it "does with pattern" do
@@ -421,9 +361,6 @@ describe Iterator do
       iter = (1..3).each.skip(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
 
     it "is cool to skip 0 elements" do
@@ -444,9 +381,6 @@ describe Iterator do
       iter.next.should eq(4)
       iter.next.should eq(0)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
 
     it "can skip everything" do
@@ -477,9 +411,6 @@ describe Iterator do
       iter.next.should eq([4, 5, 6])
       iter.next.should eq([7, 8])
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2, 3])
     end
   end
 
@@ -526,9 +457,6 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does first with more than available" do
@@ -553,9 +481,6 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does take_while with more than available" do
@@ -588,9 +513,6 @@ describe Iterator do
       a.should eq(6)
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
   end
 
@@ -601,9 +523,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(0)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "with block" do
@@ -612,9 +531,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
   end
 
@@ -625,9 +541,6 @@ describe Iterator do
       iter.next.should eq({2, 1})
       iter.next.should eq({3, 2})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, 0})
     end
 
     it "does with_index with offset from range" do
@@ -636,9 +549,6 @@ describe Iterator do
       iter.next.should eq({2, 11})
       iter.next.should eq({3, 12})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, 10})
     end
 
     it "does with_index from range, with block" do
@@ -665,9 +575,6 @@ describe Iterator do
       iter.next.should eq({2, "a"})
       iter.next.should eq({3, "a"})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, "a"})
     end
   end
 
@@ -680,12 +587,6 @@ describe Iterator do
       iter.next.should eq({2, 'b'})
       iter.next.should eq({3, 'c'})
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq({1, 'a'})
-
-      iter.rewind
-      iter.to_a.should eq([{1, 'a'}, {2, 'b'}, {3, 'c'}])
     end
   end
 
@@ -711,12 +612,6 @@ describe Iterator do
       iter.next.should eq({:c, 3})
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
-
-      iter.rewind
-      iter.to_a.should eq([1, 2, 'a', 'b', {:c, 3}])
     end
 
     it "flattens an iterator of mixed-type elements and iterators" do
@@ -727,12 +622,6 @@ describe Iterator do
       iter.next.should eq('a')
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
-
-      iter.rewind
-      iter.to_a.should eq([1, 2, 'a'])
     end
 
     it "flattens an iterator of mixed-type elements and iterators and iterators of iterators" do
@@ -745,12 +634,6 @@ describe Iterator do
       iter.next.should eq("foo")
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
-
-      iter.rewind
-      iter.to_a.should eq([1, 2, 'a', 'b', "foo"])
     end
 
     it "flattens deeply-nested and mixed type iterators" do
@@ -766,12 +649,6 @@ describe Iterator do
       iter.next.should eq("a")
 
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
-
-      iter.rewind
-      iter.to_a.should eq([1, 2, 3, 4, 5, 6, 7, "a"])
     end
 
     it "flattens a variety of edge cases" do
@@ -795,7 +672,6 @@ describe Iterator do
       iter = [1, [2, 3], 4].each.flatten
 
       iter.to_a.should eq([1, 2, 3, 4])
-      iter.rewind.to_a.should eq([1, 2, 3, 4])
     end
   end
 
@@ -809,8 +685,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
-
-      iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
     end
 
     it "flattens returned items" do
@@ -819,8 +693,6 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should eq(3)
-
-      iter.rewind.to_a.should eq([1, 2, 3])
     end
 
     it "flattens returned iterators" do
@@ -832,8 +704,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
-
-      iter.rewind.to_a.should eq([1, 1, 2, 2, 3, 3])
     end
 
     it "flattens returned values" do
@@ -853,8 +723,6 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
-
-      iter.rewind.to_a.should eq([1, 2, 2, 3, 3])
     end
   end
 
@@ -884,9 +752,6 @@ describe Iterator do
       iter = ary.slice_after(&.even?)
       iter.next.should eq([1, 3, 5, 8])
       iter.next.should eq([10])
-
-      iter.rewind
-      iter.next.should eq([1, 3, 5, 8])
     end
 
     it "slices after with reuse = true" do
@@ -991,9 +856,6 @@ describe Iterator do
       iter = ary.slice_before(&.even?)
       iter.next.should eq([1, 3, 5])
       iter.next.should eq([8])
-
-      iter.rewind
-      iter.next.should eq([1, 3, 5])
     end
 
     it "slices before with reuse = true" do
@@ -1094,9 +956,6 @@ describe Iterator do
       iter = ary.slice_when { |x, y| x != y }
       iter.next.should eq([1, 1, 1])
       iter.next.should eq([2, 2])
-
-      iter.rewind
-      iter.next.should eq([1, 1, 1])
     end
 
     it "slices when with reuse = true" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -251,9 +251,6 @@ describe "Number" do
       iter.next.should eq(0.1)
       iter.next.should eq(0.2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(0.0)
     end
 
     it "iterator without limit" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -258,9 +258,6 @@ describe "Range" do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does next with exclusive range" do
@@ -269,18 +266,11 @@ describe "Range" do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does with endless range" do
       r = (3..nil)
       iter = r.each
-      iter.next.should eq(3)
-      iter.next.should eq(4)
-
-      iter.rewind
       iter.next.should eq(3)
       iter.next.should eq(4)
     end
@@ -321,9 +311,6 @@ describe "Range" do
       iter.next.should eq(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
 
     it "does next with exclusive range" do
@@ -332,9 +319,6 @@ describe "Range" do
       iter.next.should eq(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(2)
     end
 
     it "does next with beginless range" do
@@ -344,9 +328,6 @@ describe "Range" do
       iter.next.should eq(1)
       iter.next.should eq(0)
       iter.next.should eq(-1)
-
-      iter.rewind
-      iter.next.should eq(2)
     end
 
     it "reverse cycles" do
@@ -421,9 +402,6 @@ describe "Range" do
       iter.next.should eq(3)
       iter.next.should eq(5)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does next with exclusive range" do
@@ -432,9 +410,6 @@ describe "Range" do
       iter.next.should eq(1)
       iter.next.should eq(3)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "does next with exclusive range (2)" do
@@ -444,9 +419,6 @@ describe "Range" do
       iter.next.should eq(3)
       iter.next.should eq(5)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(1)
     end
 
     it "is empty with .. and begin > end" do
@@ -468,10 +440,6 @@ describe "Range" do
     it "does with endless range" do
       a = (1...nil)
       iter = a.step(2)
-      iter.next.should eq(1)
-      iter.next.should eq(3)
-
-      iter.rewind
       iter.next.should eq(1)
       iter.next.should eq(3)
     end

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -311,9 +311,6 @@ describe "Set" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
   end
 
   it "check subset" do

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -272,12 +272,6 @@ describe "Slice" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
-
-    iter.rewind
-    iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
   end
 
   it "does reverse iterator" do
@@ -287,9 +281,6 @@ describe "Slice" do
     iter.next.should eq(2)
     iter.next.should eq(1)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(3)
   end
 
   it "does index iterator" do
@@ -298,9 +289,6 @@ describe "Slice" do
     iter.next.should eq(0)
     iter.next.should eq(1)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(0)
   end
 
   it "does to_a" do

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -160,12 +160,6 @@ describe "StaticArray" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
-
-    iter.rewind
-    iter.cycle.first(5).to_a.should eq([1, 2, 3, 1, 2])
   end
 
   it "iterates with reverse each" do
@@ -175,11 +169,5 @@ describe "StaticArray" do
     iter.next.should eq(2)
     iter.next.should eq(1)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(3)
-
-    iter.rewind
-    iter.cycle.first(5).to_a.should eq([3, 2, 1, 3, 2])
   end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2006,16 +2006,10 @@ describe "String" do
     iter.next.should eq('b')
     iter.next.should eq('c')
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq('a')
   end
 
   it "gets each_char with empty string" do
     iter = "".each_char
-    iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
     iter.next.should be_a(Iterator::Stop)
   end
 
@@ -2046,9 +2040,6 @@ describe "String" do
     iter.next.should eq('b'.ord)
     iter.next.should eq('c'.ord)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq('a'.ord)
   end
 
   it "cycles bytes" do
@@ -2095,9 +2086,6 @@ describe "String" do
     iter.next.should eq("bar")
     iter.next.should eq("baz")
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq("foo")
   end
 
   it "gets each_line iterator with chomp = false" do
@@ -2106,9 +2094,6 @@ describe "String" do
     iter.next.should eq("bar\n")
     iter.next.should eq("baz\n")
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq("foo\n")
   end
 
   it "has yields to each_codepoint" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -198,9 +198,6 @@ describe "Tuple" do
     iter.next.should eq(2)
     iter.next.should eq(3)
     iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq(1)
   end
 
   it "does map" do
@@ -236,9 +233,6 @@ describe "Tuple" do
       iter.next.should eq(2)
       iter.next.should eq(1)
       iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq(3)
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -2179,15 +2179,6 @@ class Array(T)
       @stop = true
       stop
     end
-
-    def rewind
-      @cycles = (@n - @size + 1..@n).to_a.reverse!
-      @pool.replace(@array)
-      @stop = @size > @n
-      @i = @size - 1
-      @first = true
-      self
-    end
   end
 
   private class CombinationIterator(T)
@@ -2249,15 +2240,6 @@ class Array(T)
       @stop = true
       stop
     end
-
-    def rewind
-      @pool.replace(@copy)
-      @indices = (0...@size).to_a
-      @stop = @size > @n
-      @i = @size - 1
-      @first = true
-      self
-    end
   end
 
   private class RepeatedCombinationIterator(T)
@@ -2315,17 +2297,6 @@ class Array(T)
 
       @stop = true
       stop
-    end
-
-    def rewind
-      if @n > 0
-        @indices.fill(0)
-        @pool.fill(@copy[0])
-      end
-      @stop = @size > @n
-      @i = @size - 1
-      @first = true
-      self
     end
   end
 

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -42,9 +42,6 @@ abstract class CSV::Lexer
   private abstract def next_char_no_column_increment
   private abstract def current_char
 
-  # Rewinds this lexer to its beginning.
-  abstract def rewind
-
   # Returns the next `Token` in this CSV.
   def next_token
     if @last_empty_column

--- a/src/csv/lexer/io_based.cr
+++ b/src/csv/lexer/io_based.cr
@@ -7,11 +7,6 @@ class CSV::Lexer::IOBased < CSV::Lexer
     @current_char = @io.read_char || '\0'
   end
 
-  def rewind
-    @io.rewind
-    @current_char = @io.read_char || '\0'
-  end
-
   private def consume_unquoted_cell
     @buffer.clear
     while true

--- a/src/csv/lexer/string_based.cr
+++ b/src/csv/lexer/string_based.cr
@@ -11,10 +11,6 @@ class CSV::Lexer::StringBased < CSV::Lexer
     end
   end
 
-  def rewind
-    @reader.pos = 0
-  end
-
   private def consume_unquoted_cell
     start_pos = @reader.pos
     end_pos = start_pos

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -66,11 +66,6 @@ class CSV::Parser
     end
   end
 
-  # Rewinds this parser to the first row.
-  def rewind
-    @lexer.rewind
-  end
-
   private struct RowIterator
     include Iterator(Array(String))
 
@@ -81,10 +76,6 @@ class CSV::Parser
 
     def next
       @parser.next_row || stop
-    end
-
-    def rewind
-      @parser.rewind
     end
   end
 end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -287,11 +287,6 @@ class Dir
     def next
       @dir.read || stop
     end
-
-    def rewind
-      @dir.rewind
-      self
-    end
   end
 
   private struct ChildIterator
@@ -306,11 +301,6 @@ class Dir
         return entry unless excluded.includes?(entry)
       end
       stop
-    end
-
-    def rewind
-      @dir.rewind
-      self
     end
   end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1086,10 +1086,6 @@ class Hash(K, V)
         stop
       end
     end
-
-    def rewind
-      @current = @hash.@first
-    end
   end
 
   private class EntryIterator(K, V)

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -740,11 +740,6 @@ module Indexable(T)
         value
       end
     end
-
-    def rewind
-      @index = 0
-      self
-    end
   end
 
   private class ReverseItemIterator(A, T)
@@ -762,11 +757,6 @@ module Indexable(T)
         value
       end
     end
-
-    def rewind
-      @index = @array.size - 1
-      self
-    end
   end
 
   private class IndexIterator(A)
@@ -783,11 +773,6 @@ module Indexable(T)
         @index += 1
         value
       end
-    end
-
-    def rewind
-      @index = 0
-      self
     end
   end
 end

--- a/src/int.cr
+++ b/src/int.cr
@@ -573,11 +573,6 @@ struct Int
         stop
       end
     end
-
-    def rewind
-      @index = T.zero
-      self
-    end
   end
 
   private class UptoIterator(T, N)
@@ -600,12 +595,6 @@ struct Int
       @current += 1 unless @done
       value
     end
-
-    def rewind
-      @current = @from
-      @done = !(@from <= @to)
-      self
-    end
   end
 
   private class DowntoIterator(T, N)
@@ -627,12 +616,6 @@ struct Int
       @done = @current == @to
       @current -= 1 unless @done
       value
-    end
-
-    def rewind
-      @current = @from
-      @done = !(@from >= @to)
-      self
     end
   end
 end

--- a/src/io.cr
+++ b/src/io.cr
@@ -1168,11 +1168,6 @@ abstract class IO
     def next
       @io.gets(*@args, **@nargs) || stop
     end
-
-    def rewind
-      @io.rewind
-      self
-    end
   end
 
   private struct CharIterator(I)
@@ -1184,11 +1179,6 @@ abstract class IO
     def next
       @io.read_char || stop
     end
-
-    def rewind
-      @io.rewind
-      self
-    end
   end
 
   private struct ByteIterator(I)
@@ -1199,11 +1189,6 @@ abstract class IO
 
     def next
       @io.read_byte || stop
-    end
-
-    def rewind
-      @io.rewind
-      self
     end
   end
 end

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -33,9 +33,6 @@ require "./enumerable"
 # element in the sequence or `Iterator::Stop::INSTANCE`, which signals the end of the sequence
 # (you can invoke `stop` inside an iterator as a shortcut).
 #
-# Additionally, an `Iterator` can implement `rewind`, which must rewind the iterator to
-# its initial state. This is needed to implement the `cycle` method.
-#
 # For example, this is an iterator that returns a sequence of `N` zeros:
 #
 # ```
@@ -54,18 +51,10 @@ require "./enumerable"
 #       stop
 #     end
 #   end
-#
-#   def rewind
-#     @produced = 0
-#     self
-#   end
 # end
 #
 # zeros = Zeros.new(5)
 # zeros.to_a # => [0, 0, 0, 0, 0]
-#
-# zeros.rewind
-# zeros.first(3).to_a # => [0, 0, 0]
 # ```
 #
 # The standard library provides iterators for many classes, like `Array`, `Hash`, `Range`, `String` and `IO`.
@@ -86,12 +75,6 @@ module Iterator(T)
   # To use it, include this module in your iterator and make sure that the wrapped
   # iterator is stored in the `@iterator` instance variable.
   module IteratorWrapper
-    # Rewinds the wrapped iterator and returns `self`.
-    def rewind
-      @iterator.rewind
-      self
-    end
-
     # Invokes `next` on the wrapped iterator and returns `stop` if
     # the given value was a `Iterator::Stop`. Otherwise, returns the value.
     macro wrapped_next
@@ -124,10 +107,6 @@ module Iterator(T)
     def next
       @element
     end
-
-    def rewind
-      self
-    end
   end
 
   def self.of(&block : -> T)
@@ -154,9 +133,6 @@ module Iterator(T)
   # Returns the next element in this iterator, or `Iterator::Stop::INSTANCE` if there
   # are no more elements.
   abstract def next
-
-  # Rewinds the iterator to its original state.
-  abstract def rewind
 
   # Returns an iterator that returns elements from the original iterator until
   # it is exhausted and then returns the elements of the second iterator.
@@ -195,12 +171,6 @@ module Iterator(T)
         value
       end
     end
-
-    def rewind
-      @iterator1.rewind
-      @iterator2.rewind
-      @iterator1_consumed = false
-    end
   end
 
   # The same as `#chain`, but have better performance when the quantity of
@@ -230,14 +200,6 @@ module Iterator(T)
 
     def initialize(@iterators)
       @current = @iterators.next
-    end
-
-    def rewind
-      @iterators.rewind
-      @iterators.each &.rewind
-      @iterators.rewind
-      @current = @iterators.next
-      self
     end
 
     def next : T | Stop
@@ -333,11 +295,6 @@ module Iterator(T)
         @values.dup
       end
     end
-
-    def rewind
-      @values.clear
-      super
-    end
   end
 
   # Returns an iterator that repeatedly returns the elements of the original
@@ -363,16 +320,36 @@ module Iterator(T)
     include IteratorWrapper
 
     def initialize(@iterator : I)
+      @values = [] of T
+      @use_values = false
+      @index = 0
     end
 
     def next
-      value = @iterator.next
-      if value.is_a?(Stop)
-        @iterator.rewind
-        @iterator.next
-      else
-        value
+      if @use_values
+        return stop if @values.empty?
+
+        if @index >= @values.size
+          @index = 1
+          return @values.first
+        end
+
+        @index += 1
+        return @values[@index - 1]
       end
+
+      value = @iterator.next
+
+      if value.is_a?(Stop)
+        @use_values = true
+        return stop if @values.empty?
+
+        @index = 1
+        return @values.first
+      end
+
+      @values << value
+      value
     end
   end
 
@@ -400,25 +377,42 @@ module Iterator(T)
 
     def initialize(@iterator : I, @n : N)
       @count = 0
+      @values = [] of T
+      @use_values = false
+      @index = 0
     end
 
     def next
       return stop if @count >= @n
+
+      if @count > 0
+        return stop if @values.empty?
+
+        if @index >= @values.size
+          @count += 1
+          return stop if @count >= @n
+
+          @index = 1
+          return @values.first
+        end
+
+        @index += 1
+        return @values[@index - 1]
+      end
+
       value = @iterator.next
+
       if value.is_a?(Stop)
         @count += 1
         return stop if @count >= @n
+        return stop if @values.empty?
 
-        @iterator.rewind
-        @iterator.next
-      else
-        value
+        @index = 1
+        return @values.first
       end
-    end
 
-    def rewind
-      @count = 0
-      super
+      @values << value
+      value
     end
   end
 
@@ -511,15 +505,6 @@ module Iterator(T)
       end
     end
 
-    def rewind
-      @generators.each &.rewind
-      @generators.clear
-      @generators << @iterator
-      @stopped.each &.rewind
-      @stopped.clear
-      self
-    end
-
     def self.element_type(element)
       case element
       when Stop
@@ -600,14 +585,6 @@ module Iterator(T)
           value
         end
       end
-    end
-
-    def rewind
-      @nest_iterator.try &.rewind
-      @nest_iterator = nil
-      @stopped.each &.rewind
-      @stopped.clear
-      super
     end
 
     def self.iterator_type(iter, func)
@@ -880,11 +857,6 @@ module Iterator(T)
       end
       @iterator.next
     end
-
-    def rewind
-      @n = @original
-      super
-    end
   end
 
   # Returns an iterator that only starts to return elements once the given block
@@ -918,11 +890,6 @@ module Iterator(T)
           return value
         end
       end
-    end
-
-    def rewind
-      @returned_false = false
-      super
     end
   end
 
@@ -1037,11 +1004,6 @@ module Iterator(T)
         stop
       end
     end
-
-    def rewind
-      @n = @original
-      super
-    end
   end
 
   # Returns an iterator that returns elements while the given block returns a
@@ -1074,11 +1036,6 @@ module Iterator(T)
         @returned_false = true
         stop
       end
-    end
-
-    def rewind
-      @returned_false = false
-      super
     end
   end
 
@@ -1160,11 +1117,6 @@ module Iterator(T)
         end
       end
     end
-
-    def rewind
-      @hash.clear
-      super
-    end
   end
 
   # Returns an iterator that returns a `Tuple` of the element and its index.
@@ -1201,11 +1153,6 @@ module Iterator(T)
       value = {v, @index}
       @index += 1
       value
-    end
-
-    def rewind
-      @index = @offset
-      super
     end
   end
 
@@ -1265,12 +1212,6 @@ module Iterator(T)
       return stop if v2.is_a?(Stop)
 
       {v1, v2}
-    end
-
-    def rewind
-      @iterator1.rewind
-      @iterator2.rewind
-      self
     end
   end
 
@@ -1347,11 +1288,6 @@ module Iterator(T)
         return tuple
       end
       stop
-    end
-
-    def rewind
-      @iterator.rewind
-      init_state
     end
 
     private def init_state
@@ -1465,14 +1401,6 @@ module Iterator(T)
         end
       end
     end
-
-    def rewind
-      @iterator.rewind
-      @values.clear
-      @end = false
-      @clear_on_next = false
-      self
-    end
   end
 
   # Returns an iterator over chunks of elements, where each
@@ -1583,15 +1511,6 @@ module Iterator(T)
 
         @values << value
       end
-    end
-
-    def rewind
-      @iterator.rewind
-      @values.clear
-      @end = false
-      @has_value_to_add = false
-      @value_to_add = nil
-      self
     end
   end
 
@@ -1716,15 +1635,6 @@ module Iterator(T)
       else
         @reuse ? @values : @values.dup
       end
-    end
-
-    def rewind
-      @iterator.rewind
-      @values.clear
-      @end = false
-      @has_previous_value = false
-      @previous_value = nil
-      self
     end
   end
 end

--- a/src/number.cr
+++ b/src/number.cr
@@ -296,10 +296,5 @@ struct Number
         value
       end
     end
-
-    def rewind
-      @n = @original
-      self
-    end
   end
 end

--- a/src/range.cr
+++ b/src/range.cr
@@ -390,12 +390,6 @@ struct Range(B, E)
         end
       end
     end
-
-    def rewind
-      @current = @range.begin
-      @reached_end = false
-      self
-    end
   end
 
   private class ReverseIterator(B, E)
@@ -404,8 +398,12 @@ struct Range(B, E)
     @range : Range(B, E)
     @current : E
 
-    def initialize(@range : Range(B, E), @current = range.end)
-      rewind
+    def initialize(@range : Range(B, E))
+      if range.excludes_end?
+        @current = range.end.not_nil!
+      else
+        @current = range.end.not_nil!.succ
+      end
     end
 
     def next
@@ -413,16 +411,6 @@ struct Range(B, E)
 
       return stop if !begin_value.nil? && @current <= begin_value
       return @current = @current.pred
-    end
-
-    def rewind
-      if @range.excludes_end?
-        @current = @range.end.not_nil!
-      else
-        @current = @range.end.not_nil!.succ
-      end
-
-      self
     end
   end
 
@@ -455,12 +443,6 @@ struct Range(B, E)
           stop
         end
       end
-    end
-
-    def rewind
-      @current = @range.begin
-      @reached_end = false
-      self
     end
 
     def sum(initial)

--- a/src/string.cr
+++ b/src/string.cr
@@ -4299,13 +4299,6 @@ class String
       value
     end
 
-    def rewind
-      @reader.pos = 0
-      @end = false
-      check_empty
-      self
-    end
-
     private def check_empty
       @end = true if @reader.string.bytesize == 0
     end
@@ -4344,12 +4337,6 @@ class String
       end
 
       value
-    end
-
-    def rewind
-      @offset = 0
-      @end = false
-      self
     end
   end
 end


### PR DESCRIPTION
This is a controversial PR. It removes the `#rewind` method from all existing `Iterator`s.

The reasons for this PR are explained in [this comment](https://github.com/crystal-lang/crystal/pull/3795#issuecomment-463740692) but I'll explain it again here.

The reason why I originally added `Iterator#rewind` was:
- I saw that Ruby has `Enumerable#cycle`
- I thought of a way to implement it and the first idea I had was to be able to rewind iterators

Later on I found our that `cycle` was actually implemented in Ruby by building an internal Array of the elements in the Enumerable.

I think the advantages of implementing `cycle` like this, and removing `rewind` are:
- some iterators can't be rewinded (like `Iterator.of`)
- some iterators can be rewinded, but they actually don't end up rewinding anything (this is case of `STDIN.each_line`, which doesn't give an error, we can't detect the error and it simply works wrong)
- implementing `Iterator` is simple: just implement `next`, no need to think about rewinding

This is a breaking change. However, I seriously doubt anyone out there is using `rewind` on `Iterator` (but maybe they are using `cycle`). I'm not sure, of course, but in any case I'd prefer to remove it.