### PR TITLE
Check for recursive initialization of class variables and constants

### DIFF
--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -577,4 +577,32 @@ describe "Codegen: class var" do
 
     mod.to_s.should_not contain("x:init")
   end
+
+  it "catch infinite loop in class var initializer" do
+    run(%(
+      require "prelude"
+
+      module Crystal
+        def self.main_user_code(argc : Int32, argv : UInt8**)
+          LibCrystalMain.__crystal_main(argc, argv)
+        rescue ex
+          print "error: \#{ex.message}"
+        end
+      end
+
+      class Foo
+        @@x : Int32 = init
+
+        def self.init
+          @@x + 1
+        end
+
+        def self.x
+          @@x
+        end
+      end
+
+      nil
+    )).to_string.should eq("error: Recursion while initializing class variables and/or constants")
+  end
 end


### PR DESCRIPTION
This PR was motivated by https://github.com/crystal-lang/crystal/issues/8157

It will check for recursive execution of `__crystal_once` and avoid that raising an exception. That exception will crash the program but it will allow better understanding about where the problem is.

I also did a refactor of `src/crystal/once.cr` and added some documentation about how it works.