### PR TITLE
Allow getting a TypeNode's name without type vars

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1725,8 +1725,18 @@ module Crystal::Macros
     def union_types : ArrayLiteral(TypeNode)
     end
 
-    # Returns the fully qualified name of this type.
-    def name : MacroId
+    # Returns the fully qualified name of this type.  Optionally without *generic_args* if `self` is a generic type; see `#type_vars`.
+    #
+    # ```
+    # class Foo(T); end
+    #
+    # module Bar::Baz; end
+    #
+    # {{Bar::Baz.name}}                 # => Bar::Baz
+    # {{Foo.name}}                      # => Foo(T)
+    # {{Foo.name(generic_args: false)}} # => Foo
+    # ```
+    def name(*, generic_args : BoolLiteral = true) : MacroId
     end
 
     # Returns the type variables of the generic type. If the type is not

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1519,7 +1519,17 @@ module Crystal
       when "union_types"
         interpret_argless_method(method, args) { TypeNode.union_types(self) }
       when "name"
-        interpret_argless_method(method, args) { MacroId.new(type.devirtualize.to_s) }
+        interpret_argless_method(method, args) do
+          generic_args = if named_args && (generic_arg = named_args["generic_args"]?)
+                           generic_arg
+                         else
+                           BoolLiteral.new true
+                         end
+
+          raise "named argument 'generic_args' to TypeNode#name must be a bool, not #{generic_args.class_desc}" unless generic_args.is_a?(BoolLiteral)
+
+          MacroId.new(type.devirtualize.to_s(generic_args: generic_args.value))
+        end
       when "type_vars"
         interpret_argless_method(method, args) { TypeNode.type_vars(type) }
       when "instance_vars"

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -719,6 +719,12 @@ module Crystal
       nil
     end
 
+    def to_s(*, generic_args : Bool = true)
+      String.build do |io|
+        to_s_with_options io, generic_args: generic_args
+      end
+    end
+
     def inspect(io : IO) : Nil
       to_s(io)
     end


### PR DESCRIPTION
Follow up to https://github.com/crystal-lang/crystal/pull/8458, was easier to redo the branch versus figuring out git :grimacing:.