### PR TITLE
fix(web_socket): call `on_close` for all errors

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -104,7 +104,7 @@ class HTTP::WebSocket
     loop do
       begin
         info = @ws.receive(@buffer)
-      rescue IO::Error | Errno
+      rescue
         @on_close.try &.call("")
         break
       end

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -104,7 +104,7 @@ class HTTP::WebSocket
     loop do
       begin
         info = @ws.receive(@buffer)
-      rescue IO::EOFError
+      rescue IO::Error | Errno
         @on_close.try &.call("")
         break
       end


### PR DESCRIPTION
I occasionally see `Errno` on our webserver when calling `run` and all the clean-up code is in the `on_close` callback which is not called.

Consider the [websocket handler](https://github.com/crystal-lang/crystal/blob/0e2e1d067af09e7b1e4573a7258c433e3cf8fa17/src/http/server/handlers/websocket_handler.cr#L43) in the stdlib, when run is called and an IO error such as `Errno` occurs `on_close` is never called and hence any references stored by the user defined code are leaked

Not something I'm able to replicate, hence the lack of tests, but I see it in the logs and our monitoring also confirms a leak.