### PR TITLE
Fix expected error in tcp_server_spec for musl

### DIFF
--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -50,7 +50,7 @@ describe TCPServer do
 
         it "raises when not binding with reuse_port" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
-            expect_raises_errno(Errno::EADDRINUSE, {% if flag?(:linux) %}"listen: "{% else %}"bind: "{% end %}) do
+            expect_raises_errno(Errno::EADDRINUSE, {% if flag?(:gnu) %}"listen: "{% else %}"bind: "{% end %}) do
               TCPServer.open(address, server.local_address.port) { }
             end
           end


### PR DESCRIPTION
It seems only glibc errors at listen. This spec failed on musl because it errors at bind.

We could also consider removing these strict checks for very specific error messages. It would probably suffice to check that it either contains `bind` or `listen` with any libc implementation.
But I guess being a bit more strict avoids accidentally triggering unexpected errors which would then still meet the expectation.

And in the end, it doesn't really matter if such specs happen to occasionally fail on a new platform. Having a few false positives isn't an issue.
In Crystal's aport this spec is simply muted (https://git.alpinelinux.org/aports/tree/community/crystal/fix-spec-std-socket-tcp_server_spec.cr.patch?id=29c6464be19088283c52dd74e90bbbd4f9829a6c).