### PR TITLE
Add the binary name of the project/lib to the .gitignore.

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -62,6 +62,7 @@ module Crystal
           gitignore.should contain("/.shards/")
           gitignore.should contain("/shard.lock")
           gitignore.should contain("/lib/")
+          gitignore.should contain("/example")
         end
 
         with_file "example_app/.gitignore" do |gitignore|
@@ -69,6 +70,7 @@ module Crystal
           gitignore.should contain("/.shards/")
           gitignore.should_not contain("/shard.lock")
           gitignore.should contain("/lib/")
+          gitignore.should contain("/example")
         end
 
         {"example", "example_app", "example-lib", "camel_example-camel_lib"}.each do |name|

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -9,3 +9,5 @@
 # Dependencies will be locked in applications that use them
 /shard.lock
 <%- end -%>
+
+/<%= config.name -%>


### PR DESCRIPTION
A lazy developer might run `crystal build src/project.cr` and accidentally add the `./project` binary. Safer to ignore any built binaries.