### PR TITLE
Try to open stdio in non-blocking mode

### DIFF
--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe IO::FileDescriptor do
   it "reopen STDIN with the right mode" do
-    code = "puts \"\#{STDIN.blocking} \#{STDIN.info.type}\""
+    code = %q(puts "#{STDIN.blocking} #{STDIN.info.type}")
     build(code) do |binpath|
       `#{binpath} < #{binpath}`.chomp.should eq("true File")
       `echo "" | #{binpath}`.chomp.should eq("false Pipe")

--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -1,0 +1,11 @@
+require "../../spec_helper"
+
+describe IO::FileDescriptor do
+  it "reopen STDIN with the right mode" do
+    code = "puts \"\#{STDIN.blocking} \#{STDIN.info.type}\""
+    build(code) do |binpath|
+      `#{binpath} < #{binpath}`.chomp.should eq("true File")
+      `echo "" | #{binpath}`.chomp.should eq("false Pipe")
+    end
+  end
+end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -12,10 +12,10 @@ class IO::FileDescriptor < IO
   def initialize(@fd, blocking = nil)
     @closed = system_closed?
 
-    if blocking == nil
+    if blocking.nil?
       blocking =
         case system_info.type
-        when File::Type::Pipe, File::Type::Socket, File::Type::CharacterDevice
+        when .pipe?, .socket?, .character_device?
           false
         else
           true

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -9,8 +9,18 @@ class IO::FileDescriptor < IO
   # platform-specific.
   getter fd
 
-  def initialize(@fd, blocking = false)
+  def initialize(@fd, blocking = nil)
     @closed = system_closed?
+
+    if blocking == nil
+      blocking =
+        case system_info.type
+        when File::Type::Pipe, File::Type::Socket, File::Type::CharacterDevice
+          false
+        else
+          true
+        end
+    end
 
     unless blocking || {{flag?(:win32)}}
       self.blocking = false
@@ -25,10 +35,10 @@ class IO::FileDescriptor < IO
     # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
     path = uninitialized UInt8[256]
     ret = LibC.ttyname_r(fd, path, 256)
-    return new(fd, blocking: true) unless ret == 0
+    return new(fd) unless ret == 0
 
     clone_fd = LibC.open(path, LibC::O_RDWR)
-    return new(fd, blocking: true) if clone_fd == -1
+    return new(fd) if clone_fd == -1
 
     # We don't buffer output for TTY devices to see their output right away
     io = new(clone_fd)


### PR DESCRIPTION
Currently if the stdio descriptors are not a TTY they are re-opened with `blocking: true`. That makes sense for files, for example if the output is being redirected (i.e: `./foo > somefile`). But it doesn't if the input is a pipe (i.e: `cat | ./foo`).

The problem is that programs like this will block all the fibers:
```crystal
spawn do
  STDIN.gets
end
```

We used to have problems with stdio (#2713) but it was fixed by not changing the blocking mode from the original file descriptor (#6518)

This PR adds a third state to the `blocking` argument of `FileDescriptor.new`. When a `nil` is passed (the default) it detects the type of descriptor and sets the blocking mode accordingly.

Unfortunately this is quite difficult to test, so there is no specs to find regressions. I added a spec to check the STDIN opens in different modes depending on the fd type. But please, help me find if I didn't miss anything and I'm actually breaking everything again 😅 