### PR TITLE
Rename Process kill methods to signal [by @jan-zajic]

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -224,20 +224,6 @@ describe Process do
     process.terminated?.should be_true
   end
 
-  it "checks for existence after terminate" do
-    process = Process.new("yes")
-    process.exists?.should be_true
-    process.terminated?.should be_false
-
-    process.terminate
-    process.exists?.should be_true
-    process.terminated?.should be_false
-
-    process.wait
-    process.exists?.should be_false
-    process.terminated?.should be_true
-  end
-
   describe "executable_path" do
     it "searches executable" do
       Process.executable_path.should be_a(String | Nil)

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -155,24 +155,24 @@ describe Process do
     end
   end
 
-  describe "kill" do
+  describe "signal" do
     it "kills a process" do
       process = Process.new("yes")
-      process.kill(Signal::KILL).should be_nil
+      process.signal(Signal::KILL).should be_nil
     end
 
     it "kills many process" do
       process1 = Process.new("yes")
       process2 = Process.new("yes")
-      process1.kill(Signal::KILL).should be_nil
-      process2.kill(Signal::KILL).should be_nil
+      process1.signal(Signal::KILL).should be_nil
+      process2.signal(Signal::KILL).should be_nil
     end
   end
 
   it "gets the pgid of a process id" do
     process = Process.new("yes")
     Process.pgid(process.pid).should be_a(Int32)
-    process.kill(Signal::KILL)
+    process.signal(Signal::KILL)
     Process.pgid.should eq(Process.pgid(Process.pid))
   end
 
@@ -219,6 +219,20 @@ describe Process do
     process.terminated?.should be_false
 
     # Reap, gone now
+    process.wait
+    process.exists?.should be_false
+    process.terminated?.should be_true
+  end
+
+  it "checks for existence after terminate" do
+    process = Process.new("yes")
+    process.exists?.should be_true
+    process.terminated?.should be_false
+
+    process.terminate
+    process.exists?.should be_true
+    process.terminated?.should be_false
+
     process.wait
     process.exists?.should be_false
     process.terminated?.should be_true

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -214,7 +214,7 @@ describe Process do
     process.terminated?.should be_false
 
     # Kill, zombie now
-    process.kill
+    process.signal(Signal::KILL)
     process.exists?.should be_true
     process.terminated?.should be_false
 
@@ -222,6 +222,15 @@ describe Process do
     process.wait
     process.exists?.should be_false
     process.terminated?.should be_true
+  end
+
+  it "terminates the process" do
+    process = Process.new("yes")
+    process.exists?.should be_true
+    process.terminated?.should be_false
+
+    process.terminate
+    process.wait
   end
 
   describe "executable_path" do

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -11,7 +11,7 @@ describe "Signal" do
     Signal::USR1.trap do
       ran = true
     end
-    Process.kill Signal::USR1, Process.pid
+    Process.signal Signal::USR1, Process.pid
     10.times do |i|
       break if ran
       sleep 0.1
@@ -21,7 +21,7 @@ describe "Signal" do
 
   it "ignores a signal" do
     Signal::USR2.ignore
-    Process.kill Signal::USR2, Process.pid
+    Process.signal Signal::USR2, Process.pid
   end
 
   it "CHLD.reset sets default Crystal child handler" do

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -163,7 +163,7 @@ module Crystal::Playground
         Log.info { "Code execution killed (session=#{@session_key}, filename=#{@running_process_filename})." }
         @process = nil
         File.delete @running_process_filename rescue nil
-        process.kill rescue nil
+        process.terminate rescue nil
       end
     end
 

--- a/src/concurrent/future.cr
+++ b/src/concurrent/future.cr
@@ -126,7 +126,7 @@ end
 # Calling `get` before the delay has elapsed results in the call waiting for the delay
 # to fully elapse and compute to next finish, then the value is returned.
 # ```
-# d = delay(1) { Process.kill(Signal::KILL, Process.pid) }
+# d = delay(1) { Process.signal(Signal::KILL, Process.pid) }
 # # ... long operations ...
 # d.cancel
 # ```

--- a/src/process.cr
+++ b/src/process.cr
@@ -44,7 +44,7 @@ class Process
     nil
   end
 
-  # Sends a *signal* to the process identified by the given *pid*.
+  # Sends *signal* to the process identified by *pid*.
   def self.signal(signal : Signal, pid : Int) : Nil
     ret = LibC.kill(pid, signal.value)
     raise RuntimeError.from_errno("kill") if ret < 0

--- a/src/process.cr
+++ b/src/process.cr
@@ -394,7 +394,7 @@ class Process
     close_io @error
   end
 
-  # Ask process for terminate gracefully
+  # Asks the process to terminate gracefully
   def terminate
     signal Signal::TERM
   end

--- a/src/process.cr
+++ b/src/process.cr
@@ -356,7 +356,7 @@ class Process
     signal sig
   end
 
-  # Sends *signal* to the process.
+  # Sends *signal* to this process.
   def signal(signal : Signal)
     Process.signal signal, @pid
   end
@@ -394,7 +394,7 @@ class Process
     close_io @error
   end
 
-  # Asks the process to terminate gracefully
+  # Asks this process to terminate gracefully
   def terminate
     signal Signal::TERM
   end

--- a/src/process.cr
+++ b/src/process.cr
@@ -36,12 +36,18 @@ class Process
   end
 
   # Sends a *signal* to the processes identified by the given *pids*.
+  @[Deprecated("Use #signal instead")]
   def self.kill(signal : Signal, *pids : Int)
     pids.each do |pid|
-      ret = LibC.kill(pid, signal.value)
-      raise RuntimeError.from_errno("kill") if ret < 0
+      signal(signal, pid)
     end
     nil
+  end
+
+  # Sends a *signal* to the process identified by the given *pid*.
+  def self.signal(signal : Signal, pid : Int) : Nil
+    ret = LibC.kill(pid, signal.value)
+    raise RuntimeError.from_errno("kill") if ret < 0
   end
 
   # Returns `true` if the process identified by *pid* is valid for
@@ -193,7 +199,7 @@ class Process
       $? = process.wait
       value
     rescue ex
-      process.kill
+      process.terminate
       raise ex
     end
   end
@@ -345,8 +351,14 @@ class Process
   end
 
   # See also: `Process.kill`
+  @[Deprecated("Use #signal instead")]
   def kill(sig = Signal::TERM)
-    Process.kill sig, @pid
+    signal sig
+  end
+
+  # Sends *signal* to the process.
+  def signal(signal : Signal)
+    Process.signal signal, @pid
   end
 
   # Waits for this process to complete and closes any pipes.
@@ -380,6 +392,11 @@ class Process
     close_io @input
     close_io @output
     close_io @error
+  end
+
+  # Ask process for terminate gracefully
+  def terminate
+    signal Signal::TERM
   end
 
   # :nodoc:


### PR DESCRIPTION
> Rename Process#kill(Signal) to Process#signal(Signal) that we can eventually implement on Windows (if needed) with a deprecation notice. The name kill is confusing as it can mean two things - send signal to process, or send signal kill (9) to process when argument omitted. But currently default behavior of kill method without providing signal argument is to send term signal to process (simulates posix behavior of kill command, but we need to remove POSIXisms of apis to become really portable)

Closes #8642. I'm re-creating the PR to be able to resolve outstanding comments.

This probably should be squash-merged, with the above message.