### PR TITLE
JSON/YAML: add `use_discriminator`

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -328,6 +328,25 @@ struct JSONAttrPersonWithYAMLInitializeHook
   end
 end
 
+abstract class JSONShape
+  include JSON::Serializable
+
+  use_discriminator "type", {point: JSONPoint, circle: JSONCircle}
+
+  property type : String
+end
+
+class JSONPoint < JSONShape
+  property x : Int32
+  property y : Int32
+end
+
+class JSONCircle < JSONShape
+  property x : Int32
+  property y : Int32
+  property radius : Int32
+end
+
 describe "JSON mapping" do
   it "works with record" do
     JSONAttrPoint.new(1, 2).to_json.should eq "{\"x\":1,\"y\":2}"
@@ -809,5 +828,30 @@ describe "JSON mapping" do
 
     JSONAttrPersonWithYAMLInitializeHook.from_json(person.to_json).msg.should eq "Hello Vasya"
     JSONAttrPersonWithYAMLInitializeHook.from_yaml(person.to_yaml).msg.should eq "Hello Vasya"
+  end
+
+  describe "use_discriminator" do
+    it "deserializes with discriminator" do
+      point = JSONShape.from_json(%({"type": "point", "x": 1, "y": 2})).as(JSONPoint)
+      point.x.should eq(1)
+      point.y.should eq(2)
+
+      circle = JSONShape.from_json(%({"type": "circle", "x": 1, "y": 2, "radius": 3})).as(JSONCircle)
+      circle.x.should eq(1)
+      circle.y.should eq(2)
+      circle.radius.should eq(3)
+    end
+
+    it "raises if missing discriminator" do
+      expect_raises(JSON::MappingError, "Missing JSON discriminator field 'type'") do
+        JSONShape.from_json("{}")
+      end
+    end
+
+    it "raises if unknown discriminator value" do
+      expect_raises(JSON::MappingError, %(Unknown 'type' discriminator value: "unknown")) do
+        JSONShape.from_json(%({"type": "unknown"}))
+      end
+    end
   end
 end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -331,7 +331,7 @@ end
 abstract class JSONShape
   include JSON::Serializable
 
-  use_discriminator "type", {point: JSONPoint, circle: JSONCircle}
+  use_json_discriminator "type", {point: JSONPoint, circle: JSONCircle}
 
   property type : String
 end
@@ -830,7 +830,7 @@ describe "JSON mapping" do
     JSONAttrPersonWithYAMLInitializeHook.from_yaml(person.to_yaml).msg.should eq "Hello Vasya"
   end
 
-  describe "use_discriminator" do
+  describe "use_json_discriminator" do
     it "deserializes with discriminator" do
       point = JSONShape.from_json(%({"type": "point", "x": 1, "y": 2})).as(JSONPoint)
       point.x.should eq(1)

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -288,7 +288,7 @@ end
 abstract class YAMLShape
   include YAML::Serializable
 
-  use_discriminator "type", {point: YAMLPoint, circle: YAMLCircle}
+  use_yaml_discriminator "type", {point: YAMLPoint, circle: YAMLCircle}
 
   property type : String
 end
@@ -808,7 +808,7 @@ describe "YAML::Serializable" do
     it { YAMLAttrModuleTest2.from_yaml(%({"bar": 30, "moo": 40})).to_tuple.should eq({40, 15, 30}) }
   end
 
-  describe "use_discriminator" do
+  describe "use_yaml_discriminator" do
     it "deserializes with discriminator" do
       point = YAMLShape.from_yaml(%({"type": "point", "x": 1, "y": 2})).as(YAMLPoint)
       point.x.should eq(1)

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -285,6 +285,25 @@ class YAMLAttrModuleTest2 < YAMLAttrModuleTest
   end
 end
 
+abstract class YAMLShape
+  include YAML::Serializable
+
+  use_discriminator "type", {point: YAMLPoint, circle: YAMLCircle}
+
+  property type : String
+end
+
+class YAMLPoint < YAMLShape
+  property x : Int32
+  property y : Int32
+end
+
+class YAMLCircle < YAMLShape
+  property x : Int32
+  property y : Int32
+  property radius : Int32
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -787,5 +806,30 @@ describe "YAML::Serializable" do
     it { YAMLAttrModuleTest.from_yaml(%({"phoo": 20})).to_tuple.should eq({10, 20}) }
     it { YAMLAttrModuleTest2.from_yaml(%({"phoo": 20, "bar": 30})).to_tuple.should eq({10, 20, 30}) }
     it { YAMLAttrModuleTest2.from_yaml(%({"bar": 30, "moo": 40})).to_tuple.should eq({40, 15, 30}) }
+  end
+
+  describe "use_discriminator" do
+    it "deserializes with discriminator" do
+      point = YAMLShape.from_yaml(%({"type": "point", "x": 1, "y": 2})).as(YAMLPoint)
+      point.x.should eq(1)
+      point.y.should eq(2)
+
+      circle = YAMLShape.from_yaml(%({"type": "circle", "x": 1, "y": 2, "radius": 3})).as(YAMLCircle)
+      circle.x.should eq(1)
+      circle.y.should eq(2)
+      circle.radius.should eq(3)
+    end
+
+    it "raises if missing discriminator" do
+      expect_raises(YAML::ParseException, "Missing YAML discriminator field 'type'") do
+        YAMLShape.from_yaml("{}")
+      end
+    end
+
+    it "raises if unknown discriminator value" do
+      expect_raises(YAML::ParseException, %(Unknown 'type' discriminator value: "unknown")) do
+        YAMLShape.from_yaml(%({"type": "unknown"}))
+      end
+    end
   end
 end

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -123,7 +123,7 @@ module JSON
   # [GeoJSON](https://tools.ietf.org/html/rfc7946) each object has a "type"
   # field, and the rest of the fields, and their meaning, depend on its value.
   #
-  # You can use `JSON::Serializable.use_discriminator` for this use case.
+  # You can use `JSON::Serializable.use_json_discriminator` for this use case.
   module Serializable
     annotation Options
     end
@@ -366,7 +366,7 @@ module JSON
     # abstract class Shape
     #   include JSON::Serializable
     #
-    #   use_discriminator "type", {point: Point, circle: Circle}
+    #   use_json_discriminator "type", {point: Point, circle: Circle}
     #
     #   property type : String
     # end
@@ -385,7 +385,7 @@ module JSON
     # Shape.from_json(%({"type": "point", "x": 1, "y": 2}))               # => #<Point:0x10373ae20 @type="point", @x=1, @y=2>
     # Shape.from_json(%({"type": "circle", "x": 1, "y": 2, "radius": 3})) # => #<Circle:0x106a4cea0 @type="circle", @x=1, @y=2, @radius=3>
     # ```
-    macro use_discriminator(field, mapping)
+    macro use_json_discriminator(field, mapping)
       {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
         {% mapping.raise "mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
       {% end %}

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -2,9 +2,6 @@ module JSON
   annotation Field
   end
 
-  annotation Discriminator
-  end
-
   # The `JSON::Serializable` module automatically generates methods for JSON serialization when included.
   #
   # ### Example
@@ -118,6 +115,15 @@ module JSON
   #   @a : Int32?
   # end
   # ```
+  #
+  # ### Discriminator field
+  #
+  # A very common JSON serialization strategy for handling different objects
+  # under a same hierarchy is to use a discriminator field. For example in
+  # [GeoJSON](https://tools.ietf.org/html/rfc7946) each object has a "type"
+  # field, and the rest of the fields, and their meaning, depend on its value.
+  #
+  # You can use `JSON::Serializable.use_discriminator` for this use case.
   module Serializable
     annotation Options
     end
@@ -127,33 +133,7 @@ module JSON
       # so it overloads well with other possible initializes
 
       def self.new(pull : ::JSON::PullParser)
-        {% verbatim do %}
-          {% begin %}
-            {% discriminators = @type.instance_vars.select { |ivar| ivar.annotation(::JSON::Discriminator) } %}
-            {% if !discriminators.empty? %}
-              {% if discriminators.size > 1 %}
-                {% raise "Multiple JSON::Discriminator annotations found for type #{@type}, instance variables #{discriminators.map { |var| "@#{var}" }.join(", ").id}" %}
-              {% end %}
-              {% discriminator = discriminators[0] %}
-              {% mapping = discriminator.annotation(::JSON::Discriminator)[0] %}
-              {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
-                {% raise "Argument to JSON::Discriminator must be a HashLiteral ot NamedTupleLiteral, not #{mapping}" %}
-              {% end %}
-              any = JSON::Any.new(pull)
-              discriminator_value = any[{{discriminator.id.stringify}}].to_s
-              case discriminator_value
-              {% for key, value in mapping %}
-                when {{key.id.stringify}}
-                  {{value.id}}.from_json(any.to_json)
-              {% end %}
-              else
-                raise "Unexpected {{discriminator.id}}: #{discriminator_value}"
-              end
-            {% else %}
-              new_from_json_pull_parser(pull)
-            {% end %}
-          {% end %}
-        {% end %}
+        new_from_json_pull_parser(pull)
       end
 
       private def self.new_from_json_pull_parser(pull : ::JSON::PullParser)
@@ -368,6 +348,82 @@ module JSON
       protected def on_to_json(json)
         json_unmapped.each do |key, value|
           json.field(key) { value.to_json(json) }
+        end
+      end
+    end
+
+    # Tells this class to decode JSON by using a field as a discriminator.
+    #
+    # - *field* must be the field name to use as a discriminator
+    # - *mapping* must be a hash or named tuple where each key-value pair
+    #   maps a discriminator value to a class to deserialize
+    #
+    # For example:
+    #
+    # ```
+    # require "json"
+    #
+    # abstract class Shape
+    #   include JSON::Serializable
+    #
+    #   use_discriminator "type", {point: Point, circle: Circle}
+    #
+    #   property type : String
+    # end
+    #
+    # class Point < Shape
+    #   property x : Int32
+    #   property y : Int32
+    # end
+    #
+    # class Circle < Shape
+    #   property x : Int32
+    #   property y : Int32
+    #   property radius : Int32
+    # end
+    #
+    # Shape.from_json(%({"type": "point", "x": 1, "y": 2}))               # => #<Point:0x10373ae20 @type="point", @x=1, @y=2>
+    # Shape.from_json(%({"type": "circle", "x": 1, "y": 2, "radius": 3})) # => #<Circle:0x106a4cea0 @type="circle", @x=1, @y=2, @radius=3>
+    # ```
+    macro use_discriminator(field, mapping)
+      {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
+        {% mapping.raise "mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
+      {% end %}
+
+      def self.new(pull : ::JSON::PullParser)
+        location = pull.location
+
+        discriminator_value = nil
+
+        # Try to find the discriminator while also getting the raw
+        # string value of the parsed JSON, so then we can pass it
+        # to the final type.
+        json = String.build do |io|
+          JSON.build(io) do |builder|
+            builder.start_object
+            pull.read_object do |key|
+              if key == {{field.id.stringify}}
+                discriminator_value = pull.read_string
+                builder.field(key, discriminator_value)
+              else
+                builder.field(key) { pull.read_raw(builder) }
+              end
+            end
+            builder.end_object
+          end
+        end
+
+        unless discriminator_value
+          raise ::JSON::MappingError.new("Missing JSON discriminator field '{{field.id}}'", to_s, nil, *location, nil)
+        end
+
+        case discriminator_value
+        {% for key, value in mapping %}
+          when {{key.id.stringify}}
+            {{value.id}}.from_json(json)
+        {% end %}
+        else
+          raise ::JSON::MappingError.new("Unknown '{{field.id}}' discriminator value: #{discriminator_value.inspect}", to_s, nil, *location, nil)
         end
       end
     end

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -114,6 +114,15 @@ module YAML
   #   @a : Int32?
   # end
   # ```
+  #
+  # ### Discriminator field
+  #
+  # A very common YAML serialization strategy for handling different objects
+  # under a same hierarchy is to use a discriminator field. For example in
+  # [GeoJSON](https://tools.ietf.org/html/rfc7946) each object has a "type"
+  # field, and the rest of the fields, and their meaning, depend on its value.
+  #
+  # You can use `YAML::Serializable.use_discriminator` for this use case.
   module Serializable
     annotation Options
     end
@@ -123,6 +132,10 @@ module YAML
       # so it overloads well with other possible initializes
 
       def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+        new_from_yaml_node(ctx, node)
+      end
+
+      private def self.new_from_yaml_node(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
         ctx.read_alias(node, \{{@type}}) do |obj|
           return obj
         end
@@ -141,7 +154,7 @@ module YAML
 
       macro inherited
         def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
-          super
+          new_from_yaml_node(ctx, node)
         end
       end
     end
@@ -317,6 +330,82 @@ module YAML
           key.to_yaml(yaml)
           value.to_yaml(yaml)
         end
+      end
+    end
+
+    # Tells this class to decode YAML by using a field as a discriminator.
+    #
+    # - *field* must be the field name to use as a discriminator
+    # - *mapping* must be a hash or named tuple where each key-value pair
+    #   maps a discriminator value to a class to deserialize
+    #
+    # For example:
+    #
+    # ```
+    # require "yaml"
+    #
+    # abstract class Shape
+    #   include YAML::Serializable
+    #
+    #   use_discriminator "type", {point: Point, circle: Circle}
+    #
+    #   property type : String
+    # end
+    #
+    # class Point < Shape
+    #   property x : Int32
+    #   property y : Int32
+    # end
+    #
+    # class Circle < Shape
+    #   property x : Int32
+    #   property y : Int32
+    #   property radius : Int32
+    # end
+    #
+    # Shape.from_yaml(%(
+    #   type: point
+    #   x: 1
+    #   y: 2
+    # )) # => #<Point:0x10373ae20 @type="point", @x=1, @y=2>
+    #
+    # Shape.from_yaml(%(
+    #   type: circle
+    #   x: 1
+    #   y: 2
+    #   radius: 3
+    # )) # => #<Circle:0x106a4cea0 @type="circle", @x=1, @y=2, @radius=3>
+    # ```
+    macro use_discriminator(field, mapping)
+      {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
+        {% mapping.raise "mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
+      {% end %}
+
+      private def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+        ctx.read_alias(node, \{{@type}}) do |obj|
+          return obj
+        end
+
+        unless node.is_a?(YAML::Nodes::Mapping)
+          node.raise "expected YAML mapping, not #{node.class}" 
+        end
+
+        node.each do |key, value|
+          next unless key.is_a?(YAML::Nodes::Scalar) && value.is_a?(YAML::Nodes::Scalar)
+          next unless key.value == {{field.id.stringify}}
+
+          discriminator_value = value.value
+          case discriminator_value
+          {% for key, value in mapping %}
+            when {{key.id.stringify}}
+              return {{value.id}}.new(ctx, node)
+          {% end %}
+          else
+            node.raise "Unknown '{{field.id}}' discriminator value: #{discriminator_value.inspect}"
+          end
+        end
+
+        node.raise "Missing YAML discriminator field '{{field.id}}'"
       end
     end
   end

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -122,7 +122,7 @@ module YAML
   # [GeoJSON](https://tools.ietf.org/html/rfc7946) each object has a "type"
   # field, and the rest of the fields, and their meaning, depend on its value.
   #
-  # You can use `YAML::Serializable.use_discriminator` for this use case.
+  # You can use `YAML::Serializable.use_yaml_discriminator` for this use case.
   module Serializable
     annotation Options
     end
@@ -347,7 +347,7 @@ module YAML
     # abstract class Shape
     #   include YAML::Serializable
     #
-    #   use_discriminator "type", {point: Point, circle: Circle}
+    #   use_yaml_discriminator "type", {point: Point, circle: Circle}
     #
     #   property type : String
     # end
@@ -376,7 +376,7 @@ module YAML
     #   radius: 3
     # )) # => #<Circle:0x106a4cea0 @type="circle", @x=1, @y=2, @radius=3>
     # ```
-    macro use_discriminator(field, mapping)
+    macro use_yaml_discriminator(field, mapping)
       {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
         {% mapping.raise "mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
       {% end %}
@@ -387,7 +387,7 @@ module YAML
         end
 
         unless node.is_a?(YAML::Nodes::Mapping)
-          node.raise "expected YAML mapping, not #{node.class}" 
+          node.raise "expected YAML mapping, not #{node.class}"
         end
 
         node.each do |key, value|


### PR DESCRIPTION
**Note:** This is a PR that also serves as an RFC. I decided to go the PR route because I wanted to provide code that proves that this is possible, and show how it could be done.

## What

The idea of this PR is to provide a way to deserialize a group of objects based on a field. This is **very** typical in JSON APIs. For example:

```json
[
  {
    "type": "point",
    "x": 1,
    "y": 2
  },
  {
    "type": "circle",
    "x": 3,
    "y": 4,
    "radius": 5
  }
]
```

Here the parser expects to decide what properties each object has based on the value of the "type" property.

There's no nice way to do this. [It's definitely possible](https://forum.crystal-lang.org/t/deserialize-from-yaml-based-on-a-propertys-value/1219) but since this use case is so common it would be great to provide built-in support for it.

With this PR it would work like this (it already works ga:

```crystal
require "json"

abstract class Shape
  include JSON::Serializable

  use_discriminator "type", {
    point: Point,
    circle: Circle,
  }

  property type : String
end

class Point < Shape
  property x : Int32
  property y : Int32
end

class Circle < Shape
  property x : Int32
  property y : Int32
  property radius : Int32
end

shapes = Array(Shape).from_json(%(
[
  {
    "type": "point",
    "x": 1,
    "y": 2
  },
  {
    "type": "circle",
    "x": 3,
    "y": 4,
    "radius": 5
  }
]
))
pp shapes
```

Output:

```
[#<Point:0x109b16dc0 @type="point", @x=1, @y=2>,
 #<Circle:0x109b20e70 @radius=5, @type="circle", @x=3, @y=4>]
```