### PR TITLE
Remove the event loop fiber

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -3,16 +3,6 @@ require "./event"
 class Thread
   # :nodoc:
   getter(event_base) { Crystal::Event::Base.new }
-
-  # :nodoc:
-  getter(loop_fiber) do
-    Fiber.new(name: "Event Loop") do
-      loop do
-        self.event_base.run_once
-        Crystal::Scheduler.reschedule
-      end
-    end
-  end
 end
 
 module Crystal::EventLoop
@@ -22,16 +12,12 @@ module Crystal::EventLoop
     end
   {% end %}
 
-  def self.resume
-    loop_fiber.resume
+  def self.run_once
+    Thread.current.event_base.run_once
   end
 
   private def self.event_base
     Thread.current.event_base
-  end
-
-  private def self.loop_fiber
-    Thread.current.loop_fiber
   end
 
   def self.create_resume_event(fiber)

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -136,12 +136,15 @@ class Crystal::Scheduler
   {% end %}
 
   protected def reschedule : Nil
-    if runnable = @lock.sync { @runnables.shift? }
-      unless runnable == Fiber.current
-        runnable.resume
+    loop do
+      if runnable = @lock.sync { @runnables.shift? }
+        unless runnable == Fiber.current
+          runnable.resume
+        end
+        break
+      else
+        Crystal::EventLoop.run_once
       end
-    else
-      Crystal::EventLoop.resume
     end
 
     {% if flag?(:preview_mt) %}


### PR DESCRIPTION
Since the commit https://github.com/crystal-lang/crystal/commit/284fb1e35abce2ecbebe41b3d6a78bf757145b9b there is actually no need to have a dedicated fiber to run the event loop. This is because now the event loop callbacks do not resume fibers directly and also it's not executing in endless non-returning mode.

With these changes the event loop is executed by any fiber that calls for a `reschedule` and there are no more fibers in the queue. This removes an extra context switch in those cases and provide a small but noticeable performance improvement for IO intensive apps.