### PR TITLE
JSON: use enums instead of symbols

### DIFF
--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -307,4 +307,18 @@ describe JSON::Builder do
       builder.start_object
     end
   end
+
+  it "#next_is_object_key?" do
+    io = IO::Memory.new
+    builder = JSON::Builder.new(io)
+    builder.next_is_object_key?.should be_false
+    builder.start_document
+    builder.next_is_object_key?.should be_false
+    builder.start_object
+    builder.next_is_object_key?.should be_true
+    builder.scalar("foo")
+    builder.next_is_object_key?.should be_false
+    builder.scalar("bar")
+    builder.next_is_object_key?.should be_true
+  end
 end

--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -1,17 +1,19 @@
 require "spec"
 require "json"
 
-private def it_lexes(string, expected_type, file = __FILE__, line = __LINE__)
+private def it_lexes(string, expected_kind : JSON::Token::Kind, expected_to_s = string, file = __FILE__, line = __LINE__)
   it "lexes #{string} from string", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(expected_type)
+    token.kind.should eq(expected_kind)
+    token.to_s.should eq(expected_to_s)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
-    token.type.should eq(expected_type)
+    token.kind.should eq(expected_kind)
+    token.to_s.should eq(expected_to_s)
   end
 end
 
@@ -19,15 +21,17 @@ private def it_lexes_string(string, string_value, file = __FILE__, line = __LINE
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.kind.should eq(JSON::Token::Kind::String)
     token.string_value.should eq(string_value)
+    token.to_s.should eq(token.string_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.kind.should eq(JSON::Token::Kind::String)
     token.string_value.should eq(string_value)
+    token.to_s.should eq(token.string_value)
   end
 end
 
@@ -35,17 +39,19 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:INT)
+    token.kind.should eq(JSON::Token::Kind::Int)
     token.int_value.should eq(int_value)
     token.raw_value.should eq(string)
+    token.to_s.should eq(token.raw_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
-    token.type.should eq(:INT)
+    token.kind.should eq(JSON::Token::Kind::Int)
     token.int_value.should eq(int_value)
     token.raw_value.should eq(string)
+    token.to_s.should eq(token.raw_value)
   end
 end
 
@@ -53,29 +59,31 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:FLOAT)
+    token.kind.should eq(JSON::Token::Kind::Float)
     token.float_value.should eq(float_value)
     token.raw_value.should eq(string)
+    token.to_s.should eq(token.raw_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new IO::Memory.new(string)
     token = lexer.next_token
-    token.type.should eq(:FLOAT)
+    token.kind.should eq(JSON::Token::Kind::Float)
     token.float_value.should eq(float_value)
     token.raw_value.should eq(string)
+    token.to_s.should eq(token.raw_value)
   end
 end
 
 describe JSON::Lexer do
-  it_lexes "", :EOF
-  it_lexes "{", :"{"
-  it_lexes "}", :"}"
-  it_lexes "[", :"["
-  it_lexes "]", :"]"
-  it_lexes ",", :","
-  it_lexes ":", :":"
-  it_lexes " \n\t\r :", :":"
+  it_lexes "", :EOF, expected_to_s: "<EOF>"
+  it_lexes "{", :begin_object
+  it_lexes "}", :end_object
+  it_lexes "[", :begin_array
+  it_lexes "]", :end_array
+  it_lexes ",", :comma
+  it_lexes ":", :colon
+  it_lexes " \n\t\r :", :colon, expected_to_s: ":"
   it_lexes "true", :true
   it_lexes "false", :false
   it_lexes "null", :null

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -250,7 +250,7 @@ describe "JSON mapping" do
 
   it "raises if not an object" do
     error_message = <<-'MSG'
-      Expected begin_object but was string at 1:1
+      Expected BeginObject but was String at 1:1
         parsing StrictJSONPerson at 0:0
       MSG
     ex = expect_raises JSON::MappingError, error_message do
@@ -263,7 +263,7 @@ describe "JSON mapping" do
 
   it "raises if data type does not match" do
     error_message = <<-'MSG'
-      Expected int but was string at 3:15
+      Expected Int but was String at 3:15
         parsing StrictJSONPerson#age at 3:3
       MSG
     ex = expect_raises JSON::MappingError, error_message do

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -2,42 +2,42 @@ require "spec"
 require "json"
 
 class JSON::PullParser
-  def assert(event_kind : Symbol)
+  def assert(event_kind : Kind)
     kind.should eq(event_kind)
     read_next
   end
 
   def assert(value : Nil)
-    kind.should eq(:null)
+    kind.should eq(JSON::PullParser::Kind::Null)
     read_next
   end
 
   def assert(value : Int)
-    kind.should eq(:int)
+    kind.should eq(JSON::PullParser::Kind::Int)
     int_value.should eq(value)
     read_next
   end
 
   def assert(value : Float)
-    kind.should eq(:float)
+    kind.should eq(JSON::PullParser::Kind::Float)
     float_value.should eq(value)
     read_next
   end
 
   def assert(value : Bool)
-    kind.should eq(:bool)
+    kind.should eq(JSON::PullParser::Kind::Bool)
     bool_value.should eq(value)
     read_next
   end
 
   def assert(value : String)
-    kind.should eq(:string)
+    kind.should eq(JSON::PullParser::Kind::String)
     string_value.should eq(value)
     read_next
   end
 
   def assert(value : String)
-    kind.should eq(:string)
+    kind.should eq(JSON::PullParser::Kind::String)
     string_value.should eq(value)
     read_next
     yield
@@ -62,10 +62,10 @@ class JSON::PullParser
   end
 
   def assert_array
-    kind.should eq(:begin_array)
+    kind.should eq(JSON::PullParser::Kind::BeginArray)
     read_next
     yield
-    kind.should eq(:end_array)
+    kind.should eq(JSON::PullParser::Kind::EndArray)
     read_next
   end
 
@@ -74,10 +74,10 @@ class JSON::PullParser
   end
 
   def assert_object
-    kind.should eq(:begin_object)
+    kind.should eq(JSON::PullParser::Kind::BeginObject)
     read_next
     yield
-    kind.should eq(:end_object)
+    kind.should eq(JSON::PullParser::Kind::EndObject)
     read_next
   end
 
@@ -96,7 +96,7 @@ private def assert_pull_parse(string)
   it "parses #{string}" do
     parser = JSON::PullParser.new string
     parser.assert JSON.parse(string).raw
-    parser.kind.should eq(:EOF)
+    parser.kind.should eq(JSON::PullParser::Kind::EOF)
   end
 end
 
@@ -104,7 +104,7 @@ private def assert_pull_parse_error(string)
   it "errors on #{string}" do
     expect_raises JSON::ParseException do
       parser = JSON::PullParser.new string
-      while parser.kind != :EOF
+      until parser.kind.eof?
         parser.read_next
       end
     end
@@ -166,7 +166,7 @@ describe JSON::PullParser do
     parser = JSON::PullParser.new(("[" * 513) + ("]" * 513))
     expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
       while true
-        break if parser.kind == :EOF
+        break if parser.kind.eof?
         parser.read_next
       end
     end
@@ -176,7 +176,7 @@ describe JSON::PullParser do
     parser = JSON::PullParser.new((%({"x": ) * 513) + ("}" * 513))
     expect_raises JSON::ParseException, "Nesting of 513 is too deep" do
       while true
-        break if parser.kind == :EOF
+        break if parser.kind.eof?
         parser.read_next
       end
     end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -428,7 +428,7 @@ describe "JSON mapping" do
 
   it "raises if not an object" do
     error_message = <<-'MSG'
-      Expected begin_object but was string at 1:1
+      Expected BeginObject but was String at 1:1
         parsing StrictJSONAttrPerson at 0:0
       MSG
     ex = expect_raises JSON::MappingError, error_message do

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -70,7 +70,7 @@ describe "JSON serialization" do
     end
 
     it "raises an error Hash(String, Int32)#from_json with null value" do
-      expect_raises(JSON::ParseException, "Expected int but was null") do
+      expect_raises(JSON::ParseException, "Expected Int but was Null") do
         Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null}))
       end
     end

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -25,10 +25,10 @@ end
 
 def BigDecimal.new(pull : JSON::PullParser)
   case pull.kind
-  when :int
+  when .int?
     pull.read_int
     value = pull.raw_value
-  when :float
+  when .float?
     pull.read_float
     value = pull.raw_value
   else

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -22,23 +22,23 @@ struct JSON::Any
   # Reads a `JSON::Any` value from the given pull parser.
   def self.new(pull : JSON::PullParser)
     case pull.kind
-    when :null
+    when .null?
       new pull.read_null
-    when :bool
+    when .bool?
       new pull.read_bool
-    when :int
+    when .int?
       new pull.read_int
-    when :float
+    when .float?
       new pull.read_float
-    when :string
+    when .string?
       new pull.read_string
-    when :begin_array
+    when .begin_array?
       ary = [] of JSON::Any
       pull.read_array do
         ary << new(pull)
       end
       new ary
-    when :begin_object
+    when .begin_object?
       hash = {} of String => JSON::Any
       pull.read_object do |key|
         hash[key] = new(pull)

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -280,6 +280,13 @@ class JSON::Builder
     end
   end
 
+  # Returns `true` if the next thing that must pushed into this
+  # builder is an object key (so a string) or the end of an object.
+  def next_is_object_key? : Bool
+    state = @state.last
+    state.is_a?(ObjectState) && state.name
+  end
+
   private def scalar(string = false)
     start_scalar(string)
     yield.tap { end_scalar(string) }

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -87,7 +87,7 @@ end
 
 def Float32.new(pull : JSON::PullParser)
   case pull.kind
-  when :int
+  when .int?
     value = pull.int_value.to_f32
     pull.read_next
     value
@@ -102,7 +102,7 @@ end
 
 def Float64.new(pull : JSON::PullParser)
   case pull.kind
-  when :int
+  when .int?
     value = pull.int_value.to_f
     pull.read_next
     value
@@ -212,9 +212,9 @@ end
 
 def Enum.new(pull : JSON::PullParser)
   case pull.kind
-  when :int
+  when .int?
     from_value(pull.read_int)
-  when :string
+  when .string?
     parse(pull.read_string)
   else
     raise "Expecting int or string in JSON for #{self.class}, not #{pull.kind}"
@@ -231,7 +231,7 @@ def Union.new(pull : JSON::PullParser)
 
     {% for type, index in T %}
       {% if type == Nil %}
-        return pull.read_null if pull.kind == :null
+        return pull.read_null if pull.kind.null?
       {% elsif type == Bool ||
                  type == Int8 || type == Int16 || type == Int32 || type == Int64 ||
                  type == UInt8 || type == UInt16 || type == UInt32 || type == UInt64 ||

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -37,19 +37,19 @@ abstract class JSON::Lexer
 
     case current_char
     when '\0'
-      @token.type = :EOF
+      @token.kind = :EOF
     when '{'
-      next_char :"{"
+      next_char :begin_object
     when '}'
-      next_char :"}"
+      next_char :end_object
     when '['
-      next_char :"["
+      next_char :begin_array
     when ']'
-      next_char :"]"
+      next_char :end_array
     when ','
-      next_char :","
+      next_char :comma
     when ':'
-      next_char :":"
+      next_char :colon
     when 'f'
       consume_false
     when 'n'
@@ -57,7 +57,7 @@ abstract class JSON::Lexer
     when 't'
       consume_true
     when '"'
-      @token.type = :STRING
+      @token.kind = :string
       @skip ? consume_string_skip : consume_string
     else
       consume_number
@@ -98,7 +98,7 @@ abstract class JSON::Lexer
   private def consume_true
     if next_char == 'r' && next_char == 'u' && next_char == 'e'
       next_char
-      @token.type = :true
+      @token.kind = :true
     else
       unexpected_char
     end
@@ -107,7 +107,7 @@ abstract class JSON::Lexer
   private def consume_false
     if next_char == 'a' && next_char == 'l' && next_char == 's' && next_char == 'e'
       next_char
-      @token.type = :false
+      @token.kind = :false
     else
       unexpected_char
     end
@@ -116,7 +116,7 @@ abstract class JSON::Lexer
   private def consume_null
     if next_char == 'u' && next_char == 'l' && next_char == 'l'
       next_char
-      @token.type = :null
+      @token.kind = :null
     else
       unexpected_char
     end
@@ -239,7 +239,7 @@ abstract class JSON::Lexer
       when '0'..'9'
         unexpected_char
       else
-        @token.type = :INT
+        @token.kind = :int
         @token.int_value = 0_i64
         number_end
       end
@@ -262,7 +262,7 @@ abstract class JSON::Lexer
       when 'e', 'E'
         consume_exponent(negative, integer.to_f64, digits)
       else
-        @token.type = :INT
+        @token.kind = :int
         @token.int_value = negative ? -integer : integer
         number_end
       end
@@ -295,7 +295,7 @@ abstract class JSON::Lexer
     if char == 'e' || char == 'E'
       consume_exponent(negative, float, digits)
     else
-      @token.type = :FLOAT
+      @token.kind = :float
       # If there's a chance of overflow, we parse the raw string
       if digits >= 18
         @token.float_value = number_string.to_f64
@@ -334,7 +334,7 @@ abstract class JSON::Lexer
       unexpected_char
     end
 
-    @token.type = :FLOAT
+    @token.kind = :float
 
     exponent = -exponent if negative_exponent
     float *= (10_f64 ** exponent)
@@ -354,8 +354,8 @@ abstract class JSON::Lexer
     next_char_no_column_increment
   end
 
-  private def next_char(token_type)
-    @token.type = token_type
+  private def next_char(kind : Token::Kind)
+    @token.kind = kind
     next_char
   end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -110,7 +110,7 @@ module JSON
       rescue exc : ::JSON::ParseException
         raise ::JSON::MappingError.new(exc.message, self.class.to_s, nil, *%location, exc)
       end
-      while %pull.kind != :end_object
+      until %pull.kind.end_object?
         %key_location = %pull.location
         key = %pull.read_object_key
         case key

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -172,7 +172,7 @@ module JSON
         rescue exc : ::JSON::ParseException
           raise ::JSON::MappingError.new(exc.message, self.class.to_s, nil, *%location, exc)
         end
-        while pull.kind != :end_object
+        until pull.kind.end_object?
           %key_location = pull.location
           key = pull.read_object_key
           case key

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -1,5 +1,21 @@
 class JSON::Token
-  property type : Symbol
+  enum Kind
+    Null
+    False
+    True
+    Int
+    Float
+    String
+    BeginArray
+    EndArray
+    BeginObject
+    EndObject
+    Colon
+    Comma
+    EOF
+  end
+
+  property kind : Kind
   property string_value : String
   property int_value : Int64
   property float_value : Float64
@@ -8,7 +24,7 @@ class JSON::Token
   property raw_value : String
 
   def initialize
-    @type = :EOF
+    @kind = :EOF
     @line_number = 0
     @column_number = 0
     @string_value = ""
@@ -17,16 +33,70 @@ class JSON::Token
     @raw_value = ""
   end
 
-  def to_s(io : IO) : Nil
-    case @type
-    when :INT
-      @int_value.to_s(io)
-    when :FLOAT
-      @float_value.to_s(io)
-    when :STRING
-      @string_value.to_s(io)
+  @[Deprecated("Use JSON::Token#kind, which is an enum")]
+  def type : Symbol
+    case @kind
+    when .null?
+      :null
+    when .false?
+      :false
+    when .true?
+      :true
+    when .int?
+      :INT
+    when .float?
+      :FLOAT
+    when .string?
+      :STRING
+    when .begin_array?
+      :"["
+    when .end_array?
+      :"]"
+    when .begin_object?
+      :"{"
+    when .end_object?
+      :"}"
+    when .colon?
+      :":"
+    when .comma?
+      :","
+    when .eof?
+      :EOF
     else
-      @type.to_s(io)
+      raise "Unknown token kind: #{@kind}"
+    end
+  end
+
+  def to_s(io : IO) : Nil
+    case @kind
+    when .null?
+      io << "null"
+    when .false?
+      io << "false"
+    when .true?
+      io << "true"
+    when .int?
+      raw_value.to_s(io)
+    when .float?
+      raw_value.to_s(io)
+    when .string?
+      string_value.to_s(io)
+    when .begin_array?
+      io << '['
+    when .end_array?
+      io << ']'
+    when .begin_object?
+      io << '{'
+    when .end_object?
+      io << '}'
+    when .colon?
+      io << ':'
+    when .comma?
+      io << ','
+    when .eof?
+      io << "<EOF>"
+    else
+      raise "Unknown token kind: #{@kind}"
     end
   end
 end

--- a/src/oauth/access_token.cr
+++ b/src/oauth/access_token.cr
@@ -43,7 +43,7 @@ class OAuth::AccessToken
       when "oauth_token_secret"
         secret = pull.read_string
       else
-        if pull.kind == :STRING
+        if pull.kind.string?
           extra ||= {} of String => String
           extra[key] = pull.read_string
         else


### PR DESCRIPTION
This changes `JSON::Lexer` and `JSON::PullParser` to expose enums instead of symbols for token kinds and pull parser state kinds. Symbols work but they are not type-safe. Plus enums gives enumerate (duh) all possible states.

The PullParser has already proven to be very useful but moving forward I wouldn't like to keep the Symbols interface so it's better now or never.

This is a breaking change:
- `JSON::Lexer::Token#type : Symbol` is replaced by `JSON::Lexer::Token#kind : JSON::Lexer::Token::Kind`
- `JSON::PullParser#kind : Symbol` is replaced by `JSON::PullParser#kind : JSON::PullParser::Kind`

To make it easy to upgrade I kept `JSON::Lexer::Token#type : Symbol` as deprecated and also made `JSON::PullParser::Kind` be comparable to symbols, with a deprecation notice. That way we don't actually break anything but if you run the compiler with `--warnings=all` then you can fix things at your time.

Once merged, in a subsequent PR I'll try to document all of these types, including the ones in the YAML module.

I also added `JSON::Builder#next_is_object_key?` because I think it's useful and I at least needed it for optimizing one thing in https://github.com/Blacksmoke16/oq (though I didn't send a PR there yet).