### PR TITLE
Platform dependent public API

### DIFF
--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -51,3 +51,8 @@ end
 # using `ldflags`: `@[Link(ldflags: "-Lvendor/bin")]`.
 annotation Link
 end
+
+# This annotations marks methods, classes and constants as platform dependent.
+#
+annotation Platform
+end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -242,6 +242,7 @@ module Crystal
       types["ReturnsTwice"] = @returns_twice_annotation = AnnotationType.new self, self, "ReturnsTwice"
       types["ThreadLocal"] = @thread_local_annotation = AnnotationType.new self, self, "ThreadLocal"
       types["Deprecated"] = @deprecated_annotation = AnnotationType.new self, self, "Deprecated"
+      types["Platform"] = @platform_annotation = AnnotationType.new self, self, "Platform"
 
       define_crystal_constants
     end
@@ -463,7 +464,7 @@ module Crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation
-                     flags_annotation link_annotation extern_annotation deprecated_annotation) %}
+                     flags_annotation link_annotation extern_annotation deprecated_annotation platform_annotation) %}
       def {{name.id}}
         @{{name.id}}.not_nil!
       end

--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -3,30 +3,68 @@
     <%= Crystal::Doc.anchor_link(title) %>
     <%= title %>
   </h2>
-  <% methods.each do |method| %>
-    <div class="entry-detail" id="<%= method.html_id %>">
-      <div class="signature">
-        <%= method.abstract? ? "abstract " : "" %>
-        <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
+  <% unless cross_platform_methods.empty? %>
+    <% cross_platform_methods.each do |method| %>
+      <div class="entry-detail" id="<%= method.html_id %>">
+        <div class="signature">
+          <%= method.abstract? ? "abstract " : "" %>
+          <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
 
-        <a class="method-permalink" href="<%= method.anchor %>">#</a>
-      </div>
-      <% if doc = method.formatted_doc %>
-        <div class="doc">
-          <% if doc_copied_from = method.doc_copied_from %>
-            <div class="doc-inherited">
-              Description copied from <%= doc_copied_from.kind %> <%= doc_copied_from.link_from(method.type) %>
-            </div>
-          <% end %>
-          <%= doc %>
+          <a class="method-permalink" href="<%= method.anchor %>">#</a>
         </div>
-      <% end %>
-      <br/>
-      <div>
-        <% if source_link = method.source_link %>
-          [<a href="<%= source_link %>" target="_blank">View source</a>]
+        <% if doc = method.formatted_doc %>
+          <div class="doc">
+            <% if doc_copied_from = method.doc_copied_from %>
+              <div class="doc-inherited">
+                Description copied from <%= doc_copied_from.kind %> <%= doc_copied_from.link_from(method.type) %>
+              </div>
+            <% end %>
+            <%= doc %>
+          </div>
         <% end %>
+        <br/>
+        <div>
+          <% if source_link = method.source_link %>
+            [<a href="<%= source_link %>" target="_blank">View source</a>]
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
+  <% end %>
+  <% unless platform_dependent_methods.empty? %>
+    <h3>
+      Platform dependent
+    </h3>
+    <p>
+      <span  class="warning">
+      Warning: Following methods are available only on listed platforms. If you used them, the resulting program cannot be compiled on other supported platforms.
+      </span>
+    </p>
+    <% platform_dependent_methods.each do |method| %>
+      <div class="entry-detail" id="<%= method.html_id %>">
+        <div class="signature">
+          <%= method.abstract? ? "abstract " : "" %>
+          <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
+          <a class="method-permalink" href="<%= method.anchor %>">#</a>
+          <span class="platform">Available on platforms: <%= method.platforms %></span>
+        </div>
+        <% if doc = method.formatted_doc %>
+          <div class="doc">
+            <% if doc_copied_from = method.doc_copied_from %>
+              <div class="doc-inherited">
+                Description copied from <%= doc_copied_from.kind %> <%= doc_copied_from.link_from(method.type) %>
+              </div>
+            <% end %>
+            <%= doc %>
+          </div>
+        <% end %>
+        <br/>
+        <div>
+          <% if source_link = method.source_link %>
+            [<a href="<%= source_link %>" target="_blank">View source</a>]
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/src/compiler/crystal/tools/doc/html/_method_summary.html
+++ b/src/compiler/crystal/tools/doc/html/_method_summary.html
@@ -1,16 +1,41 @@
 <% unless methods.empty? %>
-  <h2>
-    <%= Crystal::Doc.anchor_link(title) %>
-    <%= title %>
-  </h2>
-  <ul class="list-summary">
-    <% methods.each do |method| %>
-      <li class="entry-summary">
-        <a href="<%= method.anchor %>" class="signature"><strong><%= method.prefix %><%= method.name %></strong><%= method.args_to_s %></a>
-        <% if summary = method.formatted_summary %>
-          <div class="summary"><%= summary %></div>
+  <% unless cross_platform_methods.empty? %>
+    <h2>
+      <%= Crystal::Doc.anchor_link(title) %>
+      <%= title %>
+    </h2>
+    <ul class="list-summary">
+      <% cross_platform_methods.each do |method| %>
+        <li class="entry-summary">
+          <a href="<%= method.anchor %>" class="signature"><strong><%= method.prefix %><%= method.name %></strong><%= method.args_to_s %></a>
+          <% if summary = method.formatted_summary %>
+            <div class="summary"><%= summary %></div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>  
+  <% end %>
+  <% unless platform_dependent_methods.empty? %>
+    <h3 class="collapsible-header">
+      Platform dependent
+    </h3>
+    <div class=" collapsible-content">
+      <p>
+        <span  class="warning">
+        Warning: Following methods are available only on listed platforms. If you used them, the resulting program cannot be compiled on other supported platforms.
+        </span>
+      </p>
+      <ul class="list-summary">
+        <% platform_dependent_methods.each do |method| %>
+          <li class="entry-summary">
+            <a href="<%= method.anchor %>" class="signature"><strong><%= method.prefix %><%= method.name %></strong><%= method.args_to_s %></a>
+            <span class="platform"><%= method.platforms %></span>
+            <% if summary = method.formatted_summary %>
+              <div class="summary"><%= summary %></div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-    <% end %>
-  </ul>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -261,6 +261,14 @@ body {
   transition: background .15s, border-color .15s;
 }
 
+.entry-summary .platform {
+  padding: 4px 8px;
+  display: inline-block;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
+  margin-bottom: 4px;
+  font-style: italic;
+}
+
 .superclass-hierarchy .superclass a:hover,
 .other-type a:hover,
 .entry-summary .signature:hover {
@@ -295,6 +303,12 @@ body {
   border: 1px solid #f0f0f0;
   font-family: Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;
   transition: .2s ease-in-out;
+}
+
+.entry-detail .platform {
+  display: block;
+  font-style: italic;
+  font-size: 0.9em;
 }
 
 .entry-detail:target .signature {
@@ -672,3 +686,33 @@ span.flag.purple {
 .main-content h6:hover .anchor .octicon-link {
   visibility: visible
 }
+
+span.warning {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
+  border-radius: .25rem;
+}
+
+.collapsible-header {
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
+/* Style the collapsible content. Note: hidden by default */
+.collapsible-content {
+  display: none;
+}
+
+.collapsible-header:before {
+  transform: rotateZ(-90deg);
+  content: "▼";
+  display: inline-block;
+}
+
+.collapsible-header.active:before {
+  transform: rotateZ(0);
+}
+
+

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -195,4 +195,18 @@ document.addEventListener('DOMContentLoaded', function() {
   };
   window.addEventListener("hashchange", scrollToEntryFromLocationHash, false);
   scrollToEntryFromLocationHash();
+
+  var coll = document.getElementsByClassName("collapsible-header");
+  var i;
+  for (i = 0; i < coll.length; i++) {
+    coll[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.display === "block") {
+        content.style.display = "none";
+      } else {
+        content.style.display = "block";
+      }
+    });
+  }
 });

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -148,4 +148,11 @@ class Crystal::Doc::Macro
     # macros does not support annotations
     nil
   end
+
+  def platform_dependent?
+    false
+  end
+
+  def platforms
+  end
 end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -323,4 +323,18 @@ class Crystal::Doc::Method
   def annotations(annotation_type)
     @def.annotations(annotation_type)
   end
+
+  def platform_dependent?
+    !!annotations(@generator.program.platform_annotation)
+  end
+
+  def platforms
+    if anns = annotations(@generator.program.platform_annotation)
+      platforms = [] of String
+      anns.each do |ann|
+        platforms = platforms + PlatformAnnotation.from(ann).platforms
+      end
+      platforms.join(", ")
+    end
+  end
 end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -21,6 +21,17 @@ module Crystal::Doc
     ANCHOR
   end
 
+  abstract struct MethodsTemplate
+    getter methods : Array(Method) | Array(Macro)
+    getter cross_platform_methods : Array(Method) | Array(Macro)
+    getter platform_dependent_methods : Array(Method) | Array(Macro)
+    getter title : String
+
+    def initialize(@title : String, @methods : Array(Method) | Array(Macro))
+      @platform_dependent_methods, @cross_platform_methods = @methods.partition &.platform_dependent?
+    end
+  end
+
   record TypeTemplate, type : Type, types : Array(Type) do
     ECR.def_to_s "#{__DIR__}/html/type.html"
   end
@@ -29,11 +40,11 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/_list_items.html"
   end
 
-  record MethodSummaryTemplate, title : String, methods : Array(Method) | Array(Macro) do
+  struct MethodSummaryTemplate < MethodsTemplate
     ECR.def_to_s "#{__DIR__}/html/_method_summary.html"
   end
 
-  record MethodDetailTemplate, title : String, methods : Array(Method) | Array(Macro) do
+  struct MethodDetailTemplate < MethodsTemplate
     ECR.def_to_s "#{__DIR__}/html/_method_detail.html"
   end
 


### PR DESCRIPTION
This PR introduce *Platform* annotation, which should be used to mark platform dependent API's in Std lib or any other libraries. Example usage is:
```
{% if flag?(:unix) || flag?(:docs) %}
@[Platform("Unix")]
def self.fork : Process
end
{% end %}
```
(see that or :docs flag, docs should be generated always same in my opinion, it's confusing to generate different api docs on different platforms)

which would newly emit compiler warning:
![sample-compiler-warning](https://user-images.githubusercontent.com/14123071/69719572-0db05e80-1111-11ea-8c7e-51e788fd7820.png)
and create separate section in docs after cross-platform methods (methods summary):
![sample-docs-summary](https://user-images.githubusercontent.com/14123071/69719797-8ca59700-1111-11ea-9f68-2ddeb91b8d43.png)
and methods details:
![sample-docs-detail](https://user-images.githubusercontent.com/14123071/69719803-916a4b00-1111-11ea-9d9e-6c63dc6e7733.png)

it's only example, i don't made decision if we keep fork method and i don't mark any methods with this new annotation yet, that would be the subject for another PRs.

Resulting docs contains methods for all supported platforms but properly labeled and every consumer of this platform depended api is properly informed by compiler warning. This works for any other library so consumer can be informed in docs which methods are unsafe for use for cross-platform development and informed by compiler warning if do so.