### PR TITLE
 Compiler: don't precompute sizeof on abstract structs and modules

### DIFF
--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -199,4 +199,40 @@ describe "Code gen: sizeof" do
       size.should eq(16)
     end
   {% end %}
+
+  it "doesn't precompute sizeof of abstract struct (#7741)" do
+    run(%(
+      abstract struct Base
+      end
+
+      struct Foo(T) < Base
+        def initialize(@x : T)
+        end
+      end
+
+      z = sizeof(Base)
+
+      Foo({Int32, Int32, Int32, Int32})
+
+      z)).to_i.should eq(16)
+  end
+
+  it "doesn't precompute sizeof of module (#7741)" do
+    run(%(
+      module Base
+      end
+
+      struct Foo(T)
+        include Base
+
+        def initialize(@x : T)
+        end
+      end
+
+      z = sizeof(Base)
+
+      Foo({Int32, Int32, Int32, Int32})
+
+      z)).to_i.should eq(16)
+  end
 end

--- a/spec/compiler/semantic/sizeof_spec.cr
+++ b/spec/compiler/semantic/sizeof_spec.cr
@@ -22,7 +22,10 @@ describe "Semantic: sizeof" do
   end
 
   it "gives error if using instance_sizeof on something that's not a class" do
-    assert_error "instance_sizeof(Int32)", "Int32 is not a class, it's a struct"
+    assert_error %(
+      instance_sizeof(Int32)
+      ),
+      "instance_sizeof can only be used with a class, but Int32 is a struct"
   end
 
   it "gives error if using instance_sizeof on a struct" do
@@ -32,7 +35,7 @@ describe "Semantic: sizeof" do
 
       instance_sizeof(Foo)
       ),
-      "Foo is not a class, it's a struct"
+      "instance_sizeof can only be used with a class, but Foo is a struct"
   end
 
   it "gives error if using instance_sizeof on a module" do
@@ -42,7 +45,7 @@ describe "Semantic: sizeof" do
 
       instance_sizeof(Moo)
       ),
-      "Moo is not a class, it's a module"
+      "instance_sizeof can only be used with a class, but Moo is a module"
   end
 
   it "gives error if using instance_sizeof on a generic type without type vars" do

--- a/spec/compiler/semantic/sizeof_spec.cr
+++ b/spec/compiler/semantic/sizeof_spec.cr
@@ -25,6 +25,26 @@ describe "Semantic: sizeof" do
     assert_error "instance_sizeof(Int32)", "Int32 is not a class, it's a struct"
   end
 
+  it "gives error if using instance_sizeof on a struct" do
+    assert_error %(
+      struct Foo
+      end
+
+      instance_sizeof(Foo)
+      ),
+      "Foo is not a class, it's a struct"
+  end
+
+  it "gives error if using instance_sizeof on a module" do
+    assert_error %(
+      module Moo
+      end
+
+      instance_sizeof(Moo)
+      ),
+      "Moo is not a class, it's a module"
+  end
+
   it "gives error if using instance_sizeof on a generic type without type vars" do
     assert_error "instance_sizeof(Array)", "can't take instance_sizeof uninstantiated generic type Array(T)"
   end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -714,7 +714,7 @@ module Crystal
       if exp_type
         instance_type = exp_type.instance_type.devirtualize
         if instance_type.struct? || instance_type.module?
-          node.exp.raise "#{instance_type} is not a class, it's a #{instance_type.type_desc}"
+          node.exp.raise "instance_sizeof can only be used with a class, but #{instance_type} is a #{instance_type.type_desc}"
         end
       end
 

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -713,7 +713,7 @@ module Crystal
 
       if exp_type
         instance_type = exp_type.instance_type.devirtualize
-        unless instance_type.class?
+        if instance_type.struct? || instance_type.module?
           node.exp.raise "#{instance_type} is not a class, it's a #{instance_type.type_desc}"
         end
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2568,7 +2568,8 @@ module Crystal
       # Try to resolve the sizeof right now to a number literal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
-      if type && !node.exp.is_a?(TypeOf)
+      if type && !node.exp.is_a?(TypeOf) &&
+         !(type.module? || (type.abstract? && type.struct?))
         expanded = NumberLiteral.new(@program.size_of(type.sizeof_type).to_s, :i32)
         expanded.type = @program.int32
         node.expanded = expanded


### PR DESCRIPTION
Fixes #7741

And a few other fixes/improvements too.

I'm marking it as a breaking change too because `instance_sizeof` could be incorrectly invoked with non-class stuff (like structs) and so this will make compiling (but incorrect) code to stop compiling... but I think it's fine.