### PR TITLE
[RFC] [WIP] Add support for concurrent specs

### DIFF
--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -11,37 +11,40 @@ module Spec
     # :nodoc:
     def initialize(@parent : Context, @description : String,
                    @file : String, @line : Int32, @end_line : Int32,
-                   @focus : Bool, tags,
+                   @focus : Bool, @async : Bool, tags,
                    @block : (->) | Nil)
       initialize_tags(tags)
     end
 
     # :nodoc:
     def run
-      Spec.root_context.check_nesting_spec(file, line) do
-        Spec.formatters.each(&.before_example(description))
+      Spec.formatters.each(&.before_example(description))
 
-        unless block = @block
-          @parent.report(:pending, description, file, line)
-          return
-        end
-
-        non_nil_block = block
-        start = Time.monotonic
-
-        Spec.run_before_each_hooks
-
-        ran = @parent.run_around_each_hooks(Example::Procsy.new(self) { internal_run(start, non_nil_block) })
-        ran || internal_run(start, non_nil_block)
-
-        Spec.run_after_each_hooks
-
-        # We do this to give a chance for signals (like CTRL+C) to be handled,
-        # which currently are only handled when there's a fiber switch
-        # (IO stuff, sleep, etc.). Without it the user might wait more than needed
-        # after pressing CTRL+C to quit the tests.
-        Fiber.yield
+      unless block = @block
+        @parent.report(:pending, description, file, line)
+        return
       end
+
+      non_nil_block = block
+      start = Time.monotonic
+
+      Spec.run_before_each_hooks
+
+      ran = @parent.run_around_each_hooks(Example::Procsy.new(self) { internal_run(start, non_nil_block) })
+      ran || internal_run(start, non_nil_block)
+
+      Spec.run_after_each_hooks
+
+      # We do this to give a chance for signals (like CTRL+C) to be handled,
+      # which currently are only handled when there's a fiber switch
+      # (IO stuff, sleep, etc.). Without it the user might wait more than needed
+      # after pressing CTRL+C to quit the tests.
+      Fiber.yield
+    end
+
+    def run(&on_finish)
+      run
+      on_finish.call
     end
 
     private def internal_run(start, block)

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -19,6 +19,9 @@ module Spec
     # Does this example or example group have `focus: true` on it?
     getter? focus : Bool
 
+    # Does this example or example group have `async: true` on it?
+    getter? async : Bool
+
     # The tags defined on this example or example group
     getter tags : Set(String)?
 

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -14,8 +14,8 @@ module Spec::Methods
   # ```
   #
   # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
-  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    Spec.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
+  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, async : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    Spec.root_context.describe(description.to_s, file, line, end_line, focus, async, tags, &block)
   end
 
   # Defines an example group that establishes a specific context,
@@ -25,8 +25,8 @@ module Spec::Methods
   # It is functionally equivalent to `#describe`.
   #
   # If `focus` is `true`, only this `context`, and others marked with `focus: true`, will run.
-  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    describe(description.to_s, file, line, end_line, focus, tags, &block)
+  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, async : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    describe(description.to_s, file, line, end_line, focus, async, tags, &block)
   end
 
   # Defines a concrete test case.
@@ -41,8 +41,8 @@ module Spec::Methods
   # It is usually used inside a `#describe` or `#context` section.
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    Spec.root_context.it(description.to_s, file, line, end_line, focus, tags, &block)
+  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, async : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    Spec.root_context.it(description.to_s, file, line, end_line, focus, async, tags, &block)
   end
 
   # Defines a pending test case.
@@ -58,15 +58,15 @@ module Spec::Methods
   # It is usually used inside a `#describe` or `#context` section.
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    pending(description, file, line, end_line, focus, tags)
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, async : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+    pending(description, file, line, end_line, focus, async, tags)
   end
 
   # Defines a yet-to-be-implemented pending test case
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil)
-    Spec.root_context.pending(description.to_s, file, line, end_line, focus, tags)
+  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, async : Bool = false, tags : String | Enumerable(String) | Nil = nil)
+    Spec.root_context.pending(description.to_s, file, line, end_line, focus, async, tags)
   end
 
   # Fails an example.


### PR DESCRIPTION
The move to allow `focus: true` and `before_each` in specs opened the door to asynchronous specs since `it` no longer runs the spec eagerly. This is something I've been wanting for a while because the majority of your time spent in running the test suite for a typical web app is spent in I/O with the DB rather than in CPU time.

If all of your specs are asynchronous, your suite is only as slow as your slowest spec:

```crystal
require "spec"

describe "somethign async", async: true do
  50.times do |i|
    it "does a thing that takes a long time(#{i})" do
      sleep rand.seconds # Sleep up to 1 second
    end
  end
end
```

With this PR, this is the result:

```
$ crystal/bin/crystal async_spec.cr
Using compiled compiler at crystal/.build/crystal
..................................................

Finished in 998.02 milliseconds
50 examples, 0 failures, 0 errors, 0 pending
```

### A few things I had to do to make this happen:

- All `Example`s are now direct children of the `RootContext`
  - I have no idea if this was necessary, but it sure made it a lot easier for me to understand.
  - Without this change, async specs that had sync ancestors were not invoked until they were reached. That could probably be worked around, I just wasn't sure how. Maybe the `if async` checks could handle that.
  - It probably makes the changes to `ExampleGroup#run` here unnecessary
- An async `ExampleGroup` makes all its descendants async
  - This is similar to how a focused `ExampleGroup` runs all its descendants even if they're not focused, letting those descendants "inherit" the focus status

### Important notes

A spec suite that contains `async` specs cannot depend on any global mutable state. For example, you may not be able to run `User.count.should eq 1` unless all of your specs run within their own isolated transaction which is rolled back at the end of each example. And even then! :-)