### PR TITLE
Compiler: fix bug related to types that can't be inferred

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -516,7 +516,7 @@ describe "Semantic: class" do
       foo = Foo.new
       foo.@y
       ),
-      "Can't infer the type of instance variable '@y' of Foo"
+      "can't infer the type of instance variable '@y' of Foo"
   end
 
   it "errors if reading ivar from non-ivar container" do
@@ -603,7 +603,7 @@ describe "Semantic: class" do
 
       Bar.new(Foo.new).foo
       ",
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "doesn't mark instance variable as nilable if calling another initialize" do
@@ -961,7 +961,7 @@ describe "Semantic: class" do
       f = Foo.new
       f.@foo
       ),
-      "Can't infer the type of instance variable '@foo' of Foo"
+      "can't infer the type of instance variable '@foo' of Foo"
   end
 
   it "doesn't crash with top-level initialize (#2601)" do

--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -221,7 +221,7 @@ describe "Semantic: class var" do
 
       Foo.foo
       ",
-      "Can't infer the type of class variable '@@foo' of Foo"
+      "can't infer the type of class variable '@@foo' of Foo"
   end
 
   it "errors if using class variable at the top level" do
@@ -308,7 +308,7 @@ describe "Semantic: class var" do
         end
       end
       ),
-      "can't use Class as the type of class variable @@class of Foo, use a more specific type"
+      "can't use Class as the type of class variable '@@class' of Foo, use a more specific type"
   end
 
   it "gives correct error when trying to use Int as a class variable type" do

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -1860,7 +1860,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "says undefined instance variable on assign" do
@@ -1874,7 +1874,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "errors if declaring instance var and turns out to be nilable" do
@@ -2603,7 +2603,7 @@ describe "Semantic: instance var" do
       point = Bar.new(1)
       Foo.new(1).x
       ),
-      "Can't infer the type of instance variable '@x' of Bar"
+      "can't infer the type of instance variable '@x' of Bar"
   end
 
   it "infers type from array literal in generic type" do
@@ -3086,7 +3086,7 @@ describe "Semantic: instance var" do
 
       Foo(Int32).new.bar
       ),
-      "can't use Bar(T) as the type of instance variable @bar of Foo(T), use a more specific type"
+      "can't infer the type parameter T for the generic class Bar(T)"
   end
 
   it "doesn't crash on missing var on subclass, with superclass not specifying a type" do
@@ -3577,7 +3577,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "doesn't infer from class method with multiple statements and return, on non-easy return (2)" do
@@ -3605,7 +3605,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "infer from class method where new is redefined" do
@@ -3658,7 +3658,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "infers in multiple assign for tuple type (1)" do
@@ -3704,7 +3704,7 @@ describe "Semantic: instance var" do
 
       Foo.new(3).foo
       ),
-      "Can't infer the type of instance variable '@foo' of Foo(Int32)"
+      "can't infer the type of instance variable '@foo' of Foo(Int32)"
   end
 
   it "doesn't crash when inferring from new without matches (#2538)" do
@@ -3777,7 +3777,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "can't infer type from initializer in non-generic module" do
@@ -3796,7 +3796,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Moo"
+      "can't infer the type of instance variable '@x' of Moo"
   end
 
   it "can't infer type from initializer in generic module type" do
@@ -3815,7 +3815,7 @@ describe "Semantic: instance var" do
 
       Foo.new.x
       ),
-      "Can't infer the type of instance variable '@x' of Moo(T)"
+      "can't infer the type of instance variable '@x' of Moo(T)"
   end
 
   it "can't infer type from initializer in generic class type" do
@@ -3830,7 +3830,7 @@ describe "Semantic: instance var" do
 
       Foo(Int32).new.x
       ),
-      "Can't infer the type of instance variable '@x' of Foo(T)"
+      "can't infer the type of instance variable '@x' of Foo(T)"
   end
 
   it "infers type from self (#2575)" do
@@ -3969,7 +3969,7 @@ describe "Semantic: instance var" do
         end
       end
       ),
-      "can't use Class as the type of instance variable @class of Foo, use a more specific type"
+      "can't use Class as the type of instance variable '@class' of Foo, use a more specific type"
   end
 
   it "errors when using Class in generic type" do
@@ -3979,7 +3979,7 @@ describe "Semantic: instance var" do
         end
       end
       ),
-      "can't use Class as the type of instance variable @class of Foo(T), use a more specific type"
+      "can't use Class as the type of instance variable '@class' of Foo(T), use a more specific type"
   end
 
   it "doesn't error when using Class but specifying type" do
@@ -4689,7 +4689,7 @@ describe "Semantic: instance var" do
 
       Bar.new
       ),
-      "Can't infer the type of instance variable '@bar' of Foo"
+      "can't infer the type of instance variable '@bar' of Foo"
   end
 
   it "can't infer type when using operation on const (#4054)" do
@@ -4704,7 +4704,7 @@ describe "Semantic: instance var" do
 
       Foo.new
       ),
-      "Can't infer the type of instance variable '@baz' of Foo"
+      "can't infer the type of instance variable '@baz' of Foo"
   end
 
   it "instance variables initializers are used in class variables initialized objects (#3988)" do
@@ -4822,7 +4822,7 @@ describe "Semantic: instance var" do
         @x = Gen.new
       end
       ),
-      "can't use Gen(T) as the type of instance variable @x of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "doesn't consider instance var as nilable if assigned before self access (#4981)" do
@@ -4964,7 +4964,7 @@ describe "Semantic: instance var" do
 
       Foo.new(1).foo
     ),
-      "Can't infer the type of instance variable '@foo' of Foo"
+      "can't infer the type of instance variable '@foo' of Foo"
   end
 
   it "can guess the type from double-splat argument with double-splated type" do
@@ -5010,7 +5010,7 @@ describe "Semantic: instance var" do
 
       Foo.new(foo: 1).foo
     ),
-      "Can't infer the type of instance variable '@foo' of Foo"
+      "can't infer the type of instance variable '@foo' of Foo"
   end
 
   it "cannot guess type from argument assigned in body" do
@@ -5024,7 +5024,7 @@ describe "Semantic: instance var" do
 
       Foo.new "foo"
       ),
-      "Can't infer the type of instance variable '@x' of Foo"
+      "can't infer the type of instance variable '@x' of Foo"
   end
 
   it "can't infer type of generic method that returns self (#5383)" do
@@ -5035,12 +5035,14 @@ describe "Semantic: instance var" do
       end
 
       class Foo
-        def initialize(x, y)
+        def initialize
           @x = Gen.new { 1 }
         end
       end
+
+      Foo.new
       ),
-      "can't use Gen(T) as the type of instance variable @x of Foo, use a more specific type"
+      "type must be Gen(T), not Nil"
   end
 
   it "guesses virtual array type (1) (#5342)" do
@@ -5240,7 +5242,9 @@ describe "Semantic: instance var" do
           @x = Gen.new { }
         end
       end
+
+      Foo.new
       ),
-      "can't use Gen(T) as the type of instance variable @x of Foo, use a more specific type"
+      "can't infer the type parameter T for the generic class Gen(T)"
   end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5223,4 +5223,24 @@ describe "Semantic: instance var" do
       Foo.new.x
       )) { int32 }
   end
+
+  it "doesn't infer unbound generic type on non-generic call (#6390)" do
+    assert_error %(
+      class Gen(T)
+        def self.new(&block)
+          Gen(T).build
+        end
+
+        def self.build : self
+        end
+      end
+
+      class Foo
+        def initialize
+          @x = Gen.new { }
+        end
+      end
+      ),
+      "can't use Gen(T) as the type of instance variable @x of Foo, use a more specific type"
+  end
 end

--- a/spec/compiler/semantic/nilable_instance_var_spec.cr
+++ b/spec/compiler/semantic/nilable_instance_var_spec.cr
@@ -43,7 +43,7 @@ describe "Semantic: nilable instance var" do
       p.value = Baz.new
       p.value.foo + 1
       ),
-      "Can't infer the type of instance variable '@foo' of Foo"
+      "can't infer the type of instance variable '@foo' of Foo"
   end
 
   it "says instance var was not initialized in all of the initialize methods, with var declaration" do

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -306,7 +306,7 @@ module Crystal
   class Program
     def undefined_global_variable(node, similar_name)
       common = String.build do |str|
-        str << "Can't infer the type of global variable '#{node.name}'"
+        str << "can't infer the type of global variable '#{node.name}'"
         if similar_name
           str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
         end
@@ -324,7 +324,7 @@ module Crystal
 
     def undefined_class_variable(node, owner, similar_name)
       common = String.build do |str|
-        str << "Can't infer the type of class variable '#{node.name}' of #{owner.devirtualize}"
+        str << "can't infer the type of class variable '#{node.name}' of #{owner.devirtualize}"
         if similar_name
           str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
         end
@@ -342,7 +342,7 @@ module Crystal
 
     def undefined_instance_variable(node, owner, similar_name)
       common = String.build do |str|
-        str << "Can't infer the type of instance variable '#{node.name}' of #{owner.devirtualize}"
+        str << "can't infer the type of instance variable '#{node.name}' of #{owner.devirtualize}"
         if similar_name
           str << colorize(" (did you mean #{similar_name}?)").yellow.bold.to_s
         end

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -638,11 +638,11 @@ struct Crystal::TypeDeclarationProcessor
       entries.each do |name, error|
         case name
         when .starts_with?("$")
-          error.node.raise "can't use #{error.type} as the type of global variable #{name}, use a more specific type"
+          error.node.raise "can't use #{error.type} as the type of global variable '#{name}', use a more specific type"
         when .starts_with?("@@")
-          error.node.raise "can't use #{error.type} as the type of class variable #{name} of #{type}, use a more specific type"
+          error.node.raise "can't use #{error.type} as the type of class variable '#{name}' of #{type}, use a more specific type"
         when .starts_with?("@")
-          error.node.raise "can't use #{error.type} as the type of instance variable #{name} of #{type}, use a more specific type"
+          error.node.raise "can't use #{error.type} as the type of instance variable '#{name}' of #{type}, use a more specific type"
         end
       end
     end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -1073,21 +1073,16 @@ module Crystal
     end
 
     def check_allowed_in_generics(node, type)
-      # Types such as Object, Int, etc., are not allowed in generics
-      # and as variables types, so we disallow them.
-      if type && !type.allowed_in_generics?
-        @error = Error.new(node, type)
-        return nil
-      end
-
-      case type
-      when GenericClassType
+      if type.is_a?(GenericClassType)
+        nil
+      elsif type.is_a?(GenericModuleType)
+        nil
+      elsif type && !type.allowed_in_generics?
+        # Types such as Object, Int, etc., are not allowed in generics
+        # and as variables types, so we disallow them.
         @error = Error.new(node, type)
         nil
-      when GenericModuleType
-        @error = Error.new(node, type)
-        nil
-      when NonGenericClassType
+      elsif type.is_a?(NonGenericClassType)
         type.virtual_type
       else
         type

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -631,6 +631,14 @@ module Crystal
       return type if type
 
       type = guess_type_call_with_type_annotation(node)
+
+      # If the type is unbound (uninstantiated generic) but the call
+      # wasn't something like `Gen(Int32).something` then we can never
+      # guess a type, the type is probably inferred from type restrictions
+      if !obj.is_a?(Generic) && type.try &.unbound?
+        return nil
+      end
+
       return type if type
 
       nil


### PR DESCRIPTION
This PR fixes #6390 and also improves error messages a bit.

For example before this PR, if you had:

```crystal
class Foo
  def initialize
    @x = Array.new(3, 10)
  end
end

Foo.new
```

the compiler would say:

```
Error in foo.cr:3: can't use Array(T) as the type of instance variable @x of Foo, use a more specific type

    @x = Array.new(3, 10)
         ^~~~~
```

That's probably a bit misleading: it's leaking the fact that the compiler infers the above to be an uninstantiated array type and says "you can't do that".

With this PR the error message is:

```
Error in foo.cr:7: instantiating 'Foo.class#new()'

Foo.new
    ^~~

in foo.cr:3: can't infer the type of instance variable '@x' of Foo
...
```

I think that's better: it's less misleading and it might hint that your best choice is to put a type annotation on `@x`.

This is also better because for this code:

```crystal
class Foo
  def initialize
    @x = Array.new(3, 10 + "x")
  end
end

Foo.new
```

you used to get:

```
Error in foo.cr:3: can't use Array(T) as the type of instance variable @x of Foo, use a more specific type

    @x = Array.new(3, 10 + "x")
         ^~~~~
```

that is, even if we have a semantic error in that line (`10 + "x"`) the compiler would first complain that it can't infer the type. With this PR the error is:

```
Error in foo.cr:7: instantiating 'Foo.class#new()'

Foo.new
    ^~~

in foo.cr:3: no overload matches 'Int32#+' with type String
Overloads are:
 - Int32#+(other : Int8)
 - Int32#+(other : Int16)
 - Int32#+(other : Int32)
 - Int32#+(other : Int64)
 - Int32#+(other : Int128)
 - Int32#+(other : UInt8)
 - Int32#+(other : UInt16)
 - Int32#+(other : UInt32)
 - Int32#+(other : UInt64)
 - Int32#+(other : UInt128)
 - Int32#+(other : Float32)
 - Int32#+(other : Float64)
 - Number#+()

    @x = Array.new(3, 10 + "x")
                         ^
```