### PR TITLE
Require openssl algorithm in pkcs5

### DIFF
--- a/spec/std/openssl/pkcs5_spec.cr
+++ b/spec/std/openssl/pkcs5_spec.cr
@@ -1,6 +1,5 @@
 require "spec"
 require "openssl/pkcs5"
-require "openssl/algorithm"
 
 describe OpenSSL::PKCS5 do
   it "computes pbkdf2_hmac_sha1" do

--- a/src/openssl/pkcs5.cr
+++ b/src/openssl/pkcs5.cr
@@ -1,4 +1,5 @@
 require "openssl"
+require "openssl/algorithm"
 
 module OpenSSL::PKCS5
   def self.pbkdf2_hmac_sha1(secret, salt, iterations = 2**16, key_size = 64) : Bytes


### PR DESCRIPTION
Before this patch, a program simply of

    require "openssl"
    OpenSSL::PKCS5.pbkdf2_hmac("secret", "salt")

would not run due to not having the openssl/algorithm required.