### PR TITLE
have a better error message when a filename is misspelled

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -102,7 +102,11 @@ class Crystal::Command
     when File.file?(command)
       run_command(single_file: true)
     else
-      error "unknown command (and file not found): #{command}"
+      if command =~ /.+#{File::SEPARATOR}.+/ || command.ends_with?(".cr")
+        error "file not found: #{command}"
+      else
+        error "unknown command: #{command}"
+      end
     end
   rescue ex : Crystal::LocationlessException
     error ex.message

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -102,7 +102,7 @@ class Crystal::Command
     when File.file?(command)
       run_command(single_file: true)
     else
-      error "unknown command: #{command}"
+      error "unknown command (and file not found): #{command}"
     end
   rescue ex : Crystal::LocationlessException
     error ex.message

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -102,8 +102,8 @@ class Crystal::Command
     when File.file?(command)
       run_command(single_file: true)
     else
-      if command =~ /.+#{File::SEPARATOR}.+/ || command.ends_with?(".cr")
-        error "file not found: #{command}"
+      if command.ends_with?(".cr")
+        error "file not found: '#{command}'"
       else
         error "unknown command: #{command}"
       end
@@ -499,7 +499,7 @@ class Crystal::Command
   private def gather_sources(filenames)
     filenames.map do |filename|
       unless File.file?(filename)
-        error "File #{filename} does not exist"
+        error "File '#{filename}' does not exist"
       end
       filename = File.expand_path(filename)
       Compiler::Source.new(filename, File.read(filename))

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -103,7 +103,7 @@ class Crystal::Command
       run_command(single_file: true)
     else
       if command.ends_with?(".cr")
-        error "file not found: '#{command}'"
+        error "file '#{command}' does not exist"
       else
         error "unknown command: #{command}"
       end
@@ -499,7 +499,7 @@ class Crystal::Command
   private def gather_sources(filenames)
     filenames.map do |filename|
       unless File.file?(filename)
-        error "File '#{filename}' does not exist"
+        error "file '#{filename}' does not exist"
       end
       filename = File.expand_path(filename)
       Compiler::Source.new(filename, File.read(filename))


### PR DESCRIPTION
It's a bit confusing to enter a filename and have crystal say "invalid command"

```
$ ./bin/crystal filename.cr
Error: unknown command: filename.cr
```
So attempt clarify.
```
$ ./bin/crystal filename.cr
Error: unknown command (and file not found): filename.cr
```