### PR TITLE
Formatter - fix comment indentation

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1318,4 +1318,21 @@ describe Crystal::Formatter do
   assert_format "long_variable_name = [\n  {\n    :foo => 1,\n  },\n  {\n    :bar => 2,\n  },\n]"
   assert_format "long_variable_name = [1, 2, 3,\n                      4, 5, 6]"
   assert_format "long_variable_name = [1, 2, 3, # foo\n                      4, 5, 6]"
+
+  # #7599
+  assert_format <<-CODE
+    # module comment
+    module Foo
+      # class comment
+      class Bar
+        def method # this is a method
+          # method comment
+          if 1 == 1
+            # block comment
+            a = 1
+          end
+        end
+      end
+    end
+    CODE
 end


### PR DESCRIPTION
issue: https://github.com/crystal-lang/crystal/issues/7599
Note the variable `@inside_def` was a leftover from a previous cleanup that's why I remove it.
with this PR it's possible to have the correct comment indentation for this example:

```
# module comment
module Foo
  # class comment
  class Bar
    # method comment
    def method # this is a method
      # this is a comment
      if 1 == 1
        # block comment
      end
    end
  end
end

```