### PR TITLE
Docs: fix link to constructor not working

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -28,4 +28,20 @@ describe Doc::Type do
     doc_alias_type = generator.type(alias_type)
     doc_alias_type.types.size.should eq(0)
   end
+
+  it "finds construct when searching class method (#8095)" do
+    result = semantic(%(
+      class Foo
+        def initialize(x)
+        end
+      end
+    ))
+
+    program = result.program
+
+    generator = Doc::Generator.new program, [""], ".", "html", nil
+    foo = generator.type(program.types["Foo"])
+    foo.lookup_class_method("new").should_not be_nil
+    foo.lookup_class_method("new", 1).should_not be_nil
+  end
 end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -425,11 +425,11 @@ class Crystal::Doc::Type
   end
 
   def lookup_class_method(name)
-    lookup_in_methods class_methods, name
+    lookup_in_methods all_class_methods, name
   end
 
   def lookup_class_method(name, args_size)
-    lookup_in_methods class_methods, name, args_size
+    lookup_in_methods all_class_methods, name, args_size
   end
 
   def lookup_macro(name)


### PR DESCRIPTION
Fixes #8095

`class_methods` doesn't include constructors, because that method is used for the "Class method" section and "Constructors" has a different section.