### PR TITLE
Http optimizations

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -160,6 +160,21 @@ describe HTTP::Headers do
     headers.includes_word?("foo", "baz").should be_true
   end
 
+  it "doesn't match word with comma separated value, partial match" do
+    headers = HTTP::Headers{"foo" => "bar, bazo"}
+    headers.includes_word?("foo", "baz").should be_false
+  end
+
+  it "matches word with comma separated value, partial match (array)" do
+    headers = HTTP::Headers{"foo" => ["foo", "baz, bazo"]}
+    headers.includes_word?("foo", "baz").should be_true
+  end
+
+  it "doesn't match word with comma separated value, partial match (array)" do
+    headers = HTTP::Headers{"foo" => ["foo", "bar, bazo"]}
+    headers.includes_word?("foo", "baz").should be_false
+  end
+
   it "matches word among headers" do
     headers = HTTP::Headers.new
     headers.add("foo", "bar")

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -138,6 +138,13 @@ module HTTP
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
+    it "parses GET with spaces in request line" do
+      request = Request.from_io(IO::Memory.new("GET   /   HTTP/1.1  \r\nHost: host.example.org\r\n\r\n")).as(Request)
+      request.method.should eq("GET")
+      request.path.should eq("/")
+      request.headers.should eq({"Host" => "host.example.org"})
+    end
+
     it "parses empty header" do
       request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
       request.method.should eq("GET")

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -49,11 +49,16 @@ struct HTTP::Headers
   end
 
   def initialize
-    @hash = Hash(Key, Array(String)).new
+    # We keep a Hash with String | Array(String) values because
+    # the most common case is a single value and so we avoid allocating
+    # memory for arrays.
+    @hash = Hash(Key, String | Array(String)).new
   end
 
   def []=(key, value : String)
-    self[wrap(key)] = [value]
+    check_invalid_header_content(value)
+
+    @hash[wrap(key)] = value
   end
 
   def []=(key, value : Array(String))
@@ -83,21 +88,31 @@ struct HTTP::Headers
   def includes_word?(key, word)
     return false if word.empty?
 
-    word = word.downcase
-    # iterates over all header values avoiding the concatenation
-    get?(key).try &.each do |value|
-      value = value.downcase
-      offset = 0
-      while true
-        start = value.index(word, offset)
-        break unless start
-        offset = start + word.size
-
-        # check if the match is not surrounded by alphanumeric chars
-        next if start > 0 && value[start - 1].ascii_alphanumeric?
-        next if start + word.size < value.size && value[start + word.size].ascii_alphanumeric?
-        return true
+    values = @hash[wrap(key)]?
+    case values
+    when Nil
+      false
+    when String
+      includes_word_in_header_value?(word.downcase, values.downcase)
+    else
+      word = word.downcase
+      values.any? do |value|
+        includes_word_in_header_value?(word, value.downcase)
       end
+    end
+  end
+
+  private def includes_word_in_header_value?(word, value)
+    offset = 0
+    while true
+      start = value.index(word, offset)
+      return false unless start
+      offset = start + word.size
+
+      # check if the match is not surrounded by alphanumeric chars
+      next if start > 0 && value[start - 1].ascii_alphanumeric?
+      next if start + word.size < value.size && value[start + word.size].ascii_alphanumeric?
+      return true
     end
 
     false
@@ -165,15 +180,15 @@ struct HTTP::Headers
 
     other.each do |key, value|
       this_value = @hash[wrap(key)]?
-      if this_value
-        case value
-        when String
-          return false unless this_value.size == 1 && this_value[0] == value
-        when Array(String)
-          return false unless this_value == value
-        else
-          false
-        end
+      case {value, this_value}
+      when {String, String}
+        return false unless value == this_value
+      when {Array, Array}
+        return false unless value == this_value
+      when {String, Array}
+        return false unless this_value.size == 1 && this_value[0] == value
+      when {Array, String}
+        return false unless value.size == 1 && value[0] == this_value
       else
         return false unless value.nil?
       end
@@ -184,16 +199,16 @@ struct HTTP::Headers
 
   def each
     @hash.each do |key, value|
-      yield({key.name, value})
+      yield({key.name, cast(value)})
     end
   end
 
   def get(key)
-    @hash[wrap(key)]
+    cast @hash[wrap(key)]
   end
 
   def get?(key)
-    @hash[wrap(key)]?
+    @hash[wrap(key)]?.try { |value| cast(value) }
   end
 
   def dup
@@ -218,8 +233,13 @@ struct HTTP::Headers
       io << ", " if index > 0
       key.name.inspect(io)
       io << " => "
-      if values.size == 1
-        values.first.inspect(io)
+      case values
+      when Array
+        if values.size == 1
+          values.first.inspect(io)
+        else
+          values.inspect(io)
+        end
       else
         values.inspect(io)
       end
@@ -259,9 +279,13 @@ struct HTTP::Headers
     key = wrap(key)
     existing = @hash[key]?
     if existing
-      existing << value
+      if existing.is_a?(Array)
+        existing << value
+      else
+        @hash[key] = [existing, value]
+      end
     else
-      @hash[key] = [value]
+      @hash[key] = value
     end
   end
 
@@ -269,7 +293,13 @@ struct HTTP::Headers
     key = wrap(key)
     existing = @hash[key]?
     if existing
-      existing.concat value
+      if existing.is_a?(Array)
+        existing.concat value
+      else
+        new_value = [existing]
+        new_value.concat(value)
+        @hash[key] = new_value
+      end
     else
       @hash[key] = value
     end
@@ -287,7 +317,11 @@ struct HTTP::Headers
     value
   end
 
-  private def concat(values)
+  private def concat(values : String)
+    values
+  end
+
+  private def concat(values : Array(String))
     case values.size
     when 0
       ""

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -93,22 +93,18 @@ class HTTP::Request
 
   # :nodoc:
   record BadRequest
+  # :nodoc:
+  record RequestLine, method : String, resource : String, http_version : String
 
   # Returns a `HTTP::Request` instance if successfully parsed,
   # `nil` on EOF or `BadRequest` otherwise.
-  def self.from_io(io)
-    request_line = io.gets(4096, chomp: true)
-    return unless request_line
-
-    parts = request_line.split
-    return BadRequest.new unless parts.size == 3
-
-    method, resource, http_version = parts
-
-    return BadRequest.new unless HTTP::SUPPORTED_VERSIONS.includes?(http_version)
+  def self.from_io(io) : HTTP::Request | BadRequest | Nil
+    line = parse_request_line(io)
+    return line unless line.is_a?(RequestLine)
 
     HTTP.parse_headers_and_body(io) do |headers, body|
-      request = new method, resource, headers, body, http_version
+      # No need to dup headers since nobody else holds them
+      request = new line.method, line.resource, headers, body, line.http_version
 
       if io.responds_to?(:remote_address)
         request.remote_address = io.remote_address.try &.to_s
@@ -119,6 +115,89 @@ class HTTP::Request
 
     # Malformed or unexpectedly ended http request
     BadRequest.new
+  end
+
+  private METHODS = %w(GET HEAD POST PUT DELETE CONNECT OPTIONS PATCH TRACE)
+
+  private def self.parse_request_line(io : IO) : RequestLine | BadRequest | Nil
+    # Optimization: see if we have a peek buffer
+    # (avoids a string allocation for the entire request line)
+    if peek = io.peek
+      # peek.empty? means there's no more input (EOF), so no more requests
+      return nil if peek.empty?
+
+      # See if we can find \r\n (first \n, then \r before it)
+      index = peek.index('\n'.ord.to_u8)
+      # TODO: eventually increase the 4096 bytes limit
+      if index && index > 0 && index < 4096 && peek[index - 1] == '\r'.ord.to_u8
+        parts = parse_request_line(peek[0, index - 1])
+        io.skip(index + 1) # Must skip until after \r\n
+        return parts
+      end
+    end
+
+    request_line = io.gets(4096, chomp: true)
+    return BadRequest.new unless request_line
+
+    parse_request_line(request_line)
+  end
+
+  private def self.parse_request_line(line : String) : RequestLine | BadRequest
+    parse_request_line(line.to_slice)
+  end
+
+  private def self.parse_request_line(slice : Bytes) : RequestLine | BadRequest
+    space_index = slice.index(' '.ord.to_u8)
+
+    # Oops, only a single part (should be three)
+    return BadRequest.new unless space_index
+
+    subslice = slice[0...space_index]
+
+    # Optimization: see if it's one of the common methods
+    # (avoids a string allocation for these methods)
+    method = METHODS.find { |method| method.to_slice == subslice } ||
+             String.new(subslice)
+
+    # Skip spaces.
+    # The RFC just mentions a single space but most servers allow multiple.
+    while space_index < slice.size && slice[space_index] == ' '.ord.to_u8
+      space_index += 1
+    end
+
+    # Oops, we only found the "method" part followed by spaces
+    return BadRequest.new if space_index == slice.size
+
+    next_space_index = slice.index(' '.ord.to_u8, offset: space_index)
+
+    # Oops, we only found two parts (should be three)
+    return BadRequest.new unless next_space_index
+
+    resource = String.new(slice[space_index...next_space_index])
+
+    # Skip spaces again
+    space_index = next_space_index
+    while space_index < slice.size && slice[space_index] == ' '.ord.to_u8
+      space_index += 1
+    end
+
+    next_space_index = slice.index(' '.ord.to_u8, offset: space_index) || slice.size
+
+    subslice = slice[space_index...next_space_index]
+
+    # Optimization: avoid allocating a string for common HTTP version
+    http_version = HTTP::SUPPORTED_VERSIONS.find { |version| version.to_slice == subslice }
+    return BadRequest.new unless http_version
+
+    # Skip trailing spaces
+    space_index = next_space_index
+    while space_index < slice.size
+      # Oops, we find something else (more than three parts)
+      return BadRequest.new unless slice[space_index] == ' '.ord.to_u8
+      space_index += 1
+    end
+
+    RequestLine.new method: method, resource: resource, http_version: http_version
   end
 
   # Returns the request's path component.


### PR DESCRIPTION
These are a series of refactors to improve parsing of HTTP requests. Check each commit for more details (each has a description in it).

This is more code, more complex code, and more low-level code, but that's the whole idea of Crystal: if you want to go deeper and optimize hot paths you can do it in Crystal itself.

I wrote this benchmark:

```crystal
require "benchmark"
require "http"

# # request.txt was generated using this code
# request = <<-REQUEST.lines.join("\r\n") + "\r\n\r\n"
# GET /hello.htm HTTP/1.1
# User-Agent: Mozilla/4.0 (compatible; MSIE5.01; Windows NT)
# Host: www.tutorialspoint.com
# Accept-Language: en-us
# Accept-Encoding: gzip, deflate
# Connection: Keep-Alive
# REQUEST
# File.write("request.txt", request)

io = File.open("request.txt")

Benchmark.ips do |x|
  x.report("from_io") do
    io.rewind
    HTTP::Request.from_io(io)
  end
end
```

I read from a file to simulate reading from an external resource, though the entire file probably fits `IO::Buffered`'s buffer (but the same should be true for `Socket`). But later I'll show the results with `IO::Memory` too.

If I run the above benchmark against `master`:

```
$ crystal foo.cr --release
from_io 335.90k (  2.98µs) (± 1.07%)  2.1kB/op  fastest
```

When against this PR:

```
$ bin/crystal foo.cr --release
from_io 495.93k (  2.02µs) (± 0.85%)  816B/op  fastest
```

So a 30% improvement! 😄 

Also note the memory allocated per op: 2.1kB before, now 816B. This is the main reason it's faster.

If I use `IO::Memory` instead of `File` I get:

```
Before: from_io 509.34k (  1.96µs) (± 0.75%)  2.1kB/op  fastest
After:  from_io   1.01M (991.82ns) (± 0.75%)  816B/op  fastest
```

Since HTTP servers are pretty common in Crystal I thought this is a good way to optimize all apps out there. I know usually a lot more goes on in a typical web server (for example rendering) but the less time and memory the framework takes for itself, the better.

I didn't benchmark an HTTP::Server with `ab` or similar after this change, but you are welcome to do that and post the results here!