### PR TITLE
Update `for` expression error

### DIFF
--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -245,10 +245,11 @@ module Crystal
           exp.raise "can't interate TypeNode of type #{type}, only tuple or named tuple types"
         end
       else
-        node.exp.raise
-          "`for` expression must be one of the following types:\n" \
-          "ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral not #{exp.class_desc}\n" \
-          "Expression: #{exp}"
+        node.exp.raise <<-ERROR
+                       `for` expression must be one of the following types:
+                       ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral not #{exp.class_desc}
+                       Expression: #{exp}
+                       ERROR
       end
 
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -245,7 +245,10 @@ module Crystal
           exp.raise "can't interate TypeNode of type #{type}, only tuple or named tuple types"
         end
       else
-        node.exp.raise "for expression must be an array, hash or tuple literal, not #{exp.class_desc}:\n\n#{exp}"
+        node.exp.raise
+          "`for` expression must be one of the following types:\n" \
+          "ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral not #{exp.class_desc}\n" \
+          "Expression: #{exp}"
       end
 
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -246,7 +246,7 @@ module Crystal
         end
       else
         node.exp.raise <<-ERROR
-                       `for` expression must be one of the following types:
+                       `for` expression must be of one of the following types:
                        ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral not #{exp.class_desc}
                        Expression: #{exp}
                        ERROR

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -245,11 +245,7 @@ module Crystal
           exp.raise "can't interate TypeNode of type #{type}, only tuple or named tuple types"
         end
       else
-        node.exp.raise <<-ERROR
-                       `for` expression must be of one of the following types:
-                       ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral, not #{exp.class_desc}
-                       Expression: #{exp}
-                       ERROR
+        node.exp.raise "`for` expression must be an array, hash, tuple, named tuple or a range literal, not #{exp.class_desc}:\n\n#{exp}"
       end
 
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -247,7 +247,7 @@ module Crystal
       else
         node.exp.raise <<-ERROR
                        `for` expression must be of one of the following types:
-                       ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral not #{exp.class_desc}
+                       ArrayLiteral, HashLiteral, TupleLiteral, NamedTupleLiteral or RangeLiteral, not #{exp.class_desc}
                        Expression: #{exp}
                        ERROR
       end


### PR DESCRIPTION
This updates the `for` expression error a bit. It was slightly outdated. It also changes `array, hash` into `ArrayLiteral, HashLiteral` which is more consistent with `exp.class_desc` being a type.