### PR TITLE
Add IO overload to Benchmark

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -64,7 +64,7 @@ end
 describe Benchmark::IPS::Entry, "#calculate_stats" do
   it "correctly calculates basic stats" do
     e = create_entry
-    e.calculate_stats([2, 4, 4, 4, 5, 5, 7, 9])
+    e.calculate_stats({2, 4, 4, 4, 5, 5, 7, 9})
 
     e.size.should eq(8)
     e.mean.should eq(5.0)

--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -9,13 +9,12 @@ typeof(begin
 end)
 
 describe Benchmark::IPS::Job do
-  it "works in general / integration test" do
+  it "executes in non-interactive" do
     # test several things to avoid running a benchmark over and over again in
     # the specs
-    j = Benchmark::IPS::Job.new(0.001, 0.001, interactive: false)
+    j = Benchmark::IPS::Job.new(0.001, 0.001)
     a = j.report("a") { sleep 0.001 }
     b = j.report("b") { sleep 0.002 }
-
     j.execute
 
     # the mean should be calculated
@@ -27,6 +26,17 @@ describe Benchmark::IPS::Job do
     first, second = [a.slower, b.slower].sort
     first.should eq(1)
     second.should be > 1
+  end
+
+  it "executes interactively with an IO" do
+    io = IO::Memory.new
+    Benchmark.ips(0.001, 0.001, io) do |bm|
+      bm.report("first benchmark") { sleep 0.001 }
+      bm.report("second benchmark") { sleep 0.002 }
+    end
+    result = io.to_s
+    result.should contain "first benchmark"
+    result.should contain "second benchmark"
   end
 end
 

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -85,15 +85,15 @@ module Benchmark
 
   # Main interface of the `Benchmark` module. Yields a `Job` to which
   # one can report the benchmarks. See the module's description.
-  def bm
+  def bm(io : IO = STDOUT)
     {% if !flag?(:release) %}
       puts "Warning: benchmarking without the `--release` flag won't yield useful results"
     {% end %}
 
-    report = BM::Job.new
-    yield report
-    report.execute
-    report
+    job = BM::Job.new
+    yield job
+    job.execute io
+    job
   end
 
   # Instruction per second interface of the `Benchmark` module. Yields a `Job`
@@ -101,22 +101,22 @@ module Benchmark
   #
   # The optional parameters *calculation* and *warmup* set the duration of
   # those stages in seconds. For more detail on these stages see
-  # `Benchmark::IPS`. When the *interactive* parameter is `true`, results are
-  # displayed and updated as they are calculated, otherwise all at once.
-  def ips(calculation = 5, warmup = 2, interactive = STDOUT.tty?)
+  # `Benchmark::IPS`. The IO must be a valid TTY to show interactive results, that will be
+  # displayed and updated as they are calculated. Otherwise, use `IPS::Job` directly.
+  def ips(calculation = 5, warmup = 2, io : IO = STDOUT)
     {% if !flag?(:release) %}
       puts "Warning: benchmarking without the `--release` flag won't yield useful results"
     {% end %}
 
-    job = IPS::Job.new(calculation, warmup, interactive)
+    job = IPS::Job.new(calculation, warmup)
     yield job
-    job.execute
-    job.report
+    job.execute io
+    job.report io
     job
   end
 
   # Returns the time used to execute the given block.
-  def measure(label = "") : BM::Tms
+  def measure(label : String = "") : BM::Tms
     t0, r0 = Process.times, Time.monotonic
     yield
     t1, r1 = Process.times, Time.monotonic

--- a/src/benchmark/bm.cr
+++ b/src/benchmark/bm.cr
@@ -44,27 +44,26 @@ module Benchmark
       end
 
       # Reports a single benchmark unit.
-      def report(label = " ", &block)
+      def report(label : String = " ", &block)
         @label_width = label.size if label.size > @label_width
         @reports << {label, block}
       end
 
       # :nodoc:
-      def execute
-        if @label_width > 0
-          print " " * @label_width
+      def execute(io : IO = STDOUT) : Nil
+        @label_width.times do
+          io << ' '
         end
-        puts "       user     system      total        real"
+        io.puts "       user     system      total        real"
 
         @reports.each do |report|
           label, block = report
-          print label
+          io.print label
           diff = @label_width - label.size + 1
-          if diff > 0
-            print " " * diff
+          diff.times do
+            io << ' '
           end
-          print Benchmark.measure(label, &block)
-          puts
+          io.puts Benchmark.measure(label, &block)
         end
       end
     end

--- a/src/benchmark/bm.cr
+++ b/src/benchmark/bm.cr
@@ -1,7 +1,7 @@
 module Benchmark
   module BM
     # A data object, representing the times associated with a benchmark measurement.
-    class Tms
+    struct Tms
       # User CPU time
       getter utime : Float64
 

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -12,7 +12,7 @@ module Benchmark
   # which are then reported. Additionally we compare the means to that of the
   # fastest.
   module IPS
-    class Job
+    struct Job
       # List of all entries in the benchmark.
       # After #execute, these are populated with the resulting statistics.
       property items : Array(Entry)
@@ -155,14 +155,10 @@ module Benchmark
       # Number of bytes allocated per operation
       property! bytes_per_op : Int32
 
-      @ran : Bool
-      @ran = false
+      # The stats have been calculated
+      getter? ran : Bool = false
 
       def initialize(@label : String, @action : ->)
-      end
-
-      def ran?
-        @ran
       end
 
       def call


### PR DESCRIPTION
This change allows benchmarkers to directly send the report to an IO, in order to build a Markdown benchmark report for example.  Before creating a subprocess was the only way to do this.
The `interactive` ivar is no longer needed.