### PR TITLE
Hash now uses an open addressing algorithm

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -341,6 +341,13 @@ describe "Hash" do
     h.to_h.should be(h)
   end
 
+  it "clones with size = 1" do
+    h1 = {1 => 2}
+    h2 = h1.clone
+    h1.should_not be(h2)
+    h1.should eq(h2)
+  end
+
   it "clones" do
     h1 = {1 => 2, 3 => 4}
     h2 = h1.clone

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -557,24 +557,80 @@ describe "Hash" do
     h.first.should eq({1, 2})
   end
 
-  it "gets first key" do
-    h = {1 => 2, 3 => 4}
-    h.first_key.should eq(1)
+  describe "first_key" do
+    it "gets first key" do
+      h = {1 => 2, 3 => 4}
+      h.first_key.should eq(1)
+    end
+
+    it "raises on first key (nilable key)" do
+      h = {} of Int32? => Int32
+      expect_raises(Exception, "Can't get first key of empty Hash") do
+        h.first_key
+      end
+    end
+
+    it "doesn't raise on first key (nilable key)" do
+      h = {nil => 1} of Int32? => Int32
+      h.first_key.should be_nil
+    end
   end
 
-  it "gets first value" do
-    h = {1 => 2, 3 => 4}
-    h.first_value.should eq(2)
+  describe "first_value" do
+    it "gets first value" do
+      h = {1 => 2, 3 => 4}
+      h.first_value.should eq(2)
+    end
+
+    it "raises on first value (nilable value)" do
+      h = {} of Int32 => Int32?
+      expect_raises(Exception, "Can't get first value of empty Hash") do
+        h.first_value
+      end
+    end
+
+    it "doesn't raise on first value (nilable value)" do
+      h = {1 => nil} of Int32 => Int32?
+      h.first_value.should be_nil
+    end
   end
 
-  it "gets last key" do
-    h = {1 => 2, 3 => 4}
-    h.last_key.should eq(3)
+  describe "last_key" do
+    it "gets last key" do
+      h = {1 => 2, 3 => 4}
+      h.last_key.should eq(3)
+    end
+
+    it "raises on last key (nilable key)" do
+      h = {} of Int32? => Int32
+      expect_raises(Exception, "Can't get last key of empty Hash") do
+        h.last_key
+      end
+    end
+
+    it "doesn't raise on last key (nilable key)" do
+      h = {nil => 1} of Int32? => Int32
+      h.last_key.should be_nil
+    end
   end
 
-  it "gets last value" do
-    h = {1 => 2, 3 => 4}
-    h.last_value.should eq(4)
+  describe "last_value" do
+    it "gets last value" do
+      h = {1 => 2, 3 => 4}
+      h.last_value.should eq(4)
+    end
+
+    it "raises on last value (nilable value)" do
+      h = {} of Int32 => Int32?
+      expect_raises(Exception, "Can't get last value of empty Hash") do
+        h.last_value
+      end
+    end
+
+    it "doesn't raise on last value (nilable value)" do
+      h = {1 => nil} of Int32 => Int32?
+      h.last_value.should be_nil
+    end
   end
 
   it "shifts" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -665,6 +665,16 @@ describe "Hash" do
     h.empty?.should be_true
   end
 
+  it "shifts: delete elements in the middle position and then in the first position" do
+    h = {1 => 'a', 2 => 'b', 3 => 'c', 4 => 'd'}
+    h.delete(2)
+    h.delete(3)
+    h.delete(1)
+    h.size.should eq(1)
+    h.should eq({4 => 'd'})
+    h.first.should eq({4, 'd'})
+  end
+
   it "shifts?" do
     h = {1 => 2}
     h.shift?.should eq({1, 2})

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -290,6 +290,20 @@ describe "Hash" do
       a.delete(2).should be_nil
     end
 
+    it "deletes many in the beginning and then will need a resize" do
+      h = {} of Int32 => Int32
+      8.times do |i|
+        h[i] = i
+      end
+      5.times do |i|
+        h.delete(i)
+      end
+      (9..12).each do |i|
+        h[i] = i
+      end
+      h.should eq({5 => 5, 6 => 6, 7 => 7, 9 => 9, 10 => 10, 11 => 11, 12 => 12})
+    end
+
     describe "with block" do
       it "returns the value if a key is found" do
         a = {1 => 2}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -635,9 +635,33 @@ describe "Hash" do
 
   it "shifts" do
     h = {1 => 2, 3 => 4}
+
     h.shift.should eq({1, 2})
     h.should eq({3 => 4})
+    h.first_key.should eq(3)
+    h.first_value.should eq(4)
+    h[1]?.should be_nil
+    h[3].should eq(4)
+
+    h.each.to_a.should eq([{3, 4}])
+    h.each_key.to_a.should eq([3])
+    h.each_value.to_a.should eq([4])
+
     h.shift.should eq({3, 4})
+    h.empty?.should be_true
+
+    expect_raises(IndexError) do
+      h.shift
+    end
+
+    20.times do |i|
+      h[i] = i
+    end
+    h.size.should eq(20)
+
+    20.times do |i|
+      h.shift.should eq({i, i})
+    end
     h.empty?.should be_true
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -892,18 +892,53 @@ describe "Hash" do
 
   it "creates with initial capacity" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234)
-    hash.@buckets_size.should eq(1234)
+    hash.@indices_size_pow2.should eq(11)
   end
 
   it "creates with initial capacity and default value" do
     hash = Hash(Int32, Int32).new(default_value: 3, initial_capacity: 1234)
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash.@indices_size_pow2.should eq(11)
   end
 
   it "creates with initial capacity and block" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234) { |h, k| h[k] = 3 }
     hash[1].should eq(3)
-    hash.@buckets_size.should eq(1234)
+    hash.@indices_size_pow2.should eq(11)
+  end
+
+  describe "some edge cases while changing the implementation to open addressing" do
+    it "edge case 1" do
+      h = {1 => 10}
+      h[1]?.should eq(10)
+      h.size.should eq(1)
+
+      h.delete(1)
+      h[1]?.should be_nil
+      h.size.should eq(0)
+
+      h[2] = 10
+      h[2]?.should eq(10)
+      h.size.should eq(1)
+
+      h[2] = 10
+      h[2]?.should eq(10)
+      h.size.should eq(1)
+    end
+
+    it "edge case 2" do
+      hash = Hash(Int32, Int32).new(initial_capacity: 0)
+      hash.@indices_size_pow2.should eq(0)
+      hash[1] = 2
+      hash[1].should eq(2)
+    end
+
+    it "edge case 3" do
+      h = {} of Int32 => Int32
+      (1 << 17).times do |i|
+        h[i] = i
+        h[i].should eq(i)
+      end
+    end
   end
 end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -355,18 +355,95 @@ describe "Hash" do
     h.to_h.should be(h)
   end
 
-  it "clones with size = 1" do
-    h1 = {1 => 2}
-    h2 = h1.clone
-    h1.should_not be(h2)
-    h1.should eq(h2)
+  describe "clone" do
+    it "clones with size = 1" do
+      h1 = {1 => 2}
+      h2 = h1.clone
+      h1.should_not be(h2)
+      h1.should eq(h2)
+    end
+
+    it "clones empty hash" do
+      h1 = {} of Int32 => Int32
+      h2 = h1.clone
+      h2.empty?.should be_true
+    end
+
+    it "clones small hash" do
+      h1 = {} of Int32 => Array(Int32)
+      4.times do |i|
+        h1[i] = [i]
+      end
+      h2 = h1.clone
+      h1.should_not be(h2)
+      h1.should eq(h2)
+
+      4.times do |i|
+        h1[i].should_not be(h2[i])
+      end
+
+      h1.delete(0)
+      h2[0].should eq([0])
+    end
+
+    it "clones big hash" do
+      h1 = {} of Int32 => Array(Int32)
+      1_000.times do |i|
+        h1[i] = [i]
+      end
+      h2 = h1.clone
+      h1.should_not be(h2)
+      h1.should eq(h2)
+
+      1_000.times do |i|
+        h1[i].should_not be(h2[i])
+      end
+
+      h1.delete(0)
+      h2[0].should eq([0])
+    end
   end
 
-  it "clones" do
-    h1 = {1 => 2, 3 => 4}
-    h2 = h1.clone
-    h1.should_not be(h2)
-    h1.should eq(h2)
+  describe "dup" do
+    it "dups empty hash" do
+      h1 = {} of Int32 => Int32
+      h2 = h1.dup
+      h2.empty?.should be_true
+    end
+
+    it "dups small hash" do
+      h1 = {} of Int32 => Array(Int32)
+      4.times do |i|
+        h1[i] = [i]
+      end
+      h2 = h1.dup
+      h1.should_not be(h2)
+      h1.should eq(h2)
+
+      4.times do |i|
+        h1[i].should be(h2[i])
+      end
+
+      h1.delete(0)
+      h2[0].should eq([0])
+    end
+
+    it "dups big hash" do
+      h1 = {} of Int32 => Array(Int32)
+      1_000.times do |i|
+        h1[i] = [i]
+      end
+      h2 = h1.dup
+      h1.should_not be(h2)
+      h1.should eq(h2)
+
+      1_000.times do |i|
+        h1[i].should be(h2[i])
+      end
+
+      h1.delete(0)
+      h2[0].should eq([0])
+    end
   end
 
   it "initializes with block" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1030,6 +1030,18 @@ describe "Hash" do
     hash.@indices_size_pow2.should eq(11)
   end
 
+  it "rehashes" do
+    a = [1]
+    h = {a => 0}
+    (10..20).each do |i|
+      h[[i]] = i
+    end
+    a << 2
+    h[a]?.should be_nil
+    h.rehash
+    h[a].should eq(0)
+  end
+
   describe "some edge cases while changing the implementation to open addressing" do
     it "edge case 1" do
       h = {1 => 10}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -747,6 +747,18 @@ describe "Hash" do
     h.to_a.size.should eq(0)
   end
 
+  it "clears after shift" do
+    h = {1 => 2, 3 => 4}
+    h.shift
+    h.clear
+    h.empty?.should be_true
+    h.to_a.size.should eq(0)
+    h[5] = 6
+    h.empty?.should be_false
+    h[5].should eq(6)
+    h.should eq({5 => 6})
+  end
+
   it "computes hash" do
     h1 = { {1 => 2} => {3 => 4} }
     h2 = { {1 => 2} => {3 => 4} }

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -218,16 +218,16 @@ class Hash(K, V)
   # less than 11 are ignored.
   def initialize(block : (Hash(K, V), K -> V)? = nil, *, initial_capacity = nil)
     initial_capacity = (initial_capacity || 0).to_i32
-    initial_indices_size = Math.pw2ceil(initial_capacity)
 
     # Same as the empty hash case
     # (but this constructor is a bit more expensive in terms of code execution).
-    if initial_indices_size == 0
+    if initial_capacity == 0
       @entries = Pointer(Entry(K, V)).null
       @indices = Pointer(UInt8).null
       @indices_size_pow2 = 0
       @indices_bytesize = 1
     else
+      initial_indices_size = Math.pw2ceil(initial_capacity)
       @entries = Pointer(Entry(K, V)).malloc(initial_indices_size / 2)
 
       # Check if we can avoid allocating the `@indices` buffer for

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -598,9 +598,10 @@ class Hash(K, V)
             else
               @indices.as(UInt32*)[index].to_i32!
             end
-    # Because 0 means empty we return -1,
-    # otherwise we decrement the value (so we can represent the index "0")
-    value == 0 ? -1 : value - 1
+
+    # Because we increment the value by one when we store the value
+    # here we have to substract one
+    value - 1
   end
 
   # Sets `@indices` at `index` with the given value.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -607,6 +607,7 @@ class Hash(K, V)
     @size = 0
     @deleted_count = 0
     @indices_bytesize = 1
+    @first = 0
   end
 
   # Gets from `@indices` at the given `index`.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -374,8 +374,8 @@ class Hash(K, V)
   # Upserts the key-value-hash triplet by doing a linear scan
   # first to see if the key already exists.
   # Returns true if the key was updated or inserted without needing
-  # a resize. Returns false if a resize was needed (and one) and
-  # the key wasn't inserted.
+  # a resize. Returns false if a resize was needed and the key
+  # wasn't inserted.
   private def upsert_linear_scan(key, value, hash) : Bool
     # Just do a linear scan...
     each_entry_with_index do |entry, index|

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1376,7 +1376,8 @@ class Hash(K, V)
 
   # Returns the first key in the hash.
   def first_key
-    first_key?.not_nil!
+    entry = first_entry?
+    entry ? entry.key : raise "Can't get first key of empty Hash"
   end
 
   # Returns the first key if it exists, or returns `nil`.
@@ -1393,7 +1394,8 @@ class Hash(K, V)
 
   # Returns the first value in the hash.
   def first_value
-    first_value?.not_nil!
+    entry = first_entry?
+    entry ? entry.value : raise "Can't get first value of empty Hash"
   end
 
   # Returns the first value if it exists, or returns `nil`.
@@ -1410,7 +1412,8 @@ class Hash(K, V)
 
   # Returns the last key in the hash.
   def last_key
-    last_key?.not_nil!
+    entry = last_entry?
+    entry ? entry.key : raise "Can't get last key of empty Hash"
   end
 
   # Returns the last key if it exists, or returns `nil`.
@@ -1427,7 +1430,8 @@ class Hash(K, V)
 
   # Returns the last value in the hash.
   def last_value
-    last_value?.not_nil!
+    entry = last_entry?
+    entry ? entry.value : raise "Can't get last value of empty Hash"
   end
 
   # Returns the last value if it exists, or returns `nil`.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -699,7 +699,9 @@ class Hash(K, V)
   end
 
   # Yields each non-deleted Entry with its index inside `@entries`.
-  private def each_entry_with_index
+  private def each_entry_with_index : Nil
+    return if @size == 0
+
     entries_size.times do |i|
       entry = get_entry(i)
       yield entry, i unless entry.deleted?

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -379,7 +379,7 @@ class Hash(K, V)
   private def upsert_linear_scan(key, value, hash) : Bool
     # Just do a linear scan...
     each_entry_with_index do |entry, index|
-      if hash == entry.hash && entry.key == key
+      if entry.matches?(hash, key)
         set_entry(index, Entry(K, V).new(entry.hash, entry.key, value))
         return true
       end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -525,7 +525,7 @@ class Hash(K, V)
     # have many deleted elements.
     if @deleted_count < @size
       # First grow `@entries`
-      @entries = @entries.realloc(indices_size)
+      realloc_entries(indices_size)
       double_indices_size
 
       # If we didn't have `@indices` and we still don't have 16 entries
@@ -828,6 +828,10 @@ class Hash(K, V)
   # Allocates `size` number of entries for `@entries`.
   private def malloc_entries(size)
     Pointer(Entry(K, V)).malloc(size)
+  end
+
+  private def realloc_entries(size)
+    @entries = @entries.realloc(size)
   end
 
   # Marks all existing entries as deleted

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -534,9 +534,14 @@ class Hash(K, V)
         return
       end
 
-      # Otherwise, we must start using `@indices`
+      # Otherwise, we must either start using `@indices`
+      # or grow the ones we had.
       @indices_bytesize = compute_indices_bytesize(indices_size)
-      @indices = malloc_indices(indices_size)
+      if @indices.null?
+        @indices = malloc_indices(indices_size)
+      else
+        @indices = realloc_indices(indices_size)
+      end
     end
 
     do_compaction

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -754,6 +754,9 @@ class Hash(K, V)
   # Internal implementation ends
   # ===========================================================================
 
+  # Returns the number of elements in this Hash.
+  getter size : Int32
+
   # Sets the value of *key* to the given *value*.
   #
   # ```

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -589,7 +589,7 @@ class Hash(K, V)
   # whether the maximum hash size is reached.
   private def double_indices_size : Nil
     if indices_size == MAXIMUM_INDICES_SIZE
-      raise "Maximim Hash size reached"
+      raise "Maximum Hash size reached"
     end
 
     @indices_size_pow2 += 1

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -230,7 +230,13 @@ class Hash(K, V)
       @indices_size_pow2 = 0
       @indices_bytesize = 1
     else
-      initial_indices_size = Math.pw2ceil(initial_capacity)
+      # Translate initial capacity to the nearest power of 2, but keep it a minimum of 8.
+      if initial_capacity < 8
+        initial_indices_size = 8
+      else
+        initial_indices_size = Math.pw2ceil(initial_capacity)
+      end
+
       @entries = Pointer(Entry(K, V)).malloc(initial_indices_size / 2)
 
       # Check if we can avoid allocating the `@indices` buffer for

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -158,12 +158,6 @@ class Hash(K, V)
   # Could be a Slice but this way we might save a few bounds checking.
   @indices : Pointer(UInt8)
 
-  # The size of `@indices` given as a power of 2.
-  # For example if it's 4 it means 2**4 so size 16.
-  # Can be zero when hash is totally empty.
-  # Otherwise guaranteed to be at least 3.
-  @indices_size_pow2 : UInt32
-
   # The number of actual entries in the hash.
   # Exposed to the user via the `size` getter.
   @size : Int32
@@ -177,6 +171,12 @@ class Hash(K, V)
   # - 2 means `Pointer(UInt16)`
   # - 4 means `Pointer(UInt32)`
   @indices_bytesize : Int8
+
+  # The size of `@indices` given as a power of 2.
+  # For example if it's 4 it means 2**4 so size 16.
+  # Can be zero when hash is totally empty.
+  # Otherwise guaranteed to be at least 3.
+  @indices_size_pow2 : UInt8
 
   # The optional block that triggers on non-existing keys.
   @block : (self, K -> V)?
@@ -234,7 +234,7 @@ class Hash(K, V)
         @indices_bytesize = 1
       end
 
-      @indices_size_pow2 = Math.log2(initial_indices_size).to_u32
+      @indices_size_pow2 = Math.log2(initial_indices_size).to_u8
     end
 
     @size = 0

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -36,11 +36,161 @@ class Hash(K, V)
   include Enumerable({K, V})
   include Iterable({K, V})
 
-  getter size : Int32
-  @buckets_size : Int32
-  @first : Entry(K, V)?
-  @last : Entry(K, V)?
+  # ===========================================================================
+  # Overall explanation of the algorithm
+  # ===========================================================================
+  #
+  # Hash implements an open addressing collision resolution method:
+  # https://en.wikipedia.org/wiki/Open_addressing
+  #
+  # The collision resolution is done using Linear Probing:
+  # https://en.wikipedia.org/wiki/Linear_probing
+  #
+  # The algorithm is partially based on Ruby's one but they are not exactly the same:
+  # https://github.com/ruby/ruby/blob/a4c09342a2219a8374240ef8d0ca86abe287f715/st.c#L1-L101
+  #
+  # There are two main data structures:
+  #
+  # - @entries:
+  #     A continguous buffer (Pointer) of hash entries (Entry) in the order
+  #     they were inserted. This makes it possible for Hash to preserve
+  #     order of insertion.
+  #     An entry holds a key-value pair together with the key's hash code.
+  #     An entry can also be marked as deleted. This is accomplished by using
+  #     0 as the hash code value. Because 0 is a valid hash code value, when
+  #     computing the key's hash code if it's 0 then it's replaced by another
+  #     value (UInt32::MAX). The alternative would be to use a boolean but
+  #     that involves more memory allocated and worse performance.
+  # - @indices:
+  #     A buffer of indices into the @entries buffer.
+  #     An index might mean it's empty. We could use -1 for this but because
+  #     of an optimization we'll explain later we use 0, and all other values
+  #     represent indices which are 1 less than their actual value (so value
+  #     3 means index 2).
+  #     When a key-value pair is inserted we first find the key's hash and
+  #     then fit it (by modulo) into the indices buffer size. For example,
+  #     assuming we are inserting a new key-value pair with key "hello",
+  #     if the indices size is 128, the key is "hello" and its hash is
+  #     987 then fitting it into 128 is (987 % 128) gives 91. Lets also
+  #     assume there are already 3 entries in @entries. We go ahead an add
+  #     a new entry at index 3, and at position 91 in @indices we store 3
+  #     (well, actually 4 because we store 1 more than the actual index
+  #     because 0 means empty, as explained above).
+  #
+  # Open addressing means that if, in the example above, we go and try to
+  # insert another key with a hash that will be placed in the same position
+  # in indices (let's say, 91 again), because it's occupied we will insert
+  # it into the next non-empty slot. We try with 92. If it's empty we again
+  # go and insert it intro `@entries` and store the index at 92 (continuing
+  # with the previous example we would store the value 4).
+  #
+  # If we keep the size of @indices the same as @entries it means that in the worse
+  # case @indices is full and when finding a match we have to traverse it all,
+  # which is bad. That's why we always make the size of @indices at least twice
+  # as big as the size of @entries, so the non-empty indices will tend to be
+  # spread apart with empty indices in the middle.
+  #
+  # Also, we always keep the sizes of `@indices` and `@entries` (`indices_size` / 2)
+  # powers of 2, with the smallest size of `@indices` being 8 (and thus of
+  # `@entries` being 4).
+  #
+  # The size of `@indices` is stored as a number that has to be powered by 2 in
+  # `@indices_size_pow2`. For example if `@indices_size_pow2` is 3 then the actual
+  # size is 2**3 = 8.
+  #
+  # Next comes the optimizations.
+  #
+  # The first one is that for an empty hash we don't allocate `@entries`
+  # nor `@indices`, and there are a few checks against these when adding
+  # and fetching elements. Sometimes hashes are created empty and remain empty
+  # for some time or for the duration of the program when not used, and this
+  # helps save some memory.
+  #
+  # The second optimization is that for small hashes (less or equal to 16 elements)
+  # we don't allocate `@indices` and just perform a linear scan on `@entries`.
+  # This is an heuristic but in practice it's faster to search linearly in small
+  # hashes. There's another heuristic here: if we have less than or equal to 8
+  # elements we just compare values when doing the linear scan. If we have between
+  # 9 and 16 we first compute the hash code of the key and compare the hash codes
+  # first (at this point computing the hash code plus comparing them might become
+  # cheaper than doing a full comparison each time). This optimization also exists
+  # in the Ruby implementation (though it seems hash values are always compared).
+  #
+  # A third optimization is in the way `@indices` is allocated: when the number
+  # of entries is less than or equal to 128 (2 ** 8 / 2) the indexes values will range between
+  # 0 and 128. That means we can use `Pointer(UInt8)` as the type of `@indices`.
+  # (we can't do it for ranges between 0 and 256 because we need a value that means
+  # "empty"). Similarly, for ranges between 128 and 32768 (2 ** 16 / 2) we can use
+  # `Pointer(UInt16)`. This saves some memory (and the performance difference is
+  # noticeable). We store the bytesize of the `@indices` buffer in `@indices_bytesize`
+  # with values 1 (UInt8), 2 (UInt16) or 4 (UInt32). This optimization also exists
+  # in the Ruby implementation.
+  #
+  # Another optimization is, when fitting a value inside the range of `@indices`,
+  # to use masking (value & mask) instead of `remainder` or `%`, which apparently
+  # are much slower. This optimization also exists in the Ruby implementation.
+  #
+  # We also keep track of the number of deleted entries (`@deleted_count`). When an
+  # entry is deleted we just mark it as deleted by using the special hash value 0.
+  # Only when the hash needs to be resized we do something with this instance variable:
+  # if we have many deleted entries (at least as many as the number of non-deleted
+  # entries) we compact the map and avoid a resize. Otherwise we remove the non-deleted
+  # entries but also resize both the `@entries` and `@indices` buffer. This probably
+  # avoids an edge case where one deletes and inserts an element and there is a constant
+  # shift of the buffer (expensive).
+  #
+  # There might be other optimizations to try out, like not using Linear Probing,
+  # but for now this implementaton is much faster than the old one which used
+  # linked lists (closed addressing).
+  #
+  # All methods that deal with this implementation come after the constructors.
+  # Then all other methods use the internal methods, usually using other high-level
+  # methods.
+
+  # The buffer of entries.
+  # Might be null if the hash is empty at the very beginning.
+  # Has always the size of `indices_size` / 2.
+  @entries : Pointer(Entry(K, V))
+
+  # The buffer of indices into entries. Its size is given by `@indices_size_pow2`.
+  # Might be null if the hash is empty at the very beginning or when the hash
+  # size is less than or equal to 16.
+  # Could be a Slice but this way we might save a few bounds checking.
+  @indices : Pointer(UInt8)
+
+  # The size of `@indices` given as a power of 2.
+  # For example if it's 4 it means 2**4 so size 16.
+  # Can be zero when hash is totally empty.
+  # Otherwise guaranteed to be at least 3.
+  @indices_size_pow2 : UInt32
+
+  # The number of actual entries in the hash.
+  # Exposed to the user via the `size` getter.
+  @size : Int32
+
+  # The number of deleted entries.
+  # Resets to zero when the hash resizes.
+  @deleted_count : Int32
+
+  # The actual type of `@indices`:
+  # - 1 means `Pointer(UInt8)`
+  # - 2 means `Pointer(UInt16)`
+  # - 4 means `Pointer(UInt32)`
+  @indices_bytesize : Int8
+
+  # The optional block that triggers on non-existing keys.
   @block : (self, K -> V)?
+
+  # Creates a new empty `Hash`.
+  def initialize
+    @entries = Pointer(Entry(K, V)).null
+    @indices = Pointer(UInt8).null
+    @indices_size_pow2 = 0
+    @size = 0
+    @deleted_count = 0
+    @block = nil
+    @indices_bytesize = 1
+  end
 
   # Creates a new empty `Hash` with a *block* for handling missing keys.
   #
@@ -60,13 +210,35 @@ class Hash(K, V)
   # a hash will hold is known, the hash should be initialized with that
   # capacity for improved performance. Otherwise, the default is 11 and inputs
   # less than 11 are ignored.
-  def initialize(block : (Hash(K, V), K -> V)? = nil, initial_capacity = nil)
-    initial_capacity ||= 11
-    initial_capacity = 11 if initial_capacity < 11
-    initial_capacity = initial_capacity.to_i
-    @buckets = Pointer(Entry(K, V)?).malloc(initial_capacity)
-    @buckets_size = initial_capacity
+  def initialize(block : (Hash(K, V), K -> V)? = nil, *, initial_capacity = nil)
+    initial_capacity = (initial_capacity || 0).to_i32
+    initial_indices_size = Math.pw2ceil(initial_capacity)
+
+    # Same as the empty hash case
+    # (but this constructor is a bit more expensive in terms of code execution).
+    if initial_indices_size == 0
+      @entries = Pointer(Entry(K, V)).null
+      @indices = Pointer(UInt8).null
+      @indices_size_pow2 = 0
+      @indices_bytesize = 1
+    else
+      @entries = Pointer(Entry(K, V)).malloc(initial_indices_size / 2)
+
+      # Check if we can avoid allocating the `@indices` buffer for
+      # small hashes.
+      if initial_indices_size > MAX_INDICES_SIZE_LINEAR_SCAN
+        @indices_bytesize = compute_indices_bytesize(initial_indices_size)
+        @indices = malloc_indices(initial_indices_size)
+      else
+        @indices = Pointer(UInt8).null
+        @indices_bytesize = 1
+      end
+
+      @indices_size_pow2 = Math.log2(initial_indices_size).to_u32
+    end
+
     @size = 0
+    @deleted_count = 0
     @block = block
   end
 
@@ -118,6 +290,479 @@ class Hash(K, V)
     new(initial_capacity: initial_capacity) { default_value }
   end
 
+  # ===========================================================================
+  # Internal implementation starts
+  # ===========================================================================
+
+  # Maximum number of `indices_size` for which we do a linear scan
+  # (maximum of 16 entries in `@entries`)
+  private MAX_INDICES_SIZE_LINEAR_SCAN = 32
+
+  # Maximum number of `indices_size` for which we can represent `@indices`
+  # as Pointer(UInt8).
+  private MAX_INDICES_BYTESIZE_1 = 256
+
+  # Maximum number of `indices_size` for which we can represent `@indices`
+  # as Pointer(UInt16).
+  private MAX_INDICES_BYTESIZE_2 = 65536
+
+  # Inserts or updates a key-value pair.
+  private def upsert(key, value) : Nil
+    # Empty hash table so only initialize entries for now
+    if @entries.null?
+      @indices_size_pow2 = 3
+      @entries = Pointer(Entry(K, V)).malloc(4)
+    end
+
+    hash = key_hash(key)
+
+    # No indices allocated yet so try to do a linear scan
+    if @indices.null?
+      # Try to do an upsert by doing a linear scan
+      upserted = upsert_linear_scan(key, value, hash)
+      return if upserted
+
+      # If we couldn't upsert it means the table was full
+      # so a resize might have been done.
+      # Now, it could happen that we are still with less than 16 elements
+      # and so `@indices` will be null, in which case we only need to
+      # add the key-value pair at the end of the `@entries` buffer.
+      if @indices.null?
+        add_entry_and_increment_size(hash, key, value)
+        return
+      end
+
+      # Otherwise `@indices` became non-null which means we can't do
+      # a linear scan anymore.
+    end
+
+    # Fit the hash value into an index in `@indices`
+    index = fit_in_indices(hash)
+
+    while true
+      entry_index = get_index(index)
+
+      # If the index entry is empty...
+      if entry_index == -1
+        # If we reached the maximum in `@entries` it's time to resize
+        if entries_full?
+          resize
+          # We have to fit the hash into an index in `@indices` again, and try again
+          index = fit_in_indices(hash)
+          next
+        end
+
+        # We have free space: store the index and then insert the entry
+        set_index(index, entries_size)
+        add_entry_and_increment_size(hash, key, value)
+        break
+      end
+
+      # We found a non-empty slot, let's see if the key we have matches
+      entry = get_entry(entry_index)
+      if entry.matches?(hash, key)
+        # If it does we just update the entry
+        set_entry(entry_index, Entry(K, V).new(hash, key, value))
+        break
+      else
+        # Otherwise we have to keep looking...
+        index = next_index(index)
+      end
+    end
+  end
+
+  # Upserts the key-value-hash triplet by doing a linear scan
+  # first to see if the key already exists.
+  # Returns true if the key was updated or inserted without needing
+  # a resize. Returns false if a resize was needed (and one) and
+  # the key wasn't inserted.
+  private def upsert_linear_scan(key, value, hash) : Bool
+    # Just do a linear scan...
+    each_entry_with_index do |entry, index|
+      if hash == entry.hash && entry.key == key
+        set_entry(index, Entry(K, V).new(entry.hash, entry.key, value))
+        return true
+      end
+    end
+
+    # If full, resize. Otherwise we have space so add as last.
+    if entries_full?
+      resize
+      false
+    else
+      add_entry_and_increment_size(hash, key, value)
+      true
+    end
+  end
+
+  # Implementation of deleting a key.
+  # Returns the deleted Entry, if it existed, `nil` otherwise.
+  private def delete_impl(key) : Entry(K, V)?
+    # Empty hash table, nothing to do
+    if @indices_size_pow2 == 0
+      return nil
+    end
+
+    hash = key_hash(key)
+
+    # No indices allocated yet so do linear scan
+    if @indices.null?
+      return delete_linear_scan(key, hash)
+    end
+
+    # Fit hash into `@indices` size
+    index = fit_in_indices(hash)
+    while true
+      entry_index = get_index(index)
+
+      # If we find an empty index slot, there's no such key
+      if entry_index == -1
+        return nil
+      end
+
+      # We found a non-empty slot, let's see if the key we have matches
+      entry = get_entry(entry_index)
+      if entry.matches?(hash, key)
+        delete_entry_and_update_counts(entry_index)
+        return entry
+      else
+        # If it doesn't, check the next index...
+        index = next_index(index)
+      end
+    end
+  end
+
+  # Delete by doing a linear scan over `@entries`.
+  # Returns the deleted Entry, if it existed, `nil` otherwise.
+  private def delete_linear_scan(key, hash) : Entry(K, V)?
+    each_entry_with_index do |entry, index|
+      if entry.matches?(hash, key)
+        delete_entry_and_update_counts(index)
+        return entry
+      end
+    end
+
+    nil
+  end
+
+  # Finds an entry with the given key.
+  protected def find_entry(key) : Entry(K, V)?
+    # Empty hash table so there's no way it's there
+    if @indices_size_pow2 == 0
+      return nil
+    end
+
+    # No indices allocated yet so do linear scan
+    if @indices.null?
+      return find_entry_linear_scan(key)
+    end
+
+    hash = key_hash(key)
+
+    # Fit hash into `@indices` size
+    index = fit_in_indices(hash)
+    while true
+      entry_index = get_index(index)
+
+      # If we find an empty index slot, there's no such key
+      if entry_index == -1
+        return nil
+      end
+
+      # We found a non-empty slot, let's see if the key we have matches
+      entry = get_entry(entry_index)
+      if entry.matches?(hash, key)
+        # It does!
+        return entry
+      else
+        # Nope, move on to the next slot
+        index = next_index(index)
+      end
+    end
+  end
+
+  # Finds an Entry with the given key by doing a linear scan.
+  private def find_entry_linear_scan(key) : Entry(K, V)?
+    # If we have less than 8 elements we avoid computing the hash
+    # code and directly compare the keys (might be cheaper than
+    # computing a hash code of a complex structure).
+    if entries_size <= 8
+      each_entry_with_index do |entry|
+        return entry if entry.key == key
+      end
+    else
+      hash = key_hash(key)
+      each_entry_with_index do |entry|
+        return entry if entry.matches?(hash, key)
+      end
+    end
+
+    nil
+  end
+
+  # Tries to resize the hash table in the condition that there are
+  # no more available entries to add.
+  # Might not result in a resize if there are many entries marked as
+  # deleted. In that case the entries table is simply compacted.
+  # However, in case of a resize deleted entries are also compcated.
+  private def resize : Nil
+    # If we don't have `@indices` it means we have less than 16 elements
+    # in `@entries` so just grow that. Here we don't try to compact
+    # deleted elements (might not be worth it).
+    if @indices.null?
+      @entries = @entries.realloc(indices_size)
+      double_indices_size
+      # Stop doing linear scan when we have more than 16 entries
+      if indices_size > MAX_INDICES_SIZE_LINEAR_SCAN
+        @indices_bytesize = compute_indices_bytesize(indices_size)
+        @indices = malloc_indices(indices_size)
+      else
+        return
+      end
+    else
+      # Only resize if we don't have many deleted elements.
+      if @deleted_count < @size
+        @entries = @entries.realloc(indices_size)
+        double_indices_size
+        @indices_bytesize = compute_indices_bytesize(indices_size)
+        @indices = realloc_indices(indices_size)
+      end
+
+      # Must must clear the indices because we'll rebuild them from scratch
+      clear_indices
+    end
+
+    # Here we traverse the `@entries` and compute their new index in `@indices`
+    # while moving non-deleted entries to the beginning (compaction).
+    new_entry_index = 0
+    each_entry_with_index do |entry, entry_index|
+      # First we move the index to its new index (if we need to do that)
+      set_entry(new_entry_index, entry) if entry_index != new_entry_index
+
+      # Then we try to find an empty index slot (we should find one now
+      # that we have more space)
+      index = fit_in_indices(entry.hash)
+      until get_index(index) == -1
+        index = next_index(index)
+      end
+
+      set_index(index, new_entry_index)
+      new_entry_index += 1
+    end
+
+    # We have to mark entries starting from the final new index
+    # as deleted so the GC can collect them.
+    entries_to_clear = entries_size - new_entry_index
+    if entries_to_clear > 0
+      (entries + new_entry_index).clear(entries_to_clear)
+    end
+
+    # After compaction we no longer have deleted entries
+    @deleted_count = 0
+  end
+
+  # After this it's 1 << 28, and with entries being Int32
+  # (4 bytes) it's 1 << 30 of actual bytesize and the
+  # next value would be 1 << 31 which overflows `Int32`.
+  private MAXIMUM_INDICES_SIZE = 1 << 28
+
+  # Doubles the value of `@indices_size` but first checks
+  # whether the maximum hash size is reached.
+  private def double_indices_size : Nil
+    if indices_size == MAXIMUM_INDICES_SIZE
+      raise "Maximim Hash size reached"
+    end
+
+    @indices_size_pow2 += 1
+  end
+
+  # Implementation of clearing the hash table.
+  private def clear_impl : Nil
+    @entries = Pointer(Entry(K, V)).null
+    @indices = Pointer(UInt8).null
+    @indices_size_pow2 = 0
+    @size = 0
+    @deleted_count = 0
+    @indices_bytesize = 1
+  end
+
+  # Gets from `@indices` at the given `index`.
+  # Returns the index in `@entries` or `-1` if the slot is empty.
+  private def get_index(index : Int32) : Int32
+    # Check what we have: UInt8, Int16 or UInt32 buckets
+    value = case @indices_bytesize
+            when 1
+              @indices[index].to_i32!
+            when 2
+              @indices.as(UInt16*)[index].to_i32!
+            else
+              @indices.as(UInt32*)[index].to_i32!
+            end
+    # Because 0 means empty we return -1,
+    # otherwise we decrement the value (so we can represent the index "0")
+    value == 0 ? -1 : value - 1
+  end
+
+  # Sets `@indices` at `index` with the given value.
+  private def set_index(index, value) : Nil
+    # We actually store 1 more than the value because 0 means empty.
+    value += 1
+
+    # We also have to see what we have: UInt8, UInt16 or UInt32 buckets.
+    case @indices_bytesize
+    when 1
+      @indices[index] = value.to_u8!
+    when 2
+      @indices.as(UInt16*)[index] = value.to_u16!
+    else
+      @indices.as(UInt32*)[index] = value.to_u32!
+    end
+  end
+
+  # Marks `@indices` at `index` as empty.
+  private def empty_index(index) : Nil
+    case @indices_bytesize
+    when 1
+      @indices[index] = 0_u8
+    when 2
+      @indices.as(UInt16*)[index] = 0_u16
+    else
+      @indices.as(UInt32*)[index] = 0_u32
+    end
+  end
+
+  # Returns the capacity of `@indices`.
+  private def indices_size
+    1 << @indices_size_pow2
+  end
+
+  # Computes what bytesize we'll store in `@indices` according to its size
+  private def compute_indices_bytesize(size) : Int8
+    case
+    when size <= MAX_INDICES_BYTESIZE_1
+      1_i8
+    when size <= MAX_INDICES_BYTESIZE_2
+      2_i8
+    else
+      4_i8
+    end
+  end
+
+  # Allocates `size` number of indices for `@indices`.
+  private def malloc_indices(size)
+    Pointer(UInt8).malloc(size * @indices_bytesize)
+  end
+
+  # Reallocates `size` number of indices for `@indices`.
+  private def realloc_indices(size)
+    @indices.realloc(size * @indices_bytesize)
+  end
+
+  # Marks all existing indices as empty.
+  private def clear_indices : Nil
+    @indices.clear(indices_size * @indices_bytesize)
+  end
+
+  # Returns the entry in `@entries` at `index`.
+  private def get_entry(index) : Entry(K, V)
+    @entries[index]
+  end
+
+  # Sets the entry in `@entries` at `index`.
+  private def set_entry(index, value) : Nil
+    @entries[index] = value
+  end
+
+  # Adds an entry at the end and also increments this hash's size.
+  private def add_entry_and_increment_size(hash, key, value) : Nil
+    set_entry(entries_size, Entry(K, V).new(hash, key, value))
+    @size += 1
+  end
+
+  # Marks an entry in `@entries` at `index` as deleted
+  # *without* modifying any counters (`@size` and `@deleted_count`).
+  private def delete_entry(index) : Nil
+    set_entry(index, Entry(K, V).deleted)
+  end
+
+  # Marks an entry in `@entries` at `index` as deleted
+  # and updates the `@size` and `@deleted_count` counters.
+  private def delete_entry_and_update_counts(index) : Nil
+    delete_entry(index)
+    @size -= 1
+    @deleted_count += 1
+  end
+
+  # Returns true if there's no place for new entries without doing a resize.
+  private def entries_full? : Bool
+    entries_size == indices_size / 2
+  end
+
+  # Yields each non-deleted Entry with its index inside `@entries`.
+  private def each_entry_with_index
+    entries_size.times do |i|
+      entry = get_entry(i)
+      yield entry, i unless entry.deleted?
+    end
+  end
+
+  # Computes the next index in `@indices`, needed when an index is not empty.
+  private def next_index(index : Int32) : Int32
+    fit_in_indices(index + 1)
+  end
+
+  # Fits a value inside the range of `@indices`
+  private def fit_in_indices(value) : Int32
+    # We avoid doing modulo (`%` or `remainder`) because it's much
+    # slower than `<<` + `-` + `&`.
+    # For example if `@indices_size_pow2` is 8 then `indices_size`
+    # will be 256 (1 << 8) and the mask we use is 0xFF, which is 256 - 1.
+    (value & ((1_u32 << @indices_size_pow2) - 1)).to_i32!
+  end
+
+  # Returns the first `Entry` or `nil` if non exists.
+  private def first_entry?
+    return nil if @size == 0
+
+    each_entry_with_index do |entry|
+      return entry
+    end
+
+    # Might happen if the Hash is modified concurrently
+    nil
+  end
+
+  # Returns the first `Entry` or `nil` if non exists.
+  private def last_entry?
+    return nil if @size == 0
+
+    (entries_size - 1).downto(0).each do |i|
+      entry = get_entry(i)
+      return entry unless entry.deleted?
+    end
+
+    # Might happen if the Hash is modified concurrently
+    nil
+  end
+
+  protected getter entries
+
+  # Returns the total number of existing entries, including
+  # deleted and non-deleted ones.
+  protected def entries_size
+    @size + @deleted_count
+  end
+
+  # Computes the hash of a key.
+  private def key_hash(key)
+    hash = key.hash.to_u32!
+    hash == 0 ? UInt32::MAX : hash
+  end
+
+  # ===========================================================================
+  # Internal implementation ends
+  # ===========================================================================
+
   # Sets the value of *key* to the given *value*.
   #
   # ```
@@ -126,21 +771,7 @@ class Hash(K, V)
   # h["foo"] # => "bar"
   # ```
   def []=(key : K, value : V)
-    rehash if @size > 5 * @buckets_size
-
-    index = bucket_index key
-    entry = insert_in_bucket index, key, value
-    return value unless entry
-
-    @size += 1
-
-    if last = @last
-      last.fore = entry
-      entry.back = last
-    end
-
-    @last = entry
-    @first = entry unless @first
+    upsert(key, value)
     value
   end
 
@@ -342,43 +973,8 @@ class Hash(K, V)
   # h.delete("baz") { |key| "#{key} not found" } # => "baz not found"
   # ```
   def delete(key)
-    index = bucket_index(key)
-    entry = @buckets[index]
-
-    previous_entry = nil
-    while entry
-      if entry.key == key
-        back_entry = entry.back
-        fore_entry = entry.fore
-        if fore_entry
-          if back_entry
-            back_entry.fore = fore_entry
-            fore_entry.back = back_entry
-          else
-            @first = fore_entry
-            fore_entry.back = nil
-          end
-        else
-          if back_entry
-            back_entry.fore = nil
-            @last = back_entry
-          else
-            @first = nil
-            @last = nil
-          end
-        end
-        if previous_entry
-          previous_entry.next = entry.next
-        else
-          @buckets[index] = entry.next
-        end
-        @size -= 1
-        return entry.value
-      end
-      previous_entry = entry
-      entry = entry.next
-    end
-    yield key
+    entry = delete_impl(key)
+    entry ? entry.value : yield key
   end
 
   # Deletes each key-value pair for which the given block returns `true`.
@@ -429,10 +1025,8 @@ class Hash(K, V)
   #
   # The enumeration follows the order the keys were inserted.
   def each : Nil
-    current = @first
-    while current
-      yield({current.key, current.value})
-      current = current.fore
+    each_entry_with_index do |entry, i|
+      yield({entry.key, entry.value})
     end
   end
 
@@ -449,7 +1043,7 @@ class Hash(K, V)
   #
   # The enumeration follows the order the keys were inserted.
   def each
-    EntryIterator(K, V).new(self, @first)
+    EntryIterator(K, V).new(self)
   end
 
   # Calls the given block for each key-value pair and passes in the key.
@@ -484,7 +1078,7 @@ class Hash(K, V)
   #
   # The enumeration follows the order the keys were inserted.
   def each_key
-    KeyIterator(K, V).new(self, @first)
+    KeyIterator(K, V).new(self)
   end
 
   # Calls the given block for each key-value pair and passes in the value.
@@ -519,7 +1113,7 @@ class Hash(K, V)
   #
   # The enumeration follows the order the keys were inserted.
   def each_value
-    ValueIterator(K, V).new(self, @first)
+    ValueIterator(K, V).new(self)
   end
 
   # Returns a new `Array` with all the keys.
@@ -759,11 +1353,11 @@ class Hash(K, V)
   # hash # => {:a => 2, :b => 3, :c => 4}
   # ```
   def transform_values!(&block : V -> V)
-    current = @first
-    while current
-      current.value = yield(current.value)
-      current = current.fore
+    each_entry_with_index do |entry, i|
+      new_value = yield entry.value
+      set_entry(i, Entry(K, V).new(entry.hash, entry.key, new_value))
     end
+    self
   end
 
   # Zips two arrays into a `Hash`, taking keys from *ary1* and values from *ary2*.
@@ -782,7 +1376,7 @@ class Hash(K, V)
 
   # Returns the first key in the hash.
   def first_key
-    @first.not_nil!.key
+    first_key?.not_nil!
   end
 
   # Returns the first key if it exists, or returns `nil`.
@@ -794,12 +1388,12 @@ class Hash(K, V)
   # hash.first_key? # => nil
   # ```
   def first_key?
-    @first.try &.key
+    first_entry?.try &.key
   end
 
   # Returns the first value in the hash.
   def first_value
-    @first.not_nil!.value
+    first_value?.not_nil!
   end
 
   # Returns the first value if it exists, or returns `nil`.
@@ -811,12 +1405,12 @@ class Hash(K, V)
   # hash.first_value? # => nil
   # ```
   def first_value?
-    @first.try &.value
+    first_entry?.try &.value
   end
 
   # Returns the last key in the hash.
   def last_key
-    @last.not_nil!.key
+    last_key?.not_nil!
   end
 
   # Returns the last key if it exists, or returns `nil`.
@@ -828,12 +1422,12 @@ class Hash(K, V)
   # hash.last_key? # => nil
   # ```
   def last_key?
-    @last.try &.key
+    last_entry?.try &.key
   end
 
   # Returns the last value in the hash.
   def last_value
-    @last.not_nil!.value
+    last_value?.not_nil!
   end
 
   # Returns the last value if it exists, or returns `nil`.
@@ -845,7 +1439,7 @@ class Hash(K, V)
   # hash.last_value? # => nil
   # ```
   def last_value?
-    @last.try &.value
+    last_entry?.try &.value
   end
 
   # Deletes and returns the first key-value pair in the hash,
@@ -890,7 +1484,7 @@ class Hash(K, V)
   # hash                # => {}
   # ```
   def shift
-    first = @first
+    first = first_entry?
     if first
       delete first.key
       {first.key, first.value}
@@ -906,12 +1500,7 @@ class Hash(K, V)
   # hash.clear # => {}
   # ```
   def clear
-    @buckets_size.times do |i|
-      @buckets[i] = nil
-    end
-    @size = 0
-    @first = nil
-    @last = nil
+    clear_impl
     self
   end
 
@@ -950,7 +1539,7 @@ class Hash(K, V)
   # hash_a # => {"foo" => "bar"}
   # ```
   def dup
-    hash = Hash(K, V).new(initial_capacity: @buckets_size)
+    hash = Hash(K, V).new(initial_capacity: @size)
     each do |key, value|
       hash[key] = value
     end
@@ -966,7 +1555,7 @@ class Hash(K, V)
   # hash_a # => {"foobar" => {"foo" => "bar"}}
   # ```
   def clone
-    hash = Hash(K, V).new(initial_capacity: @buckets_size)
+    hash = Hash(K, V).new(initial_capacity: @size)
     each do |key, value|
       hash[key] = value.clone
     end
@@ -1047,91 +1636,65 @@ class Hash(K, V)
   # {"foo" => "bar", "baz" => "bar"}.invert # => {"bar" => "baz"}
   # ```
   def invert
-    hash = Hash(V, K).new(initial_capacity: @buckets_size)
+    hash = Hash(V, K).new(initial_capacity: @size)
     self.each do |k, v|
       hash[v] = k
     end
     hash
   end
 
-  protected def find_entry(key)
-    return nil if empty?
+  struct Entry(K, V)
+    getter key, value, hash
 
-    index = bucket_index key
-    entry = @buckets[index]
-    find_entry_in_bucket entry, key
-  end
-
-  private def insert_in_bucket(index, key, value)
-    entry = @buckets[index]
-    if entry
-      while entry
-        if entry.key == key
-          entry.value = value
-          return nil
-        end
-        if entry.next
-          entry = entry.next
-        else
-          return entry.next = Entry(K, V).new(key, value)
-        end
-      end
-    else
-      return @buckets[index] = Entry(K, V).new(key, value)
+    def initialize(@hash : UInt32, @key : K, @value : V)
     end
-  end
 
-  private def find_entry_in_bucket(entry, key)
-    while entry
-      if entry.key == key
-        return entry
-      end
-      entry = entry.next
+    def self.deleted
+      key = uninitialized K
+      value = uninitialized V
+      new(0_u32, key, value)
     end
-    nil
-  end
 
-  private def bucket_index(key)
-    key.hash.remainder(@buckets_size).to_i
-  end
-
-  private def calculate_new_size(size)
-    new_size = 8
-    HASH_PRIMES.each do |hash_size|
-      return hash_size if new_size > size
-      new_size <<= 1
+    def deleted?
+      @hash == 0_u32
     end
-    raise "Hash table too big"
-  end
 
-  private class Entry(K, V)
-    getter key : K
-    property value : V
-
-    # Next in the linked list of each bucket
-    property next : self?
-
-    # Next in the ordered sense of hash
-    property fore : self?
-
-    # Previous in the ordered sense of hash
-    property back : self?
-
-    def initialize(@key : K, @value : V)
+    def matches?(hash, key)
+      # Tiny optimization: for these primitive types it's faster to just
+      # compare the key instead of comparing the hash and the key.
+      # We still have to skip hashes with value 0 (means deleted).
+      {% if K == Bool ||
+              K == Char ||
+              K == Symbol ||
+              K < Int::Primitive ||
+              K < Float::Primitive ||
+              K < Enum %}
+        @key == key && @hash != 0_u32
+      {% else %}
+        @hash == hash && @key == key
+      {% end %}
     end
   end
 
   private module BaseIterator
-    def initialize(@hash, @current)
+    def initialize(@hash)
+      @index = 0
     end
 
     def base_next
-      if current = @current
-        value = yield current
-        @current = current.fore
-        value
-      else
-        stop
+      while true
+        if @index < @hash.entries_size
+          entry = @hash.entries[@index]
+          if entry.deleted?
+            @index += 1
+          else
+            value = yield entry
+            @index += 1
+            return value
+          end
+        else
+          return stop
+        end
       end
     end
   end
@@ -1141,7 +1704,7 @@ class Hash(K, V)
     include Iterator({K, V})
 
     @hash : Hash(K, V)
-    @current : Entry(K, V)?
+    @index : Int32
 
     def next
       base_next { |entry| {entry.key, entry.value} }
@@ -1153,7 +1716,7 @@ class Hash(K, V)
     include Iterator(K)
 
     @hash : Hash(K, V)
-    @current : Entry(K, V)?
+    @index : Int32
 
     def next
       base_next &.key
@@ -1165,43 +1728,10 @@ class Hash(K, V)
     include Iterator(V)
 
     @hash : Hash(K, V)
-    @current : Entry(K, V)?
+    @index : Int32
 
     def next
       base_next &.value
     end
   end
-
-  # :nodoc:
-  HASH_PRIMES = [
-    8 + 3,
-    16 + 3,
-    32 + 5,
-    64 + 3,
-    128 + 3,
-    256 + 27,
-    512 + 9,
-    1024 + 9,
-    2048 + 5,
-    4096 + 3,
-    8192 + 27,
-    16384 + 43,
-    32768 + 3,
-    65536 + 45,
-    131072 + 29,
-    262144 + 3,
-    524288 + 21,
-    1048576 + 7,
-    2097152 + 17,
-    4194304 + 15,
-    8388608 + 9,
-    16777216 + 43,
-    33554432 + 35,
-    67108864 + 15,
-    134217728 + 29,
-    268435456 + 3,
-    536870912 + 11,
-    1073741824 + 85,
-    0,
-  ]
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -620,18 +620,6 @@ class Hash(K, V)
     end
   end
 
-  # Marks `@indices` at `index` as empty.
-  private def empty_index(index) : Nil
-    case @indices_bytesize
-    when 1
-      @indices[index] = 0_u8
-    when 2
-      @indices.as(UInt16*)[index] = 0_u16
-    else
-      @indices.as(UInt32*)[index] = 0_u32
-    end
-  end
-
   # Returns the capacity of `@indices`.
   private def indices_size
     1 << @indices_size_pow2


### PR DESCRIPTION
This improves its performance, both in time (always) and memory (generally).

Fixes #4557

## The algorithm

The algorithm is basically the one that [Ruby](https://github.com/ruby/ruby/blob/master/st.c#L1-L101
) uses.

## How to review this

There's just a single commit. My recommendation is to first look at the final code, which is thoroughly documented (the important bits are at the top), then at the diff.

I tried to document this really well because otherwise in a month I won't remember any of this. It also enables anyone to understand how it works and possibly keep optimizing things.

## Why?

The old Hash implementation uses closed addressing: buckets with linked lists. This apparently isn't great because of pointer chasing and not having good cache locality. Using open addressing removes pointer chasing and improves cache locality. It could just be a theory but empirically it performs much better.

## Give me some benchmarks!

I used this code as a benchmark:

<details>
 <summary>Code for benchmarking old Hash vs. new Hash</summary>

```crystal
require "benchmark"
require "./old_hash"
require "random/secure"

def benchmark_create_empty
  Benchmark.ips do |x|
    x.report("old, create") do
      OldHash(Int32, Int32).new
    end
    x.report("new, create") do
      Hash(String, String).new
    end
  end
end

def benchmark_insert_strings(sizes)
  sizes.each do |size|
    values = Array.new(size) { Random::Secure.hex }

    Benchmark.ips do |x|
      x.report("old, insert (type: String, size: #{size})") do
        hash = OldHash(String, String).new
        values.each do |value|
          hash[value] = value
        end
      end
      x.report("new, insert (type: String, size: #{size})") do
        hash = Hash(String, String).new
        values.each do |value|
          hash[value] = value
        end
      end
    end
  end
end

def benchmark_insert_ints(sizes)
  sizes.each do |size|
    values = Array.new(size) { rand(Int32) }

    Benchmark.ips do |x|
      x.report("old, insert (type: Int32, size: #{size})") do
        hash = OldHash(Int32, Int32).new
        values.each do |value|
          hash[value] = value
        end
      end
      x.report("new, insert (type: Int32, size: #{size})") do
        hash = Hash(Int32, Int32).new
        values.each do |value|
          hash[value] = value
        end
      end
    end
  end
end

def benchmark_read_strings(sizes)
  sizes.each do |size|
    values = Array.new(size) { Random::Secure.hex }

    old_hash = OldHash(String, String).new
    new_hash = Hash(String, String).new

    values.each do |value|
      old_hash[value] = value
      new_hash[value] = value
    end

    Benchmark.ips do |x|
      x.report("old, read (type: String, size: #{size})") do
        values.each do |value|
          old_hash[value]
        end
      end
      x.report("new, read (type: String, size: #{size})") do
        values.each do |value|
          new_hash[value]
        end
      end
    end
  end
end

def benchmark_read_ints(sizes)
  sizes.each do |size|
    values = Array.new(size) { rand(1_00_000) }

    old_hash = OldHash(Int32, Int32).new
    new_hash = Hash(Int32, Int32).new

    values.each do |value|
      old_hash[value] = value
      new_hash[value] = value
    end

    Benchmark.ips do |x|
      x.report("old, read (type: Int32, size: #{size})") do
        values.each do |value|
          old_hash[value]
        end
      end
      x.report("new, read (type: Int32, size: #{size})") do
        values.each do |value|
          new_hash[value]
        end
      end
    end
  end
end

sizes = [5, 10, 15, 20, 30, 50, 100, 200, 500, 1_000, 10_000, 100_000]

benchmark_create_empty()
puts
benchmark_insert_strings(sizes)
puts
benchmark_insert_ints(sizes)
puts
benchmark_read_strings(sizes)
puts
benchmark_read_ints(sizes)
```
</details>

Results:

```
old, create  18.50M ( 54.06ns) (± 1.82%)   160B/op   2.34× slower
new, create  43.32M ( 23.08ns) (± 0.88%)  64.0B/op        fastest

old, insert (type: String, size: 5)   3.60M (277.58ns) (± 7.01%)  480B/op   1.38× slower
new, insert (type: String, size: 5)   4.97M (201.28ns) (± 4.77%)  384B/op        fastest
old, insert (type: String, size: 10)   1.95M (513.74ns) (± 1.64%)  801B/op   1.33× slower
new, insert (type: String, size: 10)   2.59M (386.02ns) (± 3.01%)  832B/op        fastest
old, insert (type: String, size: 15)   1.27M (786.17ns) (± 3.56%)  1.09kB/op   1.55× slower
new, insert (type: String, size: 15)   1.98M (505.71ns) (± 4.48%)    832B/op        fastest
old, insert (type: String, size: 20) 922.03k (  1.08µs) (± 0.99%)  1.41kB/op   1.37× slower
new, insert (type: String, size: 20)   1.27M (788.95ns) (± 2.86%)  1.67kB/op        fastest
old, insert (type: String, size: 30) 639.38k (  1.56µs) (± 5.63%)  2.03kB/op   1.58× slower
new, insert (type: String, size: 30)   1.01M (992.38ns) (± 6.01%)  1.67kB/op        fastest
old, insert (type: String, size: 50) 355.49k (  2.81µs) (± 5.77%)  3.28kB/op   1.49× slower
new, insert (type: String, size: 50) 530.85k (  1.88µs) (± 3.95%)  3.81kB/op        fastest
old, insert (type: String, size: 100) 154.93k (  6.45µs) (± 4.04%)  7.06kB/op   1.81× slower
new, insert (type: String, size: 100) 280.47k (  3.57µs) (± 3.92%)  7.09kB/op        fastest
old, insert (type: String, size: 200)  71.71k ( 13.94µs) (± 3.27%)  13.3kB/op   1.91× slower
new, insert (type: String, size: 200) 136.71k (  7.31µs) (± 2.21%)  14.5kB/op        fastest
old, insert (type: String, size: 500)  23.46k ( 42.62µs) (± 3.53%)  36.1kB/op   2.46× slower
new, insert (type: String, size: 500)  57.82k ( 17.30µs) (± 4.78%)  28.4kB/op        fastest
old, insert (type: String, size: 1000)  12.78k ( 78.27µs) (± 1.72%)  67.4kB/op   2.20× slower
new, insert (type: String, size: 1000)  28.12k ( 35.56µs) (± 4.20%)  56.4kB/op        fastest
old, insert (type: String, size: 10000)   1.00k (997.78µs) (± 6.41%)  662kB/op   2.12× slower
new, insert (type: String, size: 10000)   2.13k (469.91µs) (± 5.39%)  896kB/op        fastest

old, insert (type: Int32, size: 5)   4.83M (207.19ns) (± 0.80%)  400B/op   1.78× slower
new, insert (type: Int32, size: 5)   8.60M (116.23ns) (± 1.76%)  240B/op        fastest
old, insert (type: Int32, size: 10)   2.78M (359.30ns) (± 0.91%)  640B/op   1.72× slower
new, insert (type: Int32, size: 10)   4.79M (208.73ns) (± 1.11%)  448B/op        fastest
old, insert (type: Int32, size: 15)   1.90M (525.28ns) (± 2.96%)  880B/op   1.75× slower
new, insert (type: Int32, size: 15)   3.33M (300.60ns) (± 5.98%)  448B/op        fastest
old, insert (type: Int32, size: 20)   1.30M (769.02ns) (± 6.52%)  1.09kB/op   1.54× slower
new, insert (type: Int32, size: 20)   2.00M (500.54ns) (± 4.76%)    976B/op        fastest
old, insert (type: Int32, size: 30) 972.78k (  1.03µs) (± 4.94%)  1.56kB/op   1.72× slower
new, insert (type: Int32, size: 30)   1.67M (597.26ns) (± 4.29%)    976B/op        fastest
old, insert (type: Int32, size: 50) 582.06k (  1.72µs) (± 5.23%)   2.5kB/op   1.50× slower
new, insert (type: Int32, size: 50) 872.34k (  1.15µs) (± 7.97%)  1.88kB/op        fastest
old, insert (type: Int32, size: 100) 234.48k (  4.26µs) (± 7.09%)   5.5kB/op   2.08× slower
new, insert (type: Int32, size: 100) 488.20k (  2.05µs) (± 6.79%)  4.14kB/op        fastest
old, insert (type: Int32, size: 200) 126.98k (  7.88µs) (± 4.74%)  10.2kB/op   1.84× slower
new, insert (type: Int32, size: 200) 233.78k (  4.28µs) (± 7.45%)  8.47kB/op        fastest
old, insert (type: Int32, size: 500)  40.86k ( 24.47µs) (± 4.14%)  28.3kB/op   2.55× slower
new, insert (type: Int32, size: 500) 104.34k (  9.58µs) (± 7.55%)  16.5kB/op        fastest
old, insert (type: Int32, size: 1000)  17.87k ( 55.97µs) (± 3.24%)  51.8kB/op   2.57× slower
new, insert (type: Int32, size: 1000)  45.98k ( 21.75µs) (± 7.72%)  32.5kB/op        fastest
old, insert (type: Int32, size: 10000)   1.52k (658.91µs) (± 3.88%)  506kB/op   2.16× slower
new, insert (type: Int32, size: 10000)   3.28k (305.04µs) (± 4.09%)  513kB/op        fastest

old, read (type: String, size: 5)  11.64M ( 85.90ns) (± 6.51%)  0.0B/op   2.25× slower
new, read (type: String, size: 5)  26.20M ( 38.16ns) (± 2.98%)  0.0B/op        fastest
old, read (type: String, size: 10)   5.69M (175.80ns) (± 4.64%)  0.0B/op   1.39× slower
new, read (type: String, size: 10)   7.93M (126.07ns) (± 6.97%)  0.0B/op        fastest
old, read (type: String, size: 15)   4.15M (240.69ns) (± 2.01%)  0.0B/op   1.16× slower
new, read (type: String, size: 15)   4.82M (207.47ns) (± 3.30%)  0.0B/op        fastest
old, read (type: String, size: 20)   2.93M (341.71ns) (± 1.47%)  0.0B/op   1.52× slower
new, read (type: String, size: 20)   4.46M (224.21ns) (± 1.25%)  0.0B/op        fastest
old, read (type: String, size: 30)   1.87M (534.24ns) (± 2.90%)  0.0B/op   1.45× slower
new, read (type: String, size: 30)   2.71M (369.30ns) (± 1.90%)  0.0B/op        fastest
old, read (type: String, size: 50) 992.08k (  1.01µs) (± 4.51%)  0.0B/op   1.71× slower
new, read (type: String, size: 50)   1.70M (589.77ns) (± 1.65%)  0.0B/op        fastest
old, read (type: String, size: 100) 596.10k (  1.68µs) (± 1.60%)  0.0B/op   1.40× slower
new, read (type: String, size: 100) 832.91k (  1.20µs) (± 1.82%)  0.0B/op        fastest
old, read (type: String, size: 200) 260.30k (  3.84µs) (± 1.63%)  0.0B/op   1.53× slower
new, read (type: String, size: 200) 398.84k (  2.51µs) (± 1.84%)  0.0B/op        fastest
old, read (type: String, size: 500) 111.03k (  9.01µs) (± 2.89%)  0.0B/op   1.40× slower
new, read (type: String, size: 500) 155.71k (  6.42µs) (± 3.33%)  0.0B/op        fastest
old, read (type: String, size: 1000)  41.59k ( 24.04µs) (± 3.07%)  0.0B/op   1.71× slower
new, read (type: String, size: 1000)  71.27k ( 14.03µs) (± 3.81%)  0.0B/op        fastest
old, read (type: String, size: 10000)   2.66k (376.32µs) (± 4.55%)  0.0B/op   2.46× slower
new, read (type: String, size: 10000)   6.54k (152.95µs) (± 4.03%)  0.0B/op        fastest

old, read (type: Int32, size: 5)  23.67M ( 42.24ns) (± 1.64%)  0.0B/op   2.30× slower
new, read (type: Int32, size: 5)  54.35M ( 18.40ns) (± 3.14%)  0.0B/op        fastest
old, read (type: Int32, size: 10)  11.66M ( 85.77ns) (± 4.63%)  0.0B/op   1.85× slower
new, read (type: Int32, size: 10)  21.58M ( 46.33ns) (± 3.20%)  0.0B/op        fastest
old, read (type: Int32, size: 15)   7.81M (128.00ns) (± 4.15%)  0.0B/op   1.49× slower
new, read (type: Int32, size: 15)  11.63M ( 86.00ns) (± 3.99%)  0.0B/op        fastest
old, read (type: Int32, size: 20)   5.80M (172.48ns) (± 5.34%)  0.0B/op   1.73× slower
new, read (type: Int32, size: 20)  10.02M ( 99.77ns) (± 4.54%)  0.0B/op        fastest
old, read (type: Int32, size: 30)   3.67M (272.51ns) (± 2.99%)  0.0B/op   1.84× slower
new, read (type: Int32, size: 30)   6.74M (148.30ns) (± 1.97%)  0.0B/op        fastest
old, read (type: Int32, size: 50)   2.05M (488.04ns) (± 5.57%)  0.0B/op   1.89× slower
new, read (type: Int32, size: 50)   3.87M (258.41ns) (± 4.24%)  0.0B/op        fastest
old, read (type: Int32, size: 100)   1.09M (921.59ns) (± 8.72%)  0.0B/op   1.70× slower
new, read (type: Int32, size: 100)   1.84M (542.80ns) (± 5.52%)  0.0B/op        fastest
old, read (type: Int32, size: 200) 535.83k (  1.87µs) (± 5.84%)  0.0B/op   1.66× slower
new, read (type: Int32, size: 200) 891.31k (  1.12µs) (± 5.49%)  0.0B/op        fastest
old, read (type: Int32, size: 500) 236.68k (  4.23µs) (± 3.61%)  0.0B/op   1.52× slower
new, read (type: Int32, size: 500) 360.85k (  2.77µs) (± 4.31%)  0.0B/op        fastest
old, read (type: Int32, size: 1000) 106.13k (  9.42µs) (± 4.88%)  0.0B/op   1.66× slower
new, read (type: Int32, size: 1000) 175.92k (  5.68µs) (± 4.08%)  0.0B/op        fastest
old, read (type: Int32, size: 10000)   4.60k (217.62µs) (± 2.94%)  0.0B/op   3.00× slower
new, read (type: Int32, size: 10000)  13.80k ( 72.47µs) (± 1.67%)  0.0B/op        fastest
```

As you can see the new implementation is always faster than the old one. Sometimes more memory is used, sometimes less.

I also ran some @kostya [benchmarks](https://github.com/kostya/benchmarks) that used Hash in their implementation. Here are the results:

#### [Havlak](https://github.com/kostya/benchmarks/blob/master/havlak/havlak.cr):
```
old: 12.49s, 375.1Mb
new: 7.58s, 215.7Mb
```

Havlak seems to be a benchmark measuring how well a language performs in general algorithmic tasks... the new results look good! 😊

#### [Brainfuck](https://github.com/kostya/benchmarks/blob/master/brainfuck/brainfuck.cr):
```
old: 5.20s, 1.8Mb
new: 4.22s, 1.8Mb
```

#### [JSON](https://github.com/kostya/benchmarks/blob/master/json/test.cr) (when using `JSON.parse`):
```
old: 2.20s, 1137.0Mb
new: 2.07s, 961.3Mb
```

#### [Knucleotide](https://github.com/kostya/crystal-benchmarks-game/blob/master/knucleotide/knucleotide.cr):
```
old: 1.63s, 26.5Mb
new: 1.01s, 32.4Mb
```

Then some more benchmarks...

There's `HTTP::Request#from_io` which I [recently optimized](https://github.com/crystal-lang/crystal/pull/8002):
```
old: from_io 498.47k (  2.01µs) (± 0.89%)  816B/op  fastest
new: from_io 549.22k (  1.82µs) (± 1.89%)  720B/op  fastest
```

(using `wrk` against the sample http server increases the requests/sec from 118355.73 to about 122000)

Also for curiosity I compared creating a Hash with 1_000_000 elements and seeing how it compares to Ruby and the old Hash.

<details>
  <summary>Code for creating a Hash with 1_000_000 elements in Ruby and Crystal</summary>

```crystal
size = 1_000_000

h = {0 => 0}

time = Time.now
size.times do |i|
  h[i] = i
end
puts "Insert: #{Time.now - time}"

time = Time.now
size.times do |i|
  h[i]
end
puts "Read: #{Time.now - time}"
```
</details>

Results:

```
Ruby 2.7-dev:
  Insert: 0.151813
  Read:   0.13749
Crystal old:
  Insert: 0.238662
  Read:   0.129462
Crystal new:
  Insert: 0.070804
  Read:   0.041008
```

Ruby was faster than Crystal! Ruby is simply amazing ❤️. But now Crystal is even faster!

## The compiler uses Hash all over the place!

So compile times now should go down! Right? ... Right?

Well, unfortunately no. I think the main reason is that the times are bound by the number of method instances, not by the performance of the many hashes used.

Memory consumption did seem to go down a bit.

## When will I have this?

~We could push this to 0.31.0. Or... we could have it in 0.30.0 if we delay the release a bit more (note: I don't manage releases, but if the community doesn't mind waiting a bit to get a huge performance boost in their apps then I think we could relax the release date).~

In 0.31.0.

## Final thoughts

1. Thank you Ruby! ❤️ ❤️ ❤️ 
1. Thank you Vladimir Makarov! ❤️ ❤️ ❤️ 
1. Algorithms are cool!
1. There's an optimization in the original Ruby algorithm which uses bitmasks instead of `remainder` or `%` to fit a number inside a range... I did that as almost the last thing because I didn't believe it would improve performance a lot... and it doubled the performance! 😮 
1. Feel free to target this PR and benchmark your code and post any interesting speedups here!
1. I hope CI 32 bits passes! 😊 