### PR TITLE
Add alias for Set#+ => Set#|

### DIFF
--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -142,6 +142,14 @@ describe "Set" do
     set3.should eq(Set{1, 2, 3, 4, 5, "3"})
   end
 
+  it "aliases + to |" do
+    set1 = Set{1, 1, 2, 3}
+    set2 = Set{3, 4, 5}
+    set3 = set1 + set2
+    set4 = set1 | set2
+    set3.should eq(set4)
+  end
+
   it "does -" do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = Set{2, 4, 6}

--- a/src/set.cr
+++ b/src/set.cr
@@ -208,7 +208,7 @@ struct Set(T)
   # ```
   # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}
   # ```
-  def +(other : Set(U))
+  def +(other : Set(U)) forall U
     self | other
   end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -203,9 +203,7 @@ struct Set(T)
     set
   end
 
-  # Addition: returns a new, unique set containing the elements from both sets.
-  # Because sets cannot have duplicates, this is equivalent to the union of
-  # both sets.
+  # Addition: returns a new set containing the unique elements from both sets.
   #
   # ```
   # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}

--- a/src/set.cr
+++ b/src/set.cr
@@ -203,13 +203,13 @@ struct Set(T)
     set
   end
 
-  # Addition: returns a new set containing the elements from both sets.
+  # Addition: returns a new, unique set containing the elements from both sets.
+  # Because sets cannot have duplicates, this is equivalent to the union of
+  # both sets.
   #
   # ```
   # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}
   # ```
-  #
-  # Alias for `#|` (Union).
   def +(other)
     self | other
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -203,6 +203,17 @@ struct Set(T)
     set
   end
 
+  # Addition: returns a new set containing the elements from both sets.
+  #
+  # ```
+  # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}
+  # ```
+  #
+  # Alias for `#|` (Union).
+  def +(other)
+    self | other
+  end
+
   # Difference: returns a new set containing elements in this set that are not
   # present in the other.
   #

--- a/src/set.cr
+++ b/src/set.cr
@@ -210,7 +210,7 @@ struct Set(T)
   # ```
   # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}
   # ```
-  def +(other)
+  def +(other : Set(U))
     self | other
   end
 


### PR DESCRIPTION
Adds the ability to use ` Set{1, 2, 3} + Set{3, 4, 5}` syntax as an alias for the little-known `Set{1, 2, 3} | Set{3, 4, 5}` syntax for adding (unioning) two `Set(T)` objects. I have long used a similar monkey-patch to enable idiomatic set addition in my projects.

Includes a spec that merely checks that the alias is in place, since existing specs cover `|`.

This PR is equivalent to this monkey patch:
```crystal
struct Set(T)
  def +(other)
    self | other
  end
end
```

Thanks to @asterite for encouraging me to submit this PR and @Blacksmoke16 and @watzon for vetting the idea in gitter.
