### PR TITLE
Compiler: give precedence to T.class over Class

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -712,4 +712,18 @@ describe "Restrictions" do
       ),
       "no overload matches"
   end
+
+  it "gives precedence to T.class over Class (#7392)" do
+    assert_type(%(
+      def foo(x : Class)
+        'a'
+      end
+
+      def foo(x : Int32.class)
+        1
+      end
+
+      foo(Int32)
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -374,6 +374,17 @@ module Crystal
     def restriction_of?(other : Metaclass, owner)
       name.restriction_of?(other.name, owner)
     end
+
+    def restriction_of?(other : Path, owner)
+      other_type = owner.lookup_type(other)
+
+      # Special case: when comparing Foo.class to Class, Foo.class has precedence
+      if other_type == other_type.program.class_type
+        return true
+      end
+
+      super
+    end
   end
 
   class Type


### PR DESCRIPTION
Fixes #7392 

This is just a small thing, but it makes sense, and I'm trying to get rid of every bug we have reported, so...