### PR TITLE
Refactor StaticFileHandler to use Path

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -7,7 +7,7 @@ require "mime"
 class HTTP::StaticFileHandler
   include HTTP::Handler
 
-  @public_dir : String
+  @public_dir : Path
 
   # Creates a handler that will serve files in the given *public_dir*, after
   # expanding it (using `File#expand_path`).
@@ -19,7 +19,7 @@ class HTTP::StaticFileHandler
   # If *directory_listing* is `false`, directory listing is disabled. This means that
   # paths matching directories are ignored and next handler is called.
   def initialize(public_dir : String, fallthrough = true, directory_listing = true)
-    @public_dir = File.expand_path public_dir
+    @public_dir = Path.new(public_dir).expand
     @fallthrough = !!fallthrough
     @directory_listing = !!directory_listing
   end
@@ -36,7 +36,7 @@ class HTTP::StaticFileHandler
     end
 
     original_path = context.request.path.not_nil!
-    is_dir_path = original_path.ends_with? "/"
+    is_dir_path = Path.posix(original_path).ends_with_separator?
     request_path = self.request_path(URI.decode(original_path))
 
     # File path cannot contains '\0' (NUL) because all filesystem I know
@@ -46,18 +46,23 @@ class HTTP::StaticFileHandler
       return
     end
 
-    expanded_path = File.expand_path(request_path, "/")
-    if is_dir_path && !expanded_path.ends_with? "/"
-      expanded_path = "#{expanded_path}/"
+    request_path = Path.posix(request_path)
+    expanded_path = request_path.expand("/")
+    if is_dir_path && !expanded_path.ends_with_separator?
+      expanded_path = expanded_path.join("")
     end
-    is_dir_path = expanded_path.ends_with? "/"
+    is_dir_path = expanded_path.ends_with_separator?
 
-    file_path = File.join(@public_dir, expanded_path)
+    file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
     is_dir = Dir.exists? file_path
     is_file = !is_dir && File.exists?(file_path)
 
     if request_path != expanded_path || is_dir && !is_dir_path
-      redirect_to context, "#{expanded_path}#{is_dir && !is_dir_path ? "/" : ""}"
+      redirect_path = expanded_path
+      if is_dir && !is_dir_path
+        redirect_path = expanded_path.join("")
+      end
+      redirect_to context, redirect_path
       return
     end
 
@@ -73,7 +78,7 @@ class HTTP::StaticFileHandler
         return
       end
 
-      context.response.content_type = MIME.from_filename(file_path, "application/octet-stream")
+      context.response.content_type = MIME.from_filename(file_path.to_s, "application/octet-stream")
       context.response.content_length = File.size(file_path)
       File.open(file_path) do |file|
         IO.copy(file, context.response)
@@ -92,7 +97,7 @@ class HTTP::StaticFileHandler
   private def redirect_to(context, url)
     context.response.status = :found
 
-    url = URI.encode(url)
+    url = URI.encode(url.to_s)
     context.response.headers.add "Location", url
   end
 
@@ -142,6 +147,6 @@ class HTTP::StaticFileHandler
   end
 
   private def directory_listing(io, request_path, path)
-    DirectoryListing.new(request_path, path).to_s(io)
+    DirectoryListing.new(request_path.to_s, path.to_s).to_s(io)
   end
 end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -48,11 +48,6 @@ class HTTP::StaticFileHandler
 
     request_path = Path.posix(request_path)
     expanded_path = request_path.expand("/")
-    if is_dir_path && !expanded_path.ends_with_separator?
-      # Append / to path if missing
-      expanded_path = expanded_path.join("")
-    end
-    is_dir_path = expanded_path.ends_with_separator?
 
     file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
     is_dir = Dir.exists? file_path

--- a/src/http/server/handlers/static_file_handler.html
+++ b/src/http/server/handlers/static_file_handler.html
@@ -7,9 +7,10 @@
     <h2>Directory listing for <%= HTML.escape request_path %></h2>
     <hr/>
     <ul>
-      <% Dir.each_child(path) do |entry| %>
+      <% encoded_request_path = URI.encode(request_path) %>
+      <% each_entry do |entry| %>
         <li>
-          <a href="<%= request_path == "/" ? "" : escaped_request_path %>/<%= URI.encode entry %>"><%= HTML.escape entry %></a>
+          <a href="<%= encoded_request_path %><%= URI.encode entry %>"><%= HTML.escape entry %></a>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
This enables the handler to work with Windows-flavoured file paths on win32.