### PR TITLE
Exhaustive case

### DIFF
--- a/samples/brainfuck.cr
+++ b/samples/brainfuck.cr
@@ -45,6 +45,7 @@ class Program
       when '.'; print tape.get.chr
       when '['; pc = @bracket_map[pc] if tape.get == 0
       when ']'; pc = @bracket_map[pc] if tape.get != 0
+      else # skip
       end
       pc += 1
     end

--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -145,7 +145,7 @@ class Program
     program = [] of Instruction
     i = from
     while i < to
-      case char = source[i]
+      case source[i]
       when '+'
         program << Increment.new(1)
       when '-'

--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -145,7 +145,7 @@ class Program
     program = [] of Instruction
     i = from
     while i < to
-      case source[i]
+      case char = source[i]
       when '+'
         program << Increment.new(1)
       when '-'
@@ -167,6 +167,8 @@ class Program
         i = matching_close_index
       when ']'
         abort "Unmatched ']' at position #{i}"
+      else
+        # skip
       end
       i += 1
     end
@@ -181,6 +183,8 @@ class Program
         open_count += 1
       when ']'
         open_count -= 1
+      else
+        # go on
       end
 
       if open_count == 0

--- a/samples/mt_gc_test.cr
+++ b/samples/mt_gc_test.cr
@@ -195,10 +195,16 @@ def run(threads_num, fibers_num, loops_num, log)
   context.log "Done"
 end
 
+enum Mode
+  Run
+  Ips
+  Measure
+end
+
 threads_num = 4
 fibers_num = 1_000
 loops_num = 20
-mode = :run
+mode : Mode = :run
 
 OptionParser.parse do |parser|
   parser.on("-i", "--ips", "Benchmark with ips") { mode = :ips }
@@ -218,12 +224,12 @@ OptionParser.parse do |parser|
 end
 
 case mode
-when :run
+when .run?
   run(threads_num, fibers_num, loops_num, true)
-when :ips
+when .ips?
   Benchmark.ips do |x|
     x.report("run") { run(threads_num, fibers_num, loops_num, false) }
   end
-when :measure
+when .measure?
   puts Benchmark.measure { run(threads_num, fibers_num, loops_num, false) }
 end

--- a/samples/pretty_json.cr
+++ b/samples/pretty_json.cr
@@ -46,8 +46,8 @@ class PrettyPrinter
       read_object
     when .eof?
       # We are done
-    else
-      raise "Bug: unexpected kind: #{@pull.kind}"
+    when .end_array?, .end_object?
+      raise "Bug: shouldn't happen"
     end
   end
 

--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -386,6 +386,8 @@ while true
         speed_down[3] = true
       when LibSDL::Key::L
         turn_right[3] = true
+      else
+        # ignore
       end
     when LibSDL::KEYUP
       case event.key.key_sym.sym
@@ -421,7 +423,11 @@ while true
         speed_down[3] = false
       when LibSDL::Key::L
         turn_right[3] = false
+      else
+        # ignore
       end
+    else
+      # ignore
     end
   end
 

--- a/samples/sdl/tv.cr
+++ b/samples/sdl/tv.cr
@@ -1,6 +1,17 @@
 require "./sdl/sdl"
 
 class ColorMaker
+  enum State
+    BlueUp
+    BlueDown
+    GreenUp
+    GreenDown
+    RedUp
+    RedDown
+  end
+
+  @state : State
+
   def initialize(@delay : Int32)
     @r = 0
     @g = 255
@@ -19,22 +30,22 @@ class ColorMaker
 
   def next_state
     case @state
-    when :green_up
+    when .green_up?
       @g += 1
       @state = :red_down if @g == 255
-    when :red_down
+    when .red_down?
       @r -= 1
       @state = :blue_up if @r == 0
-    when :blue_up
+    when .blue_up?
       @b += 1
       @state = :green_down if @b == 255
-    when :green_down
+    when .green_down?
       @g -= 1
       @state = :red_up if @g == 0
-    when :red_up
+    when .red_up?
       @r += 1
       @state = :blue_down if @r == 255
-    when :blue_down
+    when .blue_down?
       @b -= 1
       @state = :green_up if @b == 0
     end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -207,14 +207,12 @@ describe "Semantic: case" do
       )
   end
 
-  it "always warns on condless case without else" do
-    assert_warning %(
+  it "never warns on condless case without else" do
+    assert_no_warnings %(
         case
         when 1 == 2
-        when 3 == 4
         end
-      ),
-      "warning in line 3\nWarning: case without condition must have an `else` clause."
+      )
   end
 
   it "always requires an else for Flags enum (no coverage)" do

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -1,0 +1,207 @@
+require "../../spec_helper"
+
+describe "Semantic: case" do
+  it "checks exhaustiveness of union type" do
+    assert_warning %(
+        a = 1 || nil
+        case a
+        when Int32
+        end
+      ),
+      "warning in line 4\nWarning: case is not exhaustive.\n\nMissing types: Nil"
+  end
+
+  it "checks exhaustiveness of single type" do
+    assert_warning %(
+        case 1
+        when Nil
+        end
+      ),
+      "warning in line 3\nWarning: case is not exhaustive.\n\nMissing types: Int32"
+  end
+
+  it "covers all types" do
+    assert_no_warnings %(
+        a = 1 || nil
+        case a
+        when Int32
+        when Nil
+        end
+      )
+  end
+
+  it "can't prove exhaustiveness" do
+    assert_warning %(
+        struct Int32
+          def ===(other)
+            true
+          end
+        end
+
+        case 1
+        when 2
+        end
+      ),
+      "warning in line 9\nWarning: can't prove case is exhaustive.\n\nPlease add an `else` clause."
+  end
+
+  it "checks exhaustiveness of bool type (missing true)" do
+    assert_warning %(
+        struct Bool
+          def ===(other)
+            true
+          end
+        end
+
+        case false
+        when false
+        end
+      ),
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: true"
+  end
+
+  it "checks exhaustiveness of bool type (missing false)" do
+    assert_warning %(
+        struct Bool
+          def ===(other)
+            true
+          end
+        end
+
+        case false
+        when true
+        end
+      ),
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: false"
+  end
+
+  it "checks exhaustiveness of enum via question method" do
+    assert_warning %(
+        struct Enum
+          def ==(other : self)
+            value == other.value
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        when .red?
+        end
+      ),
+      "warning in line 16\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+  end
+
+  it "checks exhaustiveness of enum via const" do
+    assert_warning %(
+        struct Enum
+          def ==(other : self)
+            value == other.value
+          end
+
+          def ===(other)
+            true
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        when Color::Red
+        end
+      ),
+      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+  end
+
+  it "checks exhaustiveness of enum (all cases covered)" do
+    assert_no_warnings %(
+        struct Enum
+          def ==(other : self)
+            value == other.value
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        when .red?
+        when .green?
+        when .blue?
+        end
+      )
+  end
+
+  it "checks exhaustiveness of bool type with other types" do
+    assert_no_warnings %(
+        struct Bool
+          def ===(other)
+            true
+          end
+        end
+
+        case 1 || true
+        when Int32
+        when true
+        when false
+        end
+      )
+  end
+
+  it "checks exhaustiveness of union type with virtual type" do
+    assert_warning %(
+        class Foo
+        end
+
+        class Bar < Foo
+        end
+
+        a = 1 || Foo.new || Bar.new
+        case a
+        when Foo
+        end
+      ),
+      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing types: Int32"
+  end
+
+  it "checks exhaustiveness, covers when base type covers" do
+    assert_no_warnings %(
+        class Foo
+        end
+
+        class Bar < Foo
+        end
+
+        a = Bar.new
+        case a
+        when Foo
+        end
+      )
+  end
+
+  it "checks exhaustiveness, covers when base type covers (generic type)" do
+    assert_no_warnings %(
+        class Foo(T)
+        end
+
+        a = Foo(Int32).new
+        case a
+        when Foo
+        end
+      )
+  end
+end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -234,4 +234,14 @@ describe "Semantic: case" do
         end
       )
   end
+
+  it "always warns on condless case without else" do
+    assert_warning %(
+        case
+        when 1 == 2
+        when 3 == 4
+        end
+      ),
+      "warning in line 3\nWarning: case without condition must have an `else` clause."
+  end
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -8,7 +8,7 @@ describe "Semantic: case" do
         when Int32
         end
       ),
-      "warning in line 4\nWarning: case is not exhaustive.\n\nMissing types: Nil"
+      "warning in line 4\nWarning: case is not exhaustive.\n\nMissing types:\n - Nil"
   end
 
   it "checks exhaustiveness of single type" do
@@ -17,7 +17,7 @@ describe "Semantic: case" do
         when Nil
         end
       ),
-      "warning in line 3\nWarning: case is not exhaustive.\n\nMissing types: Int32"
+      "warning in line 3\nWarning: case is not exhaustive.\n\nMissing types:\n - Int32"
   end
 
   it "covers all types" do
@@ -53,7 +53,7 @@ describe "Semantic: case" do
         when false
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: true"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - true"
   end
 
   it "checks exhaustiveness of bool type (missing false)" do
@@ -64,7 +64,7 @@ describe "Semantic: case" do
         when true
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: false"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - false"
   end
 
   it "checks exhaustiveness of enum via question method" do
@@ -82,7 +82,7 @@ describe "Semantic: case" do
         when .red?
         end
       ),
-      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
   end
 
   it "checks exhaustiveness of enum via const" do
@@ -100,7 +100,7 @@ describe "Semantic: case" do
         when Color::Red
         end
       ),
-      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
   end
 
   it "checks exhaustiveness of enum (all cases covered)" do
@@ -147,7 +147,7 @@ describe "Semantic: case" do
         when Foo
         end
       ),
-      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing types: Int32"
+      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing types:\n - Int32"
   end
 
   it "checks exhaustiveness, covers when base type covers" do
@@ -256,7 +256,7 @@ describe "Semantic: case" do
         when .red?
         end
       ),
-      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+      "warning in line 20\nWarning: case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
   end
 
   it "checks exhaustiveness of union with bool" do
@@ -268,7 +268,7 @@ describe "Semantic: case" do
         when true
         end
       ),
-      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing cases: false, Int32"
+      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing cases:\n - false\n - Int32"
   end
 
   it "checks exhaustiveness for tuple literal, and passes" do
@@ -295,7 +295,7 @@ describe "Semantic: case" do
         when {Char, Char}
         end
       ),
-      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Int32}"
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Int32}"
   end
 
   it "checks exhaustiveness for tuple literal of 3 elements, and warns" do
@@ -311,7 +311,7 @@ describe "Semantic: case" do
         when {Char, Char, Char}
         end
       ),
-      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Int32, Char}, {Int32, Int32, Char}"
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Int32, Char}\n - {Int32, Int32, Char}"
   end
 
   it "checks exhaustiveness for tuple literal of 2 elements, first is bool" do
@@ -322,7 +322,7 @@ describe "Semantic: case" do
         when {true, Char}
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {false, Char}"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - {false, Char}"
   end
 
   it "checks exhaustiveness for tuple literal of 2 elements, first is enum" do
@@ -340,7 +340,7 @@ describe "Semantic: case" do
         when {.blue?, Char}
         end
       ),
-      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases: {Color::Green, Char}"
+      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Color::Green, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with types and underscore at first position" do
@@ -351,7 +351,7 @@ describe "Semantic: case" do
         when {_, Int32}
         end
       ),
-      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Char}, {Int32, Char}"
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Char}\n - {Int32, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with types and underscore at second position" do
@@ -362,7 +362,7 @@ describe "Semantic: case" do
         when {Int32, _}
         end
       ),
-      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Char}, {Char, Int32}"
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Char}\n - {Char, Int32}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at first position" do
@@ -373,7 +373,7 @@ describe "Semantic: case" do
         when {_, Int32}
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {Bool, Char}"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Bool, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at first position, with partial match" do
@@ -385,7 +385,7 @@ describe "Semantic: case" do
         when {false, Char}
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {true, Char}"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - {true, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at second position" do
@@ -396,7 +396,7 @@ describe "Semantic: case" do
         when {Int32, _}
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Bool}"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Bool}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at second position, with partial match" do
@@ -408,7 +408,7 @@ describe "Semantic: case" do
         when {Char, false}
         end
       ),
-      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {Char, true}"
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, true}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at first position" do
@@ -425,7 +425,7 @@ describe "Semantic: case" do
         when {_, Int32}
         end
       ),
-      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases: {Color, Char}"
+      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Color, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at first position, partial match" do
@@ -443,7 +443,7 @@ describe "Semantic: case" do
         when {.blue?, Char}
         end
       ),
-      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases: {Color::Red, Char}, {Color::Green, Char}"
+      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Color::Red, Char}\n - {Color::Green, Char}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at second position" do
@@ -460,7 +460,7 @@ describe "Semantic: case" do
         when {Int32, _}
         end
       ),
-      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Color}"
+      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Color}"
   end
 
   it "checks exhaustiveness for tuple literal with bool and underscore at second position, partial match" do
@@ -478,7 +478,7 @@ describe "Semantic: case" do
         when {Char, .blue?}
         end
       ),
-      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Color::Red}, {Char, Color::Green}"
+      "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Color::Red}\n - {Char, Color::Green}"
   end
 end
 

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -267,4 +267,43 @@ describe "Semantic: case" do
       ),
       "warning in line 17\nWarning: can't prove case is exhaustive.\n\nPlease add an `else` clause."
   end
+
+  it "checks exhaustiveness of enum combined with another type" do
+    assert_warning %(
+        struct Enum
+          def ==(other : self)
+            value == other.value
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red || 1
+        case e
+        when Int32
+        when .red?
+        end
+      ),
+      "warning in line 16\nWarning: case is not exhaustive for enum Color.\n\nMissing members: Green, Blue"
+  end
+
+  it "checks exhaustiveness of union with bool" do
+    assert_warning %(
+        struct Bool
+          def ===(other)
+            true
+          end
+        end
+
+        e = 1 || true
+        case e
+        when true
+        end
+      ),
+      "warning in line 10\nWarning: case is not exhaustive.\n\nMissing cases: false, Int32"
+  end
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -244,4 +244,27 @@ describe "Semantic: case" do
       ),
       "warning in line 3\nWarning: case without condition must have an `else` clause."
   end
+
+  it "always requires an else for Flags enum" do
+    assert_warning %(
+        struct Enum
+          def includes?(other : self)
+            false
+          end
+        end
+
+        @[Flags]
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        when .red?
+        end
+      ),
+      "warning in line 17\nWarning: can't prove case is exhaustive.\n\nPlease add an `else` clause."
+  end
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -217,7 +217,7 @@ describe "Semantic: case" do
       "warning in line 3\nWarning: case without condition must have an `else` clause."
   end
 
-  it "always requires an else for Flags enum" do
+  it "always requires an else for Flags enum (no coverage)" do
     assert_warning %(
         struct Enum
           def includes?(other : self)
@@ -235,6 +235,31 @@ describe "Semantic: case" do
         e = Color::Red
         case e
         when .red?
+        end
+      ),
+      "warning in line 17\nWarning: can't prove case is exhaustive.\n\nPlease add an `else` clause."
+  end
+
+  it "always requires an else for Flags enum (all members covered but doesn't count)" do
+    assert_warning %(
+        struct Enum
+          def includes?(other : self)
+            false
+          end
+        end
+
+        @[Flags]
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        when .red?
+        when .green?
+        when .blue?
         end
       ),
       "warning in line 17\nWarning: can't prove case is exhaustive.\n\nPlease add an `else` clause."

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -306,4 +306,84 @@ describe "Semantic: case" do
       ),
       "warning in line 10\nWarning: case is not exhaustive.\n\nMissing cases: false, Int32"
   end
+
+  it "checks exhaustiveness for tuple literal, and passes" do
+    assert_no_warnings %(
+        a = 1 || 'a'
+        b = 1 || 'a'
+
+        case {a, b}
+        when {Int32, Char}
+        when {Int32, Int32}
+        when {Char, Int32}
+        when {Char, Char}
+        end
+      )
+  end
+
+  it "checks exhaustiveness for tuple literal of 2 elements, and warns" do
+    assert_warning %(
+        a = 1 || 'a'
+
+        case {a, a}
+        when {Int32, Char}
+        when {Int32, Int32}
+        when {Char, Char}
+        end
+      ),
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Int32}"
+  end
+
+  it "checks exhaustiveness for tuple literal of 3 elements, and warns" do
+    assert_warning %(
+        a = 1 || 'a'
+
+        case {a, a, a}
+        when {Int32, Int32, Int32}
+        when {Int32, Char, Int32}
+        when {Int32, Char, Char}
+        when {Char, Int32, Int32}
+        when {Char, Char, Int32}
+        when {Char, Char, Char}
+        end
+      ),
+      "warning in line 5\nWarning: case is not exhaustive.\n\nMissing cases: {Char, Int32, Char}, {Int32, Int32, Char}"
+  end
+
+  it "checks exhaustiveness for tuple literal of 2 elements, first is bool" do
+    assert_warning %(
+        struct Bool
+          def ===(other)
+            true
+          end
+        end
+
+        case {true, 'a'}
+        when {true, Char}
+        end
+      ),
+      "warning in line 9\nWarning: case is not exhaustive.\n\nMissing cases: {false, Char}"
+  end
+
+  it "checks exhaustiveness for tuple literal of 2 elements, first is enum" do
+    assert_warning %(
+        struct Enum
+          def ==(other : self)
+            value == other.value
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        case {Color::Red, 'a'}
+        when {.red?, Char}
+        when {.blue?, Char}
+        end
+      ),
+      "warning in line 15\nWarning: case is not exhaustive.\n\nMissing cases: {Color::Green, Char}"
+  end
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -204,4 +204,34 @@ describe "Semantic: case" do
         end
       )
   end
+
+  it "checks exhaustiveness of nil type with nil literal" do
+    assert_no_warnings %(
+        struct Nil
+          def ===(other)
+            true
+          end
+        end
+
+        case nil
+        when nil
+        end
+      )
+  end
+
+  it "checks exhaustiveness of nilable type with nil literal" do
+    assert_no_warnings %(
+        struct Nil
+          def ===(other)
+            true
+          end
+        end
+
+        a = 1 || nil
+        case a
+        when nil
+        when Int32
+        end
+      )
+  end
 end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -505,6 +505,25 @@ describe "Semantic: case" do
       ),
       "warning in line 19\nWarning: case is not exhaustive.\n\nMissing cases:\n - {Char, Color::Red}\n - {Char, Color::Green}"
   end
+
+  it "checks exhaustiveness for tuple literal, with call" do
+    assert_no_warnings %(
+        struct Int
+          def bar
+            1 || 'a'
+          end
+        end
+
+        foo = 1
+
+        case {foo.bar, foo.bar}
+        when {Int32, Char}
+        when {Int32, Int32}
+        when {Char, Int32}
+        when {Char, Char}
+        end
+      )
+  end
 end
 
 private def bool_case_eq

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -539,6 +539,8 @@ describe "Semantic: splat" do
           expect_splat "x", 0, 10, 0
         when 1
           expect_splat "y", 1, 20, 1
+        else
+          fail "shouldn't happen"
         end
         i += 1
       end
@@ -560,6 +562,8 @@ describe "Semantic: splat" do
           expect_splat "a1", 0, 10, 0
         when 1
           expect_splat "a2", 1, 20, 1
+        else
+          fail "shouldn't happen"
         end
         i += 1
       end
@@ -576,6 +580,8 @@ describe "Semantic: splat" do
           expect_splat "a3", 2, 50, 4
         when 3
           expect_splat "a3", 2, 60, 5
+        else
+          fail "shouldn't happen"
         end
         i += 1
       end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -134,6 +134,11 @@ def assert_warning(code, message, inject_primitives = true)
   warning_failures[0].should start_with(message)
 end
 
+def assert_no_warnings(code, inject_primitives = true)
+  warning_failures = warnings_result(code, inject_primitives)
+  warning_failures.size.should eq(0)
+end
+
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil)
   assert_macro(macro_args, macro_body, expected, expected_pragmas, flags) { call_args }
 end

--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -1,31 +1,35 @@
 require "spec"
 require "ecr/lexer"
 
+private def t(type : ECR::Lexer::Token::Type)
+  type
+end
+
 describe "ECR::Lexer" do
   it "lexes without interpolation" do
     lexer = ECR::Lexer.new("hello")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello")
     token.line_number.should eq(1)
     token.column_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <% %>" do
     lexer = ECR::Lexer.new("hello <% foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(9)
@@ -33,20 +37,20 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(16)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <%- %>" do
     lexer = ECR::Lexer.new("<%- foo %>")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(4)
@@ -58,7 +62,7 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("<% foo -%>")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(3)
@@ -70,7 +74,7 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("<% \"-%\" %>")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq(" \"-%\" ")
   end
 
@@ -78,7 +82,7 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%= foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
@@ -92,13 +96,13 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <%= -%>" do
@@ -117,13 +121,13 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%# foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq("# foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(9)
@@ -131,20 +135,20 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <%# -%>" do
     lexer = ECR::Lexer.new("<%# foo -%>")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq("# foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(3)
@@ -156,13 +160,13 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%% foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("<% foo %>")
     token.line_number.should eq(1)
     token.column_number.should eq(10)
@@ -170,26 +174,26 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <%%= %>" do
     lexer = ECR::Lexer.new("hello <%%= foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("<%= foo %>")
     token.line_number.should eq(1)
     token.column_number.should eq(10)
@@ -197,37 +201,37 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(18)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 
   it "lexes with <% %> and correct location info" do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq("hi\nthere ")
     token.line_number.should eq(1)
     token.column_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::Control)
+    token.type.should eq(t :control)
     token.value.should eq(" foo\nbar ")
     token.line_number.should eq(2)
     token.column_number.should eq(9)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::String)
+    token.type.should eq(t :string)
     token.value.should eq(" baz")
     token.line_number.should eq(3)
     token.column_number.should eq(7)
 
     token = lexer.next_token
-    token.type.should eq(ECR::Lexer::Token::Type::EOF)
+    token.type.should eq(t :eof)
   end
 end

--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -6,26 +6,26 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello")
     token.line_number.should eq(1)
     token.column_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <% %>" do
     lexer = ECR::Lexer.new("hello <% foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(9)
@@ -33,20 +33,20 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(16)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <%- %>" do
     lexer = ECR::Lexer.new("<%- foo %>")
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(4)
@@ -58,7 +58,7 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("<% foo -%>")
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(3)
@@ -70,7 +70,7 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("<% \"-%\" %>")
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq(" \"-%\" ")
   end
 
@@ -78,13 +78,13 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%= foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:OUTPUT)
+    token.type.should eq(ECR::Lexer::Token::Type::Output)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(10)
@@ -92,20 +92,20 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <%= -%>" do
     lexer = ECR::Lexer.new("<%= foo -%>")
 
     token = lexer.next_token
-    token.type.should eq(:OUTPUT)
+    token.type.should eq(ECR::Lexer::Token::Type::Output)
     token.value.should eq(" foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(4)
@@ -117,13 +117,13 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%# foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq("# foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(9)
@@ -131,20 +131,20 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <%# -%>" do
     lexer = ECR::Lexer.new("<%# foo -%>")
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq("# foo ")
     token.line_number.should eq(1)
     token.column_number.should eq(3)
@@ -156,13 +156,13 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello <%% foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("<% foo %>")
     token.line_number.should eq(1)
     token.column_number.should eq(10)
@@ -170,26 +170,26 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(17)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <%%= %>" do
     lexer = ECR::Lexer.new("hello <%%= foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hello ")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("<%= foo %>")
     token.line_number.should eq(1)
     token.column_number.should eq(10)
@@ -197,37 +197,37 @@ describe "ECR::Lexer" do
     token.suppress_trailing?.should be_false
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" bar")
     token.line_number.should eq(1)
     token.column_number.should eq(18)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 
   it "lexes with <% %> and correct location info" do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq("hi\nthere ")
     token.line_number.should eq(1)
     token.column_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
+    token.type.should eq(ECR::Lexer::Token::Type::Control)
     token.value.should eq(" foo\nbar ")
     token.line_number.should eq(2)
     token.column_number.should eq(9)
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
+    token.type.should eq(ECR::Lexer::Token::Type::String)
     token.value.should eq(" baz")
     token.line_number.should eq(3)
     token.column_number.should eq(7)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(ECR::Lexer::Token::Type::EOF)
   end
 end

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -193,6 +193,8 @@ describe "NamedTuple" do
       when 1
         key.should eq(:b)
         value.should eq("hello")
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil
@@ -208,6 +210,8 @@ describe "NamedTuple" do
         key.should eq(:a)
       when 1
         key.should eq(:b)
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil
@@ -223,6 +227,8 @@ describe "NamedTuple" do
         value.should eq(1)
       when 1
         value.should eq("hello")
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil
@@ -242,6 +248,8 @@ describe "NamedTuple" do
         key.should eq(:b)
         value.should eq("hello")
         index.should eq(1)
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -183,6 +183,7 @@ describe "Number" do
         when 0 then x.should eq(0.0)
         when 1 then x.should eq(0.1)
         when 2 then x.should eq(0.2)
+        else        fail "shouldn't happen"
         end
         count += 1
       end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2083,6 +2083,8 @@ describe "String" do
         c.should eq('b')
       when 2
         c.should eq('c')
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil
@@ -2135,6 +2137,8 @@ describe "String" do
         b.should eq('b'.ord)
       when 2
         b.should eq('c'.ord)
+      else
+        fail "shouldn't happen"
       end
       i += 1
     end.should be_nil

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -257,6 +257,8 @@ struct CallStack
             elsif value.responds_to?(:to_i)
               high_pc = low_pc.as(LibC::SizeT) + value.to_i
             end
+          else
+            # Not an attribute we care
           end
         end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -331,6 +331,8 @@ struct Char
         else # at the beginning of the set or escaped
           return not_negated if self == char
         end
+      else
+        # go on
       end
 
       if range && previous

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -430,7 +430,7 @@ class Crystal::CodeGenVisitor
 
       accept body
       inline_call_return_value target_def, body
-      return true
+      true
     when Var
       if body.name == "self"
         return true unless @needs_value
@@ -438,16 +438,18 @@ class Crystal::CodeGenVisitor
         @last = self_type.passed_as_self? ? call_args.first : type_id(self_type)
         inline_call_return_value target_def, body
         return true
+      else
+        false
       end
     when InstanceVar
       return true unless @needs_value
 
       read_instance_var(body.type, self_type, body.name, call_args.first)
       inline_call_return_value target_def, body
-      return true
+      true
+    else
+      false
     end
-
-    false
   end
 
   def inline_call_return_value(target_def, body)
@@ -524,6 +526,8 @@ class Crystal::CodeGenVisitor
         else
           @last = llvm_nil
         end
+      else
+        # go on
       end
     end
 

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -188,6 +188,8 @@ class Crystal::CodeGenVisitor
         value = upcast(value, compatible_type, value_type)
         return assign(target_pointer, target_type, compatible_type, value)
       end
+    else
+      # go on
     end
 
     value = to_rhs(value, value_type)
@@ -449,6 +451,8 @@ class Crystal::CodeGenVisitor
         value = downcast(value, to_type, compatible_type, true)
         return value
       end
+    else
+      # go on
     end
 
     _, value_ptr = union_type_and_value_pointer(value, from_type)
@@ -663,6 +667,8 @@ class Crystal::CodeGenVisitor
         value = upcast(value, compatible_type, from_type)
         return upcast(value, to_type, compatible_type)
       end
+    else
+      # go on
     end
 
     union_ptr = alloca(llvm_type(to_type))

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -181,6 +181,8 @@ class Crystal::CodeGenVisitor
       return read_virtual_class_var_ptr(class_var, owner)
     when VirtualMetaclassType
       return read_virtual_metaclass_class_var_ptr(class_var, owner)
+    else
+      # go on
     end
 
     initializer = class_var.initializer

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -310,7 +310,10 @@ module Crystal
              @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME,
              ONCE_INIT, ONCE
           @codegen.accept node
+        else
+          # go on
         end
+
         false
       end
 
@@ -1109,6 +1112,8 @@ module Crystal
       when ClassVar
         # This is the case of a class var initializer
         initialize_class_var(var)
+      else
+        # go on
       end
 
       @last = llvm_nil

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -128,6 +128,7 @@ class Crystal::CodeGenVisitor
     when ">=" then return codegen_binary_op_gte(t1, t2, p1, p2)
     when "==" then return codegen_binary_op_eq(t1, t2, p1, p2)
     when "!=" then return codegen_binary_op_ne(t1, t2, p1, p2)
+    else # go on
     end
 
     tmax, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -27,6 +27,8 @@ class Crystal::Codegen::Target
       @architecture = "x86_64"
     when .starts_with?("arm")
       @architecture = "arm"
+    else
+      # no need to tweak the architecture
     end
   end
 

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -196,6 +196,8 @@ module Crystal
           when IntegerType, EnumType
             interpreter = MathInterpreter.new(namespace, visitor)
             @compile_time_value = interpreter.interpret(value) rescue nil
+          else
+            # go on
           end
         end
       end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -112,6 +112,8 @@ module Crystal
         if File.file?(filename)
           return format_error_from_file(filename)
         end
+      else
+        # go on
       end
 
       return format_error(source) if source
@@ -207,12 +209,16 @@ module Crystal
 
     def source_lines(filename)
       case filename
+      when Nil
+        nil
       when String
         if File.file? filename
-          source_lines = File.read_lines(filename)
+          File.read_lines(filename)
+        else
+          nil
         end
       when VirtualFile
-        source_lines = filename.source.lines
+        filename.source.lines
       end
     end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -451,6 +451,7 @@ module Crystal
           else
             produce_tuple = false
           end
+
           if produce_tuple
             case matched_type
             when TupleInstanceType
@@ -462,6 +463,8 @@ module Crystal
               return NamedTupleLiteral.new(entries)
             when UnionType
               return TupleLiteral.map(matched_type.union_types) { |t| TypeNode.new(t) }
+            else
+              # go on
             end
           end
         end
@@ -534,12 +537,12 @@ module Crystal
       case node.name
       when "@type"
         target = @scope == @program.class_type ? @scope : @scope.instance_type
-        return @last = TypeNode.new(target.devirtualize)
+        @last = TypeNode.new(target.devirtualize)
       when "@def"
-        return @last = @def || NilLiteral.new
+        @last = @def || NilLiteral.new
+      else
+        node.raise "unknown macro instance var: '#{node.name}'"
       end
-
-      node.raise "unknown macro instance var: '#{node.name}'"
     end
 
     def visit(node : TupleLiteral)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1458,20 +1458,20 @@ module Crystal
         case arg = args.first?
         when StringLiteral, SymbolLiteral
           if method == "=="
-            return BoolLiteral.new(@value == arg.value)
+            BoolLiteral.new(@value == arg.value)
           else
-            return BoolLiteral.new(@value != arg.value)
+            BoolLiteral.new(@value != arg.value)
           end
         else
-          return super
+          super
         end
       when "stringify", "class_name", "symbolize"
-        return super
+        super
+      else
+        value = StringLiteral.new(@value).interpret(method, args, named_args, block, interpreter)
+        value = MacroId.new(value.value) if value.is_a?(StringLiteral)
+        value
       end
-
-      value = StringLiteral.new(@value).interpret(method, args, named_args, block, interpreter)
-      value = MacroId.new(value.value) if value.is_a?(StringLiteral)
-      value
     rescue UndefinedMacroMethodError
       raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
     end
@@ -1488,20 +1488,20 @@ module Crystal
         case arg = args.first?
         when MacroId
           if method == "=="
-            return BoolLiteral.new(@value == arg.value)
+            BoolLiteral.new(@value == arg.value)
           else
-            return BoolLiteral.new(@value != arg.value)
+            BoolLiteral.new(@value != arg.value)
           end
         else
-          return super
+          super
         end
       when "stringify", "class_name", "symbolize"
-        return super
+        super
+      else
+        value = StringLiteral.new(@value).interpret(method, args, named_args, block, interpreter)
+        value = SymbolLiteral.new(value.value) if value.is_a?(StringLiteral)
+        value
       end
-
-      value = StringLiteral.new(@value).interpret(method, args, named_args, block, interpreter)
-      value = SymbolLiteral.new(value.value) if value.is_a?(StringLiteral)
-      value
     rescue UndefinedMacroMethodError
       raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
     end
@@ -2217,6 +2217,8 @@ private def interpret_array_or_tuple_method(object, klass, method, args, block, 
           Crystal::MacroId.new((object.elements.join ", ") + arg.value)
         end
       end
+    else
+      object.wrong_number_of_arguments "#{klass}#splat", args.size, "0..1"
     end
   when "empty?"
     object.interpret_argless_method(method, args) { Crystal::BoolLiteral.new(object.elements.empty?) }

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -23,13 +23,15 @@ module Crystal
       if with_literals
         case self
         when NumberLiteral
-          return NumberLiteralType.new(type.program, self)
+          NumberLiteralType.new(type.program, self)
         when SymbolLiteral
-          return SymbolLiteralType.new(type.program, self)
+          SymbolLiteralType.new(type.program, self)
+        else
+          type
         end
+      else
+        type
       end
-
-      type
     end
 
     def set_type(type : Type)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -43,6 +43,8 @@ class Crystal::Call
     when LibType
       # `LibFoo.call` has a separate logic
       return recalculate_lib_call obj_type
+    else
+      # Nothing
     end
 
     # Check if its call is inside LibFoo
@@ -514,14 +516,9 @@ class Crystal::Call
   end
 
   def named_tuple_indexer_helper(args, arg_types, owner, instance_type, nilable)
-    arg = args.first
-
-    case arg
+    case arg = args.first
     when SymbolLiteral, StringLiteral
       name = arg.value
-    end
-
-    if name
       index = instance_type.name_index(name)
       if index || nilable
         indexer_def = yield instance_type, (index || -1)
@@ -530,8 +527,9 @@ class Crystal::Call
       else
         raise "missing key '#{name}' for named tuple #{owner}"
       end
+    else
+      nil
     end
-    nil
   end
 
   def replace_splats
@@ -699,6 +697,8 @@ class Crystal::Call
         return result
       when Type::DefInMacroLookup
         return nil
+      else
+        # Check next target
       end
     end
   end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -632,6 +632,8 @@ class Crystal::Call
       unless scope_type.has_protected_access_to?(owner_type)
         raise "protected method '#{match.def.name}' called for #{match.def.owner}"
       end
+    when .public?
+      # okay
     end
   end
 

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -163,6 +163,8 @@ module Crystal
           node_to_discard.discarded = true
         when TypeDeclaration
           node_to_discard.discarded = true
+        else
+          # nothing to do
         end
       end
     end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -61,6 +61,7 @@ module Crystal
 
     def initialize(@program : Program)
       @transformed = Set(Def).new.compare_by_identity
+      @exhaustiveness_checker = ExhaustivenessChecker.new(@program)
       @def_nest_count = 0
       @last_is_truthy = false
       @last_is_falsey = false
@@ -166,6 +167,15 @@ module Crystal
         end
       end
       false
+    end
+
+    def transform(node : Case)
+      @exhaustiveness_checker.check(node)
+
+      if expanded = node.expanded
+        return expanded.transform(self)
+      end
+      node
     end
 
     def transform(node : ExpandableNode)

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -33,6 +33,8 @@ module Crystal
         end
       when ClassType
         cleanup_single_type(type, transformer)
+      else
+        # no need to clean up
       end
     end
 
@@ -458,6 +460,8 @@ module Crystal
           if owner.passed_as_self?
             arg.raise "#{message} (closured vars: self)"
           end
+        else
+          # nothing to do
         end
       end
     end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -563,6 +563,8 @@ module Crystal
         node.truthy = true
       when cond_is_falsey
         node.falsey = true
+      else
+        # Not a special condition
       end
 
       if node.falsey?

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -240,6 +240,8 @@ module Crystal
         io << "'self' was used before initializing instance variable '#{nil_reason.name}', rendering it nilable"
       when :initialized_in_rescue
         io << "Instance variable '#{nil_reason.name}' is initialized inside a begin-rescue, so it can potentially be left uninitialized if an exception is raised and rescued"
+      else
+        # TODO: we should probably change nil_reason to be an enum so we don't need this else branch
       end
     end
 

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -76,7 +76,8 @@ struct Crystal::ExhaustivenessChecker
       @program.report_warning(node, <<-MSG)
         case is not exhaustive.
 
-        Missing types: #{targets.map(&.type).join(", ")}
+        Missing types:
+         - #{targets.map(&.type).join("\n - ")}
         MSG
       return
     end
@@ -88,14 +89,16 @@ struct Crystal::ExhaustivenessChecker
       @program.report_warning(node, <<-MSG)
         case is not exhaustive.
 
-        Missing cases: #{single_target.missing_cases.join(", ")}
+        Missing cases:
+         - #{single_target.missing_cases.join("\n - ")}
         MSG
       return
     when EnumTarget
       @program.report_warning(node, <<-MSG)
         case is not exhaustive for enum #{single_target.type}.
 
-        Missing members: #{single_target.members.map(&.name).join(", ")}
+        Missing members:
+         - #{single_target.members.map(&.name).join("\n - ")}
         MSG
       return
     else
@@ -106,7 +109,8 @@ struct Crystal::ExhaustivenessChecker
       @program.report_warning(node, <<-MSG)
         case is not exhaustive.
 
-        Missing cases: #{targets.flat_map(&.missing_cases).join(", ")}
+        Missing cases:
+         - #{targets.flat_map(&.missing_cases).join("\n - ")}
         MSG
       return
     end
@@ -176,12 +180,13 @@ struct Crystal::ExhaustivenessChecker
       missing_cases = targets
         .flat_map(&.missing_cases)
         .map { |cases| "{#{cases}}" }
-        .join(", ")
+        .join("\n - ")
 
       @program.report_warning(node, <<-MSG)
       case is not exhaustive.
 
-      Missing cases: #{missing_cases}
+      Missing cases:
+       - #{missing_cases}
       MSG
       return
     end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -96,6 +96,9 @@ struct Crystal::ExhaustivenessChecker
           else
             found_false = true
           end
+        when NilLiteral
+          # A nil literal is the same as matching the Nil type
+          cond_types.reject! &.nil_type?
         else
           # Nothing to do
         end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -50,7 +50,7 @@ struct Crystal::ExhaustivenessChecker
     found_true = false
 
     # All enum members, as strings, in case we are matching against an enum
-    enum_members = if single_cond_type.is_a?(EnumType)
+    enum_members = if single_cond_type.is_a?(EnumType) && !single_cond_type.flags?
                      single_cond_type.types.values.select(Const).map(&.name)
                    else
                      nil

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -1,4 +1,72 @@
 struct Crystal::ExhaustivenessChecker
+  # A target to check for exhaustiveness
+  abstract class Target
+    # The type this target is based on.
+    getter type
+
+    def initialize(@type : Type)
+    end
+
+    # Was this target covered?
+    abstract def covered? : Bool
+
+    # What are the cases that we didn't cover?
+    abstract def missing_cases : Array(String)
+  end
+
+  # A bool target. Subtargets are the `false` and `true` literals.
+  class BoolTarget < Target
+    property? found_true = false
+    property? found_false = false
+
+    def covered? : Bool
+      found_true? && found_false?
+    end
+
+    def missing_cases : Array(String)
+      missing_cases = [] of String
+      missing_cases << "false" unless found_false?
+      missing_cases << "true" unless found_true?
+      missing_cases
+    end
+  end
+
+  # An enum target. Subtargets are the enum members.
+  class EnumTarget < Target
+    getter members : Array(Const)
+
+    @original_members_size : Int32
+
+    def initialize(type)
+      super
+      @members = type.types.values.select(Const)
+      @original_members_size = @members.size
+    end
+
+    def covered? : Bool
+      @members.empty?
+    end
+
+    def missing_cases : Array(String)
+      if @original_members_size == @members.size
+        [type.to_s]
+      else
+        @members.map(&.to_s)
+      end
+    end
+  end
+
+  # Any other target is a type target. The target to cover is the type itself.
+  class TypeTarget < Target
+    def covered? : Bool
+      false
+    end
+
+    def missing_cases : Array(String)
+      [type.to_s]
+    end
+  end
+
   def initialize(@program : Program)
   end
 
@@ -29,131 +97,130 @@ struct Crystal::ExhaustivenessChecker
     # Compute all types that we must cover.
     # We only take into account union types and single types,
     # never virtual types because these can be extended.
-    #
-    # Also remember whether it's just a single type we are checking
-    # (useful for Bool and Enum later on).
     if cond_type.is_a?(UnionType)
       cond_types = cond_type.union_types.dup.map(&.devirtualize.as(Type))
-      single_cond_type = nil
     else
       cond_types = [cond_type.devirtualize]
-      single_cond_type = cond_type.devirtualize
     end
 
-    # Are all when clauses types (paths)?
-    all_whens_are_types = true
+    # Compute all the targets that we must cover
+    targets = cond_types.map do |cond_type|
+      if cond_type.is_a?(BoolType)
+        BoolTarget.new(cond_type)
+      elsif cond_type.is_a?(EnumType) && !cond_type.flags?
+        EnumTarget.new(cond_type)
+      else
+        TypeTarget.new(cond_type)
+      end
+    end
 
-    # Did we find the `false` literal in any `when`?
-    found_false = false
+    # Are all patterns Path types?
+    all_patterns_are_types = true
 
-    # Did we find the `true` literal in any `when`?
-    found_true = false
+    # Are all patterns things that we can handle?
+    # For example an integer literal is something that we don't
+    # take into account for exhaustiveness.
+    all_provable_patterns = true
 
-    # All enum members, as strings, in case we are matching against an enum
-    enum_members = if single_cond_type.is_a?(EnumType) && !single_cond_type.flags?
-                     single_cond_type.types.values.select(Const).map(&.name)
-                   else
-                     nil
-                   end
+    # Is any type a @[Flags] enum?
+    has_flags_enum = cond_types.any? { |type| type.is_a?(EnumType) && type.flags? }
 
     # Start checking each `when`...
     node.whens.each do |a_when|
       a_when.conds.each do |when_cond|
-        # In case of a Path that points to a type,
-        # remove that type from the types we must cover
-        if when_cond.is_a?(Path) &&
-           !when_cond.syntax_replacement && !when_cond.target_const &&
-           when_cond.type?
-          cond_types.reject! { |type| type.implements?(when_cond.type.devirtualize) }
-          next
-        end
-
-        # At this point we are matching against other things than types/paths
-        all_whens_are_types = false
-
-        # If we are matching against an enum type and the Path denotes an enum member,
-        # delete it from the members we must cover
-        if when_cond.is_a?(Path) &&
-           enum_members && single_cond_type.is_a?(EnumType) &&
-           (target_const = when_cond.target_const)
-          matching_member = single_cond_type.types.find { |k, v| v == target_const }
-          if matching_member
-            enum_members.delete(matching_member[1].name.to_s)
-          end
-        end
-
         case when_cond
+        when Path
+          # In case of a Path that points to a type,
+          # remove that type from the types we must cover
+          if !when_cond.syntax_replacement && !when_cond.target_const &&
+             when_cond.type?
+            remove_type_from_targets(targets, when_cond.type)
+            next
+          end
+
+          all_patterns_are_types = false
+
+          # If we find a constant that doesn't point to a type (so a value),
+          # if it's an enum member, try to remove it from the targets.
+          if (target_const = when_cond.target_const) &&
+             target_const.namespace.is_a?(EnumType)
+            remove_enum_member_from_targets(targets, target_const)
+            next
+          end
+
+          all_provable_patterns = false
         when Call
+          all_patterns_are_types = false
+
           # Check if it's something like `.foo?` to remove that member from the ones
           # we must cover.
           # Note: a user could override the meaning of such methods.
           # In the future it would be wise to mark these as non-redefinable
           # so this checks are sounds.
-          if enum_members && when_cond.obj.is_a?(ImplicitObj) &&
+          if when_cond.obj.is_a?(ImplicitObj) &&
              when_cond.args.empty? && when_cond.named_args.nil? &&
              !when_cond.block && !when_cond.block_arg && when_cond.name.ends_with?('?')
-            enum_value = when_cond.name.rchop
-            enum_members.reject! { |value| value.underscore == enum_value }
+            remove_enum_member_name_from_targets(targets, when_cond.name.rchop)
+          else
+            all_provable_patterns = false
           end
         when BoolLiteral
-          # Note that we found some bool literals
-          if when_cond.value
-            found_true = true
-          else
-            found_false = true
-          end
+          all_patterns_are_types = false
+
+          remove_bool_literal_from_targets(targets, when_cond.value)
         when NilLiteral
+          all_patterns_are_types = false
+
           # A nil literal is the same as matching the Nil type
-          cond_types.reject! &.nil_type?
+          remove_type_from_targets(targets, @program.nil_type)
         else
-          # Nothing to do
+          all_patterns_are_types = false
+          all_provable_patterns = false
         end
       end
     end
 
-    # If we found both `true` and `false` we covered Bool
-    if found_false && found_true
-      cond_types.delete(@program.bool)
-    end
+    targets.reject! &.covered?
 
     # If we covered all types, we are done.
     # This works even when matching against Bool or Enum.
-    return if cond_types.empty?
+    return if targets.empty?
 
-    # If we didn't cover all types, but we tried to match against types,
-    # we know the user forgot some types.
-    if all_whens_are_types
+    if targets.all?(&.is_a?(TypeTarget)) && all_patterns_are_types
       @program.report_warning(node, <<-MSG)
         case is not exhaustive.
 
-        Missing types: #{cond_types.join(", ")}
+        Missing types: #{targets.map(&.type).join(", ")}
         MSG
       return
     end
 
-    # Check the bool case
-    if single_cond_type.is_a?(BoolType) && !(found_false && found_true)
-      missing_cases = [] of String
-      missing_cases << "false" unless found_false
-      missing_cases << "true" unless found_true
+    single_target = targets.size == 1 ? targets.first : nil
 
+    case single_target
+    when BoolTarget
       @program.report_warning(node, <<-MSG)
         case is not exhaustive.
 
-        Missing cases: #{missing_cases.join(", ")}
+        Missing cases: #{single_target.missing_cases.join(", ")}
         MSG
       return
+    when EnumTarget
+      @program.report_warning(node, <<-MSG)
+        case is not exhaustive for enum #{single_target.type}.
+
+        Missing members: #{single_target.members.map(&.name).join(", ")}
+        MSG
+      return
+    else
+      # No specific error messages for non-single types
     end
 
-    # Check the enum case
-    if single_cond_type.is_a?(EnumType) && enum_members
-      # All enum members covered
-      return if enum_members.empty?
-
+    if all_provable_patterns && !has_flags_enum
       @program.report_warning(node, <<-MSG)
-        case is not exhaustive for enum #{single_cond_type}.
+        case is not exhaustive.
 
-        Missing members: #{enum_members.join(", ")}
+        Missing cases: #{targets.flat_map(&.missing_cases).join(", ")}
         MSG
       return
     end
@@ -164,5 +231,38 @@ struct Crystal::ExhaustivenessChecker
 
       Please add an `else` clause.
       MSG
+  end
+
+  private def remove_type_from_targets(targets, type : Type)
+    type = type.devirtualize
+    targets.reject! { |target| target.type.implements?(type) }
+  end
+
+  private def remove_enum_member_from_targets(targets, member)
+    targets.each do |target|
+      if target.is_a?(EnumTarget)
+        target.members.delete(member)
+      end
+    end
+  end
+
+  private def remove_enum_member_name_from_targets(targets, name)
+    targets.each do |target|
+      if target.is_a?(EnumTarget)
+        target.members.reject! { |member| member.name.underscore == name }
+      end
+    end
+  end
+
+  private def remove_bool_literal_from_targets(targets, bool)
+    targets.each do |target|
+      if target.is_a?(BoolTarget)
+        if bool
+          target.found_true = true
+        else
+          target.found_false = true
+        end
+      end
+    end
   end
 end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -1,0 +1,159 @@
+struct Crystal::ExhaustivenessChecker
+  def initialize(@program : Program)
+  end
+
+  def check(node : Case)
+    cond = node.cond
+
+    # No condition means it's just like a series of if/else
+    return unless cond
+
+    # TODO: check exhaustiveness over a tuple
+    return if cond.is_a?(TupleLiteral)
+
+    # If there's an else clause we don't need to check anything
+    return if node.else
+
+    cond_type = cond.type?
+
+    # No type on condition means we couldn't type it so we can't
+    # check of exhasutiveness.
+    return unless cond_type
+
+    # Compute all types that we must cover.
+    # We only take into account union types and single types,
+    # never virtual types because these can be extended.
+    #
+    # Also remember whether it's just a single type we are checking
+    # (useful for Bool and Enum later on).
+    if cond_type.is_a?(UnionType)
+      cond_types = cond_type.union_types.dup.map(&.devirtualize.as(Type))
+      single_cond_type = nil
+    else
+      cond_types = [cond_type.devirtualize]
+      single_cond_type = cond_type.devirtualize
+    end
+
+    # Are all when clauses types (paths)?
+    all_whens_are_types = true
+
+    # Did we find the `false` literal in any `when`?
+    found_false = false
+
+    # Did we find the `true` literal in any `when`?
+    found_true = false
+
+    # All enum members, as strings, in case we are matching against an enum
+    enum_members = if single_cond_type.is_a?(EnumType)
+                     single_cond_type.types.values.select(Const).map(&.name)
+                   else
+                     nil
+                   end
+
+    # Start checking each `when`...
+    node.whens.each do |a_when|
+      a_when.conds.each do |when_cond|
+        # In case of a Path that points to a type,
+        # remove that type from the types we must cover
+        if when_cond.is_a?(Path) &&
+           !when_cond.syntax_replacement && !when_cond.target_const &&
+           when_cond.type?
+          cond_types.reject! { |type| type.implements?(when_cond.type.devirtualize) }
+          next
+        end
+
+        # At this point we are matching against other things than types/paths
+        all_whens_are_types = false
+
+        # If we are matching against an enum type and the Path denotes an enum member,
+        # delete it from the members we must cover
+        if when_cond.is_a?(Path) &&
+           enum_members && single_cond_type.is_a?(EnumType) &&
+           (target_const = when_cond.target_const)
+          matching_member = single_cond_type.types.find { |k, v| v == target_const }
+          if matching_member
+            enum_members.delete(matching_member[1].name.to_s)
+          end
+        end
+
+        case when_cond
+        when Call
+          # Check if it's something like `.foo?` to remove that member from the ones
+          # we must cover.
+          # Note: a user could override the meaning of such methods.
+          # In the future it would be wise to mark these as non-redefinable
+          # so this checks are sounds.
+          if enum_members && when_cond.obj.is_a?(ImplicitObj) &&
+             when_cond.args.empty? && when_cond.named_args.nil? &&
+             !when_cond.block && !when_cond.block_arg && when_cond.name.ends_with?('?')
+            enum_value = when_cond.name.rchop
+            enum_members.reject! { |value| value.underscore == enum_value }
+          end
+        when BoolLiteral
+          # Note that we found some bool literals
+          if when_cond.value
+            found_true = true
+          else
+            found_false = true
+          end
+        else
+          # Nothing to do
+        end
+      end
+    end
+
+    # If we found both `true` and `false` we covered Bool
+    if found_false && found_true
+      cond_types.delete(@program.bool)
+    end
+
+    # If we covered all types, we are done.
+    # This works even when matching against Bool or Enum.
+    return if cond_types.empty?
+
+    # If we didn't cover all types, but we tried to match against types,
+    # we know the user forgot some types.
+    if all_whens_are_types
+      @program.report_warning(node, <<-MSG)
+        case is not exhaustive.
+
+        Missing types: #{cond_types.join(", ")}
+        MSG
+      return
+    end
+
+    # Check the bool case
+    if single_cond_type.is_a?(BoolType) && !(found_false && found_true)
+      missing_cases = [] of String
+      missing_cases << "false" unless found_false
+      missing_cases << "true" unless found_true
+
+      @program.report_warning(node, <<-MSG)
+        case is not exhaustive.
+
+        Missing cases: #{missing_cases.join(", ")}
+        MSG
+      return
+    end
+
+    # Check the enum case
+    if single_cond_type.is_a?(EnumType) && enum_members
+      # All enum members covered
+      return if enum_members.empty?
+
+      @program.report_warning(node, <<-MSG)
+        case is not exhaustive for enum #{single_cond_type}.
+
+        Missing members: #{enum_members.join(", ")}
+        MSG
+      return
+    end
+
+    # Otherwise we can't prove exhaustiveness and an `else` clause is required
+    @program.report_warning(node, <<-MSG)
+      can't prove case is exhaustive.
+
+      Please add an `else` clause.
+      MSG
+  end
+end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -372,9 +372,7 @@ struct Crystal::ExhaustivenessChecker
       when BoolPattern
         subtargets[pattern.value].each &.cover(patterns, index + 1)
       when UnderscorePattern
-        subtargets.each do |key, targets|
-          subtargets.each_value &.each &.cover(patterns, index + 1)
-        end
+        subtargets.each_value &.each &.cover(patterns, index + 1)
       when EnumMemberPattern, EnumMemberNamePattern
         # No cover
       end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -158,7 +158,10 @@ struct Crystal::ExhaustivenessChecker
             all_provable_patterns = false
           end
         else
-          # TODO ...
+          # Not a tuple literal so we don't care
+          # TOOD: one could put `Tuple` or `Object` here and that would make
+          # the entire tuple match, but who would do that?
+          # We can do it, but it has very low priority.
         end
       end
     end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -394,7 +394,7 @@ struct Crystal::ExhaustivenessChecker
       if subtargets = @subtargets
         subtargets.all? { |b, targets| targets.all? &.covered? }
       else
-        @type_covered || found_true? && found_false?
+        @type_covered || (found_true? && found_false?)
       end
     end
 

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -8,12 +8,6 @@ struct Crystal::ExhaustivenessChecker
 
     cond = node.cond
 
-    unless cond
-      @program.report_warning(node,
-        "case without condition must have an `else` clause.")
-      return
-    end
-
     # No condition means it's just like a series of if/else
     return unless cond
 

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -17,34 +17,27 @@ struct Crystal::ExhaustivenessChecker
     # No condition means it's just like a series of if/else
     return unless cond
 
-    # TODO: check exhaustiveness over a tuple
-    return if cond.is_a?(TupleLiteral)
+    if cond.is_a?(TupleLiteral)
+      check_tuple_exp(node, cond)
+    else
+      check_single_exp(node, cond)
+    end
+  end
 
+  private def check_single_exp(node, cond)
     cond_type = cond.type?
 
     # No type on condition means we couldn't type it so we can't
-    # check of exhasutiveness.
+    # check exhasutiveness.
     return unless cond_type
 
     # Compute all types that we must cover.
     # We only take into account union types and single types,
     # never virtual types because these can be extended.
-    if cond_type.is_a?(UnionType)
-      cond_types = cond_type.union_types.dup.map(&.devirtualize.as(Type))
-    else
-      cond_types = [cond_type.devirtualize]
-    end
+    cond_types = expand_types(cond_type)
 
     # Compute all the targets that we must cover
-    targets = cond_types.map do |cond_type|
-      if cond_type.is_a?(BoolType)
-        BoolTarget.new(cond_type)
-      elsif cond_type.is_a?(EnumType) && !cond_type.flags?
-        EnumTarget.new(cond_type)
-      else
-        TypeTarget.new(cond_type)
-      end
-    end
+    targets = cond_types.map { |cond_type| compute_target(cond_type) }
 
     # Are all patterns Path types?
     all_patterns_are_types = true
@@ -78,7 +71,6 @@ struct Crystal::ExhaustivenessChecker
     targets.reject! &.covered?
 
     # If we covered all types, we are done.
-    # This works even when matching against Bool or Enum.
     return if targets.empty?
 
     if targets.all?(&.is_a?(TypeTarget)) && all_patterns_are_types
@@ -128,6 +120,122 @@ struct Crystal::ExhaustivenessChecker
       MSG
   end
 
+  private def check_tuple_exp(node, cond)
+    elements = cond.elements
+
+    # No type on condition means we couldn't type it so we can't
+    # check exhasutiveness.
+    return unless elements.all? &.type?
+
+    element_types = elements.map &.type
+
+    all_expanded_types = element_types.map do |element_type|
+      expand_types(element_type)
+    end
+
+    # Compute all the targets that we must cover
+    targets = compute_targets(all_expanded_types)
+
+    # Are all patterns Path types?
+    all_patterns_are_types = true
+
+    # Are all patterns things that we can handle?
+    # For example an integer literal is something that we don't
+    # take into account for exhaustiveness.
+    all_provable_patterns = true
+
+    # Is any type a @[Flags] enum?
+    has_flags_enum = all_expanded_types.any? &.any? { |type| type.is_a?(EnumType) && type.flags? }
+
+    # Start checking each `when`...
+    node.whens.each do |a_when|
+      a_when.conds.each do |when_cond|
+        if when_cond.is_a?(TupleLiteral)
+          pattern_infos = when_cond.elements.map do |when_cond_exp|
+            when_pattern_info(when_cond_exp)
+          end
+
+          if !pattern_infos.all? &.pattern_is_type
+            all_patterns_are_types = false
+          end
+
+          if pattern_infos.all? &.pattern
+            patterns = pattern_infos.map &.pattern.not_nil!
+            targets.each &.cover(patterns, 0)
+          else
+            all_provable_patterns = false
+          end
+        else
+          # TODO ...
+        end
+      end
+    end
+
+    targets.reject! &.reject_covered!
+
+    # If we covered all types, we are done.
+    return if targets.empty?
+
+    # If all patterns are stuff we can handle, show the missing cases
+    if all_provable_patterns
+      missing_cases = targets
+        .flat_map(&.missing_cases)
+        .map { |cases| "{#{cases}}" }
+        .join(", ")
+
+      @program.report_warning(node, <<-MSG)
+      case is not exhaustive.
+
+      Missing cases: #{missing_cases}
+      MSG
+      return
+    end
+
+    # Otherwise we can't prove exhaustiveness and an `else` clause is required
+    @program.report_warning(node, <<-MSG)
+      can't prove case is exhaustive.
+
+      Please add an `else` clause.
+      MSG
+  end
+
+  private def compute_targets(type_groups)
+    type_groups.first.map do |type|
+      compute_target(type).tap do |target|
+        target.add_subtargets(type_groups, 1)
+      end
+    end
+  end
+
+  # Retuens an array of all the types inside `type`:
+  # for unions it's all the union types, otherwise it's just that type.
+  private def expand_types(type)
+    if type.is_a?(UnionType)
+      type.union_types.map(&.devirtualize.as(Type))
+    else
+      [type.devirtualize]
+    end
+  end
+
+  private def compute_target(type)
+    ExhaustivenessChecker.compute_target(type)
+  end
+
+  def self.compute_target(type)
+    case type
+    when BoolType
+      BoolTarget.new(type)
+    when EnumType
+      if type.flags?
+        TypeTarget.new(type)
+      else
+        EnumTarget.new(type)
+      end
+    else
+      TypeTarget.new(type)
+    end
+  end
+
   record PatternInfo,
     pattern : Pattern?,
     pattern_is_type : Bool do
@@ -144,7 +252,7 @@ struct Crystal::ExhaustivenessChecker
       if !when_cond.syntax_replacement && !when_cond.target_const &&
          when_cond.type?
         return PatternInfo.new(
-          pattern: TypePattern.new(when_cond.type),
+          pattern: TypePattern.new(when_cond.type.devirtualize),
           pattern_is_type: true
         )
       end
@@ -207,6 +315,11 @@ struct Crystal::ExhaustivenessChecker
   alias Pattern = TypePattern | EnumMemberPattern | EnumMemberNamePattern | BoolPattern
 
   # A target to check for exhaustiveness
+  #
+  # Every target can also have subtargets, used when matching against a tuple literal.
+  # For example, the BoolTarget will have one subtarget for the value `false` and
+  # one for the value `true`. When a pattern like `{false, ...}` is passed to it,
+  # only patterns for the `false` subtarget will be covered.
   abstract class Target
     # The type this target is based on.
     getter type
@@ -220,23 +333,35 @@ struct Crystal::ExhaustivenessChecker
     # Other, more specific, patterns will partially cover a target.
     def cover(pattern : Pattern) : Nil
       if pattern.is_a?(TypePattern)
-        if @type.implements?(pattern.type.devirtualize)
+        if @type.implements?(pattern.type)
           @type_covered = true
         end
       end
     end
+
+    # Covers this target and subsequent subtargets with the patterns starting
+    # at index.
+    abstract def cover(patterns : Array(Pattern), index : Int32) : Nil
+
+    # Removes covered subtargets from this target, and returns whether
+    # this target ended up being entirely covered.
+    abstract def reject_covered! : Bool
 
     # Was this target covered?
     abstract def covered? : Bool
 
     # What are the cases that we didn't cover?
     abstract def missing_cases : Array(String)
+
+    # Add subtargets for the given type groups, starting at index.
+    abstract def add_subtargets(type_groups : Array(Array(Type)), index : Int32) : Nil
   end
 
   # A bool target. Subtargets are the `false` and `true` literals.
   class BoolTarget < Target
     property? found_true = false
     property? found_false = false
+    property! subtargets : Hash(Bool, Target)
 
     def cover(pattern : Pattern) : Nil
       super
@@ -250,15 +375,71 @@ struct Crystal::ExhaustivenessChecker
       end
     end
 
+    def cover(patterns : Array(Pattern), index : Int32) : Nil
+      if index == patterns.size - 1
+        cover(patterns.last)
+        return
+      end
+
+      pattern = patterns[index]
+      case pattern
+      when TypePattern
+        if @type.implements?(pattern.type)
+          subtargets.each do |key, subtarget|
+            subtarget.cover(patterns, index + 1)
+          end
+        end
+      when BoolPattern
+        subtargets[pattern.value].cover(patterns, index + 1)
+      else
+        # Not a matching pattern
+      end
+    end
+
+    def reject_covered! : Bool
+      if subtargets = @subtargets
+        subtargets.reject! { |b, target| target.reject_covered! }
+        subtargets.all? { |b, target| target.covered? }
+      else
+        covered?
+      end
+    end
+
     def covered? : Bool
-      @type_covered || found_true? && found_false?
+      if subtargets = @subtargets
+        subtargets.all? { |b, target| target.covered? }
+      else
+        @type_covered || found_true? && found_false?
+      end
     end
 
     def missing_cases : Array(String)
-      missing_cases = [] of String
-      missing_cases << "false" unless found_false?
-      missing_cases << "true" unless found_true?
-      missing_cases
+      if subtargets = @subtargets
+        subtargets.flat_map do |bool, target|
+          target.missing_cases.map do |missing_case|
+            "#{bool}, #{missing_case}"
+          end
+        end
+      else
+        missing_cases = [] of String
+        missing_cases << "false" unless found_false?
+        missing_cases << "true" unless found_true?
+        missing_cases
+      end
+    end
+
+    def add_subtargets(type_groups : Array(Array(Type)), index : Int32) : Nil
+      return if index >= type_groups.size
+
+      subtargets = @subtargets = {} of Bool => Target
+
+      type_groups[index].each do |expanded_type|
+        {true, false}.each do |bool_value|
+          target = ExhaustivenessChecker.compute_target(expanded_type)
+          target.add_subtargets(type_groups, index + 1)
+          subtargets[bool_value] = target
+        end
+      end
     end
   end
 
@@ -267,6 +448,8 @@ struct Crystal::ExhaustivenessChecker
     getter members : Array(Const)
 
     @original_members_size : Int32
+
+    property! subtargets : Hash(Const, Target)
 
     def initialize(type)
       super
@@ -287,27 +470,145 @@ struct Crystal::ExhaustivenessChecker
       end
     end
 
+    def cover(patterns : Array(Pattern), index : Int32) : Nil
+      if index == patterns.size - 1
+        cover(patterns.last)
+        return
+      end
+
+      pattern = patterns[index]
+      case pattern
+      when TypePattern
+        if @type.implements?(pattern.type)
+          subtargets.each do |key, subtarget|
+            subtarget.cover(patterns, index + 1)
+          end
+        end
+      when EnumMemberPattern
+        subtargets.each do |member, target|
+          if member == pattern.member
+            target.cover(patterns, index + 1)
+          end
+        end
+      when EnumMemberNamePattern
+        subtargets.each do |member, target|
+          if member.name.underscore == pattern.name
+            target.cover(patterns, index + 1)
+          end
+        end
+      else
+        # Not a matching pattern
+      end
+    end
+
+    def reject_covered! : Bool
+      if subtargets = @subtargets
+        subtargets.reject! { |c, target| target.reject_covered! }
+        subtargets.all? { |c, target| target.covered? }
+      else
+        covered?
+      end
+    end
+
     def covered? : Bool
-      @type_covered || @members.empty?
+      if subtargets = @subtargets
+        subtargets.all? { |c, target| target.covered? }
+      else
+        @type_covered || @members.empty?
+      end
     end
 
     def missing_cases : Array(String)
-      if @original_members_size == @members.size
-        [type.to_s]
+      if subtargets = @subtargets
+        subtargets.flat_map do |const, target|
+          target.missing_cases.map do |missing_case|
+            "#{const}, #{missing_case}"
+          end
+        end
       else
-        @members.map(&.to_s)
+        if @original_members_size == @members.size
+          [type.to_s]
+        else
+          @members.map(&.to_s)
+        end
+      end
+    end
+
+    def add_subtargets(type_groups : Array(Array(Type)), index : Int32) : Nil
+      return if index >= type_groups.size
+
+      subtargets = @subtargets = {} of Const => Target
+
+      type_groups[index].each do |expanded_type|
+        @members.each do |member|
+          target = ExhaustivenessChecker.compute_target(expanded_type)
+          target.add_subtargets(type_groups, index + 1)
+          subtargets[member] = target
+        end
       end
     end
   end
 
   # Any other target is a type target. The target to cover is the type itself.
   class TypeTarget < Target
+    property! subtargets : Array(Target)
+
+    def cover(patterns : Array(Pattern), index : Int32) : Nil
+      if index == patterns.size - 1
+        cover(patterns.last)
+        return
+      end
+
+      pattern = patterns[index]
+      case pattern
+      when TypePattern
+        if @type.implements?(pattern.type)
+          subtargets.each &.cover(patterns, index + 1)
+        end
+      else
+        # Not a matching pattern
+      end
+    end
+
+    def reject_covered! : Bool
+      if subtargets = @subtargets
+        subtargets.reject! &.reject_covered!
+        subtargets.all? &.covered?
+      else
+        covered?
+      end
+    end
+
     def covered? : Bool
-      @type_covered
+      if subtargets = @subtargets
+        subtargets.all? &.covered?
+      else
+        @type_covered
+      end
     end
 
     def missing_cases : Array(String)
-      [type.to_s]
+      if subtargets = @subtargets
+        subtargets.flat_map do |target|
+          target.missing_cases.map do |missing_case|
+            "#{type}, #{missing_case}"
+          end
+        end
+      else
+        [type.to_s]
+      end
+    end
+
+    def add_subtargets(type_groups : Array(Array(Type)), index : Int32) : Nil
+      return if index >= type_groups.size
+
+      subtargets = @subtargets = [] of Target
+
+      type_groups[index].each do |expanded_type|
+        target = ExhaustivenessChecker.compute_target(expanded_type)
+        target.add_subtargets(type_groups, index + 1)
+        subtargets << target
+      end
     end
   end
 end

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -3,16 +3,22 @@ struct Crystal::ExhaustivenessChecker
   end
 
   def check(node : Case)
+    # If there's an else clause we don't need to check anything
+    return if node.else
+
     cond = node.cond
+
+    unless cond
+      @program.report_warning(node,
+        "case without condition must have an `else` clause.")
+      return
+    end
 
     # No condition means it's just like a series of if/else
     return unless cond
 
     # TODO: check exhaustiveness over a tuple
     return if cond.is_a?(TupleLiteral)
-
-    # If there's an else clause we don't need to check anything
-    return if node.else
 
     cond_type = cond.type?
 

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -144,9 +144,6 @@ struct Crystal::ExhaustivenessChecker
     # take into account for exhaustiveness.
     all_provable_patterns = true
 
-    # Is any type a @[Flags] enum?
-    has_flags_enum = all_expanded_types.any? &.any? { |type| type.is_a?(EnumType) && type.flags? }
-
     # Start checking each `when`...
     node.whens.each do |a_when|
       a_when.conds.each do |when_cond|
@@ -183,11 +180,11 @@ struct Crystal::ExhaustivenessChecker
         .join("\n - ")
 
       @program.report_warning(node, <<-MSG)
-      case is not exhaustive.
+        case is not exhaustive.
 
-      Missing cases:
-       - #{missing_cases}
-      MSG
+        Missing cases:
+         - #{missing_cases}
+        MSG
       return
     end
 

--- a/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
@@ -66,6 +66,8 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
       initializers << Initializer.new(current_type, target, value, MetaVars.new)
       node.type = @program.nil
       return
+    else
+      # TODO: can this happen?
     end
   end
 

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -194,6 +194,8 @@ class Crystal::Call
       return if convert_numeric_argument self_arg, unaliased_type, expected_type, actual_type, index
     when FloatType
       return if convert_numeric_argument self_arg, unaliased_type, expected_type, actual_type, index
+    else
+      # go on
     end
 
     implicit_call = Conversions.try_to_unsafe(self_arg.clone, parent_visitor) do |ex|

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -639,7 +639,11 @@ module Crystal
           if cond.name == "class"
             return IsA.new(right_side, Metaclass.new(obj.clone).at(obj))
           end
+        else
+          # no special treatment
         end
+      else
+        # no special treatment
       end
 
       Call.new(cond, "===", right_side)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3016,6 +3016,15 @@ module Crystal
     end
 
     def visit(node : Case)
+      # For exhaustiveness check, which is done in CleanupTransformer,
+      # we need to know the type of `cond`. However, LiteralExpander will
+      # work with copies of `cond` in case they are Var or InstanceVar so
+      # here we type them so their type is available later on.
+      cond = node.cond
+      if cond.is_a?(Var) || cond.is_a?(InstanceVar)
+        cond.accept(self)
+      end
+
       expand(node)
       false
     end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3045,8 +3045,12 @@ module Crystal
       # work with copies of `cond` in case they are Var or InstanceVar so
       # here we type them so their type is available later on.
       cond = node.cond
-      if cond.is_a?(Var) || cond.is_a?(InstanceVar)
-        cond.accept(self)
+      case cond
+      when Var          then cond.accept(self)
+      when InstanceVar  then cond.accept(self)
+      when TupleLiteral then cond.accept(self)
+      else
+        # Nothing to do
       end
 
       expand(node)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3046,9 +3046,17 @@ module Crystal
       # here we type them so their type is available later on.
       cond = node.cond
       case cond
-      when Var          then cond.accept(self)
-      when InstanceVar  then cond.accept(self)
-      when TupleLiteral then cond.accept(self)
+      when Var         then cond.accept(self)
+      when InstanceVar then cond.accept(self)
+      when TupleLiteral
+        cond.elements.each do |element|
+          case element
+          when Var         then element.accept(self)
+          when InstanceVar then element.accept(self)
+          else
+            # Nothing to do
+          end
+        end
       else
         # Nothing to do
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -443,6 +443,8 @@ module Crystal
           node.bind_to(var)
           return false
         end
+      else
+        raise "Bug: unexpected var type: #{var.class}"
       end
 
       node.type = @program.nil
@@ -522,6 +524,8 @@ module Crystal
 
         class_var = visit_class_var var
         class_var.thread_local = true if thread_local
+      else
+        raise "Bug: unexpected var type: #{var.class}"
       end
 
       node.type = @program.nil unless node.type?
@@ -585,10 +589,10 @@ module Crystal
         expanded.accept self
         node.bind_to expanded
         node.expanded = expanded
-        return false
+      else
+        visit_global node
       end
 
-      visit_global node
       false
     end
 
@@ -627,12 +631,12 @@ module Crystal
     def lookup_similar_instance_variable_name(node, owner)
       case owner
       when NonGenericModuleType, GenericClassType, GenericModuleType
-        return nil
-      end
-
-      Levenshtein.find(node.name) do |finder|
-        owner.all_instance_vars.each_key do |name|
-          finder.test(name)
+        nil
+      else
+        Levenshtein.find(node.name) do |finder|
+          owner.all_instance_vars.each_key do |name|
+            finder.test(name)
+          end
         end
       end
     end
@@ -1380,9 +1384,9 @@ module Crystal
         case exp
         when Var, InstanceVar, ClassVar, Global
           next
+        else
+          return true
         end
-
-        return true
       end
 
       false
@@ -1405,6 +1409,8 @@ module Crystal
         case exp
         when Var, InstanceVar, ClassVar, Global
           next
+        else
+          # go on
         end
 
         temp_var = @program.new_temp_var.at(arg.location)
@@ -1517,6 +1523,8 @@ module Crystal
               arg.args.push TypeNode.new(arg_type)
             end
           end
+        else
+          # keep checking
         end
       end
     end
@@ -1546,6 +1554,8 @@ module Crystal
           if instance_type.namespace.is_a?(LibType) && (named_args = node.named_args)
             return special_c_struct_or_union_new_with_named_args(node, instance_type, named_args)
           end
+        else
+          # go on, nothing special
         end
       end
 
@@ -1817,6 +1827,8 @@ module Crystal
       when Expressions
         return unless exp = exp.single_expression?
         return get_expression_var(exp)
+      else
+        # go on
       end
       nil
     end
@@ -1841,6 +1853,8 @@ module Crystal
         node.raise "can't cast to Reference yet"
       when @program.class_type
         node.raise "can't cast to Class yet"
+      else
+        # go on
       end
 
       obj_type = node.obj.type?
@@ -1946,6 +1960,8 @@ module Crystal
         elsif or_right_type_filters
           filter_vars or_right_type_filters.not
         end
+      else
+        # go on
       end
 
       before_else_vars = @vars.dup
@@ -1966,6 +1982,8 @@ module Crystal
           @or_left_type_filters = or_left_type_filters = then_type_filters
           @or_right_type_filters = or_right_type_filters = else_type_filters
           @type_filters = TypeFilters.or(cond_type_filters, then_type_filters, else_type_filters)
+        else
+          # go on: a regular if
         end
       end
 
@@ -2257,6 +2275,8 @@ module Crystal
       when Expressions
         return unless node = node.single_expression?
         return get_while_cond_assign_target(node)
+      else
+        # go on
       end
 
       nil
@@ -2413,13 +2433,13 @@ module Crystal
         node.raise "can't create instance of a union type"
       when PointerInstanceType
         node.raise "can't create instance of a pointer type"
-      end
+      else
+        if !instance_type.virtual? && instance_type.abstract?
+          node.raise "can't instantiate abstract #{instance_type.type_desc} #{instance_type}"
+        end
 
-      if !instance_type.virtual? && instance_type.abstract?
-        node.raise "can't instantiate abstract #{instance_type.type_desc} #{instance_type}"
+        node.type = instance_type
       end
-
-      node.type = instance_type
     end
 
     def visit_pointer_malloc(node)
@@ -2480,6 +2500,8 @@ module Crystal
           node.extra = convert_call
           return
         end
+      else
+        # go on
       end
 
       unsafe_call = Conversions.to_unsafe(node, Var.new("value").at(node), self, actual_type, expected_type)
@@ -2543,6 +2565,8 @@ module Crystal
         return unless obj_type.is_a?(LibType)
 
         obj_type.lookup_var(exp.name)
+      else
+        nil
       end
     end
 
@@ -3076,6 +3100,8 @@ module Crystal
         case exp
         when Var, IsA, RespondsTo, Not
           return type_filters.not
+        else
+          # go on
         end
       end
 

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -37,6 +37,8 @@ module Crystal
                 false
               when NonGenericClassType, GenericClassType
                 true
+              else
+                false
               end
 
       if check

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -75,6 +75,8 @@ module Crystal
           end
           node.has_parentheses = true
         end
+      else
+        # not a special call
       end
 
       # Convert 'a <= b <= c' to 'a <= b && b <= c'

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -760,6 +760,8 @@ module Crystal
             context.set_free_var(name, type_var)
             return type_var
           end
+        else
+          # Restriction is not possible (maybe retur nil here?)
         end
       else
         type_var = type_var.type? || type_var

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -376,6 +376,8 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
               expanded = expanded_type.value
             when Type
               expanded = TypeNode.new(expanded_type)
+            else
+              # go on
             end
           end
           expanded
@@ -497,8 +499,8 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
   def class_var_owner(node)
     scope = (@scope || current_type).class_var_owner
-    case scope
-    when Program
+
+    if scope.is_a?(Program)
       node.raise "can't use class variables at the top level"
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -185,6 +185,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
           type.extern = true
         when @program.packed_annotation
           type.packed = true
+        else
+          # not a built-in annotation
         end
       end
 
@@ -349,6 +351,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
                       receiver.raise "can't define method in generic instance #{metaclass}"
                     when GenericModuleInstanceMetaclassType
                       receiver.raise "can't define method in generic instance #{metaclass}"
+                    else
+                      # go on
                     end
                     metaclass
                   end
@@ -458,6 +462,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         type.add_link_annotation(LinkAnnotation.from(ann))
       when @program.call_convention_annotation
         type.call_convention = parse_call_convention(ann, type.call_convention)
+      else
+        # not a built-in annotation
       end
       type.add_annotation(annotation_type, ann)
     end
@@ -807,6 +813,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       # Don't give an error yet: wait to see if the
       # call doesn't resolve to a method/macro
       return false
+    else
+      # go on
     end
 
     node.raise "can't apply visibility modifier"

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -408,6 +408,8 @@ struct Crystal::TypeDeclarationProcessor
         process_owner_guessed_instance_var_declaration(including_type, name, type_info)
         remove_error including_type, name
       end
+    else
+      # TODO: can this be reached?
     end
   end
 
@@ -643,6 +645,8 @@ struct Crystal::TypeDeclarationProcessor
           error.node.raise "can't use #{error.type} as the type of class variable '#{name}' of #{type}, use a more specific type"
         when .starts_with?("@")
           error.node.raise "can't use #{error.type} as the type of instance variable '#{name}' of #{type}, use a more specific type"
+        else
+          # TODO: can this be reached?
         end
       end
     end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -151,6 +151,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
       declare_instance_var(node, var)
     when ClassVar
       declare_class_var(node, var, false)
+    else
+      raise "Unexpected TypeDeclaration var type: #{var.class}"
     end
 
     false
@@ -218,6 +220,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     when NonGenericModuleType
       declare_instance_var(owner, node, var)
       return
+    else
+      # Error, continue
     end
 
     node.raise "can only declare instance variables of a non-generic class, not a #{owner.type_desc} (#{owner})"
@@ -253,6 +257,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
       declare_instance_var(node, var)
     when ClassVar
       declare_class_var(node, var, true)
+    else
+      # nothing (it's a var)
     end
     false
   end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -110,6 +110,8 @@ module Crystal
           process_uninitialized_instance_var(owner, var, node.declared_type)
         when GenericModuleType
           process_uninitialized_instance_var(owner, var, node.declared_type)
+        else
+          # TODO: can this be reached?
         end
       end
     end
@@ -190,6 +192,8 @@ module Crystal
             process_lib_out(owner, exp, type)
           when GenericModuleType
             process_lib_out(owner, exp, type)
+          else
+            # TODO: can this be reached?
           end
         end
       end
@@ -278,6 +282,8 @@ module Crystal
 
                 owner_vars = @class_vars[owner] ||= {} of String => TypeInfo
                 add_type_info(owner_vars, target.name, tuple_type, target)
+              else
+                # TODO: can this be reached?
               end
             end
           end
@@ -313,6 +319,8 @@ module Crystal
         value = process_assign_instance_var(owner, target, value)
       when GenericModuleType
         value = process_assign_instance_var(owner, target, value)
+      else
+        # go on
       end
 
       unless current_type.allows_instance_vars?

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -94,16 +94,16 @@ class Crystal::Type
         if @raise
           node.raise "#{type_var} is not a type, it's a constant"
         else
-          return nil
+          nil
         end
       when Type
-        return type_var
-      end
-
-      if @raise
-        raise_undefined_constant(node)
+        type_var
       else
-        nil
+        if @raise
+          raise_undefined_constant(node)
+        else
+          nil
+        end
       end
     end
 
@@ -246,6 +246,8 @@ class Crystal::Type
             type_var.raise "can only splat tuple type, not #{splat_type}"
           end
           next
+        else
+          # go on
         end
 
         # Check the case of T resolving to a number
@@ -264,6 +266,8 @@ class Crystal::Type
           when ASTNode
             type_vars << type
             next
+          else
+            # go on
           end
         end
 
@@ -274,6 +278,8 @@ class Crystal::Type
         case instance_type
         when GenericUnionType, PointerType, StaticArrayType, TupleType, ProcType
           check_type_can_be_stored(type_var, type, "can't use #{type} as a generic type argument")
+        else
+          # go on
         end
 
         type_vars << type.virtual_type

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -13,6 +13,8 @@ module Crystal
         first, second = types
         did_merge, merged_type = type_merge_two(first, second)
         return merged_type if did_merge
+      else
+        # combined_union_of
       end
 
       combined_union_of compact_types(types)
@@ -29,6 +31,8 @@ module Crystal
         first, second = nodes
         did_merge, merged_type = type_merge_two(first.type?, second.type?)
         return merged_type if did_merge
+      else
+        # combined_union_of
       end
 
       combined_union_of compact_types(nodes, &.type?)
@@ -340,29 +344,29 @@ private def class_common_ancestor(t1, t2)
 
   case t1
   when t1.program.struct, t1.program.number, t1.program.int, t1.program.float
-    return nil
+    nil
   when t2
-    return t1
+    t1
+  else
+    if t1.depth == t2.depth
+      t1_superclass = t1.superclass
+      t2_superclass = t2.superclass
+
+      if t1_superclass && t2_superclass
+        return t1_superclass.common_ancestor(t2_superclass)
+      end
+    elsif t1.depth > t2.depth
+      t1_superclass = t1.superclass
+      if t1_superclass
+        return t1_superclass.common_ancestor(t2)
+      end
+    elsif t1.depth < t2.depth
+      t2_superclass = t2.superclass
+      if t2_superclass
+        return t1.common_ancestor(t2_superclass)
+      end
+    end
+
+    nil
   end
-
-  if t1.depth == t2.depth
-    t1_superclass = t1.superclass
-    t2_superclass = t2.superclass
-
-    if t1_superclass && t2_superclass
-      return t1_superclass.common_ancestor(t2_superclass)
-    end
-  elsif t1.depth > t2.depth
-    t1_superclass = t1.superclass
-    if t1_superclass
-      return t1_superclass.common_ancestor(t2)
-    end
-  elsif t1.depth < t2.depth
-    t2_superclass = t2.superclass
-    if t2_superclass
-      return t1.common_ancestor(t2_superclass)
-    end
-  end
-
-  nil
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -849,6 +849,8 @@ module Crystal
           if next_char == 'n' && next_char == 'o' && next_char == 't' && next_char == 'a' && next_char == 't' && next_char == 'i' && next_char == 'o' && next_char == 'n'
             return check_ident_or_keyword(:annotation, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'b'
@@ -861,6 +863,8 @@ module Crystal
           if next_char == 'e' && next_char == 'a' && next_char == 'k'
             return check_ident_or_keyword(:break, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'c'
@@ -873,6 +877,8 @@ module Crystal
           if next_char == 'a' && next_char == 's' && next_char == 's'
             return check_ident_or_keyword(:class, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'd'
@@ -882,6 +888,8 @@ module Crystal
             return check_ident_or_keyword(:def, start)
           end
         when 'o' then return check_ident_or_keyword(:do, start)
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'e'
@@ -895,7 +903,11 @@ module Crystal
               if next_char == 'f'
                 return check_ident_or_keyword(:elsif, start)
               end
+            else
+              # scan_ident
             end
+          else
+            # scan_ident
           end
         when 'n'
           case next_char
@@ -909,11 +921,15 @@ module Crystal
             if next_char == 'm'
               return check_ident_or_keyword(:enum, start)
             end
+          else
+            # scan_ident
           end
         when 'x'
           if next_char == 't' && next_char == 'e' && next_char == 'n' && next_char == 'd'
             return check_ident_or_keyword(:extend, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'f'
@@ -930,6 +946,8 @@ module Crystal
           if next_char == 'n'
             return check_ident_or_keyword(:fun, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'i'
@@ -947,6 +965,8 @@ module Crystal
               if next_char == 't' && next_char == 'a' && next_char == 'n' && next_char == 'c' && next_char == 'e' && next_char == '_' && next_char == 's' && next_char == 'i' && next_char == 'z' && next_char == 'e' && next_char == 'o' && next_char == 'f'
                 return check_ident_or_keyword(:instance_sizeof, start)
               end
+            else
+              # scan_ident
             end
           else
             next_char
@@ -958,6 +978,8 @@ module Crystal
           if next_char == '_' && next_char == 'a' && next_char == '?'
             return check_ident_or_keyword(:is_a?, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'l'
@@ -966,6 +988,8 @@ module Crystal
           if next_char == 'b'
             return check_ident_or_keyword(:lib, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'm'
@@ -980,7 +1004,11 @@ module Crystal
             if next_char == 'u' && next_char == 'l' && next_char == 'e'
               return check_ident_or_keyword(:module, start)
             end
+          else
+            # scan_ident
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'n'
@@ -998,7 +1026,11 @@ module Crystal
             else
               return check_ident_or_keyword(:nil, start)
             end
+          else
+            # scan_ident
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'o'
@@ -1016,6 +1048,8 @@ module Crystal
           if next_char == 't'
             return check_ident_or_keyword(:out, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'p'
@@ -1034,7 +1068,11 @@ module Crystal
             if next_char == 't' && next_char == 'e' && next_char == 'c' && next_char == 't' && next_char == 'e' && next_char == 'd'
               return check_ident_or_keyword(:protected, start)
             end
+          else
+            # scan_ident
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'r'
@@ -1051,6 +1089,8 @@ module Crystal
               if next_char == 'o' && next_char == 'n' && next_char == 'd' && next_char == 's' && next_char == '_' && next_char == 't' && next_char == 'o' && next_char == '?'
                 return check_ident_or_keyword(:responds_to?, start)
               end
+            else
+              # scan_ident
             end
           when 't'
             if next_char == 'u' && next_char == 'r' && next_char == 'n'
@@ -1060,7 +1100,11 @@ module Crystal
             if next_char == 'u' && next_char == 'i' && next_char == 'r' && next_char == 'e'
               return check_ident_or_keyword(:require, start)
             end
+          else
+            # scan_ident
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 's'
@@ -1074,6 +1118,8 @@ module Crystal
               end
             when 'f'
               return check_ident_or_keyword(:self, start)
+            else
+              # scan_ident
             end
           end
         when 'i'
@@ -1088,6 +1134,8 @@ module Crystal
           if next_char == 'p' && next_char == 'e' && next_char == 'r'
             return check_ident_or_keyword(:super, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 't'
@@ -1111,6 +1159,8 @@ module Crystal
               return check_ident_or_keyword(:type, start)
             end
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'u'
@@ -1126,6 +1176,8 @@ module Crystal
               if next_char == 'i' && next_char == 't' && next_char == 'i' && next_char == 'a' && next_char == 'l' && next_char == 'i' && next_char == 'z' && next_char == 'e' && next_char == 'd'
                 return check_ident_or_keyword(:uninitialized, start)
               end
+            else
+              # scan_ident
             end
           when 'l'
             if next_char == 'e' && next_char == 's' && next_char == 's'
@@ -1135,6 +1187,8 @@ module Crystal
             if next_char == 'i' && next_char == 'l'
               return check_ident_or_keyword(:until, start)
             end
+          else
+            # scan_ident
           end
         end
         scan_ident(start)
@@ -1155,11 +1209,15 @@ module Crystal
             if next_char == 'l' && next_char == 'e'
               return check_ident_or_keyword(:while, start)
             end
+          else
+            # scan_ident
           end
         when 'i'
           if next_char == 't' && next_char == 'h'
             return check_ident_or_keyword(:with, start)
           end
+        else
+          # scan_ident
         end
         scan_ident(start)
       when 'y'
@@ -1211,6 +1269,8 @@ module Crystal
                 return @token
               end
             end
+          else
+            # scan_ident
           end
         else
           unless ident_part?(current_char)
@@ -1556,6 +1616,8 @@ module Crystal
         end
 
         check_value_fits_in_uint64 string_value, num_size, start
+      else
+        # TODO: handle i128 and u128
       end
     end
 
@@ -2189,6 +2251,8 @@ module Crystal
               next_char
               nest += 1
             end
+          else
+            # no nesting
           end
         end
 
@@ -2249,8 +2313,9 @@ module Crystal
             break
           when '\0'
             raise "unterminated macro"
+          else
+            char = next_char
           end
-          char = next_char
         end
         @token.type = :MACRO_LITERAL
         @token.value = string_range(start)
@@ -2305,6 +2370,8 @@ module Crystal
               nest += 1
               whitespace = true
             end
+          else
+            # not a keyword
           end
         else
           whitespace = false
@@ -2403,6 +2470,8 @@ module Crystal
                 if delimiter_state.open_count == 0
                   delimiter_state = nil
                 end
+              else
+                # Nothing to do
               end
             end
 
@@ -2477,6 +2546,8 @@ module Crystal
           end
         when 'n'
           next_char == 'n' && next_char == 'o' && next_char == 't' && next_char == 'a' && next_char == 't' && next_char == 'i' && next_char == 'o' && next_char == 'n' && peek_not_ident_part_or_end_next_char && :annotation
+        else
+          false
         end
       when 'b'
         next_char == 'e' && next_char == 'g' && next_char == 'i' && next_char == 'n' && peek_not_ident_part_or_end_next_char && :begin

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -619,6 +619,8 @@ module Crystal
           case atomic
           when ClassDef, ModuleDef, EnumDef, FunDef, Def
             break
+          else
+            # continue chaining
           end
 
           # Allow '.' after newline for chaining calls
@@ -1410,6 +1412,8 @@ module Crystal
         end
       when :CONST, :"::"
         types = parse_rescue_types
+      else
+        # keep going
       end
 
       check SemicolonOrNewLine
@@ -1984,6 +1988,8 @@ module Crystal
         end
 
         result = RegexLiteral.new(result, options)
+      else
+        # no special treatment
       end
 
       result.end_location = token_end_location
@@ -2952,6 +2958,8 @@ module Crystal
         else
           unexpected_token @token.to_s, "parentheses are mandatory for macro arguments"
         end
+      else
+        # keep going
       end
 
       end_location = nil
@@ -3123,8 +3131,7 @@ module Crystal
     def parse_macro_control(start_location, macro_state = Token::MacroState.default)
       next_token_skip_space_or_newline
 
-      case @token.type
-      when :IDENT
+      if @token.type == :IDENT
         case @token.value
         when :for
           next_token_skip_space
@@ -3169,6 +3176,8 @@ module Crystal
             if (exp = macro_if.exp).is_a?(If)
               exp.then, exp.else = exp.else, exp.then
             end
+          else
+            # Nothing special to do
           end
           return macro_if
         when :begin
@@ -3203,6 +3212,8 @@ module Crystal
           check :"%}"
 
           return MacroVerbatim.new(body).at_end(token_end_location)
+        else
+          # will be parsed as a normal expression
         end
       end
 
@@ -3588,6 +3599,8 @@ module Crystal
         double_splat = true
         allow_external_name = false
         next_token_skip_space
+      else
+        # not a splat
       end
 
       found_space = false
@@ -3885,6 +3898,8 @@ module Crystal
           a_else = parse_expressions
         when :elsif
           a_else = parse_if check_end: false
+        else
+          # go on
         end
       end
 
@@ -3953,6 +3968,8 @@ module Crystal
       when :nil?
         obj = Var.new("self").at(location)
         return parse_nil?(obj)
+      else
+        # Not a special call, go on
       end
 
       name = @token.value.to_s
@@ -3982,6 +3999,8 @@ module Crystal
         @calls_initialize = true
       when "previous_def"
         @calls_previous_def = true
+      else
+        # Not a special call
       end
 
       call_args = preserve_stop_on_do(@stop_on_do) { parse_call_args stop_on_do_after_space: @stop_on_do }
@@ -4357,6 +4376,8 @@ module Crystal
         return nil unless next_comes_colon_space?
       when :yield
         return nil if @stop_on_yield > 0 && !next_comes_colon_space?
+      else
+        # keep going
       end
 
       args = [] of ASTNode
@@ -4505,6 +4526,8 @@ module Crystal
             splat = :double
             next_token
           end
+        else
+          # not a splat
         end
 
         arg = parse_op_assign_no_control
@@ -4518,6 +4541,8 @@ module Crystal
           arg = Splat.new(arg).at(arg.location)
         when :double
           arg = DoubleSplat.new(arg).at(arg.location)
+        else
+          # no splat
         end
 
         arg
@@ -4575,12 +4600,13 @@ module Crystal
 
       global = false
 
-      case @token.type
-      when :"::"
+      if @token.type == :UNDERSCORE
+        return node_and_next_token Underscore.new.at(location)
+      end
+
+      if @token.type == :"::"
         global = true
         next_token_skip_space_or_newline
-      when :UNDERSCORE
-        return node_and_next_token Underscore.new.at(location)
       end
 
       check :CONST
@@ -4862,8 +4888,7 @@ module Crystal
           end
         else
           if allow_primitives
-            case @token.type
-            when :NUMBER
+            if @token.type == :NUMBER
               num = NumberLiteral.new(@token.value.to_s, @token.number_kind).at(@token.location)
               types << node_and_next_token(num)
               skip_space
@@ -4975,34 +5000,32 @@ module Crystal
           next_token_skip_space
           if @token.type == :"."
             next_token_skip_space
-            if @token.keyword?(:class)
-              return true
-            end
+            @token.keyword?(:class)
           else
-            return true
+            true
           end
         when :UNDERSCORE
-          return true
+          true
         when :"->"
-          return true
+          true
         when :"*"
           next_token
-          return true if @token.type == :CONST
+          @token.type == :CONST
         when :NUMBER
-          return allow_int && @token.number_kind == :i32
+          allow_int && @token.number_kind == :i32
         when :IDENT
           case @token.value
           when :typeof, :self, :sizeof, :instance_sizeof, :offsetof
-            return true
+            true
+          else
+            false
           end
         when :"::"
           next_token_skip_space
-          if @token.type == :CONST
-            return true
-          end
+          @token.type == :CONST
+        else
+          false
         end
-
-        false
       ensure
         @token.copy_from(@temp_token)
         self.current_pos, @line_number, @column_number = old_pos, old_line, old_column
@@ -5702,6 +5725,8 @@ module Crystal
           when :protected
             visibility = Visibility::Protected
             next_token_skip_space
+          else
+            # not a visibility modifier
           end
 
           def_location = @token.location
@@ -5752,21 +5777,17 @@ module Crystal
     def end_token?
       case @token.type
       when :"}", :"]", :"%}", :EOF
-        return true
-      end
-
-      if @token.type == :IDENT
+        true
+      when :IDENT
         case @token.value
         when :do, :end, :else, :elsif, :when, :rescue, :ensure, :then
-          if next_comes_colon_space?
-            return false
-          end
-
-          return true
+          !next_comes_colon_space?
+        else
+          false
         end
+      else
+        false
       end
-
-      false
     end
 
     def can_be_assigned?(node)
@@ -5868,7 +5889,11 @@ module Crystal
           unless next_comes_colon_space?
             raise "void value expression", @token, @token.value.to_s.size
           end
+        else
+          # not a void expression
         end
+      else
+        # not a void expression
       end
     end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -201,6 +201,8 @@ module Crystal
         @str << "begin"
         @indent += 1
         newline
+      else
+        # Not a special condition
       end
 
       if @inside_macro > 0
@@ -222,6 +224,8 @@ module Crystal
         @indent -= 1
         append_indent
         @str << "end"
+      else
+        # Not a special condition
       end
 
       false

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -60,19 +60,20 @@ module Crystal
     def needs_suffix?(node : NumberLiteral)
       case node.kind
       when :i32
-        return false
+        false
       when :f64
         # If there's no '.' nor 'e', for example in `1_f64`,
         # we need to include it (#3315)
         node.value.each_char do |char|
-          case char
-          when '.', 'e'
+          if char == '.' || char == 'e'
             return false
           end
         end
-      end
 
-      true
+        true
+      else
+        true
+      end
     end
 
     def visit(node : CharLiteral)
@@ -522,6 +523,8 @@ module Crystal
         @str << exp.value.inspect_unquoted.gsub('`', "\\`")
       when StringInterpolation
         visit_interpolation exp, &.inspect_unquoted.gsub('`', "\\`")
+      else
+        raise "Bug: shouldn't happen"
       end
       @str << '`'
       false
@@ -885,6 +888,8 @@ module Crystal
             @str << ']'
             return false
           end
+        else
+          # Not a special type
         end
       end
 
@@ -1011,6 +1016,8 @@ module Crystal
           Regex.append_source exp.value, @str
         when StringInterpolation
           visit_interpolation(exp) { |s| Regex.append_source s, @str }
+        else
+          raise "Bug: shouldn't happen"
         end
         @str << '/'
       end

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -239,6 +239,8 @@ module Crystal
         if (obj = cond.obj).is_a?(Var)
           filters = TypeFilters.new(obj, SimpleTypeFilter.new(cond.const.type))
         end
+      else
+        # go on
       end
 
       if filters

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -282,9 +282,9 @@ class Crystal::Doc::Generator
       case type
       when Const, LibType
         next
+      else
+        types << type(type) if must_include? type
       end
-
-      types << type(type) if must_include? type
     end
 
     types.sort_by! &.name.downcase

--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -124,6 +124,8 @@ module Crystal::Doc::Highlighter
         break
       when :EOF
         raise "Unterminated symbol array literal"
+      else
+        raise "Bug: shouldn't happen"
       end
     end
   end

--- a/src/compiler/crystal/tools/doc/markdown/parser.cr
+++ b/src/compiler/crystal/tools/doc/markdown/parser.cr
@@ -409,6 +409,8 @@ class Crystal::Doc::Markdown::Parser
           cursor = pos + 1
           in_link = false
         end
+      else
+        # Nothing
       end
       last_is_space = pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
       pos += 1
@@ -446,6 +448,8 @@ class Crystal::Doc::Markdown::Parser
         if bracket_count == 0
           break
         end
+      else
+        # nothing to do
       end
       pos += 1
     end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -250,6 +250,8 @@ class Crystal::Doc::Method
     end
 
     case return_type
+    when Nil
+      # Nothing to do
     when ASTNode
       io << " : "
       node_to_html return_type, io, links: links

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -490,6 +490,8 @@ module Crystal
         when :DELIMITER_END
           heredoc_end = @line
           break
+        else
+          raise "Bug: unexpected token: #{@token.type}"
         end
       end
 
@@ -767,6 +769,8 @@ module Crystal
             write @token.raw
             next_token
             break
+          else
+            raise "Bug: unexpected token #{@token.type}"
           end
           count += 1
         end
@@ -3028,6 +3032,8 @@ module Crystal
         else
           clear_object(node.obj)
         end
+      else
+        # nothing to do
       end
     end
 
@@ -3290,6 +3296,8 @@ module Crystal
         write_keyword :private, " "
       when .protected?
         write_keyword :protected, " "
+      when .public?
+        # no keyword needed
       end
       accept node.exp
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -147,6 +147,8 @@ module Crystal
       when name.index("__")                  then raise Error.new("NAME must not have consecutive underscores")
       when !name.each_char.all? { |c| c.alphanumeric? || c == '-' || c == '_' }
         raise Error.new("NAME must only contain alphanumerical characters, underscores or dashes")
+      else
+        # name is valid
       end
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -354,6 +354,8 @@ module Crystal::Playground
           context.response << page
           return
         end
+      else
+        # Not a special path
       end
 
       call_next(context)

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -508,6 +508,8 @@ module Crystal::Playground
               source = json["source"].as_s
               tag = json["tag"].as_i
               session.format source, tag
+            else
+              # TODO: maybe raise because it's an unexpected message?
             end
           end
         end

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -9,6 +9,8 @@ module Crystal
       HierarchyPrinter.new(program, exp).execute
     when "json"
       JSONHierarchyPrinter.new(program, exp).execute
+    else
+      raise "Unknown hierarchy format: #{format}"
     end
   end
 

--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -36,7 +36,7 @@ module Crystal
           right = " " * (available_width - cell.text.size - left.size)
           "#{left}#{cell.text}#{right}"
         else
-          raise "Uknown alignment: #{cell.align}"
+          raise "Unknown alignment: #{cell.align}"
         end
       end
     end

--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -35,6 +35,8 @@ module Crystal
           left = " " * ((available_width - cell.text.size) // 2)
           right = " " * (available_width - cell.text.size - left.size)
           "#{left}#{cell.text}#{right}"
+        else
+          raise "Uknown alignment: #{cell.align}"
         end
       end
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -923,6 +923,8 @@ module Crystal
         if a_macro.args.size != 1
           raise TypeException.new "macro 'method_missing' expects 1 argument (call)"
         end
+      else
+        # normal macro
       end
 
       macros = (@macros ||= {} of String => Array(Macro))
@@ -3398,6 +3400,8 @@ private def add_instance_var_initializer(including_types, name, value, meta_vars
       type.add_instance_var_initializer(name, value, meta_vars)
     when Crystal::GenericModuleType
       type.add_instance_var_initializer(name, value, meta_vars)
+    else
+      # skip
     end
   end
 end

--- a/src/crystal/iconv.cr
+++ b/src/crystal/iconv.cr
@@ -66,6 +66,8 @@ struct Crystal::Iconv
         raise ArgumentError.new "Incomplete multibyte sequence"
       when Errno::EILSEQ
         raise ArgumentError.new "Invalid multibyte sequence"
+      else
+        # All is good
       end
     end
   end

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -162,12 +162,16 @@ class CSV::Builder
           case byte.unsafe_chr
           when @separator, @quote_char, '\n'
             return true
+          else
+            # keep scanning
           end
         end
+        false
       when .all?
-        return true
+        true
+      else
+        false
       end
-      return false
     end
   end
 end

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -122,6 +122,8 @@ abstract class CSV::Lexer
     case next_char
     when '\r', '\n', '\0'
       @last_empty_column = true
+    else
+      # not empty
     end
   end
 

--- a/src/csv/lexer/string_based.cr
+++ b/src/csv/lexer/string_based.cr
@@ -34,6 +34,8 @@ class CSV::Lexer::StringBased < CSV::Lexer
         break
       when @quote_char
         raise "Unexpected quote"
+      else
+        # go on
       end
     end
     @reader.string.byte_slice(start_pos, end_pos - start_pos)

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -243,6 +243,8 @@ class Dir
                 yield fullpath if next_cmd.path == entry.name
               when EntryMatch
                 yield fullpath if next_cmd.matches?(entry.name)
+              else
+                # go on
               end
 
               if entry.dir?

--- a/src/ecr/lexer.cr
+++ b/src/ecr/lexer.cr
@@ -1,7 +1,14 @@
 # :nodoc:
 class ECR::Lexer
   class Token
-    property type : Symbol
+    enum Type
+      String
+      Output
+      Control
+      EOF
+    end
+
+    property type : Type
     property value : String
     property line_number : Int32
     property column_number : Int32
@@ -59,6 +66,8 @@ class ECR::Lexer
 
         return consume_control(is_output, is_escape)
       end
+    else
+      # consume string
     end
 
     consume_string
@@ -77,11 +86,13 @@ class ECR::Lexer
         if peek_next_char == '%'
           break
         end
+      else
+        # keep going
       end
       next_char
     end
 
-    @token.type = :STRING
+    @token.type = :string
     @token.value = string_range(start_pos)
     @token
   end
@@ -128,11 +139,19 @@ class ECR::Lexer
           setup_control_token(start_pos, is_escape)
           break
         end
+      else
+        # keep going
       end
       next_char
     end
 
-    @token.type = is_escape ? :STRING : (is_output ? :OUTPUT : :CONTROL)
+    if is_escape
+      @token.type = :string
+    elsif is_output
+      @token.type = :output
+    else
+      @token.type = :control
+    end
     @token
   end
 

--- a/src/ecr/processor.cr
+++ b/src/ecr/processor.cr
@@ -18,7 +18,7 @@ module ECR
     String.build do |str|
       while true
         case token.type
-        when :STRING
+        when .string?
           string = token.value
           token = lexer.next_token
 
@@ -28,7 +28,7 @@ module ECR
           str << " << "
           string.inspect(str)
           str << '\n'
-        when :OUTPUT
+        when .output?
           string = token.value
           line_number = token.line_number
           column_number = token.column_number
@@ -43,7 +43,7 @@ module ECR
           str << ")#<loc:pop>.to_s "
           str << buffer_name
           str << '\n'
-        when :CONTROL
+        when .control?
           string = token.value
           line_number = token.line_number
           column_number = token.column_number
@@ -58,7 +58,7 @@ module ECR
           str << string
           str << "#<loc:pop>"
           str << '\n'
-        when :EOF
+        when .eof?
           break
         end
       end
@@ -69,7 +69,7 @@ module ECR
     # To suppress leading indentation we find the last index of a newline and
     # then check if all chars after that are whitespace.
     # We use a Char::Reader for this for maximum efficiency.
-    if (token.type == :OUTPUT || token.type == :CONTROL) && token.suppress_leading?
+    if (token.type.output? || token.type.control?) && token.suppress_leading?
       char_index = string.rindex('\n')
       char_index = char_index ? char_index + 1 : 0
       byte_index = string.char_index_to_byte_index(char_index).not_nil!
@@ -86,7 +86,7 @@ module ECR
   end
 
   private def suppress_trailing_whitespace(token, suppress_trailing)
-    if suppress_trailing && token.type == :STRING
+    if suppress_trailing && token.type.string?
       newline_index = token.value.index('\n')
       token.value = token.value[newline_index + 1..-1] if newline_index
     end

--- a/src/file.cr
+++ b/src/file.cr
@@ -441,6 +441,9 @@ class File < IO::FileDescriptor
             preader.next_char
           when ']'
             raise BadPatternError.new "Invalid character set: empty character set"
+          else
+            # Nothing
+            # TODO: check if this branch is fine
           end
 
           while pnext
@@ -463,6 +466,9 @@ class File < IO::FileDescriptor
                   raise BadPatternError.new "Invalid character set: missing range end"
                 when '\\'
                   range_end = preader.next_char
+                else
+                  # Nothing
+                  # TODO: check if this branch is fine
                 end
                 range = (pchar..range_end)
                 character_matched = true if range.includes?(char)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -65,6 +65,8 @@ module HTTP
               body = Gzip::Reader.new(body, sync_close: true)
             when "deflate"
               body = Flate::Reader.new(body, sync_close: true)
+            else
+              # not a format we support
             end
           {% end %}
         end
@@ -313,16 +315,16 @@ module HTTP
   def self.keep_alive?(message)
     case message.headers["Connection"]?.try &.downcase
     when "keep-alive"
-      return true
+      true
     when "close", "upgrade"
-      return false
-    end
-
-    case message.version
-    when "HTTP/1.0"
       false
     else
-      true
+      case message.version
+      when "HTTP/1.0"
+        false
+      else
+        true
+      end
     end
   end
 
@@ -411,6 +413,8 @@ module HTTP
         io << '\\'
       when 0x00..0x1F, 0x7F
         raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+      else
+        # output byte as is
       end
       io.write_byte byte
     end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -58,6 +58,8 @@ module HTTP
             case encoding
             when "gzip", "deflate"
               raise "Can't decompress because `-D without_zlib` was passed at compile time"
+            else
+              # not a format we support
             end
           {% else %}
             case encoding

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -162,6 +162,8 @@ module HTTP::FormData
         size = value.to_u64
       when "name"
         name = value
+      else
+        # not a field we are interested in
       end
     end
 

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -78,6 +78,8 @@ class HTTP::Server::RequestProcessor
         when ChunkedContent
           # Close the connection if the IO has still bytes to read.
           break unless body.closed?
+        else
+          # Nothing to do
         end
       end
     rescue IO::Error

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -145,6 +145,8 @@ class HTTP::WebSocket
           @current_message.clear
           break
         end
+      when Protocol::Opcode::CONTINUATION
+        # TODO: (asterite) I think this is good, but this case wasn't originally handled
       end
     end
   end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -186,6 +186,8 @@ class HTTP::WebSocket::Protocol
     when 127
       size = 0_u64
       8.times { size <<= 8; size += @io.read_byte.not_nil! }
+    else
+      # not a special case
     end
     size
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -544,13 +544,13 @@ struct Int
 
     case self
     when 0
-      return "0"
+      "0"
     when 1
-      return "1"
-    end
-
-    internal_to_s(base, upcase) do |ptr, count|
-      String.new(ptr, count, count)
+      "1"
+    else
+      internal_to_s(base, upcase) do |ptr, count|
+        String.new(ptr, count, count)
+      end
     end
   end
 
@@ -561,14 +561,12 @@ struct Int
     case self
     when 0
       io << '0'
-      return
     when 1
       io << '1'
-      return
-    end
-
-    internal_to_s(base, upcase) do |ptr, count|
-      io.write_utf8 Slice.new(ptr, count)
+    else
+      internal_to_s(base, upcase) do |ptr, count|
+        io.write_utf8 Slice.new(ptr, count)
+      end
     end
   end
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -116,6 +116,8 @@ class IO
             if old_in_buffer_left == @in_buffer_left
               @iconv.handle_invalid(pointerof(@in_buffer), pointerof(@in_buffer_left))
             end
+          else
+            # Not an error we can handle
           end
 
           # Continue decoding after an error

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -130,6 +130,8 @@ struct JSON::Any
     case @raw
     when Hash, Array
       self[key]?
+    else
+      nil
     end
   end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -50,6 +50,8 @@ class JSON::Builder
       raise JSON::Error.new("Unterminated JSON array")
     when ObjectState
       raise JSON::Error.new("Unterminated JSON object")
+    when DocumentEndState
+      # okay
     end
   end
 
@@ -295,6 +297,8 @@ class JSON::Builder
   private def start_scalar(string = false)
     object_value = false
     case state = @state.last
+    when DocumentStartState
+      # okay
     when StartState
       raise JSON::Error.new("Write before start_document")
     when DocumentEndState
@@ -320,6 +324,8 @@ class JSON::Builder
     when ObjectState
       colon if state.name
       @state[-1] = ObjectState.new(empty: false, name: !state.name)
+    else
+      raise "Bug: unexpected state: #{state.class}"
     end
   end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -279,6 +279,8 @@ def Union.new(pull : JSON::PullParser)
       value = pull.read?({{type}})
       return value unless value.nil?
     {% end %}
+    else
+      # no priority type
     end
   {% end %}
 

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -371,6 +371,8 @@ class JSON::PullParser
         case token.kind
         when .comma?, .end_array?, .end_object?, .eof?
           unexpected_token
+        else
+          # okay
         end
 
         if obj.try(&.object?) && token.kind.string?
@@ -385,6 +387,8 @@ class JSON::PullParser
         case next_token.kind
         when .comma?, .colon?, .end_array?, .end_object?, .eof?
           unexpected_token
+        else
+          # okay
         end
       when .eof?
         @kind = :EOF
@@ -448,6 +452,8 @@ class JSON::PullParser
     case next_token.kind
     when .comma?, .end_object?, .colon?, .eof?
       unexpected_token
+    else
+      # okay
     end
   end
 

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -27,6 +27,8 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                   check_array(type)
                 when Type::Kind::Struct
                   check_struct(type)
+                else
+                  # go on
                 end
 
     # Ensure we have at most four uniquely addressable members

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -500,6 +500,8 @@ module MIME
           io << '\\'
         when 0x00..0x1F, 0x7F
           raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+        else
+          # leave the byte as is
         end
         io.write_byte byte
       end

--- a/src/oauth/request_token.cr
+++ b/src/oauth/request_token.cr
@@ -13,6 +13,8 @@ class OAuth::RequestToken
       case key
       when "oauth_token"        then token = value
       when "oauth_token_secret" then secret = value
+      else
+        # Not a key we are interested in
       end
     end
 

--- a/src/openssl/ssl/hostname_validation.cr
+++ b/src/openssl/ssl/hostname_validation.cr
@@ -57,7 +57,11 @@ module OpenSSL::SSL::HostnameValidation
           if LibC.inet_pton(LibC::AF_INET6, hostname, pointerof(addr6).as(Void*)) > 0
             return Result::MatchFound if addr6.unsafe_as(StaticArray(UInt32, 4)) == data.as(StaticArray(UInt32, 4)*).value
           end
+        else
+          # not a length we expect
         end
+      else
+        # not a type we expect
       end
     end
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -682,6 +682,7 @@ struct Path
     case home
     when String then home = Path[home]
     when Bool   then home = Path.home
+    when Path # no transformation needed
     end
 
     home.to_kind(@kind).normalize

--- a/src/path.cr
+++ b/src/path.cr
@@ -733,6 +733,8 @@ struct Path
       # No separators on any side so we need to add one
       bytesize += 1
       add_separator = true
+    else
+      # There's at least on separator in the middle, so nothing to do
     end
 
     new_name = String.new(bytesize) do |buffer|
@@ -833,6 +835,8 @@ struct Path
           byte_count -= 1
         when {false, false}
           str << separators[0] unless str.bytesize == 0
+        else
+          # There's one separator, so nothing to do
         end
 
         last_ended_with_separator = ends_with_separator?(part)

--- a/src/pretty_print.cr
+++ b/src/pretty_print.cr
@@ -3,7 +3,7 @@
 #
 # ### References
 #
-# * [Ruby's prettyprint.rb](https://github.com/ruby/ruby/blob/trunk/lib/prettyprint.rb)
+# * [Ruby's prettyprint.rb](https://github.com/ruby/ruby/blob/master/lib/prettyprint.rb)
 # * [Christian Lindig, Strictly Pretty, March 2000](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.34.2200)
 # * [Philip Wadler, A prettier printer, March 1998](http://homepages.inf.ed.ac.uk/wadler/topics/language-design.html#prettier)
 class PrettyPrint

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -300,16 +300,16 @@ module Crystal::SignalChildHandler
       when -1
         return if Errno.value == Errno::ECHILD
         raise RuntimeError.from_errno("waitpid")
-      end
-
-      @@mutex.lock
-      if channel = @@waiting.delete(pid)
-        @@mutex.unlock
-        channel.send(exit_code)
-        channel.close
       else
-        @@pending[pid] = exit_code
-        @@mutex.unlock
+        @@mutex.lock
+        if channel = @@waiting.delete(pid)
+          @@mutex.unlock
+          channel.send(exit_code)
+          channel.close
+        else
+          @@pending[pid] = exit_code
+          @@mutex.unlock
+        end
       end
     end
   end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -189,6 +189,8 @@ class Socket
         addrinfo.value.ai_addr.as(LibC::SockaddrIn6*).copy_to(pointerof(@addr).as(LibC::SockaddrIn6*), 1)
       when Family::INET
         addrinfo.value.ai_addr.as(LibC::SockaddrIn*).copy_to(pointerof(@addr).as(LibC::SockaddrIn*), 1)
+      else
+        # TODO: (asterite) UNSPEC and UNIX unsupported?
       end
     end
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -377,7 +377,7 @@ module Spec
     # If *message* is a regular expression, it is used to match the error message.
     #
     # It returns the rescued exception.
-    def expect_raises(klass : T.class, message = nil, file = __FILE__, line = __LINE__) forall T
+    def expect_raises(klass : T.class, message : String | Regex | Nil = nil, file = __FILE__, line = __LINE__) forall T
       yield
     rescue ex : T
       # We usually bubble Spec::AssertaionFailed, unless this is the expected exception
@@ -404,6 +404,8 @@ module Spec
           fail "Expected #{klass} with #{message.inspect}, got #<#{ex.class}: " \
                "#{ex_to_s}> with backtrace:\n#{backtrace}", file, line
         end
+      when Nil
+        # No need to check the message
       end
 
       ex

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -92,6 +92,7 @@ module Spec
       when :error   then "error"
       when :fail    then "failure"
       when :pending then "skipped"
+      else               nil
       end
     end
 

--- a/src/spec/tap_formatter.cr
+++ b/src/spec/tap_formatter.cr
@@ -10,6 +10,8 @@ class Spec::TAPFormatter < Spec::Formatter
       @io << "not ok"
     when :pending
       @io << "ok"
+    else
+      # shouldn't happen (TODO: maybe turn this into an enum?)
     end
 
     @counter += 1

--- a/src/string.cr
+++ b/src/string.cr
@@ -541,6 +541,8 @@ class String
       ptr += 1
     when '+'
       ptr += 1
+    else
+      # no sign prefix
     end
 
     found_digit = false
@@ -1384,18 +1386,18 @@ class String
 
     case chars.size
     when 0
-      return self
+      self
     when 1
-      return strip(chars[0])
-    end
+      strip(chars[0])
+    else
+      excess_left = calc_excess_left(chars)
+      if excess_left == bytesize
+        return ""
+      end
 
-    excess_left = calc_excess_left(chars)
-    if excess_left == bytesize
-      return ""
+      excess_right = calc_excess_right(chars)
+      remove_excess(excess_left, excess_right)
     end
-
-    excess_right = calc_excess_right(chars)
-    remove_excess(excess_left, excess_right)
   end
 
   # Returns a new string where leading and trailing characters for which
@@ -2018,6 +2020,8 @@ class String
         buffer << capture
         index = end_index + 1
         first_index = index
+      else
+        # Nothing
       end
     end
 

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -118,6 +118,8 @@ struct String::Formatter(A)
       val = consume_dynamic_value
       flags.width = val
       flags.width_size = val.to_s.size
+    else
+      # no width
     end
     flags
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -1495,6 +1495,8 @@ struct Time
         zone = location.lookup(range[0] - 1)
       when .>=(range[1])
         zone = location.lookup(range[1])
+      else
+        # in range
       end
     end
 

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -297,6 +297,8 @@ struct Time::Format
         next_char
       when '+'
         next_char
+      else
+        # no sign prefix
       end
 
       @unix_seconds = consume_number_i64(19) * (negative ? -1 : 1)

--- a/src/time/format/pattern.cr
+++ b/src/time/format/pattern.cr
@@ -147,6 +147,8 @@ struct Time::Format
               microseconds
             when '9'
               nanoseconds
+            else
+              raise "Bug: someone forgot to match some numbers"
             end
           else
             char '%'

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -70,7 +70,7 @@ module Unicode
       case char
       when 'ı' then 'I'
       when 'i' then 'İ'
-      else           nil
+      else          nil
       end
     else
       nil
@@ -147,7 +147,7 @@ module Unicode
       case char
       when 'I' then 'ı'
       when 'İ' then 'i'
-      else           nil
+      else          nil
       end
     else
       nil

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -68,9 +68,9 @@ module Unicode
   private def self.check_upcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'ı'; 'I'
-      when 'i'; 'İ'
-      else      nil
+      when 'ı' then 'I'
+      when 'i' then 'İ'
+      else           nil
       end
     else
       nil

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -145,9 +145,9 @@ module Unicode
   private def self.check_downcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'I'; 'ı'
-      when 'İ'; 'i'
-      else      nil
+      when 'I' then 'ı'
+      when 'İ' then 'i'
+      else           nil
       end
     else
       nil

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -68,11 +68,13 @@ module Unicode
   private def self.check_upcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'ı'; return 'I'
-      when 'i'; return 'İ'
+      when 'ı'; 'I'
+      when 'i'; 'İ'
+      else      nil
       end
+    else
+      nil
     end
-    nil
   end
 
   private def self.check_upcase_ranges(char)
@@ -143,11 +145,13 @@ module Unicode
   private def self.check_downcase_turkic(char, options)
     if options.turkic?
       case char
-      when 'I'; return 'ı'
-      when 'İ'; return 'i'
+      when 'I'; 'ı'
+      when 'İ'; 'i'
+      else      nil
       end
+    else
+      nil
     end
-    nil
   end
 
   private def self.check_downcase_fold(char, options)

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -167,6 +167,7 @@ struct XML::Node
   def inspect(io : IO) : Nil
     io << "#<XML::"
     case type
+    when XML::Node::Type::NONE               then io << "None"
     when XML::Node::Type::ELEMENT_NODE       then io << "Element"
     when XML::Node::Type::ATTRIBUTE_NODE     then io << "Attribute"
     when XML::Node::Type::TEXT_NODE          then io << "Text"
@@ -286,11 +287,11 @@ struct XML::Node
   def namespace
     case type
     when Type::DOCUMENT_NODE, Type::ATTRIBUTE_DECL, Type::DTD_NODE, Type::ELEMENT_DECL
-      return nil
+      nil
+    else
+      ns = @node.value.ns
+      ns ? Namespace.new(document, ns) : nil
     end
-
-    ns = @node.value.ns
-    ns ? Namespace.new(document, ns) : nil
   end
 
   # Returns namespaces in scope for self – those defined on self element

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -139,6 +139,8 @@ struct YAML::Any
     case @raw
     when Hash, Array
       self[index_or_key]?
+    else
+      nil
     end
   end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -196,6 +196,8 @@ def NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
             %var{key.id} = {{type}}.new(ctx, value)
             %found{key.id} = true
         {% end %}
+      else
+        # ignore the key
       end
     end
 

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -125,6 +125,8 @@ class YAML::Nodes::Builder
       current << node
     when Mapping
       current << node
+    else
+      raise "Can't push into #{current.class}"
     end
   end
 

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -241,6 +241,20 @@ class YAML::PullParser
         skip
       end
       read_next
+    when .document_start?
+      read_next
+      until kind.document_end?
+        skip
+      end
+      read_next
+    when .stream_start?
+      read_next
+      until kind.stream_end?
+        skip
+      end
+      read_next
+    else
+      read_next
     end
   end
 

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -56,6 +56,8 @@ class YAML::PullParser
       ptr = @event.data.sequence_start.tag
     when .scalar?
       ptr = @event.data.scalar.tag
+    else
+      # no tag
     end
     ptr ? String.new(ptr) : nil
   end

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -80,30 +80,30 @@ module YAML::Schema::Core
          .starts_with?("+0x"),
          .starts_with?("-0x")
       value = string.to_i64?(base: 16, prefix: true)
-      return value || string
+      value || string
     when .starts_with?("0."),
          .starts_with?('.')
       value = parse_float?(string)
-      return value || string
+      value || string
     when .starts_with?('0')
       return 0_i64 if string.size == 1
       value = string.to_i64?(base: 8, prefix: true, leading_zero_is_octal: true)
-      return value || string
+      value || string
     when .starts_with?('-'),
          .starts_with?('+')
       value = parse_number?(string)
-      return value || string
+      value || string
+    else
+      if string[0].ascii_number?
+        value = parse_number?(string)
+        return value if value
+
+        value = parse_time?(string)
+        return value if value
+      end
+
+      string
     end
-
-    if string[0].ascii_number?
-      value = parse_number?(string)
-      return value if value
-
-      value = parse_time?(string)
-      return value if value
-    end
-
-    string
   end
 
   # Returns whether a string is reserved and must non be output
@@ -288,6 +288,8 @@ module YAML::Schema::Core
       yield source.value
     when "tag:yaml.org,2002:timestamp"
       yield parse_time(source.value, source.location)
+    else
+      # not a tag we support
     end
   end
 


### PR DESCRIPTION
Part of: #8001
Related: #4837, #4870

This PR is the initial step towards having `case` be exhaustive.

What that means is that the compiler must be able to prove that all `when` cover all cases of the expression given to `case`, or otherwise an `else` must be given.

As an initial step, if the compiler can't prove that all `when` are covered a **warning** will be issues. This will help the transition of shards authors. **The warning will eventually become an error.**

The compiler will be able to prove that all types in a union or single type are covered (not including inheritance because inheritance is open). It can also prove that all enum members of a given enum are covered.

Some things missing:
- [x] don't include `Flags` enums in the check
- [x] allow mixing enums without other types in the check
- [x] check exhaustiveness of `case` over a tuple literal
- [x] improve the warning message

but I didn't want to spend time and effort on those things until we all agree that this is the direction we want to take.

An example of how it works:

```crystal
a = 1 || 'x' || "foo"
case a
when Int32
  # ...
when String
  # ...
end
```

In the example above the compiler will issue a warning saying that the case is not exhaustive and `Char` is missing to be covered.

Note that right now if you cover all cases the compiler won't issue a warning but there will still be an implicit `else nil`, but eventually that will change to `else unreachable` of some sort.

Then this PR makes all `case` be exhaustive by adding an `else` clause when needed. While doing that I felt:
- some `else` were just "yeah, I know I didn't want to cover this case" (but what about someone other than me? would they know?)
- some `else` made me stop and think "hm, why was this left out?"
- some `else` I knew I ignored in the past, but this time around I couldn't remember why I did that and I left a "TODO" to check it
- some `else` were missing a few types or enum cases and I added them for clarity
- some code were using symbols and I decided to change them to `enum` so the compiler could check I covered all cases
- I changed a few `case` to `if` when I considered it was more readable/clear

It was a bit tedious to add all the `else` in one go, but doing it as you code is probably not tedious and it can actually be helpful. I find that it's a bit tedious that the compiler will ask you to write an `else unreachable` for things that it knows can't be reached, so the state before this PR also has some bad things to it.

There were around 250 warnings in this entire repo. Considering that [cloc](http://cloc.sourceforge.net/) says there are 218466 lines of pure Crystal code (excluding comments),  it's 1 warning per 874 lines of code, which I think isn't that bad. Also 30 of those warnings were in the lexer when scanning identifiers, so the distribution might actually be like 1 warning per 1000 lines of code (well, it depends on how often you use `case`... let's say it depends on the case ;-)).

I also wanted to see what warnings I needed to fix for a couple of shards, so I chose `shards`, `crystal-db` and `crystal-pg`. To my surprise, **no warnings were issued**, which is a good sign.

But please, if you can, try the compiler in this PR against your project and see if the warnings make sense and are generally good to have.