### PR TITLE
Channel::Buffered, only enqueue one waiting fiber at a time

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -223,8 +223,9 @@ class Channel::Buffered(T) < Channel(T)
     raise_if_closed
 
     @queue << value
-    Crystal::Scheduler.enqueue @receivers
-    @receivers.clear
+    if receiver = @receivers.shift?
+      Crystal::Scheduler.enqueue receiver
+    end
 
     self
   end
@@ -237,8 +238,9 @@ class Channel::Buffered(T) < Channel(T)
     end
 
     @queue.shift.tap do
-      Crystal::Scheduler.enqueue @senders
-      @senders.clear
+      if sender = @senders.shift?
+        Crystal::Scheduler.enqueue sender
+      end
     end
   end
 


### PR DESCRIPTION
Speeds up `Channel::Buffered` with many senders and/or receivers. 

```
original 184.39k (  5.42µs) (± 2.92%)  0.0B/op  42.21× slower
improved   7.78M (128.49ns) (± 2.07%)  0.0B/op        fastest
```