### PR TITLE
Add type restrictions to INI

### DIFF
--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -54,22 +54,8 @@ describe "INI" do
       it "parses empty section" do
         INI.parse("[section]").should eq({"section" => Hash(String, String).new})
       end
-
-      it "parses a file" do
-        INI.parse(File.read datapath("test_file.ini")).should eq({
-          "general" => {
-            "log_level" => "D",
-          },
-          "section1" => {
-            "foo" => "1.1",
-            "bar" => "2",
-          },
-          "section2" => {
-            "x.y.z" => "coco lala",
-          },
-        })
-      end
     end
+
     describe "from IO" do
       it "parses a file" do
         File.open datapath("test_file.ini") do |file|

--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -2,71 +2,91 @@ require "./spec_helper"
 require "ini"
 
 describe "INI" do
-  describe "parse from string" do
-    it "fails on malformed section" do
-      expect_raises(INI::ParseException, "unterminated section") do
-        INI.parse("[section")
-      end
-    end
-
-    it "fails on data after section" do
-      expect_raises(INI::ParseException, "data after section") do
-        INI.parse("[section] foo  ")
-      end
-    end
-
-    it "fails on malformed declaration" do
-      expect_raises(INI::ParseException, "expected declaration") do
-        INI.parse("foobar")
+  describe "parse" do
+    describe "from String" do
+      it "fails on malformed section" do
+        expect_raises(INI::ParseException, "unterminated section") do
+          INI.parse("[section")
+        end
       end
 
-      expect_raises(INI::ParseException, "expected declaration") do
-        INI.parse("foo: bar")
+      it "fails on data after section" do
+        expect_raises(INI::ParseException, "data after section") do
+          INI.parse("[section] foo  ")
+        end
+      end
+
+      it "fails on malformed declaration" do
+        expect_raises(INI::ParseException, "expected declaration") do
+          INI.parse("foobar")
+        end
+
+        expect_raises(INI::ParseException, "expected declaration") do
+          INI.parse("foo: bar")
+        end
+      end
+
+      it "parses key = value" do
+        INI.parse("key = value").should eq({"" => {"key" => "value"}})
+      end
+
+      it "parses empty values" do
+        INI.parse("key = ").should eq({"" => {"key" => ""}})
+      end
+
+      it "ignores whitespaces" do
+        INI.parse("   key   =   value  ").should eq({"" => {"key" => "value"}})
+        INI.parse("  [foo]").should eq({"foo" => Hash(String, String).new})
+      end
+
+      it "ignores comments" do
+        INI.parse("; foo\n# bar\nkey = value").should eq({"" => {"key" => "value"}})
+      end
+
+      it "parses sections" do
+        INI.parse("[section]\na = 1").should eq({"section" => {"a" => "1"}})
+      end
+
+      it "parses a reopened section" do
+        INI.parse("[foo]\na=1\n[foo]\nb=2").should eq({"foo" => {"a" => "1", "b" => "2"}})
+      end
+
+      it "parses empty section" do
+        INI.parse("[section]").should eq({"section" => Hash(String, String).new})
+      end
+
+      it "parses a file" do
+        INI.parse(File.read datapath("test_file.ini")).should eq({
+          "general" => {
+            "log_level" => "D",
+          },
+          "section1" => {
+            "foo" => "1.1",
+            "bar" => "2",
+          },
+          "section2" => {
+            "x.y.z" => "coco lala",
+          },
+        })
       end
     end
-
-    it "parses key = value" do
-      INI.parse("key = value").should eq({"" => {"key" => "value"}})
-    end
-
-    it "parses empty values" do
-      INI.parse("key = ").should eq({"" => {"key" => ""}})
-    end
-
-    it "ignores whitespaces" do
-      INI.parse("   key   =   value  ").should eq({"" => {"key" => "value"}})
-      INI.parse("  [foo]").should eq({"foo" => Hash(String, String).new})
-    end
-
-    it "ignores comments" do
-      INI.parse("; foo\n# bar\nkey = value").should eq({"" => {"key" => "value"}})
-    end
-
-    it "parses sections" do
-      INI.parse("[section]\na = 1").should eq({"section" => {"a" => "1"}})
-    end
-
-    it "parses a reopened section" do
-      INI.parse("[foo]\na=1\n[foo]\nb=2").should eq({"foo" => {"a" => "1", "b" => "2"}})
-    end
-
-    it "parses empty section" do
-      INI.parse("[section]").should eq({"section" => Hash(String, String).new})
-    end
-
-    it "parses a file" do
-      INI.parse(File.read datapath("test_file.ini")).should eq({
-        "general" => {
-          "log_level" => "D",
-        },
-        "section1" => {
-          "foo" => "1.1",
-          "bar" => "2",
-        },
-        "section2" => {
-          "x.y.z" => "coco lala",
-        },
-      })
+    describe "from IO" do
+      it "parses a file" do
+        File.open datapath("test_file.ini") do |file|
+          INI.parse(file).should eq({
+            "general" => {
+              "log_level" => "D",
+            },
+            "section1" => {
+              "foo" => "1.1",
+              "bar" => "2",
+            },
+            "section2" => {
+              "x.y.z" => "coco lala",
+            },
+          })
+        end
+      end
     end
   end
 

--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -3,7 +3,7 @@ require "ini"
 
 describe "INI" do
   describe "parse" do
-    describe "from String" do
+    context "from String" do
       it "fails on malformed section" do
         expect_raises(INI::ParseException, "unterminated section") do
           INI.parse("[section")
@@ -56,7 +56,7 @@ describe "INI" do
       end
     end
 
-    describe "from IO" do
+    context "from IO" do
       it "parses a file" do
         File.open datapath("test_file.ini") do |file|
           INI.parse(file).should eq({

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -21,7 +21,7 @@ class INI
   #
   # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => "1"}}
   # ```
-  def self.parse(str) : Hash(String, Hash(String, String))
+  def self.parse(str : String) : Hash(String, Hash(String, String))
     ini = Hash(String, Hash(String, String)).new
     current_section = ini[""] = Hash(String, String).new
     lineno = 0
@@ -65,12 +65,12 @@ class INI
   #
   # INI.build({"foo" => {"a" => "1"}}, true) # => "[foo]\na = 1\n\n"
   # ```
-  def self.build(ini, space : Bool = false) : String
+  def self.build(ini : Hash(String, Hash(String, String)) | T, space : Bool = false) : String forall T
     String.build { |str| build str, ini, space }
   end
 
   # Appends INI data to the given IO.
-  def self.build(io : IO, ini, space : Bool = false)
+  def self.build(io : IO, ini : Hash(String, Hash(String, String)) | T, space : Bool = false) : Nil forall T
     ini.each do |section, contents|
       io << '[' << section << "]\n"
       contents.each do |key, value|

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -21,7 +21,7 @@ class INI
   #
   # INI.parse("[foo]\na = 1") # => {"foo" => {"a" => "1"}}
   # ```
-  def self.parse(str : String) : Hash(String, Hash(String, String))
+  def self.parse(str : String | IO) : Hash(String, Hash(String, String))
     ini = Hash(String, Hash(String, String)).new
     current_section = ini[""] = Hash(String, String).new
     lineno = 0

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -65,12 +65,12 @@ class INI
   #
   # INI.build({"foo" => {"a" => "1"}}, true) # => "[foo]\na = 1\n\n"
   # ```
-  def self.build(ini : Hash(String, Hash(String, String)) | T, space : Bool = false) : String forall T
+  def self.build(ini, space : Bool = false) : String
     String.build { |str| build str, ini, space }
   end
 
   # Appends INI data to the given IO.
-  def self.build(io : IO, ini : Hash(String, Hash(String, String)) | T, space : Bool = false) : Nil forall T
+  def self.build(io : IO, ini, space : Bool = false) : Nil
     ini.each do |section, contents|
       io << '[' << section << "]\n"
       contents.each do |key, value|


### PR DESCRIPTION
Having type restrictions helps to know which type is expected when looking at the API docs, but still supporting exotic types with Unions like `NamedTuple` with `Int32` and `Char` values.