### PR TITLE
Extend Big* classes support for JSON serialization

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -338,12 +338,12 @@ describe "JSON serialization" do
 
     it "does for BigInt" do
       big = BigInt.new("123456789123456789123456789123456789123456789")
-      big.to_json.should eq("123456789123456789123456789123456789123456789")
+      big.to_json.should eq(%("123456789123456789123456789123456789123456789"))
     end
 
     it "does for BigFloat" do
       big = BigFloat.new("1234.567891011121314")
-      big.to_json.should eq("1234.567891011121314")
+      big.to_json.should eq(%("1234.567891011121314"))
     end
 
     it "does for UUID" do

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -1,44 +1,81 @@
 require "json"
 require "big"
 
-def BigInt.new(pull : JSON::PullParser)
-  pull.read_int
-  BigInt.new(pull.raw_value)
-end
-
-def BigInt.from_json_object_key?(key : String)
-  BigInt.new(key)
-rescue ArgumentError
-  nil
-end
-
-def BigFloat.new(pull : JSON::PullParser)
-  pull.read_float
-  BigFloat.new(pull.raw_value)
-end
-
-def BigFloat.from_json_object_key?(key : String)
-  BigFloat.new(key)
-rescue ArgumentError
-  nil
-end
-
-def BigDecimal.new(pull : JSON::PullParser)
-  case pull.kind
-  when .int?
-    pull.read_int
-    value = pull.raw_value
-  when .float?
-    pull.read_float
-    value = pull.raw_value
-  else
-    value = pull.read_string
+struct BigInt
+  def self.new(pull : JSON::PullParser)
+    case pull.kind
+    when .int?
+      pull.read_int
+      value = pull.raw_value
+    else
+      value = pull.read_string
+    end
+    new(value)
   end
-  BigDecimal.new(value)
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue ArgumentError
+    nil
+  end
+
+  def to_json(json : JSON::Builder)
+    json.string(to_s)
+  end
 end
 
-def BigDecimal.from_json_object_key?(key : String)
-  BigDecimal.new(key)
-rescue InvalidBigDecimalException
-  nil
+struct BigFloat
+  def self.new(pull : JSON::PullParser)
+    case pull.kind
+    when .int?
+      pull.read_int
+      value = pull.raw_value
+    when .float?
+      pull.read_float
+      value = pull.raw_value
+    else
+      value = pull.read_string
+    end
+    new(value)
+  end
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue ArgumentError
+    nil
+  end
+
+  def to_json(json : JSON::Builder)
+    json.string(to_s)
+  end
+end
+
+struct BigDecimal
+  def self.new(pull : JSON::PullParser)
+    case pull.kind
+    when .int?
+      pull.read_int
+      value = pull.raw_value
+    when .float?
+      pull.read_float
+      value = pull.raw_value
+    else
+      value = pull.read_string
+    end
+    new(value)
+  end
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue InvalidBigDecimalException
+    nil
+  end
+
+  def to_json_object_key
+    to_s
+  end
+
+  def to_json(json : JSON::Builder)
+    json.string(to_s)
+  end
 end

--- a/src/big/yaml.cr
+++ b/src/big/yaml.cr
@@ -1,26 +1,29 @@
 require "yaml"
 require "big"
 
-def BigInt.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-  unless node.is_a?(YAML::Nodes::Scalar)
-    node.raise "Expected scalar, not #{node.class}"
+struct BigInt
+  def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+    new(node.value)
   end
-
-  BigInt.new(node.value)
 end
 
-def BigFloat.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-  unless node.is_a?(YAML::Nodes::Scalar)
-    node.raise "Expected scalar, not #{node.class}"
+struct BigFloat
+  def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+    new(node.value)
   end
-
-  BigFloat.new(node.value)
 end
 
-def BigDecimal.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-  unless node.is_a?(YAML::Nodes::Scalar)
-    node.raise "Expected scalar, not #{node.class}"
+struct BigDecimal
+  def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+    new(node.value)
   end
-
-  BigDecimal.new(node.value)
 end


### PR DESCRIPTION
- Allows to serialize `BigDecimal` objects (to strings)
- Changes `Big*` classes to serialize as strings (in order to avoid overflows)
- Allows to deserialize `Big*` objects from strings
- Allows to deserialize `BigFloat` from ints
- Allows `BigDecimal` to be used as JSON keys

Closes #7856