### PR TITLE
Reference global Spec in `be_a` macro

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -368,7 +368,7 @@ module Spec
 
     # Creates an `Expectation` that passes if actual is of type *type* (`is_a?`).
     macro be_a(type)
-      Spec::BeAExpectation({{type}}).new
+      ::Spec::BeAExpectation({{type}}).new
     end
 
     # Runs the block and passes if it raises an exception of type *klass* and the error message matches.


### PR DESCRIPTION
Because it was doing `Spec::BeAExpectation`, if you use `be_a` inside a module where theree's a `Spec` type, it will find that instead of the global one.