### PR TITLE
Fix flake: compress handler specs

### DIFF
--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -38,13 +38,9 @@ describe HTTP::CompressHandler do
     response2 = HTTP::Client::Response.from_io(io, decompress: false)
     body = response2.body
 
-    io2 = IO::Memory.new
-    deflate = Flate::Writer.new(io2)
-    deflate.print "Hello"
-    deflate.close
-    io2.rewind
-
-    body.to_slice.should eq(io2.to_slice)
+    io2 = IO::Memory.new(body)
+    flate = Flate::Reader.new(io2)
+    flate.gets_to_end.should eq("Hello")
   end
 
   it "deflates gzip if has deflate in 'deflate' Accept-Encoding header" do
@@ -66,12 +62,8 @@ describe HTTP::CompressHandler do
     response2 = HTTP::Client::Response.from_io(io, decompress: false)
     body = response2.body
 
-    io2 = IO::Memory.new
-    deflate = Gzip::Writer.new(io2)
-    deflate.print "Hello"
-    deflate.close
-    io2.rewind
-
-    body.to_slice.should eq(io2.to_slice)
+    io2 = IO::Memory.new(body)
+    gzip = Gzip::Reader.new(io2)
+    gzip.gets_to_end.should eq("Hello")
   end
 end


### PR DESCRIPTION
This makes these tests more robust. It turns out when you compress using gzip the value depends... on time too? Look at this: https://play.crystal-lang.org/#/r/6ytn

So instead of compressing twice and checking that the values match, which might not happen if we just cross a second boundary, we decompress it and check that it's the same thing that we compressed.