### PR TITLE
Fix: UUID#to_slice returns a dangling pointer

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -92,6 +92,7 @@ describe "UUID" do
     uuid = UUID.new(uuid, version: UUID::Version::V2, variant: UUID::Variant::Microsoft)
     uuid.version.should eq UUID::Version::V2
     uuid.variant.should eq UUID::Variant::Microsoft
+    uuid.bytes.should eq(UInt8.static_array(80, 161, 29, 166, 55, 123, 43, 223, 217, 240, 7, 111, 157, 182, 28, 147))
     uuid.to_s.should eq "50a11da6-377b-2bdf-d9f0-076f9db61c93"
   end
 

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -161,9 +161,9 @@ struct UUID
     end
   end
 
-  # Returns 16-byte slice.
-  def to_slice
-    @bytes.to_slice
+  # Returns the binary representation of the UUID.
+  def bytes : StaticArray(UInt8, 16)
+    @bytes.dup
   end
 
   # Returns unsafe pointer to 16-bytes.
@@ -173,7 +173,7 @@ struct UUID
 
   # Returns `true` if `other` UUID represents the same UUID, `false` otherwise.
   def ==(other : UUID)
-    to_slice == other.to_slice
+    @bytes == other.@bytes
   end
 
   # Convert to `String` in literal format.
@@ -184,7 +184,7 @@ struct UUID
   end
 
   def to_s(io : IO) : Nil
-    slice = to_slice
+    slice = @bytes.to_slice
 
     buffer = uninitialized UInt8[36]
     buffer_ptr = buffer.to_unsafe
@@ -200,7 +200,7 @@ struct UUID
   end
 
   def hexstring
-    to_slice.hexstring
+    @bytes.to_slice.hexstring
   end
 
   def urn


### PR DESCRIPTION
I thought we had `#to_unsafe_slice` somewhere in the stdlib but we don't, and we probably don't want to introduce it (unsafe is _bad_)~~, so I changed `UUID#to_slice` to allocate HEAP memory and thus return a safe slice instead, and changed the internal implementation to still take advantage of the unsafe slice~~. I removed `UUID#to_slice` and added `UUID#bytes` that returns a StaticArray that can be passed around, and sometimes be accessible as a slice (in safe contexts).

fixes #7894