### PR TITLE
Add doc property to CStructOrUnionDef AST node

### DIFF
--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1819,6 +1819,7 @@ module Crystal
     property name : String
     property body : ASTNode
     property? union : Bool
+    property doc : String?
 
     def initialize(@name, body = nil, @union = false)
       @body = Expressions.from(body)


### PR DESCRIPTION
I'm not sure why the CStructOrUnionDef AST node doesn't have a _doc_ property but adding it will be useful in https://github.com/crystal-lang/crystal_lib/pull/61 .