### PR TITLE
JSON and YAML: allow deserializing abstract types

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -342,7 +342,7 @@ class JSONChild2 < JSONBaseType
   property z : Int32
 end
 
-describe "JSON mapping" do
+describe JSON::Serializable do
   it "works with record" do
     JSONAttrPoint.new(1, 2).to_json.should eq "{\"x\":1,\"y\":2}"
     JSONAttrPoint.from_json(%({"x": 1, "y": 2})).should eq JSONAttrPoint.new(1, 2)

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -328,6 +328,20 @@ struct JSONAttrPersonWithYAMLInitializeHook
   end
 end
 
+abstract class JSONBaseType
+  include JSON::Serializable
+end
+
+class JSONChild1 < JSONBaseType
+  property x : Int32
+  property y : Int32
+end
+
+class JSONChild2 < JSONBaseType
+  property w : Int32
+  property z : Int32
+end
+
 describe "JSON mapping" do
   it "works with record" do
     JSONAttrPoint.new(1, 2).to_json.should eq "{\"x\":1,\"y\":2}"
@@ -708,6 +722,25 @@ describe "JSON mapping" do
     obj = JSONAttrWithNilableUnion2.from_json(%({}))
     obj.value.should be_nil
     obj.to_json.should eq(%({}))
+  end
+
+  it "deserializes abstract type" do
+    objs = Array(JSONBaseType).from_json(%(
+      [
+        {"x": 1, "y": 2},
+        {"w": 3, "z": 4}
+      ]
+    ))
+
+    objs.size.should eq(2)
+
+    child1 = objs[0].as(JSONChild1)
+    child1.x.should eq(1)
+    child1.y.should eq(2)
+
+    child2 = objs[1].as(JSONChild2)
+    child2.w.should eq(3)
+    child2.z.should eq(4)
   end
 
   describe "parses JSON with presence markers" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -285,6 +285,20 @@ class YAMLAttrModuleTest2 < YAMLAttrModuleTest
   end
 end
 
+abstract class YAMLBaseType
+  include YAML::Serializable
+end
+
+class YAMLChild1 < YAMLBaseType
+  property x : Int32
+  property y : Int32
+end
+
+class YAMLChild2 < YAMLBaseType
+  property w : Int32
+  property z : Int32
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -613,6 +627,25 @@ describe "YAML::Serializable" do
 
     rec = YAMLAttrRecursiveHash.from_yaml(yaml)
     rec.other["foo"].other.should be(rec.other)
+  end
+
+  it "deserializes abstract type" do
+    objs = Array(YAMLBaseType).from_yaml(%(
+      [
+        {"x": 1, "y": 2},
+        {"w": 3, "z": 4}
+      ]
+    ))
+
+    objs.size.should eq(2)
+
+    child1 = objs[0].as(YAMLChild1)
+    child1.x.should eq(1)
+    child1.y.should eq(2)
+
+    child2 = objs[1].as(YAMLChild2)
+    child2.w.should eq(3)
+    child2.z.should eq(4)
   end
 
   describe "parses yaml with defaults" do


### PR DESCRIPTION
This is something that wasn't possible right now, and I think just trying to deserialize every concrete subtype makes sense. In a way this is similar to how unions are deserialized.