### PR TITLE
Add missing `require` statements for the API

### DIFF
--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -26,6 +26,8 @@ require "./benchmark/**"
 # calculation time. This can be configured:
 #
 # ```
+# require "benchmark"
+#
 # Benchmark.ips(warmup: 4, calculation: 10) do |x|
 #   x.report("sleep") { sleep 0.01 }
 # end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -15,6 +15,7 @@ struct BigInt < Int
   #
   # ```
   # require "big"
+  #
   # BigInt.new # => 0
   # ```
   def initialize
@@ -26,6 +27,8 @@ struct BigInt < Int
   # Raises `ArgumentError` if the string doesn't denote a valid integer.
   #
   # ```
+  # require "big"
+  #
   # BigInt.new("123456789123456789123456789123456789") # => 123456789123456789123456789123456789
   # BigInt.new("123_456_789_123_456_789_123_456_789")  # => 123456789012345678901234567890
   # BigInt.new("1234567890ABCDEF", base: 16)           # => 1311768467294899695
@@ -350,6 +353,8 @@ struct BigInt < Int
   # Returns a string representation of self.
   #
   # ```
+  # require "big"
+  #
   # BigInt.new("123456789101101987654321").to_s # => 123456789101101987654321
   # ```
   def to_s : String
@@ -365,6 +370,8 @@ struct BigInt < Int
   # Returns a string containing the representation of big radix base (2 through 36).
   #
   # ```
+  # require "big"
+  #
   # BigInt.new("123456789101101987654321").to_s(8)  # => "32111154373025463465765261"
   # BigInt.new("123456789101101987654321").to_s(16) # => "1a249b1f61599cd7eab1"
   # BigInt.new("123456789101101987654321").to_s(36) # => "k3qmt029k48nmpd"
@@ -583,6 +590,7 @@ struct Int
   # Returns a `BigInt` representing this integer.
   # ```
   # require "big"
+  #
   # 123.to_big_i
   # ```
   def to_big_i : BigInt
@@ -600,6 +608,7 @@ struct Float
   # Returns a `BigInt` representing this float (rounded using `floor`).
   # ```
   # require "big"
+  #
   # 1212341515125412412412421.0.to_big_i
   # ```
   def to_big_i : BigInt
@@ -613,6 +622,7 @@ class String
   # Raises `ArgumentError` if this string doesn't denote a valid integer.
   # ```
   # require "big"
+  #
   # "3a060dbf8d1a5ac3e67bc8f18843fc48".to_big_i(16)
   # ```
   def to_big_i(base = 10) : BigInt
@@ -625,6 +635,7 @@ module Math
   #
   # ```
   # require "big"
+  #
   # Math.sqrt((1000_000_000_0000.to_big_i*1000_000_000_00000.to_big_i))
   # ```
   def sqrt(value : BigInt)

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -130,6 +130,8 @@ struct BigRational < Number
   # Divides the rational by (2 ** *other*)
   #
   # ```
+  # require "big"
+  #
   # BigRational.new(2, 3) >> 2 # => 1/6
   # ```
   def >>(other : Int)
@@ -139,6 +141,8 @@ struct BigRational < Number
   # Multiplies the rational by (2 ** *other*)
   #
   # ```
+  # require "big"
+  #
   # BigRational.new(2, 3) << 2 # => 8/3
   # ```
   def <<(other : Int)
@@ -198,6 +202,8 @@ struct BigRational < Number
   # Optionally takes a radix base (2 through 36).
   #
   # ```
+  # require "big"
+  #
   # r = BigRational.new(8243243, 562828882)
   # r.to_s     # => "8243243/562828882"
   # r.to_s(16) # => "7dc82b/218c1652"
@@ -248,6 +254,7 @@ struct Int
   # Returns a `BigRational` representing this integer.
   # ```
   # require "big"
+  #
   # 123.to_big_r
   # ```
   def to_big_r
@@ -281,6 +288,7 @@ struct Float
   # Returns a `BigRational` representing this float.
   # ```
   # require "big"
+  #
   # 123.0.to_big_r
   # ```
   def to_big_r
@@ -296,6 +304,7 @@ module Math
   # Returns the sqrt of a `BigRational`.
   # ```
   # require "big"
+  #
   # Math.sqrt((1000_000_000_0000.to_big_r*1000_000_000_00000.to_big_r))
   # ```
   def sqrt(value : BigRational)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -54,6 +54,8 @@ struct BitArray
   # Raises `IndexError` if trying to access a bit outside the array's range.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba[3] = true
   # ```
@@ -75,6 +77,8 @@ struct BitArray
   # Raises `IndexError` if the starting index is out of range.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba[0] = true; ba[2] = true; ba[4] = true
   # ba # => BitArray[10101]
@@ -99,6 +103,8 @@ struct BitArray
   # Raises `IndexError` if the starting index is out of range.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba[0] = true; ba[2] = true; ba[4] = true
   # ba # => BitArray[10101]
@@ -175,6 +181,8 @@ struct BitArray
   # Raises `IndexError` if trying to access a bit outside the array's range.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba[3] # => false
   # ba.toggle(3)
@@ -188,6 +196,8 @@ struct BitArray
   # Inverts all bits in the array. Falses become `true` and vice versa.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba[2] = true; ba[3] = true
   # ba # => BitArray[00110]
@@ -203,6 +213,8 @@ struct BitArray
   # Creates a string representation of self.
   #
   # ```
+  # require "bit_array"
+  #
   # ba = BitArray.new(5)
   # ba.to_s # => "BitArray[00000]"
   # ```

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -14,12 +14,16 @@
 #
 # There are alternative ways to change the foreground color:
 # ```
+# require "colorize"
+#
 # "foo".colorize.fore(:green)
 # "foo".colorize.green
 # ```
 #
 # To change the background color, the following methods are available:
 # ```
+# require "colorize"
+#
 # "foo".colorize.back(:green)
 # "foo".colorize.on(:green)
 # "foo".colorize.on_green
@@ -27,16 +31,22 @@
 #
 # You can also pass an RGB color to `colorize`:
 # ```
+# require "colorize"
+#
 # "foo".colorize(Colorize::ColorRGB.new(0, 255, 255)) # => "foo" in aqua
 # ```
 #
 # Or an 8-bit color:
 # ```
+# require "colorize"
+#
 # "foo".colorize(Colorize::Color256.new(208)) # => "foo" in orange
 # ```
 #
 # It's also possible to change the text decoration:
 # ```
+# require "colorize"
+#
 # "foo".colorize.mode(:underline)
 # "foo".colorize.underline
 # ```
@@ -44,12 +54,16 @@
 # The `colorize` method returns a `Colorize::Object` instance,
 # which allows chaining methods together:
 # ```
+# require "colorize"
+#
 # "foo".colorize.fore(:yellow).back(:blue).mode(:underline)
 # ```
 #
 # With the `toggle` method you can temporarily disable adding the escape codes.
 # Settings of the instance are preserved however and can be turned back on later:
 # ```
+# require "colorize"
+#
 # "foo".colorize(:red).toggle(false)              # => "foo" without color
 # "foo".colorize(:red).toggle(false).toggle(true) # => "foo" in red
 # ```
@@ -57,6 +71,8 @@
 # The color `:default` will just leave the object as it is (but it's an `Colorize::Object(String)` then).
 # That's handy in for example conditions:
 # ```
+# require "colorize"
+#
 # "foo".colorize(some_bool ? :green : :default)
 # ```
 #
@@ -98,6 +114,8 @@ module Colorize
   # The default value is `true`.
   #
   # ```
+  # require "colorize"
+  #
   # Colorize.enabled = true
   # "hello".colorize.red.to_s # => "\e[31mhello\e[0m"
   #

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -84,6 +84,8 @@ struct Complex
   # Writes this complex object to an *io*.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).to_s # => "42.0 + 2.0i"
   # ```
   def to_s(io : IO) : Nil
@@ -96,6 +98,8 @@ struct Complex
   # Writes this complex object to an *io*, surrounded by parentheses.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).inspect # => "(42.0 + 2.0i)"
   # ```
   def inspect(io : IO) : Nil
@@ -108,6 +112,8 @@ struct Complex
   # number form, using the Pythagorean theorem.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).abs  # => 42.04759208325728
   # Complex.new(-42, 2).abs # => 42.04759208325728
   # ```
@@ -118,6 +124,8 @@ struct Complex
   # Returns the square of absolute value in a number form.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).abs2 # => 1768
   # ```
   def abs2
@@ -136,6 +144,8 @@ struct Complex
   # Returns a `Tuple` with the `abs` value and the `phase`.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).polar # => {42.047592083257278, 0.047583103276983396}
   # ```
   def polar
@@ -145,6 +155,8 @@ struct Complex
   # Returns the conjugate of `self`.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(42, 2).conj  # => 42.0 - 2.0i
   # Complex.new(42, -2).conj # => 42.0 + 2.0i
   # ```
@@ -181,6 +193,8 @@ struct Complex
   # Calculates the exp of `self`.
   #
   # ```
+  # require "complex"
+  #
   # Complex.new(4, 2).exp # => -22.720847417619233 + 49.645957334580565i
   # ```
   def exp

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -18,6 +18,8 @@ class Crypto::Bcrypt::Password
   # Hashes a password.
   #
   # ```
+  # require "crypto/bcrypt/password"
+  #
   # password = Crypto::Bcrypt::Password.create("super secret", cost: 10)
   # # => $2a$10$rI4xRiuAN2fyiKwynO6PPuorfuoM4L2PVv6hlnVJEmNLjqcibAfHq
   # ```
@@ -33,6 +35,8 @@ class Crypto::Bcrypt::Password
   # Loads a bcrypt hash.
   #
   # ```
+  # require "crypto/bcrypt/password"
+  #
   # password = Crypto::Bcrypt::Password.new("$2a$10$X6rw/jDiLBuzHV./JjBNXe8/Po4wTL0fhdDNdAdjcKN/Fup8tGCya")
   # password.version # => "2a"
   # password.salt    # => "X6rw/jDiLBuzHV./JjBNXe"
@@ -54,6 +58,8 @@ class Crypto::Bcrypt::Password
   # Verifies a password against the hash.
   #
   # ```
+  # require "crypto/bcrypt/password"
+  #
   # password = Crypto::Bcrypt::Password.create("super secret")
   # password == "wrong secret" # => false
   # password == "super secret" # => true

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -65,6 +65,8 @@ class CSV
   # non-standard csv cell separators and quote characters.
   #
   # ```
+  # require "csv"
+  #
   # CSV.parse("one,two\nthree")
   # # => [["one", "two"], ["three"]]
   # CSV.parse("one;two\n'three;'", separator: ';', quote_char: '\'')
@@ -79,6 +81,8 @@ class CSV
   # See `CSV.parse` about the *separator* and *quote_char* arguments.
   #
   # ```
+  # require "csv"
+  #
   # CSV.each_row("one,two\nthree") do |row|
   #   puts row
   # end
@@ -101,6 +105,8 @@ class CSV
   # See `CSV.parse` about the *separator* and *quote_char* arguments.
   #
   # ```
+  # require "csv"
+  #
   # rows = CSV.each_row("one,two\nthree")
   # rows.next # => ["one", "two"]
   # rows.next # => ["three"]
@@ -114,6 +120,8 @@ class CSV
   # Takes optional *quoting* argument to define quote behavior.
   #
   # ```
+  # require "csv"
+  #
   # result = CSV.build do |csv|
   #   csv.row "one", "two"
   #   csv.row "three"
@@ -137,6 +145,8 @@ class CSV
   # that writes to the given `IO`.
   #
   # ```
+  # require "csv"
+  #
   # io = IO::Memory.new
   # io.puts "HEADER"
   # CSV.build(io) do |csv|

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -12,6 +12,8 @@ abstract class Digest::Base
   # method available. Returns the resulting digest afterwards.
   #
   # ```
+  # require "digest/md5"
+  #
   # digest = Digest::MD5.digest do |ctx|
   #   ctx.update "f"
   #   ctx.update "oo"
@@ -28,6 +30,8 @@ abstract class Digest::Base
   # Returns the hexadecimal representation of the hash of *data*.
   #
   # ```
+  # require "digest/md5"
+  #
   # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
   # ```
   def self.hexdigest(data) : String
@@ -39,6 +43,9 @@ abstract class Digest::Base
   # afterwards.
   #
   # ```
+  # require "digest/md5"
+  #
+  # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
   # Digest::MD5.hexdigest do |ctx|
   #   ctx.update "f"
   #   ctx.update "oo"
@@ -56,6 +63,8 @@ abstract class Digest::Base
   # Returns the base64-encoded hash of *data*.
   #
   # ```
+  # require "digest/sha1"
+  #
   # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
   # ```
   def self.base64digest(data) : String
@@ -65,6 +74,8 @@ abstract class Digest::Base
   # Returns the base64-encoded hash of *data*.
   #
   # ```
+  # require "digest/sha1"
+  #
   # Digest::SHA1.base64digest do |ctx|
   #   ctx.update "f"
   #   ctx.update "oo"

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -18,6 +18,8 @@ module FileUtils
   # and invoked the block, restoring the original working directory when the block exits.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.cd("/tmp") { Dir.current } # => "/tmp"
   # ```
   #
@@ -30,6 +32,8 @@ module FileUtils
   # Returns `true` if content are the same, `false` otherwise.
   #
   # ```
+  # require "file_utils"
+  #
   # File.write("file.cr", "1")
   # File.write("bar.cr", "1")
   # FileUtils.cmp("file.cr", "bar.cr") # => true
@@ -48,6 +52,8 @@ module FileUtils
   # Returns `true` if content are the same, `false` otherwise.
   #
   # ```
+  # require "file_utils"
+  #
   # File.write("afile", "123")
   # stream1 = File.open("afile")
   # stream2 = IO::Memory.new("123")
@@ -73,6 +79,8 @@ module FileUtils
   # If the file does not exist, it will be created.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.touch("afile.cr")
   # ```
   #
@@ -87,6 +95,8 @@ module FileUtils
   # If the file does not exist, it will be created.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.touch(["foo", "bar"])
   # ```
   def touch(paths : Enumerable(String), time : Time = Time.utc)
@@ -100,6 +110,8 @@ module FileUtils
   # Permission bits are copied too.
   #
   # ```
+  # require "file_utils"
+  #
   # File.chmod("afile", 0o600)
   # FileUtils.cp("afile", "afile_copy")
   # File.info("afile_copy").permissions.value # => 0o600
@@ -117,6 +129,8 @@ module FileUtils
   # *dest* must be an existing directory.
   #
   # ```
+  # require "file_utils"
+  #
   # Dir.mkdir("files")
   # FileUtils.cp({"bar.cr", "afile"}, "files")
   # ```
@@ -131,6 +145,8 @@ module FileUtils
   # If *src_path* is a directory, this method copies all its contents recursively.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.cp_r("files", "dir")
   # ```
   def cp_r(src_path : String, dest_path : String)
@@ -150,6 +166,8 @@ module FileUtils
   # If *dest_path* already exists and is a directory, creates a link *dest_path/src_path*.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create a hard link, pointing from /usr/bin/emacs to /usr/bin/vim
   # FileUtils.ln("/usr/bin/vim", "/usr/bin/emacs")
   # # Create a hard link, pointing from /tmp/foo.c to foo.c
@@ -167,6 +185,8 @@ module FileUtils
   # If *dest_dir* is not a directory, raises an `ArgumentError`.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create /usr/bin/vim, /usr/bin/emacs, and /usr/bin/nano as hard links
   # FileUtils.ln(["vim", "emacs", "nano"], "/usr/bin")
   # ```
@@ -182,6 +202,8 @@ module FileUtils
   # If *dest_path* already exists and is a directory, creates a link *dest_path/src_path*.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create a symbolic link pointing from logs to /var/log
   # FileUtils.ln_s("/var/log", "logs")
   # # Create a symbolic link pointing from /tmp/src to src
@@ -199,6 +221,8 @@ module FileUtils
   # If *dest_dir* is not a directory, raises an `ArgumentError`.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create symbolic links in src/ pointing to every .c file in the current directory
   # FileUtils.ln_s(Dir["*.c"], "src")
   # ```
@@ -214,6 +238,8 @@ module FileUtils
   # or if `dest_path/src_path` exists.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create a symbolic link pointing from bar.c to foo.c, even if bar.c already exists
   # FileUtils.ln_sf("foo.c", "bar.c")
   # ```
@@ -232,6 +258,8 @@ module FileUtils
   # If *dest_dir* is not a directory, raises an `ArgumentError`.
   #
   # ```
+  # require "file_utils"
+  #
   # # Create symbolic links in src/ pointing to every .c file in the current directory,
   # # even if it means overwriting files in src/
   # FileUtils.ln_sf(Dir["*.c"], "src")
@@ -248,6 +276,8 @@ module FileUtils
   # can be specified, with a default of 777 (0o777).
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mkdir("src")
   # ```
   #
@@ -260,6 +290,8 @@ module FileUtils
   # can be specified, with a default of 777 (0o777).
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mkdir(["foo", "bar"])
   # ```
   def mkdir(paths : Enumerable(String), mode = 0o777) : Nil
@@ -273,6 +305,8 @@ module FileUtils
   # with a default of 777 (0o777).
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mkdir_p("foo")
   # ```
   #
@@ -286,6 +320,8 @@ module FileUtils
   # with a default of 777 (0o777).
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mkdir_p(["foo", "bar", "baz", "dir1", "dir2", "dir3"])
   # ```
   def mkdir_p(paths : Enumerable(String), mode = 0o777) : Nil
@@ -297,6 +333,8 @@ module FileUtils
   # Moves *src_path* to *dest_path*.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mv("afile", "afile.cr")
   # ```
   #
@@ -308,6 +346,8 @@ module FileUtils
   # Moves every *srcs* to *dest*.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.mv(["foo", "bar"], "src")
   # ```
   def mv(srcs : Enumerable(String), dest : String) : Nil
@@ -323,6 +363,8 @@ module FileUtils
   # Returns the current working directory.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.pwd
   # ```
   #
@@ -334,6 +376,8 @@ module FileUtils
   # Deletes the *path* file given.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm("afile.cr")
   # ```
   #
@@ -345,6 +389,8 @@ module FileUtils
   # Deletes all *paths* file given.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm(["dir/afile", "afile_copy"])
   # ```
   def rm(paths : Enumerable(String)) : Nil
@@ -357,6 +403,8 @@ module FileUtils
   # If *path* is a directory, this method removes all its contents recursively.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm_r("dir")
   # FileUtils.rm_r("file.cr")
   # ```
@@ -376,6 +424,8 @@ module FileUtils
   # If one path is a directory, this method removes all its contents recursively.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm_r(["files", "bar.cr"])
   # ```
   def rm_r(paths : Enumerable(String)) : Nil
@@ -389,6 +439,8 @@ module FileUtils
   # Ignores all errors.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm_rf("dir")
   # FileUtils.rm_rf("file.cr")
   # FileUtils.rm_rf("non_existent_file")
@@ -405,6 +457,8 @@ module FileUtils
   # Ignores all errors.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rm_rf(["dir", "file.cr", "non_existent_file"])
   # ```
   def rm_rf(paths : Enumerable(String)) : Nil
@@ -419,6 +473,8 @@ module FileUtils
   # Removes the directory at the given *path*.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rmdir("baz")
   # ```
   #
@@ -430,6 +486,8 @@ module FileUtils
   # Removes all directories at the given *paths*.
   #
   # ```
+  # require "file_utils"
+  #
   # FileUtils.rmdir(["dir1", "dir2", "dir3"])
   # ```
   def rmdir(paths : Enumerable(String)) : Nil

--- a/src/html.cr
+++ b/src/html.cr
@@ -28,6 +28,8 @@ module HTML
   # the given *io*.
   #
   # ```
+  # require "html"
+  #
   # io = IO::Memory.new
   # HTML.escape("Crystal & You", io) # => nil
   # io.to_s                          # => "Crystal &amp; You"
@@ -84,6 +86,8 @@ module HTML
   # without a trailing semicolon (such as `&copy`).
   #
   # ```
+  # require "html"
+  #
   # HTML.unescape("Crystal &amp; You") # => "Crystal & You"
   # ```
   def self.unescape(string : String) : String

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -72,6 +72,8 @@ class HTTP::Client
   # Returns the target host.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # client.host # => "www.example.com"
   # ```
@@ -80,6 +82,8 @@ class HTTP::Client
   # Returns the target port.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # client.port # => 80
   # ```
@@ -90,6 +94,8 @@ class HTTP::Client
   # Changes made after the initial request will have no effect.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com", tls: true
   # client.tls # => #<OpenSSL::SSL::Context::Client ...>
   # ```
@@ -149,6 +155,9 @@ class HTTP::Client
   # to port 443 and sets tls to `true`.
   #
   # ```
+  # require "http/client"
+  # require "uri"
+  #
   # uri = URI.parse("https://secure.example.com")
   # client = HTTP::Client.new(uri)
   #
@@ -176,6 +185,9 @@ class HTTP::Client
   # https protocol, which defaults to port 443 and sets tls to `true`.
   #
   # ```
+  # require "http/client"
+  # require "uri"
+  #
   # uri = URI.parse("https://secure.example.com")
   # HTTP::Client.new(uri) do |client|
   #   client.tls? # => #<OpenSSL::SSL::Context::Client>
@@ -206,6 +218,8 @@ class HTTP::Client
   # the client afterwards.
   #
   # ```
+  # require "http/client"
+  #
   # HTTP::Client.new("www.example.com") do |client|
   #   client.get "/"
   # end
@@ -231,6 +245,8 @@ class HTTP::Client
   # Sets the number of seconds to wait when reading before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.read_timeout = 1.5
   # begin
@@ -246,6 +262,8 @@ class HTTP::Client
   # Sets the read timeout with a `Time::Span`, to wait when reading before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.read_timeout = 5.minutes
   # begin
@@ -261,6 +279,8 @@ class HTTP::Client
   # Sets the number of seconds to wait when connecting, before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.connect_timeout = 1.5
   # begin
@@ -276,6 +296,8 @@ class HTTP::Client
   # Sets the open timeout with a `Time::Span` to wait when connecting, before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.connect_timeout = 5.minutes
   # begin
@@ -293,6 +315,8 @@ class HTTP::Client
   # Sets the number of seconds to wait when resolving a name, before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.dns_timeout = 1.5
   # begin
@@ -310,6 +334,8 @@ class HTTP::Client
   # Sets the number of seconds to wait when resolving a name with a `Time::Span`, before raising an `IO::Timeout`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("example.org")
   # client.dns_timeout = 1.5.seconds
   # begin
@@ -328,6 +354,8 @@ class HTTP::Client
   #
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new("www.example.com")
   # client.before_request do |request|
   #   request.headers["Authorization"] = "XYZ123"
@@ -344,6 +372,8 @@ class HTTP::Client
     # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new("www.example.com")
     # response = client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!")
     # response.body #=> "..."
@@ -356,6 +386,8 @@ class HTTP::Client
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new("www.example.com")
     # client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!") do |response|
     #   response.body_io.gets #=> "..."
@@ -371,6 +403,8 @@ class HTTP::Client
     # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
     #
     # ```
+    # require "http/client"
+    #
     # response = HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!")
     # response.body #=> "..."
     # ```
@@ -382,6 +416,8 @@ class HTTP::Client
     # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
     #
     # ```
+    # require "http/client"
+    #
     # HTTP::Client.{{method.id}}("/", headers: HTTP::Headers{"User-Agent" => "AwesomeApp"}, body: "Hello!") do |response|
     #   response.body_io.gets #=> "..."
     # end
@@ -396,6 +432,8 @@ class HTTP::Client
     # to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new "www.example.com"
     # response = client.{{method.id}} "/", form: "foo=bar"
     # ```
@@ -410,6 +448,8 @@ class HTTP::Client
     # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new "www.example.com"
     # client.{{method.id}}("/", form: "foo=bar") do |response|
     #   response.body_io.gets
@@ -427,6 +467,8 @@ class HTTP::Client
     # to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new "www.example.com"
     # response = client.{{method.id}} "/", form: {"foo" => "bar"}
     # ```
@@ -440,6 +482,8 @@ class HTTP::Client
     # The "Content-type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # client = HTTP::Client.new "www.example.com"
     # client.{{method.id}}("/", form: {"foo" => "bar"}) do |response|
     #   response.body_io.gets
@@ -456,6 +500,8 @@ class HTTP::Client
     # to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # response = HTTP::Client.{{method.id}} "http://www.example.com", form: "foo=bar"
     # ```
     def self.{{method.id}}(url, headers : HTTP::Headers? = nil, tls = nil, *, form : String | IO | Hash) : HTTP::Client::Response
@@ -469,6 +515,8 @@ class HTTP::Client
     # The "Content-Type" header is set to "application/x-www-form-urlencoded".
     #
     # ```
+    # require "http/client"
+    #
     # HTTP::Client.{{method.id}}("http://www.example.com", form: "foo=bar") do |response|
     #   response.body_io.gets
     # end
@@ -486,6 +534,8 @@ class HTTP::Client
   # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # response = client.exec HTTP::Request.new("GET", "/")
   # response.body # => "..."
@@ -521,6 +571,8 @@ class HTTP::Client
   # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # client.exec(HTTP::Request.new("GET", "/")) do |response|
   #   response.body_io.gets # => "..."
@@ -604,6 +656,8 @@ class HTTP::Client
   # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # response = client.exec "GET", "/"
   # response.body # => "..."
@@ -616,6 +670,8 @@ class HTTP::Client
   # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
   #
   # ```
+  # require "http/client"
+  #
   # client = HTTP::Client.new "www.example.com"
   # client.exec("GET", "/") do |response|
   #   response.body_io.gets # => "..."
@@ -631,6 +687,8 @@ class HTTP::Client
   # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
   #
   # ```
+  # require "http/client"
+  #
   # response = HTTP::Client.exec "GET", "http://www.example.com"
   # response.body # => "..."
   # ```
@@ -645,6 +703,8 @@ class HTTP::Client
   # The response will have its body as an `IO` accessed via `HTTP::Client::Response#body_io`.
   #
   # ```
+  # require "http/client"
+  #
   # HTTP::Client.exec("GET", "http://www.example.com") do |response|
   #   response.body_io.gets # => "..."
   # end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -214,6 +214,8 @@ module HTTP
   # Parse a time string using the formats specified by [RFC 2616](https://tools.ietf.org/html/rfc2616#section-3.3.1)
   #
   # ```
+  # require "http"
+  #
   # HTTP.parse_time("Sun, 14 Feb 2016 21:00:00 GMT")  # => "2016-02-14 21:00:00 UTC"
   # HTTP.parse_time("Sunday, 14-Feb-16 21:00:00 GMT") # => "2016-02-14 21:00:00 UTC"
   # HTTP.parse_time("Sun Feb 14 21:00:00 2016")       # => "2016-02-14 21:00:00 UTC"
@@ -232,6 +234,8 @@ module HTTP
   # timezone `GMT` (interpreted as `UTC`).
   #
   # ```
+  # require "http"
+  #
   # HTTP.format_time(Time.utc(2016, 2, 15)) # => "Mon, 15 Feb 2016 00:00:00 GMT"
   # ```
   #
@@ -244,6 +248,8 @@ module HTTP
   # quoted-string.
   #
   # ```
+  # require "http"
+  #
   # quoted = %q(\"foo\\bar\")
   # HTTP.dequote_string(quoted) # => %q("foo\bar")
   # ```
@@ -269,6 +275,8 @@ module HTTP
   # contains an invalid character.
   #
   # ```
+  # require "http"
+  #
   # string = %q("foo\ bar")
   # io = IO::Memory.new
   # HTTP.quote_string(string, io)
@@ -293,6 +301,8 @@ module HTTP
   # quoted-string. May raise when *string* contains an invalid character.
   #
   # ```
+  # require "http"
+  #
   # string = %q("foo\ bar")
   # HTTP.quote_string(string) # => %q(\"foo\\\ bar\")
   # ```

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -166,6 +166,8 @@ module HTTP
     # no explicit domain restriction and the path `/`.
     #
     # ```
+    # require "http/client"
+    #
     # request = HTTP::Request.new "GET", "/"
     # request.cookies["foo"] = "bar"
     # ```
@@ -178,6 +180,8 @@ module HTTP
     # `ArgumentError` is raised.
     #
     # ```
+    # require "http/client"
+    #
     # response = HTTP::Client::Response.new(200)
     # response.cookies["foo"] = HTTP::Cookie.new("foo", "bar", "/admin", Time.utc + 12.hours, secure: true)
     # ```
@@ -201,6 +205,8 @@ module HTTP
     # Gets the current `HTTP::Cookie` for the given *key* or `nil` if none is set.
     #
     # ```
+    # require "http/client"
+    #
     # request = HTTP::Request.new "GET", "/"
     # request.cookies["foo"]? # => nil
     # request.cookies["foo"] = "bar"

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -81,6 +81,8 @@ module HTTP::FormData
   # Parses a multipart/form-data message, yielding a `FormData::Parser`.
   #
   # ```
+  # require "http"
+  #
   # form_data = "--aA40\r\nContent-Disposition: form-data; name=\"field1\"\r\n\r\nfield data\r\n--aA40--"
   # HTTP::FormData.parse(IO::Memory.new(form_data), "aA40") do |part|
   #   part.name             # => "field1"
@@ -99,6 +101,8 @@ module HTTP::FormData
   # Parses a multipart/form-data message, yielding a `FormData::Parser`.
   #
   # ```
+  # require "http"
+  #
   # headers = HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=aA40"}
   # body = "--aA40\r\nContent-Disposition: form-data; name=\"field1\"\r\n\r\nfield data\r\n--aA40--"
   # request = HTTP::Request.new("POST", "/", headers, body)
@@ -171,6 +175,8 @@ module HTTP::FormData
   # `Builder#finish` is called on the builder when the block returns.
   #
   # ```
+  # require "http"
+  #
   # io = IO::Memory.new
   # HTTP::FormData.build(io, "boundary") do |builder|
   #   builder.field("foo", "bar")
@@ -191,6 +197,8 @@ module HTTP::FormData
   # builder when the block returns.
   #
   # ```
+  # require "http"
+  #
   # io = IO::Memory.new
   # response = HTTP::Server::Response.new io
   # HTTP::FormData.build(response, "boundary") do |builder|

--- a/src/http/formdata/builder.cr
+++ b/src/http/formdata/builder.cr
@@ -4,6 +4,8 @@ module HTTP::FormData
   # ### Example
   #
   # ```
+  # require "http"
+  #
   # io = IO::Memory.new
   # builder = HTTP::FormData::Builder.new(io, "aA47")
   # builder.field("name", "joe")

--- a/src/http/formdata/parser.cr
+++ b/src/http/formdata/parser.cr
@@ -15,6 +15,8 @@ module HTTP::FormData
     # into memory.
     #
     # ```
+    # require "http"
+    #
     # form_data = "--aA40\r\nContent-Disposition: form-data; name=\"field1\"; filename=\"foo.txt\"; size=13\r\nContent-Type: text/plain\r\n\r\nfield data\r\n--aA40--"
     # parser = HTTP::FormData::Parser.new(IO::Memory.new(form_data), "aA40")
     # parser.next do |part|

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -75,6 +75,8 @@ struct HTTP::Headers
   # The *word* is expected to match between word boundaries (i.e. non-alphanumeric chars).
   #
   # ```
+  # require "http/headers"
+  #
   # headers = HTTP::Headers{"Connection" => "keep-alive, Upgrade"}
   # headers.includes_word?("Connection", "Upgrade") # => true
   # ```

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -8,6 +8,8 @@ module HTTP
     # Parses an HTTP query string into a `HTTP::Params`
     #
     # ```
+    # require "http/params"
+    #
     # HTTP::Params.parse("foo=bar&foo=baz&qux=zoo")
     # # => #<HTTP::Params @raw_params = {"foo" => ["bar", "baz"], "qux" => ["zoo"]}>
     # ```
@@ -23,6 +25,8 @@ module HTTP
     # Parses an HTTP query and yields each key-value pair.
     #
     # ```
+    # require "http/params"
+    #
     # query = "foo=bar&foo=baz&qux=zoo"
     # HTTP::Params.parse(query) do |key, value|
     #   # ...
@@ -79,6 +83,8 @@ module HTTP
     # Returns the given key value pairs as a url-encoded HTTP form/query.
     #
     # ```
+    # require "http/params"
+    #
     # HTTP::Params.encode({"foo" => "bar", "baz" => "qux"}) # => "foo=bar&baz=qux"
     # ```
     def self.encode(hash : Hash(String, String))
@@ -92,6 +98,8 @@ module HTTP
     # Returns the given key value pairs as a url-encoded HTTP form/query.
     #
     # ```
+    # require "http/params"
+    #
     # HTTP::Params.encode({foo: "bar", baz: "qux"}) # => "foo=bar&baz=qux"
     # ```
     def self.encode(named_tuple : NamedTuple)
@@ -109,6 +117,8 @@ module HTTP
     # Keys and values are escaped using `URI#escape`.
     #
     # ```
+    # require "http/params"
+    #
     # params = HTTP::Params.build do |form|
     #   form.add "color", "black"
     #   form.add "name", "crystal"
@@ -143,6 +153,8 @@ module HTTP
     # Returns first value for specified param name.
     #
     # ```
+    # require "http/params"
+    #
     # params = HTTP::Params.parse("email=john@example.org")
     # params["email"]              # => "john@example.org"
     # params["non_existent_param"] # KeyError
@@ -296,6 +308,8 @@ module HTTP
     # Serializes to string representation as http url-encoded form.
     #
     # ```
+    # require "http/params"
+    #
     # params = HTTP::Params.parse("item=keychain&item=keynote&email=john@example.org")
     # params.to_s # => "item=keychain&item=keynote&email=john%40example.org"
     # ```

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -160,6 +160,8 @@ class HTTP::Server
   # and port the server listens on.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_tcp("127.0.0.100", 8080) # => Socket::IPAddress.new("127.0.0.100", 8080)
   # ```
@@ -178,6 +180,8 @@ class HTTP::Server
   # returning the local address and port the server listens on.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_tcp(8080) # => Socket::IPAddress.new("127.0.0.1", 8080)
   # ```
@@ -192,6 +196,8 @@ class HTTP::Server
   # and port the server listens on.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_tcp(Socket::IPAddress.new("127.0.0.100", 8080)) # => Socket::IPAddress.new("127.0.0.100", 8080)
   # server.bind_tcp(Socket::IPAddress.new("127.0.0.100", 0))    # => Socket::IPAddress.new("127.0.0.100", 35487)
@@ -208,6 +214,8 @@ class HTTP::Server
   # Returns the `Socket::IPAddress` with the determined port number.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_unused_port # => Socket::IPAddress.new("127.0.0.1", 12345)
   # ```
@@ -218,6 +226,8 @@ class HTTP::Server
   # Creates a `UNIXServer` bound to *path* and adds it as a socket.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_unix "/tmp/my-socket.sock"
   # ```
@@ -232,6 +242,8 @@ class HTTP::Server
   # Creates a `UNIXServer` bound to *address* and adds it as a socket.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind_unix(Socket::UNIXAddress.new("/tmp/my-socket.sock"))
   # ```
@@ -245,6 +257,8 @@ class HTTP::Server
     # The SSL server wraps a `TCPServer` listening on `host:port`.
     #
     # ```
+    # require "http/server"
+    #
     # server = HTTP::Server.new { }
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
@@ -265,6 +279,8 @@ class HTTP::Server
     # The SSL server wraps a `TCPServer` listening on an unused port on *host*.
     #
     # ```
+    # require "http/server"
+    #
     # server = HTTP::Server.new { }
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
@@ -280,6 +296,8 @@ class HTTP::Server
     # The SSL server wraps a `TCPServer` listening on an unused port on *host*.
     #
     # ```
+    # require "http/server"
+    #
     # server = HTTP::Server.new { }
     # context = OpenSSL::SSL::Context::Server.new
     # context.certificate_chain = "openssl.crt"
@@ -295,6 +313,8 @@ class HTTP::Server
   # Returns the effective address it is bound to.
   #
   # ```
+  # require "http/server"
+  #
   # server = HTTP::Server.new { }
   # server.bind("tcp://localhost:80")  # => Socket::IPAddress.new("127.0.0.1", 8080)
   # server.bind("unix:///tmp/server.sock")  # => Socket::UNIXAddress.new("/tmp/server.sock")

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -5,6 +5,8 @@
 # ### A custom handler
 #
 # ```
+# require "http/server/handler"
+#
 # class CustomHandler
 #   include HTTP::Handler
 #

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -20,6 +20,8 @@ class HTTP::WebSocket
   # apart from `wss` and `https` will be treated as the default which is `ws`.
   #
   # ```
+  # require "http/web_socket"
+  #
   # HTTP::WebSocket.new(URI.parse("ws://websocket.example.com/chat"))        # Creates a new WebSocket to `websocket.example.com`
   # HTTP::WebSocket.new(URI.parse("wss://websocket.example.com/chat"))       # Creates a new WebSocket with TLS to `websocket.example.com`
   # HTTP::WebSocket.new(URI.parse("http://websocket.example.com:8080/chat")) # Creates a new WebSocket to `websocket.example.com` on port `8080`
@@ -34,6 +36,8 @@ class HTTP::WebSocket
   # and will raise an exception if the handshake did not complete successfully.
   #
   # ```
+  # require "http/web_socket"
+  #
   # HTTP::WebSocket.new("websocket.example.com", "/chat")            # Creates a new WebSocket to `websocket.example.com`
   # HTTP::WebSocket.new("websocket.example.com", "/chat", tls: true) # Creates a new WebSocket with TLS to `ẁebsocket.example.com`
   # ```

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -17,6 +17,8 @@ class INI
   # Raises a `ParseException` on any errors.
   #
   # ```
+  # require "ini"
+  #
   # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => "1"}}
   # ```
   def self.parse(str) : Hash(String, Hash(String, String))
@@ -59,6 +61,8 @@ class INI
   # Generates an INI-style configuration from a given hash.
   #
   # ```
+  # require "ini"
+  #
   # INI.build({"foo" => {"a" => "1"}}, true) # => "[foo]\na = 1\n\n"
   # ```
   def self.build(ini, space : Bool = false) : String

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -2,6 +2,8 @@
 # and can be used for traversing dynamic or unknown JSON structures.
 #
 # ```
+# require "json"
+#
 # obj = JSON.parse(%({"access": [{"name": "mapping", "speed": "fast"}, {"name": "any", "speed": "slow"}]}))
 # obj["access"][1]["name"].as_s  # => "any"
 # obj["access"][1]["speed"].as_s # => "slow"

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -48,6 +48,8 @@ module JSON
   # To change how individual instance variables are parsed and serialized, the annotation `JSON::Field`
   # can be placed on the instance variable. Annotating property, getter and setter macros is also allowed.
   # ```
+  # require "json"
+  #
   # class A
   #   include JSON::Serializable
   #
@@ -66,6 +68,8 @@ module JSON
   #
   # Deserialization also respects default values of variables:
   # ```
+  # require "json"
+  #
   # struct A
   #   include JSON::Serializable
   #   @a : Int32
@@ -84,6 +88,8 @@ module JSON
   # document will be stored in a `Hash(String, JSON::Any)`. On serialization, any keys inside json_unmapped
   # will be serialized and appended to the current json object.
   # ```
+  # require "json"
+  #
   # struct A
   #   include JSON::Serializable
   #   include JSON::Serializable::Unmapped
@@ -101,6 +107,8 @@ module JSON
   # * **emit_nulls**: if `true`, emits a `null` value for all nilable properties (by default nulls are not emitted)
   #
   # ```
+  # require "json"
+  #
   # @[JSON::Serializable::Options(emit_nulls: true)]
   # class A
   #   include JSON::Serializable

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -48,6 +48,8 @@ module Levenshtein
   # Finds the closest string to a given string amongst many strings.
   #
   # ```
+  # require "levenshtein"
+  #
   # finder = Levenshtein::Finder.new "hallo"
   # finder.test "hay"
   # finder.test "hall"

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -39,6 +39,7 @@ require "crystal/system/mime"
 #
 # ```
 # require "mime"
+#
 # MIME.from_extension?(".cr")     # => nil
 # MIME.extensions("text/crystal") # => Set(String).new
 #
@@ -53,6 +54,8 @@ require "crystal/system/mime"
 # `IO` to read the database from.
 #
 # ```
+# require "mime"
+#
 # # Load user-defined MIME types
 # File.open("~/.mime.types") do |io|
 #   MIME.load_mime_database(io)

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -34,6 +34,8 @@ module MIME
     # Returns the value for the parameter given by *key*. If not found, raises `KeyError`.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.parse("text/plain; charset=UTF-8")["charset"] # => "UTF-8"
     # MIME::MediaType.parse("text/plain; charset=UTF-8")["foo"]     # raises KeyError
     # ```
@@ -44,6 +46,8 @@ module MIME
     # Returns the value for the parameter given by *key*. If not found, returns `nil`.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.parse("text/plain; charset=UTF-8")["charset"]? # => "UTF-8"
     # MIME::MediaType.parse("text/plain; charset=UTF-8")["foo"]?     # => nil
     # ```
@@ -54,6 +58,8 @@ module MIME
     # Sets the value of parameter *key* to the given value.
     #
     # ```
+    # require "mime/media_type"
+    #
     # mime_type = MIME::MediaType.parse("x-application/example")
     # mime_type["foo"] = "bar"
     # mime_type["foo"] # => "bar"
@@ -66,6 +72,8 @@ module MIME
     # Returns the value for the parameter given by *key*, or when not found the value given by *default*.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.parse("x-application/example").fetch("foo", "baz")          # => "baz"
     # MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo", "baz") # => "bar"
     # ```
@@ -76,6 +84,8 @@ module MIME
     # Returns the value for the parameter given by *key*, or when not found calls the given block with the *key*.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.parse("x-application/example").fetch("foo") { |key| key }          # => "foo"
     # MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo") { |key| key } # => "bar"
     # ```
@@ -98,6 +108,8 @@ module MIME
     # First component of `media_type`.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.new("text/plain").type # => "text"
     # MIME::MediaType.new("foo").type        # => "foo"
     # ```
@@ -110,6 +122,8 @@ module MIME
     # Second component of `media_type` or `nil`.
     #
     # ```
+    # require "mime/media_type"
+    #
     # MIME::MediaType.new("text/plain").sub_type # => "plain"
     # MIME::MediaType.new("foo").sub_type        # => nil
     # ```

--- a/src/mime/multipart.cr
+++ b/src/mime/multipart.cr
@@ -14,6 +14,8 @@ module MIME::Multipart
   # block is executing. The IO is closed as soon as the supplied block returns.
   #
   # ```
+  # require "mime/multipart"
+  #
   # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
   # MIME::Multipart.parse(IO::Memory.new(multipart), "aA40") do |headers, io|
   #   headers["Content-Type"] # => "text/plain"
@@ -33,6 +35,8 @@ module MIME::Multipart
   # `nil` is the boundary was not found.
   #
   # ```
+  # require "mime/multipart"
+  #
   # MIME::Multipart.parse_boundary("multipart/mixed; boundary=\"abcde\"") # => "abcde"
   # ```
   def self.parse_boundary(content_type)
@@ -54,6 +58,9 @@ module MIME::Multipart
   # block is executing. The IO is closed as soon as the supplied block returns.
   #
   # ```
+  # require "http"
+  # require "mime/multipart"
+  #
   # headers = HTTP::Headers{"Content-Type" => "multipart/mixed; boundary=aA40"}
   # body = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
   # request = HTTP::Request.new("POST", "/", headers, body)
@@ -93,6 +100,8 @@ module MIME::Multipart
   # Returns a unique string suitable for use as a multipart boundary.
   #
   # ```
+  # require "mime/multipart"
+  #
   # MIME::Multipart.generate_boundary # => "---------------------------dQu6bXHYb4m5zrRC3xPTGwV"
   # ```
   def self.generate_boundary

--- a/src/mime/multipart/builder.cr
+++ b/src/mime/multipart/builder.cr
@@ -4,6 +4,8 @@ module MIME::Multipart
   # ### Example
   #
   # ```
+  # require "mime/multipart"
+  #
   # io = IO::Memory.new # This is a stub. Actually, any IO can be used.
   # multipart = MIME::Multipart::Builder.new(io)
   # multipart.body_part HTTP::Headers{"Content-Type" => "text/plain"}, "hello!"
@@ -25,6 +27,8 @@ module MIME::Multipart
     # boundary parameter added.
     #
     # ```
+    # require "mime/multipart"
+    #
     # io = IO::Memory.new # This is a stub. Actually, any IO can be used.
     # builder = MIME::Multipart::Builder.new(io, "a4VF")
     # builder.content_type("mixed") # => "multipart/mixed; boundary=\"a4VF\""

--- a/src/mime/multipart/parser.cr
+++ b/src/mime/multipart/parser.cr
@@ -4,6 +4,8 @@ module MIME::Multipart
   # ### Example
   #
   # ```
+  # require "mime/multipart"
+  #
   # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
   # parser = MIME::Multipart::Parser.new(IO::Memory.new(multipart), "aA40")
   #
@@ -36,6 +38,8 @@ module MIME::Multipart
     # into memory.
     #
     # ```
+    # require "mime/multipart"
+    #
     # multipart = "--aA40\r\nContent-Type: text/plain\r\n\r\nbody\r\n--aA40--"
     # parser = MIME::Multipart::Parser.new(IO::Memory.new(multipart), "aA40")
     # parser.next do |headers, io|

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -91,6 +91,8 @@ class OptionParser
   # Example:
   #
   # ```
+  # require "option_parser"
+  #
   # parser = OptionParser.new
   # parser.banner = "Usage: crystal [command] [switches] [program file] [--] [arguments]"
   # ```

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -99,6 +99,8 @@ class Socket < IO
   # Connects the socket to a remote host:port.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.tcp(Socket::Family::INET)
   # sock.connect "crystal-lang.org", 80
   # ```
@@ -111,6 +113,8 @@ class Socket < IO
   # Connects the socket to a remote address. Raises if the connection failed.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.unix
   # sock.connect Socket::UNIXAddress.new("/tmp/service.sock")
   # ```
@@ -142,6 +146,8 @@ class Socket < IO
   # Binds the socket to a local address.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.tcp(Socket::Family::INET)
   # sock.bind "localhost", 1234
   # ```
@@ -154,6 +160,8 @@ class Socket < IO
   # Binds the socket on *port* to all local interfaces.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.tcp(Socket::Family::INET6)
   # sock.bind 1234
   # ```
@@ -166,6 +174,8 @@ class Socket < IO
   # Binds the socket to a local address.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.udp(Socket::Family::INET)
   # sock.bind Socket::IPAddress.new("192.168.1.25", 80)
   # ```
@@ -253,6 +263,8 @@ class Socket < IO
   # Sends a message to a previously connected remote address.
   #
   # ```
+  # require "socket"
+  #
   # sock = Socket.udp(Socket::Family::INET)
   # sock.connect("example.com", 2000)
   # sock.send("text message")
@@ -270,6 +282,8 @@ class Socket < IO
   # Sends a message to the specified remote address.
   #
   # ```
+  # require "socket"
+  #
   # server = Socket::IPAddress.new("10.0.3.1", 2022)
   # sock = Socket.udp(Socket::Family::INET)
   # sock.connect("example.com", 2000)
@@ -286,6 +300,8 @@ class Socket < IO
   # Receives a text message from the previously bound address.
   #
   # ```
+  # require "socket"
+  #
   # server = Socket.udp(Socket::Family::INET)
   # server.bind("localhost", 1234)
   #
@@ -304,6 +320,8 @@ class Socket < IO
   # Receives a binary message from the previously bound address.
   #
   # ```
+  # require "socket"
+  #
   # server = Socket.udp(Socket::Family::INET)
   # server.bind("localhost", 1234)
   #

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -64,6 +64,8 @@ class Socket
   #
   # Example:
   # ```
+  # require "socket"
+  #
   # Socket::IPAddress.new("127.0.0.1", 8080)
   # Socket::IPAddress.new("fe80::2ab2:bdff:fe59:8e2c", 1234)
   # ```
@@ -119,6 +121,8 @@ class Socket
     # raised. Domain names will not be resolved.
     #
     # ```
+    # require "socket"
+    #
     # Socket::IPAddress.parse("tcp://127.0.0.1:8080") # => Socket::IPAddress.new("127.0.0.1", 8080)
     # Socket::IPAddress.parse("udp://[::1]:8080")     # => Socket::IPAddress.new("::1", 8080)
     # ```
@@ -293,6 +297,8 @@ class Socket
   #
   # Example:
   # ```
+  # require "socket"
+  #
   # Socket::UNIXAddress.new("/tmp/my.sock")
   # ```
   struct UNIXAddress < Address
@@ -323,6 +329,8 @@ class Socket
     # path.
     #
     # ```
+    # require "socket"
+    #
     # Socket::UNIXAddress.parse("unix:///foo.sock") # => Socket::UNIXAddress.new("/foo.sock")
     # Socket::UNIXAddress.parse("unix://foo.sock")  # => Socket::UNIXAddress.new("foo.sock")
     # ```

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -25,6 +25,8 @@ class Socket
     #
     # Example:
     # ```
+    # require "socket"
+    #
     # addrinfos = Socket::Addrinfo.resolve("example.org", "http", type: Socket::Type::STREAM, protocol: Socket::Protocol::TCP)
     # ```
     def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
@@ -136,6 +138,8 @@ class Socket
     #
     # Example:
     # ```
+    # require "socket"
+    #
     # addrinfos = Socket::Addrinfo.tcp("example.org", 80)
     # ```
     def self.tcp(domain, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
@@ -153,6 +157,8 @@ class Socket
     #
     # Example:
     # ```
+    # require "socket"
+    #
     # addrinfos = Socket::Addrinfo.udp("example.org", 53)
     # ```
     def self.udp(domain, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -60,6 +60,8 @@ class UDPSocket < IPSocket
   # Receives a text message from the previously bound address.
   #
   # ```
+  # require "socket"
+  #
   # server = UDPSocket.new
   # server.bind("localhost", 1234)
   #
@@ -78,6 +80,8 @@ class UDPSocket < IPSocket
   # Receives a binary message from the previously bound address.
   #
   # ```
+  # require "socket"
+  #
   # server = UDPSocket.new
   # server.bind "localhost", 1234
   #

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -49,6 +49,8 @@ class UNIXSocket < Socket
   # Returns a pair of unamed UNIX sockets.
   #
   # ```
+  # require "socket"
+  #
   # left, right = UNIXSocket.pair
   #
   # spawn do

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -25,6 +25,8 @@ class StringPool
   # Returns the size
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # pool.size # => 0
   # ```
@@ -41,6 +43,8 @@ class StringPool
   # Returns `true` if the `StringPool` has no element otherwise returns `false`.
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # pool.empty? # => true
   # pool.get("crystal")
@@ -56,6 +60,8 @@ class StringPool
   # Otherwise a new string is created, put in the pool and returned.
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # ptr = Pointer.malloc(9) { |i| ('a'.ord + i).to_u8 }
   # slice = Slice.new(ptr, 3)
@@ -73,6 +79,8 @@ class StringPool
   # Otherwise a new string is created, put in the pool and returned.
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # pool.get("hey".to_unsafe, 3)
   # pool.size # => 1
@@ -124,6 +132,8 @@ class StringPool
   # Otherwise a new string is created, put in the pool and returned.
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # io = IO::Memory.new "crystal"
   # pool.empty? # => true
@@ -140,6 +150,8 @@ class StringPool
   # Otherwise a new string is created, put in the pool and returned.
   #
   # ```
+  # require "string_pool"
+  #
   # pool = StringPool.new
   # string = "crystal"
   # pool.empty? # => true

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -81,6 +81,8 @@ class StringScanner
   # returns the matched string. Otherwise, the scanner returns `nil`.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("test string")
   # s.scan(/\w+/)   # => "test"
   # s.scan(/\w+/)   # => nil
@@ -96,6 +98,8 @@ class StringScanner
   # advances the scan offset. Returns `nil` if no match.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("test string")
   # s.scan_until(/tr/) # => "test str"
   # s.scan_until(/tr/) # => nil
@@ -153,6 +157,8 @@ class StringScanner
   # offset. The last match is still saved, however.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("this is a string")
   # s.offset = 5
   # s.check(/\w+/) # => "is"
@@ -166,6 +172,8 @@ class StringScanner
   # scan offset. The last match is still saved, however.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("test string")
   # s.check_until(/tr/) # => "test str"
   # s.check_until(/g/)  # => "test string"
@@ -179,6 +187,8 @@ class StringScanner
   # Raises an exception if there was no last match or if there is no subgroup.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("Fri Dec 12 1975 14:39")
   # regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
   # s.scan(regex) # => "Fri Dec 12"
@@ -199,6 +209,8 @@ class StringScanner
   # Returns `nil` if there was no last match or if there is no subgroup.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("Fri Dec 12 1975 14:39")
   # regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
   # s.scan(regex)  # => "Fri Dec 12"
@@ -221,6 +233,8 @@ class StringScanner
   # Returns `true` if the scan offset is at the end of the string.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("this is a string")
   # s.eos?                # => false
   # s.scan(/(\w+\s?){4}/) # => "this is a string"
@@ -256,6 +270,8 @@ class StringScanner
   # Returns the remainder of the string after the scan offset.
   #
   # ```
+  # require "string_scanner"
+  #
   # s = StringScanner.new("this is a string")
   # s.scan(/(\w+\s?){2}/) # => "this is "
   # s.rest                # => "a string"

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -26,6 +26,8 @@ class URI
   # Returns the scheme component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com").scheme           # => "http"
   # URI.parse("mailto:alice@example.com").scheme # => "mailto"
   # ```
@@ -37,6 +39,8 @@ class URI
   # Returns the host component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com").host # => "foo.com"
   # ```
   getter host : String?
@@ -47,6 +51,8 @@ class URI
   # Returns the port component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com:5432").port # => 5432
   # ```
   getter port : Int32?
@@ -57,6 +63,8 @@ class URI
   # Returns the path component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com/bar").path # => "/bar"
   # ```
   getter path : String?
@@ -67,6 +75,8 @@ class URI
   # Returns the query component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com/bar?q=1").query # => "q=1"
   # ```
   getter query : String?
@@ -77,6 +87,8 @@ class URI
   # Returns the user component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://admin:password@foo.com").user # => "admin"
   # ```
   getter user : String?
@@ -87,6 +99,8 @@ class URI
   # Returns the password component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://admin:password@foo.com").password # => "password"
   # ```
   getter password : String?
@@ -97,6 +111,8 @@ class URI
   # Returns the fragment component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://foo.com/bar#section1").fragment # => "section1"
   # ```
   getter fragment : String?
@@ -107,6 +123,8 @@ class URI
   # Returns the opaque component of the URI.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("mailto:alice@example.com").opaque # => "alice@example.com"
   # ```
   getter opaque : String?
@@ -122,6 +140,8 @@ class URI
   # Returns the host part of the URI and unwrap brackets for IPv6 addresses.
   #
   # ```
+  # require "uri"
+  #
   # URI.parse("http://[::1]/bar").hostname # => "::1"
   # URI.parse("http://[::1]/bar").host     # => "[::1]"
   # ```
@@ -132,6 +152,8 @@ class URI
   # Returns the full path of this URI.
   #
   # ```
+  # require "uri"
+  #
   # uri = URI.parse "http://foo.com/posts?id=30&limit=5#time=1305298413"
   # uri.full_path # => "/posts?id=30&limit=5"
   # ```
@@ -219,6 +241,8 @@ class URI
   # e.g. `application/x-www-form-urlencoded` wants this replace.
   #
   # ```
+  # require "uri"
+  #
   # URI.unescape("%27Stop%21%27%20said%20Fred")                  # => "'Stop!' said Fred"
   # URI.unescape("%27Stop%21%27+said+Fred", plus_to_space: true) # => "'Stop!' said Fred"
   # ```
@@ -260,6 +284,8 @@ class URI
   # encoded to `'%2B'`. e.g. `application/x-www-form-urlencoded` want this replace.
   #
   # ```
+  # require "uri"
+  #
   # URI.escape("'Stop!' said Fred")                      # => "%27Stop%21%27%20said%20Fred"
   # URI.escape("'Stop!' said Fred", space_to_plus: true) # => "%27Stop%21%27+said+Fred"
   # ```
@@ -274,6 +300,8 @@ class URI
   # `true` are not escaped, other characters are escaped.
   #
   # ```
+  # require "uri"
+  #
   # # Escape URI path
   # URI.escape("/foo/file?(1).txt") do |byte|
   #   URI.unreserved?(byte) || byte.chr == '/'
@@ -333,6 +361,8 @@ class URI
   # the provided username and password.
   #
   # ```
+  # require "uri"
+  #
   # uri = URI.parse "http://admin:password@foo.com"
   # uri.userinfo # => "admin:password"
   # ```
@@ -507,6 +537,8 @@ class URI
   # otherwise returns `nil`.
   #
   # ```
+  # require "uri"
+  #
   # URI.default_port "http"  # => 80
   # URI.default_port "ponzi" # => nil
   # ```
@@ -520,6 +552,8 @@ class URI
   # *scheme*, if any, will be unregistered.
   #
   # ```
+  # require "uri"
+  #
   # URI.set_default_port "ponzi", 9999
   # ```
   def self.set_default_port(scheme : String, port : Int32?) : Nil

--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -1,6 +1,8 @@
 # Weak Reference class that allows a referenced object to be garbage-collected.
 #
 # ```
+# require "weak_ref"
+#
 # ref = WeakRef.new("oof".reverse)
 # p ref.value # => "foo"
 # GC.collect

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -496,6 +496,7 @@ struct XML::Node
   #
   # ```
   # require "xml"
+  #
   # doc = XML.parse("<person></person>")
   #
   # doc.xpath_bool("count(//person) > 0") # => true
@@ -507,6 +508,10 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `Float64`.
   #
   # ```
+  # require "xml"
+  #
+  # doc = XML.parse("<person></person>")
+  #
   # doc.xpath_float("count(//person)") # => 1.0
   # ```
   def xpath_float(path, namespaces = nil, variables = nil)
@@ -516,6 +521,10 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `NodeSet`.
   #
   # ```
+  # require "xml"
+  #
+  # doc = XML.parse("<person></person>")
+  #
   # nodes = doc.xpath_nodes("//person")
   # nodes.class       # => XML::NodeSet
   # nodes.map(&.name) # => ["person"]
@@ -528,6 +537,10 @@ struct XML::Node
   # or `nil` if not found
   #
   # ```
+  # require "xml"
+  #
+  # doc = XML.parse("<person></person>")
+  #
   # doc.xpath_node("//person")  # => #<XML::Node:0x2013e80 name="person">
   # doc.xpath_node("//invalid") # => nil
   # ```
@@ -538,6 +551,10 @@ struct XML::Node
   # Searches this node for XPath *path* and restricts the return type to `String`.
   #
   # ```
+  # require "xml"
+  #
+  # doc = XML.parse("<person></person>")
+  #
   # doc.xpath_string("string(/persons/person[1])")
   # ```
   def xpath_string(path, namespaces = nil, variables = nil)

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -56,6 +56,8 @@ module YAML::Schema::Core
   # the string had a plain style.
   #
   # ```
+  # require "yaml"
+  #
   # YAML::Schema::Core.parse_scalar("hello") # => "hello"
   # YAML::Schema::Core.parse_scalar("1.2")   # => 1.2
   # YAML::Schema::Core.parse_scalar("false") # => false
@@ -108,6 +110,8 @@ module YAML::Schema::Core
   # with a plain style, according to the core schema.
   #
   # ```
+  # require "yaml"
+  #
   # YAML::Schema::Core.reserved_string?("hello") # => false
   # YAML::Schema::Core.reserved_string?("1.2")   # => true
   # YAML::Schema::Core.reserved_string?("false") # => true

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -48,6 +48,8 @@ module YAML
   # To change how individual instance variables are parsed and serialized, the annotation `YAML::Field`
   # can be placed on the instance variable. Annotating property, getter and setter macros is also allowed.
   # ```
+  # require "yaml"
+  #
   # class A
   #   include YAML::Serializable
   #
@@ -65,6 +67,8 @@ module YAML
   #
   # Deserialization also respects default values of variables:
   # ```
+  # require "yaml"
+  #
   # struct A
   #   include YAML::Serializable
   #   @a : Int32
@@ -83,6 +87,8 @@ module YAML
   # document will be stored in a `Hash(String, YAML::Any)`. On serialization, any keys inside yaml_unmapped
   # will be serialized appended to the current yaml object.
   # ```
+  # require "yaml"
+  #
   # struct A
   #   include YAML::Serializable
   #   include YAML::Serializable::Unmapped
@@ -100,6 +106,8 @@ module YAML
   # * **emit_nulls**: if `true`, emits a `null` value for all nilable properties (by default nulls are not emitted)
   #
   # ```
+  # require "yaml"
+  #
   # @[YAML::Serializable::Options(emit_nulls: true)]
   # class A
   #   include YAML::Serializable

--- a/src/zip/file.cr
+++ b/src/zip/file.cr
@@ -6,6 +6,8 @@ require "./file_info"
 # ### Example
 #
 # ```
+# require "zip"
+#
 # Zip::File.open("./file.zip") do |file|
 #   # Iterate through all entries printing their filename and contents
 #   file.entries.each do |entry|

--- a/src/zip/reader.cr
+++ b/src/zip/reader.cr
@@ -11,6 +11,8 @@ require "./file_info"
 # ### Example
 #
 # ```
+# require "zip"
+#
 # File.open("./file.zip") do |file|
 #   Zip::Reader.open(file) do |zip|
 #     zip.each_entry do |entry|

--- a/src/zip/writer.cr
+++ b/src/zip/writer.cr
@@ -5,6 +5,8 @@ require "./file_info"
 # ### Example
 #
 # ```
+# require "zip"
+#
 # File.open("./file.zip", "w") do |file|
 #   Zip::Writer.open(file) do |zip|
 #     # Add a file with a String content


### PR DESCRIPTION
The purpose of this PR is to add missing `require` statements in examples, it addresses this [issue](https://github.com/crystal-lang/crystal/issues/7487)

I went through the current docs (0.27.2) and check all the provided examples.


### Issues
Iterator example: 
[link](https://github.com/crystal-lang/crystal/blob/master/src/iterator.cr#L180)
```
array_of_iters = [[1], [2, 3], [4, 5, 6]]
iter = Iterator(Int32).chain array_of_iters
ter.next # => 1
iter.next # => 2
iter.next # => 3
iter.next # => 4
```

returns this error:
```
instantiating 'Iterator::ChainsAll(Array(Int32), Int32)#next()'
src/iterator.cr:207: undefined method 'next' for Array(Int32)
```