### PR TITLE
Minor lchop? ASCII-only optimization

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1112,8 +1112,12 @@ class String
   def lchop? : String?
     return if empty?
 
-    reader = Char::Reader.new(self)
-    unsafe_byte_slice_string(reader.current_char_width, bytesize - reader.current_char_width)
+    if ascii_only?
+      unsafe_byte_slice_string(1, bytesize - 1)
+    else
+      reader = Char::Reader.new(self)
+      unsafe_byte_slice_string(reader.current_char_width, bytesize - reader.current_char_width)
+    end
   end
 
   # Returns a new `String` with *prefix* removed from the beginning of the string if possible, else returns `nil`.


### PR DESCRIPTION
```cr
Benchmark.ips do |bm|
  bm.report "new lchop?" do
    "hello".new_lchop?
  end

  bm.report "old lchop?" do
    "hello".lchop?
  end
end
```
```
new lchop?  45.52M ( 21.97ns) (±13.10%)  32.0B/op        fastest
old lchop?  33.30M ( 30.03ns) (±10.04%)  32.0B/op   1.37× slower
```
I ran it a lot of times and the old `lchop?` was always at least 1.3 times slower.