### PR TITLE
Added String#presence

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -730,6 +730,12 @@ describe "String" do
     it { "hello".blank?.should be_false }
   end
 
+  describe "presence" do
+    it { " \t\n".presence.should be_nil }
+    it { "\u{1680}\u{2029}".presence.should be_nil }
+    it { "hello".presence.should eq("hello") }
+  end
+
   describe "index" do
     describe "by char" do
       it { "foo".index('o').should eq(1) }

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -106,7 +106,7 @@ struct Nil
     raise NilAssertionError.new
   end
 
-  # Returns `self`
+  # Returns `self`.
   # This method enables to call the `presence` method (see `String#presence`) on a union with `Nil`.
   # The idea is to return `nil` when the value is `nil` or empty.
   #

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -112,8 +112,8 @@ struct Nil
   #
   # ```
   # config = {"empty" => ""}
-  # config["empty"]?.presence || "default"   # => "default"
-  # config["missing"]?.presence || "default" # => "default"
+  # config["empty"]?.presence   # => nil
+  # config["missing"]?.presence # => nil
   # ```
   def presence
     self

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -106,6 +106,19 @@ struct Nil
     raise NilAssertionError.new
   end
 
+  # Returns `self`
+  # Added to make the code below compile.
+  #
+  # ```
+  # data = {} of Symbol => String
+  # data[:missing_key]?.presence || "default" # => "default"
+  # ```
+  #
+  # See also: `String#presence`.
+  def presence
+    self
+  end
+
   def clone
     self
   end

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -107,14 +107,14 @@ struct Nil
   end
 
   # Returns `self`
-  # Added to make the code below compile.
+  # This method enables to call the `presence` method (see `String#presence`) on a union with `Nil`.
+  # The idea is to return `nil` when the value is `nil` or empty.
   #
   # ```
-  # data = {} of Symbol => String
-  # data[:missing_key]?.presence || "default" # => "default"
+  # config = {"empty" => ""}
+  # config["empty"]?.presence || "default"   # => "default"
+  # config["missing"]?.presence || "default" # => "default"
   # ```
-  #
-  # See also: `String#presence`.
   def presence
     self
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2405,10 +2405,15 @@ class String
   # Returns `self` if not blank, otherwise returns `nil`.
   #
   # ```
-  # "".presence        # => nil
-  # "   ".presence     # => nil
-  # "   a   ".presence # => "   a   "
+  # "a".presence || "default" # => "a"
+  # "".presence || "default"  # => "default"
+  # nil.presence || "default" # => "default"
+  #
+  # data = {} of Symbol => String
+  # data[:missing_key]?.presence || "default" # => "default"
   # ```
+  #
+  # See also: `Nil#presence`.
   def presence
     self if !blank?
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2405,9 +2405,9 @@ class String
   # Returns `self` if not blank, otherwise returns `nil`.
   #
   # ```
-  # "".presence         # => nil
-  # "   ".presence      # => nil
-  # "   a   ".presence  # => "   a   "
+  # "".presence        # => nil
+  # "   ".presence     # => nil
+  # "   a   ".presence # => "   a   "
   # ```
   def presence
     self if !blank?

--- a/src/string.cr
+++ b/src/string.cr
@@ -2405,12 +2405,15 @@ class String
   # Returns `self` unless `#blank?` is `true` in which case it returns `nil`.
   #
   # ```
-  # "a".presence || "default" # => "a"
-  # "".presence || "default"  # => "default"
-  # nil.presence || "default" # => "default"
+  # "a".presence || "default"         # => "a"
+  # "".presence || "default"          # => "default"
+  # "   ".presence || "default"       # => nil
+  # "    a    ".presence || "default" # => "a"
+  # nil.presence || "default"         # => "default"
   #
-  # data = {} of Symbol => String
-  # data[:missing_key]?.presence || "default" # => "default"
+  # config = {"empty" => ""}
+  # config["empty"]?.presence || "default"   # => "default"
+  # config["missing"]?.presence || "default" # => "default"
   # ```
   #
   # See also: `Nil#presence`.

--- a/src/string.cr
+++ b/src/string.cr
@@ -2402,7 +2402,7 @@ class String
     true
   end
 
-  # Returns `self` if not blank, otherwise returns `nil`.
+  # Returns `self` unless `#blank?` is `true` in which case it returns `nil`.
   #
   # ```
   # "a".presence || "default" # => "a"

--- a/src/string.cr
+++ b/src/string.cr
@@ -2402,6 +2402,17 @@ class String
     true
   end
 
+  # Returns `self` if not blank, otherwise returns `nil`.
+  #
+  # ```
+  # "".presence         # => nil
+  # "   ".presence      # => nil
+  # "   a   ".presence  # => "   a   "
+  # ```
+  def presence
+    self if !blank?
+  end
+
   def ==(other : self)
     return true if same?(other)
     return false unless bytesize == other.bytesize

--- a/src/string.cr
+++ b/src/string.cr
@@ -2414,7 +2414,7 @@ class String
   # ```
   #
   # See also: `Nil#presence`.
-  def presence
+  def presence : self?
     self if !blank?
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -2408,7 +2408,7 @@ class String
   # "a".presence || "default" # => "a"
   # "".presence || "default"  # => "default"
   # "   ".presence            # => nil
-  # "    a    ".presence      # => "a"
+  # "    a    ".presence      # => "    a    "
   # nil.presence              # => nil
   #
   # config = {"empty" => ""}

--- a/src/string.cr
+++ b/src/string.cr
@@ -2405,11 +2405,11 @@ class String
   # Returns `self` unless `#blank?` is `true` in which case it returns `nil`.
   #
   # ```
-  # "a".presence || "default" # => "a"
-  # "".presence || "default"  # => "default"
-  # "   ".presence            # => nil
-  # "    a    ".presence      # => "    a    "
-  # nil.presence              # => nil
+  # "a".presence         # => "a"
+  # "".presence          # => nil
+  # "   ".presence       # => nil
+  # "    a    ".presence # => "    a    "
+  # nil.presence         # => nil
   #
   # config = {"empty" => ""}
   # config["empty"]?.presence || "default"   # => "default"

--- a/src/string.cr
+++ b/src/string.cr
@@ -2405,11 +2405,11 @@ class String
   # Returns `self` unless `#blank?` is `true` in which case it returns `nil`.
   #
   # ```
-  # "a".presence || "default"         # => "a"
-  # "".presence || "default"          # => "default"
-  # "   ".presence || "default"       # => nil
-  # "    a    ".presence || "default" # => "a"
-  # nil.presence || "default"         # => "default"
+  # "a".presence || "default" # => "a"
+  # "".presence || "default"  # => "default"
+  # "   ".presence            # => nil
+  # "    a    ".presence      # => "a"
+  # nil.presence              # => nil
   #
   # config = {"empty" => ""}
   # config["empty"]?.presence || "default"   # => "default"


### PR DESCRIPTION
Added String#presence method that returns `self` if not blank, otherwise it returns `nil`.

Based on ActiveSupport#presence: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/blank.rb#L45

This can be useful for params parsing:

```crystal
state   = params[:state]   if params[:state]
country = params[:country] if params[:country]
region  = state || country || "US"

# becomes

region = params[:state].presence || params[:country].presence || "US"
```
Or for example CSV parsing (to avoid blank strings in DB):

```crystal
flip_record.buyer_first_name = csv["buyerFirstName"].presence
flip_record.buyer_last_name = csv["buyerLastName"].presence
```

Thanks!