### PR TITLE
Add sub/superset checking methods to Hash

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -99,6 +99,53 @@ describe "Hash" do
     end
   end
 
+  context "subset/superset operators" do
+    h1 = {"a" => 1, "b" => 2}
+    h2 = {"a" => 1, "b" => 2, "c" => 3}
+    h3 = {"c" => 3}
+    h4 = {} of Nil => Nil
+
+    describe "<" do
+      it do
+        (h1 < h2).should be_true
+        (h2 < h1).should be_false
+        (h1 < h1).should be_false
+        (h1 < h3).should be_false
+        (h1 < h4).should be_false
+      end
+    end
+
+    describe "<=" do
+      it do
+        (h1 <= h2).should be_true
+        (h2 <= h1).should be_false
+        (h1 <= h1).should be_true
+        (h1 <= h3).should be_false
+        (h1 <= h4).should be_false
+      end
+    end
+
+    describe ">" do
+      it do
+        (h1 > h2).should be_false
+        (h2 > h1).should be_true
+        (h1 > h1).should be_false
+        (h1 > h3).should be_false
+        (h1 > h4).should be_true
+      end
+    end
+
+    describe ">=" do
+      it do
+        (h1 >= h2).should be_false
+        (h2 >= h1).should be_true
+        (h1 >= h1).should be_true
+        (h1 >= h3).should be_false
+        (h1 >= h4).should be_true
+      end
+    end
+  end
+
   describe "[]" do
     it "gets" do
       a = {1 => 2}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -105,43 +105,43 @@ describe "Hash" do
     h3 = {"c" => 3}
     h4 = {} of Nil => Nil
 
-    describe "<" do
+    describe "#proper_subset?" do
       it do
-        (h1 < h2).should be_true
-        (h2 < h1).should be_false
-        (h1 < h1).should be_false
-        (h1 < h3).should be_false
-        (h1 < h4).should be_false
+        h1.proper_subset?(h2).should be_true
+        h2.proper_subset?(h1).should be_false
+        h1.proper_subset?(h1).should be_false
+        h1.proper_subset?(h3).should be_false
+        h1.proper_subset?(h4).should be_false
       end
     end
 
-    describe "<=" do
+    describe "#subset?" do
       it do
-        (h1 <= h2).should be_true
-        (h2 <= h1).should be_false
-        (h1 <= h1).should be_true
-        (h1 <= h3).should be_false
-        (h1 <= h4).should be_false
+        h1.subset?(h2).should be_true
+        h2.subset?(h1).should be_false
+        h1.subset?(h1).should be_true
+        h1.subset?(h3).should be_false
+        h1.subset?(h4).should be_false
       end
     end
 
-    describe ">" do
+    describe "#proper_superset?" do
       it do
-        (h1 > h2).should be_false
-        (h2 > h1).should be_true
-        (h1 > h1).should be_false
-        (h1 > h3).should be_false
-        (h1 > h4).should be_true
+        h1.proper_superset?(h2).should be_false
+        h2.proper_superset?(h1).should be_true
+        h1.proper_superset?(h1).should be_false
+        h1.proper_superset?(h3).should be_false
+        h1.proper_superset?(h4).should be_true
       end
     end
 
-    describe ">=" do
+    describe "#superset?" do
       it do
-        (h1 >= h2).should be_false
-        (h2 >= h1).should be_true
-        (h1 >= h1).should be_true
-        (h1 >= h3).should be_false
-        (h1 >= h4).should be_true
+        h1.superset?(h2).should be_false
+        h2.superset?(h1).should be_true
+        h1.superset?(h1).should be_true
+        h1.superset?(h3).should be_false
+        h1.superset?(h4).should be_true
       end
     end
   end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -113,6 +113,10 @@ describe "Hash" do
         h1.proper_subset_of?(h3).should be_false
         h1.proper_subset_of?(h4).should be_false
       end
+
+      it "handles edge case where both values are nil" do
+        {"a" => nil}.proper_subset_of?({"b" => nil, "c" => nil}).should be_false
+      end
     end
 
     describe "#subset_of?" do
@@ -122,6 +126,10 @@ describe "Hash" do
         h1.subset_of?(h1).should be_true
         h1.subset_of?(h3).should be_false
         h1.subset_of?(h4).should be_false
+      end
+
+      it "handles edge case where both values are nil" do
+        {"a" => nil}.subset_of?({"b" => nil}).should be_false
       end
     end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -105,43 +105,43 @@ describe "Hash" do
     h3 = {"c" => 3}
     h4 = {} of Nil => Nil
 
-    describe "#proper_subset?" do
+    describe "#proper_subset_of?" do
       it do
-        h1.proper_subset?(h2).should be_true
-        h2.proper_subset?(h1).should be_false
-        h1.proper_subset?(h1).should be_false
-        h1.proper_subset?(h3).should be_false
-        h1.proper_subset?(h4).should be_false
+        h1.proper_subset_of?(h2).should be_true
+        h2.proper_subset_of?(h1).should be_false
+        h1.proper_subset_of?(h1).should be_false
+        h1.proper_subset_of?(h3).should be_false
+        h1.proper_subset_of?(h4).should be_false
       end
     end
 
-    describe "#subset?" do
+    describe "#subset_of?" do
       it do
-        h1.subset?(h2).should be_true
-        h2.subset?(h1).should be_false
-        h1.subset?(h1).should be_true
-        h1.subset?(h3).should be_false
-        h1.subset?(h4).should be_false
+        h1.subset_of?(h2).should be_true
+        h2.subset_of?(h1).should be_false
+        h1.subset_of?(h1).should be_true
+        h1.subset_of?(h3).should be_false
+        h1.subset_of?(h4).should be_false
       end
     end
 
-    describe "#proper_superset?" do
+    describe "#proper_superset_of?" do
       it do
-        h1.proper_superset?(h2).should be_false
-        h2.proper_superset?(h1).should be_true
-        h1.proper_superset?(h1).should be_false
-        h1.proper_superset?(h3).should be_false
-        h1.proper_superset?(h4).should be_true
+        h1.proper_superset_of?(h2).should be_false
+        h2.proper_superset_of?(h1).should be_true
+        h1.proper_superset_of?(h1).should be_false
+        h1.proper_superset_of?(h3).should be_false
+        h1.proper_superset_of?(h4).should be_true
       end
     end
 
-    describe "#superset?" do
+    describe "#superset_of?" do
       it do
-        h1.superset?(h2).should be_false
-        h2.superset?(h1).should be_true
-        h1.superset?(h1).should be_true
-        h1.superset?(h3).should be_false
-        h1.superset?(h4).should be_true
+        h1.superset_of?(h2).should be_false
+        h2.superset_of?(h1).should be_true
+        h1.superset_of?(h1).should be_true
+        h1.superset_of?(h3).should be_false
+        h1.superset_of?(h4).should be_true
       end
     end
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1748,25 +1748,25 @@ class Hash(K, V)
   end
 
   # Returns `true` if `self` is a subset of *other*.
-  def proper_subset?(other : Hash)
+  def proper_subset_of?(other : Hash)
     return false if other.size <= size
     all? { |key, value| other[key]? == value }
   end
 
   # Returns `true` if `self` is a subset of *other* or equals to *other*.
-  def subset?(other : Hash)
+  def subset_of?(other : Hash)
     return false if other.size < size
     all? { |key, value| other[key]? == value }
   end
 
   # Returns `true` if *other* is a subset of `self`.
-  def superset?(other : Hash)
-    other.subset?(self)
+  def superset_of?(other : Hash)
+    other.subset_of?(self)
   end
 
   # Returns `true` if *other* is a subset of `self` or equals to `self`.
-  def proper_superset?(other : Hash)
-    other.proper_subset?(self)
+  def proper_superset_of?(other : Hash)
+    other.proper_subset_of?(self)
   end
 
   # See `Object#hash(hasher)`

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1747,6 +1747,30 @@ class Hash(K, V)
     true
   end
 
+  # Returns `true` if `self` is a subset of *other*.
+  def <(other : Hash)
+    return false if size >= other.size
+    self <= other
+  end
+
+  # Returns `true` if `self` is a subset of *other* or equals to *other*.
+  def <=(other : Hash)
+    return false if size > other.size
+    all? do |key, value|
+      other[key]? == value
+    end
+  end
+
+  # Returns `true` if *other* is a subset of `self`.
+  def >(other : Hash)
+    other < self
+  end
+
+  # Returns `true` if *other* is a subset of `self` or equals to `self`.
+  def >=(other : Hash)
+    other <= self
+  end
+
   # See `Object#hash(hasher)`
   def hash(hasher)
     # The hash value must be the same regardless of the

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1748,27 +1748,25 @@ class Hash(K, V)
   end
 
   # Returns `true` if `self` is a subset of *other*.
-  def <(other : Hash)
-    return false if size >= other.size
-    self <= other
+  def proper_subset?(other : Hash)
+    return false if other.size <= size
+    all? { |key, value| other[key]? == value }
   end
 
   # Returns `true` if `self` is a subset of *other* or equals to *other*.
-  def <=(other : Hash)
-    return false if size > other.size
-    all? do |key, value|
-      other[key]? == value
-    end
+  def subset?(other : Hash)
+    return false if other.size < size
+    all? { |key, value| other[key]? == value }
   end
 
   # Returns `true` if *other* is a subset of `self`.
-  def >(other : Hash)
-    other < self
+  def superset?(other : Hash)
+    other.subset?(self)
   end
 
   # Returns `true` if *other* is a subset of `self` or equals to `self`.
-  def >=(other : Hash)
-    other <= self
+  def proper_superset?(other : Hash)
+    other.proper_subset?(self)
   end
 
   # See `Object#hash(hasher)`

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1750,13 +1750,19 @@ class Hash(K, V)
   # Returns `true` if `self` is a subset of *other*.
   def proper_subset_of?(other : Hash)
     return false if other.size <= size
-    all? { |key, value| other[key]? == value }
+    all? do |key, value|
+      other_value = other.fetch(key) { return false }
+      other_value == value
+    end
   end
 
   # Returns `true` if `self` is a subset of *other* or equals to *other*.
   def subset_of?(other : Hash)
     return false if other.size < size
-    all? { |key, value| other[key]? == value }
+    all? do |key, value|
+      other_value = other.fetch(key) { return false }
+      other_value == value
+    end
   end
 
   # Returns `true` if *other* is a subset of `self`.


### PR DESCRIPTION
Adds sub/superset checking methods to the `Hash` class (matching the ones in `Set`):

- `Hash#subset_of?(other : Hash)`
- `Hash#proper_subset_of?(other : Hash)`
- `Hash#superset_of?(other : Hash)`
- `Hash#proper_superset_of?(other : Hash)`