### PR TITLE
Fix leaking TCP socket after failed SSL connect in HTTP::Client#socket

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -758,7 +758,14 @@ class HTTP::Client
 
     {% if !flag?(:without_openssl) %}
       if tls = @tls
-        socket = OpenSSL::SSL::Socket::Client.new(socket, context: tls, sync_close: true, hostname: @host)
+        tcp_socket = socket
+        begin
+          socket = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host)
+        rescue exc
+          # TODO: This fixes #7843 but needs a spec
+          tcp_socket.close
+          raise exc
+        end
       end
     {% end %}
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -762,7 +762,7 @@ class HTTP::Client
         begin
           socket = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host)
         rescue exc
-          # TODO: This fixes #7843 but needs a spec
+         # don't leak the TCP socket when the SSL connection failed
           tcp_socket.close
           raise exc
         end


### PR DESCRIPTION
Fixes #7843

I couldn't make a spec for this, but this fix is good anyway.