### PR TITLE
Improve Time::Span initialization API

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -11,31 +11,45 @@ describe Time::Span do
     t1 = Time::Span.new nanoseconds: 123_456_789_123
     t1.to_s.should eq("00:02:03.456789123")
 
-    t1 = Time::Span.new 1, 2, 3
+    t1 = Time::Span.new hours: 1, minutes: 2, seconds: 3
     t1.to_s.should eq("01:02:03")
 
-    t1 = Time::Span.new 1, 2, 3, 4
+    t1 = Time::Span.new minutes: 2, seconds: 3
+    t1.to_s.should eq("00:02:03")
+
+    t1 = Time::Span.new seconds: 3
+    t1.to_s.should eq("00:00:03")
+
+    t1 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4
     t1.to_s.should eq("1.02:03:04")
 
-    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t1.to_s.should eq("1.02:03:04.005000000")
 
-    t1 = Time::Span.new -1, 2, -3, 4, -5_000_000
+    t1 = Time::Span.new days: -1, hours: 2, minutes: -3, seconds: 4, nanoseconds: -5_000_000
     t1.to_s.should eq("-22:02:56.005000000")
 
-    t1 = Time::Span.new 0, 25, 0, 0, 0
+    t1 = Time::Span.new hours: 25
     t1.to_s.should eq("1.01:00:00")
+
+    t1 = Time::Span.new(1, 2, 3)
+    t1.to_s.should eq("01:02:03")
+    typeof(t1).should eq(Time::Span)
+
+    t1 = Time::Span.new(1, 2, 3, 4, 5)
+    t1.to_s.should eq("1.02:03:04.000000005")
+    typeof(t1).should eq(Time::Span)
   end
 
   it "initializes with big seconds value" do
-    t = Time::Span.new 0, 0, 1231231231231
+    t = Time::Span.new hours: 0, minutes: 0, seconds: 1231231231231
     t.total_seconds.should eq(1231231231231)
   end
 
   it "days overflows" do
     expect_overflow do
       days = 106751991167301
-      Time::Span.new days, 0, 0, 0, 0
+      Time::Span.new days: days
     end
   end
 
@@ -58,6 +72,7 @@ describe Time::Span do
     ts.minutes.should eq(14)
     ts.seconds.should eq(7)
     ts.milliseconds.should eq(0)
+    ts.nanoseconds.should eq(0)
   end
 
   it "min seconds" do
@@ -88,7 +103,7 @@ describe Time::Span do
   end
 
   it "negative timespan" do
-    ts = Time::Span.new -23, -59, -59
+    ts = Time::Span.new hours: -23, minutes: -59, seconds: -59
     ts.days.should eq(0)
     ts.hours.should eq(-23)
     ts.minutes.should eq(-59)
@@ -97,7 +112,7 @@ describe Time::Span do
   end
 
   it "test properties" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t2 = -t1
 
     t1.days.should eq(1)
@@ -118,8 +133,8 @@ describe Time::Span do
   end
 
   it "test add" do
-    t1 = Time::Span.new 2, 3, 4, 5, 6_000_000
-    t2 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 2, hours: 3, minutes: 4, seconds: 5, nanoseconds: 6_000_000
+    t2 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t3 = t1 + t2
 
     t3.days.should eq(3)
@@ -197,8 +212,8 @@ describe Time::Span do
   end
 
   it "test subtract" do
-    t1 = Time::Span.new 2, 3, 4, 5, 6_000_000
-    t2 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 2, hours: 3, minutes: 4, seconds: 5, nanoseconds: 6_000_000
+    t2 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t3 = t1 - t2
 
     t3.to_s.should eq("1.01:01:01.001000000")
@@ -207,23 +222,23 @@ describe Time::Span do
   end
 
   it "test multiply" do
-    t1 = Time::Span.new 5, 4, 3, 2, 1_000_000
+    t1 = Time::Span.new days: 5, hours: 4, minutes: 3, seconds: 2, nanoseconds: 1_000_000
     t2 = t1 * 61
     t3 = t1 * 0.5
 
-    t2.should eq(Time::Span.new 315, 7, 5, 2, 61_000_000)
-    t3.should eq(Time::Span.new 2, 14, 1, 31, 500_000)
+    t2.should eq(Time::Span.new days: 315, hours: 7, minutes: 5, seconds: 2, nanoseconds: 61_000_000)
+    t3.should eq(Time::Span.new days: 2, hours: 14, minutes: 1, seconds: 31, nanoseconds: 500_000)
 
     # TODO check overflow
   end
 
   it "test divide" do
-    t1 = Time::Span.new 3, 3, 3, 3, 3_000_000
+    t1 = Time::Span.new days: 3, hours: 3, minutes: 3, seconds: 3, nanoseconds: 3_000_000
     t2 = t1 / 2
     t3 = t1 / 1.5
 
-    t2.should eq(Time::Span.new(1, 13, 31, 31, 501_000_000) + Time::Span.new(nanoseconds: 500_000))
-    t3.should eq(Time::Span.new 2, 2, 2, 2, 2_000_000)
+    t2.should eq(Time::Span.new(days: 1, hours: 13, minutes: 31, seconds: 31, nanoseconds: 501_000_000) + Time::Span.new(nanoseconds: 500_000))
+    t3.should eq(Time::Span.new days: 2, hours: 2, minutes: 2, seconds: 2, nanoseconds: 2_000_000)
 
     # TODO check overflow
   end
@@ -237,7 +252,7 @@ describe Time::Span do
   end
 
   it "test to_s" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t2 = -t1
 
     t1.to_s.should eq("1.02:03:04.005000000")
@@ -248,7 +263,7 @@ describe Time::Span do
   end
 
   it "test totals" do
-    t1 = Time::Span.new 1, 2, 3, 4, 5_000_000
+    t1 = Time::Span.new days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5_000_000
     t1.total_days.should be_close(1.08546, 1e-05)
     t1.total_hours.should be_close(26.0511, 1e-04)
     t1.total_minutes.should be_close(1563.07, 1e-02)
@@ -266,7 +281,7 @@ describe Time::Span do
   end
 
   it "test zero?" do
-    Time::Span.new(nanoseconds: 0).zero?.should eq true
+    Time::Span::ZERO.zero?.should eq true
     Time::Span.new(nanoseconds: 123456789).zero?.should eq false
   end
 

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -227,7 +227,7 @@ describe Time do
   describe "#shift" do
     it "adds hours, minutes, seconds" do
       t1 = Time.utc(2002, 2, 25, 15, 25, 13)
-      t2 = t1 + Time::Span.new 3, 54, 1
+      t2 = t1 + Time::Span.new(hours: 3, minutes: 54, seconds: 1)
 
       t2.should eq Time.utc(2002, 2, 25, 19, 19, 14)
     end
@@ -439,7 +439,7 @@ describe Time do
 
   it "#time_of_day" do
     t = Time.utc 2014, 10, 30, 21, 18, 13
-    t.time_of_day.should eq(Time::Span.new(21, 18, 13))
+    t.time_of_day.should eq(Time::Span.new(hours: 21, minutes: 18, seconds: 13))
   end
 
   describe "#day_of_week" do

--- a/src/time.cr
+++ b/src/time.cr
@@ -908,7 +908,7 @@ struct Time
   # This is equivalent to creating a `Time::Span` from the time-of-day fields:
   #
   # ```
-  # time.time_of_day == Time::Span.new(time.hour, time.minute, time.second, time.nanosecond)
+  # time.time_of_day == Time::Span.new(hours: time.hour, minutes: time.minute, seconds: time.second, nanoseconds: time.nanosecond)
   # ```
   def time_of_day : Time::Span
     Span.new(nanoseconds: NANOSECONDS_PER_SECOND * (offset_seconds % SECONDS_PER_DAY) + nanosecond)

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -5,9 +5,9 @@
 # Check all `#new` methods for details.
 #
 # ```
-# Time::Span.new(nanoseconds: 10_000) # => 00:00:00.000010000
-# Time::Span.new(10, 10, 10)          # => 10:10:10
-# Time::Span.new(10, 10, 10, 10)      # => 10.10:10:10
+# Time::Span.new(nanoseconds: 10_000)                           # => 00:00:00.000010000
+# Time::Span.new(hours: 10, minutes: 10, seconds: 10)           # => 10:10:10
+# Time::Span.new(days: 10, hours: 10, minutes: 10, seconds: 10) # => 10.10:10:10
 # ```
 #
 # Calculation between `Time` also returns a `Time::Span`.
@@ -21,7 +21,7 @@
 # Inspection:
 #
 # ```
-# span = Time::Span.new(20, 10, 10)
+# span = Time::Span.new(hours: 20, minutes: 10, seconds: 10)
 # span.hours   # => 20
 # span.minutes # => 10
 # span.seconds # => 10
@@ -30,8 +30,8 @@
 # Calculation:
 #
 # ```
-# a = Time::Span.new(20, 10, 10)
-# b = Time::Span.new(10, 10, 10)
+# a = Time::Span.new(hours: 20, minutes: 10, seconds: 10)
+# b = Time::Span.new(hours: 10, minutes: 10, seconds: 10)
 # c = a - b # => 10:00:00
 # c.hours   # => 10
 # ```
@@ -53,14 +53,16 @@ struct Time::Span
   # @nanoseconds can either be negative or positive).
   @nanoseconds : Int32
 
-  def self.new(hours : Int, minutes : Int, seconds : Int)
-    new(0, hours, minutes, seconds)
+  @[Deprecated("Use `new` with named arguments instead.")]
+  def self.new(_hours : Int, _minutes : Int, _seconds : Int)
+    new(0, _hours, _minutes, _seconds)
   end
 
-  def self.new(days : Int, hours : Int, minutes : Int, seconds : Int, nanoseconds : Int = 0)
+  @[Deprecated("Use `new` with named arguments instead.")]
+  def self.new(_days : Int, _hours : Int, _minutes : Int, _seconds : Int, _nanoseconds : Int = 0)
     new(
-      seconds: compute_seconds!(days, hours, minutes, seconds),
-      nanoseconds: nanoseconds.to_i64,
+      seconds: compute_seconds!(_days, _hours, _minutes, _seconds),
+      nanoseconds: _nanoseconds.to_i64,
     )
   end
 
@@ -88,6 +90,13 @@ struct Time::Span
     new(
       seconds: nanoseconds.to_i64.tdiv(NANOSECONDS_PER_SECOND),
       nanoseconds: nanoseconds.to_i64.remainder(NANOSECONDS_PER_SECOND),
+    )
+  end
+
+  def self.new(*, days : Int = 0, hours : Int = 0, minutes : Int = 0, seconds : Int = 0, nanoseconds : Int = 0)
+    new(
+      seconds: compute_seconds!(days, hours, minutes, seconds),
+      nanoseconds: nanoseconds.to_i64,
     )
   end
 
@@ -398,7 +407,7 @@ end
 struct Int
   # Returns a `Time::Span` of `self` weeks.
   def weeks : Time::Span
-    Time::Span.new 7 * self, 0, 0, 0
+    Time::Span.new(days: (7 * self))
   end
 
   # :ditto:
@@ -408,7 +417,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` days.
   def days : Time::Span
-    Time::Span.new self, 0, 0, 0
+    Time::Span.new(days: self)
   end
 
   # :ditto:
@@ -418,7 +427,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` hours.
   def hours : Time::Span
-    Time::Span.new self, 0, 0
+    Time::Span.new(hours: self)
   end
 
   # :ditto:
@@ -428,7 +437,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` minutes.
   def minutes : Time::Span
-    Time::Span.new 0, self, 0
+    Time::Span.new(minutes: self)
   end
 
   # :ditto:
@@ -438,7 +447,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` seconds.
   def seconds : Time::Span
-    Time::Span.new 0, 0, self
+    Time::Span.new(seconds: self)
   end
 
   # :ditto:
@@ -448,7 +457,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` milliseconds.
   def milliseconds : Time::Span
-    Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND)
+    Time::Span.new(nanoseconds: (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND))
   end
 
   # :ditto:
@@ -458,7 +467,7 @@ struct Int
 
   # Returns a `Time::Span` of `self` microseconds.
   def microseconds : Time::Span
-    Time::Span.new 0, 0, 0, 0, (self.to_i64 * Time::NANOSECONDS_PER_MICROSECOND)
+    Time::Span.new(nanoseconds: (self.to_i64 * Time::NANOSECONDS_PER_MICROSECOND))
   end
 
   # :ditto:

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -66,6 +66,15 @@ struct Time::Span
     )
   end
 
+  # Creates a new `Time::Span` from *seconds* and *nanoseconds*.
+  #
+  # Nanoseconds get normalized in the range of `0...1_000_000_000`,
+  # the nanosecond overflow gets added as seconds.
+  #
+  # ```
+  # Time::Span.new(seconds: 30)                 # => 00:00:30
+  # Time::Span.new(seconds: 5, nanoseconds: 12) # => 00:00:05.000000012
+  # ```
   def initialize(*, seconds : Int, nanoseconds : Int)
     # Normalize nanoseconds in the range 0...1_000_000_000
     seconds += nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
@@ -86,6 +95,15 @@ struct Time::Span
     @nanoseconds = nanoseconds.to_i32
   end
 
+  # Creates a new `Time::Span` from the *nanosenconds* given
+  #
+  # Nanoseconds get normalized in the range of `0...1_000_000_000`,
+  # the nanosecond overflow gets added as seconds.
+  #
+  # ```
+  # Time::Span.new(nanoseconds: 500_000_000)   # => 00:00:00.500000000
+  # Time::Span.new(nanoseconds: 5_500_000_000) # => 00:00:05.500000000
+  # ```
   def self.new(*, nanoseconds : Int)
     new(
       seconds: nanoseconds.to_i64.tdiv(NANOSECONDS_PER_SECOND),
@@ -93,6 +111,15 @@ struct Time::Span
     )
   end
 
+  # Creates a new `Time::Span` from the *days*, *hours*, *minutes*, *seconds* and *nanoseconds* given
+  #
+  # Any time unit can be ommited.
+  #
+  # ```
+  # Time::Span.new(days: 1)                                                   # => 1.00:00:00
+  # Time::Span.new(days: 1, hours: 2, minutes: 3)                             # => 01:02:03
+  # Time::Span.new(days: 1, hours: 2, minutes: 3, seconds: 4, nanoseconds: 5) # => 1.02:03:04.000000005
+  # ```
   def self.new(*, days : Int = 0, hours : Int = 0, minutes : Int = 0, seconds : Int = 0, nanoseconds : Int = 0)
     new(
       seconds: compute_seconds(days, hours, minutes, seconds),


### PR DESCRIPTION
Resolves https://github.com/crystal-lang/crystal/issues/7795

I also refactored the `self.compute_seconds` as it now can safely rely on `OverflowError`, which was introduced in 0.31