### PR TITLE
Allow setting default capacity for StringPool

### DIFF
--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -65,4 +65,12 @@ describe StringPool do
     end
     pool.size.should eq(10_000)
   end
+
+  it "can be created with larger initial capacity" do
+    pool = StringPool.new(capacity: 32)
+    s1 = pool.get "foo"
+    s2 = pool.get "foo"
+    s1.should be(s2)
+    pool.size.should eq(1)
+  end
 end

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -67,7 +67,7 @@ describe StringPool do
   end
 
   it "can be created with larger initial capacity" do
-    pool = StringPool.new(capacity: 32)
+    pool = StringPool.new(initial_capacity: 32)
     s1 = pool.get "foo"
     s2 = pool.get "foo"
     s1.should be(s2)

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -33,8 +33,18 @@ class StringPool
   getter size : Int32
 
   # Creates a new empty string pool.
-  def initialize
-    @capacity = 8
+  #
+  # The *initial_capacity* is useful to avoid unnecessary reallocations
+  # of the internal buffers in case of growth. If you have an estimate
+  # of the maximum number of elements the pool will hold it should
+  # be initialized with that capacity for improved performance.
+  #
+  # ```
+  # pool = StringPool.new(256)
+  # pool.size # => 0
+  # ```
+  def initialize(initial_capacity = 8)
+    @capacity = initial_capacity
     @hashes = Pointer(UInt64).malloc(@capacity, 0_u64)
     @values = Pointer(String).malloc(@capacity, "")
     @size = 0


### PR DESCRIPTION
I think the previous default capacity of 8 entries is way too low for any read world use case, but maybe I'm wrong, can revert it if you want to. 