### PR TITLE
Use SOURCE_DATE_EPOCH only to determine compiler date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,12 @@ override FLAGS += $(if $(release),--release )$(if $(stats),--stats )$(if $(progr
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
+SOURCE_DATE_EPOCH := $(shell git show -s --format=%ct HEAD 2> /dev/null)
 EXPORTS := \
   $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src") \
   CRYSTAL_CONFIG_LIBRARY_PATH="$(shell crystal env CRYSTAL_LIBRARY_PATH)" \
-  CRYSTAL_CONFIG_BUILD_COMMIT="$(CRYSTAL_CONFIG_BUILD_COMMIT)"
+  CRYSTAL_CONFIG_BUILD_COMMIT="$(CRYSTAL_CONFIG_BUILD_COMMIT)" \
+	SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)"
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
 LLVM_EXT_DIR = src/llvm/ext

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ override FLAGS += $(if $(release),--release )$(if $(stats),--stats )$(if $(progr
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
-SOURCE_DATE_EPOCH := $(shell git show -s --format=%ct HEAD 2> /dev/null)
+SOURCE_DATE_EPOCH := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
 EXPORTS := \
   $(if $(release),,CRYSTAL_CONFIG_PATH="$(PWD)/src") \
   CRYSTAL_CONFIG_LIBRARY_PATH="$(shell crystal env CRYSTAL_LIBRARY_PATH)" \

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -32,8 +32,12 @@ module Crystal
     end
 
     def self.date
-      time = {{ (env("SOURCE_DATE_EPOCH") || `date +%s`).to_i }}
-      Time.unix(time).to_s("%Y-%m-%d")
+      source_date_epoch = {{ (t = env("SOURCE_DATE_EPOCH")) && !t.empty? ? t.to_i : nil }}
+      if source_date_epoch
+        Time.unix(source_date_epoch).to_s("%Y-%m-%d")
+      else
+        ""
+      end
     end
 
     @@default_target : Crystal::Codegen::Target?


### PR DESCRIPTION
This removes a platform-specific detail from the compiler (see #9054). With this change, the compiler does not automatically use the current time as build date. It must be set by env var `SOURCE_DATE_EPOCH`. Otherwise it's just empty.

This env var is by default populated in the Makefile in the same way we're already handling `CRYSTAL_CONFIG_BUILD_COMMIT` there.

Resolves #9057

This approach was suggested by @asterite in https://github.com/crystal-lang/crystal/pull/9057#issuecomment-613660736 and I agree that this is probably the best solution (per https://github.com/crystal-lang/crystal/pull/9057#issuecomment-613712633).