### PR TITLE
Add missing `Regex#hash` and `Regex::MatchData#hash`

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -265,4 +265,11 @@ describe "Regex::MatchData" do
     m2.should be_truthy
     m1.should eq(m2)
   end
+
+  it "hashes" do
+    re = /(a|b)/
+    hash = re.match("a").hash
+    hash.should eq(re.match("a").hash)
+    hash.should_not eq(re.match("b").hash)
+  end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -162,4 +162,20 @@ describe "Regex" do
     regex = /foo/
     regex.clone.should be(regex)
   end
+
+  it "checks equality by ==" do
+    regex = Regex.new("foo", Regex::Options::IGNORE_CASE)
+    (regex == Regex.new("foo", Regex::Options::IGNORE_CASE)).should be_true
+    (regex == Regex.new("foo")).should be_false
+    (regex == Regex.new("bar", Regex::Options::IGNORE_CASE)).should be_false
+    (regex == Regex.new("bar")).should be_false
+  end
+
+  it "hashes" do
+    hash = Regex.new("foo", Regex::Options::IGNORE_CASE).hash
+    hash.should eq(Regex.new("foo", Regex::Options::IGNORE_CASE).hash)
+    hash.should_not eq(Regex.new("foo").hash)
+    hash.should_not eq(Regex.new("bar", Regex::Options::IGNORE_CASE).hash)
+    hash.should_not eq(Regex.new("bar").hash)
+  end
 end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -383,6 +383,13 @@ class Regex
     source == other.source && options == other.options
   end
 
+  # See `Object#hash(hasher)`
+  def hash(hasher)
+    hasher = source.hash hasher
+    hasher = options.hash hasher
+    hasher
+  end
+
   # Case equality. This is equivalent to `#match` or `#=~` but only returns
   # `true` or `false`. Used in `case` expressions. The special variable
   # `$~` will contain a `Regex::MatchData` if there was a match, `nil` otherwise.

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -377,6 +377,13 @@ class Regex
       return @ovector.memcmp(other.@ovector, size * 2) == 0
     end
 
+    # See `Object#hash(hasher)`
+    def hash(hasher)
+      hasher = regex.hash hasher
+      hasher = string.hash hasher
+      Slice.new(@ovector, size * 2).hash(hasher)
+    end
+
     private def check_index_out_of_bounds(index)
       raise_invalid_group_index(index) unless valid_group?(index)
     end


### PR DESCRIPTION
When a class has custom `==`, it should define `hash` for its custom equality.
However `Regex` and `Regex::MatchData` is missing its own `hash` method.

This PR adds `hash` method for them and also adds spec for these. Thank you.