### PR TITLE
Remove String#at

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -3,7 +3,7 @@ require "../support/finalize"
 
 private class StringWrapper
   delegate downcase, to: @string
-  delegate upcase, capitalize, at, scan, to: @string
+  delegate upcase, capitalize, char_at, scan, to: @string
 
   @string : String
 
@@ -152,10 +152,10 @@ describe Object do
       wrapper.upcase.should eq("HELLO")
       wrapper.capitalize.should eq("Hello")
 
-      wrapper.at(0).should eq('H')
-      wrapper.at(index: 1).should eq('e')
+      wrapper.char_at(0).should eq('H')
+      wrapper.char_at(index: 1).should eq('e')
 
-      wrapper.at(10) { 20 }.should eq(20)
+      wrapper.char_at(10) { 20 }.should eq(20)
 
       matches = [] of String
       wrapper.scan(/l/) do |match|

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1709,6 +1709,12 @@ describe "String" do
 
   it "does char_at" do
     "いただきます".char_at(2).should eq('だ')
+    "foo".char_at(0).should eq('f')
+    "foo".char_at(4) { 'x' }.should eq('x')
+
+    expect_raises(IndexError) do
+      "foo".char_at(4)
+    end
   end
 
   it "does byte_at" do
@@ -2409,15 +2415,6 @@ describe "String" do
     string = "foo"
     clone = string.clone
     string.should be(clone)
-  end
-
-  it "#at" do
-    "foo".at(0).should eq('f')
-    "foo".at(4) { 'x' }.should eq('x')
-
-    expect_raises(IndexError) do
-      "foo".at(4)
-    end
   end
 
   it "allocates buffer of correct size when UInt8 is given to new (#3332)" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -825,6 +825,16 @@ class String
     self[regex, group]?.not_nil!
   end
 
+  @[Deprecated("Use `String#char_at` instead.")]
+  def at(index : Int)
+    char_at(index)
+  end
+
+  @[Deprecated("Use `String#char_at` instead.")]
+  def at(index : Int)
+    char_at(index) { yield }
+  end
+
   def char_at(index : Int)
     char_at(index) { raise IndexError.new }
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -714,7 +714,7 @@ class String
   # "hello"[5]  # raises IndexError
   # ```
   def [](index : Int)
-    at(index) { raise IndexError.new }
+    char_at(index) { raise IndexError.new }
   end
 
   # Returns a substring by using a Range's *begin* and *end*
@@ -797,7 +797,7 @@ class String
   end
 
   def []?(index : Int)
-    at(index) { nil }
+    char_at(index) { nil }
   end
 
   def []?(str : String | Char)
@@ -825,11 +825,11 @@ class String
     self[regex, group]?.not_nil!
   end
 
-  def at(index : Int)
-    at(index) { raise IndexError.new }
+  def char_at(index : Int)
+    char_at(index) { raise IndexError.new }
   end
 
-  def at(index : Int)
+  def char_at(index : Int)
     if ascii_only?
       byte = byte_at?(index)
       if byte
@@ -881,10 +881,6 @@ class String
 
   def codepoint_at(index)
     char_at(index).ord
-  end
-
-  def char_at(index)
-    self[index]
   end
 
   def byte_at(index)


### PR DESCRIPTION
It is a duplicate of `String#char_at`, which is less explicit.
Nor `String#at` or `String#char_at` are documented, though public methods.
Not sure about the degree of deprecation we want (only a comment, using deprecated annotation or none?).