### PR TITLE
YAML: let String handle numbers too

### DIFF
--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -103,6 +103,12 @@ private class YAMLWithPresence
   })
 end
 
+private class YAMLWithString
+  YAML.mapping({
+    value: String,
+  })
+end
+
 class YAMLRecursive
   YAML.mapping({
     name:  String,
@@ -529,5 +535,13 @@ describe "YAML mapping" do
 
   it "calls #finalize" do
     assert_finalizes(:yaml) { YAMLWithFinalize.from_yaml("---\nvalue: 1\n") }
+  end
+
+  it "parses string even if it looks like a number" do
+    yaml = YAMLWithString.from_yaml <<-YAML
+      ---
+      value: 12.34
+      YAML
+    yaml.value.should eq("12.34")
   end
 end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -55,10 +55,8 @@ describe "YAML serialization" do
       String.from_yaml("hello").should eq("hello")
     end
 
-    it "raises on reserved string" do
-      expect_raises(YAML::ParseException) do
-        String.from_yaml(%(1.2))
-      end
+    it "can parse string that looks like a number" do
+      String.from_yaml(%(1.2)).should eq ("1.2")
     end
 
     it "does Float32#from_yaml" do

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -53,7 +53,17 @@ end
 {% end %}
 
 def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-  parse_scalar(ctx, node, self)
+  ctx.read_alias(node, String) do |obj|
+    return obj
+  end
+
+  if node.is_a?(YAML::Nodes::Scalar)
+    value = node.value
+    ctx.record_anchor(node, value)
+    value
+  else
+    node.raise "Expected String, not #{node.class.name}"
+  end
 end
 
 def Float32.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)


### PR DESCRIPTION
Fixes #5798

I already gave a lot of reasons why this is a good/correct change (every other statically typed language does this), plus we recently bumped into this with something like:

```yaml
version: 2.8
```

If I say I want to read the version as a string, there's no reason why I have to go and modify the yaml file to add an annotation like `!string` or put it in quotes. People don't do that, at all. And there's no point forcing people to do that (and sometimes it's impossible because the yaml is not in their control).

Or imagine have some kind of code:

```yaml
code: abc123
```

That looks like a String. Now this (imagine someone is editing it manually, typing it):

```yaml
code: 12e45
```

Oops! You just input something that looks like a floating point number. You should be more careful when that happens and put quotes around it. Right? No... people don't do that, they don't care about how the machine will work in this case, they are just editing a string in their mind. And I think that's fine.