### PR TITLE
Correctly support websocket close codes

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -490,7 +490,7 @@ module Crystal::Playground
         origin = context.request.headers["Origin"]
         if !accept_request?(origin)
           Log.warn { "Invalid Request Origin: #{origin}" }
-          ws.close "Invalid Request Origin"
+          ws.close HTTP::WebSocket::CloseCodes::PolicyViolation, "Invalid Request Origin"
         else
           @sessions_key += 1
           @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @port)

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -109,6 +109,7 @@ class HTTP::WebSocket
         info = @ws.receive(@buffer)
       rescue
         @on_close.try &.call("")
+        @closed = true
         break
       end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -60,7 +60,7 @@ class HTTP::WebSocket
   def on_binary(&@on_binary : Bytes ->)
   end
 
-  def on_close(&@on_close : String ->)
+  def on_close(&@on_close : Int32, String ->)
   end
 
   protected def check_open
@@ -97,10 +97,15 @@ class HTTP::WebSocket
     end
   end
 
-  def close(message = nil)
+  @[Deprecated("Use WebSocket#close(code, message) instead")]
+  def close(message)
+    close(nil, message)
+  end
+
+  def close(code : Int? = nil, message = nil)
     return if closed?
     @closed = true
-    @ws.close(message)
+    @ws.close(code, message)
   end
 
   def run
@@ -108,7 +113,7 @@ class HTTP::WebSocket
       begin
         info = @ws.receive(@buffer)
       rescue
-        @on_close.try &.call("")
+        @on_close.try &.call(CloseCodes::AbnormalClosure, "")
         @closed = true
         break
       end
@@ -143,9 +148,18 @@ class HTTP::WebSocket
       when .close?
         @current_message.write @buffer[0, info.size]
         if info.final
-          message = @current_message.to_s
-          @on_close.try &.call(message)
-          close(message)
+          @current_message.rewind
+
+          if @current_message.size >= 2
+            code = @current_message.read_bytes(UInt16, IO::ByteFormat::NetworkEndian).to_i
+          else
+            code = CloseCodes::NoStatusReceived
+          end
+          message = @current_message.gets_to_end
+
+          @on_close.try &.call(code, message)
+          close(code)
+
           @current_message.clear
           break
         end

--- a/src/http/web_socket/close_codes.cr
+++ b/src/http/web_socket/close_codes.cr
@@ -1,0 +1,17 @@
+module HTTP::WebSocket::CloseCodes
+  NormalClosure           = 1000
+  GoingAway               = 1001
+  ProtocolError           = 1002
+  UnsupportedData         = 1003
+  NoStatusReceived        = 1005
+  AbnormalClosure         = 1006
+  InvalidFramePayloadData = 1007
+  PolicyViolation         = 1008
+  MessageTooBig           = 1009
+  MandatoryExtension      = 1010
+  InternalServerError     = 1011
+  ServiceRestart          = 1012
+  TryAgainLater           = 1013
+  BadGateway              = 1014
+  TLSHandshake            = 1015
+end


### PR DESCRIPTION
The first two bytes of the message in a WebSocket Close frame is anumeric code. Make sure to always encode this correctly, to avoid being in violation of the websocket spec. Also automatically decode this for clients.

This is a breaking change since on_close now takes two arguments: close code and message, but this change is unable to be made in a backwards compatible way.

Closes #6469