### PR TITLE
Workaround IO::Evented#evented_write invalid IndexError error

### DIFF
--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -70,7 +70,7 @@ module IO::Evented
 
     begin
       loop do
-        bytes_written = yield slice
+        bytes_written = (yield slice).to_i64
         if bytes_written != -1
           slice += bytes_written
           return if slice.size == 0

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -70,6 +70,7 @@ module IO::Evented
 
     begin
       loop do
+        # TODO: Investigate why the .to_i64 is needed as a workaround for #8230
         bytes_written = (yield slice).to_i64
         if bytes_written != -1
           slice += bytes_written

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -163,7 +163,11 @@ struct Slice(T)
   # slice2 = slice + 2
   # slice2 # => Slice[12, 13, 14]
   # ```
+  @[NoInline] 
   def +(offset : Int)
+    # This method has NotInline as a workaround for #8230. 
+    # To avoid been inlined in Evented#evented_write.
+    # Making `@size &- offset` also seems to fix the issue.
     check_size(offset)
 
     Slice.new(@pointer + offset, @size - offset, read_only: @read_only)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -163,11 +163,7 @@ struct Slice(T)
   # slice2 = slice + 2
   # slice2 # => Slice[12, 13, 14]
   # ```
-  @[NoInline] 
   def +(offset : Int)
-    # This method has NotInline as a workaround for #8230. 
-    # To avoid been inlined in Evented#evented_write.
-    # Making `@size &- offset` also seems to fix the issue.
     check_size(offset)
 
     Slice.new(@pointer + offset, @size - offset, read_only: @read_only)


### PR DESCRIPTION
Fixes #8230

The issue started appearing after overflow is turned on by default.
But it is not exhibited if `Slice#+` is not inlined in `Evented#evented_write`.
If overflows are avoided in `@size &- offset` but it seems more a hack and fragile since it would be changing the semantics.