### PR TITLE
Compiler: Move LLVMId from CodeGenVisitor to Program

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -69,6 +69,10 @@ module Crystal
       visitor.modules
     end
 
+    def llvm_id
+      @llvm_id ||= LLVMId.new(self)
+    end
+
     def llvm_typer
       @llvm_typer ||= LLVMTyper.new(self, LLVM::Context.new)
     end
@@ -163,7 +167,6 @@ module Crystal
       @main_llvm_context = @main_mod.context
       @llvm_typer = LLVMTyper.new(@program, @llvm_context)
       @main_llvm_typer = @llvm_typer
-      @llvm_id = LLVMId.new(@program)
       @main_ret_type = node.type? || @program.nil_type
       ret_type = @llvm_typer.llvm_return_type(@main_ret_type)
       @main = @llvm_mod.functions.add(MAIN_NAME, [llvm_context.int32, llvm_context.void_pointer.pointer], ret_type)

--- a/src/compiler/crystal/codegen/match.cr
+++ b/src/compiler/crystal/codegen/match.cr
@@ -63,7 +63,7 @@ class Crystal::CodeGenVisitor
   end
 
   private def create_match_fun_body(type : VirtualType, type_id)
-    min, max = @llvm_id.min_max_type_id(type.base_type).not_nil!
+    min, max = @program.llvm_id.min_max_type_id(type.base_type).not_nil!
     ret(
       and(
         builder.icmp(LLVM::IntPredicate::SGE, type_id, int(min)),

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -988,7 +988,7 @@ class Crystal::CodeGenVisitor
   end
 
   def create_metaclass_fun(name)
-    id_to_metaclass = @llvm_id.id_to_metaclass.to_a.sort_by! &.[0]
+    id_to_metaclass = @program.llvm_id.id_to_metaclass.to_a.sort_by! &.[0]
 
     in_main do
       define_main_function(name, ([llvm_context.int32]), llvm_context.int32) do |func|

--- a/src/compiler/crystal/codegen/type_id.cr
+++ b/src/compiler/crystal/codegen/type_id.cr
@@ -69,6 +69,6 @@ class Crystal::CodeGenVisitor
   end
 
   private def type_id_impl(type)
-    int(@llvm_id.type_id(type))
+    int(@program.llvm_id.type_id(type))
   end
 end


### PR DESCRIPTION
This will allow accessing the type-id's of the program across the different `LLVMTyper` instances that already have a reference to the program.

It is also a more reasonable place for the LLVMId instance since they are expected to be scoped to the whole program.