### PR TITLE
Avoid lazy inizialization of class variables assigned with simple values

### DIFF
--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -551,4 +551,14 @@ describe "Codegen: class var" do
       a &+ b &+ c &+ d
       )).to_i.should eq(1 + 1 + 10 + 20)
   end
+
+  it "inline initialization of simple class var" do
+    mod = codegen(%(
+      class Foo
+        @@x = 1
+      end
+    ))
+
+    mod.to_s.should_not contain("x:init")
+  end
 end

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -155,6 +155,14 @@ class Crystal::CodeGenVisitor
     end
   end
 
+  def initialize_simple_class_var(owner, class_var, initializer)
+    global = declare_class_var(owner, initializer.name, class_var.type, class_var.thread_local?)
+    request_value do
+      accept initializer.node
+    end
+    global.initializer = @last
+  end
+
   def read_class_var(node : ClassVar)
     class_var = node.var
     read_class_var(node, class_var)
@@ -180,7 +188,7 @@ class Crystal::CodeGenVisitor
     end
 
     initializer = class_var.initializer
-    if !initializer || class_var.uninitialized?
+    if !initializer || initializer.node.simple_literal? || class_var.uninitialized?
       # Read directly without init flag, but make sure to declare the global in this module too
       global_name = class_var_global_name(class_var.owner, class_var.name)
       global = get_global global_name, class_var.type, class_var

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -275,10 +275,24 @@ module Crystal
         when ClassVarInitializer
           next unless initializer.node.simple_literal?
 
-          class_var = initializer.owner.class_vars[initializer.name]
+          owner = initializer.owner
+          class_var = owner.class_vars[initializer.name]
           next if class_var.thread_local?
 
-          initialize_class_var(initializer.owner, initializer.name, initializer.meta_vars, initializer.node)
+          initialize_simple_class_var(owner, class_var, initializer)
+          owner.all_subclasses.each do |subclass|
+            if subclass.is_a?(ClassVarContainer)
+              initialize_simple_class_var(subclass, class_var, initializer)
+            end
+          end
+
+          if owner.responds_to?(:raw_including_types) && (including_types = owner.raw_including_types)
+            including_types.each do |type|
+              if type.is_a?(ClassVarContainer)
+                initialize_simple_class_var(type, class_var, initializer)
+              end
+            end
+          end
         end
       end
     end
@@ -950,8 +964,12 @@ module Crystal
       # or a class variable initializer
       unless target_type
         if target.is_a?(ClassVar)
-          # This is the case of a class var initializer
-          initialize_class_var(target)
+          class_var = target.var.initializer.try(&.owner.lookup_class_var(target.name))
+
+          if !class_var || class_var.thread_local? || !value.simple_literal?
+            # This is the case of a class var initializer
+            initialize_class_var(target)
+          end
         end
         return false
       end


### PR DESCRIPTION
Currently all class variables are lazily initialized even when they are declared with a simple initializer with a literal of a simple type. This prevents that and do a direct initialization of the global variable, quite similar to simple constants.

I'm not so happy with this patch as I do with the result, so I'm open to suggestions about how to write this better.