### PR TITLE
Remove unsafe Time contructor

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -268,7 +268,7 @@ struct Time
   # ```
   # Time.utc - Time::UNIX_EPOCH
   # ```
-  UNIX_EPOCH = new(unsafe_utc_seconds: 62135596800)
+  UNIX_EPOCH = new(seconds: 62135596800, nanoseconds: 0, location: Location::UTC)
 
   # :nodoc:
   MAX_SECONDS = 315537897599_i64
@@ -485,13 +485,6 @@ struct Time
     unless 0 <= @nanoseconds < NANOSECONDS_PER_SECOND
       raise ArgumentError.new "Invalid time: nanoseconds out of range"
     end
-  end
-
-  # :nodoc:
-  protected def initialize(*, unsafe_utc_seconds : Int64)
-    @seconds = unsafe_utc_seconds
-    @nanoseconds = 0
-    @location = Location::UTC
   end
 
   # Creates a new `Time` instance that corresponds to the number of *seconds*


### PR DESCRIPTION
#8112 added a new unsafe `Time` constructor to avoid a circular dependency on `UNIX_EPOCH` (see https://github.com/crystal-lang/crystal/pull/8112/commits/975c08f11041142164e2f77ef3309cb1844a0fe5). But this is unncessary because there is already a constructor that does not rely on `UNIX_EPOCH`, we can just use that one for the constant value.

/cc @waj 