### PR TITLE
Detect deprecation on initialize methods and methods with named args

### DIFF
--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -99,6 +99,32 @@ describe "Code gen: warnings" do
       inject_primitives: false
   end
 
+  it "detects deprecated initialize" do
+    assert_warning %(
+      class Foo
+        @[Deprecated]
+        def initialize
+        end
+      end
+
+      Foo.new
+    ), "Warning in line 8: Deprecated Foo.new.",
+      inject_primitives: false
+  end
+
+  it "detects deprecated initialize with named arguments" do
+    assert_warning %(
+      class Foo
+        @[Deprecated]
+        def initialize(*, a)
+        end
+      end
+
+      Foo.new(a: 2)
+    ), "Warning in line 8: Deprecated Foo.new:a.",
+      inject_primitives: false
+  end
+
   it "informs warnings once per call site location (a)" do
     warning_failures = warnings_result %(
       class Foo

--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -88,6 +88,17 @@ describe "Code gen: warnings" do
       inject_primitives: false
   end
 
+  it "detects deprecated methods with named arguments" do
+    assert_warning %(
+      @[Deprecated]
+      def foo(*, a)
+      end
+
+      foo(a: 2)
+    ), "Warning in line 6: Deprecated top-level foo:a.",
+      inject_primitives: false
+  end
+
   it "informs warnings once per call site location (a)" do
     warning_failures = warnings_result %(
       class Foo

--- a/src/compiler/crystal/codegen/warnings.cr
+++ b/src/compiler/crystal/codegen/warnings.cr
@@ -53,6 +53,7 @@ module Crystal
 
       if (ann = node.target_def.annotation(@program.deprecated_annotation)) &&
          (deprecated_annotation = DeprecatedAnnotation.from(ann))
+        return if compiler_expanded_call(node)
         return if ignore_warning_due_to_location(node.location)
         short_reference = node.target_def.short_reference
         warning_key = node.location.try { |l| "#{short_reference} #{l}" }
@@ -80,6 +81,11 @@ module Crystal
       return @program.warnings_exclude.any? do |path|
         filename.starts_with?(path)
       end
+    end
+
+    private def compiler_expanded_call(node : Call)
+      # Compiler generates a `_.initialize` call in `new`
+      node.obj.as?(Var).try { |v| v.name == "_" } && node.name == "initialize"
     end
   end
 

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -103,6 +103,7 @@ class Crystal::Def
     expansion.yields = yields
     expansion.raises = raises?
     expansion.free_vars = free_vars
+    expansion.annotations = annotations
     if owner = self.owner?
       expansion.owner = owner
     end

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -141,6 +141,7 @@ module Crystal
       new_def.new = true
       new_def.doc = doc
       new_def.free_vars = free_vars
+      new_def.annotations = annotations
 
       # Forward block argument if any
       if uses_block_arg?
@@ -288,6 +289,8 @@ module Crystal
       expansion = Def.new(name, def_args, Nop.new, splat_index: splat_index).at(self)
       expansion.yields = yields
       expansion.visibility = visibility
+      expansion.annotations = annotations
+
       if uses_block_arg?
         block_arg = self.block_arg.not_nil!
         expansion.block_arg = block_arg.clone


### PR DESCRIPTION
Annotations were not kept from the original method to the expanded overload for named args.
For generated `.new` methods the annotations of the matching `#initialize` should be kept.

The call from new to initialize should not generate a warning since it's an implementation detail. For this case, an explicit check following the convention used by the compiler is used.

Fixes #7714 
