### PR TITLE
added documentation to BigInt, BigFloat, and BigDecimal

### DIFF
--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -8,6 +8,17 @@ require "big"
 #
 # The general idea and some of the arithmetic algorithms were adapted from
 # the MIT/APACHE -licensed https://github.com/akubera/bigdecimal-rs
+#
+# ### Usage:
+# ```
+# require "big"
+# # From a string representation
+# BigDecimal.new("123456789123456789.123456789123456789") # => 123456789123456789.123456789123456789
+# # Defaults to 0
+# BigDecimal.new                                          # => 0
+# # From a number
+# BigDecimal.new(UInt64::MAX) + BigDecimal.new(1.234)     # => 18446744073709551616.234
+# ```
 
 class InvalidBigDecimalException < Exception
   def initialize(big_decimal_str : String, reason : String)

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -4,6 +4,17 @@ require "big"
 # A `BigFloat` can represent arbitrarily large floats.
 #
 # It is implemented under the hood with [GMP](https://gmplib.org/).
+#
+# ### Usage:
+# ```
+# require "big"
+# # From a string representation
+# BigFloat.new("123456789123456789.123456789123456789") # => 123456789123456789.123
+# # Defaults to 0
+# BigFloat.new                                          # => 0
+# # From a number
+# (BigFloat.new Float64::MAX) * 2		                # => 359538626972463141629000000... (with a lot of zeroes)
+# ```
 struct BigFloat < Float
   include Comparable(Int)
   include Comparable(BigFloat)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -5,6 +5,19 @@ require "random"
 # A `BigInt` can represent arbitrarily large integers.
 #
 # It is implemented under the hood with [GMP](https://gmplib.org/).
+#
+# ### Usage:
+# ```
+# require "big"
+# # From a string representation
+# BigInt.new("123456789123456789123456789123456789") # => 123456789123456789123456789123456789
+# # With an optionally specified base
+# BigInt.new("1234567890ABCDEF", base: 16)           # => 1311768467294899695
+# # Defaults to 0
+# BigInt.new                                         # => 0
+# # From a number
+# (BigInt.new 18_446_744_073_709_551_615) + 1        # => 18446744073709551616
+# ```
 struct BigInt < Int
   include Comparable(Int::Signed)
   include Comparable(Int::Unsigned)


### PR DESCRIPTION
I feel that it's important to note that in order to use the big numbers, you need to `require "big"`. This adds some basic usage to the top of each of the Big... structs that don't already have it. 