### PR TITLE
IO: Polish IO closing for MT

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -386,6 +386,14 @@ describe IO do
 
       str.read_fully?(slice).should be_nil
     end
+
+    it "raises if trying to read to an IO not opened for reading" do
+      IO.pipe do |r, w|
+        expect_raises(IO::Error, "File not open for reading") do
+          w.gets
+        end
+      end
+    end
   end
 
   describe "write operations" do
@@ -472,6 +480,17 @@ describe IO do
       io << "hello"
       io.skip_to_end
       io.read_byte.should be_nil
+    end
+
+    it "raises if trying to write to an IO not opened for writing" do
+      IO.pipe do |r, w|
+        # unless sync is used the flush on close triggers the exception again
+        r.sync = true
+
+        expect_raises(IO::Error, "File not open for writing") do
+          r << "hello"
+        end
+      end
     end
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -822,54 +822,54 @@ describe IO do
         io.encoding.should eq("UTF-16LE")
       end
     end
+  end
 
-    describe "#close" do
-      it "aborts 'read' in a different thread" do
-        ch = Channel(Symbol).new(1)
+  describe "#close" do
+    it "aborts 'read' in a different thread" do
+      ch = Channel(Symbol).new(1)
 
-        IO.pipe do |read, write|
-          f = spawn do
-            ch.send :start
-            read.gets
-          rescue
-            ch.send :end
-          end
-
-          delay(1) { ch.send :timeout }
-
-          ch.receive.should eq(:start)
-          while f.running?
-            # Wait until the fiber is blocked
-            Fiber.yield
-          end
-          read.close
-          ch.receive.should eq(:end)
+      IO.pipe do |read, write|
+        f = spawn do
+          ch.send :start
+          read.gets
+        rescue
+          ch.send :end
         end
+
+        delay(1) { ch.send :timeout }
+
+        ch.receive.should eq(:start)
+        while f.running?
+          # Wait until the fiber is blocked
+          Fiber.yield
+        end
+        read.close
+        ch.receive.should eq(:end)
       end
+    end
 
-      it "aborts 'write' in a different thread" do
-        ch = Channel(Symbol).new(1)
+    it "aborts 'write' in a different thread" do
+      ch = Channel(Symbol).new(1)
 
-        IO.pipe do |read, write|
-          f = spawn do
-            ch.send :start
-            loop do
-              write.puts "some line"
-            end
-          rescue
-            ch.send :end
+      IO.pipe do |read, write|
+        f = spawn do
+          ch.send :start
+          loop do
+            write.puts "some line"
           end
-
-          delay(1) { ch.send :timeout }
-
-          ch.receive.should eq(:start)
-          while f.running?
-            # Wait until the fiber is blocked
-            Fiber.yield
-          end
-          write.close
-          ch.receive.should eq(:end)
+        rescue
+          ch.send :end
         end
+
+        delay(1) { ch.send :timeout }
+
+        ch.receive.should eq(:start)
+        while f.running?
+          # Wait until the fiber is blocked
+          Fiber.yield
+        end
+        write.close
+        ch.receive.should eq(:end)
       end
     end
   end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -9,7 +9,11 @@ module Crystal::System::FileDescriptor
 
   private def unbuffered_read(slice : Bytes)
     evented_read(slice, "Error reading file") do
-      LibC.read(@fd, slice, slice.size)
+      LibC.read(@fd, slice, slice.size).tap do |return_code|
+        if return_code == -1 && Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for reading"
+        end
+      end
     end
   end
 

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -6,7 +6,11 @@ module Crystal::System::FileDescriptor
   private def unbuffered_read(slice : Bytes)
     bytes_read = LibC._read(@fd, slice, slice.size)
     if bytes_read == -1
-      raise Errno.new("Error reading file")
+      if Errno.value == Errno::EBADF
+        raise IO::Error.new "File not open for reading"
+      else
+        raise Errno.new("Error reading file")
+      end
     end
     bytes_read
   end

--- a/src/crystal/thread_local_value.cr
+++ b/src/crystal/thread_local_value.cr
@@ -24,7 +24,7 @@ struct Crystal::ThreadLocalValue(T)
     end
   end
 
-  def each_and_clear
+  def consume_each
     @mutex.sync do
       @values.each_value { |t| yield t }
       @values.clear

--- a/src/crystal/thread_local_value.cr
+++ b/src/crystal/thread_local_value.cr
@@ -24,14 +24,9 @@ struct Crystal::ThreadLocalValue(T)
     end
   end
 
-  def each
+  def each_and_clear
     @mutex.sync do
       @values.each_value { |t| yield t }
-    end
-  end
-
-  def clear
-    @mutex.sync do
       @values.clear
     end
   end

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -170,21 +170,17 @@ module IO::Evented
   end
 
   def evented_close
-    @read_event.each &.free
-    @read_event.clear
+    @read_event.each_and_clear &.free
 
-    @write_event.each &.free
-    @write_event.clear
+    @write_event.each_and_clear &.free
 
-    @readers.each do |readers|
+    @readers.each_and_clear do |readers|
       Crystal::Scheduler.enqueue readers
     end
-    @readers.clear
 
-    @writers.each do |writers|
+    @writers.each_and_clear do |writers|
       Crystal::Scheduler.enqueue writers
     end
-    @writers.clear
   end
 
   private def resume_pending_readers

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -170,15 +170,15 @@ module IO::Evented
   end
 
   def evented_close
-    @read_event.each_and_clear &.free
+    @read_event.consume_each &.free
 
-    @write_event.each_and_clear &.free
+    @write_event.consume_each &.free
 
-    @readers.each_and_clear do |readers|
+    @readers.consume_each do |readers|
       Crystal::Scheduler.enqueue readers
     end
 
-    @writers.each_and_clear do |writers|
+    @writers.consume_each do |writers|
       Crystal::Scheduler.enqueue writers
     end
   end


### PR DESCRIPTION
For now IO#close is not thread-safe. You should not close the IO from concurrently.

Even though if that's the case, before this PR the LibEvent events could be freed twice and the awaiting readers/writers fibers could be enqueued again. This is now fixed by the changes in `io/evented.cr`.

I also align the exception raised when the awaiting reader is awakened with a EBADF / closed fd.

The `IO::Error` added is to match the description when a writer is awakened with a EBADF. These does not match 100% the error if the fd was closed from the beginning. This bugs me a little.

Also the `socket.cr` does not have this special handling of Errno in `unbuffered_read`/`unbuffered_write`.

The exact exception type and message might come back with Errno exceptions are revisited.

After this PR if `IO#close` is called concurrently from multiple threads one might fail with `Errno.new("Error closing file")` in `Crystal::System::FileDescriptor#file_descriptor_close` since the fd might be already closed. Without adding a lock for `IO#close` it is not possible to prevent this situation. The implementation of `evented_close` it is thread-safe now and that protects the runtime enough.