### PR TITLE
Fix for "NamedTuple Compilation Failure on 0.32.0"

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1224,5 +1224,10 @@ describe "Hash" do
       h = ({} of String => Int32).compare_by_identity
       h.clone.compare_by_identity?.should be_true
     end
+
+    it "compiles" do
+      h = Hash(NoReturn, NoReturn).new
+      h.has_key?(nil).should be_false
+    end
   end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -935,11 +935,11 @@ class Hash(K, V)
         if key.responds_to?(:object_id)
           entry_key.object_id == key.object_id
         else
-          false
+          return false
         end
       elsif key.responds_to?(:object_id)
         # because entry_key doesn't respond to :object_id
-        false
+        return false
       else
         entry_key == key
       end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -908,7 +908,7 @@ class Hash(K, V)
     else
       hash = key.hash.to_u32!
     end
-    hash == 0 ? UInt32::MAX : hash
+    hash == 0_u32 ? UInt32::MAX : hash
   end
 
   private def entry_matches?(entry, hash, key)


### PR DESCRIPTION
Possible fix for https://github.com/crystal-lang/crystal/issues/8595.

Includes a test demonstrating the failure/bug as well as a fix. I'm not super-satisfied because it seems like the broken code **should** work, which indicates a possible root-cause elsewhere.

Even something as seemingly innocuous as adding an alternative that returns a literal `false` is enough to break it again:
```
if @compare_by_identity && entry_key.responds_to?(:object_id) && key.responds_to?(:object_id)
  entry_key.object_id == key.object_id
elsif @compare_by_identity
  false
else
  ...
  ...
```

Interestingly, return a `nil` succeeds:
```
if @compare_by_identity && entry_key.responds_to?(:object_id) && key.responds_to?(:object_id)
  entry_key.object_id == key.object_id
elsif @compare_by_identity
  nil
else
  ...
  ...
```
