### PR TITLE
Fix parser crash for 'alias Foo?'

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1169,6 +1169,7 @@ module Crystal
 
     it_parses "alias Foo = Bar", Alias.new("Foo".path, "Bar".path)
     it_parses "alias Foo::Bar = Baz", Alias.new(Path.new(["Foo", "Bar"]), "Baz".path)
+    assert_syntax_error "alias Foo?"
 
     it_parses "def foo\n1\nend\nif 1\nend", [Def.new("foo", body: 1.int32), If.new(1.int32)] of ASTNode
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5414,7 +5414,9 @@ module Crystal
 
       next_token_skip_space_or_newline
 
-      name = parse_ident(allow_type_vars: false).as(Path)
+      name = parse_ident(allow_type_vars: false, parse_nilable: false)
+      raise "BUG: Alias name can only be a Path" unless name.is_a?(Path)
+
       skip_space
       check :"="
       next_token_skip_space_or_newline

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1265,7 +1265,7 @@ module Crystal
       doc = @token.doc
 
       next_token_skip_space
-      name = parse_ident(allow_type_vars: false, parse_nilable: false).as(Path)
+      name = parse_path
       skip_space
 
       args = [] of ASTNode
@@ -1588,7 +1588,7 @@ module Crystal
       next_token_skip_space_or_newline
       name_location = @token.location
 
-      name = parse_ident allow_type_vars: false
+      name = parse_path
       skip_space
 
       type_vars, splat_index = parse_type_vars
@@ -1611,8 +1611,6 @@ module Crystal
       end_location = token_end_location
       check_ident :end
       next_token_skip_space
-
-      raise "BUG: ClassDef name can only be a Path" unless name.is_a?(Path)
 
       @type_nest -= 1
 
@@ -1675,7 +1673,7 @@ module Crystal
       next_token_skip_space_or_newline
 
       name_location = @token.location
-      name = parse_ident allow_type_vars: false
+      name = parse_path
       skip_space
 
       type_vars, splat_index = parse_type_vars
@@ -1686,8 +1684,6 @@ module Crystal
       end_location = token_end_location
       check_ident :end
       next_token_skip_space
-
-      raise "BUG: ModuleDef name can only be a Path" unless name.is_a?(Path)
 
       @type_nest -= 1
 
@@ -1705,8 +1701,7 @@ module Crystal
       next_token_skip_space_or_newline
 
       name_location = @token.location
-      name = parse_ident(allow_type_vars: false, parse_nilable: false).as(Path)
-
+      name = parse_path
       skip_statement_end
 
       end_location = token_end_location
@@ -4564,6 +4559,12 @@ module Crystal
       parse_ident_after_colons(location, global, allow_type_vars, parse_nilable)
     end
 
+    def parse_path
+      name = parse_ident(allow_type_vars: false, parse_nilable: false)
+      raise "BUG: expected a Path" unless name.is_a?(Path)
+      name
+    end
+
     def parse_ident_after_colons(location, global, allow_type_vars, parse_nilable)
       start_line = location.line_number
       start_column = location.column_number
@@ -5414,8 +5415,7 @@ module Crystal
 
       next_token_skip_space_or_newline
 
-      name = parse_ident(allow_type_vars: false, parse_nilable: false)
-      raise "BUG: Alias name can only be a Path" unless name.is_a?(Path)
+      name = parse_path
 
       skip_space
       check :"="
@@ -5599,7 +5599,7 @@ module Crystal
 
       next_token_skip_space_or_newline
 
-      name = parse_ident allow_type_vars: false
+      name = parse_path
       skip_space
 
       case @token.type
@@ -5618,8 +5618,6 @@ module Crystal
       check_ident :end
       end_location = token_end_location
       next_token_skip_space
-
-      raise "BUG: EnumDef name can only be a Path" unless name.is_a?(Path)
 
       enum_def = EnumDef.new name, members, base_type
       enum_def.doc = doc


### PR DESCRIPTION
> cast from Crystal::Generic to Crystal::Path failed

(found by fuzzing)

Also make all `parse_ident()` calls more consistent