### PR TITLE
Top level exception handler

### DIFF
--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -82,8 +82,10 @@ module Crystal
   # is not setup yet, so nothing that allocates memory
   # in Crystal (like `new` for classes) can be used.
   def self.main(argc : Int32, argv : UInt8**)
-    main do
-      main_user_code(argc, argv)
+    handle_exceptions do
+      main do
+        main_user_code(argc, argv)
+      end
     end
   end
 
@@ -95,6 +97,26 @@ module Crystal
   # more details.
   def self.main_user_code(argc : Int32, argv : UInt8**)
     LibCrystalMain.__crystal_main(argc, argv)
+  end
+
+  protected def self.handle_exceptions
+    begin
+      yield
+    rescue e
+      LibC.dprintf 2, "Unhandled exception in main (%s): %s\n", e.class.name, e.message || "(no message)"
+      begin
+        if bt = e.backtrace?
+          bt.each do |frame|
+            LibC.dprintf 2, "  %s\n", frame
+          end
+        else
+          LibC.dprintf 2, "  (no backtrace)\n"
+        end
+      rescue e
+        LibC.dprintf 2, "Error while trying to dump the backtrace (%s): %s\n", e.class.name, e.message || "(no message)"
+      end
+      2
+    end
   end
 end
 

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -103,17 +103,17 @@ module Crystal
     begin
       yield
     rescue e
-      LibC.dprintf 2, "Unhandled exception in main (%s): %s\n", e.class.name, e.message || "(no message)"
+      Crystal::System.print_error "Unhandled exception in main (%s): %s\n", e.class.name, e.message || "(no message)"
       begin
         if bt = e.backtrace?
           bt.each do |frame|
-            LibC.dprintf 2, "  %s\n", frame
+            Crystal::System.print_error "  %s\n", frame
           end
         else
-          LibC.dprintf 2, "  (no backtrace)\n"
+          Crystal::System.print_error "  (no backtrace)\n"
         end
       rescue e
-        LibC.dprintf 2, "Error while trying to dump the backtrace (%s): %s\n", e.class.name, e.message || "(no message)"
+        Crystal::System.print_error "Error while trying to dump the backtrace (%s): %s\n", e.class.name, e.message || "(no message)"
       end
       2
     end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -334,7 +334,7 @@ fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
       stack_bottom = Fiber.current.@stack_bottom
       stack_top <= addr < stack_bottom
     rescue e
-      LibC.dprintf 2, "Error while trying to determine if a stack overflow has occurred. Probable memory corrpution\n"
+      Crystal::System.print_error "Error while trying to determine if a stack overflow has occurred. Probable memory corrpution\n"
       false
     end
 


### PR DESCRIPTION
There are many issues where the reported error contains a `Failed to raise an exception: END_OF_STACK`. Many times this is because an error happens outside the `begin/rescue` around `__crystal_main` and it ends hiding the real source of the issue. (#8387, #6249, #7810, among others)

I added this exception handler a the top level of `Crystal.main` to dump the unhandled exception. I tried to be as conservative as possible, executing the least amount of Crystal's std code.