### PR TITLE
IO: Set fd to -1 on closed File/Socket

### DIFF
--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "socket"
 require "../../support/errno"
+require "../../support/fibers"
 require "../../support/tempfile"
 
 describe UNIXServer do

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -173,7 +173,7 @@ module Crystal::System::File
   private def flock(op : LibC::FlockOp, blocking : Bool = true)
     op |= LibC::FlockOp::NB unless blocking
 
-    if LibC.flock(@fd, op) != 0
+    if LibC.flock(fd, op) != 0
       raise Errno.new("flock")
     end
 

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -123,7 +123,12 @@ module Crystal::System::FileDescriptor
   end
 
   def file_descriptor_close
-    if LibC.close(@fd) != 0
+    # Clear the @fd before actually closing it in order to
+    # reduce the chance of reading an outdated fd value
+    fd = @fd
+    @fd = -1
+
+    if LibC.close(fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -5,11 +5,11 @@ require "io/evented"
 module Crystal::System::FileDescriptor
   include IO::Evented
 
-  @fd : Int32
+  @volatile_fd : Atomic(Int32)
 
   private def unbuffered_read(slice : Bytes)
     evented_read(slice, "Error reading file") do
-      LibC.read(@fd, slice, slice.size).tap do |return_code|
+      LibC.read(fd, slice, slice.size).tap do |return_code|
         if return_code == -1 && Errno.value == Errno::EBADF
           raise IO::Error.new "File not open for reading"
         end
@@ -19,7 +19,7 @@ module Crystal::System::FileDescriptor
 
   private def unbuffered_write(slice : Bytes)
     evented_write(slice, "Error writing file") do |slice|
-      LibC.write(@fd, slice, slice.size).tap do |return_code|
+      LibC.write(fd, slice, slice.size).tap do |return_code|
         if return_code == -1 && Errno.value == Errno::EBADF
           raise IO::Error.new "File not open for writing"
         end
@@ -54,7 +54,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_closed?
-    LibC.fcntl(@fd, LibC::F_GETFL) == -1
+    LibC.fcntl(fd, LibC::F_GETFL) == -1
   end
 
   def self.fcntl(fd, cmd, arg = 0)
@@ -64,7 +64,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_info
-    if LibC.fstat(@fd, out stat) != 0
+    if LibC.fstat(fd, out stat) != 0
       raise Errno.new("Unable to get info")
     end
 
@@ -72,7 +72,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_seek(offset, whence : IO::Seek) : Nil
-    seek_value = LibC.lseek(@fd, offset, whence)
+    seek_value = LibC.lseek(fd, offset, whence)
 
     if seek_value == -1
       raise Errno.new "Unable to seek"
@@ -80,25 +80,25 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_pos
-    pos = LibC.lseek(@fd, 0, IO::Seek::Current)
+    pos = LibC.lseek(fd, 0, IO::Seek::Current)
     raise Errno.new "Unable to tell" if pos == -1
     pos
   end
 
   private def system_tty?
-    LibC.isatty(@fd) == 1
+    LibC.isatty(fd) == 1
   end
 
   private def system_reopen(other : IO::FileDescriptor)
     {% if LibC.methods.includes? "dup3".id %}
       # dup doesn't copy the CLOEXEC flag, so copy it manually using dup3
       flags = other.close_on_exec? ? LibC::O_CLOEXEC : 0
-      if LibC.dup3(other.@fd, @fd, flags) == -1
+      if LibC.dup3(other.fd, fd, flags) == -1
         raise Errno.new("Could not reopen file descriptor")
       end
     {% else %}
       # dup doesn't copy the CLOEXEC flag, copy it manually to the new
-      if LibC.dup2(other.@fd, @fd) == -1
+      if LibC.dup2(other.fd, fd) == -1
         raise Errno.new("Could not reopen file descriptor")
       end
 
@@ -123,12 +123,11 @@ module Crystal::System::FileDescriptor
   end
 
   def file_descriptor_close
-    # Clear the @fd before actually closing it in order to
+    # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value
-    fd = @fd
-    @fd = -1
+    _fd = @volatile_fd.swap(-1)
 
-    if LibC.close(fd) != 0
+    if LibC.close(_fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -213,7 +213,7 @@ module Crystal::System::File
   end
 
   private def system_truncate(size : Int) : Nil
-    if LibC._chsize(@fd, size) != 0
+    if LibC._chsize(fd, size) != 0
       raise Errno.new("Error truncating file #{path.inspect}")
     end
   end

--- a/src/file.cr
+++ b/src/file.cr
@@ -785,7 +785,7 @@ class File < IO::FileDescriptor
       raise ArgumentError.new("Bytesize out of bounds")
     end
 
-    io = PReader.new(fd, offset, bytesize)
+    io = PReader.new(self, offset, bytesize)
     yield io ensure io.close
   end
 

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -4,7 +4,7 @@ class File::PReader < IO
 
   getter? closed = false
 
-  def initialize(@fd : Int32, @offset : Int32, @bytesize : Int32)
+  def initialize(@file : File, @offset : Int32, @bytesize : Int32)
     @pos = 0
   end
 
@@ -14,7 +14,7 @@ class File::PReader < IO
     count = slice.size
     count = Math.min(count, @bytesize - @pos)
 
-    bytes_read = Crystal::System::FileDescriptor.pread(@fd, slice[0, count], @offset + @pos)
+    bytes_read = Crystal::System::FileDescriptor.pread(@file.fd, slice[0, count], @offset + @pos)
 
     @pos += bytes_read
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -7,9 +7,12 @@ class IO::FileDescriptor < IO
 
   # The raw file-descriptor. It is defined to be an `Int`, but its size is
   # platform-specific.
-  getter fd
+  def fd
+    @volatile_fd.get
+  end
 
-  def initialize(@fd, blocking = nil)
+  def initialize(fd, blocking = nil)
+    @volatile_fd = Atomic.new(fd)
     @closed = system_closed?
 
     if blocking.nil?
@@ -69,7 +72,7 @@ class IO::FileDescriptor < IO
     end
 
     def fcntl(cmd, arg = 0)
-      Crystal::System::FileDescriptor.fcntl(@fd, cmd, arg)
+      Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
     end
   {% end %}
 
@@ -171,7 +174,7 @@ class IO::FileDescriptor < IO
     if closed?
       io << "(closed)"
     else
-      io << " fd=" << @fd
+      io << " fd=" << fd
     end
     io << '>'
   end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -38,7 +38,11 @@ class Socket < IO
   # :nodoc:
   SOMAXCONN = 128
 
-  getter fd : Int32
+  @volatile_fd : Atomic(Int32)
+
+  def fd : Int32
+    @volatile_fd.get
+  end
 
   @closed : Bool
 
@@ -69,7 +73,7 @@ class Socket < IO
     fd = LibC.socket(family, type, protocol)
     raise Errno.new("failed to create socket:") if fd == -1
     init_close_on_exec(fd)
-    @fd = fd
+    @volatile_fd = Atomic.new(fd)
 
     self.sync = true
     unless blocking
@@ -78,9 +82,10 @@ class Socket < IO
   end
 
   # Creates a Socket from an existing socket file descriptor.
-  def initialize(@fd : Int32, @family, @type, @protocol = Protocol::IP, blocking = false)
+  def initialize(fd : Int32, @family, @type, @protocol = Protocol::IP, blocking = false)
+    @volatile_fd = Atomic.new(fd)
     @closed = false
-    init_close_on_exec(@fd)
+    init_close_on_exec(fd)
 
     self.sync = true
     unless blocking
@@ -355,13 +360,13 @@ class Socket < IO
   end
 
   private def shutdown(how)
-    if LibC.shutdown(@fd, how) != 0
+    if LibC.shutdown(fd, how) != 0
       raise Errno.new("shutdown #{how}")
     end
   end
 
   def inspect(io : IO) : Nil
-    io << "#<#{self.class}:fd #{@fd}>"
+    io << "#<#{self.class}:fd #{fd}>"
   end
 
   def send_buffer_size
@@ -520,7 +525,7 @@ class Socket < IO
   end
 
   def fcntl(cmd, arg = 0)
-    self.class.fcntl @fd, cmd, arg
+    self.class.fcntl fd, cmd, arg
   end
 
   def finalize
@@ -539,13 +544,13 @@ class Socket < IO
 
   private def unbuffered_read(slice : Bytes)
     evented_read(slice, "Error reading socket") do
-      LibC.recv(@fd, slice, slice.size, 0).to_i32
+      LibC.recv(fd, slice, slice.size, 0).to_i32
     end
   end
 
   private def unbuffered_write(slice : Bytes)
     evented_write(slice, "Error writing to socket") do |slice|
-      LibC.send(@fd, slice, slice.size, 0)
+      LibC.send(fd, slice, slice.size, 0)
     end
   end
 
@@ -562,13 +567,12 @@ class Socket < IO
     @closed = true
     evented_close
 
-    # Clear the @fd before actually closing it in order to
+    # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value
-    fd = @fd
-    @fd = -1
+    _fd = @volatile_fd.swap(-1)
 
     err = nil
-    if LibC.close(fd) != 0
+    if LibC.close(_fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -562,8 +562,13 @@ class Socket < IO
     @closed = true
     evented_close
 
+    # Clear the @fd before actually closing it in order to
+    # reduce the chance of reading an outdated fd value
+    fd = @fd
+    @fd = -1
+
     err = nil
-    if LibC.close(@fd) != 0
+    if LibC.close(fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore


### PR DESCRIPTION
Based on https://github.com/crystal-lang/crystal/pull/8733#discussion_r379699783

When closing a File or Socket the fd is set to -1 to force an invalid file descriptor on other threads that passed the `check_open` assertion before closing it.

Atomic is used to force a volatile Java-like semantics so the reads are sequentially consistent with the writes of other threads.