### PR TITLE
implement IO::MultiWriter#flush

### DIFF
--- a/spec/std/io/multi_writer_spec.cr
+++ b/spec/std/io/multi_writer_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../spec_helper"
 
 describe "IO::MultiWriter" do
   describe "#write" do
@@ -47,6 +48,23 @@ describe "IO::MultiWriter" do
       writer.close
 
       io.closed?.should eq(true)
+    end
+  end
+
+  describe "#flush" do
+    it "writes to IO and File" do
+      with_tempfile("multiple_writer_spec") do |path|
+        file = File.new(path, "w")
+        io = IO::Memory.new
+
+        writer = IO::MultiWriter.new(io, file)
+
+        writer.puts "foo bar"
+        writer.flush
+
+        io.to_s.should eq("foo bar\n")
+        File.read(path).should eq("foo bar\n")
+      end
     end
   end
 end

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -47,4 +47,8 @@ class IO::MultiWriter < IO
 
     @writers.each { |writer| writer.close } if sync_close?
   end
+
+  def flush
+    @writers.each(&.flush)
+  end
 end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -7,9 +7,6 @@
 # When you are developing the system, however, you probably want to know about the program’s internal state,
 # and would set the `Logger` to `DEBUG`.
 #
-# If logging to multiple locations is required, an `IO::MultiWriter` can be
-# used.
-#
 # ### Example
 #
 # ```
@@ -35,6 +32,18 @@
 #   log.fatal("Caught exception; exiting")
 #   log.fatal(err)
 # end
+# ```
+#
+# If logging to multiple locations is required, an `IO::MultiWriter` can be
+# used.
+#
+# ```
+# file = File.new("production.log", "a")
+# writer = IO::MultiWriter.new(file, STDOUT)
+#
+# log = Logger.new(writer)
+# log.level = Logger::DEBUG
+# log.debug("Created logger")
 # ```
 class Logger
   property level : Severity


### PR DESCRIPTION
Hi.

I'd like to start with an issue I faced while trying to log output to stdout as well as file.

Logging to file doesn't work in the next example:

```crystal
require "logger"

log_file = File.new("test.log", "a")
writer = IO::MultiWriter.new(log_file, STDOUT)

log = Logger.new(writer)
log.level = Logger::DEBUG
log.debug("Created logger")
```
It is fixed by patching `IO::MultiWriter` class.

```crystal
class IO::MultiWriter < IO
  def flush
    @writers.each(&.flush)
  end
end
```

This PR includes fixes and some specs.
Also, I added an example of how to do logging to file and stdout.