### PR TITLE
Disallow '!' or '?' at the end of the LHS in an assignment

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -152,6 +152,8 @@ module Crystal
     it_parses "@a, b = 1, 2", MultiAssign.new(["@a".instance_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
     it_parses "@@a, b = 1, 2", MultiAssign.new(["@@a".class_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
+    assert_syntax_error "b? = 1", "unexpected token: ="
+    assert_syntax_error "b! = 1", "unexpected token: ="
     assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"
 
     assert_syntax_error "1 == 2, a = 4"

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -229,7 +229,7 @@ class Crystal::Command
       end
     end
 
-    if time?
+    if time
       puts "Execute: #{elapsed_time}"
     end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -206,7 +206,7 @@ class Crystal::Command
   end
 
   private def execute(output_filename, run_args, compiler, *, error_on_exit = false)
-    time? = @time && !@progress_tracker.stats?
+    time = @time && !@progress_tracker.stats?
     status, elapsed_time = @progress_tracker.stage("Execute") do
       begin
         elapsed = Time.measure do

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -315,7 +315,6 @@ module Crystal
           break
         when :"="
           slash_is_regex!
-
           if atomic.is_a?(Call) && atomic.name == "[]"
             next_token_skip_space_or_newline
 
@@ -331,6 +330,11 @@ module Crystal
 
             if atomic.is_a?(Var) && atomic.name == "self"
               raise "can't change the value of self", location
+            end
+
+            if atomic.is_a?(Call) && (atomic.name.ends_with?('?') ||
+               atomic.name.ends_with?('!'))
+              raise "unexpected token: =", location
             end
 
             atomic = Var.new(atomic.name).at(atomic) if atomic.is_a?(Call)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -333,7 +333,7 @@ module Crystal
             end
 
             if atomic.is_a?(Call) && (atomic.name.ends_with?('?') ||
-               atomic.name.ends_with?('!'))
+               (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
               raise "unexpected token: =", location
             end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -332,8 +332,7 @@ module Crystal
               raise "can't change the value of self", location
             end
 
-            if atomic.is_a?(Call) && (atomic.name.ends_with?('?') ||
-               (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
+            if atomic.is_a?(Call) && (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
               raise "unexpected token: =", location
             end
 


### PR DESCRIPTION
Issue: https://github.com/crystal-lang/crystal/issues/6685
This affects mainly variable defined in the top level, instance and class variable raise already an exception.

I'm curious how do you guys debug the compiler, I'm still new here and I was just adding `puts` statement for debugging, is there any trick to know that could make me or someone else more productive in the future?