### PR TITLE
Add Big*#//, BigInt#&-ops and missing #floor, #ceil, #trunc

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -147,6 +147,17 @@ describe BigDecimal do
     expect_raises(DivisionByZeroError) do
       BigDecimal.new(-1) / BigDecimal.new(0)
     end
+
+    expect_raises(DivisionByZeroError) do
+      BigDecimal.new(0) // BigDecimal.new(0)
+    end
+    expect_raises(DivisionByZeroError) do
+      BigDecimal.new(1) // BigDecimal.new(0)
+    end
+    expect_raises(DivisionByZeroError) do
+      BigDecimal.new(-1) // BigDecimal.new(0)
+    end
+
     BigDecimal.new(1).should eq(BigDecimal.new(1) / BigDecimal.new(1))
     BigDecimal.new(10).should eq(BigDecimal.new(100, 1) / BigDecimal.new(100000000, 8))
     BigDecimal.new(5.to_big_i, 1_u64).should eq(BigDecimal.new(1) / BigDecimal.new(2))
@@ -160,6 +171,18 @@ describe BigDecimal do
     BigDecimal.new(500.to_big_i, 0).should eq(BigDecimal.new(-1000) / BigDecimal.new(-2))
     BigDecimal.new(0).should eq(BigDecimal.new(0) / BigDecimal.new(1))
     BigDecimal.new("3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".to_big_i, 100_u64).should eq(BigDecimal.new(1) / BigDecimal.new(3))
+
+    BigDecimal.new(0).should eq(BigDecimal.new(1) // BigDecimal.new(2))
+    BigDecimal.new(-1).should eq(BigDecimal.new(1) // BigDecimal.new(-2))
+    BigDecimal.new(-1).should eq(BigDecimal.new(1) // BigDecimal.new(-2000))
+    BigDecimal.new(-500).should eq(BigDecimal.new(1000) // BigDecimal.new(-2))
+    BigDecimal.new(-500).should eq(BigDecimal.new(-1000) // BigDecimal.new(2))
+    BigDecimal.new(500).should eq(BigDecimal.new(-1000) // BigDecimal.new(-2))
+    BigDecimal.new(0).should eq(BigDecimal.new(-1) // BigDecimal.new(-2))
+    BigDecimal.new(0).should eq(BigDecimal.new(-1) // BigDecimal.new(-2000))
+    BigDecimal.new(500).should eq(BigDecimal.new(-1000) // BigDecimal.new(-2))
+    BigDecimal.new(0).should eq(BigDecimal.new(0) // BigDecimal.new(1))
+    BigDecimal.new(0).should eq(BigDecimal.new(1) // BigDecimal.new(3))
 
     BigDecimal.new(33333.to_big_i, 5_u64).should eq(BigDecimal.new(1).div(BigDecimal.new(3), 5))
     BigDecimal.new(33.to_big_i, 5_u64).should eq(BigDecimal.new(1).div(BigDecimal.new(3000), 5))
@@ -393,6 +416,39 @@ describe BigDecimal do
 
     negative_one.normalize_quotient(negative_one, positive_ten).should eq(positive_ten)
     negative_one.normalize_quotient(negative_one, negative_ten).should eq(negative_ten)
+  end
+
+  describe "#ceil" do
+    it { 2.0.to_big_d.ceil.should eq(2) }
+    it { 2.1.to_big_d.ceil.should eq(3) }
+    it { 2.9.to_big_d.ceil.should eq(3) }
+
+    it { 2.01.to_big_d.ceil.should eq(3) }
+    it { 2.11.to_big_d.ceil.should eq(3) }
+    it { 2.91.to_big_d.ceil.should eq(3) }
+
+    it { -2.01.to_big_d.ceil.should eq(-2) }
+    it { -2.91.to_big_d.ceil.should eq(-2) }
+  end
+
+  describe "#floor" do
+    it { 2.1.to_big_d.floor.should eq(2) }
+    it { 2.9.to_big_d.floor.should eq(2) }
+    it { -2.9.to_big_d.floor.should eq(-3) }
+
+    it { 2.11.to_big_d.floor.should eq(2) }
+    it { 2.91.to_big_d.floor.should eq(2) }
+    it { -2.91.to_big_d.floor.should eq(-3) }
+  end
+
+  describe "#trunc" do
+    it { 2.1.to_big_d.trunc.should eq(2) }
+    it { 2.9.to_big_d.trunc.should eq(2) }
+    it { -2.9.to_big_d.trunc.should eq(-2) }
+
+    it { 2.11.to_big_d.trunc.should eq(2) }
+    it { 2.91.to_big_d.trunc.should eq(2) }
+    it { -2.91.to_big_d.trunc.should eq(-2) }
   end
 
   describe "#inspect" do

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -109,6 +109,18 @@ describe "BigFloat" do
     it { ("5.5".to_big_f / 16_u8).to_s.should eq("0.34375") }
   end
 
+  describe "//" do
+    it { ("1.0".to_big_f // "2.0".to_big_f).to_s.should eq("0") }
+    it { ("0.04".to_big_f // "89.0001".to_big_f).to_s.should eq("0") }
+    it { ("-5.5".to_big_f // "5.5".to_big_f).to_s.should eq("-1") }
+    it { ("5.5".to_big_f // "-5.5".to_big_f).to_s.should eq("-1") }
+    expect_raises(DivisionByZeroError) { 0.1.to_big_f // 0 }
+    it { ("5.5".to_big_f // 16_u64).to_s.should eq("0") }
+    it { ("5.5".to_big_f // 16_u8).to_s.should eq("0") }
+
+    it { ("-1".to_big_f // 2_u8).to_s.should eq("-1") }
+  end
+
   describe "**" do
     # TODO: investigate why in travis this gives ""1.79559999999999999991"
     # it { ("1.34".to_big_f ** 2).to_s.should eq("1.79559999999999999994") }

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -88,6 +88,15 @@ describe "BigInt" do
     (5.to_big_i + Int64::MAX).should eq(Int64::MAX.to_big_i + 5)
 
     (2 + 1.to_big_i).should eq(3.to_big_i)
+
+    (1.to_big_i &+ 2.to_big_i).should eq(3.to_big_i)
+    (1.to_big_i &+ 2).should eq(3.to_big_i)
+    (1.to_big_i &+ 2_u8).should eq(3.to_big_i)
+    (5.to_big_i &+ (-2_i64)).should eq(3.to_big_i)
+    (5.to_big_i &+ Int64::MAX).should be > Int64::MAX.to_big_i
+    (5.to_big_i &+ Int64::MAX).should eq(Int64::MAX.to_big_i &+ 5)
+
+    (2 &+ 1.to_big_i).should eq(3.to_big_i)
   end
 
   it "subs" do
@@ -100,6 +109,16 @@ describe "BigInt" do
 
     (5 - 1.to_big_i).should eq(4.to_big_i)
     (-5 - 1.to_big_i).should eq(-6.to_big_i)
+
+    (5.to_big_i &- 2.to_big_i).should eq(3.to_big_i)
+    (5.to_big_i &- 2).should eq(3.to_big_i)
+    (5.to_big_i &- 2_u8).should eq(3.to_big_i)
+    (5.to_big_i &- (-2_i64)).should eq(7.to_big_i)
+    (-5.to_big_i &- Int64::MAX).should be < -Int64::MAX.to_big_i
+    (-5.to_big_i &- Int64::MAX).should eq(-Int64::MAX.to_big_i &- 5)
+
+    (5 &- 1.to_big_i).should eq(4.to_big_i)
+    (-5 &- 1.to_big_i).should eq(-6.to_big_i)
   end
 
   it "negates" do
@@ -113,6 +132,13 @@ describe "BigInt" do
     (3 * 2.to_big_i).should eq(6.to_big_i)
     (3_u8 * 2.to_big_i).should eq(6.to_big_i)
     (2.to_big_i * Int64::MAX).should eq(2.to_big_i * Int64::MAX.to_big_i)
+
+    (2.to_big_i &* 3.to_big_i).should eq(6.to_big_i)
+    (2.to_big_i &* 3).should eq(6.to_big_i)
+    (2.to_big_i &* 3_u8).should eq(6.to_big_i)
+    (3 &* 2.to_big_i).should eq(6.to_big_i)
+    (3_u8 &* 2.to_big_i).should eq(6.to_big_i)
+    (2.to_big_i &* Int64::MAX).should eq(2.to_big_i &* Int64::MAX.to_big_i)
   end
 
   it "gets absolute value" do
@@ -124,6 +150,13 @@ describe "BigInt" do
     (10.to_big_i / 3).should eq(3.to_big_i)
     (10 / 3.to_big_i).should eq(3.to_big_i)
     ((Int64::MAX.to_big_i * 2.to_big_i) / Int64::MAX).should eq(2.to_big_i)
+  end
+
+  it "divides" do
+    (10.to_big_i // 3.to_big_i).should eq(3.to_big_i)
+    (10.to_big_i // 3).should eq(3.to_big_i)
+    (10 // 3.to_big_i).should eq(3.to_big_i)
+    ((Int64::MAX.to_big_i * 2.to_big_i) // Int64::MAX).should eq(2.to_big_i)
   end
 
   it "divides with negative numbers" do
@@ -139,6 +172,21 @@ describe "BigInt" do
     (-6.to_big_i / 2).should eq(-3.to_big_i)
     (6.to_big_i / -2).should eq(-3.to_big_i)
     (-6.to_big_i / -2).should eq(3.to_big_i)
+  end
+
+  it "divides with negative numbers" do
+    (7.to_big_i // 2).should eq(3.to_big_i)
+    (7.to_big_i // 2.to_big_i).should eq(3.to_big_i)
+    (7.to_big_i // -2).should eq(-4.to_big_i)
+    (7.to_big_i // -2.to_big_i).should eq(-4.to_big_i)
+    (-7.to_big_i // 2).should eq(-4.to_big_i)
+    (-7.to_big_i // 2.to_big_i).should eq(-4.to_big_i)
+    (-7.to_big_i // -2).should eq(3.to_big_i)
+    (-7.to_big_i // -2.to_big_i).should eq(3.to_big_i)
+
+    (-6.to_big_i // 2).should eq(-3.to_big_i)
+    (6.to_big_i // -2).should eq(-3.to_big_i)
+    (-6.to_big_i // -2).should eq(3.to_big_i)
   end
 
   it "tdivs" do
@@ -221,6 +269,20 @@ describe "BigInt" do
 
     expect_raises DivisionByZeroError do
       10 / 0.to_big_i
+    end
+  end
+
+  it "raises if divides by zero" do
+    expect_raises DivisionByZeroError do
+      10.to_big_i // 0.to_big_i
+    end
+
+    expect_raises DivisionByZeroError do
+      10.to_big_i // 0
+    end
+
+    expect_raises DivisionByZeroError do
+      10 // 0.to_big_i
     end
   end
 

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -157,6 +157,13 @@ describe BigRational do
     (1 / br(10, 7)).should eq(br(7, 10))
   end
 
+  it "#//" do
+    (br(10, 7) // br(3, 7)).should eq(br(9, 3))
+    expect_raises(DivisionByZeroError) { br(10, 7) / br(0, 10) }
+    (br(10, 7) // 3).should eq(0)
+    (1 // br(10, 7)).should eq(0)
+  end
+
   it "#- (negation)" do
     (-br(10, 3)).should eq(br(-10, 3))
   end
@@ -176,6 +183,39 @@ describe BigRational do
 
   it "#>>" do
     (br(10, 3) >> 2).should eq(br(5, 6))
+  end
+
+  it "#ceil" do
+    br(2, 1).ceil.should eq(2)
+    br(21, 10).ceil.should eq(3)
+    br(29, 10).ceil.should eq(3)
+
+    br(201, 100).ceil.should eq(3)
+    br(211, 100).ceil.should eq(3)
+    br(291, 100).ceil.should eq(3)
+
+    br(-201, 100).ceil.should eq(-2)
+    br(-291, 100).ceil.should eq(-2)
+  end
+
+  it "#floor" do
+    br(21, 10).floor.should eq(2)
+    br(29, 10).floor.should eq(2)
+    br(-29, 10).floor.should eq(-3)
+
+    br(211, 100).floor.should eq(2)
+    br(291, 100).floor.should eq(2)
+    br(-291, 100).floor.should eq(-3)
+  end
+
+  it "#trunc" do
+    br(21, 10).trunc.should eq(2)
+    br(29, 10).trunc.should eq(2)
+    br(-29, 10).trunc.should eq(-2)
+
+    br(211, 100).trunc.should eq(2)
+    br(291, 100).trunc.should eq(2)
+    br(-291, 100).trunc.should eq(-2)
   end
 
   it "#hash" do

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -140,6 +140,10 @@ struct BigFloat < Float
     end
   end
 
+  def //(other : Number)
+    (self / other).floor
+  end
+
   def **(other : Int)
     BigFloat.new { |mpf| LibGMP.mpf_pow_ui(mpf, self, other.to_u64) }
   end
@@ -321,6 +325,10 @@ struct Number
 
   def /(other : BigFloat)
     to_big_f / other
+  end
+
+  def //(other : BigFloat)
+    to_big_f // other
   end
 
   def to_big_f

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -122,6 +122,10 @@ struct BigInt < Int
     end
   end
 
+  def &+(other) : BigInt
+    self + other
+  end
+
   def -(other : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.sub(mpz, self, other) }
   end
@@ -134,6 +138,10 @@ struct BigInt < Int
     else
       self - other.to_big_i
     end
+  end
+
+  def &-(other) : BigInt
+    self - other
   end
 
   def - : BigInt
@@ -160,7 +168,16 @@ struct BigInt < Int
     self * other.to_big_i
   end
 
+  def &*(other) : BigInt
+    self * other
+  end
+
   def /(other : Int) : BigInt
+    # TODO replace to float division
+    self // other
+  end
+
+  def //(other : Int) : BigInt
     check_division_by_zero other
 
     if other < 0
@@ -558,6 +575,10 @@ struct Int
     other + self
   end
 
+  def &+(other : BigInt) : BigInt
+    self + other
+  end
+
   def -(other : BigInt) : BigInt
     if self < 0
       -(abs + other)
@@ -571,12 +592,24 @@ struct Int
     end
   end
 
+  def &-(other : BigInt) : BigInt
+    self - other
+  end
+
   def *(other : BigInt) : BigInt
     other * self
   end
 
+  def &*(other : BigInt) : BigInt
+    self * other
+  end
+
   def /(other : BigInt) : BigInt
-    to_big_i / other
+    self // other
+  end
+
+  def //(other : BigInt) : BigInt
+    to_big_i // other
   end
 
   def %(other : BigInt) : BigInt

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -127,6 +127,23 @@ struct BigRational < Number
     self / other.to_big_r
   end
 
+  def //(other)
+    (self / other).floor
+  end
+
+  def ceil
+    diff = (denominator - numerator % denominator) % denominator
+    BigRational.new(numerator + diff, denominator)
+  end
+
+  def floor
+    BigRational.new(numerator - numerator % denominator, denominator)
+  end
+
+  def trunc
+    self < 0 ? ceil : floor
+  end
+
   # Divides the rational by (2 ** *other*)
   #
   # ```
@@ -275,6 +292,10 @@ struct Int
 
   def /(other : BigRational)
     self.to_big_r / other
+  end
+
+  def //(other : BigRational)
+    self.to_big_r // other
   end
 
   def *(other : BigRational)


### PR DESCRIPTION
This PR unifies the API for numbers regarding `//`, `&`-ops, `#floor`, `#ceil` and `#trunc` across numbers and big numbers.

This is an intermediate step to replace `/` with `//` across the stdlib.