### PR TITLE
Hash: optimize `to_a`, `keys` and `values`

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -817,6 +817,18 @@ describe "Hash" do
     h.to_a.should eq([{1, "hello"}, {2, "bye"}])
   end
 
+  it "does to_a after shift" do
+    h = {1 => 'a', 2 => 'b', 3 => 'c'}
+    h.shift
+    h.to_a.should eq([{2, 'b'}, {3, 'c'}])
+  end
+
+  it "does to_a after delete" do
+    h = {1 => 'a', 2 => 'b', 3 => 'c'}
+    h.delete(2)
+    h.to_a.should eq([{1, 'a'}, {3, 'c'}])
+  end
+
   it "clears" do
     h = {1 => 2, 3 => 4}
     h.clear


### PR DESCRIPTION
`Hash#to_a` was using the method from `Enumerable` but that doesn't preallocate an Array with a good initial size.

Benchmark:

```crystal
require "benchmark"
require "./old_hash"

[5, 10, 15, 20, 30, 50, 100, 500, 1_000].each do |size|
  new_hash = Hash(Int32, Int32).new
  size.times do |i|
    new_hash[i] = i
  end

  old_hash = OldHash(Int32, Int32).new
  size.times do |i|
    old_hash[i] = i
  end

  Benchmark.ips do |x|
    x.report("old (#{size})") { old_hash.to_a }
    x.report("new (#{size})") { new_hash.to_a }
  end
end
```

Results:

```
old (5)  12.82M ( 77.98ns) (± 2.43%)   128B/op   1.79× slower
new (5)  23.00M ( 43.47ns) (± 3.40%)  80.0B/op        fastest
old (10)   7.88M (126.93ns) (± 0.94%)  240B/op   2.23× slower
new (10)  17.53M ( 57.04ns) (± 2.17%)  128B/op        fastest
old (15)   5.20M (192.49ns) (± 0.92%)  448B/op   2.91× slower
new (15)  15.10M ( 66.21ns) (± 2.26%)  160B/op        fastest
old (20)   4.81M (208.00ns) (± 0.92%)  448B/op   2.69× slower
new (20)  12.94M ( 77.26ns) (± 1.35%)  208B/op        fastest
old (30)   3.29M (304.00ns) (± 1.23%)  896B/op   3.02× slower
new (30)   9.94M (100.64ns) (± 1.04%)  288B/op        fastest
old (50)   2.14M (466.62ns) (± 1.78%)  1.66kB/op   3.14× slower
new (50)   6.73M (148.68ns) (± 3.46%)    480B/op        fastest
old (100)   1.14M (879.71ns) (± 0.62%)  3.65kB/op   3.03× slower
new (100)   3.45M (289.90ns) (± 1.01%)  1.04kB/op        fastest
old (500) 317.24k (  3.15µs) (± 3.64%)  12.7kB/op   2.54× slower
new (500) 804.41k (  1.24µs) (± 0.55%)  3.96kB/op        fastest
old (1000) 167.01k (  5.99µs) (± 0.26%)  24.7kB/op   3.59× slower
new (1000) 600.38k (  1.67µs) (± 0.34%)  7.86kB/op        fastest
```

For `keys` and `values` it's now a bit faster because `Array.new(size, &block)` is slightly faster than `Array.new(size)` + appending later because the first version doesn't need index bounds checking.