### PR TITLE
Fix Slice#clone for non-primitive types and deep copy

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -413,6 +413,11 @@ describe "Slice" do
     slice = Slice.new(6, read_only: true) { |i| i + 1 }
     slice[2..4].read_only?.should be_true
   end
+
+  it "#clone non-primitive" do
+    slice = Slice["abc", "a"]
+    slice.clone.should eq slice
+  end
 end
 
 private def itself(*args)

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -414,9 +414,46 @@ describe "Slice" do
     slice[2..4].read_only?.should be_true
   end
 
-  it "#clone non-primitive" do
-    slice = Slice["abc", "a"]
-    slice.clone.should eq slice
+  describe "#clone" do
+    it "clones primitive" do
+      slice = Slice[1, 2]
+      slice.clone.should eq slice
+    end
+
+    it "clones non-primitive" do
+      slice = Slice["abc", "a"]
+      slice.clone.should eq slice
+    end
+
+    it "buffer copy" do
+      slice = Slice["foo"]
+      copy = slice.clone
+      slice[0] = "bar"
+      copy.should_not eq slice
+    end
+
+    it "deep copy" do
+      slice = Slice[["foo"]]
+      copy = slice.clone
+      slice[0] << "bar"
+      copy.should_not eq slice
+    end
+  end
+
+  describe "#dup" do
+    it "buffer copy" do
+      slice = Slice["foo"]
+      copy = slice.dup
+      slice[0] = "bar"
+      copy.should_not eq slice
+    end
+
+    it "don't deep copy" do
+      slice = Slice[["foo"]]
+      copy = slice.dup
+      slice[0] << "bar"
+      copy.should eq slice
+    end
   end
 end
 

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -119,9 +119,23 @@ struct Slice(T)
     new(size, read_only: read_only) { value }
   end
 
-  # Returns a copy of this slice.
-  # This method allocates memory for the slice copy.
+  # Returns a deep copy of this slice.
+  #
+  # This method allocates memory for the slice copy and stores the return values
+  # from calling `#clone` on each item.
   def clone
+    pointer = Pointer(T).malloc(size)
+    copy = self.class.new(pointer, size)
+    each_with_index do |item, i|
+      copy[i] = item.clone
+    end
+    copy
+  end
+
+  # Returns a shallow copy of this slice.
+  #
+  # This method allocates memory for the slice copy and duplicates the values.
+  def dup
     pointer = Pointer(T).malloc(size)
     copy = self.class.new(pointer, size)
     copy.copy_from(self)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -122,7 +122,8 @@ struct Slice(T)
   # Returns a copy of this slice.
   # This method allocates memory for the slice copy.
   def clone
-    copy = self.class.new(size)
+    pointer = Pointer(T).malloc(size)
+    copy = self.class.new(pointer, size)
     copy.copy_from(self)
     copy
   end


### PR DESCRIPTION
Fixes `Slice#clone` for non-primitive types (#7590) and fixes `Sice#clone` to perform a deep copy, `Slice#dup` a memory copy.