### PR TITLE
Move Adler32 and CRC32 to Digest

### DIFF
--- a/spec/std/digest/adler32_spec.cr
+++ b/spec/std/digest/adler32_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+require "digest/adler32"
+
+describe Digest::Adler32 do
+  it "should be able to calculate adler32" do
+    adler = Digest::Adler32.checksum("foo").to_s(16)
+    adler.should eq("2820145")
+  end
+
+  it "should be able to calculate adler32 combined" do
+    adler1 = Digest::Adler32.checksum("hello")
+    adler2 = Digest::Adler32.checksum(" world!")
+    combined = Digest::Adler32.combine(adler1, adler2, " world!".size)
+    Digest::Adler32.checksum("hello world!").should eq(combined)
+  end
+end

--- a/spec/std/digest/crc32_spec.cr
+++ b/spec/std/digest/crc32_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+require "digest/crc32"
+
+describe Digest::CRC32 do
+  it "should be able to calculate crc32" do
+    crc = Digest::CRC32.checksum("foo").to_s(16)
+    crc.should eq("8c736521")
+  end
+
+  it "should be able to calculate crc32 combined" do
+    crc1 = Digest::CRC32.checksum("hello")
+    crc2 = Digest::CRC32.checksum(" world!")
+    combined = Digest::CRC32.combine(crc1, crc2, " world!".size)
+    Digest::CRC32.checksum("hello world!").should eq(combined)
+  end
+end

--- a/spec/std/zip/zip_spec.cr
+++ b/spec/std/zip/zip_spec.cr
@@ -59,7 +59,7 @@ describe Zip do
     io = IO::Memory.new
 
     text = "contents of foo"
-    crc32 = CRC32.checksum(text)
+    crc32 = Digest::CRC32.checksum(text)
 
     Zip::Writer.open(io) do |zip|
       entry = Zip::Writer::Entry.new("foo.txt")
@@ -98,7 +98,7 @@ describe Zip do
     io = IO::Memory.new
 
     text = "contents of foo"
-    crc32 = CRC32.checksum(text)
+    crc32 = Digest::CRC32.checksum(text)
 
     Zip::Writer.open(io) do |zip|
       entry = Zip::Writer::Entry.new("foo.txt")

--- a/src/adler32/adler32.cr
+++ b/src/adler32/adler32.cr
@@ -1,20 +1,23 @@
-require "lib_z"
+require "digest"
 
 module Adler32
+  @[Deprecated("Use `Digest::Adler32.initial` instead")]
   def self.initial : UInt32
-    LibZ.adler32(0, nil, 0).to_u32
+    Digest::Adler32.initial
   end
 
+  @[Deprecated("Use `Digest::Adler32.checksum` instead")]
   def self.checksum(data) : UInt32
-    update(data, initial)
+    Digest::Adler32.checksum(data)
   end
 
+  @[Deprecated("Use `Digest::Adler32.update` instead")]
   def self.update(data, adler32 : UInt32) : UInt32
-    slice = data.to_slice
-    LibZ.adler32(adler32, slice, slice.size).to_u32
+    Digest::Adler32.update(data, adler32)
   end
 
+  @[Deprecated("Use `Digest::Adler32.combine` instead")]
   def self.combine(adler1 : UInt32, adler2 : UInt32, len) : UInt32
-    LibZ.adler32_combine(adler1, adler2, len).to_u32
+    Digest::Adler32.combine(adler1, adler2, len)
   end
 end

--- a/src/crc32/crc32.cr
+++ b/src/crc32/crc32.cr
@@ -1,20 +1,23 @@
-require "lib_z"
+require "digest"
 
 module CRC32
+  @[Deprecated("Use `Digest::CRC32.initial` instead")]
   def self.initial : UInt32
-    LibZ.crc32(0, nil, 0).to_u32
+    Digest::CRC32.initial
   end
 
+  @[Deprecated("Use `Digest::CRC32.checksum` instead")]
   def self.checksum(data) : UInt32
-    update(data, initial)
+    Digest::CRC32.checksum(data)
   end
 
+  @[Deprecated("Use `Digest::CRC32.update` instead")]
   def self.update(data, crc32 : UInt32) : UInt32
-    slice = data.to_slice
-    LibZ.crc32(crc32, slice, slice.size).to_u32
+    Digest::CRC32.update(data, crc32)
   end
 
+  @[Deprecated("Use `Digest::CRC32.combine` instead")]
   def self.combine(crc1 : UInt32, crc2 : UInt32, len) : UInt32
-    LibZ.crc32_combine(crc1, crc2, len).to_u32
+    Digest::CRC32.combine(crc1, crc2, len)
   end
 end

--- a/src/digest/adler32.cr
+++ b/src/digest/adler32.cr
@@ -1,0 +1,21 @@
+require "lib_z"
+
+# Implements the Adler32 checksum algorithm.
+module Digest::Adler32
+  def self.initial : UInt32
+    LibZ.adler32(0, nil, 0).to_u32
+  end
+
+  def self.checksum(data) : UInt32
+    update(data, initial)
+  end
+
+  def self.update(data, adler32 : UInt32) : UInt32
+    slice = data.to_slice
+    LibZ.adler32(adler32, slice, slice.size).to_u32
+  end
+
+  def self.combine(adler1 : UInt32, adler2 : UInt32, len) : UInt32
+    LibZ.adler32_combine(adler1, adler2, len).to_u32
+  end
+end

--- a/src/digest/crc32.cr
+++ b/src/digest/crc32.cr
@@ -1,0 +1,21 @@
+require "lib_z"
+
+# Implements the CRC32 checksum algorithm.
+module Digest::CRC32
+  def self.initial : UInt32
+    LibZ.crc32(0, nil, 0).to_u32
+  end
+
+  def self.checksum(data) : UInt32
+    update(data, initial)
+  end
+
+  def self.update(data, crc32 : UInt32) : UInt32
+    slice = data.to_slice
+    LibZ.crc32(crc32, slice, slice.size).to_u32
+  end
+
+  def self.combine(crc1 : UInt32, crc2 : UInt32, len) : UInt32
+    LibZ.crc32_combine(crc1, crc2, len).to_u32
+  end
+end

--- a/src/gzip/gzip.cr
+++ b/src/gzip/gzip.cr
@@ -1,5 +1,5 @@
 require "flate"
-require "crc32"
+require "digest/crc32"
 
 # The Gzip module contains readers and writers of gzip format compressed
 # data, as specified in [RFC 1952](https://www.ietf.org/rfc/rfc1952.txt).

--- a/src/gzip/reader.cr
+++ b/src/gzip/reader.cr
@@ -43,7 +43,7 @@ class Gzip::Reader < IO
   # Creates a new reader from the given *io*.
   def initialize(@io : IO, @sync_close = false)
     # CRC32 of written data
-    @crc32 = CRC32.initial
+    @crc32 = Digest::CRC32.initial
 
     # Total size of the original (uncompressed) input data modulo 2^32.
     @isize = 0_u32
@@ -101,7 +101,7 @@ class Gzip::Reader < IO
         end
 
         # Reset checksum and total size for next entry
-        @crc32 = CRC32.initial
+        @crc32 = Digest::CRC32.initial
         @isize = 0_u32
 
         # Check if another header with data comes
@@ -115,7 +115,7 @@ class Gzip::Reader < IO
         end
       else
         # Update CRC32 and total data size
-        @crc32 = CRC32.update(slice[0, read_bytes], @crc32)
+        @crc32 = Digest::CRC32.update(slice[0, read_bytes], @crc32)
 
         # Using wrapping addition here because isize is only 32 bits wide but
         # uncompressed data size can be bigger.

--- a/src/gzip/writer.cr
+++ b/src/gzip/writer.cr
@@ -37,7 +37,7 @@ class Gzip::Writer < IO
   # Creates a new writer to the given *io*.
   def initialize(@io : IO, @level = Gzip::DEFAULT_COMPRESSION, @sync_close = false)
     # CRC32 of written data
-    @crc32 = CRC32.initial
+    @crc32 = Digest::CRC32.initial
 
     # Total size of the original (uncompressed) input data modulo 2^32.
     @isize = 0
@@ -77,7 +77,7 @@ class Gzip::Writer < IO
     flate_io.write(slice)
 
     # Update CRC32 and total data size
-    @crc32 = CRC32.update(slice, @crc32)
+    @crc32 = Digest::CRC32.update(slice, @crc32)
 
     # Using wrapping addition here because isize is only 32 bits wide but
     # uncompressed data size can be bigger.

--- a/src/zip/checksum_reader.cr
+++ b/src/zip/checksum_reader.cr
@@ -3,7 +3,7 @@ module Zip
   # optionally verifying the computed value against an
   # expected one.
   private class ChecksumReader < IO
-    getter crc32 = CRC32.initial
+    getter crc32 = Digest::CRC32.initial
 
     def initialize(@io : IO, @filename : String, verify @expected_crc32 : UInt32? = nil)
     end
@@ -15,7 +15,7 @@ module Zip
           raise Zip::Error.new("Checksum failed for entry #{@filename} (expected #{expected_crc32}, got #{crc32}")
         end
       else
-        @crc32 = CRC32.update(slice[0, read_bytes], @crc32)
+        @crc32 = Digest::CRC32.update(slice[0, read_bytes], @crc32)
       end
       read_bytes
     end

--- a/src/zip/checksum_writer.cr
+++ b/src/zip/checksum_writer.cr
@@ -3,7 +3,7 @@ module Zip
   # checksum while writing to an underlying IO.
   private class ChecksumWriter < IO
     getter count = 0_u32
-    getter crc32 = CRC32.initial
+    getter crc32 = Digest::CRC32.initial
     getter! io : IO
 
     def initialize(@compute_crc32 = false)
@@ -17,13 +17,13 @@ module Zip
       return if slice.empty?
 
       @count += slice.size
-      @crc32 = CRC32.update(slice, @crc32) if @compute_crc32
+      @crc32 = Digest::CRC32.update(slice, @crc32) if @compute_crc32
       io.write(slice)
     end
 
     def io=(@io)
       @count = 0_u32
-      @crc32 = CRC32.initial
+      @crc32 = Digest::CRC32.initial
     end
   end
 end

--- a/src/zip/zip.cr
+++ b/src/zip/zip.cr
@@ -1,5 +1,5 @@
 require "flate"
-require "crc32"
+require "digest/crc32"
 require "./*"
 
 # The Zip module contains readers and writers of the zip

--- a/src/zlib/reader.cr
+++ b/src/zlib/reader.cr
@@ -16,7 +16,7 @@ class Zlib::Reader < IO
   def initialize(@io : IO, @sync_close = false, dict : Bytes? = nil)
     Zlib::Reader.read_header(io, dict)
     @flate_io = Flate::Reader.new(@io, dict: dict)
-    @adler32 = Adler32.initial
+    @adler32 = Digest::Adler32.initial
     @end = false
   end
 
@@ -50,7 +50,7 @@ class Zlib::Reader < IO
       end
 
       checksum = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
-      dict_checksum = Adler32.checksum(dict)
+      dict_checksum = Digest::Adler32.checksum(dict)
       if checksum != dict_checksum
         raise Zlib::Error.new("Dictionary ADLER-32 checksum mismatch")
       end
@@ -75,7 +75,7 @@ class Zlib::Reader < IO
       end
     else
       # Update ADLER-32 checksum
-      @adler32 = Adler32.update(slice[0, read_bytes], @adler32)
+      @adler32 = Digest::Adler32.update(slice[0, read_bytes], @adler32)
     end
     read_bytes
   end

--- a/src/zlib/writer.cr
+++ b/src/zlib/writer.cr
@@ -15,7 +15,7 @@ class Zlib::Writer < IO
   # Creates a new writer to the given *io*.
   def initialize(@io : IO, @level = Zlib::DEFAULT_COMPRESSION, @sync_close = false, @dict : Bytes? = nil)
     @wrote_header = false
-    @adler32 = Adler32.initial
+    @adler32 = Digest::Adler32.initial
     @flate_io = Flate::Writer.new(@io, level: level, dict: @dict)
   end
 
@@ -52,7 +52,7 @@ class Zlib::Writer < IO
     write_header unless @wrote_header
 
     @flate_io.write(slice)
-    @adler32 = Adler32.update(slice, @adler32)
+    @adler32 = Digest::Adler32.update(slice, @adler32)
   end
 
   # Flushes data, forcing writing the zlib header if no
@@ -113,7 +113,7 @@ class Zlib::Writer < IO
     @io.write_byte flg
 
     if dict
-      dict_checksum = Adler32.checksum(dict)
+      dict_checksum = Digest::Adler32.checksum(dict)
       @io.write_bytes(dict_checksum, IO::ByteFormat::BigEndian)
     end
   end

--- a/src/zlib/zlib.cr
+++ b/src/zlib/zlib.cr
@@ -1,5 +1,5 @@
 require "flate"
-require "adler32"
+require "digest/adler32"
 require "./*"
 
 # The Zlib module contains readers and writers of zlib format compressed


### PR DESCRIPTION
Adler32 and CRC32 interface are kept unmodified and hence they don't implement `Digest::Base`, but their results are 32-bit fixes intead of a slice/string; plus they support the combine alternative. I think the current API while simple is enough.

The top-level versions are deprecated.