### PR TITLE
Compiler: store and restore debug location when going to main

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -170,4 +170,24 @@ describe "Code gen: debug" do
       Foo.new.bar
       ), debug: Crystal::Debug::All)
   end
+
+  it "stores and restores debug location after jumping to main (#6920)" do
+    codegen(%(
+      require "prelude"
+
+      Module.method
+
+      module Module
+        def self.value
+          1 &+ 2
+        end
+
+        @@x : Int32 = value
+
+        def self.method
+          @@x
+        end
+      end
+    ), debug: Crystal::Debug::All)
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1565,6 +1565,8 @@ module Crystal
       old_entry_block = @entry_block
       old_alloca_block = @alloca_block
       old_needs_value = @needs_value
+      old_debug_location = @current_debug_location
+
       @llvm_mod = @main_mod
       @llvm_context = @main_llvm_context
       @llvm_typer = @main_llvm_typer
@@ -1573,6 +1575,8 @@ module Crystal
       @ensure_exception_handlers = nil
       @rescue_block = nil
       @catch_pad = nil
+
+      clear_current_debug_location if @debug.line_numbers?
 
       block_value = yield
 
@@ -1589,6 +1593,7 @@ module Crystal
       @alloca_block = old_alloca_block
       @needs_value = old_needs_value
       context.fun = old_fun
+      set_current_debug_location old_debug_location if @debug.line_numbers?
 
       block_value
     end


### PR DESCRIPTION
Fixes #8233
Fixes #7060
Fixes #6920

(which are all just the same bug, but this way it looks like this is a killer PR! 😛)

@bcardiff I'm putting this for 0.31.1 because even though it's not a bug introduced there, it's something that will likely fix a lot of the existing issues with debug info.