### PR TITLE
Add support for LLVM 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       <<: *env
       TRAVIS_OS_NAME: osx
     steps:
+      - run: echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> $BASH_ENV
       - restore_cache:
           keys:
             - brew-cache-v1

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ EXPORTS := \
 SHELL = sh
 LLVM_CONFIG_FINDER := \
   [ -n "$(LLVM_CONFIG)" ] && command -v "$(LLVM_CONFIG)" || \
+  command -v llvm-config-8 || command -v llvm-config-8.0 || command -v llvm-config80 || \
+    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 8.0*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-7 || \
     (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.1*) command -v llvm-config;; *) false;; esac)) || \
   command -v llvm-config-7.0 || command -v llvm-config70 || \

--- a/bin/ci
+++ b/bin/ci
@@ -89,9 +89,16 @@ prepare_build() {
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.29.0/crystal-0.29.0-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.29.0-1 crystal;popd'
 
-  on_osx brew install llvm@7 gmp libevent pcre pkg-config
+  on_osx brew install llvm@8 gmp libevent pcre pkg-config
   on_osx brew upgrade libyaml
-  on_osx brew link --force llvm@7
+  on_osx brew link --force llvm@8
+  # Note: brew link --force might show:
+  #   Warning: Refusing to link macOS-provided software: llvm
+  #
+  #   If you need to have llvm first in your PATH run:
+  #     echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
+  #
+  # This is added in the .circleci/config.yml
 
   on_tag verify_version
 }

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -95,10 +95,17 @@ LLVMMetadataRef LLVMExtDIBuilderCreateFunction(
 #endif
     bool IsOptimized,
     LLVMValueRef Func) {
+#if LLVM_VERSION_GE(8, 0)
+  DISubprogram *Sub = Dref->createFunction(
+      unwrapDI<DIScope>(Scope), StringRef(Name), StringRef(LinkageName), unwrapDI<DIFile>(File), Line,
+      unwrapDI<DISubroutineType>(CompositeType),
+      ScopeLine, Flags, DISubprogram::toSPFlags(IsLocalToUnit, IsDefinition, IsOptimized));
+#else
   DISubprogram *Sub = Dref->createFunction(
       unwrapDI<DIScope>(Scope), Name, LinkageName, unwrapDI<DIFile>(File), Line,
       unwrapDI<DISubroutineType>(CompositeType), IsLocalToUnit, IsDefinition,
       ScopeLine, Flags, IsOptimized);
+#endif
   unwrap<Function>(Func)->setSubprogram(Sub);
   return wrap(Sub);
 }

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -2,6 +2,8 @@
 lib LibLLVM
   LLVM_CONFIG = {{
                   `[ -n "$LLVM_CONFIG" ] && command -v "$LLVM_CONFIG" || \
+                   command -v llvm-config-8 || command -v llvm-config-8.0 || command -v llvm-config80 || \
+                   (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 8.0*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-7 || \
                    (command -v llvm-config > /dev/null && (case "$(llvm-config --version)" in 7.1*) command -v llvm-config;; *) false;; esac)) || \
                    command -v llvm-config-7.0 || command -v llvm-config70 || \
@@ -37,6 +39,7 @@ end
 
 {% begin %}
   lib LibLLVM
+    IS_80 = {{LibLLVM::VERSION.starts_with?("8.0")}}
     IS_71 = {{LibLLVM::VERSION.starts_with?("7.1")}}
     IS_70 = {{LibLLVM::VERSION.starts_with?("7.0")}}
     IS_60 = {{LibLLVM::VERSION.starts_with?("6.0")}}


### PR DESCRIPTION
~~The `IsLocalToUnit`, `IsDefinition`, `IsOptimized` were always used with the same values and the API regarding them changed in llvm 8.0.~~ 

Update: Use `DISubprogram::toSPFlags` to keep functionality & LibLLVMExt API

t - 2 months before llvm 9.0 is released.