### PR TITLE
Fix exceptions not being inspectable when running binary from PATH

### DIFF
--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -367,7 +367,9 @@ struct CallStack
       @@base_address : UInt64|UInt32|Nil
 
       protected def self.read_dwarf_sections
-        Debug::ELF.open(PROGRAM_NAME) do |elf|
+        program = Process.executable_path
+        return unless program && File.readable? program
+        Debug::ELF.open(program) do |elf|
           elf.read_section?(".text") do |sh, _|
             @@base_address = sh.addr - sh.offset
           end


### PR DESCRIPTION
If the binary is added to $PATH, PROGRAM_NAME is the name of the file,
but not the path to read debug information from. This causes a file open
error, which is incredibly hard to debug. Using `Process.executable_path` will
instead always be the current executable.

A simple demonstration of this issue is:

```crystal
def bar
  raise "Oh no it didn't work"
rescue e
  puts e.inspect_with_backtrace
end

bar
```

Build and move this binary somewhere in your `$PATH`:

```shell
$ crystal build exceptions.cr
$ mv exceptions ~/.local/bin
$ exceptions
Unhandled exception: Error opening file 'exceptions' with mode 'r': No such file or directory (Errno)             
Error while trying to dump the backtrace: Error opening file 'exceptions' with mode 'r': No such file or directory (Errno)
```

With this patch, the exception is printed as expected:

```
Oh no it didn't work (Exception)
  from exceptions.cr:2:3 in 'bar'
  from exceptions.cr:11:1 in '__crystal_main'
  from /home/will/projects/gh/crystal-lang/crystal/src/crystal/main.cr:106:5 in 'main_user_code'
  from /home/will/projects/gh/crystal-lang/crystal/src/crystal/main.cr:92:7 in 'main'
  from /home/will/projects/gh/crystal-lang/crystal/src/crystal/main.cr:115:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```