### PR TITLE
Close underlying WebSocket connection when connection is closed

### DIFF
--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -38,7 +38,7 @@ class HTTP::WebSocketHandler
       response.headers["Connection"] = "Upgrade"
       response.headers["Sec-WebSocket-Accept"] = accept_code
       response.upgrade do |io|
-        ws_session = WebSocket.new(io)
+        ws_session = WebSocket.new(io, sync_close: false)
         @proc.call(ws_session, context)
         ws_session.run
       ensure

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -41,6 +41,7 @@ class HTTP::WebSocketHandler
         ws_session = WebSocket.new(io)
         @proc.call(ws_session, context)
         ws_session.run
+      ensure
         io.close
       end
     else

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -106,6 +106,7 @@ class HTTP::WebSocket
         info = @ws.receive(@buffer)
       rescue
         @on_close.try &.call("")
+        @ws.close
         break
       end
 
@@ -141,7 +142,7 @@ class HTTP::WebSocket
         if info.final
           message = @current_message.to_s
           @on_close.try &.call(message)
-          close(message) unless closed?
+          close(message)
           @current_message.clear
           break
         end

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -2,8 +2,8 @@ class HTTP::WebSocket
   getter? closed = false
 
   # :nodoc:
-  def initialize(io : IO)
-    initialize(Protocol.new(io))
+  def initialize(io : IO, sync_close = true)
+    initialize(Protocol.new(io, sync_close: sync_close))
   end
 
   # :nodoc:

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -35,7 +35,7 @@ class HTTP::WebSocket::Protocol
     size : Int32,
     final : Bool
 
-  def initialize(@io : IO, masked = false)
+  def initialize(@io : IO, masked = false, @sync_close = true)
     @header = uninitialized UInt8[2]
     @mask = uninitialized UInt8[4]
     @mask_offset = 0
@@ -232,13 +232,13 @@ class HTTP::WebSocket::Protocol
   end
 
   def close(message = nil)
-    return unless @io.closed?
+    return if @io.closed?
     if message
       send(message.to_slice, Opcode::CLOSE)
     else
       send(Bytes.empty, Opcode::CLOSE)
     end
-    @io.close
+    @io.close if @sync_close
   end
 
   def self.new(host : String, path : String, port = nil, tls = false, headers = HTTP::Headers.new)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -232,11 +232,13 @@ class HTTP::WebSocket::Protocol
   end
 
   def close(message = nil)
+    return unless @io.closed?
     if message
       send(message.to_slice, Opcode::CLOSE)
     else
       send(Bytes.empty, Opcode::CLOSE)
     end
+    @io.close
   end
 
   def self.new(host : String, path : String, port = nil, tls = false, headers = HTTP::Headers.new)


### PR DESCRIPTION
This fixes #7199 by making `WebSocket::Protocol#close` call `TCPSocket#close`. `WebSocket#close` is called when an exception is raised, or when a CLOSE opcode is received.

Also wrapped `ws_session.run` in a begin...ensure to make sure that the `io` is closed on exceptions.