### PR TITLE
Deprecate String#codepoint_at

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -907,6 +907,7 @@ class String
     byte_slice start, bytesize - start
   end
 
+  @[Deprecated("Use .char_at(index).ord instead")]
   def codepoint_at(index)
     char_at(index).ord
   end


### PR DESCRIPTION
Ref #8449

I'm not sure if the use of `String#codepoint_at` should be removed in this PR or in follow-up PR where `String#codepoint_at` is removed.

I see some other deprecation warnings when running crystal specs, so I assume it may be intentional and serves as a reminder to remove usage later when the method itself is removed.

Let me know if `String#codepoint_at` usage should be removed in this PR.