### PR TITLE
Spec: add support for `focus`

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -69,14 +69,20 @@ describe "BigFloat" do
   end
 
   describe "-@" do
-    bf = "0.12345".to_big_f
-    it { (-bf).to_s.should eq("-0.12345") }
+    it do
+      bf = "0.12345".to_big_f
+      (-bf).to_s.should eq("-0.12345")
+    end
 
-    bf = "61397953.0005354".to_big_f
-    it { (-bf).to_s.should eq("-61397953.0005354") }
+    it do
+      bf = "61397953.0005354".to_big_f
+      (-bf).to_s.should eq("-61397953.0005354")
+    end
 
-    bf = "395.009631567315769036".to_big_f
-    it { (-bf).to_s.should eq("-395.009631567315769036") }
+    it do
+      bf = "395.009631567315769036".to_big_f
+      (-bf).to_s.should eq("-395.009631567315769036")
+    end
   end
 
   describe "+" do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -99,10 +99,6 @@ describe "URI" do
     assert_uri("http://example.com//foo", scheme: "http", host: "example.com", path: "//foo")
     assert_uri("///foo", host: "", path: "/foo")
 
-    pending "path with escape" do
-      assert_uri("http://www.example.com/file%20one%26two", scheme: "http", host: "example.com", path: "/file one&two", raw_path: "/file%20one%26two")
-    end
-
     # query
     assert_uri("http://www.example.com/foo?q=1", scheme: "http", host: "www.example.com", path: "/foo", query: "q=1")
     assert_uri("http://www.example.com/foo?", scheme: "http", host: "www.example.com", path: "/foo", query: "")

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -1,4 +1,5 @@
 require "llvm"
+require "../exception"
 
 class Crystal::Codegen::Target
   class Error < Crystal::LocationlessException

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -1,3 +1,5 @@
+require "./codegen/target"
+
 module Crystal
   module Config
     def self.path

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -63,6 +63,18 @@ require "./spec/dsl"
 # # Run the spec or group defined in line 14 of spec/my/test/file_spec.cr
 # crystal spec spec/my/test/file_spec.cr:14
 # ```
+#
+# ## Focusing on a group of specs
+#
+# A `describe`, `context` or `it` can be marked with `focus: true`, like this:
+#
+# ```
+# it "adds", focus: true do
+#   (2 + 2).should_not eq(5)
+# end
+# ```
+#
+# If any such thing is marked with `focus: true` then only those examples will run.
 module Spec
 end
 

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -197,8 +197,6 @@ module Spec
   class NestedContext < Context
     include Item
 
-    getter! parent : Context
-
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
                    @focus : Bool)

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -109,55 +109,16 @@ module Spec
     lines << line
   end
 
-  @@split_filter : NamedTuple(remainder: Int32, quotient: Int32)? = nil
+  record SplitFilter, remainder : Int32, quotient : Int32
+
+  @@split_filter : SplitFilter? = nil
 
   def self.add_split_filter(filter)
     if filter
       r, m = filter.split('%').map &.to_i
-      @@split_filter = {remainder: r, quotient: m}
+      @@split_filter = SplitFilter.new(remainder: r, quotient: m)
     else
       @@split_filter = nil
-    end
-  end
-
-  @@spec_counter = -1
-
-  def self.split_filter_matches
-    split_filter = @@split_filter
-
-    if split_filter
-      @@spec_counter += 1
-      @@spec_counter % split_filter[:quotient] == split_filter[:remainder]
-    else
-      true
-    end
-  end
-
-  # :nodoc:
-  def self.matches?(description, file, line, end_line = line)
-    spec_pattern = @@pattern
-    spec_line = @@line
-    locations = @@locations
-
-    # When a method invokes `it` and only forwards line information,
-    # not end_line information (this can happen in code before we
-    # introduced the end_line feature) then running a spec by giving
-    # a line won't work because end_line might be located before line.
-    # So, we also check `line == spec_line` to somehow preserve
-    # backwards compatibility.
-    if spec_line && (line == spec_line || line <= spec_line <= end_line)
-      return true
-    end
-
-    if locations
-      lines = locations[file]?
-      return true if lines && lines.any? { |l| line == l || line <= l <= end_line }
-    end
-
-    if spec_pattern || spec_line || locations
-      Spec::RootContext.matches?(description, spec_pattern, spec_line, locations)
-    else
-      true
     end
   end
 
@@ -199,10 +160,33 @@ module Spec
   # :nodoc:
   def self.run
     start_time = Time.monotonic
+
     at_exit do
+      run_filters
+      root_context.run
+    ensure
       elapsed_time = Time.monotonic - start_time
-      Spec::RootContext.finish(elapsed_time, @@aborted)
-      exit 1 unless Spec::RootContext.succeeded && !@@aborted
+      root_context.finish(elapsed_time, @@aborted)
+      exit 1 unless root_context.succeeded && !@@aborted
+    end
+  end
+
+  # :nodoc:
+  def self.run_filters
+    if pattern = @@pattern
+      root_context.filter_by_pattern(pattern)
+    end
+
+    if line = @@line
+      root_context.filter_by_line(line)
+    end
+
+    if locations = @@locations
+      root_context.filter_by_locations(locations)
+    end
+
+    if split_filter = @@split_filter
+      root_context.filter_by_split(split_filter)
     end
   end
 end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -8,6 +8,7 @@ module Spec
     error:   :red,
     pending: :yellow,
     comment: :cyan,
+    focus:   :cyan,
   }
 
   private LETTERS = {
@@ -125,6 +126,9 @@ module Spec
   # :nodoc:
   class_property? fail_fast = false
 
+  # :nodoc:
+  class_property? focus = false
+
   # Instructs the spec runner to execute the given block
   # before each spec, regardless of where this method is invoked.
   def self.before_each(&block)
@@ -179,6 +183,10 @@ module Spec
 
     if split_filter = @@split_filter
       root_context.filter_by_split(split_filter)
+    end
+
+    if focus = @@focus
+      root_context.filter_by_focus
     end
   end
 end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -122,16 +122,8 @@ module Spec
     end
   end
 
-  @@fail_fast = false
-
   # :nodoc:
-  def self.fail_fast=(@@fail_fast)
-  end
-
-  # :nodoc:
-  def self.fail_fast?
-    @@fail_fast
-  end
+  class_property? fail_fast = false
 
   # Instructs the spec runner to execute the given block
   # before each spec, regardless of where this method is invoked.

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -4,7 +4,6 @@ module Spec
   class Example
     include Item
 
-    getter parent : Context
     getter block : ->
     getter? pending : Bool
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -1,0 +1,48 @@
+require "./item"
+
+module Spec
+  class Example
+    include Item
+
+    getter parent : Context
+    getter block : ->
+    getter? pending : Bool
+
+    def initialize(@parent : Context, @description : String,
+                   @file : String, @line : Int32, @end_line : Int32,
+                   @block : ->, @pending : Bool)
+    end
+
+    def run
+      Spec.root_context.check_nesting_spec(file, line) do
+        Spec.formatters.each(&.before_example(description))
+
+        if pending?
+          Spec.root_context.report(:pending, description, file, line)
+          return
+        end
+
+        start = Time.monotonic
+        begin
+          Spec.run_before_each_hooks
+          block.call
+          Spec.root_context.report(:success, description, file, line, Time.monotonic - start)
+        rescue ex : Spec::AssertionFailed
+          Spec.root_context.report(:fail, description, file, line, Time.monotonic - start, ex)
+          Spec.abort! if Spec.fail_fast?
+        rescue ex
+          Spec.root_context.report(:error, description, file, line, Time.monotonic - start, ex)
+          Spec.abort! if Spec.fail_fast?
+        ensure
+          Spec.run_after_each_hooks
+
+          # We do this to give a chance for signals (like CTRL+C) to be handled,
+          # which currently are only handled when there's a fiber switch
+          # (IO stuff, sleep, etc.). Without it the user might wait more than needed
+          # after pressing CTRL+C to quit the tests.
+          Fiber.yield
+        end
+      end
+    end
+  end
+end

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -10,6 +10,7 @@ module Spec
 
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
+                   @focus : Bool,
                    @block : ->, @pending : Bool)
     end
 

--- a/src/spec/filters.cr
+++ b/src/spec/filters.cr
@@ -1,0 +1,123 @@
+require "./item"
+require "./example"
+require "./context"
+
+module Spec
+  module Item
+    def matches_pattern?(pattern : Regex) : Bool
+      !!(@description =~ pattern)
+    end
+
+    def matches_line?(line : Int32) : Bool
+      @line == line || @line <= line <= @end_line
+    end
+
+    def matches_locations?(locations : Hash(String, Array(Int32))) : Bool
+      lines = locations[file]?
+      !!(lines && lines.any? { |line| matches_line?(line) })
+    end
+  end
+
+  class RootContext
+    def filter_by_pattern(pattern : Regex)
+      children.select!(&.filter_by_pattern(pattern))
+    end
+
+    def filter_by_line(line : Int32)
+      children.select!(&.filter_by_line(line))
+    end
+
+    def filter_by_locations(locations : Hash(String, Array(Int32)))
+      children.select!(&.filter_by_locations(locations))
+    end
+
+    def filter_by_split(split_filter : SplitFilter)
+      children.select!(&.filter_by_split(split_filter))
+    end
+  end
+
+  class NestedContext
+    # Filters a context and its children by pattern.
+    # Returns `true` if the context matches the pattern, `false` otherwise.
+    def filter_by_pattern(pattern : Regex) : Bool
+      return true if matches_pattern?(pattern)
+
+      children.select!(&.filter_by_pattern(pattern))
+      !children.empty?
+    end
+
+    # Filters a context and its children by line.
+    # Returns `true` if the context matches the line, `false` otherwise.
+    def filter_by_line(line : Int32) : Bool
+      # If any children matches then we match too, but we filter children
+      if children.any? &.matches_line?(line)
+        children.select!(&.filter_by_line(line))
+        return true
+      end
+
+      # Otherwise check if we match. If we do it means the line is inside
+      # this context but outside a nested context or example, so then we
+      # have to run all contexts and examples inside ourselves.
+      if matches_line?(line)
+        return true
+      end
+
+      false
+    end
+
+    # Filters a context and its children by the given locations.
+    # Returns `true` if the context matches the locations, `false` otherwise.
+    def filter_by_locations(locations : Hash(String, Array(Int32))) : Bool
+      # If any children matches then we match too, but we filter children
+      if children.any? &.matches_locations?(locations)
+        children.select!(&.filter_by_locations(locations))
+        return true
+      end
+
+      # Otherwise check if we match. If we do it means the line is inside
+      # this context but outside a nested context or example, so then we
+      # have to run all contexts and examples inside ourselves.
+      if matches_locations?(locations)
+        return true
+      end
+
+      false
+    end
+
+    # Filters a context and its children by the given split filter
+    # Returns `true` if the context matches the filter, `false` otherwise.
+    def filter_by_split(split_filter : SplitFilter) : Bool
+      children.select!(&.filter_by_split(split_filter))
+      !children.empty?
+    end
+  end
+
+  class Example
+    # Returns `true` if the example matches the pattern,
+    # `false` otherwise.
+    def filter_by_pattern(pattern : Regex) : Bool
+      matches_pattern?(pattern)
+    end
+
+    # Returns `true` if the example is contained in the given line,
+    # `false` otherwise.
+    def filter_by_line(line : Int32) : Bool
+      matches_line?(line)
+    end
+
+    # Returns `true` if the example is contained in the any of the given locations,
+    # `false` otherwise.
+    def filter_by_locations(locations : Hash(String, Array(Int32))) : Bool
+      matches_locations?(locations)
+    end
+
+    @@example_counter = -1
+
+    # Returns `true` if the example is matches the given split filter,
+    # `false` otherwise.`
+    def filter_by_split(split_filter : SplitFilter) : Bool
+      @@example_counter += 1
+      @@example_counter % split_filter.quotient == split_filter.remainder
+    end
+  end
+end

--- a/src/spec/filters.cr
+++ b/src/spec/filters.cr
@@ -31,6 +31,10 @@ module Spec
       children.select!(&.filter_by_locations(locations))
     end
 
+    def filter_by_focus
+      children.select!(&.filter_by_focus)
+    end
+
     def filter_by_split(split_filter : SplitFilter)
       children.select!(&.filter_by_split(split_filter))
     end
@@ -84,6 +88,16 @@ module Spec
       false
     end
 
+    # Filters a context and its children that are marked as focus.
+    # Returns `true` if the context or any of its children have focus,
+    # `false` otherwise.
+    def filter_by_focus : Bool
+      return true if focus?
+
+      children.select!(&.filter_by_focus)
+      !children.empty?
+    end
+
     # Filters a context and its children by the given split filter
     # Returns `true` if the context matches the filter, `false` otherwise.
     def filter_by_split(split_filter : SplitFilter) : Bool
@@ -109,6 +123,11 @@ module Spec
     # `false` otherwise.
     def filter_by_locations(locations : Hash(String, Array(Int32))) : Bool
       matches_locations?(locations)
+    end
+
+    # Returns `true` if this example is marked as focus, `false` otherwise
+    def filter_by_focus : Bool
+      @focus
     end
 
     @@example_counter = -1

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -35,7 +35,7 @@ module Spec
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec::RootContext.print_results(elapsed_time, aborted)
+      Spec.root_context.print_results(elapsed_time, aborted)
     end
   end
 
@@ -91,7 +91,7 @@ module Spec
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec::RootContext.print_results(elapsed_time, aborted)
+      Spec.root_context.print_results(elapsed_time, aborted)
     end
   end
 

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -3,6 +3,7 @@ module Spec
   #
   # Info that `describe`, `context` and `it` all have in common.
   module Item
+    getter parent : Context
     getter description : String
     getter file : String
     getter line : Int32

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -1,0 +1,11 @@
+module Spec
+  # :nodoc:
+  #
+  # Info that `describe`, `context` and `it` all have in common.
+  module Item
+    getter description : String
+    getter file : String
+    getter line : Int32
+    getter end_line : Int32
+  end
+end

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -7,5 +7,6 @@ module Spec
     getter file : String
     getter line : Int32
     getter end_line : Int32
+    getter? focus : Bool
   end
 end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -12,8 +12,10 @@ module Spec::Methods
   #   end
   # end
   # ```
-  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    Spec.root_context.describe(description.to_s, file, line, end_line, &block)
+  #
+  # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
+  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
+    Spec.root_context.describe(description.to_s, file, line, end_line, focus, &block)
   end
 
   # Defines an example group that establishes a specific context,
@@ -21,8 +23,10 @@ module Spec::Methods
   # Inside *&block* examples are defined by `#it` or `#pending`.
   #
   # It is functionally equivalent to `#describe`.
-  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    describe(description.to_s, file, line, end_line, &block)
+  #
+  # If `focus` is `true`, only this `context`, and others marked with `focus: true`, will run.
+  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
+    describe(description.to_s, file, line, end_line, focus, &block)
   end
 
   # Defines a concrete test case.
@@ -35,8 +39,10 @@ module Spec::Methods
   # ```
   #
   # It is usually used inside a `#describe` or `#context` section.
-  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    Spec.root_context.it(description.to_s, file, line, end_line, &block)
+  #
+  # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
+  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
+    Spec.root_context.it(description.to_s, file, line, end_line, focus, &block)
   end
 
   # Defines a pending test case.
@@ -50,13 +56,17 @@ module Spec::Methods
   # ```
   #
   # It is usually used inside a `#describe` or `#context` section.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    Spec.root_context.pending(description.to_s, file, line, end_line, &block)
+  #
+  # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
+    Spec.root_context.pending(description.to_s, file, line, end_line, focus, &block)
   end
 
   # Defines a yet-to-be-implemented pending test case
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__)
-    pending(description, file, line, end_line) { }
+  #
+  # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false)
+    pending(description, file, line, end_line, focus) { }
   end
 
   # DEPRECATED: Use `#it`

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -36,34 +36,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    description = description.to_s
-    Spec::RootContext.check_nesting_spec(file, line) do
-      return unless Spec.split_filter_matches
-      return unless Spec.matches?(description, file, line, end_line)
-
-      Spec.formatters.each(&.before_example(description))
-
-      start = Time.monotonic
-      begin
-        Spec.run_before_each_hooks
-        block.call
-        Spec::RootContext.report(:success, description, file, line, Time.monotonic - start)
-      rescue ex : Spec::AssertionFailed
-        Spec::RootContext.report(:fail, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      rescue ex
-        Spec::RootContext.report(:error, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      ensure
-        Spec.run_after_each_hooks
-
-        # We do this to give a chance for signals (like CTRL+C) to be handled,
-        # which currently are only handled when there's a fiber switch
-        # (IO stuff, sleep, etc.). Without it the user might wait more than needed
-        # after pressing CTRL+C to quit the tests.
-        Fiber.yield
-      end
-    end
+    Spec::RootContext.it(description.to_s, file, line, end_line, &block)
   end
 
   # Defines a pending test case.
@@ -78,14 +51,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    description = description.to_s
-    Spec::RootContext.check_nesting_spec(file, line) do
-      return unless Spec.matches?(description, file, line, end_line)
-
-      Spec.formatters.each(&.before_example(description))
-
-      Spec::RootContext.report(:pending, description, file, line)
-    end
+    Spec::RootContext.pending(description.to_s, file, line, end_line, &block)
   end
 
   # Defines a yet-to-be-implemented pending test case

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -12,8 +12,8 @@ module Spec::Methods
   #   end
   # end
   # ```
-  def describe(description, file = __FILE__, line = __LINE__, &block)
-    Spec::RootContext.describe(description.to_s, file, line, &block)
+  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    Spec.root_context.describe(description.to_s, file, line, end_line, &block)
   end
 
   # Defines an example group that establishes a specific context,
@@ -21,8 +21,8 @@ module Spec::Methods
   # Inside *&block* examples are defined by `#it` or `#pending`.
   #
   # It is functionally equivalent to `#describe`.
-  def context(description, file = __FILE__, line = __LINE__, &block)
-    describe(description.to_s, file, line, &block)
+  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    describe(description.to_s, file, line, end_line, &block)
   end
 
   # Defines a concrete test case.
@@ -36,7 +36,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    Spec::RootContext.it(description.to_s, file, line, end_line, &block)
+    Spec.root_context.it(description.to_s, file, line, end_line, &block)
   end
 
   # Defines a pending test case.
@@ -51,7 +51,7 @@ module Spec::Methods
   #
   # It is usually used inside a `#describe` or `#context` section.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    Spec::RootContext.pending(description.to_s, file, line, end_line, &block)
+    Spec.root_context.pending(description.to_s, file, line, end_line, &block)
   end
 
   # Defines a yet-to-be-implemented pending test case


### PR DESCRIPTION
This PR includes a series of refactors to `Spec` in order to be able to support `focus`. Then it adds supports for it.

From one of the commits description:

> Before this commit an `it` block ran immediately. This makes it hard to implement other filtering mechanisms. In particular to implement something like RSpec's `focus` we need to first know whether there's any example marked with `focus: true`. Without collecting all examples first we can't do this.

## focus: true

Now you can mark `describe`, `context` and `it` with `focus: true`.

When you do that, only the things that are marked with `focus: true` will run. This is really useful to, well, focus on one or several specs. One can usually pass a line number, but in my experience it sometimes happens that you add stuff at the top of the spec file and the the line numbers shift. Adjusting the numbers is a bit tedious.

When any spec is marked with `focus: true` a new message appears at the end of the spec run:
> Only running `focus: true`

(in cyan)

This is because you might forget that you left a `focus: true` and don't understand why only just a couple of specs run.

## Better line matching

Now an entire `describe`/`context` will run if you specify a line that the `describe` contains but no inner `describe`/`it` matches. This is similar to RSpec. And this was impossible to do without collecting things.

An example:

```crystal
require "spec"

describe "foo" do
  describe "bar" do
    it "one" do
    end
# <-------- if you mark this line, the entire "bar" will run
    it "two" do
    end
  end

  describe "baz"
  end
end
```

Previously nothing ran.

## tags

I didn't implement it yet. But with this in place #8068 should become much, much simpler to do.

## Breaking change?

This is a breaking change because if you do something like:

```crystal
foo = 1
it "..."  do
  foo.should eq(1)
end

foo = 2
it "..."  do
  foo.should eq(2)
end
```

then it will fail because each `it` runs at the end of the program and `foo`'s value will have changed.

However, I think this isn't that bad:
- we only had two occurrences of this in the standard library so it's probably not common
- it's easy to fix
- RSpec works exactly like that too

Another thing: `pending` block will now be compiled but not ran. Apparently this wasn't the case before. In one spec we passed `raw_url` to URI but I have no idea what that is, so I removed it.