### PR TITLE
Random::ISAAC: fix initial seed

### DIFF
--- a/spec/std/random/isaac_spec.cr
+++ b/spec/std/random/isaac_spec.cr
@@ -349,4 +349,10 @@ describe "Random::ISAAC" do
   it "can be initialized without explicit seed" do
     Random::ISAAC.new.should be_a Random::ISAAC
   end
+
+  it "different instances generate different numbers (#7976)" do
+    isaacs = Array.new(1000) { Random::ISAAC.new }
+    values = isaacs.map(&.rand(10_000_000))
+    values.uniq.size.should be > 2
+  end
 end

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -301,4 +301,11 @@ describe "Random" do
       hex.should eq("9fd857f462831002ffffffffffffffff0000000000000000e88d3a30db4e730021b8a5e33b020000362f518e0700000062da")
     end
   end
+
+  it "returns a random static array" do
+    {% for type in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64).map(&.id) %}
+      array = TestRNG.new(RNG_DATA_32).rand(StaticArray({{type}}, 4))
+      typeof(array).should eq(StaticArray({{type}}, 4))
+    {% end %}
+  end
 end

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -302,6 +302,13 @@ describe "Random" do
     end
   end
 
+  it "returns a random integer" do
+    {% for type in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64).map(&.id) %}
+      value = TestRNG.new(RNG_DATA_32).rand({{type}})
+      typeof(value).should eq({{type}})
+    {% end %}
+  end
+
   it "returns a random static array" do
     {% for type in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64).map(&.id) %}
       array = TestRNG.new(RNG_DATA_32).rand(StaticArray({{type}}, 4))

--- a/src/random.cr
+++ b/src/random.cr
@@ -289,6 +289,28 @@ module Random
     end
   end
 
+  # Returns a StaticArray filled with random integers.
+  # Note that this only works with StaticArray of integer types.
+  #
+  # ```
+  # Random.new.rand(StaticArray(Int32, 4))  # => StaticArray[4795590, -1987398873, 1859211601, 546845569]
+  # Random.new.rand(StaticArray(UInt16, 2)) # => StaticArray[49247, 53674]
+  # ```
+  def rand(type : StaticArray(T, N).class) forall T, N
+    {%
+      if T != Int8 && T != UInt8 &&
+         T != Int16 && T != UInt16 &&
+         T != Int32 && T != UInt32 &&
+         T != Int64 && T != UInt64
+        raise "Random::Secure#random_static argument must be StaticArray of integer type"
+      end
+    %}
+
+    buffer = uninitialized UInt8[sizeof(StaticArray(T, N))]
+    random_bytes(buffer.to_slice)
+    buffer.unsafe_as(StaticArray(T, N))
+  end
+
   # Fills a given slice with random bytes.
   #
   # ```

--- a/src/random.cr
+++ b/src/random.cr
@@ -289,26 +289,39 @@ module Random
     end
   end
 
-  # Returns a StaticArray filled with random integers.
-  # Note that this only works with StaticArray of integer types.
-  #
-  # ```
-  # Random.new.rand(StaticArray(Int32, 4))  # => StaticArray[4795590, -1987398873, 1859211601, 546845569]
-  # Random.new.rand(StaticArray(UInt16, 2)) # => StaticArray[49247, 53674]
-  # ```
-  def rand(type : StaticArray(T, N).class) forall T, N
-    {%
-      if T != Int8 && T != UInt8 &&
-         T != Int16 && T != UInt16 &&
-         T != Int32 && T != UInt32 &&
-         T != Int64 && T != UInt64
-        raise "Random::Secure#random_static argument must be StaticArray of integer type"
-      end
-    %}
+  {% for type, values in {
+                           "Int8".id   => %w(20 -66 89 19),
+                           "UInt8".id  => %w(186 221 127 245),
+                           "Int16".id  => %w(-32554 32169 -20152 -7686),
+                           "UInt16".id => %w(39546 44091 2874 17348),
+                           "Int32".id  => %w(1870830079 -1043532158 -867180637 -1216773590),
+                           "UInt32".id => %w(3147957137 4245108745 2207809043 3184391838),
+                           "Int64".id  => %w(4438449217673515190 8514493061600538358 -4874671083204037318 -7825896160729246667),
+                           "UInt64".id => %w(15004487597684511003 12027825265648206103 11303949506191212698 6228566501671148658),
+                         } %}
+    # Returns a random {{type}}
+    #
+    # ```
+    # rand({{type}}) # => {{values[0].id}}
+    # ```
+    def rand(type : {{type}}.class) : {{type}}
+      rand_type_from_bytes(type)
+    end
 
-    buffer = uninitialized UInt8[sizeof(StaticArray(T, N))]
+    # Returns a StaticArray filled with random {{type}} values.
+    #
+    # ```
+    # rand(StaticArray({{type}}, 4)) # => StaticArray[{{values.join(", ").id}}]
+    # ```
+    def rand(type : StaticArray({{type}}, _).class)
+      rand_type_from_bytes(type)
+    end
+  {% end %}
+
+  private def rand_type_from_bytes(t : T.class) forall T
+    buffer = uninitialized UInt8[sizeof(T)]
     random_bytes(buffer.to_slice)
-    buffer.unsafe_as(StaticArray(T, N))
+    buffer.unsafe_as(T)
   end
 
   # Fills a given slice with random bytes.

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -12,13 +12,8 @@ class Random::ISAAC
   private getter bb
   private getter cc
 
-  private alias Seeds = StaticArray(UInt32, 8)
-
   private def random_seeds
-    result = uninitialized Seeds
-    result_slice = result.unsafe_as(StaticArray(UInt8, sizeof(Seeds))).to_slice
-    Random::Secure.random_bytes(result_slice)
-    result
+    Random::Secure.rand(StaticArray(UInt32, 8))
   end
 
   def initialize(seeds = random_seeds)


### PR DESCRIPTION
Fixes #7976

In the old code `unsafe_as` returned a copy of the static array and so it was initializing something else other than what was returned.