### PR TITLE
Hide hidden matches in non-recursive directories if `match_hidden` is false.

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -315,6 +315,16 @@ describe "Dir" do
         ].sort
       end
     end
+
+    context "match_hidden: false" do
+      it "ignores hidden files" do
+        Dir.glob("#{datapath}/dir/dots/*", match_hidden: false).size.should eq 0
+      end
+
+      it "ignores hidden files recursively" do
+        Dir.glob("#{datapath}/dir/dots/**/*", match_hidden: false).size.should eq 0
+      end
+    end
   end
 
   describe "cd" do

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -166,6 +166,7 @@ class Dir
         when EntryMatch
           return if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           each_child(path) do |entry|
+            next if entry[0] == '.' && !options[:match_hidden]
             yield join(path, entry) if cmd.matches?(entry)
           end
         when DirectoryMatch

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -166,7 +166,7 @@ class Dir
         when EntryMatch
           return if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           each_child(path) do |entry|
-            next if entry[0] == '.' && !options[:match_hidden]
+            next if !options[:match_hidden] && entry.starts_with?('.')
             yield join(path, entry) if cmd.matches?(entry)
           end
         when DirectoryMatch
@@ -220,7 +220,7 @@ class Dir
 
             if entry = dir.try(&.read)
               next if {".", ".."}.includes?(entry)
-              next if entry[0] == '.' && !options[:match_hidden]
+              next if !options[:match_hidden] && entry.starts_with?('.')
 
               if dir_path.bytesize == 0
                 fullpath = entry


### PR DESCRIPTION
Fixes #7769 