### PR TITLE
Add Benchmark.memory

### DIFF
--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -1,7 +1,7 @@
 require "./benchmark/**"
 
 # The Benchmark module provides methods for benchmarking Crystal code, giving
-# detailed reports on the time taken for each task.
+# detailed reports on the time and memory taken for each task.
 #
 # ### Measure the number of iterations per second of each task
 #
@@ -137,5 +137,16 @@ module Benchmark
   # ```
   def realtime : Time::Span
     Time.measure { yield }
+  end
+
+  # Returns the memory in bytes that the given block consumes.
+  #
+  # ```
+  # Benchmark.memory { Array(Int32).new } # => 32
+  # ```
+  def memory
+    bytes_before_measure = GC.stats.total_bytes
+    yield
+    (GC.stats.total_bytes - bytes_before_measure).to_i64
   end
 end

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -87,9 +87,8 @@ module Benchmark
           target = Time.monotonic + @calculation_time
 
           loop do
-            bytes_before_measure = GC.stats.total_bytes
-            elapsed = Time.measure { item.call_for_100ms }
-            bytes += (GC.stats.total_bytes - bytes_before_measure).to_i64
+            bytes_taken = Benchmark.memory { elapsed = Time.measure { item.call_for_100ms } }
+            bytes += bytes_taken
             cycles += item.cycles
             measurements << elapsed
             break if Time.monotonic >= target

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -88,7 +88,9 @@ module Benchmark
 
           loop do
             elapsed = nil
-            bytes_taken = Benchmark.memory { elapsed = Time.measure { item.call_for_100ms } }
+            bytes_taken = Benchmark.memory do
+              elapsed = Time.measure { item.call_for_100ms }
+            end
             bytes += bytes_taken
             cycles += item.cycles
             measurements << elapsed.not_nil!

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -87,10 +87,11 @@ module Benchmark
           target = Time.monotonic + @calculation_time
 
           loop do
+            elapsed = nil
             bytes_taken = Benchmark.memory { elapsed = Time.measure { item.call_for_100ms } }
             bytes += bytes_taken
             cycles += item.cycles
-            measurements << elapsed
+            measurements << elapsed.not_nil!
             break if Time.monotonic >= target
           end
 


### PR DESCRIPTION
Sometimes not only execution speed is of interest but also the consumed memory, when your program runs on a device with low RAM for example, like a Raspberry Pi. So I think it would be good to abstract IPS' internal GC stats total bytes computation into a method which can be conveniently used instead of having to wait for a benchmark entry to finish first just to see the consumed memory. There's also that `` Warning: benchmarking without the `--release` flag won't yield useful results `` message then which is unwanted output in that case.