### PR TITLE
Add deprecation message to PartialComparable

### DIFF
--- a/src/partial_comparable.cr
+++ b/src/partial_comparable.cr
@@ -7,8 +7,7 @@
 #
 # `PartialComparable` uses `<=>` to implement the conventional
 # comparison operators (`<`, `<=`, `==`, `>=`, and `>`).
-#
-# DEPRECATED: This module is deprecated as of Crystal 0.28.0. Its behaviour has been fully integrated into `Comparable`.
+@[Deprecated("This module is deprecated as of Crystal 0.28.0. Its behaviour has been fully integrated into `Comparable`.")]
 module PartialComparable(T)
   # Compares this object to *other* based on the receiver's `<=>` method,
   # returning `true` if it returns a negative number.

--- a/src/partial_comparable.cr
+++ b/src/partial_comparable.cr
@@ -1,3 +1,4 @@
+@[Deprecated("This module is deprecated as of Crystal 0.28.0. Its behaviour has been fully integrated into `Comparable`.")]
 # The `PartialComparable` mixin is used by classes whose objects may be partially ordered.
 #
 # Including types must provide an `<=>` method, which compares the receiver against
@@ -7,7 +8,6 @@
 #
 # `PartialComparable` uses `<=>` to implement the conventional
 # comparison operators (`<`, `<=`, `==`, `>=`, and `>`).
-@[Deprecated("This module is deprecated as of Crystal 0.28.0. Its behaviour has been fully integrated into `Comparable`.")]
 module PartialComparable(T)
   # Compares this object to *other* based on the receiver's `<=>` method,
   # returning `true` if it returns a negative number.

--- a/src/partial_comparable.cr
+++ b/src/partial_comparable.cr
@@ -7,6 +7,8 @@
 #
 # `PartialComparable` uses `<=>` to implement the conventional
 # comparison operators (`<`, `<=`, `==`, `>=`, and `>`).
+#
+# DEPRECATED: This module is deprecated as of Crystal 0.28.0. Its behaviour has been fully integrated into `Comparable`.
 module PartialComparable(T)
   # Compares this object to *other* based on the receiver's `<=>` method,
   # returning `true` if it returns a negative number.


### PR DESCRIPTION
Follow up on #6611 

Adding `@[Deprecated]` annotation to `#<=>` method is not detected by the warning feature. I don't think it makes sense to add annotations to the other methods. This module seems to be pretty much not used anywhere at all.