### PR TITLE
Compiler: fix new/initialize lookup regarding modules

### DIFF
--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1352,4 +1352,20 @@ describe "Semantic: module" do
       Gen(Int32).foo
       )) { int32.metaclass }
   end
+
+  it "doesn't look up initialize past module that defines initialize (#7007)" do
+    assert_error %(
+      module Moo
+        def initialize(x)
+        end
+      end
+
+      class Foo
+        include Moo
+      end
+
+      Foo.new
+      ),
+      "wrong number of arguments"
+  end
 end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -61,10 +61,10 @@ class Crystal::Call
       end
     end
 
-    # Another special case: initialize is only looked up one level,
+    # Another special case: `new` and `initialize` are only looked up one level,
     # so we must find the first one defined.
     new_owner = owner
-    while defs.empty? && def_name == "initialize"
+    while defs.empty? && (def_name == "initialize" || def_name == "new")
       new_owner = new_owner.superclass
       if new_owner
         defs = new_owner.lookup_defs(def_name)

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -36,7 +36,7 @@ module Crystal
       # `new` must only be searched in ancestors if this type itself doesn't define
       # an `initialize` or `self.new` method. This was already computed in `new.cr`
       # and can be known by invoking `lookup_new_in_ancestors?`
-      if my_parents && !(!lookup_new_in_ancestors? && is_new)
+      if my_parents && !(is_new && !lookup_new_in_ancestors?)
         my_parents.each do |parent|
           matches = parent.lookup_matches(signature, owner, parent, matches_array)
           if matches.cover_all?
@@ -44,6 +44,11 @@ module Crystal
           else
             matches_array = matches.matches
           end
+
+          # If this is a `new` method, once a parent defines an `initialize`
+          # method and we couldn't find any matches we must not go up in the
+          # hierarchy.
+          break if is_new && parent.has_def_without_parents?(signature.name)
         end
       end
 


### PR DESCRIPTION
Fixes #7007

It turned out the issue was that even this compiled:

```crystal
module Base
  def initialize(x)
  end
end

class Foo
  include Base
end

Foo.new # Works, finds then one in Reference, but shouldn't!
```

The problem was that `new`/`initialize` lookup looked past modules that defined an `initialize` method and this was wrong.