### PR TITLE
 Implementation: allow to lookup class and module implementations

### DIFF
--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -468,4 +468,12 @@ describe "implementations" do
     foo
     )
   end
+
+  it "find const implementation" do
+    assert_implementations %(
+    ༓Foo = 42
+
+    F‸oo
+    )
+  end
 end

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -368,4 +368,104 @@ describe "implementations" do
     Bar.bar
     )
   end
+
+  it "find class implementation" do
+    assert_implementations %(
+    ༓class Foo
+    end
+
+    F‸oo
+    )
+  end
+
+  it "find open class implementation" do
+    assert_implementations %(
+    ༓class Foo
+      def foo
+      end
+    end
+
+    ༓class Foo
+      def bar
+      end
+    end
+
+    F‸oo
+    )
+  end
+
+  it "find struct implementation" do
+    assert_implementations %(
+    ༓struct Foo
+    end
+
+    F‸oo
+    )
+  end
+
+  it "find module implementation" do
+    assert_implementations %(
+    ༓module Foo
+    end
+
+    F‸oo
+    )
+  end
+
+  it "find enum implementation" do
+    assert_implementations %(
+    ༓enum Foo
+      Foo
+    end
+
+    F‸oo
+    )
+  end
+
+  it "find enum value implementation" do
+    assert_implementations %(
+    enum Foo
+      ༓Foo
+    end
+
+    Foo::F‸oo
+    )
+  end
+
+  it "find class implementation via alias" do
+    assert_implementations %(
+    ༓class Foo
+    end
+
+    alias Bar = Foo
+
+    B‸ar
+    )
+  end
+
+  it "find class defined by macro" do
+    assert_implementations %(
+    macro foo
+      class Foo
+      end
+    end
+
+    ༓foo
+
+    F‸oo
+    )
+  end
+
+  it "find class inside method" do
+    assert_implementations %(
+    ༓class Foo
+    end
+
+    def foo
+      F‸oo
+    end
+
+    foo
+    )
+  end
 end

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -432,12 +432,12 @@ describe "implementations" do
     )
   end
 
-  it "find class implementation via alias" do
+  it "find alias implementation" do
     assert_implementations %(
-    ༓class Foo
+    class Foo
     end
 
-    alias Bar = Foo
+    ༓alias Bar = Foo
 
     B‸ar
     )

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -566,6 +566,7 @@ module Crystal
 
   class Path
     property target_const : Const?
+    property target_type : Type?
     property syntax_replacement : ASTNode?
   end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -183,7 +183,8 @@ module Crystal
 
       type = lookup_scope.lookup_type_var(node,
         free_vars: free_vars,
-        find_root_generic_type_parameters: find_root_generic_type_parameters)
+        find_root_generic_type_parameters: find_root_generic_type_parameters,
+        remove_alias: false)
 
       case type
       when Const
@@ -218,6 +219,7 @@ module Crystal
         # It's different if from a virtual type we do `v.class.new`
         # because the class could be any in the hierarchy.
         node.type = check_type_in_type_args(type.remove_alias_if_simple).devirtualize
+        node.target_type = type
       when ASTNode
         type.accept self unless type.type?
         node.syntax_replacement = type

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -52,8 +52,8 @@ class Crystal::Type
 
   # Similar to `lookup_type`, but the result might also be an ASTNode, for example when
   # looking `N` relative to a StaticArray.
-  def lookup_type_var(node : Path, free_vars : Hash(String, TypeVar)? = nil, find_root_generic_type_parameters = true) : Type | ASTNode
-    TypeLookup.new(self, self.instance_type, true, false, free_vars, find_root_generic_type_parameters).lookup_type_var(node).not_nil!
+  def lookup_type_var(node : Path, free_vars : Hash(String, TypeVar)? = nil, find_root_generic_type_parameters = true, remove_alias = true) : Type | ASTNode
+    TypeLookup.new(self, self.instance_type, true, false, free_vars, find_root_generic_type_parameters, remove_alias).lookup_type_var(node).not_nil!
   end
 
   # Similar to `lookup_type_var`, but might return `nil`.
@@ -62,7 +62,7 @@ class Crystal::Type
   end
 
   private struct TypeLookup
-    def initialize(@root : Type, @self_type : Type, @raise : Bool, @allow_typeof : Bool, @free_vars : Hash(String, TypeVar)? = nil, @find_root_generic_type_parameters = true)
+    def initialize(@root : Type, @self_type : Type, @raise : Bool, @allow_typeof : Bool, @free_vars : Hash(String, TypeVar)? = nil, @find_root_generic_type_parameters = true, @remove_alias = true)
       @in_generic_args = 0
 
       # If we are looking types inside a non-instantiated generic type,
@@ -131,7 +131,7 @@ class Crystal::Type
             type.process_value
           end
         end
-        type = type.remove_alias_if_simple
+        type = type.remove_alias_if_simple if @remove_alias
       end
 
       type

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -107,15 +107,11 @@ module Crystal
     end
 
     def visit(node : Call)
-      if node.location
-        if @target_location.between?(node.name_location, node.name_end_location)
-          if target_defs = node.target_defs
-            target_defs.each do |target_def|
-              @locations << target_def.location.not_nil!
-            end
-          end
-        else
-          contains_target(node)
+      return contains_target(node) unless node.location && @target_location.between?(node.name_location, node.name_end_location)
+
+      if target_defs = node.target_defs
+        target_defs.each do |target_def|
+          @locations << target_def.location.not_nil!
         end
       end
     end

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -116,6 +116,15 @@ module Crystal
       end
     end
 
+    def visit(node : Path)
+      return contains_target(node) unless (loc = node.location) && (end_loc = node.end_location) && @target_location.between?(loc, end_loc)
+
+      target = node.target_const || node.type?.try &.instance_type
+      target.try &.locations.try &.each do |loc|
+        @locations << loc
+      end
+    end
+
     def visit(node)
       contains_target(node)
     end

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -119,7 +119,7 @@ module Crystal
     def visit(node : Path)
       return contains_target(node) unless (loc = node.location) && (end_loc = node.end_location) && @target_location.between?(loc, end_loc)
 
-      target = node.target_const || node.type?.try &.instance_type
+      target = node.target_const || node.target_type
       target.try &.locations.try &.each do |loc|
         @locations << loc
       end


### PR DESCRIPTION
Fixed #4941

Image:

![2019-05-06 8:39:32](https://user-images.githubusercontent.com/6679325/57224715-4093e780-7045-11e9-81cb-12a39e7c1d8b.png)

I think it is totally useful, however this implementation cannot work on some corner case. One corner case, method argument restriction:

```crystal
def foo(x : ‸Foo)
end

foo
```

It is hard to implement for now. Another corner case, macro argument:

```crystal
record Foo,
  x : ‸Bar
```

It is impossible.

- - -

@faustinoaq Sorry for the late. Is this okay?