### PR TITLE
Fix time format RFC 3339 to not include offset seconds

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -368,6 +368,7 @@ describe "JSON serialization" do
     describe "Time" do
       it "#to_json" do
         Time.utc(2016, 11, 16, 12, 55, 48).to_json.should eq(%("2016-11-16T12:55:48Z"))
+        Time.local(2016, 11, 16, 12, 55, 48, location: Time::Location.fixed(7200)).to_json.should eq(%("2016-11-16T12:55:48+02:00"))
       end
 
       it "omit sub-second precision" do

--- a/spec/std/time/custom_formats_spec.cr
+++ b/spec/std/time/custom_formats_spec.cr
@@ -5,6 +5,7 @@ describe "Time::Format" do
     it "parses regular format" do
       time = Time.utc(2016, 2, 15)
       Time::Format::RFC_3339.format(time).should eq "2016-02-15T00:00:00Z"
+      Time::Format::RFC_3339.format(Time.local(2016, 2, 15, location: Time::Location.fixed(3600))).should eq "2016-02-15T00:00:00+01:00"
       Time::Format::RFC_3339.parse("2016-02-15T00:00:00+00:00").should eq time
       Time::Format::RFC_3339.parse("2016-02-15t00:00:00+00:00").should eq time
       Time::Format::RFC_3339.parse("2016-02-15 00:00:00+00:00").should eq time

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -29,7 +29,7 @@ struct Time::Format
       char 'T', 't', ' '
       twenty_four_hour_time_with_seconds
       second_fraction?(fraction_digits: fraction_digits)
-      time_zone_z_or_offset(force_colon: true)
+      time_zone_z_or_offset(force_colon: true, format_seconds: false)
     end
   end
 end

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -29,7 +29,7 @@ struct Time::Format
       char 'T', 't', ' '
       twenty_four_hour_time_with_seconds
       second_fraction?(fraction_digits: fraction_digits)
-      time_zone_z_or_offset(force_colon: true, format_seconds: false)
+      time_zone_z_or_offset(force_colon: true)
     end
   end
 end

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -175,7 +175,7 @@ struct Time::Format
     end
 
     def time_zone(with_seconds = false)
-      time_zone_offset(allow_seconds: with_seconds)
+      time_zone_offset(format_seconds: with_seconds)
     end
 
     def time_zone_z_or_offset(**options)
@@ -186,12 +186,12 @@ struct Time::Format
       end
     end
 
-    def time_zone_offset(force_colon = false, allow_colon = true, allow_seconds = true)
-      time.zone.format(io, with_colon: force_colon, with_seconds: allow_seconds)
+    def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = true, parse_seconds = true)
+      time.zone.format(io, with_colon: force_colon, with_seconds: format_seconds)
     end
 
     def time_zone_colon(with_seconds = false)
-      time_zone_offset(force_colon: true, allow_seconds: with_seconds)
+      time_zone_offset(force_colon: true, format_seconds: with_seconds)
     end
 
     def time_zone_colon_with_seconds
@@ -203,7 +203,7 @@ struct Time::Format
     end
 
     def time_zone_rfc2822
-      time_zone_offset(allow_colon: false, allow_seconds: false)
+      time_zone_offset(allow_colon: false, format_seconds: false)
     end
 
     def time_zone_gmt_or_rfc2822(**options)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -186,7 +186,7 @@ struct Time::Format
       end
     end
 
-    def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = true, parse_seconds = true)
+    def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = false, parse_seconds = true)
       time.zone.format(io, with_colon: force_colon, with_seconds: format_seconds)
     end
 
@@ -203,7 +203,7 @@ struct Time::Format
     end
 
     def time_zone_rfc2822
-      time_zone_offset(allow_colon: false, format_seconds: false)
+      time_zone_offset(allow_colon: false)
     end
 
     def time_zone_gmt_or_rfc2822(**options)

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -338,7 +338,7 @@ struct Time::Format
       next_char
     end
 
-    def time_zone_offset(force_colon = false, allow_colon = true, allow_seconds = true, force_zero_padding = true, force_minutes = true)
+    def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = false, parse_seconds = true, force_zero_padding = true, force_minutes = true)
       case current_char
       when '-'
         sign = -1
@@ -386,7 +386,7 @@ struct Time::Format
       end
 
       seconds = 0
-      if @reader.has_next? && allow_seconds
+      if @reader.has_next? && parse_seconds
         pos = @reader.pos
         if char == ':'
           char = next_char


### PR DESCRIPTION
Fixes #7489

This still allows parsing offset seconds even if seconds are not specified in RFC 3339. I think it's better to be a bit lenient here to be able to parse values even if they're not 100% correct according to the spec.