### PR TITLE
Correct duplicated articles/prepositions in comments

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -5,7 +5,7 @@
 # some in `tools`, some here, and some create a Compiler and
 # manipulate it.
 #
-# Other commands create a `Compiler` and use it to to build
+# Other commands create a `Compiler` and use it to build
 # an executable.
 
 require "json"

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -79,7 +79,7 @@ module Crystal
             # If the argument types are compatible with the match's argument types,
             # we are done. We don't just compare types with ==, there is a special case:
             # a function type with return T can be transpass a restriction of a function
-            # with with the same arguments but which returns Void.
+            # with the same arguments but which returns Void.
             arg_types_equal = signature.arg_types.equals?(match.arg_types) { |x, y| x.compatible_with?(y) }
             if (match_named_args = match.named_arg_types) && (signature_named_args = signature.named_args) &&
                match_named_args.size == signature_named_args.size

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -263,7 +263,7 @@ module HTTP
 
     # Deletes and returns the `HTTP::Cookie` for the specified *key*, or
     # returns `nil` if *key* cannot be found in the collection. Note that
-    # *key* should match the the name attribute of the desired `HTTP::Cookie`.
+    # *key* should match the name attribute of the desired `HTTP::Cookie`.
     def delete(key)
       @cookies.delete(key)
     end


### PR DESCRIPTION
Vanish 'the the' / 'with with' / 'to to'.

> War.. War never changes.
>
> From "Fallout 4"
