### PR TITLE
Split std_specs in 32 bits ci

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -77,8 +77,19 @@ build() {
 
   case $ARCH in
     i386)
-      with_build_env 'make crystal std_spec threads=1'
-      with_build_env 'CRYSTAL_SPEC_COMPILER_THREADS=1 make compiler_spec docs threads=1'
+      with_build_env 'make crystal threads=1'
+      with_build_env 'SPEC_SPLIT="0%4" make std_spec threads=1'
+      with_build_env 'SPEC_SPLIT="1%4" make std_spec threads=1'
+      with_build_env 'SPEC_SPLIT="2%4" make std_spec threads=1'
+      with_build_env 'SPEC_SPLIT="3%4" make std_spec threads=1'
+
+      parts=16
+      i=0
+      while [ $i -lt $parts ]; do
+        with_build_env "CRYSTAL_SPEC_COMPILER_THREADS=1 SPEC_SPLIT=\"$i%$parts\" make compiler_spec threads=1"
+        i=$((i + 1))
+      done
+
       with_build_env 'make docs threads=1'
       ;;
     *)

--- a/bin/ci
+++ b/bin/ci
@@ -74,7 +74,18 @@ prepare_system() {
 
 build() {
   with_build_env 'make std_spec clean threads=1'
-  with_build_env 'make crystal std_spec compiler_spec docs threads=1'
+
+  case $ARCH in
+    i386)
+      with_build_env 'make crystal std_spec threads=1'
+      with_build_env 'CRYSTAL_SPEC_COMPILER_THREADS=1 make compiler_spec docs threads=1'
+      with_build_env 'make docs threads=1'
+      ;;
+    *)
+      with_build_env 'make crystal std_spec compiler_spec docs threads=1'
+      ;;
+  esac
+
   with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
 }
 

--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Codegen: private" do
   it "codegens private def in same file" do
-    compiler = Compiler.new
+    compiler = create_spec_compiler
     sources = [
       Compiler::Source.new("foo.cr", %(
                                         private def foo
@@ -22,7 +22,7 @@ describe "Codegen: private" do
   end
 
   it "codegens overloaded private def in same file" do
-    compiler = Compiler.new
+    compiler = create_spec_compiler
     sources = [
       Compiler::Source.new("foo.cr", %(
                                         private def foo(x : Int32)

--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -226,7 +226,7 @@ describe "Code gen: warnings" do
           end
         )
 
-        compiler = Compiler.new
+        compiler = create_spec_compiler
         compiler.warnings = Warnings::All
         compiler.warnings_exclude << Crystal.normalize_path "lib"
         compiler.prelude = "empty"

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:bits32) %}
+
 require "spec"
 require "compiler/crystal/formatter"
 require "compiler/crystal/command/format"

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -118,6 +118,8 @@ if ENV["SPEC_VERBOSE"]? == "1"
   Spec.override_default_formatter(Spec::VerboseFormatter.new)
 end
 
+Spec.add_split_filter ENV["SPEC_SPLIT"]?
+
 {% unless flag?(:win32) %}
   # TODO(windows): re-enable this once Signal is ported
   Signal::INT.trap { Spec.abort! }

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -109,6 +109,30 @@ module Spec
     lines << line
   end
 
+  @@split_filter : NamedTuple(remainder: Int32, quotient: Int32)? = nil
+
+  def self.add_split_filter(filter)
+    if filter
+      r, m = filter.split('%').map &.to_i
+      @@split_filter = {remainder: r, quotient: m}
+    else
+      @@split_filter = nil
+    end
+  end
+
+  @@spec_counter = -1
+
+  def self.split_filter_matches
+    split_filter = @@split_filter
+
+    if split_filter
+      @@spec_counter += 1
+      @@spec_counter % split_filter[:quotient] == split_filter[:remainder]
+    else
+      true
+    end
+  end
+
   # :nodoc:
   def self.matches?(description, file, line, end_line = line)
     spec_pattern = @@pattern

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -38,6 +38,7 @@ module Spec::Methods
   def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     description = description.to_s
     Spec::RootContext.check_nesting_spec(file, line) do
+      return unless Spec.split_filter_matches
       return unless Spec.matches?(description, file, line, end_line)
 
       Spec.formatters.each(&.before_example(description))


### PR DESCRIPTION
Only for std_specs run against the compiled compiler which seems to be the one failing

This introduces a way to run a subset of the specs via an env var `SPEC_SPLIT`. Is not expected to be used as a public API but is a workaround to help a bit the CI.

Let's see how it works...