### PR TITLE
Compiler: don't skip all yield nodes if one is missing an exp type

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1522,4 +1522,19 @@ describe "Code gen: block" do
       foo{|_, _| }
       ))
   end
+
+  it "doesn't crash on yield exp without a type (#8100)" do
+    codegen(%(
+      def foo
+        x = 1
+        if x.is_a?(Char)
+          yield x
+        else
+          yield x
+        end
+      end
+
+      foo { |x| }
+    ))
+  end
 end


### PR DESCRIPTION
Fixes #8100

It seems when some yield expression didn't have a type we would break out from the yield typing logic. It makes sense to skip that yield but not all yields. This essentially changes a `return` for a `next` in a nested loop, but because the logic was getting a bit large and confusing a method was extracted for the contents of one loop.