### PR TITLE
String interpolation: combine contiguous string literals

### DIFF
--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -5,6 +5,10 @@ describe "Normalize: string interpolation" do
     assert_expand %("foo\#{bar}baz"), %(::String.interpolation("foo", bar, "baz"))
   end
 
+  it "normalizes string interpolation with multiple lines" do
+    assert_expand %("foo\n\#{bar}\nbaz\nqux\nfox"), %(::String.interpolation("foo\\n", bar, "\\nbaz\\nqux\\nfox"))
+  end
+
   it "normalizes heredoc" do
     assert_normalize "<<-FOO\nhello\nFOO", %("hello")
   end


### PR DESCRIPTION
Fixes #8576

I think this should go in 0.32.1 because this was an accidental breaking change.

The fix is done at normalization because doing it before breaks the formatter a bit (mainly around string literals that aren't actually string literals, like `__FILE__`), but this way is fine.