### PR TITLE
Super-fancy refactor of Process::Status

### DIFF
--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -16,7 +16,7 @@ struct Crystal::System::Process
   # def pid : Int
 
   # Waits until the process finishes and returns its status code
-  # def wait : Int
+  # def wait : ::Process::Status
 
   # Whether the process is still registered in the system.
   # def exists? : Bool

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -30,9 +30,9 @@ struct Crystal::System::Process
       raise RuntimeError.from_winerror("GetExitCodeProcess")
     end
     if exit_code == LibC::STILL_ACTIVE
-      raise "BUG: process still active"
+      raise ::Process::Status::UnexpectedStatusError.new(exit_code.to_i32!, "The process might still be active")
     end
-    exit_code
+    ::Process::Status::Exited.new(exit_code.to_i32!)
   end
 
   def exists?

--- a/src/process.cr
+++ b/src/process.cr
@@ -9,6 +9,7 @@ class Process
   record Tms, utime : Float64, stime : Float64, cutime : Float64, cstime : Float64
 end
 
+require "process/status"
 require "crystal/system/process"
 
 class Process
@@ -303,7 +304,7 @@ class Process
     end
     @wait_count = 0
 
-    Process::Status.new(@process_info.wait)
+    @process_info.wait
   ensure
     close
   end

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -1,11 +1,5 @@
 # The status of a terminated process. Returned by `Process#wait`.
 class Process::Status
-  # Platform-specific exit status code, which usually contains either the exit code or a termination signal.
-  # The other `Process::Status` methods extract the values from `exit_status`.
-  def exit_status : Int32
-    @exit_status.to_i32!
-  end
-
   {% if flag?(:win32) %}
     # :nodoc:
     def initialize(@exit_status : UInt32)
@@ -73,5 +67,11 @@ class Process::Status
   private def signal_code
     # define __WTERMSIG(status) ((status) & 0x7f)
     @exit_status & 0x7f
+  end
+
+  # Platform-specific exit status code, which usually contains either the exit code or a termination signal.
+  @[Deprecated("Use `Process::Status#exit_code`")]
+  def exit_status : Int32
+    @exit_status.to_i32!
   end
 end

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -49,7 +49,14 @@ class Process::Status
   end
 
   # If `normal_exit?` is `true`, returns the exit code of the process.
+  #
+  # * POSIX: Otherwise, returns a placeholder negative value related to the exit signal.
+  # * Windows: The exit is always "normal" but the exit codes can be negative
+  #   (wrapped around after `Int32::MAX`; take them modulo 2**32 if the actual value is needed)
   def exit_code : Int32
+    if !normal_exit?
+      return -signal_code
+    end
     {% if flag?(:unix) %}
       # define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
       (@exit_status & 0xff00) >> 8


### PR DESCRIPTION
This uses a hierarchy of structs; it's a type-safe approach to the variety of POSIX exit statuses.

Based on https://github.com/crystal-lang/crystal/issues/8381#issuecomment-612487955, https://github.com/crystal-lang/crystal/issues/8381#issuecomment-612691909

[Usage examples](https://github.com/crystal-lang/crystal/pull/9064#issuecomment-613693961)

It is also backwards-compatible

I don't know how this will be received, but it doesn't matter, I had to put this out there :joy: 