### PR TITLE
Add alias/merge methods to YAML::Builder and YAML::Nodes::Builder

### DIFF
--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "yaml"
 
 private def assert_built(expected, expect_document_end = false)
-  # libyaml 0.2.1 removed the errorneously written document end marker (`...`) after some scalars in root context (see https://github.com/yaml/libyaml/pull/18).
+  # libyaml 0.2.1 removed the erroneously written document end marker (`...`) after some scalars in root context (see https://github.com/yaml/libyaml/pull/18).
   # Earlier libyaml releases still write the document end marker and this is hard to fix on Crystal's side.
   # So we just ignore it and adopt the specs accordingly to coincide with the used libyaml version.
   if expect_document_end

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -25,7 +25,7 @@ describe YAML::Builder do
   end
 
   it "writes alias" do
-    assert_built("--- *key\n", expect_document_end: true) do
+    assert_built("--- *key\n") do
       itself.alias "key"
     end
   end

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -130,10 +130,10 @@ describe YAML::Builder do
     end
   end
 
-  it "writes mapping with extend" do
+  it "writes mapping with merge" do
     assert_built("---\n<<: *key\n") do
       mapping do
-        itself.extend "key"
+        merge "key"
       end
     end
   end

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -24,6 +24,12 @@ describe YAML::Builder do
     end
   end
 
+  it "writes alias" do
+    assert_built("--- *key\n", expect_document_end: true) do
+      itself.alias "key"
+    end
+  end
+
   it "writes scalar with style" do
     assert_built(%(--- "1"\n)) do
       scalar(1, style: YAML::ScalarStyle::DOUBLE_QUOTED)
@@ -111,6 +117,23 @@ describe YAML::Builder do
         scalar(1)
         scalar("bar")
         scalar(2)
+      end
+    end
+  end
+
+  it "writes mapping with alias" do
+    assert_built("---\nfoo: *bar\n") do
+      mapping do
+        scalar "foo"
+        itself.alias "bar"
+      end
+    end
+  end
+
+  it "writes mapping with extend" do
+    assert_built("---\n<<: *key\n") do
+      mapping do
+        itself.extend "key"
       end
     end
   end

--- a/spec/std/yaml/nodes/builder_spec.cr
+++ b/spec/std/yaml/nodes/builder_spec.cr
@@ -43,12 +43,12 @@ describe YAML::Nodes::Builder do
     end
   end
 
-  describe "#extend" do
+  describe "#merge" do
     describe "within a mapping" do
       it "writes correctly" do
         assert_built("---\n<<: *bar\n") do
           mapping do
-            itself.extend "bar"
+            merge "bar"
           end
         end
       end

--- a/spec/std/yaml/nodes/builder_spec.cr
+++ b/spec/std/yaml/nodes/builder_spec.cr
@@ -1,0 +1,57 @@
+require "spec"
+require "yaml"
+
+private def assert_built(expected, expect_document_end = false)
+  # libyaml 0.2.1 removed the errorneously written document end marker (`...`) after some scalars in root context (see https://github.com/yaml/libyaml/pull/18).
+  # Earlier libyaml releases still write the document end marker and this is hard to fix on Crystal's side.
+  # So we just ignore it and adopt the specs accordingly to coincide with the used libyaml version.
+  if expect_document_end
+    if YAML.libyaml_version < SemanticVersion.new(0, 2, 1)
+      expected += "...\n"
+    end
+  end
+
+  nodes_builder = YAML::Nodes::Builder.new
+
+  with nodes_builder yield nodes_builder
+
+  string = YAML.build do |builder|
+    nodes_builder.document.to_yaml builder
+  end
+  string.should eq(expected)
+end
+
+describe YAML::Nodes::Builder do
+  describe "#alias" do
+    describe "as a scalar value" do
+      it "wirtes correctly" do
+        assert_built("--- *key\n", expect_document_end: true) do
+          itself.alias "key"
+        end
+      end
+    end
+
+    describe "within a mapping" do
+      it "wirtes correctly" do
+        assert_built("---\nfoo: *bar\n") do
+          mapping do
+            scalar "foo"
+            itself.alias "bar"
+          end
+        end
+      end
+    end
+  end
+
+  describe "#extend" do
+    describe "within a mapping" do
+      it "wirtes correctly" do
+        assert_built("---\n<<: *bar\n") do
+          mapping do
+            itself.extend "bar"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/std/yaml/nodes/builder_spec.cr
+++ b/spec/std/yaml/nodes/builder_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "yaml"
 
 private def assert_built(expected, expect_document_end = false)
-  # libyaml 0.2.1 removed the errorneously written document end marker (`...`) after some scalars in root context (see https://github.com/yaml/libyaml/pull/18).
+  # libyaml 0.2.1 removed the erroneously written document end marker (`...`) after some scalars in root context (see https://github.com/yaml/libyaml/pull/18).
   # Earlier libyaml releases still write the document end marker and this is hard to fix on Crystal's side.
   # So we just ignore it and adopt the specs accordingly to coincide with the used libyaml version.
   if expect_document_end
@@ -24,7 +24,7 @@ end
 describe YAML::Nodes::Builder do
   describe "#alias" do
     describe "as a scalar value" do
-      it "wirtes correctly" do
+      it "writes correctly" do
         assert_built("--- *key\n", expect_document_end: true) do
           itself.alias "key"
         end
@@ -32,7 +32,7 @@ describe YAML::Nodes::Builder do
     end
 
     describe "within a mapping" do
-      it "wirtes correctly" do
+      it "writes correctly" do
         assert_built("---\nfoo: *bar\n") do
           mapping do
             scalar "foo"
@@ -45,7 +45,7 @@ describe YAML::Nodes::Builder do
 
   describe "#extend" do
     describe "within a mapping" do
-      it "wirtes correctly" do
+      it "writes correctly" do
         assert_built("---\n<<: *bar\n") do
           mapping do
             itself.extend "bar"

--- a/spec/std/yaml/nodes/builder_spec.cr
+++ b/spec/std/yaml/nodes/builder_spec.cr
@@ -25,7 +25,7 @@ describe YAML::Nodes::Builder do
   describe "#alias" do
     describe "as a scalar value" do
       it "writes correctly" do
-        assert_built("--- *key\n", expect_document_end: true) do
+        assert_built("--- *key\n") do
           itself.alias "key"
         end
       end

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -142,7 +142,7 @@ class YAML::Builder
   #   end
   # end
   #
-  # yaml => "---\nkey: *example\n"
+  # yaml # => "---\nkey: *example\n"
   # ```
   def alias(anchor : String) : Nil
     LibYAML.yaml_alias_event_initialize(pointerof(@event), anchor)
@@ -160,7 +160,7 @@ class YAML::Builder
   #   end
   # end
   #
-  # yaml => "---\<<: *development\n"
+  # yaml # => "---\n<<: *development\n"
   # ```
   def extend(anchor : String) : Nil
     self.scalar "<<"

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -130,9 +130,41 @@ class YAML::Builder
     yield.tap { end_mapping }
   end
 
-  def alias(anchor : String)
+  # Aliases *anchor*.
+  #
+  # ```crystal
+  # require "yaml"
+  #
+  # yaml = YAML.build do |builder|
+  #   builder.mapping do
+  #     builder.scalar "key"
+  #     builder.alias "example"
+  #   end
+  # end
+  #
+  # yaml => "---\nkey: *example\n"
+  # ```
+  def alias(anchor : String) : Nil
     LibYAML.yaml_alias_event_initialize(pointerof(@event), anchor)
     yaml_emit("alias")
+  end
+
+  # Extends *anchor*.
+  #
+  # ```crystal
+  # require "yaml"
+  #
+  # yaml = YAML.build do |builder|
+  #   builder.mapping do
+  #     buidler.extend "development"
+  #   end
+  # end
+  #
+  # yaml => "---\<<: *development\n"
+  # ```
+  def extend(anchor : String) : Nil
+    self.scalar "<<"
+    self.alias anchor
   end
 
   # Flushes any pending data to the underlying `IO`.

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -149,7 +149,7 @@ class YAML::Builder
     yaml_emit("alias")
   end
 
-  # Emits the scalar "<<" followed by an alias to the given *anchor*.
+  # Emits the scalar `"<<"` followed by an alias to the given *anchor*.
   #
   # See [YAML Merge](https://yaml.org/type/merge.html).
   #

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -130,7 +130,7 @@ class YAML::Builder
     yield.tap { end_mapping }
   end
 
-  # Aliases *anchor*.
+  # Emits an alias to the given *anchor*.
   #
   # ```crystal
   # require "yaml"
@@ -149,20 +149,22 @@ class YAML::Builder
     yaml_emit("alias")
   end
 
-  # Extends *anchor*.
+  # Emits the scalar "<<" followed by an alias to the given *anchor*.
+  #
+  # See [YAML Merge](https://yaml.org/type/merge.html).
   #
   # ```crystal
   # require "yaml"
   #
   # yaml = YAML.build do |builder|
   #   builder.mapping do
-  #     builder.extend "development"
+  #     builder.merge "development"
   #   end
   # end
   #
   # yaml # => "---\n<<: *development\n"
   # ```
-  def extend(anchor : String) : Nil
+  def merge(anchor : String) : Nil
     self.scalar "<<"
     self.alias anchor
   end

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -156,7 +156,7 @@ class YAML::Builder
   #
   # yaml = YAML.build do |builder|
   #   builder.mapping do
-  #     buidler.extend "development"
+  #     builder.extend "development"
   #   end
   # end
   #

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -22,6 +22,50 @@ class YAML::Nodes::Builder
     @anchor_count = 0
   end
 
+  # Aliases *anchor*.
+  #
+  # ```crystal
+  # require "yaml"
+  #
+  # nodes_builder = YAML::Nodes::Builder.new
+  #
+  # nodes_builder.mapping do
+  #   nodes_builder.scalar "foo"
+  #   nodes_builder.alias "key"
+  # end
+  #
+  # yaml = YAML.build do |builder|
+  #   nodes_builder.document.to_yaml builder
+  # end
+  #
+  # yaml => "---\nkey: *foo\n"
+  # ```
+  def alias(anchor : String) : Nil
+    push_node Alias.new anchor
+  end
+
+  # Extends *anchor*.
+  #
+  # ```crystal
+  # require "yaml"
+  #
+  # nodes_builder = YAML::Nodes::Builder.new
+  #
+  # nodes_builder.mapping do
+  #   nodes_builder.extend "key"
+  # end
+  #
+  # yaml = YAML.build do |builder|
+  #   nodes_builder.document.to_yaml builder
+  # end
+  #
+  # yaml => "---\n<<: *key\n"
+  # ```
+  def extend(anchor : String) : Nil
+    self.scalar "<<"
+    self.alias anchor
+  end
+
   def scalar(value, anchor : String? = nil, tag : String? = nil,
              style : YAML::ScalarStyle = YAML::ScalarStyle::ANY,
              reference = nil) : Nil

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -22,7 +22,7 @@ class YAML::Nodes::Builder
     @anchor_count = 0
   end
 
-  # Aliases *anchor*.
+  # Emits an alias to the given *anchor*.
   #
   # ```crystal
   # require "yaml"
@@ -44,7 +44,9 @@ class YAML::Nodes::Builder
     push_node Alias.new anchor
   end
 
-  # Extends *anchor*.
+  # Emits the scalar "<<" followed by an alias to the given *anchor*.
+  #
+  # See [YAML Merge](https://yaml.org/type/merge.html).
   #
   # ```crystal
   # require "yaml"
@@ -52,7 +54,7 @@ class YAML::Nodes::Builder
   # nodes_builder = YAML::Nodes::Builder.new
   #
   # nodes_builder.mapping do
-  #   nodes_builder.extend "key"
+  #   nodes_builder.merge "key"
   # end
   #
   # yaml = YAML.build do |builder|
@@ -61,7 +63,7 @@ class YAML::Nodes::Builder
   #
   # yaml # => "---\n<<: *key\n"
   # ```
-  def extend(anchor : String) : Nil
+  def merge(anchor : String) : Nil
     self.scalar "<<"
     self.alias anchor
   end

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -38,7 +38,7 @@ class YAML::Nodes::Builder
   #   nodes_builder.document.to_yaml builder
   # end
   #
-  # yaml => "---\nkey: *foo\n"
+  # yaml # => "---\nkey: *foo\n"
   # ```
   def alias(anchor : String) : Nil
     push_node Alias.new anchor
@@ -59,7 +59,7 @@ class YAML::Nodes::Builder
   #   nodes_builder.document.to_yaml builder
   # end
   #
-  # yaml => "---\n<<: *key\n"
+  # yaml # => "---\n<<: *key\n"
   # ```
   def extend(anchor : String) : Nil
     self.scalar "<<"

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -44,7 +44,7 @@ class YAML::Nodes::Builder
     push_node Alias.new anchor
   end
 
-  # Emits the scalar "<<" followed by an alias to the given *anchor*.
+  # Emits the scalar `"<<"` followed by an alias to the given *anchor*.
   #
   # See [YAML Merge](https://yaml.org/type/merge.html).
   #


### PR DESCRIPTION
Resolves #7821.

* Adds `alias` and `merge` methods to `YAML::Nodes::Builder`
* Adds `merge` method to `YAML::Builder`
* Also adds documentation blocks and specs for each