### PR TITLE
Fiber#wakeup to wake up sleeping fibers

### DIFF
--- a/spec/std/fiber_spec.cr
+++ b/spec/std/fiber_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+
+describe Fiber do
+  it "can be woken up from sleep" do
+    took = Time.measure do
+      ch = Channel(Nil).new
+      f = spawn do
+        sleep 2
+        ch.send nil
+      end
+      f.wakeup
+      ch.receive
+    end
+    took.should be < 1.seconds
+  end
+end

--- a/src/crystal/event.cr
+++ b/src/crystal/event.cr
@@ -33,6 +33,12 @@ struct Crystal::Event
     @freed = true
   end
 
+  def delete
+    unless LibEvent2.event_del(@event) == 0
+      raise "Error deleting event"
+    end
+  end
+
   # :nodoc:
   struct Base
     def initialize

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -119,6 +119,15 @@ class Fiber
     Crystal::Scheduler.resume(self)
   end
 
+  # Wakeup a sleeping fiber
+  def wakeup
+    raise "Can't wakeup dead fibers" if dead?
+    raise "Can't wakeup one self" if self == Fiber.current
+    @resume_event.try &.delete
+    Crystal::Scheduler.enqueue(Fiber.current)
+    Crystal::Scheduler.resume(self)
+  end
+
   # :nodoc:
   def resume_event
     @resume_event ||= Crystal::EventLoop.create_resume_event(self)


### PR DESCRIPTION
Allow waking up sleeping fibers. I know this is a controversial topic, "fibers shouldn't have a public API" etc., but `Channel` doesn't have timeout mechanism and in our app we can over time accumulate hundreds of thousands of sleeping fibers that eventually will wake up and do nothing, so we've monkey patched our app with this functionality. 

Very simplified we got something like this now:
```crystal
ch = Channel(Int32).new
loop do
  waiting = true
  f = spawn do
    sleep 60
    ch.close if waiting
  end
  v = ch.receive? || break
  waiting = false
  f.wakeup
  work(v)
end
``` 

Of course a "native" timeout argument to `Channel#receive` and `Channel#send` would be even more elegant (and one that don't necessarily closes the channel, but raises a `Channel::Timeout` exception maybe). 