### PR TITLE
Refactor is_crystal_repo based on project name

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -229,7 +229,7 @@ describe Doc::Generator do
       program = Program.new
       generator = Doc::Generator.new program, ["."]
       doc_type = Doc::Type.new generator, program
-      generator.is_crystal_repo = true
+      generator.project_info.name = "Crystal"
 
       pseudo_def = Def.new "__crystal_pseudo_typeof"
       pseudo_def.doc = "Foo"

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -2,7 +2,6 @@ class Crystal::Doc::Generator
   getter program : Program
 
   @base_dir : String
-  property is_crystal_repo : Bool
   @repository : String? = nil
   getter repository_name = ""
   getter project_info
@@ -41,7 +40,6 @@ class Crystal::Doc::Generator
     @base_dir = Dir.current.chomp
     @types = {} of Crystal::Type => Doc::Type
     @repo_name = ""
-    @is_crystal_repo = false
     compute_repository
   end
 
@@ -240,7 +238,7 @@ class Crystal::Doc::Generator
   end
 
   def crystal_builtin?(type)
-    return false unless @is_crystal_repo
+    return false unless project_info.crystal_stdlib?
     return false unless type.is_a?(Const) || type.is_a?(NonGenericModuleType)
 
     crystal_type = @program.types["Crystal"]
@@ -396,8 +394,6 @@ class Crystal::Doc::Generator
     git_matches = remotes.each_line.compact_map do |line|
       GIT_REMOTE_PATTERNS.each_key.compact_map(&.match(line)).first?
     end.to_a
-
-    @is_crystal_repo = git_matches.any? { |gr| gr.string =~ %r{github\.com[/:]crystal-lang/crystal(?:\.git)?\s} }
 
     origin = git_matches.find(&.string.starts_with?("origin")) || git_matches.first?
     return unless origin

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -20,7 +20,7 @@ class Crystal::Doc::Method
 
   def name
     name = @def.name
-    if @generator.is_crystal_repo
+    if @generator.project_info.crystal_stdlib?
       name.lchop(PSEUDO_METHOD_PREFIX)
     else
       name

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -8,6 +8,10 @@ module Crystal::Doc
 
     def_equals_and_hash @name, @version
 
+    def crystal_stdlib?
+      name == "Crystal"
+    end
+
     def fill_with_defaults
       unless version?
         if git_version = ProjectInfo.find_git_version


### PR DESCRIPTION
This changes how the docs generator knows it's working on stdlib. Previously it looked for a git remote pointing to `github.com/crystal-lang/crystal`. Now with #8792 it can simply tell by the project name. That allows generating stdlib docs outside a git environment (for example from a tarball) which was impossible before.

For refernce: #7904 might add a separate option for enabling ouput of stdlib features which could make this change obsolete. But that's not fleshed out yet, and this is a simple improvement we can do right now.