### PR TITLE
Fix GenericClassType vs GenericClassInstanceType restrictions

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -62,6 +62,96 @@ describe "Restrictions" do
     end
   end
 
+  describe "restriction_of?" do
+    describe "GenericClassType vs GenericClassInstanceType" do
+      it "inserts GenericClassInstanceType before GenericClassType" do
+        assert_type(%(
+          class Foo(T)
+          end
+
+          def bar(a : Foo)
+            1
+          end
+
+          def bar(a : Foo(Int32))
+            true
+          end
+
+          {
+            bar(Foo(Int32).new),
+            bar(Foo(Float64).new)
+          }
+          )) { tuple_of([bool, int32]) }
+      end
+
+      it "keeps GenericClassInstanceType before GenericClassType" do
+        assert_type(%(
+          class Foo(T)
+          end
+
+          def bar(a : Foo(Int32))
+            true
+          end
+
+          def bar(a : Foo)
+            1
+          end
+
+          {
+            bar(Foo(Int32).new),
+            bar(Foo(Float64).new)
+          }
+          )) { tuple_of([bool, int32]) }
+      end
+
+      it "works with classes in different namespaces" do
+        assert_type(%(
+          class Foo(T)
+          end
+
+          class Mod::Foo(G)
+          end
+
+          def bar(a : Foo(Int32))
+            true
+          end
+
+          def bar(a : Mod::Foo)
+            1
+          end
+
+          {
+            bar(Foo(Int32).new),
+            bar(Mod::Foo(Int32).new)
+          }
+          )) { tuple_of([bool, int32]) }
+      end
+
+      it "doesn't mix different generic classes" do
+        assert_type(%(
+          class Foo(T)
+          end
+
+          class Bar(U)
+          end
+
+          def bar(a : Bar(Int32))
+            true
+          end
+
+          def bar(a : Foo)
+            1
+          end
+
+          {
+            bar(Foo(Int32).new),
+            bar(Bar(Int32).new)
+          }
+          )) { tuple_of([int32, bool]) }
+      end
+    end
+  end
+
   it "self always matches instance type in restriction" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -316,8 +316,7 @@ module Crystal
       #
       # Here, self is `Array`, other is `Array(Int32)`
 
-      return unless self == other.generic_type
-
+      # Even when the underlying generic type is the same,
       # `SomeGeneric` is never a restriction of `SomeGeneric(X)`
       false
     end
@@ -335,10 +334,9 @@ module Crystal
       #
       # Here, self is `Array(Int32)`, other is `Array`
 
-      return unless self.generic_type == other
-
+      # When the underlying generic type is the same:
       # `SomeGeneric(X)` is always a restriction of `SomeGeneric`
-      true
+      self.generic_type == other
     end
   end
 


### PR DESCRIPTION
I can't find an issue this may have solved (hard to search!), but basically:

```cr
class Foo(T)
end

def bar(a : Foo)
  1
end

def bar(a : Foo(Int32))
  true
end

# Before:
bar(Foo(Int32).new) # => 1

# After
bar(Foo(Int32).new) # => true
```
:tada: 