### PR TITLE
Fix &block restriction for documentation

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -914,7 +914,7 @@ abstract class IO
   # # hello
   # # world
   # ```
-  def each_line(*args, **options, &block : String -> _) : Nil
+  def each_line(*args, **options, &block : String ->) : Nil
     while line = gets(*args, **options)
       yield line
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3390,7 +3390,7 @@ class String
   # # even the monkey seems to want
   # # a little coat of straw
   # ```
-  def each_line(chomp = true, &block : String -> _) : Nil
+  def each_line(chomp = true, &block : String ->) : Nil
     return if empty?
 
     offset = 0


### PR DESCRIPTION
The return type of these blocks is not used. So the right documentation is `String ->` without the underscore.

I think there is an underlying issue I didn't dig far enough. The [build log](https://circleci.com/gh/bcardiff/crystal/1373?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) shown that [this exit](https://github.com/crystal-lang/crystal/pull/7546/commits/db2c377dc34f447a9f26615db74434003e77221b#diff-3920767d4904eb70109bd332570d8cc4R77) triggers an error in [this block usage](https://github.com/crystal-lang/crystal/blob/51238b4e03e18773c9be96d72f9d64deb723bb5f/src/compiler/crystal/compiler.cr#L400) but this change solved the issue and the restriction was added recently in #7419