### PR TITLE
Spec: let `should be_nil` and `should be_a(...)` cast the value

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -580,6 +580,21 @@ module Spec
       end
       expectation.cast_should_not(self)
     end
+
+    @[Deprecated("Expectations (what you pass to `should`) must include Spec::Expectation")]
+    def should(expectation, file = __FILE__, line = __LINE__)
+      unless expectation.match self
+        fail(expectation.failure_message(self), file, line)
+      end
+    end
+
+    @[Deprecated("Expectations (what you pass to `should_not`) must include Spec::Expectation")]
+    def should_not(expectation, file = __FILE__, line = __LINE__)
+      if expectation.match self
+        fail(expectation.negative_failure_message(self), file, line)
+      end
+      expectation.cast_should_not(self)
+    end
   end
 end
 


### PR DESCRIPTION
A way to solve [this forum request](https://forum.crystal-lang.org/t/var-should-not-be-nil-does-not-eliminate-var-of-nil-from-subsequent-type-inference/1165)

Before this PR we had to do this:

```crystal
index = "foo".index('o')
index.should_not be_nil
foo[index.not_nil!].should eq('o')
```

The `not_nil!` is needed because the compiler has no way to know that the `should_not be_nil` means that `index` will not be `nil`.

With this PR we can now do:

```crystal
index = "foo".index('o')
index = index.should_not be_nil
foo[index].should eq('o')
```

Basically, the result of `obj.should_not be_nil` will return `obj` as a non-nil object.

The same applies for `obj.should be_a(T)` and `obj.should_not be_a(T)`.

This still doesn't automatically restrict the var but is significantly better than the old option.

This PR is a breaking change because I introduced the `Expectation` module that all expectations must include. An alternative to implement this PR is to overload `should` and `should_not` with `BeNil` and `BeA` but it felt like a worse option and it's less extensible.

This is just a draft because together with this PR we can actually change many `should_not be_nil` combined with `not_nil!` in the stdlib specs.

Finally, this PR also finally documents the way to extend `spec` with custom expectations.

💭 In RSpec they are called "matchers", maybe we could rename them to be consistent with the Ruby world? It's also shorter.