### PR TITLE
 Compiler: make automatic cast work with `with ... yield`

### DIFF
--- a/spec/compiler/semantic/automatic_cast.cr
+++ b/spec/compiler/semantic/automatic_cast.cr
@@ -436,4 +436,22 @@ describe "Semantic: automatic cast" do
       ),
       "no overload matches"
   end
+
+  it "can use automatic cast with `with ... yield` (#7736)" do
+    assert_type(%(
+      def foo
+        with 1 yield
+      end
+
+      struct Int32
+        def bar(x : Int64)
+          x
+        end
+      end
+
+      foo do
+        bar(1)
+      end
+      )) { int64 }
+  end
 end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -72,6 +72,17 @@ module Crystal
       end
     end
 
+    def inspect_with_backtrace(io : IO) : Nil
+      to_s(io)
+
+      backtrace?.try &.each do |frame|
+        io.print "  from "
+        io.puts frame
+      end
+
+      io.flush
+    end
+
     def to_s_with_source(source, io)
       io << "Error "
       append_to_s source, io


### PR DESCRIPTION
Fixes #7736

There's also a separate commit that makes exceptions show the full (crystal) backtrace when they fail on specs. It was driving me a bit crazy, not being able to see why spec failed (it got broke some time ago by someone else).