### PR TITLE
Do not build empty INI section

### DIFF
--- a/spec/std/ini_spec.cr
+++ b/spec/std/ini_spec.cr
@@ -77,7 +77,7 @@ describe "INI" do
   end
 
   describe "build to an INI-formatted output" do
-    it "build from a Hash" do
+    it "builds from a Hash" do
       INI.build({
         "general" => {
           "log_level" => 'D',
@@ -91,7 +91,7 @@ describe "INI" do
         },
       }, true).should eq(File.read datapath("test_file.ini"))
     end
-    it "build from a NamedTuple" do
+    it "builds from a NamedTuple" do
       INI.build({
         "general": {
           "log_level": 'D',
@@ -105,8 +105,17 @@ describe "INI" do
         },
       }, true).should eq(File.read datapath("test_file.ini"))
     end
-    it "build with no spaces around `=`" do
+
+    it "builds with no spaces around `=`" do
       INI.build({"foo" => {"a" => "1"}}, false).should eq("[foo]\na=1\n\n")
+    end
+
+    it "builds with no sections" do
+      INI.build({"" => {"a" => "1"}}, false).should eq("a=1\n")
+    end
+
+    it "builds an empty section before non-empty sections" do
+      INI.build({"foo" => {"a" => "1"}, "" => {"b" => "2"}}, false).should eq("b=2\n[foo]\na=1\n\n")
     end
   end
 end

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -71,7 +71,12 @@ class INI
 
   # Appends INI data to the given IO.
   def self.build(io : IO, ini, space : Bool = false) : Nil
+    # An empty section has to be at first, to prevent being included in another one.
+    ini[""]?.try &.each do |key, value|
+      io << key << (space ? " = " : '=') << value << '\n'
+    end
     ini.each do |section, contents|
+      next if section.to_s.empty?
       io << '[' << section << "]\n"
       contents.each do |key, value|
         io << key << (space ? " = " : '=') << value << '\n'


### PR DESCRIPTION
Having an INI file with no section is valid. However, the current builder will add an empty section `[]`, which will result of a changed file.