### PR TITLE
OAuth2: don't parse error as JSON

### DIFF
--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -149,7 +149,7 @@ class OAuth2::Client
     when 200, 201
       OAuth2::AccessToken.from_json(response.body)
     else
-      raise OAuth2::Error.from_json(response.body)
+      raise OAuth2::Error.new(response.body)
     end
   end
 

--- a/src/oauth2/error.cr
+++ b/src/oauth2/error.cr
@@ -1,28 +1,2 @@
 class OAuth2::Error < Exception
-  getter error : String
-  getter error_description : String?
-
-  def initialize(@error, @error_description)
-    if error_description = @error_description
-      super("#{@error}: #{error_description}")
-    else
-      super(@error)
-    end
-  end
-
-  def self.new(pull : JSON::PullParser)
-    error = nil
-    error_description = nil
-
-    pull.read_object do |key|
-      case key
-      when "error"             then error = pull.read_string
-      when "error_description" then error_description = pull.read_string
-      else
-        raise "Unknown key in oauth2 error json: #{key}"
-      end
-    end
-
-    new error.not_nil!, error_description
-  end
 end


### PR DESCRIPTION
Fixes #7464

Let's not parse the error as the JSON documented in the [RFC](https://tools.ietf.org/html/rfc6749#section-4.1.2.1). Instead, just treat the whole response body as the exception message. One can parse it from there if needed, but I think it's usually not needed.