### PR TITLE
Fixes: Can't compile new versions on OpenBSD

### DIFF
--- a/src/thread.cr
+++ b/src/thread.cr
@@ -83,6 +83,8 @@ class Thread
       if ptr = LibC.pthread_getspecific(@@current_key)
         ptr.as(Thread)
       else
+        # Thread#start sets @@current as soon it starts. Thus we know
+        # that if @@current is not set then we are in the main thread
         self.current = new
       end
     end

--- a/src/thread.cr
+++ b/src/thread.cr
@@ -83,7 +83,7 @@ class Thread
       if ptr = LibC.pthread_getspecific(@@current_key)
         ptr.as(Thread)
       else
-        raise "BUG: Thread.current returned NULL"
+        self.current = new
       end
     end
 


### PR DESCRIPTION
Fixes: https://github.com/crystal-lang/crystal/issues/8290

Regression occurred in 573cdc7090a714a3f7617a78f37b5bfa75ef30cf

The common code path was modified to set the current thread in the getter (if not already set) but the corresponding code branch for OpenBSD + Android was not.

Fix tested on OpenBSD.
