### PR TITLE
Add Enumerable#last/last? methods

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -887,7 +887,7 @@ describe "Array" do
     end
 
     it "raises when empty" do
-      expect_raises IndexError do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).last
       end
     end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -380,7 +380,7 @@ describe "Deque" do
     end
 
     it "raises when empty" do
-      expect_raises IndexError do
+      expect_raises Enumerable::EmptyError do
         Deque(Int32).new.last
       end
     end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -466,6 +466,38 @@ describe "Enumerable" do
     end
   end
 
+  describe "last" do
+    it "gets last" do
+      (1..3).last.should eq(3)
+    end
+
+    it "calls block if empty" do
+      (1...1).last { 10 }.should eq(10)
+    end
+
+    it "raises if enumerable is empty" do
+      expect_raises Enumerable::EmptyError do
+        (1...1).last
+      end
+    end
+
+    it "doesn't raise if last element is nil" do
+      [nil].last.should be_nil
+    end
+
+    it { [-1, -2, -3].last.should eq(-3) }
+  end
+
+  describe "last?" do
+    it "gets last?" do
+      (1..3).last?.should eq(3)
+    end
+
+    it "returns nil if enumerable is empty" do
+      (1...1).last?.should be_nil
+    end
+  end
+
   describe "flat_map" do
     it "does example 1" do
       [1, 2, 3, 4].flat_map { |e| [e, -e] }.should eq([1, -1, 2, -2, 3, -3, 4, -4])

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -493,8 +493,13 @@ module Enumerable(T)
     nil
   end
 
-  # Returns the last element in the collection. Raises `Enumerable::EmptyError`
-  # if the collection is empty.
+  # Returns the last element of `self` if it's not empty,
+  # or the given block's value.
+  #
+  # ```
+  # ([1, 2, 3]).last { 4 }   # => 3
+  # ([] of Int32).last { 4 } # => 4
+  # ```
   def last
     found = false
     obj = uninitialized T
@@ -507,13 +512,23 @@ module Enumerable(T)
     obj
   end
 
-  # :ditto:
+  # Returns the last element of `self` if it's not empty,
+  # or raises `Enumerable::EmptyError`.
+  #
+  # ```
+  # ([1, 2, 3]).last   # => 3
+  # ([] of Int32).last # raises Enumerable::EmptyError
+  # ```
   def last
     last { raise Enumerable::EmptyError.new }
   end
 
-  # Returns the last element in the collection.
-  # When the collection is empty, returns `nil`.
+  # Returns the last element of `self` if it's not empty, or `nil`.
+  #
+  # ```
+  # ([1, 2, 3]).last?   # => 3
+  # ([] of Int32).last? # => nil
+  # ```
   def last?
     last { nil }
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -493,6 +493,31 @@ module Enumerable(T)
     nil
   end
 
+  # Returns the last element in the collection. Raises `Enumerable::EmptyError`
+  # if the collection is empty.
+  def last
+    found = false
+    obj = uninitialized T
+
+    each do |elem|
+      found = true
+      obj = elem
+    end
+    return yield unless found
+    obj
+  end
+
+  # :ditto:
+  def last
+    last { raise Enumerable::EmptyError.new }
+  end
+
+  # Returns the last element in the collection.
+  # When the collection is empty, returns `nil`.
+  def last?
+    last { nil }
+  end
+
   # Returns a new array with the concatenated results of running the block
   # (which is expected to return arrays) once for every element in the collection.
   #

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -502,34 +502,9 @@ module Indexable(T)
     nil
   end
 
-  # Returns the last element of `self` if it's not empty, or raises `IndexError`.
-  #
-  # ```
-  # ([1, 2, 3]).last   # => 3
-  # ([] of Int32).last # raises IndexError
-  # ```
-  def last
-    last { raise IndexError.new }
-  end
-
-  # Returns the last element of `self` if it's not empty, or the given block's value.
-  #
-  # ```
-  # ([1, 2, 3]).last { 4 }   # => 3
-  # ([] of Int32).last { 4 } # => 4
-  # ```
+  # :inherited:
   def last
     size == 0 ? yield : unsafe_fetch(size - 1)
-  end
-
-  # Returns the last element of `self` if it's not empty, or `nil`.
-  #
-  # ```
-  # ([1, 2, 3]).last?   # => 3
-  # ([] of Int32).last? # => nil
-  # ```
-  def last?
-    last { nil }
   end
 
   # Same as `#each`, but works in reverse.


### PR DESCRIPTION
- Adds `Enumerable#last?`, `Enumerable#last` and `Enumerable#last(&)` methods
- Makes `Indexable#last?` and `Indexable#last` inherit from `Enumerable`
- Due to the above `Indexable#last` throws now `Enumerable::EmptyError` instead of `IndexError`

Aligns with #8999