### PR TITLE
Fix document of Int#gcd

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -400,7 +400,7 @@ struct Int
   # its type.
   #
   # ```
-  # 5.gcd(10) # => 2
+  # 5.gcd(10) # => 5
   # 5.gcd(7)  # => 1
   # ```
   def gcd(other : self) : self


### PR DESCRIPTION
Tiny fix to document of `Int#gcd`

```crystal
# NG
5.gcd(10) # => 2

# OK
5.gcd(10) # => 5
```
