### PR TITLE
Install LLVM 10 for OSX CI

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -111,8 +111,8 @@ prepare_build() {
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.33.0/crystal-0.33.0-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.33.0-1 crystal;popd'
 
-  on_osx brew install llvm@9 gmp libevent pcre openssl pkg-config
-  on_osx brew link --force llvm@9
+  on_osx brew install llvm@10 gmp libevent pcre openssl pkg-config
+  on_osx brew link --force llvm@10
   # Note: brew link --force might show:
   #   Warning: Refusing to link macOS-provided software: llvm
   #


### PR DESCRIPTION
LLVM 10 has been releases on homebrew. 

The osx ci is failing since `LLVM_CONFIG` environment variable in `test_darwin` points to a non-aliased llvm-config path. Either that path or the formula version needs to change when a new llvm formula version is released in homebrew for now.