### PR TITLE
Optimize `Array#*`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -133,7 +133,11 @@ describe "Array" do
   end
 
   it "does *" do
+    (([] of Int32) * 10).empty?.should be_true
+    ([1, 2, 3] * 0).empty?.should be_true
+    ([1] * 3).should eq([1, 1, 1])
     ([1, 2, 3] * 3).should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    ([1, 2] * 10).should eq([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
   end
 
   describe "[]" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -325,11 +325,31 @@ class Array(T)
   # ["a", "b", "c"] * 2 # => [ "a", "b", "c", "a", "b", "c" ]
   # ```
   def *(times : Int)
-    ary = Array(T).new(size * times)
-    times.times do
-      ary.concat(self)
+    if times == 0 || empty?
+      return Array(T).new
     end
-    ary
+
+    if times == 1
+      return dup
+    end
+
+    if size == 1
+      return Array(T).new(times, first)
+    end
+
+    new_size = size * times
+    Array(T).build(new_size) do |buffer|
+      buffer.copy_from(to_unsafe, size)
+      n = size
+
+      while n <= new_size // 2
+        (buffer + n).copy_from(buffer, n)
+        n *= 2
+      end
+
+      (buffer + n).copy_from(buffer, new_size - n)
+      new_size
+    end
   end
 
   # Append. Alias for `push`.


### PR DESCRIPTION
We use the same trick of multiple memcpy like we do in `String#*` and also consider a few edge cases like 0 and 1.

Benchmark:

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("old (1*100)") do
    [1] * 100
  end
  x.report("new (1*100)") do
    [1].mul(100)
  end
end

Benchmark.ips do |x|
  x.report("old (3*100)") do
    [1, 2, 3] * 100
  end
  x.report("new (3*100)") do
    [1, 2, 3].mul(100)
  end
end

Benchmark.ips do |x|
  x.report("old (3*1)") do
    [1, 2, 3] * 1
  end
  x.report("new (3*1)") do
    [1, 2, 3].mul(1)
  end
end
```

Results:

```
old (1*100)   1.62M (616.99ns) (± 6.18%)  528B/op   3.12× slower
new (1*100)   5.06M (197.73ns) (±13.24%)  528B/op        fastest
old (3*100)   1.25M (802.79ns) (± 3.55%)  2.08kB/op   1.58× slower
new (3*100)   1.96M (509.59ns) (± 2.59%)  2.08kB/op        fastest
old (3*1)  14.50M ( 68.96ns) (±12.02%)  96.0B/op   1.03× slower
new (3*1)  14.88M ( 67.21ns) (± 8.74%)  96.0B/op        fastest
```

I also got curious about this:

```crystal
Benchmark.ips do |x|
  x.report("old (1*100)") do
    [1] * 100
  end
  x.report("new (1*100)") do
    [1].mul(100)
  end
  x.report("Array.new(size, value)") do
    Array.new(100, 1)
  end
end
```

Because they are essentially the same except that `[1] * 100` is shorter to read/write and fancier.

Results:

```
           old (1*100)   1.74M (574.33ns) (± 0.96%)  528B/op   3.36× slower
           new (1*100)   5.48M (182.38ns) (± 1.00%)  528B/op   1.07× slower
Array.new(size, value)   5.85M (170.95ns) (± 1.37%)  480B/op        fastest
```

So it's not that much worse so now it becomes kind of acceptable to do.