### PR TITLE
IO: Detect closed IO when resuming readable/writable event

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -828,7 +828,7 @@ describe IO do
         ch = Channel(Symbol).new(1)
 
         IO.pipe do |read, write|
-          spawn do
+          f = spawn do
             ch.send :start
             read.gets
           rescue
@@ -838,6 +838,10 @@ describe IO do
           delay(1) { ch.send :timeout }
 
           ch.receive.should eq(:start)
+          while f.running?
+            # Wait until the fiber is blocked
+            Fiber.yield
+          end
           read.close
           ch.receive.should eq(:end)
         end

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -108,7 +108,7 @@ describe UDPSocket do
           sleep 100.milliseconds
           udp.close
         end
-        expect_raises_errno(Errno::EBADF, "Error receiving datagram: Bad file descriptor") { udp.receive }
+        expect_raises(IO::Error, "Closed stream") { udp.receive }
       end
     end
   end

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -40,6 +40,13 @@ module Crystal::System::File
 
     oflag = m | o
   end
+
+  # Closes the internal file descriptor without notifying libevent.
+  # This is directly used after the fork of a process to close the
+  # parent's Crystal::Signal.@@pipe reference before re initializing
+  # the event loop. In the case of a fork that will exec there is even
+  # no need to initialize the event loop at all.
+  # def file_description_close
 end
 
 {% if flag?(:unix) %}

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -46,7 +46,7 @@ module Crystal::System::File
   # parent's Crystal::Signal.@@pipe reference before re initializing
   # the event loop. In the case of a fork that will exec there is even
   # no need to initialize the event loop at all.
-  # def file_description_close
+  # def file_descriptor_close
 end
 
 {% if flag?(:unix) %}

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -115,10 +115,10 @@ module Crystal::System::FileDescriptor
     # always lead to undefined results. This is not specific to libevent.
     evented_close
 
-    file_description_close
+    file_descriptor_close
   end
 
-  def file_description_close
+  def file_descriptor_close
     if LibC.close(@fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -115,6 +115,10 @@ module Crystal::System::FileDescriptor
     # always lead to undefined results. This is not specific to libevent.
     evented_close
 
+    file_description_close
+  end
+
+  def file_description_close
     if LibC.close(@fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -114,6 +114,10 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_close
+    file_description_close
+  end
+
+  def file_description_close
     err = nil
     if LibC._close(@fd) != 0
       case Errno.value

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -114,10 +114,10 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_close
-    file_description_close
+    file_descriptor_close
   end
 
-  def file_description_close
+  def file_descriptor_close
     err = nil
     if LibC._close(@fd) != 0
       case Errno.value

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -131,6 +131,8 @@ module IO::Evented
       @read_timed_out = false
       yield Timeout.new("Read timed out")
     end
+
+    check_open
   end
 
   private def add_read_event(timeout = @read_timeout) : Nil
@@ -154,6 +156,8 @@ module IO::Evented
       @write_timed_out = false
       yield Timeout.new("Write timed out")
     end
+
+    check_open
   end
 
   private def add_write_event(timeout = @write_timeout) : Nil

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -177,7 +177,11 @@ class IO::FileDescriptor < IO
   private def unbuffered_close
     return if @closed
 
-    system_close ensure @closed = true
+    # Set before the @closed state so the pending
+    # IO::Evented readers and writers can be cancelled
+    # knowing the IO is in a closed state.
+    @closed = true
+    system_close
   end
 
   private def unbuffered_flush

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -220,7 +220,7 @@ module Crystal::Signal
   # Replaces the signal pipe so the child process won't share the file
   # descriptors of the parent process and send it received signals.
   def self.after_fork
-    @@pipe.each(&.close)
+    @@pipe.each(&.file_description_close)
   ensure
     @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
   end
@@ -243,7 +243,7 @@ module Crystal::Signal
     end
   ensure
     {% unless flag?(:preview_mt) %}
-      @@pipe.each(&.close)
+      @@pipe.each(&.file_description_close)
     {% end %}
   end
 

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -220,7 +220,7 @@ module Crystal::Signal
   # Replaces the signal pipe so the child process won't share the file
   # descriptors of the parent process and send it received signals.
   def self.after_fork
-    @@pipe.each(&.file_description_close)
+    @@pipe.each(&.file_descriptor_close)
   ensure
     @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
   end
@@ -243,7 +243,7 @@ module Crystal::Signal
     end
   ensure
     {% unless flag?(:preview_mt) %}
-      @@pipe.each(&.file_description_close)
+      @@pipe.each(&.file_descriptor_close)
     {% end %}
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -556,6 +556,12 @@ class Socket < IO
   private def unbuffered_close
     return if @closed
 
+    # Perform libevent cleanup before LibC.close.
+    # Using a file descriptor after it has been closed is never defined and can
+    # always lead to undefined results. This is not specific to libevent.
+    @closed = true
+    evented_close
+
     err = nil
     if LibC.close(@fd) != 0
       case Errno.value
@@ -565,9 +571,6 @@ class Socket < IO
         err = Errno.new("Error closing socket")
       end
     end
-
-    @closed = true
-    evented_close
 
     raise err if err
   end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -250,7 +250,7 @@ class Socket < IO
         if closed?
           return
         elsif Errno.value == Errno::EAGAIN
-          wait_readable
+          wait_readable rescue nil
         else
           raise Errno.new("accept")
         end


### PR DESCRIPTION
This should fix some race conditions detected in the preview_mt build.

I think there are still some race conditions in `IO::Evented` since there is no guarantee that, for example, a thread closes the IO while another thread has already initiated a read operation, succeed the `check_open` in `IO::Bufferend#read`, but haven't reach the unbuffered_read -> evented_read -> wait_readable.

There is currently no mechanism to ensure that the check for open IO holds long enough until the fibers reschedule.

Even without fixing that scenario this PR should improove the current state for MT:

* If the IO was closed by another thread while waiting we need to check if it's open or not.
* If it's closed an IO::Error is raised as a result of the read/write operation as if the IO was has been closed from the beginning.
* The event_close is now performed before actually closing the underlying file descriptor to prevent libevent accessing it in a closed state.
* The @closed = true in IO::FileDescriptor needs to happen before the system_close so it is available when the awaiting fibers are woken up.