### PR TITLE
Fix select with receive? and closed channels

### DIFF
--- a/spec/compiler/normalize/select_spec.cr
+++ b/spec/compiler/normalize/select_spec.cr
@@ -30,7 +30,7 @@ describe "Normalize: case" do
 
   it "normalizes select with else" do
     assert_expand "select; when foo; body; else; baz; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.select({foo_select_action}, true)
+      __temp_1, __temp_2 = ::Channel.non_blocking_select({foo_select_action})
       case __temp_1
       when 0
         body

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -75,6 +75,15 @@ describe Channel do
           typeof(m).should eq(Nil)
         end
       end
+
+      it "raises if channel was closed" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          expect_raises Channel::ClosedError do
+            Channel.select(ch.receive_select_action)
+          end
+        end
+      end
     end
 
     context "receive raise-on-close multi-channel" do

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -82,7 +82,7 @@ describe "unbuffered" do
 
   it "works with select else" do
     ch1 = Channel(Int32).new
-    Channel.select({ch1.receive_select_action}, true).should eq({1, Channel::NotReady})
+    Channel.select({ch1.receive_select_action}, true).should eq({1, Channel::NotReady.new})
   end
 
   it "can send and receive nil" do

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -1,33 +1,9 @@
 require "spec"
+require "./spec_helper"
 
 private def yield_to(fiber)
   Crystal::Scheduler.enqueue(Fiber.current)
   Crystal::Scheduler.resume(fiber)
-end
-
-# Right after executing the block in a spawn,
-# it will wait for the block to finish.
-# If there is an exception in the block it will be
-# re-raised in the current fiber. Ideal for specs.
-private def spawn_and_wait(before : Proc(_), &block : -> _)
-  before_done = Channel(Nil).new
-  done = Channel(Exception?).new
-
-  spawn do
-    begin
-      before_done.receive
-      block.call
-
-      done.send nil
-    rescue e
-      done.send e
-    end
-  end
-
-  parallel(before.call, before_done.send(nil))
-
-  ex = done.receive
-  raise ex if ex
 end
 
 describe Channel do

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -1,41 +1,5 @@
 require "spec"
-
-private class Witness
-  @checked = false
-
-  def check
-    @checked = true
-  end
-
-  def checked?
-    @checked
-  end
-end
-
-private def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block : Witness -> _)
-  before_done = Channel(Nil).new
-  done = Channel(Exception?).new
-  w = Witness.new
-
-  spawn do
-    begin
-      before_done.receive
-      block.call w
-
-      done.send nil
-    rescue e
-      done.send e
-    end
-  end
-
-  parallel(before.call, before_done.send(nil))
-
-  ex = done.receive
-  unless w.checked?
-    fail "Failed to stress expected path", file, line
-  end
-  raise ex if ex
-end
+require "../spec_helper"
 
 describe "select" do
   it "select many receviers" do

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -14,3 +14,73 @@ end
     it(description, file, line, end_line, &block)
   end
 {% end %}
+
+private class Witness
+  @checked = false
+
+  def check
+    @checked = true
+  end
+
+  def checked?
+    @checked
+  end
+end
+
+def spawn_and_wait(before : Proc(_), file = __FILE__, line = __LINE__, &block)
+  spawn_and_check(before, file, line) do |w|
+    block.call
+    w.check
+  end
+end
+
+def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block : Witness -> _)
+  done = Channel(Exception?).new
+  w = Witness.new
+
+  # State of the "before" filter:
+  # 0 - not started
+  # 1 - started
+  # 2 - completed
+  x = Atomic(Int32).new(0)
+
+  before_fiber = spawn do
+    x.set(1)
+
+    # This is a workaround to ensure the "before" fiber
+    # is unscheduled. Otherwise it might stay alive running the event loop
+    spawn(same_thread: true) do
+      while x.get != 2
+        Fiber.yield
+      end
+    end
+
+    before.call
+    x.set(2)
+  end
+
+  spawn do
+    begin
+      # Wait until the "before" fiber starts
+      while x.get == 0
+        Fiber.yield
+      end
+
+      # Now wait until the "before" fiber is blocked
+      while !before_fiber.resumable?
+        Fiber.yield
+      end
+      block.call w
+
+      done.send nil
+    rescue e
+      done.send e
+    end
+  end
+
+  ex = done.receive
+  unless w.checked?
+    fail "Failed to stress expected path", file, line
+  end
+  raise ex if ex
+end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -25,9 +25,7 @@ class Channel(T)
   @lock = Crystal::SpinLock.new
   @queue : Deque(T)?
 
-  module NotReady
-    extend self
-  end
+  record NotReady
 
   module SelectAction(S)
     abstract def execute : S | NotReady
@@ -342,7 +340,7 @@ class Channel(T)
 
     if non_blocking
       ops_locks.each &.unlock
-      return ops.size, NotReady
+      return ops.size, NotReady.new
     end
 
     state = Atomic(SelectState).new(SelectState::Active)
@@ -388,7 +386,7 @@ class Channel(T)
     end
 
     def execute : Channel::NotReady | T
-      @channel.receive_internal { return NotReady }
+      @channel.receive_internal { return NotReady.new }
     end
 
     def result : T
@@ -425,7 +423,7 @@ class Channel(T)
     end
 
     def execute : Channel::NotReady?
-      @channel.send_internal(@value) { return NotReady }
+      @channel.send_internal(@value) { return NotReady.new }
       nil
     end
 

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -277,10 +277,6 @@ class Channel(T)
 
   def self.receive_first(channels : Tuple | Array)
     _, value = self.select(channels.map(&.receive_select_action))
-    if value.is_a?(NotReady)
-      raise "BUG: Channel.select returned not ready status"
-    end
-
     value
   end
 
@@ -298,7 +294,9 @@ class Channel(T)
   end
 
   def self.select(ops : Indexable(SelectAction))
-    select_impl(ops, false)
+    i, m = select_impl(ops, false)
+    raise "BUG: blocking select returned not ready status" if m.is_a?(NotReady)
+    return i, m
   end
 
   @[Deprecated("Use Channel.non_blocking_select")]

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -16,6 +16,11 @@ require "crystal/spin_lock"
 # channel.receive # => 0
 # channel.receive # => 1
 # ```
+#
+# NOTE: Althought a `Channel(Nil)` or any other nilable types like `Channel(Int32?)` are valid
+# they are discouraged since from certain methods or constructs it receiving a `nil` as data
+# will be indistinguishable from a closed channel.
+#
 class Channel(T)
   @lock = Crystal::SpinLock.new
   @queue : Deque(T)?

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -348,7 +348,6 @@ class Channel(T)
     end
 
     ops.each_with_index do |op, index|
-      ignore = false
       result = op.execute
 
       unless result.is_a?(NotReady)

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -120,14 +120,18 @@ class Channel(T)
 
       @senders.each do |sender|
         sender.state_ptr.value = DeliveryState::Closed
-        sender.select_context.try &.try_trigger
-        sender.fiber.enqueue
+        select_context = sender.select_context
+        if select_context.nil? || select_context.try_trigger
+          sender.fiber.enqueue
+        end
       end
 
       @receivers.each do |receiver|
         receiver.state_ptr.value = DeliveryState::Closed
-        receiver.select_context.try &.try_trigger
-        receiver.fiber.enqueue
+        select_context = receiver.select_context
+        if select_context.nil? || select_context.try_trigger
+          receiver.fiber.enqueue
+        end
       end
 
       @senders.clear

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -515,10 +515,10 @@ module Crystal
         case_else = Call.new(nil, "raise", args: [StringLiteral.new("BUG: invalid select index")] of ASTNode, global: true).at(node)
       end
 
+      call_name = node.else ? "non_blocking_select" : "select"
       call_args = [TupleLiteral.new(tuple_values).at(node)] of ASTNode
-      call_args << BoolLiteral.new(true) if node.else
 
-      call = Call.new(channel, "select", call_args).at(node)
+      call = Call.new(channel, call_name, call_args).at(node)
       multi = MultiAssign.new(targets, [call] of ASTNode)
       case_cond = Var.new(index_name).at(node)
       a_case = Case.new(case_cond, case_whens, case_else).at(node)


### PR DESCRIPTION
This PR implements https://gist.github.com/bcardiff/289953a80eb3a0512a2a2f8c8dfeb1db while fixing the behavior of `select` over closed or closing channels.

The main guidance where:

* `Channel#receive` vs `Channel#receive?` differs on their behavior for closed channels. Using them directly is always blocking.
* Performing an operation over a closed and closing the channel during the operation must behave in the same way.

There was a need to extend the design of `SelectAction` and some overload/exceptions were used used to make typing work.
Regarding typing, blocking and non-blocking select have different methods so their typing can differ. Blocking select will never return `NotReady`.

Closes #8301
Fixes #8300
Follow up of https://github.com/crystal-lang/crystal/pull/8243#issuecomment-539686184
