### PR TITLE
Allow Spec's .pending and .it to accept constant

### DIFF
--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -36,6 +36,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    description = description.to_s
     Spec::RootContext.check_nesting_spec(file, line) do
       return unless Spec.matches?(description, file, line, end_line)
 
@@ -76,6 +77,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    description = description.to_s
     Spec::RootContext.check_nesting_spec(file, line) do
       return unless Spec.matches?(description, file, line, end_line)
 


### PR DESCRIPTION
This enables to use `pending` and `it` with a constant as description argument:

```cr
pending Foo do
end
it Foo do
end
```

This already works for `describe` and `context`, but for both `pending` and `it` raised an error because of mismatching types.