### PR TITLE
Revert "Prevent static linking segfaults"

### DIFF
--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -1,9 +1,4 @@
-# libunwind prevents END_OF_STACK errors, but the backtrace is empty
-# https://github.com/crystal-lang/crystal/issues/4276#issuecomment-313678321
-{% if flag?(:musl) && flag?(:static) %}
-require "llvm/lib_llvm"
-require "llvm/enums"
-{% elsif flag?(:openbsd) %}
+{% if flag?(:openbsd) %}
   @[Link("c++abi")]
 {% end %}
 lib LibUnwind


### PR DESCRIPTION
- Reverts crystal-lang/crystal#6945
- Related to https://github.com/crystal-lang/crystal/issues/7480
- After the merge of https://github.com/crystal-lang/crystal/pull/7479 , we can find a better way for static linking.