### PR TITLE
Add Enumerable#each_cons_pair and Iterator#cons_pair yielding a tuple

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -320,6 +320,14 @@ describe "Enumerable" do
     end
   end
 
+  describe "#each_cons_pair" do
+    it "returns running pairs" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4].each_cons_pair { |a, b| array << [a, b] }
+      array.should eq([[1, 2], [2, 3], [3, 4]])
+    end
+  end
+
   describe "each_slice" do
     it "returns partial slices" do
       array = [] of Array(Int32)

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -235,84 +235,88 @@ describe "Enumerable" do
     end
   end
 
-  describe "each_cons" do
-    it "returns running pairs" do
-      array = [] of Array(Int32)
-      [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
-      array.should eq([[1, 2], [2, 3], [3, 4]])
-    end
-
-    it "returns running triples" do
-      array = [] of Array(Int32)
-      [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
-      array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    end
-
-    it "returns each_cons iterator" do
-      iter = [1, 2, 3, 4, 5].each_cons(3)
-      iter.next.should eq([1, 2, 3])
-      iter.next.should eq([2, 3, 4])
-      iter.next.should eq([3, 4, 5])
-      iter.next.should be_a(Iterator::Stop)
-    end
-
-    it "returns each_cons iterator with reuse = true" do
-      iter = [1, 2, 3, 4, 5].each_cons(3, reuse: true)
-
-      a = iter.next
-      a.should eq([1, 2, 3])
-
-      b = iter.next
-      b.should be(a)
-    end
-
-    it "returns each_cons iterator with reuse = array" do
-      reuse = [] of Int32
-      iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
-
-      a = iter.next
-      a.should eq([1, 2, 3])
-      a.should be(reuse)
-    end
-
-    it "returns each_cons iterator with reuse = deque" do
-      reuse = Deque(Int32).new
-      iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
-
-      a = iter.next
-      a.should eq(Deque{1, 2, 3})
-      a.should be(reuse)
-    end
-
-    it "yields running pairs with reuse = true" do
-      array = [] of Array(Int32)
-      object_ids = Set(UInt64).new
-      [1, 2, 3, 4].each_cons(2, reuse: true) do |pair|
-        object_ids << pair.object_id
-        array << pair.dup
+  describe "#each_cons" do
+    context "iterator" do
+      it "iterates" do
+        iter = [1, 2, 3, 4, 5].each_cons(3)
+        iter.next.should eq([1, 2, 3])
+        iter.next.should eq([2, 3, 4])
+        iter.next.should eq([3, 4, 5])
+        iter.next.should be_a(Iterator::Stop)
       end
-      array.should eq([[1, 2], [2, 3], [3, 4]])
-      object_ids.size.should eq(1)
+
+      it "iterates with reuse = true" do
+        iter = [1, 2, 3, 4, 5].each_cons(3, reuse: true)
+
+        a = iter.next
+        a.should eq([1, 2, 3])
+
+        b = iter.next
+        b.should be(a)
+      end
+
+      it "iterates with reuse = array" do
+        reuse = [] of Int32
+        iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
+
+        a = iter.next
+        a.should eq([1, 2, 3])
+        a.should be(reuse)
+      end
+
+      it "iterates with reuse = deque" do
+        reuse = Deque(Int32).new
+        iter = [1, 2, 3, 4, 5].each_cons(3, reuse: reuse)
+
+        a = iter.next
+        a.should eq(Deque{1, 2, 3})
+        a.should be(reuse)
+      end
     end
 
-    it "yields running pairs with reuse = array" do
-      array = [] of Array(Int32)
-      reuse = [] of Int32
-      [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
-        pair.should be(reuse)
-        array << pair.dup
+    context "yield" do
+      it "returns running pairs" do
+        array = [] of Array(Int32)
+        [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
+        array.should eq([[1, 2], [2, 3], [3, 4]])
       end
-      array.should eq([[1, 2], [2, 3], [3, 4]])
-    end
 
-    it "yields running pairs with reuse = deque" do
-      array = [] of Deque(Int32)
-      reuse = Deque(Int32).new
-      [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
-        pair.should be(reuse)
-        array << pair.dup
+      it "returns running triples" do
+        array = [] of Array(Int32)
+        [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
+        array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
       end
-      array.should eq([Deque{1, 2}, Deque{2, 3}, Deque{3, 4}])
+
+      it "yields running pairs with reuse = true" do
+        array = [] of Array(Int32)
+        object_ids = Set(UInt64).new
+        [1, 2, 3, 4].each_cons(2, reuse: true) do |pair|
+          object_ids << pair.object_id
+          array << pair.dup
+        end
+        array.should eq([[1, 2], [2, 3], [3, 4]])
+        object_ids.size.should eq(1)
+      end
+
+      it "yields running pairs with reuse = array" do
+        array = [] of Array(Int32)
+        reuse = [] of Int32
+        [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
+          pair.should be(reuse)
+          array << pair.dup
+        end
+        array.should eq([[1, 2], [2, 3], [3, 4]])
+      end
+
+      it "yields running pairs with reuse = deque" do
+        array = [] of Deque(Int32)
+        reuse = Deque(Int32).new
+        [1, 2, 3, 4].each_cons(2, reuse: reuse) do |pair|
+          pair.should be(reuse)
+          array << pair.dup
+        end
+        array.should eq([Deque{1, 2}, Deque{2, 3}, Deque{3, 4}])
+      end
     end
   end
 

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -104,7 +104,7 @@ describe Iterator do
     end
   end
 
-  describe "cons" do
+  describe "#cons" do
     it "conses" do
       iter = (1..5).each.cons(3)
       iter.next.should eq([1, 2, 3])
@@ -165,6 +165,17 @@ describe Iterator do
         value.should eq(Deque{3, 4, 5})
         iter.next.should be_a(Iterator::Stop)
       end
+    end
+  end
+
+  describe "#cons_pair" do
+    it "conses" do
+      iter = (1..5).each.cons_pair
+      iter.next.should eq({1, 2})
+      iter.next.should eq({2, 3})
+      iter.next.should eq({3, 4})
+      iter.next.should eq({4, 5})
+      iter.next.should be_a(Iterator::Stop)
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -289,6 +289,10 @@ module Enumerable(T)
   #
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
+  #
+  # Chunks of two items can be iterated using `#each_cons_pair`, an optimized
+  # implementation for the special case of `size == 2` which avoids heap
+  # allocations.
   def each_cons(count : Int, reuse = false)
     raise ArgumentError.new "Invalid cons size: #{count}" if count <= 0
     if reuse.nil? || reuse.is_a?(Bool)
@@ -311,6 +315,40 @@ module Enumerable(T)
       end
     end
     nil
+  end
+
+  # Iterates over the collection yielding pairs of adjacent items,
+  # but advancing one by one.
+  #
+  # ```
+  # [1, 2, 3, 4, 5].each_cons do |a, b|
+  #   puts "#{a}, #{b}"
+  # end
+  # ```
+  #
+  # Prints:
+  #
+  # ```text
+  # 1, 2
+  # 2, 3
+  # 3, 4
+  # 4, 5
+  # ```
+  #
+  # Chunks of more than two items can be iterated using `#each_cons`.
+  # This method is just an optimized implementation for the special case of
+  # `size == 2` to avoid heap allocations.
+  def each_cons_pair(& : (T, T) -> _) : Nil
+    last_elem = uninitialized T
+    first_iteration = true
+    each do |elem|
+      if first_iteration
+        first_iteration = false
+      else
+        yield last_elem, elem
+      end
+      last_elem = elem
+    end
   end
 
   # Iterates over the collection in slices of size *count*,


### PR DESCRIPTION
`Enumerable#each_cons` has a variable chunk size that can be selected dynamically.
This PR adds a special case for the most common use case of iterating over pairs. It simply yields tuples of adjacent items. This avoids heap allocations and makes it easier to use because you don't need to deconstruct an array.

```cr
# new:
[1, 2, 3, 4, 5].each_cons do |a, b|
  puts a * b
end
# old:
[1, 2, 3, 4, 5].each_cons(2, reuse: true) do |pair|
  a, b = pair
  puts a * b
end
```

Benchmark:
```
# iterating over (1..1000).to_a
new 228.27k (  4.38µs) (±17.91%)   0.0B/op        fastest
old  33.13k ( 30.19µs) (± 9.87%)  80.0B/op   6.89× slower
```

It's a convenience feature that also improves performance.

I've added the same behaviour to `Iterator#cons`