### PR TITLE
Integer: Improve #gcd types and improve performance a bit.

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -334,19 +334,15 @@ describe "BigInt" do
     a_17 = a * 17
 
     (abc * b).gcd(abc * c).should eq(abc)
+    abc.gcd(a_17).should eq(a)
     (abc * b).lcm(abc * c).should eq(abc * b * c)
     (abc * b).gcd(abc * c).should be_a(BigInt)
 
     (a_17).gcd(17).should eq(17)
-    (17).gcd(a_17).should eq(17)
     (-a_17).gcd(17).should eq(17)
-    (-17).gcd(a_17).should eq(17)
 
     (a_17).gcd(17).should be_a(Int::Unsigned)
-    (17).gcd(a_17).should be_a(Int::Unsigned)
-
     (a_17).lcm(17).should eq(a_17)
-    (17).lcm(a_17).should eq(a_17)
   end
 
   it "can use Number::[]" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -136,6 +136,23 @@ describe "Int" do
     end
   end
 
+  describe "gcd" do
+    it { 14.gcd(0).should eq(14) }
+    it { 14.gcd(1).should eq(1) }
+    it { 10.gcd(75).should eq(5) }
+    it { 10.gcd(-75).should eq(5) }
+    it { -10.gcd(75).should eq(5) }
+
+    it { 7.gcd(5).should eq(1) }   # prime
+    it { 14.gcd(25).should eq(1) } # coprime
+    it { 24.gcd(40).should eq(8) } # common divisor
+
+    it "doesn't silently overflow" { 614_889_782_588_491_410_i64.gcd(53).should eq(1) }
+    it "raises on too big result to fit in result type" do
+      expect_raises(OverflowError, "Arithmetic overflow") { Int64::MIN.gcd(1) }
+    end
+  end
+
   describe "lcm" do
     it { 2.lcm(2).should eq(2) }
     it { 3.lcm(-7).should eq(21) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -395,10 +395,9 @@ struct Int
     (self & mask) == mask
   end
 
-  # Returns the greatest common divisor of `self` and `other` (which
-  # is an `Int` of some kind). The return type is whichever side can
-  # fit the biggest values. If either is signed and has value equal to
-  # `MIN` of its type, then overflow will be raised.
+  # Returns the greatest common divisor of `self` and `other`. Signed
+  # integers may raise overflow if either has value equal to `MIN` of
+  # its type.
   #
   # ```
   # 5.gcd(10) # => 2

--- a/src/int.cr
+++ b/src/int.cr
@@ -395,8 +395,47 @@ struct Int
     (self & mask) == mask
   end
 
-  def gcd(other : Int)
-    self == 0 ? other.abs : (other % self).gcd(self)
+  # Returns the greatest common divisor of `self` and `other` (which
+  # is an `Int` of some kind). The return type is whichever side can
+  # fit the biggest values. If either is signed and has value equal to
+  # `MIN` of its type, then overflow will be raised.
+  #
+  # ```
+  # 5.gcd(10) # => 2
+  # 5.gcd(7)  # => 1
+  # ```
+  def gcd(other : self) : self
+    u = self.abs
+    v = other.abs
+    shift = self.class.zero
+    return v if u == 0
+    return u if v == 0
+
+    # Let shift := lg K, where K is the greatest power of 2
+    # dividing both u and v.
+    while (u | v) & 1 == 0
+      shift &+= 1
+      u = u.unsafe_shr 1
+      v = v.unsafe_shr 1
+    end
+    while u & 1 == 0
+      u = u.unsafe_shr 1
+    end
+    # From here on, u is always odd.
+    loop do
+      # remove all factors of 2 in v -- they are not common
+      # note: v is not zero, so while will terminate
+      while v & 1 == 0
+        v = v.unsafe_shr 1
+      end
+      # Now u and v are both odd. Swap if necessary so u <= v,
+      # then set v = v - u (which is even).
+      u, v = v, u if u > v
+      v &-= u
+      break if v.zero?
+    end
+    # restore common factors of 2
+    u.unsafe_shl shift
   end
 
   def lcm(other : Int)

--- a/src/int.cr
+++ b/src/int.cr
@@ -399,6 +399,9 @@ struct Int
   # integers may raise overflow if either has value equal to `MIN` of
   # its type.
   #
+  # Implementation heavily inspired by
+  # https://en.wikipedia.org/wiki/Binary_GCD_algorithm#Iterative_version_in_C
+  #
   # ```
   # 5.gcd(10) # => 2
   # 5.gcd(7)  # => 1

--- a/src/int.cr
+++ b/src/int.cr
@@ -406,10 +406,10 @@ struct Int
   def gcd(other : self) : self
     u = self.abs
     v = other.abs
-    shift = self.class.zero
     return v if u == 0
     return u if v == 0
 
+    shift = self.class.zero
     # Let shift := lg K, where K is the greatest power of 2
     # dividing both u and v.
     while (u | v) & 1 == 0


### PR DESCRIPTION
This provide an implementation of binary gcd.
If called with different types, gcd will no longer respond with a
union type. EDIT: Now restricted to only accept the same type, to avoid method clutter. 

Also adds tests for gcd - previously only BigInt#gcd and #lcm had tests.

Alternative to #6694
Would resolve #6683