### PR TITLE
feat(slice.cr): add `unsafe_bytes` method

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -143,6 +143,11 @@ describe "Slice" do
 
     expect_raises(IndexError) { slice.copy_to(pointer, 5) }
   end
+  
+  it "does convert to_bytes" do
+    slice = Slice.new(3) { |i| i + 1 }
+    slice.to_bytes.should eq(Bytes[1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0])
+  end
 
   describe ".copy_to(Slice)" do
     it "copies bytes" do

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -144,9 +144,9 @@ describe "Slice" do
     expect_raises(IndexError) { slice.copy_to(pointer, 5) }
   end
 
-  it "does convert to_bytes" do
+  it "does provide access to unsafe_bytes" do
     slice = Slice.new(3) { |i| i + 1 }
-    slice.to_bytes.should eq(Bytes[1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0])
+    slice.unsafe_bytes.should eq(Bytes[1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0])
   end
 
   describe ".copy_to(Slice)" do

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -143,7 +143,7 @@ describe "Slice" do
 
     expect_raises(IndexError) { slice.copy_to(pointer, 5) }
   end
-  
+
   it "does convert to_bytes" do
     slice = Slice.new(3) { |i| i + 1 }
     slice.to_bytes.should eq(Bytes[1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0])

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -415,6 +415,11 @@ struct Slice(T)
     @pointer.move_to(target.to_unsafe, size)
   end
 
+  # Returns the `Slice(UInt8)` representation of the underlying bytes
+  def to_bytes
+    Slice(UInt8).new(self.to_unsafe.as(Pointer(UInt8)), self.bytesize)
+  end
+
   # Moves the contents of *source* into this slice. *source* and `self` may
   # overlap; the copy is always done in a non-destructive manner.
   #

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -416,7 +416,7 @@ struct Slice(T)
   end
 
   # Returns the `Slice(UInt8)` representation of the underlying bytes
-  def to_bytes
+  def unsafe_bytes
     Slice(UInt8).new(self.to_unsafe.as(Pointer(UInt8)), self.bytesize)
   end
 


### PR DESCRIPTION
for obtaining the `Slice(UInt8)` representation of the underlying bytes of any slice.