### PR TITLE
Spec::JUnitFormatter enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,21 +15,22 @@
 
 LLVM_CONFIG ?= ## llvm-config command path to use
 
-release ?=      ## Compile in release mode
-stats ?=        ## Enable statistics output
-progress ?=     ## Enable progress output
-threads ?=      ## Maximum number of threads to use
-debug ?=        ## Add symbolic debug info
-verbose ?=      ## Run specs in verbose mode
-junit_output ?= ## Directory to output junit results
-static ?=       ## Enable static linking
+release ?=           ## Compile in release mode
+stats ?=             ## Enable statistics output
+progress ?=          ## Enable progress output
+threads ?=           ## Maximum number of threads to use
+debug ?=             ## Add symbolic debug info
+verbose ?=           ## Run specs in verbose mode
+junit_output ?=      ## Directory to output junit results
+junit_output_path ?= ## Path to output junit results
+static ?=            ## Enable static linking
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
 override FLAGS += $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler
-SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
+SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )$(if $(junit_output_path),--junit_output_path $(junit_output_path) )
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
 EXPORTS := \
   $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src") \

--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,21 @@
 
 LLVM_CONFIG ?= ## llvm-config command path to use
 
-release ?=           ## Compile in release mode
-stats ?=             ## Enable statistics output
-progress ?=          ## Enable progress output
-threads ?=           ## Maximum number of threads to use
-debug ?=             ## Add symbolic debug info
-verbose ?=           ## Run specs in verbose mode
-junit_output ?=      ## Directory to output junit results
-junit_output_path ?= ## Path to output junit results
-static ?=            ## Enable static linking
+release ?=      ## Compile in release mode
+stats ?=        ## Enable statistics output
+progress ?=     ## Enable progress output
+threads ?=      ## Maximum number of threads to use
+debug ?=        ## Add symbolic debug info
+verbose ?=      ## Run specs in verbose mode
+junit_output ?= ## Path to output junit results
+static ?=       ## Enable static linking
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
 override FLAGS += $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler
-SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )$(if $(junit_output_path),--junit_output_path $(junit_output_path) )
+SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
 EXPORTS := \
   $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src") \

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -16,7 +16,7 @@ describe "JUnit Formatter" do
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports failures" do
@@ -33,7 +33,7 @@ describe "JUnit Formatter" do
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports errors" do
@@ -50,7 +50,7 @@ describe "JUnit Formatter" do
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "reports mixed results" do
@@ -77,7 +77,7 @@ describe "JUnit Formatter" do
                  </testsuite>
                  XML
 
-    output.chomp.should eq(expected)
+    output.should eq(expected)
   end
 
   it "escapes spec names" do
@@ -125,7 +125,7 @@ private def build_report
   formatter = Spec::JUnitFormatter.new(output)
   yield formatter
   formatter.finish(Time::Span.zero, false)
-  output.to_s
+  output.to_s.chomp
 end
 
 private def exception_with_backtrace(msg)

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -81,16 +81,19 @@ describe "JUnit Formatter" do
   it "reports mixed results" do
     now = Time.utc
 
+    this_filename = __FILE__
+
     output = build_report_with_mocked_timestamp(now) do |f|
       f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, 2.seconds, nil)
       f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, 0.5.seconds, nil)
       f.report Spec::Result.new(:error, "should do something3", "spec/some_spec.cr", 65, nil, nil)
       f.report Spec::Result.new(:error, "should do something4", "spec/some_spec.cr", 80, nil, nil)
+      f.report Spec::Result.new(:pending, "should do something5", this_filename, 90, nil, nil)
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" disabled="0" errors="2" failures="1" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="5" disabled="1" errors="2" failures="1" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>
@@ -100,6 +103,9 @@ describe "JUnit Formatter" do
                    </testcase>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something4">
                      <error/>
+                   </testcase>
+                   <testcase file="#{this_filename}" classname="spec.std.spec.junit_formatter_spec" name="should do something5">
+                     <skipped/>
                    </testcase>
                  </testsuite>
                  XML

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -109,10 +109,14 @@ describe "JUnit Formatter" do
   it "escapes spec names" do
     output = build_report do |f|
       f.report Spec::Result.new(:success, %(complicated " <n>'&ame), __FILE__, __LINE__, nil, nil)
+      f.report Spec::Result.new(:success, %(ctrl characters follow - \r\n), __FILE__, __LINE__, nil, nil)
     end
 
     name = XML.parse(output).xpath_string("string(//testsuite/testcase[1]/@name)")
     name.should eq(%(complicated \" <n>'&ame))
+
+    name = XML.parse(output).xpath_string("string(//testsuite/testcase[2]/@name)")
+    name.should eq(%(ctrl characters follow - \\r\\n))
   end
 
   it "report failure stacktrace if present" do

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -10,7 +10,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0">
+                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
@@ -26,7 +26,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0">
+                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <failure/>
                    </testcase>
@@ -43,7 +43,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0">
+                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <error/>
                    </testcase>
@@ -63,7 +63,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" disabled="0" errors="2" failures="1" time="0.0">
+                 <testsuite tests="4" disabled="0" errors="2" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -3,16 +3,14 @@ require "xml"
 
 describe "JUnit Formatter" do
   it "reports successful results" do
-    now = Time.utc
-
-    output = build_report_with_mocked_timestamp(now) do |f|
+    output = build_report_with_no_timestamp do |f|
       f.report Spec::Result.new(:success, "should do something", "spec/some_spec.cr", 33, nil, nil)
       f.report Spec::Result.new(:success, "should do something else", "spec/some_spec.cr", 50, nil, nil)
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
@@ -22,15 +20,13 @@ describe "JUnit Formatter" do
   end
 
   it "reports skipped" do
-    now = Time.utc
-
-    output = build_report_with_mocked_timestamp(now) do |f|
+    output = build_report_with_no_timestamp do |f|
       f.report Spec::Result.new(:pending, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="1" errors="0" failures="0" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="1" disabled="1" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <skipped/>
                    </testcase>
@@ -41,15 +37,13 @@ describe "JUnit Formatter" do
   end
 
   it "reports failures" do
-    now = Time.utc
-
-    output = build_report_with_mocked_timestamp(now) do |f|
+    output = build_report_with_no_timestamp do |f|
       f.report Spec::Result.new(:fail, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <failure/>
                    </testcase>
@@ -60,15 +54,13 @@ describe "JUnit Formatter" do
   end
 
   it "reports errors" do
-    now = Time.utc
-
-    output = build_report_with_mocked_timestamp(now) do |f|
+    output = build_report_with_no_timestamp do |f|
       f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil, nil)
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <error/>
                    </testcase>
@@ -79,11 +71,9 @@ describe "JUnit Formatter" do
   end
 
   it "reports mixed results" do
-    now = Time.utc
-
     this_filename = __FILE__
 
-    output = build_report_with_mocked_timestamp(now) do |f|
+    output = build_report_with_no_timestamp do |f|
       f.report Spec::Result.new(:success, "should do something1", "spec/some_spec.cr", 33, 2.seconds, nil)
       f.report Spec::Result.new(:fail, "should do something2", "spec/some_spec.cr", 50, 0.5.seconds, nil)
       f.report Spec::Result.new(:error, "should do something3", "spec/some_spec.cr", 65, nil, nil)
@@ -93,7 +83,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="5" disabled="1" errors="2" failures="1" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                 <testsuite tests="5" disabled="1" errors="2" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>
@@ -161,11 +151,11 @@ private def build_report
   output.to_s.chomp
 end
 
-private def build_report_with_mocked_timestamp(timestamp)
+private def build_report_with_no_timestamp
   output = build_report do |formatter|
     yield formatter
   end
-  output.gsub(/timestamp="(.+?)"/, %(timestamp="#{timestamp.to_rfc3339}"))
+  output.gsub(/\s*timestamp="(.+?)"/, "")
 end
 
 private def exception_with_backtrace(msg)

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -21,6 +21,25 @@ describe "JUnit Formatter" do
     output.should eq(expected)
   end
 
+  it "reports skipped" do
+    now = Time.utc
+
+    output = build_report_with_mocked_timestamp(now) do |f|
+      f.report Spec::Result.new(:pending, "should do something", "spec/some_spec.cr", 33, nil, nil)
+    end
+
+    expected = <<-XML
+                 <?xml version="1.0"?>
+                 <testsuite tests="1" disabled="1" errors="0" failures="0" time="0.0" timestamp="#{now.to_rfc3339}" hostname="#{System.hostname}">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                     <skipped/>
+                   </testcase>
+                 </testsuite>
+                 XML
+
+    output.should eq(expected)
+  end
+
   it "reports failures" do
     now = Time.utc
 

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -10,7 +10,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
+                 <testsuite tests="2" skipped="0" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
@@ -26,7 +26,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="1" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
+                 <testsuite tests="1" skipped="1" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <skipped/>
                    </testcase>
@@ -43,7 +43,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0" hostname="#{System.hostname}">
+                 <testsuite tests="1" skipped="0" errors="0" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <failure/>
                    </testcase>
@@ -60,7 +60,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
+                 <testsuite tests="1" skipped="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <error/>
                    </testcase>
@@ -80,7 +80,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" disabled="1" errors="1" failures="1" time="0.0" hostname="#{System.hostname}">
+                 <testsuite tests="4" skipped="1" errors="1" failures="1" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -10,7 +10,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" errors="0" failures="0">
+                 <testsuite tests="2" errors="0" failures="0" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
@@ -26,7 +26,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="0" failures="1">
+                 <testsuite tests="1" errors="0" failures="1" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <failure/>
                    </testcase>
@@ -43,7 +43,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="1" failures="0">
+                 <testsuite tests="1" errors="1" failures="0" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <error/>
                    </testcase>
@@ -63,9 +63,9 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" errors="2" failures="1">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1"/>
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2">
+                 <testsuite tests="4" errors="2" failures="1" time="0.0">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>
                    </testcase>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something3">

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -129,9 +129,7 @@ private def build_report
 end
 
 private def exception_with_backtrace(msg)
-  begin
-    raise Exception.new(msg)
-  rescue e
-    e
-  end
+  raise Exception.new(msg)
+rescue e
+  e
 end

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -124,7 +124,7 @@ private def build_report
   output = String::Builder.new
   formatter = Spec::JUnitFormatter.new(output)
   yield formatter
-  formatter.finish
+  formatter.finish(Time::Span.zero, false)
   output.to_s
 end
 

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -10,7 +10,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="2" errors="0" failures="0" time="0.0">
+                 <testsuite tests="2" disabled="0" errors="0" failures="0" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
                  </testsuite>
@@ -26,7 +26,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="0" failures="1" time="0.0">
+                 <testsuite tests="1" disabled="0" errors="0" failures="1" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <failure/>
                    </testcase>
@@ -43,7 +43,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="1" errors="1" failures="0" time="0.0">
+                 <testsuite tests="1" disabled="0" errors="1" failures="0" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
                      <error/>
                    </testcase>
@@ -63,7 +63,7 @@ describe "JUnit Formatter" do
 
     expected = <<-XML
                  <?xml version="1.0"?>
-                 <testsuite tests="4" errors="2" failures="1" time="0.0">
+                 <testsuite tests="4" disabled="0" errors="2" failures="1" time="0.0">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
                      <failure/>

--- a/spec/std/spec/tap_formatter_spec.cr
+++ b/spec/std/spec/tap_formatter_spec.cr
@@ -5,7 +5,7 @@ private def build_report
   String.build do |io|
     formatter = Spec::TAPFormatter.new(io)
     yield formatter
-    formatter.finish
+    formatter.finish(Time::Span.zero, false)
   end
 end
 

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -129,8 +129,12 @@ OptionParser.parse do |opts|
       abort("order must be either 'default', 'random', or a numeric seed value")
     end
   end
-  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output") do |output_dir|
-    junit_formatter = Spec::JUnitFormatter.file(output_dir)
+  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output within the given OUTPUT_DIR") do |output_dir|
+    junit_formatter = Spec::JUnitFormatter.file(Path[output_dir, "output.xml"])
+    Spec.add_formatter(junit_formatter)
+  end
+  opts.on("--junit_output_path OUTPUT_PATH", "generate JUnit XML output under the given OUTPUT_PATH") do |output_path|
+    junit_formatter = Spec::JUnitFormatter.file(Path[output_path])
     Spec.add_formatter(junit_formatter)
   end
   opts.on("--help", "show this help") do |pattern|

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -129,12 +129,8 @@ OptionParser.parse do |opts|
       abort("order must be either 'default', 'random', or a numeric seed value")
     end
   end
-  opts.on("--junit_output OUTPUT_DIR", "generate JUnit XML output within the given OUTPUT_DIR") do |output_dir|
-    junit_formatter = Spec::JUnitFormatter.file(Path[output_dir, "output.xml"])
-    Spec.add_formatter(junit_formatter)
-  end
-  opts.on("--junit_output_path OUTPUT_PATH", "generate JUnit XML output under the given OUTPUT_PATH") do |output_path|
-    junit_formatter = Spec::JUnitFormatter.file(Path[output_path])
+  opts.on("--junit_output OUTPUT_PATH", "generate JUnit XML output within the given OUTPUT_PATH") do |output_path|
+    junit_formatter = Spec::JUnitFormatter.file(Path.new(output_path))
     Spec.add_formatter(junit_formatter)
   end
   opts.on("--help", "show this help") do |pattern|

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -65,7 +65,7 @@ module Spec
     end
 
     def finish(elapsed_time, aborted = false)
-      Spec.formatters.each(&.finish)
+      Spec.formatters.each(&.finish(elapsed_time, aborted))
       Spec.formatters.each(&.print_results(elapsed_time, aborted))
     end
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -45,19 +45,17 @@ module Spec
     end
 
     private def internal_run(start, block)
-      begin
-        @parent.run_before_each_hooks
-        block.call
-        @parent.report(:success, description, file, line, Time.monotonic - start)
-      rescue ex : Spec::AssertionFailed
-        @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      rescue ex
-        @parent.report(:error, description, file, line, Time.monotonic - start, ex)
-        Spec.abort! if Spec.fail_fast?
-      ensure
-        @parent.run_after_each_hooks
-      end
+      @parent.run_before_each_hooks
+      block.call
+      @parent.report(:success, description, file, line, Time.monotonic - start)
+    rescue ex : Spec::AssertionFailed
+      @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
+      Spec.abort! if Spec.fail_fast?
+    rescue ex
+      @parent.report(:error, description, file, line, Time.monotonic - start, ex)
+      Spec.abort! if Spec.fail_fast?
+    ensure
+      @parent.run_after_each_hooks
     end
   end
 end

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -16,7 +16,7 @@ module Spec
     def report(result)
     end
 
-    def finish
+    def finish(elapsed_time, aborted)
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
@@ -30,7 +30,7 @@ module Spec
       @io.flush
     end
 
-    def finish
+    def finish(elapsed_time, aborted)
       @io.puts
     end
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -100,7 +100,12 @@ module Spec
     end
 
     private def classname(result)
-      result.file.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+      path = Path[result.file].expand
+      path.to_s
+        .lchop(Dir.current)
+        .rchop(path.extension)
+        .gsub(File::SEPARATOR, '.')
+        .strip('.')
     end
   end
 end

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -18,7 +18,7 @@ module Spec
       io = @io
       io.puts %(<?xml version="1.0"?>)
       io << %(<testsuite tests=") << @results.size
-      io << %(" disabled=") << (@summary[:pending]? || 0)
+      io << %(" skipped=") << (@summary[:pending]? || 0)
       io << %(" errors=") << (@summary[:error]? || 0)
       io << %(" failures=") << (@summary[:fail]? || 0)
       io << %(" time=") << elapsed_time.to_f

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -17,7 +17,9 @@ module Spec
       io.puts %(<?xml version="1.0"?>)
       io << %(<testsuite tests=") << @results.size
       io << %(" errors=") << (@summary[:error]? || 0)
-      io << %(" failures=") << (@summary[:fail]? || 0) << %(">)
+      io << %(" failures=") << (@summary[:fail]? || 0)
+      io << %(" time=") << elapsed_time.to_f
+      io << %(">)
 
       io.puts
 
@@ -42,6 +44,11 @@ module Spec
       HTML.escape(classname(result), io)
       io << %(" name=")
       HTML.escape(result.description, io)
+
+      if elapsed = result.elapsed
+        io << %(" time=")
+        io << elapsed.to_f
+      end
 
       if tag = inner_content_tag(result.kind)
         io.puts %(">)

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -21,7 +21,7 @@ module Spec
       io << %(" skipped=") << (@summary[:pending]? || 0)
       io << %(" errors=") << (@summary[:error]? || 0)
       io << %(" failures=") << (@summary[:fail]? || 0)
-      io << %(" time=") << elapsed_time.to_f
+      io << %(" time=") << elapsed_time.total_seconds
       io << %(" timestamp=") << @started_at.to_rfc3339
       io << %(" hostname=") << System.hostname
       io << %(">)
@@ -52,7 +52,7 @@ module Spec
 
       if elapsed = result.elapsed
         io << %(" time=")
-        io << elapsed.to_f
+        io << elapsed.total_seconds
       end
 
       if tag = inner_content_tag(result.kind)

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -20,6 +20,7 @@ module Spec
       io << %(" errors=") << (@summary[:error]? || 0)
       io << %(" failures=") << (@summary[:fail]? || 0)
       io << %(" time=") << elapsed_time.to_f
+      io << %(" hostname=") << System.hostname
       io << %(">)
 
       io.puts

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -16,6 +16,7 @@ module Spec
       io = @io
       io.puts %(<?xml version="1.0"?>)
       io << %(<testsuite tests=") << @results.size
+      io << %(" disabled=") << (@summary[:pending]? || 0)
       io << %(" errors=") << (@summary[:error]? || 0)
       io << %(" failures=") << (@summary[:fail]? || 0)
       io << %(" time=") << elapsed_time.to_f

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -58,7 +58,7 @@ module Spec
       if tag = inner_content_tag(result.kind)
         io.puts %(">)
 
-        if exception = result.exception
+        if (exception = result.exception) && result.kind != :pending
           write_inner_content(tag, exception, io)
         else
           io << "    <" << tag << "/>\n"
@@ -71,8 +71,9 @@ module Spec
 
     private def inner_content_tag(kind)
       case kind
-      when :error then "error"
-      when :fail  then "failure"
+      when :error   then "error"
+      when :fail    then "failure"
+      when :pending then "skipped"
       end
     end
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -3,6 +3,8 @@ require "html"
 module Spec
   # :nodoc:
   class JUnitFormatter < Formatter
+    @started_at = Time.utc
+
     @results = [] of Spec::Result
     @summary = {} of Symbol => Int32
 
@@ -20,6 +22,7 @@ module Spec
       io << %(" errors=") << (@summary[:error]? || 0)
       io << %(" failures=") << (@summary[:fail]? || 0)
       io << %(" time=") << elapsed_time.to_f
+      io << %(" timestamp=") << @started_at.to_rfc3339
       io << %(" hostname=") << System.hostname
       io << %(">)
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -41,6 +41,21 @@ module Spec
       JUnitFormatter.new(file)
     end
 
+    private def escape_xml_attr(value)
+      String.build do |io|
+        reader = Char::Reader.new(value)
+        while reader.has_next?
+          case current_char = reader.current_char
+          when .control?
+            current_char.to_s.inspect_unquoted(io)
+          else
+            current_char.to_s(io)
+          end
+          reader.next_char
+        end
+      end
+    end
+
     # -------- private utility methods
     private def write_report(result, io)
       io << %(  <testcase file=")
@@ -48,7 +63,7 @@ module Spec
       io << %(" classname=")
       HTML.escape(classname(result), io)
       io << %(" name=")
-      HTML.escape(result.description, io)
+      HTML.escape(escape_xml_attr(result.description), io)
 
       if elapsed = result.elapsed
         io << %(" time=")

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -34,10 +34,9 @@ module Spec
       io.close
     end
 
-    def self.file(output_dir)
-      Dir.mkdir_p(output_dir)
-      output_file_path = File.join(output_dir, "output.xml")
-      file = File.new(output_file_path, "w")
+    def self.file(output_path : Path)
+      Dir.mkdir_p(output_path.dirname)
+      file = File.new(output_path, "w")
       JUnitFormatter.new(file)
     end
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -12,7 +12,7 @@ module Spec
       @results << result
     end
 
-    def finish
+    def finish(elapsed_time, aborted)
       io = @io
       io.puts %(<?xml version="1.0"?>)
       io << %(<testsuite tests=") << @results.size

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -80,6 +80,11 @@ module Spec
         HTML.escape(message, io)
         io << '"'
       end
+      if tag == :error
+        io << %( type=")
+        io << exception.class.name
+        io << '"'
+      end
       io << '>'
 
       if backtrace = exception.backtrace?

--- a/src/spec/tap_formatter.cr
+++ b/src/spec/tap_formatter.cr
@@ -23,7 +23,7 @@ class Spec::TAPFormatter < Spec::Formatter
     @io.puts
   end
 
-  def finish
+  def finish(elapsed_time, aborted)
     @io << "1.." << @counter
     @io.puts
   end


### PR DESCRIPTION
- Outputs elapsed time for testsuite and single testcases
- Outputs timestamp for testsuite
- Outputs hostname for testsuite
- Outputs exception class name as an `<error type="...">` attribute
- Escapes control characters within `<testcase name="...">` attribute
- Marks `pending` testcases as `skipped`
- Returns count for `skipped` testcases (from `pending`)
- `<testcase classname="...">` is now built from relative path (to `Dir.current`)
- Changes `—junit_output` flag to take full path to the junit xml file, instead of just a directory