### PR TITLE
WebSocket#close accepts code and reason arguments

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -275,14 +275,16 @@ describe HTTP::WebSocket do
   end
 
   describe "close" do
-    it "closes with message" do
-      message = "bye"
+    it "closes with code and response" do
+      response = "bye"
+      code = 4000_i16
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
-      ws.close(message)
+      ws.close(code, response)
       bytes = io.to_slice
       (bytes[0] & 0x0f).should eq(0x8) # CLOSE frame
-      String.new(bytes[2, bytes[1]]).should eq(message)
+      IO::ByteFormat::NetworkEndian.decode(Int16, bytes[2, 3]).should eq(code)
+      String.new(bytes[4, bytes[1] - 2]).should eq(response)
     end
 
     it "closes without message" do

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -489,7 +489,7 @@ module Crystal::Playground
         origin = context.request.headers["Origin"]
         if !accept_request?(origin)
           @logger.warn "Invalid Request Origin: #{origin}"
-          ws.close "Invalid Request Origin"
+          ws.close 1002, "Invalid Request Origin"
         else
           @sessions_key += 1
           @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @port, @logger)

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -147,9 +147,9 @@ class HTTP::WebSocket
             code = @current_message.read_bytes(Int16, IO::ByteFormat::NetworkEndian)
             reason = @current_message.gets_to_end
             @on_close.try &.call(code, reason)
-            close(code, reason) unless closed?
           rescue IO::EOFError
             @on_close.try &.call(nil, nil)
+          ensure
             close unless closed?
           end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -90,10 +90,11 @@ class HTTP::WebSocket
     end
   end
 
-  def close(message = nil)
+  # Closes the websocket with *reason* and *code*.
+  def close(reason : String? = nil, code : Int16? = nil)
     return if closed?
     @closed = true
-    @ws.close(message)
+    @ws.close(reason, code)
   end
 
   def run

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -229,7 +229,20 @@ class HTTP::WebSocket::Protocol
     end
   end
 
-  def close(message = nil)
+  def close(reason : String? = nil, code : Int16? = nil)
+    if code
+      raw = uninitialized UInt8[2]
+      IO::ByteFormat::BigEndian.encode(code, raw.to_slice)
+
+      message = String.new(raw)
+
+      if reason
+        message += reason
+      end
+    else
+      message = reason
+    end
+
     if message
       send(message.to_slice, Opcode::CLOSE)
     else


### PR DESCRIPTION
Fixes #6469

~~I saw WebSocket#close specs and they are pretty simple, but I'm absolutely not sure how to convert `String.new(bytes[2, bytes[1]]).should eq(message)` line to test both reason and code arguments.~~

Also see https://developer.mozilla.org/ru/docs/Web/API/WebSocket/close.