### PR TITLE
let `crystal tool expand` find target location into the deep of `require`

### DIFF
--- a/src/compiler/crystal/tools/expand.cr
+++ b/src/compiler/crystal/tools/expand.cr
@@ -128,6 +128,23 @@ module Crystal
       @in_defs && contains_target(node)
     end
 
+    def visit(node : Require)
+      return false if node.string == "prelude"
+
+      if loc_start = node.location
+        loc_end = node.end_location || loc_start
+        if @target_location.between?(loc_start, loc_end)
+          @found_nodes << node
+          return false
+        end
+      end
+
+      # Find target location into required file.
+      # It is needed when target location is out of main file. (#6098)
+      node.expanded.try &.accept self
+      false
+    end
+
     def visit(node : Call)
       if loc_start = node.location
         # If node.obj (a.k.a. an receiver) is a Path, it may be macro call and node.obj has no expansion surely.
@@ -140,11 +157,16 @@ module Crystal
           else
             @message = "no expansion found: #{node} may not be a macro"
           end
-          false
-        else
-          contains_target(node)
+          return false
         end
       end
+
+      return true if contains_target(node)
+
+      # Find target location into macro expansion.
+      # Because macro expansion may contain `require`.
+      node.expanded.try &.accept self
+      false
     end
 
     def visit(node : MacroFor | MacroIf | MacroExpression)
@@ -152,11 +174,17 @@ module Crystal
         loc_end = node.end_location || loc_start
         if @target_location.between?(loc_start, loc_end) && node.expanded
           @found_nodes << node
-          false
-        else
-          contains_target(node)
+          return false
         end
       end
+
+      node.expanded.try &.accept self
+      false
+    end
+
+    def visit(node : Expressions | ModuleDef | ClassDef)
+      # These top-level nodes can contain `require`, so always returns `true`.
+      true
     end
 
     def visit(node)
@@ -178,7 +206,7 @@ module Crystal
       end
     end
 
-    def transform(node : MacroFor | MacroIf | MacroExpression)
+    def transform(node : Require | MacroFor | MacroIf | MacroExpression)
       if expanded = node.expanded
         self.expanded = true
         expanded


### PR DESCRIPTION
Fixed #6098

As a side effect, `crystal tool expand` can expand `require` statement now.
I think it may help us.

Example:

```console
$ cat -n test.cr
     1	macro test
     2	  def to_json
     3	    "hey"
     4	  end
     5	end
     6
     7	class Test
     8	  test
     9	end
$ cat -n main.cr
     1	require "./test"
     2	p Test.new.to_json
$ # issue is fixed.
$ bin/crystal tool expand -c test.cr:8:3 main.cr
1 expansion found
expansion 1:
   test

# expand macro 'test' (test.cr:1:1)
~> def to_json
     "hey"
   end

$ # now `require` can be expanded
$ bin/crystal tool expand -c main.cr:1:1 main.cr
1 expansion found
expansion 1:
   require "./test"

~>
   # /Users/makenowjust/Projects/github.com/MakeNowJust/crystal/test.cr
   macro test
     def to_json
       "hey"
     end
   end
   class Test
     test
   end

# expand macro 'test' (/Users/makenowjust/Projects/github.com/MakeNowJust/crystal/test.cr:1:1)
~>
   # /Users/makenowjust/Projects/github.com/MakeNowJust/crystal/test.cr
   macro test
     def to_json
       "hey"
     end
   end
   class Test
     def to_json
       "hey"
     end
   end

```

- - -

Note that spec is missing for now.
Because there are no foundation to write `tool expand` spec over multiple files currently.
How to write spec is better...?