### PR TITLE
Windows: Remove the workaround using vsnprintf.

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/stdio.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdio.cr
@@ -1,14 +1,8 @@
 require "./stddef"
 
+@[Link("legacy_stdio_definitions")]
 lib LibC
   fun printf(format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
-  fun vsnprintf(str : Char*, size : SizeT, format : Char*, ap : VaList) : Int
-  fun snprintf = __crystal_snprintf(str : Char*, size : SizeT, format : Char*, ...) : Int
-end
-
-fun __crystal_snprintf(str : LibC::Char*, size : LibC::SizeT, format : LibC::Char*, ...) : LibC::Int
-  VaList.open do |varargs|
-    LibC.vsnprintf(str, size, format, varargs)
-  end
+  fun snprintf(buffer : Char*, count : SizeT, format : Char*, ...) : Int
 end


### PR DESCRIPTION
This is not needed, the functions are both defined in [**legacy_stdio_definitions.cpp**](https://github.com/ojdkbuild/tools_toolchain_vs2017bt_1416/blob/d3cdb9a6cb3d92f6081290849f4386a9ff2ce30a/VC/Tools/MSVC/14.16.27023/crt/src/linkopts/legacy_stdio_definitions.cpp#L164) in the same way. So use snprintf directly.


This partly reverts #5533.

But add `Link(legacy_stdio_definitions)`, as [**that's where these functions reside now**](https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=vs-2019#stdio_and_conio), since VS 2015.
(This one is [**needed**](https://github.com/crystal-lang/crystal/blob/ae9257a0496e087a3f9a44c066087e52567d9736/.github/workflows/win.yml#L88) regardless of this change)