### PR TITLE
Adds support for __dir__, but parses it as __DIR__ (and emits __DIR__ in the code formatter)

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -400,8 +400,10 @@ describe Crystal::Formatter do
   assert_format %("foo \#{ 1  +  2 }"), %("foo \#{1 + 2}")
   assert_format %("foo \#{ 1 } \#{ __DIR__ }"), %("foo \#{1} \#{__DIR__}")
   assert_format %("foo \#{ __DIR__ }"), %("foo \#{__DIR__}")
+  assert_format %("foo \#{ __dir__ }"), %("foo \#{__DIR__}")
   assert_format "__FILE__", "__FILE__"
   assert_format "__DIR__", "__DIR__"
+  assert_format "__dir__", "__DIR__"
   assert_format "__LINE__", "__LINE__"
 
   assert_format %("\#{foo = 1\n}"), %("\#{foo = 1}")

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -373,6 +373,12 @@ describe "Lexer" do
     token.type.should eq(:__DIR__)
   end
 
+  it "lexes __dir__ as __DIR__" do
+    lexer = Lexer.new "__dir__"
+    token = lexer.next_token
+    token.type.should eq(:__DIR__)
+  end
+
   it "lexes dot and ident" do
     lexer = Lexer.new ".read"
     token = lexer.next_token

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1171,14 +1171,20 @@ module Crystal
         case next_char
         when '_'
           case next_char
-          when 'D'
-            if next_char == 'I' && next_char == 'R' && next_char == '_' && next_char == '_'
-              if ident_part_or_end?(peek_next_char)
-                scan_ident(start)
-              else
-                next_char
-                @token.type = :__DIR__
-                return @token
+          when 'D', 'd'
+            case next_char
+            when 'I', 'i'
+              case next_char
+              when 'R', 'r'
+                if next_char == '_' && next_char == '_'
+                  if ident_part_or_end?(peek_next_char)
+                    scan_ident(start)
+                  else
+                    next_char
+                    @token.type = :__DIR__
+                    return @token
+                  end
+                end
               end
             end
           when 'E'


### PR DESCRIPTION
Fixes #8546.

Would this be a good workaround? I've been doing the advent of code puzzles, and I thought it was cool that my programs were almost exactly the same for both Ruby and Crystal:

```
puts File.read(File.join(__DIR__, "input")).lines.sum { |n| (n.to_i / 3).floor.to_i - 2 }
```

```
def fuel_for(mass)
  fuel = (mass.to_i / 3).floor.to_i - 2
  return 0 if fuel <= 0
  fuel + fuel_for(fuel)
end

puts File.read(
  File.join(__DIR__, "input")
).lines.sum { |mass| fuel_for(mass) }
```

So `__DIR__` is the only difference (and it took me a little while to figure out.) I think it would just be nice to support `__dir__` in this way. I know compatibility isn't a goal, but this might reduce a little bit of friction for Rubyists.