### PR TITLE
Use flag?(:i386) instead of i686

### DIFF
--- a/spec/compiler/codegen/asm_spec.cr
+++ b/spec/compiler/codegen/asm_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: asm" do
   # TODO: arm asm tests
-  {% if flag?(:i686) || flag?(:x86_64) %}
+  {% if flag?(:i386) || flag?(:x86_64) %}
     it "codegens without inputs" do
       run(%(
         dst = uninitialized Int32

--- a/src/callstack.cr
+++ b/src/callstack.cr
@@ -52,7 +52,7 @@ struct CallStack
     @backtrace ||= decode_backtrace
   end
 
-  {% if flag?(:gnu) && flag?(:i686) %}
+  {% if flag?(:gnu) && flag?(:i386) %}
     # This is only used for the workaround described in `Exception.unwind`
     @@makecontext_range : Range(Void*, Void*)?
 
@@ -84,7 +84,7 @@ struct CallStack
            {% end %}
       bt << ip
 
-      {% if flag?(:gnu) && flag?(:i686) %}
+      {% if flag?(:gnu) && flag?(:i386) %}
         # This is a workaround for glibc bug: https://sourceware.org/bugzilla/show_bug.cgi?id=18635
         # The unwind info is corrupted when `makecontext` is used.
         # Stop the backtrace here. There is nothing interest beyond this point anyway.

--- a/src/fiber/context/i386.cr
+++ b/src/fiber/context/i386.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:i686) %}
+{% skip_file unless flag?(:i386) %}
 
 class Fiber
   # :nodoc:

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -48,7 +48,7 @@ lib LibIntrinsics
   fun va_start = "llvm.va_start"(ap : Void*)
   fun va_end = "llvm.va_end"(ap : Void*)
 
-  {% if flag?(:i686) || flag?(:x86_64) %}
+  {% if flag?(:i386) || flag?(:x86_64) %}
     fun pause = "llvm.x86.sse2.pause"
   {% end %}
 end
@@ -59,7 +59,7 @@ module Intrinsics
   end
 
   def self.pause
-    {% if flag?(:i686) || flag?(:x86_64) %}
+    {% if flag?(:i386) || flag?(:x86_64) %}
       LibIntrinsics.pause
     {% end %}
   end

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -10,7 +10,7 @@ lib LibC
   alias Int = Int32
   alias UInt = UInt32
 
-  {% if flag?(:win32) || flag?(:i686) || flag?(:arm) %}
+  {% if flag?(:win32) || flag?(:i386) || flag?(:arm) %}
     alias Long = Int32
     alias ULong = UInt32
   {% elsif flag?(:x86_64) || flag?(:aarch64) %}


### PR DESCRIPTION
The normalized architecture i386 is the one present in the flags

Fixes #8824.
The cause was a conflict between

* https://github.com/crystal-lang/crystal/pull/7282/files#diff-782340590099fc3f5015755a3b74b586R31
* https://github.com/crystal-lang/crystal/pull/7282/files#diff-0817fdb7bea983f15d454e56956e8725R21
* https://github.com/crystal-lang/crystal/pull/8772/files#diff-782340590099fc3f5015755a3b74b586L31

And this PR should be the missing piece.

The test ecosystem is not checking progress on the 32-bits platform, obviously. Because there is no cross-compiling there. Progress is guaranteed on 64-bits on nightlies thanks to test_dist_linux_on_docker job though.