### PR TITLE
Add Number#positive? and #negative?

### DIFF
--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -174,6 +174,30 @@ describe "Number" do
     1f32.zero?.should eq false
   end
 
+  it "test positive?" do
+    0.positive?.should eq false
+    0.0.positive?.should eq false
+    0f32.positive?.should eq false
+    1.positive?.should eq true
+    1.0.positive?.should eq true
+    1f32.positive?.should eq true
+    -1.positive?.should eq false
+    -1.0.positive?.should eq false
+    -1f32.positive?.should eq false
+  end
+
+  it "test negative?" do
+    0.positive?.should eq false
+    0.0.positive?.should eq false
+    0f32.positive?.should eq false
+    1.positive?.should eq false
+    1.0.positive?.should eq false
+    1f32.positive?.should eq false
+    -1.positive?.should eq true
+    -1.0.positive?.should eq true
+    -1f32.positive?.should eq true
+  end
+
   describe "step" do
     it "from int to float" do
       count = 0

--- a/src/number.cr
+++ b/src/number.cr
@@ -255,6 +255,28 @@ struct Number
     self == 0
   end
 
+  # Returns `true` if value is larger than zero.
+  #
+  # ```
+  # -5.zero? # => false
+  # 0.zero?  # => false
+  # 5.zero?  # => true
+  # ```
+  def positive? : Bool
+    self > 0
+  end
+
+  # Returns `true` if value is smaller than zero.
+  #
+  # ```
+  # -5.zero? # => true
+  # 0.zero?  # => false
+  # 5.zero?  # => false
+  # ```
+  def positive? : Bool
+    self < 0
+  end
+
   private class StepIterator(T, L, B)
     include Iterator(T)
 


### PR DESCRIPTION
For example, when an array `[-2, -1, 0, 1, 2]` is given, I'd like to write
```crystal
[-2, -1, 0, 1, 2].select(&.positive?)
[-2, -1, 0, 1, 2].select(&.negative?)
```
instead of
```crystal
[-2, -1, 0, 1, 2].select { |i| i > 0 }
[-2, -1, 0, 1, 2].select { |i| i < 0 }
```

So I added `Number#positive?` and `#negative?` like Ruby.
