### PR TITLE
Fix TCPServer spec to not assume error message for double binding

### DIFF
--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -54,7 +54,7 @@ describe TCPServer do
 
         it "raises when not binding with reuse_port" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
-            expect_raises_errno(Errno::EADDRINUSE, {% if flag?(:gnu) %}"listen: "{% else %}"bind: "{% end %}) do
+            expect_raises_errno(Errno::EADDRINUSE) do
               TCPServer.open(address, server.local_address.port) { }
             end
           end


### PR DESCRIPTION
Latest glibc has changed to report failure at `bind: `. To avoid validating over-specific error message, it should be sufficient to check for EADDRINUSE.

Fixes #7422