### PR TITLE
Allow timeout in select statements

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -208,6 +208,8 @@ abstract class Channel(T)
   struct TimeoutAction
     include SelectAction
 
+    @timeout_at : Time::Span
+
     def initialize(timeout : Time::Span)
       @timeout_at = Time.monotonic + timeout
     end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -208,20 +208,20 @@ abstract class Channel(T)
   struct TimeoutAction
     include SelectAction
 
-    def initialize(@timeout : Time::Span)
+    def initialize(timeout : Time::Span)
+      @timeout_at = Time.monotonic + timeout
     end
 
     def ready?
-      Fiber.current.timed_out
+      Fiber.current.timed_out?
     end
 
-    def execute
+    def execute : Nil
       Fiber.current.timed_out = false
-      nil
     end
 
     def wait
-      Fiber.timeout @timeout
+      Fiber.timeout @timeout_at - Time.monotonic
     end
 
     def unwait

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -203,6 +203,31 @@ abstract class Channel(T)
       @channel.unwait_for_send
     end
   end
+
+  # :nodoc:
+  struct TimeoutAction
+    include SelectAction
+
+    def initialize(@timeout : Time::Span)
+    end
+
+    def ready?
+      Fiber.current.timed_out
+    end
+
+    def execute
+      Fiber.current.timed_out = false
+      nil
+    end
+
+    def wait
+      Fiber.timeout @timeout
+    end
+
+    def unwait
+      Fiber.cancel_timeout
+    end
+  end
 end
 
 # Buffered channel, using a queue.

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -30,14 +30,16 @@ def sleep
   Crystal::Scheduler.reschedule
 end
 
-# timeout keyword for use in `select`
+# Timeout keyword for use in `select`.
 #
+# ```
 # select
 # when x = ch.recieve
 #   puts "got #{x}"
 # when timeout(1.seconds)
 #   puts "timeout"
 # end
+# ```
 def timeout_select_action(timeout)
   Channel::TimeoutAction.new(timeout)
 end

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -30,6 +30,18 @@ def sleep
   Crystal::Scheduler.reschedule
 end
 
+# timeout keyword for use in `select`
+#
+# select
+# when x = ch.recieve
+#   puts "got #{x}"
+# when timeout(1.seconds)
+#   puts "timeout"
+# end
+def timeout_select_action(timeout)
+  Channel::TimeoutAction.new(timeout)
+end
+
 # Spawns a new fiber.
 #
 # The newly created fiber doesn't run as soon as spawned.

--- a/src/crystal/event.cr
+++ b/src/crystal/event.cr
@@ -33,6 +33,12 @@ struct Crystal::Event
     @freed = true
   end
 
+  def delete
+    unless LibEvent2.event_del(@event) == 0
+      raise "Error deleting event"
+    end
+  end
+
   # :nodoc:
   struct Base
     def initialize

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -22,6 +22,14 @@ module Crystal::EventLoop
     end
   end
 
+  def self.create_timeout_event(fiber)
+    @@eb.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
+      f = data.as(Fiber)
+      f.timed_out = true
+      f.resume
+    end
+  end
+
   def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false)
     flags = LibEvent2::EventFlags::Write
     flags |= LibEvent2::EventFlags::Persist | LibEvent2::EventFlags::ET if edge_triggered

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -34,6 +34,14 @@ class Crystal::Scheduler
     Thread.current.scheduler.sleep(time)
   end
 
+  def self.timeout(time : Time::Span) : Nil
+    Thread.current.scheduler.timeout(time)
+  end
+
+  def self.cancel_timeout : Nil
+    Thread.current.scheduler.cancel_timeout
+  end
+
   def self.yield : Nil
     Thread.current.scheduler.yield
   end
@@ -122,5 +130,13 @@ class Crystal::Scheduler
   protected def yield(fiber : Fiber) : Nil
     @current.resume_event.add(0.seconds)
     resume(fiber)
+  end
+
+  protected def timeout(time : Time::Span) : Nil
+    @current.timeout_event.add(time)
+  end
+
+  protected def cancel_timeout : Nil
+    @current.timeout_event.delete
   end
 end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -22,7 +22,7 @@ class Fiber
   @timeout_event : Crystal::Event?
   protected property stack_bottom : Void*
   property name : String?
-  property timed_out = false
+  property? timed_out = false
   @alive = true
   @current_thread = Atomic(Thread?).new(nil)
 

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -19,8 +19,10 @@ class Fiber
   @context : Context
   @stack : Void*
   @resume_event : Crystal::Event?
+  @timeout_event : Crystal::Event?
   protected property stack_bottom : Void*
   property name : String?
+  property timed_out = false
   @alive = true
   @current_thread = Atomic(Thread?).new(nil)
 
@@ -88,6 +90,7 @@ class Fiber
 
     # Delete the resume event if it was used by `yield` or `sleep`
     @resume_event.try &.free
+    @timeout_event.try &.free
 
     @alive = false
     Crystal::Scheduler.reschedule
@@ -122,6 +125,22 @@ class Fiber
   # :nodoc:
   def resume_event
     @resume_event ||= Crystal::EventLoop.create_resume_event(self)
+  end
+
+  # :nodoc:
+  def timeout_event
+    @timeout_event ||= Crystal::EventLoop.create_timeout_event(self)
+  end
+
+  # The current fiber will resume after a period of time
+  # and have the property `timed_out` set to true.
+  # The timeout can be cancelled with `cancel_timeout`
+  def self.timeout(timeout : Time::Span?) : Nil
+    Crystal::Scheduler.timeout(timeout)
+  end
+
+  def self.cancel_timeout
+    Crystal::Scheduler.cancel_timeout
   end
 
   def self.yield


### PR DESCRIPTION
timeout keyword for use in `select`

```crystal
select
when x = ch.receive
  puts "got #{x}"
when timeout(1.seconds)
  puts "timeout"
end
```

Implemented by a `timeout_event` on the fiber, much like the `resume_event` but that sets a new Fiber property called `timed_out`, before resuming the fiber.

In contrast to:
```crystal
def sleep_select_action(timeout)
  chan = Channel(Nil).new
  spawn do
    sleep(timeout)
    chan.send(nil)
  end
  Channel::ReceiveAction.new(chan)
end
```
this is much more resource efficient, as no allocations are made (new fiber and new channel in the case above) and the timer is deleted as soon as any other event has occurred. 