### PR TITLE
Refactor Dir.mkdir_p to use Path#each_parent

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -67,23 +67,32 @@ describe "Dir" do
     end
   end
 
-  it "tests mkdir_p with a new path" do
-    with_tempfile("mkdir_p") do |path|
-      Dir.mkdir_p(path)
-      Dir.exists?(path).should be_true
-      path = File.join(path, "a", "b", "c")
-      Dir.mkdir_p(path)
-      Dir.exists?(path).should be_true
+  describe ".mkdir_p" do
+    it "with a new path" do
+      with_tempfile("mkdir_p-new") do |path|
+        Dir.mkdir_p(path)
+        Dir.exists?(path).should be_true
+        path = File.join(path, "a", "b", "c")
+        Dir.mkdir_p(path)
+        Dir.exists?(path).should be_true
+      end
+    end
+
+    context "path exists" do
+      it "fails when path is a file" do
+        expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath("test_file.txt")}': File exists") do
+          Dir.mkdir_p(datapath("test_file.txt"))
+        end
+      end
+
+      it "noop when path is a directory" do
+        Dir.exists?(datapath("dir")).should be_true
+        Dir.mkdir_p(datapath("dir"))
+        Dir.exists?(datapath("dir")).should be_true
+      end
     end
   end
 
-  it "tests mkdir_p with an existing path" do
-    Dir.mkdir_p(datapath)
-    # FIXME: Refactor Dir#mkdir_p to remove leading `./` in error message
-    expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("dir", "f1.txt")}'") do
-      Dir.mkdir_p(datapath("dir", "f1.txt"))
-    end
-  end
 
   it "tests rmdir with an nonexistent path" do
     with_tempfile("nonexistant") do |path|

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -93,7 +93,6 @@ describe "Dir" do
     end
   end
 
-
   it "tests rmdir with an nonexistent path" do
     with_tempfile("nonexistant") do |path|
       expect_raises_errno(Errno::ENOENT, "Unable to remove directory '#{path}'") do

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -340,16 +340,6 @@ describe "FileUtils" do
     end
   end
 
-  it "tests mkdir_p with a new path" do
-    with_tempfile("mkdir_p-new") do |path1|
-      FileUtils.mkdir_p(path1).should be_nil
-      Dir.exists?(path1).should be_true
-      path2 = File.join({path1, "a", "b", "c"})
-      FileUtils.mkdir_p(path2).should be_nil
-      Dir.exists?(path2).should be_true
-    end
-  end
-
   it "tests mkdir_p with multiples new path" do
     with_tempfile("mkdir_p-multi1", "mkdir_p-multi2") do |path1, path2|
       FileUtils.mkdir_p([path1, path2]).should be_nil
@@ -363,19 +353,10 @@ describe "FileUtils" do
     end
   end
 
-  it "tests mkdir_p with an existing path" do
-    FileUtils.mkdir_p(datapath).should be_nil
-    # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
-    expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
-      FileUtils.mkdir_p(datapath("test_file.txt"))
-    end
-  end
-
   it "tests mkdir_p with multiple existing path" do
     FileUtils.mkdir_p([datapath, datapath]).should be_nil
     with_tempfile("mkdir_p-existing") do |path|
-      # FIXME: Refactor FileUtils.mkdir_p to remove leading './' in error message
-      expect_raises_errno(Errno::EEXIST, "Unable to create directory './#{datapath("test_file.txt")}'") do
+      expect_raises_errno(Errno::EEXIST, "Unable to create directory '#{datapath("test_file.txt")}'") do
         FileUtils.mkdir_p([datapath("test_file.txt"), path])
       end
     end

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -1,6 +1,6 @@
 require "file_utils"
 
-SPEC_TEMPFILE_PATH = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}")
+SPEC_TEMPFILE_PATH    = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}")
 SPEC_TEMPFILE_CLEANUP = ENV["SPEC_TEMPFILE_CLEANUP"]? != "0"
 
 # Expands *paths* in a unique temp folder and yield them to the block.

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -1,11 +1,6 @@
 require "file_utils"
 
-{% if flag?(:win32) %}
-  SPEC_TEMPFILE_PATH = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}").gsub("C:\\", '/').gsub('\\', '/')
-{% else %}
-  SPEC_TEMPFILE_PATH = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}")
-{% end %}
-
+SPEC_TEMPFILE_PATH = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}")
 SPEC_TEMPFILE_CLEANUP = ENV["SPEC_TEMPFILE_CLEANUP"]? != "0"
 
 # Expands *paths* in a unique temp folder and yield them to the block.

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -232,33 +232,21 @@ class Dir
   #
   # NOTE: *mode* is ignored on windows.
   def self.mkdir(path, mode = 0o777)
-    Crystal::System::Dir.create(path, mode)
+    Crystal::System::Dir.create(path.to_s, mode)
   end
 
   # Creates a new directory at the given path, including any non-existing
   # intermediate directories. The linux-style permission mode can be specified,
   # with a default of 777 (0o777).
-  def self.mkdir_p(path, mode = 0o777)
-    return 0 if Dir.exists?(path)
+  def self.mkdir_p(path, mode = 0o777) : Nil
+    return if Dir.exists?(path)
 
-    components = path.split(File::SEPARATOR)
-    case components.first
-    when ""
-      components.shift
-      subpath = "/"
-    when "."
-      subpath = components.shift
-    else
-      subpath = "."
+    path = Path.new path
+
+    path.each_parent do |parent|
+      mkdir(parent, mode) unless Dir.exists?(parent)
     end
-
-    components.each do |component|
-      subpath = File.join subpath, component
-
-      mkdir(subpath, mode) unless Dir.exists?(subpath)
-    end
-
-    0
+    mkdir(path, mode) unless Dir.exists?(path)
   end
 
   # Removes the directory at the given path.


### PR DESCRIPTION
Also moves specs from file_utils_spec to dir_spec because that's where
the core method is implemented.

Now .mkdir_p works with windows paths and the workaround in
tempfile helper is no longer necessary.