### PR TITLE
Optimized Implementation of `Array#fill` for Zero Values

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -648,29 +648,44 @@ describe "Array" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'x']
       a.fill('x').should eq(expected)
+      a = [1, 2, 3]
+      expected = [0, 0, 0]
+      a.fill(0).should eq(expected)
     end
 
     it "replaces only values between index and size" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', 0, 2).should eq(expected)
+      a = [1, 2, 3]
+      expected = [0, 0, 3]
+      a.fill(0, 0, 2).should eq(expected)
     end
 
     it "replaces only values between index and size (2)" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', 1, 2).should eq(expected)
+      a = [1, 2, 3]
+      expected = [1, 0, 0]
+      a.fill(0, 1, 2).should eq(expected)
     end
 
     it "replaces all values from index onwards" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', -2).should eq(expected)
+      a = [1, 2, 3]
+      expected = [1, 0, 0]
+      a.fill(0, -2).should eq(expected)
     end
 
     it "raises when given big negative number (#4539)" do
       expect_raises(IndexError) do
         ['a', 'b', 'c'].fill('x', -4)
+      end
+      expect_raises(IndexError) do
+        [1, 2, 3].fill(0, -4)
       end
     end
 
@@ -678,11 +693,17 @@ describe "Array" do
       a = ['a', 'b', 'c']
       expected = ['a', 'b', 'x']
       a.fill('x', -1, 1).should eq(expected)
+      a = [1, 2, 3]
+      expected = [1, 2, 0]
+      a.fill(0, -1, 1).should eq(expected)
     end
 
     it "raises when given big negative number in from/count (#4539)" do
       expect_raises(IndexError) do
         ['a', 'b', 'c'].fill('x', -4, 1)
+      end
+      expect_raises(IndexError) do
+        [1, 2, 3].fill(0, -4, 1)
       end
     end
 
@@ -690,18 +711,27 @@ describe "Array" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', -3..1).should eq(expected)
+      a = [1, 2, 3]
+      expected = [0, 0, 3]
+      a.fill(0, -3..1).should eq(expected)
     end
 
     it "replaces only values in range without end" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
       a.fill('x', 1..nil).should eq(expected)
+      a = [1, 2, 3]
+      expected = [1, 0, 0]
+      a.fill(0, 1..nil).should eq(expected)
     end
 
     it "replaces only values in range begin" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
       a.fill('x', nil..1).should eq(expected)
+      a = [1, 2, 3]
+      expected = [0, 0, 3]
+      a.fill(0, nil..1).should eq(expected)
     end
 
     it "works with a block" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -861,7 +861,17 @@ class Array(T)
   # a.fill(9) # => [9, 9, 9]
   # ```
   def fill(value : T)
-    fill { value }
+    {% if Int::Primitive.union_types.includes?(T) %}
+      if value == 0
+        to_unsafe.clear(size)
+
+        self
+      else
+        fill { value }
+      end
+    {% else %}
+      fill { value }
+    {% end %}
   end
 
   # Replaces every element in `self`, starting at *from*, with the given *value*. Returns `self`.
@@ -873,7 +883,21 @@ class Array(T)
   # a.fill(9, 2) # => [1, 2, 9, 9, 9]
   # ```
   def fill(value : T, from : Int)
-    fill(from) { value }
+    {% if Int::Primitive.union_types.includes?(T) %}
+      if value == 0
+        from += size if from < 0
+
+        raise IndexError.new unless 0 <= from < size
+
+        (to_unsafe + from).clear(size - from)
+
+        self
+      else
+        fill(from) { value }
+      end
+    {% else %}
+      fill(from) { value }
+    {% end %}
   end
 
   # Replaces every element in `self`, starting at *from* and only *count* times,
@@ -886,7 +910,23 @@ class Array(T)
   # a.fill(9, 2, 2) # => [1, 2, 9, 9, 5]
   # ```
   def fill(value : T, from : Int, count : Int)
-    fill(from, count) { value }
+    {% if Int::Primitive.union_types.includes?(T) %}
+      if value == 0
+        return self if count <= 0
+
+        from += size if from < 0
+
+        raise IndexError.new unless 0 <= from < size && from + count <= size
+
+        (to_unsafe + from).clear(count)
+
+        self
+      else
+        fill(from, count) { value }
+      end
+    {% else %}
+      fill(from, count) { value }
+    {% end %}
   end
 
   # Replaces every element in *range* with *value*. Returns `self`.
@@ -898,7 +938,17 @@ class Array(T)
   # a.fill(9, 2..3) # => [1, 2, 9, 9, 5]
   # ```
   def fill(value : T, range : Range)
-    fill(range) { value }
+    {% if Int::Primitive.union_types.includes?(T) %}
+      if value == 0
+        fill(value, *Indexable.range_to_index_and_count(range, size))
+
+        self
+      else
+        fill(range) { value }
+      end
+    {% else %}
+      fill(range) { value }
+    {% end %}
   end
 
   # Returns the first *n* elements of the array.


### PR DESCRIPTION
See discussion here:

https://forum.crystal-lang.org/t/fastest-and-iconic-way-to-zero-an-array/1799/16

This PR provides a high performance (~10x) means to initialize arrays of integers to zero by optimizing that case in `Array#fill`.

```
Using compiled compiler at .build/crystal
          fill(0)   2.50M (400.01ns) (± 1.82%)  0.0B/op   1.43× slower
       fill(0, 0)   2.52M (397.50ns) (± 2.39%)  0.0B/op   1.42× slower
fill(0, 0, 1_000)   3.57M (279.82ns) (± 2.95%)  0.0B/op        fastest
      fill(0, ..)   2.48M (403.21ns) (± 3.81%)  0.0B/op   1.44× slower
```
```
Using compiled compiler at .build/crystal
          fill(0)  23.72M ( 42.16ns) (± 4.14%)  0.0B/op   1.15× slower
       fill(0, 0)  25.42M ( 39.34ns) (± 2.81%)  0.0B/op   1.08× slower
fill(0, 0, 1_000)  27.29M ( 36.65ns) (± 5.10%)  0.0B/op   1.00× slower
      fill(0, ..)  27.37M ( 36.54ns) (± 3.41%)  0.0B/op        fastest
```
