### PR TITLE
 Don't include private constants in the docs 

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -83,8 +83,8 @@ describe Doc::Generator do
     end
   end
 
-  describe "constants" do
-    it "should be empty when there are only private constants" do
+  describe "collect_constants" do
+    it "returns empty array when constants are private" do
       program = Program.new
       generator = Doc::Generator.new program, ["foo"], ".", "html", nil
       doc_type = Doc::Type.new generator, program
@@ -94,7 +94,7 @@ describe Doc::Generator do
       constant.add_location Location.new "foo", 1, 1
       program.types[constant.name] = constant
 
-      generator.constants.should be_empty
+      generator.collect_constants(doc_type).should be_empty
     end
   end
 end

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -82,7 +82,7 @@ describe Doc::Generator do
       generator.must_include_toplevel?(doc_type).should be_false
     end
   end
-  
+
   describe "constants" do
     it "should be empty when there are only private constants" do
       program = Program.new

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -82,4 +82,19 @@ describe Doc::Generator do
       generator.must_include_toplevel?(doc_type).should be_false
     end
   end
+  
+  describe "constants" do
+    it "should be empty when there are only private constants" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      doc_type = Doc::Type.new generator, program
+
+      constant = Const.new program, program, "Foo", 1.int32
+      constant.private = true
+      constant.add_location Location.new "foo", 1, 1
+      program.types[constant.name] = constant
+
+      generator.constants.should be_empty
+    end
+  end
 end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -261,7 +261,7 @@ class Crystal::Doc::Generator
     types = [] of Constant
 
     parent.type.types?.try &.each_value do |type|
-      if type.is_a?(Const) && must_include? type
+      if type.is_a?(Const) && must_include?(type) && !type.private?
         types << Constant.new(self, parent, type)
       end
     end


### PR DESCRIPTION
This no longer includes private constants in the documentation, just like private methods.