### PR TITLE
Remove Slice#pointer

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -4,7 +4,7 @@ describe "Slice" do
   it "gets pointer and size" do
     pointer = Pointer.malloc(1, 0)
     slice = Slice.new(pointer, 1)
-    slice.pointer(0).should eq(pointer)
+    slice.to_unsafe.should eq(pointer)
     slice.size.should eq(1)
   end
 
@@ -75,12 +75,6 @@ describe "Slice" do
   it "does to_s for bytes" do
     slice = Bytes[1, 2, 3]
     slice.to_s.should eq("Bytes[1, 2, 3]")
-  end
-
-  it "gets pointer" do
-    slice = Slice.new(4, 0)
-    expect_raises(IndexError) { slice.pointer(5) }
-    expect_raises(IndexError) { slice.pointer(-1) }
   end
 
   it "does copy_from pointer" do

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -49,8 +49,8 @@ describe StringPool do
     pool = StringPool.new
     slice = Bytes.new(3, 'a'.ord.to_u8)
 
-    s1 = pool.get(slice.pointer(slice.size), slice.size)
-    s2 = pool.get(slice.pointer(slice.size), slice.size)
+    s1 = pool.get(slice.to_unsafe, slice.size)
+    s2 = pool.get(slice.to_unsafe, slice.size)
 
     s1.should eq("aaa")
     s2.should eq("aaa")

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -202,7 +202,7 @@ module Base64
   private def to_base64(data, chars, pad = false)
     bytes = chars.to_unsafe
     size = data.size
-    cstr = data.pointer(size)
+    cstr = data.to_unsafe
     endcstr = cstr + size - size % 3
     while cstr < endcstr
       n = Intrinsics.bswap32(cstr.as(UInt32*).value)
@@ -234,7 +234,7 @@ module Base64
   private def from_base64(data)
     size = data.size
     dt = DECODE_TABLE.to_unsafe
-    cstr = data.pointer(size)
+    cstr = data.to_unsafe
     start_cstr = cstr
     while (size > 0) && (sym = cstr[size - 1]) && (sym == NL || sym == NR || sym == PAD)
       size -= 1

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -53,7 +53,7 @@ class HTTP::WebSocket::Protocol
       return if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)
-      (@buffer + @pos).copy_from(slice.pointer(count), count)
+      (@buffer + @pos).copy_from(slice.to_unsafe, count)
       @pos += count
 
       if @pos == @buffer.size

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -72,7 +72,7 @@ module IO::Buffered
     end
 
     to_read = Math.min(count, @in_buffer_rem.size)
-    slice.copy_from(@in_buffer_rem.pointer(to_read), to_read)
+    slice.copy_from(@in_buffer_rem.to_unsafe, to_read)
     @in_buffer_rem += to_read
     to_read
   end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -105,7 +105,7 @@ abstract class OpenSSL::SSL::Socket < IO
     count = slice.size
     return 0 if count == 0
 
-    LibSSL.ssl_read(@ssl, slice.pointer(count), count).tap do |bytes|
+    LibSSL.ssl_read(@ssl, slice.to_unsafe, count).tap do |bytes|
       if bytes <= 0 && !LibSSL.ssl_get_error(@ssl, bytes).zero_return?
         raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_read")
       end
@@ -118,7 +118,7 @@ abstract class OpenSSL::SSL::Socket < IO
     return if slice.empty?
 
     count = slice.size
-    bytes = LibSSL.ssl_write(@ssl, slice.pointer(count), count)
+    bytes = LibSSL.ssl_write(@ssl, slice.to_unsafe, count)
     unless bytes > 0
       raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_write")
     end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -513,7 +513,8 @@ class Regex
       capture_number = (name_table[capture_offset].to_u16 << 8) | name_table[capture_offset + 1].to_u16
 
       name_offset = capture_offset + 2
-      name = String.new((name_table + name_offset).pointer(name_entry_size - 3))
+      checked = name_table[name_offset, name_entry_size - 3]
+      name = String.new(checked.to_unsafe)
 
       lookup[capture_number] = name
     end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -147,9 +147,7 @@ struct Slice(T)
   # slice2 # => Slice[12, 13, 14]
   # ```
   def +(offset : Int)
-    unless 0 <= offset <= size
-      raise IndexError.new
-    end
+    check_size(offset)
 
     Slice.new(@pointer + offset, @size - offset, read_only: @read_only)
   end
@@ -245,14 +243,6 @@ struct Slice(T)
     self
   end
 
-  def pointer(size)
-    unless 0 <= size <= @size
-      raise IndexError.new
-    end
-
-    @pointer
-  end
-
   def shuffle!(random = Random::DEFAULT)
     check_writable
 
@@ -299,12 +289,15 @@ struct Slice(T)
 
   def copy_from(source : Pointer(T), count)
     check_writable
+    check_size(count)
 
-    pointer(count).copy_from(source, count)
+    @pointer.copy_from(source, count)
   end
 
   def copy_to(target : Pointer(T), count)
-    pointer(count).copy_to(target, count)
+    check_size(count)
+
+    @pointer.copy_to(target, count)
   end
 
   # Copies the contents of this slice into *target*.
@@ -321,8 +314,9 @@ struct Slice(T)
   # ```
   def copy_to(target : self)
     target.check_writable
+    raise IndexError.new if target.size < size
 
-    @pointer.copy_to(target.pointer(size), size)
+    @pointer.copy_to(target.to_unsafe, size)
   end
 
   # Copies the contents of *source* into this slice.
@@ -335,12 +329,13 @@ struct Slice(T)
 
   def move_from(source : Pointer(T), count)
     check_writable
+    check_size(count)
 
-    pointer(count).move_from(source, count)
+    @pointer.move_from(source, count)
   end
 
   def move_to(target : Pointer(T), count)
-    pointer(count).move_to(target, count)
+    @pointer.move_to(target, count)
   end
 
   # Moves the contents of this slice into *target*. *target* and `self` may
@@ -360,8 +355,9 @@ struct Slice(T)
   # See also: `Pointer#move_to`.
   def move_to(target : self)
     target.check_writable
+    raise IndexError.new if target.size < size
 
-    @pointer.move_to(target.pointer(size), size)
+    @pointer.move_to(target.to_unsafe, size)
   end
 
   # Moves the contents of *source* into this slice. *source* and `self` may
@@ -565,6 +561,12 @@ struct Slice(T)
 
   protected def check_writable
     raise "Can't write to read-only Slice" if @read_only
+  end
+
+  private def check_size(count : Int)
+    unless 0 <= count <= size
+      raise IndexError.new
+    end
   end
 end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -152,7 +152,7 @@ class String
   # String.new(slice) # => "abcd"
   # ```
   def self.new(slice : Bytes)
-    new(slice.pointer(slice.size), slice.size)
+    new(slice.to_unsafe, slice.size)
   end
 
   # Creates a new `String` from the given *bytes*, which are encoded in the given *encoding*.

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -70,7 +70,7 @@ class StringPool
   # pool.empty? # => false
   #  ```
   def get(slice : Bytes)
-    get slice.pointer(slice.size), slice.size
+    get slice.to_unsafe, slice.size
   end
 
   # Returns a `String` with the contents given by the pointer *str* of size *len*.


### PR DESCRIPTION
Issue: https://github.com/crystal-lang/crystal/issues/7004
As discussed with @straight-shoota and @asterite `Slice#pointer` is a confusing method and it should be removed.
 The code was refactored to keep the verification logic in `Slice` mainly for copy methods.

I was thinking if we should add a deprecation warning or just mention this as a breaking change in case someone is using `Slice#pointer`.