### PR TITLE
Increase precision of `Process.times`

### DIFF
--- a/src/lib_c/x86_64-darwin/c/sys/times.cr
+++ b/src/lib_c/x86_64-darwin/c/sys/times.cr
@@ -1,4 +1,7 @@
 require "./types"
+require "c/stdlib"
+require "c/sys/times"
+require "c/unistd"
 
 lib LibC
   struct Tms
@@ -8,5 +11,28 @@ lib LibC
     tms_cstime : ClockT
   end
 
+  struct RUsage
+    ru_utime : Timeval
+    ru_stime : Timeval
+    ru_maxrss : Int32
+    ru_ix_rss : Int32
+    ru_idrss : Int32
+    ru_isrss : Int32
+    ru_minflt : Int32
+    ru_majflt : Int32
+    ru_nswap : Int32
+    ru_inblock : Int32
+    ru_oublock : Int32
+    ru_msgsnd : Int32
+    ru_msgrcv : Int32
+    ru_nsignals : Int32
+    ru_nvcsw : Int32
+    ru_nivcsw : Int32
+  end
+
+  RUSAGE_SELF = 0
+  RUSAGE_CHILDREN = -1
+
   fun times(x0 : Tms*) : ClockT
+  fun getrusage(who : Int, usage : RUsage*) : Int16
 end

--- a/src/process.cr
+++ b/src/process.cr
@@ -69,9 +69,15 @@ class Process
   # Returns a `Tms` for the current process. For the children times, only those
   # of terminated children are returned.
   def self.times : Tms
-    hertz = LibC.sysconf(LibC::SC_CLK_TCK).to_f
-    LibC.times(out tms)
-    Tms.new(tms.tms_utime / hertz, tms.tms_stime / hertz, tms.tms_cutime / hertz, tms.tms_cstime / hertz)
+    LibC.getrusage(LibC::RUSAGE_SELF, out usage)
+    LibC.getrusage(LibC::RUSAGE_CHILDREN, out child)
+
+    Tms.new(
+      usage.ru_utime.tv_sec.to_f64 + usage.ru_utime.tv_usec.to_f64 / 1e6,
+      usage.ru_stime.tv_sec.to_f64 + usage.ru_stime.tv_usec.to_f64 / 1e6,
+      child.ru_utime.tv_sec.to_f64 + child.ru_utime.tv_usec.to_f64 / 1e6,
+      child.ru_stime.tv_sec.to_f64 + child.ru_stime.tv_usec.to_f64 / 1e6,
+    )
   end
 
   # Runs the given block inside a new process and


### PR DESCRIPTION
Moving to LibC's `getrusage` API gives us 4 orders of magnitude more precision.

Resolves #7964