### PR TITLE
Format: Fix indent in arguments

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1570,4 +1570,19 @@ describe Crystal::Formatter do
     end
     ex.line_number.should eq(5)
   end
+
+  # #8197
+  assert_format <<-CODE
+    foo
+      .foo1(bar
+        .bar1
+        .bar2)
+    CODE
+
+  assert_format <<-CODE
+    foo.foo1(
+      bar
+        .bar1
+        .bar2)
+    CODE
 end


### PR DESCRIPTION
Fixed #8197

Also remove `@multiline_call_indent` trick introduced by #5234.
It was originally introduced for dot alignment as `@dot_column`.
However it is removed and this trick can be implemented without any trick.

Thank you.