### PR TITLE
HTTP: Make return value of Response#status_code an Int32

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -146,7 +146,8 @@ module HTTP
       it "sets status code" do
         io = IO::Memory.new
         response = Response.new(io)
-        response.status_code = 201
+        return_value = response.status_code = 201
+        return_value.should eq 201
         response.status.should eq HTTP::Status::CREATED
       end
 

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -70,6 +70,7 @@ class HTTP::Server
     # Convenience method to set the HTTP status code.
     def status_code=(status_code : Int32)
       self.status = HTTP::Status.new(status_code)
+      status_code
     end
 
     # See `IO#write(slice)`.


### PR DESCRIPTION
In #7247 the idea was to keep the `Response#status_code` API. The setter should return the same `Int32` value that it is assigned and not the new `HTTP::Status`. cc: @dwightwatson

---

NB: Discovered while testing amber controller fixtures where

```crystal
respond_with do
  html ->{ redirect_to "/some_path" }
end
```

stopped compiling because the block was no longer returning `Int32` since the value was determined by the setter called in [Amber's HTTP::Server::Context#halt!](https://github.com/amberframework/amber/blob/master/src/amber/router/context.cr#L66).