### PR TITLE
Print built sample command in CI.

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -97,7 +97,7 @@ build() {
       ;;
   esac
 
-  with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
+  with_build_env 'find samples -name "*.cr" | xargs -tn 1 ./bin/crystal build --no-codegen'
 }
 
 format() {


### PR DESCRIPTION
Makes also xargs compatible with Busybox, used in Alpine.

Purpose: little PR to know failed samples in CI.