### PR TITLE
GC: Fix gc_none with preview_mt

### DIFF
--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -67,11 +67,9 @@ module GC
     end
   {% end %}
 
-  @@stack_bottom = Pointer(Void).null
-
   # :nodoc:
   def self.current_thread_stack_bottom
-    {Pointer(Void).null, @@stack_bottom}
+    {Pointer(Void).null, Pointer(Void).null}
   end
 
   # :nodoc:


### PR DESCRIPTION
The initialization of the fiber was blocked in Crystal::OnceState lock

<details>
<summary>Example stack-trace before this PR using channel_primes</summary>

```
Call graph:
    2723 Thread_1015273   DispatchQueue_1: com.apple.main-thread  (serial)
      2723 start  (in libdyld.dylib) + 1  [0x7fff6315b3d5]
        2723 main  (in channel_primes) + 9  [0x10c62e129]  main.cr:106
          2723 *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32  (in channel_primes) + 35  [0x10c69cc73]  main.cr:86
            2723 __crystal_main  (in channel_primes) + 88  [0x10c6225e8]  callstack.cr:30
              2723 __crystal_once  (in channel_primes) + 13  [0x10c622b6d]  once.cr:48
                2723 *Crystal::OnceState#once<Pointer(Bool), Pointer(Void)>:(Pointer(Bool) | Nil)  (in channel_primes) + 57  [0x10c69c149]  once.cr:57
                  2723 *Mutex#lock:Nil  (in channel_primes) + 42  [0x10c6961ca]  mutex.cr:13
                    2723 *Fiber::current:Fiber  (in channel_primes) + 9  [0x10c666b49]  fiber.cr:102
                      2723 *Crystal::Scheduler::current_fiber:Fiber  (in channel_primes) + 9  [0x10c669479]  scheduler.cr:15
                        2723 *Thread::current:Thread  (in channel_primes) + 54  [0x10c666086]  thread.cr:70
                          2723 *Thread::new:Thread  (in channel_primes) + 207  [0x10c66618f]  thread.cr:47
                            2723 *Thread#initialize:Nil  (in channel_primes) + 84  [0x10c6661f4]  thread.cr:50
                              2723 *Fiber::new<Pointer(Void), Thread>:Fiber  (in channel_primes) + 230  [0x10c6669c6]  fiber.cr:63
                                2723 *Fiber#initialize<Pointer(Void), Thread>:Nil  (in channel_primes) + 113  [0x10c666a41]  fiber.cr:66
                                  2723 ~GC::stack_bottom:read  (in channel_primes) + 30  [0x10c62e32e]
                                    2723 __crystal_once  (in channel_primes) + 13  [0x10c622b6d]  once.cr:48
                                      2723 *Crystal::OnceState#once<Pointer(Bool), Pointer(Void)>:(Pointer(Bool) | Nil)  (in channel_primes) + 57  [0x10c69c149]  once.cr:57
                                        2723 *Mutex#lock:Nil  (in channel_primes) + 25  [0x10c6961b9]  mutex.cr:11
                                          2480 *Crystal::SpinLock#lock:Nil  (in channel_primes) + 74  [0x10c662cda]  spin_lock.cr:8
                                          + 2479 *Intrinsics::pause:Nil  (in channel_primes) + 6,7,...  [0x10c666046,0x10c666047,...]  intrinsics.cr:62
                                          + 1 *Intrinsics::pause:Nil  (in channel_primes) + 1  [0x10c666041]  intrinsics.cr:61
                                          122 *Crystal::SpinLock#lock:Nil  (in channel_primes) + 52,74,...  [0x10c662cc4,0x10c662cda,...]  spin_lock.cr:8
                                          97 *Crystal::SpinLock#lock:Nil  (in channel_primes) + 64  [0x10c662cd0]  spin_lock.cr:8
                                          + 97 *Atomic(Int32)@Atomic(T)#get:Int32  (in channel_primes) + 6,1  [0x10c662d56,0x10c662d51]  atomic.cr:191
                                          24 *Crystal::SpinLock#lock:Nil  (in channel_primes) + 48  [0x10c662cc0]  spin_lock.cr:0
```

</details>