### PR TITLE
Allowing JSON.mapping & YAML.mapping converter attribute to be applied to Array and Hashes.

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -133,7 +133,7 @@ private class JSONWithRaw
   })
 end
 
-private class JSONWithJSONArrayConverter
+private class JSONWithArrayConverter
   JSON.mapping({
     values: {type: Array(Time), converter: JSON::ArrayConverter(Time::EpochConverter)},
   })
@@ -141,7 +141,7 @@ end
 
 private class JSONWithJSONHashValueConverter
   JSON.mapping({
-    birthdays: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)}
+    birthdays: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)},
   })
 end
 
@@ -469,13 +469,13 @@ describe "JSON mapping" do
 
   it "uses JSON::ArrayConverter" do
     string = %({"values":[1459859781,1567628762]})
-    json = JSONWithJSONArrayConverter.from_json(string)
+    json = JSONWithArrayConverter.from_json(string)
     json.values.should be_a(Array(Time))
     json.values.should eq([Time.unix(1459859781), Time.unix(1567628762)])
     json.to_json.should eq(string)
   end
 
-  it "uses JSON::HashConverter" do
+  it "uses JSON::HashValueConverter" do
     string = %({"birthdays":{"foo":1459859781,"bar":1567628762}})
     json = JSONWithJSONHashValueConverter.from_json(string)
     json.birthdays.should be_a(Hash(String, Time))

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -139,6 +139,12 @@ private class JSONWithJSONArrayConverter
   })
 end
 
+private class JSONWithJSONHashValueConverter
+  JSON.mapping({
+    birthdays: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)}
+  })
+end
+
 private class JSONWithRoot
   JSON.mapping({
     result: {type: Array(JSONPerson), root: "heroes"},
@@ -466,6 +472,14 @@ describe "JSON mapping" do
     json = JSONWithJSONArrayConverter.from_json(string)
     json.values.should be_a(Array(Time))
     json.values.should eq([Time.unix(1459859781), Time.unix(1567628762)])
+    json.to_json.should eq(string)
+  end
+
+  it "uses JSON::HashConverter" do
+    string = %({"birthdays":{"foo":1459859781,"bar":1567628762}})
+    json = JSONWithJSONHashValueConverter.from_json(string)
+    json.birthdays.should be_a(Hash(String, Time))
+    json.birthdays.should eq({"foo" => Time.unix(1459859781), "bar" => Time.unix(1567628762)})
     json.to_json.should eq(string)
   end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -336,11 +336,9 @@ describe "JSON mapping" do
   end
 
   it "outputs JSON with properties key" do
-    input = {
-      properties: {"foo" => "bar"},
-    }.to_json
-    json = JSONWithPropertiesKey.from_json(input)
-    json.to_json.should eq(input)
+    string = %({"properties":{"foo":"bar"}})
+    json = JSONWithPropertiesKey.from_json(string)
+    json.to_json.should eq(string)
   end
 
   it "parses json with keywords" do

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -133,6 +133,12 @@ private class JSONWithRaw
   })
 end
 
+private class JSONWithJSONArrayConverter
+  JSON.mapping({
+    values: {type: Array(Time), converter: JSON::ArrayConverter(Time::EpochConverter)},
+  })
+end
+
 private class JSONWithRoot
   JSON.mapping({
     result: {type: Array(JSONPerson), root: "heroes"},
@@ -454,6 +460,14 @@ describe "JSON mapping" do
     json = JSONWithTimeEpochMillis.from_json(string)
     json.value.should be_a(Time)
     json.value.should eq(Time.unix_ms(1459860483856))
+    json.to_json.should eq(string)
+  end
+
+  it "uses JSON::ArrayConverter" do
+    string = %({"values":[1459859781,1567628762]})
+    json = JSONWithJSONArrayConverter.from_json(string)
+    json.values.should be_a(Array(Time))
+    json.values.should eq([Time.unix(1459859781), Time.unix(1567628762)])
     json.to_json.should eq(string)
   end
 

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -96,6 +96,12 @@ private class YAMLWithTimeEpochMillis
   })
 end
 
+private class YAMLWithArrayConverter
+  YAML.mapping({
+    values: {type: Array(Time), converter: YAML::ArrayConverter(Time::EpochConverter)},
+  })
+end
+
 private class YAMLWithPresence
   YAML.mapping({
     first_name: {type: String?, presence: true, nilable: true},
@@ -485,6 +491,14 @@ describe "YAML mapping" do
     yaml.value.should be_a(Time)
     yaml.value.should eq(Time.unix_ms(1459860483856))
     yaml.to_yaml.should eq("---\nvalue: 1459860483856\n")
+  end
+
+  it "uses YAML::ArrayConverter" do
+    string = %({"values":[1459859781,1567628762]})
+    yaml = YAMLWithArrayConverter.from_yaml(string)
+    yaml.values.should be_a(Array(Time))
+    yaml.values.should eq([Time.unix(1459859781), Time.unix(1567628762)])
+    yaml.to_yaml.should eq(%(---\nvalues:\n- 1459859781\n- 1567628762\n))
   end
 
   describe "parses YAML with presence markers" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -293,6 +293,20 @@ module JSON::ArrayConverter(Converter)
   end
 end
 
+module JSON::HashValueConverter(Converter)
+  def self.from_json(pull : JSON::PullParser)
+    hash = Hash(String, typeof(Converter.from_json(pull))).new
+    pull.read_object do |key, key_location|
+      parsed_key = String.from_json_object_key?(key)
+      unless parsed_key
+        raise JSON::ParseException.new("Can't convert #{key.inspect} into String", *key_location)
+      end
+      hash[parsed_key] = Converter.from_json(pull)
+    end
+    hash
+  end
+end
+
 module Time::EpochConverter
   def self.from_json(value : JSON::PullParser) : Time
     Time.unix(value.read_int)

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -283,6 +283,16 @@ struct Time::Format
   end
 end
 
+module JSON::ArrayConverter(Converter)
+  def self.from_json(pull : JSON::PullParser)
+    ary = Array(typeof(Converter.from_json(pull))).new
+    pull.read_array do
+      ary << Converter.from_json(pull)
+    end
+    ary
+  end
+end
+
 module Time::EpochConverter
   def self.from_json(value : JSON::PullParser) : Time
     Time.unix(value.read_int)

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -161,6 +161,33 @@ struct Time
   end
 end
 
+# Converter to be used with `JSON.mapping`
+# to serialize an `Array(T)` instance with a custom converter
+# since the unix epoch. See `Time#to_unix`.
+#
+# ```
+# require "json"
+#
+# class Timestamp
+#   JSON.mapping({
+#     values: {type: Array(Time), converter: JSON::ArrayConverter(Time::EpochConverter)},
+#   })
+# end
+#
+# timestamp = Timestamp.from_json(%({"dates":[1459859781,1567628762]}))
+# timestamp.values  # => [2016-04-05 12:36:21 UTC, 2019-09-04 20:26:02 UTC]
+# timestamp.to_json # => %({"dates":[1459859781,1567628762]})
+# ```
+module JSON::ArrayConverter(Converter)
+  def self.to_json(values : Array, builder : JSON::Builder)
+    builder.array do
+      values.each do |value|
+        Converter.to_json(value, builder)
+      end
+    end
+  end
+end
+
 # Converter to be used with `JSON.mapping` and `YAML.mapping`
 # to serialize a `Time` instance as the number of seconds
 # since the unix epoch. See `Time#to_unix`.
@@ -232,3 +259,4 @@ module String::RawConverter
     json.raw(value)
   end
 end
+

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -162,8 +162,7 @@ struct Time
 end
 
 # Converter to be used with `JSON.mapping`
-# to serialize an `Array(T)` instance with a custom converter
-# since the unix epoch. See `Time#to_unix`.
+# to serialize the `Array(T)` elements with the custom converter.
 #
 # ```
 # require "json"
@@ -189,8 +188,7 @@ module JSON::ArrayConverter(Converter)
 end
 
 # Converter to be used with `JSON.mapping`
-# to serialize a `Time` instance as the number of seconds
-# from a `Hash(K, V)` values.
+# to serialize the `Hash(K, V)` values elements with the custom converter.
 #
 # ```
 # require "json"
@@ -203,7 +201,7 @@ end
 #
 # timestamp = Timestamp.from_json(%({"birthdays":{"foo":1459859781,"bar":1567628762}}))
 # timestamp.values  # => {"foo" => 2016-04-05 12:36:21 UTC, "bar" => 2019-09-04 20:26:02 UTC)}
-# timestamp.to_json # => ({"birthdays":{"foo":1459859781,"bar":1567628762}}))
+# timestamp.to_json # => {"birthdays":{"foo":1459859781,"bar":1567628762}}
 # ```
 module JSON::HashValueConverter(Converter)
   def self.to_json(values : Hash, builder : JSON::Builder)

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -188,6 +188,35 @@ module JSON::ArrayConverter(Converter)
   end
 end
 
+# Converter to be used with `JSON.mapping`
+# to serialize a `Time` instance as the number of seconds
+# from a `Hash(K, V)` values.
+#
+# ```
+# require "json"
+#
+# class Timestamp
+#   JSON.mapping({
+#     values: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)},
+#   })
+# end
+#
+# timestamp = Timestamp.from_json(%({"birthdays":{"foo":1459859781,"bar":1567628762}}))
+# timestamp.values  # => {"foo" => 2016-04-05 12:36:21 UTC, "bar" => 2019-09-04 20:26:02 UTC)}
+# timestamp.to_json # => ({"birthdays":{"foo":1459859781,"bar":1567628762}}))
+# ```
+module JSON::HashValueConverter(Converter)
+  def self.to_json(values : Hash, builder : JSON::Builder)
+    builder.object do
+      values.each do |key, value|
+        builder.field key.to_json_object_key do
+          Converter.to_json(value, builder)
+        end
+      end
+    end
+  end
+end
+
 # Converter to be used with `JSON.mapping` and `YAML.mapping`
 # to serialize a `Time` instance as the number of seconds
 # since the unix epoch. See `Time#to_unix`.
@@ -259,4 +288,3 @@ module String::RawConverter
     json.raw(value)
   end
 end
-

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -290,6 +290,22 @@ module Time::EpochMillisConverter
   end
 end
 
+module YAML::ArrayConverter(Converter)
+  def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Array
+    unless node.is_a?(YAML::Nodes::Sequence)
+      node.raise "Expected sequence, not #{node.class}"
+    end
+
+    ary = Array(typeof(Converter.from_yaml(ctx, node))).new
+
+    node.each do |value|
+      ary << Converter.from_yaml(ctx, value)
+    end
+
+    ary
+  end
+end
+
 struct Slice
   def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     {% if T != UInt8 %}


### PR DESCRIPTION
# What is this PR for?

This PR is for making `JSON.mapping` & `YAML.mapping` support a converter to be applied to an Array or a Hash. 

👉 Closes https://github.com/crystal-lang/crystal/issues/7981