### PR TITLE
YAML: fix test checking serialization of slices for libyaml 0.2.2

### DIFF
--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -6,8 +6,7 @@ private def assert_built(expected, expect_document_end = false)
   # Earlier libyaml releases still write the document end marker and this is hard to fix on Crystal's side.
   # So we just ignore it and adopt the specs accordingly to coincide with the used libyaml version.
   if expect_document_end
-    major, minor, _ = YAML.libyaml_version
-    if major == 0 && minor < 2
+    if YAML.libyaml_version < SemanticVersion.new(0, 2, 1)
       expected += "...\n"
     end
   end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -15,8 +15,7 @@ alias YamlRec = Int32 | Array(YamlRec) | Hash(YamlRec, YamlRec)
 # Earlier libyaml releases still write the document end marker and this is hard to fix on Crystal's side.
 # So we just ignore it and adopt the specs accordingly to coincide with the used libyaml version.
 private def assert_yaml_document_end(actual, expected)
-  major, minor, _ = YAML.libyaml_version
-  if major == 0 && minor < 2
+  if YAML.libyaml_version < SemanticVersion.new(0, 2, 1)
     expected += "...\n"
   end
 
@@ -332,7 +331,13 @@ describe "YAML serialization" do
     end
 
     it "does for bytes" do
-      "hello".to_slice.to_yaml.should eq("--- !!binary 'aGVsbG8=\n\n'\n")
+      yaml = "hello".to_slice.to_yaml
+
+      if YAML.libyaml_version < SemanticVersion.new(0, 2, 2)
+        yaml.should eq("--- !!binary 'aGVsbG8=\n\n'\n")
+      else
+        yaml.should eq("--- !!binary 'aGVsbG8=\n\n  '\n")
+      end
     end
 
     it "does a full document" do

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -2,6 +2,7 @@ require "./yaml/*"
 require "./yaml/schema/*"
 require "./yaml/schema/core/*"
 require "./yaml/nodes/*"
+require "semantic_version"
 
 require "base64"
 
@@ -159,8 +160,9 @@ module YAML
   end
 
   # Returns the used version of `libyaml`.
-  def self.libyaml_version : {Int32, Int32, Int32}
+  def self.libyaml_version : SemanticVersion
     LibYAML.yaml_get_version(out major, out minor, out patch)
-    {major, minor, patch}
+
+    SemanticVersion.new(major, minor, patch)
   end
 end


### PR DESCRIPTION
Fixes #7548

I'm marking this as a (small) breaking change because I changed `YAML.libyaml_version` to return a `SemanticVersion` object, which is easier to deal with.