### PR TITLE
Remove special handling for version tags in docs generator

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -25,7 +25,7 @@ describe Crystal::Doc::ProjectInfo do
   describe "#fill_with_defaults" do
     it "empty folder" do
       assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new(nil, nil))
-      assert_with_defaults(ProjectInfo.new("foo", "v1.0"), ProjectInfo.new("foo", "v1.0"))
+      assert_with_defaults(ProjectInfo.new("foo", "1.0"), ProjectInfo.new("foo", "1.0"))
     end
 
     context "with shard.yml" do
@@ -34,17 +34,17 @@ describe Crystal::Doc::ProjectInfo do
       end
 
       it "no git" do
-        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "v1.0"))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
-        assert_with_defaults(ProjectInfo.new(nil, "v2.0"), ProjectInfo.new("foo", "v2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0"))
       end
 
       it "git but no commit" do
         run_git "init"
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", nil))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
-        assert_with_defaults(ProjectInfo.new(nil, "v2.0"), ProjectInfo.new("foo", "v2.0"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0"))
       end
 
       it "git tagged version" do
@@ -53,8 +53,8 @@ describe Crystal::Doc::ProjectInfo do
         run_git "commit -m 'Initial commit' --no-gpg-sign"
         run_git "tag v3.0"
 
-        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "v3.0"))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "3.0"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
       end
 
       it "git tagged version dirty" do
@@ -64,9 +64,9 @@ describe Crystal::Doc::ProjectInfo do
         run_git "tag v3.0"
         File.write("foo.txt", "bar")
 
-        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "v3.0-dev"))
-        assert_with_defaults(ProjectInfo.new(nil, "v1.1"), ProjectInfo.new("foo", "v1.1"))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "3.0-dev"))
+        assert_with_defaults(ProjectInfo.new(nil, "1.1"), ProjectInfo.new("foo", "1.1"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
       end
 
       it "git non-tagged commit" do
@@ -75,8 +75,8 @@ describe Crystal::Doc::ProjectInfo do
         run_git "commit -m 'Initial commit' --no-gpg-sign"
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "master"))
-        assert_with_defaults(ProjectInfo.new(nil, "v1.1"), ProjectInfo.new("foo", "v1.1"))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, "1.1"), ProjectInfo.new("foo", "1.1"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
       end
 
       it "git non-tagged commit dirty" do
@@ -86,8 +86,8 @@ describe Crystal::Doc::ProjectInfo do
         File.write("foo.txt", "bar")
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "master-dev"))
-        assert_with_defaults(ProjectInfo.new(nil, "v1.1"), ProjectInfo.new("foo", "v1.1"))
-        assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
+        assert_with_defaults(ProjectInfo.new(nil, "1.1"), ProjectInfo.new("foo", "1.1"))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
       end
     end
 
@@ -98,9 +98,9 @@ describe Crystal::Doc::ProjectInfo do
       run_git "commit -m 'Remove shard.yml' --no-gpg-sign"
       run_git "tag v4.0"
 
-      assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new(nil, "v4.0"))
-      assert_with_defaults(ProjectInfo.new("foo", nil), ProjectInfo.new("foo", "v4.0"))
-      assert_with_defaults(ProjectInfo.new("bar", "v2.0"), ProjectInfo.new("bar", "v2.0"))
+      assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new(nil, "4.0"))
+      assert_with_defaults(ProjectInfo.new("foo", nil), ProjectInfo.new("foo", "4.0"))
+      assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0"))
     end
   end
 
@@ -131,24 +131,22 @@ describe Crystal::Doc::ProjectInfo do
 
     # Tagged commit
     run_git "tag v0.1.0"
-    ProjectInfo.find_git_version.should eq "v0.1.0"
+    ProjectInfo.find_git_version.should eq "0.1.0"
 
     # Tagged commit, dirty workdir
     File.write("file.txt", "bar")
-    ProjectInfo.find_git_version.should eq "v0.1.0-dev"
+    ProjectInfo.find_git_version.should eq "0.1.0-dev"
 
     # Tagged commit, dirty index
     run_git "add file.txt"
-    ProjectInfo.find_git_version.should eq "v0.1.0-dev"
+    ProjectInfo.find_git_version.should eq "0.1.0-dev"
 
     run_git "reset --hard v0.1.0"
-    ProjectInfo.find_git_version.should eq "v0.1.0"
+    ProjectInfo.find_git_version.should eq "0.1.0"
 
     # Multiple tags
     run_git "tag v0.2.0"
-    ProjectInfo.find_git_version.should eq "v0.1.0"
-  end
-
+    ProjectInfo.find_git_version.should eq "0.1.0"
   end
 
   describe ".read_shard_properties" do
@@ -178,27 +176,27 @@ describe Crystal::Doc::ProjectInfo do
 
     it "name and version" do
       File.write("shard.yml", "name: bar\nversion: 1.0")
-      ProjectInfo.read_shard_properties.should eq({"bar", "v1.0"})
+      ProjectInfo.read_shard_properties.should eq({"bar", "1.0"})
     end
 
     it "duplicate properties uses first one" do
       File.write("shard.yml", "name: bar\nversion: 1.0\nname: foo\nversion: foo")
-      ProjectInfo.read_shard_properties.should eq({"bar", "v1.0"})
+      ProjectInfo.read_shard_properties.should eq({"bar", "1.0"})
     end
 
     it "strip whitespace" do
       File.write("shard.yml", "name: bar  \nversion: 1.0  ")
-      ProjectInfo.read_shard_properties.should eq({"bar", "v1.0"})
+      ProjectInfo.read_shard_properties.should eq({"bar", "1.0"})
     end
 
     it "strip quotes" do
       File.write("shard.yml", "name: 'bar'\nversion: '1.0'")
-      ProjectInfo.read_shard_properties.should eq({"bar", "v1.0"})
+      ProjectInfo.read_shard_properties.should eq({"bar", "1.0"})
     end
 
     it "ignores comments" do
       File.write("shard.yml", "name: bar # comment\nversion: 1.0 # comment")
-      ProjectInfo.read_shard_properties.should eq({"bar", "v1.0"})
+      ProjectInfo.read_shard_properties.should eq({"bar", "1.0"})
 
       File.write("shard.yml", "name: # comment\nversion: # comment")
       ProjectInfo.read_shard_properties.should eq({nil, nil})

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -30,15 +30,19 @@ module Crystal::Doc
       Process.run("git", ["rev-parse", "--is-inside-work-tree"]).success?
     end
 
+    VERSION_TAG = /^v(\d+[-.][-.a-zA-Z\d]+)$/
+
     def self.find_git_version
       if ref = git_ref
-        case git_clean?
-        when Nil
-        when true
-          ref
-        when false
-          "#{ref}-dev"
+        if ref.matches?(VERSION_TAG)
+          ref = ref.byte_slice(1)
         end
+
+        unless git_clean?
+          ref = "#{ref}-dev"
+        end
+
+        ref
       end
     end
 
@@ -92,12 +96,7 @@ module Crystal::Doc
         end
       end
 
-      version = version.presence
-      if version
-        version = "v#{version}"
-      end
-
-      return name.presence, version
+      return name.presence, version.presence
     end
   end
 end

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -60,10 +60,9 @@ module Crystal::Doc
       return unless status.success?
       io.rewind
       tags = io.to_s.lines
-      versions = tags.select(&.starts_with?("v"))
-      # Only accept when there's exactly one version tag pointing at HEAD.
-      if versions.size == 1
-        return versions.first.byte_slice(1)
+      # Return tag if commit is tagged, select first one if multiple
+      if tag = tags.first?
+        return tag
       end
 
       # Otherwise, return current branch name
@@ -93,7 +92,12 @@ module Crystal::Doc
         end
       end
 
-      return name.presence, version.presence
+      version = version.presence
+      if version
+        version = "v#{version}"
+      end
+
+      return name.presence, version
     end
   end
 end


### PR DESCRIPTION
This was trying to be too smart but it wouldn't work reliably without
proper version tag recognition. This added complexity is also unnecessary.
Just displaying the plain git tag (plus suffix if dirty) should be sufficient.