### PR TITLE
StringPool#clear

### DIFF
--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -65,4 +65,12 @@ describe StringPool do
     end
     pool.size.should eq(10_000)
   end
+
+  it "can be cleared" do
+    pool = StringPool.new
+    pool.get "foo"
+    pool.size.should eq(1)
+    pool.clear
+    pool.size.should eq(0)
+  end
 end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -34,7 +34,7 @@ class StringPool
 
   # Creates a new empty string pool.
   def initialize
-    @capacity = 8
+    @capacity = @initial_capacity = 8
     @hashes = Pointer(UInt64).malloc(@capacity, 0_u64)
     @values = Pointer(String).malloc(@capacity, "")
     @size = 0
@@ -184,6 +184,13 @@ class StringPool
         put_on_rehash(old_hashes[i], old_values[i])
       end
     end
+  end
+
+  def clear
+    @capacity = @initial_capacity
+    @hashes = Pointer(UInt64).malloc(@capacity, 0_u64)
+    @values = Pointer(String).malloc(@capacity, "")
+    @size = 0
   end
 
   private def hash(str, len)


### PR DESCRIPTION
Allow clearing a `StringPool`, resetting the buffers to their initial capacity 