### PR TITLE
Fix method names incorrectly stripped in doc generator

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -231,11 +231,17 @@ describe Doc::Generator do
       doc_type = Doc::Type.new generator, program
       generator.is_crystal_repo = true
 
-      a_def = Def.new "__crystal_pseudo_foo"
-      a_def.doc = "Foo"
-      doc_method = Doc::Method.new generator, doc_type, a_def, false
-      doc_method.name.should eq "foo"
+      pseudo_def = Def.new "__crystal_pseudo_typeof"
+      pseudo_def.doc = "Foo"
+      doc_method = Doc::Method.new generator, doc_type, pseudo_def, false
+      doc_method.name.should eq "typeof"
       doc_method.doc.not_nil!.should contain %(NOTE: This is a pseudo-method)
+
+      regular_def = Def.new "pseudo_bar"
+      regular_def.doc = "Foo"
+      doc_method = Doc::Method.new generator, doc_type, regular_def, false
+      doc_method.name.should eq "pseudo_bar"
+      doc_method.doc.not_nil!.should_not contain %(NOTE: This is a pseudo-method)
     end
   end
 end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -21,7 +21,7 @@ class Crystal::Doc::Method
   def name
     name = @def.name
     if @generator.is_crystal_repo
-      name.lstrip(PSEUDO_METHOD_PREFIX)
+      name.lchop(PSEUDO_METHOD_PREFIX)
     else
       name
     end


### PR DESCRIPTION
Fixes a bug introduced in #8327 by confusing `String#lstrip` and `String#lchop` 🙄 