### PR TITLE
Regex: let a regex be multiline by default, `m` means DOTALL

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -13,7 +13,9 @@ describe "Regex" do
 
   it "does inspect" do
     /foo/.inspect.should eq("/foo/")
-    /foo/.inspect.should eq("/foo/")
+    /foo/i.inspect.should eq("/foo/i")
+    /foo/m.inspect.should eq("/foo/m")
+    /foo/x.inspect.should eq("/foo/x")
     /foo/imx.inspect.should eq("/foo/imx")
   end
 
@@ -65,12 +67,11 @@ describe "Regex" do
     ("HeLlO" =~ /hello/i).should eq(0)
   end
 
-  it "matches lines beginnings on ^ in multiline mode" do
-    ("foo\nbar" =~ /^bar/).should be_nil
-    ("foo\nbar" =~ /^bar/m).should eq(4)
+  it "matches lines beginnings (multiline on by default)" do
+    ("foo\nbar" =~ /^bar/).should eq(4)
   end
 
-  it "matches multiline" do
+  it "matches multiline (pcre dotall)" do
     ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
     ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -4105,7 +4105,7 @@ class String
   end
 
   def starts_with?(re : Regex)
-    !!($~ = re.match_at_byte_index(self, 0, Regex::Options::ANCHORED))
+    !!($~ = re.match_at_byte_index(self, 0, Regex::Options::PCRE_ANCHORED))
   end
 
   def ends_with?(str : String)

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -90,7 +90,7 @@ class StringScanner
   # s.scan(/.*/)    # => ""
   # ```
   def scan(pattern)
-    match(pattern, advance: true, options: Regex::Options::ANCHORED)
+    match(pattern, advance: true, options: Regex::Options::PCRE_ANCHORED)
   end
 
   # Scans the string _until_ the *pattern* is matched. Returns the substring up
@@ -109,7 +109,7 @@ class StringScanner
     match(pattern, advance: true, options: Regex::Options::None)
   end
 
-  private def match(pattern, advance = true, options = Regex::Options::ANCHORED)
+  private def match(pattern, advance = true, options = Regex::Options::PCRE_ANCHORED)
     match = pattern.match_at_byte_index(@str, @byte_offset, options)
     @last_match = match
     if match
@@ -165,7 +165,7 @@ class StringScanner
   # s.check(/\w+/) # => "is"
   # ```
   def check(pattern)
-    match(pattern, advance: false, options: Regex::Options::ANCHORED)
+    match(pattern, advance: false, options: Regex::Options::PCRE_ANCHORED)
   end
 
   # Returns the value that `#scan_until` would return, without advancing the


### PR DESCRIPTION
Fixes #8062

It's more intuitive this way, and it's also closer to how Ruby works.

I renamed `Options` members to separate values from PCRE from the ones we expose to the user because they are slightly different. In particular `MULTILINE` and `PCRE_MULTILINE` have different values.