### PR TITLE
Spec: restrict the type returned by `should_not be_nil` and others

### DIFF
--- a/spec/std/spec/expectations_spec.cr
+++ b/spec/std/spec/expectations_spec.cr
@@ -23,6 +23,20 @@ describe "expectations" do
     it { 100_000.should_not be_a(String) }
     it { 100_000.should be_a(Int32) }
     it { "Hello".should_not be_a(Int32) }
+
+    it "restricts type on should" do
+      x = 1 || 'a'
+      y = x.should be_a(Int32)
+      typeof(x).should eq(Int32 | Char)
+      typeof(y).should eq(Int32)
+    end
+
+    it "restricts type on should_not" do
+      x = 1 || 'a'
+      y = x.should_not be_a(Char)
+      typeof(x).should eq(Int32 | Char)
+      typeof(y).should eq(Int32)
+    end
   end
 
   describe "be_close" do
@@ -34,6 +48,13 @@ describe "expectations" do
     it { nil.should be_nil }
     it { "".should_not be_nil }
     it { 10.should_not be_nil }
+
+    it "restricts type on should_not" do
+      x = 1 || nil
+      y = x.should_not be_nil
+      typeof(x).should eq(Int32?)
+      typeof(y).should eq(Int32)
+    end
   end
 
   describe "be_falsey" do

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -419,7 +419,7 @@ module Spec
   module ObjectExtensions
     # Validates an expectation and fails the example if it does not match.
     #
-    # This overload returns a value whose type is restricted to the expected type.. For example:
+    # This overload returns a value whose type is restricted to the expected type. For example:
     #
     # ```
     # x = 1 || 'a'

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -419,10 +419,70 @@ module Spec
   module ObjectExtensions
     # Validates an expectation and fails the example if it does not match.
     #
+    # This overload will be called when doing:
+    #
+    # ```
+    # result = subject.should be_a(Type)
+    # # result will be a Type
+    # ```
+    #
+    # and make sure, at compile-time, that the returned object is of type `Type`.
+    #
+    # See `Spec::Expecations` for available expectations.
+    def should(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) forall T
+      if expectation.match self
+        self.is_a?(T) ? self : (raise "Bug: expected #{self} to be a #{T}")
+      else
+        fail(expectation.failure_message(self), file, line)
+      end
+    end
+
+    # Validates an expectation and fails the example if it does not match.
+    #
     # See `Spec::Expecations` for available expectations.
     def should(expectation, file = __FILE__, line = __LINE__)
       unless expectation.match self
         fail(expectation.failure_message(self), file, line)
+      end
+    end
+
+    # Validates an expectation and fails the example if it matches.
+    #
+    # This overload will be called when doing:
+    #
+    # ```
+    # result = subject.should_not be_a(Type)
+    # # result will not be a Type
+    # ```
+    #
+    # and make sure, at compile-time, that the returned object is not of type `Type`.
+    #
+    # See `Spec::Expecations` for available expectations.
+    def should_not(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) forall T
+      if expectation.match self
+        fail(expectation.negative_failure_message(self), file, line)
+      else
+        self.is_a?(T) ? (raise "Bug: expected #{self} not to be a #{T}") : self
+      end
+    end
+
+    # Validates an expectation and fails the example if it matches.
+    #
+    # This overload will be called when doing:
+    #
+    # ```
+    # result = subject.should_not be_nil
+    # # result will not be nil
+    # ```
+    #
+    # and make sure, at compile-time, that the returned object is not `nil`.
+    #
+    # See `Spec::Expecations` for available expectations.
+    def should_not(expectation : BeNilExpectation, file = __FILE__, line = __LINE__)
+      if expectation.match self
+        fail(expectation.negative_failure_message(self), file, line)
+      else
+        self.not_nil!
       end
     end
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -419,7 +419,7 @@ module Spec
   module ObjectExtensions
     # Validates an expectation and fails the example if it does not match.
     #
-    # This overload returns a value whose type is restricted. For example:
+    # This overload returns a value whose type is restricted to the expected type.. For example:
     #
     # ```
     # x = 1 || 'a'

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -448,7 +448,8 @@ module Spec
 
     # Validates an expectation and fails the example if it matches.
     #
-    # This overload returns a value whose type is restricted. For example:
+    # This overload returns a value whose type is restricted to exclude the given
+    # type in `should_not be_a`. For example:
     #
     # ```
     # x = 1 || 'a'
@@ -468,7 +469,7 @@ module Spec
 
     # Validates an expectation and fails the example if it matches.
     #
-    # This overload returns a value whose type is restricted. For example:
+    # This overload returns a value whose type is restricted to be not `Nil`. For example:
     #
     # ```
     # x = 1 || nil

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -419,17 +419,17 @@ module Spec
   module ObjectExtensions
     # Validates an expectation and fails the example if it does not match.
     #
-    # This overload will be called when doing:
+    # This overload returns a value whose type is restricted. For example:
     #
     # ```
-    # result = subject.should be_a(Type)
-    # # result will be a Type
+    # x = 1 || 'a'
+    # typeof(x) # => Int32 | Char
+    # x = x.should be_a(Int32)
+    # typeof(x) # => Int32
     # ```
-    #
-    # and make sure, at compile-time, that the returned object is of type `Type`.
     #
     # See `Spec::Expecations` for available expectations.
-    def should(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) forall T
+    def should(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) : T forall T
       if expectation.match self
         self.is_a?(T) ? self : (raise "Bug: expected #{self} to be a #{T}")
       else
@@ -448,14 +448,14 @@ module Spec
 
     # Validates an expectation and fails the example if it matches.
     #
-    # This overload will be called when doing:
+    # This overload returns a value whose type is restricted. For example:
     #
     # ```
-    # result = subject.should_not be_a(Type)
-    # # result will not be a Type
+    # x = 1 || 'a'
+    # typeof(x) # => Int32 | Char
+    # x = x.should_not be_a(Char)
+    # typeof(x) # => Int32
     # ```
-    #
-    # and make sure, at compile-time, that the returned object is not of type `Type`.
     #
     # See `Spec::Expecations` for available expectations.
     def should_not(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) forall T
@@ -468,14 +468,14 @@ module Spec
 
     # Validates an expectation and fails the example if it matches.
     #
-    # This overload will be called when doing:
+    # This overload returns a value whose type is restricted. For example:
     #
     # ```
-    # result = subject.should_not be_nil
-    # # result will not be nil
+    # x = 1 || nil
+    # typeof(x) # => Int32 | Nil
+    # x = x.should_not be_nil
+    # typeof(x) # => Int32
     # ```
-    #
-    # and make sure, at compile-time, that the returned object is not `nil`.
     #
     # See `Spec::Expecations` for available expectations.
     def should_not(expectation : BeNilExpectation, file = __FILE__, line = __LINE__)


### PR DESCRIPTION
Fixes #8369

Follow up to #8240