### PR TITLE
Add `Regex#matches?` and `String#matches?`

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -95,6 +95,17 @@ describe "Regex" do
     $2.should eq("ba")
   end
 
+  describe "matches?" do
+    it "matches but create no MatchData" do
+      /f(o+)(bar?)/.matches?("fooba").should eq(true)
+      /f(o+)(bar?)/.matches?("barfo").should eq(false)
+    end
+
+    it "can specify initial position of matching" do
+      /f(o+)(bar?)/.matches?("fooba", 1).should eq(false)
+    end
+  end
+
   describe "name_table" do
     it "is a map of capture group number to name" do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1966,6 +1966,11 @@ describe "String" do
     match[0].should eq("")
   end
 
+  it "matches, but returns Bool" do
+    "foo".matches?(/foo/).should eq(true)
+    "foo".matches?(/bar/).should eq(false)
+  end
+
   it "has size (same as size)" do
     "テスト".size.should eq(3)
   end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -491,13 +491,13 @@ class Regex
   end
 
   # Match at character index. It behaves like `#match`, however it returns `Bool` value.
-  # It does not create `MatchData` and does not update `$~` also.
+  # It neither returns `MatchData` nor assigns it to the `$~` variable.
   #
   # ```
   # /foo/.matches?("bar") # => false
   # /foo/.matches?("foo") # => true
   #
-  # # `$~` is not set even if last matching is succeeded.
+  # # `$~` is not set even if last match succeeds.
   # $~ # raises Exception
   # ```
   def matches?(str, pos = 0, options = Regex::Options::None) : Bool

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -509,7 +509,7 @@ class Regex
   end
 
   # Match at byte index. It behaves like `#match_at_byte_inbdex`, however it returns `Bool` value.
-  # It does not create `MatchData` and does not update `$~` also.
+  # It neither returns `MatchData` nor assigns it to the `$~` variable.
   def matches_at_byte_index?(str, byte_index = 0, options = Regex::Options::None) : Bool
     return false if byte_index > str.bytesize
 

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -481,14 +481,36 @@ class Regex
 
     ovector_size = (@captures + 1) * 3
     ovector = Pointer(Int32).malloc(ovector_size)
-    ret = LibPCRE.exec(@re, @extra, str, str.bytesize, byte_index, (options | Options::NO_UTF8_CHECK), ovector, ovector_size)
-    if ret > 0
+    if internal_matches?(str, byte_index, options, ovector, ovector_size)
       match = MatchData.new(self, @re, str, byte_index, ovector, @captures)
     else
       match = nil
     end
 
     $~ = match
+  end
+
+  # Match at character index. It behaves like `#match`, however it does not create `MatchData`.
+  def matches?(str, pos = 0, options = Regex::Options::None) : Bool
+    if byte_index = str.char_index_to_byte_index(pos)
+      matches_at_byte_index?(str, byte_index, options)
+    else
+      false
+    end
+  end
+
+  # Match at byte index. It behaves like `#match`, however it does not create `MatchData`.
+  def matches_at_byte_index?(str, byte_index = 0, options = Regex::Options::None) : Bool
+    return false if byte_index > str.bytesize
+
+    internal_matches?(str, byte_index, options, nil, 0)
+  end
+
+  # Calls `pcre_exec` C function, and handles returning value.
+  private def internal_matches?(str, byte_index, options, ovector, ovector_size)
+    ret = LibPCRE.exec(@re, @extra, str, str.bytesize, byte_index, (options | Options::NO_UTF8_CHECK), ovector, ovector_size)
+    # TODO: when `ret < -1`, it means PCRE error. It should handle correctly.
+    ret >= 0
   end
 
   # Returns a `Hash` where the values are the names of capture groups and the

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -490,7 +490,16 @@ class Regex
     $~ = match
   end
 
-  # Match at character index. It behaves like `#match`, however it does not create `MatchData`.
+  # Match at character index. It behaves like `#match`, however it returns `Bool` value.
+  # It does not create `MatchData` and does not update `$~` also.
+  #
+  # ```
+  # /foo/.matches?("bar") # => false
+  # /foo/.matches?("foo") # => true
+  #
+  # # `$~` is not set even if last matching is succeeded.
+  # $~ # raises Exception
+  # ```
   def matches?(str, pos = 0, options = Regex::Options::None) : Bool
     if byte_index = str.char_index_to_byte_index(pos)
       matches_at_byte_index?(str, byte_index, options)
@@ -499,7 +508,8 @@ class Regex
     end
   end
 
-  # Match at byte index. It behaves like `#match`, however it does not create `MatchData`.
+  # Match at byte index. It behaves like `#match_at_byte_inbdex`, however it returns `Bool` value.
+  # It does not create `MatchData` and does not update `$~` also.
   def matches_at_byte_index?(str, byte_index = 0, options = Regex::Options::None) : Bool
     return false if byte_index > str.bytesize
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -3834,13 +3834,31 @@ class String
   end
 
   # Finds match of *regex*, starting at *pos*.
+  # It updaate `$~` by its result.
+  #
+  # ```
+  # "foo".match(/foo/) # => Regex::MatchData("foo")
+  # $~                 # => Regex::MatchData("foo")
+  #
+  # "foo".match(/bar/) # => nil
+  # $~                 # raises Exception
+  # ```
   def match(regex : Regex, pos = 0) : Regex::MatchData?
     match = regex.match self, pos
     $~ = match
     match
   end
 
-  # Finds match of *regex* like `#match`, but it does not create `MatchData`.
+  # Finds match of *regex* like `#match`, but it returns `Bool` value.
+  # It does not create `MatchData` and does not update `$~` also.
+  #
+  # ```
+  # "foo".matches?(/bar/) # => false
+  # "foo".matches?(/foo/) # => true
+  #
+  # # `$~` is not set even if last matching is succeeded.
+  # $~ # raises Exception
+  # ```
   def matches?(regex : Regex, pos = 0) : Bool
     regex.matches? self, pos
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3834,7 +3834,7 @@ class String
   end
 
   # Finds match of *regex*, starting at *pos*.
-  # It updaate `$~` by its result.
+  # It also updates `$~` with the result.
   #
   # ```
   # "foo".match(/foo/) # => Regex::MatchData("foo")
@@ -3850,13 +3850,13 @@ class String
   end
 
   # Finds match of *regex* like `#match`, but it returns `Bool` value.
-  # It does not create `MatchData` and does not update `$~` also.
+  # It neither returns `MatchData` nor assigns it to the `$~` variable.
   #
   # ```
   # "foo".matches?(/bar/) # => false
   # "foo".matches?(/foo/) # => true
   #
-  # # `$~` is not set even if last matching is succeeded.
+  # # `$~` is not set even if last match succeeds.
   # $~ # raises Exception
   # ```
   def matches?(regex : Regex, pos = 0) : Bool

--- a/src/string.cr
+++ b/src/string.cr
@@ -3840,6 +3840,11 @@ class String
     match
   end
 
+  # Finds match of *regex* like `#match`, but it does not create `MatchData`.
+  def matches?(regex : Regex, pos = 0) : Bool
+    regex.matches? self, pos
+  end
+
   # Searches the string for instances of *pattern*,
   # yielding a `Regex::MatchData` for each match.
   def scan(pattern : Regex)


### PR DESCRIPTION
Fixed #8950

It is another version of `match` method, which does not allocate `MatchData` when matched, instead it returns `true` or `false`. Avoiding allocation, it is efficient in fact.

https://github.com/crystal-lang/crystal/issues/8950#issuecomment-607516911