### PR TITLE
Base class for exceptions, not handled by default

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -47,8 +47,8 @@ describe "Code gen: cast" do
       begin
         a.as(Char)
         false
-      rescue ex
-        ex.message.not_nil!.includes?("cast from Int32 to Char failed") && (ex.class == TypeCastError)
+      rescue ex : TypeCastError
+        ex.message.not_nil!.includes?("cast from Int32 to Char failed")
       end
       )).to_b.should be_true
   end
@@ -71,8 +71,8 @@ describe "Code gen: cast" do
       begin
         a.as(Float64 | Char)
         false
-      rescue ex
-        ex.message.not_nil!.includes?("cast from Int32 to (Char | Float64) failed") && (ex.class == TypeCastError)
+      rescue ex : TypeCastError
+        ex.message.not_nil!.includes?("cast from Int32 to (Char | Float64) failed")
       end
       )).to_b.should be_true
   end
@@ -119,8 +119,8 @@ describe "Code gen: cast" do
       begin
         a.as(CastSpecBaz)
         false
-      rescue ex
-        ex.message.not_nil!.includes?("cast from CastSpecBar to CastSpecBaz failed") && (ex.class == TypeCastError)
+      rescue ex : TypeCastError
+        ex.message.not_nil!.includes?("cast from CastSpecBar to CastSpecBaz failed")
       end
       )).to_b.should be_true
   end
@@ -186,8 +186,8 @@ describe "Code gen: cast" do
       begin
         a.as(Nil)
         false
-      rescue ex
-        ex.message.not_nil!.includes?("cast from Reference to Nil failed") && (ex.class == TypeCastError)
+      rescue ex : TypeCastError
+        ex.message.not_nil!.includes?("cast from Reference to Nil failed")
       end
       )).to_b.should be_true
   end

--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -1319,4 +1319,24 @@ describe "Code gen: exception" do
       end
     ))
   end
+
+  it "default rescue doesn't handle Raisable" do
+    run(%(
+      require "prelude"
+
+      def foo
+        begin
+          begin
+            raise Raisable.new("foo")
+          rescue
+            1
+          end
+        rescue Raisable
+          2
+        end
+      end
+
+      foo
+      )).to_i.should eq(2)
+  end
 end

--- a/spec/compiler/codegen/special_vars_spec.cr
+++ b/spec/compiler/codegen/special_vars_spec.cr
@@ -29,7 +29,7 @@ describe "Codegen: special vars" do
 
         begin
           #{name}
-        rescue ex
+        rescue ex : NilAssertionError
           "ouch"
         end
         )).to_string.should eq("ouch")
@@ -49,7 +49,7 @@ describe "Codegen: special vars" do
 
         begin
           #{name}
-        rescue ex
+        rescue ex : NilAssertionError
           "ouch"
         end
         )).to_string.should eq("foo")

--- a/spec/compiler/normalize/select_spec.cr
+++ b/spec/compiler/normalize/select_spec.cr
@@ -10,7 +10,7 @@ describe "Normalize: case" do
       when 1
         baz
       else
-        ::raise("BUG: invalid select index")
+        ::raise(::UnexpectedStateError.new("BUG: invalid select index"))
       end
       CODE
   end
@@ -23,7 +23,7 @@ describe "Normalize: case" do
         x = __temp_2.as(typeof(foo))
         x + 1
       else
-        ::raise("BUG: invalid select index")
+        ::raise(::UnexpectedStateError.new("BUG: invalid select index"))
       end
       CODE
   end
@@ -48,7 +48,7 @@ describe "Normalize: case" do
         x = __temp_2.as(typeof(foo?))
         x + 1
       else
-        ::raise("BUG: invalid select index")
+        ::raise(::UnexpectedStateError.new("BUG: invalid select index"))
       end
       CODE
   end
@@ -61,7 +61,7 @@ describe "Normalize: case" do
         x = __temp_2.as(typeof(foo!))
         x + 1
       else
-        ::raise("BUG: invalid select index")
+        ::raise(::UnexpectedStateError.new("BUG: invalid select index"))
       end
       CODE
   end

--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -144,12 +144,23 @@ describe "Semantic: exception" do
       ") { nilable int32 }
   end
 
-  it "errors if catched exception is not a subclass of Exception" do
-    assert_error "begin; rescue ex : Int32; end", "Int32 is not a subclass of Exception"
+  it "errors if catched exception is not a subclass of Raisable" do
+    assert_error "begin; rescue ex : Int32; end", "Int32 is not a subclass of Exception (or Raisable)"
   end
 
-  it "errors if catched exception is not a subclass of Exception without var" do
-    assert_error "begin; rescue Int32; end", "Int32 is not a subclass of Exception"
+  it "errors if catched exception is not a subclass of Raisable without var" do
+    assert_error "begin; rescue Int32; end", "Int32 is not a subclass of Exception (or Raisable)"
+  end
+
+  it "allows rescue from Raisable exception" do
+    assert_type("
+      a = nil
+      begin
+      rescue ex : Raisable
+        a = ex
+      end
+      a
+    ") { union_of(nil_type, raisable.virtual_type) }
   end
 
   assert_syntax_error "begin; rescue ex; rescue ex : Foo; end; ex",

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -146,7 +146,7 @@ describe StringScanner, "#[]" do
     s = StringScanner.new("Fri Dec 12 1975 14:39")
     s.scan(/this is not there/)
 
-    expect_raises(Exception, "Nil assertion failed") { s[0] }
+    expect_raises(IndexError) { s[0] }
   end
 
   it "raises when there is no subgroup" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -147,11 +147,11 @@ describe "String" do
 
     it "gets with a string" do
       "FooBar"["Bar"].should eq "Bar"
-      expect_raises(Exception, "Nil assertion failed") { "FooBar"["Baz"] }
+      expect_raises(ArgumentError, "Value not found in the string") { "FooBar"["Baz"] }
     end
 
     it "gets with a char" do
-      expect_raises(Exception, "Nil assertion failed") { "foo/bar"['-'] }
+      expect_raises(ArgumentError, "Value not found in the string") { "foo/bar"['-'] }
     end
   end
 
@@ -163,7 +163,7 @@ describe "String" do
 
     it "gets with a char" do
       "foo/bar"['/'].should eq '/'
-      expect_raises(Exception, "Nil assertion failed") { "foo/bar"['-'] }
+      expect_raises(ArgumentError, "Value not found in the string") { "foo/bar"['-'] }
       "foo/bar"['/']?.should eq '/'
       "foo/bar"['-']?.should be_nil
     end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -49,7 +49,7 @@ class Channel(T)
     # wait_result_impl with the right type and Channel.select_impl
     # to allow dispatching over unions that will not happen
     def wait_result(context : SelectContext)
-      raise "BUG: Unexpected call to #{typeof(self)}#wait_result(context : #{typeof(context)})"
+      raise UnexpectedStateError.new "BUG: Unexpected call to #{typeof(self)}#wait_result(context : #{typeof(context)})"
     end
 
     def wait_result(context : SelectContext(S))
@@ -58,7 +58,7 @@ class Channel(T)
 
     # idem wait_result/wait_result_impl
     def unwait(context : SelectContext)
-      raise "BUG: Unexpected call to #{typeof(self)}#unwait(context : #{typeof(context)})"
+      raise UnexpectedStateError.new "BUG: Unexpected call to #{typeof(self)}#unwait(context : #{typeof(context)})"
     end
 
     def unwait(context : SelectContext(S))
@@ -232,7 +232,7 @@ class Channel(T)
       when DeliveryState::Closed
         raise ClosedError.new
       else
-        raise "BUG: Fiber was awaken without channel delivery state set"
+        raise UnexpectedStateError.new "BUG: Fiber was awaken without channel delivery state set"
       end
     end
 
@@ -291,7 +291,7 @@ class Channel(T)
     case state
     when DeliveryState::Delivered
       @lock.unlock
-      raise "BUG: Unexpected UseDefault value for delivered receive" if value.is_a?(UseDefault)
+      raise UnexpectedStateError.new "BUG: Unexpected UseDefault value for delivered receive" if value.is_a?(UseDefault)
       value
     when DeliveryState::Closed
       @lock.unlock
@@ -309,7 +309,7 @@ class Channel(T)
       when DeliveryState::Closed
         yield
       else
-        raise "BUG: Fiber was awaken without channel delivery state set"
+        raise UnexpectedStateError.new "BUG: Fiber was awaken without channel delivery state set"
       end
     end
   end
@@ -397,7 +397,7 @@ class Channel(T)
 
   def self.select(ops : Indexable(SelectAction))
     i, m = select_impl(ops, false)
-    raise "BUG: blocking select returned not ready status" if m.is_a?(NotReady)
+    raise UnexpectedStateError.new "BUG: blocking select returned not ready status" if m.is_a?(NotReady)
     return i, m
   end
 
@@ -470,7 +470,7 @@ class Channel(T)
       end
     end
 
-    raise "BUG: Fiber was awaken from select but no action was activated"
+    raise UnexpectedStateError.new "BUG: Fiber was awaken from select but no action was activated"
   end
 
   # :nodoc:
@@ -524,9 +524,9 @@ class Channel(T)
       when DeliveryState::Closed
         raise ClosedError.new
       when DeliveryState::None
-        raise "BUG: StrictReceiveAction.wait_result_impl called with DeliveryState::None"
+        raise UnexpectedStateError.new "BUG: StrictReceiveAction.wait_result_impl called with DeliveryState::None"
       else
-        raise "unreachable"
+        raise UnexpectedStateError.new "unreachable"
       end
     end
 
@@ -589,9 +589,9 @@ class Channel(T)
       when DeliveryState::Closed
         nil
       when DeliveryState::None
-        raise "BUG: LooseReceiveAction.wait_result_impl called with DeliveryState::None"
+        raise UnexpectedStateError.new "BUG: LooseReceiveAction.wait_result_impl called with DeliveryState::None"
       else
-        raise "unreachable"
+        raise UnexpectedStateError.new "unreachable"
       end
     end
 
@@ -649,9 +649,9 @@ class Channel(T)
       when DeliveryState::Closed
         raise ClosedError.new
       when DeliveryState::None
-        raise "BUG: SendAction.wait_result_impl called with DeliveryState::None"
+        raise UnexpectedStateError.new "BUG: SendAction.wait_result_impl called with DeliveryState::None"
       else
-        raise "unreachable"
+        raise UnexpectedStateError.new "unreachable"
       end
     end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -209,7 +209,8 @@ module Crystal
       types["Range"] = range = @range = GenericClassType.new self, self, "Range", struct_t, ["B", "E"]
       range.struct = true
 
-      types["Exception"] = @exception = NonGenericClassType.new self, self, "Exception", reference
+      types["Raisable"] = @raisable = NonGenericClassType.new self, self, "Raisable", reference
+      types["Exception"] = @exception = NonGenericClassType.new self, self, "Exception", raisable
 
       types["Enum"] = enum_t = @enum = NonGenericClassType.new self, self, "Enum", value
       abstract_value_type(enum_t)
@@ -459,7 +460,7 @@ module Crystal
 
     {% for name in %w(object no_return value number reference void nil bool char int int8 int16 int32 int64 int128
                      uint8 uint16 uint32 uint64 uint128 float float32 float64 string symbol pointer array static_array
-                     exception tuple named_tuple proc union enum range regex crystal
+                     raisable exception tuple named_tuple proc union enum range regex crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -517,7 +517,8 @@ module Crystal
       if node_else = node.else
         case_else = node_else.clone
       else
-        case_else = Call.new(nil, "raise", args: [StringLiteral.new("BUG: invalid select index")] of ASTNode, global: true).at(node)
+        exception = Call.new(Path.global("UnexpectedStateError").at(node), "new", args: [StringLiteral.new("BUG: invalid select index")] of ASTNode).at(node)
+        case_else = Call.new(nil, "raise", args: [exception] of ASTNode, global: true).at(node)
       end
 
       call_name = node.else ? "non_blocking_select" : "select"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2689,8 +2689,8 @@ module Crystal
         types = node_types.map do |type|
           type.accept self
           instance_type = type.type.instance_type
-          unless instance_type.implements?(@program.exception)
-            type.raise "#{instance_type} is not a subclass of Exception"
+          unless instance_type.implements?(@program.raisable)
+            type.raise "#{instance_type} is not a subclass of Exception (or Raisable)"
           end
           instance_type
         end

--- a/src/crystal/at_exit_handlers.cr
+++ b/src/crystal/at_exit_handlers.cr
@@ -2,7 +2,7 @@
 module Crystal::AtExitHandlers
   @@running = false
 
-  private class_getter(handlers) { [] of Int32, ::Exception? -> }
+  private class_getter(handlers) { [] of Int32, ::Raisable? -> }
 
   def self.add(handler)
     raise "Cannot use at_exit from an at_exit handler" if @@running

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -38,7 +38,7 @@ module Crystal
       begin
         yield
         0
-      rescue ex
+      rescue ex : Raisable
         1
       end
 
@@ -90,7 +90,7 @@ module Crystal
     main do
       main_user_code(argc, argv)
     end
-  rescue ex
+  rescue ex : Raisable
     Crystal::System.print_exception "Unhandled exception", ex
     1
   end

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -6,7 +6,7 @@ class Thread
   protected class_getter(threads) { Thread::LinkedList(Thread).new }
 
   @th : LibC::PthreadT
-  @exception : Exception?
+  @exception : Raisable?
   @detached = Atomic(UInt8).new(0)
   @main_fiber : Fiber?
 
@@ -125,7 +125,7 @@ class Thread
 
     begin
       @func.call
-    rescue ex
+    rescue ex : Raisable
       @exception = ex
     ensure
       Thread.threads.delete(self)

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -5,7 +5,7 @@ class Thread
   # all thread objects, so the GC can see them (it doesn't scan thread locals)
   @@threads = Thread::LinkedList(Thread).new
 
-  @exception : Exception?
+  @exception : Raisable?
   @detached = Atomic(UInt8).new(0)
   @main_fiber : Fiber?
 
@@ -57,7 +57,7 @@ class Thread
 
     begin
       @func.call
-    rescue ex
+    rescue ex : Raisable
       @exception = ex
     ensure
       @@threads.delete(self)

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -3,6 +3,12 @@ require "system_error"
 
 CallStack.skip(__FILE__)
 
+# This alias is defined to make the standard library code compatible with
+# Crystal version < 0.34 and should be removed after the release of 0.34
+{% unless @type.has_constant?("Raisable") %}
+  alias Raisable = Exception
+{% end %}
+
 # Represents errors that occur during application execution.
 #
 # Exception and its descendants are used to communicate between raise and
@@ -11,15 +17,15 @@ CallStack.skip(__FILE__)
 # exception’s class name), an optional descriptive string, and
 # optional traceback information.
 # Exception subclasses may add additional information.
-class Exception
+class Raisable
   getter message : String?
   # Returns the previous exception at the time this exception was raised.
   # This is useful for wrapping exceptions and retaining the original
   # exception information.
-  getter cause : Exception?
+  getter cause : Raisable?
   property callstack : CallStack?
 
-  def initialize(@message : String? = nil, @cause : Exception? = nil)
+  def initialize(@message : String? = nil, @cause : Raisable? = nil)
   end
 
   # Returns any backtrace associated with the exception.

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -11,12 +11,20 @@ CallStack.skip(__FILE__)
 
 # Represents errors that occur during application execution.
 #
-# Exception and its descendants are used to communicate between raise and
+# Raisable and its descendants are used to communicate between raise and
 # rescue statements in `begin ... end` blocks.
-# Exception objects carry information about the exception – its type (the
+# Raisable objects carry information about the exception – its type (the
 # exception’s class name), an optional descriptive string, and
 # optional traceback information.
-# Exception subclasses may add additional information.
+# Raisable subclasses may add additional information.
+# Raisable objects that are not subclasses of `Exception` are not handled
+# by default on a `rescue` statement, and the type must be explicitly specified:
+# ```
+# begin
+#   raise Raisable.new
+# rescue Raisable
+# end
+# ```
 class Raisable
   getter message : String?
   # Returns the previous exception at the time this exception was raised.
@@ -74,6 +82,21 @@ class Raisable
 
     io.flush
   end
+end
+
+# The base class for most common errors that might be handled at runtime
+#
+# Instances of this class (and subclasses) are handled by `rescue` statements
+# without types.
+#
+# ```
+# begin
+#   # ...
+# rescue
+#   # Any exception of `Exception` class is handled here
+# end
+# ```
+class Exception
 end
 
 # Raised when the given index is invalid.

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -198,3 +198,7 @@ end
 class RuntimeError < Exception
   include SystemError
 end
+
+# Raised when there is an inconsistent or unreachable state
+class UnexpectedStateError < Raisable
+end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -104,7 +104,7 @@ end
 # ```
 # [1, "hi"][1].as(Int32) # raises TypeCastError (cast to Int32 failed)
 # ```
-class TypeCastError < Exception
+class TypeCastError < Raisable
   def initialize(message = "Type Cast error")
     super(message)
   end
@@ -154,7 +154,7 @@ end
 #
 # This can be used either to stub out method bodies, or when the method is not
 # implemented on the current platform.
-class NotImplementedError < Exception
+class NotImplementedError < Raisable
   def initialize(item)
     super("Not Implemented: #{item}")
   end
@@ -165,7 +165,7 @@ end
 # ```
 # "hello".index('x').not_nil! # raises NilAssertionError ("hello" does not contain 'x')
 # ```
-class NilAssertionError < Exception
+class NilAssertionError < Raisable
   def initialize(message = "Nil assertion failed")
     super(message)
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -129,7 +129,7 @@ class Fiber
   def run
     GC.unlock_read
     @proc.call
-  rescue ex
+  rescue ex : Raisable
     if name = @name
       STDERR.print "Unhandled exception in spawn(name: #{name}): "
     else

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -467,7 +467,7 @@ end
 # passed as the second argument to the block, if the program terminates
 # normally or `exit(status)` is called explicitly, then the second argument
 # will be `nil`.
-def at_exit(&handler : Int32, Exception? ->) : Nil
+def at_exit(&handler : Int32, Raisable? ->) : Nil
   Crystal::AtExitHandlers.add(handler)
 end
 

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -30,8 +30,8 @@ struct Log::Entry
   getter message : String
   getter timestamp = Time.local
   getter context = Log.context
-  getter exception : Exception?
+  getter exception : Raisable?
 
-  def initialize(@source : String, @severity : Severity, @message : String, @exception : Exception?)
+  def initialize(@source : String, @severity : Severity, @message : String, @exception : Raisable?)
   end
 end

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -43,7 +43,7 @@ class Log
                              } %}
 
     # Logs a message if the logger's current severity is lower or equal to `{{severity}}`.
-    def {{method.id}}(*, exception : Exception? = nil)
+    def {{method.id}}(*, exception : Raisable? = nil)
       return unless backend = @backend
       severity = Severity.new({{severity}})
       return unless level <= severity

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -37,7 +37,7 @@ class Log
 
   {% for method in %i(debug verbose info warn error fatal) %}
     # See `Log#{{method.id}}`.
-    def self.{{method.id}}(*, exception : Exception? = nil)
+    def self.{{method.id}}(*, exception : Raisable? = nil)
       Top.{{method.id}}(exception: exception) do
         yield
       end

--- a/src/process.cr
+++ b/src/process.cr
@@ -225,7 +225,7 @@ class Process
         File.open(File::NULL, "w")
       end
     else
-      raise "BUG: impossible type in ExecStdio #{stdio.class}"
+      raise UnexpectedStateError.new "BUG: impossible type in ExecStdio #{stdio.class}"
     end
   end
 
@@ -322,7 +322,7 @@ class Process
       when STDERR
         @error, fork_io = IO.pipe(write_blocking: true)
       else
-        raise "BUG: unknown destination io #{dst_io}"
+        raise UnexpectedStateError.new "BUG: unknown destination io #{dst_io}"
       end
 
       fork_io
@@ -335,7 +335,7 @@ class Process
         File.open(File::NULL, "w")
       end
     else
-      raise "BUG: impossible type in stdio #{stdio.class}"
+      raise UnexpectedStateError.new "BUG: impossible type in stdio #{stdio.class}"
     end
   end
 
@@ -411,7 +411,7 @@ class Process
     if channel = @channel
       channel
     else
-      raise "BUG: Notification channel was not initialized for this process"
+      raise UnexpectedStateError.new "BUG: Notification channel was not initialized for this process"
     end
   end
 

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -104,7 +104,7 @@ end
   #
   # This will set the exception's callstack if it hasn't been already.
   # Re-raising a previously catched exception won't replace the callstack.
-  def raise(exception : Exception) : NoReturn
+  def raise(exception : Raisable) : NoReturn
     {% if flag?(:debug_raise) %}
       STDERR.puts
       STDERR.puts "Attempting to raise: "
@@ -207,7 +207,7 @@ end
   #
   # This will set the exception's callstack if it hasn't been already.
   # Re-raising a previously catched exception won't replace the callstack.
-  def raise(exception : Exception) : NoReturn
+  def raise(exception : Raisable) : NoReturn
     {% if flag?(:debug_raise) %}
       STDERR.puts
       STDERR.puts "Attempting to raise: "

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -333,7 +333,7 @@ fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
       stack_top = Pointer(Void).new(Fiber.current.@stack.address - 4096)
       stack_bottom = Fiber.current.@stack_bottom
       stack_top <= addr < stack_bottom
-    rescue e
+    rescue e : Raisable
       Crystal::System.print_error "Error while trying to determine if a stack overflow has occurred. Probable memory corruption\n"
       false
     end

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -21,7 +21,7 @@ module Spec
     file : String,
     line : Int32,
     elapsed : Time::Span?,
-    exception : Exception?
+    exception : Raisable?
 
   # :nodoc:
   def self.root_context

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -51,7 +51,7 @@ module Spec
     rescue ex : Spec::AssertionFailed
       @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
       Spec.abort! if Spec.fail_fast?
-    rescue ex
+    rescue ex : Raisable
       @parent.report(:error, description, file, line, Time.monotonic - start, ex)
       Spec.abort! if Spec.fail_fast?
     ensure

--- a/src/string.cr
+++ b/src/string.cr
@@ -838,15 +838,15 @@ class String
   end
 
   def [](str : String | Char)
-    self[str]?.not_nil!
+    self[str]? || raise ArgumentError.new("Value not found in the string")
   end
 
   def [](regex : Regex)
-    self[regex]?.not_nil!
+    self[regex]? || raise ArgumentError.new("Value didn't match in the string")
   end
 
   def [](regex : Regex, group)
-    self[regex, group]?.not_nil!
+    self[regex, group]? || raise ArgumentError.new("Value didn't match in the string")
   end
 
   def char_at(index : Int)

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -201,7 +201,7 @@ class StringScanner
   # s["day"]      # => "12"
   # ```
   def [](n)
-    @last_match.not_nil![n]
+    (@last_match || raise IndexError.new)[n]
   end
 
   # Returns the nilable *n*-th subgroup in the most recent match.


### PR DESCRIPTION
This was a feature that was requested many times and initially I was against it, but lately we found some use cases where it might come handy.

Until now any exception raised in the program could be handled with a `begin/rescue` without types. In other words, an `rescue` statement handles, by default, any subclass of `Exception` class.

With this PR, there is now a `Raisable` where `Exception` inherits from. The `rescue` statements without types still handle only `Exception` instances. So in order to handle other exceptions, an explicit type must be specified.

Some already existing exceptions extends now from `Raisable`: `TypeCastError`, `NotImplementedError` and `NilAssertionError`. There are exceptions that normally shouldn't be handled in any program and they necessarily indicate a bug in the source code. There is a new exception type `UnexpectedStateError`, also extending from `Raisable`, useful for unreachable or inconsistent sates. These exceptions are normally errors that cannot be just ignored and retried. They should either crash the program or be logged with a big red flag.

Although this is a breaking change, most programs should continue running normally without changes.
