### PR TITLE
Compiler: don't merge union types if there's a type annotation

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -411,4 +411,24 @@ describe "Code gen: cast" do
       x.foo
       )).to_i.should eq(1)
   end
+
+  it "fails cast virtual type to union" do
+    run(%(
+      require "prelude"
+
+      class Base; end
+      class One < Base; end
+      class Two < Base; end
+      class Three < Base; end
+
+      x = One.new || Two.new
+
+      begin
+        w = x.as(Two | Three)
+        1
+      rescue ex
+        2
+      end
+      )).to_i.should eq(2)
+  end
 end

--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -359,4 +359,15 @@ describe "Semantic: cast" do
       x.foo if x
       )) { nil_type }
   end
+
+  it "casts to union, doesn't merge to parent type" do
+    assert_type(%(
+      class Base; end
+      class One < Base; end
+      class Two < Base; end
+      class Three < Base; end
+
+      (One.new || Three.new).as(One | Two)
+      )) { union_of types["One"], types["Two"] }
+  end
 end

--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -510,4 +510,26 @@ describe "Semantic: class var" do
       Foo(Int32).inc
       )) { int32 }
   end
+
+  it "types union without going to parent (#9050)" do
+    assert_type(%(
+      class Base; end
+      class One < Base; end
+      class Two < Base; end
+
+      class Foo
+        @@x : One | Two = One.new
+
+        def self.x=(@@x)
+        end
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x = Two.new
+      Foo.x
+      )) { union_of types["One"], types["Two"] }
+  end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5247,4 +5247,25 @@ describe "Semantic: instance var" do
       ),
       "can't infer the type parameter T for the generic class Gen(T)"
   end
+
+  it "types union without going to parent (#9050)" do
+    assert_type(%(
+      class Base; end
+      class One < Base; end
+      class Two < Base; end
+
+      class Foo
+        @x : One | Two
+
+        def initialize(@x)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new(One.new).x
+      )) { union_of types["One"], types["Two"] }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -899,7 +899,7 @@ module Crystal
         types = other.union_types.compact_map do |t|
           restrict(t, context).as(Type?)
         end
-        program.type_merge types
+        program.type_merge_union_of types
       elsif other.is_a?(VirtualType)
         result = base_type.restrict(other.base_type, context) || other.base_type.restrict(base_type, context)
         result ? result.virtual_type : nil

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -181,8 +181,8 @@ struct Crystal::TypeDeclarationProcessor
     var = MetaTypeVar.new(name)
     var.owner = owner
     var.type = type
-    var.bind_to(var)
     var.freeze_type = type if freeze_type
+    var.bind_to(var)
     var.location = location
 
     annotations.try &.each do |annotation_type, ann|

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -154,7 +154,7 @@ class Crystal::Type
 
         type.virtual_type
       end
-      program.type_merge(types)
+      program.type_merge_union_of(types)
     end
 
     def lookup(node : Metaclass)

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -166,7 +166,7 @@ module Crystal
       # Sort by depth so that types deep in the hierarchy will combine with
       # types we find first.
       if merge_to_parent == false
-        types = types.sort_by!(&.depth)
+        types.sort_by!(&.depth)
       end
 
       types.each do |t2|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3017,7 +3017,7 @@ module Crystal
 
     def virtual_type
       if union_types.any? { |t| t.virtual_type != t }
-        program.type_merge(union_types.map(&.virtual_type)).not_nil!
+        program.type_merge_union_of(union_types.map(&.virtual_type)).not_nil!
       else
         self
       end
@@ -3050,7 +3050,8 @@ module Crystal
           new_union_types << type.replace_type_parameters(instance)
         end
       end
-      program.type_merge(new_union_types) || program.no_return
+
+      program.type_merge_union_of(new_union_types) || program.no_return
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -109,7 +109,11 @@ class HTTP::Client
     alias TLSContext = Bool | Nil
   {% else %}
     getter! tls : OpenSSL::SSL::Context::Client
-    @socket : TCPSocket | OpenSSL::SSL::Socket | Nil
+
+    # TODO: change this to
+    # @socket : TCPSocket | OpenSSL::SSL::Socket | Nil
+    @socket : IO | Nil
+
     alias TLSContext = OpenSSL::SSL::Context::Client | Bool | Nil
   {% end %}
 


### PR DESCRIPTION
Fixes #9050

It would be nice to test the ecosystem if this goes through because it's a big change. 