### PR TITLE
Fix error when raising a macro exception with empty message

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -299,6 +299,16 @@ describe "Semantic: macro" do
     ex.to_s.should_not contain("expanding macro")
   end
 
+  it "executes raise inside macro, with empty message (#8631)" do
+    assert_error %(
+      macro foo
+        {{ raise "" }}
+      end
+
+      foo
+      ), ""
+  end
+
   it "can specify tuple as return type" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -124,8 +124,10 @@ module Crystal
         io << '\n'
       end
 
-      io << error_headline(error_message_lines.shift)
-      io << remaining error_message_lines
+      unless error_message_lines.empty?
+        io << error_headline(error_message_lines.shift)
+        io << remaining error_message_lines
+      end
 
       if inner
         return if inner.is_a? MethodTraceException && !inner.has_message?


### PR DESCRIPTION
Unmasked stacktrace:
> Unhandled exception: Index out of bounds (IndexError)
  from src/array.cr:0:13 in 'shift'
  from src/compiler/crystal/semantic/exception.cr:127:28 in 'append_to_s'
  from src/compiler/crystal/semantic/exception.cr:95:7 in 'to_s_with_source'
  from src/compiler/crystal/exception.cr:12:7 in 'to_s'
  from src/io.cr:184:5 in '<<'
  from src/io.cr:241:5 in 'puts'
  from src/compiler/crystal/command.cr:115:7 in 'run'
  from src/compiler/crystal/command.cr:46:5 in 'run'
  from src/compiler/crystal/command.cr:45:3 in 'run'
  from src/compiler/crystal.cr:8:1 in '__crystal_main'
  from src/crystal/main.cr:97:5 in 'main_user_code'
  from src/crystal/main.cr:86:7 in 'main'
  from src/crystal/main.cr:106:3 in 'main'
  from __libc_start_main
  from _start
  from ???

Fixes #8631