### PR TITLE
Restore File.join for single arguments

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -322,6 +322,8 @@ describe "File" do
     File.join(["foo", "/", "bar"]).should eq("foo/bar")
     File.join(["foo", "/", "/", "bar"]).should eq("foo/bar")
     File.join(["/", "/foo", "/", "bar/", "/"]).should eq("/foo/bar/")
+    File.join(["foo"]).should eq("foo")
+    File.join("foo").should eq("foo")
   end
 
   it "chown" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -690,8 +690,8 @@ class File < IO::FileDescriptor
   # File.join("foo/", "/bar/", "/baz")   # => "foo/bar/baz"
   # File.join("/foo/", "/bar/", "/baz/") # => "/foo/bar/baz/"
   # ```
-  def self.join(first : String | Path, *parts : String | Path) : String
-    Path.new(first, *parts).to_s
+  def self.join(*parts : String | Path) : String
+    Path.new(*parts).to_s
   end
 
   # Returns a new string formed by joining the strings using `File::SEPARATOR`.


### PR DESCRIPTION
After [a change in file.cr in #5635](https://github.com/crystal-lang/crystal/pull/5635/files#diff-f8eae7ee99e3c68635bfdd55a95eb2c0R693) `File.join(str)` no longer compiles.

Although it can be argued that if someone uses that call it can be removed, it is useful in case of tuple and splats.

NB: found it while smoke testing the release with amber