### PR TITLE
Add class info to not-nil assertion of getter!

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -229,7 +229,7 @@ describe Object do
   describe "getter!" do
     it "uses getter!" do
       obj = TestObject.new
-      expect_raises(NilAssertionError, "getter5 cannot be nil") do
+      expect_raises(NilAssertionError, "TestObject#getter5 cannot be nil") do
         obj.getter5
       end
       obj.getter5 = 5
@@ -240,7 +240,7 @@ describe Object do
 
     it "uses getter! with type declaration" do
       obj = TestObject.new
-      expect_raises(NilAssertionError, "getter6 cannot be nil") do
+      expect_raises(NilAssertionError, "TestObject#getter6 cannot be nil") do
         obj.getter6
       end
       obj.getter6 = 6
@@ -379,7 +379,7 @@ describe Object do
   describe "property!" do
     it "uses property!" do
       obj = TestObject.new
-      expect_raises(NilAssertionError, "property5 cannot be nil") do
+      expect_raises(NilAssertionError, "TestObject#property5 cannot be nil") do
         obj.property5
       end
       obj.property5 = 5
@@ -388,7 +388,7 @@ describe Object do
 
     it "uses property! with type declaration" do
       obj = TestObject.new
-      expect_raises(NilAssertionError, "property6 cannot be nil") do
+      expect_raises(NilAssertionError, "TestObject#property6 cannot be nil") do
         obj.property6
       end
       obj.property6 = 6

--- a/src/object.cr
+++ b/src/object.cr
@@ -489,11 +489,11 @@ class Object
         \{% if name.is_a?(TypeDeclaration) %}
           {{var_prefix}}\{{name}}?
 
-          def {{method_prefix}}\{{name.var.id}}?
+          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}?
             {{var_prefix}}\{{name.var.id}}
           end
 
-          def {{method_prefix}}\{{name.var.id}}
+          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
             if (value = {{var_prefix}}\{{name.var.id}}).nil?
               ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
             else
@@ -620,7 +620,7 @@ class Object
         \{% if name.is_a?(TypeDeclaration) %}
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}}?
+          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}?
             if (value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else
@@ -904,7 +904,7 @@ class Object
         \{% if name.is_a?(TypeDeclaration) %}
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}}
+          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}?
             if (value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else

--- a/src/object.cr
+++ b/src/object.cr
@@ -257,11 +257,12 @@ class Object
     pointerof(x).as(T*).value
   end
 
-  {% for prefixes in { {"", "", "@"}, {"class_", "self.", "@@"} } %}
+  {% for prefixes in { {"", "", "@", "#"}, {"class_", "self.", "@@", "."} } %}
     {%
       macro_prefix = prefixes[0].id
       method_prefix = prefixes[1].id
       var_prefix = prefixes[2].id
+      doc_prefix = prefixes[3].id
     %}
 
     # Defines getter methods for each of the given arguments.
@@ -487,20 +488,31 @@ class Object
       \{% for name in names %}
         \{% if name.is_a?(TypeDeclaration) %}
           {{var_prefix}}\{{name}}?
-          \{% name = name.var %}
-        \{% end %}
 
-        def {{method_prefix}}\{{name.id}}?
-          {{var_prefix}}\{{name.id}}
-        end
-
-        def {{method_prefix}}\{{name.id}}
-          if (\%value = {{var_prefix}}\{{name.id}}).nil?
-            ::raise NilAssertionError.new("\{{name.id}} cannot be nil")
-          else
-            \%value
+          def {{method_prefix}}\{{name.var.id}}?
+            {{var_prefix}}\{{name.var.id}}
           end
-        end
+
+          def {{method_prefix}}\{{name.var.id}}
+            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
+            else
+              value
+            end
+          end
+        \{% else %}
+          def {{method_prefix}}\{{name.id}}?
+            {{var_prefix}}\{{name.id}}
+          end
+
+          def {{method_prefix}}\{{name.id}}
+            if (value = {{var_prefix}}\{{name.id}}).nil?
+              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
+            else
+              value
+            end
+          end
+        \{% end %}
       \{% end %}
     end
 


### PR DESCRIPTION
Continuation of #8200 to address some comments about adding class information. Thought it was a good idea.

The error messages now look like:

```
Class#some_property cannot be nil
Class.some_class_property cannot be nil
```

Added type annotations to generated getter methods when they are available.