### PR TITLE
rename access_token to token

### DIFF
--- a/src/oauth2/access_token/access_token.cr
+++ b/src/oauth2/access_token/access_token.cr
@@ -59,12 +59,6 @@ abstract class OAuth2::AccessToken
   # will be the string "[1,2,3]".
   property extra : Hash(String, String)?
 
-  @[Deprecated("Use `token` instead of `access_token`")]
-  def initialize(access_token : String, expires_in : Int?, @refresh_token : String? = nil, @scope : String? = nil, @extra = nil)
-    @token = access_token
-    @expires_in = expires_in.try &.to_i64
-  end
-
   def initialize(@token : String, expires_in : Int?, @refresh_token : String? = nil, @scope : String? = nil, @extra = nil)
     @expires_in = expires_in.try &.to_i64
   end

--- a/src/oauth2/access_token/bearer.cr
+++ b/src/oauth2/access_token/bearer.cr
@@ -10,18 +10,18 @@ class OAuth2::AccessToken::Bearer < OAuth2::AccessToken
   end
 
   def authenticate(request : HTTP::Request, tls)
-    request.headers["Authorization"] = "Bearer #{access_token}"
+    request.headers["Authorization"] = "Bearer #{token}"
   end
 
   def to_json(json : JSON::Builder)
     json.object do
       json.field "token_type", "bearer"
-      json.field "access_token", access_token
+      json.field "access_token", token
       json.field "expires_in", expires_in
       json.field "refresh_token", refresh_token if refresh_token
       json.field "scope", scope if scope
     end
   end
 
-  def_equals_and_hash access_token, expires_in, refresh_token, scope
+  def_equals_and_hash token, expires_in, refresh_token, scope
 end


### PR DESCRIPTION
This renames `OAuth2::AccessToken#access_token` to `OAuth2::AccessToken#token`.  I also added some depreciation warnings for `OAuth2::AccessToken#access_token`

fixes https://github.com/crystal-lang/crystal/issues/7910