### PR TITLE
Fix overflow in Random::Secure's overridden rand_type

### DIFF
--- a/spec/std/random/secure_spec.cr
+++ b/spec/std/random/secure_spec.cr
@@ -17,4 +17,11 @@ describe "Random::Secure" do
     bytes = Random::Secure.random_bytes(10000)
     bytes[9990, 10].should_not eq(Bytes.new(10))
   end
+
+  it "returns a random integer in range (#8219)" do
+    {% for type in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64).map(&.id) %}
+      value = Random::Secure.rand({{type}}::MIN..{{type}}::MAX)
+      typeof(value).should eq({{type}})
+    {% end %}
+  end
 end

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -53,7 +53,7 @@ module Random::Secure
   {% for type in [Int8, Int16, Int32, Int64] %}
     private def rand_type(type : {{type}}.class, needed_bytes = sizeof({{type}})) : {{type}}
       result = rand_type({{"U#{type}".id}}, needed_bytes)
-      {{type}}.new(result)
+      {{type}}.new!(result)
     end
   {% end %}
 end


### PR DESCRIPTION
This follows the earlier change https://github.com/crystal-lang/crystal/commit/0690e2f7f77e35ddea268b3039167ec88034bb8f#diff-ab21012862ff4bc662382874cb0c0485R240

Fixes #8219