### PR TITLE
Fix incorrect Int#% overflow

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -469,6 +469,10 @@ describe "Int" do
     (4 % 2).should eq(0)
   end
 
+  it "% doesn't overflow (#7979)" do
+    (53 % 532_000_782_588_491_410).should eq(53)
+  end
+
   it "does times" do
     i = sum = 0
     3.times do |n|

--- a/src/int.cr
+++ b/src/int.cr
@@ -172,7 +172,7 @@ struct Int
   def %(other : Int)
     if other == 0
       raise DivisionByZeroError.new
-    elsif (self ^ other) >= 0
+    elsif (self < 0) == (other < 0)
       self.unsafe_mod(other)
     else
       me = self.unsafe_mod(other)


### PR DESCRIPTION
Fixes #7979

Doing `(x ^ y) >= 0` doesn't work well for determining whether `x` and `y` have the same sign when their types are not the same (for example `Int32` and `Int64`). 