### PR TITLE
Do not collapse whitespaces in playground sidebar.

### DIFF
--- a/src/compiler/crystal/tools/playground/public/application.css
+++ b/src/compiler/crystal/tools/playground/public/application.css
@@ -132,7 +132,7 @@ h4 {
 
 .sidebar div {
   position: absolute;
-  white-space: nowrap;
+  white-space: pre;
   left: 0;
   right: 0;
 }


### PR DESCRIPTION
`"   3"` should be show as `"   3"`, not `" 3"`.
