### PR TITLE
validate xml element names

### DIFF
--- a/spec/std/xml/builder_spec.cr
+++ b/spec/std/xml/builder_spec.cr
@@ -20,6 +20,22 @@ describe XML::Builder do
     end
   end
 
+  it "errors on invalid element names" do
+    expect_raises(XML::Error, "Invalid element name: '1'") do
+      XML.build do |xml|
+        xml.element("1") do
+        end
+      end
+    end
+
+    expect_raises(XML::Error, "Invalid element name: 'a b=\"c\"'") do
+      XML.build do |xml|
+        xml.element("a b=\"c\"") do
+        end
+      end
+    end
+  end
+
   it "writes nested element" do
     assert_built(%[<?xml version="1.0"?>\n<foo><bar/></foo>\n]) do
       element("foo") do
@@ -52,6 +68,42 @@ describe XML::Builder do
     assert_built(%[<?xml version="1.0"?>\n<foo x:id="1" xmlns:x="http://ww.foo.com"/>\n]) do
       element("foo") do
         attribute("x", "id", "http://ww.foo.com", 1)
+      end
+    end
+  end
+
+  it "writes element with namespace" do
+    assert_built(%[<?xml version=\"1.0\"?>\n<foo xmlns=\"bar\">baz</foo>\n]) do
+      element(nil, "foo", "bar") do
+        text "baz"
+      end
+    end
+  end
+
+  it "writes element with prefix" do
+    assert_built(%[<?xml version=\"1.0\"?>\n<foo:bar>baz</foo:bar>\n]) do
+      element("foo", "bar", nil) do
+        text "baz"
+      end
+    end
+  end
+
+  it "errors on invalid element name with prefix" do
+    expect_raises(XML::Error, "Invalid element name: 'foo=bar'") do
+      XML.build do |xml|
+        xml.element("foo=", "bar", nil) do
+          xml.text "baz"
+        end
+      end
+    end
+  end
+
+  it "errors on invalid element name with prefix and namespace" do
+    expect_raises(XML::Error, "Invalid element name: 'foo bar'") do
+      XML.build do |xml|
+        xml.element("foo ", "bar", "ns") do
+          xml.text "baz"
+        end
       end
     end
   end

--- a/spec/std/xml/builder_spec.cr
+++ b/spec/std/xml/builder_spec.cr
@@ -89,7 +89,7 @@ describe XML::Builder do
   end
 
   it "errors on invalid element name with prefix" do
-    expect_raises(XML::Error, "Invalid element name: 'foo=bar'") do
+    expect_raises(XML::Error, "Invalid prefix: 'foo='") do
       XML.build do |xml|
         xml.element("foo=", "bar", nil) do
           xml.text "baz"
@@ -99,7 +99,7 @@ describe XML::Builder do
   end
 
   it "errors on invalid element name with prefix and namespace" do
-    expect_raises(XML::Error, "Invalid element name: 'foo bar'") do
+    expect_raises(XML::Error, "Invalid prefix: 'foo '") do
       XML.build do |xml|
         xml.element("foo ", "bar", "ns") do
           xml.text "baz"

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -44,11 +44,14 @@ struct XML::Builder
 
   # Emits the start of an element.
   def start_element(name : String) : Nil
-    call StartElement, string_to_unsafe(name)
+    element_name = string_to_unsafe name
+    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) if LibXML.xmlValidateNameValue(element_name).zero?
+    call StartElement, element_name
   end
 
   # Emits the start of an element with namespace info.
   def start_element(prefix : String?, name : String, namespace_uri : String?) : Nil
+    raise XML::Error.new("Invalid element name: '#{prefix}#{name}'", __LINE__) if LibXML.xmlValidateNameValue(string_to_unsafe("#{prefix}#{name}")).zero?
     call StartElementNS, string_to_unsafe(prefix), string_to_unsafe(name), string_to_unsafe(namespace_uri)
   end
 

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -44,8 +44,9 @@ struct XML::Builder
 
   # Emits the start of an element.
   def start_element(name : String) : Nil
-    check_valid_element_name name, string_to_unsafe(name), "element name"
-    call StartElement, name
+    unsafe_name = string_to_unsafe(name)
+    check_valid_element_name name, unsafe_name, "element name"
+    call StartElement, unsafe_name
   end
 
   # Emits the start of an element with namespace info.

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -44,14 +44,14 @@ struct XML::Builder
 
   # Emits the start of an element.
   def start_element(name : String) : Nil
-    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) unless validate_element_name name
+    check_valid_element_name name, "element name"
     call StartElement, name
   end
 
   # Emits the start of an element with namespace info.
   def start_element(prefix : String?, name : String, namespace_uri : String?) : Nil
-    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) unless validate_element_name name
-    raise XML::Error.new("Invalid prefix: '#{prefix}'", __LINE__) if prefix && !validate_element_name prefix
+    check_valid_element_name name, "element name"
+    check_valid_element_name prefix, "prefix" if prefix
     call StartElementNS, string_to_unsafe(prefix), string_to_unsafe(name), string_to_unsafe(namespace_uri)
   end
 
@@ -287,8 +287,8 @@ struct XML::Builder
     Pointer(UInt8).null
   end
 
-  private def validate_element_name(name : String) : Bool
-    LibXML.xmlValidateNameValue(string_to_unsafe(name)) == 1
+  private def check_valid_element_name(name : String, element_type : String) : Nil
+    raise XML::Error.new("Invalid #{element_type}: '#{name}'", 0) if LibXML.xmlValidateNameValue(string_to_unsafe(name)).zero?
   end
 end
 

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -44,14 +44,14 @@ struct XML::Builder
 
   # Emits the start of an element.
   def start_element(name : String) : Nil
-    element_name = string_to_unsafe name
-    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) if LibXML.xmlValidateNameValue(element_name).zero?
-    call StartElement, element_name
+    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) unless validate_element_name name
+    call StartElement, name
   end
 
   # Emits the start of an element with namespace info.
   def start_element(prefix : String?, name : String, namespace_uri : String?) : Nil
-    raise XML::Error.new("Invalid element name: '#{prefix}#{name}'", __LINE__) if LibXML.xmlValidateNameValue(string_to_unsafe("#{prefix}#{name}")).zero?
+    raise XML::Error.new("Invalid element name: '#{name}'", __LINE__) unless validate_element_name name
+    raise XML::Error.new("Invalid prefix: '#{prefix}'", __LINE__) if prefix && !validate_element_name prefix
     call StartElementNS, string_to_unsafe(prefix), string_to_unsafe(name), string_to_unsafe(namespace_uri)
   end
 
@@ -285,6 +285,10 @@ struct XML::Builder
 
   private def string_to_unsafe(string : Nil)
     Pointer(UInt8).null
+  end
+
+  private def validate_element_name(name : String) : Bool
+    LibXML.xmlValidateNameValue(string_to_unsafe(name)) == 1
   end
 end
 


### PR DESCRIPTION
Uses `LibXML.xmlValidateNameValue` to validate the provided name when using `XML::Builder` to build elements.

Fixes #7963 
Fixes https://github.com/Blacksmoke16/oq/issues/9