### PR TITLE
Drop uppercase F32 and F64 float number suffixes

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -313,6 +313,14 @@ describe "Lexer" do
   assert_syntax_error "00", "octal constants should be prefixed with 0o"
   assert_syntax_error "01_i64", "octal constants should be prefixed with 0o"
 
+  assert_syntax_error "4f33", "invalid float suffix"
+  assert_syntax_error "4f65", "invalid float suffix"
+  assert_syntax_error "4f22", "invalid float suffix"
+  # Tests for #8782
+  assert_syntax_error "4F32", "unexpected token: F32"
+  assert_syntax_error "4F64", "unexpected token: F64"
+  assert_syntax_error "0F32", "unexpected token: F32"
+
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1434,7 +1434,7 @@ module Crystal
             end
           end
 
-          if current_char == 'f' || current_char == 'F'
+          if current_char == 'f'
             suffix_size = consume_float_suffix
           else
             @token.number_kind = :f64
@@ -1462,12 +1462,12 @@ module Crystal
           next_char
         end
 
-        if current_char == 'f' || current_char == 'F'
+        if current_char == 'f'
           suffix_size = consume_float_suffix
         else
           @token.number_kind = :f64
         end
-      when 'f', 'F'
+      when 'f'
         is_integer = false
         suffix_size = consume_float_suffix
       when 'i'


### PR DESCRIPTION
With Crystal 0.32.1,

```crystal
# OK
0f32

# OK
1f32

# ERROR
0F32

# OK
1F32
```

~This PR fixes `0F32` not to cause an error.~ EDIT: We decided to drop uppercase suffixes. Please see following discussion.