### PR TITLE
Optimize Levenshtein.distance

### DIFF
--- a/spec/std/levenshtein_spec.cr
+++ b/spec/std/levenshtein_spec.cr
@@ -14,6 +14,10 @@ describe "levenshtein" do
   it { Levenshtein.distance("hippo", "zzzzzzzz").should eq(8) }
   it { Levenshtein.distance("hello", "hallo").should eq(1) }
   it { Levenshtein.distance("こんにちは", "こんちは").should eq(1) }
+  it { Levenshtein.distance("한자", "漢字").should eq(2) }
+  it { Levenshtein.distance("abc", "cba").should eq(2) }
+  it { Levenshtein.distance("かんじ", "じんか").should eq(2) }
+  it { Levenshtein.distance("", "かんじ").should eq(3) }
 
   it "finds with finder" do
     finder = Levenshtein::Finder.new "hallo"

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -47,28 +47,29 @@ module Levenshtein
 
       last_cost
     else
-      reader1 = Char::Reader.new(string1)
-      reader2 = Char::Reader.new(string2)
+      reader = Char::Reader.new(string1)
+  
+      # Use an array instead of a reader to decode the string only once
+      chars = string2.chars 
 
       # This is to allocate less memory
       if t_size > s_size
-        reader2, reader1 = reader1, reader2
+        chars, reader = reader, chars
         t_size = s_size
       end
 
       v = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
       last_cost = 1
-      reader1.each do |char1|
+      reader.each do |char1|
         j = 0
-        reader2.each do |char2|
+        chars.each do |char2|
           sub_cost = char1 == char2 ? 0 : 1
           cost = Math.min(Math.min(last_cost, v[j + 1]), v[j] + sub_cost)
           v[j] = last_cost
           last_cost = cost
           j += 1
         end
-        reader2.pos = 0
 
         last_cost += 1
 

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -13,11 +13,11 @@ module Levenshtein
   def self.distance(string1 : String, string2 : String) : Int32
     return 0 if string1 == string2
 
-    s = string1.chars
-    t = string2.chars
+    s = string1.to_unsafe
+    t = string2.to_unsafe
 
-    s_size = s.size
-    t_size = t.size
+    s_size = string1.size
+    t_size = string2.size
 
     return t_size if s_size == 0
     return s_size if t_size == 0

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -29,7 +29,7 @@ module Levenshtein
         t_size, s_size = s_size, t_size
       end
 
-      v = Pointer(Int32).malloc(t_size + 1) { |i| i }
+      costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
       i = 0
       last_cost = 0
@@ -38,11 +38,11 @@ module Levenshtein
 
         t_size.times do |j|
           sub_cost = s[i] == t[j] ? 0 : 1
-          cost = Math.min(Math.min(last_cost + 1, v[j + 1] + 1), v[j] + sub_cost)
-          v[j] = last_cost
+          cost = Math.min(Math.min(last_cost + 1, costs[j + 1] + 1), costs[j] + sub_cost)
+          costs[j] = last_cost
           last_cost = cost
         end
-        v[t_size] = last_cost
+        costs[t_size] = last_cost
       end
 
       last_cost
@@ -58,22 +58,20 @@ module Levenshtein
         t_size = s_size
       end
 
-      v = Pointer(Int32).malloc(t_size + 1) { |i| i }
+      costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
       last_cost = 1
       reader.each do |char1|
-        j = 0
-        chars.each do |char2|
+        chars.each_with_index do |char2, index|
           sub_cost = char1 == char2 ? 0 : 1
-          cost = Math.min(Math.min(last_cost, v[j + 1]), v[j] + sub_cost)
-          v[j] = last_cost
+          cost = Math.min(Math.min(last_cost, costs[index + 1]), costs[index] + sub_cost)
+          costs[index] = last_cost
           last_cost = cost
-          j += 1
         end
 
         last_cost += 1
 
-        v[t_size] = last_cost
+        costs[t_size] = last_cost
       end
 
       last_cost

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -48,9 +48,9 @@ module Levenshtein
       last_cost
     else
       reader = Char::Reader.new(string1)
-  
-      # Use an array instead of a reader to decode the string only once
-      chars = string2.chars 
+
+      # Use an array instead of a reader to decode the second string only once
+      chars = string2.chars
 
       # This is to allocate less memory
       if t_size > s_size

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -31,7 +31,6 @@ module Levenshtein
 
       costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
-      i = 0
       last_cost = 0
       s_size.times do |i|
         last_cost = i + 1

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -19,15 +19,13 @@ module Levenshtein
     return t_size if s_size == 0
     return s_size if t_size == 0
 
-    if string1.ascii_only? && string2.ascii_only?
+    if t_size > s_size
+      string1, string2 = string2, string1
+    end
+    
+    if string1.single_byte_optimizable? && string2.single_byte_optimizable?
       s = string1.to_unsafe
       t = string2.to_unsafe
-
-      # This is to allocate less memory
-      if t_size > s_size
-        t, s = s, t
-        t_size, s_size = s_size, t_size
-      end
 
       costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
@@ -50,12 +48,6 @@ module Levenshtein
 
       # Use an array instead of a reader to decode the second string only once
       chars = string2.chars
-
-      # This is to allocate less memory
-      if t_size > s_size
-        chars, reader = reader, chars
-        t_size = s_size
-      end
 
       costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -19,11 +19,12 @@ module Levenshtein
     return t_size if s_size == 0
     return s_size if t_size == 0
 
+    # This is to allocate less memory
     if t_size > s_size
       string1, string2 = string2, string1
       t_size, s_size = s_size, t_size
     end
-    
+
     if string1.single_byte_optimizable? && string2.single_byte_optimizable?
       s = string1.to_unsafe
       t = string2.to_unsafe

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -25,13 +25,13 @@ module Levenshtein
       t_size, s_size = s_size, t_size
     end
 
+    costs = Slice(Int32).malloc(t_size + 1) { |i| i }
+    last_cost = 0
+
     if string1.single_byte_optimizable? && string2.single_byte_optimizable?
       s = string1.to_unsafe
       t = string2.to_unsafe
 
-      costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
-
-      last_cost = 0
       s_size.times do |i|
         last_cost = i + 1
 
@@ -51,9 +51,6 @@ module Levenshtein
       # Use an array instead of a reader to decode the second string only once
       chars = string2.chars
 
-      costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
-
-      last_cost = 0
       reader.each_with_index do |char1, i|
         last_cost = i + 1
 

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -25,7 +25,7 @@ module Levenshtein
       t_size, s_size = s_size, t_size
     end
 
-    costs = Slice(Int32).malloc(t_size + 1) { |i| i }
+    costs = Slice(Int32).new(t_size + 1) { |i| i }
     last_cost = 0
 
     if string1.single_byte_optimizable? && string2.single_byte_optimizable?

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -21,6 +21,7 @@ module Levenshtein
 
     if t_size > s_size
       string1, string2 = string2, string1
+      t_size, s_size = s_size, t_size
     end
     
     if string1.single_byte_optimizable? && string2.single_byte_optimizable?
@@ -51,17 +52,16 @@ module Levenshtein
 
       costs = Pointer(Int32).malloc(t_size + 1) { |i| i }
 
-      last_cost = 1
-      reader.each do |char1|
-        chars.each_with_index do |char2, index|
+      last_cost = 0
+      reader.each_with_index do |char1, i|
+        last_cost = i + 1
+
+        chars.each_with_index do |char2, j|
           sub_cost = char1 == char2 ? 0 : 1
-          cost = Math.min(Math.min(last_cost, costs[index + 1]), costs[index] + sub_cost)
-          costs[index] = last_cost
+          cost = Math.min(Math.min(last_cost + 1, costs[j + 1] + 1), costs[j] + sub_cost)
+          costs[j] = last_cost
           last_cost = cost
         end
-
-        last_cost += 1
-
         costs[t_size] = last_cost
       end
 


### PR DESCRIPTION
This avoids two expensive array allocations (`.chars`) because the strings can already be accessed directly.
This improves speed and vastly improves memory allocation.

```cr
Benchmark.ips do |bm|
  bm.report "old" do
    Levenshtein.distance("algorithm", "altruistic")
    Levenshtein.distance("hello", "hallo")
    Levenshtein.distance("こんにちは", "こんちは")
    Levenshtein.distance("hey", "hey")
    Levenshtein.distance("hippo", "zzzzzzzz")
    Levenshtein.distance("a" * 100000, "hello")
    Levenshtein.distance("hello", "a" * 100000)
  end

  bm.report "new" do
    Levenshtein.new_distance("algorithm", "altruistic")
    Levenshtein.new_distance("hello", "hallo")
    Levenshtein.new_distance("こんにちは", "こんちは")
    Levenshtein.new_distance("hey", "hey")
    Levenshtein.new_distance("hippo", "zzzzzzzz")
    Levenshtein.new_distance("a" * 100000, "hello")
    Levenshtein.new_distance("hello", "a" * 100000)
  end
end
```
```
old 295.78  (  3.38ms) (± 8.86%)  0.95MB/op   2.26× slower
new 669.21  (  1.49ms) (± 8.87%)   195kB/op        fastest
```