### PR TITLE
Update `to_s` and `inspect` to have similar signatures accross the stdlib

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -857,7 +857,7 @@ class Array(T)
   end
 
   # :nodoc:
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     to_s io
   end
 
@@ -1725,7 +1725,7 @@ class Array(T)
     self
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     executed = exec_recursive(:to_s) do
       io << '['
       join ", ", io, &.inspect(io)

--- a/src/benchmark/bm.cr
+++ b/src/benchmark/bm.cr
@@ -30,7 +30,7 @@ module Benchmark
       end
 
       # Prints *utime*, *stime*, *total* and *real* to the given IO.
-      def to_s(io : IO)
+      def to_s(io : IO) : Nil
         io.printf "  %.6f   %.6f   %.6f (  %.6f)", utime, stime, total, real
       end
     end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -298,11 +298,6 @@ struct BigDecimal < Number
     end
   end
 
-  def inspect(io : IO) : Nil
-    to_s(io)
-    io << "_big_d"
-  end
-
   def to_big_d
     self
   end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -271,7 +271,7 @@ struct BigDecimal < Number
     end
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     factor_powers_of_ten
 
     s = @value.to_s
@@ -298,7 +298,7 @@ struct BigDecimal < Number
     end
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
     io << "_big_d"
   end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -272,12 +272,12 @@ struct BigFloat < Float
     mpf
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
     io << "_big_f"
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     cstr = LibGMP.mpf_get_str(nil, out expptr, 10, 0, self)
     length = LibC.strlen(cstr)
     io << '-' if self < 0

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -272,11 +272,6 @@ struct BigFloat < Float
     mpf
   end
 
-  def inspect(io : IO) : Nil
-    to_s(io)
-    io << "_big_f"
-  end
-
   def to_s(io : IO) : Nil
     cstr = LibGMP.mpf_get_str(nil, out expptr, 10, 0, self)
     length = LibC.strlen(cstr)

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -344,11 +344,6 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
-  def inspect(io : IO) : Nil
-    to_s io
-    io << "_big_i"
-  end
-
   # TODO: improve this
   def_hash to_u64
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -344,7 +344,7 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s io
     io << "_big_i"
   end
@@ -357,12 +357,12 @@ struct BigInt < Int
   # ```
   # BigInt.new("123456789101101987654321").to_s # => 123456789101101987654321
   # ```
-  def to_s
+  def to_s : String
     String.new(to_cstr)
   end
 
   # ditto
-  def to_s(io)
+  def to_s(io : IO) : Nil
     str = to_cstr
     io.write_utf8 Slice.new(str, LibC.strlen(str))
   end
@@ -374,7 +374,7 @@ struct BigInt < Int
   # BigInt.new("123456789101101987654321").to_s(16) # => "1a249b1f61599cd7eab1"
   # BigInt.new("123456789101101987654321").to_s(36) # => "k3qmt029k48nmpd"
   # ```
-  def to_s(base : Int)
+  def to_s(base : Int) : String
     raise "Invalid base #{base}" unless 2 <= base <= 36
     cstr = LibGMP.get_str(nil, base, self)
     String.new(cstr)

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -203,20 +203,20 @@ struct BigRational < Number
   # r.to_s(16) # => "7dc82b/218c1652"
   # r.to_s(36) # => "4woiz/9b3djm"
   # ```
-  def to_s(base = 10)
+  def to_s(base = 10) : String
     String.new(to_cstr(base))
   end
 
-  def to_s(io : IO, base = 10)
+  def to_s(io : IO, base = 10) : Nil
     str = to_cstr(base)
     io.write_utf8 Slice.new(str, LibC.strlen(str))
   end
 
-  def inspect
+  def inspect : String
     to_s
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s io
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -203,7 +203,7 @@ struct BigRational < Number
   # r.to_s(16) # => "7dc82b/218c1652"
   # r.to_s(36) # => "4woiz/9b3djm"
   # ```
-  def to_s(base = 10) : String
+  def to_s(base : Int = 10) : String
     String.new(to_cstr(base))
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -207,7 +207,7 @@ struct BigRational < Number
     String.new(to_cstr(base))
   end
 
-  def to_s(io : IO, base = 10) : Nil
+  def to_s(io : IO, base : Int = 10) : Nil
     str = to_cstr(base)
     io.write_utf8 Slice.new(str, LibC.strlen(str))
   end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -206,7 +206,7 @@ struct BitArray
   # ba = BitArray.new(5)
   # ba.to_s # => "BitArray[00000]"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << "BitArray["
     each do |value|
       io << (value ? '1' : '0')
@@ -215,7 +215,7 @@ struct BitArray
   end
 
   # ditto
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -54,12 +54,12 @@ struct Bool
   end
 
   # Returns `"true"` for `true` and `"false"` for `false`.
-  def to_s
+  def to_s : String
     self ? "true" : "false"
   end
 
   # Appends `"true"` for `true` and `"false"` for `false` to the given IO.
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << to_s
   end
 

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -49,7 +49,7 @@ abstract class Channel(T)
     receive_impl { return nil }
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -471,7 +471,7 @@ struct Char
   # 'あ'.inspect      # => "'あ'"
   # '\u0012'.inspect # => "'\\u{12}'"
   # ```
-  def inspect
+  def inspect : String
     dump_or_inspect do |io|
       if ascii_control?
         io << "\\u{"
@@ -486,7 +486,7 @@ struct Char
   # Appends this char as a string that contains a char literal to the given `IO`.
   #
   # See also: `#inspect`.
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << inspect
   end
 
@@ -751,7 +751,7 @@ struct Char
   # 'a'.to_s # => "a"
   # 'あ'.to_s # => "あ"
   # ```
-  def to_s
+  def to_s : String
     String.new(4) do |buffer|
       appender = buffer.appender
       each_byte { |byte| appender << byte }
@@ -762,7 +762,7 @@ struct Char
   # Appends this char to the given `IO`.
   #
   # This appends this char's bytes as encoded by UTF-8 to the given `IO`.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     if ascii?
       byte = ord.to_u8
 

--- a/src/class.cr
+++ b/src/class.cr
@@ -1,5 +1,5 @@
 class Class
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 
@@ -145,7 +145,7 @@ class Class
     self == ::Nil
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << {{ @type.name.stringify }}
   end
 

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -298,13 +298,13 @@ struct Colorize::Object(T)
     self
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     surround(io) do
       io << @object
     end
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     surround(io) do
       @object.inspect(io)
     end

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -129,7 +129,7 @@ class Crystal::Codegen::Target
     target.create_target_machine(self.to_s, cpu: cpu, features: features, opt_level: opt_level).not_nil!
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << architecture << '-' << vendor << '-' << environment
   end
 end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -7,7 +7,7 @@ module Crystal
 
     @filename : String | VirtualFile | Nil
 
-    def to_s(io)
+    def to_s(io) : Nil
       to_s_with_source(nil, io)
     end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -551,7 +551,7 @@ module Crystal
       node.raise "can't execute #{node.class_desc} in a macro"
     end
 
-    def to_s
+    def to_s : String
       @str.to_s
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -579,7 +579,7 @@ module Crystal
       file_module(filename)
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << "<Program>"
     end
   end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -462,7 +462,7 @@ module Crystal
       self
     end
 
-    def inspect(io)
+    def inspect(io : IO) : Nil
       io << name
       if type = type?
         io << " : "

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -18,7 +18,7 @@ module Crystal
       TypeFilteredNode.new(@filter, @node)
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       @filter.to_s(io)
     end
   end
@@ -65,7 +65,7 @@ module Crystal
       @type == other.type
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << "F("
       @type.to_s(io)
       io << ')'
@@ -87,7 +87,7 @@ module Crystal
       @filter1 == other.@filter1 && @filter2 == other.@filter2
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << '(' << @filter1 << " && " << @filter2 << ')'
     end
   end
@@ -111,7 +111,7 @@ module Crystal
       @filter1 == other.@filter1 && @filter2 == other.@filter2
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << '(' << @filter1 << " || " << @filter2 << ')'
     end
   end
@@ -140,7 +140,7 @@ module Crystal
       true
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << "truthy"
     end
   end
@@ -202,7 +202,7 @@ module Crystal
       @filter == other.filter
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << '!'
       @filter.to_s(io)
     end
@@ -216,7 +216,7 @@ module Crystal
       other.try &.filter_by_responds_to(@name)
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << "responds_to?(" << @name << ')'
     end
   end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -40,11 +40,11 @@ class Crystal::Location
     min <= self && self <= max
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << filename << ':' << line_number << ':' << column_number
   end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -3,11 +3,11 @@ require "./visitor"
 
 module Crystal
   class ASTNode
-    def inspect(io)
+    def inspect(io : IO) : Nil
       to_s(io)
     end
 
-    def to_s(io, macro_expansion_pragmas = nil, emit_doc = false)
+    def to_s(io : IO, macro_expansion_pragmas = nil, emit_doc = false) : Nil
       visitor = ToSVisitor.new(io, macro_expansion_pragmas: macro_expansion_pragmas, emit_doc: emit_doc)
       self.accept visitor
     end
@@ -1558,11 +1558,11 @@ module Crystal
       @inside_macro = old_inside_macro
     end
 
-    def to_s
+    def to_s : String
       @str.to_s
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       @str.to_s(io)
     end
   end

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -115,7 +115,7 @@ module Crystal
       @doc_buffer = other.doc_buffer
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       @value ? @value.to_s(io) : @type.to_s(io)
     end
   end

--- a/src/compiler/crystal/syntax/virtual_file.cr
+++ b/src/compiler/crystal/syntax/virtual_file.cr
@@ -15,11 +15,11 @@ class Crystal::VirtualFile
   def initialize(@macro : Macro, @source : String, @expanded_location : Location?)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "expanded macro: " << @macro.name
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -54,7 +54,7 @@ class Crystal::Doc::Macro
     "macro "
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << name
     args_to_s io
   end
@@ -63,7 +63,7 @@ class Crystal::Doc::Macro
     String.build { |io| args_to_s io }
   end
 
-  def args_to_s(io)
+  def args_to_s(io : IO) : Nil
     return unless has_args?
 
     printed = false
@@ -92,7 +92,7 @@ class Crystal::Doc::Macro
     io << ')'
   end
 
-  def arg_to_s(arg : Arg, io)
+  def arg_to_s(arg : Arg, io : IO) : Nil
     if arg.external_name != arg.name
       name = arg.external_name.empty? ? "_" : arg.external_name
       if Symbol.needs_quotes? name

--- a/src/compiler/crystal/tools/doc/main.cr
+++ b/src/compiler/crystal/tools/doc/main.cr
@@ -1,6 +1,6 @@
 module Crystal::Doc
   record Main, body : String, program : Type, repository_name : String do
-    def to_s(io : IO)
+    def to_s(io : IO) : Nil
       to_json(io)
     end
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -105,7 +105,7 @@ class Crystal::Doc::Method
     "#" + URI.escape(id)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << name
     args_to_s io
   end
@@ -114,7 +114,7 @@ class Crystal::Doc::Method
     String.build { |io| args_to_s io }
   end
 
-  def args_to_s(io)
+  def args_to_s(io : IO) : Nil
     args_to_html(io, links: false)
   end
 
@@ -122,7 +122,7 @@ class Crystal::Doc::Method
     String.build { |io| args_to_html io }
   end
 
-  def args_to_html(io, links = true)
+  def args_to_html(io : IO, links = true) : Nil
     return_type = self.return_type
 
     return unless has_args? || return_type

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -122,7 +122,7 @@ class Crystal::Doc::Method
     String.build { |io| args_to_html io }
   end
 
-  def args_to_html(io : IO, links = true) : Nil
+  def args_to_html(io : IO, links : Bool = true) : Nil
     return_type = self.return_type
 
     return unless has_args? || return_type

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -461,12 +461,12 @@ class Crystal::Doc::Type
     @generator.macro(self, a_macro)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << name
     append_type_vars io
   end
 
-  private def append_type_vars(io)
+  private def append_type_vars(io : IO) : Nil
     type = @type
     if type_vars = type_vars()
       io << '('

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4135,7 +4135,7 @@ module Crystal
       raise "BUG: unexpected node: #{node.class} at #{node.location}"
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << @output
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -255,7 +255,7 @@ module Crystal::Playground
       end
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       body = content
       # avoid the layout if the file is a full html
       if File.extname(@filename).starts_with?(".htm") && content.starts_with?("<!")
@@ -309,7 +309,7 @@ module Crystal::Playground
       Dir["playground/*.{md,html,cr}"]
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       render_with_layout(io) do
         ECR.embed "#{__DIR__}/views/_workbook.html.ecr", io
         nil

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1689,7 +1689,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << '*' << @splatted_type
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1411,7 +1411,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << @literal.type
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3267,7 +3267,7 @@ module Crystal
       base_type.implements?(other.base_type)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1660,7 +1660,7 @@ module Crystal
       true
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << @name
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2835,7 +2835,7 @@ module Crystal
       instance_type.class_var_owner
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s(io)
       io << ".class"
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1919,7 +1919,7 @@ module Crystal
       false
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       generic_type.append_full_name(io)
       io << '('
       type_vars.each_value.with_index do |type_var, i|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2752,7 +2752,7 @@ module Crystal
       instance_type.replace_type_parameters(instance).metaclass
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << @name
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3201,7 +3201,7 @@ module Crystal
       base_type.replace_type_parameters(instance).virtual_type
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       base_type.to_s(io)
       io << '+'
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2337,7 +2337,7 @@ module Crystal
       tuple_types.any? &.unbound?
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "Tuple("
       @tuple_types.join(", ", io) do |tuple_type|
         tuple_type = tuple_type.devirtualize unless codegen

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2804,7 +2804,7 @@ module Crystal
       end
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s(io)
       io << ".class"
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1732,7 +1732,7 @@ module Crystal
       add_instance_var_initializer @including_types, name, value, meta_vars
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       super
       if generic_args
         io << '('

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -684,15 +684,15 @@ module Crystal
       nil
     end
 
-    def inspect(io)
+    def inspect(io : IO) : Nil
       to_s(io)
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       to_s_with_options(io)
     end
 
-    abstract def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    abstract def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
 
     def pretty_print(pp)
       pp.text to_s
@@ -727,7 +727,7 @@ module Crystal
       @types
     end
 
-    def append_full_name(io, codegen = false)
+    def append_full_name(io : IO, codegen = false) : Nil
       case namespace
       when Program
         # Skip
@@ -749,7 +749,7 @@ module Crystal
       String.build { |io| append_full_name(io) }
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       append_full_name(io, codegen: codegen)
     end
   end
@@ -1396,7 +1396,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << @literal.type
     end
   end
@@ -1411,7 +1411,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << @literal.type
     end
   end
@@ -1660,7 +1660,7 @@ module Crystal
       true
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << @name
     end
   end
@@ -1689,7 +1689,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << '*' << @splatted_type
     end
   end
@@ -1732,7 +1732,7 @@ module Crystal
       add_instance_var_initializer @including_types, name, value, meta_vars
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       super
       if generic_args
         io << '('
@@ -1792,7 +1792,7 @@ module Crystal
       end
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       super
       if generic_args
         io << '('
@@ -1919,7 +1919,7 @@ module Crystal
       false
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       generic_type.append_full_name(io)
       io << '('
       type_vars.each_value.with_index do |type_var, i|
@@ -2221,7 +2221,7 @@ module Crystal
       super
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << "Proc("
       arg_types.each do |type|
         type = type.devirtualize unless codegen
@@ -2334,7 +2334,7 @@ module Crystal
       tuple_types.any? &.unbound?
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << "Tuple("
       @tuple_types.join(", ", io) do |tuple_type|
         tuple_type = tuple_type.devirtualize unless codegen
@@ -2451,7 +2451,7 @@ module Crystal
       entries.any? { |entry| entry.type.includes_type?(type) || entry.type.has_in_type_vars?(type) }
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << "NamedTuple("
       @entries.join(", ", io) do |entry|
         if Symbol.needs_quotes?(entry.name)
@@ -2749,7 +2749,7 @@ module Crystal
       instance_type.replace_type_parameters(instance).metaclass
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << @name
     end
   end
@@ -2801,7 +2801,7 @@ module Crystal
       end
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       instance_type.to_s(io)
       io << ".class"
     end
@@ -2832,7 +2832,7 @@ module Crystal
       instance_type.class_var_owner
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       instance_type.to_s(io)
       io << ".class"
     end
@@ -2969,7 +2969,7 @@ module Crystal
       program.type_merge(new_union_types) || program.no_return
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       io << '(' unless skip_union_parens
       union_types = @union_types
       # Make sure to put Nil at the end
@@ -3198,7 +3198,7 @@ module Crystal
       base_type.replace_type_parameters(instance).virtual_type
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       base_type.to_s(io)
       io << '+'
     end
@@ -3264,7 +3264,7 @@ module Crystal
       base_type.implements?(other.base_type)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false)
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
       instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2224,7 +2224,7 @@ module Crystal
       super
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "Proc("
       arg_types.each do |type|
         type = type.devirtualize unless codegen

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1396,7 +1396,7 @@ module Crystal
       super(program)
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << @literal.type
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -692,7 +692,7 @@ module Crystal
       to_s_with_options(io)
     end
 
-    abstract def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    abstract def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
 
     def pretty_print(pp)
       pp.text to_s

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1792,7 +1792,7 @@ module Crystal
       end
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       super
       if generic_args
         io << '('

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -749,7 +749,7 @@ module Crystal
       String.build { |io| append_full_name(io) }
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       append_full_name(io, codegen: codegen)
     end
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -727,7 +727,7 @@ module Crystal
       @types
     end
 
-    def append_full_name(io : IO, codegen = false) : Nil
+    def append_full_name(io : IO, codegen : Bool = false) : Nil
       case namespace
       when Program
         # Skip

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2972,7 +2972,7 @@ module Crystal
       program.type_merge(new_union_types) || program.no_return
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << '(' unless skip_union_parens
       union_types = @union_types
       # Make sure to put Nil at the end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2454,7 +2454,7 @@ module Crystal
       entries.any? { |entry| entry.type.includes_type?(type) || entry.type.has_in_type_vars?(type) }
     end
 
-    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen = false) : Nil
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "NamedTuple("
       @entries.join(", ", io) do |entry|
         if Symbol.needs_quotes?(entry.name)

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -86,7 +86,7 @@ struct Complex
   # ```
   # Complex.new(42, 2).to_s # => "42.0 + 2.0i"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << @real
     io << (@imag >= 0 ? " + " : " - ")
     io << @imag.abs
@@ -98,7 +98,7 @@ struct Complex
   # ```
   # Complex.new(42, 2).inspect # => "(42.0 + 2.0i)"
   # ```
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << '('
     to_s(io)
     io << ')'

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -87,11 +87,11 @@ class Crypto::Bcrypt
     end
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << to_s
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -63,11 +63,11 @@ class Crypto::Bcrypt::Password
     Crypto::Subtle.constant_time_compare(@raw_hash, hashed_password)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << @raw_hash
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 end

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -289,8 +289,7 @@ struct Crystal::Hasher
     value.crystal_type_id.hash(self)
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "#{self.class}(hidden_state)"
-    nil
   end
 end

--- a/src/debug/mach_o.cr
+++ b/src/debug/mach_o.cr
@@ -204,7 +204,7 @@ module Debug
         bytes == other.bytes
       end
 
-      def inspect(io)
+      def inspect(io : IO) : Nil
         io << bytes.to_slice.hexstring
       end
     end
@@ -309,7 +309,7 @@ module Debug
           Stab.new(value) if stab?
         end
 
-        def to_s(io)
+        def to_s(io : IO) : Nil
           if stab?
             io << "STAB(#{stab})"
             return
@@ -335,7 +335,7 @@ module Debug
           io << n.join('|')
         end
 
-        def inspect(io)
+        def inspect(io : IO) : Nil
           to_s(io)
         end
       end
@@ -357,7 +357,7 @@ module Debug
         type.stab
       end
 
-      def inspect(io)
+      def inspect(io : IO) : Nil
         io << "#{self.class.name}(type=#{type}, name=#{name.inspect}, sect=#{sect}, desc=#{desc}, value=#{value})"
       end
     end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -330,7 +330,7 @@ class Deque(T)
     self
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     executed = exec_recursive(:inspect) do
       io << "Deque{"
       join ", ", io, &.inspect(io)
@@ -483,7 +483,7 @@ class Deque(T)
     self
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     inspect(io)
   end
 

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -266,11 +266,11 @@ class Dir
     Crystal::System::Dir.delete(path)
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "#<Dir:" << @path << '>'
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/ecr/macros.cr
+++ b/src/ecr/macros.cr
@@ -33,7 +33,7 @@ module ECR
   # end
   # ```
   macro def_to_s(filename)
-    def to_s(__io__)
+    def to_s(__io__ : IO) : Nil
       ECR.embed {{filename}}, "__io__"
     end
   end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -39,21 +39,21 @@ class Exception
     {% end %}
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << message
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << "#<" << self.class.name << ':' << message << '>'
   end
 
-  def inspect_with_backtrace
+  def inspect_with_backtrace : String
     String.build do |io|
       inspect_with_backtrace io
     end
   end
 
-  def inspect_with_backtrace(io : IO)
+  def inspect_with_backtrace(io : IO) : Nil
     io << message << " (" << self.class << ")\n"
     backtrace?.try &.each do |frame|
       io.print "  from "

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -133,7 +133,7 @@ class Fiber
     Crystal::Scheduler.yield
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "#<" << self.class.name << ":0x"
     object_id.to_s(16, io)
     if name = @name
@@ -142,7 +142,7 @@ class Fiber
     io << '>'
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -897,11 +897,10 @@ class File < IO::FileDescriptor
     yield io ensure io.close
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "#<File:" << @path
     io << " (closed)" if closed?
     io << '>'
-    io
   end
 
   # TODO: use fcntl/lockf instead of flock (which doesn't lock over NFS)

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -58,7 +58,7 @@ class File
       new(int.to_i16)
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << (owner_read? ? 'r' : '-')
       io << (owner_write? ? 'w' : '-')
       io << (owner_execute? ? 'x' : '-')

--- a/src/flate/reader.cr
+++ b/src/flate/reader.cr
@@ -149,7 +149,7 @@ class Flate::Reader < IO
   end
 
   # :nodoc:
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 end

--- a/src/flate/writer.cr
+++ b/src/flate/writer.cr
@@ -81,7 +81,7 @@ class Flate::Writer < IO
   end
 
   # :nodoc:
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -186,11 +186,6 @@ struct Float32
     Printer.print(self, io)
   end
 
-  def inspect(io : IO) : Nil
-    to_s(io)
-    io << "_f32"
-  end
-
   def clone
     self
   end

--- a/src/float.cr
+++ b/src/float.cr
@@ -176,17 +176,17 @@ struct Float32
     self ** other.to_f32
   end
 
-  def to_s
+  def to_s : String
     String.build(22) do |buffer|
       Printer.print(self, buffer)
     end
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     Printer.print(self, io)
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
     io << "_f32"
   end
@@ -265,13 +265,13 @@ struct Float64
     self ** other.to_f64
   end
 
-  def to_s
+  def to_s : String
     String.build(22) do |buffer|
       Printer.print(self, buffer)
     end
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     Printer.print(self, io)
   end
 

--- a/src/float/printer.cr
+++ b/src/float/printer.cr
@@ -13,7 +13,7 @@ module Float::Printer
   #
   # It is used by `Float64#to_s` and it is probably not necessary to use
   # this directly.
-  def print(v : Float64 | Float32, io : IO)
+  def print(v : Float64 | Float32, io : IO) : Nil
     d = IEEE.to_uint(v)
 
     if IEEE.sign(d) < 0

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -930,7 +930,7 @@ class Hash(K, V)
     hash
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 
@@ -941,7 +941,7 @@ class Hash(K, V)
   # h.to_s       # => "{\"foo\" => \"bar\"}"
   # h.to_s.class # => String
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     executed = exec_recursive(:to_s) do
       io << '{'
       found_one = false

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -210,7 +210,7 @@ struct HTTP::Headers
     object_id == other.object_id
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << "HTTP::Headers{"
     @hash.each_with_index do |(key, values), index|
       io << ", " if index > 0
@@ -225,7 +225,7 @@ struct HTTP::Headers
     io << '}'
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -300,7 +300,7 @@ module HTTP
     # params.to_s # => "item=keychain&item=keynote&email=john%40example.org"
     # ```
     # TODO: `to_s` should escape @ to %40 ?
-    def to_s(io)
+    def to_s(io : IO) : Nil
       builder = Builder.new(io)
       each do |name, value|
         builder.add(name, value)
@@ -339,7 +339,7 @@ module HTTP
         self
       end
 
-      def to_s(io)
+      def to_s(io : IO) : Nil
         io << @io.to_s
       end
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -445,15 +445,15 @@ struct Int
   private DIGITS_UPCASE   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   private DIGITS_BASE62   = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-  def to_s
+  def to_s : String
     to_s(10)
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     to_s(10, io)
   end
 
-  def to_s(base : Int, upcase : Bool = false)
+  def to_s(base : Int, upcase : Bool = false) : String
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
@@ -469,7 +469,7 @@ struct Int
     end
   end
 
-  def to_s(base : Int, io : IO, upcase : Bool = false)
+  def to_s(base : Int, io : IO, upcase : Bool = false) : Nil
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
@@ -514,7 +514,7 @@ struct Int
     yield ptr, count
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     type = case self
            when Int8    then "_i8"
            when Int16   then "_i16"

--- a/src/int.cr
+++ b/src/int.cr
@@ -514,25 +514,6 @@ struct Int
     yield ptr, count
   end
 
-  def inspect(io : IO) : Nil
-    type = case self
-           when Int8    then "_i8"
-           when Int16   then "_i16"
-           when Int32   then ""
-           when Int64   then "_i64"
-           when Int128  then "_i128"
-           when UInt8   then "_u8"
-           when UInt16  then "_u16"
-           when UInt32  then "_u32"
-           when UInt64  then "_u64"
-           when UInt128 then "_u128"
-           else              raise "BUG: impossible"
-           end
-
-    to_s(io)
-    io << type
-  end
-
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -153,7 +153,7 @@ class IO::FileDescriptor < IO
     other
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "#<IO::FileDescriptor:"
     if closed?
       io << "(closed)"
@@ -161,7 +161,6 @@ class IO::FileDescriptor < IO
       io << " fd=" << @fd
     end
     io << '>'
-    io
   end
 
   def pretty_print(pp)

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -397,7 +397,7 @@ class IO::Memory < IO
   # io.print 1, 2, 3
   # io.to_s # => "123"
   # ```
-  def to_s
+  def to_s : String
     String.new @buffer, @bytesize
   end
 
@@ -414,7 +414,7 @@ class IO::Memory < IO
   end
 
   # Appends this internal buffer to the given `IO`.
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io.write(to_slice)
   end
 

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -244,12 +244,12 @@ struct JSON::Any
   end
 
   # :nodoc:
-  def inspect(io)
+  def inspect(io : IO) : Nil
     @raw.inspect(io)
   end
 
   # :nodoc:
-  def to_s(io)
+  def to_s(io : IO) : Nil
     @raw.to_s(io)
   end
 

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -17,7 +17,7 @@ class JSON::Token
     @raw_value = ""
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     case @type
     when :INT
       @int_value.to_s(io)

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -101,7 +101,7 @@ class LLVM::Module
     @unwrap == other.@unwrap
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     LLVM.to_io(LibLLVM.print_module_to_string(self), io)
     self
   end

--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -41,7 +41,7 @@ struct LLVM::Target
     target_machine ? TargetMachine.new(target_machine) : raise "Couldn't create target machine"
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "LLVM::Target(name="
     name.inspect(io)
     io << ", description="
@@ -49,7 +49,7 @@ struct LLVM::Target
     io << ')'
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -162,7 +162,7 @@ struct LLVM::Type
     Context.new(LibLLVM.get_type_context(self), dispose_on_finalize: false)
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     LLVM.to_io(LibLLVM.print_type_to_string(self), io)
     self
   end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -103,7 +103,7 @@ module LLVM::ValueMethods
     LibLLVM.dump_value self
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     LLVM.to_io(LibLLVM.print_value_to_string(self), io)
     self
   end

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -14,7 +14,7 @@ module MIME
       end
     end
 
-    def to_s(io : IO)
+    def to_s(io : IO) : Nil
       io << media_type
 
       @params.each do |key, value|

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -245,7 +245,7 @@ struct NamedTuple
   end
 
   # Same as `to_s`.
-  def inspect
+  def inspect : String
     to_s
   end
 
@@ -319,7 +319,7 @@ struct NamedTuple
   # tuple = {name: "Crystal", year: 2011}
   # tuple.to_s # => %({name: "Crystal", year: 2011})
   # ```
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << '{'
     {% for key, value, i in T %}
       {% if i > 0 %}

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -73,22 +73,22 @@ struct Nil
   end
 
   # Returns an empty string.
-  def to_s
+  def to_s : String
     ""
   end
 
   # Doesn't write anything to the given `IO`.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     # Nothing to do
   end
 
   # Returns `"nil"`.
-  def inspect
+  def inspect : String
     "nil"
   end
 
   # Writes `"nil"` to the given `IO`.
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "nil"
   end
 

--- a/src/oauth/authorization_header.cr
+++ b/src/oauth/authorization_header.cr
@@ -17,11 +17,11 @@ struct OAuth::AuthorizationHeader
     @first = false
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     @str.to_s(io)
   end
 
-  def to_s
+  def to_s : String
     @str.to_s
   end
 end

--- a/src/oauth/params.cr
+++ b/src/oauth/params.cr
@@ -16,7 +16,7 @@ struct OAuth::Params
     end
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     @params.sort_by! &.[0]
     @params.each_with_index do |(key, value), i|
       io << "%26" if i > 0

--- a/src/object.cr
+++ b/src/object.cr
@@ -91,7 +91,7 @@ class Object
   # Descendants must usually **not** override this method. Instead,
   # they must override `to_s(io)`, which must append to the given
   # IO object.
-  def to_s
+  def to_s : String
     String.build do |io|
       to_s io
     end
@@ -102,7 +102,7 @@ class Object
   #
   # An object must never append itself to the io argument,
   # as this will in turn call `to_s(io)` on it.
-  abstract def to_s(io : IO)
+  abstract def to_s(io : IO) : Nil
 
   # Returns a `String` representation of this object.
   #
@@ -112,7 +112,7 @@ class Object
   # Classes must usually **not** override this method. Instead,
   # they must override `inspect(io)`, which must append to the
   # given `IO` object.
-  def inspect
+  def inspect : String
     String.build do |io|
       inspect io
     end
@@ -123,7 +123,7 @@ class Object
   #
   # Similar to `to_s(io)`, but usually appends more information
   # about this object.
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     to_s io
   end
 

--- a/src/openssl/digest/digest_base.cr
+++ b/src/openssl/digest/digest_base.cr
@@ -32,7 +32,7 @@ module OpenSSL
       digest.hexstring
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << hexdigest
     end
   end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -163,7 +163,7 @@ class OptionParser
   end
 
   # Returns all the setup options, formatted in a help message.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     if banner = @banner
       io << banner
       io << '\n'

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -318,7 +318,7 @@ struct Pointer(T)
   # ptr2 = Pointer(Int32).new(0)
   # ptr2.to_s # => "Pointer(Int32).null"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << "Pointer("
     io << T.to_s
     io << ')'

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -190,7 +190,7 @@ struct Proc
     self
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "#<"
     io << {{@type.name.stringify}}
     io << ":0x"

--- a/src/range.cr
+++ b/src/range.cr
@@ -295,14 +295,14 @@ struct Range(B, E)
   end
 
   # :nodoc:
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     @begin.try &.inspect(io)
     io << (@exclusive ? "..." : "..")
     @end.try &.inspect(io)
   end
 
   # :nodoc:
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -73,7 +73,6 @@ class Reference
       io << " ..."
     end
     io << '>'
-    nil
   end
 
   def pretty_print(pp) : Nil
@@ -109,7 +108,6 @@ class Reference
     io << "#<" << self.class.name << ":0x"
     object_id.to_s(16, io)
     io << '>'
-    nil
   end
 
   # :nodoc:

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -435,7 +435,7 @@ class Regex
   # ```
   # /ab+c/ix.inspect # => "/ab+c/ix"
   # ```
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << '/'
     Regex.append_source(source, io)
     io << '/'
@@ -532,7 +532,7 @@ class Regex
   # re = /A*/                  # => "(?-imsx:A*)"
   # "Crystal".match(/t#{re}l/) # => nil
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << "(?"
     io << 'i' if options.ignore_case?
     io << "ms" if options.multiline?

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -325,11 +325,11 @@ class Regex
       hash
     end
 
-    def inspect(io : IO)
+    def inspect(io : IO) : Nil
       to_s(io)
     end
 
-    def to_s(io : IO)
+    def to_s(io : IO) : Nil
       name_table = @regex.name_table
 
       io << "Regex::MatchData("

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -67,7 +67,7 @@ struct SemanticVersion
   # semver = SemanticVersion.parse("0.27.1")
   # semver.to_s # => "0.27.1"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << major << '.' << minor << '.' << patch
     unless prerelease.identifiers.empty?
       io << '-'
@@ -144,7 +144,7 @@ struct SemanticVersion
     # semver = SemanticVersion.parse("0.27.1-rc.1")
     # semver.prerelease.to_s # => "rc.1"
     # ```
-    def to_s(io : IO)
+    def to_s(io : IO) : Nil
       identifiers.join('.', io)
     end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -323,7 +323,7 @@ struct Set(T)
   end
 
   # Alias of `#to_s`.
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 
@@ -350,7 +350,7 @@ struct Set(T)
   end
 
   # Writes a string representation of the set to *io*.
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "Set{"
     join ", ", io, &.inspect(io)
     io << '}'

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -373,7 +373,7 @@ struct Slice(T)
     source.move_to(self)
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 
@@ -495,7 +495,7 @@ struct Slice(T)
     self
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     if T == UInt8
       io << "Bytes["
       # Inspect using to_s because we know this is a UInt8.

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -361,7 +361,7 @@ class Socket < IO
     end
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "#<#{self.class}:fd #{@fd}>"
   end
 

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -240,7 +240,7 @@ class Socket
         address == other.address
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       if family == Family::INET6
         io << '[' << address << ']' << ':' << port
       else
@@ -248,7 +248,7 @@ class Socket
       end
     end
 
-    def inspect(io)
+    def inspect(io : IO) : Nil
       io << "Socket::IPAddress("
       to_s(io)
       io << ")"
@@ -361,7 +361,7 @@ class Socket
       path == other.path
     end
 
-    def to_s(io)
+    def to_s(io : IO) : Nil
       io << path
     end
 

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -259,7 +259,7 @@ struct StaticArray(T, N)
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
   # array.to_s # => "StaticArray[1, 2, 3]"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << "StaticArray["
     join ", ", io, &.inspect(io)
     io << ']'

--- a/src/string.cr
+++ b/src/string.cr
@@ -4211,11 +4211,11 @@ class String
     self
   end
 
-  def to_s
+  def to_s : String
     self
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io.write_utf8(to_slice)
   end
 

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -97,7 +97,7 @@ class String::Builder < IO
     @bytesize -= amount
   end
 
-  def to_s
+  def to_s : String
     raise "Can only invoke 'to_s' once on String::Builder" if @finished
     @finished = true
 

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -268,7 +268,7 @@ class StringScanner
   #
   # Includes the current position of the offset, the total size of the string,
   # and five characters near the current position.
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << "#<StringScanner "
     offset = offset()
     io << offset << '/' << @str.size

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -106,7 +106,6 @@ struct Struct
       @{{ivar.id}}.inspect(io)
     {% end %}
     io << ')'
-    nil
   end
 
   def pretty_print(pp) : Nil
@@ -132,7 +131,7 @@ struct Struct
   end
 
   # Same as `#inspect(io)`.
-  def to_s(io)
+  def to_s(io : IO) : Nil
     inspect(io)
   end
 end

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -34,7 +34,7 @@ struct Symbol
   # ```
   # :crystal.inspect # => ":crystal"
   # ```
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << ':'
 
     value = to_s
@@ -50,7 +50,7 @@ struct Symbol
   # ```
   # :crystal.to_s # => "crystal"
   # ```
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << to_s
   end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -1031,7 +1031,7 @@ struct Time
   # When the location is `UTC`, the offset is omitted. Offset seconds are omitted if `0`.
   #
   # The name of the location is appended unless it is a fixed zone offset.
-  def inspect(io : IO, with_nanoseconds = true)
+  def inspect(io : IO, with_nanoseconds = true) : Nil
     to_s "%F %T", io
 
     if with_nanoseconds
@@ -1049,8 +1049,6 @@ struct Time
       zone.format(io)
       io << ' ' << location.name unless location.fixed?
     end
-
-    io
   end
 
   # Prints this `Time` to *io*.
@@ -1059,7 +1057,7 @@ struct Time
   # Nanoseconds are always omitted.
   # When the location is `UTC`, the offset is replaced with the string `UTC`.
   # Offset seconds are omitted if `0`.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     to_s("%F %T ", io)
 
     if utc?

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -92,10 +92,9 @@ struct Time::Format
   end
 
   # Formats a `Time` into the given *io*.
-  def format(time : Time, io : IO)
+  def format(time : Time, io : IO) : Nil
     formatter = Formatter.new(time, io)
     formatter.visit(pattern)
-    io
   end
 end
 

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -109,7 +109,7 @@ class Time::Location
     #
     # It contains the `name`, hour-minute-second format (see `#format`),
     # `offset` in seconds and `"DST"` if `#dst?`, otherwise `"STD"`.
-    def inspect(io : IO)
+    def inspect(io : IO) : Nil
       io << "Time::Location::Zone("
       io << @name << ' ' unless @name.nil?
       format(io)
@@ -176,7 +176,7 @@ class Time::Location
   record ZoneTransition, when : Int64, index : UInt8, standard : Bool, utc : Bool do
     getter? standard, utc
 
-    def inspect(io : IO)
+    def inspect(io : IO) : Nil
       io << "Time::Location::ZoneTransition("
       io << '#' << index << ' '
       Time.unix(self.when).to_s("%F %T", io)
@@ -364,11 +364,11 @@ class Time::Location
   end
 
   # Prints `name` to *io*.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     io << name
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << "#<Time::Location "
     to_s(io)
     io << '>'

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -341,7 +341,7 @@ struct Time::Span
     cmp
   end
 
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     if to_i < 0 || nanoseconds < 0
       io << '-'
     end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -370,7 +370,7 @@ struct Tuple
   end
 
   # Same as `to_s`.
-  def inspect
+  def inspect : String
     to_s
   end
 
@@ -380,7 +380,7 @@ struct Tuple
   # tuple = {1, "hello"}
   # tuple.to_s # => "{1, \"hello\"}"
   # ```
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << '{'
     join ", ", io, &.inspect(io)
     io << '}'

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -154,7 +154,7 @@ class URI
     !absolute?
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     if scheme
       io << scheme
       io << ':'

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -177,13 +177,13 @@ struct UUID
   end
 
   # Convert to `String` in literal format.
-  def inspect(io : IO)
+  def inspect(io : IO) : Nil
     io << "UUID("
     to_s(io)
     io << ')'
   end
 
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     slice = to_slice
 
     buffer = uninitialized UInt8[36]

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -58,13 +58,13 @@ struct XML::Attributes
     end
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << '['
     join ", ", io, &.inspect(io)
     io << ']'
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s(io)
   end
 

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -19,7 +19,7 @@ struct XML::Namespace
     @ns.value.prefix ? String.new(@ns.value.prefix) : nil
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     io << "#<XML::Namespace:0x"
     object_id.to_s(16, io)
 
@@ -34,10 +34,9 @@ struct XML::Namespace
     end
 
     io << '>'
-    io
   end
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     to_s io
   end
 end

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -169,7 +169,7 @@ struct XML::Node
   end
 
   # Returns detailed information for this node including node type, name, attributes and children.
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << "#<XML::"
     case type
     when XML::Type::ELEMENT_NODE       then io << "Element"
@@ -226,7 +226,6 @@ struct XML::Node
     end
 
     io << '>'
-    io
   end
 
   # Returns the next sibling node or `nil` if not found.
@@ -412,7 +411,7 @@ struct XML::Node
   # Serialize this Node as XML to *io* using default options.
   #
   # See `#to_xml`.
-  def to_s(io : IO)
+  def to_s(io : IO) : Nil
     to_xml io
   end
 

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -31,7 +31,7 @@ struct XML::NodeSet
   # See `Object#hash(hasher)`
   def_hash object_id
 
-  def inspect(io)
+  def inspect(io : IO) : Nil
     io << '['
     join ", ", io, &.inspect(io)
     io << ']'
@@ -45,7 +45,7 @@ struct XML::NodeSet
     @set.address
   end
 
-  def to_s(io)
+  def to_s(io : IO) : Nil
     join '\n', io
   end
 

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -279,12 +279,12 @@ struct YAML::Any
   end
 
   # :nodoc:
-  def inspect(io)
+  def inspect(io : IO) : Nil
     @raw.inspect(io)
   end
 
   # :nodoc:
-  def to_s(io)
+  def to_s(io : IO) : Nil
     @raw.to_s(io)
   end
 


### PR DESCRIPTION
I noticed some differences the signatures of some `to_s` methods that take IO.  This just adds some types explicitly and changes some of the methods to use the same signature.