### PR TITLE
Fix Path.new receiving Path as first argument

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -66,6 +66,13 @@ describe Path do
     end
 
     it { Path.new.to_s.should eq "" }
+
+    it "joins components" do
+      Path.new("foo", "bar").should eq Path.new("foo").join("bar")
+      Path.new(Path.new("foo"), "bar").should eq Path.new("foo", "bar")
+      Path.new(Path.posix("foo"), "bar").should eq Path.new("foo", "bar")
+      Path.new(Path.windows("foo"), "bar").should eq Path.new("foo", "bar")
+    end
   end
 
   describe ".posix" do
@@ -80,6 +87,13 @@ describe Path do
     end
 
     it { Path.posix.to_s.should eq "" }
+
+    it "joins components" do
+      Path.posix("foo", "bar").should eq Path.posix("foo").join("bar")
+      Path.posix(Path.new("foo"), "bar").should eq Path.posix("foo", "bar")
+      Path.posix(Path.posix("foo"), "bar").should eq Path.posix("foo", "bar")
+      Path.posix(Path.windows("foo"), "bar").should eq Path.posix("foo", "bar")
+    end
   end
 
   describe ".windows" do
@@ -94,6 +108,13 @@ describe Path do
     end
 
     it { Path.windows.to_s.should eq "" }
+
+    it "joins components" do
+      Path.windows("foo", "bar").should eq Path.windows("foo").join("bar")
+      Path.windows(Path.new("foo"), "bar").should eq Path.windows("foo", "bar")
+      Path.windows(Path.posix("foo"), "bar").should eq Path.windows("foo", "bar")
+      Path.windows(Path.windows("foo"), "bar").should eq Path.windows("foo", "bar")
+    end
   end
 
   it ".[]" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -98,12 +98,17 @@ struct Path
   end
 
   # :ditto:
-  def self.new(name : String, *parts) : Path
+  def self.new(path : Path) : Path
+    path.to_native
+  end
+
+  # :ditto:
+  def self.new(name : String | Path, *parts : String | Path) : Path
     new(name).join(*parts)
   end
 
   # :ditto:
-  def self.[](name : String, *parts) : Path
+  def self.[](name : String | Path, *parts) : Path
     new(name, *parts)
   end
 
@@ -123,7 +128,12 @@ struct Path
   end
 
   # :ditto:
-  def self.posix(name : String, *parts) : Path
+  def self.posix(path : Path) : Path
+    path.to_posix
+  end
+
+  # :ditto:
+  def self.posix(name : String | Path, *parts : String | Path) : Path
     posix(name).join(parts)
   end
 
@@ -138,7 +148,12 @@ struct Path
   end
 
   # :ditto:
-  def self.windows(name : String, *parts) : Path
+  def self.windows(path : Path) : Path
+    path.to_windows
+  end
+
+  # :ditto:
+  def self.windows(name : String | Path, *parts : String | Path) : Path
     windows(name).join(parts)
   end
 
@@ -528,6 +543,11 @@ struct Path
     @name.byte_at?(1) === ':' && @name.char_at(0).ascii_letter?
   end
 
+  # Converts this path to a native path.
+  def to_native : Path
+    to_kind(Kind.native)
+  end
+
   # Converts this path to a Windows path.
   #
   # ```
@@ -761,6 +781,8 @@ struct Path
   # ```
   def join(parts : Enumerable) : Path
     if parts.is_a?(Indexable)
+      return self if parts.empty?
+
       # If it's just a single part we can avoid one allocation of String.build
       return join(parts.first) if parts.size == 1
 


### PR DESCRIPTION
`Path.new(Path.new(""))` did not work because of the way the constructors are defined. But this should work. Especially when using multiple arguments to join a path, the first component should be able to be a `Path` instance. After the first component this already worked because the splat argument is delegated to `#join`.