### PR TITLE
Remove top-level assert_responds_to macro

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -185,11 +185,3 @@ macro p!(*exps)
     }
   {% end %}
 end
-
-macro assert_responds_to(var, method)
-  if {{var}}.responds_to?(:{{method}})
-    {{var}}
-  else
-    raise "Expected {{var}} to respond to :{{method}}, not #{ {{var}} }"
-  end
-end


### PR DESCRIPTION
It's an old macro with no docs that is no longer used, nor encouraged.