### PR TITLE
add some Time static methods: now_utc_to_unix*

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -273,6 +273,13 @@ struct Time
   # :nodoc:
   MAX_SECONDS = 315537897599_i64
 
+  # epoch's timestamp in second since `0001-01-01 00:00:00`
+  EPOCH_SECONDS_TIMESTAMP = 62135596800_i64
+  EPOCH_SECONDS_TIMESTAMP_F64 = 62135596800_f64
+
+  # epoch's timestamp in msecond since `0001-01-01 00:00:00`
+  EPOCH_MSECONDS_TIMESTAMP = 62135596800000_i64
+
   # `DayOfWeek` represents a day of the week in the Gregorian calendar.
   #
   # ```
@@ -739,6 +746,36 @@ struct Time
       seconds: total_seconds - other.total_seconds,
       nanoseconds: nanosecond - other.nanosecond,
     )
+  end
+
+  # Returns an utc epoch current timestamp in second
+  #
+  #```
+  # Time.now_utc_to_unix # => 1452567845
+  #```
+  def self.now_utc_to_unix : Int64
+    seconds, nanoseconds = Crystal::System::Time.compute_utc_seconds_and_nanoseconds
+    seconds - EPOCH_SECONDS_TIMESTAMP
+  end
+
+  # Returns an utc epoch current timestamp in msecond
+  #
+  #```
+  # Time.now_utc_to_unix_ms # => 1452567845876
+  #```
+  def self.now_utc_to_unix_ms : Int64
+    seconds, nanoseconds = Crystal::System::Time.compute_utc_seconds_and_nanoseconds
+    (seconds * 1_000 + (nanoseconds / NANOSECONDS_PER_MILLISECOND)) - EPOCH_MSECONDS_TIMESTAMP
+  end
+
+  # Returns an utc epoch current timestamp in second as float64
+  #
+  #```
+  # Time.now_utc_to_unix_f # => 1452567845.876736
+  #```
+  def self.now_utc_to_unix_f : Float64
+    seconds, nanoseconds = Crystal::System::Time.compute_utc_seconds_and_nanoseconds
+    (seconds.to_f + (nanoseconds.to_f / 1e9)) - EPOCH_SECONDS_TIMESTAMP_F64
   end
 
   # Returns a copy of `self` with time-of-day components (hour, minute, second,


### PR DESCRIPTION
Hi, I did some Time helpers that give the current utc timestamp in second `Time.now_utc_to_unix`, msecond `Time.now_utc_to_unix_ms` and second as `Float64` `Time.now_utc_to_unix_f`. Because sometimes I don't want to make an instance of Time when I only want the current timestamp.

Here's a simple benchmark:
```
$> cat main.cr
ITER = 10_000_000

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.utc.to_unix
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.utc.to_unix: " + (_end - _start).to_s + " ms"

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.utc.to_unix_ms
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.utc.to_unix_ms: " + (_end - _start).to_s + " ms"

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.utc.to_unix_f
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.utc.to_unix_f: " + (_end - _start).to_s + " ms"

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.now_utc_to_unix
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.now_utc_to_unix: " + (_end - _start).to_s + " ms"

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.now_utc_to_unix_ms
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.now_utc_to_unix_ms: " + (_end - _start).to_s + " ms"

_start = Time.utc.to_unix_ms
i = 0
while i < ITER
  Time.now_utc_to_unix_f
  i += 1
end
_end = Time.utc.to_unix_ms
puts ITER.to_s + " Time.now_utc_to_unix_f: " + (_end - _start).to_s + " ms"
```
```
$> ./repo/bin/crystal build main.cr
$> ./main
10000000 Time.utc.to_unix: 664 ms
10000000 Time.utc.to_unix_ms: 928 ms
10000000 Time.utc.to_unix_f: 732 ms
10000000 Time.now_utc_to_unix: 355 ms
10000000 Time.now_utc_to_unix_ms: 593 ms
10000000 Time.now_utc_to_unix_f: 433 ms
```

Regards