### PR TITLE
Remove old duplicated 'def contains_target'

### DIFF
--- a/src/compiler/crystal/tools/expand.cr
+++ b/src/compiler/crystal/tools/expand.cr
@@ -162,19 +162,6 @@ module Crystal
     def visit(node)
       contains_target(node)
     end
-
-    private def contains_target(node)
-      if loc_start = node.location
-        loc_end = node.end_location || loc_start
-        # if it is not between, it could be the case that node is the top level Expressions
-        # in which the (start) location might be in one file and the end location in another.
-        @target_location.between?(loc_start, loc_end) || loc_start.filename != loc_end.filename
-      else
-        # if node has no location, assume they may contain the target.
-        # for example with the main expressions ast node this matters
-        true
-      end
-    end
   end
 
   class ExpandTransformer < Transformer

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -123,18 +123,5 @@ module Crystal
     def visit(node)
       contains_target(node)
     end
-
-    private def contains_target(node)
-      if loc_start = node.location
-        loc_end = node.end_location || loc_start
-        # if it is not between, it could be the case that node is the top level Expressions
-        # in which the (start) location might be in one file and the end location in another.
-        @target_location.between?(loc_start, loc_end) || loc_start.filename != loc_end.filename
-      else
-        # if node has no location, assume they may contain the target.
-        # for example with the main expressions ast node this matters
-        true
-      end
-    end
   end
 end


### PR DESCRIPTION
It is already defined at `TypedDefProcessor` as the same. So, It's not needed.