### PR TITLE
Add `Enumerable#first` with fallback block

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -781,7 +781,7 @@ describe "Array" do
     end
 
     it "raises when empty" do
-      expect_raises IndexError do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).first
       end
     end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -315,7 +315,7 @@ describe "Deque" do
     end
 
     it "raises when empty" do
-      expect_raises IndexError do
+      expect_raises Enumerable::EmptyError do
         Deque(Int32).new.first
       end
     end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -443,6 +443,10 @@ describe "Enumerable" do
   end
 
   describe "first" do
+    it "calls block if empty" do
+      (1...1).first { 10 }.should eq(10)
+    end
+
     it "gets first" do
       (1..3).first.should eq(1)
     end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -481,6 +481,11 @@ module Enumerable(T)
 
   # Returns the first element in the collection,
   # or the given block's value.
+  #
+  # ```
+  # ([1, 2, 3]).first { 4 }   # => 1
+  # ([] of Int32).first { 4 } # => 4
+  # ```
   def first
     each { |e| return e }
     yield
@@ -488,12 +493,22 @@ module Enumerable(T)
 
   # Returns the first element in the collection. Raises `Enumerable::EmptyError`
   # if the collection is empty.
+  #
+  # ```
+  # ([1, 2, 3]).first   # => 1
+  # ([] of Int32).first # raises Enumerable::EmptyError
+  # ```
   def first
     first { raise Enumerable::EmptyError.new }
   end
 
   # Returns the first element in the collection.
   # When the collection is empty, returns `nil`.
+  #
+  # ```
+  # ([1, 2, 3]).first?   # => 1
+  # ([] of Int32).first? # => nil
+  # ```
   def first?
     first { nil }
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -480,7 +480,7 @@ module Enumerable(T)
   end
 
   # Returns the first element in the collection,
-  # or the given block's value.
+  # If the collection is empty, calls the block and returns its value.
   #
   # ```
   # ([1, 2, 3]).first { 4 }   # => 1

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -479,18 +479,23 @@ module Enumerable(T)
     if_none
   end
 
+  # Returns the first element in the collection,
+  # or the given block's value.
+  def first
+    each { |e| return e }
+    yield
+  end
+
   # Returns the first element in the collection. Raises `Enumerable::EmptyError`
   # if the collection is empty.
   def first
-    each { |e| return e }
-    raise Enumerable::EmptyError.new
+    first { raise Enumerable::EmptyError.new }
   end
 
   # Returns the first element in the collection.
   # When the collection is empty, returns `nil`.
   def first?
-    each { |e| return e }
-    nil
+    first { nil }
   end
 
   # Returns a new array with the concatenated results of running the block

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -434,16 +434,6 @@ module Indexable(T)
     true
   end
 
-  # Returns the first element of `self` if it's not empty, or raises `IndexError`.
-  #
-  # ```
-  # ([1, 2, 3]).first   # => 1
-  # ([] of Int32).first # raises IndexError
-  # ```
-  def first
-    first { raise IndexError.new }
-  end
-
   # Returns the first element of `self` if it's not empty, or the given block's value.
   #
   # ```
@@ -452,16 +442,6 @@ module Indexable(T)
   # ```
   def first
     size == 0 ? yield : unsafe_fetch(0)
-  end
-
-  # Returns the first element of `self` if it's not empty, or `nil`.
-  #
-  # ```
-  # ([1, 2, 3]).first?   # => 1
-  # ([] of Int32).first? # => nil
-  # ```
-  def first?
-    first { nil }
   end
 
   # See `Object#hash(hasher)`

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -434,12 +434,7 @@ module Indexable(T)
     true
   end
 
-  # Returns the first element of `self` if it's not empty, or the given block's value.
-  #
-  # ```
-  # ([1, 2, 3]).first { 4 }   # => 1
-  # ([] of Int32).first { 4 } # => 4
-  # ```
+  # :inherited:
   def first
     size == 0 ? yield : unsafe_fetch(0)
   end


### PR DESCRIPTION
Such a method exists in `Indexable`, but not in `Enumerable`.
It simplify `first`/`first?` implementation a bit.