### PR TITLE
[WIP] Synchronize logger severities with RFC 5424.

### DIFF
--- a/src/logger.cr
+++ b/src/logger.cr
@@ -90,11 +90,23 @@ class Logger
     # Generic (useful) information about system operation
     INFO
 
+    # Normal but significant conditions
+    NOTICE
+
     # A warning
     WARN
 
     # A handleable error condition
     ERROR
+
+    # Critical conditions
+    CRITICAL
+
+    # Action must be taken immediately
+    ALERT
+
+    # System is unusable
+    EMERGENCY
 
     # An unhandleable error that results in a program crash
     FATAL


### PR DESCRIPTION
Also attempt to provide compatibility with other logger implementations by @Blacksmoke16 and @watzon.

### Problem scope

Logger severities aren't portable between different crystal loggers.  This tends to lock applications in to a particular logger or reduce the number of message types they can log.


### Severities differences

EMERG in [crylog](https://github.com/Blacksmoke16/crylog/blob/ee97471bb247a1b415d38ec24c0e4eb771ff40cd/src/logger.cr#L35) and [strange](https://github.com/hydecr/strange/blob/92a1397575e33b60ab899c12d83f2866af1a3352/src/strange/formatter/color_formatter.cr#L34).
EMERG missing in crystal.

WARNING in crylog and strange.
WARN in crystal.

CRITICAL missing in crystal.
ALERT missing in crystal.
NOTICE missing in crystal.

FATAL in crystal isn't described in the RFC.  If kept where does it fit?  Higher or lower than EMERGENCY?

UNKNOWN in crystal.  What purpose does it serve?

### Numerical order

Sometimes in filters (like color) it's useful to check severity > INFO.  The RFC numbers seem backwards when used for this purpose.  Numerical syslog compatility may not be necessary since it's not popular in any serialized format and they aren't used except when making `syslog()` calls.  An output class can easily map `severity name -> syslog  name` when there is a 1 <-> mapping.

### Customized logging levels with sane defaults?

Should there be a way to customize logging levels for compatility with other applications/libraries?


### Personal preferences

When I started writing this I only cared about the portability issues from a programmers perspective.  Writing `.emerg` or `.emergency` is not worth fighting over.  Thinking about it more reminded me of hours and hours of combing through log files and always significantly slowed by shifts in name length.

Example output:
```
[2019-09-03T20:28:00.032959000Z] DEBUG: foo bar baz
[2019-09-03T20:28:00.034013000Z] CRITICAL: baz foo
[2019-09-03T20:28:00.034019000Z] ALERT: baz
[2019-09-03T20:28:00.034024000Z] ERROR: baz foo
[2019-09-03T20:28:00.034029000Z] CRITICAL: baz foo bar
[2019-09-03T20:28:00.034034000Z] INFO: baz
[2019-09-03T20:28:00.034039000Z] EMERGENCY: foo bar baz
[2019-09-03T20:28:00.034044000Z] NOTICE: bar baz
```

EMERGENCY is particularly jarring when attempting to read multiple log messages that are related to each other.  Wanting EMERGENCY to stick out more seems natural at first, except people don't read logs start to end.  They search them.  Many tools or loggers color the output highlighting important messages like EMERG and CRIT.

Shorter names such as EMERG and CRIT throw off formatting less and allow more data per line when reading logs.


### Single character spacing.

One extreme option is using a single character to represent levels with uniform spacing.

EMERGENCY and DEBUG in perfect harmony with uniform spacing.
```
[2019-09-03T20:28:00.034959000Z] N: foo bar baz
[2019-09-03T20:28:00.034013000Z] E: baz foo
[2019-09-03T20:28:00.034019000Z] E: baz
[2019-09-03T20:28:00.034024000Z] D: baz foo
[2019-09-03T20:28:00.034029000Z] W: baz foo bar
[2019-09-03T20:28:00.034034000Z] E: baz
[2019-09-03T20:28:00.034039000Z] E: foo bar baz
[2019-09-03T20:28:00.034044000Z] D: bar baz
```

### Next steps

1. Civilized discussion
2. Bike shedding
3. Battle Royal

