### PR TITLE
Compiler: turn exhaustive case warnings into errors

### DIFF
--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -13,10 +13,6 @@ describe "Code gen: case" do
     run("require \"prelude\"; case 1; when 0; 2; else; 3; end").to_i.should eq(3)
   end
 
-  it "codegens case without whens" do
-    run("require \"prelude\"; case 1; end").to_string.should eq ""
-  end
-
   it "codegens case without whens but else" do
     run("require \"prelude\"; case 1; else; 2; end").to_i.should eq(2)
   end

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -25,6 +25,7 @@ describe "Code gen: void" do
           foo
         when 2
           raise \"oh no\"
+        else
         end
       end
 
@@ -47,6 +48,7 @@ describe "Code gen: void" do
           foo
         when 2
           raise \"oh no\"
+        else
         end
       end
 

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -6,103 +6,103 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with var in cond" do
-    assert_expand_second "x = 1; case x; when 1; 'b'; end", "if 1 === x\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when 1; 'b'; else; end", "if 1 === x\n  'b'\nend"
   end
 
   it "normalizes case with Path to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo; 'b'; end", "if x.is_a?(Foo)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo; 'b'; else; end", "if x.is_a?(Foo)\n  'b'\nend"
   end
 
   it "normalizes case with generic to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T); 'b'; end", "if x.is_a?(Foo(T))\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo(T); 'b'; else; end", "if x.is_a?(Foo(T))\n  'b'\nend"
   end
 
   it "normalizes case with Path.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo.class; 'b'; else; end", "if x.is_a?(Foo.class)\n  'b'\nend"
   end
 
   it "normalizes case with Generic.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; else; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
   end
 
   it "normalizes case with many expressions in when" do
-    assert_expand_second "x = 1; case x; when 1, 2; 'b'; end", "if (1 === x) || (2 === x)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when 1, 2; 'b'; else; end", "if (1 === x) || (2 === x)\n  'b'\nend"
   end
 
   it "normalizes case with implicit call" do
-    assert_expand "case x; when .foo(1); 2; end", "__temp_1 = x\nif __temp_1.foo(1)\n  2\nend"
+    assert_expand "case x; when .foo(1); 2; else; end", "__temp_1 = x\nif __temp_1.foo(1)\n  2\nend"
   end
 
   it "normalizes case with implicit responds_to? (#3040)" do
-    assert_expand "case x; when .responds_to?(:foo); 2; end", "__temp_1 = x\nif __temp_1.responds_to?(:foo)\n  2\nend"
+    assert_expand "case x; when .responds_to?(:foo); 2; else; end", "__temp_1 = x\nif __temp_1.responds_to?(:foo)\n  2\nend"
   end
 
   it "normalizes case with implicit is_a? (#3040)" do
-    assert_expand "case x; when .is_a?(T); 2; end", "__temp_1 = x\nif __temp_1.is_a?(T)\n  2\nend"
+    assert_expand "case x; when .is_a?(T); 2; else; end", "__temp_1 = x\nif __temp_1.is_a?(T)\n  2\nend"
   end
 
   it "normalizes case with implicit as (#3040)" do
-    assert_expand "case x; when .as(T); 2; end", "__temp_1 = x\nif __temp_1.as(T)\n  2\nend"
+    assert_expand "case x; when .as(T); 2; else; end", "__temp_1 = x\nif __temp_1.as(T)\n  2\nend"
   end
 
   it "normalizes case with implicit as? (#3040)" do
-    assert_expand "case x; when .as?(T); 2; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
+    assert_expand "case x; when .as?(T); 2; else; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
   end
 
   it "normalizes case with implicit !" do
-    assert_expand "case x; when .!; 2; end", "__temp_1 = x\nif !__temp_1\n  2\nend"
+    assert_expand "case x; when .!; 2; else; end", "__temp_1 = x\nif !__temp_1\n  2\nend"
   end
 
   it "normalizes case with assignment" do
-    assert_expand "case x = 1; when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
+    assert_expand "case x = 1; when 2; 3; else; end", "x = 1\nif 2 === x\n  3\nend"
   end
 
   it "normalizes case with assignment wrapped by paren" do
-    assert_expand "case (x = 1); when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
+    assert_expand "case (x = 1); when 2; 3; else; end", "x = 1\nif 2 === x\n  3\nend"
   end
 
   it "normalizes case without value" do
-    assert_expand "case when 2; 3; when 4; 5; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2; 3; when 4; 5; else; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
   it "normalizes case without value with many expressions in when" do
-    assert_expand "case when 2, 9; 3; when 4; 5; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2, 9; 3; when 4; 5; else; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
   it "normalizes case with nil to is_a?" do
-    assert_expand_second "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when nil; 'b'; else; end", "if x.is_a?(::Nil)\n  'b'\nend"
   end
 
   it "normalizes case with multiple expressions" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; end", "if (2 === x) && (3 === y)\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; else; end", "if (2 === x) && (3 === y)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and types" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; else; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and implicit obj" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; end", "if x.foo && y.bar\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; else; end", "if x.foo && y.bar\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and comma" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; else; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
   end
 
   it "normalizes case with multiple expressions with underscore" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; end", "if 2 === x\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; else; end", "if 2 === x\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; end", "if true\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; else; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores twice" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; end", "if true\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; else; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and non-tuple" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; else; end", "if 1 === {x, y}\n  4\nend"
   end
 
   it "normalizes case without when and else" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -112,6 +112,10 @@ def assert_error(str, message, inject_primitives = true)
   end
 end
 
+def assert_no_errors(*args)
+  semantic(*args)
+end
+
 def warnings_result(code, inject_primitives = true)
   code = inject_primitives(code) if inject_primitives
 

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -22,7 +22,7 @@ class Crystal::CodeGenVisitor
 
     call_args, has_out = prepare_call_args node, owner
 
-    # It can happen that one of the arguments caused an unreacahble
+    # It can happen that one of the arguments caused an unreachable
     # to happen, so we must stop here
     return false if @builder.end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1514,6 +1514,10 @@ module Crystal
       false
     end
 
+    def visit(node : Unreachable)
+      builder.unreachable
+    end
+
     def check_proc_is_not_closure(value, type)
       check_fun_name = "~check_proc_is_not_closure"
       func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -807,4 +807,12 @@ module Crystal
       end
     end
   end
+
+  # Ficticious node to mean a location in code shouldn't be reached.
+  # This is used in the implicit `else` branch of a case.
+  class Unreachable < ASTNode
+    def clone_without_location
+      Unreachable.new
+    end
+  end
 end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -175,9 +175,67 @@ module Crystal
       @exhaustiveness_checker.check(node)
 
       if expanded = node.expanded
+        unless node.else
+          replace_unreacahble_if_needed(node, expanded)
+        end
+
         return expanded.transform(self)
       end
+
       node
+    end
+
+    # If any of the types checked in `case` is an enum, it can happen that
+    # the unreachable can be reached by doing `SomeEnum.new(some_value)`.
+    # In that case we replace the Unreachable node with `raise "..."`.
+    # In the future we should disallow creating such values unless the
+    # enum is marked as "open".
+    def replace_unreacahble_if_needed(node, expanded)
+      cond = node.cond
+      return unless cond
+
+      if cond.is_a?(TupleLiteral)
+        return unless cond.elements.all?(&.type?) &&
+                      cond.elements.any? { |element| has_enum_type?(element.type) }
+      else
+        cond_type = cond.type?
+        return unless cond_type && has_enum_type?(cond_type)
+      end
+
+      an_if = find_unreachable_parent(expanded)
+      unless an_if
+        node.raise "BUG: expected to find Unreachable node"
+      end
+
+      an_if.else = build_raise("Unhandled case: enum value outside of defined enum members", node)
+    end
+
+    def has_enum_type?(type)
+      if type.is_a?(UnionType)
+        type.union_types.any? &.is_a?(EnumType)
+      else
+        type.is_a?(EnumType)
+      end
+    end
+
+    def find_unreachable_parent(expanded)
+      # An expanded case is either a series of if/else, or
+      # a bunch of assignments and then a series of if/else.
+      # The if/else chain always comes last.
+      if expanded.is_a?(Expressions)
+        expanded = expanded.expressions.last
+      end
+
+      while expanded.is_a?(If)
+        if an_else = expanded.else
+          if an_else.is_a?(Unreachable)
+            return expanded
+          else
+            expanded = an_else
+          end
+        end
+      end
+      nil
     end
 
     def transform(node : ExpandableNode)
@@ -504,7 +562,7 @@ module Crystal
       build_raise ex_msg, node
     end
 
-    def build_raise(msg, node)
+    def build_raise(msg : String, node : ASTNode)
       call = Call.global("raise", StringLiteral.new(msg).at(node)).at(node)
       call.accept MainVisitor.new(@program)
       call

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -176,7 +176,7 @@ module Crystal
 
       if expanded = node.expanded
         unless node.else
-          replace_unreacahble_if_needed(node, expanded)
+          replace_unreachable_if_needed(node, expanded)
         end
 
         return expanded.transform(self)
@@ -190,7 +190,7 @@ module Crystal
     # In that case we replace the Unreachable node with `raise "..."`.
     # In the future we should disallow creating such values unless the
     # enum is marked as "open".
-    def replace_unreacahble_if_needed(node, expanded)
+    def replace_unreachable_if_needed(node, expanded)
       cond = node.cond
       return unless cond
 

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -67,50 +67,46 @@ struct Crystal::ExhaustivenessChecker
     return if targets.empty?
 
     if targets.all?(&.is_a?(TypeTarget)) && all_patterns_are_types
-      @program.report_warning(node, <<-MSG)
+      node.raise <<-MSG
         case is not exhaustive.
 
         Missing types:
          - #{targets.map(&.type).join("\n - ")}
         MSG
-      return
     end
 
     single_target = targets.size == 1 ? targets.first : nil
 
     case single_target
     when BoolTarget
-      @program.report_warning(node, <<-MSG)
+      node.raise <<-MSG
         case is not exhaustive.
 
         Missing cases:
          - #{single_target.missing_cases.join("\n - ")}
         MSG
-      return
     when EnumTarget
-      @program.report_warning(node, <<-MSG)
+      node.raise <<-MSG
         case is not exhaustive for enum #{single_target.type}.
 
         Missing members:
          - #{single_target.members.map(&.name).join("\n - ")}
         MSG
-      return
     else
       # No specific error messages for non-single types
     end
 
     if all_provable_patterns && !has_flags_enum
-      @program.report_warning(node, <<-MSG)
+      node.raise <<-MSG
         case is not exhaustive.
 
         Missing cases:
          - #{targets.flat_map(&.missing_cases).join("\n - ")}
         MSG
-      return
     end
 
     # Otherwise we can't prove exhaustiveness and an `else` clause is required
-    @program.report_warning(node, <<-MSG)
+    node.raise <<-MSG
       can't prove case is exhaustive.
 
       Please add an `else` clause.
@@ -173,17 +169,16 @@ struct Crystal::ExhaustivenessChecker
         .map { |cases| "{#{cases}}" }
         .join("\n - ")
 
-      @program.report_warning(node, <<-MSG)
+      node.raise <<-MSG
         case is not exhaustive.
 
         Missing cases:
          - #{missing_cases}
         MSG
-      return
     end
 
     # Otherwise we can't prove exhaustiveness and an `else` clause is required
-    @program.report_warning(node, <<-MSG)
+    node.raise <<-MSG
       can't prove case is exhaustive.
 
       Please add an `else` clause.

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -465,9 +465,7 @@ module Crystal
         a_if = wh_if
       end
 
-      if node_else = node.else
-        a_if.not_nil!.else = node_else
-      end
+      a_if.not_nil!.else = node.else || Unreachable.new
 
       final_if = final_if.not_nil!
       final_exp = if assigns && !assigns.empty?

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3159,6 +3159,10 @@ module Crystal
       false
     end
 
+    def visit(node : Unreachable)
+      node.type = @program.no_return
+    end
+
     # # Helpers
 
     def free_vars

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2843,7 +2843,7 @@ module Crystal
             end
           end
         else
-          # If there's no ensure, because all rescue/else end with unreacahble
+          # If there's no ensure, because all rescue/else end with unreachable
           # we know all the vars after the exception handler will have the types
           # after the handle (begin) block.
           @vars = after_exception_handler_vars

--- a/src/compiler/crystal/semantic/to_s.cr
+++ b/src/compiler/crystal/semantic/to_s.cr
@@ -79,5 +79,10 @@ module Crystal
       @str << node.value
       false
     end
+
+    def visit(node : Unreachable)
+      @str << %(raise "unreachable")
+      false
+    end
   end
 end

--- a/src/compiler/crystal/semantic/transformer.cr
+++ b/src/compiler/crystal/semantic/transformer.cr
@@ -2,7 +2,7 @@ require "../syntax/transformer"
 
 module Crystal
   class Transformer
-    def transform(node : MetaVar | MetaMacroVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | AssignWithRestriction | YieldBlockBinder | MacroId)
+    def transform(node : MetaVar | MetaMacroVar | Primitive | TypeFilteredNode | TupleIndexer | TypeNode | AssignWithRestriction | YieldBlockBinder | MacroId | Unreachable)
       node
     end
 


### PR DESCRIPTION
This PR consists of two things:
1. if a case is not exhaustive it will now be an error instead of a warning
2. if a case is exhaustive, the `else` branch is unreachable (with type `NoReturn`) instead of `nil`

The second point means this:

```crystal
x = 1 || "a"
z = case x
when Int32
  true
when String
  false
end

typeof(z) # => Bool
```

Before this PR `typeof(z)` was `Bool | Nil`.

Now, when comparing against types there's no way to reach the `else` because the compiler proved that all cases are covered.

However, when comparing against enum values, it's possible that the `else` branch is reached if we use `SomeEnum.new(some_int_value)` and it falls outside of the valid enum members. If that's the case, the `else` branch will raise an `Exception` saying "Unhandled case: enum value outside of defined enum members".

I thought about making the message tell you which enum value was that, but it would make the code a lot more complex. And I don't want to make it more complex if the code might not be needed later on.

In the future, I'd like the language to prevent creating enum values outside of the declared members, unless the enum is marked in a special way, for example with an `@[OpenEnum]` annotation. In that case the compiler would also always require an `else` in such case. Then the `else` will be really unreachable.

But this can be done in a later PR after we decide we want that.