### PR TITLE
Enforce type checking in Hash's methods

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1016,7 +1016,7 @@ class Hash(K, V)
   # h.has_key?("foo") # => true
   # h.has_key?("bar") # => false
   # ```
-  def has_key?(key)
+  def has_key?(key : K)
     !!find_entry(key)
   end
 
@@ -1027,7 +1027,7 @@ class Hash(K, V)
   # h.has_value?("foo") # => false
   # h.has_value?("bar") # => true
   # ```
-  def has_value?(val)
+  def has_value?(val : V)
     each_value do |value|
       return true if value == val
     end
@@ -1042,7 +1042,7 @@ class Hash(K, V)
   # h.fetch("foo", "foo") # => "bar"
   # h.fetch("bar", "foo") # => "foo"
   # ```
-  def fetch(key, default)
+  def fetch(key : K, default)
     fetch(key) { default }
   end
 
@@ -1054,7 +1054,7 @@ class Hash(K, V)
   # h.fetch("bar") { "default value" }  # => "default value"
   # h.fetch("bar") { |key| key.upcase } # => "BAR"
   # ```
-  def fetch(key)
+  def fetch(key : K)
     entry = find_entry(key)
     entry ? entry.value : yield key
   end
@@ -1077,7 +1077,7 @@ class Hash(K, V)
   # hash.key_for("qux")    # => "baz"
   # hash.key_for("foobar") # raises KeyError (Missing hash key for value: foobar)
   # ```
-  def key_for(value)
+  def key_for(value : V)
     key_for(value) { raise KeyError.new "Missing hash key for value: #{value}" }
   end
 
@@ -1089,7 +1089,7 @@ class Hash(K, V)
   # hash.key_for?("qux")    # => "baz"
   # hash.key_for?("foobar") # => nil
   # ```
-  def key_for?(value)
+  def key_for?(value : V)
     key_for(value) { nil }
   end
 
@@ -1100,7 +1100,7 @@ class Hash(K, V)
   # hash.key_for("bar") { |value| value.upcase } # => "foo"
   # hash.key_for("qux") { |value| value.upcase } # => "QUX"
   # ```
-  def key_for(value)
+  def key_for(value : V)
     each do |k, v|
       return k if v == value
     end
@@ -1114,7 +1114,7 @@ class Hash(K, V)
   # h.delete("foo")     # => "bar"
   # h.fetch("foo", nil) # => nil
   # ```
-  def delete(key)
+  def delete(key : K)
     delete(key) { nil }
   end
 
@@ -1126,7 +1126,7 @@ class Hash(K, V)
   # h.fetch("foo", nil)                          # => nil
   # h.delete("baz") { |key| "#{key} not found" } # => "baz not found"
   # ```
-  def delete(key)
+  def delete(key : K)
     entry = delete_impl(key)
     entry ? entry.value : yield key
   end
@@ -1298,7 +1298,7 @@ class Hash(K, V)
   # h.key_index("foo") # => 0
   # h.key_index("qux") # => nil
   # ```
-  def key_index(key)
+  def key_index(key : K)
     each_with_index do |(my_key, my_value), index|
       return index if key == my_key
     end
@@ -1406,7 +1406,7 @@ class Hash(K, V)
   # h = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.reject!("a", "c")
   # h # => {"b" => 2, "d" => 4}
   # ```
-  def reject!(keys : Array | Tuple)
+  def reject!(keys : Array(K) | Tuple)
     keys.each { |k| delete(k) }
     self
   end
@@ -1420,7 +1420,7 @@ class Hash(K, V)
   # ```
   # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select("a", "c") # => {"a" => 1, "c" => 3}
   # ```
-  def select(keys : Array | Tuple)
+  def select(keys : Array(K) | Tuple)
     hash = {} of K => V
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
@@ -1436,7 +1436,7 @@ class Hash(K, V)
   # h = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select!("a", "c")
   # h # => {"a" => 1, "c" => 3}
   # ```
-  def select!(keys : Array | Tuple)
+  def select!(keys : Array(K) | Tuple)
     each { |k, v| delete(k) unless keys.includes?(k) }
     self
   end


### PR DESCRIPTION
Noticed that I had a bug similar to this that went undetected for a while in my code: 

```crystal
h = Hash(String, String).new
h.delete(1)
```

This PR enforces type checking on most public methods in `Hash` to catch above bugs at compile time. 
