### PR TITLE
Keep expanding home in CRYSTAL_CACHE_DIR

### DIFF
--- a/src/compiler/crystal/codegen/cache_dir.cr
+++ b/src/compiler/crystal/codegen/cache_dir.cr
@@ -73,7 +73,7 @@ module Crystal
       ]
       candidates = candidates
         .compact
-        .map { |file| File.expand_path(file) }
+        .map { |file| File.expand_path(file, home: true) }
         .uniq
 
       # Return the first one for which we could create a directory


### PR DESCRIPTION
Fixes a small regression from #7903

Somebody with more time than me to spend on this might want to go through and evaluate all `File.expand_path` uses in the compiler  for whether it's safe and beneficial to expand home.