### PR TITLE
Make compiler warnings opt-in

### DIFF
--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -1,0 +1,11 @@
+# This annotations marks methods, classes, constants, and macros as deprecated.
+#
+# It receives an optional `StringLiteral` as single argument containing a deprecation notice.
+#
+# ```
+# @[Deprecated("Use `#bar` instead")]
+# def foo
+# end
+# ```
+annotation Deprecated
+end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -526,7 +526,7 @@ class Crystal::Command
 
   private def setup_compiler_warning_options(opts, compiler)
     compiler.warnings_exclude << Crystal.normalize_path "lib"
-    opts.on("--warnings all|none", "Which warnings detect. (default: all)") do |w|
+    opts.on("--warnings all|none", "Which warnings detect. (default: none)") do |w|
       compiler.warnings = case w
                           when "all"
                             Crystal::Warnings::All

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -104,7 +104,7 @@ module Crystal
     property? wants_doc = false
 
     # Which kind of warnings wants to be detected.
-    property warnings : Warnings = Warnings::All
+    property warnings : Warnings = Warnings::None
 
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -116,7 +116,7 @@ module Crystal
     property codegen_target = Config.default_target
 
     # Which kind of warnings wants to be detected.
-    property warnings : Warnings = Warnings::All
+    property warnings : Warnings = Warnings::None
 
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String

--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -2,6 +2,7 @@
 # It, for example, doesn't include API for the compiler, but does include
 # the fictitious API for the Crystal::Macros module.
 
+require "./annotations"
 require "./big"
 require "./compiler/crystal/macros"
 require "./crypto/**"

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -28,6 +28,7 @@ require "indexable"
 require "string"
 
 # Alpha-sorted list
+require "annotations"
 require "array"
 require "atomic"
 require "bool"


### PR DESCRIPTION
Closes #7652 and Closes #7650.

Change compiler warnings to be opt-in. Will help gather feedback without a default noisy output for everybody.