### PR TITLE
Spec: add `before_suite` and `after_suite`

### DIFF
--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -131,6 +131,18 @@ module Spec
 
   # Instructs the spec runner to execute the given block
   # before each spec, regardless of where this method is invoked.
+  #
+  # If multiple blocks are registered they run in the order
+  # that they are given.
+  #
+  # For example:
+  #
+  # ```
+  # Spec.before_each { puts 1 }
+  # Spec.before_each { puts 2 }
+  # ```
+  #
+  # will print, just before each spec, 1 and then 2.
   def self.before_each(&block)
     before_each = @@before_each ||= [] of ->
     before_each << block
@@ -138,6 +150,18 @@ module Spec
 
   # Instructs the spec runner to execute the given block
   # after each spec, regardless of where this method is invoked.
+  #
+  # If multiple blocks are registered they run in the reversed
+  # order that they are given.
+  #
+  # For example:
+  #
+  # ```
+  # Spec.after_each { puts 1 }
+  # Spec.after_each { puts 2 }
+  # ```
+  #
+  # will print, just after each spec, 2 and then 1.
   def self.after_each(&block)
     after_each = @@after_each ||= [] of ->
     after_each << block
@@ -188,7 +212,7 @@ module Spec
 
   # :nodoc:
   def self.run_after_each_hooks
-    @@after_each.try &.each &.call
+    @@after_each.try &.reverse_each &.call
   end
 
   # :nodoc:


### PR DESCRIPTION
Fixes #8235

Also changes the way `Spec.after_each` run: they now run in reverse order.

I tried it in RSpec and it works the same, and it makes sense because one usually does this:

```crystal
# In one part of the code
Spec.before_suite do
  # set up thing 1
end

Spec.after_suite do
  # tear down thing 1
end

# In some other part of the code
Spec.before_suite do
  # set up thing 2
end

Spec.after_suite do
  # tear down thing 2
end
```

and in the end, because of the order things are called, you get:

```
# set up thing 1
# set up thing 2
# tear down thing 2
# tear down thing 1
```

Same goes for `before_each` and `after_each`: they are normally registered in pairs one after the other.

No specs for this, sorry, but the code is relatively trivial.

💭 Now that I think about it, what happens if one hook fails with an exception? I just tried it in RSpec and you get something like "An error occurred in an `after(:suite)` hook" and then a nicely printed exception. We should probably do the same, but I'd like to do that in a separate PR (and it doesn't need to be there in 0.31.1, after all if you get a failure it's something wrong in your setup).