### PR TITLE
TypeNode#annotated_types

### DIFF
--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -794,4 +794,116 @@ describe "Semantic: annotation" do
       ))
     end
   end
+
+  describe "#annotated_types" do
+    it "returns an empty array if there are none defined" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        module Moo
+        end
+
+        {% if Foo.annotated_types.empty? %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
+    it "includes annotated modules" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        module Moo
+        end
+
+        {% if Foo.annotated_types.size == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
+    it "includes annotated classes" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        class Moo
+        end
+
+        {% if Foo.annotated_types.size == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
+    it "includes annotated structs" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        struct Moo
+        end
+
+        {% if Foo.annotated_types.size == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
+    it "does not duplicate types if multiple annotations of same type are applied" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        @[Foo]
+        struct Moo
+        end
+
+        {% if Foo.annotated_types.size == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
+    it "works with multiple types/annotations" do
+      assert_type(%(
+        annotation Foo; end
+        annotation Bar; end
+
+        @[Foo]
+        struct Chicken; end
+
+        @[Foo]
+        @[Bar]
+        class Cow; end
+
+        @[Foo]
+        module Turkey; end
+
+        class Monkey; end
+
+        {% if Foo.annotated_types.size == 3 && Bar.annotated_types.size == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+  end
 end

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -881,6 +881,26 @@ describe "Semantic: annotation" do
       )) { int32 }
     end
 
+    it "does not include children of a parent type" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        abstract struct Moo
+        end
+
+        struct Bar < Moo
+        end
+
+        {% if Foo.annotated_types == [Moo] %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+
     it "works with multiple types/annotations" do
       assert_type(%(
         annotation Foo; end

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -821,7 +821,7 @@ describe "Semantic: annotation" do
         module Moo
         end
 
-        {% if Foo.annotated_types.size == 1 %}
+        {% if Foo.annotated_types == [Moo] %}
           1
         {% else %}
           'a'
@@ -838,7 +838,7 @@ describe "Semantic: annotation" do
         class Moo
         end
 
-        {% if Foo.annotated_types.size == 1 %}
+        {% if Foo.annotated_types == [Moo] %}
           1
         {% else %}
           'a'
@@ -855,7 +855,7 @@ describe "Semantic: annotation" do
         struct Moo
         end
 
-        {% if Foo.annotated_types.size == 1 %}
+        {% if Foo.annotated_types == [Moo] %}
           1
         {% else %}
           'a'
@@ -873,7 +873,7 @@ describe "Semantic: annotation" do
         struct Moo
         end
 
-        {% if Foo.annotated_types.size == 1 %}
+        {% if Foo.annotated_types == [Moo] %}
           1
         {% else %}
           'a'
@@ -898,7 +898,7 @@ describe "Semantic: annotation" do
 
         class Monkey; end
 
-        {% if Foo.annotated_types.size == 3 && Bar.annotated_types.size == 1 %}
+        {% if Foo.annotated_types == [Chicken, Cow, Turkey] && Bar.annotated_types == [Cow] %}
           1
         {% else %}
           'a'

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1755,6 +1755,10 @@ module Crystal::Macros
     def annotations(type : TypeNode) : ArrayLiteral(Annotation)
     end
 
+    # Returns an array of `TypeNode` that are annotated with `self`.
+    def annotated_types : ArrayLiteral(TypeNode)
+    end
+
     # Returns the number of elements in this tuple type or tuple metaclass type.
     # Gives a compile error if this is not one of those types.
     def size : NumberLiteral

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1538,8 +1538,7 @@ module Crystal
           type = self.type.instance_type
           case type
           when Crystal::AnnotationType
-            types = type.class_types
-            ArrayLiteral.map(types) { |class_type| TypeNode.new class_type }
+            ArrayLiteral.map(type.annotated_types) { |t| TypeNode.new t }
           else
             raise "undefined method 'annotated_types' for TypeNode of type #{type} (must be an annotation type)"
           end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1533,6 +1533,17 @@ module Crystal
           return ArrayLiteral.new if annotations.nil?
           ArrayLiteral.map(annotations, &.itself)
         end
+      when "annotated_types"
+        interpret_argless_method(method, args) do
+          type = self.type.instance_type
+          case type
+          when Crystal::AnnotationType
+            types = type.class_types
+            ArrayLiteral.map(types) { |class_type| TypeNode.new class_type }
+          else
+            raise "undefined method 'annotated_types' for TypeNode of type #{type} (must be an annotation type)"
+          end
+        end
       when "size"
         interpret_argless_method(method, args) do
           type = self.type.instance_type

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -188,6 +188,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         end
       end
 
+      annotation_type.class_types << type unless annotation_type.class_types.includes? type
       type.add_annotation(annotation_type, ann)
     end
 
@@ -238,6 +239,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     attach_doc type, node
 
     process_annotations(annotations) do |annotation_type, ann|
+      annotation_type.class_types << type unless annotation_type.class_types.includes? type
       type.add_annotation(annotation_type, ann)
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -188,7 +188,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         end
       end
 
-      annotation_type.class_types << type unless annotation_type.class_types.includes? type
+      annotation_type.class_types << type
       type.add_annotation(annotation_type, ann)
     end
 
@@ -239,7 +239,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     attach_doc type, node
 
     process_annotations(annotations) do |annotation_type, ann|
-      annotation_type.class_types << type unless annotation_type.class_types.includes? type
+      annotation_type.class_types << type
       type.add_annotation(annotation_type, ann)
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -188,7 +188,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         end
       end
 
-      annotation_type.class_types << type
+      annotation_type.annotated_types << type
       type.add_annotation(annotation_type, ann)
     end
 
@@ -239,7 +239,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     attach_doc type, node
 
     process_annotations(annotations) do |annotation_type, ann|
-      annotation_type.class_types << type
+      annotation_type.annotated_types << type
       type.add_annotation(annotation_type, ann)
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2685,7 +2685,7 @@ module Crystal
   end
 
   class AnnotationType < NamedType
-    property class_types : Array(Type) = [] of Type
+    property class_types : Set(Type) = Set(Type).new
 
     def type_desc
       "annotation"

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2685,6 +2685,8 @@ module Crystal
   end
 
   class AnnotationType < NamedType
+    property class_types : Array(Type) = [] of Type
+
     def type_desc
       "annotation"
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2685,7 +2685,7 @@ module Crystal
   end
 
   class AnnotationType < NamedType
-    property class_types : Set(Type) = Set(Type).new
+    property annotated_types : Set(Type) = Set(Type).new
 
     def type_desc
       "annotation"


### PR DESCRIPTION
Returns an array of all types (struct/class/module) with the given annotation.  Addresses some of #7274.  

```crystal
annotation Foo
end

@[Foo(val: 1)]
class Bar
end

@[Foo(val: 2)]
class Baz
end

class Blah
end

{% for a in Foo.annotated_types %}
  pp {{a.annotation(Foo)[:val]}}
{% end %}

# => 1
# => 2
```

A future PR could add `#annotated_methods`/`#annotated_variables`, but `#annotated_types` is the more useful one IMO.

/cc @vladfaust 