### PR TITLE
Include Indexable into String

### DIFF
--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -36,7 +36,7 @@ module LexerObjects
     def next_unicode_tokens_should_be(expected_unicode_codes)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:STRING)
-      token.value.as(String).char_at(0).ord.should eq(expected_unicode_codes)
+      token.value.as(String).at(0).ord.should eq(expected_unicode_codes)
     end
 
     def next_string_token_should_be(expected_string)

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1707,10 +1707,6 @@ describe "String" do
     "\u{AB}1".codepoint_at(1).should eq('1'.ord)
   end
 
-  it "does char_at" do
-    "いただきます".char_at(2).should eq('だ')
-  end
-
   it "does byte_at" do
     "hello".byte_at(1).should eq('e'.ord)
     expect_raises(IndexError) { "hello".byte_at(5) }

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -194,7 +194,7 @@ class Hash(K, V)
   # h.dig? "a", "b", "c", "d", "e" # => nil
   # ```
   def dig?(key : K, *subkeys)
-    if (value = self[key]?) && value.responds_to?(:dig?)
+    if (value = self[key]?) && !value.is_a?(K) && value.responds_to?(:dig?)
       value.dig?(*subkeys)
     end
   end
@@ -213,7 +213,7 @@ class Hash(K, V)
   # h.dig "a", "b", "c", "d", "e" # raises KeyError
   # ```
   def dig(key : K, *subkeys)
-    if (value = self[key]) && value.responds_to?(:dig)
+    if (value = self[key]) && !value.is_a?(K) && value.responds_to?(:dig)
       return value.dig(*subkeys)
     end
     raise KeyError.new "Hash value not diggable for key: #{key.inspect}"

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -130,7 +130,7 @@ struct NamedTuple
   # h.dig? "a", "b", "c", "d", "e" # => nil
   # ```
   def dig?(key : Symbol | String, *subkeys)
-    if (value = self[key]?) && value.responds_to?(:dig?)
+    if (value = self[key]?) && !value.is_a?(Symbol | String) && value.responds_to?(:dig?)
       value.dig?(*subkeys)
     end
   end
@@ -149,7 +149,7 @@ struct NamedTuple
   # h.dig "a", "b", "c", "d", "e" # raises KeyError
   # ```
   def dig(key : Symbol | String, *subkeys)
-    if (value = self[key]) && value.responds_to?(:dig)
+    if (value = self[key]) && !value.is_a?(Symbol | String) && value.responds_to?(:dig)
       return value.dig(*subkeys)
     end
     raise KeyError.new "NamedTuple value not diggable for key: #{key.inspect}"

--- a/src/path.cr
+++ b/src/path.cr
@@ -650,7 +650,7 @@ struct Path
   # Path.posix("foo/bar").join(Path.windows("baz\baq"))  # => Path.posix("foo/bar/baz/baq")
   # Path.windows("foo\\bar").join(Path.posix("baz/baq")) # => Path.posix("foo\\bar\\baz/baq")
   # ```
-  def join(parts : Enumerable) : Path
+  def join(parts : Enumerable(String | Path)) : Path
     new_name = String.build do |str|
       str << @name
       last_ended_with_separator = ends_with_separator?

--- a/src/string.cr
+++ b/src/string.cr
@@ -808,7 +808,7 @@ class String
     self[regex, group]?.not_nil!
   end
 
-  # WIP TODO: improve this
+  # TODO: improve this
   def unsafe_fetch(index : Int) : Char
     at(index)
   end
@@ -3696,6 +3696,8 @@ class String
 
   # Yields each character in the string to the block.
   #
+  # DEPRECATED: `each_char` is deprecated, use `each` instead.
+  #
   # ```
   # array = [] of Char
   # "ab☃".each_char do |char|
@@ -3704,18 +3706,12 @@ class String
   # array # => ['a', 'b', '☃']
   # ```
   def each_char : Nil
-    if ascii_only?
-      each_byte do |byte|
-        yield (byte < 0x80 ? byte.unsafe_chr : Char::REPLACEMENT)
-      end
-    else
-      Char::Reader.new(self).each do |char|
-        yield char
-      end
-    end
+    each { |c| yield c }
   end
 
   # Returns an `Iterator` over each character in the string.
+  #
+  # DEPRECATED: `each_char` is deprecated, use `each` instead.
   #
   # ```
   # chars = "ab☃".each_char
@@ -3724,7 +3720,22 @@ class String
   # chars.next # => '☃'
   # ```
   def each_char
-    CharIterator.new(Char::Reader.new(self))
+    each
+  end
+
+  # Yields each character and its index in the string to the block.
+  #
+  # DEPRECATED: `each_char_with_index` is deprecated, use `each_with_index` instead.
+  #
+  # ```
+  # array = [] of Tuple(Char, Int32)
+  # "ab☃".each_char_with_index do |char, index|
+  #   array << {char, index}
+  # end
+  # array # => [{'a', 0}, {'b', 1}, {'☃', 2}]
+  # ```
+  def each_char_with_index
+    each_with_index { |c, i| yield c, i }
   end
 
   # Yields each character and its index in the string to the block.
@@ -3736,7 +3747,7 @@ class String
   # end
   # array # => [{'a', 0}, {'b', 1}, {'☃', 2}]
   # ```
-  def each_char_with_index
+  def each_with_index(&block : Char, Int32 ->)
     i = 0
     each_char do |char|
       yield char, i

--- a/src/string.cr
+++ b/src/string.cr
@@ -130,6 +130,8 @@ require "c/string"
 # is not good. It's better if programs are more resilient, but
 # show a replacement character when there's an error in incoming data.
 class String
+  include Indexable(Char)
+
   # :nodoc:
   TYPE_ID = "".crystal_type_id
 
@@ -702,21 +704,6 @@ class String
     end
   end
 
-  # Returns the `Char` at the given *index*, or raises `IndexError` if out of bounds.
-  #
-  # Negative indices can be used to start counting from the end of the string.
-  #
-  # ```
-  # "hello"[0]  # => 'h'
-  # "hello"[1]  # => 'e'
-  # "hello"[-1] # => 'o'
-  # "hello"[-2] # => 'l'
-  # "hello"[5]  # raises IndexError
-  # ```
-  def [](index : Int)
-    at(index) { raise IndexError.new }
-  end
-
   # Returns a substring by using a Range's *begin* and *end*
   # as character indices. Indices can be negative to start
   # counting from the end of the string.
@@ -796,10 +783,6 @@ class String
     end
   end
 
-  def []?(index : Int)
-    at(index) { nil }
-  end
-
   def []?(str : String | Char)
     includes?(str) ? str : nil
   end
@@ -823,6 +806,11 @@ class String
 
   def [](regex : Regex, group)
     self[regex, group]?.not_nil!
+  end
+
+  # WIP TODO: improve this
+  def unsafe_fetch(index : Int) : Char
+    at(index)
   end
 
   def at(index : Int)

--- a/src/string.cr
+++ b/src/string.cr
@@ -868,11 +868,7 @@ class String
   end
 
   def codepoint_at(index)
-    char_at(index).ord
-  end
-
-  def char_at(index)
-    self[index]
+    at(index).ord
   end
 
   def byte_at(index)


### PR DESCRIPTION
Follow up of https://github.com/crystal-lang/crystal/issues/7619

The end goal is to remove duplication with the `Indexable` module, benefit from methods from the module and no longer use the `Indexable.self.range_to_index_and_count` [class method](https://github.com/crystal-lang/crystal/blob/master/src/indexable.cr#L622).

I had a hard time to figure out why I got `Error opening file '/app/s/r/c/c/o/m/p/i/l/e/r/c/r/y/s/t/a/l/c/r' with mode 'r': No such file or directory (Errno)`. That's because `String` was assumed not to be an `Enumerable`

I'm still worry about slower performance, for example with `String#size` and `String#each`.

Feedbacks welcome.