### PR TITLE
Parser: correctly parse `foo:"bar"` inside call or named tuple

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1508,6 +1508,12 @@ module Crystal
       it_parses "{% begin %}%q#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%q#{open} %s #{close}"))
     end
 
+    it_parses %(foo(bar:"a", baz:"b")), Call.new(nil, "foo", named_args: [NamedArgument.new("bar", "a".string), NamedArgument.new("baz", "b".string)])
+    it_parses %(foo(bar:a, baz:b)), Call.new(nil, "foo", named_args: [NamedArgument.new("bar", "a".call), NamedArgument.new("baz", "b".call)])
+    it_parses %({foo:"a", bar:"b"}), NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("foo", "a".string), NamedTupleLiteral::Entry.new("bar", "b".string)])
+    it_parses %({foo:'a', bar:'b'}), NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("foo", CharLiteral.new('a')), NamedTupleLiteral::Entry.new("bar", CharLiteral.new('b'))])
+    it_parses %({foo:a, bar:b}), NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("foo", "a".call), NamedTupleLiteral::Entry.new("bar", "b".call)])
+
     assert_syntax_error "return do\nend", "unexpected token: do"
 
     %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -64,6 +64,7 @@ module Crystal
       @slash_is_regex = true
       @wants_raw = false
       @wants_def_or_macro_name = false
+      @wants_symbol = true
       @string_pool = string_pool || StringPool.new
 
       # When lexing macro tokens, when we encounter `#{` inside
@@ -452,172 +453,182 @@ module Crystal
         next_char :";"
       when ':'
         char = next_char
-        case char
-        when ':'
-          next_char :"::"
-        when '+'
-          next_char_and_symbol "+"
-        when '-'
-          next_char_and_symbol "-"
-        when '*'
-          if next_char == '*'
-            next_char_and_symbol "**"
-          else
-            symbol "*"
-          end
-        when '/'
-          case next_char
-          when '/'
-            next_char_and_symbol "//"
-          else
-            symbol "/"
-          end
-        when '='
-          case next_char
-          when '='
-            if next_char == '='
-              next_char_and_symbol "==="
-            else
-              symbol "=="
-            end
-          when '~'
-            next_char_and_symbol "=~"
-          else
-            unknown_token
-          end
-        when '!'
-          case next_char
-          when '='
-            next_char_and_symbol "!="
-          when '~'
-            next_char_and_symbol "!~"
-          else
-            symbol "!"
-          end
-        when '<'
-          case next_char
-          when '='
-            if next_char == '>'
-              next_char_and_symbol "<=>"
-            else
-              symbol "<="
-            end
-          when '<'
-            next_char_and_symbol "<<"
-          else
-            symbol "<"
-          end
-        when '>'
-          case next_char
-          when '='
-            next_char_and_symbol ">="
-          when '>'
-            next_char_and_symbol ">>"
-          else
-            symbol ">"
-          end
-        when '&'
-          case next_char
+
+        if @wants_symbol
+          case char
+          when ':'
+            next_char :"::"
           when '+'
-            next_char_and_symbol "&+"
+            next_char_and_symbol "+"
           when '-'
-            next_char_and_symbol "&-"
+            next_char_and_symbol "-"
           when '*'
-            case next_char
-            when '*'
-              next_char_and_symbol "&**"
+            if next_char == '*'
+              next_char_and_symbol "**"
             else
-              symbol "&*"
+              symbol "*"
             end
-          else
-            symbol "&"
-          end
-        when '|'
-          next_char_and_symbol "|"
-        when '^'
-          next_char_and_symbol "^"
-        when '~'
-          next_char_and_symbol "~"
-        when '%'
-          next_char_and_symbol "%"
-        when '['
-          if next_char == ']'
+          when '/'
+            case next_char
+            when '/'
+              next_char_and_symbol "//"
+            else
+              symbol "/"
+            end
+          when '='
             case next_char
             when '='
-              next_char_and_symbol "[]="
-            when '?'
-              next_char_and_symbol "[]?"
+              if next_char == '='
+                next_char_and_symbol "==="
+              else
+                symbol "=="
+              end
+            when '~'
+              next_char_and_symbol "=~"
             else
-              symbol "[]"
+              unknown_token
             end
-          else
-            unknown_token
-          end
-        when '"'
-          line = @line_number
-          column = @column_number
-          start = current_pos + 1
-          io = IO::Memory.new
-          while true
-            char = next_char
-            case char
-            when '\\'
-              case char = next_char
-              when 'a'
-                io << '\a'
-              when 'b'
-                io << '\b'
-              when 'n'
-                io << '\n'
-              when 'r'
-                io << '\r'
-              when 't'
-                io << '\t'
-              when 'v'
-                io << '\v'
-              when 'f'
-                io << '\f'
-              when 'e'
-                io << '\e'
-              when 'x'
-                io.write_byte consume_string_hex_escape
-              when 'u'
-                io << consume_string_unicode_escape
-              when '0', '1', '2', '3', '4', '5', '6', '7'
-                io.write_byte consume_octal_escape(char)
-              when '\n'
-                incr_line_number nil
-                io << '\n'
+          when '!'
+            case next_char
+            when '='
+              next_char_and_symbol "!="
+            when '~'
+              next_char_and_symbol "!~"
+            else
+              symbol "!"
+            end
+          when '<'
+            case next_char
+            when '='
+              if next_char == '>'
+                next_char_and_symbol "<=>"
+              else
+                symbol "<="
+              end
+            when '<'
+              next_char_and_symbol "<<"
+            else
+              symbol "<"
+            end
+          when '>'
+            case next_char
+            when '='
+              next_char_and_symbol ">="
+            when '>'
+              next_char_and_symbol ">>"
+            else
+              symbol ">"
+            end
+          when '&'
+            case next_char
+            when '+'
+              next_char_and_symbol "&+"
+            when '-'
+              next_char_and_symbol "&-"
+            when '*'
+              case next_char
+              when '*'
+                next_char_and_symbol "&**"
+              else
+                symbol "&*"
+              end
+            else
+              symbol "&"
+            end
+          when '|'
+            next_char_and_symbol "|"
+          when '^'
+            next_char_and_symbol "^"
+          when '~'
+            next_char_and_symbol "~"
+          when '%'
+            next_char_and_symbol "%"
+          when '['
+            if next_char == ']'
+              case next_char
+              when '='
+                next_char_and_symbol "[]="
+              when '?'
+                next_char_and_symbol "[]?"
+              else
+                symbol "[]"
+              end
+            else
+              unknown_token
+            end
+          when '"'
+            line = @line_number
+            column = @column_number
+            start = current_pos + 1
+            io = IO::Memory.new
+            while true
+              char = next_char
+              case char
+              when '\\'
+                case char = next_char
+                when 'a'
+                  io << '\a'
+                when 'b'
+                  io << '\b'
+                when 'n'
+                  io << '\n'
+                when 'r'
+                  io << '\r'
+                when 't'
+                  io << '\t'
+                when 'v'
+                  io << '\v'
+                when 'f'
+                  io << '\f'
+                when 'e'
+                  io << '\e'
+                when 'x'
+                  io.write_byte consume_string_hex_escape
+                when 'u'
+                  io << consume_string_unicode_escape
+                when '0', '1', '2', '3', '4', '5', '6', '7'
+                  io.write_byte consume_octal_escape(char)
+                when '\n'
+                  incr_line_number nil
+                  io << '\n'
+                when '\0'
+                  raise "unterminated quoted symbol", line, column
+                else
+                  io << char
+                end
+              when '"'
+                break
               when '\0'
                 raise "unterminated quoted symbol", line, column
               else
                 io << char
               end
-            when '"'
-              break
-            when '\0'
-              raise "unterminated quoted symbol", line, column
+            end
+
+            @token.type = :SYMBOL
+            @token.value = io.to_s
+            next_char
+            set_token_raw_from_start(start - 2)
+          else
+            if ident_start?(char)
+              start = current_pos
+              while ident_part?(next_char)
+                # Nothing to do
+              end
+              if current_char == '?' || ((current_char == '!' || current_char == '=') && peek_next_char != '=')
+                next_char
+              end
+              @token.type = :SYMBOL
+              @token.value = string_range_from_pool(start)
+              set_token_raw_from_start(start - 1)
             else
-              io << char
+              @token.type = :":"
             end
           end
-
-          @token.type = :SYMBOL
-          @token.value = io.to_s
-          next_char
-          set_token_raw_from_start(start - 2)
         else
-          if ident_start?(char)
-            start = current_pos
-            while ident_part?(next_char)
-              # Nothing to do
-            end
-            if current_char == '?' || ((current_char == '!' || current_char == '=') && peek_next_char != '=')
-              next_char
-            end
-            @token.type = :SYMBOL
-            @token.value = string_range_from_pool(start)
-            set_token_raw_from_start(start - 1)
+          case char
+          when ':'
+            next_char :"::"
           else
             @token.type = :":"
           end
@@ -2968,6 +2979,11 @@ module Crystal
     def next_token_skip_statement_end
       next_token
       skip_statement_end
+    end
+
+    def next_token_never_a_symbol
+      @wants_symbol = false
+      next_token.tap { @wants_symbol = true }
     end
 
     def current_char

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2493,7 +2493,7 @@ module Crystal
     end
 
     def parse_named_tuple(location, first_key)
-      next_token
+      next_token_never_a_symbol
 
       slash_is_regex!
       next_token_skip_space
@@ -2512,7 +2512,7 @@ module Crystal
         while @token.type != :"}"
           key = @token.value.to_s
           if named_tuple_start?
-            next_token
+            next_token_never_a_symbol
           elsif string_literal_start?
             key = parse_string_without_interpolation("named tuple name", want_skip_space: false)
           else
@@ -4461,7 +4461,7 @@ module Crystal
         else
           if named_tuple_start?
             name = @token.value.to_s
-            next_token
+            next_token_never_a_symbol
           elsif string_literal_start?
             name = parse_string_without_interpolation("named argument")
           else


### PR DESCRIPTION
Fixes #9027

Diff better seen with "Hide whitespace changes" checked.