### PR TITLE
Spec::JUnitFormatter: Allow output directory as --junit_output

### DIFF
--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -35,6 +35,10 @@ module Spec
     end
 
     def self.file(output_path : Path)
+      if output_path.extension != ".xml"
+        output_path = output_path.join("output.xml")
+      end
+
       Dir.mkdir_p(output_path.dirname)
       file = File.new(output_path, "w")
       JUnitFormatter.new(file)


### PR DESCRIPTION
Follow up of https://github.com/crystal-lang/crystal/pull/8599#issuecomment-575214414