### PR TITLE
Fix unforgiving ENV["HOME"] in Path spec

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -12,7 +12,7 @@ end
 
 private def it_expands_path(path, posix, windows = posix, *, base = nil, env_home = nil, expand_base = false, home = false, file = __FILE__, line = __LINE__)
   assert_paths(path, posix, windows, %((base: "#{base}")), file, line) do |path|
-    prev_home = ENV["HOME"]
+    prev_home = ENV["HOME"]?
 
     begin
       ENV["HOME"] = env_home || (path.windows? ? HOME_WINDOWS : HOME_POSIX)


### PR DESCRIPTION
The environment variable doesn't need to be defined. Accepting `nil` is completely fine.