### PR TITLE
Custom yaml tags

### DIFF
--- a/spec/std/yaml/schema/core_spec.cr
+++ b/spec/std/yaml/schema/core_spec.cr
@@ -201,6 +201,38 @@ describe YAML::Schema::Core do
   it_parses "!!float 0", 0.0
   it_parses "!!float 2.3e4", 2.3e4
 
+  # Crystal tags
+  describe "crystal" do
+    describe "env" do
+      context "that exists" do
+        ENV["TEST_VAR"] = "yes"
+        it_parses "!crystal/env TEST_VAR", "yes"
+      end
+
+      context "that does not exist" do
+        it "should raise an exception" do
+          expect_raises KeyError, %(Missing ENV key: "FOO") do
+            YAML::Schema::Core.parse("!crystal/env FOO")
+          end
+        end
+      end
+    end
+
+    describe "env?" do
+      context "that exists" do
+        ENV["TEST_VAR"] = "yes"
+        it_parses "!crystal/env? TEST_VAR", "yes"
+      end
+
+      context "that does not exist" do
+        it_parses "!crystal/env? FOO", nil
+      end
+    end
+  end
+
+  # Custom tags
+  it_parses "!double 10", 20
+
   it "parses !!float .nan" do
     YAML::Schema::Core.parse("!!float .nan").as_f.nan?.should be_true
   end

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -304,10 +304,14 @@ class YAMLCircle < YAMLShape
   property radius : Int32
 end
 
-describe "YAML::Serializable" do
+describe YAML::Serializable do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
     YAMLAttrPoint.from_yaml("---\nx: 1\ny: 2\n").should eq YAMLAttrPoint.new(1, 2)
+  end
+
+  it "works with a custom tag processor" do
+    YAMLAttrPoint.from_yaml("---\nx: 1\ny: !double 2\n").should eq YAMLAttrPoint.new(1, 4)
   end
 
   it "empty class" do

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -1,6 +1,10 @@
 require "spec"
 require "yaml"
 
+YAML.add_tag_handler "!double" do |value|
+  value.to_i64 * 2
+end
+
 describe "YAML" do
   describe "parser" do
     it { YAML.parse("foo").should eq("foo") }

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -75,6 +75,14 @@ require "base64"
 # File.open("foo.yml", "w") { |f| {hello: "world"}.to_yaml(f) } # writes it to the file
 # ```
 module YAML
+  private alias HandlerResponse = Bool | Float64 | Int64 | String | Time | Nil
+
+  class_getter tag_handlers : Hash(String, Proc(String, HandlerResponse)) { Hash(String, Proc(String, HandlerResponse)).new }
+
+  def self.add_tag_handler(tag : String, &block : String -> HandlerResponse) : Nil
+    tag_handlers[tag] = block
+  end
+
   class Error < Exception
   end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -26,7 +26,12 @@ private def parse_scalar(ctx, node, type : T.class) forall T
   end
 
   if node.is_a?(YAML::Nodes::Scalar)
-    value = YAML::Schema::Core.parse_scalar(node)
+    value = if (tag = node.tag) && (handler = YAML.tag_handlers[tag]?)
+              handler.call node.value
+            else
+              YAML::Schema::Core.parse_scalar(node)
+            end
+
     if value.is_a?(T)
       ctx.record_anchor(node, value)
       value
@@ -58,7 +63,12 @@ def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   end
 
   if node.is_a?(YAML::Nodes::Scalar)
-    value = node.value
+    value = if (tag = node.tag) && (handler = YAML.tag_handlers[tag]?)
+              handler.call(node.value).to_s
+            else
+              node.value
+            end
+
     ctx.record_anchor(node, value)
     value
   else

--- a/src/yaml/nodes/parser.cr
+++ b/src/yaml/nodes/parser.cr
@@ -66,6 +66,11 @@ class YAML::Nodes::Parser < YAML::Parser
   end
 
   def process_tag(tag, &block)
+    node = Scalar.new @pull_parser.value
+    node.tag = tag
+
+    @pull_parser.read_next
+    yield node
   end
 
   def add_to_documents(documents, document)

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -288,6 +288,10 @@ module YAML::Schema::Core
       yield source.value
     when "tag:yaml.org,2002:timestamp"
       yield parse_time(source.value, source.location)
+    when "!crystal/env"
+      yield ENV[source.value]
+    when "!crystal/env?"
+      yield ENV[source.value]?
     else
       if handler = YAML.tag_handlers[tag]?
         yield handler.call source.value

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -288,10 +288,14 @@ module YAML::Schema::Core
       yield source.value
     when "tag:yaml.org,2002:timestamp"
       yield parse_time(source.value, source.location)
+    else
+      if handler = YAML.tag_handlers[tag]?
+        yield handler.call source.value
+      end
     end
   end
 
-  private def self.parse_null?(string)
+  private def self.parse_null?(string : String) : Bool
     case string
     when .empty?, "~", "null", "Null", "NULL"
       true
@@ -300,7 +304,7 @@ module YAML::Schema::Core
     end
   end
 
-  private def self.parse_bool?(string)
+  private def self.parse_bool?(string : String) : Bool?
     case string
     when "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON"
       true
@@ -311,20 +315,20 @@ module YAML::Schema::Core
     end
   end
 
-  private def self.parse_number?(string)
+  private def self.parse_number?(string : String) : Number::Primitive?
     parse_int?(string) || parse_float?(string)
   end
 
-  private def self.parse_int?(string)
+  private def self.parse_int?(string : String) : Int::Primitive?
     string.to_i64?(underscore: true, leading_zero_is_octal: true)
   end
 
-  private def self.parse_float?(string)
+  private def self.parse_float?(string : String) : Float::Primitive?
     string = string.delete('_') if string.includes?('_')
     string.to_f64?
   end
 
-  private def self.parse_float_infinity_and_nan?(string)
+  private def self.parse_float_infinity_and_nan?(string : String) : Float64?
     case string
     when ".inf", ".Inf", ".INF", "+.inf", "+.Inf", "+.INF"
       Float64::INFINITY
@@ -337,7 +341,7 @@ module YAML::Schema::Core
     end
   end
 
-  private def self.parse_time?(string)
+  private def self.parse_time?(string : String) : Time?
     # Minimum length is that of YYYY-M-D
     return nil if string.size < 8
 


### PR DESCRIPTION
Resolves #8598

Implementation TBD, but this is at least a start.  Assumes tags are registered globally and affect all `YAML.parse` and `from_yaml` calls.

Also implements custom `!crystal/env` and `!crystal/env?` tags within the stdlib itself.

TODO:
- [ ] I suppose I should allow custom handlers in the failsafe schema, just cast the result to strings.