### PR TITLE
Remove standard library paths compiler

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -105,7 +105,7 @@ module Crystal
     end
 
     private def lib_flags_posix
-      library_path = ["/usr/lib", "/usr/local/lib"]
+      library_path = [] of String
       has_pkg_config = nil
 
       String.build do |flags|


### PR DESCRIPTION
Defining the Linux library paths without having an option to ignore them with compiling creates potential cross-compilation issues when using tools like Yocto, that attempt to insulate the build environment from the working environment. Linux should add these paths by default, so the vast majority of builds should still run just fine.