### PR TITLE
Allow timeout in select statements

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -277,6 +277,65 @@ describe Channel do
         end
       end
     end
+
+    context "timeout" do
+      it "types" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.send "foo" }) do
+          i, m = Channel.select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+          typeof(i).should eq(Int32)
+          typeof(m).should eq(String?)
+        end
+      end
+
+      it "triggers timeout" do
+        ch = Channel(String).new
+        spawn_and_wait(->{}) do
+          i, m = Channel.select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+
+          i.should eq(1)
+          m.should eq(nil)
+        end
+      end
+
+      it "negative amounts should not trigger timeout" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.send "foo" }) do
+          i, m = Channel.select(ch.receive_select_action, timeout_select_action(-1.seconds))
+
+          i.should eq(0)
+          m.should eq("foo")
+        end
+      end
+
+      it "send raise-on-close raises if channel was closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          expect_raises Channel::ClosedError do
+            Channel.select(ch.send_select_action("foo"), timeout_select_action(0.1.seconds))
+          end
+        end
+      end
+
+      it "receive raise-on-close raises if channel was closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          expect_raises Channel::ClosedError do
+            Channel.select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+          end
+        end
+      end
+
+      it "receive nil-on-close returns index of closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          i, m = Channel.select(ch.receive_select_action?, timeout_select_action(0.1.seconds))
+
+          i.should eq(0)
+          m.should eq(nil)
+        end
+      end
+    end
   end
 
   describe ".non_blocking_select" do
@@ -364,6 +423,65 @@ describe Channel do
           i, m = Channel.non_blocking_select(ch.send_select_action("foo"), ch2.send_select_action(true))
           typeof(i).should eq(Int32)
           typeof(m).should eq(Nil | Channel::NotReady)
+        end
+      end
+    end
+
+    context "timeout" do
+      it "types" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.send "foo" }) do
+          i, m = Channel.non_blocking_select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+          typeof(i).should eq(Int32)
+          typeof(m).should eq(String | Nil | Channel::NotReady)
+        end
+      end
+
+      it "should not trigger timeout" do
+        ch = Channel(String).new
+        spawn_and_wait(->{}) do
+          i, m = Channel.non_blocking_select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+
+          i.should eq(2)
+          m.should eq(Channel::NotReady.new)
+        end
+      end
+
+      it "negative amounts should not trigger timeout" do
+        ch = Channel(String).new
+        spawn_and_wait(->{}) do
+          i, m = Channel.non_blocking_select(ch.receive_select_action, timeout_select_action(-1.seconds))
+
+          i.should eq(2)
+          m.should eq(Channel::NotReady.new)
+        end
+      end
+
+      it "send raise-on-close raises if channel was closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          expect_raises Channel::ClosedError do
+            Channel.non_blocking_select(ch.send_select_action("foo"), timeout_select_action(0.1.seconds))
+          end
+        end
+      end
+
+      it "receive raise-on-close raises if channel was closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          expect_raises Channel::ClosedError do
+            Channel.non_blocking_select(ch.receive_select_action, timeout_select_action(0.1.seconds))
+          end
+        end
+      end
+
+      it "receive nil-on-close returns index of closed while waiting" do
+        ch = Channel(String).new
+        spawn_and_wait(->{ ch.close }) do
+          i, m = Channel.non_blocking_select(ch.receive_select_action?, timeout_select_action(0.1.seconds))
+
+          i.should eq(0)
+          m.should eq(nil)
         end
       end
     end

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -79,8 +79,8 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
   end
 
   ex = done.receive
+  raise ex if ex
   unless w.checked?
     fail "Failed to stress expected path", file, line
   end
-  raise ex if ex
 end

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -52,6 +52,14 @@ class Crystal::Scheduler
     Thread.current.scheduler.sleep(time)
   end
 
+  def self.timeout(time : Time::Span) : Nil
+    Thread.current.scheduler.timeout(time)
+  end
+
+  def self.cancel_timeout : Nil
+    Thread.current.scheduler.cancel_timeout
+  end
+
   def self.yield : Nil
     Thread.current.scheduler.yield
   end
@@ -169,6 +177,14 @@ class Crystal::Scheduler
   protected def yield(fiber : Fiber) : Nil
     @current.resume_event.add(0.seconds)
     resume(fiber)
+  end
+
+  protected def timeout(time : Time::Span) : Nil
+    @current.timeout_event.add(time)
+  end
+
+  protected def cancel_timeout : Nil
+    @current.timeout_event.delete
   end
 
   {% if flag?(:preview_mt) %}

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -52,14 +52,6 @@ class Crystal::Scheduler
     Thread.current.scheduler.sleep(time)
   end
 
-  def self.timeout(time : Time::Span) : Nil
-    Thread.current.scheduler.timeout(time)
-  end
-
-  def self.cancel_timeout : Nil
-    Thread.current.scheduler.cancel_timeout
-  end
-
   def self.yield : Nil
     Thread.current.scheduler.yield
   end
@@ -177,14 +169,6 @@ class Crystal::Scheduler
   protected def yield(fiber : Fiber) : Nil
     @current.resume_event.add(0.seconds)
     resume(fiber)
-  end
-
-  protected def timeout(time : Time::Span) : Nil
-    @current.timeout_event.add(time)
-  end
-
-  protected def cancel_timeout : Nil
-    @current.timeout_event.delete
   end
 
   {% if flag?(:preview_mt) %}

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -10,6 +10,9 @@ module Crystal::EventLoop
   # Create a new resume event for a fiber.
   # def self.create_resume_event(fiber : Fiber) : Crystal::Event
 
+  # Creates a timeout_event.
+  # def self.create_timeout_event(fiber) : Crystal::Event
+
   # Creates a write event for a file descriptor.
   # def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
 

--- a/src/crystal/system/unix/event_libevent.cr
+++ b/src/crystal/system/unix/event_libevent.cr
@@ -37,6 +37,12 @@ struct Crystal::Event
     @freed = true
   end
 
+  def delete
+    unless LibEvent2.event_del(@event) == 0
+      raise "Error deleting event"
+    end
+  end
+
   # :nodoc:
   struct Base
     def initialize

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -29,6 +29,15 @@ module Crystal::EventLoop
     end
   end
 
+  # Creates a timeout_event.
+  def self.create_timeout_event(fiber) : Crystal::Event
+    event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
+      f = data.as(Fiber)
+      f.timed_out = true
+      Crystal::Scheduler.enqueue f
+    end
+  end
+
   # Creates a write event for a file descriptor.
   def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
     flags = LibEvent2::EventFlags::Write

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -19,8 +19,10 @@ class Fiber
   @context : Context
   @stack : Void*
   @resume_event : Crystal::Event?
+  @timeout_event : Crystal::Event?
   protected property stack_bottom : Void*
   property name : String?
+  property? timed_out = false
   @alive = true
   @current_thread = Atomic(Thread?).new(nil)
 
@@ -104,6 +106,7 @@ class Fiber
 
     # Delete the resume event if it was used by `yield` or `sleep`
     @resume_event.try &.free
+    @timeout_event.try &.free
 
     @alive = false
     Crystal::Scheduler.reschedule
@@ -142,6 +145,22 @@ class Fiber
   # :nodoc:
   def resume_event
     @resume_event ||= Crystal::EventLoop.create_resume_event(self)
+  end
+
+  # :nodoc:
+  def timeout_event
+    @timeout_event ||= Crystal::EventLoop.create_timeout_event(self)
+  end
+
+  # The current fiber will resume after a period of time
+  # and have the property `timed_out` set to true.
+  # The timeout can be cancelled with `cancel_timeout`
+  def self.timeout(timeout : Time::Span?) : Nil
+    Crystal::Scheduler.timeout(timeout)
+  end
+
+  def self.cancel_timeout
+    Crystal::Scheduler.cancel_timeout
   end
 
   def self.yield


### PR DESCRIPTION
* Based on #8006 by @carlhoerberg 
* Rebased regarding recent changes in the event loop and channel refactor
* Added specs
  * timeout is not activated if negative time amounts are used
  * timeout is not activated if select is non-blocking

Closes #8006