### PR TITLE
Fix make Thread#gc_thread_handler portable

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -21,6 +21,9 @@ class Thread
 
   # Associates the Thread object to the running system thread.
   # def self.current=(thread : Thread)
+
+  # Holds the GC thread handler
+  property gc_thread_handler : Void* = Pointer(Void).null
 end
 
 require "./thread_linked_list"

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -16,9 +16,6 @@ class Thread
   # :nodoc:
   property previous : Thread?
 
-  # :nodoc:
-  property gc_thread_handler : Void* = Pointer(Void).null
-
   def self.unsafe_each
     threads.unsafe_each { |thread| yield thread }
   end


### PR DESCRIPTION
This makes sure Fiber compiles on win32.

Fixes a merge order issue with #8225 and #7995.