### PR TITLE
Add Indexable#reverse_map

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -924,6 +924,12 @@ describe "Array" do
     a.should eq([2, 4, 6])
   end
 
+  it "does reverse_map" do
+    a = [1, 2, 3]
+    a.reverse_map { |x| x * 2 }.should eq([6, 4, 2])
+    a.should eq([1, 2, 3])
+  end
+
   describe "pop" do
     it "pops when non empty" do
       a = [1, 2, 3]

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -422,6 +422,12 @@ describe "Slice" do
     a.to_unsafe.should eq(b.to_unsafe)
   end
 
+  it "does reverse_map" do
+    a = Slice[1, 2, 3]
+    b = a.reverse_map { |x| x * 2 }
+    b.should eq(Slice[6, 4, 2])
+  end
+
   it "does map_with_index" do
     a = Slice[1, 1, 2, 2]
     b = a.map_with_index { |e, i| e + i }

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -109,6 +109,12 @@ describe "StaticArray" do
     a[2].should eq(1)
   end
 
+  it "does reverse_map" do
+    a = StaticArray[0, 1, 2]
+    b = a.reverse_map { |e| e * 2 }
+    b.should eq(StaticArray[4, 2, 0])
+  end
+
   it "does map" do
     a = StaticArray[0, 1, 2]
     b = a.map { |e| e * 2 }

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -219,6 +219,12 @@ describe "Tuple" do
     tuple2.should eq({11, 12, 14, 15})
   end
 
+  it "does reverse_map" do
+    tuple = {1, 2, 3}
+    tuple.reverse_map { |x| x * 2 }.should eq({6, 4, 2})
+    tuple.should eq({1, 2, 3})
+  end
+
   it "does reverse" do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -1596,6 +1596,11 @@ class Array(T)
     self
   end
 
+  # Optimized version of `Enumerable#reverse_map`.
+  def reverse_map(&block : T -> U) forall U
+    Array(U).new(size) { |i| yield @buffer[size - i - 1] }
+  end
+
   def rotate!(n = 1)
     return self if size == 0
     n %= size

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -204,6 +204,19 @@ module Indexable(T)
     ItemIterator(self, T).new(self)
   end
 
+  # Same as `#map`, but returns an `Array` with results in reverse.
+  #
+  # ```
+  # [1, 2, 3].reverse_map { |i| i * 10 } # => [30, 20, 10]
+  # ```
+  def reverse_map(& : T -> U) forall U
+    ary = [] of U
+    (size - 1).downto(0) do |i|
+      ary << yield unsafe_fetch(i)
+    end
+    ary
+  end
+
   # Calls the given block once for `count` number of elements in `self`
   # starting from index `start`, passing each element as a parameter.
   #

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -292,6 +292,16 @@ struct Slice(T)
     self
   end
 
+  # Returns a new slice where elements are mapped in reverse order by the given block.
+  #
+  # ```
+  # slice = Slice[1, 2.5, "a"]
+  # slice.reverse_map &.to_s # => Slice["a", "2.5", "1"]
+  # ```
+  def reverse_map(*, read_only = false, &block : T -> U) forall U
+    Slice.new(size, read_only: read_only) { |i| yield @pointer[size - i - 1] }
+  end
+
   def shuffle!(random = Random::DEFAULT)
     check_writable
 

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -236,6 +236,16 @@ struct StaticArray(T, N)
     self
   end
 
+  # Returns a new static array where elements are mapped in reverse order by the given block.
+  #
+  # ```
+  # slice = StaticArray[1, 2.5, "a"]
+  # slice.reverse_map &.to_s # => StaticArray["a", "2.5", "1"]
+  # ```
+  def reverse_map(&block : T -> U) forall U
+    StaticArray(U, N).new { |i| yield to_unsafe[size - i - 1] }
+  end
+
   # Returns a slice that points to the elements of this static array.
   # Changes made to the returned slice also affect this static array.
   #

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -475,6 +475,22 @@ struct Tuple
     nil
   end
 
+  # Returns a new tuple where elements are reverse mapped by the given block.
+  #
+  # ```
+  # tuple = {1, 2.5, "a"}
+  # tuple.reverse_map &.to_s # => {"a", "2.5", "1"}
+  # ```
+  def reverse_map
+    {% begin %}
+      Tuple.new(
+        {% for i in 0...T.size %}
+          (yield self[{{T.size - i - 1}}]),
+        {% end %}
+      )
+   {% end %}
+  end
+
   # Returns the first element of this tuple. Doesn't compile
   # if the tuple is empty.
   #


### PR DESCRIPTION
Create `Indexable#reverse_map` which avoids an intermediate allocation.

Here's a [gist with benchmarks](https://gist.github.com/caspiano/9d2b20a6b49586592cd9f826ddb77722)