### PR TITLE
Change `&block` to `&` for yielding method in docs

### DIFF
--- a/spec/compiler/crystal/tools/doc/method_spec.cr
+++ b/spec/compiler/crystal/tools/doc/method_spec.cr
@@ -69,7 +69,7 @@ describe Doc::Method do
 
       a_def = Def.new "foo", yields: 1
       doc_method = Doc::Method.new generator, doc_type, a_def, false
-      doc_method.args_to_s.should eq("(&block)")
+      doc_method.args_to_s.should eq("(&)")
     end
 
     it "shows return type restriction" do

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -244,7 +244,7 @@ class Crystal::Doc::Method
         arg_to_html block_arg, io, links: links
       elsif @def.yields
         io << ", " if printed
-        io << "&block"
+        io << '&'
       end
       io << ')'
     end


### PR DESCRIPTION
Since https://github.com/crystal-lang/crystal/pull/8117 is merged, anonymous block arguments can be `&` instead of `&block`, including in docs.