### PR TITLE
[WIP] Add Reader, Writer for OpenSSL::Cipher

### DIFF
--- a/src/openssl/cipher/reader.cr
+++ b/src/openssl/cipher/reader.cr
@@ -1,0 +1,68 @@
+require "openssl"
+
+class OpenSSL::Cipher::Reader < IO
+  include IO::Buffered
+
+  # Whether to close the enclosed `IO` when closing this reader.
+  property? sync_close = false
+
+  # Returns `true` if this reader is closed.
+  getter? closed = false
+
+  def initialize(@io : IO, cipher : String, key, iv, @sync_close : Bool = false)
+    @cipher = OpenSSL::Cipher.new(cipher)
+    @cipher.key = key
+    @cipher.iv = iv
+    @cipher.decrypt
+  end
+
+  def initialize(@io : IO, @cipher, @sync_close : Bool = false)
+  end
+
+  # Creates a new reader from the given *io*, yields it to the given block,
+  # and closes it at the end.
+  def self.open(io : IO, cipher : String, key, iv, sync_close = false)
+    reader = new(io, cipher: cipher, key: key, iv: iv, sync_close: sync_close)
+    yield reader ensure reader.close
+  end
+
+  # See `IO#read`.
+  def unbuffered_read(slice : Bytes)
+    check_open
+
+    return 0 if slice.empty?
+
+    read_bytes = @io.read(slice)
+
+    data = @cipher.update(slice)
+    slice.move_from(data[0, read_bytes])
+
+    read_bytes
+  end
+
+  # Always raises `IO::Error` because this is a read-only `IO`.
+  def unbuffered_write(slice : Bytes)
+    raise IO::Error.new "Can't write to OpenSSL::Cipher::Reader"
+  end
+
+  def unbuffered_flush
+    raise IO::Error.new "Can't flush OpenSSL::Cipher::Reader"
+  end
+
+  def unbuffered_close
+    return if @closed
+    @closed = true
+
+    # @io.write(@cipher.final)
+    @io.close if @sync_close
+  end
+
+  def unbuffered_rewind
+    check_open
+
+    @io.rewind
+    @cipher.reset
+
+    initialize(@io, @cipher, @sync_close)
+  end
+end

--- a/src/openssl/cipher/writer.cr
+++ b/src/openssl/cipher/writer.cr
@@ -1,0 +1,65 @@
+require "openssl"
+
+class OpenSSL::Cipher::Writer < IO
+  # Whether to close the enclosed `IO` when closing this writer.
+  property? sync_close = false
+
+  # Returns `true` if this writer is closed.
+  getter? closed = false
+
+  def initialize(@io : IO, cipher : String, key, iv, @sync_close : Bool = false)
+    @cipher = OpenSSL::Cipher.new(cipher)
+    @cipher.encrypt
+    @cipher.key = key
+    @cipher.iv = iv
+  end
+
+  # Creates a new writer to the given *filename*.
+  def self.new(filename : String, cipher : String, key, iv)
+    new(::File.new(filename, "w"), cipher: cipher, key: key, iv: iv, sync_close: true)
+  end
+
+  # Creates a new writer to the given *io*, yields it to the given block,
+  # and closes it at the end.
+  def self.open(io : IO, cipher : String, key, iv, sync_close = false)
+    writer = new(io, cipher: cipher, key: key, iv: iv, sync_close: sync_close)
+    yield writer ensure writer.close
+  end
+
+  # Creates a new writer to the given *filename*, yields it to the given block,
+  # and closes it at the end.
+  def self.open(filename : String, cipher : String, key, iv)
+    writer = new(filename, cipher: cipher, key: key, iv: iv)
+    yield writer ensure writer.close
+  end
+
+  # Always raises `IO::Error` because this is a write-only `IO`.
+  def read(slice : Bytes)
+    raise IO::Error.new("Can't read from OpenSSL::Cipher::Writer")
+  end
+
+  # See `IO#write`.
+  def write(slice : Bytes)
+    check_open
+
+    return if slice.empty?
+
+    @io.write(@cipher.update(slice))
+  end
+
+  # See `IO#flush`.
+  def flush
+    check_open
+
+    @io.flush
+  end
+
+  def close
+    return if @closed
+    @closed = true
+
+    @io.write(@cipher.final)
+    @io.flush
+    @io.close if @sync_close
+  end
+end


### PR DESCRIPTION
This is an example implementation for adding `Cipher::Reader` and `Cipher::Writer`, similarly to `Zlib`/`Gzip` already in the standard library.

It makes code for encryption/decryption much cleaner IMO. The following, for example:

```crystal
# Assuming key, iv is already defined

cipher = OpenSSL::Cipher.new("aes-128-cbc")
cipher.encrypt
cipher.key = key
cipher.iv = iv

io = IO::Memory.new
io.write(cipher.update("Some plaintext"))
io.write(cipher.final)
```

becomes

```crystal
# Assuming key, iv is already defined

io = IO::Memory.new
OpenSSL::Cipher::Writer.open(io, "aes-128-cbc", key, iv) do |writer|
    writer << "Some plaintext"
end
```

Additionally it becomes possible to wrap IOs (a socket or file, for example) like so:

```crystal
file = File.open("my_secrets", mode: "w")
file = OpenSSL::Cipher::Writer.new(file, "aes-128-cbc", key, iv)
file << "Some plaintext"
file.close
```

I consider this an interesting proposal for discussion but in no way a finished PR.

Couple thoughts/issues currently:

It may make sense to implement this instead as a `CipherBase`, `CipherIO`, similar to `DigestBase`, `DigestIO`, etc.

Currently `Cipher::Reader` will write padding to the IO, which causes the added spec to fail. I'm unsure of the best way to go about fixing this.
