### PR TITLE
Compiler: notify generic type subtypes, and handle empty subtypes

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -357,4 +357,48 @@ describe "Code gen: generic class type" do
       end
       ))
   end
+
+  it "doesn't crash on generic type restriction with initially no subtypes (#8411)" do
+    codegen(%(
+      class Foo
+      end
+
+      class Baz(T) < Foo
+        def baz
+        end
+      end
+
+      def x(z)
+      end
+
+      f = uninitialized Foo
+      if f.is_a?(Baz)
+        x(f.baz)
+      end
+
+      Baz(Int32).new
+      ))
+  end
+
+  it "doesn't crash on generic type restriction with no subtypes (#7583)" do
+    codegen(%(
+      require "prelude"
+
+      class Foo
+      end
+
+      class Baz(T) < Foo
+        def baz
+        end
+      end
+
+      def x(z)
+      end
+
+      f = uninitialized Foo
+      if f.is_a?(Baz)
+        x(f.baz)
+      end
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -295,7 +295,7 @@ module Crystal
       # It might happen that a call was made on a module or an abstract class
       # and we don't know the type because there are no including classes or subclasses.
       # In that case, turn this into an untyped expression.
-      if !node.type? && obj && obj_type && (obj_type.module? || obj_type.abstract?)
+      if !node.type? && obj && obj_type && (obj_type.module? || obj_type.abstract? || obj_type.is_a?(GenericType))
         return untyped_expression(node, "`#{node}` has no type")
       end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1537,6 +1537,9 @@ module Crystal
 
       instance.after_initialize
 
+      # Notify that a subclass/instance of self was added
+      self.notify_subclass_added if self.is_a?(SubclassObservable)
+
       # Notify parents that an instance was added
       notify_parents_subclass_added(self)
 


### PR DESCRIPTION
Fixes #7583
Fixes #8411

Two problems here:
- When a generic type was added a new subtype, the new subtype was notified to generic instances but not to the generic type itself
- A generic type might end up with no instantiations and so we should also replace it with an "untyped expression" error (which will never be triggered unless there's a bug in the compiler) 