### PR TITLE
Add timestamp macro

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2170,4 +2170,14 @@ module Crystal
       end
     end
   end
+
+  describe "timestamp" do
+    it "prints current timestamp" do
+      time = Time.utc(2020, 4, 13, 16, 8)
+      assert_macro "", %({{timestamp}}), "#{time.to_unix}_i64" do |program|
+        program.timestamp = time
+        [] of ASTNode
+      end
+    end
+  end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -149,6 +149,13 @@ module Crystal::Macros
   def skip_file : Nop
   end
 
+  # Returns the current time at compilation  as a unix time stamp.
+  #
+  # The value is identical throughout each invocation inside a program and
+  # represents the start of the compilation process.
+  def timestamp : NumberLiteral
+  end
+
   # This is the base class of all AST nodes. This methods are
   # available to all AST nodes.
   abstract class ASTNode

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -71,6 +71,8 @@ module Crystal
         interpret_read_file(node, nilable: true)
       when "run"
         interpret_run(node)
+      when "timestamp"
+        interpret_timestamp(node)
       else
         nil
       end
@@ -295,6 +297,14 @@ module Crystal
         end
 
         node.raise message.to_s
+      end
+    end
+
+    def interpret_timestamp(node)
+      if node.args.size == 0
+        @last = NumberLiteral.new(@program.timestamp.to_unix)
+      else
+        node.wrong_number_of_arguments "macro call 'timestamp'", node.args.size, 0
       end
     end
   end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -130,6 +130,9 @@ module Crystal
     # If `true` compiler will error if warnings are found.
     property error_on_warnings : Bool = false
 
+    # Returns the source time of this program.
+    property timestamp : Time = Time.utc
+
     def initialize
       super(self, self, "main")
 


### PR DESCRIPTION
This adds a new top level macro `timestamp` which returns the current time as unix timestamp.

The value is identical throughout each invocation inside a program and represents the start of the compilation process.

A use case is in the compiler which currently shells out to get the timestamp for `SOURCE_DATE_EPOCH`. This is not portable (see #9054 and #9049) and can easily be replaced by a macro feature.

https://github.com/crystal-lang/crystal/blob/b6e157b70994ad58d5428ac60609738ec4d2d807/src/compiler/crystal/config.cr#L35