### PR TITLE
Change immutable class to struct

### DIFF
--- a/src/oauth/request_token.cr
+++ b/src/oauth/request_token.cr
@@ -1,4 +1,4 @@
-class OAuth::RequestToken
+struct OAuth::RequestToken
   getter token : String
   getter secret : String
 

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -1,5 +1,5 @@
 # The status of a terminated process.
-class Process::Status
+struct Process::Status
   # Platform-specific exit status code, which usually contains either the exit code or a termination signal.
   # The other `Process::Status` methods extract the values from `exit_status`.
   getter exit_status : Int32


### PR DESCRIPTION
I noticed, after looking at the implementations, some places where classes can be changed to structs, because the objects are immutable.