### PR TITLE
Don't allow ranges to span across lines

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -812,6 +812,7 @@ module Crystal
     it_parses "(1 ... )", Expressions.new([RangeLiteral.new(1.int32, Nop.new, true)] of ASTNode)
     it_parses "foo(1.., 2)", Call.new(nil, "foo", [RangeLiteral.new(1.int32, Nop.new, false), 2.int32] of ASTNode)
     it_parses "1..;", RangeLiteral.new(1.int32, Nop.new, false)
+    it_parses "1..\n2..", Expressions.new([RangeLiteral.new(1.int32, Nop.new, false), RangeLiteral.new(2.int32, Nop.new, false)] of ASTNode)
     it_parses "{1.. => 2};", HashLiteral.new([HashLiteral::Entry.new(RangeLiteral.new(1.int32, Nop.new, false), 2.int32)])
     it_parses "..2", RangeLiteral.new(Nop.new, 2.int32, false)
     it_parses "...2", RangeLiteral.new(Nop.new, 2.int32, true)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -464,13 +464,14 @@ module Crystal
 
     def new_range(exp, location, exclusive)
       check_void_value exp, location
-      next_token_skip_space_or_newline
+      next_token_skip_space
       check_void_expression_keyword
       right = if end_token? ||
                  @token.type == :")" ||
                  @token.type == :"," ||
                  @token.type == :";" ||
-                 @token.type == :"=>"
+                 @token.type == :"=>" ||
+                 @token.type == :NEWLINE
                 Nop.new
               else
                 parse_or


### PR DESCRIPTION
`1..\n2..` was turning into `(1..2)..`

This is a backwards-incompatible change because `1..\n2` is also no longer parsed as one range.