### PR TITLE
Optimize Enumerable#join

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -693,9 +693,9 @@ module Enumerable(T)
   # (1), (2), (3), (4), (5)
   # ```
   def join(separator, io : IO)
-    start = 0
+    start = false
     each do |elem|
-      start == 1 ? io << separator : (start = 1)
+      start ? io << separator : (start = true)
       yield elem, io
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -695,8 +695,9 @@ module Enumerable(T)
   def join(separator, io : IO)
     start = false
     each do |elem|
-      start ? io << separator : (start = true)
+      io << separator unless first
       yield elem, io
+      first = false
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -693,7 +693,7 @@ module Enumerable(T)
   # (1), (2), (3), (4), (5)
   # ```
   def join(separator, io : IO)
-    start = false
+    first = true
     each do |elem|
       io << separator unless first
       yield elem, io

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -695,7 +695,7 @@ module Enumerable(T)
   def join(separator, io : IO)
     start = 0
     each do |elem|
-      start == 1 ? io << separator : (start = 0)
+      start == 1 ? io << separator : (start = 1)
       yield elem, io
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -692,9 +692,10 @@ module Enumerable(T)
   # ```text
   # (1), (2), (3), (4), (5)
   # ```
-  def join(separator, io)
-    each_with_index do |elem, i|
-      io << separator if i > 0
+  def join(separator, io : IO)
+    start = 0
+    each do |elem|
+      start == 1 ? io << separator : (start = 0)
       yield elem, io
     end
   end


### PR DESCRIPTION
This is an insignificant PR; I noticed this when working on a lexer/builder.

```cr
require "benchmark"

module Enumerable
  def new_join(separator, io)
    start = false
    each do |elem|
      start ? io << separator : (start = true)
      yield elem, io
    end
  end
end

SMALL = StaticArray(Int32, 4).new 123
BIG = StaticArray(Int32, 999).new 123

Benchmark.ips do |x|
  x.report("small old join") { SMALL.join("", STDOUT) {|e|} }
  x.report("small new join") { SMALL.new_join("", STDOUT) {|e|} }

  x.report("big old join") { BIG.join("", STDOUT) {|e|} }
  x.report("big new join") { BIG.new_join("", STDOUT) {|e|} }
end
```
Result:
```
small old join  73.28M ( 13.65ns) (± 0.81%)  0 B/op         fastest
small new join  72.57M ( 13.78ns) (± 2.34%)  0 B/op    1.01× slower
  big old join 226.14k (  4.42µs) (± 1.16%)  0 B/op  324.02× slower
  big new join 231.49k (  4.32µs) (± 1.36%)  0 B/op  316.54× slower
```
 
Edit My bad I mess up the condition, it wasn't doing anything. Fixed and result updated.
Using booleans are easier to understand.