### PR TITLE
Fix expected error message in libxml2 error spec

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -158,23 +158,14 @@ describe XML do
   end
 
   it "handles errors" do
-    xml = XML.parse(%(<people>))
+    xml = XML.parse(%(<people></foo>))
     xml.root.not_nil!.name.should eq("people")
     errors = xml.errors.not_nil!
     errors.size.should eq(1)
 
-    # Starting from libxml2 2.9.10 the error message has changed,
-    # both messages are accepted.
-    if errors[0].message.not_nil!.starts_with?("Premature")
-      # libxml2 < 2.9.10
-      expected_message = "Premature end of data in tag people line 1"
-    else
-      # libxml2 >= 2.9.10
-      expected_message = "EndTag: '</' not found"
-    end
-    errors[0].message.should eq(expected_message)
+    errors[0].message.should eq("Opening and ending tag mismatch: people line 1 and foo")
     errors[0].line_number.should eq(1)
-    errors[0].to_s.should eq(expected_message)
+    errors[0].to_s.should eq("Opening and ending tag mismatch: people line 1 and foo")
   end
 
   it "gets root namespaces scopes" do

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -162,9 +162,19 @@ describe XML do
     xml.root.not_nil!.name.should eq("people")
     errors = xml.errors.not_nil!
     errors.size.should eq(1)
-    errors[0].message.should eq("Premature end of data in tag people line 1")
+
+    # Starting from libxml2 2.9.10 the error message has changed,
+    # both messages are accepted.
+    if errors[0].message.not_nil!.starts_with?("Premature")
+      # libxml2 < 2.9.10
+      expected_message = "Premature end of data in tag people line 1"
+    else
+      # libxml2 >= 2.9.10
+      expected_message = "EndTag: '</' not found"
+    end
+    errors[0].message.should eq(expected_message)
     errors[0].line_number.should eq(1)
-    errors[0].to_s.should eq("Premature end of data in tag people line 1")
+    errors[0].to_s.should eq(expected_message)
   end
 
   it "gets root namespaces scopes" do


### PR DESCRIPTION
Starting from libxml2 2.9.10 the error message for the case we're testing has changed from `Premature end of data in tag people line 1` to `EndTag: '</' not found`.
The change was introduced by this commit in libxml2: https://gitlab.gnome.org/GNOME/libxml2/commit/62150ed2ab19a4dd76c15acc62c7d923d9f3b2cc