### PR TITLE
Enable IO specs on win32

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "../spec_helper"
 
 private class BufferedWrapper < IO
   include IO::Buffered
@@ -416,7 +416,7 @@ describe "IO::Buffered" do
     io.read_char.should eq('b')
   end
 
-  describe "encoding" do
+  pending_win32 describe: "encoding" do
     describe "decode" do
       it "gets_to_end" do
         str = "Hello world" * 200

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
-require "big"
+{% unless flag?(:win32) %}
+  require "big"
+{% end %}
 require "base64"
 
 # This is a non-optimized version of IO::Memory so we can test
@@ -80,7 +82,7 @@ end
 
 describe IO do
   describe "partial read" do
-    it "doesn't block on first read.  blocks on 2nd read" do
+    pending_win32 "doesn't block on first read.  blocks on 2nd read" do
       IO.pipe do |read, write|
         write.puts "hello"
         slice = Bytes.new 1024
@@ -494,7 +496,7 @@ describe IO do
     end
   end
 
-  describe "encoding" do
+  pending_win32 describe: "encoding" do
     describe "decode" do
       it "gets_to_end" do
         str = "Hello world" * 200
@@ -843,7 +845,7 @@ describe IO do
     end
   end
 
-  describe "#close" do
+  pending_win32 describe: "#close" do
     it "aborts 'read' in a different thread" do
       ch = Channel(Symbol).new(1)
 
@@ -889,6 +891,8 @@ describe IO do
     end
   end
 
-  typeof(STDIN.cooked { })
-  typeof(STDIN.cooked!)
+  {% unless flag?(:win32) %}
+    typeof(STDIN.cooked { })
+    typeof(STDIN.cooked!)
+  {% end %}
 end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "../spec_helper"
 
 describe IO::Memory do
   it "writes" do
@@ -373,7 +373,7 @@ describe IO::Memory do
     io.gets_to_end.should eq("")
   end
 
-  describe "encoding" do
+  pending_win32 describe: "encoding" do
     describe "decode" do
       it "gets_to_end" do
         str = "Hello world" * 200

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -89,12 +89,12 @@ require "./std/indexable_spec.cr"
 require "./std/ini_spec.cr"
 require "./std/int_spec.cr"
 require "./std/io/argf_spec.cr"
-# require "./std/io/buffered_spec.cr" (failed codegen)
+require "./std/io/buffered_spec.cr"
 require "./std/io/byte_format_spec.cr"
 require "./std/io/delimited_spec.cr"
 require "./std/io/hexdump_spec.cr"
-# require "./std/io/io_spec.cr" (failed codegen)
-# require "./std/io/memory_spec.cr" (failed codegen)
+require "./std/io/io_spec.cr"
+require "./std/io/memory_spec.cr"
 require "./std/io/multi_writer_spec.cr"
 require "./std/io/sized_spec.cr"
 require "./std/io/stapled_spec.cr"

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -104,7 +104,7 @@ module Crystal::System::FileDescriptor
       end
     {% else %}
       # dup doesn't copy the CLOEXEC flag, copy it manually to the new
-      if LibC.dup2(other.fd, self.fd) == -1
+      if LibC._dup2(other.fd, self.fd) == -1
         raise Errno.new("Could not reopen file descriptor")
       end
 

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -15,4 +15,5 @@ lib LibC
   fun _chsize(fd : Int, size : Long) : Int
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _pipe(pfds : Int*, psize : UInt, textmode : Int) : Int
+  fun _dup2(fd1 : Int, fd2 : Int) : Int
 end


### PR DESCRIPTION
This was originally a part of #8683. I removed IO specs because there was an issue which appeard only after rebasing against master (https://github.com/crystal-lang/crystal/pull/8683#issuecomment-587706480).

The reason is pretty simple though. It's the `#close` specs. They never worked before but were wrapped in an unrelated `pending_win32`. [94bf654a](https://github.com/crystal-lang/crystal/commit/94bf654a27ca09517acbe3b35cbc64593cedddad?w=1) reorganized the spec and suddenly `#close` specs were running and causing failures in other places.