### PR TITLE
Compiler: fix a couple of issues with unbound/abstract generic types

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -332,4 +332,29 @@ describe "Code gen: generic class type" do
       Bar(Int32).new.as(Moo).foo
       ))
   end
+
+  it "doesn't consider abstract generic instantiation when restricting type (#5190)" do
+    codegen(%(
+      abstract class Foo(E)
+        abstract def foo
+      end
+
+      abstract class Bar(E) < Foo(E)
+      end
+
+      class Baz(E) < Bar(E)
+        def foo
+        end
+      end
+
+      ptr = Pointer(Foo(String)).malloc(1_u64)
+
+      Baz(String).new
+
+      x = ptr.value
+      if x.is_a?(Bar)
+        x.foo
+      end
+      ))
+  end
 end

--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -310,4 +310,26 @@ describe "Code gen: generic class type" do
       foo(Gen.new("hello") || Gen.new('z')).as(String)
       )).to_string.should eq("hello")
   end
+
+  it "doesn't consider abstract types for including types (#7200)" do
+    codegen(%(
+      module Moo
+      end
+
+      abstract class Foo(T)
+        include Moo
+
+        def foo
+          bar
+        end
+      end
+
+      class Bar(T) < Foo(T)
+        def bar
+        end
+      end
+
+      Bar(Int32).new.as(Moo).foo
+      ))
+  end
 end

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1076,4 +1076,30 @@ describe "Semantic: generic class" do
       f.foo
       )) { generic_class "Foo", 1.int32 }
   end
+
+  it "doesn't consider unbound generic instantiations as concrete (#7200)" do
+    assert_type(%(
+      module Moo
+      end
+
+      abstract class Foo(T)
+        include Moo
+
+        def call
+          T.as(Int32.class)
+        end
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class MooHolder
+        def initialize(@moo : Moo)
+        end
+      end
+
+      moo = MooHolder.new(Bar(Int32).new)
+      moo.@moo.call
+      )) { int32.metaclass }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2635,7 +2635,7 @@ module Crystal
           type.accept self
           instance_type = type.type.instance_type
           unless instance_type.implements?(@program.exception)
-            type.raise "#{type} is not a subclass of Exception"
+            type.raise "#{instance_type} is not a subclass of Exception"
           end
           instance_type
         end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -917,7 +917,9 @@ module Crystal
       elsif base_type.is_a?(GenericInstanceType) && other.is_a?(GenericType)
         # Consider the case of Foo(Int32) vs. Bar(T), with Bar(T) < Foo(T):
         # we want to return Bar(Int32), so we search in Bar's generic instantiations
-        other.generic_types.values.each do |instance|
+        other.generic_types.each_value do |instance|
+          next if instance.unbound? || instance.abstract?
+
           if instance.implements?(base_type)
             return instance
           end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3277,6 +3277,9 @@ private def add_to_including_types(type : Crystal::GenericType, all_types)
     # Unbound generic types are not concrete types
     next if generic_type.unbound?
 
+    # Abstract types also shouldn't form the union of including types
+    next if generic_type.abstract?
+
     all_types << generic_type unless all_types.includes?(generic_type)
   end
   type.subclasses.each do |subclass|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3274,6 +3274,9 @@ end
 
 private def add_to_including_types(type : Crystal::GenericType, all_types)
   type.generic_types.each_value do |generic_type|
+    # Unbound generic types are not concrete types
+    next if generic_type.unbound?
+
     all_types << generic_type unless all_types.includes?(generic_type)
   end
   type.subclasses.each do |subclass|


### PR DESCRIPTION
Fixes #5190
Fixes #7200

## General explanation of the fix

The compiler stores all generic type instantiation of a generic type.

When you have this:

```crystal
class Foo(T)
end

class Bar(T) < Foo(T)
end

Foo(Int32)
```

then `Foo(Int32)` is a generic instantiation of `Foo(T)`.

Now let's say we have:

```crystal
module Moo
end

class Foo(T)
  include Moo
end

class Bar(T) < Foo(T)
end
```

and you have an instance variable of type `Moo`. The compiler will track all including types of `Moo` and consider `Moo` as a union of all those possible types.

Now, in `Bar(T) < Foo(T)` the compiler will create a generic instantiation of `Foo(T)` with `T` being a type parameter... it's also `Foo(T)` but it's different than the generic type `Foo(T)`. The reason is that you could have `class SomeClass(T) < Gen(Int32, T)` where `T` is a type parameter but `Int32` is a concrete type.

The problem is that this `Foo(T)` instantiation was also considered in the types included by `Moo`. And also abstract types, which can't be instantiated.

If you think having the compiler remember all generic instantiations is ugly and inefficient, you are probably right, but that's the way Crystal works (very different than any other language). I'm not convinced it's a good idea, but it seems to work and people are happy with the language, so... :-)

In fact, we disallow doing `@x : Foo` where `Foo` is a generic type, but we allow `@x : Moo`, where `Moo` is included by a generic type, effectively making `@x` have the type of all generic instantiations... so it's a bit strange. Maybe we could allow `@x : Foo` too, though I don't know what's a use case for that.

The thing is, `Moo` is used as an interface, and we expect `Moo` and its including types to provide some method. The `T` in `Foo` isn't going to leak outside `Foo` when considering its `Moo` interface.

This problem exists because there's no virtual dispatch like it's done in C++/C#/Java. But to be able to do that with need type signatures in every method. Tradeoffs... I guess it's fine because this makes Crystal different and unique, though it's not ideal for efficient and modular compilation and code generation.

Anyway, a couple of bugfixes :-)