### PR TITLE
GC: Use upstream patch for green threads support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 90705311d22e86220fba1b140fe62bfa2662dfdd
+          git checkout e942880dda3b100ff1143cce88b579bbec3f05b9
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -63,7 +63,7 @@ class Fiber
   def initialize(@stack : Void*, thread)
     @proc = Proc(Void).new { }
     @context = Context.new(_fiber_get_stack_top)
-    @stack_bottom = GC.current_thread_stack_bottom
+    thread.gc_thread_handler, @stack_bottom = GC.current_thread_stack_bottom
     @name = "main"
     @current_thread.set(thread)
     Fiber.fibers.push(self)

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -71,7 +71,7 @@ module GC
 
   # :nodoc:
   def self.current_thread_stack_bottom
-    @@stack_bottom
+    {Pointer(Void).null, @@stack_bottom}
   end
 
   # :nodoc:

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -21,6 +21,9 @@ class Thread
   # :nodoc:
   property previous : Thread?
 
+  # :nodoc:
+  property gc_thread_handler : Void* = Pointer(Void).null
+
   def self.unsafe_each
     threads.unsafe_each { |thread| yield thread }
   end


### PR DESCRIPTION
This requires also an update of the distribution-scripts (~~reason why this PR is draft~~).
A compiler with the updated GC 8.0.4 + upstream patch will be available in circleci for a smoke testing. So far it seems to work locally.

The preview_mt jobs will fail with compilation issues since the 0.31.0 has the old patch bundled.

As of the changes itself, bdw-gc patch ended returning an opaque thread handler that is stored now in `Thread.gc_thread_handler` and a `StackBase` structure that is the stackbottom in most architectures. In IA-64 includes the reg_base, but we don't support IA-64. Since the fibers only knows about the stackbottom, I preferred to leave the reg_base commented.

Depends on: https://github.com/crystal-lang/distribution-scripts/pull/47

Fixes: #8213