### PR TITLE
Refactor Array with Crystal::Buffer

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -460,11 +460,11 @@ describe "Array" do
     it "concats enumerable to empty array (#2047)" do
       a = [] of Int32
       a.concat(1..1)
-      a.@capacity.should eq(3)
+      a.@buffer.capacity.should eq(3)
 
       a = [] of Int32
       a.concat(1..4)
-      a.@capacity.should eq(6)
+      a.@buffer.capacity.should eq(6)
     end
 
     it "concats a union of arrays" do

--- a/src/crystal/buffer.cr
+++ b/src/crystal/buffer.cr
@@ -1,0 +1,48 @@
+# :nodoc:
+class Crystal::Buffer(T)
+  getter capacity : Int32
+
+  protected def initialize(@capacity)
+  end
+
+  def self.allocation_size(capacity)
+    raise ArgumentError.new("Negative capacity: #{capacity}") if capacity < 0
+    sizeof(Buffer(T)).to_u32 + capacity.to_u32 * sizeof(T)
+  end
+
+  def self.new(capacity : Int)
+    buffer = GC.malloc(allocation_size(capacity)).as(Buffer(T))
+    set_crystal_type_id(buffer)
+    buffer.initialize(capacity.to_i32)
+    GC.add_finalizer(buffer) if buffer.responds_to?(:finalize)
+    buffer
+  end
+
+  # Returns a buffer that can hold at least *capacity* elements.
+  # May return self if capacity is enough.
+  def realloc(capacity)
+    buffer = Buffer(T).new(capacity)
+    self.data.copy_to(buffer.data, self.capacity) if self.capacity > 0
+    buffer
+  end
+
+  # Returns a buffer that can hold at least *required_capacity* elements.
+  # The actual capacity is guaranteed to be a power of 2.
+  # May return self if capacity is enough.
+  def ensure_capacity(required_capacity)
+    if required_capacity > @capacity
+      self.realloc(Math.pw2ceil(required_capacity))
+    else
+      self
+    end
+  end
+
+  def double_capacity
+    realloc(@capacity == 0 ? 3 : (@capacity * 2))
+  end
+
+  @[AlwaysInline]
+  def data : T*
+    Pointer(T).new(object_id + sizeof(Buffer(T)))
+  end
+end


### PR DESCRIPTION
I extracted some of the refactors to make Array thread-safe. I think they are worth in its own and can be used in other structures: `Deque(T)`, `String::Builder`, `IO::Memory` since they use pointer-based buffers like Array.

This is clash a bit with #8036 since it affects the internal representation of the Array.

I wanted to remove as much as possible the usage of `to_unsafe` method in Array implementation. Those were overused to get a pointer to the data of the buffer but should be framed for C interop when possible. This aspect is one of the conflicts with #8036.

The `Crystal::Buffer` is allocated with the capacity and then with the buffer in an inlined way. The buffer can't be resized inplace have convenient methods to move data, ensure capacity, use power of two sizes, etc. as used in other containers.

Some future benefits of using `Crystal::Buffer`:

* Remove duplication logic of containers `Deque(T)`, `String::Builder`, `IO::Memory` 
* Probably allow allocation of atomic buffers
* It encapsulates the direct usage of Pointer