### PR TITLE
Fix infinite loop in asm with 3 colons and a variable

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1410,7 +1410,7 @@ module Crystal
     assert_syntax_error %q(asm("nop" ::: "#{foo}")), "interpolation not allowed in asm clobber"
     assert_syntax_error %q(asm("nop" :::: "#{volatile}")), "interpolation not allowed in asm option"
     assert_syntax_error %q(asm("" ::: ""(var))), "unexpected token: ("
-    assert_syntax_error %q(asm("" : 1), "unexpected token: 1"
+    assert_syntax_error %q(asm("" : 1)), "unexpected token: 1"
 
     it_parses "foo begin\nbar do\nend\nend", Call.new(nil, "foo", Expressions.new([Call.new(nil, "bar", block: Block.new)] of ASTNode))
     it_parses "foo 1.bar do\nend", Call.new(nil, "foo", args: [Call.new(1.int32, "bar")] of ASTNode, block: Block.new)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1409,6 +1409,7 @@ module Crystal
 
     assert_syntax_error %q(asm("nop" ::: "#{foo}")), "interpolation not allowed in asm clobber"
     assert_syntax_error %q(asm("nop" :::: "#{volatile}")), "interpolation not allowed in asm option"
+    assert_syntax_error %q(asm("" ::: ""(var))), "unexpected token: ("
 
     it_parses "foo begin\nbar do\nend\nend", Call.new(nil, "foo", Expressions.new([Call.new(nil, "bar", block: Block.new)] of ASTNode))
     it_parses "foo 1.bar do\nend", Call.new(nil, "foo", args: [Call.new(1.int32, "bar")] of ASTNode, block: Block.new)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1410,6 +1410,7 @@ module Crystal
     assert_syntax_error %q(asm("nop" ::: "#{foo}")), "interpolation not allowed in asm clobber"
     assert_syntax_error %q(asm("nop" :::: "#{volatile}")), "interpolation not allowed in asm option"
     assert_syntax_error %q(asm("" ::: ""(var))), "unexpected token: ("
+    assert_syntax_error %q(asm("" : 1), "unexpected token: 1"
 
     it_parses "foo begin\nbar do\nend\nend", Call.new(nil, "foo", Expressions.new([Call.new(nil, "bar", block: Block.new)] of ASTNode))
     it_parses "foo 1.bar do\nend", Call.new(nil, "foo", args: [Call.new(1.int32, "bar")] of ASTNode, block: Block.new)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4961,6 +4961,8 @@ module Crystal
         elsif @token.type == :":"
           next_token_skip_space_or_newline
           part_index += 1
+        else
+          unexpected_token
         end
 
         case part_index


### PR DESCRIPTION
This fixes an infinite compile loop when doing `asm("" ::: ""(var))`. The `until @token.type == :")"` loop never gets exited.