### PR TITLE
Return nil (and don't raise) when "Content-Type" header is an empty string.

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -284,6 +284,11 @@ class HTTP::Client
       response.charset.should eq("UTF-8")
     end
 
+    it "returns content type as nil when empty (#8398)" do
+      response = Response.new(:ok, "", headers: HTTP::Headers{"Content-Type" => ""})
+      response.content_type.should be_nil
+    end
+
     it "returns status_code" do
       response = Response.new(:created)
       response.status_code.should eq 201

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -63,7 +63,7 @@ class HTTP::Client::Response
   end
 
   def mime_type : MIME::MediaType?
-    if content_type = headers["Content-Type"]?
+    if content_type = headers["Content-Type"]?.presence
       MIME::MediaType.parse(content_type)
     end
   end


### PR DESCRIPTION
This PR changes the behavior of `HTTP::Client::Response#mime_type` to return `nil` (and not raise) when `Content-Type` header is an empty string.

As per https://github.com/crystal-lang/crystal/issues/8398#issuecomment-547595695
Fixes #8398