### PR TITLE
Add BigInt#unsafe_shr

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -406,6 +406,10 @@ describe "BigInt" do
     it { BigInt.new("1180591620717411303424").humanize_bytes.should eq("1.0ZiB") }
     it { BigInt.new("1208925819614629174706176").humanize_bytes.should eq("1.0YiB") }
   end
+
+  it "has unsafe_shr (#8691)" do
+    BigInt.new(8).unsafe_shr(1).should eq(4)
+  end
 end
 
 describe "BigInt Math" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -355,6 +355,13 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.fdiv_q_2exp(mpz, self, other) }
   end
 
+  # :nodoc:
+  #
+  # Because every Int needs this method.
+  def unsafe_shr(count : Int) : self
+    self >> count
+  end
+
   def <<(other : Int) : BigInt
     BigInt.new { |mpz| LibGMP.mul_2exp(mpz, self, other) }
   end


### PR DESCRIPTION
Fixes #8691

The original snippet from that issue now correctly raises overflow because it's operating on Int32.