### PR TITLE
Revert "Deprecate String#codepoint_at"

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -901,7 +901,6 @@ class String
     byte_slice start, bytesize - start
   end
 
-  @[Deprecated("Use .char_at(index).ord instead")]
   def codepoint_at(index)
     char_at(index).ord
   end


### PR DESCRIPTION
Reverts crystal-lang/crystal#8475

See https://github.com/crystal-lang/crystal/pull/8476#issuecomment-597507582 and thumbs up in https://github.com/crystal-lang/crystal/pull/8476#issuecomment-597587441