### PR TITLE
Fix specs on win32

### DIFF
--- a/spec/std/concurrent_spec.cr
+++ b/spec/std/concurrent_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "./spec_helper"
 
 private def method_with_named_args(chan, x = 1, y = 2)
   chan.send(x + y)
@@ -18,32 +18,33 @@ private def raising_job : String
 end
 
 describe "concurrent" do
-  {% unless flag?(:win32) %}
-    describe "parallel" do
-      it "does four things concurrently" do
-        a, b, c, d = parallel(1 + 2, "hello".size, [1, 2, 3, 4].size, nil)
-        a.should eq(3)
-        b.should eq(5)
-        c.should eq(4)
-        d.should be_nil
+  describe "parallel" do
+    pending_win32 "does four things concurrently" do
+      a, b, c, d = parallel(1 + 2, "hello".size, [1, 2, 3, 4].size, nil)
+      a.should eq(3)
+      b.should eq(5)
+      c.should eq(4)
+      d.should be_nil
+    end
+
+    pending_win32 "re-raises errors from Fibers as ConcurrentExecutionException" do
+      exception = expect_raises(ConcurrentExecutionException) do
+        a, b = parallel(raising_job, raising_job)
       end
 
-      it "re-raises errors from Fibers as ConcurrentExecutionException" do
-        exception = expect_raises(ConcurrentExecutionException) do
-          a, b = parallel(raising_job, raising_job)
-        end
+      exception.cause.should be_a(SomeParallelJobException)
+    end
 
-        exception.cause.should be_a(SomeParallelJobException)
-      end
-
-      it "is strict about the return value type" do
+    # FIXME: Compiler bug with typeof inside an unused block https://github.com/crystal-lang/crystal/issues/8669
+    {% unless flag?(:win32) %}
+      pending_win32 "is strict about the return value type" do
         a, b = parallel(1 + 2, "hello")
 
         typeof(a).should eq(Int32)
         typeof(b).should eq(String)
       end
-    end
-  {% end %}
+    {% end %}
+  end
 
   describe "spawn" do
     it "uses spawn macro" do

--- a/spec/std/crystal/hasher_spec.cr
+++ b/spec/std/crystal/hasher_spec.cr
@@ -250,18 +250,16 @@ describe "Crystal::Hasher" do
       1_i32.hash.should eq(1_f64.hash)
     end
 
-    {% unless flag?(:win32) %}
-      it "should 1_f32 and 1.to_big_f hashes equal" do
-        1_f32.hash.should eq(1.to_big_f.hash)
-      end
+    pending_win32 "should 1_f32 and 1.to_big_f hashes equal" do
+      1_f32.hash.should eq(1.to_big_f.hash)
+    end
 
-      it "should 1_f32 and 1.to_big_r hashes equal" do
-        1_f32.hash.should eq(1.to_big_r.hash)
-      end
+    pending_win32 "should 1_f32 and 1.to_big_r hashes equal" do
+      1_f32.hash.should eq(1.to_big_r.hash)
+    end
 
-      it "should 1_f32 and 1.to_big_i hashes equal" do
-        1_f32.hash.should eq(1.to_big_i.hash)
-      end
-    {% end %}
+    pending_win32 "should 1_f32 and 1.to_big_i hashes equal" do
+      1_f32.hash.should eq(1.to_big_i.hash)
+    end
   end
 end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -305,7 +305,7 @@ describe "Dir" do
     it "pattern ending with .." do
       Dir["#{datapath}/dir/.."].sort.should eq [
         datapath("dir", ".."),
-      ]
+      ].sort
     end
 
     it "pattern ending with */.." do
@@ -313,13 +313,13 @@ describe "Dir" do
         datapath("dir", "dots", ".."),
         datapath("dir", "subdir", ".."),
         datapath("dir", "subdir2", ".."),
-      ]
+      ].sort
     end
 
     it "pattern ending with ." do
       Dir["#{datapath}/dir/."].sort.should eq [
         datapath("dir", "."),
-      ]
+      ].sort
     end
 
     it "pattern ending with */." do
@@ -327,7 +327,7 @@ describe "Dir" do
         datapath("dir", "dots", "."),
         datapath("dir", "subdir", "."),
         datapath("dir", "subdir2", "."),
-      ]
+      ].sort
     end
 
     context "match_hidden: true" do

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -266,8 +266,7 @@ describe "Dir" do
       end
     end
 
-    # TODO: This spec is broken on win32 because of `raise` weirdness on windows
-    pending_win32 "tests with relative path starting recursive" do
+    it "tests with relative path starting recursive" do
       Dir["**/dir/*/"].sort.should eq [
         datapath("dir", "dots", ""),
         datapath("dir", "subdir", ""),
@@ -298,8 +297,12 @@ describe "Dir" do
       Dir[""].should eq [] of String
     end
 
-    pending_win32 "root pattern" do
-      Dir["/"].should eq ["/"]
+    it "root pattern" do
+      {% if flag?(:windows) %}
+        Dir["C:/"].should eq ["C:\\"]
+      {% else %}
+        Dir["/"].should eq ["/"]
+      {% end %}
     end
 
     it "pattern ending with .." do

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -274,7 +274,7 @@ describe "Dir" do
       ].sort
     end
 
-    it "matches symlinks" do
+    pending_win32 "matches symlinks" do
       link = datapath("f1_link.txt")
       non_link = datapath("non_link.txt")
 

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -257,11 +257,11 @@ describe "Dir" do
 
     it "tests with relative path (starts with ..)" do
       Dir.cd(datapath) do
-        base_path = "../data/dir"
+        base_path = Path["..", "data", "dir"]
         Dir["#{base_path}/*/"].sort.should eq [
-          File.join(base_path, "dots", ""),
-          File.join(base_path, "subdir", ""),
-          File.join(base_path, "subdir2", ""),
+          base_path.join("dots", "").to_s,
+          base_path.join("subdir", "").to_s,
+          base_path.join("subdir2", "").to_s,
         ].sort
       end
     end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -364,7 +364,7 @@ describe "Dir" do
     end
 
     it "raises" do
-      expect_raises_errno(Errno::ENOENT, "Error while changing directory to '/nope'") do
+      expect_raises_errno(Errno::ENOENT, {{ flag?(:win32) ? /SetCurrentDirectory: .* No such file or directory/ : "Error while changing directory to '/nope'" }}) do
         Dir.cd("/nope")
       end
     end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1077,48 +1077,46 @@ describe "File" do
   end
 
   # TODO: these specs don't compile on win32 because iconv isn't implemented
-  {% unless flag?(:win32) %}
-    describe "encoding" do
-      it "writes with encoding" do
-        with_tempfile("encoding-write.txt") do |path|
-          File.write(path, "hello", encoding: "UCS-2LE")
-          File.read(path).to_slice.should eq("hello".encode("UCS-2LE"))
-        end
+  describe "encoding" do
+    pending_win32 "writes with encoding" do
+      with_tempfile("encoding-write.txt") do |path|
+        File.write(path, "hello", encoding: "UCS-2LE")
+        File.read(path).to_slice.should eq("hello".encode("UCS-2LE"))
       end
+    end
 
-      it "reads with encoding" do
-        with_tempfile("encoding-read.txt") do |path|
-          File.write(path, "hello", encoding: "UCS-2LE")
-          File.read(path, encoding: "UCS-2LE").should eq("hello")
-        end
+    pending_win32 "reads with encoding" do
+      with_tempfile("encoding-read.txt") do |path|
+        File.write(path, "hello", encoding: "UCS-2LE")
+        File.read(path, encoding: "UCS-2LE").should eq("hello")
       end
+    end
 
-      it "opens with encoding" do
-        with_tempfile("encoding-open.txt") do |path|
-          File.write(path, "hello", encoding: "UCS-2LE")
-          File.open(path, encoding: "UCS-2LE") do |file|
-            file.gets_to_end.should eq("hello")
-          end
-        end
-      end
-
-      it "does each line with encoding" do
-        with_tempfile("encoding-each_line.txt") do |path|
-          File.write(path, "hello", encoding: "UCS-2LE")
-          File.each_line(path, encoding: "UCS-2LE") do |line|
-            line.should eq("hello")
-          end
-        end
-      end
-
-      it "reads lines with encoding" do
-        with_tempfile("encoding-read_lines.txt") do |path|
-          File.write(path, "hello", encoding: "UCS-2LE")
-          File.read_lines(path, encoding: "UCS-2LE").should eq(["hello"])
+    pending_win32 "opens with encoding" do
+      with_tempfile("encoding-open.txt") do |path|
+        File.write(path, "hello", encoding: "UCS-2LE")
+        File.open(path, encoding: "UCS-2LE") do |file|
+          file.gets_to_end.should eq("hello")
         end
       end
     end
-  {% end %}
+
+    pending_win32 "does each line with encoding" do
+      with_tempfile("encoding-each_line.txt") do |path|
+        File.write(path, "hello", encoding: "UCS-2LE")
+        File.each_line(path, encoding: "UCS-2LE") do |line|
+          line.should eq("hello")
+        end
+      end
+    end
+
+    pending_win32 "reads lines with encoding" do
+      with_tempfile("encoding-read_lines.txt") do |path|
+        File.write(path, "hello", encoding: "UCS-2LE")
+        File.read_lines(path, encoding: "UCS-2LE").should eq(["hello"])
+      end
+    end
+  end
 
   describe "closed stream" do
     it "raises if writing on a closed stream" do

--- a/spec/std/float_printer_spec.cr
+++ b/spec/std/float_printer_spec.cr
@@ -106,7 +106,7 @@ describe "#print Float64" do
     test_pair 5.5626846462680035e-309, "5.562684646268003e-309"
   end
 
-  it "falure case" do
+  pending_win32 "failure case" do
     # grisu cannot do this number, so it should fall back to libc
     test_pair 3.5844466002796428e+298, "3.5844466002796428e+298"
   end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -731,8 +731,7 @@ describe "Int" do
     {% end %}
   end
 
-  {% unless flag?(:win32) %}
-  it "compares signed vs. unsigned integers" do
+  pending_win32 "compares signed vs. unsigned integers" do
     signed_ints = [Int8::MAX, Int16::MAX, Int32::MAX, Int64::MAX, Int8::MIN, Int16::MIN, Int32::MIN, Int64::MIN, 0_i8, 0_i16, 0_i32, 0_i64]
     unsigned_ints = [UInt8::MAX, UInt16::MAX, UInt32::MAX, UInt64::MAX, 0_u8, 0_u16, 0_u32, 0_u64]
 
@@ -749,7 +748,6 @@ describe "Int" do
       end
     end
   end
-  {% end %}
 
   {% if compare_versions(Crystal::VERSION, "0.26.1") > 0 %}
     it "compares equality and inequality of signed vs. unsigned integers" do

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -631,8 +631,7 @@ describe Path do
     end
 
     it "doesn't expand ~" do
-      ["~", "~/foo"].each do |path|
-        path = Path[path]
+      [Path["~"], Path["~", "foo"]].each do |path|
         path.expand(base: "", expand_base: false).should eq path
       end
     end

--- a/spec/std/raise_spec.cr
+++ b/spec/std/raise_spec.cr
@@ -1,16 +1,16 @@
-require "spec"
+require "./spec_helper"
 
 describe "raise" do
   callstack_on_rescue = nil
 
-  it "should set exception's callstack" do
+  pending_win32 "should set exception's callstack" do
     exception = expect_raises Exception, "without callstack" do
       raise "without callstack"
     end
     exception.callstack.should_not be_nil
   end
 
-  it "shouldn't overwrite the callstack on re-raise" do
+  pending_win32 "shouldn't overwrite the callstack on re-raise" do
     exception_after_reraise = expect_raises Exception, "exception to be rescued" do
       begin
         raise "exception to be rescued"

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -7,7 +7,7 @@ end
 
 {% if flag?(:win32) %}
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    pending(description, file, line, end_line)
+    pending("#{description} [win32]", file, line, end_line)
   end
 {% else %}
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -7,7 +7,7 @@ end
 
 {% if flag?(:win32) %}
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
-    pending(description, file, line, end_line, &block)
+    pending(description, file, line, end_line)
   end
 {% else %}
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -161,7 +161,13 @@ class Dir
           path_stack << {next_pos, root, nil}
         when DirectoriesOnly
           raise "unreachable" unless path
-          fullpath = path == File::SEPARATOR_STRING ? path : path + File::SEPARATOR
+          # FIXME: [win32] File::SEPARATOR_STRING comparison is not sufficient for Windows paths.
+          if path == File::SEPARATOR_STRING
+            fullpath = path
+          else
+            fullpath = Path[path].join("").to_s
+          end
+
           if dir_entry
             yield fullpath if dir_entry.dir?
           else


### PR DESCRIPTION
This either fixes or disables specs that don't succeed on win32.

With this and #8668 `win32_std_spec.cr` should be all green :+1:

```
Finished in 6.84 seconds
4920 examples, 1 failures, 5 errors, 13 pending
```