### PR TITLE
Mention git pre-commit hook in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,17 @@ your own projects; a not so clean history is to prefer once a commit landed ther
 git push -f origin my_feature_branch
 ```
 
+## Git pre-commit hook
+
+Code submitted to this repository should be formatted according to `crystal tool format`.
+A pre-commit hook can be installed into the local git repo to ensure the formatter validates every commit: https://gist.github.com/straight-shoota/fdaf4cf1954e084cd5abccf8f77975f6
+
+Install the pre-commit hook:
+
+```sh
+curl https://gist.githubusercontent.com/straight-shoota/fdaf4cf1954e084cd5abccf8f77975f6/raw/pre-commit > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
 ## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of Conduct][ccoc].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ git push -f origin my_feature_branch
 ## Git pre-commit hook
 
 Code submitted to this repository should be formatted according to `crystal tool format`.
-A pre-commit hook can be installed into the local git repo to ensure the formatter validates every commit: https://gist.github.com/straight-shoota/fdaf4cf1954e084cd5abccf8f77975f6
+A pre-commit hook can be installed into the local git repo to ensure the formatter validates every commit: https://github.com/crystal-lang/crystal/blob/master/scripts/git/pre-commit
 
 Install the pre-commit hook:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ A pre-commit hook can be installed into the local git repo to ensure the formatt
 Install the pre-commit hook:
 
 ```sh
-curl https://gist.githubusercontent.com/straight-shoota/fdaf4cf1954e084cd5abccf8f77975f6/raw/pre-commit > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+ln -s scripts/git/pre-commit .git/hooks
 ```
 
 ## Code of Conduct

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /bin/sh
 #
 # This script ensures Crystal code is correctly formatted before committing it.
 # It won't apply any format changes automatically.
@@ -17,4 +17,9 @@ changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$
 
 [ -z "$changed_cr_files" ] && exit 0
 
-exec crystal tool format --check $changed_cr_files >&2
+if [ -x bin/crystal ]; then
+  # use bin/crystal wrapper when available to run local compiler build
+  exec bin/crystal tool format --check $changed_cr_files >&2
+else
+  exec crystal tool format --check $changed_cr_files >&2
+fi

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# This script ensures Crystal code is correctly formatted before committing it.
+# It won't apply any format changes automatically.
+#
+# Only staged files (the ones to be committed) are being processed, but each file is checked
+# entirely as it is stored on disc, even parts that are not staged.
+#
+# To use this script, it needs to be installed in the local git repository. For example by running
+# `ln -s scripts/git/pre-commit .git/hooks` in the root folder.
+#
+# Called by "git commit" with no arguments. The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+changed_cr_files=$(git diff --cached --name-only --diff-filter=A | grep '\.cr$')
+
+[ -z "$changed_cr_files" ] && exit 0
+
+exec crystal tool format --check "$changed_cr_files" >&2

--- a/scripts/git/pre-commit
+++ b/scripts/git/pre-commit
@@ -13,8 +13,8 @@
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 
-changed_cr_files=$(git diff --cached --name-only --diff-filter=A | grep '\.cr$')
+changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$')
 
 [ -z "$changed_cr_files" ] && exit 0
 
-exec crystal tool format --check "$changed_cr_files" >&2
+exec crystal tool format --check $changed_cr_files >&2


### PR DESCRIPTION
This adds the git pre-commit hook proposed in #7145 to `CONTRIBUTING.md`. The hook is provided as a gist instead of directly inside the repository.

Gist: https://gist.github.com/straight-shoota/fdaf4cf1954e084cd5abccf8f77975f6

Closes #7145