### PR TITLE
Change CRYSTAL_PATH to allow shards to hide std-lib

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -138,7 +138,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=$CRYSTAL_ROOT/src:lib
+export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
 export CRYSTAL_HAS_WRAPPER=true
 
 if [ -x "$CRYSTAL_DIR/crystal" ]; then


### PR DESCRIPTION
Ref: https://github.com/crystal-lang/crystal/pull/8364#issuecomment-545092803

The distribution-scripts counter part is at https://github.com/crystal-lang/distribution-scripts/pull/56
