### PR TITLE
Add `offset` argument to all `map_with_index` methods

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1588,12 +1588,23 @@ describe "Array" do
     ary2.should eq([1, 2, 4, 5])
   end
 
+  it "does map_with_index, with offset" do
+    ary = [1, 1, 2, 2]
+    ary2 = ary.map_with_index(10) { |e, i| e + i }
+    ary2.should eq([11, 12, 14, 15])
+  end
+
   it "does map_with_index!" do
     ary = [0, 1, 2]
     ary2 = ary.map_with_index! { |e, i| i * 2 }
-    ary[0].should eq(0)
-    ary[1].should eq(2)
-    ary[2].should eq(4)
+    ary.should eq([0, 2, 4])
+    ary2.should be(ary)
+  end
+
+  it "does map_with_index!, with offset" do
+    ary = [0, 1, 2]
+    ary2 = ary.map_with_index!(10) { |e, i| i * 2 }
+    ary.should eq([20, 22, 24])
     ary2.should be(ary)
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -627,8 +627,8 @@ describe "Enumerable" do
 
   describe "map_with_index" do
     it "yields the element and the index" do
-      result = ["Alice", "Bob"].map_with_index { |name, i| "User ##{i}: #{name}" }
-      result.should eq ["User #0: Alice", "User #1: Bob"]
+      result = SpecEnumerable.new.map_with_index { |e, i| "Value ##{i}: #{e}" }
+      result.should eq ["Value #0: 1", "Value #1: 2", "Value #2: 3"]
     end
 
     it "yields the element and the index of an iterator" do

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -231,6 +231,14 @@ describe "Pointer" do
     a[2].should eq(5)
   end
 
+  it "maps_with_index!, with offset" do
+    a = Pointer(Int32).malloc(3) { |i| i + 1 }
+    a.map_with_index!(3, offset: 10) { |e, i| e + i }
+    a[0].should eq(11)
+    a[1].should eq(13)
+    a[2].should eq(15)
+  end
+
   it "raises if mallocs negative size" do
     expect_raises(ArgumentError) { Pointer.malloc(-1, 0) }
   end

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -428,10 +428,23 @@ describe "Slice" do
     b.should eq(Slice[1, 2, 4, 5])
   end
 
+  it "does map_with_index, with offset" do
+    a = Slice[1, 1, 2, 2]
+    b = a.map_with_index(10) { |e, i| e + i }
+    b.should eq(Slice[11, 12, 14, 15])
+  end
+
   it "does map_with_index!" do
     a = Slice[1, 1, 2, 2]
     b = a.map_with_index! { |e, i| e + i }
     a.should eq(Slice[1, 2, 4, 5])
+    a.to_unsafe.should eq(b.to_unsafe)
+  end
+
+  it "does map_with_index!, with offset" do
+    a = Slice[1, 1, 2, 2]
+    b = a.map_with_index!(10) { |e, i| e + i }
+    a.should eq(Slice[11, 12, 14, 15])
     a.to_unsafe.should eq(b.to_unsafe)
   end
 

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -129,12 +129,27 @@ describe "StaticArray" do
     b.should eq(StaticArray[1, 2, 4, 5])
   end
 
+  it "does map_with_index, with offset" do
+    a = StaticArray[1, 1, 2, 2]
+    b = a.map_with_index(10) { |e, i| e + i }
+    b.should eq(StaticArray[11, 12, 14, 15])
+  end
+
   it "does map_with_index!" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.map_with_index! { |e, i| i * 2 }
     a[0].should eq(0)
     a[1].should eq(2)
     a[2].should eq(4)
+    a.should be_a(StaticArray(Int32, 3))
+  end
+
+  it "does map_with_index!, with offset" do
+    a = StaticArray(Int32, 3).new { |i| i + 1 }
+    a.map_with_index!(10) { |e, i| i * 2 }
+    a[0].should eq(20)
+    a[1].should eq(22)
+    a[2].should eq(24)
     a.should be_a(StaticArray(Int32, 3))
   end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2045,6 +2045,24 @@ describe "String" do
     i.should eq(3)
   end
 
+  it "does each_char_with_index" do
+    s = "abc"
+    values = [] of {Char, Int32}
+    s.each_char_with_index do |c, i|
+      values << {c, i}
+    end
+    values.should eq([{'a', 0}, {'b', 1}, {'c', 2}])
+  end
+
+  it "does each_char_with_index, with offset" do
+    s = "abc"
+    values = [] of {Char, Int32}
+    s.each_char_with_index(10) do |c, i|
+      values << {c, i}
+    end
+    values.should eq([{'a', 10}, {'b', 11}, {'c', 12}])
+  end
+
   it "gets each_char iterator" do
     iter = "abc".each_char
     iter.next.should eq('a')

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -213,6 +213,12 @@ describe "Tuple" do
     tuple2.should eq({1, 2, 4, 5})
   end
 
+  it "does map_with_index, with offset" do
+    tuple = {1, 1, 2, 2}
+    tuple2 = tuple.map_with_index(10) { |e, i| e + i }
+    tuple2.should eq({11, 12, 14, 15})
+  end
+
   it "does reverse" do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -1058,13 +1058,19 @@ class Array(T)
   end
 
   # Optimized version of `Enumerable#map_with_index`.
-  def map_with_index(&block : T, Int32 -> U) forall U
-    Array(U).new(size) { |i| yield @buffer[i], i }
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index(offset = 0, &block : T, Int32 -> U) forall U
+    Array(U).new(size) { |i| yield @buffer[i], offset + i }
   end
 
   # Like `map_with_index`, but mutates `self` instead of allocating a new object.
-  def map_with_index!(&block : (T, Int32) -> T)
-    to_unsafe.map_with_index!(size) { |e, i| yield e, i }
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
+    to_unsafe.map_with_index!(size) { |e, i| yield e, offset + i }
     self
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -734,9 +734,12 @@ module Enumerable(T)
   # ["Alice", "Bob"].map_with_index { |name, i| "User ##{i}: #{name}" }
   # # => ["User #0: Alice", "User #1: Bob"]
   # ```
-  def map_with_index(&block : T, Int32 -> U) forall U
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index(offset = 0, &block : T, Int32 -> U) forall U
     ary = [] of U
-    each_with_index { |e, i| ary << yield e, i }
+    each_with_index(offset) { |e, i| ary << yield e, i }
     ary
   end
 

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -383,9 +383,12 @@ struct Pointer(T)
   end
 
   # Like `map!`, but yields 2 arguments, the element and its index
-  def map_with_index!(count : Int, &block)
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index!(count : Int, offset = 0, &block)
     count.times do |i|
-      self[i] = yield self[i], i
+      self[i] = yield self[i], offset + i
     end
     self
   end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -324,16 +324,22 @@ struct Slice(T)
   end
 
   # Like `map!`, but the block gets passed both the element and its index.
-  def map_with_index!(&block : (T, Int32) -> T)
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
     check_writable
 
-    @pointer.map_with_index!(size) { |e, i| yield e, i }
+    @pointer.map_with_index!(size) { |e, i| yield e, offset + i }
     self
   end
 
   # Like `map`, but the block gets passed both the element and its index.
-  def map_with_index(*, read_only = false, &block : (T, Int32) -> U) forall U
-    Slice.new(size, read_only: read_only) { |i| yield @pointer[i], i }
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index(offset = 0, *, read_only = false, &block : (T, Int32) -> U) forall U
+    Slice.new(size, read_only: read_only) { |i| yield @pointer[i], offset + i }
   end
 
   def copy_from(source : Pointer(T), count)

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -209,14 +209,20 @@ struct StaticArray(T, N)
   end
 
   # Like `map!`, but the block gets passed both the element and its index.
-  def map_with_index!(&block : (T, Int32) -> T)
-    to_unsafe.map_with_index!(size) { |e, i| yield e, i }
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
+    to_unsafe.map_with_index!(size) { |e, i| yield e, offset + i }
     self
   end
 
   # Like `map`, but the block gets passed both the element and its index.
-  def map_with_index(&block : (T, Int32) -> U) forall U
-    StaticArray(U, N).new { |i| yield to_unsafe[i], i }
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index(offset = 0, &block : (T, Int32) -> U) forall U
+    StaticArray(U, N).new { |i| yield to_unsafe[i], offset + i }
   end
 
   # Reverses the elements of this array in-place, then returns `self`.

--- a/src/string.cr
+++ b/src/string.cr
@@ -3805,11 +3805,13 @@ class String
   # end
   # array # => [{'a', 0}, {'b', 1}, {'☃', 2}]
   # ```
-  def each_char_with_index
-    i = 0
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def each_char_with_index(offset = 0)
     each_char do |char|
-      yield char, i
-      i += 1
+      yield char, offset
+      offset += 1
     end
   end
 

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -414,11 +414,14 @@ struct Tuple
   # tuple = {1, 2.5, "a"}
   # tuple.map_with_index { |e, i| "tuple[#{i}]: #{e}" } # => {"tuple[0]: 1", "tuple[1]: 2.5", "tuple[2]: a"}
   # ```
-  def map_with_index
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  def map_with_index(offset = 0)
     {% begin %}
       Tuple.new(
         {% for i in 0...T.size %}
-          (yield self[{{i}}], {{i}}),
+          (yield self[{{i}}], offset + {{i}}),
         {% end %}
       )
     {% end %}


### PR DESCRIPTION
Since `each_with_index` accepts an optional `offset` argument I think it makes sense for `map_with_index` to accept one too.

Ref: https://forum.crystal-lang.org/t/difference-between-array-elements/1189