### PR TITLE
Combine Time::Span and Time::MonthSpan

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -118,17 +118,17 @@ describe Time::Span do
   end
 
   it "test add" do
-    t1 = Time::Span.new 2, 3, 4, 5, 6_000_000
-    t2 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = 1.year  + 2.months + 3.days + 4.hours + 5.minutes + 6.seconds + 7_000_000.nanoseconds
+    t2 = 2.years + 3.months + 4.days + 5.hours + 6.minutes + 7.seconds + 8_000_000.nanoseconds
     t3 = t1 + t2
 
-    t3.days.should eq(3)
-    t3.hours.should eq(5)
-    t3.minutes.should eq(7)
-    t3.seconds.should eq(9)
-    t3.milliseconds.should eq(11)
-    t3.nanoseconds.should eq(11_000_000)
-    t3.to_s.should eq("3.05:07:09.011000000")
+    t3.years.should eq 3
+    t3.months.should eq 5
+    t3.days.should eq 7
+    t3.hours.should eq 9
+    t3.minutes.should eq 11
+    t3.seconds.should eq 13
+    t3.nanoseconds.should eq 15_000_000
 
     # TODO check overflow
   end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -364,24 +364,29 @@ describe Time do
       t = Time.utc 2014, 10, 31, 21, 18, 13
       t2 = t.shift months: 1
       t2.should eq Time.utc(2014, 11, 30, 21, 18, 13)
+      (t + 1.month).should eq t2
 
       t = Time.utc 2014, 10, 31, 21, 18, 13
       t2 = t.shift months: -1
       t2.should eq Time.utc(2014, 9, 30, 21, 18, 13)
+      (t - 1.month).should eq t2
 
       t = Time.utc 2014, 10, 31, 21, 18, 13
       t2 = t.shift months: 6
       t2.should eq Time.utc(2015, 4, 30, 21, 18, 13)
+      (t + 6.months).should eq t2
     end
 
     it "adds years" do
       t = Time.utc 2014, 10, 30, 21, 18, 13
       t2 = t.shift years: 1
       t2.should eq Time.utc(2015, 10, 30, 21, 18, 13)
+      (t + 1.year).should eq t2
 
       t = Time.utc 2014, 10, 30, 21, 18, 13
       t2 = t.shift years: -2
       t2.should eq Time.utc(2012, 10, 30, 21, 18, 13)
+      (t - 2.years).should eq t2
     end
 
     it "adds hours" do

--- a/src/time.cr
+++ b/src/time.cr
@@ -554,50 +554,29 @@ struct Time
   #
   # See `#shift` for details.
   def +(span : Time::Span) : Time
-    shift span.to_i, span.nanoseconds
+    if span.total_months == 0
+      shift(
+        seconds: span.to_i,
+        nanoseconds: span.nanoseconds
+      )
+    else
+      shift(
+        months: span.total_months,
+        seconds: span.to_i,
+        nanoseconds: span.nanoseconds,
+      )
+    end
   end
 
   # Returns a copy of this `Time` with *span* subtracted.
   #
   # See `#shift` for details.
   def -(span : Time::Span) : Time
-    shift -span.to_i, -span.nanoseconds
-  end
-
-  # Returns a copy of this `Time` with *span* added.
-  #
-  # It adds the number of months with overflow increasing the year.
-  # If the resulting day-of-month would be invalid, it is adjusted to the last
-  # valid day of the moneth.
-  #
-  # For example, adding `1.month` to `2007-03-31` would result in the invalid
-  # date `2007-04-31` which will be adjusted to `2007-04-30`.
-  #
-  # This operates on the local time-line, such that the local date-time
-  # represenations of month and year are increased by the specified amount.
-  #
-  # If the resulting date-time is ambiguous due to time zone transitions,
-  # a correct time will be returned, but it does not guarantee which.
-  def +(span : Time::MonthSpan) : Time
-    shift months: span.value.to_i
-  end
-
-  # Returns a copy of this `Time` with *span* subtracted.
-  #
-  # It adds the number of months with overflow decreasing the year.
-  # If the resulting day-of-month would be invalid, it is adjusted to the last
-  # valid day of the moneth.
-  #
-  # For example, subtracting `1.month` from `2007-05-31` would result in the invalid
-  # date `2007-04-31` which will be adjusted to `2007-04-30`.
-  #
-  # This operates on the local time-line, such that the local date-time
-  # represenations of month and year are decreased by the specified amount.
-  #
-  # If the resulting date-time is ambiguous due to time zone transitions,
-  # a correct time will be returned, but it does not guarantee which.
-  def -(span : Time::MonthSpan) : Time
-    shift months: -span.value.to_i
+    shift(
+      months: -span.total_months,
+      seconds: -span.to_i,
+      nanoseconds: -span.nanoseconds,
+    )
   end
 
   # Returns a copy of this `Time` shifted by the number of *seconds* and
@@ -705,10 +684,7 @@ struct Time
         year -= 1
       end
 
-      maxday = Time.days_in_month(year, month)
-      if day > maxday
-        day = maxday
-      end
+      day = { day, Time.days_in_month(year, month) }.min
 
       seconds += Time.absolute_days(year, month, day).to_i64 * SECONDS_PER_DAY
       seconds += offset_seconds % SECONDS_PER_DAY
@@ -735,7 +711,11 @@ struct Time
   # The difference between local date-time representations may equal to a
   # different duration, depending on time zone transitions.
   def -(other : Time) : Time::Span
+    years = year - other.year
+    months = month - other.month
+
     Span.new(
+      months: years * 12 - months,
       seconds: total_seconds - other.total_seconds,
       nanoseconds: nanosecond - other.nanosecond,
     )
@@ -887,7 +867,8 @@ struct Time
     # This calculation needs to be in UTC to avoid issues with changes in
     # the time zone offset (such as daylight savings time).
     # TODO: Use #shift or #to_local_in instead
-    time = Time.utc(year, 1, 1, hour, minute, second, nanosecond: nanosecond) + ordinal.days
+    base_time = Time.utc(year, 1, 1, hour, minute, second, nanosecond: nanosecond)
+    time = base_time + ordinal.days
 
     # If the location is UTC, we're done
     return time if location.utc?


### PR DESCRIPTION
I was trying to map [Neo4j's `Duration` type](https://neo4j.com/docs/cypher-manual/current/syntax/temporal/#cypher-temporal-durations) to Crystal's `Time::Span` but kept running into issues due to `Time::Span` and `Time::MonthSpan` being separate types. This PR combines them into `Time::Span`.

If I'm being completely honest, I can't imagine a realistic scenario where someone would need to specify a duration of `1.year + 1.day` for anything but right now that's impossible with Crystal in a scenario where anyone _could_ need it. In my case, if someone does actually store that duration in their Neo4j database, we have no way to represent it.

I was going to write a wrapper around both types for the Neo4j driver but I figured it might be worth combining them in the core library. I could imagine people running into the same issues elsewhere, such as with [Postgres's `INTERVAL` type](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT) or any time you need to deal with user-supplied time spans.

_Note:_ There were previously no specs for `Time::MonthSpan`. This PR adds a spec regarding months/years for `Time::Span` and a few for `Time#{+,-}(Time::Span)`.