### PR TITLE
Fix File.size and File.info to work with Path parameters

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -143,7 +143,7 @@ class File < IO::FileDescriptor
   # File.info("bar", follow_symlinks: false).type.symlink? # => true
   # ```
   def self.info(path : Path | String, follow_symlinks = true) : Info
-    info?(path, follow_symlinks) || raise Errno.new("Unable to get info for '#{path.inspect_unquoted}''")
+    info?(path, follow_symlinks) || raise Errno.new("Unable to get info for '#{path.to_s.inspect_unquoted}''")
   end
 
   # Returns `true` if *path* exists else returns `false`
@@ -175,7 +175,7 @@ class File < IO::FileDescriptor
   def self.size(filename : Path | String) : UInt64
     info(filename).size
   rescue ex : Errno
-    raise Errno.new("Error determining size of '#{filename.inspect_unquoted}'", ex.errno)
+    raise Errno.new("Error determining size of '#{filename.to_s.inspect_unquoted}'", ex.errno)
   end
 
   # Returns `true` if the file at *path* is empty, otherwise returns `false`.


### PR DESCRIPTION
Currently, `File.size` and `File.info` do not work with `Path` parameter types because the error path tries to call `inspect_unquoted`, which is only available for `String`s. 

This path simply call `to_s` on the `Path` parameters to convert them back to strings.