### PR TITLE
Move bsearch-related private top-level methods to Range

### DIFF
--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -1,73 +1,73 @@
-{% for p in [64, 32] %}
-  # Cast integer as floating number value with keeping binary structure.
-  private def int_as_float(i : Int{{ p }})
-    # Integer uses two's complement to represent signed number, but
-    # floating number value uses sign bit. This difference causes a
-    # problem that it reproduce incorrect value when you sum positive
-    # number and negative number. It fixes this problem.
-    if i < 0
-      i = -i
-      -i.unsafe_as(Float{{ p }})
-    else
-      i.unsafe_as(Float{{ p }})
-    end
-  end
-
-  # Cast floating number value as integer with keeping binary structure.
-  private def float_as_int(f : Float{{ p }})
-    if f < 0
-      f = -f
-      -f.unsafe_as(Int{{ p }})
-    else
-      f.unsafe_as(Int{{ p }})
-    end
-  end
-
-  private def bsearch_internal(from : Float{{ p }}, to, exclusive, &block)
-    bsearch_internal from, to.to_f{{ p }}, exclusive do |value|
-      yield value
-    end
-  end
-
-  private def bsearch_internal(from, to : Float{{ p }}, exclusive)
-    bsearch_internal from.to_f{{ p }}, to, exclusive do |value|
-      yield value
-    end
-  end
-
-  private def bsearch_internal(from : Float{{ p }}, to : Float{{ p }}, exclusive)
-    from = float_as_int from
-    to = float_as_int to
-    to -= 1 if exclusive
-
-    bsearch_internal(from, to, false){ |i| yield int_as_float i }
-      .try{ |i| int_as_float i }
-  end
-
-  private def bsearch_internal(from : Int{{ p }}, to : Int{{ p }}, exclusive)
-    saved_to = to
-    satisfied = nil
-    while from < to
-      mid = (from < 0) == (to < 0) ? from + ((to - from) >> 1)
-          : (from < -to) ? -(((- from - to - 1) >> 1) + 1) : ((from + to) >> 1)
-
-      if yield mid
-        satisfied = mid
-        to = mid
+struct Range(B, E)
+  {% for p in [64, 32] %}
+    # Cast integer as floating number value with keeping binary structure.
+    private def int_as_float(i : Int{{ p }})
+      # Integer uses two's complement to represent signed number, but
+      # floating number value uses sign bit. This difference causes a
+      # problem that it reproduce incorrect value when you sum positive
+      # number and negative number. It fixes this problem.
+      if i < 0
+        i = -i
+        -i.unsafe_as(Float{{ p }})
       else
-        from = mid + 1
+        i.unsafe_as(Float{{ p }})
       end
     end
 
-    if !exclusive && from == saved_to && yield from
-      satisfied = from
+    # Cast floating number value as integer with keeping binary structure.
+    private def float_as_int(f : Float{{ p }})
+      if f < 0
+        f = -f
+        -f.unsafe_as(Int{{ p }})
+      else
+        f.unsafe_as(Int{{ p }})
+      end
     end
 
-    satisfied
-  end
-{% end %}
+    private def bsearch_internal(from : Float{{ p }}, to, exclusive, &block)
+      bsearch_internal from, to.to_f{{ p }}, exclusive do |value|
+        yield value
+      end
+    end
 
-struct Range(B, E)
+    private def bsearch_internal(from, to : Float{{ p }}, exclusive)
+      bsearch_internal from.to_f{{ p }}, to, exclusive do |value|
+        yield value
+      end
+    end
+
+    private def bsearch_internal(from : Float{{ p }}, to : Float{{ p }}, exclusive)
+      from = float_as_int from
+      to = float_as_int to
+      to -= 1 if exclusive
+
+      bsearch_internal(from, to, false){ |i| yield int_as_float i }
+        .try{ |i| int_as_float i }
+    end
+
+    private def bsearch_internal(from : Int{{ p }}, to : Int{{ p }}, exclusive)
+      saved_to = to
+      satisfied = nil
+      while from < to
+        mid = (from < 0) == (to < 0) ? from + ((to - from) >> 1)
+            : (from < -to) ? -(((- from - to - 1) >> 1) + 1) : ((from + to) >> 1)
+
+        if yield mid
+          satisfied = mid
+          to = mid
+        else
+          from = mid + 1
+        end
+      end
+
+      if !exclusive && from == saved_to && yield from
+        satisfied = from
+      end
+
+      satisfied
+    end
+  {% end %}
+
   # By using binary search, returns the first value
   # for which the passed block returns `true`.
   #


### PR DESCRIPTION
This moves methods that are used for implementing binary search into `Range` instead of leaving it outside on the top-level, they don't belong on the top-level. Then the `private` attribute of the methods also makes sense because private methods on the top-level can still be called and `private` does nothing. I found these when doing `{% puts @type.methods %}`.