### PR TITLE
[Compiler] Add sitemap to doc generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ compiler_spec: $(O)/compiler_spec ## Run compiler specs
 
 .PHONY: docs
 docs: ## Generate standard library documentation
-	$(BUILD_PATH) ./bin/crystal docs -b https://crystal-lang.org/api/latest src/docs_main.cr
+	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr
 
 .PHONY: crystal
 crystal: $(O)/crystal ## Build the compiler

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ compiler_spec: $(O)/compiler_spec ## Run compiler specs
 
 .PHONY: docs
 docs: ## Generate standard library documentation
-	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr
+	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS)
 
 .PHONY: crystal
 crystal: $(O)/crystal ## Build the compiler

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -175,8 +175,12 @@ Options:
 .Pp
 .It Fl o Ar DIR, Fl -output Ar DIR
 Set the output directory (default: ./docs).
-.It Fl b Ar URL, Fl -canonical-base-url Ar URL
-Set the canonical base URL.
+.It Fl b Ar URL, Fl -sitemap-base-url Ar URL
+Set the sitemap base URL. Sitemap will only be generated when this option is set.
+.It Fl -sitemap-priority Ar PRIO
+Set the priority assigned to sitemap entries (default: 1.0).
+.It Fl -sitemap-changefreq Ar FREQ
+Set the changefreq assigned to sitemap entries (default: never).
 .El
 .Pp
 .It

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -244,4 +244,22 @@ describe Doc::Generator do
       doc_method.doc.not_nil!.should_not contain %(NOTE: This is a pseudo-method)
     end
   end
+
+  it "generates sitemap" do
+    program = Program.new
+    generator = Doc::Generator.new program, ["."]
+    doc_type = Doc::Type.new generator, program
+
+    Doc::SitemapTemplate.new([doc_type], "http://example.com/api/1.0", "0.8", "monthly").to_s.should eq <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+          <loc>http://example.com/api/1.0/toplevel.html</loc>
+          <priority>0.8</priority>
+          <changefreq>monthly</changefreq>
+        </url>
+      </urlset>
+
+      XML
+  end
 end

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -4,7 +4,7 @@ describe Doc::Generator do
   describe "#must_include_toplevel?" do
     it "returns false if program has nothing" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       generator.must_include_toplevel?(doc_type).should be_false
@@ -12,7 +12,7 @@ describe Doc::Generator do
 
     it "returns true if program has constant" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       constant = Const.new program, program, "Foo", 1.int32
@@ -24,7 +24,7 @@ describe Doc::Generator do
 
     it "returns false if program has constant which is defined in other place" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       constant = Const.new program, program, "Foo", 1.int32
@@ -36,7 +36,7 @@ describe Doc::Generator do
 
     it "returns true if program has macro" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo"
@@ -48,7 +48,7 @@ describe Doc::Generator do
 
     it "returns false if program has macro which is defined in other place" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo"
@@ -60,7 +60,7 @@ describe Doc::Generator do
 
     it "returns true if program has method" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -72,7 +72,7 @@ describe Doc::Generator do
 
     it "returns false if program has method which is defined in other place" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -86,7 +86,7 @@ describe Doc::Generator do
   describe "#collect_constants" do
     it "returns empty array when constants are private" do
       program = Program.new
-      generator = Doc::Generator.new program, ["foo"], ".", "html", nil
+      generator = Doc::Generator.new program, ["foo"]
       doc_type = Doc::Type.new generator, program
 
       constant = Const.new program, program, "Foo", 1.int32
@@ -102,7 +102,7 @@ describe Doc::Generator do
     describe "with a Deprecated annotation, and no docs" do
       it "should generate just the Deprecated tag" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -115,7 +115,7 @@ describe Doc::Generator do
     describe "with a Deprecated annotation, and docs" do
       it "should generate both the docs and Deprecated tag" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -129,7 +129,7 @@ describe Doc::Generator do
     describe "with no annotation, and no docs" do
       it "should generate nothing" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -140,7 +140,7 @@ describe Doc::Generator do
 
     it "should generate the first sentence" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -151,7 +151,7 @@ describe Doc::Generator do
 
     it "should generate the first line" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -165,7 +165,7 @@ describe Doc::Generator do
     describe "with a Deprecated annotation, and no docs" do
       it "should generate just the Deprecated tag" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -178,7 +178,7 @@ describe Doc::Generator do
     describe "with a Deprecated annotation, and docs" do
       it "should generate both the docs and Deprecated tag" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -192,7 +192,7 @@ describe Doc::Generator do
     describe "with no annotation, and no docs" do
       it "should generate nothing" do
         program = Program.new
-        generator = Doc::Generator.new program, ["."], ".", "html", nil
+        generator = Doc::Generator.new program, ["."]
         doc_type = Doc::Type.new generator, program
 
         a_def = Def.new "foo"
@@ -203,7 +203,7 @@ describe Doc::Generator do
 
     it "should generate the full document" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -214,7 +214,7 @@ describe Doc::Generator do
 
     it "should generate the full document" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo"
@@ -227,7 +227,7 @@ describe Doc::Generator do
   describe "crystal repo" do
     it "inserts pseudo methods" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
       generator.is_crystal_repo = true
 

--- a/spec/compiler/crystal/tools/doc/macro_spec.cr
+++ b/spec/compiler/crystal/tools/doc/macro_spec.cr
@@ -4,7 +4,7 @@ describe Doc::Macro do
   describe "args_to_s" do
     it "shows simple args" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg, "bar".arg]
@@ -14,7 +14,7 @@ describe Doc::Macro do
 
     it "shows splat arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg], splat_index: 0
@@ -24,7 +24,7 @@ describe Doc::Macro do
 
     it "shows simple arg and splat arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg, "bar".arg], splat_index: 1
@@ -34,7 +34,7 @@ describe Doc::Macro do
 
     it "shows double splat arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", double_splat: "foo".arg
@@ -44,7 +44,7 @@ describe Doc::Macro do
 
     it "shows double splat arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", double_splat: "foo".arg
@@ -54,7 +54,7 @@ describe Doc::Macro do
 
     it "shows simple arg and double splat arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg], double_splat: "bar".arg
@@ -64,7 +64,7 @@ describe Doc::Macro do
 
     it "shows block arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", block_arg: "foo".arg
@@ -74,7 +74,7 @@ describe Doc::Macro do
 
     it "shows simple arg and block arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg], block_arg: "bar".arg
@@ -84,7 +84,7 @@ describe Doc::Macro do
 
     it "shows external name of arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg(external_name: "bar")]
@@ -94,7 +94,7 @@ describe Doc::Macro do
 
     it "shows external name of arg with quotes and escaping" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg(external_name: "<<-< uouo fish life")]
@@ -104,7 +104,7 @@ describe Doc::Macro do
 
     it "shows default value with highlighting" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_macro = Macro.new "foo", ["foo".arg(default_value: 1.int32)]

--- a/spec/compiler/crystal/tools/doc/method_spec.cr
+++ b/spec/compiler/crystal/tools/doc/method_spec.cr
@@ -4,7 +4,7 @@ describe Doc::Method do
   describe "args_to_s" do
     it "shows simple args" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg, "bar".arg]
@@ -14,7 +14,7 @@ describe Doc::Method do
 
     it "shows splat args" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg], splat_index: 0
@@ -24,7 +24,7 @@ describe Doc::Method do
 
     it "shows underscore restriction" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg(restriction: Crystal::Underscore.new)], splat_index: 0
@@ -34,7 +34,7 @@ describe Doc::Method do
 
     it "shows double splat args" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", double_splat: "foo".arg
@@ -44,7 +44,7 @@ describe Doc::Method do
 
     it "shows block args" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", block_arg: "foo".arg
@@ -54,7 +54,7 @@ describe Doc::Method do
 
     it "shows block args with underscore" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", block_arg: "foo".arg(restriction: Crystal::ProcNotation.new(([Crystal::Underscore.new] of Crystal::ASTNode), Crystal::Underscore.new))
@@ -64,7 +64,7 @@ describe Doc::Method do
 
     it "shows block args if a def has `yield`" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", yields: 1
@@ -74,7 +74,7 @@ describe Doc::Method do
 
     it "shows return type restriction" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", return_type: "Foo".path
@@ -84,7 +84,7 @@ describe Doc::Method do
 
     it "shows args and return type restriction" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg], return_type: "Foo".path
@@ -94,7 +94,7 @@ describe Doc::Method do
 
     it "shows external name of arg" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg(external_name: "bar")]
@@ -104,7 +104,7 @@ describe Doc::Method do
 
     it "shows external name of arg with quotes and escaping" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg(external_name: "<<-< uouo fish life")]
@@ -114,7 +114,7 @@ describe Doc::Method do
 
     it "shows typeof restriction of arg with highlighting" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg(restriction: TypeOf.new([1.int32] of ASTNode))]
@@ -124,7 +124,7 @@ describe Doc::Method do
 
     it "shows default value of arg with highlighting" do
       program = Program.new
-      generator = Doc::Generator.new program, ["."], ".", "html", nil
+      generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
 
       a_def = Def.new "foo", ["foo".arg(default_value: 1.int32)]
@@ -142,7 +142,7 @@ describe Doc::Method do
           end
         end
         ", wants_doc: true).program
-      generator = Doc::Generator.new program, [""], ".", "html", nil
+      generator = Doc::Generator.new program, [""]
       method = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
@@ -162,7 +162,7 @@ describe Doc::Method do
           end
         end
         ", wants_doc: true).program
-      generator = Doc::Generator.new program, [""], ".", "html", nil
+      generator = Doc::Generator.new program, [""]
       method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
       method.doc.should eq("Some docs")
       method.doc_copied_from.should eq(generator.type(program.types["Foo"]))
@@ -180,7 +180,7 @@ describe Doc::Method do
           end
         end
         ", wants_doc: true).program
-      generator = Doc::Generator.new program, [""], ".", "html", nil
+      generator = Doc::Generator.new program, [""]
       method = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
@@ -201,7 +201,7 @@ describe Doc::Method do
           end
         end
         ", wants_doc: true).program
-      generator = Doc::Generator.new program, [""], ".", "html", nil
+      generator = Doc::Generator.new program, [""]
       method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
@@ -226,7 +226,7 @@ describe Doc::Method do
           end
         end
         ", wants_doc: true).program
-      generator = Doc::Generator.new program, [""], ".", "html", nil
+      generator = Doc::Generator.new program, [""]
       method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
       method.doc.should eq("Before\n\nSome docs\n\nAfter")
       method.doc_copied_from.should be_nil

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -23,7 +23,7 @@ describe Doc::Type do
     alias_type = program.types["Alias"]
     alias_type.add_location(Location.new("./foo.cr", 1, 1))
 
-    generator = Doc::Generator.new program, ["."], ".", "html", nil
+    generator = Doc::Generator.new program, ["."]
 
     doc_alias_type = generator.type(alias_type)
     doc_alias_type.types.size.should eq(0)
@@ -39,7 +39,7 @@ describe Doc::Type do
 
     program = result.program
 
-    generator = Doc::Generator.new program, [""], ".", "html", nil
+    generator = Doc::Generator.new program, [""]
     foo = generator.type(program.types["Foo"])
     foo.lookup_class_method("new").should_not be_nil
     foo.lookup_class_method("new", 1).should_not be_nil

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -9,6 +9,9 @@ class Crystal::Command
   private def docs
     output_format = "html"
     output_directory = File.join(".", "docs")
+    sitemap_base_url = nil
+    sitemap_priority = "1.0"
+    sitemap_changefreq = "never"
 
     compiler = Compiler.new
 
@@ -27,10 +30,25 @@ class Crystal::Command
       opts.on("--format=FORMAT", "-f FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
         if !VALID_OUTPUT_FORMATS.includes? value
           STDERR.puts "Invalid format '#{value}'"
-          puts opts
-          exit
+          abort opts
         end
         output_format = value
+      end
+
+      opts.on("--canonical-base-url=URL", "Deprecated option. Use --sitemap-base-url instead.") do |value|
+        abort "Option --canonical-base-url is no longer supported.  Use --sitemap-base-url instead."
+      end
+
+      opts.on("--sitemap-base-url=URL", "-b URL", "Set the sitemap base URL and generates sitemap") do |value|
+        sitemap_base_url = value
+      end
+
+      opts.on("--sitemap-priority=PRIO", "Set the sitemap priority (default: 1.0)") do |value|
+        sitemap_priority = value
+      end
+
+      opts.on("--sitemap-changefreq=FREQ", "Set the sitemap changefreq (default: never)") do |value|
+        sitemap_changefreq = value
       end
 
       opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
@@ -83,6 +101,6 @@ class Crystal::Command
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 
-    Doc::Generator.new(result.program, included_dirs, output_directory, output_format).run
+    Doc::Generator.new(result.program, included_dirs, output_directory, output_format, sitemap_base_url, sitemap_priority, sitemap_changefreq).run
   end
 end

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -9,7 +9,6 @@ class Crystal::Command
   private def docs
     output_format = "html"
     output_directory = File.join(".", "docs")
-    canonical_base_url = nil
 
     compiler = Compiler.new
 
@@ -32,10 +31,6 @@ class Crystal::Command
           exit
         end
         output_format = value
-      end
-
-      opts.on("--canonical-base-url=URL", "-b URL", "Set the canonical base url") do |value|
-        canonical_base_url = value
       end
 
       opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
@@ -88,6 +83,6 @@ class Crystal::Command
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 
-    Doc::Generator.new(result.program, included_dirs, output_directory, output_format, canonical_base_url).run
+    Doc::Generator.new(result.program, included_dirs, output_directory, output_format).run
   end
 end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -28,7 +28,7 @@ class Crystal::Doc::Generator
     },
   }
 
-  def initialize(@program : Program, @included_dirs : Array(String), @output_dir : String, @output_format : String, @canonical_base_url : String?)
+  def initialize(@program : Program, @included_dirs : Array(String), @output_dir : String, @output_format : String)
     @base_dir = Dir.current.chomp
     @types = {} of Crystal::Type => Doc::Type
     @repo_name = ""
@@ -89,7 +89,7 @@ class Crystal::Doc::Generator
     raw_body = read_readme
     body = doc(program_type, raw_body)
 
-    File.write File.join(@output_dir, "index.html"), MainTemplate.new(body, types, repository_name, @canonical_base_url)
+    File.write File.join(@output_dir, "index.html"), MainTemplate.new(body, types, repository_name)
 
     main_index = Main.new(raw_body, Type.new(self, @program), repository_name)
     File.write File.join(@output_dir, "index.json"), main_index
@@ -112,7 +112,7 @@ class Crystal::Doc::Generator
         filename = File.join(dir, "#{type.name}.html")
       end
 
-      File.write filename, TypeTemplate.new(type, all_types, @canonical_base_url)
+      File.write filename, TypeTemplate.new(type, all_types)
 
       next if type.program?
 

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -28,7 +28,12 @@ class Crystal::Doc::Generator
     },
   }
 
-  def initialize(@program : Program, @included_dirs : Array(String), @output_dir : String, @output_format : String)
+  def self.new(program : Program, included_dirs : Array(String))
+    new(program, included_dirs, ".", "html", nil)
+  end
+
+  def initialize(@program : Program, @included_dirs : Array(String),
+                 @output_dir : String, @output_format : String)
     @base_dir = Dir.current.chomp
     @types = {} of Crystal::Type => Doc::Type
     @repo_name = ""

--- a/src/compiler/crystal/tools/doc/html/_head.html
+++ b/src/compiler/crystal/tools/doc/html/_head.html
@@ -1,18 +1,6 @@
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="generator" content="Crystal Docs <%= Crystal::VERSION %>">
 
-<%- if base_url = canonical_base_url -%>
-  <%- if path = type.try(&.path) -%>
-    <%- base_url = File.join(base_url, path) -%>
-  <%- end -%>
-  <link rel="canonical" href="<%= base_url %>">
-<% end -%>
-<%- base_path = type.try(&.path_to("")) -%>
-
-<link href="<%= base_path %>css/style.css" rel="stylesheet" type="text/css">
-
+<link href="<%= base_path %>css/style.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript" src="<%= base_path %>js/doc.js"></script>
-<script type="text/javascript">
-  CrystalDoc.base_path = "<%= base_path %>";
-</script>

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <%= HeadTemplate.new(nil, canonical_base_url) %>
+  <%= HeadTemplate.new("") %>
   <meta id="repository-name" content="<%= repository_name %>">
   <title>README - <%= repository_name %></title>
+  <script type="text/javascript">
+  CrystalDoc.base_path = "";
+  </script>
 </head>
 <body>
 

--- a/src/compiler/crystal/tools/doc/html/sitemap.xml
+++ b/src/compiler/crystal/tools/doc/html/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <% types.each do |type| %><url>
+    <loc><%= ::Path.posix(base_url, type.path) %></loc>
+    <priority><%= priority %></priority>
+    <changefreq><%= changefreq %></changefreq>
+  </url><% end %>
+</urlset>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <%= HeadTemplate.new(type, canonical_base_url) %>
+  <%= HeadTemplate.new(type.path_to "") %>
   <meta id="repository-name" content="<%= type.repository_name %>">
   <title><%= type.full_name %> - <%= type.repository_name %></title>
+  <script type="text/javascript">
+    CrystalDoc.base_path = "<%= type.path_to "" %>";
+  </script>
 </head>
 <body>
 

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -56,4 +56,8 @@ module Crystal::Doc
   struct StyleTemplate
     ECR.def_to_s "#{__DIR__}/html/css/style.css"
   end
+
+  record SitemapTemplate, types : Array(Type), base_url : String, priority : String, changefreq : String do
+    ECR.def_to_s "#{__DIR__}/html/sitemap.xml"
+  end
 end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -1,7 +1,7 @@
 require "ecr/macros"
 
 module Crystal::Doc
-  record TypeTemplate, type : Type, types : Array(Type), canonical_base_url : String? do
+  record TypeTemplate, type : Type, types : Array(Type) do
     ECR.def_to_s "#{__DIR__}/html/type.html"
   end
 
@@ -25,11 +25,11 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/_other_types.html"
   end
 
-  record MainTemplate, body : String, types : Array(Type), repository_name : String, canonical_base_url : String? do
+  record MainTemplate, body : String, types : Array(Type), repository_name : String do
     ECR.def_to_s "#{__DIR__}/html/main.html"
   end
 
-  record HeadTemplate, type : Type?, canonical_base_url : String? do
+  record HeadTemplate, base_path : String do
     ECR.def_to_s "#{__DIR__}/html/_head.html"
   end
 


### PR DESCRIPTION
The doc generator can produce a `sitemap.xml` which lists all HTML pages accessible for search engines. The goal is to use this sitemap to assign lower priorities to outdated doc pages on https://crystal-lang.org/api/ to make the most recent release (`latest`) show up first in search results. See crystal-lang/crystal-website#79 for details. Having such a sitemap is generally useful for shards as well, so it  makes sense to directly integrate it into the docs generator.

Sitemaps are only generated when `--sitemap-base-url=URL` option is set. Sitemaps require absolute paths, so it can't be produced without a base url. Additional options are `--sitemap-priority` and `--sitemap-changefreq` which correspond do the [respective sitemap features](https://www.sitemaps.org/protocol.html#xmlTagDefinitions).

This also reverts #5990 which tried an alternative approach to solving the search priority issue using canonical URLs. But this completely removes older versions from search results.

Ideally, `sitemap.xml` should be compressed, but the compiler is supposed to be built without libz, so this needs to be done separately.