### PR TITLE
Rework File::Info user and group methods

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -393,58 +393,58 @@ describe "File" do
     end
   end
 
-  it "gets info for this file" do
-    info = File.info(datapath("test_file.txt"))
-    info.type.should eq(File::Type::File)
-  end
-
-  it "gets info for this directory" do
-    info = File.info(datapath)
-    info.type.should eq(File::Type::Directory)
-  end
-
-  # TODO: support stating nul on windows
-  pending_win32 "gets info for a character device" do
-    info = File.info(File::NULL)
-    info.type.should eq(File::Type::CharacterDevice)
-  end
-
-  it "gets info for a symlink" do
-    info = File.info(datapath("symlink.txt"), follow_symlinks: false)
-    info.type.should eq(File::Type::Symlink)
-  end
-
-  it "gets info for open file" do
-    File.open(datapath("test_file.txt"), "r") do |file|
-      info = file.info
+  describe "File::Info" do
+    it "gets for this file" do
+      info = File.info(datapath("test_file.txt"))
       info.type.should eq(File::Type::File)
     end
-  end
 
-  it "gets info for pipe" do
-    IO.pipe do |r, w|
-      r.info.type.should eq(File::Type::Pipe)
-      w.info.type.should eq(File::Type::Pipe)
+    it "gets for this directory" do
+      info = File.info(datapath)
+      info.type.should eq(File::Type::Directory)
     end
-  end
 
-  it "gets info for non-existent file and raises" do
-    expect_raises_errno(Errno::ENOENT, "Unable to get info for 'non-existent'") do
-      File.info("non-existent")
+    # TODO: support stating nul on windows
+    pending_win32 "gets for a character device" do
+      info = File.info(File::NULL)
+      info.type.should eq(File::Type::CharacterDevice)
     end
-  end
 
-  it "gets info mtime for new file" do
-    with_tempfile("mtime") do |path|
-      File.touch(path)
-      File.open(path) do |file|
-        file.info.modification_time.should be_close(Time.utc, 1.seconds)
+    it "gets for a symlink" do
+      info = File.info(datapath("symlink.txt"), follow_symlinks: false)
+      info.type.should eq(File::Type::Symlink)
+    end
+
+    it "gets for open file" do
+      File.open(datapath("test_file.txt"), "r") do |file|
+        info = file.info
+        info.type.should eq(File::Type::File)
       end
-      File.info(path).modification_time.should be_close(Time.utc, 1.seconds)
     end
-  end
 
-  describe "File::Info" do
+    it "gets for pipe" do
+      IO.pipe do |r, w|
+        r.info.type.should eq(File::Type::Pipe)
+        w.info.type.should eq(File::Type::Pipe)
+      end
+    end
+
+    it "gets for non-existent file and raises" do
+      expect_raises_errno(Errno::ENOENT, "Unable to get info for 'non-existent'") do
+        File.info("non-existent")
+      end
+    end
+
+    it "gets mtime for new file" do
+      with_tempfile("mtime") do |path|
+        File.touch(path)
+        File.open(path) do |file|
+          file.info.modification_time.should be_close(Time.utc, 1.seconds)
+        end
+        File.info(path).modification_time.should be_close(Time.utc, 1.seconds)
+      end
+    end
+
     it "tests equal for the same file" do
       File.info(datapath("test_file.txt")).should eq(File.info(datapath("test_file.txt")))
     end

--- a/src/crystal/system/unix/file_info.cr
+++ b/src/crystal/system/unix/file_info.cr
@@ -47,12 +47,12 @@ struct Crystal::System::FileInfo < ::File::Info
     {% end %}
   end
 
-  def owner : UInt32
-    @stat.st_uid.to_u32
+  def owner_id : String
+    @stat.st_uid.to_s
   end
 
-  def group : UInt32
-    @stat.st_gid.to_u32
+  def group_id : String
+    @stat.st_gid.to_s
   end
 
   def same_file?(other : ::File::Info) : Bool

--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -4,7 +4,7 @@ module Crystal::System::User
   private GETPW_R_SIZE_MAX = 1024 * 16
 
   private def from_struct(pwd)
-    user = String.new(pwd.pw_gecos).split(",").first
+    user = String.new(pwd.pw_gecos).partition(',')[0]
     new(String.new(pwd.pw_name), pwd.pw_uid.to_s, pwd.pw_gid.to_s, user, String.new(pwd.pw_dir), String.new(pwd.pw_shell))
   end
 

--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -74,12 +74,12 @@ struct Crystal::System::FileInfo < ::File::Info
     Time.from_filetime(@file_attributes.ftLastWriteTime)
   end
 
-  def owner : UInt32
-    0_u32
+  def owner_id : String
+    "0"
   end
 
-  def group : UInt32
-    0_u32
+  def group_id : String
+    "0"
   end
 
   def same_file?(other : ::File::Info) : Bool

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -93,11 +93,23 @@ class File
     # The last time this file was modified.
     abstract def modification_time : Time
 
-    # The user ID of the file's owner.
-    abstract def owner : UInt32
+    # The user ID that the file belongs to.
+    abstract def owner_id : String
+
+    # :ditto:
+    @[Deprecated("Use File#owner_id instead")]
+    def owner : UInt32
+      owner_id.to_u32
+    end
 
     # The group ID that the file belongs to.
-    abstract def group : UInt32
+    abstract def group_id : String
+
+    # :ditto:
+    @[Deprecated("Use File#group_id instead")]
+    def group : UInt32
+      group_id.to_u32
+    end
 
     # Returns true if this `Info` and *other* are of the same file.
     #

--- a/src/system/group.cr
+++ b/src/system/group.cr
@@ -57,6 +57,6 @@ class System::Group
   end
 
   def to_s(io)
-    io << name << " (" << id << ")"
+    io << name << " (" << id << ')'
   end
 end

--- a/src/system/user.cr
+++ b/src/system/user.cr
@@ -69,6 +69,6 @@ class System::User
   end
 
   def to_s(io)
-    io << username << " (" << id << ")"
+    io << username << " (" << id << ')'
   end
 end


### PR DESCRIPTION
Since https://github.com/crystal-lang/crystal/pull/7725 is merged, the `File::Info` can be improved accordingly.
Several points are addressed in this PR, devised into separate commits:
- `File::Info#owner` and `File::Info#group`  are renamed to `File::Info#user_id` and `File::Info#group_id`
  - to match `System::User#id` and `System::Group#id`
  - more importantly because they return IDs (as String)
- [Controversial Commit] Use `UInt32` instead of `String` for user/group ids
  - because that what they are - Integer Inentifiers
  - this drops the need to cast several time with `to_s` then back to `to_u32`, the user need to pre-validate its type if coming from a `String`
  - for those worried about cross-platform compatibility,  see the last commit solving this issue adding system `#user`/`#group` to `File::Info`
-  Add `File::Info#user` and `File::Info#group`
   - this is supposed to be a generic user/group interface
   - this prevents to be forces to use UInt32 IDs as String, and then casting them back.
___
In fact, `File::Info#user_id` and `File::Info#group_id` are UN*X specific (on Windows as for now, `0` is hard-coded), there are several options, not sure what's would be the best:
- having only `File::Info#user` and `File::Info#group`, then call `#id`, but this means having extra calls and operations when wanting to only retrieve an ID
- having something like `File::Info#unix` with all UN*X specificities inside it, like `gid`, `uid`, `mtime`, `atime`, etc. This method will raise at compile time if called on a Windows system.