### PR TITLE
Zip::Writer: fix written bytes for STORED compression method

### DIFF
--- a/src/zip/writer.cr
+++ b/src/zip/writer.cr
@@ -112,7 +112,11 @@ class Zip::Writer
       raise "Unsupported compression method: #{entry.compression_method}"
     end
 
-    @written += @compressed_size_counter.count
+    if entry.compression_method.stored?
+      @written += @uncompressed_size_counter.count
+    else
+      @written += @compressed_size_counter.count
+    end
 
     crc32 = @uncompressed_size_counter.crc32.to_u32
     uncompressed_size = @uncompressed_size_counter.count


### PR DESCRIPTION
See https://forum.crystal-lang.org/t/writing-a-file-to-zip-as-stored-not-deflate/1088