### PR TITLE
Turn abstract return type erros into warnings

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -395,8 +395,8 @@ describe "Semantic: abstract def" do
       )
   end
 
-  it "errors if missing return type" do
-    assert_error %(
+  it "warning if missing return type" do
+    assert_warning %(
       abstract class Foo
         abstract def foo : Int32
       end
@@ -407,11 +407,11 @@ describe "Semantic: abstract def" do
         end
       end
       ),
-      "this method overrides Foo#foo() which has an explicit return type of Int32.\n\nPlease add an explicit return type (Int32 or a subtype of it) to this method as well."
+      "warning in line 8\nWarning: this method overrides Foo#foo() which has an explicit return type of Int32.\n\nPlease add an explicit return type (Int32 or a subtype of it) to this method as well."
   end
 
-  it "errors if different return type" do
-    assert_error %(
+  it "warning if different return type" do
+    assert_warning %(
       abstract class Foo
         abstract def foo : Int32
       end
@@ -425,7 +425,7 @@ describe "Semantic: abstract def" do
         end
       end
       ),
-      "this method must return Int32, which is the return type of the overridden method Foo#foo(), or a subtype of it, not Bar::Int32"
+      "warning in line 11\nWarning: this method must return Int32, which is the return type of the overridden method Foo#foo(), or a subtype of it, not Bar::Int32"
   end
 
   it "can return a more specific type" do
@@ -543,7 +543,7 @@ describe "Semantic: abstract def" do
   end
 
   it "is missing a return type in subclass of generic subclass" do
-    assert_error %(
+    assert_warning %(
         abstract class Foo(T)
           abstract def foo : T
         end
@@ -553,6 +553,34 @@ describe "Semantic: abstract def" do
           end
         end
       ),
-      "this method overrides Foo(T)#foo() which has an explicit return type of T.\n\nPlease add an explicit return type (Int32 or a subtype of it) to this method as well."
+      "warning in line 8\nWarning: this method overrides Foo(T)#foo() which has an explicit return type of T.\n\nPlease add an explicit return type (Int32 or a subtype of it) to this method as well."
+  end
+
+  it "can't find parent return type" do
+    assert_warning %(
+        abstract class Foo
+          abstract def foo : Unknown
+        end
+
+        class Bar < Foo
+          def foo
+          end
+        end
+      ),
+      "warning in line 4\nWarning: can't resolve return type Unknown"
+  end
+
+  it "can't find child return type" do
+    assert_warning %(
+        abstract class Foo
+          abstract def foo : Int32
+        end
+
+        class Bar < Foo
+          def foo : Unknown
+          end
+        end
+      ),
+      "warning in line 8\nWarning: can't resolve return type Unknown"
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -117,6 +117,7 @@ def warnings_result(code, inject_primitives = true)
   compiler.warnings = Warnings::All
   compiler.error_on_warnings = false
   compiler.prelude = "empty" # avoid issues in the current std lib
+  compiler.color = false
   apply_program_flags(compiler.flags)
   result = compiler.compile Compiler::Source.new("code.cr", code), output_filename
 


### PR DESCRIPTION
Follow up to #7956

We agreed that making them errors will cause a massive breaking change.
Making them warnings first will make fixing these things easier while things still keep working.