### PR TITLE
Add deprecation notice for Time.now

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -524,8 +524,22 @@ struct Time
     utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
   end
 
-  def self.now(*args)
-    {% raise "`Time.now` has been removed in Crystal 0.28.0, use `Time.local` or `Time.utc` instead.\n\nMore information on this change: https://github.com/crystal-lang/crystal/issues/5346" %}
+  # Creates a new `Time` instance representing the current time from the
+  # system clock observed in *location* (defaults to local time zone).
+  #
+  # DEPRECATED: `Time.now` is deprecated, use `Time.local` or `Time.utc` instead.
+  # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
+  def self.now(location : Location = Location.local) : Time
+    local(location)
+  end
+
+  # Creates a new `Time` instance representing the current time from the
+  # system clock in UTC.
+  #
+  # DEPRECATED: `Time.utc_now` is deprecated, use `Time.utc` instead.
+  # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
+  def self.utc_now : Time
+    utc
   end
 
   # Creates a new `Time` instance with the same local date-time representation

--- a/src/time.cr
+++ b/src/time.cr
@@ -526,24 +526,14 @@ struct Time
 
   # Creates a new `Time` instance representing the current time from the
   # system clock observed in *location* (defaults to local time zone).
-  #
-  # DEPRECATED: `Time.now` is deprecated, use `Time.local` or `Time.utc` instead.
-  # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
-  {% if compare_versions(Crystal::VERSION, "0.28.0-0") >= 0 %}
-    @[Deprecated("`Time.now` is deprecated, use `Time.local` or `Time.utc` instead.")]
-  {% end %}
+  @[Deprecated("`Time.now` is deprecated, use `Time.local` or `Time.utc` instead.")]
   def self.now(location : Location = Location.local) : Time
     local(location)
   end
 
   # Creates a new `Time` instance representing the current time from the
   # system clock in UTC.
-  #
-  # DEPRECATED: `Time.utc_now` is deprecated, use `Time.utc` instead.
-  # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
-  {% if compare_versions(Crystal::VERSION, "0.28.0-0") >= 0 %}
-    @[Deprecated("`Time.utc_now` is deprecated, use `Time.utc` instead.")]
-  {% end %}
+  @[Deprecated("`Time.utc_now` is deprecated, use `Time.utc` instead.")]
   def self.utc_now : Time
     utc
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -529,6 +529,9 @@ struct Time
   #
   # DEPRECATED: `Time.now` is deprecated, use `Time.local` or `Time.utc` instead.
   # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
+  {% if compare_versions(Crystal::VERSION, "0.28.0-0") >= 0 %}
+    @[Deprecated("`Time.now` is deprecated, use `Time.local` or `Time.utc` instead.")]
+  {% end %}
   def self.now(location : Location = Location.local) : Time
     local(location)
   end
@@ -538,6 +541,9 @@ struct Time
   #
   # DEPRECATED: `Time.utc_now` is deprecated, use `Time.utc` instead.
   # More information on this change: https://github.com/crystal-lang/crystal/issues/5346
+  {% if compare_versions(Crystal::VERSION, "0.28.0-0") >= 0 %}
+    @[Deprecated("`Time.utc_now` is deprecated, use `Time.utc` instead.")]
+  {% end %}
   def self.utc_now : Time
     utc
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -526,14 +526,14 @@ struct Time
 
   # Creates a new `Time` instance representing the current time from the
   # system clock observed in *location* (defaults to local time zone).
-  @[Deprecated("`Time.now` is deprecated, use `Time.local` or `Time.utc` instead.")]
+  @[Deprecated("Use `Time.local` or `Time.utc` instead.")]
   def self.now(location : Location = Location.local) : Time
     local(location)
   end
 
   # Creates a new `Time` instance representing the current time from the
   # system clock in UTC.
-  @[Deprecated("`Time.utc_now` is deprecated, use `Time.utc` instead.")]
+  @[Deprecated("Use `Time.utc` instead.")]
   def self.utc_now : Time
     utc
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -524,6 +524,10 @@ struct Time
     utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
   end
 
+  def self.now(*args)
+    {% raise "`Time.now` has been removed in Crystal 0.28.0, use `Time.local` or `Time.utc` instead.\n\nMore information on this change: https://github.com/crystal-lang/crystal/issues/5346" %}
+  end
+
   # Creates a new `Time` instance with the same local date-time representation
   # (wall clock) in a different *location*.
   #


### PR DESCRIPTION
This is a follow up on #5346 and adds the following error message for `Time.now`, guiding the user to fixing this breaking change:

```
`Time.now` has been removed in Crystal 0.28.0, use `Time.local` or `Time.utc` instead.

More information on this change: https://github.com/crystal-lang/crystal/issues/5346
```