### PR TITLE
Creating ** method in BigDecimal and BigRational

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -454,4 +454,8 @@ describe BigDecimal do
   describe "#inspect" do
     it { "123".to_big_d.inspect.should eq("123") }
   end
+
+  describe "#**" do
+    it { (Math.log(2).to_big_d**3).should eq(0.333024651988929466145240916046094220685147532677) }
+  end
 end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -210,7 +210,7 @@ struct BigDecimal < Number
     k = self
     result = k.class.new(1)
     while exponent > 0
-      result *= k
+      result *= k if exponent & 0b1 != 0
       exponent = exponent.unsafe_shr(1)
       k *= k if exponent > 0
     end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -199,11 +199,20 @@ struct BigDecimal < Number
     (self / other).floor
   end
 
-  # Returns the value of raising `self` to the power of *other* exponent.
-  def **(other : Int)
-    result = 1
-    other.times do
-      result *= self
+  # Returns the value of raising `self` to the power of *exponent* exponent.
+  # 
+  # Raise `ArgumentError` if *exponent* is negative.
+  def **(exponent : Int)
+    if exponent < 0
+      raise ArgumentError.new "Cannot raise a BigDecimal to a negative integer power."
+    end
+
+    k = self
+    result = k.class.new(1)
+    while exponent > 0
+      result *= k
+      exponent = exponent.unsafe_shr(1)
+      k *= k if exponent > 0
     end
     result
   end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -199,6 +199,10 @@ struct BigDecimal < Number
     (self / other).floor
   end
 
+  def **(other : Int)
+    ([self] * other).reduce { |i, j| i * j }
+  end
+
   # Divides `self` with another `BigDecimal`, with a optionally configurable *max_div_iterations*, which
   # defines a maximum number of iterations in case the division is not exact.
   #

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -200,7 +200,7 @@ struct BigDecimal < Number
   end
 
   # Returns the value of raising `self` to the power of *exponent* exponent.
-  # 
+  #
   # Raise `ArgumentError` if *exponent* is negative.
   def **(exponent : Int)
     if exponent < 0

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -199,7 +199,7 @@ struct BigDecimal < Number
     (self / other).floor
   end
 
-  # Returns `self` at the power `other`
+  # Returns the value of raising `self` to the power of *other* exponent.
   def **(other : Int)
     result = 1
     other.times do

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -200,7 +200,11 @@ struct BigDecimal < Number
   end
 
   def **(other : Int)
-    ([self] * other).reduce { |i, j| i * j }
+    result = 1
+    other.times do
+      result *= self
+    end
+    result
   end
 
   # Divides `self` with another `BigDecimal`, with a optionally configurable *max_div_iterations*, which

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -199,6 +199,7 @@ struct BigDecimal < Number
     (self / other).floor
   end
 
+  # Returns `self` at the power `other`
   def **(other : Int)
     result = 1
     other.times do

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -170,6 +170,7 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_neg(mpq, self) }
   end
 
+  # Returns `self` at the power `other`
   def **(other : Int)
     result = 1
     other.times do

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -170,11 +170,20 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_neg(mpq, self) }
   end
 
-  # Returns `self` at the power `other`
-  def **(other : Int)
-    result = 1
-    other.times do
-      result *= self
+  # Returns the value of raising `self` to the power of *exponent* exponent.
+  #
+  # Raise `ArgumentError` if *exponent* is negative.
+  def **(exponent : Int)
+    if exponent < 0
+      raise ArgumentError.new "Cannot raise a BigRational to a negative integer power."
+    end
+
+    k = self
+    result = k.class.new(1)
+    while exponent > 0
+      result *= k
+      exponent = exponent.unsafe_shr(1)
+      k *= k if exponent > 0
     end
     result
   end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -181,7 +181,7 @@ struct BigRational < Number
     k = self
     result = k.class.new(1)
     while exponent > 0
-      result *= k
+      result *= k if exponent & 0b1 != 0
       exponent = exponent.unsafe_shr(1)
       k *= k if exponent > 0
     end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -171,7 +171,11 @@ struct BigRational < Number
   end
 
   def **(other : Int)
-    ([self] * other).reduce { |i, j| i * j }
+    result = 1
+    other.times do
+      result *= self
+    end
+    result
   end
 
   # Returns a new `BigRational` as 1/r.

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -170,6 +170,10 @@ struct BigRational < Number
     BigRational.new { |mpq| LibGMP.mpq_neg(mpq, self) }
   end
 
+  def **(other : Int)
+    ([self] * other).reduce { |i, j| i * j }
+  end
+
   # Returns a new `BigRational` as 1/r.
   #
   # This will raise an exception if rational is 0.


### PR DESCRIPTION
Resolves [#7680](https://github.com/crystal-lang/crystal/issues/7680)

Adds `**` method to BigRational and BigDecimal