### PR TITLE
Add a `empty?` method for `IO`.

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -128,6 +128,13 @@ abstract class IO
     raise IO::Error.new "Closed stream" if closed?
   end
 
+  # Returns `true` when all buffered data as been read.
+  #
+  # `IO` defines this as a `true` value, but including types may override.
+  def empty? : Bool
+    true
+  end
+
   # Flushes buffered data, if any.
   #
   # `IO` defines this is a no-op method, but including types may override.

--- a/src/io.cr
+++ b/src/io.cr
@@ -128,7 +128,7 @@ abstract class IO
     raise IO::Error.new "Closed stream" if closed?
   end
 
-  # Returns `true` when all buffered data as been read.
+  # Returns `true` when all buffered data has been read.
   #
   # `IO` defines this as a `true` value, but including types may override.
   def empty? : Bool

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -43,7 +43,7 @@ module IO::Buffered
     @buffer_size = value
   end
 
-  # Indicates if there is the input buffer is empty.
+  # Indicates if the input buffer is empty.
   def empty? : Bool
     @in_buffer_rem.size == 0
   end

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -43,6 +43,11 @@ module IO::Buffered
     @buffer_size = value
   end
 
+  # Indicates if there is the input buffer is empty.
+  def empty? : Bool
+    @in_buffer_rem.size == 0
+  end
+
   # :nodoc:
   def read_byte : UInt8?
     check_open


### PR DESCRIPTION
This PR adds an **empty?** method to the `IO` class allowing to know when there are still data in the input buffer. This is relevant for any class including the `IO::Buffered` module, such as the `Socket` class for instance.

This problem has been discussed here: https://forum.crystal-lang.org/t/check-for-new-received-message-in-http-websocket/1599/3

Thanks to the reviewers!

EDIT: of course, it's always when you pushed your code that you see your typos everywhere... but now it's fixed.