### PR TITLE
Quality checks / Deprecated methods

### DIFF
--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -24,7 +24,7 @@ _crystal()
                 COMPREPLY=( $(compgen -f ${cur}) )
             fi
             ;;
-        compile)
+        build)
             if [[ ${cur} == -* ]] ; then
                 local opts="--cross-compile --debug --emit --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --help"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -26,7 +26,7 @@ _crystal()
             ;;
         build)
             if [[ ${cur} == -* ]] ; then
-                local opts="--cross-compile --debug --emit --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --help"
+                local opts="--cross-compile --debug --emit --error-on-warnings --exclude-warnings --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --warnings --help"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
                 COMPREPLY=($(_crystal_compgen_files $cur))
@@ -34,7 +34,7 @@ _crystal()
             ;;
         run)
             if [[ ${cur} == -* ]] ; then
-                local opts="--debug --define --emit --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose"
+                local opts="--debug --define --emit --error-on-warnings --exclude-warnings --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose --warnings"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
                 COMPREPLY=($(_crystal_compgen_files $cur))

--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -1,0 +1,157 @@
+require "../spec_helper"
+
+describe "Code gen: warnings" do
+  it "detects top-level deprecated methods" do
+    assert_warning %(
+      @[Deprecated("Do not use me")]
+      def foo
+      end
+
+      foo
+    ), "Warning in line 6: Deprecated top-level foo. Do not use me",
+      inject_primitives: false
+  end
+
+  it "deprecation reason is optional" do
+    assert_warning %(
+      @[Deprecated]
+      def foo
+      end
+
+      foo
+    ), "Warning in line 6: Deprecated top-level foo.",
+      inject_primitives: false
+  end
+
+  it "detects deprecated instance methods" do
+    assert_warning %(
+      class Foo
+        @[Deprecated("Do not use me")]
+        def m
+        end
+      end
+
+      Foo.new.m
+    ), "Warning in line 8: Deprecated Foo#m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated class methods" do
+    assert_warning %(
+      class Foo
+        @[Deprecated("Do not use me")]
+        def self.m
+        end
+      end
+
+      Foo.m
+    ), "Warning in line 8: Deprecated Foo.m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated generic instance methods" do
+    assert_warning %(
+      class Foo(T)
+        @[Deprecated("Do not use me")]
+        def m
+        end
+      end
+
+      Foo(Int32).new.m
+    ), "Warning in line 8: Deprecated Foo(Int32)#m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated generic class methods" do
+    assert_warning %(
+      class Foo(T)
+        @[Deprecated("Do not use me")]
+        def self.m
+        end
+      end
+
+      Foo(Int32).m
+    ), "Warning in line 8: Deprecated Foo(Int32).m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated module methods" do
+    assert_warning %(
+      module Foo
+        @[Deprecated("Do not use me")]
+        def self.m
+        end
+      end
+
+      Foo.m
+    ), "Warning in line 8: Deprecated Foo.m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "ignore deprecation excluded locations" do
+    with_tempfile("check_warnings_excludes") do |path|
+      FileUtils.mkdir_p File.join(path, "lib")
+
+      # NOTE tempfile might be created in symlinked folder
+      # which affects how to match current dir /var/folders/...
+      # with the real path /private/var/folders/...
+      path = File.real_path(path)
+
+      main_filename = File.join(path, "main.cr")
+      output_filename = File.join(path, "main")
+
+      Dir.cd(path) do
+        File.write main_filename, %(
+          require "./lib/foo"
+
+          bar
+          foo
+        )
+        File.write File.join(path, "lib", "foo.cr"), %(
+          @[Deprecated("Do not use me")]
+          def foo
+          end
+
+          def bar
+            foo
+          end
+        )
+
+        compiler = Compiler.new
+        compiler.warnings = Warnings::All
+        compiler.warnings_exclude << Crystal.normalize_path "lib"
+        compiler.prelude = "empty"
+        result = compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
+
+        result.program.warning_failures.size.should eq(1)
+      end
+    end
+  end
+
+  it "errors if invalid argument type" do
+    assert_error %(
+      @[Deprecated(42)]
+      def foo
+      end
+      ),
+      "Error in line 3: first argument must be a String"
+  end
+
+  it "errors if too many arguments" do
+    assert_error %(
+      @[Deprecated("Do not use me", "extra arg")]
+      def foo
+      end
+      ),
+      "Error in line 3: wrong number of deprecated annotation arguments (given 2, expected 1)"
+  end
+
+  it "errors if missing link arguments" do
+    assert_error %(
+      @[Deprecated(invalid: "Do not use me")]
+      def foo
+      end
+      ),
+      "Error in line 3: too many named arguments (given 1, expected maximum 0)"
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -108,6 +108,21 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
+def assert_warning(code, message, inject_primitives = true)
+  code = inject_primitives(code) if inject_primitives
+
+  output_filename = Crystal.tempfile("crystal-spec-output")
+
+  compiler = Compiler.new
+  compiler.warnings = Warnings::All
+  compiler.error_on_warnings = false
+  compiler.prelude = "empty" # avoid issues in the current std lib
+  result = compiler.compile Compiler::Source.new("code.cr", code), output_filename
+
+  result.program.warning_failures.size.should eq(1)
+  result.program.warning_failures[0].should start_with(message)
+end
+
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil)
   assert_macro(macro_args, macro_body, expected, expected_pragmas, flags) { call_args }
 end

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -16,6 +16,8 @@ class Crystal::CodeGenVisitor
       return false
     end
 
+    check_call_to_deprecated_method node
+
     owner = node.name == "super" ? node.scope : node.target_def.owner
 
     call_args, has_out = prepare_call_args node, owner

--- a/src/compiler/crystal/codegen/warnings.cr
+++ b/src/compiler/crystal/codegen/warnings.cr
@@ -1,0 +1,91 @@
+module Crystal
+  struct DeprecatedAnnotation
+    getter message : String?
+
+    def initialize(@message = nil)
+    end
+
+    def self.from(ann : Annotation)
+      args = ann.args
+      named_args = ann.named_args
+
+      if named_args
+        ann.raise "too many named arguments (given #{named_args.size}, expected maximum 0)"
+      end
+
+      message = nil
+      count = 0
+
+      args.each do |arg|
+        case count
+        when 0
+          arg.raise "first argument must be a String" unless arg.is_a?(StringLiteral)
+          message = arg.value
+        else
+          ann.wrong_number_of "deprecated annotation arguments", args.size, "1"
+        end
+
+        count += 1
+      end
+
+      new(message)
+    end
+  end
+
+  class Def
+    def short_reference
+      case owner
+      when Program
+        "top-level #{name}"
+      when .metaclass?
+        "#{owner.instance_type}.#{name}"
+      else
+        "#{owner}##{name}"
+      end
+    end
+  end
+
+  class CodeGenVisitor
+    def check_call_to_deprecated_method(node : Call)
+      return unless @program.warnings.all?
+
+      if (ann = node.target_def.annotation(@program.deprecated_annotation)) &&
+         (deprecated_annotation = DeprecatedAnnotation.from(ann))
+        return if ignore_warning_due_to_location(node.location)
+
+        message = deprecated_annotation.message
+        message = message ? " #{message}" : ""
+
+        full_message = node.warning "Deprecated #{node.target_def.short_reference}.#{message}"
+
+        @program.warning_failures << full_message
+      end
+    end
+
+    private def ignore_warning_due_to_location(location : Location?)
+      return false unless location
+
+      filename = location.original_filename
+      return false unless filename
+
+      return @program.warnings_exclude.any? do |path|
+        filename.starts_with?(path)
+      end
+    end
+  end
+
+  class Command
+    def report_warnings(result : Compiler::Result)
+      return if result.program.warning_failures.empty?
+
+      result.program.warning_failures.each do |message|
+        STDERR.puts message
+      end
+      STDERR.puts "A total of #{result.program.warning_failures.size} warnings were found."
+    end
+
+    def warnings_fail_on_exit?(result : Compiler::Result)
+      result.program.error_on_warnings && result.program.warning_failures.size > 0
+    end
+  end
+end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -64,7 +64,10 @@ class Crystal::Command
       init
     when "build".starts_with?(command)
       options.shift
-      build
+      result = build
+      report_warnings result
+      exit 1 if warnings_fail_on_exit?(result)
+      result
     when "play".starts_with?(command)
       options.shift
       playground
@@ -168,7 +171,9 @@ class Crystal::Command
   private def run_command(single_file = false)
     config = create_compiler "run", run: true, single_file: single_file
     if config.specified_output
-      config.compile
+      result = config.compile
+      report_warnings result
+      exit 1 if warnings_fail_on_exit?(result)
       return
     end
 
@@ -177,6 +182,9 @@ class Crystal::Command
     result = config.compile output_filename
 
     unless config.compiler.no_codegen?
+      report_warnings result
+      exit 1 if warnings_fail_on_exit?(result)
+
       execute output_filename, config.arguments, config.compiler
     end
   end
@@ -197,7 +205,7 @@ class Crystal::Command
     {config, result}
   end
 
-  private def execute(output_filename, run_args, compiler)
+  private def execute(output_filename, run_args, compiler, *, error_on_exit = false)
     time? = @time && !@progress_tracker.stats?
     status, elapsed_time = @progress_tracker.stage("Execute") do
       begin
@@ -226,7 +234,7 @@ class Crystal::Command
     end
 
     if status.normal_exit?
-      exit status.exit_code
+      exit error_on_exit ? 1 : status.exit_code
     else
       case status.exit_signal
       when ::Signal::KILL
@@ -353,6 +361,7 @@ class Crystal::Command
         opts.on("--mattr CPU", "Target specific features") do |features|
           compiler.mattr = features
         end
+        setup_compiler_warning_options(opts, compiler)
       end
 
       opts.on("--no-color", "Disable colored output") do
@@ -511,7 +520,29 @@ class Crystal::Command
       @color = false
       compiler.color = false
     end
+    setup_compiler_warning_options(opts, compiler)
     opts.invalid_option { }
+  end
+
+  private def setup_compiler_warning_options(opts, compiler)
+    compiler.warnings_exclude << Crystal.normalize_path "lib"
+    opts.on("--warnings all|none", "Which warnings detect. (default: all)") do |w|
+      compiler.warnings = case w
+                          when "all"
+                            Crystal::Warnings::All
+                          when "none"
+                            Crystal::Warnings::None
+                          else
+                            error "--warnings should be all, or none"
+                            raise "unreachable"
+                          end
+    end
+    opts.on("--error-on-warnings", "Treat warnings as errors.") do |w|
+      compiler.error_on_warnings = true
+    end
+    opts.on("--exclude-warnings <path>", "Exclude warnings from path (default: lib)") do |f|
+      compiler.warnings_exclude << Crystal.normalize_path f
+    end
   end
 
   private def validate_emit_values(values)

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -72,27 +72,17 @@ class Crystal::Command
     )
       @format_stdin = files.size == 1 && files[0] == "-"
 
-      includes = normalize_paths includes
-      excludes = normalize_paths excludes
+      includes.map! { |p| Crystal.normalize_path p }
+      excludes.map! { |p| Crystal.normalize_path p }
       excludes = excludes - includes
       if files.empty?
         files = Dir["./**/*.cr"]
       else
-        files = normalize_paths files
+        files.map! { |p| Crystal.normalize_path p }
       end
 
       @files = files
       @excludes = excludes
-    end
-
-    private def normalize_paths(paths)
-      path_start = ".#{File::SEPARATOR}"
-      paths.map do |path|
-        unless path.starts_with?(path_start) || path.starts_with?(File::SEPARATOR)
-          path = path_start + path
-        end
-        path.rstrip(File::SEPARATOR)
-      end
     end
 
     def run

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -72,6 +72,7 @@ class Crystal::Command
     output_filename = Crystal.tempfile "spec"
 
     result = compiler.compile sources, output_filename
-    execute output_filename, options, compiler
+    report_warnings result
+    execute output_filename, options, compiler, error_on_exit: warnings_fail_on_exit?(result)
   end
 end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -12,6 +12,11 @@ module Crystal
     Default     = LineNumbers
   end
 
+  enum Warnings
+    All
+    None
+  end
+
   # Main interface to the compiler.
   #
   # A Compiler parses source code, type checks it and
@@ -97,6 +102,15 @@ module Crystal
     # If `true`, doc comments are attached to types and methods
     # and can later be used to generate API docs.
     property? wants_doc = false
+
+    # Which kind of warnings wants to be detected.
+    property warnings : Warnings = Warnings::All
+
+    # Paths to ignore for warnings detection.
+    property warnings_exclude : Array(String) = [] of String
+
+    # If `true` compiler will error if warnings are found.
+    property error_on_warnings : Bool = false
 
     @[Flags]
     enum EmitTarget
@@ -196,6 +210,9 @@ module Crystal
       program.stdout = stdout
       program.show_error_trace = show_error_trace?
       program.progress_tracker = @progress_tracker
+      program.warnings = @warnings
+      program.warnings_exclude = @warnings_exclude.map { |p| File.expand_path p }
+      program.error_on_warnings = @error_on_warnings
       program
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -115,6 +115,18 @@ module Crystal
 
     property codegen_target = Config.default_target
 
+    # Which kind of warnings wants to be detected.
+    property warnings : Warnings = Warnings::All
+
+    # Paths to ignore for warnings detection.
+    property warnings_exclude : Array(String) = [] of String
+
+    # Detected warning failures.
+    property warning_failures = [] of String
+
+    # If `true` compiler will error if warnings are found.
+    property error_on_warnings : Bool = false
+
     def initialize
       super(self, self, "main")
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -226,6 +226,7 @@ module Crystal
       types["Raises"] = @raises_annotation = AnnotationType.new self, self, "Raises"
       types["ReturnsTwice"] = @returns_twice_annotation = AnnotationType.new self, self, "ReturnsTwice"
       types["ThreadLocal"] = @thread_local_annotation = AnnotationType.new self, self, "ThreadLocal"
+      types["Deprecated"] = @deprecated_annotation = AnnotationType.new self, self, "Deprecated"
 
       define_crystal_constants
     end
@@ -447,7 +448,7 @@ module Crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation
-                     flags_annotation link_annotation extern_annotation) %}
+                     flags_annotation link_annotation extern_annotation deprecated_annotation) %}
       def {{name.id}}
         @{{name.id}}.not_nil!
       end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -13,6 +13,21 @@ module Crystal
       ::raise exception_type.for_node(self, message, inner)
     end
 
+    def warning(message, inner = nil, exception_type = Crystal::TypeException)
+      # TODO extract message formatting from exceptions
+      String.build do |io|
+        exception = exception_type.for_node(self, message, inner)
+        io << "Warning "
+        exception.append_to_s(nil, io)
+        # Macro errors will first include the trace of the macro
+        # expansions, and then the warning message.
+        # In other warning messages the code snippet includes a newline
+        if exception.@filename.is_a?(VirtualFile)
+          io.puts
+        end
+      end
+    end
+
     def simple_literal?
       case self
       when Nop, NilLiteral, BoolLiteral, NumberLiteral, CharLiteral,

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -214,6 +214,7 @@ module Crystal
       a_def.always_inline = always_inline?
       a_def.returns_twice = returns_twice?
       a_def.naked = naked?
+      a_def.annotations = annotations
       a_def.new = new?
       a_def
     end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1049,6 +1049,12 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         node.returns_twice = true
       when @program.raises_annotation
         node.raises = true
+      when @program.deprecated_annotation
+        # Check whether a DeprecatedAnnotation can be built.
+        # There is no need to store it, but enforcing
+        # arguments makes sense here.
+        DeprecatedAnnotation.from(ann)
+        yield annotation_type, ann
       else
         yield annotation_type, ann
       end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -37,4 +37,12 @@ module Crystal
       str
     end.join '\n'
   end
+
+  def self.normalize_path(path)
+    path_start = ".#{File::SEPARATOR}"
+    unless path.starts_with?(path_start) || path.starts_with?(File::SEPARATOR)
+      path = path_start + path
+    end
+    path.rstrip(File::SEPARATOR)
+  end
 end


### PR DESCRIPTION
This PR adds to `build` and `spec` commands a `--check` option.

The `--check` option will notify if the emitted program is using any method marked as `@[Deprecated("migration message")]`.

For the `build` command if `--check` detect issues the exit status is `1`.

For the `spec` command I think it would be better to, even if quality checks errors are detected, to run the specs. But to do so `Crystal::Command#execute` needs to be refactored to overwrite the normal exit path. Before doing so, feedback is welcome.

I detect two issues, these are fixed in the PR but could be extracted if preferred.
* The bash autocompletion was still referring to compile instead of the build command
* The annotations were not cloned in `Def`

I didn't cover and I think it can be delayed:
* Deprecation of a whole class/module.
* Structured json output format of this messages
* A proper refactor to product warning messages without creating a `Crystal::TypeException`

The tool as is, already help me detect lots of `/` that we need to change to `//`.