### PR TITLE
Macro `map_with_index`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -601,6 +601,32 @@ module Crystal
         assert_macro "x", %({{x.map { |e| e.id }}}), [ArrayLiteral.new(["hello".call] of ASTNode)] of ASTNode, "[hello]"
       end
 
+      describe "#map_with_index" do
+        context "with both arguments" do
+          it "returns the resulting array" do
+            assert_macro "", %({{[1, 2, 3].map_with_index { |e, idx| e == 2 || idx <= 1 }}}), [] of ASTNode, %([true, true, false])
+          end
+        end
+
+        context "without the index argument" do
+          it "returns the resulting array" do
+            assert_macro "", %({{[1, 2, 3].map_with_index { |e| e }}}), [] of ASTNode, %([1, 2, 3])
+          end
+        end
+
+        context "without the element argument" do
+          it "returns the resulting array" do
+            assert_macro "", %({{[1, 2, 3].map_with_index { |_, idx| idx }}}), [] of ASTNode, %([0, 1, 2])
+          end
+        end
+
+        context "without either argument" do
+          it "returns the resulting array" do
+            assert_macro "", %({{[1, 2, 3].map_with_index { 7 }}}), [] of ASTNode, %([7, 7, 7])
+          end
+        end
+      end
+
       it "executes select" do
         assert_macro "", %({{[1, 2, 3].select { |e| e == 1 }}}), [] of ASTNode, "[1]"
       end
@@ -928,6 +954,32 @@ module Crystal
 
       it "executes map with arg" do
         assert_macro "x", %({{x.map { |e| e.id }}}), [TupleLiteral.new(["hello".call] of ASTNode)] of ASTNode, "{hello}"
+      end
+
+      describe "#map_with_index" do
+        context "with both arguments" do
+          it "returns the resulting tuple" do
+            assert_macro "", %({{{1, 2, 3}.map_with_index { |e, idx| e == 2 || idx <= 1 }}}), [] of ASTNode, %({true, true, false})
+          end
+        end
+
+        context "without the index argument" do
+          it "returns the resulting tuple" do
+            assert_macro "", %({{{1, 2, 3}.map_with_index { |e| e }}}), [] of ASTNode, %({1, 2, 3})
+          end
+        end
+
+        context "without the element argument" do
+          it "returns the resulting tuple" do
+            assert_macro "", %({{{1, 2, 3}.map_with_index { |_, idx| idx }}}), [] of ASTNode, %({0, 1, 2})
+          end
+        end
+
+        context "without either argument" do
+          it "returns the resulting tuple" do
+            assert_macro "", %({{{1, 2, 3}.map_with_index { 7 }}}), [] of ASTNode, %({7, 7, 7})
+          end
+        end
       end
 
       it "executes select" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -622,6 +622,10 @@ module Crystal::Macros
     def map(&block) : ArrayLiteral
     end
 
+    # Similar to `Enumerable#map_with_index`
+    def map_with_index(&block) : ArrayLiteral
+    end
+
     # Similar to `Enumerable#select`
     def select(&block) : ArrayLiteral
     end
@@ -836,7 +840,7 @@ module Crystal::Macros
 
   # A tuple literal.
   #
-  # Its macro methods are the same as `ArrayLiteral`.
+  # Its macro methods are nearly the same as `ArrayLiteral`.
   class TupleLiteral < ASTNode
   end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -82,7 +82,7 @@ module Crystal
       @last = Nop.new
     end
 
-    def define_var(name, value)
+    def define_var(name : String, value : ASTNode) : Nil
       @vars[name] = value
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2222,6 +2222,19 @@ private def interpret_array_or_tuple_method(object, klass, method, args, block, 
         interpreter.accept block.body
       end
     end
+  when "map_with_index"
+    object.interpret_argless_method(method, args) do
+      raise "map_with_index expects a block" unless block
+
+      block_arg = block.args[0]?
+      index_arg = block.args[1]?
+
+      klass.map_with_index(object.elements) do |elem, idx|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.define_var(index_arg.name, Crystal::NumberLiteral.new idx) if index_arg
+        interpreter.accept block.body
+      end
+    end
   when "select"
     object.interpret_argless_method(method, args) do
       raise "select expects a block" unless block

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -339,6 +339,10 @@ module Crystal
       new(values.map { |value| (yield value).as(ASTNode) }, of: of)
     end
 
+    def self.map_with_index(values)
+      new(values.map_with_index { |value, idx| (yield value, idx).as(ASTNode) }, of: nil)
+    end
+
     def accept_children(visitor)
       @name.try &.accept visitor
       elements.each &.accept visitor
@@ -448,6 +452,10 @@ module Crystal
 
     def self.map(values)
       new(values.map { |value| (yield value).as(ASTNode) })
+    end
+
+    def self.map_with_index(values)
+      new(values.map_with_index { |value, idx| (yield value, idx).as(ASTNode) })
     end
 
     def accept_children(visitor)


### PR DESCRIPTION
* Implements the `map_with_index` method on `TupleLiteral` and `ArrayLiteral`.
* ~Reorganizes the macro method specs a bit~
  * ~Alphabetizes each type~
  * ~Use the constant type vs string~
  * ~Updates some type's structure to use the standard format~
    * ~Mainly just `TupleLiteral` and `ArrayLiteral`.~
  * ~Marks some missing tests as pending~
    * ~Can make another PR later to fill these in.~

Reorganization will be handled in another PR.

Use case is something like (pseudo code):
```cr
initializer = some_class_def.methods.find(&.name.==("initialize"))
service_ann.args.map_with_index { |arg, idx| arg.as(initializer.args[idx].restriction) } 
```