### PR TITLE
Compiler and LLVM refactors and minor additions

### DIFF
--- a/src/compiler/crystal/codegen/crystal_llvm_builder.cr
+++ b/src/compiler/crystal/codegen/crystal_llvm_builder.cr
@@ -65,10 +65,18 @@ module Crystal
       @builder.to_unsafe
     end
 
-    macro method_missing(call)
-      return llvm_nil if @end
+    {% for name in %w(add add_handler alloca and ashr atomicrmw bit_cast build_catch_ret call
+                     catch_pad catch_switch cmpxchg cond current_debug_location exact_sdiv
+                     extract_value fadd fcmp fdiv fence fmul fp2si fp2ui fpext fptrunc fsub
+                     global_string_pointer icmp inbounds_gep int2ptr invoke landing_pad load
+                     lshr mul not or phi ptr2int sdiv select set_current_debug_location sext
+                     shl si2fp srem store store_volatile sub switch trunc udiv ui2fp urem xor
+                     zext) %}
+      def {{name.id}}(*args, **kwargs)
+        return llvm_nil if @end
 
-      @builder.{{call}}
-    end
+        @builder.{{name.id}}(*args, **kwargs)
+      end
+    {% end %}
   end
 end

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -124,7 +124,7 @@ module Crystal
     end
 
     delegate ptr2int, int2ptr, and, or, not, bit_cast,
-      trunc, load, store, br, insert_block, position_at_end,
+      trunc, load, store, load_volatile, store_volatile, br, insert_block, position_at_end,
       cond, phi, extract_value, to: builder
 
     def ret

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -125,7 +125,7 @@ module Crystal
 
     delegate ptr2int, int2ptr, and, or, not, bit_cast,
       trunc, load, store, load_volatile, store_volatile, br, insert_block, position_at_end,
-      cond, phi, extract_value, to: builder
+      cond, phi, extract_value, switch, to: builder
 
     def ret
       builder.ret

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -89,6 +89,14 @@ class LLVM::Builder
     Value.new LibLLVM.build_load(self, ptr, name)
   end
 
+  def store_volatile(value, ptr)
+    store(value, ptr).tap { |v| v.volatile = true }
+  end
+
+  def load_volatile(ptr, name = "")
+    load(ptr, name).tap { |v| v.volatile = true }
+  end
+
   {% for method_name in %w(gep inbounds_gep) %}
     def {{method_name.id}}(value, indices : Array(LLVM::ValueRef), name = "")
       # check_value(value)


### PR DESCRIPTION
Add methods to emit LLVM's `switch` and helpers for `load volatile` and `store volatile`.

This also removes a method_missing used for delegation in favor of explicit macro expansion. This is easier to track and to customize later if needed.