### PR TITLE
Fix typo 'intepret_array_or_tuple_method'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2101,7 +2101,7 @@
 * Added `Array#fill` (thanks @Exilor).
 * Added `Array#uniq`.
 * Optimized `File.read_lines`.
-* Allow any expression inside `{% ... %}` so that you can intepret code without outputting the result.
+* Allow any expression inside `{% ... %}` so that you can interpret code without outputting the result.
 * Allow `\` at the end of a line.
 * Allow using `if` and `unless` inside macro expressions.
 * Allow marking a `fun/def` as `@[Raises]` (useful when a function can potentially raise from a callback).

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -790,7 +790,7 @@ module Crystal
           self
         end
       else
-        value = intepret_array_or_tuple_method(self, ArrayLiteral, method, args, block, interpreter)
+        value = interpret_array_or_tuple_method(self, ArrayLiteral, method, args, block, interpreter)
         value || super
       end
     end
@@ -1002,7 +1002,7 @@ module Crystal
 
   class TupleLiteral
     def interpret(method, args, block, interpreter)
-      value = intepret_array_or_tuple_method(self, TupleLiteral, method, args, block, interpreter)
+      value = interpret_array_or_tuple_method(self, TupleLiteral, method, args, block, interpreter)
       value || super
     end
   end
@@ -2063,7 +2063,7 @@ module Crystal
   end
 end
 
-private def intepret_array_or_tuple_method(object, klass, method, args, block, interpreter)
+private def interpret_array_or_tuple_method(object, klass, method, args, block, interpreter)
   case method
   when "any?"
     object.interpret_argless_method(method, args) do


### PR DESCRIPTION
A few areas in the compiler had a typo in the word 'interpret'.