### PR TITLE
Disable Thread specs on musl

### DIFF
--- a/spec/std/thread/condition_variable_spec.cr
+++ b/spec/std/thread/condition_variable_spec.cr
@@ -1,3 +1,11 @@
+{% if flag?(:musl) %}
+  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
+  # they're disabled for now to reduce noise.
+  # See https://github.com/crystal-lang/crystal/issues/8738
+  pending Thread::ConditionVariable
+  {% skip_file %}
+{% end %}
+
 require "spec"
 
 describe Thread::ConditionVariable do

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -1,3 +1,11 @@
+{% if flag?(:musl) %}
+  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
+  # they're disabled for now to reduce noise.
+  # See https://github.com/crystal-lang/crystal/issues/8738
+  pending Thread::Mutex
+  {% skip_file %}
+{% end %}
+
 require "spec"
 require "../../support/errno"
 

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -1,5 +1,18 @@
 require "spec"
 
+{% if flag?(:musl) %}
+  # FIXME: These thread specs occasionally fail on musl, so they're disabled
+  # for now to reduce noise.
+  # See https://github.com/crystal-lang/crystal/issues/8738
+  describe Thread do
+    pending "allows passing an argumentless fun to execute"
+    pending "raises inside thread and gets it on join"
+    pending "returns current thread object"
+    pending "yields the processor"
+  end
+  {% skip_file %}
+{% end %}
+
 describe Thread do
   it "allows passing an argumentless fun to execute" do
     a = 0

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -1,15 +1,10 @@
 require "spec"
 
 {% if flag?(:musl) %}
-  # FIXME: These thread specs occasionally fail on musl, so they're disabled
-  # for now to reduce noise.
+  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
+  # they're disabled for now to reduce noise.
   # See https://github.com/crystal-lang/crystal/issues/8738
-  describe Thread do
-    pending "allows passing an argumentless fun to execute"
-    pending "raises inside thread and gets it on join"
-    pending "returns current thread object"
-    pending "yields the processor"
-  end
+  pending Thread
   {% skip_file %}
 {% end %}
 


### PR DESCRIPTION
These thread specs occasionally fail on musl, so they're disabled for now to reduce noise.

See https://github.com/crystal-lang/crystal/issues/8738