### PR TITLE
CI: Avoid 32 bits failures and improve behavior when failures happen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout e942880dda3b100ff1143cce88b579bbec3f05b9
+          git checkout aca99b2078a171d8b4acb91a984ee21b163ee9f7
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts
@@ -301,7 +301,22 @@ jobs:
           cd /tmp/workspace/distribution-scripts
           source build.env
           cd docker
-          make CRYSTAL_DEB=/tmp/workspace/build/crystal_${CRYSTAL_VERSION}-1_amd64.deb
+          make all64 CRYSTAL_DEB=/tmp/workspace/build/crystal_${CRYSTAL_VERSION}-1_amd64.deb
+      - persist_to_workspace:
+          root: /tmp/workspace/distribution-scripts/docker/
+          paths:
+            - build
+
+  dist_docker32:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: |
+          cd /tmp/workspace/distribution-scripts
+          source build.env
+          cd docker
+          make all32 CRYSTAL_DEB=/tmp/workspace/build/crystal_${CRYSTAL_VERSION}-1_i386.deb
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/docker/
           paths:
@@ -400,6 +415,27 @@ jobs:
       - run: bin/ci prepare_build
       - run: bin/ci build
 
+  test_dist_linux32_std_on_docker:
+    machine: true
+    environment:
+      <<: *env
+      TRAVIS_OS_NAME: linux
+      ARCH: i386
+      ARCH_CMD: linux32
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: |
+          cd /tmp/workspace/distribution-scripts
+          source ./build.env
+          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-i386.tar.gz | docker image load
+          export DOCKER_TEST_PREFIX="crystallang/crystal:$DOCKER_TAG-i386" >> $BASH_ENV
+      - checkout
+      - run: bin/ci prepare_system
+      - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
+      - run: bin/ci prepare_build
+      - run: bin/ci with_build_env 'make std_spec threads=1'
+
 workflows:
   version: 2
   test_all_platforms:
@@ -468,6 +504,10 @@ workflows:
           filters: *per_tag
           requires:
             - dist_linux
+      - dist_docker32:
+          filters: *per_tag
+          requires:
+            - dist_linux32
       - dist_snap:
           filters: *per_tag
           requires:
@@ -480,6 +520,10 @@ workflows:
           filters: *per_tag
           requires:
             - dist_docker
+      - test_dist_linux32_std_on_docker:
+          filters: *per_tag
+          requires:
+            - dist_docker32
       # Tagged release do not publish docker images since they are unsigned
       # publish_docker:
       - dist_docs:
@@ -530,6 +574,9 @@ workflows:
       - dist_docker:
           requires:
             - dist_linux
+      - dist_docker32:
+          requires:
+            - dist_linux32
       - dist_snap:
           requires:
             - dist_linux
@@ -539,6 +586,9 @@ workflows:
       - test_dist_linux_on_docker:
           requires:
             - dist_docker
+      - test_dist_linux32_std_on_docker:
+          requires:
+            - dist_docker32
       - publish_docker:
           requires:
             - dist_docker
@@ -596,6 +646,10 @@ workflows:
           filters: *maintenance
           requires:
             - dist_linux
+      - dist_docker32:
+          filters: *maintenance
+          requires:
+            - dist_linux32
       - dist_snap:
           filters: *maintenance
           requires:
@@ -608,6 +662,10 @@ workflows:
           filters: *maintenance
           requires:
             - dist_docker
+      - test_dist_linux32_std_on_docker:
+          filters: *maintenance
+          requires:
+            - dist_docker32
       - publish_docker:
           filters: *maintenance
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,9 @@ jobs:
             source build.env
             cd linux
             make all64 release=true
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/linux/build
+          destination: build
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/linux/
           paths:
@@ -249,6 +252,9 @@ jobs:
             source build.env
             cd linux
             make all32 release=true
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/linux/build
+          destination: build
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/linux/
           paths:
@@ -287,6 +293,9 @@ jobs:
             bundle check || bundle install --binstubs
             cd ../darwin
             make
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/darwin/build
+          destination: build
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/darwin/
           paths:
@@ -349,6 +358,9 @@ jobs:
             source build.env
             cd snapcraft
             CRYSTAL_RELEASE_LINUX64_TARGZ=/tmp/workspace/build/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz make
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/snapcraft/build
+          destination: build
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/snapcraft/
           paths:
@@ -379,6 +391,9 @@ jobs:
           cd docs
           gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-build.tar.gz | docker image load
           make CRYSTAL_DOCKER_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}-build
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/docs/build
+          destination: build
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/docs/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,6 @@ workflows:
             - dist_linux
             - dist_linux32
             - dist_darwin
-            - dist_docker
             - dist_snap
             - dist_docs
 
@@ -600,7 +599,6 @@ workflows:
             - dist_linux
             - dist_linux32
             - dist_darwin
-            - dist_docker
             - dist_snap
             - dist_docs
 
@@ -680,7 +678,6 @@ workflows:
             - dist_linux
             - dist_linux32
             - dist_darwin
-            - dist_docker
             - dist_snap
             - dist_docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,10 +495,6 @@ workflows:
           filters: *per_tag
       - prepare_common:
           filters: *per_tag
-          requires:
-            - test_linux
-            - test_darwin
-            - check_format
       - prepare_tagged:
           filters: *per_tag
           requires:
@@ -568,11 +564,7 @@ workflows:
       - test_darwin
       - test_preview_mt
       - check_format
-      - prepare_common:
-          requires:
-            - test_linux
-            - test_darwin
-            - check_format
+      - prepare_common
       - prepare_nightly:
           requires:
             - prepare_common
@@ -635,10 +627,6 @@ workflows:
           filters: *maintenance
       - prepare_common:
           filters: *maintenance
-          requires:
-            - test_linux
-            - test_darwin
-            - check_format
       - prepare_maintenance:
           filters: *maintenance
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,19 @@ jobs:
           paths:
             - docs
 
-  test_linux32:
+  test_linux32_std:
     machine: true
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux
       ARCH: i386
       ARCH_CMD: linux32
-    steps: *ci_steps
+    steps:
+      - checkout
+      - run: bin/ci prepare_system
+      - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
+      - run: bin/ci prepare_build
+      - run: bin/ci with_build_env 'make std_spec threads=1'
 
   test_darwin:
     macos:
@@ -405,7 +410,7 @@ workflows:
               ignore:
                 - /release\/.+/
                 - /.*\bci\b.*/
-      - test_linux32:
+      - test_linux32_std:
           filters: *unless_maintenance
       - test_darwin:
           filters: *unless_maintenance
@@ -429,7 +434,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      - test_linux32:
+      - test_linux32_std:
           filters: *per_tag
       - test_darwin:
           filters: *per_tag
@@ -501,7 +506,7 @@ workflows:
                 - master
     jobs:
       - test_linux
-      - test_linux32
+      - test_linux32_std
       - test_darwin
       - test_preview_mt
       - check_format
@@ -557,7 +562,7 @@ workflows:
               only:
                 - /release\/.+/
                 - /.*\bci\b.*/
-      - test_linux32:
+      - test_linux32_std:
           filters: *maintenance
       - test_darwin:
           filters: *maintenance


### PR DESCRIPTION
It seems the CI is able to run the std_specs for 32 bits fine enough when using a released compiler. There is some heavy memory consuming specs. But building the compiler is the thing that often fails. For example when running the run macro to embed tool init .ecr templates. (See #8279 for a potential fix idea)

Meanwhile, we are near to drop 32bits packages (and CI). LLVM 8 is not even available in their apt repo for 32 bits.

Before dropping 32 bits CI (maybe temporarily) this PR introduce a couple of changes and improvements in the CI.

* For 32 bits only std_specs are run
* On nightlies, maintenance, and tagged releases the std_specs are run using the recently built compiler.
  * this recently built compiler fails less often, but there build process is different from the one used to run the per-commit workflow.
* The distributions jobs can start before the test jobs finished. 
  * Darwin builds usually took longer to start, delaying the build queue.
  * Failures along the way might cause longer delays.
* How build output is stored in artifacts also changed a bit
  * docker images dump is no longer persisted (it was never actually used)
  * steps that produce files for the final artifacts are also available in each independent steps.

~~This PR is marked as draft until the [changes in distributions-scripts](https://github.com/crystal-lang/distribution-scripts/pull/48) are merged in master.~~
A sample of the final workflow is already available at https://circleci.com/workflow-run/2fbeef10-7614-4805-aedf-702ab979477b