### PR TITLE
Drop support for comma separators in enums and other cleanups

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -935,7 +935,6 @@ describe Crystal::Formatter do
   assert_format "# Hello\n#\n# ```\n# puts 1+2 # bye\n# 1+2 # hello\n#\n# 1+2\n# ```\n\n# ```\n# puts 1+2\n\n# ```\n# puts 1+2\n\n# Hola\n#\n#     1+2\n#     foo do\n#     3+4\n#     end\n\n# Hey\n#\n#     1+2\n#     foo do\n#     3+4\n#     end\n#\n# ```\n# 1+2\n# ```\n#\n#     1+2\n#\n# Bye\n", "# Hello\n#\n# ```\n# puts 1 + 2 # bye\n# 1 + 2      # hello\n#\n# 1 + 2\n# ```\n\n# ```\n# puts 1+2\n\n# ```\n# puts 1+2\n\n# Hola\n#\n#     1+2\n#     foo do\n#     3+4\n#     end\n\n# Hey\n#\n#     1+2\n#     foo do\n#     3+4\n#     end\n#\n# ```\n# 1 + 2\n# ```\n#\n#     1+2\n#\n# Bye"
   assert_format "macro foo\n  {% for value, i in values %}\\\n    {% if true %}\\\n    {% end %}\\\n    {{ 1 }}/\n  {% end %}\\\nend\n\n{\n  1 => 2,\n  1234 => 5,\n}\n", "macro foo\n  {% for value, i in values %}\\\n    {% if true %}\\\n    {% end %}\\\n    {{ 1 }}/\n  {% end %}\\\nend\n\n{\n     1 => 2,\n  1234 => 5,\n}"
   assert_format "a = \"\n\"\n1    # 1\n12 # 2\n", "a = \"\n\"\n1  # 1\n12 # 2"
-  assert_format "enum Foo\n  A,   B,   C\nend\n", "enum Foo\n  A; B; C\nend"
   assert_format "enum Foo\n  A;   B;   C\nend\n", "enum Foo\n  A; B; C\nend"
   assert_format "# ```\n# macro foo\n#   1\n# end\n# ```\n", "# ```\n# macro foo\n#   1\n# end\n# ```"
   assert_format "class Foo\n  # ```\n  # 1\n  # ```\nend\n", "class Foo\n  # ```\n  # 1\n  # ```\nend"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1395,6 +1395,7 @@ module Crystal
     it_parses "enum Foo; @[Bar]; end", EnumDef.new("Foo".path, [Annotation.new("Bar".path)] of ASTNode)
 
     assert_syntax_error "enum Foo; A B; end", "expecting ';', 'end' or newline after enum member"
+    assert_syntax_error "enum Foo\n  A,   B,   C\nend\n", "expecting ';', 'end' or newline after enum member"
 
     it_parses "1.[](2)", Call.new(1.int32, "[]", 2.int32)
     it_parses "1.[]?(2)", Call.new(1.int32, "[]?", 2.int32)

--- a/spec/compiler/semantic/c_enum_spec.cr
+++ b/spec/compiler/semantic/c_enum_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Semantic: c enum" do
   it "types enum value" do
-    assert_type("lib LibFoo; enum Bar; X; Y; Z = 10, W; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
+    assert_type("lib LibFoo; enum Bar; X; Y; Z = 10; W; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
   end
 
   it "allows using an enum as a type in a fun" do

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -188,8 +188,7 @@ class Crystal::CodeGenVisitor
     read_function_name = "~#{const.llvm_name}:read"
     func = @main_mod.functions[read_function_name]? || create_read_const_function(read_function_name, const)
     func = check_main_fun read_function_name, func
-    @last = call func
-    @last
+    call func
   end
 
   def create_read_const_function(fun_name, const)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -19,9 +19,6 @@ class Crystal::CodeGenVisitor
     @last = case node.name
             when "binary"
               codegen_primitive_binary node, target_def, call_args
-            when "cast"
-              # TODO 0.28.0 delete :cast
-              codegen_primitive_convert node, target_def, call_args, checked: !target_def.name.ends_with?('!')
             when "convert"
               codegen_primitive_convert node, target_def, call_args, checked: true
             when "unchecked_convert"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5677,8 +5677,7 @@ module Crystal
           skip_space
 
           case @token.type
-          # TODO: remove comma support after 0.28.0
-          when :",", :";", :NEWLINE, :EOF
+          when :";", :NEWLINE, :EOF
             next_token_skip_statement_end
           else
             unless @token.keyword?(:end)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2231,8 +2231,7 @@ module Crystal
       end
 
       # This is the case of an enum member
-      # TODO: remove comma support after 0.28.0
-      if @token.type == :";" || (node.name[0]?.try(&.ascii_uppercase?) && @token.type == :",")
+      if @token.type == :";"
         next_token
         @lexer.skip_space
         if @token.type == :COMMENT

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -86,7 +86,7 @@ struct Char
   # '\u007f'.ord # => 127
   # '☃'.ord      # => 9731
   # ```
-  @[Primitive(:cast)]
+  @[Primitive(:convert)]
   def ord : Int32
   end
 
@@ -117,7 +117,7 @@ struct Symbol
   end
 
   # Returns a unique number for this symbol.
-  @[Primitive(:cast)]
+  @[Primitive(:convert)]
   def to_i : Int32
   end
 
@@ -280,20 +280,16 @@ end
                              to_u8: UInt8, to_u16: UInt16, to_u32: UInt32, to_u64: UInt64, to_u128: UInt128,
                              to_f32: Float32, to_f64: Float64,
                            } %}
-        # TODO 0.28.0 replace with @[Primitive(:convert)]
-
         # Returns `self` converted to `{{type}}`.
         # Raises `OverflowError` in case of overflow.
-        @[Primitive(:cast)]
+        @[Primitive(:convert)]
         @[Raises]
         def {{name.id}} : {{type}}
         end
 
-        # TODO 0.28.0 replace with @[Primitive(:unchecked_convert)]
-
         # Returns `self` converted to `{{type}}`.
         # In case of overflow a wrapping is performed.
-        @[Primitive(:cast)]
+        @[Primitive(:unchecked_convert)]
         def {{name.id}}! : {{type}}
         end
       {% end %}
@@ -328,7 +324,7 @@ end
       # ```
       # 97.unsafe_chr # => 'a'
       # ```
-      @[Primitive(:cast)]
+      @[Primitive(:convert)]
       def unsafe_chr : Char
       end
 


### PR DESCRIPTION
* Cleanup code
* Cleanup unneeded primitives
* Remove support for commas inside enums (Follow up from #7618)