### PR TITLE
ARGF: remove unnecessary operations about `read_count`.

### DIFF
--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -83,9 +83,7 @@ class IO::ARGF < IO
           @current_io = nil
         else
           read_next_argv
-          slice += read_count
-          count -= read_count
-          read_count += read slice[0, count]
+          read_count = read slice[0, count]
         end
       end
     end


### PR DESCRIPTION
Because of the condition at line 79, `read_count` is always 0 in this branch.

I think some operations are unnecessary.