### PR TITLE
Some rework of top level error handling

### DIFF
--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -42,13 +42,18 @@ module Crystal
         1
       end
 
-    AtExitHandlers.exception = ex if ex
+    status = AtExitHandlers.run status, ex
+    handle_stdio_errors { STDOUT.flush }
+    handle_stdio_errors { STDERR.flush }
 
-    status = AtExitHandlers.run status
-    STDOUT.flush
-    STDERR.flush
-
+    raise ex if ex
     status
+  end
+
+  private def self.handle_stdio_errors
+    yield
+  rescue IO::Error
+  rescue Errno
   end
 
   # Main method run by all Crystal programs at startup.
@@ -82,11 +87,12 @@ module Crystal
   # is not setup yet, so nothing that allocates memory
   # in Crystal (like `new` for classes) can be used.
   def self.main(argc : Int32, argv : UInt8**)
-    handle_exceptions do
-      main do
-        main_user_code(argc, argv)
-      end
+    main do
+      main_user_code(argc, argv)
     end
+  rescue ex
+    Crystal::System.print_exception "Unhandled exception", ex
+    1
   end
 
   # Executes the main user code. This normally is executed
@@ -97,26 +103,6 @@ module Crystal
   # more details.
   def self.main_user_code(argc : Int32, argv : UInt8**)
     LibCrystalMain.__crystal_main(argc, argv)
-  end
-
-  protected def self.handle_exceptions
-    begin
-      yield
-    rescue e
-      Crystal::System.print_error "Unhandled exception in main (%s): %s\n", e.class.name, e.message || "(no message)"
-      begin
-        if bt = e.backtrace?
-          bt.each do |frame|
-            Crystal::System.print_error "  %s\n", frame
-          end
-        else
-          Crystal::System.print_error "  (no backtrace)\n"
-        end
-      rescue e
-        Crystal::System.print_error "Error while trying to dump the backtrace (%s): %s\n", e.class.name, e.message || "(no message)"
-      end
-      2
-    end
   end
 end
 

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -43,14 +43,15 @@ module Crystal
       end
 
     status = AtExitHandlers.run status, ex
-    handle_stdio_errors { STDOUT.flush }
-    handle_stdio_errors { STDERR.flush }
+    ignore_stdio_errors { STDOUT.flush }
+    ignore_stdio_errors { STDERR.flush }
 
     raise ex if ex
     status
   end
 
-  private def self.handle_stdio_errors
+  # :nodoc:
+  def self.ignore_stdio_errors
     yield
   rescue IO::Error
   rescue Errno

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -11,4 +11,19 @@ module Crystal::System
       LibC._write 2, buffer, len
     {% end %}
   end
+
+  def self.print_exception(message, ex)
+    print_error "%s: %s (%s)\n", message, ex.message || "(no message)", ex.class.name
+    begin
+      if bt = ex.backtrace?
+        bt.each do |frame|
+          print_error "  from %s\n", frame
+        end
+      else
+        print_error "  (no backtrace)\n"
+      end
+    rescue ex
+      print_error "Error while trying to dump the backtrace: %s (%s)\n", ex.message || "(no message)", ex.class.name
+    end
+  end
 end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -501,15 +501,15 @@ end
 # Registered `at_exit` procs are executed.
 def exit(status = 0) : NoReturn
   status = AtExitHandlers.run status
-  STDOUT.flush
-  STDERR.flush
+  Crystal.ignore_stdio_errors { STDOUT.flush }
+  Crystal.ignore_stdio_errors { STDERR.flush }
   Process.exit(status)
 end
 
 # Terminates execution immediately, printing *message* to `STDERR` and
 # then calling `exit(status)`.
 def abort(message = nil, status = 1) : NoReturn
-  STDERR.puts message if message
+  Crystal.ignore_stdio_errors { STDERR.puts message } if message
   exit status
 end
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -440,8 +440,6 @@ end
 module AtExitHandlers
   @@running = false
 
-  class_property exception : Exception?
-
   private class_getter(handlers) { [] of Int32, Exception? -> }
 
   def self.add(handler)
@@ -450,7 +448,7 @@ module AtExitHandlers
     handlers << handler
   end
 
-  def self.run(status)
+  def self.run(status, exception = nil)
     @@running = true
 
     if handlers = @@handlers
@@ -459,19 +457,10 @@ module AtExitHandlers
         begin
           handler.call status, exception
         rescue handler_ex
-          STDERR.puts "Error running at_exit handler: #{handler_ex}"
+          Crystal::System.print_error "Error running at_exit handler: %s\n", handler_ex.message || ""
           status = 1 if status.zero?
         end
       end
-    end
-
-    if ex = @@exception
-      # Print the exception after all at_exit handlers, to make sure
-      # the user sees it.
-
-      STDERR.print "Unhandled exception: "
-      ex.inspect_with_backtrace(STDERR)
-      STDERR.flush
     end
 
     status


### PR DESCRIPTION
In this PR I did some refactors and changes from the previous PR I sent (#8735)

Basically errors raised at `at_exit` handlers are also reported using `print_error` and also exceptions raised when flushing STDOUT and STDERR are now ignored to avoid duplicate errors like #7810 

Fixes #7810