### PR TITLE
Type node#name without generic args

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -416,6 +416,16 @@ module Crystal
         assert_macro "", %({{"foo_bar".camelcase}}), [] of ASTNode, %("FooBar")
       end
 
+      it "executes camelcase with lower" do
+        assert_macro "", %({{"foo_bar".camelcase(lower: true)}}), [] of ASTNode, %("fooBar")
+      end
+
+      it "executes camelcase with invalid lower arg type" do
+        expect_raises(Crystal::TypeException, "named argument 'lower' to StringLiteral#camelcase must be a bool, not NumberLiteral") do
+          assert_macro "", %({{"foo_bar".camelcase(lower: 99)}}), [] of ASTNode, ""
+        end
+      end
+
       it "executes underscore" do
         assert_macro "", %({{"FooBar".underscore}}), [] of ASTNode, %("foo_bar")
       end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1124,9 +1124,17 @@ module Crystal
           end
         end
 
+        describe "generic type" do
+          it "includes the generic_args of the type by default" do
+            assert_macro("klass", "{{klass.name}}", "SomeType(A, B)") do |program|
+              [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+            end
+          end
+        end
+
         describe :generic_args do
           describe true do
-            it "includes the generic_args of the type " do
+            it "includes the generic_args of the type" do
               assert_macro("klass", "{{klass.name(generic_args: true)}}", "SomeType(A, B)") do |program|
                 [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
               end
@@ -1134,7 +1142,7 @@ module Crystal
           end
 
           describe false do
-            it "does not include the generic_args of the type " do
+            it "does not include the generic_args of the type" do
               assert_macro("klass", "{{klass.name(generic_args: false)}}", "SomeType") do |program|
                 [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
               end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -11,7 +11,7 @@ private def declare_class_var(container : ClassVarContainer, name, var_type : Ty
 end
 
 module Crystal
-  describe "macro methods" do
+  describe Macro do
     describe "node methods" do
       describe "location" do
         location = Location.new("foo.cr", 1, 2)
@@ -1102,10 +1102,54 @@ module Crystal
       assert_macro "", %({% a = 1 %}{{a}}), [] of ASTNode, "1"
     end
 
-    describe "type methods" do
-      it "executes name" do
-        assert_macro("x", "{{x.name}}", "String") do |program|
-          [TypeNode.new(program.string)] of ASTNode
+    describe TypeNode do
+      describe "#name" do
+        describe "simple type" do
+          it "returns the name of the type" do
+            assert_macro("x", "{{x.name}}", "String") do |program|
+              [TypeNode.new(program.string)] of ASTNode
+            end
+          end
+        end
+
+        describe "namespaced type" do
+          it "should return the FQN of the type" do
+            assert_macro("type", "{{type.name}}", "SomeModule::SomeType") do |program|
+              mod = NonGenericModuleType.new(program, program, "SomeModule")
+
+              klass = NonGenericClassType.new(program, mod, "SomeType", program.reference)
+
+              [TypeNode.new(klass)] of ASTNode
+            end
+          end
+        end
+
+        describe :generic_args do
+          describe true do
+            it "includes the generic_args of the type " do
+              assert_macro("klass", "{{klass.name(generic_args: true)}}", "SomeType(A, B)") do |program|
+                [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+              end
+            end
+          end
+
+          describe false do
+            it "does not include the generic_args of the type " do
+              assert_macro("klass", "{{klass.name(generic_args: false)}}", "SomeType") do |program|
+                [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+              end
+            end
+          end
+
+          describe "with an invalid type argument" do
+            it "should raise the proper exception" do
+              expect_raises(Crystal::TypeException, "named argument 'generic_args' to TypeNode#name must be a bool, not NumberLiteral") do
+                assert_macro("x", "{{x.name(generic_args: 99)}}", "String") do |program|
+                  [TypeNode.new(program.string)] of ASTNode
+                end
+              end
+            end
+          end
         end
       end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -393,7 +393,7 @@ module Crystal::Macros
     end
 
     # Similar to `String#camelcase`.
-    def camelcase : StringLiteral
+    def camelcase(*, lower : BoolLiteral = false) : StringLiteral
     end
 
     # Similar to `String#capitalize`.

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1721,8 +1721,18 @@ module Crystal::Macros
     def union_types : ArrayLiteral(TypeNode)
     end
 
-    # Returns the fully qualified name of this type.
-    def name : MacroId
+    # Returns the fully qualified name of this type.  Optionally without *generic_args* if `self` is a generic type; see `#type_vars`.
+    #
+    # ```
+    # class Foo(T); end
+    #
+    # module Bar::Baz; end
+    #
+    # {{Bar::Baz.name}}                 # => Bar::Baz
+    # {{Foo.name}}                      # => Foo(T)
+    # {{Foo.name(generic_args: false)}} # => Foo
+    # ```
+    def name(*, generic_args : BoolLiteral = true) : MacroId
     end
 
     # Returns the type variables of the generic type. If the type is not

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -363,9 +363,14 @@ module Crystal
         end
 
         args = node.args.map { |arg| accept arg }
+        named_args = Hash(String, ASTNode).new
+
+        if (nargs = node.named_args)
+          nargs.each_with_object(named_args) { |arg, named_arg_hash| named_arg_hash[arg.name] = accept arg.value }
+        end
 
         begin
-          @last = receiver.interpret(node.name, args, node.block, self)
+          @last = receiver.interpret(node.name, args, named_args, node.block, self)
         rescue ex : MacroRaiseException
           raise ex
         rescue ex : Crystal::Exception
@@ -511,13 +516,15 @@ module Crystal
 
     def visit(node : Splat)
       node.exp.accept self
-      @last = @last.interpret("splat", [] of ASTNode, nil, self)
+      named_args = Hash(String, ASTNode).new
+      @last = @last.interpret("splat", [] of ASTNode, named_args, nil, self)
       false
     end
 
     def visit(node : DoubleSplat)
       node.exp.accept self
-      @last = @last.interpret("double_splat", [] of ASTNode, nil, self)
+      named_args = Hash(String, ASTNode).new
+      @last = @last.interpret("double_splat", [] of ASTNode, named_args, nil, self)
       false
     end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -363,10 +363,10 @@ module Crystal
         end
 
         args = node.args.map { |arg| accept arg }
-        named_args = Hash(String, ASTNode).new
+        named_args = nil
 
         if (nargs = node.named_args)
-          nargs.each_with_object(named_args) { |arg, named_arg_hash| named_arg_hash[arg.name] = accept arg.value }
+          named_args = nargs.each_with_object(Hash(String, ASTNode).new) { |arg, named_arg_hash| named_arg_hash[arg.name] = accept arg.value }
         end
 
         begin
@@ -516,15 +516,13 @@ module Crystal
 
     def visit(node : Splat)
       node.exp.accept self
-      named_args = Hash(String, ASTNode).new
-      @last = @last.interpret("splat", [] of ASTNode, named_args, nil, self)
+      @last = @last.interpret("splat", [] of ASTNode, nil, nil, self)
       false
     end
 
     def visit(node : DoubleSplat)
       node.exp.accept self
-      named_args = Hash(String, ASTNode).new
-      @last = @last.interpret("double_splat", [] of ASTNode, named_args, nil, self)
+      @last = @last.interpret("double_splat", [] of ASTNode, nil, nil, self)
       false
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1515,7 +1515,13 @@ module Crystal
       when "union_types"
         interpret_argless_method(method, args) { TypeNode.union_types(self) }
       when "name"
-        interpret_argless_method(method, args) { MacroId.new(type.devirtualize.to_s) }
+        interpret_argless_method(method, args) do
+          generic_args = ((nargs = named_args) && (garg = nargs["generic_args"]?)) ? garg : BoolLiteral.new(true)
+
+          raise "named argument 'generic_args' to TypeNode#name must be a bool, not #{generic_args.class_desc}" unless generic_args.is_a?(BoolLiteral)
+
+          MacroId.new(type.devirtualize.to_s(generic_args: generic_args.value))
+        end
       when "type_vars"
         interpret_argless_method(method, args) { TypeNode.type_vars(type) }
       when "instance_vars"

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1520,7 +1520,11 @@ module Crystal
         interpret_argless_method(method, args) { TypeNode.union_types(self) }
       when "name"
         interpret_argless_method(method, args) do
-          generic_args = ((nargs = named_args) && (garg = nargs["generic_args"]?)) ? garg : BoolLiteral.new(true)
+          generic_args = if named_args && (generic_arg = named_args["generic_args"]?)
+                           generic_arg
+                         else
+                           BoolLiteral.new true
+                         end
 
           raise "named argument 'generic_args' to TypeNode#name must be a bool, not #{generic_args.class_desc}" unless generic_args.is_a?(BoolLiteral)
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -325,7 +325,7 @@ module Crystal
       end
     end
 
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "id"
         interpret_argless_method("id", args) { MacroId.new(to_macro_id) }
@@ -428,7 +428,7 @@ module Crystal
   end
 
   class NumberLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when ">"
         bool_bin_op(method, args) { |me, other| me > other }
@@ -562,7 +562,7 @@ module Crystal
   end
 
   class StringLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "==", "!="
         case arg = args.first?
@@ -645,7 +645,7 @@ module Crystal
         end
       when "camelcase"
         interpret_argless_method(method, args) do
-          lower = named_args["lower"]? || BoolLiteral.new(false)
+          lower = ((nargs = named_args) && (lower_arg = nargs["lower"]?)) ? lower_arg : BoolLiteral.new(false)
 
           raise "named argument 'lower' to StringLiteral#camelcase must be a bool, not #{lower.class_desc}" unless lower.is_a?(BoolLiteral)
 
@@ -792,7 +792,7 @@ module Crystal
   end
 
   class StringInterpolation
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "expressions"
         interpret_argless_method(method, args) { ArrayLiteral.new(expressions) }
@@ -803,7 +803,7 @@ module Crystal
   end
 
   class ArrayLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "of"
         interpret_argless_method(method, args) { @of || Nop.new }
@@ -822,7 +822,7 @@ module Crystal
   end
 
   class HashLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "empty?"
         interpret_argless_method(method, args) { BoolLiteral.new(entries.empty?) }
@@ -916,7 +916,7 @@ module Crystal
   end
 
   class NamedTupleLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "empty?"
         interpret_argless_method(method, args) { BoolLiteral.new(entries.empty?) }
@@ -1026,14 +1026,14 @@ module Crystal
   end
 
   class TupleLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       value = interpret_array_or_tuple_method(self, TupleLiteral, method, args, block, interpreter)
       value || super
     end
   end
 
   class RangeLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "begin"
         interpret_argless_method(method, args) { self.from }
@@ -1090,7 +1090,7 @@ module Crystal
   end
 
   class RegexLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "source"
         interpret_argless_method(method, args) { @value }
@@ -1113,7 +1113,7 @@ module Crystal
       @name
     end
 
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -1150,7 +1150,7 @@ module Crystal
   end
 
   class Block
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "body"
         interpret_argless_method(method, args) { @body }
@@ -1169,7 +1169,7 @@ module Crystal
   end
 
   class ProcNotation
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "inputs"
         interpret_argless_method(method, args) { ArrayLiteral.new(@inputs || [] of ASTNode) }
@@ -1182,7 +1182,7 @@ module Crystal
   end
 
   class ProcLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "args", "body"
         @def.interpret(method, args, named_args, block, interpreter)
@@ -1193,7 +1193,7 @@ module Crystal
   end
 
   class ProcPointer
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "obj"
         interpret_argless_method(method, args) { @obj || NilLiteral.new }
@@ -1208,7 +1208,7 @@ module Crystal
   end
 
   class Expressions
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "expressions"
         interpret_argless_method(method, args) do
@@ -1221,7 +1221,7 @@ module Crystal
   end
 
   class BinaryOp
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "left"
         interpret_argless_method(method, args) { @left }
@@ -1234,7 +1234,7 @@ module Crystal
   end
 
   class TypeDeclaration
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "var"
         interpret_argless_method(method, args) do
@@ -1253,7 +1253,7 @@ module Crystal
   end
 
   class UninitializedVar
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "var"
         interpret_argless_method(method, args) do
@@ -1270,7 +1270,7 @@ module Crystal
   end
 
   class Union
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "resolve"
         interpret_argless_method(method, args) { interpreter.resolve(self) }
@@ -1285,7 +1285,7 @@ module Crystal
   end
 
   class Arg
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(external_name) }
@@ -1302,7 +1302,7 @@ module Crystal
   end
 
   class Def
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -1345,7 +1345,7 @@ module Crystal
   end
 
   class Macro
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -1372,7 +1372,7 @@ module Crystal
   end
 
   class UnaryExpression
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "exp"
         interpret_argless_method(method, args) { @exp }
@@ -1383,7 +1383,7 @@ module Crystal
   end
 
   class OffsetOf
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "type"
         interpret_argless_method(method, args) { @offsetof_type }
@@ -1396,7 +1396,7 @@ module Crystal
   end
 
   class VisibilityModifier
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "exp"
         interpret_argless_method(method, args) { @exp }
@@ -1411,7 +1411,7 @@ module Crystal
   end
 
   class IsA
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "receiver"
         interpret_argless_method(method, args) { @obj }
@@ -1424,7 +1424,7 @@ module Crystal
   end
 
   class RespondsTo
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "receiver"
         interpret_argless_method(method, args) { @obj }
@@ -1437,7 +1437,7 @@ module Crystal
   end
 
   class Require
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "path"
         interpret_argless_method(method, args) { StringLiteral.new(@string) }
@@ -1448,7 +1448,7 @@ module Crystal
   end
 
   class MacroId
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "==", "!="
         case arg = args.first?
@@ -1478,7 +1478,7 @@ module Crystal
   end
 
   class SymbolLiteral
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "==", "!="
         case arg = args.first?
@@ -1504,7 +1504,7 @@ module Crystal
   end
 
   class TypeNode
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "abstract?"
         interpret_argless_method(method, args) { BoolLiteral.new(type.abstract?) }
@@ -1829,7 +1829,7 @@ module Crystal
   end
 
   class Call
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(name) }
@@ -1864,7 +1864,7 @@ module Crystal
   end
 
   class NamedArgument
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(name) }
@@ -1877,7 +1877,7 @@ module Crystal
   end
 
   class If
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "cond"
         interpret_argless_method(method, args) { @cond }
@@ -1892,7 +1892,7 @@ module Crystal
   end
 
   class Case
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "cond"
         interpret_argless_method(method, args) { cond || Nop.new }
@@ -1907,7 +1907,7 @@ module Crystal
   end
 
   class When
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "conds"
         interpret_argless_method(method, args) { ArrayLiteral.new(conds) }
@@ -1920,7 +1920,7 @@ module Crystal
   end
 
   class Assign
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "target"
         interpret_argless_method(method, args) { target }
@@ -1933,7 +1933,7 @@ module Crystal
   end
 
   class MultiAssign
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "targets"
         interpret_argless_method(method, args) { ArrayLiteral.new(targets) }
@@ -1950,7 +1950,7 @@ module Crystal
       @name
     end
 
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -1961,7 +1961,7 @@ module Crystal
   end
 
   class ReadInstanceVar
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "obj"
         interpret_argless_method(method, args) { @obj }
@@ -1978,7 +1978,7 @@ module Crystal
       @name
     end
 
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -1993,7 +1993,7 @@ module Crystal
       @name
     end
 
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { MacroId.new(@name) }
@@ -2004,7 +2004,7 @@ module Crystal
   end
 
   class Path
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "names"
         interpret_argless_method(method, args) do
@@ -2029,7 +2029,7 @@ module Crystal
   end
 
   class While
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "cond"
         interpret_argless_method(method, args) { @cond }
@@ -2042,7 +2042,7 @@ module Crystal
   end
 
   class Cast
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "obj"
         interpret_argless_method(method, args) { obj }
@@ -2055,7 +2055,7 @@ module Crystal
   end
 
   class NilableCast
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "obj"
         interpret_argless_method(method, args) { obj }
@@ -2068,7 +2068,7 @@ module Crystal
   end
 
   class Splat
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "exp"
         interpret_argless_method(method, args) { exp }
@@ -2079,7 +2079,7 @@ module Crystal
   end
 
   class Generic
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "name"
         interpret_argless_method(method, args) { name }
@@ -2106,7 +2106,7 @@ module Crystal
   end
 
   class Annotation
-    def interpret(method, args, named_args, block, interpreter)
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter)
       case method
       when "[]"
         interpret_one_arg_method(method, args) do |arg|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -718,6 +718,12 @@ module Crystal
       nil
     end
 
+    def to_s(*, generic_args : Bool = true)
+      String.build do |io|
+        to_s_with_options io, generic_args: generic_args
+      end
+    end
+
     def inspect(io : IO) : Nil
       to_s(io)
     end


### PR DESCRIPTION
Requires #8429.  Will make this a draft until thats merged, then can rebase.

This PR allows getting the name of a `TypeNode` without the type's type vars.  The main use case for this is when iterating over the subclasses of a parent type, where the children have type vars, and you're wanting to include data from a macro or annotation as generic type arguments.  Currently since the type vars were always included you couldn't just do like `{{"#{type.name}(#{ann[:theType]})".id}}` since that would expand to say `SomeType(T)(Foo)`.  This allows skipping the `(T)` to make supplying the generic types easier.

See https://github.com/Blacksmoke16/assert/blob/master/src/assert.cr#L152 where I have to `gsub` the type arguments away before adding my own.