### PR TITLE
Compiler: use virtual type for `uninitialized`

### DIFF
--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -170,4 +170,19 @@ describe "Semantic: pointer" do
       ),
       "undefined local variable or method 'foo'"
   end
+
+  it "can assign pointerof virtual type (#8216)" do
+    semantic(%(
+      class Base
+      end
+
+      class Sub < Base
+      end
+
+      u = uninitialized Base
+
+      x : Pointer(Base)
+      x = pointerof(u)
+    ))
+  end
 end

--- a/spec/compiler/semantic/uninitialized_spec.cr
+++ b/spec/compiler/semantic/uninitialized_spec.cr
@@ -146,4 +146,17 @@ describe "Semantic: uninitialized" do
       x = uninitialized Int32
       )) { int32 }
   end
+
+  it "uses virtual type for uninitialized (#8216)" do
+    assert_type(%(
+      class Base
+      end
+
+      class Sub < Base
+      end
+
+      u = uninitialized Base
+      u
+      )) { types["Base"].virtual_type! }
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -252,7 +252,7 @@ module Crystal
   class PointerOf
     def map_type(type)
       old_type = self.type?
-      new_type = type.try &.program.pointer_of(type)
+      new_type = type.program.pointer_of(type)
       if old_type && grew?(old_type, new_type)
         raise "recursive pointerof expansion: #{old_type}, #{new_type}, ..."
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -466,6 +466,7 @@ module Crystal
         # TODO: should we be using a binding here to recompute the type?
         if declared_type = node.declared_type.type?
           var_type = check_declare_var_type node, declared_type, "a variable"
+          var_type = var_type.virtual_type
           var.type = var_type
         else
           node.raise "can't infer type of type declaration"


### PR DESCRIPTION
Fixes #8216

The issue was that `uninitialized T` would get a type `T` instead of `T+` if `T` had subtypes. Then `pointerof` would get a type that didn't match the expected virtual type.

@bcardiff This should probably go into 0.31.1