### PR TITLE
Delay releasing of fiber stack in multithread mode

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -82,7 +82,11 @@ class Fiber
     ex.inspect_with_backtrace(STDERR)
     STDERR.flush
   ensure
-    Fiber.stack_pool.release(@stack)
+    {% if flag?(:preview_mt) %}
+      Crystal::Scheduler.enqueue_free_stack @stack
+    {% else %}
+      Fiber.stack_pool.release(@stack)
+    {% end %}
 
     # Remove the current fiber from the linked list
     Fiber.fibers.delete(self)


### PR DESCRIPTION
This PR fixes an issue found by @asterite in multithread mode (`-Dpreview_mt`)
For example, this code currently fails with really random and nasty errors:

```crystal
1000000.times { spawn { } }
sleep 0.1
```

This is because the fiber stacks are reused but in multithread mode this reuse can happen before the current fiber actually finishes using it.

I didn't add a spec because I don't know how to consistently reproduce it with an example that doesn't involve 1M fibers :)