### PR TITLE
Deprecate redundant OptionParser#parse!

### DIFF
--- a/samples/mt_gc_test.cr
+++ b/samples/mt_gc_test.cr
@@ -200,7 +200,7 @@ fibers_num = 1_000
 loops_num = 20
 mode = :run
 
-OptionParser.parse! do |parser|
+OptionParser.parse do |parser|
   parser.on("-i", "--ips", "Benchmark with ips") { mode = :ips }
   parser.on("-m", "--measure", "Benchmark with measure") { mode = :measure }
   parser.on("-f FIBERS", "--fibers=FIBERS", "Specifies the number of fibers") { |v| fibers_num = v.to_i }

--- a/samples/wordcount.cr
+++ b/samples/wordcount.cr
@@ -35,7 +35,7 @@ end
 output_filename = nil
 ignore_case = false
 
-OptionParser.parse! do |opts|
+OptionParser.parse do |opts|
   opts.banner = "Usage: wordcount [OPTIONS] [FILES]"
   opts.on("-o NAME", "set output filename") do |filename|
     output_filename = filename

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -51,16 +51,15 @@ class OptionParser
     block : String ->
 
   # Creates a new parser, with its configuration specified in the block,
-  # and uses it to parse the passed *args*.
-  def self.parse(args) : self
+  # and uses it to parse the passed *args* (defaults to `ARGV`).
+  def self.parse(args = ARGV) : self
     parser = OptionParser.new
     yield parser
     parser.parse(args)
     parser
   end
 
-  # Creates a new parser, with its configuration specified in the block,
-  # and uses it to parse the arguments passed to the program.
+  @[Deprecated("Use `parse` instead.")]
   def self.parse! : self
     parse(ARGV) { |parser| yield parser }
   end
@@ -181,15 +180,14 @@ class OptionParser
     end
   end
 
-  # Parses the passed *args*, running the handlers associated to each option.
-  def parse(args)
+  # Parses the passed *args* (defaults to `ARGV`), running the handlers associated to each option.
+  def parse(args = ARGV)
     ParseTask.new(self, args).parse
   end
 
-  # Parses the passed the arguments passed to the program,
-  # running the handlers associated to each option.
+  @[Deprecated("Use `parse` instead.")]
   def parse!
-    parse ARGV
+    parse
   end
 
   private def check_starts_with_dash(arg, name, allow_empty = false)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -66,7 +66,7 @@ require "./spec/dsl"
 module Spec
 end
 
-OptionParser.parse! do |opts|
+OptionParser.parse do |opts|
   opts.banner = "crystal spec runner"
   opts.on("-e ", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
     Spec.pattern = pattern


### PR DESCRIPTION
Partially based on @chocolateboy's suggestion, @jhass's thumbs up in #7846 and review requests by @straight-shoota to prefer arguments over additional methods.