### PR TITLE
Compiler: consider abstract method implementation in supertype

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -583,4 +583,23 @@ describe "Semantic: abstract def" do
       ),
       "warning in line 8\nWarning: can't resolve return type Unknown"
   end
+
+  it "doesn't crash when abstract method is implemented by supertype (#8031)" do
+    semantic(%(
+      module Base(T)
+        def size
+        end
+      end
+
+      module Child(T)
+        include Base(T)
+
+        abstract def size
+      end
+
+      class Foo
+        include Child(Int32)
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -127,7 +127,9 @@ class Crystal::AbstractDefChecker
     # we check if they match.
     if t2.is_a?(GenericType)
       generic_base = find_base_generic_instantiation(t1, t2)
-      m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
+      if generic_base
+        m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
+      end
     end
 
     m2.args.zip(m1.args) do |a2, a1|
@@ -171,10 +173,11 @@ class Crystal::AbstractDefChecker
     # and just then we check if they match.
     if base_type.is_a?(GenericType)
       generic_base = find_base_generic_instantiation(type, base_type)
-
-      replacer = ReplacePathWithTypeVar.new(base_type, generic_base)
-      base_return_type_node = base_return_type_node.clone
-      base_return_type_node.accept(replacer)
+      if generic_base
+        replacer = ReplacePathWithTypeVar.new(base_type, generic_base)
+        base_return_type_node = base_return_type_node.clone
+        base_return_type_node.accept(replacer)
+      end
     end
 
     base_return_type = base_type.lookup_type?(base_return_type_node)
@@ -212,9 +215,34 @@ class Crystal::AbstractDefChecker
   end
 
   def find_base_generic_instantiation(type : Type, base_type : GenericType)
-    type.ancestors.find do |t|
+    base = type.ancestors.find do |t|
       t.is_a?(GenericInstanceType) && t.generic_type == base_type
-    end.as(GenericInstanceType)
+    end
+
+    # It might happen that we don't find a generic instantiation in the ancestors
+    # if the method is implemented in a supertype of where the abstract method is
+    # defined, like:
+    #
+    # ```
+    # module Base(T)
+    #   def size
+    #   end
+    # end
+    #
+    # module Child(T)
+    #   include Base(T)
+    #
+    #   abstract def size
+    # end
+    #
+    # class Foo
+    #   include Child(Int32)
+    # end
+    # ```
+    #
+    # In the above we are looking for `size` and usually expect it
+    # to be in subtypes of `Child`, but in this case it's in a supertype.
+    base ? base.as(GenericInstanceType) : nil
   end
 
   private def this_warning_will_become_an_error


### PR DESCRIPTION
Fixes #8031

Note that there are still cases that work work well when a method is implemented by a supertype (who would have thought it?) but I'll (try to) fix those in a separate PR.