### PR TITLE
Don't close pipes used for signal handlers in MT

### DIFF
--- a/src/signal.cr
+++ b/src/signal.cr
@@ -242,7 +242,9 @@ module Crystal::Signal
       LibC.signal(signal, LibC::SIG_DFL) if signal.set?
     end
   ensure
-    @@pipe.each(&.close)
+    {% unless flag?(:preview_mt) %}
+      @@pipe.each(&.close)
+    {% end %}
   end
 
   private def self.reader


### PR DESCRIPTION
This should fix #8375 

In MT mode, `fork` is disabled and the event loop is not reinitialized. In other words, `fork` only works to run a process (i.e: do an `exec`) right away, without any context switch or IO operations in between.