### PR TITLE
Path: optimize `join` by precomputing capacity if possible

### DIFF
--- a/src/path.cr
+++ b/src/path.cr
@@ -647,7 +647,18 @@ struct Path
   # Path.windows("foo\\bar").join(Path.posix("baz/baq")) # => Path.windows("foo\\bar\\baz/baq")
   # ```
   def join(parts : Enumerable) : Path
-    new_name = String.build do |str|
+    if parts.is_a?(Indexable)
+      # If we know how many parts we have we can compute an approximation of
+      # the string's capacity: this path's size plus the parts' size plus the
+      # separators between them
+      capacity = @name.bytesize +
+                 parts.sum(&.to_s.bytesize) +
+                 parts.size
+    else
+      capacity = 64
+    end
+
+    new_name = String.build(capacity) do |str|
       str << @name
       last_ended_with_separator = ends_with_separator?
 


### PR DESCRIPTION
Nothing spectacular, but still...

Code:

```crystal
require "benchmark"

base = "/Users/someone/foo/bar"
parts = ["baz", "qux", "foo", "bar", "baz"]

Benchmark.ips do |x|
  x.report("join") do
    Path.new(base).join(parts)
  end
  x.report("join (new)") do
    Path.new(base).join2(parts)
  end
end

base = "/Users/someone/foo/bar"
parts = ["baz.cr"]

Benchmark.ips do |x|
  x.report("join") do
    Path.new(base).join(parts)
  end
  x.report("join (new)") do
    Path.new(base).join2(parts)
  end
end
```

Results:

```
      join   5.28M (189.53ns) (± 3.96%)  176B/op   1.05× slower
join (new)   5.52M (181.08ns) (± 1.03%)  160B/op        fastest
      join   8.64M (115.69ns) (± 3.00%)  176B/op   1.22× slower
join (new)  10.57M ( 94.59ns) (± 3.49%)  144B/op        fastest
```

`Path#join` also has a bug: in one part of the code it calls `parts.size` but it's not fine to assume that given that it's just `Enumerable`. But it's probably fine because at least in the std all enumerables have a known size.