### PR TITLE
Compiler: allow assigning Proc(R) to Proc(Nil)

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -774,4 +774,49 @@ describe "Code gen: proc" do
       a
       )).to_i.should eq(2)
   end
+
+  it "can assign proc that returns anything to proc that returns nil (#3655)" do
+    run(%(
+      class Foo
+        @block : -> Nil
+
+        def initialize(@block)
+        end
+
+        def call
+          @block.call
+        end
+      end
+
+      a = 1
+      block = ->{ a = 2 }
+
+      Foo.new(block).call
+
+      a
+      )).to_i.should eq(2)
+  end
+
+  it "can assign proc that returns anything to proc that returns nil, using union type (#3655)" do
+    run(%(
+      class Foo
+        @block : -> Nil
+
+        def initialize(@block)
+        end
+
+        def call
+          @block.call
+        end
+      end
+
+      a = 1
+      block1 = ->{ a = 2 }
+      block2 = ->{ a = 3; nil }
+
+      Foo.new(block2 || block1).call
+
+      a
+      )).to_i.should eq(3)
+  end
 end

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -1051,4 +1051,14 @@ describe "Semantic: proc" do
       foo(->(x : String) { 1 })
       )) { proc_of string, nil_type }
   end
+
+  it "casts to Proc(Nil) when specified in return type" do
+    assert_type(%(
+      def foo : Proc(Nil)
+        ->{ 1 }
+      end
+
+      foo
+      )) { proc_of nil_type }
+  end
 end

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -889,7 +889,7 @@ describe "Semantic: proc" do
       )) { union_of proc_of(int32, int32), proc_of(int32, nil_type) }
   end
 
-  it "can assign proc that returns anything to proc that returns nil (#3655)" do
+  it "can assign proc that returns anything to proc that returns nil, with instance var (#3655)" do
     assert_type(%(
       class Foo
         @block : -> Nil
@@ -904,6 +904,36 @@ describe "Semantic: proc" do
       end
 
       Foo.new.block
+      )) { proc_of(nil_type) }
+  end
+
+  it "can assign proc that returns anything to proc that returns nil, with class var (#3655)" do
+    assert_type(%(
+      module Moo
+        @@block : -> Nil = ->{ nil }
+
+        def self.block=(@@block)
+        end
+
+        def self.block
+          @@block
+        end
+      end
+
+      Moo.block = ->{ 1 }
+      Moo.block
+      )) { proc_of(nil_type) }
+  end
+
+  it "can assign proc that returns anything to proc that returns nil, with local var (#3655)" do
+    assert_type(%(
+      proc : -> Nil
+
+      a = ->{ 1 }
+      b = ->{ nil }
+      proc = a || b
+
+      proc
       )) { proc_of(nil_type) }
   end
 

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -889,6 +889,14 @@ describe "Semantic: proc" do
       )) { union_of proc_of(int32, int32), proc_of(int32, nil_type) }
   end
 
+  it "merges return type" do
+    assert_type(%(
+      a = ->(x : Int32) { 1 }
+      b = ->(x : Int32) { nil }
+      (a || b).call(1)
+      )) { nilable int32 }
+  end
+
   it "can assign proc that returns anything to proc that returns nil, with instance var (#3655)" do
     assert_type(%(
       class Foo

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -881,12 +881,12 @@ describe "Semantic: proc" do
       )) { proc_of(int32) }
   end
 
-  it "merges Proc that returns Nil with another one that returns something else (#3655)" do
+  it "*doesn't* merge Proc that returns Nil with another one that returns something else (#3655) (this was reverted)" do
     assert_type(%(
       a = ->(x : Int32) { 1 }
       b = ->(x : Int32) { nil }
       a || b
-      )) { proc_of(int32, nil_type) }
+      )) { union_of proc_of(int32, int32), proc_of(int32, nil_type) }
   end
 
   it "can assign proc that returns anything to proc that returns nil (#3655)" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -274,6 +274,16 @@ class Crystal::CodeGenVisitor
     store value, target_pointer
   end
 
+  def assign_distinct(target_pointer, target_type : ProcInstanceType, value_type : MixedUnionType, value)
+    # The only case when a union is assigned to a proc is when
+    # target_type is Proc(*T, Nil) and all the types in the union are Proc(*T, R).
+    # In that case we can simply get the union value and cast it to the target type.
+    # Cast of a non-void proc to a void proc
+    _, union_value_ptr = union_type_and_value_pointer(value, value_type)
+    value = bit_cast(union_value_ptr, llvm_type(target_type).pointer)
+    store load(value), target_pointer
+  end
+
   def assign_distinct(target_pointer, target_type : Type, value_type : Type, value)
     raise "BUG: trying to assign #{target_type} <- #{value_type}"
   end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -39,7 +39,6 @@ module Crystal
       if !type.no_return? && (freeze_type = @freeze_type) && !type.implements?(freeze_type)
         raise_frozen_type freeze_type, type, self
       end
-
       @type = type
     end
 
@@ -135,7 +134,7 @@ module Crystal
       new_type = map_type(new_type) if new_type
 
       if new_type && (freeze_type = @freeze_type)
-        new_type = assign_type(freeze_type, new_type)
+        new_type = restrict_type_to_freeze_type(freeze_type, new_type)
       end
 
       return if @type.same? new_type
@@ -197,7 +196,7 @@ module Crystal
       new_type = map_type(new_type) if new_type
 
       if new_type && (freeze_type = @freeze_type)
-        new_type = assign_type(freeze_type, new_type)
+        new_type = restrict_type_to_freeze_type(freeze_type, new_type)
       end
 
       return if @type.same? new_type
@@ -228,7 +227,7 @@ module Crystal
     # in the case where freeze_type is not nil.
     #
     # Special cases are listed inside the method body.
-    def assign_type(freeze_type, type)
+    def restrict_type_to_freeze_type(freeze_type, type)
       # We allow assigning Proc(*T, R) to Proc(*T, Nil)
       if freeze_type.is_a?(ProcInstanceType) && freeze_type.return_type.nil_type?
         if (type.is_a?(UnionType) && type.union_types.all?(&.implements?(freeze_type))) ||

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -285,16 +285,6 @@ module Crystal
         return self
       end
 
-      # For Proc(..., Nil), Proc(..., T) we keep Proc(..., Nil)
-      if return_type.nil_type? && arg_types == other.arg_types
-        return self
-      end
-
-      # Same but the other way around
-      if other.return_type.nil_type? && arg_types == other.arg_types
-        return other
-      end
-
       nil
     end
   end


### PR DESCRIPTION
This PR:
- reverts #7527
- fixes #7698

Then it implements what #7527 was trying to accomplish in a different way.

What #7527 did was merging any two proc types with same argument types but different return types, where one return type was nil, to that return type with nil. Example:

```crystal
a = ->{ 1 }
b = ->{ nil }  # Proc(Nil)
typeof(a)      # => Proc(Int32)
typeof(b)      # => Proc(Int32)
typeof(a || b) # => Proc(Nil)
```

The problem is, it's not good to discard the information returned by `b`.

What this PR does is just allowing the assignment of such procs to instance and class variables, and local variables with a type annotation. For example:

```crystal
class Foo
  @block : -> Nil

  def initialize(block)
    @block = block
  end

  def block
    @block
  end
end

a = ->{ 1 }
b = ->{ nil }

Foo.new(a) # okay
Foo.new(b) # okay

c = a || b
typeof(c) # => Proc(Int32) | Proc(Nil)
Foo.new(c) # also okay!
```

Note that `c` preserves the real type. But when we assign it to the instance variable `@block`, which is already typed to be `Proc(Nil)`, just then the information is lost. And this is fine because, since the return type is `Nil` there's no other thing to do than losing that information.

The compiler had no such logic for this before. The only thing the compiler did, all the time was:
- if you assign to a variable, you make the union of the variable's existing type with the new type, then you assign that to the variable

So, this introduces new logic to apply just when assigning a type to a variable whose type is already determined by the user. This is the new `assign_type` method. You don't need to know about this. I'm just mentioning it here because this might feel like a cheap implementation. However, this is the **only** case need so far. If we need more special cases like this, we can refactor the code to make it a bit more generic.

Also, because the compiler will now try to do this when you specify a type, this now behaves like this:

```crystal
def foo : Proc(Nil)
  ->{ 1 }
end

typeof(foo) # => Proc(Nil)
```

Which I think is good. If you explicitly declare the return type of the Proc to be Nil, the only reason you might want to do that (other than verify the type matches) is to return such type, not a type with more information in the return type. So this would be analogous to explicitly using the `Nil` return type.

Finally, I think this is important to have in the language because the case of wanting to store callbacks is very common. In many cases callbacks don't return anything, and forcing the users to type that extra `nil` inside their procs is not nice. Also, the compiler error of that is probably not very intuitive.