### PR TITLE
Compiler: fix private def defined inside macro

### DIFF
--- a/spec/compiler/semantic/private_spec.cr
+++ b/spec/compiler/semantic/private_spec.cr
@@ -20,6 +20,27 @@ describe "Semantic: private" do
     end
   end
 
+  it "doesn't find private def defined in macro in another file (#7681)" do
+    expect_raises Crystal::TypeException, "undefined local variable or method 'foo'" do
+      compiler = Compiler.new
+      sources = [
+        Compiler::Source.new("foo.cr", %(
+                                          {% begin %}
+                                            private def foo
+                                              1
+                                            end
+                                          {% end %}
+                                        )),
+        Compiler::Source.new("bar.cr", %(
+                                          foo
+                                        )),
+      ]
+      compiler.no_codegen = true
+      compiler.prelude = "empty"
+      compiler.compile sources, "output"
+    end
+  end
+
   it "finds private def in same file" do
     compiler = Compiler.new
     sources = [

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -584,11 +584,8 @@ module Crystal
     def check_private(node)
       return nil unless node.visibility.private?
 
-      location = node.location
-      return nil unless location
-
-      filename = location.filename
-      return nil unless filename.is_a?(String)
+      filename = node.location.try &.original_filename
+      return nil unless filename
 
       file_module(filename)
     end


### PR DESCRIPTION
Fixes #7681

Using `Location#original_filename` will go out of macros to find the filename where the macro was pasted.