### PR TITLE
Number: remove type suffix from inspect. Add `#dump` method to show it.

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -394,4 +394,12 @@ describe BigDecimal do
     negative_one.normalize_quotient(negative_one, positive_ten).should eq(positive_ten)
     negative_one.normalize_quotient(negative_one, negative_ten).should eq(negative_ten)
   end
+
+  describe "#dump" do
+    it { "123".to_big_d.dump.should eq("123_big_d") }
+  end
+
+  describe "#inspect" do
+    it { "123".to_big_d.inspect.should eq("123") }
+  end
 end

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -187,8 +187,12 @@ describe "BigFloat" do
     it { "1234567890123456789".to_big_f.to_s.should eq("1234567890123456789") }
   end
 
+  describe "#dump" do
+    it { "2.3".to_big_f.dump.should eq("2.3_big_f") }
+  end
+
   describe "#inspect" do
-    it { "2.3".to_big_f.inspect.should eq("2.3_big_f") }
+    it { "2.3".to_big_f.inspect.should eq("2.3") }
   end
 
   it "#hash" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -259,8 +259,12 @@ describe "BigInt" do
     a.to_big_f.should eq(BigFloat.new("1234567890123456789.0"))
   end
 
+  describe "#dump" do
+    it { "2".to_big_i.dump.should eq("2_big_i") }
+  end
+
   describe "#inspect" do
-    it { "2".to_big_i.inspect.should eq("2_big_i") }
+    it { "2".to_big_i.inspect.should eq("2") }
   end
 
   it "does gcd and lcm" do

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -192,6 +192,14 @@ describe BigRational do
     x = br(10, 3)
     x.clone.should eq(x)
   end
+
+  describe "#dump" do
+    it { 123.to_big_r.dump.should eq("123_big_r") }
+  end
+
+  describe "#inspect" do
+    it { 123.to_big_r.inspect.should eq("123") }
+  end
 end
 
 describe "BigRational Math" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -204,13 +204,33 @@ describe "Float" do
     end
   end
 
+  describe "#dump" do
+    it "does dump for f64" do
+      3.2.dump.should eq("3.2")
+    end
+
+    it "does dump for f32" do
+      3.2_f32.dump.should eq("3.2_f32")
+    end
+
+    it "does dump for f64 with IO" do
+      str = String.build { |io| 3.2.dump(io) }
+      str.should eq("3.2")
+    end
+
+    it "does dump for f32" do
+      str = String.build { |io| 3.2_f32.dump(io) }
+      str.should eq("3.2_f32")
+    end
+  end
+
   describe "#inspect" do
     it "does inspect for f64" do
       3.2.inspect.should eq("3.2")
     end
 
     it "does inspect for f32" do
-      3.2_f32.inspect.should eq("3.2_f32")
+      3.2_f32.inspect.should eq("3.2")
     end
 
     it "does inspect for f64 with IO" do
@@ -220,7 +240,7 @@ describe "Float" do
 
     it "does inspect for f32" do
       str = String.build { |io| 3.2_f32.inspect(io) }
-      str.should eq("3.2_f32")
+      str.should eq("3.2")
     end
   end
 

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -220,24 +220,45 @@ describe "Int" do
     end
   end
 
-  describe "#inspect" do
+  describe "#dump" do
     it "appends the type" do
-      23.inspect.should eq("23")
-      23_i8.inspect.should eq("23_i8")
-      23_i16.inspect.should eq("23_i16")
-      -23_i64.inspect.should eq("-23_i64")
-      23_u8.inspect.should eq("23_u8")
-      23_u16.inspect.should eq("23_u16")
-      23_u32.inspect.should eq("23_u32")
-      23_u64.inspect.should eq("23_u64")
+      23.dump.should eq("23")
+      23_i8.dump.should eq("23_i8")
+      23_i16.dump.should eq("23_i16")
+      -23_i64.dump.should eq("-23_i64")
+      23_u8.dump.should eq("23_u8")
+      23_u16.dump.should eq("23_u16")
+      23_u32.dump.should eq("23_u32")
+      23_u64.dump.should eq("23_u64")
     end
 
     it "appends the type using IO" do
+      str = String.build { |io| 23.dump(io) }
+      str.should eq("23")
+
+      str = String.build { |io| -23_i64.dump(io) }
+      str.should eq("-23_i64")
+    end
+  end
+
+  describe "#inspect" do
+    it "doesn't append the type" do
+      23.inspect.should eq("23")
+      23_i8.inspect.should eq("23")
+      23_i16.inspect.should eq("23")
+      -23_i64.inspect.should eq("-23")
+      23_u8.inspect.should eq("23")
+      23_u16.inspect.should eq("23")
+      23_u32.inspect.should eq("23")
+      23_u64.inspect.should eq("23")
+    end
+
+    it "doesn't append the type using IO" do
       str = String.build { |io| 23.inspect(io) }
       str.should eq("23")
 
       str = String.build { |io| -23_i64.inspect(io) }
-      str.should eq("-23_i64")
+      str.should eq("-23")
     end
   end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -298,9 +298,8 @@ struct BigDecimal < Number
     end
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_big_d"
+  def dump_suffix : String
+    "_big_d"
   end
 
   def to_big_d

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -272,9 +272,8 @@ struct BigFloat < Float
     mpf
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_big_f"
+  def dump_suffix : String
+    "_big_f"
   end
 
   def to_s(io : IO)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -344,9 +344,8 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
-  def inspect(io)
-    to_s io
-    io << "_big_i"
+  def dump_suffix : String
+    "_big_i"
   end
 
   # TODO: improve this

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -220,6 +220,10 @@ struct BigRational < Number
     to_s io
   end
 
+  def dump_suffix : String
+    "_big_r"
+  end
+
   def clone
     self
   end

--- a/src/float.cr
+++ b/src/float.cr
@@ -186,9 +186,8 @@ struct Float32
     Printer.print(self, io)
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_f32"
+  def dump_suffix : String
+    "_f32"
   end
 
   def clone
@@ -273,6 +272,10 @@ struct Float64
 
   def to_s(io : IO)
     Printer.print(self, io)
+  end
+
+  def dump_suffix : String
+    ""
   end
 
   def clone

--- a/src/int.cr
+++ b/src/int.cr
@@ -514,25 +514,6 @@ struct Int
     yield ptr, count
   end
 
-  def inspect(io)
-    type = case self
-           when Int8    then "_i8"
-           when Int16   then "_i16"
-           when Int32   then ""
-           when Int64   then "_i64"
-           when Int128  then "_i128"
-           when UInt8   then "_u8"
-           when UInt16  then "_u16"
-           when UInt32  then "_u32"
-           when UInt64  then "_u64"
-           when UInt128 then "_u128"
-           else              raise "BUG: impossible"
-           end
-
-    to_s(io)
-    io << type
-  end
-
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.
@@ -642,6 +623,10 @@ struct Int8
     Intrinsics.popcount8(self)
   end
 
+  def dump_suffix : String
+    "_i8"
+  end
+
   def clone
     self
   end
@@ -667,6 +652,10 @@ struct Int16
 
   def popcount
     Intrinsics.popcount16(self)
+  end
+
+  def dump_suffix : String
+    "_i16"
   end
 
   def clone
@@ -696,6 +685,10 @@ struct Int32
     Intrinsics.popcount32(self)
   end
 
+  def dump_suffix : String
+    ""
+  end
+
   def clone
     self
   end
@@ -721,6 +714,10 @@ struct Int64
 
   def popcount
     Intrinsics.popcount64(self)
+  end
+
+  def dump_suffix : String
+    "_i64"
   end
 
   def clone
@@ -752,6 +749,10 @@ struct Int128
     Intrinsics.popcount128(self)
   end
 
+  def dump_suffix : String
+    "_i128"
+  end
+
   def clone
     self
   end
@@ -777,6 +778,10 @@ struct UInt8
 
   def popcount
     Intrinsics.popcount8(self)
+  end
+
+  def dump_suffix : String
+    "_u8"
   end
 
   def clone
@@ -806,6 +811,10 @@ struct UInt16
     Intrinsics.popcount16(self)
   end
 
+  def dump_suffix : String
+    "_u16"
+  end
+
   def clone
     self
   end
@@ -831,6 +840,10 @@ struct UInt32
 
   def popcount
     Intrinsics.popcount32(self)
+  end
+
+  def dump_suffix : String
+    "_u32"
   end
 
   def clone
@@ -860,6 +873,10 @@ struct UInt64
     Intrinsics.popcount64(self)
   end
 
+  def dump_suffix : String
+    "_u64"
+  end
+
   def clone
     self
   end
@@ -886,6 +903,10 @@ struct UInt128
 
   def popcount
     Intrinsics.popcount128(self)
+  end
+
+  def dump_suffix : String
+    "_u128"
   end
 
   def clone

--- a/src/number.cr
+++ b/src/number.cr
@@ -268,6 +268,35 @@ struct Number
     self == 0
   end
 
+  # Returns a string representation of this number including a suffix
+  # that shows it's type. The suffix is not shown for `Int32` and `Float64`
+  # because they are the default integer and float types respectively, in Crystal.
+  #
+  # ```
+  # 1.dump     # => "1"
+  # 1_i64.dump # => "1_i64"
+  # 1_u8.dump  # => "1_u8"
+  # ```
+  def dump : String
+    String.build do |io|
+      dump(io)
+    end
+  end
+
+  # Appends a string representation of this number including a suffix
+  # that shows it's type. The suffix is not shown for `Int32` and `Float64`
+  # because they are the default integer and float types respectively, in Crystal.
+  #
+  # See `#dump`.
+  def dump(io : IO)
+    to_s(io)
+    io << dump_suffix
+  end
+
+  # Returns the suffix used for `#dump`.
+  # Can return an empty string if there's no suffix.
+  abstract def dump_suffix : String
+
   private class StepIterator(T, L, B)
     include Iterator(T)
 


### PR DESCRIPTION
Fixes #6196

I added `dump` because many seem to want it. I'll personally never use it (we can use `typeof`) so if there isn't a strong reason to want it we can remove it.