### PR TITLE
Remove self restriction from Object.from_{json,yaml}

### DIFF
--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -8,7 +8,7 @@
 # Int32.from_json("1")                # => 1
 # Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
 # ```
-def Object.from_json(string_or_io) : self
+def Object.from_json(string_or_io)
   parser = JSON::PullParser.new(string_or_io)
   new parser
 end
@@ -21,7 +21,7 @@ end
 # ```
 # Int32.from_json(%({"main": 1}), root: "main") # => 1
 # ```
-def Object.from_json(string_or_io, root : String) : self
+def Object.from_json(string_or_io, root : String)
   parser = JSON::PullParser.new(string_or_io)
   parser.on_key!(root) do
     new parser

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -1,4 +1,4 @@
-def Object.from_yaml(string_or_io : String | IO) : self
+def Object.from_yaml(string_or_io : String | IO)
   new(YAML::ParseContext.new, parse_yaml(string_or_io))
 end
 


### PR DESCRIPTION
Object.new is not restricted to self, so .from_json and .from_yaml should neither.

The generic `Object.new` is typically supposed to return a new instance of the respective type. That's the default behaviour. But the method can be overridden by implementing classes.

The overloads `.new(JSON::PullParser)` and `.new(YAML::ParseContext, YAML::Nodes::Node)` are not required to return an instance of the type either. There may be valid use cases where the return value is actually a different type. 

/cc #8473 for context