### PR TITLE
Fix formatting issue in crystal init template

### DIFF
--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -7,11 +7,11 @@ TODO: Write a description here
 <%- if config.skeleton_type == "lib" -%>
 1. Add the dependency to your `shard.yml`:
 
-   ```yaml
-   dependencies:
-     <%= config.name %>:
-       github: <%= config.github_name %>/<%= config.name %>
-   ```
+```yaml
+dependencies:
+  <%= config.name %>:
+    github: <%= config.github_name %>/<%= config.name %>
+```
 
 2. Run `shards install`
 <%- else -%>


### PR DESCRIPTION
The template for the `readme.md` file used by `crystal init` had redundant indentation for the first fenced codeblock.

Here's what's generated when that file is read by `crystal docs`:

<img width="1680" alt="before" src="https://user-images.githubusercontent.com/51792731/67138282-78af7100-f206-11e9-92e7-0a5e6a727d7a.png">

And here's the output with the indentation removed:

<img width="1680" alt="after" src="https://user-images.githubusercontent.com/51792731/67138299-a5638880-f206-11e9-9f58-e3ed6822c1b7.png">