### PR TITLE
WebSocket: add blockable recieve and recieve_raw methods

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -5,19 +5,19 @@ require "random/secure"
 require "../../support/ssl"
 
 private def assert_text_packet(packet, size, final = false)
-  assert_packet packet, HTTP::WebSocket::Protocol::Opcode::TEXT, size, final: final
+  assert_packet packet, HTTP::WebSocket::Opcode::TEXT, size, final: final
 end
 
 private def assert_binary_packet(packet, size, final = false)
-  assert_packet packet, HTTP::WebSocket::Protocol::Opcode::BINARY, size, final: final
+  assert_packet packet, HTTP::WebSocket::Opcode::BINARY, size, final: final
 end
 
 private def assert_ping_packet(packet, size, final = false)
-  assert_packet packet, HTTP::WebSocket::Protocol::Opcode::PING, size, final: final
+  assert_packet packet, HTTP::WebSocket::Opcode::PING, size, final: final
 end
 
 private def assert_close_packet(packet, size, final = false)
-  assert_packet packet, HTTP::WebSocket::Protocol::Opcode::CLOSE, size, final: final
+  assert_packet packet, HTTP::WebSocket::Opcode::CLOSE, size, final: final
 end
 
 private def assert_packet(packet, opcode, size, final = false)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -16,15 +16,6 @@ class HTTP::WebSocket::Protocol
     RSV3  = 0x10
   end
 
-  enum Opcode : UInt8
-    CONTINUATION = 0x0
-    TEXT         = 0x1
-    BINARY       = 0x2
-    CLOSE        = 0x8
-    PING         = 0x9
-    PONG         = 0xA
-  end
-
   MASK_BIT = 128_u8
   VERSION  = "13"
 
@@ -307,3 +298,5 @@ class HTTP::WebSocket::Protocol
     {% end %}
   end
 end
+
+require "../web_socket"


### PR DESCRIPTION
To resolve #5600, I added a couple new methods to WebSocket. 

Like TCP sockets, these methods block until a message is received, and returns it. Unlike TCP sockets, a WebSocket message can consist of several wire packets. In addition, it returns one of 5 message structs depending on what opcode was received. The body of the message can be either String or Bytes depending on the opcode (Bytes for Binary, String for everything else).

I also refactored `run` to use the new `receive` method.

`receive_raw` simply returns a message struct. `receive` wraps `receive_raw` to provide behaviors like responding to PING with PONG, and closing the socket on a CLOSE message.

I have three concerns with this approach which I would like input on:

1. This is technically a breaking change, as before, during `run`, those behaviors (pong, close) were executed after the user-supplied callback was called, and now they are executed before. Probably the code can be changed to maintain compatibility.

2. I would like to add unit tests for `receive` and `receive_raw`, but not sure how to mock the `HTTP::WebSocket::Protocol` inside. Are there any examples in the stdlib using mocks?

3. I'm not sure what nomenclature to use for the "body" of the message struct. The spec references "payload data" so maybe `payload` would make more sense than `message`.