### PR TITLE
Update docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Try it online
 Documentation
 -------------
 
-* [Official docs](http://crystal-lang.org/docs)
+* [Official docs](https://crystal-lang.org/reference/)
 * [Standard library API](https://crystal-lang.org/api)
 * [Roadmap](https://github.com/crystal-lang/crystal/wiki/Roadmap)
 


### PR DESCRIPTION
This pull request updates the docs link in the README file. The url http://crystal-lang.org/docs redirects to https://crystal-lang.org/reference/ so it makes sense to link to it directly. Thoughts?