### PR TITLE
Implement named/pos_args annotation methods

### DIFF
--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -12,7 +12,43 @@ describe "Semantic: annotation" do
     type.name.should eq("Foo")
   end
 
-  describe "#*_args" do
+  describe "#args/named_args" do
+    describe "#args" do
+      it "returns an empty TupleLiteral if there are none defined" do
+        assert_type(%(
+          annotation Foo
+          end
+
+          @[Foo]
+          module Moo
+          end
+
+          {% if (args = Moo.annotation(Foo).args) && args.is_a? TupleLiteral && args.empty? %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
+      end
+
+      it "returns a TupleLiteral if there are positional arguments defined" do
+        assert_type(%(
+          annotation Foo
+          end
+
+          @[Foo(1, "foo", true)]
+            module Moo
+          end
+
+          {% if Moo.annotation(Foo).args == {1, "foo", true} %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
+      end
+    end
+
     describe "#named_args" do
       it "returns an empty NamedTupleLiteral if there are none defined" do
         assert_type(%(
@@ -49,42 +85,6 @@ describe "Semantic: annotation" do
       end
     end
 
-    describe "#pos_args" do
-      it "returns an empty TupleLiteral if there are none defined" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo]
-          module Moo
-          end
-
-          {% if (args = Moo.annotation(Foo).pos_args) && args.is_a? TupleLiteral && args.empty? %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-
-      it "returns a TupleLiteral if there are positional arguments defined" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo(1, "foo", true)]
-            module Moo
-          end
-
-          {% if Moo.annotation(Foo).pos_args == {1, "foo", true} %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-    end
-
     it "returns a correctly with both positional and named arguments" do
       assert_type(%(
         annotation Foo
@@ -94,7 +94,7 @@ describe "Semantic: annotation" do
           module Moo
         end
 
-        {% if Moo.annotation(Foo).pos_args == {1, "foo", true} && Moo.annotation(Foo).named_args == {foo: "bar", cat: 0..0} %}
+        {% if Moo.annotation(Foo).args == {1, "foo", true} && Moo.annotation(Foo).named_args == {foo: "bar", cat: 0..0} %}
           1
         {% else %}
           'a'

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -16,72 +16,72 @@ describe "Semantic: annotation" do
     describe "#named_args" do
       it "returns an empty NamedTupleLiteral if there are none defined" do
         assert_type(%(
-        annotation Foo
-        end
+          annotation Foo
+          end
 
-        @[Foo]
-        module Moo
-        end
+          @[Foo]
+          module Moo
+          end
 
-        {% if (args = Moo.annotation(Foo).named_args) && args.is_a? NamedTupleLiteral && args.empty? %}
-          1
-        {% else %}
-          'a'
-        {% end %}
-      )) { int32 }
+          {% if (args = Moo.annotation(Foo).named_args) && args.is_a? NamedTupleLiteral && args.empty? %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
       end
 
       it "returns a NamedTupleLiteral if there are named arguments defined" do
         assert_type(%(
-        annotation Foo
-        end
+          annotation Foo
+          end
 
-        @[Foo(extra: "three", "foo": 99)]
-          module Moo
-        end
+          @[Foo(extra: "three", "foo": 99)]
+            module Moo
+          end
 
-        {% if Moo.annotation(Foo).named_args == {extra: "three", foo: 99} %}
-          1
-        {% else %}
-          'a'
-        {% end %}
-      )) { int32 }
+          {% if Moo.annotation(Foo).named_args == {extra: "three", foo: 99} %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
       end
     end
 
     describe "#pos_args" do
       it "returns an empty TupleLiteral if there are none defined" do
         assert_type(%(
-        annotation Foo
-        end
+          annotation Foo
+          end
 
-        @[Foo]
-        module Moo
-        end
+          @[Foo]
+          module Moo
+          end
 
-        {% if (args = Moo.annotation(Foo).pos_args) && args.is_a? TupleLiteral && args.empty? %}
-          1
-        {% else %}
-          'a'
-        {% end %}
-      )) { int32 }
+          {% if (args = Moo.annotation(Foo).pos_args) && args.is_a? TupleLiteral && args.empty? %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
       end
 
       it "returns a TupleLiteral if there are positional arguments defined" do
         assert_type(%(
-        annotation Foo
-        end
+          annotation Foo
+          end
 
-        @[Foo(1, "foo", true)]
-          module Moo
-        end
+          @[Foo(1, "foo", true)]
+            module Moo
+          end
 
-        {% if Moo.annotation(Foo).pos_args == {1, "foo", true} %}
-          1
-        {% else %}
-          'a'
-        {% end %}
-      )) { int32 }
+          {% if Moo.annotation(Foo).pos_args == {1, "foo", true} %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
       end
     end
 

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -14,76 +14,6 @@ describe "Semantic: annotation" do
 
   describe "arguments" do
     describe "#args" do
-      it "returns a NamedTupleLiteral with empty values if there are non defined" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo]
-          module Moo
-          end
-
-          {% if (args = Moo.annotation(Foo).args) && args["named"].empty? && args["positional"].empty? %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-
-      it "returns an empty NamedTuple if there no named arguments defined" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo(1, "foo", true)]
-          module Moo
-          end
-
-          {% if (args = Moo.annotation(Foo).args) && args["named"].empty? && args["positional"] == {1, "foo", true} %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-
-      it "returns an empty Tuple if there no positional arguments defined" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo(foo: "bar", "cat": 0..0)]
-          module Moo
-          end
-
-          {% if (args = Moo.annotation(Foo).args) && args["positional"].empty? && args["named"] == {foo: "bar", cat: 0..0} %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-
-      it "returns a correctly with both types of args" do
-        assert_type(%(
-          annotation Foo
-          end
-
-          @[Foo(1, "foo", true, foo: "bar", "cat": 0..0)]
-            module Moo
-          end
-
-          {% if Moo.annotation(Foo).args == {named: {foo: "bar", cat: 0..0}, positional: {1, "foo", true}} %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
-      end
-    end
-
-    describe "#pos_args" do
       it "returns an empty TupleLiteral if there are none defined" do
         assert_type(%(
           annotation Foo
@@ -93,7 +23,7 @@ describe "Semantic: annotation" do
           module Moo
           end
 
-          {% if (args = Moo.annotation(Foo).pos_args) && args.is_a? TupleLiteral && args.empty? %}
+          {% if (pos_args = Moo.annotation(Foo).args) && pos_args.is_a? TupleLiteral && pos_args.empty? %}
             1
           {% else %}
             'a'
@@ -110,7 +40,7 @@ describe "Semantic: annotation" do
             module Moo
           end
 
-          {% if Moo.annotation(Foo).pos_args == {1, "foo", true} %}
+          {% if Moo.annotation(Foo).args == {1, "foo", true} %}
             1
           {% else %}
             'a'
@@ -155,7 +85,7 @@ describe "Semantic: annotation" do
       end
     end
 
-    it "returns a correctly with #named_args and #pos_args" do
+    it "returns a correctly with named and positional args" do
       assert_type(%(
         annotation Foo
         end
@@ -164,7 +94,7 @@ describe "Semantic: annotation" do
           module Moo
         end
 
-        {% if Moo.annotation(Foo).pos_args == {1, "foo", true} && Moo.annotation(Foo).named_args == {foo: "bar", cat: 0..0} %}
+        {% if Moo.annotation(Foo).args == {1, "foo", true} && Moo.annotation(Foo).named_args == {foo: "bar", cat: 0..0} %}
           1
         {% else %}
           'a'

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -12,6 +12,97 @@ describe "Semantic: annotation" do
     type.name.should eq("Foo")
   end
 
+  describe "#*_args" do
+    describe "#named_args" do
+      it "returns an empty NamedTupleLiteral if there are none defined" do
+        assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        module Moo
+        end
+
+        {% if (args = Moo.annotation(Foo).named_args) && args.is_a? NamedTupleLiteral && args.empty? %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+      end
+
+      it "returns a NamedTupleLiteral if there are named arguments defined" do
+        assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo(extra: "three", "foo": 99)]
+          module Moo
+        end
+
+        {% if Moo.annotation(Foo).named_args == {extra: "three", foo: 99} %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+      end
+    end
+
+    describe "#pos_args" do
+      it "returns an empty TupleLiteral if there are none defined" do
+        assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo]
+        module Moo
+        end
+
+        {% if (args = Moo.annotation(Foo).pos_args) && args.is_a? TupleLiteral && args.empty? %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+      end
+
+      it "returns a TupleLiteral if there are positional arguments defined" do
+        assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo(1, "foo", true)]
+          module Moo
+        end
+
+        {% if Moo.annotation(Foo).pos_args == {1, "foo", true} %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+      end
+    end
+
+    it "returns a correctly with both positional and named arguments" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        @[Foo(1, "foo", true, foo: "bar", "cat": 0..0)]
+          module Moo
+        end
+
+        {% if Moo.annotation(Foo).pos_args == {1, "foo", true} && Moo.annotation(Foo).named_args == {foo: "bar", cat: 0..0} %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      )) { int32 }
+    end
+  end
+
   describe "#annotations" do
     it "returns an empty array if there are none defined" do
       assert_type(%(

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -878,13 +878,8 @@ module Crystal::Macros
     def [](name : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
 
-    # Returns a `NamedTupleLiteral(named: NamedTupleLiteral, positional: TupleLiteral)`
-    # representing the positional and named arguments on `self`.
-    def args : NamedTupleLiteral(named: NamedTupleLiteral, positional: TupleLiteral)
-    end
-
     # Returns a `TupleLiteral` representing the positional arguments on `self`.
-    def pos_args : TupleLiteral
+    def args : TupleLiteral
     end
 
     # Returns a `NamedTupleLiteral` representing the named arguments on `self`.

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -874,8 +874,16 @@ module Crystal::Macros
 
     # Returns the value of a named argument,
     # or NilLiteral if the named argument isn't
-    # used in this attribute.
+    # used on `self`.
     def [](name : SymbolLiteral | StringLiteral | MacroId) : ASTNode
+    end
+
+    # Returns a `NamedTupleLiteral` representing the named arguments on `self`.
+    def named_args : NamedTupleLiteral
+    end
+
+    # Returns a `TupleLiteral` representing the positional arguments on `self`.
+    def pos_args : TupleLiteral
     end
   end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -878,8 +878,13 @@ module Crystal::Macros
     def [](name : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
 
+    # Returns a `NamedTupleLiteral(named: NamedTupleLiteral, positional: TupleLiteral)`
+    # representing the positional and named arguments on `self`.
+    def args : NamedTupleLiteral(named: NamedTupleLiteral, positional: TupleLiteral)
+    end
+
     # Returns a `TupleLiteral` representing the positional arguments on `self`.
-    def args : TupleLiteral
+    def pos_args : TupleLiteral
     end
 
     # Returns a `NamedTupleLiteral` representing the named arguments on `self`.

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -878,12 +878,12 @@ module Crystal::Macros
     def [](name : SymbolLiteral | StringLiteral | MacroId) : ASTNode
     end
 
-    # Returns a `NamedTupleLiteral` representing the named arguments on `self`.
-    def named_args : NamedTupleLiteral
+    # Returns a `TupleLiteral` representing the positional arguments on `self`.
+    def args : TupleLiteral
     end
 
-    # Returns a `TupleLiteral` representing the positional arguments on `self`.
-    def pos_args : TupleLiteral
+    # Returns a `NamedTupleLiteral` representing the named arguments on `self`.
+    def named_args : NamedTupleLiteral
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2107,16 +2107,6 @@ module Crystal
         end
       when "args"
         interpret_argless_method(method, args) do
-          named_args = get_named_annotation_args self
-          pos_args = TupleLiteral.new self.args
-
-          NamedTupleLiteral.new([
-            NamedTupleLiteral::Entry.new("named", named_args),
-            NamedTupleLiteral::Entry.new("positional", pos_args),
-          ])
-        end
-      when "pos_args"
-        interpret_argless_method(method, args) do
           TupleLiteral.new self.args
         end
       when "named_args"

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2105,6 +2105,18 @@ module Crystal
           end
           named_arg.try(&.value) || NilLiteral.new
         end
+      when "named_args"
+        interpret_argless_method(method, args) do
+          if named_args = self.named_args
+            NamedTupleLiteral.new(named_args.map { |arg| NamedTupleLiteral::Entry.new(arg.name, arg.value) })
+          else
+            NamedTupleLiteral.new
+          end
+        end
+      when "pos_args"
+        interpret_argless_method(method, args) do
+          TupleLiteral.new self.args
+        end
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2107,20 +2107,34 @@ module Crystal
         end
       when "args"
         interpret_argless_method(method, args) do
+          named_args = get_named_annotation_args self
+          pos_args = TupleLiteral.new self.args
+
+          NamedTupleLiteral.new([
+            NamedTupleLiteral::Entry.new("named", named_args),
+            NamedTupleLiteral::Entry.new("positional", pos_args),
+          ])
+        end
+      when "pos_args"
+        interpret_argless_method(method, args) do
           TupleLiteral.new self.args
         end
       when "named_args"
         interpret_argless_method(method, args) do
-          if named_args = self.named_args
-            NamedTupleLiteral.new(named_args.map { |arg| NamedTupleLiteral::Entry.new(arg.name, arg.value) })
-          else
-            NamedTupleLiteral.new
-          end
+          get_named_annotation_args self
         end
       else
         super
       end
     end
+  end
+end
+
+private def get_named_annotation_args(object)
+  if named_args = object.named_args
+    Crystal::NamedTupleLiteral.new(named_args.map { |arg| Crystal::NamedTupleLiteral::Entry.new(arg.name, arg.value) })
+  else
+    Crystal::NamedTupleLiteral.new
   end
 end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2105,6 +2105,10 @@ module Crystal
           end
           named_arg.try(&.value) || NilLiteral.new
         end
+      when "args"
+        interpret_argless_method(method, args) do
+          TupleLiteral.new self.args
+        end
       when "named_args"
         interpret_argless_method(method, args) do
           if named_args = self.named_args
@@ -2112,10 +2116,6 @@ module Crystal
           else
             NamedTupleLiteral.new
           end
-        end
-      when "pos_args"
-        interpret_argless_method(method, args) do
-          TupleLiteral.new self.args
         end
       else
         super


### PR DESCRIPTION
Resolves #7692.

Adds `#named_args` and `#args` methods to `Annotation`.