### PR TITLE
Better handle file names starting with ~ in Path#expand

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -569,6 +569,10 @@ describe Path do
       it_expands_path("~", "/", "\\", base: "/tmp/gumby/ddd", env_home: "/")
       it_expands_path("~/a", "/a", "\\a", base: "/tmp/gumby/ddd", env_home: "/")
     end
+
+    describe "ignores name starting with ~" do
+      it_expands_path("~foo.txt", "/current/~foo.txt", "\\current\\~foo.txt", base: "/current", env_home: "/")
+    end
   end
 
   describe "#<=>" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -564,14 +564,10 @@ struct Path
 
     name = @name
 
-    if name.starts_with?('~')
-      home = home.to_kind(@kind).normalize
-
-      if name.size == 1
-        name = home.to_s
-      else
-        name = home.join(name.byte_slice(2, name.bytesize - 2)).to_s
-      end
+    if name == "~"
+      name = home.to_kind(@kind).normalize.to_s
+    elsif name.starts_with?("~/")
+      name = home.to_kind(@kind).normalize.join(name.byte_slice(2, name.bytesize - 2)).to_s
     end
 
     unless new_instance(name).absolute?


### PR DESCRIPTION
Currently `p Path.new("~foo.txt").expand` gives: `Path["/home/crystal/oo.txt"]`.

The expected return value could either be `Path["/home/crystal/~foo.txt"]` or `Path["/home/foo.txt"]` depending on wether or not you'd like to support the `~username` notation like Ruby's `File.expand_path` does.

I implemented the former as it's much simpler.

