### PR TITLE
Fix regular failing spec with preview_mt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
       - run: bin/ci with_build_env 'make crystal'
-      - run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 verbose=1 FLAGS="-D preview_mt"'
+      - run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt"'
 
   check_format:
     machine: true

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -65,11 +65,21 @@ describe HTTP::Server do
       ch.send :end
     end
 
+    # wait for the server to start listening, and a little longer
+    # so the spawn that performs the accept has chance to run
+    while !server.listening?
+      Fiber.yield
+    end
+    sleep 0.2
+
     delay(1) { ch.send :timeout }
 
     TCPSocket.open(address.address, address.port) { }
 
+    # wait before closing the server
+    sleep 0.2
     server.close
+
     ch.receive.should eq(:end)
   end
 

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -70,14 +70,14 @@ describe HTTP::Server do
     while !server.listening?
       Fiber.yield
     end
-    sleep 0.2
+    sleep 0.1
 
     delay(1) { ch.send :timeout }
 
     TCPSocket.open(address.address, address.port) { }
 
     # wait before closing the server
-    sleep 0.2
+    sleep 0.1
     server.close
 
     ch.receive.should eq(:end)


### PR DESCRIPTION
The changed spec is the one that regularly fails with preview_mt.

I was unable to narrow it down further. It only fails on CircleCI, I was not able to reproduce it locally.

The verbose flag is removed for convenience.