### PR TITLE
Deprecate Enumerable#grep

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -521,6 +521,7 @@ module Enumerable(T)
   # ```
   # ["Alice", "Bob"].grep(/^A/) # => ["Alice"]
   # ```
+  @[Deprecated("Use `#select` instead")]
   def grep(pattern)
     self.select { |elem| pattern === elem }
   end
@@ -1220,9 +1221,10 @@ module Enumerable(T)
   #
   # ```
   # [1, 3, 2, 5, 4, 6].select(3..5) # => [3, 5, 4]
+  # ["Alice", "Bob"].select(/^A/)   # => ["Alice"]
   # ```
   def select(pattern)
-    self.select { |e| pattern === e }
+    self.select { |elem| pattern === elem }
   end
 
   # Returns the number of elements in the collection.


### PR DESCRIPTION
`Enumerable#grep` aliases `Enumerable#select`, which has already multiple overloads.

Reasons of the change:
- `select` is more widely used, `grep` is only present in this very method
- `select` is a more descriptive English word about the action performed than `grep`
- follows the least aliases principle

Forum thread: https://forum.crystal-lang.org/t/remove-enumerable-grep/1323