### PR TITLE
Add debug log helper function for codegen

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1810,7 +1810,7 @@ module Crystal
     end
 
     def printf(format, args = [] of LLVM::Value)
-      call @program.printf(@llvm_mod), [builder.global_string_pointer(format)] + args
+      call @program.printf(@llvm_mod, llvm_context), [builder.global_string_pointer(format)] + args
     end
 
     def allocate_aggregate(type)

--- a/src/compiler/crystal/codegen/crystal_llvm_builder.cr
+++ b/src/compiler/crystal/codegen/crystal_llvm_builder.cr
@@ -32,9 +32,6 @@ module Crystal
     end
 
     def unreachable
-      if ENV["UNREACHABLE"]? == "1"
-        printf "Reached the unreachable!"
-      end
       return if @end
       value = @builder.unreachable
       @end = true

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -124,7 +124,7 @@ module Crystal
     end
 
     delegate ptr2int, int2ptr, and, or, not, bit_cast,
-      trunc, load, store, br, insert_block, position_at_end, unreachable,
+      trunc, load, store, br, insert_block, position_at_end,
       cond, phi, extract_value, to: builder
 
     def ret

--- a/src/compiler/crystal/codegen/phi.cr
+++ b/src/compiler/crystal/codegen/phi.cr
@@ -33,6 +33,10 @@ class Crystal::CodeGenVisitor
       @codegen.llvm_typer
     end
 
+    def unreachable
+      @codegen.unreachable
+    end
+
     def add(value, type : Nil, last = false)
       unreachable
     end

--- a/src/llvm/basic_block.cr
+++ b/src/llvm/basic_block.cr
@@ -17,4 +17,9 @@ struct LLVM::BasicBlock
   def to_unsafe
     @unwrap
   end
+
+  def name
+    block_name = LibLLVMExt.basic_block_name(self)
+    block_name ? LLVM.string_and_dispose(block_name) : nil
+  end
 end

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -453,4 +453,13 @@ char *LLVMNormalizeTargetTriple(const char* triple) {
 }
 #endif
 
+char *LLVMExtBasicBlockName(LLVMBasicBlockRef BB) {
+#if LLVM_VERSION_GE(4, 0)
+  // It seems to work since llvm-4.0 https://stackoverflow.com/a/46045548/30948
+  return strdup(unwrap(BB)->getName().data());
+#else
+  return NULL
+#endif
+}
+
 }

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -138,4 +138,6 @@ lib LibLLVMExt
   {% end %}
 
   fun normalize_target_triple = LLVMNormalizeTargetTriple(triple : Char*) : Char*
+
+  fun basic_block_name = LLVMExtBasicBlockName(basic_block : LibLLVM::BasicBlockRef) : Char*
 end


### PR DESCRIPTION
While working with some changes in the codegen is convenient to printf some messages. This PR improves the state of the art to include such messages.

The `debug_codegen_log` function has some documentation for the allowed variations.

Including some `debug_codegen_log` calls in `codegen_dispatch` for example would print

```
<block: next_def @ src/compiler/crystal/codegen/call.cr:385> 
<block: current_def1 @ src/compiler/crystal/codegen/call.cr:368> 
```

Allowing easy tracing of the execution of the LLVM IR code and mapping which part of the codegen code generates the llvm code.

Those logs messages will not generate code unless `CRYSTAL_DEBUG_CODEGEN` env var is set.

To achieve this some additional things were covered:

* The codegen `printf` needed a fix (missing argument)
* Add some code name extraction with through LLVMExt
* Refactor the codegen `unreachable` to use `debug_codegen_log` instead of a custom `printf` call.