### PR TITLE
Experiment: add MAIN_FILE constant

### DIFF
--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -108,7 +108,7 @@ module Crystal
     property? show_error_trace = false
 
     # The main filename of this program
-    property filename : String?
+    getter filename : String?
 
     # A `ProgressTracker` object which tracks compilation progress.
     property progress_tracker = ProgressTracker.new
@@ -228,6 +228,14 @@ module Crystal
       types["ThreadLocal"] = @thread_local_annotation = AnnotationType.new self, self, "ThreadLocal"
 
       define_crystal_constants
+    end
+
+    def filename=(filename : String?)
+      @filename = filename
+
+      if filename
+        types["MAIN_FILE"] = Const.new self, self, "MAIN_FILE", StringLiteral.new(filename)
+      end
     end
 
     # Returns a `LiteralExpander` useful to expand literal like arrays and hashes


### PR DESCRIPTION
This PR lets the compiler include a predefined constant, `MAIN_FILE` with the full filename of the first file that's being compiled.

With this you can do:

```crystal
if __FILE__ == MAIN_FILE
  puts "Main program..."
end
```

This is similar to Python's `if __name__ == __main__` and Ruby's not that common `if __FILE__ == $0`.

I just want to gather opinions on this because it's asked from time to time, like today: https://forum.crystal-lang.org/t/is-there-any-equivalent-to-cs-main-or-pythons-if-main-statement/450

(note: Ideally this would be named `__MAIN__` but that parses as a variable, not a constant, so we would need a small hack to make that parse as a constant, that's why I went with `MAIN_FILE`)