### PR TITLE
Deprecate char#ord and int#chr

### DIFF
--- a/samples/brainfuck.cr
+++ b/samples/brainfuck.cr
@@ -42,7 +42,7 @@ class Program
       when '<'; tape.devance
       when '+'; tape.inc
       when '-'; tape.dec
-      when '.'; print tape.get.chr
+      when '.'; print tape.get.char
       when '['; pc = @bracket_map[pc] if tape.get == 0
       when ']'; pc = @bracket_map[pc] if tape.get != 0
       end

--- a/samples/compiler/transformer_example.cr
+++ b/samples/compiler/transformer_example.cr
@@ -2,14 +2,14 @@
 # to transform source code.
 #
 # Here we transform all number literals with their char
-# equivalent using `chr`.
+# equivalent using `char`.
 
 # Use `require "compiler/crystal/syntax"` in your programs
 require "../../src/compiler/crystal/syntax"
 
 class Charify < Crystal::Transformer
   def transform(node : Crystal::NumberLiteral)
-    Crystal::CharLiteral.new(node.value.to_i.chr)
+    Crystal::CharLiteral.new(node.value.to_i.char)
   end
 end
 

--- a/samples/meteor.cr
+++ b/samples/meteor.cr
@@ -119,7 +119,7 @@ def to_utf8(raw_sol)
     raw_sol.each do |m|
       id = get_id(m)
       50.times do |i|
-        buf[i] = '0'.ord.to_u8 + id if bm(m, i) != 0
+        buf[i] = '0'.codepoint.to_u8 + id if bm(m, i) != 0
       end
     end
     {50, 50}

--- a/samples/meteor.cr
+++ b/samples/meteor.cr
@@ -132,7 +132,7 @@ def print_sol(str)
     puts if i % 5 == 0
     print ' ' if (i + 5) % 10 == 0
     print ' '
-    print c.chr
+    print c.char
     i += 1
   end
   puts

--- a/samples/sudoku.cr
+++ b/samples/sudoku.cr
@@ -70,7 +70,7 @@ def sd_solve(mr, mc, s)
   ret = [] of Array(Int32)
   sr, sc, hints = Array.new(729, 0), Array.new(324, 9), 0
   (0...81).each do |i|
-    a = ('1' <= s[i] <= '9') ? s[i].ord - 49 : -1
+    a = ('1' <= s[i] <= '9') ? s[i].codepoint - 49 : -1
     if a >= 0
       sd_update(mr, mc, sr, sc, i * 9 + a, 1)
       hints += 1
@@ -113,7 +113,7 @@ def sd_solve(mr, mc, s)
     end
     break if i < 0
     o = [] of Int32
-    (0...81).each { |j| o.push((s[j].ord - 49).to_i32) }
+    (0...81).each { |j| o.push((s[j].codepoint - 49).to_i32) }
     (0...i).each do |j|
       r = mr[cc[j]][cr[j]]
       o[r // 9] = r % 9 + 1

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -993,7 +993,7 @@ describe "Code gen: block" do
 
       foo do
         a = 'A'
-        a.ord
+        a.codepoint
       end
       ").to_i.should eq(65)
   end

--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -72,7 +72,7 @@ describe "Code gen: case" do
       when Int32
         a.foo
       when Char
-        a.ord
+        a.codepoint
       end.to_i!
       ").to_i.should eq(-1)
   end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -46,7 +46,7 @@ describe "Codegen: is_a?" do
   end
 
   it "evaluate method on filtered type" do
-    run("a = 1; a = 'a'; if a.is_a?(Char); a.codepoint; else; 0; end").to_i.chr.should eq('a')
+    run("a = 1; a = 'a'; if a.is_a?(Char); a.codepoint; else; 0; end").to_i.char.should eq('a')
   end
 
   it "evaluate method on filtered type nilable type not-nil" do

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -46,7 +46,7 @@ describe "Codegen: is_a?" do
   end
 
   it "evaluate method on filtered type" do
-    run("a = 1; a = 'a'; if a.is_a?(Char); a.ord; else; 0; end").to_i.chr.should eq('a')
+    run("a = 1; a = 'a'; if a.is_a?(Char); a.codepoint; else; 0; end").to_i.chr.should eq('a')
   end
 
   it "evaluate method on filtered type nilable type not-nil" do

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -38,7 +38,7 @@ describe "Code gen: primitives" do
     run("'a'").to_i.should eq('a'.codepoint)
   end
 
-  it "codegens char ord" do
+  it "codegens char codepoint" do
     run("'a'.codepoint").to_i.should eq('a'.codepoint)
   end
 

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -35,11 +35,11 @@ describe "Code gen: primitives" do
   end
 
   it "codegens char" do
-    run("'a'").to_i.should eq('a'.ord)
+    run("'a'").to_i.should eq('a'.codepoint)
   end
 
   it "codegens char ord" do
-    run("'a'.ord").to_i.should eq('a'.ord)
+    run("'a'.codepoint").to_i.should eq('a'.codepoint)
   end
 
   it "codegens f32" do

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -85,7 +85,7 @@ describe "Code gen: union type" do
 
       struct Char
         def to_i
-          ord
+          codepoint
         end
       end
 

--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -30,13 +30,13 @@ module LexerObjects
     def next_unicode_tokens_should_be(expected_unicode_codes : Array)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:STRING)
-      token.value.as(String).chars.map(&.ord).should eq(expected_unicode_codes)
+      token.value.as(String).chars.map(&.codepoint).should eq(expected_unicode_codes)
     end
 
     def next_unicode_tokens_should_be(expected_unicode_codes)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:STRING)
-      token.value.as(String).char_at(0).ord.should eq(expected_unicode_codes)
+      token.value.as(String).char_at(0).codepoint.should eq(expected_unicode_codes)
     end
 
     def next_string_token_should_be(expected_string)

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -391,14 +391,14 @@ describe "Lexer" do
     lexer = Lexer.new "'á'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(225)
+    token.value.as(Char).codepoint.should eq(225)
   end
 
   it "lexes utf-8 multibyte char" do
     lexer = Lexer.new "'日'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(26085)
+    token.value.as(Char).codepoint.should eq(26085)
   end
 
   it "doesn't raise if slash r with slash n" do
@@ -423,28 +423,28 @@ describe "Lexer" do
     lexer = Lexer.new "'\\uFEDA'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(0xFEDA)
+    token.value.as(Char).codepoint.should eq(0xFEDA)
   end
 
   it "lexes char with unicode codepoint and curly with zeros" do
     lexer = Lexer.new "'\\u{0}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(0)
+    token.value.as(Char).codepoint.should eq(0)
   end
 
   it "lexes char with unicode codepoint and curly" do
     lexer = Lexer.new "'\\u{A5}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(0xA5)
+    token.value.as(Char).codepoint.should eq(0xA5)
   end
 
   it "lexes char with unicode codepoint and curly with six hex digits" do
     lexer = Lexer.new "'\\u{10FFFF}'"
     token = lexer.next_token
     token.type.should eq(:CHAR)
-    token.value.as(Char).ord.should eq(0x10FFFF)
+    token.value.as(Char).codepoint.should eq(0x10FFFF)
   end
 
   it "lexes float then zero (bug)" do

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -467,7 +467,7 @@ describe "Semantic: def overload" do
       end
 
       def foo(x : Char)
-        x.ord
+        x.codepoint
         'a'
       end
 
@@ -953,7 +953,7 @@ describe "Semantic: def overload" do
 			end
 
 			def do_something(value : Char)
-			  value.ord
+			  value.codepoint
 			  false
 			end
 

--- a/spec/compiler/semantic/is_a_spec.cr
+++ b/spec/compiler/semantic/is_a_spec.cr
@@ -63,7 +63,7 @@ describe "Semantic: is_a?" do
       if a.is_a?(Int32)
         a.to_i32
       else
-        a.ord
+        a.codepoint
       end
       ") { int32 }
   end

--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -34,7 +34,7 @@ describe "Semantic: primitives" do
   end
 
   it "types char ord" do
-    assert_type("'a'.ord") { int32 }
+    assert_type("'a'.codepoint") { int32 }
   end
 
   it "types a symbol" do

--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -33,7 +33,7 @@ describe "Semantic: primitives" do
     assert_type("'a'") { char }
   end
 
-  it "types char ord" do
+  it "types char codepoint" do
     assert_type("'a'.codepoint") { int32 }
   end
 

--- a/spec/compiler/semantic/responds_to_spec.cr
+++ b/spec/compiler/semantic/responds_to_spec.cr
@@ -25,7 +25,7 @@ describe "Semantic: responds_to?" do
       if a.responds_to?(:\"+\")
         a.to_i32
       else
-        a.ord
+        a.codepoint
       end
       ") { int32 }
   end

--- a/spec/compiler/semantic/ssa_spec.cr
+++ b/spec/compiler/semantic/ssa_spec.cr
@@ -653,7 +653,7 @@ describe "Semantic: ssa" do
         if 1 == 2
           foo { }
         end
-        a.ord
+        a.codepoint
       else
         1
       end

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -117,7 +117,7 @@ describe "Semantic: while" do
   it "doesn't modify var's type before while" do
     assert_type(%(
       x = 'x'
-      x.ord
+      x.codepoint
       while 1 == 2
         x = 1
       end

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -87,7 +87,7 @@ describe "Base64" do
 
     it "works for most characters" do
       a = String.build(65536 * 4) do |buf|
-        65536.times { |i| buf << (i + 1).chr }
+        65536.times { |i| buf << (i + 1).char }
       end
       b = Base64.encode(a)
       Digest::MD5.hexdigest(Base64.decode_string(b)).should eq(Digest::MD5.hexdigest(a))
@@ -155,13 +155,13 @@ describe "Base64" do
         "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")
     end
     it "with spec symbols" do
-      s = String.build { |b| (160..179).each { |i| b << i.chr } }
+      s = String.build { |b| (160..179).each { |i| b << i.char } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
       Base64.strict_encode(s).should eq(se)
     end
 
     it "encode to stream" do
-      s = String.build { |b| (160..179).each { |i| b << i.chr } }
+      s = String.build { |b| (160..179).each { |i| b << i.char } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
       io = IO::Memory.new
       Base64.strict_encode(s, io).should eq(56)
@@ -172,13 +172,13 @@ describe "Base64" do
 
   describe "urlsafe" do
     it "work" do
-      s = String.build { |b| (160..179).each { |i| b << i.chr } }
+      s = String.build { |b| (160..179).each { |i| b << i.char } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw=="
       Base64.urlsafe_encode(s).should eq(se)
     end
 
     it "encode to stream" do
-      s = String.build { |b| (160..179).each { |i| b << i.chr } }
+      s = String.build { |b| (160..179).each { |i| b << i.char } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw=="
       io = IO::Memory.new
       Base64.urlsafe_encode(s, io).should eq(56)

--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -12,7 +12,7 @@ describe "Char::Reader" do
   it "iterates through empty string" do
     reader = Char::Reader.new("")
     reader.pos.should eq(0)
-    reader.current_char.ord.should eq(0)
+    reader.current_char.codepoint.should eq(0)
     reader.error.should be_nil
     reader.has_next?.should be_false
 
@@ -26,7 +26,7 @@ describe "Char::Reader" do
     reader.pos.should eq(0)
     reader.current_char.should eq('a')
     reader.has_next?.should be_true
-    reader.next_char.ord.should eq(0)
+    reader.next_char.codepoint.should eq(0)
     reader.has_next?.should be_false
 
     expect_raises IndexError do
@@ -37,20 +37,20 @@ describe "Char::Reader" do
   it "iterates through chars" do
     reader = Char::Reader.new("há日本語")
     reader.pos.should eq(0)
-    reader.current_char.ord.should eq(104)
+    reader.current_char.codepoint.should eq(104)
     reader.has_next?.should be_true
 
-    reader.next_char.ord.should eq(225)
+    reader.next_char.codepoint.should eq(225)
 
     reader.pos.should eq(1)
-    reader.current_char.ord.should eq(225)
+    reader.current_char.codepoint.should eq(225)
 
-    reader.next_char.ord.should eq(26085)
-    reader.next_char.ord.should eq(26412)
-    reader.next_char.ord.should eq(35486)
+    reader.next_char.codepoint.should eq(26085)
+    reader.next_char.codepoint.should eq(26412)
+    reader.next_char.codepoint.should eq(35486)
     reader.has_next?.should be_true
 
-    reader.next_char.ord.should eq(0)
+    reader.next_char.codepoint.should eq(0)
     reader.has_next?.should be_false
 
     expect_raises IndexError do
@@ -60,21 +60,21 @@ describe "Char::Reader" do
 
   it "peeks next char" do
     reader = Char::Reader.new("há日本語")
-    reader.peek_next_char.ord.should eq(225)
+    reader.peek_next_char.codepoint.should eq(225)
   end
 
   it "sets pos" do
     reader = Char::Reader.new("há日本語")
     reader.pos = 1
     reader.pos.should eq(1)
-    reader.current_char.ord.should eq(225)
+    reader.current_char.codepoint.should eq(225)
   end
 
   it "is an Enumerable(Char)" do
     reader = Char::Reader.new("abc")
     sum = 0
     reader.each do |char|
-      sum += char.ord
+      sum += char.codepoint
     end.should be_nil
     sum.should eq(294)
   end
@@ -89,7 +89,7 @@ describe "Char::Reader" do
   it "starts at end" do
     reader = Char::Reader.new(at_end: "")
     reader.pos.should eq(0)
-    reader.current_char.ord.should eq(0)
+    reader.current_char.codepoint.should eq(0)
     reader.has_previous?.should be_false
   end
 

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -133,22 +133,22 @@ describe "Char" do
   end
 
   it "escapes" do
-    '\a'.ord.should eq(7)
-    '\b'.ord.should eq(8)
-    '\t'.ord.should eq(9)
-    '\n'.ord.should eq(10)
-    '\v'.ord.should eq(11)
-    '\f'.ord.should eq(12)
-    '\r'.ord.should eq(13)
-    '\e'.ord.should eq(27)
-    '\''.ord.should eq(39)
-    '\\'.ord.should eq(92)
+    '\a'.codepoint.should eq(7)
+    '\b'.codepoint.should eq(8)
+    '\t'.codepoint.should eq(9)
+    '\n'.codepoint.should eq(10)
+    '\v'.codepoint.should eq(11)
+    '\f'.codepoint.should eq(12)
+    '\r'.codepoint.should eq(13)
+    '\e'.codepoint.should eq(27)
+    '\''.codepoint.should eq(39)
+    '\\'.codepoint.should eq(92)
   end
 
   it "escapes with unicode" do
-    '\u{12}'.ord.should eq(1 * 16 + 2)
-    '\u{A}'.ord.should eq(10)
-    '\u{AB}'.ord.should eq(10 * 16 + 11)
+    '\u{12}'.codepoint.should eq(1 * 16 + 2)
+    '\u{A}'.codepoint.should eq(10)
+    '\u{AB}'.codepoint.should eq(10 * 16 + 11)
   end
 
   it "does to_i without a base" do
@@ -236,7 +236,7 @@ describe "Char" do
   end
 
   it "does ord for multibyte char" do
-    '日'.ord.should eq(26085)
+    '日'.codepoint.should eq(26085)
   end
 
   it "does to_s for single-byte char" do
@@ -339,7 +339,7 @@ describe "Char" do
   end
 
   it "does each_byte" do
-    'a'.each_byte(&.should eq('a'.ord)).should be_nil
+    'a'.each_byte(&.should eq('a'.codepoint)).should be_nil
   end
 
   it "does bytes" do
@@ -347,12 +347,12 @@ describe "Char" do
   end
 
   it "#===(:Int)" do
-    ('c'.ord).should eq(99)
+    ('c'.codepoint).should eq(99)
     ('c' === 99_u8).should be_true
     ('c' === 99).should be_true
     ('z' === 99).should be_false
 
-    ('酒'.ord).should eq(37202)
+    ('酒'.codepoint).should eq(37202)
     ('酒' === 37202).should be_true
   end
 

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -235,7 +235,7 @@ describe "Char" do
     'a'.to_f64?.should be_nil
   end
 
-  it "does ord for multibyte char" do
+  it "does codepoint for multibyte char" do
     '日'.codepoint.should eq(26085)
   end
 

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -283,7 +283,7 @@ describe "Char" do
 
     it "raises on codepoint bigger than 0x10ffff" do
       expect_raises InvalidByteSequenceError do
-        (0x10ffff + 1).unsafe_chr.bytesize
+        (0x10ffff + 1).unsafe_char.bytesize
       end
     end
   end
@@ -334,7 +334,7 @@ describe "Char" do
 
   it "raises on codepoint bigger than 0x10ffff when doing each_byte" do
     expect_raises InvalidByteSequenceError do
-      (0x10ffff + 1).unsafe_chr.each_byte { |b| }
+      (0x10ffff + 1).unsafe_char.each_byte { |b| }
     end
   end
 
@@ -358,12 +358,12 @@ describe "Char" do
 
   it "does ascii_number?" do
     256.times do |i|
-      chr = i.chr
-      ("01".chars.includes?(chr) == chr.ascii_number?(2)).should be_true
-      ("01234567".chars.includes?(chr) == chr.ascii_number?(8)).should be_true
-      ("0123456789".chars.includes?(chr) == chr.ascii_number?).should be_true
-      ("0123456789".chars.includes?(chr) == chr.ascii_number?(10)).should be_true
-      ("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".includes?(chr) == chr.ascii_number?(36)).should be_true
+      char = i.char
+      ("01".chars.includes?(char) == char.ascii_number?(2)).should be_true
+      ("01234567".chars.includes?(char) == char.ascii_number?(8)).should be_true
+      ("0123456789".chars.includes?(char) == char.ascii_number?).should be_true
+      ("0123456789".chars.includes?(char) == char.ascii_number?(10)).should be_true
+      ("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".includes?(char) == char.ascii_number?(36)).should be_true
       unless 2 <= i <= 36
         expect_raises ArgumentError do
           '0'.ascii_number?(i)

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -386,13 +386,13 @@ describe "Char" do
   end
 
   it "does mark?" do
-    0x300.chr.mark?.should be_true
+    0x300.char.mark?.should be_true
   end
 
   it "does ascii?" do
     'a'.ascii?.should be_true
-    127.chr.ascii?.should be_true
-    128.chr.ascii?.should be_false
+    127.char.ascii?.should be_true
+    128.char.ascii?.should be_false
     '酒'.ascii?.should be_false
   end
 

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -18,8 +18,8 @@ describe Digest::SHA1 do
 
     it "does digest for #{string.inspect} in a block" do
       bytes = Digest::SHA1.digest do |ctx|
-        string.each_char do |chr|
-          ctx.update chr.to_s
+        string.each_char do |char|
+          ctx.update char.to_s
         end
       end
 

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -822,8 +822,8 @@ describe "File" do
       i = 0
       file.each_byte do |byte|
         case i
-        when 0 then byte.should eq('H'.ord)
-        when 1 then byte.should eq('e'.ord)
+        when 0 then byte.should eq('H'.codepoint)
+        when 1 then byte.should eq('e'.codepoint)
         else
           break
         end
@@ -1131,7 +1131,7 @@ describe "File" do
       expect_raises(IO::Error, "Closed stream") { io.seek(1) }
       expect_raises(IO::Error, "Closed stream") { io.gets }
       expect_raises(IO::Error, "Closed stream") { io.read_byte }
-      expect_raises(IO::Error, "Closed stream") { io.write_byte('a'.ord.to_u8) }
+      expect_raises(IO::Error, "Closed stream") { io.write_byte('a'.codepoint.to_u8) }
     end
   end
 

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -191,7 +191,7 @@ describe HTTP::Headers do
 
   it "can create header value with all US-ASCII visible chars (#2999)" do
     headers = HTTP::Headers.new
-    value = (32..126).map(&.chr).join
+    value = (32..126).map(&.char).join
     headers.add("foo", value)
   end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -84,7 +84,7 @@ module HTTP
     end
 
     it "serialize POST (with bytes body)" do
-      request = Request.new "POST", "/", body: Bytes['a'.ord, 'b'.ord]
+      request = Request.new "POST", "/", body: Bytes['a'.codepoint, 'b'.codepoint]
       io = IO::Memory.new
       request.to_io(io)
       io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nab")

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -183,7 +183,7 @@ describe HTTP::WebSocket do
       8.times { |i| received_size <<= 8; received_size += bytes[2 + i] }
       received_size.should eq(size)
       size.times do |i|
-        bytes[10 + i].should eq('a'.ord)
+        bytes[10 + i].should eq('a'.codepoint)
       end
     end
 
@@ -216,7 +216,7 @@ describe HTTP::WebSocket do
       2.times { |i| received_size <<= 8; received_size += first_frame[2 + i] }
       received_size.should eq(1024)
       received_size.times do |i|
-        bytes[4 + i].should eq('a'.ord)
+        bytes[4 + i].should eq('a'.codepoint)
       end
 
       (second_frame[0] & 0x80).should_not eq(0) # FINAL bit set
@@ -226,7 +226,7 @@ describe HTTP::WebSocket do
       2.times { |i| received_size <<= 8; received_size += second_frame[2 + i] }
       received_size.should eq(512)
       received_size.times do |i|
-        bytes[4 + i].should eq('a'.ord)
+        bytes[4 + i].should eq('a'.codepoint)
       end
     end
 
@@ -250,11 +250,11 @@ describe HTTP::WebSocket do
       bytes.size.should eq(11)     # 2 bytes header, 4 bytes mask, 5 bytes content
       bytes[1].bit(7).should eq(1) # For mask bit
       (bytes[1] - 128).should eq(sent_string.size)
-      (bytes[2] ^ bytes[6]).should eq('h'.ord)
-      (bytes[3] ^ bytes[7]).should eq('e'.ord)
-      (bytes[4] ^ bytes[8]).should eq('l'.ord)
-      (bytes[5] ^ bytes[9]).should eq('l'.ord)
-      (bytes[2] ^ bytes[10]).should eq('o'.ord)
+      (bytes[2] ^ bytes[6]).should eq('h'.codepoint)
+      (bytes[3] ^ bytes[7]).should eq('e'.codepoint)
+      (bytes[4] ^ bytes[8]).should eq('l'.codepoint)
+      (bytes[5] ^ bytes[9]).should eq('l'.codepoint)
+      (bytes[2] ^ bytes[10]).should eq('o'.codepoint)
     end
 
     it "sends long data with correct header" do
@@ -271,7 +271,7 @@ describe HTTP::WebSocket do
       8.times { |i| received_size <<= 8; received_size += bytes[2 + i] }
       received_size.should eq(size)
       size.times do |i|
-        (bytes[14 + i] ^ bytes[10 + (i % 4)]).should eq('a'.ord)
+        (bytes[14 + i] ^ bytes[10 + (i % 4)]).should eq('a'.codepoint)
       end
     end
   end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -775,6 +775,6 @@ describe "Int" do
 
   it "#unsafe_chr" do
     65.unsafe_chr.should eq('A')
-    (0x10ffff + 1).unsafe_chr.ord.should eq(0x10ffff + 1)
+    (0x10ffff + 1).unsafe_chr.codepoint.should eq(0x10ffff + 1)
   end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -765,16 +765,16 @@ describe "Int" do
     end
   end
 
-  it "#chr" do
-    65.chr.should eq('A')
+  it "#char" do
+    65.char.should eq('A')
 
     expect_raises(ArgumentError, "#{0x10ffff + 1} out of char range") do
-      (0x10ffff + 1).chr
+      (0x10ffff + 1).char
     end
   end
 
-  it "#unsafe_chr" do
-    65.unsafe_chr.should eq('A')
-    (0x10ffff + 1).unsafe_chr.codepoint.should eq(0x10ffff + 1)
+  it "#unsafe_char" do
+    65.unsafe_char.should eq('A')
+    (0x10ffff + 1).unsafe_char.codepoint.should eq(0x10ffff + 1)
   end
 end

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -162,7 +162,7 @@ describe "IO::Buffered" do
   it "writes bytes" do
     str = IO::Memory.new
     io = BufferedWrapper.new(str)
-    10_000.times { io.write_byte 'a'.ord.to_u8 }
+    10_000.times { io.write_byte 'a'.codepoint.to_u8 }
     io.flush
     str.to_s.should eq("a" * 10_000)
   end
@@ -196,11 +196,11 @@ describe "IO::Buffered" do
 
   it "reads byte" do
     io = BufferedWrapper.new(IO::Memory.new("hello"))
-    io.read_byte.should eq('h'.ord)
-    io.read_byte.should eq('e'.ord)
-    io.read_byte.should eq('l'.ord)
-    io.read_byte.should eq('l'.ord)
-    io.read_byte.should eq('o'.ord)
+    io.read_byte.should eq('h'.codepoint)
+    io.read_byte.should eq('e'.codepoint)
+    io.read_byte.should eq('l'.codepoint)
+    io.read_byte.should eq('l'.codepoint)
+    io.read_byte.should eq('o'.codepoint)
     io.read_char.should be_nil
   end
 
@@ -235,7 +235,7 @@ describe "IO::Buffered" do
 
     900.times do
       10.times do |i|
-        slice[i].should eq('a'.ord + i)
+        slice[i].should eq('a'.codepoint + i)
       end
     end
   end
@@ -312,7 +312,7 @@ describe "IO::Buffered" do
 
       byte = Bytes.new(1)
       io.read_fully(byte)
-      byte[0].should eq('a'.ord.to_u8)
+      byte[0].should eq('a'.codepoint.to_u8)
 
       str.gets_to_end.should eq("bc")
     end
@@ -328,7 +328,7 @@ describe "IO::Buffered" do
       io.buffer_size.times do
         byte = Bytes.new(1)
         io.read_fully(byte)
-        byte[0].should eq('a'.ord.to_u8)
+        byte[0].should eq('a'.codepoint.to_u8)
       end
 
       io.read_buffering = false
@@ -339,7 +339,7 @@ describe "IO::Buffered" do
 
       byte = Bytes.new(1)
       io.read_fully(byte)
-      byte[0].should eq('b'.ord.to_u8)
+      byte[0].should eq('b'.codepoint.to_u8)
 
       str.gets_to_end.should eq("cde")
     end
@@ -353,7 +353,7 @@ describe "IO::Buffered" do
       io.read_buffering = false
       io.read_buffering?.should be_false
 
-      io.read_byte.should eq('a'.ord.to_u8)
+      io.read_byte.should eq('a'.codepoint.to_u8)
 
       str.gets_to_end.should eq("bc")
     end
@@ -367,7 +367,7 @@ describe "IO::Buffered" do
       io.read_buffering?.should be_true
 
       io.buffer_size.times do
-        io.read_byte.should eq('a'.ord.to_u8)
+        io.read_byte.should eq('a'.codepoint.to_u8)
       end
 
       io.read_buffering = false
@@ -376,7 +376,7 @@ describe "IO::Buffered" do
       str << "bcde"
       str.pos -= 4
 
-      io.read_byte.should eq('b'.ord.to_u8)
+      io.read_byte.should eq('b'.codepoint.to_u8)
 
       str.gets_to_end.should eq("cde")
     end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -126,8 +126,8 @@ describe IO do
     it "iterates by byte" do
       io = SimpleIOMemory.new("ab")
       bytes = io.each_byte
-      bytes.next.should eq('a'.ord)
-      bytes.next.should eq('b'.ord)
+      bytes.next.should eq('a'.codepoint)
+      bytes.next.should eq('b'.codepoint)
       bytes.next.should be_a(Iterator::Stop)
     end
   end
@@ -303,11 +303,11 @@ describe IO do
 
     it "reads byte" do
       io = SimpleIOMemory.new("hello")
-      io.read_byte.should eq('h'.ord)
-      io.read_byte.should eq('e'.ord)
-      io.read_byte.should eq('l'.ord)
-      io.read_byte.should eq('l'.ord)
-      io.read_byte.should eq('o'.ord)
+      io.read_byte.should eq('h'.codepoint)
+      io.read_byte.should eq('e'.codepoint)
+      io.read_byte.should eq('l'.codepoint)
+      io.read_byte.should eq('l'.codepoint)
+      io.read_byte.should eq('o'.codepoint)
       io.read_char.should be_nil
     end
 
@@ -345,7 +345,7 @@ describe IO do
       io.each_byte do |b|
         bytes << b
       end
-      bytes.should eq ['a'.ord.to_u8, 'b'.ord.to_u8, 'c'.ord.to_u8]
+      bytes.should eq ['a'.codepoint.to_u8, 'b'.codepoint.to_u8, 'c'.codepoint.to_u8]
     end
 
     it "raises on EOF with read_line" do
@@ -429,7 +429,7 @@ describe IO do
 
     it "writes bytes" do
       io = SimpleIOMemory.new
-      10_000.times { io.write_byte 'a'.ord.to_u8 }
+      10_000.times { io.write_byte 'a'.codepoint.to_u8 }
       io.gets_to_end.should eq("a" * 10_000)
     end
 

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -20,9 +20,9 @@ describe IO::Memory do
 
   it "reads byte" do
     io = IO::Memory.new("abc")
-    io.read_byte.should eq('a'.ord)
-    io.read_byte.should eq('b'.ord)
-    io.read_byte.should eq('c'.ord)
+    io.read_byte.should eq('a'.codepoint)
+    io.read_byte.should eq('b'.codepoint)
+    io.read_byte.should eq('c'.codepoint)
     io.read_byte.should be_nil
   end
 
@@ -259,7 +259,7 @@ describe IO::Memory do
   end
 
   it "creates from slice" do
-    slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
+    slice = Slice.new(6) { |i| ('a'.codepoint + i).to_u8 }
     io = IO::Memory.new slice
     io.gets(2).should eq("ab")
     io.gets(3).should eq("cde")
@@ -273,7 +273,7 @@ describe IO::Memory do
   end
 
   it "creates from slice, non-writeable" do
-    slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
+    slice = Slice.new(6) { |i| ('a'.codepoint + i).to_u8 }
     io = IO::Memory.new slice, writeable: false
 
     expect_raises(IO::Error, "Read-only stream") do
@@ -291,7 +291,7 @@ describe IO::Memory do
   it "writes past end with write_byte" do
     io = IO::Memory.new
     io.pos = 1000
-    io.write_byte 'a'.ord.to_u8
+    io.write_byte 'a'.codepoint.to_u8
     io.to_slice.to_a.should eq([0] * 1000 + [97])
   end
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -98,9 +98,9 @@ describe "IO::Sized" do
   it "read_byte" do
     io = IO::Memory.new "abcdefg"
     sized = IO::Sized.new(io, read_size: 3)
-    sized.read_byte.should eq('a'.ord)
-    sized.read_byte.should eq('b'.ord)
-    sized.read_byte.should eq('c'.ord)
+    sized.read_byte.should eq('a'.codepoint)
+    sized.read_byte.should eq('b'.codepoint)
+    sized.read_byte.should eq('c'.codepoint)
     sized.read_byte.should be_nil
   end
 

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -342,8 +342,8 @@ describe "Slice" do
 
   it "does rindex" do
     slice = "foobar".to_slice
-    slice.rindex('o'.ord.to_u8).should eq(2)
-    slice.rindex('z'.ord.to_u8).should be_nil
+    slice.rindex('o'.codepoint.to_u8).should eq(2)
+    slice.rindex('z'.codepoint.to_u8).should be_nil
   end
 
   it "does bytesize" do

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -34,7 +34,7 @@ describe StringPool do
 
   it "gets slice" do
     pool = StringPool.new
-    slice = Bytes.new(3, 'a'.ord.to_u8)
+    slice = Bytes.new(3, 'a'.codepoint.to_u8)
 
     s1 = pool.get(slice)
     s2 = pool.get(slice)
@@ -47,7 +47,7 @@ describe StringPool do
 
   it "gets pointer with size" do
     pool = StringPool.new
-    slice = Bytes.new(3, 'a'.ord.to_u8)
+    slice = Bytes.new(3, 'a'.codepoint.to_u8)
 
     s1 = pool.get(slice.to_unsafe, slice.size)
     s2 = pool.get(slice.to_unsafe, slice.size)

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2489,12 +2489,12 @@ describe "String" do
 
     it "gets chars" do
       string = String.new(Bytes[255, 0, 0, 0, 65])
-      string.chars.should eq([Char::REPLACEMENT, 0.chr, 0.chr, 0.chr, 65.chr])
+      string.chars.should eq([Char::REPLACEMENT, 0.char, 0.char, 0.char, 65.char])
     end
 
     it "gets chars (2)" do
       string = String.new(Bytes[255, 0])
-      string.chars.should eq([Char::REPLACEMENT, 0.chr])
+      string.chars.should eq([Char::REPLACEMENT, 0.char])
     end
 
     it "valid_encoding?" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -908,9 +908,9 @@ describe "String" do
   end
 
   describe "byte_index" do
-    it { "foo".byte_index('o'.ord).should eq(1) }
-    it { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
-    it { "foo".byte_index('a'.ord).should be_nil }
+    it { "foo".byte_index('o'.codepoint).should eq(1) }
+    it { "foo bar booz".byte_index('o'.codepoint, 3).should eq(9) }
+    it { "foo".byte_index('a'.codepoint).should be_nil }
 
     it "gets byte index of string" do
       "hello world".byte_index("he").should eq(0)
@@ -1712,10 +1712,10 @@ describe "String" do
   end
 
   it "escapes with octal" do
-    "\3"[0].ord.should eq(3)
-    "\23"[0].ord.should eq((2 * 8) + 3)
-    "\123"[0].ord.should eq((1 * 8 * 8) + (2 * 8) + 3)
-    "\033"[0].ord.should eq((3 * 8) + 3)
+    "\3"[0].codepoint.should eq(3)
+    "\23"[0].codepoint.should eq((2 * 8) + 3)
+    "\123"[0].codepoint.should eq((1 * 8 * 8) + (2 * 8) + 3)
+    "\033"[0].codepoint.should eq((3 * 8) + 3)
     "\033a"[1].should eq('a')
   end
 
@@ -1723,7 +1723,7 @@ describe "String" do
     "\u{12}".codepoint_at(0).should eq(1 * 16 + 2)
     "\u{A}".codepoint_at(0).should eq(10)
     "\u{AB}".codepoint_at(0).should eq(10 * 16 + 11)
-    "\u{AB}1".codepoint_at(1).should eq('1'.ord)
+    "\u{AB}1".codepoint_at(1).should eq('1'.codepoint)
   end
 
   it "does char_at" do
@@ -1737,12 +1737,12 @@ describe "String" do
   end
 
   it "does byte_at" do
-    "hello".byte_at(1).should eq('e'.ord)
+    "hello".byte_at(1).should eq('e'.codepoint)
     expect_raises(IndexError) { "hello".byte_at(5) }
   end
 
   it "does byte_at?" do
-    "hello".byte_at?(1).should eq('e'.ord)
+    "hello".byte_at?(1).should eq('e'.codepoint)
     "hello".byte_at?(5).should be_nil
   end
 
@@ -1752,9 +1752,9 @@ describe "String" do
 
   it "allows creating a string with zeros" do
     p = Pointer(UInt8).malloc(3)
-    p[0] = 'a'.ord.to_u8
-    p[1] = '\0'.ord.to_u8
-    p[2] = 'b'.ord.to_u8
+    p[0] = 'a'.codepoint.to_u8
+    p[1] = '\0'.codepoint.to_u8
+    p[2] = 'b'.codepoint.to_u8
     s = String.new(p, 3)
     s[0].should eq('a')
     s[1].should eq('\0')
@@ -1844,7 +1844,7 @@ describe "String" do
     "あ".ascii_only?.should be_false
 
     str = String.new(1) do |buffer|
-      buffer.value = 'a'.ord.to_u8
+      buffer.value = 'a'.codepoint.to_u8
       {1, 0}
     end
     str.ascii_only?.should be_true
@@ -2092,11 +2092,11 @@ describe "String" do
     s.each_byte do |b|
       case i
       when 0
-        b.should eq('a'.ord)
+        b.should eq('a'.codepoint)
       when 1
-        b.should eq('b'.ord)
+        b.should eq('b'.codepoint)
       when 2
-        b.should eq('c'.ord)
+        b.should eq('c'.codepoint)
       end
       i += 1
     end.should be_nil
@@ -2105,9 +2105,9 @@ describe "String" do
 
   it "gets each_byte iterator" do
     iter = "abc".each_byte
-    iter.next.should eq('a'.ord)
-    iter.next.should eq('b'.ord)
-    iter.next.should eq('c'.ord)
+    iter.next.should eq('a'.codepoint)
+    iter.next.should eq('b'.codepoint)
+    iter.next.should eq('c'.codepoint)
     iter.next.should be_a(Iterator::Stop)
   end
 

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -460,7 +460,7 @@ describe "URI" do
     reserved_chars = Set{':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
 
     ('\u{00}'..'\u{7F}').each do |char|
-      URI.reserved?(char.ord.to_u8).should eq(reserved_chars.includes?(char))
+      URI.reserved?(char.codepoint.to_u8).should eq(reserved_chars.includes?(char))
     end
   end
 
@@ -468,7 +468,7 @@ describe "URI" do
     unreserved_chars = ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '.', '-', '~']
 
     ('\u{00}'..'\u{7F}').each do |char|
-      URI.unreserved?(char.ord.to_u8).should eq(unreserved_chars.includes?(char))
+      URI.unreserved?(char.codepoint.to_u8).should eq(unreserved_chars.includes?(char))
     end
   end
 

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -283,7 +283,7 @@ module Base64
   end
 
   private DECODE_TABLE = Array(Int8).new(256) do |i|
-    case i.unsafe_chr
+    case i.unsafe_char
     when 'A'..'Z' then (i - 0x41).to_i8
     when 'a'..'z' then (i - 0x47).to_i8
     when '0'..'9' then (i + 0x04).to_i8

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -23,9 +23,9 @@ module Base64
   private CHARS_STD  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
   private CHARS_SAFE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
   private LINE_SIZE  = 60
-  private PAD        = '='.ord.to_u8
-  private NL         = '\n'.ord.to_u8
-  private NR         = '\r'.ord.to_u8
+  private PAD        = '='.codepoint.to_u8
+  private NL         = '\n'.codepoint.to_u8
+  private NR         = '\r'.codepoint.to_u8
 
   # Returns the base64-encoded version of *data*.
   # This method complies with [RFC 2045](https://tools.ietf.org/html/rfc2045).

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -296,7 +296,7 @@ struct BigFloat < Float
         io << '.'
         decimal_set = true
       end
-      io << cstr[i].unsafe_chr
+      io << cstr[i].unsafe_char
     end
     (expptr - length).times { io << 0 } if expptr > 0
     if !decimal_set

--- a/src/char.cr
+++ b/src/char.cr
@@ -44,7 +44,7 @@ struct Char
   ZERO = '\0'
 
   # The maximum character.
-  MAX = 0x10ffff.unsafe_chr
+  MAX = 0x10ffff.unsafe_char
 
   # The maximum valid codepoint for a character.
   MAX_CODEPOINT = 0x10ffff
@@ -90,7 +90,7 @@ struct Char
   # 'a' + 2 # => 'c'
   # ```
   def +(other : Int) : Char
-    (codepoint + other).chr
+    (codepoint + other).char
   end
 
   # Returns a char that has this char's codepoint minus *other*.
@@ -100,7 +100,7 @@ struct Char
   # 'c' - 2 # => 'a'
   # ```
   def -(other : Int) : Char
-    (codepoint - other).chr
+    (codepoint - other).char
   end
 
   # The comparison operator.
@@ -425,7 +425,7 @@ struct Char
   #
   # This method allows creating a `Range` of chars.
   def succ
-    (codepoint + 1).chr
+    (codepoint + 1).char
   end
 
   # Returns a Char that is one codepoint smaller than this char's codepoint.
@@ -435,7 +435,7 @@ struct Char
   # 'ぃ'.pred # => 'あ'
   # ```
   def pred
-    (codepoint - 1).chr
+    (codepoint - 1).char
   end
 
   # Returns `true` if this char is an ASCII control character.

--- a/src/char.cr
+++ b/src/char.cr
@@ -60,7 +60,7 @@ struct Char
   # 'c' - 'a' # => 2
   # ```
   def -(other : Char)
-    ord - other.ord
+    codepoint - other.codepoint
   end
 
   # Concatenates this char and *string*.
@@ -90,7 +90,7 @@ struct Char
   # 'a' + 2 # => 'c'
   # ```
   def +(other : Int) : Char
-    (ord + other).chr
+    (codepoint + other).chr
   end
 
   # Returns a char that has this char's codepoint minus *other*.
@@ -100,7 +100,7 @@ struct Char
   # 'c' - 2 # => 'a'
   # ```
   def -(other : Int) : Char
-    (ord - other).chr
+    (codepoint - other).chr
   end
 
   # The comparison operator.
@@ -121,7 +121,7 @@ struct Char
   # Returns `true` if this char is an ASCII character
   # (codepoint is in (0..127))
   def ascii?
-    ord < 128
+    codepoint < 128
   end
 
   # Returns `true` if this char is an ASCII number in specified base.
@@ -247,7 +247,7 @@ struct Char
   # 'b'.ascii_whitespace?  # => false
   # ```
   def ascii_whitespace?
-    self == ' ' || 9 <= ord <= 13
+    self == ' ' || 9 <= codepoint <= 13
   end
 
   # Returns `true` if this char is a whitespace according to unicode.
@@ -425,7 +425,7 @@ struct Char
   #
   # This method allows creating a `Range` of chars.
   def succ
-    (ord + 1).chr
+    (codepoint + 1).chr
   end
 
   # Returns a Char that is one codepoint smaller than this char's codepoint.
@@ -435,7 +435,7 @@ struct Char
   # 'ぃ'.pred # => 'あ'
   # ```
   def pred
-    (ord - 1).chr
+    (codepoint - 1).chr
   end
 
   # Returns `true` if this char is an ASCII control character.
@@ -450,7 +450,7 @@ struct Char
   # end
   # ```
   def ascii_control?
-    ord < 0x20 || (0x7F <= ord <= 0x9F)
+    codepoint < 0x20 || (0x7F <= codepoint <= 0x9F)
   end
 
   # Returns `true` if this char is a control character according to unicode.
@@ -475,7 +475,7 @@ struct Char
     dump_or_inspect do |io|
       if ascii_control?
         io << "\\u{"
-        ord.to_s(16, io)
+        codepoint.to_s(16, io)
         io << '}'
       else
         to_s(io)
@@ -501,9 +501,9 @@ struct Char
   # ```
   def dump
     dump_or_inspect do |io|
-      if ascii_control? || ord >= 0x80
+      if ascii_control? || codepoint >= 0x80
         io << "\\u{"
-        ord.to_s(16, io)
+        codepoint.to_s(16, io)
         io << '}'
       else
         to_s(io)
@@ -576,9 +576,9 @@ struct Char
       return unless '0' <= self <= '9'
       self - '0'
     else
-      ord = ord()
-      if 0 <= ord < 256
-        digit = String::CHAR_TO_DIGIT.to_unsafe[ord]
+      codepoint = codepoint()
+      if 0 <= codepoint < 256
+        digit = String::CHAR_TO_DIGIT.to_unsafe[codepoint]
         return if digit == -1 || digit >= base
         digit.to_i32
       end
@@ -680,7 +680,7 @@ struct Char
   def each_byte : Nil
     # See http://en.wikipedia.org/wiki/UTF-8#Sample_code
 
-    c = ord
+    c = codepoint
     if c < 0x80
       # 0xxxxxxx
       yield c.to_u8
@@ -713,7 +713,7 @@ struct Char
   def bytesize
     # See http://en.wikipedia.org/wiki/UTF-8#Sample_code
 
-    c = ord
+    c = codepoint
     if c < 0x80
       # 0xxxxxxx
       1
@@ -764,7 +764,7 @@ struct Char
   # This appends this char's bytes as encoded by UTF-8 to the given `IO`.
   def to_s(io : IO) : Nil
     if ascii?
-      byte = ord.to_u8
+      byte = codepoint.to_u8
 
       # Optimization: writing a slice is much slower than writing a byte
       if io.has_non_utf8_encoding?
@@ -786,13 +786,13 @@ struct Char
   # Returns `true` if the codepoint is equal to *byte* ignoring the type.
   #
   # ```
-  # 'c'.ord       # => 99
+  # 'c'.codepoint # => 99
   # 'c' === 99_u8 # => true
   # 'c' === 99    # => true
   # 'z' === 99    # => false
   # ```
   def ===(byte : Int)
-    ord === byte
+    codepoint === byte
   end
 
   def clone

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -121,7 +121,7 @@ struct Char
       end
 
       decode_char_at(next_pos) do |code_point|
-        code_point.unsafe_chr
+        code_point.unsafe_char
       end
     end
 
@@ -252,7 +252,7 @@ struct Char
         @current_char_width = width
         @end = @pos == @string.bytesize
         @error = error
-        @current_char = code_point.unsafe_chr
+        @current_char = code_point.unsafe_char
       end
     end
 
@@ -268,7 +268,7 @@ struct Char
           @current_char_width = width
           @end = @pos == @string.bytesize
           @error = error
-          @current_char = code_point.unsafe_chr
+          @current_char = code_point.unsafe_char
         end
       end
     end

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -243,7 +243,7 @@ struct Char
     end
 
     private macro invalid_byte_sequence(width)
-      return yield Char::REPLACEMENT.ord, {{width}}, first.to_u8
+      return yield Char::REPLACEMENT.codepoint, {{width}}, first.to_u8
     end
 
     @[AlwaysInline]

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -429,7 +429,7 @@ module Crystal
     end
 
     def visit(node : CharLiteral)
-      @last = int32(node.value.ord)
+      @last = int32(node.value.codepoint)
     end
 
     def visit(node : NumberLiteral)
@@ -2177,7 +2177,7 @@ module Crystal
             str << char
           else
             str << '.'
-            char.ord.to_s(16, str, upcase: true)
+            char.codepoint.to_s(16, str, upcase: true)
             str << '.'
           end
         end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -157,7 +157,7 @@ class Crystal::CodeGenVisitor
     @last =
       case value = const.compile_time_value
       when Bool   then int1(value ? 1 : 0)
-      when Char   then int32(value.ord)
+      when Char   then int32(value.codepoint)
       when Int8   then int8(value)
       when Int16  then int16(value)
       when Int32  then int32(value)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -613,7 +613,7 @@ module Crystal
               # clash of 'a' and 'A' by using 'A-' for 'A'.
               str << char << '-'
             else
-              str << char.ord
+              str << char.codepoint
             end
           end
         end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -732,11 +732,11 @@ module Crystal
         interpret_one_arg_method(method, args) do |arg|
           case arg
           when CharLiteral
-            chr = arg.value
+            char = arg.value
           else
             raise "StringLiteral#count expects char, not #{arg.class_desc}"
           end
-          NumberLiteral.new(@value.count(chr))
+          NumberLiteral.new(@value.count(char))
         end
       when "starts_with?"
         interpret_one_arg_method(method, args) do |arg|

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1228,7 +1228,7 @@ module Crystal
           end
           @token.type = :CONST
           @token.value = string_range_from_pool(start)
-        elsif current_char.ascii_lowercase? || current_char == '_' || current_char.ord > 0x9F
+        elsif current_char.ascii_lowercase? || current_char == '_' || current_char.codepoint > 0x9F
           next_char
           scan_ident(start)
         else
@@ -2942,7 +2942,7 @@ module Crystal
     end
 
     def ident_start?(char)
-      char.ascii_letter? || char == '_' || char.ord > 0x9F
+      char.ascii_letter? || char == '_' || char.codepoint > 0x9F
     end
 
     def ident_part?(char)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -731,7 +731,7 @@ module Crystal
             @token.value = '\v'
           when 'u'
             value = consume_char_unicode_escape
-            @token.value = value.chr
+            @token.value = value.char
           when '0'
             @token.value = '\0'
           when '\0'
@@ -2540,14 +2540,14 @@ module Crystal
         next_char
         consume_string_unicode_brace_escape
       else
-        consume_non_braced_unicode_escape.chr.to_s
+        consume_non_braced_unicode_escape.char.to_s
       end
     end
 
     def consume_string_unicode_brace_escape
       String.build do |str|
         while true
-          str << consume_braced_unicode_escape(allow_spaces: true).chr
+          str << consume_braced_unicode_escape(allow_spaces: true).char
           break unless current_char == ' '
         end
       end

--- a/src/compiler/crystal/tools/doc/markdown/parser.cr
+++ b/src/compiler/crystal/tools/doc/markdown/parser.cr
@@ -367,7 +367,7 @@ class Crystal::Doc::Markdown::Parser
           @renderer.text line.byte_slice(cursor, pos - cursor)
           cursor = pos + 1
           @renderer.begin_inline_code
-          idx = (str + pos + 1).to_slice(bytesize).index('`'.ord).not_nil!
+          idx = (str + pos + 1).to_slice(bytesize).index('`'.codepoint).not_nil!
           @renderer.text line.byte_slice(cursor, idx)
           pos = pos + 1 + idx
           @renderer.end_inline_code
@@ -379,12 +379,12 @@ class Crystal::Doc::Markdown::Parser
           if link
             @renderer.text line.byte_slice(cursor, pos - cursor)
 
-            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.ord).not_nil!
+            bracket_idx = (str + pos + 2).to_slice(bytesize - pos - 2).index(']'.codepoint).not_nil!
             alt = line.byte_slice(pos + 2, bracket_idx)
 
             @renderer.image link, alt
 
-            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.ord).not_nil!
+            paren_idx = (str + pos + 2 + bracket_idx + 1).to_slice(bytesize - pos - 2 - bracket_idx - 1).index(')'.codepoint).not_nil!
             pos += 2 + bracket_idx + 1 + paren_idx
             cursor = pos + 1
           end
@@ -404,7 +404,7 @@ class Crystal::Doc::Markdown::Parser
           @renderer.text line.byte_slice(cursor, pos - cursor)
           @renderer.end_link
 
-          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord).not_nil!
+          paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.codepoint).not_nil!
           pos += paren_idx + 1
           cursor = pos + 1
           in_link = false
@@ -424,7 +424,7 @@ class Crystal::Doc::Markdown::Parser
   def has_closing?(char, count, str, pos, bytesize)
     str += pos
     bytesize -= pos
-    idx = str.to_slice(bytesize).index char.ord
+    idx = str.to_slice(bytesize).index char.codepoint
     return false unless idx
 
     if count == 2
@@ -455,7 +455,7 @@ class Crystal::Doc::Markdown::Parser
 
     return nil unless str[bracket_idx + 1] === '('
 
-    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.ord
+    paren_idx = (str + bracket_idx + 1).to_slice(bytesize - bracket_idx - 1).index ')'.codepoint
     return nil unless paren_idx
 
     String.new(Slice.new(str + bracket_idx + 2, paren_idx - 1))
@@ -472,7 +472,7 @@ class Crystal::Doc::Markdown::Parser
 
   def line_is_all?(line, char)
     line.each_byte do |byte|
-      return false if byte != char.ord
+      return false if byte != char.codepoint
     end
     true
   end

--- a/src/compiler/crystal/tools/doc/markdown/parser.cr
+++ b/src/compiler/crystal/tools/doc/markdown/parser.cr
@@ -101,7 +101,7 @@ class Crystal::Doc::Markdown::Parser
     bytesize = line.bytesize
     str = line.to_unsafe
     pos = level
-    while pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
+    while pos < bytesize && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
@@ -302,7 +302,7 @@ class Crystal::Doc::Markdown::Parser
     str = line.to_unsafe
     pos = 0
 
-    while pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
+    while pos < bytesize && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
@@ -315,9 +315,9 @@ class Crystal::Doc::Markdown::Parser
     last_is_space = true
 
     while pos < bytesize
-      case str[pos].unsafe_chr
+      case str[pos].unsafe_char
       when '*'
-        if pos + 1 < bytesize && str[pos + 1].unsafe_chr == '*'
+        if pos + 1 < bytesize && str[pos + 1].unsafe_char == '*'
           if two_stars || has_closing?('*', 2, str, (pos + 2), bytesize)
             @renderer.text line.byte_slice(cursor, pos - cursor)
             pos += 1
@@ -340,7 +340,7 @@ class Crystal::Doc::Markdown::Parser
           one_star = !one_star
         end
       when '_'
-        if pos + 1 < bytesize && str[pos + 1].unsafe_chr == '_'
+        if pos + 1 < bytesize && str[pos + 1].unsafe_char == '_'
           if two_underscores || (last_is_space && has_closing?('_', 2, str, (pos + 2), bytesize))
             @renderer.text line.byte_slice(cursor, pos - cursor)
             pos += 1
@@ -410,7 +410,7 @@ class Crystal::Doc::Markdown::Parser
           in_link = false
         end
       end
-      last_is_space = pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
+      last_is_space = pos < bytesize && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
@@ -428,17 +428,17 @@ class Crystal::Doc::Markdown::Parser
     return false unless idx
 
     if count == 2
-      return false unless idx + 1 < bytesize && str[idx + 1].unsafe_chr == char
+      return false unless idx + 1 < bytesize && str[idx + 1].unsafe_char == char
     end
 
-    !str[idx - 1].unsafe_chr.ascii_whitespace?
+    !str[idx - 1].unsafe_char.ascii_whitespace?
   end
 
   def check_link(str, pos, bytesize)
     # We need to count nested brackets to do it right
     bracket_count = 1
     while pos < bytesize
-      case str[pos].unsafe_chr
+      case str[pos].unsafe_char
       when '['
         bracket_count += 1
       when ']'
@@ -481,7 +481,7 @@ class Crystal::Doc::Markdown::Parser
     bytesize = line.bytesize
     str = line.to_unsafe
     pos = 0
-    while pos < bytesize && pos < 6 && str[pos].unsafe_chr == '#'
+    while pos < bytesize && pos < 6 && str[pos].unsafe_char == '#'
       pos += 1
     end
     pos == 0 ? nil : pos
@@ -491,7 +491,7 @@ class Crystal::Doc::Markdown::Parser
     bytesize = line.bytesize
     str = line.to_unsafe
     pos = 0
-    while pos < bytesize && pos < 4 && str[pos].unsafe_chr.ascii_whitespace?
+    while pos < bytesize && pos < 4 && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
@@ -506,17 +506,17 @@ class Crystal::Doc::Markdown::Parser
     bytesize = line.bytesize
     str = line.to_unsafe
     pos = 0
-    while pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
+    while pos < bytesize && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
     return false unless pos < bytesize
-    return false unless prefix ? str[pos].unsafe_chr == prefix : (str[pos].unsafe_chr == '*' || str[pos].unsafe_chr == '-' || str[pos].unsafe_chr == '+')
+    return false unless prefix ? str[pos].unsafe_char == prefix : (str[pos].unsafe_char == '*' || str[pos].unsafe_char == '-' || str[pos].unsafe_char == '+')
 
     pos += 1
 
     return false unless pos < bytesize
-    str[pos].unsafe_chr.ascii_whitespace?
+    str[pos].unsafe_char.ascii_whitespace?
   end
 
   def previous_line_is_not_intended_and_starts_with_bullet_list_marker?(prefix)
@@ -542,19 +542,19 @@ class Crystal::Doc::Markdown::Parser
     bytesize = line.bytesize
     str = line.to_unsafe
     pos = 0
-    while pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
+    while pos < bytesize && str[pos].unsafe_char.ascii_whitespace?
       pos += 1
     end
 
     return false unless pos < bytesize
-    return false unless str[pos].unsafe_chr.ascii_number?
+    return false unless str[pos].unsafe_char.ascii_number?
 
-    while pos < bytesize && str[pos].unsafe_chr.ascii_number?
+    while pos < bytesize && str[pos].unsafe_char.ascii_number?
       pos += 1
     end
 
     return false unless pos < bytesize
-    str[pos].unsafe_chr == '.'
+    str[pos].unsafe_char == '.'
   end
 
   def next_lines_empty_of_code?

--- a/src/crypto/bcrypt/base64.cr
+++ b/src/crypto/bcrypt/base64.cr
@@ -88,6 +88,6 @@ module Crypto::Bcrypt::Base64
   end
 
   private def self.char64(x)
-    TABLE[x.ord]? || -1
+    TABLE[x.codepoint]? || -1
   end
 end

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -224,7 +224,7 @@ struct Crystal::Hasher
   end
 
   def char(value)
-    value.ord.hash(self)
+    value.codepoint.hash(self)
   end
 
   def enum(value)

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -159,7 +159,7 @@ class CSV::Builder
       case @quoting
       when .rfc?
         value.each_byte do |byte|
-          case byte.unsafe_chr
+          case byte.unsafe_char
           when @separator, @quote_char, '\n'
             return true
           end

--- a/src/debug/dwarf/strings.cr
+++ b/src/debug/dwarf/strings.cr
@@ -13,7 +13,7 @@ module Debug
       def decode(strp)
         # See if we can read it from the buffer
         if strp < @buffer.size
-          index = @buffer.index('\0'.ord, offset: strp)
+          index = @buffer.index('\0'.codepoint, offset: strp)
           return String.new(@buffer[strp, index - strp]) if index
         end
 

--- a/src/debug/elf.cr
+++ b/src/debug/elf.cr
@@ -4,7 +4,7 @@ module Debug
   # Documentation:
   # - <http://www.sco.com/developers/gabi/latest/contents.html>
   struct ELF
-    MAGIC = UInt8.slice(0x7f, 'E'.ord, 'L'.ord, 'F'.ord)
+    MAGIC = UInt8.slice(0x7f, 'E'.codepoint, 'L'.codepoint, 'F'.codepoint)
 
     enum Klass : UInt8
       ELF32 = 1

--- a/src/html.cr
+++ b/src/html.cr
@@ -154,7 +154,7 @@ module HTML
              codepoint & 0xFFFF >= 0xFFFE ||
              # unicode control characters expect space
              (codepoint < 0x0020 && !{0x0009, 0x000A, 0x000C}.includes?(codepoint))
-        codepoint.unsafe_chr
+        codepoint.unsafe_char
       end
     end
   end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -166,7 +166,7 @@ module HTTP
 
     # Get where the header value starts (skip space)
     middle_index = colon_index + 1
-    while middle_index < bytesize && cstr[middle_index].unsafe_chr.ascii_whitespace?
+    while middle_index < bytesize && cstr[middle_index].unsafe_char.ascii_whitespace?
       middle_index += 1
     end
 
@@ -377,7 +377,7 @@ module HTTP
     String.build do |io|
       while quoted_pair_index
         io.write(data[0, quoted_pair_index])
-        io << data[quoted_pair_index + 1].chr
+        io << data[quoted_pair_index + 1].char
 
         data += quoted_pair_index + 2
         quoted_pair_index = data.index('\\'.codepoint)
@@ -407,7 +407,7 @@ module HTTP
       when '\t'.codepoint, ' '.codepoint, '"'.codepoint, '\\'.codepoint
         io << '\\'
       when 0x00..0x1F, 0x7F
-        raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+        raise ArgumentError.new("String contained invalid character #{byte.char.inspect}")
       end
       io.write_byte byte
     end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -86,12 +86,12 @@ module HTTP
       return nil if peek.empty?
 
       # See if we can find \n
-      index = peek.index('\n'.ord.to_u8)
+      index = peek.index('\n'.codepoint.to_u8)
       if index
         end_index = index
 
         # Also check (and discard) \r before that
-        if index > 0 && peek[index - 1] == '\r'.ord.to_u8
+        if index > 0 && peek[index - 1] == '\r'.codepoint.to_u8
           end_index -= 1
         end
 
@@ -161,7 +161,7 @@ module HTTP
     bytesize = slice.size
 
     # Get the colon index and name
-    colon_index = slice.index(':'.ord.to_u8) || 0
+    colon_index = slice.index(':'.codepoint.to_u8) || 0
     name = header_name(slice[0, colon_index])
 
     # Get where the header value starts (skip space)
@@ -174,9 +174,9 @@ module HTTP
     right_index = bytesize
     if middle_index >= right_index
       return {name, ""}
-    elsif right_index > 1 && cstr[right_index - 2] == '\r'.ord.to_u8 && cstr[right_index - 1] == '\n'.ord.to_u8
+    elsif right_index > 1 && cstr[right_index - 2] == '\r'.codepoint.to_u8 && cstr[right_index - 1] == '\n'.codepoint.to_u8
       right_index -= 2
-    elsif right_index > 0 && cstr[right_index - 1] == '\n'.ord.to_u8
+    elsif right_index > 0 && cstr[right_index - 1] == '\n'.codepoint.to_u8
       right_index -= 1
     end
 
@@ -371,7 +371,7 @@ module HTTP
   # ```
   def self.dequote_string(str)
     data = str.to_slice
-    quoted_pair_index = data.index('\\'.ord)
+    quoted_pair_index = data.index('\\'.codepoint)
     return str unless quoted_pair_index
 
     String.build do |io|
@@ -380,7 +380,7 @@ module HTTP
         io << data[quoted_pair_index + 1].chr
 
         data += quoted_pair_index + 2
-        quoted_pair_index = data.index('\\'.ord)
+        quoted_pair_index = data.index('\\'.codepoint)
       end
       io.write(data)
     end
@@ -404,7 +404,7 @@ module HTTP
 
     string.each_byte do |byte|
       case byte
-      when '\t'.ord, ' '.ord, '"'.ord, '\\'.ord
+      when '\t'.codepoint, ' '.codepoint, '"'.codepoint, '\\'.codepoint
         io << '\\'
       when 0x00..0x1F, 0x7F
         raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -204,7 +204,7 @@ module HTTP
     private def read_chunk_size
       line = @io.read_line(@max_headers_size, chomp: true)
 
-      if index = line.byte_index(';'.ord)
+      if index = line.byte_index(';'.codepoint)
         chunk_size = line.byte_slice(0, index)
       else
         chunk_size = line

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -42,7 +42,7 @@ struct HTTP::Headers
 
       return byte if char.ascii_lowercase? || char == '-' # Optimize the common case
       return byte + 32 if char.ascii_uppercase?
-      return '-'.ord if char == '_'
+      return '-'.codepoint if char == '_'
 
       byte
     end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -38,7 +38,7 @@ struct HTTP::Headers
     end
 
     private def normalize_byte(byte)
-      char = byte.unsafe_chr
+      char = byte.unsafe_char
 
       return byte if char.ascii_lowercase? || char == '-' # Optimize the common case
       return byte + 32 if char.ascii_uppercase?
@@ -351,7 +351,7 @@ struct HTTP::Headers
 
   private def invalid_value_char(value)
     value.each_byte do |byte|
-      unless valid_char?(char = byte.unsafe_chr)
+      unless valid_char?(char = byte.unsafe_char)
         return char
       end
     end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -43,7 +43,7 @@ module HTTP
       bytesize = query.bytesize
       while i < bytesize
         byte = query.unsafe_byte_at(i)
-        char = byte.unsafe_chr
+        char = byte.unsafe_char
 
         case char
         when '='

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -130,14 +130,14 @@ class HTTP::Request
       return nil if peek.empty?
 
       # See if we can find \n
-      index = peek.index('\n'.ord.to_u8)
+      index = peek.index('\n'.codepoint.to_u8)
       if index
         return HTTP::Status::URI_TOO_LONG if index > max_request_line_size
 
         end_index = index
 
         # Also check (and discard) \r before that
-        if index > 0 && peek[index - 1] == '\r'.ord.to_u8
+        if index > 0 && peek[index - 1] == '\r'.codepoint.to_u8
           end_index -= 1
         end
 
@@ -163,7 +163,7 @@ class HTTP::Request
   end
 
   private def self.parse_request_line(slice : Bytes) : RequestLine | HTTP::Status
-    space_index = slice.index(' '.ord.to_u8)
+    space_index = slice.index(' '.codepoint.to_u8)
 
     # Oops, only a single part (should be three)
     return HTTP::Status::BAD_REQUEST unless space_index
@@ -177,14 +177,14 @@ class HTTP::Request
 
     # Skip spaces.
     # The RFC just mentions a single space but most servers allow multiple.
-    while space_index < slice.size && slice[space_index] == ' '.ord.to_u8
+    while space_index < slice.size && slice[space_index] == ' '.codepoint.to_u8
       space_index += 1
     end
 
     # Oops, we only found the "method" part followed by spaces
     return HTTP::Status::BAD_REQUEST if space_index == slice.size
 
-    next_space_index = slice.index(' '.ord.to_u8, offset: space_index)
+    next_space_index = slice.index(' '.codepoint.to_u8, offset: space_index)
 
     # Oops, we only found two parts (should be three)
     return HTTP::Status::BAD_REQUEST unless next_space_index
@@ -193,11 +193,11 @@ class HTTP::Request
 
     # Skip spaces again
     space_index = next_space_index
-    while space_index < slice.size && slice[space_index] == ' '.ord.to_u8
+    while space_index < slice.size && slice[space_index] == ' '.codepoint.to_u8
       space_index += 1
     end
 
-    next_space_index = slice.index(' '.ord.to_u8, offset: space_index) || slice.size
+    next_space_index = slice.index(' '.codepoint.to_u8, offset: space_index) || slice.size
 
     subslice = slice[space_index...next_space_index]
 
@@ -209,7 +209,7 @@ class HTTP::Request
     space_index = next_space_index
     while space_index < slice.size
       # Oops, we find something else (more than three parts)
-      return HTTP::Status::BAD_REQUEST unless slice[space_index] == ' '.ord.to_u8
+      return HTTP::Status::BAD_REQUEST unless slice[space_index] == ' '.codepoint.to_u8
       space_index += 1
     end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -323,7 +323,7 @@ struct Int
   end
 
   def ===(char : Char)
-    self === char.ord
+    self === char.codepoint
   end
 
   # Returns this number's *bit*th bit, starting with the least-significant.
@@ -592,7 +592,7 @@ struct Int
 
     if neg
       ptr -= 1
-      ptr.value = '-'.ord.to_u8
+      ptr.value = '-'.codepoint.to_u8
     end
 
     count = (ptr_end - ptr).to_i32

--- a/src/int.cr
+++ b/src/int.cr
@@ -67,11 +67,26 @@ struct Int
   # ```
   # 97.chr # => 'a'
   # ```
+  @[Deprecated("Use .char instead, which is less cryptic")]
   def chr
     unless 0 <= self <= Char::MAX_CODEPOINT
       raise ArgumentError.new("#{self} out of char range")
     end
-    unsafe_chr
+    unsafe_char
+  end
+
+  # Returns a `Char` that has the unicode codepoint of `self`.
+  #
+  # Raises `ArgumentError` if this integer's value doesn't fit a char's range (`0..0x10ffff`).
+  #
+  # ```
+  # 97.char # => 'a'
+  # ```
+  def char
+    unless 0 <= self <= Char::MAX_CODEPOINT
+      raise ArgumentError.new("#{self} out of char range")
+    end
+    unsafe_char
   end
 
   def ~

--- a/src/io.cr
+++ b/src/io.cr
@@ -36,7 +36,7 @@ require "c/errno"
 #   end
 # end
 #
-# slice = Slice.new(9) { |i| ('a'.ord + i).to_u8 }
+# slice = Slice.new(9) { |i| ('a'.codepoint + i).to_u8 }
 # String.new(slice) # => "abcdefghi"
 #
 # io = SimpleSliceIO.new(slice)
@@ -105,7 +105,7 @@ abstract class IO
   #
   # ```
   # io = IO::Memory.new
-  # slice = Bytes.new(4) { |i| ('a'.ord + i).to_u8 }
+  # slice = Bytes.new(4) { |i| ('a'.codepoint + i).to_u8 }
   # io.write(slice)
   # io.to_s # => "abcd"
   # ```
@@ -624,7 +624,7 @@ abstract class IO
     # If the char's representation is a single byte and we have an encoding,
     # search the delimiter in the buffer
     if ascii && decoder
-      return decoder.gets(self, delimiter.ord.to_u8, limit: limit, chomp: chomp)
+      return decoder.gets(self, delimiter.codepoint.to_u8, limit: limit, chomp: chomp)
     end
 
     # If there's no encoding, the delimiter is ASCII and we can peek,
@@ -643,7 +643,7 @@ abstract class IO
   private def gets_peek(delimiter, limit, chomp, peek)
     limit = Int32::MAX if limit < 0
 
-    delimiter_byte = delimiter.ord.to_u8
+    delimiter_byte = delimiter.codepoint.to_u8
 
     # We first check, if the delimiter is already in the peek buffer.
     # In that case it's much faster to create a String from a slice

--- a/src/io.cr
+++ b/src/io.cr
@@ -328,22 +328,22 @@ abstract class IO
     first = peek[0].to_u32
     skip(1)
     if first < 0x80
-      return first.unsafe_chr, 1
+      return first.unsafe_char, 1
     end
 
     second = peek_or_read_masked(peek, 1)
     if first < 0xe0
-      return ((first & 0x1f) << 6 | second).unsafe_chr, 2
+      return ((first & 0x1f) << 6 | second).unsafe_char, 2
     end
 
     third = peek_or_read_masked(peek, 2)
     if first < 0xf0
-      return ((first & 0x0f) << 12 | (second << 6) | third).unsafe_chr, 3
+      return ((first & 0x0f) << 12 | (second << 6) | third).unsafe_char, 3
     end
 
     fourth = peek_or_read_masked(peek, 3)
     if first < 0xf8
-      return ((first & 0x07) << 18 | (second << 12) | (third << 6) | fourth).unsafe_chr, 4
+      return ((first & 0x07) << 18 | (second << 12) | (third << 6) | fourth).unsafe_char, 4
     end
 
     raise InvalidByteSequenceError.new("Unexpected byte 0x#{first.to_s(16)} in UTF-8 byte sequence")
@@ -354,16 +354,16 @@ abstract class IO
     return nil unless first
 
     first = first.to_u32
-    return first.unsafe_chr, 1 if first < 0x80
+    return first.unsafe_char, 1 if first < 0x80
 
     second = read_utf8_masked_byte
-    return ((first & 0x1f) << 6 | second).unsafe_chr, 2 if first < 0xe0
+    return ((first & 0x1f) << 6 | second).unsafe_char, 2 if first < 0xe0
 
     third = read_utf8_masked_byte
-    return ((first & 0x0f) << 12 | (second << 6) | third).unsafe_chr, 3 if first < 0xf0
+    return ((first & 0x0f) << 12 | (second << 6) | third).unsafe_char, 3 if first < 0xf0
 
     fourth = read_utf8_masked_byte
-    return ((first & 0x07) << 18 | (second << 12) | (third << 6) | fourth).unsafe_chr, 4 if first < 0xf8
+    return ((first & 0x07) << 18 | (second << 12) | (third << 6) | fourth).unsafe_char, 4 if first < 0xf8
 
     raise InvalidByteSequenceError.new("Unexpected byte 0x#{first.to_s(16)} in UTF-8 byte sequence")
   end
@@ -778,7 +778,7 @@ abstract class IO
 
     # One byte: use gets(Char)
     if delimiter.bytesize == 1
-      return gets(delimiter.unsafe_byte_at(0).unsafe_chr, chomp: chomp)
+      return gets(delimiter.unsafe_byte_at(0).unsafe_char, chomp: chomp)
     end
 
     # One char: use gets(Char)

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -39,7 +39,7 @@ class IO::Memory < IO
   # The IO starts at position zero for reading.
   #
   # ```
-  # slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
+  # slice = Slice.new(6) { |i| ('a'.codepoint + i).to_u8 }
   # io = IO::Memory.new slice, writeable: false
   # io.pos            # => 0
   # io.read(slice)    # => 6
@@ -134,13 +134,13 @@ class IO::Memory < IO
 
   # :nodoc:
   def gets(delimiter : Char, limit : Int32, chomp = false)
-    return super if @encoding || delimiter.ord >= 128
+    return super if @encoding || delimiter.codepoint >= 128
 
     check_open
 
     raise ArgumentError.new "Negative limit" if limit < 0
 
-    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.ord)
+    index = (@buffer + @pos).to_slice(@bytesize - @pos).index(delimiter.codepoint)
     if index
       if index >= limit
         index = limit

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -125,7 +125,7 @@ class JSON::Builder
         when .ascii_control?
           io.write string.to_slice[start_pos, reader.pos - start_pos]
           io << "\\u"
-          ord = char.ord
+          ord = char.codepoint
           io << '0' if ord < 0x1000
           io << '0' if ord < 0x100
           io << '0' if ord < 0x10

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -125,11 +125,11 @@ class JSON::Builder
         when .ascii_control?
           io.write string.to_slice[start_pos, reader.pos - start_pos]
           io << "\\u"
-          ord = char.codepoint
-          io << '0' if ord < 0x1000
-          io << '0' if ord < 0x100
-          io << '0' if ord < 0x10
-          ord.to_s(16, io)
+          codepoint = char.codepoint
+          io << '0' if codepoint < 0x1000
+          io << '0' if codepoint < 0x100
+          io << '0' if codepoint < 0x10
+          codepoint.to_s(16, io)
           reader.next_char
           start_pos = reader.pos
           next

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -194,9 +194,9 @@ abstract class JSON::Lexer
           raise "Unterminated UTF-16 sequence"
         end
         hexnum2 = read_hex_number
-        (0x10000 | (hexnum1 & 0x3FF) << 10 | (hexnum2 & 0x3FF)).chr
+        (0x10000 | (hexnum1 & 0x3FF) << 10 | (hexnum2 & 0x3FF)).char
       else
-        hexnum1.chr
+        hexnum1.char
       end
     else
       raise "Unknown escape char: #{char}"

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -135,7 +135,7 @@ abstract class JSON::Lexer
         next_char
         break
       else
-        if 0 <= current_char.ord < 32
+        if 0 <= current_char.codepoint < 32
           unexpected_char
         end
       end
@@ -159,7 +159,7 @@ abstract class JSON::Lexer
         next_char
         break
       else
-        if 0 <= current_char.ord < 32
+        if 0 <= current_char.codepoint < 32
           unexpected_char
         else
           @buffer << char

--- a/src/json/lexer/string_based.cr
+++ b/src/json/lexer/string_based.cr
@@ -24,7 +24,7 @@ class JSON::Lexer::StringBased < JSON::Lexer
         next_char
         break
       else
-        if 0 <= current_char.ord < 32
+        if 0 <= current_char.codepoint < 32
           unexpected_char
         end
       end

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -257,7 +257,7 @@ module MIME
         sub_type_start = reader.pos
         reader.next_char
       else
-        if TSPECIAL_CHARACTERS.includes?(char) || 0x20 > char.ord > 0x7F
+        if TSPECIAL_CHARACTERS.includes?(char) || 0x20 > char.codepoint > 0x7F
           return nil
         end
 

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -115,7 +115,7 @@ module MIME
     # ```
     #
     def type : String
-      index = media_type.byte_index('/'.ord) || media_type.bytesize
+      index = media_type.byte_index('/'.codepoint) || media_type.bytesize
       media_type.byte_slice(0, index)
     end
 
@@ -128,7 +128,7 @@ module MIME
     # MIME::MediaType.new("foo").sub_type        # => nil
     # ```
     def sub_type : String?
-      index = media_type.byte_index('/'.ord) || return
+      index = media_type.byte_index('/'.codepoint) || return
       media_type.byte_slice(index + 1, media_type.bytesize - index - 1)
     end
 
@@ -484,7 +484,7 @@ module MIME
 
     # :nodoc:
     def self.token?(char : Char)
-      !TSPECIAL_CHARACTERS.includes?(char) && 0x20 <= char.ord < 0x7F
+      !TSPECIAL_CHARACTERS.includes?(char) && 0x20 <= char.codepoint < 0x7F
     end
 
     # :nodoc:
@@ -496,7 +496,7 @@ module MIME
     def self.quote_string(string, io)
       string.each_byte do |byte|
         case byte
-        when '"'.ord, '\\'.ord
+        when '"'.codepoint, '\\'.codepoint
           io << '\\'
         when 0x00..0x1F, 0x7F
           raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -499,7 +499,7 @@ module MIME
         when '"'.codepoint, '\\'.codepoint
           io << '\\'
         when 0x00..0x1F, 0x7F
-          raise ArgumentError.new("String contained invalid character #{byte.chr.inspect}")
+          raise ArgumentError.new("String contained invalid character #{byte.char.inspect}")
         end
         io.write_byte byte
       end

--- a/src/mime/multipart/parser.cr
+++ b/src/mime/multipart/parser.cr
@@ -115,7 +115,7 @@ module MIME::Multipart
 
         0.upto(transport_padding_crlf.bytesize - 3) do |i| # 3 constant to ignore "\r\n" at end
           byte = transport_padding_crlf.to_unsafe[i]
-          fail("padding contained non-whitespace character") unless byte == ' '.ord || byte == '\t'.ord
+          fail("padding contained non-whitespace character") unless byte == ' '.codepoint || byte == '\t'.codepoint
         end
       end
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -291,7 +291,7 @@ struct Path
 
     current = bytes.size - 1
 
-    separators = self.separators.map &.ord
+    separators = self.separators.map &.codepoint
 
     # skip trailing separators
     while separators.includes?(bytes[current]) && current > 0
@@ -336,14 +336,14 @@ struct Path
     current = bytes.size - 1
 
     # if the pattern is `foo.`, it has no extension
-    return "" if bytes[current] == '.'.ord
+    return "" if bytes[current] == '.'.codepoint
 
-    separators = self.separators.map &.ord
+    separators = self.separators.map &.codepoint
 
     # position the reader at the last `.` or SEPARATOR
     # that is not the first char
     while !separators.includes?(bytes[current]) &&
-          bytes[current] != '.'.ord &&
+          bytes[current] != '.'.codepoint &&
           current > 0
       current -= 1
     end
@@ -721,7 +721,7 @@ struct Path
 
       # Add separator if needed
       if add_separator
-        buffer.value = separators[0].ord.to_u8
+        buffer.value = separators[0].codepoint.to_u8
         buffer += 1
       end
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -255,7 +255,7 @@ struct Path
     return if @name.empty? || @name == "."
 
     first_char = @name.char_at(0)
-    unless separators.includes?(first_char) || (first_char == '.' && separators.includes?(@name.byte_at?(1).try &.unsafe_chr)) || (windows? && (windows_drive? || unc_share?))
+    unless separators.includes?(first_char) || (first_char == '.' && separators.includes?(@name.byte_at?(1).try &.unsafe_char)) || (windows? && (windows_drive? || unc_share?))
       yield new_instance(".")
     end
 
@@ -416,7 +416,7 @@ struct Path
           reader.next_char
           if str.bytesize > dotdot
             str.back 1
-            while str.bytesize > dotdot && !separators.includes?((str.buffer + str.bytesize).value.unsafe_chr)
+            while str.bytesize > dotdot && !separators.includes?((str.buffer + str.bytesize).value.unsafe_char)
               str.back 1
             end
           elsif !root
@@ -431,7 +431,7 @@ struct Path
 
           # real path element
           # add slash if needed
-          if str.bytesize > anchor_pos && !separators.includes?((str.buffer + str.bytesize - 1).value.unsafe_chr)
+          if str.bytesize > anchor_pos && !separators.includes?((str.buffer + str.bytesize - 1).value.unsafe_char)
             str << separators[0]
           end
 
@@ -447,7 +447,7 @@ struct Path
         str << '.'
       end
 
-      last_char = (str.buffer + str.bytesize - 1).value.unsafe_chr
+      last_char = (str.buffer + str.bytesize - 1).value.unsafe_char
 
       if add_separator_at_end && !separators.includes?(last_char)
         str << separators[0]
@@ -927,7 +927,7 @@ struct Path
     if windows?
       if windows_drive?
         drive = @name.byte_slice(0, 2)
-        if separators.includes?(@name.byte_at?(2).try(&.chr))
+        if separators.includes?(@name.byte_at?(2).try(&.char))
           return drive, @name.byte_slice(2, 1)
         else
           return drive, nil

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -2,7 +2,7 @@
 # * can't be expressed in Crystal (need to be expressed in LLVM). For example unary
 #   and binary math operators fall into this category.
 # * should always be inlined with an LLVM instruction for performance reasons, even
-#   in non-release builds. An example of this is `Char#ord`, which could be implemented
+#   in non-release builds. An example of this is `Char#codepoint`, which could be implemented
 #   in Crystal by assigning `self` to a variable and casting a pointer to it to `Int32`,
 #   and then reading back the value.
 
@@ -87,7 +87,27 @@ struct Char
   # '☃'.ord      # => 9731
   # ```
   @[Primitive(:cast)]
+  @[Deprecated("Use .codepoint instead, which is less cryptic")]
   def ord : Int32
+  end
+
+  # Returns the codepoint of this char.
+  #
+  # The codepoint is the integer representation.
+  # The Universal Coded Character Set (UCS) standard, commonly known as Unicode,
+  # assigns names and meanings to numbers, these numbers are called codepoints.
+  #
+  # For values below and including 127 this matches the ASCII codes
+  # and thus its byte representation.
+  #
+  # ```
+  # 'a'.codepoint      # => 97
+  # '\0'.codepoint     # => 0
+  # '\u007f'.codepoint # => 127
+  # '☃'.codepoint      # => 9731
+  # ```
+  @[Primitive(:cast)]
+  def codepoint : Int32
   end
 
   {% for op, desc in {

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -349,7 +349,22 @@ end
       # 97.unsafe_chr # => 'a'
       # ```
       @[Primitive(:cast)]
+      @[Deprecated("Use .unsafe_char instead, which is less cryptic")]
       def unsafe_chr : Char
+      end
+
+      # Returns a `Char` that has the unicode codepoint of `self`,
+      # without checking if this integer is in the range valid for
+      # chars (`0..0x10ffff`).
+      #
+      # You should never use this method unless `char` turns out to
+      # be a bottleneck.
+      #
+      # ```
+      # 97.unsafe_char # => 'a'
+      # ```
+      @[Primitive(:cast)]
+      def unsafe_char : Char
       end
 
       {% for int2 in ints %}

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -307,7 +307,7 @@ class Regex
     String.build do |result|
       str.each_byte do |byte|
         {% begin %}
-          case byte.unsafe_chr
+          case byte.unsafe_char
           when {{*SPECIAL_CHARACTERS}}
             result << '\\'
             result.write_byte byte

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -58,7 +58,7 @@ struct Slice(T)
   # method does not allocate heap memory.
   #
   # ```
-  # ptr = Pointer.malloc(9) { |i| ('a'.ord + i).to_u8 }
+  # ptr = Pointer.malloc(9) { |i| ('a'.codepoint + i).to_u8 }
   #
   # slice = Slice.new(ptr, 3)
   # slice.size # => 3
@@ -495,33 +495,33 @@ struct Slice(T)
           0.upto(7) do |j|
             buffer[index_offset + 7 - j] = to_hex((i >> (4 * j)) & 0xf)
           end
-          buffer[index_offset + 8] = ' '.ord.to_u8
-          buffer[index_offset + 9] = ' '.ord.to_u8
+          buffer[index_offset + 8] = ' '.codepoint.to_u8
+          buffer[index_offset + 9] = ' '.codepoint.to_u8
           index_offset += 77
         end
 
         buffer[hex_offset] = to_hex(v >> 4)
         buffer[hex_offset + 1] = to_hex(v & 0x0f)
-        buffer[hex_offset + 2] = ' '.ord.to_u8
+        buffer[hex_offset + 2] = ' '.codepoint.to_u8
         hex_offset += 3
 
-        buffer[ascii_offset] = (v > 31 && v < 127) ? v : '.'.ord.to_u8
+        buffer[ascii_offset] = (v > 31 && v < 127) ? v : '.'.codepoint.to_u8
         ascii_offset += 1
 
         if i % 8 == 7
-          buffer[hex_offset] = ' '.ord.to_u8
+          buffer[hex_offset] = ' '.codepoint.to_u8
           hex_offset += 1
         end
 
         if i % 16 == 15 && ascii_offset < str_size
-          buffer[ascii_offset] = '\n'.ord.to_u8
+          buffer[ascii_offset] = '\n'.codepoint.to_u8
           hex_offset += 27
           ascii_offset += 61
         end
       end
 
       while hex_offset % 77 < 60
-        buffer[hex_offset] = ' '.ord.to_u8
+        buffer[hex_offset] = ' '.codepoint.to_u8
         hex_offset += 1
       end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -702,7 +702,7 @@ class String
 
     if strict
       if whitespace
-        while endptr < string_end && endptr.value.chr.ascii_whitespace?
+        while endptr < string_end && endptr.value.char.ascii_whitespace?
           endptr += 1
         end
       end
@@ -711,7 +711,7 @@ class String
     else
       ptr = to_unsafe
       if whitespace
-        while ptr < string_end && ptr.value.chr.ascii_whitespace?
+        while ptr < string_end && ptr.value.char.ascii_whitespace?
           ptr += 1
         end
       end

--- a/src/string.cr
+++ b/src/string.cr
@@ -521,7 +521,7 @@ class String
 
     # Skip leading whitespace
     if whitespace
-      while ptr.value.unsafe_chr.ascii_whitespace?
+      while ptr.value.unsafe_char.ascii_whitespace?
         ptr += 1
       end
     end
@@ -529,7 +529,7 @@ class String
     negative = false
 
     # Check + and -
-    case ptr.value.unsafe_chr
+    case ptr.value.unsafe_char
     when '-'
       if unsigned
         return ToU64Info.new 0, true, true
@@ -543,11 +543,11 @@ class String
     found_digit = false
 
     # Check leading zero
-    if ptr.value.unsafe_chr == '0'
+    if ptr.value.unsafe_char == '0'
       ptr += 1
 
       if prefix
-        case ptr.value.unsafe_chr
+        case ptr.value.unsafe_char
         when 'b'
           base = 2
           ptr += 1
@@ -579,7 +579,7 @@ class String
 
     digits = (base == 62 ? CHAR_TO_DIGIT62 : CHAR_TO_DIGIT).to_unsafe
     while ptr.value != 0
-      if underscore && ptr.value.unsafe_chr == '_'
+      if underscore && ptr.value.unsafe_char == '_'
         break if last_is_underscore
         last_is_underscore = true
         ptr += 1
@@ -613,7 +613,7 @@ class String
     if found_digit
       unless ptr.value == 0
         if whitespace
-          while ptr.value.unsafe_chr.ascii_whitespace?
+          while ptr.value.unsafe_char.ascii_whitespace?
             ptr += 1
           end
         end
@@ -861,7 +861,7 @@ class String
     if ascii_only?
       byte = byte_at?(index)
       if byte
-        return byte < 0x80 ? byte.unsafe_chr : Char::REPLACEMENT
+        return byte < 0x80 ? byte.unsafe_char : Char::REPLACEMENT
       else
         return yield
       end
@@ -945,7 +945,7 @@ class String
     if ascii_only? && (options.none? || options.ascii?)
       String.new(bytesize) do |buffer|
         bytesize.times do |i|
-          buffer[i] = to_unsafe[i].unsafe_chr.downcase.codepoint.to_u8
+          buffer[i] = to_unsafe[i].unsafe_char.downcase.codepoint.to_u8
         end
         {@bytesize, @length}
       end
@@ -972,7 +972,7 @@ class String
     if ascii_only? && (options.none? || options.ascii?)
       String.new(bytesize) do |buffer|
         bytesize.times do |i|
-          buffer[i] = to_unsafe[i].unsafe_chr.upcase.codepoint.to_u8
+          buffer[i] = to_unsafe[i].unsafe_char.upcase.codepoint.to_u8
         end
         {@bytesize, @length}
       end
@@ -1000,9 +1000,9 @@ class String
       String.new(bytesize) do |buffer|
         bytesize.times do |i|
           if i == 0
-            buffer[i] = to_unsafe[i].unsafe_chr.upcase.codepoint.to_u8
+            buffer[i] = to_unsafe[i].unsafe_char.upcase.codepoint.to_u8
           else
-            buffer[i] = to_unsafe[i].unsafe_chr.downcase.codepoint.to_u8
+            buffer[i] = to_unsafe[i].unsafe_char.downcase.codepoint.to_u8
           end
         end
         {@bytesize, @length}
@@ -1073,7 +1073,7 @@ class String
   # ```
   def chomp(suffix : String)
     if suffix.bytesize == 1
-      chomp(suffix.to_unsafe[0].unsafe_chr)
+      chomp(suffix.to_unsafe[0].unsafe_char)
     elsif ends_with?(suffix)
       unsafe_byte_slice_string(0, bytesize - suffix.bytesize)
     else
@@ -1264,8 +1264,8 @@ class String
 
     i = 0
     while i < bytesize
-      high_nibble = to_unsafe[i].unsafe_chr.to_u8?(16)
-      low_nibble = to_unsafe[i + 1].unsafe_chr.to_u8?(16)
+      high_nibble = to_unsafe[i].unsafe_char.to_u8?(16)
+      low_nibble = to_unsafe[i + 1].unsafe_char.to_u8?(16)
       return unless high_nibble && low_nibble
 
       bytes[i // 2] = (high_nibble << 4) | low_nibble
@@ -1533,7 +1533,7 @@ class String
 
   private def calc_excess_right
     i = bytesize - 1
-    while i >= 0 && to_unsafe[i].unsafe_chr.ascii_whitespace?
+    while i >= 0 && to_unsafe[i].unsafe_char.ascii_whitespace?
       i -= 1
     end
     bytesize - 1 - i
@@ -1569,7 +1569,7 @@ class String
     excess_left = 0
     # All strings end with '\0', and it's not a whitespace
     # so it's safe to access past 1 byte beyond the string data
-    while to_unsafe[excess_left].unsafe_chr.ascii_whitespace?
+    while to_unsafe[excess_left].unsafe_char.ascii_whitespace?
       excess_left += 1
     end
     excess_left
@@ -1639,7 +1639,7 @@ class String
     return delete(from) if to.empty?
 
     if from.bytesize == 1
-      return gsub(from.unsafe_byte_at(0).unsafe_chr, to[0])
+      return gsub(from.unsafe_byte_at(0).unsafe_char, to[0])
     end
 
     multi = nil
@@ -1665,7 +1665,7 @@ class String
       each_char do |ch|
         if ch.codepoint < 256
           if (a = table[ch.codepoint]) >= 0
-            buffer << a.unsafe_chr
+            buffer << a.unsafe_char
           else
             buffer << ch
           end
@@ -1996,21 +1996,21 @@ class String
 
     while index = replacement.byte_index('\\'.codepoint.to_u8, index)
       index += 1
-      chr = replacement.to_unsafe[index].unsafe_chr
-      case chr
+      char = replacement.to_unsafe[index].unsafe_char
+      case char
       when '\\'
         buffer.write(replacement.unsafe_byte_slice(first_index, index - first_index))
         index += 1
         first_index = index
       when '0'..'9'
         buffer.write(replacement.unsafe_byte_slice(first_index, index - 1 - first_index))
-        buffer << match_data[chr - '0']?
+        buffer << match_data[char - '0']?
         index += 1
         first_index = index
       when 'k'
         index += 1
-        chr = replacement.to_unsafe[index].unsafe_chr
-        next unless chr == '<'
+        char = replacement.to_unsafe[index].unsafe_char
+        next unless char == '<'
 
         buffer.write(replacement.unsafe_byte_slice(first_index, index - 2 - first_index))
 
@@ -2058,7 +2058,7 @@ class String
   # ```
   def gsub(char : Char, replacement)
     if replacement.is_a?(String) && replacement.bytesize == 1
-      return gsub(char, replacement.unsafe_byte_at(0).unsafe_chr)
+      return gsub(char, replacement.unsafe_byte_at(0).unsafe_char)
     end
 
     if includes?(char)
@@ -2168,7 +2168,7 @@ class String
   # ```
   def gsub(string : String, replacement)
     if string.bytesize == 1
-      gsub(string.unsafe_byte_at(0).unsafe_chr, replacement)
+      gsub(string.unsafe_byte_at(0).unsafe_char, replacement)
     else
       gsub(string) { replacement }
     end
@@ -3103,7 +3103,7 @@ class String
         while i < bytesize
           c = to_unsafe[i]
           i += 1
-          if c.unsafe_chr.ascii_whitespace?
+          if c.unsafe_char.ascii_whitespace?
             piece_bytesize = i - 1 - index
             piece_size = single_byte_optimizable ? piece_bytesize : 0
             yield String.new(to_unsafe + index, piece_bytesize, piece_size)
@@ -3121,7 +3121,7 @@ class String
         while i < bytesize
           c = to_unsafe[i]
           i += 1
-          unless c.unsafe_chr.ascii_whitespace?
+          unless c.unsafe_char.ascii_whitespace?
             index = i - 1
             looking_for_space = true
             break
@@ -3795,7 +3795,7 @@ class String
   def each_char : Nil
     if ascii_only?
       each_byte do |byte|
-        yield (byte < 0x80 ? byte.unsafe_chr : Char::REPLACEMENT)
+        yield (byte < 0x80 ? byte.unsafe_char : Char::REPLACEMENT)
       end
     else
       Char::Reader.new(self).each do |char|
@@ -3858,7 +3858,7 @@ class String
   # array # => [97, 98, 9731]
   # ```
   #
-  # See also: `Char#ord`.
+  # See also: `Char#codepoint`.
   def each_codepoint
     each_char do |char|
       yield char.codepoint
@@ -3874,7 +3874,7 @@ class String
   # codepoints.next # => 9731
   # ```
   #
-  # See also: `Char#ord`.
+  # See also: `Char#codepoint`.
   def each_codepoint
     each_char.map &.codepoint
   end
@@ -3885,7 +3885,7 @@ class String
   # "ab☃".codepoints # => [97, 98, 9731]
   # ```
   #
-  # See also: `Char#ord`.
+  # See also: `Char#codepoint`.
   def codepoints
     codepoints = Array(Int32).new(@length > 0 ? @length : bytesize)
     each_codepoint do |codepoint|

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -14,14 +14,14 @@ class String
   def to_utf16 : Slice(UInt16)
     size = 0
     each_char do |char|
-      size += char.ord < 0x10000 ? 1 : 2
+      size += char.codepoint < 0x10000 ? 1 : 2
     end
 
     slice = Slice(UInt16).new(size + 1)
 
     i = 0
     each_char do |char|
-      ord = char.ord
+      ord = char.codepoint
       if ord <= 0xd800 || (0xe000 <= ord < 0x10000)
         # One UInt16 is enough
         slice[i] = ord.to_u16

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -21,16 +21,16 @@ class String
 
     i = 0
     each_char do |char|
-      ord = char.codepoint
-      if ord <= 0xd800 || (0xe000 <= ord < 0x10000)
+      codepoint = char.codepoint
+      if codepoint <= 0xd800 || (0xe000 <= codepoint < 0x10000)
         # One UInt16 is enough
-        slice[i] = ord.to_u16
-      elsif ord >= 0x10000
+        slice[i] = codepoint.to_u16
+      elsif codepoint >= 0x10000
         # Needs surrogate pair
-        ord -= 0x10000
-        slice[i] = 0xd800_u16 + ((ord >> 10) & 0x3ff) # Keep top 10 bits
+        codepoint -= 0x10000
+        slice[i] = 0xd800_u16 + ((codepoint >> 10) & 0x3ff) # Keep top 10 bits
         i += 1
-        slice[i] = 0xdc00_u16 + (ord & 0x3ff) # Keep low 10 bits
+        slice[i] = 0xdc00_u16 + (codepoint & 0x3ff) # Keep low 10 bits
       else
         # Invalid char: use replacement
         slice[i] = 0xfffd_u16

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -127,7 +127,7 @@ class String
         codepoint = 0xfffd
       end
 
-      yield codepoint.chr
+      yield codepoint.char
 
       i += 1
     end
@@ -152,7 +152,7 @@ class String
         codepoint = 0xfffd
       end
 
-      yield codepoint.chr
+      yield codepoint.char
 
       pointer = pointer + 1
     end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -73,7 +73,7 @@ class StringPool
   # require "string_pool"
   #
   # pool = StringPool.new
-  # ptr = Pointer.malloc(9) { |i| ('a'.ord + i).to_u8 }
+  # ptr = Pointer.malloc(9) { |i| ('a'.codepoint + i).to_u8 }
   # slice = Slice.new(ptr, 3)
   # pool.empty? # => true
   # pool.get(slice)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -243,30 +243,30 @@ struct Time::Format
     end
 
     def pad2(value, padding)
-      io.write_byte padding.ord.to_u8 if value < 10
+      io.write_byte padding.codepoint.to_u8 if value < 10
       io << value
     end
 
     def pad3(value, padding)
-      io.write_byte padding.ord.to_u8 if value < 100
+      io.write_byte padding.codepoint.to_u8 if value < 100
       pad2 value, padding
     end
 
     def pad4(value, padding)
-      io.write_byte padding.ord.to_u8 if value < 1000
+      io.write_byte padding.codepoint.to_u8 if value < 1000
       pad3 value, padding
     end
 
     def pad6(value, padding)
-      io.write_byte padding.ord.to_u8 if value < 100000
-      io.write_byte padding.ord.to_u8 if value < 10000
+      io.write_byte padding.codepoint.to_u8 if value < 100000
+      io.write_byte padding.codepoint.to_u8 if value < 10000
       pad4 value, padding
     end
 
     def pad9(value, padding)
-      io.write_byte padding.ord.to_u8 if value < 100000000
-      io.write_byte padding.ord.to_u8 if value < 10000000
-      io.write_byte padding.ord.to_u8 if value < 1000000
+      io.write_byte padding.codepoint.to_u8 if value < 100000000
+      io.write_byte padding.codepoint.to_u8 if value < 10000000
+      io.write_byte padding.codepoint.to_u8 if value < 1000000
       pad6 value, padding
     end
   end

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -81,7 +81,7 @@ class Time::Location
 
     # 1-byte version, then 15 bytes of padding
     version = io.read_byte
-    raise InvalidTZDataError.new unless {0_u8, '2'.ord, '3'.ord}.includes?(version)
+    raise InvalidTZDataError.new unless {0_u8, '2'.codepoint, '3'.codepoint}.includes?(version)
     io.skip(15)
 
     # six big-endian 32-bit integers:

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -45,7 +45,7 @@ module Unicode
       return
     end
 
-    result = special_cases_upcase[char.ord]?
+    result = special_cases_upcase[char.codepoint]?
     if result
       result.each { |c| yield c.unsafe_chr if c != 0 }
       return
@@ -57,7 +57,7 @@ module Unicode
   private def self.check_upcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_lowercase?
-        return (char.ord - 32).unsafe_chr
+        return (char.codepoint - 32).unsafe_chr
       else
         return char
       end
@@ -76,11 +76,11 @@ module Unicode
   end
 
   private def self.check_upcase_ranges(char)
-    result = search_ranges(upcase_ranges, char.ord)
+    result = search_ranges(upcase_ranges, char.codepoint)
     return char + result if result
 
-    result = search_alternate(alternate_ranges, char.ord)
-    return char - 1 if result && (char.ord - result).odd?
+    result = search_alternate(alternate_ranges, char.codepoint)
+    return char - 1 if result && (char.codepoint - result).odd?
 
     char
   end
@@ -119,7 +119,7 @@ module Unicode
       return
     end
 
-    result = special_cases_downcase[char.ord]?
+    result = special_cases_downcase[char.codepoint]?
     if result
       result.each { |c| yield c.unsafe_chr if c != 0 }
       return
@@ -131,7 +131,7 @@ module Unicode
   private def self.check_downcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_uppercase?
-        return (char.ord + 32).unsafe_chr
+        return (char.codepoint + 32).unsafe_chr
       else
         return char
       end
@@ -152,57 +152,57 @@ module Unicode
 
   private def self.check_downcase_fold(char, options)
     if options.fold?
-      result = search_ranges(casefold_ranges, char.ord)
-      return {char.ord + result} if result
+      result = search_ranges(casefold_ranges, char.codepoint)
+      return {char.codepoint + result} if result
 
-      return fold_cases[char.ord]?
+      return fold_cases[char.codepoint]?
     end
     nil
   end
 
   private def self.check_downcase_ranges(char)
-    result = search_ranges(downcase_ranges, char.ord)
+    result = search_ranges(downcase_ranges, char.codepoint)
     return char + result if result
 
-    result = search_alternate(alternate_ranges, char.ord)
-    return char + 1 if result && (char.ord - result).even?
+    result = search_alternate(alternate_ranges, char.codepoint)
+    return char + 1 if result && (char.codepoint - result).even?
 
     char
   end
 
   # :nodoc:
   def self.lowercase?(char : Char)
-    in_category?(char.ord, category_Ll)
+    in_category?(char.codepoint, category_Ll)
   end
 
   # :nodoc:
   def self.uppercase?(char : Char)
-    in_category?(char.ord, category_Lu)
+    in_category?(char.codepoint, category_Lu)
   end
 
   # :nodoc:
   def self.letter?(char : Char)
-    in_any_category?(char.ord, category_Lu, category_Ll, category_Lt)
+    in_any_category?(char.codepoint, category_Lu, category_Ll, category_Lt)
   end
 
   # :nodoc:
   def self.number?(char : Char)
-    in_any_category?(char.ord, category_Nd, category_Nl, category_No)
+    in_any_category?(char.codepoint, category_Nd, category_Nl, category_No)
   end
 
   # :nodoc:
   def self.control?(char : Char)
-    in_any_category?(char.ord, category_Cs, category_Co, category_Cn, category_Cf, category_Cc)
+    in_any_category?(char.codepoint, category_Cs, category_Co, category_Cn, category_Cf, category_Cc)
   end
 
   # :nodoc:
   def self.whitespace?(char : Char)
-    in_any_category?(char.ord, category_Zs, category_Zl, category_Zp)
+    in_any_category?(char.codepoint, category_Zs, category_Zl, category_Zp)
   end
 
   # :nodoc:
   def self.mark?(char : Char)
-    in_any_category?(char.ord, category_Mn, category_Me, category_Mc)
+    in_any_category?(char.codepoint, category_Mn, category_Me, category_Mc)
   end
 
   private def self.search_ranges(haystack, needle)

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -47,7 +47,7 @@ module Unicode
 
     result = special_cases_upcase[char.codepoint]?
     if result
-      result.each { |c| yield c.unsafe_chr if c != 0 }
+      result.each { |c| yield c.unsafe_char if c != 0 }
       return
     end
 
@@ -57,7 +57,7 @@ module Unicode
   private def self.check_upcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_lowercase?
-        return (char.codepoint - 32).unsafe_chr
+        return (char.codepoint - 32).unsafe_char
       else
         return char
       end
@@ -94,7 +94,7 @@ module Unicode
     return result if result
 
     results = check_downcase_fold(char, options)
-    return results[0].unsafe_chr if results && results.size == 1
+    return results[0].unsafe_char if results && results.size == 1
 
     check_downcase_ranges(char)
   end
@@ -115,13 +115,13 @@ module Unicode
 
     result = check_downcase_fold(char, options)
     if result
-      result.each { |c| yield c.unsafe_chr if c != 0 }
+      result.each { |c| yield c.unsafe_char if c != 0 }
       return
     end
 
     result = special_cases_downcase[char.codepoint]?
     if result
-      result.each { |c| yield c.unsafe_chr if c != 0 }
+      result.each { |c| yield c.unsafe_char if c != 0 }
       return
     end
 
@@ -131,7 +131,7 @@ module Unicode
   private def self.check_downcase_ascii(char, options)
     if (char.ascii? && options.none?) || options.ascii?
       if char.ascii_uppercase?
-        return (char.codepoint + 32).unsafe_chr
+        return (char.codepoint + 32).unsafe_char
       else
         return char
       end

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -181,7 +181,7 @@ class URI
   # Reserved characters are ':', '/', '?', '#', '[', ']', '@', '!',
   # '$', '&', "'", '(', ')', '*', '+', ',', ';' and '='.
   def self.reserved?(byte) : Bool
-    char = byte.unsafe_chr
+    char = byte.unsafe_char
     '&' <= char <= ',' ||
       {'!', '#', '$', '/', ':', ';', '?', '@', '[', ']', '='}.includes?(char)
   end
@@ -191,7 +191,7 @@ class URI
   #
   # Unreserved characters are ASCII letters, ASCII digits, `_`, `.`, `-` and `~`.
   def self.unreserved?(byte) : Bool
-    char = byte.unsafe_chr
+    char = byte.unsafe_char
     char.ascii_alphanumeric? ||
       {'_', '.', '-', '~'}.includes?(char)
   end
@@ -213,7 +213,7 @@ class URI
     bytesize = string.bytesize
     while i < bytesize
       byte = string.unsafe_byte_at(i)
-      char = byte.unsafe_chr
+      char = byte.unsafe_char
       i = decode_one(string, bytesize, i, byte, char, io, plus_to_space) { |byte| yield byte }
     end
     io
@@ -234,7 +234,7 @@ class URI
   # `.encode_www_form(string : String, *, space_to_plus : Bool = true) : String`.
   def self.encode(string : String, io : IO, space_to_plus : Bool = false, &block) : Nil
     string.each_byte do |byte|
-      char = byte.unsafe_chr
+      char = byte.unsafe_char
       if char == ' ' && space_to_plus
         io.write_byte '+'.codepoint.to_u8
       elsif char.ascii? && yield(byte) && (!space_to_plus || char != '+')
@@ -265,7 +265,7 @@ class URI
     if char == '%' && i < bytesize - 2
       i += 1
       first = string.unsafe_byte_at(i)
-      first_num = first.unsafe_chr.to_i? 16
+      first_num = first.unsafe_char.to_i? 16
       unless first_num
         io.write_byte byte
         return i
@@ -273,7 +273,7 @@ class URI
 
       i += 1
       second = string.unsafe_byte_at(i)
-      second_num = second.unsafe_chr.to_i? 16
+      second_num = second.unsafe_char.to_i? 16
       unless second_num
         io.write_byte byte
         io.write_byte first

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -236,12 +236,12 @@ class URI
     string.each_byte do |byte|
       char = byte.unsafe_chr
       if char == ' ' && space_to_plus
-        io.write_byte '+'.ord.to_u8
+        io.write_byte '+'.codepoint.to_u8
       elsif char.ascii? && yield(byte) && (!space_to_plus || char != '+')
         io.write_byte byte
       else
-        io.write_byte '%'.ord.to_u8
-        io.write_byte '0'.ord.to_u8 if byte < 16
+        io.write_byte '%'.codepoint.to_u8
+        io.write_byte '0'.codepoint.to_u8 if byte < 16
         byte.to_s(16, io, upcase: true)
       end
     end
@@ -257,7 +257,7 @@ class URI
   # Unencodes one character. Private API
   def self.decode_one(string, bytesize, i, byte, char, io, plus_to_space = false)
     if plus_to_space && char == '+'
-      io.write_byte ' '.ord.to_u8
+      io.write_byte ' '.codepoint.to_u8
       i += 1
       return i
     end

--- a/src/uri/punycode.cr
+++ b/src/uri/punycode.cr
@@ -137,7 +137,7 @@ class URI
           bias = adapt i - oldi, outsize, oldi == 0
           n += i // outsize
           i %= outsize
-          output.insert i, n.chr
+          output.insert i, n.char
           i += 1
           init = true
         end

--- a/src/uri/punycode.cr
+++ b/src/uri/punycode.cr
@@ -67,9 +67,9 @@ class URI
         next if m == prev
         prev = m
 
-        raise Exception.new("Overflow: input needs wider integers to process") if m.ord - n > (Int32::MAX - delta) // h
-        delta += (m.ord - n) * h
-        n = m.ord + 1
+        raise Exception.new("Overflow: input needs wider integers to process") if m.codepoint - n > (Int32::MAX - delta) // h
+        delta += (m.codepoint - n) * h
+        n = m.codepoint + 1
 
         string.each_char do |c|
           if c < m
@@ -117,11 +117,11 @@ class URI
 
         digit = case c
                 when .ascii_lowercase?
-                  c.ord - 0x61
+                  c.codepoint - 0x61
                 when .ascii_uppercase?
-                  c.ord - 0x41
+                  c.codepoint - 0x41
                 when .ascii_number?
-                  c.ord - 0x30 + 26
+                  c.codepoint - 0x30 + 26
                 else
                   raise ArgumentError.new("Invalid input")
                 end

--- a/src/uri/uri_parser.cr
+++ b/src/uri/uri_parser.cr
@@ -142,7 +142,7 @@ class URI
         elsif end_of_host?
           unless start == @ptr
             @uri.port = (start...@ptr).reduce(0) do |memo, i|
-              (memo * 10) + (@input[i] - '0'.ord)
+              (memo * 10) + (@input[i] - '0'.codepoint)
             end
           end
           return parse_path
@@ -232,12 +232,12 @@ class URI
     end
 
     private def alpha?
-      ('a'.ord <= c && c <= 'z'.ord) ||
-        ('A'.ord <= c && c <= 'Z'.ord)
+      ('a'.codepoint <= c && c <= 'z'.codepoint) ||
+        ('A'.codepoint <= c && c <= 'Z'.codepoint)
     end
 
     private def numeric?
-      '0'.ord <= c && c <= '9'.ord
+      '0'.codepoint <= c && c <= '9'.codepoint
     end
 
     private def end_of_host?

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -189,7 +189,7 @@ struct UUID
     buffer = uninitialized UInt8[36]
     buffer_ptr = buffer.to_unsafe
 
-    buffer_ptr[8] = buffer_ptr[13] = buffer_ptr[18] = buffer_ptr[23] = '-'.ord.to_u8
+    buffer_ptr[8] = buffer_ptr[13] = buffer_ptr[18] = buffer_ptr[23] = '-'.codepoint.to_u8
     slice[0, 4].hexstring(buffer_ptr + 0)
     slice[4, 2].hexstring(buffer_ptr + 9)
     slice[6, 2].hexstring(buffer_ptr + 14)

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -271,7 +271,7 @@ struct XML::Builder
       raise ArgumentError.new("Quote char must be ' or \", not #{char}")
     end
 
-    call SetQuoteChar, char.ord
+    call SetQuoteChar, char.codepoint
   end
 
   private macro call(name, *args)


### PR DESCRIPTION
As mentioned in #8449 , they are now `Char#codepoint` and `Int#char` in this pull request.

The background of these two cryptic methods is that they actually come from an old programming language, Pascal.

http://xoomer.virgilio.it/gciabu/engl/pascal/pas036.htm

The reason of having int#char instead of `Int#to_char` or others is because when we say `1.char`, it looks more like "accessing a `char` property of a number" or "getting a number as char form".

By contrast, `1.to_char` and other `to_x` ideas look like "convert the number to a char", which may cause confusion with `Int#to_s`.

`Char#codepoint` has the similar idea: to avoid the use of `to_x`, to prevent the confusion with `Char#to_i`, and to keep it slightly shorter compared to `to_codepoint`.

For the merging, I would suggest that we either merge this before the release to deprecate `String#codepoint_at`, `Char#ord` and `Int#chr` together, or we deprecate `String#codepoint_at` first, and then deprecate the other two in future releases. I personally like to deprecate it together, because it will avoid one refactor.

Sorry for creating this pull request before any further discussions. The original issue is quite inactive, so we may continue discussions here.

It's my first commit to Crystal, any ideas or suggestions will be much appreciated. Considering that `Char#ord` and `Int#chr` are widely used in the source code, I might miss some points.