### PR TITLE
Fix examples 2019 04

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -363,8 +363,8 @@ describe Time do
       t2 = t.shift months: 1
       t2.should eq Time.utc(2014, 11, 30, 21, 18, 13)
 
-      t2 = t.shift months: 1
-      t2.should eq Time.utc(2014, 11, 30, 21, 18, 13)
+      t2 = t.shift months: -1
+      t2.should eq Time.utc(2014, 9, 30, 21, 18, 13)
 
       t = Time.utc 2014, 10, 31, 21, 18, 13
       t2 = t.shift months: 1

--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -22,7 +22,7 @@ end
 # end
 #
 # (IOMode::Write | IOMode::Async).value # => 6
-# puts IOMode::Write | IOMode::Async    # => Write | Async
+# (IOMode::Write | IOMode::Async).to_s  # => "Write | Async"
 # ```
 annotation Flags
 end

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -11,7 +11,6 @@ require "mime/multipart"
 #
 # ```
 # require "http"
-# require "tempfile"
 #
 # server = HTTP::Server.new do |context|
 #   name = nil

--- a/src/path.cr
+++ b/src/path.cr
@@ -48,11 +48,11 @@
 # ```
 # Path.posix("/foo/./bar").normalize   # => Path.posix("/foo/bar")
 # Path.windows("/foo/./bar").normalize # => Path.windows("\\foo\\bar")
-
+#
 # Path.posix("/foo").absolute?   # => true
 # Path.windows("/foo").absolute? # => false
 #
-# Path.posix("foo") == Path.posix("FOO")    # => false
+# Path.posix("foo") == Path.posix("FOO")     # => false
 # Path.windows("foo") == Path.windows("FOO") # => true
 # ```
 struct Path
@@ -647,8 +647,8 @@ struct Path
   # Non-matching paths are implicitly converted to this path's kind.
   #
   # ```
-  # Path.posix("foo/bar").join(Path.windows("baz\baq"))  # => Path.posix("foo/bar/baz/baq")
-  # Path.windows("foo\\bar").join(Path.posix("baz/baq")) # => Path.posix("foo\\bar\\baz/baq")
+  # Path.posix("foo/bar").join(Path.windows("baz\\baq")) # => Path.posix("foo/bar/baz/baq")
+  # Path.windows("foo\\bar").join(Path.posix("baz/baq")) # => Path.windows("foo\\bar\\baz/baq")
   # ```
   def join(parts : Enumerable) : Path
     new_name = String.build do |str|
@@ -751,8 +751,8 @@ struct Path
   # See `#anchor` for the combination of drive and `#root`.
   #
   # ```
-  # Path.windows("C:\Program Files").drive    # => Path.windows("C:")
-  # Path.windows("\\host\share\folder").drive # => Path.windows("\\host\share")
+  # Path.windows("C:\\Program Files").drive     # => Path.windows("C:")
+  # Path.windows("\\host\\share\\folder").drive # => nil
   # ```
   #
   # NOTE: Drives are only available for Windows paths. It can either be a drive letter (`C:`) or a UNC share (`\\host\share`).
@@ -767,10 +767,10 @@ struct Path
   # See `#anchor` for the combination of `#drive` and root.
   #
   # ```
-  # Path["/etc/"].root                       # => Path["/"]
-  # Path.windows("C:Program Files").root     # => nil
-  # Path.windows("C:\Program Files").root    # => Path.windows("\")
-  # Path.windows("\\host\share\folder").root # => Path.windows("\")
+  # Path["/etc/"].root                         # => Path["/"]
+  # Path.windows("C:Program Files").root       # => nil
+  # Path.windows("C:\\Program Files").root     # => Path.windows("\\")
+  # Path.windows("\\host\\share\\folder").root # => Path.windows("\\")
   # ```
   def root : Path?
     if root = drive_and_root[1]
@@ -781,10 +781,10 @@ struct Path
   # Returns the concatenation of `#drive` and `#root`.
   #
   # ```
-  # Path["/etc/"].anchor                       # => Path["/"]
-  # Path.windows("C:Program Files").anchor     # => Path.windows("C:")
-  # Path.windows("C:\Program Files").anchor    # => Path.windows("C:\")
-  # Path.windows("\\host\share\folder").anchor # => Path.windows("\\host\share\")
+  # Path["/etc/"].anchor                         # => Path["/"]
+  # Path.windows("C:Program Files").anchor       # => Path.windows("C:")
+  # Path.windows("C:\\Program Files").anchor     # => Path.windows("C:\\")
+  # Path.windows("\\host\\share\\folder").anchor # => Path.windows("\\")
   # ```
   def anchor : Path?
     drive, root = drive_and_root

--- a/src/path.cr
+++ b/src/path.cr
@@ -781,10 +781,10 @@ struct Path
   # Returns the concatenation of `#drive` and `#root`.
   #
   # ```
-  # Path["/etc/"].anchor                         # => Path["/"]
-  # Path.windows("C:Program Files").anchor       # => Path.windows("C:")
-  # Path.windows("C:\\Program Files").anchor     # => Path.windows("C:\\")
-  # Path.windows("\\host\\share\\folder").anchor # => Path.windows("\\")
+  # Path["/etc/"].anchor                           # => Path["/"]
+  # Path.windows("C:Program Files").anchor         # => Path.windows("C:")
+  # Path.windows("C:\\Program Files").anchor       # => Path.windows("C:\\")
+  # Path.windows("\\\\host\\share\\folder").anchor # => Path.windows("\\\\host\\share\\")
   # ```
   def anchor : Path?
     drive, root = drive_and_root

--- a/src/path.cr
+++ b/src/path.cr
@@ -751,8 +751,8 @@ struct Path
   # See `#anchor` for the combination of drive and `#root`.
   #
   # ```
-  # Path.windows("C:\\Program Files").drive     # => Path.windows("C:")
-  # Path.windows("\\host\\share\\folder").drive # => nil
+  # Path.windows("C:\\Program Files").drive       # => Path.windows("C:")
+  # Path.windows("\\\\host\\share\\folder").drive # => Path.windows("\\\\host\\share")
   # ```
   #
   # NOTE: Drives are only available for Windows paths. It can either be a drive letter (`C:`) or a UNC share (`\\host\share`).
@@ -767,10 +767,10 @@ struct Path
   # See `#anchor` for the combination of `#drive` and root.
   #
   # ```
-  # Path["/etc/"].root                         # => Path["/"]
-  # Path.windows("C:Program Files").root       # => nil
-  # Path.windows("C:\\Program Files").root     # => Path.windows("\\")
-  # Path.windows("\\host\\share\\folder").root # => Path.windows("\\")
+  # Path["/etc/"].root                           # => Path["/"]
+  # Path.windows("C:Program Files").root         # => nil
+  # Path.windows("C:\\Program Files").root       # => Path.windows("\\")
+  # Path.windows("\\\\host\\share\\folder").root # => Path.windows("\\")
   # ```
   def root : Path?
     if root = drive_and_root[1]

--- a/src/string.cr
+++ b/src/string.cr
@@ -2419,7 +2419,7 @@ class String
   # "abcdef".compare("ABCDEF", case_insensitive: true) # => 0
   # "abcdef".compare("ABCDEG", case_insensitive: true) # => -1
   #
-  # "heIIo".compare("heııo", case_insensitive: true, Unicode::CaseOptions::Turkic) # => 0
+  # "heIIo".compare("heııo", case_insensitive: true, options: Unicode::CaseOptions::Turkic) # => 0
   # ```
   def compare(other : String, case_insensitive = false, options = Unicode::CaseOptions::None)
     return self <=> other unless case_insensitive

--- a/src/time.cr
+++ b/src/time.cr
@@ -560,8 +560,8 @@ struct Time
   # new_year = Time.utc(2019, 1, 1, 0, 0, 0)
   # tokyo = new_year.to_local_in(Time::Location.load("Asia/Tokyo"))
   # new_york = new_year.to_local_in(Time::Location.load("America/New_York"))
-  # tokyo.to_s    # => "2019-01-01 00:00:00 +09:00"
-  # new_york.to_s # => "2019-01-01 00:00:00 -05:00"
+  # tokyo.inspect    # => "2019-01-01 00:00:00.0 +09:00 Asia/Tokyo"
+  # new_york.inspect # => "2019-01-01 00:00:00.0 -05:00 America/New_York"
   # ```
   def to_local_in(location : Location)
     local_seconds = offset_seconds

--- a/src/time.cr
+++ b/src/time.cr
@@ -391,7 +391,7 @@ struct Time
   #
   # ```
   # time = Time.utc(2016, 2, 15)
-  # time.to_s # => "2016-02-15 00:00:00 +00:00"
+  # time.to_s # => "2016-02-15 00:00:00 UTC"
   # ```
   #
   # The local date-time representation is resolved to a single instant based on
@@ -560,8 +560,8 @@ struct Time
   # new_year = Time.utc(2019, 1, 1, 0, 0, 0)
   # tokyo = new_year.to_local_in(Time::Location.load("Asia/Tokyo"))
   # new_york = new_year.to_local_in(Time::Location.load("America/New_York"))
-  # tokyo.to_s    # => 2019-01-01 00:00:00.0 +09:00 Asia/Tokyo
-  # new_york.to_s # => 2019-01-01 00:00:00.0 -05:00 America/New_York
+  # tokyo.to_s    # => "2019-01-01 00:00:00 +09:00"
+  # new_york.to_s # => "2019-01-01 00:00:00 -05:00"
   # ```
   def to_local_in(location : Location)
     local_seconds = offset_seconds
@@ -683,10 +683,11 @@ struct Time
   #
   # If the day-of-month resulting from shifting by *years* and *months* would be
   # invalid, the date is adjusted to the last valid day of the month.
-  # For example, adding one month to `2018-07-31` would result in the invalid
-  # date `2018-08-31` which will be adjusted to `2018-08-30`:
+  # For example, adding one month to `2018-08-31` would result in the invalid
+  # date `2018-09-31` which will be adjusted to `2018-09-30`:
   # ```
-  # Time.utc(2018, 7, 31).shift(months: 1) # => Time.utc(2018, 8, 30)
+  # Time.utc(2018, 7, 31).shift(months: 1) # => Time.utc(2018, 8, 31)
+  # Time.utc(2018, 8, 31).shift(months: 1) # => Time.utc(2018, 9, 30)
   # ```
   #
   # Overflow in smaller units is transferred to the next larger unit.
@@ -695,9 +696,9 @@ struct Time
   # granularity. This is relevant because the order of operations can change the result:
   #
   # ```
-  # Time.utc(2018, 7, 31).shift(months: 1, days: -1)       # => Time.utc(2018, 8, 29)
-  # Time.utc(2018, 7, 31).shift(months: 1).shift(days: -1) # => Time.utc(2018, 8, 29)
-  # Time.utc(2018, 7, 31).shift(days: -1).shift(months: 1) # => Time.utc(2018, 8, 30)
+  # Time.utc(2018, 8, 31).shift(months: 1, days: -1)       # => Time.utc(2018, 9, 29)
+  # Time.utc(2018, 8, 31).shift(months: 1).shift(days: -1) # => Time.utc(2018, 9, 29)
+  # Time.utc(2018, 8, 31).shift(days: -1).shift(months: 1) # => Time.utc(2018, 9, 30)
   # ```
   #
   # There is no explicit limit on the input values but the shift must result

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -85,7 +85,7 @@ struct Tuple
   #
   # ```
   # Tuple(String, Int64).from(["world", 2_i64])       # => {"world", 2_i64}
-  # Tuple(String, Int64).from(["world", 2_i64]).class # => {String, Int64}
+  # Tuple(String, Int64).from(["world", 2_i64]).class # => Tuple(String, Int64)
   # ```
   #
   # See also: `#from`.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -232,7 +232,7 @@ class URI
   # ```
   # uri = URI.parse("HTTP://example.COM:80/./foo/../bar/")
   # uri.normalize!
-  # uri # => http://example.com/bar/
+  # uri # => "http://example.com/bar/"
   # ```
   def normalize! : URI
     @scheme = @scheme.try &.downcase


### PR DESCRIPTION
Congrats 0.28.0! Let's catch up the examples code too!
- checked by https://github.com/maiha/crystal-examples
- target src: master branch ( `67167d960 Format: remove old code to format &.[] (#7699)
`)
- compiler: Crystal 0.29.0-dev [67167d9] (2019-04-25)

For convenience, commits are divided file by file, so please apply squash merge.

Best regards,