### PR TITLE
Make `SemanticVersion::Prerelease` comparable

### DIFF
--- a/spec/std/semantic_version_spec.cr
+++ b/spec/std/semantic_version_spec.cr
@@ -42,4 +42,21 @@ describe SemanticVersion do
       pair[0].should eq(pair[1])
     end
   end
+
+  describe SemanticVersion::Prerelease do
+    it "compares <" do
+      sprereleases = %w[
+        alpha.1
+        beta.1
+        beta.2
+      ]
+      prereleases = sprereleases.map { |s|
+        SemanticVersion::Prerelease.parse(s)
+      }
+
+      prereleases.each_cons(2) do |pair|
+        pair[0].should be < pair[1]
+      end
+    end
+  end
 end

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -109,6 +109,8 @@ struct SemanticVersion
 
   # Contains the pre-release version related to this semantic version
   struct Prerelease
+    include Comparable(self)
+
     # Parses a `Prerelease` from the given pre-release version string
     #
     # ```


### PR DESCRIPTION
There is no reason that `SemanticVersion::Prerelease` does not include `Comparable`.