### PR TITLE
Fix Channel#close could renqueue select fiber

### DIFF
--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -107,6 +107,30 @@ describe "select" do
     x.should eq 1
   end
 
+  it "select fiber has one chance to be enqueued into scheduler" do
+    ch1 = Channel(Int32).new
+    ch2 = Channel(Int32).new
+    ch3 = Channel(Int32).new
+
+    spawn do
+      select
+      when x = ch1.receive
+      when x = ch2.receive
+      end
+
+      x.should eq(1)
+    end
+
+    spawn do
+      ch1.send 1
+      ch3.send 3
+      ch2.close
+    end
+
+    ch3.receive.should eq(3)
+    Fiber.yield
+  end
+
   it "select same channel multiple times" do
     ch = Channel(Int32).new
 

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -96,13 +96,21 @@ class Channel(T)
       @closed = true
 
       @senders.each do |sender|
-        sender.state_ptr.value = DeliveryState::Closed
-        sender.fiber.enqueue
+        if (select_context = sender.select_context) && !select_context.try_trigger
+          next
+        else
+          sender.state_ptr.value = DeliveryState::Closed
+          sender.fiber.enqueue
+        end
       end
 
       @receivers.each do |receiver|
-        receiver.state_ptr.value = DeliveryState::Closed
-        receiver.fiber.enqueue
+        if (select_context = receiver.select_context) && !select_context.try_trigger
+          next
+        else
+          receiver.state_ptr.value = DeliveryState::Closed
+          receiver.fiber.enqueue
+        end
       end
 
       @senders.clear


### PR DESCRIPTION
refer to #8300 . If the `select_context` has been triggered in other channel, channel will not enqueue the fiber into scheduler. 