### PR TITLE
Compiler: don't say "undefined method" on abstract leaf types

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1091,4 +1091,66 @@ describe "Semantic: class" do
       ),
       "can't read instance variables of union types (@x of (Bar | Foo))"
   end
+
+  it "types as no return if calling method on abstract class with all abstract subclasses (#6996)" do
+    assert_type(%(
+      require "prelude"
+
+      abstract class Foo
+        abstract def foo?
+      end
+
+      abstract class Bar < Foo
+      end
+
+      Pointer(Foo).malloc(1_u64).value.foo?
+      )) { no_return }
+  end
+
+  it "types as no return if calling method on abstract class with generic subclasses but no instances (#6996)" do
+    assert_type(%(
+      require "prelude"
+
+      abstract class Foo
+        abstract def foo?
+      end
+
+      class Bar(T) < Foo
+        def foo?
+          true
+        end
+      end
+
+      Pointer(Foo).malloc(1_u64).value.foo?
+      )) { no_return }
+  end
+
+  it "types as no return if calling method on abstract generic class (#6996)" do
+    assert_type(%(
+      require "prelude"
+
+      abstract class Foo(T)
+        abstract def foo?
+      end
+
+      Pointer(Foo(Int32)).malloc(1_u64).value.foo?
+      )) { no_return }
+  end
+
+  it "types as no return if calling method on generic class with subclasses (#6996)" do
+    assert_type(%(
+      require "prelude"
+
+      abstract class Foo(T)
+        abstract def foo?
+      end
+
+      abstract class Bar(T) < Foo(T)
+      end
+
+      Bar(Int32)
+
+      Pointer(Foo(Int32)).malloc(1_u64).value.foo?
+      )) { no_return }
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -293,7 +293,7 @@ class Crystal::Call
       # don't give error. This is to allow small code comments without giving
       # compile errors, which will anyway appear once you add concrete
       # subclasses and instances.
-      if def_name == "new" || !(!owner.metaclass? && owner.abstract? && (owner.leaf? || owner.is_a?(GenericClassInstanceType)))
+      if def_name == "new" || !(!owner.metaclass? && owner.abstract_leaf?)
         raise_matches_not_found(matches.owner || owner, def_name, arg_types, named_args_types, matches, with_literals: with_literals)
       end
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -41,6 +41,25 @@ module Crystal
       false
     end
 
+    # Returns `true` if this type is abstract and and it has no
+    # concrete subclasses. This can happen if this type has abstract
+    # subclasses, or non-abstract generic subclasses without instantiations.
+    def abstract_leaf?
+      type = self.devirtualize
+
+      case type
+      when GenericType
+        (type.abstract? && type.generic_types.empty?) ||
+          (type.generic_types.all? { |name, type| type.abstract_leaf? })
+      when GenericClassInstanceType
+        type.abstract? && type.subclasses.all?(&.abstract_leaf?)
+      when ClassType
+        type.abstract? && type.subclasses.all?(&.abstract_leaf?)
+      else
+        false
+      end
+    end
+
     # Returns `true` if this type is a struct.
     def struct?
       false

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -41,7 +41,7 @@ module Crystal
       false
     end
 
-    # Returns `true` if this type is abstract and and it has no
+    # Returns `true` if this type is abstract and it has no
     # concrete subclasses. This can happen if this type has abstract
     # subclasses, or non-abstract generic subclasses without instantiations.
     def abstract_leaf?


### PR DESCRIPTION
Fixes #6996

Consider this code:

```crystal
abstract class Foo
end

foos = [] of Foo
foos.all?(&.valid?) # => true
```

The code above compiles fine in Crystal. The reason is that, because `Foo` is abstract, only its subclasses can actually be instantiated. But there are no subclasses! So there's no way to actually instantiate a `Foo`.

The compiler will then consider any call on such abstract types to be valid, but produce `NoReturn`... which makes sense: there's no way to reach that (but see the "Reaching that NoReturn" at the end).

The reason this also compiles is because Crystal tries to mimic Ruby. Let's consider this Ruby code:

```ruby
class Foo
end

foos = [] of Foo
foos.all?(&:valid?) # => true
```

It works! Because we didn't pass any Foo, it's trivially true. Ruby doesn't even need to check that `valid?` method, **and Crystal does the same thing**.

Crystal is always "if you don't call it, we don't know". Which makes sense according to its prototypey and duck-typey nature.

## But it didn't always work

If `Foo` had an abstract subclasses, the compiler used to complain:

```crystal
abstract class Foo
end

abstract class Bar < Foo
end

foos = [] of Foo
foos.all?(&.valid?) # Error: undefined method 'valid?' for Foo+
```

The bug is that the compiler just checked whether `Foo` was abstract without subclasses. But the condition should also apply if `Foo` is abstract and all of its subclasses are in the same condition. The compiler calls this "abstract leaf".

It can also happen with generic types, even if they are concrete:

```crystal
abstract class Foo
end

class Bar(T) < Foo
end

foos = [] of Foo
foos.all?(&.valid?) # => true
```

The above snippet didn't work, but with this PR it works. It works because `Bar(T)` has no generic instances. `Foo` was never actually instantiated.

And if you do instantiate `Bar` you'll get an error saying "undefined method 'valid?' for Bar(Int32) (compile-time type is Foo+)".

## Why is this useful?

This is useful because one could define a hierarchy of abstract types, or generic types, and write code to work with that. Maybe a test creates instances. Maybe other tests don't because they expect third party shards to defined subclasses. All of these cases should work.

## Reaching that NoReturn

Actually, there is:

```crystal
abstract class Foo
end

ptr = Pointer(Foo).malloc(1)
ptr.value.valid?
```

The above compiles fine and raises an error on runtime:

```
can't execute `ptr.value.valid?` at /Users/asterite/Projects/crystal/foo.cr:5:3: `ptr.value.valid?` has no type (Exception)
```

But that's unsafe and it usually never happens in real code: the pointer is inside an array, there are bound checks, etc.

