### PR TITLE
Add String overloads for ljust, rjust and center that take an IO

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1997,6 +1997,13 @@ describe "String" do
     it { "123".ljust(5).should eq("123  ") }
     it { "12".ljust(7, '-').should eq("12-----") }
     it { "12".ljust(7, 'あ').should eq("12あああああ") }
+
+    describe "to io" do
+      it { with_io_memory { |io| "123".ljust(2, io) }.should eq("123") }
+      it { with_io_memory { |io| "123".ljust(5, io) }.should eq("123  ") }
+      it { with_io_memory { |io| "12".ljust(7, '-', io) }.should eq("12-----") }
+      it { with_io_memory { |io| "12".ljust(7, 'あ', io) }.should eq("12あああああ") }
+    end
   end
 
   describe "rjust" do
@@ -2004,6 +2011,13 @@ describe "String" do
     it { "123".rjust(5).should eq("  123") }
     it { "12".rjust(7, '-').should eq("-----12") }
     it { "12".rjust(7, 'あ').should eq("あああああ12") }
+
+    describe "to io" do
+      it { with_io_memory { |io| "123".rjust(2, io) }.should eq("123") }
+      it { with_io_memory { |io| "123".rjust(5, io) }.should eq("  123") }
+      it { with_io_memory { |io| "12".rjust(7, '-', io) }.should eq("-----12") }
+      it { with_io_memory { |io| "12".rjust(7, 'あ', io) }.should eq("あああああ12") }
+    end
   end
 
   describe "center" do
@@ -2011,6 +2025,13 @@ describe "String" do
     it { "123".center(5).should eq(" 123 ") }
     it { "12".center(7, '-').should eq("--12---") }
     it { "12".center(7, 'あ').should eq("ああ12あああ") }
+
+    describe "to io" do
+      it { with_io_memory { |io| "123".center(2, io) }.should eq("123") }
+      it { with_io_memory { |io| "123".center(5, io) }.should eq(" 123 ") }
+      it { with_io_memory { |io| "12".center(7, '-', io) }.should eq("--12---") }
+      it { with_io_memory { |io| "12".center(7, 'あ', io) }.should eq("ああ12あああ") }
+    end
   end
 
   describe "succ" do
@@ -2577,4 +2598,10 @@ describe "String" do
       String.interpolation("a", 123, "b", 456, "cde").should eq("a123b456cde")
     end
   end
+end
+
+private def with_io_memory
+  io = IO::Memory.new
+  yield io
+  io.to_s
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3607,7 +3607,7 @@ class String
   # "Purple".ljust(8, '-') # => "Purple--"
   # "Aubergine".ljust(8)   # => "Aubergine"
   # ```
-  def ljust(len, char : Char = ' ')
+  def ljust(len : Int, char : Char = ' ')
     just len, char, -1
   end
 
@@ -3619,7 +3619,7 @@ class String
   # "Purple".ljust(8, io)
   # io.to_s # => "Purple  "
   # ```
-  def ljust(len, io : IO) : Nil
+  def ljust(len : Int, io : IO) : Nil
     ljust(len, ' ', io)
   end
 
@@ -3631,7 +3631,7 @@ class String
   # "Purple".ljust(8, '-', io)
   # io.to_s # => "Purple--"
   # ```
-  def ljust(len, char : Char, io : IO) : Nil
+  def ljust(len : Int, char : Char, io : IO) : Nil
     io << self
     (len - size).times { io << char }
   end
@@ -3643,7 +3643,7 @@ class String
   # "Purple".rjust(8, '-') # => "--Purple"
   # "Aubergine".rjust(8)   # => "Aubergine"
   # ```
-  def rjust(len, char : Char = ' ')
+  def rjust(len : Int, char : Char = ' ')
     just len, char, 1
   end
 
@@ -3655,7 +3655,7 @@ class String
   # "Purple".rjust(8, io)
   # io.to_s # => "  Purple"
   # ```
-  def rjust(len, io : IO) : Nil
+  def rjust(len : Int, io : IO) : Nil
     rjust(len, ' ', io)
   end
 
@@ -3667,7 +3667,7 @@ class String
   # "Purple".rjust(8, '-', io)
   # io.to_s # => "--Purple"
   # ```
-  def rjust(len, char : Char, io : IO) : Nil
+  def rjust(len : Int, char : Char, io : IO) : Nil
     (len - size).times { io << char }
     io << self
   end
@@ -3680,7 +3680,7 @@ class String
   # "Purple".center(9, '-') # => "-Purple--"
   # "Aubergine".center(8)   # => "Aubergine"
   # ```
-  def center(len, char : Char = ' ')
+  def center(len : Int, char : Char = ' ')
     just len, char, 0
   end
 
@@ -3692,7 +3692,7 @@ class String
   # "Purple".center(9, io)
   # io.to_s # => " Purple  "
   # ```
-  def center(len, io : IO) : Nil
+  def center(len : Int, io : IO) : Nil
     center(len, ' ', io)
   end
 
@@ -3704,7 +3704,7 @@ class String
   # "Purple".center(9, '-', io)
   # io.to_s # => "-Purple--"
   # ```
-  def center(len, char : Char, io : IO) : Nil
+  def center(len : Int, char : Char, io : IO) : Nil
     difference = len - size
 
     if difference <= 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -3611,6 +3611,31 @@ class String
     just len, char, -1
   end
 
+  # Adds spaces to right of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".ljust(8, io)
+  # io.to_s # => "Purple  "
+  # ```
+  def ljust(len, io : IO) : Nil
+    ljust(len, ' ', io)
+  end
+
+  # Adds instances of *char* to right of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".ljust(8, '-', io)
+  # io.to_s # => "Purple--"
+  # ```
+  def ljust(len, char : Char, io : IO) : Nil
+    io << self
+    (len - size).times { io << char }
+  end
+
   # Adds instances of *char* to left of the string until it is at least size of *len*.
   #
   # ```
@@ -3620,6 +3645,31 @@ class String
   # ```
   def rjust(len, char : Char = ' ')
     just len, char, 1
+  end
+
+  # Adds spaces to left of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".rjust(8, io)
+  # io.to_s # => "  Purple"
+  # ```
+  def rjust(len, io : IO) : Nil
+    rjust(len, ' ', io)
+  end
+
+  # Adds instances of *char* to left of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".rjust(8, '-', io)
+  # io.to_s # => "--Purple"
+  # ```
+  def rjust(len, char : Char, io : IO) : Nil
+    (len - size).times { io << char }
+    io << self
   end
 
   # Adds instances of *char* to left ond right of the string until it is at least size of *len*.
@@ -3632,6 +3682,42 @@ class String
   # ```
   def center(len, char : Char = ' ')
     just len, char, 0
+  end
+
+  # Adds spaces to left ond right of the string until it is at least size of *len*,
+  # then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".center(9, io)
+  # io.to_s # => " Purple  "
+  # ```
+  def center(len, io : IO) : Nil
+    center(len, ' ', io)
+  end
+
+  # Adds instances of *char* to left ond right of the string until it is at least size of *len*,
+  # then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".center(9, '-', io)
+  # io.to_s # => "-Purple--"
+  # ```
+  def center(len, char : Char, io : IO) : Nil
+    difference = len - size
+
+    if difference <= 0
+      io << self
+      return
+    end
+
+    left_padding = difference // 2
+    right_padding = difference - left_padding
+
+    left_padding.times { io << char }
+    io << self
+    right_padding.times { io << char }
   end
 
   private def just(len, char, justify)


### PR DESCRIPTION
Useful to avoid memory allocations, as always.

In particular we could use it in the new Log module to avoid memory allocations at all when logging stuff: https://github.com/crystal-lang/crystal/pull/8847/files#r395989420