### PR TITLE
Add version selector to API docs

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -180,6 +180,8 @@ In case no default can be found, this option is mandatory.
 .It Fl -project-version Ar VERSION
 Set the project version. The default value is extracted from current git commit or shard.yml if available.
 In case no default can be found, this option is mandatory.
+.It Fl -json_config_url Ar URL
+Set the URL pointing to a config file (used for discovering versions).
 .It Fl o Ar DIR, Fl -output Ar DIR
 Set the output directory (default: ./docs).
 .It Fl b Ar URL, Fl -sitemap-base-url Ar URL

--- a/scripts/docs-versions.sh
+++ b/scripts/docs-versions.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env sh
+
+git tag --list | \
+grep -v -E '0\.1?[0-9]\.' | \
+grep '^[0-9]' | \
+tac | \
+awk '
+  BEGIN {
+    print "{"
+    print "  \"versions\": ["
+    getline current_version < "src/VERSION"
+    printf "    {\"name\": \"" current_version "\", \"url\": \"/api/master/\", \"released\": false}"
+  }
+
+  {
+    printf ",\n    {\"name\": \"" $1 "\", \"url\": \"/api/" $1 "/\"}"
+  }
+
+  END {
+    print "\n  ]"
+    print "}"
+  }
+'

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -44,6 +44,10 @@ class Crystal::Command
         output_format = value
       end
 
+      opts.on("--json_config_url=URL", "Set the URL pointing to a config file (used for discovering versions)") do |value|
+        project_info.json_config_url = value
+      end
+
       opts.on("--canonical-base-url=URL", "Deprecated option. Use --sitemap-base-url instead.") do |value|
         abort "Option --canonical-base-url is no longer supported.  Use --sitemap-base-url instead."
       end

--- a/src/compiler/crystal/tools/doc/html/_head.html
+++ b/src/compiler/crystal/tools/doc/html/_head.html
@@ -1,6 +1,11 @@
 <meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="generator" content="Crystal Docs <%= Crystal::VERSION %>">
+<meta name="crystal_docs.project_version" content="<%= project_info.version %>">
+<meta name="crystal_docs.project_name" content="<%= project_info.name %>">
+<% if json_config_url = project_info.json_config_url %>
+  <meta name="crystal_docs.json_config_url" content="<%= json_config_url %>">
+<% end %>
 
 <link href="<%= base_path %>css/style.css" rel="stylesheet" type="text/css" />
 <script type="text/javascript" src="<%= base_path %>js/doc.js"></script>

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -56,6 +56,7 @@ body {
   padding: 0 0 30px;
   box-shadow: inset -3px 0 4px rgba(0,0,0,.35);
   line-height: 1.2;
+  z-index: 0;
 }
 
 .sidebar .search-box {
@@ -107,9 +108,7 @@ body {
 }
 
 .project-summary {
-  display: inline-block;
   padding: 9px 15px 30px 30px;
-  text-align: right;
 }
 
 .project-name {
@@ -121,7 +120,39 @@ body {
 
 .project-version {
   margin-top: 5px;
-  display: block;
+  display: inline-block;
+  position: relative;
+}
+
+.project-version > form::after {
+  position: absolute;
+  right: 0;
+  top: 0;
+  content: "\25BC";
+  font-size: .6em;
+  line-height: 1.2rem;
+  z-index: -1;
+}
+
+.project-versions-nav {
+  cursor: pointer;
+  margin: 0;
+  padding: 0 .9em 0 0;
+  border: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+}
+.project-versions-nav:focus {
+  outline: none;
+}
+
+.project-versions-nav > option {
+  color: initial;
 }
 
 .sidebar ul {

--- a/src/compiler/crystal/tools/doc/html/js/_navigator.js
+++ b/src/compiler/crystal/tools/doc/html/js/_navigator.js
@@ -4,23 +4,23 @@ Navigator = function(sidebar, searchInput, list, leaveSearchScope){
 
   var performingSearch = false;
 
-  document.addEventListener('CrystalDoc:searchStarted', function(){
+  document.addEventListener('CrystalDocs:searchStarted', function(){
     performingSearch = true;
   });
-  document.addEventListener('CrystalDoc:searchDebounceStarted', function(){
+  document.addEventListener('CrystalDocs:searchDebounceStarted', function(){
     performingSearch = true;
   });
-  document.addEventListener('CrystalDoc:searchPerformed', function(){
+  document.addEventListener('CrystalDocs:searchPerformed', function(){
     performingSearch = false;
   });
-  document.addEventListener('CrystalDoc:searchDebounceStopped', function(event){
+  document.addEventListener('CrystalDocs:searchDebounceStopped', function(event){
     performingSearch = false;
   });
 
   function delayWhileSearching(callback) {
     if(performingSearch){
-      document.addEventListener('CrystalDoc:searchPerformed', function listener(){
-        document.removeEventListener('CrystalDoc:searchPerformed', listener);
+      document.addEventListener('CrystalDocs:searchPerformed', function listener(){
+        document.removeEventListener('CrystalDocs:searchPerformed', listener);
 
         // add some delay to let search results display kick in
         setTimeout(callback, 100);

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -1,7 +1,7 @@
-CrystalDoc.searchIndex = (CrystalDoc.searchIndex || false);
-CrystalDoc.MAX_RESULTS_DISPLAY = 140;
+CrystalDocs.searchIndex = (CrystalDocs.searchIndex || false);
+CrystalDocs.MAX_RESULTS_DISPLAY = 140;
 
-CrystalDoc.runQuery = function(query) {
+CrystalDocs.runQuery = function(query) {
   function searchType(type, query, results) {
     var matches = [];
     var matchedFields = [];
@@ -141,11 +141,11 @@ CrystalDoc.runQuery = function(query) {
   }
 
   var results = [];
-  searchType(CrystalDoc.searchIndex.program, query, results);
+  searchType(CrystalDocs.searchIndex.program, query, results);
   return results;
 };
 
-CrystalDoc.rankResults = function(results, query) {
+CrystalDocs.rankResults = function(results, query) {
   function uniqueArray(ar) {
     var j = {};
 
@@ -167,42 +167,42 @@ CrystalDoc.rankResults = function(results, query) {
     var bOnlyDocs = bHasDocs && b.matched_fields.length == 1;
 
     if (a.result_type == "type" && b.result_type != "type" && !aOnlyDocs) {
-      if(CrystalDoc.DEBUG) { console.log("a is type b not"); }
+      if(CrystalDocs.DEBUG) { console.log("a is type b not"); }
       return -1;
     } else if (b.result_type == "type" && a.result_type != "type" && !bOnlyDocs) {
-      if(CrystalDoc.DEBUG) { console.log("b is type, a not"); }
+      if(CrystalDocs.DEBUG) { console.log("b is type, a not"); }
       return 1;
     }
     if (a.matched_fields.includes("name")) {
       if (b.matched_fields.includes("name")) {
-        var a_name = (CrystalDoc.prefixForType(a.result_type) || "") + ((a.result_type == "type") ? a.full_name : a.name);
-        var b_name = (CrystalDoc.prefixForType(b.result_type) || "") + ((b.result_type == "type") ? b.full_name : b.name);
+        var a_name = (CrystalDocs.prefixForType(a.result_type) || "") + ((a.result_type == "type") ? a.full_name : a.name);
+        var b_name = (CrystalDocs.prefixForType(b.result_type) || "") + ((b.result_type == "type") ? b.full_name : b.name);
         a_name = a_name.toLowerCase();
         b_name = b_name.toLowerCase();
         for(var i = 0; i < query.normalizedTerms.length; i++) {
           var term = query.terms[i].replace(/^::?|::?$/, "");
           var a_orig_index = a_name.indexOf(term);
           var b_orig_index = b_name.indexOf(term);
-          if(CrystalDoc.DEBUG) { console.log("term: " + term + " a: " + a_name + " b: " + b_name); }
-          if(CrystalDoc.DEBUG) { console.log(a_orig_index, b_orig_index, a_orig_index - b_orig_index); }
+          if(CrystalDocs.DEBUG) { console.log("term: " + term + " a: " + a_name + " b: " + b_name); }
+          if(CrystalDocs.DEBUG) { console.log(a_orig_index, b_orig_index, a_orig_index - b_orig_index); }
           if (a_orig_index >= 0) {
             if (b_orig_index >= 0) {
-              if(CrystalDoc.DEBUG) { console.log("both have exact match", a_orig_index > b_orig_index ? -1 : 1); }
+              if(CrystalDocs.DEBUG) { console.log("both have exact match", a_orig_index > b_orig_index ? -1 : 1); }
               if(a_orig_index != b_orig_index) {
-                if(CrystalDoc.DEBUG) { console.log("both have exact match at different positions", a_orig_index > b_orig_index ? 1 : -1); }
+                if(CrystalDocs.DEBUG) { console.log("both have exact match at different positions", a_orig_index > b_orig_index ? 1 : -1); }
                 return a_orig_index > b_orig_index ? 1 : -1;
               }
             } else {
-              if(CrystalDoc.DEBUG) { console.log("a has exact match, b not"); }
+              if(CrystalDocs.DEBUG) { console.log("a has exact match, b not"); }
               return -1;
             }
           } else if (b_orig_index >= 0) {
-            if(CrystalDoc.DEBUG) { console.log("b has exact match, a not"); }
+            if(CrystalDocs.DEBUG) { console.log("b has exact match, a not"); }
             return 1;
           }
         }
       } else {
-        if(CrystalDoc.DEBUG) { console.log("a has match in name, b not"); }
+        if(CrystalDocs.DEBUG) { console.log("a has match in name, b not"); }
         return -1;
       }
     } else if (
@@ -213,19 +213,19 @@ CrystalDoc.rankResults = function(results, query) {
     }
 
     if (matchedTermsDiff != 0 || (aHasDocs != bHasDocs)) {
-      if(CrystalDoc.DEBUG) { console.log("matchedTermsDiff: " + matchedTermsDiff, aHasDocs, bHasDocs); }
+      if(CrystalDocs.DEBUG) { console.log("matchedTermsDiff: " + matchedTermsDiff, aHasDocs, bHasDocs); }
       return matchedTermsDiff;
     }
 
     var matchedFieldsDiff = b.matched_fields.length - a.matched_fields.length;
     if (matchedFieldsDiff != 0) {
-      if(CrystalDoc.DEBUG) { console.log("matched to different number of fields: " + matchedFieldsDiff); }
+      if(CrystalDocs.DEBUG) { console.log("matched to different number of fields: " + matchedFieldsDiff); }
       return matchedFieldsDiff > 0 ? 1 : -1;
     }
 
     var nameCompare = a.name.localeCompare(b.name);
     if(nameCompare != 0){
-      if(CrystalDoc.DEBUG) { console.log("nameCompare resulted in: " + a.name + "<=>" + b.name + ": " + nameCompare); }
+      if(CrystalDocs.DEBUG) { console.log("nameCompare resulted in: " + a.name + "<=>" + b.name + ": " + nameCompare); }
       return nameCompare > 0 ? 1 : -1;
     }
 
@@ -234,7 +234,7 @@ CrystalDoc.rankResults = function(results, query) {
         var term = query.terms[i];
         var aIndex = a.args_string.indexOf(term);
         var bIndex = b.args_string.indexOf(term);
-        if(CrystalDoc.DEBUG) { console.log("index of " + term + " in args_string: " + aIndex + " - " + bIndex); }
+        if(CrystalDocs.DEBUG) { console.log("index of " + term + " in args_string: " + aIndex + " - " + bIndex); }
         if(aIndex >= 0){
           if(bIndex >= 0){
             if(aIndex != bIndex){
@@ -263,7 +263,7 @@ CrystalDoc.rankResults = function(results, query) {
   return results;
 };
 
-CrystalDoc.prefixForType = function(type) {
+CrystalDocs.prefixForType = function(type) {
   switch (type) {
     case "instance_method":
       return "#";
@@ -278,14 +278,14 @@ CrystalDoc.prefixForType = function(type) {
   }
 };
 
-CrystalDoc.displaySearchResults = function(results, query) {
+CrystalDocs.displaySearchResults = function(results, query) {
   function sanitize(html){
     return html.replace(/<(?!\/?code)[^>]+>/g, "");
   }
 
   // limit results
-  if (results.length > CrystalDoc.MAX_RESULTS_DISPLAY) {
-    results = results.slice(0, CrystalDoc.MAX_RESULTS_DISPLAY);
+  if (results.length > CrystalDocs.MAX_RESULTS_DISPLAY) {
+    results = results.slice(0, CrystalDocs.MAX_RESULTS_DISPLAY);
   }
 
   var $frag = document.createDocumentFragment();
@@ -293,12 +293,12 @@ CrystalDoc.displaySearchResults = function(results, query) {
   $resultsElem.innerHTML = "<!--" + JSON.stringify(query) + "-->";
 
   results.forEach(function(result, i) {
-    var url = CrystalDoc.base_path + result.href;
+    var url = CrystalDocs.base_path + result.href;
     var type = false;
 
     var title = query.highlight(result.result_type == "type" ? result.full_name : result.name);
 
-    var prefix = CrystalDoc.prefixForType(result.result_type);
+    var prefix = CrystalDocs.prefixForType(result.result_type);
     if (prefix) {
       title = "<b>" + prefix + "</b>" + title;
     }
@@ -347,10 +347,10 @@ CrystalDoc.displaySearchResults = function(results, query) {
 
   $resultsElem.appendChild($frag);
 
-  CrystalDoc.toggleResultsList(true);
+  CrystalDocs.toggleResultsList(true);
 };
 
-CrystalDoc.toggleResultsList = function(visible) {
+CrystalDocs.toggleResultsList = function(visible) {
   if (visible) {
     document.querySelector(".types-list").classList.add("hidden");
     document.querySelector(".search-results").classList.remove("hidden");
@@ -360,20 +360,20 @@ CrystalDoc.toggleResultsList = function(visible) {
   }
 };
 
-CrystalDoc.Query = function(string) {
+CrystalDocs.Query = function(string) {
   this.original = string;
   this.terms = string.split(/\s+/).filter(function(word) {
-    return CrystalDoc.Query.stripModifiers(word).length > 0;
+    return CrystalDocs.Query.stripModifiers(word).length > 0;
   });
 
-  var normalized = this.terms.map(CrystalDoc.Query.normalizeTerm);
+  var normalized = this.terms.map(CrystalDocs.Query.normalizeTerm);
   this.normalizedTerms = normalized;
 
   function runMatcher(field, matcher) {
     if (!field) {
       return false;
     }
-    var normalizedValue = CrystalDoc.Query.normalizeTerm(field);
+    var normalizedValue = CrystalDocs.Query.normalizeTerm(field);
 
     var matches = [];
     normalized.forEach(function(term) {
@@ -431,7 +431,7 @@ CrystalDoc.Query = function(string) {
         methodName = term.substring(i+1);
 
         if(termType != "") {
-          if(CrystalDoc.Query.normalizeTerm(type.full_name).indexOf(termType) < 0){
+          if(CrystalDocs.Query.normalizeTerm(type.full_name).indexOf(termType) < 0){
             return false;
           }
         }
@@ -457,10 +457,10 @@ CrystalDoc.Query = function(string) {
     );
   };
 };
-CrystalDoc.Query.normalizeTerm = function(term) {
+CrystalDocs.Query.normalizeTerm = function(term) {
   return term.toLowerCase();
 };
-CrystalDoc.Query.stripModifiers = function(term) {
+CrystalDocs.Query.stripModifiers = function(term) {
   switch (term[0]) {
     case "#":
     case ".":
@@ -472,34 +472,34 @@ CrystalDoc.Query.stripModifiers = function(term) {
   }
 }
 
-CrystalDoc.search = function(string) {
-  if(!CrystalDoc.searchIndex) {
-    console.log("CrystalDoc search index not initialized, delaying search");
+CrystalDocs.search = function(string) {
+  if(!CrystalDocs.searchIndex) {
+    console.log("CrystalDocs search index not initialized, delaying search");
 
-    document.addEventListener("CrystalDoc:loaded", function listener(){
-      document.removeEventListener("CrystalDoc:loaded", listener);
-      CrystalDoc.search(string);
+    document.addEventListener("CrystalDocs:loaded", function listener(){
+      document.removeEventListener("CrystalDocs:loaded", listener);
+      CrystalDocs.search(string);
     });
     return;
   }
 
-  document.dispatchEvent(new Event("CrystalDoc:searchStarted"));
+  document.dispatchEvent(new Event("CrystalDocs:searchStarted"));
 
-  var query = new CrystalDoc.Query(string);
-  var results = CrystalDoc.runQuery(query);
-  results = CrystalDoc.rankResults(results, query);
-  CrystalDoc.displaySearchResults(results, query);
+  var query = new CrystalDocs.Query(string);
+  var results = CrystalDocs.runQuery(query);
+  results = CrystalDocs.rankResults(results, query);
+  CrystalDocs.displaySearchResults(results, query);
 
-  document.dispatchEvent(new Event("CrystalDoc:searchPerformed"));
+  document.dispatchEvent(new Event("CrystalDocs:searchPerformed"));
 };
 
-CrystalDoc.initializeIndex = function(data) {
-  CrystalDoc.searchIndex = data;
+CrystalDocs.initializeIndex = function(data) {
+  CrystalDocs.searchIndex = data;
 
-  document.dispatchEvent(new Event("CrystalDoc:loaded"));
+  document.dispatchEvent(new Event("CrystalDocs:loaded"));
 };
 
-CrystalDoc.loadIndex = function() {
+CrystalDocs.loadIndex = function() {
   function loadJSON(file, callback) {
     var xobj = new XMLHttpRequest();
     xobj.overrideMimeType("application/json");
@@ -519,7 +519,7 @@ CrystalDoc.loadIndex = function() {
   }
 
   function parseJSON(json) {
-    CrystalDoc.initializeIndex(JSON.parse(json));
+    CrystalDocs.initializeIndex(JSON.parse(json));
   }
 
   for(var i = 0; i < document.scripts.length; i++){
@@ -542,5 +542,5 @@ CrystalDoc.loadIndex = function() {
 
 // Callback for jsonp
 function crystal_doc_search_index_callback(data) {
-  CrystalDoc.initializeIndex(data);
+  CrystalDocs.initializeIndex(data);
 }

--- a/src/compiler/crystal/tools/doc/html/js/_versions.js
+++ b/src/compiler/crystal/tools/doc/html/js/_versions.js
@@ -1,0 +1,67 @@
+CrystalDocs.initializeVersions = function () {
+  function loadJSON(file, callback) {
+    var xobj = new XMLHttpRequest();
+    xobj.overrideMimeType("application/json");
+    xobj.open("GET", file, true);
+    xobj.onreadystatechange = function() {
+      if (xobj.readyState == 4 && xobj.status == "200") {
+        callback(xobj.responseText);
+      }
+    };
+    xobj.send(null);
+  }
+
+  function parseJSON(json) {
+    CrystalDocs.loadConfig(JSON.parse(json));
+  }
+
+  $elem = document.querySelector("html > head > meta[name=\"crystal_docs.json_config_url\"]")
+  if ($elem == undefined) {
+    return
+  }
+  jsonURL = $elem.getAttribute("content")
+  if (jsonURL && jsonURL != "") {
+    loadJSON(jsonURL, parseJSON);
+  }
+}
+
+CrystalDocs.loadConfig = function (config) {
+  var projectVersions = config["versions"]
+  var currentVersion = document.querySelector("html > head > meta[name=\"crystal_docs.project_version\"]").getAttribute("content")
+
+  var currentVersionInList = projectVersions.find(function (element) {
+    element.version == currentVersion
+  })
+
+  if (!currentVersionInList) {
+    projectVersions.unshift({ name: currentVersion, url: '#' })
+  }
+
+  $version = document.querySelector(".project-summary > .project-version")
+  $version.innerHTML = ""
+
+  $select = document.createElement("select")
+  $select.classList.add("project-versions-nav")
+  $select.addEventListener("change", function () {
+    window.location.href = this.value
+  })
+  projectVersions.forEach(function (version) {
+    $item = document.createElement("option")
+    $item.setAttribute("value", version.url)
+    $item.append(document.createTextNode(version.name))
+
+    if (version.name == currentVersion) {
+      $item.setAttribute("selected", true)
+      $item.setAttribute("disabled", true)
+    }
+    $select.append($item)
+  });
+  $form = document.createElement("form")
+  $form.setAttribute("autocomplete", "off")
+  $form.append($select)
+  $version.append($form)
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  CrystalDocs.initializeVersions()
+})

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -1,6 +1,6 @@
-window.CrystalDoc = (window.CrystalDoc || {});
+window.CrystalDocs = (window.CrystalDocs || {});
 
-CrystalDoc.base_path = (CrystalDoc.base_path || "");
+CrystalDocs.base_path = (CrystalDocs.base_path || "");
 
 <%= JsSearchTemplate.new %>
 <%= JsNavigatorTemplate.new %>
@@ -62,28 +62,28 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   var leaveSearchScope = function(){
-    CrystalDoc.toggleResultsList(false);
+    CrystalDocs.toggleResultsList(false);
     window.focus();
   }
 
   var navigator = new Navigator(document.querySelector('.types-list'), searchInput, document.querySelector(".search-results"), leaveSearchScope);
 
-  CrystalDoc.loadIndex();
+  CrystalDocs.loadIndex();
   var searchTimeout;
   var lastSearchText = false;
   var performSearch = function() {
-    document.dispatchEvent(new Event("CrystalDoc:searchDebounceStarted"));
+    document.dispatchEvent(new Event("CrystalDocs:searchDebounceStarted"));
 
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(function() {
       var text = searchInput.value;
 
       if(text == "") {
-        CrystalDoc.toggleResultsList(false);
+        CrystalDocs.toggleResultsList(false);
       }else if(text == lastSearchText){
-        document.dispatchEvent(new Event("CrystalDoc:searchDebounceStopped"));
+        document.dispatchEvent(new Event("CrystalDocs:searchDebounceStopped"));
       }else{
-        CrystalDoc.search(text);
+        CrystalDocs.search(text);
         navigator.highlightFirst();
         searchInput.focus();
       }
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var searchQuery = location.hash.substring(3);
     history.pushState({searchQuery: searchQuery}, "Search for " + searchQuery, location.href.replace(/#q=.*/, ""));
     searchInput.value = searchQuery;
-    document.addEventListener('CrystalDoc:loaded', performSearch);
+    document.addEventListener('CrystalDocs:loaded', performSearch);
   }
 
   if (searchInput.value.length == 0) {

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -4,6 +4,7 @@ CrystalDocs.base_path = (CrystalDocs.base_path || "");
 
 <%= JsSearchTemplate.new %>
 <%= JsNavigatorTemplate.new %>
+<%= JsVersionsTemplate.new %>
 <%= JsUsageModal.new %>
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -5,7 +5,7 @@
   <meta id="repository-name" content="<%= project_info.name %>">
   <title><%= project_info.name %> <%= project_info.version %></title>
   <script type="text/javascript">
-  CrystalDoc.base_path = "";
+  CrystalDocs.base_path = "";
   </script>
 </head>
 <body>

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <%= HeadTemplate.new("") %>
+  <%= HeadTemplate.new(project_info, "") %>
   <meta id="repository-name" content="<%= project_info.name %>">
   <title><%= project_info.name %> <%= project_info.version %></title>
   <script type="text/javascript">

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -5,7 +5,7 @@
   <meta id="repository-name" content="<%= project_info.name %>">
   <title><%= type.full_name %> - <%= project_info.name %> <%= project_info.version %></title>
   <script type="text/javascript">
-    CrystalDoc.base_path = "<%= type.path_to "" %>";
+    CrystalDocs.base_path = "<%= type.path_to "" %>";
   </script>
 </head>
 <body>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <%= HeadTemplate.new(type.path_to "") %>
+  <%= HeadTemplate.new(project_info, type.path_to "") %>
   <meta id="repository-name" content="<%= project_info.name %>">
   <title><%= type.full_name %> - <%= project_info.name %> <%= project_info.version %></title>
   <script type="text/javascript">

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -2,11 +2,12 @@ module Crystal::Doc
   class ProjectInfo
     property! name : String
     property! version : String
+    property json_config_url : String? = nil
 
     def initialize(@name : String? = nil, @version : String? = nil)
     end
 
-    def_equals_and_hash @name, @version
+    def_equals_and_hash @name, @version, @json_config_url
 
     def crystal_stdlib?
       name == "Crystal"

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -69,6 +69,10 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/js/_navigator.js"
   end
 
+  struct JsVersionsTemplate
+    ECR.def_to_s "#{__DIR__}/html/js/_versions.js"
+  end
+
   struct JsUsageModal
     ECR.def_to_s "#{__DIR__}/html/js/_usage-modal.js"
   end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -49,7 +49,7 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/main.html"
   end
 
-  record HeadTemplate, base_path : String do
+  record HeadTemplate, project_info : ProjectInfo, base_path : String do
     ECR.def_to_s "#{__DIR__}/html/_head.html"
   end
 


### PR DESCRIPTION
This adds a version select box to the sidebar on the API docs. The idea is described in https://github.com/crystal-lang/crystal/pull/7011#issuecomment-583656393

This is an opt-in feature of the docs generator. It doesn't work out of the box. You need to publish a JavaScript config file which describes the available releases that should be shown in the version select.
The content of such a file looks like this (example for stdlib, reduced to versions >= 0.30.0):
```js
var projectVersions = [
  {name: "0.35.0-dev", url: "/api/master/", released: false},
  {name: "0.34.0", url: "/api/0.34.0/", latest: true},
  {name: "0.33.0", url: "/api/0.33.0/"},
  {name: "0.32.1", url: "/api/0.32.1/"},
  {name: "0.32.0", url: "/api/0.32.0/"},
  {name: "0.31.1", url: "/api/0.31.1/"},
  {name: "0.31.0", url: "/api/0.31.0/"},
  {name: "0.30.1", url: "/api/0.30.1/"},
  {name: "0.30.0", url: "/api/0.30.0/"}
];
```

In order to properly resolve #7011 we should probably add some additional notification when browsing an outdated or unreleased version. This is signalled by `latest: true` and `released: false` which currently both don't have any effect. But I'd like to land this PR first and then continue with the next steps.