### PR TITLE
Compiler: Avoid showing duplicate entries as warnings

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -108,7 +108,7 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
-def assert_warning(code, message, inject_primitives = true)
+def warnings_result(code, inject_primitives = true)
   code = inject_primitives(code) if inject_primitives
 
   output_filename = Crystal.tempfile("crystal-spec-output")
@@ -119,8 +119,13 @@ def assert_warning(code, message, inject_primitives = true)
   compiler.prelude = "empty" # avoid issues in the current std lib
   result = compiler.compile Compiler::Source.new("code.cr", code), output_filename
 
-  result.program.warning_failures.size.should eq(1)
-  result.program.warning_failures[0].should start_with(message)
+  result.program.warning_failures
+end
+
+def assert_warning(code, message, inject_primitives = true)
+  warning_failures = warnings_result(code, inject_primitives)
+  warning_failures.size.should eq(1)
+  warning_failures[0].should start_with(message)
 end
 
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil)

--- a/src/compiler/crystal/codegen/warnings.cr
+++ b/src/compiler/crystal/codegen/warnings.cr
@@ -46,17 +46,26 @@ module Crystal
   end
 
   class CodeGenVisitor
+    @deprecated_methods_detected = Set(String).new
+
     def check_call_to_deprecated_method(node : Call)
       return unless @program.warnings.all?
 
       if (ann = node.target_def.annotation(@program.deprecated_annotation)) &&
          (deprecated_annotation = DeprecatedAnnotation.from(ann))
         return if ignore_warning_due_to_location(node.location)
+        short_reference = node.target_def.short_reference
+        warning_key = node.location.try { |l| "#{short_reference} #{l}" }
+
+        # skip warning if the call site was already informed
+        # if there is no location information just inform it.
+        return if !warning_key || @deprecated_methods_detected.includes?(warning_key)
+        @deprecated_methods_detected.add(warning_key) if warning_key
 
         message = deprecated_annotation.message
         message = message ? " #{message}" : ""
 
-        full_message = node.warning "Deprecated #{node.target_def.short_reference}.#{message}"
+        full_message = node.warning "Deprecated #{short_reference}.#{message}"
 
         @program.warning_failures << full_message
       end


### PR DESCRIPTION
A leftover from #7596. Warnings should appear once per deprecated methods and not once per invocation.
