### PR TITLE
Faster mutex implementation (optionally reentrant)

### DIFF
--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -7,15 +7,15 @@ describe Mutex do
     mutex.unlock
   end
 
-  it "raises if unlocks without lock" do
-    mutex = Mutex.new
+  it "raises if unlocks without lock (reentrant)" do
+    mutex = Mutex.new(reentrant: true)
     expect_raises(Exception, "Attempt to unlock a mutex which is not locked") do
       mutex.unlock
     end
   end
 
-  it "can be locked many times from the same fiber" do
-    mutex = Mutex.new
+  it "can be locked many times from the same fiber (reentrant)" do
+    mutex = Mutex.new(reentrant: true)
     mutex.lock
     mutex.lock
     mutex.unlock

--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -12,7 +12,7 @@
 class Crystal::OnceState
   @rec = [] of Bool*
   {% if flag?(:preview_mt) %}
-    @mutex = Mutex.new
+    @mutex = Mutex.new(reentrant: true)
   {% end %}
 
   def once(flag : Bool*, initializer : Void*)

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -2,35 +2,71 @@ require "crystal/spin_lock"
 
 # A fiber-safe mutex.
 class Mutex
+  @state = Atomic(Int32).new(0)
   @mutex_fiber : Fiber?
   @lock_count = 0
   @queue = Deque(Fiber).new
+  @queue_count = Atomic(Int32).new(0)
   @lock = Crystal::SpinLock.new
 
-  def lock
-    @lock.lock
-    mutex_fiber = @mutex_fiber
-    current_fiber = Fiber.current
+  def initialize(*, @reentrant = false)
+  end
 
-    if !mutex_fiber
-      @mutex_fiber = current_fiber
-      @lock.unlock
-    elsif mutex_fiber == current_fiber
-      @lock_count += 1 # recursive lock
-      @lock.unlock
-    else
-      @queue << current_fiber
-      @lock.unlock
-      Crystal::Scheduler.reschedule
+  @[AlwaysInline]
+  def lock
+    if @state.swap(1) == 0
+      @mutex_fiber = Fiber.current if @reentrant
+      return
     end
 
+    if @reentrant && @mutex_fiber == Fiber.current
+      @lock_count += 1
+      return
+    end
+
+    lock_slow
     nil
   end
 
-  def unlock
-    @lock.lock
+  @[NoInline]
+  private def lock_slow
+    loop do
+      break if try_lock
 
-    begin
+      @lock.sync do
+        @queue_count.add(1)
+        if @state.get == 0
+          if @state.swap(1) == 0
+            @queue_count.add(-1)
+            @mutex_fiber = Fiber.current
+            return
+          end
+        end
+
+        @queue.push Fiber.current
+      end
+      Crystal::Scheduler.reschedule
+    end
+
+    @mutex_fiber = Fiber.current
+    nil
+  end
+
+  private def try_lock
+    i = 1000
+    while @state.swap(1) != 0
+      while @state.get != 0
+        Intrinsics.pause
+        i &-= 1
+        return false if i == 0
+      end
+    end
+
+    true
+  end
+
+  def unlock
+    if @reentrant
       unless @mutex_fiber == Fiber.current
         raise "Attempt to unlock a mutex which is not locked"
       end
@@ -40,15 +76,26 @@ class Mutex
         return
       end
 
-      if fiber = @queue.try &.shift?
-        @mutex_fiber = fiber
-        fiber.enqueue
-      else
-        @mutex_fiber = nil
-      end
-    ensure
-      @lock.unlock
+      @mutex_fiber = nil
     end
+
+    @state.lazy_set(0)
+
+    if @queue_count.get == 0
+      return
+    end
+
+    fiber = nil
+    @lock.sync do
+      if @queue_count.get == 0
+        return
+      end
+
+      if fiber = @queue.shift?
+        @queue_count.add(-1)
+      end
+    end
+    fiber.enqueue if fiber
 
     nil
   end


### PR DESCRIPTION
I made some improvements in the `Mutex` implementation to optimize the time it takes to lock/unlock and handoff the ownership to waiting fibers.

Current implementation is quite slow (specially in MT mode) because it always tries to be extremely fair by passing the ownership to the first fiber in the waiting queue. But that fiber might be running in a thread that is already sleeping, and waking up threads is costly and slow. So now the fiber is still awaken but it doesn't automatically have the ownership of the lock. Instead it will compete again with other fibers that might not be sleeping yet. Also, the lock will spin some time before sleeping allowing small critical sections to be acquired without passing through the waiting queue at all.

So, the changes included in this PR are:
  * The `lock` will spin some time before sleeping
  * The `Mutex` is not reentrant by default. Reentrancy requires keeping track of the locking mutex. Non-reentrant mutex just stores an atomic bit and it's much faster to "swap" the content than doing an atomic CAS operation.
  * Ownership is not passed to the waiting fibers. They are just awaken and will try again to obtain the lock.
  * An atomic count of the number of waiting fibers is kept, so the lock over the queue can be optimistically skipped. This makes the `unlock` faster if no fibers are waiting.

I was running a benchmark https://gist.github.com/waj/0c4b5835af088e8921fee4cc2c6006ed#file-bm_lock-cr (provided by @carlhoerberg, thanks Carl!) and these are the results:

Before changes:
```
$ crystal run --release bm_lock.cr
Mutex.synchronize  78.03M ( 12.82ns) (± 1.39%)  0.0B/op  fastest

$ crystal run --release -D preview_mt bm_lock.cr
Mutex.synchronize 110.29k (  9.07µs) (± 2.15%)  0.0B/op  fastest
```

After changes:
```
$ bin/crystal run --release bm_lock.cr
Mutex.synchronize 107.36M (  9.31ns) (± 2.08%)  0.0B/op  fastest

$ bin/crystal run --release -D preview_mt bm_lock.cr
Mutex.synchronize  40.15M ( 24.91ns) (±41.89%)  0.0B/op  fastest
```

I was also running another test (https://gist.github.com/waj/0c4b5835af088e8921fee4cc2c6006ed#file-test-mutex-cr) to evaluate the correctness of the mutex:

Before changes:
```
$ crystal run --release test-cr.cr -- 1000000
00:00:00.042806000
4000000

$ crystal run --release -D preview_mt test-cr.cr -- 1000000
00:00:18.215747000
4000000
```

After changes:
```
$ bin/crystal run --release test-cr.cr -- 1000000
00:00:00.029512000
4000000

$ bin/crystal run --release -D preview_mt test-cr.cr -- 1000000
00:00:00.124867000
4000000
```