### PR TITLE
Array: fix range assignment index out of bounds

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -379,6 +379,30 @@ describe "Array" do
       a[nil..2] = [6, 7]
       a.should eq([6, 7, 4, 5])
     end
+
+    it "replaces entire range with a value for empty array (#8341)" do
+      a = [] of Int32
+      a[..] = 6
+      a.should eq([6])
+    end
+
+    it "pushes a new value with []=(...)" do
+      a = [1, 2, 3]
+      a[3..] = 4
+      a.should eq([1, 2, 3, 4])
+    end
+
+    it "replaces entire range with an array for empty array (#8341)" do
+      a = [] of Int32
+      a[..] = [1, 2, 3]
+      a.should eq([1, 2, 3])
+    end
+
+    it "concats a new array with []=(...)" do
+      a = [1, 2, 3]
+      a[3..] = [4, 5, 6]
+      a.should eq([1, 2, 3, 4, 5, 6])
+    end
   end
 
   describe "values_at" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -400,7 +400,9 @@ class Array(T)
   def []=(index : Int, count : Int, value : T)
     raise ArgumentError.new "Negative count: #{count}" if count < 0
 
-    index = check_index_out_of_bounds index
+    index += size if index < 0
+    raise IndexError.new unless 0 <= index <= size
+
     count = index + count <= size ? count : size - index
 
     case count
@@ -456,7 +458,9 @@ class Array(T)
   def []=(index : Int, count : Int, values : Array(T))
     raise ArgumentError.new "Negative count: #{count}" if count < 0
 
-    index = check_index_out_of_bounds index
+    index += size if index < 0
+    raise IndexError.new unless 0 <= index <= size
+
     count = index + count <= size ? count : size - index
     diff = values.size - count
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -401,6 +401,10 @@ class Array(T)
     raise ArgumentError.new "Negative count: #{count}" if count < 0
 
     index += size if index < 0
+
+    # We allow index == size because the range to replace
+    # can start at exactly the end of the array.
+    # So, we can't use check_index_out_of_bounds.
     raise IndexError.new unless 0 <= index <= size
 
     count = index + count <= size ? count : size - index
@@ -459,6 +463,10 @@ class Array(T)
     raise ArgumentError.new "Negative count: #{count}" if count < 0
 
     index += size if index < 0
+
+    # We allow index == size because the range to replace
+    # can start at exactly the end of the array.
+    # So, we can't use check_index_out_of_bounds.
     raise IndexError.new unless 0 <= index <= size
 
     count = index + count <= size ? count : size - index


### PR DESCRIPTION
Fixes #8341

The main fix is that the `index` that we pass can be the `size` of the Array, because it starts a range from there and it should work if `count` is zero (or a greater value too). The usual `check_index_out_of_bounds` checks for `index < size`, in this case we need `index <= size`.