### PR TITLE
Refactor codegen of unions

### DIFF
--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -697,33 +697,4 @@ class Crystal::CodeGenVisitor
   def upcast_distinct(value, to_type : Type, from_type : Type)
     raise "BUG: trying to upcast #{to_type} <- #{from_type}"
   end
-
-  def store_in_union(union_pointer, value_type, value)
-    store type_id(value, value_type), union_type_id(union_pointer)
-    casted_value_ptr = cast_to_pointer(union_value(union_pointer), value_type)
-    store value, casted_value_ptr
-  end
-
-  def store_bool_in_union(union_type, union_pointer, value)
-    store type_id(value, @program.bool), union_type_id(union_pointer)
-
-    # To store a boolean in a union
-    # we sign-extend it to the size in bits of the union
-    union_value_type = llvm_union_value_type(union_type)
-    union_size = @llvm_typer.size_of(union_value_type)
-    int_type = llvm_context.int((union_size * 8).to_i32)
-
-    bool_as_extended_int = builder.zext(value, int_type)
-    casted_value_ptr = bit_cast(union_value(union_pointer), int_type.pointer)
-    store bool_as_extended_int, casted_value_ptr
-  end
-
-  def store_nil_in_union(union_pointer, target_type)
-    union_value_type = llvm_union_value_type(target_type)
-    value = union_value_type.null
-
-    store type_id(value, @program.nil), union_type_id(union_pointer)
-    casted_value_ptr = bit_cast union_value(union_pointer), union_value_type.pointer
-    store value, casted_value_ptr
-  end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -174,7 +174,7 @@ class Crystal::CodeGenVisitor
   end
 
   def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : VoidType, value)
-    store type_id(value_type), union_type_id(target_pointer)
+    store_void_in_union target_pointer, target_type
   end
 
   def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : BoolType, value)
@@ -641,7 +641,7 @@ class Crystal::CodeGenVisitor
 
   def upcast_distinct(value, to_type : MixedUnionType, from_type : VoidType)
     union_ptr = alloca(llvm_type(to_type))
-    store type_id(from_type), union_type_id(union_ptr)
+    store_void_in_union union_ptr, to_type
     union_ptr
   end
 

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -162,11 +162,6 @@ class Crystal::CodeGenVisitor
       union_type.union_types.any? { |ut| value_type.implements?(ut) || ut.implements?(value_type) }
   end
 
-  def assign_distinct_union_types(target_pointer, target_type, value_type, value)
-    casted_value = cast_to_pointer value, target_type
-    store load(casted_value), target_pointer
-  end
-
   def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilableType, value)
     store_in_union target_type, target_pointer, value_type, value
   end
@@ -427,7 +422,7 @@ class Crystal::CodeGenVisitor
         phi.add final_value, to_type, last: true
       end
     else
-      cast_to_pointer value, to_type
+      downcast_distinct_union_types(value, to_type, from_type)
     end
   end
 
@@ -636,7 +631,7 @@ class Crystal::CodeGenVisitor
         phi.add final_value, to_type, last: true
       end
     else
-      cast_to_pointer value, to_type
+      upcast_distinct_union_types(value, to_type, from_type)
     end
   end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2068,9 +2068,9 @@ module Crystal
 
       if type.is_a?(VirtualType)
         if type.struct?
-          if type.remove_indirection.is_a?(UnionType)
+          if (_type = type.remove_indirection).is_a?(UnionType)
             # For a struct we need to cast the second part of the union to the base type
-            value_ptr = gep(pointer, 0, 1)
+            _, value_ptr = union_type_and_value_pointer(pointer, _type)
             pointer = bit_cast value_ptr, llvm_type(type.base_type).pointer
           else
             # Nothing, there's only one subclass so it's the struct already

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2051,14 +2051,6 @@ module Crystal
       type.passed_by_value? ? load value : value
     end
 
-    def union_type_id(union_pointer)
-      aggregate_index union_pointer, 0
-    end
-
-    def union_value(union_pointer)
-      aggregate_index union_pointer, 1
-    end
-
     def aggregate_index(ptr, index)
       gep ptr, 0, index
     end

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -36,7 +36,7 @@ class Crystal::CodeGenVisitor
     cond = llvm_true
 
     if has_nil || has_bool || has_pointer
-      type_id = load union_type_id(@last)
+      type_id, value_ptr = union_type_and_value_pointer(@last)
 
       if has_nil
         is_nil = equal? type_id, type_id(@program.nil)
@@ -44,7 +44,7 @@ class Crystal::CodeGenVisitor
       end
 
       if has_bool
-        value = load(bit_cast union_value(@last), llvm_context.int1.pointer)
+        value = load(bit_cast value_ptr, llvm_context.int1.pointer)
         is_bool = equal? type_id, type_id(@program.bool)
         cond = and cond, not(and(is_bool, not(value)))
       end
@@ -54,7 +54,7 @@ class Crystal::CodeGenVisitor
           next unless union_type.is_a?(PointerInstanceType)
 
           is_pointer = equal? type_id, type_id(union_type)
-          pointer_value = load(bit_cast union_value(@last), llvm_type(union_type).pointer)
+          pointer_value = load(bit_cast value_ptr, llvm_type(union_type).pointer)
           pointer_null = null_pointer?(pointer_value)
           cond = and cond, not(and(is_pointer, pointer_null))
         end

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -36,7 +36,7 @@ class Crystal::CodeGenVisitor
     cond = llvm_true
 
     if has_nil || has_bool || has_pointer
-      type_id, value_ptr = union_type_and_value_pointer(@last)
+      type_id, value_ptr = union_type_and_value_pointer(@last, type)
 
       if has_nil
         is_nil = equal? type_id, type_id(@program.nil)

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -197,9 +197,5 @@ module Crystal
     def llvm_struct_size(type)
       llvm_struct_type(type).size
     end
-
-    def llvm_union_value_type(type)
-      llvm_typer.union_value_type(type)
-    end
   end
 end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -239,45 +239,6 @@ module Crystal
       llvm_type(type.pointer_type, wants_size)
     end
 
-    private def create_llvm_type(type : MixedUnionType, wants_size)
-      llvm_name = llvm_name(type, wants_size)
-      if s = @structs[llvm_name]?
-        return s
-      end
-
-      @llvm_context.struct(llvm_name) do |a_struct|
-        if wants_size
-          @wants_size_cache[type] = a_struct
-        else
-          @cache[type] = a_struct
-          @structs[llvm_name] = a_struct
-        end
-
-        max_size = 0
-        type.expand_union_types.each do |subtype|
-          unless subtype.void?
-            size = size_of(llvm_type(subtype, wants_size: true))
-            max_size = size if size > max_size
-          end
-        end
-
-        max_size /= pointer_size.to_f
-        max_size = max_size.ceil.to_i
-
-        max_size = 1 if max_size == 0
-
-        llvm_value_type = size_t.array(max_size)
-
-        if wants_size
-          @wants_size_union_value_cache[type] = llvm_value_type
-        else
-          @union_value_cache[type] = llvm_value_type
-        end
-
-        [@llvm_context.int32, llvm_value_type]
-      end
-    end
-
     private def create_llvm_type(type : TypeDefType, wants_size)
       llvm_type(type.typedef, wants_size)
     end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -15,7 +15,6 @@ module Crystal
     def initialize(@program : Program, @llvm_context : LLVM::Context)
       @cache = TypeCache.new
       @struct_cache = TypeCache.new
-      @union_value_cache = TypeCache.new
 
       # For union types we just need to know the maximum size of their types.
       # It might happen that we have a recursive type, for example:

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -45,7 +45,6 @@ module Crystal
       # types, because there can be cycles.
       @wants_size_cache = TypeCache.new
       @wants_size_struct_cache = TypeCache.new
-      @wants_size_union_value_cache = TypeCache.new
 
       @structs = {} of String => LLVM::Type
 

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -546,9 +546,5 @@ module Crystal
     def pointer_size
       @pointer_size ||= size_of(@llvm_context.void_pointer)
     end
-
-    def union_value_type(type : MixedUnionType)
-      @union_value_cache[type] ||= llvm_type(type).struct_element_types[1]
-    end
   end
 end

--- a/src/compiler/crystal/codegen/type_id.cr
+++ b/src/compiler/crystal/codegen/type_id.cr
@@ -48,10 +48,6 @@ class Crystal::CodeGenVisitor
     builder.select null_pointer?(fun_ptr), type_id(@program.nil), type_id(type.proc_type)
   end
 
-  private def type_id_impl(value, type : MixedUnionType)
-    load(union_type_id(value))
-  end
-
   private def type_id_impl(value, type : VirtualMetaclassType)
     value
   end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -1,0 +1,85 @@
+module Crystal
+  class LLVMTyper
+    private def create_llvm_type(type : MixedUnionType, wants_size)
+      llvm_name = llvm_name(type, wants_size)
+      if s = @structs[llvm_name]?
+        return s
+      end
+
+      @llvm_context.struct(llvm_name) do |a_struct|
+        if wants_size
+          @wants_size_cache[type] = a_struct
+        else
+          @cache[type] = a_struct
+          @structs[llvm_name] = a_struct
+        end
+
+        max_size = 0
+        type.expand_union_types.each do |subtype|
+          unless subtype.void?
+            size = size_of(llvm_type(subtype, wants_size: true))
+            max_size = size if size > max_size
+          end
+        end
+
+        max_size /= pointer_size.to_f
+        max_size = max_size.ceil.to_i
+
+        max_size = 1 if max_size == 0
+
+        llvm_value_type = size_t.array(max_size)
+
+        if wants_size
+          @wants_size_union_value_cache[type] = llvm_value_type
+        else
+          @union_value_cache[type] = llvm_value_type
+        end
+
+        [@llvm_context.int32, llvm_value_type]
+      end
+    end
+  end
+
+  class CodeGenVisitor
+    def union_type_id(union_pointer)
+      aggregate_index union_pointer, 0
+    end
+
+    def union_value(union_pointer)
+      aggregate_index union_pointer, 1
+    end
+
+    def store_in_union(union_pointer, value_type, value)
+      store type_id(value, value_type), union_type_id(union_pointer)
+      casted_value_ptr = cast_to_pointer(union_value(union_pointer), value_type)
+      store value, casted_value_ptr
+    end
+
+    def store_bool_in_union(union_type, union_pointer, value)
+      store type_id(value, @program.bool), union_type_id(union_pointer)
+
+      # To store a boolean in a union
+      # we sign-extend it to the size in bits of the union
+      union_value_type = llvm_union_value_type(union_type)
+      union_size = @llvm_typer.size_of(union_value_type)
+      int_type = llvm_context.int((union_size * 8).to_i32)
+
+      bool_as_extended_int = builder.zext(value, int_type)
+      casted_value_ptr = bit_cast(union_value(union_pointer), int_type.pointer)
+      store bool_as_extended_int, casted_value_ptr
+    end
+
+    def store_nil_in_union(union_pointer, target_type)
+      union_value_type = llvm_union_value_type(target_type)
+      value = union_value_type.null
+
+      store type_id(value, @program.nil), union_type_id(union_pointer)
+      casted_value_ptr = bit_cast union_value(union_pointer), union_value_type.pointer
+      store value, casted_value_ptr
+    end
+
+    private def type_id_impl(value, type : MixedUnionType)
+      load(union_type_id(value))
+    end
+  end
+end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -43,9 +43,7 @@ module Crystal
 
         llvm_value_type = size_t.array(max_size)
 
-        if wants_size
-          @wants_size_union_value_cache[type] = llvm_value_type
-        else
+        if !wants_size
           @union_value_cache[type] = llvm_value_type
         end
 

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -50,6 +50,10 @@ module Crystal
         [@llvm_context.int32, llvm_value_type]
       end
     end
+
+    def union_value_type(type : MixedUnionType)
+      @union_value_cache[type] ||= llvm_type(type).struct_element_types[1]
+    end
   end
 
   class CodeGenVisitor
@@ -80,7 +84,7 @@ module Crystal
 
       # To store a boolean in a union
       # we sign-extend it to the size in bits of the union
-      union_value_type = llvm_union_value_type(union_type)
+      union_value_type = @llvm_typer.union_value_type(union_type)
       union_size = @llvm_typer.size_of(union_value_type)
       int_type = llvm_context.int((union_size * 8).to_i32)
 
@@ -90,7 +94,7 @@ module Crystal
     end
 
     def store_nil_in_union(union_pointer, target_type)
-      union_value_type = llvm_union_value_type(target_type)
+      union_value_type = @llvm_typer.union_value_type(target_type)
       value = union_value_type.null
 
       store type_id(value, @program.nil), union_type_id(union_pointer)

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -1,3 +1,17 @@
+# Here lies the logic of the representation of the MixedUnionType.
+#
+# Which structure is used to represent them is defined in `LLVMTyper#create_llvm_type`.
+#
+# The `#union_type_and_value_pointer` will allow to read the current value of the union.
+# The `#store*_in_union` operations allow to write the value in a unions.
+# The `#{assign|downcast|upcast}_distinct_union_types` operation matches the
+# semantics described in `./casts.cr`
+#
+# Together these operations should encapsulate the binary representation of the MixedUnionType.
+#
+# Other unions like ReferenceUnionType that have a more trivial
+# representation are not handled here.
+#
 module Crystal
   class LLVMTyper
     private def create_llvm_type(type : MixedUnionType, wants_size)

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -41,7 +41,11 @@ module Crystal
   end
 
   class CodeGenVisitor
-    def union_type_and_value_pointer(union_pointer)
+    def union_type_and_value_pointer(union_pointer, type : UnionType)
+      raise "BUG: trying to access union_type_and_value_pointer of a #{type} from #{union_pointer}"
+    end
+
+    def union_type_and_value_pointer(union_pointer, type : MixedUnionType)
       {load(union_type_id(union_pointer)), union_value(union_pointer)}
     end
 
@@ -53,7 +57,7 @@ module Crystal
       aggregate_index union_pointer, 1
     end
 
-    def store_in_union(union_pointer, value_type, value)
+    def store_in_union(union_type, union_pointer, value_type, value)
       store type_id(value, value_type), union_type_id(union_pointer)
       casted_value_ptr = cast_to_pointer(union_value(union_pointer), value_type)
       store value, casted_value_ptr
@@ -87,7 +91,7 @@ module Crystal
     end
 
     private def type_id_impl(value, type : MixedUnionType)
-      union_type_and_value_pointer(value)[0]
+      union_type_and_value_pointer(value, type)[0]
     end
   end
 end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -90,6 +90,19 @@ module Crystal
       store type_id(@program.void), union_type_id(union_pointer)
     end
 
+    def assign_distinct_union_types(target_pointer, target_type, value_type, value)
+      casted_value = cast_to_pointer value, target_type
+      store load(casted_value), target_pointer
+    end
+
+    def downcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)
+      cast_to_pointer value, to_type
+    end
+
+    def upcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)
+      cast_to_pointer value, to_type
+    end
+
     private def type_id_impl(value, type : MixedUnionType)
       union_type_and_value_pointer(value, type)[0]
     end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -78,6 +78,10 @@ module Crystal
       store value, casted_value_ptr
     end
 
+    def store_void_in_union(union_pointer, target_type)
+      store type_id(@program.void), union_type_id(union_pointer)
+    end
+
     private def type_id_impl(value, type : MixedUnionType)
       load(union_type_id(value))
     end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -43,16 +43,12 @@ module Crystal
 
         llvm_value_type = size_t.array(max_size)
 
-        if !wants_size
-          @union_value_cache[type] = llvm_value_type
-        end
-
         [@llvm_context.int32, llvm_value_type]
       end
     end
 
     def union_value_type(type : MixedUnionType)
-      @union_value_cache[type] ||= llvm_type(type).struct_element_types[1]
+      llvm_type(type).struct_element_types[1]
     end
   end
 

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -41,6 +41,10 @@ module Crystal
   end
 
   class CodeGenVisitor
+    def union_type_and_value_pointer(union_pointer)
+      {load(union_type_id(union_pointer)), union_value(union_pointer)}
+    end
+
     def union_type_id(union_pointer)
       aggregate_index union_pointer, 0
     end
@@ -83,7 +87,7 @@ module Crystal
     end
 
     private def type_id_impl(value, type : MixedUnionType)
-      load(union_type_id(value))
+      union_type_and_value_pointer(value)[0]
     end
   end
 end


### PR DESCRIPTION
This PR performs refactors and some code cleanups to move all the code related to the binary representation of the unions to a new file `codegen/unions.cr`.

The code cleanup is mainly related to how caching of the `llvm_value`/`union_value_cache` was done.

This will serve as a basis for changing the representation of the unions later.

I thought it would be easier to understand if the refactor itself was put in an independent PR.