### PR TITLE
Implement JSON,YAML discriminator in runtime

### DIFF
--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -391,40 +391,41 @@ module JSON
       {% end %}
 
       def self.new(pull : ::JSON::PullParser)
-        location = pull.location
+        ::JSON::Serializable.discriminate(pull, {{field}}, {{mapping}})
+      end
+    end
 
-        discriminator_value = nil
+    def self.discriminate(pull, field, mapping)
+      location = pull.location
 
-        # Try to find the discriminator while also getting the raw
-        # string value of the parsed JSON, so then we can pass it
-        # to the final type.
-        json = String.build do |io|
-          JSON.build(io) do |builder|
-            builder.start_object
-            pull.read_object do |key|
-              if key == {{field.id.stringify}}
-                discriminator_value = pull.read_string
-                builder.field(key, discriminator_value)
-              else
-                builder.field(key) { pull.read_raw(builder) }
-              end
+      discriminator_value = nil
+
+      # Try to find the discriminator while also getting the raw
+      # string value of the parsed JSON, so then we can pass it
+      # to the final type.
+      json = String.build do |io|
+        JSON.build(io) do |builder|
+          builder.start_object
+          pull.read_object do |key|
+            if key == field
+              discriminator_value = pull.read_string
+              builder.field(key, discriminator_value)
+            else
+              builder.field(key) { pull.read_raw(builder) }
             end
-            builder.end_object
           end
+          builder.end_object
         end
+      end
 
-        unless discriminator_value
-          raise ::JSON::MappingError.new("Missing JSON discriminator field '{{field.id}}'", to_s, nil, *location, nil)
-        end
+      unless discriminator_value
+        raise ::JSON::MappingError.new("Missing JSON discriminator field '#{field}'", to_s, nil, *location, nil)
+      end
 
-        case discriminator_value
-        {% for key, value in mapping %}
-          when {{key.id.stringify}}
-            {{value.id}}.from_json(json)
-        {% end %}
-        else
-          raise ::JSON::MappingError.new("Unknown '{{field.id}}' discriminator value: #{discriminator_value.inspect}", to_s, nil, *location, nil)
-        end
+      if target = mapping[discriminator_value]?
+        target.from_json(json)
+      else
+        raise ::JSON::MappingError.new("Unknown '#{field}' discriminator value: #{discriminator_value.inspect}", to_s, nil, *location, nil)
       end
     end
   end


### PR DESCRIPTION
Followup to #8406 which completely implements the discriminators as a runtime method instead of a macro.

The change from the previous implementation is small. But having it as a runtime method provides much more flexibility. For example, you can defining different sets of discrimination rules without having to define a supertype for each of them. And most importantly, discriminated types don't need to inherit from the same supertype.

So far, this is only the minimal change as a proof of concept.

1. The implementation is not specific to `Serializable`, so I'd suggest to place the method directly in the `JSON`/`YAML` namespaces.
2. Alternatively we could even consider to place the method on the pull parser for JSON. That would make some kind of sense. But not so much for YAML, I guess.
3. The method name `discriminate` is up for debate. Any ideas?
4. The definition of an initializer method is trivial, I'd suggest to completely remove the macro methods:
```cr
use_json_discriminator "type", {point: Point, circle: Circle}
# vs.
def self.new(pull : ::JSON::PullParser)
  JSON.discriminate(pull, "type", {point: Point, circle: Circle}
end
```
5. Support for aliases in YAML still needs to be implemented. But I presume that should not be an issue.
6. Specs and documentation will be added when the previous points are settled.