### PR TITLE
Fix File#pos, File#seek and File#truncate over 2G on Windows

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -213,7 +213,7 @@ module Crystal::System::File
   end
 
   private def system_truncate(size : Int) : Nil
-    if LibC._chsize(fd, size) != 0
+    if LibC._chsize_s(fd, size) != 0
       raise ::File::Error.from_errno("Error truncating file", file: path)
     end
   end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -78,7 +78,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_seek(offset, whence : IO::Seek) : Nil
-    seek_value = LibC._lseek(fd, offset, whence)
+    seek_value = LibC._lseeki64(fd, offset, whence)
 
     if seek_value == -1
       raise IO::Error.from_errno "Unable to seek"
@@ -86,7 +86,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_pos
-    pos = LibC._lseek(fd, 0, IO::Seek::Current)
+    pos = LibC._lseeki64(fd, 0, IO::Seek::Current)
     raise IO::Error.from_errno "Unable to tell" if pos == -1
     pos
   end

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -3,7 +3,7 @@ require "c/stdint"
 lib LibC
   fun _write(fd : Int, buffer : UInt8*, count : UInt) : Int
   fun _read(fd : Int, buffer : UInt8*, count : UInt) : Int
-  fun _lseek(fd : Int, offset : Long, origin : Int) : Long
+  fun _lseeki64(fd : Int, offset : Int64, origin : Int) : Int64
   fun _isatty(fd : Int) : Int
   fun _close(fd : Int) : Int
   fun _wopen(filename : WCHAR*, oflag : Int, ...) : Int
@@ -12,7 +12,7 @@ lib LibC
   fun _wunlink(filename : WCHAR*) : Int
   fun _wmktemp_s(template : WCHAR*, sizeInChars : SizeT) : ErrnoT
   fun _wrename(oldname : WCHAR*, newname : WCHAR*) : Int
-  fun _chsize(fd : Int, size : Long) : Int
+  fun _chsize_s(fd : Int, size : Int64) : ErrnoT
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _pipe(pfds : Int*, psize : UInt, textmode : Int) : Int
   fun _dup2(fd1 : Int, fd2 : Int) : Int


### PR DESCRIPTION
[_lseek][_lseeki64] and [_chsize][] cannot handle files bigger than 2G because they use Long, whose maximum size is 2G on Windows. This commit uses [_lseeki64][] and [_chsize_s][] instead.

[_chsize]: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/chsize
[_chsize_s]: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/chsize-s
[_lseeki64]: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/lseek-lseeki64