### PR TITLE
feature(time): add Time.now_seconds class method

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -741,6 +741,11 @@ struct Time
     )
   end
 
+  # Returns an epoch current timestamp in second
+  def self.now_seconds : Int64
+    (Time.utc - Time::UNIX_EPOCH).to_i
+  end
+
   # Returns a copy of `self` with time-of-day components (hour, minute, second,
   # nanoseconds) set to zero.
   #


### PR DESCRIPTION
Hi, added Time.now_seconds method. JS's Time.now like method, that give the current ts in second.
Didn't add spec since it uses Time.utc and Time::Span which already have specs.