### PR TITLE
Numbers: Use binary primitive for Float#fdiv

### DIFF
--- a/src/big/number.cr
+++ b/src/big/number.cr
@@ -4,6 +4,10 @@ struct BigInt
 end
 
 struct BigFloat
+  def fdiv(other : Number::Primitive) : self
+    self.class.new(self / other)
+  end
+
   def /(other : UInt8 | UInt16 | UInt32 | UInt64)
     # Division by 0 in BigFloat is not allowed, there is no BigFloat::Infinitiy
     raise DivisionByZeroError.new if other == 0
@@ -96,6 +100,12 @@ struct UInt128
   Number.expand_div [BigFloat], BigFloat
   Number.expand_div [BigDecimal], BigDecimal
   Number.expand_div [BigRational], BigRational
+end
+
+struct Float
+  def fdiv(other : BigInt | BigFloat | BigDecimal | BigRational) : self
+    self.class.new(self / other)
+  end
 end
 
 struct Float32

--- a/src/float.cr
+++ b/src/float.cr
@@ -65,13 +65,6 @@ struct Float
     !nan? && !infinite?
   end
 
-  # Float divivision that will obey the left hand side argument type.
-  def fdiv(other) : self
-    # TODO: replace with fdiv primitve after 0.31.0
-    # This is to implement efficiently the // operation
-    self.class.new(self / other)
-  end
-
   def modulo(other)
     if other == 0.0
       raise DivisionByZeroError.new

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -401,7 +401,7 @@ end
           end
         {% end %}
 
-        # Returns the float division of division `self` and *other*.
+        # Returns the float division of `self` and *other*.
         @[Primitive(:binary)]
         def fdiv(other : {{num.id}}) : self
         end

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -400,6 +400,11 @@ end
           def {{op.id}}(other : {{num.id}}) : self
           end
         {% end %}
+
+        # Returns the float division of division `self` and *other*.
+        @[Primitive(:binary)]
+        def fdiv(other : {{num.id}}) : self
+        end
       {% end %}
 
       # Returns the result of division `self` and *other*.


### PR DESCRIPTION
This is a follow up of #8120 

fdiv is a binary primitive since 0.31 so the code in float.cr can go away in favor of the one in primitive.cr

The changes in bin/number.cr look a bit convoluted but is because that file has all the code required to make big and primitive numbers work together.