### PR TITLE
Avoid using the default --exclude-warnings value if some is specified

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -549,7 +549,7 @@ class Crystal::Command
 
   private def setup_compiler_warning_options(opts, compiler)
     compiler.warnings_exclude << Crystal.normalize_path "lib"
-    compiler.warnings_exclude_default = true
+    warnings_exclude_default = true
     opts.on("--warnings all|none", "Which warnings detect. (default: all)") do |w|
       compiler.warnings = case w
                           when "all"
@@ -565,10 +565,10 @@ class Crystal::Command
       compiler.error_on_warnings = true
     end
     opts.on("--exclude-warnings <path>", "Exclude warnings from path (default: lib)") do |f|
-      if compiler.warnings_exclude_default
+      if warnings_exclude_default
         # if an --exclude-warnings is used explicitly, then we remove the default value
         compiler.warnings_exclude.clear
-        compiler.warnings_exclude_default = false
+        warnings_exclude_default = false
       end
       compiler.warnings_exclude << Crystal.normalize_path f
     end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -549,6 +549,7 @@ class Crystal::Command
 
   private def setup_compiler_warning_options(opts, compiler)
     compiler.warnings_exclude << Crystal.normalize_path "lib"
+    compiler.warnings_exclude_default = true
     opts.on("--warnings all|none", "Which warnings detect. (default: all)") do |w|
       compiler.warnings = case w
                           when "all"
@@ -564,6 +565,11 @@ class Crystal::Command
       compiler.error_on_warnings = true
     end
     opts.on("--exclude-warnings <path>", "Exclude warnings from path (default: lib)") do |f|
+      if compiler.warnings_exclude_default
+        # if an --exclude-warnings is used explicitly, then we remove the default value
+        compiler.warnings_exclude.clear
+        compiler.warnings_exclude_default = false
+      end
       compiler.warnings_exclude << Crystal.normalize_path f
     end
   end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -112,6 +112,8 @@ module Crystal
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String
 
+    property warnings_exclude_default : Bool = true
+
     # If `true` compiler will error if warnings are found.
     property error_on_warnings : Bool = false
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -112,8 +112,6 @@ module Crystal
     # Paths to ignore for warnings detection.
     property warnings_exclude : Array(String) = [] of String
 
-    property warnings_exclude_default : Bool = true
-
     # If `true` compiler will error if warnings are found.
     property error_on_warnings : Bool = false
 


### PR DESCRIPTION
Currently there is no way to exclude the default value of lib from the `--exclude-warnings` path.

This PR solves that. If the used mentions some `--exclude-warnings` the default value it is discarded.

This will allow some more exhauistive deprecation checks for dependencies when wanted.

Note: It would be great if the `OptionParser` supported some better constructs to detect if an option was not explictly used, or some way to inject default values. But with the current  features, this is the best I could do.