### PR TITLE
Compiler: raise on new on abstract class

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1067,4 +1067,42 @@ describe "Code gen: class" do
       Foo(Int32).new.x
       )).to_i.should eq(42)
   end
+
+  it "raises when trying to instantiate abstract class (#3835)" do
+    run(%(
+      require "prelude"
+
+      abstract class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      begin
+        (Foo || Bar).new
+        1
+      rescue
+        2
+      end
+      )).to_i.should eq(2)
+  end
+
+  it "raises when trying to instantiate abstract generic class (#3835)" do
+    run(%(
+      require "prelude"
+
+      abstract class Foo(T)
+      end
+
+      class Bar < Foo(Int32)
+      end
+
+      begin
+        (Foo(Int32) || Bar).new
+        1
+      rescue
+        2
+      end
+      )).to_i.should eq(2)
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1182,6 +1182,20 @@ module Crystal
       false
     end
 
+    protected def define_allocate(metaclass)
+      if metaclass.instance_type.abstract?
+        metaclass.add_def(
+          Def.new("allocate",
+            body: Call.new(nil, "raise",
+              args: [StringLiteral.new("can't instantiate abstract class #{metaclass.instance_type}")] of ASTNode,
+              global: true
+            ))
+        )
+      else
+        metaclass.add_def Def.new("allocate", body: Primitive.new("allocate"))
+      end
+    end
+
     def type_desc
       case
       when extern? && extern_union?
@@ -1200,7 +1214,7 @@ module Crystal
     include ClassVarContainer
 
     protected def initialize_metaclass(metaclass)
-      metaclass.add_def Def.new("allocate", body: Primitive.new("allocate"))
+      define_allocate(metaclass)
     end
 
     def virtual_type
@@ -1762,7 +1776,7 @@ module Crystal
     end
 
     protected def initialize_metaclass(metaclass)
-      metaclass.add_def Def.new("allocate", body: Primitive.new("allocate"))
+      define_allocate(metaclass)
     end
 
     def type_desc


### PR DESCRIPTION
Fixes #3835

This one is a weird one. Given:

```crystal
abstract class Foo
end

class Bar < Foo
end

class Baz < Foo
end
```

If you write `Bar.new || Baz.new`, the compiler will unify the type to "`Foo` or any of its subclasses" (`Foo+`). The same happens when you do `Bar || Baz`, it will be `Foo.class+`.

You can do:

```crystal
(Bar || Baz).new
```

and everything's fine. But you could also do:

```crystal
(Foo || Baz).new
```

and that would somehow create a `Foo` instance, even though `Foo` is abstract! The compiler has no way to know that when you end up with `Foo.class+`, the real types might be abstract types.

To solve this, we allow to invoke `new` but when you try to do it with an abstract class it will raise at runtime. This is not type-safe, but if we disallow this then we couldn't implement, for example, a lookup table:

```crystal
lookup = {"Bar" => Bar, "Baz" => Baz} # gets the type Hash(String, Foo.class+) 
lookup["Bar"].new
```