### PR TITLE
Fix Def#to_s with **options and &block

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -161,4 +161,5 @@ describe "ASTNode#to_s" do
   expect_to_s %[(1..)]
   expect_to_s %[..3]
   expect_to_s "offsetof(Foo, @bar)"
+  expect_to_s "def foo(**options, &block)\nend"
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -674,6 +674,7 @@ module Crystal
           @str << ", " if printed_arg
           @str << "**"
           double_splat.accept self
+          printed_arg = true
         end
         if block_arg = node.block_arg
           @str << ", " if printed_arg


### PR DESCRIPTION
Fixed #7853

It's quite simple bug: missing a line `printed_arg = true` on outputting `**options`. Thank you.