### PR TITLE
Allow running compiler_specs with specific flags

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -176,7 +176,7 @@ end
 private def encode_program_flags : String
   f = [] of String
   apply_program_flags(f)
-  f.map { |x| "-D#{x}" }.join(" ") || ""
+  f.map { |x| "-D#{x}" }.join(' ')
 end
 
 class Crystal::SpecRunOutput


### PR DESCRIPTION
Fixes #7805 

This PR solves the mentioned issue in the narrowest way: 1.a (only affecting the specs) + 2.a (only allowing compiler flags).

This is use full for testing compiler features behind flags locally and could be used for testing compiler with different configurations in CI.