### PR TITLE
`JSON::PullParser` overflow handling

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -329,4 +329,49 @@ describe JSON::PullParser do
     assert_raw %({"foo":[1,2,{"bar":[1,"hello",true,false,1.5]}]})
     assert_raw %({"foo":"bar"})
   end
+
+  describe "read?" do
+    {% for pair in [[Int8, 1_i8],
+                    [Int16, 1_i16],
+                    [Int32, 1_i32],
+                    [Int64, 1_i64],
+                    [UInt8, 1_u8],
+                    [UInt16, 1_u16],
+                    [UInt32, 1_u32],
+                    [UInt64, 1_u64],
+                    [Float32, 1.0_f32],
+                    [Float64, 1.0],
+                    [String, "foo"],
+                    [Bool, true]] %}
+      {% type = pair[0] %}
+      {% value = pair[1] %}
+
+      it "reads {{type}} when the token is a compatible kind" do
+        pull = JSON::PullParser.new({{value}}.to_json)
+        pull.read?({{type}}).should eq({{value}})
+      end
+
+      it "returns nil instead of {{type}} when the token is not compatible" do
+        pull = JSON::PullParser.new(%({"foo": "bar"}))
+        pull.read?({{type}}).should be_nil
+      end
+    {% end %}
+
+    {% for pair in [[Int8, Int64::MAX],
+                    [Int16, Int64::MAX],
+                    [Int32, Int64::MAX],
+                    [UInt8, -1],
+                    [UInt16, -1],
+                    [UInt32, -1],
+                    [UInt64, -1],
+                    [Float32, Float64::MAX]] %}
+      {% type = pair[0] %}
+      {% value = pair[1] %}
+
+      it "returns nil in place of {{type}} when an overflow occurs" do
+        pull = JSON::PullParser.new({{value}}.to_json)
+        pull.read?({{type}}).should be_nil
+      end
+    {% end %}
+  end
 end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -234,6 +234,17 @@ describe "JSON serialization" do
         end
         ex.location.should eq({2, 3})
       end
+
+      it "captures overflows for integer types" do
+        ex = expect_raises(JSON::ParseException) do
+          Array(Int32).from_json <<-JSON
+            [
+              #{Int64::MAX.to_json}
+            ]
+            JSON
+        end
+        ex.location.should eq({2, 3})
+      end
     end
   end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -77,7 +77,13 @@ end
                          "UInt64" => "u64",
                        } %}
   def {{type.id}}.new(pull : JSON::PullParser)
-    {{type.id}}.new!(pull.read_int)
+    location = pull.location
+    value = pull.read_int
+    begin
+      value.to_{{method.id}}
+    rescue ex : OverflowError
+      raise JSON::ParseException.new("Can't read {{type.id}}", *location, ex)
+    end
   end
 
   def {{type.id}}.from_json_object_key?(key : String)

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -279,7 +279,7 @@ class JSON::PullParser
   # UInt64 is a special case due to exceeding bounds of @int_value
   def read?(klass : UInt64.class)
     UInt64.new(raw_value).tap { read_next } if kind.int?
-  rescue OverflowError
+  rescue ArgumentError
     nil
   end
 

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -268,41 +268,26 @@ class JSON::PullParser
     read_bool if kind.bool?
   end
 
-  def read?(klass : Int8.class)
-    read_int.to_i8! if kind.int?
-  end
+  {% for type in [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32] %}
+    def read?(klass : {{type}}.class)
+      {{type}}.new(int_value).tap { read_next } if kind.int?
+    rescue OverflowError
+      nil
+    end
+  {% end %}
 
-  def read?(klass : Int16.class)
-    read_int.to_i16! if kind.int?
-  end
-
-  def read?(klass : Int32.class)
-    read_int.to_i32! if kind.int?
-  end
-
-  def read?(klass : Int64.class)
-    read_int.to_i64! if kind.int?
-  end
-
-  def read?(klass : UInt8.class)
-    read_int.to_u8! if kind.int?
-  end
-
-  def read?(klass : UInt16.class)
-    read_int.to_u16! if kind.int?
-  end
-
-  def read?(klass : UInt32.class)
-    read_int.to_u32! if kind.int?
-  end
-
+  # UInt64 is a special case due to exceeding bounds of @int_value
   def read?(klass : UInt64.class)
-    read_int.to_u64! if kind.int?
+    UInt64.new(raw_value).tap { read_next } if kind.int?
+  rescue OverflowError
+    nil
   end
 
   def read?(klass : Float32.class)
     return read_int.to_f32 if kind.int?
-    return read_float.to_f32 if kind.float?
+    return float_value.to_f32.tap { read_next } if kind.float?
+  rescue OverflowError
+    nil
   end
 
   def read?(klass : Float64.class)


### PR DESCRIPTION
Changes behaviour of:

- `JSON::PullParser#read?` to either fully read into the specified type, or return nil
- Numeric primitive instantiation from `JSON::PullParser` to raise a `JSON::ParseException` wrapping an `OverflowError` in the case of overflow.

Fixes #8694