### PR TITLE
Compiler: parse `{% unless ~ end %}` as Unless instead of swapped If

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1610,4 +1610,33 @@ describe Crystal::Formatter do
       # second comment
     }
     CODE
+
+  # #9014
+  assert_format <<-CODE
+    {%
+      unless true
+        1
+      end
+    %}
+    CODE
+
+  assert_format <<-CODE
+    {%
+      unless true
+        1
+      else
+        2
+      end
+    %}
+    CODE
+
+  assert_format <<-CODE
+    {%
+      if true
+        1
+      else
+        2
+      end
+    %}
+    CODE
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -844,7 +844,8 @@ module Crystal
     it_parses "{% a = 1 if 2 %}", MacroExpression.new(If.new(2.int32, Assign.new("a".var, 1.int32)), output: false)
     it_parses "{% if 1; 2; end %}", MacroExpression.new(If.new(1.int32, 2.int32), output: false)
     it_parses "{%\nif 1; 2; end\n%}", MacroExpression.new(If.new(1.int32, 2.int32), output: false)
-    it_parses "{% unless 1; 2; end %}", MacroExpression.new(If.new(1.int32, Nop.new, 2.int32), output: false)
+    it_parses "{% unless 1; 2; end %}", MacroExpression.new(Unless.new(1.int32, 2.int32, Nop.new), output: false)
+    it_parses "{% unless 1; 2; else 3; end %}", MacroExpression.new(Unless.new(1.int32, 2.int32, 3.int32), output: false)
     it_parses "{%\n1\n2\n3\n%}", MacroExpression.new(Expressions.new([1.int32, 2.int32, 3.int32] of ASTNode), output: false)
 
     it_parses "{{ 1 // 2 }}", MacroExpression.new(Expressions.from([Call.new(1.int32, "//", 2.int32)] of ASTNode))

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3173,9 +3173,8 @@ module Crystal
           when MacroIf
             macro_if.then, macro_if.else = macro_if.else, macro_if.then
           when MacroExpression
-            if (exp = macro_if.exp).is_a?(If)
-              exp.then, exp.else = exp.else, exp.then
-            end
+            exp = macro_if.exp.as(If)
+            macro_if.exp = Unless.new(exp.cond, exp.then, exp.else).at(exp)
           else
             # Nothing special to do
           end


### PR DESCRIPTION
Fixed #9014

Currently, `{% unless 1; 2; else 3; end %}` is parsed as `{% if 1; 3; else 2; end %}`.
However this causes some issue like #9014, so this fixes it is parsed as `Unless` ASTNode simply.

Thank you.