### PR TITLE
Cleanup Digest and OpenSSL::Digest

### DIFF
--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -38,19 +38,17 @@ describe Digest::MD5 do
   it "resets" do
     digest = Digest::MD5.new
     digest.update "foo"
-    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
-    # Check internal state isn't modified by first hexdigest call.
-    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+    digest.final.hexstring.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
 
     digest.reset
     digest.update "foo"
-    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+    digest.final.hexstring.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
   it "can't call final twice" do
     digest = Digest::MD5.new
     digest.final
-    expect_raises(Digest::ApiMisuse) do
+    expect_raises(Digest::FinalizedError) do
       digest.final
     end
   end

--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -34,4 +34,20 @@ describe Digest::MD5 do
   it "calculates base64'd hash from string" do
     Digest::MD5.base64digest("foo").should eq("rL0Y20zC+Fzt72VPzMSk2A==")
   end
+
+  it "resets" do
+    digest = Digest::MD5.new
+    digest.update "foo"
+    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+    # Check internal state isn't modified by first hexdigest call.
+    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+
+    digest.reset
+    digest.update "foo"
+    digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+  end
+
+  it "return the digest size" do
+    Digest::MD5.new.digest_size.should eq 16
+  end
 end

--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -47,6 +47,14 @@ describe Digest::MD5 do
     digest.hexdigest.should eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 
+  it "can't call final twice" do
+    digest = Digest::MD5.new
+    digest.final
+    expect_raises(Digest::ApiMisuse) do
+      digest.final
+    end
+  end
+
   it "return the digest size" do
     Digest::MD5.new.digest_size.should eq 16
   end

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -10,28 +10,26 @@ describe Digest::SHA1 do
     {"a", "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8", "hvfkN/qlp/zhXR3cuerq6jd2Z7g="},
     {"0123456701234567012345670123456701234567012345670123456701234567", "e0c094e867ef46c350ef54a7f59dd60bed92ae83", "4MCU6GfvRsNQ71Sn9Z3WC+2SroM="},
     {"fooø", "dcf4a1e3542b1a40a4ac2a3f7c92ffdb2d19812f", "3PSh41QrGkCkrCo/fJL/2y0ZgS8="},
-  ].each do |(string, hexdigest, base64digest)|
+  ].each do |(string, hexstring, base64digest)|
     it "does digest for #{string.inspect}" do
       bytes = Digest::SHA1.digest(string)
-      bytes.to_slice.hexstring.should eq(hexdigest)
+      bytes.hexstring.should eq(hexstring)
     end
 
     it "resets" do
       digest = Digest::SHA1.new
       digest.update string
-      digest.hexdigest.should eq(hexdigest)
-      # Check internal state isn't modified by first hexdigest call.
-      digest.hexdigest.should eq(hexdigest)
+      digest.final.hexstring.should eq(hexstring)
 
       digest.reset
       digest.update string
-      digest.hexdigest.should eq(hexdigest)
+      digest.final.hexstring.should eq(hexstring)
     end
 
-    it "resets" do
+    it "can't call #final more than once" do
       digest = Digest::SHA1.new
       digest.final
-      expect_raises(Digest::ApiMisuse) do
+      expect_raises(Digest::FinalizedError) do
         digest.final
       end
     end
@@ -43,11 +41,11 @@ describe Digest::SHA1 do
         end
       end
 
-      bytes.to_slice.hexstring.should eq(hexdigest)
+      bytes.hexstring.should eq(hexstring)
     end
 
-    it "does hexdigest for #{string.inspect}" do
-      Digest::SHA1.hexdigest(string).should eq(hexdigest)
+    it "does final.hexstring for #{string.inspect}" do
+      Digest::SHA1.hexdigest(string).should eq(hexstring)
     end
 
     it "does base64digest for #{string.inspect}" do

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -28,6 +28,14 @@ describe Digest::SHA1 do
       digest.hexdigest.should eq(hexdigest)
     end
 
+    it "resets" do
+      digest = Digest::SHA1.new
+      digest.final
+      expect_raises(Digest::ApiMisuse) do
+        digest.final
+      end
+    end
+
     it "does digest for #{string.inspect} in a block" do
       bytes = Digest::SHA1.digest do |ctx|
         string.each_char do |chr|

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -44,7 +44,7 @@ describe Digest::SHA1 do
       bytes.hexstring.should eq(hexstring)
     end
 
-    it "does final.hexstring for #{string.inspect}" do
+    it "does hexdigest for #{string.inspect}" do
       Digest::SHA1.hexdigest(string).should eq(hexstring)
     end
 

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -16,6 +16,18 @@ describe Digest::SHA1 do
       bytes.to_slice.hexstring.should eq(hexdigest)
     end
 
+    it "resets" do
+      digest = Digest::SHA1.new
+      digest.update string
+      digest.hexdigest.should eq(hexdigest)
+      # Check internal state isn't modified by first hexdigest call.
+      digest.hexdigest.should eq(hexdigest)
+
+      digest.reset
+      digest.update string
+      digest.hexdigest.should eq(hexdigest)
+    end
+
     it "does digest for #{string.inspect} in a block" do
       bytes = Digest::SHA1.digest do |ctx|
         string.each_char do |chr|
@@ -33,5 +45,9 @@ describe Digest::SHA1 do
     it "does base64digest for #{string.inspect}" do
       Digest::SHA1.base64digest(string).should eq(base64digest)
     end
+  end
+
+  it "returns the digest_size" do
+    Digest::SHA1.new.digest_size.should eq(20)
   end
 end

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -10,13 +10,19 @@ describe OpenSSL::Digest do
     it "should be able to calculate #{algorithm}" do
       digest = OpenSSL::Digest.new(algorithm)
       digest << "fooø"
-      digest.hexdigest.should eq(expected)
-      # Check internal state isn't modified by first hexdigest call.
-      digest.hexdigest.should eq(expected)
+      digest.final.hexstring.should eq(expected)
 
       digest.reset
       digest << "fooø"
       digest.hexdigest.should eq(expected)
+    end
+  end
+
+  it "can't call #final more than once" do
+    digest = OpenSSL::Digest.new("SHA1")
+    digest.final
+    expect_raises(Digest::FinalizedError) do
+      digest.final
     end
   end
 
@@ -50,6 +56,6 @@ describe OpenSSL::Digest do
     digest << r
     r.close
 
-    digest.hexdigest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+    digest.final.hexstring.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
   end
 end

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -11,6 +11,12 @@ describe OpenSSL::Digest do
       digest = OpenSSL::Digest.new(algorithm)
       digest << "fooø"
       digest.hexdigest.should eq(expected)
+      # Check internal state isn't modified by first hexdigest call.
+      digest.hexdigest.should eq(expected)
+
+      digest.reset
+      digest << "fooø"
+      digest.hexdigest.should eq(expected)
     end
   end
 

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -24,7 +24,6 @@ abstract class Digest::Base
     context = new
     yield context
     context.final
-    context.result
   end
 
   # Returns the hexadecimal representation of the hash of *data*.
@@ -89,4 +88,28 @@ abstract class Digest::Base
 
     Base64.strict_encode(hashsum)
   end
+
+  def update(data) : self
+    update data.to_slice
+  end
+
+  def final : Bytes
+    dst = Bytes.new digest_size
+    final dst
+  end
+
+  # Dups and finishes the digest.
+  def digest : Bytes
+    dup.final
+  end
+
+  # Returns a hexadecimal-encoded digest.
+  def hexdigest : String
+    digest.hexstring
+  end
+
+  abstract def update(data : Bytes) : self
+  abstract def final(dst : Bytes) : Bytes
+  abstract def reset : self
+  abstract def digest_size : Int32
 end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -102,7 +102,9 @@ abstract class Digest::Base
     update data.to_slice
   end
 
-  # Returns the final digest output.  Only call once.
+  # Returns the final digest output.
+  #
+  # This method can only be called once and raises `FinalizedError` on subsequent calls.
   #
   # NOTE: `.dup.final` call may be used to get an intermediate hash value.
   def final : Bytes

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -24,7 +24,7 @@ abstract class Digest::Base
     # end
     # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.digest : Bytes
+    def self.digest(& : Digest::Base -> _) : Bytes
       context = new
       yield context
       context.final

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -12,8 +12,8 @@ abstract class Digest::Base
       end
     end
 
-    # Yields an instance of `self` which can receive calls to `#update(data : String | Bytes)` and returns the finalized digest.
-    # method available. Returns the resulting digest afterwards.
+    # Yields an instance of `self` which can receive calls to `#update(data : String | Bytes)`
+    # and returns the finalized digest afterwards.
     #
     # ```
     # require "digest/md5"

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -1,7 +1,7 @@
 require "base64"
 
 module Digest
-  class DigestFinalizedError < Exception
+  class FinalizedError < Exception
   end
 end
 
@@ -121,7 +121,7 @@ abstract class Digest::Base
   end
 
   protected def check_finished : Nil
-    raise ApiMisuse.new("finish already called") if @finished
+    raise FinalizedError.new("finish already called") if @finished
   end
 
   protected def set_finished : Nil
@@ -135,9 +135,9 @@ abstract class Digest::Base
     self
   end
 
-  # When creating new digest class call #check_finished before mutating.
+  # When creating a new digest class call #check_finished before mutating.
   abstract def update(data : Bytes) : self
-  # When creating new digest class call #set_finished before mutating.
+  # When creating a new digest class call #set_finished before mutating.
   abstract def final(dst : Bytes) : Bytes
   abstract def digest_size : Int32
 end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -1,7 +1,7 @@
 require "base64"
 
 module Digest
-  class ApiMisuse < Exception
+  class DigestFinalizedError < Exception
   end
 end
 

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -103,6 +103,7 @@ abstract class Digest::Base
   end
 
   # Returns the final digest output.  Only call once.
+  # `.dup.final` may be used to get an intermediate hash value.
   def final : Bytes
     dst = Bytes.new digest_size
     final dst

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -76,7 +76,9 @@ abstract class Digest::Base
       base64digest &.update(data)
     end
 
-    # Returns the base64-encoded hash of *data*.
+    # Yields a context object with an `#update(data : String | Bytes)`
+    # method available. Returns the resulting digest in base64 representation
+    # afterwards.
     #
     # ```
     # require "digest/sha1"

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -1,92 +1,94 @@
 require "base64"
 
 abstract class Digest::Base
-  # Returns the hash of *data*. *data* must respond to `#to_slice`.
-  def self.digest(data)
-    digest do |ctx|
-      ctx.update(data.to_slice)
-    end
-  end
-
-  # Yields a context object with an `#update(data : String | Bytes)`
-  # method available. Returns the resulting digest afterwards.
-  #
-  # ```
-  # require "digest/md5"
-  #
-  # digest = Digest::MD5.digest do |ctx|
-  #   ctx.update "f"
-  #   ctx.update "oo"
-  # end
-  # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
-  # ```
-  def self.digest
-    context = new
-    yield context
-    context.final
-  end
-
-  # Returns the hexadecimal representation of the hash of *data*.
-  #
-  # ```
-  # require "digest/md5"
-  #
-  # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
-  # ```
-  def self.hexdigest(data) : String
-    hexdigest &.update(data)
-  end
-
-  # Yields a context object with an `#update(data : String | Bytes)`
-  # method available. Returns the resulting digest in hexadecimal representation
-  # afterwards.
-  #
-  # ```
-  # require "digest/md5"
-  #
-  # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
-  # Digest::MD5.hexdigest do |ctx|
-  #   ctx.update "f"
-  #   ctx.update "oo"
-  # end
-  # # => "acbd18db4cc2f85cedef654fccc4a4d8"
-  # ```
-  def self.hexdigest : String
-    hashsum = digest do |ctx|
-      yield ctx
+  macro inherited
+    # Returns the hash of *data*. *data* must respond to `#to_slice`.
+    def self.digest(data)
+      digest do |ctx|
+        ctx.update(data.to_slice)
+      end
     end
 
-    hashsum.to_slice.hexstring
-  end
-
-  # Returns the base64-encoded hash of *data*.
-  #
-  # ```
-  # require "digest/sha1"
-  #
-  # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
-  # ```
-  def self.base64digest(data) : String
-    base64digest &.update(data)
-  end
-
-  # Returns the base64-encoded hash of *data*.
-  #
-  # ```
-  # require "digest/sha1"
-  #
-  # Digest::SHA1.base64digest do |ctx|
-  #   ctx.update "f"
-  #   ctx.update "oo"
-  # end
-  # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
-  # ```
-  def self.base64digest : String
-    hashsum = digest do |ctx|
-      yield ctx
+    # Yields a context object with an `#update(data : String | Bytes)`
+    # method available. Returns the resulting digest afterwards.
+    #
+    # ```
+    # require "digest/md5"
+    #
+    # digest = Digest::MD5.digest do |ctx|
+    #   ctx.update "f"
+    #   ctx.update "oo"
+    # end
+    # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
+    # ```
+    def self.digest
+      context = new
+      yield context
+      context.final
     end
 
-    Base64.strict_encode(hashsum)
+    # Returns the hexadecimal representation of the hash of *data*.
+    #
+    # ```
+    # require "digest/md5"
+    #
+    # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
+    # ```
+    def self.hexdigest(data) : String
+      hexdigest &.update(data)
+    end
+
+    # Yields a context object with an `#update(data : String | Bytes)`
+    # method available. Returns the resulting digest in hexadecimal representation
+    # afterwards.
+    #
+    # ```
+    # require "digest/md5"
+    #
+    # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
+    # Digest::MD5.hexdigest do |ctx|
+    #   ctx.update "f"
+    #   ctx.update "oo"
+    # end
+    # # => "acbd18db4cc2f85cedef654fccc4a4d8"
+    # ```
+    def self.hexdigest : String
+      hashsum = digest do |ctx|
+        yield ctx
+      end
+
+      hashsum.to_slice.hexstring
+    end
+
+    # Returns the base64-encoded hash of *data*.
+    #
+    # ```
+    # require "digest/sha1"
+    #
+    # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
+    # ```
+    def self.base64digest(data) : String
+      base64digest &.update(data)
+    end
+
+    # Returns the base64-encoded hash of *data*.
+    #
+    # ```
+    # require "digest/sha1"
+    #
+    # Digest::SHA1.base64digest do |ctx|
+    #   ctx.update "f"
+    #   ctx.update "oo"
+    # end
+    # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
+    # ```
+    def self.base64digest : String
+      hashsum = digest do |ctx|
+        yield ctx
+      end
+
+      Base64.strict_encode(hashsum)
+    end
   end
 
   def update(data) : self

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -1,8 +1,6 @@
 require "base64"
 
-module Digest
-  class Digest::FinalizedError < Exception
-  end
+class Digest::FinalizedError < Exception
 end
 
 abstract class Digest::Base

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -26,7 +26,7 @@ abstract class Digest::Base
     # end
     # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.digest
+    def self.digest : Bytes
       context = new
       yield context
       context.final

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -14,7 +14,7 @@ abstract class Digest::Base
       end
     end
 
-    # Yields a context object with an `#update(data : String | Bytes)`
+    # Yields an instance of `self` which can receive calls to `#update(data : String | Bytes)` and returns the finalized digest.
     # method available. Returns the resulting digest afterwards.
     #
     # ```

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -103,7 +103,8 @@ abstract class Digest::Base
   end
 
   # Returns the final digest output.  Only call once.
-  # `.dup.final` may be used to get an intermediate hash value.
+  #
+  # NOTE: `.dup.final` call may be used to get an intermediate hash value.
   def final : Bytes
     dst = Bytes.new digest_size
     final dst

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -55,7 +55,7 @@ abstract class Digest::Base
     # end
     # # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.hexdigest : String
+    def self.hexdigest(& : Digest::Base -> _) : String
       hashsum = digest do |ctx|
         yield ctx
       end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -87,7 +87,7 @@ abstract class Digest::Base
     # end
     # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def self.base64digest : String
+    def self.base64digest(& : Digest::Base -> _) : String
       hashsum = digest do |ctx|
         yield ctx
       end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -147,7 +147,12 @@ abstract class Digest::Base
     raise FinalizedError.new("finish already called") if @finished
   end
 
+  # Hashes data incrementally.
   abstract def update_impl(data : Bytes) : Nil
+  # Stores the output digest of #digest_size bytes in dst.
   abstract def final_impl(dst : Bytes) : Nil
+  # Resets the object to it's initial state.
+  abstract def reset_impl : Nil
+  # Returns the digest output size in bytes.
   abstract def digest_size : Int32
 end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -1,7 +1,7 @@
 require "base64"
 
 module Digest
-  class FinalizedError < Exception
+class Digest::FinalizedError < Exception
   end
 end
 

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -23,7 +23,7 @@ class Digest::MD5 < Digest::Base
     update(slice.to_unsafe, slice.bytesize.to_u32)
   end
 
-  def update(inBuf, inLen)
+  private def update(inBuf, inLen)
     tmp_in = uninitialized UInt32[16]
 
     # compute number of bytes mod 64
@@ -76,57 +76,57 @@ class Digest::MD5 < Digest::Base
   S43 = 15
   S44 = 21
 
-  PADDING = begin
+  private PADDING = begin
     padding = StaticArray(UInt8, 64).new(0_u8)
     padding[0] = 0x80_u8
     padding
   end
 
-  def f(x, y, z)
+  private def f(x, y, z)
     (x & y) | ((~x) & z)
   end
 
-  def g(x, y, z)
+  private def g(x, y, z)
     (x & z) | (y & (~z))
   end
 
-  def h(x, y, z)
+  private def h(x, y, z)
     x ^ y ^ z
   end
 
-  def i(x, y, z)
+  private def i(x, y, z)
     y ^ (x | (~z))
   end
 
-  def rotate_left(x, n)
+  private def rotate_left(x, n)
     (x << n) | (x >> (32 - n))
   end
 
-  def ff(a, b, c, d, x, s, ac)
+  private def ff(a, b, c, d, x, s, ac)
     a &+= f(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
     a &+= b
   end
 
-  def gg(a, b, c, d, x, s, ac)
+  private def gg(a, b, c, d, x, s, ac)
     a &+= g(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
     a &+= b
   end
 
-  def hh(a, b, c, d, x, s, ac)
+  private def hh(a, b, c, d, x, s, ac)
     a &+= h(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
     a &+= b
   end
 
-  def ii(a, b, c, d, x, s, ac)
+  private def ii(a, b, c, d, x, s, ac)
     a &+= i(b, c, d) &+ x &+ ac.to_u32
     a = rotate_left a, s
     a &+= b
   end
 
-  def transform(in)
+  private def transform(in)
     a, b, c, d = @buf
 
     # Round 1

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -16,6 +16,8 @@ class Digest::MD5 < Digest::Base
   end
 
   def reset : self
+    super
+
     @i[0] = 0_u32
     @i[1] = 0_u32
     @buf[0] = 0x67452301_u32
@@ -26,6 +28,7 @@ class Digest::MD5 < Digest::Base
   end
 
   def update(data : Bytes) : self
+    check_finished
     update(data.to_unsafe, data.bytesize.to_u32)
     self
   end
@@ -215,6 +218,8 @@ class Digest::MD5 < Digest::Base
   end
 
   def final(dst : Bytes) : Bytes
+    set_finished
+
     tmp_in = uninitialized UInt32[16]
 
     # save number of bits

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -25,7 +25,6 @@ class Digest::MD5 < Digest::Base
   end
 
   private def update_impl(data : Bytes) : Nil
-    check_finished
     update(data.to_unsafe, data.bytesize.to_u32)
   end
 

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -15,22 +15,18 @@ class Digest::MD5 < Digest::Base
     reset
   end
 
-  def reset : self
-    super
-
+  private def reset_impl : Nil
     @i[0] = 0_u32
     @i[1] = 0_u32
     @buf[0] = 0x67452301_u32
     @buf[1] = 0xEFCDAB89_u32
     @buf[2] = 0x98BADCFE_u32
     @buf[3] = 0x10325476_u32
-    self
   end
 
-  def update(data : Bytes) : self
+  private def update_impl(data : Bytes) : Nil
     check_finished
     update(data.to_unsafe, data.bytesize.to_u32)
-    self
   end
 
   private def update(inBuf, inLen)
@@ -217,9 +213,7 @@ class Digest::MD5 < Digest::Base
     @buf[3] &+= d
   end
 
-  def final(dst : Bytes) : Bytes
-    set_finished
-
+  private def final_impl(dst : Bytes) : Nil
     tmp_in = uninitialized UInt32[16]
 
     # save number of bits
@@ -253,8 +247,6 @@ class Digest::MD5 < Digest::Base
       dst[ii + 3] = ((@buf[i] >> 24) & 0xFF).to_u8
       ii += 4
     end
-
-    dst
   end
 
   def digest_size : Int32

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -44,7 +44,7 @@ class Digest::SHA1 < Digest::Base
     end
   end
 
-  def process_message_block
+  private def process_message_block
     k = {0x5A827999_u32, 0x6ED9EBA1_u32, 0x8F1BBCDC_u32, 0xCA62C1D6_u32}
 
     w = uninitialized UInt32[80]

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -21,6 +21,8 @@ class Digest::SHA1 < Digest::Base
   end
 
   def reset : self
+    super
+
     @length_low = 0_u32
     @length_high = 0_u32
     @message_block_index = 0
@@ -33,6 +35,8 @@ class Digest::SHA1 < Digest::Base
   end
 
   def update(data : Bytes) : self
+    check_finished
+
     data.each do |byte|
       @message_block[@message_block_index] = byte & 0xFF_u8
       @message_block_index += 1
@@ -53,6 +57,8 @@ class Digest::SHA1 < Digest::Base
   end
 
   def final(dst : Bytes) : Bytes
+    set_finished
+
     pad_message
 
     @length_low = 0_u32

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -48,7 +48,6 @@ class Digest::SHA1 < Digest::Base
         process_message_block
       end
     end
-    self
   end
 
   private def final_impl(dst : Bytes) : Nil

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -21,9 +21,6 @@ class Digest::SHA1 < Digest::Base
   end
 
   def reset : self
-    @message_block.each_index do |i|
-      @message_block[i] = 0_u8
-    end
     @length_low = 0_u32
     @length_high = 0_u32
     @message_block_index = 0

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -20,9 +20,7 @@ class Digest::SHA1 < Digest::Base
     reset
   end
 
-  def reset : self
-    super
-
+  private def reset_impl : Nil
     @length_low = 0_u32
     @length_high = 0_u32
     @message_block_index = 0
@@ -31,12 +29,9 @@ class Digest::SHA1 < Digest::Base
     @intermediate_hash[2] = 0x98BADCFE_u32
     @intermediate_hash[3] = 0x10325476_u32
     @intermediate_hash[4] = 0xC3D2E1F0_u32
-    self
   end
 
-  def update(data : Bytes) : self
-    check_finished
-
+  private def update_impl(data : Bytes) : Nil
     data.each do |byte|
       @message_block[@message_block_index] = byte & 0xFF_u8
       @message_block_index += 1
@@ -56,9 +51,7 @@ class Digest::SHA1 < Digest::Base
     self
   end
 
-  def final(dst : Bytes) : Bytes
-    set_finished
-
+  private def final_impl(dst : Bytes) : Nil
     pad_message
 
     @length_low = 0_u32
@@ -66,8 +59,6 @@ class Digest::SHA1 < Digest::Base
     {% for i in 0...20 %}
       dst[{{i}}] = (@intermediate_hash[{{i >> 2}}] >> 8 * (3 - ({{i & 0x03}}))).to_u8!
     {% end %}
-
-    dst
   end
 
   private def process_message_block

--- a/src/openssl/digest/digest.cr
+++ b/src/openssl/digest/digest.cr
@@ -48,30 +48,24 @@ module OpenSSL
       Digest.new(@name, ctx)
     end
 
-    def reset : self
-      super
-
+    private def reset_impl : Nil
       if LibCrypto.evp_digestinit_ex(self, to_unsafe_md, nil) != 1
         raise Error.new "Digest initialization failed."
       end
-      self
     end
 
-    def update(data : String | Slice) : self
+    private def update_impl(data : Bytes) : Nil
       check_finished
       if LibCrypto.evp_digestupdate(self, data, data.bytesize) != 1
         raise Error.new "EVP_DigestUpdate"
       end
-      self
     end
 
-    def final(data : Bytes) : Bytes
-      set_finished
+    private def final_impl(data : Bytes) : Nil
       raise ArgumentError.new("data size incorrect") unless data.bytesize == digest_size
       if LibCrypto.evp_digestfinal_ex(@ctx, data, nil) != 1
         raise Error.new "EVP_DigestFinal_ex"
       end
-      data
     end
 
     def digest_size : Int32

--- a/src/openssl/digest/digest_base.cr
+++ b/src/openssl/digest/digest_base.cr
@@ -23,19 +23,9 @@ module OpenSSL
       update(data)
     end
 
-    # Clones and finishes the digest.
-    def digest : Bytes
-      self.clone.finish
-    end
-
     # Returns a base64-encoded digest.
     def base64digest : String
       Base64.strict_encode(digest)
-    end
-
-    # Returns a hexadecimal-encoded digest.
-    def hexdigest : String
-      digest.hexstring
     end
 
     # :ditto:

--- a/src/openssl/digest/digest_base.cr
+++ b/src/openssl/digest/digest_base.cr
@@ -10,7 +10,7 @@ module OpenSSL
     end
 
     # Reads the io's data and updates the digest with it.
-    def update(io : IO) : Digest
+    def update(io : IO) : self
       buffer = uninitialized UInt8[4096]
       while (read_bytes = io.read(buffer.to_slice)) > 0
         self << buffer.to_slice[0, read_bytes]
@@ -19,16 +19,17 @@ module OpenSSL
     end
 
     # :ditto:
-    def <<(data) : Digest
+    def <<(data) : self
       update(data)
     end
 
     # Returns a base64-encoded digest.
+    @[Deprecated("Use `Base64.strict_encode(final)` instead.")]
     def base64digest : String
       Base64.strict_encode(digest)
     end
 
-    # :ditto:
+    @[Deprecated("Use `io << final.hexstring` instead.")]
     def to_s(io : IO) : Nil
       io << hexdigest
     end

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -12,7 +12,7 @@ module OpenSSL
   # io = OpenSSL::DigestIO.new(underlying_io, "SHA256")
   # buffer = Bytes.new(256)
   # io.read(buffer)
-  # io.digest.hexstring # => "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+  # io.final.hexstring # => "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
   # ```
   class DigestIO < IO
     getter io : IO


### PR DESCRIPTION
* Use a Digest::Base as a common base class.
* Remove duplicate methods.
* Mark various methods private.
* Add specs to test #reset and internal state.

Digest::Base
* Add abstract methods solidifying the interface.

