### PR TITLE
Add Enumerable#empty? method

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -10,6 +10,13 @@ private class SpecEnumerable
   end
 end
 
+private class SpecEmptyEnumerable
+  include Enumerable(Int32)
+
+  def each(&block : T -> _)
+  end
+end
+
 describe "Enumerable" do
   describe "all? with block" do
     it "returns true" do
@@ -414,6 +421,11 @@ describe "Enumerable" do
       iter.next.should eq({2, "a"})
       iter.next.should be_a(Iterator::Stop)
     end
+  end
+
+  describe "empty?" do
+    it { SpecEnumerable.new.empty?.should be_false }
+    it { SpecEmptyEnumerable.new.empty?.should be_true }
   end
 
   describe "find" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1241,6 +1241,17 @@ module Enumerable(T)
     count { true }
   end
 
+  # Returns `true` if `self` is empty, `false` otherwise.
+  #
+  # ```
+  # ([] of Int32).empty? # => true
+  # ([1]).empty?         # => false
+  # ```
+  def empty?
+    each { return false }
+    true
+  end
+
   # Returns an `Array` with the first *count* elements removed
   # from the original collection.
   #


### PR DESCRIPTION
For some reason there's only `Indexable#empty?`, whereas IMHO `Enumerable` deserves it's own one too.