### PR TITLE
Fixes issue with aarch64 invalid memory access

### DIFF
--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -1,6 +1,6 @@
 lib Intrinsics
   fun debugtrap = "llvm.debugtrap"
-  {% if flag?(:x86_64) %}
+  {% if flag?(:x86_64) || flag?(:aarch64) %}
     fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -1,6 +1,6 @@
 lib Intrinsics
   fun debugtrap = "llvm.debugtrap"
-  {% if flag?(:x86_64) || flag?(:aarch64) %}
+  {% if flag?(:bits64) %}
     fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
     fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)


### PR DESCRIPTION
This change properly maps the 64bit Intrinsics memory methods for `aarch64` architecture.

This fixes issue #7293 and possibly #7299