### PR TITLE
Make File.rename overwrite the destination file on Windows, like elsewhere

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -516,6 +516,17 @@ describe "File" do
       end
     end
 
+    it "replaces a file" do
+      with_tempfile("rename-source.txt", "rename-target.txt") do |source_path, target_path|
+        File.write(source_path, "foo")
+        File.write(target_path, "bar")
+        File.rename(source_path, target_path)
+        File.exists?(source_path).should be_false
+        File.read(target_path).strip.should eq("foo")
+        File.delete(target_path)
+      end
+    end
+
     it "raises if old file doesn't exist" do
       with_tempfile("rename-fail-source.txt", "rename-fail-target.txt") do |source_path, target_path|
         expect_raises(File::NotFoundError, "Error renaming file: '#{source_path}' -> '#{target_path}'") do

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -3,6 +3,7 @@ require "c/fcntl"
 require "c/fileapi"
 require "c/sys/utime"
 require "c/sys/stat"
+require "c/winbase"
 
 module Crystal::System::File
   def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions) : LibC::Int
@@ -197,8 +198,8 @@ module Crystal::System::File
   end
 
   def self.rename(old_path : String, new_path : String) : Nil
-    if LibC._wrename(to_windows_path(old_path), to_windows_path(new_path)) != 0
-      raise ::File::Error.from_errno("Error renaming file", file: old_path, other: new_path)
+    if LibC.MoveFileExW(to_windows_path(old_path), to_windows_path(new_path), LibC::MOVEFILE_REPLACE_EXISTING) == 0
+      raise ::File::Error.from_winerror("Error renaming file", file: old_path, other: new_path)
     end
   end
 

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -11,7 +11,6 @@ lib LibC
   fun _wchmod(filename : WCHAR*, pmode : Int) : Int
   fun _wunlink(filename : WCHAR*) : Int
   fun _wmktemp_s(template : WCHAR*, sizeInChars : SizeT) : ErrnoT
-  fun _wrename(oldname : WCHAR*, newname : WCHAR*) : Int
   fun _chsize_s(fd : Int, size : Int64) : ErrnoT
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _pipe(pfds : Int*, psize : UInt, textmode : Int) : Int

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -90,4 +90,13 @@ lib LibC
   fun GetEnvironmentStringsW : LPWCH
   fun FreeEnvironmentStringsW(lpszEnvironmentBlock : LPWCH) : BOOL
   fun SetEnvironmentVariableW(lpName : LPWSTR, lpValue : LPWSTR) : BOOL
+
+  MOVEFILE_REPLACE_EXISTING      =  0x1_u32
+  MOVEFILE_COPY_ALLOWED          =  0x2_u32
+  MOVEFILE_DELAY_UNTIL_REBOOT    =  0x4_u32
+  MOVEFILE_WRITE_THROUGH         =  0x8_u32
+  MOVEFILE_CREATE_HARDLINK       = 0x10_u32
+  MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20_u32
+
+  fun MoveFileExW(lpExistingFileName : LPWSTR, lpNewFileName : LPWSTR, dwFlags : DWORD) : BOOL
 end


### PR DESCRIPTION
The compiler, for example, relies on it here: https://github.com/crystal-lang/crystal/blob/0bb3fe98d0b2698e646ab6eb24097eb6e4e8bafa/src/compiler/crystal/compiler.cr#L702 But right now it throws an error that the file already exists.

You could argue whether it's desirable. For example, Python, to preserve backwards compatibility where the behavior differed like this for ages, decided to keep `rename` as replacing on Unix but erroring on Windows, but also added [`replace`](https://docs.python.org/3/library/os.html#os.replace) to replace on both. So on Unix they don't have any `rename` which would error out if the destination exists.

Another important caveat is that replacing a file like that is *atomic* on Unix, but on Windows that is impossible to achieve.

Let me know what you think, I could do the same as Python instead.