### PR TITLE
Extract POSIX implementation of Process and Signal to a portable API

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -175,7 +175,7 @@ describe Process do
 
   it "gets the pgid of a process id" do
     process = Process.new("yes")
-    Process.pgid(process.pid).should be_a(Int32)
+    Process.pgid(process.pid).should be_a(Int64)
     process.kill(Signal::KILL)
     Process.pgid.should eq(Process.pgid(Process.pid))
   end

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -1,0 +1,5 @@
+{% if flag?(:unix) %}
+  require "./unix/process"
+{% else %}
+  {% raise "No Crystal::Process implementation available" %}
+{% end %}

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -1,0 +1,254 @@
+require "c/signal"
+require "c/stdlib"
+require "c/sys/resource"
+require "c/unistd"
+
+class Process
+  protected def wait_system
+    Crystal::SignalChildHandler.wait(@waitpid, @pid)
+  end
+
+  protected def self.exit_system(status = 0) : NoReturn
+    LibC.exit(status)
+  end
+
+  protected def self.pid_system : Int64
+    LibC.getpid.to_i64
+  end
+
+  protected def self.ppid_system : Int64
+    LibC.getppid.to_i64
+  end
+
+  protected def exists_system?
+    Process.exists_system?(@pid)
+  end
+
+  protected def self.exists_system?(pid : Int64)
+    ret = LibC.kill(pid, 0)
+    return true if ret == 0
+    return false if Errno.value == Errno::ESRCH
+    raise Errno.new("kill")
+  end
+
+  protected def pgid_system : Int64
+    Process.pgid_system(@pid)
+  end
+
+  protected def self.pgid_system(pid : Int64) : Int64
+    ret = LibC.getpgid(pid)
+    raise Errno.new("getpgid") if ret < 0
+    ret.to_i64
+  end
+
+  protected def signal_system(signal : Signal)
+    ret = LibC.kill(@pid, signal.value)
+    raise Errno.new("kill") if ret < 0
+  end
+
+  protected def create_and_exec(command : String, args : (Array | Tuple)?, env : Env?, clear_env : Bool, fork_input : IO::FileDescriptor, fork_output : IO::FileDescriptor, fork_error : IO::FileDescriptor, chdir : String?)
+    reader_pipe, writer_pipe = IO.pipe
+
+    pid = create_and_exec_impl(command, args, env, clear_env, fork_input, fork_output, fork_error, chdir, reader_pipe, writer_pipe)
+    writer_pipe.close
+    bytes = uninitialized UInt8[4]
+    if reader_pipe.read(bytes.to_slice) == 4
+      errno = IO::ByteFormat::SystemEndian.decode(Int32, bytes.to_slice)
+      message_size = reader_pipe.read_bytes(Int32)
+      if message_size > 0
+        message = String.build(message_size) { |io| IO.copy(reader_pipe, io, message_size) }
+      end
+      reader_pipe.close
+      raise Errno.new(message, errno)
+    end
+    reader_pipe.close
+    pid
+  end
+
+  protected def create_and_exec_impl(command : String, args : (Array | Tuple)?, env : Env?, clear_env : Bool, fork_input : IO::FileDescriptor, fork_output : IO::FileDescriptor, fork_error : IO::FileDescriptor, chdir : String?, reader_pipe : IO::FileDescriptor, writer_pipe : IO::FileDescriptor)
+    if pid = Process.fork_internal(will_exec: true)
+      return pid
+    end
+    begin
+      reader_pipe.close
+      writer_pipe.close_on_exec = true
+      Process.exec_internal(command, args, env, clear_env, fork_input, fork_output, fork_error, chdir)
+    rescue ex : Errno
+      writer_pipe.write_bytes(ex.errno)
+      writer_pipe.write_bytes(ex.message.try(&.bytesize) || 0)
+      writer_pipe << ex.message
+      writer_pipe.close
+    rescue ex
+      ex.inspect_with_backtrace STDERR
+      STDERR.flush
+    ensure
+      LibC._exit 127
+    end
+  end
+
+  protected def self.fork_system : Process
+    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
+    if pid = fork_internal(will_exec: false)
+      return new pid
+    end
+    begin
+      yield
+      LibC._exit 0
+    rescue ex
+      ex.inspect_with_backtrace STDERR
+      STDERR.flush
+      LibC._exit 1
+    ensure
+      LibC._exit 254 # not reached
+    end
+  end
+
+  protected def self.fork_system : Process?
+    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
+    if pid = fork_internal(will_exec: false)
+      new pid
+    end
+  end
+
+  ORIGINAL_STDIN  = IO::FileDescriptor.new(0, blocking: true)
+  ORIGINAL_STDOUT = IO::FileDescriptor.new(1, blocking: true)
+  ORIGINAL_STDERR = IO::FileDescriptor.new(2, blocking: true)
+
+  protected def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)
+    src_io = to_real_fd(src_io)
+    dst_io.reopen(src_io)
+    dst_io.blocking = true
+    dst_io.close_on_exec = false
+  end
+
+  protected def self.to_real_fd(fd : IO::FileDescriptor)
+    case fd
+    when STDIN  then ORIGINAL_STDIN
+    when STDOUT then ORIGINAL_STDOUT
+    when STDERR then ORIGINAL_STDERR
+    else             fd
+    end
+  end
+
+  protected def self.exec_internal(command, args : (Array | Tuple)?, env, clear_env, input, output, error, chdir) : NoReturn
+    reopen_io(input, ORIGINAL_STDIN)
+    reopen_io(output, ORIGINAL_STDOUT)
+    reopen_io(error, ORIGINAL_STDERR)
+
+    ENV.clear if clear_env
+    env.try &.each do |key, val|
+      if val
+        ENV[key] = val
+      else
+        ENV.delete key
+      end
+    end
+
+    Dir.cd(chdir) if chdir
+
+    argv = [command.check_no_null_byte.to_unsafe]
+    args.try &.each do |arg|
+      argv << arg.check_no_null_byte.to_unsafe
+    end
+    argv << Pointer(UInt8).null
+
+    LibC.execvp(command, argv)
+
+    error_message = String.build do |io|
+      io << "execvp ("
+      command.inspect_unquoted(io)
+      args.try &.each do |arg|
+        io << ' '
+        arg.inspect(io)
+      end
+      io << ")"
+    end
+    raise Errno.new(error_message)
+  end
+
+  protected def self.prepare_shell_system(command, args)
+    command = %(#{command} "${@}") unless command.includes?(' ')
+    shell_args = ["-c", command, "--"]
+
+    if args
+      unless command.includes?(%("${@}"))
+        raise ArgumentError.new(%(can't specify arguments in both, command and args without including "${@}" into your command))
+      end
+
+      {% if flag?(:freebsd) %}
+        shell_args << ""
+      {% end %}
+
+      shell_args.concat(args)
+    end
+
+    command = "/bin/sh"
+    {command, shell_args}
+  end
+
+  # :nodoc:
+  protected def self.fork_internal(*, will_exec : Bool) : Int64?
+    newmask = uninitialized LibC::SigsetT
+    oldmask = uninitialized LibC::SigsetT
+
+    LibC.sigfillset(pointerof(newmask))
+    ret = LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), pointerof(oldmask))
+    raise Errno.new("Failed to disable signals") unless ret == 0
+
+    case pid = LibC.fork
+    when 0
+      # child:
+      pid = nil
+      if will_exec
+        # reset signal handlers, then sigmask (inherited on exec):
+        Crystal::Signal.after_fork_before_exec
+        LibC.sigemptyset(pointerof(newmask))
+        LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
+      else
+        {% unless flag?(:preview_mt) %}
+          ::Process.after_fork_child_callbacks.each(&.call)
+        {% end %}
+        LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
+      end
+    when -1
+      # error:
+      errno = Errno.value
+      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
+      raise Errno.new("fork", errno)
+    else
+      # parent:
+      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
+    end
+
+    pid.try &.to_i64
+  end
+
+  protected def close_system
+  end
+
+  protected def self.chroot_system(path : String) : Nil
+    path.check_no_null_byte
+    if LibC.chroot(path) != 0
+      raise Errno.new("Failed to chroot")
+    end
+
+    if LibC.chdir("/") != 0
+      errno = Errno.new("chdir after chroot failed")
+      errno.callstack = CallStack.new
+      errno.inspect_with_backtrace(STDERR)
+      abort("Unresolvable state, exiting...")
+    end
+  end
+
+  protected def self.times_system : Tms
+    LibC.getrusage(LibC::RUSAGE_SELF, out usage)
+    LibC.getrusage(LibC::RUSAGE_CHILDREN, out child)
+
+    Tms.new(
+      usage.ru_utime.tv_sec.to_f64 + usage.ru_utime.tv_usec.to_f64 / 1e6,
+      usage.ru_stime.tv_sec.to_f64 + usage.ru_stime.tv_usec.to_f64 / 1e6,
+      child.ru_utime.tv_sec.to_f64 + child.ru_utime.tv_usec.to_f64 / 1e6,
+      child.ru_stime.tv_sec.to_f64 + child.ru_stime.tv_usec.to_f64 / 1e6,
+    )
+  end
+end

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -24,6 +24,14 @@ class Process
     Process.exists_system?(@pid)
   end
 
+  protected def terminate_system
+    signal_system Signal::TERM
+  end
+
+  protected def interrupt_system
+    signal_system Signal::KILL
+  end
+
   protected def self.exists_system?(pid : Int64)
     ret = LibC.kill(pid, 0)
     return true if ret == 0

--- a/src/process.cr
+++ b/src/process.cr
@@ -1,7 +1,4 @@
-require "c/signal"
-require "c/stdlib"
-require "c/sys/resource"
-require "c/unistd"
+require "crystal/system/process"
 
 class Process
   # Terminate the current process immediately. All open files, pipes and sockets
@@ -9,52 +6,42 @@ class Process
   # not run any handlers registered with `at_exit`, use `::exit` for that.
   #
   # *status* is the exit status of the current process.
-  def self.exit(status = 0)
-    LibC.exit(status)
+  def self.exit(status = 0) : NoReturn
+    exit_system(status)
   end
 
   # Returns the process identifier of the current process.
-  def self.pid : LibC::PidT
-    LibC.getpid
+  def self.pid : Int64
+    pid_system
   end
 
   # Returns the process group identifier of the current process.
-  def self.pgid : LibC::PidT
+  def self.pgid : Int64
     pgid(0)
   end
 
   # Returns the process group identifier of the process identified by *pid*.
-  def self.pgid(pid : Int32) : LibC::PidT
-    ret = LibC.getpgid(pid)
-    raise Errno.new("getpgid") if ret < 0
-    ret
+  def self.pgid(pid : Int64) : Int64
+    Process.pgid_system(pid)
   end
 
   # Returns the process identifier of the parent process of the current process.
-  def self.ppid : LibC::PidT
-    LibC.getppid
+  def self.ppid : Int64
+    ppid_system
   end
 
   # Sends a *signal* to the processes identified by the given *pids*.
-  def self.kill(signal : Signal, *pids : Int)
+  def self.kill(signal : Signal, *pids : Int64) : Nil
     pids.each do |pid|
-      ret = LibC.kill(pid, signal.value)
-      raise Errno.new("kill") if ret < 0
+      Process.new(pid).kill(signal)
     end
-    nil
   end
 
   # Returns `true` if the process identified by *pid* is valid for
   # a currently registered process, `false` otherwise. Note that this
   # returns `true` for a process in the zombie or similar state.
-  def self.exists?(pid : Int)
-    ret = LibC.kill(pid, 0)
-    if ret == 0
-      true
-    else
-      return false if Errno.value == Errno::ESRCH
-      raise Errno.new("kill")
-    end
+  def self.exists?(pid : Int) : Bool
+    Process.exists_system?(pid)
   end
 
   # A struct representing the CPU current times of the process,
@@ -69,86 +56,24 @@ class Process
   # Returns a `Tms` for the current process. For the children times, only those
   # of terminated children are returned.
   def self.times : Tms
-    LibC.getrusage(LibC::RUSAGE_SELF, out usage)
-    LibC.getrusage(LibC::RUSAGE_CHILDREN, out child)
-
-    Tms.new(
-      usage.ru_utime.tv_sec.to_f64 + usage.ru_utime.tv_usec.to_f64 / 1e6,
-      usage.ru_stime.tv_sec.to_f64 + usage.ru_stime.tv_usec.to_f64 / 1e6,
-      child.ru_utime.tv_sec.to_f64 + child.ru_utime.tv_usec.to_f64 / 1e6,
-      child.ru_stime.tv_sec.to_f64 + child.ru_stime.tv_usec.to_f64 / 1e6,
-    )
+    times_system
   end
 
   # Runs the given block inside a new process and
   # returns a `Process` representing the new child process.
+  #
+  # Available only on Unix-like operating systems.
   def self.fork : Process
-    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
-
-    if pid = fork_internal(will_exec: false)
-      new pid
-    else
-      begin
-        yield
-        LibC._exit 0
-      rescue ex
-        ex.inspect_with_backtrace STDERR
-        STDERR.flush
-        LibC._exit 1
-      ensure
-        LibC._exit 254 # not reached
-      end
-    end
+    fork_system { yield }
   end
 
   # Duplicates the current process.
   # Returns a `Process` representing the new child process in the current process
   # and `nil` inside the new child process.
+  #
+  # Available only on Unix-like operating systems.
   def self.fork : Process?
-    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
-
-    if pid = fork_internal(will_exec: false)
-      new pid
-    else
-      nil
-    end
-  end
-
-  # :nodoc:
-  protected def self.fork_internal(*, will_exec : Bool)
-    newmask = uninitialized LibC::SigsetT
-    oldmask = uninitialized LibC::SigsetT
-
-    LibC.sigfillset(pointerof(newmask))
-    ret = LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), pointerof(oldmask))
-    raise Errno.new("Failed to disable signals") unless ret == 0
-
-    case pid = LibC.fork
-    when 0
-      # child:
-      pid = nil
-      if will_exec
-        # reset signal handlers, then sigmask (inherited on exec):
-        Crystal::Signal.after_fork_before_exec
-        LibC.sigemptyset(pointerof(newmask))
-        LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
-      else
-        {% unless flag?(:preview_mt) %}
-          Process.after_fork_child_callbacks.each(&.call)
-        {% end %}
-        LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
-      end
-    when -1
-      # error:
-      errno = Errno.value
-      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
-      raise Errno.new("fork", errno)
-    else
-      # parent:
-      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
-    end
-
-    pid
+    fork_system
   end
 
   # How to redirect the standard input, output and error IO of a process.
@@ -186,14 +111,14 @@ class Process
   #
   # Returns the block's value.
   def self.run(command : String, args = nil, env : Env = nil, clear_env : Bool = false, shell : Bool = false,
-               input : Stdio = Redirect::Pipe, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : String? = nil)
+               input : Stdio = Redirect::Pipe, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : String? = nil, &block : Process ->)
     process = new(command, args, env, clear_env, shell, input, output, error, chdir)
     begin
       value = yield process
       $? = process.wait
       value
     rescue ex
-      process.kill
+      process.terminate
       raise ex
     end
   end
@@ -229,7 +154,7 @@ class Process
     end
   end
 
-  getter pid : Int32
+  getter pid : Int64 = 0
 
   # A pipe to this process's input. Raises if a pipe wasn't asked when creating the process.
   getter! input : IO::FileDescriptor
@@ -240,7 +165,8 @@ class Process
   # A pipe to this process's error. Raises if a pipe wasn't asked when creating the process.
   getter! error : IO::FileDescriptor
 
-  @waitpid : Channel(Int32)
+  # channel of process exit code
+  @waitpid : Channel(Int32) = Channel(Int32).new(1)
   @wait_count = 0
 
   # Creates a process, executes it, but doesn't wait for it to complete.
@@ -256,43 +182,8 @@ class Process
     fork_output = stdio_to_fd(output, for: STDOUT)
     fork_error = stdio_to_fd(error, for: STDERR)
 
-    reader_pipe, writer_pipe = IO.pipe
-
-    if pid = Process.fork_internal(will_exec: true)
-      @pid = pid
-    else
-      begin
-        reader_pipe.close
-        writer_pipe.close_on_exec = true
-        Process.exec_internal(command, args, env, clear_env, fork_input, fork_output, fork_error, chdir)
-      rescue ex : Errno
-        writer_pipe.write_bytes(ex.errno)
-        writer_pipe.write_bytes(ex.message.try(&.bytesize) || 0)
-        writer_pipe << ex.message
-        writer_pipe.close
-      rescue ex
-        ex.inspect_with_backtrace STDERR
-        STDERR.flush
-      ensure
-        LibC._exit 127
-      end
-    end
-
-    writer_pipe.close
-    bytes = uninitialized UInt8[4]
-    if reader_pipe.read(bytes.to_slice) == 4
-      errno = IO::ByteFormat::SystemEndian.decode(Int32, bytes.to_slice)
-      message_size = reader_pipe.read_bytes(Int32)
-      if message_size > 0
-        message = String.build(message_size) { |io| IO.copy(reader_pipe, io, message_size) }
-      end
-      reader_pipe.close
-      raise Errno.new(message, errno)
-    end
-    reader_pipe.close
-
-    @waitpid = Crystal::SignalChildHandler.wait(pid)
-
+    @pid = create_and_exec(command, args, env, clear_env, fork_input, fork_output, fork_error, chdir)
+    @waitpid = wait_system
     fork_input.close unless fork_input == input || fork_input == STDIN
     fork_output.close unless fork_output == output || fork_output == STDOUT
     fork_error.close unless fork_error == error || fork_error == STDERR
@@ -344,26 +235,24 @@ class Process
     end
   end
 
-  private def initialize(@pid)
-    @waitpid = Crystal::SignalChildHandler.wait(pid)
+  protected def initialize(@pid)
+    wait_system
     @wait_count = 0
   end
 
   # See also: `Process.kill`
   def kill(sig = Signal::TERM)
-    Process.kill sig, @pid
+    signal_system sig
   end
 
   # Waits for this process to complete and closes any pipes.
   def wait : Process::Status
     close_io @input # only closed when a pipe was created but not managed by copy_io
-
     @wait_count.times do
       ex = channel.receive
       raise ex if ex
     end
     @wait_count = 0
-
     Process::Status.new(@waitpid.receive)
   ensure
     close
@@ -377,39 +266,29 @@ class Process
 
   # Whether this process is already terminated.
   def terminated?
-    @waitpid.closed? || !Process.exists?(@pid)
+    @waitpid.closed? || !exists_system?
+  end
+
+  # Closes any system resources held for the process.
+  def close
+    close_io
+    close_system
   end
 
   # Closes any pipes to the child process.
-  def close
+  def close_io
     close_io @input
     close_io @output
     close_io @error
   end
 
   # :nodoc:
-  protected def self.prepare_args(command, args, shell)
+  protected def self.prepare_args(command : String, args, shell)
     if shell
-      command = %(#{command} "${@}") unless command.includes?(' ')
-      shell_args = ["-c", command, "--"]
-
-      if args
-        unless command.includes?(%("${@}"))
-          raise ArgumentError.new(%(can't specify arguments in both, command and args without including "${@}" into your command))
-        end
-
-        {% if flag?(:freebsd) %}
-          shell_args << ""
-        {% end %}
-
-        shell_args.concat(args)
-      end
-
-      command = "/bin/sh"
-      args = shell_args
+      prepare_shell_system(command, args)
+    else
+      {command, args}
     end
-
-    {command, args}
   end
 
   private def channel
@@ -451,70 +330,14 @@ class Process
     end
   end
 
-  ORIGINAL_STDIN  = IO::FileDescriptor.new(0, blocking: true)
-  ORIGINAL_STDOUT = IO::FileDescriptor.new(1, blocking: true)
-  ORIGINAL_STDERR = IO::FileDescriptor.new(2, blocking: true)
-
-  # :nodoc:
-  protected def self.exec_internal(command, args, env, clear_env, input, output, error, chdir) : NoReturn
-    reopen_io(input, ORIGINAL_STDIN)
-    reopen_io(output, ORIGINAL_STDOUT)
-    reopen_io(error, ORIGINAL_STDERR)
-
-    ENV.clear if clear_env
-    env.try &.each do |key, val|
-      if val
-        ENV[key] = val
-      else
-        ENV.delete key
-      end
-    end
-
-    Dir.cd(chdir) if chdir
-
-    argv = [command.check_no_null_byte.to_unsafe]
-    args.try &.each do |arg|
-      argv << arg.check_no_null_byte.to_unsafe
-    end
-    argv << Pointer(UInt8).null
-
-    LibC.execvp(command, argv)
-
-    error_message = String.build do |io|
-      io << "execvp ("
-      command.inspect_unquoted(io)
-      args.try &.each do |arg|
-        io << ' '
-        arg.inspect(io)
-      end
-      io << ")"
-    end
-    raise Errno.new(error_message)
-  end
-
-  private def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)
-    src_io = to_real_fd(src_io)
-
-    dst_io.reopen(src_io)
-    dst_io.blocking = true
-    dst_io.close_on_exec = false
-  end
-
-  private def self.to_real_fd(fd : IO::FileDescriptor)
-    case fd
-    when STDIN  then ORIGINAL_STDIN
-    when STDOUT then ORIGINAL_STDOUT
-    when STDERR then ORIGINAL_STDERR
-    else             fd
-    end
-  end
-
   private def close_io(io)
     io.close if io
   end
 
   # Changes the root directory and the current working directory for the current
   # process.
+  #
+  # Available only on Unix-like operating systems.
   #
   # Security: `chroot` on its own is not an effective means of mitigation. At minimum
   # the process needs to also drop privileges as soon as feasible after the `chroot`.
@@ -526,17 +349,7 @@ class Process
   # Process.chroot("/var/empty")
   # ```
   def self.chroot(path : String) : Nil
-    path.check_no_null_byte
-    if LibC.chroot(path) != 0
-      raise Errno.new("Failed to chroot")
-    end
-
-    if LibC.chdir("/") != 0
-      errno = Errno.new("chdir after chroot failed")
-      errno.callstack = CallStack.new
-      errno.inspect_with_backtrace(STDERR)
-      abort("Unresolvable state, exiting...")
-    end
+    chroot_system(path)
   end
 end
 
@@ -588,13 +401,17 @@ def `(command) : String
 end
 
 # See also: `Process.fork`
+#
+# Available only on Unix-like operating systems.
 def fork
-  Process.fork { yield }
+  ::Process.fork { yield }
 end
 
 # See also: `Process.fork`
+#
+# Available only on Unix-like operating systems.
 def fork
-  Process.fork
+  ::Process.fork
 end
 
 require "./process/*"

--- a/src/process.cr
+++ b/src/process.cr
@@ -15,15 +15,17 @@ class Process
     pid_system
   end
 
-  # Returns the process group identifier of the current process.
-  def self.pgid : Int64
-    pgid(0)
-  end
+  {% if flag?(:unix) || flag?(:docs) %}
+    # Returns the process group identifier of the current process.
+    def self.pgid : Int64
+      pgid(0)
+    end
 
-  # Returns the process group identifier of the process identified by *pid*.
-  def self.pgid(pid : Int64) : Int64
-    Process.pgid_system(pid)
-  end
+    # Returns the process group identifier of the process identified by *pid*.
+    def self.pgid(pid : Int64) : Int64
+      Process.pgid_system(pid)
+    end
+  {% end %}
 
   # Returns the process identifier of the parent process of the current process.
   def self.ppid : Int64
@@ -59,22 +61,24 @@ class Process
     times_system
   end
 
-  # Runs the given block inside a new process and
-  # returns a `Process` representing the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  def self.fork : Process
-    fork_system { yield }
-  end
+  {% if flag?(:unix) || flag?(:docs) %}
+    # Runs the given block inside a new process and
+    # returns a `Process` representing the new child process.
+    #
+    # Available only on Unix-like operating systems.
+    def self.fork : Process
+      fork_system { yield }
+    end
 
-  # Duplicates the current process.
-  # Returns a `Process` representing the new child process in the current process
-  # and `nil` inside the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  def self.fork : Process?
-    fork_system
-  end
+    # Duplicates the current process.
+    # Returns a `Process` representing the new child process in the current process
+    # and `nil` inside the new child process.
+    #
+    # Available only on Unix-like operating systems.
+    def self.fork : Process?
+      fork_system
+    end
+  {% end %}
 
   # How to redirect the standard input, output and error IO of a process.
   enum Redirect
@@ -334,23 +338,25 @@ class Process
     io.close if io
   end
 
-  # Changes the root directory and the current working directory for the current
-  # process.
-  #
-  # Available only on Unix-like operating systems.
-  #
-  # Security: `chroot` on its own is not an effective means of mitigation. At minimum
-  # the process needs to also drop privileges as soon as feasible after the `chroot`.
-  # Changes to the directory hierarchy or file descriptors passed via `recvmsg(2)` from
-  # outside the `chroot` jail may allow a restricted process to escape, even if it is
-  # unprivileged.
-  #
-  # ```
-  # Process.chroot("/var/empty")
-  # ```
-  def self.chroot(path : String) : Nil
-    chroot_system(path)
-  end
+  {% if flag?(:unix) || flag?(:docs) %}
+    # Changes the root directory and the current working directory for the current
+    # process.
+    #
+    # Available only on Unix-like operating systems.
+    #
+    # Security: `chroot` on its own is not an effective means of mitigation. At minimum
+    # the process needs to also drop privileges as soon as feasible after the `chroot`.
+    # Changes to the directory hierarchy or file descriptors passed via `recvmsg(2)` from
+    # outside the `chroot` jail may allow a restricted process to escape, even if it is
+    # unprivileged.
+    #
+    # ```
+    # Process.chroot("/var/empty")
+    # ```
+    def self.chroot(path : String) : Nil
+      chroot_system(path)
+    end
+  {% end %}
 end
 
 # Executes the given command in a subshell.
@@ -400,18 +406,20 @@ def `(command) : String
   output
 end
 
-# See also: `Process.fork`
-#
-# Available only on Unix-like operating systems.
-def fork
-  ::Process.fork { yield }
-end
+{% if flag?(:unix) || flag?(:docs) %}
+  # See also: `Process.fork`
+  #
+  # Available only on Unix-like operating systems.
+  def fork
+    ::Process.fork { yield }
+  end
 
-# See also: `Process.fork`
-#
-# Available only on Unix-like operating systems.
-def fork
-  ::Process.fork
-end
+  # See also: `Process.fork`
+  #
+  # Available only on Unix-like operating systems.
+  def fork
+    ::Process.fork
+  end
+{% end %}
 
 require "./process/*"

--- a/src/process.cr
+++ b/src/process.cr
@@ -273,6 +273,16 @@ class Process
     @waitpid.closed? || !exists_system?
   end
 
+  # Terminate process gracefully
+  def terminate
+    terminate_system
+  end
+
+  # Terminate process immediately (kill it)
+  def interrupt
+    interrupt_system
+  end
+
   # Closes any system resources held for the process.
   def close
     close_io

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -270,13 +270,11 @@ module Crystal::SignalChildHandler
   # Process#wait through a channel, that may be created before or after the
   # child process exited.
 
-  @@pending = {} of LibC::PidT => Int32
-  @@waiting = {} of LibC::PidT => Channel(Int32)
+  @@pending = {} of Int64 => Int32
+  @@waiting = {} of Int64 => Channel(Int32)
   @@mutex = Mutex.new(:unchecked)
 
-  def self.wait(pid : LibC::PidT) : Channel(Int32)
-    channel = Channel(Int32).new(1)
-
+  def self.wait(channel : Channel(Int32), pid : Int64) : Channel(Int32)
     @@mutex.lock
     if exit_code = @@pending.delete(pid)
       @@mutex.unlock
@@ -292,7 +290,7 @@ module Crystal::SignalChildHandler
 
   def self.call : Nil
     loop do
-      pid = LibC.waitpid(-1, out exit_code, LibC::WNOHANG)
+      pid = LibC.waitpid(-1, out exit_code, LibC::WNOHANG).to_i64
 
       case pid
       when 0


### PR DESCRIPTION
Prepare Process API for Windows implementation. After discussion in #8518 i extract the system implementation which provide 
the following private interface (all methods are protected):
```
# for current running program
self.exit_system(status : Int32) : NoReturn
self.pid_system : Int64
self.ppid_system : Int64
self.fork_system(&) : Process
self.fork_system : Process?
self.chroot_system(path : String) : Nil
self.times_system : Tms

# for Process instance
terminate_system : Nil
kill_system : Nil
close_system: Nil
exist_system? : Bool
signal_system(signal : Signal) : Ni
wait_system : Nil
pgid_system : Int64
create_and_exec(command, *args, ...) : Int64

# for given pid
self.exists_system?(pid : Int64)
self.pgid_system(pid : Int64) : Int64

# util
self.prepare_shell_system(command : String, args : Enumerable(String)) : {String, Enumerable(String)}
```

Public API design for Process
There need to be some changes to remove POSIXisms and make it portable.
* ~~kill method is renamed to signal~~ move to #8642
* new methods terminate (graceful), interrupt (immediately)

Precursor PR: #8518