### PR TITLE
Add String#occurrences

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1303,6 +1303,12 @@ describe "String" do
     end
   end
 
+  describe "occurrences" do
+    it "returns the amount of occurrences of a string in a string" do
+      "hello hello".occurrences("ll").should eq(2)
+    end
+  end
+
   describe "gsub" do
     it "gsubs char with char" do
       "foobar".gsub('o', 'e').should eq("feebar")

--- a/src/string.cr
+++ b/src/string.cr
@@ -2029,6 +2029,18 @@ class String
     end
   end
 
+  # Returns the amount of occurrences of *pattern* in `self`.
+  def find(pattern : String)
+    return self.size + 1 if pattern.empty?
+    count = 0
+    index = 0
+    while index = byte_index(pattern, index)
+      count += 1
+      index += pattern.bytesize
+    end
+    count
+  end
+
   # Returns a `String` where each character yielded to the given block
   # is replaced by the block's return value.
   #

--- a/src/string.cr
+++ b/src/string.cr
@@ -2030,6 +2030,10 @@ class String
   end
 
   # Returns the amount of occurrences of *pattern* in `self`.
+  #
+  # ```
+  # "hello hello".find("ll") # => 2
+  # ```
   def find(pattern : String)
     return self.size + 1 if pattern.empty?
     count = 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -2029,18 +2029,18 @@ class String
     end
   end
 
-  # Returns the amount of occurrences of *pattern* in `self`.
+  # Returns the amount of occurrences of *string* in `self`.
   #
   # ```
-  # "hello hello".find("ll") # => 2
+  # "hello hello".occurrences("ll") # => 2
   # ```
-  def find(pattern : String)
-    return self.size + 1 if pattern.empty?
+  def occurrences(of string : String)
+    return self.size + 1 if string.empty?
     count = 0
     index = 0
-    while index = byte_index(pattern, index)
+    while index = byte_index(string, index)
       count += 1
-      index += pattern.bytesize
+      index += string.bytesize
     end
     count
   end


### PR DESCRIPTION
This adds `String#occurrences` which returns the amount of occurrences of a string in a string.
This is already possible with `"hello hello".scan("ll").size # => 2` but that's very inefficient (creates an array + a bunch of strings, just to get the array's size).
The best name for this method, `count` is unfortunately already taken by `String#count`.