### PR TITLE
Compiler: fix enum overflow math

### DIFF
--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -472,4 +472,14 @@ describe "Semantic: enum" do
       ),
       "value of enum member V9 would overflow the base type UInt8"
   end
+
+  it "doesn't overflow when going from negative to zero (#7874)" do
+    semantic(%(
+      enum Nums
+        Zero  = -2
+        One
+        Two
+      end
+    ))
+  end
 end

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -482,4 +482,14 @@ describe "Semantic: enum" do
       end
     ))
   end
+
+  it "doesn't overflow on flags member (#7877)" do
+    semantic(%(
+      @[Flags]
+      enum Filter
+        A = 1 << 29
+        B
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -679,17 +679,18 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
 
       const_value.type = enum_type
-      new_counter =
-        if is_flags
-          if counter == 0 # In case the member is set to 0
-            1
-          else
-            counter &* 2
-          end
+      if is_flags
+        if counter == 0 # In case the member is set to 0
+          new_counter = 1
+          overflow = false
         else
-          counter &+ 1
+          new_counter = counter &* 2
+          overflow = !default_value && counter.sign != new_counter.sign
         end
-      overflow = !default_value && (new_counter.abs < counter.abs)
+      else
+        new_counter = counter &+ 1
+        overflow = !default_value && counter > 0 && new_counter < 0
+      end
       new_counter = overflow ? counter : new_counter
       {new_counter, all_value, overflow}
     else


### PR DESCRIPTION
Fixes #7877
Fixes #7874

Hopefully the manual overflow detection is good now.

Maybe as a hot-fix for 0.29.1? I'm not sure how common are enums with negative values...

(Side note: Eventually we might want to have either methods to check whether an operation would overflow (and the value of the operation in case of non-overflow) or a new operator. LLVM has these operations as built-in, returning a tuple of the new value and a bool. They are currently used by the overflow check to throw an exception, but I'd like to also have operations that return this tuple.)