### PR TITLE
Fix record macro with inheritance

### DIFF
--- a/spec/std/record_spec.cr
+++ b/spec/std/record_spec.cr
@@ -14,6 +14,11 @@ private module RecordSpec
     y = [2, 3]
 end
 
+private abstract struct Base
+end
+
+private record Sub < Base, x : Int32
+
 describe "record" do
   it "defines record with type declarations" do
     ary = [2, 3]
@@ -59,5 +64,15 @@ describe "record" do
     cloned.x.should eq(0)
     cloned.y.should eq(rec.y)
     cloned.y.should_not be(rec.y)
+  end
+
+  it "can clone record with parent type" do
+    rec = Sub.new 1
+    rec.clone.x.should eq(1)
+  end
+
+  it "can copy_with record with parent type" do
+    rec = Sub.new 1
+    rec.copy_with(x: 2).x.should eq(2)
   end
 end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -89,31 +89,31 @@ macro record(name, *properties)
                       end
                     end
                   }})
-      {{name.id}}.new({{
-                        *properties.map do |property|
-                          if property.is_a?(Assign)
-                            "_#{property.target.id}".id
-                          elsif property.is_a?(TypeDeclaration)
-                            "_#{property.var.id}".id
-                          else
-                            "_#{property.id}".id
-                          end
-                        end
-                      }})
+      self.class.new({{
+                       *properties.map do |property|
+                         if property.is_a?(Assign)
+                           "_#{property.target.id}".id
+                         elsif property.is_a?(TypeDeclaration)
+                           "_#{property.var.id}".id
+                         else
+                           "_#{property.id}".id
+                         end
+                       end
+                     }})
     end
 
     def clone
-      {{name.id}}.new({{
-                        *properties.map do |property|
-                          if property.is_a?(Assign)
-                            "@#{property.target.id}.clone".id
-                          elsif property.is_a?(TypeDeclaration)
-                            "@#{property.var.id}.clone".id
-                          else
-                            "@#{property.id}.clone".id
-                          end
-                        end
-                      }})
+      self.class.new({{
+                       *properties.map do |property|
+                         if property.is_a?(Assign)
+                           "@#{property.target.id}.clone".id
+                         elsif property.is_a?(TypeDeclaration)
+                           "@#{property.var.id}.clone".id
+                         else
+                           "@#{property.id}.clone".id
+                         end
+                       end
+                     }})
     end
   end
 end


### PR DESCRIPTION
This didn't work:

```crystal
abstract struct Base; end

record Point < Base, x = 0, y = 0

Point.new(1, 2).clone
```

But with this PR it does.