### PR TITLE
Activate compiler warnings by default

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -138,7 +138,7 @@ describe HTTP::Server do
 
   it "handles Expect: 100-continue correctly when body isn't read" do
     server = HTTP::Server.new do |context|
-      context.response.respond_with_error("I don't want your body", 400)
+      context.response.respond_with_status(400, "I don't want your body")
     end
 
     address = server.bind_unused_port

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -379,7 +379,7 @@ describe "OptionParser" do
           opts.on("--f FLAG", "some flag") do |v|
             f = v
           end
-        end.parse!
+        end.parse
         f.should eq("hi")
       ensure
         ARGV.clear

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -530,7 +530,7 @@ class Crystal::Command
 
   private def setup_compiler_warning_options(opts, compiler)
     compiler.warnings_exclude << Crystal.normalize_path "lib"
-    opts.on("--warnings all|none", "Which warnings detect. (default: none)") do |w|
+    opts.on("--warnings all|none", "Which warnings detect. (default: all)") do |w|
       compiler.warnings = case w
                           when "all"
                             Crystal::Warnings::All

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -104,7 +104,7 @@ module Crystal
     property? wants_doc = false
 
     # Which kind of warnings wants to be detected.
-    property warnings : Warnings = Warnings::None
+    property warnings : Warnings = Warnings::All
 
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -119,7 +119,7 @@ module Crystal
     property codegen_target = Config.default_target
 
     # Which kind of warnings wants to be detected.
-    property warnings : Warnings = Warnings::None
+    property warnings : Warnings = Warnings::All
 
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -14,7 +14,7 @@
 # upcase = false
 # destination = "World"
 #
-# OptionParser.parse! do |parser|
+# OptionParser.parse do |parser|
 #   parser.banner = "Usage: salute [arguments]"
 #   parser.on("-u", "--upcase", "Upcases the salute") { upcase = true }
 #   parser.on("-t NAME", "--to=NAME", "Specifies the name to salute") { |name| destination = name }


### PR DESCRIPTION
Meanwhile... fix some deprecation warnings in the specs and docs.

Now that #8120 is merged, we can activate warnings since there should not be false positives.