### PR TITLE
Remove README link in API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_sidebar.html
+++ b/src/compiler/crystal/tools/doc/html/_sidebar.html
@@ -15,10 +15,6 @@
         <%= project_info.version %>
       </span>
     </div>
-
-    <div class="repository-links">
-      <a href="<%= current_type.try(&.path_to("")) %>index.html">README</a>
-    </div>
   </div>
 
   <div class="search-results" class="hidden">

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -166,10 +166,6 @@ body {
   color: #866BA6;
 }
 
-.repository-links {
-  padding: 5px 15px 5px 30px;
-}
-
 .types-list li ul {
   overflow: hidden;
   height: 0;

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -353,11 +353,9 @@ CrystalDoc.displaySearchResults = function(results, query) {
 CrystalDoc.toggleResultsList = function(visible) {
   if (visible) {
     document.querySelector(".types-list").classList.add("hidden");
-    document.querySelector(".repository-links").classList.add("hidden");
     document.querySelector(".search-results").classList.remove("hidden");
   } else {
     document.querySelector(".types-list").classList.remove("hidden");
-    document.querySelector(".repository-links").classList.remove("hidden");
     document.querySelector(".search-results").classList.add("hidden");
   }
 };


### PR DESCRIPTION
The README i.e. the index page of the API documentation is now linked from the project name, so the explicit README link is only a duplicate.

Also removes repository-links section which had only this single item.
It can be added again in case of future expansion.

Follow-up to #8792.