### PR TITLE
Refactor Crystal::Init adding name validation

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -63,10 +63,9 @@ The crystal command accepts the following options
 .It
 .Cm init
 TYPE
-NAME
-.Op DIR
+.Op DIR | NAME DIR
 .Pp
-Generate a new project.
+Generates a new Crystal project.
 .Pp
 TYPE is one of:
 .Bl -tag -width "12345678" -compact
@@ -79,9 +78,9 @@ Creates an application skeleton
 
 This initializes the lib/app project folder as a git repository, with a license file, a README file, a .travis.yml file for Travis CI integration, a shard.yml for use with shards (the Crystal dependency manager), a .gitignore file, and src and spec folders.
 .Bd -literal -offset
-NAME - name of project to be generated, e.g.: example
+DIR  - directory where project will be generated
 .Pp
-DIR  - directory where project will be generated, default: NAME
+NAME - name of project to be generated (default: basename of DIR)
 .Ed
 .Pp
 Options:

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -228,12 +228,15 @@ module Crystal
 
     it "errors if files will be overwritten by a generated file" do
       within_temporary_directory do
-        File.touch("README.md")
+        File.write("README.md", "content before init")
 
         ex = expect_raises(Crystal::Init::FilesConflictError) do
           exec_init("my_lib", ".")
         end
-        ex.conflicting_files.should contain("./README.md")
+        ex.conflicting_files.should contain("README.md")
+
+        File.read("README.md").should eq("content before init")
+        File.exists?("LICENSE").should_not be_true
       end
     end
 
@@ -258,6 +261,112 @@ module Crystal
         File.read("README.md").should eq("content before init")
         File.exists?("LICENSE").should be_true
       end
+    end
+  end
+
+  describe ".parse_args" do
+    it "DIR" do
+      config = Crystal::Init.parse_args(["lib", "foo"])
+      config.name.should eq "foo"
+      config.dir.should eq "foo"
+      config.expanded_dir.should eq ::Path[Dir.current, "foo"]
+    end
+
+    it "DIR with path" do
+      path = ::Path["foo", "bar"].to_s
+      config = Crystal::Init.parse_args(["lib", path])
+      config.name.should eq "bar"
+      config.dir.should eq path
+      config.expanded_dir.should eq ::Path[Dir.current, "foo", "bar"]
+    end
+
+    it "DIR (relative to home)" do
+      path = ::Path["~", "foo"].to_s
+      config = Crystal::Init.parse_args(["lib", path])
+      config.name.should eq "foo"
+      config.dir.should eq path
+      config.expanded_dir.should eq ::Path.home.join("foo")
+    end
+
+    it "DIR (absolute)" do
+      path = ::Path[::Path[Dir.current].anchor.to_s, "foo"].to_s
+      config = Crystal::Init.parse_args(["lib", path])
+      config.name.should eq "foo"
+      config.dir.should eq path
+      config.expanded_dir.should eq ::Path[path]
+    end
+
+    it "DIR = ." do
+      within_temporary_directory do
+        config = Crystal::Init.parse_args(["lib", "."])
+        config.name.should eq File.basename(Dir.current)
+        config.dir.should eq "."
+        config.expanded_dir.should eq ::Path[Dir.current]
+      end
+    end
+
+    it "NAME DIR" do
+      config = Crystal::Init.parse_args(["lib", "foo", "foo-shard"])
+      config.name.should eq "foo"
+      config.dir.should eq "foo-shard"
+      config.expanded_dir.should eq ::Path[Dir.current, "foo-shard"]
+    end
+  end
+
+  describe ".validate_name" do
+    it "empty" do
+      expect_raises Crystal::Init::Error, "NAME must not be empty" do
+        Crystal::Init.validate_name("")
+      end
+    end
+    it "length" do
+      Crystal::Init.validate_name("a" * 50)
+      expect_raises Crystal::Init::Error, "NAME must not be longer than 50 characters" do
+        Crystal::Init.validate_name("a" * 51)
+      end
+    end
+    it "uppercase" do
+      expect_raises Crystal::Init::Error, "NAME should be all lower cased" do
+        Crystal::Init.validate_name("Foo")
+      end
+    end
+    it "contain crystal" do
+      expect_raises Crystal::Init::Error, "NAME should not contain 'crystal'" do
+        Crystal::Init.validate_name("foo-crystal")
+      end
+    end
+    it "digits" do
+      Crystal::Init.validate_name("i18n")
+      expect_raises Crystal::Init::Error, "NAME must start with a letter" do
+        Crystal::Init.validate_name("4u")
+      end
+    end
+    it "dashes" do
+      Crystal::Init.validate_name("foo-bar")
+      expect_raises Crystal::Init::Error, "NAME must start with a letter" do
+        Crystal::Init.validate_name("-foo")
+      end
+      expect_raises Crystal::Init::Error, "NAME must not have consecutive dashes" do
+        Crystal::Init.validate_name("foo--bar")
+      end
+    end
+    it "underscores" do
+      Crystal::Init.validate_name("foo_bar")
+      expect_raises Crystal::Init::Error, "NAME must start with a letter" do
+        Crystal::Init.validate_name("_foo")
+      end
+      expect_raises Crystal::Init::Error, "NAME must not have consecutive underscores" do
+        Crystal::Init.validate_name("foo__bar")
+      end
+    end
+    it "invalid character" do
+      expect_raises Crystal::Init::Error, "NAME must only contain alphanumerical characters, underscores or dashes" do
+        Crystal::Init.validate_name("foo bar")
+      end
+      expect_raises Crystal::Init::Error, "NAME must only contain alphanumerical characters, underscores or dashes" do
+        Crystal::Init.validate_name("foo\abar")
+      end
+      Crystal::Init.validate_name("grüß-gott")
     end
   end
 end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -330,11 +330,6 @@ module Crystal
         Crystal::Init.validate_name("Foo")
       end
     end
-    it "contain crystal" do
-      expect_raises Crystal::Init::Error, "NAME should not contain 'crystal'" do
-        Crystal::Init.validate_name("foo-crystal")
-      end
-    end
     it "digits" do
       Crystal::Init.validate_name("i18n")
       expect_raises Crystal::Init::Error, "NAME must start with a letter" do

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -44,16 +44,17 @@ module Crystal
 
       OptionParser.parse(args) do |opts|
         opts.banner = <<-USAGE
-          Usage: crystal init TYPE NAME [DIR]
+          Usage: crystal init TYPE (DIR | NAME DIR)
+
+          Initializes a project folder as a git repository and default folder
+          structure for Crystal projects.
 
           TYPE is one of:
-              lib                      creates library skeleton
-              app                      creates application skeleton
+              lib                      Creates a library skeleton
+              app                      Creates an application skeleton
 
-          NAME - name of project to be generated,
-                 eg: example
-          DIR  - directory where project will be generated,
-                 default: NAME, eg: ./custom/path/example
+          DIR  - directory where project will be generated
+          NAME - name of project to be generated, default: basename of DIR
 
           USAGE
 
@@ -72,8 +73,16 @@ module Crystal
 
         opts.unknown_args do |args, after_dash|
           config.skeleton_type = fetch_skeleton_type(opts, args)
-          config.name = fetch_name(opts, args)
-          config.dir = fetch_directory(args, config.name)
+          dir = fetch_required_parameter(opts, args, "DIR")
+          if args.empty?
+            # crystal init TYPE DIR
+            config.dir = dir
+            config.name = config.expanded_dir.basename
+          else
+            # crystal init TYPE NAME DIR
+            config.name = dir
+            config.dir = args.shift
+          end
         end
       end
 
@@ -81,10 +90,7 @@ module Crystal
         raise Error.new "Cannot use --force and --skip-existing together"
       end
 
-      if config.name == "."
-        config.dir = Dir.current
-        config.name = File.basename config.dir
-      end
+      validate_name(config.name)
 
       config.author = fetch_author
       config.email = fetch_email
@@ -116,20 +122,6 @@ module Crystal
       github_user || "your-github-user"
     end
 
-    def self.fetch_name(opts, args)
-      fetch_required_parameter(opts, args, "NAME")
-    end
-
-    def self.fetch_directory(args, project_name)
-      directory = args.empty? ? project_name : args.shift
-
-      if File.file?(directory)
-        raise Error.new "#{directory.inspect} is a file"
-      end
-
-      directory
-    end
-
     def self.fetch_skeleton_type(opts, args)
       skeleton_type = fetch_required_parameter(opts, args, "TYPE")
       unless skeleton_type.in?("lib", "app")
@@ -143,6 +135,20 @@ module Crystal
         raise Error.new "Argument #{name} is missing", opts
       end
       args.shift
+    end
+
+    def self.validate_name(name)
+      case
+      when name.blank?                       then raise Error.new("NAME must not be empty")
+      when name.size > 50                    then raise Error.new("NAME must not be longer than 50 characters")
+      when name.each_char.any?(&.uppercase?) then raise Error.new("NAME should be all lower cased")
+      when name.index("crystal")             then raise Error.new("NAME should not contain 'crystal'")
+      when !name[0].ascii_letter?            then raise Error.new("NAME must start with a letter")
+      when name.index("--")                  then raise Error.new("NAME must not have consecutive dashes")
+      when name.index("__")                  then raise Error.new("NAME must not have consecutive underscores")
+      when !name.each_char.all? { |c| c.alphanumeric? || c == '-' || c == '_' }
+        raise Error.new("NAME must only contain alphanumerical characters, underscores or dashes")
+      end
     end
 
     class Config
@@ -168,10 +174,17 @@ module Crystal
         @skip_existing = false
       )
       end
+
+      @expanded_dir : ::Path?
+
+      def expanded_dir
+        @expanded_dir ||= ::Path.new(dir).expand(home: true)
+      end
     end
 
     abstract class View
       getter config : Config
+      getter full_path : ::Path
 
       @@views = [] of View.class
 
@@ -184,12 +197,17 @@ module Crystal
       end
 
       def initialize(@config)
+        @full_path = config.expanded_dir.join(path)
+      end
+
+      def overwriting?
+        File.exists?(full_path)
       end
 
       def render
-        overwriting = File.exists?(full_path)
+        overwriting = overwriting?
 
-        Dir.mkdir_p(File.dirname(full_path))
+        Dir.mkdir_p(full_path.dirname)
         File.write(full_path, to_s)
         puts log_message(overwriting) unless config.silent
       end
@@ -206,39 +224,41 @@ module Crystal
         config.name.split('-').map(&.camelcase).join("::")
       end
 
-      abstract def full_path
+      abstract def path
     end
 
     class InitProject
       getter config : Config
-      @views : Array(View)?
 
       def initialize(@config : Config)
       end
 
-      def overwrite_checks
-        overwriting_files = views.compact_map do |view|
-          path = view.full_path
-          File.exists?(path) ? path : nil
+      def overwrite_checks(views)
+        existing_views, new_views = views.partition(&.overwriting?)
+
+        if existing_views.any? && !config.skip_existing
+          raise FilesConflictError.new existing_views.map(&.path)
         end
 
-        if overwriting_files.any?
-          if config.skip_existing
-            views.reject! { |view| File.exists?(view.full_path) }
-          else
-            raise FilesConflictError.new overwriting_files
-          end
-        end
+        new_views
       end
 
       def run
-        overwrite_checks unless config.force
+        if File.file?(config.expanded_dir)
+          raise Error.new "#{config.dir.inspect} is a file"
+        end
+
+        views = self.views
+
+        unless config.force
+          views = overwrite_checks(views)
+        end
 
         views.each &.render
       end
 
-      def views
-        @views ||= View.views.map(&.new(config))
+      private def views
+        View.views.map(&.new(config))
       end
     end
 
@@ -249,8 +269,8 @@ module Crystal
         puts command
       end
 
-      def full_path
-        "#{config.dir}/.git"
+      def path
+        ".git"
       end
 
       private def command
@@ -260,11 +280,12 @@ module Crystal
 
     TEMPLATE_DIR = "#{__DIR__}/init/template"
 
-    macro template(name, template_path, full_path)
+    macro template(name, template_path, destination_path)
       class {{name.id}} < View
         ECR.def_to_s "{{TEMPLATE_DIR.id}}/{{template_path.id}}"
-        def full_path
-          "#{config.dir}/#{{{full_path}}}"
+
+        def path
+          {{destination_path}}
         end
       end
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -142,7 +142,6 @@ module Crystal
       when name.blank?                       then raise Error.new("NAME must not be empty")
       when name.size > 50                    then raise Error.new("NAME must not be longer than 50 characters")
       when name.each_char.any?(&.uppercase?) then raise Error.new("NAME should be all lower cased")
-      when name.index("crystal")             then raise Error.new("NAME should not contain 'crystal'")
       when !name[0].ascii_letter?            then raise Error.new("NAME must start with a letter")
       when name.index("--")                  then raise Error.new("NAME must not have consecutive dashes")
       when name.index("__")                  then raise Error.new("NAME must not have consecutive underscores")

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -175,11 +175,9 @@ module Crystal
       )
       end
 
-      @expanded_dir : ::Path?
+      getter expanded_dir : ::Path { ::Path.new(dir).expand(home: true) }
 
-      def expanded_dir
-        @expanded_dir ||= ::Path.new(dir).expand(home: true)
-      end
+      getter github_repo : String { "#{github_name}/#{expanded_dir.basename}" }
     end
 
     abstract class View

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -10,7 +10,7 @@ TODO: Write a description here
    ```yaml
    dependencies:
      <%= config.name %>:
-       github: <%= config.github_name %>/<%= config.name %>
+       github: <%= config.github_repo %>
    ```
 
 2. Run `shards install`
@@ -34,7 +34,7 @@ TODO: Write development instructions here
 
 ## Contributing
 
-1. Fork it (<https://github.com/<%= config.github_name %>/<%= config.name %>/fork>)
+1. Fork it (<https://github.com/<%= config.github_repo %>/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Follows up on #8681 with improvements from https://github.com/crystal-lang/crystal/issues/8682#issuecomment-573420302:

* If only two argument are given to `crystal init` (the first is always the type), the second one is `DIR`. `NAME` is derived from its basename. When three arguments are given, the second is `NAME` and the third one `DIR` (as before). The effective change is now you can pass in only a directory path and the name is automatically extracted from the path instead of (unexpectedly) using the entire path as name.
* `DIR` is expanded using `Path#expand(home: true)`
* `NAME` is validated to match the [specification for a shard name](https://github.com/crystal-lang/shards/blob/master/SPEC.md#name).

This PR also adds specs for `.parse_args` and `.validate_name`. A few minor refactors were necessary to make sure error messages present only the original argument path, not the expanded path. This also leads to simplified code.

I'm not sure about stripping `crystal-`, `-crystal` and `.cr` as suggested in https://github.com/crystal-lang/crystal/issues/8682#issuecomment-579574452 This could be implemented, but I'd rather have the user specify the name explicitly. Also the shard spec does not completely prohibit `crystal` in the name. It's only a recommendation. So I'm not even sure if `crystal init foo-crystal` should fail at all. Maybe print a warning, though?

`foo.cr` is technically an invalid name, because the spec prohibits dots in the name.
But I would actually suggest to change that and allow dots. I'm not sure whether there is an explicit reason for that. /cc @ysbaddaden
