### PR TITLE
Use constant for websocket protocol GUID string

### DIFF
--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -8,6 +8,8 @@ require "uri"
 
 # :nodoc:
 class HTTP::WebSocket::Protocol
+  GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
   @[Flags]
   enum Flags : UInt8
     FINAL = 0x80
@@ -301,9 +303,9 @@ class HTTP::WebSocket::Protocol
 
   def self.key_challenge(key)
     {% if flag?(:without_openssl) %}
-      Digest::SHA1.base64digest("#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+      Digest::SHA1.base64digest("#{key}#{GUID}")
     {% else %}
-      Base64.strict_encode(OpenSSL::SHA1.hash("#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+      Base64.strict_encode(OpenSSL::SHA1.hash("#{key}#{GUID}"))
     {% end %}
   end
 end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -303,9 +303,9 @@ class HTTP::WebSocket::Protocol
 
   def self.key_challenge(key)
     {% if flag?(:without_openssl) %}
-      Digest::SHA1.base64digest("#{key}#{GUID}")
+      Digest::SHA1.base64digest(key + GUID)
     {% else %}
-      Base64.strict_encode(OpenSSL::SHA1.hash("#{key}#{GUID}"))
+      Base64.strict_encode(OpenSSL::SHA1.hash(key + GUID))
     {% end %}
   end
 end


### PR DESCRIPTION
I think it would make sense to extract this magic WebSocket protocol string to a constant for clarification.