### PR TITLE
[compiler] Fix detect musl libc at runtime

### DIFF
--- a/spec/compiler/config_spec.cr
+++ b/spec/compiler/config_spec.cr
@@ -1,0 +1,14 @@
+require "../spec_helper"
+require "./spec_helper"
+
+describe Crystal::Config do
+  it ".default_target" do
+    Crystal::Config.default_target.should eq Crystal::Codegen::Target.new({{ `crystal --version`.lines[-1] }}.lstrip("Default target: "))
+  end
+
+  {% if flag?(:linux) %}
+    it ".linux_runtime_libc" do
+      Crystal::Config.linux_runtime_libc.should eq {{ flag?(:musl) ? "musl" : "gnu" }}
+    end
+  {% end %}
+end

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -133,4 +133,16 @@ class Crystal::Codegen::Target
   def to_s(io : IO) : Nil
     io << architecture << '-' << vendor << '-' << environment
   end
+
+  def ==(other : self)
+    return false unless architecture == other.architecture
+
+    # If any vendor is unknown, we can skip it. But if both are known, they must
+    # match.
+    if vendor != "unknown" && other.vendor != "unknown"
+      return false unless vendor == other.vendor
+    end
+
+    environment == other.environment
+  end
 end

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -65,7 +65,11 @@ module Crystal
         return "gnu"
       end
 
-      if ldd_version.starts_with?("musl")
+      # Generally, `ldd --version` should print `musl`.
+      # But there is a bug in alpine 3.10 which breaks `ldd --version`.
+      # But detection still works with `-musl`, and it doesn't do harm in other
+      # cases.
+      if ldd_version.starts_with?("musl") || ldd_version.includes?("-musl")
         "musl"
       else
         "gnu"

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -50,14 +50,14 @@ module Crystal
           # in order to use the appropriate environment target.
           default_libc = target.gnu? ? "-gnu" : "-musl"
 
-          target = Crystal::Codegen::Target.new(target.to_s.sub(default_libc, "-#{runtime_libc}"))
+          target = Crystal::Codegen::Target.new(target.to_s.sub(default_libc, "-#{linux_runtime_libc}"))
         end
 
         target
       end
     end
 
-    private def self.runtime_libc
+    def self.linux_runtime_libc
       ldd_version = String.build do |io|
         Process.run("ldd", {"--version"}, output: io, error: io)
       rescue Errno


### PR DESCRIPTION
The output from `ldd --version` is used to determine whether the default target libc is musl or gnu.

On alpine 3.10, the output from `ldd --version` is broken which leads to incorrect detection as gnu.
This regression bug in has been fixed in alpine edge (https://gitlab.alpinelinux.org/alpine/aports/commit/2f2f995d9d52484720dbe8b4b1649c132ec1feee) but it's still in 3.10. This PR fixes that by recognizing the alternative (error) output to successfully detect musl. It's not super important but a small improvement for a specific case.

The second commit adds specs for `Crystal::Config.default_target` which could help detect such issues earlier (assuming we get CI running on musl some time #6943).

Fixes #7926, #8330