### PR TITLE
Fix corruption of thread linked list

### DIFF
--- a/src/thread.cr
+++ b/src/thread.cr
@@ -34,9 +34,7 @@ class Thread
       Pointer(Void).null
     }, self.as(Void*))
 
-    if ret == 0
-      Thread.threads.push(self)
-    else
+    if ret != 0
       raise Errno.new("pthread_create", ret)
     end
   end
@@ -124,6 +122,7 @@ class Thread
   end
 
   protected def start
+    Thread.threads.push(self)
     Thread.current = self
     @main_fiber = fiber = Fiber.new(stack_address, self)
 


### PR DESCRIPTION
When a new thread finishes very quickly it could happen that the removal from the linked list was executed before the push. The linked list didn't check for that situation and it ends corrupted.

This is what was causing errors while the GC runs on the specs. There are some tests that create new threads with an almost empty body. 

Fixes #8184 