### PR TITLE
Make some macro methods more uniform

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1218,6 +1218,18 @@ module Crystal
           [TypeNode.new(program.union_of(program.string, program.nil))] of ASTNode
         end
       end
+
+      it "executes resolve" do
+        assert_macro("x", "{{x.resolve}}", "String") do |program|
+          [TypeNode.new(program.string)] of ASTNode
+        end
+      end
+
+      it "executes resolve?" do
+        assert_macro("x", "{{x.resolve?}}", "String") do |program|
+          [TypeNode.new(program.string)] of ASTNode
+        end
+      end
     end
 
     describe "type declaration methods" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1230,6 +1230,18 @@ module Crystal
           [TypeNode.new(program.string)] of ASTNode
         end
       end
+
+      it "executes union_types (union)" do
+        assert_macro("x", "{{x.union_types}}", %([Bool, Int32])) do |program|
+          [TypeNode.new(program.union_of(program.int32, program.bool))] of ASTNode
+        end
+      end
+
+      it "executes union_types (non-union)" do
+        assert_macro("x", "{{x.union_types}}", %([Int32])) do |program|
+          [TypeNode.new(program.int32)] of ASTNode
+        end
+      end
     end
 
     describe "type declaration methods" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1680,6 +1680,10 @@ module Crystal
         assert_macro "x", %({{x.resolve?}}), [Generic.new("Foo".path, ["String".path] of ASTNode)] of ASTNode, %(nil)
         assert_macro "x", %({{x.resolve?}}), [Generic.new("Array".path, ["Foo".path] of ASTNode)] of ASTNode, %(nil)
       end
+
+      it "executes types" do
+        assert_macro "x", %({{x.types}}), [Generic.new("Foo".path, ["T".path] of ASTNode)] of ASTNode, "[Foo(T)]"
+      end
     end
 
     describe "union methods" do
@@ -1733,6 +1737,10 @@ module Crystal
       it "executes resolve?" do
         assert_macro "x", %({{x.resolve?}}), [Path.new("String")] of ASTNode, %(String)
         assert_macro "x", %({{x.resolve?}}), [Path.new("Foo")] of ASTNode, %(nil)
+      end
+
+      it "executes types" do
+        assert_macro "x", %({{x.types}}), [Path.new("String")] of ASTNode, %([String])
       end
     end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1674,6 +1674,15 @@ module Crystal
       it "executes types" do
         assert_macro "x", %({{x.types}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "[Int32, String]"
       end
+
+      it "executes resolve" do
+        assert_macro "x", %({{x.resolve}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "(Int32 | String)"
+      end
+
+      it "executes resolve?" do
+        assert_macro "x", %({{x.resolve?}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "(Int32 | String)"
+        assert_macro "x", %({{x.resolve?}}), [Crystal::Union.new(["Int32".path, "Unknown".path] of ASTNode)] of ASTNode, "nil"
+      end
     end
 
     describe "range methods" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1297,6 +1297,12 @@ module Crystal::Macros
     # returns a `NilLiteral`.
     def resolve? : ASTNode | NilLiteral
     end
+
+    # Returns this path inside an array literal.
+    # This method exists so you can call `types` on the type of a type
+    # declaration and get all types, whether it's a Generic, Path or Union.
+    def types : ArrayLiteral(ASTNode)
+    end
   end
 
   # A class definition.
@@ -1343,6 +1349,12 @@ module Crystal::Macros
     # Resolves this path to a `TypeNode` if it denotes a type,
     # or otherwise returns a `NilLiteral`.
     def resolve? : ASTNode | NilLiteral
+    end
+
+    # Returns this generic inside an array literal.
+    # This method exists so you can call `types` on the type of a type
+    # declaration and get all types, whether it's a Generic, Path or Union.
+    def types : ArrayLiteral(ASTNode)
     end
   end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1697,7 +1697,7 @@ module Crystal::Macros
     end
 
     # Returns the types forming a union type, if this is a union type.
-    # Gives a compile error otherwise.
+    # Otherwise returns this single type inside an array literal (so you can safely call `union_types` on any type and treat all types uniformly).
     #
     # See also: `union?`.
     def union_types : ArrayLiteral(TypeNode)

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1411,6 +1411,16 @@ module Crystal::Macros
 
   # A type union, like `(Int32 | String)`.
   class Union < ASTNode
+    # Resolves this union to a `TypeNode`. Gives a compile-time error
+    # if any type inside the union can't be resolved.
+    def resolve : ASTNode
+    end
+
+    # Resolves this union to a `TypeNode`. Returns a `NilLiteral`
+    # if any type inside the union can't be resolved.
+    def resolve? : ASTNode | NilLiteral
+    end
+
     # Returns the types of this union.
     def types : ArrayLiteral(ASTNode)
     end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1815,6 +1815,14 @@ module Crystal::Macros
     def overrides?(type : TypeNode, method : StringLiteral | SymbolLiteral | MacroId) : Bool
     end
 
+    # Returns `self`. This method exists so you can safely call `resolve` on a node and resolve it to a type, even if it's a type already.
+    def resolve : TypeNode
+    end
+
+    # Returns `self`. This method exists so you can safely call `resolve` on a node and resolve it to a type, even if it's a type already.
+    def resolve? : TypeNode
+    end
+
     # Returns `true` if *other* is an ancestor of `self`.
     def <(other : TypeNode) : BoolLiteral
     end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -484,6 +484,31 @@ module Crystal
       nil
     end
 
+    def resolve(node : Union)
+      union_type = @program.union_of(node.types.map do |type|
+        resolve(type).type
+      end)
+      TypeNode.new(union_type.not_nil!)
+    end
+
+    def resolve?(node : Union)
+      union_type = @program.union_of(node.types.map do |type|
+        resolved = resolve?(type)
+        return nil unless resolved
+
+        resolved.type
+      end)
+      TypeNode.new(union_type.not_nil!)
+    end
+
+    def resolve(node : ASTNode?)
+      node.raise "can't resolve #{node} (#{node.class_desc})"
+    end
+
+    def resolve?(node : ASTNode)
+      node.raise "can't resolve #{node} (#{node.class_desc})"
+    end
+
     def visit(node : Splat)
       node.exp.accept self
       @last = @last.interpret("splat", [] of ASTNode, nil, self)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1266,6 +1266,10 @@ module Crystal
   class Union
     def interpret(method, args, block, interpreter)
       case method
+      when "resolve"
+        interpret_argless_method(method, args) { interpreter.resolve(self) }
+      when "resolve?"
+        interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
       when "types"
         interpret_argless_method(method, args) { ArrayLiteral.new(@types) }
       else

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1645,6 +1645,10 @@ module Crystal
           value = arg2.to_string("second argument to 'TypeNode#overrides?")
           TypeNode.overrides?(type, arg1.type, value)
         end
+      when "resolve"
+        interpret_argless_method(method, args) { self }
+      when "resolve?"
+        interpret_argless_method(method, args) { self }
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1507,7 +1507,7 @@ module Crystal
       when "nilable?"
         interpret_argless_method(method, args) { BoolLiteral.new(type.nilable?) }
       when "union_types"
-        interpret_argless_method(method, args) { TypeNode.union_types(type) }
+        interpret_argless_method(method, args) { TypeNode.union_types(self) }
       when "name"
         interpret_argless_method(method, args) { MacroId.new(type.devirtualize.to_s) }
       when "type_vars"
@@ -1738,9 +1738,14 @@ module Crystal
       end
     end
 
-    def self.union_types(type)
-      raise "undefined method 'union_types' for TypeNode of type #{type} (must be a union type)" unless type.is_a?(UnionType)
-      ArrayLiteral.map(type.union_types) { |uniontype| TypeNode.new(uniontype) }
+    def self.union_types(type_node)
+      type = type_node.type
+
+      if type.is_a?(UnionType)
+        ArrayLiteral.map(type.union_types) { |uniontype| TypeNode.new(uniontype) }
+      else
+        ArrayLiteral.new([type_node] of ASTNode)
+      end
     end
 
     def self.constants(type)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1990,6 +1990,8 @@ module Crystal
         interpret_argless_method(method, args) { interpreter.resolve(self) }
       when "resolve?"
         interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
+      when "types"
+        interpret_argless_method(method, args) { ArrayLiteral.new([self] of ASTNode) }
       else
         super
       end
@@ -2069,6 +2071,8 @@ module Crystal
         interpret_argless_method(method, args) { interpreter.resolve(self) }
       when "resolve?"
         interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
+      when "types"
+        interpret_argless_method(method, args) { ArrayLiteral.new([self] of ASTNode) }
       else
         super
       end


### PR DESCRIPTION
Related issue: https://forum.crystal-lang.org/t/add-nilable-to-more-macro-types/273

This PR does these things (you can check each commit too):
- Add `Union#resolve` and `Union#resolve?`: this was missing. For example [this code](https://play.crystal-lang.org/#/r/78lk) doesn't compile but it should (if you replace `decl.type.nilable?` with `decl.type.resolve.nilable?`).
- Add `TypeNode#resolve` and `TypeNode#resolve?`: so in case you either get a Path, Union, Generic or an already resolved TypeNode you can always call `resolve` on it and get a TypeNode
- Add `Path#types` and `Generic#types`: there's already `Union#types` which returns a union's types. Instead of casing on it we can define `types` in these two other types two so you can always call `types` on something that looks like a type and work with that in a uniform way
- Let `TypeNode#union_types` also work for non-union types: same reason as before to make it easier to work uniformly with unions and non-unions by providing a way to convert a type to a list of types it holds (for a non-union it's just that type).

These are small improvements that, I believe, will make the life of macro users a bit more simple.