### PR TITLE
Use CRYSTAL_OPTS env variable as default compiler options

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -68,6 +68,7 @@ class Crystal::Command
       init
     when "build".starts_with?(command)
       options.shift
+      use_crystal_opts
       result = build
       report_warnings result
       exit 1 if warnings_fail_on_exit?(result)
@@ -86,12 +87,15 @@ class Crystal::Command
       env
     when command == "eval"
       options.shift
+      use_crystal_opts
       eval
     when "run".starts_with?(command)
       options.shift
+      use_crystal_opts
       run_command(single_file: false)
     when "spec/".starts_with?(command)
       options.shift
+      use_crystal_opts
       spec
     when "tool".starts_with?(command)
       options.shift
@@ -103,6 +107,7 @@ class Crystal::Command
       puts Crystal::Config.description
       exit
     when File.file?(command)
+      use_crystal_opts
       run_command(single_file: true)
     else
       if command.ends_with?(".cr")
@@ -584,5 +589,9 @@ class Crystal::Command
     # This is for the case where the main command is wrong
     @color = false if ARGV.includes?("--no-color") || ENV["TERM"]? == "dumb"
     Crystal.error msg, @color, exit_code: exit_code
+  end
+
+  private def use_crystal_opts
+    @options = ENV.fetch("CRYSTAL_OPTS", "").split.concat(options)
   end
 end


### PR DESCRIPTION
This PR make the compiler read the `CRYSTAL_OPTS` environment variable and use is as additional compiler flags in some commands: build, eval, run, spec and <file>.

This is handy to configure the compiler to be more pedantic regarding deprecations for example. The compiler is sometimes used in postinstall tasks where injecting flags is not possible.

With this and #8899 we should be able to checks deprecation along all the source code used to build and app.