### PR TITLE
Compiler: fix overload of union type through alias against type

### DIFF
--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -334,4 +334,20 @@ describe "Semantic: alias" do
       f.call(a.itself)
       )) { nil_type }
   end
+
+  it "overloads union type through alias" do
+    assert_type(%(
+      alias X = Int8 | Int32
+
+      def foo(x : Int32)
+        1
+      end
+
+      def foo(x : X)
+        'a'
+      end
+
+      foo(1)
+     ), inject_primitives: false) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -580,7 +580,7 @@ module Crystal
 
   class UnionType
     def restriction_of?(type, owner)
-      self == type || union_types.any? &.restriction_of?(type, owner)
+      self == type || union_types.all? &.restriction_of?(type, owner)
     end
 
     def restrict(other : Union, context)


### PR DESCRIPTION
If you do this:

```crystal
def foo(x : Int32)
  1
end

def foo(x : Int8 | Int32)
  'a'
end

foo(1) # =>  1
```

It works because `Int32` is "stricter" than `Int8 | Int32` and the other way around is not true, so the `Int32` overload takes precedence (when ordering overloads).

However, before this PR, when using an alias to define the union:

```crystal
alias A = Int8 | Int32

def foo(x : Int32)
  1
end

def foo(x : A)
  'a'
end

foo(1) # =>  'a'
```

It didn't work well! The reason was an incorrect logic when defining which type is stricter than the other. In this case, the union type, through the alias type, ended up stricter than the other type and eventually **overwrote** the other method (the first method could never be called/reached).

While working on something else I noticed this was affecting this line:

https://github.com/crystal-lang/crystal/blob/bb287bf4c767538fa1e473c1bae6f8898a1e96fd/src/big/big_int.cr#L265

and this line:

https://github.com/crystal-lang/crystal/blob/bb287bf4c767538fa1e473c1bae6f8898a1e96fd/src/big/big_int.cr#L279

Because `Int::Unsigned` is an alias, the first overload was overwritten because of this bug.

This PR fixes this situation.

Changing `any?` to `all?` is also consistent with another part of the code where unions are checked for strictness:

https://github.com/crystal-lang/crystal/blob/bb287bf4c767538fa1e473c1bae6f8898a1e96fd/src/compiler/crystal/semantic/restrictions.cr#L285

