### PR TITLE
Add #every top-level method

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -104,6 +104,20 @@ def loop
   end
 end
 
+# Repeatedly executes the block, but with the given delay between executions.
+#
+# ```
+# every 1.second do
+#   puts Time.local
+# end
+# ```
+def every(delay : Time::Span) : Nil
+  loop do
+    yield
+    sleep delay
+  end
+end
+
 # Reads a line from `STDIN`.
 #
 # See also: `IO#gets`.


### PR DESCRIPTION
 Just a suggestion, I just wrote this method in my code and thought it might be useful if it were in the stdlib.

Example run in the playground:

https://carc.in/#/r/8voj