### PR TITLE
Add ability to tag specs

### DIFF
--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -31,8 +31,8 @@ describe Spec::ExampleGroup do
   describe "#report" do
     it "should include parent's description" do
       root = FakeRootContext.new
-      child = Spec::ExampleGroup.new(root, "child", "f.cr", 1, 10, false)
-      grand_child = Spec::ExampleGroup.new(child, "grand_child", "f.cr", 2, 9, false)
+      child = Spec::ExampleGroup.new(root, "child", "f.cr", 1, 10, false, nil)
+      grand_child = Spec::ExampleGroup.new(child, "grand_child", "f.cr", 2, 9, false, nil)
 
       grand_child.report(:fail, "oops", "f.cr", 3, nil, nil)
 

--- a/spec/std/spec/filters_spec.cr
+++ b/spec/std/spec/filters_spec.cr
@@ -2,6 +2,7 @@ require "./spec_helper"
 
 module Spec::Item
   setter focus : Bool
+  setter tags : Set(String)?
 end
 
 describe Spec::RootContext do
@@ -108,6 +109,39 @@ describe Spec::RootContext do
         root = build_spec("f.cr")
         root.children[1].as(Spec::ExampleGroup).focus = true
         root.run_filters(focus: true)
+        all_spec_descriptions(root).should eq %w[root context_f_2 example_f_2_1 example_f_2_2]
+      end
+    end
+
+    describe "by tags" do
+      it "on an example" do
+        root = build_spec("f.cr")
+        root.children[1].as(Spec::ExampleGroup).children[1].as(Spec::Example).tags = Set{"fast"}
+        root.run_filters(tags: Set{"fast"})
+        all_spec_descriptions(root).should eq %w[root context_f_2 example_f_2_2]
+      end
+
+      it "on a context" do
+        root = build_spec("f.cr")
+        root.children[1].as(Spec::ExampleGroup).tags = Set{"fast"}
+        root.run_filters(tags: Set{"fast"})
+        all_spec_descriptions(root).should eq %w[root context_f_2 example_f_2_1 example_f_2_2]
+      end
+    end
+
+    describe "by anti_tags" do
+      it "on an example" do
+        root = build_spec("f.cr")
+        root.children[0].as(Spec::ExampleGroup).children[0].as(Spec::Example).tags = Set{"slow"}
+        root.children[0].as(Spec::ExampleGroup).children[1].as(Spec::Example).tags = Set{"slow"}
+        root.run_filters(anti_tags: Set{"slow"})
+        all_spec_descriptions(root).should eq %w[root context_f_2 example_f_2_1 example_f_2_2]
+      end
+
+      it "on a context" do
+        root = build_spec("f.cr")
+        root.children[0].as(Spec::ExampleGroup).tags = Set{"slow"}
+        root.run_filters(anti_tags: Set{"slow"})
         all_spec_descriptions(root).should eq %w[root context_f_2 example_f_2_1 example_f_2_2]
       end
     end

--- a/spec/std/spec/spec_helper.cr
+++ b/spec/std/spec/spec_helper.cr
@@ -20,9 +20,9 @@ def build_spec(filename, root = nil, count = 2)
 
   1.upto(count) do |i|
     line = (i - 1) * 10
-    root.children << Spec::ExampleGroup.new(root, "context_#{name}_#{i}", filename, line + 1, line + 9, false).tap do |c|
-      c.children << Spec::Example.new(c, "example_#{name}_#{i}_1", filename, line + 2, line + 4, false, nil)
-      c.children << Spec::Example.new(c, "example_#{name}_#{i}_2", filename, line + 6, line + 8, false, nil)
+    root.children << Spec::ExampleGroup.new(root, "context_#{name}_#{i}", filename, line + 1, line + 9, false, nil).tap do |c|
+      c.children << Spec::Example.new(c, "example_#{name}_#{i}_1", filename, line + 2, line + 4, false, nil, nil)
+      c.children << Spec::Example.new(c, "example_#{name}_#{i}_2", filename, line + 6, line + 8, false, nil, nil)
     end
   end
 

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -51,7 +51,7 @@ require "./spec/dsl"
 # and run the specs of a project by running `crystal spec`.
 #
 # ```console
-# # Run  all specs in files matching spec/**/*_spec.cr
+# # Run all specs in files matching spec/**/*_spec.cr
 # crystal spec
 #
 # # Run all specs in files matching spec/my/test/**/*_spec.cr
@@ -62,6 +62,12 @@ require "./spec/dsl"
 #
 # # Run the spec or group defined in line 14 of spec/my/test/file_spec.cr
 # crystal spec spec/my/test/file_spec.cr:14
+#
+# # Run all specs tagged with "fast"
+# crystal spec --tag 'fast'
+#
+# # Run all specs not tagged with "slow"
+# crystal spec --tag '~slow'
 # ```
 #
 # ## Focusing on a group of specs
@@ -110,6 +116,9 @@ OptionParser.parse do |opts|
       STDERR.puts "location #{location} must be file:line"
       exit 1
     end
+  end
+  opts.on("--tag TAG", "run examples with the specified TAG, or exclude examples by adding ~ before the TAG.") do |tag|
+    Spec.add_tag tag
   end
   opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
     if mode == "default" || mode == "random"

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -162,10 +162,10 @@ module Spec
       end
     end
 
-    def describe(description, file, line, end_line, focus, &block)
+    def describe(description, file, line, end_line, focus, tags, &block)
       Spec.focus = true if focus
 
-      context = Spec::ExampleGroup.new(@@current_context, description, file, line, end_line, focus)
+      context = Spec::ExampleGroup.new(@@current_context, description, file, line, end_line, focus, tags)
       @@current_context.children << context
 
       old_context = @@current_context
@@ -177,19 +177,19 @@ module Spec
       end
     end
 
-    def it(description, file, line, end_line, focus, &block)
-      add_example(description, file, line, end_line, focus, block)
+    def it(description, file, line, end_line, focus, tags, &block)
+      add_example(description, file, line, end_line, focus, tags, block)
     end
 
-    def pending(description, file, line, end_line, focus)
-      add_example(description, file, line, end_line, focus, nil)
+    def pending(description, file, line, end_line, focus, tags)
+      add_example(description, file, line, end_line, focus, tags, nil)
     end
 
-    private def add_example(description, file, line, end_line, focus, block)
+    private def add_example(description, file, line, end_line, focus, tags, block)
       check_nesting_spec(file, line) do
         Spec.focus = true if focus
         @@current_context.children <<
-          Example.new(@@current_context, description, file, line, end_line, focus, block)
+          Example.new(@@current_context, description, file, line, end_line, focus, tags, block)
       end
     end
 
@@ -277,7 +277,8 @@ module Spec
 
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
-                   @focus : Bool)
+                   @focus : Bool, tags)
+      initialize_tags(tags)
     end
 
     # :nodoc:

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -133,6 +133,15 @@ module Spec
     lines << line
   end
 
+  # :nodoc:
+  def self.add_tag(tag)
+    if anti_tag = tag.lchop?('~')
+      (@@anti_tags ||= Set(String).new) << anti_tag
+    else
+      (@@tags ||= Set(String).new) << tag
+    end
+  end
+
   record SplitFilter, remainder : Int32, quotient : Int32
 
   @@split_filter : SplitFilter? = nil
@@ -280,7 +289,7 @@ module Spec
 
   # :nodoc:
   def self.run_filters
-    root_context.run_filters(@@pattern, @@line, @@locations, @@split_filter, @@focus)
+    root_context.run_filters(@@pattern, @@line, @@locations, @@split_filter, @@focus, @@tags, @@anti_tags)
   end
 end
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -11,8 +11,9 @@ module Spec
     # :nodoc:
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
-                   @focus : Bool,
+                   @focus : Bool, tags,
                    @block : (->) | Nil)
+      initialize_tags(tags)
     end
 
     # :nodoc:

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -18,5 +18,12 @@ module Spec
 
     # Does this example or example group have `focus: true` on it?
     getter? focus : Bool
+
+    # The tags defined on this example or example group
+    getter tags : Set(String)?
+
+    private def initialize_tags(tags)
+      @tags = tags.is_a?(String) ? Set{tags} : tags.try(&.to_set)
+    end
   end
 end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -14,8 +14,8 @@ module Spec::Methods
   # ```
   #
   # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
-  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
-    Spec.root_context.describe(description.to_s, file, line, end_line, focus, &block)
+  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    Spec.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
   # Defines an example group that establishes a specific context,
@@ -25,8 +25,8 @@ module Spec::Methods
   # It is functionally equivalent to `#describe`.
   #
   # If `focus` is `true`, only this `context`, and others marked with `focus: true`, will run.
-  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
-    describe(description.to_s, file, line, end_line, focus, &block)
+  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
   # Defines a concrete test case.
@@ -41,8 +41,8 @@ module Spec::Methods
   # It is usually used inside a `#describe` or `#context` section.
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
-    Spec.root_context.it(description.to_s, file, line, end_line, focus, &block)
+  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    Spec.root_context.it(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
   # Defines a pending test case.
@@ -58,15 +58,15 @@ module Spec::Methods
   # It is usually used inside a `#describe` or `#context` section.
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
-    pending(description, file, line, end_line, focus)
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    pending(description, file, line, end_line, focus, tags)
   end
 
   # Defines a yet-to-be-implemented pending test case
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false)
-    Spec.root_context.pending(description.to_s, file, line, end_line, focus)
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil)
+    Spec.root_context.pending(description.to_s, file, line, end_line, focus, tags)
   end
 
   # DEPRECATED: Use `#it`


### PR DESCRIPTION
This PR adds support for tagging specs similar (but not identical) to RSpec's tagging.

Example:
```crystal
describe Foo do
  it "#my_fast_method", tags: "fast" do
  end

  it "#my_slow_method", tags: "slow" do
  end
end
```

To run it, you can do `crystal spec --tag fast` to run the specs tagged "fast" only, or `crystal spec --tag ~slow` to run the specs *not* tagged "slow"

Additionally,
- Tagging can be added at any level (describe/context/it).
- Multiple tags can be specified at any level.
- Tags can be specified as a single string or as anything that can become a `Set(String)` via `to_set`, typically an `Array(String)` or a `Tuple` of Strings.
  - `it "stuff", tags: "slow"`
  - `it "stuff", tags: ["slow", "cli"]`
  - `it "stuff", tags: {"slow", "cli"}`
- Multiple tags can be passed to `crystal spec` by specifying `--tag` multiple times.

#### Differences to RSpec tagging

- RSpec tagging is done via general metadata options on each describe/context/it.  This PR is instead a purpose driven `tags` keyword parameter.
- In RSpec, you tag as follows:
  - `it "stuff", :slow => true do` and run it with `rspec --tag slow`
  - `it "stuff", :custom_key => custom_value do` and run it with `rspec --tag custom_key:custom_value`

  Implementation wise (and performance-wise) I felt it much cleaner to just make them all strings.  So the "equivalent" in this PR is

  - `it "stuff", tags: "slow" do` and run it with `crystal spec --tag slow`
  - `it "stuff", tags: "custom_key:custom_value" do` and run it with `crystal spec --tag custom_key:custom_value`

  Note that in RSpec you *can* do `rspec --tag custom_key` to run anything tagged with that key regardless of value.  However, I felt the complexity to support Hash style args (and likely NamedTuple as well) wasn't worth it for this one feature, when the workaround is to just tag it explicitly with a second tag (e.g. `it "stuff", tags: ["custom_key", "custom_key:custom_value"] do`)

#### TODO

- ~~I still have to verify all of the various filtering combinations on the RSpec side (between tags, anti-tags, description, pattern, file, locations) and determine precendence and logic (i.e. AND/OR), then see if that's what we also want it to do here.~~
  See https://github.com/crystal-lang/crystal/pull/8068#issuecomment-526372069 and subsequent discussion in https://github.com/crystal-lang/crystal/pull/8125#issuecomment-526372807
- I'm not sure how to write specs for this, and there aren't specs for the existing filtering code (like locations).  I did a lot of manual testing with this, so it works.