### PR TITLE
Compiler: fix named args type matching

### DIFF
--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -906,4 +906,14 @@ describe "Semantic: proc" do
       Foo.new.block
       )) { proc_of(nil_type) }
   end
+
+  it "can pass proc that returns T as Void with named args (#7523)" do
+    assert_type(%(
+      def foo(proc : ->)
+        proc
+      end
+
+      foo(proc: ->{ 1 })
+      )) { proc_of(nil_type) }
+  end
 end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -80,7 +80,7 @@ module Crystal
                match_named_args.size == signature_named_args.size
               match_named_args = match_named_args.sort_by &.name
               signature_named_args = signature_named_args.sort_by &.name
-              named_arg_types_equal = match_named_args.equals?(signature_named_args) do |x, y|
+              named_arg_types_equal = signature_named_args.equals?(match_named_args) do |x, y|
                 x.name == y.name && x.type.compatible_with?(y.type)
               end
             else


### PR DESCRIPTION
Fixes #7523

The order of matching named arguments type was wrong (match vs. signature but should have been the other way around).