### PR TITLE
Allow abort to run without arguments

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -515,7 +515,7 @@ end
 
 # Terminates execution immediately, printing *message* to `STDERR` and
 # then calling `exit(status)`.
-def abort(message, status = 1) : NoReturn
+def abort(message = nil, status = 1) : NoReturn
   STDERR.puts message if message
   exit status
 end


### PR DESCRIPTION
There are cases when terminal output is handled separately via logging classes or similar and but we still want to `abort` nicely.

Also aligns functionality with ruby equivalent.