### PR TITLE
 Do not generate debug metadata for arguments of naked functions

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -118,7 +118,7 @@ class Crystal::CodeGenVisitor
 
         create_local_copy_of_fun_args(target_def, self_type, args, is_fun_literal, is_closure)
 
-        if @debug.variables?
+        if @debug.variables? && !target_def.naked?
           in_alloca_block do
             args_offset = !is_fun_literal && self_type.passed_as_self? ? 2 : 1
             location = target_def.location


### PR DESCRIPTION
When building Crystal locally from 0.28 tag or master with Crystal 0.28 from official RPM and trying to compile anything with the resulting compiler, I was getting this error:
```
.build/crystal build ./test.cr
Invalid memory access (signal 11) at address 0x7f20a83a4f08
[0x7a17a6] *CallStack::print_backtrace:Int32 +118
[0x7884a9] __crystal_sigfault_handler +217
[0x16ba8f5] sigfault_handler +40
[0x7f20a8aaf070] ???
[0x7f20a83a4f08] ???
```

I was able to pinpoint it to `Fiber#swapcontext` in the scheduler, specifically when resuming to main Fiber.
Checking the assembly, I noticed that arguments are being copied when invoking `swapcontext`, generating this code

Scheduler#resume:
```
    0x7f98c4 <+292>: movq   0x30(%rsp), %rax # pointerof(current)
    0x7f98c9 <+297>: addq   $0x8, %rax       # + @context
    0x7f98cd <+301>: movq   0x20(%rsp), %rdx # pointerof(fiber)
    0x7f98d2 <+306>: addq   $0x8, %rdx'      # + @context

    0x7f98d6 <+310>: movq   %rax, %rdi       # first arg
    0x7f98d9 <+313>: movq   %rdx, %rsi       # second arg
    0x7f98dc <+316>: callq  0x7ee330         ; *Fiber::swapcontext<Pointer(Fiber::Context), Pointer(Fiber::Context)>:Nil
```

Fiber#makecontext
```
->  0x7ee330 <+0>:  movq   %rdi, 0x8(%rsp)  
    0x7ee335 <+5>:  movq   %rsi, (%rsp)     

    0x7ee339 <+9>:  movq   0x8(%rsp), %rax  
    0x7ee33e <+14>: movq   (%rsp), %rcx     
```
Corrupting the return address stored on the stack.
After that, I checked the changes between v0.27.2 (working for me) and v0.28.0 (not working for me)
And saw this change:
```
-    Fiber.swapcontext(pointerof(current.@stack_top), fiber.@stack_top)
+    Fiber.swapcontext(pointerof(current.@context), pointerof(fiber.@context))
```
Which was triggering args copying due to:
https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/semantic/main_visitor.cr#L2495
https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/codegen/fun.cr#L497

This fix has resolved the issue for me. I'm still not sure though why it's not present in the official distribution and why it hasn't failed for someone else by this point.