### PR TITLE
Fix spec reporting with nested context

### DIFF
--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -1,0 +1,20 @@
+require "spec"
+
+private class FakeRootContext < Spec::RootContext
+  def report_formatters(result)
+  end
+end
+
+describe Spec::NestedContext do
+  describe "#report" do
+    it "should include parent's description" do
+      root = FakeRootContext.new
+      child = Spec::NestedContext.new(root, "child", "f.cr", 1, 10, false)
+      grand_child = Spec::NestedContext.new(child, "grand_child", "f.cr", 2, 9, false)
+
+      grand_child.report(:fail, "oops", "f.cr", 3, nil, nil)
+
+      root.@results[:fail].first.description.should eq("child grand_child oops")
+    end
+  end
+end

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -45,9 +45,13 @@ module Spec
     def report(kind, full_description, file, line, elapsed = nil, ex = nil)
       result = Result.new(kind, full_description, file, line, elapsed, ex)
 
-      Spec.formatters.each(&.report(result))
+      report_formatters result
 
       @results[result.kind] << result
+    end
+
+    def report_formatters(result)
+      Spec.formatters.each(&.report(result))
     end
 
     def succeeded

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -208,8 +208,8 @@ module Spec
       Spec.formatters.each(&.pop)
     end
 
-    def report(result)
-      parent.report Result.new(result.kind, "#{@description} #{result.description}", result.file, result.line, result.elapsed, result.exception)
+    def report(kind, description, file, line, elapsed = nil, ex = nil)
+      parent.report kind, "#{@description} #{description}", file, line, elapsed, ex
     end
   end
 end

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -17,7 +17,7 @@ module Spec
         Spec.formatters.each(&.before_example(description))
 
         unless block = @block
-          Spec.root_context.report(:pending, description, file, line)
+          @parent.report(:pending, description, file, line)
           return
         end
 
@@ -25,12 +25,12 @@ module Spec
         begin
           Spec.run_before_each_hooks
           block.call
-          Spec.root_context.report(:success, description, file, line, Time.monotonic - start)
+          @parent.report(:success, description, file, line, Time.monotonic - start)
         rescue ex : Spec::AssertionFailed
-          Spec.root_context.report(:fail, description, file, line, Time.monotonic - start, ex)
+          @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
           Spec.abort! if Spec.fail_fast?
         rescue ex
-          Spec.root_context.report(:error, description, file, line, Time.monotonic - start, ex)
+          @parent.report(:error, description, file, line, Time.monotonic - start, ex)
           Spec.abort! if Spec.fail_fast?
         ensure
           Spec.run_after_each_hooks


### PR DESCRIPTION
Fixes #8207 

The report of failure was using directly the root context instead of going through the whole hierarchy of contexts.