### PR TITLE
Compiler: Honor LIBRARY_PATH as default library path

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -105,7 +105,8 @@ module Crystal
     end
 
     private def lib_flags_posix
-      library_path = ["/usr/lib", "/usr/local/lib"]
+      library_path = ENV["LIBRARY_PATH"]?.try(&.split(':', remove_empty: true)) ||
+                     ["/usr/lib", "/usr/local/lib"]
       has_pkg_config = nil
 
       String.build do |flags|


### PR DESCRIPTION
* If not set, default to /usr/lib, /usr/local/lib.
* If set to empty it allows you to skip adding /usr/lib and /usr/local/lib to the linker.
* Setting to a `list:of:directories`, those directories will be used for static libs lookup and appended as `-L` in the linker.

Closes #8326

We will fail to lookup some libraries if we don't keep the default, probably because:

* OSX does not set LIBRARY_PATH by default
* FreeBSD won't search /usr/local/lib by default

I check that GCC seems to add directory with some heuristics https://github.com/gcc-mirror/gcc/blob/41d6b10e96a1de98e90a7c0378437c3255814b16/config/lib-link.m4#L389-L396

Note: I accidentally pushed it to master as e1b4e8fd5e5b6ddc1e5426803b559ad4992dd133, but I rolled back ef5f10f6ead9004ae65db5f2fb637bb718659abd. (I will learn to use git worktrees better next time ¬¬, sorry)
