### PR TITLE
Enforce hash key types at compile time

### DIFF
--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -179,13 +179,6 @@ describe "Set" do
   end
 
   it "does -" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
-    set3 = set1 - set2
-    set3.should eq(Set{1, 3, 5})
-  end
-
-  it "does -" do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = [2, 4, 5]
     set3 = set1 - set2
@@ -242,13 +235,6 @@ describe "Set" do
   end
 
   it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = Set{2, 4, 'a'}
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 5})
-  end
-
-  it "does subtract" do
     set1 = Set{1, 2, 3, 4, 'b'}
     set2 = Set{2, 4, 5}
     set1.subtract set2
@@ -258,13 +244,6 @@ describe "Set" do
   it "does subtract" do
     set1 = Set{1, 2, 3, 4, 5}
     set2 = [2, 4, 6]
-    set1.subtract set2
-    set1.should eq(Set{1, 3, 5})
-  end
-
-  it "does subtract" do
-    set1 = Set{1, 2, 3, 4, 5}
-    set2 = [2, 4, 'a']
     set1.subtract set2
     set1.should eq(Set{1, 3, 5})
   end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -576,11 +576,11 @@ module Crystal
       file_module?(filename).try &.lookup_matches(signature)
     end
 
-    def file_module?(filename)
+    def file_module?(filename : String)
       file_modules[filename]?
     end
 
-    def file_module(filename)
+    def file_module(filename : String)
       file_modules[filename] ||= FileModule.new(self, self, filename)
     end
 

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -463,7 +463,7 @@ struct Crystal::TypeDeclarationProcessor
     ancestor = owner.ancestors.first?
     ancestor = uninstantiate(ancestor)
     if ancestor
-      ancestor_non_nilable = @non_nilable_instance_vars[ancestor]?
+      ancestor_non_nilable = @non_nilable_instance_vars[ancestor]? if ancestor.is_a?(Type)
     end
 
     # If the ancestor has non-nilable instance vars, check that all initialize either call
@@ -538,7 +538,7 @@ struct Crystal::TypeDeclarationProcessor
 
     owner.ancestors.any? do |ancestor|
       ancestor = uninstantiate(ancestor)
-      @instance_vars_outside[ancestor]?.try &.includes?(name)
+      @instance_vars_outside[ancestor]?.try &.includes?(name) if ancestor.is_a? Type
     end
   end
 
@@ -553,7 +553,7 @@ struct Crystal::TypeDeclarationProcessor
   end
 
   private def compute_non_nilable_outside_single(owner, non_nilable_outisde)
-    if vars = @instance_vars_outside[owner]?
+    if owner.is_a?(Type) && (vars = @instance_vars_outside[owner]?)
       non_nilable_outisde ||= [] of String
       vars.each do |name|
         non_nilable_outisde << name unless non_nilable_outisde.includes?(name)
@@ -570,7 +570,7 @@ struct Crystal::TypeDeclarationProcessor
 
     owner.ancestors.each do |ancestor|
       ancestor = uninstantiate(ancestor)
-      infos = @initialize_infos[ancestor]?
+      infos = @initialize_infos[ancestor]? if ancestor.is_a?(Type)
       return infos if infos && !infos.empty?
     end
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -470,7 +470,7 @@ module Crystal::Playground
 
       agent_ws = PathWebSocketHandler.new "/agent" do |ws, context|
         match_data = context.request.path.not_nil!.match(/\/(\d+)\/(\d+)$/).not_nil!
-        session_key = match_data[1]?.try(&.to_i)
+        session_key = match_data[1]?.try(&.to_i) || 0
         tag = match_data[2]?.try(&.to_i)
         @logger.info "#{context.request.path} WebSocket connected (session=#{session_key}, tag=#{tag})"
 

--- a/src/compiler/crystal/tools/typed_def_processor.cr
+++ b/src/compiler/crystal/tools/typed_def_processor.cr
@@ -11,7 +11,7 @@ module Crystal::TypedDefProcessor
 
   private def process_result(result : Compiler::Result)
     process_type result.program
-    if file_module = result.program.file_module? target_location.original_filename
+    if (filename = target_location.original_filename) && (file_module = result.program.file_module?(filename))
       process_type file_module
     end
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -329,7 +329,7 @@ class Hash(K, V)
 
   # Inserts or updates a key-value pair.
   # Returns an `Entry` if it was updated, otherwise `nil`.
-  private def upsert(key, value) : Entry(K, V)?
+  private def upsert(key : K, value : V) : Entry(K, V)?
     # Empty hash table so only initialize entries for now
     if @entries.null?
       @indices_size_pow2 = 3
@@ -416,7 +416,7 @@ class Hash(K, V)
 
   # Implementation of deleting a key.
   # Returns the deleted Entry, if it existed, `nil` otherwise.
-  private def delete_impl(key) : Entry(K, V)?
+  private def delete_impl(key : K) : Entry(K, V)?
     # Empty hash table, nothing to do
     if @indices_size_pow2 == 0
       return nil
@@ -465,7 +465,7 @@ class Hash(K, V)
   end
 
   # Finds an entry with the given key.
-  protected def find_entry(key) : Entry(K, V)?
+  protected def find_entry(key : K) : Entry(K, V)?
     # Empty hash table so there's no way it's there
     if @indices_size_pow2 == 0
       return nil
@@ -501,7 +501,7 @@ class Hash(K, V)
   end
 
   # Finds an Entry with the given key by doing a linear scan.
-  private def find_entry_linear_scan(key) : Entry(K, V)?
+  private def find_entry_linear_scan(key : K) : Entry(K, V)?
     # If we have less than 8 elements we avoid computing the hash
     # code and directly compare the keys (might be cheaper than
     # computing a hash code of a complex structure).
@@ -902,7 +902,7 @@ class Hash(K, V)
   end
 
   # Computes the hash of a key.
-  private def key_hash(key)
+  private def key_hash(key : K)
     if @compare_by_identity && key.responds_to?(:object_id)
       hash = key.object_id.hash.to_u32!
     else
@@ -911,7 +911,7 @@ class Hash(K, V)
     hash == 0 ? UInt32::MAX : hash
   end
 
-  private def entry_matches?(entry, hash, key)
+  private def entry_matches?(entry, hash, key : K)
     # Tiny optimization: for these primitive types it's faster to just
     # compare the key instead of comparing the hash and the key.
     # We still have to skip hashes with value 0 (means deleted).
@@ -927,7 +927,7 @@ class Hash(K, V)
     {% end %}
   end
 
-  private def entry_matches?(entry, key)
+  private def entry_matches?(entry : Entry(K, V), key : K)
     entry_key = entry.key
 
     if @compare_by_identity
@@ -1022,7 +1022,7 @@ class Hash(K, V)
   # h = Hash(String, String).new
   # h["foo"] # raises KeyError
   # ```
-  def [](key)
+  def [](key : K)
     fetch(key) do
       if (block = @block) && key.is_a?(K)
         block.call(self, key.as(K))
@@ -1043,7 +1043,7 @@ class Hash(K, V)
   # h = Hash(String, String).new("bar")
   # h["foo"]? # => nil
   # ```
-  def []?(key)
+  def []?(key : K)
     fetch(key, nil)
   end
 
@@ -1093,7 +1093,7 @@ class Hash(K, V)
   # h.has_key?("foo") # => true
   # h.has_key?("bar") # => false
   # ```
-  def has_key?(key)
+  def has_key?(key : K)
     !!find_entry(key)
   end
 
@@ -1104,7 +1104,7 @@ class Hash(K, V)
   # h.has_value?("foo") # => false
   # h.has_value?("bar") # => true
   # ```
-  def has_value?(val)
+  def has_value?(val : V)
     each_value do |value|
       return true if value == val
     end
@@ -1119,7 +1119,7 @@ class Hash(K, V)
   # h.fetch("foo", "foo") # => "bar"
   # h.fetch("bar", "foo") # => "foo"
   # ```
-  def fetch(key, default)
+  def fetch(key : K, default)
     fetch(key) { default }
   end
 
@@ -1131,7 +1131,7 @@ class Hash(K, V)
   # h.fetch("bar") { "default value" }  # => "default value"
   # h.fetch("bar") { |key| key.upcase } # => "BAR"
   # ```
-  def fetch(key)
+  def fetch(key : K)
     entry = find_entry(key)
     entry ? entry.value : yield key
   end
@@ -1752,8 +1752,12 @@ class Hash(K, V)
     self
   end
 
-  # Compares with *other*. Returns `true` if all key-value pairs are the same.
   def ==(other : Hash)
+    false
+  end
+
+  # Compares with *other*. Returns `true` if all key-value pairs are the same.
+  def ==(other : self)
     return false unless size == other.size
     each do |key, value|
       entry = other.find_entry(key)

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -220,7 +220,7 @@ module MIME
     # If the same extension had a different type registered before, it needs to
     # be removed from the extensions list.
     if previous_type = @@types[extension]?
-      if extensions = @@extensions[parse_media_type(previous_type)]?
+      if (parsed_type = parse_media_type(previous_type)) && (extensions = @@extensions[parsed_type]?)
         extensions.delete(extension)
       end
     end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -72,7 +72,7 @@ struct NamedTuple
   #
   # speak_about(**{thing: String, n: Int64}.from(hash)) # => "I see 2 worlds"
   # ```
-  def from(hash : Hash)
+  def from(hash : Hash(K, V)) forall K, V
     if size != hash.size
       raise ArgumentError.new("Expected a hash with #{size} keys but one with #{hash.size} keys was given.")
     end
@@ -80,7 +80,13 @@ struct NamedTuple
     {% begin %}
       NamedTuple.new(
       {% for key, value in T %}
-        {{key.stringify}}: self[{{key.symbolize}}].cast(hash.fetch({{key.symbolize}}) { hash["{{key}}"] }),
+        {% if K == String %}
+          {{key.stringify}}: self[{{key.symbolize}}].cast(hash[{{key.stringify}}]),
+        {% elsif K == Symbol %}
+          {{key.stringify}}: self[{{key.symbolize}}].cast(hash[{{key.symbolize}}]),
+        {% else %}
+          {% raise "Hash keys must be String or Symbol to convert into a NamedTuple" %}
+        {% end %}
       {% end %}
       )
     {% end %}

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -254,7 +254,7 @@ class Regex
 
       caps = [] of String?
       (1...size).each do |i|
-        caps << self[i]? unless name_table.has_key? i
+        caps << self[i]? unless name_table.has_key? i.to_u16
       end
 
       caps
@@ -276,7 +276,7 @@ class Regex
 
       caps = {} of String => String?
       (1...size).each do |i|
-        if (name = name_table[i]?) && !caps.has_key?(name)
+        if (name = name_table[i.to_u16]?) && !caps.has_key?(name)
           caps[name] = self[name]?
         end
       end
@@ -315,7 +315,7 @@ class Regex
 
       hash = {} of (String | Int32) => String?
       (0...size).each do |i|
-        if name = name_table[i]?
+        if name = name_table[i.to_u16]?
           hash[name] = self[name]? unless hash.has_key?(name)
         else
           hash[i] = self[i]?
@@ -334,7 +334,7 @@ class Regex
 
       io << "Regex::MatchData("
       size.times do |i|
-        io << ' ' << name_table.fetch(i, i) << ':' if i > 0
+        io << ' ' << name_table.fetch(i.to_u16, i) << ':' if i > 0
         self[i]?.inspect(io)
       end
       io << ')'
@@ -350,7 +350,7 @@ class Regex
             if i == 0
               self[i].pretty_print pp
             else
-              pp.text "#{name_table.fetch(i, i)}:"
+              pp.text "#{name_table.fetch(i.to_u16, i)}:"
               pp.nest do
                 pp.breakable ""
                 self[i]?.pretty_print pp

--- a/src/set.cr
+++ b/src/set.cr
@@ -132,7 +132,7 @@ struct Set(T)
   # s.includes? 5 # => true
   # s.includes? 9 # => false
   # ```
-  def includes?(object)
+  def includes?(object : T)
     @hash.has_key?(object)
   end
 
@@ -144,7 +144,7 @@ struct Set(T)
   # s.delete 5
   # s.includes? 5 # => false
   # ```
-  def delete(object)
+  def delete(object : T)
     @hash.delete(object)
     self
   end

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -61,7 +61,11 @@ struct YAML::Any
 
       new hash
     when YAML::Nodes::Alias
-      anchors[node.anchor]
+      if anchor = node.anchor
+        anchors[anchor]
+      else
+        raise "Unknown YAML alias: #{node}"
+      end
     else
       raise "Unknown node: #{node.class}"
     end
@@ -101,7 +105,14 @@ struct YAML::Any
         raise "Expected int key for Array#[], not #{object.class}"
       end
     when Hash
-      object[index_or_key]
+      case index_or_key
+      when String
+        object[Any.new(index_or_key)]
+      when Any
+        object[index_or_key]
+      else
+        raise "Expected YAML::Any | String, not #{object.class}"
+      end
     else
       raise "Expected Array or Hash, not #{object.class}"
     end
@@ -120,7 +131,14 @@ struct YAML::Any
         nil
       end
     when Hash
-      object[index_or_key]?
+      case index_or_key
+      when String
+        object[Any.new(index_or_key)]
+      when Any
+        object[index_or_key]
+      else
+        raise "Expected YAML::Any | String, not #{object.class}"
+      end
     else
       raise "Expected Array or Hash, not #{object.class}"
     end
@@ -296,14 +314,14 @@ struct YAML::Any
     @raw.pretty_print(pp)
   end
 
-  # Returns `true` if both `self` and *other*'s raw object are equal.
-  def ==(other : YAML::Any)
-    raw == other.raw
-  end
-
   # Returns `true` if the raw object is equal to *other*.
   def ==(other)
     raw == other
+  end
+
+  # Returns `true` if both `self` and *other*'s raw object are equal.
+  def ==(other : YAML::Any)
+    raw == other.raw
   end
 
   # See `Object#hash(hasher)`

--- a/src/yaml/parse_context.cr
+++ b/src/yaml/parse_context.cr
@@ -46,7 +46,9 @@ class YAML::ParseContext
 
   private def read_alias_impl(node, expected_crystal_type_id, raise_on_alias)
     if node.is_a?(YAML::Nodes::Alias)
-      value = @anchors[node.anchor]?
+      if anchor = node.anchor
+        value = @anchors[anchor]?
+      end
 
       if value
         object_id, crystal_type_id = value


### PR DESCRIPTION
I noticed in one of my apps, I changed the type of a hash key, assuming the compiler would point out all the places I missed. But then all my `Hash#[]?(key)` calls started to fail silently and my `Hash#fetch(key, &)` calls invoked their blocks when I didn't expect them to.

I looked into how much code it would take to get the compiler to enforce the key types. It was more than I expected at first because I forgot the compiler is _also_ written in Crystal and uses these same hashes. :joy:

I don't think the semantics of this PR are correct yet, especially `Hash#==(other : Hash)`. I hardcoded `false` just to get that to compile, but before I spend too much time on trying to polish it all up, I'd like to get some conversation going about the pros and cons of this patch in case the current live functionality of this was intentional with full knowledge of the tradeoffs. 🙂