### PR TITLE
Add String::Builder#clear

### DIFF
--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -10,7 +10,7 @@ describe String::Builder do
   end
 
   it "clears" do
-    builder = String::Builder.new
+    io = String::Builder.new
     io << 123
     io.to_s.should eq("123")
 

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -9,6 +9,17 @@ describe String::Builder do
     str.should eq("123456")
   end
 
+  it "clears" do
+    builder = String::Builder.new
+    io << 123
+    io.to_s.should eq("123")
+
+    io.clear
+
+    io << "hello"
+    io.to_s.should eq("hello")
+  end
+
   it "raises if invokes to_s twice" do
     builder = String::Builder.new
     builder << 123

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -277,6 +277,8 @@ module MIME
         end
       end
 
+      io = String::Builder.new
+
       # 3. Resolve continuation parameters
       #
       #     extended-parameter := (extended-initial-name "=" extended-value) /
@@ -307,23 +309,23 @@ module MIME
         # All other pieces are extended-parameter and need to be sequentially
         # ordered by section number
         valid = false
-        composite_value = String.build do |io|
-          counter = 0
-          loop do
-            part_key = "#{base_key}*#{counter}"
-            if part = pieces[part_key]?
-              valid = true
-              io << part
-            elsif part = pieces["#{part_key}*"]?
-              valid = true
+        counter = 0
+        loop do
+          part_key = "#{base_key}*#{counter}"
+          if part = pieces[part_key]?
+            valid = true
+            io << part
+          elsif part = pieces["#{part_key}*"]?
+            valid = true
 
-              io << decode_rfc2231(part) || next
-            else
-              break
-            end
-            counter += 1
+            io << decode_rfc2231(part) || next
+          else
+            break
           end
+          counter += 1
         end
+        composite_value = io.to_s
+        io.clear
         if valid
           params[base_key] = composite_value
         else

--- a/src/string.cr
+++ b/src/string.cr
@@ -254,16 +254,21 @@ class String
   end
 
   # Builds a `String` by creating a `String::Builder` with the given initial capacity, yielding
-  # it to the block and finally getting a `String` out of it. The `String::Builder` automatically
-  # resizes as needed.
+  # it to the block and finally getting a `String` out of it.
+  # The `String::Builder` automatically resizes as needed.
   #
   # ```
-  # str = String.build do |str|
-  #   str << "hello "
-  #   str << 1
+  # string = String.build do |io|
+  #   io << "hello "
+  #   1.upto(5) { |i| io << i }
+  #   io << " hello"
   # end
-  # str # => "hello 1"
+  # string # => "hello 12345 hello"
   # ```
+  #
+  # NOTE: When you use this in a loop, consider using the `String::Builder` class
+  # and invoke `clear` on it to clear its contents after you are done with building.
+  # Otherwise you create a new `String::Builder` in every loop iteration.
   def self.build(capacity = 64) : self
     String::Builder.build(capacity) do |builder|
       yield builder

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -2,7 +2,7 @@ require "io"
 
 # Similar to `IO::Memory`, but optimized for building a single string.
 #
-# You should never have to deal with this class. Instead, use `String.build`.
+# See also: `String.build`.
 class String::Builder < IO
   getter bytesize : Int32
   getter capacity : Int32
@@ -32,6 +32,23 @@ class String::Builder < IO
     io = new(string.bytesize)
     io << string
     io
+  end
+
+  # Resets the position to zero.
+  #
+  # ```
+  # io = String::Builder.new
+  #
+  # 1.upto(5) { |i| io << i }
+  # io.to_s # => "12345"
+  #
+  # io.clear
+  #
+  # io.to_s # => ""
+  # ```
+  def clear
+    @bytesize = 0
+    @finished = false
   end
 
   def read(slice : Bytes)
@@ -88,7 +105,7 @@ class String::Builder < IO
   end
 
   # Moves the write pointer, and the resulting string bytesize,
-  # by the given *amount*.
+  # back by the given *amount*.
   def back(amount : Int)
     unless 0 <= amount <= @bytesize
       raise ArgumentError.new "Invalid back amount"

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -116,7 +116,7 @@ class String::Builder < IO
 
   # Returns the contents of this builder as a string.
   # This method can only be invoked once.
-  # Use `clear` to clear this builder's contents and invoke `to_s` again.
+  # Use `clear` to clear this builder's contents and be able to invoke `to_s` again.
   def to_s
     raise "Can only invoke 'to_s' once on String::Builder" if @finished
     @finished = true

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -114,6 +114,9 @@ class String::Builder < IO
     @bytesize -= amount
   end
 
+  # Returns the contents of this builder as a string.
+  # This method can only be invoked once.
+  # Use `clear` to clear this builder's contents and invoke `to_s` again.
   def to_s
     raise "Can only invoke 'to_s' once on String::Builder" if @finished
     @finished = true


### PR DESCRIPTION
One of my instance variables in my class is a `String::Builder` and I would really like to clear it efficiently instead of having to build a new `String::Builder` every time I want to build a new string with it.
So I added this which simply sets the bytesize of the builder to zero so the old bytes from the other string build are simply overwritten by the new string build.

```crystal
io = String::Builder.new

Benchmark.ips do |bm|
  bm.report("new") do
    io = String::Builder.new
  end

  bm.report("clear") do
    io.clear
  end
end
```
```
  new   6.86M (145.79ns) (±12.55%)  176 B/op  88.42× slower
clear  606.5M (  1.65ns) (± 6.06%)    0 B/op        fastest
```
This also adds a NOTE to `String.build` which suggests that when you use `String.build` in a loop, that you should use the `String::Builder` class and simply clear the old contents of the builder and then build a new string with the same builder. That's of course much faster than creating a new `String::Builder` everytime which is done by `String.build` in a loop. I did these improvements in `src/mime/media_type.cr`, for example.
```crystal
io = String::Builder.new

Benchmark.ips do |bm|
  bm.report("build") do
    10.times do
      String.build do |io|
        io << "abc"
      end
    end
  end

  bm.report("clear") do
    10.times do
      io << "abc"
      io.to_s
      io.clear
    end
  end
end
```
```
build 516.91k (  1.93µs) (±21.86%)  2083 B/op  19.69× slower
clear  10.18M ( 98.27ns) (±11.60%)     0 B/op        fastest
```