### PR TITLE
Channel`s non-blocking receive method added

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -187,13 +187,13 @@ describe "unbuffered" do
     closed.should be_true
   end
 
-  it "return nil on empty channel" do
+  it "returns nil on empty channel" do
     ch = Channel(Int32).new
     value = ch.nb_receive
     value.should eq(nil)
   end
 
-  it "return sended value" do
+  it "returns sent value" do
     ch = Channel(Int32).new
     ch.send(1)
     ch.nb_receive.should eq(1)
@@ -323,12 +323,12 @@ describe "buffered" do
     ch.pretty_inspect.should eq("#<Channel(Int32):0x#{ch.object_id.to_s(16)}>")
   end
 
-  it "return nil on empty channel" do
+  it "returns nil on empty channel" do
     ch = Channel(Int32).new(2)
     ch.nb_receive.should eq(nil)
   end
 
-  it "return sended value" do
+  it "returns sent value" do
     ch = Channel(Int32).new(2)
     ch.send(1)
     ch.nb_receive.should eq(1)

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -186,6 +186,18 @@ describe "unbuffered" do
 
     closed.should be_true
   end
+
+  it "return nil on empty channel" do
+    ch = Channel(Int32).new
+    value = ch.nb_receive
+    value.should eq(nil)
+  end
+
+  it "return sended value" do
+    ch = Channel(Int32).new
+    ch.send(1)
+    ch.nb_receive.should eq(1)
+  end
 end
 
 describe "buffered" do
@@ -309,5 +321,16 @@ describe "buffered" do
   it "does pretty_inspect on buffered channel" do
     ch = Channel(Int32).new(10)
     ch.pretty_inspect.should eq("#<Channel(Int32):0x#{ch.object_id.to_s(16)}>")
+  end
+
+  it "return nil on empty channel" do
+    ch = Channel(Int32).new(2)
+    ch.nb_receive.should eq(nil)
+  end
+
+  it "return sended value" do
+    ch = Channel(Int32).new(2)
+    ch.send(1)
+    ch.nb_receive.should eq(1)
   end
 end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -157,6 +157,14 @@ class Channel(T)
     receive_impl { return nil }
   end
 
+  # Receives a value from the channel.
+  # If there is a value waiting, it is returned immediately. Otherwise, this method returns nil.
+  #
+  # Returns `nil` if the channel is closed.
+  def nb_receive
+    @lock.sync { closed? ? nil : receive_internal { nil } }
+  end
+
   def receive_impl
     @lock.sync do
       receive_internal do


### PR DESCRIPTION
I think having receive method that does not blocks current fiber is great idea. 
Synthetical example:
```
spawn do
  i = 0
  loop do
    sleep 3
    channel.send(i)
    i += 1
  end
end

spawn do
  loop do
     value = channel.nb_receive
     if value
      puts "#{Time.local}, empty: #{false}, value: #{value}"
     else
      puts "#{Time.local}, empty: #{true}"
     end

     sleep 1
  end
end

sleep 1000000
```

Real use case:
```
class NewClientsHandler
  def initialize(server : TCPServer, channel : Channel(TCPSocket))
    @channel = channel
    @server = server
  end

  def call
    loop do
      if client_socket = @server.accept?
        @channel.send(client_socket)
      end
    end
  end
end


class Server
  def initialize
    @server = TCPServer.new("localhost", '1234')
    @new_clients_channel = Channel(TCPSocket).new
    @clients = [] of ClientHandler
  end

  def start
    start_new_users_handling

    loop do
      handle_new_users

      # process messages from clients
    end
  end

  def start_new_users_handling
    spawn NewClientsHandler.new(@server, @new_clients_channel).call
  end

  def handle_new_users
    new_client_socket = @new_clients_channel.nb_receive
    return if new_client_socket.nil?

    client_handler = ClientHandler.new(new_client_socket)
    @clients << client_handler

    spawn client_handler.call
  end
end

Server.new.start

```