### PR TITLE
Compiler: correctly check abstract methods

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -394,4 +394,60 @@ describe "Semantic: abstract def" do
       end
       )
   end
+
+  it "errors if missing return type" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo : Int32
+      end
+
+      class Bar < Foo
+        def foo
+          1
+        end
+      end
+      ),
+      "this method overrides Foo#foo() which has an explicit return type of Int32: please add an explicit return type to this method as well"
+  end
+
+  it "errors if different return type" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo : Int32
+      end
+
+      class Bar < Foo
+        struct Int32
+        end
+
+        def foo : Int32
+          1
+        end
+      end
+      ),
+      "this method must return Int32, which is the return type of the overwritten method Foo#foo(), not Bar::Int32"
+  end
+
+  it "can return a more specific type" do
+    assert_type(%(
+      class Parent
+      end
+
+      class Child < Parent
+      end
+
+
+      abstract class Foo
+        abstract def foo : Parent
+      end
+
+      class Bar < Foo
+        def foo : Child
+          Child.new
+        end
+      end
+
+      Bar.new.foo
+      )) { types["Child"] }
+  end
 end

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -23,7 +23,7 @@ private class ReverseResponseOutput < IO
   def initialize(@output : IO)
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     slice.reverse_each do |byte|
       @output.write_byte(byte)
     end

--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -16,7 +16,7 @@ private class PartialReaderIO < IO
     read_size
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : NoReturn
     raise "write"
   end
 end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -42,7 +42,7 @@ private class SimpleIOMemory < IO
     count
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     count = slice.size
     new_bytesize = bytesize + count
     if new_bytesize > @capacity

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -5,8 +5,7 @@ private class NoPeekIO < IO
     0
   end
 
-  def write(bytes : Bytes)
-    0
+  def write(bytes : Bytes) : Nil
   end
 
   def peek

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -69,9 +69,15 @@ class Crystal::Program
     node, processor = @progress_tracker.stage("Semantic (type declarations)") do
       TypeDeclarationProcessor.new(self).process(node)
     end
-    @progress_tracker.stage("Semantic (abstract def check)") do
-      AbstractDefChecker.new(self).run
+
+    # TODO: remove this check a couple of versions after 0.30.0 once
+    # we are sure it's working fine for everyone
+    unless has_flag?("skip_abstract_def_check")
+      @progress_tracker.stage("Semantic (abstract def check)") do
+        AbstractDefChecker.new(self).run
+      end
     end
+
     {node, processor}
   end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -44,10 +44,6 @@ class Crystal::AbstractDefChecker
     @all_checked << type
 
     if type.abstract? || type.module?
-      # TODO: check generic types too
-      # (it's tricky because of type parameter resolution)
-      return if type.is_a?(GenericType)
-
       type.defs.try &.each_value do |defs_with_metadata|
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
@@ -69,9 +65,10 @@ class Crystal::AbstractDefChecker
   end
 
   def check_implemented_in_subtypes(base, type, method)
-    # TODO: check generic modules
     subtypes = case type
                when NonGenericModuleType
+                 type.raw_including_types
+               when GenericModuleType
                  type.raw_including_types
                else
                  type.subclasses
@@ -123,6 +120,16 @@ class Crystal::AbstractDefChecker
 
     return false if m1.args.size < m2.args.size
 
+    # If the base type is a generic type, we find the generic instantiation of
+    # t1 for it. This will have a mapping of type vars to types, for example
+    # T will be Int32 in something like `class Bar < Foo(Int32)` with `Foo(T)`.
+    # Then we replace all `T` in the base method with `Int32`, and just then
+    # we check if they match.
+    if t2.is_a?(GenericType)
+      generic_base = find_base_generic_instantiation(t1, t2)
+      m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
+    end
+
     m2.args.zip(m1.args) do |a2, a1|
       r1 = a1.restriction
       r2 = a2.restriction
@@ -151,17 +158,74 @@ class Crystal::AbstractDefChecker
     base_return_type_node = base_method.return_type
     return unless base_return_type_node
 
+    original_base_return_type = base_type.lookup_type(base_return_type_node)
+
+    # If the base type is a generic type, we find the generic instantiation of
+    # t1 for it. This will have a mapping of type vars to types, for example
+    # T will be Int32 in something like `class Bar < Foo(Int32)` with `Foo(T)`.
+    # Then we replace all `T` in the base method return type with `Int32`,
+    # and just then we check if they match.
+    if base_type.is_a?(GenericType)
+      generic_base = find_base_generic_instantiation(type, base_type)
+
+      replacer = ReplacePathWithTypeVar.new(base_type, generic_base)
+      base_return_type_node = base_return_type_node.clone
+      base_return_type_node.accept(replacer)
+    end
+
     base_return_type = base_type.lookup_type(base_return_type_node)
 
     return_type_node = method.return_type
     unless return_type_node
-      method.raise "this method overrides #{Call.def_full_name(base_type, base_method)} which has an explicit return type of #{base_return_type}: please add an explicit return type to this method as well"
+      method.raise "this method overrides #{Call.def_full_name(base_type, base_method)} which has an explicit return type of #{original_base_return_type}.\n#{@program.colorize("Please add an explicit return type (#{base_return_type} or a subtype of it) to this method as well.").yellow.bold}"
     end
 
     return_type = type.lookup_type(return_type_node)
 
     unless return_type.implements?(base_return_type)
-      return_type_node.raise "this method must return #{base_return_type}, which is the return type of the overwritten method #{Call.def_full_name(base_type, base_method)}, not #{return_type}"
+      return_type_node.raise "this method must return #{base_return_type}, which is the return type of the overridden method #{Call.def_full_name(base_type, base_method)}, or a subtype of it, not #{return_type}"
+    end
+  end
+
+  def replace_method_arg_paths_with_type_vars(base_type : Type, method : Def, generic_type : GenericInstanceType)
+    replacer = ReplacePathWithTypeVar.new(base_type, generic_type)
+
+    method = method.clone
+    method.args.each do |arg|
+      arg.restriction.try &.accept(replacer)
+    end
+    method
+  end
+
+  def find_base_generic_instantiation(type : Type, base_type : GenericType)
+    type.ancestors.find do |t|
+      t.is_a?(GenericInstanceType) && t.generic_type == base_type
+    end.as(GenericInstanceType)
+  end
+
+  class ReplacePathWithTypeVar < Visitor
+    def initialize(@base_type : GenericType, @generic_type : GenericInstanceType)
+    end
+
+    def visit(node : Path)
+      if !node.global? && node.names.size == 1
+        # Check if it matches any of the generic type vars
+        name = node.names.first
+
+        type_var = @generic_type.type_vars[name]?
+        if type_var.is_a?(Var)
+          # Check that it's actually a type parameter on the base type
+          if @base_type.lookup_type?(node).is_a?(TypeParameter)
+            node.type = type_var.type
+          end
+        end
+      end
+
+      false
+    end
+
+    def visit(node : ASTNode)
+      true
     end
   end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -44,6 +44,10 @@ class Crystal::AbstractDefChecker
     @all_checked << type
 
     if type.abstract? || type.module?
+      # TODO: check generic types too
+      # (it's tricky because of type parameter resolution)
+      return if type.is_a?(GenericType)
+
       type.defs.try &.each_value do |defs_with_metadata|
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -80,6 +80,13 @@ class Crystal::Type
     delegate program, to: @root
 
     def lookup(node : Path)
+      # A Path might have a type set.
+      # This is at least done in AbstractDefChecker when we replace type
+      # parameters with concrete types.
+      if type = node.type?
+        return type
+      end
+
       type_var = lookup_type_var?(node)
 
       case type_var

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -11,7 +11,6 @@
 # [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer).
 class Deque(T)
   include Indexable(T)
-  include Comparable(Deque)
 
   # This Deque is based on a circular buffer. It works like a normal array, but when an item is removed from the left
   # side, instead of shifting all the items, only the start position is shifted. This can lead to configurations like:

--- a/src/flate/writer.cr
+++ b/src/flate/writer.cr
@@ -43,7 +43,7 @@ class Flate::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_open
 
     return if slice.empty?

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -78,7 +78,7 @@ module HTTP
       @io.skip(bytes_count)
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : NoReturn
       raise IO::Error.new "Can't write to UnknownLengthContent"
     end
   end
@@ -213,7 +213,7 @@ module HTTP
       end
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : NoReturn
       raise IO::Error.new "Can't write to ChunkedContent"
     end
 

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -74,7 +74,7 @@ class HTTP::Server
     end
 
     # See `IO#write(slice)`.
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       return if slice.empty?
 
       @output.write(slice)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -49,7 +49,7 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       return if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -54,7 +54,7 @@ class IO::ARGF < IO
     end
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : NoReturn
     raise IO::Error.new "Can't write to ARGF"
   end
 

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -124,7 +124,7 @@ module IO::Buffered
   end
 
   # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_open
 
     return if slice.empty?

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -107,7 +107,7 @@ class IO::Delimited < IO
     read_bytes
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     raise IO::Error.new "Can't write to IO::Delimited"
   end
 

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -32,7 +32,7 @@ class IO::Hexdump < IO
     end
   end
 
-  def write(buf : Bytes)
+  def write(buf : Bytes) : Nil
     return if buf.empty?
 
     @io.write(buf).tap do

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,7 +82,7 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_writeable
     check_open
 

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -29,7 +29,7 @@ class IO::MultiWriter < IO
     @writers = writers.map(&.as(IO)).to_a
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     check_open
 
     return if slice.empty?

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -72,7 +72,7 @@ class IO::Sized < IO
     end
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : NoReturn
     raise IO::Error.new "Can't write to IO::Sized"
   end
 

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -42,7 +42,7 @@ module OpenSSL
       read_bytes
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       return if slice.empty?
 
       if @mode.write?

--- a/src/random.cr
+++ b/src/random.cr
@@ -66,7 +66,7 @@ module Random
   #
   # The integers must be uniformly distributed between `0` and
   # the maximal value for the chosen type.
-  abstract def next_u : UInt
+  abstract def next_u
 
   # Generates a random `Bool`.
   #

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -217,7 +217,7 @@ class Socket < IO
   # socket.puts Time.utc
   # socket.close
   # ```
-  def accept
+  def accept : Socket
     accept? || raise IO::Error.new("Closed stream")
   end
 

--- a/src/socket/server.cr
+++ b/src/socket/server.cr
@@ -14,7 +14,7 @@ class Socket
     # ```
     #
     # If the server is closed after invoking this method, an `IO::Error` (closed stream) exception must be raised.
-    abstract def accept : Socket
+    abstract def accept : IO
 
     # Accepts an incoming connection and returns the client socket.
     #
@@ -29,7 +29,7 @@ class Socket
     #   socket.close
     # end
     # ```
-    abstract def accept? : Socket?
+    abstract def accept? : IO?
 
     # Accepts an incoming connection and yields the client socket to the block.
     # Eventually closes the connection when the block returns.

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -103,7 +103,7 @@ class TCPServer < TCPSocket
   #   end
   # end
   # ```
-  def accept?
+  def accept? : TCPSocket?
     if client_fd = accept_impl
       sock = TCPSocket.new(fd: client_fd, family: family, type: type, protocol: protocol)
       sock.sync = sync?

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,7 +38,7 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     return if slice.empty?
 
     count = slice.size

--- a/src/zip/checksum_reader.cr
+++ b/src/zip/checksum_reader.cr
@@ -24,7 +24,7 @@ module Zip
       @io.peek
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : NoReturn
       raise IO::Error.new "Can't write to Zip::Reader or Zip::File entry"
     end
   end

--- a/src/zip/checksum_writer.cr
+++ b/src/zip/checksum_writer.cr
@@ -13,7 +13,7 @@ module Zip
       raise IO::Error.new "Can't read from Zip::Writer entry"
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       return if slice.empty?
 
       @count += slice.size


### PR DESCRIPTION
Fixes #3546
Fixes #6085
Fixes #6762

This PR does a few things.

## Return types are checked 🎉 

Return types of abstract methods are now checked in subtypes.

It took me a long time to implement this because I didn't know how to resolve this issue: the abstract method check runs after the first compiler pass where all types and methods are defined, but **before** method bodies are typed (and so, actual method return types are computed). So by the time we could check whether an abstract method was correctly implemented (the return type matches) a different error might have been triggered.

Also, if you have something like this:

```crystal
abstract class Foo
  abstract def foo : String
end

class Bar < Foo
  def foo
    1
  end
end
```

what would the error be? It will be something like "Method Bar#foo must return String because it implements the abstract method Foo#foo which returns String", which is a mouthful of words. But also looking at the code it's not clear that `Bar#foo` must return a String, because that code and the abstract method are far away (probably in a different file). 

One way to solve this, which is what this PR does, is to force subtypes to include an explicit return type if the abstract method has one. Once this is required we can check whether the return type matches without actually typing the body. Actually checking whether the body complies to the explicit return type always comes next, at some point.

This is backwards incompatible because for existing code you will be required to add explicit return type annotations. However, I think this is good: it solves the problem I mention above where it wasn't clear that `Bar#foo` was supposed to return `String`, because now that will be explicitly written. (well, the connection with the abstract method is still missing, and for that maybe I'd like to make an `Overrides` annotation mandatory, at least for this case... but not a part of this PR or discussion).

So for instance, in the above code you will now get this error (featuring the [super nice error formatting](#7748) made by @martimatix:

```
In foo.cr:6:7

 6 | def foo
         ^--
Error: this method overrides Foo#foo() which has an explicit return type of String.
Please add an explicit return type (String or a subtype of it) to this method as well
```

Then let's say you go ahead and modify it to this:

```crystal
class Bar < Foo
  def foo : Int32
    1
  end
end
```

You get this error:

```
In foo.cr:6:13

 6 | def foo : Int32
               ^----
Error: this method must return String, which is the return type of the overwritten
method Foo#foo(), or a subtype of it, not Int32
```

Changing `Int32` to `String` and fixing the body compiles as expected.

(the error messages are still long, but I think the resulting code is clearer and more explicit)

Also note that the error message says it must return the base type or a subtype of it. For example, this is valid:

```crystal
class Parent; end
class Child < Parent; end

abstract class Foo
  abstract def foo : Parent
end

class Bar < Foo
  def foo : Child
    Child.new
  end
end
```

The code above is fine. After all, `Child` is a `Parent` so if you didn't know whether you have a `Foo` or a `Bar` you still can treat it as a `Parent` (and this is how other statically typed languages with subtyping work).

Finally, the third commit in this PR adds some explicit return type annotations to comply with this change. I was able to fix it in a few minutes, so even though this is a breaking change it should be forward to fix it. And if not, I also added a flag, `skip_abstract_def_check`, which will skip this check altogether. This is useful in case you can't upgrade right now, or in case I got something wrong in the check algorithm.

I also fixed a couple of incorrect things:
- for `Random#next_u` there was no `UInt` type (and some Random instances return `UInt32`, some `UInt64`, some `UInt8`... maybe this should be unified, I don't know... but not part of this PR or issue)
- for `Socket::Server` (or something like that) the return type was incorrect
- `Deque` included `Comparable` but never implemented `<=>`: I decided to remove the inclusion of `Comparable` because I think we can move that to `Indexable`, but I'd like to do it in a different commit (and nothing is lost here anyway because it could never be used as a `Comparable`).

## Abstract methods are now correctly checked for generic types! 🎉 

So for example this works fine:

```crystal
abstract class Foo(T)
  abstract foo(x : T)
end

class Bar(U) < Foo(U)
  def foo(x : U) # OK
  end
end

class Baz < Foo(Int32)
  def foo(x : Int32) # OK
  end
end
```

The compiler knows that the `T` in `Foo` in `Baz` is an `Int32` so it checks against that. Kind of obvious, I know, but it wasn't that straight-forward to implement. And for return types it will suggest the correct (instantiated) type.

And this also works for generic modules. So previously these were all skipped (because the implementation wasn't correct, so it was turned off... though for generic classes it was turned on but it worked incorrectly! see #6762). So this code used to compile:

```crystal
class Foo
  include Enumerable(Int32)
end
```

But now it correctly gives an error:

```
In src/enumerable.cr:37:16

 37 | abstract def each(&block : T -> _)
                   ^---
Error: abstract `def Enumerable(T)#each(&block)` must be implemented by Foo
```