### PR TITLE
Allow JSON::PullParser instances to be inspected

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -374,4 +374,10 @@ describe JSON::PullParser do
       end
     {% end %}
   end
+
+  # Added due to an issue with private enums not being inspectable.
+  it "can be inspected" do
+    pull = JSON::PullParser.new("null")
+    pull.inspect
+  end
 end

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -13,6 +13,7 @@ class JSON::PullParser
     EOF
   end
 
+  # :nodoc:
   enum ObjectStackKind
     Object
     Array

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -13,7 +13,7 @@ class JSON::PullParser
     EOF
   end
 
-  private enum ObjectStackKind
+  enum ObjectStackKind
     Object
     Array
   end


### PR DESCRIPTION
Given this code:

```crystal
require "json"
JSON::PullParser.new("null").inspect
```

I get the following compile-time error:

```
 crystal json_error.cr
Showing last frame. Use --error-trace for full trace.

There was a problem expanding macro 'macro_4607045632'

Code in /usr/local/Cellar/crystal/0.34.0/src/enum.cr:139:5

 139 | {% if @type.has_attribute?("Flags") %}
       ^
Called macro defined in /usr/local/Cellar/crystal/0.34.0/src/enum.cr:139:5

 139 | {% if @type.has_attribute?("Flags") %}

Which expanded to:

 > 2 |       case value
 > 3 |
 > 4 |       when JSON::PullParser::ObjectStackKind::Object.value
                  ^----------------------------------------
Error: private constant JSON::PullParser::ObjectStackKind::Object referenced
```

The issue is that [enums must be public in order to be `inspect`able](https://github.com/crystal-lang/crystal/blob/7217aad30f87064ea2807133f924256c324dbc83/src/enum.cr#L142-L146). I discovered this because objects must be `inspect`able in order to do use them in a Crystal playground, so I couldn't instantiate a `JSON::PullParser` while experimenting with something today.

I checked and this is the only place `private enum` is used within Crystal itself. It seems to be pretty uncommon in general, too. Only [one repo uses it](https://github.com/search?q=%22private+enum%22+language%3Acrystal&type=Code) apart from this one and two others that copied the code from this one.

I don't think this is an ideal solution, to be clear. It is simply the easiest solution I could think of to solve the immediate problem. If there were more code in the wild that used `private enum`, I probably wouldn't even bother with this band-aid. I think an ideal solution would be to support this construct without barring a program from compiling even if downstream code my program does not own calls this method. I'm just not sure how to do that yet.