### PR TITLE
[Experimental] Allow user-defined macro methods

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1838,4 +1838,68 @@ describe "Code gen: macro" do
       (Foo.new || Bar.new).foo
     )).to_string.should eq("Foo")
   end
+
+  it "invokes macro method inside Crystal::Macros module" do
+    run(%(
+      module Crystal::Macros
+        macro foo(x)
+          x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of ASTNode" do
+    run(%(
+      class Crystal::Macros::StringLiteral
+        macro plus_bar
+          self + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ x.plus_bar }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of any type" do
+    run(%(
+      module Foo
+        macro foo(x)
+          x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ Foo.foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of any type, with return" do
+    run(%(
+      module Foo
+        macro foo(x)
+          return x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ Foo.foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -589,6 +589,24 @@ module Crystal
       end
     end
 
+    def visit(node : While)
+      while true
+        node.cond.accept self
+        break if !@last.truthy?
+        node.body.accept self
+      end
+      false
+    end
+
+    def visit(node : Until)
+      while true
+        node.cond.accept self
+        break if @last.truthy?
+        node.body.accept self
+      end
+      false
+    end
+
     def visit(node : OpAssign)
       @program.normalize(node).accept self
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -589,6 +589,11 @@ module Crystal
       end
     end
 
+    def visit(node : OpAssign)
+      @program.normalize(node).accept self
+      false
+    end
+
     def visit(node : ASTNode)
       cant_execute(node)
     end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -74,6 +74,9 @@ module Crystal
 
     record MacroVarKey, name : String, exps : Array(ASTNode)?
 
+    getter program
+    property? macro_method_mode = false
+
     def initialize(@program : Program,
                    @scope : Type, @path_lookup : Type, @location : Location?,
                    @vars = {} of String => ASTNode, @block : Block? = nil, @def : Def? = nil,
@@ -573,7 +576,24 @@ module Crystal
       false
     end
 
+    def visit(node : Return)
+      if macro_method_mode?
+        exp = node.exp
+        if exp
+          exp.accept self
+        else
+          @last = NilLiteral.new
+        end
+      else
+        cant_execute(node)
+      end
+    end
+
     def visit(node : ASTNode)
+      cant_execute(node)
+    end
+
+    def cant_execute(node)
       node.raise "can't execute #{node.class_desc} in a macro"
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -38,8 +38,65 @@ module Crystal
     end
 
     def interpret_top_level_call(node)
-      interpret_top_level_call?(node) ||
-        node.raise("undefined macro method: '#{node.name}'")
+      value = interpret_top_level_call?(node)
+      return value if value
+
+      args = node.args.map do |arg|
+        accept(arg)
+        @last
+      end
+
+      named_args = node.named_args.try &.map do |named_arg|
+        accept(named_arg.value)
+        NamedArgument.new(named_arg.name, @last)
+      end
+
+      # Top-levels macro calls are looked up inside the Crystal::Macros module,
+      # just like built-in top-level macro methods.
+      macros = @program.crystal.lookup_type?(Path.new("Macros"))
+      if macros
+        value = interpret_call_inside_type(macros, node.name, args, named_args, node.block)
+        return value if value
+      end
+
+      node.raise("undefined macro method: '#{node.name}'")
+    end
+
+    def interpret_call_inside_type(owner, name, args, named_args, block, self self_value = nil)
+      if named_args.is_a?(Hash)
+        named_args = named_args.map do |name, value|
+          NamedArgument.new(name, value)
+        end
+      end
+
+      matching_macro = owner.lookup_macro(name, args, named_args)
+      return unless matching_macro.is_a?(Macro)
+
+      interpreter = MacroInterpreter.new(
+        @program,
+        @scope,
+        @program.crystal,
+        matching_macro,
+        Call.new(
+          obj: nil,
+          name: name,
+          args: args,
+          named_args: named_args,
+          block: block),
+        nil,
+        true)
+      interpreter.macro_method_mode = true
+      interpreter.define_var("self", self_value) if self_value
+
+      vars = Set(String).new
+      matching_macro.args.each do |arg|
+        vars << arg.name
+      end
+
+      body = gather_macro_literals(matching_macro.body)
+      body_node = Parser.parse(body, def_vars: [vars])
+      interpreter.accept(body_node)
+      @last = interpreter.last
     end
 
     def interpret_top_level_call?(node)
@@ -73,6 +130,38 @@ module Crystal
         interpret_run(node)
       else
         nil
+      end
+    end
+
+    def gather_macro_literals(body)
+      gatherer = MacroLiteralGatherer.new
+      body.accept gatherer
+      gatherer.to_s
+    end
+
+    class MacroLiteralGatherer < Visitor
+      def initialize
+        @io = String::Builder.new
+      end
+
+      def visit(node : Expressions)
+        node.expressions.each do |exp|
+          exp.accept self
+        end
+        false
+      end
+
+      def visit(node : MacroLiteral)
+        @io << node.value
+        false
+      end
+
+      def visit(node)
+        node.raise "Can't use #{node.class} this inside macro methods"
+      end
+
+      def to_s
+        @io.to_s
       end
     end
 
@@ -373,6 +462,14 @@ module Crystal
       when "!"
         BoolLiteral.new(!truthy?)
       else
+        # Try to lookup a type for this node, for example Crystal::Macros::StringLiteral
+        owner = interpreter.program.crystal.lookup_type?(Path.new(["Macros", class_desc]))
+        if owner
+          # Then try to lookup a user-defined macro in that type
+          value = interpreter.interpret_call_inside_type(owner, method, args, named_args, block, self: self)
+          return value if value
+        end
+
         raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
       end
     end
@@ -1674,6 +1771,10 @@ module Crystal
       when "resolve?"
         interpret_argless_method(method, args) { self }
       else
+        # Lookup a user-defined macro method inside the type
+        value = interpreter.interpret_call_inside_type(type, method, args, named_args, block)
+        return value if value
+
         super
       end
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -897,6 +897,21 @@ module Crystal
         end
       when "values"
         interpret_argless_method(method, args) { ArrayLiteral.map entries, &.value }
+      when "each"
+        interpret_argless_method(method, args) do
+          raise "each expects a block" unless block
+
+          block_arg_key = block.args[0]?
+          block_arg_value = block.args[1]?
+
+          entries.each do |entry|
+            interpreter.define_var(block_arg_key.name, entry.key) if block_arg_key
+            interpreter.define_var(block_arg_value.name, entry.value) if block_arg_value
+            interpreter.accept block.body
+          end
+
+          NilLiteral.new
+        end
       when "map"
         interpret_argless_method(method, args) do
           raise "map expects a block" unless block
@@ -991,6 +1006,21 @@ module Crystal
         end
       when "values"
         interpret_argless_method(method, args) { ArrayLiteral.map entries, &.value }
+      when "each"
+        interpret_argless_method(method, args) do
+          raise "each expects a block" unless block
+
+          block_arg_key = block.args[0]?
+          block_arg_value = block.args[1]?
+
+          entries.each do |entry|
+            interpreter.define_var(block_arg_key.name, MacroId.new(entry.key)) if block_arg_key
+            interpreter.define_var(block_arg_value.name, entry.value) if block_arg_value
+            interpreter.accept block.body
+          end
+
+          NilLiteral.new
+        end
       when "map"
         interpret_argless_method(method, args) do
           raise "map expects a block" unless block
@@ -1102,6 +1132,17 @@ module Crystal
         interpret_argless_method(method, args) { self.to }
       when "excludes_end?"
         interpret_argless_method(method, args) { BoolLiteral.new(self.exclusive?) }
+      when "each"
+        raise "each expects a block" unless block
+
+        block_arg = block.args.first?
+
+        interpret_to_range(interpreter).each do |num|
+          interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
+          interpreter.accept block.body
+        end
+
+        NilLiteral.new
       when "map"
         raise "map expects a block" unless block
 
@@ -2346,6 +2387,34 @@ private def interpret_array_or_tuple_method(object, klass, method, args, block, 
     object.interpret_argless_method(method, args) { object.elements.last? || Crystal::NilLiteral.new }
   when "size"
     object.interpret_argless_method(method, args) { Crystal::NumberLiteral.new(object.elements.size) }
+  when "each"
+    object.interpret_argless_method(method, args) do
+      raise "each expects a block" unless block
+
+      block_arg = block.args.first?
+
+      object.elements.each do |elem|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.accept block.body
+      end
+
+      Crystal::NilLiteral.new
+    end
+  when "each_with_index"
+    object.interpret_argless_method(method, args) do
+      raise "each_with_index expects a block" unless block
+
+      block_arg = block.args[0]?
+      index_arg = block.args[1]?
+
+      object.elements.each_with_index do |elem, idx|
+        interpreter.define_var(block_arg.name, elem) if block_arg
+        interpreter.define_var(index_arg.name, Crystal::NumberLiteral.new idx) if index_arg
+        interpreter.accept block.body
+      end
+
+      Crystal::NilLiteral.new
+    end
   when "map"
     object.interpret_argless_method(method, args) do
       raise "map expects a block" unless block

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -217,6 +217,8 @@ module Crystal
       types["Proc"] = @proc = ProcType.new self, self, "Proc", value, ["T", "R"]
       types["Union"] = @union = GenericUnionType.new self, self, "Union", value, ["T"]
       types["Crystal"] = @crystal = NonGenericModuleType.new self, self, "Crystal"
+      crystal.types["Macros"] = macros = NonGenericModuleType.new self, crystal, "Macros"
+      define_crystal_macros_ast_nodes(macros)
 
       types["ARGC_UNSAFE"] = @argc = argc_unsafe = Const.new self, self, "ARGC_UNSAFE", Primitive.new("argc", int32)
       types["ARGV_UNSAFE"] = @argv = argv_unsafe = Const.new self, self, "ARGV_UNSAFE", Primitive.new("argv", pointer_of(pointer_of(uint8)))
@@ -287,6 +289,22 @@ module Crystal
 
     private def define_crystal_constant(name, value)
       crystal.types[name] = Const.new self, crystal, name, value
+    end
+
+    private def define_crystal_macros_ast_nodes(macros)
+      macros.types["ASTNode"] = ast_node = NonGenericClassType.new self, macros, "ASTNode", reference
+
+      %w(Annotation Arg ArrayLiteral Assign BinaryOp Block BoolLiteral
+        Call Case Cast CharLiteral ClassDef ClassVar Def Expressions
+        Generic Global HashLiteral If ImplicitObj InstanceVar IsA Macro
+        MacroId MetaVar MultiAssign NamedArgument NamedTupleLiteral NilableCast
+        NilLiteral Nop NumberLiteral OffsetOf Path ProcLiteral ProcNotation ProcPointer
+        RangeLiteral ReadInstanceVar RegexLiteral Require RespondsTo Splat
+        StringInterpolation StringLiteral SymbolLiteral TupleLiteral TypeDeclaration
+        TypeNode UnaryExpression UninitializedVar Union Var VisibilityModifier
+        When While).each do |name|
+        macros.types[name] = NonGenericClassType.new self, macros, name, ast_node
+      end
     end
 
     property(target_machine : LLVM::TargetMachine) { codegen_target.to_target_machine }


### PR DESCRIPTION
Implements #8835

This is a quick (but not dirty: there are a few comments and even specs) experiment to see how hard would it be to get user-defined macro methods.

Before this PR, macro methods, those that you can call while inside macros, were hardcoded inside the compiler. For example calling `debug` or `puts` inside a macro, or the method `StringLiteral#downcase`.

This PR allows users to extend these methods in these ways:

1. If you define a macro inside the `Crystal::Macros` module, it can be called as a top-level macro method inside macros. The `debug` macro method is documented [here](https://crystal-lang.org/api/0.33.0/Crystal/Macros.html#debug(format=true):Nop-instance-method), inside the `Crystal::Macros` module, like any other top-level macro method, so I thought for consistency it would make sense for user-defined top-level methods to be defined inside that module too.
2. If you define a macro method inside, say, `Crystal::Macros::StringLiteral`, then when invoking that method on an actual string literal (inside macros) it will be found
3. If you define a macro method inside a type, for example a macro `bar` inside `Foo`, and you write `Foo.bar` inside macro code, it will be found and called.

You can see examples of all of these in the PR's specs.

## There's a big difference between these new macros methods and regular macros

All of these macros that you can define work in a **different** way than regular methods. The reason is that normal macros generate code: by default the things that you write are the generated code, and to do some logic you use `{% ... %}`, and to interpolate code to generate you use `{{ ... }}`. However, the macro methods introduce here don't allow `{% ... %}` nor `{{ ... }}` because they are already operating on AST nodes and they produce AST nodes, not code. So calling those methods outside macros is allowed but doesn't make sense (they just produce static code).

For example:

```crystal
module Crystal::Macros
  macro foo(x)
    x + "bar"
  end
end

macro bar(x)
  {{ foo(x) }}
end

bar("foo")
```

Now how the macro method `foo` computes a different value depending on the value of `x`. But this is only if you call it from inside other macros. If you call it like `Crystal::Macros.foo("hello")` then the `x` that's mentioned there is just text, not a reference to the variable. It would need to be `{{ x }}` inside the regular macro methods.

But I think that's fine.

## What's missing

Now, because these macro methods don't allow `{% %}`, and because iteration methods such as `each` simply don't exist in macro land, and because `while` doesn't work inside macro land, things are still a bit restrictive.

My idea forward would be to **maybe**:
- [x] allow `while` inside macros (same for `until`), 
- [x] and also implement the many `each` and `each_with_index` methods, 
- [ ] and even eventually remove `{% for ... %}` and replace it with `.each` (but this last point is not necessary).

And to polish things up, I would define all built-in macro methods in Crystal code but tagged with `@[Primitive]`, the same way it's done with primitive methods.

- [x] Another thing that probably doesn't work right now is defining a macro inside `Crystal::Macros::ASTNode` and finding it through `Crystal::Macros::StringLiteral`, because that hierarchy is fake and is not defined anywhere (but this is a simple fix).

I won't keep working on this because 1.0 might be near and I don't want to introduce a new feature that will radically change the existing language, but if there's interest and approval I will (if I have time).