### PR TITLE
Int#divisible_by? doesn't care about the value being floored.

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -366,7 +366,7 @@ struct Int
   end
 
   def divisible_by?(num)
-    self % num == 0
+    remainder(num) == 0
   end
 
   def even?


### PR DESCRIPTION
The if statement in % might be optimized away by LLVM, but why
force an optimization if the code isn't harder to understand when doing the optimized thing?