### PR TITLE
[BUG] CSV cell String containing number only must be escaped with quotes

### DIFF
--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -158,6 +158,7 @@ class CSV::Builder
     private def needs_quotes?(value : String)
       case @quoting
       when .rfc?
+        return true if value =~ /\d+/ 
         value.each_byte do |byte|
           case byte.unsafe_chr
           when @separator, @quote_char, '\n'


### PR DESCRIPTION
## Current Behavior

Writing cell with a string number then importing in excel of libre office will let the tool treat it as a number. 

For example:

```crystal
require "csv"

str = CSV.build do |csv|
  csv.row "015551234" #Assuming first column is a phone number
end

str.to_s # "015551234"
```

This would be imported as `15551234` in Excel of Libre Office.

## Expected behavior

The output should be quoted: `"015551234"`.

Currently there's zero way to quote this number, as using `"` character will lead to quote escaping:

```crystal
require "csv"

str = CSV.build do |csv|
  csv.row "\"015551234\"" 
end

str.to_s # ""015551234""
```

@ Crystal team: I'm just waiting for direction (actually I'm not sure about RFC for CSV on theses cases) before creating specs and real PR

Thanks :)