### PR TITLE
Allow rendering tags on methods without any docs

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -1,7 +1,7 @@
 require "../../../spec_helper"
 
 describe Doc::Generator do
-  describe "must_include_toplevel?" do
+  describe "#must_include_toplevel?" do
     it "returns false if program has nothing" do
       program = Program.new
       generator = Doc::Generator.new program, ["foo"], ".", "html", nil
@@ -83,7 +83,7 @@ describe Doc::Generator do
     end
   end
 
-  describe "collect_constants" do
+  describe "#collect_constants" do
     it "returns empty array when constants are private" do
       program = Program.new
       generator = Doc::Generator.new program, ["foo"], ".", "html", nil
@@ -95,6 +95,132 @@ describe Doc::Generator do
       program.types[constant.name] = constant
 
       generator.collect_constants(doc_type).should be_empty
+    end
+  end
+
+  describe "#formatted_summary" do
+    describe "with a Deprecated annotation, and no docs" do
+      it "should generate just the Deprecated tag" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_summary.should eq %(<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+      end
+    end
+
+    describe "with a Deprecated annotation, and docs" do
+      it "should generate both the docs and Deprecated tag" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        a_def.doc = "Some Method"
+        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_summary.should eq %(<p>Some Method</p>\n\n<p><span class=\"flag red\">DEPRECATED</span>  don't use me</p>\n\n)
+      end
+    end
+
+    describe "with no annotation, and no docs" do
+      it "should generate nothing" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_summary.should be_nil
+      end
+    end
+
+    it "should generate the first sentence" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.doc = "Some Method.  Longer description"
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.formatted_summary.should eq %(<p>Some Method.</p>)
+    end
+
+    it "should generate the first line" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.doc = "Some Method\n\nMore Data"
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.formatted_summary.should eq %(<p>Some Method</p>)
+    end
+  end
+
+  describe "#formatted_doc" do
+    describe "with a Deprecated annotation, and no docs" do
+      it "should generate just the Deprecated tag" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_doc.should eq %(<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+      end
+    end
+
+    describe "with a Deprecated annotation, and docs" do
+      it "should generate both the docs and Deprecated tag" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        a_def.doc = "Some Method"
+        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p><span class=\"flag red\">DEPRECATED</span>  don't use me</p>\n\n)
+      end
+    end
+
+    describe "with no annotation, and no docs" do
+      it "should generate nothing" do
+        program = Program.new
+        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        doc_type = Doc::Type.new generator, program
+
+        a_def = Def.new "foo"
+        doc_method = Doc::Method.new generator, doc_type, a_def, false
+        doc_method.formatted_doc.should be_nil
+      end
+    end
+
+    it "should generate the full document" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.doc = "Some Method.  Longer description"
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.formatted_doc.should eq %(<p>Some Method.  Longer description</p>)
+    end
+
+    it "should generate the full document" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.doc = "Some Method\n\nMore Data"
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p>More Data</p>)
     end
   end
 end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -172,7 +172,7 @@ struct BigInt < Int
     self * other
   end
 
-  @[Deprecated("BigInt#/ will return a BigFloat in 0.29.0. Use BigInt#// for integer division.")]
+  @[Deprecated("`BigInt#/` will return a `BigFloat` in 0.29.0. Use `BigInt#//` for integer division.")]
   def /(other : Int) : BigInt
     # TODO replace to float division
     self // other
@@ -605,7 +605,7 @@ struct Int
     self * other
   end
 
-  @[Deprecated("Int#/(other: BigInt) will return a BigFloat in 0.29.0. Use Int#// for integer division.")]
+  @[Deprecated("`Int#/(other: BigInt)` will return a `BigFloat` in 0.29.0. Use `Int#//` for integer division.")]
   def /(other : BigInt) : BigInt
     self // other
   end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -274,14 +274,14 @@ class Crystal::Doc::Generator
 
   def summary(obj : Type | Method | Macro | Constant)
     doc = obj.doc
-    return nil unless doc
 
-    summary obj, doc
+    return if !doc && !obj.annotations(@program.deprecated_annotation)
+
+    summary obj, doc || ""
   end
 
   def summary(context, string)
-    line = fetch_doc_lines(string).lines.first?
-    return nil unless line
+    line = fetch_doc_lines(string).lines.first? || ""
 
     dot_index = line =~ /\.($|\s)/
     if dot_index
@@ -293,9 +293,10 @@ class Crystal::Doc::Generator
 
   def doc(obj : Type | Method | Macro | Constant)
     doc = obj.doc
-    return nil unless doc
 
-    doc obj, doc
+    return if !doc && !obj.annotations(@program.deprecated_annotation)
+
+    doc obj, doc || ""
   end
 
   def doc(context, string)
@@ -307,14 +308,8 @@ class Crystal::Doc::Generator
     generate_flags markdown
   end
 
-  def fetch_doc_lines(doc)
-    doc.gsub /\n+/ do |match|
-      if match.size == 1
-        " "
-      else
-        "\n"
-      end
-    end
+  def fetch_doc_lines(doc : String) : String
+    doc.gsub /\n+/ { |match| match.size == 1 ? " " : "\n" }
   end
 
   # Replaces flag keywords with html equivalent

--- a/src/int.cr
+++ b/src/int.cr
@@ -117,7 +117,7 @@ struct Int
     self.class.new(to_f // other)
   end
 
-  @[Deprecated("Int#/ will return a Float in 0.29.0. Use Int#// for integer division.")]
+  @[Deprecated("`Int#/` will return a `Float` in 0.29.0. Use `Int#//` for integer division.")]
   def /(other : Int)
     self // other
   end


### PR DESCRIPTION
Fixes #7895.

* Only skip generating docs if the method does not have any docs and doesn't have `Deprecated` annotation
* Adds specs for generating summary/docs for a method
* Fixes some type links on Int `Deprecated` messages, so that they are linkable in the API docs