### PR TITLE
Show warnings on docs command

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -84,6 +84,8 @@ class Crystal::Command
         puts opts
         exit
       end
+
+      setup_compiler_warning_options(opts, compiler)
     end
 
     if options.empty?
@@ -102,5 +104,8 @@ class Crystal::Command
     result = compiler.top_level_semantic sources
 
     Doc::Generator.new(result.program, included_dirs, output_directory, output_format, sitemap_base_url, sitemap_priority, sitemap_changefreq).run
+
+    report_warnings result
+    exit 1 if warnings_fail_on_exit?(result)
   end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -326,7 +326,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
 
     node.doc ||= annotations_doc(annotations)
-    check_ditto node
+    check_ditto node, node.location
 
     is_instance_method = false
 
@@ -672,7 +672,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
       const_member = enum_type.add_constant member
       const_member.doc = member.doc
-      check_ditto const_member
+      check_ditto const_member, member.location
 
       if member_location = member.location
         const_member.add_location(member_location)
@@ -754,7 +754,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     const = Const.new(@program, scope, name, value)
     const.private = true if target.visibility.private?
 
-    check_ditto node
+    check_ditto node, node.location
     attach_doc const, node
 
     scope.types[name] = const
@@ -851,7 +851,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
 
     node.doc ||= annotations_doc(annotations)
-    check_ditto node
+    check_ditto node, node.location
 
     # Copy call convention from lib, if any
     scope = current_type
@@ -1056,14 +1056,18 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
   end
 
-  def check_ditto(node : Def | Assign | FunDef | Const) : Nil
+  def check_ditto(node : Def | Assign | FunDef | Const, location : Location?) : Nil
     return if !@program.wants_doc?
     stripped_doc = node.doc.try &.strip
     if stripped_doc == ":ditto:"
       node.doc = @last_doc
     elsif stripped_doc == "ditto"
-      # TODO: remove after 0.33.0
-      @program.warning_failures << "`ditto` is no longer supported. Use `:ditto:` instead"
+      # TODO: remove after 0.34.0
+      if location
+        # Show one line above to highlight the ditto line
+        location = Location.new(location.filename, location.line_number - 1, location.column_number)
+      end
+      @program.report_warning_at location, "`ditto` is no longer supported. Use `:ditto:` instead"
       node.doc = @last_doc
     else
       @last_doc = node.doc

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -6,5 +6,20 @@ module Crystal
 
       self.warning_failures << node.warning(message)
     end
+
+    def report_warning_at(location : Location?, message : String)
+      return unless self.warnings.all?
+      return if self.ignore_warning_due_to_location?(location)
+
+      if location
+        message = String.build do |io|
+          exception = SyntaxException.new message, location.line_number, location.column_number, location.filename
+          exception.warning = true
+          exception.append_to_s(nil, io)
+        end
+      end
+
+      self.warning_failures << message
+    end
   end
 end

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -38,7 +38,7 @@ module Crystal
 
       io << error_body(source, default_message)
       io << '\n'
-      io << colorize("Error: #{error_message_lines.shift}").yellow.bold
+      io << colorize("#{@warning ? "Warning" : "Error"}: #{error_message_lines.shift}").yellow.bold
       io << remaining error_message_lines
     end
 


### PR DESCRIPTION
The warnings added by https://github.com/crystal-lang/crystal/pull/6362#issuecomment-586345051 were neither shown, nor have location information.

Without the error reporting, the user will never notice the deprecation warning for nodoc and ditto and things will break silently.

There are some tech-debt between `TypeError` and `SyntaxError` since the `@warning` is defined in the base class `Crystal::Exception` but the formatting of the message live in each class.