### PR TITLE
Don't resume fibers directly from event loop callbacks (fixes #8044).

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -13,12 +13,17 @@ module Crystal::EventLoop
   end
 
   private def self.loop_fiber
-    @@loop_fiber ||= Fiber.new { @@eb.run_loop }
+    @@loop_fiber ||= Fiber.new do
+      loop do
+        @@eb.run_once
+        Crystal::Scheduler.reschedule
+      end
+    end
   end
 
   def self.create_resume_event(fiber)
     @@eb.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
-      data.as(Fiber).resume
+      Crystal::Scheduler.enqueue data.as(Fiber)
     end
   end
 

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -99,7 +99,7 @@ module IO::Evented
     @read_timed_out = timed_out
 
     if reader = @readers.try &.shift?
-      reader.resume
+      Crystal::Scheduler.enqueue reader
     end
   end
 
@@ -108,7 +108,7 @@ module IO::Evented
     @write_timed_out = timed_out
 
     if writer = @writers.try &.shift?
-      writer.resume
+      Crystal::Scheduler.enqueue writer
     end
   end
 


### PR DESCRIPTION
This is required to enable compatibility with libevent 2.1.11, because
a warning is now raised if a `fork` is executed from within the event loop (https://github.com/libevent/libevent/commit/497ef904d544ac51de43934549dbeccce8e6e8f8).
Since most Crystal code actually runs from within the event loop (from libevent point of view)
the solution is enqueue the fibers and resume them outside the call to `event_base_loop`.

I tested this patch with `samples/http_server` and apparently this also contributes with a (totally unexpected) performance improvement (5% to 10%) 