### PR TITLE
Restrict bsearch block type

### DIFF
--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -147,7 +147,7 @@ module Indexable(T)
   # [2, 5, 7, 10].bsearch { |x| x >= 4 } # => 5
   # [2, 5, 7, 10].bsearch { |x| x > 10 } # => nil
   # ```
-  def bsearch
+  def bsearch(&block : T -> Bool)
     bsearch_index { |value| yield value }.try { |index| unsafe_fetch(index) }
   end
 
@@ -166,7 +166,7 @@ module Indexable(T)
   # [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 } # => 1
   # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
   # ```
-  def bsearch_index
+  def bsearch_index(&block : T, Int32 -> Bool)
     (0...size).bsearch { |index| yield unsafe_fetch(index), index }
   end
 

--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -81,7 +81,7 @@ struct Range(B, E)
   # ```
   #
   # Returns `nil` if the block didn't return `true` for any value.
-  def bsearch
+  def bsearch(&block : B | E -> Bool)
     from = self.begin
     to = self.end
 


### PR DESCRIPTION
Fixes #7727

Currently `Indexable#bsearch`, `Indexable#bsearch_index` and `Range#bsearch` all take a block that accepts anything as a return value. This is a bit unintuitive because the block should only return
`true` or `false`. It also happens that Ruby provides the same functionality but an integer can be returned from the block and this might confuse people coming from Ruby.

I thought about making the block return `Bool | Nil` but I think it doesn't make sense for `Nil` to appear there (`nil` is usually combined with non-bool types, but those types can't make it into `bsearch`'s block).
