### PR TITLE
Compiler: avoid remove_indirection in TypeDefType

### DIFF
--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -114,7 +114,7 @@ class Crystal::Call
       if call_arg.is_a?(Out)
         arg_type = arg.type
         if arg_type.is_a?(PointerInstanceType)
-          if arg_type.element_type.remove_indirection.void?
+          if arg_type.element_type.remove_typedef.void?
             call_arg.raise "can't use out with Void* (argument #{lib_arg_name(arg, i)} of #{untyped_def.owner}.#{untyped_def.name} is Void*)"
           end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2547,8 +2547,12 @@ module Crystal
       super(program, namespace, name)
     end
 
-    delegate remove_typedef, remove_indirection, pointer?, defs,
+    delegate remove_typedef, pointer?, defs,
       macros, reference_link?, parents, to: typedef
+
+    def remove_indirection
+      self
+    end
 
     def type_def_type?
       true


### PR DESCRIPTION
Otherwise, actual type in upcast/downcast/assign was lost in Lib type declaration.

There was already a `remove_typedef` that seems more accurate for the `check_fun_out_args`.

Discovered while trying to change the union codegen strategy.