### PR TITLE
Fix docs of Enumerable#each_cons_pair and Iterator#cons_pair

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -321,7 +321,7 @@ module Enumerable(T)
   # but advancing one by one.
   #
   # ```
-  # [1, 2, 3, 4, 5].each_cons do |a, b|
+  # [1, 2, 3, 4, 5].each_cons_pair do |a, b|
   #   puts "#{a}, #{b}"
   # end
   # ```

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -314,7 +314,7 @@ module Iterator(T)
   # Returns an iterator that returns consecutive pairs of adjacent items.
   #
   # ```
-  # iter = (1..5).each.cons
+  # iter = (1..5).each.cons_pair
   # iter.next # => {1, 2}
   # iter.next # => {2, 3}
   # iter.next # => {3, 4}


### PR DESCRIPTION
Method names in sample codes are incorrect.
