### PR TITLE
Add annotation Deprecated

### DIFF
--- a/src/annotations/deprecated.cr
+++ b/src/annotations/deprecated.cr
@@ -3,7 +3,7 @@
 # It receives a `StringLiteral` as single argument containing a deprecation notice.
 #
 # ```cr
-# @[Deprecated("#foo has been deprecated, use #bar instead")]
+# @[Deprecated("use #bar instead")]
 # def foo
 # end
 # ```

--- a/src/annotations/deprecated.cr
+++ b/src/annotations/deprecated.cr
@@ -3,7 +3,7 @@
 # It receives a `StringLiteral` as single argument containing a deprecation notice.
 #
 # ```cr
-# @[Deprecated("use #bar instead")]
+# @[Deprecated("Use #bar instead")]
 # def foo
 # end
 # ```

--- a/src/annotations/deprecated.cr
+++ b/src/annotations/deprecated.cr
@@ -1,0 +1,11 @@
+# This annotations marks methods, types or constants as deprecated.
+#
+# It receives a `StringLiteral` as single argument containing a deprecation notice.
+#
+# ```cr
+# @[Deprecated("#foo has been deprecated, use #bar instead")]
+# def foo
+# end
+# ```
+annotation Deprecated
+end

--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -2,6 +2,7 @@
 # It, for example, doesn't include API for the compiler, but does include
 # the fictitious API for the Crystal::Macros module.
 
+require "./annotations/*"
 require "./big"
 require "./compiler/crystal/macros"
 require "./crypto/**"

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -28,6 +28,7 @@ require "indexable"
 require "string"
 
 # Alpha-sorted list
+require "annotations/*"
 require "array"
 require "atomic"
 require "bool"


### PR DESCRIPTION
This allows us to use `@[Deprecated]` without needing a version check to guard whether the compiler is 0.28.0 and supports it. As an additional benefit, this also adds it to the API docs.

Other compiler annotations should be documented similarly, but I'd like to get `Deprecated` merged soon in order to be able to finalize deprecation messages for 0.28.0 (for example for #7586).