### PR TITLE
Compiler: fix missing `name_location` of some calls

### DIFF
--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -3,7 +3,9 @@ require "../../spec_helper"
 describe "Normalize: op assign" do
   ["+", "-", "*", "&+", "&-", "&*"].each do |op|
     it "normalizes var #{op}=" do
-      assert_normalize "a = 1; a #{op}= 2", "a = 1\na = a #{op} 2"
+      node = assert_normalize "a = 1; a #{op}= 2", "a = 1\na = a #{op} 2"
+      assert_name_location node.as(Expressions).expressions[1].as(Assign).value,
+        1, 10
     end
   end
 
@@ -16,7 +18,9 @@ describe "Normalize: op assign" do
   end
 
   it "normalizes exp.value +=" do
-    assert_normalize "a.b += 1", "__temp_1 = a\n__temp_1.b = __temp_1.b + 1"
+    node = assert_normalize "a.b += 1", "__temp_1 = a\n__temp_1.b = __temp_1.b + 1"
+    assert_name_location node.as(Expressions).expressions[1].as(Call).args[0],
+      1, 5
   end
 
   it "normalizes exp.value ||=" do
@@ -28,19 +32,27 @@ describe "Normalize: op assign" do
   end
 
   it "normalizes var.value +=" do
-    assert_normalize "a = 1; a.b += 2", "a = 1\na.b = a.b + 2"
+    node = assert_normalize "a = 1; a.b += 2", "a = 1\na.b = a.b + 2"
+    assert_name_location node.as(Expressions).expressions[1].as(Call).args[0],
+      1, 12
   end
 
   it "normalizes @var.value +=" do
-    assert_normalize "@a.b += 2", "@a.b = @a.b + 2"
+    node = assert_normalize "@a.b += 2", "@a.b = @a.b + 2"
+    assert_name_location node.as(Call).args[0],
+      1, 6
   end
 
   it "normalizes @@var.value +=" do
-    assert_normalize "@@a.b += 2", "@@a.b = @@a.b + 2"
+    node = assert_normalize "@@a.b += 2", "@@a.b = @@a.b + 2"
+    assert_name_location node.as(Call).args[0],
+      1, 7
   end
 
   it "normalizes exp[value] +=" do
-    assert_normalize "a[b, c] += 1", "__temp_1 = b\n__temp_2 = c\n__temp_3 = a\n__temp_3[__temp_1, __temp_2] = __temp_3[__temp_1, __temp_2] + 1"
+    node = assert_normalize "a[b, c] += 1", "__temp_1 = b\n__temp_2 = c\n__temp_3 = a\n__temp_3[__temp_1, __temp_2] = __temp_3[__temp_1, __temp_2] + 1"
+    assert_name_location node.as(Expressions).expressions[3].as(Call).args[2],
+      1, 9
   end
 
   it "normalizes exp[value] ||=" do
@@ -52,18 +64,34 @@ describe "Normalize: op assign" do
   end
 
   it "normalizes exp[0] +=" do
-    assert_normalize "a[0] += 1", "__temp_2 = a\n__temp_2[0] = __temp_2[0] + 1"
+    node = assert_normalize "a[0] += 1", "__temp_2 = a\n__temp_2[0] = __temp_2[0] + 1"
+    assert_name_location node.as(Expressions).expressions[1].as(Call).args[1],
+      1, 6
   end
 
   it "normalizes var[0] +=" do
-    assert_normalize "a = 1; a[0] += 1", "a = 1\na[0] = a[0] + 1"
+    node = assert_normalize "a = 1; a[0] += 1", "a = 1\na[0] = a[0] + 1"
+    assert_name_location node.as(Expressions).expressions[1].as(Call).args[1],
+      1, 13
   end
 
   it "normalizes @var[0] +=" do
-    assert_normalize "@a[0] += 1", "@a[0] = @a[0] + 1"
+    node = assert_normalize "@a[0] += 1", "@a[0] = @a[0] + 1"
+    assert_name_location node.as(Call).args[1],
+      1, 7
   end
 
   it "normalizes @@var[0] +=" do
-    assert_normalize "@@a[0] += 1", "@@a[0] = @@a[0] + 1"
+    node = assert_normalize "@@a[0] += 1", "@@a[0] = @@a[0] + 1"
+    assert_name_location node.as(Call).args[1],
+      1, 8
   end
+end
+
+private def assert_name_location(node, line_number, column_number, spec_file = __FILE__, spec_line = __LINE__)
+  node.name_location.should_not be_nil, spec_file, spec_line
+
+  name_location = node.name_location.not_nil!
+  name_location.line_number.should eq(line_number), spec_file, spec_line
+  name_location.column_number.should eq(column_number), spec_file, spec_line
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1889,6 +1889,28 @@ module Crystal
         loc = node.location.not_nil!
         loc.line_number.should eq(2)
       end
+
+      it "sets location of +=" do
+        parser = Parser.new("a = 1; a += 2")
+        node = parser.parse.as(Expressions).expressions[1]
+
+        node.name_location.should_not be_nil
+        name_location = node.name_location.not_nil!
+
+        name_location.line_number.should eq(1)
+        name_location.column_number.should eq(10)
+      end
+
+      it "sets location of obj.x += as call" do
+        parser = Parser.new("a = 1; a.x += 2")
+        node = parser.parse.as(Expressions).expressions[1]
+
+        node.name_location.should_not be_nil
+        name_location = node.name_location.not_nil!
+
+        name_location.line_number.should eq(1)
+        name_location.column_number.should eq(12)
+      end
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -72,6 +72,7 @@ def assert_normalize(from, to, flags = nil)
   from_nodes = Parser.parse(from)
   to_nodes = program.normalize(from_nodes)
   to_nodes.to_s.strip.should eq(to.strip)
+  to_nodes
 end
 
 def assert_expand(from : String, to)

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -341,6 +341,7 @@ class Crystal::CodeGenVisitor
     call.scope = with_scope || node.scope
     call.with_scope = with_scope
     call.uses_with_scope = node.uses_with_scope?
+    call.name_location = node.name_location
 
     is_super = node.name == "super"
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -14,7 +14,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_primitive(call, node, target_def, call_args)
-    @call_location = call.name_location if call && call.location
+    @call_location = call.try &.name_location
 
     @last = case node.name
             when "binary"

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -236,6 +236,7 @@ module Crystal
 
       # (2) = tmp.exp
       call = Call.new(tmp.clone, target.name).at(node)
+      call.name_location = node.name_location
 
       case node.op
       when "||"
@@ -243,6 +244,7 @@ module Crystal
         #
         # (3) = tmp.exp=(b)
         right = Call.new(tmp.clone, "#{target.name}=", node.value).at(node)
+        right.name_location = node.name_location
 
         # (4) = (2) || (3)
         call = Or.new(call, right).at(node)
@@ -251,15 +253,18 @@ module Crystal
         #
         # (3) = tmp.exp=(b)
         right = Call.new(tmp.clone, "#{target.name}=", node.value).at(node)
+        right.name_location = node.name_location
 
         # (4) = (2) && (3)
         call = And.new(call, right).at(node)
       else
         # (3) = (2) + b
         call = Call.new(call, node.op, node.value).at(node)
+        call.name_location = node.name_location
 
         # (4) = tmp.exp=((3))
         call = Call.new(tmp.clone, "#{target.name}=", call).at(node)
+        call.name_location = node.name_location
       end
 
       # (1); (4)
@@ -313,12 +318,14 @@ module Crystal
         #
         # (2) = tmp[tmp1, tmp2, ...]?
         call = Call.new(tmp.clone, "[]?", tmp_args).at(node)
+        call.name_location = node.name_location
 
         # (3) = tmp[tmp1, tmp2, ...] = b
         args = Array(ASTNode).new(tmp_args.size + 1)
         tmp_args.each { |arg| args << arg.clone }
         args << node.value
         right = Call.new(tmp.clone, "[]=", args).at(node)
+        right.name_location = node.name_location
 
         # (3) = (2) || (4)
         call = Or.new(call, right).at(node)
@@ -327,34 +334,44 @@ module Crystal
         #
         # (2) = tmp[tmp1, tmp2, ...]?
         call = Call.new(tmp.clone, "[]?", tmp_args).at(node)
+        call.name_location = node.name_location
 
         # (3) = tmp[tmp1, tmp2, ...] = b
         args = Array(ASTNode).new(tmp_args.size + 1)
         tmp_args.each { |arg| args << arg.clone }
         args << node.value
         right = Call.new(tmp.clone, "[]=", args).at(node)
+        right.name_location = node.name_location
 
         # (3) = (2) && (4)
         call = And.new(call, right).at(node)
       else
         # (2) = tmp[tmp1, tmp2, ...]
         call = Call.new(tmp.clone, "[]", tmp_args).at(node)
+        call.name_location = node.name_location
 
         # (3) = (2) + b
         call = Call.new(call, node.op, node.value).at(node)
+        call.name_location = node.name_location
 
         # (4) tmp.[]=(tmp1, tmp2, ..., (3))
         args = Array(ASTNode).new(tmp_args.size + 1)
         tmp_args.each { |arg| args << arg.clone }
         args << call
         call = Call.new(tmp.clone, "[]=", args).at(node)
+        call.name_location = node.name_location
       end
 
       # (1); (4)
-      exps = Array(ASTNode).new(tmp_assigns.size + 2)
-      exps.concat(tmp_assigns)
-      exps << call
-      Expressions.new(exps).at(node)
+      if tmp_assigns.empty?
+        call
+      else
+        exps = Array(ASTNode).new(tmp_assigns.size + 2)
+        exps.concat(tmp_assigns)
+        exps << call
+
+        Expressions.new(exps).at(node)
+      end
     end
 
     def transform_op_assign_simple(node, target)
@@ -374,6 +391,7 @@ module Crystal
       else
         # (1) = a + b
         call = Call.new(target, node.op, node.value).at(node)
+        call.name_location = node.name_location
 
         # a = (1)
         Assign.new(target.clone, call).at(node)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -722,6 +722,7 @@ module Crystal
     property target : ASTNode
     property op : String
     property value : ASTNode
+    property name_location : Location?
 
     def initialize(@target, @op, @value)
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -328,6 +328,8 @@ module Crystal
       atomic = parse_question_colon
 
       while true
+        name_location = @token.location
+
         case @token.type
         when :SPACE
           next_token
@@ -428,6 +430,7 @@ module Crystal
           next_token_skip_space_or_newline
           value = parse_op_assign_no_control
           atomic = OpAssign.new(atomic, method, value).at(location)
+          atomic.name_location = name_location
         else
           break
         end
@@ -714,12 +717,14 @@ module Crystal
               atomic.name_location = name_location
               next
             when :"+=", :"-=", :"*=", :"/=", :"//=", :"%=", :"|=", :"&=", :"^=", :"**=", :"<<=", :">>=", :"||=", :"&&=", :"&+=", :"&-=", :"&*="
+              name_location = @token.location
               method = @token.type.to_s.byte_slice(0, @token.type.to_s.size - 1)
               next_token_skip_space_or_newline
               value = parse_op_assign
               call = Call.new(atomic, name).at(location)
               call.name_location = name_location
               atomic = OpAssign.new(call, method, value).at(location)
+              atomic.name_location = name_location
               next
             else
               call_args = preserve_stop_on_do { space_consumed ? parse_call_args_space_consumed : parse_call_args }


### PR DESCRIPTION
Fixes #8191

I _think_ these were all the missing cases, but I'm not sure.

We have two choices:
1. use `location` if `name_location` is missing: that way we'll never know if we missed setting a `name_location` somewhere
2. just use `name_location` and crash if it's missing: bad for users, though they can still compile their code with `--no-debug`, but we'll know we are missing something and we can fix it

Probably 2 is better, so I didn't change anything else.

In any case, this line is smelly:

https://github.com/crystal-lang/crystal/blob/d1a8e77237aa8af11a63ac4f98368d6d432cd113/src/compiler/crystal/codegen/primitives.cr#L17

it's strange that we check `call.location` to determine copying `call.name_location`. Shouldn't we check for `name_location`?

(though this seems to work, probably because `location` is set in more places than `name_location`)