### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 34f76b4dd6fa030f1fe5a89df9fe634dca1060a5
+          git checkout 7d45d71fc8085b9ffc512b18538055a0dcb85851
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This update will make darwin .tag.gz and .pkg official packages to use llvm 6.0.1 (instead of 3.9.1 👻)

This is not upgrading to llvm 8 since its support is landing in this very release.