### PR TITLE
Build: Automated snap publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout a9e28e721e54583ae18576f69e093e79f1f5c597
+          git checkout 34f76b4dd6fa030f1fe5a89df9fe634dca1060a5
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts
@@ -132,6 +132,10 @@ jobs:
           echo "export CRYSTAL_VERSION=$CIRCLE_TAG" >> build.env
           echo "export DOCKER_TAG=$CIRCLE_TAG" >> build.env
 
+          # Snapcraft configuration
+          echo "export SNAP_GRADE=stable" >> build.env
+          echo "export SNAP_CHANNEL=edge" >> build.env
+
           cat build.env
       - persist_to_workspace:
           root: /tmp/workspace
@@ -155,6 +159,10 @@ jobs:
 
           # Build from working directory (needed for omnibus and when version does not match branch/tag)
           echo "export FORCE_GIT_TAGGED=0" >> build.env
+
+          # Snapcraft configuration
+          echo "export SNAP_GRADE=devel" >> build.env
+          echo "export SNAP_CHANNEL=edge" >> build.env
 
           cat build.env
       - persist_to_workspace:
@@ -180,6 +188,10 @@ jobs:
 
           # Build from working directory (needed for omnibus and when version does not match branch/tag)
           echo "export FORCE_GIT_TAGGED=0" >> build.env
+
+          # Snapcraft configuration
+          echo "export SNAP_GRADE=devel" >> build.env
+          echo "export SNAP_CHANNEL=edge/$VERSION" >> build.env
 
           cat build.env
       - persist_to_workspace:
@@ -283,6 +295,38 @@ jobs:
           docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
           docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}
           docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}-build
+
+  dist_snap:
+    docker:
+      - image: cibuilds/snapcraft:stable
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          command: |
+            apt-get install -y make
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+            cd snapcraft
+            CRYSTAL_RELEASE_LINUX64_TARGZ=/tmp/workspace/build/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz make
+      - persist_to_workspace:
+          root: /tmp/workspace/distribution-scripts/snapcraft/
+          paths:
+            - build
+
+  publish_snap:
+    docker:
+      - image: cibuilds/snapcraft:stable
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          command: |
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+
+            echo $SNAPCRAFT_TOKEN | snapcraft login --with -
+            snapcraft push /tmp/workspace/build/*.snap --release=$SNAP_CHANNEL
 
   dist_docs:
     machine: true
@@ -396,6 +440,14 @@ workflows:
           filters: *per_tag
           requires:
             - dist_linux
+      - dist_snap:
+          filters: *per_tag
+          requires:
+            - dist_linux
+      - publish_snap:
+          filters: *per_tag
+          requires:
+            - dist_snap
       - test_dist_linux_on_docker:
           filters: *per_tag
           requires:
@@ -413,6 +465,7 @@ workflows:
             - dist_linux32
             - dist_darwin
             - dist_docker
+            - dist_snap
             - dist_docs
 
   nightly_release:
@@ -449,6 +502,12 @@ workflows:
       - dist_docker:
           requires:
             - dist_linux
+      - dist_snap:
+          requires:
+            - dist_linux
+      - publish_snap:
+          requires:
+            - dist_snap
       - test_dist_linux_on_docker:
           requires:
             - dist_docker
@@ -464,6 +523,7 @@ workflows:
             - dist_linux32
             - dist_darwin
             - dist_docker
+            - dist_snap
             - dist_docs
 
   maintenance_release:
@@ -507,6 +567,14 @@ workflows:
           filters: *maintenance
           requires:
             - dist_linux
+      - dist_snap:
+          filters: *maintenance
+          requires:
+            - dist_linux
+      - publish_snap:
+          filters: *maintenance
+          requires:
+            - dist_snap
       - test_dist_linux_on_docker:
           filters: *maintenance
           requires:
@@ -526,5 +594,6 @@ workflows:
             - dist_linux32
             - dist_darwin
             - dist_docker
+            - dist_snap
             - dist_docs
 


### PR DESCRIPTION
* Bump distribution-scripts
* Run snapcraft for tagged, nightlies and maintenance workflows.
* Only tagged builds are marked with snap grade stable to ensure tagged builds are the only ones that can make their way to stable channel.
* Snaps are always published to edge channel.
* The generated .snap file is available as an artifact and the end of the workflow.

This enables nightlies releases in a fully automated fashion easy to use from Linux distros and that is already integrated in TravisCI

Fixes #5836
Ref: https://changelog.travis-ci.com/crystal-nightlies-support-105460