### PR TITLE
Allow config of IO buffer size

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -59,7 +59,22 @@ require "c/errno"
 # avoided, as string operations might need to read extra bytes in order to get characters
 # in the given encoding.
 abstract class IO
-  BUFFER_SIZE = 8192
+  # Changes the default buffer size that is used in `IO.copy`, `IO::Buffered`
+  # and othe operations. The first invocation defines the value.
+  # Defaults to 8192 (8kb)
+  #
+  # ```
+  # IO.set_buffer_size 16384
+  # ```
+  macro set_buffer_size(value)
+    {% if !IO.has_constant?(:BUFFER_SIZE) %}
+      ::IO::BUFFER_SIZE = {{value}}
+    {% end %}
+  end
+
+  macro finished
+    set_buffer_size 8192
+  end
 
   # Argument to a `seek` operation.
   enum Seek

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -11,7 +11,7 @@ module IO::Buffered
   @sync = false
   @read_buffering = true
   @flush_on_newline = false
-  @buffer_size = 8192
+  @buffer_size = IO::BUFFER_SIZE
 
   # Reads at most *slice.size* bytes from the wrapped `IO` into *slice*.
   # Returns the number of bytes read.


### PR DESCRIPTION
follow up from https://forum.crystal-lang.org/t/io-copy-buffer-too-small/1873

I try to make it from env vars instead of macros, but the math interpreter does not allow env vars to be read. And going all the way with macro run seems too much for this.
