### PR TITLE
Fix {Array, Deque, Hash}#== and #hash for recursive data

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1,6 +1,6 @@
 require "spec"
 
-private alias RecursiveArray = Array(RecursiveArray)
+private alias RecursiveArray = Array(RecursiveArray) | Int32
 
 private class BadSortingClass
   include Comparable(self)
@@ -71,6 +71,16 @@ describe "Array" do
       (a == b).should be_true
       (b == c).should be_false
       (a == d).should be_false
+    end
+
+    it "compares recurisve" do
+      a = [] of RecursiveArray
+      b = [] of RecursiveArray
+      a << b
+      b << a
+      (a == b).should be_true
+      b << 1
+      (a == b).should be_false
     end
   end
 
@@ -807,10 +817,20 @@ describe "Array" do
     end
   end
 
-  it "does hash" do
-    a = [1, 2, [3]]
-    b = [1, 2, [3]]
-    a.hash.should eq(b.hash)
+  describe "hash" do
+    it "hashes" do
+      a = [1, 2, [3]]
+      b = [1, 2, [3]]
+      a.hash.should eq(b.hash)
+    end
+
+    it "hashes recursive" do
+      a = [] of RecursiveArray
+      b = [] of RecursiveArray
+      a << b
+      b << a
+      a.hash.should eq(b.hash)
+    end
   end
 
   describe "index" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -34,7 +34,7 @@ private class DequeTester
   end
 end
 
-private alias RecursiveDeque = Deque(RecursiveDeque)
+private alias RecursiveDeque = Deque(RecursiveDeque) | Int32
 
 describe "Deque" do
   describe "implementation" do
@@ -144,6 +144,16 @@ describe "Deque" do
       (a == b).should be_true
       (b == c).should be_false
       (a == d).should be_false
+    end
+
+    it "compares recursive" do
+      a = Deque(RecursiveDeque).new
+      b = Deque(RecursiveDeque).new
+      a << b
+      b << a
+      (a == b).should be_true
+      b << 1
+      (a == b).should be_false
     end
   end
 
@@ -332,10 +342,20 @@ describe "Deque" do
     end
   end
 
-  it "does hash" do
-    a = Deque{1, 2, Deque{3}}
-    b = Deque{1, 2, Deque{3}}
-    a.hash.should eq(b.hash)
+  describe "hash" do
+    it "hashes" do
+      a = Deque{1, 2, Deque{3}}
+      b = Deque{1, 2, Deque{3}}
+      a.hash.should eq(b.hash)
+    end
+
+    it "hashes recursive" do
+      a = Deque(RecursiveDeque).new
+      b = Deque(RecursiveDeque).new
+      a << b
+      b << a
+      a.hash.should eq(b.hash)
+    end
   end
 
   describe "insert" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -86,6 +86,14 @@ describe "Hash" do
       b = { {1 => 2} => 3 }
       a.should eq(b)
     end
+
+    it "compares recursive" do
+      a = {} of RecursiveHash => RecursiveHash
+      b = {} of RecursiveHash => RecursiveHash
+      a[b] = b
+      b[a] = a
+      (a == b).should be_true
+    end
   end
 
   describe "[]" do
@@ -870,15 +878,25 @@ describe "Hash" do
     h.should eq({5 => 6})
   end
 
-  it "computes hash" do
-    h1 = { {1 => 2} => {3 => 4} }
-    h2 = { {1 => 2} => {3 => 4} }
-    h1.hash.should eq(h2.hash)
+  describe "hash" do
+    it "hashes" do
+      h1 = { {1 => 2} => {3 => 4} }
+      h2 = { {1 => 2} => {3 => 4} }
+      h1.hash.should eq(h2.hash)
 
-    h3 = {1 => 2, 3 => 4}
-    h4 = {3 => 4, 1 => 2}
+      h3 = {1 => 2, 3 => 4}
+      h4 = {3 => 4, 1 => 2}
 
-    h3.hash.should eq(h4.hash)
+      h3.hash.should eq(h4.hash)
+    end
+
+    it "hashes recursive" do
+      a = {} of RecursiveHash => RecursiveHash
+      b = {} of RecursiveHash => RecursiveHash
+      a[b] = b
+      b[a] = a
+      a.hash.should eq(b.hash)
+    end
   end
 
   it "fetches from empty hash with default value" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -163,12 +163,24 @@ class Array(T)
   # ary == [2, 3]    # => false
   # ```
   def ==(other : Array)
-    equals?(other) { |x, y| x == y }
+    exec_recursive_pair(:==, other) do
+      return false unless equals?(other) { |x, y| x == y }
+    end
+
+    true
   end
 
   # :nodoc:
   def ==(other)
     false
+  end
+
+  # See `Object#hash(hasher)`
+  def hash(hasher)
+    # TODO: it returns same hash value when an array is recursive.
+    # While `Hash` works fine, but it is inefficient.
+    exec_recursive_outer(:hash) { hasher = super(hasher) }
+    hasher
   end
 
   # Combined comparison operator.

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -109,12 +109,24 @@ class Deque(T)
   # deq == Deque{2, 3}    # => false
   # ```
   def ==(other : Deque)
-    equals?(other) { |x, y| x == y }
+    exec_recursive_pair(:==, other) do
+      return false unless equals?(other) { |x, y| x == y }
+    end
+
+    true
   end
 
   # :nodoc:
   def ==(other)
     false
+  end
+
+  # See `Object#hash(hasher)`
+  def hash(hasher)
+    # TODO: it returns same hash value when an array is recursive.
+    # While `Hash` works fine, but it is inefficient.
+    exec_recursive_outer(:hash) { hasher = super(hasher) }
+    hasher
   end
 
   # Concatenation. Returns a new `Deque` built by concatenating

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -136,6 +136,76 @@ class Reference
   # :nodoc:
   module ExecRecursive
     alias Registry = Hash({UInt64, Symbol}, Bool)
+    alias Outers = Hash(Symbol, Bool)
+
+    class OuterSignal < Exception
+    end
+
+    {% if flag?(:preview_mt) %}
+      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
+      @@outers = Crystal::ThreadLocalValue(Outers).new
+    {% else %}
+      @@exec_recursive = Registry.new
+      @@outers = Outers.new
+    {% end %}
+
+    def self.hash
+      {% if flag?(:preview_mt) %}
+        @@exec_recursive.get { Registry.new }
+      {% else %}
+        @@exec_recursive
+      {% end %}
+    end
+
+    def self.outers
+      {% if flag?(:preview_mt) %}
+        @@outers.get { Outers.new }
+      {% else %}
+        @@outers
+      {% end %}
+    end
+  end
+
+  private def exec_recursive(method)
+    hash = ExecRecursive.hash
+    key = {object_id, method}
+    if hash[key]?
+      false
+    else
+      hash[key] = true
+      begin
+        yield
+      ensure
+        hash.delete(key)
+      end
+      true
+    end
+  end
+
+  private def exec_recursive_outer(method)
+    outers = ExecRecursive.outers
+    outmost = !outers[method]?
+
+    unless outmost
+      unless exec_recursive(method) { yield }
+        raise ExecRecursive::OuterSignal.new
+      end
+      return true
+    end
+
+    outers[method] = true
+    begin
+      exec_recursive(method) { yield }
+    rescue ExecRecursive::OuterSignal
+      return false
+    ensure
+      outers.delete method
+    end
+  end
+
+  # :nodoc:
+  module ExecRecursivePair
+    alias Registry = Hash({UInt64, UInt64, Symbol}, Bool)
 
     {% if flag?(:preview_mt) %}
       @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
@@ -152,15 +222,19 @@ class Reference
     end
   end
 
-  private def exec_recursive(method)
-    hash = ExecRecursive.hash
-    key = {object_id, method}
+  private def exec_recursive_pair(method, pair)
+    hash = ExecRecursivePair.hash
+    pair_id = pair.object_id
+    key = {object_id, pair_id, method}
     if hash[key]?
       false
     else
       hash[key] = true
-      value = yield
-      hash.delete(key)
+      begin
+        yield
+      ensure
+        hash.delete key
+      end
       true
     end
   end


### PR DESCRIPTION
`Reference#recursive_exec_pair` is added for `#==`, and `Reference#recursive_exec_outer` is added for `#hash`.

Now, `==` works for recursive collections and they can store to `Hash` as key, then this example works:

```crystal
alias Rec = Array(Rec)

a = [] of Rec
b = [] of Rec
c = [] of Rec

a << b
b << a
c << c << c

p! a == b # => true
p! a == c # => false

hash = {} of Rec => Int32
hash[a] = 1
hash[b] = 2
hash[c] = 3

p! hash # => {[[[...]]] => 2, [[...], [...]] => 3}
```

Note that such example works fine in Ruby also, so I think Crystal should support recursive collection equality and hashing.

Thank you.