### PR TITLE
clear OpenSSL thread error queue each time, might help with certain f…

### DIFF
--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -79,8 +79,11 @@ module OpenSSL
     end
 
     protected def fetch_error_details
-      code = LibCrypto.err_get_error
-      message = String.new(LibCrypto.err_error_string(code, nil)) unless code == 0
+      message = nil
+      while((code = LibCrypto.err_get_error) != 0)
+        message ||= ""
+        message += String.new(LibCrypto.err_error_string(code, nil))
+      end
       {code, message || "Unknown or no error"}
     end
   end


### PR DESCRIPTION
…ailure cases.

It wasn't clear if this is absolutely necessary but it does follow the spec:
6d0835759b131748582cfccb694d16f59205bfe6

And apparently some people have run into problems if they don't do it this way:
https://github.com/nodejs/node-v0.x-archive/issues/1719

I think if you call it more than once it's supposed to give "more detailed" error messages with each invocation or something along those lines.