### PR TITLE
add endless range fix for strings and arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -281,6 +281,15 @@ describe "Array" do
       [1, 2, 3][1, 3]?.should eq([2, 3])
       [1, 2, 3][4, 0]?.should be_nil
     end
+
+    it "gets with range without end" do
+      [1, 2, 3][1..nil]?.should eq([2, 3])
+      [1, 2, 3][4..nil]?.should be_nil
+    end
+
+    it "gets with range without beginning" do
+      [1, 2, 3][nil..1]?.should eq([1, 2])
+    end
   end
 
   describe "[]=" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -188,6 +188,15 @@ describe "String" do
       "hello"[1, 3]?.should eq("ell")
       "hello"[6, 3]?.should be_nil
     end
+
+    it "gets with range without end" do
+      "hello"[1..nil]?.should eq("ello")
+      "hello"[6..nil]?.should be_nil
+    end
+
+    it "gets with range without beginning" do
+      "hello"[nil..2]?.should eq("hel")
+    end
   end
 
   describe "byte_slice" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -537,13 +537,14 @@ class Array(T)
     self[*Indexable.range_to_index_and_count(range, size)]
   end
 
-  # Like `#[Range(Int, Int)]`, but returns `nil` if the range's start is out of range.
+  # Like `#[Range]`, but returns `nil` if the range's start is out of range.
   #
   # ```
   # a = ["a", "b", "c", "d", "e"]
   # a[6..10]? # => nil
+  # a[6..]?   # => nil
   # ```
-  def []?(range : Range(Int, Int))
+  def []?(range : Range)
     self[*Indexable.range_to_index_and_count(range, size)]?
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -752,12 +752,13 @@ class String
     self[*Indexable.range_to_index_and_count(range, size)]
   end
 
-  # Like `#[Range(Int, Int)]`, but returns `nil` if the range's start is out of range.
+  # Like `#[Range]`, but returns `nil` if the range's start is out of range.
   #
   # ```
   # "hello"[6..7]? # => nil
+  # "hello"[6..]?  # => nil
   # ```
-  def []?(range : Range(Int, Int))
+  def []?(range : Range)
     self[*Indexable.range_to_index_and_count(range, size)]?
   end
 


### PR DESCRIPTION
### Description
This basically fixes crystal-lang/crystal#8539. This behavior is observed in `array.cr` as well. So, this PR takes care of that as well.