### PR TITLE
Some misbehaving SSL servers hang at the end instead of responding wi…

### DIFF
--- a/spec/manual/https_client_spec.cr
+++ b/spec/manual/https_client_spec.cr
@@ -12,8 +12,4 @@ describe "https requests" do
       break
     end
   end
-
-  it "can fetch from IIS servers that don't shutdown gracefully" do
-    HTTP::Client.post("https://login.microsoftonline.com/common/oauth2/token", form: {"hi" => "a"}).body
-  end
 end

--- a/spec/manual/https_client_spec.cr
+++ b/spec/manual/https_client_spec.cr
@@ -12,4 +12,8 @@ describe "https requests" do
       break
     end
   end
+
+  it "can fetch from IIS servers that don't shutdown gracefully" do
+    HTTP::Client.post("https://login.microsoftonline.com/common/oauth2/token", form: {"hi" => "a"}).body
+  end
 end

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -36,22 +36,21 @@ describe OpenSSL::SSL::Socket do
     end
   end
 
-  it "can close connection on servers that don't shut down right" do
+  it "closes connection to server that doesn't properly terminate SSL session" do
     tcp_server = TCPServer.new(0)
     server_context, client_context = ssl_context_pair
 
-    OpenSSL::SSL::Server.open(tcp_server, server_context, sync_close: true) do |server|
-      client_done = Channel(Nil).new
-      spawn do
-        OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com", sync_close: true) do |socket|
-        end
-        client_done.send(nil)
+    client_successfully_closed_socket = Channel(Nil).new
+    spawn do
+      OpenSSL::SSL::Server.open(tcp_server, server_context, sync_close: true) do |server|
+        server_client = server.accept
+        # require client to close the socket from its side, without the server closing it, IIS behave this way.
+        client_successfully_closed_socket.receive
+        server_client.close
       end
-      client = server.accept
-      # allow client to close the socket from its side, without the server closing it, IIS behaves this way
-      # should not hang
-      client_done.receive
-      client.close
     end
+    OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com", sync_close: true) do |socket|
+    end
+    client_successfully_closed_socket.send(nil)
   end
 end

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -49,10 +49,9 @@ describe OpenSSL::SSL::Socket do
         server_client.close
       end
     end
-    socket = TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port
+    socket = TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port)
     socket = OpenSSL::SSL::Socket::Client.new(socket, client_context, hostname: "example.com", sync_close: true)
     socket.close
-    end
     client_successfully_closed_socket.send(nil)
   end
 end

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -49,7 +49,9 @@ describe OpenSSL::SSL::Socket do
         server_client.close
       end
     end
-    OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com", sync_close: true) do |socket|
+    socket = TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port
+    socket = OpenSSL::SSL::Socket::Client.new(socket, client_context, hostname: "example.com", sync_close: true)
+    socket.close
     end
     client_successfully_closed_socket.send(nil)
   end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -154,8 +154,8 @@ abstract class OpenSSL::SSL::Socket < IO
       loop do
         begin
           ret = LibSSL.ssl_shutdown(@ssl)
-          break if ret == 1 # done bidirectional
-          break if ret == 0 && @sync_close # done unidirectional, "this first successful call to SSL_shutdown() is sufficient"
+          break if ret == 1                # done bidirectional
+          break if ret == 0 && sync_close? # done unidirectional, "this first successful call to SSL_shutdown() is sufficient"
           raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_shutdown") if ret < 0
         rescue e : OpenSSL::SSL::Error
           case e.error

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -154,7 +154,8 @@ abstract class OpenSSL::SSL::Socket < IO
       loop do
         begin
           ret = LibSSL.ssl_shutdown(@ssl)
-          break if ret == 1
+          break if ret == 1 # done bidirectional
+          break if ret == 0 && @sync_close # done unidirectional, "this first successful call to SSL_shutdown() is sufficient"
           raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_shutdown") if ret < 0
         rescue e : OpenSSL::SSL::Error
           case e.error
@@ -171,7 +172,7 @@ abstract class OpenSSL::SSL::Socket < IO
 
         # ret == 0, retry, shutdown is not complete yet
       end
-    rescue IO::Error
+    rescue IO::Error | Errno
     ensure
       @bio.io.close if @sync_close
     end


### PR DESCRIPTION
…th an SSL close_notify alert.  the docs for SSL_shutdown say 'If a unidirectional shutdown is enough (the underlying connection shall be closed anyway), this first successful call to SSL_shutdown() is sufficient.' which seems to fix the problem.  Also capture Errno's during close instead of bubbling them up, same as IO::Errors. Closes #7136

Sorry I couldn't format the commit message easily on the command line...