### PR TITLE
Format code in comments following # =>

### DIFF
--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4516,7 +4516,15 @@ module Crystal
         raw_after_comment_value = value[1..-1]
         after_comment_value = raw_after_comment_value.strip
         if after_comment_value.starts_with?("=>")
-          value = "\# => #{after_comment_value[2..-1].strip}"
+          # If a comment starts with `=>`, it indicates the result of an expression which
+          # is a valid expression itself and should be properly formatted.
+          formatted_result_expression = after_comment_value[2..-1]
+          begin
+            formatted_result_expression = Formatter.format(formatted_result_expression)
+          rescue Crystal::SyntaxException
+            # A failure to parse the comment is ignored. It is only a comment after all.
+          end
+          value = "\# => #{formatted_result_expression.strip}"
         elsif after_comment_value.each_char.all? { |c| c.ascii_whitespace? || c == '#' }
           # Nothing, leave sequences of whitespaces and '#' as is
         else


### PR DESCRIPTION
Implements the feature discussed in  #7272.

Using the same example as in the issue:
```crystal
a = [1, 2, 3]
a.permutations    # => [[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]]
a.permutations(1) # => [[1],[2],[3]]
a.permutations(2) # => [[1,2],[1,3],[2,1],[2,3],[3,1],[3,2]]
a.permutations(3) # => [[1,2,3],[1,3,2],[2,1,3],[2,3,1],[3,1,2],[3,2,1]]
a.permutations(0) # => [[]]
a.permutations(4) # => []
```
The above is now formatted like this:
```crystal
a = [1, 2, 3]
a.permutations    # => [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
a.permutations(1) # => [[1], [2], [3]]
a.permutations(2) # => [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
a.permutations(3) # => [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
a.permutations(0) # => [[]]
a.permutations(4) # => []
```

Note that the last two lines are no valid Crystal expressions in which case the formatter doesn't change them.

This is my first attempt at a contribution to the project so if I did anything wrong please let me know and I will try to improve.