### PR TITLE
Formatter: remove unnecessary escape sequences 

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -122,7 +122,7 @@ describe Doc::Generator do
         a_def.doc = "Some Method"
         a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
         doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_summary.should eq %(<p>Some Method</p>\n\n<p><span class=\"flag red\">DEPRECATED</span>  don't use me</p>\n\n)
+        doc_method.formatted_summary.should eq %(<p>Some Method</p>\n\n<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
       end
     end
 
@@ -185,7 +185,7 @@ describe Doc::Generator do
         a_def.doc = "Some Method"
         a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
         doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p><span class=\"flag red\">DEPRECATED</span>  don't use me</p>\n\n)
+        doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
       end
     end
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -406,6 +406,11 @@ describe Crystal::Formatter do
   assert_format "__DIR__", "__DIR__"
   assert_format "__LINE__", "__LINE__"
 
+  assert_format %q("\\\"\#\a\b\n\r\t\v\f\e")
+  assert_format %q("\a\c\b\d"), %q("\ac\bd")
+  assert_format %q("\\\"\#\a\b\n\r\t#{foo}\v\f\e")
+  assert_format %q("\a\c#{foo}\b\d"), %q("\ac#{foo}\bd")
+
   assert_format %("\#{foo = 1\n}"), %("\#{foo = 1}")
   assert_format %("\#{\n  foo = 1\n}")
   assert_format %("\#{\n  foo = 1}"), %("\#{\n  foo = 1\n}")

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -81,8 +81,8 @@ module Crystal
     it_parses ":[]=", "[]=".symbol
     it_parses ":[]?", "[]?".symbol
     it_parses %(:"\\\\foo"), "\\foo".symbol
-    it_parses %(:"\\\"foo"), "\"foo".symbol
-    it_parses %(:"\\\"foo\\\""), "\"foo\"".symbol
+    it_parses %(:"\\"foo"), "\"foo".symbol
+    it_parses %(:"\\"foo\\""), "\"foo\"".symbol
     it_parses %(:"\\a\\b\\n\\r\\t\\v\\f\\e"), "\a\b\n\r\t\v\f\e".symbol
     it_parses %(:"\\u{61}"), "a".symbol
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -69,7 +69,7 @@ describe "ASTNode#to_s" do
   expect_to_s "def foo(x : T = 1)\nend"
   expect_to_s "def foo(x : X, y : Y) forall X, Y\nend"
   expect_to_s %(foo : A | (B -> C))
-  expect_to_s %[%("\#{foo}")], %["\\\"\#{foo}\\\""]
+  expect_to_s %[%("\#{foo}")], %["\\"\#{foo}\\""]
   expect_to_s "class Foo\n  private def bar\n  end\nend"
   expect_to_s "foo(&.==(2))"
   expect_to_s "foo.nil?"

--- a/spec/compiler/semantic/responds_to_spec.cr
+++ b/spec/compiler/semantic/responds_to_spec.cr
@@ -10,7 +10,7 @@ describe "Semantic: responds_to?" do
       require "primitives"
 
       a = 1 || 'a'
-      if a.responds_to?(:\"+\")
+      if a.responds_to?(:"+")
         a
       end
       )

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -23,7 +23,7 @@ describe "ECR" do
       %(__str__ << " 2 "),
       %(#<loc:push>#<loc:"foo.cr",2,25> end #<loc:pop>),
       %(__str__ << "\\n"),
-      %(#<loc:push>#<loc:\"foo.cr\",3,3> # skip #<loc:pop>),
+      %(#<loc:push>#<loc:"foo.cr",3,3> # skip #<loc:pop>),
       %(__str__ << " "),
       %(__str__ << "<% \\"string\\" %>"),
     ]

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -128,7 +128,7 @@ describe "JUnit Formatter" do
     end
 
     name = XML.parse(output).xpath_string("string(//testsuite/testcase[1]/@name)")
-    name.should eq(%(complicated \" <n>'&ame))
+    name.should eq(%(complicated " <n>'&ame))
 
     name = XML.parse(output).xpath_string("string(//testsuite/testcase[2]/@name)")
     name.should eq(%(ctrl characters follow - \\r\\n))

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1527,7 +1527,7 @@ describe "String" do
   it "#dump" do
     "a".dump.should eq %("a")
     "\\".dump.should eq %("\\\\")
-    "\"".dump.should eq %("\\\"")
+    "\"".dump.should eq %("\\"")
     "\a".dump.should eq %("\\a")
     "\b".dump.should eq %("\\b")
     "\e".dump.should eq %("\\e")
@@ -1555,7 +1555,7 @@ describe "String" do
   it "#inspect" do
     "a".inspect.should eq %("a")
     "\\".inspect.should eq %("\\\\")
-    "\"".inspect.should eq %("\\\"")
+    "\"".inspect.should eq %("\\"")
     "\a".inspect.should eq %("\\a")
     "\b".inspect.should eq %("\\b")
     "\e".inspect.should eq %("\\e")

--- a/spec/std/xml/builder_spec.cr
+++ b/spec/std/xml/builder_spec.cr
@@ -10,7 +10,7 @@ end
 
 describe XML::Builder do
   it "writes document" do
-    assert_built(%[<?xml version=\"1.0\"?>\n\n]) do
+    assert_built(%[<?xml version="1.0"?>\n\n]) do
     end
   end
 
@@ -73,7 +73,7 @@ describe XML::Builder do
   end
 
   it "writes element with namespace" do
-    assert_built(%[<?xml version=\"1.0\"?>\n<foo xmlns=\"bar\">baz</foo>\n]) do
+    assert_built(%[<?xml version="1.0"?>\n<foo xmlns="bar">baz</foo>\n]) do
       element(nil, "foo", "bar") do
         text "baz"
       end
@@ -81,7 +81,7 @@ describe XML::Builder do
   end
 
   it "writes element with prefix" do
-    assert_built(%[<?xml version=\"1.0\"?>\n<foo:bar>baz</foo:bar>\n]) do
+    assert_built(%[<?xml version="1.0"?>\n<foo:bar>baz</foo:bar>\n]) do
       element("foo", "bar", nil) do
         text "baz"
       end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -740,7 +740,7 @@ module Crystal
             raise "invalid char escape sequence '\\#{char2}'", line, column
           end
         when '\''
-          raise "invalid empty char literal (did you mean '\\\''?)", line, column
+          raise "invalid empty char literal (did you mean '\\''?)", line, column
         when '\0'
           raise "unterminated char literal", line, column
         else

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -737,7 +737,7 @@ module Crystal
           when '\0'
             raise "unterminated char literal", line, column
           else
-            raise "invalid char escape sequence", line, column
+            raise "invalid char escape sequence '\\#{char2}'", line, column
           end
         when '\''
           raise "invalid empty char literal (did you mean '\\\''?)", line, column
@@ -1895,6 +1895,8 @@ module Crystal
     end
 
     def next_string_token(delimiter_state)
+      reset_token
+
       @token.line_number = @line_number
       @token.delimiter_state = delimiter_state
 
@@ -1941,6 +1943,14 @@ module Crystal
             end
           else
             case char = next_char
+            when '\\'
+              string_token_escape_value "\\"
+            when string_end
+              string_token_escape_value string_end.to_s
+            when string_nest
+              string_token_escape_value string_nest.to_s
+            when '#'
+              string_token_escape_value "#"
             when 'a'
               string_token_escape_value "\a"
             when 'b'
@@ -2003,6 +2013,7 @@ module Crystal
             else
               @token.type = :STRING
               @token.value = current_char.to_s
+              @token.invalid_escape = true
               next_char
             end
           end
@@ -2129,6 +2140,8 @@ module Crystal
     end
 
     def next_macro_token(macro_state, skip_whitespace)
+      reset_token
+
       nest = macro_state.nest
       control_nest = macro_state.control_nest
       whitespace = macro_state.whitespace
@@ -2626,6 +2639,8 @@ module Crystal
     end
 
     def next_string_array_token
+      reset_token
+
       while true
         if current_char == '\n'
           next_char
@@ -2879,6 +2894,7 @@ module Crystal
       @token.location = nil
       @token.passed_backslash_newline = false
       @token.doc_buffer = nil unless @token.type == :SPACE || @token.type == :NEWLINE
+      @token.invalid_escape = false
       @token_end_location = nil
     end
 

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -14,6 +14,7 @@ module Crystal
     property doc_buffer : IO::Memory?
     property raw : String
     property start : Int32
+    property invalid_escape : Bool
 
     record MacroState,
       whitespace : Bool,
@@ -76,6 +77,7 @@ module Crystal
       @passed_backslash_newline = false
       @raw = ""
       @start = 0
+      @invalid_escape = false
     end
 
     def doc

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -472,7 +472,11 @@ module Crystal
       while true
         case @token.type
         when :STRING
-          write @token.raw
+          if @token.invalid_escape
+            write @token.value
+          else
+            write @token.raw
+          end
           next_string_token
         when :INTERPOLATION_START
           # This is the case of #{__DIR__}
@@ -583,7 +587,11 @@ module Crystal
             write "}"
             @token.delimiter_state = delimiter_state
           else
-            write @token.raw
+            if @token.invalid_escape
+              write @token.value
+            else
+              write @token.raw
+            end
           end
           next_string_token
         else

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -300,8 +300,8 @@ class Regex
   # Returns a `String` constructed by escaping any metacharacters in *str*.
   #
   # ```
-  # string = Regex.escape("\*?{}.") # => "\\*\\?\\{\\}\\."
-  # /#{string}/                     # => /\*\?\{\}\./
+  # string = Regex.escape("*?{}.") # => "\\*\\?\\{\\}\\."
+  # /#{string}/                    # => /\*\?\{\}\./
   # ```
   def self.escape(str) : String
     String.build do |result|


### PR DESCRIPTION
After https://github.com/crystal-lang/crystal/issues/8459, I'd like to make invalid escape sequences a syntax error. The first step towards doing that is to introduce a warning, and to make the formatter automatically correct this mistake.

However, I found plumbing the warning apparatus (in `Program`, which is a hell class) through to the `Parser` painful, so I left it out for now.

I'd like feedback on whether a warning should necessarily be required before making this change, given that the formatter can fix it automatically. And if not, how is the best way to plumb this (duplicate the code, or pass the whole `Program` into the `Parser`?)