### PR TITLE
Allow building compiler without 'playground', to avoid dependency on sockets

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -75,7 +75,12 @@ class Crystal::Command
       result
     when "play".starts_with?(command)
       options.shift
-      playground
+      {% if flag?(:without_playground) %}
+        puts "Crystal was compiled without playground support"
+        exit 1
+      {% else %}
+        playground
+      {% end %}
     when "deps".starts_with?(command)
       STDERR.puts "Please use 'shards': 'crystal deps' has been removed"
       exit 1

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -1,6 +1,5 @@
 require "option_parser"
 require "file_utils"
-require "socket"
 require "colorize"
 require "digest/md5"
 

--- a/src/compiler/crystal/tools/playground/agent.cr
+++ b/src/compiler/crystal/tools/playground/agent.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:without_playground) %}
+
 require "http"
 require "json"
 

--- a/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
+++ b/src/compiler/crystal/tools/playground/agent_instrumentor_transformer.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:without_playground) %}
+
 module Crystal
   class Playground::AgentInstrumentorTransformer < Transformer
     class MacroDefNameCollector < Visitor

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:without_playground) %}
+
 require "http/server"
 require "log"
 require "ecr/macros"


### PR DESCRIPTION
This would, for example, be useful to bootstrap the compiler on Windows before having a "socket" implementation.