### PR TITLE
Bcrypt: rename `Password#==` to `Password#verify`

### DIFF
--- a/spec/std/crypto/bcrypt/password_spec.cr
+++ b/spec/std/crypto/bcrypt/password_spec.cr
@@ -38,26 +38,15 @@ describe "Crypto::Bcrypt::Password" do
     end
   end
 
-  describe "==" do
+  describe "verify" do
     password = Crypto::Bcrypt::Password.create("secret", 4)
 
     it "verifies password is incorrect" do
-      (password == "wrong").should be_false
+      (password.verify "wrong").should be_false
     end
 
     it "verifies password is correct" do
-      (password == "secret").should be_true
-    end
-
-    it "works with Password" do
-      (password == password).should be_true
-
-      other_password = Crypto::Bcrypt::Password.create("wrong", 4)
-      (password == other_password).should be_false
-    end
-
-    it "works with other types" do
-      (password == 0.815).should be_false
+      (password.verify "secret").should be_true
     end
   end
 end

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -9,8 +9,8 @@ require "../subtle"
 # password = Crypto::Bcrypt::Password.create("super secret", cost: 10)
 # # => $2a$10$rI4xRiuAN2fyiKwynO6PPuorfuoM4L2PVv6hlnVJEmNLjqcibAfHq
 #
-# password == "wrong secret" # => false
-# password == "super secret" # => true
+# password.verify("wrong secret") # => false
+# password.verify("super secret") # => true
 # ```
 #
 # See `Crypto::Bcrypt` for hints to select the cost when generating hashes.
@@ -61,12 +61,17 @@ class Crypto::Bcrypt::Password
   # require "crypto/bcrypt/password"
   #
   # password = Crypto::Bcrypt::Password.create("super secret")
-  # password == "wrong secret" # => false
-  # password == "super secret" # => true
+  # password.verify("wrong secret") # => false
+  # password.verify("super secret") # => true
   # ```
-  def ==(password : String) : Bool
+  def verify(password : String) : Bool
     hashed_password = Bcrypt.new(password, salt, cost)
     Crypto::Subtle.constant_time_compare(@raw_hash, hashed_password)
+  end
+
+  @[Deprecated("Use Crypto::Bcrypt::Password#verify")]
+  def ==(password : String) : Bool
+    verify(password)
   end
 
   def to_s(io : IO) : Nil

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -69,7 +69,7 @@ class Crypto::Bcrypt::Password
     Crypto::Subtle.constant_time_compare(@raw_hash, hashed_password)
   end
 
-  @[Deprecated("Use Crypto::Bcrypt::Password#verify")]
+  @[Deprecated("Use `Crypto::Bcrypt::Password#verify`")]
   def ==(password : String) : Bool
     verify(password)
   end


### PR DESCRIPTION
Fixes #7753