### PR TITLE
Ensure UNIXServer is accepting before closing in specs

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -735,9 +735,7 @@ describe "buffered" do
     # after the third receive, since the buffer is 2
     # f should be able to exec fully
     ch.receive
-    until f.dead?
-      Fiber.yield
-    end
+    wait_until_finished f
     done.should be_true
   end
 

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -72,9 +72,7 @@ describe "select" do
       end
     end
 
-    until f.dead?
-      Fiber.yield
-    end
+    wait_until_finished f
 
     res.should eq (0...10).to_a
   end
@@ -128,9 +126,7 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    until f.dead?
-      Fiber.yield
-    end
+    wait_until_finished f
     x.should eq(1)
   end
 
@@ -156,9 +152,7 @@ describe "select" do
     end
 
     ch3.receive.should eq(3)
-    until f.dead?
-      Fiber.yield
-    end
+    wait_until_finished f
     x.should eq(1)
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -858,10 +858,8 @@ describe IO do
         delay(1) { ch.send :timeout }
 
         ch.receive.should eq(:start)
-        while f.running?
-          # Wait until the fiber is blocked
-          Fiber.yield
-        end
+        wait_until_blocked f
+
         read.close
         ch.receive.should eq(:end)
       end
@@ -883,10 +881,8 @@ describe IO do
         delay(1) { ch.send :timeout }
 
         ch.receive.should eq(:start)
-        while f.running?
-          # Wait until the fiber is blocked
-          Fiber.yield
-        end
+        wait_until_blocked f
+
         write.close
         ch.receive.should eq(:end)
       end

--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -20,9 +20,7 @@ describe Mutex do
     end.to_a
 
     fibers.each do |f|
-      while !f.dead?
-        Fiber.yield
-      end
+      wait_until_finished f
     end
 
     x.should eq(1000)

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -96,9 +96,7 @@ describe UNIXServer do
         ch.receive.should eq(:begin)
 
         # wait for the server to call accept
-        until f.resumable?
-          Fiber.yield
-        end
+        wait_until_blocked f
 
         server.close
         ch.receive.should eq(:end)
@@ -139,9 +137,7 @@ describe UNIXServer do
         ch.receive.should eq(:begin)
 
         # wait for the server to call accept
-        until f.resumable?
-          Fiber.yield
-        end
+        wait_until_blocked f
 
         server.close
         ch.receive.should eq(:end)

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -83,7 +83,7 @@ describe UNIXServer do
 
         delay(1) { ch.send :timeout }
 
-        spawn do
+        f = spawn do
           begin
             ch.send(:begin)
             server.accept
@@ -94,6 +94,12 @@ describe UNIXServer do
         end
 
         ch.receive.should eq(:begin)
+
+        # wait for the server to call accept
+        until f.resumable?
+          Fiber.yield
+        end
+
         server.close
         ch.receive.should eq(:end)
 
@@ -124,13 +130,19 @@ describe UNIXServer do
 
         delay(1) { ch.send :timeout }
 
-        spawn do
+        f = spawn do
           ch.send :begin
           ret = server.accept?
           ch.send :end
         end
 
         ch.receive.should eq(:begin)
+
+        # wait for the server to call accept
+        until f.resumable?
+          Fiber.yield
+        end
+
         server.close
         ch.receive.should eq(:end)
 

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../support/tempfile"
+require "../support/fibers"
 
 def datapath(*components)
   File.join("spec", "std", "data", *components)
@@ -67,9 +68,7 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
       end
 
       # Now wait until the "before" fiber is blocked
-      while !before_fiber.resumable?
-        Fiber.yield
-      end
+      wait_until_blocked before_fiber
       block.call w
 
       done.send nil

--- a/spec/support/fibers.cr
+++ b/spec/support/fibers.cr
@@ -1,0 +1,11 @@
+def wait_until_blocked(f : Fiber)
+  until f.resumable?
+    Fiber.yield
+  end
+end
+
+def wait_until_finished(f : Fiber)
+  until f.dead?
+    Fiber.yield
+  end
+end


### PR DESCRIPTION
In multi-thread the .accept might not execute right after the :begin is received.

more [sporadic failures](https://circleci.com/gh/straight-shoota/crystal/772?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in preview_mt fixed.