### PR TITLE
Fix `RegexLiteral#to_s` output when first character of literal is whitespace

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -47,6 +47,8 @@ describe "ASTNode#to_s" do
   expect_to_s %(/\\//), "/\\//"
   expect_to_s %(/\#{1 / 2}/)
   expect_to_s %<%r(/)>, %(/\\//)
+  expect_to_s %(/ /), %(/\\ /)
+  expect_to_s %(%r( )), %(/\\ /)
   expect_to_s %(foo &.bar), %(foo(&.bar))
   expect_to_s %(foo &.bar(1, 2, 3)), %(foo(&.bar(1, 2, 3)))
   expect_to_s %(foo { |i| i.bar { i } }), "foo do |i|\n  i.bar do\n    i\n  end\nend"

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1017,8 +1017,10 @@ module Crystal
         @str << '/'
         case exp = node.value
         when StringLiteral
+          @str << '\\' if exp.value[0]?.try &.ascii_whitespace?
           Regex.append_source exp.value, @str
         when StringInterpolation
+          @str << '\\' if exp.expressions.first?.as?(StringLiteral).try &.value[0]?.try &.ascii_whitespace?
           visit_interpolation(exp) { |s| Regex.append_source s, @str }
         else
           raise "Bug: shouldn't happen"


### PR DESCRIPTION
Fixed #9016

This PR changes `RegexLiteral#to_s` inserts backslash if first character of literal is whitespace.