### PR TITLE
Fix compile on win32

### DIFF
--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -10,7 +10,7 @@ module Crystal::System::Time
   NANOSECONDS_PER_FILETIME_TICK = 100
 
   NANOSECONDS_PER_SECOND    = 1_000_000_000
-  FILETIME_TICKS_PER_SECOND = NANOSECONDS_PER_SECOND / NANOSECONDS_PER_FILETIME_TICK
+  FILETIME_TICKS_PER_SECOND = NANOSECONDS_PER_SECOND // NANOSECONDS_PER_FILETIME_TICK
 
   BIAS_TO_OFFSET_FACTOR = -60
 
@@ -49,7 +49,7 @@ module Crystal::System::Time
       raise WinError.new("QueryPerformanceCounter")
     end
 
-    {ticks / @@performance_frequency, (ticks.remainder(@@performance_frequency) * NANOSECONDS_PER_SECOND / @@performance_frequency).to_i32}
+    {ticks // @@performance_frequency, (ticks.remainder(@@performance_frequency) * NANOSECONDS_PER_SECOND / @@performance_frequency).to_i32}
   end
 
   def self.load_localtime : ::Time::Location?

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -254,20 +254,22 @@ module GC
   end
 
   # pushes the stack of pending fibers when the GC wants to collect memory:
-  GC.before_collect do
-    Fiber.unsafe_each do |fiber|
-      fiber.push_gc_roots unless fiber.running?
-    end
-
-    {% if flag?(:preview_mt) %}
-      Thread.unsafe_each do |thread|
-        if scheduler = thread.@scheduler
-          fiber = scheduler.@current
-          GC.set_stackbottom(thread, fiber.@stack_bottom)
-        end
+  {% unless flag?(:win32) %}
+    GC.before_collect do
+      Fiber.unsafe_each do |fiber|
+        fiber.push_gc_roots unless fiber.running?
       end
-    {% end %}
 
-    GC.unlock_write
-  end
+      {% if flag?(:preview_mt) %}
+        Thread.unsafe_each do |thread|
+          if scheduler = thread.@scheduler
+            fiber = scheduler.@current
+            GC.set_stackbottom(thread, fiber.@stack_bottom)
+          end
+        end
+      {% end %}
+
+      GC.unlock_write
+    end
+  {% end %}
 end

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -35,11 +35,13 @@ module Spec
         ensure
           Spec.run_after_each_hooks
 
-          # We do this to give a chance for signals (like CTRL+C) to be handled,
-          # which currently are only handled when there's a fiber switch
-          # (IO stuff, sleep, etc.). Without it the user might wait more than needed
-          # after pressing CTRL+C to quit the tests.
-          Fiber.yield
+          {% unless flag?(:win32) %}
+            # We do this to give a chance for signals (like CTRL+C) to be handled,
+            # which currently are only handled when there's a fiber switch
+            # (IO stuff, sleep, etc.). Without it the user might wait more than needed
+            # after pressing CTRL+C to quit the tests.
+            Fiber.yield
+          {% end %}
         end
       end
     end


### PR DESCRIPTION
This applies the arithmetic operator change to win32-specific implementation and moves references to `Fiber` behind a flag. The latter can be removed after #7995, but right now it is required to build specs on win32.