### PR TITLE
Let exec_recursive use a thread-local data structure

### DIFF
--- a/src/reference.cr
+++ b/src/reference.cr
@@ -135,8 +135,20 @@ class Reference
 
   # :nodoc:
   module ExecRecursive
+    alias Registry = Hash({UInt64, Symbol}, Bool)
+
+    {% if flag?(:preview_mt) %}
+      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
+    {% else %}
+      @@exec_recursive = Registry.new
+    {% end %}
+
     def self.hash
-      @@exec_recursive ||= {} of {UInt64, Symbol} => Bool
+      {% if flag?(:preview_mt) %}
+        @@exec_recursive.get { Registry.new }
+      {% else %}
+        @@exec_recursive
+      {% end %}
     end
   end
 


### PR DESCRIPTION
ExecRecursive.hash might be used by different threads at the same time so we have to make sure its accessed is bound to the current thread.

Addresses https://github.com/crystal-lang/crystal/issues/8140#issuecomment-527260754