### PR TITLE
Compiler: fix subclass observer

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -283,4 +283,31 @@ describe "Code gen: generic class type" do
       Bar(Int32).new.as(Foo(Int32)).class.name
       )).to_string.should eq("Bar(Int32)")
   end
+
+  it "recomputes two calls that look the same due to generic type being instantiated (#7728)" do
+    run(%(
+      require "prelude"
+
+      abstract class Base
+      end
+
+      class Gen(T) < Base
+        def initialize(@x : T)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      def foo(gen)
+        gen.x
+        gen.x
+      end
+
+      foo(Gen.new(1) || Gen.new(1.5))
+      foo(Gen.new(true) || Gen.new(1_u8))
+      foo(Gen.new("hello") || Gen.new('z')).as(String)
+      )).to_string.should eq("hello")
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -969,7 +969,7 @@ module Crystal
     end
 
     def remove_subclass_observer(observer)
-      @subclass_observers.try &.delete(observer)
+      @subclass_observers.try &.reject! &.same?(observer)
     end
 
     def notify_subclass_added
@@ -1509,16 +1509,16 @@ module Crystal
 
       instance.after_initialize
 
-      # Notify modules that an instance was added
-      notify_parent_modules_subclass_added(self)
+      # Notify parents that an instance was added
+      notify_parents_subclass_added(self)
 
       instance
     end
 
-    def notify_parent_modules_subclass_added(type)
+    def notify_parents_subclass_added(type)
       type.parents.try &.each do |parent|
-        parent.notify_subclass_added if parent.is_a?(NonGenericModuleType)
-        notify_parent_modules_subclass_added parent
+        parent.notify_subclass_added if parent.is_a?(SubclassObservable)
+        notify_parents_subclass_added parent
       end
     end
 


### PR DESCRIPTION
Fixes #7728

SubclassObserver was deleting nodes by equality when they should be deleted by reference.

To explain a bit more, when the compiler has:

```crystal
x.foo(...)
```

if `x` is a virtual type (like `Foo+`, which means "Foo or any of its subclasses") the compiler will add an observer on `Foo` so that whenever a new subclass is added, that call is recomputed. This isn't generally needed because the class hierarchy is known before starting to type calls, but with generic types it's trickier: a generic type instance (like `Gen(Int32)`) is considered like a new subclass that must be considered in the call.

The problem was that the `Call`s added as observers to these types were stored in an `Array` and deleted by equality... but two Calls that are syntactically the same are considered equal, and so a second same call was not considered when a generic type instance was created. 