### PR TITLE
OptionParser rewrite with subcommands

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -101,8 +101,8 @@ describe "OptionParser" do
     expect_capture_option ["--flag=123"], "--flag=FLAG", "123"
   end
 
-  it "has required option with = (3) raises" do
-    expect_missing_option ["--flag="], "--flag=FLAG", "--flag"
+  it "has required option with = (3) handles empty" do
+    expect_capture_option ["--flag="], "--flag=FLAG", ""
   end
 
   it "raises if missing required argument separated from long flag" do
@@ -115,6 +115,14 @@ describe "OptionParser" do
 
   it "has required option with long flag space" do
     expect_capture_option ["--flag", "123"], "--flag ", "123"
+  end
+
+  it "gets short option with value -- (#8937)" do
+    expect_capture_option ["-f", "--"], "-f ARG", "--"
+  end
+
+  it "gets long option with value -- (#8937)" do
+    expect_capture_option ["--flag", "--"], "--flag [ARG]", "--"
   end
 
   it "doesn't raise if required option is not specified" do

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -542,4 +542,27 @@ describe "OptionParser" do
     bar.should be_false
     args.should eq(%w(--bar))
   end
+
+  it "can run a callback on every argument" do
+    args = %w(--foo file --bar)
+    foo = false
+    bar = false
+    OptionParser.parse(args) do |opts|
+      opts.on("--foo", "") { foo = true }
+      opts.on("--bar", "") { bar = true }
+      opts.before_each do |arg|
+        if arg == "file"
+          opts.stop
+        end
+      end
+      opts.unknown_args do |before, after|
+        before.should eq(%w(file))
+        after.should eq(%w(--bar))
+      end
+    end
+
+    foo.should be_true
+    bar.should be_false
+    args.should eq(%w(file --bar))
+  end
 end

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -470,6 +470,53 @@ describe "OptionParser" do
     z.should be_true
   end
 
+  it "parses with subcommands twice" do
+    args = %w(--verbose subcommand --foo 1 --bar sub2 -z)
+    verbose = false
+    subcommand = false
+    foo = nil
+    bar = false
+    sub2 = false
+    z = false
+
+    parser = OptionParser.new do |opts|
+      opts.on("subcommand", "") do
+        subcommand = true
+        opts.on("--foo arg", "") { |v| foo = v }
+        opts.on("--bar", "") { bar = true }
+        opts.on("sub2", "") { sub2 = true }
+      end
+      opts.on("--verbose", "") { verbose = true }
+      opts.on("-z", "--baz", "") { z = true }
+    end
+
+    parser.parse args
+
+    verbose.should be_true
+    subcommand.should be_true
+    foo.should be("1")
+    bar.should be_true
+    sub2.should be_true
+    z.should be_true
+
+    args = %w(--verbose subcommand --foo 1 --bar sub2 -z)
+    verbose = false
+    subcommand = false
+    foo = nil
+    bar = false
+    sub2 = false
+    z = false
+
+    parser.parse args
+
+    verbose.should be_true
+    subcommand.should be_true
+    foo.should be("1")
+    bar.should be_true
+    sub2.should be_true
+    z.should be_true
+  end
+
   it "unregisters subcommands on call" do
     foo = false
     bar = false

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -524,4 +524,22 @@ describe "OptionParser" do
           -f, --foo                        Foo
       USAGE
   end
+
+  it "stops when asked" do
+    args = %w(--foo --stop --bar)
+    foo = false
+    bar = false
+    OptionParser.parse(args) do |opts|
+      opts.on("--foo", "") { foo = true }
+      opts.on("--bar", "") { bar = true }
+      opts.on("--stop", "") { opts.stop }
+      opts.unknown_args do |before, after|
+        before.should eq(%w())
+        after.should eq(%w(--bar))
+      end
+    end
+    foo.should be_true
+    bar.should be_false
+    args.should eq(%w(--bar))
+  end
 end

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -429,12 +429,8 @@ describe "OptionParser" do
     end
   end
 
-  it "raises if flag doesn't start with dash (#4001)" do
+  it "raises if flag pair doesn't start with dash (#4001)" do
     OptionParser.parse([] of String) do |opts|
-      expect_raises ArgumentError, %(Argument 'flag' ("foo") must start with a dash) do
-        opts.on("foo", "") { }
-      end
-
       expect_raises ArgumentError, %(Argument 'short_flag' ("foo") must start with a dash) do
         opts.on("foo", "bar", "baz") { }
       end
@@ -445,5 +441,87 @@ describe "OptionParser" do
 
       opts.on("", "-bar", "baz") { }
     end
+  end
+
+  it "handles subcommands" do
+    args = %w(--verbose subcommand --foo 1 --bar sub2 -z)
+    verbose = false
+    subcommand = false
+    foo = nil
+    bar = false
+    sub2 = false
+    z = false
+    OptionParser.parse(args) do |opts|
+      opts.on("subcommand", "") do
+        subcommand = true
+        opts.on("--foo arg", "") { |v| foo = v }
+        opts.on("--bar", "") { bar = true }
+        opts.on("sub2", "") { sub2 = true }
+      end
+      opts.on("--verbose", "") { verbose = true }
+      opts.on("-z", "--baz", "") { z = true }
+    end
+
+    verbose.should be_true
+    subcommand.should be_true
+    foo.should be("1")
+    bar.should be_true
+    sub2.should be_true
+    z.should be_true
+  end
+
+  it "unregisters subcommands on call" do
+    foo = false
+    bar = false
+    baz = false
+    OptionParser.parse(%w(foo baz)) do |opts|
+      opts.on("foo", "") do
+        foo = true
+        opts.on("bar", "") { bar = true }
+      end
+      opts.on("baz", "") { baz = true }
+    end
+    foo.should be_true
+    bar.should be_false
+    baz.should be_false
+  end
+
+  it "handles subcommand --help well (top level)" do
+    help = nil
+    OptionParser.parse(%w(--help)) do |opts|
+      opts.banner = "Usage: foo"
+      opts.on("subcommand", "Subcommand Description") do
+        opts.on("-f", "--foo", "Foo") { }
+      end
+      opts.on("--verbose", "Verbose mode") { }
+      opts.on("--help", "Help") { help = opts.to_s }
+    end
+
+    help.should eq <<-USAGE
+      Usage: foo
+          subcommand                       Subcommand Description
+          --verbose                        Verbose mode
+          --help                           Help
+      USAGE
+  end
+
+  it "handles subcommand --help well (subcommand)" do
+    help = nil
+    OptionParser.parse(%w(subcommand --help)) do |opts|
+      opts.banner = "Usage: foo"
+      opts.on("subcommand", "Subcommand Description") do
+        opts.banner = "Usage: foo subcommand"
+        opts.on("-f", "--foo", "Foo") { }
+      end
+      opts.on("--verbose", "Verbose mode") { }
+      opts.on("--help", "Help") { help = opts.to_s }
+    end
+
+    help.should eq <<-USAGE
+      Usage: foo subcommand
+          --verbose                        Verbose mode
+          --help                           Help
+          -f, --foo                        Foo
+      USAGE
   end
 end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -220,8 +220,9 @@ class OptionParser
     end
   end
 
-  # Adds a separator, with an optional header message,
-  # that will be used to print the help.
+  # Adds a separator, with an optional header message, that will be used to
+  # print the help. The seperator is placed between the flags registered (`#on`)
+  # before, and the flags registered after the call.
   #
   # This way, you can group the different options in an easier to read way.
   def separator(message = "")
@@ -231,21 +232,23 @@ class OptionParser
   # Sets a handler for regular arguments that didn't match any of the setup options.
   #
   # You typically use this to get the main arguments (not modifiers)
-  # that your program expects (for example, filenames)
+  # that your program expects (for example, filenames). The default behaviour
+  # is to do nothing. The arguments can also be extracted from the *args* array
+  # passed to `#parse` after parsing.
   def unknown_args(&@unknown_args : Array(String), Array(String) ->)
   end
 
   # Sets a handler for when a option that expects an argument wasn't given any.
   #
   # You typically use this to display a help message.
-  # The default raises `MissingOption`.
+  # The default behaviour is to raise `MissingOption`.
   def missing_option(&@missing_option : String ->)
   end
 
   # Sets a handler for option arguments that didn't match any of the setup options.
   #
   # You typically use this to display a help message.
-  # The default raises `InvalidOption`.
+  # The default behaviour is to raise `InvalidOption`.
   def invalid_option(&@invalid_option : String ->)
   end
 

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -295,6 +295,14 @@ class OptionParser
 
   # Parses the passed *args* (defaults to `ARGV`), running the handlers associated to each option.
   def parse(args = ARGV)
+    old_flags = @flags.clone
+    old_handlers = @handlers.clone
+    old_banner = @banner
+    old_unknown_args = @unknown_args
+    old_missing_option = @missing_option
+    old_invalid_option = @invalid_option
+    old_before_each = @before_each
+
     # List of indexes in `args` which have been handled and must be deleted
     handled_args = [] of Int32
     double_dash_index = nil
@@ -417,6 +425,15 @@ class OptionParser
         @invalid_option.call(arg)
       end
     end
+  ensure
+    @flags = old_flags.not_nil!
+    @handlers = old_handlers.not_nil!
+    @stop = false
+    @banner = old_banner
+    @unknown_args = old_unknown_args
+    @missing_option = old_missing_option.not_nil!
+    @invalid_option = old_invalid_option.not_nil!
+    @before_each = old_before_each
   end
 
   @[Deprecated("Use `parse` instead.")]

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -249,6 +249,15 @@ class OptionParser
   def invalid_option(&@invalid_option : String ->)
   end
 
+  # Sets a handler which runs before each argument is parsed. This callback is
+  # not passed flag arguments. For example, `--foo=foo_arg --bar bar_arg` would
+  # pass `--foo=foo_arg` and `--bar` to the callback only.
+  #
+  # You typically use this to implement advanced option parsing behaviour such
+  # as treating all options after a filename differently (along with `#stop`).
+  def before_each(&@before_each : String ->)
+  end
+
   # Stops the current parse and returns immediately, leaving the remaining flags
   # unparsed. This is treated identically to `--` being inserted *behind* the
   # current parsed flag.
@@ -295,6 +304,10 @@ class OptionParser
         double_dash_index = arg_index - 1
         @stop = false
         break
+      end
+
+      if before_each = @before_each
+        before_each.call(arg)
       end
 
       # -- means to stop parsing arguments


### PR DESCRIPTION
I got angry with `OptionParser` for being a pile of bad code so I rewrote the implementation. It's simpler now, and easier to understand the implementation, and not `O(n^2)` so probably miles faster. And it has a completely compatible interface, no changes were required to any existing usages across the stdlib.

While I was rewriting it I had a universe brain moment and realised that I could make it handle subcommands very simply, so I threw that in as a bonus.

Example subcommand usage:
```cr
OptionParser.parse(args) do |opts|
  opts.on("subcommand", "Description") do
    opts.on("--foo arg", "Foo") { |v| foo = v }
    opts.on("--bar", "Bar") { bar = true }
    opts.on("-z", "--baz", "Baz") { z = true }
  end
  opts.on("--verbose", "") { verbose = true }
end
```

There's some tweaks still required to get the `to_s` output to not suck when using subcommands but I wanted to submit this for comment before I forgot about it tomorrow morning.

Fixes #8937.