### PR TITLE
Allow include and extend inside enum declarations

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1396,6 +1396,9 @@ module Crystal
 
     it_parses "enum Foo; @[Bar]; end", EnumDef.new("Foo".path, [Annotation.new("Bar".path)] of ASTNode)
 
+    it_parses "enum Foo; include Bar; end", EnumDef.new("Foo".path, [Include.new("Bar".path)] of ASTNode)
+    it_parses "enum Foo; extend Bar; end", EnumDef.new("Foo".path, [Extend.new("Bar".path)] of ASTNode)
+
     assert_syntax_error "enum Foo; A B; end", "expecting ';', 'end' or newline after enum member"
     assert_syntax_error "enum Foo\n  A,   B,   C\nend\n", "expecting ';', 'end' or newline after enum member"
 

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -492,4 +492,40 @@ describe "Semantic: enum" do
       end
     ))
   end
+
+  it "can include module" do
+    assert_type(%(
+      module Moo
+        def moo
+          1
+        end
+      end
+
+      enum Color
+        Red
+
+        include Moo
+      end
+
+      Color::Red.moo
+      )) { int32 }
+  end
+
+  it "can extend module" do
+    assert_type(%(
+      module Moo
+        def moo
+          1
+        end
+      end
+
+      enum Color
+        Red
+
+        extend Moo
+      end
+
+      Color.moo
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5715,6 +5715,10 @@ module Crystal
             member = parse_macro.at(def_location)
             member = VisibilityModifier.new(visibility, member) if visibility
             members << member
+          when :include
+            members << parse_include
+          when :extend
+            members << parse_extend
           else
             unexpected_token
           end


### PR DESCRIPTION
Fixes #8946

For some reason this wasn't allowed, but it's very easy to implement and it makes sense.