### PR TITLE
Add missing LLVM::Attribute members

### DIFF
--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -2,58 +2,62 @@ module LLVM
   {% if LibLLVM.has_constant?(:AttributeRef) %}
     @[Flags]
     enum Attribute : UInt64
-      Alignment                   = 1 << 0
-      AllocSize                   = 1 << 1
-      AlwaysInline                = 1 << 2
-      ArgMemOnly                  = 1 << 3
-      Builtin                     = 1 << 4
-      ByVal                       = 1 << 5
-      Cold                        = 1 << 6
-      Convergent                  = 1 << 7
-      Dereferenceable             = 1 << 8
-      DereferenceableOrNull       = 1 << 9
-      InAlloca                    = 1 << 10
-      InReg                       = 1 << 11
-      InaccessibleMemOnly         = 1 << 12
-      InaccessibleMemOrArgMemOnly = 1 << 13
-      InlineHint                  = 1 << 14
-      JumpTable                   = 1 << 15
-      MinSize                     = 1 << 16
-      Naked                       = 1 << 17
-      Nest                        = 1 << 18
-      NoAlias                     = 1 << 19
-      NoBuiltin                   = 1 << 20
-      NoCapture                   = 1 << 21
-      NoDuplicate                 = 1 << 22
-      NoImplicitFloat             = 1 << 23
-      NoInline                    = 1 << 24
-      NoRecurse                   = 1 << 25
-      NoRedZone                   = 1 << 26
-      NoReturn                    = 1 << 27
-      NoUnwind                    = 1 << 28
-      NonLazyBind                 = 1 << 29
-      NonNull                     = 1 << 30
-      OptimizeForSize             = 1 << 31
-      OptimizeNone                = 1 << 32
-      ReadNone                    = 1 << 33
-      ReadOnly                    = 1 << 34
-      Returned                    = 1 << 35
-      ReturnsTwice                = 1 << 36
-      SExt                        = 1 << 37
-      SafeStack                   = 1 << 38
-      SanitizeAddress             = 1 << 39
-      SanitizeMemory              = 1 << 40
-      SanitizeThread              = 1 << 41
-      StackAlignment              = 1 << 42
-      StackProtect                = 1 << 43
-      StackProtectReq             = 1 << 44
-      StackProtectStrong          = 1 << 45
-      StructRet                   = 1 << 46
-      SwiftError                  = 1 << 47
-      SwiftSelf                   = 1 << 48
-      UWTable                     = 1 << 49
-      WriteOnly                   = 1 << 50
-      ZExt                        = 1 << 51
+      Alignment
+      AllocSize
+      AlwaysInline
+      ArgMemOnly
+      Builtin
+      ByVal
+      Cold
+      Convergent
+      Dereferenceable
+      DereferenceableOrNull
+      InAlloca
+      InReg
+      InaccessibleMemOnly
+      InaccessibleMemOrArgMemOnly
+      InlineHint
+      JumpTable
+      MinSize
+      Naked
+      Nest
+      NoAlias
+      NoBuiltin
+      NoCapture
+      NoDuplicate
+      NoFree
+      NoImplicitFloat
+      NoInline
+      NoRecurse
+      NoRedZone
+      NoReturn
+      NoSync
+      NoUnwind
+      NonLazyBind
+      NonNull
+      OptimizeForSize
+      OptimizeNone
+      ReadNone
+      ReadOnly
+      Returned
+      ImmArg
+      ReturnsTwice
+      SExt
+      SafeStack
+      SanitizeAddress
+      SanitizeMemory
+      SanitizeThread
+      StackAlignment
+      StackProtect
+      StackProtectReq
+      StackProtectStrong
+      StructRet
+      SwiftError
+      SwiftSelf
+      UWTable
+      WillReturn
+      WriteOnly
+      ZExt
 
       @@kind_ids = load_llvm_kinds_from_names.as(Hash(Attribute, UInt32))
 
@@ -97,11 +101,13 @@ module LLVM
         kinds[NoBuiltin] = kind_for_name("nobuiltin")
         kinds[NoCapture] = kind_for_name("nocapture")
         kinds[NoDuplicate] = kind_for_name("noduplicate")
+        kinds[NoFree] = kind_for_name("nofree")
         kinds[NoImplicitFloat] = kind_for_name("noimplicitfloat")
         kinds[NoInline] = kind_for_name("noinline")
         kinds[NoRecurse] = kind_for_name("norecurse")
         kinds[NoRedZone] = kind_for_name("noredzone")
         kinds[NoReturn] = kind_for_name("noreturn")
+        kinds[NoSync] = kind_for_name("nosync")
         kinds[NoUnwind] = kind_for_name("nounwind")
         kinds[NonLazyBind] = kind_for_name("nonlazybind")
         kinds[NonNull] = kind_for_name("nonnull")
@@ -110,6 +116,7 @@ module LLVM
         kinds[ReadNone] = kind_for_name("readnone")
         kinds[ReadOnly] = kind_for_name("readonly")
         kinds[Returned] = kind_for_name("returned")
+        kinds[ImmArg] = kind_for_name("immarg")
         kinds[ReturnsTwice] = kind_for_name("returns_twice")
         kinds[SExt] = kind_for_name("signext")
         kinds[SafeStack] = kind_for_name("safestack")
@@ -124,6 +131,7 @@ module LLVM
         kinds[SwiftError] = kind_for_name("swifterror")
         kinds[SwiftSelf] = kind_for_name("swiftself")
         kinds[UWTable] = kind_for_name("uwtable")
+        kinds[WillReturn] = kind_for_name("willreturn")
         kinds[WriteOnly] = kind_for_name("writeonly")
         kinds[ZExt] = kind_for_name("zeroext")
         kinds


### PR DESCRIPTION
cc @anatol 

Applying this patch (or actually a subset of it, only `ImmArg` needs to be added) should allow building crystal for LLVM 9.

`ImmArg` is set on some function args by default, it can be ignored, just needs to be mapped correctly so as to not fail.

Fixes #8294.