### PR TITLE
[RFC] Implement String wrappers

### DIFF
--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -137,7 +137,7 @@ class Program
     new source.chars
   end
 
-  def self.new(source : Array(Char))
+  def self.new(source : String::Chars)
     new parse(source, 0, source.size)
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -606,7 +606,7 @@ describe IO do
         buffer = uninitialized UInt8[1024]
         bytes_read = io.read_utf8(buffer.to_slice) # => 3
         bytes_read.should eq(3)
-        buffer.to_slice[0, bytes_read].to_a.should eq("你".bytes)
+        buffer.to_slice[0, bytes_read].to_a.should eq("你".bytes.to_a)
       end
 
       it "raises on incomplete byte sequence" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1722,7 +1722,7 @@ describe "String" do
   end
 
   it "does chars" do
-    "ぜんぶ".chars.should eq(['ぜ', 'ん', 'ぶ'])
+    "ぜんぶ".chars.to_a.should eq(['ぜ', 'ん', 'ぶ'])
   end
 
   it "allows creating a string with zeros" do
@@ -2066,21 +2066,21 @@ describe "String" do
   end
 
   it "gets lines" do
-    "".lines.should eq([] of String)
-    "\n".lines.should eq([""] of String)
-    "\r".lines.should eq(["\r"] of String)
-    "\r\n".lines.should eq([""] of String)
-    "foo".lines.should eq(["foo"])
-    "foo\n".lines.should eq(["foo"])
-    "foo\r\n".lines.should eq(["foo"])
-    "foo\nbar\r\nbaz\n".lines.should eq(["foo", "bar", "baz"])
-    "foo\nbar\r\nbaz\r\n".lines.should eq(["foo", "bar", "baz"])
+    "".lines.to_a.should eq([] of String)
+    "\n".lines.to_a.should eq([""] of String)
+    "\r".lines.to_a.should eq(["\r"] of String)
+    "\r\n".lines.to_a.should eq([""] of String)
+    "foo".lines.to_a.should eq(["foo"])
+    "foo\n".lines.to_a.should eq(["foo"])
+    "foo\r\n".lines.to_a.should eq(["foo"])
+    "foo\nbar\r\nbaz\n".lines.to_a.should eq(["foo", "bar", "baz"])
+    "foo\nbar\r\nbaz\r\n".lines.to_a.should eq(["foo", "bar", "baz"])
   end
 
   it "gets lines with chomp = false" do
-    "foo".lines(chomp: false).should eq(["foo"])
-    "foo\nbar\r\nbaz\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\n"])
-    "foo\nbar\r\nbaz\r\n".lines(chomp: false).should eq(["foo\n", "bar\r\n", "baz\r\n"])
+    "foo".lines(chomp: false).to_a.should eq(["foo"])
+    "foo\nbar\r\nbaz\n".lines(chomp: false).to_a.should eq(["foo\n", "bar\r\n", "baz\n"])
+    "foo\nbar\r\nbaz\r\n".lines(chomp: false).to_a.should eq(["foo\n", "bar\r\n", "baz\r\n"])
   end
 
   it "gets each_line" do
@@ -2448,12 +2448,12 @@ describe "String" do
 
     it "gets chars" do
       string = String.new(Bytes[255, 0, 0, 0, 65])
-      string.chars.should eq([Char::REPLACEMENT, 0.chr, 0.chr, 0.chr, 65.chr])
+      string.chars.to_a.should eq([Char::REPLACEMENT, 0.chr, 0.chr, 0.chr, 65.chr])
     end
 
     it "gets chars (2)" do
       string = String.new(Bytes[255, 0])
-      string.chars.should eq([Char::REPLACEMENT, 0.chr])
+      string.chars.to_a.should eq([Char::REPLACEMENT, 0.chr])
     end
 
     it "valid_encoding?" do
@@ -2463,7 +2463,7 @@ describe "String" do
 
     it "scrubs" do
       string = String.new(Bytes[255, 129, 97, 255, 97])
-      string.scrub.bytes.should eq([239, 191, 189, 97, 239, 191, 189, 97])
+      string.scrub.bytes.to_a.should eq([239, 191, 189, 97, 239, 191, 189, 97])
 
       string.scrub("?").should eq("?a?a")
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4695,8 +4695,7 @@ module Crystal
 
         begin
           formatted_comment = Formatter.format(comment)
-          formatted_lines = formatted_comment.lines
-          formatted_lines.map! do |line|
+          formatted_lines = formatted_comment.lines.map do |line|
             String.build do |str|
               sharp_index.times { str << ' ' }
               str << "# "

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -6,7 +6,7 @@ class Markdown::Parser
   @lines : Array(String)
 
   def initialize(text : String, @renderer : Renderer)
-    @lines = text.lines
+    @lines = text.lines.to_a
     @line = 0
   end
 

--- a/src/uri/punycode.cr
+++ b/src/uri/punycode.cr
@@ -99,7 +99,7 @@ class URI
 
     def self.decode(string)
       output, _, rest = string.rpartition(DELIMITER)
-      output = output.chars
+      output = output.chars.to_a
 
       n = INITIAL_N
       bias = INITIAL_BIAS


### PR DESCRIPTION
This wrappers represents the string as a sequence of Chars, Lines or Bytes

Implements #7645 

This PR mainly exists to show how String wrappers can be implemented in practice, with as little breaking changes as possible.

Main advantages are:
- performance gain by removing the need of an intermediate Array
- less boilerplating by using `Indexable` (no need to reimplement)
- benefit from all methods brought by `Indexable`

Disadvantages - breaking changes:
- `String#chars` -> `String#chars.to_a`
- `String#bytes` -> `String#bytes.to_a`
- `String#lines` -> `String#lines(chomp = true).to_a`

Another thing is the chomp argument to pass for every lines related methods, `@chomp` is now an ivar to pass only once in the constructor.

We can see latter what we do for other existing methods `each_char`, `each_char_with_index`, `each_line` etc