### PR TITLE
Socket#sendfile

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -1147,8 +1147,7 @@ abstract class IO
 
     if socket = dst.as?(Socket)
       if file = src.as?(IO::FileDescriptor)
-        socket.sendfile file, limit
-        return limit
+        return socket.sendfile file, limit
       end
     end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1115,6 +1115,12 @@ abstract class IO
   # io2.to_s # => "hello"
   # ```
   def self.copy(src, dst) : UInt64
+    if socket = dst.as?(Socket)
+      if file = src.as?(File)
+        return socket.sendfile file, file.size - file.pos
+      end
+    end
+
     buffer = uninitialized UInt8[4096]
     count = 0_u64
     while (len = src.read(buffer.to_slice).to_i32) > 0

--- a/src/io.cr
+++ b/src/io.cr
@@ -1139,6 +1139,13 @@ abstract class IO
 
     limit = limit.to_u64
 
+    if socket = dst.as?(Socket)
+      if file = src.as?(IO::FileDescriptor)
+        socket.sendfile file, limit
+        return limit
+      end
+    end
+
     buffer = uninitialized UInt8[4096]
     remaining = limit
     while (len = src.read(buffer.to_slice[0, Math.min(buffer.size, Math.max(remaining, 0))])) > 0

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -96,10 +96,10 @@ module IO::Buffered
   # peek data if the current buffer is empty:
   # otherwise no read is performed and whatever
   # is in the buffer is returned.
-  def peek : Bytes?
+  def peek(fill = true) : Bytes?
     check_open
 
-    if @in_buffer_rem.empty?
+    if @in_buffer_rem.empty? && fill
       fill_buffer
       if @in_buffer_rem.empty?
         return Bytes.empty # EOF

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -43,4 +43,5 @@ lib LibC
   fun sysconf(name : Int) : Long
   fun unlink(name : Char*) : Int
   fun write(fd : Int, buf : Void*, n : SizeT) : SSizeT
+  fun sendfile(fd_out : Int, fd_in : Int, offset : OffT*, count : SizeT) : SSizeT
 end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -300,6 +300,12 @@ class Socket < IO
     end
   end
 
+  def sendfile(file : IO::FileDescriptor, count)
+    evented_sendfile(count, "sendfile") do |remaining|
+      LibC.sendfile(fd, file.fd, nil, remaining)
+    end
+  end
+
   # Sends a message to the specified remote address.
   #
   # ```

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -300,8 +300,11 @@ class Socket < IO
     end
   end
 
-  def sendfile(file : IO::FileDescriptor, count)
-    evented_sendfile(count, "sendfile") do |remaining|
+  # Zero-copy implementation of sending *limit* bytes of *file*
+  # to the socket
+  # Returns the number of bytes sent
+  def sendfile(file : IO::FileDescriptor, limit : Int) : UInt64
+    evented_sendfile(limit, "sendfile") do |remaining|
       LibC.sendfile(fd, file.fd, nil, remaining)
     end
   end


### PR DESCRIPTION
Request for comments

Benchmark result:
```
    copy 4.0kiB 209.50k (  4.77µs) (± 3.76%)  0.0B/op   1.23× slower
sendfile 4.0kiB 257.89k (  3.88µs) (± 3.72%)  0.0B/op        fastest
    copy 1.0MiB   1.09k (914.69µs) (± 5.40%)  0.0B/op   2.30× slower
sendfile 1.0MiB   2.51k (397.83µs) (± 2.92%)  0.0B/op        fastest
    copy 128MiB   7.94  (125.88ms) (± 5.99%)  0.0B/op   2.16× slower
sendfile 128MiB  17.17  ( 58.24ms) (± 3.59%)  0.0B/op        fastest
```

Benchmark code:
```crystal
require "benchmark"
require "socket"

nc = Process.new "nc", ["-l", "-k", "localhost", "1234"]

{ 4096, 1024**2, 128 * 1024**2 }.each do |size|
  TCPSocket.open("localhost", 1234) do |s|
    File.open("/tmp/a", "w+") do |a|
      a.delete
      a.print "a" * size

      Benchmark.ips do |x|
        x.report("copy #{size.humanize_bytes}") do
          a.rewind
          IO.copy a, s, a.size
        end
        x.report("sendfile #{size.humanize_bytes}") do
          a.rewind
          s.sendfile a, a.size
        end
      end
    end
  end
end
nc.kill
```