### PR TITLE
Implement .! in compiler

### DIFF
--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -49,6 +49,10 @@ describe "Normalize: case" do
     assert_expand "case x; when .as?(T); 2; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
   end
 
+  it "normalizes case with implicit !" do
+    assert_expand "case x; when .!; 2; end", "__temp_1 = x\nif !__temp_1\n  2\nend"
+  end
+
   it "normalizes case with assignment" do
     assert_expand "case x = 1; when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
   end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -130,6 +130,7 @@ module Crystal
     it_parses "+ 1", Call.new(1.int32, "+")
     it_parses "~ 1", Call.new(1.int32, "~")
     it_parses "1.~", Call.new(1.int32, "~")
+    it_parses "1.!", Not.new(1.int32)
     it_parses "1 && 2", And.new(1.int32, 2.int32)
     it_parses "1 || 2", Or.new(1.int32, 2.int32)
     it_parses "&- 1", Call.new(1.int32, "&-")
@@ -375,6 +376,7 @@ module Crystal
     it_parses "foo &.[0]", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "[]", 0.int32)))
     it_parses "foo &.[0] = 1", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "[]=", 0.int32, 1.int32)))
     it_parses "foo(&.is_a?(T))", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], IsA.new(Var.new("__arg0"), "T".path)))
+    it_parses "foo(&.!)", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Not.new(Var.new("__arg0"))))
     it_parses "foo(&.responds_to?(:foo))", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], RespondsTo.new(Var.new("__arg0"), "foo")))
     it_parses "foo &.each {\n}", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
     it_parses "foo &.each do\nend", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
@@ -941,6 +943,12 @@ module Crystal
       )
     )
 
+    it_parses "foo.!", Not.new("foo".call)
+    it_parses "foo.!.!", Not.new(Not.new("foo".call))
+    it_parses "foo.!(  )", Not.new("foo".call)
+
+    it_parses "foo &.!", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Not.new(Var.new("__arg0"))))
+
     # multiline pseudo methods (#8318)
     it_parses "sizeof(\n  Int32\n)", SizeOf.new(Path.new("Int32"))
     it_parses "instance_sizeof(\n  Int32\n)", InstanceSizeOf.new(Path.new("Int32"))
@@ -952,6 +960,7 @@ module Crystal
     it_parses "1.is_a?(\n  Int32\n)", IsA.new(1.int32, Path.new("Int32"))
     it_parses "1.responds_to?(\n  :foo\n)", RespondsTo.new(1.int32, "foo")
     it_parses "1.nil?(\n)", IsA.new(1.int32, Path.global("Nil"), nil_check: true)
+    it_parses "1.!(\n)", Not.new(1.int32)
 
     it_parses "/foo/", regex("foo")
     it_parses "/foo/i", regex("foo", Regex::Options::IGNORE_CASE)
@@ -1058,6 +1067,7 @@ module Crystal
     it_parses "case 1\nwhen .is_a?(T)\n2\nend", Case.new(1.int32, [When.new([IsA.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
     it_parses "case 1\nwhen .as(T)\n2\nend", Case.new(1.int32, [When.new([Cast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
     it_parses "case 1\nwhen .as?(T)\n2\nend", Case.new(1.int32, [When.new([NilableCast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
+    it_parses "case 1\nwhen .!()\n2\nend", Case.new(1.int32, [When.new([Not.new(ImplicitObj.new)] of ASTNode, 2.int32)])
     it_parses "case when 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
     it_parses "case \nwhen 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
     it_parses "case {1, 2}\nwhen {3, 4}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode)] of ASTNode, 5.int32)])
@@ -1650,7 +1660,7 @@ module Crystal
 
     assert_syntax_error "def foo(var : Foo+); end"
 
-    %w(&& || !).each do |name|
+    %w(&& ||).each do |name|
       assert_syntax_error "foo.#{name}"
       assert_syntax_error "foo.#{name}()"
       assert_syntax_error "foo &.#{name}"

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -616,6 +616,7 @@ module Crystal
       check_implicit_obj IsA
       check_implicit_obj Cast
       check_implicit_obj NilableCast
+      check_implicit_obj Not
 
       case cond
       when NilLiteral
@@ -641,9 +642,14 @@ module Crystal
 
     macro check_implicit_obj(type)
       if cond.is_a?({{type}})
-        if (obj = cond.obj).is_a?(ImplicitObj)
+        cond_obj = cond.is_a?(Not) ? cond.exp : cond.obj
+        if cond_obj.is_a?(ImplicitObj)
           implicit_call = cond.clone.as({{type}})
-          implicit_call.obj = temp_var.clone
+          if implicit_call.is_a?(Not)
+            implicit_call.exp = temp_var.clone
+          else
+            implicit_call.obj = temp_var.clone
+          end
           return implicit_call
         end
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3346,5 +3346,9 @@ module Crystal
     def visit(node : When | Unless | Until | MacroLiteral | OpAssign)
       raise "BUG: #{node.class_desc} node '#{node}' (#{node.location}) should have been eliminated in normalize"
     end
+
+    def visit(node : ImplicitObj)
+      raise "BUG: #{node.class_desc} node '#{node}' (#{node.location}) should have been eliminated in expand"
+    end
   end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3929,6 +3929,7 @@ module Crystal
       doc = @token.doc
 
       if @token.type == :"!"
+        # only trigger from `parse_when_expression`
         obj = Var.new("self").at(location)
         return parse_negation_suffix(obj)
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -601,7 +601,7 @@ module Crystal
       end
     end
 
-    AtomicWithMethodCheck = [:IDENT, :CONST, :"+", :"-", :"*", :"/", :"//", :"%", :"|", :"&", :"^", :"~", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :"!~", :">>", :">", :">=", :"<=>", :"===", :"[]", :"[]=", :"[]?", :"[", :"&+", :"&-", :"&*", :"&**"]
+    AtomicWithMethodCheck = [:IDENT, :CONST, :"+", :"-", :"*", :"/", :"//", :"%", :"|", :"&", :"^", :"~", :"!", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :"!~", :">>", :">", :">=", :"<=>", :"===", :"[]", :"[]=", :"[]?", :"[", :"&+", :"&-", :"&*", :"&**"]
 
     def parse_atomic_with_method
       location = @token.location
@@ -667,6 +667,9 @@ module Crystal
             atomic = parse_responds_to(atomic).at(location)
           elsif @token.value == :nil?
             atomic = parse_nil?(atomic).at(location)
+          elsif @token.type == :"!"
+            atomic = parse_negation_suffix(atomic).at(location)
+            atomic = parse_atomic_method_suffix_special(atomic, location)
           elsif @token.type == :"["
             return parse_atomic_method_suffix(atomic, location)
           else
@@ -901,6 +904,18 @@ module Crystal
       end
 
       IsA.new(atomic, Path.global("Nil"), nil_check: true)
+    end
+
+    def parse_negation_suffix(atomic)
+      next_token
+
+      if @token.type == :"("
+        next_token_skip_space_or_newline
+        check :")"
+        next_token_skip_space
+      end
+
+      Not.new(atomic)
     end
 
     def parse_atomic
@@ -1524,6 +1539,9 @@ module Crystal
         call = parse_atomic_method_suffix_special(call, location)
       elsif @token.value == :nil?
         call = parse_nil?(obj).at(location)
+        call = parse_atomic_method_suffix_special(call, location)
+      elsif @token.type == :"!"
+        call = parse_negation_suffix(obj).at(location)
         call = parse_atomic_method_suffix_special(call, location)
       elsif @token.type == :"["
         call = parse_atomic_method_suffix obj, location
@@ -2704,6 +2722,7 @@ module Crystal
         when IsA         then call.obj = ImplicitObj.new
         when Cast        then call.obj = ImplicitObj.new
         when NilableCast then call.obj = ImplicitObj.new
+        when Not         then call.exp = ImplicitObj.new
         else
           raise "BUG: expected Call, RespondsTo, IsA, Cast or NilableCast"
         end
@@ -3908,6 +3927,11 @@ module Crystal
       location = @token.location
       end_location = token_end_location
       doc = @token.doc
+
+      if @token.type == :"!"
+        obj = Var.new("self").at(location)
+        return parse_negation_suffix(obj)
+      end
 
       case @token.value
       when :is_a?


### PR DESCRIPTION
Implements the boolean negation to be written as a regular method call.

I first see mentioned it here in #8327 where @straight-shoota documented it, but it was never implemented. Second time he mentioned it in issue #8383. Also compiler have warning `'!' is a pseudo-method and can't be redefined` but if you try used it, current stack is:
```
expecting any of these tokens: IDENT, CONST, +, -, *, /, //, %, |, &, ^, ~, **, <<, <, <=, ==, !=, =~, !~, >>, >, >=, <=>, ===, [], []=, []?, [, &+, &-, &*, &** (not '!') (Crystal::SyntaxException)
	 from src/compiler/crystal/syntax/lexer.cr:3001:9 in 'raise'
	 from src/compiler/crystal/syntax/lexer.cr:3000:5 in 'raise'
	 from src/compiler/crystal/syntax/parser.cr:267:11 in 'check'
```
ie it not pass even `lexer` and in `parser` it's not implemented.