### PR TITLE
Deprecate top-level with_color. Add Colorize.with

### DIFF
--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -6,7 +6,7 @@ private def colorize(obj, *args)
 end
 
 private def with_color_wrap(*args)
-  with_color(*args).toggle(true)
+  Colorize.with(*args).toggle(true)
 end
 
 private class ColorizeToS
@@ -127,6 +127,32 @@ describe "colorize" do
 
   it "inspects" do
     colorize("hello", :red).inspect.should eq("\e[31m\"hello\"\e[0m")
+  end
+
+  describe "with_color deprecated top-level method" do
+    it "without args" do
+      io = IO::Memory.new
+      with_color.red.surround(io) do
+        io << "hello"
+        with_color.green.surround(io) do
+          io << "world"
+        end
+        io << "bye"
+      end
+      io.to_s.should eq("\e[31mhello\e[0;32mworld\e[0;31mbye\e[0m")
+    end
+
+    it "with args" do
+      io = IO::Memory.new
+      with_color(:red).surround(io) do
+        io << "hello"
+        with_color(:green).surround(io) do
+          io << "world"
+        end
+        io << "bye"
+      end
+      io.to_s.should eq("\e[31mhello\e[0;32mworld\e[0;31mbye\e[0m")
+    end
   end
 
   it "colorizes with surround" do

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -132,9 +132,9 @@ describe "colorize" do
   describe "with_color deprecated top-level method" do
     it "without args" do
       io = IO::Memory.new
-      with_color.red.surround(io) do
+      with_color.red.toggle(true).surround(io) do
         io << "hello"
-        with_color.green.surround(io) do
+        with_color.green.toggle(true).surround(io) do
           io << "world"
         end
         io << "bye"
@@ -144,9 +144,9 @@ describe "colorize" do
 
     it "with args" do
       io = IO::Memory.new
-      with_color(:red).surround(io) do
+      with_color(:red).toggle(true).surround(io) do
         io << "hello"
-        with_color(:green).surround(io) do
+        with_color(:green).toggle(true).surround(io) do
           io << "world"
         end
         io << "bye"

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -135,14 +135,29 @@ module Colorize
   def self.reset(io = STDOUT)
     io << "\e[0m" if enabled?
   end
+
+  # Helper method to use colorize with `IO`.
+  #
+  # ```
+  # io = IO::Memory.new
+  # io << "not-green"
+  # Colorize.with.green.bold.surround(io) do
+  #   io << "green and bold if Colorize.enabled"
+  # end
+  # ```
+  def self.with
+    "".colorize
+  end
 end
 
+@[Deprecated("Use `Colorize.with`")]
 def with_color
-  "".colorize
+  Colorize.with
 end
 
+@[Deprecated("Use `Colorize.with.fore(color)`")]
 def with_color(color : Symbol)
-  "".colorize(color)
+  Colorize.with.fore(color)
 end
 
 module Colorize::ObjectExtensions

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -56,7 +56,7 @@ module Crystal
     end
 
     def with_color
-      ::with_color.toggle(@color)
+      Colorize.with.toggle(@color)
     end
 
     def replace_leading_tabs_with_spaces(line)
@@ -126,7 +126,7 @@ module Crystal
       size ||= 0
       io << '\n'
       io << (" " * (offset + column_number - 1))
-      with_color.green.bold.surround(io) do
+      Colorize.with.green.bold.surround(io) do
         io << '^'
         if size > 0
           io << ("-" * (size - 1))

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -263,7 +263,7 @@ module Crystal
     end
 
     def with_color
-      ::with_color.toggle(@program.color?)
+      Colorize.with.toggle(@program.color?)
     end
   end
 


### PR DESCRIPTION
Plus some minimum docs.

The top-level method is not needed and it had no docs at all.