### PR TITLE
Handle too long URIs and too large header fields in HTTP::Request.from_io

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -190,6 +190,28 @@ describe HTTP::ChunkedContent do
     end
   end
 
+  describe "long trailer part" do
+    it "fails for long single header" do
+      mem = IO::Memory.new("0\r\nFoo: Bar Baz Qux\r\n\r\n")
+
+      chunked = HTTP::ChunkedContent.new(mem, max_headers_size: 12)
+      expect_raises(IO::Error, "Trailing headers too long") do
+        chunked.gets
+      end
+      chunked.headers.empty?.should be_true
+    end
+
+    it "fails for long combined headers" do
+      mem = IO::Memory.new("0\r\nFoo: Bar\r\nBaz: Qux\r\n\r\n")
+
+      chunked = HTTP::ChunkedContent.new(mem, max_headers_size: 12)
+      expect_raises(IO::Error, "Trailing headers too long") do
+        chunked.gets
+      end
+      chunked.headers.should eq HTTP::Headers{"Foo" => "Bar"}
+    end
+  end
+
   it "fails if not properly delimited" do
     mem = IO::Memory.new("0\r\n")
 

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -124,12 +124,12 @@ class HTTP::Client
     end
 
     it "parses long request lines" do
-      request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 #{"OK" * 16000}\r\n\r\n"))
+      request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 #{"OK" * 600_000}\r\n\r\n"))
       request.should eq(nil)
     end
 
     it "parses long headers" do
-      request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 OK\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
+      request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 OK\r\n#{"X-Test-Header: A pretty log header value\r\n" * 100_000}\r\n"))
       request.should eq(nil)
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -205,24 +205,24 @@ module HTTP
 
       it "handles malformed request" do
         request = Request.from_io(IO::Memory.new("nonsense"))
-        request.should be_a(Request::BadRequest)
+        request.should eq HTTP::Status::BAD_REQUEST
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nX-Test-Header: \u{0}\r\n"))
-        request.should be_a(Request::BadRequest)
+        request.should eq HTTP::Status::BAD_REQUEST
       end
 
       it "handles unsupported HTTP version" do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.2\r\nContent-Length: 0\r\n\r\n"))
-        request.should be_a(Request::BadRequest)
+        request.should eq HTTP::Status::BAD_REQUEST
       end
 
       it "handles long request lines" do
         request = Request.from_io(IO::Memory.new("GET /#{"a" * 4096} HTTP/1.1\r\n\r\n"))
-        request.should be_a(Request::BadRequest)
+        request.should eq HTTP::Status::BAD_REQUEST
       end
 
       it "handles long headers" do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
-        request.should be_a(Request::BadRequest)
+        request.should eq HTTP::Status::BAD_REQUEST
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -217,13 +217,13 @@ module HTTP
 
       describe "long request lines" do
         it "handles long URI" do
-          path = "a" * (1_048_561)
+          path = "a" * 8177
           request = Request.from_io(IO::Memory.new("GET /#{path} HTTP/1.1\r\n\r\n")).as(Request)
-          request.path.count('a').should eq 1_048_561
+          request.path.count('a').should eq 8177
         end
 
         it "fails for too-long URI" do
-          request = Request.from_io(IO::Memory.new("GET /#{"a" * 1_048_576} HTTP/1.1\r\n\r\n"))
+          request = Request.from_io(IO::Memory.new("GET /#{"a" * 8192} HTTP/1.1\r\n\r\n"))
           request.should eq HTTP::Status::URI_TOO_LONG
         end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -126,102 +126,104 @@ module HTTP
       end
     end
 
-    it "parses GET" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.example.org"})
-    end
+    describe ".from_io" do
+      it "parses GET" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.headers.should eq({"Host" => "host.example.org"})
+      end
 
-    it "parses GET (just \\n instead of \\r\\n)" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.example.org"})
-    end
+      it "parses GET (just \\n instead of \\r\\n)" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.headers.should eq({"Host" => "host.example.org"})
+      end
 
-    it "parses GET with query params" do
-      request = Request.from_io(IO::Memory.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/greet")
-      request.headers.should eq({"Host" => "host.example.org"})
-    end
+      it "parses GET with query params" do
+        request = Request.from_io(IO::Memory.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/greet")
+        request.headers.should eq({"Host" => "host.example.org"})
+      end
 
-    it "parses GET without \\r" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.example.org"})
-    end
+      it "parses GET without \\r" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.headers.should eq({"Host" => "host.example.org"})
+      end
 
-    it "parses empty string (EOF), returns nil" do
-      Request.from_io(IO::Memory.new("")).should be_nil
-    end
+      it "parses empty string (EOF), returns nil" do
+        Request.from_io(IO::Memory.new("")).should be_nil
+      end
 
-    it "parses empty string (EOF), returns nil (no peek)" do
-      Request.from_io(EmptyIO.new).should be_nil
-    end
+      it "parses empty string (EOF), returns nil (no peek)" do
+        Request.from_io(EmptyIO.new).should be_nil
+      end
 
-    it "parses GET with spaces in request line" do
-      request = Request.from_io(IO::Memory.new("GET   /   HTTP/1.1  \r\nHost: host.example.org\r\n\r\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.example.org"})
-    end
+      it "parses GET with spaces in request line" do
+        request = Request.from_io(IO::Memory.new("GET   /   HTTP/1.1  \r\nHost: host.example.org\r\n\r\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.headers.should eq({"Host" => "host.example.org"})
+      end
 
-    it "parses empty header" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.example.org", "Referer" => ""})
-    end
+      it "parses empty header" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.headers.should eq({"Host" => "host.example.org", "Referer" => ""})
+      end
 
-    it "parses GET with cookie" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: a=b\r\n\r\n")).as(Request)
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.cookies["a"].value.should eq("b")
+      it "parses GET with cookie" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nCookie: a=b\r\n\r\n")).as(Request)
+        request.method.should eq("GET")
+        request.path.should eq("/")
+        request.cookies["a"].value.should eq("b")
 
-      # Headers should not be modified (#2920)
-      request.headers.should eq({"Host" => "host.example.org", "Cookie" => "a=b"})
-    end
+        # Headers should not be modified (#2920)
+        request.headers.should eq({"Host" => "host.example.org", "Cookie" => "a=b"})
+      end
 
-    it "headers are case insensitive" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
-      headers = request.headers.not_nil!
-      headers["HOST"].should eq("host.example.org")
-      headers["host"].should eq("host.example.org")
-      headers["Host"].should eq("host.example.org")
-    end
+      it "headers are case insensitive" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
+        headers = request.headers.not_nil!
+        headers["HOST"].should eq("host.example.org")
+        headers["host"].should eq("host.example.org")
+        headers["Host"].should eq("host.example.org")
+      end
 
-    it "parses POST (with body)" do
-      request = Request.from_io(IO::Memory.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).as(Request)
-      request.method.should eq("POST")
-      request.path.should eq("/foo")
-      request.headers.should eq({"Content-Length" => "13"})
-      request.body.not_nil!.gets_to_end.should eq("thisisthebody")
-    end
+      it "parses POST (with body)" do
+        request = Request.from_io(IO::Memory.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).as(Request)
+        request.method.should eq("POST")
+        request.path.should eq("/foo")
+        request.headers.should eq({"Content-Length" => "13"})
+        request.body.not_nil!.gets_to_end.should eq("thisisthebody")
+      end
 
-    it "handles malformed request" do
-      request = Request.from_io(IO::Memory.new("nonsense"))
-      request.should be_a(Request::BadRequest)
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nX-Test-Header: \u{0}\r\n"))
-      request.should be_a(Request::BadRequest)
-    end
+      it "handles malformed request" do
+        request = Request.from_io(IO::Memory.new("nonsense"))
+        request.should be_a(Request::BadRequest)
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nX-Test-Header: \u{0}\r\n"))
+        request.should be_a(Request::BadRequest)
+      end
 
-    it "handles unsupported HTTP version" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.2\r\nContent-Length: 0\r\n\r\n"))
-      request.should be_a(Request::BadRequest)
-    end
+      it "handles unsupported HTTP version" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.2\r\nContent-Length: 0\r\n\r\n"))
+        request.should be_a(Request::BadRequest)
+      end
 
-    it "handles long request lines" do
-      request = Request.from_io(IO::Memory.new("GET /#{"a" * 4096} HTTP/1.1\r\n\r\n"))
-      request.should be_a(Request::BadRequest)
-    end
+      it "handles long request lines" do
+        request = Request.from_io(IO::Memory.new("GET /#{"a" * 4096} HTTP/1.1\r\n\r\n"))
+        request.should be_a(Request::BadRequest)
+      end
 
-    it "handles long headers" do
-      request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
-      request.should be_a(Request::BadRequest)
+      it "handles long headers" do
+        request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\n#{"X-Test-Header: A pretty log header value\r\n" * 1000}\r\n"))
+        request.should be_a(Request::BadRequest)
+      end
     end
 
     describe "keep-alive" do

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -913,6 +913,102 @@ module HTTP
     end
   end
 
+  describe "#max_request_line_size" do
+    it "sets and gets size" do
+      server = HTTP::Server.new { |ctx| }
+      server.max_request_line_size.should eq HTTP::MAX_REQUEST_LINE_SIZE
+      server.@processor.max_request_line_size.should eq HTTP::MAX_REQUEST_LINE_SIZE
+      server.max_request_line_size = 20
+      server.max_request_line_size.should eq 20
+      server.@processor.max_request_line_size.should eq 20
+    end
+
+    it "respects size on request" do
+      server = HTTP::Server.new { |ctx| }
+      read = IO::Memory.new("GET /1234567 HTTP/1.1\r\n\r\n")
+      write = IO::Memory.new
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::OK
+
+      read.rewind
+      write.clear
+
+      server.max_request_line_size = 20
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::URI_TOO_LONG
+    end
+  end
+
+  describe "#max_request_line_size" do
+    it "sets and gets size" do
+      server = HTTP::Server.new { |ctx| }
+      server.max_request_line_size.should eq HTTP::MAX_REQUEST_LINE_SIZE
+      server.@processor.max_request_line_size.should eq HTTP::MAX_REQUEST_LINE_SIZE
+      server.max_request_line_size = 20
+      server.max_request_line_size.should eq 20
+      server.@processor.max_request_line_size.should eq 20
+    end
+
+    it "respects size on request" do
+      server = HTTP::Server.new { |ctx| }
+      read = IO::Memory.new("GET /1234567 HTTP/1.1\r\n\r\n")
+      write = IO::Memory.new
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::OK
+
+      read.rewind
+      write.clear
+
+      server.max_request_line_size = 20
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::URI_TOO_LONG
+    end
+  end
+
+  describe "#max_headers_size" do
+    it "sets and gets size" do
+      server = HTTP::Server.new { |ctx| }
+      server.max_headers_size.should eq HTTP::MAX_HEADERS_SIZE
+      server.@processor.max_headers_size.should eq HTTP::MAX_HEADERS_SIZE
+      server.max_headers_size = 20
+      server.max_headers_size.should eq 20
+      server.@processor.max_headers_size.should eq 20
+    end
+
+    it "respects size on request" do
+      server = HTTP::Server.new { |ctx| }
+      read = IO::Memory.new("GET /foo HTTP/1.1\r\nFoo: Bar Baz\r\n\r\n")
+      write = IO::Memory.new
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::OK
+
+      read.rewind
+      write.clear
+
+      server.max_headers_size = 10
+
+      io = IO::Stapled.new(read, write)
+      server.@processor.process(io, io)
+      write.rewind
+      HTTP::Client::Response.from_io(write).status.should eq HTTP::Status::REQUEST_HEADER_FIELDS_TOO_LARGE
+    end
+  end
+
   typeof(begin
     # Initialize with custom host
     server = Server.new { |ctx| }

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -149,5 +149,7 @@ class HTTP::Client::Response
     HTTP.parse_headers_and_body(io, body_type: body_type, decompress: decompress) do |headers, body|
       return yield new status, nil, headers, status_message, http_version, body
     end
+
+    nil
   end
 end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -192,7 +192,7 @@ module HTTP
     end
 
     private def read_chunk_size
-      line = @io.read_line(HTTP::MAX_HEADER_SIZE, chomp: true)
+      line = @io.read_line(HTTP::MAX_HEADERS_SIZE, chomp: true)
 
       if index = line.byte_index(';'.ord)
         chunk_size = line.byte_slice(0, index)
@@ -205,7 +205,7 @@ module HTTP
 
     private def read_trailer
       while true
-        line = @io.read_line(HTTP::MAX_HEADER_SIZE, chomp: true)
+        line = @io.read_line(HTTP::MAX_HEADERS_SIZE, chomp: true)
         break if line.empty?
 
         key, value = HTTP.parse_header(line)

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -97,7 +97,17 @@ module HTTP
     # in the chunked trailer part (see [RFC 7230 section 4.1.2](https://tools.ietf.org/html/rfc7230#section-4.1.2)).
     getter headers : HTTP::Headers { HTTP::Headers.new }
 
-    def initialize(@io : IO)
+    # Returns the maximum permitted combined size for the trailing headers.
+    #
+    # When parsing the trailing headers `ChunkedContent` keeps track of the
+    # amount of total bytes consumed for all headers (including line breaks).
+    # If the combined byte size of all headers is larger than the permitted size,
+    # `IO::Error` is raised.
+    #
+    # Default: `HTTP::MAX_HEADERS_SIZE`
+    getter max_headers_size : Int32
+
+    def initialize(@io : IO, *, @max_headers_size : Int32 = HTTP::MAX_HEADERS_SIZE)
       @chunk_remaining = -1
       @received_final_chunk = false
     end
@@ -192,7 +202,7 @@ module HTTP
     end
 
     private def read_chunk_size
-      line = @io.read_line(HTTP::MAX_HEADERS_SIZE, chomp: true)
+      line = @io.read_line(@max_headers_size, chomp: true)
 
       if index = line.byte_index(';'.ord)
         chunk_size = line.byte_slice(0, index)
@@ -204,9 +214,15 @@ module HTTP
     end
 
     private def read_trailer
+      max_size = @max_headers_size
+
       while true
-        line = @io.read_line(HTTP::MAX_HEADERS_SIZE, chomp: true)
+        line = @io.read_line(max_size + 1, chomp: true)
         break if line.empty?
+        max_size -= line.bytesize
+        if max_size < 0
+          raise IO::Error.new("Trailing headers too long")
+        end
 
         key, value = HTTP.parse_header(line)
         break unless headers.add?(key, value)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -101,8 +101,8 @@ class HTTP::Request
 
   # Returns a `HTTP::Request` instance if successfully parsed,
   # `nil` on EOF or `HTTP::Status` otherwise.
-  def self.from_io(io) : HTTP::Request | HTTP::Status | Nil
-    line = parse_request_line(io)
+  def self.from_io(io, *, max_request_line_size : Int32 = 1_048_576) : HTTP::Request | HTTP::Status | Nil
+    line = parse_request_line(io, max_request_line_size)
     return line unless line.is_a?(RequestLine)
 
     HTTP.parse_headers_and_body(io) do |headers, body|
@@ -122,7 +122,7 @@ class HTTP::Request
 
   private METHODS = %w(GET HEAD POST PUT DELETE CONNECT OPTIONS PATCH TRACE)
 
-  private def self.parse_request_line(io : IO) : RequestLine | HTTP::Status | Nil
+  private def self.parse_request_line(io : IO, max_size : Int32) : RequestLine | HTTP::Status | Nil
     # Optimization: see if we have a peek buffer
     # (avoids a string allocation for the entire request line)
     if peek = io.peek
@@ -131,8 +131,9 @@ class HTTP::Request
 
       # See if we can find \n
       index = peek.index('\n'.ord.to_u8)
-      # TODO: eventually increase the 4096 bytes limit
-      if index && index < 4096
+      if index
+        return HTTP::Status::URI_TOO_LONG if index > max_size
+
         end_index = index
 
         # Also check (and discard) \r before that
@@ -146,8 +147,13 @@ class HTTP::Request
       end
     end
 
-    request_line = io.gets(4096, chomp: true)
+    request_line = io.gets(max_size + 1, chomp: true)
     return nil unless request_line
+
+    # Identify Request-URI too long
+    if request_line.bytesize > max_size
+      return HTTP::Status::URI_TOO_LONG
+    end
 
     parse_request_line(request_line)
   end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -105,7 +105,7 @@ class HTTP::Request
     line = parse_request_line(io, max_request_line_size)
     return line unless line.is_a?(RequestLine)
 
-    HTTP.parse_headers_and_body(io) do |headers, body|
+    status = HTTP.parse_headers_and_body(io) do |headers, body|
       # No need to dup headers since nobody else holds them
       request = new line.method, line.resource, headers, body, line.http_version, internal: nil
 
@@ -117,7 +117,7 @@ class HTTP::Request
     end
 
     # Malformed or unexpectedly ended http request
-    HTTP::Status::BAD_REQUEST
+    status || HTTP::Status::BAD_REQUEST
   end
 
   private METHODS = %w(GET HEAD POST PUT DELETE CONNECT OPTIONS PATCH TRACE)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -97,13 +97,11 @@ class HTTP::Request
   end
 
   # :nodoc:
-  record BadRequest
-  # :nodoc:
   record RequestLine, method : String, resource : String, http_version : String
 
   # Returns a `HTTP::Request` instance if successfully parsed,
-  # `nil` on EOF or `BadRequest` otherwise.
-  def self.from_io(io) : HTTP::Request | BadRequest | Nil
+  # `nil` on EOF or `HTTP::Status` otherwise.
+  def self.from_io(io) : HTTP::Request | HTTP::Status | Nil
     line = parse_request_line(io)
     return line unless line.is_a?(RequestLine)
 
@@ -119,12 +117,12 @@ class HTTP::Request
     end
 
     # Malformed or unexpectedly ended http request
-    BadRequest.new
+    HTTP::Status::BAD_REQUEST
   end
 
   private METHODS = %w(GET HEAD POST PUT DELETE CONNECT OPTIONS PATCH TRACE)
 
-  private def self.parse_request_line(io : IO) : RequestLine | BadRequest | Nil
+  private def self.parse_request_line(io : IO) : RequestLine | HTTP::Status | Nil
     # Optimization: see if we have a peek buffer
     # (avoids a string allocation for the entire request line)
     if peek = io.peek
@@ -154,15 +152,15 @@ class HTTP::Request
     parse_request_line(request_line)
   end
 
-  private def self.parse_request_line(line : String) : RequestLine | BadRequest
+  private def self.parse_request_line(line : String) : RequestLine | HTTP::Status
     parse_request_line(line.to_slice)
   end
 
-  private def self.parse_request_line(slice : Bytes) : RequestLine | BadRequest
+  private def self.parse_request_line(slice : Bytes) : RequestLine | HTTP::Status
     space_index = slice.index(' '.ord.to_u8)
 
     # Oops, only a single part (should be three)
-    return BadRequest.new unless space_index
+    return HTTP::Status::BAD_REQUEST unless space_index
 
     subslice = slice[0...space_index]
 
@@ -178,12 +176,12 @@ class HTTP::Request
     end
 
     # Oops, we only found the "method" part followed by spaces
-    return BadRequest.new if space_index == slice.size
+    return HTTP::Status::BAD_REQUEST if space_index == slice.size
 
     next_space_index = slice.index(' '.ord.to_u8, offset: space_index)
 
     # Oops, we only found two parts (should be three)
-    return BadRequest.new unless next_space_index
+    return HTTP::Status::BAD_REQUEST unless next_space_index
 
     resource = String.new(slice[space_index...next_space_index])
 
@@ -199,13 +197,13 @@ class HTTP::Request
 
     # Optimization: avoid allocating a string for common HTTP version
     http_version = HTTP::SUPPORTED_VERSIONS.find { |version| version.to_slice == subslice }
-    return BadRequest.new unless http_version
+    return HTTP::Status::BAD_REQUEST unless http_version
 
     # Skip trailing spaces
     space_index = next_space_index
     while space_index < slice.size
       # Oops, we find something else (more than three parts)
-      return BadRequest.new unless slice[space_index] == ' '.ord.to_u8
+      return HTTP::Status::BAD_REQUEST unless slice[space_index] == ' '.ord.to_u8
       space_index += 1
     end
 

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -156,6 +156,41 @@ class HTTP::Server
     @processor = RequestProcessor.new(handler)
   end
 
+  # Returns the maximum permitted size for the request line in an HTTP request.
+  #
+  # The request line is the first line of a request, consisting of method,
+  # resource and HTTP version and the delimiting line break.
+  # If the request line has a larger byte size than the permitted size,
+  # the server responds with the status code `414 URI Too Long` (see `HTTP::Status::URI_TOO_LONG`).
+  #
+  # Default: `HTTP::MAX_REQUEST_LINE_SIZE`
+  def max_request_line_size : Int32
+    @processor.max_request_line_size
+  end
+
+  # Sets the maximum permitted size for the request line in an HTTP request.
+  def max_request_line_size=(size : Int32)
+    @processor.max_request_line_size = size
+  end
+
+  # Returns the maximum permitted combined size for the headers in an HTTP request.
+  #
+  # When parsing a request, the server keeps track of the amount of total bytes
+  # consumed for all headers (including line breaks).
+  # If combined byte size of all headers is larger than the permitted size,
+  # the server responds with the status code `432 Request Header Fields Too Large`
+  # (see `HTTP::Status::REQUEST_HEADER_FIELDS_TOO_LARGE`).
+  #
+  # Default: `HTTP::MAX_HEADERS_SIZE`
+  def max_headers_size : Int32
+    @processor.max_headers_size
+  end
+
+  # Sets the maximum permitted combined size for the headers in an HTTP request.
+  def max_headers_size=(size : Int32)
+    @processor.max_headers_size = size
+  end
+
   # Creates a `TCPServer` listening on `host:port` and adds it as a socket, returning the local address
   # and port the server listens on.
   #

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -1,6 +1,12 @@
 require "../server"
 
 class HTTP::Server::RequestProcessor
+  # Maximum permitted size of the request line in an HTTP request.
+  property max_request_line_size = HTTP::MAX_REQUEST_LINE_SIZE
+
+  # Maximum permitted combined size of the headers in an HTTP request.
+  property max_headers_size = HTTP::MAX_HEADERS_SIZE
+
   def initialize(&@handler : HTTP::Handler::HandlerProc)
     @wants_close = false
   end
@@ -19,7 +25,11 @@ class HTTP::Server::RequestProcessor
 
     begin
       until @wants_close
-        request = HTTP::Request.from_io(input)
+        request = HTTP::Request.from_io(
+          input,
+          max_request_line_size: max_request_line_size,
+          max_headers_size: max_headers_size,
+        )
 
         # EOF
         break unless request

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -24,8 +24,8 @@ class HTTP::Server::RequestProcessor
         # EOF
         break unless request
 
-        if request.is_a?(HTTP::Request::BadRequest)
-          response.respond_with_error("Bad Request", 400)
+        if request.is_a?(HTTP::Status)
+          response.respond_with_error(request.description, request.value)
           response.close
           return
         end


### PR DESCRIPTION
This change removes `HTTP::Request::BadRequest` which was just a status type to signal an error in the request parser. Instead, `Request.from_io` directly returns an `HTTP::Status`  which can designate a different status code than `400 Bad Request`.

When a URI is too long (max size is configurable, defaults to 1MB), it returns `414 Request-URI too long`.
When the header fields are to large (`HTTP::MAX_HEADER_SIZE` = 1MB), it returns `431 Request Header Fields Too Large`.

Fixes #7838 