### PR TITLE
Fix mutex specs race condition on mt

### DIFF
--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -46,13 +46,15 @@ describe Mutex do
 
     it "can't be unlocked by another fiber" do
       mutex = nil
+      done = false
 
       spawn do
         mutex = Mutex.new
         mutex.not_nil!.lock
+        done = true
       end
 
-      until mutex
+      until done
         Fiber.yield
       end
 
@@ -80,13 +82,15 @@ describe Mutex do
 
     it "can't be unlocked by another fiber" do
       mutex = nil
+      done = false
 
       spawn do
         mutex = Mutex.new(:reentrant)
         mutex.not_nil!.lock
+        done = true
       end
 
-      until mutex
+      until done
         Fiber.yield
       end
 


### PR DESCRIPTION
In https://circleci.com/gh/crystal-lang/crystal/36001 I experienced a race condition introduced in https://github.com/crystal-lang/crystal/pull/8563 .

After this changes the loop will not only wait for the mutex to be assigned but for the lock to occur.