### PR TITLE
Add CRYSTAL_LIBRARY_PATH for lookup static libraries

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -75,6 +75,16 @@ module Crystal
     end
   end
 
+  class CrystalLibraryPath
+    def self.default_path : String
+      ENV.fetch("CRYSTAL_LIBRARY_PATH", Crystal::Config.library_path)
+    end
+
+    class_getter paths : Array(String) do
+      default_path.split(':', remove_empty: true)
+    end
+  end
+
   class Program
     def lib_flags
       has_flag?("windows") ? lib_flags_windows : lib_flags_posix
@@ -111,7 +121,9 @@ module Crystal
 
             static = has_flag?("static") || ann.static?
 
-            if has_pkg_config && (libflags = pkg_config_flags(libname, static, library_path))
+            if static && (static_lib = find_static_lib(libname, CrystalLibraryPath.paths))
+              flags << ' ' << static_lib
+            elsif has_pkg_config && (libflags = pkg_config_flags(libname, static, library_path))
               flags << ' ' << libflags
             elsif static && (static_lib = find_static_lib(libname, library_path))
               flags << ' ' << static_lib

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -137,6 +137,10 @@ module Crystal
           end
         end
 
+        # Append the CRYSTAL_LIBRARY_PATH values as -L flags.
+        CrystalLibraryPath.paths.each do |path|
+          flags << " -L#{path}"
+        end
         # Append the default paths as -L flags in case the linker doesn't know
         # about them (eg: FreeBSD won't search /usr/local/lib by default):
         library_path.each do |path|

--- a/src/compiler/crystal/command/env.cr
+++ b/src/compiler/crystal/command/env.cr
@@ -7,9 +7,10 @@ class Crystal::Command
     end
 
     vars = {
-      "CRYSTAL_CACHE_DIR" => CacheDir.instance.dir,
-      "CRYSTAL_PATH"      => CrystalPath.default_path,
-      "CRYSTAL_VERSION"   => Config.version || "",
+      "CRYSTAL_CACHE_DIR"    => CacheDir.instance.dir,
+      "CRYSTAL_PATH"         => CrystalPath.default_path,
+      "CRYSTAL_VERSION"      => Config.version || "",
+      "CRYSTAL_LIBRARY_PATH" => CrystalLibraryPath.default_path,
     }
 
     if ARGV.empty?

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -69,5 +69,9 @@ module Crystal
         "gnu"
       end
     end
+
+    def self.library_path
+      {{env("CRYSTAL_CONFIG_LIBRARY_PATH") || ""}}
+    end
   end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -256,6 +256,7 @@ module Crystal
       define_crystal_string_constant "DEFAULT_PATH", Crystal::Config.path
       define_crystal_string_constant "DESCRIPTION", Crystal::Config.description
       define_crystal_string_constant "PATH", Crystal::CrystalPath.default_path
+      define_crystal_string_constant "LIBRARY_PATH", Crystal::CrystalLibraryPath.default_path
       define_crystal_string_constant "VERSION", Crystal::Config.version
       define_crystal_string_constant "LLVM_VERSION", Crystal::Config.llvm_version
     end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -216,7 +216,8 @@ class Crystal::Doc::Generator
     return false unless type.namespace == crystal_type
 
     {"BUILD_COMMIT", "BUILD_DATE", "CACHE_DIR", "DEFAULT_PATH",
-     "DESCRIPTION", "PATH", "VERSION", "LLVM_VERSION"}.each do |name|
+     "DESCRIPTION", "PATH", "VERSION", "LLVM_VERSION",
+     "LIBRARY_PATH"}.each do |name|
       return true if type == crystal_type.types[name]?
     end
 


### PR DESCRIPTION
The compiler will use the `CRYSTAL_LIBRARY_PATH` environment variable as a first lookup destination for the static libraries that are wanted to be linked.

It follows the other configuration options conventions:
* Upon building the compiler the `CRYSTAL_CONFIG_LIBRARY_PATH` variable can be used to define the default embedded.
* The `Crystal::LIBRARY_PATH` constant is defined on compiled programs.

Ref: https://forum.crystal-lang.org/t/rfc-link-configuration/546