### PR TITLE
Json keys

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -45,6 +45,30 @@ describe "JSON serialization" do
       Hash(String, Int32).from_json(%({"foo": 1, "bar": 2})).should eq({"foo" => 1, "bar" => 2})
     end
 
+    it "does Hash(Int32, String)#from_json" do
+      Hash(Int32, String).from_json(%({"1": "x", "2": "y"})).should eq({1 => "x", 2 => "y"})
+    end
+
+    it "does Hash(Float32, String)#from_json" do
+      Hash(Float32, String).from_json(%({"1.23": "x", "4.56": "y"})).should eq({1.23_f32 => "x", 4.56_f32 => "y"})
+    end
+
+    it "does Hash(Float64, String)#from_json" do
+      Hash(Float64, String).from_json(%({"1.23": "x", "4.56": "y"})).should eq({1.23 => "x", 4.56 => "y"})
+    end
+
+    it "does Hash(BigInt, String)#from_json" do
+      Hash(BigInt, String).from_json(%({"12345678901234567890": "x"})).should eq({"12345678901234567890".to_big_i => "x"})
+    end
+
+    it "does Hash(BigFloat, String)#from_json" do
+      Hash(BigFloat, String).from_json(%({"1234567890.123456789": "x"})).should eq({"1234567890.123456789".to_big_f => "x"})
+    end
+
+    it "does Hash(BigDecimal, String)#from_json" do
+      Hash(BigDecimal, String).from_json(%({"1234567890.123456789": "x"})).should eq({"1234567890.123456789".to_big_d => "x"})
+    end
+
     it "raises an error Hash(String, Int32)#from_json with null value" do
       expect_raises(JSON::ParseException, "Expected int but was null") do
         Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null}))
@@ -276,8 +300,24 @@ describe "JSON serialization" do
       {"foo" => 1, "bar" => 2}.to_json.should eq(%({"foo":1,"bar":2}))
     end
 
-    it "does for Hash with non-string keys" do
+    it "does for Hash with symbol keys" do
       {:foo => 1, :bar => 2}.to_json.should eq(%({"foo":1,"bar":2}))
+    end
+
+    it "does for Hash with int keys" do
+      {1 => 2, 3 => 6}.to_json.should eq(%({"1":2,"3":6}))
+    end
+
+    it "does for Hash with Float32 keys" do
+      {1.2_f32 => 2, 3.4_f32 => 6}.to_json.should eq(%({"1.2":2,"3.4":6}))
+    end
+
+    it "does for Hash with Float64 keys" do
+      {1.2 => 2, 3.4 => 6}.to_json.should eq(%({"1.2":2,"3.4":6}))
+    end
+
+    it "does for Hash with BigInt keys" do
+      {123.to_big_i => 2}.to_json.should eq(%({"123":2}))
     end
 
     it "does for Hash with newlines" do

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -6,9 +6,21 @@ def BigInt.new(pull : JSON::PullParser)
   BigInt.new(pull.raw_value)
 end
 
+def BigInt.from_json_object_key?(key : String)
+  BigInt.new(key)
+rescue ArgumentError
+  nil
+end
+
 def BigFloat.new(pull : JSON::PullParser)
   pull.read_float
   BigFloat.new(pull.raw_value)
+end
+
+def BigFloat.from_json_object_key?(key : String)
+  BigFloat.new(key)
+rescue ArgumentError
+  nil
 end
 
 def BigDecimal.new(pull : JSON::PullParser)
@@ -23,4 +35,10 @@ def BigDecimal.new(pull : JSON::PullParser)
     value = pull.read_string
   end
   BigDecimal.new(value)
+end
+
+def BigDecimal.from_json_object_key?(key : String)
+  BigDecimal.new(key)
+rescue InvalidBigDecimalException
+  nil
 end

--- a/src/json.cr
+++ b/src/json.cr
@@ -1,5 +1,51 @@
 # The JSON module allows parsing and generating [JSON](http://json.org/) documents.
 #
+# ### General type-safe interface
+#
+# The general type-safe interface for parsing JSON is to invoke `T.from_json` on a
+# target type `T` and pass either a `String` or `IO` as an argument.
+#
+# ```
+# require "json"
+#
+# json_text = %([1, 2, 3])
+# Array(Int32).from_json(json_text) # => [1, 2, 3]
+#
+# json_text = %({"x": 1, "y": 2})
+# Hash(String, Int32).from_json(json_text) # => {"x" => 1, "y" => 2}
+# ```
+#
+# Serializing is achieved by invoking `to_json`, which returns a `String`, or
+# `to_json(io : IO)`, which will stream the JSON to an `IO`.
+#
+# ```
+# require "json"
+#
+# [1, 2, 3].to_json            # => "[1, 2, 3]"
+# {"x" => 1, "y" => 2}.to_json # => "{\"x\": 1, \"y\": 2}
+# ```
+#
+# Most types in the standard library implement these methods. For user-defined types
+# you can define a `self.new(pull : JSON::PullParser)` for parsing and
+# `to_json(builder : JSON::Builder)` for serializing. The following sections
+# show convenient ways to do this using either `JSON.mapping` or `JSON::Serializable`.
+#
+# NOTE: JSON object keys are always strings but they can still be parsed
+# and deserialized to other types. To deserialize, define a
+# `T.from_json_object_key?(key : String) : T?` method, which can return `nil`
+# if the string can't be parsed into that type. To serialize, define a
+# `to_json_object_key : String` method can be serialized that way.
+# All integer and float types in the standard library can be deserialized that way.
+#
+# ```
+# require "json"
+#
+# json_text = %({"1" => 2, "3" => 4})
+# Hash(Int32, Int32).from_json(json_text) # => {1 => 2, 3 => 4}
+#
+# {1.5 => 2}.to_json # => "{\"1.5\" => 2}"
+# ```
+#
 # ### Parsing and generating with `JSON.mapping`
 #
 # Use `JSON.mapping` to define how an object is mapped to JSON, making it

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -86,8 +86,9 @@ class JSON::PullParser
   def read_object
     read_begin_object
     while kind != :end_object
+      key_location = location
       key = read_object_key
-      yield key
+      yield key, key_location
     end
     read_end_object
   end

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -28,6 +28,10 @@ struct Nil
   def to_json(json : JSON::Builder)
     json.null
   end
+
+  def to_json_object_key
+    ""
+  end
 end
 
 struct Bool
@@ -40,11 +44,19 @@ struct Int
   def to_json(json : JSON::Builder)
     json.number(self)
   end
+
+  def to_json_object_key
+    to_s
+  end
 end
 
 struct Float
   def to_json(json : JSON::Builder)
     json.number(self)
+  end
+
+  def to_json_object_key
+    to_s
   end
 end
 
@@ -52,11 +64,19 @@ class String
   def to_json(json : JSON::Builder)
     json.string(self)
   end
+
+  def to_json_object_key
+    self
+  end
 end
 
 struct Symbol
   def to_json(json : JSON::Builder)
     json.string(to_s)
+  end
+
+  def to_json_object_key
+    to_s
   end
 end
 
@@ -77,10 +97,15 @@ struct Set
 end
 
 class Hash
+  # Serializes this Hash into JSON.
+  #
+  # Keys are serialized by invoking `to_json_object_key` on them.
+  # Values are serialized with the usual `to_json(json : JSON::Builder)`
+  # method.
   def to_json(json : JSON::Builder)
     json.object do
       each do |key, value|
-        json.field key do
+        json.field key.to_json_object_key do
           value.to_json(json)
         end
       end

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -328,6 +328,17 @@ struct YAML::Any
   def clone
     Any.new(raw.clone)
   end
+
+  # Forwards `to_json_object_key` to `raw` if it responds to that method,
+  # raises `JSON::Error` otherwise.
+  def to_json_object_key
+    raw = @raw
+    if raw.responds_to?(:to_json_object_key)
+      raw.to_json_object_key
+    else
+      raise JSON::Error.new("can't convert #{raw.class} to a JSON object key")
+    end
+  end
 end
 
 class Object


### PR DESCRIPTION
Fixes #7942

Also document a bit the type-safe way to parse JSON (I don't think it was documented before, and mapping/serializable doesn't count because it doesn't talk about primitive types, Array, Hash, etc.)

I decided to only provide out-of-the-box serialization of json object keys for ints and floats, because their text representation is pretty obvious. Other types are more controversial but could be provided by shards.