### PR TITLE
Fix Unicode not showing up in the API docs

### DIFF
--- a/scripts/unicode_data.ecr
+++ b/scripts/unicode_data.ecr
@@ -4,7 +4,6 @@
 #
 # DO NOT EDIT
 
-# :nodoc:
 module Unicode
   # Most case conversions map a range to another range.
   # Here we store: {from, to, delta}

--- a/src/unicode/data.cr
+++ b/src/unicode/data.cr
@@ -4,7 +4,6 @@
 #
 # DO NOT EDIT
 
-# :nodoc:
 module Unicode
   # Most case conversions map a range to another range.
   # Here we store: {from, to, delta}


### PR DESCRIPTION
Fix up of #7513.

`Unicode` shows up now:

![image](https://user-images.githubusercontent.com/35064754/56764642-7fa07e00-67a5-11e9-947b-43d054d7240b.png)
