### PR TITLE
Compiler: fix inherited visibility of macro hooks

### DIFF
--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -41,16 +41,16 @@ class Crystal::Program
     {interpreter.to_s, interpreter.macro_expansion_pragmas}
   end
 
-  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, mode : Parser::ParseMode = :normal)
-    parse_macro_source generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def, inside_type, inside_exp, &.parse(mode)
+  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, mode : Parser::ParseMode = :normal, visibility : Visibility = :public)
+    parse_macro_source generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def, inside_type, inside_exp, visibility, &.parse(mode)
   end
 
-  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false)
+  def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, visibility : Visibility = :public)
     begin
       parser = Parser.new(generated_source, @program.string_pool, [vars.dup])
       parser.filename = VirtualFile.new(the_macro, generated_source, node.location)
       parser.macro_expansion_pragmas = macro_expansion_pragmas
-      parser.visibility = node.visibility
+      parser.visibility = visibility
       parser.def_nest = 1 if current_def && !current_def.is_a?(External)
       parser.fun_nest = 1 if current_def && current_def.is_a?(External)
       parser.type_nest = 1 if inside_type

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -293,7 +293,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     args = expand_macro_arguments(node, expansion_scope)
 
     @exp_nest -= 1
-    generated_nodes = expand_macro(the_macro, node) do
+    generated_nodes = expand_macro(the_macro, node, visibility: node.visibility) do
       old_args = node.args
       node.args = args
       expanded_macro, macro_expansion_pragmas = @program.expand_macro the_macro, node, expansion_scope, expansion_scope, @untyped_def
@@ -309,7 +309,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     true
   end
 
-  def expand_macro(the_macro, node, mode = nil)
+  def expand_macro(the_macro, node, mode = nil, *, visibility : Visibility)
     expanded_macro, macro_expansion_pragmas =
       eval_macro(node) do
         yield
@@ -332,6 +332,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
       inside_type: !current_type.is_a?(Program),
       inside_exp: @exp_nest > 0,
       mode: mode,
+      visibility: visibility,
     )
 
     if node_doc = node.doc
@@ -399,7 +400,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
     skip_macro_exception = nil
 
-    generated_nodes = expand_macro(the_macro, node, mode: mode) do
+    generated_nodes = expand_macro(the_macro, node, mode: mode, visibility: :public) do
       begin
         @program.expand_macro node, (@scope || current_type), @path_lookup, free_vars, @untyped_def
       rescue ex : SkipMacroException

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1003,7 +1003,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     type_with_hooks.as?(ModuleType).try &.hooks.try &.each do |hook|
       next if hook.kind != kind
 
-      expansion = expand_macro(hook.macro, node) do
+      expansion = expand_macro(hook.macro, node, visibility: :public) do
         if call
           @program.expand_macro hook.macro, call, current_type.instance_type
         else
@@ -1180,7 +1180,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def process_finished_hooks
     @finished_hooks.each do |hook|
       self.current_type = hook.scope
-      expansion = expand_macro(hook.macro, hook.macro) do
+      expansion = expand_macro(hook.macro, hook.macro, visibility: :public) do
         @program.expand_macro hook.macro.body, hook.scope
       end
       program.add_finished_hook(hook.scope, hook.macro, expansion)


### PR DESCRIPTION
Fixes #8794

When expanding a macro we always pass a related ASTNode and were taking the visibility from it. The problem is, on macro hooks the node was the class definition, and if it was `private` it was taken from that which was wrong.

To make the code simpler, now the macro expansion code requires an explicit visibility to be passed. Then in all places I made sure to pass the correct visibility. For macro hooks the initial visibility should always be `public`.