### PR TITLE
Add method to get an array of types a module is directly included in

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1155,6 +1155,63 @@ module Crystal
     end
 
     describe "type methods" do
+      describe "#all_includers" do
+        it "returns an array of types `self` is included in" do
+          assert_type(%(
+            module Foo
+            end
+
+            module Baz
+              module Tar
+                include Baz
+              end
+            end
+
+            abstract class Parent
+            end
+
+            module Enumt(T)
+              include Baz
+            end
+
+            class Bar < Parent
+              include Foo
+              include Baz
+            end
+
+            struct Str
+              include Enumt(String)
+              include Baz
+            end
+
+            struct Gen(T)
+              include Baz
+            end
+
+            abstract struct AStr
+              include Baz
+            end
+
+            abstract class ACla
+              include Baz
+            end
+
+            class SubT(T)
+              include Baz
+            end
+
+            class ChildT(T) < SubT(T)
+            end
+
+          {% if Baz.all_includers.map(&.stringify) == ["Baz::Tar", "Enumt(T)", "Bar", "Str", "Gen(T)", "AStr", "ACla", "SubT(T)"] && Enumt.all_includers.map(&.stringify) == ["Str"]  %}
+            1
+          {% else %}
+            'a'
+          {% end %}
+        )) { int32 }
+        end
+      end
+
       it "executes name" do
         assert_macro("x", "{{x.name}}", "String") do |program|
           [TypeNode.new(program.string)] of ASTNode

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1155,7 +1155,7 @@ module Crystal
     end
 
     describe TypeNode do
-      describe "#all_includers" do
+      describe "#includers" do
         it "returns an array of types `self` is included in" do
           assert_type(%(
             module Foo
@@ -1203,7 +1203,7 @@ module Crystal
             class ChildT(T) < SubT(T)
             end
 
-          {% if Baz.all_includers.map(&.stringify) == ["Baz::Tar", "Enumt(T)", "Bar", "Str", "Gen(T)", "AStr", "ACla", "SubT(T)"] && Enumt.all_includers.map(&.stringify) == ["Str"]  %}
+          {% if Baz.includers.map(&.stringify) == ["Baz::Tar", "Enumt(T)", "Bar", "Str", "Gen(T)", "AStr", "ACla", "SubT(T)"] && Enumt.includers.map(&.stringify) == ["Str"]  %}
             1
           {% else %}
             'a'

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1154,7 +1154,7 @@ module Crystal
       assert_macro "", %({% a = 1 %}{{a}}), [] of ASTNode, "1"
     end
 
-    describe "type methods" do
+    describe TypeNode do
       describe "#all_includers" do
         it "returns an array of types `self` is included in" do
           assert_type(%(

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1758,6 +1758,10 @@ module Crystal::Macros
     def all_subclasses : ArrayLiteral(TypeNode)
     end
 
+    # Returns all the types `self` is included in.
+    def all_includers : ArrayLiteral(TypeNode)
+    end
+
     # Returns the constants and types defined by this type.
     def constants : ArrayLiteral(MacroId)
     end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1754,12 +1754,12 @@ module Crystal::Macros
     def subclasses : ArrayLiteral(TypeNode)
     end
 
-    # Returns all subclasses of this type.
-    def all_subclasses : ArrayLiteral(TypeNode)
+    # Returns all the types `self` is directly included in.
+    def includers : ArrayLiteral(TypeNode)
     end
 
-    # Returns all the types `self` is included in.
-    def all_includers : ArrayLiteral(TypeNode)
+    # Returns all subclasses of this type.
+    def all_subclasses : ArrayLiteral(TypeNode)
     end
 
     # Returns the constants and types defined by this type.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1534,6 +1534,8 @@ module Crystal
         interpret_argless_method(method, args) { TypeNode.subclasses(type) }
       when "all_subclasses"
         interpret_argless_method(method, args) { TypeNode.all_subclasses(type) }
+      when "all_includers"
+        interpret_argless_method(method, args) { TypeNode.including_types type }
       when "constants"
         interpret_argless_method(method, args) { TypeNode.constants(type) }
       when "constant"
@@ -1562,8 +1564,6 @@ module Crystal
         fetch_annotation(self, method, args) do |type|
           self.type.annotation(type)
         end
-      when "included"
-        interpret_argless_method(method, args) { TypeNode.including_types type }
       when "annotations"
         fetch_annotation(self, method, args) do |type|
           annotations = self.type.annotations(type)
@@ -1669,14 +1669,15 @@ module Crystal
     end
 
     def self.including_types(type)
-      if type.is_a? NonGenericModuleType
+      case type
+      when NonGenericModuleType, GenericModuleType
         return empty_no_return_array unless types = type.raw_including_types
         return ArrayLiteral.map(types) do |including_type|
           TypeNode.new including_type
         end
+      else
+        empty_no_return_array
       end
-
-      empty_no_return_array
     end
 
     def self.type_vars(type)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1562,6 +1562,8 @@ module Crystal
         fetch_annotation(self, method, args) do |type|
           self.type.annotation(type)
         end
+      when "included"
+        interpret_argless_method(method, args) { TypeNode.including_types type }
       when "annotations"
         fetch_annotation(self, method, args) do |type|
           annotations = self.type.annotations(type)
@@ -1664,6 +1666,17 @@ module Crystal
       else
         super
       end
+    end
+
+    def self.including_types(type)
+      if type.is_a? NonGenericModuleType
+        return empty_no_return_array unless types = type.raw_including_types
+        return ArrayLiteral.map(types) do |including_type|
+          TypeNode.new including_type
+        end
+      end
+
+      empty_no_return_array
     end
 
     def self.type_vars(type)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1535,7 +1535,7 @@ module Crystal
       when "all_subclasses"
         interpret_argless_method(method, args) { TypeNode.all_subclasses(type) }
       when "all_includers"
-        interpret_argless_method(method, args) { TypeNode.all_includers type }
+        interpret_argless_method(method, args) { TypeNode.all_includers(type) }
       when "constants"
         interpret_argless_method(method, args) { TypeNode.constants(type) }
       when "constant"

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1535,7 +1535,7 @@ module Crystal
       when "all_subclasses"
         interpret_argless_method(method, args) { TypeNode.all_subclasses(type) }
       when "all_includers"
-        interpret_argless_method(method, args) { TypeNode.including_types type }
+        interpret_argless_method(method, args) { TypeNode.all_includers type }
       when "constants"
         interpret_argless_method(method, args) { TypeNode.constants(type) }
       when "constant"
@@ -1668,7 +1668,7 @@ module Crystal
       end
     end
 
-    def self.including_types(type)
+    def self.all_includers(type)
       case type
       when NonGenericModuleType, GenericModuleType
         return empty_no_return_array unless types = type.raw_including_types

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1671,8 +1671,9 @@ module Crystal
     def self.all_includers(type)
       case type
       when NonGenericModuleType, GenericModuleType
-        return empty_no_return_array unless types = type.raw_including_types
-        return ArrayLiteral.map(types) do |including_type|
+        types = type.raw_including_types
+        return empty_no_return_array unless types
+        ArrayLiteral.map(types) do |including_type|
           TypeNode.new including_type
         end
       else

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1534,8 +1534,8 @@ module Crystal
         interpret_argless_method(method, args) { TypeNode.subclasses(type) }
       when "all_subclasses"
         interpret_argless_method(method, args) { TypeNode.all_subclasses(type) }
-      when "all_includers"
-        interpret_argless_method(method, args) { TypeNode.all_includers(type) }
+      when "includers"
+        interpret_argless_method(method, args) { TypeNode.includers(type) }
       when "constants"
         interpret_argless_method(method, args) { TypeNode.constants(type) }
       when "constant"
@@ -1668,7 +1668,7 @@ module Crystal
       end
     end
 
-    def self.all_includers(type)
+    def self.includers(type)
       case type
       when NonGenericModuleType, GenericModuleType
         types = type.raw_including_types


### PR DESCRIPTION
```cr
module Foo
end

module Baz
  module Tar
    include Baz
  end
end

abstract class Parent
end

class Bar < Parent
  include Foo
  include Baz
end

struct Str
  include Baz
end

struct Gen(T)
  include Baz
end

abstract struct AStr
  include Baz
end

abstract class ACla
  include Baz
end

class SubT(T)
  include Baz
end

class ChildT(T) < SubT(T)
end

{{Baz.all_includers.map &.name.stringify}} # => ["Baz::Tar", "Bar", "Str", "Gen(T)", "AStr", "ACla", "SubT(T)"]
```

Questions:
* ~How do I test this?~
* ~Are there any other types that can include a module i should try?~
* ~Any other ideas for a better name?~

I also noticed that types with generics include the generic type vars in their name.  I would have thought `Gen(T)` would have just been `Gen`...not sure if this is intended or not.

EDIT:  I added it to `macros.cr`, will include that in feedback fixes.