### PR TITLE
Compiler: devirtualize `@type` inside macros

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1823,4 +1823,19 @@ describe "Code gen: macro" do
       end
     )).to_string.chomp.should eq("2")
   end
+
+  it "devirtualizes @type" do
+    run(%(
+      class Foo
+        def foo
+          {{@type.id.stringify}}
+        end
+      end
+
+      class Bar < Foo
+      end
+
+      (Foo.new || Bar.new).foo
+    )).to_string.should eq("Foo")
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -533,7 +533,7 @@ module Crystal
       case node.name
       when "@type"
         target = @scope == @program.class_type ? @scope : @scope.instance_type
-        return @last = TypeNode.new(target)
+        return @last = TypeNode.new(target.devirtualize)
       when "@def"
         return @last = @def || NilLiteral.new
       end


### PR DESCRIPTION
Fixes an issue discussed [in the forums](https://forum.crystal-lang.org/t/detecting-class-types/1090)