### PR TITLE
allow to initialize Time::Span only with seconds

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -11,6 +11,9 @@ describe Time::Span do
     t1 = Time::Span.new nanoseconds: 123_456_789_123
     t1.to_s.should eq("00:02:03.456789123")
 
+    t1 = Time::Span.new seconds: 61
+    t1.to_s.should eq("00:01:01")
+
     t1 = Time::Span.new 1, 2, 3
     t1.to_s.should eq("01:02:03")
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -64,7 +64,7 @@ struct Time::Span
     )
   end
 
-  def initialize(*, seconds : Int, nanoseconds : Int)
+  def initialize(*, seconds : Int, nanoseconds : Int = 0)
     # Normalize nanoseconds in the range 0...1_000_000_000
     seconds += nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
     nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND)


### PR DESCRIPTION
This is a really tiny change to allow initialize `Time::Span` only with seconds.