### PR TITLE
Use "shards version" command in generated VERSION constant

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -159,7 +159,7 @@ module Crystal
           example.should eq(<<-EOF
         # TODO: Write documentation for `Example`
         module Example
-          VERSION = "0.1.0"
+          VERSION = {{ `shards version "\#{__DIR__}"`.chomp.stringify }}
 
           # TODO: Put your code here
         end

--- a/src/compiler/crystal/tools/init/template/example.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example.cr.ecr
@@ -1,6 +1,6 @@
 # TODO: Write documentation for `<%= module_name %>`
 module <%= module_name %>
-  VERSION = "0.1.0"
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 
   # TODO: Put your code here
 end


### PR DESCRIPTION
This removes 2nd place where the shard version constant is being defined - 1st being `version` value defined in `shard.yml` - reducing the surface for mistakes in this regard.