### PR TITLE
Ensure sending fiber finished in select specs

### DIFF
--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -128,7 +128,7 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    while !f.dead?
+    until f.dead?
       Fiber.yield
     end
     x.should eq(1)
@@ -156,7 +156,7 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    while !f.dead?
+    until f.dead?
       Fiber.yield
     end
     x.should eq(1)

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -114,7 +114,7 @@ describe "select" do
     ch3 = Channel(Int32).new
     x = nil
 
-    spawn do
+    f = spawn do
       select
       when x = ch1.receive
       when x = ch2.receive
@@ -128,7 +128,9 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    Fiber.yield
+    while !f.dead?
+      Fiber.yield
+    end
     x.should eq(1)
   end
 
@@ -138,7 +140,7 @@ describe "select" do
     ch3 = Channel(Int32).new
     x = nil
 
-    spawn do
+    f = spawn do
       select
       when ch1.send 1
         x = 1
@@ -154,7 +156,9 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    Fiber.yield
+    while !f.dead?
+      Fiber.yield
+    end
     x.should eq(1)
   end
 


### PR DESCRIPTION
These specs are failing every now and then on preview_mt.

The changes ensure the sending fiber finished executing before performing the assertion in the main fiber.

Sample of the failure: https://circleci.com/gh/crystal-lang/crystal/37483?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link