### PR TITLE
YAML: emit unicode characters as such

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -289,6 +289,10 @@ describe "YAML serialization" do
       String.from_yaml("hel\\lo".to_yaml).should eq("hel\\lo")
     end
 
+    it "does for String with unicode characters (#8131)" do
+      "你好".to_yaml.should contain("你好")
+    end
+
     it "quotes string if reserved" do
       ["1", "1.2", "true", "2010-11-12"].each do |string|
         string.to_yaml.should eq(%(--- "#{string}"\n))

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -39,6 +39,7 @@ class YAML::Builder
     @closed = false
     @nesting = 0
     LibYAML.yaml_emitter_initialize(@emitter)
+    LibYAML.yaml_emitter_set_unicode(@emitter, 1)
     LibYAML.yaml_emitter_set_output(@emitter, ->(data, buffer, size) {
       data_io = Box(IO).unbox(data)
       data_io.write(Slice.new(buffer, size))

--- a/src/yaml/lib_yaml.cr
+++ b/src/yaml/lib_yaml.cr
@@ -143,6 +143,7 @@ lib LibYAML
   fun yaml_emitter_emit(emitter : Emitter*, event : Event*) : Int
   fun yaml_emitter_delete(emitter : Emitter*)
   fun yaml_emitter_flush(emitter : Emitter*) : Int
+  fun yaml_emitter_set_unicode(emitter : Emitter*, unicode : Int)
 
   fun yaml_get_version(major : LibC::Int*, minor : LibC::Int*, patch : LibC::Int*)
 end


### PR DESCRIPTION
Fixes #8131

Eventually we can make this configurable. I checked with [Ruby's Psych](https://github.com/ruby/psych/blob/e01839af57df559b26f74e906062be6c692c89c8/ext/psych/psych_emitter.c#L64) and it's not configurable. Additionally, I never though about YAML not doing this by default and I don't know in which case I'd like to turn this off. But if we want to do that, let's do it as a separate issue/PR. 