### PR TITLE
Display deprecated label when @[Deprecated] is used

### DIFF
--- a/src/compiler/crystal/tools/doc/constant.cr
+++ b/src/compiler/crystal/tools/doc/constant.cr
@@ -38,4 +38,8 @@ class Crystal::Doc::Constant
       builder.field "summary", formatted_summary
     end
   end
+
+  def annotations(annotation_type)
+    @const.annotations(annotation_type)
+  end
 end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -300,6 +300,7 @@ class Crystal::Doc::Generator
 
   def doc(context, string)
     string = isolate_flag_lines string
+    string += build_flag_lines_from_annotations context
     markdown = String.build do |io|
       Markdown.parse string, MarkdownDocRenderer.new(context, io)
     end
@@ -338,6 +339,19 @@ class Crystal::Doc::Generator
           io << '\n' << line
         else
           io << line
+        end
+      end
+    end
+  end
+
+  def build_flag_lines_from_annotations(context)
+    first = true
+    String.build do |io|
+      if anns = context.annotations(@program.deprecated_annotation)
+        anns.each do |ann|
+          io << "\n\n" if first
+          first = false
+          io << "DEPRECATED: #{DeprecatedAnnotation.from(ann).message}\n\n"
         end
       end
     end

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -139,4 +139,9 @@ class Crystal::Doc::Macro
       builder.field "def", self.macro
     end
   end
+
+  def annotations(annotation_type)
+    # macros does not support annotations
+    nil
+  end
 end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -223,4 +223,8 @@ class Crystal::Doc::Method
       builder.field "def", self.def
     end
   end
+
+  def annotations(annotation_type)
+    @def.annotations(annotation_type)
+  end
 end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -837,4 +837,8 @@ class Crystal::Doc::Type
       builder.field "name", name
     end
   end
+
+  def annotations(annotation_type)
+    @type.annotations(annotation_type)
+  end
 end


### PR DESCRIPTION
~~Depends on #7652 (marked as draft until merged)~~

The last commit of the PR adds support of the doc generator tool to understand the `@[Deprecated]` and emit the same label that is currently emitted when a `# DEPRECATED: ...` comment is found.

Even before this PR the labels are only emitted for methods. But the implementation will be ready to handle them once other annotations are preserved by the parser/compiler.

<details><summary>Show me a sample (with screenshot)</summary><p>

Given the following code:

```crystal
module FOO
  # DEPRECATED: Use `Bar` instead1
  @[Deprecated("Use `Bar` instead2", "sdfs")]
  class Foo
    # DEPRECATED: Use `VAL_B` instead1
    @[Deprecated("Use `VAL_B` instead2")]
    VAL_A = 10
    VAL_B = 20

    # DEPRECATED: Use `#bar` instead1
    @[Deprecated("Use `#bar` instead2")]
    def foo
    end

    # DEPRECATED
    @[Deprecated]
    def foo2
    end

    def bar
    end

    # DEPRECATED: Use `#qux` instead1
    @[Deprecated("Use `#qux` instead2")]
    macro baz
    end

    macro qux
    end
  end

  class Bar
  end
end
```

This is the generated output:

![screencapture-file-Users-bcardiff-Projects-crystal-master-docs-FOO-Foo-html-2019-04-08-17_50_00](https://user-images.githubusercontent.com/459923/55755966-d88eb900-5a26-11e9-9556-0dd300223a8d.png)

</p></details>