### PR TITLE
Docs: Add `from_yaml` description & example

### DIFF
--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -1,3 +1,13 @@
+# Deserializes the given YAML in *string_or_io* into
+# an instance of `self`. This simply creates an instance of
+# `YAML::ParseContext` and invokes `new(parser, yaml)`:
+# classes that want to provide YAML deserialization must provide an
+# `def initialize(parser : YAML::ParseContext, yaml : string_or_io)`
+# method.
+#
+# ```
+# Hash(String, String).from_yaml("{env: production}") # => {"env" => "production"}
+# ```
 def Object.from_yaml(string_or_io : String | IO)
   new(YAML::ParseContext.new, parse_yaml(string_or_io))
 end


### PR DESCRIPTION
Hey! I just noticed that some basic enough [functionality](https://crystal-lang.org/api/0.32.1/Object.html#from_yaml(string_or_io:String%7CIO)-class-method) is not documented. Added :)