### PR TITLE
Add HTTP::Client#write_timeout

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -223,6 +223,20 @@ module HTTP
       end
     end
 
+    it "tests write_timeout" do
+      # Here we don't want to write a response on the server side because
+      # it doesn't make sense to try to write because the client will already
+      # timeout on read. Writing a response could lead on an exception in
+      # the server if the socket is closed.
+      test_server("localhost", 0, 0, write_response: false) do |server|
+        client = Client.new("localhost", server.local_address.port)
+        expect_raises(IO::Timeout, "Write timed out") do
+          client.write_timeout = 0.001
+          client.post("/", body: "a" * 5_000_000)
+        end
+      end
+    end
+
     it "tests connect_timeout" do
       test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -117,6 +117,7 @@ class HTTP::Client
   @dns_timeout : Float64?
   @connect_timeout : Float64?
   @read_timeout : Float64?
+  @write_timeout : Float64?
 
   # Creates a new HTTP client with the given *host*, *port* and *tls*
   # configurations. If no port is given, the default one will
@@ -293,6 +294,18 @@ class HTTP::Client
   # ```
   def read_timeout=(read_timeout : Time::Span)
     self.read_timeout = read_timeout.total_seconds
+  end
+
+  # Sets the write timeout - if any chunk of request is not written
+  # within the number of seconds provided, `IO::Timeout` exception is raised.
+  def write_timeout=(write_timeout : Number)
+    @write_timeout = write_timeout.to_f
+  end
+
+  # Sets the write timeout - if any chunk of request is not written
+  # within the provided `Time::Span`,  `IO::Timeout` exception is raised.
+  def write_timeout=(write_timeout : Time::Span)
+    self.write_timeout = write_timeout.total_seconds
   end
 
   # Sets the number of seconds to wait when connecting, before raising an `IO::Timeout`.
@@ -754,6 +767,7 @@ class HTTP::Client
     hostname = @host.starts_with?('[') && @host.ends_with?(']') ? @host[1..-2] : @host
     socket = TCPSocket.new hostname, @port, @dns_timeout, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
+    socket.write_timeout = @write_timeout if @write_timeout
     socket.sync = false
 
     {% if !flag?(:without_openssl) %}


### PR DESCRIPTION
Fixes #8487 • (fwiw, Ruby [has it](https://ruby-doc.org/stdlib-2.6/libdoc/net/http/rdoc/Net/HTTP.html#write_timeout) since version `2.6.0` - see the [relevant ticket](https://bugs.ruby-lang.org/issues/13396))