### PR TITLE
Revert semantical evaluation of pending blocks

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -126,6 +126,12 @@ describe "Spec matchers" do
     ex.message.should eq "can't nest `it` or `pending`"
     ex.file.should eq __FILE__
   end
+
+  describe "pending block is not compiled" do
+    pending "pending has block with valid syntax, but invalid semantics" do
+      UndefinedConstant.undefined_method
+    end
+  end
 end
 
 describe "Spec" do

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -164,18 +164,18 @@ module Spec
     end
 
     def it(description, file, line, end_line, focus, &block)
-      add_example(description, file, line, end_line, focus, block, pending: false)
+      add_example(description, file, line, end_line, focus, block)
     end
 
-    def pending(description, file, line, end_line, focus, &block)
-      add_example(description, file, line, end_line, focus, block, pending: true)
+    def pending(description, file, line, end_line, focus)
+      add_example(description, file, line, end_line, focus, nil)
     end
 
-    private def add_example(description, file, line, end_line, focus, block, pending)
+    private def add_example(description, file, line, end_line, focus, block)
       check_nesting_spec(file, line) do
         Spec.focus = true if focus
         @@current_context.children <<
-          Example.new(@@current_context, description, file, line, end_line, focus, block, pending)
+          Example.new(@@current_context, description, file, line, end_line, focus, block)
       end
     end
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -4,20 +4,19 @@ module Spec
   class Example
     include Item
 
-    getter block : ->
-    getter? pending : Bool
+    getter block : (->) | Nil
 
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
                    @focus : Bool,
-                   @block : ->, @pending : Bool)
+                   @block : (->) | Nil)
     end
 
     def run
       Spec.root_context.check_nesting_spec(file, line) do
         Spec.formatters.each(&.before_example(description))
 
-        if pending?
+        unless block = @block
           Spec.root_context.report(:pending, description, file, line)
           return
         end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -59,14 +59,14 @@ module Spec::Methods
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, &block)
-    Spec.root_context.pending(description.to_s, file, line, end_line, focus, &block)
+    pending(description, file, line, end_line, focus)
   end
 
   # Defines a yet-to-be-implemented pending test case
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false)
-    pending(description, file, line, end_line, focus) { }
+    Spec.root_context.pending(description.to_s, file, line, end_line, focus)
   end
 
   # DEPRECATED: Use `#it`


### PR DESCRIPTION
Follow up to #8125 which reverts the change that the contents of `pending` blocks are evaluated in the compiler.

It's not necessary to compile pending blocks since they're not executed anyway. Avoiding this allows to define pending specs which uses code that is not currently working but supposed to be implemented/fixed at some point. It still needs to be valid Crystal, though obviously.

The alternative would be to comment out the code that does not compile. But I prefer leaving the spec explicitly written in code, and when the implementation is done, you simply need to replace `pending` with `it` and it will compile.

To only check if some piece of code compiles it can simply be wrapped in `typeof()`. This is applied in numerous places around the stdlib specs. You shouldn't use `pending` for this.

/cc https://github.com/crystal-lang/crystal/pull/8125#issuecomment-530708236
