### PR TITLE
Number: let `inspect` not show the type suffix

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -394,4 +394,8 @@ describe BigDecimal do
     negative_one.normalize_quotient(negative_one, positive_ten).should eq(positive_ten)
     negative_one.normalize_quotient(negative_one, negative_ten).should eq(negative_ten)
   end
+
+  describe "#inspect" do
+    it { "123".to_big_d.inspect.should eq("123") }
+  end
 end

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -188,7 +188,7 @@ describe "BigFloat" do
   end
 
   describe "#inspect" do
-    it { "2.3".to_big_f.inspect.should eq("2.3_big_f") }
+    it { "2.3".to_big_f.inspect.should eq("2.3") }
   end
 
   it "#hash" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -260,7 +260,7 @@ describe "BigInt" do
   end
 
   describe "#inspect" do
-    it { "2".to_big_i.inspect.should eq("2_big_i") }
+    it { "2".to_big_i.inspect.should eq("2") }
   end
 
   it "does gcd and lcm" do

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -192,6 +192,10 @@ describe BigRational do
     x = br(10, 3)
     x.clone.should eq(x)
   end
+
+  describe "#inspect" do
+    it { 123.to_big_r.inspect.should eq("123") }
+  end
 end
 
 describe "BigRational Math" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -210,7 +210,7 @@ describe "Float" do
     end
 
     it "does inspect for f32" do
-      3.2_f32.inspect.should eq("3.2_f32")
+      3.2_f32.inspect.should eq("3.2")
     end
 
     it "does inspect for f64 with IO" do
@@ -220,7 +220,7 @@ describe "Float" do
 
     it "does inspect for f32" do
       str = String.build { |io| 3.2_f32.inspect(io) }
-      str.should eq("3.2_f32")
+      str.should eq("3.2")
     end
   end
 

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -221,23 +221,23 @@ describe "Int" do
   end
 
   describe "#inspect" do
-    it "appends the type" do
+    it "doesn't append the type" do
       23.inspect.should eq("23")
-      23_i8.inspect.should eq("23_i8")
-      23_i16.inspect.should eq("23_i16")
-      -23_i64.inspect.should eq("-23_i64")
-      23_u8.inspect.should eq("23_u8")
-      23_u16.inspect.should eq("23_u16")
-      23_u32.inspect.should eq("23_u32")
-      23_u64.inspect.should eq("23_u64")
+      23_i8.inspect.should eq("23")
+      23_i16.inspect.should eq("23")
+      -23_i64.inspect.should eq("-23")
+      23_u8.inspect.should eq("23")
+      23_u16.inspect.should eq("23")
+      23_u32.inspect.should eq("23")
+      23_u64.inspect.should eq("23")
     end
 
-    it "appends the type using IO" do
+    it "doesn't append the type using IO" do
       str = String.build { |io| 23.inspect(io) }
       str.should eq("23")
 
       str = String.build { |io| -23_i64.inspect(io) }
-      str.should eq("-23_i64")
+      str.should eq("-23")
     end
   end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -298,11 +298,6 @@ struct BigDecimal < Number
     end
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_big_d"
-  end
-
   def to_big_d
     self
   end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -272,11 +272,6 @@ struct BigFloat < Float
     mpf
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_big_f"
-  end
-
   def to_s(io : IO)
     cstr = LibGMP.mpf_get_str(nil, out expptr, 10, 0, self)
     length = LibC.strlen(cstr)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -344,11 +344,6 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
-  def inspect(io)
-    to_s io
-    io << "_big_i"
-  end
-
   # TODO: improve this
   def_hash to_u64
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -186,11 +186,6 @@ struct Float32
     Printer.print(self, io)
   end
 
-  def inspect(io)
-    to_s(io)
-    io << "_f32"
-  end
-
   def clone
     self
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -514,25 +514,6 @@ struct Int
     yield ptr, count
   end
 
-  def inspect(io)
-    type = case self
-           when Int8    then "_i8"
-           when Int16   then "_i16"
-           when Int32   then ""
-           when Int64   then "_i64"
-           when Int128  then "_i128"
-           when UInt8   then "_u8"
-           when UInt16  then "_u16"
-           when UInt32  then "_u32"
-           when UInt64  then "_u64"
-           when UInt128 then "_u128"
-           else              raise "BUG: impossible"
-           end
-
-    to_s(io)
-    io << type
-  end
-
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.

--- a/src/object.cr
+++ b/src/object.cr
@@ -104,10 +104,38 @@ class Object
   # as this will in turn call `to_s(io)` on it.
   abstract def to_s(io : IO)
 
-  # Returns a `String` representation of this object.
+  # Returns a `String` representation of this object suitable
+  # to be embedded inside other expressions, sometimes providing
+  # more information about this object.
   #
-  # Similar to `to_s`, but usually returns more information about
-  # this object.
+  # `#inspect` (and `#inspect(io)`) are the methods used when
+  # you invoke `#to_s` or `#inspect` on an object that holds
+  # other objects and wants to show them. For example when you
+  # invoke `Array#to_s`, `#inspect` will be invoked on each element:
+  #
+  # ```
+  # ary = ["one", "two", "three, etc."]
+  # ary.inspect # => ["one", "two", "three, etc."]
+  # ```
+  #
+  # Note that if Array invoked `#to_s` on each of the elements
+  # above, the output would have been this:
+  #
+  # ```
+  # ary = ["one", "two", "three, etc."]
+  # # If inspect invoked to_s on each element...
+  # ary.inspect # => [one, two, three, etc.]
+  # ```
+  #
+  # Note that it's not clear how many elements the array has,
+  # or which are they, because `#to_s` doesn't guarantee that
+  # the string representation is clearly delimited (in the case
+  # of `String` the quotes are not shown).
+  #
+  # Also note that sometimes the output of `#inspect` will look
+  # like a Crystal expression that will compile, but this isn't
+  # always the case, nor is it necessary. Notably, `Reference#inspect`
+  # and `Struct#inspect` return values that don't compile.
   #
   # Classes must usually **not** override this method. Instead,
   # they must override `inspect(io)`, which must append to the
@@ -121,8 +149,7 @@ class Object
   # Appends a string representation of this object
   # to the given `IO` object.
   #
-  # Similar to `to_s(io)`, but usually appends more information
-  # about this object.
+  # See `#inspect`.
   def inspect(io : IO)
     to_s io
   end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -56,6 +56,18 @@ class Reference
     hasher.reference(self)
   end
 
+  # Appends a String representation of this object
+  # which includes its class name, its object address
+  # and the values of all instance variables.
+  #
+  # ```
+  # class Person
+  #   def initialize(@name : String, @age : Int32)
+  #   end
+  # end
+  #
+  # Person.new("John", 32).inspect # => #<Person:0x10fd31f20 @name="John", @age=32>
+  # ```
   def inspect(io : IO) : Nil
     io << "#<" << {{@type.name.id.stringify}} << ":0x"
     object_id.to_s(16, io)
@@ -105,6 +117,17 @@ class Reference
     {% end %}
   end
 
+  # Appends a short String representation of this object
+  # which includes its class name and its object address.
+  #
+  # ```
+  # class Person
+  #   def initialize(@name : String, @age : Int32)
+  #   end
+  # end
+  #
+  # Person.new("John", 32).to_s # => #<Person:0x10a199f20>
+  # ```
   def to_s(io : IO) : Nil
     io << "#<" << self.class.name << ":0x"
     object_id.to_s(16, io)


### PR DESCRIPTION
Fixes #6196 

Also clarifies the difference between `to_s` and `inspect`.

I'll repeat it here: the idea of `inspect` is to give a string representation that's **clearly delimited** and so it's suitable to be embedded inside other expressions. That's why `Array#to_s` invokes `inspect` on each element, because in the case of for example `String`, `to_s` doesn't show the quotes but `inspect` does. `inspect` has **nothing to do** with showing something that resembles a Crystal expression, or something that shows types.

If many of you want a way to make it easier to know the types of an object tree then maybe you can open an issue to discuss it. For example the method could check the constructors of an object to maybe create expressions that recreate an object, thought this isn't always possible... but it's an idea. And it probably belongs in a shard (in my opinion).

Finally, my opinion expressed [here](https://github.com/crystal-lang/crystal/pull/7518#issuecomment-470673749) about me not wanting to continue developing or using Crystal is not a threat, it's just how I feel: why would I use a language that I started which I find ugly and verbose in its output and which doesn't show the clean and beautiful output of Ruby? This is just something I feel super strong about, that's all.