### PR TITLE
Optimized version of `Tuple#to_a`

### DIFF
--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -293,4 +293,13 @@ describe "Tuple" do
     ({/o+/, "bar"} === {"fox", "bar"}).should be_true
     ({1, 2} === nil).should be_false
   end
+
+  it "does to_a" do
+    ary = {1, 'a', true}.to_a
+    ary.should eq([1, 'a', true])
+    ary.size.should eq(3)
+
+    ary = Tuple.new.to_a
+    ary.size.should eq(0)
+  end
 end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -376,6 +376,15 @@ struct Tuple
     to_s
   end
 
+  def to_a
+    Array(Union(*T)).build(size) do |buffer|
+      {% for i in 0...T.size %}
+        buffer[{{i}}] = self[{{i}}]
+      {% end %}
+      size
+    end
+  end
+
   # Appends a string representation of this tuple to the given `IO`.
   #
   # ```


### PR DESCRIPTION
Benchmark:

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("old") do
    {1, 2, 3, 4}.to_a
  end
  x.report("new") do
    {1, 2, 3, 4}.to_a2
  end
end
```

Results:

```
old  24.58M ( 40.68ns) (± 2.92%)  64.0B/op   1.42× slower
new  34.95M ( 28.62ns) (± 2.73%)  64.0B/op        fastest
```

It's not much but it's something.