### PR TITLE
Compiler: give parser error when assigning a constant inside a multiassign

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -152,6 +152,8 @@ module Crystal
     it_parses "@a, b = 1, 2", MultiAssign.new(["@a".instance_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
     it_parses "@@a, b = 1, 2", MultiAssign.new(["@@a".class_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
+    assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"
+
     assert_syntax_error "1 == 2, a = 4"
     assert_syntax_error "x : String, a = 4"
     assert_syntax_error "b, 1 == 2, a = 4"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -164,14 +164,14 @@ module Crystal
         unexpected_token
       end
 
-      targets = exps[0...assign_index].map { |exp| to_lhs(exp) }
+      targets = exps[0...assign_index].map { |exp| multiassign_left_hand(exp) }
 
       assign = exps[assign_index]
       values = [] of ASTNode
 
       case assign
       when Assign
-        targets << to_lhs(assign.target)
+        targets << multiassign_left_hand(assign.target)
         values << assign.value
       when Call
         assign.name = assign.name.byte_slice(0, assign.name.bytesize - 1)
@@ -216,9 +216,9 @@ module Crystal
       end
     end
 
-    def to_lhs(exp)
-      if exp.is_a?(Path) && inside_def?
-        raise "dynamic constant assignment. Constants can only be declared at the top level or inside other types."
+    def multiassign_left_hand(exp)
+      if exp.is_a?(Path)
+        raise "can't assign to constant in multiple assignment", exp.location.not_nil!
       end
 
       if exp.is_a?(Call) && !exp.obj && exp.args.empty?


### PR DESCRIPTION
Fixes #7428

I also renamed a method name because it was a bit cryptic.