### PR TITLE
Change bsearch's `/ 2` to `>> 1` for faster performance

### DIFF
--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -48,8 +48,8 @@
     saved_to = to
     satisfied = nil
     while from < to
-      mid = (from < 0) == (to < 0) ? from + (to - from) / 2
-          : (from < -to) ? -((- from - to - 1) / 2 + 1) : (from + to) / 2
+      mid = (from < 0) == (to < 0) ? from + ((to - from) >> 1)
+          : (from < -to) ? -(((- from - to - 1) >> 1) + 1) : ((from + to) >> 1)
 
       if yield mid
         satisfied = mid
@@ -102,7 +102,7 @@ struct Range(B, E)
     saved_to = to
     satisfied = nil
     while from < to
-      mid = from + (to - from) / 2
+      mid = from + ((to - from) >> 1)
 
       if yield mid
         satisfied = mid


### PR DESCRIPTION
Using the benchmark:

```crystal
require "benchmark"

RANGE = (0..100_000_000)
ARRAY = RANGE.to_a

Benchmark.ips do |x|
  x.report("Array#bsearch") { ARRAY.bsearch { |number| number > 77_777_777 } }
  x.report("Range#bsearch") { RANGE.bsearch { |number| number > 77_777_777 } }
end
```

Before:
```
Array#bsearch   6.83M (146.38ns) (± 2.92%)  0 B/op        fastest
Range#bsearch   6.11M ( 163.7ns) (± 2.31%)  0 B/op   1.12× slower
```

After:
```
Array#bsearch   13.1M ( 76.35ns) (± 3.12%)  0 B/op        fastest
Range#bsearch   9.88M (101.23ns) (± 3.00%)  0 B/op   1.33× slower
```

---

I was surprised to see how much slower bsearch was than find (originally noticed in @konung's [fast-crystal](https://github.com/konung/fast-crystal#arraybsearch-vs-arrayfind-code)), so I'm looking into better algorithms.  Until I find one that works well, I figured I'd submit this simple win.  It uses the less expensive shift-right operation to do integer division by 2 as opposed to the division operation.  This change provides a 48% speedup in Array#bsearch and a 38% speedup in Range#bsearch
