### PR TITLE
Compiler: avoid internal globals of type i128 or u128

### DIFF
--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -48,7 +48,15 @@ class Crystal::CodeGenVisitor
     global_name = const.llvm_name
     global = @main_mod.globals[global_name]? ||
              @main_mod.globals.add(@main_llvm_typer.llvm_type(const.value.type), global_name)
-    global.linkage = LLVM::Linkage::Internal if @single_module
+
+    type = const.value.type
+    # TODO: there's an LLVM bug that prevents us from having internal globals of type i128 or u128:
+    # https://bugs.llvm.org/show_bug.cgi?id=42932
+    # so we just use global.
+    if @single_module && !(type.is_a?(IntegerType) && (type.kind == :i128 || type.kind == :u128))
+      global.linkage = LLVM::Linkage::Internal if @single_module
+    end
+
     global
   end
 


### PR DESCRIPTION
Workaround for https://github.com/crystal-lang/crystal/pull/8032#issuecomment-519544358

Credits go to @asterite 