### PR TITLE
Implement string interpolation as a call to String.interpolation

### DIFF
--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -2,13 +2,7 @@ require "../../spec_helper"
 
 describe "Normalize: string interpolation" do
   it "normalizes string interpolation" do
-    assert_expand "\"foo\#{bar}baz\"", "(((::String::Builder.new << \"foo\") << bar) << \"baz\").to_s"
-  end
-
-  it "normalizes string interpolation with long string" do
-    s = "*" * 200
-    assert_expand "\"foo\#{bar}#{s}\"",
-      "((((::String::Builder.new(218)) << \"foo\") << bar) << \"#{s}\").to_s"
+    assert_expand %("foo\#{bar}baz"), %(::String.interpolation("foo", bar, "baz"))
   end
 
   it "normalizes heredoc" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2511,4 +2511,31 @@ describe "String" do
       "hello".scrub.should eq("hello")
     end
   end
+
+  describe "interpolation" do
+    it "of a single string" do
+      string = "hello"
+      String.interpolation(string).should be(string)
+    end
+
+    it "of a single non-string" do
+      String.interpolation(123).should eq("123")
+    end
+
+    it "of string and char" do
+      String.interpolation("hello", '!').should eq("hello!")
+    end
+
+    it "of char and string" do
+      String.interpolation('!', "hello").should eq("!hello")
+    end
+
+    it "of multiple strings" do
+      String.interpolation("a", "bcd", "ef").should eq("abcdef")
+    end
+
+    it "of multiple possibly non-strings" do
+      String.interpolation("a", 123, "b", 456, "cde").should eq("a123b456cde")
+    end
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2516,8 +2516,7 @@ describe "String" do
     it "of a single string" do
       string = "hello"
       interpolated = String.interpolation(string)
-      interpolated.should_not be(string)
-      interpolated.should eq(string)
+      interpolated.should be(string)
     end
 
     it "of a single non-string" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2515,7 +2515,9 @@ describe "String" do
   describe "interpolation" do
     it "of a single string" do
       string = "hello"
-      String.interpolation(string).should be(string)
+      interpolated = String.interpolation(string)
+      interpolated.should_not be(string)
+      interpolated.should eq(string)
     end
 
     it "of a single non-string" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -4438,11 +4438,15 @@ class String
   # "#{value}" # same as String.interpolation(value)
   # ```
   #
-  # In this case the implementation just returns the same string value.
+  # In this case the implementation just returns a new string with the contents
+  # of `value`.
   #
   # NOTE: there should never be a need to call this method instead of using string interpolation.
   def self.interpolation(value : String)
-    value
+    String.new(value.bytesize) do |buffer|
+      buffer.copy_from(value.to_unsafe, value.bytesize)
+      {value.bytesize, value.size_known? ? value.size : 0}
+    end
   end
 
   # Implementation of string interpolation of a single non-string value.

--- a/src/string.cr
+++ b/src/string.cr
@@ -4438,15 +4438,11 @@ class String
   # "#{value}" # same as String.interpolation(value)
   # ```
   #
-  # In this case the implementation just returns a new string with the contents
-  # of `value`.
+  # In this case the implementation just returns the same string.
   #
   # NOTE: there should never be a need to call this method instead of using string interpolation.
   def self.interpolation(value : String)
-    String.new(value.bytesize) do |buffer|
-      buffer.copy_from(value.to_unsafe, value.bytesize)
-      {value.bytesize, value.size_known? ? value.size : 0}
-    end
+    value
   end
 
   # Implementation of string interpolation of a single non-string value.

--- a/src/string.cr
+++ b/src/string.cr
@@ -4471,7 +4471,7 @@ class String
   #
   # ```
   # char = '!'
-  # "hello#{value}" # same as String.interpolation("hello", char)
+  # "hello#{char}" # same as String.interpolation("hello", char)
   # ```
   #
   # In this case the implementation just does `value + char`.


### PR DESCRIPTION
Before this PR, a string interpolation like:

```crystal
"hello #{world}!"
```

was roughly expanded to:

```crystal
String.build do |io|
  io << "hello "
  io << world
  io << "!"
end
```

In this PR it's expanded to:

```crystal
String.interpolation("hello ", world, "!")
```

The benefits of doing this are:
- We can change how string interpolation works without modifying the compiler: we just need to modify the definition of `String.interpolation`
- The way string interpolation works is more visible: anyone can go to the source code and see how it's done, in Crystal, instead of looking at the compiler's source code
- We can provide optimized overloads. Right now there are a few:
  - when interpolating a single string value, like `"#{value}"`, we return the same `value`. This is uncommon, but why not?
  - similarly, interpolating a single non-string value just calls `to_s` on it: much more efficient than using `String.build`
  - when interpolating multiple strings we can precompute the total bytesize, something that the `String.build` approach can't do
  - when interpolating a char at the beginning or end we use `+` (uncommon, but why not?)
- Eliminates [discussions](https://github.com/crystal-lang/crystal/pull/8339#discussion_r335447286) like "Instead of doing `"foo#{bar}"` you should do `"foo" + bar`". String interpolation will provide the most performant implementation, always (and I plan to further optimize this by inlining constants if possible, but in a separate PR).

A small benchmark:

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("interpolation") do
    var1 = "hello"
    var2 = "world"
    "foo #{var1} bar #{var2} baz"
  end
end
```

Results:

```
before: interpolation   8.51M (117.49ns) (± 4.86%)  224B/op  fastest
after:  interpolation  21.81M ( 45.85ns) (± 3.71%)  48.0B/op  fastest
```