### PR TITLE
Allow protected methods on API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -3,6 +3,7 @@
   <% methods.each do |method| %>
     <div class="entry-detail" id="<%= method.html_id %>">
       <div class="signature">
+        <%= method.protected? ? "protected " : "" %>
         <%= method.abstract? ? "abstract " : "" %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
 

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -46,7 +46,11 @@ class Crystal::Doc::Macro
     ""
   end
 
-  def abstract?
+  def abstract? : Bool
+    false
+  end
+
+  def protected? : Bool
     false
   end
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -55,8 +55,12 @@ class Crystal::Doc::Method
     {type.name, "self"}.includes?(return_type.to_s)
   end
 
-  def abstract?
+  def abstract? : Bool
     @def.abstract?
+  end
+
+  def protected? : Bool
+    @def.visibility.protected?
   end
 
   def return_type

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -162,10 +162,7 @@ class Crystal::Doc::Type
         defs = [] of Method
         @type.defs.try &.each do |def_name, defs_with_metadata|
           defs_with_metadata.each do |def_with_metadata|
-            case def_with_metadata.def.visibility
-            when .private?
-              next
-            end
+            next if def_with_metadata.def.visibility.private?
 
             if @generator.must_include? def_with_metadata.def
               defs << method(def_with_metadata.def, false)
@@ -185,10 +182,7 @@ class Crystal::Doc::Type
       @type.metaclass.defs.try &.each_value do |defs_with_metadata|
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
-          case a_def.visibility
-          when .private?
-            next
-          end
+          next if a_def.visibility.private?
 
           body = a_def.body
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -163,7 +163,7 @@ class Crystal::Doc::Type
         @type.defs.try &.each do |def_name, defs_with_metadata|
           defs_with_metadata.each do |def_with_metadata|
             case def_with_metadata.def.visibility
-            when .private?, .protected?
+            when .private?
               next
             end
 
@@ -186,7 +186,7 @@ class Crystal::Doc::Type
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
           case a_def.visibility
-          when .private?, .protected?
+          when .private?
             next
           end
 


### PR DESCRIPTION
Allows protected methods to be displayed on the generated API docs.

Example: 
![image](https://user-images.githubusercontent.com/12136995/57987599-acb51900-7a51-11e9-8afc-676f17a8ab31.png)
