### PR TITLE
Path: optimize `join` for the case of joining one single part

### DIFF
--- a/src/path.cr
+++ b/src/path.cr
@@ -621,6 +621,73 @@ struct Path
     expanded.normalize(remove_final_separator: false)
   end
 
+  # Appends the given *part* to this path and returns the joined path.
+  #
+  # ```
+  # Path["foo"].join("bar")     # => Path["foo/bar"]
+  # Path["foo/"].join("/bar")   # => Path["foo/bar"]
+  # Path["/foo/"].join("/bar/") # => Path["/foo/bar/"]
+  # ```
+  def join(part) : Path
+    # If we are joining a single part we can use `String.new` instead of
+    # `String.build` which avoids an extra allocation.
+    # Given that `File.join(arg1, arg2)` is the most common usage
+    # it's good if we can optimize this case.
+
+    if part.is_a?(Path) && posix? && part.windows?
+      part = part.to_posix.to_s
+    else
+      part = part.to_s
+      part.check_no_null_byte
+    end
+
+    if @name.empty?
+      if part.empty?
+        # We could use `separators[0].to_s` but then we'd have to
+        # convert Char to String which involves a memory allocation
+        return new_instance(windows? ? "\\" : "/")
+      else
+        return new_instance(part)
+      end
+    end
+
+    bytesize = @name.bytesize + part.bytesize # bytesize of the resulting string
+    add_separator = false                     # do we need to add a separate between the parts?
+    part_ptr = part.to_unsafe                 # where do we start copying from `part`?
+    part_bytesize = part.bytesize             # how much do we copy from `part`?
+
+    case {ends_with_separator?, starts_with_separator?(part)}
+    when {true, true}
+      # There are separators on both sides so we'll just lchop from the right part
+      bytesize -= 1
+      part_ptr += 1
+      part_bytesize -= 1
+    when {false, false}
+      # No separators on any side so we need to add one
+      bytesize += 1
+      add_separator = true
+    end
+
+    new_name = String.new(bytesize) do |buffer|
+      # Copy name
+      buffer.copy_from(@name.to_unsafe, @name.bytesize)
+      buffer += @name.bytesize
+
+      # Add separator if needed
+      if add_separator
+        buffer.value = separators[0].ord.to_u8
+        buffer += 1
+      end
+
+      # Copy the part
+      buffer.copy_from(part_ptr, part_bytesize)
+
+      {bytesize, @name.ascii_only? && part.ascii_only? ? bytesize : 0}
+    end
+
+    new_instance new_name
+  end
+
   # Appends the given *parts* to this path and returns the joined path.
   #
   # ```
@@ -649,7 +716,7 @@ struct Path
   def join(parts : Enumerable) : Path
     if parts.is_a?(Indexable)
       # If it's just a single part we can avoid one allocation of String.build
-      return join_one(parts.first) if parts.size == 1
+      return join(parts.first) if parts.size == 1
 
       # If we know how many parts we have we can compute an approximation of
       # the string's capacity: this path's size plus the parts' size plus the
@@ -703,65 +770,6 @@ struct Path
 
         str.write part.unsafe_byte_slice(byte_start, byte_count)
       end
-    end
-
-    new_instance new_name
-  end
-
-  # If we are joining a single part we can use `String.new` instead of
-  # `String.build` which avoids an extra allocation.
-  # Given that `File.join(arg1, arg2)` is the most common usage
-  # it's good if we can optimize this case.
-  private def join_one(part)
-    if part.is_a?(Path) && posix? && part.windows?
-      part = part.to_posix.to_s
-    else
-      part = part.to_s
-      part.check_no_null_byte
-    end
-
-    if @name.empty?
-      if part.empty?
-        # We could use `separators[0].to_s` but then we'd have to
-        # convert Char to String which involves a memory allocation
-        return new_instance(windows? ? "\\" : "/")
-      else
-        return new_instance(part)
-      end
-    end
-
-    bytesize = @name.bytesize + part.bytesize # bytesize of the resulting string
-    add_separator = false                     # do we need to add a separate between the parts?
-    part_ptr = part.to_unsafe                 # where do we start copying from `part`?
-    part_bytesize = part.bytesize             # how much do we copy from `part`?
-
-    case {ends_with_separator?, starts_with_separator?(part)}
-    when {true, true}
-      # There are separators on both sides so we'll just lchop from the right part
-      bytesize -= 1
-      part_ptr += 1
-      part_bytesize -= 1
-    when {false, false}
-      # No separators on any side so we need to add one
-      bytesize += 1
-      add_separator = true
-    end
-
-    new_name = String.new(bytesize) do |buffer|
-      # Copy name
-      buffer.copy_from(@name.to_unsafe, @name.bytesize)
-      buffer += @name.bytesize
-
-      # Add separator if needed
-      if add_separator
-        buffer.value = separators[0].ord.to_u8
-        buffer += 1
-      end
-
-      # Copy the part
-      buffer.copy_from(part_ptr, part_bytesize)
-
-      {bytesize, @name.ascii_only? && part.ascii_only? ? bytesize : 0}
     end
 
     new_instance new_name

--- a/src/path.cr
+++ b/src/path.cr
@@ -648,6 +648,9 @@ struct Path
   # ```
   def join(parts : Enumerable) : Path
     if parts.is_a?(Indexable)
+      # If it's just a single part we can avoid one allocation of String.build
+      return join_one(parts.first) if parts.size == 1
+
       # If we know how many parts we have we can compute an approximation of
       # the string's capacity: this path's size plus the parts' size plus the
       # separators between them
@@ -668,7 +671,6 @@ struct Path
           # Every POSIX path is also a valid Windows path, so we only need to
           # convert the other way around (see `#to_windows`, `#to_posix`).
           part = part.to_posix if posix? && part.windows?
-
           part = part.@name
         else
           part = part.to_s
@@ -701,6 +703,65 @@ struct Path
 
         str.write part.unsafe_byte_slice(byte_start, byte_count)
       end
+    end
+
+    new_instance new_name
+  end
+
+  # If we are joining a single part we can use `String.new` instead of
+  # `String.build` which avoids an extra allocation.
+  # Given that `File.join(arg1, arg2)` is the most common usage
+  # it's good if we can optimize this case.
+  private def join_one(part)
+    if part.is_a?(Path) && posix? && part.windows?
+      part = part.to_posix.to_s
+    else
+      part = part.to_s
+      part.check_no_null_byte
+    end
+
+    if @name.empty?
+      if part.empty?
+        # We could use `separators[0].to_s` but then we'd have to
+        # convert Char to String which involves a memory allocation
+        return new_instance(windows? ? "\\" : "/")
+      else
+        return new_instance(part)
+      end
+    end
+
+    bytesize = @name.bytesize + part.bytesize # bytesize of the resulting string
+    add_separator = false                     # do we need to add a separate between the parts?
+    part_ptr = part.to_unsafe                 # where do we start copying from `part`?
+    part_bytesize = part.bytesize             # how much do we copy from `part`?
+
+    case {ends_with_separator?, starts_with_separator?(part)}
+    when {true, true}
+      # There are separators on both sides so we'll just lchop from the right part
+      bytesize -= 1
+      part_ptr += 1
+      part_bytesize -= 1
+    when {false, false}
+      # No separators on any side so we need to add one
+      bytesize += 1
+      add_separator = true
+    end
+
+    new_name = String.new(bytesize) do |buffer|
+      # Copy name
+      buffer.copy_from(@name.to_unsafe, @name.bytesize)
+      buffer += @name.bytesize
+
+      # Add separator if needed
+      if add_separator
+        buffer.value = separators[0].ord.to_u8
+        buffer += 1
+      end
+
+      # Copy the part
+      buffer.copy_from(part_ptr, part_bytesize)
+
+      {bytesize, @name.ascii_only? && part.ascii_only? ? bytesize : 0}
     end
 
     new_instance new_name


### PR DESCRIPTION
Follow up to #8078

This optimizes `Path#join` (and `File.join`) for the most common case:

```crystal
File.join("prefix", "suffix")
```

When we just have two pieces to combine it becomes easier to compute the total bytesize needed for the string and we can use `String.new` instead of `String.build`, the latter involving an extra allocation for the `String::Builder` class (and there's also no need to write things though a pointer, check capacity, etc.)

This results in more code, but I think it's good if we optimize for this case because it's so common.

Benchmark code:

```crystal
require "benchmark"

base = "/Users/someone/foo/bar"
parts = ["baz.cr"]

Benchmark.ips do |x|
  x.report("join") do
    Path.new(base).join(parts)
  end
end
```

Results:

```
before: 10.90M ( 91.78ns) (± 2.80%)  144B/op
after:  19.14M ( 52.23ns) (±11.85%)  48.0B/op
```

That's twice as fast and with a third of the memory used.

Another benchmark (`Dir.glob` uses a lot of `File.join(x, y)`):

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("Dir.glob") do
    Dir.glob("*/*.cr") do
    end
  end
end
```

Results:

```
before: 1.85k (541.76µs) (± 4.57%)  56.0kB/op
after:  1.89k (528.95µs) (±10.02%)  42.3kB/op
```

Not a lot of speed improvement because the `File.info?` call is the bottleneck (but that's solved by #8081), but look at the memory: 42.3kB/op vs. 56kB/op. Huge difference!