### PR TITLE
Compiler: fix a couple of issues with `as`, `as?` and unions

### DIFF
--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -308,4 +308,15 @@ describe "Semantic: cast" do
       1.as(Int)
       )) { int32 }
   end
+
+  it "doesn't crash with typeof no-type (#7441)" do
+    assert_type(%(
+      a = 1
+      if a.is_a?(Char)
+        1.as(typeof(a))
+      else
+        ""
+      end
+      )) { string }
+  end
 end

--- a/spec/compiler/semantic/nilable_cast_spec.cr
+++ b/spec/compiler/semantic/nilable_cast_spec.cr
@@ -36,4 +36,15 @@ describe "Semantic: nilable cast" do
       Bar.new.as?(Foo)
       )) { nilable types["Foo"].virtual_type! }
   end
+
+  it "doesn't crash with typeof no-type (#7441)" do
+    assert_type(%(
+      a = 1
+      if a.is_a?(Char)
+        1.as?(typeof(a))
+      else
+        ""
+      end
+      )) { string }
+  end
 end

--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -165,4 +165,18 @@ describe "Semantic: union" do
       {foo(1), foo("hi")}
       )) { tuple_of([int32, string]) }
   end
+
+  it "doesn't crash with union of no-types (#5805)" do
+    assert_type(%(
+      class Gen(T)
+      end
+
+      foo = 42
+      if foo.is_a?(String)
+        Gen(typeof(foo) | Int32)
+      else
+        'a'
+      end
+      )) { union_of char, generic_class("Gen", int32).metaclass }
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -296,6 +296,32 @@ module Crystal
     end
   end
 
+  class Union
+    property? inside_is_a = false
+
+    def update(from = nil)
+      computed_types = types.compact_map do |subtype|
+        instance_type = subtype.type?
+        next unless instance_type
+
+        unless instance_type.allowed_in_generics?
+          subtype.raise "can't use #{instance_type} in unions yet, use a more specific type"
+        end
+        instance_type.virtual_type
+      end
+
+      return if computed_types.empty?
+
+      program = computed_types.first.program
+
+      if inside_is_a?
+        self.type = program.type_merge_union_of(computed_types)
+      else
+        self.type = program.type_merge(computed_types)
+      end
+    end
+  end
+
   class Cast
     property? upcast = false
 

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -300,8 +300,10 @@ module Crystal
     property? upcast = false
 
     def update(from = nil)
+      to_type = to.type?
+      return unless to_type
+
       obj_type = obj.type?
-      to_type = to.type
 
       @upcast = false
 

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -335,8 +335,10 @@ module Crystal
     getter! non_nilable_type : Type
 
     def update(from = nil)
+      to_type = to.type?
+      return unless to_type
+
       obj_type = obj.type?
-      to_type = to.type
 
       @upcast = false
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -123,7 +123,7 @@ module Crystal
       ))
       @found_self_in_initialize_call = nil
       @used_ivars_in_calls_in_initialize = nil
-      @in_is_a = false
+      @inside_is_a = false
 
       # We initialize meta_vars from vars given in the constructor.
       # We store those meta vars either in the typed def or in the program
@@ -323,23 +323,8 @@ module Crystal
       node.types.each &.accept self
       @in_type_args -= 1
 
-      old_in_is_a, @in_is_a = @in_is_a, false
-
-      types = node.types.map do |subtype|
-        instance_type = subtype.type
-        unless instance_type.allowed_in_generics?
-          subtype.raise "can't use #{instance_type} in unions yet, use a more specific type"
-        end
-        instance_type.virtual_type
-      end
-
-      @in_is_a = old_in_is_a
-
-      if @in_is_a
-        node.type = @program.type_merge_union_of(types)
-      else
-        node.type = @program.type_merge(types)
-      end
+      node.inside_is_a = @inside_is_a
+      node.update
 
       false
     end
@@ -1770,9 +1755,9 @@ module Crystal
       node.obj.accept self
 
       @in_type_args += 1
-      @in_is_a = true
+      @inside_is_a = true
       node.const.accept self
-      @in_is_a = false
+      @inside_is_a = false
       @in_type_args -= 1
 
       node.type = program.bool


### PR DESCRIPTION
Fixes #5805
Fixes #7441

The first two commits use `.type?` instead of `.type` on a couple of nodes because their types might not be computed yet.

The third commit makes computing a union's type reactive (make it depend on the inner types, and if they change, recompute) and also use `.type?` instead of `.type` because of the same reason as above.