### PR TITLE
Compiler: fix type of vars after begin/rescue if all rescue unreachable

### DIFF
--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -670,4 +670,20 @@ describe "Semantic: exception" do
       foo
     )) { nilable int32 }
   end
+
+  it "gets a non-nilable type if all rescue are unreachable (#8751)" do
+    semantic(%(
+      while true
+        begin
+          foo = 1
+          break
+        rescue
+          foo
+          break
+        end
+
+        foo &+ 2
+      end
+      ))
+  end
 end

--- a/spec/compiler/semantic/ssa_spec.cr
+++ b/spec/compiler/semantic/ssa_spec.cr
@@ -267,7 +267,7 @@ describe "Semantic: ssa" do
         LibC.exit
       end
       a
-      )) { union_of [int32, char, string] of Type }
+      )) { string }
   end
 
   it "types a var after rescue as being nilable" do

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2795,23 +2795,26 @@ module Crystal
             before_var = before_ensure_vars[name]?
             @vars[name] = var unless var.same?(before_var)
           end
-        else
-          @vars = exception_handler_vars
-        end
 
-        # However, those previous variables can't be nil afterwards:
-        # if an exception was raised then we won't be running the code
-        # after the ensure clause, so variables don't matter. But if
-        # an exception was not raised then all variables were declared
-        # successfully.
-        @vars.each do |name, var|
-          unless before_body_vars[name]?
-            # But if the variable is already nilable after the begin
-            # block it must remain nilable
-            unless after_exception_handler_vars[name]?.try &.nil_if_read?
-              var.nil_if_read = false
+          # However, those previous variables can't be nil afterwards:
+          # if an exception was raised then we won't be running the code
+          # after the ensure clause, so variables don't matter. But if
+          # an exception was not raised then all variables were declared
+          # successfully.
+          @vars.each do |name, var|
+            unless before_body_vars[name]?
+              # But if the variable is already nilable after the begin
+              # block it must remain nilable
+              unless after_exception_handler_vars[name]?.try &.nil_if_read?
+                var.nil_if_read = false
+              end
             end
           end
+        else
+          # If there's no ensure, because all rescue/else end with unreacahble
+          # we know all the vars after the exception handler will have the types
+          # after the handle (begin) block.
+          @vars = after_exception_handler_vars
         end
       end
 


### PR DESCRIPTION
Fixes #8751

The type of the vars after an exception handler where all rescue/else clauses end up being unreachable (break or raise, essentially NoReturn) was taken from an incorrect computation. This fixes it.

The diff is essentially replacing:

```crystal
@vars = exception_handler_vars
```

with 

```crystal
@vars = after_exception_handler_vars
```

and then moving the logic that begins with the "However, ..." comment to inside an `if` branch because it doesn't need to be applied if all rescue/else are unreachable.