### PR TITLE
Restriction update: generic vs path - specs

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -63,8 +63,8 @@ describe "Restrictions" do
   end
 
   describe "restriction_of?" do
-    describe "Metaclass vs Metaclass-with-free-vars" do
-      it "inserts Metaclass before Metaclass-with-free-vars" do
+    describe "Metaclass vs Metaclass" do
+      it "inserts typed Metaclass before untyped Metaclass" do
         assert_type(%(
           def foo(a : T.class) forall T
             1
@@ -78,7 +78,7 @@ describe "Restrictions" do
           )) { bool }
       end
 
-      it "keeps Metaclass before Metaclass-with-free-vars" do
+      it "keeps typed Metaclass before untyped Metaclass" do
         assert_type(%(
           def foo(a : Int32.class)
             true
@@ -89,6 +89,138 @@ describe "Restrictions" do
           end
 
           foo(Int32)
+          )) { bool }
+      end
+    end
+
+    describe "Path vs Path" do
+      it "inserts typed Path before untyped Path" do
+        assert_type(%(
+          def foo(a : T) forall T
+            1
+          end
+
+          def foo(a : Int32)
+            true
+          end
+
+          foo(1)
+          )) { bool }
+      end
+
+      it "keeps typed Path before untyped Path" do
+        assert_type(%(
+          def foo(a : Int32)
+            true
+          end
+
+          def foo(a : T) forall T
+            1
+          end
+
+          foo(1)
+          )) { bool }
+      end
+    end
+
+    describe "Generic vs Path" do
+      it "inserts typed Generic before untyped Path" do
+        assert_type(%(
+          def foo(a : T) forall T
+            1
+          end
+
+          def foo(a : Array(Int32))
+            true
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+
+      it "keeps typed Generic before untyped Path" do
+        assert_type(%(
+          def foo(a : Array(Int32))
+            true
+          end
+
+          def foo(a : T) forall T
+            1
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+
+      it "inserts untyped Generic before untyped Path" do
+        assert_type(%(
+          def foo(a : T) forall T
+            1
+          end
+
+          def foo(a : Array(T)) forall T
+            true
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+
+      it "inserts untyped Generic before untyped Path (2)" do
+        assert_type(%(
+          def foo(a : T) forall T
+            1
+          end
+
+          def foo(a : Array)
+            true
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+
+      it "keeps untyped Generic before untyped Path" do
+        assert_type(%(
+          def foo(a : Array(T)) forall T
+            true
+          end
+
+          def foo(a : T) forall T
+            1
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+    end
+
+    describe "Generic vs Generic" do
+      it "inserts typed Generic before untyped Generic" do
+        assert_type(%(
+          def foo(a : Array(T)) forall T
+            1
+          end
+
+          def foo(a : Array(Int32))
+            true
+          end
+
+          foo(Array(Int32).new)
+          )) { bool }
+      end
+
+      it "keeps typed Generic before untyped Generic" do
+        assert_type(%(
+          def foo(a : Array(Int32))
+            true
+          end
+
+          def foo(a : Array(T)) forall T
+            1
+          end
+
+          foo(Array(Int32).new)
           )) { bool }
       end
     end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -261,6 +261,13 @@ module Crystal
         end
       end
 
+      # ```
+      # def foo(param : T) forall T
+      # end
+      #
+      # def foo(param : Array(Foo))
+      # end
+      # ```
       false
     end
 
@@ -281,6 +288,16 @@ module Crystal
 
   class Generic
     def restriction_of?(other : Path, owner)
+      # ```
+      # def foo(param : Array(T)) forall T
+      # end
+      #
+      # def foo(param : Int32)
+      # end
+      # ```
+      #
+      # Here, self is `Array`, other is `Int32`
+
       self_type = owner.lookup_type?(self)
       if self_type
         other_type = owner.lookup_path(other)
@@ -289,7 +306,20 @@ module Crystal
         end
       end
 
-      false
+      # `Array(T)` is always more strict than `Foo`
+      #
+      # Useful in cases where `Array(T)` overload must be checked before
+      # `T` overload:
+      # ```
+      # def foo(param : T) forall T
+      # end
+      #
+      # def foo(param : Array(T)) forall T
+      # end
+      #
+      # foo([1])
+      # ```
+      true
     end
 
     def restriction_of?(other : Generic, owner)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -372,24 +372,7 @@ module Crystal
 
   class Metaclass
     def restriction_of?(other : Metaclass, owner)
-      self_type = owner.lookup_type?(self)
-      other_type = owner.lookup_type?(other)
-      if self_type && other_type
-        self_type.restriction_of?(other_type, owner)
-      elsif self_type
-        # `other` cannot resolve to a type, it's probably a free variable like:
-        #
-        # ```
-        # def foo(param : T.class) forall T
-        # end
-        #
-        # def foo(param : Int32.class)
-        # end
-        # ```
-        true
-      else
-        false
-      end
+      name.restriction_of?(other.name, owner)
     end
   end
 


### PR DESCRIPTION
* Makes this work:
```cr
def foo(a : T) forall T
  1
end

def foo(a : Array(T)) forall T
  true
end

foo(Array(Int32).new) # => true
```
* Adds some restriction specs for Path vs Path & Generic vs path
* Simplify Metaclass vs Metaclass restriction implementation