### PR TITLE
Explicitly Convert `Float32` to `Float64` Before Call

### DIFF
--- a/spec/std/float_printer_spec.cr
+++ b/spec/std/float_printer_spec.cr
@@ -135,6 +135,8 @@ describe "#print Float32" do
   it { test_pair 1000000000000000.0_f32, "1.0e+15" }
   it { test_pair 1111111111111111.0_f32, "1.1111111e+15" }
   it { test_pair -3.9292015898194142585311918e-10_f32, "-3.9292017e-10" }
+  # fails grisu check; ensures libc fallback works correctly
+  it { test_pair 85_f32 / 512_f32, "0.166016" }
 
   it "largest float" do
     test_pair 3.4028234e38_f32, "3.4028235e+38"

--- a/src/float/printer.cr
+++ b/src/float/printer.cr
@@ -44,7 +44,7 @@ module Float::Printer
       if v.class == Float64
         LibC.snprintf(buffer.to_unsafe, BUFFER_SIZE, "%.17g", v)
       else
-        LibC.snprintf(buffer.to_unsafe, BUFFER_SIZE, "%g", v)
+        LibC.snprintf(buffer.to_unsafe, BUFFER_SIZE, "%g", v.to_f64)
       end
       len = LibC.strlen(buffer)
       io.write_utf8 buffer.to_slice[0, len]


### PR DESCRIPTION
Since we're already on the slow path, explicitly convert the `Float32` values to a `Float64` value before making the `snprintf` call. Includes a test that demonstrates the fix/failure.

This addresses https://github.com/crystal-lang/crystal/issues/8837
