### PR TITLE
Add missing documentation for ArrayLiteral.reduce with memo

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -580,6 +580,7 @@ module Crystal
 
       it "executes reduce with initial value" do
         assert_macro "", %({{[1, 2, 3].reduce(4) { |acc, val| acc * val }}}), [] of ASTNode, "24"
+        assert_macro "", %({{[1, 2, 3].reduce([] of NumberLiteral) { |acc, val| acc = [val]+acc }}}), [] of ASTNode, "[3, 2, 1]"
       end
 
       it "executes map with constants" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -634,6 +634,10 @@ module Crystal::Macros
     def reduce(&block) : ASTNode
     end
 
+    # Similar to `Enumerable#reduce`
+    def reduce(memo : ASTNode, &block) : ASTNode
+    end
+
     # Similar to `Array#shuffle`
     def shuffle : ArrayLiteral
     end


### PR DESCRIPTION
Hi, i found while writing macros that ArrayLiteral don't have reduce method that would allow me to pass initial value. Until i try it, and voilà, it worked. So i look into the spec and there's even a test for it. So it's only missing in generated docs here: https://crystal-lang.org/api/Crystal/Macros.html. So i add it to the definition. As bonus i add test similar to Enumerable, see my other PR  #8378.

Related to #8377.