### PR TITLE
Improve Box of reference types

### DIFF
--- a/spec/std/box_spec.cr
+++ b/spec/std/box_spec.cr
@@ -6,4 +6,19 @@ describe "Box" do
     box = Box.box(a)
     Box(Int32).unbox(box).should eq(1)
   end
+
+  it "boxing a reference returns the same pointer" do
+    a = "foo"
+    box = Box.box(a)
+    box.address.should eq(a.object_id)
+
+    Box(String).unbox(box).should be(a)
+  end
+
+  it "boxing nil returns a null pointer" do
+    box = Box.box(nil)
+    box.address.should eq(0)
+
+    Box(Nil).unbox(box).should be_nil
+  end
 end

--- a/src/box.cr
+++ b/src/box.cr
@@ -14,6 +14,11 @@ class Box(T)
   def initialize(@object : T)
   end
 
+  # Creates a Box for a reference type (or `nil`) and returns the same pointer (or `NULL`)
+  def self.box(r : Reference?) : Void*
+    r.as(Void*)
+  end
+
   # Creates a Box for an object and returns it as a `Void*`.
   def self.box(object) : Void*
     new(object).as(Void*)
@@ -22,6 +27,13 @@ class Box(T)
   # Unboxes a `Void*` into an object of type `T`. Note that for this you must
   # specify T: `Box(T).unbox(data)`.
   def self.unbox(pointer : Void*) : T
-    pointer.as(self).object
+    {% if T <= Reference %}
+      pointer.as(T)
+    {% elsif T == Nil %}
+      # FIXME: This branch could be merged with the previous one once the issue #8015 is fixed
+      nil
+    {% else %}
+      pointer.as(self).object
+    {% end %}
   end
 end


### PR DESCRIPTION
Right now `Box(T)` always allocates memory to create a box for any object. With these changes it only allocates memory for value types.

For example:

```crystal
Box.box(123)   # => Pointer(Void)@0x104a29ff0
Box.box(nil)   # => Pointer(Void).null

foo = Foo.new  # => #<Foo:0x10b1b7ff0>
Box.box(foo)   # => Pointer(Void)@0x10b1b7ff0