### PR TITLE
Add detection of linux environment in compiler config

### DIFF
--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -8,7 +8,7 @@ class Crystal::Codegen::Target
   getter vendor : String
   getter environment : String
 
-  def initialize(target_triple = Crystal::Config.default_target_triple)
+  def initialize(target_triple : String)
     # Let LLVM convert the user-inputted target triple into at least a target
     # triple with the architecture, vendor and OS in the correct place.
     target_triple = LLVM.normalize_triple(target_triple.downcase)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -88,7 +88,7 @@ module Crystal
 
     # Codegen target to use in the compilation.
     # If not set, asks LLVM the default one for the current machine.
-    property codegen_target = Codegen::Target.new
+    property codegen_target = Config.default_target
 
     # If `true`, prints the link command line that is performed
     # to create the executable.

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -37,7 +37,7 @@ module Crystal
     @@default_target : Crystal::Codegen::Target?
 
     def self.default_target : Crystal::Codegen::Target
-      @@default_target || begin
+      @@default_target ||= begin
         target = Crystal::Codegen::Target.new({{env("CRYSTAL_CONFIG_TARGET")}} || LLVM.default_target_triple)
 
         if target.linux?
@@ -51,7 +51,7 @@ module Crystal
           target = Crystal::Codegen::Target.new(target.to_s.sub(default_libc, "-#{runtime_libc}"))
         end
 
-        @@default_target = target
+        target
       end
     end
 

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -41,9 +41,9 @@ module Crystal
         target = Crystal::Codegen::Target.new({{env("CRYSTAL_CONFIG_TARGET")}} || LLVM.default_target_triple)
 
         if target.linux?
-          # The linux binary runs as well on linux-gnu as linux-musl, but the
-          # default target needs to match the C library used on the current
-          # system.
+          # The statically linked linux binary runs as well on linux-gnu as
+          # on linux-musl, but the default target needs to match the C
+          # library used on the current system.
           # This can be automatically detected from the output of `ldd --version`
           # in order to use the appropriate environment target.
           default_libc = target.gnu? ? "-gnu" : "-musl"
@@ -57,7 +57,7 @@ module Crystal
 
     private def self.runtime_libc
       ldd_version = String.build do |io|
-        Process.new("ldd", {"--version"}, output: io, error: io).wait
+        Process.run("ldd", {"--version"}, output: io, error: io)
       rescue Errno
         # In case of an error (eg. `ldd` not available), we assume it's gnu.
         return "gnu"

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -18,7 +18,7 @@ module Crystal
         Crystal #{version} #{formatted_sha}(#{date})
 
         LLVM: #{llvm_version}
-        Default target: #{self.default_target_triple}
+        Default target: #{self.default_target}
         DOC
     end
 
@@ -34,8 +34,40 @@ module Crystal
       Time.unix(time).to_s("%Y-%m-%d")
     end
 
-    def self.default_target_triple
-      {{env("CRYSTAL_CONFIG_TARGET")}} || LLVM.default_target_triple
+    @@default_target : Crystal::Codegen::Target?
+
+    def self.default_target : Crystal::Codegen::Target
+      @@default_target || begin
+        target = Crystal::Codegen::Target.new({{env("CRYSTAL_CONFIG_TARGET")}} || LLVM.default_target_triple)
+
+        if target.linux?
+          # The linux binary runs as well on linux-gnu as linux-musl, but the
+          # default target needs to match the C library used on the current
+          # system.
+          # This can be automatically detected from the output of `ldd --version`
+          # in order to use the appropriate environment target.
+          musl_environment = musl_environment?
+          if musl_environment && target.gnu?
+            target = Crystal::Codegen::Target.new(target.to_s.sub("-gnu", "-musl"))
+          elsif !musl_environment && target.musl?
+            target = Crystal::Codegen::Target.new(target.to_s.sub("-musl", "-gnu"))
+          end
+        end
+
+        @@default_target = target
+      end
+    end
+
+    private def self.musl_environment?
+      ldd_version = String.build do |io|
+        Process.new("ldd", ["--version"], output: io, error: io).wait
+      rescue Errno
+        # In case of an error (for example `ldd` not available), we simply
+        # assume it's not musl
+        return false
+      end
+
+      ldd_version.starts_with?("musl")
     end
   end
 end

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -59,8 +59,7 @@ module Crystal
       ldd_version = String.build do |io|
         Process.new("ldd", {"--version"}, output: io, error: io).wait
       rescue Errno
-        # In case of an error (for example `ldd` not available), we simply
-        # assume it's gnu.
+        # In case of an error (eg. `ldd` not available), we assume it's gnu.
         return "gnu"
       end
 

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -57,7 +57,7 @@ module Crystal
 
     private def self.runtime_libc
       ldd_version = String.build do |io|
-        Process.new("ldd", ["--version"], output: io, error: io).wait
+        Process.new("ldd", {"--version"}, output: io, error: io).wait
       rescue Errno
         # In case of an error (for example `ldd` not available), we simply
         # assume it's gnu.

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -12,7 +12,7 @@ module Crystal
 
     @crystal_path : Array(String)
 
-    def initialize(path = CrystalPath.default_path, codegen_target = Codegen::Target.new)
+    def initialize(path = CrystalPath.default_path, codegen_target = Config.default_target)
       @crystal_path = path.split(':').reject &.empty?
       add_target_path(codegen_target)
     end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -113,7 +113,7 @@ module Crystal
     # A `ProgressTracker` object which tracks compilation progress.
     property progress_tracker = ProgressTracker.new
 
-    property codegen_target = Codegen::Target.new
+    property codegen_target = Config.default_target
 
     def initialize
       super(self, self, "main")


### PR DESCRIPTION
Fixes #7196

This change allows to use the same compiler binary with both gnu and musl.

In the process, I renamed `Config.default_target_triple` to `Config.default_target` and it now returns a `Codegen::Target` instance. We need the instance anyway to check whether it's linux.

I also replaced all usages of `Target.new` with `Config.default_target` which better communicates the purpose and avoids weird interdependency.

This does not add a `--host-target` option, which was also discussed in #7196 but that can be left for another PR.