### PR TITLE
Deprecate Path#dirname

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -166,10 +166,6 @@ describe Path do
     assert_paths("foo/bar/./.", [".", "foo", "foo/bar", "foo/bar/."], &.parents)
   end
 
-  describe "#dirname" do
-    assert_paths("/Users/foo/bar.cr", "/Users/foo", &.dirname)
-  end
-
   describe "#basename" do
     assert_paths_raw("/foo/bar/baz.cr", "baz.cr", &.basename)
     assert_paths_raw("/foo/", "foo", &.basename)

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -167,7 +167,7 @@ describe Path do
   end
 
   describe "#dirname" do
-    assert_paths_raw("/Users/foo/bar.cr", "/Users/foo", &.dirname)
+    assert_paths("/Users/foo/bar.cr", "/Users/foo", &.dirname)
   end
 
   describe "#basename" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -255,7 +255,7 @@ class File < IO::FileDescriptor
   # File.dirname("/foo/bar/file.cr") # => "/foo/bar"
   # ```
   def self.dirname(path) : String
-    Path.new(path).dirname
+    Path.new(path).dirname.to_s
   end
 
   # Returns the last component of the given *path*.

--- a/src/file.cr
+++ b/src/file.cr
@@ -255,7 +255,7 @@ class File < IO::FileDescriptor
   # File.dirname("/foo/bar/file.cr") # => "/foo/bar"
   # ```
   def self.dirname(path) : String
-    Path.new(path).dirname.to_s
+    Path.new(path).parent.to_s
   end
 
   # Returns the last component of the given *path*.

--- a/src/path.cr
+++ b/src/path.cr
@@ -174,9 +174,9 @@ struct Path
   # Returns all components of this path except the last one.
   #
   # ```
-  # Path["/foo/bar/file.cr"].dirname # => "/foo/bar"
+  # Path["/foo/bar/file.cr"].dirname # => Path["/foo/bar]"
   # ```
-  def dirname : String
+  def dirname : Path
     reader = Char::Reader.new(at_end: @name)
     separators = self.separators
 
@@ -199,22 +199,22 @@ struct Path
       current = reader.current_char
 
       if separators.includes?(current)
-        return current.to_s
+        return Path.new current.to_s
       else
         # skip windows here for next condition regarding anchor
         if windows? && reader.has_next? && reader.peek_next_char == ':'
           reader.next_char
         else
-          return "."
+          return Path.new "."
         end
       end
     end
 
     if windows? && reader.current_char == ':' && reader.pos == 1 && (anchor = self.anchor)
-      return anchor.to_s
+      return anchor
     end
 
-    @name.byte_slice(0, reader.pos + 1)
+    Path.new @name.byte_slice(0, reader.pos + 1)
   end
 
   # Returns the parent path of this path.

--- a/src/path.cr
+++ b/src/path.cr
@@ -174,9 +174,27 @@ struct Path
   # Returns all components of this path except the last one.
   #
   # ```
-  # Path["/foo/bar/file.cr"].dirname # => Path["/foo/bar]"
+  # Path["/foo/bar/file.cr"].dirname # => "/foo/bar]"
   # ```
+  @[Deprecated("Use `Path#parent.to_s` instead")]
   def dirname : Path
+    parent.to_s
+  end
+
+  # Returns the parent path of this path, all components of this path except the last one.
+  #
+  # If the path is empty or `"."`, it returns `"."`. If the path is rooted
+  # and in the top-most hierarchy, the root path is returned.
+  #
+  # ```
+  # Path["foo/bar/file.cr"].parent # => Path["foo/bar"]
+  # Path["foo"].parent             # => Path["."]
+  # Path["/foo"].parent            # => Path["/"]
+  # Path["/"].parent               # => Path["/"]
+  # Path[""].parent                # => Path["."]
+  # Path["foo/bar/."].parent       # => Path["foo/bar"]
+  # ```
+  def parent : Path
     reader = Char::Reader.new(at_end: @name)
     separators = self.separators
 
@@ -199,13 +217,13 @@ struct Path
       current = reader.current_char
 
       if separators.includes?(current)
-        return Path.new current.to_s
+        return new_instance current.to_s
       else
         # skip windows here for next condition regarding anchor
         if windows? && reader.has_next? && reader.peek_next_char == ':'
           reader.next_char
         else
-          return Path.new "."
+          return new_instance "."
         end
       end
     end
@@ -214,24 +232,7 @@ struct Path
       return anchor
     end
 
-    Path.new @name.byte_slice(0, reader.pos + 1)
-  end
-
-  # Returns the parent path of this path.
-  #
-  # If the path is empty or `"."`, it returns `"."`. If the path is rooted
-  # and in the top-most hierarchy, the root path is returned.
-  #
-  # ```
-  # Path["foo/bar/file.cr"].parent # => Path["foo/bar"]
-  # Path["foo"].parent             # => Path["."]
-  # Path["/foo"].parent            # => Path["/"]
-  # Path["/"].parent               # => Path["/"]
-  # Path[""].parent                # => Path["."]
-  # Path["foo/bar/."].parent       # => Path["foo/bar"]
-  # ```
-  def parent : Path
-    new_instance dirname
+    new_instance @name.byte_slice(0, reader.pos + 1)
   end
 
   # Returns all parent paths of this path beginning with the topmost path.

--- a/src/path.cr
+++ b/src/path.cr
@@ -174,7 +174,7 @@ struct Path
   # Returns all components of this path except the last one.
   #
   # ```
-  # Path["/foo/bar/file.cr"].dirname # => "/foo/bar]"
+  # Path["/foo/bar/file.cr"].dirname # => "/foo/bar"
   # ```
   @[Deprecated("Use `Path#parent.to_s` instead")]
   def dirname : Path


### PR DESCRIPTION
Here is the use case I faced, how to get the directory name?

With either
`File.basename(File.dirname(Dir.current))`
or
`Path.new(Path.new(Dir.current).dirname).basename.to_s`
or a mix of both.

One can also use this, but this isn't as clear nor as efficient:
`Path.new(Dir.current).parts.last.lchop`

Now, one can do:
`Path.new(Dir.current).dirname.basename.to_s`
and the root directory of the current one:
`Path.new(Dir.current).dirname.dirname.basename.to_s`

If a `String` is wanted, `#to_s` can still be called.

---
**EDIT**: There is already `Path#parent`, deprecating `Path#dirname`