### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 7d45d71fc8085b9ffc512b18538055a0dcb85851
+          git checkout 4f026790ccff94e250ce8580b736815411eb09a4
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
Includes https://github.com/crystal-lang/distribution-scripts/pull/44

linux binaries will ship with llvm-8 and it will allow unblocking the linux nightlies as described in https://github.com/crystal-lang/distribution-scripts/pull/43
