### PR TITLE
Pass the command line to cl.exe through a file

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -22,7 +22,7 @@ module Crystal
   # optionally generates an executable.
   class Compiler
     CC = ENV["CC"]? || "cc"
-    CL = "cl"
+    CL = "cl.exe"
 
     # A source to the compiler: its filename and source code.
     record Source,
@@ -314,22 +314,29 @@ module Crystal
 
       target_machine.emit_obj_to_file llvm_mod, object_name
 
-      stdout.puts linker_command(program, object_name, output_filename, nil)
+      stdout.puts linker_command(program, [object_name], output_filename, nil)
     end
 
-    private def linker_command(program : Program, object_name, output_filename, output_dir)
+    private def linker_command(program : Program, object_names, output_filename, output_dir)
       if program.has_flag? "windows"
-        if object_name
-          object_name = %("#{object_name}")
-        else
-          object_name = %(%*)
-        end
-
         if link_flags = @link_flags.presence
           link_flags = "/link #{link_flags}"
         end
 
-        %(#{CL} #{object_name} "/Fe#{output_filename}" #{program.lib_flags} #{link_flags})
+        args = %(#{object_names.join(" ")} "/Fe#{output_filename}" #{program.lib_flags} #{link_flags})
+        cmd = "#{CL} #{args}"
+
+        if cmd.to_utf16.size > 32000
+          # The command line would be too big, pass the args through a UTF-16-encoded file instead.
+          # TODO: Do this the proper way when iconv is supported.
+          cmd_filename = "#{output_dir}/link_command.cmd"
+          cmd_16 = "\ufeff#{args}".to_utf16
+          cmd_bytes = cmd_16.to_unsafe.as(UInt8*).to_slice(cmd_16.bytesize)
+          File.write(cmd_filename, cmd_bytes)
+          cmd = "#{CL} @#{cmd_filename}"
+        end
+
+        {cmd, nil}
       else
         if thin_lto
           clang = ENV["CLANG"]? || "clang"
@@ -344,17 +351,11 @@ module Crystal
           cc = CC
         end
 
-        if object_name
-          object_name = %('#{object_name}')
-        else
-          object_name = %("${@}")
-        end
-
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
         link_flags += " -static" if static?
 
-        %(#{cc} #{object_name} -o '#{output_filename}' #{link_flags} #{program.lib_flags})
+        { %(#{cc} "${@}" -o '#{output_filename}' #{link_flags} #{program.lib_flags}), object_names }
       end
     end
 
@@ -389,9 +390,9 @@ module Crystal
 
       @progress_tracker.stage("Codegen (linking)") do
         Dir.cd(output_dir) do
-          linker_command = linker_command(program, nil, output_filename, output_dir)
+          linker_command = linker_command(program, object_names, output_filename, output_dir)
 
-          process_wrapper(linker_command, object_names) do |command, args|
+          process_wrapper(*linker_command) do |command, args|
             Process.run(command, args, shell: true,
               input: Process::Redirect::Close, output: Process::Redirect::Inherit, error: Process::Redirect::Pipe) do |process|
               process.error.each_line(chomp: false) do |line|
@@ -563,15 +564,8 @@ module Crystal
       end
     end
 
-    private def system(command, args = nil)
-      process_wrapper(command, args) do
-        ::system(command, args)
-        $?
-      end
-    end
-
     private def process_wrapper(command, args = nil)
-      stdout.puts "#{command} #{args.join " "}" if verbose?
+      stdout.puts command.sub(%("${@}"), args && args.join(" ")) if verbose?
 
       status = yield command, args
 


### PR DESCRIPTION
This is necessary because large projects (like the Crystal compiler) surpass the maximal size for the command line when linking the numerous object files.

This PR also makes Crystal actually be able to run the linker subprocess on Windows, as it replaces the unsupported combination of `args` and `shell: true`.

This PR is technically independent from #9043, but clearly some shell-escaping would be very helpful here.