### PR TITLE
Fix cipher expectation in OpenSSL Socket spec

### DIFF
--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -15,7 +15,9 @@ describe OpenSSL::SSL::Socket do
       end
 
       client = server.accept
-      client.cipher.should contain "RSA"
+      cipher = client.cipher
+      cipher.upcase.should eq cipher
+      cipher.should_not be_empty
       client.close
     end
   end

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -15,9 +15,7 @@ describe OpenSSL::SSL::Socket do
       end
 
       client = server.accept
-      cipher = client.cipher
-      cipher.upcase.should eq cipher
-      cipher.should_not be_empty
+      client.cipher.should_not be_empty
       client.close
     end
   end


### PR DESCRIPTION
Recent OpenSSL defaults to TLS_AES_256_GCM_SHA384.
Fixes #7869.