### PR TITLE
Rename Process kill methods to signal

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -159,24 +159,24 @@ describe Process do
     end
   end
 
-  describe "kill" do
+  describe "signal" do
     it "kills a process" do
       process = Process.new("yes")
-      process.kill(Signal::KILL).should be_nil
+      process.signal(Signal::KILL).should be_nil
     end
 
     it "kills many process" do
       process1 = Process.new("yes")
       process2 = Process.new("yes")
-      process1.kill(Signal::KILL).should be_nil
-      process2.kill(Signal::KILL).should be_nil
+      process1.signal(Signal::KILL).should be_nil
+      process2.signal(Signal::KILL).should be_nil
     end
   end
 
   it "gets the pgid of a process id" do
     process = Process.new("yes")
     Process.pgid(process.pid).should be_a(Int32)
-    process.kill(Signal::KILL)
+    process.signal(Signal::KILL)
     Process.pgid.should eq(Process.pgid(Process.pid))
   end
 

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -228,6 +228,20 @@ describe Process do
     process.terminated?.should be_true
   end
 
+  it "checks for existence after terminate" do
+    process = Process.new("yes")
+    process.exists?.should be_true
+    process.terminated?.should be_false
+
+    process.terminate
+    process.exists?.should be_true
+    process.terminated?.should be_false
+
+    process.wait
+    process.exists?.should be_false
+    process.terminated?.should be_true
+  end
+
   describe "executable_path" do
     it "searches executable" do
       Process.executable_path.should be_a(String | Nil)

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -11,7 +11,7 @@ describe "Signal" do
     Signal::USR1.trap do
       ran = true
     end
-    Process.kill Signal::USR1, Process.pid
+    Process.signal Signal::USR1, Process.pid
     10.times do |i|
       break if ran
       sleep 0.1
@@ -21,7 +21,7 @@ describe "Signal" do
 
   it "ignores a signal" do
     Signal::USR2.ignore
-    Process.kill Signal::USR2, Process.pid
+    Process.signal Signal::USR2, Process.pid
   end
 
   it "CHLD.reset sets default Crystal child handler" do

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -161,7 +161,7 @@ module Crystal::Playground
         @logger.info "Code execution killed (session=#{@session_key}, filename=#{@running_process_filename})."
         @process = nil
         File.delete @running_process_filename rescue nil
-        process.kill rescue nil
+        process.signal rescue nil
       end
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -161,7 +161,7 @@ module Crystal::Playground
         @logger.info "Code execution killed (session=#{@session_key}, filename=#{@running_process_filename})."
         @process = nil
         File.delete @running_process_filename rescue nil
-        process.signal rescue nil
+        process.signal(::Signal::TERM) rescue nil
       end
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -161,7 +161,7 @@ module Crystal::Playground
         @logger.info "Code execution killed (session=#{@session_key}, filename=#{@running_process_filename})."
         @process = nil
         File.delete @running_process_filename rescue nil
-        process.signal(::Signal::TERM) rescue nil
+        process.terminate rescue nil
       end
     end
 

--- a/src/concurrent/future.cr
+++ b/src/concurrent/future.cr
@@ -121,7 +121,7 @@ end
 # Access to get is synchronized between fibers. *&block* is only called once.
 # May be canceled before *&block* is called by calling `cancel`.
 # ```
-# d = delay(1) { Process.kill(Signal::KILL, Process.pid) }
+# d = delay(1) { Process.signal(Signal::KILL, Process.pid) }
 # # ... long operations ...
 # d.cancel
 # ```

--- a/src/process.cr
+++ b/src/process.cr
@@ -35,8 +35,17 @@ class Process
     LibC.getppid
   end
 
-  # Sends a *signal* to the processes identified by the given *pids*.
+  @[Deprecated("Use #signal instead")]
   def self.kill(signal : Signal, *pids : Int)
+    pids.each do |pid|
+      ret = LibC.kill(pid, signal.value)
+      raise Errno.new("kill") if ret < 0
+    end
+    nil
+  end
+
+  # Sends a *signal* to the processes identified by the given *pids*.
+  def self.signal(signal : Signal, *pids : Int)
     pids.each do |pid|
       ret = LibC.kill(pid, signal.value)
       raise Errno.new("kill") if ret < 0
@@ -193,7 +202,7 @@ class Process
       $? = process.wait
       value
     rescue ex
-      process.kill
+      process.signal
       raise ex
     end
   end
@@ -349,9 +358,14 @@ class Process
     @wait_count = 0
   end
 
-  # See also: `Process.kill`
+  @[Deprecated("Use #signal instead")]
   def kill(sig = Signal::TERM)
-    Process.kill sig, @pid
+    signal sig
+  end
+
+  # See also: `Process.signal`
+  def signal(sig = Signal::TERM)
+    Process.signal sig, @pid
   end
 
   # Waits for this process to complete and closes any pipes.

--- a/src/process.cr
+++ b/src/process.cr
@@ -199,7 +199,7 @@ class Process
       $? = process.wait
       value
     rescue ex
-      process.signal Signal::TERM
+      process.terminate
       raise ex
     end
   end
@@ -397,6 +397,11 @@ class Process
     close_io @input
     close_io @output
     close_io @error
+  end
+
+  # Ask process for terminate gracefully
+  def terminate
+    signal Signal::TERM
   end
 
   # :nodoc:

--- a/src/process.cr
+++ b/src/process.cr
@@ -35,21 +35,19 @@ class Process
     LibC.getppid
   end
 
+  # Sends a *signal* to the processes identified by the given *pids*.
   @[Deprecated("Use #signal instead")]
   def self.kill(signal : Signal, *pids : Int)
     pids.each do |pid|
-      ret = LibC.kill(pid, signal.value)
-      raise Errno.new("kill") if ret < 0
+      signal signal, pid
     end
     nil
   end
 
-  # Sends a *signal* to the processes identified by the given *pids*.
-  def self.signal(signal : Signal, *pids : Int)
-    pids.each do |pid|
-      ret = LibC.kill(pid, signal.value)
-      raise Errno.new("kill") if ret < 0
-    end
+  # Sends a *signal* to the process identified by the given *pid*.
+  def self.signal(signal : Signal, pid : Int)
+    ret = LibC.kill(pid, signal.value)
+    raise Errno.new("kill") if ret < 0
     nil
   end
 
@@ -358,14 +356,15 @@ class Process
     @wait_count = 0
   end
 
+  # See also: `Process.kill`
   @[Deprecated("Use #signal instead")]
   def kill(sig = Signal::TERM)
     signal sig
   end
 
-  # See also: `Process.signal`
-  def signal(sig)
-    Process.signal sig, @pid
+  # Sends *signal* to the process.
+  def signal(signal : Signal)
+    Process.signal signal, @pid
   end
 
   # Waits for this process to complete and closes any pipes.

--- a/src/process.cr
+++ b/src/process.cr
@@ -202,7 +202,7 @@ class Process
       $? = process.wait
       value
     rescue ex
-      process.signal
+      process.signal Signal::TERM
       raise ex
     end
   end
@@ -364,7 +364,7 @@ class Process
   end
 
   # See also: `Process.signal`
-  def signal(sig = Signal::TERM)
+  def signal(sig)
     Process.signal sig, @pid
   end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -39,7 +39,7 @@ class Process
   @[Deprecated("Use #signal instead")]
   def self.kill(signal : Signal, *pids : Int)
     pids.each do |pid|
-      signal signal, pid
+      signal(signal, pid)
     end
     nil
   end

--- a/src/process.cr
+++ b/src/process.cr
@@ -45,10 +45,9 @@ class Process
   end
 
   # Sends a *signal* to the process identified by the given *pid*.
-  def self.signal(signal : Signal, pid : Int)
+  def self.signal(signal : Signal, pid : Int) : Nil
     ret = LibC.kill(pid, signal.value)
     raise Errno.new("kill") if ret < 0
-    nil
   end
 
   # Returns `true` if the process identified by *pid* is valid for


### PR DESCRIPTION
As suggested by @ysbaddaden in #8518 and further discussed in draft #8536 rename Process#kill(Signal) to Process#signal(Signal) that we can eventually implement on Windows (if needed) with a deprecation notice. The name kill is confusing as it can means two things - send signal to process, or send signal kill (9) to process when argument ommited. But currently default behavior of kill method without providing signal argument is to send term signal to process (simulates posix behavior of kill command, but we need to remove POSIXisms of apis to become realy portable imho).

