### PR TITLE
Add Log handler for HTTP::Server

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -5,6 +5,7 @@ require "./server/handler"
 require "./server/response"
 require "./server/request_processor"
 require "./common"
+require "log"
 {% unless flag?(:without_openssl) %}
   require "openssl"
 {% end %}
@@ -128,6 +129,8 @@ require "./common"
 # Reusing the connection also requires that the request body (if present) is
 # entirely consumed in the handler chain. Otherwise the connection will be closed.
 class HTTP::Server
+  Log = ::Log.for("http.server")
+
   @sockets = [] of Socket::Server
 
   # Returns `true` if this server is closed.
@@ -498,9 +501,9 @@ class HTTP::Server
     @processor.process(io, io)
   end
 
+  # This method handles exceptions raised at `Socket#accept?`.
   private def handle_exception(e : Exception)
-    e.inspect_with_backtrace STDERR
-    STDERR.flush
+    Log.debug(exception: e) { "Error while connecting a new socket" }
   end
 
   # Builds all handlers as the middleware for `HTTP::Server`.

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -503,7 +503,10 @@ class HTTP::Server
 
   # This method handles exceptions raised at `Socket#accept?`.
   private def handle_exception(e : Exception)
-    Log.debug(exception: e) { "Error while connecting a new socket" }
+    # TODO: This needs more refinement. Not every exception is an actual server
+    # error and should be logged as such. Client malfunction should only be informational.
+    # See https://github.com/crystal-lang/crystal/pull/9034#discussion_r407038999
+    Log.error(exception: e) { "Error while connecting a new socket" }
   end
 
   # Builds all handlers as the middleware for `HTTP::Server`.


### PR DESCRIPTION
Previously, errors while establishing a connection where just dumped out to STDERR.
Such errors are usually not very relevant but sometimes you might want to delve into details. The new Log system offers a great solution to bury these errors as debug messages, still making them available when logger level is low enough.

This creates a new dependency from `HTTP::Server` to `Log` that has not been there before. But I think that's okay. `HTTP::Server` is quite a high level API in stdlib terms and should often be used with a logging system anyways. And we would probably want to use the new Log system more often now in stdlib libraries.

In case you don't want that behaviour, overwriting `handle_exception` still allows inserting specific behaviour. But the default implementation should do a sane thing and not spill every failed SSL connection attempt to STDERR but still have a way to get access to these errors.