### PR TITLE
Add HTTP::Request#remote_address

### DIFF
--- a/spec/std/http/spec_helper.cr
+++ b/spec/std/http/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../spec_helper"
 
 private def wait_for(timeout = 5.seconds)
   now = Time.monotonic

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -20,6 +20,15 @@ class HTTP::Request
   @query_params : Params?
   @uri : URI?
 
+  # The network address that sent the request to an HTTP server.
+  #
+  # `HTTP::Server` will try to fill this property, and its value
+  # will have a format like "IP:port", but this format is not guaranteed.
+  # Middlewares can overwrite this value.
+  #
+  # This property is not used by `HTTP::Client`.
+  property remote_address : String?
+
   def initialize(@method : String, @resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, @version = "HTTP/1.1")
     @headers = headers.try(&.dup) || Headers.new
     self.body = body
@@ -99,7 +108,13 @@ class HTTP::Request
     return BadRequest.new unless HTTP::SUPPORTED_VERSIONS.includes?(http_version)
 
     HTTP.parse_headers_and_body(io) do |headers, body|
-      return new method, resource, headers, body, http_version
+      request = new method, resource, headers, body, http_version
+
+      if io.responds_to?(:remote_address)
+        request.remote_address = io.remote_address.try &.to_s
+      end
+
+      return request
     end
 
     # Malformed or unexpectedly ended http request

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -179,4 +179,14 @@ abstract class OpenSSL::SSL::Socket < IO
       String.new(host_name)
     end
   end
+
+  def local_address
+    io = @bio.io
+    io.responds_to?(:local_address) ? io.local_address : nil
+  end
+
+  def remote_address
+    io = @bio.io
+    io.responds_to?(:remote_address) ? io.remote_address : nil
+  end
 end


### PR DESCRIPTION
This PR adds a `remote_address` **property** to `HTTP::Request`.

Some details:
- the property is of type `String?`. It can be `nil` if the address can't be determined, but this usually won't happen. It's also nilable because for `HTTP::Client` it doesn't make sense. It's `String` and not a structured object like `IPAddress` because a middleware might want to overwrite this property, for example using the `X-Forwarded-By` or `X-Real-IP` headers. Also, this field is apparently commonly used for logging so it being a String is probably fine and the most flexible option.
- I'm not super convinced about using `responds_to?(:remote_address)` to determine this, I'd maybe like a module that defines this as an abstract method, but we can change the implementation later.
- I know I didn't document the `local_address` and `remote_address` getters of `OpenSSL::SSL::Socket`, but only because the underlying `IO` is not necessarily a `IPSocket`, so the type of those getters isn't `IPAddress`. Maybe we can assume the underlying `IO` is `IPSocket`, otherwise raise in this case. But this is something that we can improve later.
- If you have a better idea for the doc comments of `HTTP::Request#remote_address`, let me know

The idea here is to define an API that's usable and we won't modify later on. I think adding `HTTP::Request#remote_address : String?` is enough for this. We can redefine the implementation details I mention above in subsequent PRs. 

Fixes #453
Related to #5784
Supersedes #7302