### PR TITLE
Hash: use integer division instead of float division

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -237,7 +237,7 @@ class Hash(K, V)
         initial_indices_size = Math.pw2ceil(initial_capacity)
       end
 
-      @entries = malloc_entries(initial_indices_size / 2)
+      @entries = malloc_entries(initial_indices_size // 2)
 
       # Check if we can avoid allocating the `@indices` buffer for
       # small hashes.
@@ -884,7 +884,7 @@ class Hash(K, V)
 
   # Returns the capacity of `@entries`.
   protected def entries_capacity
-    indices_size / 2
+    indices_size // 2
   end
 
   # Computes the hash of a key.


### PR DESCRIPTION
Fixes a couple of warnings in `src/hash.cr`:

```
$ bin/crystal spec/std/hash_spec.cr --warnings=all
In src/hash.cr:240:54

 240 | @entries = malloc_entries(initial_indices_size / 2)
                                                      ^
Warning: Deprecated Int32#/. `Int#/` will return a `Float` in 0.29.0. Use `Int#//` for integer division.

In src/hash.cr:887:18

 887 | indices_size / 2
                    ^
Warning: Deprecated Int32#/. `Int#/` will return a `Float` in 0.29.0. Use `Int#//` for integer division.

A total of 2 warnings were found.
```

Thanks @Blacksmoke16 for finding this (though next time please report it as an issue, I might forget what I read in gitter 😊)