### PR TITLE
CI: Update osx & Xcode used in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: "9.0"
+      xcode: "11.1.0"
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -57,6 +57,7 @@ jobs:
             - brew-cache-v1
       - checkout
       - run: bin/ci prepare_system
+      - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig"' >> $BASH_ENV
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
       - run: bin/ci build
@@ -262,7 +263,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: "9.0"
+      xcode: "11.1.0"
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:

--- a/bin/ci
+++ b/bin/ci
@@ -111,8 +111,7 @@ prepare_build() {
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.31.1/crystal-0.31.1-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.31.1-1 crystal;popd'
 
-  on_osx brew install llvm@8 gmp libevent pcre pkg-config
-  on_osx brew upgrade libyaml
+  on_osx brew install llvm@8 gmp libevent pcre openssl pkg-config
   on_osx brew link --force llvm@8
   # Note: brew link --force might show:
   #   Warning: Refusing to link macOS-provided software: llvm


### PR DESCRIPTION
Xcode 9.1 is already without support in CircleCI
The MACOSX_DEPLOYMENT_TARGET will still be 10.11 in distribution-scripts

Success workflow https://circleci.com/workflow-run/c7d83edd-3624-495b-9b1d-229d6e8cfdbb