### PR TITLE
Enable more win32 specs

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -17,7 +17,7 @@ jobs:
           make
       - name: Cross-compile stdlib specs
         run: |
-          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc --exclude-warnings spec/std spec/std_spec.cr
+          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc --exclude-warnings spec/std spec/std_spec.cr -Dwithout_zlib -Dwithout_openssl
       - name: Upload compiled object
         uses: actions/upload-artifact@v1
         with:

--- a/spec/generate_windows_spec.sh
+++ b/spec/generate_windows_spec.sh
@@ -65,7 +65,7 @@ echo
 for spec in $(find "spec/$SPEC_SUITE" -type f -iname "*_spec.cr" | sort); do
   require="require \"./${spec##spec/}\""
 
-  if ! linker_command=$($CRYSTAL_BIN build --cross-compile --target x86_64--windows-msvc "$spec" 2>/dev/null); then
+  if ! linker_command=$($CRYSTAL_BIN build --cross-compile --target x86_64--windows-msvc -Dwithout_zlib -Dwithout_openssl "$spec" 2>/dev/null); then
     echo "# $require (failed codegen)"
     continue
   fi

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "http/client/response"
 
-class HTTP::Client
+class HTTP::Client::Response
   describe Response do
     it "parses response with body" do
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"))

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "http/cookie"
+require "http/headers"
 
 private def parse_first_cookie(header)
   cookies = HTTP::Cookie::Parser.parse_cookies(header)

--- a/spec/std/http/formdata/builder_spec.cr
+++ b/spec/std/http/formdata/builder_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
-require "http"
+require "http/formdata"
+require "http/server/response"
 
 describe HTTP::FormData::Builder do
   it "builds valid form-data messages" do

--- a/spec/std/http/formdata/parser_spec.cr
+++ b/spec/std/http/formdata/parser_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "http"
+require "http/formdata"
 
 describe HTTP::FormData::Parser do
   it "parses formdata" do

--- a/spec/std/http/formdata_spec.cr
+++ b/spec/std/http/formdata_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
-require "http"
+require "http/formdata"
+require "http/server/response"
 
 describe HTTP::FormData do
   describe ".parse(IO, String)" do
@@ -94,7 +95,7 @@ describe HTTP::FormData do
     end
   end
 
-  describe ".build(HTTP::Response, String)" do
+  describe ".build(HTTP::Server::Response, String)" do
     it "builds a message" do
       io = IO::Memory.new
       response = HTTP::Server::Response.new(io)

--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -44,7 +44,7 @@ describe HTTP do
     end
 
     it "with local time zone" do
-      time = Time.local(1994, 11, 6, 8, 49, 37, nanosecond: 0, location: Time::Location.load("Europe/Berlin"))
+      time = Time.local(1994, 11, 6, 8, 49, 37, nanosecond: 0, location: Time::Location.fixed(3600))
       HTTP.format_time(time).should eq(time.to_utc.to_s("%a, %d %b %Y %H:%M:%S GMT"))
     end
   end

--- a/spec/std/http/server/handlers/error_handler_spec.cr
+++ b/spec/std/http/server/handlers/error_handler_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "http/server"
+require "http/server/handler"
 
 describe HTTP::ErrorHandler do
   it "rescues from exception" do

--- a/spec/std/http/server/handlers/handler_spec.cr
+++ b/spec/std/http/server/handlers/handler_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "http/server"
+require "http/server/handler"
 
 private class EmptyHTTPHandler
   include HTTP::Handler

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "http/server"
+require "http/server/handler"
 
 describe HTTP::LogHandler do
   it "logs" do

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -1,5 +1,6 @@
 require "../../../spec_helper"
-require "http/server"
+require "http/server/handler"
+require "http/client/response"
 
 private def handle(request, fallthrough = true, directory_listing = true, ignore_body = false)
   io = IO::Memory.new

--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -246,7 +246,9 @@ describe HTTP::Server::RequestProcessor do
 
   it "handles Errno" do
     processor = HTTP::Server::RequestProcessor.new { }
-    input = RaiseErrno.new(Errno::ECONNRESET)
+    # Using EPERM here instead of a more reasonable ECONNRESET because the
+    # latter is not available on all platforms (win32).
+    input = RaiseErrno.new(Errno::EPERM)
     output = IO::Memory.new
     processor.process(input, output)
     output.rewind.gets_to_end.empty?.should be_true

--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -1,6 +1,8 @@
-require "spec"
+require "../spec_helper"
 require "json"
-require "yaml"
+{% unless flag?(:win32) %}
+  require "yaml"
+{% end %}
 
 describe JSON::Any do
   describe "casts" do
@@ -170,7 +172,7 @@ describe JSON::Any do
     any2.as_a[0].as_a.should_not be(any.as_a[0].as_a)
   end
 
-  it "#to_yaml" do
+  pending_win32 "#to_yaml" do
     any = JSON.parse <<-JSON
       {
         "foo": "bar",

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -1,8 +1,10 @@
-require "spec"
+require "../spec_helper"
 require "json"
 require "uuid"
 require "uuid/json"
-require "big/json"
+{% unless flag?(:win32) %}
+  require "big/json"
+{% end %}
 
 private class JSONPerson
   JSON.mapping({
@@ -38,9 +40,11 @@ private class JSONWithUUID
   JSON.mapping value: UUID
 end
 
-private class JSONWithBigDecimal
-  JSON.mapping value: BigDecimal
-end
+{% unless flag?(:win32) %}
+  private class JSONWithBigDecimal
+    JSON.mapping value: BigDecimal
+  end
+{% end %}
 
 private class JSONWithTime
   JSON.mapping({
@@ -612,7 +616,7 @@ describe "JSON mapping" do
     end
   end
 
-  describe "BigDecimal" do
+  pending_win32 describe: "BigDecimal" do
     it "parses json string with BigDecimal" do
       json = JSONWithBigDecimal.from_json(%({"value": "10.05"}))
       json.value.should eq(BigDecimal.new("10.05"))

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -1,10 +1,12 @@
-require "spec"
+require "../spec_helper"
 require "json"
-require "big"
-require "big/json"
+{% unless flag?(:win32) %}
+  require "yaml"
+  require "big"
+  require "big/json"
+{% end %}
 require "uuid"
 require "uuid/json"
-require "yaml"
 
 record JSONAttrPoint, x : Int32, y : Int32 do
   include JSON::Serializable
@@ -94,11 +96,13 @@ class JSONAttrWithUUID
   property value : UUID
 end
 
-class JSONAttrWithBigDecimal
-  include JSON::Serializable
+{% unless flag?(:win32) %}
+  class JSONAttrWithBigDecimal
+    include JSON::Serializable
 
-  property value : BigDecimal
-end
+    property value : BigDecimal
+  end
+{% end %}
 
 class JSONAttrWithTime
   include JSON::Serializable
@@ -297,36 +301,38 @@ class JSONAttrModuleTest2 < JSONAttrModuleTest
   end
 end
 
-struct JSONAttrPersonWithYAML
-  include JSON::Serializable
-  include YAML::Serializable
+{% unless flag?(:win32) %}
+  struct JSONAttrPersonWithYAML
+    include JSON::Serializable
+    include YAML::Serializable
 
-  property name : String
-  property age : Int32?
+    property name : String
+    property age : Int32?
 
-  def initialize(@name : String, @age : Int32? = nil)
-  end
-end
-
-struct JSONAttrPersonWithYAMLInitializeHook
-  include JSON::Serializable
-  include YAML::Serializable
-
-  property name : String
-  property age : Int32?
-
-  def initialize(@name : String, @age : Int32? = nil)
-    after_initialize
+    def initialize(@name : String, @age : Int32? = nil)
+    end
   end
 
-  @[JSON::Field(ignore: true)]
-  @[YAML::Field(ignore: true)]
-  property msg : String?
+  struct JSONAttrPersonWithYAMLInitializeHook
+    include JSON::Serializable
+    include YAML::Serializable
 
-  def after_initialize
-    @msg = "Hello " + name
+    property name : String
+    property age : Int32?
+
+    def initialize(@name : String, @age : Int32? = nil)
+      after_initialize
+    end
+
+    @[JSON::Field(ignore: true)]
+    @[YAML::Field(ignore: true)]
+    property msg : String?
+
+    def after_initialize
+      @msg = "Hello " + name
+    end
   end
-end
+{% end %}
 
 abstract class JSONShape
   include JSON::Serializable
@@ -781,7 +787,7 @@ describe "JSON mapping" do
     end
   end
 
-  describe "BigDecimal" do
+  pending_win32 describe: "BigDecimal" do
     it "parses json string with BigDecimal" do
       json = JSONAttrWithBigDecimal.from_json(%({"value": "10.05"}))
       json.value.should eq(BigDecimal.new("10.05"))
@@ -810,7 +816,7 @@ describe "JSON mapping" do
     it { JSONAttrModuleTest2.from_json(%({"bar": 30, "moo": 40})).to_tuple.should eq({40, 15, 30}) }
   end
 
-  it "works together with yaml" do
+  pending_win32 "works together with yaml" do
     person = JSONAttrPersonWithYAML.new("Vasya", 30)
     person.to_json.should eq "{\"name\":\"Vasya\",\"age\":30}"
     person.to_yaml.should eq "---\nname: Vasya\nage: 30\n"
@@ -819,7 +825,7 @@ describe "JSON mapping" do
     JSONAttrPersonWithYAML.from_yaml(person.to_yaml).should eq person
   end
 
-  it "yaml and json with after_initialize hook" do
+  pending_win32 "yaml and json with after_initialize hook" do
     person = JSONAttrPersonWithYAMLInitializeHook.new("Vasya", 30)
     person.msg.should eq "Hello Vasya"
 

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -1,7 +1,9 @@
-require "spec"
+require "../spec_helper"
 require "json"
-require "big"
-require "big/json"
+{% unless flag?(:win32) %}
+  require "big"
+  require "big/json"
+{% end %}
 require "uuid"
 require "uuid/json"
 
@@ -57,15 +59,15 @@ describe "JSON serialization" do
       Hash(Float64, String).from_json(%({"1.23": "x", "4.56": "y"})).should eq({1.23 => "x", 4.56 => "y"})
     end
 
-    it "does Hash(BigInt, String)#from_json" do
+    pending_win32 "does Hash(BigInt, String)#from_json" do
       Hash(BigInt, String).from_json(%({"12345678901234567890": "x"})).should eq({"12345678901234567890".to_big_i => "x"})
     end
 
-    it "does Hash(BigFloat, String)#from_json" do
+    pending_win32 "does Hash(BigFloat, String)#from_json" do
       Hash(BigFloat, String).from_json(%({"1234567890.123456789": "x"})).should eq({"1234567890.123456789".to_big_f => "x"})
     end
 
-    it "does Hash(BigDecimal, String)#from_json" do
+    pending_win32 "does Hash(BigDecimal, String)#from_json" do
       Hash(BigDecimal, String).from_json(%({"1234567890.123456789": "x"})).should eq({"1234567890.123456789".to_big_d => "x"})
     end
 
@@ -113,19 +115,19 @@ describe "JSON serialization" do
       tuple.should be_a(NamedTuple(x: Int32?, y: String))
     end
 
-    it "does for BigInt" do
+    pending_win32 "does for BigInt" do
       big = BigInt.from_json("123456789123456789123456789123456789123456789")
       big.should be_a(BigInt)
       big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
     end
 
-    it "does for BigFloat" do
+    pending_win32 "does for BigFloat" do
       big = BigFloat.from_json("1234.567891011121314")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
-    it "does for BigFloat from int" do
+    pending_win32 "does for BigFloat from int" do
       big = BigFloat.from_json("1234")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234"))
@@ -149,13 +151,13 @@ describe "JSON serialization" do
       uuid.should eq(UUID.new("ee843b26-56d8-472b-b343-0b94ed9077ff"))
     end
 
-    it "does for BigDecimal from int" do
+    pending_win32 "does for BigDecimal from int" do
       big = BigDecimal.from_json("1234")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234"))
     end
 
-    it "does for BigDecimal from float" do
+    pending_win32 "does for BigDecimal from float" do
       big = BigDecimal.from_json("1234.05")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234.05"))
@@ -355,7 +357,7 @@ describe "JSON serialization" do
       {1.2 => 2, 3.4 => 6}.to_json.should eq(%({"1.2":2,"3.4":6}))
     end
 
-    it "does for Hash with BigInt keys" do
+    pending_win32 "does for Hash with BigInt keys" do
       {123.to_big_i => 2}.to_json.should eq(%({"123":2}))
     end
 
@@ -375,12 +377,12 @@ describe "JSON serialization" do
       JSONSpecEnum::One.to_json.should eq("1")
     end
 
-    it "does for BigInt" do
+    pending_win32 "does for BigInt" do
       big = BigInt.new("123456789123456789123456789123456789123456789")
       big.to_json.should eq("123456789123456789123456789123456789123456789")
     end
 
-    it "does for BigFloat" do
+    pending_win32 "does for BigFloat" do
       big = BigFloat.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
     end

--- a/spec/std/mime/media_type_spec.cr
+++ b/spec/std/mime/media_type_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "../spec_helper"
 require "mime/media_type"
 
 private def parse(string)
@@ -62,10 +62,6 @@ describe MIME::MediaType do
       expect_raises(MIME::Error, "Duplicate key 'key' at 15") { parse(%(foo; key=val1; key=the-key-appears-again-which-is-bogus)) }
 
       parse(%(FORM-DATA;NAMe="foo")).should eq({"form-data", {"name" => "foo"}})
-
-      # From RFC 2231:
-
-      parse(%(application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A)).should eq({"application/x-stuff", {"title" => "This is ***fun***"}})
 
       parse(%(message/external-body; access-type=URL; URL*0="ftp://";URL*1="cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar")).should eq({
         "message/external-body",
@@ -205,8 +201,6 @@ describe MIME::MediaType do
       parse(%(attachment; filename="foo-ae.html"; filename*=UTF-8''foo-%c3%a4.html)).should eq({"attachment", {"filename" => "foo-ä.html"}})
       # attfnboth2
       parse(%(attachment; filename*=UTF-8''foo-%c3%a4.html; filename="foo-ae.html")).should eq({"attachment", {"filename" => "foo-ä.html"}})
-      # attfnboth3
-      parse(%(attachment; filename*0*=ISO-8859-15''euro-sign%3d%a4; filename*=ISO-8859-1''currency-sign%3d%a4)).should eq({"attachment", {"filename" => "currency-sign=¤"}})
       # attnewandfn
       parse(%(attachment; foobar=x; filename="foo.html")).should eq({"attachment", {"foobar" => "x", "filename" => "foo.html"}})
 
@@ -223,6 +217,13 @@ describe MIME::MediaType do
       # Skip whitespace after =
       parse(%(form-data; foo= foo)).should eq({"form-data", {"foo" => "foo"}})
       parse(%(form-data; foo= " foo ")).should eq({"form-data", {"foo" => " foo "}})
+    end
+
+    pending_win32 "parses params with encoding" do
+      # From RFC 2231:
+      parse(%(application/x-stuff; title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A)).should eq({"application/x-stuff", {"title" => "This is ***fun***"}})
+      # attfnboth3
+      parse(%(attachment; filename*0*=ISO-8859-15''euro-sign%3d%a4; filename*=ISO-8859-1''currency-sign%3d%a4)).should eq({"attachment", {"filename" => "currency-sign=¤"}})
     end
 
     it "sets default charset to utf-8 for text media types" do

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -1,5 +1,7 @@
-require "big"
-require "spec"
+require "./spec_helper"
+{% unless flag?(:win32) %}
+  require "big"
+{% end %}
 
 private class TestRNG(T)
   include Random
@@ -39,7 +41,7 @@ describe "Random" do
     end
   end
 
-  it "limited BigInt" do
+  pending_win32 "limited BigInt" do
     rand(1.to_big_i).should eq(0.to_big_i)
 
     x = rand(2.to_big_i)
@@ -47,7 +49,7 @@ describe "Random" do
     x.should be < 2
   end
 
-  it "limited large BigInt" do
+  pending_win32 "limited large BigInt" do
     max = "1234567890123456789012345".to_big_i
     x = rand(max)
     x.should be >= 0
@@ -102,7 +104,7 @@ describe "Random" do
     end
   end
 
-  it "does with BigInt range" do
+  pending_win32 "does with BigInt range" do
     [1.to_big_i...2.to_big_i,
      -"1234567890123456789012345".to_big_i...7.to_big_i,
      -7.to_big_i..."1234567890123456789012345".to_big_i].each do |range|
@@ -134,24 +136,32 @@ describe "Random" do
     x.should be < 3.3_f32
   end
 
-  it "raises on invalid range" do
-    expect_raises ArgumentError, "Invalid range for rand: 1...1" do
-      rand(1...1)
+  describe "raises on invalid range" do
+    it "Int32 range" do
+      expect_raises ArgumentError, "Invalid range for rand: 1...1" do
+        rand(1...1)
+      end
+      expect_raises ArgumentError, "Invalid range for rand: 1..0" do
+        rand(1..0)
+      end
     end
-    expect_raises ArgumentError, "Invalid range for rand: 1..0" do
-      rand(1..0)
+
+    pending_win32 "BigInt range" do
+      expect_raises ArgumentError, "Invalid range for rand: #{1.to_big_i...1.to_big_i}" do
+        rand(1.to_big_i...1.to_big_i)
+      end
+      expect_raises ArgumentError, "Invalid range for rand: #{1.to_big_i..0.to_big_i}" do
+        rand(1.to_big_i..0.to_big_i)
+      end
     end
-    expect_raises ArgumentError, "Invalid range for rand: #{1.to_big_i...1.to_big_i}" do
-      rand(1.to_big_i...1.to_big_i)
-    end
-    expect_raises ArgumentError, "Invalid range for rand: #{1.to_big_i..0.to_big_i}" do
-      rand(1.to_big_i..0.to_big_i)
-    end
-    expect_raises ArgumentError, "Invalid range for rand: 1.0...1.0" do
-      rand(1.0...1.0)
-    end
-    expect_raises ArgumentError, "Invalid range for rand: 1.0..0.0" do
-      rand(1.0..0.0)
+
+    it "Float64 range" do
+      expect_raises ArgumentError, "Invalid range for rand: 1.0...1.0" do
+        rand(1.0...1.0)
+      end
+      expect_raises ArgumentError, "Invalid range for rand: 1.0..0.0" do
+        rand(1.0..0.0)
+      end
     end
   end
 

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -1,5 +1,7 @@
-require "spec"
-require "big"
+require "./spec_helper"
+{% unless flag?(:win32) %}
+  require "big"
+{% end %}
 
 struct RangeSpecIntWrapper
   include Comparable(self)
@@ -85,11 +87,14 @@ describe "Range" do
     it "called with no block is specialized for performance" do
       (1..3).sum.should eq 6
       (1...3).sum.should eq 3
-      (BigInt.new("1")..BigInt.new("1 000 000 000")).sum.should eq BigInt.new("500 000 000 500 000 000")
       (1..3).sum(4).should eq 10
       (3..1).sum(4).should eq 4
       (1..11).step(2).sum.should eq 36
       (1...11).step(2).sum.should eq 25
+    end
+
+    pending_win32 "called with no block is specialized for performance (BigInt)" do
+      (BigInt.new("1")..BigInt.new("1 000 000 000")).sum.should eq BigInt.new("500 000 000 500 000 000")
       (BigInt.new("1")..BigInt.new("1 000 000 000")).step(2).sum.should eq BigInt.new("250 000 000 000 000 000")
     end
 
@@ -124,7 +129,9 @@ describe "Range" do
       (0_u8...10_u8).bsearch { |x| x >= 10 }.should eq nil
       (0_u32..10_u32).bsearch { |x| x >= 10 }.should eq 10_u32
       (0_u32...10_u32).bsearch { |x| x >= 10 }.should eq nil
+    end
 
+    pending_win32 "BigInt" do
       (BigInt.new("-10")...BigInt.new("10")).bsearch { |x| x >= -5 }.should eq BigInt.new("-5")
     end
 

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -1,5 +1,7 @@
-require "spec"
-require "xml"
+require "../spec_helper"
+{% unless flag?(:win32) %}
+  require "xml"
+{% end %}
 
 class Spec::JUnitFormatter
   property started_at
@@ -101,7 +103,7 @@ describe "JUnit Formatter" do
     output.should eq(expected)
   end
 
-  it "encodes class names from the relative file path" do
+  pending_win32 "encodes class names from the relative file path" do
     output = build_report do |f|
       f.report Spec::Result.new(:success, "foo", __FILE__, __LINE__, nil, nil)
     end
@@ -110,7 +112,7 @@ describe "JUnit Formatter" do
     classname.should eq("spec.std.spec.junit_formatter_spec")
   end
 
-  it "outputs timestamp according to RFC 3339" do
+  pending_win32 "outputs timestamp according to RFC 3339" do
     now = Time.utc
 
     output = build_report(timestamp: now) do |f|
@@ -121,7 +123,7 @@ describe "JUnit Formatter" do
     classname.should eq(now.to_rfc3339)
   end
 
-  it "escapes spec names" do
+  pending_win32 "escapes spec names" do
     output = build_report do |f|
       f.report Spec::Result.new(:success, %(complicated " <n>'&ame), __FILE__, __LINE__, nil, nil)
       f.report Spec::Result.new(:success, %(ctrl characters follow - \r\n), __FILE__, __LINE__, nil, nil)
@@ -134,7 +136,7 @@ describe "JUnit Formatter" do
     name.should eq(%(ctrl characters follow - \\r\\n))
   end
 
-  it "report failure stacktrace if present" do
+  pending_win32 "report failure stacktrace if present" do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|
@@ -149,7 +151,7 @@ describe "JUnit Formatter" do
     backtrace.should eq(cause.backtrace.join('\n'))
   end
 
-  it "report error stacktrace if present" do
+  pending_win32 "report error stacktrace if present" do
     cause = exception_with_backtrace("Something happened")
 
     output = build_report do |f|

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -10,9 +10,17 @@ end
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     pending("#{description} [win32]", file, line, end_line)
   end
+
+  def pending_win32(*, describe, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    pending_win32(describe, file, line, end_line) { }
+  end
 {% else %}
   def pending_win32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
     it(description, file, line, end_line, &block)
+  end
+
+  def pending_win32(*, describe, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+    describe(describe, file, line, end_line, &block)
   end
 {% end %}
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "./spec_helper"
 
 describe "String" do
   describe "[]" do
@@ -1697,6 +1697,11 @@ describe "String" do
     ("こんに%xちは" % 123).should eq("こんに7bちは")
     ("こんに%Xちは" % 123).should eq("こんに7Bちは")
 
+    span = 1.second
+    ("%s" % span).should eq(span.to_s)
+  end
+
+  pending_win32 "does % with floats" do
     ("%f" % 123).should eq("123.000000")
 
     ("%g" % 123).should eq("123")
@@ -1716,9 +1721,6 @@ describe "String" do
     ("%a" % 12345678.45).should eq("0x1.78c29ce666666p+23")
     ("%A" % 12345678.45).should eq("0X1.78C29CE666666P+23")
     ("%100.50g" % 123.45).should eq("                                                  123.4500000000000028421709430404007434844970703125")
-
-    span = 1.second
-    ("%s" % span).should eq(span.to_s)
 
     ("%.2f" % 2.536_f32).should eq("2.54")
     ("%0*.*f" % [10, 2, 2.536_f32]).should eq("0000002.54")
@@ -2066,7 +2068,7 @@ describe "String" do
     sprintf("Hello %d world", [123]).should eq("Hello 123 world")
   end
 
-  it "formats floats (#1562)" do
+  pending_win32 "formats floats (#1562)" do
     sprintf("%12.2f %12.2f %6.2f %.2f" % {2.0, 3.0, 4.0, 5.0}).should eq("        2.00         3.00   4.00 5.00")
   end
 
@@ -2298,7 +2300,7 @@ describe "String" do
       end
     end
 
-    it "applies formatting to %<...> placeholder" do
+    pending_win32 "applies formatting to %<...> placeholder" do
       res = "change %<this>.2f" % {"this" => 23.456}
       res.should eq "change 23.46"
 
@@ -2388,7 +2390,7 @@ describe "String" do
     end
   end
 
-  describe "encode" do
+  pending_win32 describe: "encode" do
     it "encodes" do
       bytes = "Hello".encode("UCS-2LE")
       bytes.to_a.should eq([72, 0, 101, 0, 108, 0, 108, 0, 111, 0])

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -1,5 +1,7 @@
-require "spec"
-require "big"
+require "./spec_helper"
+{% unless flag?(:win32) %}
+  require "big"
+{% end %}
 
 private module StructSpec
   struct TestClass
@@ -10,12 +12,14 @@ private module StructSpec
     end
   end
 
-  struct BigIntWrapper
-    @value : BigInt
+  {% unless flag?(:win32) %}
+    struct BigIntWrapper
+      @value : BigInt
 
-    def initialize(@value : BigInt)
+      def initialize(@value : BigInt)
+      end
     end
-  end
+  {% end %}
 
   struct DupCloneStruct
     property x, y
@@ -54,7 +58,7 @@ describe "Struct" do
     s.hash.should eq(s.dup.hash)
   end
 
-  it "does hash for struct wrapper (#1940)" do
+  pending_win32 "does hash for struct wrapper (#1940)" do
     s = StructSpec::BigIntWrapper.new(BigInt.new(0))
     s.hash.should eq(s.dup.hash)
   end

--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -1,9 +1,9 @@
-require "spec"
+require "./spec_helper"
 require "system"
 
 describe System do
   describe "hostname" do
-    it "returns current hostname" do
+    pending_win32 "returns current hostname" do
       shell_hostname = `hostname`.strip
       $?.success?.should be_true # The hostname command has to be available
       hostname = System.hostname

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -178,7 +178,7 @@ require "./std/slice_spec.cr"
 require "./std/spec/context_spec.cr"
 require "./std/spec/expectations_spec.cr"
 require "./std/spec/filters_spec.cr"
-# require "./std/spec/junit_formatter_spec.cr" (failed linking)
+require "./std/spec/junit_formatter_spec.cr"
 require "./std/spec_spec.cr"
 require "./std/spec/tap_formatter_spec.cr"
 require "./std/static_array_spec.cr"

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -99,14 +99,14 @@ require "./std/io/multi_writer_spec.cr"
 require "./std/io/sized_spec.cr"
 require "./std/io/stapled_spec.cr"
 require "./std/iterator_spec.cr"
-# require "./std/json/any_spec.cr" (failed linking)
+require "./std/json/any_spec.cr"
 require "./std/json/builder_spec.cr"
 require "./std/json/lexer_spec.cr"
-# require "./std/json/mapping_spec.cr" (failed linking)
+require "./std/json/mapping_spec.cr"
 require "./std/json/parser_spec.cr"
 require "./std/json/pull_parser_spec.cr"
-# require "./std/json/serializable_spec.cr" (failed linking)
-# require "./std/json/serialization_spec.cr" (failed linking)
+require "./std/json/serializable_spec.cr"
+require "./std/json/serialization_spec.cr"
 # require "./std/kernel_spec.cr" (failed codegen)
 require "./std/levenshtein_spec.cr"
 # require "./std/llvm/aarch64_spec.cr" (failed linking)

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -115,7 +115,7 @@ require "./std/levenshtein_spec.cr"
 # require "./std/llvm/type_spec.cr" (failed linking)
 # require "./std/llvm/x86_64_abi_spec.cr" (failed linking)
 # require "./std/llvm/x86_abi_spec.cr" (failed linking)
-# require "./std/logger_spec.cr" (failed codegen)
+require "./std/logger_spec.cr"
 require "./std/match_data_spec.cr"
 # require "./std/math_spec.cr" (failed linking)
 # require "./std/mime/media_type_spec.cr" (failed linking)

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -118,10 +118,10 @@ require "./std/levenshtein_spec.cr"
 require "./std/logger_spec.cr"
 require "./std/match_data_spec.cr"
 # require "./std/math_spec.cr" (failed linking)
-# require "./std/mime/media_type_spec.cr" (failed linking)
-# require "./std/mime/multipart/builder_spec.cr" (failed codegen)
-# require "./std/mime/multipart/parser_spec.cr" (failed codegen)
-# require "./std/mime/multipart_spec.cr" (failed codegen)
+require "./std/mime/media_type_spec.cr"
+require "./std/mime/multipart/builder_spec.cr"
+require "./std/mime/multipart/parser_spec.cr"
+require "./std/mime/multipart_spec.cr"
 require "./std/mime_spec.cr"
 # require "./std/mutex_spec.cr" (failed codegen)
 require "./std/named_tuple_spec.cr"

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -190,7 +190,7 @@ require "./std/string/utf16_spec.cr"
 require "./std/struct_spec.cr"
 require "./std/symbol_spec.cr"
 # require "./std/system/group_spec.cr" (failed codegen)
-# require "./std/system_spec.cr" (failed codegen)
+require "./std/system_spec.cr"
 # require "./std/system/user_spec.cr" (failed codegen)
 # require "./std/thread/condition_variable_spec.cr" (failed codegen)
 # require "./std/thread/mutex_spec.cr" (failed codegen)

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -159,7 +159,7 @@ require "./std/random/isaac_spec.cr"
 require "./std/random/pcg32_spec.cr"
 require "./std/random/secure_spec.cr"
 require "./std/random_spec.cr"
-# require "./std/range_spec.cr" (failed linking)
+require "./std/range_spec.cr"
 require "./std/record_spec.cr"
 require "./std/reference_spec.cr"
 require "./std/regex_spec.cr"

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -185,7 +185,7 @@ require "./std/static_array_spec.cr"
 require "./std/string_builder_spec.cr"
 require "./std/string_pool_spec.cr"
 require "./std/string_scanner_spec.cr"
-# require "./std/string_spec.cr" (failed codegen)
+require "./std/string_spec.cr"
 require "./std/string/utf16_spec.cr"
 # require "./std/struct_spec.cr" (failed linking)
 require "./std/symbol_spec.cr"

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -187,7 +187,7 @@ require "./std/string_pool_spec.cr"
 require "./std/string_scanner_spec.cr"
 require "./std/string_spec.cr"
 require "./std/string/utf16_spec.cr"
-# require "./std/struct_spec.cr" (failed linking)
+require "./std/struct_spec.cr"
 require "./std/symbol_spec.cr"
 # require "./std/system/group_spec.cr" (failed codegen)
 # require "./std/system_spec.cr" (failed codegen)

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -62,27 +62,27 @@ require "./std/gc_spec.cr"
 # require "./std/gzip/gzip_spec.cr" (failed linking)
 require "./std/hash_spec.cr"
 require "./std/html_spec.cr"
-# require "./std/http/chunked_content_spec.cr" (failed codegen)
+require "./std/http/chunked_content_spec.cr"
 # require "./std/http/client/client_spec.cr" (failed codegen)
-# require "./std/http/client/response_spec.cr" (failed codegen)
-# require "./std/http/cookie_spec.cr" (failed codegen)
-# require "./std/http/formdata/builder_spec.cr" (failed codegen)
-# require "./std/http/formdata/parser_spec.cr" (failed codegen)
-# require "./std/http/formdata_spec.cr" (failed codegen)
+require "./std/http/client/response_spec.cr"
+require "./std/http/cookie_spec.cr"
+require "./std/http/formdata/builder_spec.cr"
+require "./std/http/formdata/parser_spec.cr"
+require "./std/http/formdata_spec.cr"
 require "./std/http/headers_spec.cr"
-# require "./std/http/http_spec.cr" (failed linking)
+require "./std/http/http_spec.cr"
 require "./std/http/params_spec.cr"
-# require "./std/http/request_spec.cr" (failed codegen)
+require "./std/http/request_spec.cr"
 # require "./std/http/server/handlers/compress_handler_spec.cr" (failed codegen)
-# require "./std/http/server/handlers/error_handler_spec.cr" (failed codegen)
-# require "./std/http/server/handlers/handler_spec.cr" (failed codegen)
-# require "./std/http/server/handlers/log_handler_spec.cr" (failed codegen)
-# require "./std/http/server/handlers/static_file_handler_spec.cr" (failed codegen)
+require "./std/http/server/handlers/error_handler_spec.cr"
+require "./std/http/server/handlers/handler_spec.cr"
+require "./std/http/server/handlers/log_handler_spec.cr"
+require "./std/http/server/handlers/static_file_handler_spec.cr"
 # require "./std/http/server/handlers/websocket_handler_spec.cr" (failed codegen)
-# require "./std/http/server/request_processor_spec.cr" (failed codegen)
-# require "./std/http/server/response_spec.cr" (failed linking)
+require "./std/http/server/request_processor_spec.cr"
+require "./std/http/server/response_spec.cr"
 # require "./std/http/server/server_spec.cr" (failed codegen)
-# require "./std/http/status_spec.cr" (failed codegen)
+require "./std/http/status_spec.cr"
 # require "./std/http/web_socket_spec.cr" (failed codegen)
 require "./std/humanize_spec.cr"
 require "./std/indexable_spec.cr"

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -158,7 +158,7 @@ require "./std/raise_spec.cr"
 require "./std/random/isaac_spec.cr"
 require "./std/random/pcg32_spec.cr"
 require "./std/random/secure_spec.cr"
-# require "./std/random_spec.cr" (failed linking)
+require "./std/random_spec.cr"
 # require "./std/range_spec.cr" (failed linking)
 require "./std/record_spec.cr"
 require "./std/reference_spec.cr"

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -192,6 +192,10 @@ module Crystal::System::File
     end
   end
 
+  def self.readlink(path) : String
+    raise NotImplementedError.new("readlink")
+  end
+
   def self.rename(old_path : String, new_path : String) : Nil
     if LibC._wrename(to_windows_path(old_path), to_windows_path(new_path)) != 0
       raise Errno.new("Error renaming file from #{old_path.inspect} to #{new_path.inspect}")

--- a/src/http.cr
+++ b/src/http.cr
@@ -1,9 +1,9 @@
 require "uri"
-{% if flag?(:win32) %}
-  require "./http/common"
-{% else %}
-  require "./http/**"
+{% unless flag?(:win32) %}
+  require "./http/client"
+  require "./http/server"
 {% end %}
+require "./http/common"
 
 # The HTTP module contains `HTTP::Client`, `HTTP::Server` and `HTTP::WebSocket` implementations.
 module HTTP

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -1,4 +1,3 @@
-require "../client"
 require "../common"
 require "mime/media_type"
 

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -291,7 +291,7 @@ module HTTP
     end
 
     # Adds `Cookie` headers for the cookies in this collection to the
-    # given `HTTP::Header` instance and returns it. Removes any existing
+    # given `HTTP::Headers` instance and returns it. Removes any existing
     # `Cookie` headers in it.
     def add_request_headers(headers)
       headers.delete("Cookie")
@@ -301,7 +301,7 @@ module HTTP
     end
 
     # Adds `Set-Cookie` headers for the cookies in this collection to the
-    # given `HTTP::Header` instance and returns it. Removes any existing
+    # given `HTTP::Headers` instance and returns it. Removes any existing
     # `Set-Cookie` headers in it.
     def add_response_headers(headers)
       headers.delete("Set-Cookie")

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -3,6 +3,7 @@ require "uri"
 require "./server/context"
 require "./server/handler"
 require "./server/response"
+require "./server/request_processor"
 require "./common"
 {% unless flag?(:without_openssl) %}
   require "openssl"

--- a/src/http/server/context.cr
+++ b/src/http/server/context.cr
@@ -1,3 +1,6 @@
+require "../request"
+require "./response"
+
 class HTTP::Server
   # Instances of this class are passed to an `HTTP::Server` handler.
   class Context

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -1,3 +1,5 @@
+require "./context"
+
 # A handler is a class which includes `HTTP::Handler` and implements the `call` method.
 # You can use a handler to intercept any incoming request and can modify the response.
 # These can be used for request throttling, ip-based whitelisting, adding custom headers e.g.

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:win32) %}
+
 require "base64"
 require "../../web_socket"
 

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -1,4 +1,4 @@
-require "../server"
+require "./handler"
 
 class HTTP::Server::RequestProcessor
   # Maximum permitted size of the request line in an HTTP request.

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -1,3 +1,7 @@
+require "http/headers"
+require "http/status"
+require "http/cookie"
+
 class HTTP::Server
   # The response to configure and write to in an `HTTP::Server` handler.
   #
@@ -29,6 +33,8 @@ class HTTP::Server
     # The status code of this response, which must be set before writing the response
     # body. If not set, the default value is 200 (OK).
     property status : HTTP::Status
+
+    @cookies : HTTP::Cookies?
 
     # :nodoc:
     def initialize(@io : IO, @version = "HTTP/1.1")

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -178,6 +178,7 @@ class Logger
 
     progname_to_s = progname.to_s
     message_to_s = message.to_s
+
     @mutex.synchronize do
       formatter.call(severity, datetime, progname_to_s, message_to_s, io)
       io.puts

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -119,11 +119,12 @@ module Spec
 
     private def classname(result)
       path = Path[result.file].expand
-      path.to_s
+      path = path.to_s
         .lchop(Dir.current)
         .rchop(path.extension)
-        .gsub(File::SEPARATOR, '.')
-        .strip('.')
+        .lchop(Path::SEPARATORS[0])
+
+      Path[path].parts.join(".")
     end
   end
 end

--- a/src/windows_stubs.cr
+++ b/src/windows_stubs.cr
@@ -64,6 +64,36 @@ class Process
   def self.exit(status = 0)
     LibC.exit(status)
   end
+
+  def self.pid
+    1
+  end
+end
+
+class Mutex
+  enum Protection
+    Checked
+    Reentrant
+    Unchecked
+  end
+
+  def initialize(@protection : Protection = :checked)
+  end
+
+  def lock
+  end
+
+  def unlock
+  end
+
+  def synchronize
+    lock
+    begin
+      yield
+    ensure
+      unlock
+    end
+  end
 end
 
 def sleep(seconds : Number)


### PR DESCRIPTION
Followup on #8670. This PR enables a lot of more specs for building on win32.

Often just a few specs needed to be disabled in order to make the rest of a spec file compile and pass. This affects mostly specs working with big numbers or yaml.

All specs pass on win32.

With this and #8668 we should get 6464 examples passing on win32, that's 70% of all standard lib specs.