### PR TITLE
Benchmark::IPS::Entry: promote bytes_per_op to UInt64

### DIFF
--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -100,7 +100,7 @@ module Benchmark
           ips = measurements.map { |m| item.cycles.to_f / m.total_seconds }
           item.calculate_stats(ips)
 
-          item.bytes_per_op = (bytes.to_f / cycles.to_f).round.to_i
+          item.bytes_per_op = (bytes.to_f / cycles.to_f).round.to_u64
 
           if @interactive
             run_comparison
@@ -152,7 +152,7 @@ module Benchmark
       property! slower : Float64
 
       # Number of bytes allocated per operation
-      property! bytes_per_op : Int32
+      property! bytes_per_op : UInt64
 
       @ran : Bool
       @ran = false


### PR DESCRIPTION
Well, nobody has that much memory but it looks like there's at
least a bug which can let it overflow an Int32 and we shouldn't
just fail at that.

fixes #9075