### PR TITLE
Parse newline before clsoing paren of pseudo method call

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -941,6 +941,18 @@ module Crystal
       )
     )
 
+    # multiline pseudo methods (#8318)
+    it_parses "sizeof(\n  Int32\n)", SizeOf.new(Path.new("Int32"))
+    it_parses "instance_sizeof(\n  Int32\n)", InstanceSizeOf.new(Path.new("Int32"))
+    it_parses "typeof(\n  1\n)", TypeOf.new([1.int32] of ASTNode)
+    it_parses "offsetof(\n  Foo,\n  @foo\n)", OffsetOf.new(Path.new("Foo"), InstanceVar.new("@foo"))
+    it_parses "pointerof(\n  foo\n)", PointerOf.new("foo".call)
+    it_parses "1.as(\n  Int32\n)", Cast.new(1.int32, Path.new("Int32"))
+    it_parses "1.as?(\n  Int32\n)", NilableCast.new(1.int32, Path.new("Int32"))
+    it_parses "1.is_a?(\n  Int32\n)", IsA.new(1.int32, Path.new("Int32"))
+    it_parses "1.responds_to?(\n  :foo\n)", RespondsTo.new(1.int32, "foo")
+    it_parses "1.nil?(\n)", IsA.new(1.int32, Path.global("Nil"), nil_check: true)
+
     it_parses "/foo/", regex("foo")
     it_parses "/foo/i", regex("foo", Regex::Options::IGNORE_CASE)
     it_parses "/foo/m", regex("foo", Regex::Options::MULTILINE)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -831,7 +831,7 @@ module Crystal
       if @token.type == :"("
         next_token_skip_space_or_newline
         type = parse_single_type
-        skip_space
+        skip_space_or_newline
         check :")"
         next_token_skip_space
       else
@@ -847,7 +847,7 @@ module Crystal
       if @token.type == :"("
         next_token_skip_space_or_newline
         type = parse_single_type
-        skip_space
+        skip_space_or_newline
         check :")"
         end_location = token_end_location
         next_token_skip_space
@@ -4914,6 +4914,9 @@ module Crystal
         exps << parse_op_assign
         if @token.type == :","
           next_token_skip_space_or_newline
+        else
+          skip_space_or_newline
+          check :")"
         end
       end
 
@@ -5440,7 +5443,7 @@ module Crystal
       end
 
       exp = parse_op_assign
-      skip_space
+      skip_space_or_newline
 
       end_location = token_end_location
       check :")"
@@ -5466,7 +5469,7 @@ module Crystal
       location = @token.location
       exp = parse_single_type.at(location)
 
-      skip_space
+      skip_space_or_newline
 
       end_location = token_end_location
       check :")"


### PR DESCRIPTION
Fixed #8318

Note that this fix does not need to modify formatter because all pseudo methods are formatted as if these methods are usual `Call`.