### PR TITLE
IO::Hexdump: forward missing methods to underlaying IO

### DIFF
--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -40,27 +40,5 @@ class IO::Hexdump < IO
     end
   end
 
-  def peek
-    @io.peek
-  end
-
-  def closed?
-    @io.closed?
-  end
-
-  def close
-    @io.close
-  end
-
-  def flush
-    @io.flush
-  end
-
-  def tty?
-    @io.tty?
-  end
-
-  def pos
-    @io.pos
-  end
+  delegate :peek, :close, :closed?, :flush, :tty?, :pos, :pos=, :seek, to: @io
 end

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -59,4 +59,8 @@ class IO::Hexdump < IO
   def tty?
     @io.tty?
   end
+
+  def pos
+    @io.pos
+  end
 end


### PR DESCRIPTION
Allows you do things like `IO::Hexdump#pos` when the underlaying IO supports it. 