### PR TITLE
Add command and args to execvp error message

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -17,8 +17,8 @@ describe Process do
 
   it "raises if command could not be executed" do
     # FIXME: Oddly doubled error message
-    expect_raises_errno(Errno::ENOENT, "execvp: No such file or directory: No such file or directory") do
-      Process.new("foobarbaz")
+    expect_raises_errno(Errno::ENOENT, %(execvp (foobarbaz "foo"): No such file or directory: No such file or directory)) do
+      Process.new("foobarbaz", ["foo"])
     end
   end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -457,7 +457,17 @@ class Process
     argv << Pointer(UInt8).null
 
     LibC.execvp(command, argv)
-    raise Errno.new("execvp")
+
+    error_message = String.build do |io|
+      io << "execvp ("
+      command.inspect_unquoted(io)
+      args.try &.each do |arg|
+        io << ' '
+        arg.inspect(io)
+      end
+      io << ")"
+    end
+    raise Errno.new(error_message)
   end
 
   private def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)


### PR DESCRIPTION
When `LibC.execvp` fails, it would previously raise an `Errno` with message `execvp` followed by the reason of failure (for example `No such file or directory`). But that's not a great help for debugging, unless you know *which* command was to be executed.

This PR adds the command and it's arguments to the error message. I'm not sure if the arguments are really necessary.

Related to #7508