### PR TITLE
Add Hash#includes?(other : Hash) overload

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -97,6 +97,22 @@ describe "Hash" do
     end
   end
 
+  describe "#includes?" do
+    it "returns true if all key-values are matching" do
+      h = (0..10).to_h { |i| {i.to_s, i} }
+      h.includes?({"0" => 0}).should be_true
+      h.includes?({"0" => 0, "10" => 10}).should be_true
+    end
+
+    it "returns false if any key-value is different" do
+      h = (0..10).to_h { |i| {i.to_s, i} }
+      h.includes?({0 => 0}).should be_false
+      h.includes?({"0" => 10}).should be_false
+      h.includes?({"0" => 0, "10" => 11}).should be_false
+      h.includes?({"0" => 0, "11" => 10}).should be_false
+    end
+  end
+
   describe "[]=" do
     it "overrides value" do
       a = {1 => 2}

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -141,6 +141,23 @@ class Hash(K, V)
     end
   end
 
+  # Returns `true` if *other* hash is included in the `self`,
+  # i.e. all keys and values from *other* are present in `self`.
+  #
+  # ```
+  # h = {"foo" => "bar", "qux" => "quux"}
+  # h.includes?({"foo" => "bar", "qux" => "quux"}) # => true
+  # h.includes?({"foo" => "bar"})                  # => true
+  # h.includes?({"baz" => "bar", "qux" => "quux"}) # => false
+  # h.includes?({"foo" => "baz"})                  # => false
+  # h.includes?({"baz" => "bar"})                  # => false
+  # ```
+  def includes?(other : Hash)
+    other.all? do |key, value|
+      self[key]? == value
+    end
+  end
+
   # Returns the value for the key given by *key*.
   # If not found, returns `nil`. This ignores the default value set by `Hash.new`.
   #


### PR DESCRIPTION
This PR allows checking if a `Hash` includes given subset denoted by given *other* `Hash`.
Functionality asked for instance at [SO](https://stackoverflow.com/questions/7584801/how-to-check-if-an-hash-is-completely-included-in-another-hash) - Ruby version.

Supersedes #7498 since it's a more versatile implementation, enhancing `Hash` API without a need for introducing special cases in `ContainExpection` matcher.