### PR TITLE
HTTP::Client: don't turn body_io into nil if content-length is zero

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -123,6 +123,12 @@ class HTTP::Client
       response.body.should eq("")
     end
 
+    it "parses response without body but Content-Length == 0, block form (#8461)" do
+      Response.from_io(IO::Memory.new("HTTP/1.1 301 OK\r\nContent-Length: 0\r\n\r\n")) do |response|
+        response.body_io.gets_to_end.should eq("")
+      end
+    end
+
     it "parses long request lines" do
       request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 #{"OK" * 600_000}\r\n\r\n"))
       request.should eq(nil)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -38,10 +38,7 @@ module HTTP
         if body_type.prohibited?
           body = nil
         elsif content_length = content_length(headers)
-          if content_length >= 0
-            # Don't create IO for Content-Length == 0
-            body = FixedLengthContent.new(io, content_length)
-          end
+          body = FixedLengthContent.new(io, content_length)
         elsif headers["Transfer-Encoding"]? == "chunked"
           body = ChunkedContent.new(io)
         elsif body_type.mandatory?

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -38,7 +38,7 @@ module HTTP
         if body_type.prohibited?
           body = nil
         elsif content_length = content_length(headers)
-          if content_length != 0
+          if content_length >= 0
             # Don't create IO for Content-Length == 0
             body = FixedLengthContent.new(io, content_length)
           end


### PR DESCRIPTION
Fixes #8461