### PR TITLE
Some compiler optimizations

### DIFF
--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -323,7 +323,11 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
                Parser::ParseMode::Normal
              end
 
-    generated_nodes = @program.parse_macro_source(expanded_macro, macro_expansion_pragmas, the_macro, node, Set.new(@vars.keys),
+    # We could do Set.new(@vars.keys) but that creates an intermediate array
+    local_vars = Set(String).new(initial_capacity: @vars.size)
+    @vars.each_key { |key| local_vars << key }
+
+    generated_nodes = @program.parse_macro_source(expanded_macro, macro_expansion_pragmas, the_macro, node, local_vars,
       current_def: @typed_def,
       inside_type: !current_type.is_a?(Program),
       inside_exp: @exp_nest > 0,

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -938,7 +938,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def visit(node : Block)
-    old_vars_keys = @vars.keys
+    # Remember how many local vars we had before the block
+    old_vars_size = @vars.size
 
     # When accepting a block, declare variables for block arguments.
     # These are needed for macro expansions to parser identifiers
@@ -949,9 +950,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     node.body.accept self
 
-    # Now remove these vars, but only if they weren't vars before
-    node.args.each do |arg|
-      @vars.delete(arg.name) unless old_vars_keys.includes?(arg.name)
+    # After the block we should have the same number of local vars
+    # (blocks can't declare inject local vars to the outer scope)
+    while @vars.size > old_vars_size
+      @vars.delete(@vars.last_key)
     end
 
     false

--- a/src/set.cr
+++ b/src/set.cr
@@ -37,6 +37,9 @@ struct Set(T)
     @hash = Hash(T, Nil).new(initial_capacity: initial_capacity)
   end
 
+  protected def initialize(*, using_hash @hash : Hash(T, Nil))
+  end
+
   # Optimized version of `new` used when *other* is also an `Indexable`
   def self.new(other : Indexable(T))
     Set(T).new(other.size).concat(other)
@@ -347,7 +350,7 @@ struct Set(T)
 
   # Returns a new `Set` with all of the same elements.
   def dup
-    set = Set.new(self)
+    set = Set(T).new(using_hash: @hash.dup)
     set.compare_by_identity if compare_by_identity?
     set
   end


### PR DESCRIPTION
Some optimizations from musings in https://github.com/crystal-lang/crystal/issues/8527#issuecomment-559300111

The first two commits are self-explanatory. The third commits has a big commit message explaining the description of the problem. After reading that you can understand how it applies to this particular example:

```crystal
require "spec"

macro assert(call, file = __FILE__, line = __LINE__)
  {% obj = call.receiver %}
  {% name = call.name %}
  %obj = {{obj}}
  %call = %obj.{{name}}
  unless %call
    fail "Expected #{%obj} to be {{name[0...-1]}}"
  end
end

describe "Foo" do
  {% for i in 0..12_000 %}
    it "bar {{i}}" do
      a = [1, 2, 3]
      assert a.empty?
    end
  {% end %}
end
```

In the above code the `assert` macro will define the local variables `%obj` and `%call` which will actually expand to variables named something like `__temp1` and so on, and they'll all be different. Because of the above compiler bug, all these local variables will be seen in each `assert` macro invocation. So the first `assert` expansion can only see the `a` local variable. The second one will see that plus the two local variables introduced by the previous macro invocation (which shouldn't be seen, but that's the bug the third commit is fixing). On each invocation a `Set` is created with these local vars. That has something like quadratic complexity which explains why the above code was taking 12 seconds. Now it takes 0.4s (well, at least the "main" semantic phase).

I always thought macro expansion was slow, but apparently it's not. Or at least not that slow.

Once we merge this PR we can see if #3095 is still slow for the [snippet](https://github.com/crystal-lang/crystal/issues/3095#issuecomment-237614293) I found it to be slow.

