### PR TITLE
Fix File.dirname with unicode chars

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -279,6 +279,7 @@ describe "File" do
     File.dirname("/Users/foo/bar.cr").should eq("/Users/foo")
     File.dirname("foo").should eq(".")
     File.dirname("").should eq(".")
+    File.dirname("/τελεία/τελεία").should eq("/τελεία")
   end
 
   it "gets basename" do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -279,7 +279,7 @@ describe "File" do
     File.dirname("/Users/foo/bar.cr").should eq("/Users/foo")
     File.dirname("foo").should eq(".")
     File.dirname("").should eq(".")
-    File.dirname("/τελεία/τελεία").should eq("/τελεία")
+    File.dirname("/τελεία/łódź").should eq("/τελεία")
   end
 
   it "gets basename" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -225,7 +225,7 @@ struct Path
       return anchor.to_s
     end
 
-    @name.byte_slice(0, reader.pos + 1)
+    @name.byte_slice(0, reader.pos + reader.current_char_width)
   end
 
   # Returns the parent path of this path.


### PR DESCRIPTION
Fixes #8910

There are a lot of `+ 1` in the code that might be worth reviewing. If someone wants they can try adding unicode tests to all of the `File` or `Path` methods to make sure they work well.