### PR TITLE
Allow Crystal::System.print_error to use printf like format

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -141,15 +141,15 @@ struct CallStack
     if frame
       offset, sname = frame
       if repeated_frame.count == 0
-        LibC.dprintf 2, "[0x%lx] %s +%ld\n", repeated_frame.ip, sname, offset
+        Crystal::System.print_error "[0x%lx] %s +%ld\n", repeated_frame.ip, sname, offset
       else
-        LibC.dprintf 2, "[0x%lx] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
+        Crystal::System.print_error "[0x%lx] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
       end
     else
       if repeated_frame.count == 0
-        LibC.dprintf 2, "[0x%lx] ???\n", repeated_frame.ip
+        Crystal::System.print_error "[0x%lx] ???\n", repeated_frame.ip
       else
-        LibC.dprintf 2, "[0x%lx] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
+        Crystal::System.print_error "[0x%lx] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
       end
     end
   end

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -243,7 +243,7 @@ class Crystal::Scheduler
       if env_workers && !env_workers.empty?
         workers = env_workers.to_i?
         if !workers || workers < 1
-          LibC.dprintf 2, "FATAL: Invalid value for CRYSTAL_WORKERS: #{env_workers}\n"
+          Crystal::System.print_error "FATAL: Invalid value for CRYSTAL_WORKERS: #{env_workers}\n"
           exit 1
         end
 

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -2,11 +2,13 @@ module Crystal::System
   # Prints directly to stderr without going through an IO.
   # This is useful for error messages from components that are required for
   # IO to work (fibers, scheduler, event_loop).
-  def self.print_error(message)
+  def self.print_error(message, *args)
     {% if flag?(:unix) %}
-      LibC.dprintf 2, message
+      LibC.dprintf 2, message, *args
     {% elsif flag?(:win32) %}
-      LibC._write 2, message, message.bytesize
+      buffer = StaticArray(UInt8, 512).new(0_u8)
+      len = LibC.snprintf(buffer, buffer.size, message, *args)
+      LibC._write 2, buffer, len
     {% end %}
   end
 end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -45,7 +45,7 @@ private def traverse_eh_table(leb, start, ip, actions)
 
   lp_start_encoding = leb.read_uint8 # @LPStart encoding
   if lp_start_encoding != 0xff_u8
-    LibC.dprintf 2, "Unexpected encoding for LPStart: #{lp_start_encoding}\n"
+    Crystal::System.print_error "Unexpected encoding for LPStart: #{lp_start_encoding}\n"
     LibC.exit 1
   end
 
@@ -55,7 +55,7 @@ private def traverse_eh_table(leb, start, ip, actions)
 
   cs_encoding = leb.read_uint8 # CS Encoding (1: uleb128, 3: uint32)
   if cs_encoding != 1 && cs_encoding != 3
-    LibC.dprintf 2, "Unexpected CS encoding: #{cs_encoding}\n"
+    Crystal::System.print_error "Unexpected CS encoding: #{cs_encoding}\n"
     LibC.exit 1
   end
 
@@ -193,7 +193,7 @@ end
   @[Raises]
   fun __crystal_raise(unwind_ex : LibUnwind::Exception*) : NoReturn
     ret = LibUnwind.raise_exception(unwind_ex)
-    LibC.dprintf 2, "Failed to raise an exception: %s\n", ret.to_s
+    Crystal::System.print_error "Failed to raise an exception: %s\n", ret.to_s
     CallStack.print_backtrace
     LibC.exit(ret)
   end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -339,9 +339,9 @@ fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
     end
 
   if is_stack_overflow
-    LibC.dprintf 2, "Stack overflow (e.g., infinite or very deep recursion)\n"
+    Crystal::System.print_error "Stack overflow (e.g., infinite or very deep recursion)\n"
   else
-    LibC.dprintf 2, "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
+    Crystal::System.print_error "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
   end
 
   CallStack.print_backtrace


### PR DESCRIPTION
Replace dprintf calls with print_error

This is needed to make #8735 pass on windows.

Some calls can be changed to remove the string interpolation after this PR, but that can be deferred if wanted.