### PR TITLE
Playground: Compile programs using without_openssl flag

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -55,6 +55,7 @@ module Crystal::Playground
       output_filename = tempfile "play-#{@session_key}-#{tag}"
       compiler = Compiler.new
       compiler.color = false
+      compiler.flags << "without_openssl"
       begin
         @logger.info "Instrumented code compilation started (session=#{@session_key}, tag=#{tag})."
         result = compiler.compile sources, output_filename


### PR DESCRIPTION
So, after upgrading to mojave...

I was able to experience #7209 / #6875 

Every program input in the playground will include `playground/agent.cr` which triggers the following dependencies

* https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/tools/playground/agent.cr#L1
* https://github.com/crystal-lang/crystal/blob/master/src/http.cr#L2
* https://github.com/crystal-lang/crystal/blob/master/src/http/server.cr#L8

The websocket communication with the playground server does not require openssl, that is the reasone `without_openssl` flag exists actually.

Adding that flag to the compilation process will prevent this issues. 

⚠️  It will also mean that openssl is not available to be used in the scripts in the playground. ⚠️ 

Another alternative would be to detect if it is available, and if not, ignore it.
It seems that the previous default openssl library was enough to build the samples in osx.

cc: @dustinlahr, @thebradhimself