### PR TITLE
Add continuous testing on Windows using GitHub Actions

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,6 +1,6 @@
 name: Windows CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   linux-job:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -15,22 +15,24 @@ jobs:
       - name: Build Crystal
         run: |
           make
-      - name: Write an example program
+      - name: Cross-compile stdlib specs
         run: |
-          echo 'puts "Hello world!"' > hello_world.cr
-      - name: Cross-compile the program for Windows
-        run: |
-          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc hello_world.cr
+          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc --exclude-warnings spec/std spec/std_spec.cr
       - name: Upload compiled object
         uses: actions/upload-artifact@v1
         with:
           name: objs
-          path: hello_world.o
+          path: std_spec.o
 
   windows-job:
     needs: linux-job
     runs-on: windows-latest
     steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+      - name: Download Crystal source
+        uses: actions/checkout@v2
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@233eac407f2676fcb3648e3b153b48e60d003803
       - name: Cache libraries
@@ -86,7 +88,7 @@ jobs:
           name: objs
       - name: Link the executable
         run: |
-          cl objs\hello_world.o /Fehello_world libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
+          cl objs\std_spec.o /Festd_spec libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
       - name: Run the executable
         run: |
-          .\hello_world.exe
+          .\std_spec.exe

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,0 +1,78 @@
+name: Windows CI
+
+on: push
+
+jobs:
+  linux-job:
+    runs-on: ubuntu-latest
+    container: crystallang/crystal:latest
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Install LLVM
+        run: |
+          apt-get -q update; apt-get -qy install llvm-8-dev
+      - name: Build Crystal
+        run: |
+          make
+      - name: Write an example program
+        run: |
+          echo 'puts "Hello world!"' > hello_world.cr
+      - name: Cross-compile the program for Windows
+        run: |
+          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc hello_world.cr
+      - name: Upload compiled object
+        uses: actions/upload-artifact@v1
+        with:
+          name: objs
+          path: hello_world.o
+
+  windows-job:
+    needs: linux-job
+    runs-on: windows-latest
+    steps:
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@233eac407f2676fcb3648e3b153b48e60d003803
+      - name: Download libgc
+        uses: actions/checkout@v2
+        with:
+          repository: ivmai/bdwgc
+          ref: v7.6.4
+          path: bdwgc
+      - name: Download libatomic_ops
+        uses: actions/checkout@v2
+        with:
+          repository: ivmai/libatomic_ops
+          ref: v7.6.2
+          path: bdwgc/libatomic_ops
+      - name: Download win32.mak
+        run: |
+          iwr https://gist.github.com/ynkdir/688e62f419e5374347bf/raw/d250598ddf5129addd212b8390279a01bca12706/win32.mak -OutFile bdwgc\ntwin32.mak
+      - name: Build libgc
+        working-directory: ./bdwgc
+        run: |
+          nmake -f NT_X64_STATIC_THREADS_MAKEFILE nodebug=1 _CL_=-DDONT_USE_USER32_DLL
+      - name: Download libpcre
+        run: |
+          iwr https://ftp.pcre.org/pub/pcre/pcre-8.42.zip -OutFile pcre.zip
+          Expand-Archive pcre.zip -DestinationPath .
+          mv pcre* pcre
+      - name: Build libpcre
+        working-directory: ./pcre
+        run: |
+          cmake . -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON
+          cmake --build . --config release
+      - name: Gather libraries
+        run: |
+          mv pcre/release/pcre.lib pcre.lib
+          mv bdwgc/gc.lib gc.lib
+      - name: Download compiled object
+        uses: actions/download-artifact@v1
+        with:
+          name: objs
+      - name: Link the executable
+        run: |
+          cl objs\hello_world.o /Fehello_world pcre.lib gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
+      - name: Run the executable
+        run: |
+          .\hello_world.exe

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -33,46 +33,60 @@ jobs:
     steps:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@233eac407f2676fcb3648e3b153b48e60d003803
+      - name: Cache libraries
+        id: cache-libs
+        uses: actions/cache@v1
+        with:
+          path: libs
+          key: win-libs-v1
       - name: Download libgc
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: ivmai/bdwgc
           ref: v7.6.4
           path: bdwgc
       - name: Download libatomic_ops
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: ivmai/libatomic_ops
           ref: v7.6.2
           path: bdwgc/libatomic_ops
       - name: Download win32.mak
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://gist.github.com/ynkdir/688e62f419e5374347bf/raw/d250598ddf5129addd212b8390279a01bca12706/win32.mak -OutFile bdwgc\ntwin32.mak
       - name: Build libgc
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
           nmake -f NT_X64_STATIC_THREADS_MAKEFILE nodebug=1 _CL_=-DDONT_USE_USER32_DLL
       - name: Download libpcre
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://ftp.pcre.org/pub/pcre/pcre-8.42.zip -OutFile pcre.zip
           Expand-Archive pcre.zip -DestinationPath .
           mv pcre* pcre
       - name: Build libpcre
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./pcre
         run: |
           cmake . -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON
           cmake --build . --config release
       - name: Gather libraries
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          mv pcre/release/pcre.lib pcre.lib
-          mv bdwgc/gc.lib gc.lib
+          mkdir libs
+          mv pcre/release/pcre.lib libs/pcre.lib
+          mv bdwgc/gc.lib libs/gc.lib
       - name: Download compiled object
         uses: actions/download-artifact@v1
         with:
           name: objs
       - name: Link the executable
         run: |
-          cl objs\hello_world.o /Fehello_world pcre.lib gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
+          cl objs\hello_world.o /Fehello_world libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
       - name: Run the executable
         run: |
           .\hello_world.exe

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   linux-job:
     runs-on: ubuntu-latest
-    container: crystallang/crystal:latest
+    container: crystallang/crystal:0.32.1
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a pipeline using a Linux job that cross-compiles for Windows, followed by an actual Windows job linking and running that.
    
Based on https://github.com/crystal-lang/crystal/wiki/Porting-to-Windows/30956f45a4e739204881694ee6c92f4fb0bc5395

Note that all the actual commits from this PR are prefixed with "Win CI:", the rest is merges of pull requests that this relies on.
This PR creates and touches *only* the file ".github/workflows/win.yml".

**[Example in action](https://github.com/oprypin/crystal/actions?query=branch%3Agh-ci+is%3Asuccess)**

Fixes #8666.