### PR TITLE
Compiler: fix abstract def check regarding generic ancestor lookup

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -602,4 +602,38 @@ describe "Semantic: abstract def" do
       end
     ))
   end
+
+  it "implements through extend (considers original type for generic lookup) (#8096)" do
+    semantic(%(
+      module ICallable(T)
+        abstract def call(foo : T)
+      end
+
+      module Moo
+        def call(foo : Int32)
+        end
+      end
+
+      module Caller
+        extend ICallable(Int32)
+        extend Moo
+      end
+    ))
+  end
+
+  it "implements through extend (considers original type for generic lookup) (2) (#8096)" do
+    semantic(%(
+      module ICallable(T)
+        abstract def call(foo : T)
+      end
+
+      module Caller
+        extend ICallable(Int32)
+        extend self
+
+        def call(foo : Int32)
+        end
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -134,9 +134,7 @@ class Crystal::AbstractDefChecker
       # We must find the generic instantiation starting from the target type,
       # not from t1, because maybe t1 doesn't reach the generic base type.
       generic_base = find_base_generic_instantiation(target_type, t2)
-      if generic_base
-        m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
-      end
+      m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
     end
 
     m2.args.zip(m1.args) do |a2, a1|
@@ -182,11 +180,9 @@ class Crystal::AbstractDefChecker
     # and just then we check if they match.
     if base_type.is_a?(GenericType)
       generic_base = find_base_generic_instantiation(target_type, base_type)
-      if generic_base
-        replacer = ReplacePathWithTypeVar.new(base_type, generic_base)
-        base_return_type_node = base_return_type_node.clone
-        base_return_type_node.accept(replacer)
-      end
+      replacer = ReplacePathWithTypeVar.new(base_type, generic_base)
+      base_return_type_node = base_return_type_node.clone
+      base_return_type_node.accept(replacer)
     end
 
     base_return_type = base_type.lookup_type?(base_return_type_node)
@@ -224,34 +220,9 @@ class Crystal::AbstractDefChecker
   end
 
   def find_base_generic_instantiation(type : Type, base_type : GenericType)
-    base = type.ancestors.find do |t|
+    type.ancestors.find do |t|
       t.is_a?(GenericInstanceType) && t.generic_type == base_type
-    end
-
-    # It might happen that we don't find a generic instantiation in the ancestors
-    # if the method is implemented in a supertype of where the abstract method is
-    # defined, like:
-    #
-    # ```
-    # module Base(T)
-    #   def size
-    #   end
-    # end
-    #
-    # module Child(T)
-    #   include Base(T)
-    #
-    #   abstract def size
-    # end
-    #
-    # class Foo
-    #   include Child(Int32)
-    # end
-    # ```
-    #
-    # In the above we are looking for `size` and usually expect it
-    # to be in subtypes of `Child`, but in this case it's in a supertype.
-    base ? base.as(GenericInstanceType) : nil
+    end.as(GenericInstanceType)
   end
 
   private def this_warning_will_become_an_error


### PR DESCRIPTION
Fixes #8096

Thank you @Exilor ! Thanks to your bug report I was able to understand why other (rare) cases were failing too.

The code is this:

```crystal
module ICallable(T)
  abstract def call(foo : Proc(T))
end

module Caller
  extend self
  extend ICallable(Nil)

  def call(foo : Proc(Nil))
  end
end
```

And the compiler will check that `ICallable(T)#call` is implemented by all concrete subtype. One such subtype is `Caller:Module` (where class methods live). Does it provide a `call` method? No. Then the compiler goes and check whether any ancestor of `Caller:Module` provides it. Because it extends `self` it checks whether `Caller` (where instance methods live) provides it. And it does! But we must check whether that matches the method in the generic type. For that the compiler will try to find the generic instantiation of that module. That is, because we are checking a subtype of `ICallable(T)` then at some point there must have been some `include ICallable(X)` in the chain, to know what type `X` is. The problem was that the compiler would start the search from the current ancestor, in this case `Caller`, and not from the main type we were checking in the first place (`Caller:Module`).

It's a bit confusing. That's why I also added a similar spec which is a bit simpler:

```crystal
module ICallable(T)
  abstract def call(foo : T)
end

module Moo
  def call(foo : Int32)
  end
end

module Caller
  extend ICallable(Int32)
  extend Moo
end
```

Here the compiler again will check whether `Caller:Module` implements `call`. It will find that `Moo` has it and then it will try to find the `include/extend ICallable`, but it won't find starting from `Moo`, it will find it starting from `Caller:Module`. Well, at least in this case, in other cases it might happen that `Moo` is the one that is including the other module.