### PR TITLE
Fix warning on using Channel.select

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -362,7 +362,7 @@ describe "unbuffered" do
 
   it "works with select else" do
     ch1 = Channel(Int32).new
-    Channel.select({ch1.receive_select_action}, true).should eq({1, Channel::NotReady.new})
+    Channel.non_blocking_select({ch1.receive_select_action}).should eq({1, Channel::NotReady.new})
   end
 
   it "can send and receive nil" do


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/issues/8409#issuecomment-548513517