### PR TITLE
Run CI specs in verbose mode to see where it fails

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -73,6 +73,7 @@ prepare_system() {
 }
 
 build() {
+	with_build_env 'make deps'
 	with_build_env 'bin/crystal spec/std_spec.cr --verbose'
 	with_build_env 'make crystal threads=1'
 	with_build_env 'bin/crystal spec/std_spec.cr --verbose'

--- a/bin/ci
+++ b/bin/ci
@@ -73,8 +73,10 @@ prepare_system() {
 }
 
 build() {
-  with_build_env 'make std_spec clean threads=1'
-  with_build_env 'make crystal std_spec compiler_spec docs threads=1'
+	with_build_env 'bin/crystal spec/std_spec.cr --verbose'
+	with_build_env 'make crystal threads=1'
+	with_build_env 'bin/crystal spec/std_spec.cr --verbose'
+	with_build_env 'bin/crystal spec/compiler_spec.cr --verbose'
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
 }
 


### PR DESCRIPTION
I'm trying to see why/where linux32 fails with "out of memory".