### PR TITLE
Hash: fix initial indices size to avoid a resize

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1126,19 +1126,19 @@ describe "Hash" do
 
   it "creates with initial capacity" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234)
-    hash.@indices_size_pow2.should eq(11)
+    hash.@indices_size_pow2.should eq(12)
   end
 
   it "creates with initial capacity and default value" do
     hash = Hash(Int32, Int32).new(default_value: 3, initial_capacity: 1234)
     hash[1].should eq(3)
-    hash.@indices_size_pow2.should eq(11)
+    hash.@indices_size_pow2.should eq(12)
   end
 
   it "creates with initial capacity and block" do
     hash = Hash(Int32, Int32).new(initial_capacity: 1234) { |h, k| h[k] = 3 }
     hash[1].should eq(3)
-    hash.@indices_size_pow2.should eq(11)
+    hash.@indices_size_pow2.should eq(12)
   end
 
   it "rehashes" do

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -232,12 +232,15 @@ class Hash(K, V)
     else
       # Translate initial capacity to the nearest power of 2, but keep it a minimum of 8.
       if initial_capacity < 8
-        initial_indices_size = 8
+        initial_entries_size = 8
       else
-        initial_indices_size = Math.pw2ceil(initial_capacity)
+        initial_entries_size = Math.pw2ceil(initial_capacity)
       end
 
-      @entries = malloc_entries(initial_indices_size // 2)
+      # Because we always keep indice_size >= entries_size * 2
+      initial_indices_size = initial_entries_size * 2
+
+      @entries = malloc_entries(initial_entries_size)
 
       # Check if we can avoid allocating the `@indices` buffer for
       # small hashes.


### PR DESCRIPTION
Fixes #8181