### PR TITLE
Ensure LibUnwind::Exception struct is not atomic

### DIFF
--- a/spec/std/data/collect_within_ensure
+++ b/spec/std/data/collect_within_ensure
@@ -1,0 +1,5 @@
+begin
+  raise "Oh no!"
+ensure
+  GC.collect
+end

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -47,14 +47,16 @@ describe "Exception" do
     ex.inspect_with_backtrace.should contain("inner")
   end
 
-  it "collect memory within ensure block" do
-    sample = datapath("collect_within_ensure")
+  {% unless flag?(:win32) %}
+    it "collect memory within ensure block" do
+      sample = datapath("collect_within_ensure")
 
-    output, error = compile_and_run_file(sample)
+      output, error = compile_and_run_file(sample)
 
-    output.to_s.empty?.should be_true
-    error.to_s.should contain("Unhandled exception: Oh no! (Exception)")
-    error.to_s.should_not contain("Invalid memory access")
-    error.to_s.should_not contain("Illegal instruction")
-  end
+      output.to_s.empty?.should be_true
+      error.to_s.should contain("Unhandled exception: Oh no! (Exception)")
+      error.to_s.should_not contain("Invalid memory access")
+      error.to_s.should_not contain("Illegal instruction")
+    end
+  {% end %}
 end

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -1,4 +1,16 @@
-require "spec"
+require "./spec_helper"
+
+private def compile_and_run_file(source_file)
+  with_tempfile("executable_file") do |executable_file|
+    Process.run("bin/crystal", ["build", "--release", "-o", executable_file, source_file])
+    File.exists?(executable_file).should be_true
+
+    output, error = IO::Memory.new, IO::Memory.new
+    Process.run executable_file, output: output, error: error
+
+    {output.to_s, error.to_s}
+  end
+end
 
 private class FooError < Exception
   def message
@@ -33,5 +45,16 @@ describe "Exception" do
     ex.inspect_with_backtrace.should contain("wrapper")
     ex.inspect_with_backtrace.should contain("Caused by")
     ex.inspect_with_backtrace.should contain("inner")
+  end
+
+  it "collect memory within ensure block" do
+    sample = datapath("collect_within_ensure")
+
+    output, error = compile_and_run_file(sample)
+
+    output.to_s.empty?.should be_true
+    error.to_s.should contain("Unhandled exception: Oh no! (Exception)")
+    error.to_s.should_not contain("Invalid memory access")
+    error.to_s.should_not contain("Illegal instruction")
   end
 end

--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -115,7 +115,7 @@ lib LibUnwind
       exception_cleanup : LibC::SizeT
       private1 : UInt64
       private2 : UInt64
-      exception_object : UInt64
+      exception_object : Void*
       exception_type_id : Int32
     end
 

--- a/src/callstack/lib_unwind.cr
+++ b/src/callstack/lib_unwind.cr
@@ -97,7 +97,7 @@ lib LibUnwind
       pr_cache : ControlBlock_PrCache
       # __align : LibC::LongLong # Force alignment of next item to 8-byte boundary
 
-      exception_object : UInt64
+      exception_object : Void*
       exception_type_id : Int32
       __align : StaticArray(UInt8, 4)
     end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -200,7 +200,7 @@ end
 
   # :nodoc:
   fun __crystal_get_exception(unwind_ex : LibUnwind::Exception*) : UInt64
-    unwind_ex.value.exception_object
+    unwind_ex.value.exception_object.address
   end
 
   # Raises the *exception*.
@@ -218,7 +218,7 @@ end
     unwind_ex = Pointer(LibUnwind::Exception).malloc
     unwind_ex.value.exception_class = LibC::SizeT.zero
     unwind_ex.value.exception_cleanup = LibC::SizeT.zero
-    unwind_ex.value.exception_object = exception.object_id
+    unwind_ex.value.exception_object = exception.as(Void*)
     unwind_ex.value.exception_type_id = exception.crystal_type_id
     __crystal_raise(unwind_ex)
   end


### PR DESCRIPTION
Currently any structure not containing any pointer is allocated with `GC.malloc_atomic`. This makes the GC faster by avoiding scan some memory regions unnecessary.

`LibUnwind::Exception` actually contains a pointer but it was being casted to `UInt64` hidding it from the compiler.

When the `ensure` block for example, contains calls that ends running the GC, the exception object would be cleaned. Later the exception is re-raised but now with a dangling pointer.

The problem was easily reproduced running this code in release mode:

```crystal
begin
  raise "Oh no!"
ensure
  GC.collect
end
```