### PR TITLE
Compiler: sizeof(Bool) must be 1, not 0

### DIFF
--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -95,6 +95,10 @@ describe "Code gen: sizeof" do
     run("sizeof(Nil)").to_i.should eq(0)
   end
 
+  it "gets sizeof Bool (#8272)" do
+    run("sizeof(Bool)").to_i.should eq(1)
+  end
+
   it "can use sizeof in type argument (1)" do
     run(%(
       struct StaticArray

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -85,6 +85,9 @@ module Crystal
         # `Pointer(Void).malloc` must work like `Pointer(UInt8).malloc`,
         # that is, consider Void like the size of a byte.
         1
+      elsif type.is_a?(BoolType)
+        # LLVM reports 0 for bool (i1) but it must be 1 because it does occupy memory
+        1
       else
         llvm_typer.size_of(llvm_typer.llvm_type(type))
       end


### PR DESCRIPTION
Fixes #8272

I don't know why LLVM returns 0 for bool (`i1`). It seems that in C++ [sizeof(bool) is implementation defined](https://stackoverflow.com/questions/4897844/is-sizeofbool-defined-in-the-c-language-standard) which isn't really good, so maybe LLVM chooses to return 0.

It's also interesting to know that (before this PR):

```crystal
p sizeof(Bool) # => 0
p sizeof(Bool[1]) # => 1
```

That is, a static array of just one bool occupies one byte, per a bool occupies 0. In all other cases you have that `sizeof(T) == sizeof(T[1])` because a static array has its memory inlined.

There are many ways we can solve this: we could use `sizeof(T[1])` in `Pointer`, when we need to know the size of memory allocated by a pointer. Or we could make `sizeof(Bool)` be 1. I chose the latter because I think it's more intuitive, but I'm not sure.