### PR TITLE
Bump distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout a6a7a322df05fd57e8f1b1b9020045dd13e679c0
+          git checkout ab683792f34c60159f0e697adf792ff5b0fcbf91
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This PR bumps distribution scripts to include

* https://github.com/crystal-lang/distribution-scripts/pull/30
* https://github.com/crystal-lang/distribution-scripts/pull/31

As a summary

* Includes the required GC MT patch. Ref: #7546
* It removes the GCF patch since the bdw-gc is bumped to 7.6.12.
* It defines the default value for CRYSTAL_LIBRARY_PATH env variable to favor embedded libraries. Ref: #7562
* Remove generated docs from linux packages

