### PR TITLE
Fix: File.basename skips first char when removing suffix

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -174,11 +174,13 @@ describe Path do
     assert_paths_raw("/foo/bar/baz.cr", "baz.cr", &.basename)
     assert_paths_raw("/foo/", "foo", &.basename)
     assert_paths_raw("foo", "foo", &.basename)
+    assert_paths_raw("x", "x", &.basename)
     assert_paths_raw("", "", &.basename)
     assert_paths_raw(".", ".", &.basename)
     assert_paths_raw("/.", ".", &.basename)
     assert_paths_raw("/", "/", &.basename)
     assert_paths_raw("////", "/", &.basename)
+    assert_paths_raw("a/x", "x", &.basename)
     assert_paths_raw("a/.x", ".x", &.basename)
     assert_paths_raw("a/x.", "x.", &.basename)
 
@@ -197,6 +199,8 @@ describe Path do
       assert_paths_raw("\\foo\\bar\\baz.cr.tmp", "\\foo\\bar\\baz", "baz", &.basename(".cr.tmp"))
       assert_paths_raw("/foo/bar/baz.cr.tmp", "baz.cr", &.basename(".tmp"))
       assert_paths_raw("\\foo\\bar\\baz.cr.tmp", "\\foo\\bar\\baz.cr", "baz.cr", &.basename(".tmp"))
+      assert_paths_raw("a.txt", "a", &.basename(".txt"))
+      assert_paths_raw("a.x", "a", &.basename(".x"))
     end
   end
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -311,9 +311,12 @@ struct Path
     end
 
     # read suffix
-    if suffix && suffix.bytesize < current && suffix == @name.byte_slice(current - suffix.bytesize + 1, suffix.bytesize)
+    if suffix && suffix.bytesize <= current && suffix == @name.byte_slice(current - suffix.bytesize + 1, suffix.bytesize)
       current -= suffix.bytesize
     end
+
+    # one character left?
+    return @name.byte_slice(0, 1) if current == 0
 
     end_pos = {current, 1}.max
 


### PR DESCRIPTION
When removing the suffix, the first character of Path's `@name` is skipped, so the following case erroneously returns the whole file name, not removing the suffix:

```crystal
File.basename("a.txt", ".txt").should eq("a")
# => failure: expected "a" but got "a.txt"
```

This is a quick fix. Feel free to rewrite a proper patch if needed.