### PR TITLE
Compiler: merge procs with the same arguments type and Nil | T return type to Nil return type

### DIFF
--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -880,4 +880,30 @@ describe "Semantic: proc" do
       Foo.new.x
       )) { proc_of(int32) }
   end
+
+  it "merges Proc that returns Nil with another one that returns something else (#3655)" do
+    assert_type(%(
+      a = ->(x : Int32) { 1 }
+      b = ->(x : Int32) { nil }
+      a || b
+      )) { proc_of(int32, nil_type) }
+  end
+
+  it "can assign proc that returns anything to proc that returns nil (#3655)" do
+    assert_type(%(
+      class Foo
+        @block : -> Nil
+
+        def initialize
+          @block = ->{ 1 }
+        end
+
+        def block
+          @block
+        end
+      end
+
+      Foo.new.block
+      )) { proc_of(nil_type) }
+  end
 end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -271,12 +271,24 @@ module Crystal
 
   class ProcInstanceType
     def common_ancestor(other : ProcInstanceType)
+      # For Proc(..., NoReturn), Proc(..., T) we keep Proc(..., T)
       if return_type.no_return? && arg_types == other.arg_types
         return other
       end
 
+      # Same but the other way around
       if other.return_type.no_return? && arg_types == other.arg_types
         return self
+      end
+
+      # For Proc(..., Nil), Proc(..., T) we keep Proc(..., Nil)
+      if return_type.nil_type? && arg_types == other.arg_types
+        return self
+      end
+
+      # Same but the other way around
+      if other.return_type.nil_type? && arg_types == other.arg_types
+        return other
       end
 
       nil

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2213,7 +2213,10 @@ module Crystal
 
     def implements?(other : Type)
       if other.is_a?(ProcInstanceType)
-        if (self.return_type.no_return? || other.return_type.void?) &&
+        # - Proc(..., NoReturn) can be cast to Proc(..., T)
+        # - Anything can be cast to Proc(..., Void)
+        # - Anything can be cast to Proc(..., Nil)
+        if (self.return_type.no_return? || other.return_type.void? || other.return_type.nil_type?) &&
            arg_types == other.arg_types
           return true
         end


### PR DESCRIPTION
Fixes #3655

The idea here is that a proc that returns any type `T` is compatible with a proc with the same argument types that returns `Nil`. The union type of those things is just the type of the proc that returns `Nil`, as in "in the general case we don't know anything about the value being returned".

This is a rule that's currently being applied in a few places, this fixes the language to apply it in more (all?) places.