### PR TITLE
Rename YAML::Builder.new with block to YAML::Builder.build

### DIFF
--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -178,4 +178,28 @@ describe YAML::Builder do
       builder.start_mapping
     end
   end
+
+  it ".build (with block)" do
+    String.build do |io|
+      YAML::Builder.build(io) do |builder|
+        builder.stream do
+          builder.document do
+            builder.scalar(1)
+          end
+        end
+      end
+    end.should eq 1.to_yaml
+  end
+
+  it ".new (with block)" do
+    String.build do |io|
+      YAML::Builder.new(io) do |builder|
+        builder.stream do
+          builder.document do
+            builder.scalar(1)
+          end
+        end
+      end
+    end.should eq 1.to_yaml
+  end
 end


### PR DESCRIPTION
The method is not a constructor and doesn't return an instance of YAML::Builder which I'd usually expect from a .new method.

Extracted from https://github.com/crystal-lang/crystal/pull/8876#discussion_r387898070