### PR TITLE
Add --mcmodel option to compiler

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -132,6 +132,8 @@ Pass additional flags to the linker. Though you can specify those flags on the s
 Specify a specific CPU to generate code for. This will pass a -mcpu flag to LLVM, and is only intended to be used for cross-compilation. For a list of available CPUs, invoke "llvm-as < /dev/null | llc -march=xyz -mcpu=help".
 .It Fl -mattr Ar CPU
 Override or control specific attributes of the target, such as whether SIMD operations are enabled or not. The default set of attributes is set by the current CPU. This will pass a -mattr flag to LLVM, and is only intended to be used for cross-compilation. For a list of available attributes, invoke "llvm-as < /dev/null | llc -march=xyz -mattr=help".
+.It Fl -mcmodel default|kernel|small|medium|large
+Specifies a specific code model to generate code for. This will pass a --code-model flag to LLVM.
 .It Fl -no-color
 Disable colored output.
 .It Fl -no-codegen

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -105,7 +105,8 @@ class Crystal::Codegen::Target
     environment_parts.includes?("gnueabihf") || environment_parts.includes?("musleabihf")
   end
 
-  def to_target_machine(cpu = "", features = "", release = false) : LLVM::TargetMachine
+  def to_target_machine(cpu = "", features = "", release = false,
+                        code_model = LLVM::CodeModel::Default) : LLVM::TargetMachine
     case @architecture
     when "i386", "x86_64"
       LLVM.init_x86
@@ -127,7 +128,7 @@ class Crystal::Codegen::Target
     opt_level = release ? LLVM::CodeGenOptLevel::Aggressive : LLVM::CodeGenOptLevel::None
 
     target = LLVM::Target.from_triple(self.to_s)
-    target.create_target_machine(self.to_s, cpu: cpu, features: features, opt_level: opt_level).not_nil!
+    target.create_target_machine(self.to_s, cpu: cpu, features: features, opt_level: opt_level, code_model: code_model).not_nil!
   end
 
   def to_s(io : IO) : Nil

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -550,7 +550,7 @@ class Crystal::Command
                             Crystal::Warnings::None
                           else
                             error "--warnings should be all, or none"
-                            raise "unreachable"
+                            exit 1
                           end
     end
     opts.on("--error-on-warnings", "Treat warnings as errors.") do |w|

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -366,16 +366,11 @@ class Crystal::Command
         end
         opts.on("--mcmodel MODEL", "Target specific code model") do |mcmodel|
           compiler.mcmodel = case mcmodel
-                             when "default"
-                               LLVM::CodeModel::Default
-                             when "small"
-                               LLVM::CodeModel::Small
-                             when "kernel"
-                               LLVM::CodeModel::Kernel
-                             when "medium"
-                               LLVM::CodeModel::Medium
-                             when "large"
-                               LLVM::CodeModel::Large
+                             when "default" then LLVM::CodeModel::Default
+                             when "small"   then LLVM::CodeModel::Small
+                             when "kernel"  then LLVM::CodeModel::Kernel
+                             when "medium"  then LLVM::CodeModel::Medium
+                             when "large"   then LLVM::CodeModel::Large
                              else
                                error "--mcmodel should be one of: default, kernel, small, medium, large"
                                raise "unreachable"

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -364,7 +364,7 @@ class Crystal::Command
         opts.on("--mattr CPU", "Target specific features") do |features|
           compiler.mattr = features
         end
-        opts.on("--mcmodel CPU", "Target specific code model") do |mcmodel|
+        opts.on("--mcmodel MODEL", "Target specific code model") do |mcmodel|
           compiler.mcmodel = case mcmodel
                              when "default"
                                LLVM::CodeModel::Default

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -550,7 +550,7 @@ class Crystal::Command
                             Crystal::Warnings::None
                           else
                             error "--warnings should be all, or none"
-                            exit 1
+                            raise "unreachable"
                           end
     end
     opts.on("--error-on-warnings", "Treat warnings as errors.") do |w|

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -364,6 +364,23 @@ class Crystal::Command
         opts.on("--mattr CPU", "Target specific features") do |features|
           compiler.mattr = features
         end
+        opts.on("--mcmodel CPU", "Target specific code model") do |mcmodel|
+          compiler.mcmodel = case mcmodel
+            when "default"
+              LLVM::CodeModel::Default
+            when "small"
+              LLVM::CodeModel::Small
+            when "kernel"
+              LLVM::CodeModel::Kernel
+            when "medium"
+              LLVM::CodeModel::Medium
+            when "large"
+              LLVM::CodeModel::Large
+            else
+              error "--mcmodel should be one of: default, kernel, small, medium, large"
+              raise "unreachable"
+            end
+        end
         setup_compiler_warning_options(opts, compiler)
       end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -366,20 +366,20 @@ class Crystal::Command
         end
         opts.on("--mcmodel CPU", "Target specific code model") do |mcmodel|
           compiler.mcmodel = case mcmodel
-            when "default"
-              LLVM::CodeModel::Default
-            when "small"
-              LLVM::CodeModel::Small
-            when "kernel"
-              LLVM::CodeModel::Kernel
-            when "medium"
-              LLVM::CodeModel::Medium
-            when "large"
-              LLVM::CodeModel::Large
-            else
-              error "--mcmodel should be one of: default, kernel, small, medium, large"
-              raise "unreachable"
-            end
+                             when "default"
+                               LLVM::CodeModel::Default
+                             when "small"
+                               LLVM::CodeModel::Small
+                             when "kernel"
+                               LLVM::CodeModel::Kernel
+                             when "medium"
+                               LLVM::CodeModel::Medium
+                             when "large"
+                               LLVM::CodeModel::Large
+                             else
+                               error "--mcmodel should be one of: default, kernel, small, medium, large"
+                               raise "unreachable"
+                             end
         end
         setup_compiler_warning_options(opts, compiler)
       end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -84,6 +84,9 @@ module Crystal
     # If `true`, runs LLVM optimizations.
     property? release = false
 
+    # Sets the code model. Check LLVM docs to learn about this.
+    property mcmodel = LLVM::CodeModel::Default
+
     # If `true`, generates a single LLVM module. By default
     # one LLVM module is created for each type in a program.
     property? single_module = false
@@ -249,7 +252,7 @@ module Crystal
 
     private def bc_flags_changed?(output_dir)
       bc_flags_changed = true
-      current_bc_flags = "#{@codegen_target}|#{@mcpu}|#{@mattr}|#{@release}|#{@link_flags}"
+      current_bc_flags = "#{@codegen_target}|#{@mcpu}|#{@mattr}|#{@release}|#{@link_flags}|#{@mcmodel}"
       bc_flags_filename = "#{output_dir}/bc_flags"
       if File.file?(bc_flags_filename)
         previous_bc_flags = File.read(bc_flags_filename).strip
@@ -521,7 +524,7 @@ module Crystal
     end
 
     getter(target_machine : LLVM::TargetMachine) do
-      @codegen_target.to_target_machine(@mcpu || "", @mattr || "", @release)
+      @codegen_target.to_target_machine(@mcpu || "", @mattr || "", @release, @mcmodel)
     rescue ex : ArgumentError
       stderr.print colorize("Error: ").red.bold
       stderr.print "llc: "


### PR DESCRIPTION
This patch adds a compiler option to specify the target code model.