### PR TITLE
Int div deprecation

### DIFF
--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -75,10 +75,10 @@ describe "Deque" do
     it "works the same as array when inserting at 1/8 size and deleting at 3/4 size" do
       DequeTester.new.test do
         1000.times do
-          step { c.insert(c.size / 8, i) }
+          step { c.insert(c.size // 8, i) }
         end
         1000.times do
-          step { c.delete_at(c.size * 3 / 4) }
+          step { c.delete_at(c.size * 3 // 4) }
         end
       end
     end
@@ -86,10 +86,10 @@ describe "Deque" do
     it "works the same as array when inserting at 3/4 size and deleting at 1/8 size" do
       DequeTester.new.test do
         1000.times do
-          step { c.insert(c.size * 3 / 4, i) }
+          step { c.insert(c.size * 3 // 4, i) }
         end
         1000.times do
-          step { c.delete_at(c.size / 8) }
+          step { c.delete_at(c.size // 8) }
         end
       end
     end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -118,7 +118,7 @@ describe "Enumerable" do
       [1, 2].chunk { false }.to_a.should eq [{false, [1, 2]}]
       [1, 1, 2, 3, 3].chunk(&.itself).to_a.should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
       [1, 1, 2, 3, 3].chunk(&.<=(2)).to_a.should eq [{true, [1, 1, 2]}, {false, [3, 3]}]
-      (0..10).chunk(&./(3)).to_a.should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
+      (0..10).chunk(&.//(3)).to_a.should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
     end
 
     it "work with class" do
@@ -132,7 +132,7 @@ describe "Enumerable" do
     end
 
     it "rewind" do
-      i = (0..10).chunk(&./(3))
+      i = (0..10).chunk(&.//(3))
       i.next.should eq({0, [0, 1, 2]})
       i.next.should eq({1, [3, 4, 5]})
     end
@@ -193,7 +193,7 @@ describe "Enumerable" do
       [1, 2].chunks { false }.should eq [{false, [1, 2]}]
       [1, 1, 2, 3, 3].chunks(&.itself).should eq [{1, [1, 1]}, {2, [2]}, {3, [3, 3]}]
       [1, 1, 2, 3, 3].chunks(&.<=(2)).should eq [{true, [1, 1, 2]}, {false, [3, 3]}]
-      (0..10).chunks(&./(3)).should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
+      (0..10).chunks(&.//(3)).should eq [{0, [0, 1, 2]}, {1, [3, 4, 5]}, {2, [6, 7, 8]}, {3, [9, 10]}]
     end
 
     it "work with class" do
@@ -201,7 +201,7 @@ describe "Enumerable" do
     end
 
     it "work with pure enumerable" do
-      SpecEnumerable.new.chunks(&./(2)).should eq [{0, [1]}, {1, [2, 3]}]
+      SpecEnumerable.new.chunks(&.//(2)).should eq [{0, [1]}, {1, [2, 3]}]
     end
 
     it "returns elements for which the block returns Enumerable::Chunk::Alone in separate Arrays" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -429,7 +429,7 @@ describe "Int" do
   it "holds true that x == q*y + r" do
     [5, -5, 6, -6, 10, -10].each do |x|
       [3, -3].each do |y|
-        q = x / y
+        q = x // y
         r = x % y
         (q*y + r).should eq(x)
       end

--- a/spec/std/random/secure_spec.cr
+++ b/spec/std/random/secure_spec.cr
@@ -9,7 +9,7 @@ describe "Random::Secure" do
     x.should be >= 123456
     x.should be < 654321
 
-    Random::Secure.rand(Int64::MAX / 2).should be <= (Int64::MAX / 2)
+    Random::Secure.rand(Int64::MAX // 2).should be <= (Int64::MAX // 2)
   end
 
   it "fully fills a large buffer" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -1474,7 +1474,7 @@ class Array(T)
     return self if size == 0
     n %= size
     return self if n == 0
-    if n <= size / 2
+    if n <= size // 2
       tmp = self[0..n]
       @buffer.move_from(@buffer + n, size - n)
       (@buffer + size - n).copy_from(tmp.to_unsafe, n)
@@ -1946,7 +1946,7 @@ class Array(T)
   end
 
   protected def self.heap_sort!(a, n)
-    (n / 2).downto 0 do |p|
+    (n // 2).downto 0 do |p|
       heapify!(a, p, n)
     end
     while n > 1
@@ -1958,14 +1958,14 @@ class Array(T)
 
   protected def self.heapify!(a, p, n)
     v, c = a[p], p
-    while c < (n - 1) / 2
+    while c < (n - 1) // 2
       c = 2 * (c + 1)
       c -= 1 if cmp(a[c], a[c - 1]) < 0
       break unless cmp(v, a[c]) <= 0
       a[p] = a[c]
       p = c
     end
-    if n & 1 == 0 && c == n / 2 - 1
+    if n & 1 == 0 && c == n // 2 - 1
       c = 2 * c + 1
       if cmp(v, a[c]) < 0
         a[p] = a[c]
@@ -1976,7 +1976,7 @@ class Array(T)
   end
 
   protected def self.center_median!(a, n)
-    b, c = a + n / 2, a + n - 1
+    b, c = a + n // 2, a + n - 1
     if cmp(a.value, b.value) <= 0
       if cmp(b.value, c.value) <= 0
         return
@@ -1995,7 +1995,7 @@ class Array(T)
   end
 
   protected def self.partition_for_quick_sort!(a, n)
-    v, l, r = a[n / 2], a + 1, a + n - 1
+    v, l, r = a[n // 2], a + 1, a + n - 1
     loop do
       while cmp(l.value, v) < 0
         l += 1
@@ -2044,7 +2044,7 @@ class Array(T)
   end
 
   protected def self.heap_sort!(a, n, comp)
-    (n / 2).downto 0 do |p|
+    (n // 2).downto 0 do |p|
       heapify!(a, p, n, comp)
     end
     while n > 1
@@ -2056,14 +2056,14 @@ class Array(T)
 
   protected def self.heapify!(a, p, n, comp)
     v, c = a[p], p
-    while c < (n - 1) / 2
+    while c < (n - 1) // 2
       c = 2 * (c + 1)
       c -= 1 if cmp(a[c], a[c - 1], comp) < 0
       break unless cmp(v, a[c], comp) <= 0
       a[p] = a[c]
       p = c
     end
-    if n & 1 == 0 && c == n / 2 - 1
+    if n & 1 == 0 && c == n // 2 - 1
       c = 2 * c + 1
       if cmp(v, a[c], comp) < 0
         a[p] = a[c]
@@ -2074,7 +2074,7 @@ class Array(T)
   end
 
   protected def self.center_median!(a, n, comp)
-    b, c = a + n / 2, a + n - 1
+    b, c = a + n // 2, a + n - 1
     if cmp(a.value, b.value, comp) <= 0
       if cmp(b.value, c.value, comp) <= 0
         return
@@ -2093,7 +2093,7 @@ class Array(T)
   end
 
   protected def self.partition_for_quick_sort!(a, n, comp)
-    v, l, r = a[n / 2], a + 1, a + n - 1
+    v, l, r = a[n // 2], a + 1, a + n - 1
     loop do
       while l < a + n && cmp(l.value, v, comp) < 0
         l += 1

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -191,7 +191,7 @@ module Base64
 
   private def encode_size(str_size, new_lines = false)
     size = (str_size * 4 / 3.0).to_i + 4
-    size += size / LINE_SIZE if new_lines
+    size += size // LINE_SIZE if new_lines
     size
   end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -172,6 +172,7 @@ struct BigInt < Int
     self * other
   end
 
+  @[Deprecated("BigInt#/ will return a BigFloat in 0.29.0. Use BigInt#// for integer division.")]
   def /(other : Int) : BigInt
     # TODO replace to float division
     self // other
@@ -604,6 +605,7 @@ struct Int
     self * other
   end
 
+  @[Deprecated("Int#/(other: BigInt) will return a BigFloat in 0.29.0. Use Int#// for integer division.")]
   def /(other : BigInt) : BigInt
     self // other
   end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -696,7 +696,7 @@ module Random
       needed_parts += 1
     end
 
-    limit = rand_max / max * max
+    limit = rand_max // max * max
 
     loop do
       result = BigInt.new(next_u)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -153,7 +153,7 @@ struct BitArray
     else
       ba = BitArray.new(count)
       start_bit_index, start_sub_index = start.divmod(32)
-      end_bit_index = (start + count) / 32
+      end_bit_index = (start + count) // 32
 
       i = 0
       bits = @bits[start_bit_index]

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -102,7 +102,7 @@ module Crystal
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
 
           # FIXME structs like LibC::PthreadMutexT generate huge offset values
-          next if offset > UInt64::MAX / 8u64
+          next if offset > UInt64::MAX // 8u64
 
           member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)
           element_types << member

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -427,7 +427,7 @@ module Crystal
       jobs_count = 0
       wait_channel = Channel(Array(String)).new(@n_threads)
 
-      units.each_slice(Math.max(units.size / @n_threads, 1)) do |slice|
+      units.each_slice(Math.max(units.size // @n_threads, 1)) do |slice|
         jobs_count += 1
         spawn do
           # For stats output we want to count how many previous

--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -32,7 +32,7 @@ module Crystal
         when :right
           "%+#{available_width}s" % cell.text
         when :center
-          left = " " * ((available_width - cell.text.size) / 2)
+          left = " " * ((available_width - cell.text.size) // 2)
           right = " " * (available_width - cell.text.size - left.size)
           "#{left}#{cell.text}#{right}"
         end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1273,7 +1273,7 @@ module Crystal
     end
 
     def normal_rank
-      (@rank - 1) / 2
+      (@rank - 1) // 2
     end
 
     def range

--- a/src/crystal/compiler_rt.cr
+++ b/src/crystal/compiler_rt.cr
@@ -26,11 +26,11 @@ fun __mulodi4(a : Int64, b : Int64, overflow : Int32*) : Int64
     return result
   end
   if sa == sb
-    if abs_a > max / abs_b
+    if abs_a > max // abs_b
       overflow.value = 1
     end
   else
-    if abs_a > min / (0i64 &- abs_b)
+    if abs_a > min // (0i64 &- abs_b)
       overflow.value = 1
     end
   end

--- a/src/crystal/event.cr
+++ b/src/crystal/event.cr
@@ -24,7 +24,7 @@ struct Crystal::Event
   def add(timeout : Time::Span)
     add LibC::Timeval.new(
       tv_sec: LibC::TimeT.new(timeout.total_seconds),
-      tv_usec: timeout.nanoseconds / 1_000
+      tv_usec: timeout.nanoseconds // 1_000
     )
   end
 

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -244,7 +244,7 @@ struct Crystal::Hasher
   end
 
   private def read_u24(ptr, rest)
-    ptr[0].to_u64 | (ptr[rest/2].to_u64 << 8) | (ptr[rest - 1].to_u64 << 16)
+    ptr[0].to_u64 | (ptr[rest // 2].to_u64 << 8) | (ptr[rest - 1].to_u64 << 16)
   end
 
   private def read_u32(ptr)

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -125,7 +125,7 @@ module Crystal::System::File
   private def self.to_timeval(time : ::Time)
     t = uninitialized LibC::Timeval
     t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
-    t.tv_usec = typeof(t.tv_usec).new(time.nanosecond / ::Time::NANOSECONDS_PER_MICROSECOND)
+    t.tv_usec = typeof(t.tv_usec).new(time.nanosecond // ::Time::NANOSECONDS_PER_MICROSECOND)
     t
   end
 

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -28,8 +28,8 @@ module Crystal::System::Time
   def self.monotonic : {Int64, Int32}
     {% if flag?(:darwin) %}
       info = mach_timebase_info
-      total_nanoseconds = LibC.mach_absolute_time * info.numer / info.denom
-      seconds = total_nanoseconds / 1_000_000_000
+      total_nanoseconds = LibC.mach_absolute_time * info.numer // info.denom
+      seconds = total_nanoseconds // 1_000_000_000
       nanoseconds = total_nanoseconds.remainder(1_000_000_000)
       {seconds.to_i64, nanoseconds.to_i32}
     {% else %}

--- a/src/debug/dwarf/line_numbers.cr
+++ b/src/debug/dwarf/line_numbers.cr
@@ -266,7 +266,7 @@ module Debug
           registers.address += {{operation_advance}} * sequence.minimum_instruction_length
         else
           registers.address += sequence.minimum_instruction_length *
-            ((registers.op_index + operation_advance) / sequence.maximum_operations_per_instruction)
+            ((registers.op_index + operation_advance) // sequence.maximum_operations_per_instruction)
           registers.op_index = (registers.op_index + operation_advance) % sequence.maximum_operations_per_instruction
         end
       end
@@ -281,7 +281,7 @@ module Debug
           if opcode >= sequence.opcode_base
             # special opcode
             adjusted_opcode = opcode - sequence.opcode_base
-            operation_advance = adjusted_opcode / sequence.line_range
+            operation_advance = adjusted_opcode // sequence.line_range
             increment_address_and_op_index(operation_advance)
             registers.line &+= sequence.line_base + (adjusted_opcode % sequence.line_range)
             register_to_matrix(sequence, registers)
@@ -336,7 +336,7 @@ module Debug
               registers.basic_block = true
             when LNS::ConstAddPc
               adjusted_opcode = 255 - sequence.opcode_base
-              operation_advance = adjusted_opcode / sequence.line_range
+              operation_advance = adjusted_opcode // sequence.line_range
               increment_address_and_op_index(operation_advance)
             when LNS::FixedAdvancePc
               registers.address += @io.read_bytes(UInt16).not_nil!

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -224,7 +224,7 @@ class Deque(T)
     rindex -= @capacity if rindex >= @capacity
     value = @buffer[rindex]
 
-    if index > @size / 2
+    if index > @size // 2
       # Move following items to the left, starting with the first one
       # [56-01234] -> [6x-01235]
       dst = rindex
@@ -296,7 +296,7 @@ class Deque(T)
     rindex = @start + index
     rindex -= @capacity if rindex >= @capacity
 
-    if index > @size / 2
+    if index > @size // 2
       # Move following items to the right, starting with the last one
       # [56-01234] -> [4560123^]
       dst = @start + @size
@@ -421,7 +421,7 @@ class Deque(T)
       @start = (@start + n) % @capacity
     else
       # Turn *n* into an equivalent index in range -size/2 .. size/2
-      half = @size / 2
+      half = @size // 2
       if n.abs >= half
         n = (n + half) % @size - half
       end

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -9,7 +9,7 @@ class Fiber
 
     # Removes and frees at most *count* stacks from the top of the pool,
     # returning memory to the operating system.
-    def collect(count = lazy_size / 2)
+    def collect(count = lazy_size // 2)
       count.times do
         if stack = @deque.shift?
           LibC.munmap(stack, STACK_SIZE)

--- a/src/float/printer/cached_powers.cr
+++ b/src/float/printer/cached_powers.cr
@@ -157,7 +157,7 @@ module Float::Printer::CachedPowers
     min_exp = MIN_TARGET_EXP - (exp + DiyFP::SIGNIFICAND_SIZE)
     max_exp = MAX_TARGET_EXP - (exp + DiyFP::SIGNIFICAND_SIZE)
     k = ((min_exp + DiyFP::SIGNIFICAND_SIZE - 1) * D_1_LOG2_10).ceil
-    index = ((CACHED_POWER_OFFSET + k.to_i - 1) / CACHED_EXP_STEP) + 1
+    index = ((CACHED_POWER_OFFSET + k.to_i - 1) // CACHED_EXP_STEP) + 1
     pow = PowCache[index]
     return DiyFP.new(pow.significand, pow.binary_exp), pow.decimal_exp.to_i
   end

--- a/src/float/printer/grisu3.cr
+++ b/src/float/printer/grisu3.cr
@@ -251,7 +251,7 @@ module Float::Printer::Grisu3
     # with the divisor exponent + 1. And the divisor is the biggest power of ten
     # that is smaller than integrals.
     while kappa > 0
-      digit = integrals / divisor
+      digit = integrals // divisor
       # pp [digit, kappa]
       buffer[length] = 48_u8 + digit
       length += 1
@@ -271,7 +271,7 @@ module Float::Printer::Grisu3
         return weeded, kappa, length
       end
 
-      divisor /= 10
+      divisor //= 10
     end
 
     # The integrals have been generated. We are at the point of the decimal

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -76,14 +76,14 @@ struct Number
   # Number.si_prefix(3) # => 'k'
   # ```
   def self.si_prefix(magnitude : Int, prefixes = SI_PREFIXES) : Char?
-    index = (magnitude / 3)
+    index = (magnitude // 3)
     prefixes = prefixes[magnitude < 0 ? 0 : 1]
     prefixes[index.clamp((-prefixes.size + 1)..(prefixes.size - 1))]
   end
 
   # :nodoc:
   def self.prefix_index(i, group = 3)
-    ((i - (i > 0 ? 1 : 0)) / group) * group
+    ((i - (i > 0 ? 1 : 0)) // group) * group
   end
 
   # Pretty prints this number as a `String` in a human-readable format.

--- a/src/int.cr
+++ b/src/int.cr
@@ -117,6 +117,7 @@ struct Int
     self.class.new(to_f // other)
   end
 
+  @[Deprecated("Int#/ will return a Float in 0.29.0. Use Int#// for integer division.")]
   def /(other : Int)
     self // other
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -362,7 +362,7 @@ struct Int
   end
 
   def lcm(other : Int)
-    (self * other).abs / gcd(other)
+    (self * other).abs // gcd(other)
   end
 
   def divisible_by?(num)

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -62,7 +62,7 @@ module IO::Buffered
       # If we are asked to read more than half the buffer's size,
       # read directly into the slice, as it's not worth the extra
       # memory copy.
-      if !read_buffering? || count >= BUFFER_SIZE / 2
+      if !read_buffering? || count >= BUFFER_SIZE // 2
         return unbuffered_read(slice[0, count]).to_i
       else
         fill_buffer

--- a/src/llvm/abi.cr
+++ b/src/llvm/abi.cr
@@ -17,7 +17,7 @@ abstract class LLVM::ABI
   def size(type : Type, pointer_size)
     case type.kind
     when Type::Kind::Integer
-      (type.int_width + 7) / 8
+      (type.int_width + 7) // 8
     when Type::Kind::Float
       4
     when Type::Kind::Double
@@ -44,13 +44,13 @@ abstract class LLVM::ABI
 
   def align_offset(offset, type)
     align = align(type)
-    (offset + align - 1) / align * align
+    (offset + align - 1) // align * align
   end
 
   def align(type : Type, pointer_size)
     case type.kind
     when Type::Kind::Integer
-      (type.int_width + 7) / 8
+      (type.int_width + 7) // 8
     when Type::Kind::Float
       4
     when Type::Kind::Double

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -101,7 +101,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                elsif size <= 8
                  context.int64
                else
-                 context.int64.array(((size + 7) / 8).to_u64)
+                 context.int64.array(((size + 7) // 8).to_u64)
                end
         ArgType.direct(rty, cast)
       else
@@ -130,7 +130,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                elsif size <= 8
                  context.int64
                else
-                 context.int64.array(((size + 7) / 8).to_u64)
+                 context.int64.array(((size + 7) // 8).to_u64)
                end
         ArgType.direct(aty, cast)
       else

--- a/src/llvm/abi/arm.cr
+++ b/src/llvm/abi/arm.cr
@@ -50,9 +50,9 @@ class LLVM::ABI::ARM < LLVM::ABI
         non_struct(aty, context)
       else
         if align(aty) <= 4
-          ArgType.direct(aty, context.int32.array(((size(aty) + 3) / 4).to_u64))
+          ArgType.direct(aty, context.int32.array(((size(aty) + 3) // 4).to_u64))
         else
-          ArgType.direct(aty, context.int64.array(((size(aty) + 7) / 8).to_u64))
+          ArgType.direct(aty, context.int64.array(((size(aty) + 7) // 8).to_u64))
         end
       end
     end

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -53,7 +53,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
   end
 
   def classify(type)
-    words = (size(type) + 7) / 8
+    words = (size(type) + 7) // 8
     reg_classes = Array.new(words, RegClass::NoClass)
     if words > 4
       all_mem(reg_classes)
@@ -70,8 +70,8 @@ class LLVM::ABI::X86_64 < LLVM::ABI
 
     misalign = off % t_align
     if misalign != 0
-      i = off / 8
-      e = (off + t_size + 7) / 8
+      i = off // 8
+      e = (off + t_size + 7) // 8
       while i < e
         unify(cls, ix + 1, RegClass::Memory)
         i += 1
@@ -81,11 +81,11 @@ class LLVM::ABI::X86_64 < LLVM::ABI
 
     case ty.kind
     when Type::Kind::Integer, Type::Kind::Pointer
-      unify(cls, ix + off / 8, RegClass::Int)
+      unify(cls, ix + off // 8, RegClass::Int)
     when Type::Kind::Float
-      unify(cls, ix + off / 8, (off % 8 == 4) ? RegClass::SSEFv : RegClass::SSEFs)
+      unify(cls, ix + off // 8, (off % 8 == 4) ? RegClass::SSEFv : RegClass::SSEFs)
     when Type::Kind::Double
-      unify(cls, ix + off / 8, RegClass::SSEDs)
+      unify(cls, ix + off // 8, RegClass::SSEDs)
     when Type::Kind::Struct
       classify_struct(ty.struct_element_types, cls, ix, off, ty.packed_struct?)
     when Type::Kind::Array
@@ -225,7 +225,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
   def align(type : Type)
     case type.kind
     when Type::Kind::Integer
-      (type.int_width + 7) / 8
+      (type.int_width + 7) // 8
     when Type::Kind::Float
       4
     when Type::Kind::Double
@@ -250,7 +250,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
   def size(type : Type)
     case type.kind
     when Type::Kind::Integer
-      (type.int_width + 7) / 8
+      (type.int_width + 7) // 8
     when Type::Kind::Float
       4
     when Type::Kind::Double
@@ -277,7 +277,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
 
   def align(offset, type)
     align = align(type)
-    (offset + align - 1) / align * align
+    (offset + align - 1) // align * align
   end
 
   enum RegClass

--- a/src/llvm/target_data.cr
+++ b/src/llvm/target_data.cr
@@ -7,7 +7,7 @@ struct LLVM::TargetData
   end
 
   def size_in_bytes(type)
-    size_in_bits(type) / 8
+    size_in_bits(type) // 8
   end
 
   def abi_size(type)

--- a/src/number.cr
+++ b/src/number.cr
@@ -158,7 +158,7 @@ struct Number
   # 11.divmod(-3) # => {-4, -1}
   # ```
   def divmod(number)
-    {(self / number).floor, self % number}
+    {(self // number).floor, self % number}
   end
 
   # The comparison operator.

--- a/src/random.cr
+++ b/src/random.cr
@@ -150,7 +150,7 @@ module Random
         # 0 to 15, only with the `UInt8`, `UInt16`, `UInt32` and `UInt64` ranges.
         #
         # Another problem is how to actually compute the *limit*. The obvious way to do it, which is
-        # `(RAND_MAX + 1) / max * max`, fails because `RAND_MAX` is usually already the highest
+        # `(RAND_MAX + 1) // max * max`, fails because `RAND_MAX` is usually already the highest
         # number that an integer type can hold. And even the *limit* itself will often be
         # `RAND_MAX + 1`, meaning that we don't have to discard anything. The ways to deal with this
         # are described below.
@@ -192,7 +192,7 @@ module Random
           limit =
             if rand_max > 0
               # `rand_max` didn't overflow, so we can calculate the *limit* the straightforward way.
-              rand_max / max &* max
+              rand_max // max &* max
             else
               # *rand_max* is `{{utype}}::MAX + 1`, need the same wraparound trick. *limit* might
               # overflow, which means it would've been `{{utype}}::MAX + 1`, but didn't fit into
@@ -230,7 +230,7 @@ module Random
       end
 
       # Generates a random integer in range `{{type}}::MIN..{{type}}::MAX`.
-      private def rand_type(type : {{type}}.class, needed_parts = sizeof({{type}}) / sizeof(typeof(next_u))) : {{type}}
+      private def rand_type(type : {{type}}.class, needed_parts = sizeof({{type}}) // sizeof(typeof(next_u))) : {{type}}
         # Build up the number combining multiple outputs from the RNG.
         result = {{utype}}.new!(next_u)
         (needed_parts - 1).times do

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -83,7 +83,7 @@ class Random::PCG32
       end
       cur_plus = (cur_mult &+ 1) &* cur_plus
       cur_mult &*= cur_mult
-      deltau64 /= 2
+      deltau64 //= 2
     end
     @state = acc_mult &* @state &+ acc_plus
   end

--- a/src/range.cr
+++ b/src/range.cr
@@ -316,7 +316,7 @@ struct Range(B, E)
       e -= 1 if @exclusive
       n = e - b + 1
       if n >= 0
-        initial + n * (b + e) / 2
+        initial + n * (b + e) // 2
       else
         initial
       end
@@ -454,10 +454,10 @@ struct Range(B, E)
 
       if b.is_a?(Int) && e.is_a?(Int) && d.is_a?(Int)
         e -= 1 if @range.excludes_end?
-        n = (e - b) / d + 1
+        n = (e - b) // d + 1
         if n >= 0
           e = b + (n - 1) * d
-          initial + n * (b + e) / 2
+          initial + n * (b + e) // 2
         else
           initial
         end

--- a/src/string.cr
+++ b/src/string.cr
@@ -523,7 +523,7 @@ class String
 
     negative = false
     found_digit = false
-    mul_overflow = ~0_u64 / base
+    mul_overflow = ~0_u64 // base
 
     # Check + and -
     case ptr.value.unsafe_chr
@@ -1231,7 +1231,7 @@ class String
   def hexbytes? : Bytes?
     return unless bytesize.divisible_by?(2)
 
-    bytes = Bytes.new(bytesize / 2)
+    bytes = Bytes.new(bytesize // 2)
 
     i = 0
     while i < bytesize
@@ -1239,7 +1239,7 @@ class String
       low_nibble = to_unsafe[i + 1].unsafe_chr.to_u8?(16)
       return unless high_nibble && low_nibble
 
-      bytes[i / 2] = (high_nibble << 4) | low_nibble
+      bytes[i // 2] = (high_nibble << 4) | low_nibble
       i += 2
     end
 
@@ -2555,7 +2555,7 @@ class String
       buffer.copy_from(to_unsafe, bytesize)
       n = bytesize
 
-      while n <= total_bytesize / 2
+      while n <= total_bytesize // 2
         (buffer + n).copy_from(buffer, n)
         n *= 2
       end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -91,7 +91,7 @@ class StringPool
   end
 
   private def get(hash : UInt64, str : UInt8*, len)
-    rehash if @size >= @capacity / 4 * 3
+    rehash if @size >= @capacity // 4 * 3
 
     mask = (@capacity - 1).to_u64
     index = hash & mask

--- a/src/time.cr
+++ b/src/time.cr
@@ -524,7 +524,7 @@ struct Time
   # ```
   def self.unix_ms(milliseconds : Int) : Time
     milliseconds = milliseconds.to_i64
-    seconds = UNIX_EPOCH.total_seconds + (milliseconds / 1_000)
+    seconds = UNIX_EPOCH.total_seconds + (milliseconds // 1_000)
     nanoseconds = (milliseconds % 1000) * NANOSECONDS_PER_MILLISECOND
     utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
   end
@@ -783,12 +783,12 @@ struct Time
 
   # Returns the hour of the day (`0..23`).
   def hour : Int32
-    ((offset_seconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR).to_i
+    ((offset_seconds % SECONDS_PER_DAY) // SECONDS_PER_HOUR).to_i
   end
 
   # Returns the minute of the hour (`0..59`).
   def minute : Int32
-    ((offset_seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).to_i
+    ((offset_seconds % SECONDS_PER_HOUR) // SECONDS_PER_MINUTE).to_i
   end
 
   # Returns the second of the minute (`0..59`).
@@ -798,7 +798,7 @@ struct Time
 
   # Returns the millisecond of the second (`0..999`).
   def millisecond : Int32
-    nanosecond / NANOSECONDS_PER_MILLISECOND
+    nanosecond // NANOSECONDS_PER_MILLISECOND
   end
 
   # Returns the nanosecond of the second (`0..999_999_999`).
@@ -832,7 +832,7 @@ struct Time
     # The addition by +10 consists of +7 to start the week numbering with 1
     # instead of 0 and +3 because the first week has already started in the
     # previous year and the first Monday is actually in week 2.
-    week_number = (day_year - day_of_week.to_i + 10) / 7
+    week_number = (day_year - day_of_week.to_i + 10) // 7
 
     if week_number == 0
       # Week number 0 means the date belongs to the last week of the previous year.
@@ -926,7 +926,7 @@ struct Time
 
   # Returns the day of the week (`Monday..Sunday`).
   def day_of_week : Time::DayOfWeek
-    days = offset_seconds / SECONDS_PER_DAY
+    days = offset_seconds // SECONDS_PER_DAY
     DayOfWeek.new days.to_i % 7 + 1
   end
 
@@ -1239,7 +1239,7 @@ struct Time
   # time.to_unix_ms # => 1452567845678
   # ```
   def to_unix_ms : Int64
-    to_unix * 1_000 + (nanosecond / NANOSECONDS_PER_MILLISECOND)
+    to_unix * 1_000 + (nanosecond // NANOSECONDS_PER_MILLISECOND)
   end
 
   # Returns the number of seconds since the Unix epoch
@@ -1327,8 +1327,8 @@ struct Time
   end
 
   def_at_beginning(year) { Time.local(year, 1, 1, location: location) }
-  def_at_beginning(semester) { Time.local(year, ((month - 1) / 6) * 6 + 1, 1, location: location) }
-  def_at_beginning(quarter) { Time.local(year, ((month - 1) / 3) * 3 + 1, 1, location: location) }
+  def_at_beginning(semester) { Time.local(year, ((month - 1) // 6) * 6 + 1, 1, location: location) }
+  def_at_beginning(quarter) { Time.local(year, ((month - 1) // 3) * 3 + 1, 1, location: location) }
   def_at_beginning(month) { Time.local(year, month, 1, location: location) }
   def_at_beginning(day) { Time.local(year, month, day, location: location) }
   def_at_beginning(hour) { Time.local(year, month, day, hour, location: location) }
@@ -1435,7 +1435,7 @@ struct Time
 
     year -= 1
 
-    year * 365 + year / 4 - year / 100 + year / 400 + days_in_year
+    year * 365 + year // 4 - year // 100 + year // 400 + days_in_year
   end
 
   protected def total_seconds
@@ -1451,21 +1451,21 @@ struct Time
   # The return value is a tuple consisting of year (`1..9999`), month (`1..12`),
   # day (`1..31`) and ordinal day of the year (`1..366`).
   protected def year_month_day_day_year : {Int32, Int32, Int32, Int32}
-    total_days = (offset_seconds / SECONDS_PER_DAY).to_i
+    total_days = (offset_seconds // SECONDS_PER_DAY).to_i
 
-    num400 = total_days / DAYS_PER_400_YEARS
+    num400 = total_days // DAYS_PER_400_YEARS
     total_days -= num400 * DAYS_PER_400_YEARS
 
-    num100 = total_days / DAYS_PER_100_YEARS
+    num100 = total_days // DAYS_PER_100_YEARS
     if num100 == 4 # leap
       num100 = 3
     end
     total_days -= num100 * DAYS_PER_100_YEARS
 
-    num4 = total_days / DAYS_PER_4_YEARS
+    num4 = total_days // DAYS_PER_4_YEARS
     total_days -= num4 * DAYS_PER_4_YEARS
 
-    numyears = total_days / 365
+    numyears = total_days // 365
     if numyears == 4 # leap
       numyears = 3
     end

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -96,11 +96,11 @@ struct Time::Format
         digits = @reader.pos - pos
         if digits > 6
           # make sure to avoid overflow
-          decimals = decimals / 10_i64 ** (digits - 6)
+          decimals = decimals // 10_i64 ** (digits - 6)
           digits = 6
         end
 
-        @nanosecond_offset = decimals.to_i64 * 10 ** 9 / 10 ** digits * decimal_seconds
+        @nanosecond_offset = decimals.to_i64 * 10 ** 9 // 10 ** digits * decimal_seconds
       end
     end
   end

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -20,7 +20,7 @@ struct Time::Format
     end
 
     def year_divided_by_100
-      io << time.year / 100
+      io << time.year // 100
     end
 
     def full_or_short_year
@@ -136,7 +136,7 @@ struct Time::Format
     end
 
     def microseconds
-      pad6 time.nanosecond / 1000, '0'
+      pad6 time.nanosecond // 1000, '0'
     end
 
     def nanoseconds

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -165,8 +165,8 @@ class Time::Location
         sign = '+'
       end
       seconds = offset % 60
-      minutes = offset / 60
-      hours = minutes / 60
+      minutes = offset // 60
+      hours = minutes // 60
       minutes = minutes % 60
       {sign, hours, minutes, seconds}
     end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -181,12 +181,12 @@ struct Time::Span
 
   # Returns the number of milliseconds of the second (`0..999`) in this time span.
   def milliseconds : Int32
-    nanoseconds / NANOSECONDS_PER_MILLISECOND
+    nanoseconds // NANOSECONDS_PER_MILLISECOND
   end
 
   # Returns the number of microseconds of the second (`0..999999`) in this time span.
   def microseconds : Int32
-    nanoseconds / NANOSECONDS_PER_MICROSECOND
+    nanoseconds // NANOSECONDS_PER_MICROSECOND
   end
 
   # Returns the number of nanoseconds of the second (`0..999_999_999`)
@@ -317,7 +317,7 @@ struct Time::Span
     nanoseconds = self.nanoseconds.tdiv(number)
 
     remainder = to_i.remainder(number)
-    nanoseconds += (remainder * NANOSECONDS_PER_SECOND) / number
+    nanoseconds += (remainder * NANOSECONDS_PER_SECOND) // number
 
     # TODO check overflow
     Span.new(

--- a/src/uri/punycode.cr
+++ b/src/uri/punycode.cr
@@ -26,14 +26,14 @@ class URI
     private BASE36 = "abcdefghijklmnopqrstuvwxyz0123456789"
 
     private def self.adapt(delta, numpoints, firsttime)
-      delta /= firsttime ? DAMP : 2
-      delta += delta / numpoints
+      delta //= firsttime ? DAMP : 2
+      delta += delta // numpoints
       k = 0
-      while delta > ((BASE - TMIN) * TMAX) / 2
-        delta /= BASE - TMIN
+      while delta > ((BASE - TMIN) * TMAX) // 2
+        delta //= BASE - TMIN
         k += BASE
       end
-      k + (((BASE - TMIN + 1) * delta) / (delta + SKEW))
+      k + (((BASE - TMIN + 1) * delta) // (delta + SKEW))
     end
 
     def self.encode(string)
@@ -67,7 +67,7 @@ class URI
         next if m == prev
         prev = m
 
-        raise Exception.new("Overflow: input needs wider integers to process") if m.ord - n > (Int32::MAX - delta) / h
+        raise Exception.new("Overflow: input needs wider integers to process") if m.ord - n > (Int32::MAX - delta) // h
         delta += (m.ord - n) * h
         n = m.ord + 1
 
@@ -82,7 +82,7 @@ class URI
               t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias
               break if q < t
               io << BASE36[t + ((q - t) % (BASE - t))]
-              q = (q - t) / (BASE - t)
+              q = (q - t) // (BASE - t)
               k += BASE
             end
             io << BASE36[q]
@@ -135,7 +135,7 @@ class URI
         else
           outsize = output.size + 1
           bias = adapt i - oldi, outsize, oldi == 0
-          n += i / outsize
+          n += i // outsize
           i %= outsize
           output.insert i, n.chr
           i += 1

--- a/src/zip/file_info.cr
+++ b/src/zip/file_info.cr
@@ -161,7 +161,7 @@ module Zip::FileInfo
 
     time = (@time.hour << 11) |
            (@time.minute << 5) |
-           (@time.second / 2)
+           (@time.second // 2)
 
     {date.to_u16, time.to_u16}
   end


### PR DESCRIPTION
Depends on #7638.

This PR replaces (hopefully) all usages of `Int#/` with `Int#//`.

`Int#/` is marked as deprecated. This will cause some noise while building the compiler and specs since the method is still tested and used in places like macro interpreter. Without turning off warnings on some lexical scope we will need to tolerate that noise for a bit.

Since the stdlib is not ignored bye defualt (only `./lib`) if there are some functions without coverage in the stdlib users will notice them and will be able to report :-)

Ref: #2968

---

Submitting as draft until #7638 is merged