### PR TITLE
Docs: Include crystal built-in constants in docs

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -168,6 +168,7 @@ class Crystal::Doc::Generator
 
   def must_include?(const : Crystal::Const)
     return false if nodoc?(const)
+    return true if crystal_builtin?(const)
 
     const.locations.try &.any? { |location| must_include? location }
   end


### PR DESCRIPTION
Fix #7613