### PR TITLE
Remove redundant calls to `Object.to_s` in interpolation

### DIFF
--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -135,7 +135,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     if created_new_type && superclass
       if node.struct? != superclass.struct?
-        node.raise "can't make #{node.struct? ? "struct" : "class"} '#{node.name}' inherit #{superclass.type_desc} '#{superclass.to_s}'"
+        node.raise "can't make #{node.struct? ? "struct" : "class"} '#{node.name}' inherit #{superclass.type_desc} '#{superclass}'"
       end
 
       if superclass.struct? && !superclass.abstract?

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5873,19 +5873,19 @@ module Crystal
     end
 
     def check(token_types : Array)
-      raise "expecting any of these tokens: #{token_types.join ", "} (not '#{@token.type.to_s}')", @token unless token_types.any? { |type| @token.type == type }
+      raise "expecting any of these tokens: #{token_types.join ", "} (not '#{@token.type}')", @token unless token_types.any? { |type| @token.type == type }
     end
 
     def check(token_type)
-      raise "expecting token '#{token_type}', not '#{@token.to_s}'", @token unless token_type == @token.type
+      raise "expecting token '#{token_type}', not '#{@token}'", @token unless token_type == @token.type
     end
 
     def check_token(value)
-      raise "expecting token '#{value}', not '#{@token.to_s}'", @token unless @token.type == :TOKEN && @token.value == value
+      raise "expecting token '#{value}', not '#{@token}'", @token unless @token.type == :TOKEN && @token.value == value
     end
 
     def check_ident(value)
-      raise "expecting identifier '#{value}', not '#{@token.to_s}'", @token unless @token.keyword?(value)
+      raise "expecting identifier '#{value}', not '#{@token}'", @token unless @token.keyword?(value)
     end
 
     def check_ident

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -409,7 +409,7 @@ module Spec
       ex
     rescue ex
       backtrace = ex.backtrace.join('\n') { |f| "  # #{f}" }
-      fail "Expected #{klass}, got #<#{ex.class}: #{ex.to_s}> with backtrace:\n" \
+      fail "Expected #{klass}, got #<#{ex.class}: #{ex}> with backtrace:\n" \
            "#{backtrace}", file, line
     else
       fail "Expected #{klass} but nothing was raised", file, line


### PR DESCRIPTION
Each expression enclosed by `#{ ... }` ends up invoking `Object.to_s`, so here we remove redundant calls to `.to_s` in a couple of places.

Autodetected by https://github.com/crystal-ameba/ameba/pull/137