### PR TITLE
Set HTTP::Headers in read-only mode after HTTP::Headers were written

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -209,7 +209,7 @@ describe HTTP::Headers do
 
   it "raises when read_only (#8712)" do
     headers = HTTP::Headers.new
-    headers.read_only = true
+    headers.read_only!
 
     expect_raises(ReadOnlyError) { headers["Foo"] = "Bar" }
     expect_raises(ReadOnlyError) { headers["Foo"] = ["Bar", "Baz"] }

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -206,4 +206,18 @@ describe HTTP::Headers do
     headers.add?("foobar", invalid_value).should be_false
     headers.add?("foobar", [invalid_value]).should be_false
   end
+
+  it "raises when read_only (#8712)" do
+    headers = HTTP::Headers.new
+    headers.read_only = true
+
+    expect_raises(ReadOnlyError) { headers["Foo"] = "Bar" }
+    expect_raises(ReadOnlyError) { headers["Foo"] = ["Bar", "Baz"] }
+    expect_raises(ReadOnlyError) { headers.add "Foo", "Bar" }
+    expect_raises(ReadOnlyError) { headers.add "Foo", ["Bar", "Baz"] }
+    expect_raises(ReadOnlyError) { headers.add? "Foo", "Bar" }
+    expect_raises(ReadOnlyError) { headers.add? "Foo", ["Bar", "Baz"] }
+    expect_raises(ReadOnlyError) { headers.delete "Foo" }
+    expect_raises(ReadOnlyError) { headers.merge!({"Foo" => "Bar"}) }
+  end
 end

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -207,9 +207,9 @@ describe HTTP::Headers do
     headers.add?("foobar", [invalid_value]).should be_false
   end
 
-  it "raises when read_only (#8712)" do
+  it "raises when already sent (#8712)" do
     headers = HTTP::Headers.new
-    headers.read_only!
+    headers.mark_as_sent!
 
     expect_raises(ReadOnlyError) { headers["Foo"] = "Bar" }
     expect_raises(ReadOnlyError) { headers["Foo"] = ["Bar", "Baz"] }

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -207,17 +207,41 @@ describe HTTP::Headers do
     headers.add?("foobar", [invalid_value]).should be_false
   end
 
-  it "raises when already sent (#8712)" do
-    headers = HTTP::Headers.new
-    headers.mark_as_sent!
+  describe "sent" do
+    it "raises when already sent (#8712)" do
+      headers = HTTP::Headers.new
+      headers.sent = true
 
-    expect_raises(ReadOnlyError) { headers["Foo"] = "Bar" }
-    expect_raises(ReadOnlyError) { headers["Foo"] = ["Bar", "Baz"] }
-    expect_raises(ReadOnlyError) { headers.add "Foo", "Bar" }
-    expect_raises(ReadOnlyError) { headers.add "Foo", ["Bar", "Baz"] }
-    expect_raises(ReadOnlyError) { headers.add? "Foo", "Bar" }
-    expect_raises(ReadOnlyError) { headers.add? "Foo", ["Bar", "Baz"] }
-    expect_raises(ReadOnlyError) { headers.delete "Foo" }
-    expect_raises(ReadOnlyError) { headers.merge!({"Foo" => "Bar"}) }
+      expect_raises(ReadOnlyError) { headers["Foo"] = "Bar" }
+      expect_raises(ReadOnlyError) { headers["Foo"] = ["Bar", "Baz"] }
+      expect_raises(ReadOnlyError) { headers.add "Foo", "Bar" }
+      expect_raises(ReadOnlyError) { headers.add "Foo", ["Bar", "Baz"] }
+      expect_raises(ReadOnlyError) { headers.add? "Foo", "Bar" }
+      expect_raises(ReadOnlyError) { headers.add? "Foo", ["Bar", "Baz"] }
+      expect_raises(ReadOnlyError) { headers.delete "Foo" }
+      expect_raises(ReadOnlyError) { headers.merge!({"Foo" => "Bar"}) }
+    end
+
+    it "can still read them" do
+      headers = HTTP::Headers{"Foo" => "Bar"}
+      headers.sent = true
+
+      headers["Foo"].should eq("Bar")
+    end
+
+    it "can still read them" do
+      headers = HTTP::Headers{"Foo" => "Bar"}
+      headers.sent = true
+
+      headers["Foo"].should eq("Bar")
+    end
+
+    it "can write them if sent is false" do
+      headers = HTTP::Headers{"Foo" => "Bar"}
+      headers.sent = true
+      headers.sent = false
+
+      headers["Foo"] = ["Bar", "Baz"]
+    end
   end
 end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -185,6 +185,17 @@ describe HTTP::Server::Response do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\nHello")
   end
 
+  it "raises if setting headers but response was already sent (#8712)" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.print("Hello")
+    response.flush
+
+    expect_raises(ReadOnlyError) do
+      response.headers["Content-Type"] = "text/plain"
+    end
+  end
+
   describe "#respond_with_status" do
     it "uses default values" do
       io = IO::Memory.new

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -455,14 +455,14 @@ describe "Slice" do
 
   it "creates read-only slice" do
     slice = Slice.new(3, 0, read_only: true)
-    expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 1 }
-    expect_raises(Exception, "Can't write to read-only Slice") { slice.copy_from(slice) }
+    expect_raises(ReadOnlyError, "Can't write to read-only Slice") { slice[0] = 1 }
+    expect_raises(ReadOnlyError, "Can't write to read-only Slice") { slice.copy_from(slice) }
 
     subslice = slice[0, 1]
-    expect_raises(Exception, "Can't write to read-only Slice") { subslice[0] = 1 }
+    expect_raises(ReadOnlyError, "Can't write to read-only Slice") { subslice[0] = 1 }
 
     slice = Bytes[1, 2, 3, read_only: true]
-    expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 0_u8 }
+    expect_raises(ReadOnlyError, "Can't write to read-only Slice") { slice[0] = 0_u8 }
   end
 
   it "hashes each item in collection" do

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -169,3 +169,15 @@ end
 class RuntimeError < Exception
   include SystemError
 end
+
+# Raised when trying to modify an object that is read-only.
+#
+# ```
+# slice = Slice.new(10, read_only: true) { |i| i }
+# slice[0] = 1
+# ```
+class ReadOnlyError < Exception
+  def initialize(message)
+    super(message)
+  end
+end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -48,16 +48,24 @@ struct HTTP::Headers
     end
   end
 
-  # Determines whethere these headers are in read-only mode.
-  # When in read-only mode, trying to modify these headers will
-  # raise `ReadOnlyError`.
-  property? read_only = false
-
   def initialize
     # We keep a Hash with String | Array(String) values because
     # the most common case is a single value and so we avoid allocating
     # memory for arrays.
     @hash = Hash(Key, String | Array(String)).new
+    @read_only = false
+  end
+
+  # Makes these headers read-only.
+  # When in read-only mode, trying to modify these headers
+  # will raise `ReadOnlyError`.
+  def read_only!
+    @read_only = true
+  end
+
+  # Returns `true` if these headers are in read-only mode.
+  def read_only?
+    @read_only
   end
 
   def []=(key, value : String)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -56,10 +56,12 @@ struct HTTP::Headers
     @sent = false
   end
 
-  # Marks these headers as being sent.
-  # If so, trying to modify these headers will raise `ReadOnlyError`.
-  def mark_as_sent!
-    @sent = true
+  # Marks these headers as being sent or not.
+  # If sent, trying to modify these headers will raise `ReadOnlyError`.
+  #
+  # You usually shouldn't set this property unless you are implementing
+  # an HTTP server. This property is controlled by `HTTP::Server`.
+  def sent=(@sent)
   end
 
   # Returns `true` if these headers were already sent.

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -162,7 +162,7 @@ class HTTP::Server
       end
       @io << "\r\n"
       @wrote_headers = true
-      headers.read_only = true
+      headers.read_only!
     end
 
     protected def wrote_headers?

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -162,6 +162,7 @@ class HTTP::Server
       end
       @io << "\r\n"
       @wrote_headers = true
+      headers.read_only = true
     end
 
     protected def wrote_headers?

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -50,6 +50,7 @@ class HTTP::Server
     def reset
       # This method is called by RequestProcessor to avoid allocating a new instance for each iteration.
       @headers.clear
+      @headers.sent = false
       @cookies = nil
       @status = :ok
       @wrote_headers = false
@@ -162,7 +163,7 @@ class HTTP::Server
       end
       @io << "\r\n"
       @wrote_headers = true
-      headers.mark_as_sent!
+      headers.sent = true
     end
 
     protected def wrote_headers?

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -162,7 +162,7 @@ class HTTP::Server
       end
       @io << "\r\n"
       @wrote_headers = true
-      headers.read_only!
+      headers.mark_as_sent!
     end
 
     protected def wrote_headers?

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -761,7 +761,7 @@ struct Slice(T)
   end
 
   protected def check_writable
-    raise "Can't write to read-only Slice" if @read_only
+    raise ReadOnlyError.new("Can't write to read-only Slice") if @read_only
   end
 
   private def check_size(count : Int)


### PR DESCRIPTION
Fixes #8712