### PR TITLE
Union::OrderedConverter

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -127,6 +127,18 @@ private class JSONWithTimeEpochMillis
   })
 end
 
+private class JSONWithOrderedUnion
+  JSON.mapping({
+    value: {type: Int64 | Float64, converter: Union::OrderedConverter(Int64, Float64)},
+  })
+end
+
+private class JSONWithComplexOrderedUnion
+  JSON.mapping({
+    value: {type: Int64 | Float64 | Array(Int32), converter: Union::OrderedConverter(Int64, Float64, Array(Int32))},
+  })
+end
+
 private class JSONWithRaw
   JSON.mapping({
     value: {type: String, converter: String::RawConverter},
@@ -480,6 +492,20 @@ describe "JSON mapping" do
     json = JSONWithJSONHashValueConverter.from_json(string)
     json.birthdays.should be_a(Hash(String, Time))
     json.birthdays.should eq({"foo" => Time.unix(1459859781), "bar" => Time.unix(1567628762)})
+    json.to_json.should eq(string)
+  end
+
+  it "uses Union::OrderedConverter" do
+    string = %({"value":1})
+    json = JSONWithOrderedUnion.from_json(string)
+    json.value.should be_a(Int64)
+    json.to_json.should eq(string)
+  end
+
+  it "uses Union::OrderedConverter on complex types" do
+    string = %({"value":[1,2,3]})
+    json = JSONWithComplexOrderedUnion.from_json(string)
+    json.value.should be_a(Array(Int32))
     json.to_json.should eq(string)
   end
 

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -201,6 +201,20 @@ class JSONAttrWithTimeEpochMillis
   property value : Time
 end
 
+class JSONAttrWithOrderedUnion
+  include JSON::Serializable
+
+  @[JSON::Field(converter: Union::OrderedConverter(Int64, Float64))]
+  property value : Int64 | Float64
+end
+
+class JSONAttrWithComplexOrderedUnion
+  include JSON::Serializable
+
+  @[JSON::Field(converter: Union::OrderedConverter(Int64, Float64, Array(Int32)))]
+  property value : Int64 | Float64 | Array(Int32)
+end
+
 class JSONAttrWithRaw
   include JSON::Serializable
 
@@ -655,6 +669,20 @@ describe "JSON mapping" do
     json = JSONAttrWithTimeEpochMillis.from_json(string)
     json.value.should be_a(Time)
     json.value.should eq(Time.unix_ms(1459860483856))
+    json.to_json.should eq(string)
+  end
+
+  it "uses Union::OrderedConverter" do
+    string = %({"value":1})
+    json = JSONAttrWithOrderedUnion.from_json(string)
+    json.value.should be_a(Int64)
+    json.to_json.should eq(string)
+  end
+
+  it "uses Union::OrderedConverter on complex types" do
+    string = %({"value":[1,2,3]})
+    json = JSONAttrWithComplexOrderedUnion.from_json(string)
+    json.value.should be_a(Array(Int32))
     json.to_json.should eq(string)
   end
 

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -286,3 +286,31 @@ module String::RawConverter
     json.raw(value)
   end
 end
+
+# Converter to be used with `JSON.mapping` and `YAML.mapping` to read JSON
+# values into a `Union` type with a non-standard type order.
+#
+# Default conversion prioritises component types based on an alphabetical order
+# due to type system behaviour. This may be used to to specify an alternative
+# order as required.
+#
+# ```
+# require "json"
+#
+# class Example
+#   JSON.mapping({
+#     value:           {type: Int64 | Float64},
+#     converted_value: {type: Int64 | Float64, converter: Union::OrderedConverter(Int64, Float64)},
+#   })
+# end
+#
+# example = Example.from_json(%({"value": 1, "converted_value": 1}))
+# example.value           # => "1.0"
+# example.converted_value # => "1"
+# example.to_json         # => %({"value": 1.0, "converted_value": 1})
+# ```
+module Union::OrderedConverter(*T)
+  def self.to_json(value, json : JSON::Builder)
+    value.to_json(json)
+  end
+end


### PR DESCRIPTION
Provides a generalised converter for reading JSON values into union types based on an arbitrary type order.