### PR TITLE
Add name to error message in non-nil asserting getters

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -229,7 +229,7 @@ describe Object do
   describe "getter!" do
     it "uses getter!" do
       obj = TestObject.new
-      expect_raises(Exception, "Nil assertion failed") do
+      expect_raises(NilAssertionError, "getter5 cannot be nil") do
         obj.getter5
       end
       obj.getter5 = 5
@@ -240,7 +240,7 @@ describe Object do
 
     it "uses getter! with type declaration" do
       obj = TestObject.new
-      expect_raises(Exception, "Nil assertion failed") do
+      expect_raises(NilAssertionError, "getter6 cannot be nil") do
         obj.getter6
       end
       obj.getter6 = 6
@@ -379,7 +379,7 @@ describe Object do
   describe "property!" do
     it "uses property!" do
       obj = TestObject.new
-      expect_raises(Exception, "Nil assertion failed") do
+      expect_raises(NilAssertionError, "property5 cannot be nil") do
         obj.property5
       end
       obj.property5 = 5
@@ -388,7 +388,7 @@ describe Object do
 
     it "uses property! with type declaration" do
       obj = TestObject.new
-      expect_raises(Exception, "Nil assertion failed") do
+      expect_raises(NilAssertionError, "property6 cannot be nil") do
         obj.property6
       end
       obj.property6 = 6

--- a/src/object.cr
+++ b/src/object.cr
@@ -496,7 +496,7 @@ class Object
 
         def {{method_prefix}}\{{name.id}}
           if (\%value = {{var_prefix}}\{{name.id}}).nil?
-            raise NilAssertionError.new("\{{name.id}} cannot be nil")
+            ::raise NilAssertionError.new("\{{name.id}} cannot be nil")
           else
             \%value
           end

--- a/src/object.cr
+++ b/src/object.cr
@@ -495,7 +495,11 @@ class Object
         end
 
         def {{method_prefix}}\{{name.id}}
-          {{var_prefix}}\{{name.id}}.not_nil!
+          if (\%value = {{var_prefix}}\{{name.id}}).nil?
+            raise NilAssertionError.new("\{{name.id}} cannot be nil")
+          else
+            \%value
+          end
         end
       \{% end %}
     end


### PR DESCRIPTION
Adds the getter's name to the error message when the non-nil assertion fails. This resolves issue #6431 . Affects `getter!`, `property!`, `class_getter!`, and `class_property!`.

```crystal
class Foo
  getter! bar

  def initialize(@bar : Int32? = nil)
  end
end

Foo.new.bar # NilAssertionError: bar can't be nil
```