### PR TITLE
Attempted String::Formatter has no type fix

### DIFF
--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -55,7 +55,7 @@ struct String::Formatter(A)
     next_char
     arg = current_arg
     if arg.is_a?(Hash) || arg.is_a?(NamedTuple)
-      target_arg = arg[key]
+      target_arg = arg[key] unless arg.empty?
     else
       raise ArgumentError.new "One hash or named tuple required"
     end


### PR DESCRIPTION
Fix #7461

I'm not super familiar with what overall is going on but this seems to fix it.  If I had to guess it would be because the type from the arg doesn't exist (for some reason, maybe the cause of that is at a lower level/someplace else?) and this causes `target_arg` to be typeless.  This change makes `target_arg` nil if a type does not exist, which is an allowable type for it.