### PR TITLE
Refactor IO::Syscall as IO::Evented

### DIFF
--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -1,4 +1,3 @@
-require "./syscall"
 require "crystal/system/file_descriptor"
 
 # An `IO` over a file descriptor.


### PR DESCRIPTION
I started this refactor in my MT experiments, but I think it stands on its own:

`Evented` is closer to what the module is trying to achieve (abstract event loop details), and method naming follows that from `IO::Buffered` (e.g. `evented_read` instead of `read_syscall_helper`).

Refactors the `FileDescriptor` and `Socket` IO classes to move implementation details into `IO::Evented` to 1. reduce duplication, and 2. avoid direct accesses to internal details (such as `@writers` or `@read_event`).