### PR TITLE
Compiler: fix type flow of var in if with &&

### DIFF
--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -337,4 +337,18 @@ describe "Semantic: if" do
       foo
       )) { nilable int32 }
   end
+
+  it "doesn't consider nil type in else branch with if with && (#7434)" do
+    assert_type(%(
+      def foo
+        if true && (y = 1 || nil)
+        else
+          return 1
+        end
+        y
+      end
+
+      foo
+      ), inject_primitives: false) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1999,7 +1999,12 @@ module Crystal
         next if then_var.same?(else_var)
 
         if_var = MetaVar.new(name)
-        if_var.nil_if_read = !!(then_var.try(&.nil_if_read?) || else_var.try(&.nil_if_read?))
+
+        # Only copy `nil_if_read` from each branch if it's not unreachable
+        then_var_nil_if_read = !then_unreachable && then_var.try(&.nil_if_read?)
+        else_var_nil_if_read = !else_unreachable && else_var.try(&.nil_if_read?)
+
+        if_var.nil_if_read = !!(then_var_nil_if_read || else_var_nil_if_read)
 
         # Check if no types were changes in either then 'then' and 'else' branches
         if cond_var && then_var.same?(before_then_var) && else_var.same?(before_else_var) && !then_unreachable && !else_unreachable


### PR DESCRIPTION
Fixes #7434

This one is harder to explain so I'm going to skip that.