### PR TITLE
Improve URL encoding

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -8,6 +8,46 @@ private def assert_uri(string, file = __FILE__, line = __LINE__, **args)
   end
 end
 
+private def it_encodes(string, expected_result, file = __FILE__, line = __LINE__, **options)
+  it "encodes #{string.inspect}", file, line do
+    URI.encode(string, **options).should eq(expected_result), file, line
+
+    String.build do |io|
+      URI.encode(string, io, **options)
+    end.should eq(expected_result), file, line
+  end
+end
+
+private def it_decodes(string, expected_result, file = __FILE__, line = __LINE__, **options)
+  it "decodes #{string.inspect}", file, line do
+    URI.decode(string, **options).should eq(expected_result), file, line
+
+    String.build do |io|
+      URI.decode(string, io, **options)
+    end.should eq(expected_result), file, line
+  end
+end
+
+private def it_encodes_www_form(string, expected_result, file = __FILE__, line = __LINE__, **options)
+  it "encodes #{string.inspect}", file, line do
+    URI.encode_www_form(string, **options).should eq(expected_result), file, line
+
+    String.build do |io|
+      URI.encode_www_form(string, io, **options)
+    end.should eq(expected_result), file, line
+  end
+end
+
+private def it_decodes_www_form(string, expected_result, file = __FILE__, line = __LINE__, **options)
+  it "decodes #{string.inspect}", file, line do
+    URI.decode_www_form(string, **options).should eq(expected_result), file, line
+
+    String.build do |io|
+      URI.decode_www_form(string, io, **options)
+    end.should eq(expected_result), file, line
+  end
+end
+
 describe "URI" do
   describe ".parse" do
     # scheme
@@ -224,6 +264,7 @@ describe "URI" do
     it { URI.parse("http://www.example.com").userinfo.should be_nil }
     it { URI.parse("http://foo@www.example.com").userinfo.should eq("foo") }
     it { URI.parse("http://foo:bar@www.example.com").userinfo.should eq("foo:bar") }
+    it { URI.new(user: "ä /", password: "ö :").userinfo.should eq("%C3%A4+%2F:%C3%B6+%3A") }
   end
 
   describe "to_s" do
@@ -305,112 +346,96 @@ describe "URI" do
     end
   end
 
-  describe ".unescape" do
-    {
-      {"hello", "hello"},
-      {"hello%20world", "hello world"},
-      {"hello+world", "hello+world"},
-      {"hello%", "hello%"},
-      {"hello%2", "hello%2"},
-      {"hello%2B", "hello+"},
-      {"hello%2Bworld", "hello+world"},
-      {"hello%2%2Bworld", "hello%2+world"},
-      {"%E3%81%AA%E3%81%AA", "なな"},
-      {"%e3%81%aa%e3%81%aa", "なな"},
-      {"%27Stop%21%27+said+Fred", "'Stop!'+said+Fred"},
-    }.each do |(from, to)|
-      it "unescapes #{from}" do
-        URI.unescape(from).should eq(to)
-      end
+  describe ".decode" do
+    it_decodes("hello", "hello")
+    it_decodes("hello%20world", "hello world")
+    it_decodes("hello+world", "hello+world")
+    it_decodes("hello%", "hello%")
+    it_decodes("hello%2", "hello%2")
+    it_decodes("hello%2B", "hello+")
+    it_decodes("hello%2Bworld", "hello+world")
+    it_decodes("hello%2%2Bworld", "hello%2+world")
+    it_decodes("%E3%81%AA%E3%81%AA", "なな")
+    it_decodes("%e3%81%aa%e3%81%aa", "なな")
+    it_decodes("%27Stop%21%27+said+Fred", "'Stop!'+said+Fred")
+    it_decodes("hello+world", "hello world", plus_to_space: true)
+    it_decodes("+%2B %20", "++  ")
 
-      it "unescapes #{from} to IO" do
-        String.build do |str|
-          URI.unescape(from, str)
-        end.should eq(to)
-      end
-    end
-
-    it "unescapes plus to space" do
-      URI.unescape("hello+world", plus_to_space: true).should eq("hello world")
-      String.build do |str|
-        URI.unescape("hello+world", str, plus_to_space: true)
-      end.should eq("hello world")
-    end
-
-    it "does not unescape string when block returns true" do
-      URI.unescape("hello%26world") { |byte| URI.reserved? byte }
-        .should eq("hello%26world")
+    it "does not decode string when block returns true" do
+      String.build do |io|
+        URI.decode("hello%26world", io) { |byte| URI.reserved? byte }
+      end.should eq("hello%26world")
     end
   end
 
-  describe ".escape" do
-    [
-      {"hello", "hello"},
-      {"hello%20world", "hello world"},
-      {"hello%25", "hello%"},
-      {"hello%252", "hello%2"},
-      {"hello%2B", "hello+"},
-      {"hello%2Bworld", "hello+world"},
-      {"hello%252%2Bworld", "hello%2+world"},
-      {"%E3%81%AA%E3%81%AA", "なな"},
-      {"%27Stop%21%27%20said%20Fred", "'Stop!' said Fred"},
-      {"%0A", "\n"},
-    ].each do |(from, to)|
-      it "escapes #{to}" do
-        URI.escape(to).should eq(from)
-      end
+  describe ".encode" do
+    it_encodes("hello", "hello")
+    it_encodes("hello world", "hello%20world")
+    it_encodes("hello%", "hello%25")
+    it_encodes("hello%2", "hello%252")
+    it_encodes("hello+", "hello+")
+    it_encodes("hello+world", "hello+world")
+    it_encodes("hello%2+world", "hello%252+world")
+    it_encodes("なな", "%E3%81%AA%E3%81%AA")
+    it_encodes("'Stop!' said Fred", "'Stop!'%20said%20Fred")
+    it_encodes("\n", "%0A")
+    it_encodes("https://en.wikipedia.org/wiki/Crystal (programming language)", "https://en.wikipedia.org/wiki/Crystal%20(programming%20language)")
+    it_encodes("\xFF", "%FF") # encodes invalid UTF-8 character
+    it_encodes("hello world", "hello+world", space_to_plus: true)
+    it_encodes("'Stop!' said Fred", "'Stop!'+said+Fred", space_to_plus: true)
 
-      it "escapes #{to} to IO" do
-        String.build do |str|
-          URI.escape(to, str)
-        end.should eq(from)
-      end
-    end
-
-    describe "invalid utf8 strings" do
-      input = String.new(1) { |buf| buf.value = 255_u8; {1, 0} }
-
-      it "escapes without failing" do
-        URI.escape(input).should eq("%FF")
-      end
-
-      it "escapes to IO without failing" do
-        String.build do |str|
-          URI.escape(input, str)
-        end.should eq("%FF")
-      end
-    end
-
-    it "escape space to plus when space_to_plus flag is true" do
-      URI.escape("hello world", space_to_plus: true).should eq("hello+world")
-      URI.escape("'Stop!' said Fred", space_to_plus: true).should eq("%27Stop%21%27+said+Fred")
-    end
-
-    it "does not escape character when block returns true" do
-      URI.unescape("hello&world") { |byte| URI.reserved? byte }
-        .should eq("hello&world")
+    it "does not encode character when block returns true" do
+      String.build do |io|
+        URI.decode("hello&world", io) { |byte| URI.reserved? byte }
+      end.should eq("hello&world")
     end
   end
 
-  describe "reserved?" do
-    reserved_chars = Set.new([':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='])
+  describe ".encode_www_form" do
+    it_encodes_www_form("", "")
+    it_encodes_www_form("abc", "abc")
+    it_encodes_www_form("1%41", "1%2541")
+    it_encodes_www_form("a b+", "a+b%2B")
+    it_encodes_www_form("a b+", "a%20b%2B", space_to_plus: false)
+    it_encodes_www_form("10%", "10%25")
+    it_encodes_www_form(" ?&=#+%!<>#\"{}|\\^[]`☺\t:/@$'()*,;", "+%3F%26%3D%23%2B%25%21%3C%3E%23%22%7B%7D%7C%5C%5E%5B%5D%60%E2%98%BA%09%3A%2F%40%24%27%28%29%2A%2C%3B")
+    it_encodes_www_form("* foo=bar baz&hello/", "%2A+foo%3Dbar+baz%26hello%2F")
+  end
+
+  describe ".decode_www_form" do
+    it_decodes_www_form("", "")
+    it_decodes_www_form("abc", "abc")
+    it_decodes_www_form("1%41", "1A")
+    it_decodes_www_form("1%41%42%43", "1ABC")
+    it_decodes_www_form("%4a", "J")
+    it_encodes_www_form("hello+", "hello%2B")
+    it_encodes_www_form("hello+world", "hello%2Bworld")
+    it_encodes_www_form("hello%2+world", "hello%252%2Bworld")
+    it_encodes_www_form("'Stop!' said Fred", "%27Stop%21%27+said+Fred")
+    it_decodes_www_form("a+b", "a b")
+    it_decodes_www_form("a%20b", "a b")
+    it_decodes_www_form("%20%3F%26%3D%23%2B%25%21%3C%3E%23%22%7B%7D%7C%5C%5E%5B%5D%60%E2%98%BA%09%3A%2F%40%24%27%28%29%2A%2C%3B", " ?&=#+%!<>#\"{}|\\^[]`☺\t:/@$'()*,;")
+    it_decodes_www_form("+%2B %20", " +  ")
+
+    it_decodes_www_form("%", "%")
+    it_decodes_www_form("%1", "%1")
+    it_decodes_www_form("123%45%6", "123E%6")
+    it_decodes_www_form("%zzzzz", "%zzzzz")
+  end
+
+  it ".reserved?" do
+    reserved_chars = {':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
 
     ('\u{00}'..'\u{7F}').each do |char|
-      ok = reserved_chars.includes? char
-      it "should return #{ok} on given #{char}" do
-        URI.reserved?(char.ord.to_u8).should eq(ok)
-      end
+      URI.reserved?(char.ord.to_u8).should eq(reserved_chars.includes?(char))
     end
   end
 
-  describe "unreserved?" do
-    unreserved_chars = Set.new(('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '.', '-', '~'])
+  it ".unreserved?" do
+    unreserved_chars = ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '.', '-', '~']
 
     ('\u{00}'..'\u{7F}').each do |char|
-      ok = unreserved_chars.includes? char
-      it "should return #{ok} on given #{char}" do
-        URI.unreserved?(char.ord.to_u8).should eq(ok)
-      end
+      URI.unreserved?(char.ord.to_u8).should eq(unreserved_chars.includes?(char))
     end
   end
 end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -424,7 +424,7 @@ describe "URI" do
   end
 
   it ".reserved?" do
-    reserved_chars = {':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
+    reserved_chars = Set{':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
 
     ('\u{00}'..'\u{7F}').each do |char|
       URI.reserved?(char.ord.to_u8).should eq(reserved_chars.includes?(char))

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -39,7 +39,7 @@ class Crystal::Doc::Macro
   end
 
   def anchor
-    '#' + URI.escape(id)
+    '#' + URI.encode(id)
   end
 
   def prefix

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -102,7 +102,7 @@ class Crystal::Doc::Method
   end
 
   def anchor
-    "#" + URI.escape(id)
+    "#" + URI.encode(id)
   end
 
   def to_s(io : IO) : Nil

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -28,8 +28,8 @@ module HTTP
                    @expires : Time? = nil, @domain : String? = nil,
                    @secure : Bool = false, @http_only : Bool = false,
                    @samesite : SameSite? = nil, @extension : String? = nil)
-      @name = URI.unescape name
-      @value = URI.unescape value
+      @name = URI.decode_www_form name
+      @value = URI.decode_www_form value
     end
 
     def to_set_cookie_header
@@ -38,7 +38,7 @@ module HTTP
       domain = @domain
       samesite = @samesite
       String.build do |header|
-        header << "#{URI.escape @name}=#{URI.escape value}"
+        header << to_cookie_header
         header << "; domain=#{domain}" if domain
         header << "; path=#{path}" if path
         header << "; expires=#{HTTP.format_time(expires)}" if expires
@@ -50,7 +50,7 @@ module HTTP
     end
 
     def to_cookie_header
-      "#{@name}=#{URI.escape value}"
+      "#{URI.encode_www_form(@name)}=#{URI.encode_www_form(value)}"
     end
 
     def expired?

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -38,7 +38,7 @@ module HTTP
       domain = @domain
       samesite = @samesite
       String.build do |header|
-        header << to_cookie_header
+        to_cookie_header(header)
         header << "; domain=#{domain}" if domain
         header << "; path=#{path}" if path
         header << "; expires=#{HTTP.format_time(expires)}" if expires
@@ -50,7 +50,15 @@ module HTTP
     end
 
     def to_cookie_header
-      "#{URI.encode_www_form(@name)}=#{URI.encode_www_form(value)}"
+      String.build do |io|
+        to_cookie_header(io)
+      end
+    end
+
+    def to_cookie_header(io)
+      URI.encode_www_form(@name, io)
+      io << '='
+      URI.encode_www_form(value, io)
     end
 
     def expired?

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -114,7 +114,7 @@ module HTTP
     #
     # The yielded object has an `add` method that accepts two arguments,
     # a key (`String`) and a value (`String` or `Nil`).
-    # Keys and values are escaped using `URI#escape`.
+    # Keys and values are escaped using `URI.encode_www_form`.
     #
     # ```
     # require "http/params"
@@ -322,13 +322,8 @@ module HTTP
     end
 
     # :nodoc:
-    def self.encode_www_form_component(string : String, io : IO)
-      URI.escape(string, io, true)
-    end
-
-    # :nodoc:
     def self.decode_one_www_form_component(query, bytesize, i, byte, char, buffer)
-      URI.unescape_one query, bytesize, i, byte, char, buffer, true
+      URI.decode_one query, bytesize, i, byte, char, buffer, true
     end
 
     # HTTP params builder.
@@ -347,9 +342,9 @@ module HTTP
       def add(key, value : String?)
         @io << '&' unless @first
         @first = false
-        URI.escape key, @io
+        URI.encode_www_form key, @io
         @io << '='
-        Params.encode_www_form_component value, @io if value
+        URI.encode_www_form value, @io if value
         self
       end
 

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -37,7 +37,7 @@ class HTTP::StaticFileHandler
 
     original_path = context.request.path.not_nil!
     is_dir_path = original_path.ends_with? "/"
-    request_path = self.request_path(URI.unescape(original_path))
+    request_path = self.request_path(URI.decode(original_path))
 
     # File path cannot contains '\0' (NUL) because all filesystem I know
     # don't accept '\0' character as file name.
@@ -92,7 +92,7 @@ class HTTP::StaticFileHandler
   private def redirect_to(context, url)
     context.response.status = :found
 
-    url = URI.escape(url) { |byte| URI.unreserved?(byte) || byte.chr == '/' }
+    url = URI.encode(url)
     context.response.headers.add "Location", url
   end
 
@@ -132,7 +132,7 @@ class HTTP::StaticFileHandler
 
     def escaped_request_path
       @escaped_request_path ||= begin
-        esc_path = URI.escape(request_path) { |byte| URI.unreserved?(byte) || byte.chr == '/' }
+        esc_path = URI.encode(request_path)
         esc_path = esc_path.chomp('/')
         esc_path
       end

--- a/src/http/server/handlers/static_file_handler.html
+++ b/src/http/server/handlers/static_file_handler.html
@@ -9,7 +9,7 @@
     <ul>
       <% Dir.each_child(path) do |entry| %>
         <li>
-          <a href="<%= request_path == "/" ? "" : escaped_request_path %>/<%= URI.escape entry %>"><%= HTML.escape entry %></a>
+          <a href="<%= request_path == "/" ? "" : escaped_request_path %>/<%= URI.encode entry %>"><%= HTML.escape entry %></a>
         </li>
       <% end %>
     </ul>

--- a/src/oauth/authorization_header.cr
+++ b/src/oauth/authorization_header.cr
@@ -10,9 +10,9 @@ struct OAuth::AuthorizationHeader
     return unless value
 
     @str << ", " unless @first
-    @str << key
+    URI.encode_www_form key, @str
     @str << %(=")
-    URI.escape value, @str
+    URI.encode_www_form value, @str
     @str << '"'
     @first = false
   end

--- a/src/oauth/params.cr
+++ b/src/oauth/params.cr
@@ -6,7 +6,7 @@ struct OAuth::Params
 
   def add(key, value)
     if value
-      @params << {URI.escape(key), URI.escape(value)}
+      @params << {URI.encode_www_form(key, space_to_plus: false), URI.encode_www_form(value, space_to_plus: false)}
     end
   end
 
@@ -20,9 +20,9 @@ struct OAuth::Params
     @params.sort_by! &.[0]
     @params.each_with_index do |(key, value), i|
       io << "%26" if i > 0
-      URI.escape key, io
+      URI.encode_www_form key, io, space_to_plus: false
       io << "%3D"
-      URI.escape value, io
+      URI.encode_www_form value, io, space_to_plus: false
     end
   end
 end

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -9,10 +9,10 @@ struct OAuth::Signature
 
   def key
     String.build do |str|
-      URI.escape @client_shared_secret, str
+      URI.encode_www_form @client_shared_secret, str, space_to_plus: false
       str << '&'
       if token_shared_secret = @token_shared_secret
-        URI.escape token_shared_secret, str
+        URI.encode_www_form token_shared_secret, str, space_to_plus: false
       end
     end
   end
@@ -47,14 +47,14 @@ struct OAuth::Signature
       str << '&'
       str << (tls ? "https" : "http")
       str << "%3A%2F%2F"
-      URI.escape host, str
+      URI.encode_www_form host, str, space_to_plus: false
       if port
         str << "%3A"
         str << port
       end
       uri_path = request.path || "/"
       uri_path = "/" if uri_path.empty?
-      URI.escape(uri_path, str)
+      URI.encode_www_form(uri_path, str, space_to_plus: false)
       str << '&'
       str << params
     end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -40,8 +40,8 @@ require "./uri/encoding"
 # * `.encode_www_form(string : String, io : IO, *, space_to_plus : Bool = true) : Nil`: Encodes a string as a `x-www-form-urlencoded` component to an IO.
 #
 # The main difference is that `.encode_www_form` encodes reserved characters
-# (see `.reserved?`), while `.encode` does not. The decode methods are exactly
-# similar except for the handling of `+` characters.
+# (see `.reserved?`), while `.encode` does not. The decode methods are
+# identical except for the handling of `+` characters.
 #
 # NOTE: `HTTP::Params` provides a higher-level API for handling `x-www-form-urlencoded`
 # serialized data.

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -1,0 +1,300 @@
+class URI
+  # URL-decodes *string*.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.decode("hello%20world!")                                 # => "hello world!"
+  # URI.decode("put:%20it+%D0%B9")                               # => "put: it+й"
+  # URI.decode("http://example.com/Crystal%20is%20awesome%20=)") # => "http://example.com/Crystal is awesome =)"
+  # ```
+  #
+  # By default, `+` is decoded literally. If *plus_to_space* is `true`, `+` is
+  # decoded as space character (`0x20`). Percent-encoded values such as `%20`
+  # and `%2B` are always decoded as characters with the respective codepoint.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.decode("peter+%2B+paul")                      # => "peter+++paul"
+  # URI.decode("peter+%2B+paul", plus_to_space: true) # => "peter + paul"
+  # ```
+  #
+  # * `.encode` is the reverse operation.
+  # * `.decode_www_form` encodes plus to space by default.
+  def self.decode(string : String, *, plus_to_space : Bool = false) : String
+    String.build { |io| decode(string, io, plus_to_space: plus_to_space) }
+  end
+
+  # URL-decodes a string and writes the result to *io*.
+  #
+  # See `.decode(string : String, *, plus_to_space : Bool = false) : String` for details.
+  def self.decode(string : String, io : IO, *, plus_to_space : Bool = false) : Nil
+    self.decode(string, io, plus_to_space: plus_to_space) { false }
+  end
+
+  # URL-encodes *string*.
+  #
+  # Reserved and unreserved characters are not escaped, so this only modifies some
+  # special characters as well as non-ASCII characters. `.reserved?` and `.unreserved?`
+  # provide more details on these character classes.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode("hello world!")                             # => "hello%20world!"
+  # URI.encode("put: it+й")                                # => "put:%20it+%D0%B9"
+  # URI.encode("http://example.com/Crystal is awesome =)") # => "http://example.com/Crystal%20is%20awesome%20=)"
+  # ```
+  #
+  # By default, the space character (`0x20`) is encoded as `%20` and `+` is
+  # encoded literally. If *space_to_plus* is `true`, space character is encoded
+  # as `+` and `+` is encoded as `%2B`:
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode("peter + paul")                      # => "peter%20+%20paul"
+  # URI.encode("peter + paul", space_to_plus: true) # => "peter+%2B+paul"
+  # ```
+  #
+  # * `.decode` is the reverse operation.
+  # * `.encode_www_form` also escapes reserved characters.
+  def self.encode(string : String, *, space_to_plus : Bool = false) : String
+    String.build { |io| encode(string, io, space_to_plus: space_to_plus) }
+  end
+
+  # URL-encodes *string* and writes the result to *io*.
+  #
+  # See `.encode(string : String, *, space_to_plus : Bool = false) : String` for details.
+  def self.encode(string : String, io : IO, *, space_to_plus : Bool = false) : Nil
+    self.encode(string, io, space_to_plus: space_to_plus) { |byte| URI.reserved?(byte) || URI.unreserved?(byte) }
+  end
+
+  # URL-decodes *string* as [`x-www-form-urlencoded`](https://url.spec.whatwg.org/#urlencoded-serializing).
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.decode_www_form("hello%20world!")                           # => "hello world!"
+  # URI.decode_www_form("put:%20it+%D0%B9")                         # => "put: it й"
+  # URI.decode_www_form("http://example.com/Crystal+is+awesome+=)") # => "http://example.com/Crystal is awesome =)"
+  # ```
+  #
+  # By default, `+` is decoded as space character (`0x20`). If *plus_to_space*
+  # is `false`, `+` is decoded literally as `+`. Percent-encoded values such as
+  # `%20` and `%2B` are always decoded as characters with the respective codepoint.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.decode_www_form("peter+%2B+paul")                       # => "peter + paul"
+  # URI.decode_www_form("peter+%2B+paul", plus_to_space: false) # => "peter+++paul"
+  # ```
+  #
+  # * `.encode_www_form` is the reverse operation.
+  # * `.decode` encodes plus literally by default.
+  def self.decode_www_form(string : String, *, plus_to_space : Bool = true) : String
+    decode(string, plus_to_space: plus_to_space)
+  end
+
+  # URL-decodes *string* as [`x-www-form-urlencoded`](https://url.spec.whatwg.org/#urlencoded-serializing)
+  # and writes the result to *io*.
+  #
+  # See `self.decode_www_form(string : String, *, plus_to_space : Bool = true) : String`
+  # for details.
+  def self.decode_www_form(string : String, io : IO, *, plus_to_space : Bool = true) : Nil
+    decode(string, io, plus_to_space: plus_to_space)
+  end
+
+  @[Deprecated("Use .decode or .decode_www_form instead")]
+  def self.unescape(string : String, io : IO, plus_to_space = false)
+    decode_www_form(string, io, plus_to_space: plus_to_space)
+  end
+
+  @[Deprecated("Use .decode or .decode_www_form instead")]
+  def self.unescape(string : String, plus_to_space = false)
+    decode_www_form(string, plus_to_space: plus_to_space)
+  end
+
+  # URL-encodes *string* as [`x-www-form-urlencoded`](https://url.spec.whatwg.org/#urlencoded-serializing).
+  #
+  # Reserved characters are escaped, unreserved characters are not.
+  # `.reserved?` and `.unreserved?` provide more details on these character
+  # classes.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode_www_form("hello world!")                    # => "hello+world%21")
+  # URI.encode_www_form("put: it+й")                       # => "put%3A+it%2B%D0%B9"
+  # URI.encode("http://example.com/Crystal is awesome =)") # => "http%3A%2F%2Fexample.com%2FCrystal+is+awesome+%3D%29"
+  # ```
+  #
+  # The encoded string returned from this method can be used as name or value
+  # components for a `application/x-www-form-urlencoded` format serialization.
+  # `HTTP::Params` provides a higher-level API for this use case.
+  #
+  # By default, the space character (`0x20`) is encoded as `+` and `+` is encoded
+  # as `%2B`. If *space_to_plus* is `false`, space character is encoded as `%20`
+  # and `'+'` is encoded literally.
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode_www_form("peter + paul")                       # => "peter+%2B+paul"
+  # URI.encode_www_form("peter + paul", space_to_plus: false) # => "peter%20+%20paul"
+  # ```
+  # ```
+  #
+  # * `.decode_www_form` is the reverse operation.
+  # * `.encode` does not escape reserved characters.
+  def self.encode_www_form(string : String, *, space_to_plus : Bool = true) : String
+    String.build do |io|
+      encode_www_form(string, io, space_to_plus: space_to_plus)
+    end
+  end
+
+  # URL-encodes *string* as [`x-www-form-urlencoded`](https://url.spec.whatwg.org/#urlencoded-serializing)
+  # and writes the result to *io*.
+  #
+  # See `.encode_www_form(string : String, *, space_to_plus : Bool = true)` for
+  # details.
+  def self.encode_www_form(string : String, io : IO, *, space_to_plus : Bool = true) : Nil
+    encode(string, io, space_to_plus: space_to_plus) do |byte|
+      URI.unreserved?(byte)
+    end
+  end
+
+  @[Deprecated("Use .encode or .encode_www_form instead")]
+  def self.escape(string : String, io : IO, space_to_plus = false)
+    encode_www_form(string, io, space_to_plus: space_to_plus)
+  end
+
+  @[Deprecated("Use .encode or .encode_www_form instead")]
+  def self.escape(string : String, space_to_plus = false)
+    encode_www_form(string, space_to_plus: space_to_plus)
+  end
+
+  # Returns whether given byte is reserved character defined in
+  # [RFC 3986](https://tools.ietf.org/html/rfc3986).
+  #
+  # Reserved characters are ':', '/', '?', '#', '[', ']', '@', '!',
+  # '$', '&', "'", '(', ')', '*', '+', ',', ';' and '='.
+  def self.reserved?(byte) : Bool
+    char = byte.unsafe_chr
+    '&' <= char <= ',' ||
+      {'!', '#', '$', '/', ':', ';', '?', '@', '[', ']', '='}.includes?(char)
+  end
+
+  # Returns whether given byte is unreserved character defined in
+  # [RFC 3986](https://tools.ietf.org/html/rfc3986).
+  #
+  # Unreserved characters are ASCII letters, ASCII digits, `_`, `.`, `-` and `~`.
+  def self.unreserved?(byte) : Bool
+    char = byte.unsafe_chr
+    char.ascii_alphanumeric? ||
+      {'_', '.', '-', '~'}.includes?(char)
+  end
+
+  # URL-decodes *string* and writes the result to *io*.
+  #
+  # The block is called for each percent-encoded ASCII character and determines
+  # whether the value is to be decoded. When the return value is falsey,
+  # the character is decoded. Non-ASCII characters are always decoded.
+  #
+  # By default, `+` is decoded literally. If *plus_to_space* is `true`, `+` is
+  # decoded as space character (`0x20`).
+  #
+  # This method enables some customization, but typical use cases can be implemented
+  # by either `.decode(string : String, *, plus_to_space : Bool = false) : String` or
+  # `.deode_www_form(string : String, *, plus_to_space : Bool = true) : String`.
+  def self.decode(string : String, io : IO, *, plus_to_space : Bool = false, &block) : Nil
+    i = 0
+    bytesize = string.bytesize
+    while i < bytesize
+      byte = string.unsafe_byte_at(i)
+      char = byte.unsafe_chr
+      i = decode_one(string, bytesize, i, byte, char, io, plus_to_space) { |byte| yield byte }
+    end
+    io
+  end
+
+  # URL-encodes *string* and writes the result to an `IO`.
+  #
+  # The block is called for each ascii character (codepoint less than `0x80`) and
+  # determines whether the value is to be encoded. When the return value is falsey,
+  # the character is encoded. Non-ASCII characters are always encoded.
+  #
+  # By default, the space character (`0x20`) is encoded as `%20` and `+` is
+  # encoded literally. If *space_to_plus* is `true`, space character is encoded
+  # as `+` and `+` is encoded as `%2B`.
+  #
+  # This method enables some customization, but typical use cases can be implemented
+  # by either `.encode(string : String, *, space_to_plus : Bool = false) : String` or
+  # `.encode_www_form(string : String, *, space_to_plus : Bool = true) : String`.
+  def self.encode(string : String, io : IO, space_to_plus : Bool = false, &block) : Nil
+    string.each_byte do |byte|
+      char = byte.unsafe_chr
+      if char == ' ' && space_to_plus
+        io.write_byte '+'.ord.to_u8
+      elsif char.ascii? && yield(byte) && (!space_to_plus || char != '+')
+        io.write_byte byte
+      else
+        io.write_byte '%'.ord.to_u8
+        io.write_byte '0'.ord.to_u8 if byte < 16
+        byte.to_s(16, io, upcase: true)
+      end
+    end
+    io
+  end
+
+  # :nodoc:
+  def self.decode_one(string, bytesize, i, byte, char, io, plus_to_space = false)
+    self.decode_one(string, bytesize, i, byte, char, io, plus_to_space) { false }
+  end
+
+  # :nodoc:
+  # Unencodes one character. Private API
+  def self.decode_one(string, bytesize, i, byte, char, io, plus_to_space = false)
+    if plus_to_space && char == '+'
+      io.write_byte ' '.ord.to_u8
+      i += 1
+      return i
+    end
+
+    if char == '%' && i < bytesize - 2
+      i += 1
+      first = string.unsafe_byte_at(i)
+      first_num = first.unsafe_chr.to_i? 16
+      unless first_num
+        io.write_byte byte
+        return i
+      end
+
+      i += 1
+      second = string.unsafe_byte_at(i)
+      second_num = second.unsafe_chr.to_i? 16
+      unless second_num
+        io.write_byte byte
+        io.write_byte first
+        return i
+      end
+
+      encoded = (first_num * 16 + second_num).to_u8
+      i += 1
+      if encoded < 0x80 && yield encoded
+        io.write_byte byte
+        io.write_byte first
+        io.write_byte second
+        return i
+      end
+      io.write_byte encoded
+      return i
+    end
+
+    io.write_byte byte
+    i += 1
+    i
+  end
+end

--- a/src/uri/uri_parser.cr
+++ b/src/uri/uri_parser.cr
@@ -97,14 +97,14 @@ class URI
       loop do
         if c === '@'
           if password_flag
-            @uri.password = URI.unescape(from_input(start))
+            @uri.password = URI.decode_www_form(from_input(start))
           else
-            @uri.user = URI.unescape(from_input(start))
+            @uri.user = URI.decode_www_form(from_input(start))
           end
           @ptr += 1
           return parse_host
         elsif c === ':'
-          @uri.user = URI.unescape(from_input(start))
+          @uri.user = URI.decode_www_form(from_input(start))
           password_flag = true
           @ptr += 1
           start = @ptr
@@ -120,11 +120,11 @@ class URI
       return parse_path if c === '/'
       loop do
         if c === ':' && !bracket_flag
-          @uri.host = URI.unescape(from_input(start))
+          @uri.host = URI.decode(from_input(start))
           @ptr += 1
           return parse_port
         elsif end_of_host?
-          @uri.host = URI.unescape(from_input(start))
+          @uri.host = URI.decode(from_input(start))
           return parse_path
         else
           bracket_flag = true if c === '['


### PR DESCRIPTION
* Adds methods URI.encode and URI.decode for URL encoding without
  escaping reserved characters. These are to be used when encoding URLs.
* URI.escape and URI.unescape are renamed to URI.encode_www_form and
URI.decode_www_form. These are to be used for `x-www-form-urlencoded` serialization.

The specific implementations are explained in the documentation.
Method names have been chosen according to the names of other APIs, especially Elixir's, per https://github.com/crystal-lang/crystal/pull/3515#issuecomment-335878803 and https://github.com/crystal-lang/crystal/pull/3515#issuecomment-509262082

All these methods have been moved to a separate file in `src/uri/encoding.cr` to clean up the main file. They're an isolated domain just live in URI's class namespace.

There were two variants of escape/unescape receiving a block, which allow for custom modifications of the encoding rules. I'm not sure whether we need to expose them at all in the public API. Use cases should be pretty rare.
So maybe, we should `nodoc` them. I only kept the variant writing to IO. Such low-level methods to not need to provide a string variant. This at least reduces the impact on the public API a bit.

Closes #3515