### PR TITLE
Tweak CI scripts a bit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,4 +684,3 @@ workflows:
             - dist_darwin
             - dist_snap
             - dist_docs
-

--- a/bin/ci
+++ b/bin/ci
@@ -73,8 +73,6 @@ prepare_system() {
 }
 
 build() {
-  with_build_env 'make std_spec clean threads=1'
-
   case $ARCH in
     i386)
       with_build_env 'make crystal threads=1'


### PR DESCRIPTION
This PR removes an additional (?) `make std_spec clean` call in `bin/ci build` task.