### PR TITLE
Add support for LLVM 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ EXPORTS := \
 SHELL = sh
 LLVM_CONFIG_FINDER := \
   [ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+  command -v llvm-config-7 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.1*) command -v llvm-config;; *) false;; esac)) || \
+  command -v llvm-config-7.0 || command -v llvm-config70 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-6.0 || command -v llvm-config60 || \
     (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 6.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-5.0 || command -v llvm-config50 || \

--- a/bin/ci
+++ b/bin/ci
@@ -89,9 +89,9 @@ prepare_build() {
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.29.0/crystal-0.29.0-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.29.0-1 crystal;popd'
 
-  on_osx brew install llvm@6 gmp libevent pcre pkg-config
+  on_osx brew install llvm@7 gmp libevent pcre pkg-config
   on_osx brew upgrade libyaml
-  on_osx brew link --force llvm@6
+  on_osx brew link --force llvm@7
 
   on_tag verify_version
 }

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -240,7 +240,7 @@ class Crystal::CodeGenVisitor
       gep_call_arg = bit_cast gep(call_arg, 0, 0), llvm_context.void_pointer
       size = @abi.size(abi_arg_type.type)
       align = @abi.align(abi_arg_type.type)
-      memcpy(final_value_casted, gep_call_arg, int32(size), int32(align), int1(0))
+      memcpy(final_value_casted, gep_call_arg, int32(size), align, int1(0))
       call_arg = load final_value
     else
       # Keep same call arg
@@ -500,7 +500,7 @@ class Crystal::CodeGenVisitor
             final_value_casted = bit_cast final_value, llvm_context.void_pointer
             size = @abi.size(abi_return.type)
             align = @abi.align(abi_return.type)
-            memcpy(final_value_casted, cast2, int32(size), int32(align), int1(0))
+            memcpy(final_value_casted, cast2, int32(size), align, int1(0))
             @last = final_value
           end
         when LLVM::ABI::ArgKind::Indirect

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -1,14 +1,29 @@
-lib Intrinsics
+# Intrinsics as exported by LLVM.
+# Use `Intrinsics` to have a unified API across LLVM versions.
+lib LibIntrinsics
   fun debugtrap = "llvm.debugtrap"
   {% if flag?(:bits64) %}
-    fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
-    fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
-    fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, align : UInt32, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, align : UInt32, is_volatile : Bool)
+    {% else %}
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
+    {% end %}
   {% else %}
-    fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
-    fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
-    fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, align : UInt32, is_volatile : Bool)
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, align : UInt32, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, align : UInt32, is_volatile : Bool)
+    {% else %}
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, is_volatile : Bool)
+    {% end %}
   {% end %}
+
   fun read_cycle_counter = "llvm.readcyclecounter" : UInt64
   fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
 
@@ -32,6 +47,112 @@ lib Intrinsics
 
   fun va_start = "llvm.va_start"(ap : Void*)
   fun va_end = "llvm.va_end"(ap : Void*)
+end
+
+module Intrinsics
+  def self.debugtrap
+    LibIntrinsics.debugtrap
+  end
+
+  macro memcpy(dest, src, len, is_volatile)
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      LibIntrinsics.memcpy({{dest}}, {{src}}, {{len}}, 0, {{is_volatile}})
+    {% else %}
+      LibIntrinsics.memcpy({{dest}}, {{src}}, {{len}}, {{is_volatile}})
+    {% end %}
+  end
+
+  macro memmove(dest, src, len, is_volatile)
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      LibIntrinsics.memmove({{dest}}, {{src}}, {{len}}, 0, {{is_volatile}})
+    {% else %}
+      LibIntrinsics.memmove({{dest}}, {{src}}, {{len}}, {{is_volatile}})
+    {% end %}
+  end
+
+  macro memset(dest, val, len, is_volatile)
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      LibIntrinsics.memset({{dest}}, {{val}}, {{len}}, 0, {{is_volatile}})
+    {% else %}
+      LibIntrinsics.memset({{dest}}, {{val}}, {{len}}, {{is_volatile}})
+    {% end %}
+  end
+
+  def self.read_cycle_counter
+    LibIntrinsics.read_cycle_counter
+  end
+
+  def self.bswap32(id)
+    LibIntrinsics.bswap32(id)
+  end
+
+  def self.popcount8(src)
+    LibIntrinsics.popcount8(src)
+  end
+
+  def self.popcount16(src)
+    LibIntrinsics.popcount16(src)
+  end
+
+  def self.popcount32(src)
+    LibIntrinsics.popcount32(src)
+  end
+
+  def self.popcount64(src)
+    LibIntrinsics.popcount64(src)
+  end
+
+  def self.popcount128(src)
+    LibIntrinsics.popcount128(src)
+  end
+
+  macro countleading8(src, zero_is_undef)
+    LibIntrinsics.countleading8({{src}}, {{zero_is_undef}})
+  end
+
+  macro countleading16(src, zero_is_undef)
+    LibIntrinsics.countleading16({{src}}, {{zero_is_undef}})
+  end
+
+  macro countleading32(src, zero_is_undef)
+    LibIntrinsics.countleading32({{src}}, {{zero_is_undef}})
+  end
+
+  macro countleading64(src, zero_is_undef)
+    LibIntrinsics.countleading64({{src}}, {{zero_is_undef}})
+  end
+
+  macro countleading128(src, zero_is_undef)
+    LibIntrinsics.countleading128({{src}}, {{zero_is_undef}})
+  end
+
+  macro counttrailing8(src, zero_is_undef)
+    LibIntrinsics.counttrailing8({{src}}, {{zero_is_undef}})
+  end
+
+  macro counttrailing16(src, zero_is_undef)
+    LibIntrinsics.counttrailing16({{src}}, {{zero_is_undef}})
+  end
+
+  macro counttrailing32(src, zero_is_undef)
+    LibIntrinsics.counttrailing32({{src}}, {{zero_is_undef}})
+  end
+
+  macro counttrailing64(src, zero_is_undef)
+    LibIntrinsics.counttrailing64({{src}}, {{zero_is_undef}})
+  end
+
+  macro counttrailing128(src, zero_is_undef)
+    LibIntrinsics.counttrailing128({{src}}, {{zero_is_undef}})
+  end
+
+  def self.va_start(ap)
+    LibIntrinsics.va_start(ap)
+  end
+
+  def self.va_end(ap)
+    LibIntrinsics.va_end(ap)
+  end
 end
 
 macro debugger

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -314,7 +314,7 @@ LLVMMetadataRef LLVMTemporaryMDNode2(LLVMContextRef C, LLVMMetadataRef *MDs,
                   .release());
 }
 
-void LLVMMetadataReplaceAllUsesWith(LLVMMetadataRef MD, LLVMMetadataRef New) {
+void LLVMMetadataReplaceAllUsesWith2(LLVMMetadataRef MD, LLVMMetadataRef New) {
   auto *Node = unwrap<MDNode>(MD);
   Node->replaceAllUsesWith(unwrap<MDNode>(New));
   MDNode::deleteTemporary(Node);

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -87,7 +87,7 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit2(DIBuilderRef Dref, unsigned Lang
 #endif
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateFunction(
+LLVMMetadataRef LLVMDIBuilderCreateFunction2(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     const char *LinkageName, LLVMMetadataRef File, unsigned Line,
     LLVMMetadataRef CompositeType, bool IsLocalToUnit, bool IsDefinition,
@@ -107,7 +107,7 @@ LLVMMetadataRef LLVMDIBuilderCreateFunction(
   return wrap(Sub);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(DIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock2(DIBuilderRef Dref,
                                                 LLVMMetadataRef Scope,
                                                 LLVMMetadataRef File,
                                                 unsigned Line,
@@ -116,7 +116,7 @@ LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(DIBuilderRef Dref,
                                        unwrapDI<DIFile>(File), Line, Column));
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateBasicType(DIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreateBasicType2(DIBuilderRef Dref,
                                              const char *Name,
                                              uint64_t SizeInBits,
                                              uint64_t AlignInBits,
@@ -128,7 +128,7 @@ LLVMMetadataRef LLVMDIBuilderCreateBasicType(DIBuilderRef Dref,
 #endif
 }
 
-LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(DIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray2(DIBuilderRef Dref,
                                                   LLVMMetadataRef *Data,
                                                   unsigned Length) {
   Metadata **DataValue = unwrap(Data);
@@ -137,7 +137,7 @@ LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(DIBuilderRef Dref,
           .get());
 }
 
-LLVMMetadataRef LLVMDIBuilderGetOrCreateArray(DIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderGetOrCreateArray2(DIBuilderRef Dref,
                                               LLVMMetadataRef *Data,
                                               unsigned Length) {
   Metadata **DataValue = unwrap(Data);
@@ -146,13 +146,13 @@ LLVMMetadataRef LLVMDIBuilderGetOrCreateArray(DIBuilderRef Dref,
 }
 
 LLVMMetadataRef
-LLVMDIBuilderCreateSubroutineType(DIBuilderRef Dref, LLVMMetadataRef File,
+LLVMDIBuilderCreateSubroutineType2(DIBuilderRef Dref, LLVMMetadataRef File,
                                   LLVMMetadataRef ParameterTypes) {
   DISubroutineType *CT = Dref->createSubroutineType(DITypeRefArray(unwrap<MDTuple>(ParameterTypes)));
   return wrap(CT);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateAutoVariable(
+LLVMMetadataRef LLVMDIBuilderCreateAutoVariable2(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     LLVMMetadataRef File, unsigned Line, LLVMMetadataRef Ty,
     int AlwaysPreserve,
@@ -174,7 +174,7 @@ LLVMMetadataRef LLVMDIBuilderCreateAutoVariable(
   return wrap(V);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateParameterVariable(
+LLVMMetadataRef LLVMDIBuilderCreateParameterVariable2(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     unsigned ArgNo, LLVMMetadataRef File, unsigned Line,
     LLVMMetadataRef Ty, int AlwaysPreserve,
@@ -190,7 +190,7 @@ LLVMMetadataRef LLVMDIBuilderCreateParameterVariable(
   return wrap(V);
 }
 
-LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd(DIBuilderRef Dref,
+LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd2(DIBuilderRef Dref,
                                              LLVMValueRef Storage,
                                              LLVMMetadataRef VarInfo,
                                              LLVMMetadataRef Expr,
@@ -204,12 +204,12 @@ LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd(DIBuilderRef Dref,
   return wrap(Instr);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateExpression(DIBuilderRef Dref, int64_t *Addr,
+LLVMMetadataRef LLVMDIBuilderCreateExpression2(DIBuilderRef Dref, int64_t *Addr,
                                               size_t Length) {
   return wrap(Dref->createExpression(ArrayRef<int64_t>(Addr, Length)));
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateEnumerationType(
+LLVMMetadataRef LLVMDIBuilderCreateEnumerationType2(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
     uint64_t AlignInBits, LLVMMetadataRef Elements,
@@ -228,7 +228,7 @@ LLVMMetadataRef LLVMDIBuilderCreateEnumerator(DIBuilderRef Dref,
 }
 
 LLVMMetadataRef
-LLVMDIBuilderCreateStructType(DIBuilderRef Dref,
+LLVMDIBuilderCreateStructType2(DIBuilderRef Dref,
                               LLVMMetadataRef Scope,
                               const char *Name,
                               LLVMMetadataRef File,
@@ -250,7 +250,7 @@ LLVMDIBuilderCreateStructType(DIBuilderRef Dref,
 }
 
 LLVMMetadataRef
-LLVMDIBuilderCreateReplaceableCompositeType(DIBuilderRef Dref,
+LLVMDIBuilderCreateReplaceableCompositeType2(DIBuilderRef Dref,
                                             LLVMMetadataRef Scope,
                                             const char *Name,
                                             LLVMMetadataRef File,
@@ -277,7 +277,7 @@ LLVMDIBuilderReplaceTemporary(DIBuilderRef Dref,
 }
 
 LLVMMetadataRef
-LLVMDIBuilderCreateMemberType(DIBuilderRef Dref, LLVMMetadataRef Scope,
+LLVMDIBuilderCreateMemberType2(DIBuilderRef Dref, LLVMMetadataRef Scope,
                               const char *Name, LLVMMetadataRef File,
                               unsigned Line, uint64_t SizeInBits,
                               uint64_t AlignInBits, uint64_t OffsetInBits,
@@ -293,7 +293,7 @@ LLVMDIBuilderCreateMemberType(DIBuilderRef Dref, LLVMMetadataRef Scope,
   return wrap(DT);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreatePointerType(DIBuilderRef Dref,
+LLVMMetadataRef LLVMDIBuilderCreatePointerType2(DIBuilderRef Dref,
                                                LLVMMetadataRef PointeeType,
                                                uint64_t SizeInBits,
                                                uint64_t AlignInBits,
@@ -307,7 +307,7 @@ LLVMMetadataRef LLVMDIBuilderCreatePointerType(DIBuilderRef Dref,
   return wrap(T);
 }
 
-LLVMMetadataRef LLVMTemporaryMDNode(LLVMContextRef C, LLVMMetadataRef *MDs,
+LLVMMetadataRef LLVMTemporaryMDNode2(LLVMContextRef C, LLVMMetadataRef *MDs,
                                     unsigned Count) {
   return wrap(MDTuple::getTemporary(*unwrap(C),
                                     ArrayRef<Metadata *>(unwrap(MDs), Count))
@@ -441,7 +441,11 @@ void LLVMWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
   if (EC) return;
 
   llvm::ModuleSummaryIndex moduleSummaryIndex = llvm::buildModuleSummaryIndex(*m, nullptr, nullptr);
+#if LLVM_VERSION_GE(7, 0)
+  llvm::WriteBitcodeToFile(*m, OS, true, &moduleSummaryIndex, true);
+#else
   llvm::WriteBitcodeToFile(m, OS, true, &moduleSummaryIndex, true);
+#endif
 #endif
 }
 

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -449,9 +449,9 @@ void LLVMWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
 #endif
 }
 
-// LLVMNormalizeTargetTriple is available from LLVM in LLVM 8 and up,
+// LLVMNormalizeTargetTriple is available from LLVM in LLVM 7 and up,
 // in lower releases, we emulate it.
-#if LLVM_VERSION_LE(7, 0)
+#if LLVM_VERSION_LE(6, 0)
 char *LLVMNormalizeTargetTriple(const char* triple) {
     return strdup(Triple::normalize(StringRef(triple)).c_str());
 }

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -56,27 +56,23 @@ template <typename T> T *unwrapDIptr(LLVMMetadataRef v) {
 
 extern "C" {
 
-LLVMDIBuilderRef LLVMNewDIBuilder(LLVMModuleRef mref) {
+LLVMDIBuilderRef LLVMExtNewDIBuilder(LLVMModuleRef mref) {
   Module *m = unwrap(mref);
   return wrap(new DIBuilder(*m));
 }
 
-#if LLVM_VERSION_LE(5, 0)
-void LLVMDIBuilderFinalize(LLVMDIBuilderRef dref) { unwrap(dref)->finalize(); }
-#endif
+// Missing LLVMDIBuilderFinalize in LLVM <= 5.0
+void LLVMExtDIBuilderFinalize(LLVMDIBuilderRef dref) { unwrap(dref)->finalize(); }
 
-LLVMMetadataRef LLVMDIBuilderCreateFile2(DIBuilderRef Dref, const char *File,
-                                        const char *Dir) {
+LLVMMetadataRef LLVMExtDIBuilderCreateFile(
+    DIBuilderRef Dref, const char *File, const char *Dir) {
   return wrap(Dref->createFile(File, Dir));
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateCompileUnit2(DIBuilderRef Dref, unsigned Lang,
-                                               const char *File,
-                                               const char *Dir,
-                                               const char *Producer,
-                                               int Optimized,
-                                               const char *Flags,
-                                               unsigned RuntimeVersion) {
+LLVMMetadataRef LLVMExtDIBuilderCreateCompileUnit(
+    DIBuilderRef Dref, unsigned Lang, const char *File, const char *Dir,
+    const char *Producer, int Optimized, const char *Flags,
+    unsigned RuntimeVersion) {
 #if LLVM_VERSION_LE(3, 9)
   return wrap(Dref->createCompileUnit(Lang, File, Dir, Producer, Optimized,
                                       Flags, RuntimeVersion));
@@ -87,7 +83,7 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit2(DIBuilderRef Dref, unsigned Lang
 #endif
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateFunction2(
+LLVMMetadataRef LLVMExtDIBuilderCreateFunction(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     const char *LinkageName, LLVMMetadataRef File, unsigned Line,
     LLVMMetadataRef CompositeType, bool IsLocalToUnit, bool IsDefinition,
@@ -107,20 +103,16 @@ LLVMMetadataRef LLVMDIBuilderCreateFunction2(
   return wrap(Sub);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock2(DIBuilderRef Dref,
-                                                LLVMMetadataRef Scope,
-                                                LLVMMetadataRef File,
-                                                unsigned Line,
-                                                unsigned Column) {
+LLVMMetadataRef LLVMExtDIBuilderCreateLexicalBlock(
+    DIBuilderRef Dref, LLVMMetadataRef Scope, LLVMMetadataRef File,
+    unsigned Line, unsigned Column) {
   return wrap(Dref->createLexicalBlock(unwrapDI<DIDescriptor>(Scope),
                                        unwrapDI<DIFile>(File), Line, Column));
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateBasicType2(DIBuilderRef Dref,
-                                             const char *Name,
-                                             uint64_t SizeInBits,
-                                             uint64_t AlignInBits,
-                                             unsigned Encoding) {
+LLVMMetadataRef LLVMExtDIBuilderCreateBasicType(
+    DIBuilderRef Dref, const char *Name, uint64_t SizeInBits,
+    uint64_t AlignInBits, unsigned Encoding) {
 #if LLVM_VERSION_LE(3, 9)
   return wrap(Dref->createBasicType(Name, SizeInBits, AlignInBits, Encoding));
 #else
@@ -128,31 +120,28 @@ LLVMMetadataRef LLVMDIBuilderCreateBasicType2(DIBuilderRef Dref,
 #endif
 }
 
-LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray2(DIBuilderRef Dref,
-                                                  LLVMMetadataRef *Data,
-                                                  unsigned Length) {
+LLVMMetadataRef LLVMExtDIBuilderGetOrCreateTypeArray(
+    DIBuilderRef Dref, LLVMMetadataRef *Data, unsigned Length) {
   Metadata **DataValue = unwrap(Data);
   return wrap(
       Dref->getOrCreateTypeArray(ArrayRef<Metadata *>(DataValue, Length))
           .get());
 }
 
-LLVMMetadataRef LLVMDIBuilderGetOrCreateArray2(DIBuilderRef Dref,
-                                              LLVMMetadataRef *Data,
-                                              unsigned Length) {
+LLVMMetadataRef LLVMExtDIBuilderGetOrCreateArray(
+    DIBuilderRef Dref, LLVMMetadataRef *Data, unsigned Length) {
   Metadata **DataValue = unwrap(Data);
   return wrap(
       Dref->getOrCreateArray(ArrayRef<Metadata *>(DataValue, Length)).get());
 }
 
-LLVMMetadataRef
-LLVMDIBuilderCreateSubroutineType2(DIBuilderRef Dref, LLVMMetadataRef File,
-                                  LLVMMetadataRef ParameterTypes) {
+LLVMMetadataRef LLVMExtDIBuilderCreateSubroutineType(
+    DIBuilderRef Dref, LLVMMetadataRef File, LLVMMetadataRef ParameterTypes) {
   DISubroutineType *CT = Dref->createSubroutineType(DITypeRefArray(unwrap<MDTuple>(ParameterTypes)));
   return wrap(CT);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateAutoVariable2(
+LLVMMetadataRef LLVMExtDIBuilderCreateAutoVariable(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     LLVMMetadataRef File, unsigned Line, LLVMMetadataRef Ty,
     int AlwaysPreserve,
@@ -174,7 +163,7 @@ LLVMMetadataRef LLVMDIBuilderCreateAutoVariable2(
   return wrap(V);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateParameterVariable2(
+LLVMMetadataRef LLVMExtDIBuilderCreateParameterVariable(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     unsigned ArgNo, LLVMMetadataRef File, unsigned Line,
     LLVMMetadataRef Ty, int AlwaysPreserve,
@@ -190,12 +179,9 @@ LLVMMetadataRef LLVMDIBuilderCreateParameterVariable2(
   return wrap(V);
 }
 
-LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd2(DIBuilderRef Dref,
-                                             LLVMValueRef Storage,
-                                             LLVMMetadataRef VarInfo,
-                                             LLVMMetadataRef Expr,
-                                             LLVMValueRef DL,
-                                             LLVMBasicBlockRef Block) {
+LLVMValueRef LLVMExtDIBuilderInsertDeclareAtEnd(
+    DIBuilderRef Dref, LLVMValueRef Storage, LLVMMetadataRef VarInfo,
+    LLVMMetadataRef Expr, LLVMValueRef DL, LLVMBasicBlockRef Block) {
   Instruction *Instr =
     Dref->insertDeclare(unwrap(Storage), unwrap<DILocalVariable>(VarInfo),
                         unwrapDI<DIExpression>(Expr),
@@ -204,12 +190,12 @@ LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd2(DIBuilderRef Dref,
   return wrap(Instr);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateExpression2(DIBuilderRef Dref, int64_t *Addr,
-                                              size_t Length) {
+LLVMMetadataRef LLVMExtDIBuilderCreateExpression(
+    DIBuilderRef Dref, int64_t *Addr, size_t Length) {
   return wrap(Dref->createExpression(ArrayRef<int64_t>(Addr, Length)));
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateEnumerationType2(
+LLVMMetadataRef LLVMExtDIBuilderCreateEnumerationType(
     DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
     LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
     uint64_t AlignInBits, LLVMMetadataRef Elements,
@@ -221,27 +207,22 @@ LLVMMetadataRef LLVMDIBuilderCreateEnumerationType2(
   return wrap(enumType);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreateEnumerator(DIBuilderRef Dref,
-                                              const char *Name, int64_t Value) {
+LLVMMetadataRef LLVMExtDIBuilderCreateEnumerator(
+    DIBuilderRef Dref, const char *Name, int64_t Value) {
   DIEnumerator *e = Dref->createEnumerator(Name, Value);
   return wrap(e);
 }
 
-LLVMMetadataRef
-LLVMDIBuilderCreateStructType2(DIBuilderRef Dref,
-                              LLVMMetadataRef Scope,
-                              const char *Name,
-                              LLVMMetadataRef File,
-                              unsigned Line,
-                              uint64_t SizeInBits,
-                              uint64_t AlignInBits,
+LLVMMetadataRef LLVMExtDIBuilderCreateStructType(
+    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
+    LLVMMetadataRef File, unsigned Line, uint64_t SizeInBits,
+    uint64_t AlignInBits,
 #if LLVM_VERSION_LE(3, 9)
-                              unsigned Flags,
+    unsigned Flags,
 #else
-                              DINode::DIFlags Flags,
+    DINode::DIFlags Flags,
 #endif
-                              LLVMMetadataRef DerivedFrom,
-                              LLVMMetadataRef Elements) {
+    LLVMMetadataRef DerivedFrom, LLVMMetadataRef Elements) {
   DICompositeType *CT = Dref->createStructType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
       SizeInBits, AlignInBits, Flags, unwrapDI<DIType>(DerivedFrom),
@@ -249,13 +230,9 @@ LLVMDIBuilderCreateStructType2(DIBuilderRef Dref,
   return wrap(CT);
 }
 
-LLVMMetadataRef
-LLVMDIBuilderCreateReplaceableCompositeType2(DIBuilderRef Dref,
-                                            LLVMMetadataRef Scope,
-                                            const char *Name,
-                                            LLVMMetadataRef File,
-                                            unsigned Line)
-{
+LLVMMetadataRef LLVMExtDIBuilderCreateReplaceableCompositeType(
+  DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
+  LLVMMetadataRef File, unsigned Line) {
   DICompositeType *CT = Dref->createReplaceableCompositeType(llvm::dwarf::DW_TAG_structure_type,
                                                              Name,
                                                              unwrapDI<DIScope>(Scope),
@@ -264,11 +241,8 @@ LLVMDIBuilderCreateReplaceableCompositeType2(DIBuilderRef Dref,
   return wrap(CT);
 }
 
-void
-LLVMDIBuilderReplaceTemporary(DIBuilderRef Dref,
-                              LLVMMetadataRef From,
-                              LLVMMetadataRef To)
-{
+void LLVMExtDIBuilderReplaceTemporary(
+  DIBuilderRef Dref, LLVMMetadataRef From, LLVMMetadataRef To) {
   auto *Node = unwrap<MDNode>(From);
   auto *Type = unwrap<DIType>(To);
 
@@ -276,28 +250,24 @@ LLVMDIBuilderReplaceTemporary(DIBuilderRef Dref,
   Dref->replaceTemporary(std::move(fwd_decl), Type);
 }
 
-LLVMMetadataRef
-LLVMDIBuilderCreateMemberType2(DIBuilderRef Dref, LLVMMetadataRef Scope,
-                              const char *Name, LLVMMetadataRef File,
-                              unsigned Line, uint64_t SizeInBits,
-                              uint64_t AlignInBits, uint64_t OffsetInBits,
+LLVMMetadataRef LLVMExtDIBuilderCreateMemberType(
+    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name, LLVMMetadataRef File,
+    unsigned Line, uint64_t SizeInBits, uint64_t AlignInBits, uint64_t OffsetInBits,
 #if LLVM_VERSION_LE(3, 9)
-                              unsigned Flags,
+    unsigned Flags,
 #else
-                              DINode::DIFlags Flags,
+    DINode::DIFlags Flags,
 #endif
-                              LLVMMetadataRef Ty) {
+    LLVMMetadataRef Ty) {
   DIDerivedType *DT = Dref->createMemberType(
       unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
       SizeInBits, AlignInBits, OffsetInBits, Flags, unwrapDI<DIType>(Ty));
   return wrap(DT);
 }
 
-LLVMMetadataRef LLVMDIBuilderCreatePointerType2(DIBuilderRef Dref,
-                                               LLVMMetadataRef PointeeType,
-                                               uint64_t SizeInBits,
-                                               uint64_t AlignInBits,
-                                               const char *Name) {
+LLVMMetadataRef LLVMExtDIBuilderCreatePointerType(
+    DIBuilderRef Dref, LLVMMetadataRef PointeeType,
+    uint64_t SizeInBits, uint64_t AlignInBits, const char *Name) {
   DIDerivedType *T = Dref->createPointerType(unwrapDI<DIType>(PointeeType),
                                              SizeInBits, AlignInBits,
 #if LLVM_VERSION_GE(5, 0)
@@ -307,31 +277,31 @@ LLVMMetadataRef LLVMDIBuilderCreatePointerType2(DIBuilderRef Dref,
   return wrap(T);
 }
 
-LLVMMetadataRef LLVMTemporaryMDNode2(LLVMContextRef C, LLVMMetadataRef *MDs,
-                                    unsigned Count) {
+LLVMMetadataRef LLVMTemporaryMDNode2(
+    LLVMContextRef C, LLVMMetadataRef *MDs, unsigned Count) {
   return wrap(MDTuple::getTemporary(*unwrap(C),
                                     ArrayRef<Metadata *>(unwrap(MDs), Count))
                   .release());
 }
 
-void LLVMMetadataReplaceAllUsesWith2(LLVMMetadataRef MD, LLVMMetadataRef New) {
+void LLVMMetadataReplaceAllUsesWith2(
+  LLVMMetadataRef MD, LLVMMetadataRef New) {
   auto *Node = unwrap<MDNode>(MD);
   Node->replaceAllUsesWith(unwrap<MDNode>(New));
   MDNode::deleteTemporary(Node);
 }
 
-void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Bref, unsigned Line,
-                                  unsigned Col, LLVMMetadataRef Scope,
-                                  LLVMMetadataRef InlinedAt) {
+void LLVMExtSetCurrentDebugLocation(
+  LLVMBuilderRef Bref, unsigned Line, unsigned Col, LLVMMetadataRef Scope,
+  LLVMMetadataRef InlinedAt) {
   unwrap(Bref)->SetCurrentDebugLocation(
       DebugLoc::get(Line, Col, Scope ? unwrap<MDNode>(Scope) : nullptr,
                     InlinedAt ? unwrap<MDNode>(InlinedAt) : nullptr));
 }
 
-LLVMValueRef LLVMExtBuildCmpxchg(LLVMBuilderRef B,
-                               LLVMValueRef PTR, LLVMValueRef Cmp, LLVMValueRef New,
-                               LLVMAtomicOrdering SuccessOrdering,
-                               LLVMAtomicOrdering FailureOrdering) {
+LLVMValueRef LLVMExtBuildCmpxchg(
+    LLVMBuilderRef B, LLVMValueRef PTR, LLVMValueRef Cmp, LLVMValueRef New,
+    LLVMAtomicOrdering SuccessOrdering, LLVMAtomicOrdering FailureOrdering) {
   return wrap(unwrap(B)->CreateAtomicCmpXchg(unwrap(PTR), unwrap(Cmp), unwrap(New),
     (llvm::AtomicOrdering)SuccessOrdering, (llvm::AtomicOrdering)FailureOrdering));
 }
@@ -345,8 +315,9 @@ void LLVMExtSetOrdering(LLVMValueRef MemAccessInst, LLVMAtomicOrdering Ordering)
   return cast<StoreInst>(P)->setOrdering(O);
 }
 
-LLVMValueRef LLVMExtBuildCatchPad(LLVMBuilderRef B, LLVMValueRef ParentPad,
-                                  unsigned ArgCount, LLVMValueRef *LLArgs, const char *Name) {
+LLVMValueRef LLVMExtBuildCatchPad(
+    LLVMBuilderRef B, LLVMValueRef ParentPad, unsigned ArgCount,
+    LLVMValueRef *LLArgs, const char *Name) {
 #if LLVM_VERSION_GE(3, 8)
   Value **Args = unwrap(LLArgs);
   return wrap(unwrap(B)->CreateCatchPad(
@@ -356,9 +327,8 @@ LLVMValueRef LLVMExtBuildCatchPad(LLVMBuilderRef B, LLVMValueRef ParentPad,
 #endif
 }
 
-LLVMValueRef LLVMExtBuildCatchRet(LLVMBuilderRef B,
-                                  LLVMValueRef Pad,
-                                  LLVMBasicBlockRef BB) {
+LLVMValueRef LLVMExtBuildCatchRet(
+    LLVMBuilderRef B, LLVMValueRef Pad, LLVMBasicBlockRef BB) {
 #if LLVM_VERSION_GE(3, 8)
   return wrap(unwrap(B)->CreateCatchRet(cast<CatchPadInst>(unwrap(Pad)),
                                               unwrap(BB)));
@@ -367,11 +337,9 @@ LLVMValueRef LLVMExtBuildCatchRet(LLVMBuilderRef B,
 #endif
 }
 
-LLVMValueRef LLVMExtBuildCatchSwitch(LLVMBuilderRef B,
-                                     LLVMValueRef ParentPad,
-                                     LLVMBasicBlockRef BB,
-                                     unsigned NumHandlers,
-                                     const char *Name) {
+LLVMValueRef LLVMExtBuildCatchSwitch(
+    LLVMBuilderRef B, LLVMValueRef ParentPad, LLVMBasicBlockRef BB,
+    unsigned NumHandlers, const char *Name) {
 #if LLVM_VERSION_GE(3, 8)
   if (ParentPad == nullptr) {
     Type *Ty = Type::getTokenTy(unwrap(B)->getContext());
@@ -384,17 +352,15 @@ LLVMValueRef LLVMExtBuildCatchSwitch(LLVMBuilderRef B,
 #endif
 }
 
-void LLVMExtAddHandler(LLVMValueRef CatchSwitchRef,
-                       LLVMBasicBlockRef Handler) {
+void LLVMExtAddHandler(LLVMValueRef CatchSwitchRef, LLVMBasicBlockRef Handler) {
 #if LLVM_VERSION_GE(3, 8)
   Value *CatchSwitch = unwrap(CatchSwitchRef);
   cast<CatchSwitchInst>(CatchSwitch)->addHandler(unwrap(Handler));
 #endif
 }
 
-OperandBundleDef *LLVMExtBuildOperandBundleDef(const char *Name,
-                                                           LLVMValueRef *Inputs,
-                                                           unsigned NumInputs) {
+OperandBundleDef *LLVMExtBuildOperandBundleDef(
+    const char *Name, LLVMValueRef *Inputs, unsigned NumInputs) {
 #if LLVM_VERSION_GE(3, 8)
   return new OperandBundleDef(Name, makeArrayRef(unwrap(Inputs), NumInputs));
 #else
@@ -402,10 +368,9 @@ OperandBundleDef *LLVMExtBuildOperandBundleDef(const char *Name,
 #endif
 }
 
-LLVMValueRef LLVMExtBuildCall(LLVMBuilderRef B, LLVMValueRef Fn,
-                                          LLVMValueRef *Args, unsigned NumArgs,
-                                          OperandBundleDef *Bundle,
-                                          const char *Name) {
+LLVMValueRef LLVMExtBuildCall(
+    LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args, unsigned NumArgs,
+    OperandBundleDef *Bundle, const char *Name) {
 #if LLVM_VERSION_GE(3, 8)
   unsigned Len = Bundle ? 1 : 0;
   ArrayRef<OperandBundleDef> Bundles = makeArrayRef(Bundle, Len);
@@ -416,10 +381,10 @@ LLVMValueRef LLVMExtBuildCall(LLVMBuilderRef B, LLVMValueRef Fn,
 #endif
 }
 
-LLVMValueRef LLVMExtBuildInvoke(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args,
-                    unsigned NumArgs, LLVMBasicBlockRef Then,
-                    LLVMBasicBlockRef Catch, OperandBundleDef *Bundle,
-                    const char *Name) {
+LLVMValueRef LLVMExtBuildInvoke(
+    LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef *Args, unsigned NumArgs,
+    LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, OperandBundleDef *Bundle,
+    const char *Name) {
 #if LLVM_VERSION_GE(3, 8)
   unsigned Len = Bundle ? 1 : 0;
   ArrayRef<OperandBundleDef> Bundles = makeArrayRef(Bundle, Len);
@@ -431,7 +396,7 @@ LLVMValueRef LLVMExtBuildInvoke(LLVMBuilderRef B, LLVMValueRef Fn, LLVMValueRef 
 #endif
 }
 
-void LLVMWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
+void LLVMExtWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
 #if LLVM_VERSION_GE(4, 0)
   // https://github.com/ldc-developers/ldc/pull/1840/files
   Module *m = unwrap(mref);
@@ -449,13 +414,10 @@ void LLVMWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
 #endif
 }
 
-// LLVMNormalizeTargetTriple is available from LLVM in LLVM 7 and up,
-// in lower releases, we emulate it.
-#if LLVM_VERSION_LE(6, 0)
-char *LLVMNormalizeTargetTriple(const char* triple) {
-    return strdup(Triple::normalize(StringRef(triple)).c_str());
+// Missing LLVMNormalizeTargetTriple in LLVM <= 7.0
+char *LLVMExtNormalizeTargetTriple(const char* triple) {
+  return strdup(Triple::normalize(StringRef(triple)).c_str());
 }
-#endif
 
 char *LLVMExtBasicBlockName(LLVMBasicBlockRef BB) {
 #if LLVM_VERSION_GE(4, 0)

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -37,6 +37,7 @@ end
 
 {% begin %}
   lib LibLLVM
+    IS_71 = {{LibLLVM::VERSION.starts_with?("7.1")}}
     IS_70 = {{LibLLVM::VERSION.starts_with?("7.0")}}
     IS_60 = {{LibLLVM::VERSION.starts_with?("6.0")}}
     IS_50 = {{LibLLVM::VERSION.starts_with?("5.0")}}

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -172,6 +172,7 @@ lib LibLLVM
   fun get_insert_block = LLVMGetInsertBlock(builder : BuilderRef) : BasicBlockRef
   fun get_named_function = LLVMGetNamedFunction(mod : ModuleRef, name : UInt8*) : ValueRef
   fun get_named_global = LLVMGetNamedGlobal(mod : ModuleRef, name : UInt8*) : ValueRef
+  fun get_count_params = LLVMCountParams(fn : ValueRef) : UInt
   fun get_param = LLVMGetParam(fn : ValueRef, index : Int32) : ValueRef
   fun get_param_types = LLVMGetParamTypes(function_type : TypeRef, dest : TypeRef*)
   fun get_params = LLVMGetParams(fn : ValueRef, params : ValueRef*)
@@ -368,6 +369,14 @@ lib LibLLVM
 
   fun const_int_get_sext_value = LLVMConstIntGetSExtValue(ValueRef) : Int64
   fun const_int_get_zext_value = LLVMConstIntGetZExtValue(ValueRef) : UInt64
+
+  fun get_num_operands = LLVMGetNumOperands(val : ValueRef) : Int32
+  fun get_operand = LLVMGetOperand(val : ValueRef, index : UInt) : ValueRef
+
+  fun get_num_arg_operands = LLVMGetNumArgOperands(instr : ValueRef) : UInt
+  fun get_arg_operand = LLVMGetArgOperand(val : ValueRef, index : UInt) : ValueRef
+
+  fun set_instr_param_alignment = LLVMSetInstrParamAlignment(instr : ValueRef, index : UInt, align : UInt)
 
   fun set_param_alignment = LLVMSetParamAlignment(arg : ValueRef, align : UInt)
 end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -37,6 +37,7 @@ end
 
 {% begin %}
   lib LibLLVM
+    IS_70 = {{LibLLVM::VERSION.starts_with?("7.0")}}
     IS_60 = {{LibLLVM::VERSION.starts_with?("6.0")}}
     IS_50 = {{LibLLVM::VERSION.starts_with?("5.0")}}
     IS_40 = {{LibLLVM::VERSION.starts_with?("4.0")}}

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -2,6 +2,10 @@
 lib LibLLVM
   LLVM_CONFIG = {{
                   `[ -n "$LLVM_CONFIG" ] && command -v "$LLVM_CONFIG" || \
+                   command -v llvm-config-7 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.1*) command -v llvm-config;; *) false;; esac)) || \
+                   command -v llvm-config-7.0 || command -v llvm-config70 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-6.0 || command -v llvm-config60 || \
                    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 6.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-5.0 || command -v llvm-config50 || \

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -44,6 +44,8 @@ end
     IS_40 = {{LibLLVM::VERSION.starts_with?("4.0")}}
     IS_39 = {{LibLLVM::VERSION.starts_with?("3.9")}}
     IS_38 = {{LibLLVM::VERSION.starts_with?("3.8")}}
+
+    IS_LT_70 = IS_38 || IS_39 || IS_40 || IS_50 || IS_60
   end
 {% end %}
 
@@ -366,4 +368,6 @@ lib LibLLVM
 
   fun const_int_get_sext_value = LLVMConstIntGetSExtValue(ValueRef) : Int64
   fun const_int_get_zext_value = LLVMConstIntGetZExtValue(ValueRef) : UInt64
+
+  fun set_param_alignment = LLVMSetParamAlignment(arg : ValueRef, align : UInt)
 end

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -13,7 +13,7 @@ lib LibLLVMExt
   fun create_di_builder = LLVMNewDIBuilder(LibLLVM::ModuleRef) : DIBuilder
   fun di_builder_finalize = LLVMDIBuilderFinalize(DIBuilder)
 
-  fun di_builder_create_function = LLVMDIBuilderCreateFunction(
+  fun di_builder_create_function = LLVMDIBuilderCreateFunction2(
     builder : DIBuilder, scope : Metadata, name : Char*,
     linkage_name : Char*, file : Metadata, line : UInt,
     composite_type : Metadata, is_local_to_unit : Bool, is_definition : Bool,
@@ -27,19 +27,19 @@ lib LibLLVMExt
                                                                        producer : Char*,
                                                                        optimized : Int, flags : Char*,
                                                                        runtime_version : UInt) : Metadata
-  fun di_builder_create_lexical_block = LLVMDIBuilderCreateLexicalBlock(builder : DIBuilder,
+  fun di_builder_create_lexical_block = LLVMDIBuilderCreateLexicalBlock2(builder : DIBuilder,
                                                                         scope : Metadata,
                                                                         file : Metadata,
                                                                         line : Int,
                                                                         column : Int) : Metadata
 
-  fun di_builder_create_basic_type = LLVMDIBuilderCreateBasicType(builder : DIBuilder,
+  fun di_builder_create_basic_type = LLVMDIBuilderCreateBasicType2(builder : DIBuilder,
                                                                   name : Char*,
                                                                   size_in_bits : UInt64,
                                                                   align_in_bits : UInt64,
                                                                   encoding : UInt) : Metadata
 
-  fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable(builder : DIBuilder,
+  fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable2(builder : DIBuilder,
                                                                         scope : Metadata,
                                                                         name : Char*,
                                                                         file : Metadata, line : UInt,
@@ -48,46 +48,46 @@ lib LibLLVMExt
                                                                         flags : LLVM::DIFlags,
                                                                         align_in_bits : UInt32) : Metadata
 
-  fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable(builder : DIBuilder,
+  fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable2(builder : DIBuilder,
                                                                                   scope : Metadata,
                                                                                   name : Char*, arg_no : UInt,
                                                                                   file : Metadata, line : UInt, type : Metadata,
                                                                                   always_preserve : Int, flags : LLVM::DIFlags) : Metadata
 
-  fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
+  fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd2(builder : DIBuilder,
                                                                          storage : LibLLVM::ValueRef,
                                                                          var_info : Metadata,
                                                                          expr : Metadata,
                                                                          dl : LibLLVM::ValueRef,
                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
 
-  fun di_builder_create_expression = LLVMDIBuilderCreateExpression(builder : DIBuilder,
+  fun di_builder_create_expression = LLVMDIBuilderCreateExpression2(builder : DIBuilder,
                                                                    addr : Int64*, length : SizeT) : Metadata
 
-  fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
+  fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
   fun di_builder_create_enumerator = LLVMDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : Metadata
-  fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType(builder : DIBuilder,
+  fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType2(builder : DIBuilder,
                                                                               scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
                                                                               size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
 
-  fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
-  fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
+  fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
+  fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType2(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
 
-  fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType(builder : DIBuilder,
+  fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType2(builder : DIBuilder,
                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
                                                                     align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
 
-  fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType(builder : DIBuilder,
+  fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType2(builder : DIBuilder,
                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
                                                                     align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
 
-  fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType(builder : DIBuilder,
+  fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType2(builder : DIBuilder,
                                                                       pointee_type : Metadata,
                                                                       size_in_bits : UInt64,
                                                                       align_in_bits : UInt64,
                                                                       name : Char*) : Metadata
 
-  fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
+  fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType2(builder : DIBuilder,
                                                                                                  scope : Metadata,
                                                                                                  name : Char*,
                                                                                                  file : Metadata,

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -28,70 +28,70 @@ lib LibLLVMExt
                                                                        optimized : Int, flags : Char*,
                                                                        runtime_version : UInt) : Metadata
   fun di_builder_create_lexical_block = LLVMDIBuilderCreateLexicalBlock2(builder : DIBuilder,
-                                                                        scope : Metadata,
-                                                                        file : Metadata,
-                                                                        line : Int,
-                                                                        column : Int) : Metadata
+                                                                         scope : Metadata,
+                                                                         file : Metadata,
+                                                                         line : Int,
+                                                                         column : Int) : Metadata
 
   fun di_builder_create_basic_type = LLVMDIBuilderCreateBasicType2(builder : DIBuilder,
-                                                                  name : Char*,
-                                                                  size_in_bits : UInt64,
-                                                                  align_in_bits : UInt64,
-                                                                  encoding : UInt) : Metadata
+                                                                   name : Char*,
+                                                                   size_in_bits : UInt64,
+                                                                   align_in_bits : UInt64,
+                                                                   encoding : UInt) : Metadata
 
   fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable2(builder : DIBuilder,
-                                                                        scope : Metadata,
-                                                                        name : Char*,
-                                                                        file : Metadata, line : UInt,
-                                                                        type : Metadata,
-                                                                        always_preserve : Int,
-                                                                        flags : LLVM::DIFlags,
-                                                                        align_in_bits : UInt32) : Metadata
+                                                                         scope : Metadata,
+                                                                         name : Char*,
+                                                                         file : Metadata, line : UInt,
+                                                                         type : Metadata,
+                                                                         always_preserve : Int,
+                                                                         flags : LLVM::DIFlags,
+                                                                         align_in_bits : UInt32) : Metadata
 
   fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable2(builder : DIBuilder,
-                                                                                  scope : Metadata,
-                                                                                  name : Char*, arg_no : UInt,
-                                                                                  file : Metadata, line : UInt, type : Metadata,
-                                                                                  always_preserve : Int, flags : LLVM::DIFlags) : Metadata
+                                                                                   scope : Metadata,
+                                                                                   name : Char*, arg_no : UInt,
+                                                                                   file : Metadata, line : UInt, type : Metadata,
+                                                                                   always_preserve : Int, flags : LLVM::DIFlags) : Metadata
 
   fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd2(builder : DIBuilder,
-                                                                         storage : LibLLVM::ValueRef,
-                                                                         var_info : Metadata,
-                                                                         expr : Metadata,
-                                                                         dl : LibLLVM::ValueRef,
-                                                                         block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
+                                                                          storage : LibLLVM::ValueRef,
+                                                                          var_info : Metadata,
+                                                                          expr : Metadata,
+                                                                          dl : LibLLVM::ValueRef,
+                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
 
   fun di_builder_create_expression = LLVMDIBuilderCreateExpression2(builder : DIBuilder,
-                                                                   addr : Int64*, length : SizeT) : Metadata
+                                                                    addr : Int64*, length : SizeT) : Metadata
 
   fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
   fun di_builder_create_enumerator = LLVMDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : Metadata
   fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType2(builder : DIBuilder,
-                                                                              scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
-                                                                              size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
+                                                                               scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
+                                                                               size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
 
   fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
   fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType2(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
 
   fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType2(builder : DIBuilder,
-                                                                    scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
-                                                                    align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
+                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
+                                                                     align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
 
   fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType2(builder : DIBuilder,
-                                                                    scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
-                                                                    align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
+                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
+                                                                     align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
 
   fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType2(builder : DIBuilder,
-                                                                      pointee_type : Metadata,
-                                                                      size_in_bits : UInt64,
-                                                                      align_in_bits : UInt64,
-                                                                      name : Char*) : Metadata
+                                                                       pointee_type : Metadata,
+                                                                       size_in_bits : UInt64,
+                                                                       align_in_bits : UInt64,
+                                                                       name : Char*) : Metadata
 
   fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType2(builder : DIBuilder,
-                                                                                                 scope : Metadata,
-                                                                                                 name : Char*,
-                                                                                                 file : Metadata,
-                                                                                                 line : UInt) : Metadata
+                                                                                                  scope : Metadata,
+                                                                                                  name : Char*,
+                                                                                                  file : Metadata,
+                                                                                                  line : UInt) : Metadata
   fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
 
   fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, Int, Int, Metadata, Metadata)

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -10,91 +10,91 @@ lib LibLLVMExt
   type Metadata = Void*
   type OperandBundleDefRef = Void*
 
-  fun create_di_builder = LLVMNewDIBuilder(LibLLVM::ModuleRef) : DIBuilder
-  fun di_builder_finalize = LLVMDIBuilderFinalize(DIBuilder)
+  fun create_di_builder = LLVMExtNewDIBuilder(LibLLVM::ModuleRef) : DIBuilder
+  fun di_builder_finalize = LLVMExtDIBuilderFinalize(DIBuilder)
 
-  fun di_builder_create_function = LLVMDIBuilderCreateFunction2(
+  fun di_builder_create_function = LLVMExtDIBuilderCreateFunction(
     builder : DIBuilder, scope : Metadata, name : Char*,
     linkage_name : Char*, file : Metadata, line : UInt,
     composite_type : Metadata, is_local_to_unit : Bool, is_definition : Bool,
     scope_line : UInt, flags : LLVM::DIFlags, is_optimized : Bool, func : LibLLVM::ValueRef
   ) : Metadata
 
-  fun di_builder_create_file = LLVMDIBuilderCreateFile2(builder : DIBuilder, file : Char*, dir : Char*) : Metadata
-  fun di_builder_create_compile_unit = LLVMDIBuilderCreateCompileUnit2(builder : DIBuilder,
-                                                                       lang : UInt, file : Char*,
-                                                                       dir : Char*,
-                                                                       producer : Char*,
-                                                                       optimized : Int, flags : Char*,
-                                                                       runtime_version : UInt) : Metadata
-  fun di_builder_create_lexical_block = LLVMDIBuilderCreateLexicalBlock2(builder : DIBuilder,
-                                                                         scope : Metadata,
-                                                                         file : Metadata,
-                                                                         line : Int,
-                                                                         column : Int) : Metadata
+  fun di_builder_create_file = LLVMExtDIBuilderCreateFile(builder : DIBuilder, file : Char*, dir : Char*) : Metadata
+  fun di_builder_create_compile_unit = LLVMExtDIBuilderCreateCompileUnit(builder : DIBuilder,
+                                                                         lang : UInt, file : Char*,
+                                                                         dir : Char*,
+                                                                         producer : Char*,
+                                                                         optimized : Int, flags : Char*,
+                                                                         runtime_version : UInt) : Metadata
+  fun di_builder_create_lexical_block = LLVMExtDIBuilderCreateLexicalBlock(builder : DIBuilder,
+                                                                           scope : Metadata,
+                                                                           file : Metadata,
+                                                                           line : Int,
+                                                                           column : Int) : Metadata
 
-  fun di_builder_create_basic_type = LLVMDIBuilderCreateBasicType2(builder : DIBuilder,
-                                                                   name : Char*,
-                                                                   size_in_bits : UInt64,
-                                                                   align_in_bits : UInt64,
-                                                                   encoding : UInt) : Metadata
+  fun di_builder_create_basic_type = LLVMExtDIBuilderCreateBasicType(builder : DIBuilder,
+                                                                     name : Char*,
+                                                                     size_in_bits : UInt64,
+                                                                     align_in_bits : UInt64,
+                                                                     encoding : UInt) : Metadata
 
-  fun di_builder_create_auto_variable = LLVMDIBuilderCreateAutoVariable2(builder : DIBuilder,
-                                                                         scope : Metadata,
-                                                                         name : Char*,
-                                                                         file : Metadata, line : UInt,
-                                                                         type : Metadata,
-                                                                         always_preserve : Int,
-                                                                         flags : LLVM::DIFlags,
-                                                                         align_in_bits : UInt32) : Metadata
+  fun di_builder_create_auto_variable = LLVMExtDIBuilderCreateAutoVariable(builder : DIBuilder,
+                                                                           scope : Metadata,
+                                                                           name : Char*,
+                                                                           file : Metadata, line : UInt,
+                                                                           type : Metadata,
+                                                                           always_preserve : Int,
+                                                                           flags : LLVM::DIFlags,
+                                                                           align_in_bits : UInt32) : Metadata
 
-  fun di_builder_create_parameter_variable = LLVMDIBuilderCreateParameterVariable2(builder : DIBuilder,
-                                                                                   scope : Metadata,
-                                                                                   name : Char*, arg_no : UInt,
-                                                                                   file : Metadata, line : UInt, type : Metadata,
-                                                                                   always_preserve : Int, flags : LLVM::DIFlags) : Metadata
+  fun di_builder_create_parameter_variable = LLVMExtDIBuilderCreateParameterVariable(builder : DIBuilder,
+                                                                                     scope : Metadata,
+                                                                                     name : Char*, arg_no : UInt,
+                                                                                     file : Metadata, line : UInt, type : Metadata,
+                                                                                     always_preserve : Int, flags : LLVM::DIFlags) : Metadata
 
-  fun di_builder_insert_declare_at_end = LLVMDIBuilderInsertDeclareAtEnd2(builder : DIBuilder,
-                                                                          storage : LibLLVM::ValueRef,
-                                                                          var_info : Metadata,
-                                                                          expr : Metadata,
-                                                                          dl : LibLLVM::ValueRef,
-                                                                          block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
+  fun di_builder_insert_declare_at_end = LLVMExtDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
+                                                                            storage : LibLLVM::ValueRef,
+                                                                            var_info : Metadata,
+                                                                            expr : Metadata,
+                                                                            dl : LibLLVM::ValueRef,
+                                                                            block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
 
-  fun di_builder_create_expression = LLVMDIBuilderCreateExpression2(builder : DIBuilder,
-                                                                    addr : Int64*, length : SizeT) : Metadata
+  fun di_builder_create_expression = LLVMExtDIBuilderCreateExpression(builder : DIBuilder,
+                                                                      addr : Int64*, length : SizeT) : Metadata
 
-  fun di_builder_get_or_create_array = LLVMDIBuilderGetOrCreateArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
-  fun di_builder_create_enumerator = LLVMDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : Metadata
-  fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType2(builder : DIBuilder,
-                                                                               scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
-                                                                               size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
+  fun di_builder_get_or_create_array = LLVMExtDIBuilderGetOrCreateArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
+  fun di_builder_create_enumerator = LLVMExtDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : Metadata
+  fun di_builder_create_enumeration_type = LLVMExtDIBuilderCreateEnumerationType(builder : DIBuilder,
+                                                                                 scope : Metadata, name : Char*, file : Metadata, line_number : UInt,
+                                                                                 size_in_bits : UInt64, align_in_bits : UInt64, elements : Metadata, underlying_type : Metadata) : Metadata
 
-  fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray2(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
-  fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType2(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
+  fun di_builder_get_or_create_type_array = LLVMExtDIBuilderGetOrCreateTypeArray(builder : DIBuilder, data : Metadata*, length : SizeT) : Metadata
+  fun di_builder_create_subroutine_type = LLVMExtDIBuilderCreateSubroutineType(builder : DIBuilder, file : Metadata, parameter_types : Metadata) : Metadata
 
-  fun di_builder_create_struct_type = LLVMDIBuilderCreateStructType2(builder : DIBuilder,
-                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
-                                                                     align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
+  fun di_builder_create_struct_type = LLVMExtDIBuilderCreateStructType(builder : DIBuilder,
+                                                                       scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
+                                                                       align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : Metadata, element_types : Metadata) : Metadata
 
-  fun di_builder_create_member_type = LLVMDIBuilderCreateMemberType2(builder : DIBuilder,
-                                                                     scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
-                                                                     align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
+  fun di_builder_create_member_type = LLVMExtDIBuilderCreateMemberType(builder : DIBuilder,
+                                                                       scope : Metadata, name : Char*, file : Metadata, line : UInt, size_in_bits : UInt64,
+                                                                       align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : Metadata) : Metadata
 
-  fun di_builder_create_pointer_type = LLVMDIBuilderCreatePointerType2(builder : DIBuilder,
-                                                                       pointee_type : Metadata,
-                                                                       size_in_bits : UInt64,
-                                                                       align_in_bits : UInt64,
-                                                                       name : Char*) : Metadata
+  fun di_builder_create_pointer_type = LLVMExtDIBuilderCreatePointerType(builder : DIBuilder,
+                                                                         pointee_type : Metadata,
+                                                                         size_in_bits : UInt64,
+                                                                         align_in_bits : UInt64,
+                                                                         name : Char*) : Metadata
 
-  fun di_builder_create_replaceable_composite_type = LLVMDIBuilderCreateReplaceableCompositeType2(builder : DIBuilder,
-                                                                                                  scope : Metadata,
-                                                                                                  name : Char*,
-                                                                                                  file : Metadata,
-                                                                                                  line : UInt) : Metadata
-  fun di_builder_replace_temporary = LLVMDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
+  fun di_builder_create_replaceable_composite_type = LLVMExtDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
+                                                                                                    scope : Metadata,
+                                                                                                    name : Char*,
+                                                                                                    file : Metadata,
+                                                                                                    line : UInt) : Metadata
+  fun di_builder_replace_temporary = LLVMExtDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
 
-  fun set_current_debug_location = LLVMSetCurrentDebugLocation2(LibLLVM::BuilderRef, Int, Int, Metadata, Metadata)
+  fun set_current_debug_location = LLVMExtSetCurrentDebugLocation(LibLLVM::BuilderRef, Int, Int, Metadata, Metadata)
 
   fun build_cmpxchg = LLVMExtBuildCmpxchg(builder : LibLLVM::BuilderRef, pointer : LibLLVM::ValueRef, cmp : LibLLVM::ValueRef, new : LibLLVM::ValueRef, success_ordering : LLVM::AtomicOrdering, failure_ordering : LLVM::AtomicOrdering) : LibLLVM::ValueRef
   fun set_ordering = LLVMExtSetOrdering(value : LibLLVM::ValueRef, ordering : LLVM::AtomicOrdering)
@@ -134,10 +134,10 @@ lib LibLLVMExt
                                         name : LibC::Char*) : LibLLVM::ValueRef
 
   {% unless LibLLVM::IS_38 || LibLLVM::IS_39 %}
-    fun write_bitcode_with_summary_to_file = LLVMWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
+    fun write_bitcode_with_summary_to_file = LLVMExtWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
   {% end %}
 
-  fun normalize_target_triple = LLVMNormalizeTargetTriple(triple : Char*) : Char*
+  fun normalize_target_triple = LLVMExtNormalizeTargetTriple(triple : Char*) : Char*
 
   fun basic_block_name = LLVMExtBasicBlockName(basic_block : LibLLVM::BasicBlockRef) : Char*
 end

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -243,7 +243,7 @@ struct Pointer(T)
     raise ArgumentError.new("Negative count") if count < 0
 
     if self.class == source.class
-      Intrinsics.memcpy(self.as(Void*), source.as(Void*), bytesize(count), 0_u32, false)
+      Intrinsics.memcpy(self.as(Void*), source.as(Void*), bytesize(count), false)
     else
       while (count -= 1) >= 0
         self[count] = source[count]
@@ -256,7 +256,7 @@ struct Pointer(T)
     raise ArgumentError.new("Negative count") if count < 0
 
     if self.class == source.class
-      Intrinsics.memmove(self.as(Void*), source.as(Void*), bytesize(count), 0_u32, false)
+      Intrinsics.memmove(self.as(Void*), source.as(Void*), bytesize(count), false)
     else
       if source.address < address
         copy_from source, count
@@ -500,7 +500,7 @@ struct Pointer(T)
   # ptr.to_slice(6) # => Slice[0, 0, 0, 13, 14, 15]
   # ```
   def clear(count = 1)
-    Intrinsics.memset(self.as(Void*), 0_u8, bytesize(count), 0_u32, false)
+    Intrinsics.memset(self.as(Void*), 0_u8, bytesize(count), false)
   end
 
   def clone

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -37,6 +37,58 @@ private struct LEBReader
   end
 end
 
+private def traverse_eh_table(leb, start, ip, actions)
+  # Ref: https://chromium.googlesource.com/native_client/pnacl-libcxxabi/+/master/src/cxa_personality.cpp
+
+  throw_offset = ip - 1 - start
+  # puts "Personality - actions : #{actions}, start: #{start}, ip: #{ip}, throw_offset: #{throw_offset}"
+
+  lp_start_encoding = leb.read_uint8 # @LPStart encoding
+  if lp_start_encoding != 0xff_u8
+    LibC.dprintf 2, "Unexpected encoding for LPStart: #{lp_start_encoding}\n"
+    LibC.exit 1
+  end
+
+  if leb.read_uint8 != 0xff_u8 # @TType encoding
+    leb.read_uleb128           # @TType base offset
+  end
+
+  cs_encoding = leb.read_uint8 # CS Encoding (1: uleb128, 3: uint32)
+  if cs_encoding != 1 && cs_encoding != 3
+    LibC.dprintf 2, "Unexpected CS encoding: #{cs_encoding}\n"
+    LibC.exit 1
+  end
+
+  cs_table_length = leb.read_uleb128 # CS table length
+  cs_table_end = leb.data + cs_table_length
+
+  while leb.data < cs_table_end
+    cs_offset = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
+    cs_length = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
+    cs_addr = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
+    action = leb.read_uleb128
+    # puts "cs_offset: #{cs_offset}, cs_length: #{cs_length}, cs_addr: #{cs_addr}, action: #{action}"
+
+    if cs_addr != 0
+      if cs_offset <= throw_offset && throw_offset <= cs_offset + cs_length
+        if actions.includes? LibUnwind::Action::SEARCH_PHASE
+          # puts "found"
+          return LibUnwind::ReasonCode::HANDLER_FOUND
+        end
+
+        if actions.includes? LibUnwind::Action::HANDLER_FRAME
+          unwind_ip = start + cs_addr
+          yield unwind_ip
+          # puts "install"
+          return LibUnwind::ReasonCode::INSTALL_CONTEXT
+        end
+      end
+    end
+  end
+
+  return nil
+end
+
 {% if flag?(:win32) %}
   require "callstack/lib_unwind"
 
@@ -106,41 +158,14 @@ end
     lsd = __crystal_get_language_specific_data(ucb)
 
     ip = __crystal_unwind_get_ip(context)
-    throw_offset = ip - 1 - start
-
     leb = LEBReader.new(lsd)
-    leb.read_uint8               # @LPStart encoding
-    if leb.read_uint8 != 0xff_u8 # @TType encoding
-      leb.read_uleb128           # @TType base offset
+
+    reason = traverse_eh_table(leb, start, ip, actions) do |unwind_ip|
+      __crystal_unwind_set_gr(context, LibUnwind::EH_REGISTER_0, ucb.address.to_u32)
+      __crystal_unwind_set_gr(context, LibUnwind::EH_REGISTER_1, ucb.value.exception_type_id.to_u32)
+      __crystal_unwind_set_ip(context, unwind_ip)
     end
-    leb.read_uint8                     # CS Encoding
-    cs_table_length = leb.read_uleb128 # CS table length
-    cs_table_end = leb.data + cs_table_length
-
-    while leb.data < cs_table_end
-      cs_offset = leb.read_uint32
-      cs_length = leb.read_uint32
-      cs_addr = leb.read_uint32
-      action = leb.read_uleb128
-      #puts "cs_offset: #{cs_offset}, cs_length: #{cs_length}, cs_addr: #{cs_addr}, action: #{action}"
-
-      if cs_addr != 0
-        if cs_offset <= throw_offset && throw_offset <= cs_offset + cs_length
-          if actions.includes? LibUnwind::Action::SEARCH_PHASE
-            #puts "found"
-            return LibUnwind::ReasonCode::HANDLER_FOUND
-          end
-
-          if actions.includes? LibUnwind::Action::HANDLER_FRAME
-            __crystal_unwind_set_gr(context, LibUnwind::EH_REGISTER_0, ucb.address.to_u32)
-            __crystal_unwind_set_gr(context, LibUnwind::EH_REGISTER_1, ucb.value.exception_type_id.to_u32)
-            __crystal_unwind_set_ip(context, start + cs_addr)
-            #puts "install"
-            return LibUnwind::ReasonCode::INSTALL_CONTEXT
-          end
-        end
-      end
-    end
+    return reason if reason
 
     __crystal_continue_unwind
   end
@@ -149,56 +174,16 @@ end
   fun __crystal_personality(version : Int32, actions : LibUnwind::Action, exception_class : UInt64, exception_object : LibUnwind::Exception*, context : Void*) : LibUnwind::ReasonCode
     start = LibUnwind.get_region_start(context)
     ip = LibUnwind.get_ip(context)
-    throw_offset = ip - 1 - start
     lsd = LibUnwind.get_language_specific_data(context)
-    #puts "Personality - actions : #{actions}, start: #{start}, ip: #{ip}, throw_offset: #{throw_offset}"
 
     leb = LEBReader.new(lsd)
-    lp_start_encoding = leb.read_uint8 # @LPStart encoding
-    if lp_start_encoding != 0xff_u8
-      LibC.dprintf 2, "Unexpected encoding for LPStart: #{lp_start_encoding}\n"
-      LibC.exit 1
+    reason = traverse_eh_table(leb, start, ip, actions) do |unwind_ip|
+      LibUnwind.set_gr(context, LibUnwind::EH_REGISTER_0, exception_object.address)
+      LibUnwind.set_gr(context, LibUnwind::EH_REGISTER_1, exception_object.value.exception_type_id)
+      LibUnwind.set_ip(context, unwind_ip)
     end
+    return reason if reason
 
-    if leb.read_uint8 != 0xff_u8 # @TType encoding
-      leb.read_uleb128           # @TType base offset
-    end
-
-    cs_encoding = leb.read_uint8 # CS Encoding (1: uleb128, 3: uint32)
-    if cs_encoding != 1 && cs_encoding != 3
-      LibC.dprintf 2, "Unexpected CS encoding: #{cs_encoding}\n"
-      LibC.exit 1
-    end
-
-    cs_table_length = leb.read_uleb128 # CS table length
-    cs_table_end = leb.data + cs_table_length
-
-    while leb.data < cs_table_end
-      cs_offset = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
-      cs_length = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
-      cs_addr = cs_encoding == 3 ? leb.read_uint32 : leb.read_uleb128
-      action = leb.read_uleb128
-      #puts "cs_offset: #{cs_offset}, cs_length: #{cs_length}, cs_addr: #{cs_addr}, action: #{action}"
-
-      if cs_addr != 0
-        if cs_offset <= throw_offset && throw_offset <= cs_offset + cs_length
-          if actions.includes? LibUnwind::Action::SEARCH_PHASE
-            #puts "found"
-            return LibUnwind::ReasonCode::HANDLER_FOUND
-          end
-
-          if actions.includes? LibUnwind::Action::HANDLER_FRAME
-            LibUnwind.set_gr(context, LibUnwind::EH_REGISTER_0, exception_object.address)
-            LibUnwind.set_gr(context, LibUnwind::EH_REGISTER_1, exception_object.value.exception_type_id)
-            LibUnwind.set_ip(context, start + cs_addr)
-            #puts "install"
-            return LibUnwind::ReasonCode::INSTALL_CONTEXT
-          end
-        end
-      end
-    end
-
-    #puts "continue"
     return LibUnwind::ReasonCode::CONTINUE_UNWIND
   end
 {% end %}

--- a/src/string.cr
+++ b/src/string.cr
@@ -2569,7 +2569,7 @@ class String
       return ""
     elsif bytesize == 1
       return String.new(times) do |buffer|
-        Intrinsics.memset(buffer.as(Void*), to_unsafe[0], times, 0, false)
+        Intrinsics.memset(buffer.as(Void*), to_unsafe[0], times, false)
         {times, times}
       end
     end
@@ -3621,7 +3621,7 @@ class String
       end
 
       if count == 1
-        Intrinsics.memset(buffer.as(Void*), char.ord.to_u8, difference.to_u32, 0_u32, false)
+        Intrinsics.memset(buffer.as(Void*), char.ord.to_u8, difference.to_u32, false)
         buffer += difference
       else
         difference.times do


### PR DESCRIPTION
Fixes #6754

The issue with the exception handing was that the assumptions in the code traversing eh_table structures didn't hold in llvm-7 and the code didn't have assertions for them. They were harder to diagnose. The code is now extracted and reused for arm.