### PR TITLE
Fix typo in example

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -732,7 +732,7 @@ end
 #
 # ```
 # select
-# when x = ch.recieve
+# when x = ch.receive
 #   puts "got #{x}"
 # when timeout(1.seconds)
 #   puts "timeout"


### PR DESCRIPTION
Related #8704

Since #8506 is in 0.33.0 already it would make sense to add this fix in 0.33.0 too.