### PR TITLE
Remove expand home (`~`) by default in File.expand_path and Path#expand, now opt-in argument

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -582,26 +582,26 @@ describe "File" do
     end
 
     it "converts a pathname to an absolute pathname, using ~ (home) as base" do
-      File.expand_path("~/").should eq(File.join(home, ""))
-      File.expand_path("~/..badfilename").should eq(File.join(home, "..badfilename"))
-      File.expand_path("..").should eq("/#{base.split('/')[0...-1].join('/')}".gsub(%r{\A//}, "/"))
-      File.expand_path("~/a", "~/b").should eq(File.join(home, "a"))
-      File.expand_path("~").should eq(home)
-      File.expand_path("~", "/tmp/gumby/ddd").should eq(home)
-      File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))
+      File.expand_path("~/", home: true).should eq(File.join(home, ""))
+      File.expand_path("~/..badfilename", home: true).should eq(File.join(home, "..badfilename"))
+      File.expand_path("..", home: true).should eq("/#{base.split('/')[0...-1].join('/')}".gsub(%r{\A//}, "/"))
+      File.expand_path("~/a", "~/b", home: true).should eq(File.join(home, "a"))
+      File.expand_path("~", home: true).should eq(home)
+      File.expand_path("~", "/tmp/gumby/ddd", home: true).should eq(home)
+      File.expand_path("~/a", "/tmp/gumby/ddd", home: true).should eq(File.join([home, "a"]))
     end
 
     it "converts a pathname to an absolute pathname, using ~ (home) as base (trailing /)" do
       prev_home = home
       begin
         ENV["HOME"] = File.expand_path(datapath)
-        File.expand_path("~/").should eq(File.join(home, ""))
-        File.expand_path("~/..badfilename").should eq(File.join(home, "..badfilename"))
-        File.expand_path("..").should eq("/#{base.split('/')[0...-1].join('/')}".gsub(%r{\A//}, "/"))
-        File.expand_path("~/a", "~/b").should eq(File.join(home, "a"))
-        File.expand_path("~").should eq(home)
-        File.expand_path("~", "/tmp/gumby/ddd").should eq(home)
-        File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))
+        File.expand_path("~/", home: true).should eq(File.join(home, ""))
+        File.expand_path("~/..badfilename", home: true).should eq(File.join(home, "..badfilename"))
+        File.expand_path("..", home: true).should eq("/#{base.split('/')[0...-1].join('/')}".gsub(%r{\A//}, "/"))
+        File.expand_path("~/a", "~/b", home: true).should eq(File.join(home, "a"))
+        File.expand_path("~", home: true).should eq(home)
+        File.expand_path("~", "/tmp/gumby/ddd", home: true).should eq(home)
+        File.expand_path("~/a", "/tmp/gumby/ddd", home: true).should eq(File.join([home, "a"]))
       ensure
         ENV["HOME"] = prev_home
       end
@@ -611,13 +611,13 @@ describe "File" do
       prev_home = home
       begin
         ENV["HOME"] = "/"
-        File.expand_path("~/").should eq(home)
-        File.expand_path("~/..badfilename").should eq(File.join(home, "..badfilename"))
-        File.expand_path("..").should eq("/#{base.split('/')[0...-1].join('/')}".gsub(/\A\/\//, "/"))
-        File.expand_path("~/a", "~/b").should eq(File.join(home, "a"))
-        File.expand_path("~").should eq(home)
-        File.expand_path("~", "/tmp/gumby/ddd").should eq(home)
-        File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))
+        File.expand_path("~/", home: true).should eq(home)
+        File.expand_path("~/..badfilename", home: true).should eq(File.join(home, "..badfilename"))
+        File.expand_path("..", home: true).should eq("/#{base.split('/')[0...-1].join('/')}".gsub(/\A\/\//, "/"))
+        File.expand_path("~/a", "~/b", home: true).should eq(File.join(home, "a"))
+        File.expand_path("~", home: true).should eq(home)
+        File.expand_path("~", "/tmp/gumby/ddd", home: true).should eq(home)
+        File.expand_path("~/a", "/tmp/gumby/ddd", home: true).should eq(File.join([home, "a"]))
       ensure
         ENV["HOME"] = prev_home
       end

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -18,14 +18,6 @@ private def it_expands_path(path, posix, windows = posix, *, base = nil, env_hom
       ENV["HOME"] = env_home || (path.windows? ? HOME_WINDOWS : HOME_POSIX)
 
       base_arg = base || (path.windows? ? BASE_WINDOWS : BASE_POSIX)
-      home_arg = case home
-                 when Path   then home
-                 when String then home
-                 when Bool   then Path.home
-                   #       home ? Path.home : raise "invalid value 'false' for home"
-                 else raise "invalid type for home #{home}"
-                 end
-      #      puts "#{typeof(home_arg)} #{home_arg.class} #{home_arg.inspect} #{home.inspect}"
       path.expand(base_arg.not_nil!, expand_base: !!expand_base, home: home)
     ensure
       ENV["HOME"] = prev_home
@@ -552,9 +544,11 @@ describe Path do
       it_expands_path("C:\\foo", "D:/C:\\foo", "C:\\foo", base: "D:/")
     end
 
-    describe "doesn't expand ~" do
-      path = Path["~"]
-      path.expand.should_not eq path.expand(home: "/foo")
+    it "doesn't expand ~" do
+      ["~", "~/foo"].each do |path|
+        path = Path[path]
+        path.expand(base: "", expand_base: false).should eq path
+      end
     end
 
     describe "checks all possible types for expand(home:)" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -338,8 +338,9 @@ class File < IO::FileDescriptor
   # Converts *path* to an absolute path. Relative paths are
   # referenced from the current working directory of the process unless
   # *dir* is given, in which case it will be used as the starting point.
-  # "~/" is expanded to the value passed to *home* or the user's home directory
-  # when *home* is `true`.
+  # "~" is expanded to the value passed to *home*.
+  # If it is `false` (default), home is not expanded.
+  # If `true`, it is expanded to the user's home directory (`Path.home`).
   #
   # ```
   # File.expand_path("foo")                 # => "/home/.../foo"

--- a/src/file.cr
+++ b/src/file.cr
@@ -338,14 +338,16 @@ class File < IO::FileDescriptor
   # Converts *path* to an absolute path. Relative paths are
   # referenced from the current working directory of the process unless
   # *dir* is given, in which case it will be used as the starting point.
+  # "~/" is expanded to the value passed to *home* or the user's home directory
+  # when *home* is `true`.
   #
   # ```
-  # File.expand_path("foo")             # => "/home/.../foo"
-  # File.expand_path("~/crystal/foo")   # => "/home/crystal/foo"
-  # File.expand_path("baz", "/foo/bar") # => "/foo/bar/baz"
+  # File.expand_path("foo")                 # => "/home/.../foo"
+  # File.expand_path("~/foo", home: "/bar") # => "/bar/foo"
+  # File.expand_path("baz", "/foo/bar")     # => "/foo/bar/baz"
   # ```
-  def self.expand_path(path, dir = nil) : String
-    Path.new(path).expand(dir || Dir.current).to_s
+  def self.expand_path(path, dir = nil, *, home = false) : String
+    Path.new(path).expand(dir || Dir.current, home: home).to_s
   end
 
   class BadPatternError < Exception


### PR DESCRIPTION
Path#absolute doesn't expand "~/" and may be used for secure path
resolution.

---

(final behavior)

`home` specifies the home directory which `~` will expand to.

* "~" is expanded to the value passed to `home`.
* If it is `false` (default), home is not expanded.
* If `true`, it is expanded to the user's home directory (`Path.home`).