### PR TITLE
Optimize Dir.glob

### DIFF
--- a/src/crystal/system/dir.cr
+++ b/src/crystal/system/dir.cr
@@ -1,11 +1,34 @@
 # :nodoc:
 module Crystal::System::Dir
+  # :nodoc:
+  #
+  # Information about a directory entry.
+  #
+  # In particular we only care about the name and whether its
+  # a directory or not to improve the performance of Dir.glob
+  # by avoid having to call File.info on every directory entry.
+  # In the future we might change Dir's API to expose these entries
+  # with more info but right now it's not necessary.
+  struct Entry
+    getter name
+    getter? dir
+
+    def initialize(@name : String, @dir : Bool)
+    end
+  end
+
   # Returns a new handle to an iterator of entries inside *path*.
   # def self.open(path : String) : Handle
 
+  # Returns the next directory entry name in the iterator represented by *handle*, or
+  # `nil` if iteration is complete.
+  def self.next(dir) : String?
+    next_entry(dir).try &.name
+  end
+
   # Returns the next directory entry in the iterator represented by *handle*, or
   # `nil` if iteration is complete.
-  # def self.next(handle : Handle) : String?
+  # def self.next_entry(handle : Handle) : Entry?
 
   # Rewinds the iterator to the beginning of the directory.
   # def self.rewind(handle : Handle) : Nil

--- a/src/crystal/system/unix/dir.cr
+++ b/src/crystal/system/unix/dir.cr
@@ -7,12 +7,14 @@ module Crystal::System::Dir
     dir
   end
 
-  def self.next(dir) : String?
+  def self.next_entry(dir) : Entry?
     # LibC.readdir returns NULL and sets errno for failure or returns NULL for EOF but leaves errno as is.
     # This means we need to reset `Errno` before calling `readdir`.
     Errno.value = 0
     if entry = LibC.readdir(dir)
-      String.new(entry.value.d_name.to_unsafe)
+      name = String.new(entry.value.d_name.to_unsafe)
+      dir = entry.value.d_type == LibC::DT_DIR
+      Entry.new(name, dir)
     elsif Errno.value != 0
       raise Errno.new("readdir")
     else

--- a/src/lib_c/aarch64-linux-gnu/c/dirent.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : Long

--- a/src/lib_c/aarch64-linux-musl/c/dirent.cr
+++ b/src/lib_c/aarch64-linux-musl/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : OffT

--- a/src/lib_c/arm-linux-gnueabihf/c/dirent.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : Long

--- a/src/lib_c/i386-linux-gnu/c/dirent.cr
+++ b/src/lib_c/i386-linux-gnu/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : Long

--- a/src/lib_c/i386-linux-musl/c/dirent.cr
+++ b/src/lib_c/i386-linux-musl/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : OffT

--- a/src/lib_c/x86_64-darwin/c/dirent.cr
+++ b/src/lib_c/x86_64-darwin/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_reclen : UShort

--- a/src/lib_c/x86_64-freebsd/c/dirent.cr
+++ b/src/lib_c/x86_64-freebsd/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     {% if flag?(:freebsd11) %}
       d_fileno : UInt

--- a/src/lib_c/x86_64-linux-gnu/c/dirent.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : Long

--- a/src/lib_c/x86_64-linux-musl/c/dirent.cr
+++ b/src/lib_c/x86_64-linux-musl/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_ino : InoT
     d_off : OffT

--- a/src/lib_c/x86_64-openbsd/c/dirent.cr
+++ b/src/lib_c/x86_64-openbsd/c/dirent.cr
@@ -3,6 +3,8 @@ require "./sys/types"
 lib LibC
   type DIR = Void
 
+  DT_DIR = 4
+
   struct Dirent
     d_fileno : InoT
     d_off : OffT


### PR DESCRIPTION
This PR optimized `Dir.glob` by avoiding unnecessary calls to `File.info?` for each directory entry because `readdir` already gives us that information.

This is similar to [how Python does it](https://www.python.org/dev/peps/pep-0471/) since some time ago and I can imagine Ruby does that too, probably other languages as well.

I just wanted to optimize this so the public API is still the same. I just exposed internally the information of whether a dir entry is a directory or not just for this purpose.

In the future we can consider whether it makes sense to expose this information in a public API but right now I'd like to avoid huge breaking changes, or having to think about new APIs. I think the change here is pretty straight-forward and small that it's not a big deal to introduce this optimization.

I wrote this benchmark:

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("Dir.glob") do
    Dir.glob("*/*.cr") do
    end
  end
end
```

Results:

```
before: 1.73k (578.82µs) (± 2.60%)  67.3kB/op
after:  2.46k (407.11µs) (± 0.82%)  67.8kB/op
```