### PR TITLE
Handle signals in a separate fiber

### DIFF
--- a/src/signal.cr
+++ b/src/signal.cr
@@ -208,13 +208,16 @@ module Crystal::Signal
 
   private def self.process(signal) : Nil
     if handler = @@handlers[signal]?
-      handler.call(signal)
+      non_nil_handler = handler # if handler is closured it will also have the Nil type
+      spawn do
+        non_nil_handler.call(signal)
+      rescue ex
+        ex.inspect_with_backtrace(STDERR)
+        fatal("uncaught exception while processing handler for #{signal}")
+      end
     else
       fatal("missing handler for #{signal}")
     end
-  rescue ex
-    ex.inspect_with_backtrace(STDERR)
-    fatal("uncaught exception while processing handler for #{signal}")
   end
 
   # Replaces the signal pipe so the child process won't share the file


### PR DESCRIPTION
Fixes #7336

I had to assign `handler` to a separate variable because when it's closured all types assigned to it are in the closure (this includes `Nil` because it's the type that it gets after the `if`). Another alternative is to use `not_nil!` but that's maybe uglier and more cryptic.

The main problem this fixes is that when a signal is handled the runtime currently executes it in the same fiber in which the signal trapping/checking happens, and this prevents multiple signals to run concurrently. This in particular affects SIGCHLD, which is called when a child process ends. 