### PR TITLE
take type id into account when calling offsetof on reference types

### DIFF
--- a/spec/compiler/codegen/offsetof_spec.cr
+++ b/spec/compiler/codegen/offsetof_spec.cr
@@ -1,0 +1,35 @@
+require "../../spec_helper"
+
+describe "Code gen: offsetof" do
+  it "returns offset allowing manual access of first struct field" do
+    code = "struct Foo; @x = 42; def x; @x; end; end;
+            f = Foo.new
+            (pointerof(f).as(Void*) + offsetof(Foo, @x).to_i64()).as(Int32*).value == f.x"
+
+    run(code).to_b.should be_true
+  end
+
+  it "returns offset allowing manual access of struct field that isn't first" do
+    code = "struct Foo; @x = 1; @y = 42; def x; @x; end; def y; @y; end; end;
+            f = Foo.new
+            (pointerof(f).as(Void*) + offsetof(Foo, @y).to_i64()).as(Int32*).value == f.y"
+
+    run(code).to_b.should be_true
+  end
+
+  it "returns offset allowing manual access of first class field" do
+    code = "class Bar; @x = 42; def x; @x; end; end;
+            b = Bar.new
+            (b.as(Void*) + offsetof(Bar, @x).to_i64()).as(Int32*).value == b.x"
+
+    run(code).to_b.should be_true
+  end
+
+  it "returns offset allowing manual access of class field that isn't first" do
+    code = "class Bar; @x = 1; @y = 42; def x; @x; end; def y; @y; end; end;
+            b = Bar.new
+            (b.as(Void*) + offsetof(Bar, @y).to_i64()).as(Int32*).value == b.y"
+
+    run(code).to_b.should be_true
+  end
+end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -97,7 +97,7 @@ module Crystal
     end
 
     def instance_offset_of(type, element_index)
-      llvm_typer.offset_of(llvm_typer.llvm_struct_type(type), element_index)
+      llvm_typer.offset_of(llvm_typer.llvm_struct_type(type), element_index + 1)
     end
   end
 


### PR DESCRIPTION
Previously all offsets of reference types were off by 4 bytes.
This changes the offsetof implementation for reference types to
add an additional 4 bytes and adds tests that ensure using the
offset on classes and structs result in access to the intended
variable.

see https://github.com/crystal-lang/crystal/issues/7967 for context

*Note this is my first time contributing and I'm not super familiar with the entirety of the codebase. If something should done in a different way, please let me know. This is also my first time working with an LLVM project. I wasn't sure if the type_id is the crystal one which seems to be of type Int32, or something internal to LLVM like this (https://llvm.org/doxygen/classllvm_1_1Metadata.html#a91c7b9c7cf6694f41b9030429b582d26) which is an unsigned int.