### PR TITLE
Restore Time.new(Location) as deprecated method

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -432,6 +432,11 @@ struct Time
   end
 
   @[Deprecated("Use `Time.local` instead.")]
+  def self.new(location : Location = Location.local) : Time
+    local(location)
+  end
+
+  @[Deprecated("Use `Time.local` instead.")]
   def self.new(year : Int32, month : Int32, day : Int32, hour : Int32 = 0, minute : Int32 = 0, second : Int32 = 0, *, nanosecond : Int32 = 0, location : Location = Location.local) : Time
     local(year, month, day, hour, minute, second, nanosecond: nanosecond, location: location)
   end


### PR DESCRIPTION
As part of #7586 to avoid major breaking changes in #5346 the following constructor should be added.

I notice that this overload was missing in https://github.com/crystal-lang/crystal/pull/7668#issuecomment-482733404