### PR TITLE
Add `IO::Buffered#flush_on_newline` back and set it to true for non-tty

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -283,6 +283,30 @@ describe "IO::Buffered" do
     str.to_s.should eq("hello" * 10_000)
   end
 
+  describe "flush_on_newline" do
+    it "flushes on \n" do
+      str = IO::Memory.new
+      io = BufferedWrapper.new(str)
+      io.flush_on_newline = true
+
+      io << "hello\nworld"
+      str.to_s.should eq("hello\n")
+      io.flush
+      str.to_s.should eq("hello\nworld")
+    end
+
+    it "doesn't write past count" do
+      str = IO::Memory.new
+      io = BufferedWrapper.new(str)
+      io.flush_on_newline = true
+
+      slice = Slice.new(10) { |i| i == 9 ? '\n'.ord.to_u8 : ('a'.ord + i).to_u8 }
+      io.write slice[0, 4]
+      io.flush
+      str.to_s.should eq("abcd")
+    end
+  end
+
   describe "sync" do
     it "syncs (write)" do
       str = IO::Memory.new

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -189,6 +189,7 @@ class HTTP::Server
         @in_buffer_rem = Bytes.empty
         @out_count = 0
         @sync = false
+        @flush_on_newline = false
         @chunked = false
         @closed = false
       end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -32,22 +32,27 @@ class IO::FileDescriptor < IO
 
   # :nodoc:
   def self.from_stdio(fd)
-    # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
-    # We need to reopen it to use O_NONBLOCK without causing other programs to break
+    {% if flag?(:win32) %}
+      new(fd)
+    {% else %}
+      # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
+      # We need to reopen it to use O_NONBLOCK without causing other programs to break
 
-    # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
-    path = uninitialized UInt8[256]
-    ret = LibC.ttyname_r(fd, path, 256)
-    return new(fd).tap(&.flush_on_newline=(true)) unless ret == 0
+      # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
+      # For non-tty we set flush_on_newline to true for reasons described in STDOUT and STDERR docs.
+      path = uninitialized UInt8[256]
+      ret = LibC.ttyname_r(fd, path, 256)
+      return new(fd).tap(&.flush_on_newline=(true)) unless ret == 0
 
-    clone_fd = LibC.open(path, LibC::O_RDWR)
-    return new(fd).tap(&.flush_on_newline=(true)) if clone_fd == -1
+      clone_fd = LibC.open(path, LibC::O_RDWR)
+      return new(fd).tap(&.flush_on_newline=(true)) if clone_fd == -1
 
-    # We don't buffer output for TTY devices to see their output right away
-    io = new(clone_fd)
-    io.close_on_exec = true
-    io.sync = true
-    io
+      # We don't buffer output for TTY devices to see their output right away
+      io = new(clone_fd)
+      io.close_on_exec = true
+      io.sync = true
+      io
+    {% end %}
   end
 
   def blocking

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -38,10 +38,10 @@ class IO::FileDescriptor < IO
     # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
     path = uninitialized UInt8[256]
     ret = LibC.ttyname_r(fd, path, 256)
-    return new(fd) unless ret == 0
+    return new(fd).tap(&.flush_on_newline=(true)) unless ret == 0
 
     clone_fd = LibC.open(path, LibC::O_RDWR)
-    return new(fd) if clone_fd == -1
+    return new(fd).tap(&.flush_on_newline=(true)) if clone_fd == -1
 
     # We don't buffer output for TTY devices to see their output right away
     io = new(clone_fd)

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -1,40 +1,27 @@
 require "crystal/at_exit_handlers"
 
-{% if flag?(:win32) %}
-  # The standard input file descriptor. Contains data piped to the program.
-  STDIN = IO::FileDescriptor.new(0)
-
-  # The standard output file descriptor.
-  #
-  # Typically used to output data and information.
-  STDOUT = IO::FileDescriptor.new(1)
-
-  # The standard error file descriptor.
-  #
-  # Typically used to output error messages and diagnostics.
-  STDERR = IO::FileDescriptor.new(2)
-{% else %}
+{% unless flag?(:win32) %}
   require "c/unistd"
-
-  # The standard input file descriptor. Contains data piped to the program.
-  STDIN = IO::FileDescriptor.from_stdio(0)
-
-  # The standard output file descriptor.
-  #
-  # Typically used to output data and information.
-  #
-  # When this is a TTY device, `sync` will be true for it
-  # at the start of the program.
-  STDOUT = IO::FileDescriptor.from_stdio(1)
-
-  # The standard error file descriptor.
-  #
-  # Typically used to output error messages and diagnostics.
-  #
-  # When this is a TTY device, `sync` will be true for it
-  # at the start of the program.
-  STDERR = IO::FileDescriptor.from_stdio(2)
 {% end %}
+
+# The standard input file descriptor. Contains data piped to the program.
+STDIN = IO::FileDescriptor.from_stdio(0)
+
+# The standard output file descriptor.
+#
+# Typically used to output data and information.
+#
+# When this is a TTY device, `sync` will be true for it
+# at the start of the program.
+STDOUT = IO::FileDescriptor.from_stdio(1)
+
+# The standard error file descriptor.
+#
+# Typically used to output error messages and diagnostics.
+#
+# When this is a TTY device, `sync` will be true for it
+# at the start of the program.
+STDERR = IO::FileDescriptor.from_stdio(2)
 
 # The name, the program was called with.
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -11,16 +11,34 @@ STDIN = IO::FileDescriptor.from_stdio(0)
 #
 # Typically used to output data and information.
 #
-# When this is a TTY device, `sync` will be true for it
-# at the start of the program.
+# At the start of the program STDOUT is configured like this:
+# - if it's a TTY device (like the console) then `sync` is `true`,
+#   meaning that output will be outputted as soon as it is written
+#   to STDOUT. This is so users can see real time output data.
+# - if it's not a TTY device (like a file, or because the output
+#   was piped to a file) then `sync` is `false` but `flush_on_newline`
+#   is `true`. This is so that if you pipe the output to a file, and,
+#   for example, you `tail -f`, you can see data on a line-per-line basis.
+#   This is convenient but slower than with `flush_on_newline` set to `false`.
+#   If you need a bit more performance and you don't care about near real-time
+#   output you can do `STDOUT.flush_on_newline = false`.
 STDOUT = IO::FileDescriptor.from_stdio(1)
 
 # The standard error file descriptor.
 #
 # Typically used to output error messages and diagnostics.
 #
-# When this is a TTY device, `sync` will be true for it
-# at the start of the program.
+# At the start of the program STDERR is configured like this:
+# - if it's a TTY device (like the console) then `sync` is `true`,
+#   meaning that output will be outputted as soon as it is written
+#   to STDERR. This is so users can see real time output data.
+# - if it's not a TTY device (like a file, or because the output
+#   was piped to a file) then `sync` is `false` but `flush_on_newline`
+#   is `true`. This is so that if you pipe the output to a file, and,
+#   for example, you `tail -f`, you can see data on a line-per-line basis.
+#   This is convenient but slower than with `flush_on_newline` set to `false`.
+#   If you need a bit more performance and you don't care about near real-time
+#   output you can do `STDERR.flush_on_newline = false`.
 STDERR = IO::FileDescriptor.from_stdio(2)
 
 # The name, the program was called with.


### PR DESCRIPTION
Reverts #7470
Fixes #7431 (somehow)

Before #7470 if you output to the console and redirected that output to somewhere else, for example a file, then you would see output right after each line was emitted.

Once we merged #7470 you would only see output after the IO buffer was full and it was flushed.

That meant that if you did `tail -f` on that file you wouldn't see new lines appended to it immediately. I believe this is not very intuitive. If you don't output enough data you might think something is broken and lose a lot of time debugging this.

This PR reverts the behavior back to how it was before.

This is **slower**, but you still have the option to make is faster (if you don't care about not seeing "correct" output using `tail -f`) by doing:

```crystal
STDOUT.flush_on_newline = false
```

If we don't add this method back, the only options you have are:
- fully buffer the output: fast, but not very intuitive
- no buffer: **very** slow, but intuitive

With `flush_on_newline` it's not fast but it's also not **very** slow. So I think this is a good default.

💭 We could also consider having an environment variable, for example `CRYSTAL_STDOUT_FLUSH_ON_NEWLINE` so you can control, at runtime, how the program behaves (on startup). That means that you can compile your program once and control how it behaves later on. But I didn't include this here. We can discuss it in a different issue if needed, and do it in a separate PR.

Please 👍 if you agree with this change, 👎 if not.