### PR TITLE
Compiler: virtualize Proc types before instantiation

### DIFF
--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -958,4 +958,31 @@ describe "Semantic: proc" do
 
     ex.to_s.should contain "'bar' exists as a macro, but macros can't be used in proc pointers"
   end
+
+  it "virtualizes proc type (#6789)" do
+    assert_type(%(
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      class Capture(T)
+        def initialize(@block : Foo -> T)
+        end
+
+        def block
+          @block
+        end
+      end
+
+      def capture(&block : Foo -> T) forall T
+        Capture.new(block)
+      end
+
+      capture do |foo|
+        Foo.new
+      end.block
+      )) { proc_of(types["Foo"].virtual_type!, types["Foo"].virtual_type!) }
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -415,8 +415,8 @@ module Crystal
       return unless self.def.args.all? &.type?
       return unless self.def.type?
 
-      types = self.def.args.map &.type
-      return_type = @force_nil ? self.def.type.program.nil : self.def.type
+      types = self.def.args.map &.type.virtual_type
+      return_type = @force_nil ? self.def.type.program.nil : self.def.type.virtual_type
 
       expected_return_type = @expected_return_type
       if expected_return_type && !expected_return_type.nil_type? && !return_type.implements?(expected_return_type)


### PR DESCRIPTION
Fixes #6789

We must always use virtual types as generic arguments in types. It's a bit annoying that we have to remember to do so before calling `instantiate` or `proc_of`. The alternative would be to do that inside `instantiate` but for that we would need to create a separate array to hold the types and it would be a bit slower. This fixes the issue but eventually it would be nice to refactor it in that way if performance isn't impacted.