### PR TITLE
Spec: Add ability to randomize specs

### DIFF
--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -1,15 +1,31 @@
 require "./spec_helper"
 
 describe Spec::ExampleGroup do
-  it "#randomize" do
-    root = build_spec("f.cr", count: 20)
+  describe "#randomize" do
+    it "by default" do
+      root = build_spec("f.cr", count: 20)
 
-    before_randomize = all_spec_descriptions(root)
-    root.randomize
-    after_randomize = all_spec_descriptions(root)
+      before_randomize = all_spec_descriptions(root)
+      root.randomize(Random::DEFAULT)
+      after_randomize = all_spec_descriptions(root)
 
-    after_randomize.should_not eq before_randomize
-    after_randomize.sort.should eq before_randomize.sort
+      after_randomize.should_not eq before_randomize
+      after_randomize.sort.should eq before_randomize.sort
+    end
+
+    it "with a seed" do
+      seed = Random::Secure.rand(1..99999).to_u64
+
+      root = build_spec("f.cr", count: 20)
+      root.randomize(Random::PCG32.new(seed))
+      after_randomize1 = all_spec_descriptions(root)
+
+      root = build_spec("f.cr", count: 20)
+      root.randomize(Random::PCG32.new(seed))
+      after_randomize2 = all_spec_descriptions(root)
+
+      after_randomize1.should eq after_randomize2
+    end
   end
 
   describe "#report" do

--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -1,6 +1,17 @@
 require "./spec_helper"
 
 describe Spec::ExampleGroup do
+  it "#randomize" do
+    root = build_spec("f.cr", count: 20)
+
+    before_randomize = all_spec_descriptions(root)
+    root.randomize
+    after_randomize = all_spec_descriptions(root)
+
+    after_randomize.should_not eq before_randomize
+    after_randomize.sort.should eq before_randomize.sort
+  end
+
   describe "#report" do
     it "should include parent's description" do
       root = FakeRootContext.new

--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -14,7 +14,7 @@ describe Spec::ExampleGroup do
     end
 
     it "with a seed" do
-      seed = Random::Secure.rand(1..99999).to_u64
+      seed = 12345_u64
 
       root = build_spec("f.cr", count: 20)
       root.randomize(Random::PCG32.new(seed))

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -79,7 +79,11 @@ require "./spec/dsl"
 # ## Randomizing order of specs
 #
 # Specs, by default, run in the order defined, but can be run in a random order
-# by passing --order random to `crystal spec`.
+# by passing `--order random` to `crystal spec`.
+#
+# Specs run in random order will display a seed value upon completion. This seed
+# value can be used to rerun the specs in that same order by passing the seed
+# value to `--order`.
 module Spec
 end
 
@@ -107,12 +111,13 @@ OptionParser.parse do |opts|
       exit 1
     end
   end
-  opts.on("--order MODE", "run examples in random order by passing MODE as 'random'") do |mode|
-    unless %[default random].includes?(mode)
-      STDERR.puts "order must be either 'default' or 'random'"
+  opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
+    if mode =~ /\A(?:default|random|\d{1,5})\Z/
+      Spec.order = mode
+    else
+      STDERR.puts "order must be either 'default', 'random', or a seed value"
       exit 1
     end
-    Spec.order = mode
   end
   opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
     junit_formatter = Spec::JUnitFormatter.file(output_dir)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -114,11 +114,10 @@ OptionParser.parse do |opts|
   opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
     if mode == "default" || mode == "random"
       Spec.order = mode
-    elsif mode.to_u64?
-      Spec.order = mode.to_u64
+    elsif seed = mode.to_u64?
+      Spec.order = seed
     else
-      STDERR.puts "order must be either 'default', 'random', or a seed value"
-      exit 1
+      abort("order must be either 'default', 'random', or a numeric seed value")
     end
   end
   opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -75,6 +75,11 @@ require "./spec/dsl"
 # ```
 #
 # If any such thing is marked with `focus: true` then only those examples will run.
+#
+# ## Randomizing order of specs
+#
+# Specs, by default, run in the order defined, but can be run in a random order
+# by passing --order random to `crystal spec`.
 module Spec
 end
 
@@ -101,6 +106,13 @@ OptionParser.parse do |opts|
       STDERR.puts "location #{location} must be file:line"
       exit 1
     end
+  end
+  opts.on("--order MODE", "run examples in random order by passing MODE as 'random'") do |mode|
+    unless %[default random].includes?(mode)
+      STDERR.puts "order must be either 'default' or 'random'"
+      exit 1
+    end
+    Spec.order = mode
   end
   opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
     junit_formatter = Spec::JUnitFormatter.file(output_dir)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -112,8 +112,10 @@ OptionParser.parse do |opts|
     end
   end
   opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
-    if mode =~ /\A(?:default|random|\d{1,5})\Z/
+    if mode == "default" || mode == "random"
       Spec.order = mode
+    elsif mode.to_u64?
+      Spec.order = mode.to_u64
     else
       STDERR.puts "order must be either 'default', 'random', or a seed value"
       exit 1

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -5,6 +5,11 @@ module Spec
   abstract class Context
     # All the children, which can be `describe`/`context` or `it`
     getter children = [] of ExampleGroup | Example
+
+    def randomize
+      children.each { |c| c.randomize if c.responds_to?(:randomize) }
+      children.shuffle!
+    end
   end
 
   # :nodoc:

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -7,7 +7,9 @@ module Spec
     getter children = [] of ExampleGroup | Example
 
     def randomize(randomizer)
-      children.each { |c| c.randomize(randomizer) if c.responds_to?(:randomize) }
+      children.each do |child|
+        child.randomize(randomizer) if child.is_a?(ExampleGroup)
+      end
       children.shuffle!(randomizer)
     end
   end

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -6,9 +6,9 @@ module Spec
     # All the children, which can be `describe`/`context` or `it`
     getter children = [] of ExampleGroup | Example
 
-    def randomize
-      children.each { |c| c.randomize if c.responds_to?(:randomize) }
-      children.shuffle!
+    def randomize(randomizer)
+      children.each { |c| c.randomize(randomizer) if c.responds_to?(:randomize) }
+      children.shuffle!(randomizer)
     end
   end
 
@@ -144,6 +144,10 @@ module Spec
       puts "Finished in #{Spec.to_human(elapsed_time)}"
       puts Spec.color("#{total} examples, #{failures.size} failures, #{errors.size} errors, #{pendings.size} pending", final_status)
       puts Spec.color("Only running `focus: true`", :focus) if Spec.focus?
+
+      if randomizer_seed = Spec.randomizer_seed
+        puts Spec.color("Randomized with seed: #{randomizer_seed}", :order)
+      end
 
       unless failures_and_errors.empty?
         puts

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -80,11 +80,11 @@ module Spec
       when UInt64
         mode
       else
-        raise ArgumentError.new("order must be either 'default', 'random', or a seed value")
+        raise ArgumentError.new("order must be either 'default', 'random', or a numeric seed value")
       end
 
     @@randomizer_seed = seed
-    @@randomizer = seed && Random::PCG32.new(seed)
+    @@randomizer = seed ? Random::PCG32.new(seed) : nil
   end
 
   # :nodoc:

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -66,23 +66,25 @@ module Spec
   end
 
   # :nodoc:
-  class_getter randomizer_seed : Int32?
+  class_getter randomizer_seed : UInt64?
   class_getter randomizer : Random::PCG32?
 
   # :nodoc:
   def self.order=(mode)
     seed =
       case mode
+      when "default"
+        nil
       when "random"
-        Random::Secure.rand(1..99999) # 5 digits or less for simplicity
-      when /\A(\d{1,5})\Z/
-        $1.to_i
+        Random::Secure.rand(1..99999).to_u64 # 5 digits or less for simplicity
+      when UInt64
+        mode
+      else
+        raise ArgumentError.new("order must be either 'default', 'random', or a seed value")
       end
 
-    if seed
-      @@randomizer_seed = seed
-      @@randomizer = Random::PCG32.new(seed.to_u64)
-    end
+    @@randomizer_seed = seed
+    @@randomizer = seed && Random::PCG32.new(seed)
   end
 
   # :nodoc:

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -253,9 +253,7 @@ module Spec
     @@start_time = Time.monotonic
 
     at_exit do
-      if randomizer = @@randomizer
-        root_context.randomize(randomizer)
-      end
+      maybe_randomize
       run_filters
       run_before_suite_hooks
       root_context.run
@@ -269,6 +267,13 @@ module Spec
     elapsed_time = Time.monotonic - @@start_time.not_nil!
     root_context.finish(elapsed_time, @@aborted)
     exit 1 if !root_context.succeeded || @@aborted
+  end
+
+  # :nodoc:
+  def self.maybe_randomize
+    if randomizer = @@randomizer
+      root_context.randomize(randomizer)
+    end
   end
 
   # :nodoc:

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -64,6 +64,13 @@ module Spec
     finish_run
   end
 
+  @@order = "default"
+
+  # :nodoc:
+  def self.order=(mode)
+    @@order = mode
+  end
+
   # :nodoc:
   def self.pattern=(pattern)
     @@pattern = Regex.new(Regex.escape(pattern))
@@ -232,6 +239,7 @@ module Spec
     @@start_time = Time.monotonic
 
     at_exit do
+      root_context.randomize if @@order == "random"
       run_filters
       run_before_suite_hooks
       root_context.run


### PR DESCRIPTION
This PR adds the ability to run specs in a random order.  To do so, just pass `--order random` to `crystal spec`.  Randomized specs will output a seed which can be used if the tests need to be run in the same previous random order.  To do so, just pass `--order <seed-value>`.

Default
![crystal 2019-10-11 13-41-07](https://user-images.githubusercontent.com/52120/66672786-174b3900-ec2d-11e9-86fd-55134915051c.png)

With random
![crystal 2019-10-11 16-02-41](https://user-images.githubusercontent.com/52120/66681366-99912880-ec40-11e9-926f-bdeae261fc81.png)

With seed
![crystal 2019-10-11 16-03-33](https://user-images.githubusercontent.com/52120/66681414-b0d01600-ec40-11e9-86f2-c20e23145ced.png)

---

Note that this PR takes some of the test infrastructure stuff I built in #8242 in order to test the randomization.