### PR TITLE
Correctly implement bit_length for BigIng

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -791,7 +791,8 @@ describe "Int" do
     end
 
     pending_win32 "for BigInt" do
-      BigInt.new("1234567890123456789012345678901234567890").bit_length.should eq(130)
+      (10.to_big_i ** 20).bit_length.should eq(67)
+      (10.to_big_i ** 309).bit_length.should eq(1027)
     end
   end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -793,6 +793,7 @@ describe "Int" do
     pending_win32 "for BigInt" do
       (10.to_big_i ** 20).bit_length.should eq(67)
       (10.to_big_i ** 309).bit_length.should eq(1027)
+      (10.to_big_i ** 3010).bit_length.should eq(10000)
     end
   end
 end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -390,6 +390,10 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
+  def bit_length : Int32
+    LibGMP.sizeinbase(self, 2).to_i
+  end
+
   # TODO: improve this
   def_hash to_u64
 

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -97,6 +97,7 @@ lib LibGMP
   fun popcount = __gmpz_popcount(op : MPZ*) : BitcntT
   fun scan0 = __gmpz_scan0(op : MPZ*, starting_bit : BitcntT) : BitcntT
   fun scan1 = __gmpz_scan1(op : MPZ*, starting_bit : BitcntT) : BitcntT
+  fun sizeinbase = __gmpz_sizeinbase(op : MPZ*, base : Int) : SizeT
 
   # # Comparison
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -420,13 +420,14 @@ struct Int
   # 0b100.bit_length # => 3
   # 0b101.bit_length # => 3
   # ```
-  def bit_length : self
+  def bit_length : Int32
     x = self < 0 ? ~self : self
 
     if x.is_a?(Int::Primitive)
-      self.class.new(sizeof(self) * 8 - x.leading_zeros_count)
+      Int32.new(sizeof(self) * 8 - x.leading_zeros_count)
     else
-      self.class.new(Math.log2(x).to_i + 1)
+      # Safe fallback for any non-primitive Int type
+      to_s(2).size
     end
   end
 


### PR DESCRIPTION
Follow up to #8924

Some bugs were detected, so this fixes that.

Also:
- Made `bit_length` always return `Int32` which makes more sense
- Optimized for `BigInt`: I found the specific function to this in libgmp

Here's a benchmark:

```
require "big"
require "benchmark"

i = 10.to_big_i ** 309

Benchmark.ips do |x|
  x.report("bit_length") do
    i.bit_length
  end
  x.report("to_s(2).size") do
    i.to_s(2).size
  end
end
```

Output:

```
  bit_length 113.16M (  8.84ns) (± 3.95%)    0.0B/op         fastest
to_s(2).size 333.97k (  2.99µs) (± 5.92%)  2.63kB/op  338.85× slower
```

Also a benchmark for Ruby:

```ruby
require "benchmark/ips"

i = 10 ** 309

Benchmark.ips do |x|
  x.report("bit_length") do
    i.bit_length
  end
end
```

Output:

```
Warming up --------------------------------------
          bit_length   424.827k i/100ms
Calculating -------------------------------------
          bit_length     17.227M (± 3.5%) i/s -     86.240M in   5.012266s
```

About 10x faster than Ruby :-)