### PR TITLE
Array: optimize shift

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -379,6 +379,15 @@ describe "Array" do
       a[nil..2] = [6, 7]
       a.should eq([6, 7, 4, 5])
     end
+
+    it "optimizes when index is 0" do
+      a = [1, 2, 3, 4, 5, 6, 7, 8]
+      buffer = a.@buffer
+      a[0..2] = 10
+      a.should eq([10, 4, 5, 6, 7, 8])
+      a.@offset_to_buffer.should eq(2)
+      a.@buffer.should eq(buffer + 2)
+    end
   end
 
   describe "values_at" do
@@ -493,6 +502,15 @@ describe "Array" do
       a = [1, 2, 3, 4]
       a.delete_at(1).should eq(2)
       a.should eq([1, 3, 4])
+    end
+
+    it "deletes at beginning is same as shift" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      a.delete_at(0)
+      a.should eq([2, 3, 4])
+      a.@offset_to_buffer.should eq(1)
+      a.@buffer.should eq(buffer + 1)
     end
 
     it "deletes use range" do
@@ -1059,6 +1077,101 @@ describe "Array" do
         a.shift(-1)
       end
     end
+
+    it "shifts one and resizes" do
+      a = [1, 2, 3, 4]
+      old_capacity = a.@capacity
+      a.shift.should eq(1)
+      a.@offset_to_buffer.should eq(1)
+      a << 5
+      a.@capacity.should eq(old_capacity * 2)
+      a.@offset_to_buffer.should eq(1)
+      a.size.should eq(4)
+      a.should eq([2, 3, 4, 5])
+    end
+
+    it "shifts almost all and then avoid resize" do
+      a = [1, 2, 3, 4]
+      old_capacity = a.@capacity
+      (1..3).each do |i|
+        a.shift.should eq(i)
+      end
+      a.@offset_to_buffer.should eq(3)
+      a << 5
+      a.@capacity.should eq(old_capacity)
+      a.@offset_to_buffer.should eq(0)
+      a.size.should eq(2)
+      a.should eq([4, 5])
+    end
+
+    it "shifts and then concats Array" do
+      size = 10_000
+      a = (1..size).to_a
+      (size - 1).times do
+        a.shift
+      end
+      a.size.should eq(1)
+      a.concat((1..size).to_a)
+      a.size.should eq(size + 1)
+      a.should eq([size] + (1..size).to_a)
+    end
+
+    it "shifts and then concats Enumerable" do
+      size = 10_000
+      a = (1..size).to_a
+      (size - 1).times do
+        a.shift
+      end
+      a.size.should eq(1)
+      a.concat((1..size))
+      a.size.should eq(size + 1)
+      a.should eq([size] + (1..size).to_a)
+    end
+
+    it "shifts all" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      4.times do
+        a.shift
+      end
+      a.size.should eq(0)
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
+    end
+
+    it "shifts all after pop" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      a.pop
+      3.times do
+        a.shift
+      end
+      a.size.should eq(0)
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
+    end
+
+    it "pops after shift" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      3.times do
+        a.shift
+      end
+      a.pop
+      a.size.should eq(0)
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
+    end
+
+    it "shifts all with shift(n)" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      a.shift
+      a.shift(3)
+      a.size.should eq(0)
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
+    end
   end
 
   describe "shuffle" do
@@ -1337,6 +1450,26 @@ describe "Array" do
       a = [] of Int32
       a.unshift(1, 2, 3).should be(a)
       a.should eq([1, 2, 3])
+    end
+
+    it "unshifts after shift" do
+      a = [1, 2, 3, 4]
+      buffer = a.@buffer
+      a.shift
+      a.unshift(10)
+      a.should eq([10, 2, 3, 4])
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
+    end
+
+    it "unshifts many after many shifts" do
+      a = [1, 2, 3, 4, 5, 6, 7, 8]
+      buffer = a.@buffer
+      3.times { a.shift }
+      a.unshift(10, 20, 30)
+      a.should eq([10, 20, 30, 4, 5, 6, 7, 8])
+      a.@offset_to_buffer.should eq(0)
+      a.@buffer.should eq(buffer)
     end
   end
 


### PR DESCRIPTION
Fixes #5126
Closes #5148

Some time ago I thought that making `shift` be efficient (O(1)) wasn't hard. The problem was that we needed to add an extra instance variable to `Array` for that and I didn't want to increase its size just to optimize a single method.

I turns out, Array's previous layout was like this:

```
  type_id    : Int32   # 4 bytes -|
  size       : Int32   # 4 bytes  |- packed as 8 bytes

  capacity   : Int32   # 4 bytes, aligned to 8 bytes

  buffer     : Pointer # 8 bytes  |- another 8 bytes
```

Because, at least in 64 bits, memory is aligned to 8 bytes, the `capacity` field was still taking 8 bytes. So... we still have 4 bytes left.

(and, well, for 32 bits it'll be a bit bigger, but I don't think by too much because the main bulk is the buffer)

My first idea was to include an `@first : Int32` instance variable which gets incremented on `shift`. Then replace `to_unsafe` with `@buffer + @first` and use `to_unsafe` everywhere instead of `@buffer.` That works but it turns out to be really slow to perform that math all the time.

Then I realized we can do something better: when we shift we can increment that variable but also increment `@buffer`! I called this new variable `@offset_to_buffer`, and doing `@buffer - @offset_to_buffer` points to the originally allocated buffer so we can reallocate it.

The diff isn't big but I added a lot of comments so it's clear. With this `shift` is optimized and also `insert 0, object`, `delete_at(0)`, `[]=(index, count, value)` when index is 0, and `unshift` (if previously shifted).

So we got it! `Array#shift` is efficient like in Ruby, and `Array` can be used like a queue or dequeue. `Deque` is still useful because of its circular nature, though.